### PR TITLE
Toolboxing

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -15,7 +15,7 @@ RCD
 	flags = FPRINT | TABLEPASS| CONDUCT
 	force = 10.0
 	throwforce = 10.0
-	throw_speed = 1
+	throw_speed = 3
 	throw_range = 5
 	w_class = 3.0
 	m_amt = 30000

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -10,7 +10,7 @@
 	throwforce = 10
 	w_class = 3.0
 	throw_speed = 2
-	throw_range = 10
+	throw_range = 7
 	force = 10
 	m_amt = 90
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
@@ -20,7 +20,6 @@
 	var/sprite_name = "fire_extinguisher"
 
 	reagents_to_log=list(
-		"fuel"  =  "welder fuel",
 		"plasma"=  "plasma",
 		"pacid" =  "polytrinic acid",
 		"sacid" =  "sulphuric acid"
@@ -65,6 +64,7 @@
 	user << "The safety is [safety ? "on" : "off"]."
 	return
 
+/*
 /obj/item/weapon/extinguisher/attackby(obj/item/W, mob/user)
 	if(user.stat || user.restrained() || user.lying)  return
 
@@ -94,6 +94,7 @@
 		W.loc=src
 		user << "You cram \the [W] into the nozzle of \the [src]."
 		msg_admin_attack("[user]/[user.ckey] has crammed \a [W] into a [src].")
+		*/
 
 
 /obj/item/weapon/extinguisher/afterattack(atom/target, mob/user , flag)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -19,7 +19,7 @@
 /obj/item/weapon/kitchen/utensil
 	force = 5.0
 	w_class = 1.0
-	throwforce = 5.0
+	throwforce = 0.0
 	throw_speed = 3
 	throw_range = 5
 	flags = FPRINT | TABLEPASS | CONDUCT
@@ -210,7 +210,7 @@
 	icon_state = "rolling_pin"
 	force = 8.0
 	throwforce = 10.0
-	throw_speed = 2
+	throw_speed = 3
 	throw_range = 7
 	w_class = 3.0
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked") //I think the rollingpin attackby will end up ignoring this anyway.
@@ -261,11 +261,11 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = "tray"
 	desc = "A metal tray to lay food on."
-	throwforce = 12.0
+	throwforce = 5.0
 	throwforce = 10.0
-	throw_speed = 1
+	throw_speed = 3
 	throw_range = 5
-	w_class = 3.0
+	w_class = 4.0
 	flags = FPRINT | TABLEPASS | CONDUCT
 	m_amt = 3000
 	/* // NOPE

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -6,7 +6,7 @@
 	force = 3.0
 	throwforce = 5.0
 	throw_speed = 3
-	throw_range = 10
+	throw_range = 7
 	w_class = 3.0
 	flags = FPRINT | TABLEPASS
 	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -4,12 +4,14 @@
 	icon_state = "briefcase"
 	item_state = "briefcase"
 	flags = FPRINT | TABLEPASS| CONDUCT
+	hitsound = "swing_hit"
 	force = 8.0
-	throw_speed = 1
+	throw_speed = 2
 	throw_range = 4
 	w_class = 4.0
 	max_w_class = 3
-	max_combined_w_class = 16
+	max_combined_w_class = 21
+	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 
 /obj/item/weapon/storage/briefcase/New()
 	..()

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -5,14 +5,14 @@
 	icon_state = "red"
 	item_state = "toolbox_red"
 	flags = FPRINT | TABLEPASS| CONDUCT
-	force = 5.0
+	force = 10.0
 	throwforce = 10.0
-	throw_speed = 1
+	throw_speed = 2
 	throw_range = 7
 	w_class = 4.0
 	origin_tech = "combat=1"
 	attack_verb = list("robusted")
-	hitsound = "swing_hit"
+	hitsound = "sound/weapons/smash.ogg"
 
 	New()
 		..()
@@ -73,7 +73,8 @@
 	icon_state = "syndicate"
 	item_state = "toolbox_syndi"
 	origin_tech = "combat=1;syndicate=1"
-	force = 7.0
+	force = 15.0
+	throwforce = 18.0
 
 	New()
 		..()

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -102,12 +102,13 @@
 	flags = FPRINT | TABLEPASS| CONDUCT
 	slot_flags = SLOT_BELT
 	force = 6.0
-	throw_speed = 2
-	throw_range = 9
+	throw_speed = 3
+	throw_range = 7
 	w_class = 2.0
 	m_amt = 80
 	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("pinched", "nipped")
+	hitsound = "sound/items/Wirecutter.ogg"
 	sharp = 1
 	edge = 1
 
@@ -140,7 +141,7 @@
 	//Amount of OUCH when it's thrown
 	force = 3.0
 	throwforce = 5.0
-	throw_speed = 1
+	throw_speed = 3
 	throw_range = 5
 	w_class = 2.0
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1381,6 +1381,7 @@ datum
 				if(method == TOUCH)
 					M.adjust_fire_stacks(volume / 10)
 				return
+			/*
 			reaction_obj(var/obj/O, var/volume)
 				var/turf/the_turf = get_turf(O)
 				if(!the_turf)
@@ -1389,6 +1390,7 @@ datum
 			reaction_turf(var/turf/T, var/volume)
 				new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
 				return
+			*/
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
 				M.adjustToxLoss(1)


### PR DESCRIPTION
Weapon Changes

-Fire Extinguishers can no longer be unwrenched to make them fillable with any reagent you desire
-Can't cram objects inside an extinguisher anymore
-Toolboxes are now fairly robust weapons--the Syndi toolbox will be notedly nasty; hit sound also changed.
-Adjusted some throwspeed/throw-range on a number of common melee "weapons"
-Wirecutters now make a snipping sound when attacking instead of bludgeoning.
-Welding fuel won't be able to soak objects/turfs with "cleanable fuel" (the stuff you always see Chaplains setting ablaze..). Dowsing mobs in fuel is unchanged, however.
