### PR TITLE
Cell changes

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -168,7 +168,7 @@
 
 /obj/item/weapon/legcuffs/beartrap
 	name = "bear trap"
-	throw_speed = 2
+	throw_speed = 1
 	throw_range = 1
 	icon_state = "beartrap0"
 	desc = "A trap used to catch bears and other legged creatures."
@@ -185,26 +185,31 @@
 		icon_state = "beartrap[armed]"
 		user << "<span class='notice'>[src] is now [armed ? "armed" : "disarmed"]</span>"
 
+
 /obj/item/weapon/legcuffs/beartrap/Crossed(AM as mob|obj)
-	if(armed)
-		if(ishuman(AM))
-			if(isturf(src.loc))
+	if(armed && isturf(src.loc))
+		if( (iscarbon(AM) || isanimal(AM)) && !istype(AM, /mob/living/simple_animal/parrot) && !istype(AM, /mob/living/simple_animal/construct) && !istype(AM, /mob/living/simple_animal/shade) && !istype(AM, /mob/living/simple_animal/hostile/viscerator))
+			var/mob/living/L = AM
+			armed = 0
+			icon_state = "beartrap0"
+			playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
+			L.visible_message("<span class='danger'>[L] triggers \the [src].</span>", \
+					"<span class='userdanger'>You trigger \the [src]!</span>")
+
+			if(ishuman(AM))
 				var/mob/living/carbon/H = AM
-				if(H.m_intent == "run")
-					armed = 0
+				if(H.lying)
+					H.apply_damage(20,BRUTE,"chest")
+				else
+					H.apply_damage(20,BRUTE,(pick("l_leg", "r_leg")))
+				if(!H.legcuffed) //beartrap can't cuff you leg if there's already a beartrap or legcuffs.
 					H.legcuffed = src
 					src.loc = H
-					H.update_inv_legcuffed()
-					H << "\red <B>You step on \the [src]!</B>"
+					H.update_inv_legcuffed(0)
 					feedback_add_details("handcuffs","B") //Yes, I know they're legcuffs. Don't change this, no need for an extra variable. The "B" is used to tell them apart.
-					for(var/mob/O in viewers(H, null))
-						if(O == H)
-							continue
-						O.show_message("\red <B>[H] steps on \the [src].</B>", 1)
-		if(isanimal(AM) && !istype(AM, /mob/living/simple_animal/parrot) && !istype(AM, /mob/living/simple_animal/construct) && !istype(AM, /mob/living/simple_animal/shade) && !istype(AM, /mob/living/simple_animal/hostile/viscerator))
-			armed = 0
-			var/mob/living/simple_animal/SA = AM
-			SA.health -= 20
+
+			else
+				L.apply_damage(20,BRUTE)
 	..()
 
 
@@ -591,13 +596,13 @@
 	item_state = "RPED"
 	w_class = 5
 	can_hold = list("/obj/item/weapon/stock_parts","/obj/item/weapon/cell")
-	storage_slots = 14
+	storage_slots = 50
 	use_to_pickup = 1
 	allow_quick_gather = 1
 	allow_quick_empty = 1
 	collection_mode = 1
 	max_w_class = 3
-	max_combined_w_class = 28
+	max_combined_w_class = 100
 
 /obj/item/weapon/storage/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exchanging or installing parts.

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -9,7 +9,7 @@
 	var/range = 2 //this is roughly the size of brig cell
 	var/disable = 0
 	var/last_flash = 0 //Don't want it getting spammed like regular flashes
-	var/strength = 10 //How weakened targets are when flashed.
+	var/strength = 5 //How weakened targets are when flashed.
 	var/base_state = "mflash"
 	anchored = 1
 
@@ -17,7 +17,7 @@
 	name = "portable flasher"
 	desc = "A portable flashing device. Wrench to activate and deactivate. Cannot detect slow movements."
 	icon_state = "pflash1"
-	strength = 8
+	strength = 4
 	anchored = 0
 	base_state = "pflash"
 	density = 1
@@ -84,7 +84,7 @@
 			var/datum/organ/internal/eyes/E = H.internal_organs_by_name["eyes"]
 			if ((E.damage > E.min_bruised_damage && prob(E.damage + 50)))
 				flick("e_flash", O:flash)
-				E.damage += rand(1, 5)
+				E.damage += rand(1, 2)
 		else
 			if(!O.blinded)
 				flick("flash", O:flash)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -72,7 +72,7 @@
 	if(iscarbon(M))
 		var/safety = M:eyecheck()
 		if(safety <= 0)
-			M.Weaken(10)
+			M.Weaken(5)
 			flick("e_flash", M.flash)
 
 			if(ishuman(M) && ishuman(user) && M.stat!=DEAD)
@@ -198,7 +198,7 @@
 				var/mob/living/carbon/M = loc
 				var/safety = M.eyecheck()
 				if(safety <= 0)
-					M.Weaken(10)
+					M.Weaken(5)
 					flick("e_flash", M.flash)
 					for(var/mob/O in viewers(M, null))
 						O.show_message("<span class='disarm'>[M] is blinded by the flash!</span>")

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -13,7 +13,7 @@
 	m_amt = 500
 	origin_tech = "materials=1"
 	var/dispenser = 0
-	var/breakouttime = 1200 //Deciseconds = 120s = 2 minutes
+	var/breakouttime = 600 //Deciseconds = 60s = 1 minutes
 
 /obj/item/weapon/handcuffs/attack(mob/living/carbon/C, mob/user)
 	if(M_CLUMSY in user.mutations && prob(50))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -164,7 +164,7 @@
 	msg_admin_attack("[key_name(user)] stunned [key_name(L)] with the [src].")
 
 	deductcharge(hitcost)
-	
+
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		H.forcesay(hit_appends)
@@ -220,7 +220,7 @@
 
 //secborg stun baton module
 /obj/item/weapon/melee/baton/robot
-	hitcost = 500	
+	hitcost = 500
 
 /obj/item/weapon/melee/baton/robot/attack_self(mob/user)
 	//try to find our power cell
@@ -247,8 +247,8 @@
 	force = 3
 	throwforce = 5
 	stunforce = 0
-	agonyforce = 60	//same force as a stunbaton, but uses way more charge.
-	hitcost = 2500
+	agonyforce = 42	//less than a stunbaton and uses way more charge.
+	hitcost = 3750
 	attack_verb = list("poked")
 	slot_flags = null
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -872,7 +872,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 			M.equip_if_possible(pda, slot_r_store)
 			M.equip_if_possible(new /obj/item/clothing/glasses/sunglasses(M), slot_l_store)
-			M.equip_if_possible(new /obj/item/weapon/gun/energy(M), slot_belt)
+			M.equip_if_possible(new /obj/item/weapon/gun/energy/pulse_rifle/M1911(M), slot_belt)
 
 			var/obj/item/weapon/card/id/centcom/W = new(M)
 			W.name = "[M.real_name]'s ID Card"

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -154,44 +154,13 @@
 			if(w_uniform)
 				w_uniform.add_fingerprint(M)
 			var/datum/organ/external/affecting = get_organ(ran_zone(M.zone_sel.selecting))
-
-			if (istype(r_hand,/obj/item/weapon/gun) || istype(l_hand,/obj/item/weapon/gun))
-				var/obj/item/weapon/gun/W = null
-				var/chance = 0
-
-				if (istype(l_hand,/obj/item/weapon/gun))
-					W = l_hand
-					chance = hand ? 40 : 20
-
-				if (istype(r_hand,/obj/item/weapon/gun))
-					W = r_hand
-					chance = !hand ? 40 : 20
-
-				if (prob(chance))
-					visible_message("<spawn class=danger>[src]'s [W] goes off during struggle!")
-					var/list/turfs = list()
-					for(var/turf/T in view())
-						turfs += T
-					var/turf/target = pick(turfs)
-					return W.afterattack(target,src)
-
 			var/randn = rand(1, 100)
-
-			if(!src.handcuffed)  // Bone White - disarm knockdown only occurs if you have an aggressive grab on the target,  Longer duration (8) to allow handcuffing.
-				//check for an aggressive grab
-				for (var/obj/item/weapon/grab/G in src.grabbed_by)
-					if (G.assailant == M && G.state >= GRAB_AGGRESSIVE)
-						randn -= 30  // this value is the % chance of knockdown if you disarm someone whilst you have an aggressive grab.
-			else
-			//if target is handcuffed, always push them over
-				randn = 0
-
-			if (randn <= 0)
-				apply_effect(4, WEAKEN, run_armor_check(affecting, "melee")) // first var here is the length of the knockdown
+			if (randn <= 25)
+				apply_effect(2, WEAKEN, run_armor_check(affecting, "melee"))
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-				visible_message("\red <B>[M] has floored [src]!</B>")
-				M.attack_log += text("\[[time_stamp()]\] <font color='red'>Floored [src.name] ([src.ckey])</font>")
-				src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been floored by [M.name] ([M.ckey])</font>")
+				visible_message("\red <B>[M] has pushed [src]!</B>")
+				M.attack_log += text("\[[time_stamp()]\] <font color='red'>Pushed [src.name] ([src.ckey])</font>")
+				src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been pushed by [M.name] ([M.ckey])</font>")
 				if(!iscarbon(M))
 					LAssailant = null
 				else
@@ -199,6 +168,7 @@
 
 				log_attack("[M.name] ([M.ckey]) pushed [src.name] ([src.ckey])")
 				return
+
 			if(randn <= 45 && !lying)
 				if(head)
 					var/obj/item/clothing/head/H = head

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -93,11 +93,12 @@
 
 
 /obj/item/weapon/pen/paralysis/New()
-	var/datum/reagents/R = new/datum/reagents(50)
+	var/datum/reagents/R = new/datum/reagents(55)
 	reagents = R
 	R.my_atom = src
 	R.add_reagent("stoxin", 30)
 	R.add_reagent("mutetoxin", 15)
+	R.add_reagent("tirizene", 10)
 	..()
 	return
 
@@ -108,5 +109,5 @@
 	..()
 	msg_admin_attack("[user.name] ([user.ckey]) Used the [name] to stab [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
 	if(reagents.total_volume)
-		if(M.reagents) reagents.trans_to(M, 50) //used to be 150
+		if(M.reagents) reagents.trans_to(M, 55) //used to be 150
 	return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -54,7 +54,7 @@
 	var/areastring = null
 	var/obj/item/weapon/cell/cell
 	var/start_charge = 90				// initial cell charge %
-	var/cell_type = 5000				// 0=no cell, 1=regular, 2=high-cap (x5) <- old, now it's just 0=no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
+	var/cell_type = 2500				// 0=no cell, 1=regular, 2=high-cap (x5) <- old, now it's just 0=no cell, otherwise dictate cellcapacity by changing this value. 1 used to be 1000, 2 was 2500
 	var/opened = 0 //0=closed, 1=opened, 2=cover removed
 	var/shorted = 0
 	var/lighting = 3

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -4,6 +4,7 @@
 	icon_state = "laser"
 	item_state = "laser"
 	fire_sound = 'sound/weapons/Laser.ogg'
+	charge_cost = 830
 	w_class = 3.0
 	m_amt = 2000
 	origin_tech = "combat=3;magnets=2"
@@ -39,10 +40,10 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/weapon/gun/energy/laser/captain/process()
 	charge_tick++
-	if(charge_tick < 4) 
+	if(charge_tick < 4)
 		return 0
 	charge_tick = 0
-	if(!power_supply) 
+	if(!power_supply)
 		return 0
 	power_supply.give(1000)
 	update_icon()
@@ -53,7 +54,7 @@ obj/item/weapon/gun/energy/laser/retro
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 
 /obj/item/weapon/gun/energy/laser/cyborg/process()
-	return 1		
+	return 1
 
 /obj/item/weapon/gun/energy/laser/cyborg/process_chambered()
 	if(in_chamber)
@@ -77,7 +78,6 @@ obj/item/weapon/gun/energy/laser/retro
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	origin_tech = "combat=4;materials=3;powerstorage=3"
 	projectile_type = "/obj/item/projectile/beam/heavylaser"
-	charge_cost = 1250
 
 	isHandgun()
 		return 0
@@ -109,7 +109,7 @@ obj/item/weapon/gun/energy/laser/retro
 	name = "laser tag gun"
 	icon_state = "bluetag"
 	desc = "Standard issue weapon of the Imperial Guard"
-	projectile_type = "/obj/item/projectile/lastertag/blue"
+	projectile_type = "/obj/item/projectile/lasertag/blue"
 	origin_tech = "combat=1;magnets=2"
 	clumsy_check = 0
 	var/charge_tick = 0
@@ -146,7 +146,7 @@ obj/item/weapon/gun/energy/laser/retro
 	name = "laser tag gun"
 	icon_state = "redtag"
 	desc = "Standard issue weapon of the Imperial Guard"
-	projectile_type = "/obj/item/projectile/lastertag/red"
+	projectile_type = "/obj/item/projectile/lasertag/red"
 	origin_tech = "combat=1;magnets=2"
 	clumsy_check = 0
 	var/charge_tick = 0

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -5,7 +5,7 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	force = 10
 	fire_sound = 'sound/weapons/pulse.ogg'
-	charge_cost = 2000
+	charge_cost = 200
 	projectile_type = "/obj/item/projectile/beam/pulse"
 	cell_type = "/obj/item/weapon/cell/super"
 	var/mode = 2

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -35,8 +35,8 @@
 	damage = 60
 	stun = 5
 	weaken = 5
-	stutter = 5	
-	
+	stutter = 5
+
 /obj/item/projectile/beam/xray
 	name = "xray beam"
 	icon_state = "xray"
@@ -75,7 +75,7 @@
 		var/mob/living/carbon/human/M = target
 		if(istype(M.wear_suit))
 			if(M.wear_suit.type in suit_types)
-				M.Weaken(34)
+				M.adjustHalLoss(34)
 	return 1
 
 /obj/item/projectile/lasertag/omni

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2079,6 +2079,19 @@ datum
 				M.silent += REM + 1
 				..()
 
+		staminatoxin
+			name = "Tirizene"
+			id = "tirizene"
+			description = "A toxin that affects the stamina of a person when injected into the bloodstream."
+			reagent_state = LIQUID
+			color = "#6E2828"
+			data = 13
+
+			on_mob_life(var/mob/living/M)
+				M.adjustHalLoss(REM * data)
+				data = max(data - 1, 3)
+				..()
+
 		mindbreaker
 			name = "Mindbreaker Toxin"
 			id = "mindbreaker"


### PR DESCRIPTION
This was originally only going to be a small patch, but meh.

-Lowers the cell charge in APCs to 2500 (previously was 5000)
-Lowers the energy cost of lethal laser guns from 1000 to 830 (you can now get 12 shots off instead of 10. NOTE: this does NOT apply to energy guns; this is only laser guns that fire ONLY lethals)
-Lowers the energy cost of the laser cannon from 1250 to 1000
-Fixes laser tag guns not working
-Changes effect of getting shot with a laser tag beam (while wearing a laser tag vest) to HalLoss damage (instead of just a flat out instant weakened state---ie: no more one shot instanwins for laser tag)
-Reworks bear traps a bit; they'll now deal damage and play a sound when activated
-Part exchanger holds more; it can now hold up 50 items (up from 14) and has a combined weight class of 100 (up from 28)
-Brings the handcuffs breakout time in line with the other cuff breakout times (60 seconds instead of 120).
-Lowers wall and portable flasher weakened durations (from 10 to 5 for wall and 8 to 4 for portable) and lessens the eye damage they can cause.
-lowers the weakened duration on flashes from 10 to 5.
-Increases the hit cost of the cattleprod from 2500 to 3750 (oversight when costs were adjusted)
-Lowers the agony amount the cattleprod causes from 60 to 42 (again, oversight)
-Implementes Tirizene; a reagent that causes HalLoss
-Added Tirizene to parapens
-Reworks pushing to its original status, but the weakened duration has been halved (from 4 to 2)
-Disarming will no longer cause guns to "go off in the struggle"

Overall, this should improve combat situations by a decent amount by making them more dynamic
