### PR TITLE
Stamina

### DIFF
--- a/code/WorkInProgress/ZomgPonies/mobs/pony.dm
+++ b/code/WorkInProgress/ZomgPonies/mobs/pony.dm
@@ -43,7 +43,7 @@
 		else
 			if(O.force)
 				var/damage = O.force
-				if (O.damtype == HALLOSS)
+				if (O.damtype == STAMINA)
 					damage = 0
 				health -= damage
 				for(var/mob/M in viewers(src, null))

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -96,6 +96,7 @@
 
 	//game_options.txt configs
 
+	var/health_threshold_softcrit = 0
 	var/health_threshold_crit = 0
 	var/health_threshold_dead = -100
 

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -479,7 +479,7 @@
 	..()
 
 /obj/item/weapon/holo
-	damtype = HALLOSS
+	damtype = STAMINA
 
 /obj/item/weapon/holo/esword
 	desc = "May the force be within you. Sorta"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -314,8 +314,8 @@ About the new airlock wires panel:
 				return
 		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
 			user << "\red <B>You feel a powerful shock course through your body!</B>"
-			user.halloss += 10
-			user.stunned += 10
+			user.staminaloss += 50
+			user.stunned += 5
 			return
 	..(user)
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -188,8 +188,10 @@ REAGENT SCANNER
 					var/datum/data/record/V = virusDB[ID]
 					user.show_message(text("\red Warning: Pathogen [V.fields["name"]] detected in subject's blood. Known antigen : [V.fields["antigen"]]"))
 //			user.show_message(text("\red Warning: Unknown pathogen detected in subject's blood."))
+	if(M.getStaminaLoss())
+		user.show_message("<span class='info'>Subject appears to be suffering from fatigue.</span>")
 	if (M.getCloneLoss())
-		user.show_message("\red Subject appears to have been imperfectly cloned.")
+		user.show_message("<span class='warning'>Subject appears to have [M.getCloneLoss() > 30 ? "severe" : "minor"] cellular damage.</span>")
 //	if (M.reagents && M.reagents.get_reagent_amount("inaprovaline"))
 //		user.show_message("\blue Bloodstream Analysis located [M.reagents:get_reagent_amount("inaprovaline")] units of rejuvenation chemicals.")
 	if (M.has_brain_worms())

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -110,7 +110,7 @@
 	health -= M.melee_damage_upper
 	healthcheck()
 	return
-	
+
 /obj/structure/grille/mech_melee_attack(obj/mecha/M)
 	if(..())
 		playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
@@ -132,7 +132,7 @@
 	if(!Proj)	return
 
 	//Tasers and the like should not damage grilles.
-	if(Proj.damage_type == HALLOSS)
+	if(Proj.damage_type == STAMINA)
 		return
 
 	src.health -= Proj.damage*0.2

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -8,32 +8,32 @@ var/global/wcColored
 	var/list/brig = list("#aa0808", "#7f0606", "#ff0000")
 	var/list/common = list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8fcf44", "#ffffff")
 
-	wcBar = pick(bar)	
+	wcBar = pick(bar)
 	wcBrig = pick(brig)
 	wcCommon = pick(common)
-	
+
 /obj/proc/color_windows(var/obj/W as obj)
 	if(!wcColored)
 		sleep(50) // Sleeping to make sure the glass has initialized on the map
 		wcColored = 1
-		
+
 	var/list/wcBarAreas = list(/area/crew_quarters/bar)
 	var/list/wcBrigAreas = list(/area/security,/area/security/main,/area/security/lobby,/area/security/brig,/area/security/permabrig,/area/security/prison,/area/security/prison/cell_block/A,/area/security/prison/cell_block/B,/area/security/prison/cell_block/C,/area/security/execution,/area/security/processing,/area/security/interrogation,/area/security/interrogationobs,/area/security/evidence,/area/security/prisonlockers,/area/security/medbay,/area/security/processing,/area/security/warden,/area/security/armoury,/area/security/securearmoury,/area/security/armoury/gamma,/area/security/securehallway,/area/security/hos,/area/security/podbay,/area/security/detectives_office,/area/security/range,/area/security/nuke_storage,/area/security/checkpoint,/area/security/checkpoint2,/area/security/checkpoint2,/area/security/checkpoint/supply,/area/security/checkpoint/engineering,/area/security/checkpoint/medical,/area/security/checkpoint/science,/area/security/vacantoffice,/area/security/vacantoffice2,/area/prison,/area/prison/arrival_airlock,/area/prison/control,/area/prison/crew_quarters,/area/prison/rec_room,/area/prison/closet,/area/prison/hallway/fore,/area/prison/hallway/aft,/area/prison/hallway/port,/area/prison/hallway/starboard,/area/prison/morgue,/area/prison/medical_research,/area/prison/medical,/area/prison/solar,/area/prison/podbay,/area/prison/solar_control,/area/prison/solitary,/area/prison/cell_block,/area/prison/cell_block/A,/area/prison/cell_block/B,/area/prison/cell_block/C,/area/shuttle/gamma/space,/area/shuttle/gamma/station)
-	
+
 	var/newcolor
 	for(var/A in wcBarAreas)
 		if(W.areaMaster == locate(A))
 			newcolor = wcBar
 			break
-	
+
 	for(var/A in wcBrigAreas)
 		if(W.areaMaster == locate(A))
 			newcolor = wcBrig
 			break
-			
-	if(!newcolor)	
+
+	if(!newcolor)
 		newcolor = wcCommon
-		
+
 	return newcolor
 
 /obj/structure/window
@@ -56,10 +56,10 @@ var/global/wcColored
 	var/sheets = 1 // Number of sheets needed to build this window (determines how much shit is spawned by destroy())
 //	var/silicate = 0 // number of units of silicate
 //	var/icon/silicateIcon = null // the silicated icon
-	
+
 /obj/structure/window/bullet_act(var/obj/item/projectile/Proj)
 	//Tasers and the like should not damage windows.
-	if(Proj.damage_type == HALLOSS)
+	if(Proj.damage_type == STAMINA)
 		return
 
 	health -= Proj.damage
@@ -281,7 +281,7 @@ var/global/wcColored
 				if(G.amount>=G.max_amount)
 					continue
 				G.attackby(NG, user)
-			
+
 			if (reinf)
 				var/obj/item/stack/rods/NR = new (src.loc)
 				for (var/obj/item/stack/rods/R in src.loc)
@@ -289,7 +289,7 @@ var/global/wcColored
 						continue
 					if(R.amount>=R.max_amount)
 						continue
-					R.attackby(NR, user)			
+					R.attackby(NR, user)
 
 		user << "<span class='notice'>You have disassembled the window.</span>"
 		disassembled = 1
@@ -316,8 +316,8 @@ var/global/wcColored
 
 /obj/structure/window/mech_melee_attack(obj/mecha/M)
 	if(..())
-		hit(M.force, 1)	
-	
+		hit(M.force, 1)
+
 /obj/structure/window/proc/hit(var/damage, var/sound_effect = 1)
 	if(reinf) damage *= 0.5
 	health = max(0, health - damage)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -303,7 +303,7 @@ proc/check_panel(mob/M)
 					if(weapon_name)
 						my_target << sound(pick('sound/weapons/genhit1.ogg', 'sound/weapons/genhit2.ogg', 'sound/weapons/genhit3.ogg'))
 						my_target.show_message("\red <B>[my_target] has been attacked with [weapon_name] by [src.name] </B>", 1)
-						my_target.halloss += 8
+						my_target.staminaloss += 30
 						if(prob(20)) my_target.eye_blurry += 3
 						if(prob(33))
 							if(!locate(/obj/effect/overlay) in my_target.loc)
@@ -311,7 +311,7 @@ proc/check_panel(mob/M)
 					else
 						my_target << sound(pick('sound/weapons/punch1.ogg','sound/weapons/punch2.ogg','sound/weapons/punch3.ogg','sound/weapons/punch4.ogg'))
 						my_target.show_message("\red <B>[src.name] has punched [my_target]!</B>", 1)
-						my_target.halloss += 4
+						my_target.staminaloss += 30
 						if(prob(33))
 							if(!locate(/obj/effect/overlay) in my_target.loc)
 								fake_blood(my_target)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -187,6 +187,11 @@
 				if(status == "")
 					status = "OK"
 				src.show_message(text("\t []My [] is [].",status=="OK"?"\blue ":"\red ",org.display_name,status),1)
+			if(staminaloss)
+				if(staminaloss > 30)
+					src << "<span class='info'>You're completely exhausted.</span>"
+				else
+					src << "<span class='info'>You feel fatigued.</span>"
 			if((SKELETON in H.mutations) && (!H.w_uniform) && (!H.wear_suit))
 				H.play_xylophone()
 		else if(lying) // /vg/: For hugs. This is how update_icon figgers it out, anyway.  - N3X15

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -33,7 +33,7 @@
 
 			visible_message("\red <B>[M] has punched [src]!</B>")
 
-			apply_damage(damage, HALLOSS, affecting, armor_block)
+			apply_damage(damage, STAMINA, affecting, armor_block)
 			if(damage >= 9)
 				visible_message("\red <B>[M] has weakened [src]!</B>")
 				apply_effect(4, WEAKEN, armor_block)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -15,7 +15,7 @@
 
 	if((M_RUN in mutations)) return -1
 
-	var/health_deficiency = (100 - health)
+	var/health_deficiency = (100 - health + staminaloss)
 
 	if(health_deficiency >= 40) tally += (health_deficiency / 25)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1062,6 +1062,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 					adjustHalLoss(-3)
 			else if(sleeping)
 				handle_dreams()
+				adjustStaminaLoss(-10)
 				adjustHalLoss(-3)
 				if (mind)
 					if((mind.active && client != null) || immune_to_ssd) //This also checks whether a client is connected, if not, sleep is not reduced.
@@ -1166,6 +1167,8 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			// If you're dirty, your gloves will become dirty, too.
 			if(gloves && germ_level > gloves.germ_level && prob(10))
 				gloves.germ_level += 1
+
+			CheckStamina()
 
 		return 1
 
@@ -1356,7 +1359,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 						if(2)	healths.icon_state = "health7"
 						else
 							//switch(health - halloss)
-							switch(100 - ((species && species.flags & NO_PAIN) ? 0 : traumatic_shock))
+							switch(100 - ((species && species.flags & NO_PAIN) ? 0 : traumatic_shock) - staminaloss)
 								if(100 to INFINITY)		healths.icon_state = "health0"
 								if(80 to 100)			healths.icon_state = "health1"
 								if(60 to 80)			healths.icon_state = "health2"

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -569,6 +569,9 @@
 
 			//Other
 			handle_statuses()
+
+			CheckStamina()
+
 		return 1
 
 

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -24,11 +24,13 @@
 			adjustCloneLoss(damage/(blocked+1))
 		if(HALLOSS)
 			adjustHalLoss(damage/(blocked+1))
+		if(STAMINA)
+			adjustStaminaLoss(damage/(blocked+1))
 	updatehealth()
 	return 1
 
 
-/mob/living/proc/apply_damages(var/brute = 0, var/burn = 0, var/tox = 0, var/oxy = 0, var/clone = 0, var/halloss = 0, var/def_zone = null, var/blocked = 0)
+/mob/living/proc/apply_damages(var/brute = 0, var/burn = 0, var/tox = 0, var/oxy = 0, var/clone = 0, var/halloss = 0, var/def_zone = null, var/blocked = 0, var/stamina = 0)
 	if(blocked >= 2)	return 0
 	if(brute)	apply_damage(brute, BRUTE, def_zone, blocked)
 	if(burn)	apply_damage(burn, BURN, def_zone, blocked)
@@ -36,6 +38,7 @@
 	if(oxy)		apply_damage(oxy, OXY, def_zone, blocked)
 	if(clone)	apply_damage(clone, CLONE, def_zone, blocked)
 	if(halloss) apply_damage(halloss, HALLOSS, def_zone, blocked)
+	if(stamina) apply_damage(stamina, STAMINA, def_zone, blocked)
 	return 1
 
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -14,8 +14,8 @@
 	var/fireloss = 0.0	//Burn damage caused by being way too hot, too cold or burnt.
 	var/cloneloss = 0	//Damage caused by being cloned or ejected from the cloner early. slimes also deal cloneloss damage to victims
 	var/brainloss = 0	//'Retardation' damage caused by someone hitting you in the head with a bible or being infected with brainrot.
-	var/halloss = 0		//Hallucination damage. 'Fake' damage obtained through hallucinating or the holodeck. Sleeping should cause it to wear off.
-
+	var/halloss = 0		//Hallucination damage; utilize this largely for fake "pain" based damage. Sleeping should cause it to wear of
+	var/staminaloss = 0 //Stamina damage, or exhaustion. You recover it slowly naturally, and are stunned if it gets too high. Holodeck and hallucinations deal this.
 
 	var/hallucination = 0 //Directly affects how long a mob will hallucinate for
 	var/list/atom/hallucinations = list() //A list of hallucinated people that try to attack the mob. See /obj/effect/fake_attacker in hallucinations.dm

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -112,7 +112,7 @@
 /mob/living/simple_animal/construct/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(O.force)
 		var/damage = O.force
-		if (O.damtype == HALLOSS)
+		if (O.damtype == STAMINA)
 			damage = 0
 		adjustBruteLoss(damage)
 		for(var/mob/M in viewers(src, null))
@@ -154,7 +154,7 @@
 	if(O.force)
 		if(O.force >= 11)
 			var/damage = O.force
-			if (O.damtype == HALLOSS)
+			if (O.damtype == STAMINA)
 				damage = 0
 			adjustBruteLoss(damage)
 			for(var/mob/M in viewers(src, null))
@@ -282,7 +282,7 @@
 	if(O.force)
 		if(O.force >= 11)
 			var/damage = O.force
-			if (O.damtype == HALLOSS)
+			if (O.damtype == STAMINA)
 				damage = 0
 			adjustBruteLoss(damage)
 			for(var/mob/M in viewers(src, null))

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -141,7 +141,7 @@
 	else
 		if(O.force)
 			var/damage = O.force
-			if (O.damtype == HALLOSS)
+			if (O.damtype == STAMINA)
 				damage = 0
 			adjustBruteLoss(damage)
 			for(var/mob/M in viewers(src, null))

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -61,7 +61,7 @@
 	if(O.force)
 		if(prob(80))
 			var/damage = O.force
-			if (O.damtype == HALLOSS)
+			if (O.damtype == STAMINA)
 				damage = 0
 			health -= damage
 			visible_message("\red \b [src] has been attacked with the [O] by [user]. ")

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -46,7 +46,7 @@
 		else
 			if(O.force)
 				var/damage = O.force
-				if (O.damtype == HALLOSS)
+				if (O.damtype == STAMINA)
 					damage = 0
 				health -= damage
 				for(var/mob/M in viewers(src, null))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -161,7 +161,7 @@
 
 			if( abs(Environment.temperature - bodytemperature) > 40 )
 				bodytemperature += ((Environment.temperature - bodytemperature) / 5)
-			
+
 			if(min_oxy)
 				if(Environment.oxygen < min_oxy)
 					atmos_suitable = 0
@@ -188,7 +188,7 @@
 					atmos_suitable = 0
 			if(flags & NO_BREATHE || flags & IS_SYNTHETIC)
 				atmos_suitable = 1
-				
+
 	//Atmos effect
 	if(bodytemperature < minbodytemp)
 		adjustBruteLoss(cold_damage_per_tick)
@@ -398,7 +398,7 @@
 	else
 		if(O.force)
 			var/damage = O.force
-			if (O.damtype == HALLOSS)
+			if (O.damtype == STAMINA)
 				damage = 0
 			adjustBruteLoss(damage)
 			for(var/mob/M in viewers(src, null))

--- a/code/modules/mob/living/simple_animal/vox.dm
+++ b/code/modules/mob/living/simple_animal/vox.dm
@@ -36,7 +36,7 @@
 	if(O.force)
 		if(O.force >= 25)
 			var/damage = O.force
-			if (O.damtype == HALLOSS)
+			if (O.damtype == STAMINA)
 				damage = 0
 			health -= damage
 			for(var/mob/M in viewers(src, null))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -245,7 +245,7 @@
 				mouthshoot = 0
 				return
 			in_chamber.on_hit(M)
-			if (in_chamber.damage_type != HALLOSS)
+			if (in_chamber.damage_type != STAMINA)
 				user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, "head", used_weapon = "Point blank shot in the mouth with \a [in_chamber]", sharp=1)
 				user.death()
 			else

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -66,6 +66,7 @@
 	icon_state = "omnilaser"
 	hitsound = null
 	damage = 0
+	damage_type = STAMINA
 	flag = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)
@@ -75,7 +76,7 @@
 		var/mob/living/carbon/human/M = target
 		if(istype(M.wear_suit))
 			if(M.wear_suit.type in suit_types)
-				M.adjustHalLoss(34)
+				M.adjustStaminaLoss(34)
 	return 1
 
 /obj/item/projectile/lasertag/omni

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -75,7 +75,7 @@
 	name = "disabler beam"
 	icon_state = "omnilaser"
 	damage = 34
-	damage_type = HALLOSS
+	damage_type = STAMINA
 	var/range = 8
 
 /obj/item/projectile/energy/disabler/Range()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2088,7 +2088,7 @@ datum
 			data = 13
 
 			on_mob_life(var/mob/living/M)
-				M.adjustHalLoss(REM * data)
+				M.adjustStaminaLoss(REM * data)
 				data = max(data - 1, 3)
 				..()
 

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -474,6 +474,7 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define OXY			"oxy"
 #define CLONE		"clone"
 #define HALLOSS		"halloss"
+#define STAMINA 	"stamina"
 
 #define STUN		"stun"
 #define WEAKEN		"weaken"
@@ -633,6 +634,7 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 #define OXY			"oxy"
 #define CLONE		"clone"
 #define HALLOSS		"halloss"
+#define STAMINA 	"stamina"
 
 #define STUN		"stun"
 #define WEAKEN		"weaken"


### PR DESCRIPTION
Stamina Patch

-Implements Stamina, a new damage type

Ok, this definitely needs explanation:

Provided we go back to non-instantaneous stuns for tasers, I thoroughly believe that the Stamina damage type resolves a lot of the problems HalLoss has. First, an explanation of how it works:

-Stamina damage is tracked from 0 to 100
-Taking stamina damage will make you appear to be hurt, even though you're not taking any real damage
-Stamina damage slows you down based on the same formula as if you had taken actual damage
-Upon taking 100 stamina damage MINUS how much real damage you've already taken, you will collapse on the floor for 5 seconds; this means that if someone has 50 tox/brute/burn/oxy/clone damage, they can only take 50 stamina damage before collapsing, while someone who is at 0 real damage will have to take a full 100 stamina damage before collapsing.
-Effectiveness is IMPOSSIBLE to reduce with painkillers (load up on painkillers all you want, you're still going to get slowed and still going to get stunned) 
-Examining yourself will reveal if you're under the effects of Staminaloss (so will a health analyzer)

While this may sound identical to HalLoss--it's not, and I'll explain below why I believe it solves a lot of HalLoss's issues:

-HalLoss is also tracked from 0 to 100
-upon hitting 100 HalLoss, you will be knocked unconscious for 10 seconds
-HalLoss is a part of a mob's total health, therefore it causes slowdown because it lowers your effective health
-HalLoss also causes a huge indepedent slow; it's effectively double-proccing a slow--once from your total health being lowered and again just from being HalLoss
-HalLoss, by virtue of causes pain also triggers an additional movement slow by inducing the mob into shock which (not surprisingly) slows movement even more and can (in very rare cases) lead to an additional paralysis time from the shock itself.
-The end result is a literal triple-bundle of slows all being applied at once. This means that taking even very little HalLoss means you're effectively ground to an absolute halt; additionally, even after the unconscious state wears off, you can barely move because of how HalLoss value have to decrease---not to mention you have to wait for shock to wear off (andddd the latter, in particular takes a very long time). In an actual scenario, this means that if an officer hits you with a taser even once, then keeps on missing (or runs out of ammo), you're left in a state of incredible weakness for a good 30-60 seconds
-Painkillers greatly reduce and even completely eliminate the effectiveness of HalLoss--no matter how much painkillers are nerfed, you will always---always be able to abuse them against paincrit.

Functionally, both accomplish similar things, but I feel stamina accomplishes it better and doesn't have the abusiveness of triple-stacked slows behind it, plus it lacks the inherent weakness of HalLoss as well.

If you would like to see StaminaLoss in action, then I recommend checking out the disabler that you can order form cargo. Alternatively, grab a toy lasergun and put some the related armor on and have a buddy do the same while you take turns shooting each other. Parapens also come loaded with a reagent that induces staminaloss.

Other Changes:

-Changes the flavortext for clone damage on Health Analyzers and gives a very rough idea of how much or how little clone damage someone has.
-Updates rolling on the ground to extinguish yourself; it now has the proper delay before you're extinguished and makes you actually roll around.
-Makes the rejuvinate verb reset HalLoss and StaminaLoss
