### PR TITLE
Movement speed

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/human/movement_delay()
 	var/tally = 0
+	if(status_flags & GOTTAGOFAST)
+		tally -= 1
 
 	if(species && species.flags & IS_SLOW)
 		tally = 5
@@ -8,10 +10,6 @@
 
 	if(embedded_flag)
 		handle_embedded_objects() //Moving with objects stuck in you can cause bad times.
-
-	if(reagents.has_reagent("hyperzine")) return -1
-
-	if(reagents.has_reagent("nuka_cola")) return -1
 
 	if((M_RUN in mutations)) return -1
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -113,10 +113,8 @@
 
 /mob/living/carbon/monkey/movement_delay()
 	var/tally = 0
-	if(reagents)
-		if(reagents.has_reagent("hyperzine")) return -1
-
-		if(reagents.has_reagent("nuka_cola")) return -1
+	if(status_flags & GOTTAGOFAST)
+		tally -= 1
 
 	var/health_deficiency = (100 - health)
 	if(health_deficiency >= 45) tally += (health_deficiency / 25)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -391,10 +391,18 @@ datum
 						del(A)
 						update_total()
 						my_atom.on_reagent_change()
+						check_gofast(my_atom)
 						return 0
 
 
 				return 1
+
+			check_gofast(var/mob/M)
+				if(istype(M, /mob))
+					if(M.reagents.has_reagent("hyperzine")||M.reagents.has_reagent("nuka_cola"))
+						return 1
+					else
+						M.status_flags &= ~GOTTAGOFAST
 
 			update_total()
 				total_volume = 0

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1948,7 +1948,9 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
 				if(prob(5)) M.emote(pick("twitch","blink_r","shiver"))
-				..()
+				M.status_flags |= GOTTAGOFAST
+				holder.remove_reagent(src.id, 0.5 * REAGENTS_METABOLISM)
+			//	..()
 				return
 
 		cryoxadone
@@ -3219,6 +3221,7 @@ datum
 						M.druggy = max(M.druggy, 30)
 						M.dizziness +=5
 						M.drowsyness = 0
+						M.status_flags |= GOTTAGOFAST
 						..()
 						return
 

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -498,6 +498,7 @@ var/list/global_mutations = list() // list of hidden mutation things
 #define CANPUSH		8
 #define LEAPING		16
 #define PASSEMOTES	32      //Mob has a cortical borer or holders inside of it that need to see emotes.
+#define GOTTAGOFAST	64
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define DISFIGURED	16384	//I'll probably move this elsewhere if I ever get wround to writing a bitflag mob-damage system


### PR DESCRIPTION
Changes how hyperzine/nuka cola behaves:

-Hyperzine metabolism lowered from 0.4 to 0.2
-Hyperzine/nuka cola increases your movement speed by one level.
-Hyperzine/nuka cola no longer prevent you from being encumbered

Essentially it's a speed boost chem now, but if you've taken damage you're still going to be slowed. That is to say, it's far far more effective and useful if you're not slowed by anything and are at full health, but if you're wearing a whole bunch of gear/heavily damaged, it's not going to be nearly as effective as it was before.
