### PR TITLE
Assorted Fixes / Changes

### DIFF
--- a/code/game/machinery/hydroponics.dm
+++ b/code/game/machinery/hydroponics.dm
@@ -713,24 +713,19 @@
 				check_level_sanity()
 				update_icon()
 
-		//Check if container is Plant-B-Gone spray (doesn't work with other sprays, may add in future)
-		else if (istype(O, /obj/item/weapon/reagent_containers/spray/plantbgone))
+		//Check if container is any spray container
+		else if (istype(O, /obj/item/weapon/reagent_containers/spray))
+			var/obj/item/weapon/reagent_containers/spray/S = O
 			//Check if there is a plant in the tray
 			if(seed)
-				health -= rand(5,20)
-
-				if(pestlevel > 0)
-					pestlevel -= 2
-
-				if(weedlevel > 0)
-					weedlevel -= 3
-
-				toxins += 4
-
-				check_level_sanity()
-
+				if(!S.reagents.total_volume)
+					user << "\red [S] is empty."
+					return
+				//Container not empty, transfer contents to tray
+				S.reagents.trans_to(src, S.amount_per_transfer_from_this)
 				visible_message("\red <B>\The [src] has been sprayed with \the [O][(user ? " by [user]." : ".")]")
 				playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
+				check_level_sanity()
 				update_icon()
 			else
 				user << "There's nothing in [src] to spray!"

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -480,7 +480,7 @@
 
 		if(S.brute_dam)
 			var/obj/item/weapon/weldingtool/WT = src
-			if (WT.remove_fuel(0,user))
+			if (WT.remove_fuel(0,null))
 				playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
 				S.heal_damage(15,0,0,1)
 				user.visible_message("\red \The [user] patches some dents on \the [M]'s [S.display_name] with \the [src].")

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -495,6 +495,9 @@ datum
 					var/mob/living/carbon/human/human = M
 					if(human.dna.mutantrace == null)
 						M << "\red Your flesh rapidly mutates!"
+						M << "<b>You are now a Shadow Person, a mutant race of darkness-dwelling humanoids.</b>"
+						M << "\red Your body reacts violently to light. \green However, it naturally heals in darkness."
+						M << "Aside from your new traits, you are mentally unchanged and retain your prior obligations."
 						human.dna.mutantrace = "shadow"
 						human.update_mutantrace()
 				..()


### PR DESCRIPTION
Hydroponics trays can now be sprayed with any spray container (Space
Cleaner bottles, Chemsprayers, Plant-B-Gone bottles, etc) and will
correctly transfer the actual reagents to the tray and remove them from
the container.

Repairing robotic limbs with a welder will no longer cause eye damage.
This will allow medical to repair IPCs and prosthetic limbs again
without needing a welding mask/goggles. May also extend to fixing up
borgs with a welder too. The sounds and other recent IPC changes are
unaffected.

Anyone injected with Slime Toxin, the special reagent from Green Slime
Extract, will now receive some messages explaining their new form.
Should hopefully avoid confusion regarding Shadow People and the
previously unexplained damage they were receiving. At this time, the
dark sight for Shadow People is likely still not functioning properly,
and will hopefully be improved in the near future.
