### PR TITLE
more advanced hotkey mode system + AZERTY hotkey mode

### DIFF
--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -55,3 +55,19 @@
 	// /vg/: MEDIAAAAAAAA
 	// Set on login.
 	var/datum/media_manager/media = null
+
+	/////////////////////////////////////////////////////////////////////
+	//adv. hotkey mode vars, code using them in /interface/interface.dm//
+	/////////////////////////////////////////////////////////////////////
+
+	var/hotkeytype = "QWERTY" //what set of hotkeys is in use(defaulting to QWERTY because I can't be bothered to ake this save on SQL)
+	var/hotkeyon = 0 //is the hotkey on?
+
+	var/hotkeylist = list( //list defining hotkey types, look at lists in place for structure if adding any if the future
+		"QWERTY" = list(
+			"on" = "hotkeymode",
+			"off" = "macro"),
+		"AZERTY" = list(
+			"on" = "AZERTYon",
+			"off" = "AZERTYoff")
+	)

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -119,3 +119,34 @@ Admin:
 	src << other
 	if(holder)
 		src << admin
+
+
+/client/verb/hotkey_toggle()//toggles hotkey mode between on and off, respects selected type
+	set name = ".Toggle hotkey mode"
+
+	hotkeyon = !hotkeyon//toggle the var
+
+	var/hotkeys = hotkeylist[hotkeytype]//get the list containing the hotkey names
+	var/hotkeyname = hotkeys[hotkeyon ? "on" : "off"]//get the name of the hotkey, to not clutter winset() to much
+
+	winset(usr, "mainwindow", "macro=[hotkeyname]")//change the hotkey
+	usr << (hotkeyon ? "Hotkey mode enabled." : "Hotkey mode disabled.")//feedback to the user
+
+	if(hotkeyon)//using an if statement because I don't want to clutter winset() with ? operators
+		winset(usr, "mainwindow.hotkey_toggle", "is-checked=true")//checks the button
+		winset(usr, "mainwindow.mapwindow", "focus=true")//sets mapwindow focus
+	else
+		winset(usr, "mainwindow.hotkey_toggle", "is-checked=false")//unchecks the button
+		winset(usr, "mainwindow.input", "focus=true")//sets focus
+
+/client/verb/hotkey_mode()//asks user for the hotkey type and changes the macro accordingly
+	set name = "Set hotkey mode"
+	set category = "Preferences"
+
+	hotkeytype = input("Choose hotkey mode", "Hotkey mode") as null|anything in hotkeylist//ask the user for the hotkey type
+
+	var/hotkeys = hotkeylist[hotkeytype]//get the list containing the hotkey names
+	var/hotkeyname = hotkeys[hotkeyon ? "on" : "off"]//get the name of the hotkey, to not clutter winset() to much
+
+	winset(usr, "mainwindow", "macro=[hotkeyname]")//change the hotkey
+	usr << "Hotkey mode changed to [hotkeytype]."

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -121,6 +121,8 @@ Admin:
 		src << admin
 
 
+//adv. hotkey mode verbs, vars located in /code/modules/client/client defines.dm
+
 /client/verb/hotkey_toggle()//toggles hotkey mode between on and off, respects selected type
 	set name = ".Toggle hotkey mode"
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,7 +1,439 @@
+macro "AZERTYoff"
+	elem 
+		name = "TAB"
+		command = ".Toggle-hotkey-mode"
+		is-disabled = false
+	elem 
+		name = "CENTER+REP"
+		command = ".center"
+		is-disabled = false
+	elem 
+		name = "NORTHEAST"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHEAST"
+		command = ".southeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHWEST"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "NORTHWEST"
+		command = ".northwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+WEST"
+		command = "westface"
+		is-disabled = false
+	elem 
+		name = "WEST+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+NORTH"
+		command = "northface"
+		is-disabled = false
+	elem 
+		name = "NORTH+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "CTRL+EAST"
+		command = "eastface"
+		is-disabled = false
+	elem 
+		name = "EAST+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+SOUTH"
+		command = "southface"
+		is-disabled = false
+	elem 
+		name = "SOUTH+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "INSERT"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "DELETE"
+		command = "delete-key-pressed"
+		is-disabled = false
+	elem 
+		name = "CTRL+1"
+		command = "a-intent help"
+		is-disabled = false
+	elem 
+		name = "CTRL+2"
+		command = "a-intent disarm"
+		is-disabled = false
+	elem 
+		name = "CTRL+3"
+		command = "a-intent grab"
+		is-disabled = false
+	elem 
+		name = "CTRL+4"
+		command = "a-intent hurt"
+		is-disabled = false
+	elem 
+		name = "CTRL+A"
+		command = ".northwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+D+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+E"
+		command = "quick-equip"
+		is-disabled = false
+	elem 
+		name = "CTRL+F"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "CTRL+G"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "CTRL+Q+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+R"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+S+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "CTRL+W"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+X"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+Z+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "F1"
+		command = "adminhelp"
+		is-disabled = false
+	elem 
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+		is-disabled = false
+	elem 
+		name = "F2"
+		command = "ooc"
+		is-disabled = false
+	elem 
+		name = "F2+REP"
+		command = ".screenshot auto"
+		is-disabled = false
+	elem 
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+		is-disabled = false
+	elem 
+		name = "F3"
+		command = "say"
+		is-disabled = false
+	elem 
+		name = "F4"
+		command = "me"
+		is-disabled = false
+	elem 
+		name = "F5"
+		command = "asay"
+		is-disabled = false
+	elem 
+		name = "F6"
+		command = "Player-Panel-New"
+		is-disabled = false
+	elem 
+		name = "F7"
+		command = "Admin-PM"
+		is-disabled = false
+	elem 
+		name = "F8"
+		command = "Invisimin"
+		is-disabled = false
+	elem 
+		name = "F12"
+		command = "F12"
+		is-disabled = false
+
+macro "AZERTYon"
+	elem 
+		name = "TAB"
+		command = ".Toggle-hotkey-mode"
+		is-disabled = false
+	elem 
+		name = "CENTER+REP"
+		command = ".center"
+		is-disabled = false
+	elem 
+		name = "NORTHEAST"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHEAST"
+		command = ".southeast"
+		is-disabled = false
+	elem 
+		name = "SOUTHWEST"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "NORTHWEST"
+		command = ".northwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+WEST"
+		command = "westface"
+		is-disabled = false
+	elem 
+		name = "WEST+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+NORTH"
+		command = "northface"
+		is-disabled = false
+	elem 
+		name = "NORTH+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "CTRL+EAST"
+		command = "eastface"
+		is-disabled = false
+	elem 
+		name = "EAST+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+SOUTH"
+		command = "southface"
+		is-disabled = false
+	elem 
+		name = "SOUTH+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "INSERT"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "DELETE"
+		command = "delete-key-pressed"
+		is-disabled = false
+	elem 
+		name = "1"
+		command = "a-intent help"
+		is-disabled = false
+	elem 
+		name = "CTRL+1"
+		command = "a-intent help"
+		is-disabled = false
+	elem 
+		name = "2"
+		command = "a-intent disarm"
+		is-disabled = false
+	elem 
+		name = "CTRL+2"
+		command = "a-intent disarm"
+		is-disabled = false
+	elem 
+		name = "3"
+		command = "a-intent grab"
+		is-disabled = false
+	elem 
+		name = "CTRL+3"
+		command = "a-intent grab"
+		is-disabled = false
+	elem 
+		name = "4"
+		command = "a-intent harm"
+		is-disabled = false
+	elem 
+		name = "CTRL+4"
+		command = "a-intent harm"
+		is-disabled = false
+	elem 
+		name = "A"
+		command = ".northwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+A"
+		command = ".northwest"
+		is-disabled = false
+	elem 
+		name = "D+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "CTRL+D+REP"
+		command = ".east"
+		is-disabled = false
+	elem 
+		name = "E"
+		command = "quick-equip"
+		is-disabled = false
+	elem 
+		name = "CTRL+E"
+		command = "quick-equip"
+		is-disabled = false
+	elem 
+		name = "F"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "CTRL+F"
+		command = "a-intent left"
+		is-disabled = false
+	elem 
+		name = "G"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "CTRL+G"
+		command = "a-intent right"
+		is-disabled = false
+	elem 
+		name = "H"
+		command = ".holster"
+		is-disabled = false
+	elem 
+		name = "CTRL+H"
+		command = ".holster"
+		is-disabled = false
+	elem 
+		name = "Q+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "CTRL+Q+REP"
+		command = ".west"
+		is-disabled = false
+	elem 
+		name = "R"
+		command = ".southwest"
+		is-disabled = false
+	elem 
+		name = "CTRL+R"
+		command = ".southwest"
+		is-disabled = false
+	elem "s_key"
+		name = "S+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "CTRL+S+REP"
+		command = ".south"
+		is-disabled = false
+	elem 
+		name = "T"
+		command = "say"
+		is-disabled = false
+	elem 
+		name = "W"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+W"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "X"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "CTRL+X"
+		command = ".northeast"
+		is-disabled = false
+	elem 
+		name = "Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem 
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+		is-disabled = false
+	elem "w_key"
+		name = "Z+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "CTRL+Z+REP"
+		command = ".north"
+		is-disabled = false
+	elem 
+		name = "F1"
+		command = "adminhelp"
+		is-disabled = false
+	elem 
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+		is-disabled = false
+	elem 
+		name = "F2"
+		command = "ooc"
+		is-disabled = false
+	elem 
+		name = "F2+REP"
+		command = ".screenshot auto"
+		is-disabled = false
+	elem 
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+		is-disabled = false
+	elem 
+		name = "F3"
+		command = "say"
+		is-disabled = false
+	elem 
+		name = "F4"
+		command = "me"
+		is-disabled = false
+	elem 
+		name = "F5"
+		command = "asay"
+		is-disabled = false
+	elem 
+		name = "F6"
+		command = "Player-Panel-New"
+		is-disabled = false
+	elem 
+		name = "F7"
+		command = "Admin-PM"
+		is-disabled = false
+	elem 
+		name = "F8"
+		command = "Invisimin"
+		is-disabled = false
+	elem 
+		name = "F12"
+		command = "F12"
+		is-disabled = false
+
 macro "macro"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
+		command = ".Toggle-hotkey-mode"
 		is-disabled = false
 	elem 
 		name = "CENTER+REP"
@@ -179,7 +611,7 @@ macro "macro"
 macro "hotkeymode"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true\""
+		command = ".Toggle-hotkey-mode"
 		is-disabled = false
 	elem 
 		name = "CENTER+REP"
@@ -1207,7 +1639,7 @@ window "mainwindow"
 		on-size = ""
 		text = "Hotkey Toggle"
 		image = ""
-		command = ".winset \"mainwindow.macro!=macro ? mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true : mainwindow.macro=hotkeymode hotkey_toggle.is-checked=true mapwindow.map.focus=true\""
+		command = ".Toggle-hotkey-mode"
 		is-flat = false
 		stretch = false
 		is-checked = false

--- a/paradise.dme
+++ b/paradise.dme
@@ -1243,7 +1243,7 @@
 #include "code\modules\mob\living\simple_animal\friendly\corgi.dm"
 #include "code\modules\mob\living\simple_animal\friendly\crab.dm"
 #include "code\modules\mob\living\simple_animal\friendly\farm_animals.dm"
-#include "code\modules\mob\living\simple_animal\friendly\Fox.dm"
+#include "code\modules\mob\living\simple_animal\friendly\fox.dm"
 #include "code\modules\mob\living\simple_animal\friendly\lizard.dm"
 #include "code\modules\mob\living\simple_animal\friendly\mouse.dm"
 #include "code\modules\mob\living\simple_animal\friendly\slime.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1243,7 +1243,7 @@
 #include "code\modules\mob\living\simple_animal\friendly\corgi.dm"
 #include "code\modules\mob\living\simple_animal\friendly\crab.dm"
 #include "code\modules\mob\living\simple_animal\friendly\farm_animals.dm"
-#include "code\modules\mob\living\simple_animal\friendly\fox.dm"
+#include "code\modules\mob\living\simple_animal\friendly\Fox.dm"
 #include "code\modules\mob\living\simple_animal\friendly\lizard.dm"
 #include "code\modules\mob\living\simple_animal\friendly\mouse.dm"
 #include "code\modules\mob\living\simple_animal\friendly\slime.dm"


### PR DESCRIPTION
Adds a more advanced hotkey mode system, using verbs instead of .dmf defined .winset commands, this new system allows for easier addition of additional hotkey presets(AZERTY, DVORAK, you name the keyboard type, it can be added).

How it works:

Macros are defined in the .dmf, in this PR.
The .dmf has 4 macros, QWERTY on, QWERTY off, AZERTY on, AZERTY off.
This PR does NOT allow for macros to be defined at runtime by the user, for obvious reasons.
(note: not even adminbus can add or edit macros, they can modify the list keeping track of them in /client datums, but the most that'll do is break macro switching for that verb)

The way switching hotkey mode works now: verbs; 
Pressing the hotkey mode button (at the bottom right of the screen) toggles hotkey mode for the selected keyboard type.

Selecting the keyboard type is done by using the "Set hotkey mode" verb in the preferences tab.
Both pressing tab on your keyboard and using the button at the bottom right of the window activates the verb ".Toggle hotkey mode", which simply checks what keyboard type the user has active, and toggles hotkey mode

Vars for keeping track & names of the macros are in /code/modules/client/client defined.dm, the NAMES (note, only the names, the names simply correspond to a macro in /interface/skin.dmf)
are kept track of in the list /client/hotkeylist, using the following format

$name_of_keyboard_type = list(
         "on" = $name_of_macro_if_on,
         "off" = $name_of_macro_if_off)

Both verbs simply work by doing winset(usr, mainwindow, "macro=[$name of macro selected]"), among some variable sets for keeping track ,and winsetting the hotkeymode button on the window checked if required and setting focusses.