### PR TITLE
Let observers join as drones instantly

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -117,9 +117,16 @@
 	var/deathtimeseconds = round((deathtime - deathtimeminutes * 600) / 10,1)
 
 	if (deathtime < 6000)
-		usr << "You have been dead for[pluralcheck] [deathtimeseconds] seconds."
-		usr << "You must wait 10 minutes to respawn as a drone!"
-		return
+		if(istype(src,/mob/dead/observer))
+			var/mob/dead/observer/O = src	
+			if(O.started_as_observer == 0)
+				usr << "You have been dead for[pluralcheck] [deathtimeseconds] seconds."
+				usr << "You must wait 10 minutes to respawn as a drone!"
+				return			
+		else
+			usr << "You have been dead for[pluralcheck] [deathtimeseconds] seconds."
+			usr << "You must wait 10 minutes to respawn as a drone!"
+			return
 
 	for(var/obj/machinery/drone_fabricator/DF in world)
 		if(DF.stat & NOPOWER || !DF.produce_drones)


### PR DESCRIPTION
Changes:
1) Observers can now instantly join as drones, without having to wait ten minutes.