### PR TITLE
Fix alien observer picking

### DIFF
--- a/code/WorkInProgress/ZomgPonies/mobs/metroid/powers.dm
+++ b/code/WorkInProgress/ZomgPonies/mobs/metroid/powers.dm
@@ -250,7 +250,7 @@
 
 			if(new_slime.client)
 				if(babies.len)
-					var/list/candidates = get_slime_candidates()
+					var/list/candidates = get_candidates(BE_SLIME)
 					if(candidates.len)
 						var/mob/dead/observer/picked = pick(candidates)
 						var/mob/living/carbon/slime/S = pick(babies)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -311,80 +311,17 @@ proc/isInSight(var/atom/A, var/atom/B)
 			return M
 	return null
 
-// Will return a list of active candidates. It increases the buffer 5 times until it finds a candidate which is active within the buffer.
-/proc/get_active_candidates(var/buffer = 1)
-
-	var/list/candidates = list() //List of candidate KEYS to assume control of the new larva ~Carn
-	var/i = 0
-	while(candidates.len <= 0 && i < 5)
-		for(var/mob/G in respawnable_list)
-			if(((G.client.inactivity/10)/60) <= buffer + i) // the most active players are more likely to become an alien
+/proc/get_candidates(be_special_flag=0, afk_bracket=3000)
+	var/list/candidates = list()
+	// Keep looping until we find a non-afk candidate within the time bracket (we limit the bracket to 10 minutes (6000))
+	while(!candidates.len && afk_bracket < 6000)
+		for(var/mob/dead/observer/G in player_list)
+			if(G.client != null)
 				if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-					candidates += G.key
-		i++
+					if(!G.client.is_afk(afk_bracket) && (G.client.prefs.be_special & be_special_flag))
+						candidates += G.client
+		afk_bracket += 600 // Add a minute to the bracket, for every attempt
 	return candidates
-
-// Same as above but for alien candidates.
-
-/proc/get_alien_candidates()
-
-	var/list/candidates = list() //List of candidate KEYS to assume control of the new larva ~Carn
-	var/i = 0
-	while(candidates.len <= 0 && i < 5)
-		for(var/mob/G in respawnable_list)
-			if( G.client && G.client.prefs.be_special & BE_ALIEN)
-				if(((G.client.inactivity/10)/60) <= ALIEN_SELECT_AFK_BUFFER + i) // the most active players are more likely to become an alien
-					if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-						candidates += G.key
-		i++
-	return candidates
-	
-/proc/get_blob_candidates()
-
-	var/list/candidates = list() //List of candidate KEYS to assume control of the new blob core ~Carn
-	var/i = 0
-	while(candidates.len <= 0 && i < 5)
-		for(var/mob/G in respawnable_list)
-			if( G.client && G.client.prefs.be_special & BE_BLOB)
-				if(((G.client.inactivity/10)/60) <= ALIEN_SELECT_AFK_BUFFER + i) // the most active players are more likely to become an alien
-					if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-						candidates += G.key
-		i++
-	return candidates	
-	
-/proc/get_vox_candidates()
-
-	var/list/candidates = list() //List of candidate KEYS to assume control of the new blob core ~Carn
-	var/i = 0
-	while(candidates.len <= 0 && i < 5)
-		for(var/mob/G in respawnable_list)
-			if( G.client && G.client.prefs.be_special & BE_RAIDER)
-				if(((G.client.inactivity/10)/60) <= ALIEN_SELECT_AFK_BUFFER + i) // the most active players are more likely to become an alien
-					if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-						candidates += G.key
-		i++
-	return candidates	
-
-/proc/get_slime_candidates()
-
-	var/list/candidates = list() //List of candidate KEYS to assume control of the new larva ~Carn
-	var/i = 0
-	while(candidates.len <= 0 && i < 5)
-		for(var/mob/G in respawnable_list)
-			if( G.client && G.client.prefs.be_special & BE_SLIME)
-				if(((G.client.inactivity/10)/60) <= ALIEN_SELECT_AFK_BUFFER + i) // the most active players are more likely to become a slime
-					if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-						candidates += G.key
-		i++
-	return candidates
-
-proc/get_candidates(be_special_flag=0)
-	. = list()
-	for(var/mob/G in respawnable_list)
-		if(G)
-			if(!(G.mind && G.mind.current && G.mind.current.stat != DEAD))
-				if(!G.client.is_afk() && (G.client.prefs.be_special & be_special_flag))
-					. += G.client
 
 /proc/ScreenText(obj/O, maptext="", screen_loc="CENTER-7,CENTER-7", maptext_height=480, maptext_width=480)
 	if(!isobj(O))	O = new /obj/screen/text()

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -181,7 +181,7 @@
 			if(temp_vent.network.normal_members.len > 50) // Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
 
-	var/list/candidates = get_alien_candidates()
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 
 	if(prob(40)) spawncount++ //sometimes, have two larvae spawn instead of one
 	while((spawncount >= 1) && vents.len && candidates.len)

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -26,7 +26,7 @@
 			if(temp_vent.network.normal_members.len > 50)	//Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
 
-	var/list/candidates = get_alien_candidates()
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 
 	while(spawncount > 0 && vents.len && candidates.len)
 		var/obj/vent = pick(vents)

--- a/code/modules/events/borers.dm
+++ b/code/modules/events/borers.dm
@@ -26,7 +26,7 @@
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent
 
-	var/list/candidates = get_alien_candidates()
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 	while(spawncount > 0 && vents.len && candidates.len)
 		var/obj/vent = pick_n_take(vents)
 		var/client/C = pick_n_take(candidates)

--- a/maps/cyberiad.dmm
+++ b/maps/cyberiad.dmm
@@ -153,7 +153,7 @@
 "acW" = (/obj/machinery/light/small{dir = 1},/obj/machinery/alarm{pixel_y = 23},/turf/simulated/floor{tag = "icon-vault"; icon_state = "vault"},/area/security/nuke_storage)
 "acX" = (/obj/machinery/power/apc{dir = 1; name = "Vault APC"; pixel_x = 0; pixel_y = 25},/obj/structure/cable{icon_state = "0-2"; d2 = 2},/turf/simulated/floor{tag = "icon-vault (SOUTHWEST)"; icon_state = "vault"; dir = 10},/area/security/nuke_storage)
 "acY" = (/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/machinery/status_display{density = 0; layer = 4; pixel_x = 0; pixel_y = 32},/turf/simulated/floor{tag = "icon-vault (SOUTHWEST)"; icon_state = "vault"; dir = 10},/area/security/nuke_storage)
-"acZ" = (/obj/item/device/radio/intercom{broadcasting = 0; freerange = 0; frequency = 1475; listening = 1; name = "Station Intercom (Security)"; pixel_x = -30; pixel_y = 0},/obj/machinery/hologram/holopad,/turf/simulated/floor{icon_state = "dark"},/area/security/hos)
+"acZ" = (/obj/item/device/radio/intercom{broadcasting = 0; freerange = 0; frequency = 1475; listening = 1; name = "Station Intercom (Security)"; pixel_x = -30; pixel_y = 0},/turf/simulated/floor{icon_state = "dark"},/area/security/hos)
 "ada" = (/obj/structure/table/woodentable,/obj/item/weapon/stamp/hos,/obj/machinery/light/small/lamp/green{on = 0; pixel_x = -3; pixel_y = 8},/obj/machinery/atmospherics/unary/vent_scrubber{on = 1; scrub_N2O = 1; scrub_Toxins = 1},/turf/simulated/floor/carpet,/area/security/hos)
 "adb" = (/obj/structure/table/woodentable,/obj/machinery/atmospherics/unary/vent_pump,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; tag = ""},/turf/simulated/floor/carpet,/area/security/hos)
 "adc" = (/obj/structure/table/woodentable,/turf/simulated/floor/carpet,/area/security/hos)


### PR DESCRIPTION
Changes:
1) Minor mapfix.
2) Alien candidates are now picked from all observers, rather than just respawnable mobs. This means people who've previously been aliens will be able to become one again.