### PR TITLE
Kitchen Food Processor Nerfs [Ready to Merge]

### DIFF
--- a/code/modules/food/cooker.dm
+++ b/code/modules/food/cooker.dm
@@ -37,19 +37,10 @@ obj/machinery/cooker/proc/checkValid(obj/item/check, mob/user)
 	if(on)
 		user << "<span class='notice'>[src] is still active!</span>"
 		return 0
-	if(istype(check, /obj/item/weapon/grab) || istype(check, /obj/item/tk_grab))
-		user << "<span class='warning'>That isn't going to fit.</span>"
-		return 0
-	if(istype(check, /obj/item/weapon/reagent_containers/glass))
-		user << "<span class='warning'>That would probably break [src].</span>"
-		return 0
-	if(istype(check, /obj/item/weapon/disk/nuclear))
-		user << "Central command would kill you if you [thiscooktype] that."
-		return 0
-	if(istype(check, /obj/item/flag))
-		user << "<span class='warning'>That isn't going to fit.</span>"
-		return 0
-	return 1
+	if(istype(check, /obj/item/weapon/reagent_containers/food/snacks))
+		return 1
+	user << "<span class ='notice'>You can only process food!</span>"
+	return 0
 
 obj/machinery/cooker/proc/setIcon(obj/item/copyme, obj/item/copyto)
 	copyto.color = foodcolor

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3112,7 +3112,7 @@
         name = "ice cream cone"
         desc = "Delicious ice cream."
         icon_state = "icecream_cone"
-        volume = 500
+        volume = 50
         New()
                 ..()
                 reagents.add_reagent("nutriment", 2)
@@ -3124,7 +3124,7 @@
         name = "chocolate ice cream cone"
         desc = "Delicious ice cream."
         icon_state = "icecream_cup"
-        volume = 500
+        volume = 50
         New()
                 ..()
                 reagents.add_reagent("nutriment", 4)
@@ -3140,7 +3140,7 @@
 	bitesize = 2
 	New()
 		..()
-		reagents.add_reagent("nutriment", 30)
+		reagents.add_reagent("nutriment", 3)
 /obj/item/weapon/reagent_containers/food/snacks/deepfryholder
 	name = "Deep Fried Foods Holder Obj"
 	desc = "If you can see this description the code for the deep fryer fucked up."
@@ -3149,7 +3149,7 @@
 	bitesize = 2
 	New()
 		..()
-		reagents.add_reagent("nutriment", 30)
+		reagents.add_reagent("nutriment", 3)
 
 // Flour + egg = dough
 /obj/item/weapon/reagent_containers/food/snacks/flour/attackby(obj/item/weapon/W as obj, mob/user as mob)


### PR DESCRIPTION
- The cereal maker, deep fryer, and the grill can only process food
items instead of almost anything.
- Deep frying and cerealizing food add 3 nutriment from 30.
- Ice cream cones have a reagent storage volume of 50 from 300.