### PR TITLE
Malf AI fixes, prevent IPC's from becoming vampires

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -15,7 +15,7 @@
 	var/const/waittime_l = 600
 	var/const/waittime_h = 1800 // started at 1800
 
-	var/AI_win_timeleft = 5400 //started at 5400, in case I change this for testing round end.
+	var/AI_win_timeleft = 2000 //started at 2000, in case I change this for testing round end.
 	var/malf_mode_declared = 0
 	var/station_captured = 0
 	var/to_nuke_or_not_to_nuke = 0
@@ -88,8 +88,8 @@
 
 
 /datum/game_mode/malfunction/process()
-	if ((apcs > 0) && malf_mode_declared)
-		AI_win_timeleft -= apcs * last_tick_duration //Victory timer now de-increments based on how many APCs are hacked. --NeoFite
+	if (apcs >= 3 && malf_mode_declared)
+		AI_win_timeleft -= ((apcs/6)*last_tick_duration) //Victory timer now de-increments based on how many APCs are hacked. --NeoFite
 	..()
 	if (AI_win_timeleft<=0)
 		check_win()

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -9,6 +9,7 @@
 	config_tag = "vampire"
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent")
+	protected_species = list("Machine")
 	required_players = 2
 	required_players_secret = 10
 	required_enemies = 1

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -5,7 +5,7 @@
 	icon_state = "separator-AO1"
 	layer = MOB_LAYER+1 // Overhead
 	anchored = 1
-	density = 0
+	density = 1
 	var/transform_dead = 0
 	var/transform_standing = 0
 	var/cooldown_duration = 600 // 1 minute


### PR DESCRIPTION
Changes:
1) The Malf AI timer should now count down properly, instead of six seconds at a time.
2) Fixes the cyborg transformer.
3) IPC's will no longer be vampires.