### PR TITLE
Tweaking of Movement Speed

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -134,6 +134,7 @@ var/intercom_range_display_status = 0
 	src.verbs += /client/proc/count_objects_all
 	src.verbs += /client/proc/cmd_assume_direct_control	//-errorage
 	src.verbs += /client/proc/startSinglo
+	src.verbs += /client/proc/ticklag
 	src.verbs += /client/proc/cmd_admin_grantfullaccess
 	src.verbs += /client/proc/kaboom
 //	src.verbs += /client/proc/splash

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -53,13 +53,13 @@
 /mob/living/carbon/alien/humanoid/movement_delay()
 	var/tally = 0
 	if (istype(src, /mob/living/carbon/alien/humanoid/queen))
-		tally += 5
+		tally += 4
 	if (istype(src, /mob/living/carbon/alien/humanoid/drone))
-		tally += 1
+		tally += 0
 	if (istype(src, /mob/living/carbon/alien/humanoid/sentinel))
-		tally += 1
+		tally += 0
 	if (istype(src, /mob/living/carbon/alien/humanoid/hunter))
-		tally = -1 // hunters go supersuperfast
+		tally = -2 // hunters go supersuperfast
 	return (tally + move_delay_add + config.alien_delay)
 
 /mob/living/carbon/alien/humanoid/Process_Spacemove(var/check_drift = 0)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -245,14 +245,14 @@
 			if("run")
 				if(mob.drowsyness > 0)
 					move_delay += 6
-				move_delay += config.run_speed
+				move_delay += 1+config.run_speed
 			if("walk")
-				move_delay += config.walk_speed
+				move_delay += 1+config.walk_speed
 		move_delay += mob.movement_delay()
 
 		if(config.Tickcomp)
 			move_delay -= 1.3
-			var/tickcomp = (1 / (world.tick_lag)) * 1.3
+			var/tickcomp = ((1/(world.tick_lag))*1.3)
 			move_delay = move_delay + tickcomp
 
 		if(istype(mob.buckled, /obj/vehicle) || istype(mob.buckled, /obj/structure/stool/bed/chair/cart))

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -167,7 +167,7 @@ var/MAX_EXPLOSION_RANGE = 14
 
 #define FLOWFRAC 0.99				// fraction of gas transfered per process
 
-#define SHOES_SLOWDOWN 0			// How much shoes slow you down by default. Negative values speed you up
+#define SHOES_SLOWDOWN -1.0			// How much shoes slow you down by default. Negative values speed you up
 
 
 //ITEM INVENTORY SLOT BITMASKS

--- a/paradise.dme
+++ b/paradise.dme
@@ -863,6 +863,7 @@
 #include "code\modules\admin\verbs\randomverbs.dm"
 #include "code\modules\admin\verbs\striketeam.dm"
 #include "code\modules\admin\verbs\striketeam_syndicate.dm"
+#include "code\modules\admin\verbs\ticklag.dm"
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\vox_raiders.dm"
 #include "code\modules\assembly\assembly.dm"


### PR DESCRIPTION
This is an *almost* complete revert of the previous movement speed tweaks patch.

Basically, while day to day movement speed was more or less the same with the previous patch, it created a few abusive edge cases or annoyances for playing the game: 

-Space movement speed was insanely fast, to the point of being uncontrollable
-The "run speed" genetic power was behaving like hyperzine instead of preventing encumbrance

What will be kept, however, is the movement buff to walking; it previously took 32-35 seconds to cross from one side of the bridge hallway to another; with this patch, the travel time will be around 20 seconds. Walking will still be slow, but won't feel like a nightmare traveling from place to place with it anymore.

Admin Stuffs
-Re-adds the ability to adjust ticklag and tick compensation, on the fly, on a live server.

