### PR TITLE
Minor Fixes

### DIFF
--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -930,6 +930,10 @@ var/list/datum/dna/hivemind_bank = list()
 
 	var/mob/living/carbon/human/T = changeling_sting(40, /mob/proc/changeling_extract_dna_sting)
 	if(!T)	return 0
+	if(T.species.flags & NO_SCAN) // Yeah, this needs the same protection, otherwise you can steal DNA from Slime People and then blood overdose when you turn into one.
+		src << "<span class='warning'>We do not know how to parse this creature's DNA!</span>"
+		changeling.chem_charges += 40
+		return 0
 
 	T.dna.real_name = T.real_name
 	changeling.absorbed_dna |= T.dna

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -111,8 +111,8 @@
 /obj/item/weapon/robot_module/crisis
 	name = "crisis robot module"
 	stacktypes = list(
-		/obj/item/stack/medical/ointment = 5,
-		/obj/item/stack/medical/bruise_pack = 5,
+		/obj/item/stack/medical/advanced/ointment = 5,
+		/obj/item/stack/medical/advanced/bruise_pack = 5,
 		/obj/item/stack/medical/splint = 5
 		)
 


### PR DESCRIPTION
1. Fixes bug where recharging would give the crisis cyborg ointment and bruise packs instead of the advanced versions.
2. Fixes bug where changelings could use the Extract DNA Sting to take DNA from races with the NO_CLONE flag, and the proceed to transform into said species, which would result in death if transforming from a species with blood into a slime person.