### PR TITLE
Hostile Lockdown

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -92,8 +92,6 @@ rcd light flash thingy on matter drain
 	for(var/obj/machinery/door/D in airlocks)
 		spawn()
 			if(istype(D, /obj/machinery/door/airlock))
-				if(D.z != 1)
-					continue
 				AL = D
 				if(AL.canAIControl() && !AL.stat) //Must be powered and have working AI wire.
 					AL.locked = 0 //For airlocks that were bolted open.


### PR DESCRIPTION
Emergency Hotfix for an issue involving an infinite loop for malf AI's hostile lockdown.