### PR TITLE
Security and Syndicate Cyborg Changes [Ready to Merge]

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -338,9 +338,9 @@
 	src.modules += new /obj/item/device/flash/cyborg(src)
 	src.modules += new /obj/item/device/flashlight(src)
 	src.modules += new /obj/item/weapon/melee/energy/sword/cyborg(src)
-	src.modules += new /obj/item/weapon/gun/energy/crossbow/cyborg(src)
+	src.modules += new /obj/item/weapon/gun/energy/printer(src)
+	src.modules += new /obj/item/weapon/gun/projectile/revolver/grenadelauncher/multi/cyborg(src)
 	src.modules += new /obj/item/weapon/card/emag(src)
-	src.modules += new /obj/item/weapon/gun/energy/laser/cyborg(src)
 	src.modules += new /obj/item/weapon/tank/jetpack/carbondioxide(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = null

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -257,3 +257,43 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	projectile_type = "/obj/item/projectile/beam/disabler"
 	cell_type = "/obj/item/weapon/cell"
 	charge_cost = 500
+
+
+
+/* 3d printer 'pseudo guns' for borgs */
+
+/obj/item/weapon/gun/energy/printer
+	name = "cyborg lmg"
+	desc = "A machinegun that fires 3d-printed flachettes slowly regenerated using a cyborg's internal power source."
+	icon_state = "l6closed0"
+	icon = 'icons/obj/gun.dmi'
+	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
+	cell_type = "/obj/item/weapon/cell/secborg"
+	projectile_type = "/obj/item/projectile/bullet/midbullet3"
+	charge_cost = 400 //Yeah, let's NOT give them a 300 round clip that recharges, 15 is more reasonable and will actually hurt the borg's battery for overuse.
+	var/charge_tick = 0
+	var/recharge_time = 5
+
+/obj/item/weapon/gun/energy/printer/update_icon()
+	return
+
+/obj/item/weapon/gun/energy/printer/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/item/weapon/gun/energy/printer/Destroy()
+	processing_objects.Remove(src)
+	..()
+
+/obj/item/weapon/gun/energy/printer/process()
+	charge_tick++
+	if(charge_tick < recharge_time) return 0
+	charge_tick = 0
+
+	if(!power_supply) return 0 //sanity
+	if(isrobot(src.loc))
+		var/mob/living/silicon/robot/R = src.loc
+		if(R && R.cell)
+			if(R.cell.use(charge_cost)) 		//Take power from the borg...
+				power_supply.give(charge_cost)	//...to recharge the shot
+	return 1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -270,7 +270,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	fire_sound = 'sound/weapons/Gunshot_smg.ogg'
 	cell_type = "/obj/item/weapon/cell/secborg"
 	projectile_type = "/obj/item/projectile/bullet/midbullet3"
-	charge_cost = 400 //Yeah, let's NOT give them a 300 round clip that recharges, 15 is more reasonable and will actually hurt the borg's battery for overuse.
+	charge_cost = 300 //Yeah, let's NOT give them a 300 round clip that recharges, 20 is more reasonable and will actually hurt the borg's battery for overuse.
 	var/charge_tick = 0
 	var/recharge_time = 5
 

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -28,19 +28,19 @@
 	..()
 
 /obj/item/weapon/gun/energy/taser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
-	return 1
+	charge_tick++
+	if(charge_tick < recharge_time) return 0
+	charge_tick = 0
 
-/obj/item/weapon/gun/energy/taser/cyborg/process_chambered()
-	if(in_chamber)
-		return 1
+	if(!power_supply) return 0 //sanity
 	if(isrobot(src.loc))
 		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell && R.cell.charge >= 250)
-			R.cell.use(250)
-			in_chamber = new /obj/item/projectile/energy/electrode(src)
-			return 1
-	return 0
+		if(R && R.cell)
+			if(R.cell.use(charge_cost)) 		//Take power from the borg...
+				power_supply.give(charge_cost)	//... to recharge the shot
 
+	update_icon()
+	return 1
 
 /obj/item/weapon/gun/energy/stunrevolver
 	name = "stun revolver"
@@ -87,24 +87,6 @@
 
 /obj/item/weapon/gun/energy/crossbow/update_icon()
 	return
-
-/obj/item/weapon/gun/energy/crossbow/cyborg
-	desc = "An energy-based crossbow that draws power from the cyborg's internal energy cell directly."
-
-/obj/item/weapon/gun/energy/crossbow/cyborg/process()
-	return 1
-
-/obj/item/weapon/gun/energy/crossbow/cyborg/process_chambered()
-	if(in_chamber)
-		return 1
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell && R.cell.charge >= 250)
-			R.cell.use(250)
-			in_chamber = new /obj/item/projectile/energy/bolt(src)
-			return 1
-	return 0
-
 /obj/item/weapon/gun/energy/crossbow/largecrossbow
 	name = "Energy Crossbow"
 	desc = "A weapon favored by syndicate carp hunters."

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -48,3 +48,11 @@
 	item_state = "bulldog"
 	icon_override = 'icons/mob/in-hand/guns.dmi'
 	mag_type = "/obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi"
+
+/obj/item/weapon/gun/projectile/revolver/grenadelauncher/multi/cyborg
+	desc = "A 6-shot grenade launcher."
+	icon = 'icons/mecha/mecha_equipment.dmi'
+	icon_state = "mecha_grenadelnchr"
+
+/obj/item/weapon/gun/projectile/revolver/grenadelauncher/multi/cyborg/attack_self()
+	return


### PR DESCRIPTION
- Security cyborg's taser now properly draws from a cell that slowly
recharges from the cyborg's main battery, rather than drawing directly
from the main battery. 6 shots then CLICK until it recharges.
- Replaces Syndicate cyborg's recharging energy crossbow with a
non-recharging grenade launcher, still stuns, but does a good bit more
damage. (TG port)
- Replaces the Syndicate cyborg's laser with an LMG. (TG port)
 - Nerfs cost per projectile to 300 from TG's 20, because a 300 shot
recharging clip is utterly overpowered, not to mention the fact that it
hardly affected the borg's battery when recharging.
 - Cost of the cyborg's laser gun prior was 830, so this is still a buff.
However it no longer pulls directly from the cyborg's main battery,
instead pulling from a 6000 charge battery that slowly recharges from
the main battery.