### PR TITLE
Fixes possible runtime error with dressers

### DIFF
--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -12,7 +12,7 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 
-		var/choice = input(user, "Underwear, Undershirt, or Socks?", "Changing") as null|anything in list("Underwear","Undershirt","Socks")
+		var/choice = input(user, "Underwear, or Undershirt?", "Changing") as null|anything in list("Underwear","Undershirt")
 
 		if(!Adjacent(user))
 			return


### PR DESCRIPTION
We don't have socks, there is no code for what happens when you select the socks option, so removed the option and text.