### PR TITLE
Adds Injection Only type viruses

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -425,6 +425,9 @@ var/list/admin_verbs_mod = list(
 		if ("Badmin") severity = 99
 
 	D.makerandom(severity)
+
+	D.spreadtype = input("What method of contagion should the disease have?", "Give Disease") in list("Airborne","Contact","Injection")
+
 	D.infectionchance = input("How virulent is this disease? (1-100)", "Give Disease", D.infectionchance) as num
 
 	if(istype(T,/mob/living/carbon/human))

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -1,7 +1,7 @@
 /datum/disease2/disease
 	var/infectionchance = 70
 	var/speed = 1
-	var/spreadtype = "Contact" // Can also be "Airborne"
+	var/spreadtype = "Contact" // Can also be "Airborne" or "Injection"
 	var/stage = 1
 	var/stageprob = 10
 	var/dead = 0
@@ -16,7 +16,7 @@
 	uniqueID = rand(0,10000)
 	..()
 
-/datum/disease2/disease/proc/makerandom(var/greater=0)
+/datum/disease2/disease/proc/makerandom(var/greater=0, var/allow_injection=0)
 	for(var/i=1 ; i <= max_stage ; i++ )
 		var/datum/disease2/effectholder/holder = new /datum/disease2/effectholder
 		holder.stage = i
@@ -30,6 +30,7 @@
 	antigen |= text2num(pick(ANTIGENS))
 	antigen |= text2num(pick(ANTIGENS))
 	spreadtype = prob(70) ? "Airborne" : "Contact"
+	if(allow_injection) spreadtype = prob(20) ? spreadtype : "Injection"
 
 	if(all_species.len)
 		affected_species = get_infectable_species()

--- a/code/modules/virus2/helpers.dm
+++ b/code/modules/virus2/helpers.dm
@@ -24,6 +24,8 @@ proc/get_infection_chance(var/mob/living/carbon/M, var/vector = "Airborne")
 			if(istype(M:wear_suit, /obj/item/clothing/suit/bio_suit) && istype(M:head, /obj/item/clothing/head/bio_hood))
 				score += 15
 
+		if (vector == "Injection") score = 30  // Makes sure Injection viruses cannot be caught normally
+
 
 //  log_debug("[M]'s resistance to [vector] viruses: [score]")
 

--- a/code/modules/virus2/items_devices.dm
+++ b/code/modules/virus2/items_devices.dm
@@ -50,7 +50,7 @@
 /obj/item/weapon/virusdish/random/New()
 	..()
 	src.virus2 = new /datum/disease2/disease
-	src.virus2.makerandom()
+	src.virus2.makerandom(0, 1) // Virus dishes get minor effects only on creation, and have a chance of being injection type
 	growth = rand(5, 50)
 
 /obj/item/weapon/virusdish/attackby(var/obj/item/weapon/W as obj,var/mob/living/carbon/user as mob)


### PR DESCRIPTION
Third virus transmission type, only transmits through blood injection.
Contacting infected blood will _NOT_ transmit the disease, only through
getting infected blood into your blood will the disease be transmitted.

Opens up a whole new ballgame for targeted viruses, along with disabled
mutations.  Antagonist and Security-Buffing Virologists unite!