### PR TITLE
Singularity re-start fixes

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -186,7 +186,7 @@ datum/controller/game_controller/proc/process()
 				machines_cost = (world.timeofday - timer) / 10
 
 				sleep(breather_ticks)
-				
+
 				//BOTS
 				timer = world.timeofday
 				process_bots()
@@ -280,7 +280,7 @@ datum/controller/game_controller/proc/process()
 
 					continue
 
-		Machinery.removeAtProcessing()
+		if(Machinery) Machinery.removeAtProcessing()
 
 /datum/controller/game_controller/proc/process_bots()
 	for(var/obj/machinery/bot/Bot in aibots)
@@ -289,8 +289,8 @@ datum/controller/game_controller/proc/process()
 			spawn(0)
 				Bot.bot_process()
 			continue
-		aibots -= Bot		
-		
+		aibots -= Bot
+
 /datum/controller/game_controller/proc/processObjects()
 	for (var/obj/Object in processing_objects)
 		if (Object && Object.loc)

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -12,16 +12,21 @@
 /obj/machinery/the_singularitygen/process()
 	var/turf/T = get_turf(src)
 	if(src.energy >= 200)
-		if(fingerprintshidden && fingerprintshidden.len)
-			var/prints
-			for(var/i = 1, i < fingerprintshidden.len, i++)
-				if(i > fingerprintshidden.len)
-					break
-				if(i == 1)
-					prints += fingerprintshidden[i]
-				else
-					prints += ", [fingerprintshidden[i]]"
-			log_admin("New singularity made, all touchers. [prints]. Last touched by [fingerprintslast].")
+		var/admin_message = "New singularity made"
+		world << "lengthy = [length(fingerprintshidden)]"
+		if(fingerprintshidden && length(fingerprintshidden))
+			admin_message +=  "touched by: "
+			if(islist(fingerprintshidden))
+				for(var/fp in fingerprintshidden)
+					admin_message += "[fp], "
+				admin_message += " - Last touched by [fingerprintslast]. at [x],[y],[z]"
+			else
+				admin_message += fingerprintshidden
+
+			log_admin(admin_message)
+		message_admins("[admin_message] at [x],[y],[z]",1)
+		investigate_log("[admin_message] at [x],[y],[z]","singulo")
+
 		new /obj/machinery/singularity/(T, 50)
 		if(src) del(src)
 
@@ -34,6 +39,9 @@
 				"You secure the [src.name] to the floor.", \
 				"You hear a ratchet")
 			src.add_hiddenprint(user)
+
+
+
 		else
 			user.visible_message("[user.name] unsecures [src.name] from the floor.", \
 				"You unsecure the [src.name] from the floor.", \


### PR DESCRIPTION
1) Fixes an exception which prevented singularity generators from
spawning a singularity if they had fingerprints on them
2) Fixes an exception which was called on machineryprocess on the
deleted singularity generator

NOTES

For some obscure reason, hidden fingerprint logging on machinery does
not create a list if there is only one entry.  I couldn't find why, so I
wrote code to account for either a string or list for the singularity
generator ONLY.