### PR TITLE
Fix for atom/add_hiddenprint()

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -257,16 +257,25 @@ its easier to just keep the beam vertical.
 			return 0
 		if(H.gloves)
 			if(fingerprintslast != H.ckey)
+				//Add the list if it does not exist.
+				if(!fingerprintshidden)
+					fingerprintshidden = list()
 				fingerprintshidden += text("\[[time_stamp()]\] (Wearing gloves). Real name: [], Key: []",H.real_name, H.key)
 				fingerprintslast = H.ckey
 			return 0
 		if(!( fingerprints ))
 			if(fingerprintslast != H.ckey)
+				//Add the list if it does not exist.
+				if(!fingerprintshidden)
+					fingerprintshidden = list()
 				fingerprintshidden += text("\[[time_stamp()]\] Real name: [], Key: []",H.real_name, H.key)
 				fingerprintslast = H.ckey
 			return 1
 	else
 		if(fingerprintslast != M.ckey)
+			//Add the list if it does not exist.
+			if(!fingerprintshidden)
+				fingerprintshidden = list()
 			fingerprintshidden += text("\[[time_stamp()]\] Real name: [], Key: []",M.real_name, M.key)
 			fingerprintslast = M.ckey
 	return


### PR DESCRIPTION
1) add_hiddenprint was not assigning the list type to fingerprintshidden
on all atoms correctly.  This has now been resolved.

NOTES

This was what was causing the issues with the singularity restart, but I
expect this to also have many other implications.  Some bugs may develop
in live testing, but I believe this will cause far more good than harm,
as all the code expects to find a list.  (fingerprintshidden is always
declared as a list)