### PR TITLE
Language Fixes

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -207,6 +207,8 @@
 			hear += C.mob
 		else if(C.mob && C.mob.loc.loc in hear_and_objects)
 			hear += C.mob
+		else if(C.mob && C.mob.loc.loc.loc in hear_and_objects)
+			hear += C.mob
 	return hear
 
 
@@ -456,6 +458,6 @@ proc/isInSight(var/atom/A, var/atom/B)
 		if(our_area == get_area_master(C))
 			return 0
 	return 1
-	
+
 /proc/MinutesToTicks(var/minutes as num)
 	return minutes * 60 * 10

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -83,7 +83,7 @@ var/list/department_radio_keys = list(
 		else
 			dongle = H.r_ear
 		if(!istype(dongle)) return
-		if(dongle.translate_binary) return 1
+		if(dongle.translate_hive) return 1
 
 /mob/living/say(var/message)
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -62,31 +62,28 @@
 	if(!other)
 		return 1
 	//Universal speak makes everything understandable, for obvious reasons.
-	else if(other.universal_speak || src.universal_speak || src.universal_understand)
+	if(other.universal_speak || src.universal_speak || src.universal_understand)
 		return 1
-	else if (src.stat == 2)
+	if (src.stat == 2)
 		return 1
-	else if (speaking) //Language check.
 
-		var/understood
-		for(var/datum/language/L in src.languages)
-			if(speaking.name == L.name)
-				understood = 1
-				break
-
-		if(understood || universal_speak)
+	if(!speaking) //Handle languages later
+		if(other.universal_speak || src.universal_speak)
 			return 1
-		else
-			return 0
+		if(isAI(src) && ispAI(other))
+			return 1
+		if (istype(other, src.type) || istype(src, other.type))
+			return 1
+		if (istype(other, /mob/living/carbon/human) && (istype(src, /mob/living/carbon/human) || istype(src, /mob/living/silicon/pai)))
+			return 1
+		if(istype(other, /mob/living/carbon/alien) && istype(src, /mob/living/carbon/alien))
+			return 1
+		return 0
 
-	else if(other.universal_speak || src.universal_speak)
-		return 1
-	else if(isAI(src) && ispAI(other))
-		return 1
-	else if (istype(other, src.type) || istype(src, other.type))
-		return 1
-	else if (istype(other, /mob/living/carbon/human) && istype(src, /mob/living/carbon/human))
-		return 1
+	for(var/datum/language/L in src.languages) //Handling languages
+		if(speaking.name == L.name)
+			return 1
+
 	return 0
 
 /mob/proc/say_quote(var/text,var/datum/language/speaking)


### PR DESCRIPTION
- Allows pAIs to hear from inside bags and PDAs (But if you put one
inside a PDA and then in a bag, no hearing. THANKS HORRID NON-RECURSIVE
SAY CODE)
- Allows pAIs to understand carbons speaking in common.
- Allows different caste xenos to understand each other.
- Fixes bug where the binary encryption key allowed use of the Xenomorph hivemind.