### PR TITLE
Added printing functionality to the Body Scanner and the Chem Master

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -363,6 +363,7 @@
 	var/bottlesprite = "1" //yes, strings
 	var/pillsprite = "1"
 	var/client/has_sprites = list()
+	var/printing = null
 
 /obj/machinery/chem_master/New()
 	var/datum/reagents/R = new/datum/reagents(100)
@@ -439,7 +440,33 @@
 		usr << browse(null, "window=chemmaster")
 		usr.unset_machine()
 		return
-
+	
+	if (href_list["print_p"])
+		if (!(src.printing))
+			src.printing = 1
+			for(var/mob/O in viewers(usr))
+				O.show_message("\blue \the [src] rattles and prints out a sheet of paper.", 1)
+			sleep(25)
+			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( src.loc )
+			P.info = "<CENTER><B>Chemical Analysis</B></CENTER><BR>"
+			P.info += "<b>Time of analysis:</b> [worldtime2text(world.time)]<br><br>"
+			P.info += "<b>Chemical name:</b> [href_list["name"]]<br>"
+			if(href_list["name"] == "Blood")
+				var/datum/reagents/R = beaker:reagents
+				var/datum/reagent/blood/G
+				for(var/datum/reagent/F in R.reagent_list)
+					if(F.name == href_list["name"])
+						G = F
+						break
+				var/B = G.data["blood_type"]
+				var/C = G.data["blood_DNA"]
+				P.info += "<b>Description:</b><br>Blood Type: [B]<br>DNA: [C]"
+			else
+				P.info += "<b>Description:</b> [href_list["desc"]]"
+			P.info += "<br><br><b>Notes:</b><br>"
+			P.name = "Chemical Analysis - [href_list["name"]]"
+			src.printing = null
+	
 	if(beaker)
 		var/datum/reagents/R = beaker:reagents
 		if (href_list["analyze"])
@@ -454,9 +481,11 @@
 					var/A = G.name
 					var/B = G.data["blood_type"]
 					var/C = G.data["blood_DNA"]
-					dat += "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[A]<BR><BR>Description:<BR>Blood Type: [B]<br>DNA: [C]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
+					dat += "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[A]<BR><BR>Description:<BR>Blood Type: [B]<br>DNA: [C]"
 				else
-					dat += "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
+					dat += "<TITLE>Chemmaster 3000</TITLE>Chemical infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]"
+				dat += "<BR><BR><A href='?src=\ref[src];print_p=1;desc=[href_list["desc"]];name=[href_list["name"]]'>(Print Analysis)</A><BR>"
+				dat += "<A href='?src=\ref[src];main=1'>(Back)</A>"
 			else
 				dat += "<TITLE>Condimaster 3000</TITLE>Condiment infos:<BR><BR>Name:<BR>[href_list["name"]]<BR><BR>Description:<BR>[href_list["desc"]]<BR><BR><BR><A href='?src=\ref[src];main=1'>(Back)</A>"
 			usr << browse(dat, "window=chem_master;size=575x400")

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -311,7 +311,7 @@
 	id = "retractor"
 	build_type = AUTOLATHE
 	materials = list("$metal" = 6000, "$glass" = 3000)
-	build_path = /obj/item/weapon/
+	build_path = /obj/item/weapon/retractor
 	category = list("initial", "Medical")
 	
 /datum/design/scalpel

--- a/nano/templates/chem_dispenser.tmpl
+++ b/nano/templates/chem_dispenser.tmpl
@@ -64,9 +64,9 @@ Used In File(s): \code\modules\reagents\Chemistry-Machinery.dm
 				{{empty}}
 					<span class="bad">
 						{{if data.glass}}
-							Glass
+							Glass 
 						{{else}}
-							Beaker
+							Beaker 
 						{{/if}}
 						is empty
 					</span>
@@ -75,10 +75,10 @@ Used In File(s): \code\modules\reagents\Chemistry-Machinery.dm
 				<span class="average"><i>
 					No 
 					{{if data.glass}}
-						Glass
+						Glass 
 					{{else}}
-						Beaker
-					{{/if}} 
+						Beaker 
+					{{/if}}
 					loaded
 				</i></span>
 			{{/if}}


### PR DESCRIPTION
As suggested on the forums, added printing functionality to the Body Scanner:

![bodyscanprint](https://cloud.githubusercontent.com/assets/147366/5954156/eefaf464-a793-11e4-9b63-f1d7acfb02fc.png)

Analysis from The Chem Master 3000 can also be printed out (here shown with blood, other chems also works):

![chemanalyzeprint](https://cloud.githubusercontent.com/assets/147366/5954166/0d60e800-a794-11e4-8c78-c52db3582821.png)

These can easily be clipped to the autopsy report as part of the morgue workflow.

Plus a couple fixes: Retractor autolathe and typo in the chem dispenser.