### PR TITLE
Dismemberment Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -314,8 +314,8 @@ emp_act
 		forcesay(hit_appends)	//forcesay checks stat already
 
 	if (I.damtype == BRUTE)
-		if((I.edge && prob(2 * I.force)) || (I.force > 20 && prob(I.force)))
-			if(affecting.brute_dam >= affecting.max_damage * config.organ_health_multiplier)
+		if((affecting.brute_dam + I.force) >= affecting.max_damage * config.organ_health_multiplier)
+			if(I.edge && prob(I.force))
 				affecting.dismember_limb()
 
 /*	//Melee weapon embedded object code. Commented out, as most people on the forums seem to find this annoying and think it does not contribute to general gameplay. - Dave

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -567,7 +567,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		O.setAmputatedTree()
 
 //Handles dismemberment
-/datum/organ/external/proc/droplimb(var/override = 0,var/no_explode = 0, var/spawn_limb=0)
+/datum/organ/external/proc/droplimb(var/override = 0,var/no_explode = 0,var/amputation=0, var/spawn_limb=0)
 	if(destspawn) return
 	if(override)
 		status |= ORGAN_DESTROYED
@@ -585,9 +585,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		germ_level = 0
 
+		// If any organs are attached to this, destroy them
+		for(var/datum/organ/external/O in children)
+			O.droplimb(1, no_explode, amputation)
+
 		//Replace all wounds on that arm with one wound on parent organ.
 		wounds.Cut()
-		if (parent)
+		if (parent && !amputation)
 			var/datum/wound/W
 			if(max_damage < 50)
 				W = new/datum/wound/lost_limb/small(max_damage)
@@ -596,10 +600,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 			parent.wounds += W
 			parent.update_damages()
 		update_damages()
-
-		// If any organs are attached to this, destroy them
-		for(var/datum/organ/external/O in children)
-			O.droplimb(1)
 
 		var/obj/organ	//Dropped limb object
 

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -216,7 +216,7 @@
 		var/datum/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("\blue [user] cuts off [target]'s [affected.display_name] with \the [tool].", \
 		"\blue You cut off [target]'s [affected.display_name] with \the [tool].")
-		affected.droplimb(1,0)
+		affected.droplimb(1,1,1)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/datum/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
Fixes+Nerfs Dismemberment

-Tweaked dismemberment probabilities a bit (should be harder to dismember a body part now)--also prevents dismemberment entirely unless an item has the "edge" flag.
-Fixed a bug where dismembered body parts were getting wounds (Bay)
-Amputation (the surgery) will no longer create a wound on the parent organ, meaning no more broken bones from this "surgery" (Bay)

Basically, I was seeing too many body parts flying off from weapon attacks, particularly when the esword was involved; this should help cut down on that a bit--further tweaks may be needed though, especially for the head, hands, and feet.

There was also a bug where if you cut someone's arm or leg off, the hand/foot would fly off as well (intentional) AND (this is the bug) apply damage to the now non-existent arm/leg; effectively meaning a lucky two e-sword dismember on an arm/leg (60 damage) would end up causing 80 damage. This fix also means explosions shouldn't be so horrendously lethal.

