### PR TITLE
Cyborg Cell Recharging Fix

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -286,8 +286,11 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	..()
 
 /obj/item/weapon/gun/energy/printer/process()
+	if(power_supply.charge == power_supply.maxcharge)
+		return 0
 	charge_tick++
-	if(charge_tick < recharge_time) return 0
+	if(charge_tick < recharge_time)
+		return 0
 	charge_tick = 0
 
 	if(!power_supply) return 0 //sanity

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -28,8 +28,11 @@
 	..()
 
 /obj/item/weapon/gun/energy/taser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
+	if(power_supply.charge == power_supply.maxcharge)
+		return 0
 	charge_tick++
-	if(charge_tick < recharge_time) return 0
+	if(charge_tick < recharge_time)
+		return 0
 	charge_tick = 0
 
 	if(!power_supply) return 0 //sanity


### PR DESCRIPTION
- Fix for syndicate borg LMG and security borg draining extra charge
while in the hotbar, despite being fully charged.