### PR TITLE
Turns off exchange objective during autotraitor

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -98,7 +98,7 @@
 			traitor.objectives += block_objective
 
 	else
-		if(!exchange_blue && traitors.len >= 5) 	//Set up an exchange if there are enough traitors
+		if(!exchange_blue && traitors.len >= 5 && name != "AutoTraitor") 	//Set up an exchange if there are enough traitors, turned off during autotraitor temporarily due to bugs.
 			if(!exchange_red)
 				exchange_red = traitor
 			else


### PR DESCRIPTION
Currently causes runtimes due to traitors being assigned the objective mid-round without having someone to assign the corresponding objective to. Disables the objective for the Autotraitor gamemode to prevent this.