### PR TITLE
Disability fixes

### DIFF
--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -67,7 +67,7 @@
 	disability=EPILEPSY
 
 	New()
-		block=HEADACHEBLOCK
+		block=EPILEPSYBLOCK
 
 /datum/dna/gene/disability/cough
 	name="Coughing"

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -49,7 +49,6 @@
 	NERVOUSBLOCK       = getAssignedBlock("NERVOUS",       numsToAssign)
 
 	// Bay muts
-	HEADACHEBLOCK      = getAssignedBlock("HEADACHE",      numsToAssign)
 	NOBREATHBLOCK      = getAssignedBlock("NOBREATH",      numsToAssign, DNA_HARD_BOUNDS, good=1)
 	REMOTEVIEWBLOCK    = getAssignedBlock("REMOTEVIEW",    numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	REGENERATEBLOCK    = getAssignedBlock("REGENERATE",    numsToAssign, DNA_HARDER_BOUNDS, good=1)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -476,7 +476,7 @@
 	value = 0xFFF
 	//block = 3
 	New()
-		block = HEADACHEBLOCK
+		block = EPILEPSYBLOCK
 		..()
 
 /obj/item/weapon/dnainjector/antiepi
@@ -486,7 +486,7 @@
 	value = 0x001
 	//block = 3
 	New()
-		block = HEADACHEBLOCK
+		block = EPILEPSYBLOCK
 		..()
 
 /obj/item/weapon/dnainjector/anticough

--- a/code/global.dm
+++ b/code/global.dm
@@ -55,7 +55,6 @@ var/MONKEYBLOCK = 50 // Monkey block will always be the DNA_SE_LENGTH
 var/BLOCKADD = 0
 var/DIFFMUT = 0
 
-var/HEADACHEBLOCK = 0
 var/NOBREATHBLOCK = 0
 var/REMOTEVIEWBLOCK = 0
 var/REGENERATEBLOCK = 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -529,7 +529,8 @@
 		if(client.prefs.disabilities & DISABILITY_FLAG_DEAF)
 			new_character.dna.SetSEState(DEAFBLOCK,1,1)
 			new_character.sdisabilities |= DEAF
-
+			
+		domutcheck(new_character)
 		new_character.dna.UpdateSE()
 
 


### PR DESCRIPTION
This pull request fixes two things:

- Disabilities properly updated when new player is made

As it is, disabilities aren't activated when the new player mob is made. As a consequence, the only way to fix genetic disabilities involves activating the blocks manually. Essentially, you have to inject patients with the same SE they already have, and *then* injecting them with a Clean SE. Forget using ryetalyn.

This fixes that.

----

- Fixed epilepsy disability not linked to proper SE block

If you gave someone the epilepsy block it didn't do anything, while the headache block gave epilepsy. Instead, the epilepsy block is now linked to the epilepsy disability, and the headache block is removed.