### PR TITLE
Fixes artificer spell being removed

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -792,7 +792,7 @@ datum/mind
 					if(src in ticker.mode.wizards)
 						ticker.mode.wizards -= src
 						special_role = null
-						current.spellremove(current, config.feature_object_spell_system? "object":"verb")
+						current.spellremove(current)
 						current.faction = list("Station")
 						current << "\red <FONT size = 3><B>You have been brainwashed! You are no longer a wizard!</B></FONT>"
 						log_admin("[key_name_admin(usr)] has de-wizard'ed [current].")

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -192,7 +192,7 @@
 				var/area/wizard_station/A = locate()
 				if(usr in A.contents)
 					uses = max_uses
-					H.spellremove(usr)
+					H.spellremove(usr,0)
 					temp = "All spells have been removed. You may now memorize a new set of spells."
 					feedback_add_details("wizard_spell_learned","UM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
 				else

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -273,8 +273,9 @@
 //OTHER PROCS
 
 //To batch-remove wizard spells. Linked to mind.dm.
-/mob/proc/spellremove(var/mob/M as mob)
+/mob/proc/spellremove(var/mob/M as mob, var/removeallspells=1)
 	for(var/obj/effect/proc_holder/spell/wizard/spell_to_remove in src.spell_list)
+		if (spell_to_remove.name == "Artificer" && !removeallspells) continue
 		del(spell_to_remove)
 		update_power_buttons()
 


### PR DESCRIPTION
Artificer spell is tied to the soul shards and shouldn't be forgotten when the "relearn spell" option is chosen.

Fixes https://github.com/ParadiseSS13/Paradise/issues/257