### PR TITLE
Minor Traitor Objective Fixes [Balance] [Bugfix]

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -743,7 +743,7 @@ datum/objective/destroy
 		var/mob/living/silicon/ai/target_ai = pick(possible_targets)
 		target = target_ai.mind
 		if(target && target.current)
-			explanation_text = "Destroy [target.name], the experimental AI."
+			explanation_text = "Destroy [target.current.real_name], the experimental AI."
 		else
 			explanation_text = "Free Objective"
 		return target

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -143,7 +143,7 @@
 						traitor.objectives += steal_objective
 		switch(rand(1,100))
 			if(1 to 30) // Die glorious death
-				if (!(locate(/datum/objective/die) in traitor.objectives) && !(locate(/datum/objective/steal) in traitor.objectives))
+				if (!(locate(/datum/objective/die) in traitor.objectives) && !(locate(/datum/objective/steal) in traitor.objectives) && !(locate(/datum/objective/steal/exchange) in traitor.objectives) && !(locate(/datum/objective/steal/exchange/backstab) in traitor.objectives))
 					var/datum/objective/die/die_objective = new
 					die_objective.owner = traitor
 					traitor.objectives += die_objective

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -107,7 +107,7 @@
 				assign_exchange_role(exchange_blue)
 		else
 			var/list/active_ais = active_ais()
-			if(active_ais.len && prob(100/(num_players()*3)))
+			if(active_ais.len && prob(10)) // Leaving this at a flat chance for now, problems with the num_players() proc.
 				var/datum/objective/destroy/destroy_objective = new
 				destroy_objective.owner = traitor
 				destroy_objective.find_target()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -107,7 +107,7 @@
 				assign_exchange_role(exchange_blue)
 		else
 			var/list/active_ais = active_ais()
-			if(active_ais.len && prob(100/num_players()))
+			if(active_ais.len && prob(100/(num_players()*3)))
 				var/datum/objective/destroy/destroy_objective = new
 				destroy_objective.owner = traitor
 				destroy_objective.find_target()


### PR DESCRIPTION
- Fixes traitors getting "Die a glorious death" objective along with an exchange/steal objective.
- Destroy AI objective reduced to flat 10% chance instead of scaling inversely with player count.
- Destroy AI now shows name after name changes.