### PR TITLE
Minor Traitor/Ling Tweaks/Fixes [BUGFIX] [BALANCE]

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -105,7 +105,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		changeling.objectives += debrain_objective
 
 	var/list/active_ais = active_ais()
-	if(active_ais.len && prob(10)) // num_players() proc is designed for roundstart, changed to fixed value to prevent problems with mid-round objective randomization.
+	if(active_ais.len && prob(4)) // Leaving this at a flat chance for now, problems with the num_players() proc due to latejoin antags.
 		var/datum/objective/destroy/destroy_objective = new
 		destroy_objective.owner = changeling
 		destroy_objective.find_target()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -420,7 +420,7 @@ datum/objective/escape
 			return 0
 		if(!emergency_shuttle.returned())
 			return 0
-		if(!owner.current || owner.current.stat ==2)
+		if(!owner.current || owner.current.stat == DEAD)
 			return 0
 		var/turf/location = get_turf(owner.current.loc)
 		if(!location)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -107,7 +107,7 @@
 				assign_exchange_role(exchange_blue)
 		else
 			var/list/active_ais = active_ais()
-			if(active_ais.len && prob(10)) // Leaving this at a flat chance for now, problems with the num_players() proc.
+			if(active_ais.len && prob(4)) // Leaving this at a flat chance for now, problems with the num_players() proc due to latejoin antags.
 				var/datum/objective/destroy/destroy_objective = new
 				destroy_objective.owner = traitor
 				destroy_objective.find_target()

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -27,3 +27,17 @@
 /obj/item/clothing/suit/storage/hear_talk(mob/M, var/msg)
 	pockets.hear_talk(M, msg)
 	..()
+
+/obj/item/clothing/suit/storage/proc/return_inv()
+
+	var/list/L = list(  )
+
+	L += src.contents
+
+	for(var/obj/item/weapon/storage/S in src)
+		L += S.return_inv()
+	for(var/obj/item/weapon/gift/G in src)
+		L += G.gift
+		if (istype(G.gift, /obj/item/weapon/storage))
+			L += G.gift:return_inv()
+	return L

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -40,6 +40,20 @@
 	hold.hear_talk(M, msg, verb, speaking)
 	..()
 
+/obj/item/clothing/accessory/storage/proc/return_inv()
+
+	var/list/L = list(  )
+
+	L += src.contents
+
+	for(var/obj/item/weapon/storage/S in src)
+		L += S.return_inv()
+	for(var/obj/item/weapon/gift/G in src)
+		L += G.gift
+		if (istype(G.gift, /obj/item/weapon/storage))
+			L += G.gift:return_inv()
+	return L
+
 /obj/item/clothing/accessory/storage/attack_self(mob/user as mob)
 	if (has_suit)	//if we are part of a suit
 		hold.open(user)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -57,18 +57,20 @@
 			client.verbs |= H.species.abilities
 
 	CallHook("Login", list("client" = src.client, "mob" = src))
-	
+
 	//Update morgues on login/logout
 	if (stat == DEAD)
 		var/obj/structure/morgue/Morgue = null
 		var/mob/living/carbon/human/C = null
 		if (istype(src,/mob/dead/observer)) //We're a ghost, let's find our corpse
 			var/mob/dead/observer/G = src
+			if(!G.mind) //This'll probably break morgue sprites, but the line under the next If statement causes runtimes with Assume Direct Control.
+				return
 			if (G.can_reenter_corpse && G.mind.current)
 				C = G.mind.current
 		else if (istype(src,/mob/living/carbon/human))
 			C = src
-		
+
 		if (C) //We found our corpse, is it inside a morgue?
 			if (istype(C.loc,/obj/structure/morgue))
 				Morgue = C.loc
@@ -78,4 +80,4 @@
 					Morgue = B.loc
 			if (Morgue)
 				Morgue.update()
-	
+

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -10,18 +10,20 @@
 			if(admins_number == 0) //Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
 				send2adminirc("[key_name(src)] logged out - no more admins online.")
 	..()
-	
+
 	//Update morgues on login/logout
 	if (stat == DEAD)
 		var/obj/structure/morgue/Morgue = null
 		var/mob/living/carbon/human/C = null
 		if (istype(src,/mob/dead/observer)) //We're a ghost, let's find our corpse
 			var/mob/dead/observer/G = src
+			if(!G.mind) //This'll probably break morgue sprites, but the line under the next If statement causes runtimes with Assume Direct Control.
+				return 1
 			if (G.can_reenter_corpse && G.mind.current)
 				C = G.mind.current
 		else if (istype(src,/mob/living/carbon/human))
 			C = src
-		
+
 		if (C) //We found our corpse, is it inside a morgue?
 			if (istype(C.loc,/obj/structure/morgue))
 				Morgue = C.loc

--- a/code/modules/surgery/braincore.dm
+++ b/code/modules/surgery/braincore.dm
@@ -12,7 +12,8 @@
 /datum/surgery_step/brain/saw_skull
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75, \
+	/obj/item/weapon/melee/arm_blade = 60 // Dr. Chang E. Ling, MD
 	)
 
 	min_duration = 50
@@ -67,7 +68,8 @@
 /datum/surgery_step/brain/saw_spine
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75, \
+	/obj/item/weapon/melee/arm_blade = 60
 	)
 
 	min_duration = 50

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -187,7 +187,8 @@
 /datum/surgery_step/generic/cut_limb
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75, \
+	/obj/item/weapon/melee/arm_blade = 60
 	)
 
 	min_duration = 110

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -12,7 +12,8 @@
 /datum/surgery_step/ribcage/saw_ribcage
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75, \
+	/obj/item/weapon/melee/arm_blade = 60
 	)
 
 	min_duration = 50
@@ -146,7 +147,7 @@
 		user.visible_message(msg, self_msg)
 
 		target.op_stage.ribcage = 0
-		
+
 //////////////////////////////////////////////////////////////////
 //					ALIEN EMBRYO SURGERY						//
 //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Destroy AI objective chance lowered from 10% to 4%, should be just a little bit less likely than Hijack.
- Changeling arm blades can be used in ghetto surgery as circular saws, which will help changelings with debrain objectives a bit.
- Fixes runtime at living.dm line 195, when return_inv() is called for objects that didn't have the proc.
- 'stat == 2' changed to 'stat == DEAD' in objective.dm for consistency.