### PR TITLE
[Bug-Fix] Re-adds missing seeds, floodlight wrenching

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -4,6 +4,7 @@
 	name = "Emergency Floodlight"
 	icon = 'icons/obj/machines/floodlight.dmi'
 	icon_state = "flood00"
+	anchored = 0
 	density = 1
 	var/on = 0
 	var/obj/item/weapon/stock_parts/cell/high/cell = null
@@ -63,6 +64,21 @@
 
 
 /obj/machinery/floodlight/attackby(obj/item/weapon/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/weapon/wrench))
+		if (!anchored && !isinspace())
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+			user.visible_message( \
+				"[user] tightens \the [src]'s casters.", \
+				"<span class='notice'> You have tightened \the [src]'s casters.</span>", \
+				"You hear ratchet.")
+			anchored = 1
+		else if(anchored)
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+			user.visible_message( \
+				"[user] loosens \the [src]'s casters.", \
+				"<span class='notice'> You have loosened \the [src]'s casters.</span>", \
+				"You hear ratchet.")
+			anchored = 0
 	if (istype(W, /obj/item/weapon/screwdriver))
 		if (!open)
 			if(unlocked)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -890,7 +890,8 @@
 					/obj/item/seeds/sunflowerseed = 3,/obj/item/seeds/tomatoseed = 3,/obj/item/seeds/towermycelium = 3,/obj/item/seeds/wheatseed = 3,/obj/item/seeds/appleseed = 3,
 					/obj/item/seeds/poppyseed = 3,/obj/item/seeds/ambrosiavulgarisseed = 3,/obj/item/seeds/whitebeetseed = 3,/obj/item/seeds/watermelonseed = 3,/obj/item/seeds/limeseed = 3,
 					/obj/item/seeds/lemonseed = 3,/obj/item/seeds/orangeseed = 3,/obj/item/seeds/grassseed = 3,/obj/item/seeds/cocoapodseed = 3,
-					/obj/item/seeds/cabbageseed = 3,/obj/item/seeds/grapeseed = 3,/obj/item/seeds/pumpkinseed = 3,/obj/item/seeds/cherryseed = 3,/obj/item/seeds/plastiseed = 3,/obj/item/seeds/riceseed = 3)
+					/obj/item/seeds/cabbageseed = 3,/obj/item/seeds/grapeseed = 3,/obj/item/seeds/pumpkinseed = 3,/obj/item/seeds/cherryseed = 3,/obj/item/seeds/plastiseed = 3,/obj/item/seeds/riceseed = 3,
+					/obj/item/seeds/tobaccoseed = 3, /obj/item/seeds/coffeeaseed = 3, /obj/item/seeds/teaasperaseed = 3)
 
 	contraband = list(/obj/item/seeds/amanitamycelium = 2,/obj/item/seeds/glowshroom = 2,/obj/item/seeds/libertymycelium = 2,/obj/item/seeds/nettleseed = 2,
 						/obj/item/seeds/plumpmycelium = 2,/obj/item/seeds/reishimycelium = 2)


### PR DESCRIPTION
Re-adds Tobacco, Coffee Arabica, and Tea Aspera seeds to the seed
vendors. They were accidentally removed in the Econ revert.

Allows floodlights to be wrenched into place like the carts, to avoid
accidentally pushing them away.