### PR TITLE
New +MENTOR permission for mentors

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -227,7 +227,7 @@ proc/tg_text2list(text, glue=",", assocglue=";")
 		. += copytext(text, last_found, found)
 		last_found = found + delim_len
 	while(found)
-	
+
 /proc/text2numlist(text, delimiter="\n")
 	var/list/num_list = list()
 	for(var/x in text2list(text, delimiter))
@@ -347,6 +347,7 @@ proc/tg_text2list(text, glue=",", assocglue=";")
 	if(rights & R_SOUNDS)		. += "[seperator]+SOUND"
 	if(rights & R_SPAWN)		. += "[seperator]+SPAWN"
 	if(rights & R_MOD)			. += "[seperator]+MODERATOR"
+	if(rights & R_MENTOR)		. += "[seperator]+MENTOR"
 	return .
 
 /proc/ui_style2icon(ui_style)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -120,18 +120,19 @@ var/global/normal_ooc_colour = "#002eb8"
 	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
 	var/list/heard = get_mobs_in_view(7, src.mob)
 	var/mob/S = src.mob
-	
+
 	var/display_name = S.key
 	if(S.stat != DEAD)
 		display_name = S.name
-	
+
 	// Handle non-admins
 	for(var/mob/M in heard)
 		if(!M.client)
 			continue
 		var/client/C = M.client
-		if (C in admins)
-			continue //they are handled after that
+		if(C in admins)
+			if(C.holder.rights | R_MENTOR)
+				continue //they are handled after that
 
 		if(C.prefs.toggles & CHAT_LOOC)
 			if(holder)
@@ -141,15 +142,16 @@ var/global/normal_ooc_colour = "#002eb8"
 					else
 						display_name = holder.fakekey
 			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
-	
+
 	// Now handle admins
 	display_name = S.key
 	if(S.stat != DEAD)
 		display_name = "[S.name]/([S.key])"
-	
+
 	for(var/client/C in admins)
-		if(C.prefs.toggles & CHAT_LOOC)
-			var/prefix = "(R)LOOC"
-			if (C.mob in heard)
-				prefix = "LOOC"
-			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+		if(C.holder.rights | R_MENTOR)
+			if(C.prefs.toggles & CHAT_LOOC)
+				var/prefix = "(R)LOOC"
+				if (C.mob in heard)
+					prefix = "LOOC"
+				C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -77,7 +77,7 @@
 
 				num_admins_online++
 
-			else if(R_MOD & C.holder.rights)
+			else if((R_MOD | R_MENTOR) & C.holder.rights)
 				modmsg += "\t[C] is a [C.holder.rank]"
 
 				if(isobserver(C.mob))
@@ -98,9 +98,9 @@
 				if(!C.holder.fakekey)
 					msg += "\t[C] is a [C.holder.rank]\n"
 					num_admins_online++
-			else if (R_MOD & C.holder.rights)
+			else if ((R_MOD | R_MENTOR) & C.holder.rights)
 				modmsg += "\t[C] is a [C.holder.rank]\n"
 				num_mods_online++
 
-	msg = "<b>Current Admins ([num_admins_online]):</b>\n" + msg + "\n<b> Current Mentors ([num_mods_online]):</b>\n" + modmsg
+	msg = "<b>Current Admins ([num_admins_online]):</b>\n" + msg + "\n<b> Current Mods/Mentors ([num_mods_online]):</b>\n" + modmsg
 	src << msg

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -41,6 +41,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 				if("sound","sounds")			rights |= R_SOUNDS
 				if("spawn","create")			rights |= R_SPAWN
 				if("mod")						rights |= R_MOD
+				if("mentor")					rights |= R_MENTOR
 
 		admin_ranks[rank] = rights
 		previous_rights = rights

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -44,7 +44,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggleprayers,			/*toggles prayers on/off*/
 //	/client/proc/toggle_hear_radio,		/*toggles whether we hear the radio*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
-	/client/proc/secrets,
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggledsay,		/*toggles dsay on/off for everyone*/
@@ -54,7 +53,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_mod_say,
 	/datum/admins/proc/show_player_info,
 	/client/proc/free_slot,			/*frees slot for chosen job*/
-	/client/proc/cmd_admin_rejuvenate,
 	/client/proc/toggleattacklogs,
 	/client/proc/toggledebuglogs,
 	/client/proc/update_mob_sprite,
@@ -62,9 +60,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/man_up,
 	/client/proc/global_man_up,
 	/client/proc/delbook,
-	/client/proc/event_manager_panel,
-	/client/proc/empty_ai_core_toggle_latejoin,
-	/client/proc/fax_panel
+	/client/proc/empty_ai_core_toggle_latejoin
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -97,6 +93,9 @@ var/list/admin_verbs_event = list(
 	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/
 	/client/proc/response_team, // Response Teams admin verb
 	/client/proc/cmd_admin_create_centcom_report,
+	/client/proc/fax_panel,
+	/client/proc/secrets,
+	/client/proc/event_manager_panel
 	)
 
 var/list/admin_verbs_spawn = list(
@@ -121,21 +120,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/delbook,
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
-	/client/proc/set_ooc,
-
-	//Doubling of certain event verbs for senior admins
-	/datum/admins/proc/access_news_network,	/*allows access of newscasters*/
-	/client/proc/cmd_admin_direct_narrate,	/*send text directly to a player with no padding. Useful for narratives and fluff-text*/
-	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/
-	/client/proc/toggle_random_events,
-	/client/proc/toggle_ert_calling,
-	/client/proc/one_click_antag,
-	/client/proc/cmd_admin_change_custom_event,
-	/client/proc/cmd_admin_create_centcom_report,
-	/client/proc/cmd_admin_dress,
-	/client/proc/editappear,
-	/client/proc/response_team, // Response Teams admin verb
-	/client/proc/nanomapgen_DumpImage
+	/client/proc/set_ooc
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/cmd_admin_list_open_jobs,
@@ -165,7 +150,8 @@ var/list/admin_verbs_permissions = list(
 	/client/proc/edit_admin_permissions
 	)
 var/list/admin_verbs_rejuv = list(
-	/client/proc/respawn_character
+	/client/proc/respawn_character,
+	/client/proc/cmd_admin_rejuvenate
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
@@ -188,7 +174,6 @@ var/list/admin_verbs_mentor = list(
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
 	/client/proc/cmd_admin_pm_by_key_panel,	/*admin-pm list by key*/
-	/client/proc/cmd_mod_say,
 	/client/proc/cmd_mentor_check_new_players
 )
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -185,6 +185,12 @@ var/list/admin_verbs_mod = list(
 //	/client/proc/cmd_admin_subtle_message 	/*send an message to somebody as a 'voice in their head'*/
 )
 
+var/list/admin_verbs_mentor = list(
+	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
+	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
+	/client/proc/cmd_admin_pm_by_key_panel,	/*admin-pm list by key*/
+	/client/proc/cmd_mod_say,
+)
 
 /client/proc/add_admin_verbs()
 	if(holder)
@@ -202,6 +208,7 @@ var/list/admin_verbs_mod = list(
 		if(holder.rights & R_SOUNDS)		verbs += admin_verbs_sounds
 		if(holder.rights & R_SPAWN)			verbs += admin_verbs_spawn
 		if(holder.rights & R_MOD)			verbs += admin_verbs_mod
+		if(holder.rights & R_MENTOR)		verbs += admin_verbs_mentor
 
 /client/proc/admin_ghost()
 	set category = "Admin"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,10 +1,8 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
 //	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
-	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
-	/client/proc/debug_variables,		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
+	/client/proc/deadmin_self			/*destroys our own admin datum so we can play as a regular player*/
 //	/client/proc/check_antagonists,		/*shows all antags*/
-	/client/proc/cmd_mentor_check_new_players
 //	/client/proc/deadchat				/*toggles deadchat on/off*/
 	)
 var/list/admin_verbs_admin = list(
@@ -182,6 +180,7 @@ var/list/admin_verbs_mod = list(
 	/client/proc/dsay,
 	/datum/admins/proc/show_player_panel,
 	/client/proc/jobbans,
+	/client/proc/debug_variables		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 //	/client/proc/cmd_admin_subtle_message 	/*send an message to somebody as a 'voice in their head'*/
 )
 
@@ -190,6 +189,7 @@ var/list/admin_verbs_mentor = list(
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
 	/client/proc/cmd_admin_pm_by_key_panel,	/*admin-pm list by key*/
 	/client/proc/cmd_mod_say,
+	/client/proc/cmd_mentor_check_new_players
 )
 
 /client/proc/add_admin_verbs()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -21,7 +21,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 		src.verbs += /client/verb/adminhelp	// 2 minute cool-down for adminhelps//Go to hell
 	**/
 	var/msg
-	var/list/type = list("Player Complaint","Question","Bug Report","Event")
+	var/list/type = list("Question","Player Complaint")
 	var/selected_type = input("Pick a category.", "Admin Help", null, null) as null|anything in type
 	if(selected_type)
 		msg = input("Please enter your message.", "Admin Help", null, null) as text
@@ -100,9 +100,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	var/admin_number_afk = 0
 	var/list/modholders = list()
 	var/list/banholders = list()
-	var/list/debugholders = list()
 	var/list/adminholders = list()
-	var/list/eventholders = list()
 	for(var/client/X in admins)
 		if((R_MOD | R_MENTOR) & X.holder.rights)
 			if(X.is_afk())
@@ -114,10 +112,6 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 			adminholders += X
 		if(R_BAN & X.holder.rights)
 			banholders += X
-		if(R_DEBUG & X.holder.rights)
-			debugholders += X
-		if(R_EVENT & X.holder.rights)
-			eventholders += X
 
 	switch(selected_type)
 		if("Question")
@@ -129,30 +123,6 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 			else
 				if(adminholders.len)
 					for(var/client/X in adminholders)
-						if(X.prefs.sound & SOUND_ADMINHELP)
-							X << 'sound/effects/adminhelp.ogg'
-						X << msg
-		else if("Bug Report")
-			if(debugholders.len)
-				for(var/client/X in debugholders)
-					if(X.prefs.sound & SOUND_ADMINHELP)
-						X << 'sound/effects/adminhelp.ogg'
-					X << msg
-			else
-				if(adminholders.len)
-					for(var/client/X in adminholders)
-						if(X.prefs.sound & SOUND_ADMINHELP)
-							X << 'sound/effects/adminhelp.ogg'
-						X << msg
-		else if("Event")
-			if(eventholders.len)
-				for(var/client/X in eventholders)
-					if(X.prefs.sound & SOUND_ADMINHELP)
-						X << 'sound/effects/adminhelp.ogg'
-					X << msg
-			else
-				if(banholders.len)
-					for(var/client/X in banholders)
 						if(X.prefs.sound & SOUND_ADMINHELP)
 							X << 'sound/effects/adminhelp.ogg'
 						X << msg

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -104,7 +104,7 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	var/list/adminholders = list()
 	var/list/eventholders = list()
 	for(var/client/X in admins)
-		if(R_MOD & X.holder.rights)
+		if((R_MOD | R_MENTOR) & X.holder.rights)
 			if(X.is_afk())
 				admin_number_afk++
 			modholders += X

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -204,20 +204,14 @@
 
 	var/list/modholders = list()
 	var/list/banholders = list()
-	var/list/debugholders = list()
 	var/list/adminholders = list()
-	var/list/eventholders = list()
 	for(var/client/X in admins)
 		if((R_MOD | R_MENTOR) & X.holder.rights)
 			modholders += X
 		if(R_ADMIN & X.holder.rights)
 			adminholders += X
-		if(R_DEBUG & X.holder.rights)
-			debugholders += X
 		if(R_BAN & X.holder.rights)
 			banholders += X
-		if(R_EVENT & X.holder.rights)
-			eventholders += X
 
 	//we don't use message_admins here because the sender/receiver might get it too
 	for(var/client/X in admins)
@@ -231,16 +225,6 @@
 						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //inform X
 					else if(!modholders.len && X.holder.rights & R_ADMIN)
 						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //Any admins in backup of mod question
-				if("Bug Report")
-					if(X.holder.rights & R_DEBUG)
-						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //inform X
-					else if(!debugholders.len && X.holder.rights & R_ADMIN)
-						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //Any admins in backup of bug reports
-				if("Event")
-					if(X.holder.rights & R_EVENT)
-						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //inform X
-					else if(!eventholders.len && X.holder.rights & R_BAN)
-						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //Quality in backup of Event
 				if("Player Complaint")
 					if(X.holder.rights & R_BAN)
 						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //There should always be at least 1 person with +BAN on

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -103,7 +103,7 @@
 		//mod PMs are maroon
 		//PMs sent from admins and mods display their rank
 		if(holder)
-			if( holder.rights & R_MOD && !holder.rights & R_ADMIN )
+			if( holder.rights & (R_MOD | R_MENTOR) && !holder.rights & R_ADMIN )
 				recieve_color = "maroon"
 			else
 				recieve_color = "red"
@@ -208,7 +208,7 @@
 	var/list/adminholders = list()
 	var/list/eventholders = list()
 	for(var/client/X in admins)
-		if(R_MOD & X.holder.rights)
+		if((R_MOD | R_MENTOR) & X.holder.rights)
 			modholders += X
 		if(R_ADMIN & X.holder.rights)
 			adminholders += X
@@ -227,7 +227,7 @@
 		if(X.key!=key && X.key!=C.key)
 			switch(type)
 				if("Question")
-					if(X.holder.rights & R_MOD)
+					if(X.holder.rights & (R_MOD | R_MENTOR))
 						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //inform X
 					else if(!modholders.len && X.holder.rights & R_ADMIN)
 						X << "<B><font color='blue'>[type]: [key_name(src, X, 0, type)]-&gt;[key_name(C, X, 0, type)]:</B> \blue [msg]</font>" //Any admins in backup of mod question
@@ -273,6 +273,6 @@
 	for(var/client/X in admins)
 		if(X == src)
 			continue
-		if((X.holder.rights & R_ADMIN) || (X.holder.rights & R_MOD))
+		if((X.holder.rights & R_ADMIN) || (X.holder.rights & (R_MOD | R_MENTOR)))
 			X << "<B><font color='blue'>PM: [key_name(src, X, 0)]-&gt;IRC-Admins:</B> \blue [msg]</font>"
 

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -24,7 +24,7 @@
 	set name = "Msay"
 	set hidden = 1
 
-	if(!check_rights(R_ADMIN|R_MOD))	return
+	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))	return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	log_admin("MOD: [key_name(src)] : [msg]")
@@ -36,8 +36,8 @@
 		color = "adminmod"
 
 	var/channel = "MOD:"
-	if(config.mods_are_mentors)
+	if(check_rights(R_MENTOR,0))
 		channel = "MENTOR:"
 	for(var/client/C in admins)
-		if((R_ADMIN|R_MOD) & C.holder.rights)
+		if((R_ADMIN|R_MOD|R_MENTOR) & C.holder.rights)
 			C << "<span class='[color]'><span class='prefix'>[channel]</span> <EM>[key_name(src,1)]</EM> (<A HREF='?src=\ref[C.holder];adminplayerobservejump=\ref[mob]'>JMP</A>): <span class='message'>[msg]</span></span>"

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -24,7 +24,7 @@
 	set name = "Msay"
 	set hidden = 1
 
-	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))	return
+	if(!check_rights(R_ADMIN|R_MOD))	return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	log_admin("MOD: [key_name(src)] : [msg]")
@@ -36,8 +36,8 @@
 		color = "adminmod"
 
 	var/channel = "MOD:"
-	if(check_rights(R_MENTOR,0))
+	if(config.mods_are_mentors)
 		channel = "MENTOR:"
 	for(var/client/C in admins)
-		if((R_ADMIN|R_MOD|R_MENTOR) & C.holder.rights)
+		if((R_ADMIN|R_MOD) & C.holder.rights)
 			C << "<span class='[color]'><span class='prefix'>[channel]</span> <EM>[key_name(src,1)]</EM> (<A HREF='?src=\ref[C.holder];adminplayerobservejump=\ref[mob]'>JMP</A>): <span class='message'>[msg]</span></span>"

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -13,26 +13,26 @@ var/list/adminfaxes = list()
 
 /datum/fax/New()
 	faxes += src
-	
+
 /datum/fax/admin
 	var/list/reply_to = null
-	
+
 /datum/fax/admin/New()
 	adminfaxes += src
-	
-// Fax panel - lets admins check all faxes sent during the round	
+
+// Fax panel - lets admins check all faxes sent during the round
 /client/proc/fax_panel()
 	set name = "Fax Panel"
-	set category = "Admin"
+	set category = "Event"
 	if(holder)
 		holder.fax_panel(usr)
 	feedback_add_details("admin_verb","FXP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
-	
+
 /datum/admins/proc/fax_panel(var/mob/living/user)
 	var/html = "<A align='right' href='?src=\ref[src];refreshfaxpanel=1'>Refresh</A>"
 	html += "<A align='right' href='?src=\ref[src];AdminFaxCreate=1;faxtype=Administrator'>Create Fax</A>"
-	
+
 	html += "<div class='block'>"
 	html += "<h2>Admin Faxes</h2>"
 	html += "<table>"
@@ -51,14 +51,14 @@ var/list/adminfaxes = list()
 		html += "<td><A align='right' href='?src=\ref[src];AdminFaxView=\ref[A.message]'>View</A></td>"
 		if(!A.reply_to)
 			if(A.from_department == "Administrator")
-				html += "<td>N/A</td>"		
+				html += "<td>N/A</td>"
 			else
 				html += "<td><A align='right' href='?src=\ref[src];AdminFaxCreate=\ref[A.sent_by];originfax=\ref[A.origin];faxtype=[A.to_department];replyto=\ref[A.message]'>Reply</A></td>"
 			html += "<td>N/A</td>"
 		else
 			html += "<td>N/A</td>"
-			html += "<td><A align='right' href='?src=\ref[src];AdminFaxView=\ref[A.reply_to]'>Original</A></td>"		
-		html += "</tr>"	
+			html += "<td><A align='right' href='?src=\ref[src];AdminFaxView=\ref[A.reply_to]'>Original</A></td>"
+		html += "</tr>"
 	html += "</table>"
 	html += "</div>"
 
@@ -78,11 +78,10 @@ var/list/adminfaxes = list()
 		else
 			html += "<td>Unknown</td>"
 		html += "<td><A align='right' href='?src=\ref[src];AdminFaxView=\ref[F.message]'>View</A></td>"
-		html += "</tr>"	
+		html += "</tr>"
 	html += "</table>"
 	html += "</div>"
-	
+
 	var/datum/browser/popup = new(user, "fax_panel", "Fax Panel", 950, 450)
 	popup.set_content(html)
 	popup.open()
-		

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -130,8 +130,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	files.known_tech=files.possible_tech
 	for(var/datum/tech/KT in files.known_tech)
 		if(KT.level < KT.max_level)
-			KT.level=KT.max_level		
-		
+			KT.level=KT.max_level
+
 /obj/machinery/computer/rdconsole/New()
 	..()
 	files = new /datum/research(src) //Setup the research data holder.
@@ -250,11 +250,12 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				linked_destroy.loaded_item = null
 				linked_destroy.icon_state = "d_analyzer"
 				screen = 2.1
-				
+
 	else if(href_list["maxresearch"]) //Eject the item inside the destructive analyzer.
 		if(!usr.client.holder) return
+		if(usr.client.holder & R_MENTOR) return
 		screen = 0.0
-		if(alert("Are you sure you want to maximize research levels?","Confirmation","Yes","No")=="No") 
+		if(alert("Are you sure you want to maximize research levels?","Confirmation","Yes","No")=="No")
 			return
 		log_admin("[key_name(usr)] has maximized the research levels.")
 		message_admins("[key_name_admin(usr)] has maximized the research levels.")
@@ -262,7 +263,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			Maximize()
 			screen = 1.0
 			updateUsrDialog()
-			griefProtection() //Update centcomm too			
+			griefProtection() //Update centcomm too
 
 	else if(href_list["deconstruct"]) //Deconstruct the item in the destructive analyzer and update the research holder.
 		if(linked_destroy)
@@ -593,7 +594,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			spawn(20)
 				screen = 1.6
 				updateUsrDialog()
-				
+
 	else if(href_list["search"]) //Search for designs with name matching pattern
 		var/compare
 
@@ -611,7 +612,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				continue
 			if(findtext(D.name,href_list["to_search"]))
 				matching_designs.Add(D)
-				
+
 	updateUsrDialog()
 	return
 
@@ -873,7 +874,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					dat += " | <span class='bad'>LOCKED</span>"
 				dat += "<BR>"
 			dat += "</div>"
-			
+
 		if(3.17) //Display search result
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A>"
@@ -981,7 +982,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<h3>Circuit Imprinter Menu:</h3><BR>"
 			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
 			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
-			
+
 			dat += "<form name='search' action='?src=\ref[src]'> \
 			<input type='hidden' name='src' value='\ref[src]'> \
 			<input type='hidden' name='search' value='to_search'> \
@@ -1019,7 +1020,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				if(D.locked)
 					dat += " | <span class='bad'>LOCKED</span>"
 			dat += "</div>"
-			
+
 		if(4.17)
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A>"

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -700,7 +700,7 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 #define R_MOD			8192
 #define R_MENTOR		16384
 
-#define R_MAXPERMISSION 8192 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
+#define R_MAXPERMISSION 16384 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
 #define R_HOST			65535
 

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -698,6 +698,7 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 #define R_SOUNDS		2048
 #define R_SPAWN			4096
 #define R_MOD			8192
+#define R_MENTOR		16384
 
 #define R_MAXPERMISSION 8192 //This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
@@ -735,7 +736,7 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 #define BE_CULTIST		256
 #define BE_NINJA		512
 #define BE_RAIDER		1024
-#define BE_VAMPIRE		2048 
+#define BE_VAMPIRE		2048
 #define BE_MUTINEER		4096
 #define BE_BLOB			8192
 
@@ -807,7 +808,7 @@ var/list/restricted_camera_networks = list( //Those networks can only be accesse
 	"NukeOps",
 	"Thunderdome",
 	"UO45",
-	"UO45R",	
+	"UO45R",
 	"Xeno"
 	)
 


### PR DESCRIPTION
Neca asked for a new +MENTOR flag that could ONLY have the following rights and was distinct from the +MOD flag:

-Answer Questions Ahelps
-Appear in adminwho under mentors

No msay, No ghosting, no viewing variables, no players panels/notes, etc.