### PR TITLE
Added queue functionality to the autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -15,6 +15,9 @@
 	var/max_g_amount = 75000.0
 
 	var/operating = 0.0
+	var/list/queue = list()
+	var/queue_max_len = 10
+	var/turf/BuildTurf
 	anchored = 1.0
 	var/list/L = list()
 	var/list/LL = list()
@@ -92,7 +95,7 @@
 			if(AUTOLATHE_SEARCH_MENU)
 				dat = search_win(user)
 
-	var/datum/browser/popup = new(user, "autolathe", name, 500, 500)
+	var/datum/browser/popup = new(user, "autolathe", name, 800, 500)
 	popup.set_content(dat)
 	popup.open()
 
@@ -151,7 +154,7 @@
 			flick("autolathe_r",src)//plays glass insertion animation
 		stack.use(amount)
 	else
-		if(!user.before_take_item(O))
+		if(user.before_take_item(O))
 			user << "<span class='notice'>/the [O] is stuck to your hand, you can't put it in \the [src]!</span>"
 		O.loc = src
 	icon_state = "autolathe"
@@ -176,77 +179,65 @@
 /obj/machinery/autolathe/Topic(href, href_list)
 	if(..())
 		return 1
-	if (!busy)
-		if(href_list["menu"])
-			screen = text2num(href_list["menu"])
+	if(href_list["menu"])
+		screen = text2num(href_list["menu"])
 
-		if(href_list["category"])
-			selected_category = href_list["category"]
+	if(href_list["category"])
+		selected_category = href_list["category"]
 
-		if(href_list["make"])
+	if(href_list["make"])
+		BuildTurf = get_step(src.loc, get_dir(src,usr))
 
-			var/turf/T = get_step(src.loc, get_dir(src,usr))
+		/////////////////
+		//href protection
+		being_built = files.FindDesignByID(href_list["make"]) //check if it's a valid design
+		if(!being_built)
+			return
+		if(!(being_built.build_type & AUTOLATHE))
+			return
 
-			/////////////////
-			//href protection
-			being_built = files.FindDesignByID(href_list["make"]) //check if it's a valid design
-			if(!being_built)
-				return
+		//multiplier checks : only stacks can have one and its value is 1, 10 ,25 or max_multiplier
+		var/multiplier = text2num(href_list["multiplier"])
+		var/max_multiplier = min(50, being_built.materials["$metal"] ?round(m_amount/being_built.materials["$metal"]):INFINITY,being_built.materials["$glass"]?round(g_amount/being_built.materials["$glass"]):INFINITY)
+		var/is_stack = ispath(being_built.build_path, /obj/item/stack)
 
-			//multiplier checks : only stacks can have one and its value is 1, 10 ,25 or max_multiplier
-			var/multiplier = text2num(href_list["multiplier"])
-			var/max_multiplier = min(50, being_built.materials["$metal"] ?round(m_amount/being_built.materials["$metal"]):INFINITY,being_built.materials["$glass"]?round(g_amount/being_built.materials["$glass"]):INFINITY)
-			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
+		if(!is_stack && (multiplier > 1))
+			return
+		if (!(multiplier in list(1,10,25,max_multiplier))) //"enough materials ?" is checked in the build proc
+			return
+		/////////////////
+		
+		if(queue.len<queue_max_len)
+			add_to_queue(being_built,multiplier)
+		else
+			usr << "\red The autolathe queue is full!"
+		if (!busy)
+			busy = 1
+			process_queue()
+			busy = 0
+	
+	if(href_list["remove_from_queue"])
+		var/index = text2num(href_list["remove_from_queue"])
+		if(isnum(index) && IsInRange(index,1,queue.len))
+			remove_from_queue(index)
+	if(href_list["queue_move"] && href_list["index"])
+		var/index = text2num(href_list["index"])
+		var/new_index = index + text2num(href_list["queue_move"])
+		if(isnum(index) && isnum(new_index))
+			if(IsInRange(new_index,1,queue.len))
+				queue.Swap(index,new_index)
+	if(href_list["clear_queue"])
+		queue = list()
+	if(href_list["search"])
+		matching_designs.Cut()
 
-			if(!is_stack && (multiplier > 1))
-				return
-			if (!(multiplier in list(1,10,25,max_multiplier))) //"enough materials ?" is checked further down
-				return
-			/////////////////
-
-			var/coeff = (is_stack ? 1 : 2 ** prod_coeff) //stacks are unaffected by production coefficient
-			var/metal_cost = being_built.materials["$metal"]
-			var/glass_cost = being_built.materials["$glass"]
-
-			var/power = max(2000, (metal_cost+glass_cost)*multiplier/5)
-
-			if((m_amount >= metal_cost*multiplier/coeff) && (g_amount >= glass_cost*multiplier/coeff))
-				busy = 1
-				use_power(power)
-				icon_state = "autolathe"
-				flick("autolathe_n",src)
-				spawn(32/coeff)
-					use_power(power)
-					if(is_stack)
-						m_amount -= metal_cost*multiplier
-						g_amount -= glass_cost*multiplier
-						var/obj/item/stack/S = new being_built.build_path(T)
-						S.amount = multiplier
-					else
-						m_amount -= metal_cost/coeff
-						g_amount -= glass_cost/coeff
-						var/obj/item/new_item = new being_built.build_path(T)
-						new_item.m_amt /= coeff
-						new_item.g_amt /= coeff
-					if(m_amount < 0)
-						m_amount = 0
-					if(g_amount < 0)
-						g_amount = 0
-					busy = 0
-					src.updateUsrDialog()
-					
-		if(href_list["search"])
-			matching_designs.Cut()
-
-			for(var/datum/design/D in files.known_designs)
-				if(findtext(D.name,href_list["to_search"]))
-					matching_designs.Add(D)
-					
-	else
-		usr << "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>"
-
+		for(var/datum/design/D in files.known_designs)
+			if(findtext(D.name,href_list["to_search"]))
+				matching_designs.Add(D)
+		
+	
 	src.updateUsrDialog()
-
+	
 	return
 
 /obj/machinery/autolathe/RefreshParts()
@@ -260,8 +251,134 @@
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		prod_coeff += M.rating - 1
 
+/obj/machinery/autolathe/proc/get_coeff(var/datum/design/D)
+	var/coeff = (ispath(D.build_path,/obj/item/stack) ? 1 : 2 ** prod_coeff)//stacks are unaffected by production coefficient
+	return coeff
+
+/obj/machinery/autolathe/proc/build_item(var/datum/design/D, var/multiplier)
+	desc = initial(desc)+"\nIt's building \a [initial(D.name)]."
+	var/is_stack = ispath(D.build_path, /obj/item/stack)
+	var/coeff = get_coeff(D)
+	var/metal_cost = D.materials["$metal"]
+	var/glass_cost = D.materials["$glass"]
+	var/power = max(2000, (metal_cost+glass_cost)*multiplier/5)
+	if (can_build(D,multiplier))
+		use_power(power)
+		icon_state = "autolathe"
+		flick("autolathe_n",src)
+		updateUsrDialog()
+		sleep(32/coeff)
+		if(is_stack)
+			m_amount -= metal_cost*multiplier
+			g_amount -= glass_cost*multiplier
+			var/obj/item/stack/S = new D.build_path(BuildTurf)
+			S.amount = multiplier
+		else
+			m_amount -= metal_cost/coeff
+			g_amount -= glass_cost/coeff
+			var/obj/item/new_item = new D.build_path(BuildTurf)
+			new_item.m_amt /= coeff
+			new_item.g_amt /= coeff
+		if(m_amount < 0)
+			m_amount = 0
+		if(g_amount < 0)
+			g_amount = 0
+	updateUsrDialog()
+	desc = initial(desc)
+
+/obj/machinery/autolathe/proc/can_build(var/datum/design/D,var/multiplier=1,var/custom_metal,var/custom_glass)
+	var/coeff = get_coeff(D)
+	
+	var/m_amount_tmp = m_amount
+	if(custom_metal)
+		m_amount_tmp = custom_metal
+	var/g_amount_tmp = g_amount
+	if(custom_glass)
+		g_amount_tmp = custom_glass
+
+	if(D.materials["$metal"] && (m_amount_tmp*multiplier < (D.materials["$metal"] / coeff)))
+		return 0
+	if(D.materials["$glass"] && (g_amount_tmp*multiplier < (D.materials["$glass"] / coeff)))
+		return 0
+	return 1
+
+/obj/machinery/autolathe/proc/get_design_cost_as_list(var/datum/design/D,var/multiplier=1)
+	var/list/OutputList = list(0,0)
+	var/coeff = get_coeff(D)
+	if(D.materials["$metal"])
+		OutputList[1] = (D.materials["$metal"] / coeff)*multiplier
+	if(D.materials["$glass"])
+		OutputList[2] = (D.materials["$glass"] / coeff)*multiplier
+	return OutputList
+
+/obj/machinery/autolathe/proc/get_queue()
+	var/temp_metal = m_amount
+	var/temp_glass = g_amount
+	var/output = "<td valign='top' style='width: 300px'>"
+	output += "<div class='statusDisplay'>"
+	output += "<b>Queue contains:</b>"
+	if (!istype(queue) || !queue.len)
+		output += "<br>Nothing"
+	else
+		output += "<ol>"
+		var/i = 0
+		var/datum/design/D
+		for(var/list/L in queue)
+			i++
+			D = L[1]
+			var/multiplier = L[2]
+			var/obj/part = D.build_path
+			var/list/LL = get_design_cost_as_list(D,multiplier)
+			var/is_stack = (multiplier>1)
+			output += "<li[!can_build(D,multiplier,temp_metal,temp_glass)?" style='color: #f00;'":null]>[initial(part.name)][is_stack?" (x[multiplier])":null] - [i>1?"<a href='?src=\ref[src];queue_move=-1;index=[i]' class='arrow'>&uarr;</a>":null] [i<queue.len?"<a href='?src=\ref[src];queue_move=+1;index=[i]' class='arrow'>&darr;</a>":null] <a href='?src=\ref[src];remove_from_queue=[i]'>Remove</a></li>"
+			temp_metal = max(temp_metal-LL[1],1)
+			temp_glass = max(temp_glass-LL[2],1)
+		
+		output += "</ol>"
+		output += "<a href='?src=\ref[src];clear_queue=1'>Clear queue</a>"
+	output += "</div></td>"
+	return output
+
+/obj/machinery/autolathe/proc/add_to_queue(D,var/multiplier)
+	if(!istype(queue))
+		queue = list()
+	if(D)
+		queue.Add(list(list(D,multiplier)))
+	return queue.len
+
+/obj/machinery/autolathe/proc/remove_from_queue(index)
+	if(!isnum(index) || !istype(queue) || (index<1 || index>queue.len))
+		return 0
+	queue.Cut(index,++index)
+	return 1
+
+/obj/machinery/autolathe/proc/process_queue()
+	var/datum/design/D = queue[1][1]
+	var/multiplier = queue[1][2]
+	if(!D)
+		remove_from_queue(1)
+		if(queue.len)
+			return process_queue()
+		else
+			return
+	while(D)
+		if(stat&(NOPOWER|BROKEN))
+			return 0
+		if(!can_build(D,multiplier))
+			visible_message("\icon[src] <b>\The [src]</b> beeps, \"Not enough resources. Queue processing terminated.\"")
+			queue = list()
+			return 0
+		
+		remove_from_queue(1)
+		build_item(D,multiplier)
+		D = listgetindex(listgetindex(queue, 1),1)
+		multiplier = listgetindex(listgetindex(queue,1),2)
+	//visible_message("\icon[src] <b>\The [src]</b> beeps, \"Queue processing finished successfully.\"")
+
 /obj/machinery/autolathe/proc/main_win(mob/user)
-	var/dat = "<div class='statusDisplay'><h3>Autolathe Menu:</h3><br>"
+	var/dat = "<table style='width:100%'><tr>"
+	dat += "<td valign='top' style='margin-right: 300px'>"
+	dat += "<div class='statusDisplay'><h3>Autolathe Menu:</h3><br>"
 	dat += "<b>Metal amount:</b> [src.m_amount] / [max_m_amount] cm<sup>3</sup><br>"
 	dat += "<b>Glass amount:</b> [src.g_amount] / [max_g_amount] cm<sup>3</sup>"
 
@@ -285,11 +402,16 @@
 		line_length++
 
 	dat += "</tr></table></div>"
+	dat += "</td>"
+	dat += get_queue()
+	dat += "</tr></table>"
 	return dat
 
 /obj/machinery/autolathe/proc/category_win(mob/user,var/selected_category)
-	var/dat = "<A href='?src=\ref[src];menu=[AUTOLATHE_MAIN_MENU]'>Return to main menu</A>"
-	dat += "<div class='statusDisplay'><h3>Browsing [selected_category]:</h3><br>"
+	var/dat = "<table style='width:100%'><tr><td valign='top' style='margin-right: 300px'>"
+	dat += "<div class='statusDisplay'>"
+	dat += "<A href='?src=\ref[src];menu=[AUTOLATHE_MAIN_MENU]'>Return to main menu</A>"
+	dat += "<h3>Browsing [selected_category]:</h3><br>"
 	dat += "<b>Metal amount:</b> [src.m_amount] / [max_m_amount] cm<sup>3</sup><br>"
 	dat += "<b>Glass amount:</b> [src.g_amount] / [max_g_amount] cm<sup>3</sup><hr>"
 
@@ -314,11 +436,16 @@
 		dat += "[get_design_cost(D)]<br>"
 
 	dat += "</div>"
+	dat += "</td>"
+	dat += get_queue()
+	dat += "</tr></table>"
 	return dat
 	
 /obj/machinery/autolathe/proc/search_win(mob/user)
-	var/dat = "<A href='?src=\ref[src];menu=[AUTOLATHE_MAIN_MENU]'>Return to main menu</A>"
-	dat += "<div class='statusDisplay'><h3>Search results:</h3><br>"
+	var/dat = "<table style='width:100%'><tr><td valign='top' style='margin-right: 300px'>"
+	dat += "<div class='statusDisplay'>"
+	dat += "<A href='?src=\ref[src];menu=[AUTOLATHE_MAIN_MENU]'>Return to main menu</A>"
+	dat += "<h3>Search results:</h3><br>"
 	dat += "<b>Metal amount:</b> [src.m_amount] / [max_m_amount] cm<sup>3</sup><br>"
 	dat += "<b>Glass amount:</b> [src.g_amount] / [max_g_amount] cm<sup>3</sup><hr>"
 
@@ -340,19 +467,13 @@
 		dat += "[get_design_cost(D)]<br>"
 
 	dat += "</div>"
+	dat += "</td>"
+	dat += get_queue()
+	dat += "</tr></table>"
 	return dat
 
-/obj/machinery/autolathe/proc/can_build(var/datum/design/D)
-	var/coeff = (ispath(D.build_path,/obj/item/stack) ? 1 : 2 ** prod_coeff)
-
-	if(D.materials["$metal"] && (m_amount < (D.materials["$metal"] / coeff)))
-		return 0
-	if(D.materials["$glass"] && (g_amount < (D.materials["$glass"] / coeff)))
-		return 0
-	return 1
-
 /obj/machinery/autolathe/proc/get_design_cost(var/datum/design/D)
-	var/coeff = (ispath(D.build_path,/obj/item/stack) ? 1 : 2 ** prod_coeff)
+	var/coeff = get_coeff(D)
 	var/dat
 	if(D.materials["$metal"])
 		dat += "[D.materials["$metal"] / coeff] metal "
@@ -378,7 +499,7 @@
 
 	if(hack)
 		for(var/datum/design/D in files.possible_designs)
-			if((D.build_type & 4) && ("hacked" in D.category))
+			if((D.build_type & AUTOLATHE) && ("hacked" in D.category))
 				files.known_designs += D
 	else
 		for(var/datum/design/D in files.known_designs)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -5,8 +5,8 @@
 	icon_state = "cameracase"
 	w_class = 2
 	anchored = 0
-	m_amt = 700
-	g_amt = 300
+	m_amt = 400
+	g_amt = 250
 
 	//	Motion, EMP-Proof, X-Ray
 	var/list/obj/item/possible_upgrades = list(/obj/item/device/assembly/prox_sensor, /obj/item/stack/sheet/mineral/osmium, /obj/item/weapon/stock_parts/scanning_module)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -16,8 +16,8 @@
 	desc = "Retracts stuff."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "retractor"
-	m_amt = 10000
-	g_amt = 5000
+	m_amt = 6000
+	g_amt = 3000
 	flags = FPRINT | TABLEPASS | CONDUCT
 	w_class = 2.0
 	origin_tech = "materials=1;biotech=1"
@@ -265,8 +265,8 @@ LOOK FOR SURGERY.DM*/
 	desc = "This stops bleeding."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "cautery"
-	m_amt = 5000
-	g_amt = 2500
+	m_amt = 2500
+	g_amt = 750
 	flags = FPRINT | TABLEPASS | CONDUCT
 	w_class = 2.0
 	origin_tech = "materials=1;biotech=1"
@@ -356,8 +356,8 @@ LOOK FOR SURGERY.DM*/
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "drill"
 	hitsound = 'sound/weapons/circsawhit.ogg'
-	m_amt = 15000
-	g_amt = 10000
+	m_amt = 10000
+	g_amt = 6000
 	flags = FPRINT | TABLEPASS | CONDUCT
 	force = 15.0
 	w_class = 2.0
@@ -385,8 +385,8 @@ LOOK FOR SURGERY.DM*/
 	throwforce = 5.0
 	throw_speed = 3
 	throw_range = 5
-	m_amt = 10000
-	g_amt = 5000
+	m_amt = 4000
+	g_amt = 1000
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
@@ -637,8 +637,8 @@ LOOK FOR SURGERY.DM*/
 	throwforce = 9.0
 	throw_speed = 3
 	throw_range = 5
-	m_amt = 20000
-	g_amt = 10000
+	m_amt = 10000
+	g_amt = 6000
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 	sharp = 1

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -147,7 +147,7 @@
 
 	//Cost to make in the autolathe
 	m_amt = 70
-	g_amt = 30
+	g_amt = 20
 
 	//R&D tech level
 	origin_tech = "engineering=1"

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -3,8 +3,8 @@
 	desc = "Used to remotely activate devices."
 	icon_state = "signaller"
 	item_state = "signaler"
-	m_amt = 1000
-	g_amt = 200
+	m_amt = 400
+	g_amt = 120
 	origin_tech = "magnets=1"
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -226,7 +226,7 @@
 	name = "large beaker"
 	desc = "A large beaker. Can hold up to 100 units."
 	icon_state = "beakerlarge"
-	g_amt = 5000
+	g_amt = 2500
 	volume = 100
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,50,100)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -230,7 +230,7 @@
 	name = "Metal"
 	id = "metal"
 	build_type = AUTOLATHE
-	materials = list("$metal" = MINERAL_MATERIAL_AMOUNT)
+	materials = list("$metal" = 3750)
 	build_path = /obj/item/stack/sheet/metal
 	category = list("initial","Construction")
 	
@@ -254,7 +254,7 @@
 	name = "Reinforced Glass"
 	id = "rglass"
 	build_type = AUTOLATHE
-	materials = list("$metal" = 1000, "$glass" = MINERAL_MATERIAL_AMOUNT)
+	materials = list("$metal" = 1875, "$glass" = MINERAL_MATERIAL_AMOUNT)
 	build_path = /obj/item/stack/sheet/rglass
 	category = list("initial","Construction")
 
@@ -262,7 +262,7 @@
 	name = "Metal Rod"
 	id = "rods"
 	build_type = AUTOLATHE
-	materials = list("$metal" = 1000)
+	materials = list("$metal" = 1875)
 	build_path = /obj/item/stack/rods
 	category = list("initial","Construction")
 	


### PR DESCRIPTION
Added queue functionality to the autolathe, similar to the robotic fabricator

No items in queue:
![emptylist](https://cloud.githubusercontent.com/assets/147366/6232174/991b4602-b6ca-11e4-8857-c7175eb8bc02.png)

Items added to the queue:
![filled](https://cloud.githubusercontent.com/assets/147366/6232177/9eaf1e54-b6ca-11e4-82e3-c5e65e32e4d4.png)

* Items are processed at the same speed as before (around 4 s per item at lowest upgrades)
* The queue is processed automatically, can't be paused, and is cleared if there's insufficient resources
* Stacks of metal/glass/etc can also be queued