### PR TITLE
Fix rev highpop feature

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -445,7 +445,7 @@ Implants;
 /datum/game_mode/proc/num_players_started()
 	. = 0
 	for(var/mob/living/carbon/human/H in player_list)
-		if(P.client)
+		if(H.client)
 			. ++
 
 ///////////////////////////////////

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -442,6 +442,11 @@ Implants;
 		if(P.client && P.ready)
 			. ++
 
+/datum/game_mode/proc/num_players_started()
+	. = 0
+	for(var/mob/living/carbon/human/H in player_list)
+		if(P.client)
+			. ++
 
 ///////////////////////////////////
 //Keeps track of all living heads//

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -75,7 +75,7 @@
 
 /datum/game_mode/revolution/post_setup()
 	var/list/heads = get_living_heads()
-	if(num_players() >= 40)
+	if(num_players_started() >= 30)
 		heads += get_extra_living_heads()
 		extra_heads = 1
 
@@ -113,7 +113,7 @@
 
 /datum/game_mode/proc/forge_revolutionary_objectives(var/datum/mind/rev_mind)
 	var/list/heads = get_living_heads()
-	if(num_players() >= 40)
+	if(num_players_started() >= 30)
 		heads += get_extra_living_heads()
 		extra_heads = 1
 	for(var/datum/mind/head_mind in heads)


### PR DESCRIPTION
- Lowered number required for highpop extra targets from 40 to 30 since TONS of people latejoin. We can adjust that number once the other rev fixes are in.
- Fixes a proc that only checked new_player and not spawned in mobs that have clients.
