### PR TITLE
Chem Boom Nerf

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1147,13 +1147,13 @@ steam.start() -- spawns the effect
 
 			// Clamp all values to MAX_EXPLOSION_RANGE
 			if (round(amount/12) > 0)
-				devastation = min (MAX_EXPLOSION_RANGE, devastation + round(amount/12))
+				devastation = min (MAX_EX_DEVESTATION_RANGE, devastation + round(amount/12))
 
 			if (round(amount/6) > 0)
-				heavy = min (MAX_EXPLOSION_RANGE, heavy + round(amount/6))
+				heavy = min (MAX_EX_HEAVY_RANGE, heavy + round(amount/6))
 
 			if (round(amount/3) > 0)
-				light = min (MAX_EXPLOSION_RANGE, light + round(amount/3))
+				light = min (MAX_EX_LIGHT_RANGE, light + round(amount/3))
 
 			if (flash && flashing_factor)
 				flash += (round(amount/4) * flashing_factor)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -373,23 +373,14 @@ datum
 				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 				s.set_up(2, 1, location)
 				s.start()
-				for(var/mob/living/carbon/M in viewers(world.view, location))
-					switch(get_dist(M, location))
-						if(0 to 3)
-							if(hasvar(M, "glasses"))
-								if(istype(M:glasses, /obj/item/clothing/glasses/sunglasses))
-									continue
-
-							flick("e_flash", M.flash)
-							M.Weaken(15)
-
-						if(4 to 5)
-							if(hasvar(M, "glasses"))
-								if(istype(M:glasses, /obj/item/clothing/glasses/sunglasses))
-									continue
-
-							flick("e_flash", M.flash)
-							M.Stun(5)
+				for(var/mob/living/carbon/C in hearers(5, location))
+					if(C.eyecheck())
+						continue
+					flick("e_flash", C.flash)
+					if(get_dist(C, location) < 4)
+						C.Weaken(5)
+						continue
+					C.Stun(5)
 
 		napalm
 			name = "Napalm"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -31,12 +31,6 @@ datum
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/datum/effect/effect/system/reagents_explosion/e = new()
 				e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)
-				e.holder_damage(holder.my_atom)
-				if(isliving(holder.my_atom))
-					e.amount *= 0.5
-					var/mob/living/L = holder.my_atom
-					if(L.stat!=DEAD)
-						e.amount *= 0.5
 				e.start()
 				holder.clear_reagents()
 				return
@@ -356,12 +350,6 @@ datum
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/datum/effect/effect/system/reagents_explosion/e = new()
 				e.set_up(round (created_volume/2, 1), holder.my_atom, 0, 0)
-				e.holder_damage(holder.my_atom)
-				if(isliving(holder.my_atom))
-					e.amount *= 0.5
-					var/mob/living/L = holder.my_atom
-					if(L.stat!=DEAD)
-						e.amount *= 0.5
 				e.start()
 
 				holder.clear_reagents()

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -156,6 +156,10 @@ var/turf/space/Space_Tile = locate(/turf/space) // A space tile to reference whe
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
 var/MAX_EXPLOSION_RANGE = 14
+var/MAX_EX_DEVESTATION_RANGE = 3
+var/MAX_EX_HEAVY_RANGE = 7
+var/MAX_EX_LIGHT_RANGE = 14
+var/MAX_EX_FLASH_RANGE = 14
 //#define MAX_EXPLOSION_RANGE		14					// Defaults to 12 (was 8) -- TLE
 
 #define HUMAN_STRIP_DELAY 40 //takes 40ds = 4s to strip someone.
@@ -735,7 +739,7 @@ var/list/TAGGERLOCATIONS = list("Disposals",
 #define BE_CULTIST		256
 #define BE_NINJA		512
 #define BE_RAIDER		1024
-#define BE_VAMPIRE		2048 
+#define BE_VAMPIRE		2048
 #define BE_MUTINEER		4096
 #define BE_BLOB			8192
 
@@ -807,7 +811,7 @@ var/list/restricted_camera_networks = list( //Those networks can only be accesse
 	"NukeOps",
 	"Thunderdome",
 	"UO45",
-	"UO45R",	
+	"UO45R",
 	"Xeno"
 	)
 


### PR DESCRIPTION
Nerfs Chemical Explosions

-Forces chemical grenades to obey the bomb cap (meaning no more nitroglycerin+bluespace beakers wiping an entire department off the map); the max size explosion you'll be able to attain will be 3,7,14 (just like with plasma bombs).
-Removes the snowflake code for explosive reactions taking place inside mobs; this means that 40 units potassium pill+40 units water pill won't gib the mob anymore, instead it'll create an explosion just as if it had taken place inside a beaker or any other reagent container. Now, two 50 unit pills (one of potassium and one of water) will result in a size -1,0,2 explosion and deal around ~30 brute damage to the mob the reaction took place in. It'll still be incredibly useful if you can pull it off,, it just won't be cheap-win ridiculous anymore.

Update
-Updates the flash powder code so it's not so ridiculously snowflake; also brings its stun/weaken durations to more realistic values similar to flashbangs instead of a crazy weaken duration of 15; it now stuns you if you're 5 tiles away for 5 ticks; 4 tiles or closer and it weakens you for 5 ticks.
