### PR TITLE
Added repair functionality to spacepods

### DIFF
--- a/code/game/vehicles/spacepods/spacepod.dm
+++ b/code/game/vehicles/spacepods/spacepod.dm
@@ -161,10 +161,12 @@
 /obj/spacepod/attackby(obj/item/W as obj, mob/user as mob)
 	if(iscrowbar(W))
 		hatch_open = !hatch_open
+		playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
 		user << "<span class='notice'>You [hatch_open ? "open" : "close"] the maintenance hatch.</span>"
 	if(istype(W, /obj/item/weapon/stock_parts/cell))
 		if(!hatch_open)
-			return ..()
+			user << "\red The maintenance hatch is closed!"
+			return
 		if(battery)
 			user << "<span class='notice'>The pod already has a battery.</span>"
 			return
@@ -174,7 +176,8 @@
 		return
 	if(istype(W, /obj/item/device/spacepod_equipment))
 		if(!hatch_open)
-			return ..()
+			user << "\red The maintenance hatch is closed!"
+			return
 		if(!equipment_system)
 			user << "<span class='warning'>The pod has no equipment datum, yell at pomf</span>"
 			return

--- a/code/game/vehicles/spacepods/spacepod.dm
+++ b/code/game/vehicles/spacepods/spacepod.dm
@@ -432,6 +432,7 @@
 
 
 /obj/spacepod/MouseDrop_T(mob/M as mob, mob/user as mob)
+	if(!isliving(M)) return
 	if(M != user)
 		if(M.stat != 0)
 			if(allow2enter)


### PR DESCRIPTION
As discussed here: http://nanotrasen.se/phpBB3/viewtopic.php?f=12&t=3822

- One welder use consumes 3 fuel and repairs 10 hull damage
- Fully repairing a sec spacepod requires around 40-42 welder uses,
and around 120-140 fuel
- Standard welder must be refueled about 6-7 times to fully repair a sec pod (civ pod needs less ofc due to lower health). Better welders requires less refueling but still demands a fair bit of time.