### PR TITLE
Respawn as the new cargo mobs, language fixes

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -107,7 +107,11 @@ proc/get_radio_key_from_channel(var/channel)
 				listening_obj |= O
 
 		for(var/mob/M in player_list)
-			if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS))
+			if (!M.client)
+				continue //skip monkeys and leavers
+			if (istype(M, /mob/new_player))
+				continue
+			if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS) && src.client) // src.client is so that ghosts don't have to listen to mice
 				listening |= M
 				continue
 			if(M.loc && M.locs[1] in hearturfs)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -114,6 +114,7 @@ var/list/ai_list = list()
 
 	//Languages
 	add_language("Robot Talk", 1)
+	add_language("Galactic Common", 1)
 	add_language("Sol Common", 1)
 	add_language("Tradeband", 1)
 	add_language("Sinta'unathi", 0)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -84,6 +84,7 @@
 		radio = card.radio
 		
 	//Default languages without universal translator software
+	add_language("Galactic Common", 1)
 	add_language("Sol Common", 1)
 	add_language("Tradeband", 1)
 	add_language("Gutter", 1)	

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -59,6 +59,7 @@
 			
 /obj/item/weapon/robot_module/proc/add_languages(var/mob/living/silicon/robot/R)
 	//full set of languages
+	R.add_language("Galactic Common", 1)
 	R.add_language("Sol Common", 1)
 	R.add_language("Tradeband", 1)
 	R.add_language("Sinta'unathi", 0)
@@ -266,6 +267,7 @@
 		
 /obj/item/weapon/robot_module/butler/add_languages(var/mob/living/silicon/robot/R)
 	//full set of languages
+	R.add_language("Galactic Common", 1)
 	R.add_language("Sol Common", 1)
 	R.add_language("Tradeband", 1)
 	R.add_language("Sinta'unathi", 1)
@@ -371,7 +373,7 @@
 		src.emag.reagents.add_reagent("pacid", 125)
 		src.emag.reagents.add_reagent("sacid", 125)
 		
-/obj/item/weapon/robot_module/butler/add_languages(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/alien/hunter/add_languages(var/mob/living/silicon/robot/R)
 	..()
 	R.add_language("xenocommon", 1)
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -435,6 +435,12 @@
 		return 1 // ZOMG PONIES WHEEE
 	if(ispath(MP, /mob/living/simple_animal/fox))
 		return 1
+	if(ispath(MP, /mob/living/simple_animal/chick))
+		return 1
+	if(ispath(MP, /mob/living/simple_animal/pug))
+		return 1
+	if(ispath(MP, /mob/living/simple_animal/butterfly))
+		return 1
 	//Not in here? Must be untested!
 	return 0
 
@@ -459,6 +465,12 @@
 	if(ispath(MP, /mob/living/simple_animal/pony))
 		return 1
 	if(ispath(MP, /mob/living/simple_animal/fox))
+		return 1
+	if(ispath(MP, /mob/living/simple_animal/chick))
+		return 1
+	if(ispath(MP, /mob/living/simple_animal/pug))
+		return 1
+	if(ispath(MP, /mob/living/simple_animal/butterfly))
 		return 1
 
 //Antag Creatures!


### PR DESCRIPTION
Changes:
1) Lets you respawn as chicks, pugs and BUTTERFLIES.
2) Ensures silicons have Galactic Common.
3) Fixes players being able to see chatter in the lobby.