### PR TITLE
New mutation, new clown feature

### DIFF
--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -162,6 +162,10 @@
 		block = COMICBLOCK
 
 	OnSay(var/mob/M, var/message)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if((H.wear_id && istype(H.wear_id,/obj/item/weapon/card/id/syndicate)) && (H.wear_mask && istype(H.wear_mask,/obj/item/clothing/mask/gas/voice)))
+				return message
 		if(message)
 			message = "<span class='sans'>[message]</span>"
 			return message

--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -17,7 +17,7 @@
 		message = replacetext(message,"!","!!")
 		return uppertext(message)
 
-
+/* BROKEN WITH NEW SAYCODE
 /datum/dna/gene/disability/speech/whisper
 	name = "Quiet"
 	desc = "Damages the subjects vocal cords"
@@ -36,7 +36,7 @@
 
 	OnSay(var/mob/M, var/message)
 		M.whisper(message)
-
+*/
 
 /datum/dna/gene/disability/dizzy
 	name = "Dizzy"

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -98,7 +98,7 @@
 
 	// Disabilities
 	LOUDBLOCK      = getAssignedBlock("LOUD",       numsToAssign)
-	WHISPERBLOCK   = getAssignedBlock("WHISPER",    numsToAssign)
+	//WHISPERBLOCK   = getAssignedBlock("WHISPER",    numsToAssign) BROKEN WITH NEW SAYCODE
 	DIZZYBLOCK     = getAssignedBlock("DIZZY",      numsToAssign)
 
 

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -227,9 +227,8 @@
 		H.equip_or_collect(new /obj/item/weapon/storage/fancy/crayons(H), slot_in_backpack)
 		H.equip_or_collect(new /obj/item/weapon/reagent_containers/spray/waterflower(H), slot_in_backpack)
 		H.mutations.Add(M_CLUMSY)
-		if(prob(50))
-			H.dna.SetSEState(COMICBLOCK,1,1)
-			genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
+		H.dna.SetSEState(COMICBLOCK,1,1)
+		genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
 		return 1
 
 

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -227,8 +227,9 @@
 		H.equip_or_collect(new /obj/item/weapon/storage/fancy/crayons(H), slot_in_backpack)
 		H.equip_or_collect(new /obj/item/weapon/reagent_containers/spray/waterflower(H), slot_in_backpack)
 		H.mutations.Add(M_CLUMSY)
-		H.dna.SetSEState(COMICBLOCK,1,1)
-		genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
+		if(prob(50))
+			H.dna.SetSEState(COMICBLOCK,1,1)
+			genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
 		return 1
 
 

--- a/code/global.dm
+++ b/code/global.dm
@@ -101,7 +101,7 @@ var/POLYMORPHBLOCK = 0
 // /vg/ Mutations
 ///////////////////////////////
 var/LOUDBLOCK = 0
-var/WHISPERBLOCK = 0
+//var/WHISPERBLOCK = 0
 var/DIZZYBLOCK = 0
 
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -1,9 +1,10 @@
 //admin verb groups - They can overlap if you so wish. Only one of each verb will exist in the verbs list regardless
 var/list/admin_verbs_default = list(
 //	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
-	/client/proc/deadmin_self			/*destroys our own admin datum so we can play as a regular player*/
+	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 //	/client/proc/check_antagonists,		/*shows all antags*/
 //	/client/proc/deadchat				/*toggles deadchat on/off*/
+	/client/proc/cmd_mentor_check_new_players
 	)
 var/list/admin_verbs_admin = list(
 	/client/proc/check_antagonists,		/*shows all antags*/
@@ -176,8 +177,7 @@ var/list/admin_verbs_mod = list(
 var/list/admin_verbs_mentor = list(
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
-	/client/proc/cmd_admin_pm_by_key_panel,	/*admin-pm list by key*/
-	/client/proc/cmd_mentor_check_new_players
+	/client/proc/cmd_admin_pm_by_key_panel	/*admin-pm list by key*/
 )
 
 /client/proc/add_admin_verbs()

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -315,7 +315,7 @@
 	desc = "The language of clown planet. Mother tongue of clowns throughout the Galaxy."
 	speech_verb = "honks"
 	ask_verb = "honks"
-	exclain_verb = "honks"
+	exclaim_verb = "honks"
 	colour = "clown"
 	key = "0"
 	syllables = list ("honk","squeak","bonk","toot","narf","zub","wee","wub","norf")

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -215,7 +215,7 @@
 	var/new_name = "[pick(list("To Sleep Beneath","Wind Over","Embrace of","Dreams of","Witnessing","To Walk Beneath","Approaching the"))]"
 	new_name += " [pick(list("the Void","the Sky","Encroaching Night","Planetsong","Starsong","the Wandering Star","the Empty Day","Daybreak","Nightfall","the Rain"))]"
 	return new_name
-	
+
 /datum/language/trinary
 	name = "Trinary"
 	desc = "A modification of binary to allow fuzzy logic. 0 is no, 1 is maybe, 2 is yes. Credited with giving Machine People the ability to think creatively."
@@ -225,8 +225,8 @@
 	colour = "trinary"
 	key = "5"
 	flags = RESTRICTED | WHITELISTED
-	syllables = list("02011","01222","10100","10210","21012","02011","21200","1002","2001","0002","0012","0012","000","120","121","201","220","10","11","0")	
-	
+	syllables = list("02011","01222","10100","10210","21012","02011","21200","1002","2001","0002","0012","0012","000","120","121","201","220","10","11","0")
+
 /datum/language/kidan
 	name = "Chittin"
 	desc = "The noise made by rubbing its antennae together is actually a complex form of communication for Kidan."
@@ -237,7 +237,7 @@
 	key = "4"
 	flags = RESTRICTED | WHITELISTED
 	syllables = list("click","clack")
-	
+
 /datum/language/slime
 	name = "Bubblish"
 	desc = "The language of slimes. It's a mixture of bubbling noises and pops. Very difficult to speak without mechanical aid for humans."
@@ -309,6 +309,16 @@
 	colour = "rough"
 	key = "3"
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
+
+/datum/language/clown
+	name = "Clownish"
+	desc = "The language of clown planet. Mother tongue of clowns throughout the Galaxy."
+	speech_verb = "honks"
+	ask_verb = "honks"
+	exclain_verb = "honks"
+	colour = "clown"
+	key = "0"
+	syllables = list ("honk","squeak","bonk","toot","narf","zub","wee","wub","norf")
 
 /datum/language/xenocommon
 	name = "Xenomorph"

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -408,7 +408,7 @@ var/MAX_EX_FLASH_RANGE = 14
 
 // /vg/ muts
 #define M_LOUD		208		// CAUSES INTENSE YELLING
-#define M_WHISPER	209		// causes quiet whispering
+//#define M_WHISPER	209		// causes quiet whispering
 #define M_DIZZY		210		// Trippy.
 
 //disabilities

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -77,6 +77,7 @@ h1.alert, h2.alert		{color: #000000;}
 .trinary				{color: #727272;}
 .kidan					{color: #664205;}
 .slime					{color: #0077AA;}
+.clown					{color: #ff0000;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
 .sans					{font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}


### PR DESCRIPTION
- COMIC mutation. Talk in Comic Sans. Works over radio, and works with alien languages.
- Gives the clown COMIC for added HONK.
- Adds Mk2 and Mk3 drone icons Pics: http://baystation12.net/forums/viewtopic.php?f=44&p=259489#p259487
- Changes the clown intro pic to awesome FoSart https://www.dropbox.com/s/iqen0vmgj8hbwn7/fos1.png?raw=1
- Makes sure all staff have "Check new players"
- Adds a new secondary language anyone can learn: Clownish
- EMERGENCY: Removes WHISPER disability which causes infinite loops and crashes