### PR TITLE
Make sure dead people don't get a typing indicator

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -13,7 +13,7 @@ var/global/image/typing_indicator
 		typing_indicator = image('icons/mob/talk.dmi',null,"typing")
 
 	if(client)
-		if(client.prefs.toggles & SHOW_TYPING)
+		if((client.prefs.toggles & SHOW_TYPING) || stat != CONSCIOUS)
 			overlays -= typing_indicator
 		else
 			if(state)


### PR DESCRIPTION
Changes:
1) Makes sure dead people never get a typing indicator. Shouldn't normally happen, but apparently a changeling mute sting can cause it.