### PR TITLE
Compact Defib - Overlay Fix

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -52,20 +52,20 @@
 /obj/item/weapon/defibrillator/proc/update_overlays()
 	overlays.Cut()
 	if(!on)
-		overlays += "defibunit-paddles"
+		overlays += "[icon_state]-paddles"
 	if(powered)
-		overlays += "defibunit-powered"
+		overlays += "[icon_state]-powered"
 	if(!bcell)
-		overlays += "defibunit-nocell"
+		overlays += "[icon_state]-nocell"
 	if(!safety)
-		overlays += "defibunit-emagged"
+		overlays += "[icon_state]-emagged"
 
 /obj/item/weapon/defibrillator/proc/update_charge()
 	if(powered) //so it doesn't show charge if it's unpowered
 		if(bcell)
 			var/ratio = bcell.charge / bcell.maxcharge
 			ratio = Ceiling(ratio*4) * 25
-			overlays += "defibunit-charge[ratio]"
+			overlays += "[icon_state]-charge[ratio]"
 
 /obj/item/weapon/defibrillator/CheckParts()
 	bcell = locate(/obj/item/weapon/stock_parts/cell) in contents


### PR DESCRIPTION
The compact defib units now use the belt overlay, as opposed to the back-mounted ones.

Pre-Fix:
![defibold](https://cloud.githubusercontent.com/assets/5769931/6339569/1dd173e4-bb85-11e4-9d5f-953bb4ca93fa.PNG)

Post-Fix:
![defibnew](https://cloud.githubusercontent.com/assets/5769931/6339573/21ee9600-bb85-11e4-9feb-aa1ba71d482b.PNG)



