### PR TITLE
Fixes, Genetics, and Balance

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -207,6 +207,8 @@ mob/airflow_hit(atom/A)
 	for(var/mob/M in hearers(src))
 		M.show_message("\red <B>\The [src] slams into \a [A]!</B>",1,"\red You hear a loud slam!",2)
 	playsound(src.loc, "smash.ogg", 25, 1, -1)
+	if(!(status_flags & CANSTUN) && !(status_flags & CANWEAKEN))
+		return 0
 	weakened = max(weakened, (istype(A,/obj/item) ? A:w_class : rand(1,5))) //Heheheh
 	. = ..()
 
@@ -237,6 +239,9 @@ mob/living/carbon/human/airflow_hit(atom/A)
 
 	blocked = run_armor_check("groin","melee")
 	apply_damage(b_loss/3, BRUTE, "groin", blocked, 0, "Airflow")
+
+	if(!(status_flags & CANSTUN) && !(status_flags & CANWEAKEN))
+		return 0
 
 	if(airflow_speed > 10)
 		paralysis += round(airflow_speed * vsc.airflow_stun)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -107,7 +107,7 @@
 			if(ismob(A))
 				changeNext_move(CLICK_CD_MELEE)
 			UnarmedAttack(A, 1)
-					
+
 		return
 
 	if(!isturf(loc)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
@@ -126,7 +126,7 @@
 				if(ismob(A))
 					changeNext_move(CLICK_CD_MELEE)
 				UnarmedAttack(A, 1)
-				
+
 			return
 		else // non-adjacent click
 			if(W)
@@ -136,9 +136,9 @@
 
 	return
 
-/mob/proc/changeNext_move(num)	
+/mob/proc/changeNext_move(num)
 	next_move = world.time + num
-	
+
 // Default behavior: ignore double clicks, consider them normal clicks instead
 /mob/proc/DblClickOn(var/atom/A, var/params)
 	return
@@ -344,21 +344,9 @@
 		if(available >= 5000000)
 			L.damage = 205
 		if(L.damage >= 200)
-			apply_damage(15, BURN, (hand ? "l_hand" : "r_hand"))
-			//usr:Stun(15)
-			//usr:Weaken(15)
-			//if(usr:status_flags & CANSTUN) // stun is usually associated with stutter
-			//	usr:stuttering += 20
 			time = 200
-			src << "<span class='warning'>[G] overload from the massive current shocking you in the process!"
 		else if(L.damage >= 100)
-			apply_damage(5, BURN, (hand ? "l_hand" : "r_hand"))
-			//usr:Stun(10)
-			//usr:Weaken(10)
-			//if(usr:status_flags & CANSTUN) // stun is usually associated with stutter
-			//	usr:stuttering += 10
 			time = 150
-			src << "<span class='warning'>[G] overload from the massive current shocking you in the process!"
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(5, 1, src)
 		s.start()

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -53,8 +53,6 @@
 	/////////////////////////
 
 	var/power = force
-	if(HULK in user.mutations)
-		power *= 2
 
 	if(!istype(M, /mob/living/carbon/human))
 		if(istype(M, /mob/living/carbon/slime))

--- a/code/datums/spells/genetic.dm
+++ b/code/datums/spells/genetic.dm
@@ -20,8 +20,8 @@
 	for(var/mob/living/target in targets)
 		for(var/x in mutations)
 			target.mutations.Add(x)
-			if(x == HULK && ishuman(target))
-				target:hulk_time=world.time + duration
+		/*	if(x == HULK && ishuman(target))
+				target:hulk_time=world.time + duration */
 		target.disabilities |= disabilities
 		target.update_mutations()	//update target's mutation overlays
 		spawn(duration)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -107,10 +107,6 @@
 	src.thrower = thrower
 	src.throw_source = get_turf(src)	//store the origin turf
 
-	if(usr)
-		if(HULK in usr.mutations)
-			src.throwing = 2 // really strong throw!
-
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
 

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -47,6 +47,7 @@
 	desc = "Enables the subject to bend low levels of light around themselves, creating a cloaking effect."
 	activation_messages = list("You begin to fade into the shadows.")
 	deactivation_messages = list("You become fully visible.")
+	activation_prob=10
 
 	New()
 		block=SHADOWBLOCK
@@ -66,6 +67,7 @@
 	desc = "The subject becomes able to subtly alter light patterns to become invisible, as long as they remain still."
 	activation_messages = list("You feel one with your surroundings.")
 	deactivation_messages = list("You feel oddly exposed.")
+	activation_prob=10
 
 	New()
 		block=CHAMELEONBLOCK

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -7,6 +7,7 @@
 	activation_messages=list("You feel no need to breathe.")
 	mutation=NO_BREATH
 	instability=2
+	activation_prob=10
 
 	New()
 		block=NOBREATHBLOCK
@@ -112,10 +113,57 @@
 		..(M,connected,flags)
 		M.pass_flags |= 1
 
+
+// OLD HULK BEHAVIOR
+/datum/dna/gene/basic/hulk
+	name="Hulk"
+	activation_messages=list("Your muscles hurt.")
+	mutation=HULK
+	activation_prob=5
+
+	New()
+		block=HULKBLOCK
+
+	can_activate(var/mob/M,var/flags)
+		// Can't be big AND small.
+		if(DWARF in M.mutations)
+			return 0
+		return ..(M,flags)
+
+	activate(var/mob/M, var/connected, var/flags)
+		..()
+		var/status = CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH
+		M.status_flags &= ~status
+
+	deactivate(var/mob/M, var/connected, var/flags)
+		..()
+		M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH
+
+	OnDrawUnderlays(var/mob/M,var/g,var/fat)
+		if(HULK in M.mutations)
+			if(fat)
+				return "hulk_[fat]_s"
+			else
+				return "hulk_[g]_s"
+		return 0
+
+	OnMobLife(var/mob/living/carbon/human/M)
+		if(!istype(M)) return
+		if ((HULK in M.mutations) && M.health <= 25)
+			M.mutations.Remove(HULK)
+			M.dna.SetSEState(HULKBLOCK,0)
+			M.update_mutations()		//update our mutation overlays
+			M.update_body()
+			M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH //temporary fix until the problem can be solved.
+			M << "<span class='danger'>You suddenly feel very weak.</span>"
+			M.Weaken(3)
+			M.emote("collapse")
+
 /datum/dna/gene/basic/xray
 	name="X-Ray Vision"
 	activation_messages=list("The walls suddenly disappear.")
 	mutation=XRAY
+	activation_prob=10
 	instability=2
 
 	New()
@@ -125,7 +173,7 @@
 	name="Telekenesis"
 	activation_messages=list("You feel smarter.")
 	mutation=TK
-	activation_prob=15
+	activation_prob=10
 	instability=5
 
 	New()

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -2,7 +2,7 @@
 This is /vg/'s nerf for hulk.  Feel free to steal it.
 
 Obviously, requires DNA2.
-*/
+
 
 // When hulk was first applied (world.time).
 /mob/living/carbon/human/var/hulk_time=0
@@ -84,7 +84,7 @@ Obviously, requires DNA2.
 	//M.say(pick("",";")+pick("HULK MAD","YOU MADE HULK ANGRY")) // Just a note to security.
 	message_admins("[key_name(usr)] has hulked out! ([formatJumpTo(usr)])")
 	return
-
+*/
 
 ///////////////////Vanilla Morph////////////////////////////////////
 
@@ -222,19 +222,19 @@ Obviously, requires DNA2.
 /obj/effect/proc_holder/spell/wizard/targeted/remotetalk/choose_targets(mob/user = usr)
 	var/list/targets = new /list()
 	var/list/validtargets = new /list()
-	for(var/mob/M in living_mob_list)	
+	for(var/mob/M in living_mob_list)
 		if(M && M.mind)
 			var/special_role = M.mind.special_role
 			if (special_role == "Wizard" || special_role == "Ninja" || special_role == "Syndicate" || special_role == "Syndicate Commando" || special_role == "Vox Raider" || special_role == "Alien")
 				continue
-				
+
 			validtargets += M
-		
+
 	if(!validtargets.len || validtargets.len == 1)
 		usr << "<span class='warning'>There are no valid targets!</span>"
 		start_recharge()
 		return
-		
+
 	targets += input("Choose the target to talk to.", "Targeting") as mob in validtargets
 
 	perform(targets)
@@ -280,7 +280,7 @@ Obviously, requires DNA2.
 	icon_power_button = "genetic_view"
 
 /obj/effect/proc_holder/spell/wizard/targeted/remoteview/choose_targets(mob/user = usr)
-	var/list/targets = living_mob_list 
+	var/list/targets = living_mob_list
 	var/list/remoteviewers = new /list()
 	for(var/mob/M in targets)
 		if(REMOTE_VIEW in M.mutations)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -88,12 +88,14 @@
 		update_icons()
 
 /mob/living/carbon/alien/humanoid/hunter/throw_impact(A)
-	var/msg = ""
+
+	if(!leaping)
+		return ..()
 
 	if(A)
 		if(istype(A, /mob/living))
 			var/mob/living/L = A
-			msg = "<span class ='alertalien'>[src] pounces on [A]!</span>"
+			L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
 			L.Weaken(5)
 			sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 			step_towards(src,L)
@@ -103,13 +105,12 @@
 			spawn(pounce_cooldown_time) //3s by default
 				pounce_cooldown = !pounce_cooldown
 		else
-			msg = "<span class ='alertalien'>[src] smashes into [A]!</span>"
+			visible_message("<span class ='danger'>[src] smashes into [A]!</span>", "<span class ='alertalien'>[src] smashes into [A]!</span>")
 			weakened = 2
 
 		if(leaping)
 			leaping = 0
 			update_canmove()
-			visible_message(msg)
 
 
 /mob/living/carbon/alien/humanoid/float(on)
@@ -157,7 +158,5 @@
 
 
 	src.throwing = 0
-	if(isobj(src))
-		src.throw_impact(get_turf(src))
 
 	return 1

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -22,7 +22,7 @@
 		name = text("alien ([rand(1, 1000)])")
 	real_name = name
 	add_language("Xenomorph")
-	add_language("Hivemind") 
+	add_language("Hivemind")
 	..()
 
 //This is fine, works the same as a human
@@ -65,7 +65,7 @@
 	return (tally + move_delay_add + config.alien_delay)
 
 /mob/living/carbon/alien/humanoid/Process_Spacemove(var/check_drift = 0)
-	return 1
+	return 0
 
 ///mob/living/carbon/alien/humanoid/bullet_act(var/obj/item/projectile/Proj) taken care of in living
 
@@ -121,7 +121,7 @@
 	show_message("<span class='userdanger'>The blob attacks!</span>")
 	adjustFireLoss(damage)
 	return
-	
+
 /mob/living/carbon/alien/humanoid/meteorhit(O as obj)
 	for(var/mob/M in viewers(src, null))
 		if ((M.client && !( M.blinded )))
@@ -271,7 +271,7 @@
 				if (HULK in M.mutations)//HULK SMASH
 					damage += 14
 					spawn(0)
-						Weaken(damage) // Why can a hulk knock an alien out but not knock out a human? Damage is robust enough.
+						Paralyse(1)
 						step_away(src,M,15)
 						sleep(3)
 						step_away(src,M,15)
@@ -279,7 +279,7 @@
 				visible_message("<span class='danger'>[M] has punched [src]!</span>", \
 						"<span class='userdanger'>[M] has punched [src]!</span>")
 				if ((stat != DEAD) && (damage > 9||prob(5)))//Regular humans have a very small chance of weakening an alien.
-					Weaken(1,5)
+					Paralyse(2)
 					visible_message("<span class='danger'>[M] has weakened [src]!</span>", \
 							"<span class='userdanger'>[M] has weakened [src]!</span>", \
 							"<span class='danger'>You hear someone fall.</span>")
@@ -292,7 +292,7 @@
 		if ("disarm")
 			if (!lying)
 				if (prob(5))//Very small chance to push an alien down.
-					Weaken(2)
+					Paralyse(2)
 					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 					visible_message("<span class='danger'>[M] has pushed down [src]!</span>", \
 							"<span class='userdanger'>[M] has pushed down [src]!</span>")

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -24,7 +24,7 @@
 	real_name = name
 	regenerate_icons()
 	add_language("Xenomorph")
-	add_language("Hivemind") 
+	add_language("Hivemind")
 	..()
 
 //This is fine, works the same as a human
@@ -128,7 +128,7 @@
 //can't equip anything
 /mob/living/carbon/alien/larva/attack_ui(slot_id)
 	return
-	
+
 /mob/living/carbon/alien/larva/meteorhit(O as obj)
 	for(var/mob/M in viewers(src, null))
 		if ((M.client && !( M.blinded )))
@@ -254,7 +254,7 @@
 				visible_message("<span class='danger'>[M] has kicked [src]!</span>", \
 						"<span class='userdanger'>[M] has kicked [src]!</span>")
 				if ((stat != DEAD) && (damage > 4.9))
-					Weaken(rand(5,10))
+					Paralyse(rand(5,10))
 					visible_message("<span class='danger'>[M] has weakened [src]!</span>", \
 							"<span class='userdanger'>[M] has weakened [src]!</span>", \
 							"<span class='danger'>You hear someone fall.</span>")

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/alien/proc/handle_chemicals_in_body()
-	if(reagents) reagents.metabolize(src)
+	if(reagents)
+		reagents.metabolize(src)
 
 	if (drowsyness)
 		drowsyness--

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -78,7 +78,10 @@
 
 
 /mob/living/carbon/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/def_zone = null)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)	//godmode
+		return 0
+	if(NO_SHOCK in mutations) //shockproof
+		return 0
 	shock_damage *= siemens_coeff
 	if (shock_damage<1)
 		return 0
@@ -99,8 +102,14 @@
 				"\red <B>You feel a powerful shock course through your body!</B>", \
 				"\red You hear a heavy electrical crack." \
 			)
-		Stun(10)//This should work for now, more is really silly and makes you lay there forever
-		Weaken(10)
+		jitteriness += 1000 //High numbers for violent convulsions
+		do_jitter_animation(jitteriness)
+		stuttering += 2
+		Stun(2)
+		spawn(20)
+			jitteriness -= 990 //Still jittery, but vastly less
+			Stun(3)
+			Weaken(3)
 	if (shock_damage > 200)
 		src.visible_message(
 			"\red [src] was arc flashed by the [source]!", \
@@ -588,6 +597,6 @@
 
 /mob/living/carbon/proc/canBeHandcuffed()
 	return 0
-	
+
 /mob/living/carbon/is_muzzled()
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -403,7 +403,7 @@
 				L.amount_grown = min(L.amount_grown + damage, L.max_grown)
 			var/datum/organ/external/affecting = get_organ(ran_zone(L.zone_sel.selecting))
 			var/armor_block = run_armor_check(affecting, "melee")
-			apply_damage(damage, BRUTE, affecting, armor_block)		
+			apply_damage(damage, BRUTE, affecting, armor_block)
 
 /mob/living/carbon/human/proc/is_loyalty_implanted(mob/living/carbon/human/M)
 	for(var/L in M.contents)
@@ -636,7 +636,10 @@
 //Removed the horrible safety parameter. It was only being used by ninja code anyways.
 //Now checks siemens_coefficient of the affected area by default
 /mob/living/carbon/human/electrocute_act(var/shock_damage, var/obj/source, var/base_siemens_coeff = 1.0, var/def_zone = null)
-	if(status_flags & GODMODE)	return 0	//godmode
+	if(status_flags & GODMODE)	//godmode
+		return 0
+	if(NO_SHOCK in mutations) //shockproof
+		return 0
 
 	if (!def_zone)
 		def_zone = pick("l_hand", "r_hand")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -32,7 +32,9 @@
 			var/datum/organ/external/affecting = get_organ(ran_zone(M.zone_sel.selecting))
 			var/armor_block = run_armor_check(affecting, "melee")
 
-			if(HULK in M.mutations)			damage += 5
+			if(HULK in M.mutations)
+				damage += 5
+				Weaken(4)
 
 			playsound(loc, "punch", 25, 1, -1)
 
@@ -139,8 +141,9 @@
 			var/datum/organ/external/affecting = get_organ(ran_zone(M.zone_sel.selecting))
 			var/armor_block = run_armor_check(affecting, "melee")
 
-			if(HULK in M.mutations)			damage += 5
-
+			if(HULK in M.mutations)
+				damage += 5
+				Weaken(4)
 
 			playsound(loc, attack.attack_sound, 25, 1, -1)
 

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -32,7 +32,7 @@
 	timeofdeath = 0
 
 /mob/living/carbon/human/getBrainLoss()
-	if(species && species.flags & NO_INTORGANS) 
+	if(species && species.flags & NO_INTORGANS)
 		return
 	var/res = brainloss
 	var/datum/organ/internal/brain/sponge = internal_organs_by_name["brain"]
@@ -110,15 +110,12 @@
 	hud_updateflag |= 1 << HEALTH_HUD
 
 /mob/living/carbon/human/Stun(amount)
-	if(HULK in mutations)	return
 	..()
 
 /mob/living/carbon/human/Weaken(amount)
-	if(HULK in mutations)	return
 	..()
 
 /mob/living/carbon/human/Paralyse(amount)
-	if(HULK in mutations)	return
 	..()
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -62,7 +62,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 	if(life_tick%30==15)
 		hud_updateflag = 1022
-		
+
 	voice = GetVoice()
 
 	//No need to update all of these procs if the guy is dead.
@@ -1165,13 +1165,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 			//Jitteryness
 			if(jitteriness)
-				var/amplitude = min(4, (jitteriness/100) + 1)
-				var/pixel_x_diff = rand(-amplitude, amplitude)
-				var/pixel_y_diff = rand(-amplitude/3, amplitude/3)
-
-				animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff , time = 2, loop = 6)
-				animate(pixel_x = initial(pixel_x) , pixel_y = initial(pixel_y) , time = 2)
-				jitteriness = max(jitteriness-1, 0)
+				do_jitter_animation(jitteriness)
 
 			//Other
 			handle_statuses()
@@ -1926,7 +1920,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	var/client/C = client
 	for(var/mob/living/carbon/human/H in view(src, 14))
 		C.images += H.hud_list[NATIONS_HUD]
-		
+
 /mob/living/carbon/human/handle_silent()
 	if(..())
 		speech_problem_flag = 1

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -121,7 +121,10 @@
 
 		if ((HULK in mutations) && health <= 25)
 			mutations.Remove(HULK)
-			src << "\red You suddenly feel very weak."
+			dna.SetSEState(HULKBLOCK,0)
+			update_mutations()		//update our mutation overlays
+			status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH //temporary fix until the problem can be solved.
+			src << "<span class='danger'>You suddenly feel very weak.</span>"
 			Weaken(3)
 			emote("collapse")
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -131,7 +131,7 @@
 		now_pushing = 1
 		if(ismob(AM))
 			var/mob/tmob = AM
-			if(istype(tmob, /mob/living/carbon/human) && (HULK in tmob.mutations))
+			if(istype(tmob, /mob/living/carbon/human) && (FAT in tmob.mutations))
 				if(prob(70))
 					usr << "\red <B>You fail to push [tmob]'s fat ass out of the way.</B>"
 					now_pushing = 0
@@ -188,8 +188,8 @@
 		if ((O.icon_state == "flaming" && !( shielded )))
 			adjustFireLoss(40)
 		health = 100 - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()
-	return	
-	
+	return
+
 /mob/living/carbon/monkey/attack_paw(mob/living/M as mob)
 	..()
 
@@ -434,7 +434,7 @@
 		updatehealth()
 
 	return
-	
+
 /mob/living/carbon/monkey/Stat()
 	..()
 	statpanel("Status")

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -58,6 +58,8 @@
 			halloss += effect // Useful for objects that cause "subdual" damage. PAIN!
 		if(IRRADIATE)
 			radiation += max(effect * ((100-run_armor_check(null, "rad", "Your clothes feel warm.", "Your clothes feel warm."))/100),0)//Rads auto check armor
+		if(SLUR)
+			slurring = max(slurring,(effect * blocked))
 		if(STUTTER)
 			if(status_flags & CANSTUN) // stun is usually associated with stutter
 				stuttering = max(stuttering,(effect * blocked))
@@ -66,7 +68,8 @@
 		if(DROWSY)
 			drowsyness = max(drowsyness,(effect * blocked))
 		if(JITTER)
-			jitteriness = max(jitteriness,(effect * blocked))
+			if(status_flags & CANSTUN)
+				jitteriness = max(jitteriness,(effect * blocked))
 	updatehealth()
 	return 1
 
@@ -80,12 +83,13 @@
 /mob/living/carbon/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)
 	return ..()
 
-/mob/living/proc/apply_effects(var/stun = 0, var/weaken = 0, var/paralyze = 0, var/irradiate = 0, var/stutter = 0, var/eyeblur = 0, var/drowsy = 0, var/agony = 0, var/blocked = 0, var/stamina = 0, var/jitter = 0)
+/mob/living/proc/apply_effects(var/stun = 0, var/weaken = 0, var/paralyze = 0, var/irradiate = 0, var/slur = 0, var/stutter = 0, var/eyeblur = 0, var/drowsy = 0, var/agony = 0, var/blocked = 0, var/stamina = 0, var/jitter = 0)
 	if(blocked >= 100)	return 0
 	if(stun)		apply_effect(stun, STUN, blocked)
 	if(weaken)		apply_effect(weaken, WEAKEN, blocked)
 	if(paralyze)	apply_effect(paralyze, PARALYZE, blocked)
 	if(irradiate)	apply_effect(irradiate, IRRADIATE, blocked)
+	if(slur) 		apply_effect(slur, SLUR, blocked)
 	if(stutter)		apply_effect(stutter, STUTTER, blocked)
 	if(eyeblur)		apply_effect(eyeblur, EYE_BLUR, blocked)
 	if(drowsy)		apply_effect(drowsy, DROWSY, blocked)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -47,8 +47,6 @@
 /mob/living/proc/burn_skin(burn_amount)
 	if(istype(src, /mob/living/carbon/human))
 		//world << "DEBUG: burn_skin(), mutations=[mutations]"
-		if(NO_SHOCK in src.mutations) //shockproof
-			return 0
 		if (RESIST_HEAT in src.mutations) //fireproof
 			return 0
 		var/mob/living/carbon/human/H = src	//make this damage method divide the damage to be done among all the body parts, then burn each body part for that much damage. will have better effect then just randomly picking a body part
@@ -629,7 +627,8 @@
 		var/mob/living/carbon/CM = L
 		if(CM.on_fire && CM.canmove)
 			CM.fire_stacks -= 5
-			CM.Weaken(3)
+			CM.weakened = max(CM.weakened, 3)//We dont check for CANWEAKEN, I don't care how immune to weakening you are, if you're rolling on the ground, you're busy.
+			CM.update_canmove()
 			CM.spin(32,2)
 			CM.visible_message("<span class='danger'>[CM] rolls on the floor, trying to put themselves out!</span>", \
 				"<span class='notice'>You stop, drop, and roll!</span>")
@@ -761,7 +760,7 @@
 
 /mob/living/proc/can_use_vents()
 	return "You can't fit into that vent."
-	
+
 
 
 /atom/movable/proc/do_attack_animation(atom/A)
@@ -791,3 +790,15 @@
 			pixel_y_diff = -8
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
 	animate(pixel_x = initial(pixel_x), pixel_y = initial(pixel_y), time = 2)
+
+/mob/living/do_attack_animation(atom/A)
+	..()
+	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+
+/mob/living/proc/do_jitter_animation(jitteriness)
+	var/amplitude = min(4, (jitteriness/100) + 1)
+	var/pixel_x_diff = rand(-amplitude, amplitude)
+	var/pixel_y_diff = rand(-amplitude/3, amplitude/3)
+	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff , time = 2, loop = 6)
+	animate(pixel_x = initial(pixel_x) , pixel_y = initial(pixel_y) , time = 2)
+	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -855,7 +855,7 @@ var/list/slot_equipment_priority = list( \
 		return 0
 	src << message
 	return 1
-	
+
 /mob/proc/is_muzzled()
 	return 0
 
@@ -1119,16 +1119,19 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/Stun(amount)
 	if(status_flags & CANSTUN)
 		stunned = max(max(stunned,amount),0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
+		update_canmove()
 	return
 
 /mob/proc/SetStunned(amount) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
 	if(status_flags & CANSTUN)
 		stunned = max(amount,0)
+		update_canmove()
 	return
 
 /mob/proc/AdjustStunned(amount)
 	if(status_flags & CANSTUN)
 		stunned = max(stunned + amount,0)
+		update_canmove()
 	return
 
 /mob/proc/Weaken(amount)
@@ -1152,40 +1155,49 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/Paralyse(amount)
 	if(status_flags & CANPARALYSE)
 		paralysis = max(max(paralysis,amount),0)
+		update_canmove()
 	return
 
 /mob/proc/SetParalysis(amount)
 	if(status_flags & CANPARALYSE)
 		paralysis = max(amount,0)
+		update_canmove()
 	return
 
 /mob/proc/AdjustParalysis(amount)
 	if(status_flags & CANPARALYSE)
 		paralysis = max(paralysis + amount,0)
+		update_canmove()
 	return
 
 /mob/proc/Sleeping(amount)
 	sleeping = max(max(sleeping,amount),0)
+	update_canmove()
 	return
 
 /mob/proc/SetSleeping(amount)
 	sleeping = max(amount,0)
+	update_canmove()
 	return
 
 /mob/proc/AdjustSleeping(amount)
 	sleeping = max(sleeping + amount,0)
+	update_canmove()
 	return
 
 /mob/proc/Resting(amount)
 	resting = max(max(resting,amount),0)
+	update_canmove()
 	return
 
 /mob/proc/SetResting(amount)
 	resting = max(amount,0)
+	update_canmove()
 	return
 
 /mob/proc/AdjustResting(amount)
 	resting = max(resting + amount,0)
+	update_canmove()
 	return
 
 /mob/proc/get_species()

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -25,6 +25,12 @@
 			sparks.set_up(1, 1, src)
 			sparks.start()
 			proj_hit = 1
+		else if(iscarbon(target))
+			var/mob/living/carbon/C = target
+			if(HULK in C.mutations)
+				C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
+			else if(C.status_flags & CANWEAKEN)
+				C.do_jitter_animation(jitter)
 	..()
 
 /obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet


### PR DESCRIPTION
Fixes and Genetics changes (some balance too)

Fixes:
- Fixes unstunnable mobs becoming permastunned when they get thrown into objects
- Fixes the NO SHOCK power; it prevented a tiny little proc that's almost never used; it's now the same as having insulated gloves
- Fixes Xeno leaping
- Fixes Xeno visible message when pounced
- Fixes stuns, weakens, paralysis, and sleeping not being instant (I'll explain this in a bit)*
- fixes slurring not being properly applied
- shifts jitteriness to its own proc so it behaves more consistently (doesn't have to wait on life proc)
- Fixes monkies being able to push fat people
- Fixes people not floating after doing an attack animation

Features:
- Adds in TG's shocking jittery animation. Basically, when shocked, instead of just falling down, you are frozen in spot for a short while, then you fall over (https://github.com/tgstation/-tg-station/pull/6347).

![shock](https://cloud.githubusercontent.com/assets/5659269/5426450/dfdb3f5e-831f-11e4-9fab-d5ad06aaad16.gif)

Balance:
- self damage from power gloves removed (let's not punish people who can pull this off)

- A lot of the major genetics powers are now a lot harder to find; X-Ray no breathing, camo, and cloak of darkness now only have a 10% chance of becoming activated (instead of the regular 45% chance)
- TK acquisition chance lowered from 15 to 10
- Hulk acquisition chance lowered from 15 to 5

- Hulk is now a permanent mutation as it was before; overall goal is to make it more rewarding to punch things, but less rewarding to engage in weapons based combat--the mutation's unarmed ability is a bit stronger to factor in how much rarer and more difficult it is to find now, as well:
 - Specific snowflake boosts to item attack damage and throwing (and therefor stun chance) completely removed; you previously got a 2x modifier on weapons with hulk.
 - Hulk's punching now out and out stuns, in large part to compensate for their other damage/weaken boosts being axed (sorry, no more drills do 30 damage, spears doing 36, and eswords doing 60).
 - Hulks now operate off of CANSTUN/CANWEAKEN/CANPARALYZE/CANPUSH instead of a snowflake check specifically for hulk; this means that they won't be knocked over by airflow or slamming into walls, too.
 - Hulks scream when shot with tasers now

- Xenos no longer have the ability to move around freely in space
- Xenos have a chance to become paralyzed when attacked as opposed to weakened

*Explanation on making instant stuns more...instant. No, this isn't a buff to tasers, at all; basically what was happening is that when someone was stunned, paralyzed, or the likes, they wouldn't actually become impacted by that status effect until it ran on the next life proc. Currently weakening did update instantly--so you probably didn't notice any delay (since stunbatons, batons, tasers, and 99% of stuns you encounter have weaken AND stun on them); just making it so that it's consistent across the board in this behavior and to prevent some weird sitautions.

As an example of this messing things up; before this was fixed, you could shock yourself with this new door-shock animation then step 2-3 tiles away from a door before you finally got stunned by the shock---since it stuns first then weakens and it wouldn't actually stun you until the next life proc (roughly ~1.8 seconds).

