### PR TITLE
Autolathe queue shows items being processed

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -292,17 +292,17 @@
 
 /obj/machinery/autolathe/proc/can_build(var/datum/design/D,var/multiplier=1,var/custom_metal,var/custom_glass)
 	var/coeff = get_coeff(D)
-
-	var/m_amount_tmp = m_amount
+	
+	var/metal_amount = m_amount
 	if(custom_metal)
-		m_amount_tmp = custom_metal
-	var/g_amount_tmp = g_amount
+		metal_amount = custom_metal
+	var/glass_amount = g_amount
 	if(custom_glass)
-		g_amount_tmp = custom_glass
-
-	if(D.materials["$metal"] && (m_amount_tmp*multiplier < (D.materials["$metal"] / coeff)))
+		glass_amount = custom_glass
+	
+	if(D.materials["$metal"] && (metal_amount < (multiplier*D.materials["$metal"] / coeff)))
 		return 0
-	if(D.materials["$glass"] && (g_amount_tmp*multiplier < (D.materials["$glass"] / coeff)))
+	if(D.materials["$glass"] && (glass_amount < (multiplier*D.materials["$glass"] / coeff)))
 		return 0
 	return 1
 


### PR DESCRIPTION
Shows the item currently being processed by the autolathe, feels a lot more responsive this way:

![untitled](https://cloud.githubusercontent.com/assets/147366/6380855/1124699e-bd3d-11e4-9e29-a151b0ce0405.png)

Will also now use design names instead of obj names, since they're capitalized.

Fixed queue max length calculation, and increased it to 12 from 11 (10+1).