### PR TITLE
Swaps Xeno Sentinel and Hunter Health Values

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/hunter
 	name = "alien hunter"
 	caste = "h"
-	maxHealth = 150
-	health = 150
+	maxHealth = 125
+	health = 125
 	storedPlasma = 100
 	max_plasma = 150
 	icon_state = "alienh_s"

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/sentinel
 	name = "alien sentinel"
 	caste = "s"
-	maxHealth = 125
-	health = 125
+	maxHealth = 150
+	health = 150
 	storedPlasma = 100
 	max_plasma = 250
 	icon_state = "aliens_s"


### PR DESCRIPTION
Fairly simple change, hunters previously had 150 health and sentinels had 125, which didn't make much sense considering sentinels are supposed to be the defenders of the nest, yet they were more fragile than hunters. Sentinels now have 150, hunters have 125.

Also encourages players to pick hunter less often, as that's the most picked xeno class due to their high movement speed, high slash damage, and the ability to leap.