### PR TITLE
Xenoarchaeology Find icon fix

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -347,7 +347,7 @@
 			if(spawn_type)
 				var/obj/item/weapon/gun/energy/new_gun = new spawn_type(src.loc)
 				new_item = new_gun
-				new_item.icon_state = "egun[rand(1,6)]"
+				new_item.icon_state = pick("laser","retro","laser","caplaser","xray","energy","laser")
 				new_gun.desc = "This is an antique energy weapon, you're not sure if it will fire or not."
 
 				//5% chance to explode when first fired


### PR DESCRIPTION
Fixes the icons for the energy guns found through Xenoarchaeology to
actually use icons that exist.