### PR TITLE
Makes harvesting animals give meat equal to their meat amount

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -549,13 +549,7 @@
 
 // Harvest an animal's delicious byproducts
 /mob/living/simple_animal/proc/harvest()
-	if(prob(70))
-		if(meat_amount && meat_type)
-			for(var/i = 0; i < meat_amount; i++)
-				new meat_type(get_turf(src))
-		del(src)
-	else
-		gib()
+	gib()
 	return
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -549,11 +549,13 @@
 
 // Harvest an animal's delicious byproducts
 /mob/living/simple_animal/proc/harvest()
-	new meat_type (get_turf(src))
-	if(prob(95))
+	if(prob(70))
+		if(meat_amount && meat_type)
+			for(var/i = 0; i < meat_amount; i++)
+				new meat_type(get_turf(src))
 		del(src)
-		return
-	gib()
+	else
+		gib()
 	return
 
 


### PR DESCRIPTION
Currently, harvesting animals will only give one meat, disregarding the meat amount. Unless you procced the 5 % chance to gib, which would give the full amount of meat.

With this change, harvesting an animal (with a kitchen knife or a cleaver) will always give the full amount of meat. ~~Harvesting has a 30 % chance of gibbing the animal.~~ Harvesting will always gib the animal.