### PR TITLE
Adds a new machine: The Pool Controller

### DIFF
--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -33,10 +33,7 @@
 	if(!linkedturfs)
 		processing_objects.Remove(src)
 		return
-	for(var/turf/simulated/floor/beach/water/W in linkedturfs)
-		for(var/mob/M in W)
-			if(M)
-				updateMobs()
+	updateMobs()
 
 /obj/machinery/poolcontroller/proc/updateMobs()
 	for(var/turf/simulated/floor/beach/water/W in linkedturfs)
@@ -48,9 +45,11 @@
 						H.bodytemperature = min(500, H.bodytemperature + 35)
 						H.adjustFireLoss(5)
 						H << "<span class='danger'>The water is searing hot!</span>"
+						return
 					else
 						M.bodytemperature = min(500, M.bodytemperature + 35)
 						M << "<span class='danger'>The water is searing hot!</span>"
+						return
 
 				if("cold")
 					if(ishuman(M))
@@ -58,9 +57,11 @@
 						H.bodytemperature = max(80, H.bodytemperature - 80)
 						H.adjustFireLoss(5)
 						H << "<span class='danger'>The water is freezing!</span>"
+						return
 					else
 						M.bodytemperature = max(80, M.bodytemperature - 80)
 						M << "<span class='danger'>The water is freezing!</span>"
+						return
 
 				if("normal")
 					return

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -39,19 +39,19 @@
 		return
 
 	if(emagged) //Emagging unlocks more (deadly) options.
-		var/temp = input("What temperature would you like to set the pool to?", "Pool Temperature") in list("Hot","Cold", "Warm", "Cool", "Normal","Cancel") //Allow user to choose which temperature they want.
+		var/temp = input("What temperature would you like to set the pool to?", "Pool Temperature") in list("Scalding","Frigid", "Warm", "Cool", "Normal","Cancel") //Allow user to choose which temperature they want.
 
 		switch(temp) //Used for setting the actual temperature var based on user input.
-			if("Hot")
-				miston()
-				temperature = "hot"
+			if("Scalding")
+				miston() //Turn on warning mist for the pool
+				temperature = "scalding" //Burn em!
 				usr << "<span class='warning'>You flick the pool temperature to [temperature](WARNING).</span>" //Differ from standard message to make sure the user understands the temperature is harmful.
-				return
-			if("Cold")
-				temperature = "cold"
+				return //Return to avoid calling the un-unique message.
+			if("Frigid")
+				temperature = "frigid"
 				usr << "<span class='warning'>You flick the pool temperature to [temperature](WARNING).</span>" //Differ from standard message to make sure the user understands the temperature is harmful.
 				mistoff() //this won't get called otherwise
-				return
+				return //Return to avoid calling the un-unique message.
 
 			//Regular non-traitorous temperature choices still avalible.
 			if("Warm")
@@ -63,7 +63,7 @@
 			if("Cancel")
 				return
 
-		mistoff()
+		mistoff() //Remove all mist, setting it to scalding returns before now, only regular temperatures will call it
 		usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>" //Inform the mob of the temperature they just picked.
 		return
 
@@ -80,7 +80,7 @@
 			if("Cancel") //Cancel does nothing and leaves the temperature at it's previous state.
 				return
 
-		mistoff()
+		mistoff() //Remove all mist, because it shouldn't be here if the pool is not set to scalding
 		usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>" //Display what the user picked.
 		return
 
@@ -91,21 +91,13 @@
 	for(var/turf/simulated/floor/beach/water/W in linkedturfs) //Check for pool-turfs linked to the controller.
 		for(var/mob/M in W) //Check for mobs in the linked pool-turfs.
 			switch(temperature) //Apply different effects based on what the temperature is set to.
-				if("hot") //Burn the mob.
-					if(ishuman(M))
-						var/mob/living/carbon/human/H = M //If humanoid, directly apply fire damage for quicker effect.
-						H.adjustFireLoss(5)
-
+				if("scalding") //Burn the mob.
 					M.bodytemperature = min(500, M.bodytemperature + 35) //heat mob at 35k(elvin) per cycle
 					M << "<span class='danger'>The water is searing hot!</span>"
 					return
 
-				if("cold") //Freeze the mob.
-					if(ishuman(M))
-						var/mob/living/carbon/human/H = M  //If humanoid, directly apply fire damage for quicker effect.
-						H.adjustFireLoss(5)
-
-					M.bodytemperature = max(80, M.bodytemperature - 80) //Quickly cool mob at -80k per cycle
+				if("frigid") //Freeze the mob.
+					M.bodytemperature = max(80, M.bodytemperature - 35) //cool mob at -35k per cycle
 					M << "<span class='danger'>The water is freezing!</span>"
 					return
 
@@ -118,20 +110,20 @@
 					return
 
 				if("cool") //Gently cool the mob.
-					M.bodytemperature = max(290, M.bodytemperature - 15) //Cools mobs to just below normal, not enough to burn
+					M.bodytemperature = max(290, M.bodytemperature - 10) //Cools mobs to just below normal, not enough to burn
 					M << "<span class='warning'>The water is chilly.</span>" //Inform the mob it's chilly water.
 					return
 
-/obj/machinery/poolcontroller/proc/miston()
+/obj/machinery/poolcontroller/proc/miston() //Spawn /obj/effect/mist (from the shower) on all linked pool tiles
 	for(var/turf/simulated/floor/beach/water/W in linkedturfs)
 		var/M = new /obj/effect/mist(W)
 		if(misted)
 			return
 		linkedmist += M
 
-	misted = 1
+	misted = 1 //var just to keep track of when the mist on proc has been called.
 
-/obj/machinery/poolcontroller/proc/mistoff()
+/obj/machinery/poolcontroller/proc/mistoff() //Delete all /obj/effect/mist from all linked pool tiles.
 	for(var/obj/effect/mist/M in linkedmist)
 		del(M)
-	misted = 0
+	misted = 0 //no mist left, turn off the tracking var

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -6,6 +6,8 @@
 	var/list/linkedturfs = list() //List contains all of the linked pool turfs to this controller, assignment happens on New()
 	var/temperature = "normal" //The temperature of the pool, starts off on normal, which has no effects.
 	var/srange = 5 //The range of the search for pool turfs, change this for bigger or smaller pools.
+	var/linkedmist = list() //Used to keep track of created mist
+	var/misted = 0 //Used to check for mist.
 
 /obj/machinery/poolcontroller/New() //This proc automatically happens on world start
 	for(var/turf/simulated/floor/beach/water/W in range(srange,src)) //Search for /turf/simulated/floor/beach/water in the range of var/srange
@@ -41,12 +43,14 @@
 
 		switch(temp) //Used for setting the actual temperature var based on user input.
 			if("Hot")
+				miston()
 				temperature = "hot"
 				usr << "<span class='warning'>You flick the pool temperature to [temperature](WARNING).</span>" //Differ from standard message to make sure the user understands the temperature is harmful.
 				return
 			if("Cold")
 				temperature = "cold"
 				usr << "<span class='warning'>You flick the pool temperature to [temperature](WARNING).</span>" //Differ from standard message to make sure the user understands the temperature is harmful.
+				mistoff() //this won't get called otherwise
 				return
 
 			//Regular non-traitorous temperature choices still avalible.
@@ -59,6 +63,7 @@
 			if("Cancel")
 				return
 
+		mistoff()
 		usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>" //Inform the mob of the temperature they just picked.
 		return
 
@@ -75,6 +80,7 @@
 			if("Cancel") //Cancel does nothing and leaves the temperature at it's previous state.
 				return
 
+		mistoff()
 		usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>" //Display what the user picked.
 		return
 
@@ -119,3 +125,17 @@
 					M.bodytemperature = max(290, M.bodytemperature - 15) //Cools mobs to just below normal, not enough to burn
 					M << "<span class='warning'>The water is chilly.</span>" //Inform the mob it's chilly water.
 					return
+
+/obj/machinery/poolcontroller/proc/miston()
+	for(var/turf/simulated/floor/beach/water/W in linkedturfs)
+		var/M = new /obj/effect/mist(W)
+		if(misted)
+			return
+		linkedmist += M
+
+	misted = 1
+
+/obj/machinery/poolcontroller/proc/mistoff()
+	for(var/obj/effect/mist/M in linkedmist)
+		del(M)
+	misted = 0

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -1,0 +1,66 @@
+/obj/machinery/poolcontroller
+	name = "Pool Controller"
+	desc = "A controller for the nearby pool."
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "airlock_control_standby"
+	var/list/linkedturfs = list()
+	var/temperature = "normal"
+	var/srange = 5
+
+/obj/machinery/poolcontroller/New()
+	for(var/turf/simulated/floor/beach/water/W in range(srange,src))
+		src.linkedturfs += W
+	processing_objects.Add(src)
+
+/obj/machinery/poolcontroller/attack_hand()
+	if(!Adjacent(usr))
+		usr << "You moved away."
+		return
+	var/temp = input("What temperature would you like to set the pool to?", "Pool Temperature") in list("Hot","Cold","Normal","Cancel")
+	switch(temp)
+		if("Hot")
+			temperature = "hot"
+		if("Cold")
+			temperature = "cold"
+		if("Normal")
+			temperature = "normal"
+		if("Cancel")
+			return
+
+	usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>"
+
+/obj/machinery/poolcontroller/process()
+	if(!linkedturfs)
+		processing_objects.Remove(src)
+		return
+	for(var/turf/simulated/floor/beach/water/W in linkedturfs)
+		for(var/mob/M in W)
+			if(M)
+				updateMobs()
+
+/obj/machinery/poolcontroller/proc/updateMobs()
+	for(var/turf/simulated/floor/beach/water/W in linkedturfs)
+		for(var/mob/M in W)
+			switch(temperature)
+				if("hot")
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						H.bodytemperature = min(500, H.bodytemperature + 35)
+						H.adjustFireLoss(5)
+						H << "<span class='danger'>The water is searing hot!</span>"
+					else
+						M.bodytemperature = min(500, M.bodytemperature + 35)
+						M << "<span class='danger'>The water is searing hot!</span>"
+
+				if("cold")
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						H.bodytemperature = max(80, H.bodytemperature - 80)
+						H.adjustFireLoss(5)
+						H << "<span class='danger'>The water is freezing!</span>"
+					else
+						M.bodytemperature = max(80, M.bodytemperature - 80)
+						M << "<span class='danger'>The water is freezing!</span>"
+
+				if("normal")
+					return

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -12,7 +12,7 @@
 /obj/machinery/poolcontroller/New() //This proc automatically happens on world start
 	for(var/turf/simulated/floor/beach/water/W in range(srange,src)) //Search for /turf/simulated/floor/beach/water in the range of var/srange
 		src.linkedturfs += W //Add found pool turfs to the central list.
-	processing_objects.Add(src) //Add the pool controller to the processing queue to tie mob effects to the air controller.
+	..() //Changed to call parent as per MarkvA's recommendation
 
 /obj/machinery/poolcontroller/emag_act(user as mob) //Emag_act, this is called when it is hit with a cryptographic sequencer.
 	if(!emagged) //If it is not already emagged, emag it.
@@ -85,10 +85,6 @@
 		return
 
 /obj/machinery/poolcontroller/process()
-	if(!linkedturfs) //If no pool tiles are linked, remove the controller from the processing queue, no sense wasting processing power on it.
-		processing_objects.Remove(src)
-		return
-
 	updateMobs() //Call the mob affecting proc
 
 /obj/machinery/poolcontroller/proc/updateMobs()

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -3,65 +3,119 @@
 	desc = "A controller for the nearby pool."
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_control_standby"
-	var/list/linkedturfs = list()
-	var/temperature = "normal"
-	var/srange = 5
+	var/list/linkedturfs = list() //List contains all of the linked pool turfs to this controller, assignment happens on New()
+	var/temperature = "normal" //The temperature of the pool, starts off on normal, which has no effects.
+	var/srange = 5 //The range of the search for pool turfs, change this for bigger or smaller pools.
 
-/obj/machinery/poolcontroller/New()
-	for(var/turf/simulated/floor/beach/water/W in range(srange,src))
-		src.linkedturfs += W
-	processing_objects.Add(src)
+/obj/machinery/poolcontroller/New() //This proc automatically happens on world start
+	for(var/turf/simulated/floor/beach/water/W in range(srange,src)) //Search for /turf/simulated/floor/beach/water in the range of var/srange
+		src.linkedturfs += W //Add found pool turfs to the central list.
+	processing_objects.Add(src) //Add the pool controller to the processing queue to tie mob effects to the air controller.
+
+/obj/machinery/poolcontroller/emag_act(user as mob) //Emag_act, this is called when it is hit with a cryptographic sequencer.
+	if(!emagged) //If it is not already emagged, emag it.
+		user << "\red You disable \the [src]'s temperature safeguards." //Inform the mob of what emagging does.
+		emagged = 1 //Set the emag var to true.
+
+/obj/machinery/poolcontroller/attackby(obj/item/P as obj, mob/user as mob, params) //Proc is called when a user hits the pool controller with something.
+
+	if(istype(P,/obj/item/device/multitool)) //If the mob hits the pool controller with a multitool, reset the emagged status
+		if(emagged) //Check the emag status
+			user << "\red You re-enable \the [src]'s temperature safeguards." //Inform the user that they have just fixed the safeguards.
+			emagged = 0 //Set the emagged var to false.
+			return
+		else
+			user << "\red Nothing happens." //If not emagged, don't do anything, and don't tell the user that it can be emagged.
+
+		return //Return, nothing else needs to be done.
+	else //If it's not a multitool, defer to /obj/machinery/proc/attackby
+		..()
 
 /obj/machinery/poolcontroller/attack_hand()
 	if(!Adjacent(usr))
 		usr << "You moved away."
 		return
-	var/temp = input("What temperature would you like to set the pool to?", "Pool Temperature") in list("Hot","Cold","Normal","Cancel")
-	switch(temp)
-		if("Hot")
-			temperature = "hot"
-		if("Cold")
-			temperature = "cold"
-		if("Normal")
-			temperature = "normal"
-		if("Cancel")
-			return
 
-	usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>"
+	if(emagged) //Emagging unlocks more (deadly) options.
+		var/temp = input("What temperature would you like to set the pool to?", "Pool Temperature") in list("Hot","Cold", "Warm", "Cool", "Normal","Cancel") //Allow user to choose which temperature they want.
+
+		switch(temp) //Used for setting the actual temperature var based on user input.
+			if("Hot")
+				temperature = "hot"
+				usr << "<span class='warning'>You flick the pool temperature to [temperature](WARNING).</span>" //Differ from standard message to make sure the user understands the temperature is harmful.
+				return
+			if("Cold")
+				temperature = "cold"
+				usr << "<span class='warning'>You flick the pool temperature to [temperature](WARNING).</span>" //Differ from standard message to make sure the user understands the temperature is harmful.
+				return
+
+			//Regular non-traitorous temperature choices still avalible.
+			if("Warm")
+				temperature = "warm"
+			if("Cool")
+				temperature = "cool"
+			if("Normal")
+				temperature = "normal"
+			if("Cancel")
+				return
+
+		usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>" //Inform the mob of the temperature they just picked.
+		return
+
+	else
+		var/temp = input("What temperature would you like to set the pool to?", "Pool Temperature") in list("Warm","Cool","Normal","Cancel") //Allow user to choose which temperature they want.
+
+		switch(temp) //Used for setting the actual temperature var based on user input.
+			if("Warm")
+				temperature = "warm"
+			if("Cool")
+				temperature = "cool"
+			if("Normal")
+				temperature = "normal"
+			if("Cancel") //Cancel does nothing and leaves the temperature at it's previous state.
+				return
+
+		usr << "<span class='warning'>You flick the pool temperature to [temperature].</span>" //Display what the user picked.
+		return
 
 /obj/machinery/poolcontroller/process()
-	if(!linkedturfs)
+	if(!linkedturfs) //If no pool tiles are linked, remove the controller from the processing queue, no sense wasting processing power on it.
 		processing_objects.Remove(src)
 		return
-	updateMobs()
+
+	updateMobs() //Call the mob affecting proc
 
 /obj/machinery/poolcontroller/proc/updateMobs()
-	for(var/turf/simulated/floor/beach/water/W in linkedturfs)
-		for(var/mob/M in W)
-			switch(temperature)
-				if("hot")
+	for(var/turf/simulated/floor/beach/water/W in linkedturfs) //Check for pool-turfs linked to the controller.
+		for(var/mob/M in W) //Check for mobs in the linked pool-turfs.
+			switch(temperature) //Apply different effects based on what the temperature is set to.
+				if("hot") //Burn the mob.
 					if(ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.bodytemperature = min(500, H.bodytemperature + 35)
+						var/mob/living/carbon/human/H = M //If humanoid, directly apply fire damage for quicker effect.
 						H.adjustFireLoss(5)
-						H << "<span class='danger'>The water is searing hot!</span>"
-						return
-					else
-						M.bodytemperature = min(500, M.bodytemperature + 35)
-						M << "<span class='danger'>The water is searing hot!</span>"
-						return
 
-				if("cold")
+					M.bodytemperature = min(500, M.bodytemperature + 35) //heat mob at 35k(elvin) per cycle
+					M << "<span class='danger'>The water is searing hot!</span>"
+					return
+
+				if("cold") //Freeze the mob.
 					if(ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.bodytemperature = max(80, H.bodytemperature - 80)
+						var/mob/living/carbon/human/H = M  //If humanoid, directly apply fire damage for quicker effect.
 						H.adjustFireLoss(5)
-						H << "<span class='danger'>The water is freezing!</span>"
-						return
-					else
-						M.bodytemperature = max(80, M.bodytemperature - 80)
-						M << "<span class='danger'>The water is freezing!</span>"
-						return
 
-				if("normal")
+					M.bodytemperature = max(80, M.bodytemperature - 80) //Quickly cool mob at -80k per cycle
+					M << "<span class='danger'>The water is freezing!</span>"
+					return
+
+				if("normal") //Normal temp does nothing, because it's just room temperature water.
+					return
+
+				if("warm") //Gently warm the mob.
+					M.bodytemperature = min(330, M.bodytemperature + 10) //Heats up mobs to just over normal, not enough to burn
+					M << "<span class='warning'>The water is quite warm.</span>" //Inform the mob it's warm water.
+					return
+
+				if("cool") //Gently cool the mob.
+					M.bodytemperature = max(290, M.bodytemperature - 15) //Cools mobs to just below normal, not enough to burn
+					M << "<span class='warning'>The water is chilly.</span>" //Inform the mob it's chilly water.
 					return

--- a/paradise.dme
+++ b/paradise.dme
@@ -449,6 +449,7 @@
 #include "code\game\machinery\OpTable.dm"
 #include "code\game\machinery\overview.dm"
 #include "code\game\machinery\PDApainter.dm"
+#include "code\game\machinery\poolcontroller.dm"
 #include "code\game\machinery\portable_tag_turret.dm"
 #include "code\game\machinery\portable_turret.dm"
 #include "code\game\machinery\programmable_unloader.dm"


### PR DESCRIPTION
In essence, this makes a new machine using the sprite of an airlock controller, which controls the temperature of the nearest /turf/simulated/floor/beach/water. By default, this only lets people set the pool to cool down to 290k, or heat up to 330k. However, if emagged, there are two new modes: Hot and Freezing. The modes use the same code as the shower when wrenched, heating people to 500k or cooling people to 80k. This PR does not add it to the map, in order to avoid any merge conflicts.