### PR TITLE
New traitor item- Hackimplant

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -169,6 +169,9 @@
 /mob/proc/RangedAttack(var/atom/A, var/params)
 	if(ishuman(src) && (istype(src:gloves, /obj/item/clothing/gloves/color/yellow/power)) && a_intent == "harm")
 		PowerGlove(A)
+	if(ishacker(src))
+		if(istype(A, /obj/machinery/door/airlock))
+			A.attack_hand(src)
 	if(!mutations.len) return
 	if((LASER in mutations) && a_intent == "harm")
 		LaserEyes(A) // moved into a proc below

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -630,6 +630,12 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
 	cost = 8
 
+/datum/uplink_item/implants/hack
+	name = "Hack Implant"
+	desc = "An impant injected into the body, which allows the user to interface with NT door systems."
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_hack
+	cost = 20
+
 // POINTLESS BADASSERY
 
 /datum/uplink_item/badass

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -50,6 +50,7 @@
 	var/hasShocked = 0 //Prevents multiple shocks from happening
 	var/frozen = 0 //special condition for airlocks that are frozen shut, this will look weird on not normal airlocks because of a lack of special overlays.
 	autoclose = 1
+	var/hackerimplant = 0 //rawr must override topic
 
 /obj/machinery/door/airlock/command
 	name = "Airlock"
@@ -208,7 +209,7 @@
 	icon = 'icons/obj/doors/Dooruranium.dmi'
 	mineral = "uranium"
 	var/last_event = 0
-	
+
 /obj/machinery/door/airlock/process()
 	// Deliberate no call to parent.
 	if(main_power_lost_until > 0 && world.time >= main_power_lost_until)
@@ -319,7 +320,7 @@
 	else
 		user << "You do not know how to operate this airlock's mechanism."
 		return
-		
+
 
 
 /*
@@ -388,7 +389,7 @@ About the new airlock wires panel:
 	if(mainPowerCablesCut() && backupPowerCablesCut())
 		return 1
 	return 0
-	
+
 /obj/machinery/door/airlock/proc/mainPowerCablesCut()
 	return src.isWireCut(AIRLOCK_WIRE_MAIN_POWER1) || src.isWireCut(AIRLOCK_WIRE_MAIN_POWER2)
 
@@ -426,7 +427,7 @@ About the new airlock wires panel:
 		// Restore backup power only if main power is offline, otherwise permanently disable
 		backup_power_lost_until = main_power_lost_until == 0 ? -1 : 0
 		update_icon()
-		
+
 /obj/machinery/door/airlock/proc/electrify(var/duration, var/feedback = 0)
 	var/message = ""
 	if(src.isWireCut(AIRLOCK_WIRE_ELECTRIFY) && arePowerSystemsOn())
@@ -475,7 +476,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/update_icon()
 	if(overlays) overlays.Cut()
 	overlays = list()
-	if(emergency && arePowerSystemsOn()) 
+	if(emergency && arePowerSystemsOn())
 		overlays += image('icons/obj/doors/doorint.dmi', "elights")
 	if(density)
 		if(locked && lights)
@@ -494,7 +495,7 @@ About the new airlock wires panel:
 		icon_state = "door_open"
 
 	return
-	
+
 
 /obj/machinery/door/airlock/do_animate(animation)
 	switch(animation)
@@ -614,6 +615,10 @@ About the new airlock wires panel:
 	return src.attack_hand(user)
 
 /obj/machinery/door/airlock/attack_hand(mob/user as mob)
+	if(ishacker(user))
+		attack_ai(user)
+		return
+
 	if(!istype(user, /mob/living/silicon))
 		if(src.isElectrified())
 			if(src.shock(user, 100))
@@ -641,7 +646,7 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/CanUseTopic(var/mob/user, href_list)
-	if(!issilicon(user))
+	if(!issilicon(user) && !ishacker(user))
 		return STATUS_CLOSE
 
 	if(operating < 0) //emagged
@@ -918,7 +923,7 @@ About the new airlock wires panel:
 		var/obj/structure/window/killthis = (locate(/obj/structure/window) in turf)
 		if(killthis)
 			killthis.ex_act(2)//Smashin windows
-		
+
 	if(density)
 		return 1
 	operating = 1
@@ -1049,7 +1054,7 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/CanAStarPass(var/obj/item/weapon/card/id/ID)
 //Airlock is passable if it is open (!density), bot has access, and is not bolted shut)
 	return !density || (check_access(ID) && !locked)
-	
+
 /obj/machinery/door/airlock/emp_act(var/severity)
 	if(prob(40/severity))
 		var/duration = world.time + SecondsToTicks(30 / severity)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -761,7 +761,7 @@ About the new airlock wires panel:
 		if(isdhacker(usr) || ishacker(usr))
 			for(var/obj/item/weapon/implant/hack/H in usr)
 				H.powerlevel = 0
-				usr << "\red <b>Your hack-implant discharges it's energy to hack the door!</b> You will need to wait a minute for it to recharge."
+				usr << "\red <b>Your hack-implant discharges its energy to hack the door!</b> You will need to wait a minute for it to recharge."
 
 	update_icon()
 	return 1

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -50,7 +50,6 @@
 	var/hasShocked = 0 //Prevents multiple shocks from happening
 	var/frozen = 0 //special condition for airlocks that are frozen shut, this will look weird on not normal airlocks because of a lack of special overlays.
 	autoclose = 1
-	var/hackerimplant = 0 //rawr must override topic
 
 /obj/machinery/door/airlock/command
 	name = "Airlock"
@@ -757,6 +756,12 @@ About the new airlock wires panel:
 			else
 				emergency = 1
 				usr << "Emergency access has been enabled."
+
+	if(ishuman(usr))
+		if(isdhacker(usr) || ishacker(usr))
+			for(var/obj/item/weapon/implant/hack/H in usr)
+				H.powerlevel = 0
+				usr << "\red <b>Your hack-implant discharges it's energy to hack the door!</b> You will need to wait a minute for it to recharge."
 
 	update_icon()
 	return 1

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -80,6 +80,9 @@
 			else if(XRAY in M.mutations)	//mob has X-RAY vision
 				flick("flash", M.flash) //Yes, you can still get flashed wit X-Ray.
 				user << "<span class='notice'>[M] pupils give an eerie glow!</span>"
+			else if(ishacker(M) || isdhacker(M))
+				flick("flash", M.flash)
+				user << "<span class='notice'>[M]'s eyes refract the light with a metallic sheen.</span>" //Thank you, False. I am bad at writing.
 			else	//they're okay!
 				if(!M.blinded)
 					flick("flash", M.flash)	//flash the affected mob

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -597,6 +597,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 /obj/item/weapon/implant/hack
 	name = "hacking implant"
 	desc = "An implant used by hackers to interface with airlock controls"
+	var/powerlevel = 10 //This should be the same as MAXPOWER.
+	var/MAXPOWER = 10 //Max charge level, adjust to change charging time- measured in processing ticks, 10 is 5~ seconds.
 	get_data()
 		var/dat = {"
 <b>Implant Specifications:</b><BR>
@@ -614,3 +616,10 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		var/mob/living/carbon/human/H = M
 		H << "\blue You feel like you could interface with the nearest door."
 		return 1
+
+	New()
+		processing_objects.Add(src)
+
+	process()
+		if(powerlevel < src.MAXPOWER)
+			powerlevel++

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -614,7 +614,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	implanted(mob/M)
 		if(!istype(M, /mob/living/carbon/human))	return 0
 		var/mob/living/carbon/human/H = M
-		H << "\blue A digital HUD displays on your retina, allowing you to interface to the wireless controls of the nearby airlocks."
+		H << "\blue A digital HUD displays on your retina, allowing you to interface with the wireless controls of the nearby airlocks."
 		return 1
 
 	New()

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -593,3 +593,24 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		source.mind.store_memory("EMP implant can be activated [uses] time\s by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
 		source << "The implanted EMP implant can be activated [uses] time\s by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate."
 		return 1
+
+/obj/item/weapon/implant/hack
+	name = "hacking implant"
+	desc = "An implant used by hackers to interface with airlock controls"
+	get_data()
+		var/dat = {"
+<b>Implant Specifications:</b><BR>
+<b>Name:</b> Hacking Implant<BR>
+<b>Life:</b> ???<BR>
+<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
+<HR>
+<b>Implant Details:</b> Subjects injected with implant can interface with NanoTrasen door OS, like NT cyborgs.<BR>
+<b>Function:</b> Enables user to interface with NanoTrasen doors like a cyborg.<BR>
+<b>Integrity:</b> ???"}
+		return dat
+
+	implanted(mob/M)
+		if(!istype(M, /mob/living/carbon/human))	return 0
+		var/mob/living/carbon/human/H = M
+		H << "\blue You feel like you could interface with the nearest door."
+		return 1

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -614,7 +614,7 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	implanted(mob/M)
 		if(!istype(M, /mob/living/carbon/human))	return 0
 		var/mob/living/carbon/human/H = M
-		H << "\blue You feel like you could interface with the nearest door."
+		H << "\blue A digital HUD displays on your retina, allowing you to interface to the wireless controls of the nearby airlocks."
 		return 1
 
 	New()

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -149,3 +149,14 @@
 		src.imp = new /obj/item/weapon/implant/freedom( src )
 		..()
 		return
+
+/obj/item/weapon/implantcase/hack
+	name = "Glass Case- 'HackImplant'"
+	desc = "A case containing a hacking implant."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "implantcase-b"
+
+	New()
+		src.imp = new /obj/item/weapon/implant/hack( src )
+		..()
+		return

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -186,3 +186,13 @@
 		new /obj/item/weapon/grenade/empgrenade(src)
 		new /obj/item/weapon/implanter/emp/(src)
 		new /obj/item/device/flashlight/emp/(src)
+
+/obj/item/weapon/storage/box/syndie_kit/imp_hack
+	name = "Hack Implant (with injector)"
+
+/obj/item/weapon/storage/box/syndie_kit/imp_hack/New()
+	..()
+	var/obj/item/weapon/implanter/O = new(src)
+	O.imp = new /obj/item/weapon/implant/hack(O)
+	O.update()
+	return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -156,9 +156,15 @@ proc/isorgan(A)
 			return 1
 	return 0
 
-/proc/ishacker(A)
+/proc/isdhacker(A) //useful for determining if they have a discharged hacking implant
 	for(var/obj/item/weapon/implant/hack/H in A)
-		if(H && H.implanted)
+		if(H && H.implanted && H.powerlevel < H.MAXPOWER)//uses variable to determine charge time, for easy adjusting later.
+			return 1
+	return 0
+
+/proc/ishacker(A) //checks if they have a hacking implant and if it is charged
+	for(var/obj/item/weapon/implant/hack/H in A)
+		if(H && H.implanted && H.powerlevel == H.MAXPOWER)
 			return 1
 	return 0
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -156,6 +156,12 @@ proc/isorgan(A)
 			return 1
 	return 0
 
+/proc/ishacker(A)
+	for(var/obj/item/weapon/implant/hack/H in A)
+		if(H && H.implanted)
+			return 1
+	return 0
+
 proc/isnewplayer(A)
 	if(istype(A, /mob/new_player))
 		return 1


### PR DESCRIPTION
This PR adds a new traitor implant labelled simply "Hackimplant".
* Allows user to control doors like the cyborg/AI, at limit of a cooldown between button presses
* Allows user to remotely access doors within view range
* Costs 20TC currently, can be changed.
* 10 tick cooldown, modifiable with one variable change
* Shining a penlight in an implanted person's eyes gives a special message.