### PR TITLE
[Fix] Kitchen Overhaul Fixes

### DIFF
--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -79,7 +79,7 @@
 			return
 		if(exchange_parts(user, O))
 			return
-	if(istype(O, /obj/item/weapon/wrench))
+	if(!broken && istype(O, /obj/item/weapon/wrench))
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		if(anchored)
 			anchored = 0

--- a/code/modules/food/candy_maker.dm
+++ b/code/modules/food/candy_maker.dm
@@ -79,7 +79,7 @@
 			return
 		if(exchange_parts(user, O))
 			return
-	if(istype(O, /obj/item/weapon/wrench))
+	if(!broken && istype(O, /obj/item/weapon/wrench))
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		if(anchored)
 			anchored = 0

--- a/code/modules/food/grill_new.dm
+++ b/code/modules/food/grill_new.dm
@@ -82,7 +82,7 @@
 			return
 		if(exchange_parts(user, O))
 			return
-	if(istype(O, /obj/item/weapon/wrench))
+	if(!broken && istype(O, /obj/item/weapon/wrench))
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		if(anchored)
 			anchored = 0

--- a/code/modules/food/oven_new.dm
+++ b/code/modules/food/oven_new.dm
@@ -82,7 +82,7 @@
 			return
 		if(exchange_parts(user, O))
 			return
-	if(istype(O, /obj/item/weapon/wrench))
+	if(!broken && istype(O, /obj/item/weapon/wrench))
 		playsound(src, 'sound/items/Ratchet.ogg', 50, 1)
 		if(anchored)
 			anchored = 0

--- a/code/modules/reagents/reagent_containers/food/snacks/candy.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/candy.dm
@@ -600,7 +600,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/red
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_red"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#801E28"
 
@@ -612,7 +612,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/blue
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_blue"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
 
@@ -624,7 +624,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/poison
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_blue"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863353"
 
@@ -638,7 +638,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/green
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_green"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#365E30"
 
@@ -650,7 +650,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/yellow
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_yellow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
 
@@ -662,7 +662,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/orange
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_orange"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#E78108"
 
@@ -674,7 +674,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/purple
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_purple"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#993399"
 
@@ -686,7 +686,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/pink
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_pink"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
 
@@ -698,7 +698,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/rainbow
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_rainbow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#C8A5DC"
 
@@ -712,7 +712,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/bad_rainbow
 	name = "cotton candy"
 	desc = "Light and fluffy, it's like eating a cloud made from sugar!"
-	icon_state = "cottoncandy_plain"
+	icon_state = "cottoncandy_rainbow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#32127A"
 


### PR DESCRIPTION
Fixes all cotton candy flavors/colors utilizing the plain version's
sprite. This means blue cotton candy is actually blue.

Fixes fixing kitchen machines (candy maker, grill, oven, microwave) with
a wrench attempting to unfasten/refasten them to the ground.  You can
only unfasten these machines if they are not broken now.