### PR TITLE
Implant Cleanup

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -597,37 +597,37 @@ var/list/uplink_items = list()
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated using a bodily gesture to attempt to slip restraints."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
+	item = /obj/item/weapon/implanter/freedom
 	cost = 5
 
 /datum/uplink_item/implants/uplink
 	name = "Uplink Implant"
 	desc = "An implant injected into the body, and later activated using a bodily gesture to open an uplink with 5 telecrystals. The ability for an agent to open an uplink after their posessions have been stripped from them makes this implant excellent for escaping confinement."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
+	item = /obj/item/weapon/implanter/uplink
 	cost = 20
 
 /datum/uplink_item/implants/explosive
 	name = "Explosive Implant"
 	desc = "An implant injected into the body, and later activated using a vocal command to cause a large explosion from the implant."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_explosive
+	item = /obj/item/weapon/implanter/explosive
 	cost = 12
 
 /datum/uplink_item/implants/compression
 	name = "Compressed Matter Implant"
 	desc = "An implant injected into the body, and later activated using a bodily gesture to retrieve an item that was earlier compressed."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_compress
+	item = /obj/item/weapon/implanter/compressed
 	cost = 8
 
 /datum/uplink_item/implants/mindslave
 	name = "Mindslave Implant"
 	desc = "A box containing an implanter filled with a mindslave implant that when injected into another person makes them loyal to you and your cause, unless of course they're already implanted by someone else. Loyalty ends if the implant is no longer in their system."
-	item = /obj/item/weapon/storage/box/syndie_kit/mindslave
+	item = /obj/item/weapon/implanter/traitor
 	cost = 10
 
 /datum/uplink_item/implants/adrenal
 	name = "Adrenal Implant"
 	desc = "An implant injected into the body, and later activated using a bodily gesture to inject a chemical cocktail, which has a mild healing effect along with removing all stuns and increasing his speed."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_adrenal
+	item = /obj/item/weapon/implanter/adrenalin
 	cost = 8
 
 // POINTLESS BADASSERY

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -54,7 +54,7 @@
 
 
 /obj/item/weapon/implanter/traitor
-	name = "implanter-mindslave"
+	name = "implanter (Mindslave)"
 	desc = "Divide and Conquer."
 
 	New()
@@ -64,7 +64,7 @@
 		return
 
 /obj/item/weapon/implanter/loyalty
-	name = "implanter-loyalty"
+	name = "implanter (Loyalty)"
 
 /obj/item/weapon/implanter/loyalty/New()
 	src.imp = new /obj/item/weapon/implant/loyalty( src )
@@ -73,7 +73,7 @@
 	return
 
 /obj/item/weapon/implanter/dexplosive
-	name = "implanter (DE)"
+	name = "implanter (Microbomb)"
 
 /obj/item/weapon/implanter/dexplosive/New()
 	src.imp = new /obj/item/weapon/implant/dexplosive( src )
@@ -82,7 +82,7 @@
 	return
 
 /obj/item/weapon/implanter/explosive
-	name = "implanter (E)"
+	name = "implanter (Explosive)"
 
 /obj/item/weapon/implanter/explosive/New()
 	src.imp = new /obj/item/weapon/implant/explosive( src )
@@ -91,7 +91,7 @@
 	return
 
 /obj/item/weapon/implanter/adrenalin
-	name = "implanter-adrenalin"
+	name = "implanter (Adrenaline)"
 
 /obj/item/weapon/implanter/adrenalin/New()
 	src.imp = new /obj/item/weapon/implant/adrenalin(src)
@@ -100,7 +100,7 @@
 	return
 
 /obj/item/weapon/implanter/compressed
-	name = "implanter (C)"
+	name = "implanter (Compressed)"
 	icon_state = "cimplanter1"
 
 	var/list/forbidden_types=list(
@@ -152,7 +152,7 @@
 		update()
 
 /obj/item/weapon/implanter/deadman
-	name = "implanter-deadman"
+	name = "implanter (Deadman)"
 	desc = "Switch it."
 
 	New()
@@ -162,7 +162,7 @@
 		return
 
 /obj/item/weapon/implanter/death_alarm
-	name = "implanter-death alarm"
+	name = "implanter (Death Alarm)"
 	desc = "Announces the death of the implanted person over radio"
 
 	New()
@@ -172,10 +172,28 @@
 		return
 
 /obj/item/weapon/implanter/emp
-	name = "implanter-EMP"
+	name = "implanter (EMP)"
 
 	New()
 		src.imp = new /obj/item/weapon/implant/emp(src)
+		..()
+		update()
+		return
+
+/obj/item/weapon/implanter/freedom
+	name = "implanter (Freedom)"
+
+	New()
+		src.imp = new /obj/item/weapon/implant/freedom(src)
+		..()
+		update()
+		return
+
+/obj/item/weapon/implanter/uplink
+	name = "implanter (Uplink)"
+
+	New()
+		src.imp = new /obj/item/weapon/implant/uplink(src)
 		..()
 		update()
 		return


### PR DESCRIPTION
Cleans up implants on the uplink and standardizes names

- Implants purchased from the uplink will just be a straight implanter instead of an implanter in a box.
 - Helps save spess trees and increase spessmen stealth purchases.
- Standardizes implant naming convention to "implanter (Type)"
 - technically renames "dexplosive" to "microbomb"