### PR TITLE
Mindslave, Loyalty, and Knockdown fixes.

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -335,11 +335,11 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		if(!istype(M, /mob/living/carbon/human))	return 0
 		var/mob/living/carbon/human/H = M
 		if(H.mind in ticker.mode.head_revolutionaries)
-			H.visible_message("[H] seems to resist the implant!", "You feel the corporate tendrils of Nanotrasen try to invade your mind!")
+			H.visible_message("<span class='warning'>[H] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 			return 0
 		else if(H.mind in ticker.mode:revolutionaries)
 			ticker.mode:remove_revolutionary(H.mind)
-		H << "\blue You feel a surge of loyalty towards Nanotrasen."
+		H << "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>"
 		return 1
 
 /obj/item/weapon/implant/traitor
@@ -367,18 +367,18 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		if(!M.mind) return 0
 		var/mob/living/carbon/human/H = M
 		if(M == user)
-			user << "<span class='notice'>Making yourself loyal to yourself was a great idea! Perhaps the best idea, ever! Actually, you just feel like an idiot.</span>"
+			user << "<span class='notice'>Making yourself loyal to yourself was a great idea! Perhaps even the best idea ever! Actually, you just feel like an idiot.</span>"
 			if(isliving(user))
 				user:brainloss += 20
 			return
-		if(locate(/obj/item/weapon/implant/traitor) in H.contents || locate(/obj/item/weapon/implant/loyalty) in H.contents)
-			H.visible_message("[H] seems to resist the implant!", "You feel a strange sensation in your head that quickly dissipates.")
+		if(locate(/obj/item/weapon/implant/loyalty) in H.contents)
+			H.visible_message("<span class='warning'>[H] seems to resist the implant!</span>", "<span class='warning'>You feel a strange sensation in your head that quickly dissipates.</span>")
 			return 0
-		else if(H.mind in ticker.mode.traitors)
-			H.visible_message("[H] seems to resist the implant!", "You feel a familiar sensation in your head that quickly dissipates.")
+		if(locate(/obj/item/weapon/implant/traitor) in H.contents)
+			H.visible_message("<span class='warning'>[H] seems to resist the implant!</span>", "<span class='warning'>You feel a strange sensation in your head that quickly dissipates.</span>")
 			return 0
 		H.implanting = 1
-		H << "\blue You feel a surge of loyalty towards [user.name]."
+		H << "<span class='notice'>You feel completely loyal to [user.name].</span>"
 		if(!(user.mind in ticker.mode:implanter))
 			ticker.mode:implanter[ref] = list()
 		implanters = ticker.mode:implanter[ref]
@@ -389,11 +389,11 @@ the implant may become unstable and either pre-maturely inject the subject or si
 		ticker.mode:implanter[ref] = implanters
 		ticker.mode.traitors += H.mind
 		H.mind.special_role = "traitor"
-		H << "<B>\red You're now completely loyal to [user.name]!</B> You now must lay down your life to protect them and assist in their goals at any cost."
+		H << "<span class='warning'><B>You're now completely loyal to [user.name]!</B> You now must lay down your life to protect them and assist in their goals at any cost.</span>"
 		var/datum/objective/protect/p = new
 		p.owner = H.mind
 		p.target = user:mind
-		p.explanation_text = "Protect [user:real_name], the [user:mind:assigned_role=="MODE" ? (user:mind:special_role) : (user:mind:assigned_role)]."
+		p.explanation_text = "Obey every order from and protect [user:real_name], the [user:mind:assigned_role=="MODE" ? (user:mind:special_role) : (user:mind:assigned_role)]."
 		H.mind.objectives += p
 		for(var/datum/objective/objective in H.mind.objectives)
 			H << "<B>Objective #1</B>: [objective.explanation_text]"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -287,11 +287,11 @@ emp_act
 
 		switch(hit_area)
 			if("head")//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(I.force))
-					apply_effect(5, WEAKEN, armor)
-					confused += 15
+				if(stat == CONSCIOUS && prob(I.force) && armor < 50)
 					visible_message("<span class='danger'>[src] has been knocked down!</span>", \
 									"<span class='userdanger'>[src] has been knocked down!</span>")
+					apply_effect(5, WEAKEN, armor)
+					confused += 15
 					if(src != user && I.damtype == BRUTE)
 						ticker.mode.remove_revolutionary(mind)
 
@@ -307,9 +307,10 @@ emp_act
 						update_inv_glasses(0)
 
 			if("chest")//Easier to score a stun but lasts less time
-				if(prob((I.force + 10)))
+				if(stat == CONSCIOUS && I.force && prob(I.force + 10))
+					visible_message("<span class='danger'>[src] has been knocked down!</span>", \
+									"<span class='userdanger'>[src] has been knocked down!</span>")
 					apply_effect(5, WEAKEN, armor)
-					visible_message("\red <B>[src] has been knocked down!</B>")
 
 				if(bloody)
 					bloody_body(src)


### PR DESCRIPTION

Fixes/Clarity
- Loyalty and minslave implants now use spanclasses
 - This should make "so and so resists the implant!" a lot clearer to see; should also make it much clearer to the implantee what happened.
- Cleans up the grammar and word usage of mindslave implants to clarify their impact.
- Fixes a bug where you could mindslave loyalty implanted personnel.
- Fixes a bug where you could knock down people who were already unconscious

Changes
- Can mindslave other traitors now for consistency (and hilarity)
- Adds armor check to knocking someone down from hitting them in the head; having a helmet will prevent them from getting knocked down