### PR TITLE
Proper Bible Farting

### DIFF
--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -11,10 +11,8 @@
 	autoignition_temperature = 522 // Kelvin
 
 	suicide_act(mob/user)
-		user.emote("fart")
-		viewers(user) << "\red <b>[user] farts on the [src.name]!</b>"
-		viewers(user) << "\blue <b>A mysterious force smites [user]!</b>"
-		return (user.gib(1))
+		viewers(user) << "<span class='warning'><b>[user] stares into [src.name] and attempts to trascend understanding of the universe!</b></span>"
+		return (user.dust())
 
 
 /obj/item/weapon/storage/bible/booze

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -19,9 +19,6 @@
 	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
 	if(confirm == "Yes")
-		if(!canmove || restrained())	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
-			src << "You can't commit suicide whilst restrained! ((You can type Ghost instead however.))"
-			return
 		suiciding = 1
 		var/obj/item/held_item = get_active_hand()
 		if(held_item)
@@ -61,9 +58,9 @@
 				//If something went wrong, just do normal oxyloss
 				if(!(damagetype | BRUTELOSS) && !(damagetype | FIRELOSS) && !(damagetype | TOXLOSS) && !(damagetype | OXYLOSS))
 					adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-				
-				var/datum/organ/external/affected = get_organ("head")				
-				affected.add_autopsy_data("Suicide by [held_item]", 175) 
+
+				var/datum/organ/external/affected = get_organ("head")
+				affected.add_autopsy_data("Suicide by [held_item]", 175)
 
 				updatehealth()
 				return
@@ -74,10 +71,10 @@
 							"\red <b>[src] is twisting \his own neck! It looks like \he's trying to commit suicide.</b>", \
 							"\red <b>[src] is holding \his breath! It looks like \he's trying to commit suicide.</b>")
 		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-		
-		var/datum/organ/external/affected = get_organ("head")				
-		affected.add_autopsy_data("Suicide", 175) 
-		
+
+		var/datum/organ/external/affected = get_organ("head")
+		affected.add_autopsy_data("Suicide", 175)
+
 		updatehealth()
 
 /mob/living/carbon/brain/verb/suicide()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -709,7 +709,14 @@
 		// Needed for M_TOXIC_FART
 		if("fart")
 //			playsound(src.loc, 'sound/effects/fart.ogg', 50, 1, -3) //Admins still vote no to fun
-			if(TOXIC_FARTS in mutations)
+			if(locate(/obj/item/weapon/storage/bible) in get_turf(src))
+				viewers(src) << "<span class='warning'><b>[src] farts on the Bible!</b></span>"
+				viewers(src) << "<span class='notice'><b>A mysterious force smites [src]!</b></span>"
+				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+				s.set_up(3, 1, src)
+				s.start()
+				src.gib()
+			else if(TOXIC_FARTS in mutations)
 				message = "<b>[src]</b> unleashes a [pick("horrible","terrible","foul","disgusting","awful")] fart."
 			else
 				message = "<b>[src]</b> [pick("passes wind","farts")]."


### PR DESCRIPTION
- Adds in *proper* Bible farting
 - That is to say, farting on the Bible is an actual thing now, and not just a suicide type
- Bible now has a new suicide act that turns you into dust

Other
- Suiciding can be done at any time, even when restrained/stunned/etc.
 - People who want to die are just going to ghost anyway, and suiciding prevents cloning (without a TON of investment on R&D's part) anyway.