### PR TITLE
Pathing Fixes

### DIFF
--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -10,7 +10,7 @@
 	throwforce = 20
 	var/cooldown = 0 // Because spam aint cool, yo.
 
-/obj/item/weapon/katana/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/katana/energy/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	playsound(user, 'sound/weapons/blade1.ogg', 50, 1, -1)
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -73,7 +73,7 @@
 	desc = "A modified air-needle autoinjector filled with expensive regeneration nanites."
 	volume = 100
 
-/obj/item/weapon/reagent_containers/hypospray/combat/New()
+/obj/item/weapon/reagent_containers/hypospray/combat/nanites/New()
 	..()
 	reagents.add_reagent("nanites", 70)
 


### PR DESCRIPTION
Fixes a pathing issue with katanas and hyposprays.

A bit of a critical patch, as nukeop hyposprays currently contain admorinazine. Whoops.