### PR TITLE
Removes plasma mineral doors burning

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -187,6 +187,7 @@
 /obj/structure/mineral_door/transparent/plasma
 	mineralType = "plasma"
 
+/*
 	attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 		if(istype(W,/obj/item/weapon/weldingtool))
 			var/obj/item/weapon/weldingtool/WT = W
@@ -213,6 +214,7 @@
 
 			hardness -= toxinsToDeduce/100
 			CheckHardness()
+*/
 
 /obj/structure/mineral_door/transparent/diamond
 	mineralType = "diamond"


### PR DESCRIPTION
Using a welder on one creates large amounts of plasma gas, with more gas being created the higher the temperature. One use of a welding tool on a large amount of grouped plasma doors (easy to pull off given how much plasma is available on the asteroid) will create a large uncontrollable fire, and is frankly far too easy to abuse.

Behold, the aftermath of about 30 plasma doors being lit when a borg tried to deconstruct one with a welder.
![Disco Inferno](http://i.gyazo.com/a3db3d9164c9a6d0ed7c03d7582448b1.jpg)