### PR TITLE
New Feature: Temporary Fires, Napalm Rework, and Dragon's Breath Round Fix

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -102,6 +102,11 @@ turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, soh)
 		//black fire, go atmos!
 		l_color = "#010000"
 
+/obj/fire/Crossed(mob/living/L)
+	..()
+	if(isliving(L))
+		L.fire_act()
+
 /obj/fire/process()
 	. = 1
 

--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -218,6 +218,10 @@ turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, soh)
 	firelevel = fl
 	air_master.active_hotspots.Add(src)
 
+	for(var/mob/living/L in loc)
+		L.fire_act()
+
+
 
 /obj/fire/Del()
 	if (istype(loc, /turf/simulated))

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -404,14 +404,14 @@
 
 	New()
 		..()
-		var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
-		var/obj/item/weapon/reagent_containers/glass/beaker/B2 = new(src)
+		var/obj/item/weapon/reagent_containers/glass/beaker/large/B1 = new(src)
+		var/obj/item/weapon/reagent_containers/glass/beaker/large/B2 = new(src)
 
-		B1.reagents.add_reagent("aluminum", 15)
-		B1.reagents.add_reagent("fuel",20)
-		B2.reagents.add_reagent("plasma", 15)
-		B2.reagents.add_reagent("sacid", 15)
-		B1.reagents.add_reagent("incendiaryfuel",20)
+		B1.reagents.add_reagent("aluminum", 25)
+		B1.reagents.add_reagent("incendiaryfuel",25)
+		B2.reagents.add_reagent("plasma", 25)
+		B2.reagents.add_reagent("sacid", 25)
+
 
 		beakers += B1
 		beakers += B2

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -101,6 +101,7 @@
 /obj/item/projectile/bullet/incendiary/shell/Move()
 	..()
 	var/turf/location = get_turf(src)
+	new/obj/fire(location)
 	location.hotspot_expose(700, 50, 1)
 
 /obj/item/projectile/bullet/incendiary/shell/dragonsbreath

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -382,19 +382,9 @@ datum
 			required_reagents = list("aluminum" = 1, "plasma" = 1, "sacid" = 1 )
 			result_amount = 1
 			on_reaction(var/datum/reagents/holder, var/created_volume)
-				var/turf/location = get_turf(holder.my_atom.loc)
-				for(var/turf/simulated/floor/target_tile in range(0,location))
-
-					var/datum/gas_mixture/napalm = new
-					var/datum/gas/volatile_fuel/fuel = new
-					fuel.moles = created_volume
-					napalm.trace_gases += fuel
-
-					napalm.temperature = 400+T0C
-					napalm.update_values()
-
-					target_tile.assume_air(napalm)
-					spawn (0) target_tile.hotspot_expose(700, 400)
+				var/turf/simulated/T = get_turf(holder.my_atom)
+				for(var/turf/simulated/turf in range(created_volume/10,T))
+					new /obj/fire(turf)
 				holder.del_reagent("napalm")
 				return
 


### PR DESCRIPTION
Adds support for temporary fires; touching a "obj/fire" will cause living things to be set ablaze; this means we could technically have chemistry reactions that create a bunch of "fires" without them heating up the room now.

- technically "fixes" dragon's breath and incendiary rounds not having a fire trail (this also makes them not totally worthless as ammunition).
- Reworks the napalm reaction; instead of spawning plasma and igniting it, it now creates fires within a certain range of the reaction point; the bigger the created volume the bigger the fireball.
 - Tweaks the incendiary grenade a bit to better balance it out around this new function.