### PR TITLE
Bugfixes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -49,7 +49,7 @@
 	var/list/votable_modes = list()		// votable modes
 	var/list/probabilities = list()		// relative probability of each mode
 	var/humans_need_surnames = 0
-	var/allow_random_events = 1			// enables random events mid-round when set to 1
+	var/allow_random_events = 0			// enables random events mid-round when set to 1
 	var/allow_ai = 1					// allow ai job
 	var/hostedby = null
 	var/respawn = 0

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -70,8 +70,11 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-	cover = new /obj/machinery/porta_turret_cover(loc)
-	cover.Parent_Turret = src
+	if(anchored)
+		create_cover()
+	else
+		invisibility = 0
+		update_icon()
 	setup()
 
 /obj/machinery/porta_turret/proc/setup()

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -433,7 +433,7 @@
 	build_type = AUTOLATHE
 	materials = list("$metal" = 500)
 	build_path = /obj/item/weapon/flamethrower/full
-	category = list("hacked", "Weapons and ammo")
+	category = list("hacked", "Security")
 	
 /datum/design/handcuffs
 	name = "Handcuffs"


### PR DESCRIPTION
1) Disables random events by default, requires config.txt to enable
random events (https://github.com/ParadiseSS13/Paradise/issues/614)
2) Makes portable turrets respect its preset anchored value (https://github.com/ParadiseSS13/Paradise/issues/613)
3) Gives flamethrowers a valid category (https://github.com/ParadiseSS13/Paradise/issues/612)