### PR TITLE
Allow borgs to open-close lockers properly

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -311,6 +311,10 @@
 	src.add_fingerprint(user)
 	return
 
+/obj/structure/closet/attack_ai(mob/user)
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) //Robots can open/close it, but not the AI
+		attack_hand(user)
+
 /obj/structure/closet/relaymove(mob/user as mob)
 	if(user.stat || !isturf(src.loc))
 		return


### PR DESCRIPTION
On the tin. Adds attack_ai to base closet path, allows only types of /mob/living/silicon/robot that are Adjacent() to it to open. Thanks to Baystation12/Baystation12#8499 for the attack_ai code.