### PR TITLE
Combat Changeling Nerfs

### DIFF
--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -109,7 +109,7 @@
 	name = "Arm Blade"
 	desc = "We reform one of our arms into a deadly blade."
 	helptext = "Cannot be used while in lesser form."
-	chemical_cost = 20
+	chemical_cost = 25
 	dna_cost = 2
 	genetic_damage = 10
 	req_human = 1
@@ -294,7 +294,7 @@
 	name = "Chitinous Armor"
 	desc = "We turn our skin into tough chitin to protect us from damage."
 	helptext = "Upkeep of the armor requires a low expenditure of chemicals. The armor is strong against brute force, but does not provide much protection from lasers. Retreating the armor damages our genomes. Cannot be used in lesser form."
-	chemical_cost = 20
+	chemical_cost = 25
 	dna_cost = 2
 	genetic_damage = 11
 	req_human = 1
@@ -313,7 +313,7 @@
 	flags = NODROP
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	slowdown = 2
-	armor = list(melee = 65, bullet = 20, laser = 10, energy = 13, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 65, bullet = 20, laser = 10, energy = 15, bomb = 0, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = 0
 	heat_protection = 0
@@ -331,7 +331,7 @@
 	desc = "A tough, hard covering of black chitin with transparent chitin in front."
 	icon_state = "lingarmorhelmet"
 	flags = HEADCOVERSEYES | BLOCKHAIR | NODROP
-	armor = list(melee = 70, bullet = 15, laser = 7,energy = 10, bomb = 5, bio = 2, rad = 0)
+	armor = list(melee = 65, bullet = 20, laser = 10,energy = 15, bomb = 0, bio = 0, rad = 0)
 	flags_inv = HIDEEARS
 
 /obj/item/clothing/head/helmet/changeling/dropped()

--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -2,7 +2,7 @@
 	name = "Resonant Shriek"
 	desc = "Our lungs and vocal chords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded."
 	helptext = "Emits a high-frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
-	chemical_cost = 20
+	chemical_cost = 30
 	dna_cost = 1
 	req_human = 1
 
@@ -32,7 +32,7 @@
 /obj/effect/proc_holder/changeling/dissonant_shriek
 	name = "Dissonant Shriek"
 	desc = "We shift our vocal cords to release a high-frequency sound that overloads nearby electronics."
-	chemical_cost = 20
+	chemical_cost = 30
 	dna_cost = 1
 
 //A flashy ability, good for crowd control and sewing chaos.
@@ -40,7 +40,7 @@
 	for(var/obj/machinery/light/L in range(5, usr))
 		L.on = 1
 		L.broken()
-	empulse(get_turf(user), 2, 5, 1)
+	empulse(get_turf(user), 2, 4, 1)
 	return 1
 
 


### PR DESCRIPTION
- Armblade and Chitinous Armor cost from 20 to 25.
- Made armor values for chitinous helmet consistent with chitinous
armor, minor increase to the energy resistance of the armor.
- Resonant and Dissonant Shriek costs from 20 to 30.
- Dissonant Shriek light EMP range from 5 to 4, heavy EMP range is
unchanged and remains 2.

The logic behind these changes is to slightly nerf combat changelings by making it more difficult to spam shrieks, which are fairly powerful, and reduce the changeling's ability to combo powers together in order to murder a large group of people. Being able to do this if the ling has prepared I'm fine with, being able to morph an armblade and suit of armor, then proceed to murder several sec officers is a bit much though.