### PR TITLE
Applepocalypse Prevention

### DIFF
--- a/code/game/machinery/hydroponics.dm
+++ b/code/game/machinery/hydroponics.dm
@@ -109,7 +109,7 @@
 		"cryoxadone" =     list(  3,    0,   0   ),
 		"ammonia" =        list(  0.5,  0,   0   ),
 		"diethylamine" =   list(  1,    0,   0   ),
-		"nutriment" =      list(  0.5,  1,   0   ),
+		"nutriment" =      list(  0.25,  0.15,   0   ),
 		"radium" =         list( -1.5,  0,   0.2 ),
 		"adminordrazine" = list(  1,    1,   1   ),
 		"robustharvest" =  list(  0,    0.2, 0   ),
@@ -141,7 +141,7 @@
 	update_icon()
 	if(closed_system)
 		flags &= ~OPENCONTAINER
-		
+
 /obj/machinery/portable_atmospherics/hydroponics/upgraded/New()
 	..()
 	component_parts = list()
@@ -368,7 +368,7 @@
 			// Beneficial reagents have a few impacts along with health buffs.
 			if(beneficial_reagents[R.id])
 				health += beneficial_reagents[R.id][1]       * reagent_total
-				yield_mod += beneficial_reagents[R.id][2]    * reagent_total
+				yield_mod = min(100, yield_mod + (beneficial_reagents[R.id][2]    * reagent_total))
 				mutation_mod += beneficial_reagents[R.id][3] * reagent_total
 
 			// Mutagen is distinct from the previous types and mostly has a chance of proccing a mutation.


### PR DESCRIPTION
- Nutriment is no longer insanely good for increasing a hydroponics
tray's yield_mod, it's now marginally worse than robust harvest, which
is marginally more difficult to make. (Old ratio was 1u nutriment to 1 yield_mod, now it's 6.667:1. Robust Harvest keeps its 5:1 ratio).
- yield_mod is now capped at 100 instead of not at all, no more getting 2000+ items out of one
harvest.

This nerfs botany's ability to get thousands of items out of one harvest. This mechanic was frankly broken, and the large item stacks it created were enough to crash a client if right clicked, or crash the server if they were moved or deleted by the Singulo.