### PR TITLE
Chemistry Balance: Plasma

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -19,8 +19,8 @@
 	var/hackedcheck = 0
 	var/list/dispensable_reagents = list("hydrogen","lithium","carbon","nitrogen","oxygen","fluorine",
 	"sodium","aluminum","silicon","phosphorus","sulfur","chlorine","potassium","iron",
-	"copper","mercury","radium","water","ethanol","sugar","sacid","tungsten")
-	var/list/hacked_reagents = list("plasma","toxin")
+	"copper","mercury","plasma","radium","water","ethanol","sugar","sacid","tungsten")
+	var/list/hacked_reagents = list("toxin")
 	var/hack_message = "You disable the safety safeguards, enabling the \"Mad Scientist\" mode."
 	var/unhack_message = "You re-enable the safety safeguards, enabling the \"NT Standard\" mode."
 	var/list/broken_requirements = list()
@@ -283,7 +283,7 @@
 	dispensable_reagents = list()
 	var/list/special_reagents = list(list("hydrogen", "oxygen", "silicon", "phosphorus", "sulfur", "carbon", "nitrogen"),
 						 		list("lithium", "sugar", "sacid", "water", "copper", "mercury", "sodium"),
-								list("ethanol", "chlorine", "potassium", "aluminium", "radium", "fluorine", "iron"))
+								list("ethanol", "chlorine", "potassium", "aluminium","plasma", "radium", "fluorine", "iron"))
 
 /obj/machinery/chem_dispenser/constructable/New()
 	..()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1426,27 +1426,6 @@ datum
 				M.adjustToxLoss(3*REM)
 				..()
 				return
-			reaction_obj(var/obj/O, var/volume)
-				src = null
-				/*if(istype(O,/obj/item/weapon/reagent_containers/food/snacks/egg/slime))
-					var/obj/item/weapon/reagent_containers/food/snacks/egg/slime/egg = O
-					if (egg.grown)
-						egg.Hatch()*/
-				if((!O) || (!volume))	return 0
-				var/turf/the_turf = get_turf(O)
-				var/datum/gas_mixture/napalm = new
-				var/datum/gas/volatile_fuel/fuel = new
-				fuel.moles = volume
-				napalm.trace_gases += fuel
-				the_turf.assume_air(napalm)
-			reaction_turf(var/turf/T, var/volume)
-				src = null
-				var/datum/gas_mixture/napalm = new
-				var/datum/gas/volatile_fuel/fuel = new
-				fuel.moles = volume
-				napalm.trace_gases += fuel
-				T.assume_air(napalm)
-				return
 			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)//Splashing people with plasma is stronger than fuel!
 				if(!istype(M, /mob/living))
 					return

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -457,17 +457,6 @@ datum
 			required_reagents = list("sodiumchloride" = 1, "ethanol" = 1, "radium" = 1)
 			result_amount = 3
 
-		plasmasolidification
-			name = "Solid Plasma"
-			id = "solidplasma"
-			result = null
-			required_reagents = list("iron" = 5, "frostoil" = 5, "plasma" = 20)
-			result_amount = 1
-			on_reaction(var/datum/reagents/holder, var/created_volume)
-				var/location = get_turf(holder.my_atom)
-				new /obj/item/stack/sheet/mineral/plasma(location)
-				return
-
 		plastication
 			name = "Plastic"
 			id = "solidplastic"


### PR DESCRIPTION
Changes up the Plasma reagent a bit

- Plasma Reagent no longer generates plasma gas when dumped on objects or turfs
 - players could pretty much create gigantic plasma fires capable of destroying entire departments with just a little plasma and the napalm reaction; reworked naplam now fills the pyrotechnic niche.
- Removed the Plasma Solidification recipe
 - Not really needed now that Xenobio can make plasma sheets directly. Reagent dispenser spam with frostoil can also lead to mass amounts of plasma sheets to a ridiculous degree.
- Added plasma as a standard reagent to the chem dispenser (no hacking with a multitool required anymore)
 - With some of these exploits/abusive cases removed (and the fact most people know about the multitool hack now), there's really no reason to not have plasma as a standard dispenser reagent.