### PR TITLE
[Goonchem] Further Goonchem Changes

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -392,8 +392,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"
-	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a strong anaesthetic and a chemical that is capable of blocking the movement of the vocal chords. \
-	The pen holds one dose of the mixture. The pen can be refilled."
+	desc = "A syringe disguised as a functional pen. It's filled with a potent anaesthetic. \The pen holds two doses of the mixture. The pen can be refilled."
 	item = /obj/item/weapon/pen/sleepy
 	cost = 8
 	excludefrom = list("nuclear emergency")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -202,6 +202,15 @@ var/list/uplink_items = list()
 	job = list("Research Director")
 
 
+//Stimulants
+
+/datum/uplink_item/jobspecific/stims
+	name = "Stimulants"
+	desc = "A highly illegal compound containd within a comapct auto-injector; when injected it makes the user extremely resistant to incapacitation and greatly enhances the body's ability to repair itself."
+	item = /obj/item/weapon/reagent_containers/hypospray/autoinjector/stimulants
+	cost = 7
+	job = list("Scientist","Research Director","Geneticist","Chief Medical Officer","Medical Doctor","Psychiatrist","Chemist","Paramedic","Virologist","Brig Physician")
+
 // DANGEROUS WEAPONS
 
 /datum/uplink_item/dangerous

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -57,7 +57,7 @@
 	set category = "Object"
 	set desc = "Devise evil plans of evilness."
 
-	usr.visible_message("<span class = 'danger'>\ [usr] twirls \his moustache and laughs [pick("fiendishly","maniacally","diabolically","evilly","fiendishly")]!</span>")
+	usr.visible_message("<span class = 'danger'>\ [usr] twirls \his moustache and laughs [pick("fiendishly","maniacally","diabolically","evilly")]!</span>")
 
 //scarves (fit in in mask slot)
 

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -47,10 +47,17 @@
 	adjustmask(user)
 
 /obj/item/clothing/mask/fakemoustache
-	name = "fake moustache"
-	desc = "Warning: moustache is fake."
+	name = "completely real moustache"
+	desc = "moustache is totally real."
 	icon_state = "fake-moustache"
 	flags_inv = HIDEFACE
+
+/obj/item/clothing/mask/fakemoustache/verb/pontificate()
+	set name = "Pontificate Evilly"
+	set category = "Object"
+	set desc = "Devise evil plans of evilness."
+
+	usr.visible_message("<span class = 'danger'>\ [usr] twirls \his moustache and laughs [pick("fiendishly","maniacally","diabolically","evilly","fiendishly")]!</span>")
 
 //scarves (fit in in mask slot)
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -73,12 +73,10 @@
 	if(..())
 		if(reagents.total_volume)
 			if(M.reagents)
-				reagents.trans_to(M, 55)
+				reagents.trans_to(M, 50)
 
 
 /obj/item/weapon/pen/sleepy/New()
-	create_reagents(55)
-	reagents.add_reagent("stoxin", 30)
-	reagents.add_reagent("mutetoxin", 15)
-	reagents.add_reagent("tirizene", 10)
+	create_reagents(100)
+	reagents.add_reagent("ketamine", 100)
 	..()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -172,7 +172,7 @@
 /obj/item/projectile/bullet/dart/metalfoam
 	New()
 		..()
-		reagents.add_reagent("aluminium", 15)
+		reagents.add_reagent("aluminum", 15)
 		reagents.add_reagent("foaming_agent", 5)
 		reagents.add_reagent("pacid", 5)
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -283,7 +283,7 @@
 	dispensable_reagents = list()
 	var/list/special_reagents = list(list("hydrogen", "oxygen", "silicon", "phosphorus", "sulfur", "carbon", "nitrogen"),
 						 		list("lithium", "sugar", "water", "copper", "mercury", "sodium"),
-								list("ethanol", "chlorine", "potassium", "aluminium","plasma", "radium", "fluorine", "iron"))
+								list("ethanol", "chlorine", "potassium", "aluminum","plasma", "radium", "fluorine", "iron"))
 
 /obj/machinery/chem_dispenser/constructable/New()
 	..()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -346,7 +346,7 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.adjustToxLoss(1.5)
+				M.adjustToxLoss(2)
 				..()
 				return
 
@@ -483,6 +483,7 @@ datum
 			description = "An illegal chemical compound used as drug."
 			reagent_state = LIQUID
 			color = "#60A584" // rgb: 96, 165, 132
+			metabolization_rate = 0.2
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
@@ -491,7 +492,6 @@ datum
 					if(M.canmove && !M.restrained())
 						if(prob(10)) step(M, pick(cardinal))
 				if(prob(7)) M.emote(pick("twitch","drool","moan","giggle"))
-				holder.remove_reagent(src.id, 0.5 * REAGENTS_METABOLISM)
 				..()
 				return
 
@@ -658,13 +658,11 @@ datum
 			description = "A chemical element."
 			reagent_state = LIQUID
 			color = "#484848" // rgb: 72, 72, 72
+			metabolization_rate = 0.2
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				if(M.canmove && istype(M.loc, /turf/space))
-					step(M, pick(cardinal))
-				if(prob(5)) M.emote(pick("twitch","drool","moan"))
-				M.adjustBrainLoss(2)
+				M.adjustBrainLoss(0.7)
 				..()
 				return
 
@@ -698,7 +696,7 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.take_organ_damage(1*REM, 0)
+				M.adjustFireLoss(1)
 				..()
 				return
 
@@ -711,6 +709,7 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
+				M.adjustFireLoss(1)
 				M.adjustToxLoss(1*REM)
 				..()
 				return
@@ -784,7 +783,7 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
 				M.adjustToxLoss(1*REM)
-				M.take_organ_damage(0, 1*REM)
+				M.adjustFireLoss(1)
 				..()
 				return
 			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
@@ -861,8 +860,8 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.adjustToxLoss(2*REM)
-				M.take_organ_damage(0, 1*REM)
+				M.adjustToxLoss(1*REM)
+				M.adjustFireLoss(1)
 				..()
 				return
 
@@ -957,10 +956,11 @@ datum
 			description = "Radium is an alkaline earth metal. It is extremely radioactive."
 			reagent_state = SOLID
 			color = "#C7C7C7" // rgb: 199,199,199
+			metabolization_rate = 0.3
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.apply_effect(2*REM,IRRADIATE,0)
+				M.apply_effect(4*REM,IRRADIATE,0)
 				// radium may increase your chances to cure a disease
 				if(istype(M,/mob/living/carbon)) // make sure to only use it on carbon mobs
 					var/mob/living/carbon/C = M
@@ -1052,6 +1052,7 @@ datum
 			description = "Might cause unpredictable mutations. Keep away from children."
 			reagent_state = LIQUID
 			color = "#13BC5E" // rgb: 19, 188, 94
+			metabolization_rate = 0.3
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
 				if(!..())	return
@@ -1069,7 +1070,7 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				if(!M.dna) return //No robots, AIs, aliens, Ians or other mobs should be affected by this.
 				if(!M) M = holder.my_atom
-				M.apply_effect(5*REM,IRRADIATE,0)
+				M.apply_effect(2*REM,IRRADIATE,0)
 				..()
 				return
 
@@ -1193,7 +1194,7 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.apply_effect(1,IRRADIATE,0)
+				M.apply_effect(2,IRRADIATE,0)
 				..()
 				return
 
@@ -1395,10 +1396,7 @@ datum
 				if(M.stat == 2.0)
 					return
 				if(!M) M = holder.my_atom
-				if(prob(33))
-					M.take_organ_damage(1*REM, 0)
-				M.adjustOxyLoss(3)
-				if(prob(20)) M.emote("gasp")
+				M.adjustToxLoss(1)
 				..()
 				return
 
@@ -1729,7 +1727,7 @@ datum
 				if(!M) M = holder.my_atom
 				if(M.bodytemperature < 170)
 					M.adjustCloneLoss(-1)
-					M.adjustOxyLoss(-3)
+					M.adjustOxyLoss(-10)
 					M.heal_organ_damage(3,3)
 					M.adjustToxLoss(-3)
 				..()
@@ -1746,9 +1744,6 @@ datum
 				if(!M) M = holder.my_atom
 				if(M.bodytemperature < 170)
 					M.adjustCloneLoss(-3)
-					M.adjustOxyLoss(-3)
-					M.heal_organ_damage(3,3)
-					M.adjustToxLoss(-3)
 					M.status_flags &= ~DISFIGURED
 				..()
 				return

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -764,7 +764,11 @@ datum
 					M.AdjustWeakened(-1)
 				if(current_cycle >= 90)
 					M.jitteriness += 10
-				if(volume > overdose_threshold)
+				..()
+				return
+
+			overdose_process(var/mob/living/M as mob)
+				if(volume > 200)
 					M << "<span class = 'danger'>You pass out from hyperglycemic shock!</span>"
 					M.Paralyse(1)
 				..()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -662,7 +662,8 @@ datum
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
-				M.adjustBrainLoss(0.7)
+				if(prob(70))
+					M.adjustBrainLoss(1)
 				..()
 				return
 
@@ -1824,18 +1825,6 @@ datum
 					var/mob/M = holder.my_atom
 					M.status_flags &= ~FAKEDEATH
 				..()8*/
-
-		mutetoxin
-			name = "Mute Toxin"
-			id = "mutetoxin"
-			description = "A toxin that temporarily paralyzes the vocal cords."
-			reagent_state = LIQUID
-			color = "#F0F8FF" // rgb: 240, 248, 255
-
-			on_mob_life(var/mob/living/M)
-				if(!M) M = holder.my_atom
-				M.silent += REM + 1
-				..()
 
 		staminatoxin
 			name = "Tirizene"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -91,7 +91,7 @@ datum
 			name = "Unstable mutagen"
 			id = "mutagen"
 			result = "mutagen"
-			required_reagents = list("radium" = 1, "phosphorus" = 1, "chlorine" = 1)
+			required_reagents = list("radium" = 1, "plasma" = 1, "chlorine" = 1)
 			result_amount = 3
 
 		tramadol
@@ -120,13 +120,6 @@ datum
 			id = "thermite"
 			result = "thermite"
 			required_reagents = list("aluminum" = 1, "iron" = 1, "oxygen" = 1)
-			result_amount = 3
-
-		lexorin
-			name = "Lexorin"
-			id = "lexorin"
-			result = "lexorin"
-			required_reagents = list("plasma" = 1, "hydrogen" = 1, "nitrogen" = 1)
 			result_amount = 3
 
 		space_drugs
@@ -283,8 +276,8 @@ datum
 			name = "Cryoxadone"
 			id = "cryoxadone"
 			result = "cryoxadone"
-			required_reagents = list("dexalin" = 1, "water" = 1, "oxygen" = 1)
-			result_amount = 3
+			required_reagents = list("cryostylane" = 1, "plasma" = 1, "acetone" = 1, "mutagen" = 1)
+			result_amount = 4
 
 		clonexadone
 			name = "Clonexadone"
@@ -587,6 +580,7 @@ datum
 			result = "diethylamine"
 			required_reagents = list ("ammonia" = 1, "ethanol" = 1)
 			result_amount = 2
+			required_temp = 374
 
 		space_cleaner
 			name = "Space cleaner"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -128,6 +128,7 @@ datum
 			result = "space_drugs"
 			required_reagents = list("mercury" = 1, "sugar" = 1, "lithium" = 1)
 			result_amount = 3
+			mix_message = "Slightly dizzying fumes drift from the solution."
 
 		lube
 			name = "Space Lube"
@@ -382,13 +383,6 @@ datum
 			id = "zombiepowder"
 			result = "zombiepowder"
 			required_reagents = list("carpotoxin" = 5, "stoxin" = 5, "copper" = 5)
-			result_amount = 2
-
-		mutetoxin
-			name = "Mute toxin"
-			id = "mutetoxin"
-			result = "mutetoxin"
-			required_reagents = list("uranium" = 2, "water" = 1, "carbon" = 1)
 			result_amount = 2
 
 		rezadone

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -305,7 +305,7 @@ datum/reagent/salbutamol/on_mob_life(var/mob/living/M as mob)
 	name = "Salbutamol"
 	id = "salbutamol"
 	result = "salbutamol"
-	required_reagents = list("sal_acid" = 1, "lithium" = 1, "aluminium" = 1, "bromine" = 1, "ammonia" = 1)
+	required_reagents = list("sal_acid" = 1, "lithium" = 1, "aluminum" = 1, "bromine" = 1, "ammonia" = 1)
 	result_amount = 5
 
 datum/reagent/perfluorodecalin

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -187,6 +187,8 @@ datum/reagent/calomel/on_mob_life(var/mob/living/M as mob)
 			M.reagents.remove_reagent(R.id,5)
 	if(M.health > 20)
 		M.adjustToxLoss(5*REM)
+	if(prob(10))
+		M.fakevomit()
 	..()
 	return
 
@@ -344,7 +346,6 @@ datum/reagent/ephedrine
 
 datum/reagent/ephedrine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
-	M.status_flags |= IGNORESLOWDOWN
 	M.AdjustParalysis(-1)
 	M.AdjustStunned(-1)
 	M.AdjustWeakened(-1)
@@ -771,7 +772,6 @@ datum/reagent/antihol/on_mob_life(var/mob/living/M as mob)
 	M.slurring = 0
 	M.confused = 0
 	M.reagents.remove_reagent("ethanol", 8)
-	M.adjustToxLoss(-0.2*REM)
 	..()
 
 /datum/chemical_reaction/antihol
@@ -794,29 +794,24 @@ datum/reagent/antihol/on_mob_life(var/mob/living/M as mob)
 	description = "Increases run speed and eliminates stuns, can heal minor damage. If overdosed it will deal toxin damage and stun."
 	color = "#C8A5DC"
 	metabolization_rate = 0.4
-	overdose_threshold = 60
 
 datum/reagent/stimulants/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
-	M.status_flags |= IGNORESLOWDOWN
-	if(M.health < 50 && M.health > 0)
-		if(prob(50))
-			M.adjustOxyLoss(-5*REM)
-			M.adjustToxLoss(-5*REM)
-			M.adjustBruteLoss(-5*REM)
-			M.adjustFireLoss(-5*REM)
-	M.adjustFireLoss(-3*REM)
-	M.AdjustParalysis(-1)
-	M.AdjustStunned(-1)
-	M.AdjustWeakened(-1)
-	M.adjustStaminaLoss(-3*REM)
+	M.adjustOxyLoss(-5*REM)
+	M.adjustToxLoss(-5*REM)
+	M.adjustBruteLoss(-5*REM)
+	M.adjustFireLoss(-5*REM)
+	M.setStaminaLoss(0)
+	var/status = CANSTUN | CANWEAKEN | CANPARALYSE
+	M.status_flags &= ~status
 	..()
 
-datum/reagent/stimulants/overdose_process(var/mob/living/M as mob)
-	if(prob(33))
-		M.adjustStaminaLoss(5*REM)
-		M.adjustToxLoss(2*REM)
-		M.losebreath++
+datum/reagent/stimulants/reagent_deleted(var/mob/living/M as mob)
+	if(!M) M = holder.my_atom
+	M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE
+	M.adjustBruteLoss(12)
+	M.adjustToxLoss(12)
+	M.Stun(3)
 	..()
 	return
 

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -66,6 +66,7 @@ datum/reagent/salglu_solution
 	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	metabolization_rate = 0.15
 
 datum/reagent/salglu_solution/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
@@ -799,8 +800,8 @@ datum/reagent/stimulants/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	M.adjustOxyLoss(-5*REM)
 	M.adjustToxLoss(-5*REM)
-	M.adjustBruteLoss(-5*REM)
-	M.adjustFireLoss(-5*REM)
+	M.adjustBruteLoss(-10*REM)
+	M.adjustFireLoss(-10*REM)
 	M.setStaminaLoss(0)
 	var/status = CANSTUN | CANWEAKEN | CANPARALYSE
 	M.status_flags &= ~status
@@ -810,8 +811,8 @@ datum/reagent/stimulants/reagent_deleted(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE
 	M.adjustBruteLoss(12)
-	M.adjustToxLoss(12)
-	M.Stun(3)
+	M.adjustToxLoss(24)
+	M.Stun(4)
 	..()
 	return
 

--- a/code/modules/reagents/newchem/newchem_procs.dm
+++ b/code/modules/reagents/newchem/newchem_procs.dm
@@ -62,7 +62,7 @@ datum/reagents/proc/reagent_on_tick()
 
 datum/reagents/proc/check_ignoreslow(var/mob/M)
 	if(istype(M, /mob))
-		if(M.reagents.has_reagent("morphine")||M.reagents.has_reagent("ephedrine"))
+		if(M.reagents.has_reagent("morphine"))
 			return 1
 		else
 			M.status_flags &= ~IGNORESLOWDOWN

--- a/code/modules/reagents/newchem/other.dm
+++ b/code/modules/reagents/newchem/other.dm
@@ -237,8 +237,8 @@ datum/reagent/hair_dye
 	name = "hair_dye"
 	id = "hair_dye"
 	result = "hair_dye"
-	required_reagents = list("colorful_reagent" = 1, "radium" = 1, "space_drugs" = 1)
-	result_amount = 5
+	required_reagents = list("colorful_reagent" = 1, "hairgrownium" = 1)
+	result_amount = 2
 
 datum/reagent/hair_dye/reaction_mob(var/mob/living/M, var/volume)
 	if(M && ishuman(M))
@@ -290,11 +290,18 @@ datum/reagent/super_hairgrownium
 	required_reagents = list("iron" = 1, "methamphetamine " = 1, "hairgrownium" = 1)
 	result_amount = 3
 
-datum/reagent/super_hairgrownium/reaction_mob(var/mob/living/M, var/volume)
+datum/reagent/super_hairgrownium/on_mob_life(var/mob/living/M as mob)
+	if(!M) M = holder.my_atom
 	if(M && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.h_style = "Very Long Hair"
 		H.f_style = "Very Long Beard"
 		H.update_hair()
+		if(!H.wear_mask || H.wear_mask && !istype(H.wear_mask, /obj/item/clothing/mask/fakemoustache))
+			if(H.wear_mask)
+				H.unEquip(H.wear_mask)
+			var/obj/item/clothing/mask/fakemoustache = new /obj/item/clothing/mask/fakemoustache
+			H.equip_to_slot(fakemoustache, slot_wear_mask)
+			H << "<span class = 'notice'>Hair bursts forth from your every follicle!"
 	..()
 	return

--- a/code/modules/reagents/newchem/other.dm
+++ b/code/modules/reagents/newchem/other.dm
@@ -287,7 +287,7 @@ datum/reagent/super_hairgrownium
 	name = "Super Hairgrownium"
 	id = "super_hairgrownium"
 	result = "super_hairgrownium"
-	required_reagents = list("iron" = 1, "methamphetamine " = 1, "hairgrownium" = 1)
+	required_reagents = list("iron" = 1, "methamphetamine" = 1, "hairgrownium" = 1)
 	result_amount = 3
 
 datum/reagent/super_hairgrownium/on_mob_life(var/mob/living/M as mob)

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -202,7 +202,7 @@
 	name = "Flash powder"
 	id = "flash_powder"
 	result = "flash_powder"
-	required_reagents = list("aluminium" = 1, "potassium" = 1, "sulfur" = 1 )
+	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1 )
 	result_amount = 3
 
 /datum/chemical_reaction/flash_powder_flash
@@ -429,8 +429,8 @@
 /datum/chemical_reaction/napalm
 	name = "Napalm"
 	id = "napalm"
-	result = null
-	required_reagents = list("aluminium" = 1, "plasma" = 1, "sacid" = 1 )
+	result = "napalm"
+	required_reagents = list("sugar" = 1, "fuel" = 1, "ethanol" = 1 )
 	result_amount = 1
 
 datum/reagent/cryostylane

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -446,26 +446,10 @@ datum/reagent/cryostylane
 	required_reagents = list("water" = 1, "plasma" = 1, "nitrogen" = 1)
 	result_amount = 3
 
-/datum/chemical_reaction/cryostylane/on_reaction(var/datum/reagents/holder, var/created_volume)
-	holder.chem_temp = 20 // cools the fuck down
-	return
-
-
 datum/reagent/cryostylane/on_mob_life(var/mob/living/M as mob) //TODO: code freezing into an ice cube
-	if(M.reagents.has_reagent("oxygen"))
-		M.reagents.remove_reagent("oxygen", 1)
-		M.bodytemperature -= 30
+	M.bodytemperature -= 30
 	..()
 	return
-
-datum/reagent/cryostylane/on_tick()
-	if(holder.has_reagent("oxygen"))
-		holder.remove_reagent("oxygen", 1)
-		holder.chem_temp -= 10
-		holder.handle_reactions()
-	..()
-	return
-
 
 datum/reagent/cryostylane/reaction_turf(var/turf/simulated/T, var/volume)
 	if(volume >= 5)

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -200,8 +200,8 @@ datum/reagent/itching_powder/on_mob_life(var/mob/living/M as mob)
 
 datum/reagent/facid/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
-	M.adjustToxLoss(2*REM)
-	M.take_organ_damage(0, 1*REM)
+	M.adjustToxLoss(1*REM)
+	M.adjustFireLoss(1)
 	..()
 	return
 
@@ -467,7 +467,7 @@ datum/reagent/sarin
 	required_reagents = list("chlorine" = 1, "fluorine" = 1, "hydrogen" = 1, "oxygen" = 1, "phosphorus" = 1, "fuel" = 1, "acetone" = 1, "atrazine" = 1)
 	result_amount = 3
 	mix_message = "The mixture yields a colorless, odorless liquid."
-	required_temp = 373
+	required_temp = 374
 
 datum/reagent/sarin/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -354,6 +354,26 @@ datum/reagent/sodium_thiopental/on_mob_life(var/mob/living/M as mob)
 	..()
 	return
 
+datum/reagent/ketamine
+	name = "Ketamine"
+	id = "ketamine"
+	description = "A potent veterinary tranquilizer."
+	reagent_state = LIQUID
+	color = "#646EA0"
+	metabolization_rate = 0.8
+
+datum/reagent/ketamine/on_mob_life(var/mob/living/M as mob)
+	if(!M) M = holder.my_atom
+	if(current_cycle <= 10)
+		if(prob(20))
+			M.emote("yawn")
+	if(current_cycle == 6)
+		M.eye_blurry = max(M.eye_blurry, 5)
+	if(current_cycle >= 10)
+		M.Paralyse(10)
+	..()
+	return
+
 datum/reagent/sulfonal
 	name = "Sulfonal"
 	id = "sulfonal"
@@ -561,3 +581,48 @@ datum/reagent/atrazine/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volu
 	required_reagents = list("chlorine" = 1, "hydrogen" = 1, "nitrogen" = 1)
 	result_amount = 3
 	mix_message = "The mixture gives off a harsh odor"
+
+datum/reagent/capulettium
+	name = "Capulettium"
+	id = "capulettium"
+	description = "A rare drug that causes the user to appear dead for some time."
+	reagent_state = LIQUID
+	color = "#60A584"
+
+/datum/chemical_reaction/capulettium
+	name = "capulettium"
+	id = "capulettium"
+	result = "capulettium"
+	required_reagents = list("neurotoxin2" = 1, "chlorine" = 1, "hydrogen" = 1)
+	result_amount = 1
+	mix_message = "The smell of death wafts up from the solution."
+
+datum/reagent/capulettium/on_mob_life(var/mob/living/M as mob)
+	if(!M) M = holder.my_atom
+	M.eye_blurry = max(M.eye_blurry, 2)
+	if(current_cycle == 12)
+		M.emote("deathgasp")
+		M.Paralyse(10)
+	..()
+	return
+
+datum/reagent/capulettium_plus
+	name = "Capulettium Plus"
+	id = "capulettium_plus"
+	description = "A rare and expensive drug that causes the user to appear dead for some time while they retain consciousness and vision."
+	reagent_state = LIQUID
+	color = "#60A584"
+
+/datum/chemical_reaction/capulettium_plus
+	name = "capulettium_plus"
+	id = "capulettium_plus"
+	result = "capulettium_plus"
+	required_reagents = list("capulettium" = 1, "ephedrine" = 1, "methamphetamine" = 1)
+	result_amount = 3
+	mix_message = "The solution begins to slosh about violently by itself."
+
+datum/reagent/capulettium_plus/on_mob_life(var/mob/living/M as mob)
+	if(!M) M = holder.my_atom
+	M.silent += REM + 1
+	..()
+	return

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -137,3 +137,18 @@
 	reagents.add_reagent("lexorin", 1)
 	update_icon()
 	return
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/stimulants
+	name = "Stimulants autoinjector"
+	desc = "Rapidly stimulates and regernates the body's organ system."
+	icon_state = "stimpen"
+	amount_per_transfer_from_this = 50
+	possible_transfer_amounts = list(50)
+	volume = 50
+
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/stimulants/New()
+	..()
+	reagents.remove_reagent("epinephrine", 10)
+	reagents.add_reagent("stimulants", 50)
+	update_icon()
+	return

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -802,7 +802,7 @@ var/list/be_special_flags = list(
 //feel free to add shit to lists below
 var/list/tachycardics = list("coffee", "inaprovaline", "hyperzine", "nitroglycerin", "thirteenloko", "nicotine")	//increase heart rate
 var/list/bradycardics = list("neurotoxin", "cryoxadone", "clonexadone", "space_drugs", "stoxin")					//decrease heart rate
-var/list/heartstopper = list("zombie_powder") //this stops the heart
+var/list/heartstopper = list("zombie_powder", "capulettium", "capulettium_plus") //this stops the heart
 var/list/cheartstopper = list() //this stops the heart when overdose is met -- c = conditional
 
 //proc/get_pulse methods


### PR DESCRIPTION
Adds a few more chems and updates some existing ones so they behave as they properly should

Additions
- Ketamine
 - Traitor only chem loaded in sleepy pens; it knocks out quite quickly but frequently makes the user yawn, giving the person injected ample warning time
- Capulettium
 - Makes it look like you're dead; will also knock out after a short duration, but duration it does knock you out is fixed and relatively short
- Capulettium Plus
 - Also makes you look like you're dead; as long as its in your system you'll be silent
- Stimulants
 - Stims are a *TRAITOR ONLY* chem that are available to medical staff+scientists; it rapidly heals all damage types and makes you immune to stuns; when it wears off it deals heavy tox and brute damage and stuns the user for a while.

Updates
- Small numbers changed (metabolism rates and radiation rates, etc) on a number of older reagents
- Cryox Recipe Changed
- Lexorin only causes 1 TOX now, but doesn't have a recipe
- Ephedrine's slow immunity removed
- Antihol no longer heals minor amouts of TOX damage
- Mutagen recipe updated
- Calomel has a chance to make you vomit each cycle
- mutetoxin removed (capulettium replaces it)
- Super Hairgrownium now will remove the current mask you're wearing and give you a fake moustache as long as its in your system

Fixes
- Fixes a number of recipes that were calling for "aluminium" instead of "aluminum"
- Fixes Napalm not making anything

Other 
- Can now twirl fake moustaches.