### PR TITLE
Revert "Change space law iframe wiki link"

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -673,7 +673,7 @@
 		</head>
 
 		<body>
-		<iframe width='100%' height='97%' src="http://nanotrasen.se/wiki/index.php?title=Space_Law&printable=yes" frameborder="0" id="main_frame"></iframe>		</body>
+		<iframe width='100%' height='97%' src="http://nanotrasen.se/wiki/index.php?title=Space_law&printable=yes" frameborder="0" id="main_frame"></iframe>		</body>
 
 		</html>
 


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#359

With the new space law there's no reason to keep the old article around. 