### PR TITLE
Adding extra logging information to PDA for refactor prep

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -528,6 +528,7 @@ var/global/datum/controller/occupations/job_master
 			pda.ownjob = C.assignment
 			pda.ownrank = C.rank
 			pda.name = "PDA-[H.real_name] ([pda.ownjob])"
+			pda.JFLOG("Created")
 
 		return 1
 


### PR DESCRIPTION
This significantly expands the level of detail for logging what PDAs do.

I'm planning on doing a large cleanup and refactor for the PDA's but I'm looking to get some hard data on how people use them during game-play.

I intend on leaving these changes in play for two weeks and then removing them when I do the refactor. During this time I'd like to get access to the server log for PDA's. 

If there's an issue with me getting access to the full logs, I can supply a script that will strip out the non-pda data. 