### PR TITLE
[Goonchem] Fixes and Tweaks (again)

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -419,7 +419,7 @@ datum
 			id = "space_drugs"
 			description = "An illegal chemical compound used as drug."
 			reagent_state = LIQUID
-			color = "#60A584" // rgb: 96, 165, 132
+			color = "#9087A2"
 			metabolization_rate = 0.2
 
 			on_mob_life(var/mob/living/M as mob)
@@ -810,7 +810,7 @@ datum
 			description = "Radium is an alkaline earth metal. It is extremely radioactive."
 			reagent_state = SOLID
 			color = "#C7C7C7" // rgb: 199,199,199
-			metabolization_rate = 0.3
+			metabolization_rate = 0.4
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
@@ -863,7 +863,7 @@ datum
 			id = "mutagen"
 			description = "Might cause unpredictable mutations. Keep away from children."
 			reagent_state = LIQUID
-			color = "#00FF00"
+			color = "#04DF27"
 			metabolization_rate = 0.3
 
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
@@ -1064,7 +1064,7 @@ datum
 			id = "cleaner"
 			description = "A compound used to clean things. Now with 50% more sodium hypochlorite!"
 			reagent_state = LIQUID
-			color = "#A5F0EE" // rgb: 165, 240, 238
+			color = "#61C2C2"
 
 			reaction_obj(var/obj/O, var/volume)
 				if(istype(O,/obj/effect/decal/cleanable))
@@ -1250,7 +1250,7 @@ datum
 		mitocholide
 			name = "Mitocholide"
 			id = "mitocholide"
-			description = "A specialized drugs that stimulates the mitochondria of cells to encourage healing of internal organs."
+			description = "A specialized drug that stimulates the mitochondria of cells to encourage healing of internal organs."
 			reagent_state = LIQUID
 			color = "#C8A5DC" // rgb: 200, 165, 220
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -117,6 +117,7 @@ datum
 			result = "holywater"
 			required_reagents = list("water" = 1, "mercury" = 1, "wine" = 1)
 			result_amount = 3
+			mix_message = "The water somehow seems purified. Or maybe defiled."
 
 		cryptobiolin
 			name = "Cryptobiolin"

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -247,11 +247,12 @@ datum/reagent/crank/addiction_act_stage4(var/mob/living/M as mob)
 /datum/reagent/bath_salts
 	name = "Bath Salts"
 	id = "bath_salts"
-	description = "Makes you nearly impervious to stuns and grants a stamina regeneration buff, but you will be a nearly uncontrollable tramp-bearded raving lunatic."
+	description = "Sometimes packaged as a refreshing bathwater additive, these crystals are definitely not for human consumption."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 20
 	addiction_threshold = 10
+	metabolization_rate = 0.6
 
 
 /datum/reagent/bath_salts/on_mob_life(var/mob/living/M as mob)
@@ -276,9 +277,10 @@ datum/reagent/crank/addiction_act_stage4(var/mob/living/M as mob)
 	name = "bath_salts"
 	id = "bath_salts"
 	result = "bath_salts"
-	required_reagents = list("????" = 1, "saltpetre" = 1, "nutriment" = 1, "cleaner" = 1, "enzyme" = 1, "tea" = 1, "mercury" = 1)
-	result_amount = 7
+	required_reagents = list("????" = 1, "saltpetre" = 1, "nutriment" = 1, "cleaner" = 1, "enzyme" = 1, "mugwort" = 1, "mercury" = 1)
+	result_amount = 6
 	required_temp = 374
+	mix_message = "Tiny cubic crystals precipitate out of the mixture. Huh."
 
 /datum/reagent/bath_salts/overdose_process(var/mob/living/M as mob)
 	M.hallucination += 10

--- a/code/modules/reagents/newchem/food.dm
+++ b/code/modules/reagents/newchem/food.dm
@@ -125,3 +125,21 @@ datum/reagent/honey/reaction_turf(var/turf/T, var/volume)
 	if(volume >= 5)
 		new /obj/item/weapon/reagent_containers/food/snacks/honeycomb(T)
 		return */
+
+/datum/reagent/mugwort
+	name = "Mugwort"
+	id = "mugwort"
+	description = "A rather bitter herb once thought to hold magical protective properties."
+	reagent_state = LIQUID
+	color = "#21170E"
+
+datum/reagent/mugwort/on_mob_life(var/mob/living/M as mob)
+	if(!M) M = holder.my_atom
+	if(istype(M, /mob/living/carbon/human) && M.mind)
+		if(M.mind.special_role == "Wizard")
+			M.adjustToxLoss(-1*REM)
+			M.adjustOxyLoss(-1*REM)
+			M.adjustBruteLoss(-1*REM)
+			M.adjustFireLoss(-1*REM)
+	..()
+	return

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -301,9 +301,9 @@ datum/reagent/facid/reaction_obj(var/obj/O, var/volume)
 datum/reagent/initropidril
 	name = "Initropidril"
 	id = "initropidril"
-	description = "33% chance to hit with a random amount of toxin damage, 5-10% chances to cause stunning, suffocation, or immediate heart failure."
+	description = "A highly potent cardiac poison - can kill within minutes."
 	reagent_state = LIQUID
-	color = "#CF3600"
+	color = "#7F10C0"
 	metabolization_rate = 0.4
 
 datum/reagent/initropidril/on_mob_life(var/mob/living/M as mob)
@@ -324,7 +324,7 @@ datum/reagent/initropidril/on_mob_life(var/mob/living/M as mob)
 			if(3)
 				var/mob/living/carbon/human/H = M
 				if(!H.heart_attack)
-					H.visible_message("<span class = 'userdanger'>[H] clutches at their chest !</span>")
+					H.visible_message("<span class = 'userdanger'>[H] clutches at their chest!</span>")
 					H.heart_attack = 1 // rip in pepperoni
 	..()
 	return

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -14,7 +14,7 @@
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
 
 	var/list/datum/reagents/reagent_list = list()
-	var/list/reagent_ids = list("salglu_solution", "epinephrine", "spaceacillin")
+	var/list/reagent_ids = list("salglu_solution", "epinephrine", "spaceacillin", "charcoal")
 	//var/list/reagent_ids = list("salbutamol", "silver_sulfadiazine", "styptic_powder", "charcoal", "epinephrine", "spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/surgeon

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -226,6 +226,19 @@
 	New()
 		..()
 		reagents.add_reagent("tea", 30)
+		if(prob(10))
+			reagents.add_reagent("mugwort", 3)
+		src.pixel_x = rand(-10.0, 10)
+		src.pixel_y = rand(-10.0, 10)
+
+/obj/item/weapon/reagent_containers/food/drinks/mugwort
+	name = "Mugwort Tea"
+	desc = "A bitter herbal tea."
+	icon_state = "manlydorfglass"
+	item_state = "coffee"
+	New()
+		..()
+		reagents.add_reagent("mugwort", 30)
 		src.pixel_x = rand(-10.0, 10)
 		src.pixel_y = rand(-10.0, 10)
 

--- a/maps/cyberiad.dmm
+++ b/maps/cyberiad.dmm
@@ -8000,7 +8000,7 @@
 "cXR" = (/turf/space/transit/north/shuttlespace_ns10,/area/syndicate_station/transit)
 "cXS" = (/turf/space/transit/north/shuttlespace_ns1,/area/syndicate_station/transit)
 "cXT" = (/obj/effect/step_trigger/thrower{affect_ghosts = 1; direction = 2; name = "thrower_throwdown"; tiles = 0},/turf/space/transit/north/shuttlespace_ns5,/area)
-"cXU" = (/obj/structure/table/woodentable,/obj/item/trash/cheesie,/turf/unsimulated/floor{dir = 8; icon_state = "wood"},/area/wizard_station)
+"cXU" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/drinks/mugwort,/turf/unsimulated/floor{dir = 8; icon_state = "wood"},/area/wizard_station)
 "cXV" = (/obj/structure/table/woodentable,/obj/item/weapon/spacecash,/turf/unsimulated/floor{dir = 8; icon_state = "wood"},/area/wizard_station)
 "cXW" = (/obj/structure/rack,/obj/item/clothing/suit/wizrobe/red,/obj/item/clothing/shoes/sandal,/obj/item/clothing/head/wizard/red,/obj/item/weapon/staff,/turf/unsimulated/floor{icon_state = "grimy"},/area/wizard_station)
 "cXX" = (/obj/structure/rack,/obj/item/clothing/suit/wizrobe/magusred,/obj/item/clothing/head/wizard/magus,/obj/item/weapon/staff,/turf/unsimulated/floor{icon_state = "grimy"},/area/wizard_station)


### PR DESCRIPTION
More Tweaks+Fixes

- Updates even more chem's colors, reaction messages, descriptions, and metabolism rates.
- Fixes strange reagent so it behaves properly
 - When splashed (TOUCH) on simple animals it will revive them to full health
 - When injected (INGEST) into carbons (Humans, Monkies, and Xenos, mostly), it will revive them if their combined brute and fire damage is below 150--if their damage levels exceed these thresholds it will gib the mob.
- Adds in Mugwort (10% probability of vending machine tea having 3 units of mugwort in it)
 - Doesn't do anything if you're a regular person; acts like Omnizine if you're a wizard; a single mug of this starts out in the wizard den.
- Updates the Bath Salts recipe to require mugwort instead of tea.
- Borgs start with charcoal in their hyposprays.