### PR TITLE
Lethal Brain Damage

### DIFF
--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -50,7 +50,7 @@
 					B.name = "Guys Gone Wild"
 				if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks")
 					B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition")
-					H.setBrainLoss(100) // starts off retarded as fuck
+					H.setBrainLoss(99) // starts off retarded as fuck
 				if("science")
 					B.name = pick("Principle of Relativity", "Quantum Enigma: Physics Encounters Consciousness", "Programming the Universe", "Quantum Physics and Theology", "String Theory for Dummies", "How To: Build Your Own Warp Drive", "The Mysteries of Bluespace", "Playing God: Collector's Edition")
 				else

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -218,7 +218,7 @@
 	src.icon_state = "pod_1"
 	//Get the clone body ready
 	H.adjustCloneLoss(190) //new damage var so you can't eject a clone early then stab them to abuse the current damage system --NeoFite
-	H.adjustBrainLoss(190) // The rand(10, 30) will come out as extra brain damage
+	H.adjustBrainLoss(90) // The rand(10, 30) will come out as extra brain damage
 	H.Paralyse(4)
 
 	//Here let's calculate their health so the pod doesn't immediately eject them!!!
@@ -298,7 +298,7 @@
 			src.occupant.adjustCloneLoss(-((speed_coeff/2)))
 
 			//Premature clones may have brain damage.
-			src.occupant.adjustBrainLoss(-((speed_coeff/2)))
+			src.occupant.adjustBrainLoss(-((speed_coeff/20)*efficiency))
 
 			//So clones don't die of oxyloss in a running pod.
 			if (src.occupant.reagents.get_reagent_amount("salbutamol") < 5)

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -74,9 +74,6 @@
 //		return
 
 	if (M.stat !=2)
-		if(M.mind && (M.mind.assigned_role == "Chaplain"))
-			user << "\red You can't heal yourself!"
-			return
 		/*if((M.mind in ticker.mode.cult) && (prob(20)))
 			M << "\red The power of [src.deity_name] clears your mind of heresy!"
 			user << "\red You see how [M]'s eyes become clear, the cult no longer holds control over him!"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -213,31 +213,14 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 					if(3)
 						emote("drool")
 
-        /*
-		if(species.name == "Tajaran")
-			if(prob(1))
-				if(prob(1))
-					vomit(1) // Hairball
+		if(getBrainLoss() >= 100 && stat != 2) //you lapse into a coma and die without immediate aid; RIP. -Fox
+			Weaken(20)
+			losebreath += 10
+			silent += 2
 
-        */
-
-		if(stat != 2)
-			var/rn = rand(0, 200)
-			if(getBrainLoss() >= 5)
-				if(0 <= rn && rn <= 3)
-					custom_pain("Your head feels numb and painful.")
-			if(getBrainLoss() >= 15)
-				if(4 <= rn && rn <= 6) if(eye_blurry <= 0)
-					src << "\red It becomes hard to see for some reason."
-					eye_blurry = 10
-			if(getBrainLoss() >= 35)
-				if(7 <= rn && rn <= 9) if(hand && equipped())
-					src << "\red Your hand won't respond properly, you drop what you're holding."
-					drop_item()
-			if(getBrainLoss() >= 50)
-				if(10 <= rn && rn <= 12) if(!lying)
-					src << "\red Your legs won't respond properly, you fall down."
-					resting = 1
+		if(getBrainLoss() >= 120 && stat != 2) //they died from stupidity--literally. -Fox
+			visible_message("<span class='danger'><B>[src]</B> goes limp, their facial expression utterly blank.</span>")
+			death()
 
 	proc/handle_stasis_bag()
 		// Handle side effects from stasis bag
@@ -1908,7 +1891,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	else
 		losebreath += 5
 		adjustOxyLoss(10)
-		adjustBrainLoss(10)
+		adjustBrainLoss(rand(4,10))
 		Paralyse(2)
 	return
 


### PR DESCRIPTION
Makes brain damage lethal, if you acquire too much of it

- At 100 brain damage you will lapse into a coma where you cannot speak and rapidly accumulate losebreath until you (1) die (2) are treated with multiple drugs to alleviate the losebreath and lower the brain damage below 100.
- at 120 brain damage your brain is past the point of recovery, and you immediately die.
 - Health Analyzer's already display when brain damage has hit 100; "subject is brain dead".
- Brain damage no longer makes your vision blurry or you to drop your stuff/fall down/etc--helps make brain damage a "stealthier" damage type---of course, you still say utterly stupid stuff if your brain damage is 60 or greater.
 - WITHOUT OXIGEN BLOB DON'T EVOLUATE?

Made adjustments to the cloner so that you don't die immediately on being cloned; the amount of brain damage you eject with should be very *similar* to what it is on live, though someone may want to double-check my math there.


Don't do drugs, kids, you just may stupify yourself to literal death.

Other
- Chaplain can heal/brain damage himself with his own Bible now--a nice little buff for him


