### PR TITLE
Mute Changes

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -17,7 +17,7 @@ var/global/normal_ooc_colour = "#002eb8"
 		src << "\red You have OOC muted."
 		return
 
-	if(!holder)
+	if(!(holder && holder.rights && (holder.rights & R_MOD)))
 		if(!ooc_allowed)
 			src << "\red OOC is globally muted"
 			return
@@ -99,7 +99,7 @@ var/global/normal_ooc_colour = "#002eb8"
 		src << "\red You have LOOC muted."
 		return
 
-	if(!holder)
+	if(!(holder && holder.rights && (holder.rights & R_MOD)))
 		if(!ooc_allowed)
 			src << "\red LOOC is globally muted"
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1015,7 +1015,8 @@
 				return
 
 	else if(href_list["mute"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_MOD))
+			return
 
 		var/mob/M = locate(href_list["mute"])
 		if(!ismob(M))	return

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -20,11 +20,11 @@
 
 	var/stafftype = null
 
-	if (src.holder.rights & R_MOD)
-		stafftype = "MOD"
-
 	if (src.holder.rights & R_MENTOR)
 		stafftype = "MENTOR"
+
+	if (src.holder.rights & R_MOD)
+		stafftype = "MOD"
 
 	if (src.holder.rights & R_ADMIN)
 		stafftype = "ADMIN"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -152,15 +152,12 @@ proc/cmd_admin_mute(mob/M as mob, mute_type, automute = 0)
 	else
 		if(!usr || !usr.client)
 			return
-		if(!usr.client.holder)
+		if(!(usr.client.holder && usr.client.holder.rights && (usr.client.holder.rights & R_MOD)))
 			usr << "<font color='red'>Error: cmd_admin_mute: You don't have permission to do this.</font>"
 			return
 		if(!M.client)
 			usr << "<font color='red'>Error: cmd_admin_mute: This mob doesn't have a client tied to it.</font>"
-		if(M.client.holder)
-			usr << "<font color='red'>Error: cmd_admin_mute: You cannot mute an admin.</font>"
 	if(!M.client)		return
-	if(M.client.holder)	return
 
 	var/muteunmute
 	var/mute_string


### PR DESCRIPTION
- R_MOD is now needed to mute players instead of R_ADMIN.
- Admins/mods/mentors can now be muted. The first two can unmute
themselves, the third cannot.
- Global OOC mute now applies to mentors as well, but not to admins or mods.
- Global Deadchat mute still only applies to regular players.
- Individual Deadchat/OOC mutes apply to everyone, but mods/admins can unmute themselves.
- Mods using DSAY will show up as MOD instead of MENTOR (this is a fix, they were previously in the wrong order).

Discussed with @Necaladun and @Fox-McCloud.

The logic behind the first change was to give mods some ability to prevent OOC/deadchat spam if an admin is not around. Being able to mute mentors is something that was requested, this means that they can be muted from any form of communication, including AdminPM, meaning they will be unable to respond to questions or adminPM players.