### PR TITLE
Prevent life reagent from spawning spaceworms

### DIFF
--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -714,7 +714,8 @@ proc/chemical_mob_spawn(var/datum/reagents/holder, var/amount_to_spawn, var/reac
 			/mob/living/simple_animal/hostile/asteroid/hivelord,
 			/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
 			/mob/living/simple_animal/hostile/carp/holocarp,
-			/mob/living/simple_animal/hostile/mining_drone
+			/mob/living/simple_animal/hostile/mining_drone,
+			/mob/living/simple_animal/hostile/spaceWorm
 			)//exclusion list for things you don't want the reaction to create.
 		var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 		var/atom/A = holder.my_atom


### PR DESCRIPTION
Spaceworms are specifically designed as an adminbooze mob- they are NOT
currently balanced to be spawned by any reactions or such. They even can
qdel things that they eat.