### PR TITLE
Adds the most important suicide_act (Toy Katana)

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -430,7 +430,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 /obj/item/toy/katana/suicide_act(mob/user)
-	var/dmsg = pick("[user] tries to stab \the [src] into their abdomen, but it shatters! They looks as if they might die from the shame.","[user] tries to stab \the [src] into their abdomen, but \the [src] bends and breaks in half! They looks as if they might die from the shame.","[user] tries to slice their own throat, but the plastic blade has no sharpness, causing them to lose their balance, slip over, and break their neck with a loud snap!")
+	var/dmsg = pick("[user] tries to stab \the [src] into their abdomen, but it shatters! They look as if they might die from the shame.","[user] tries to stab \the [src] into their abdomen, but \the [src] bends and breaks in half! They look as if they might die from the shame.","[user] tries to slice their own throat, but the plastic blade has no sharpness, causing them to lose their balance, slip over, and break their neck with a loud snap!")
 	user.visible_message("<span class='suicide'>[dmsg] It looks like they are trying to commit suicide.</span>")
 	return (BRUTELOSS)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -429,6 +429,11 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
+/obj/item/toy/katana/suicide_act(mob/user)
+	var/dmsg = pick("[user] tries to stab \the [src] into their abdomen, but it shatters! They looks as if they might die from the shame.","[user] tries to stab \the [src] into their abdomen, but \the [src] bends and breaks in half! They looks as if they might die from the shame.","[user] tries to slice their own throat, but the plastic blade has no sharpness, causing them to lose their balance, slip over, and break their neck with a loud snap!")
+	user.visible_message("<span class='suicide'>[dmsg] It looks like they are trying to commit suicide.</span>")
+	return (BRUTELOSS)
+
 /*
  * Crayons
  */


### PR DESCRIPTION
Lolzy suicide_act for the replica katana, as requested by nomzy-xilia

`Shadow Larkens tries to stab the replica katana into their abdomen, but the replica katana bends and breaks in half! They looks as if they might die from the shame. It looks like they are trying to commit suicide.`

`The unknown tries to cut their own throat, but the plastic blade has no sharpness, causing them to lose their balance, slip over, and break their neck with a loud snap! It looks like they are trying to commit suicide.`

`The unknown tries to stab the replica katana into their abdomen, but it shatters! They looks as if they might die from the shame. It looks like they are trying to commit suicide.`