### PR TITLE
[Goonchem] Poison Traitor Bottles

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -218,6 +218,15 @@ var/list/uplink_items = list()
 	cost = 7
 	job = list("Scientist","Research Director","Geneticist","Chief Medical Officer","Medical Doctor","Psychiatrist","Chemist","Paramedic","Virologist","Brig Physician")
 
+//Tator Poison Bottles
+
+/datum/uplink_item/jobspecific/poisonbottle
+	name = "Poison Bottle"
+	desc = "The Syndicate will ship a bottle containing 40 units of a randomly selected poison. The poison can range from highly irritating to incredibly lethal."
+	item = /obj/item/weapon/reagent_containers/glass/bottle/traitor
+	cost = 2
+	job = list("Scientist","Research Director","Chief Medical Officer","Medical Doctor","Psychiatrist","Chemist","Paramedic","Virologist","Bartender")
+
 // DANGEROUS WEAPONS
 
 /datum/uplink_item/dangerous

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -251,3 +251,15 @@
 	New()
 		..()
 		reagents.add_reagent("formaldehyde", 50)
+
+
+////////////////////Traitor Poison Bottle//////////////////////////////
+
+/obj/item/weapon/reagent_containers/glass/bottle/traitor
+	desc = "It has a small skull and crossbones on it. Uh-oh!"
+	possible_transfer_amounts = list(5,10,15,25,30,40)
+	volume = 40
+
+	New()
+		..()
+		reagents.add_reagent(pick("polonium","initropidril","concentrated_initro","pancuronium","sodium_thiopental","ketamine","sulfonal","amanitin","coniine","curare","sarin","histamine","venom","cyanide"), 40)


### PR DESCRIPTION
An alternate to: https://github.com/ParadiseSS13/Paradise/pull/665

Poison Traitor bottles
- job specific traitor item limited to science, most medical positions (not Geneticist), and the bartender.
- Costs 2 TC
- A bottle will contain 40 units of a randomly selected poison; some poisons can ONLY be gotten via this bottle, such as Initro, Coniine, Polonium, etc.