### PR TITLE
Fix pool controller and picket signs

### DIFF
--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -3,6 +3,7 @@
 	desc = "A controller for the nearby pool."
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_control_standby"
+	anchored = 1 //this is what I get for assuming /obj/machinery has anchored set to 1 by default
 	var/list/linkedturfs = list() //List contains all of the linked pool turfs to this controller, assignment happens on New()
 	var/temperature = "normal" //The temperature of the pool, starts off on normal, which has no effects.
 	var/temperaturecolor = "" //used for nanoUI fancyness

--- a/paradise.dme
+++ b/paradise.dme
@@ -655,6 +655,7 @@
 #include "code\game\objects\items\weapons\scrolls.dm"
 #include "code\game\objects\items\weapons\shards.dm"
 #include "code\game\objects\items\weapons\shields.dm"
+#include "code\game\objects\items\weapons\signs.dm"
 #include "code\game\objects\items\weapons\stunbaton.dm"
 #include "code\game\objects\items\weapons\surgery_tools.dm"
 #include "code\game\objects\items\weapons\swords_axes_etc.dm"


### PR DESCRIPTION
 * Fixes "Hawke: your pool controller is affected by pressure changes n stuff"
 * Fixes #739 

I thought obj/machinery had anchored set to 1 by default, this is what I get for assuming, and git being git means PR #729 removed picket signs from the 'what to compile' list on the DME