### PR TITLE
Chemistry Smoke Changes

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -848,7 +848,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		empulse(P.loc, 3, 6, 1)
 		message += "Your [P] emits a wave of electromagnetic energy!"
 	if(i>=25 && i<=40) //Smoke
-		var/datum/effect/effect/system/chem_smoke_spread/S = new /datum/effect/effect/system/chem_smoke_spread
+		var/datum/effect/effect/system/harmless_smoke_spread/S = new /datum/effect/effect/system/harmless_smoke_spread //Why was this chem_smoke_spread when there are no chems involved?
 		S.attach(P.loc)
 		S.set_up(P, 10, 0, P.loc)
 		playsound(P.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
@@ -884,9 +884,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			message += "It melts in a puddle of plastic."
 		else
 			message += "Your [P] shatters in a thousand pieces!"
-	
+
 	JFLOG("[M]'s PDA Detonated >>> [message]")
-	
+
 	if(M && isliving(M))
 		message = "\red" + message
 		M.show_message(message, 1)
@@ -1402,26 +1402,26 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		A.emp_act(severity)
 
 /**
-*	
+*
 *	JFLOG
-*	
+*
 *	These functions as well as all the log statements are being used to gather user data for how
-*	people are using the PDA files with the intent of revising them based on this data. 
-*	
-*	They are being added on 28/03/2015 and the intent is to remove them in two weeks. If you're 
-*	reading this and it's substantially past that point, you should remove anything marked with 
-*	'JFLOG'. 
-*	
-*	All changes should be contained to PDA.dm except the creation function which is contained in 
+*	people are using the PDA files with the intent of revising them based on this data.
+*
+*	They are being added on 28/03/2015 and the intent is to remove them in two weeks. If you're
+*	reading this and it's substantially past that point, you should remove anything marked with
+*	'JFLOG'.
+*
+*	All changes should be contained to PDA.dm except the creation function which is contained in
 *	job_controller.dm.
-*	
-*																				- Jack Fractal	
+*
+*																				- Jack Fractal
 **/
 
 
 /obj/item/device/pda/proc/JFLOG_DescribeSelf()
 	return "([src]|[cartridge ? cartridge.name : "None"])"
-	
+
 /obj/item/device/pda/proc/JFLOG(message as text)
 	if (config)
 		log_pda("[JFLOG_DescribeSelf()] >>> [message]")

--- a/code/modules/events/tgevents/vent_clog.dm
+++ b/code/modules/events/tgevents/vent_clog.dm
@@ -32,5 +32,5 @@
 		var/datum/effect/effect/system/chem_smoke_spread/smoke = new
 		smoke.set_up(R, rand(1, 2), 0, vent, 0, silent = 1)
 		playsound(vent.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
-		smoke.start()
+		smoke.start(3)
 		R.delete()	//GC the reagents

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -54,15 +54,6 @@
 
 				breath = loc.remove_air(breath_moles)
 
-				// Handle chem smoke effect  -- Doohl
-				for(var/obj/effect/effect/chem_smoke/smoke in view(1, src))
-					if(smoke.reagents.total_volume)
-						smoke.reagents.reaction(src, INGEST)
-						spawn(5)
-							if(smoke)
-								smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?
-						break // If they breathe in the nasty stuff once, no need to continue checking
-
 
 		else //Still give containing object the chance to interact
 			if(istype(loc, /obj/))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -369,28 +369,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 							if(prob(5))
 								rupture_lung()
 
-					// Handle chem smoke effect  -- Doohl
-					var/block = 0
-					if(wear_mask)
-						if(wear_mask.flags & BLOCK_GAS_SMOKE_EFFECT)
-							block = 1
-					if(glasses)
-						if(glasses.flags & BLOCK_GAS_SMOKE_EFFECT)
-							block = 1
-					if(head)
-						if(head.flags & BLOCK_GAS_SMOKE_EFFECT)
-							block = 1
-
-					if(!block)
-
-						for(var/obj/effect/effect/chem_smoke/smoke in view(1, src))
-							if(smoke.reagents.total_volume)
-								smoke.reagents.reaction(src, INGEST)
-								spawn(5)
-									if(smoke)
-										smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?
-								break // If they breathe in the nasty stuff once, no need to continue checking
-
 			else //Still give containing object the chance to interact
 				if(istype(loc, /obj/))
 					var/obj/location_as_object = loc

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -250,21 +250,6 @@
 					var/breath_moles = environment.total_moles()*BREATH_PERCENTAGE
 					breath = loc.remove_air(breath_moles)
 
-					// Handle chem smoke effect  -- Doohl
-					var/block = 0
-					if(wear_mask)
-						if(istype(wear_mask, /obj/item/clothing/mask/gas))
-							block = 1
-
-					if(!block)
-
-						for(var/obj/effect/effect/chem_smoke/smoke in view(1, src))
-							if(smoke.reagents.total_volume)
-								smoke.reagents.reaction(src, INGEST)
-								spawn(5)
-									if(smoke)
-										smoke.reagents.copy_to(src, 10) // I dunno, maybe the reagents enter the blood stream through the lungs?
-								break // If they breathe in the nasty stuff once, no need to continue checking
 
 
 			else //Still give containing object the chance to interact

--- a/code/modules/reagents/newchem/food.dm
+++ b/code/modules/reagents/newchem/food.dm
@@ -119,12 +119,12 @@ datum/reagent/honey/on_mob_life(var/mob/living/M as mob)
 	M.reagents.add_reagent("sugar", 0.8)
 	..()
 	return
-/*        //Commenting this out until smoke is rewritten, otherwise, this spam so much honeycomb it's not funny
+
 datum/reagent/honey/reaction_turf(var/turf/T, var/volume)
 	src = null
 	if(volume >= 5)
 		new /obj/item/weapon/reagent_containers/food/snacks/honeycomb(T)
-		return */
+		return
 
 /datum/reagent/mugwort
 	name = "Mugwort"

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -94,13 +94,12 @@ datum/reagent/synthflesh/reaction_mob(var/mob/living/M, var/method=TOUCH, var/vo
 	..()
 	return
 
-/*      //again, not until smoke rewrite--so many gibs,aghh!
 datum/reagent/synthflesh/reaction_turf(var/turf/T, var/volume) //let's make a mess!
 	src = null
 	if(volume >= 5)
 		new /obj/effect/decal/cleanable/blood/gibs(T)
 		playsound(T, 'sound/effects/splat.ogg', 50, 1, -3)
-		return */
+		return
 
 datum/reagent/charcoal
 	name = "Charcoal"

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -260,50 +260,40 @@
 	name = "smoke_powder"
 	id = "smoke_powder"
 	result = "smoke_powder"
+	required_reagents = list("stabilizing_agent" = 1, "potassium" = 1, "sugar" = 1, "phosphorus" = 1)
+	result_amount = 1
+
+/datum/chemical_reaction/smoke
+	name = "smoke"
+	id = "smoke"
+	result = null
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
-	result_amount = 3
+	result_amount = 1
 
+/datum/chemical_reaction/smoke/on_reaction(var/datum/reagents/holder, var/created_volume)
+	var/forbidden_reagents = list(id, "sugar", "phosphorus", "potassium") //Do not transfer this stuff through smoke.
+	for(var/f_reagent in forbidden_reagents)
+		if(holder.has_reagent(f_reagent))
+			holder.remove_reagent(f_reagent, holder.get_reagent_amount(f_reagent))
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect/effect/system/chem_smoke_spread/S = new /datum/effect/effect/system/chem_smoke_spread
+	S.attach(location)
+	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
+	spawn(0)
+		if(S)
+			S.set_up(holder, 10, 0, location)
+			S.start(created_volume >= 10 ? 3 : 2)
+		if(holder && holder.my_atom)
+			holder.clear_reagents()
+	return
 
-/datum/chemical_reaction/smoke_powder_smoke
+/datum/chemical_reaction/smoke/smoke_powder
 	name = "smoke_powder_smoke"
 	id = "smoke_powder_smoke"
-	result = null
 	required_reagents = list("smoke_powder" = 1)
 	required_temp = 374
 	secondary = 1
-
-/datum/chemical_reaction/smoke_powder_smoke/on_reaction(var/datum/reagents/holder, var/created_volume)
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect/effect/system/chem_smoke_spread/S = new /datum/effect/effect/system/chem_smoke_spread
-	S.attach(location)
-	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-	spawn(0)
-		if(S)
-			S.set_up(holder, 10, 0, location)
-			S.start()
-			sleep(10)
-			S.start()
-		if(holder && holder.my_atom)
-			holder.clear_reagents()
-	return
-
-/datum/chemical_reaction/smoke_powder/on_reaction(var/datum/reagents/holder, var/created_volume)
-	if(holder.has_reagent("stabilizing_agent"))
-		return
-	holder.remove_reagent("smoke_powder", created_volume)
-	var/location = get_turf(holder.my_atom)
-	var/datum/effect/effect/system/chem_smoke_spread/S = new /datum/effect/effect/system/chem_smoke_spread
-	S.attach(location)
-	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
-	spawn(0)
-		if(S)
-			S.set_up(holder, 10, 0, location)
-			S.start()
-			sleep(10)
-			S.start()
-		if(holder && holder.my_atom)
-			holder.clear_reagents()
-	return
+	result_amount = 1
 
 /datum/reagent/sonic_powder
 	name = "Sonic Powder"


### PR DESCRIPTION
- Changes smoke so that it immediately affects all mobs in its area of effect, smoke clouds are purely visual.
 - Any mobs in the area of effect of a smoke reaction will be affected by the smoke's touch reaction, and have all reagents in the smoke container transferred into them.
- Smoke clouds are no longer opaque.
- Mixing 10u potassium, 10u sugar, and 10u phosphorus or higher will
cause an area of effect with a radius of 3 from the point of reaction. Any less will have a radius of 2.
- Same with heating 10u smoke powder.
- Smoke powder reaction now only yields 1 powder instead of 3.
- Vent clog event has a radius 3 area of effect, all other smoke effects by default should have a radius of 2
- Re-enables turf reactions for honey and synthflesh.
- Adds list of reagents for smoke not to transfer, includes sugar, phosphorus, potassium, and the smoke "reagent".

Requested by @Fox-McCloud 

Yes, this means smoke no longer procs 5+ times for everything within its range repeatedly, meaning acid smoke no longer instantly destroys all life, it's still going to hurt and poison you though.