### PR TITLE
[Goonchem] Reagent Temperatures

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -319,13 +319,23 @@ to destroy them and players will be able to make replacements.
 	build_path = /obj/machinery/chem_dispenser/constructable
 	board_type = "machine"
 	origin_tech = "materials=4;engineering=4;programming=4;plasmatech=3;biotech=3"
-	frame_desc = "Requires 1 Matter Bin, 1 Capacitor, 1 Manipulator, 1 Console Screen, and 1 Power Cell."
+	frame_desc = "Requires 2 Matter Bins, 1 Capacitor, 1 Manipulator, 1 Console Screen, and 1 Power Cell."
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 2,
 							/obj/item/weapon/stock_parts/capacitor = 1,
 							/obj/item/weapon/stock_parts/manipulator = 1,
 							/obj/item/weapon/stock_parts/console_screen = 1,
 							/obj/item/weapon/stock_parts/cell = 1)
+
+/obj/item/weapon/circuitboard/chem_heater
+	name = "circuit board (Chemical Heater)"
+	build_path = /obj/machinery/chem_heater
+	board_type = "machine"
+	origin_tech = "materials=2;engineering=2"
+	frame_desc = "Requires 1 Micro Laser and 1 Console Screen."
+	req_components = list(
+							/obj/item/weapon/stock_parts/micro_laser = 1,
+							/obj/item/weapon/stock_parts/console_screen = 1)
 
 /obj/item/weapon/circuitboard/destructive_analyzer
 	name = "Circuit board (Destructive Analyzer)"

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -112,7 +112,7 @@ datum
 					if(preserve_data)
 						trans_data = copy_data(current_reagent)
 
-					R.add_reagent(current_reagent.id, (current_reagent_transfer * multiplier), trans_data)
+					R.add_reagent(current_reagent.id, (current_reagent_transfer * multiplier), trans_data, src.chem_temp)
 					src.remove_reagent(current_reagent.id, current_reagent_transfer)
 
 				src.update_total()
@@ -205,7 +205,7 @@ datum
 					if(current_reagent.id == reagent)
 						if(preserve_data)
 							trans_data = copy_data(current_reagent)
-						R.add_reagent(current_reagent.id, amount, trans_data)
+						R.add_reagent(current_reagent.id, amount, trans_data, src.chem_temp)
 						src.remove_reagent(current_reagent.id, amount, 1)
 						break
 
@@ -325,7 +325,7 @@ datum
 								if(C.result)
 									feedback_add_details("chemical_reaction","[C.result]|[C.result_amount*multiplier]")
 									multiplier = max(multiplier, 1) //this shouldnt happen ...
-									add_reagent(C.result, C.result_amount*multiplier)
+									add_reagent(C.result, C.result_amount*multiplier, null, chem_temp)
 									set_data(C.result, preserved_data)
 
 									//add secondary products
@@ -436,10 +436,11 @@ datum
 									else R.reaction_obj(A, R.volume+volume_modifier)
 				return
 
-			add_reagent(var/reagent, var/amount, var/list/data=null)
+			add_reagent(var/reagent, var/amount, var/list/data=null, var/reagtemp = 300)
 				if(!isnum(amount)) return 1
 				update_total()
 				if(total_volume + amount > maximum_volume) amount = (maximum_volume - total_volume) //Doesnt fit in. Make it disappear. Shouldnt happen. Will happen.
+				chem_temp = round(((amount * reagtemp) + (total_volume * chem_temp)) / (total_volume + amount)) //equalize with new chems
 
 				for(var/A in reagent_list)
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -325,7 +325,7 @@ datum
 								if(C.result)
 									feedback_add_details("chemical_reaction","[C.result]|[C.result_amount*multiplier]")
 									multiplier = max(multiplier, 1) //this shouldnt happen ...
-									add_reagent(C.result, C.result_amount*multiplier, null, chem_temp)
+									add_reagent(C.result, C.result_amount*multiplier)
 									set_data(C.result, preserved_data)
 
 									//add secondary products

--- a/code/modules/reagents/newchem/chem_heater.dm
+++ b/code/modules/reagents/newchem/chem_heater.dm
@@ -32,9 +32,9 @@
 	if(on)
 		if(beaker)
 			if(beaker.reagents.chem_temp > desired_temp)
-				beaker.reagents.chem_temp += min(-1, (desired_temp - beaker.reagents.chem_temp) * heater_coefficient)
+				beaker.reagents.chem_temp += min(-1, max((desired_temp - beaker.reagents.chem_temp) * heater_coefficient, -15))
 			if(beaker.reagents.chem_temp < desired_temp)
-				beaker.reagents.chem_temp += max(1, (desired_temp - beaker.reagents.chem_temp) * heater_coefficient)
+				beaker.reagents.chem_temp += max(1, min((desired_temp - beaker.reagents.chem_temp) * heater_coefficient, 15))
 			beaker.reagents.chem_temp = round(beaker.reagents.chem_temp) //stops stuff like 456.12312312302
 
 			beaker.reagents.handle_reactions()

--- a/code/modules/reagents/newchem/chem_heater.dm
+++ b/code/modules/reagents/newchem/chem_heater.dm
@@ -7,10 +7,22 @@
 	use_power = 1
 	idle_power_usage = 40
 	var/obj/item/weapon/reagent_containers/beaker = null
-	var/temperature = 300
-	var/rate = 15 //heating/cooling rate, default is 10 kelvin per tick
+	var/desired_temp = 300
+	var/heater_coefficient = 0.03
 	var/on = FALSE
 
+/obj/machinery/chem_heater/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/chem_heater(src)
+	component_parts += new /obj/item/weapon/stock_parts/micro_laser(src)
+	component_parts += new /obj/item/weapon/stock_parts/console_screen(src)
+	RefreshParts()
+
+/obj/machinery/chem_heater/RefreshParts()
+	heater_coefficient = 0.03
+	for(var/obj/item/weapon/stock_parts/micro_laser/M in component_parts)
+		heater_coefficient *= M.rating
 
 /obj/machinery/chem_heater/process()
 	..()
@@ -19,14 +31,15 @@
 	var/state_change = 0
 	if(on)
 		if(beaker)
-			if(beaker.reagents.chem_temp > temperature)
-				beaker.reagents.chem_temp = max(beaker.reagents.chem_temp-rate, temperature)
-				beaker.reagents.handle_reactions()
-				state_change = 1
-			else if(beaker.reagents.chem_temp < temperature)
-				beaker.reagents.chem_temp = min(beaker.reagents.chem_temp+rate, temperature)
-				beaker.reagents.handle_reactions()
-				state_change = 1
+			if(beaker.reagents.chem_temp > desired_temp)
+				beaker.reagents.chem_temp += min(-1, (desired_temp - beaker.reagents.chem_temp) * heater_coefficient)
+			if(beaker.reagents.chem_temp < desired_temp)
+				beaker.reagents.chem_temp += max(1, (desired_temp - beaker.reagents.chem_temp) * heater_coefficient)
+			beaker.reagents.chem_temp = round(beaker.reagents.chem_temp) //stops stuff like 456.12312312302
+
+			beaker.reagents.handle_reactions()
+			state_change = 1
+
 	if(state_change)
 		nanomanager.update_uis(src)
 
@@ -36,6 +49,7 @@
 		beaker.reagents.handle_reactions()
 		beaker = null
 		icon_state = "mixer0b"
+		on = FALSE
 		nanomanager.update_uis(src)
 
 /obj/machinery/chem_heater/power_change()
@@ -62,6 +76,18 @@
 			icon_state = "mixer1b"
 			nanomanager.update_uis(src)
 
+	if(default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I))
+		return
+
+	if(exchange_parts(user, I))
+		return
+
+	if(panel_open)
+		if(istype(I, /obj/item/weapon/crowbar))
+			eject_beaker()
+			default_deconstruction_crowbar(I)
+			return 1
+
 /obj/machinery/chem_heater/attack_hand(var/mob/user as mob)
 	ui_interact(user)
 
@@ -80,9 +106,9 @@
 	if(href_list["adjust_temperature"])
 		var/val = href_list["adjust_temperature"]
 		if(isnum(val))
-			temperature = Clamp(temperature+val, 0, 1000)
+			desired_temp = Clamp(desired_temp+val, 0, 1000)
 		else if(val == "input")
-			temperature = Clamp(input("Please input the target temperature", name) as num, 0, 1000)
+			desired_temp = Clamp(input("Please input the target temperature", name) as num, 0, 1000)
 		else
 			return 0
 		. = 1
@@ -95,7 +121,7 @@
 	if(user.stat || user.restrained()) return
 
 	var/data[0]
-	data["targetTemp"] = temperature
+	data["targetTemp"] = desired_temp
 	data["isActive"] = on
 	data["isBeakerLoaded"] = beaker ? 1 : 0
 

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -346,7 +346,7 @@ datum/reagent/crank/addiction_act_stage4(var/mob/living/M as mob)
 	return
 
 /datum/chemical_reaction/aranesp
-	name = "aranesp"
+	name = "Aranesp"
 	id = "aranesp"
 	result = "aranesp"
 	required_reagents = list("epinephrine" = 1, "atropine" = 1, "insulin" = 1)
@@ -361,14 +361,14 @@ datum/reagent/crank/addiction_act_stage4(var/mob/living/M as mob)
 
 /datum/reagent/aranesp/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
-	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
+	var/high_message = pick("You feel like you're made of steel!", "You feel invigorated!", "You feel really buff!", "You feel on top of the world!", "You feel full of energy!")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
 	M.adjustStaminaLoss(-35)
 	M.adjustToxLoss(1)
-	if(prob(rand(1,100)))
-		M.losebreath++
-		M.adjustOxyLoss(20)
+	if(prob(3))
+		M.losebreath += 2
+		M.Stun(2)
 	..()
 	return
 

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -16,7 +16,7 @@
 	id = "stabilizing_agent"
 	result = "stabilizing_agent"
 	required_reagents = list("iron" = 1, "oxygen" = 1, "hydrogen" = 1)
-	result_amount = 3
+	result_amount = 2
 	mix_message = "The mixture becomes a yellow liquid!"
 
 /datum/reagent/clf3

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -112,6 +112,16 @@
 	build_path = /obj/item/weapon/circuitboard/chem_dispenser
 	category = list("Medical Machinery")
 
+/datum/design/chem_heater
+	name = "Machine Design (Chemical Heater Board)"
+	desc = "The circuit board for a chemical heater."
+	id = "chem_heater"
+	req_tech = list("engineering" = 2, "materials" = 2)
+	build_type = IMPRINTER
+	materials = list("$glass" = 1000, "sacid" = 20)
+	build_path = /obj/item/weapon/circuitboard/chem_heater
+	category = list ("Medical Machinery")
+
 /datum/design/sleeper
 	name = "Machine Board (Sleeper)"
 	desc = "Allows for the construction of circuit boards used to build a Sleeper."


### PR DESCRIPTION
Dramatically improves reagent temperature handling

- Beakers won't hold temperature values indefinitely (meaning empty beakers won't have any temperature)
- temperature values between two mixed reagents will now equalize based on temperature AND volume
- When a chemical reaction occurs, it will not retain its prior temperature (meaning if you make space drugs into neurotoxin, the temperature of neurotoxin will be 300 not 674).

Chem Heater changes

- Can now Build and upgrade chem heaters (better laser = faster heating)
- Rate at which temperature increases/decreases scales with the temperature differences between the reagents in the beaker and your target temperature (meaning the closer you get to your target, the slower it heats/cools).
- Chem Heater will automatically shut off when the beaker is ejected

Other Reagent related
- Improved on Aranesp's accuracy/behavior.