### PR TITLE
[Goonchem] Acid Rework

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -716,61 +716,35 @@ datum
 			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
 				if(!istype(M, /mob/living))
 					return
-				if(method == TOUCH)
+				if(method == TOUCH || method == INGEST)
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
 
-						if(H.wear_mask)
-							if(!H.wear_mask.unacidable)
-								del (H.wear_mask)
-								H.update_inv_wear_mask()
-								H << "\red Your mask melts away but protects you from the acid!"
-							else
-								H << "\red Your mask protects you from the acid!"
-							return
+						if(volume > 25)
 
-						if(H.head)
-							if(prob(15) && !H.head.unacidable)
-								del(H.head)
-								H.update_inv_head()
-								H << "\red Your helmet melts away but protects you from the acid"
-							else
-								H << "\red Your helmet protects you from the acid!"
-							return
+							if(method == TOUCH)
+								if(H.wear_mask)
+									H << "\red Your mask protects you from the acid!"
+									return
 
-					else if(ismonkey(M))
-						var/mob/living/carbon/monkey/MK = M
-						if(MK.wear_mask)
-							if(!MK.wear_mask.unacidable)
-								del (MK.wear_mask)
-								MK.update_inv_wear_mask()
-								MK << "\red Your mask melts away but protects you from the acid!"
-							else
-								MK << "\red Your mask protects you from the acid!"
-							return
+								if(H.head)
+									H << "\red Your helmet protects you from the acid!"
+									return
 
-					if(!M.unacidable)
-						if(prob(15) && istype(M, /mob/living/carbon/human) && volume >= 30)
-							var/mob/living/carbon/human/H = M
-							var/obj/item/organ/external/affecting = H.get_organ("head")
-							if(affecting)
-								if(affecting.take_damage(25, 0))
-									H.UpdateDamageIcon()
-								H.status_flags |= DISFIGURED
-								H.emote("scream")
+							if(!M.unacidable)
+								if(prob(75))
+									var/obj/item/organ/external/affecting = H.get_organ("head")
+									if(affecting)
+										affecting.take_damage(20, 0)
+										H.UpdateDamageIcon()
+										H.emote("scream")
+								else
+									M.take_organ_damage(15,0)
 						else
-							M.take_organ_damage(min(15, volume * 2)) // uses min() and volume to make sure they aren't being sprayed in trace amounts (1 unit != insta rape) -- Doohl
-				else
-					if(!M.unacidable)
-						M.take_organ_damage(min(15, volume * 2))
+							M.take_organ_damage(15,0)
 
 			reaction_obj(var/obj/O, var/volume)
-				if(istype(O,/obj/item/weapon/organ/head))
-					new/obj/item/weapon/skeleton/head(O.loc)
-					for(var/mob/M in viewers(5, O))
-						M << "\red \the [O] melts."
-					del(O)
-				if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)) && prob(10))
+				if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)) && prob(40))
 					if(!O.unacidable)
 						var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
 						I.desc = "Looks like this was \an [O] some time ago."

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -716,20 +716,19 @@ datum
 			reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
 				if(!istype(M, /mob/living))
 					return
-				if(method == TOUCH || method == INGEST)
+				if(method == TOUCH)
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
 
 						if(volume > 25)
 
-							if(method == TOUCH)
-								if(H.wear_mask)
-									H << "\red Your mask protects you from the acid!"
-									return
+							if(H.wear_mask)
+								H << "\red Your mask protects you from the acid!"
+								return
 
-								if(H.head)
-									H << "\red Your helmet protects you from the acid!"
-									return
+							if(H.head)
+								H << "\red Your helmet protects you from the acid!"
+								return
 
 							if(!M.unacidable)
 								if(prob(75))
@@ -742,6 +741,30 @@ datum
 									M.take_organ_damage(15,0)
 						else
 							M.take_organ_damage(15,0)
+
+				if(method == INGEST)
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+
+						if(volume < 10)
+							M << "<span class = 'danger'>The greenish acidic substance stings you, but isn't concentrated enough to harm you!</span>"
+
+						if(volume >=10 && volume <=25)
+							if(!H.unacidable)
+								M.take_organ_damage(min(max(volume-10,2)*2,20),0)
+								M.emote("scream")
+
+
+						if(volume > 25)
+							if(!M.unacidable)
+								if(prob(75))
+									var/obj/item/organ/external/affecting = H.get_organ("head")
+									if(affecting)
+										affecting.take_damage(20, 0)
+										H.UpdateDamageIcon()
+										H.emote("scream")
+								else
+									M.take_organ_damage(15,0)
 
 			reaction_obj(var/obj/O, var/volume)
 				if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)) && prob(40))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -377,7 +377,7 @@ datum
 			id = "sacid"
 			result = "sacid"
 			required_reagents = list("sulfur" = 1, "oxygen" = 1, "hydrogen" = 1)
-			result_amount = 3
+			result_amount = 2
 			mix_message = "The mixture gives off a sharp acidic tang."
 
 ///////Changeling Blood Test/////////////

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -231,6 +231,15 @@ datum/reagent/facid/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 
+			if(volume < 5)
+				M << "<span class = 'danger'>The blueish acidic substance stings you, but isn't concentrated enough to harm you!</span>"
+
+			if(volume >=5 && volume <=10)
+				if(!H.unacidable)
+					M.take_organ_damage(max(volume-5,2)*4,0)
+					M.emote("scream")
+
+
 			if(volume > 10)
 
 				if(method == TOUCH)

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -227,65 +227,39 @@ datum/reagent/facid
 datum/reagent/facid/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
 	if(!istype(M, /mob/living))
 		return //wooo more runtime fixin
-	if(method == TOUCH)
+	if(method == TOUCH || method == INGEST)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 
-			if(H.wear_mask)
-				if(!H.wear_mask.unacidable)
-					qdel (H.wear_mask)
-					H.update_inv_wear_mask()
-					H << "\red Your mask melts away but protects you from the acid!"
-				else
-					H << "\red Your mask protects you from the acid!"
-				return
+			if(volume > 10)
 
-			if(H.head)
-				if(prob(15) && !H.head.unacidable)
-					qdel(H.head)
-					H.update_inv_head()
-					H << "\red Your helmet melts away but protects you from the acid"
-				else
-					H << "\red Your helmet protects you from the acid!"
-				return
+				if(method == TOUCH)
+					if(H.wear_mask)
+						if(!H.wear_mask.unacidable)
+							qdel (H.wear_mask)
+							H.update_inv_wear_mask()
+							H << "\red Your mask melts away but protects you from the acid!"
+						else
+							H << "\red Your mask protects you from the acid!"
+						return
 
-			if(!H.unacidable)
-				var/obj/item/organ/external/affecting = H.get_organ("head")
-				if(affecting.take_damage(15, 0))
+					if(H.head)
+						if(!H.head.unacidable)
+							qdel(H.head)
+							H.update_inv_head()
+							H << "\red Your helmet melts away but protects you from the acid"
+						else
+							H << "\red Your helmet protects you from the acid!"
+						return
+
+				if(!H.unacidable)
+					var/obj/item/organ/external/affecting = H.get_organ("head")
+					affecting.take_damage(75, 0)
 					H.UpdateDamageIcon()
-				H.emote("scream")
-		else if(ismonkey(M))
-			var/mob/living/carbon/monkey/MK = M
-
-			if(MK.wear_mask)
-				if(!MK.wear_mask.unacidable)
-					qdel (MK.wear_mask)
-					MK.update_inv_wear_mask()
-					MK << "\red Your mask melts away but protects you from the acid!"
-				else
-					MK << "\red Your mask protects you from the acid!"
-				return
-
-			if(!MK.unacidable)
-				MK.take_organ_damage(min(15, volume * 4)) // same deal as sulphuric acid
-	else
-		if(!M.unacidable)
-			if(ishuman(M))
-				var/mob/living/carbon/human/H = M
-				var/obj/item/organ/external/affecting = H.get_organ("head")
-				if(affecting.take_damage(15, 0))
-					H.UpdateDamageIcon()
-				H.emote("scream")
-				H.status_flags |= DISFIGURED
-			else
-				M.take_organ_damage(min(15, volume * 4))
+					H.emote("scream")
+					H.status_flags |= DISFIGURED
 
 datum/reagent/facid/reaction_obj(var/obj/O, var/volume)
-	if(istype(O,/obj/item/weapon/organ/head))
-		new/obj/item/weapon/skeleton/head(O.loc)
-		for(var/mob/M in viewers(5, O))
-			M << "\red \the [O] melts."
-		qdel(O)
 	if((istype(O,/obj/item) || istype(O,/obj/effect/glowshroom)))
 		if(!O.unacidable)
 			var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)
@@ -293,6 +267,7 @@ datum/reagent/facid/reaction_obj(var/obj/O, var/volume)
 			for(var/mob/M in viewers(5, O))
 				M << "\red \the [O] melts."
 			qdel(O)
+
 /datum/chemical_reaction/facid
 	name = "Fluorosulfuric Acid"
 	id = "facid"


### PR DESCRIPTION
Reworks Acid

- Acid will become very very weak compared to its current status, post smoke rework---while acid definitely needed a nerf, it'll be to the point it just won't really be viable to weaponize.

In either case, this reworks acid---how it will work:

Sulfuric
- If you splash/ingest over 25 units it will deal 20 brute damage to the face and make them scream; if the person being splashed has a mask or hat, it will block the damage (the mask/hat isn't destroyed); obviously hat/mask don't block ingest damage.
- If you splashed/ingested under 25 units it will do 15 damage, regardless of mask/hat or not

Fluorosulfuric Acid
- If you splash/ingest over 10 units it will deal 75 brute damage to the face and make them scream; if the person being splashed has a mask or helmet it will melt them (obviously, again, this doesn't apply to ingesting it); obviously the hat/mask don't block ingest damage.
- If under 10 units is splashed/ingested, it doesn't do anything special.

On the surface 75 brute seems like a lot, but consider the former acid would deal over 200 damage in the span of about 1 second, so this is a hugely gigantic nerf to this acid while still keeping it somewhat relevant with new smoke.