### PR TITLE
Fix a minor annoyance with alien nests

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -23,7 +23,7 @@
 					return
 				buckled_mob.visible_message(\
 					"<span class='warning'>[buckled_mob.name] struggles to break free of the gelatinous resin...</span>",\
-					"<span class='warning'>You struggle to break free from the gelatinous resin... (Stay still for two minutes.)</span>",\
+					"<span class='warning'>You struggle to break free from the gelatinous resin... (This will take around 2 minutes and you need to stay still)</span>",\
 					"<span class='notice'>You hear squelching...</span>")
 				spawn(NEST_RESIST_TIME)
 					if(user && buckled_mob && user.buckled == src)

--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -23,7 +23,7 @@
 					return
 				buckled_mob.visible_message(\
 					"<span class='warning'>[buckled_mob.name] struggles to break free of the gelatinous resin...</span>",\
-					"<span class='warning'>You struggle to break free from the gelatinous resin...</span>",\
+					"<span class='warning'>You struggle to break free from the gelatinous resin... (Stay still for two minutes.)</span>",\
 					"<span class='notice'>You hear squelching...</span>")
 				spawn(NEST_RESIST_TIME)
 					if(user && buckled_mob && user.buckled == src)


### PR DESCRIPTION
The alien nest allows people to unbuckle themselves from it if they click it and wait. However, in my experience, no one knows this because it doesn't inform you of how long it will take, unlike literally every other bed/stool/chair/anything, and it also requires clicking on it instead of resisting. 
 
Also: https://github.com/tgstation/-tg-station/blob/master/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm#L21