### PR TITLE
Nar'sie can now eat the singularity

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -486,6 +486,7 @@ var/global/list/uneatable = list(
 	current_size = 9 //It moves/eats like a max-size singulo, aside from range. --NEO
 	contained = 0 //Are we going to move around?
 	dissipate = 0 //Do we lose energy over time?
+	energy = 10000 //No more Singuloth eating Nar'sie 
 	move_self = 1 //Do we move on our own?
 	grav_pull = 10 //How many tiles out do we pull?
 	consume_range = 3 //How many tiles out do we eat


### PR DESCRIPTION
Due to Nar'sie starting with either 0 or 50 energy, any singularity would destroy Nar'sie, so a guy with two Bluespace Backpacks would win vs Nar'sie. Now only the greatest of Lord Singuloths can stand a chance against Nar'sie