### PR TITLE
Nukies--Chemsprayer and New Grenades

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -279,12 +279,11 @@ var/list/uplink_items = list()
 	cost = 8
 	gamemodes = list("nuclear emergency")
 
-/datum/uplink_item/dangerous/bioterror
-	name = "Biohazardous Chemical Sprayer"
-	desc = "A chemical sprayer that allows a wide dispersal of selected chemicals. Especially tailored by the Tiger Cooperative, the deadly blend it comes stocked with will disorient, damage, and disable your foes... \
-	Use with extreme caution, to prevent exposure to yourself and your fellow operatives."
-	item = /obj/item/weapon/reagent_containers/spray/chemsprayer/bioterror
-	cost = 20
+/datum/uplink_item/dangerous/saringrenades
+	name = "Sarin Gas Grenades"
+	desc = "A box of four (4) grenades filled with sarin, a deadly neurotoxin. Use extreme caution when handling and be sure to vacate the premise after using; ensure communication is maintaind with team to avoid accidental gassings."
+	item = /obj/item/weapon/storage/box/syndie_kit/sarin
+	cost = 15
 	gamemodes = list("nuclear emergency")
 
 /datum/uplink_item/dangerous/emp

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -478,6 +478,25 @@
 		beakers += B2
 		update_icon()
 
+/obj/item/weapon/grenade/chem_grenade/saringas
+	payload_name = "saringas"
+	desc = "Contains sarin gas; extremely deadly and fast acting; use with extreme caution."
+	stage = READY
+
+	New()
+		..()
+		var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
+		var/obj/item/weapon/reagent_containers/glass/beaker/B2 = new(src)
+
+		B1.reagents.add_reagent("sarin", 25)
+		B1.reagents.add_reagent("potassium", 25)
+		B2.reagents.add_reagent("phosphorus", 25)
+		B2.reagents.add_reagent("sugar", 25)
+
+		beakers += B1
+		beakers += B2
+		update_icon()
+
 #undef EMPTY
 #undef WIRED
 #undef READY

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -186,3 +186,13 @@
 		new /obj/item/weapon/grenade/empgrenade(src)
 		new /obj/item/weapon/implanter/emp/(src)
 		new /obj/item/device/flashlight/emp/(src)
+
+/obj/item/weapon/storage/box/syndie_kit/sarin
+	name = "Sarin Gas Grenades"
+
+	New()
+		..()
+		new /obj/item/weapon/grenade/chem_grenade/saringas(src)
+		new /obj/item/weapon/grenade/chem_grenade/saringas(src)
+		new /obj/item/weapon/grenade/chem_grenade/saringas(src)
+		new /obj/item/weapon/grenade/chem_grenade/saringas(src)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1450,21 +1450,6 @@ datum
 			reagent_state = LIQUID
 			color = "#322D00"
 
-		Spores
-			name = "Spores"
-			id = "spores"
-			description = "A toxic spore cloud which blocks vision when ingested."
-			reagent_state = LIQUID
-			color = "#9ACD32" // rgb: 0, 51, 51
-
-			on_mob_life(var/mob/living/M as mob)
-				if(!M) M = holder.my_atom
-				M.adjustToxLoss(0.5*REM)
-				..()
-				M.damageoverlaytemp = 60
-				M.eye_blurry = max(M.eye_blurry, 3)
-				return
-
 		beer2	//disguised as normal beer for use by emagged brobots
 			name = "Beer"
 			id = "beer2"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -206,13 +206,6 @@
 	amount_per_transfer_from_this = (amount_per_transfer_from_this == 10 ? 5 : 10)
 	user << "<span class='notice'>You adjust the output switch. You'll now use [amount_per_transfer_from_this] units per spray.</span>"
 
-/obj/item/weapon/reagent_containers/spray/chemsprayer/bioterror/New()
-	..()
-	reagents.add_reagent("spores", 150)
-	reagents.add_reagent("cryptobiolin", 150)
-	reagents.add_reagent("mutagen", 150)
-	reagents.add_reagent("pancuronium", 150)
-
 
 // Plant-B-Gone
 /obj/item/weapon/reagent_containers/spray/plantbgone // -- Skie


### PR DESCRIPTION
Due to changes to chems, a lot of them no longer penetrate the skin---this is generally good for balance, but it very negatively impacts one of nuke ops uplink items; the bio terror chemsprayer; none of the reagents would cause any incapacitation; only the mutate chance of mutagen would apply since the other chems wouldn't penetrate the skin.....'sides this item was already kinda overpriced and underused so.....

What's being done about this?

- Removes the bioterror chemsprayer
 - Also removes its associated unique reagent "spores"

Adds in a new grenade kit for nukies instead
- Nukies can now purchase a box of 4 sarin gas grenades for a total price of 15 TC
 - With new smoke these should be pretty effective against crowds; use extreme caution with these; it's VERY easy to gas yourself or your team-mates!