### PR TITLE
Fix ID examine gender, Agent card overhaul

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -510,7 +510,7 @@ var/global/datum/controller/occupations/job_master
 			C.registered_name = H.real_name
 			C.rank = rank
 			C.assignment = title ? title : rank
-			C.sex = H.gender
+			C.sex = capitalize(H.gender)
 			C.age = H.age
 			C.name = "[C.registered_name]'s ID Card ([C.assignment])"
 			C.photo = get_id_photo(H)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -106,7 +106,6 @@
 	var/icon/side
 	var/dat
 	var/stamped=0
-	var/waiting=0
 
 /obj/item/weapon/card/id/New()
 	..()
@@ -332,20 +331,6 @@
 		H.dir = SOUTH
 		faked = getFlatIcon(H)
 		H.dir = storedDir
-
-	return faked
-
-/obj/item/weapon/card/id/syndicate/proc/fake_id_photo_2(var/mob/living/carbon/human/H)
-	if(!istype(H))
-		return
-
-	var/storedDir = H.dir
-
-	H.dir = WEST
-
-	var/icon/faked = getFlatIcon(H)
-
-	H.dir = storedDir
 
 	return faked
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -75,7 +75,7 @@
 
 /obj/item/weapon/card/emag/afterattack(atom/target, mob/user, proximity)
 	var/atom/A = target
-	if(!proximity) 
+	if(!proximity)
 		return
 	A.emag_act(user)
 
@@ -106,17 +106,21 @@
 	var/icon/side
 	var/dat
 	var/stamped=0
+	var/waiting=0
 
 /obj/item/weapon/card/id/New()
 	..()
 	spawn(30)
+	updatedat()
+
+/obj/item/weapon/card/id/proc/updatedat()
 	if(istype(loc, /mob/living/carbon/human))
 		blood_type = loc:dna:b_type
 		dna_hash = loc:dna:unique_enzymes
 		fingerprint_hash = md5(loc:dna:uni_identity)
 		dat = ("<table><tr><td>")
 		dat +=text("Name: []</A><BR>", registered_name)
-		dat +=text("Sex: []</A><BR>\n", name)
+		dat +=text("Sex: []</A><BR>\n", sex)
 		dat +=text("Age: []</A><BR>\n", age)
 		dat +=text("Rank: []</A><BR>\n", assignment)
 		dat +=text("Fingerprint: []</A><BR>\n", fingerprint_hash)
@@ -224,8 +228,8 @@
 	var/registered_user=null
 
 /obj/item/weapon/card/id/syndicate/New(mob/user as mob)
-	..()
-	if(!isnull(user)) // Runtime prevention on laggy starts or where users log out because of lag at round start.
+//	..() - Intentionally does not call parent, doesn't need to
+	if(!isnull(user) && iscarbon(user)) // Runtime prevention on laggy starts or where users log out because of lag at round start. Also stops the ID from inheriting anything but a mob name
 		registered_name = ishuman(user) ? user.real_name : user.name
 	else
 		registered_name = "Agent Card"
@@ -257,8 +261,14 @@
 			return
 		src.assignment = u
 		src.name = "[src.registered_name]'s ID Card ([src.assignment])"
-		user << "\blue You successfully forge the ID card."
 		registered_user = user
+		var/s = input(user, "Would you like to update this card's details with your own?\nNote: This will take a picture of how you currently look, so put any items in your hand down first (other than this ID), and it will assume your age, and gender.", "Agent card update choice", "No") in list("Yes","No")
+		if(s == "Yes")
+			src.setupdat()
+			spawn(0)
+			src.updatedat()
+		user << "\blue You successfully forge the ID card."
+
 	else if(!registered_user || registered_user == user)
 
 		if(!registered_user) registered_user = user  //
@@ -278,12 +288,66 @@
 					return
 				src.assignment = u
 				src.name = "[src.registered_name]'s ID Card ([src.assignment])"
+				var/s = input(user, "Would you like to update this card's details with your own?\nNote: This will take a picture of how you currently look, so put any items in your hand down first (other than this ID), and it will assume your age, and gender.", "Agent card update choice", "No") in list("Yes","No")
+				if(s == "Yes")
+					src.setupdat()
+					spawn(0)
+					src.updatedat()
 				user << "\blue You successfully forge the ID card."
 				return
 			if("Show")
 				..()
 	else
 		..()
+
+/obj/item/weapon/card/id/syndicate/proc/setupdat() //fake initilization, taken mostly from job_controller.dm
+	if(istype(src.loc, /mob/living/carbon/human)) //just adopt the syndie stuff, it would be annoying to ask them to set all of this, and the use would be limited
+		var/mob/living/carbon/human/H = loc
+		src.sex = capitalize(H.gender)
+		src.rank = src.assignment
+		src.age = H.age
+		src.photo = fake_id_photo(H)
+		var/icon/photoside = fake_id_photo(H,1)
+		front = new(photo)
+		side = new(photoside)
+
+/obj/item/weapon/card/id/syndicate/proc/fake_id_photo(var/mob/living/carbon/human/H, var/side=0)//get_id_photo wouldn't work correctly
+	if(!istype(H))
+		return
+	var/storedDir = H.dir //don't want to lose track of this
+
+	var/icon/faked
+	if(!side)
+		if(!H.equip_to_slot_if_possible(src, slot_l_store, 0, 1))
+			H << "<span class='warning'>You need to empty your pockets before taking the ID picture.</span>"
+			return
+
+	if(side)
+		H.dir = WEST //ensure the icon is actually the proper direction before copying it
+		faked = getFlatIcon(H)
+		H.dir = storedDir //reset the user back to their original direction, not even noticable they changed
+		H.equip_to_slot_if_possible(src, slot_l_hand, 0, 1)
+
+	else
+		H.dir = SOUTH
+		faked = getFlatIcon(H)
+		H.dir = storedDir
+
+	return faked
+
+/obj/item/weapon/card/id/syndicate/proc/fake_id_photo_2(var/mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+
+	var/storedDir = H.dir
+
+	H.dir = WEST
+
+	var/icon/faked = getFlatIcon(H)
+
+	H.dir = storedDir
+
+	return faked
 
 /obj/item/weapon/card/id/syndicate_command
 	name = "syndicate ID card"


### PR DESCRIPTION
Alright:
Player important notes:
 * Fixed ID-shift-click-menu-thing having a weird entry for the gender 
 * Fixed agent ID's becoming 'floor's ID: job: floor', as funny as it was
 * Overhaul agent ID's so that they generate a proper image and entries on the ID-shift-click-menu-thing (yes that removes one way to see if it's an agent ID)
 * Syndies with an agent ID can update the ID image with whatever clothes they want
 * System is still a bit finicky, but it'll work fine if you read the in-game "Note:" text

Coder notes:
 * Slight overhaul of ID 'dat' system, cards now have an update-dat proc to reset the dat
 * Agent ID changes the mobs DIR while taking image, then resets it to whatever it was before, not noticable ingame as it happens ridiculously fast
 * Agent ID will now never call it's parent with New()- calling the parent is what made the 'floor's ID' bug
