### PR TITLE
Minor cryostorage fix, admin-related feature of cryostorage

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -451,6 +451,10 @@
 					M.client.perspective = EYE_PERSPECTIVE
 					M.client.eye = src
 
+			else //because why the fuck would you keep going if the mob isn't in the pod
+				user << "<span class='notice'>You stop putting [M] into the cryopod.</span>"
+				return
+
 			if(orient_right)
 				icon_state = "[occupied_icon_state]-r"
 			else
@@ -458,8 +462,16 @@
 
 			M << "<span class='notice'>[on_enter_occupant_message]</span>"
 			M << "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>"
+
 			occupant = M
 			time_entered = world.time
+
+			if(findtext("[M.key]","@",1,2))
+				var/FT = replacetext(M.key, "@", "")
+				for(var/mob/dead/observer/Gh in respawnable_list) //this may not be foolproof but it seemed like a better option than 'in world'
+					if(Gh.key == FT)
+						if(Gh.client && Gh.client.holder) //just in case someone has a byond name with @ at the start, which I don't think is even possible but whatever
+							Gh << "<span style='color: #800080;font-weight: bold;font-size:4;'>Warning: Your body has entered cryostorage.</span>"
 
 			// Book keeping!
 			var/turf/location = get_turf(src)
@@ -530,6 +542,9 @@
 			if(L.client)
 				L.client.perspective = EYE_PERSPECTIVE
 				L.client.eye = src
+		else
+			user << "<span class='notice'>You stop [L == user ? "climbing into the cryo pod." : "putting [L] into the cryo pod."]</span>"
+			return
 
 		if(orient_right)
 			icon_state = "[occupied_icon_state]-r"
@@ -540,6 +555,13 @@
 		L << "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>"
 		occupant = L
 		time_entered = world.time
+
+		if(findtext("[L.key]","@",1,2))
+			var/FT = replacetext(L.key, "@", "")
+			for(var/mob/dead/observer/Gh in respawnable_list) //this may not be foolproof but it seemed like a better option than 'in world'
+				if(Gh.key == FT)
+					if(Gh.client && Gh.client.holder) //just in case someone has a byond name with @ at the start, which I don't think is even possible but whatever
+						Gh << "<span style='color: #800080;font-weight: bold;font-size:4;'>Warning: Your body has entered cryostorage.</span>"
 
 		// Book keeping!
 		log_admin("[key_name_admin(L)] has entered a stasis pod. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")


### PR DESCRIPTION
Player notes:
 * Nothing affecting players, just a fix to prevent the cryopod from breaking.

Admin notes:
 * If you are admin-ghosted, and your SSD-appearing body is put into cryostorage, you get a giant purple message warning you about it. Because it sucks when you get despawned while investigating something. ![picture of purple message](http://puu.sh/h7yRL/856f4adc2a.png)

Coder-maintainer notes:
 * Fixes an oversight which allowed players putting people into cryopods to simply move away, at which point the proc would continue, but not actually put the person into the pod- this also allowed for abusing cryopods as teleportation devices, because of course it did
 * May break if the admin ghost manages to get themselves removed from the respawnable list, because searching through world would be shit