### PR TITLE
Add spaceworms to /obj/effect/tear exception list

### DIFF
--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -59,7 +59,9 @@
 		/mob/living/simple_animal/hostile/panther,
 		/mob/living/simple_animal/hostile/snake,
 		/mob/living/simple_animal/hostile/retaliate,
-		/mob/living/simple_animal/hostile/retaliate/clown
+		/mob/living/simple_animal/hostile/retaliate/clown,
+		/mob/living/simple_animal/hostile/spaceWorm/,
+		/mob/living/simple_animal/hostile/spaceWorm/wormHead/
 		)//exclusion list for things you don't want the reaction to create.
 		var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 


### PR DESCRIPTION
This pull-request adds /mob/living/simple_animal/hostile/spaceWorm to the
obj/effect/tear blocked mobs list, to prevent /obj/effect/tear from
spawning them.

Players:
 * No more (possibly invincible) spaceworms from dimensional tears.

Coders: 
 * Adds the spaceworm simple animal and it's head to the blocked list of /obj/effect/tear
  * May want to consider moving to a modular system or single global list in the future, as multiple blocked vars seem redundant.