### PR TITLE
Buffs Reactive Tele-Armor

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -165,7 +165,6 @@
 	icon_state = "reactiveoff"
 	item_state = "reactiveoff"
 	blood_overlay_type = "armor"
-	slowdown = 1
 	icon_action_button = "reactiveoff"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -172,16 +172,16 @@ emp_act
 			return 1
 	if(wear_suit && istype(wear_suit, /obj/item/))
 		var/obj/item/I = wear_suit
-		if(I.IsShield() && (prob(35)))
+		if(I.IsShield() && (prob(50)))
 			visible_message("\red <B>The reactive teleport system flings [src] clear of [attack_text]!</B>")
 			var/list/turfs = new/list()
-			for(var/turf/T in orange(6))
+			for(var/turf/T in orange(6, src))
 				if(istype(T,/turf/space)) continue
 				if(T.density) continue
 				if(T.x>world.maxx-6 || T.x<6)	continue
 				if(T.y>world.maxy-6 || T.y<6)	continue
 				turfs += T
-			if(!turfs.len) turfs += pick(/turf in orange(6))
+			if(!turfs.len) turfs += pick(/turf in orange(6, src))
 			var/turf/picked = pick(turfs)
 			if(!isturf(picked)) return
 			if(buckled)


### PR DESCRIPTION
Buffs the reactive teleport armor
https://github.com/tgstation/-tg-station/pull/8689

- Chance to teleport when hit increased from 35 to 50
- Removes the slowdown from wearing the armor

Tele-armor is kinda hit and miss due to it sometimes putting you in a worse situation than you're already in--so it's still a crapshoot, of course.