### PR TITLE
Universal Brain Damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -32,8 +32,6 @@
 	timeofdeath = 0
 
 /mob/living/carbon/human/getBrainLoss()
-	if(species && species.flags & NO_INTORGANS)
-		return
 	var/res = brainloss
 	var/obj/item/organ/brain/sponge = internal_organs_by_name["brain"]
 	if(!sponge)


### PR DESCRIPTION
Quite simple: you can take brain damage, no matter who you are (meaning IPCs and slimes can take brain damage). This is brain damage as a TYPE not damage of the internal organ "brain" (which IPCs and slimes don't have). Both IPCs and slimes will still not have to worry about their brain *organ* getting damaged, as they don't have that, but brain damage as a damage *type* will now impact them.

Why? A big part of this is balance; as brain damage is now a huge downside to using drugs, this effectively gives them immunity to drugs most negative aspects--it also makes them incredibly resistant to some conditions, such as heart attacks, etc. It's also leading to stuff like Chaplains indefinitely self healing with no risks as no brain damage is actually sustained.

IC reasons? They may not have traditional brains, but they still have internal wiring/nervous systems that would function together to act as a "brain"--as such that should be able to be damaged, and it's not worth making a whole new snowflake damage type for IPCs and/or slimes internal "nervous system brain" when it would effectively accomplish the same thing as brain damage.


