### PR TITLE
Removes setting someone's mode to walk or run mode on aimmode.

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -470,13 +470,13 @@
 	//mymob.item_use_icon.color = ui_color
 	mymob.item_use_icon.alpha = ui_alpha
 
-	mymob.gun_move_icon = new /obj/screen/gun/move(null)
+	/*mymob.gun_move_icon = new /obj/screen/gun/move(null)
 	//mymob.gun_move_icon.color = ui_color
 	mymob.gun_move_icon.alpha = ui_alpha
 
 	mymob.gun_run_icon = new /obj/screen/gun/run(null)
 	//mymob.gun_run_icon.color = ui_color
-	mymob.gun_run_icon.alpha = ui_alpha
+	mymob.gun_run_icon.alpha = ui_alpha*/
 
 	if (mymob.client)
 		if (mymob.client.gun_mode) // If in aim mode, correct the sprite

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -231,14 +231,14 @@
 			if (mymob.client.target_can_click)
 				mymob.item_use_icon.dir = 1
 			src.adding += mymob.item_use_icon
-			mymob.gun_move_icon = new /obj/screen/gun/move(null)
+			/*mymob.gun_move_icon = new /obj/screen/gun/move(null)
 			if (mymob.client.target_can_move)
 				mymob.gun_move_icon.dir = 1
 				mymob.gun_run_icon = new /obj/screen/gun/run(null)
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
-			src.adding += mymob.gun_move_icon
+			src.adding += mymob.gun_move_icon*/
 
 	mymob.client.screen = null
 

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -154,14 +154,14 @@
 			if (mymob.client.target_can_click)
 				mymob.item_use_icon.dir = 1
 			src.adding += mymob.item_use_icon
-			mymob.gun_move_icon = new /obj/screen/gun/move(null)
+			/*mymob.gun_move_icon = new /obj/screen/gun/move(null)
 			if (mymob.client.target_can_move)
 				mymob.gun_move_icon.dir = 1
 				mymob.gun_run_icon = new /obj/screen/gun/run(null)
 				if (mymob.client.target_can_run)
 					mymob.gun_run_icon.dir = 1
 				src.adding += mymob.gun_run_icon
-			src.adding += mymob.gun_move_icon
+			src.adding += mymob.gun_move_icon*/
 
 	mymob.client.screen = null
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -421,7 +421,7 @@
 			if(istype(usr, /mob/living/silicon/robot))
 				usr:toggle_module(3)
 
-		if("Allow Walking")
+		/*if("Allow Walking")
 			if(gun_click_time > world.time - 30)	//give them 3 seconds between mode changes.
 				return
 			if(!istype(usr.equipped(),/obj/item/weapon/gun))
@@ -455,7 +455,7 @@
 				usr << "You need your gun in your active hand to do that!"
 				return
 			usr.client.AllowTargetRun()
-			gun_click_time = world.time
+			gun_click_time = world.time*/
 
 		if("Allow Item Use")
 			if(gun_click_time > world.time - 30)	//give them 3 seconds between mode changes.

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -105,7 +105,7 @@
 	master = null
 	dir = 2
 
-	move
+	/*move
 		name = "Allow Walking"
 		icon_state = "no_walk0"
 		screen_loc = ui_gun2
@@ -113,7 +113,7 @@
 	run
 		name = "Allow Running"
 		icon_state = "no_run0"
-		screen_loc = ui_gun3
+		screen_loc = ui_gun3*/
 
 	item
 		name = "Allow Item Use"

--- a/code/modules/projectiles/targeting.dm
+++ b/code/modules/projectiles/targeting.dm
@@ -185,9 +185,9 @@ mob/living/proc/Targeted(var/obj/item/weapon/gun/I) //Self explanitory.
 		else
 			I.lower_aim()
 			return
-		if(m_intent == "run" && T.client.target_can_move == 1 && T.client.target_can_run == 0 && (ishuman(T)))
+		/*if(m_intent == "run" && T.client.target_can_move == 1 && T.client.target_can_run == 0 && (ishuman(T)))
 			src << "\red Your move intent is now set to walk, as your targeter permits it."  //Self explanitory.
-			set_m_intent("walk")
+			set_m_intent("walk")*/
 
 		//Processing the aiming. Should be probably in separate object with process() but lasy.
 		while(targeted_by && T.client)
@@ -249,18 +249,18 @@ client/var
 //These are called by the on-screen buttons, adjusting what the victim can and cannot do.
 client/proc/add_gun_icons()
 	screen += usr.item_use_icon
-	screen += usr.gun_move_icon
+	/*screen += usr.gun_move_icon
 	if (target_can_move)
-		screen += usr.gun_run_icon
+		screen += usr.gun_run_icon*/
 
 
 
 client/proc/remove_gun_icons()
 	if(!usr) return
 	screen -= usr.item_use_icon
-	screen -= usr.gun_move_icon
+	/*screen -= usr.gun_move_icon
 	if (target_can_move)
-		screen -= usr.gun_run_icon
+		screen -= usr.gun_run_icon*/
 
 client/verb/ToggleGunMode()
 	set hidden = 1
@@ -276,7 +276,7 @@ client/verb/ToggleGunMode()
 		usr.gun_setting_icon.icon_state = "gun[gun_mode]"
 
 
-client/verb/AllowTargetMove()
+/*client/verb/AllowTargetMove()
 	set hidden=1
 
 	//Changing client's permissions
@@ -339,7 +339,7 @@ client/verb/AllowTargetRun()
 				if(target_can_run)
 					M << "Your character may now <b>run</b> at the discretion of their targeter."
 				else
-					M << "\red <b>Your character will now be shot if they run.</b>"
+					M << "\red <b>Your character will now be shot if they run.</b>"*/
 
 client/verb/AllowTargetClick()
 	set hidden=1


### PR DESCRIPTION
Aimbot mode is awful, and I would have nerfed it further, if darn bee code wasn't so reliant on it.
So, for now, this is what I've done.
-Removes the ability to set someone to walk mode and back when aiming at someone.
-Removes the damn icons for it too.
I tested this locally, and it worked, but I suck at coding (*Cough cough* Commenting out code in this case. *Cough cough*)/ Github, so I might have done something wrong.
Thanks to tigercat2000 for assisting me with this.