### PR TITLE
Fixes an oversight with NO_BREATHE and corpses

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1616,6 +1616,8 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 					var/obj/item/clothing/mask/M = H.wear_mask
 					if(M && (M.flags & MASKCOVERSMOUTH))
 						return
+					if(H.species && H.species.flags & NO_BREATHE)
+						return //no puking if you can't smell!
 					H << "<spawn class='warning'>You smell something foul..."
 					H.fakevomit()
 


### PR DESCRIPTION
This fixes:
 - Issue #778 on https://github.com/ParadiseSS13/Paradise

Player notes: IPC, Dionae, and Slime People will no longer puke at corpses.

Coder notes: There was no sanity checking to test if mobs in range of a corpse have
the NO_BREATHE flag. This commit adds such a check. It does not make
sense for species like machine people to vomit. It may make sense for
Slime People and Dionae, but, after all, it's sentient slime and a tree
thing. Are they are even capable of regurgitating their food? Either way, they don't breath.

Testing picture, because I have one for some reason;
![picture demonstrating lack of puke](http://puu.sh/hcDFT/3a428a8e34.png)