### PR TITLE
Ports "Improved eyecheck()" from -tg-

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -133,6 +133,9 @@
 	var/vision_flags = 0
 	var/darkness_view = 0//Base human is 2
 	var/invisa_view = 0
+	var/flash_protect = 0		//Mal: What level of bright light protection item has. 1 = Flashers, Flashes, & Flashbangs | 2 = Welding | -1 = OH GOD WELDING BURNT OUT MY RETINAS
+	var/tint = 0				//Mal: Sets the item's level of visual impairment tint, normally set to the same as flash_protect
+								//	   but seperated to allow items to protect but not impair vision, like space helmets
 	species_restricted = list("exclude","Kidan")
 /*
 SEE_SELF  // can see self, no matter what
@@ -236,7 +239,8 @@ BLIND     // can't see anything
 	slot_flags = SLOT_HEAD
 	var/loose = 10 // probability (0..100) of coming off your head when you fall over or lay down
 	var/blockTracking // Do we block AI tracking?
-
+	var/flash_protect = 0
+	var/tint = 0
 
 //Mask
 /obj/item/clothing/mask
@@ -247,6 +251,8 @@ BLIND     // can't see anything
 	var/mask_adjusted = 0
 	var/ignore_maskadjust = 1
 	var/adjusted_flags = null
+	var/flash_protect = 0
+	var/tint = 0
 
 //Proc that moves gas/breath masks out of the way
 /obj/item/clothing/mask/proc/adjustmask(var/mob/user)
@@ -324,6 +330,7 @@ BLIND     // can't see anything
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude","Diona","Vox")
 	loose = 0 // What kind of idiot designs a pressurized suit where the helmet can fall off?
+	flash_protect = 2
 
 /obj/item/clothing/suit/space
 	name = "Space suit"

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -137,6 +137,8 @@
 	icon_state = "sun"
 	item_state = "sunglasses"
 	darkness_view = 1
+	flash_protect = 1
+	tint = 1
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
@@ -148,6 +150,8 @@
 	icon_state = "sun"
 	item_state = "sunglasses"
 	darkness_view = 1
+	flash_protect = 1
+	tint = 1
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
@@ -160,6 +164,8 @@
 	item_state = "welding-g"
 	icon_action_button = "action_welding_g"
 	var/up = 0
+	flash_protect = 2
+	tint = 2
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
@@ -184,12 +190,16 @@
 			flags_inv |= HIDEEYES
 			icon_state = initial(icon_state)
 			usr << "You flip the [src] down to protect your eyes."
+			flash_protect = 2
+			tint = initial(tint) //better than istype
 		else
 			src.up = !src.up
 			src.flags &= ~HEADCOVERSEYES
 			flags_inv &= ~HIDEEYES
 			icon_state = "[initial(icon_state)]up"
 			usr << "You push the [src] up out of your face."
+			flash_protect = 0
+			tint = 0
 
 		usr.update_inv_glasses()
 
@@ -198,6 +208,8 @@
 	desc = "Welding goggles made from more expensive materials, strangely smells like potatoes."
 	icon_state = "rwelding-g"
 	item_state = "rwelding-g"
+	flash_protect = 2
+	tint = 0
 	icon_action_button = "action_welding_g"
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -213,6 +225,8 @@
 	icon_state = "blindfold"
 	item_state = "blindfold"
 	//vision_flags = BLIND
+	flash_protect = 2
+	tint = 3				//to make them blind
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
@@ -230,6 +244,8 @@
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Larger than average enhanced shielding blocks many flashes."
 	icon_state = "bigsunglasses"
 	item_state = "bigsunglasses"
+	flash_protect = 1
+	tint = 1
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
@@ -240,6 +256,8 @@
 	desc = "Sunglasses with a HUD."
 	icon_state = "sunhud"
 	darkness_view = 1
+	flash_protect = 1
+	tint = 1
 	var/obj/item/clothing/glasses/hud/security/hud = null
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -259,6 +277,7 @@
 	origin_tech = "magnets=3"
 	vision_flags = SEE_MOBS
 	invisa_view = 2
+	flash_protect = -1
 
 	emp_act(severity)
 		if(istype(src.loc, /mob/living/carbon/human))

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -19,6 +19,7 @@
 	name = "Advanced Health Scanner HUD"
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their health status.  Includes anti-flash filter."
 	icon_state = "advmedhud"
+	flash_protect = 1
 
 /obj/item/clothing/glasses/hud/health/night
 	name = "Night Vision Health Scanner HUD"
@@ -40,6 +41,7 @@
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status and security records."
 	icon_state = "securityhud"
 	var/global/list/jobs[0]
+	flash_protect = 1
 
 /obj/item/clothing/glasses/hud/security/jensenshades
 	name = "Augmented shades"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -20,6 +20,8 @@
 	m_amt = 1750
 	g_amt = 400
 	var/up = 0
+	flash_protect = 2
+	tint = 2
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags_inv = (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 	icon_action_button = "action_welding"
@@ -44,12 +46,16 @@
 			flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 			icon_state = initial(icon_state)
 			usr << "You flip the [src] down to protect your eyes."
+			flash_protect = 2
+			tint = 2
 		else
 			src.up = !src.up
 			src.flags &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
 			flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
 			icon_state = "[initial(icon_state)]up"
 			usr << "You push the [src] up out of your face."
+			flash_protect = 0
+			tint = 0
 		usr.update_inv_head()	//so our mob-overlays update
 
 

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -126,6 +126,7 @@
 	desc = "A lightweight space helmet with the basic ability to protect the wearer from the vacuum of space during emergencies."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
+	flash_protect = 0
 
 //Mime's Hardsuit
 /obj/item/clothing/head/helmet/space/eva/mime

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -490,6 +490,7 @@
 	_color = "medical"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 50)
+	flash_protect = 0
 
 /obj/item/clothing/suit/space/rig/medical
 	icon_state = "rig-medical"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -244,6 +244,9 @@
 /mob/living/carbon/proc/eyecheck()
 	return 0
 
+/mob/living/carbon/proc/tintcheck()
+	return 0
+
 /mob/living/carbon/proc/getDNA()
 	return dna
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1027,27 +1027,32 @@
 ///Returns a number between -1 to 2
 /mob/living/carbon/human/eyecheck()
 	var/number = 0
-	if(istype(src.head, /obj/item/clothing/head/welding))
-		if(!src.head:up)
-			number += 2
-	if(istype(src.head, /obj/item/clothing/head/helmet/space))
-		number += 2
-	if(istype(src.head, /obj/item/clothing/head/helmet/space/eva))
-		number -= 2
-	if(istype(src.head, /obj/item/clothing/head/helmet/space/rig/medical))
-		number -= 2
-	if(istype(src.glasses, /obj/item/clothing/glasses/thermal))
-		number -= 1
-	if(istype(src.glasses, /obj/item/clothing/glasses/sunglasses))
-		number += 1
-	if(istype(src.glasses, /obj/item/clothing/glasses/hud/health_advanced)) // New blueshield / brig phys no flash medi hud
-		number += 1
-	if(istype(src.glasses, /obj/item/clothing/glasses/welding))
-		var/obj/item/clothing/glasses/welding/W = src.glasses
-		if(!W.up)
-			number += 2
+	if(istype(src.head, /obj/item/clothing/head))			//are they wearing something on their head
+		var/obj/item/clothing/head/HFP = src.head			//if yes gets the flash protection value from that item
+		number += HFP.flash_protect
+	if(istype(src.glasses, /obj/item/clothing/glasses))		//glasses
+		var/obj/item/clothing/glasses/GFP = src.glasses
+		number += GFP.flash_protect
+	if(istype(src.wear_mask, /obj/item/clothing/mask))		//mask
+		var/obj/item/clothing/mask/MFP = src.wear_mask
+		number += MFP.flash_protect
 	return number
 
+///tintcheck()
+///Checks eye covering items for visually impairing tinting, such as welding masks
+///Checked in life.dm. 0 & 1 = no impairment, 2 = welding mask overlay, 3 = You can see jack, but you can't see shit.
+/mob/living/carbon/human/tintcheck()
+	var/tinted = 0
+	if(istype(src.head, /obj/item/clothing/head))
+		var/obj/item/clothing/head/HT = src.head
+		tinted += HT.tint
+	if(istype(src.glasses, /obj/item/clothing/glasses))
+		var/obj/item/clothing/glasses/GT = src.glasses
+		tinted += GT.tint
+	if(istype(src.wear_mask, /obj/item/clothing/mask))
+		var/obj/item/clothing/mask/MT = src.wear_mask
+		tinted += MT.tint
+	return tinted
 
 /mob/living/carbon/human/IsAdvancedToolUser()
 	return 1//Humans can use guns and such


### PR DESCRIPTION
Ports tgstation/-tg-station#697

Original post: 

>Changes flash/welder protection eyecheck() proc from several hard coded item checks to a /var check for eye covering items, reducing the number of IF statements and allowing greater flexibility as child items can have a different protection level to their parent.

>Created a new proc tintcheck()
 - Items have a separate tint var to allow for items to protect but not impair, such as space helmets.
 - tintcheck() adds these up for eye covering locations
 - life.dm uses this new proc when checking to apply the welder overlay instead of hardcoded if statements

Player notes: This is mostly overhead, but it means adminbooze may end with flashproof items

Admin notes: Adds new vars to masks, glasses, and hats to blind the player and to protect against flashes

Coder notes: Fairly major eyecheck overhaul, this should help out a lot when defining new sunglasses and such