### PR TITLE
Allow admins to drag-drop ghosts into mobs 

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -987,3 +987,35 @@ proc/formatLocation(var/location)
 
 proc/formatPlayerPanel(var/mob/U,var/text="PP")
 	return "<A HREF='?_src_=holder;adminplayeropts=\ref[U]'>[text]</A>"
+
+/datum/admins/proc/cmd_ghost_drag(var/mob/dead/observer/frommob, var/mob/living/tomob)
+	if(!istype(frommob))
+		return //extra sanity check to make sure only observers are shoved into things
+
+	//same as assume-direct-control perm requirements.
+	if (!check_rights(R_VAREDIT,0) || !check_rights(R_ADMIN|R_DEBUG,0))
+		return 0
+
+	if (!frommob.ckey)
+		return 0
+
+	var/question = ""
+	if (tomob.ckey)
+		question = "This mob already has a user ([tomob.key]) in control of it! "
+	question += "Are you sure you want to place [frommob.name]([frommob.key]) in control of [tomob.name]?"
+
+	var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
+	if (ask != "Yes")
+		return 1
+
+	if(tomob.client) //no need to ghostize if there is no client
+		tomob.ghostize(0)
+
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name].</span>")
+	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")
+	feedback_add_details("admin_verb","CGD")
+
+	tomob.ckey = frommob.ckey
+	qdel(frommob)
+
+	return 1

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -988,6 +988,8 @@ proc/formatLocation(var/location)
 proc/formatPlayerPanel(var/mob/U,var/text="PP")
 	return "<A HREF='?_src_=holder;adminplayeropts=\ref[U]'>[text]</A>"
 
+//returns 1 to let the dragdrop code know we are trapping this event
+//returns 0 if we don't plan to trap the event
 /datum/admins/proc/cmd_ghost_drag(var/mob/dead/observer/frommob, var/mob/living/tomob)
 	if(!istype(frommob))
 		return //extra sanity check to make sure only observers are shoved into things
@@ -999,6 +1001,7 @@ proc/formatPlayerPanel(var/mob/U,var/text="PP")
 	if (!frommob.ckey)
 		return 0
 
+
 	var/question = ""
 	if (tomob.ckey)
 		question = "This mob already has a user ([tomob.key]) in control of it! "
@@ -1006,6 +1009,9 @@ proc/formatPlayerPanel(var/mob/U,var/text="PP")
 
 	var/ask = alert(question, "Place ghost in control of mob?", "Yes", "No")
 	if (ask != "Yes")
+		return 1
+
+	if(!frommob || !tomob) //make sure the mobs don't go away while we waited for a response
 		return 1
 
 	if(tomob.client) //no need to ghostize if there is no client

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -489,6 +489,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 //this is called when a ghost is drag clicked to something.
 /mob/dead/observer/MouseDrop(atom/over)
+	if(!usr || !over) return
 	if (isobserver(usr) && usr.client && usr.client.holder && isliving(over))
 		if (usr.client.holder.cmd_ghost_drag(src,over))
 			return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -487,6 +487,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	src << browse(dat, "window=manifest;size=370x420;can_close=1")
 
+//this is called when a ghost is drag clicked to something.
+/mob/dead/observer/MouseDrop(atom/over)
+	if (isobserver(usr) && usr.client && usr.client.holder && isliving(over))
+		if (usr.client.holder.cmd_ghost_drag(src,over))
+			return
+
+	return ..()
+
 //BEGIN TELEPORT HREF CODE
 /mob/dead/observer/Topic(href, href_list)
 	if(usr != src)


### PR DESCRIPTION
Port of tgstation/-tg-station#8957

This allows administrators to drag their mouse from a ghost to a type of
/mob/living, which will then prompt them if they wish to put that ghost in
control of the mob, and obviously, that is exactly what happens if you
select yes.

Tiger's notes- Original commit by MSO had access requirements similar
to editting a ckey in vv, but, after discussing it with a headmin, and
the fact that our trialmins can assume-direct-control, this only
requires R_ADMIN & R_DEBUG, or R_VAREDIT

Player Notes; Only affects admins.

Admin Notes: Click and drag any ghost (yes that includes yourself) onto a mob, hit yes in response to the warning, ???, win. But seriously, it will warn you if the mob has a client, pay attention and try not to displace anyone :P

