### PR TITLE
Candy Fixes

### DIFF
--- a/code/modules/food/candy_maker.dm
+++ b/code/modules/food/candy_maker.dm
@@ -323,8 +323,7 @@
 		for(var/i=1,i<efficiency,i++)
 			cooked = new cooked.type(loc)
 		if(byproduct)
-			byproduct.loc = src.loc
-			byproduct = new byproduct.type(loc)
+			new byproduct(loc)
 		return
 
 /obj/machinery/candy_maker/proc/wzhzhzh(var/seconds as num)

--- a/code/modules/reagents/reagent_containers/food/snacks/candy.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/candy.dm
@@ -718,7 +718,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("lexorin", 20)
+		reagents.add_reagent("sulfonal", 20)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
 		bitesize = 4


### PR DESCRIPTION
- Fixes the bad rainbow cotton candy not actually using a "toxin" as it's reagent contents.
 - Previously contained Lexorin, now contains Sulfonal.

- Fixes the candy maker's insatiable appetite for candy moulds and the runtime it caused.
 - Incorrect recipes still destroy the mould, but successful candy
making will return it's mould as intended.