### PR TITLE
Move hostile blacklist to global variable

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -38,6 +38,33 @@ var/global/list/language_keys[0]					// Table of say codes for all languages
 var/global/list/all_nations[0]
 var/global/list/whitelisted_species = list()
 
+//global var of unsafe-to-spawn-on-reaction mobs
+var/global/list/blocked_mobs = list(/mob/living/simple_animal/hostile,
+			/mob/living/simple_animal/hostile/pirate,
+			/mob/living/simple_animal/hostile/pirate/ranged,
+			/mob/living/simple_animal/hostile/russian,
+			/mob/living/simple_animal/hostile/russian/ranged,
+			/mob/living/simple_animal/hostile/syndicate,
+			/mob/living/simple_animal/hostile/syndicate/melee,
+			/mob/living/simple_animal/hostile/syndicate/melee/space,
+			/mob/living/simple_animal/hostile/syndicate/ranged,
+			/mob/living/simple_animal/hostile/syndicate/ranged/space,
+			/mob/living/simple_animal/hostile/alien/queen/large,
+			/mob/living/simple_animal/hostile/retaliate,
+			/mob/living/simple_animal/hostile/retaliate/clown,
+			/mob/living/simple_animal/hostile/mushroom,
+			/mob/living/simple_animal/hostile/asteroid,
+			/mob/living/simple_animal/hostile/asteroid/basilisk,
+			/mob/living/simple_animal/hostile/asteroid/goldgrub,
+			/mob/living/simple_animal/hostile/asteroid/goliath,
+			/mob/living/simple_animal/hostile/asteroid/hivelord,
+			/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
+			/mob/living/simple_animal/hostile/carp/holocarp,
+			/mob/living/simple_animal/hostile/mining_drone,
+			/mob/living/simple_animal/hostile/spaceWorm,
+			/mob/living/simple_animal/hostile/spaceWorm/wormHead
+			)
+
 //Preferences stuff
 	//Hairstyles
 var/global/list/hair_styles_list = list()			//stores /datum/sprite_accessory/hair indexed by name

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -44,25 +44,8 @@
 
 
 	spawn(rand(30,120))
-		var/blocked = list(/mob/living/simple_animal/hostile,
-		/mob/living/simple_animal/hostile/pirate,
-		/mob/living/simple_animal/hostile/pirate/ranged,
-		/mob/living/simple_animal/hostile/russian,
-		/mob/living/simple_animal/hostile/russian/ranged,
-		/mob/living/simple_animal/hostile/syndicate,
-		/mob/living/simple_animal/hostile/syndicate/melee,
-		/mob/living/simple_animal/hostile/syndicate/melee/space,
-		/mob/living/simple_animal/hostile/syndicate/ranged,
-		/mob/living/simple_animal/hostile/syndicate/ranged/space,
-		/mob/living/simple_animal/hostile/alien/queen/large,
-		/mob/living/simple_animal/hostile/faithless,
-		/mob/living/simple_animal/hostile/panther,
-		/mob/living/simple_animal/hostile/snake,
-		/mob/living/simple_animal/hostile/retaliate,
-		/mob/living/simple_animal/hostile/retaliate/clown,
-		/mob/living/simple_animal/hostile/spaceWorm/,
-		/mob/living/simple_animal/hostile/spaceWorm/wormHead/
-		)//exclusion list for things you don't want the reaction to create.
+		var/blocked = blocked_mobs //global variable for blocked mobs
+
 		var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 
 		for(var/i = 1, i <= 5, i++)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -487,23 +487,8 @@ datum
 			required_other = 1
 			on_reaction(var/datum/reagents/holder)
 
-				var/blocked = list(/mob/living/simple_animal/hostile,
-					/mob/living/simple_animal/hostile/pirate,
-					/mob/living/simple_animal/hostile/pirate/ranged,
-					/mob/living/simple_animal/hostile/russian,
-					/mob/living/simple_animal/hostile/russian/ranged,
-					/mob/living/simple_animal/hostile/syndicate,
-					/mob/living/simple_animal/hostile/syndicate/melee,
-					/mob/living/simple_animal/hostile/syndicate/melee/space,
-					/mob/living/simple_animal/hostile/syndicate/ranged,
-					/mob/living/simple_animal/hostile/syndicate/ranged/space,
-					/mob/living/simple_animal/hostile/alien/queen/large,
-					/mob/living/simple_animal/hostile/faithless,
-					/mob/living/simple_animal/hostile/panther,
-					/mob/living/simple_animal/hostile/snake,
-					/mob/living/simple_animal/hostile/retaliate,
-					/mob/living/simple_animal/hostile/retaliate/clown
-					)//exclusion list for things you don't want the reaction to create.
+				var/blocked = blocked_mobs //global variable of blocked mobs
+
 				var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 
 				playsound(get_turf_loc(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -535,34 +520,13 @@ datum
 			on_reaction(var/datum/reagents/holder)
 				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
 				for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-					O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently !</span>"), 1)
+					O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently!</span>"), 1)
 				spawn(50)
 
 				if(holder && holder.my_atom)
 
-					var/blocked = list(/mob/living/simple_animal/hostile,
-						/mob/living/simple_animal/hostile/pirate,
-						/mob/living/simple_animal/hostile/pirate/ranged,
-						/mob/living/simple_animal/hostile/russian,
-						/mob/living/simple_animal/hostile/russian/ranged,
-						/mob/living/simple_animal/hostile/syndicate,
-						/mob/living/simple_animal/hostile/syndicate/melee,
-						/mob/living/simple_animal/hostile/syndicate/melee/space,
-						/mob/living/simple_animal/hostile/syndicate/ranged,
-						/mob/living/simple_animal/hostile/syndicate/ranged/space,
-						/mob/living/simple_animal/hostile/alien/queen/large,
-						/mob/living/simple_animal/hostile/retaliate,
-						/mob/living/simple_animal/hostile/retaliate/clown,
-						/mob/living/simple_animal/hostile/mushroom,
-						/mob/living/simple_animal/hostile/asteroid,
-						/mob/living/simple_animal/hostile/asteroid/basilisk,
-						/mob/living/simple_animal/hostile/asteroid/goldgrub,
-						/mob/living/simple_animal/hostile/asteroid/goliath,
-						/mob/living/simple_animal/hostile/asteroid/hivelord,
-						/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
-						/mob/living/simple_animal/hostile/carp/holocarp,
-						/mob/living/simple_animal/hostile/mining_drone
-						)//exclusion list for things you don't want the reaction to create.
+					var/blocked = blocked_mobs
+
 					var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 
 					playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -693,30 +693,8 @@ datum/reagent/life
 
 proc/chemical_mob_spawn(var/datum/reagents/holder, var/amount_to_spawn, var/reaction_name, var/mob_faction = "chemicalsummon")
 	if(holder && holder.my_atom)
-		var/blocked = list(/mob/living/simple_animal/hostile,
-			/mob/living/simple_animal/hostile/pirate,
-			/mob/living/simple_animal/hostile/pirate/ranged,
-			/mob/living/simple_animal/hostile/russian,
-			/mob/living/simple_animal/hostile/russian/ranged,
-			/mob/living/simple_animal/hostile/syndicate,
-			/mob/living/simple_animal/hostile/syndicate/melee,
-			/mob/living/simple_animal/hostile/syndicate/melee/space,
-			/mob/living/simple_animal/hostile/syndicate/ranged,
-			/mob/living/simple_animal/hostile/syndicate/ranged/space,
-			/mob/living/simple_animal/hostile/alien/queen/large,
-			/mob/living/simple_animal/hostile/retaliate,
-			/mob/living/simple_animal/hostile/retaliate/clown,
-			/mob/living/simple_animal/hostile/mushroom,
-			/mob/living/simple_animal/hostile/asteroid,
-			/mob/living/simple_animal/hostile/asteroid/basilisk,
-			/mob/living/simple_animal/hostile/asteroid/goldgrub,
-			/mob/living/simple_animal/hostile/asteroid/goliath,
-			/mob/living/simple_animal/hostile/asteroid/hivelord,
-			/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
-			/mob/living/simple_animal/hostile/carp/holocarp,
-			/mob/living/simple_animal/hostile/mining_drone,
-			/mob/living/simple_animal/hostile/spaceWorm
-			)//exclusion list for things you don't want the reaction to create.
+		var/blocked =  blocked_mobs //global variable for blocked mobs
+
 		var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)


### PR DESCRIPTION
This moves the multiple lists of blacklisted hostile mobs
(as in, unsafe or intended for special use) into a single global
variable. This means that gold slime cores and dimensional tears
now use the same list of mobs, for simplicity.

Player notes: No real effect on players, the same blocks are in place as are intended to be in place.

Admin notes: No more new hostile mobs accidentally ending up spawnable by anyone but adminbooze, (fucking spaceworms). Unless of course the coder forgets to add it to this list.

Coder notes: For any adminbooze or unique hostile mob that you do not want spawning anywhere but where you tell it too, add it to the global/list/blocked_mobs. 

This is a refactor. 