### PR TITLE
New martial arts style- Drunk Brawling

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -174,7 +174,7 @@
 			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \
 								"<span class='userdanger'>[A] has knocked [D] out with a haymaker!</span>")
 			D.apply_effect(10,WEAKEN,armor_block)
-			D.SetSleeping(5)
+			D.Paralyse(5)
 			D.forcesay(hit_appends)
 		else if(D.lying)
 			D.forcesay(hit_appends)

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -120,6 +120,66 @@
 			D.forcesay(hit_appends)
 	return 1
 
+/datum/martial_art/drunk_brawling
+	name = "Drunken Brawling"
+
+/datum/martial_art/drunk_brawling/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	if(prob(70))
+		A.visible_message("<span class='warning'>[A] tries to grab ahold of [D], but fails!</span>", \
+							"<span class='warning'>You fail to grab ahold of [D]!</span>")
+		return 1
+	D.grabbedby(A,1)
+	var/obj/item/weapon/grab/G = A.get_active_hand()
+	if(G)
+		D.visible_message("<span class='danger'>[A] grabs ahold of [D] drunkenly!</span>", \
+								"<span class='userdanger'>[A] grabs ahold of [D] drunkenly!</span>")
+	return 1
+
+/datum/martial_art/drunk_brawling/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+	add_logs(A, D, "punched")
+	A.do_attack_animation(D)
+
+	var/atk_verb = pick("jab","uppercut","overhand punch","drunken right hook","drunken left hook")
+
+	var/damage = rand(0,6)
+
+	if(atk_verb == "uppercut")
+		if(prob(90))
+			damage = 0
+		else //10% chance to do a massive amount of damage
+			damage = 14
+
+	if(prob(50)) //they are drunk, they aren't going to land half of their hits
+		damage = 0
+
+	if(!damage)
+		playsound(D.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+		D.visible_message("<span class='warning'>[A] has attempted to hit [D] with a [atk_verb]!</span>")
+		return 1 //returns 1 so that they actually miss and don't switch to attackhand damage
+
+	var/obj/item/organ/external/affecting = D.get_organ(ran_zone(A.zone_sel.selecting))
+	var/armor_block = D.run_armor_check(affecting, "melee")
+
+	playsound(D.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)
+
+
+	D.visible_message("<span class='danger'>[A] has hit [D] with a [atk_verb]!</span>", \
+								"<span class='userdanger'>[A] has hit [D] with a [atk_verb]!</span>")
+
+	D.apply_damage(damage, BRUTE, null, armor_block)
+	D.apply_effect(damage, STAMINA, armor_block)
+	if(D.getStaminaLoss() > 50)
+		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
+		if((D.stat != DEAD) && prob(knockout_prob))
+			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \
+								"<span class='userdanger'>[A] has knocked [D] out with a haymaker!</span>")
+			D.apply_effect(10,WEAKEN,armor_block)
+			D.SetSleeping(5)
+			D.forcesay(hit_appends)
+		else if(D.lying)
+			D.forcesay(hit_appends)
+	return 1
+
 /datum/martial_art/wrestling
 	name = "Wrestling"
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2384,10 +2384,12 @@ datum
 			reagent_state = LIQUID
 			nutriment_factor = 0 //So alcohol can fill you up! If they want to.
 			color = "#404030" // rgb: 64, 64, 48
+			var/datum/martial_art/drunk_brawling/F = new
 			var/dizzy_adj = 3
 			var/slurr_adj = 3
 			var/confused_adj = 2
 			var/slur_start = 65			//amount absorbed after which mob starts slurring
+			var/brawl_start = 75		//amount absorbed after which mob switches to drunken brawling as a fighting style
 			var/confused_start = 130	//amount absorbed after which mob starts confusing directions
 			var/vomit_start = 180	//amount absorbed after which mob starts vomitting
 			var/blur_start = 260	//amount absorbed after which mob starts getting blurred vision
@@ -2417,6 +2419,12 @@ datum
 				if(d >= slur_start && d < pass_out)
 					if (!M:slurring) M:slurring = 1
 					M:slurring += slurr_adj/sober_str
+				if(d >= brawl_start && ishuman(M))
+					var/mob/living/carbon/human/H = M
+					F.teach(H,1)
+					if(src.volume < 3)
+						if(H.martial_art == F)
+							F.remove(H)
 				if(d >= confused_start && prob(33))
 					if (!M:confused) M:confused = 1
 					M.confused = max(M:confused+(confused_adj/sober_str),0)
@@ -2490,6 +2498,7 @@ datum
 				description = "Just when you thought regular station whiskey was good... This silky, amber goodness has to come along and ruin everything."
 				color = "#664300" // rgb: 102, 67, 0
 				slur_start = 30		//amount absorbed after which mob starts slurring
+				brawl_start = 40
 
 			gin
 				name = "Gin"
@@ -2506,6 +2515,7 @@ datum
 				overdose_threshold = 30
 				dizzy_adj = 5
 				slur_start = 25
+				brawl_start = 40
 				confused_start = 100
 
 				//copy paste from LSD... shoot me
@@ -2583,6 +2593,7 @@ datum
 				slurr_adj = 20
 				confused_adj = 3
 				slur_start = 15
+				brawl_start = 25
 				confused_start = 40
 				blur_start = 60
 				pass_out = 80


### PR DESCRIPTION
This adds a new martial arts datum, labeled as Drunken Brawling. This
style is automatically added and removed to people via ethanol,
specifically, 10 life ticks after they start slurring their words.

The style is mostly debuffs, as there is a flat 50% chance to miss any
harm-intent hit, a 70% chance to fail to grab, and disarm is unaffected.

The actual 'features' of this style can be summarized as such:
 - Custom attack verbs
   - "jab","uppercut","overhand punch",
   "drunken right hook","drunken left hook"
   - Uppercut has a 5% chance to do 14 damage

 - Limits combat abilities
   - 70% chance to fail to passively grab
   - 50% chance to miss any harm intent
   - Disarm intent is untouched.

 - Added by ethanol when someone has had it into their system
   for a while
   - Removed as soon as the ethanol becomes lower than 3 units

Player notes:
 - When you get (very) drunk, you will now obtain this style, which can be either very bad, or very good.
 - Bar fight, anyone? Come on, Betcha can't even hit me!

Admin notes: 
 - Automatically obtained from drinking ethanol and subtypes (anything at the bar)

Coder notes: 
 - An actual (common) use for the martial arts system
 - Always overrides harm intent, intentionally, to prevent people from just falling back to attackhand if they get caught in the failure probability
 - Uppercut is extremely rare, but does over twice the damage as a normal punch