### PR TITLE
Organ/Surgery Fixes

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -80,13 +80,11 @@
 /obj/item/organ/brain/slime
 	name = "slime core"
 	desc = "A complex, organic knot of jelly and crystalline particles."
-	robotic = 2
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "green slime extract"
 
 /obj/item/organ/brain/golem
 	name = "chem"
 	desc = "A tightly furled roll of paper, covered with indecipherable runes."
-	robotic = 2
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll"

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -67,7 +67,9 @@
 
 	if(target.key)
 		target.ghostize()
-
+	var/mob/living/carbon/C = target
+	if(istype(C))
+		C.brain_op_stage = 1.0
 	if(brainmob)
 		if(brainmob.mind)
 			brainmob.mind.transfer_to(target)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -111,6 +111,9 @@
 	if(!. || !I)
 		return
 
+	var/obj/item/organ/O = I //Organs shouldn't be removed unless you call droplimb.
+	if(istype(O) && O.owner == src)
+		return
 
 	if(I == wear_suit)
 		if(s_store)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -16,7 +16,6 @@ var/list/organ_cache = list()
 
 	var/parent_organ = "chest"
 	var/robotic = 0 //For being a robot
-	var/rejecting   // Is this organ already being rejected?
 
 	var/list/datum/autopsy_data/autopsy_data = list()
 	var/list/trace_chemicals = list() // traces of chemicals in the organ,
@@ -222,7 +221,6 @@ var/list/organ_cache = list()
 
 	loc = get_turf(owner)
 	processing_objects |= src
-	rejecting = null
 	var/datum/reagent/blood/organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list
 	if(!organ_blood || !organ_blood.data["blood_DNA"])
 		owner.vessel.trans_to(src, 5, 1, 1)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -201,7 +201,7 @@
 
 	// sync the organ's damage with its wounds
 	src.update_damages()
-
+	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
 		if(!cannot_amputate && config.limbs_can_break && (brute_dam + burn_dam) >= (max_damage * config.organ_health_multiplier))
@@ -216,7 +216,7 @@
 				else
 					droplimb(0,DROPLIMB_BLUNT)
 
-	owner.updatehealth()
+	owner_old.updatehealth()
 	return update_icon()
 
 /obj/item/organ/external/proc/heal_damage(brute, burn, internal = 0, robo_repair = 0)
@@ -661,7 +661,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(DROPLIMB_BURN)
 			new /obj/effect/decal/cleanable/ash(get_turf(victim))
 		if(DROPLIMB_BLUNT)
-			var/obj/effect/decal/cleanable/blood/gibs/gore = new owner.species.single_gib_type(get_turf(victim))
+			var/obj/effect/decal/cleanable/blood/gibs/gore = new victim.species.single_gib_type(get_turf(victim))
 			if(victim.species.flesh_color)
 				gore.fleshcolor = victim.species.flesh_color
 			if(victim.species.blood_color)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -75,7 +75,11 @@
 				if(contents.len)
 					var/obj/item/removing = pick(contents)
 					removing.loc = get_turf(user.loc)
-					if(!(user.l_hand && user.r_hand))
+					var/obj/item/organ/O = removing
+					if(istype(O))
+						O.status |= ORGAN_CUT_AWAY
+						O.removed(user)
+					else if(!(user.l_hand && user.r_hand))
 						user.put_in_hands(removing)
 					user.visible_message("<span class='danger'><b>[user]</b> extracts [removing] from [src] with [W]!")
 				else


### PR DESCRIPTION
### Current Changes
- Removes the rejecting var from organs, I forgot to remove this along with organ rejection.
- Fixes droplimb runtime.
 - As a result, brute damage goring and burn ashing DESTROYS whatever limb was dismembered. They didn't do so before, due to the runtime.
- Fixes another runtime in organ_external.dm
- Makes it so you can actually clone brain transplantees again.
- Makes it so you can actually rejuvenate brain transplantees again.
- [x] Makes slime person braincores able to be placed in humanized monkeys again.
- Organ removal on a detached head now properly sets it up as if it had been removed normally, it was previously bugged as the organ was simply removed from the head without setting anything.
- unEquip no longer drops organs.
- Fixes #832
 - Fixes slime person and golem brains being damaged by EMPs.


 # De-Limb Issue
Fixing the droplimb runtime created another issue, which was previously a feature, that being that de-limbing via burn damage and non-sharp brute damage destroy organs instead of just dropping them. Another problem is that non-sharp brute damage de-limbing a person's head does not result in a brain dropping, which was what it did before #710, but after #671.