### PR TITLE
TG Spider Port

### DIFF
--- a/code/game/gamemodes/changeling/powers/spiders.dm
+++ b/code/game/gamemodes/changeling/powers/spiders.dm
@@ -8,9 +8,9 @@
 
 //Makes some spiderlings. Good for setting traps and causing general trouble.
 /obj/effect/proc_holder/changeling/spiders/sting_action(var/mob/user)
-	for(var/i=0, i<4, i++)
+	for(var/i=0, i<2, i++)
 		var/obj/effect/spider/spiderling/S = new(user.loc)
-		S.grow_as = /mob/living/simple_animal/hostile/giant_spider/hunter
+		S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter
 
 	feedback_add_details("changeling_powers","SI")
 	return 1

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -22,9 +22,9 @@
 
 /obj/effect/spider/attackby(var/obj/item/weapon/W, var/mob/user, params)
 	if(W.attack_verb.len)
-		visible_message("\red <B>\The [src] have been [pick(W.attack_verb)] with \the [W][(user ? " by [user]." : ".")]")
+		visible_message("<span class='danger'>[user] has [pick(W.attack_verb)] \the [src] with \the [W]!</span>")
 	else
-		visible_message("\red <B>\The [src] have been attacked with \the [W][(user ? " by [user]." : ".")]")
+		visible_message("<span class='danger'>[user] has attacked \the [src] with \the [W]!</span>")
 
 	var/damage = W.force / 4.0
 
@@ -45,7 +45,7 @@
 
 /obj/effect/spider/proc/healthcheck()
 	if(health <= 0)
-		del(src)
+		qdel(src)
 
 /obj/effect/spider/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > 300)
@@ -54,17 +54,18 @@
 
 /obj/effect/spider/stickyweb
 	icon_state = "stickyweb1"
-	New()
-		if(prob(50))
-			icon_state = "stickyweb2"
+
+/obj/effect/spider/stickyweb/New()
+	if(prob(50))
+		icon_state = "stickyweb2"
 
 /obj/effect/spider/stickyweb/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1
-	if(istype(mover, /mob/living/simple_animal/hostile/giant_spider))
+	if(istype(mover, /mob/living/simple_animal/hostile/poison/giant_spider))
 		return 1
 	else if(istype(mover, /mob/living))
 		if(prob(50))
-			mover << "\red You get stuck in \the [src] for a moment."
+			mover << "<span class='danger'>You get stuck in \the [src] for a moment.</span>"
 			return 0
 	else if(istype(mover, /obj/item/projectile))
 		return prob(30)
@@ -75,37 +76,40 @@
 	desc = "They seem to pulse slightly with an inner life"
 	icon_state = "eggs"
 	var/amount_grown = 0
-	New()
-		pixel_x = rand(3,-3)
-		pixel_y = rand(3,-3)
-		processing_objects.Add(src)
+	var/player_spiders = 0
+
+/obj/effect/spider/eggcluster/New()
+	pixel_x = rand(3,-3)
+	pixel_y = rand(3,-3)
+	processing_objects.Add(src)
 
 /obj/effect/spider/eggcluster/process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
-		var/num = rand(2,6)
+		var/num = rand(3,12)
 		for(var/i=0, i<num, i++)
-			new /obj/effect/spider/spiderling(src.loc)
-		del(src)
+			var/obj/effect/spider/spiderling/S = new /obj/effect/spider/spiderling(src.loc)
+			if(player_spiders)
+				S.player_spiders = 1
+		qdel(src)
 
 /obj/effect/spider/spiderling
 	name = "spiderling"
 	desc = "It never stays still for long."
 	icon_state = "spiderling"
 	anchored = 0
-	layer = 2.7
+	layer = 2.75
 	health = 3
-	var/amount_grown = -1
+	var/amount_grown = 0
 	var/grow_as = null
 	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
 	var/travelling_in_vent = 0
-	New()
-		pixel_x = rand(6,-6)
-		pixel_y = rand(6,-6)
-		processing_objects.Add(src)
-		//50% chance to grow up
-		if(prob(50))
-			amount_grown = 1
+	var/player_spiders = 0
+
+/obj/effect/spider/spiderling/New()
+	pixel_x = rand(6,-6)
+	pixel_y = rand(6,-6)
+	processing_objects.Add(src)
 
 /obj/effect/spider/spiderling/Bump(atom/user)
 	if(istype(user, /obj/structure/table))
@@ -116,7 +120,7 @@
 /obj/effect/spider/spiderling/proc/die()
 	visible_message("<span class='alert'>[src] dies!</span>")
 	new /obj/effect/decal/cleanable/spiderling_remains(src.loc)
-	del(src)
+	qdel(src)
 
 /obj/effect/spider/spiderling/healthcheck()
 	if(health <= 0)
@@ -137,8 +141,9 @@
 					entry_vent = null
 					return
 				var/obj/machinery/atmospherics/unary/vent_pump/exit_vent = pick(vents)
-				/*if(prob(50))
-					src.visible_message("<B>[src] scrambles into the ventillation ducts!</B>")*/
+				if(prob(50))
+					visible_message("<B>[src] scrambles into the ventillation ducts!</B>", \
+									"<span class='notice'>You hear something squeezing through the ventilation ducts.</span>")
 
 				spawn(rand(20,60))
 					loc = exit_vent
@@ -151,7 +156,7 @@
 							return
 
 						if(prob(50))
-							src.visible_message("\blue You hear something squeezing through the ventilation ducts.",2)
+							audible_message("<span class='notice'>You hear something squeezing through the ventilation ducts.</span>")
 						sleep(travel_time)
 
 						if(!exit_vent || exit_vent.welded)
@@ -167,30 +172,34 @@
 				entry_vent = null
 	//=================
 
-	else if(prob(25))
-		var/list/nearby = oview(5, src)
+	else if(prob(33))
+		var/list/nearby = oview(10, src)
 		if(nearby.len)
 			var/target_atom = pick(nearby)
-			walk_to(src, target_atom, 5)
-			if(prob(25))
-				src.visible_message("\blue \the [src] skitters[pick(" away"," around","")].")
-	else if(prob(5))
+			walk_to(src, target_atom)
+			if(prob(40))
+				src.visible_message("<span class='notice'>\The [src] skitters[pick(" away"," around","")].</span>")
+	else if(prob(10))
 		//ventcrawl!
 		for(var/obj/machinery/atmospherics/unary/vent_pump/v in view(7,src))
 			if(!v.welded)
 				entry_vent = v
-				walk_to(src, entry_vent, 5)
+				walk_to(src, entry_vent, 1)
 				break
-
-	if(prob(1))
-		src.visible_message("\blue \the [src] chitters.")
-	if(isturf(loc) && amount_grown > 0)
+	if(isturf(loc))
 		amount_grown += rand(0,2)
 		if(amount_grown >= 100)
 			if(!grow_as)
-				grow_as = pick(typesof(/mob/living/simple_animal/hostile/giant_spider))
-			new grow_as(src.loc)
-			del(src)
+				grow_as = pick(typesof(/mob/living/simple_animal/hostile/poison/giant_spider))
+			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(src.loc)
+			if(player_spiders)
+				var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
+				var/client/C = null
+
+				if(candidates.len)
+					C = pick(candidates)
+					S.key = C.key
+			qdel(src)
 
 /obj/effect/decal/cleanable/spiderling_remains
 	name = "spiderling remains"
@@ -204,11 +213,11 @@
 	icon_state = "cocoon1"
 	health = 60
 
-	New()
+/obj/effect/spider/cocoon/New()
 		icon_state = pick("cocoon1","cocoon2","cocoon3")
 
 /obj/effect/spider/cocoon/Destroy()
-	src.visible_message("\red \the [src] splits open.")
+	src.visible_message("<span class='danger'>\The [src] splits open.</span>")
 	for(var/atom/movable/A in contents)
 		A.loc = src.loc
 	..()

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -26,6 +26,6 @@
 		var/obj/vent = pick(vents)
 		var/obj/effect/spider/spiderling/S = new(vent.loc)
 		if(prob(66))
-			S.grow_as = /mob/living/simple_animal/hostile/giant_spider/nurse
+			S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 		vents -= vent
 		spawncount--

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -10,11 +10,11 @@
 	speak_chance = 0
 	turns_per_move = 5
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/carpmeat
-	meat_amount = 1
+	meat_amount = 2
 	response_help = "pets the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"
-	speed = 4
+	speed = 0
 	maxHealth = 25
 	health = 25
 
@@ -23,6 +23,7 @@
 	melee_damage_upper = 15
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
+	speak_emote = list("gnashes")
 
 	//Space carp aren't affected by atmos.
 	min_oxy = 0
@@ -34,6 +35,7 @@
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
+	maxbodytemp = 1500
 
 
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -23,18 +23,18 @@
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
 	stop_automated_movement_when_pulled = 0
-	maxHealth = 60
-	health = 60
+	maxHealth = 200
+	health = 200
 	melee_damage_lower = 15
 	melee_damage_upper = 20
-	heat_damage_per_tick = 20
-	cold_damage_per_tick = 20
 	var/poison_per_bite = 5
-	var/poison_type = "toxin"
+	var/poison_type = "venom"
 	faction = list("spiders")
 	var/busy = 0
 	pass_flags = PASSTABLE
 	move_to_delay = 6
+	attacktext = "bites"
+	attack_sound = 'sound/weapons/bite.ogg'
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/giant_spider/nurse
@@ -43,6 +43,7 @@
 	icon_living = "nurse"
 	icon_dead = "nurse_dead"
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/spidereggs
+	meat_amount = 4
 	maxHealth = 40
 	health = 40
 	melee_damage_lower = 5
@@ -58,19 +59,19 @@
 	icon_state = "hunter"
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
-	maxHealth = 50
-	health = 50
+	maxHealth = 120
+	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	poison_per_bite = 5
-	move_to_delay = 4
+	move_to_delay = 5
 
 /mob/living/simple_animal/hostile/giant_spider/AttackingTarget()
 	..()
 	if(isliving(target))
 		var/mob/living/L = target
 		if(L.reagents)
-			L.reagents.add_reagent("toxin", poison_per_bite)
+			L.reagents.add_reagent("venom", poison_per_bite)
 			if(prob(poison_per_bite))
 				L << "\red You feel a tiny prick."
 				L.reagents.add_reagent(poison_type, 5)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -4,8 +4,24 @@
 #define MOVING_TO_TARGET 3
 #define SPINNING_COCOON 4
 
+/mob/living/simple_animal/hostile/poison
+	var/poison_per_bite = 5
+	var/poison_type = "venom"
+
+/mob/living/simple_animal/hostile/poison/AttackingTarget()
+	..()
+	if(isliving(target))
+		var/mob/living/L = target
+		if(L.reagents)
+			L.reagents.add_reagent("venom", poison_per_bite)
+			if(prob(poison_per_bite))
+				L << "<span class='danger'>You feel a tiny prick.</span>"
+				L.reagents.add_reagent(poison_type, poison_per_bite)
+
+
+
 //basic spider mob, these generally guard nests
-/mob/living/simple_animal/hostile/giant_spider
+/mob/living/simple_animal/hostile/poison/giant_spider
 	name = "giant spider"
 	desc = "Furry and black, it makes you shudder to look at it. This one has deep red eyes."
 	icon_state = "guard"
@@ -22,13 +38,12 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
-	stop_automated_movement_when_pulled = 0
 	maxHealth = 200
 	health = 200
 	melee_damage_lower = 15
 	melee_damage_upper = 20
-	var/poison_per_bite = 5
-	var/poison_type = "venom"
+	heat_damage_per_tick = 20	//amount of damage applied if animal's body temperature is higher than maxbodytemp
+	cold_damage_per_tick = 20	//same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
 	faction = list("spiders")
 	var/busy = 0
 	pass_flags = PASSTABLE
@@ -37,7 +52,7 @@
 	attack_sound = 'sound/weapons/bite.ogg'
 
 //nursemaids - these create webs and eggs
-/mob/living/simple_animal/hostile/giant_spider/nurse
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse
 	desc = "Furry and black, it makes you shudder to look at it. This one has brilliant green eyes."
 	icon_state = "nurse"
 	icon_living = "nurse"
@@ -54,7 +69,7 @@
 	var/fed = 0
 
 //hunters have the most poison and move the fastest, so they can find prey
-/mob/living/simple_animal/hostile/giant_spider/hunter
+/mob/living/simple_animal/hostile/poison/giant_spider/hunter
 	desc = "Furry and black, it makes you shudder to look at it. This one has sparkling purple eyes."
 	icon_state = "hunter"
 	icon_living = "hunter"
@@ -66,19 +81,9 @@
 	poison_per_bite = 5
 	move_to_delay = 5
 
-/mob/living/simple_animal/hostile/giant_spider/AttackingTarget()
+/mob/living/simple_animal/hostile/poison/giant_spider/Life()
 	..()
-	if(isliving(target))
-		var/mob/living/L = target
-		if(L.reagents)
-			L.reagents.add_reagent("venom", poison_per_bite)
-			if(prob(poison_per_bite))
-				L << "\red You feel a tiny prick."
-				L.reagents.add_reagent(poison_type, 5)
-
-/mob/living/simple_animal/hostile/giant_spider/Life()
-	..()
-	if(!stat)
+	if(!stat && !ckey)
 		if(stance == HOSTILE_STANCE_IDLE)
 			//1% chance to skitter madly away
 			if(!busy && prob(1))
@@ -93,7 +98,7 @@
 
 // Chops off each leg with a 50/50 chance of harvesting one, until finally calling
 // default harvest action
-/mob/living/simple_animal/hostile/giant_spider/harvest()
+/mob/living/simple_animal/hostile/poison/giant_spider/harvest()
 	if(butcher_state > 0)
 		butcher_state--
 		icon_state = icon_dead + "[butcher_state]"
@@ -104,7 +109,7 @@
 	else
 		return ..()
 
-/mob/living/simple_animal/hostile/giant_spider/nurse/proc/GiveUp(var/C)
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/proc/GiveUp(var/C)
 	spawn(100)
 		if(busy == MOVING_TO_TARGET)
 			if(cocoon_target == C && get_dist(src,cocoon_target) > 1)
@@ -112,16 +117,16 @@
 			busy = 0
 			stop_automated_movement = 0
 
-/mob/living/simple_animal/hostile/giant_spider/nurse/Life()
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/Life()
 	..()
-	if(!stat)
+	if(!stat && !ckey)
 		if(stance == HOSTILE_STANCE_IDLE)
 			var/list/can_see = view(src, 10)
 			//30% chance to stop wandering and do something
 			if(!busy && prob(30))
 				//first, check for potential food nearby to cocoon
 				for(var/mob/living/C in can_see)
-					if(C.stat && !istype(C,/mob/living/simple_animal/hostile/giant_spider))
+					if(C.stat && !istype(C,/mob/living/simple_animal/hostile/poison/giant_spider))
 						cocoon_target = C
 						busy = MOVING_TO_TARGET
 						Goto(C, move_to_delay)
@@ -132,29 +137,11 @@
 				//second, spin a sticky spiderweb on this tile
 				var/obj/effect/spider/stickyweb/W = locate() in get_turf(src)
 				if(!W)
-					busy = SPINNING_WEB
-					src.visible_message("\blue \the [src] begins to secrete a sticky substance.")
-					stop_automated_movement = 1
-					spawn(40)
-						if(busy == SPINNING_WEB)
-							new /obj/effect/spider/stickyweb(src.loc)
-							busy = 0
-							stop_automated_movement = 0
+					Web()
 				else
 					//third, lay an egg cluster there
-					var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
-					if(!E && fed > 0)
-						busy = LAYING_EGGS
-						src.visible_message("\blue \the [src] begins to lay a cluster of eggs.")
-						stop_automated_movement = 1
-						spawn(50)
-							if(busy == LAYING_EGGS)
-								E = locate() in get_turf(src)
-								if(!E)
-									new /obj/effect/spider/eggcluster(src.loc)
-									fed--
-								busy = 0
-								stop_automated_movement = 0
+					if(fed)
+						LayEggs()
 					else
 						//fourthly, cocoon any nearby items so those pesky pinkskins can't use them
 						for(var/obj/O in can_see)
@@ -172,113 +159,110 @@
 
 			else if(busy == MOVING_TO_TARGET && cocoon_target)
 				if(get_dist(src, cocoon_target) <= 1)
-					busy = SPINNING_COCOON
-					src.visible_message("\blue \the [src] begins to secrete a sticky substance around \the [cocoon_target].")
-					stop_automated_movement = 1
-					walk(src,0)
-					spawn(50)
-						if(busy == SPINNING_COCOON)
-							if(cocoon_target && istype(cocoon_target.loc, /turf) && get_dist(src,cocoon_target) <= 1)
-								var/obj/effect/spider/cocoon/C = new(cocoon_target.loc)
-								var/large_cocoon = 0
-								C.pixel_x = cocoon_target.pixel_x
-								C.pixel_y = cocoon_target.pixel_y
-								for(var/mob/living/M in C.loc)
-									if(istype(M, /mob/living/simple_animal/hostile/giant_spider))
-										continue
-									large_cocoon = 1
-									fed++
-									src.visible_message("\red \the [src] sticks a proboscis into \the [cocoon_target] and sucks a viscous substance out.")
-									M.loc = C
-									C.pixel_x = M.pixel_x
-									C.pixel_y = M.pixel_y
-									break
-								for(var/obj/item/I in C.loc)
-									I.loc = C
-								for(var/obj/structure/S in C.loc)
-									if(!S.anchored)
-										S.loc = C
-										large_cocoon = 1
-								for(var/obj/machinery/M in C.loc)
-									if(!M.anchored)
-										M.loc = C
-										large_cocoon = 1
-								if(large_cocoon)
-									C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
-							busy = 0
-							stop_automated_movement = 0
+					Wrap()
 
 		else
 			busy = 0
 			stop_automated_movement = 0
 
+/mob/living/simple_animal/hostile/poison/giant_spider/verb/Web()
+	set name = "Lay Web"
+	set category = "Spider"
+	set desc = "Spread a sticky web to slow down prey."
+
+	var/T = src.loc
+
+	if(busy != SPINNING_WEB)
+		busy = SPINNING_WEB
+		src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance.</span>")
+		stop_automated_movement = 1
+		spawn(40)
+			if(busy == SPINNING_WEB && src.loc == T)
+				new /obj/effect/spider/stickyweb(T)
+			busy = 0
+			stop_automated_movement = 0
 
 
-/mob/living/simple_animal/hostile/giant_spider/verb/web()
-	set category = "Alien"
-	set name = "Spin Web"
-	set desc = "Create a web that slows down movement."
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/verb/Wrap()
+	set name = "Wrap"
+	set category = "Spider"
+	set desc = "Wrap up prey to feast upon and objects for safe keeping."
 
-	var/obj/effect/spider/stickyweb/W = locate() in get_turf(src)
-	if(!W)
-		src.visible_message("\blue \the [src] begins to secrete a sticky substance.")
-		if(!do_after(src, 30)) return
-		new /obj/effect/spider/stickyweb(src.loc)
+	if(!cocoon_target)
+		var/list/choices = list()
+		for(var/mob/living/L in view(1,src))
+			if(L == src)
+				continue
+			if(Adjacent(L))
+				choices += L
+		for(var/obj/O in src.loc)
+			if(Adjacent(O))
+				choices += O
+		cocoon_target = input(src,"What do you wish to cocoon?") in null|choices
 
-
-/mob/living/simple_animal/hostile/giant_spider/nurse/verb/cocoon()
-	set category = "Alien"
-	set name = "Cocoon and Feed"
-	set desc = "Cocooned an incapacitated mob so you can feed upon it."
-
-	for(var/mob/living/P in range(1,src))
-		cocoon_target = P
-		if(P.stat && !istype(P,/mob/living/simple_animal/hostile/giant_spider))
-			if(get_dist(src, cocoon_target) <= 1)
-				src.visible_message("\blue \the [src] begins to secrete a sticky substance around \the [cocoon_target].")
-				if(!do_after(src, 30)) return
+	if(cocoon_target && busy != SPINNING_COCOON)
+		busy = SPINNING_COCOON
+		src.visible_message("<span class='notice'>\the [src] begins to secrete a sticky substance around \the [cocoon_target].</span>")
+		stop_automated_movement = 1
+		walk(src,0)
+		spawn(50)
+			if(busy == SPINNING_COCOON)
 				if(cocoon_target && istype(cocoon_target.loc, /turf) && get_dist(src,cocoon_target) <= 1)
 					var/obj/effect/spider/cocoon/C = new(cocoon_target.loc)
 					var/large_cocoon = 0
 					C.pixel_x = cocoon_target.pixel_x
 					C.pixel_y = cocoon_target.pixel_y
-					for(var/mob/living/M in C.loc)
-						if(istype(M, /mob/living/simple_animal/hostile/giant_spider))
-							continue
-						large_cocoon = 1
-						fed++
-						src.visible_message("\red \the [src] sticks a proboscis into \the [cocoon_target] and sucks a viscous substance out.")
-						M.loc = C
-						C.pixel_x = M.pixel_x
-						C.pixel_y = M.pixel_y
-						break
 					for(var/obj/item/I in C.loc)
 						I.loc = C
 					for(var/obj/structure/S in C.loc)
 						if(!S.anchored)
 							S.loc = C
-						large_cocoon = 1
+							large_cocoon = 1
 					for(var/obj/machinery/M in C.loc)
 						if(!M.anchored)
 							M.loc = C
+							large_cocoon = 1
+					for(var/mob/living/L in C.loc)
+						if(istype(L, /mob/living/simple_animal/hostile/poison/giant_spider))
+							continue
 						large_cocoon = 1
+						L.loc = C
+						C.pixel_x = L.pixel_x
+						C.pixel_y = L.pixel_y
+						fed++
+						visible_message("<span class='danger'>\the [src] sticks a proboscis into \the [L] and sucks a viscous substance out.</span>")
+
+						break
 					if(large_cocoon)
 						C.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
+			cocoon_target = null
+			busy = 0
+			stop_automated_movement = 0
 
-
-/mob/living/simple_animal/hostile/giant_spider/nurse/verb/eggs()
-	set category = "Alien"
+/mob/living/simple_animal/hostile/poison/giant_spider/nurse/verb/LayEggs()
 	set name = "Lay Eggs"
-	set desc = "Lay a clutch of eggs to make new spiderlings. Requires you to have fed."
+	set category = "Spider"
+	set desc = "Lay a clutch of eggs, but you must wrap a creature for feeding first."
 
 	var/obj/effect/spider/eggcluster/E = locate() in get_turf(src)
-	if(!E && fed > 0)
-		src.visible_message("\blue \the [src] begins to lay a cluster of eggs.")
-		if(!do_after(src, 30)) return
-		E = locate() in get_turf(src)
-		if(!E)
-			new /obj/effect/spider/eggcluster(src.loc)
-			fed--
+	if(E)
+		src << "<span class='notice'>There is already a cluster of eggs here!</span>"
+	else if(!fed)
+		src << "<span class='warning'>You are too hungry to do this!</span>"
+	else if(busy != LAYING_EGGS)
+		busy = LAYING_EGGS
+		src.visible_message("<span class='notice'>\the [src] begins to lay a cluster of eggs.</span>")
+		stop_automated_movement = 1
+		spawn(50)
+			if(busy == LAYING_EGGS)
+				E = locate() in get_turf(src)
+				if(!E)
+					var/obj/effect/spider/eggcluster/C = new /obj/effect/spider/eggcluster(src.loc)
+					if(ckey)
+						C.player_spiders = 1
+					fed--
+			busy = 0
+			stop_automated_movement = 0
 
 #undef SPINNING_WEB
 #undef LAYING_EGGS

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -465,8 +465,6 @@
 
 //Antag Creatures!
 /*	if(ispath(MP, /mob/living/simple_animal/hostile/carp) && !jobban_isbanned(src, "Syndicate"))
-		return 1
-	if(ispath(MP, /mob/living/simple_animal/hostile/giant_spider) && !jobban_isbanned(src, "Syndicate"))
 		return 1 */
 	if(ispath(MP, /mob/living/simple_animal/borer) && !jobban_isbanned(src, "alien") && !jobban_isbanned(src, "Syndicate"))
 		return 1

--- a/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_autocloner.dm
@@ -23,7 +23,7 @@
 	//33% chance to spawn nasties
 	if(prob(33))
 		spawn_type = pick(\
-		/mob/living/simple_animal/hostile/giant_spider/nurse,\
+		/mob/living/simple_animal/hostile/poison/giant_spider/nurse,\
 		/mob/living/simple_animal/hostile/alien,\
 		/mob/living/simple_animal/hostile/bear,\
 		/mob/living/simple_animal/hostile/creature,\

--- a/code/modules/research/xenoarchaeology/master_controller.dm
+++ b/code/modules/research/xenoarchaeology/master_controller.dm
@@ -10,9 +10,9 @@
 	"/mob/living/simple_animal/hostile/alien",\
 	"/mob/living/simple_animal/hostile/alien/drone",\
 	"/mob/living/simple_animal/hostile/alien/sentinel",\
-	"/mob/living/simple_animal/hostile/giant_spider",\
-	"/mob/living/simple_animal/hostile/giant_spider/hunter",\
-	"/mob/living/simple_animal/hostile/giant_spider/nurse",\
+	"/mob/living/simple_animal/hostile/poison/giant_spider",\
+	"/mob/living/simple_animal/hostile/poison/giant_spider/hunter",\
+	"/mob/living/simple_animal/hostile/poison/giant_spider/nurse",\
 	"/mob/living/simple_animal/hostile/creature",\
 	"/mob/living/simple_animal/hostile/samak",\
 	"/mob/living/simple_animal/hostile/diyaab",\


### PR DESCRIPTION
Port of TG's spiders.

TG's spiders are more or less the same as we have now, only the spiderlings are more difficult to kill (by virtue how how they move); the way the procs are handled in the spiders themselves are a organized a bit better (plus spans and non-relative pathing!), and spiders are actually something to contend with in a fight.

Additionally spiders now have full support for player control if an admin so deems it; this is different than the way it used to be in the past--this makes spiders function more like Xenos. If a player controlled spider lays eggs, those eggs will have the potential to pull from players with the BE_ALIEN flag enabled. 

This does buff spiders, in particular regular spiders and hunters--both of these classes will have more health and the hunter will move faster. That said, for the spider infestation event, there shouldn't be much of a difference in terms of balance to players. Why? Infestation only spawns spiderlings that will grow into Nurses (and their health is unchanged). End result; the infestation event, on start, will be about the same, but if the spiders are given a chance to get going, then the trouble WILL start.

Related to this:
- Nerfed changeling's spider ability from 4 spiderlings to 2--the reason it was 4 is because of our weak spiderlings+spiders.

Para unique changes: 

Spiders now inject the reagent "venom" when they bite someone as opposed to "toxin"---suggestion by @TheDZD. Will make damage scale; at first damage will start out smaller than on live, but as the spider bites you more and more, it could end up doing more damage. The window to fight against the spider should be much greater, but once he has you down, you're down (which isn't that much different from live) 

Other
- Carp should move a bit faster and be a bit more resistant to high temps (but provide more meat when killed).