### PR TITLE
[Goonchem] Custom Mix Sounds and Animated Dispenser

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -352,7 +352,7 @@ datum
 											ME2.name = "used slime extract"
 											ME2.desc = "This extract has been used up."
 
-								playsound(get_turf(my_atom), 'sound/effects/bubbles.ogg', 80, 1)
+								playsound(get_turf(my_atom), C.mix_sound, 80, 1)
 
 								C.on_reaction(src, created_volume)
 								reaction_occured = 1

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -177,6 +177,10 @@
 
 			R.add_reagent(href_list["dispense"], min(amount, energy * 10, space))
 			energy = max(energy - min(amount, energy * 10, space) / 10, 0)
+			overlays.Cut()
+			icon_beaker = image('icons/obj/chemical.dmi', src, "disp_beaker") //randomize beaker overlay position.
+			icon_beaker.pixel_x = rand(-10,5)
+			overlays += icon_beaker
 
 	if(href_list["remove"])
 		if(beaker)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -16,6 +16,7 @@ datum
 		var/list/secondary_results = list()		//additional reagents produced by the reaction
 		var/required_temp = 0
 		var/mix_message = "The solution begins to bubble."
+		var/mix_sound = 'sound/effects/bubbles.ogg'
 
 
 		proc
@@ -30,6 +31,8 @@ datum
 			result = null
 			required_reagents = list("water" = 1, "potassium" = 1)
 			result_amount = 2
+			mix_message = "The mixture explodes!"
+
 			on_reaction(var/datum/reagents/holder, var/created_volume)
 				var/datum/effect/effect/system/reagents_explosion/e = new()
 				e.set_up(round (created_volume/10, 1), holder.my_atom, 0, 0)

--- a/code/modules/reagents/newchem/food.dm
+++ b/code/modules/reagents/newchem/food.dm
@@ -407,6 +407,7 @@ datum/reagent/ectoplasm/reaction_turf(var/turf/T, var/volume)
 	required_reagents = list("corn_starch" = 1, "blood" = 1)
 	result_amount = 2
 	mix_message = "The mixture congeals into a bloody mass."
+	mix_sound = 'sound/effects/blobattack.ogg'
 
 /datum/reagent/mashedpotatoes
 	name = "Mashed potatoes"
@@ -457,6 +458,7 @@ datum/reagent/ectoplasm/reaction_turf(var/turf/T, var/volume)
 	required_reagents = list("hydrogenated_soybeanoil" = 2, "meatslurry" = 1, "plasma" = 1)
 	result_amount = 4
 	mix_message = "The mixture solidifies, taking a crystalline appearance."
+	mix_sound = 'sound/effects/blobattack.ogg'
 
 /datum/reagent/pepperoni
 	name = "Pepperoni"
@@ -494,3 +496,4 @@ datum/reagent/pepperoni/reaction_mob(var/mob/living/M, var/method=TOUCH, var/vol
 	required_reagents = list("beff" = 1, "saltpetre" = 1, "synthflesh" = 1)
 	result_amount = 2
 	mix_message = "The beff and the synthflesh combine to form a smoky red log."
+	mix_sound = 'sound/effects/blobattack.ogg'

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -148,6 +148,7 @@ datum/reagent/charcoal/on_mob_life(var/mob/living/M as mob)
 	required_reagents = list("blood" = 1, "carbon" = 1, "styptic_powder" = 1)
 	result_amount = 3
 	mix_message = "The mixture knits together into a fibrous, bloody mass."
+	mix_sound = 'sound/effects/blobattack.ogg'
 
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"

--- a/code/modules/reagents/newchem/other.dm
+++ b/code/modules/reagents/newchem/other.dm
@@ -101,6 +101,7 @@ datum/reagent/acetone
 	required_reagents = list("oil" = 1)
 	result_amount = 0.5
 	required_temp = 480
+	mix_sound = null
 
 datum/reagent/colorful_reagent
 	name = "Colorful Reagent"
@@ -163,6 +164,7 @@ datum/reagent/corgium
 	required_reagents = list("egg" = 1, "colorful_reagent" = 1, "chicken_soup" = 1, "strange_reagent" = 1, "blood" = 1)
 	result_amount = 5
 	required_temp = 374
+	mix_message = "The substance turns an airy sky-blue and foams up into a new shape."
 
 /datum/chemical_reaction/flaptonium/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -32,7 +32,7 @@
 	id = "clf3"
 	result = "clf3"
 	required_reagents = list("chlorine" = 1, "fluorine" = 3)
-	result_amount = 3
+	result_amount = 2
 	required_temp = 424
 
 /datum/reagent/clf3/on_mob_life(var/mob/living/M as mob)
@@ -174,6 +174,7 @@
 	result_amount = 1
 	required_temp = 474
 	mix_message = "sparks start flying about."
+	mix_sound = null
 
 datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	src = null
@@ -216,7 +217,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	name = "Flash powder"
 	id = "flash_powder"
 	result = "flash_powder"
-	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1 )
+	required_reagents = list("aluminum" = 1, "potassium" = 1, "sulfur" = 1, "chlorine" = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/flash_powder_flash
@@ -269,7 +270,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	id = "smoke_powder"
 	result = "smoke_powder"
 	required_reagents = list("stabilizing_agent" = 1, "potassium" = 1, "sugar" = 1, "phosphorus" = 1)
-	result_amount = 1
+	result_amount = 3
 	mix_message = "The mixture sets into a greyish powder!"
 
 /datum/chemical_reaction/smoke
@@ -305,6 +306,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	secondary = 1
 	result_amount = 1
 	forbidden_reagents = list()
+	mix_sound = null
 
 /datum/reagent/sonic_powder
 	name = "Sonic Powder"

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -142,6 +142,7 @@ datum/reagent/neurotoxin2/on_mob_life(var/mob/living/M as mob)
 	required_reagents = list("space_drugs" = 1)
 	result_amount = 1
 	required_temp = 674
+	mix_sound = null
 
 datum/reagent/cyanide
 	name = "Cyanide"
@@ -209,6 +210,7 @@ datum/reagent/itching_powder/on_mob_life(var/mob/living/M as mob)
 	required_reagents = list("fuel" = 1, "ammonia" = 1, "fungus" = 1)
 	result_amount = 3
 	mix_message = "The mixture congeals and dries up, leaving behind an abrasive powder."
+	mix_sound = 'sound/effects/blobattack.ogg'
 
 datum/reagent/facid/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom


### PR DESCRIPTION
Adds in support for custom mix message sounds

- Simply put instead of a mixture always playing the bubbling noise, a chemical reaction can play a specific custom noise now. Here's a few that will play a different sound:
 - A few food reagents, synth flesh, and itching powder all use a custom sound
 - A few reagents have no mix sound (neurotoxin, black powder, smoke powder, and ash, for now).
 - More will be added, as they come (eventually all drinks are likely to use a fizzing sound).

New, real chemical dispensing action (wow!); just look how happy he is: 

![dispense](http://i.gyazo.com/ef93f23a38b6a7d8b8d02ffe16cac63e.gif)
Each time you dispense a reagent it will place the beaker at a new random position
 - This applies to the bartender machines as well
  - RIP faking that you're working in chemistry/the bar.

Other  
- Tweaked a few existing recipes numbers to align up properly
- Mix messages and jazz