### PR TITLE
Donk Pocket Fix

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -218,29 +218,15 @@
 		/obj/item/weapon/reagent_containers/food/snacks/dough,
 		/obj/item/weapon/reagent_containers/food/snacks/meatball
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/donkpocket //SPECIAL
-	proc/warm_up(var/obj/item/weapon/reagent_containers/food/snacks/donkpocket/being_cooked)
-		being_cooked.warm = 1
-		being_cooked.reagents.add_reagent("omnizine", 15)
-		being_cooked.bitesize = 6
-		being_cooked.name = "Warm " + being_cooked.name
-		being_cooked.cooltime()
-	make_food(var/obj/container as obj)
-		var/obj/item/weapon/reagent_containers/food/snacks/donkpocket/being_cooked = ..(container)
-		warm_up(being_cooked)
-		return being_cooked
+	result = /obj/item/weapon/reagent_containers/food/snacks/donkpocket
 
 /datum/recipe/microwave/donkpocket/warm
 	reagents = list() //This is necessary since this is a child object of the above recipe and we don't want donk pockets to need flour
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/donkpocket
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/donkpocket //SPECIAL
-	make_food(var/obj/container as obj)
-		var/obj/item/weapon/reagent_containers/food/snacks/donkpocket/being_cooked = locate() in container
-		if(being_cooked && !being_cooked.warm)
-			warm_up(being_cooked)
-		return being_cooked
+	result = /obj/item/weapon/reagent_containers/food/snacks/donkpocket/warm
+
 
 /*
 /datum/recipe/microwave/meatbread

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -220,12 +220,11 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/donkpocket
 
-/datum/recipe/microwave/donkpocket/warm
-	reagents = list() //This is necessary since this is a child object of the above recipe and we don't want donk pockets to need flour
+/datum/recipe/microwave/warmdonkpocket
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/donkpocket
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/donkpocket/warm
+	result = /obj/item/weapon/reagent_containers/food/snacks/warmdonkpocket
 
 
 /*

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -799,14 +799,11 @@
 		..()
 		reagents.add_reagent("nutriment", 4)
 
-	var/warm = 0
-	proc/cooltime() //Not working, derp?
-		if (src.warm)
-			spawn( 4200 )
-				src.warm = 0
-				src.reagents.del_reagent("omnizine")
-				src.name = "donk-pocket"
-		return
+/obj/item/weapon/reagent_containers/food/snacks/donkpocket/warm
+	name = "Warm Donk-pocket"
+	New()
+		..()
+		reagents.add_reagent("omnizine", 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/syndidonkpocket
 	name = "Donk-pocket"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -799,10 +799,14 @@
 		..()
 		reagents.add_reagent("nutriment", 4)
 
-/obj/item/weapon/reagent_containers/food/snacks/donkpocket/warm
+/obj/item/weapon/reagent_containers/food/snacks/warmdonkpocket
 	name = "Warm Donk-pocket"
+	desc = "The food of choice for the seasoned traitor."
+	icon_state = "donkpocket"
+	filling_color = "#DEDEAB"
 	New()
 		..()
+		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("omnizine", 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/syndidonkpocket


### PR DESCRIPTION
RIP Donk Pocket Exploit lamers 2015

Fixes Warm Donk Pocket Recipe to not be such a gosh damn awful snowflake PoS.

- Donk pockets no longer have their own special snowflake code for heating up
- Warm Donk pockets are just a recipe that require regular donk pockets and results in a new item called "Warm Donk Pocket"
- lowered Omnizine amount from 15 to 4 (I forgot about microwave duplication)

This fixes being able to upgrade a microwave and produce literally infinite donk pockets

