### PR TITLE
Removes Changeling Bloodtest

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -379,6 +379,7 @@ datum
 			mix_message = "The mixture gives off a sharp acidic tang."
 
 ///////Changeling Blood Test/////////////
+/*
 		changeling_test
 			name = "Changeling blood test"
 			id = "changelingblood"
@@ -403,6 +404,7 @@ datum
 						M.show_message( "<span class ='notice'>The blood seems to break apart in the fuel.</span>", 1)
 				holder.del_reagent("blood")
 				return
+*/
 
 /////////////////////////////////////////////NEW SLIME CORE REACTIONS/////////////////////////////////////////////
 


### PR DESCRIPTION
Requested by @Earthdivine.

[Forum Post](http://nanotrasen.se/phpBB3/viewtopic.php?f=48&t=4391)

This was introduced back when loyalty implants still made people 100% loyal to the corporation and security would implant every suspected changeling without question, turning every changeling into a friendly antag, and making for a boring round.

Currently, security just goes around blood testing everyone to root out changelings, and stun + testing everyone who refuses. This results in all of the changelings being lynched and/or cremated, making for a boring round.

Note: The administration staff are currently looking into a spam-proof and suitable replacement for this, however thus far one has not been found. The concept of confirming a changeling is fine, but the current implementation is a bit... lacking.

@ The maintainers - Might want to tag this as controversial.