### PR TITLE
Makes IPCs unable to process reagents and eat pills

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -722,7 +722,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 	proc/handle_chemicals_in_body()
 
-		if(reagents) //Synths don't process reagents. // fuck you they do now - Iamgoofball
+		if(reagents && !(species.flags & IS_SYNTHETIC)) //Synths don't process reagents. // fuck you they do now - Iamgoofball // well they shouldn't
 			var/alien = 0
 			if(species && species.reagent_tag)
 				alien = species.reagent_tag

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -21,6 +21,12 @@
 		return
 	attack(mob/M as mob, mob/user as mob, def_zone)
 		if(M == user)
+			if(istype(M, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = M
+				if(H.species.flags & IS_SYNTHETIC)
+					H << "\red You have a monitor for a head, where do you think you're going to put that?"
+					return
+
 			M << "\blue You [apply_method] [src]."
 			M.unEquip(src) //icon update
 			if(reagents.total_volume)
@@ -33,6 +39,11 @@
 			return 1
 
 		else if(istype(M, /mob/living/carbon/human) )
+
+			var/mob/living/carbon/human/H = M
+			if(H.species.flags & IS_SYNTHETIC)
+				user << "\red They have a monitor for a head, where do you think you're going to put that?"
+				return
 
 			for(var/mob/O in viewers(world.view, user))
 				O.show_message("\red [user] attempts to force [M] to [apply_method] [src].", 1)


### PR DESCRIPTION
Reverts the changes made with goonchem which allowed IPCs to eat pills and
process reagents by adding checks for IS_SYNTHETIC.

Forum thread: http://nanotrasen.se/forum/viewtopic.php?f=48&t=4407