### PR TITLE
Adds Antagonist OOC

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -62,6 +62,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/global_man_up,
 	/client/proc/delbook,
 	/client/proc/empty_ai_core_toggle_latejoin,
+	/client/proc/aooc,
 	/client/proc/freeze,
 	/client/proc/freezemecha,
 	/client/proc/alt_check

--- a/code/modules/admin/verbs/antag-ooc.dm
+++ b/code/modules/admin/verbs/antag-ooc.dm
@@ -1,0 +1,20 @@
+/client/proc/aooc(msg as text)
+	set category = "OOC"
+	set name = "AOOC"
+	set desc = "Antagonist OOC"
+
+	if(!check_rights(R_ADMIN))	return
+
+	msg = sanitize(msg)
+	if(!msg)	return
+
+	var/display_name = src.key
+	if(holder && holder.fakekey)
+		display_name = holder.fakekey
+
+	for(var/mob/M in mob_list)
+		if((M.mind && M.mind.special_role && M.client) || (M.client && M.client.holder))
+			M << "<font color='#960018'><span class='ooc'><span class='prefix'>AOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+
+
+	log_ooc("(ANTAG) [key] : [msg]")

--- a/paradise.dme
+++ b/paradise.dme
@@ -844,6 +844,7 @@
 #include "code\modules\admin\verbs\adminpm.dm"
 #include "code\modules\admin\verbs\adminsay.dm"
 #include "code\modules\admin\verbs\alt_check.dm"
+#include "code\modules\admin\verbs\antag-ooc.dm"
 #include "code\modules\admin\verbs\atmosdebug.dm"
 #include "code\modules\admin\verbs\BrokenInhands.dm"
 #include "code\modules\admin\verbs\cinematic.dm"


### PR DESCRIPTION
Ported from Baystation12/Baystation12#8411

This adds a new OOC channel for admins that can be heard by all antagonists and anyone with R_ADMIN. Requested [here](http://nanotrasen.se/phpBB3/viewtopic.php?f=12&t=156). Antagonists cannot speak over this, only see it. I believe ERT members will hear this as well, since they have a special_role.

![AOOC](http://i.gyazo.com/cf3f1cadbab99cebe277e07ffb4a9aa7.png)