### PR TITLE
Bay play_server_sound caching & admin 'who' showing account age

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -26,6 +26,20 @@
 							entry += " - <font color='black'><b>DEAD</b></font>"
 					else
 						entry += " - <font color='black'><b>DEAD</b></font>"
+
+			var/age
+			if(isnum(C.player_age))
+				age = C.player_age
+			else
+				age = 0
+
+			if(age <= 1)
+				age = "<font color='#ff0000'><b>[age]</b></font>"
+			else if(age < 10)
+				age = "<font color='#ff8c00'><b>[age]</b></font>"
+
+			entry += " - [age]"
+
 			if(is_special_character(C.mob))
 				entry += " - <b><font color='red'>Antagonist</font></b>"
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -73,7 +73,8 @@ var/list/admin_verbs_ban = list(
 	)
 var/list/admin_verbs_sounds = list(
 	/client/proc/play_local_sound,
-	/client/proc/play_sound
+	/client/proc/play_sound,
+	/client/proc/play_server_sound
 	)
 var/list/admin_verbs_event = list(
 	/client/proc/object_talk,

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -1,3 +1,5 @@
+var/list/sounds_cache = list()
+
 /client/proc/play_sound(S as sound)
 	set category = "Event"
 	set name = "Play Global Sound"
@@ -5,6 +7,11 @@
 
 	var/sound/uploaded_sound = sound(S, repeat = 0, wait = 1, channel = 777)
 	uploaded_sound.priority = 250
+
+	sounds_cache += S
+
+	if(alert("Are you sure?\nSong: [S]\nNow you can also play this sound using \"Play Server Sound\".", "Confirmation request" ,"Play", "Cancel") == "Cancel")
+		return
 
 	log_admin("[key_name(src)] played sound [S]")
 	message_admins("[key_name_admin(src)] played sound [S]", 1)
@@ -25,6 +32,21 @@
 	playsound(get_turf_loc(src.mob), S, 50, 0, 0)
 	feedback_add_details("admin_verb","PLS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/play_server_sound()
+	set category = "Event"
+	set name = "Play Server Sound"
+	if(!check_rights(R_SOUNDS))	return
+
+	var/list/sounds = file2list("sound/serversound_list.txt");
+	sounds += "--CANCEL--"
+	sounds += sounds_cache
+
+	var/melody = input("Select a sound from the server to play", "Server sound list", "--CANCEL--") in sounds
+
+	if(melody == "--CANCEL--")	return
+
+	play_sound(melody)
+	feedback_add_details("admin_verb","PSS") //If you are copy-pasting this, ensure the 2nd paramter is unique to the new proc!
 
 /*
 /client/proc/cuban_pete()

--- a/sound/serversound_list.txt
+++ b/sound/serversound_list.txt
@@ -1,0 +1,9 @@
+sound/music/b12_combined_start.ogg
+sound/music/main.ogg
+sound/music/space.ogg
+sound/music/title1.ogg
+sound/music/title2.ogg
+sound/music/traitor.ogg
+sound/items/bikehorn.ogg
+sound/effects/siren.ogg
+sound/ambience/song_game.ogg


### PR DESCRIPTION
Ports one part of Baystation12/Baystation12#8411

Player notes: Nothing for players here, really

Admin notes:
 - Sound caching system for any play-global-sounds (and a preloaded list of the sounds/music folder)
  - This means that any sound you play once, you can just select from a list next time using the "Play Server Sound" button, which loads it from the cache instead of uploading it every time

- Admin 'who' showing account age
 - Using who will now show account age.