### PR TITLE
[WIP] Medical Doctor Hypospray

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -51,6 +51,10 @@
 
 	return
 
+/obj/item/weapon/reagent_containers/hypospray/CMO
+	name = "Ancient Hypospray"
+	desc = "An older model of the DeForest Medical Coroperation hypospray without those pesky reagent restrictions."
+
 /obj/item/weapon/reagent_containers/hypospray/CMO/New()
 	..()
 	reagents.add_reagent("omnizine", 30)
@@ -152,3 +156,12 @@
 	reagents.add_reagent("stimulants", 50)
 	update_icon()
 	return
+
+/obj/item/weapon/reagent_containers/hypospray/MD
+	name = "medical hypospray"
+	desc = "The newest model of DeForest Medical Corporation hypospray is a sterile, air-needle autoinjector for rapid administration of drugs to patients."
+	allowed = list (/datum/reagent/silver_sulfadiazine, /datum/reagent/styptic_powder, /datum/reagent/salglu_solution, /datum/reagent/charcoal, /datum/reagent/omnizine, /datum/reagent/potass_iodide, /datum/reagent/sal_acid, /datum/reagent/salbutamol, /datum/reagent/perfluorodecalin, /datum/reagent/ephedrine, /datum/reagent/diphenhydramine, /datum/reagent/morphine, /datum/reagent/oculine, /datum/reagent/epinephrine, /datum/reagent/mannitol, /datum/reagent/antihol, /datum/reagent/insulin, /datum/reagent/haloperidol)
+
+/obj/item/weapon/reagent_containers/hypospray/MD/New()
+	..()
+	reagents.add_reagent("salglu_solution", 30)


### PR DESCRIPTION
This adds a hypospray intended for medical doctors, and contains Saline-Glucose Solution on spawn. 
This is here to help doctors, and make it a bit easier for them, as it's already rough, and that little extra will help, and the list of drugs is a rough draft, some of the meds you can od on will probably be modified pending feedback.
Currently the allowed list does not work, i suspect due to it being a datum, and allowed is for objects.
Any help to get the restricted list of reagents to work would be greatly appreciated
Other changed to come include adding it to spawn in backpacks/pockets of medical doctors and paramedic, make sure it does not count as a steal objective, and possible give the CMO hypospray a minor makeover.