### PR TITLE
Adds digital camera to the protolathe construction menu.

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -40,3 +40,13 @@
 	materials = list("$metal" = 30, "$glass" = 10)
 	build_path = /obj/item/weapon/disk/tech_disk
 	category = list("Miscellaneous")
+
+/datum/design/digital_camera
+	name = "Digital Camera"
+	desc = "Produce an enhanced version of the standard issue camera."
+	id = "digitalcamera"
+	req_tech = list("programming" = 2, "materials" = 2)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 500, "$glass" = 300)
+	build_path = /obj/item/device/camera/digital
+	category = list("Miscellaneous")


### PR DESCRIPTION
The digital camera allows you to save up to 10 photos, and print or delete them whenever you want. It still requires film to print photos. The cameras in the librarian's and detective's offices are replaced with digital cameras.