### PR TITLE
Emergency Ventcrawl Patch

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -153,6 +153,8 @@ obj/machinery/atmospherics/proc/check_connect_types_construction(obj/machinery/a
 /obj/machinery/atmospherics/relaymove(mob/living/user, direction)
 	if(!(direction & initialize_directions)) //can't go in a way we aren't connecting to
 		return
+	if(user.machine == src) //temporary fix until we overhaul movement code
+		return
 
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction)
 	if(target_move)


### PR DESCRIPTION
Because we have insane-r movecode than VG, there was a bug that you could
end up getting violently sucked into an atmos machine and shoved out into
the vents. This commit fixes this in a workaround manner.