### PR TITLE
Misc Fixes

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -505,7 +505,7 @@
 			if(L == default_language)
 				dat += "<b>[L.name] (:[L.key])</b> - default - <a href='byond://?src=\ref[src];default_lang=reset'>reset</a><br/>[L.desc]<br/><br/>"
 			else
-				dat += "<b>[L.name] (:[L.key])</b> - <a href='byond://?src=\ref[src];default_lang=[L]'>set default</a><br/>[L.desc]<br/><br/>"
+				dat += "<b>[L.name] (:[L.key])</b> - <a href=\"byond://?src=\ref[src];default_lang=[L]\">set default</a><br/>[L.desc]<br/><br/>"
 
 	src << browse(dat, "window=checklanguage")
 

--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -5,11 +5,7 @@
 	set name = "Set Default Language"
 	set category = "IC"
 
-	if(default_language == "unathi")
-		src << "<span class='notice'>You will now speak Sinta'unathi if you do not specify a language when speaking.</span>"
-	else if(default_language == "tajaran")
-		src << "<span class='notice'>You will now speak Siik'tajr if you do not specify a language when speaking.</span>"
-	else if(language)
+	if(language)
 		src << "<span class='notice'>You will now speak [language] if you do not specify a language when speaking.</span>"
 	else
 		src << "<span class='notice'>You will now speak whatever your standard default language is if you do not specify one when speaking.</span>"

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -32,11 +32,11 @@
 	else
 		heal_overall_damage(0, -amount)
 
-/mob/living/silicon/robot/proc/get_damaged_components(var/brute, var/burn)
+/mob/living/silicon/robot/proc/get_damaged_components(var/brute, var/burn, var/get_all)
 	var/list/datum/robot_component/parts = list()
 	for(var/V in components)
 		var/datum/robot_component/C = components[V]
-		if(C.installed == 1) if((brute && C.brute_damage) || (burn && C.electronics_damage))
+		if(C.installed == 1 || get_all) if((brute && C.brute_damage) || (burn && C.electronics_damage))
 			parts += C
 	return parts
 

--- a/code/modules/mob/spirit/viewpoint.dm
+++ b/code/modules/mob/spirit/viewpoint.dm
@@ -113,7 +113,7 @@ var/obj/cult_viewpoint/list/cult_viewpoints = list()
 /obj/cult_viewpoint/proc/get_cult_name()
 	if (cult_name)
 		return cult_name
-	return "An Unknown Servent"
+	return "An Unknown Servant"
 
 
 /obj/cult_viewpoint/proc/set_cult_name(var/newName)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -293,7 +293,7 @@
 	energy = 5
 	max_energy = 5
 	amount = 5
-	recharge_delay = 30
+	recharge_delay = 10
 	dispensable_reagents = list()
 	var/list/special_reagents = list(list("hydrogen", "oxygen", "silicon", "phosphorus", "sulfur", "carbon", "nitrogen"),
 						 		list("lithium", "sugar", "water", "copper", "mercury", "sodium"),
@@ -323,7 +323,7 @@
 		time += C.rating
 	for(var/obj/item/weapon/stock_parts/cell/P in component_parts)
 		time += round(P.maxcharge, 10000) / 10000
-	recharge_delay /= time/2         //delay between recharges, double the usual time on lowest 50% less than usual on highest
+	recharge_delay = 10 / (time/2)         //delay between recharges, double the usual time on lowest 33% less than usual on highest
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		for(i=1, i<=M.rating, i++)
 			dispensable_reagents = sortList(dispensable_reagents | special_reagents[i])

--- a/code/modules/reagents/newchem/other.dm
+++ b/code/modules/reagents/newchem/other.dm
@@ -120,7 +120,7 @@ datum/reagent/colorful_reagent
 	mix_message = "The substance flashes multiple colors and emits the smell of a pocket protector."
 
 datum/reagent/colorful_reagent/reaction_mob(var/mob/living/simple_animal/M, var/method=TOUCH, var/volume)
-    if(M)
+    if(M && istype(M))
         M.color = pick(random_color_list)
     ..()
     return


### PR DESCRIPTION
Assuming I'm not somehow screwing up my first PR, this should do the following:

* Fixes the recharge delay on Portable Chem Dispensers. The delay range now matches up with the recently sped-up full-size dispensers, and can no longer be reduced below the intended value by whacking it with an RPED. (Fixes #684)
* Fixes Cyborg Analyzers not showing destroyed components. (Fixes #829)
![cyborg component damage](https://cloud.githubusercontent.com/assets/10916307/7391580/414232de-ee50-11e4-8c74-2ace93a66583.png)
* Fixes a typo: "An Unknown Servent".
* Fixes Colorful Reagent coloring mobs that aren't simple animals (regression from #816, previously fixed in #681).
* Fixes setting certain default languages through the Check Known Languages window. (*Actually* fixes #845)
  * The languages in question are Sinta'unathi and Siik'tajr. The apostrophe in their names was breaking the HTML.
  * Also removes some non-functional code from the previous fix attempt (#882).