### PR TITLE
Cigarette Fixes/Tweaks

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -543,7 +543,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/badass/syndiecigs
 	name = "Syndicate Smokes"
-	desc = "Strong flavor, dense smoke, infused with Doctor's Delight."
+	desc = "Strong flavor, dense smoke, infused with omnizine."
 	item = /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate
 	cost = 4
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -200,7 +200,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				reagents.reaction(C, INGEST)
 			reagents.trans_to(C, REAGENTS_METABOLISM)
 			if(!reagents.total_volume) // There were reagents, but now they're gone
-				C << "<span class='notice'>Your [name] no longer tastes the same...</span>"
+				C << "<span class='notice'>Your [name] loses its flavor.</span>"
 		else // else just remove some of the reagents
 			reagents.remove_any(REAGENTS_METABOLISM)
 	return

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -185,12 +185,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(iscarbon(loc))
 		var/mob/living/carbon/C = loc
 		if(src == C.wear_mask)
-			if(istype(loc, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = loc
-				if(!(H.species.flags & IS_SYNTHETIC)) // Silly synthetics, you can't smoke. You don't even have mouths.
-					is_being_smoked = 1
-			else
-				is_being_smoked = 1
+			// There used to be a species check here, but synthetics can smoke now
+			is_being_smoked = 1
 	if(location)
 		location.hotspot_expose(700, 5)
 	if(reagents && reagents.total_volume)	//	check if it has any reagents at all

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -67,12 +67,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/type_butt = /obj/item/weapon/cigbutt
 	var/lastHolder = null
 	var/smoketime = 300
-	var/chem_volume = 15
+	var/chem_volume = 30
 
 /obj/item/clothing/mask/cigarette/New()
 	..()
 	flags |= NOREACT // so it doesn't react until you light it
-	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
+	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 30
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	..()
@@ -258,11 +258,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throw_speed = 0.5
 	item_state = "cigaroff"
 	smoketime = 1500
-	chem_volume = 20
+	chem_volume = 40
 
 /obj/item/clothing/mask/cigarette/cigar/New()
 	..()
-	reagents.add_reagent("nicotine", chem_volume)
+	reagents.add_reagent("nicotine", chem_volume/2)
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
 	name = "Cohiba Robusto Cigar"
@@ -278,7 +278,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_on = "cigar2on"
 	icon_off = "cigar2off"
 	smoketime = 7200
-	chem_volume = 30
+	chem_volume = 60
 
 /obj/item/weapon/cigbutt
 	name = "cigarette butt"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -68,14 +68,11 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/lastHolder = null
 	var/smoketime = 300
 	var/chem_volume = 15
-	var/has_nicotine = 1
 
 /obj/item/clothing/mask/cigarette/New()
 	..()
 	flags |= NOREACT // so it doesn't react until you light it
 	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 15
-	if(has_nicotine)
-		reagents.add_reagent("nicotine", 15)
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	..()
@@ -231,7 +228,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "spliffoff"
 	smoketime = 180
 	chem_volume = 50
-	has_nicotine = 0 // The plants these are made from don't actually contain nicotine
 
 /obj/item/clothing/mask/cigarette/joint/New()
 	..()
@@ -267,6 +263,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "cigaroff"
 	smoketime = 1500
 	chem_volume = 20
+
+/obj/item/clothing/mask/cigarette/cigar/New()
+	..()
+	reagents.add_reagent("nicotine", chem_volume)
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
 	name = "Cohiba Robusto Cigar"
@@ -322,6 +322,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_off = "pipeoff"
 	smoketime = 1000
 	chem_volume = 50
+
+/obj/item/clothing/mask/cigarette/pipe/New()
+	..()
+	reagents.add_reagent("nicotine", chem_volume)
 
 /obj/item/clothing/mask/cigarette/pipe/light(var/flavor_text = "[usr] lights the [name].")
 	if(!src.lit)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -176,22 +176,28 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 
 /obj/item/clothing/mask/cigarette/attack_self(mob/user as mob)
-	if(lit == 1)
+	if(lit)
 		user.visible_message("<span class='notice'>[user] calmly drops and treads on the lit [src], putting it out instantly.</span>")
 		die()
 	return ..()
 
 /obj/item/clothing/mask/cigarette/proc/smoke()
 	var/turf/location = get_turf(src)
-	var/smoker_is_synthetic = 0
-	if(istype(loc, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = loc
-		if(H.species.flags & IS_SYNTHETIC)
-			smoker_is_synthetic = 1 // Synthetics can't smoke!
+	var/is_being_smoked = 0
+	// Check whether this is actually in a mouth, being smoked
+	if(iscarbon(loc))
+		var/mob/living/carbon/C = loc
+		if(src == C.wear_mask)
+			if(istype(loc, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = loc
+				if(!(H.species.flags & IS_SYNTHETIC)) // Silly synthetics, you can't smoke. You don't even have mouths.
+					is_being_smoked = 1
+			else
+				is_being_smoked = 1
 	if(location)
 		location.hotspot_expose(700, 5)
 	if(reagents && reagents.total_volume)	//	check if it has any reagents at all
-		if(iscarbon(loc) && (src == loc:wear_mask) && !smoker_is_synthetic) // if it's in the human/monkey mouth, transfer reagents to the mob
+		if(is_being_smoked) // if it's being smoked, transfer reagents to the mob
 			var/mob/living/carbon/C = loc
 			if(prob(15)) // so it's not an instarape in case of acid
 				reagents.reaction(C, INGEST)
@@ -345,7 +351,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return
 
 /obj/item/clothing/mask/cigarette/pipe/attack_self(mob/user as mob) //Refills the pipe. Can be changed to an attackby later, if loose tobacco is added to vendors or something.
-	if(lit == 1)
+	if(lit)
 		user.visible_message("<span class='notice'>[user] puts out [src].</span>")
 		lit = 0
 		icon_state = icon_off

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -202,6 +202,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			reagents.remove_any(REAGENTS_METABOLISM)
 
 	if(has_nicotine && iscarbon(loc) && (src == loc:wear_mask) && !smoker_is_synthetic)
+		// If the cigarette has nicotine, make sure the smoker is getting a bit, even if it's not in the reagents
 		var/mob/living/carbon/C = loc
 		if (!C.reagents.has_reagent("nicotine"))
 			C.reagents.add_reagent("nicotine", 0.1)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -200,12 +200,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				C << "<span class='notice'>Your [name] no longer tastes the same...</span>"
 		else // else just remove some of the reagents
 			reagents.remove_any(REAGENTS_METABOLISM)
-
-	if(has_nicotine && iscarbon(loc) && (src == loc:wear_mask) && !smoker_is_synthetic)
-		// If the cigarette has nicotine, make sure the smoker is getting a bit, even if it's not in the reagents
-		var/mob/living/carbon/C = loc
-		if (!C.reagents.has_reagent("nicotine"))
-			C.reagents.add_reagent("nicotine", 0.1)
 	return
 
 /obj/item/clothing/mask/cigarette/proc/die()

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -154,6 +154,8 @@
 	slot_flags = SLOT_BELT
 	storage_slots = 6
 	can_hold = list("/obj/item/clothing/mask/cigarette")
+	cant_hold = list("/obj/item/clothing/mask/cigarette/cigar",
+		"/obj/item/clothing/mask/cigarette/pipe")
 	icon_type = "cigarette"
 	var/list/unlaced_cigarettes = list() // Cigarettes that haven't received reagents yet
 	var/default_reagents = list("nicotine" = 15) // List of reagents to pre-generate for each cigarette

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -155,13 +155,19 @@
 	storage_slots = 6
 	can_hold = list("/obj/item/clothing/mask/cigarette")
 	icon_type = "cigarette"
+	var/list/unlaced_cigarettes = list() // Cigarettes that haven't received reagents yet
+	var/default_reagents = list("nicotine" = 15) // List of reagents to pre-generate for each cigarette
 
 /obj/item/weapon/storage/fancy/cigarettes/New()
 	..()
 	flags |= NOREACT
-	for(var/i = 1 to storage_slots)
-		new /obj/item/clothing/mask/cigarette(src)
 	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	for(var/i = 1 to storage_slots)
+		var/obj/item/clothing/mask/cigarette/C = new /obj/item/clothing/mask/cigarette(src)
+		unlaced_cigarettes += C
+		for(var/R in default_reagents)
+			reagents.add_reagent(R, default_reagents[R])
+	
 
 /obj/item/weapon/storage/fancy/cigarettes/Destroy()
 	del(reagents)
@@ -173,22 +179,25 @@
 	desc = "There are [contents.len] cig\s left!"
 	return
 
+/obj/item/weapon/storage/fancy/cigarettes/proc/lace_cigarette(var/obj/item/clothing/mask/cigarette/C as obj)
+	if(istype(C) && (C in unlaced_cigarettes)) // Only transfer reagents to each cigarette once
+		reagents.trans_to(C, (reagents.total_volume/unlaced_cigarettes.len))
+		unlaced_cigarettes -= C
+		reagents.maximum_volume = 15 * unlaced_cigarettes.len
+
 /obj/item/weapon/storage/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)
-		var/obj/item/clothing/mask/cigarette/C = W
-		if(!istype(C)) return // what
-		reagents.trans_to(C, (reagents.total_volume/contents.len))
-		..()
+	lace_cigarette(W)
+	..()
 
 /obj/item/weapon/storage/fancy/cigarettes/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M, /mob))
 		return
 
-	if(M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
-		var/obj/item/clothing/mask/cigarette/W = new /obj/item/clothing/mask/cigarette(user)
-		reagents.trans_to(W, (reagents.total_volume/contents.len))
-		user.equip_to_slot_if_possible(W, slot_wear_mask)
-		reagents.maximum_volume = 15 * contents.len
-		contents.len--
+	if(istype(M) && M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
+		var/obj/item/clothing/mask/cigarette/C = contents[contents.len]
+		if(!istype(C)) return
+		lace_cigarette(C)
+		user.equip_to_slot_if_possible(C, slot_wear_mask)
 		user << "<span class='notice'>You take a cigarette out of the pack.</span>"
 		update_icon()
 	else
@@ -217,11 +226,7 @@
 	desc = "An obscure brand of cigarettes."
 	icon_state = "syndiepacket"
 	item_state = "cigpacket"
-
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate/New()
-	..()
-	for(var/i = 1 to storage_slots)
-		reagents.add_reagent("omnizine",15)
+	default_reagents = list("omnizine" = 15)
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_uplift
 	name = "\improper Uplift Smooth packet"
@@ -240,11 +245,7 @@
 	desc = "Smoked by the truly robust."
 	icon_state = "robustgpacket"
 	item_state = "cigpacket"
-
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_robustgold/New()
-	..()
-	for(var/i = 1 to storage_slots)
-		reagents.add_reagent("gold",1)
+	default_reagents = list("nicotine" = 14, "gold" = 1)
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_carp
 	name = "\improper Carp Classic packet"
@@ -263,14 +264,11 @@
 	desc = "Is your weight slowing you down? Having trouble running away from gravitational singularities? Can't stop stuffing your mouth? Smoke Shady Jim's Super Slims and watch all that fat burn away. Guaranteed results!"
 	icon_state = "shadyjimpacket"
 	item_state = "cigpacket"
-
-/obj/item/weapon/storage/fancy/cigarettes/cigpack_shadyjims/New()
-	..()
-	for(var/i = 1 to storage_slots)
-		reagents.add_reagent("lipolicide",4)
-		reagents.add_reagent("ammonia",2)
-		reagents.add_reagent("atrazine",1)
-		reagents.add_reagent("toxin",1.5)
+	default_reagents = list("nicotine" = 6.5,
+		"lipolicide" = 4,
+		"ammonia" = 2,
+		"atrazine" = 1,
+		"toxin" = 1.5)
 
 /*
  * Vial Box

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -163,7 +163,7 @@
 /obj/item/weapon/storage/fancy/cigarettes/New()
 	..()
 	flags |= NOREACT
-	create_reagents(15 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	create_reagents(30 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
 	for(var/i = 1 to storage_slots)
 		var/obj/item/clothing/mask/cigarette/C = new /obj/item/clothing/mask/cigarette(src)
 		unlaced_cigarettes += C
@@ -185,7 +185,7 @@
 	if(istype(C) && (C in unlaced_cigarettes)) // Only transfer reagents to each cigarette once
 		reagents.trans_to(C, (reagents.total_volume/unlaced_cigarettes.len))
 		unlaced_cigarettes -= C
-		reagents.maximum_volume = 15 * unlaced_cigarettes.len
+		reagents.maximum_volume = 30 * unlaced_cigarettes.len
 
 /obj/item/weapon/storage/fancy/cigarettes/remove_from_storage(obj/item/W as obj, atom/new_location)
 	lace_cigarette(W)
@@ -228,7 +228,7 @@
 	desc = "An obscure brand of cigarettes."
 	icon_state = "syndiepacket"
 	item_state = "cigpacket"
-	default_reagents = list("omnizine" = 15)
+	default_reagents = list("nicotine" = 15, "omnizine" = 15)
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_uplift
 	name = "\improper Uplift Smooth packet"
@@ -247,7 +247,7 @@
 	desc = "Smoked by the truly robust."
 	icon_state = "robustgpacket"
 	item_state = "cigpacket"
-	default_reagents = list("nicotine" = 14, "gold" = 1)
+	default_reagents = list("nicotine" = 15, "gold" = 1)
 
 /obj/item/weapon/storage/fancy/cigarettes/cigpack_carp
 	name = "\improper Carp Classic packet"
@@ -266,8 +266,8 @@
 	desc = "Is your weight slowing you down? Having trouble running away from gravitational singularities? Can't stop stuffing your mouth? Smoke Shady Jim's Super Slims and watch all that fat burn away. Guaranteed results!"
 	icon_state = "shadyjimpacket"
 	item_state = "cigpacket"
-	default_reagents = list("nicotine" = 6.5,
-		"lipolicide" = 4,
+	default_reagents = list("nicotine" = 15,
+		"lipolicide" = 7.5,
 		"ammonia" = 2,
 		"atrazine" = 1,
 		"toxin" = 1.5)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -63,7 +63,7 @@ datum
 					if(current_list_element > reagent_list.len) current_list_element = 1
 					var/datum/reagent/current_reagent = reagent_list[current_list_element]
 
-					src.remove_reagent(current_reagent.id, 1)
+					src.remove_reagent(current_reagent.id, min(1, amount - total_transfered))
 
 					current_list_element++
 					total_transfered++

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -11,14 +11,14 @@ datum/reagent/nicotine
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 35
-	addiction_threshold = 30
+	addiction_threshold = 0.1
 
 datum/reagent/nicotine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	var/smoke_message = pick("You can just feel your lungs dying!", "You feel relaxed.", "You feel calmed.", "You feel the lung cancer forming.", "You feel the money you wasted.", "You feel like a space cowboy.", "You feel rugged.")
 	if(prob(5))
 		M << "<span class='notice'>[smoke_message]</span>"
-	if(prob(50))
+	if(volume >= 0.2 && prob(50)) // Trace amounts of nicotine are ineffective
 		M.AdjustParalysis(-1)
 		M.AdjustStunned(-1)
 		M.AdjustWeakened(-1)

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -11,14 +11,14 @@ datum/reagent/nicotine
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 35
-	addiction_threshold = 0.1
+	addiction_threshold = 30
 
 datum/reagent/nicotine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	var/smoke_message = pick("You can just feel your lungs dying!", "You feel relaxed.", "You feel calmed.", "You feel the lung cancer forming.", "You feel the money you wasted.", "You feel like a space cowboy.", "You feel rugged.")
 	if(prob(5))
 		M << "<span class='notice'>[smoke_message]</span>"
-	if(volume >= 0.2 && prob(50)) // Trace amounts of nicotine are ineffective
+	if(prob(50))
 		M.AdjustParalysis(-1)
 		M.AdjustStunned(-1)
 		M.AdjustWeakened(-1)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -158,6 +158,11 @@
 				if(!target.is_open_container() && !ismob(target) && !istype(target, /obj/item/weapon/reagent_containers/food) && !istype(target, /obj/item/slime_extract) && !istype(target, /obj/item/clothing/mask/cigarette) && !istype(target, /obj/item/weapon/storage/fancy/cigarettes))
 					user << "\red You cannot directly fill this object."
 					return
+				if(istype(target, /obj/item/clothing/mask/cigarette))
+					var/obj/item/clothing/mask/cigarette/C = target
+					if(istype(C.loc, /obj/item/weapon/storage/fancy/cigarettes))
+						user << "\red You cannot inject a cigarette while it's still in the pack."
+						return
 				if(target.reagents.total_volume >= target.reagents.maximum_volume)
 					user << "\red [target] is full."
 					return


### PR DESCRIPTION
This PR was originally meant to make smokables harmlessly addictive. Turns out, nicotine addiction isn't supposed to be harmless. Whoops!

It's now all about fixing/tweaking smokables ~~and nicotine~~.

* Synthetics will now receive reagents from smokables.
* Cigarettes and cigars can now hold double their previous reagent capacity.
  * Doubling cigarettes was meant to be part of the goonchem transition. Doubling cigars is a logical extension of this, since they're supposed to be bigger than cigarettes anyway.
  * This also fixes special varieties of cigarette not containing their intended reagents.
* Changes the way nicotine is pre-generated in smokables:
  * Cigars start off half full of nicotine.
  * Pipes start off filled to the brim with nicotine.
  * Cigarette packs come pre-laced with 15 nicotine per cigarette, with special varieties containing additional reagents.
    * This means the cigarettes from syndicate uplinks spawn with 15 nicotine and 15 omnizine. They cost 4TC, so they probably should!
      * Also, I fixed their uplink description, because why not?
    * It was necessary to increase the lipolicide in Shady Jim's Super Slims so there was enough to not get ignored during the reagent transfer. This doesn't change the effectiveness of the lipolicide, and the other reagents remain purely cosmetic.
  * Joints no longer spawn with nicotine.
* Fixes and cleans up cigarette pack lacing, which was several kinds of broken.
  * Lacing will no longer break if you put cigarettes back into the pack.
  * You can no longer lace cigarettes that haven't been removed from the pack (and thus, haven't yet been laced by the pack).
    * I needed to add code to syringes to accomplish this. It's right next to the other big snowflake check that cigarettes are part of, so that's probably fine.
  * Honestly, it's still pretty bad.
    * ~~Also, because all cigarette packs pre-generate enough reagents to fill the box, you can't even lace them anymore. I could have just removed it. Too late now!~~
* When a smokable's reagents run out, you'll get a message:
![](https://cloud.githubusercontent.com/assets/10916307/7439701/03d9bf6a-f054-11e4-9694-28525ac93d3b.png)
  * This is intended to make it a little more obvious when the smokable's reagents are depleted.
  * This might make it a little too easy to abuse refilling smokables. I can remove this if desired.
* Prevents putting cigars and pipes into cigarette packets.
* Consolidates and reorganizes some copy-pasted cigarette code.
* Fixes synthetics who try to smoke preventing a smokable's reagents from burning off.
* Fixes the `remove_any` proc of reagents datums not properly removing fractional values.
  * This was causing lit smokables that you weren't smoking to burn off reagents 150% faster than intended.
* ~~Nicotine now has an addiction threshold of 0.1. If you smoke, you'll be addicted. I guarantee it.~~
* ~~Nicotine now requires at least 0.2 units in your system for its stun-reducing benefits.~~
  * ~~The nicotine smokables start with will provide this. Their long-term nicotine content will not.~~
* ~~If a nicotine-based smokable does not have any nicotine in its reagents, it'll put 0.1 units in you anyway.~~
  * ~~This ensures that a smokable will sate your nicotine addiction until it burns out. Also, you'll keep getting the nicotine flavor texts!~~
* ~~Smokables now have a `has_nicotine` flag, which determines whether they get the default 15 units and provide passive nicotine.~~
  * ~~This is 1 for all smokables, except joints, which are made from plants that don't contain nicotine.~~
  * ~~I considered changing the 15 units to simply match the smokable's maximum capacity, but I'm not sure if that would impact balance.~~