### PR TITLE
Explosion Damage Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -247,7 +247,7 @@
 
 				while(limbs_affected != 0)
 					processing_dismember = pick(organs)
-					if(processing_dismember.name != "chest" && processing_dismember.name != "head" && processing_dismember.name != "groin")
+					if(processing_dismember.limb_name != "chest" && processing_dismember.limb_name != "head" && processing_dismember.limb_name != "groin")
 						processing_dismember.droplimb(1,pick(0,1,2),0,1)
 						limbs_affected -= 1
 
@@ -271,7 +271,7 @@
 
 				while(limbs_affected != 0)
 					processing_dismember = pick(organs)
-					if(processing_dismember.name != "chest" && processing_dismember.name != "head" && processing_dismember.name != "groin")
+					if(processing_dismember.limb_name != "chest" && processing_dismember.limb_name != "head" && processing_dismember.limb_name != "groin")
 						processing_dismember.droplimb(1,pick(0,2),0,1)
 						limbs_affected -= 1
 
@@ -281,7 +281,7 @@
 
 				while(limbs_affected != 0)
 					processing_dismember = pick(organs)
-					if(processing_dismember.name != "chest" && processing_dismember.name != "head" && processing_dismember.name != "groin")
+					if(processing_dismember.limb_name != "chest" && processing_dismember.limb_name != "head" && processing_dismember.limb_name != "groin")
 						processing_dismember.droplimb(1,pick(0,2),0,1)
 						limbs_affected -= 1
 
@@ -303,7 +303,7 @@
 
 				while(limbs_affected != 0)
 					processing_dismember = pick(organs)
-					if(processing_dismember.name != "chest" && processing_dismember.name != "head" && processing_dismember.name != "groin")
+					if(processing_dismember.limb_name != "chest" && processing_dismember.limb_name != "head" && processing_dismember.limb_name != "groin")
 						processing_dismember.droplimb(1,1,0,1)
 						limbs_affected -= 1
 
@@ -316,7 +316,7 @@
 	var/update = 0
 	var/weapon_message = "Explosive Blast"
 	for(var/obj/item/organ/external/temp in organs)
-		switch(temp.name)
+		switch(temp.limb_name)
 			if("head")
 				update |= temp.take_damage(b_loss * 0.2, f_loss * 0.2, used_weapon = weapon_message)
 			if("chest")


### PR DESCRIPTION
Fairly high priority fix

- Fixes a bug where explosion damage was pitiful unless a full-strength blast
- Fixes a bug where the chest and groin were eligible for explosion dismemberment (thus resulting in tiny explosions insta-killing you).


Given how this had to be fixed and how this damage works--who knows how many other things like this exist in the code that are broken because of the change of organ names and "   ".

Fixes: https://github.com/ParadiseSS13/Paradise/issues/912