### PR TITLE
 Procedural Map Generator Improvements - tgstation/-tg-station#9252

### DIFF
--- a/code/modules/procedural mapping/mapGenerator.dm
+++ b/code/modules/procedural mapping/mapGenerator.dm
@@ -178,15 +178,21 @@
 	"Same turfs"=CLUSTER_CHECK_SAME_TURFS, "Same atoms"=CLUSTER_CHECK_SAME_ATOMS, "Different turfs"=CLUSTER_CHECK_DIFFERENT_TURFS, \
 	"Different atoms"=CLUSTER_CHECK_DIFFERENT_ATOMS, "All turfs"=CLUSTER_CHECK_ALL_TURFS,"All atoms"=CLUSTER_CHECK_ALL_ATOMS)
 
-	var/moduleClusters = input("Cluster Flags","Map Gen Settings") as null|anything in clusters
+	var/moduleClusters = input("Cluster Flags (Cancel to leave unchanged from defaults)","Map Gen Settings") as null|anything in clusters
 	//null for default
-
-	if(moduleClusters)
+	
+	var/theCluster = 0
+	if(moduleClusters != "None")
 		if(!clusters[moduleClusters])
 			src << "Invalid Cluster Flags"
 			return
+		theCluster = clusters[moduleClusters]
+	else
+		theCluster =  CLUSTER_CHECK_NONE
+	
+	if(theCluster)
 		for(var/datum/mapGeneratorModule/M in N.modules)
-			M.clusterCheckFlags = clusters[moduleClusters]
+			M.clusterCheckFlags = theCluster
 
 
 	src << "Defining Region"

--- a/code/modules/procedural mapping/mapGenerator.dm
+++ b/code/modules/procedural mapping/mapGenerator.dm
@@ -3,8 +3,6 @@
 
 	//Map information
 	var/list/map = list()
-	var/turf/bottomLeft = null
-	var/turf/topRight = null
 
 	//mapGeneratorModule information
 	var/list/modules = list()
@@ -13,18 +11,30 @@
 	..()
 	initialiseModules()
 
-//Defines the region the map represents, sets map, bottomLeft, topRight
+//Defines the region the map represents, sets map
 //Returns the map
 /datum/mapGenerator/proc/defineRegion(var/turf/Start, var/turf/End)
 	if(!checkRegion(Start, End))
 		return 0
 
-	if(!Start || !End)
-		return 0
-	bottomLeft = Start
-	topRight = End
+	map = block(Start,End)
+	return map
 
-	map = block(bottomLeft,topRight)
+
+//Defines the region the map represents, as a CIRCLE!, sets map
+//Returns the map
+/datum/mapGenerator/proc/defineCircularRegion(var/turf/Start, var/turf/End)
+	if(!checkRegion(Start, End))
+		return 0
+
+	var/centerX = abs(max(End.x-Start.x,1))
+	var/centerY = abs(max(End.y-Start.y,1))
+	var/centerZ = abs(max(End.z-Start.z,1))
+	var/radius = abs(max(centerX,centerY)) //take the biggest displacement as the radius
+
+	var/turf/center = locate(centerX, centerY, centerZ) //spherical maps! because Idk
+
+	map = circlerange(center,radius)
 	return map
 
 

--- a/code/modules/procedural mapping/mapGenerator.dm
+++ b/code/modules/procedural mapping/mapGenerator.dm
@@ -63,6 +63,7 @@
 	if(replace)
 		undefineRegion()
 
+	//Sphere mode engage
 	var/evenCheckZ = 0
 	if(max(bigZ,lilZ) % 2 == 0)
 		evenCheckZ = centerZ+1
@@ -188,9 +189,8 @@
 			M.clusterCheckFlags = clusters[moduleClusters]
 
 
-	//src << "Defining Region"
-	N.defineCircularRegion(Start,End)
-	//N.defineRegion(Start, End)
+	src << "Defining Region"
+	N.defineRegion(Start, End)
 	src << "Region Defined"
 	src << "Generating Region"
 	N.generate()

--- a/code/modules/procedural mapping/mapGenerator.dm
+++ b/code/modules/procedural mapping/mapGenerator.dm
@@ -13,17 +13,20 @@
 
 //Defines the region the map represents, sets map
 //Returns the map
-/datum/mapGenerator/proc/defineRegion(var/turf/Start, var/turf/End)
+/datum/mapGenerator/proc/defineRegion(var/turf/Start, var/turf/End, var/replace = 0)
 	if(!checkRegion(Start, End))
 		return 0
 
-	map = block(Start,End)
+	if(replace)
+		undefineRegion()
+
+	map |= block(Start,End)
 	return map
 
 
 //Defines the region the map represents, as a CIRCLE!, sets map
 //Returns the map
-/datum/mapGenerator/proc/defineCircularRegion(var/turf/Start, var/turf/End)
+/datum/mapGenerator/proc/defineCircularRegion(var/turf/Start, var/turf/End, var/replace = 0)
 	if(!checkRegion(Start, End))
 		return 0
 
@@ -34,8 +37,16 @@
 
 	var/turf/center = locate(centerX, centerY, centerZ) //spherical maps! because Idk
 
-	map = circlerange(center,radius)
+	if(replace)
+		undefineRegion()
+
+	map |= circlerange(center,radius)
 	return map
+
+
+//Empties the map list, he's dead jim.
+/datum/mapGenerator/proc/undefineRegion()
+	map = list() //bai bai
 
 
 //Checks for and Rejects bad region coordinates

--- a/code/modules/procedural mapping/mapGenerator.dm
+++ b/code/modules/procedural mapping/mapGenerator.dm
@@ -11,11 +11,11 @@
 //Combined defines
 #define CLUSTER_CHECK_SAMES				24 //Don't let any of the same type cluster
 #define CLUSTER_CHECK_DIFFERENTS		6  //Don't let any of different types cluster
-#define CLUSTER_CHECK_ALL_TURFS			32 //Don't let ANY turfs cluster same and different types
-#define CLUSTER_CHECK_ALL_ATOMS			64 //Don't let ANY atoms cluster same and different types
+#define CLUSTER_CHECK_ALL_TURFS			10 //Don't let ANY turfs cluster same and different types
+#define CLUSTER_CHECK_ALL_ATOMS			20 //Don't let ANY atoms cluster same and different types
 
 //All
-#define CLUSTER_CHECK_ALL				96 //Don't let anything cluster, like, at all
+#define CLUSTER_CHECK_ALL				30 //Don't let anything cluster, like, at all
 
 
 /datum/mapGenerator

--- a/code/modules/procedural mapping/mapGeneratorModule.dm
+++ b/code/modules/procedural mapping/mapGeneratorModule.dm
@@ -42,7 +42,8 @@
 			if(clusterCheckFlags & CLUSTER_CHECK_SAME_TURFS)
 				clustering = rand(clusterMin,clusterMax)
 				for(var/turf/F in trange(clustering,T))
-					if(F.type == turfPath) //NOT istype(), exact typematching
+					//if(F.type == turfPath) //NOT istype(), exact typematching
+					if(istype(F,turfPath))
 						continue
 
 				if(locate(turfPath) in trange(clustering, T))
@@ -52,12 +53,14 @@
 			if(clusterCheckFlags & CLUSTER_CHECK_DIFFERENT_TURFS)
 				clustering = rand(clusterMin,clusterMax)
 				for(var/turf/F in trange(clustering,T))
-					if(F.type != turfPath)
+					//if(F.type != turfPath)
+					if(!(istype(F,turfPath)))
 						continue
 
 		//Success!
 		if(prob(spawnableTurfs[turfPath]))
 			T.ChangeTurf(turfPath)
+
 
 	//Atoms DO care whether atoms can be placed here
 	if(checkPlaceAtom(T))
@@ -71,14 +74,16 @@
 				if(clusterCheckFlags & CLUSTER_CHECK_SAME_ATOMS)
 					clustering = rand(clusterMin, clusterMax)
 					for(var/atom/movable/M in range(clustering,T))
-						if(M.type == atomPath)
+						//if(M.type == atomPath)
+						if(istype(M,atomPath))
 							continue
 
 				//You're DIFFERENT from me? I hate you I'm going home
 				if(clusterCheckFlags & CLUSTER_CHECK_DIFFERENT_ATOMS)
 					clustering = rand(clusterMin, clusterMax)
 					for(var/atom/movable/M in range(clustering,T))
-						if(M.type != atomPath)
+						//if(M.type != atomPath)
+						if(!(istype(M,atomPath)))
 							continue
 
 			//Success!
@@ -121,11 +126,11 @@
 //Settings appropriate for turfs/atoms that cover SOME of the map region, sometimes referred to as a splatter layer.
 /datum/mapGeneratorModule/splatterLayer
 	clusterCheckFlags = CLUSTER_CHECK_ALL
-	spawnableAtoms = list(/atom = 30)
-	spawnableTurfs = list(/turf = 30)
+	spawnableAtoms = list(/atom = 15)
+	spawnableTurfs = list(/turf = 15)
 
 //Settings appropriate for turfs/atoms that cover a lot of the map region, eg a dense forest.
 /datum/mapGeneratorModule/denseLayer
 	clusterCheckFlags = CLUSTER_CHECK_NONE
-	spawnableAtoms = list(/atom = 75)
-	spawnableTurfs = list(/turf = 75)
+	spawnableAtoms = list(/atom = 35)
+	spawnableTurfs = list(/turf = 35)

--- a/code/modules/procedural mapping/mapGeneratorModule.dm
+++ b/code/modules/procedural mapping/mapGeneratorModule.dm
@@ -5,7 +5,7 @@
 	var/list/spawnableTurfs = list()
 	var/clusterMax = 5
 	var/clusterMin = 1
-	var/clusterCheckFlags = CLUSTER_CHECK_ALL_ATOMS
+	var/clusterCheckFlags = CLUSTER_CHECK_SAME_ATOMS
 	var/allowAtomsOnSpace = FALSE
 
 
@@ -31,6 +31,7 @@
 		return 0
 
 	var/clustering = 0
+	var/skipLoopIteration = FALSE
 
 	//Turfs don't care whether atoms can be placed here
 	for(var/turfPath in spawnableTurfs)
@@ -42,20 +43,23 @@
 			if(clusterCheckFlags & CLUSTER_CHECK_SAME_TURFS)
 				clustering = rand(clusterMin,clusterMax)
 				for(var/turf/F in trange(clustering,T))
-					//if(F.type == turfPath) //NOT istype(), exact typematching
 					if(istype(F,turfPath))
-						continue
-
-				if(locate(turfPath) in trange(clustering, T))
+						skipLoopIteration = TRUE
+						break
+				if(skipLoopIteration)
+					skipLoopIteration = FALSE
 					continue
 
 			//You're DIFFERENT to me? I hate you I'm going home
 			if(clusterCheckFlags & CLUSTER_CHECK_DIFFERENT_TURFS)
 				clustering = rand(clusterMin,clusterMax)
 				for(var/turf/F in trange(clustering,T))
-					//if(F.type != turfPath)
 					if(!(istype(F,turfPath)))
-						continue
+						skipLoopIteration = TRUE
+						break
+				if(skipLoopIteration)
+					skipLoopIteration = FALSE
+					continue
 
 		//Success!
 		if(prob(spawnableTurfs[turfPath]))
@@ -74,17 +78,23 @@
 				if(clusterCheckFlags & CLUSTER_CHECK_SAME_ATOMS)
 					clustering = rand(clusterMin, clusterMax)
 					for(var/atom/movable/M in range(clustering,T))
-						//if(M.type == atomPath)
 						if(istype(M,atomPath))
-							continue
+							skipLoopIteration = TRUE
+							break
+					if(skipLoopIteration)
+						skipLoopIteration = FALSE
+						continue
 
 				//You're DIFFERENT from me? I hate you I'm going home
 				if(clusterCheckFlags & CLUSTER_CHECK_DIFFERENT_ATOMS)
 					clustering = rand(clusterMin, clusterMax)
 					for(var/atom/movable/M in range(clustering,T))
-						//if(M.type != atomPath)
 						if(!(istype(M,atomPath)))
-							continue
+							skipLoopIteration = TRUE
+							break
+					if(skipLoopIteration)
+						skipLoopIteration = FALSE
+						continue
 
 			//Success!
 			if(prob(spawnableAtoms[atomPath]))
@@ -126,11 +136,11 @@
 //Settings appropriate for turfs/atoms that cover SOME of the map region, sometimes referred to as a splatter layer.
 /datum/mapGeneratorModule/splatterLayer
 	clusterCheckFlags = CLUSTER_CHECK_ALL
-	spawnableAtoms = list(/atom = 15)
-	spawnableTurfs = list(/turf = 15)
+	spawnableAtoms = list(/atom = 30)
+	spawnableTurfs = list(/turf = 30)
 
 //Settings appropriate for turfs/atoms that cover a lot of the map region, eg a dense forest.
 /datum/mapGeneratorModule/denseLayer
 	clusterCheckFlags = CLUSTER_CHECK_NONE
-	spawnableAtoms = list(/atom = 35)
-	spawnableTurfs = list(/turf = 35)
+	spawnableAtoms = list(/atom = 75)
+	spawnableTurfs = list(/turf = 75)

--- a/code/modules/procedural mapping/mapGeneratorModules/nature.dm
+++ b/code/modules/procedural mapping/mapGeneratorModules/nature.dm
@@ -4,11 +4,11 @@
 
 //Pine Trees
 /datum/mapGeneratorModule/pineTrees
-	spawnableAtoms = list(/obj/structure/flora/tree/pine = 15)
+	spawnableAtoms = list(/obj/structure/flora/tree/pine = 30)
 
 //Dead Trees
 /datum/mapGeneratorModule/deadTrees
-	spawnableAtoms = list(/obj/structure/flora/tree/dead = 5)
+	spawnableAtoms = list(/obj/structure/flora/tree/dead = 10)
 
 //Random assortment of bushes
 /datum/mapGeneratorModule/randBushes
@@ -18,7 +18,7 @@
 	..()
 	spawnableAtoms = typesof(/obj/structure/flora/ausbushes)
 	for(var/i in spawnableAtoms)
-		spawnableAtoms[i] = 15
+		spawnableAtoms[i] = 20
 
 
 //Random assortment of rocks and rockpiles
@@ -34,4 +34,4 @@
 //Grass tufts with a high spawn chance
 /datum/mapGeneratorModule/denseLayer/grassTufts
 	spawnableTurfs = list()
-	spawnableAtoms = list(/obj/structure/flora/ausbushes/grassybush = 35)
+	spawnableAtoms = list(/obj/structure/flora/ausbushes/grassybush = 75)

--- a/code/modules/procedural mapping/mapGeneratorModules/nature.dm
+++ b/code/modules/procedural mapping/mapGeneratorModules/nature.dm
@@ -4,11 +4,11 @@
 
 //Pine Trees
 /datum/mapGeneratorModule/pineTrees
-	spawnableAtoms = list(/obj/structure/flora/tree/pine = 30)
+	spawnableAtoms = list(/obj/structure/flora/tree/pine = 15)
 
 //Dead Trees
 /datum/mapGeneratorModule/deadTrees
-	spawnableAtoms = list(/obj/structure/flora/tree/dead = 10)
+	spawnableAtoms = list(/obj/structure/flora/tree/dead = 5)
 
 //Random assortment of bushes
 /datum/mapGeneratorModule/randBushes
@@ -18,7 +18,7 @@
 	..()
 	spawnableAtoms = typesof(/obj/structure/flora/ausbushes)
 	for(var/i in spawnableAtoms)
-		spawnableAtoms[i] = 20
+		spawnableAtoms[i] = 15
 
 
 //Random assortment of rocks and rockpiles
@@ -34,4 +34,4 @@
 //Grass tufts with a high spawn chance
 /datum/mapGeneratorModule/denseLayer/grassTufts
 	spawnableTurfs = list()
-	spawnableAtoms = list(/obj/structure/flora/ausbushes/grassybush = 75)
+	spawnableAtoms = list(/obj/structure/flora/ausbushes/grassybush = 35)

--- a/code/modules/procedural mapping/mapGeneratorReadme.dm
+++ b/code/modules/procedural mapping/mapGeneratorReadme.dm
@@ -125,6 +125,7 @@ Variable Breakdown (For Mappers):
 		clusterMax - The max range to check for something being "too close" for this atom/turf to spawn, the true value is random between clusterMin and clusterMax
 		clusterMin - The min range to check for something being "too close" for this atom/turf to spawn, the true value is random between clusterMin and clusterMax
 		clusterCheckFlags - A Bitfield that controls how the cluster checks work, All based on clusterMin and clusterMax guides
+		allowAtomsOnSpace - A Boolean for if we allow atoms to spawn on space tiles
 
 		clusterCheckFlags flags:
 			CLUSTER_CHECK_NONE	0 			   //No checks are done, cluster as much as possible
@@ -133,6 +134,8 @@ Variable Breakdown (For Mappers):
 			CLUSTER_CHECK_SAME_TURFS		8  //Don't let turfs of the SAME type cluster
 			CLUSTER_CHECK_SAME_ATOMS		16 //Don't let atoms of the SAME type cluster
 
+			CLUSTER_CHECK_SAMES				24 //Don't let any of the same type cluster
+			CLUSTER_CHECK_DIFFERENTS		6  //Don't let any different types cluster
 			CLUSTER_CHECK_ALL_TURFS			32 //Don't let ANY turfs cluster same and different types
 			CLUSTER_CHECK_ALL_ATOMS			64 //Don't let ANY atoms cluster same and different types
 

--- a/code/modules/procedural mapping/mapGeneratorReadme.dm
+++ b/code/modules/procedural mapping/mapGeneratorReadme.dm
@@ -136,10 +136,10 @@ Variable Breakdown (For Mappers):
 
 			CLUSTER_CHECK_SAMES				24 //Don't let any of the same type cluster
 			CLUSTER_CHECK_DIFFERENTS		6  //Don't let any different types cluster
-			CLUSTER_CHECK_ALL_TURFS			32 //Don't let ANY turfs cluster same and different types
-			CLUSTER_CHECK_ALL_ATOMS			64 //Don't let ANY atoms cluster same and different types
+			CLUSTER_CHECK_ALL_TURFS			10 //Don't let ANY turfs cluster same and different types
+			CLUSTER_CHECK_ALL_ATOMS			20 //Don't let ANY atoms cluster same and different types
 
-			CLUSTER_CHECK_ALL				96 //Don't let anything cluster, like, at all
+			CLUSTER_CHECK_ALL				30 //Don't let anything cluster, like, at all
 
 
 

--- a/code/modules/procedural mapping/mapGeneratorReadme.dm
+++ b/code/modules/procedural mapping/mapGeneratorReadme.dm
@@ -11,9 +11,13 @@ mapGenerator:
 	Desc: a mapGenerator is a master datum that collects
 	and syncs all mapGeneratorModules in it's modules list
 
-	defineRegion(var/list/startList, var/list/endList)
+	defineRegion(var/turf/Start, var/turf/End)
 		Example: defineRegion(locate(1,1,1),locate(5,5,5))
 		Desc: Sets the bounds of the mapGenerator's "map"
+
+	defineCircularRegion(var/turf/Start, var/turf/End)
+		Example: defineCircularRegion(locate(1,1,1),locate(5,5,5))
+		Desc: Sets the mapGenerator's "map" as a circle, with center in the middle of Start and End's X,Y,Z coordinates
 
 	checkRegion(var/turf/Start, var/turf/End)
 		Example: checkRegion(locate(1,1,1), locate(5,5,5))
@@ -108,8 +112,6 @@ Variable Breakdown (For Mappers):
 
 	mapGenerator
 		map - INTERNAL, do not touch
-		bottomLeft - INTERNAL, do not touch
-		topRight - INTERNAL, do not touch
 		modules - A list of typepaths of mapGeneratorModules
 
 	mapGeneratorModule
@@ -118,13 +120,20 @@ Variable Breakdown (For Mappers):
 		spawnableTurfs - A list of typepaths and their probability to spawn, eg: spawnableTurfs = list(/turf/unsimulated/floor/grass = 100)
 		clusterMax - The max range to check for something being "too close" for this atom/turf to spawn, the true value is random between clusterMin and clusterMax
 		clusterMin - The min range to check for something being "too close" for this atom/turf to spawn, the true value is random between clusterMin and clusterMax
-		clusterCheckFlags - A Bitfield that controls how the cluster checks work.
+		clusterCheckFlags - A Bitfield that controls how the cluster checks work, All based on clusterMin and clusterMax guides
 
 		clusterCheckFlags flags:
-			CLUSTER_CHECK_NONE	0 //No checks are done, cluster as much as possible
-			CLUSTER_CHECK_ATOMS	2 //Don't let atoms cluster, based on clusterMin and clusterMax as guides
-			CLUSTER_CHECK_TURFS	4 //Don't let turfs cluster, based on clusterMin and clusterMax as guides
-			CLUSTER_CHECK_ALL	6 //Don't let anything cluster, based on clusterMind and clusterMax as guides
+			CLUSTER_CHECK_NONE	0 			   //No checks are done, cluster as much as possible
+			CLUSTER_CHECK_DIFFERENT_TURFS	2  //Don't let turfs of DIFFERENT types cluster
+			CLUSTER_CHECK_DIFFERENT_ATOMS	4  //Don't let atoms of DIFFERENT types cluster
+			CLUSTER_CHECK_SAME_TURFS		8  //Don't let turfs of the SAME type cluster
+			CLUSTER_CHECK_SAME_ATOMS		16 //Don't let atoms of the SAME type cluster
+
+			CLUSTER_CHECK_ALL_TURFS			32 //Don't let ANY turfs cluster same and different types
+			CLUSTER_CHECK_ALL_ATOMS			64 //Don't let ANY atoms cluster same and different types
+
+			CLUSTER_CHECK_ALL				96 //Don't let anything cluster, like, at all
+
 
 
 */

--- a/code/modules/procedural mapping/mapGeneratorReadme.dm
+++ b/code/modules/procedural mapping/mapGeneratorReadme.dm
@@ -11,18 +11,22 @@ mapGenerator:
 	Desc: a mapGenerator is a master datum that collects
 	and syncs all mapGeneratorModules in it's modules list
 
-	defineRegion(var/turf/Start, var/turf/End)
-		Example: defineRegion(locate(1,1,1),locate(5,5,5))
+	defineRegion(var/turf/Start, var/turf/End, var/replace = 0)
+		Example: defineRegion(locate(1,1,1),locate(5,5,5),0)
 		Desc: Sets the bounds of the mapGenerator's "map"
 
-	defineCircularRegion(var/turf/Start, var/turf/End)
-		Example: defineCircularRegion(locate(1,1,1),locate(5,5,5))
+	defineCircularRegion(var/turf/Start, var/turf/End, var/replace = 0)
+		Example: defineCircularRegion(locate(1,1,1),locate(5,5,5),0)
 		Desc: Sets the mapGenerator's "map" as a circle, with center in the middle of Start and End's X,Y,Z coordinates
+
+	undefineRegion()
+		Example: undefineRegion()
+		Desc: Empties the map generator list
 
 	checkRegion(var/turf/Start, var/turf/End)
 		Example: checkRegion(locate(1,1,1), locate(5,5,5))
 		Desc: Checks if a rectangle between Start's coords and End's coords is valid
-		Existing Calls: mapGenerator/defineRegion()
+		Existing Calls: mapGenerator/defineRegion(), mapGenerator/defineCircularRegion()
 
 	generate()
 		Example: generate()

--- a/code/modules/procedural mapping/mapGenerators/nature.dm
+++ b/code/modules/procedural mapping/mapGenerators/nature.dm
@@ -2,9 +2,9 @@
 //Exists primarily as a test type.
 
 /datum/mapGenerator/nature
-	modules = list(/datum/mapGeneratorModule/pineTrees, \
+	modules = list(/datum/mapGeneratorModule/bottomLayer/grassTurfs, \
+	/datum/mapGeneratorModule/pineTrees, \
 	/datum/mapGeneratorModule/deadTrees, \
 	/datum/mapGeneratorModule/randBushes, \
 	/datum/mapGeneratorModule/randRocks, \
-	/datum/mapGeneratorModule/bottomLayer/grassTurfs, \
 	/datum/mapGeneratorModule/denseLayer/grassTufts)


### PR DESCRIPTION
>- Fixes a bug where turf cluster checks checked for atoms instead of turfs
- Changes to the clusterCheckFlag system by replacing + adding new defines
- Adds a proc `defineCircularRegion()` to define a circular map region, CIRCLES and SPHERES!
- `defineRegion()` and `defineCircularRegion()` no longer replace the map eniterely, they now add all the new turfs to the map list (no duplicates), the ability to overwrite the map has been moved to a new argument on both procs replace
- Adds a proc `undefineRegion()` which just makes the map list a new list, it's just there to look nice
- Removes bottomLeft and topRight, they weren't even needed
- Made the turf clustering checks faster by remembering that `trange()` exists, and actually using it.

So TL:DR; Circle mapgen, bugfixes, faster stuff, undefining regions.

tgstation/-tg-station#9252