### PR TITLE
Broken/Removed Limbs Falling Balance

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -91,7 +91,7 @@
 		stance_damage = 0
 
 	// standing is poor
-	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
+	if(stance_damage >= 4)
 		if(!(lying || resting))
 			if(species && !(species.flags & NO_PAIN))
 				emote("scream")


### PR DESCRIPTION
Returns falling from having broken/removed limbs to more like it used to be; if both of your legs are removed, then you'll fall onto the ground.

If one of your legs is removed (or they're both broken), you'll no longer randomly fall on the ground at random intervals.

Also prevents broken leg+missing leg = permastun.