### PR TITLE
Removes AI's Recall Shuttle Ability

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -6,7 +6,6 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/ai_alerts,
 	/mob/living/silicon/ai/proc/announcement,
 	/mob/living/silicon/ai/proc/ai_call_shuttle,
-	/mob/living/silicon/ai/proc/ai_cancel_call,
 	/mob/living/silicon/ai/proc/ai_camera_track,
 	/mob/living/silicon/ai/proc/ai_camera_list,
 	/mob/living/silicon/ai/proc/ai_goto_location,


### PR DESCRIPTION
Removes the AI's ability to recall the shuttle

This was added when we updated a few things to Bay--while I'm sure this feature works fine on Bay, it's more than a bit annoying and irritating here.

Simply put, the AI was never meant to be able to recall a shuttle; it could call it, but not recall it. This just tends to lead to traitor, hijacked, or suprecop/'I AM THE LAW' AI's over-riding Command Staff for how they feel things should progress.

In any event, this just returns things to the way it was.