### PR TITLE
Cyborg cable coil + color picking

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -142,7 +142,7 @@
 		/obj/item/stack/sheet/metal = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/rglass = 50,
-		/obj/item/stack/cable_coil = 50,
+		/obj/item/stack/cable_coil/cyborg = 50,
 		/obj/item/stack/rods = 15,
 		/obj/item/stack/tile/plasteel = 15
 		)
@@ -179,7 +179,7 @@
 		G.amount = 50
 		src.modules += G
 
-		var/obj/item/stack/cable_coil/W = new /obj/item/stack/cable_coil(src)
+		var/obj/item/stack/cable_coil/cyborg/W = new /obj/item/stack/cable_coil/cyborg(src)
 		W.amount = 50
 		src.modules += W
 
@@ -389,7 +389,7 @@
 		/obj/item/stack/tile/plasteel = 15,
 		/obj/item/stack/sheet/metal = 20,
 		/obj/item/stack/sheet/glass = 20,
-		/obj/item/stack/cable_coil = 30
+		/obj/item/stack/cable_coil/cyborg = 30
 		)
 
 	New()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -635,3 +635,11 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 	else
 		return ..()
+
+/obj/item/stack/cable_coil/cyborg
+	name = "cyborg cable coil"
+
+/obj/item/stack/cable_coil/cyborg/attack_self(mob/user)
+	var/cable_color = input(user,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
+	_color = cable_color
+	update_icon()


### PR DESCRIPTION
tgstation/-tg-station#9293

This commit makes a subtype of cable_coils for cyborgs (and drones) that
can have it's color changed by an attack_self (clicking on it)

Players:
 - Cyborgs & Drones can now pick the color of their cable by clicking on it

Coders: 
 - Cyborgs get a subtype of cable_coil, simply cable_coil/cyborg. This is to allow for them to change the color.  