### PR TITLE
Fix for changelog button to not show unmerged PRs.

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -13,7 +13,7 @@
 		src << "<span class='danger'>The wiki URL is not set in the server configuration.</span>"
 	return
 
-#define CHANGELOG "https://github.com/ParadiseSS13/Paradise/issues?q=is%3Apr+is%3Aclosed"
+#define CHANGELOG "https://github.com/ParadiseSS13/Paradise/issues?q=is%3Apr+is%3Amerged"
 /client/verb/changes()
 	set name = "Changelog"
 	set desc = "Visit Github to check out the commits."


### PR DESCRIPTION
What is says on the tin. Will no longer show PRs that got closed without merging. 