### PR TITLE
Fixes (Cyborg stuff, artifacts, cans)

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -475,6 +475,9 @@
 				P.loc = src
 				P.level = 2
 		return
+	// The magnetic gripper does a separate attackby, so bail from this one
+	else if(istype(W, /obj/item/weapon/gripper))
+		return
 
 	else
 		return attack_hand(user)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -18,6 +18,8 @@
 		/obj/item/mounted/frame/apc_frame,
 		/obj/item/mounted/frame/alarm_frame,
 		/obj/item/mounted/frame/firealarm,
+		/obj/item/mounted/frame/newscaster_frame,
+		/obj/item/mounted/frame/intercom,
 		/obj/item/weapon/table_parts,
 		/obj/item/weapon/rack_parts,
 		/obj/item/weapon/camera_assembly,

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -86,7 +86,10 @@
 		wrapped.loc = user
 
 		//Pass the attack on to the target. This might delete/relocate wrapped.
-		target.attackby(wrapped,user, params)
+		if(!target.attackby(wrapped, user, params) && target && wrapped)
+			// If the attackby didn't resolve or delete the target or wrapped, afterattack
+			// (Certain things, such as mountable frames, rely on afterattack)
+			wrapped.afterattack(target, user, 1, params)
 
 		//If wrapped did neither get deleted nor put into target, put it back into the gripper.
 		if(wrapped && user && (wrapped.loc == user))

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -193,16 +193,17 @@
 
 	var/slot_num
 	if(slot_start == 0)
-		slot_num = 1
-		slot_start = 2
+		slot_num = 0
+		slot_start = 3
 	else
-		slot_num = slot_start + 1
+		slot_num = slot_start
 
-	while(slot_start != slot_num) //If we wrap around without finding any free slots, just give up.
+	do
+		slot_num++
+		if(slot_num > 3) slot_num = 1 //Wrap around.
 		if(module_active(slot_num))
 			select_module(slot_num)
 			return
-		slot_num++
-		if(slot_num > 3) slot_num = 1 //Wrap around.
+	while(slot_start != slot_num) //If we wrap around without finding any free slots, just give up.
 
 	return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -10,7 +10,7 @@ var/list/robot_verbs_default = list(
 	icon_state = "robot"
 	maxHealth = 100
 	health = 100
-	universal_speak = 1
+	universal_understand = 1
 
 	var/sight_mode = 0
 	var/custom_name = ""

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -46,7 +46,7 @@
 
 			var/mob/living/carbon/human/H = M
 			if(H.species.flags & IS_SYNTHETIC)
-				H << "\red They have a monitor for a head, where do you think you're going to put that?"
+				user << "\red They have a monitor for a head, where do you think you're going to put that?"
 				return
 
 			for(var/mob/O in viewers(world.view, user))
@@ -83,6 +83,13 @@
 
 	afterattack(obj/target, mob/user, proximity)
 		if(!proximity) return
+
+		// Moved from the can code; not necessary since closed cans aren't open containers now, but, eh.
+		if (istype(target, /obj/item/weapon/reagent_containers/food/drinks/cans))
+			var/obj/item/weapon/reagent_containers/food/drinks/cans/cantarget = target
+			if(cantarget.canopened == 0)
+				user << "<span class='notice'>You need to open the drink you want to pour into!</span>"
+				return
 
 		if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
 

--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -92,13 +92,14 @@
 			reconnect_scanner()
 		if(owned_scanner)
 			var/artifact_in_use = 0
+			scanned_object = null
 			for(var/obj/O in owned_scanner.loc)
 				if(O == owned_scanner)
 					continue
 				if(O.invisibility)
 					continue
-				if(istype(scanned_object, /obj/machinery/artifact))
-					var/obj/machinery/artifact/A = scanned_object
+				if(istype(O, /obj/machinery/artifact))
+					var/obj/machinery/artifact/A = O
 					if(A.being_used)
 						artifact_in_use = 1
 					else


### PR DESCRIPTION
Various fixes, mostly cyborg stuff:
* Fixes cyborgs being able to speak **all** languages.
  * This included being able to speak alien, and being able to speak into (but not hear) the alien and changeling hiveminds.
  * They can still understand all languages, which is what they were given `universal_speak` in mid 2013 for (see [this commit](https://github.com/ParadiseSS13/Paradise/commit/aa60c58ecbec49ef871be3ebb54367f8247f88c8)). They now have `universal_understand` for this.
  * Most cyborg modules can speak Galactic Common, Sol Common, Tradeband, and Trinary. Service borgs can speak all languages.
* Fixes cyborg module cycling (their equivalent of hand swapping) failing under certain circumstances.
  * As a consequence of this change, trying to cycle modules with a single active module will no longer deselect it.
    * I'm considering adding a couple module management hotkeys in a feature PR, since the lack of them is a real nuisance.
* Fixes the magnetic gripper not being able to mount mountable frames, and not being able to pick up certain frames. (Fixes #858)
  * Turns out the magnetic gripper never proc'd `afterattack`s, which mountable frames rely on. I'm pretty confident that making it do so won't have any terrible consequences. *Pretty confident.*
  * Also, it was causing two `attackby`s to occur, which meant you would always `attack_hand` a wall you used it on, even if you were mounting something. I added an exception to walls for this.
  * The new newscaster and intercom frames weren't added to the magnetic gripper whitelist when they were implemented. They have been now.
    * It might make more sense to just let the magnetic gripper grip *all* mountable frames, but I'm not sure if there's some reason not to.
* Fixes the Artifact Analyzer anchoring artifacts you've already scanned and removed, instead of the one you're scanning. (Fixes #934, fixes #502)
* Fixes the can code being a big ugly blob of copy-pasted drink code, which hasn't been kept up-to-date with the drink code it was copied from, and a couple other minor drink bugs.
  * This means **IPCs can no longer drink from cans** (**including space beer**)! (Fixes #855)
    * Maybe IPCs should just be able to drink drinks.
  * Also fixes being able to pour into closed cans, by simply making them non-open containers until they're opened.
  * Also fixes the wrong person getting the failure message when trying to pour a drink into an IPC's mouth.

These have all been tested (as much as possible, anyway), and I can't think of any other fixes to lump into here, so this should be good to merge whenever.