### PR TITLE
Adds sorting by last update to changelog link

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -13,7 +13,7 @@
 		src << "<span class='danger'>The wiki URL is not set in the server configuration.</span>"
 	return
 
-#define CHANGELOG "https://github.com/ParadiseSS13/Paradise/issues?q=is%3Apr+is%3Amerged"
+#define CHANGELOG "https://github.com/ParadiseSS13/Paradise/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc"
 /client/verb/changes()
 	set name = "Changelog"
 	set desc = "Visit Github to check out the commits."


### PR DESCRIPTION
The current in-game changelog link shows merged PRs with the default sorting method, which is by date opened. I propose adding a sort filter to the link, to make it sort by date last updated.

To demonstrate why this is a good idea, compare [this link to the old changelog](https://github.com/ParadiseSS13/Paradise/issues?q=is%3Apr+is%3Amerged) and [this link to the proposed changelog](https://github.com/ParadiseSS13/Paradise/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc). At the time of writing, the Shadowlings port was merged in **2 hours ago**, but because the PR was opened **22 days ago**, it is on **page 4** of the old changelog. New, major addition; page 4. On the proposed changelog, it's the third PR listed.

The downside of sorting by last update is that old PRs which receive new comments will be bumped back to the top of the list, which may cause someone not paying attention to believe an old PR was recently merged. I consider this a significant improvement over newly-merged PRs not even being on the first page.

Of course, the best sorting method would be by date merged, but Github does not provide that for some reason. This is the best we can get without switching over to a real changelog.