### PR TITLE
Enables Bag Item Stacking

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -624,12 +624,18 @@
 	allow_quick_gather = 1
 	allow_quick_empty = 1
 	collection_mode = 1
+	display_contents_with_number = 1
 	max_w_class = 3
 	max_combined_w_class = 100
 
 /obj/item/weapon/storage/part_replacer/proc/play_rped_sound()
 	//Plays the sound for RPED exchanging or installing parts.
 	playsound(src, 'sound/items/rped.ogg', 40, 1)
+
+//Sorts stock parts inside an RPED by their rating.
+//Only use /obj/item/weapon/stock_parts/ with this sort proc!
+/proc/cmp_rped_sort(var/obj/item/weapon/stock_parts/A, var/obj/item/weapon/stock_parts/B)
+	return B.rating - A.rating
 
 /obj/item/weapon/stock_parts
 	name = "stock part"

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -19,7 +19,7 @@
 /obj/item/weapon/storage/bag
 	allow_quick_gather = 1
 	allow_quick_empty = 1
-	display_contents_with_number = 0 // UNStABLE AS FuCK, turn on when it stops crashing clients
+	display_contents_with_number = 1 // should work fine now
 	use_to_pickup = 1
 	slot_flags = SLOT_BELT
 
@@ -38,7 +38,7 @@
 	storage_slots = 30
 	can_hold = list() // any
 	cant_hold = list("/obj/item/weapon/disk/nuclear","/obj/item/flag/nation")
-	
+
 /obj/item/weapon/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts the [src.name] over their head and starts chomping at the insides! Disgusting!</span>")
 	playsound(loc, 'sound/items/eatfood.ogg', 50, 1, -1)
@@ -53,13 +53,13 @@
 		icon_state = "trashbag2"
 	else icon_state = "trashbag3"
 
-/obj/item/weapon/storage/bag/trash/cyborg	
-	
+/obj/item/weapon/storage/bag/trash/cyborg
+
 /obj/item/weapon/storage/bag/trash/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
 	J.put_in_cart(src, user)
 	J.mybag=src
 	J.update_icon()
-	
+
 /obj/item/weapon/storage/bag/trash/cyborg/janicart_insert(mob/user, obj/structure/janitorialcart/J)
 	return
 
@@ -126,7 +126,7 @@
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
 	max_w_class = 3
 	can_hold = list("/obj/item/weapon/ore")
-	
+
 /obj/item/weapon/storage/bag/ore/holding //miners, your messiah has arrived
 	name = "mining satchel of holding"
 	desc = "A revolution in convenience, this satchel allows for infinite ore storage. It's been outfitted with anti-malfunction safety measures."
@@ -134,7 +134,7 @@
 	max_combined_w_class = INFINITY
 	origin_tech = "bluespace=3"
 	icon_state = "satchel_bspace"
-	
+
 // -----------------------------
 //          Plant bag
 // -----------------------------
@@ -341,7 +341,7 @@
 	max_w_class = 3
 	w_class = 4 //Bigger than a book because physics
 	can_hold = list(/obj/item/weapon/book, /obj/item/weapon/spellbook) //No bibles, consistent with bookcase
-	
+
 /*
  * Trays - Agouri
  */
@@ -394,8 +394,8 @@
 	overlays += image("icon" = I.icon, "icon_state" = I.icon_state, "layer" = -1)
 	..()
 
-/obj/item/weapon/storage/bag/tray/cyborg	
-	
+/obj/item/weapon/storage/bag/tray/cyborg
+
 /obj/item/weapon/storage/bag/tray/cyborg/afterattack(atom/target, mob/user as mob)
 	if ( isturf(target) || istype(target,/obj/structure/table) )
 		var foundtable = istype(target,/obj/structure/table/)


### PR DESCRIPTION
Tested this out, and couldn't generate a crash from it--this got re-enabled nearly 2 years ago on TG without any major changes and they haven't had problems.

Can easily be disabled if it does generate issues.

What does it do?

If you have multiple duplicate items in a *bag of the same type, it will group them together with a number instead of having the same item display multiple times.

Non-bag storage that will utilize this feature:
- RPED

*Bag--this is an item like the the botany bag, mining satchel, trash bag, etc--not standard backpacks/satchels/etc.