### PR TITLE
Fixes Posibrains

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -23,8 +23,8 @@
 /obj/item/organ/brain/New()
 	..()
 	spawn(5)
-		for(var/mob/living/carbon/brain/bmob in src) //I'm going to hell for this, but there's no other way to stop these runtimes.
-			bmob.client.screen.len = null //clear the hud
+		if(brainmob && brainmob.client)
+			brainmob.client.screen.len = null //clear the hud
 
 /obj/item/organ/brain/proc/transfer_identity(var/mob/living/carbon/H)
 	name = "\the [H]'s [initial(src.name)]"

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -169,17 +169,16 @@
 	..()
 
 /obj/item/device/mmi/posibrain/New()
-	for(var/mob/living/carbon/brain/bmob in src) //Also going to hell for this, but this should fix the runtimes.
-		bmob = new /mob/living/carbon/brain(src)
-		bmob.name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[rand(100, 999)]"
-		bmob.real_name = src.brainmob.name
-		bmob.loc = src
-		bmob.container = src
-		bmob.robot_talk_understand = 1
-		bmob.stat = 0
-		bmob.silent = 0
-		bmob.brain_op_stage = 4.0
-		dead_mob_list -= bmob
+	src.brainmob = new(src)
+	src.brainmob.name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[rand(100, 999)]"
+	src.brainmob.real_name = src.brainmob.name
+	src.brainmob.loc = src
+	src.brainmob.container = src
+	src.brainmob.robot_talk_understand = 1
+	src.brainmob.stat = 0
+	src.brainmob.silent = 0
+	src.brainmob.brain_op_stage = 4.0
+	dead_mob_list -= src.brainmob
 
 	..()
 


### PR DESCRIPTION
Reverts changes made to brain_item.dm and posibrain.dm in the original shadowling PR. They were made to stop runtimes but apparently broke posibrains (could not activate them), the runtimes were completely senseless in the first place, and only occur on that specific branch, tested these changes and no runtimes occur.