### PR TITLE
Fixes exploded limbs not launching their contents

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -674,8 +674,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 			gore.update_icon()
 			gore.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 
-			for(var/obj/item/organ/I in internal_organs)
-				I.removed()
+			for(var/obj/item/organ/I in contents)
+				I.loc = loc
 				if(istype(loc,/turf))
 					I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 			qdel(src)


### PR DESCRIPTION
As it turns out, a limb that's been `removed()` no longer has any `internal_organs`, because all of them get `removed()` and stuffed back into the limb. Also, because they get removed, they don't need to be re-removed, simply yanked back out of the removed limb.

This fix causes all sub-organs of a limb to eject, rather than just internal organs, meaning an exploded lower body will launch the legs. A check could be added to exclude external organs, but it kinda seems like they should probably eject.

This probably fixes issue #941, but I'm not flagging it to auto-close, just in case.

Also, I guess this might be a high-priority fix, since it fixes exploding heads not ejecting brains.

For those curious, here's what it looks like when you explode a head and groin before this fix:
![dreamseeker 2015-05-06 22-49-55-33](https://cloud.githubusercontent.com/assets/10916307/7507869/d0e12072-f444-11e4-9871-e0517f50c917.png)
And after this fix:
![dreamseeker 2015-05-06 22-53-24-92](https://cloud.githubusercontent.com/assets/10916307/7507871/d364e8e2-f444-11e4-8128-066b2a31f155.png)
Those things that look like flowerpots are an organ and one of the legs on the same tile.