### PR TITLE
Various Fixes and Tweaks

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1022,6 +1022,13 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "sandstone blocks crate"
 
 
+/datum/supply_packs/materials/plastic30
+	name = "30 Plastic Sheets"
+	contains = list(/obj/item/stack/sheet/mineral/plastic)
+	amount = 30
+	cost = 25
+	containername = "plastic sheets crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -12,6 +12,10 @@
 
 /datum/job/civilian/equip(var/mob/living/carbon/human/H)
 	if(!H)	return 0
+	switch(H.backbag)
+		if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
+		if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+		if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 	H.equip_or_collect(new /obj/item/clothing/under/color/random(H), slot_w_uniform)
 	H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
 	if(H.backbag == 1)

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -53,6 +53,10 @@
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
+		switch(H.backbag)
+			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
+			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_service(H), slot_l_ear)
 		H.equip_or_collect(new /obj/item/clothing/under/rank/chef(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/clothing/suit/chef(H), slot_wear_suit)
@@ -114,6 +118,10 @@
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
+		switch(H.backbag)
+			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
+			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_cargo(H), slot_l_ear)
 		H.equip_or_collect(new /obj/item/clothing/under/rank/cargo(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/clothing/shoes/brown(H), slot_shoes)
@@ -142,6 +150,10 @@
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
+		switch(H.backbag)
+			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
+			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_cargo(H), slot_l_ear)
 		H.equip_or_collect(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
@@ -284,6 +296,10 @@
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
+		switch(H.backbag)
+			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
+			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_service(H), slot_l_ear)
 		H.equip_or_collect(new /obj/item/clothing/under/rank/janitor(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
@@ -312,6 +328,10 @@
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
+		switch(H.backbag)
+			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
+			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_service(H), slot_l_ear)
 		H.equip_or_collect(new /obj/item/clothing/under/suit_jacket/red(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/device/pda/librarian(H), slot_wear_pda)
@@ -338,6 +358,10 @@
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0
+		switch(H.backbag)
+			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
+			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
+			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_service(H), slot_l_ear)
 		H.equip_or_collect(new /obj/item/clothing/under/barber(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -78,7 +78,8 @@
 	throwforce = 0
 	w_class = 4
 	max_w_class = 2
-	storage_slots = 21
+	storage_slots = 7
+	display_contents_with_number = 0 //or else this will lead to stupid behavior.
 	can_hold = list() // any
 	cant_hold = list("/obj/item/weapon/disk/nuclear","/obj/item/flag/nation")
 	var/head = 0
@@ -107,7 +108,7 @@
 			H.losebreath += 1
 	else
 		head = 0
-		storage_slots = 21
+		storage_slots = 7
 		processing_objects.Remove(src)
 	return
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -45,11 +45,21 @@
 	build_path = /obj/item/device/robotanalyzer
 	category = list("Medical")
 
+/datum/design/healthanalyzer
+	name = "Health Analyzer Upgrade"
+	desc = "A hand-held body scanner able to distinguish vital signs of the subject."
+	id = "healthanalyzer"
+	req_tech = list("biotech" = 2, "magnets" = 2)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 20, "$glass" = 20)
+	build_path = /obj/item/device/healthanalyzer
+	category = list("Medical")
+
 /datum/design/healthanalyzer_upgrade
 	name = "Health Analyzer Upgrade"
 	desc = "An upgrade unit for expanding the functionality of a health analyzer."
 	id = "healthanalyzer_upgrade"
-	req_tech = list("biotech" = 2, "magnets" = 2)
+	req_tech = list("biotech" = 2, "magnets" = 3)
 	build_type = PROTOLATHE
 	materials = list("$metal" = 20, "$glass" = 20)
 	build_path = /obj/item/device/healthupgrade


### PR DESCRIPTION
Various fixes and a couple tweaks

- Fixes item equipping at roundstart for support/civilian jobs
 - This means no more plastic bag spawning--Yes, that was a bug.
- Fixes plastic bags combining things they probably shouldn't (fixes: https://github.com/ParadiseSS13/Paradise/issues/969)
- Adds in health analyzer to the protolathe (this was meant to be added when the health analyzer upgrade was added--for whatever reason it didn't stick?)

Non-Fixish things
- Adds in 30 sheets of plastic to order from cargo (under materials)
 - Remember plastic sheets can be used to make plastic bags.
- Lowered plastic bag's storage slots from 21 to 7 (same as a box)
 - These are bluespace toolbelts on steroids(with no real cost); these should bring them back to the realm of sanity
- Upped R&D cost on the health analyzer upgrade from magnets 2 to 3