### PR TITLE
Improved Dumping for Containers

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -39,7 +39,7 @@
 			return
 
 		if ((istype(over_object, /obj/structure/table) || istype(over_object, /turf/simulated/floor)) \
-			&& contents.len && loc == usr && !usr.stat && !usr.restrained() && over_object.Adjacent(usr) \
+			&& contents.len && loc == usr && !usr.stat && !usr.restrained() && usr.canmove && over_object.Adjacent(usr) \
 			&& !istype(src, /obj/item/weapon/storage/lockbox))
 			var/turf/T = get_turf(over_object)
 			if (istype(over_object, /turf/simulated/floor))
@@ -47,7 +47,7 @@
 					return // Can only empty containers onto the floor under you
 				if("Yes" != alert(usr,"Empty \the [src] onto \the [T]?","Confirm","Yes","No"))
 					return
-				if(!(usr && over_object && contents.len && loc == usr && !usr.stat && !usr.restrained() && get_turf(usr) == T))
+				if(!(usr && over_object && contents.len && loc == usr && !usr.stat && !usr.restrained() && usr.canmove && get_turf(usr) == T))
 					return // Something happened while the player was thinking
 			hide_from(usr)
 			usr.face_atom(over_object)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -38,6 +38,18 @@
 			show_to(M)
 			return
 
+		if((allow_quick_empty || allow_quick_gather) && istype(over_object, /obj/structure/table) \
+			&& contents.len && over_object.Adjacent(usr))
+			var/turf/T = get_turf(over_object)
+			hide_from(usr)
+			usr.face_atom(src)
+			usr.visible_message("<span class='notice'>[usr] empties \the [src] onto \the [over_object].</span>",
+				"<span class='notice'>You empty \the [src] onto \the [over_object].</span>")
+			for(var/obj/item/I in contents)
+				remove_from_storage(I, T)
+			update_icon() // For content-sensitive icons
+			return
+
 		if (!( istype(over_object, /obj/screen) ))
 			return ..()
 		if (!(src.loc == usr) || (src.loc && src.loc.loc == usr))

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -38,11 +38,19 @@
 			show_to(M)
 			return
 
-		if((allow_quick_empty || allow_quick_gather) && istype(over_object, /obj/structure/table) \
-			&& contents.len && over_object.Adjacent(usr))
+		if ((istype(over_object, /obj/structure/table) || istype(over_object, /turf/simulated/floor)) \
+			&& contents.len && loc == usr && !usr.stat && !usr.restrained() && over_object.Adjacent(usr) \
+			&& !istype(src, /obj/item/weapon/storage/lockbox))
 			var/turf/T = get_turf(over_object)
+			if (istype(over_object, /turf/simulated/floor))
+				if (get_turf(usr) != T)
+					return // Can only empty containers onto the floor under you
+				if("Yes" != alert(usr,"Empty \the [src] onto \the [T]?","Confirm","Yes","No"))
+					return
+				if(!(usr && over_object && contents.len && loc == usr && !usr.stat && !usr.restrained() && get_turf(usr) == T))
+					return // Something happened while the player was thinking
 			hide_from(usr)
-			usr.face_atom(src)
+			usr.face_atom(over_object)
 			usr.visible_message("<span class='notice'>[usr] empties \the [src] onto \the [over_object].</span>",
 				"<span class='notice'>You empty \the [src] onto \the [over_object].</span>")
 			for(var/obj/item/I in contents)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -93,22 +93,14 @@
 			user << "You can't place that item inside the disposal unit."
 			return
 
-		if(istype(I, /obj/item/weapon/storage/bag/trash))
-			var/obj/item/weapon/storage/bag/trash/T = I
-			if(T.contents.len)
-				user << "\blue You empty the bag."
-				for(var/obj/item/O in T.contents)
-					T.remove_from_storage(O,src)
-				T.update_icon()
-				update()
-				return
-
-		if(istype(I, /obj/item/weapon/storage/part_replacer))
-			var/obj/item/weapon/storage/part_replacer/P = I
-			if(P.contents.len)
-				user << "\blue You empty the RPED's contents."
-				for(var/obj/item/O in P.contents)
-					P.remove_from_storage(O,src)
+		if(istype(I, /obj/item/weapon/storage))
+			var/obj/item/weapon/storage/S = I
+			if((S.allow_quick_empty || S.allow_quick_gather) && S.contents.len)
+				S.hide_from(user)
+				user.visible_message("[user] empties \the [S] into \the [src].", "You empty \the [S] into \the [src].")
+				for(var/obj/item/O in S.contents)
+					S.remove_from_storage(O, src)
+				S.update_icon() // For content-sensitive icons
 				update()
 				return
 


### PR DESCRIPTION
This gives **all** containers the ability to be emptied onto the floor (with confirmation) or a table with a drag-drop. It also allows all "quick" containers to be emptied into a disposal unit with a click.

![emptying things](https://cloud.githubusercontent.com/assets/10916307/7549035/9fb3cb8e-f5f3-11e4-8719-01c087926e37.png)

"Quick" containers are those which can be quickly emptied (Empty Contents) or filled with a single click. These include RPEDs, pill bottles, bags (plastic, trash, mining, plant, etc.), and trays.

Prior to this, only RPEDs and trash bags could be directly emptied into a disposal. No containers could be directly emptied onto a table, and only "quick" containers could be emptied onto the floor.

This change should make it easier for...
* chemists to clean up pill mistakes.
* chemists to set out helpful pills in medbay.
* "chemists" to set out "helpful" pills in the bar.
* botanists to set out the ~~fruits of their labor~~ plants they grow.
* scientists to set out requested parts.
* chefs to move food to their counters without having to throw it.
* people to empty containers for various other reasons that I wasn't considering before extending drag-to-empty to all containers.