### PR TITLE
Removes NO_PAIN species being stun immune

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1808,9 +1808,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	return slurring
 
 /mob/living/carbon/human/handle_stunned()
-	if(species.flags & NO_PAIN)
-		stunned = 0
-		return 0
 	if(..())
 		speech_problem_flag = 1
 	return stunned


### PR DESCRIPTION
Fixes #966 

NO_PAIN species have no reason to be immune to stuns that use the Stun() proc/stunned var. Why this was a thing in the first place is beyond me, it's a stun, not pain.