### PR TITLE
Add magboots stopping airflow push to LINDA

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -488,3 +488,11 @@ emp_act
 		..()
 
 	return
+
+/mob/living/carbon/human/experience_pressure_difference(pressure_difference, direction)
+	if(shoes)
+		if(istype(shoes,/obj/item/clothing/shoes/magboots)) //TODO: Make a not-shit shoe var system to negate airflow.
+			var/obj/item/clothing/shoes/magboots/MB = shoes
+			if(MB.magpulse)
+				return 0
+	..()


### PR DESCRIPTION
This commit adds an airflow push override to humans, which triggers when
the shoes they are wearing have NO_SLIP. Therefore, magboots will prevent
people from being pushed around by "spacewind" or also known as airflow.

TL:DR; Magboots = No being pushed around by breaches