### PR TITLE
Potted Plant Hiding

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -196,6 +196,7 @@
 	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "plant-1"
 	anchored = 0
+	layer = 5
 
 /obj/structure/flora/kirbyplants/New()
 	..()


### PR DESCRIPTION
Adds in the ability to hide behind potted plants (also works for items, of course).

This is feature I always loved about Goon's plants/shrubbery--not only were they decorative, but they had a gameplay function as well; you could hide behind them and partially obscure your sprite in an attempt to ambush someone or make a quick dodge from security.

![hiding!](http://i.gyazo.com/d7234f9aaf905204d177fd5587c9388a.gif)