### PR TITLE
Species Touchups

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -126,6 +126,7 @@
 					LAssailant = M
 
 				var/damage = rand(0, M.species.max_hurt_damage)//BS12 EDIT
+				damage += attack.damage
 				if(!damage)
 					playsound(loc, attack.miss_sound, 25, 1, -1)
 					visible_message("\red <B>[M] tried to [pick(attack.attack_verb)] [src]!</B>")
@@ -143,7 +144,6 @@
 
 				visible_message("\red <B>[M] [pick(attack.attack_verb)]ed [src]!</B>")
 
-				damage += attack.damage
 				apply_damage(damage, BRUTE, affecting, armor_block, sharp=attack.sharp, edge=attack.edge) //moving this back here means Armalis are going to knock you down  70% of the time, but they're pure adminbus anyway.
 				if((stat != DEAD) && damage >= 9)
 					visible_message("<span class='danger'>[M] has weakened [src]!</span>", \

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -5,8 +5,8 @@
 	if(status_flags & GOTTAGOREALLYFAST)
 		tally -= 2
 
-	if(species && species.flags & IS_SLOW)
-		tally = 5
+	if(species.slowdown)
+		tally = species.slowdown
 
 	if (istype(loc, /turf/space)) return -1 // It's hard to be slowed down in space by... anything
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -14,6 +14,7 @@
 	var/tail                     // Name of tail image in species effects icon file.
 	var/unarmed                  //For empty hand harm-intent attack
 	var/unarmed_type = /datum/unarmed_attack
+	var/slowdown = 0              // Passive movement speed malus (or boost, if negative)
 
 	var/breath_type = "oxygen"   // Non-oxygen gas breathed, if any.
 	var/poison_type = "plasma"   // Poisonous air.
@@ -601,6 +602,7 @@
 	language = "Rootspeak"
 	unarmed_type = /datum/unarmed_attack/diona
 	primitive = /mob/living/carbon/monkey/diona
+	slowdown = 5
 
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
@@ -622,7 +624,7 @@
 	even the simplest concepts of other minds. Their alien physiology allows them survive happily off a diet of nothing but light, \
 	water and other radiation."
 
-	flags = NO_BREATHE | REQUIRE_LIGHT | IS_PLANT | RAD_ABSORB | NO_BLOOD | IS_SLOW | NO_PAIN
+	flags = NO_BREATHE | REQUIRE_LIGHT | IS_PLANT | RAD_ABSORB | NO_BLOOD | NO_PAIN
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -817,7 +817,6 @@ var/list/restricted_camera_networks = list( //Those networks can only be accesse
 
 #define NO_BLOOD		1
 #define NO_BREATHE 		2
-#define IS_SLOW 		4
 #define RAD_ABSORB		8
 #define NO_SCAN 		16
 #define NO_PAIN 		32


### PR DESCRIPTION
Most boring #1000 th PR ever!

- Touches up species' handling of  movement speed; instead of using a custom flag, now the exactly slowdown can be adjusted (increased or decrease), on a per species basis.
 - Tajarans go fast for increased brute damage, yes? No? Fine....
- Moved species' attack damage calculation up; this means that if an unarmed attack has even +1 attack damage (currently no station species), the unarmed attack will never miss. This changed, combined with adjustments to species_max_damage effectively means we can make a species who has the same max damage/weaken potential but never misses.