### PR TITLE
Black Powder Sound Tweak

### DIFF
--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -63,6 +63,8 @@
 		var/turf/simulated/wall/W = T
 		if(prob(volume/10))
 			W.ChangeTurf(/turf/simulated/floor)
+	if(istype(T, /turf/simulated/shuttle/))
+		new /obj/effect/hotspot(T)
 	return
 
 /datum/reagent/clf3/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
@@ -195,6 +197,11 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	return
 
 /datum/reagent/blackpowder/on_ex_act()
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	s.set_up(2, 1, location)
+	s.start()
+	sleep(rand(10,15))
 	blackpowder_detonate(holder, volume)
 	holder.remove_reagent("blackpowder", volume)
 	return


### PR DESCRIPTION
- Tweaks Black Powder's explosion timings so not all of the decals go off, at once.
 - This could take a while to pin down a good number on, since everyone's speakers are different.
- Made it so CLF3 creates hotspots on the shuttle.
