### PR TITLE
LINDA-Fix: Mobs On Fire

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -57,6 +57,7 @@
 /obj/effect/hotspot/New()
 	..()
 	air_master.hotspots += src
+	perform_exposure()
 
 /obj/effect/hotspot/proc/perform_exposure()
 	var/turf/simulated/floor/location = loc
@@ -175,3 +176,7 @@
 	air_update_turf()
 	return
 
+/obj/effect/hotspot/Crossed(mob/living/L)
+	..()
+	if(isliving(L))
+		L.fire_act()


### PR DESCRIPTION
- Fixes LINDA not properly igniting mobs that step on a hotspot or where a new hotspot forms.