### PR TITLE
Infrared Beam Useability

### DIFF
--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -151,6 +151,7 @@
 	var/visible = 0.0
 	var/left = null
 	anchored = 1.0
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
 
 /obj/effect/beam/i_beam/proc/hit()


### PR DESCRIPTION
Infrared assemblies are hugely under used and utilized, despite being quite unique in terms of functionality.

One of the biggest issues they have is that you can't set up very complex or interesting setups with them without the assembly easily being tampered with. For example, maybe you want a door that automatically opens when someone crosses the beam---that's easily done, but the assembly for it has to be placed out in the open where Joe McDumbface can just pick it up and walk off with it.

This change allows infrared beams to pass grills and windows, meaning you can put an assembly BEHIND glass and have it shine into places. 

More tricks, more functionality, and more possibilities.