### PR TITLE
Prevent divide by 0 runtime, fix supply shuttle

### DIFF
--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -238,7 +238,15 @@ var/list/mechtoys = list(
 		var/list/clear_turfs = list()
 
 		for(var/turf/T in area_shuttle)
-			if(T.density || T.contents.len)	continue
+			if(T.density)	continue
+			var/contcount
+			for(var/atom/A in T.contents)
+				if(istype(A,/atom/movable/lighting_overlay))
+					continue
+				if(istype(A,/obj/machinery/light))
+					continue
+				contcount++
+			if(contcount)	continue
 			clear_turfs += T
 
 		for(var/S in shoppinglist)

--- a/code/modules/lighting/light_source.dm
+++ b/code/modules/lighting/light_source.dm
@@ -120,9 +120,9 @@
    #endif
 
    #if LIGHTING_LAMBERTIAN == 1
-	. = CLAMP01((1 - CLAMP01(sqrt(.) / light_range)) * (1 / (sqrt(. + 1))))
+	. = CLAMP01((1 - CLAMP01(sqrt(.) / max(1,light_range))) * (1 / (sqrt(. + 1))))
    #else
-	. = 1 - CLAMP01(sqrt(.) / light_range)
+	. = 1 - CLAMP01(sqrt(.) / max(1,light_range))
    #endif
 
   #elif LIGHTING_FALLOFF == 2 // square
@@ -133,9 +133,9 @@
    #endif
 
    #if LIGHTING_LAMBERTIAN == 1
-	. = CLAMP01((1 - CLAMP01(. / light_range)) * (1 / (sqrt(.)**2 + )))
+	. = CLAMP01((1 - CLAMP01(. / max(1,light_range))) * (1 / (sqrt(.)**2 + )))
    #else
-	. = 1 - CLAMP01(. / light_range)
+	. = 1 - CLAMP01(. / max(1,light_range))
    #endif
   #endif
 


### PR DESCRIPTION
This commit adds a small sanity check to the falloff calculations of
lights, to prevent them from dividing by 0. This may cause undiscovered
strangeness, but strangeness is better than filling the runtime log.

This commit also fixes the supply shuttle, which was not spawning any
ordered items. It did this because it had a very basic contents.len check
which the lighting overlays triggered. The sanity check to not spawn stuff
on top of other stuff is now a for(atom) loop on the turfs, which has
snowflake checks for lights and lighting overlays.

TL:DR; Supply shuttle works now, No more spamming runtimes (which may cause things to go insane but who knows, better than dividing by 0)