### PR TITLE
Fixes mech and pod fabricators not synchronizing

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -1,15 +1,5 @@
 // Areas.dm
 
-// Added to fix mech fabs 05/2013 ~Sayu
-// This is necessary due to lighting subareas.  If you were to go in assuming that things in
-// the same logical /area have the parent /area object... well, you would be mistaken.  If you
-// want to find machines, mobs, etc, in the same logical area, you will need to check all the
-// related areas.  This returns a master contents list to assist in that.
-/proc/area_contents(var/area/A)
-	if(!istype(A)) return null
-	var/list/contents = list()
-	return contents
-
 // ===
 /area
 	var/global/global_uid = 0

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -280,8 +280,9 @@
 	temp = "Updating local R&D database..."
 	updateUsrDialog()
 	sleep(30) //only sleep if called by user
+	var/area/localarea = get_area(src)
 
-	for(var/obj/machinery/computer/rdconsole/RDC in area_contents(get_area(src)))
+	for(var/obj/machinery/computer/rdconsole/RDC in localarea.contents)
 		if(!RDC.sync)
 			continue
 		for(var/datum/tech/T in RDC.files.known_tech)

--- a/code/game/vehicles/spacepods/pod_fabricator.dm
+++ b/code/game/vehicles/spacepods/pod_fabricator.dm
@@ -291,8 +291,9 @@
 	temp = "Updating local R&D database..."
 	updateUsrDialog()
 	sleep(30) //only sleep if called by user
+	var/area/localarea = get_area(src)
 
-	for(var/obj/machinery/computer/rdconsole/RDC in area_contents(get_area(src)))
+	for(var/obj/machinery/computer/rdconsole/RDC in localarea.contents)
 		if(!RDC.sync)
 			continue
 		for(var/datum/tech/T in RDC.files.known_tech)


### PR DESCRIPTION
They used to sync, but currently, they don't. To be perfectly honest, I have no idea why the previous code ever worked, since `area_contents` seems to only ever return `null` or an empty list. This fix seems to make them all work, though.

This should probably be kinda high-priority, since it's currently impossible to sync new research to mech/pod fabs, which sucks for roboticists and maybe also mechanics.