### PR TITLE
Add light color defs for more things

### DIFF
--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -10,12 +10,6 @@
 	var/range = 25
 
 	light_color = "#7BF9FF"
-	power_change()
-		..()
-		if(!(stat & (BROKEN|NOPOWER)))
-			set_light(2)
-		else
-			set_light(0)
 
 	//Simple variable to prevent me from doing attack_hand in both this and the child computer
 	var/zone = "This computer is working on a wireless range, the range is currently limited to 25 meters."

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -3,6 +3,7 @@
 	desc = "A little security robot.  He looks less than thrilled."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "secbot0"
+	light_color = "#FF0000"
 	layer = 5.0
 	density = 0
 	anchored = 0
@@ -217,14 +218,14 @@ Auto Patrol: []"},
 	switch(mode)
 
 		if(BOT_IDLE)		// idle
-
+			flashing_lights() //make sure they disengage properly
 			walk_to(src,0)
 			look_for_perp()	// see if any criminals are in range
 			if(!mode && auto_patrol)	// still idle, and set to patrol
 				mode = BOT_START_PATROL	// switch to patrol mode
 
 		if(BOT_HUNT)		// hunting for perp
-
+			flashing_lights()
 			// if can't reach perp for long enough, go idle
 			if(frustration >= 8)
 				walk_to(src,0)
@@ -274,7 +275,7 @@ Auto Patrol: []"},
 				back_to_idle()
 
 		if(BOT_PREP_ARREST)		// preparing to arrest target
-
+			flashing_lights() //make sure they disengage properly
 			// see if he got away. If he's no no longer adjacent or inside a closet or about to get up, we hunt again.
 			if( !Adjacent(target) || !isturf(target.loc) ||  target.weakened < 2 )
 				back_to_hunt()
@@ -409,6 +410,16 @@ Auto Patrol: []"},
 	if(!isalien(target))
 		target = user
 		mode = BOT_HUNT
+
+/obj/machinery/bot/secbot/proc/flashing_lights()
+	if(mode == BOT_HUNT)
+		switch(light_color)
+			if("#FF0000")
+				light_color = "#0000FF"
+			if("#0000FF")
+				light_color = "#FF0000"
+	else
+		light_color = "#FF0000"
 
 //Secbot Construction
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -280,6 +280,8 @@ var/camera_cache_id = 1
 	desc = "Damn, they better have Paradise TV on these things."
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "entertainment"
+	light_color = "#FFEEDB"
+	light_range_on = 2
 	network = list("news")
 	luminosity = 0
 
@@ -287,16 +289,20 @@ var/camera_cache_id = 1
 	name = "Security Camera Monitor"
 	desc = "An old TV hooked into the stations camera network."
 	icon_state = "security_det"
+	light_color = "#3848B3"
+	light_power_on = 0.5
 	network = list("SS13")
 
 /obj/machinery/computer/security/mining
 	name = "Outpost Camera Monitor"
 	desc = "Used to access the various cameras on the outpost."
 	icon_state = "miningcameras"
+	light_color = "#F9BBFC"
 	network = list("Mining Outpost")
 
 /obj/machinery/computer/security/engineering
 	name = "Engineering Camera Monitor"
 	desc = "Used to monitor fires and breaches."
 	icon_state = "engineeringcameras"
+	light_color = "#FAC54B"
 	network = list("Power Alarms","Atmosphere Alarms","Fire Alarms")

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -11,7 +11,7 @@
 	var/mode = 0.0
 	var/printing = null
 
-	light_color = "#0000FF"
+	light_color = "#0099FF"
 
 	proc/is_centcom()
 		return istype(src, /obj/machinery/computer/card/centcom)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -16,7 +16,7 @@
 	var/autoprocess = 0
 	var/data[0]
 
-	light_color = "#0000FF"
+	light_color = "#315AB4"
 
 /obj/machinery/computer/cloning/New()
 	..()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -58,7 +58,7 @@ var/shuttle_call/shuttle_calls[0]
 
 	var/datum/announcement/priority/crew_announcement = new
 
-	light_color = "#0000FF"
+	light_color = "#0099FF"
 
 /obj/machinery/computer/communications/New()
 	..()

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -8,7 +8,9 @@
 	active_power_usage = 300
 	var/obj/item/weapon/circuitboard/circuit = null //if circuit==null, computer can't disassembly
 	var/processing = 0
-	luminosity = 2
+
+	var/light_range_on = 3
+	var/light_power_on = 2
 
 /obj/machinery/computer/New()
 	..()
@@ -92,10 +94,10 @@
 /obj/machinery/computer/power_change()
 	..()
 	update_icon()
-	if(!(stat & (BROKEN|NOPOWER)))
-		set_light(2)
-	else
+	if((stat & (BROKEN|NOPOWER)))
 		set_light(0)
+	else
+		set_light(light_range_on, light_power_on)
 
 
 /obj/machinery/computer/proc/set_broken()

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -5,6 +5,7 @@
 	use_power = 1
 	idle_power_usage = 250
 	active_power_usage = 500
+	light_color = "#315AB4"
 	circuit = "/obj/item/weapon/circuitboard/crew"
 	var/obj/nano_module/crew_monitor/crew_monitor
 

--- a/code/game/machinery/computer/hologram.dm
+++ b/code/game/machinery/computer/hologram.dm
@@ -20,7 +20,7 @@
 		return
 	return
 
-/obj/machinery/computer/hologram_comp/DblClick()
+/obj/machinery/computer/hologram_comp/attack_hand()
 	if (!in_range(src, usr))
 		return 0
 	src.show_console(usr)

--- a/code/game/machinery/computer/honkputer.dm
+++ b/code/game/machinery/computer/honkputer.dm
@@ -3,6 +3,7 @@
 	desc = "A yellow computer used in case of critically low levels of HONK."
 	icon = 'icons/obj/machines/HONKputer.dmi'
 	icon_state = "honk"
+	light_color = "#FF33CC"
 	req_access = list(access_clown)
 	circuit = "/obj/item/weapon/circuitboard/HONKputer"
 	var/authenticated = 0

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -9,6 +9,7 @@
 	var/opened = 0
 
 	light_color = "#FFFFFF"
+	light_range_on = "2"
 
 
 	verb/AccessInternals()

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -16,7 +16,7 @@
 	var/temp = null
 	var/printing = null
 
-	light_color = "#0000FF"
+	light_color = "#315AB4"
 
 /obj/machinery/computer/med_data/attack_ai(user as mob)
 	return src.attack_hand(user)

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -8,6 +8,7 @@
 	name = "Message Monitor Console"
 	desc = "Used to Monitor the crew's messages, that are sent via PDA. Can also be used to view Request Console messages."
 	icon_state = "comm_logs"
+	light_color = "#00b000"
 	var/hack_icon = "comm_logsc"
 	var/normal_icon = "comm_logs"
 	circuit = "/obj/item/weapon/circuitboard/message_monitor"

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -4,6 +4,7 @@
 	name = "Pod Launch Control"
 	desc = "A controll for launching pods. Some people prefer firing Mechas."
 	icon_state = "computer_generic"
+	light_color = "#00B000"
 	circuit = /obj/item/weapon/circuitboard/pod
 	var/id = 1.0
 	var/obj/machinery/mass_driver/connected = null

--- a/code/game/machinery/computer/pod_tracking_console.dm
+++ b/code/game/machinery/computer/pod_tracking_console.dm
@@ -2,6 +2,7 @@
 	name = "Pod Tracking Console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "podtracking"
+	light_color = "#C860C8"
 	req_access = list(access_robotics)
 	circuit = "/obj/item/weapon/circuitboard/pod_locater"
 

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -14,7 +14,7 @@
 	var/screen = 0 // 0 - No Access Denied, 1 - Access allowed
 	var/obj/item/weapon/card/id/prisoner/inserted_id
 
-	light_color = "#B40000"
+	light_color = "#A91515"
 
 
 	attack_ai(var/mob/user as mob)

--- a/code/game/machinery/computer/prisonshuttle.dm
+++ b/code/game/machinery/computer/prisonshuttle.dm
@@ -14,6 +14,7 @@ var/prison_shuttle_timeleft = 0
 	name = "Prison Shuttle Console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "shuttle"
+	light_color = "#00ffff"
 	req_access = list(access_security)
 	circuit = "/obj/item/weapon/circuitboard/prison_shuttle"
 	var/temp = null

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -4,6 +4,7 @@
 	name = "Employment Records"
 	desc = "Used to view personnel's employment records"
 	icon_state = "medlaptop"
+	light_color = "#00b000"
 	req_one_access = list(access_heads)
 	circuit = "/obj/item/weapon/circuitboard/skills"
 	var/obj/item/weapon/card/id/scan = null
@@ -286,7 +287,7 @@ What a mess.*/
 					temp += "<a href='?src=\ref[src];choice=Clear Screen'>No</a>"
 //RECORD CREATE
 			if ("New Record (General)")
-				
+
 				if(PDA_Manifest.len)
 					PDA_Manifest.Cut()
 				var/datum/data/record/G = new /datum/data/record()

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -15,6 +15,7 @@ var/specops_shuttle_timeleft = 0
 	name = "Spec. Ops. Shuttle Console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "shuttle"
+	light_color = "#00ffff"
 	req_access = list(access_cent_specops)
 //	req_access = list(ACCESS_CENT_SPECOPS)
 	var/temp = null
@@ -93,14 +94,14 @@ var/specops_shuttle_timeleft = 0
 
 	for(var/obj/machinery/computer/specops_shuttle/S in world)
 		S.specops_shuttle_timereset = world.time + SPECOPS_RETURN_DELAY
-		
+
 	del(announcer)
 
 /proc/specops_process()
 	var/area/centcom/specops/special_ops = locate()//Where is the specops area located?
 	var/obj/item/device/radio/intercom/announcer = new /obj/item/device/radio/intercom(null)//We need a fake AI to announce some stuff below. Otherwise it will be wonky.
 	announcer.config(list("Response Team" = 0))
-	
+
 	var/message_tracker[] = list(0,1,2,3,5,10,30,45)//Create a a list with potential time values.
 	var/message = "\"THE SPECIAL OPERATIONS SHUTTLE IS PREPARING FOR LAUNCH\""//Initial message shown.
 	if(announcer)
@@ -234,7 +235,7 @@ var/specops_shuttle_timeleft = 0
 
 	for(var/obj/machinery/computer/specops_shuttle/S in world)
 		S.specops_shuttle_timereset = world.time + SPECOPS_RETURN_DELAY
-		
+
 	del(announcer)
 
 /proc/specops_can_move()

--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -4,7 +4,7 @@
 	icon_state = "comm_logs"
 	circuit = "/obj/item/weapon/circuitboard/merch"
 
-	light_color = "#50AB00"
+	light_color = "#00CC00"
 
 /obj/item/weapon/circuitboard/merch
 	name = "\improper Merchandise Computer Circuitboard"

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -14,6 +14,7 @@ var/syndicate_elite_shuttle_timeleft = 0
 	name = "Elite Syndicate Squad Shuttle Console"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "syndishuttle"
+	light_color = "#00ffff"
 	req_access = list(access_syndicate)
 	var/temp = null
 	var/hacked = 0

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -38,7 +38,7 @@
 	component_parts += new /obj/item/stack/cable_coil(src, 1)
 	RefreshParts()
 	locate_recharge_turf()
-	
+
 /obj/machinery/mech_bay_recharge_port/upgraded/New()
 	..()
 	component_parts = list()
@@ -99,6 +99,7 @@
 	anchored = 1
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "recharge_comp"
+	light_color = "#a97faa"
 	circuit = /obj/item/weapon/circuitboard/mech_bay_power_console
 	var/obj/machinery/mech_bay_recharge_port/recharge_port
 

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -2,6 +2,7 @@
 	name = "Exosuit Control"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "mecha"
+	light_color = "#a97faa"
 	req_access = list(access_robotics)
 	circuit = "/obj/item/weapon/circuitboard/mecha_control"
 	var/list/located = list()

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -6,6 +6,8 @@
 	item_state = "candle1"
 	w_class = 1
 
+	light_color = "#E09D37"
+
 	var/wax = 200
 	var/lit = 0
 	proc

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -117,6 +117,7 @@
 	desc = "A red Nanotrasen issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = 2.0
 	brightness_on = 7 // Pretty bright.
+	light_color = "#e58775"
 	icon_state = "flare"
 	item_state = "flare"
 	icon_action_button = null	//just pull it manually, neckbeard.
@@ -175,6 +176,7 @@
 	item_state = "slime"
 	w_class = 1
 	brightness_on = 6
+	light_color = "#FFBF00"
 	on = 1 //Bio-luminesence has one setting, on.
 
 /obj/item/device/flashlight/slime/New()

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -157,6 +157,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		item_state = icon_on
 		var/turf/T = get_turf(src)
 		T.visible_message(flavor_text)
+		set_light(2, 0.25, "#E38F46")
 		processing_objects.Add(src)
 
 
@@ -203,6 +204,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/proc/die()
 	var/turf/T = get_turf(src)
+	set_light(0)
 	var/obj/item/butt = new type_butt(T)
 	transfer_fingerprints_to(butt)
 	if(ismob(loc))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -34,6 +34,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole
 	name = "R&D Console"
 	icon_state = "rdcomp"
+	light_color = "#a97faa"
 	circuit = /obj/item/weapon/circuitboard/rdconsole
 	var/datum/research/files							//Stores all the collected research data.
 	var/obj/item/weapon/disk/tech_disk/t_disk = null	//Stores the technology disk.

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -181,6 +181,7 @@
 /obj/machinery/computer/rdservercontrol
 	name = "R&D Server Controller"
 	icon_state = "rdcomp"
+	light_color = "#a96faa"
 	circuit = /obj/item/weapon/circuitboard/rdservercontrol
 	var/screen = 0
 	var/obj/machinery/r_n_d/server/temp_server


### PR DESCRIPTION
# More colors!

This PR adds more color definitions to computers, namely the couple I missed from the original PR, as well as Baystation12/Baystation12#9220

Almost every console now has an appropriate color.

Cigarettes glow slightly, just enough to make someone visible.

## Screenshots (not complete, too many consoles to do)
![merch comp](http://puu.sh/hKuJ9/0edad8a02d.png) Merch Comp
![smoking](http://puu.sh/hKuLo/c9b07f63b6.png) Smoking
![Slime core](http://puu.sh/hKuMm/57800f340d.png) Slime core flashlight
![HONKputer](http://puu.sh/hKuPp/8966a4e9cf.png) Honk!
![Pod Tracking Console](http://puu.sh/hKuSP/bf4d7d8fb0.png) Pod tracker
![Candle](http://puu.sh/hKuV9/4d3c0920a1.png) Candles

And something very special: Beepsky now flashes red and blue while hunting someone.
http://puu.sh/hKvYn/116961898b.mp4