### PR TITLE
Get_Area(), Event, and grab fixes

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -16,16 +16,10 @@
 		return A
 
 /proc/get_area(O)
-	var/atom/location = O
-	var/i
-	for(i=1, i<=20, i++)
-		if(isarea(location))
-			return location
-		else if (istype(location))
-			location = location.loc
-		else
-			return null
-	return 0
+	var/turf/loc = get_turf(O)
+	if(loc)
+		var/area/res = loc.loc
+		.= res
 
 /proc/get_area_name(N) //get area by its name
 	for(var/area/A in world)

--- a/code/modules/events/event.dm
+++ b/code/modules/events/event.dm
@@ -140,6 +140,9 @@
 	// event needs to be responsible for this, as stuff like APLUs currently make their own events for curious reasons
 	event_manager.active_events += src
 
+	if(!EM)
+		EM = new /datum/event_meta(EVENT_LEVEL_MAJOR, "Unknown, Most likely admin called", src.type)
+
 	event_meta = EM
 	severity = event_meta.severity
 	if(severity < EVENT_LEVEL_MUNDANE) severity = EVENT_LEVEL_MUNDANE

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -3,8 +3,8 @@
 
 	var/releaseWhen = 25
 	var/list/area/prisonAreas = list()
-	var/list/area/potentialAreas = list(/area/security/prison,/area/security/brig,/area/security/processing,/area/security/permabrig,/area/security/lobby,/area/security/lobby)
-	var/list/area/candidateAreas = list()
+	var/list/potentialAreas = list("/area/security/prison","/area/security/brig","/area/security/processing","/area/security/permabrig","/area/security/lobby","/area/security/lobby")
+	var/list/candidateAreas = list()
 
 /datum/event/prison_break/setup()
 	announceWhen = rand(50, 60)
@@ -13,39 +13,23 @@
 	src.startWhen = src.releaseWhen-1
 	src.endWhen = src.releaseWhen+1
 
-
-/datum/event/prison_break/announce()
-	if(prisonAreas && prisonAreas.len > 0)
-		command_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] imprisonment subroutines. Recommend station AI involvement.", "Security Alert")
-	else
-		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
-		kill()
-
-/datum/event/prison_break/setup()
-	announceWhen = rand(50, 60)
-	releaseWhen = rand(20, 30)
-
-	src.startWhen = src.releaseWhen-1
-	src.endWhen = src.releaseWhen+1
-
-
-/datum/event/prison_break/announce()
-	if(prisonAreas && prisonAreas.len > 0)
-		command_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] imprisonment subroutines. Recommend station AI involvement.", "Security Alert")
-	else
-		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
-		kill()
-
-
-/datum/event/prison_break/start()
-	for(var/areapath in potentialAreas)
-		candidateAreas += typesof(areapath)
+	for(var/areaa in potentialAreas)
+		var/path = text2path(areaa)
+		candidateAreas += typesof(path)
 
 	for(var/area/A in world)
-		if(istype(A, candidateAreas))
+		if(is_type_in_list(A, candidateAreas))
 			prisonAreas += A
 
 
+/datum/event/prison_break/announce()
+	if(prisonAreas && prisonAreas.len > 0)
+		command_announcement.Announce("[pick("Gr3y.T1d3 virus","Malignant trojan")] detected in [station_name()] imprisonment subroutines. Recommend station AI involvement.", "Security Alert")
+	else
+		world.log << "ERROR: Could not initate grey-tide. Unable find prison or brig area."
+		kill()
+
+/datum/event/prison_break/start()
 	if(prisonAreas && prisonAreas.len > 0)
 		for(var/area/A in prisonAreas)
 			for(var/obj/machinery/light/L in A)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -408,10 +408,11 @@
 	..()
 
 /obj/item/weapon/grab/Destroy()
-	affecting.pixel_x = 0
-	affecting.pixel_y = 0 //used to be an animate, not quick enough for del'ing
-	affecting.layer = initial(affecting.layer)
-	if(affecting) affecting.grabbed_by -= src
+	if(affecting)
+		affecting.pixel_x = 0
+		affecting.pixel_y = 0 //used to be an animate, not quick enough for del'ing
+		affecting.layer = initial(affecting.layer)
+		affecting.grabbed_by -= src
 	del(hud)
 	..()
 


### PR DESCRIPTION
This commit fixes the following things:
 - Get_Area() now properly returns the area
 - Events will no longer runtime upon being manually triggered by an admin
 - The prison break event works again
 - Grabbing will no longer runtime (May result in people with pixel
   offsets from a grab being stuck, better than a runtime)