### PR TITLE
Fix: Space turf depressure, admin del is now admin qdel, event manager runtime

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -244,7 +244,7 @@
 		S.update_starlight()
 
 	W.levelupdate()
-	W.CalculateAdjacentTurfs()
+	W.air_update_turf(1)
 	. = W
 
 	affecting_lights = old_affecting_lights

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -687,7 +687,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		log_admin("[key_name(usr)] deleted [O] at ([O.x],[O.y],[O.z])")
 		message_admins("[key_name_admin(usr)] deleted [O] at ([O.x],[O.y],[O.z])", 1)
 		feedback_add_details("admin_verb","DEL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-		del(O)
+		if(istype(O, /turf))
+			var/turf/T = O
+			T.ChangeTurf(/turf/space)
+			return
+		qdel(O)
 
 /client/proc/cmd_admin_list_open_jobs()
 	set category = "Admin"

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -39,8 +39,19 @@
 
 	finished_events += E
 
+	var/theseverity
+
+	if(!E.severity)
+		theseverity = EVENT_LEVEL_MODERATE
+
+	if(!E.severity == EVENT_LEVEL_MUNDANE && !E.severity == EVENT_LEVEL_MODERATE && !E.severity == EVENT_LEVEL_MAJOR)
+		theseverity = EVENT_LEVEL_MODERATE //just to be careful
+
+	if(E.severity)
+		theseverity = E.severity
+
 	// Add the event back to the list of available events
-	var/datum/event_container/EC = event_containers[E.severity]
+	var/datum/event_container/EC = event_containers[theseverity]
 	var/datum/event_meta/EM = E.event_meta
 	EC.available_events += EM
 


### PR DESCRIPTION
This commit fixes some special cases where a certain series of events
could lead to a space turf being created which was not activated in LINDA,
therefore it would not drain atmos correctly.

Things changed:
 - ChangeTurf properly updates new space tiles
 - Admin delete calls changeturf instead of del'ing turfs to satisfy LINDA
 - Admin delete now uses qdel instead of del, because everything is being
   switched to qdel.
 - Event manager has some sanity checks to prevent a runtime error