### PR TITLE
All lightbulbs in light explosion damage range break

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -560,11 +560,9 @@
 			qdel(src)
 			return
 		if(2.0)
-			if (prob(75))
-				broken()
+			broken()
 		if(3.0)
-			if (prob(50))
-				broken()
+			broken()
 	return
 
 //blob effect


### PR DESCRIPTION
- This will help really make our new lighting code stand out. All around the blast radius will be dark, except for the vented areas which will glow softly with moonlight.