### PR TITLE
Antag picker fairness

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -40,6 +40,7 @@ datum/mind
 
 	var/assigned_role
 	var/special_role
+	var/list/restricted_roles = list()
 
 	var/list/spell_list = list() // Wizard mode & "Give Spell" badmin button.
 

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -20,12 +20,6 @@
 
 	possible_traitors = get_players_for_role(BE_TRAITOR)
 
-	for(var/datum/mind/player in possible_traitors)
-		for(var/job in restricted_jobs)
-			if(player.assigned_role == job)
-				possible_traitors -= player
-
-
 	for(var/mob/new_player/P in world)
 		if(P.client && P.ready)
 			num_players++
@@ -60,6 +54,7 @@
 			continue
 		if(istype(traitor))
 			traitor.special_role = "traitor"
+			traitor.restricted_roles = restricted_jobs
 
 //	if(!traitors.len)
 //		return 0

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -47,6 +47,7 @@ var/list/blob_nodes = list()
 		var/datum/mind/blob = pick(possible_blobs)
 		infected_crew += blob
 		blob.special_role = "Blob"
+		blob.restricted_roles = restricted_jobs
 		log_game("[blob.key] (ckey) has been selected as a Blob")
 		possible_blobs -= blob
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -51,11 +51,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 	var/list/datum/mind/possible_changelings = get_players_for_role(BE_CHANGELING)
 
-	for(var/datum/mind/player in possible_changelings)
-		for(var/job in restricted_jobs)//Removing robots from the list
-			if(player.assigned_role == job)
-				possible_changelings -= player
-
 	changeling_amount = 1 + round(num_players() / 10)
 
 	if(possible_changelings.len>0)
@@ -64,6 +59,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			var/datum/mind/changeling = pick(possible_changelings)
 			possible_changelings -= changeling
 			changelings += changeling
+			changeling.restricted_roles = restricted_jobs
 			modePlayer += changelings
 		return 1
 	else
@@ -125,7 +121,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 				var/mob/living/carbon/human/H = identity_theft.target.current
 				if(H.species && H.species.flags && H.species.flags & NO_SCAN) // For species that can't be absorbed - should default to an escape objective instead
 					return
-				else	
+				else
 					identity_theft.explanation_text = "Escape on the shuttle or an escape pod with the identity of [identity_theft.target_real_name], the [identity_theft.target.assigned_role] while wearing their identification card."
 			changeling.objectives += identity_theft
 
@@ -312,4 +308,4 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		user << "<span class='warning'>We already have this DNA in storage!</span>"
 
 	return 1
-	
+

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -65,10 +65,6 @@
 		restricted_jobs += protected_jobs
 
 	var/list/cultists_possible = get_players_for_role(BE_CULTIST)
-	for(var/datum/mind/player in cultists_possible)
-		for(var/job in restricted_jobs)//Removing heads and such from the list
-			if(player.assigned_role == job)
-				cultists_possible -= player
 
 	for(var/cultists_number = 1 to max_cultists_to_start)
 		if(!cultists_possible.len)
@@ -76,6 +72,7 @@
 		var/datum/mind/cultist = pick(cultists_possible)
 		cultists_possible -= cultist
 		cult += cultist
+		cultist.restricted_roles = restricted_jobs
 
 	return (cult.len>0)
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -104,8 +104,9 @@ var/global/datum/controller/gameticker/ticker
 
 	//Configure mode and assign player to special mode stuff
 	src.mode.pre_pre_setup()
+	var/can_continue
+	can_continue = src.mode.pre_setup()//Setup special modes
 	job_master.DivideOccupations() //Distribute jobs
-	var/can_continue = src.mode.pre_setup()//Setup special modes
 	if(!can_continue)
 		del(mode)
 		current_state = GAME_STATE_PREGAME

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -55,17 +55,13 @@
 			head_check = 1
 			break
 
-	for(var/datum/mind/player in possible_headrevs)
-		for(var/job in restricted_jobs)//Removing heads and such from the list
-			if(player.assigned_role == job)
-				possible_headrevs -= player
-
 	for (var/i=1 to max_headrevs)
 		if (possible_headrevs.len==0)
 			break
 		var/datum/mind/lenin = pick(possible_headrevs)
 		possible_headrevs -= lenin
 		head_revolutionaries += lenin
+		lenin.restricted_roles = restricted_jobs
 
 	if((head_revolutionaries.len==0)||(!head_check))
 		return 0

--- a/code/game/gamemodes/revolution/rp_revolution.dm
+++ b/code/game/gamemodes/revolution/rp_revolution.dm
@@ -37,17 +37,13 @@
 			head_check = 1
 			break
 
-	for(var/datum/mind/player in possible_headrevs)
-		for(var/job in restricted_jobs)//Removing heads and such from the list
-			if(player.assigned_role == job)
-				possible_headrevs -= player
-
 	for (var/i=1 to max_headrevs)
 		if (possible_headrevs.len==0)
 			break
 		var/datum/mind/lenin = pick(possible_headrevs)
 		possible_headrevs -= lenin
 		head_revolutionaries += lenin
+		lenin.restricted_roles = restricted_jobs
 
 	if((head_revolutionaries.len==0)||(!head_check))
 		return 0

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -85,11 +85,6 @@ Made by Xhuis
 	if(!possible_shadowlings.len)
 		return 0
 
-	for(var/datum/mind/player in possible_shadowlings)
-		for(var/job in restricted_jobs)
-			if(player.assigned_role == job)
-				possible_shadowlings -= player
-
 	var/shadowlings = 2 //How many shadowlings there are; hardcoded to 2
 
 	while(shadowlings)
@@ -98,6 +93,7 @@ Made by Xhuis
 		possible_shadowlings -= shadow
 		modePlayer += shadow
 		shadow.special_role = "Shadowling"
+		shadow.restricted_roles = restricted_jobs
 		shadowlings--
 	return 1
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -50,17 +50,13 @@
 	else
 		num_traitors = max(1, min(num_players(), traitors_possible))
 
-	for(var/datum/mind/player in possible_traitors)
-		for(var/job in restricted_jobs)
-			if(player.assigned_role == job)
-				possible_traitors -= player
-
 	for(var/j = 0, j < num_traitors, j++)
 		if (!possible_traitors.len)
 			break
 		var/datum/mind/traitor = pick(possible_traitors)
 		traitors += traitor
 		traitor.special_role = "traitor"
+		traitor.restricted_roles = restricted_jobs
 		possible_traitors.Remove(traitor)
 
 	if(!traitors.len)

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -52,11 +52,6 @@
 
 	var/list/datum/mind/possible_vampires = get_players_for_role(BE_VAMPIRE)
 
-	for(var/datum/mind/player in possible_vampires)
-		for(var/job in restricted_jobs)//Removing robots from the list
-			if(player.assigned_role == job)
-				possible_vampires -= player
-
 	vampire_amount = 1 + round(num_players() / 10)
 
 	if(possible_vampires.len>0)
@@ -65,6 +60,7 @@
 			var/datum/mind/vampire = pick(possible_vampires)
 			possible_vampires -= vampire
 			vampires += vampire
+			vampire.restricted_roles = restricted_jobs
 			modePlayer += vampires
 		return 1
 	else

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -110,6 +110,9 @@ var/global/datum/controller/occupations/job_master
 			if(flag && (!player.client.prefs.be_special & flag))
 				Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 				continue
+			if(player.mind && job.title in player.mind.restricted_roles)
+				Debug("FOC incompatbile with antagonist role, Player: [player]")
+				continue
 			if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
 				Debug("FOC pass, Player: [player], Level:[level]")
 				candidates += player
@@ -136,6 +139,10 @@ var/global/datum/controller/occupations/job_master
 
 			if(!job.player_old_enough(player.client))
 				Debug("GRJ player not old enough, Player: [player]")
+				continue
+
+			if(player.mind && job.title in player.mind.restricted_roles)
+				Debug("GRJ incompatible with antagonist role, Player: [player], Job: [job.title]")
 				continue
 
 			if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
@@ -320,6 +327,10 @@ var/global/datum/controller/occupations/job_master
 
 					if(!job.player_old_enough(player.client))
 						Debug("DO player not old enough, Player: [player], Job:[job.title]")
+						continue
+
+					if(player.mind && job.title in player.mind.restricted_roles)
+						Debug("DO incompatible with antagonist role, Player: [player], Job:[job.title]")
 						continue
 
 					if(!is_job_whitelisted(player, job.title))


### PR DESCRIPTION
tgstation/-tg-station#9364

This PR can be summed up by the following:
> Players who would otherwise qualify to play as a protected role will spawn as the most wanted not protected role they qualify for if they are an onstation antagonist.

Round startup will now prioritize mode setup over job setup, therefore, if a player is picked from a possible antags pool, the job system will sort them into a job that allows them to be that antag, instead of just spawning them and preventing them from becoming an antag. 

This means that the job controller won't fuck over people unless the RNG traitor pool pick already decided against using them.