### PR TITLE
Update simulated var to bay12 refactors

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -14,6 +14,7 @@ var/global/list/ghdel_profiling = list()
 	var/pass_flags = 0
 	var/throwpass = 0
 	var/germ_level = GERM_LEVEL_AMBIENT // The higher the germ level, the more germ on the atom.
+	var/simulated = 1 //filter for actions - used by lighting overlays
 
 	///Chemistry.
 	var/datum/reagents/reagents = null

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -14,7 +14,6 @@
 	var/no_spin = 0
 	var/moved_recently = 0
 	var/mob/pulledby = null
-	var/simulated //filter for actions - used by lighting overlays
 
 	var/area/areaMaster
 	var/hard_deleted = 0

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -5,6 +5,7 @@ var/global/narsie_cometh = 0
 var/global/list/uneatable = list(
 	/turf/space,
 	/obj/effect/overlay,
+	/atom/movable/lighting_overlay,
 	/mob/dead,
 	/mob/camera,
 	/mob/new_player
@@ -222,6 +223,7 @@ var/global/list/uneatable = list(
 	for(var/atom/X in orange(grav_pull,src))
 		// N3X: Move this up here since get_dist is slow.
 		if(is_type_in_list(X, uneatable))	continue
+		if(!X.simulated)	continue
 
 		var/dist = get_dist(X, src)
 
@@ -264,6 +266,8 @@ var/global/list/uneatable = list(
 /obj/machinery/singularity/proc/consume(var/atom/A)
 	var/gain = 0
 	if(is_type_in_list(A, uneatable))
+		return 0
+	if(!A.simulated)
 		return 0
 	if (istype(A,/mob/living))//Mobs get gibbed
 		var/mob/living/M = A
@@ -560,6 +564,8 @@ var/global/list/uneatable = list(
 
 /obj/machinery/singularity/narsie/consume(var/atom/A)
 	if(is_type_in_list(A, uneatable))
+		return 0
+	if(!A.simulated)
 		return 0
 	if (istype(A,/mob/living))//Mobs get gibbed
 		A:gib()


### PR DESCRIPTION
This commit refactors the simulated var to a missed update from bay12,
which prevents the singularity or explosions from breaking lighting.