### PR TITLE
FIX: Spacepod null weapon firing runtime

### DIFF
--- a/code/game/vehicles/spacepods/spacepod.dm
+++ b/code/game/vehicles/spacepods/spacepod.dm
@@ -788,6 +788,9 @@
 		set desc = "Fire the weapons."
 		set category = "Spacepod"
 		set src = usr.loc
+		if(!equipment_system.weapon_system)
+			usr << "<span class='warning'>\The [src] has no weapons!</span>"
+			return
 		equipment_system.weapon_system.fire_weapons()
 
 obj/spacepod/verb/toggleLights()


### PR DESCRIPTION
This commit fixes a runtime error with spacepods, which would happen when
someone tried to fire the weapons while the pod has no weapons.