### PR TITLE
FIX: Floodlights no longer have 999 range

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -11,7 +11,9 @@
 	var/use = 5
 	var/unlocked = 0
 	var/open = 0
-	var/brightness_on = 999		//can't remember what the maxed out value is
+	var/brightness_on = 14
+	light_power = 20
+	//var/brightness_on = 999		//can't remember what the maxed out value is //Lighting overhaul: No max, stop TRYING TO ILLUMINATE MORE TILES THAN THE MAP CONSISTS OF.
 
 /obj/machinery/floodlight/New()
 	src.cell = new(src)


### PR DESCRIPTION
This commit fixes the fact that floodlights had literally 999 range to
them, illuminating more tiles than were actually on the map. They now have
14 range, and 20 brightness to maintain functionality similar to that
which they had before the lighting overhaul.

![new range](http://puu.sh/hNLtz/51e15614d9.png)
![max range](http://puu.sh/hNLQm/1d7e6a28d2.png)