### PR TITLE
Fixes Luminosity Checks

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -63,9 +63,9 @@
 		else
 			light_available = 5
 		if(light_available <= 2)
-			M.alpha = round(255 * 1.15)
+			M.alpha = round(M.alpha * 0.8)
 		else
-			M.alpha = round(255 * 0.80)
+			M.alpha = 255
 
 //WAS: /datum/bioEffect/chameleon
 /datum/dna/gene/basic/stealth/chameleon

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -59,7 +59,7 @@
 		var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 		var/light_available
 		if(L)
-			light_available = max(0,min(10,L.lum_r + L.lum_g + L.lum_b)-5)
+			light_available = L.get_clamped_lum()*10
 		else
 			light_available = 5
 		if(light_available <= 2)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -273,9 +273,9 @@
 	var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 	var/light_available
 	if(L)
-		light_available = max(0,min(10,L.lum_r + L.lum_g + L.lum_b)-5)
+		light_available = L.get_clamped_lum(0.5)*10
 	else
-		light_available = 5
+		light_available = 10
 
 	if(!istype(T))
 		return 0
@@ -446,7 +446,7 @@
 				if(T.y>world.maxy-outer_tele_radius || T.y<outer_tele_radius)	continue
 
 				var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
-				var/lightingcount =  max(0,min(10,L.lum_r + L.lum_g + L.lum_b)-5)
+				var/lightingcount =  L.get_clamped_lum(0.5)*10
 
 				// LIGHTING CHECK
 				if(lightingcount > max_lum) continue

--- a/code/game/objects/structures/spirit_board.dm
+++ b/code/game/objects/structures/spirit_board.dm
@@ -64,9 +64,9 @@
 	var/turf/T = get_turf(src)
 	var/atom/movable/lighting_overlay/LO = locate(/atom/movable/lighting_overlay) in T
 	if(LO)
-		light_amount = max(0,min(10,LO.lum_r + LO.lum_g + LO.lum_b)-5)
+		light_amount = LO.get_clamped_lum(0.5)*10
 	else
-		light_amount =  5
+		light_amount =  10
 
 	if(light_amount > 2)
 		M << "<span class='warning'>It's too bright here to use [src.name]!</span>"

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -281,7 +281,7 @@
 	if(!light_supplied)
 		var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in current_turf
 		if(L)
-			light_supplied = max(0,min(10,L.lum_r + L.lum_g + L.lum_b)-5)
+			light_supplied = L.get_clamped_lum()*10
 		else
 			light_supplied =  5
 

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -810,7 +810,7 @@
 			var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 			var/light_available
 			if(L)
-				light_available = max(0,min(10,L.lum_r + L.lum_g + L.lum_b))
+				light_available = L.get_clamped_lum()*10
 			else
 				light_available =  5
 			light_string = "a light level of [light_available] lumens"

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -25,6 +25,15 @@
 	. = ..()
 	verbs.Cut()
 
+/atom/movable/lighting_overlay/proc/get_clamped_lum(var/minlum = 0, var/maxlum = 1)
+	var/lum = max(lum_r, lum_g, lum_b)
+	if(lum <= minlum)
+		return 0
+	else if(lum >= maxlum)
+		return 1
+	else
+		return (lum - minlum) / (maxlum - minlum)
+
 /atom/movable/lighting_overlay/proc/update_lumcount(delta_r, delta_g, delta_b)
 	lum_r += delta_r
 	lum_g += delta_g

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -746,7 +746,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				var/turf/T = loc
 				var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 				if(L)
-					light_amount = min(10,L.lum_r + L.lum_g + L.lum_b) - 5 //hardcapped so it's not abused by having a ton of flashlights
+					light_amount = (L.get_clamped_lum()*10) - 5 //hardcapped so it's not abused by having a ton of flashlights
 				else
 					light_amount =  5
 			nutrition += light_amount
@@ -768,7 +768,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				var/turf/T = loc
 				var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 				if(L)
-					light_amount = L.lum_r + L.lum_g + L.lum_b //hardcapped so it's not abused by having a ton of flashlights
+					light_amount = L.get_clamped_lum()*10
 				else
 					light_amount =  10
 			if(light_amount > species.light_dam) //if there's enough light, start dying

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -442,7 +442,7 @@
 				var/turf/T = loc
 				var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 				if(L)
-					light_amount = min(10,L.lum_r + L.lum_g + L.lum_b) - 5 //hardcapped so it's not abused by having a ton of flashlights
+					light_amount = (L.get_clamped_lum()*10) - 5 //hardcapped so it's not abused by having a ton of flashlights
 				else
 					light_amount =  5
 

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -121,7 +121,7 @@
 		light_amount =  5
 	var/atom/movable/lighting_overlay/DL = locate(/atom/movable/lighting_overlay) in destination
 	if(DL)
-		DLlight_amount = L.lum_r + L.lum_g + L.lum_b
+		DLlight_amount = DL.lum_r + DL.lum_g + DL.lum_b
 	else
 		DLlight_amount =  5
 	if(T && destination)

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -116,19 +116,19 @@
 	var/DLlight_amount
 	var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in T
 	if(L)
-		light_amount = min(10,L.lum_r + L.lum_g + L.lum_b) - 5 //hardcapped so it's not abused by having a ton of flashlights
+		light_amount = L.lum_r + L.lum_g + L.lum_b
 	else
 		light_amount =  5
 	var/atom/movable/lighting_overlay/DL = locate(/atom/movable/lighting_overlay) in destination
 	if(DL)
-		DLlight_amount = min(10,L.lum_r + L.lum_g + L.lum_b) - 5 //hardcapped so it's not abused by having a ton of flashlights
+		DLlight_amount = L.lum_r + L.lum_g + L.lum_b
 	else
 		DLlight_amount =  5
 	if(T && destination)
 		// Don't check it twice if our destination is the tile we are on or we can't even get to our destination
 		if(T == destination)
 			destination = null
-		else if(light_amount <= 1 && DLlight_amount <= 1) // No one can see us in the darkness, right?
+		else if(light_amount < 0.1 && DLlight_amount < 0.1) // No one can see us in the darkness, right?
 			return null
 
 	// We aren't in darkness, loop for viewers.


### PR DESCRIPTION
Since the new lighting system uses a different measurement of luminosity, all of the old checks were replaced with new ones. In many cases, these new checks used calculations that would result in strange, if not totally wrong, behavior. These have been replaced with new ones, which should bring all of the luminosity checks more in line with how they worked under the old lighting system.

A few particularly noteworthy changes:
* Hydro trays will now have lumens between 0 (pitch black tile) and 10 (fully-lit tile).
  * Prior to the lighting overhaul, they would cap at 5, which is lower than the ideal light level of most plants.
  * After the overhaul, lumens would range from 3 to 6+ for trays on tiles that all appeared to be fully lit.
  * By default, hydroponics has all fully-lit tiles, which means all trays will now be getting 10 lumens.
* Dionae will no longer die in **fully-godddamn-lit tiles.**
  * As before the overhaul, 50% lit is neutral, less will deprive of nutrition, more will provide nutrition, 100% lit will heal.
* Hostile statues will no longer treat fully-lit tiles as if they were pitch black.
  * This doesn't matter because they're hilariously broken anyway!
* The Cloak of Darkness gene power will now actually work - being in light under 20% will cause you to slowly fade out, otherwise you'll be fully visible.
  * Previously, it would make you 80% opaque if you were in light over 20%, and 115% opaque if you were in light below 20%.
    * That's right. 115% opacity.
  * It isn't supposed to be possible to have both this and Chameleon, but if you do, you'll be fully visible above 20% light, and rapidly fade below 20%.

By the way: fixes #1019 and fixes #1030