### PR TITLE
FIX: Linda airflow affecting mob when it shouldn't

### DIFF
--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -118,4 +118,5 @@
 	else
 		return 0
 
-
+/mob/camera/experience_pressure_difference()
+	return 0

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -229,6 +229,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(A)
 		A.Entered(src)
 
+/mob/dead/observer/experience_pressure_difference()
+	return 0
+
 /mob/dead/observer/examine()
 	if(usr)
 		usr << desc

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -492,10 +492,8 @@ emp_act
 
 /mob/living/carbon/human/experience_pressure_difference(pressure_difference, direction)
 	if(shoes)
-		if(istype(shoes,/obj/item/clothing/shoes/magboots)) //TODO: Make a not-shit shoe var system to negate airflow.
-			var/obj/item/clothing/shoes/magboots/MB = shoes
-			if(MB.magpulse)
-				return 0
+		if(istype(shoes,/obj/item/clothing/shoes/magboots) && (shoes.flags & NOSLIP)) //TODO: Make a not-shit shoe var system to negate airflow.
+			return 0
 	..()
 
 /mob/living/carbon/human/water_act(volume, temperature, source)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -77,6 +77,9 @@
 			return
 		return ai.eyeobj.loc
 
+/mob/aiEye/experience_pressure_difference()
+	return 0
+
 // AI MOVEMENT
 
 // The AI's "eye". Described on the top of the page.


### PR DESCRIPTION
This commit fixes Linda airflow affecting AI eyes, blob overminds,
observers, and replaces the magboot check for humans with a better
version.