### PR TITLE
Lighting runtime fix

### DIFF
--- a/code/modules/lighting/light_source.dm
+++ b/code/modules/lighting/light_source.dm
@@ -50,7 +50,7 @@
 /datum/light_source/proc/destroy()
 	destroyed = 1
 	force_update()
-	if(source_atom) source_atom.light_sources -= src
+	if(source_atom && source_atom.light_sources) source_atom.light_sources -= src
 	if(top_atom) top_atom.light_sources -= src
 
 /datum/light_source/proc/update(atom/new_top_atom)


### PR DESCRIPTION
runtime error: type mismatch: null -= /datum/light_source (/datum/light_source)
proc name: destroy (/datum/light_source/proc/destroy)
  source file: light_source.dm,53
  usr: null
  src: /datum/light_source (/datum/light_source)
  call stack:
/datum/light_source (/datum/light_source): destroy()
/datum/light_source (/datum/light_source): check()
lighting (/datum/controller/process/lighting): doWork()
lighting (/datum/controller/process/lighting): process()
/datum/controller/processSched... (/datum/controller/processScheduler): runProcess(lighting (/datum/controller/process/lighting))