### PR TITLE
FIX: APC's unbuildable due to runtime

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -119,7 +119,7 @@
 	if (building==0)
 		init()
 	else
-		area = src.loc.loc:master
+		area = src.loc.loc
 		area.apc |= src
 		opened = 1
 		operating = 0


### PR DESCRIPTION
This commit fixes APC's being unbuildable due to a runtime error.
The runtime error was caused by checking for area.master, which no longer
exists after the lighting overhaul.

Fixes #1062