### PR TITLE
Nuke Ops Uplink Fix

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -755,7 +755,7 @@ var/list/uplink_items = list()
 	desc = "A crate containing 50 telecrystals worth of random syndicate leftovers."
 	cost = 20
 	item = /obj/item/weapon/storage/box/syndicate
-	excludefrom = list(/datum/game_mode/nuclear)
+	excludefrom = list("nuclear emergency")
 
 /datum/uplink_item/badass/surplus_crate/spawn_item(turf/loc, obj/item/device/uplink/U)
 	var/obj/structure/closet/crate/C = new(loc)


### PR DESCRIPTION
Fixes Nuke Ops being able to order surplus crates.

Pretty game-breaking as they can get something like 250% more TC worth of items than they start out with.