### PR TITLE
Minor refactors and fixes.

### DIFF
--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -79,23 +79,6 @@
 			return loc.Adjacent(neighbor,recurse - 1)
 		return 0
 	return ..()
-/*
-	Special case: This allows you to reach a door when it is visally on top of,
-	but technically behind, a fire door
-
-	You could try to rewrite this to be faster, but I'm not sure anything would be.
-	This can be safely removed if border firedoors are ever moved to be on top of doors
-	so they can be interacted with without opening the door.
-*/
-/obj/machinery/door/Adjacent(var/atom/neighbor)
-	var/obj/machinery/door/firedoor/border_only/BOD = locate() in loc
-	if(BOD)
-		BOD.throwpass = 1 // allow click to pass
-		. = ..()
-		BOD.throwpass = 0
-		return .
-	return ..()
-
 
 /*
 	This checks if you there is uninterrupted airspace between that turf and this one.

--- a/code/controllers/Processes/mob.dm
+++ b/code/controllers/Processes/mob.dm
@@ -30,7 +30,7 @@ var/global/datum/controller/mob_system/mob_master
 	var/starttime
 
 /datum/controller/mob_system/proc/Setup()
-	world << "\red Mob ticker starting up."
+	world << "\red \b Mob ticker starting up."
 	starttime = world.timeofday
 
 /datum/controller/mob_system/proc/process()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -239,7 +239,7 @@
 	sleep(5)
 	src.density = 0
 	sleep(5)
-	src.layer = 2.7
+	src.layer = open_layer
 	update_icon()
 	set_opacity(0)
 	operating = 0
@@ -263,7 +263,7 @@
 	operating = 1
 
 	do_animate("closing")
-	src.layer = 3.1
+	src.layer = closed_layer
 	sleep(5)
 	src.density = 1
 	sleep(5)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -18,6 +18,7 @@
 	var/nextstate = null
 
 	var/logged_users
+	closed_layer = 3.11
 
 /obj/machinery/door/firedoor/New()
 	. = ..()

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -233,11 +233,11 @@
 		user << "<span class='danger'>Subject may not have abiotic items on.</span>"
 		return
 
-	user.visible_message("\red [user] starts to put [victim] into the gibber!")
+	user.visible_message("<span class='danger'>[user] starts to put [victim] into the gibber!</span>")
 	src.add_fingerprint(user)
 	if(do_after(user, 30) && user.Adjacent(src) && victim.Adjacent(user) && !occupant)
 
-		user.visible_message("\red [user] stuffs [victim] into the gibber!")
+		user.visible_message("<span class='danger'>[user] stuffs [victim] into the gibber!</span>")
 
 		if(victim.client)
 			victim.client.perspective = EYE_PERSPECTIVE


### PR DESCRIPTION


Refactors:
 - Firelocks no longer have snowflake code in Adjacent.dm, they just have a closed_layer definition .01 above the door. tgstation/-tg-station#9511

Minor text fixes:
 - The 2 remaining text macros in gibber code have been replaced with span classes
 - Mob ticker is now \red \b, instead of just \red, as it was the only process that did not use \b when booting.