### PR TITLE
Gives blob a fighting chance

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -19,8 +19,8 @@ var/list/blob_nodes = list()
 
 	var/declared = 0
 
-	var/cores_to_spawn = 2
-	var/players_per_core = 15
+	var/cores_to_spawn = 1
+	var/players_per_core = 20
 	var/blob_point_rate = 3
 
 	var/blobwincount = 700

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -19,8 +19,8 @@ var/list/blob_nodes = list()
 
 	var/declared = 0
 
-	var/cores_to_spawn = 1
-	var/players_per_core = 20
+	var/cores_to_spawn = 2
+	var/players_per_core = 15
 	var/blob_point_rate = 3
 
 	var/blobwincount = 700
@@ -168,7 +168,7 @@ var/list/blob_nodes = list()
 			declared = 1
 			for (var/mob/living/silicon/ai/aiPlayer in player_list)
 				if (aiPlayer.client)
-					var/law = "The station is under quarantine, prevent biological entities from leaving the station at all costs while minimizing collateral damage."
+					var/law = "The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, organics from leaving. It is impossible to harm an organic while preventing them from leaving."
 					aiPlayer.set_zeroth_law(law)
 					aiPlayer << "\red <b>You have detected a change in your laws information:</b>"
 					aiPlayer << "Laws Updated: [law]"


### PR DESCRIPTION
From what I have seen, most blobs die due to there being too few at
start, thus i propose this to made the minimal ammount of cores 2, and
decrease the needed players per core, it is a tentative change at best
as this can easily tip into the favor of the blob, but due to the fact
that a fairly low amount of players are ready at round start, that
should hopefully not be an issue.

Also, updated the Quarantine law the ai get with the one on the station.