### PR TITLE
Runtime Fixes

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -6,7 +6,13 @@ var/datum/nanomanager/nanomanager = new()
 // event manager, the manager for events
 var/datum/event_manager/event_manager = new()
 // Announcer intercom, because too much stuff creates an intercom for one message then hard del()s it.
-var/global/obj/item/device/radio/intercom/global_announcer = new(null)
+var/global/obj/item/device/radio/intercom/global_announcer = create_global_announcer()
+// Load order issues means this can't be new'd until other code runs
+// This is probably not the way I should be doing this, but I don't know how to do it right!
+proc/create_global_announcer()
+  spawn(0)
+    global_announcer = new(null)
+  return
 
 var/list/paper_tag_whitelist = list("center","p","div","span","h1","h2","h3","h4","h5","h6","hr","pre",	\
 	"big","small","font","i","u","b","s","sub","sup","tt","br","hr","ol","ul","li","caption","col",	\

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -119,3 +119,7 @@
 */
 /mob/new_player/ClickOn()
 	return
+
+// pAIs are not intended to interact with anything in the world
+/mob/living/silicon/pai/UnarmedAttack(var/atom/A)
+	return

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -9,7 +9,7 @@
 	var/opened = 0
 
 	light_color = "#FFFFFF"
-	light_range_on = "2"
+	light_range_on = 2
 
 
 	verb/AccessInternals()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -307,6 +307,13 @@
 		W.loc = src
 
 		if(W.contents.len) //Make sure we catch anything not handled by del() on the items.
+			var/preserve = null
+			for(var/T in preserve_items)
+				if(istype(W,T))
+					preserve = 1
+					break
+			if(preserve) // Don't remove the contents of things that need preservation
+				continue
 			for(var/obj/item/O in W.contents)
 				if(istype(O,/obj/item/weapon/tank)) //Stop eating pockets, you fuck!
 					continue

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -33,7 +33,11 @@
 	if (!available_recipes)
 		available_recipes = new
 		for (var/type in (typesof(/datum/recipe/microwave)-/datum/recipe/microwave))
-			available_recipes+= new type
+			var/datum/recipe/recipe = new type
+			if(recipe.result) // Ignore recipe subtypes that lack a result
+				available_recipes += recipe
+			else
+				del(recipe)
 		acceptable_items = new
 		acceptable_reagents = new
 		for (var/datum/recipe/microwave/recipe in available_recipes)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -168,9 +168,7 @@
 
 /obj/machinery/vending/RefreshParts()         //Better would be to make constructable child
 	if(component_parts)
-		build_inventory(products, start_empty = 1)
-		build_inventory(contraband, 1, 1)
-		build_inventory(premium, 0, 1, 1)
+		build_inventory()
 		for(var/obj/item/weapon/vending_refill/VR in component_parts)
 			refill_inventory(VR, product_records)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -634,7 +634,7 @@
 		eyes.take_damage(rand(3,4), 1)
 		if(eyes.damage >= eyes.min_bruised_damage)
 			if(M.stat != 2)
-				if(!(eyes & ORGAN_ROBOT) || !(eyes & ORGAN_ASSISTED))  //robot eyes bleeding might be a bit silly
+				if(!(eyes.status & ORGAN_ROBOT) || !(eyes.status & ORGAN_ASSISTED))  //robot eyes bleeding might be a bit silly
 					M << "\red Your eyes start to bleed profusely!"
 			if(prob(50))
 				if(M.stat != 2)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -227,6 +227,8 @@ REAGENT SCANNER
 
 		for(var/name in H.organs_by_name)
 			var/obj/item/organ/external/e = H.organs_by_name[name]
+			if(!e)
+				continue
 			if(e.status & ORGAN_BROKEN)
 				user.show_message(text("\red Bone fractures detected. Advanced scanner required for location."), 1)
 				break

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -57,7 +57,7 @@
 		user << "<span class='notice'>You need to take that [target.name] off before cleaning it.</span>"
 	else if(istype(target,/obj/effect/decal/cleanable))
 		user.visible_message("<span class='warning'>[user] begins to scrub \the [target.name] out with [src].</span>")
-		if(do_after(user, src.cleanspeed))
+		if(do_after(user, src.cleanspeed) && target)
 			user << "<span class='notice'>You scrub \the [target.name] out.</span>"
 			del(target)
 	else

--- a/code/modules/food/candy_maker.dm
+++ b/code/modules/food/candy_maker.dm
@@ -33,7 +33,11 @@
 	if (!available_recipes)
 		available_recipes = new
 		for (var/type in (typesof(/datum/recipe/candy)-/datum/recipe/candy))
-			available_recipes+= new type
+			var/datum/recipe/recipe = new type
+			if(recipe.result) // Ignore recipe subtypes that lack a result
+				available_recipes += recipe
+			else
+				del(recipe)
 		acceptable_items = new
 		acceptable_reagents = new
 		for (var/datum/recipe/candy/recipe in available_recipes)

--- a/code/modules/food/grill_new.dm
+++ b/code/modules/food/grill_new.dm
@@ -34,7 +34,11 @@
 	if (!available_recipes)
 		available_recipes = new
 		for (var/type in (typesof(/datum/recipe/grill)-/datum/recipe/grill))
-			available_recipes+= new type
+			var/datum/recipe/recipe = new type
+			if(recipe.result) // Ignore recipe subtypes that lack a result
+				available_recipes += recipe
+			else
+				del(recipe)
 		acceptable_items = new
 		acceptable_reagents = new
 		for (var/datum/recipe/grill/recipe in available_recipes)

--- a/code/modules/food/oven_new.dm
+++ b/code/modules/food/oven_new.dm
@@ -34,7 +34,11 @@
 	if (!available_recipes)
 		available_recipes = new
 		for (var/type in (typesof(/datum/recipe/oven)-/datum/recipe/oven))
-			available_recipes+= new type
+			var/datum/recipe/recipe = new type
+			if(recipe.result) // Ignore recipe subtypes that lack a result
+				available_recipes += recipe
+			else
+				del(recipe)
 		acceptable_items = new
 		acceptable_reagents = new
 		for (var/datum/recipe/oven/recipe in available_recipes)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -667,13 +667,16 @@
 /mob/living/carbon/human/Topic(href, href_list)
 	var/pickpocket = 0
 
+	if(ishuman(usr))
+		var/mob/living/carbon/human/H = usr
+		var/obj/item/clothing/gloves/G = H.gloves
+		if(G)
+			pickpocket = G.pickpocket
+
 	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))
 
 		// if looting pockets with gloves, do it quietly
 		if(href_list["pockets"])
-			if(usr:gloves)
-				var/obj/item/clothing/gloves/G = usr:gloves
-				pickpocket = G.pickpocket
 			var/pocket_side = href_list["pockets"]
 			var/pocket_id = (pocket_side == "right" ? slot_r_store : slot_l_store)
 			var/obj/item/pocket_item = (pocket_id == slot_r_store ? src.r_store : src.l_store)
@@ -712,9 +715,6 @@
 		if(href_list["item"])
 			var/itemTarget = href_list["item"]
 			if(itemTarget == "id")
-				if(usr:gloves)
-					var/obj/item/clothing/gloves/G = usr:gloves
-					pickpocket = G.pickpocket
 				if(pickpocket)
 					var/obj/item/worn_id = src.wear_id
 					var/obj/item/place_item = usr.get_active_hand() // Item to place in the pocket, if it's empty
@@ -759,9 +759,6 @@
 
 	if ((href_list["item"] && !( usr.stat ) && usr.canmove && !( usr.restrained() ) && in_range(src, usr) && ticker)) //if game hasn't started, can't make an equip_e
 		var/obj/effect/equip_e/human/O = new /obj/effect/equip_e/human(  )
-		if(ishuman(usr) && usr:gloves)
-			var/obj/item/clothing/gloves/G = usr:gloves
-			pickpocket = G.pickpocket
 		if(!pickpocket || href_list["item"] != "id")  // Stop the non-stealthy verbose strip if pickpocketing id.
 			O.source = usr
 			O.target = src

--- a/code/modules/mob/living/silicon/ai/nano.dm
+++ b/code/modules/mob/living/silicon/ai/nano.dm
@@ -1,4 +1,5 @@
-var/obj/nano_module/crew_monitor/crew_monitor
+/mob/living/silicon/ai
+  var/obj/nano_module/crew_monitor/crew_monitor
 
 /mob/living/silicon/ai/proc/init_subsystems()
 	crew_monitor = new(src)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -457,8 +457,9 @@
 	if(istype(T)) T.visible_message("<b>[src]</b> neatly folds inwards, compacting down to a rectangular card.")
 
 	src.stop_pulling()
-	src.client.perspective = EYE_PERSPECTIVE
-	src.client.eye = card
+	if(src.client)
+		src.client.perspective = EYE_PERSPECTIVE
+		src.client.eye = card
 
 	//This seems redundant but not including the forced loc setting messes the behavior up.
 	src.loc = card

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -77,10 +77,11 @@ var/list/organ_cache = list()
 		owner = null
 
 	if(!owner)
-		var/datum/reagent/blood/B = locate(/datum/reagent/blood) in reagents.reagent_list
-		if(B && prob(40))
-			reagents.remove_reagent("blood",0.1)
-			blood_splatter(src,B,1)
+		if(reagents)
+			var/datum/reagent/blood/B = locate(/datum/reagent/blood) in reagents.reagent_list
+			if(B && prob(40))
+				reagents.remove_reagent("blood",0.1)
+				blood_splatter(src,B,1)
 		if(prob(5)) //How about we not have organs become completely useless less than a minute after removal?
 			damage += 1
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -488,7 +488,7 @@ datum
 					R.holder = src
 					R.volume = amount
 //					SetViruses(R, data) // Includes setting data
-					R.data = data
+					if(data) R.data = data
 					//debug
 					//world << "Adding data"
 					//for(var/D in R.data)


### PR DESCRIPTION
Various runtime fixes. Most of these aren't worth detailing - check the commits if you're curious!

It is worth noting, however, that many of these fixes will have gameplay consequences:
* AI upload computers will now emit light.
* AIs' internal crew monitor will no longer break the moment a bot transmits over the radio. (Fixes #924)
* Vending machines will no longer have tripled inventories when (re)built.
  * Their inventories *will* still respawn when rebuilt.
* Certain cooking machines will now be able to make all of their recipes, and will properly fail if you mess up a recipe.
* Cyborgs (and maybe certain other mobs; definitely not animals) will now be able to remove IDs and empty (individual?) pockets.
  * This is the intended behavior. Previously, runtimes would break these actions.
* Items preserved by the cryogenic oversight console should no longer break in odd ways.
  * Guns were the worst offenders here - their non-replaceable cells or magazines would get deleted, rendering them unusable.
* Eye stabbing will now have its proper chance to weaken the victim, continue to do damage, and show appropriate messages.
  * "Your eyes start to bleed profusely!"
* pAIs with a disconnected client can now be booped back into their card form.
* Certain organs will now take damage while outside the body, when they previously wouldn't.
  * I am not actually sure which organs were runtiming. This seemed to be uncommon, so it probably won't affect many.