### PR TITLE
FIX: Attack logs being backwards

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -25,7 +25,7 @@
 	return
 
 /datum/martial_art/proc/basic_hit(var/mob/living/carbon/human/A,var/mob/living/carbon/human/D)
-	add_logs(A, D, "punched")
+	add_logs(D, A, "punched")
 	A.do_attack_animation(D)
 	var/damage = rand(0,9)
 
@@ -85,7 +85,7 @@
 	return 1
 
 /datum/martial_art/boxing/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(A, D, "punched")
+	add_logs(D, A, "punched")
 	A.do_attack_animation(D)
 
 	var/atk_verb = pick("left hook","right hook","straight punch")
@@ -136,7 +136,7 @@
 	return 1
 
 /datum/martial_art/drunk_brawling/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(A, D, "punched")
+	add_logs(D, A, "punched")
 	A.do_attack_animation(D)
 
 	var/atk_verb = pick("jab","uppercut","overhand punch","drunken right hook","drunken left hook")
@@ -197,7 +197,7 @@
 
 
 /datum/martial_art/wrestling/proc/Suplex(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(A, D, "suplexed")
+	add_logs(D, A, "suplexed")
 	D.visible_message("<span class='danger'>[A] suplexes [D]!</span>", \
 								"<span class='userdanger'>[A] suplexes [D]!</span>")
 	D.forceMove(A.loc)

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -71,7 +71,7 @@
 								var/obj/item/brain/B = new /obj/item/brain(user.loc)
 								B.transfer_identity(C)
 								C.death()
-								add_logs(user, C, "magically debrained", addition="INTENT: [uppertext(user.a_intent)]")*/
+								add_logs(C, user, "magically debrained", addition="INTENT: [uppertext(user.a_intent)]")*/
 						if(C.stomach_contents && item_to_retrive in C.stomach_contents)
 							C.stomach_contents -= item_to_retrive
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -223,7 +223,7 @@
 											"<span class='userdanger'>[user] blinks \the [src] at \the [A].")
 		if(ismob(A))
 			var/mob/M = A
-			add_logs(user, M, "attacked", object="EMP-light")
+			add_logs(M, user, "attacked", object="EMP-light")
 		user << "\The [src] now has [emp_cur_charges] charge\s."
 		A.emp_act(1)
 	else

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -325,7 +325,7 @@
 			H.updatehealth() //forces health update before next life tick
 			playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 			H.emote("gasp")
-			add_logs(user, M, "stunned", object="defibrillator")
+			add_logs(M, user, "stunned", object="defibrillator")
 			defib.deductcharge(revivecost)
 			cooldown = 1
 			busy = 0
@@ -379,7 +379,7 @@
 							if(tplus > tloss)
 								H.setBrainLoss( max(0, min(99, ((tlimit - tplus) / tlimit * 100))))
 							defib.deductcharge(revivecost)
-							add_logs(user, M, "revived", object="defibrillator")
+							add_logs(M, user, "revived", object="defibrillator")
 						else
 							if(tplus > tlimit)
 								user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")
@@ -440,7 +440,7 @@
 			H.updatehealth() //forces health update before next life tick
 			playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 			H.emote("gasp")
-			add_logs(user, M, "stunned", object="defibrillator")
+			add_logs(M, user, "stunned", object="defibrillator")
 			if(isrobot(user))
 				var/mob/living/silicon/robot/R = user
 				R.cell.use(revivecost)
@@ -490,7 +490,7 @@
 							if(isrobot(user))
 								var/mob/living/silicon/robot/R = user
 								R.cell.use(revivecost)
-							add_logs(user, M, "revived", object="defibrillator")
+							add_logs(M, user, "revived", object="defibrillator")
 						else
 							if(tplus > tlimit)
 								user.visible_message("<span class='warning'>[user] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -76,7 +76,7 @@
 		loc = null
 
 		if (ismob(target))
-			add_logs(user, target, "planted [name] on")
+			add_logs(target, user, "planted [name] on")
 			user.visible_message("\red [user.name] finished planting an explosive on [target.name]!")
 			message_admins("[key_name(user, user.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) planted C4 on [key_name(target)](<A HREF='?_src_=holder;adminmoreinfo=\ref[target]'>?</A>) with [timer] second fuse",0,1)
 			log_game("[key_name(user)] planted C4 on [key_name(target)] with [timer] second fuse")

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -34,7 +34,7 @@
 			else
 				feedback_add_details("handcuffs","H")
 
-			add_logs(user, C, "handcuffed")
+			add_logs(C, user, "handcuffed", src)
 		else
 			user << "<span class='warning'>You fail to handcuff [C].</span>"
 

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -422,7 +422,7 @@
 			playsound(src,'sound/weapons/resonator_blast.ogg',50,1)
 			if(creator)
 				for(var/mob/living/L in src.loc)
-					add_logs(creator, L, "used a resonator field on", object="resonator")
+					add_logs(L, creator, "used a resonator field on", object="resonator")
 					L << "<span class='danger'>The [src.name] ruptured with you in it!</span>"
 					L.adjustBruteLoss(resonance_damage)
 			else

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -151,7 +151,7 @@
 				"<span class='userdanger'>[M] [M.attacktext] [src]!</span>")
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
 		adjustBruteLoss(damage)
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(src, M, "attacked", admin=0)
 		updatehealth()
 
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -362,7 +362,7 @@
 			user << "<span class='notice'>You already grabbed [src].</span>"
 			return
 
-	add_logs(user, src, "grabbed", addition="passively")
+	add_logs(src, user, "grabbed", addition="passively")
 
 	var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(user, src)
 	if(buckled)


### PR DESCRIPTION
This commit fixes attack logs being backwards on some erroneous add_logs
arguments.

Things fixed:
 - Martial arts
 - EMP Flashlight
 - Defibrillator
 - C4
 - Handcuffs
 - Resonant Fields
 - Alien Larva attack_animal
 - Mobs being grabbed

Fixes #1078, well enough