### PR TITLE
Secondary Languages - Species Languages

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -147,7 +147,6 @@
 	exclaim_verb = "roars"
 	colour = "soghun"
 	key = "o"
-	flags = RESTRICTED
 	syllables = list("ss","ss","ss","ss","skak","seeki","resh","las","esi","kor","sh")
 
 /datum/language/unathi/get_random_name()
@@ -165,7 +164,6 @@
 	exclaim_verb = "yowls"
 	colour = "tajaran"
 	key = "j"
-	flags = RESTRICTED
 	syllables = list("rr","rr","tajr","kir","raj","kii","mir","kra","ahk","nal","vah","khaz","jri","ran","darr", \
 	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r", \
 	"ka","aasi","far","wa","baq","ara","qara","zir","sam","mak","hrar","nja","rir","khan","jun","dar","rik","kah", \
@@ -188,7 +186,6 @@
 	exclaim_verb = "warbles"
 	colour = "skrell"
 	key = "k"
-	flags = RESTRICTED
 	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix","*","!")
 
 /datum/language/vox
@@ -199,7 +196,7 @@
 	exclaim_verb = "SHRIEKS"
 	colour = "vox"
 	key = "v"
-	flags = RESTRICTED | WHITELISTED
+	flags = WHITELISTED
 	syllables = list("ti","ti","ti","hi","hi","ki","ki","ki","ki","ya","ta","ha","ka","ya","chi","cha","kah", \
 	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
 


### PR DESCRIPTION
This commit removes the restricted flag from the following languages:
 - Skrellian
 - Vox-pidgin
 - Siik'tajr
 - Sinta'unathi

This means that players can select these languages in the secondary
language option of character setup.

This PR is being done at the request of a few people I have seen on the forums, I intend to stay out of the discussion for anything but technical explanations.

Sister forum thread: http://nanotrasen.se/phpBB3/viewtopic.php?f=48&t=4649

Relevant notifiers:
@Fj45
@SpaceManSpark
