### PR TITLE
Fixes Horrifying Loop in Simulated Turfs

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -105,7 +105,7 @@
 			bloodDNA = null
 
 		var/noslip = 0
-		for (var/obj/structure/stool/bed/chair/C in loc)
+		for (var/obj/structure/stool/bed/chair/C in contents)
 			if (C.buckled_mob == M)
 				noslip = 1
 		if (noslip)


### PR DESCRIPTION
Prior to the recent lighting changes, each simulated turf was in its own little subarea, and if you were to search the contents of that subarea, there wouldn't be much to search through.

Now, each turf is in a proper, full-sized area, each filled with many things to search through if you're trying to find something in particular.

This fixes simulated turfs looking through **the entire area they are in,** trying to find chairs, every time someone takes a step. The entire area. **Every step.** Chairs.