### PR TITLE
Spraybottle Changes

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -7,7 +7,6 @@
 	var/amount_per_transfer_from_this = 5
 	var/possible_transfer_amounts = list(5,10,15,25,30)
 	var/volume = 30
-	var/list/banned_reagents = list() //List of reagent IDs we reject.
 
 /obj/item/weapon/reagent_containers/verb/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set transfer amount"

--- a/code/modules/reagents/reagent_containers/drugs.dm
+++ b/code/modules/reagents/reagent_containers/drugs.dm
@@ -59,13 +59,6 @@
 				user << "\red [target] is full."
 				return
 
-			if(istype(target, /obj/item/weapon/reagent_containers))
-				var/obj/item/weapon/reagent_containers/RC = target
-				for(var/bad_reg in RC.banned_reagents)
-					if(reagents.has_reagent(bad_reg, 1)) //Message is a bit "Game-y" but I can't think up a better one.
-						user << "<span class='warning'>A chemical in [src] is far too dangerous to transfer to [RC]!</span>"
-						return
-
 			// /vg/: Logging transfers of bad things
 			if(target.reagents_to_log.len)
 				var/list/badshit=list()

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -121,13 +121,6 @@
 				user << "\red [target] is full."
 				return
 
-			if(istype(target, /obj/item/weapon/reagent_containers))
-				var/obj/item/weapon/reagent_containers/RC = target
-				for(var/bad_reg in RC.banned_reagents)
-					if(reagents.has_reagent(bad_reg, 1)) //Message is a bit "Game-y" but I can't think up a better one.
-						user << "<span class='warning'>A chemical in [src] is far too dangerous to transfer to [RC]!</span>"
-						return
-
 			// /vg/: Logging transfers of bad things
 			if(target.reagents_to_log.len)
 				var/list/badshit=list()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -15,7 +15,6 @@
 	amount_per_transfer_from_this = 5
 	volume = 250
 	possible_transfer_amounts = null
-	banned_reagents = list("facid","sacid")
 
 
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/A as mob|obj, mob/user as mob)
@@ -63,7 +62,7 @@
 /obj/item/weapon/reagent_containers/spray/proc/spray(var/atom/A)
 	var/obj/effect/decal/chempuff/D = new /obj/effect/decal/chempuff(get_turf(src))
 	D.create_reagents(amount_per_transfer_from_this)
-	reagents.trans_to(D, amount_per_transfer_from_this, 1/spray_currentrange)
+	reagents.trans_to(D, amount_per_transfer_from_this)
 	D.icon += mix_color_from_reagents(D.reagents.reagent_list)
 	spawn(0)
 		for(var/i=0, i<spray_currentrange, i++)
@@ -80,6 +79,11 @@
 	amount_per_transfer_from_this = (amount_per_transfer_from_this == 10 ? 5 : 10)
 	spray_currentrange = (spray_currentrange == 1 ? spray_maxrange : 1)
 	user << "<span class='notice'>You [amount_per_transfer_from_this == 10 ? "remove" : "fix"] the nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>"
+
+/obj/item/weapon/reagent_containers/spray/examine(mob/user)
+	if(..(user, 0) && user==src.loc)
+		user << "[round(src.reagents.total_volume)] units left."
+	return
 
 /obj/item/weapon/reagent_containers/spray/verb/empty()
 
@@ -161,7 +165,6 @@
 	amount_per_transfer_from_this = 10
 	volume = 600
 	origin_tech = "combat=3;materials=3;engineering=3"
-	banned_reagents = list()//the safeties are off, spray and pay!
 
 
 /obj/item/weapon/reagent_containers/spray/chemsprayer/spray(var/atom/A)


### PR DESCRIPTION
Alright, this is a partial revert of a former PR of mine.

- Reverts "Banned reagents".
 - this doesn't really effectively prevent using sulfuric and fluorosulfuric in bottles, and acid has been reworked anyway; this is more applicable to TG's horrible acid that melts literally everything.
- tweaks spray behavior to apply the correct amount of reagents (may need further tweaking)
- Re-adds examining spraybottles to see how much they have left.
 - Accidental removal.