### PR TITLE
LINDA Fixes

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -63,7 +63,7 @@
 	perform_exposure()
 
 /obj/effect/hotspot/proc/perform_exposure()
-	var/turf/simulated/floor/location = loc
+	var/turf/simulated/location = loc
 	if(!istype(location) || !(location.air))	return 0
 
 	if(volume > CELL_VOLUME*0.95)	bypassing = 1
@@ -82,7 +82,7 @@
 		location.assume_air(affected)
 
 	for(var/atom/item in loc)
-		if(item) // It's possible that the item is deleted in temperature_expose
+		if(item && item != src) // It's possible that the item is deleted in temperature_expose
 			item.fire_act(null, temperature, volume)
 
 	animate(src, color = heat2color(temperature), 5)
@@ -96,7 +96,7 @@
 		just_spawned = 0
 		return 0
 
-	var/turf/simulated/floor/location = loc
+	var/turf/simulated/location = loc
 	if(!istype(location))
 		Kill()
 		return
@@ -108,7 +108,7 @@
 		Kill()
 		return
 
-	if((!(location.air) || location.air.toxins < 0.5 || location.air.oxygen < 0.5))
+	if(!(location.air) || location.air.toxins < 0.5 || location.air.oxygen < 0.5)
 		Kill()
 		return
 

--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -234,7 +234,7 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
 	T.atmos_spawn_air(text, amount)
 
 var/const/SPAWN_HEAT = 1
-
+var/const/SPAWN_20C = 2
 var/const/SPAWN_TOXINS = 4
 var/const/SPAWN_OXYGEN = 8
 var/const/SPAWN_CO2 = 16
@@ -249,6 +249,9 @@ var/const/SPAWN_AIR = 256
 		return
 
 	var/datum/gas_mixture/G = new
+
+	if(flag & SPAWN_20C)
+		G.temperature = T20C
 
 	if(flag & SPAWN_HEAT)
 		G.temperature += 1000

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -138,6 +138,7 @@ turf/simulated/proc/share_temperature_mutual_solid(turf/simulated/sharer, conduc
 
 
 /turf/simulated/proc/process_cell()
+
 	if(archived_cycle < air_master.current_cycle) //archive self if not already done
 		archive()
 	current_cycle = air_master.current_cycle
@@ -319,7 +320,6 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 	var/datum/gas/sleeping_agent/S = new
 	A.trace_gases += S
 	for(var/turf/simulated/T in turf_list)
-		if(T == null || !istype(T))	return
 		A.oxygen 		+= T.air.oxygen
 		A.carbon_dioxide+= T.air.carbon_dioxide
 		A.nitrogen 		+= T.air.nitrogen
@@ -352,8 +352,9 @@ atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 	for(var/turf/simulated/T in turf_list)
 		T.excited = 0
 		T.recently_active = 0
+		T.excited_group = null
 		air_master.active_turfs -= T
-	air_master.excited_groups -= src
+	garbage_collect()
 
 /datum/excited_group/proc/garbage_collect()
 	for(var/turf/simulated/T in turf_list)

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -51,19 +51,27 @@
 	thermal_conductivity = 0.025
 	heat_capacity = 325000
 
+/turf/simulated/floor/engine/break_tile()
+	return //unbreakable
+
+/turf/simulated/floor/engine/burn_tile()
+	return //unburnable
+
+/turf/simulated/floor/engine/make_plating(var/force = 0)
+	if(force)
+		..()
+	return //unplateable
+
+
 /turf/simulated/floor/engine/attackby(obj/item/weapon/C as obj, mob/user as mob, params)
-	if(!C)
-		return
-	if(!user)
+	if(!C || !user)
 		return
 	if(istype(C, /obj/item/weapon/wrench))
-		user << "\blue Removing rods..."
+		user << "<span class='notice'>You begin removing rods...</span>"
 		playsound(src, 'sound/items/Ratchet.ogg', 80, 1)
 		if(do_after(user, 30))
 			new /obj/item/stack/rods(src, 2)
-			ChangeTurf(/turf/simulated/floor)
-			var/turf/simulated/floor/F = src
-			F.make_plating()
+			ChangeTurf(/turf/simulated/floor/plating)
 			return
 
 /turf/simulated/floor/engine/ex_act(severity,target)
@@ -84,23 +92,22 @@
 	icon_state = "cult"
 
 
-/turf/simulated/floor/engine/n20
-	New()
-		. = ..()
-		var/datum/gas_mixture/adding = new
-		var/datum/gas/sleeping_agent/trace_gas = new
+/turf/simulated/floor/engine/n20/New()
+	..()
+	var/datum/gas_mixture/adding = new
+	var/datum/gas/sleeping_agent/trace_gas = new
 
-		trace_gas.moles = 2000
-		adding.trace_gases += trace_gas
-		adding.temperature = T20C
+	trace_gas.moles = 6000
+	adding.trace_gases += trace_gas
+	adding.temperature = T20C
 
-		assume_air(adding)
+	assume_air(adding)
 
 /turf/simulated/floor/engine/vacuum
 	name = "vacuum floor"
 	icon_state = "engine"
 	oxygen = 0
-	nitrogen = 0.001
+	nitrogen = 0
 	temperature = TCMB
 
 /turf/simulated/floor/plating


### PR DESCRIPTION
Just some LINDA fixups.

When LINDA was ported, a few things were missed, in addition to a few fixes that came after TG's subsystem rewrite (but never the less had nothing to do with the subsystem rewrite).

This pretty much brings LINDA up to TG's standard prior to StonedOne's silly changes.

This should help behaviors of gases in some instances and also increase overall performance of LINDA.

Another thing it allows is for fires on the shuttle (YAY!)...because who doesn't want to set everyone on fire at round end?

@Tigercat2000 for review