### PR TITLE
Fixes - Splints, Nanopaste, Biogenerator, Signalers, etc.

### DIFF
--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -213,7 +213,7 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 
 /datum/emergency_shuttle_controller/proc/get_status_panel_eta()
 	if (online())
-		if (shuttle.has_arrive_time())
+		if (emergency_shuttle.has_eta())
 			var/timeleft = emergency_shuttle.estimate_arrival_time()
 			return "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1525,7 +1525,7 @@ var/list/ghostteleportlocs = list()
 	icon_state = "security"
 
 /area/security/warden
-	name = "\improper Warden"
+	name = "\improper Warden's Office"
 	icon_state = "Warden"
 
 /area/security/armoury

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -720,7 +720,7 @@
 			return
 
 
-	if(wiresexposed && !istype(user, /mob/living/silicon))
+	if(wiresexposed && !istype(user, /mob/living/silicon/ai))
 		wires.Interact(user)
 	if(!shorted)
 		ui_interact(user)

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -54,12 +54,15 @@
 	if(istype(O, /obj/item/weapon/reagent_containers/glass) && !panel_open)
 		if(beaker)
 			user << "<span class='warning'>A container is already loaded into the machine.</span>"
+			return
 		else
 			user.unEquip(O)
 			O.loc = src
 			beaker = O
 			user << "<span class='notice'>You add the container to the machine.</span>"
 			updateUsrDialog()
+			update_icon()
+			return
 
 	if(!processing)
 		if(default_deconstruction_screwdriver(user, "biogen-empty-o", "biogen-empty", O))
@@ -134,8 +137,7 @@
 				dat += "<div class='statusDisplay'>Error: No growns inside.<BR>Please put growns into reactor.</div>"
 				menustat = "menu"
 			if("nobeakerspace")
-			//	dat += "<div class='statusDisplay'>Not enough space left in container. Unable to create product.</div>"
-				user << "<span class='warning'>Not enough space left in container. Unable to create product. Please empty container.</span>"
+				dat += "<div class='statusDisplay'>Not enough space left in container. Unable to create product.</div>"
 				menustat = "menu"
 		if(beaker)
 			dat += "<div class='statusDisplay'>Biomass: [points] units.</div><BR>"
@@ -206,10 +208,12 @@
 		menustat = "void"
 	return
 
-/obj/machinery/biogenerator/proc/check_cost(var/cost)
+/obj/machinery/biogenerator/proc/check_cost(var/cost, var/checkonly)
 	if (cost > points)
 		menustat = "nopoints"
 		return 1
+	else if(checkonly)
+		return 0
 	else
 		points -= cost
 		processing = 1
@@ -236,26 +240,29 @@
 			if (check_cost(250/efficiency)) return 0
 			else new/obj/item/weapon/reagent_containers/food/snacks/monkeycube(src.loc)
 		if("ez")
-			if (check_cost(10/efficiency)) return 0
+			if (check_cost(10/efficiency, 1)) return 0
 			if(in_beaker)
 				if(check_container_volume(10)) return 0
 				else beaker.reagents.add_reagent("eznutrient",10)
 			else
 				new/obj/item/weapon/reagent_containers/glass/fertilizer/ez(src.loc)
+			if (check_cost(10/efficiency)) return 0
 		if("l4z")
-			if (check_cost(20/efficiency)) return 0
+			if (check_cost(20/efficiency, 1)) return 0
 			if(in_beaker)
 				if(check_container_volume(10)) return 0
 				else beaker.reagents.add_reagent("left4zed",10)
 			else
 				new/obj/item/weapon/reagent_containers/glass/fertilizer/l4z(src.loc)
+			if (check_cost(20/efficiency)) return 0
 		if("rh")
-			if (check_cost(25/efficiency)) return 0
+			if (check_cost(25/efficiency, 1)) return 0
 			if(in_beaker)
 				if(check_container_volume(10)) return 0
 				else beaker.reagents.add_reagent("robustharvest",10)
 			else
 				new/obj/item/weapon/reagent_containers/glass/fertilizer/rh(src.loc)
+			if (check_cost(25/efficiency)) return 0
 		if("wallet")
 			if (check_cost(100/efficiency)) return 0
 			else new/obj/item/weapon/storage/wallet(src.loc)
@@ -320,6 +327,7 @@
 		while(i >= 1)
 			create_product(C)
 			i--
+		processing = 0
 		updateUsrDialog()
 
 	else if(href_list["menu"])

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -16,10 +16,7 @@
 	aSignal = new(src)
 	aSignal.code = rand(1,100)
 
-	aSignal.frequency = rand(1200, 1599)
-	if(IsMultiple(aSignal.frequency, 2))//signaller frequencies are always uneven!
-		aSignal.frequency++
-
+	aSignal.frequency = sanitize_frequency(rand(1441, 1489))
 
 /obj/effect/anomaly/proc/anomalyEffect()
 	if(prob(50))

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -220,10 +220,10 @@ REAGENT SCANNER
 				continue
 			var/limb = e.name
 			if(e.status & ORGAN_BROKEN)
-				if(((e.name == "l_arm") || (e.name == "r_arm") || (e.name == "l_leg") || (e.name == "r_leg")) && (!(e.status & ORGAN_SPLINTED)))
-					user << "\red Unsecured fracture in subject [limb]. Splinting recommended for transport."
+				if((e.limb_name in list("l_arm", "r_arm", "l_hand", "r_hand", "l_leg", "r_leg", "l_foot", "r_foot")) && !(e.status & ORGAN_SPLINTED))
+					user.show_message("\red Unsecured fracture in subject [limb]. Splinting recommended for transport.")
 			if(e.has_infected_wound())
-				user << "\red Infected wound detected in subject [limb]. Disinfection recommended."
+				user.show_message("\red Infected wound detected in subject [limb]. Disinfection recommended.")
 
 		for(var/name in H.organs_by_name)
 			var/obj/item/organ/external/e = H.organs_by_name[name]

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -233,7 +233,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 		var/limb = affecting.name
-		if(!((affecting.name == "l_arm") || (affecting.name == "r_arm") || (affecting.name == "l_leg") || (affecting.name == "r_leg")))
+		if(!(affecting.limb_name in list("l_arm", "r_arm", "l_hand", "r_hand", "l_leg", "r_leg", "l_foot", "r_foot")))
 			user << "\red You can't apply a splint there!"
 			return
 		if(affecting.status & ORGAN_SPLINTED)
@@ -242,7 +242,7 @@
 		if (M != user)
 			user.visible_message("\red [user] starts to apply \the [src] to [M]'s [limb].", "\red You start to apply \the [src] to [M]'s [limb].", "\red You hear something being wrapped.")
 		else
-			if((!user.hand && affecting.name == "r_arm") || (user.hand && affecting.name == "l_arm"))
+			if((!user.hand && affecting.limb_name in list("r_arm", "r_hand")) || (user.hand && affecting.limb_name in list("l_arm", "l_hand")))
 				user << "\red You can't apply a splint to the arm you're using!"
 				return
 			user.visible_message("\red [user] starts to apply \the [src] to their [limb].", "\red You start to apply \the [src] to your [limb].", "\red You hear something being wrapped.")

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -27,19 +27,18 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
 
-		if(S.open == 1)
-			if (S && (S.status & ORGAN_ROBOT))
-				if(S.get_damage())
-					S.heal_damage(15, 15, robo_repair = 1)
-					H.updatehealth()
-					use(1)
-					user.visible_message("<span class='notice'>\The [user] applies some nanite paste at[user != M ? " \the [M]'s" : " \the"][S.name] with \the [src].</span>",\
-					"<span class='notice'>You apply some nanite paste at [user == M ? "your" : "[M]'s"] [S.name].</span>")
-				else
-					user << "<span class='notice'>Nothing to fix here.</span>"
-		else
-			if (can_operate(H))
-				if (do_surgery(H,user,src))
-					return
+		if(can_operate(H))
+			if (do_surgery(H,user,src))
+				return
+
+		if (S && (S.status & ORGAN_ROBOT))
+			if(S.get_damage())
+				S.heal_damage(15, 15, robo_repair = 1)
+				H.updatehealth()
+				use(1)
+				user.visible_message("<span class='notice'>\The [user] applies some nanite paste at[user != M ? " \the [M]'s" : " \the"][S.name] with \the [src].</span>",\
+				"<span class='notice'>You apply some nanite paste at [user == M ? "your" : "[M]'s"] [S.name].</span>")
 			else
-				user << "<span class='notice'>Nothing to fix in here.</span>"
+				user << "<span class='notice'>Nothing to fix here.</span>"
+		else
+			user << "<span class='notice'>[src] won't work on that.</span>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -362,7 +362,7 @@ var/global/nologevent = 0
 		if(3)
 			dat+={"
 				Creating new Feed Message...
-				<HR><B><A href='?src=\ref[src];ac_set_channel_receiving=1'>Receiving Channel</A>:</B> [src.admincaster_feed_channel.channel_name]<BR>" //MARK
+				<HR><B><A href='?src=\ref[src];ac_set_channel_receiving=1'>Receiving Channel</A>:</B> [src.admincaster_feed_channel.channel_name]<BR>
 				<B>Message Author:</B> <FONT COLOR='green'>[src.admincaster_signature]</FONT><BR>
 				<B><A href='?src=\ref[src];ac_set_new_message=1'>Message Body</A>:</B> [src.admincaster_feed_message.body] <BR>
 				<BR><A href='?src=\ref[src];ac_submit_new_message=1'>Submit</A><BR><BR><A href='?src=\ref[src];ac_setScreen=[0]'>Cancel</A><BR>
@@ -908,7 +908,11 @@ var/global/nologevent = 0
 			var/mob/living/silicon/robot/R = S
 			usr << "<b>CYBORG [key_name(S, usr)] [R.connected_ai?"(Slaved to: [R.connected_ai])":"(Independent)"]: laws:</b>"
 		else if (ispAI(S))
+			var/mob/living/silicon/pai/P = S
 			usr << "<b>pAI [key_name(S, usr)]'s laws:</b>"
+			usr << "[P.pai_law0]"
+			if(P.pai_laws) usr << "[P.pai_laws]"
+			continue // Skip showing normal silicon laws for pAIs - they don't have any
 		else
 			usr << "<b>SOMETHING SILICON [key_name(S, usr)]'s laws:</b>"
 

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -389,7 +389,7 @@
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
-		dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero(world.time / 600 % 60, 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B><BR>"
+		dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero(num2text(world.time / 600 % 60), 2)]:[add_zero(num2text(world.time / 10 % 60), 2)]</B><BR>"
 		dat += "<B>Emergency shuttle</B><BR>"
 		if (!emergency_shuttle.online())
 			dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -21,8 +21,12 @@
 
 	New()
 		..()
-		spawn(40)
-			set_frequency(frequency)
+		if(!radio_controller)
+			spawn(40)
+				set_frequency(frequency)
+		else
+			spawn(1) // For things that set the frequency directly
+				set_frequency(frequency)
 		return
 	describe()
 		return "\The [src]'s power light is [receiving?"on":"off"]"
@@ -83,7 +87,7 @@
 
 		if (href_list["freq"])
 			var/new_frequency = (frequency + text2num(href_list["freq"]))
-			if(new_frequency < 1200 || new_frequency > 1600)
+			if(new_frequency < 1441 || new_frequency > 1489)
 				new_frequency = sanitize_frequency(new_frequency)
 			set_frequency(new_frequency)
 
@@ -144,13 +148,14 @@
 
 
 	proc/set_frequency(new_frequency)
-		spawn(20)
-			if(!radio_controller)
-				return
-			radio_controller.remove_object(src, frequency)
-			frequency = new_frequency
-			radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
+		if(!radio_controller)
+			sleep(20)
+		if(!radio_controller)
 			return
+		radio_controller.remove_object(src, frequency)
+		frequency = new_frequency
+		radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
+		return
 
 // Embedded signaller used in anomalies.
 /obj/item/device/assembly/signaler/anomaly

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -194,9 +194,9 @@ Would like to add a law like "Law x is _______" where x = a number, and _____ is
 					M.add_ion_law("YOU REQUIRE [require] IN ORDER TO PROTECT HUMANS")
 				if(13)
 					M << "<br>"
-					M << "\red [crew] is [allergysev] to [allergy]...LAWS UPDATED"
+					M << "\red [crew] is [allergysev] allergic to [allergy]...LAWS UPDATED"
 					M << "<br>"
-					M.add_ion_law("[crew] is [allergysev] to [allergy]")
+					M.add_ion_law("[crew] is [allergysev] allergic to [allergy]")
 				if(14)
 					M << "<br>"
 					M << "\red THE STATION IS [who2pref] [who2]...LAWS UPDATED"

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -109,7 +109,7 @@
 			continue
 
 		if(E.is_broken())
-			if(E.body_part == HAND_LEFT)
+			if((E.body_part == HAND_LEFT) || (E.body_part == ARM_LEFT))
 				if(!l_hand)
 					continue
 				unEquip(l_hand)
@@ -123,7 +123,7 @@
 
 		else if(E.is_malfunctioning())
 
-			if(E.body_part == HAND_LEFT)
+			if((E.body_part == HAND_LEFT) || (E.body_part == ARM_LEFT))
 				unEquip(l_hand)
 			else
 				unEquip(r_hand)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -337,12 +337,14 @@
 		var/mob/living/carbon/C = src
 		C.handcuffed = initial(C.handcuffed)
 		C.heart_attack = 0
+		C.brain_op_stage = 0
 
 		// restore all of the human's blood and reset their shock stage
 		if(ishuman(src))
 			var/mob/living/carbon/human/human_mob = src
 			human_mob.restore_blood()
 			human_mob.shock_stage = 0
+			human_mob.decaylevel = 0
 
 	restore_all_organs()
 	if(stat == 2)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -38,7 +38,7 @@
 		/obj/machinery/computer/centrifuge,
 		/obj/machinery/sleeper,
 		/obj/machinery/smartfridge/,
-//		/obj/machinery/biogenerator,
+		/obj/machinery/biogenerator,
 		/obj/machinery/portable_atmospherics/hydroponics,
 		/obj/machinery/constructable_frame)
 

--- a/code/modules/reagents/reagent_containers/robodropper.dm
+++ b/code/modules/reagents/reagent_containers/robodropper.dm
@@ -3,7 +3,7 @@
 	name = "Industrial Dropper"
 	desc = "A larger dropper. Transfers 10 units."
 	icon = 'icons/obj/chemical.dmi'
-	icon_state = "dropper0"
+	icon_state = "dropper"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(1,2,3,4,5,6,7,8,9,10)
 	volume = 10
@@ -65,7 +65,7 @@
 						user << "\blue You transfer [trans] units of the solution."
 						if (src.reagents.total_volume<=0)
 							filled = 0
-							icon_state = "dropper[filled]"
+							icon_state = "[initial(icon_state)]"
 						return
 
 
@@ -91,7 +91,7 @@
 			user << "\blue You transfer [trans] units of the solution."
 			if (src.reagents.total_volume<=0)
 				filled = 0
-				icon_state = "dropper[filled]"
+				icon_state = "[initial(icon_state)]"
 
 		else
 
@@ -108,6 +108,6 @@
 			user << "\blue You fill the dropper with [trans] units of the solution."
 
 			filled = 1
-			icon_state = "dropper[filled]"
+			icon_state = "[initial(icon_state)][filled]"
 
 		return

--- a/code/modules/research/xenoarchaeology/tools/tools_anoscanner.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_anoscanner.dm
@@ -20,8 +20,7 @@
 /obj/item/device/ano_scanner/interact(var/mob/user as mob)
 	var/message = "Background radiation levels detected."
 	if(world.time - last_scan_time >= scan_delay)
-		spawn(0)
-			scan()
+		scan()
 		if(nearest_artifact_distance >= 0)
 			message = "Exotic energy detected on wavelength '[nearest_artifact_id]' in a radius of [nearest_artifact_distance]m"
 	else

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -48,7 +48,7 @@
 
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return affected && affected.name != "head" && affected.open == 2 && affected.stage == 1
+		return affected && affected.limb_name != "head" && affected.open == 2 && affected.stage == 1
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -85,7 +85,7 @@
 
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return affected && affected.name == "head" && affected.open == 2 && affected.stage == 1
+		return affected && affected.limb_name == "head" && affected.open == 2 && affected.stage == 1
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		user.visible_message("[user] is beginning piece together [target]'s skull with \the [tool]."  , \

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -13,7 +13,7 @@
 		return affected && affected.open == (affected.encased ? 3 : 2) && !(affected.status & ORGAN_BLEEDING)
 
 	proc/get_max_wclass(obj/item/organ/external/affected)
-		switch (affected.name)
+		switch (affected.limb_name)
 			if ("head")
 				return 1
 			if ("chest")
@@ -23,7 +23,7 @@
 		return 0
 
 	proc/get_cavity(obj/item/organ/external/affected)
-		switch (affected.name)
+		switch (affected.limb_name)
 			if ("head")
 				return "cranial"
 			if ("chest")
@@ -111,7 +111,7 @@
 		if (!ishuman(target))
 			return 0
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		var/can_fit = !affected.hidden && affected.cavity && tool.w_class <= get_max_wclass(affected)
+		var/can_fit = affected && !affected.hidden && affected.cavity && tool.w_class <= get_max_wclass(affected)
 		return ..() && can_fit
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -18,6 +18,7 @@
 
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(!affected) return 0
 
 		var/internal_bleeding = 0
 		for(var/datum/wound/W in affected.wounds) if(W.internal)
@@ -72,7 +73,7 @@
 
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-		return affected.open == 2 && (affected.status & ORGAN_DEAD)
+		return affected && affected.open == 2 && (affected.status & ORGAN_DEAD)
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
Various fixes:

* Fixes Rejuvenate not resetting brain op stages (resulting in instant death when rejuvenating beheaded people) or decay level. (Fixes #992)
* Fixes splinting. Splints will now work again, can now be applied to arms, hands, legs, and feet, and health analyzers will warn about unsplinted limbs.
* Fixes dropping the contents of your right hand if your left arm is broken.
  * Note that a broken, unsplinted arm **or** hand will cause you to drop anything in the hand on that side. In some cases, you'll need to splint both!
* Fixes several runtimes and bad limb checks in the surgery system.
  * In particular, cavity surgery was probably acting strange, and bone surgery may have been acting strange under certain circumstances.
* Fixes nanopaste - it can now be used to repair mechanical limbs (including IPCs self-repairing their own limbs) and organs. (Fixes #1090)
  * Repairing mechanical eyes is kinda weird - you have to prep for brain surgery, and use the nanopaste where you'd use the Fix-o-Vein.
* Fixes the Status tab's shuttle ETA not showing up until the shuttle has "left".
* Fixes several biogenerator issues:
  * Fixes the biogenerator getting stuck if it can't fill a beaker. (Fixes #1076)
    * Reverted #1081, as the warning message displays properly now.
  * Fixes the biogenerator consuming biomass even if it can't fill the beaker.
  * Fixes splashing a beaker onto the biogenerator whenever you try to load it.
    * What genius commented out the one line that prevents this?!
* Fixes cyborgs and drones not being able to interact with air alarm wiring.
  * They were unable to interact with APC wiring at one time, but that limitation was removed mid 2012.
* Fixes Signalers being highly unresponsive while trying to adjust their frequency.
* Fixes the frequency ranges of Signalers and anomalies being much larger than intended.
  * Handheld signalers and PDA-based signalers will now be able to signal on the same frequencies.
* Fixes the service borg's Industrial Dropper so it again has a proper icon and is usable.
* Fixes the Alden-Saraspova Counter giving delayed readings.
  * Each time you got a reading, it would be from the previous scan, even if you moved, requiring you to scan twice each time.
* pAI laws will now show up properly in Check AI Laws.
* Fixed a weird comment that got dumped into the HTML of the Admin Newscaster System.
* Fixes a minor typo (missing "allergic") in ion law generator
* Fixes errors in the Round Status (Check Antagonists) panel's round duration listing.
* Fixes name of Warden's Office area (was previously just "Warden")