### PR TITLE
Stat Panel Fixes

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -26,6 +26,9 @@
 	if(modifiers["shift"])
 		ShiftClickOn(A)
 		return
+	if(modifiers["alt"])
+		AltClickOn(A)
+		return
 	// You are responsible for checking config.ghost_interaction when you override this function
 	// Not all of them require checking, see below
 	A.attack_ghost(src)

--- a/code/controllers/emergency_shuttle_controller.dm
+++ b/code/controllers/emergency_shuttle_controller.dm
@@ -213,10 +213,9 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 
 /datum/emergency_shuttle_controller/proc/get_status_panel_eta()
 	if (online())
-		if (emergency_shuttle.has_eta())
-			var/timeleft = emergency_shuttle.estimate_arrival_time()
-			return "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
-
+		if (is_stranded())
+			return "ETA-ERR"
+		
 		if (waiting_to_leave())
 			if (shuttle.moving_status == SHUTTLE_WARMUP)
 				return "Departing..."
@@ -224,8 +223,9 @@ var/global/datum/emergency_shuttle_controller/emergency_shuttle
 			var/timeleft = emergency_shuttle.estimate_launch_time()
 			return "ETD-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 
-		if (is_stranded())
-			return "ETA-ERR"
+		if (emergency_shuttle.has_eta())
+			var/timeleft = emergency_shuttle.estimate_arrival_time()
+			return "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 
 	return ""
 /*

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -271,7 +271,7 @@ mob/living
 
 var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump, /obj/machinery/atmospherics/unary/vent_scrubber)
 
-/mob/living/proc/handle_ventcrawl(var/atom/clicked_on) // -- TLE -- Merged by Carn
+/mob/living/handle_ventcrawl(var/atom/clicked_on) // -- TLE -- Merged by Carn
 	if(!Adjacent(clicked_on))
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -895,9 +895,34 @@ var/list/slot_equipment_priority = list( \
 /mob/Stat()
 	..()
 
+	if(listed_turf && client)
+		if(!TurfAdjacent(listed_turf))
+			listed_turf = null
+		else
+			statpanel(listed_turf.name, null, listed_turf)
+			for(var/atom/A in listed_turf)
+				if(A.invisibility > see_invisible)
+					continue
+				if(is_type_in_list(A, shouldnt_see))
+					continue
+				statpanel(listed_turf.name, null, A)
+
+	statpanel("Status") // We only want alt-clicked turfs to come before Status
+
+	if(mind && mind.changeling)
+		add_stings_to_statpanel(mind.changeling.purchasedpowers)
+
+	if(spell_list && spell_list.len)
+		for(var/obj/effect/proc_holder/spell/wizard/S in spell_list)
+			add_spell_to_statpanel(S)
+	if(mind && istype(src, /mob/living) && mind.spell_list && mind.spell_list.len)
+		for(var/obj/effect/proc_holder/spell/wizard/S in mind.spell_list)
+			add_spell_to_statpanel(S)
+			
+
 	if(client && client.holder)
 
-		if(statpanel("Status"))	//not looking at that panel
+		if(statpanel("DI"))	//not looking at that panel
 			stat(null, "Location:\t([x], [y], [z])")
 			stat(null, "CPU:\t[world.cpu]")
 			stat(null, "Instances:\t[world.contents.len]")
@@ -973,36 +998,19 @@ var/list/slot_equipment_priority = list( \
 			else
 				stat(null, "processScheduler is not running.")
 
-	if(listed_turf && client)
-		if(!TurfAdjacent(listed_turf))
-			listed_turf = null
-		else
-			statpanel(listed_turf.name, null, listed_turf)
-			for(var/atom/A in listed_turf)
-				if(A.invisibility > see_invisible)
-					continue
-				if(is_type_in_list(A, shouldnt_see))
-					continue
-				statpanel(listed_turf.name, null, A)
-
-	if(mind && mind.changeling)
-		add_stings_to_statpanel(mind.changeling.purchasedpowers)
-
-	if(spell_list && spell_list.len)
-		for(var/obj/effect/proc_holder/spell/wizard/S in spell_list)
-			switch(S.charge_type)
-				if("recharge")
-					statpanel(S.panel,"[S.charge_counter/10.0]/[S.charge_max/10]",S)
-				if("charges")
-					statpanel(S.panel,"[S.charge_counter]/[S.charge_max]",S)
-				if("holdervar")
-					statpanel(S.panel,"[S.holder_var_type] [S.holder_var_amount]",S)
-
 
 /mob/proc/add_stings_to_statpanel(var/list/stings)
 	for(var/obj/effect/proc_holder/changeling/S in stings)
 		if(S.chemical_cost >=0 && S.can_be_used_by(src))
 			statpanel("[S.panel]",((S.chemical_cost > 0) ? "[S.chemical_cost]" : ""),S)
+/mob/proc/add_spell_to_statpanel(var/obj/effect/proc_holder/spell/wizard/S)
+	switch(S.charge_type)
+		if("recharge")
+			statpanel(S.panel,"[S.charge_counter/10.0]/[S.charge_max/10]",S)
+		if("charges")
+			statpanel(S.panel,"[S.charge_counter]/[S.charge_max]",S)
+		if("holdervar")
+			statpanel(S.panel,"[S.holder_var_type] [S.holder_var_amount]",S)
 	/* // Why have a duplicate set of turfs in the stat panel?
 	if(listed_turf)
 		if(get_dist(listed_turf,src) > 1)
@@ -1473,3 +1481,6 @@ mob/proc/yank_out_object()
 	if(isliving(src))
 		spell.action.Grant(src)
 	return
+
+/mob/proc/handle_ventcrawl()
+	return // Only living mobs can ventcrawl

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -64,7 +64,7 @@
 		return
 
 	Stat()
-		if(ticker.current_state == GAME_STATE_PREGAME)
+		if((!ticker) || ticker.current_state == GAME_STATE_PREGAME)
 			statpanel("Lobby") // First tab during pre-game.
 		..()
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -64,6 +64,8 @@
 		return
 
 	Stat()
+		if(ticker.current_state == GAME_STATE_PREGAME)
+			statpanel("Lobby") // First tab during pre-game.
 		..()
 
 		statpanel("Status")


### PR DESCRIPTION
Several fixes to the stat panel:

* Fixes the shuttle ETD not displaying properly.
  * Oops.
* Fixes spells stored in one's mind (wizard spells) not showing up in a tab.
* Fixes ghosts not being able to alt-click tiles to get a tab with their contents.
  * You still have to be adjacent to the tile, though.
* Fixes the Lobby tab not being the first tab during pre-game.
* Fixes admin debugging info not being in its own tab.
* Fixes the ordering of stat panels being inconsistent in some cases.
  * They still aren't ordered well in all cases, but I'm too lazy to fix all of it right now.