### PR TITLE
Fixes Exchange Runtime and Ling Blood Regen

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -648,7 +648,7 @@ datum/objective/steal/exchange
 		else if(faction == "blue")
 			targetinfo = new /datum/theft_objective/unique/docs_red
 		explanation_text = "Acquire [targetinfo.name] held by [target.current.real_name], the [target.assigned_role] and syndicate agent"
-		steal_target = targetinfo.typepath
+		steal_target = targetinfo
 
 datum/objective/steal/exchange/backstab
 
@@ -659,7 +659,7 @@ datum/objective/steal/exchange/backstab
 		else if(faction == "blue")
 			targetinfo = new /datum/theft_objective/unique/docs_blue
 		explanation_text = "Do not give up or lose [targetinfo.name]."
-		steal_target = targetinfo.typepath
+		steal_target = targetinfo
 
 datum/objective/download
 	proc/gen_amount_goal()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -245,7 +245,7 @@
 This function restores the subjects blood to max.
 */
 /mob/living/carbon/human/proc/restore_blood()
-	if(!species.flags & NO_BLOOD)
+	if(!(species.flags & NO_BLOOD))
 		var/blood_volume = vessel.get_reagent_amount("blood")
 		vessel.add_reagent("blood",560.0-blood_volume)
 


### PR DESCRIPTION
A couple minor fixes:

* Probably fixes a runtime in exchange (documents) objectives, which was preventing them - and possibly other objectives - from checking for completion.
  * I didn't actually get a chance to test this, because these particular objectives are too complicated to easily forcibly add. Probably fixes the runtime, though.
    * No idea if these objectives have other problems, of course!
* Fixes `restore_blood`, which a couple changeling abilities (notably, regenerative stasis) use to, well, restore blood. It had *one job,* and it was failing at it!