### PR TITLE
[Feature][Refactor][Review Requested] Nutrient Changes and Dietary Concerns

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -60,6 +60,11 @@
 #define HAS_SKIN_COLOR	32
 #define TAIL_WAGGING    64
 
+//Species Diet Flags
+#define DIET_CARN		1
+#define DIET_OMNI		2
+#define DIET_HERB		4
+
 
 //bitflags for door switches.
 #define OPEN	1

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -3,7 +3,7 @@
 	name = "chili"
 	seed_name = "chili"
 	display_name = "chili plants"
-	chems = list("capsaicin" = list(3,5), "nutriment" = list(1,25))
+	chems = list("capsaicin" = list(3,5), "plantmatter" = list(1,25))
 	mutants = list("icechili")
 	kitchen_tag = "chili"
 
@@ -23,7 +23,7 @@
 	seed_name = "ice pepper"
 	display_name = "ice-pepper plants"
 	mutants = null
-	chems = list("frostoil" = list(3,5), "nutriment" = list(1,50))
+	chems = list("frostoil" = list(3,5), "plantmatter" = list(1,50))
 	kitchen_tag = "icechili"
 
 /datum/seed/chili/ice/New()
@@ -38,7 +38,7 @@
 	seed_name = "berry"
 	display_name = "berry bush"
 	mutants = list("glowberries","poisonberries")
-	chems = list("nutriment" = list(1,10))
+	chems = list("plantmatter" = list(1,10))
 	kitchen_tag = "berries"
 
 /datum/seed/berry/New()
@@ -58,7 +58,7 @@
 	seed_name = "glowberry"
 	display_name = "glowberry bush"
 	mutants = null
-	chems = list("nutriment" = list(1,10), "uranium" = list(3,5))
+	chems = list("plantmatter" = list(1,10), "uranium" = list(3,5))
 
 /datum/seed/berry/glow/New()
 	..()
@@ -76,7 +76,7 @@
 	seed_name = "poison berry"
 	display_name = "poison berry bush"
 	mutants = list("deathberries")
-	chems = list("nutriment" = list(1), "toxin" = list(3,5))
+	chems = list("plantmatter" = list(1), "toxin" = list(3,5))
 	kitchen_tag = "poisonberries"
 
 /datum/seed/berry/poison/New()
@@ -88,7 +88,7 @@
 	seed_name = "death berry"
 	display_name = "death berry bush"
 	mutants = null
-	chems = list("nutriment" = list(1), "toxin" = list(3,3), "lexorin" = list(1,5))
+	chems = list("plantmatter" = list(1), "toxin" = list(3,3), "lexorin" = list(1,5))
 
 /datum/seed/berry/poison/death/New()
 	..()
@@ -102,7 +102,7 @@
 	seed_name = "nettle"
 	display_name = "nettles"
 	mutants = list("deathnettle")
-	chems = list("nutriment" = list(1,50), "sacid" = list(0,1))
+	chems = list("plantmatter" = list(1,50), "sacid" = list(0,1))
 	kitchen_tag = "nettle"
 
 /datum/seed/nettle/New()
@@ -122,7 +122,7 @@
 	seed_name = "death nettle"
 	display_name = "death nettles"
 	mutants = null
-	chems = list("nutriment" = list(1,50), "facid" = list(0,1))
+	chems = list("plantmatter" = list(1,50), "facid" = list(0,1))
 	kitchen_tag = "deathnettle"
 
 /datum/seed/nettle/death/New()
@@ -138,7 +138,7 @@
 	seed_name = "tomato"
 	display_name = "tomato plant"
 	mutants = list("bluetomato","bloodtomato")
-	chems = list("nutriment" = list(1,10))
+	chems = list("plantmatter" = list(1,10))
 	kitchen_tag = "tomato"
 
 /datum/seed/tomato/New()
@@ -157,8 +157,8 @@
 	name = "bloodtomato"
 	seed_name = "blood tomato"
 	display_name = "blood tomato plant"
-	mutants = list("killer")
-	chems = list("nutriment" = list(1,10), "blood" = list(1,5))
+	mutants = list("killertomato")
+	chems = list("protein" = list(1,10), "blood" = list(1,5))
 	splat_type = /obj/effect/decal/cleanable/blood/splatter
 	kitchen_tag = "bloodtomato"
 
@@ -185,7 +185,7 @@
 	seed_name = "blue tomato"
 	display_name = "blue tomato plant"
 	mutants = list("bluespacetomato")
-	chems = list("nutriment" = list(1,20), "lube" = list(1,5))
+	chems = list("plantmatter" = list(1,20), "lube" = list(1,5))
 
 /datum/seed/tomato/blue/New()
 	..()
@@ -197,7 +197,7 @@
 	seed_name = "bluespace tomato"
 	display_name = "bluespace tomato plant"
 	mutants = null
-	chems = list("nutriment" = list(1,20), "singulo" = list(10,5))
+	chems = list("plantmatter" = list(1,20), "singulo" = list(10,5))
 
 /datum/seed/tomato/blue/teleport/New()
 	..()
@@ -212,7 +212,7 @@
 	seed_name = "eggplant"
 	display_name = "eggplants"
 	mutants = list("realeggplant")
-	chems = list("nutriment" = list(1,10))
+	chems = list("plantmatter" = list(1,10))
 	kitchen_tag = "eggplant"
 
 /datum/seed/eggplant/New()
@@ -232,7 +232,7 @@
 	seed_name = "apple"
 	display_name = "apple tree"
 	mutants = list("poisonapple","goldapple")
-	chems = list("nutriment" = list(1,10))
+	chems = list("plantmatter" = list(1,10))
 	kitchen_tag = "apple"
 
 /datum/seed/apple/New()
@@ -256,7 +256,7 @@
 	seed_name = "golden apple"
 	display_name = "gold apple tree"
 	mutants = null
-	chems = list("nutriment" = list(1,10), "gold" = list(1,5))
+	chems = list("plantmatter" = list(1,10), "gold" = list(1,5))
 	kitchen_tag = "goldapple"
 
 /datum/seed/apple/gold/New()
@@ -273,7 +273,7 @@
 	seed_name = "ambrosia vulgaris"
 	display_name = "ambrosia vulgaris"
 	mutants = list("ambrosiadeus")
-	chems = list("nutriment" = list(1), "thc" = list(1,8), "silver_sulfadiazine" = list(1,8,1), "styptic_powder" = list(1,10,1), "toxin" = list(1,10))
+	chems = list("plantmatter" = list(1), "thc" = list(1,8), "silver_sulfadiazine" = list(1,8,1), "styptic_powder" = list(1,10,1), "toxin" = list(1,10))
 	kitchen_tag = "ambrosia"
 
 /datum/seed/ambrosia/New()
@@ -292,7 +292,7 @@
 	seed_name = "ambrosia deus"
 	display_name = "ambrosia deus"
 	mutants = null
-	chems = list("nutriment" = list(1), "styptic_powder" = list(1,8), "synaptizine" = list(1,8,1), "methamphetamine" = list(1,10,1), "thc" = list(1,10))
+	chems = list("plantmatter" = list(1), "styptic_powder" = list(1,8), "synaptizine" = list(1,8,1), "methamphetamine" = list(1,10,1), "thc" = list(1,10))
 	kitchen_tag = "ambrosiadeus"
 
 //Tobacco/varieties
@@ -301,7 +301,7 @@
 	seed_name = "tobacco"
 	display_name = "tobacco"
 	mutants = list("stobacco")
-	chems = list("nutriment" = list(1,40), "nicotine" = list(1,40))
+	chems = list("plantmatter" = list(1,40), "nicotine" = list(1,40))
 	kitchen_tag = "tobacco"
 
 /datum/seed/tobacco/New()
@@ -320,7 +320,7 @@
 	seed_name = "space tobacco"
 	display_name = "space tobacco"
 	mutants = null
-	chems = list("nutriment" = list(1,40), "nicotine" = list(1,20), "epinephrine" = list(1,30))
+	chems = list("plantmatter" = list(1,40), "nicotine" = list(1,20), "epinephrine" = list(1,30))
 	kitchen_tag = "stobacco"
 
 /datum/seed/tobacco/space/New()
@@ -412,7 +412,7 @@
 	seed_noun = "spores"
 	display_name = "chanterelle mushrooms"
 	mutants = list("reishi","amanita","plumphelmet")
-	chems = list("nutriment" = list(1,25), "fungus" = list(1,10))
+	chems = list("plantmatter" = list(1,25), "fungus" = list(1,10))
 	splat_type = /obj/effect/plant
 	kitchen_tag = "mushroom"
 
@@ -448,7 +448,7 @@
 	seed_name = "plump helmet"
 	display_name = "plump helmet mushrooms"
 	mutants = list("walkingmushroom","towercap")
-	chems = list("nutriment" = list(2,10))
+	chems = list("plantmatter" = list(2,10))
 	kitchen_tag = "plumphelmet"
 
 /datum/seed/mushroom/plump/New()
@@ -481,7 +481,7 @@
 	seed_name = "reishi"
 	display_name = "reishi"
 	mutants = list("libertycap","glowshroom")
-	chems = list("nutriment" = list(1,50), "psilocybin" = list(3,5))
+	chems = list("plantmatter" = list(1,50), "psilocybin" = list(3,5))
 
 /datum/seed/mushroom/hallucinogenic/New()
 	..()
@@ -499,7 +499,7 @@
 	seed_name = "liberty cap"
 	display_name = "liberty cap mushrooms"
 	mutants = null
-	chems = list("nutriment" = list(1), "morphine" = list(3,3), "space_drugs" = list(1,25))
+	chems = list("plantmatter" = list(1), "morphine" = list(3,3), "space_drugs" = list(1,25))
 	kitchen_tag = "libertycap"
 
 /datum/seed/mushroom/hallucinogenic/strong/New()
@@ -516,7 +516,7 @@
 	seed_name = "fly amanita"
 	display_name = "fly amanita mushrooms"
 	mutants = list("destroyingangel","plastic")
-	chems = list("nutriment" = list(1), "amanitin" = list(3,3), "psilocybin" = list(1,25))
+	chems = list("plantmatter" = list(1), "amanitin" = list(3,3), "psilocybin" = list(1,25))
 	kitchen_tag = "amanita"
 
 /datum/seed/mushroom/poison/New()
@@ -535,7 +535,7 @@
 	seed_name = "destroying angel"
 	display_name = "destroying angel mushrooms"
 	mutants = null
-	chems = list("nutriment" = list(1,50), "amanitin" = list(13,3), "psilocybin" = list(1,25))
+	chems = list("plantmatter" = list(1,50), "amanitin" = list(13,3), "psilocybin" = list(1,25))
 
 /datum/seed/mushroom/poison/death/New()
 	..()
@@ -605,7 +605,7 @@
 	name = "harebells"
 	seed_name = "harebell"
 	display_name = "harebells"
-	chems = list("nutriment" = list(1,20))
+	chems = list("plantmatter" = list(1,20))
 
 /datum/seed/flower/New()
 	..()
@@ -621,7 +621,7 @@
 	name = "poppies"
 	seed_name = "poppy"
 	display_name = "poppies"
-	chems = list("nutriment" = list(1,20), "styptic_powder" = list(1,10))
+	chems = list("plantmatter" = list(1,20), "styptic_powder" = list(1,10))
 	kitchen_tag = "poppy"
 
 /datum/seed/flower/poppy/New()
@@ -652,7 +652,7 @@
 	seed_name = "grape"
 	display_name = "grapevines"
 	mutants = list("greengrapes")
-	chems = list("nutriment" = list(1,10), "sugar" = list(1,5))
+	chems = list("plantmatter" = list(1,10), "sugar" = list(1,5))
 
 /datum/seed/grapes/New()
 	..()
@@ -671,7 +671,7 @@
 	seed_name = "green grape"
 	display_name = "green grapevines"
 	mutants = null
-	chems = list("nutriment" = list(1,10), "silver_sulfadiazine" = list(3,5))
+	chems = list("plantmatter" = list(1,10), "silver_sulfadiazine" = list(3,5))
 
 /datum/seed/grapes/green/New()
 	..()
@@ -682,7 +682,7 @@
 	name = "peanut"
 	seed_name = "peanut"
 	display_name = "peanut vines"
-	chems = list("nutriment" = list(1,10))
+	chems = list("plantmatter" = list(1,10))
 
 /datum/seed/peanuts/New()
 	..()
@@ -699,7 +699,7 @@
 	name = "cabbage"
 	seed_name = "cabbage"
 	display_name = "cabbages"
-	chems = list("nutriment" = list(1,10))
+	chems = list("plantmatter" = list(1,10))
 	kitchen_tag = "cabbage"
 
 /datum/seed/cabbage/New()
@@ -737,7 +737,7 @@
 	name = "corn"
 	seed_name = "corn"
 	display_name = "ears of corn"
-	chems = list("nutriment" = list(1,10), "corn_starch" = list(3,5))
+	chems = list("plantmatter" = list(1,10), "corn_starch" = list(3,5))
 	kitchen_tag = "corn"
 	trash_type = /obj/item/weapon/corncob
 
@@ -756,7 +756,7 @@
 	name = "potato"
 	seed_name = "potato"
 	display_name = "potatoes"
-	chems = list("nutriment" = list(1,10))
+	chems = list("plantmatter" = list(1,10))
 	kitchen_tag = "potato"
 
 /datum/seed/potato/New()
@@ -774,7 +774,7 @@
 	name = "soybean"
 	seed_name = "soybean"
 	display_name = "soybeans"
-	chems = list("nutriment" = list(1,20), "soybeanoil" = list(1,20))
+	chems = list("plantmatter" = list(1,20), "soybeanoil" = list(1,20))
 	kitchen_tag = "soybeans"
 
 /datum/seed/soybean/New()
@@ -792,7 +792,7 @@
 	name = "wheat"
 	seed_name = "wheat"
 	display_name = "wheat stalks"
-	chems = list("nutriment" = list(1,25))
+	chems = list("plantmatter" = list(1,25))
 	kitchen_tag = "wheat"
 
 /datum/seed/wheat/New()
@@ -810,7 +810,7 @@
 	name = "rice"
 	seed_name = "rice"
 	display_name = "rice stalks"
-	chems = list("nutriment" = list(1,25))
+	chems = list("plantmatter" = list(1,25))
 	kitchen_tag = "rice"
 
 /datum/seed/rice/New()
@@ -828,7 +828,7 @@
 	name = "carrot"
 	seed_name = "carrot"
 	display_name = "carrots"
-	chems = list("nutriment" = list(1,20), "oculine" = list(3,5))
+	chems = list("plantmatter" = list(1,20), "oculine" = list(3,5))
 	kitchen_tag = "carrot"
 
 /datum/seed/carrots/New()
@@ -862,7 +862,7 @@
 	name = "whitebeet"
 	seed_name = "white-beet"
 	display_name = "white-beets"
-	chems = list("nutriment" = list(0,20), "sugar" = list(1,5))
+	chems = list("plantmatter" = list(0,20), "sugar" = list(1,5))
 	kitchen_tag = "whitebeet"
 
 /datum/seed/whitebeets/New()
@@ -898,7 +898,7 @@
 	name = "watermelon"
 	seed_name = "watermelon"
 	display_name = "watermelon vine"
-	chems = list("nutriment" = list(1,6))
+	chems = list("plantmatter" = list(1,6))
 	kitchen_tag = "watermelon"
 
 /datum/seed/watermelon/New()
@@ -918,7 +918,7 @@
 	name = "pumpkin"
 	seed_name = "pumpkin"
 	display_name = "pumpkin vine"
-	chems = list("nutriment" = list(1,6))
+	chems = list("plantmatter" = list(1,6))
 	kitchen_tag = "pumpkin"
 
 /datum/seed/pumpkin/New()
@@ -937,7 +937,7 @@
 	name = "lime"
 	seed_name = "lime"
 	display_name = "lime trees"
-	chems = list("nutriment" = list(1,20))
+	chems = list("plantmatter" = list(1,20))
 	kitchen_tag = "lime"
 
 /datum/seed/citrus/New()
@@ -956,7 +956,7 @@
 	name = "lemon"
 	seed_name = "lemon"
 	display_name = "lemon trees"
-	chems = list("nutriment" = list(1,20))
+	chems = list("plantmatter" = list(1,20))
 	kitchen_tag = "lemon"
 
 /datum/seed/citrus/lemon/New()
@@ -969,7 +969,7 @@
 	seed_name = "orange"
 	display_name = "orange trees"
 	kitchen_tag = "orange"
-	chems = list("nutriment" = list(1,20))
+	chems = list("plantmatter" = list(1,20))
 
 /datum/seed/citrus/orange/New()
 	..()
@@ -979,7 +979,7 @@
 	name = "grass"
 	seed_name = "grass"
 	display_name = "grass"
-	chems = list("nutriment" = list(1,20))
+	chems = list("plantmatter" = list(1,20))
 	kitchen_tag = "grass"
 
 /datum/seed/grass/New()
@@ -997,7 +997,7 @@
 	name = "cocoa"
 	seed_name = "cacao"
 	display_name = "cacao tree"
-	chems = list("nutriment" = list(1,10), "coco" = list(4,5))
+	chems = list("plantmatter" = list(1,10), "coco" = list(4,5))
 
 /datum/seed/cocoa/New()
 	..()
@@ -1015,7 +1015,7 @@
 	seed_name = "cherry"
 	seed_noun = "pits"
 	display_name = "cherry tree"
-	chems = list("nutriment" = list(1,15), "sugar" = list(1,15))
+	chems = list("plantmatter" = list(1,15), "sugar" = list(1,15))
 	kitchen_tag = "cherries"
 
 /datum/seed/cherries/New()
@@ -1035,7 +1035,7 @@
 	name = "kudzu"
 	seed_name = "kudzu"
 	display_name = "kudzu vines"
-	chems = list("nutriment" = list(1,50), "charcoal" = list(1,25))
+	chems = list("plantmatter" = list(1,50), "charcoal" = list(1,25))
 
 /datum/seed/kudzu/New()
 	..()
@@ -1130,7 +1130,7 @@
 	name = "telriis"
 	seed_name = "telriis"
 	display_name = "telriis grass"
-	chems = list("wine" = list(1,5), "toxin" = list(1,5), "nutriment" = list(1,6))
+	chems = list("wine" = list(1,5), "toxin" = list(1,5), "plantmatter" = list(1,6))
 
 /datum/seed/telriis/New()
 	..()
@@ -1145,7 +1145,7 @@
 	name = "thaadra"
 	seed_name = "thaa'dra"
 	display_name = "thaa'dra lichen"
-	chems = list("frostoil" = list(1,5),"nutriment" = list(1,5))
+	chems = list("frostoil" = list(1,5),"plantmatter" = list(1,5))
 
 /datum/seed/thaadra/New()
 	..()
@@ -1160,7 +1160,7 @@
 	name = "jurlmah"
 	seed_name = "jurl'mah"
 	display_name = "jurl'mah reeds"
-	chems = list("serotrotium" = list(1,5),"nutriment" = list(1,5))
+	chems = list("serotrotium" = list(1,5),"plantmatter" = list(1,5))
 
 /datum/seed/jurlmah/New()
 	..()
@@ -1175,7 +1175,7 @@
 	name = "amauri"
 	seed_name = "amauri"
 	display_name = "amauri plant"
-	chems = list("condensedcapsaicin" = list(1,5),"nutriment" = list(1,5))
+	chems = list("condensedcapsaicin" = list(1,5),"plantmatter" = list(1,5))
 
 /datum/seed/amauri/New()
 	..()
@@ -1190,7 +1190,7 @@
 	name = "gelthi"
 	seed_name = "gelthi"
 	display_name = "gelthi plant"
-	chems = list("morphine" = list(1,5),"capsaicin" = list(1,5),"nutriment" = list(1,5))
+	chems = list("morphine" = list(1,5),"capsaicin" = list(1,5),"plantmatter" = list(1,5))
 
 /datum/seed/gelthi/New()
 	..()
@@ -1205,7 +1205,7 @@
 	name = "vale"
 	seed_name = "vale"
 	display_name = "vale bush"
-	chems = list("sal_acid" = list(1,5),"salbutamol" = list(1,2),"nutriment"= list(1,5))
+	chems = list("sal_acid" = list(1,5),"salbutamol" = list(1,2),"plantmatter"= list(1,5))
 
 /datum/seed/vale/New()
 	..()
@@ -1220,7 +1220,7 @@
 	name = "surik"
 	seed_name = "surik"
 	display_name = "surik vine"
-	chems = list("haloperidol" = list(1,3),"synaptizine" = list(1,2),"nutriment" = list(1,5))
+	chems = list("haloperidol" = list(1,3),"synaptizine" = list(1,2),"plantmatter" = list(1,5))
 
 /datum/seed/surik/New()
 	..()

--- a/code/modules/mob/living/carbon/human/species/apollo.dm
+++ b/code/modules/mob/living/carbon/human/species/apollo.dm
@@ -35,7 +35,7 @@
 		)
 
 	flags = IS_WHITELISTED | HAS_LIPS | HAS_UNDERWEAR | NO_BREATHE | HAS_SKIN_COLOR | NO_SCAN | NO_SCAN | HIVEMIND
-
+	dietflags = DIET_HERB		//bees feed off nectar, so bee people feed off plants too
 
 	base_color = "#704300"
 	flesh_color = "#704300"
@@ -88,6 +88,7 @@
 	burn_mod = 4 // holy shite, poor guys wont survive half a second cooking smores
 	brute_mod = 2 // damn, double wham, double dam
 	flags = IS_WHITELISTED | NO_BREATHE | NO_BLOOD | NO_PAIN | HAS_LIPS | NO_SCAN
+	dietflags = DIET_OMNI		//still human at their core, so they maintain their eating habits and diet
 
 	has_organ = list(
 		"heart" =    /obj/item/organ/heart,

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -6,6 +6,7 @@
 
 	default_language = "Galactic Common"
 	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN
+	dietflags = DIET_OMNI		//golems can eat anything because they are magic or something
 
 	blood_color = "#515573"
 	flesh_color = "#137E8F"

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -6,6 +6,7 @@
 	unarmed_type = /datum/unarmed_attack/punch
 
 	flags = IS_WHITELISTED | NO_BLOOD
+	dietflags = DIET_OMNI
 
 	//default_mutations=list(SKELETON) // This screws things up
 

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -18,6 +18,7 @@
 
 	flags = NO_BLOOD | NO_BREATHE | NO_SCAN
 	bodyflags = FEET_NOSLIP
+	dietflags = DIET_OMNI		//the mutation process allowed you to now digest all foods regardless of initial race
 
 /datum/species/shadow/handle_death(var/mob/living/carbon/human/H)
 	H.dust()

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -553,7 +553,7 @@
 
 	flags = IS_WHITELISTED
 	bodyflags = FEET_CLAWS
-	dietflags = DIET_OMNI
+	dietflags = DIET_HERB
 
 	blood_color = "#FB9800"
 
@@ -644,7 +644,7 @@
 	water and other radiation."
 
 	flags = NO_BREATHE | REQUIRE_LIGHT | IS_PLANT | RAD_ABSORB | NO_BLOOD | NO_PAIN
-	dietflags = DIET_HERB		//Diona regenerate nutrition in light, but could assimilate plantmatter if they ingest it
+	dietflags = 0		//Diona regenerate nutrition in light, no diet necessary
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 
@@ -730,7 +730,7 @@
 	synth_temp_gain = 10 //this should cause IPCs to stabilize at ~80 C in a 20 C environment.
 
 	flags = IS_WHITELISTED | NO_BREATHE | NO_SCAN | NO_BLOOD | NO_PAIN | IS_SYNTHETIC | NO_INTORGANS
-	dietflags = DIET_OMNI		//IPCs can't eat, this is here for the sake of standardized code
+	dietflags = 0		//IPCs can't eat, so no diet
 	blood_color = "#1F181F"
 	flesh_color = "#AAAAAA"
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -53,6 +53,7 @@
 	var/flags = 0       // Various specific features.
 	var/bloodflags=0
 	var/bodyflags=0
+	var/dietflags  = 0	// Make sure you set this, otherwise it won't be able to digest a lot of foods
 
 	var/list/abilities = list()	// For species-derived or admin-given powers
 
@@ -321,6 +322,7 @@
 	path = /mob/living/carbon/human/human
 	flags = HAS_LIPS | HAS_UNDERWEAR | CAN_BE_FAT
 	bodyflags = HAS_SKIN_TONE
+	dietflags = DIET_OMNI
 	unarmed_type = /datum/unarmed_attack/punch
 	blurb = "Humanity originated in the Sol system, and over the last five centuries has spread \
 	colonies across a wide swathe of space. They hold a wide range of forms and creeds.<br/><br/> \
@@ -348,6 +350,7 @@
 
 	flags = HAS_LIPS | HAS_UNDERWEAR
 	bodyflags = FEET_CLAWS | HAS_TAIL | HAS_SKIN_COLOR | TAIL_WAGGING
+	dietflags = DIET_CARN
 
 	cold_level_1 = 280 //Default 260 - Lower is better
 	cold_level_2 = 220 //Default 200
@@ -397,6 +400,7 @@
 
 	flags = HAS_LIPS | HAS_UNDERWEAR | CAN_BE_FAT
 	bodyflags = FEET_PADDED | HAS_TAIL | HAS_SKIN_COLOR | TAIL_WAGGING
+	dietflags = DIET_OMNI
 
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
@@ -423,6 +427,7 @@
 
 	flags = HAS_LIPS | HAS_UNDERWEAR
 	bodyflags = HAS_SKIN_COLOR
+	dietflags = DIET_HERB
 
 	flesh_color = "#8CD7A3"
 	blood_color = "#1D2CBF"
@@ -461,6 +466,7 @@
 	poison_type = "oxygen"
 
 	flags = NO_SCAN | IS_WHITELISTED
+	dietflags = DIET_OMNI
 
 	blood_color = "#2299FC"
 	flesh_color = "#808D11"
@@ -514,6 +520,7 @@
 	poison_type = "oxygen"
 
 	flags = NO_SCAN | NO_BLOOD | HAS_TAIL | NO_PAIN | IS_WHITELISTED
+	dietflags = DIET_OMNI	//should inherit this from vox, this is here just in case
 
 	blood_color = "#2299FC"
 	flesh_color = "#808D11"
@@ -546,6 +553,7 @@
 
 	flags = IS_WHITELISTED
 	bodyflags = FEET_CLAWS
+	dietflags = DIET_OMNI
 
 	blood_color = "#FB9800"
 
@@ -563,6 +571,7 @@
 	flags = IS_WHITELISTED | NO_BREATHE | HAS_LIPS | NO_INTORGANS | NO_SCAN
 	bodyflags = HAS_SKIN_COLOR
 	bloodflags = BLOOD_SLIME
+	dietflags = DIET_CARN
 
 	//ventcrawler = 1 //ventcrawling commented out
 
@@ -587,6 +596,7 @@
 	primitive = /mob/living/carbon/monkey // TODO
 
 	flags = IS_WHITELISTED | HAS_LIPS | HAS_UNDERWEAR | CAN_BE_FAT
+	dietflags = DIET_HERB
 
 	blood_color = "#A200FF"
 
@@ -634,6 +644,7 @@
 	water and other radiation."
 
 	flags = NO_BREATHE | REQUIRE_LIGHT | IS_PLANT | RAD_ABSORB | NO_BLOOD | NO_PAIN
+	dietflags = DIET_HERB		//Diona regenerate nutrition in light, but could assimilate plantmatter if they ingest it
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 
@@ -719,6 +730,7 @@
 	synth_temp_gain = 10 //this should cause IPCs to stabilize at ~80 C in a 20 C environment.
 
 	flags = IS_WHITELISTED | NO_BREATHE | NO_SCAN | NO_BLOOD | NO_PAIN | IS_SYNTHETIC | NO_INTORGANS
+	dietflags = DIET_OMNI		//IPCs can't eat, this is here for the sake of standardized code
 	blood_color = "#1F181F"
 	flesh_color = "#AAAAAA"
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1519,7 +1519,7 @@ datum
 				if(!(M.mind in ticker.mode.vampires))
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
-						if(H.species && H.species.dietflags && !(H.species.dietflags & DIET_HERB))	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
+						if(H.species && H.species.dietflags && !(H.species.dietflags & DIET_HERB))	//Make sure the species has it's dietflag set, and that it is not a herbivore
 							H.nutrition += nutriment_factor	// For hunger and fatness
 							if(prob(50)) M.heal_organ_damage(1,0)
 					if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
@@ -1540,7 +1540,7 @@ datum
 				if(!(M.mind in ticker.mode.vampires))
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
-						if(H.species && H.species.dietflags && !(H.species.dietflags & DIET_CARN))	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
+						if(H.species && H.species.dietflags && !(H.species.dietflags & DIET_CARN))	//Make sure the species has it's dietflag set, and that it is not a carnivore
 							H.nutrition += nutriment_factor	// For hunger and fatness
 							if(prob(50)) M.heal_organ_damage(1,0)
 					if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1485,10 +1485,31 @@ datum
 /////////////////////////Food Reagents////////////////////////////
 // Part of the food code. Nutriment is used instead of the old "heal_amt" code. Also is where all the food
 // 	condiments, additives, and such go.
-		nutriment
+		nutriment		// Pure nutriment, universally digestable and thus slightly less effective
 			name = "Nutriment"
 			id = "nutriment"
-			description = "All the vitamins, minerals, and carbohydrates the body needs in pure form."
+			description = "A questionable mixture of various pure nutrients commonly found in processed foods."
+			reagent_state = SOLID
+			nutriment_factor = 12 * REAGENTS_METABOLISM
+			color = "#664330" // rgb: 102, 67, 48
+
+			on_mob_life(var/mob/living/M as mob)
+				if(!M) M = holder.my_atom
+				if(!(M.mind in ticker.mode.vampires))
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						if(H.species && H.species.dietflags)	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
+							H.nutrition += nutriment_factor	// For hunger and fatness
+							if(prob(50)) M.heal_organ_damage(1,0)
+					if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
+						if(prob(50)) M.heal_organ_damage(1,0)
+				..()
+				return
+
+		protein			// Meat-based protein, digestable by carnivores and omnivores, worthless to herbivores
+			name = "Protein"
+			id = "protein"
+			description = "Various essential proteins and fats commonly found in animal flesh and blood."
 			reagent_state = SOLID
 			nutriment_factor = 15 * REAGENTS_METABOLISM
 			color = "#664330" // rgb: 102, 67, 48
@@ -1496,8 +1517,34 @@ datum
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
 				if(!(M.mind in ticker.mode.vampires))
-					M.nutrition += nutriment_factor	// For hunger and fatness
-					if(prob(50)) M.heal_organ_damage(1,0)
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						if(H.species && H.species.dietflags && !(H.species.dietflags & DIET_HERB))	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
+							H.nutrition += nutriment_factor	// For hunger and fatness
+							if(prob(50)) M.heal_organ_damage(1,0)
+					if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
+						if(prob(50)) M.heal_organ_damage(1,0)
+				..()
+				return
+
+		plantmatter		// Plant-based biomatter, digestable by herbivores and omnivores, worthless to carnivores
+			name = "Plant-matter"
+			id = "plantmatter"
+			description = "Vitamin-rich fibers and natural sugars commonly found in fresh produce."
+			reagent_state = SOLID
+			nutriment_factor = 15 * REAGENTS_METABOLISM
+			color = "#664330" // rgb: 102, 67, 48
+
+			on_mob_life(var/mob/living/M as mob)
+				if(!M) M = holder.my_atom
+				if(!(M.mind in ticker.mode.vampires))
+					if(ishuman(M))
+						var/mob/living/carbon/human/H = M
+						if(H.species && H.species.dietflags && !(H.species.dietflags & DIET_CARN))	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
+							H.nutrition += nutriment_factor	// For hunger and fatness
+							if(prob(50)) M.heal_organ_damage(1,0)
+					if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
+						if(prob(50)) M.heal_organ_damage(1,0)
 				..()
 				return
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -44,7 +44,7 @@
 		return 0
 
 	if(istype(M, /mob/living/carbon))
-		var/fullness = M.nutrition + (M.reagents.get_reagent_amount("nutriment") * 25)
+		var/fullness = M.nutrition + (M.reagents.get_reagent_amount("nutriment") * 20) + (M.reagents.get_reagent_amount("protein") * 25) + (M.reagents.get_reagent_amount("plantmatter") * 25)
 		if(M == user)								//If you're eating it yourself
 			if(istype(M,/mob/living/carbon/human))
 				var/mob/living/carbon/human/H = M
@@ -535,7 +535,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("protein", 1)
 		reagents.add_reagent("egg", 5)
 
 	throw_impact(atom/hit_atom)
@@ -635,7 +635,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 4)
+		reagents.add_reagent("protein", 4)
 		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/appendix
@@ -648,7 +648,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("protein", 3)
 		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/appendix/inflamed
@@ -699,7 +699,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("protein", 3)
 		reagents.add_reagent("carpotoxin", 3)
 		src.bitesize = 6
 
@@ -723,7 +723,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("plantmatter", 3)
 		reagents.add_reagent("psilocybin", 3)
 		src.bitesize = 6
 
@@ -735,7 +735,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("protein", 3)
 		src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/bearmeat
@@ -746,7 +746,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 12)
+		reagents.add_reagent("protein", 12)
 		reagents.add_reagent("methamphetamine", 5)
 		src.bitesize = 3
 
@@ -758,7 +758,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("protein", 3)
 		src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/spidermeat
@@ -767,7 +767,7 @@
 	icon_state = "spidermeat"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("protein", 3)
 		reagents.add_reagent("toxin", 3)
 		bitesize = 3
 
@@ -777,7 +777,7 @@
 	icon_state = "spiderleg"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 2)
+		reagents.add_reagent("protein", 2)
 		reagents.add_reagent("toxin", 2)
 		bitesize = 2
 
@@ -788,7 +788,7 @@
 	filling_color = "#DB0000"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("protein", 3)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/sausage
@@ -799,7 +799,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 6)
+		reagents.add_reagent("protein", 6)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket
@@ -1244,7 +1244,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 4)
+		reagents.add_reagent("protein", 4)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/no_raisin
@@ -1256,7 +1256,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 6)
+		reagents.add_reagent("plantmatter", 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/spacetwinkie
 	name = "Space Twinkie"
@@ -1297,7 +1297,8 @@
 	icon_state = "chinese2"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 6)
+		reagents.add_reagent("nutriment", 4)
+		reagents.add_reagent("protein", 2)
 		reagents.add_reagent("msg",4)
 		bitesize = 2
 
@@ -1672,7 +1673,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment",10)
+		reagents.add_reagent("protein",10)
 
 	afterattack(obj/O as obj, mob/user as mob, proximity)
 		if(!proximity) return
@@ -2074,7 +2075,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("plantmatter", 3)
 		reagents.add_reagent("oculine", 3)
 		bitesize = 2
 
@@ -2332,7 +2333,8 @@
 	filling_color = "#FF7575"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 30)
+		reagents.add_reagent("protein", 20)
+		reagents.add_reagent("nutriment", 10)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/meatbreadslice
@@ -2352,7 +2354,8 @@
 	filling_color = "#8AFF75"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 30)
+		reagents.add_reagent("protein", 20)
+		reagents.add_reagent("nutriment", 10)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/xenomeatbreadslice
@@ -2371,7 +2374,8 @@
 	slices_num = 5
 	New()
 		..()
-		reagents.add_reagent("nutriment", 30)
+		reagents.add_reagent("protein", 20)
+		reagents.add_reagent("nutriment", 10)
 		reagents.add_reagent("toxin", 15)
 		bitesize = 2
 
@@ -2457,7 +2461,8 @@
 	filling_color = "#E6AEDB"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 25)
+		reagents.add_reagent("protein", 15)
+		reagents.add_reagent("nutriment", 10)
 		reagents.add_reagent("mannitol", 10)
 		bitesize = 2
 
@@ -2777,7 +2782,8 @@
 	slices_num = 6
 	New()
 		..()
-		reagents.add_reagent("nutriment", 50)
+		reagents.add_reagent("protein", 30)
+		reagents.add_reagent("nutriment", 20)
 		reagents.add_reagent("tomatojuice", 6)
 		bitesize = 2
 
@@ -2796,7 +2802,8 @@
 	slices_num = 6
 	New()
 		..()
-		reagents.add_reagent("nutriment", 35)
+		reagents.add_reagent("plantmatter", 25)
+		reagents.add_reagent("nutriment", 10)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
@@ -2814,7 +2821,8 @@
 	slices_num = 6
 	New()
 		..()
-		reagents.add_reagent("nutriment", 30)
+		reagents.add_reagent("plantmatter", 20)
+		reagents.add_reagent("nutriment", 10)
 		reagents.add_reagent("tomatojuice", 6)
 		reagents.add_reagent("oculine", 12)
 		bitesize = 2
@@ -3119,7 +3127,8 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment", 6)
+		reagents.add_reagent("plantmatter", 4)
+		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("radium", 2)
 		bitesize = 2
 
@@ -3140,7 +3149,7 @@
 	icon_state = "spidereggs"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 2)
+		reagents.add_reagent("protein", 2)
 		reagents.add_reagent("toxin", 3)
 		bitesize = 2
 
@@ -3317,7 +3326,7 @@
 	bitesize = 1
 	New()
 		..()
-		reagents.add_reagent("nutriment", 1)
+		reagents.add_reagent("protein", 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet
 	name = "cutlet"
@@ -3327,7 +3336,7 @@
 	bitesize = 2
 	New()
 		..()
-		reagents.add_reagent("nutriment", 2)
+		reagents.add_reagent("protein", 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/rawmeatball
 	name = "raw meatball"
@@ -3337,7 +3346,7 @@
 	bitesize = 2
 	New()
 		..()
-		reagents.add_reagent("nutriment", 2)
+		reagents.add_reagent("protein", 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/hotdog
 	name = "hotdog"
@@ -3346,7 +3355,7 @@
 	bitesize = 2
 	New()
 		..()
-		reagents.add_reagent("nutriment", 6)
+		reagents.add_reagent("protein", 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/flatbread
 	name = "flatbread"
@@ -3375,7 +3384,7 @@
 	bitesize = 2
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("plantmatter", 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/ectoplasm
 	name = "ectoplasm"

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -6,7 +6,7 @@
 	filling_color = "#FF1C1C"
 	New()
 		..()
-		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("protein", 3)
 		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/attackby(obj/item/weapon/W as obj, mob/user as mob, params)


### PR DESCRIPTION
<b>Nutrient Changes and Dietary Concerns</b>
Splits nutriment into 3 reagents: Protein, Nutriment, and Plant-matter. Every race now has a defined diet (except Diona and IPCs who don't get nutrition from food) which dictates what types of nutrient reagents that benefit them. Nutriment is considered a neutral type, and thus can be digested by carnivores, herbivores, and omnivores alike, while protein cannot be digested by herbivores and carnivores cannot digest plant-matter.

Regardless of diet, all three nutrients will metabolize out of the body safely, meaning you cannot become fat off of a steak if you are an herbivore. You only will gain the benefits of nutrition and slight healing from the nutrient types your species can digest.

Most of the kitchen-produced foods have been largely untouched, as have most vending machine foods. Vending machine jerky and the Admiral Yamato Carp have had their reagents adjusted to include protein, and 4noraisins have had their reagents switched to plant-matter to ensure that a dietary-friendly option will be available without botany or a chef. Since kitchen-produced foods inherit the reagents of their ingredients, few higher-level foods have been adjusted, while most ingredients such as botany produce and monkey meat have been updated to properly list plant-matter or protein as appropriate. Chef food will typically include at least 2 nutrient types.

<b>Breakdown of additions, changes, etc:</b>
- Adds Protein and Plant-matter reagents, nutritional values of 15
- Reduces nutritional value of Nutriment to 12, down from 15
- Adds new flag defines for racial diets, and new dietflags var to species
(must be set manually in the species definition, otherwise it will be
null)
- Assigns each species their respective diet's flag:
 - Carnivores: Unathi, Slime People
 - Omnivores: Human, Tajaran, Vox, Shadowpeople, Golems,
Plasmaman, Nucleation, Vox Armalis
 - Herbivores: Skrell, Kidan, Grey, Wryn
 - No Diet (null dietflag): Diona, IPC
- Adds checks to all nutrient on_mob_life procs to handle simple_animals
versus carbon/human mobs
 - Simple animals will heal from any nutrient source, but don't gain
nutritional value since they don't appear to deplete it
- Adds check to Nutriment on_mob_life proc to ensure that the diet for a
species has been set
 - Failure to set a diet flag will prevent the species from benefitting
from ANY nutrients, while metabolizing the reagents normally
 - This is largely for ensuring the species is properly defined
- Adds checks to Protein and Plant-matter on_mob_life procs to handle
incompatible diets
 - Ingesting Protein does not benefit Herbivores, but will metabolize out
of the body normally
 -Ingesting Plant-matter does not benefit Carnivores, but will metabolize
out of the body normally
- Initial update of food reagents to utilize new nutrient reagents
 - Food inherits the reagents of it's ingredients in almost every case, and then adds some additional nutriment to the product
- Fixes the blood tomato mutant list to actually allow mutation into
killer tomato.

<b>I would like to request at least one other person look through this and ensure I have not missed anything important and that it is largely bug-free before it is merged. I have done testing, but given the scope of the reagent changes, I would rather it be delayed slightly than merged feature-incomplete.</b>