### PR TITLE
Fixes Air Initialization for Away Missions

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -84,8 +84,8 @@ datum/controller/air_system
 			if(istype(S))
 				air_master.add_to_active(S)
 
-/datum/controller/air_system/proc/setup_allturfs()
-	for(var/turf/simulated/T in world)
+/datum/controller/air_system/proc/setup_allturfs(var/turfs_in = world)
+	for(var/turf/simulated/T in turfs_in)
 		T.CalculateAdjacentTurfs()
 		if(!T.blocks_air)
 			if(T.air.check_tile_graphic())

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -40,6 +40,9 @@ proc/createRandomZlevel()
 		var/file = file(map)
 		if(isfile(file))
 			maploader.load_map(file)
+			// Initialize air for the away mission's turfs
+			if(air_master)
+				air_master.setup_allturfs(block(locate(1, 1, world.maxz), locate(world.maxx, world.maxy, world.maxz)))
 			world.log << "away mission loaded: [map]"
 
 		for(var/obj/effect/landmark/L in landmarks_list)


### PR DESCRIPTION
Away missions were being loaded *after* the air system had initialized all turfs in the world, meaning they were loaded with un-initialized turfs. This lead to unpredictable behavior, including runtimes when turfs tried to check walls for air they didn't have.

This fixes that by explicitly initializing air for the away mission's turfs after they load, using `setup_allturfs` with a new argument to limit which turfs it initializes.