### PR TITLE
MTTS: Control Panel Anchored, More whitelisting

### DIFF
--- a/code/modules/tram/tram.dm
+++ b/code/modules/tram/tram.dm
@@ -49,6 +49,7 @@
 
 	var/automode = 0
 	var/list/blacklist = list(/obj/tram/rail,/atom/movable/lighting_overlay)
+	var/list/ancwhitelist = list(/obj/tram, /obj/vehicle, /obj/structure/stool/bed/chair, /obj/structure/grille, /obj/structure/window)
 
 /obj/tram/tram_controller/New()
 	spawn(1)
@@ -144,7 +145,7 @@
 	if(is_type_in_list(AM, blacklist))	return 0
 	if(!AM.simulated)	return 0
 	if(AM.anchored)
-		if(istype(AM,/obj/tram) || istype(AM,/obj/vehicle))
+		if(is_type_in_list(AM, ancwhitelist))
 			return 1
 		return 0
 	return 1

--- a/code/modules/tram/tram_control_pad.dm
+++ b/code/modules/tram/tram_control_pad.dm
@@ -3,8 +3,8 @@
 	desc = "Controls a tram."
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "airlock_control_standby"
+	anchored = 1
 	var/obj/tram/tram_controller/tram_linked
-	var/list/cdir2readable = list("North","South",null,"East",null,null,null,"West")
 
 /obj/tram/controlpad/attack_hand(var/mob/user)
 	usr.set_machine(src)


### PR DESCRIPTION
This commit fixes the bug of being able to steal a tram's controller,
because it was not anchored. It also adds two new things and a minor
refactor to the "allowed-to-move-this-even-if-anchored" system, chairs,
windows, and grilles.