### PR TITLE
TeG & SM crates in cargo, SM temp increase.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -523,6 +523,25 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 20
 	containername = "Inflatable Barrier Crate"
 
+/datum/supply_packs/engineering/supermatter
+	name = "Supermatter Crystal Crate"
+	contains = list(/obj/machinery/power/supermatter)
+	cost = 50 //Yes that's a fucking lot.
+	containername = "Supermatter Shard Crate"
+	containertype = /obj/structure/closet/crate/secure/large/reinforced
+	access = access_ce
+
+/datum/supply_packs/engineering/teg
+	name = "Thermo-Electric Generator"
+	contains = list(
+		/obj/machinery/power/generator,
+		/obj/machinery/atmospherics/binary/circulator,
+		/obj/machinery/atmospherics/binary/circulator
+	)
+	cost = 25
+	containername = "Thermo-Electric Generator Components"
+	access = access_ce
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Medical /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -17,6 +17,8 @@
 
 	var/image/overlay_image
 
+	var/powercap = 500000 //Not a hard cap, but outputs above this have a 10% chance to cause the TeG to lose half it's power.
+
 /obj/machinery/power/generator/New()
 	..()
 
@@ -101,12 +103,12 @@
 		circ2.network2.update = 1
 
 	// update icon overlays and power usage only if displayed level has changed
-	if(lastgen > 250000 && prob(10))
+	if(lastgen > powercap && prob(10))
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 		s.set_up(3, 1, src)
 		s.start()
 		lastgen *= 0.5
-	var/genlev = max(0, min( round(11*lastgen / 250000), 11))
+	var/genlev = max(0, min( round(11*lastgen / powercap), 11))
 	if(lastgen > 100 && genlev == 0)
 		genlev = 1
 	if(genlev != lastgenlev)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -18,7 +18,7 @@
 //Controls how much power is produced by each collector in range - this is the main parameter for tweaking SM balance, as it basically controls how the power variable relates to the rest of the game.
 #define POWER_FACTOR 1.0
 #define DECAY_FACTOR 700			//Affects how fast the supermatter power decays
-#define CRITICAL_TEMPERATURE 800	//K
+#define CRITICAL_TEMPERATURE 5000	//K
 #define CHARGING_FACTOR 0.05
 #define DAMAGE_RATE_LIMIT 3			//damage rate cap at power = 300, scales linearly with power
 


### PR DESCRIPTION
Adds crates for TeG components and SM crystals to cargo, CE access, 25 and 50 points each, respectively.

Also increases the critical temperature for the SM to 5000 K, because running a TeG on < 800 K is impossible.

And because the TeG was scrub (would have a 10% chance to lose 50% of it's power every process(), if producing above 250 KW, I increased that too.