### PR TITLE
Fixes for Minor Admin/Backend Issues

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -69,7 +69,7 @@
 		for(var/client/C in admins)
 			if(R_ADMIN & C.holder.rights || !R_MOD & C.holder.rights)
 
-				if(C.holder.fakekey && !R_ADMIN & holder.rights)		//Mentors/Mods can't see stealthmins
+				if(C.holder.fakekey && !(R_ADMIN & holder.rights))		//Mentors/Mods can't see stealthmins
 					continue
 
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -68,9 +68,14 @@ world/IsBanned(key,address,computer_id)
 
 			var/expires = ""
 			if(text2num(duration) > 0)
-				expires = " The ban is for [duration] minutes and expires on [expiration] (server time)."
+				expires = "The ban is for [duration] minutes and expires on [expiration] (server time)."
+			if(bantype == "PERMABAN")
+				var/appealmsg = ""
+				if(config && config.banappeals)
+					appealmsg = " You may appeal it at <a href='[config.banappeals]'>[config.banappeals]</a>."
+				expires = "The ban is permanent.[appealmsg]"
 
-			var/desc = "\nReason: You, or another user of this computer or connection ([pckey]) is banned from playing here. The ban reason is:\n[reason]\nThis ban was applied by [ackey] on [bantime], [expires]"
+			var/desc = "\nReason: You, or another user of this computer or connection ([pckey]) is banned from playing here. The ban reason is:\n[reason]\nThis ban was applied by [ackey] on [bantime]. [expires]"
 
 			return list("reason"="[bantype]", "desc"="[desc]")
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -69,7 +69,7 @@ world/IsBanned(key,address,computer_id)
 			var/expires = ""
 			if(text2num(duration) > 0)
 				expires = "The ban is for [duration] minutes and expires on [expiration] (server time)."
-			if(bantype == "PERMABAN")
+			if(istext(bantype) && (bantype == "PERMABAN"))
 				var/appealmsg = ""
 				if(config && config.banappeals)
 					appealmsg = " You may appeal it at <a href='[config.banappeals]'>[config.banappeals]</a>."

--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -1,7 +1,7 @@
 proc/sql_report_karma(var/mob/spender, var/mob/receiver)
-	var/sqlspendername = spender.name
+	var/sqlspendername = sanitizeSQL(spender.name)
 	var/sqlspenderkey = spender.key
-	var/sqlreceivername = receiver.name
+	var/sqlreceivername = sanitizeSQL(receiver.name)
 	var/sqlreceiverkey = receiver.key
 	var/sqlreceiverrole = "None"
 	var/sqlreceiverspecial = "None"
@@ -10,9 +10,9 @@ proc/sql_report_karma(var/mob/spender, var/mob/receiver)
 
 	if(receiver.mind)
 		if(receiver.mind.special_role)
-			sqlreceiverspecial = receiver.mind.special_role
+			sqlreceiverspecial = sanitizeSQL(receiver.mind.special_role)
 		if(receiver.mind.assigned_role)
-			sqlreceiverrole = receiver.mind.assigned_role
+			sqlreceiverrole = sanitizeSQL(receiver.mind.assigned_role)
 
 	if(!dbcon.IsConnected())
 		log_game("SQL ERROR during karma logging. Failed to connect.")


### PR DESCRIPTION
* Fixes permanent bans being displayed to connecting players as though they were temporary ones.
  * Probably. I couldn't really test it locally. It probably works.
  * Before: "The ban is for 1 minutes and expires on \[the same time the ban was created\] (server time)."
  * After: "The ban is permanent. You may appeal it at \[appeals URL\]."
    * Assuming an appeals URL is actually set in the config.
  * I'm pretty sure the 1-minute-ban message only applies to bans before some date when the ban system was tweaked, but all permabans should see the new message, probably.
* Fixes non-admins with a rights holder (mentors and mods) being able to see stealthed admins in adminwho.
* Fixes missing sanitization in karma logging, which was causing certain player names to make the SQL insert fail.