### PR TITLE
Spellbook overhaul

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -32,7 +32,7 @@
 
 /obj/effect/proc_holder/spell/wizard/noclothes
 	name = "No Clothes"
-	desc = "This is a placeholder for knowing if you dont need clothes for any spell"
+	desc = "This always-on spell allows you to cast magic without your garments."
 
 /obj/effect/proc_holder/spell/wizard/targeted/genetic/mutate
 	name = "Mutate"

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -10,18 +10,6 @@
 		if(H.stat == 2 || !(H.client)) continue
 		if(H.mind)
 			if(H.mind.special_role == "Wizard" || H.mind.special_role == "apprentice") continue
-		if(prob(25) && !(H.mind in ticker.mode.traitors))
-			ticker.mode.traitors += H.mind
-			H.mind.special_role = "traitor"
-			var/datum/objective/survive/survive = new
-			survive.owner = H.mind
-			H.mind.objectives += survive
-			H.attack_log += "\[[time_stamp()]\] <font color='red'>Was made into a survivor, and trusts no one!</font>"
-			H << "<B>You are the survivor! Your own safety matters above all else, trust no one and kill anyone who gets in your way. However, armed as you are, now would be the perfect time to settle that score or grab that pair of yellow gloves you've been eyeing...</B>"
-			var/obj_count = 1
-			for(var/datum/objective/OBJ in H.mind.objectives)
-				H << "<B>Objective #[obj_count]</B>: [OBJ.explanation_text]"
-				obj_count++
 		var/randomizeguns = pick(gunslist)
 		var/randomizemagic = pick(magiclist)
 		var/randomizemagicspecial = pick(magicspeciallist)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -1,177 +1,475 @@
+/datum/spellbook_entry
+	var/name = "Entry Name"
+
+	var/spell_type = null
+	var/desc = ""
+	var/category = "Offensive Spells"
+	var/log_name = "XX" //What it shows up as in logs
+	var/cost = 1
+	var/refundable = 1
+	var/surplus = -1 // -1 for infinite, not used by anything atm
+	var/obj/effect/proc_holder/spell/S = null //Since spellbooks can be used by only one person anyway we can track the actual spell
+	var/buy_word = "Learn"
+
+/datum/spellbook_entry/proc/IsAvailible() // For config prefs / gamemode restrictions - these are round applied
+	return 1
+/datum/spellbook_entry/proc/CanBuy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book) // Specific circumstances
+	if(book.uses<cost)
+		return 0
+	return 1
+/datum/spellbook_entry/proc/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book) //return 1 on success
+	if(!S)
+		S = new spell_type()
+
+	//Check if we got the spell already
+	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
+		if(initial(S.name) == initial(aspell.name)) // Not using directly in case it was learned from one spellbook then upgraded in another
+			if(aspell.spell_level >= aspell.level_max)
+				user <<  "<span class='warning'>This spell cannot be improved further.</span>"
+				return 0
+			else
+				aspell.name = initial(aspell.name)
+				aspell.spell_level++
+				aspell.charge_max = round(initial(aspell.charge_max) - aspell.spell_level * (initial(aspell.charge_max) - aspell.cooldown_min)/ aspell.level_max)
+				if(aspell.charge_max < aspell.charge_counter)
+					aspell.charge_counter = aspell.charge_max
+				switch(aspell.spell_level)
+					if(1)
+						user << "<span class='notice'>You have improved [aspell.name] into Efficient [aspell.name].</span>"
+						aspell.name = "Efficient [aspell.name]"
+					if(2)
+						user << "<span class='notice'>You have further improved [aspell.name] into Quickened [aspell.name].</span>"
+						aspell.name = "Quickened [aspell.name]"
+					if(3)
+						user << "<span class='notice'>You have further improved [aspell.name] into Free [aspell.name].</span>"
+						aspell.name = "Free [aspell.name]"
+					if(4)
+						user << "<span class='notice'>You have further improved [aspell.name] into Instant [aspell.name].</span>"
+						aspell.name = "Instant [aspell.name]"
+				if(aspell.spell_level >= aspell.level_max)
+					user << "<span class='notice'>This spell cannot be strengthened any further.</span>"
+				return 1
+	//No same spell found - just learn it
+	feedback_add_details("wizard_spell_learned",log_name)
+	user.mind.AddSpell(S)
+	user << "<span class='notice'>You have learned [S.name].</span>"
+	return 1
+
+/datum/spellbook_entry/proc/CanRefund(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	if(!refundable)
+		return 0
+	if(!S)
+		S = new spell_type()
+	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
+		if(initial(S.name) == initial(aspell.name))
+			return 1
+	return 0
+
+/datum/spellbook_entry/proc/Refund(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book) //return point value or -1 for failure
+	var/area/wizard_station/A = locate()
+	if(!(user in A.contents))
+		user << "<span clas=='warning'>You can only refund spells at the wizard lair</span>"
+		return -1
+	if(!S)
+		S = new spell_type()
+	var/spell_levels = 0
+	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
+		if(initial(S.name) == initial(aspell.name))
+			spell_levels = aspell.spell_level
+			user.mind.spell_list.Remove(aspell)
+			del(S)
+			return cost * (spell_levels+1)
+	return -1
+
+/datum/spellbook_entry/proc/GetInfo()
+	if(!S)
+		S = new spell_type()
+	var/dat =""
+	dat += "<b>[initial(S.name)]</b>"
+	if(S.charge_type == "recharge")
+		dat += " Cooldown:[S.charge_max/10]"
+	dat += " Cost:[cost]<br>"
+	dat += "<i>[S.desc][desc]</i><br>"
+	dat += "[S.clothes_req?"Needs wizard garb":"Can be cast without wizard garb"]<br>"
+	return dat
+
+/datum/spellbook_entry/noclothes
+	name = "Remove Clothes Requirement"
+	spell_type = /obj/effect/proc_holder/spell/wizard/noclothes
+	log_name = "NC"
+
+/datum/spellbook_entry/fireball
+	name = "Fireball"
+	spell_type = /obj/effect/proc_holder/spell/wizard/dumbfire/fireball
+	log_name = "FB"
+
+/datum/spellbook_entry/magicm
+	name = "Magic Missile"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/projectile/magic_missile
+	log_name = "MM"
+
+/datum/spellbook_entry/disintegrate
+	name = "Disintegrate"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/inflict_handler/disintegrate
+	log_name = "DG"
+
+/datum/spellbook_entry/disabletech
+	name = "Disable Tech"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/emplosion/disable_tech
+	log_name = "DT"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/repulse
+	name = "Repulse"
+	spell_type = /obj/effect/proc_holder/spell/wizard/aoe_turf/repulse
+	log_name = "RP"
+
+/datum/spellbook_entry/smoke
+	name = "Smoke"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/smoke
+	log_name = "SM"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/blind
+	name = "Blind"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/trigger/blind
+	log_name = "BD"
+
+/datum/spellbook_entry/mindswap
+	name = "Mindswap"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/mind_transfer
+	log_name = "MT"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/forcewall
+	name = "Force Wall"
+	spell_type = /obj/effect/proc_holder/spell/wizard/aoe_turf/conjure/forcewall
+	log_name = "FW"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/blink
+	name = "Blink"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/turf_teleport/blink
+	log_name = "BL"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/teleport
+	name = "Teleport"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/area_teleport/teleport
+	log_name = "TP"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/mutate
+	name = "Mutate"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/genetic/mutate
+	log_name = "MU"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/jaunt
+	name = "Ethereal Jaunt"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/ethereal_jaunt
+	log_name = "EJ"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/knock
+	name = "Knock"
+	spell_type = /obj/effect/proc_holder/spell/wizard/aoe_turf/knock
+	log_name = "KN"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/horseman
+	name = "Curse of The Horseman"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/horsemask
+	log_name = "HH"
+
+/datum/spellbook_entry/fleshtostone
+	name = "Flesh to Stone"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/inflict_handler/flesh_to_stone
+	log_name = "FS"
+
+/datum/spellbook_entry/summonitem
+	name = "Summon Item"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/summonitem
+	log_name = "IS"
+	category = "Utility Spells"
+
+/datum/spellbook_entry/lightningbolt
+	name = "Lightning Bolt"
+	spell_type = /obj/effect/proc_holder/spell/wizard/targeted/lightning
+	log_name = "LB"
+
+/datum/spellbook_entry/item
+	name = "Buy Item"
+	category = "Artifacts"
+	refundable = 0
+	buy_word = "Summon"
+	var/item_path= null
+
+/datum/spellbook_entry/item/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	new item_path(get_turf(user))
+	feedback_add_details("wizard_spell_learned",log_name)
+	return 1
+
+/datum/spellbook_entry/item/GetInfo()
+	var/dat =""
+	dat += "<b>[name]</b>"
+	dat += " Cost:[cost]<br>"
+	dat += "<i>[desc]</i><br>"
+	if(surplus>=0)
+		dat += "[surplus] left.<br>"
+	return dat
+
+/datum/spellbook_entry/item/staffchange
+	name = "Staff of Change"
+	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
+	item_path = /obj/item/weapon/gun/magic/staff/change
+	log_name = "ST"
+
+/datum/spellbook_entry/item/staffanimation
+	name = "Staff of Animation"
+	desc = "An arcane staff capable of shooting bolts of eldritch energy which cause inanimate objects to come to life. This magic doesn't affect machines."
+	item_path = /obj/item/weapon/gun/magic/staff/animate
+	log_name = "SA"
+
+/datum/spellbook_entry/item/staffchaos
+	name = "Staff of Chaos"
+	desc = "A caprious tool that can fire all sorts of magic without any rhyme or reason. Using it on people you care about is not recommended."
+	item_path = /obj/item/weapon/gun/magic/staff/chaos
+	log_name = "SC"
+
+/datum/spellbook_entry/item/staffdoor
+	name = "Staff of Door Creation"
+	desc = "A particular staff that can mold solid metal into ornate wooden doors. Useful for getting around in the absence of other transportation. Does not work on glass."
+	item_path = /obj/item/weapon/gun/magic/staff/door
+	log_name = "SD"
+
+/datum/spellbook_entry/item/scryingorb
+	name = "Scrying Orb"
+	desc = "An incandescent orb of crackling energy, using it will allow you to ghost while alive, allowing you to spy upon the station with ease. In addition, buying it will permanently grant you x-ray vision."
+	item_path = /obj/item/weapon/scrying
+	log_name = "SO"
+
+/datum/spellbook_entry/item/scryingorb/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	if(..())
+		if (!(XRAY in user.mutations))
+			user.mutations.Add(XRAY)
+			user.sight |= (SEE_MOBS|SEE_OBJS|SEE_TURFS)
+			user.see_in_dark = 8
+			user.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+			user << "\blue The walls suddenly disappear."
+	return 1
+
+/datum/spellbook_entry/item/soulstones
+	name = "Six Soul Stone Shards and the spell Artificer"
+	desc = "Soul Stone Shards are ancient tools capable of capturing and harnessing the spirits of the dead and dying. The spell Artificer allows you to create arcane machines for the captured souls to pilot."
+	item_path = /obj/item/weapon/storage/belt/soulstone/full
+	log_name = "SS"
+
+/datum/spellbook_entry/item/soulstones/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	. =..()
+	if(.)
+		user.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/aoe_turf/conjure/construct(null))
+	return .
+
+/datum/spellbook_entry/item/wands
+	name = "Wand Assortment"
+	desc = "A collection of wands that allow for a wide variety of utility. Wands do not recharge, so be conservative in use. Comes in a handy belt."
+	item_path = /obj/item/weapon/storage/belt/wands/full
+	log_name = "WA"
+
+/datum/spellbook_entry/item/armor
+	name = "Mastercrafted Armor Set"
+	desc = "An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space."
+	item_path = /obj/item/clothing/suit/space/rig/wizard
+	log_name = "HS"
+
+/datum/spellbook_entry/item/armor/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	. = ..()
+	if(.)
+		new /obj/item/clothing/shoes/sandal(get_turf(user)) //In case they've lost them.
+		new /obj/item/clothing/gloves/color/purple(get_turf(user))//To complete the outfit
+		new /obj/item/clothing/head/helmet/space/rig/wizard(get_turf(user))
+
+/datum/spellbook_entry/item/contract
+	name = "Contract of Apprenticeship"
+	desc = "A magical contract binding an apprentice wizard to your service, using it will summon them to your side."
+	item_path = /obj/item/weapon/contract
+	log_name = "CT"
+
+/datum/spellbook_entry/summon
+	name = "Summon Stuff"
+	category = "Rituals"
+	refundable = 0
+	buy_word = "Cast"
+	var/active = 0
+
+/datum/spellbook_entry/summon/CanBuy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	return ..() && !active
+
+/datum/spellbook_entry/summon/GetInfo()
+	var/dat =""
+	dat += "<b>[name]</b>"
+	if(cost>0)
+		dat += " Cost:[cost]<br>"
+	else
+		dat += " No Cost<br>"
+	dat += "<i>[desc]</i><br>"
+	if(active)
+		dat += "<b>Already cast!</b><br>"
+	return dat
+
+/datum/spellbook_entry/summon/guns
+	name = "Summon Guns"
+	category = "Challenges"
+	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. Just be careful not to stand still too long!"
+	cost = 0
+	log_name = "SG"
+
+/datum/spellbook_entry/summon/guns/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	feedback_add_details("wizard_spell_learned",log_name)
+	user.rightandwrong(0)
+	book.uses += 1
+	active = 1
+	user << "<span class='notice'>You have cast summon guns and gained an extra charge for your spellbook.</span>"
+	return 1
+
+/datum/spellbook_entry/summon/magic
+	name = "Summon Magic"
+	category = "Challenges"
+	desc = "Share the wonders of magic with the crew and show them why they aren't to be trusted with it at the same time."
+	cost = 0
+	log_name = "SU"
+
+/datum/spellbook_entry/summon/magic/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
+	feedback_add_details("wizard_spell_learned",log_name)
+	user.rightandwrong(1)
+	book.uses += 1
+	active = 1
+	user << "<span class='notice'>You have cast summon magic and gained an extra charge for your spellbook.</span>"
+	return 1
+
 /obj/item/weapon/spellbook
 	name = "spell book"
 	desc = "The legendary book of spells of the wizard."
 	icon = 'icons/obj/library.dmi'
 	icon_state ="book"
-	throw_speed = 1
+	throw_speed = 2
 	throw_range = 5
 	w_class = 1.0
 	var/uses = 5
 	var/temp = null
-	var/max_uses = 5
 	var/op = 1
-	var/activepage
+	var/tab = null
+	var/mob/living/carbon/human/owner
+	var/list/datum/spellbook_entry/entries = list()
+	var/list/categories = list()
+
+/obj/item/weapon/spellbook/New()
+	..()
+	var/entry_types = typesof(/datum/spellbook_entry) - /datum/spellbook_entry - /datum/spellbook_entry/item - /datum/spellbook_entry/summon
+	for(var/T in entry_types)
+		var/datum/spellbook_entry/E = new T
+		if(E.IsAvailible())
+			entries |= E
+			categories |= E.category
+		else
+			del(E)
+	tab = categories[1]
 
 /obj/item/weapon/spellbook/attackby(obj/item/O as obj, mob/user as mob, params)
 	if(istype(O, /obj/item/weapon/contract))
 		var/obj/item/weapon/contract/contract = O
 		if(contract.used)
-			user << "The contract has been used, you can't get your points back now."
+			user << "<span class='warning'>The contract has been used, you can't get your points back now!</span>"
 		else
-			user << "You feed the contract back into the spellbook, refunding your points."
-			src.max_uses++
+			user << "<span class='notice'>You feed the contract back into the spellbook, refunding your points.</span>"
 			src.uses++
-			del (O)
+			qdel(O)
 
+/obj/item/weapon/spellbook/proc/GetCategoryHeader(var/category)
+	var/dat = ""
+	switch(category)
+		if("Offensive Spells")
+			dat += "Spells that can be reused endlessly.<BR>"
+			dat += "The number after the spell name is the cooldown time.<BR>"
+			dat += "You can reduce this number by spending more points on the spell.<BR>"
+		if("Utility Spells")
+			dat += "Spells that can be reused endlessly.<BR>"
+			dat += "The number after the spell name is the cooldown time.<BR>"
+			dat += "You can reduce this number by spending more points on the spell.<BR>"
+		if("Artifacts")
+			dat += "Powerful items imbued with eldritch magics. Summoning one will count towards your maximum number of uses.<BR>"
+			dat += "These items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
+		if("Challenges")
+			dat += "The Wizard Federation typically has hard limits on the potency and number of spells brought to the station based on risk.<BR>"
+			dat += "Arming the station against you will increases the risk, but will grant you one more charge for your spellbook.<BR>"
+		if("Rituals")
+			dat += "These powerful spells change the very fabric of reality. Not always in your favour.<BR>"
+	return dat
 
-
+/obj/item/weapon/spellbook/proc/wrap(var/content)
+	var/dat = ""
+	dat +="<html><head><title>Spellbook</title></head>"
+	dat += {"
+	<head>
+		<style type="text/css">
+      		body { font-size: 80%; font-family: 'Lucida Grande', Verdana, Arial, Sans-Serif; }
+      		ul#tabs { list-style-type: none; margin: 30px 0 0 0; padding: 0 0 0.3em 0; }
+      		ul#tabs li { display: inline; }
+      		ul#tabs li a { color: #42454a; background-color: #dedbde; border: 1px solid #c9c3ba; border-bottom: none; padding: 0.3em; text-decoration: none; }
+      		ul#tabs li a:hover { background-color: #f1f0ee; }
+      		ul#tabs li a.selected { color: #000; background-color: #f1f0ee; font-weight: bold; padding: 0.7em 0.3em 0.38em 0.3em; }
+      		div.tabContent { border: 1px solid #c9c3ba; padding: 0.5em; background-color: #f1f0ee; }
+      		div.tabContent.hide { display: none; }
+    	</style>
+  	</head>
+	"}
+	dat += {"[content]</body></html>"}
+	return dat
 
 /obj/item/weapon/spellbook/attack_self(mob/user as mob)
+	if(!owner)
+		user << "<span class='notice'>You bind the spellbook to yourself.</span>"
+		owner = user
+		return
+	if(user != owner)
+		user << "<span class='warning'>The [name] does not recognize you as it's owner and refuses to open!</span>"
+		return
 	user.set_machine(src)
-	var/dat
-	if(temp)
-		dat = "[temp]<BR><BR><A href='byond://?src=\ref[src];temp=1'>Clear</A>"
-	else if(!activepage || activepage == "return")
-		dat = "<B>The Book of Magic:</B><BR>"
-		dat += "Uses remaining: [uses]<BR>"
-		dat += "<HR>"
-		dat += "<A href='byond://?src=\ref[src];spell_choice=spells'>Learn and Improve Magical Abilities</A><BR>"
-		dat += "<A href='byond://?src=\ref[src];spell_choice=artifacts'>Summon Magical Tools and Weapons</A><BR>"
-		dat += "<A href='byond://?src=\ref[src];spell_choice=oneuse'>Cast Powerful One Time Spells</A><BR>"
+	var/dat = ""
 
-		dat += "<HR>"
-		dat += "<A href='byond://?src=\ref[src];spell_choice=rememorize'>Re-memorize Spells</A><BR>"
-	else if (activepage == "spells")
-		dat += "<B>Spells:</B><BR>"
-		dat += "Spells that can be reused endlessly. Unless stated otherwise all spells require full wizard garb as a focus.<BR>"
-		dat += "The number after the spell name is the cooldown time. You can reduce this number by spending more points on the spell.<BR>"
+	dat += "<ul id=\"tabs\">"
+	var/list/cat_dat = list()
+	for(var/category in categories)
+		cat_dat[category] = "<hr>"
+		dat += "<li><a [tab==category?"class=selected":""] href='byond://?src=\ref[src];page=[category]'>[category]</a></li>"
 
-		dat += "<HR>"
+	dat += "<li><a><b>Uses remaining : [uses]</b></a></li>"
+	dat += "</ul>"
 
-		dat += "<A href='byond://?src=\ref[src];spell_choice=noclothes'>Remove Clothes Requirement</A><BR>"
-		dat += "<b>Warning: this takes away 2 spell choices.</b><BR>"
+	var/datum/spellbook_entry/E
+	for(var/i=1,i<=entries.len,i++)
+		var/spell_info = ""
+		E = entries[i]
+		spell_info += E.GetInfo()
+		if(E.CanBuy(user,src))
+			spell_info+= "<a href='byond://?src=\ref[src];buy=[i]'>[E.buy_word]</A><br>"
+		else
+			spell_info+= "<span>Can't [E.buy_word]</span><br>"
+		if(E.CanRefund(user,src))
+			spell_info+= "<a href='byond://?src=\ref[src];refund=[i]'>Refund</A><br>"
+		spell_info += "<hr>"
+		if(cat_dat[E.category])
+			cat_dat[E.category] += spell_info
 
-		dat += "<A href='byond://?src=\ref[src];spell_choice=magicmissile'>Magic Missile</A> (15)<BR>"
-		dat += "<I>This spell fires several, slow moving, magic projectiles at nearby targets. If they hit a target, it is paralyzed and takes minor damage.</I><BR>"
+	for(var/category in categories)
+		dat += "<div class=\"[tab==category?"tabContent":"tabContent hide"]\" id=\"[category]\">"
+		dat += GetCategoryHeader(category)
+		dat += cat_dat[category]
+		dat += "</div>"
 
-		dat += "<A href='byond://?src=\ref[src];spell_choice=fireball'>Fireball</A> (10)<BR>"
-		dat += "<I>This spell fires a fireball in the direction you're facing and does not require wizard garb. Be careful not to fire it at people that are standing next to you.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=disintegrate'>Disintegrate</A> (60)<BR>"
-		dat += "<I>This spell instantly kills somebody adjacent to you with the vilest of magick. It has a long cooldown.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=disabletech'>Disable Technology</A> (60)<BR>"
-		dat += "<I>This spell disables all weapons, cameras and most other technology in range.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=smoke'>Smoke</A> (10)<BR>"
-		dat += "<I>This spell spawns a cloud of choking smoke at your location and does not require wizard garb.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=repulse'>Repulse</A> (40)<BR>"
-		dat += "<I>This spell throws nearby objects away from you and knocks creatures down.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=blind'>Blind</A> (30)<BR>"
-		dat += "<I>This spell temporarly blinds a single person and does not require wizard garb.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=mindswap'>Mind Transfer</A> (60)<BR>"
-		dat += "<I>This spell allows the user to switch bodies with a target. Careful to not lose your memory in the process.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=forcewall'>Forcewall</A> (10)<BR>"
-		dat += "<I>This spell creates an unbreakable wall that lasts for 30 seconds and does not need wizard garb.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=blink'>Blink</A> (2)<BR>"
-		dat += "<I>This spell randomly teleports you a short distance. Useful for evasion or getting into areas if you have patience.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=teleport'>Teleport</A> (60)<BR>"
-		dat += "<I>This spell teleports you to a type of area of your selection. Very useful if you are in danger, but has a decent cooldown, and is unpredictable.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=mutate'>Mutate</A> (60)<BR>"
-		dat += "<I>This spell causes you to turn into a hulk and gain telekinesis for a short while.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=etherealjaunt'>Ethereal Jaunt</A> (30)<BR>"
-		dat += "<I>This spell creates your ethereal form, temporarily making you invisible and able to pass through walls.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=knock'>Knock</A> (10)<BR>"
-		dat += "<I>This spell opens nearby doors and does not require wizard garb.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=horseman'>Curse of the Horseman</A> (15)<BR>"
-		dat += "<I>This spell will curse a person to wear an unremovable horse mask (it has glue on the inside) and speak like a horse. It does not require wizard garb.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=fleshtostone'>Flesh to Stone</A> (60)<BR>"
-		dat += "<I>This spell will curse a person to immediately turn into an unmoving statue. The effect will eventually wear off if the statue is not destroyed.</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=lightningbolt'>Lightning Bolt</A> (30)<BR>"
-		dat += "<I>Charge up and throw lightning bolt at the nearby enemy. Classic. The longer you charge the more powerful the spell, beware of overcharge however!</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=summonitem'>Instant Summons</A> (10)<BR>"
-		dat += "<I>This spell can be used to bind a valuable item to you, bringing it to your hand at will. Using this spell while holding the bound item will allow you to unbind it. It does not require wizard garb.</I><BR>"
-
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=return'><B>Return</B></A><BR>"
-
-	else if (activepage == "oneuse")
-		dat += "<B>One Time Spells:</B><BR>"
-		dat += "These potent spells can only be used once and will be used automatically upon purchase.<BR>"
-		dat += "The effects are global and irreversable, these spells cannot be unlearned, but they can be bought multiple times.<BR>"
-
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=summonguns'>Summon Guns</A> (One time use, global spell)<BR>"
-		dat += "<I>Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill eachother. Just be careful not to get hit in the crossfire!</I><BR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=summonmagic'>Summon Magic</A> (One time use, global spell)<BR>"
-		dat += "<I>Share the wonders of magic with the crew and show them why they aren't to be trusted with it at the same time.</I><BR>"
-
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=return'><B>Return</B></A><BR>"
-
-	else if (activepage == "artifacts")
-
-		dat += "<B>Artefacts:</B><BR>"
-		dat += "Powerful items imbued with eldritch magics. Summoning one will count towards your maximum number of uses.<BR>"
-		dat += "These items are not bound to you and can be stolen. Additionaly they cannot typically be returned once purchased.<BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=staffchange'>Staff of Change</A><BR>"
-		dat += "<I>An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=soulstone'>Six Soul Stone Shards and the spell Artificer</A><BR>"
-		dat += "<I>Soul Stone Shards are ancient tools capable of capturing and harnessing the spirits of the dead and dying. The spell Artificer allows you to create arcane machines for the captured souls to pilot.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=staffanimation'>Staff of Animation</A><BR>"
-		dat += "<I>An arcane staff capable of shooting bolts of eldritch energy which cause inanimate objects to come to life. This magic doesn't affect machines.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=staffdoor'>Staff of Door Creation</A><BR>"
-		dat += "<I>A particular staff that can mold solid metal into ornate wooden doors. Useful for getting around in the absence of other transportation. Does not work on glass.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=staffchaos'>Staff of Chaos</A><BR>"
-		dat += "<I>A caprious tool that can fire all sorts of magic without any rhyme or reason. Using it on people you care about is not recommended.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=wands'>Wand Assortment</A><BR>"
-		dat += "<I>A collection of wands that allow for a wide variety of utility. Wands do not recharge, so be conservative in use. Comes in a handy belt.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=armor'>Mastercrafted Armor Set</A><BR>"
-		dat += "<I>An artefact suit of armor that allows you to cast spells while providing more protection against attacks and the void of space.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=contract'>Contract of Apprenticeship</A><BR>"
-		dat += "<I>A magical contract binding an apprentice wizard to your service, using it will summon them to your side.</I><BR>"
-		dat += "<HR>"
-
-		dat += "<A href='byond://?src=\ref[src];spell_choice=scrying'>Scrying Orb</A><BR>"
-		dat += "<I>An incandescent orb of crackling energy, using it will allow you to ghost while alive, allowing you to spy upon the station with ease. In addition, buying it will permanently grant you x-ray vision.</I><BR>"
-
-		dat += "<HR>"
-		dat += "<A href='byond://?src=\ref[src];spell_choice=return'><B>Return</B></A><BR>"
-	user << browse(dat, "window=radio")
-	onclose(user, "radio")
+	user << browse(wrap(dat), "window=spellbook;size=600x300")
+	onclose(user, "spellbook")
 	return
 
 /obj/item/weapon/spellbook/Topic(href, href_list)
@@ -187,207 +485,23 @@
 		temp = "If you got caught sneaking a peak from your teacher's spellbook, you'd likely be expelled from the Wizard Academy. Better not."
 		return
 
+	var/datum/spellbook_entry/E = null
 	if(loc == H || (in_range(src, H) && istype(loc, /turf)))
 		H.set_machine(src)
-		if(href_list["spell_choice"])
-			if(href_list["spell_choice"] == "rememorize")
-				var/area/wizard_station/A = locate()
-				if(usr in A.contents)
-					uses = max_uses
-					H.spellremove(usr,0)
-					temp = "All spells have been removed. You may now memorize a new set of spells."
-					feedback_add_details("wizard_spell_learned","UM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-				else
-					temp = "You may only re-memorize spells whilst located inside the wizard sanctuary."
-			else if(href_list["spell_choice"] == "spells" || href_list["spell_choice"] == "artifacts" || href_list["spell_choice"] == "oneuse" || href_list["spell_choice"] == "return")
-				activepage = href_list["spell_choice"]
-			else if(uses >= 1 && max_uses >=1)
-				uses--
-			/*
-			*/
-				var/list/available_spells = list(magicmissile = "Magic Missile", fireball = "Fireball", disintegrate = "Disintegrate", disabletech = "Disable Tech", repulse = "Repulse", smoke = "Smoke", blind = "Blind", mindswap = "Mind Transfer", forcewall = "Forcewall", blink = "Blink", teleport = "Teleport", mutate = "Mutate", etherealjaunt = "Ethereal Jaunt", knock = "Knock", horseman = "Curse of the Horseman", fleshtostone = "Flesh to Stone", lightningbolt = "Lightning Bolt", summonitem = "Instant Summons", summonguns = "Summon Guns", summonmagic = "Summon Magic", staffchange = "Staff of Change", soulstone = "Six Soul Stone Shards and the spell Artificer", armor = "Mastercrafted Armor Set", staffanimate = "Staff of Animation", staffchaos = "Staff of Chaos", staffdoor = "Staff of Door Creation", wands = "Wand Assortment")
-				var/already_knows = 0
-				for(var/obj/effect/proc_holder/spell/wizard/aspell in H.spell_list)
-					if(available_spells[href_list["spell_choice"]] == initial(aspell.name))
-						already_knows = 1
-						if(aspell.spell_level >= aspell.level_max)
-							temp = "This spell cannot be improved further."
-							uses++
-							break
-						else
-							aspell.name = initial(aspell.name)
-							aspell.spell_level++
-							aspell.charge_max = round(initial(aspell.charge_max) - aspell.spell_level * (initial(aspell.charge_max) - aspell.cooldown_min)/ aspell.level_max)
-							if(aspell.charge_max < aspell.charge_counter)
-								aspell.charge_counter = aspell.charge_max
-							switch(aspell.spell_level)
-								if(1)
-									temp = "You have improved [aspell.name] into Efficient [aspell.name]."
-									aspell.name = "Efficient [aspell.name]"
-								if(2)
-									temp = "You have further improved [aspell.name] into Quickened [aspell.name]."
-									aspell.name = "Quickened [aspell.name]"
-								if(3)
-									temp = "You have further improved [aspell.name] into Free [aspell.name]."
-									aspell.name = "Free [aspell.name]"
-								if(4)
-									temp = "You have further improved [aspell.name] into Instant [aspell.name]."
-									aspell.name = "Instant [aspell.name]"
-							if(aspell.spell_level >= aspell.level_max)
-								temp += " This spell cannot be strengthened any further."
-			/*
-			*/
-				if(!already_knows)
-					switch(href_list["spell_choice"])
-						if("noclothes")
-							feedback_add_details("wizard_spell_learned","NC")
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/noclothes)
-							temp = "This teaches you how to use your spells without your magical garb, truely you are the wizardest."
-							uses--
-						if("magicmissile")
-							feedback_add_details("wizard_spell_learned","MM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/projectile/magic_missile(H))
-							temp = "You have learned magic missile."
-						if("fireball")
-							feedback_add_details("wizard_spell_learned","FB") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/dumbfire/fireball(H))
-							temp = "You have learned fireball."
-						if("disintegrate")
-							feedback_add_details("wizard_spell_learned","DG") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/inflict_handler/disintegrate(H))
-							temp = "You have learned disintegrate."
-						if("disabletech")
-							feedback_add_details("wizard_spell_learned","DT") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/emplosion/disable_tech(H))
-							temp = "You have learned disable technology."
-						if("repulse")
-							feedback_add_details("wizard_spell_learned","RP") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/aoe_turf/repulse(null))
-							temp = "You have learned repulse."
-						if("smoke")
-							feedback_add_details("wizard_spell_learned","SM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/smoke(H))
-							temp = "You have learned smoke."
-						if("blind")
-							feedback_add_details("wizard_spell_learned","BD") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/trigger/blind(H))
-							temp = "You have learned blind."
-						if("mindswap")
-							feedback_add_details("wizard_spell_learned","MT") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/mind_transfer(H))
-							temp = "You have learned mindswap."
-						if("forcewall")
-							feedback_add_details("wizard_spell_learned","FW") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/aoe_turf/conjure/forcewall(H))
-							temp = "You have learned forcewall."
-						if("blink")
-							feedback_add_details("wizard_spell_learned","BL") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/turf_teleport/blink(H))
-							temp = "You have learned blink."
-						if("teleport")
-							feedback_add_details("wizard_spell_learned","TP") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/area_teleport/teleport(H))
-							temp = "You have learned teleport."
-						if("mutate")
-							feedback_add_details("wizard_spell_learned","MU") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/genetic/mutate(H))
-							temp = "You have learned mutate."
-						if("etherealjaunt")
-							feedback_add_details("wizard_spell_learned","EJ") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/ethereal_jaunt(H))
-							temp = "You have learned ethereal jaunt."
-						if("knock")
-							feedback_add_details("wizard_spell_learned","KN") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/aoe_turf/knock(H))
-							temp = "You have learned knock."
-						if("horseman")
-							feedback_add_details("wizard_spell_learned","HH") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/horsemask(H))
-							temp = "You have learned curse of the horseman."
-						if("fleshtostone")
-							feedback_add_details("wizard_spell_learned","FS") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/inflict_handler/flesh_to_stone(H))
-							temp = "You have learned flesh to stone."
-						if("lightningbolt")
-							feedback_add_details("wizard_spell_learned","LB") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/lightning(null))
-							temp = "You have learned lightning bolt."
-						if("summonitem")
-							feedback_add_details("wizard_spell_learned","IS") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/targeted/summonitem(null))
-							temp = "You have learned instant summons."
-						if("summonguns")
-							feedback_add_details("wizard_spell_learned","SG") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.rightandwrong(0)
-							max_uses--
-							temp = "You have cast summon guns."
-						if("summonmagic")
-							feedback_add_details("wizard_spell_learned","SM") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							H.rightandwrong(1)
-							max_uses--
-							temp = "You have cast summon magic."
-						if("staffchange")
-							feedback_add_details("wizard_spell_learned","ST") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/gun/magic/staff/change(get_turf(H))
-							temp = "You have purchased a staff of change."
-							max_uses--
-						if("soulstone")
-							feedback_add_details("wizard_spell_learned","SS") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/storage/belt/soulstone/full(get_turf(H))
-							H.mind.AddSpell(new /obj/effect/proc_holder/spell/wizard/aoe_turf/conjure/construct(H))
-							temp = "You have purchased a belt full of soulstones and have learned the artificer spell."
-							max_uses--
-						if("armor")
-							feedback_add_details("wizard_spell_learned","HS") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/clothing/shoes/sandal(get_turf(H)) //In case they've lost them.
-							new /obj/item/clothing/gloves/color/purple(get_turf(H))//To complete the outfit
-							new /obj/item/clothing/suit/space/rig/wizard(get_turf(H))
-							new /obj/item/clothing/head/helmet/space/rig/wizard(get_turf(H))
-							temp = "You have purchased a suit of wizard armor."
-							max_uses--
-						if("staffanimation")
-							feedback_add_details("wizard_spell_learned","SA") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/gun/magic/staff/animate(get_turf(H))
-							temp = "You have purchased a staff of animation."
-							max_uses--
-						if("staffchaos")
-							feedback_add_details("wizard_spell_learned","SC") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/gun/magic/staff/chaos(get_turf(H))
-							temp = "You have purchased a staff of chaos."
-							max_uses--
-						if("staffdoor")
-							feedback_add_details("wizard_spell_learned","SD") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/gun/magic/staff/door(get_turf(H))
-							temp = "You have purchased a staff of door creation."
-							max_uses--
-						if("wands")
-							feedback_add_details("wizard_spell_learned","WA") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/storage/belt/wands/full(get_turf(H))
-							temp = "You have purchased an assortment of wands."
-							max_uses--
-						if("contract")
-							feedback_add_details("wizard_spell_learned","CT") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/contract(get_turf(H))
-							temp = "You have purchased a contract of apprenticeship."
-							max_uses--
-						if("scrying")
-							feedback_add_details("wizard_spell_learned","SO") //please do not change the abbreviation to keep data processing consistent. Add a unique id to any new spells
-							new /obj/item/weapon/scrying(get_turf(H))
-							if (!(XRAY in H.mutations))
-								H.mutations.Add(XRAY)
-								H.sight |= (SEE_MOBS|SEE_OBJS|SEE_TURFS)
-								H.see_in_dark = 8
-								H.see_invisible = SEE_INVISIBLE_LEVEL_TWO
-								H << "\blue The walls suddenly disappear."
-							temp = "You have purchased a scrying orb, and gained x-ray vision."
-							max_uses--
-
-		else
-			if(href_list["temp"])
-				temp = null
-				activepage = null
-		attack_self(H)
-
+		if(href_list["buy"])
+			E = entries[text2num(href_list["buy"])]
+			if(E && E.CanBuy(H,src))
+				if(E.Buy(H,src))
+					uses -= E.cost
+		else if(href_list["refund"])
+			E = entries[text2num(href_list["refund"])]
+			if(E && E.refundable)
+				var/result = E.Refund(H,src)
+				if(result > 0)
+					uses += result
+		else if(href_list["page"])
+			tab = href_list["page"]
+	attack_self(H)
 	return
 
 //Single Use Spellbooks//
@@ -398,7 +512,6 @@
 	var/used = 0
 	name = "spellbook of "
 	uses = 1
-	max_uses = 1
 	desc = "This template spellbook was never meant for the eyes of man..."
 
 /obj/item/weapon/spellbook/oneuse/New()

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -500,7 +500,7 @@
 				if(result > 0)
 					uses += result
 		else if(href_list["page"])
-			tab = href_list["page"]
+			tab = sanitize(href_list["page"])
 	attack_self(H)
 	return
 


### PR DESCRIPTION
tgstation/-tg-station#9537
Contains Commits:
 - Spellbook Refactor <AnturK/-tg-station@6380f67>
 - Splits the Spells into Offensive/Utility <AnturK/-tg-station@25ba9fb>

More or less a complete overhaul of the spellbook to a datum based system.
Current image: ![blarhgehtr](https://cloud.githubusercontent.com/assets/4047233/7668128/452a2bbe-fc28-11e4-9ccb-c1f96f552cf3.png)