### PR TITLE
Fixes - The Beach, Zipties, Matches, and Teleporting Artifacts

### DIFF
--- a/_maps/map_files/RandomZLevels/fileList.txt
+++ b/_maps/map_files/RandomZLevels/fileList.txt
@@ -7,9 +7,9 @@
 #Do NOT tick the maps during compile -- the game uses this list to decide which map to load. Ticking the maps will result in them ALL being loaded at once.
 #DO tick the associated code file for the away mission you are enabling. Otherwise, the map will be trying to reference objects which do not exist, which will cause runtime errors!
 
-#_maps/map_files/map_files/RandomZLevels/academy.dmm
-_maps/map_files/map_files/RandomZLevels/beach.dmm
-#_maps/map_files/map_files/RandomZLevels/blackmarketpackers.dmm
+#_maps/map_files/RandomZLevels/academy.dmm
+_maps/map_files/RandomZLevels/beach.dmm
+#_maps/map_files/RandomZLevels/blackmarketpackers.dmm
 _maps/map_files/RandomZLevels/challenge.dmm
 #_maps/map_files/RandomZLevels/centcomAway.dmm
 #_maps/map_files/RandomZLevels/clownplanet.dmm

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -158,6 +158,10 @@ var/last_chew = 0
 			else
 				user << "<span class='warning'>You fail to handcuff [C].</span>"
 
+/obj/item/weapon/restraints/handcuffs/cable/zipties/used
+	desc = "A pair of broken zipties."
+	icon_state = "cuff_white_used"
+
 /obj/item/weapon/restraints/handcuffs/cable/zipties/used/attack()
 	return
 

--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -193,4 +193,21 @@
 		item_state = "cigoff"
 		name = "burnt match"
 		desc = "A match. This one has seen better days."
+		processing_objects.Remove(src)
 	return ..()
+
+/obj/item/weapon/match/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if(!isliving(M))
+		return ..()
+	if(lit == 1) M.IgniteMob()
+	if(!istype(M, /mob))
+		return ..()
+
+	if(istype(M.wear_mask, /obj/item/clothing/mask/cigarette) && user.zone_sel.selecting == "mouth" && lit == 1)
+		var/obj/item/clothing/mask/cigarette/cig = M.wear_mask
+		if(M == user)
+			cig.attackby(src, user)
+		else
+			cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights the [cig.name].</span>")
+	else
+		..()

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
@@ -14,7 +14,7 @@
 		sparks.set_up(3, 0, get_turf(user))
 		sparks.start()
 		//
-		user.loc = pick(orange(get_turf(holder), 50))
+		user.forceMove(pick(trange(50, get_turf(holder))))
 		sparks = new /datum/effect/effect/system/spark_spread()
 		sparks.set_up(3, 0, get_turf(user))
 		sparks.start()
@@ -33,7 +33,7 @@
 				sparks.set_up(3, 0, get_turf(M))
 				sparks.start()
 				//
-				M.loc = pick(orange(get_turf(T), 50))
+				M.forceMove(pick(trange(50, T)))
 				sparks = new /datum/effect/effect/system/spark_spread()
 				sparks.set_up(3, 0, get_turf(M))
 				sparks.start()
@@ -52,7 +52,7 @@
 				sparks.set_up(3, 0, get_turf(M))
 				sparks.start()
 				//
-				M.loc = pick(orange(get_turf(T), 50))
+				M.forceMove(pick(trange(50, T)))
 				sparks = new /datum/effect/effect/system/spark_spread()
 				sparks.set_up(3, 0, get_turf(M))
 				sparks.start()


### PR DESCRIPTION
* Fixes some typos in the mission map list, which were preventing the Beach away mission from loading.
* Fixes zipties not having the proper icon and description when broken.
* Fixes matches lacking a custom attack proc (responsible for igniting and lighting cigarettes for other people) and processing (and generating hotspots) after being dropped.
* Fixes the Teleport artifact effect frequently inserting you into atoms instead of moving you to different turfs.