### PR TITLE
REFIXOR: Turf Gas Visuals

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -94,10 +94,14 @@ var/list/wood_icons = list("wood","wood-broken")
 /turf/simulated/floor/blob_act()
 	return
 
-turf/simulated/floor/proc/update_icon()
+/turf/simulated/floor/proc/update_icon()
 	if(lava)
 		return
-	else if(is_plasteel_floor())
+
+	if(air)
+		update_visuals(air)
+
+	if(is_plasteel_floor())
 		if(!broken && !burnt)
 			icon_state = icon_regular_floor
 	else if(is_plating())
@@ -175,10 +179,7 @@ turf/simulated/floor/proc/update_icon()
 			if( !(icon_state in wood_icons) )
 				icon_state = "wood"
 				//world << "[icon_state]y's got [icon_state]"
-	/*spawn(1)
-		if(istype(src,/turf/simulated/floor)) //Was throwing runtime errors due to a chance of it changing to space halfway through.
-			if(air)
-				update_visuals(air)*/
+
 
 /turf/simulated/floor/return_siding_icon_state()
 	..()

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -51,6 +51,11 @@
 	thermal_conductivity = 0.025
 	heat_capacity = 325000
 
+/turf/simulated/floor/engine/New()
+	..()
+	spawn(20) //engine floors tend to have gas on them
+		update_icon()
+
 /turf/simulated/floor/engine/break_tile()
 	return //unbreakable
 


### PR DESCRIPTION
This commit does the following:
 - Adds a missed call to simulated/update_icon() to update the atmos
   visuals
 - Fixes plasma not showing up on engine floors on New()