### PR TITLE
Virus Tweaks

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -918,7 +918,7 @@ var/list/slot_equipment_priority = list( \
 	if(mind && istype(src, /mob/living) && mind.spell_list && mind.spell_list.len)
 		for(var/obj/effect/proc_holder/spell/wizard/S in mind.spell_list)
 			add_spell_to_statpanel(S)
-			
+
 
 	if(client && client.holder)
 
@@ -1467,6 +1467,15 @@ mob/proc/yank_out_object()
 		else
 			src.visible_message("<span class='warning'>[src] pukes all over \himself!</span>","<span class='warning'>You puke all over yourself!</span>")
 			location.add_vomit_floor(src, 1)
+		playsound(location, 'sound/effects/splat.ogg', 50, 1)
+
+/mob/proc/fakepoop() //for aesthetic craps. Whyyyyy -Fox
+	if(stat==DEAD)
+		return
+	var/turf/location = loc
+	if (istype(location, /turf/simulated))
+		src.visible_message("<span class='warning'>[src] has explosive diarrhea all over the floor!</span>","<span class='warning'>You have explosive diarrhea all over the floor!</span>")
+		location.add_poop_floor()
 		playsound(location, 'sound/effects/splat.ogg', 50, 1)
 
 /mob/proc/AddSpell(var/obj/effect/proc_holder/spell/spell)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1381,19 +1381,31 @@ datum
 				return
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
-/*
-		nanites
+
+		nanomachines
 			name = "Nanomachines"
-			id = "nanites"
+			id = "nanomachines"
 			description = "Microscopic construction robots."
 			reagent_state = LIQUID
 			color = "#535E66" // rgb: 83, 94, 102
 
-			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
-				src = null
-				if( (prob(10) && method==TOUCH) || method==INGEST)
-					M.contract_disease(new /datum/disease/robotic_transformation(0),1)
+			on_mob_life(var/mob/living/M as mob)
+				var/datum/disease2/disease/borg = new /datum/disease2/disease
+				var/datum/disease2/effectholder/holder = new /datum/disease2/effectholder
+				var/datum/disease2/effect/borg/O = new /datum/disease2/effect/borg
+				holder.effect += O
+				holder.chance = 10
+				borg.infectionchance = 100
+				borg.antigen |= text2num(pick(ANTIGENS))
+				borg.spreadtype = "None"
+				borg.uniqueID = 1337
+				borg.effects += holder
+				borg.speed = 1
+				borg.stage = 2
+				borg.clicks = 185
+				infect_virus2(M,borg,0)
 
+/*
 		xenomicrobes
 			name = "Xenomicrobes"
 			id = "xenomicrobes"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -928,8 +928,7 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		if(prob(5))
-			reagents.add_reagent("nanites", 2)
+		reagents.add_reagent("nanomachines", 5)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/roburgerbig

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -275,4 +275,4 @@
 
 	New()
 		..()
-		reagents.add_reagent(pick("polonium","initropidril","concentrated_initro","pancuronium","sodium_thiopental","ketamine","sulfonal","amanitin","coniine","curare","sarin","histamine","venom","cyanide"), 40)
+		reagents.add_reagent(pick("polonium","initropidril","concentrated_initro","pancuronium","sodium_thiopental","ketamine","sulfonal","amanitin","coniine","curare","sarin","histamine","venom","cyanide", "nanomachines"), 40)

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -110,12 +110,13 @@
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob << "\red You feel like booping and beeping."
 		if(prob(50))
+			var/location = get_turf(mob.loc)
 			if(mob.client)
-				mob.client.mob = new/mob/living/silicon/robot(mob.loc)
+				mob.client.mob = new/mob/living/silicon/robot(location)
 			else
-				new/mob/living/silicon/robot(mob.loc)
-			var/datum/disease2/disease/D = mob:virus2
-			mob:gib()
+				new/mob/living/silicon/robot(location)
+			var/datum/disease2/disease/D = mob.virus2
+			mob.gib()
 			del D
 
 /datum/disease2/effect/omnizine

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -107,6 +107,7 @@
 /datum/disease2/effect/borg
 	name = "Borgification Disorder"
 	stage = 4
+	badness = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob << "\red You feel like booping and beeping."
 		if(prob(50))

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -844,13 +844,6 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 	activate(var/mob/living/carbon/mob,var/multiplier)
 		mob.fakevomit()
 
-
-/datum/disease2/effect/goon
-	name = "Goon Syndrome"
-	stage = 1
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.say("*fart")
-
 /datum/disease2/effect/pain_minor
 	name = "Heightened Sensitivity"
 	stage = 1

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -389,7 +389,7 @@
 		if (mob.reagents.get_reagent_amount("mannitol") < 10)
 			mob.reagents.add_reagent("mannitol", 10)
 
-/datum/disease2/effect/paroxetine
+/datum/disease2/effect/haloperidol
 	name = "Psyche Collapse Syndrome"
 	stage = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
@@ -765,7 +765,7 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 	name = "Adrenal Overload"
 	stage = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.reagents.get_reagent_amount("methamphetamine") < 15)
+		if (mob.reagents.get_reagent_amount("methamphetamine") < 5)
 			mob.reagents.add_reagent("methamphetamine", 4)
 		if (prob(30))
 			mob << "<span class='notice'>You feel a rush of energy inside you!</span>"

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -104,12 +104,26 @@
 
 ////////////////////////STAGE 4/////////////////////////////////
 
+/datum/disease2/effect/borg
+	name = "Borgification Disorder"
+	stage = 4
+	activate(var/mob/living/carbon/mob,var/multiplier)
+		mob << "\red You feel like booping and beeping."
+		if(prob(50))
+			if(mob.client)
+				mob.client.mob = new/mob/living/silicon/robot(mob.loc)
+			else
+				new/mob/living/silicon/robot(mob.loc)
+			var/datum/disease2/disease/D = mob:virus2
+			mob:gib()
+			del D
+
 /datum/disease2/effect/omnizine
 	name = "Panacea Effect"
 	stage = 4
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.reagents.get_reagent_amount("omnizine") < 1)
-			mob.reagents.add_reagent("omnizine", 1)
+		if (mob.reagents.get_reagent_amount("omnizine") < 2)
+			mob.reagents.add_reagent("omnizine", 2)
 
 /datum/disease2/effect/viralsputum_major
 	name = "Hemoptysis"
@@ -250,14 +264,6 @@
 		var/heal_amt = -5*multiplier
 		mob.apply_damages(heal_amt,heal_amt,heal_amt,heal_amt)
 
-	deactivate(var/mob/living/carbon/mob,var/multiplier)
-		if(istype(mob, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = mob
-			H << "<span class='notice'>You suddenly feel hurt and old...</span>"
-			H.age += 8
-		var/backlash_amt = 5*multiplier
-		mob.apply_damages(backlash_amt,backlash_amt,backlash_amt,backlash_amt)
-
 /datum/disease2/effect/gmagnitis
 	name = "Greater Magnitis"
 	stage = 4
@@ -350,47 +356,6 @@
 						return
 
 
-/datum/disease2/effect/fizzle
-	name = "Fizzle Effect"
-	stage = 4
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob.emote("me",1,pick("sniffles...", "clears their throat..."))
-
-/* commented out for now, fuck spiders
-/datum/disease2/effect/spider
-	name = "Arachnogenesis Effect"
-	stage = 4
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		//var/mob/living/carbon/human/H = mob
-		var/placemob = locate(mob.x + pick(1,-1), mob.y, mob.z)
-		playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
-		new /obj/effect/spider/spiderling(placemob)
-		mob.emote("me",1,"vomits up a live spider!")
-
-*/
-
-/*
-/datum/disease2/effect/orbweapon         //peopel are just griefing the shit out of each other with this..and with a constantly regenerating weapon that has a throwforce of 30? I can see why.
-	name = "Biolobulin Effect"
-	stage = 4
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		var/obj/item/toy/snappop/virus = new /obj/item/toy/snappop/virus
-		mob.equip_to_slot(virus, slot_l_hand)
-
-
-
-/obj/item/clothing/mask/gas/virusclown_hat
-
-	dropped(mob/user as mob)
-		flags &= ~NODROP
-		..()
-
-	equipped(var/mob/user, var/slot)
-		if (slot == slot_l_hand)
-			flags &= ~NODROP		//curses!
-		..()
-*/
-
 /datum/disease2/effect/plasma
 	name = "Toxin Sublimation"
 	stage = 4
@@ -419,15 +384,15 @@
 	name = "Regenerative Synapse Effect"
 	stage = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.reagents.get_reagent_amount("mannitol") < 1)
-			mob.reagents.add_reagent("mannitol", 1)
+		if (mob.reagents.get_reagent_amount("mannitol") < 10)
+			mob.reagents.add_reagent("mannitol", 10)
 
 /datum/disease2/effect/paroxetine
 	name = "Psyche Collapse Syndrome"
 	stage = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.reagents.get_reagent_amount("paroxetine") < 10)
-			mob.reagents.add_reagent("paroxetine", 1)
+		if (mob.reagents.get_reagent_amount("haloperidol") < 10)
+			mob.reagents.add_reagent("haloperidol", 1)
 
 /datum/disease2/effect/pain_major
 	name = "Phantom Pain Syndrome"
@@ -798,7 +763,7 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 	name = "Adrenal Overload"
 	stage = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.reagents.get_reagent_amount("methamphetamine") < 40)
+		if (mob.reagents.get_reagent_amount("methamphetamine") < 15)
 			mob.reagents.add_reagent("methamphetamine", 4)
 		if (prob(30))
 			mob << "<span class='notice'>You feel a rush of energy inside you!</span>"
@@ -822,7 +787,6 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 			mob.overeatduration = 1000
 
 
-
 /datum/disease2/effect/beard
 	name = "Bearding"
 	stage = 2
@@ -834,21 +798,6 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 				spawn(50)
 					H.f_style = "Full Beard"
 					H.update_hair()
-
-
-/datum/disease2/effect/poop
-	name = "Uncontrollable Bowel Syndrome"
-	stage = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		if  (prob(70))  // Bone White - Lessened the chance for actually shitting yourself.
-			mob << "<span class='notice'>[pick("Your stomach rumbles strangely.", "You feel like you're going shit your pants any second now!")]</span>"
-		else
-			mob.visible_message("<B>[mob]</B> has explosive diarrhea all over the floor!")
-			mob.nutrition -= 20
-			mob.adjustToxLoss(-3)
-			var/obj/effect/decal/cleanable/poop/P = new(get_turf(mob))
-			P.virus2 = virus_copylist(mob.virus2)
-			playsound(P.loc, 'sound/effects/splat.ogg', 50, 1)
 
 /datum/disease2/effect/bloodynose
 	name = "Intranasal Hemorrhage"
@@ -881,6 +830,25 @@ var/list/compatible_mobs = list(/mob/living/carbon/human, /mob/living/carbon/mon
 
 ////////////////////////STAGE 1/////////////////////////////////
 
+/datum/disease2/effect/poop
+	name = "Uncontrollable Bowel Syndrome"
+	stage = 1
+	activate(var/mob/living/carbon/mob,var/multiplier)
+		mob.fakepoop()
+
+
+/datum/disease2/effect/vomit
+	name = "Projectile Vomit Syndrome"
+	stage = 1
+	activate(var/mob/living/carbon/mob,var/multiplier)
+		mob.fakevomit()
+
+
+/datum/disease2/effect/goon
+	name = "Goon Syndrome"
+	stage = 1
+	activate(var/mob/living/carbon/mob,var/multiplier)
+		mob.say("*fart")
 
 /datum/disease2/effect/pain_minor
 	name = "Heightened Sensitivity"


### PR DESCRIPTION
Virus code is horrible and terrible (COLONS) and no I'm not going to fix it myself except for leaving this here: *scream


Adds a number of new virus symptoms
- Projectile vomit: vomiting
- Borgification Disorder: turns you into a borg

Additions
- Utilized Virus2 to best recreate the old borgification diseas tied to the disease-reagent "Nanomachines"

Changes
- Poop symptom is now handled by a proc. Pooping no longer lowers nutrition and it doesn't contain viruses held by the host anymore. Given this change, it's purely an aesthetic symptom now (and thus has been move down to a stage 1 symptom).
- Longevity no longer deals a ton of damage when it deactivates.
- Removed fizzle effect (kinda already covered with the invisible symptom stage 4)
- Removed some unused virus symptoms

Other semi-related
- Added nanomachines as a potentially selected reagent for traitor poison bottles.

Fixes
- Made some adjustments to various effects/symptoms so they're not so lethal (by accident) or are actually effective (or in one case, adds a reagent that doesn't exist).
