### PR TITLE
Botany Atmospheric Interactions

### DIFF
--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -1236,6 +1236,7 @@
 	seed_name = "test"
 	display_name = "test trees"
 	chems = list("omnizine" = list(1,20))
+	consume_gasses = list("oxygen" = 5)
 
 /datum/seed/test/New()
 	..()
@@ -1249,3 +1250,20 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#BB6AC4")
 	set_trait(TRAIT_PLANT_ICON,"tree")
 	set_trait(TRAIT_EXPLOSIVE, 1)
+
+/datum/seed/test2
+	name = "test2"
+	seed_name = "test2"
+	display_name = "test2 trees"
+	exude_gasses = list("toxins" = 5)
+
+/datum/seed/test2/New()
+	..()
+	set_trait(TRAIT_HARVEST_REPEAT,1)
+	set_trait(TRAIT_MATURATION,1)
+	set_trait(TRAIT_PRODUCTION,1)
+	set_trait(TRAIT_YIELD,4)
+	set_trait(TRAIT_POTENCY,15)
+	set_trait(TRAIT_PRODUCT_ICON,"treefruit")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#BB6AC4")
+	set_trait(TRAIT_PLANT_ICON,"tree")

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -287,6 +287,9 @@ var/global/list/plant_seed_sprites = list()
 /obj/item/seeds/test
 	seed_type = "test"
 
+/obj/item/seeds/test2
+	seed_type = "test2"
+
 /obj/item/seeds/stobaccoseed
 	seed_type = "stobacco"
 

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -45,7 +45,7 @@
 	// Handle life.
 	var/turf/simulated/T = get_turf(src)
 	if(istype(T))
-		health -= seed.handle_environment(T,T.return_air(),null,1)
+		health -= seed.handle_environment(T,T.return_air(),null,null,1)
 	if(health < max_health)
 		health += rand(3,5)
 		refresh_icon()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -740,6 +740,16 @@
 			A.icon_state = src.icon_state
 			A.hydrotray_type = src.type
 			del(src)
+	else if ((istype(O, /obj/item/weapon/tank) && !( src.destroyed )))
+		if (src.holding)
+			user << "\blue There is alreadu a tank loaded into the [src]."
+			return
+		var/obj/item/weapon/tank/T = O
+		user.drop_item()
+		T.loc = src
+		src.holding = T
+		update_icon()
+		return
 	else if(O && O.force && seed)
 		user.visible_message("<span class='danger'>\The [seed.display_name] has been attacked by [user] with \the [O]!</span>")
 		if(!dead)

--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -62,6 +62,8 @@
 	var/datum/gas_mixture/environment
 	// If we're closed, take from our internal sources.
 	if(closed_system && (connected_port || holding))
+		if(holding)
+			air_contents = holding.air_contents
 		environment = air_contents
 	// If atmos input is not there, grab from turf.
 	if(!environment && istype(T)) environment = T.return_air()
@@ -69,9 +71,11 @@
 
 	// Seed datum handles gasses, light and pressure.
 	if(mechanical && closed_system)
-		health -= seed.handle_environment(T,environment,tray_light)
+		health -= seed.handle_environment(T,environment,tray_light, holding)
 	else
 		health -= seed.handle_environment(T,environment)
+
+	T.air_update_turf()
 
 	// If we're attached to a pipenet, then we should let the pipenet know we might have modified some gasses
 	if (closed_system && connected_port)

--- a/code/modules/hydroponics/trays/tray_tools.dm
+++ b/code/modules/hydroponics/trays/tray_tools.dm
@@ -166,6 +166,18 @@
 
 	dat += "It thrives in a temperature of [grown_seed.get_trait(TRAIT_IDEAL_HEAT)] Kelvin."
 
+	if(grown_seed.consume_gasses && grown_seed.consume_gasses.len)
+		for(var/gas in grown_seed.consume_gasses)
+			if(gas == "carbon_dioxide")	gas = "carbon dioxide"
+			if(gas == "toxins")	gas = "plasma"
+			dat += "<br>It requires an environment rich in [gas] gas to thrive."
+
+	if(grown_seed.exude_gasses && grown_seed.exude_gasses.len)
+		for(var/gas in grown_seed.exude_gasses)
+			if(gas == "carbon_dioxide")	gas = "carbon dioxide"
+			if(gas == "toxins")	gas = "plasma"
+			dat += "<br>It releases [gas] gas as a byproduct of it's growth."
+
 	if(grown_seed.get_trait(TRAIT_LOWKPA_TOLERANCE) < 20)
 		dat += "<br>It is well adapted to low pressure levels."
 	if(grown_seed.get_trait(TRAIT_HIGHKPA_TOLERANCE) > 220)
@@ -213,7 +225,7 @@
 	if(grown_seed.get_trait(TRAIT_PARASITE))
 		dat += "<br>It is capable of parisitizing and gaining sustenance from tray weeds."
 	if(grown_seed.get_trait(TRAIT_ALTER_TEMP))
-		dat += "<br>It will periodically alter the local temperature by [grown_seed.get_trait(TRAIT_ALTER_TEMP)] degrees Kelvin."
+		dat += "<br>It will periodically alter the local temperature by [grown_seed.get_trait(TRAIT_ALTER_TEMP)] Kelvin."
 
 	if(grown_seed.get_trait(TRAIT_BIOLUM))
 		dat += "<br>It is [grown_seed.get_trait(TRAIT_BIOLUM_COLOUR)  ? "<font color='[grown_seed.get_trait(TRAIT_BIOLUM_COLOUR)]'>bio-luminescent</font>" : "bio-luminescent"]."


### PR DESCRIPTION
<h3>Re-enables botany's interactions with atmospheric conditions and gases.</h3>

Seeds can now consume and exude gases as part of their growth process.
Most seeds do not have this functionality, however it can be found on
random seeds.

Random seeds will occasionally require a gas to grow, or will produce a
gas while planted. Possible gases are Oxygen (O2), Nitrogen (N2), Carbon
Dioxide (CO2), or Plasma gas.

If a plant that affects a gas is planted, it will attempt to interact
with the environment differently depending on conditions as detailed
below:

- Tray lid down: Will always utilize the air of it's tile for atmos
interaction.
- Tray lid up, nothing connected/inserted: Will utilize the air of it's
tile for atmos interaction.
- Tray lid up, tray connected to a connector port pipe: Will attempt to
utilize the air of the pipe network the connector is part of, allowing
you to utilize canisters or direct feeds into the station's piping. If
there are no gases at all (0 total moles) in the network, it will create
an empty gas_mixture at 20C (standard room temp) in the network before
attempting atmos interactions.
- Tray lid up, tank inserted into tray: Will attempt to utilize the
contents of the inserted tank for atmos interaction. If the tank is
completely empty (0 total moles), it will create a new empty gas_mixture
at 20C before attempting atmos interactions.
- Tray lid up, tank inserted AND connector port: Will attempt to utilize
the contents of the inserted tank for atmos interaction. If the tank is
completely empty (0 total moles), it will create a new empty gas_mixture
at 20C before attempting atmos interactions. (Pretty much just ignores
the connector port)

In case it wasn't apparent from the above mentions, you can now insert
any portable tank (emergency oxygen, plasma tank, pretty much any tank
that could be hooked up to internals) into a hydroponics tray. You can
remove them with the previously added eject internal tank verb. There is
currently no visual indication of whether or not there is a tank
inserted (the tray icons are already cluttered with the sheer number of
overlays, and I didn't want to sprite another monstrosity like my past
spriting attempts yielded)

When utilizing an inserted tank for the plant's atmos interactions, it
will attempt to use distribution pressure set on the tank for the
atmospheric pressure inside the closed lid. If the tank's internal
pressure drops lower than the distribution pressure, it will use the
tank's internal pressure instead.

The alter temperature trait is now functional, and will heat/cool the
air used for the plant's atmos interactions. This means it can heat/cool
the surrounding air, inserted tanks, or the contents of a connected pipe
network.

Plant analyzers have had their readouts updated to report what (if any)
gases the plant consumes or produces during it's life. Also edited the
alter temperature trait's message on the plant analyzer to not
incorrectly refer to the change in "degrees Kelvin".

There may be a bit of wonkiness with open-air atmos interaction and gas
redistribution, which would be an issue with LINDA's processing and not
the changes in this PR.

<h1>Also, a major reminder that atmos grief is a bannable offense, and
releasing plasma-producing vines into the halls will be considered equal
to causing an atmos flood from atmospherics and dealt with accordingly.</h1>