### PR TITLE
[Fix][Oversight] Biogenerator Biomass Value Fix

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -191,9 +191,10 @@
 	var/S = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/grown/I in contents)
 		S += 5
-		if(I.reagents.get_reagent_amount("nutriment") < 0.1)
+		var/reagent_amount = I.reagents.get_reagent_amount("nutriment") + I.reagents.get_reagent_amount("plantmatter")
+		if(reagent_amount < 0.1)
 			points += 1*productivity
-		else points += I.reagents.get_reagent_amount("nutriment")*10*productivity
+		else points += reagent_amount*10*productivity
 		qdel(I)
 	if(S)
 		processing = 1


### PR DESCRIPTION
Fixes the Biogenerator only giving one point of biomass per product
inserted.

The biogenerator previously calculated the points based on the amount of
the nutriment reagent in the products inserted.

Now the biogenerator will calculate the points based on the combined
amounts of the nutriment and plant-matter reagents in the product.

Overall, this just restores the values back to their pre-Nutrient
Changes levels, as nutriment in plant products was replaced with
plant-matter for nearly every plant that had it.