### PR TITLE
Reverts Borgification Disorder

### DIFF
--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -104,22 +104,6 @@
 
 ////////////////////////STAGE 4/////////////////////////////////
 
-/datum/disease2/effect/borg
-	name = "Borgification Disorder"
-	stage = 4
-	badness = 2
-	activate(var/mob/living/carbon/mob,var/multiplier)
-		mob << "\red You feel like booping and beeping."
-		if(prob(50))
-			var/location = get_turf(mob.loc)
-			if(mob.client)
-				mob.client.mob = new/mob/living/silicon/robot(location)
-			else
-				new/mob/living/silicon/robot(location)
-			var/datum/disease2/disease/D = mob.virus2
-			mob.gib()
-			del D
-
 /datum/disease2/effect/omnizine
 	name = "Panacea Effect"
 	stage = 4


### PR DESCRIPTION
Borgification Disorder was included in #1146, along with modified nanomachines, as a throwback to the robotization disease that existed in the old disease system. Nanomachines were not intended to be merged, due to unresolved issues, and so were reverted (#1160)... but Borgification Disorder was left in, despite basically only existing for the sake of nanomachines, as a generally-available virus symptom. This PR reverts it, because...
* The reason for its existence was not accepted into the codebase.
* It's the first and only virus symptom that ensures complete destruction of the victim's mind.
* It's another super-deadly symptom competing in the stage 4 symptom bracket.
* It's basically gibbingtons-but-the-roboticist-doesn't-have-to-borg-you.
* It's meant to be *nanomachines* that *turn you into a robot,* not an spontaneous virus.