### PR TITLE
Fix for custom items not spawning

### DIFF
--- a/code/modules/customitems/item_spawning.dm
+++ b/code/modules/customitems/item_spawning.dm
@@ -47,7 +47,10 @@
 		testing("\[CustomItem\] Setting up [path] for [M.ckey] ([M.real_name]).  jobmask=[jobmask];propadjust=[propadjust]")
 		var/ok=0
 		if(jobmask!="*")
-			var/allowed_jobs = text2list(jobmask,",")
+			var/list/allowed_jobs = text2list(jobmask,",")
+			for(var/i = 1, i <= allowed_jobs.len, i++)
+				if(istext(allowed_jobs[i]))
+					allowed_jobs[i] = trim(allowed_jobs[i])
 			var/alt_blocked=0
 			if(M.mind.role_alt_title)
 				if(!(M.mind.role_alt_title in allowed_jobs))


### PR DESCRIPTION
The jobmask wasn't trimming spaces after the comma between job names, and thus thought every job after the first began with a space.