### PR TITLE
Fixes Syringe Blood Duping

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -125,7 +125,7 @@
 							B = T.take_blood(src,amount)
 
 						if (B)
-							src.reagents.reagent_list += B
+							src.reagents.reagent_list |= B
 							src.reagents.update_total()
 							src.on_reagent_change()
 							src.reagents.handle_reactions()


### PR DESCRIPTION
Under certain circumstances (thanks to @Deanthelis for helping to narrow it down), the blood reagent in a syringe could get duplicated, resulting in various bad things happening. This fixes the duplication. (Fixes #1190, fixes #645)