### PR TITLE
Overflow Rerouting System

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -81,8 +81,7 @@
 	var/forumurl = "http://baystation12.net/forums/"
 
 	var/media_base_url = "http://nanotrasen.se/media" // http://ss13.nexisonline.net/media
-	var/overflow_server_url = "byond://nanotrasen.se:6666"
-
+	var/overflow_server_url
 	var/forbid_singulo_possession = 0
 
 	//game_options.txt configs
@@ -156,6 +155,7 @@
 	var/starlight = 0	// Whether space turfs have ambient light or not
 	var/allow_holidays = 0
 	var/player_overflow_cap = 0 //number of players before the server starts rerouting
+	var/list/overflow_whitelist = list() //whitelist for overflow
 
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
@@ -653,6 +653,19 @@
 				forum_authenticated_group = value
 			else
 				diary << "Unknown setting in configuration: '[name]'"
+
+/datum/configuration/proc/loadoverflowwhitelist(filename)
+	var/list/Lines = file2list(filename)
+	for(var/t in Lines)
+		if(!t)	continue
+
+		t = trim(t)
+		if (length(t) == 0)
+			continue
+		else if (copytext(t, 1, 2) == "#")
+			continue
+
+		config.overflow_whitelist += t
 
 /datum/configuration/proc/pick_mode(mode_name)
 	// I wish I didn't have to instance the game modes in order to look up

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -81,6 +81,7 @@
 	var/forumurl = "http://baystation12.net/forums/"
 
 	var/media_base_url = "http://nanotrasen.se/media" // http://ss13.nexisonline.net/media
+	var/overflow_server_url = "byond://nanotrasen.se:6666"
 
 	var/forbid_singulo_possession = 0
 
@@ -154,6 +155,7 @@
 
 	var/starlight = 0	// Whether space turfs have ambient light or not
 	var/allow_holidays = 0
+	var/player_overflow_cap = 0 //number of players before the server starts rerouting
 
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
@@ -507,6 +509,13 @@
 				if("starlight")
 					var/vvalue = text2num(value)
 					config.starlight = vvalue >= 0 ? vvalue : 0
+
+				if("player_reroute_cap")
+					var/vvalue = text2num(value)
+					config.player_overflow_cap = vvalue >= 0 ? vvalue : 0
+
+				if("overflow_server_url")
+					config.overflow_server_url = value
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -37,6 +37,7 @@
 
 	if(config.player_overflow_cap && config.overflow_server_url) //Overflow rerouting, if set, forces players to be moved to a different server once a player cap is reached. Less rough than a pure kick.
 		if(src.client.holder)	return //admins are immune to overflow rerouting
+		if(config.overflow_whitelist.Find(lowertext(src.ckey)))	return //Whitelisted people are immune to overflow rerouting.
 		var/tally = 0
 		for(var/client/C in clients)
 			tally++

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -34,3 +34,11 @@
 		if(client)
 			handle_privacy_poll()
 			client.playtitlemusic()
+
+	if(config.player_overflow_cap && config.overflow_server_url) //Overflow rerouting, if set, forces players to be moved to a different server once a player cap is reached. Less rough than a pure kick.
+		if(src.client.holder)	return //admins are immune to overflow rerouting
+		var/tally = 0
+		for(var/client/C in clients)
+			tally++
+		if(tally > config.player_overflow_cap)
+			src << link(config.overflow_server_url)

--- a/code/world.dm
+++ b/code/world.dm
@@ -313,6 +313,7 @@ var/world_topic_spam_protect_time = world.timeofday
 	config.load("config/game_options.txt","game_options")
 	config.loadsql("config/dbconfig.txt")
 	config.loadforumsql("config/forumdbconfig.txt")
+	config.loadoverflowwhitelist("config/ofwhitelist.txt")
 	// apply some settings from config..
 
 /hook/startup/proc/loadMods()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -278,8 +278,8 @@ STARLIGHT 0
 ## Player rerouting stuff
 ## If not 0, players can be rerouted to an overflow server after a certain cap is reached
 
- ## Cap before players start being rerouted
+## Cap before players start being rerouted
 PLAYER_REROUTE_CAP 0
 
- ## Server to reroute to
-OVERFLOW_SERVER_URL byond://nanotrasen.se:6666
+## Server to reroute to
+#OVERFLOW_SERVER_URL byond://example.org:1111

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -274,3 +274,12 @@ EVENT_CUSTOM_START_MAJOR 80;100
 
 ## Strength of ambient star light. Set to 0 or less to turn off.
 STARLIGHT 0
+
+## Player rerouting stuff
+## If not 0, players can be rerouted to an overflow server after a certain cap is reached
+
+ ## Cap before players start being rerouted
+PLAYER_REROUTE_CAP 0
+
+ ## Server to reroute to
+OVERFLOW_SERVER_URL byond://nanotrasen.se:6666

--- a/config/example/ofwhitelist.txt
+++ b/config/example/ofwhitelist.txt
@@ -1,0 +1,2 @@
+#Any ckeys in this file will be ignored by the overflow system.
+example142


### PR DESCRIPTION
This commit adds an overflow rerouting system customizable by modifying
the config. 

If the config values are set, after X amount of clients have
connected, the server will start rerouting all new players to the
configuration "overflow" server.

Note that admins are immune to this, and
therefore will not be rerouted under any circumstance. 

Players that have already connected and have a body will not be rerouted either, this will
only affect new players that get sent to the lobby.

It probably would also kick players if an admin sent them to the lobby,
but that's a very special case scenario.

TL:DR; If the host configures it, the server can refuse new players after a certain amount of clients are connected, and move them to a buffer server