### PR TITLE
Ports /tg/ varedit improvements

### DIFF
--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -30,7 +30,7 @@
 
 	for(var/p in forbidden_varedit_object_types)
 		if( istype(O,p) )
-			usr << "\red It is forbidden to edit this object's variables."
+			usr << "<span class='danger'>It is forbidden to edit this object's variables.</span>"
 			return
 
 	var/list/names = list()


### PR DESCRIPTION
- Ports tgstation/-tg-station#9630 -- Makes it possible to varedit associative lists (armor values on clothing, for example).
- Adds step_x and step_y to the list of vars locked from being
varedited, accidentally changing these will break movement for everyone, tetris movement for the rest of the round.
- An admin trying to varedit a very large list will be warned before the list is opened that it may crash the server and prompted to abort.
- Changed a BYOND text macro to a span class.