### PR TITLE
Minor Atmos Fixes

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -252,6 +252,7 @@ update_flag
 	if (src.health <= 10)
 		var/atom/location = src.loc
 		location.assume_air(air_contents)
+		air_update_turf()
 
 		src.destroyed = 1
 		playsound(src.loc, 'sound/effects/spray.ogg', 10, 1, -3)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -39,7 +39,7 @@
 	return
 
 // Adds the adjacent turfs to the current atmos processing
-/turf/Destroy()
+/turf/Del()
 	if(air_master)
 		for(var/direction in cardinal)
 			if(atmos_adjacent_turfs & direction)
@@ -254,7 +254,7 @@
 			lighting_clear_overlays()
 
 	W.levelupdate()
-	W.air_update_turf(1)
+	W.CalculateAdjacentTurfs()
 	return W
 
 //////Assimilate Air//////


### PR DESCRIPTION
* Fixes air canisters not activating atmos processing when broken open.
  * This was causing broken canisters to leave tiny, super-dense clouds of gas that didn't spread out.
* Fixes turfs not activating atmos processing for nearby turfs when replaced.
  * Reverted a workaround for the issues this was causing.