### PR TITLE
Fixes Random Jobs Including Command and Whitelisted Positions

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -127,10 +127,10 @@ var/global/datum/controller/occupations/job_master
 			if(istype(job, GetJob("Civilian"))) // We don't want to give him assistant, that's boring!
 				continue
 
-			if(job in command_positions) //If you want a command position, select it!
+			if(job.title in command_positions) //If you want a command position, select it!
 				continue
 
-			if(job in whitelisted_positions) // No random whitelisted job, sorry!
+			if(job.title in whitelisted_positions) // No random whitelisted job, sorry!
 				continue
 
 			if(jobban_isbanned(player, job.title))


### PR DESCRIPTION
Pretty simple fix - when using the "Get random job if preferences unavailable" option, you're never supposed to end up with a command or whitelisted job, but due to a couple little typos, the job randomizer *would* assign you to these jobs. Not anymore!