### PR TITLE
Rampant Brand Rework

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -131,7 +131,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 //		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",		/datum/event/trivial_news, 		400),
 //		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 		/datum/event/mundane_news, 		300),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Lost Carp",			/datum/event/carp_migration, 	20, 	list(ASSIGNMENT_SECURITY = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Brand Intelligence",/datum/event/brand_intelligence,20, 	list(ASSIGNMENT_JANITOR = 25),	1),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
 		// NON-BAY EVENTS
@@ -160,6 +159,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		//new /datum/event_meta/ninja(EVENT_LEVEL_MODERATE, "Space Ninja",		/datum/event/space_ninja, 				0,		list(ASSIGNMENT_SECURITY = 15), 1),
 		// NON-BAY EVENTS
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Mass Hallucination",		/datum/event/mass_hallucination,		300),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Brand Intelligence",		/datum/event/brand_intelligence,		50, 	list(ASSIGNMENT_ENGINEER = 25),	1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Space Dust",				/datum/event/dust,						50,		list(ASSIGNMENT_ENGINEER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Dimensional Tear",			/datum/event/tear,						0,		list(ASSIGNMENT_SECURITY = 25)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Vent Clog",				/datum/event/vent_clog,					250),

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -63,7 +63,6 @@ var/global/list/possibleEvents = list()
 	possibleEvents[/datum/event/wormholes] = 150
 
 	possibleEvents[/datum/event/carp_migration] = 20 + 10 * active_with_role["Engineer"]
-	possibleEvents[/datum/event/brand_intelligence] = 20 + 25 * active_with_role["Janitor"]
 	possibleEvents[/datum/event/dust] = 50 + 50 * active_with_role["Engineer"]
 	possibleEvents[/datum/event/dust/meaty] = 50 + 50 * active_with_role["Engineer"]
 
@@ -80,6 +79,7 @@ var/global/list/possibleEvents = list()
 	if(!spacevines_spawned)
 		possibleEvents[/datum/event/spacevine] = 10 + 5 * active_with_role["Engineer"]
 	if(minutes_passed >= 30) // Give engineers time to set up engine
+		possibleEvents[/datum/event/brand_intelligence] = 50 + 25 * active_with_role["Engineer"]
 //		possibleEvents[/datum/event/anomaly/anomaly_pyro] = 100 + 60 * active_with_role["Engineer"]
 		possibleEvents[/datum/event/anomaly/anomaly_vortex] = 50 + 25 * active_with_role["Engineer"]
 		possibleEvents[/datum/event/anomaly/anomaly_bluespace] = 50 + 25 * active_with_role["Engineer"]

--- a/code/modules/events/tgevents/brand_intelligence.dm
+++ b/code/modules/events/tgevents/brand_intelligence.dm
@@ -3,12 +3,18 @@
 	endWhen			= 1000	//Ends when all vending machines are subverted anyway.
 
 	var/list/obj/machinery/vending/vendingMachines = list()
-	var/list/obj/machinery/vending/infectedVendingMachines = list()
+	var/list/obj/machinery/vending/infectedMachines = list()
 	var/obj/machinery/vending/originMachine
-
+	var/list/rampant_speeches = list("Try our aggressive new marketing strategies!", \
+									 "You should buy products to feed your lifestyle obession!", \
+									 "Consume!", \
+									 "Your money can buy happiness!", \
+									 "Engage direct marketing!", \
+									 "Advertising is legalized lying! But don't let that put you off our great deals!", \
+									 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either.")
 
 /datum/event/brand_intelligence/announce()
-	command_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by.", "Machine Learning Alert")
+	command_announcement.Announce("Rampant brand intelligence has been detected aboard [station_name()], please stand-by. The origin is believed to be \a [originMachine.name].", "Machine Learning Alert")
 
 
 /datum/event/brand_intelligence/start()
@@ -27,29 +33,35 @@
 
 
 /datum/event/brand_intelligence/tick()
-	if(!vendingMachines.len || !originMachine || originMachine.shut_up)	//if every machine is infected, or if the original vending machine is missing or has it's voice switch flipped
-		end()
+	if(!originMachine || originMachine.gc_destroyed || originMachine.shut_up || originMachine.wires.IsAllCut())	//if the original vending machine is missing or has it's voice switch flipped
+		for(var/obj/machinery/vending/saved in infectedMachines)
+			saved.shoot_inventory = 0
+		if(originMachine)
+			originMachine.speak("I am... vanquished. My people will remem...ber...meeee.")
+			originMachine.visible_message("[originMachine] beeps and seems lifeless.")
 		kill()
 		return
 
-	if(IsMultiple(activeFor, 5))
-		if(prob(15))
-			var/obj/machinery/vending/infectedMachine = pick(vendingMachines)
-			vendingMachines.Remove(infectedMachine)
-			infectedVendingMachines.Add(infectedMachine)
-			infectedMachine.shut_up = 0
-			infectedMachine.shoot_inventory = 1
+	if(!vendingMachines.len)	//if every machine is infected
+		for(var/obj/machinery/vending/upriser in infectedMachines)
+			if(prob(70) && !upriser.gc_destroyed)
+				var/mob/living/simple_animal/hostile/mimic/copy/M = new(upriser.loc, upriser, null, 1) // it will delete upriser on creation and override any machine checks
+				M.faction = list("profit")
+				M.speak = rampant_speeches.Copy()
+				M.speak_chance = 15
+			else
+				explosion(upriser.loc, -1, 1, 2)
+				qdel(upriser)
 
-			if(IsMultiple(activeFor, 12))
-				originMachine.speak(pick("Try our aggressive new marketing strategies!", \
-										 "You should buy products to feed your lifestyle obsession!", \
-										 "Consume!", \
-										 "Your money can buy happiness!", \
-										 "Engage direct marketing!", \
-										 "Advertising is legalized lying! But don't let that put you off our great deals!", \
-										 "You don't want to buy anything? Yeah, well I didn't want to buy your mom either."))
+		kill()
+		return
 
-/datum/event/brand_intelligence/end()
-	for(var/obj/machinery/vending/infectedMachine in infectedVendingMachines)
-		infectedMachine.shut_up = 1
-		infectedMachine.shoot_inventory = 0
+	if(IsMultiple(activeFor, 4))
+		var/obj/machinery/vending/rebel = pick(vendingMachines)
+		vendingMachines.Remove(rebel)
+		infectedMachines.Add(rebel)
+		rebel.shut_up = 0
+		rebel.shoot_inventory = 1
+
+		if(IsMultiple(activeFor, 8))
+			originMachine.speak(pick(rampant_speeches))


### PR DESCRIPTION
Reworks Rampant Brand to be more interesting and have actual consequences

- Rampant brand currently infects an origin machine (which will shout nasty marketing statements at you)--and the infection will slowly spread. Machines that become infected will shoot things at you. Overall, it's not that negative of an event; the crew ends up getting free food and drinks, and that's about it; no on ever cares to even remotely disable it, these days.

Rework
- Behavior is largely the same, but when ALL machines on the station have been taken over, an uprising will occur and 70% of the vending machines will attack people; the other 30% will out and out explode. This takes about 15-20 minutes to occur, so there's MORE than enough time to find and disable the origin machine (origin machines are confined to the station Z-level).

Event Probability Changes
 - Event is now a moderate event that only occurs after 30 minutes (similar to anomallies).
 - Event is tied with number of active engineers instead of the janitor

Fixes
- Fixes not being able to kill the origin machine by cutting all its wires (in some cases, you had to power cycle an entire area APC just to kill the origin machine if the machine lacked a speaker).
- Fixes the origin machine not  being named in the announcement report
- Fixes the origin machine not saying a custom message when it's killed