### PR TITLE
Mob and Blob Damage Rebalance

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -377,7 +377,7 @@
 /mob/living/carbon/human/blob_act()
 	if(stat == 2)	return
 	show_message("\red The blob attacks you!")
-	var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
+	var/dam_zone = pick("head", "chest", "groin", "l_arm", "l_hand", "r_arm", "r_hand", "l_leg", "l_foot", "r_leg", "r_foot")
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
 	apply_damage(rand(20,30), BRUTE, affecting, run_armor_check(affecting, "melee"))
 	return
@@ -412,7 +412,7 @@
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
 		if(check_shields(damage, "the [M.name]"))
 			return 0
-		var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
+		var/dam_zone = pick("head", "chest", "groin", "l_arm", "l_hand", "r_arm", "r_hand", "l_leg", "l_foot", "r_leg", "r_foot")
 		var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
 		var/armor = run_armor_check(affecting, "melee")
 
@@ -468,7 +468,7 @@
 		if(check_shields(damage, "the [M.name]"))
 			return 0
 
-		var/dam_zone = pick("head", "chest", "l_arm", "r_arm", "l_leg", "r_leg", "groin")
+		var/dam_zone = pick("head", "chest", "groin", "l_arm", "l_hand", "r_arm", "r_hand", "l_leg", "l_foot", "r_leg", "r_foot")
 
 		var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
 		var/armor_block = run_armor_check(affecting, "melee")

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -138,7 +138,7 @@
 
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		var/dam_zone = pick("chest", "l_hand", "r_hand", "l_leg", "r_leg")
+		var/dam_zone = pick("head", "chest", "groin", "l_arm", "l_hand", "r_arm", "r_hand", "l_leg", "l_foot", "r_leg", "r_foot")
 		var/obj/item/organ/external/affecting = H.get_organ(ran_zone(dam_zone))
 		H.apply_damage(damage, BRUTE, affecting, H.run_armor_check(affecting, "melee"), sharp=1, edge=1)
 		return H


### PR DESCRIPTION
Alright, so, this is a relatively simple change that should go a long way towards making fighting against blobs and hostile mobs far less frustrating.

So, have you ever noticed that when you fight hostile mobs (or a blob), you tend to break your hands a LOT? Well, this is because, on live, when a hostile mob/blob attacks you, it picks the chest, hands, or legs as a valid target--not shockingly, this has a very heavy bias towards breaking your hands and taking you out of the fight instantly.

On TG, this style zone picking isn't particularly problematic, as you cannot break bones, suffer internal organ damage, or become impacted by internal bleeding. Paradise is very different from this, as you can be impacted by all these things making blobs/hostile mobs far stronger than they otherwise should be.

Thus, I propose this:

Blobs and Hostile mobs will now consider any body part a valid target (head+chest+groin+arms+hands+legs+feet), instead of just chest+legs+hands.

Overall, you'll still be taking the same amount of *damage* from a mob, but you'll be far less likely to get both of your hands broken after 2-4 attacks. 
