### PR TITLE
Spider Event Balance

### DIFF
--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -8,7 +8,7 @@
 
 /datum/event/spider_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 50)
-	spawncount = round(num_players() * 1.5)
+	spawncount = round(num_players() * 0.8)
 	sent_spiders_to_station = 1
 
 /datum/event/spider_infestation/announce()


### PR DESCRIPTION
An alternative to: https://github.com/ParadiseSS13/Paradise/pull/1220

The idea of nerfing spiders, directly, was not popular with two of the three maintainers, so this is an alternative.

So, when a spider infestation occurs, it spawns (current number of players * 1.5) spiderlings. This means if you have 60 players, it will literally generate 90 spiderlings---given that, it's easy to miss even a few and the resulting adult spiders turning into a gigantic problem that can't be contained.

This lowers the total amount of spiderlings generated to (number of players * 0.8). If we us the previous example of 60 players, this would result in 48 spiderlings. Still a lot, but not impossible to deal with unless the crew very very deliberately ignores the spiderlings.