### PR TITLE
Reduces View Range

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -14,7 +14,7 @@ var/global/datum/global_init/init = new ()
 	mob = /mob/new_player
 	turf = /turf/space
 	area = /area/space
-	view = "17x17"
+	view = "15x15"
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 
 


### PR DESCRIPTION
Reduces view range back to 15x15. This has been discussed a little bit recently. Reverts the view range to 15x15, it was changed when UI buttons were originally added as they reduced the amount of space available on screen. After UI buttons were refactored, players gained the ability to minimize UI buttons, meaning most of the screen would be available if needed.

I'm not particularly convinced one way or the other as to whether the size should remain 17x17 or not. Players will need a period of time to adjust to the reduced view range as they had to adjust to the increased one. This should also fix the problem where sprites are distorted by the 'stretch to fit' option.