### PR TITLE
Stun+Weaken Balancing

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1005,15 +1005,15 @@ var/list/sacrificed = list()
 				O.show_message(text("\red <B>[] invokes a talisman at []</B>", usr, T), 1)
 
 			if(issilicon(T))
-				T.Weaken(15)
+				T.Weaken(10)
 
 			else if(iscarbon(T))
 				var/mob/living/carbon/C = T
 				flick("e_flash", C.flash)
 				if (!(HULK in C.mutations))
 					C.silent += 15
-				C.Weaken(25)
-				C.Stun(25)
+				C.Weaken(10)
+				C.Stun(10)
 		return
 
 /////////////////////////////////////////TWENTY-FIFTH RUNE

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -116,9 +116,9 @@
 		else
 			M.current << "\red Your piercing gaze knocks out [C.name]."
 			C << "\red You find yourself unable to move and barely able to speak"
-			C.Weaken(20)
-			C.Stun(20)
-			C.stuttering = 20
+			C.Weaken(10)
+			C.Stun(10)
+			C.stuttering = 10
 	else
 		M.current << "\red You broke your gaze."
 		return
@@ -184,8 +184,8 @@
 		for(var/mob/living/carbon/C in view(1))
 			if(!C.vampire_affected(M)) continue
 			if(!M.current.vampire_can_reach(C, 1)) continue
-			C.Stun(8)
-			C.Weaken(8)
+			C.Stun(5)
+			C.Weaken(5)
 			C.stuttering = 20
 			C << "\red You are blinded by [M.current]'s glare"
 
@@ -217,10 +217,10 @@
 			if(ishuman(C) && (C:l_ear || C:r_ear) && istype((C:l_ear || C:r_ear), /obj/item/clothing/ears/earmuffs)) continue
 			if(!C.vampire_affected(M)) continue
 			C << "<span class='warning'><font size='3'><b>You hear a ear piercing shriek and your senses dull!</font></b></span>"
-			C.Weaken(8)
+			C.Weaken(4)
 			C.ear_deaf = 20
 			C.stuttering = 20
-			C.Stun(8)
+			C.Stun(4)
 			C.Jitter(150)
 		for(var/obj/structure/window/W in view(4))
 			W.destroy()

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -548,7 +548,6 @@
 /obj/item/weapon/spellbook/oneuse/knock/recoil(mob/user as mob)
 	..()
 	user <<"<span class='warning'>You're knocked down!</span>"
-	user.Stun(20)
 	user.Weaken(20)
 
 /obj/item/weapon/spellbook/oneuse/horsemask

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -620,7 +620,7 @@ About the new airlock wires panel:
 			if(!istype(H.head, /obj/item/clothing/head/helmet))
 				visible_message("\red [user] headbutts the airlock.")
 				var/obj/item/organ/external/affecting = H.get_organ("head")
-				H.Stun(8)
+				H.Stun(5)
 				H.Weaken(5)
 				if(affecting.take_damage(10, 0))
 					H.UpdateDamageIcon()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -604,7 +604,7 @@
 					M.drop_item()
 				M.eye_blurry += 10
 				M.Paralyse(1)
-				M.Weaken(4)
+				M.Weaken(2)
 			if (eyes.damage >= eyes.min_broken_damage)
 				if(M.stat != 2)
 					M << "\red You go blind!"

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -109,7 +109,7 @@
 		s.set_up(3, 1, M)
 		s.start()
 
-		M.Weaken(10)
+		M.Weaken(5)
 
 	if(master)
 		master.receive_signal()

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -50,7 +50,7 @@
 		M.stop_pulling()
 		M << "\blue You slipped on the [name]!"
 		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(3)
+		M.Stun(4)
 		M.Weaken(2)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -85,7 +85,7 @@
 				M.take_organ_damage(2) // Was 5 -- TLE
 				M << "\blue You slipped on \the [name]!"
 				playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-				M.Weaken(10)
+				M.Weaken(7)
 				M.take_overall_damage(0, burned)
 
 	throw_impact(atom/hit_atom)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -126,14 +126,13 @@
 		playsound(get_turf(src), "swing_hit", 50, 1, -1)
 		if (M.stuttering < 8 && (!(HULK in M.mutations))  /*&& (!istype(H:wear_suit, /obj/item/clothing/suit/judgerobe))*/)
 			M.stuttering = 8
-		M.Stun(8)
-		M.Weaken(8)
+		M.Weaken(3)
 		for(var/mob/O in viewers(M))
 			if (O.client)	O.show_message("\red <B>[M] has been beaten with \the [src] by [user]!</B>", 1, "\red You hear someone fall", 2)
 	else
 		playsound(src.loc, 'sound/weapons/Genhit.ogg', 50, 1, -1)
-		M.Stun(5)
-		M.Weaken(5)
+		M.Stun(3)
+		M.Weaken(3)
 		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
 		log_attack("[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])")

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -68,7 +68,6 @@
 		m.loc = get_turf(src)
 		del src
 		var/mob/living/T = M
-		T.Weaken(10)
-		T.apply_damage(20)
+		T.Weaken(5)
 		return
 	..()

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -116,8 +116,8 @@
 					step(M, M.dir)
 					M << "\blue You slipped on the wet floor!"
 					playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-					M.Stun(5)
-					M.Weaken(3)
+					M.Stun(4)
+					M.Weaken(2)
 				else
 					M.inertia_dir = 0
 					return
@@ -134,7 +134,7 @@
 					M.take_organ_damage(2) // Was 5 -- TLE
 					M << "\blue You slipped on the floor!"
 					playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-					M.Weaken(10)
+					M.Weaken(7)
 
 			if(3) // Ice
 				if ((M.m_intent == "run") && !(istype(M:shoes, /obj/item/clothing/shoes) && M:shoes.flags&NOSLIP) && prob(30))
@@ -143,7 +143,7 @@
 					M << "\blue You slipped on the icy floor!"
 					playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
 					M.Stun(4)
-					M.Weaken(5)
+					M.Weaken(2)
 				else
 					M.inertia_dir = 0
 					return

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -109,10 +109,10 @@
 	switch(severity)
 		if(1)
 			src.take_organ_damage(20)
-			Stun(rand(5,10))
+			Stun(8)
 		if(2)
 			src.take_organ_damage(10)
-			Stun(rand(1,5))
+			Stun(3)
 	flick("noise", src:flash)
 	src << "\red <B>*BZZZT*</B>"
 	src << "\red Warning: Electromagnetic pulse detected."


### PR DESCRIPTION
This is basically this PR, minus the movement tweaks: https://github.com/tgstation/-tg-station/pull/2931


Basically nerfs some of the ridiculously long lasting stuns and weakens left in our codebase  (still is one buff)

Things Nerfed

- Cult
 - the stun rune/talisman
- Vamp
 - all stun spells have been nerfed
- Airlock brain damage stun
- Lube
- Wet Floors
- Icy Floors
- Traitor Banana Peels
- eyestabbing
- electropack
- classic baton
- EMPs on silicons 
- Stools 
 - extra 20 damage removed outright
 - tempted to remove the extra 5% chance to weaken entirely.

Things Buffed

- Soap