### PR TITLE
Fixes Stuns (Dropping Items or lack there of).

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1048,6 +1048,8 @@ var/list/slot_equipment_priority = list( \
 			else
 				lying = pick(90, 270) //180 looks like shit since BYOND inverts rather than turns in that case
 	else if(stunned)
+		drop_l_hand()
+		drop_r_hand()
 		canmove = 0
 	else
 		lying = 0
@@ -1081,6 +1083,8 @@ var/list/slot_equipment_priority = list( \
 		lying = 90
 		canmove = 0
 	else if( stunned )
+		drop_l_hand()
+		drop_r_hand()
 		canmove = 0
 	else
 		lying = 0


### PR DESCRIPTION
Stuns are meant to make you drop what's in your active hands. Normally, most players don't notice this, as the vast vast bulk of stuns in the game also have a weaken accompanying them (which does make them drop the item).

In any event, with TG mining coming up, the port of Shadowlings, and our current flashes, the need for Stun to actually make people drop their held items is needed; for example, it makes a flash an example disarm tool, as the person flashed not only drops their item (and can't pick it back up right away from the blindness), but it actually makes the flash a semi-effective base level disarm tool.


Code wise, this is pretty ugly; our update_canmove proc needs to be overhauled to TG's--but that will require quite a bit of work on refactoring buckling and vehicles, as well, so this is an interim solution to the problem at hand.