### PR TITLE
Port -tg- shuffle helper proc

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -155,16 +155,15 @@ proc/listclearnulls(list/list)
 	return output
 
 //Randomize: Return the list in a random order
-/proc/shuffle(var/list/shufflelist)
-	if(!shufflelist)
+/proc/shuffle(var/list/L)
+	if(!L)
 		return
-	var/list/new_list = list()
-	var/list/old_list = shufflelist.Copy()
-	while(old_list.len)
-		var/item = pick(old_list)
-		new_list += item
-		old_list -= item
-	return new_list
+	L = L.Copy()
+
+	for(var/i=1, i<L.len, ++i)
+		L.Swap(i,rand(i,L.len))
+
+	return L
 
 //Return a list with no duplicate entries
 /proc/uniquelist(var/list/L)

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -94,7 +94,7 @@
 			making_mage = 0
 			return
 		else
-			shuffle(candidates)
+			candidates = shuffle(candidates)
 			for(var/mob/i in candidates)
 				if(!i || !i.client) continue //Dont bother removing them from the list since we only grab one wizard
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -167,7 +167,7 @@ client/proc/one_click_antag()
 	sleep(300)
 
 	if(candidates.len)
-		shuffle(candidates)
+		candidates = shuffle(candidates)
 		for(var/mob/i in candidates)
 			if(!i || !i.client) continue //Dont bother removing them from the list since we only grab one wizard
 


### PR DESCRIPTION
-tg-'s shuffle proc can handle associative and unassociative lists,
whereas ours could only handle unassociative. This caused the holiday
controller to break.

tldr; fixes holidays, hopefully doesn't break anything else
Also includes a minor fix for two incorrect uses of the proc.