### PR TITLE
Fix species ventcrawl var not working

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -282,7 +282,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	if(!ventcrawler)
 		if(ishuman(src))
 			var/mob/living/carbon/human/H = src
-			if(!H.species.ventcrawler)	ventcrawlerlocal = H.species.ventcrawler
+			ventcrawlerlocal = H.species.ventcrawler
 
 	if(!ventcrawlerlocal)	return
 


### PR DESCRIPTION
Title.

Due to a bit of badly-thought-out unnecessary sanity-checking, this didn't work. Now it does.