### PR TITLE
Fixes Escape Objective Issues

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -388,7 +388,7 @@ datum/objective/silence
 
 
 datum/objective/escape
-	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."
+	explanation_text = "Escape on the shuttle or an escape pod alive and free."
 	var/escape_areas = list(/area/shuttle/escape/centcom,
 		/area/shuttle/escape_pod1/centcom,
 		/area/shuttle/escape_pod1/transit,
@@ -409,10 +409,8 @@ datum/objective/escape
 			return 0
 		if(!owner.current || owner.current.stat == DEAD)
 			return 0
-		if(istype(owner.current, /mob/living/carbon))
-			var/mob/living/carbon/C = owner.current
-			if (C.handcuffed) // If you're cuffed, you're in custody.
-				return 0
+		if(owner.current.restrained())
+			return 0
 		var/turf/location = get_turf(owner.current.loc)
 		if(!location)
 			return 0

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -389,6 +389,16 @@ datum/objective/silence
 
 datum/objective/escape
 	explanation_text = "Escape on the shuttle or an escape pod alive and without being in custody."
+	var/escape_areas = list(/area/shuttle/escape/centcom,
+		/area/shuttle/escape_pod1/centcom,
+		/area/shuttle/escape_pod1/transit,
+		/area/shuttle/escape_pod2/centcom,
+		/area/shuttle/escape_pod2/transit,
+		/area/shuttle/escape_pod3/centcom,
+		/area/shuttle/escape_pod3/transit,
+		/area/shuttle/escape_pod5/centcom,
+		/area/shuttle/escape_pod5/transit,
+		/area/centcom/evac)
 
 	check_completion()
 		if(issilicon(owner.current))
@@ -399,27 +409,16 @@ datum/objective/escape
 			return 0
 		if(!owner.current || owner.current.stat == DEAD)
 			return 0
+		if(istype(owner.current, /mob/living/carbon))
+			var/mob/living/carbon/C = owner.current
+			if (C.handcuffed) // If you're cuffed, you're in custody.
+				return 0
 		var/turf/location = get_turf(owner.current.loc)
 		if(!location)
 			return 0
 
-		if(istype(location, /turf/simulated/shuttle/floor4)) // Fails tratiors if they are in the shuttle brig -- Polymorph
-			if(istype(owner.current, /mob/living/carbon))
-				var/mob/living/carbon/C = owner.current
-				if (!C.handcuffed)
-					return 1
-			return 0
-
-		var/area/check_area = location.loc
-		if(istype(check_area, /area/shuttle/escape/centcom))
-			return 1
-		if(istype(check_area, /area/shuttle/escape_pod1/centcom))
-			return 1
-		if(istype(check_area, /area/shuttle/escape_pod2/centcom))
-			return 1
-		if(istype(check_area, /area/shuttle/escape_pod3/centcom))
-			return 1
-		if(istype(check_area, /area/shuttle/escape_pod5/centcom))
+		var/area/check_area = get_area(location)
+		if(check_area && check_area.type in escape_areas)
 			return 1
 		else
 			return 0


### PR DESCRIPTION
This fixes some issues which would cause the Escape objective to succeed or fail when not intended to. Because this makes the Escape requirements actually match up with the recently-replaced wording of "alive and free", that wording has been put back in.

**Before:**
* You would fail if you were in the shuttle brig and either handcuffed, or a non-carbon.
* You would succeed if you were in the shuttle brig, but straightjacketed.
* You would succeed if you were handcuffed, but anywhere else in the shuttle or a pod.
  * A cuffed prisoner in the shuttle medbay would complete their escape objective.
  * A cuffed prisoner taken to the security escape pod would complete their escape objective, assuming one of the below circumstances didn't occur.
* You would fail if in an escape pod that's still in transit when the shuttle docks.
* You would fail if your escape pod docked, and you left it before the shuttle docked.

**After:**
* If you are restrained (handcuffs or straightjacket), you fail, regardless of where you are.
  * If you aren't restrained, you will not fail, even if you're in the shuttle brig.
    * Technically, a shuttle-brigged non-carbon would now succeed in their escape objective, if it was ever possible for such a thing to have such an objective. I'm assuming it generally isn't.
* Being in an escape pod that has left the station, or being in the shuttle the escape pods dock with, counts as successfully escaping, so long as you aren't restrained.