### PR TITLE
Classic Baton Refactor

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -1775,7 +1775,7 @@
 "Ig" = (/obj/machinery/light/spot{tag = "icon-tube1 (NORTH)"; icon_state = "tube1"; dir = 1},/turf/unsimulated/floor{tag = "icon-redbluefull (WEST)"; icon_state = "redbluefull"; dir = 8},/area/tdome/tdomeobserve)
 "Ih" = (/turf/unsimulated/floor{tag = "icon-redbluefull (WEST)"; icon_state = "redbluefull"; dir = 8},/area/tdome/tdomeobserve)
 "Ii" = (/obj/machinery/vending/coffee,/turf/unsimulated/floor{tag = "icon-redbluefull (WEST)"; icon_state = "redbluefull"; dir = 8},/area/tdome/tdomeobserve)
-"Ij" = (/obj/structure/table/reinforced,/obj/item/weapon/melee/telebaton,/obj/item/weapon/paper/Court,/obj/item/weapon/pen,/turf/unsimulated/floor{tag = "icon-dark"; icon_state = "dark"},/area/admin)
+"Ij" = (/obj/structure/table/reinforced,/obj/item/weapon/melee/classic_baton/telescopic,/obj/item/weapon/paper/Court,/obj/item/weapon/pen,/turf/unsimulated/floor{tag = "icon-dark"; icon_state = "dark"},/area/admin)
 "Ik" = (/obj/structure/table/reinforced,/obj/item/weapon/scalpel,/obj/item/weapon/storage/box/syndie_kit/mindslave,/turf/unsimulated/floor{tag = "icon-dark"; icon_state = "dark"},/area/admin)
 "Il" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/box/mousetraps,/obj/item/weapon/storage/box/trackimp,/obj/item/weapon/storage/box/syndie_kit/imp_explosive,/turf/unsimulated/floor{tag = "icon-dark"; icon_state = "dark"},/area/admin)
 "Im" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/box/flashbangs,/obj/item/weapon/storage/box/flashes,/turf/unsimulated/floor{tag = "icon-dark"; icon_state = "dark"},/area/admin)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -36,7 +36,7 @@
 			H.equip_or_collect(new /obj/item/weapon/storage/box/engineer(H), slot_r_hand)
 		else
 			H.equip_or_collect(new /obj/item/weapon/storage/box/engineer(H.back), slot_in_backpack)
-			H.equip_or_collect(new /obj/item/weapon/melee/telebaton(H.back), slot_in_backpack)
+			H.equip_or_collect(new /obj/item/weapon/melee/classic_baton/telescopic(H.back), slot_in_backpack)
 		return 1
 
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -33,7 +33,7 @@
 			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
 		else
 			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-			H.equip_or_collect(new /obj/item/weapon/melee/telebaton(H.back), slot_in_backpack)
+			H.equip_or_collect(new /obj/item/weapon/melee/classic_baton/telescopic(H.back), slot_in_backpack)
 		return 1
 
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -37,7 +37,7 @@
 			if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_tox(H), slot_back)
 			if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
-		H.equip_or_collect(new /obj/item/weapon/melee/telebaton(H.back), slot_in_backpack)
+		H.equip_or_collect(new /obj/item/weapon/melee/classic_baton/telescopic(H.back), slot_in_backpack)
 		return 1
 
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -39,7 +39,7 @@
 		else
 			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/weapon/restraints/handcuffs(H), slot_in_backpack)
-			H.equip_or_collect(new /obj/item/weapon/melee/telebaton(H.back), slot_in_backpack)
+			H.equip_or_collect(new /obj/item/weapon/melee/classic_baton/telescopic(H.back), slot_in_backpack)
 		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 		L.imp_in = H
 		L.implanted = 1
@@ -139,7 +139,7 @@
 			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/weapon/storage/box/evidence(H), slot_in_backpack)
 			H.equip_or_collect(new /obj/item/device/detective_scanner(H), slot_in_backpack)
-			H.equip_or_collect(new /obj/item/weapon/melee/telebaton(H.back), slot_in_backpack)
+			H.equip_or_collect(new /obj/item/weapon/melee/classic_baton/telescopic(H.back), slot_in_backpack)
 		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 		L.imp_in = H
 		L.implanted = 1

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -34,7 +34,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			H.equip_or_collect(new /obj/item/weapon/storage/box/ids(H), slot_r_hand)
 		else
 			H.equip_or_collect(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
-			H.equip_or_collect(new /obj/item/weapon/melee/telebaton(H.back), slot_in_backpack)
+			H.equip_or_collect(new /obj/item/weapon/melee/classic_baton/telescopic(H.back), slot_in_backpack)
 		var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 		L.imp_in = H
 		L.implanted = 1
@@ -90,7 +90,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			H.equip_or_collect(new /obj/item/weapon/storage/box/ids(H), slot_r_hand)
 		else
 			H.equip_or_collect(new /obj/item/weapon/storage/box/ids(H.back), slot_in_backpack)
-			H.equip_or_collect(new /obj/item/weapon/melee/telebaton(H.back), slot_in_backpack)
+			H.equip_or_collect(new /obj/item/weapon/melee/classic_baton/telescopic(H.back), slot_in_backpack)
 		return 1
 
 

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -43,7 +43,7 @@
 		/obj/item/weapon/gun/energy/laser/bluetag,\
 		/obj/item/weapon/gun/energy/laser/redtag,\
 		/obj/item/weapon/gun/energy/laser/practice,\
-		/obj/item/weapon/melee/telebaton,\
+		/obj/item/weapon/melee/classic_baton/telescopic,\
 		/obj/item/weapon/gun/energy/kinetic_accelerator)
 
 

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -36,7 +36,7 @@
 		/obj/item/weapon/gun/energy/laser/bluetag,\
 		/obj/item/weapon/gun/energy/laser/redtag,\
 		/obj/item/weapon/gun/energy/laser/practice,\
-		/obj/item/weapon/melee/telebaton,\
+		/obj/item/weapon/melee/classic_baton/telescopic,\
 		/obj/item/weapon/gun/energy/kinetic_accelerator)
 
 

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -149,7 +149,7 @@
 		"/obj/item/weapon/melee/classic_baton",
 		"/obj/item/device/flashlight/seclite",
 		"/obj/item/taperoll/police",
-		"/obj/item/weapon/melee/telebaton"
+		"/obj/item/weapon/melee/classic_baton/telescopic"
 		)
 
 /obj/item/weapon/storage/belt/security/sec/New()
@@ -161,7 +161,7 @@
 	new /obj/item/weapon/kitchenknife/combat(src)
 	new /obj/item/weapon/melee/baton/loaded(src)
 	new /obj/item/device/flash(src)
-	new /obj/item/weapon/melee/telebaton(src)
+	new /obj/item/weapon/melee/classic_baton/telescopic(src)
 	new /obj/item/weapon/grenade/flashbang(src)
 
 /obj/item/weapon/storage/belt/soulstone

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -92,9 +92,11 @@
 					user.update_inv_l_hand(0)
 		else
 			user << "<span class='warning'>It's already fabulous!</span>"
+
 /*
  * Classic Baton
  */
+
 /obj/item/weapon/melee/classic_baton
 	name = "police baton"
 	desc = "A wooden truncheon for beating criminal scum."
@@ -102,102 +104,12 @@
 	icon_state = "baton"
 	item_state = "classic_baton"
 	slot_flags = SLOT_BELT
-	force = 10
-
-/obj/item/weapon/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
-	if ((CLUMSY in user.mutations) && prob(50))
-		user << "\red You club yourself over the head."
-		user.Weaken(3 * force)
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			H.apply_damage(2*force, BRUTE, "head")
-		else
-			user.take_organ_damage(2*force)
-		return
-/*this is already called in ..()
-	src.add_fingerprint(user)
-	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
-
-	log_attack("<font color='red'>[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])</font>")
-*/
-	if (user.a_intent == "harm")
-		if(!..()) return
-		playsound(get_turf(src), "swing_hit", 50, 1, -1)
-		if (M.stuttering < 8 && (!(HULK in M.mutations))  /*&& (!istype(H:wear_suit, /obj/item/clothing/suit/judgerobe))*/)
-			M.stuttering = 8
-		M.Weaken(3)
-		for(var/mob/O in viewers(M))
-			if (O.client)	O.show_message("\red <B>[M] has been beaten with \the [src] by [user]!</B>", 1, "\red You hear someone fall", 2)
-	else
-		playsound(src.loc, 'sound/weapons/Genhit.ogg', 50, 1, -1)
-		M.Stun(3)
-		M.Weaken(3)
-		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been attacked with [src.name] by [user.name] ([user.ckey])</font>")
-		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to attack [M.name] ([M.ckey])</font>")
-		log_attack("[user.name] ([user.ckey]) attacked [M.name] ([M.ckey]) with [src.name] (INTENT: [uppertext(user.a_intent)])")
-
-		if(!iscarbon(user))
-			M.LAssailant = null
-		else
-			M.LAssailant = user
-
-
-		src.add_fingerprint(user)
-
-		for(var/mob/O in viewers(M))
-			if (O.client)	O.show_message("\red <B>[M] has been stunned with \the [src] by [user]!</B>", 1, "\red You hear someone fall", 2)
-
-//Telescopic baton
-/obj/item/weapon/melee/telebaton
-	name = "telescopic baton"
-	desc = "A compact yet robust personal defense weapon. Can be concealed when folded."
-	icon = 'icons/obj/weapons.dmi'
-	icon_state = "telebaton_0"
-	item_state = "telebaton_0"
-	slot_flags = SLOT_BELT
-	w_class = 2
-	force = 3
+	force = 12 //9 hit crit
+	w_class = 3
 	var/cooldown = 0
-	var/on = 0
+	var/on = 1
 
-/obj/item/weapon/melee/telebaton/attack_self(mob/user as mob)
-	on = !on
-	if(on)
-		user << "<span class ='warning'>You extend the baton.</span>"
-		icon_state = "telebaton_1"
-		item_state = "nullrod"
-		w_class = 4 //doesnt fit in backpack when its on for balance
-		force = 10 //seclite damage
-		attack_verb = list("smacked", "struck", "cracked", "beaten")
-	else
-		user << "<span class ='notice'>You collapse the baton.</span>"
-		icon_state = "telebaton_0"
-		item_state = "telebaton_0" //no sprite in other words
-		slot_flags = SLOT_BELT
-		w_class = 2
-		force = 3 //not so robust now
-		attack_verb = list("hit", "poked")
-	if(istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		H.update_inv_l_hand()
-		H.update_inv_r_hand()
-	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)
-	add_fingerprint(user)
-	if (!blood_DNA) return
-	if(blood_overlay && (blood_DNA.len >= 1)) //updates blood overlay, if any
-		overlays.Cut()//this might delete other item overlays as well but eeeeeeeh
-
-		var/icon/I = new /icon(src.icon, src.icon_state)
-		I.Blend(new /icon('icons/effects/blood.dmi', rgb(255,255,255)),ICON_ADD)
-		I.Blend(new /icon('icons/effects/blood.dmi', "itemblood"),ICON_MULTIPLY)
-		blood_overlay = I
-
-		overlays += blood_overlay
-
-	return
-
-/obj/item/weapon/melee/telebaton/attack(mob/target as mob, mob/living/user as mob)
+/obj/item/weapon/melee/classic_baton/attack(mob/target as mob, mob/living/user as mob)
 	if(on)
 		add_fingerprint(user)
 		if((CLUMSY in user.mutations) && prob(50))
@@ -221,9 +133,10 @@
 			if(cooldown <= 0)
 				playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 				target.Weaken(3)
-				add_logs(target, user, "stunned", object="telescopic baton")
+				add_logs(target, user, "stunned", object="classic baton")
 				src.add_fingerprint(user)
-				target.visible_message("<span class ='danger'>[target] has been knocked down with \the [src] by [user]!</span>")
+				target.visible_message("<span class ='danger'>[user] has knocked down [target] with \the [src]!</span>", \
+					"<span class ='userdanger'>[user] has knocked down [target] with \the [src]!</span>")
 				if(!iscarbon(user))
 					target.LAssailant = null
 				else
@@ -234,6 +147,39 @@
 		return
 	else
 		return ..()
+
+//Telescopic baton
+/obj/item/weapon/melee/classic_baton/telescopic
+	name = "telescopic baton"
+	desc = "A compact yet robust personal defense weapon. Can be concealed when folded."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "telebaton_0"
+	item_state = null
+	slot_flags = SLOT_BELT
+	w_class = 2
+	force = 0
+	on = 0
+
+/obj/item/weapon/melee/classic_baton/telescopic/attack_self(mob/user as mob)
+	on = !on
+	if(on)
+		user << "<span class ='warning'>You extend the baton.</span>"
+		icon_state = "telebaton_1"
+		item_state = "nullrod"
+		w_class = 4 //doesnt fit in backpack when its on for balance
+		force = 10 //stunbaton damage
+		attack_verb = list("smacked", "struck", "cracked", "beaten")
+	else
+		user << "<span class ='notice'>You collapse the baton.</span>"
+		icon_state = "telebaton_0"
+		item_state = null //no sprite for concealment even when in hand
+		slot_flags = SLOT_BELT
+		w_class = 2
+		force = 0 //not so robust now
+		attack_verb = list("hit", "poked")
+
+	playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)
+	add_fingerprint(user)
 
 /*
  *Energy Blade

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -984,7 +984,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse_rifle/pistol/m1911(M), slot_belt)
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(M), slot_back)
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/matches(M), slot_r_store)
-			M.equip_if_possible(new /obj/item/weapon/melee/telebaton(M), slot_l_store)
+			M.equip_if_possible(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_l_store)
 
 			var/obj/item/device/pda/centcom/pda = new(M)
 			pda.owner = M.real_name
@@ -996,7 +996,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			M.equip_if_possible(pda, slot_wear_pda)
 
 			M.equip_if_possible(new /obj/item/clothing/glasses/sunglasses(M), slot_l_store)
-			M.equip_if_possible(new /obj/item/weapon/melee/telebaton(M), slot_r_store)
+			M.equip_if_possible(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
 
 			var/obj/item/weapon/card/id/W = new(M)
 			W.name = "[M.real_name]'s ID Card (Special Operations Officer)"

--- a/code/modules/admin/verbs/vox_raiders.dm
+++ b/code/modules/admin/verbs/vox_raiders.dm
@@ -14,7 +14,7 @@ var/global/vox_tick = 1
 		if(1) // Vox raider!
 			equip_to_slot_or_del(new /obj/item/clothing/suit/space/vox/carapace(src), slot_wear_suit)
 			equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/vox/carapace(src), slot_head)
-			equip_to_slot_or_del(new /obj/item/weapon/melee/telebaton(src), slot_belt)
+			equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(src), slot_belt)
 			equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/monocle(src), slot_glasses) // REPLACE WITH CODED VOX ALTERNATIVE.
 			equip_to_slot_or_del(new /obj/item/device/chameleon(src), slot_l_store)
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1,6 +1,6 @@
 
 /obj/item/clothing/suit/armor
-	allowed = list(/obj/item/weapon/gun/energy,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/device/flashlight/seclite,/obj/item/weapon/melee/telebaton)
+	allowed = list(/obj/item/weapon/gun/energy,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/device/flashlight/seclite,/obj/item/weapon/melee/classic_baton/telescopic)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT


### PR DESCRIPTION
Refactor/change documented here, primarily: https://github.com/tgstation/-tg-station/pull/6428

Refactors the Classic Baton and Telebaton

Functionality of the Telebaton will remain UNCHANGED.

This primarily impacts the classic baton, which currently is a no-cooldown instant-stun weapon.

- Classic baton will function like an always-on telebaton--same cooldown, sounds, etc; no more harm-classic batoning someone to death while keeping them stun-locked, with absolute ease.

