### PR TITLE
Untick Metastation, tick cyberiad.

### DIFF
--- a/paradise.dme
+++ b/paradise.dme
@@ -10,7 +10,7 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
-#include "_maps\metastation.dm"
+#include "_maps\cyberiad.dm"
 #include "code\_compile_options.dm"
 #include "code\hub.dm"
 #include "code\stylesheet.dm"


### PR DESCRIPTION
The .dme changes never got.. actually.. done.. ugh. I'm bad at this.

Removes metastation from being the default map when compiled, since it shouldn't be.