### PR TITLE
Force traitors into random role instead of returning to lobby.

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -381,6 +381,10 @@ var/global/datum/controller/occupations/job_master
 				Debug("AC2 Assistant located, Player: [player]")
 				AssignRole(player, "Civilian")
 
+		for(var/mob/new_player/player in unassigned)
+			if(player.mind.special_role)
+				GiveRandomJob(player)
+
 		//For ones returning to lobby
 		for(var/mob/new_player/player in unassigned)
 			if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)


### PR DESCRIPTION
This should solve the problems with players ending up with certain exploitable bugs.
Probably Fixes #1267
Probably Fixes #1235
Probably Fixes #1147