### PR TITLE
Move tram processing to internal loop, so they can go a decent speed.

### DIFF
--- a/code/modules/tram/tram_control_pad.dm
+++ b/code/modules/tram/tram_control_pad.dm
@@ -23,6 +23,8 @@
 
 	if(href_list["engine_toggle"])
 		tram_linked.automode = !tram_linked.automode
+		if(tram_linked.automode)	tram_linked.startLoop()
+		else	tram_linked.killLoop()
 	else if(href_list["close"])
 		usr.unset_machine()
 		usr << browse(null, "window=trampad")


### PR DESCRIPTION
This commit adds an internal loop for trams, which runs every 1/10th of a second. This means that trams are no longer limited by the object process calling them, and therefore move much faster.

Also contains:
 - Cleanup of damage procs, kinda, moved them.
 - Fast mode, runs twice every process. Ludicrous speed.

Example videos (Yes, I know the lights don't move, I couldn't be bothered to add them to the whitelist and recapture):
Regular speed:http://puu.sh/ig7ZC/7023b39128.mp4
~~Ludicrous speed:~~ Fast mode: http://puu.sh/ig7u2/a72ba9b0fc.mp4