### PR TITLE
Blender, food processor, gibber, monkey recycler shaking when processing

### DIFF
--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -348,6 +348,8 @@
 
 	src.operating = 1
 	update_icon()
+	var/offset = prob(50) ? -2 : 2
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
 
 	var/slab_name = occupant.name
 	var/slab_count = 3
@@ -405,5 +407,6 @@
 			gibs.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(1,5),15)
 			sleep(1)
 
+		pixel_x = initial(pixel_x) //return to it's spot after shaking
 		src.operating = 0
 		update_icon()

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -28,8 +28,12 @@
 					del(target)
 					user << "\blue You stuff the monkey in the machine."
 					playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
+					var/offset = prob(50) ? -2 : 2
+					animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
 					use_power(500)
 					src.grinded++
+					sleep(50)
+					pixel_x = initial(pixel_x)
 					user << "\blue The machine now has [grinded] monkeys worth of material stored."
 			else
 				user << "\red The machine only accepts monkeys!"

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -177,10 +177,13 @@
 			"<span class='notice'>You hear a food processor.</span>")
 
 		playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)
+		var/offset = prob(50) ? -2 : 2
+		animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = P.time*5) //start shaking
 		use_power(500)
 
 		sleep(P.time)
 
+		pixel_x = initial(pixel_x) //return to its spot after shaking
 		P.process(src.loc, O)
 		src.processing = 0
 

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -1257,8 +1257,11 @@
 	if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
 		return
 	playsound(src.loc, 'sound/machines/juicer.ogg', 20, 1)
+	var/offset = prob(50) ? -2 : 2
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
 	inuse = 1
 	spawn(50)
+		pixel_x = initial(pixel_x) //return to its spot after shaking
 		inuse = 0
 		interact(usr)
 	//Snacks
@@ -1294,8 +1297,11 @@
 	if (!beaker || (beaker && beaker.reagents.total_volume >= beaker.reagents.maximum_volume))
 		return
 	playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)
+	var/offset = prob(50) ? -2 : 2
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
 	inuse = 1
 	spawn(60)
+		pixel_x = initial(pixel_x) //return to its spot after shaking
 		inuse = 0
 		interact(usr)
 	//Snacks and Plants


### PR DESCRIPTION
tgstation/-tg-station#9806
This commit makes the machines listen in the title shake quickly, as if
vibrating, when used.

Original Post:
>Updated video: http://webmshare.com/play/0gbLg

>Made the blender, food processor and gibber shake sideways when they're processing to indicate that something's happening. Code-wise very simple and looks cool imo, especially with the gibber.

>Tell me what do you think, what other things could this kind of visual indicator be used with?

Example video:http://puu.sh/iggXz/2fbc5d3cc1.mp4
