### PR TITLE
New admin sound verb; Play a sound originating at every radio.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -75,7 +75,8 @@ var/list/admin_verbs_ban = list(
 var/list/admin_verbs_sounds = list(
 	/client/proc/play_local_sound,
 	/client/proc/play_sound,
-	/client/proc/play_server_sound
+	/client/proc/play_server_sound,
+	/client/proc/play_intercomm_sound
 	)
 var/list/admin_verbs_event = list(
 	/client/proc/object_talk,

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -48,6 +48,38 @@ var/list/sounds_cache = list()
 	play_sound(melody)
 	feedback_add_details("admin_verb","PSS") //If you are copy-pasting this, ensure the 2nd paramter is unique to the new proc!
 
+/client/proc/play_intercomm_sound()
+	set category = "Event"
+	set name = "Play Sound via Intercomms"
+	set desc = "Plays a sound at every intercomm on the station z level. Works best with small sounds."
+	if(!check_rights(R_SOUNDS))	return
+
+	var/A = alert("This will play a sound at every intercomm on the station Z, are you sure you want to continue? This works best with short sounds, beware.","Warning","Yep","Nope")
+	if(A != "Yep")	return
+
+	var/list/sounds = file2list("sound/serversound_list.txt");
+	sounds += "--CANCEL--"
+	sounds += sounds_cache
+
+	var/melody = input("Select a sound from the server to play", "Server sound list", "--CANCEL--") in sounds
+
+	if(melody == "--CANCEL--")	return
+
+	var/cvol = 35
+	var/inputvol = input("How loud would you like this to be? (1-70)", "Volume", "35") as num | null
+	if(inputvol && inputvol >= 1 && inputvol <= 70)
+		cvol = inputvol
+
+	var/list/intercomms = list()
+
+	for(var/obj/item/device/radio/intercom/I in world)
+		if(I.z != ZLEVEL_STATION)	continue
+		intercomms += I
+
+	if(intercomms.len)
+		for(var/obj/item/device/radio/intercom/I in intercomms)
+			playsound(I, melody, cvol)
+
 /*
 /client/proc/cuban_pete()
 	set category = "Event"

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -38,12 +38,10 @@ var/list/sounds_cache = list()
 	if(!check_rights(R_SOUNDS))	return
 
 	var/list/sounds = file2list("sound/serversound_list.txt");
-	sounds += "--CANCEL--"
 	sounds += sounds_cache
 
-	var/melody = input("Select a sound from the server to play", "Server sound list", "--CANCEL--") in sounds
-
-	if(melody == "--CANCEL--")	return
+	var/melody = input("Select a sound from the server to play", "Server sound list") as null|anything in sounds
+	if(!melody)	return
 
 	play_sound(melody)
 	feedback_add_details("admin_verb","PSS") //If you are copy-pasting this, ensure the 2nd paramter is unique to the new proc!
@@ -58,15 +56,14 @@ var/list/sounds_cache = list()
 	if(A != "Yep")	return
 
 	var/list/sounds = file2list("sound/serversound_list.txt");
-	sounds += "--CANCEL--"
 	sounds += sounds_cache
 
-	var/melody = input("Select a sound from the server to play", "Server sound list", "--CANCEL--") in sounds
-
-	if(melody == "--CANCEL--")	return
+	var/melody = input("Select a sound from the server to play", "Server sound list") as null|anything in sounds
+	if(!melody)	return
 
 	var/cvol = 35
 	var/inputvol = input("How loud would you like this to be? (1-70)", "Volume", "35") as num | null
+	if(!inputvol)	return
 	if(inputvol && inputvol >= 1 && inputvol <= 70)
 		cvol = inputvol
 


### PR DESCRIPTION
Note, verb may not work as one would expect it to. It just uses playsound
originating at each intercomm, therefore anyone that is out of range of
the intercomm will not start hearing it when they get in range, so walking
down the halls isn't going to keep playing the sound as one would expect.

However, the ability to play a sound which, when people are in the right
position, will appear to originate from the intercomms, could be useful
for an event.

Inspired by an offhand comment in a thread somewhere, doesn't quite work like I imagined, but figured it was still good.

Suprisingly, only lags the server for about the time it takes to load the sound, so only 1-2 seconds, at max. (High-stress on the server may cause this to be an incorrect estimate.)

Note, long sounds are not recommended, as BYOND's sound system (afaik) cannot handle live updating of sounds "playing", and can only send the sound file to a player once.