### PR TITLE
Various Fixes - Cyborg Stacks, Sleepy/Deaf Animals/pAIs, Admin Stuff, Runtimes, etc.

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -426,7 +426,7 @@ client
 
 /client/proc/view_var_Topic(href, href_list, hsrc)
 	//This should all be moved over to datum/admins/Topic() or something ~Carn
-	if( (usr.client != src) || !src.holder )
+	if(!check_rights(R_ADMIN|R_MOD))
 		return
 	if(href_list["Vars"])
 		debug_variables(locate(href_list["Vars"]))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -201,7 +201,7 @@
 			a = get_area(src.loc)
 	else
 		var/error = dist_y/2 - dist_x
-		while(src && target &&((((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)) && dist_travelled < range) || (a.has_gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && istype(src.loc, /turf))
+		while(src && target &&((((src.y < target.y && dy == NORTH) || (src.y > target.y && dy == SOUTH)) && dist_travelled < range) || (a && a.has_gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && istype(src.loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)
 				var/atom/step = get_step(src, dx)

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -12,7 +12,7 @@
 	desc = "Completely shuts down the speech center of the subject's brain."
 	activation_message   = "You feel unable to express yourself at all."
 	deactivation_message = "You feel able to speak freely again."
-	sdisability = 1
+	sdisability = MUTE
 
 	New()
 		..()

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -32,12 +32,13 @@
 
 /datum/game_mode/meteor/proc/sendmeteors()
 	nometeors = 1
-	var/waveduration = world.timeofday + rand(3000,9000)
-	var/waitduration = rand(3000,9000)
-	while(waveduration - world.timeofday > 0)
-		sleep(20)
-		spawn() spawn_meteors(6)
-	spawn(waitduration)
+	spawn()
+		var/waveduration = world.time + rand(3000,9000)
+		var/waitduration = rand(3000,9000)
+		while(waveduration - world.time > 0)
+			sleep(20)
+			spawn() spawn_meteors(6)
+		sleep(waitduration)
 		nometeors = 0
 
 /datum/game_mode/meteor/declare_completion()

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -86,6 +86,8 @@
 		return
 
 /obj/machinery/bodyscanner/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+	if(!istype(O))
+		return
 	if(O.loc == user) //no you can't pull things out of your ass
 		return
 	if(user.restrained() || user.stat || user.weakened || user.stunned || user.paralysis || user.resting) //are you cuffed, dying, lying, stunned or other

--- a/code/game/objects/items/mountable_frames/intercom.dm
+++ b/code/game/objects/items/mountable_frames/intercom.dm
@@ -6,5 +6,5 @@
 	mount_reqs = list("simfloor", "nospace")
 
 /obj/item/mounted/frame/intercom/do_build(turf/on_wall, mob/user)
-	new /obj/item/device/radio/intercom(get_turf(src), get_dir(on_wall, user), 0)
+	new /obj/item/device/radio/intercom(get_turf(src), get_dir(user, on_wall), 0)
 	qdel(src)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -31,10 +31,6 @@
 	g_amt = 0
 	created_window = /obj/structure/window/basic
 
-/obj/item/stack/sheet/glass/full/New()
-	..()
-	amount = 50
-
 /obj/item/stack/sheet/glass/attack_self(mob/user as mob)
 	construct_window(user)
 

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -1,5 +1,6 @@
 /obj/item/stack/light_w
 	name = "wired glass tiles"
+	gender = PLURAL
 	singular_name = "wired glass floor tile"
 	desc = "A glass tile, which is wired, somehow."
 	icon_state = "glass_wire"

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -90,10 +90,6 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	flags = CONDUCT
 	origin_tech = "materials=1"
 
-/obj/item/stack/sheet/metal/full/New()
-	..()
-	amount = 50
-
 /obj/item/stack/sheet/metal/cyborg
 	name = "metal"
 	desc = "Sheets made out off metal. It has been dubbed Metal Sheets."
@@ -135,10 +131,6 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 	recipes = plasteel_recipes
 	return ..()
-
-/obj/item/stack/sheet/plasteel/full/New(var/loc, var/amount=null)
-	amount = 50
-	..(loc, amount)
 
 /*
  * Wood

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -153,6 +153,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 /obj/item/stack/sheet/wood
 	name = "wooden planks"
 	desc = "One can only guess that this is a bunch of wood."
+	gender = PLURAL
 	singular_name = "wood plank"
 	icon_state = "sheet-wood"
 	origin_tech = "materials=1;biotech=1"

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -142,11 +142,11 @@
 			new_item.amount = R.res_amount*multiplier
 			//new_item.add_to_stacks(usr)
 		src.amount-=R.req_amount*multiplier
-		if (src.amount<=0)
+		if (src.amount < 1) // Just in case a stack's amount ends up fractional somehow
 			var/oldsrc = src
 			src = null //dont kill proc after del()
 			usr.unEquip(oldsrc, 1)
-			del(oldsrc)
+			del(oldsrc) // Not qdel, because qdel'd stacks act strange for cyborgs
 			if (istype(O,/obj/item))
 				usr.put_in_hands(O)
 		O.add_fingerprint(usr)
@@ -165,10 +165,11 @@
 	if (amount < used)
 		return 0
 	amount -= used
-	if (amount <= 0)
+	if (amount < 1) // Just in case a stack's amount ends up fractional somehow
 		if(usr)
 			usr.unEquip(src, 1)
-		qdel(src)
+		spawn()
+			del(src) // Not qdel, because qdel'd stacks act strange for cyborgs
 	update_icon()
 	return 1
 

--- a/code/game/objects/items/stacks/tiles/light.dm
+++ b/code/game/objects/items/stacks/tiles/light.dm
@@ -8,6 +8,7 @@
 
 /obj/item/stack/tile/light
 	name = "light tiles"
+	gender = PLURAL
 	singular_name = "light floor tile"
 	desc = "A floor tile, made out off glass. Use a multitool on it to change its color."
 	icon_state = "tile_light blue"

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -1,5 +1,6 @@
 /obj/item/stack/tile/plasteel
 	name = "floor tiles"
+	gender = PLURAL
 	singular_name = "floor tile"
 	desc = "Those could work as a pretty decent throwing weapon"
 	icon_state = "tile"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -10,6 +10,7 @@
  */
 /obj/item/stack/tile/grass
 	name = "grass tiles"
+	gender = PLURAL
 	singular_name = "grass floor tile"
 	desc = "A patch of grass like they often use on golf courses"
 	icon_state = "tile_grass"
@@ -27,6 +28,7 @@
  */
 /obj/item/stack/tile/wood
 	name = "wood floor tiles"
+	gender = PLURAL
 	singular_name = "wood floor tile"
 	desc = "an easy to fit wood floor tile"
 	icon_state = "tile-wood"

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -41,10 +41,10 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/eyes/E = H.internal_organs_by_name["eyes"]
 		flick("e_flash", M.flash)
-		E.damage += rand(1, 3)
+		if (E) E.damage += rand(1, 3)
 		M.Stun(max(10/distance, 3))
 		M.Weaken(max(10/distance, 3))
-		if (E.damage >= E.min_bruised_damage)
+		if (E && E.damage >= E.min_bruised_damage)
 			M << "<span class='warning'>Your eyes start to burn badly!</span>"
 			if(!banglet && !(istype(src , /obj/item/weapon/grenade/flashbang/clusterbang)))
 				if (E.damage >= E.min_broken_damage)

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -424,9 +424,9 @@ var/can_call_ert
 					M.equip_to_slot_or_del(new /obj/item/weapon/rcd/combat(M), slot_in_backpack)
 					M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo/large(M), slot_in_backpack)
 					M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo/large(M), slot_in_backpack)
-					M.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/full(M), slot_in_backpack)
-					M.equip_to_slot_or_del(new /obj/item/stack/sheet/glass/full(M), slot_in_backpack)
-					M.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/full(M), slot_in_backpack)
+					M.equip_to_slot_or_del(new /obj/item/stack/sheet/metal(M, amount=50), slot_in_backpack)
+					M.equip_to_slot_or_del(new /obj/item/stack/sheet/glass(M, amount=50), slot_in_backpack)
+					M.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel(M, amount=50), slot_in_backpack)
 
 					M.equip_to_slot_or_del(new /obj/item/weapon/storage/briefcase/inflatable(M), slot_r_hand)
 
@@ -560,9 +560,9 @@ var/can_call_ert
 			M.equip_to_slot_or_del(new /obj/item/weapon/rcd/combat(M), slot_in_backpack)
 			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo/large(M), slot_in_backpack)
 			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo/large(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/stack/sheet/metal/full(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/stack/sheet/glass/full(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel/full(M), slot_in_backpack)
+			M.equip_to_slot_or_del(new /obj/item/stack/sheet/metal(M, amount=50), slot_in_backpack)
+			M.equip_to_slot_or_del(new /obj/item/stack/sheet/glass(M, amount=50), slot_in_backpack)
+			M.equip_to_slot_or_del(new /obj/item/stack/sheet/plasteel(M, amount=50), slot_in_backpack)
 
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full/multitool(M), slot_belt)
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -38,6 +38,7 @@ var/global/nologevent = 0
 	if (!istype(src,/datum/admins))
 		usr << "Error: you are not an admin!"
 		return
+	if(!check_rights(R_ADMIN|R_MOD)) return
 
 	var/body = "<html><head><title>Options for [M.key]</title></head>"
 	body += "<body>Options panel for <b>[M]</b>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -65,8 +65,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/aooc,
 	/client/proc/freeze,
 	/client/proc/freezemecha,
-	/client/proc/alt_check
-
+	/client/proc/alt_check,
+	/client/proc/secrets
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -99,7 +99,6 @@ var/list/admin_verbs_event = list(
 	/client/proc/response_team, // Response Teams admin verb
 	/client/proc/cmd_admin_create_centcom_report,
 	/client/proc/fax_panel,
-	/client/proc/secrets,
 	/client/proc/event_manager_panel
 	)
 

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -12,8 +12,8 @@
 <html>
 <head>
 <title>Permissions Panel</title>
-<script type='text/javascript' src='html/search.js'></script>
-<link rel='stylesheet' type='text/css' href='html/panels.css'>
+<script type='text/javascript' src="search.js"></script>
+<link rel='stylesheet' type='text/css' href="panels.css">
 </head>
 <body onload='selectTextField();updateSearch();'>
 <div id='main'><table id='searchable' cellspacing='0'>

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -395,6 +395,7 @@
 
 
 /datum/admins/proc/check_antagonists()
+	if(!check_rights(R_ADMIN))	return
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -117,7 +117,7 @@
 			if(istype(M, /mob/new_player))
 				continue
 
-			if(M.client && M.client.holder && (M.client.holder.rights & R_ADMIN|R_MOD) && (M.client.prefs.toggles & CHAT_DEAD)) // Show the emote to admins/mods
+			if(M.client && M.client.holder && (M.client.holder.rights & (R_ADMIN|R_MOD)) && (M.client.prefs.toggles & CHAT_DEAD)) // Show the emote to admins/mods
 				M << message
 
 			else if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_DEAD)) // Show the emote to regular ghosts with deadchat toggled on

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -48,6 +48,7 @@
 
 /obj/item/organ/brain/removed(var/mob/living/user)
 
+	if(!owner) return ..() // Probably a redundant removal; just bail
 	name = "[owner.real_name]'s brain"
 
 	var/mob/living/simple_animal/borer/borer = owner.has_brain_worms()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -16,7 +16,8 @@
 	for(var/obj/item/organ/I in internal_organs)
 		if(istype(loc,/turf))
 			I.removed(src)
-			I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)
+			spawn()
+				I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)
 
 	for(var/obj/item/organ/external/E in src.organs)
 		if(istype(E, /obj/item/organ/external/chest))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -379,6 +379,9 @@ emp_act
 			return
 
 		var/obj/item/organ/external/affecting = get_organ(zone)
+		if(!affecting)
+			visible_message("\blue \The [O] misses [src] narrowly!")
+			return
 		var/hit_area = affecting.name
 
 		src.visible_message("\red [src] has been hit in the [hit_area] by [O].")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -380,7 +380,9 @@ emp_act
 
 		var/obj/item/organ/external/affecting = get_organ(zone)
 		if(!affecting)
-			visible_message("\blue \The [O] misses [src] narrowly!")
+			var/missverb = (O.gender == PLURAL) ? "whizz" : "whizzes"
+			visible_message("<span class='notice'>\The [O] [missverb] past [src]'s missing [parse_zone(zone)]!</span>",
+				"<span class='notice'>\The [O] [missverb] past your missing [parse_zone(zone)]!</span>")
 			return
 		var/hit_area = affecting.name
 

--- a/code/modules/mob/living/carbon/primitive/dionaold.dm
+++ b/code/modules/mob/living/carbon/primitive/dionaold.dm
@@ -12,6 +12,7 @@
 	var/list/donors = list()
 	var/ready_evolve = 0
 	ventcrawler = 1
+	var/environment_smash = 0 // This is a sloppy way to solve attack_animal runtimes. Stupid nymphs...
 
 /mob/living/carbon/primitive/diona/New()
 

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -7,6 +7,26 @@
 			for (var/mob/M in viewers(T))
 				M.show_message("\red The data cable rapidly retracts back into its spool.", 3, "\red You hear a click and the sound of wire spooling rapidly.", 2)
 			del(src.cable)
+	sleeping = 0
+	ear_deaf = 0
+
+	if (src.paralysis || src.stunned || src.weakened) //Stunned etc.
+		src.stat = 1
+		if (src.stunned > 0)
+			AdjustStunned(-1)
+		if (src.weakened > 0)
+			AdjustWeakened(-1)
+		if (src.paralysis > 0)
+			AdjustParalysis(-1)
+			src.eye_blind = max(eye_blind, 1)
+		else
+			src.eye_blind = 0
+
+	else	//Not stunned.
+		src.stat = 0
+
+	if(paralysis || stunned || weakened || buckled || resting || src.loc == card) canmove = 0
+	else canmove = 1
 
 	regular_hud_updates()
 	if(src.secHUD == 1)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -220,3 +220,8 @@
 	while(slot_start != slot_num) //If we wrap around without finding any free slots, just give up.
 
 	return
+
+/mob/living/silicon/robot/unEquip(obj/item/I)
+	if(I == module_active)
+		deselect_module(get_selected_module())
+	return ..()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -32,6 +32,7 @@
 	SetParalysis(min(paralysis, 30))
 	SetWeakened(min(weakened, 20))
 	sleeping = 0
+	ear_deaf = 0
 	adjustBruteLoss(0)
 	adjustToxLoss(0)
 	adjustOxyLoss(0)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -37,6 +37,7 @@
 
 	if(!stacktypes || !stacktypes.len) return
 
+	var/stack_respawned = 0
 	for(var/T in stacktypes)
 		var/O = locate(T) in src.modules
 		var/obj/item/stack/S = O
@@ -46,9 +47,12 @@
 			S = new T(src)
 			src.modules += S
 			S.amount = 1
+			stack_respawned = 1
 
 		if(S && S.amount < stacktypes[T])
 			S.amount++
+	if(stack_respawned && istype(R) && R.hud_used)
+		R.hud_used.update_robot_modules_display()
 
 /obj/item/weapon/robot_module/proc/rebuild()//Rebuilds the list so it's possible to add/remove items from the module
 	var/list/temp_list = modules

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -98,9 +98,8 @@
 		/obj/effect/effect/steam, \
 		/obj/effect/mist)
 
-		for(var/this_type in calmers)
-			var/mob/living/simple_animal/check_effect = locate() in src.loc
-			if(check_effect.type == this_type)
+		for(var/obj/effect/check_effect in src.loc)
+			if(check_effect.type in calmers)
 				calming = 1
 				break
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -104,6 +104,11 @@
 	if(health > maxHealth)
 		health = maxHealth
 
+	if(sleeping)
+		sleeping = max(sleeping-1, 0)
+	if(ear_deaf)
+		ear_deaf = max(ear_deaf-1, 0)
+
 	handle_stunned()
 	handle_weakened()
 	handle_paralysed()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -587,7 +587,7 @@
 /obj/machinery/light/power_change()
 	spawn(10)
 		var/area/A = get_area_master(src)
-		seton(A.lightswitch && A.power_light)
+		if(A) seton(A.lightswitch && A.power_light)
 
 // called when on fire
 


### PR DESCRIPTION
Fixes:

* Fixes cyborg stacks not being properly deleted, causing them to work infinitely and not restock. (Fixes #1047, fixes #1212, fixes #1217)
  * Turns out qdel wasn't deleting stacks in a timely fashion, which was a problem. Stacks simply no longer try to qdel themselves.
  * When a stack is used up, it will disappear from the module list. When recharging, the stack will be recreated, and immediately show up in the module list.
* Fixes simple animals, cyborgs, and pAIs missing handling for certain status effects, particularly deafness. (Fixes #689, fixes #1184, fixes #1253)
  * This issue would often cause problems when reconnecting or getting flashbanged.
  * These status effects still aren't all really handled *properly,* but this will be a big improvement.
* Fixes engineering ERT having infinitely-duplicable stacks of materials. (Fixes #1228)
  * Also removes the (worthlessly broken) full-stack subtypes added specifically for them.
* Fixes admins missing access to the secrets panel (was limited to admins with +EVENT, despite having checks for many different permissions levels).
* Fixes missing/broken permission checks on certain admin functions. (Fixes #1230)
  * Mentors can no longer see deadchat emotes, view player panels, view variables, or check antagonists.
  * Moderators can no longer check antagonists.
* Fixes the Permissions Panel not properly loading its javascript and style sheet.
* Fixes the Mute genetic disability causing blindness. (Fixes #1251)
* Fixes intercom frames "mounting" in the wrong direction. (Fixes #1252, fixes half of #1273)
* Fixes the gibbing of humans only throwing one organ away at a time.
  * This caused gibbing to go very slowly when the organs spent a long time traveling, such as someone gibbing in space.
* Fixes meteor mode's `sendmeteors()` hanging the ticker and rarely causing a meteor wave to last forever.
* Fixes bees not properly checking for calmers, resulting in runtimes.
* Fixes runtime in destroyed lights.
* Fixes runtime when trying to put the floor into a body scanner.
* Fixes flashbangs runtiming when flashing a human without eyes.
* Sloppily fixes diona nymphs runtiming when interacting with things that expect them to be a simple animal with an `environment_smash` var.
* Fixes runtime when a thrown object hits a human in a zone without a limb.
* Fixes brains runtiming when redundantly removed.
* Fixes thrown objects runtiming when they can't find an area.
* Fixes plurality of some plurally-named stacks.