### PR TITLE
Fixes #1279.

### DIFF
--- a/nano/templates/geoscanner.tmpl
+++ b/nano/templates/geoscanner.tmpl
@@ -109,7 +109,7 @@ Used In File(s): \code\modules\research\xenoarchaeology\machinery\geosample_scan
 <div class="item">
 	<div class="itemLabel" style="width: 21%;">Internal temperature:</div>
 	<div class="itemContent" style="width: 35%;">
-		{{:helper.displayBar(data.scanner_temperature, 0, 1273, (data.scanner_temperature > 250 ? (data.scanner_temperature > 1000 ? 'bad' : 'average') : 'good')))}}
+		{{:helper.displayBar(data.scanner_temperature, 0, 1273, (data.scanner_temperature > 250 ? (data.scanner_temperature > 1000 ? 'bad' : 'average') : 'good'))}}
 		{{:data.scanner_temperature}} K
 	</div>
 	<div class="itemContent" style="width: 44%;">


### PR DESCRIPTION
Fixes #1279.
Was fixed quite some time ago on Bay, curious no one has reported here before now.
Not an exact copy as Bay's template displays gigahertz instead of kilohertz, but didn't feel like simply changing that without cause.