### PR TITLE
Re-enables A Few Verbs, Examine, and Point

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -233,7 +233,6 @@ its easier to just keep the beam vertical.
 	set name = "Examine"
 	set category = "IC"
 	set src in view(usr.client) //If it can be seen, it can be examined.
-	set popup_menu = 0
 
 	if (!( usr ))
 		return

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -100,7 +100,7 @@
 
 /obj/machinery/dna_scannernew/verb/eject()
 	set src in oview(1)
-	set category = null
+	set category = "Object"
 	set name = "Eject DNA Scanner"
 
 	if (usr.stat != 0)
@@ -125,7 +125,7 @@
 
 /obj/machinery/dna_scannernew/verb/move_inside()
 	set src in oview(1)
-	set category = null
+	set category = "Object"
 	set name = "Enter DNA Scanner"
 
 	if (usr.stat != 0)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -484,7 +484,7 @@
 
 /obj/machinery/sleeper/verb/eject()
 	set name = "Eject Sleeper"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 	if(usr.stat != 0)
 		return
@@ -495,7 +495,7 @@
 
 /obj/machinery/sleeper/verb/remove_beaker()
 	set name = "Remove Beaker"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 	if(usr.stat != 0)
 		return
@@ -572,7 +572,7 @@
 
 /obj/machinery/sleeper/verb/move_inside()
 	set name = "Enter Sleeper"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 	if(usr.stat != 0 || !(ishuman(usr)))
 		return

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -33,7 +33,7 @@
 		return formatted
 
 /obj/machinery/computer/card/verb/eject_id()
-	set category = null
+	set category = "Object"
 	set name = "Eject ID Card"
 	set src in oview(1)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -99,7 +99,7 @@
 
 /obj/item/verb/move_to_top()
 	set name = "Move To Top"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(!istype(src.loc, /turf) || usr.stat || usr.restrained() )
@@ -534,7 +534,7 @@
 
 /obj/item/verb/verb_pickup()
 	set src in oview(1)
-	set category = null
+	set category = "Object"
 	set name = "Pick up"
 
 	if(!(usr)) //BS12 EDIT

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -989,7 +989,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 
 /obj/item/device/pda/verb/verb_remove_id()
-	set category = null
+	set category = "Object"
 	set name = "Remove id"
 	set src in usr
 
@@ -1007,7 +1007,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 
 /obj/item/device/pda/verb/verb_remove_pen()
-	set category = null
+	set category = "Object"
 	set name = "Remove pen"
 	set src in usr
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -44,7 +44,7 @@
 
 	set name = "Climb structure"
 	set desc = "Climbs onto a structure."
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	do_climb(usr)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -340,7 +340,7 @@
 
 /obj/structure/closet/verb/verb_toggleopen()
 	set src in oview(1)
-	set category = null
+	set category = "Object"
 	set name = "Toggle Open"
 
 	if(!usr.canmove || usr.stat || usr.restrained())

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -266,7 +266,7 @@
 
 /obj/structure/closet/crate/secure/verb/verb_togglelock()
 	set src in oview(1) // One square distance
-	set category = null
+	set category = "Object"
 	set name = "Toggle Lock"
 
 	if(!usr.canmove || usr.stat || usr.restrained()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -49,7 +49,7 @@
 
 /obj/structure/stool/bed/chair/verb/rotate()
 	set name = "Rotate Chair"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(config.ghost_interaction)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -465,7 +465,7 @@
 /obj/structure/table/verb/do_flip()
 	set name = "Flip table"
 	set desc = "Flips a non-reinforced table"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if (!can_touch(usr) || ismouse(usr))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -288,7 +288,7 @@ var/global/wcColored
 
 /obj/structure/window/verb/rotate()
 	set name = "Rotate Window Counter-Clockwise"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(anchored)
@@ -304,7 +304,7 @@ var/global/wcColored
 
 /obj/structure/window/verb/revrotate()
 	set name = "Rotate Window Clockwise"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(anchored)

--- a/code/game/verbs/atom_verbs.dm
+++ b/code/game/verbs/atom_verbs.dm
@@ -1,6 +1,6 @@
 /atom/movable/verb/pull()
 	set name = "Pull"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(Adjacent(usr))
@@ -9,8 +9,7 @@
 
 /atom/verb/point()
 	set name = "Point To"
-	set category = null
-	set popup_menu = 0
+	set category = "Object"
 	set src in oview()
 	var/atom/this = src//detach proc from src
 	src = null

--- a/code/modules/computer3/laptop.dm
+++ b/code/modules/computer3/laptop.dm
@@ -76,7 +76,7 @@
 
 //Quickfix until Snapshot works out how he wants to redo power. ~Z
 /obj/item/device/laptop/verb/eject_id()
-	set category = null
+	set category = "Object"
 	set name = "Eject ID Card"
 	set src in oview(1)
 
@@ -84,7 +84,7 @@
 		stored_computer.eject_id()
 
 /obj/machinery/computer3/laptop/verb/eject_id()
-	set category = null
+	set category = "Object"
 	set name = "Eject ID Card"
 	set src in oview(1)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1332,7 +1332,7 @@
 					src.adjustToxLoss(rand(1,3))
 
 /mob/living/carbon/human/verb/check_pulse()
-	set category = null
+	set category = "Object"
 	set name = "Check pulse"
 	set desc = "Approximately count somebody's pulse. Requires you to stand still at least 6 seconds."
 	set src in view(1)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -516,7 +516,7 @@ var/list/slot_equipment_priority = list( \
 
 /mob/verb/mode()
 	set name = "Activate Held Object"
-	set category = null
+	set category = "Object"
 	set src = usr
 
 	if(istype(loc,/obj/mecha)) return


### PR DESCRIPTION
- Re-enables a number of object-tab verbs.

Most of these can still be used via typing the verb in or right-clicking; I don't personally see the need for their removal, especially when the object tab, itself, shows absolutely no signs of going away any time soon (and having half removed half not isn't particularly consistent). Yes, this means easy chair rotation for ghosts again.

- Re-enables Examine and Point with right-click menu

This probably confuses new players who have been recent transfers more than anything else. Not only that, but it partially compensates for SS13's lack of 3D feel by giving you a better view of what's truly around you without having to sort through the "examine" list in the IC pop-up.

Please note, this doesn't mean that middle-click pointing or shift-click examining are going away; these short-cuts will definitely be alive and well; this is just giving you the original way of doing it back.

