### PR TITLE
Removes Emag RNG on APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -592,14 +592,10 @@
 			user << "Nothing happens."
 		else
 			flick("apc-spark", src)
-			if (do_after(user,6))
-				if(prob(50))
-					emagged = 1
-					locked = 0
-					user << "You emag the APC interface."
-					update_icon()
-				else
-					user << "You fail to [ locked ? "unlock" : "lock"] the APC interface."
+			emagged = 1
+			locked = 0
+			user << "You emag the APC interface."
+			update_icon()
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 /obj/machinery/power/apc/attack_hand(mob/user)


### PR DESCRIPTION
Probably should have just included this in the borg PR and called the PR "kills off emag RNG", but meh.

Either case, kills off the last (as far as I can tell anyway) piece of emag RNG in the game

- Removes RNG from APC emagging
- Removes the weird "do after" requirement for emagging an APC as well