### PR TITLE
[High Priority][Fix] Removes Collars from the Cargo Merch Store

### DIFF
--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -57,12 +57,6 @@
 	typepath = /obj/item/weapon/storage/box/dice
 	cost = 200
 
-/datum/storeitem/collar
-	name = "Pet Collar"
-	desc = "A box containing a pet collar; perfect for claiming a pet as your own personal accessory."
-	typepath = /obj/item/clothing/accessory/petcollar
-	cost = 350
-
 /datum/storeitem/crayons
 	name = "Crayons"
 	desc = "Let security know how they're doing by scrawling lovenotes all over their hallways."


### PR DESCRIPTION
Removes collars from the merch store, since they can be purchased MUCH
cheaper at the CritterCare vendor. The only advantage to them being here
is not needing to restock and the box you get with it.

This was meant to be included in #1295 before being merged, but was about 2 minutes late on committing it.