### PR TITLE
Autolathe Quality of Life: Build Tile

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -183,7 +183,7 @@
 		selected_category = href_list["category"]
 
 	if(href_list["make"])
-		BuildTurf = get_step(src.loc, get_dir(src,usr))
+		BuildTurf = loc
 
 		/////////////////
 		//href protection


### PR DESCRIPTION
Autolathe's currently spit out items on the floor at the location of where you're standing when you press the build button.

This changes it so the items are made and placed on top of the autolathe, like the Protolathe and circuit imprinter...and just about everything else that makes items.