### PR TITLE
Fixes Explosion Item Throwing

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -106,7 +106,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 			var/throw_dir = get_dir(epicenter,T)
 			for(var/obj/item/I in T)
 				spawn(0) //Simultaneously not one at a time
-					if(I)
+					if(I && !I.anchored)
 						var/throw_range = rand(throw_dist, max_range)
 						var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
 						I.throw_speed = 4 //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)


### PR DESCRIPTION
Courtesy of TG

Fixes anchored items (like intercoms, computers, etc.) getting thrown around by explosions.

Technically means slightly less lag from explosions too....*slight*.