### PR TITLE
Singulo Optimization

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -33,6 +33,7 @@ var/global/list/ghdel_profiling = list()
 	// Garbage collection
 	var/gc_destroyed=null
 
+	var/allow_spin = 1 //Set this to 1 for a _target_ that is being thrown at; if an atom has this set to 1 then atoms thrown AT it will not spin; currently used for the singularity. -Fox
 
 /atom/Destroy()
 	set_opacity(0)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -11,7 +11,7 @@
 	var/turf/throw_source = null
 	var/throw_speed = 2
 	var/throw_range = 7
-	var/no_spin = 0
+	var/no_spin_thrown = 0 //set this to 1 if you don't want an item that you throw to spin, no matter what. -Fox
 	var/moved_recently = 0
 	var/mob/pulledby = null
 
@@ -147,9 +147,9 @@
 	src.throwing = 1
 	src.thrower = thrower
 	src.throw_source = get_turf(src)	//store the origin turf
-
-	if(!no_spin)
-		SpinAnimation(5, 1)
+	if(target.allow_spin) // turns out 1000+ spinning objects being thrown at the singularity creates lag - Iamgoofball
+		if(!no_spin_thrown)
+			SpinAnimation(5, 1)
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -298,7 +298,7 @@ obj/item/weapon/twohanded/
 	force_wielded = 18 // Was 13, Buffed - RR
 	throwforce = 20
 	throw_speed = 3
-	no_spin = 1
+	no_spin_thrown = 1 // Thrown spears that spin look dumb. -Fox
 	flags = NOSHIELD
 	attack_verb = list("attacked", "poked", "jabbed", "torn", "gored")
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -830,6 +830,8 @@
 	float(!has_gravity)
 
 /mob/living/proc/float(on)
+	if(throwing)
+		return
 	if(on && !floating)
 		animate(src, pixel_y = 2, time = 10, loop = -1)
 		floating = 1

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -26,6 +26,7 @@
 	var/last_failed_movement = 0//Will not move in the same dir if it couldnt before, will help with the getting stuck on fields thing
 	var/last_warning
 	var/consumedSupermatter = 0 //If the singularity has eaten a supermatter shard and can go to stage six
+	allow_spin = 0
 
 /obj/singularity/New(loc, var/starting_energy = 50, var/temp = 0)
 	//CARN: admin-alert for chuckle-fuckery.


### PR DESCRIPTION
Singularity Optimization, courtesy of TG.

Items thrown AT the singularity will not spin, no matter what. As cool as it looks, it's rather expensive and incurs a decent amount of lag.

You won't notice a change in throwing+the spin animation 99% of the time; this ONLY impacts the singularity sucking in items into itself.