### PR TITLE
Powernet Tweaks

### DIFF
--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -32,16 +32,14 @@
 
 /datum/powernet
 	var/list/cables = list()	// all cables & junctions
-	var/list/nodes = list()		// all APCs & sources
+	var/list/nodes = list()		// all connected machines
 
-	var/newload = 0
-	var/load = 0
-	var/newavail = 0
-	var/avail = 0
-	var/viewload = 0
-	var/number = 0
-	var/perapc = 0			// per-apc avilability
-	var/netexcess = 0
+	var/load = 0				// the current load on the powernet, increased by each machine at processing
+	var/newavail = 0			// what available power was gathered last tick, then becomes...
+	var/avail = 0				//...the current available power in the powernet
+	var/viewload = 0			// the load as it appears on the power console (gradually updated)
+	var/number = 0				// Unused //TODEL
+	var/netexcess = 0			// excess power on the powernet (typically avail-load)
 
 
 

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -358,9 +358,9 @@
 		return 0
 	else
 		power = 1	// IVE GOT THE POWER!
-		if(PN) //runtime errors fixer. They were caused by PN.newload trying to access missing network in case of working on stored power.
+		if(PN) //runtime errors fixer. They were caused by PN.load trying to access missing network in case of working on stored power.
 			storedpower += shieldload
-			PN.newload += shieldload //uses powernet power.
+			PN.load += shieldload //uses powernet power.
 //		message_admins("[PN.load]", 1)
 //		use_power(250) //uses APC power
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -97,14 +97,14 @@
 
 	process()
 		if(attached)
-			var/datum/powernet/PN = attached.get_powernet()
+			var/datum/powernet/PN = attached.powernet
 			if(PN)
 				set_light(12)
 
 				// found a powernet, so drain up to max power from it
 
 				var/drained = min ( drain_rate, PN.avail )
-				PN.newload += drained
+				PN.load += drained
 				power_drained += drained
 
 				// if tried to drain more than available on powernet

--- a/code/modules/power/cable_logic.dm
+++ b/code/modules/power/cable_logic.dm
@@ -130,7 +130,7 @@
 	if( !(pn_input.avail >= LOGIC_HIGH))
 		pn_output.newavail = max(pn_output.avail, LOGIC_HIGH)	//Set the output avilable power to 5 or whatever it was before.
 	else
-		pn_output.newload += LOGIC_HIGH		//Otherwise increase the load to 5
+		pn_output.load += LOGIC_HIGH		//Otherwise increase the load to 5
 
 
 
@@ -202,7 +202,7 @@
 	if( (pn_input1.avail >= LOGIC_HIGH) && (pn_input2.avail >= LOGIC_HIGH) )
 		pn_output.newavail = max(pn_output.avail, LOGIC_HIGH)	//Set the output avilable power to 5 or whatever it was before.
 	else
-		pn_output.newload += LOGIC_HIGH		//Otherwise increase the load to 5
+		pn_output.load += LOGIC_HIGH		//Otherwise increase the load to 5
 
 //OR GATE
 /obj/machinery/logic/twoinput/or/process()
@@ -222,7 +222,7 @@
 	if( (pn_input1.avail >= LOGIC_HIGH) || (pn_input2.avail >= LOGIC_HIGH) )
 		pn_output.newavail = max(pn_output.avail, LOGIC_HIGH)	//Set the output avilable power to 5 or whatever it was before.
 	else
-		pn_output.newload += LOGIC_HIGH		//Otherwise increase the load to 5
+		pn_output.load += LOGIC_HIGH		//Otherwise increase the load to 5
 
 //XOR GATE
 /obj/machinery/logic/twoinput/xor/process()
@@ -242,7 +242,7 @@
 	if( (pn_input1.avail >= LOGIC_HIGH) != (pn_input2.avail >= LOGIC_HIGH) )
 		pn_output.newavail = max(pn_output.avail, LOGIC_HIGH)	//Set the output avilable power to 5 or whatever it was before.
 	else
-		pn_output.newload += LOGIC_HIGH		//Otherwise increase the load to 5
+		pn_output.load += LOGIC_HIGH		//Otherwise increase the load to 5
 
 //XNOR GATE (EQUIVALENCE)
 /obj/machinery/logic/twoinput/xnor/process()
@@ -262,7 +262,7 @@
 	if( (pn_input1.avail >= LOGIC_HIGH) == (pn_input2.avail >= LOGIC_HIGH) )
 		pn_output.newavail = max(pn_output.avail, LOGIC_HIGH)	//Set the output avilable power to 5 or whatever it was before.
 	else
-		pn_output.newload += LOGIC_HIGH		//Otherwise increase the load to 5
+		pn_output.load += LOGIC_HIGH		//Otherwise increase the load to 5
 
 #define RELAY_POWER_TRANSFER 2000	//How much power a relay transfers through.
 
@@ -284,7 +284,7 @@
 			return
 
 		if(pn_input2.avail >= RELAY_POWER_TRANSFER)
-			pn_input2.newload += RELAY_POWER_TRANSFER
+			pn_input2.load += RELAY_POWER_TRANSFER
 			pn_output.newavail += RELAY_POWER_TRANSFER
 
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -20,7 +20,7 @@
 
 /obj/machinery/power/proc/add_load(var/amount)
 	if(powernet)
-		powernet.newload += amount
+		powernet.load += amount
 
 /obj/machinery/power/proc/surplus()
 	if(powernet)
@@ -313,55 +313,25 @@
 
 
 /datum/powernet/proc/reset()
-	load = newload
-	newload = 0
+
+	//see if there's a surplus of power remaining in the powernet and stores unused power in the SMES
+	netexcess = avail - load
+
+	if(netexcess > 100 && nodes && nodes.len)		// if there was excess power last cycle
+		for(var/obj/machinery/power/smes/S in nodes)	// find the SMESes in the network
+			S.restore()				// and restore some of the power that was used
+
+	//updates the viewed load (as seen on power computers)
+	viewload = 0.8*viewload + 0.2*load
+	viewload = round(viewload)
+
+	//reset the powernet
+	load = 0
 	avail = newavail
 	newavail = 0
 
-
-	viewload = 0.8*viewload + 0.2*load
-
-	viewload = round(viewload)
-
-	var/numapc = 0
-
-	if(nodes && nodes.len) // Added to fix a bad list bug -- TLE
-		for(var/obj/machinery/power/terminal/term in nodes)
-			if( istype( term.master, /obj/machinery/power/apc ) )
-				numapc++
-
-	if(numapc)
-		perapc = avail/numapc
-
-	netexcess = avail - load
-
-	if( netexcess > 100)		// if there was excess power last cycle
-		if(nodes && nodes.len)
-			for(var/obj/machinery/power/smes/S in nodes)	// find the SMESes in the network
-				if(S.powernet == src)
-					S.restore()				// and restore some of the power that was used
-				else
-					error("[S.name] (\ref[S]) had a [S.powernet ? "different (\ref[S.powernet])" : "null"] powernet to our powernet (\ref[src]).")
-					nodes.Remove(S)
-
 /datum/powernet/proc/get_electrocute_damage()
-	switch(avail)/*
-		if (1300000 to INFINITY)
-			return min(rand(70,150),rand(70,150))
-		if (750000 to 1300000)
-			return min(rand(50,115),rand(50,115))
-		if (100000 to 750000-1)
-			return min(rand(35,101),rand(35,101))
-		if (75000 to 100000-1)
-			return min(rand(30,95),rand(30,95))
-		if (50000 to 75000-1)
-			return min(rand(25,80),rand(25,80))
-		if (25000 to 50000-1)
-			return min(rand(20,70),rand(20,70))
-		if (10000 to 25000-1)
-			return min(rand(20,65),rand(20,65))
-		if (1000 to 10000-1)
-			return min(rand(10,20),rand(10,20))*/
+	switch(avail)
 		if (5000000 to INFINITY)
 			return min(rand(200,300),rand(200,300))
 		if (4000000 to 5000000)
@@ -502,7 +472,7 @@
 		source_area.use_power(drained_energy/CELLRATE)
 	else if (istype(power_source,/datum/powernet))
 		var/drained_power = drained_energy/CELLRATE //convert from "joules" to "watts"
-		PN.newload+=drained_power
+		PN.load+=drained_power
 	else if (istype(power_source, /obj/item/weapon/stock_parts/cell))
 		cell.use(drained_energy)
 	return drained_energy

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -3,6 +3,7 @@
 
 #define SMESMAXCHARGELEVEL 200000
 #define SMESMAXOUTPUT 200000
+#define SMESRATE 0.05			// rate of internal charge to external power
 
 
 
@@ -44,7 +45,7 @@
 	spawn(5)
 		if(!powernet)
 			connect_to_network()
-		
+
 		dir_loop:
 			for(var/d in cardinal)
 				var/turf/T = get_step(src, d)
@@ -71,7 +72,7 @@
 	for(var/obj/item/weapon/stock_parts/cell/PC in component_parts)
 		C += PC.maxcharge
 	capacity = C / (15000) * 1e6
-	
+
 /obj/machinery/power/smes/proc/updateicon()
 	overlays.Cut()
 	if(stat & BROKEN)	return
@@ -225,21 +226,20 @@
 /obj/machinery/power/smes/proc/make_terminal(var/turf/T)
 	terminal = new/obj/machinery/power/terminal(T)
 	terminal.dir = get_dir(T,src)
-	terminal.master = src	
-	
+	terminal.master = src
+
 /obj/machinery/power/smes/proc/disconnect_terminal()
 	if(terminal)
 		terminal.master = null
-		terminal = null	
-	
+		terminal = null
+
 /obj/machinery/power/smes/proc/chargedisplay()
 	return round(5.5*charge/capacity)
 
-#define SMESRATE 0.05			// rate of internal charge to external power
 
 
 /obj/machinery/power/smes/process()
-	if(stat & BROKEN)	
+	if(stat & BROKEN)
 		return
 
 	//store machine state to see if we need to update the icon overlays
@@ -326,16 +326,16 @@
 
 /obj/machinery/power/smes/add_load(var/amount)
 	if(terminal && terminal.powernet)
-		terminal.powernet.newload += amount
+		terminal.powernet.load += amount
 
 
 /obj/machinery/power/smes/attack_ai(mob/user)
 	add_fingerprint(user)
 	ui_interact(user)
-	
+
 /obj/machinery/power/smes/attack_ghost(mob/user)
-	ui_interact(user)	
-	
+	ui_interact(user)
+
 /obj/machinery/power/smes/attack_hand(mob/user)
 	add_fingerprint(user)
 	ui_interact(user)

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -245,7 +245,7 @@
 		powered = 1
 		if(PN)
 			storedpower += shieldload
-			PN.newload += shieldload //uses powernet power.
+			PN.load += shieldload //uses powernet power.
 			*/
 
 /obj/machinery/shield_gen/proc/toggle()


### PR DESCRIPTION
Ports over some of Menshin's powernet tweaks: https://github.com/tgstation/-tg-station/pull/3794

Ideally, at some point, we should refactor the *entirety* of our powercode to TG's powercode; it's more efficient, has less processing, and isn't so quirky/buggy.

Performance
- Less processing
- A bit slower APC icon updates, meaning less processing
 - Yay for performance boosts

What you'll probably notice, as a player:
- Power sinks actually working effectively, like they used to
- Singulartiy beacon won't turn off after a short order
- May notice certain areas drain in power quicker if the engineers aren't doing their job
- May notice certain areas gain charger *faster* if the engineers ARE doing their job