### PR TITLE
Fixes One-Click Wizard and Runtimes

### DIFF
--- a/code/ATMOSPHERICS/pipes.dm
+++ b/code/ATMOSPHERICS/pipes.dm
@@ -470,7 +470,8 @@
 	update_icon()
 
 /obj/machinery/atmospherics/proc/universal_underlays(var/obj/machinery/atmospherics/node, var/direction)
-	var/turf/T = loc
+	var/turf/T = get_turf(src)
+	if(!istype(T)) return
 	if(node)
 		var/node_dir = get_dir(src,node)
 		if(node.icon_connect_type == "-supply")
@@ -632,6 +633,7 @@
 		underlays.Cut()
 
 		var/turf/T = get_turf(src)
+		if(!istype(T)) return
 		var/list/directions = list(NORTH, SOUTH, EAST, WEST)
 		var/node1_direction = get_dir(src, node1)
 		var/node2_direction = get_dir(src, node2)
@@ -890,6 +892,7 @@
 		*/
 
 		var/turf/T = get_turf(src)
+		if(!istype(T)) return
 		var/list/directions = list(NORTH, SOUTH, EAST, WEST)
 		var/node1_direction = get_dir(src, node1)
 		var/node2_direction = get_dir(src, node2)
@@ -1104,7 +1107,8 @@
 				node = target
 				break
 
-	var/turf/T = src.loc			// hide if turf is not intact
+	var/turf/T = get_turf(src)			// hide if turf is not intact
+	if(!istype(T)) return
 	hide(T.intact)
 	update_icon()
 

--- a/code/__HELPERS/timed_alerts.dm
+++ b/code/__HELPERS/timed_alerts.dm
@@ -20,7 +20,7 @@
 /mob/proc/timed_alert(question as text, title as text, default as text, time as num, \
 					 choice1 as text, choice2 as text, choice3 as text)
 
-	if (client) client.timed_alert(question, title, default, time, choice1, choice2, choice3)
+	if (client) return client.timed_alert(question, title, default, time, choice1, choice2, choice3)
 	return
 
 

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -151,6 +151,8 @@
 	return
 
 /obj/machinery/dna_scannernew/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
+	if(!istype(O))
+		return
 	if(O.loc == user) //no you can't pull things out of your ass
 		return
 	if(user.restrained() || user.stat || user.weakened || user.stunned || user.paralysis || user.resting) //are you cuffed, dying, lying, stunned or other

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -556,6 +556,7 @@
 
 /obj/machinery/alarm/proc/ui_air_status()
 	var/turf/location = get_turf(src)
+	if(!istype(location)) return
 	var/datum/gas_mixture/environment = location.return_air()
 	var/total = environment.oxygen + environment.carbon_dioxide + environment.toxins + environment.nitrogen
 	if(total==0)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -66,11 +66,12 @@
 			break
 
 /obj/machinery/atmospherics/unary/cryo_cell/Destroy()
-	var/turf/T = loc
-	T.contents += contents
-	var/obj/item/weapon/reagent_containers/glass/B = beaker
-	if(beaker)
-		B.loc = get_step(loc, SOUTH) //Beaker is carefully ejected from the wreckage of the cryotube
+	var/turf/T = get_turf(src)
+	if(istype(T))
+		T.contents += contents
+		var/obj/item/weapon/reagent_containers/glass/B = beaker
+		if(beaker)
+			B.loc = get_step(T, SOUTH) //Beaker is carefully ejected from the wreckage of the cryotube
 	..()
 
 /obj/machinery/atmospherics/unary/cryo_cell/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -372,6 +372,8 @@
 		var/obj/item/organ/eyes/E = H.internal_organs_by_name["eyes"]
 		if(H.species.flags & IS_SYNTHETIC)
 			return
+		if(!E) // No eyes? No problem!
+			return
 		switch(safety)
 			if(1)
 				usr << "\red Your eyes sting a little."

--- a/code/game/vehicles/spacepods/spacepod.dm
+++ b/code/game/vehicles/spacepods/spacepod.dm
@@ -241,7 +241,7 @@
 			else
 				user << "<span class='notice'>You insert \the [W] into the equipment system.</span>"
 				user.drop_item(W)
-				W.forceMove(equipment_system)
+				W.forceMove(src)
 				equipment_system.weapon_system = W
 				equipment_system.weapon_system.my_atom = src
 				return
@@ -253,7 +253,7 @@
 			else
 				user << "<span class='notice'>You insert \the [W] into the equipment system.</span>"
 				user.drop_item(W)
-				W.forceMove(equipment_system)
+				W.forceMove(src)
 				equipment_system.misc_system = W
 				equipment_system.misc_system.my_atom = src
 				return

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -150,7 +150,7 @@ client/proc/one_click_antag()
 	var/time_passed = world.time
 
 	for(var/mob/G in respawnable_list)
-		if(G.client.prefs.be_special & BE_WIZARD)
+		if(istype(G) && G.client && G.client.prefs.be_special & BE_WIZARD)
 			if(!jobban_isbanned(G, "wizard") && !jobban_isbanned(G, "Syndicate"))
 				if(player_old_enough_antag(G.client,BE_WIZARD))
 					spawn(0)
@@ -224,7 +224,7 @@ client/proc/one_click_antag()
 	var/time_passed = world.time
 
 	for(var/mob/G in respawnable_list)
-		if(G.client.prefs.be_special & BE_OPERATIVE)
+		if(istype(G) && G.client && G.client.prefs.be_special & BE_OPERATIVE)
 			if(!jobban_isbanned(G, "operative") && !jobban_isbanned(G, "Syndicate"))
 				if(player_old_enough_antag(G.client,BE_OPERATIVE))
 					spawn(0)
@@ -451,7 +451,7 @@ client/proc/one_click_antag()
 
 	//Generates a list of candidates from active ghosts.
 	for(var/mob/G in respawnable_list)
-		if(G.client.prefs.be_special & BE_RAIDER)
+		if(istype(G) && G.client && G.client.prefs.be_special & BE_RAIDER)
 			if(player_old_enough_antag(G.client,BE_RAIDER))
 				if(!jobban_isbanned(G, "raider") && !jobban_isbanned(G, "Syndicate"))
 					spawn(0)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -168,7 +168,7 @@ client/proc/one_click_antag()
 
 	if(candidates.len)
 		candidates = shuffle(candidates)
-		for(var/mob/i in candidates)
+		for(var/mob/dead/observer/i in candidates)
 			if(!i || !i.client) continue //Dont bother removing them from the list since we only grab one wizard
 
 			theghost = i

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1191,13 +1191,13 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		/* HUD shit goes here, as long as it doesn't modify sight flags */
 		// The purpose of this is to stop xray and w/e from preventing you from using huds -- Love, Doohl
 
-					switch(G.HUDType)
-						if(SECHUD)
-							process_sec_hud(src,1)
-						if(MEDHUD)
-							process_med_hud(src,1)
-						if(ANTAGHUD)
-							process_antag_hud(src)
+						switch(G.HUDType)
+							if(SECHUD)
+								process_sec_hud(src,1)
+							if(MEDHUD)
+								process_med_hud(src,1)
+							if(ANTAGHUD)
+								process_antag_hud(src)
 
 				if(head)
 					var/obj/item/clothing/head/H = head
@@ -1209,13 +1209,13 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		/* HUD shit goes here, as long as it doesn't modify sight flags */
 		// The purpose of this is to stop xray and w/e from preventing you from using huds -- Love, Doohl
 
-					switch(H.HUDType)
-						if(SECHUD)
-							process_sec_hud(src,1)
-						if(MEDHUD)
-							process_med_hud(src,1)
-						if(ANTAGHUD)
-							process_antag_hud(src)
+						switch(H.HUDType)
+							if(SECHUD)
+								process_sec_hud(src,1)
+							if(MEDHUD)
+								process_med_hud(src,1)
+							if(ANTAGHUD)
+								process_antag_hud(src)
 
 
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -441,6 +441,7 @@ datum
 				if(!isnum(amount)) return 1
 				update_total()
 				if(total_volume + amount > maximum_volume) amount = (maximum_volume - total_volume) //Doesnt fit in. Make it disappear. Shouldnt happen. Will happen.
+				if(amount <= 0) return 0
 				chem_temp = round(((amount * reagtemp) + (total_volume * chem_temp)) / (total_volume + amount)) //equalize with new chems
 
 				for(var/A in reagent_list)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -199,8 +199,9 @@ Note: Must be placed west/left of and R&D console to function.
 	src.updateUsrDialog()
 
 	if(stack)
-		src.overlays += "protolathe_[stack.name]"
+		var/stackname = stack.name
+		src.overlays += "protolathe_[stackname]"
 		sleep(10)
-		src.overlays -= "protolathe_[stack.name]"
+		src.overlays -= "protolathe_[stackname]"
 
 	return


### PR DESCRIPTION
This was supposed to just be runtime fixes, but then I figured out why Make Wizard wasn't working. After **nearly eleven months** of being broken, admins may once again make a wizard with a single click!

This doesn't fix Ragin' Mages. Still no idea what's wrong with *that.*

This also fixes a bunch of runtimes. Only one noteworthy one, though:
* Fixes welding tools trying to damage eyes that don't exist, resulting in pointless messages and runtimes.
  * Slime people will no longer get the eye-burning warning when welding, because they have no eyes to burn. It should now be more obvious that they're immune to eye damage.