### PR TITLE
[Fix] Diona Nymph runtime and Fruit Attack fixes

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -284,7 +284,7 @@
 	if(user == M)
 		return ..()
 
-	if(user.a_intent == "hurt")
+	if(user.a_intent == "harm")
 
 		// This is being copypasted here because reagent_containers (WHY DOES FOOD DESCEND FROM THAT) overrides it completely.
 		// TODO: refactor all food paths to be less horrible and difficult to work with in this respect. ~Z
@@ -349,7 +349,7 @@
 	if(istype(user.loc,/turf/space))
 		return
 
-	if(user.a_intent == "hurt")
+	if(user.a_intent == "harm")
 		user.visible_message("<span class='danger'>\The [user] squashes \the [src]!</span>")
 		seed.thrown_at(src,user)
 		sleep(-1)

--- a/code/modules/mob/living/carbon/primitive/dionaold.dm
+++ b/code/modules/mob/living/carbon/primitive/dionaold.dm
@@ -146,7 +146,7 @@
 
 	if(!src || !target || target.weedlevel == 0) return //Sanity check.
 
-	src.reagents.add_reagent("nutriment", target.weedlevel)
+	src.nutrition += target.weedlevel * 15
 	target.weedlevel = 0
 	src.visible_message("\red [src] begins rooting through [target], ripping out weeds and eating them noisily.","\red You begin rooting through [target], ripping out weeds and eating them noisily.")
 


### PR DESCRIPTION
Fixes a runtime preventing Diona Nymphs from eating weeds and regaining nutrition

Fixes fruit attacks checking for "hurt" when they should check for "harm".
- You can now smack people with fruit on harm intent.
 - This treats the fruit as a weapon and not trying to force-feed someone it.
 - If the plant has TRAIT_STINGS, it will also inject them with it's chemicals
- You can now crush a fruit in your hand on harm intent to destroy it (will not leave trash like banana peels!). This will trigger the same effects that throwing the fruit would have, except without needing to throw it.
 - Use this to activate that smoke-screen tobacco you spent all round mutating, create fruit smears beneath you, or to make a quick escape with your bluespace tomato!