### PR TITLE
Makes security officers/ warden start with disablers.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -178,7 +178,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/helmet(H), slot_head)
 		H.equip_or_collect(new /obj/item/device/pda/security(H), slot_wear_pda)
 		H.equip_or_collect(new /obj/item/clothing/gloves/color/black(H), slot_gloves)
-		H.equip_or_collect(new /obj/item/weapon/gun/energy/advtaser(H), slot_s_store)
+		H.equip_or_collect(new /obj/item/weapon/gun/energy/disabler(H), slot_s_store)
 		H.equip_or_collect(new /obj/item/device/flash(H), slot_l_store)
 		if(H.backbag == 1)
 			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -78,7 +78,7 @@
 		H.equip_or_collect(new /obj/item/clothing/glasses/sunglasses/sechud(H), slot_glasses)
 //		H.equip_or_collect(new /obj/item/clothing/mask/gas(H), slot_wear_mask) //Grab one from the armory you donk
 		H.equip_or_collect(new /obj/item/device/flash(H), slot_l_store)
-		H.equip_or_collect(new /obj/item/weapon/gun/energy/advtaser(H), slot_s_store)
+		H.equip_or_collect(new /obj/item/weapon/gun/energy/disabler(H), slot_s_store)
 		if(H.backbag == 1)
 			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
 			H.equip_or_collect(new /obj/item/weapon/restraints/handcuffs(H), slot_l_hand)


### PR DESCRIPTION
Ohhhhhh this is going to suck.

Players:
 -Security officers and wardens will now start with disablers instead of advanced tasers. There are still three in the armory.
The Head of Security will keep their instastun, mostly due to the fact that they SHOULD be strong, and until further changes to remove instastun happen (If ever), they should keep it.
Admins:
-Enjoy the large wave of adminhelps of "WHERE'S MY TASER?!"

Everyone knows my opinion on this, so I'm not going to comment even once in here.
Edit: Yes, I'm pretty aware this likely isn't happening. Also, before I forget: @tigercat2000 