### PR TITLE
Codebase Size Reduction--Music

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -127,7 +127,7 @@ var/list/ghostteleportlocs = list()
 	power_light = 0
 	power_equip = 0
 	power_environ = 0
-	ambientsounds = list('sound/ambience/ambispace.ogg','sound/music/title2.ogg','sound/music/space.ogg','sound/music/main.ogg','sound/music/traitor.ogg')
+	ambientsounds = list('sound/ambience/ambispace.ogg','sound/music/title2.ogg','sound/music/space.ogg','sound/music/traitor.ogg')
 
 //These are shuttle areas, they must contain two areas in a subgroup if you want to move a shuttle from one
 //place to another. Look at escape shuttle for example.
@@ -1444,7 +1444,7 @@ var/list/ghostteleportlocs = list()
 /area/medical/morgue
 	name = "\improper Morgue"
 	icon_state = "morgue"
-	ambientsounds = list('sound/ambience/ambimo1.ogg','sound/ambience/ambimo2.ogg','sound/music/main.ogg')
+	ambientsounds = list('sound/ambience/ambimo1.ogg','sound/ambience/ambimo2.ogg')
 
 /area/medical/chemistry
 	name = "\improper Chemistry"

--- a/code/modules/mining/mine_areas.dm
+++ b/code/modules/mining/mine_areas.dm
@@ -2,7 +2,6 @@
 
 /area/mine
 	icon_state = "mining"
-	music = 'sound/ambience/song_game.ogg'
 
 /area/mine/explored
 	name = "Mine"

--- a/sound/serversound_list.txt
+++ b/sound/serversound_list.txt
@@ -4,6 +4,7 @@ sound/music/THUNDERDOME.ogg
 sound/music/space.ogg
 sound/music/title1.ogg
 sound/music/title2.ogg
+sound/music/title3.ogg
 sound/music/traitor.ogg
 sound/items/bikehorn.ogg
 sound/effects/siren.ogg


### PR DESCRIPTION
So, after gathering some input, there apepared to be a general consensus that it was ok to cut a few music files to get the .rsc down a bit smaller for players--a number of music files were put up for evaluation, and a few of them cropped up more than others.

This *doesn't* remove the songs from the codebase, just the .RSC 

IF MERGED IN THIS REQUIRES A CLEAN COMPILE

Of note, and put in for removal from the .RSC:

- Song Game 
 - Dwarf Fortress song that is mining ambience that tends to conflict with other ambience
 - Generally disliked for its length and the fact that "if I want to listen to this, I'll bring it up and listen to it manually while mining"

- Main 
 - Old Goon song


Other
- Adds Title3.ogg to the server sound list (oversight when Title3 was added)