### PR TITLE
Update travis.yml to use BYOND 508.1289

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: c
 env:
     global:
     - BYOND_MAJOR="508"
-    - BYOND_MINOR="1287"
+    - BYOND_MINOR="1289"
     matrix:
     - DM_MAPFILE="cyberiad"
 


### PR DESCRIPTION
Now that BYOND has their latest linux build, this can be done.
Fairly important that it uses this version, since 1287 has odd bugs and developing shouldn't be done with it.