### PR TITLE
Objective Tweaks

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -94,7 +94,7 @@ datum/objective/mutiny
 	find_target_by_role(role, role_type=0)
 		..(role, role_type)
 		if(target && target.current)
-			explanation_text = "Assassinate [target.current.real_name], the [!role_type ? target.assigned_role : target.special_role]."
+			explanation_text = "Assassinate  or exile [target.current.real_name], the [!role_type ? target.assigned_role : target.special_role]."
 		else
 			explanation_text = "Free Objective"
 		return target

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -53,11 +53,6 @@
 	typepath = /obj/item/weapon/tank/jetpack
 	protected_jobs = list("Chief Engineer")
 
-/datum/theft_objective/cap_jumpsuit
-	name = "the captain's jumpsuit"
-	typepath = /obj/item/clothing/under/rank/captain
-	protected_jobs = list("Captain")
-
 /datum/theft_objective/ai
 	name = "a functional AI"
 	typepath = /obj/item/device/aicard
@@ -100,11 +95,6 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/device/aicard/C)
 			return 1
 	return 0
 
-/datum/theft_objective/corgi
-	name = "a piece of corgi meat"
-	typepath = /obj/item/weapon/reagent_containers/food/snacks/meat/corgi
-	protected_jobs = list("Head of Personnel", "Quartermaster", "Cargo Technician")
-
 /datum/theft_objective/capmedal
 	name = "the medal of captaincy"
 	typepath = /obj/item/clothing/accessory/medal/gold/captain
@@ -124,42 +114,12 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/device/aicard/C)
 	name = "any set of secret documents of any organization"
 	typepath = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's
 
-/datum/theft_objective/rd_jumpsuit
-	name = "the research director's jumpsuit"
-	typepath = /obj/item/clothing/under/rank/research_director
-	protected_jobs = list("Research Director")
-
-/datum/theft_objective/ce_jumpsuit
-	name = "the chief engineer's jumpsuit"
-	typepath = /obj/item/clothing/under/rank/chief_engineer
-	protected_jobs = list("Chief Engineer")
-
-/datum/theft_objective/cmo_jumpsuit
-	name = "the chief medical officer's jumpsuit"
-	typepath = /obj/item/clothing/under/rank/chief_medical_officer
-	protected_jobs = list("Chief Medical Officer")
-
-/datum/theft_objective/hos_jumpsuit
-	name = "the head of security's jumpsuit"
-	typepath = /obj/item/clothing/under/rank/head_of_security
-	protected_jobs = list("Head of Security")
-
-/datum/theft_objective/hop_jumpsuit
-	name = "the head of personnel's jumpsuit"
-	typepath = /obj/item/clothing/under/rank/head_of_personnel
-	protected_jobs = list("Head of Personnel")
-
 /datum/theft_objective/hypospray
 	name = "a hypospray"
 	typepath = /obj/item/weapon/reagent_containers/hypospray
 	protected_jobs = list("Chief Medical Officer")
 
-/datum/theft_objective
-	name = "the captain's pinpointer"
-	typepath = /obj/item/weapon/pinpointer
-	protected_jobs = list("Captain")
-
-/datum/theft_objective
+/datum/theft_objective/ablative
 	name = "an ablative armor vest"
 	typepath = /obj/item/clothing/suit/armor/laserproof
 	protected_jobs = list("Head of Security", "Warden")


### PR DESCRIPTION
Inspired by a recent PR on TG.

Removes a number of notoriously easy "gimme" objectives that carry little risk or that can be cheesed. End goal is to introduce a bit more dynamism+action+interaction in traitor rounds. A number of these objectives don't really encourage that.

- Removes Head jumpsuit objectives
 - Heads don't generally give a crap about their jumpsuits and really don't have any reason to want to hold onto these other than "they're a potential traitor item" (also why the hell would the syndicakes want a damn jumpsuit when they have chameleon suits); things like the captain's laser gun, CMO's hypospray, etc. all present unique challenges and typically force more interaction amongst players. 

- Removes corgi meat objective
 - Easy as pie (cargo, corgium, player controlled Ian wandering the halls) and a bit dated; doesn't really encourage interaction or incur any real risk, either.

Fixes
- Fixes the abalative armor objective not showing up
- Fixes a duplicate instance of the pinpointer objective
- Clarifies the mutiny objective