### PR TITLE
Fixes get_apc and a mountable frame issue

### DIFF
--- a/code/game/objects/items/mountable_frames/apc_frame.dm
+++ b/code/game/objects/items/mountable_frames/apc_frame.dm
@@ -9,7 +9,6 @@
 	if(..())
 		var/turf/turf_loc = get_turf(user)
 		var/area/area_loc = turf_loc.loc
-		if(istype(area_loc,/area/mine))	return
 		if (area_loc.get_apc())
 			user << "<span class='rose'>This area already has an APC.</span>"
 			return //only one APC per area

--- a/code/game/objects/items/mountable_frames/frames.dm
+++ b/code/game/objects/items/mountable_frames/frames.dm
@@ -19,7 +19,9 @@
 		if (src.mount_reqs.Find("simfloor") && !istype(turf_loc, /turf/simulated/floor))
 			user << "<span class='rose'>[src] cannot be placed on this spot.</span>"
 			return
-		if (src.mount_reqs.Find("nospace") && (areaMaster.requires_power == 0 || istype(areaMaster,/area/space)))
-			user << "<span class='rose'>[src] cannot be placed in this area.</span>"
-			return
+		if (src.mount_reqs.Find("nospace"))
+			var/area/my_area = turf_loc.loc
+			if(!istype(my_area) || (my_area.requires_power == 0 || istype(my_area,/area/space)))
+				user << "<span class='rose'>[src] cannot be placed in this area.</span>"
+				return
 		return 1

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -404,8 +404,11 @@
 	return null
 
 /area/proc/get_apc()
-	var/obj/machinery/power/apc/FINDME = locate() in src
-	if (FINDME)
+	// This was a simple locate() in src, but an unresolved BYOND bug causes trying to locate() in an
+	//  area to take an inconceivably long time, especially for large areas.
+	// See: http://www.byond.com/forum/?post=1860571
+	var/obj/machinery/power/apc/FINDME
+	for(FINDME in src)
 		return FINDME
 
 


### PR DESCRIPTION
* Fixes get_apc causing horrible freezing thanks to [an unresolved BYOND bug](http://www.byond.com/forum/?post=1860571).
  * This should fix the server freezing when placing an APC or getting shocked by a door.
  * Reverts #1338, due to that band-aid fix no longer being necessary.
* Fixes mountable frames not checking their area properly.