### PR TITLE
Fixes Cult Icon Removal, Probably

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -305,8 +305,8 @@
 /datum/game_mode/proc/cult_icon_pair_unlink(datum/mind/first_cultist,datum/mind/second_cultist)
 	if (!istype(first_cultist) || !istype(second_cultist))
 		return 0
-	remove_cult_icon(first_cultist,second_cultist)
-	remove_cult_icon(second_cultist,first_cultist)
+	remove_cult_icon_from_cultist(first_cultist,second_cultist)
+	remove_cult_icon_from_cultist(second_cultist,first_cultist)
 
 
 /datum/game_mode/proc/update_cult_icons_added(datum/mind/cult_mind)


### PR DESCRIPTION
This fixes a pretty nasty mistake in the code responsible for removing cultist icons.

A mistake that's been around since December of 2013, making cultist deconversion go *horribly wrong* all this time.

I can't actually say for sure whether this is the only issue with the cultist icon code, but this is the only immediately obvious one, so it probably fixes cult icon removal.