### PR TITLE
Removes a few Hitby Messages

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -175,7 +175,6 @@
 /obj/machinery/door/window/hitby(AM as mob|obj)
 
 	..()
-	visible_message("<span class='danger'>\The [src] was hit by \the [AM].</span>")
 	var/tforce = 0
 	if(ismob(AM))
 		tforce = 40

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -103,8 +103,6 @@
 
 
 /obj/machinery/shield/hitby(AM as mob|obj)
-	//Let everyone know we've been hit!
-	visible_message("\red <B>[src] was hit by [AM].</B>")
 
 	//Super realistic, resource-intensive, real-time damage calculations.
 	var/tforce = 0

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -99,7 +99,6 @@
 
 /obj/structure/alien/resin/hitby(atom/movable/AM)
 	..()
-	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
 	var/tforce = 0
 	if(!isobj(AM))
 		tforce = 10

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -102,7 +102,6 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 
 /obj/structure/window/hitby(AM as mob|obj)
 	..()
-	visible_message("<span class='danger'>[src] was hit by [AM].</span>")
 	var/tforce = 0
 	if(isobj(AM))
 		var/obj/item/I = AM


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/pull/10033

Removes some hitby messages to help cut down on lag.

Explosions, people gibbing (organs everywhere), the singularity, and a number of other things all throw stuff around...which can in turn proc tons and tons of messages in a very short order, which can cause lag and performance issues--this removes them to cut down on the spam players see when these events occur and to increase performance.