### PR TITLE
Explosion Rework

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -28,12 +28,11 @@ var/Debug = 0	// global debug switch
 var/Debug2 = 1   // enables detailed job debug file in secrets
 
 //This was a define, but I changed it to a variable so it can be changed in-game.(kept the all-caps definition because... code...) -Errorage
-var/MAX_EXPLOSION_RANGE = 14
 var/MAX_EX_DEVESTATION_RANGE = 3
 var/MAX_EX_HEAVY_RANGE = 7
 var/MAX_EX_LIGHT_RANGE = 14
 var/MAX_EX_FLASH_RANGE = 14
-//#define MAX_EXPLOSION_RANGE		14					// Defaults to 12 (was 8) -- TLE
+var/MAX_EX_FLAME_RANGE = 14
 
 var/list/be_special_flags = list(
 	"traitor" = BE_TRAITOR,

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -346,9 +346,6 @@
 				if("protect_roles_from_antagonist")
 					config.protect_roles_from_antagonist = 1
 
-				if("reactionary_explosions")
-					config.reactionary_explosions	= 1
-
 				if ("probability")
 					var/prob_pos = findtext(value, " ")
 					var/prob_name = null
@@ -561,6 +558,22 @@
 					config.bones_can_break = value
 				if("limbs_can_break")
 					config.limbs_can_break = value
+				if("reactionary_explosions")
+					config.reactionary_explosions	= 1
+				if("bombcap")
+					var/BombCap = text2num(value)
+					if (!BombCap)
+						continue
+					if (BombCap < 4)
+						BombCap = 4
+					if (BombCap > 128)
+						BombCap = 128
+
+					MAX_EX_DEVESTATION_RANGE = round(BombCap/4)
+					MAX_EX_HEAVY_RANGE = round(BombCap/2)
+					MAX_EX_LIGHT_RANGE = BombCap
+					MAX_EX_FLASH_RANGE = BombCap
+					MAX_EX_FLAME_RANGE = BombCap
 				if("default_laws")
 					config.default_laws = text2num(value)
 				else

--- a/code/datums/pizza_bomb.dm
+++ b/code/datums/pizza_bomb.dm
@@ -54,7 +54,7 @@
 		return
 	src.audible_message("\icon[src] <b>[src]</b> beeps, \"Enjoy the pizza!\"")
 	src.visible_message("<span class='userdanger'>\The [src] violently explodes!</span>")
-	explosion(src.loc,1,2,4) //Identical to a minibomb
+	explosion(src.loc,1,2,4,flame_range = 2) //Identical to a minibomb
 	qdel(src)
 
 /obj/item/device/pizza_bomb/attackby(var/obj/item/I, var/mob/user, params)

--- a/code/datums/spells/explosion.dm
+++ b/code/datums/spells/explosion.dm
@@ -5,10 +5,11 @@
 	var/ex_severe = 1
 	var/ex_heavy = 2
 	var/ex_light = 3
+	var/ex_flash = 4
 
 /obj/effect/proc_holder/spell/wizard/targeted/explosion/cast(list/targets)
 
 	for(var/mob/living/target in targets)
-		explosion(target.loc,ex_severe,ex_heavy,ex_light)
+		explosion(target.loc,ex_severe,ex_heavy,ex_light,ex_flash)
 
 	return

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -272,7 +272,7 @@
 	action_icon_state = "fireball"
 
 /obj/effect/proc_holder/spell/wizard/turf/fireball/cast(var/turf/T)
-	explosion(T, -1, 0, 2, 3, 0)
+	explosion(T, -1, 0, 2, 3, 0, flame_range = 2)
 
 
 /obj/effect/proc_holder/spell/wizard/targeted/inflict_handler/fireball

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -196,7 +196,7 @@ rcd light flash thingy on matter drain
 					V.show_message("<span class='notice'>You hear a loud electrical buzzing sound!</span>", 2)
 				spawn(50)
 					explosion(get_turf(M), 0,1,1,0)
-					del(M)
+					qdel(M)
 			else src << "<span class='notice'>Out of uses.</span>"
 	else src << "<span class='notice'>That's not a machine.</span>"
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -555,8 +555,8 @@
 
 /obj/item/weapon/spellbook/oneuse/fireball/recoil(mob/user as mob)
 	..()
-	explosion(user.loc, -1, 0, 2, 3, 0)
-	del(src)
+	explosion(user.loc, -1, 0, 2, 3, 0, flame_range = 2)
+	qdel(src)
 
 /obj/item/weapon/spellbook/oneuse/smoke
 	spell = /obj/effect/proc_holder/spell/wizard/targeted/smoke

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -97,6 +97,7 @@
 	icon = 'icons/obj/doors/vault.dmi'
 	opacity = 1
 	assembly_type = /obj/structure/door_assembly/door_assembly_highsecurity //Until somebody makes better sprites.
+	explosion_block = 2
 
 /obj/machinery/door/airlock/freezer
 	name = "Freezer Airlock"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -21,10 +21,15 @@ var/list/doppler_arrays = list()
 
 /obj/machinery/doppler_array/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if(istype(O, /obj/item/weapon/wrench))
+		if(!anchored && !isinspace())
+			anchored = 1
+			power_change()
+			user << "<span class='notice'>You fasten [src].</span>"
+		else if(anchored)
+			anchored = 0
+			power_change()
+			user << "<span class='notice'>You unfasten [src].</span>"
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		anchored = !anchored
-		power_change()
-		user << "You [anchored ? "wrench" : "unwrench"] [src]."
 
 /obj/machinery/doppler_array/verb/rotate()
 	set name = "Rotate Tachyon-doppler Dish"
@@ -33,12 +38,13 @@ var/list/doppler_arrays = list()
 
 	if(!usr || !isturf(usr.loc))
 		return
-	if(usr.stat || usr.restrained())
+	if(usr.stat || usr.restrained() || !usr.canmove)
 		return
 	src.dir = turn(src.dir, 90)
 	return
 
-/obj/machinery/doppler_array/proc/sense_explosion(var/x0,var/y0,var/z0,var/devastation_range,var/heavy_impact_range,var/light_impact_range,var/took)
+/obj/machinery/doppler_array/proc/sense_explosion(var/x0,var/y0,var/z0,var/devastation_range,var/heavy_impact_range,var/light_impact_range,
+												  var/took,var/orig_dev_range,var/orig_heavy_range,var/orig_light_range)
 	if(stat & NOPOWER)	return
 	if(z != z0)			return
 
@@ -59,10 +65,18 @@ var/list/doppler_arrays = list()
 	if(distance > 100)		return
 	if(!(direct & dir))	return
 
-	var/message = "Explosive disturbance detected - Epicenter at: grid ([x0],[y0]). Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range]. Temporal displacement of tachyons: [took] seconds."
+
+	var/list/messages = list("Explosive disturbance detected.", \
+							 "Epicenter at: grid ([x0],[y0]). Temporal displacement of tachyons: [took] seconds.", \
+							 "Factual: Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range].")
+
+	// If the bomb was capped, say it's theoretical size.
+	if(devastation_range < orig_dev_range || heavy_impact_range < orig_heavy_range || light_impact_range < orig_light_range)
+		messages += "Theoretical: Epicenter radius: [orig_dev_range]. Outer radius: [orig_heavy_range]. Shockwave radius: [orig_light_range]."
 
 	for(var/mob/O in hearers(src, null))
-		O.show_message("<span class='game say'><span class='name'>[src]</span> states coldly, \"[message]\"",2)
+		for(var/message in messages)
+			O.show_message("<span class='game say'><span class='name'>[src]</span> states coldly, \"[message]\"",2)
 
 
 /obj/machinery/doppler_array/power_change()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -183,13 +183,13 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			del(src)
+			qdel(src)
 		if(2.0)
 			if (prob(50))
-				del(src)
+				qdel(src)
 		if(3.0)
 			if (prob(5))
-				del(src)
+				qdel(src)
 	return
 
 /obj/machinery/hologram/blob_act()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -187,8 +187,10 @@
 	if(adminlog)
 		message_admins(adminlog)
 		log_game(adminlog)
-	explosion(get_turf(src),2,5,11)
-	del(src)
+	explosion(get_turf(src),2,5,11, flame_range = 11)
+	if(src.loc && istype(src.loc,/obj/machinery/syndicatebomb/))
+		qdel(src.loc)
+	qdel(src)
 
 /obj/item/weapon/bombcore/proc/defuse()
 //Note: 	Because of how var/defused is used you shouldn't override this UNLESS you intend to set the var to 0 or
@@ -269,16 +271,17 @@
 	var/HeavyExplosion = 2
 	var/MediumExplosion = 5
 	var/LightExplosion = 11
+	var/Flames = 11
 
 /obj/item/weapon/bombcore/badmin/explosion/detonate()
-	explosion(get_turf(src),HeavyExplosion,MediumExplosion,LightExplosion)
+	explosion(get_turf(src),HeavyExplosion,MediumExplosion,LightExplosion, flame_range = Flames)
 
 /obj/item/weapon/bombcore/miniature
 	name = "small bomb core"
 	w_class = 2
 
 /obj/item/weapon/bombcore/miniature/detonate()
-	explosion(src.loc,1,2,4) //Identical to a minibomb
+	explosion(src.loc,1,2,4,flame_range = 2) //Identical to a minibomb
 	qdel(src)
 
 ///Syndicate Detonator (aka the big red button)///

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -363,8 +363,8 @@
 
 	throw_impact(atom/hit_atom)
 		if(primed)
-			explosion(hit_atom, 0, 0, 2, 4)
-			del(src)
+			explosion(hit_atom, 0, 0, 2, 4, 0)
+			qdel(src)
 		else
 			..()
 		return

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -633,7 +633,7 @@
 						T.Entered(O)
 
 			if(prob(30))
-				explosion(T, 0, 0, 1, 3)
+				explosion(get_turf(loc), 0, 0, 1, 3)
 			spawn(0)
 				if(wreckage)
 					var/obj/effect/decal/mecha_wreckage/WR = new wreckage(T)

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -91,11 +91,11 @@
 		return answer
 
 	emp_act()
-		del src
+		qdel(src)
 		return
 
 	ex_act()
-		del src
+		qdel(src)
 		return
 
 	proc/in_mecha()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -209,8 +209,8 @@
 			new /obj/structure/alien/weeds(T, linked_node)
 
 
-/obj/structure/alien/weeds/ex_act(severity, target)
-	del(src)
+/obj/structure/alien/weeds/ex_act(severity)
+	qdel(src)
 
 
 /obj/structure/alien/weeds/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1102,11 +1102,11 @@ steam.start() -- spawns the effect
 		qdel(src)
 
 	blob_act()
-		del(src)
+		qdel(src)
 
 	bullet_act()
 		if(metal==1 || prob(50))
-			del(src)
+			qdel(src)
 
 	attack_hand(var/mob/user)
 		if ((HULK in user.mutations) || (prob(75 - metal*25)))
@@ -1115,7 +1115,7 @@ steam.start() -- spawns the effect
 				if ((O.client && !( O.blinded )))
 					O << "\red [user] smashes through the foamed metal."
 
-			del(src)
+			qdel(src)
 		else
 			user << "\blue You hit the metal foam but bounce off it."
 		return
@@ -1129,8 +1129,8 @@ steam.start() -- spawns the effect
 			for(var/mob/O in viewers(src))
 				if (O.client)
 					O << "\red [G.assailant] smashes [G.affecting] through the foamed metal wall."
-			del(I)
-			del(src)
+			qdel(I)
+			qdel(src)
 			return
 
 		if(prob(I.force*20 - metal*25))
@@ -1138,7 +1138,7 @@ steam.start() -- spawns the effect
 			for(var/mob/O in oviewers(user))
 				if ((O.client && !( O.blinded )))
 					O << "\red [user] smashes through the foamed metal."
-			del(src)
+			qdel(src)
 		else
 			user << "\blue You hit the metal foam to no effect."
 

--- a/code/game/objects/effects/sm_crystals.dm
+++ b/code/game/objects/effects/sm_crystals.dm
@@ -156,15 +156,15 @@
 /obj/effect/supermatter_crystal/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			del(src)
+			qdel(src)
 			return
 		if(2.0)
 			if (prob(50))
-				del(src)
+				qdel(src)
 				return
 		if(3.0)
 			if (prob(5))
-				del(src)
+				qdel(src)
 				return
 		else
 	return
@@ -176,4 +176,4 @@
 
 /obj/effect/supermatter_crystal/proc/CheckEndurance()
 	if(endurance <= 0)
-		del(src)
+		qdel(src)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -6,7 +6,7 @@
 	if(dx>=dy)	return dx + (0.5*dy)	//The longest side add half the shortest side approximates the hypotenuse
 	else		return dy + (0.5*dx)
 
-proc/trange(var/Dist=0,var/turf/Center=null)//alternative to range (ONLY processes turfs and thus less intensive)
+/proc/trange(var/Dist=0,var/turf/Center=null)//alternative to range (ONLY processes turfs and thus less intensive)
 	if(Center==null) return
 
 	//var/x1=((Center.x-Dist)<1 ? 1 : Center.x-Dist)
@@ -19,42 +19,60 @@ proc/trange(var/Dist=0,var/turf/Center=null)//alternative to range (ONLY process
 	return block(x1y1,x2y2)
 
 
-proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, adminlog = 1)
+/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, ignorecap = 0, flame_range = 0 ,silent = 0)
 	src = null	//so we don't abort once src is deleted
+	epicenter = get_turf(epicenter)
+
+	// Archive the uncapped explosion for the doppler array
+	var/orig_dev_range = devastation_range
+	var/orig_heavy_range = heavy_impact_range
+	var/orig_light_range = light_impact_range
+
+	if(!ignorecap)
+		// Clamp all values to MAX_EXPLOSION_RANGE
+		devastation_range = min (MAX_EX_DEVESTATION_RANGE, devastation_range)
+		heavy_impact_range = min (MAX_EX_HEAVY_RANGE, heavy_impact_range)
+		light_impact_range = min (MAX_EX_LIGHT_RANGE, light_impact_range)
+		flash_range = min (MAX_EX_FLASH_RANGE, flash_range)
+		flame_range = min (MAX_EX_FLAME_RANGE, flame_range)
+
 	spawn(0)
 		var/start = world.timeofday
-		epicenter = get_turf(epicenter)
 		if(!epicenter) return
 
-		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range)
+		var/max_range = max(devastation_range, heavy_impact_range, light_impact_range, flame_range)
 
-		// Play sounds; since playsound uses range() for each use, we'll try doing it through the player list.
-		// Playsound_local will also have an extra bonus of panning the sound, depending on the source. So stereo users will hear the direction of the explosion
-		for(var/mob/M in player_list)
-			// Double check for client
-			if(M && M.client)
-				var/turf/M_turf = get_turf(M)
-				if(M_turf && M_turf.z == epicenter.z)
-					var/dist = get_dist(M_turf, epicenter)
-					// If inside the blast radius + world.view - 2
-					if(dist <= round(max_range + world.view - 2, 1))
-						M.playsound_local(epicenter, "explosion", 100, 1)
-					// You hear a far explosion if you're outside the blast radius (*5) Small bombs shouldn't be heard all over the station.
-					else if(dist <= round(max_range * 10, 1))
-						var/far_volume = Clamp(max_range * 10, 30, 60) // Volume is based on explosion size and dist
-						far_volume += (dist > max_range * 2 ? 0 : 40) // add 40 volume if the mob is pretty close to the explosion
-						M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1)
-
-
-		var/close = range(world.view+round(devastation_range,1), epicenter)
-		// to all distanced mobs play a different sound
-		for(var/mob/M in world) if(M.z == epicenter.z) if(!(M in close))
-			// check if the mob can hear
-			if(M.ear_deaf <= 0 || !M.ear_deaf) if(!istype(M.loc,/turf/space))
-				M << 'sound/effects/explosionfar.ogg'
 		if(adminlog)
-			msg_admin_attack("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
-			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ")
+			message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
+			log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z])")
+
+		// Play sounds; we want sounds to be different depending on distance so we will manually do it ourselves.
+		// Stereo users will also hear the direction of the explosion!
+
+		// Calculate far explosion sound range. Only allow the sound effect for heavy/devastating explosions.
+		// 3/7/14 will calculate to 80 + 35
+
+		var/far_dist = 0
+		far_dist += heavy_impact_range * 5
+		far_dist += devastation_range * 20
+
+		if(!silent)
+			var/frequency = get_rand_frequency()
+			for(var/mob/M in player_list)
+				// Double check for client
+				if(M && M.client)
+					var/turf/M_turf = get_turf(M)
+					if(M_turf && M_turf.z == epicenter.z)
+						var/dist = get_dist(M_turf, epicenter)
+						// If inside the blast radius + world.view - 2
+						if(dist <= round(max_range + world.view - 2, 1))
+							M.playsound_local(epicenter, get_sfx("explosion"), 100, 1, frequency, falloff = 5) // get_sfx() is so that everyone gets the same sound
+						// You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
+						else if(dist <= far_dist)
+							var/far_volume = Clamp(far_dist, 30, 50) // Volume is based on explosion size and dist
+							far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
+							M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
+
 
 		//Pause the lighting updates for a bit
 		var/datum/controller/process/lighting = processScheduler.getProcess("lighting")
@@ -74,7 +92,8 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		var/z0 = epicenter.z
 
 		for(var/turf/T in trange(max_range, epicenter))
-			var/dist = sqrt((T.x - x0)**2 + (T.y - y0)**2)
+
+			var/dist = cheap_pythag(T.x - x0,T.y - y0)
 
 			if(config.reactionary_explosions)
 				var/turf/Trajectory = T
@@ -87,19 +106,25 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 						if(D.density && D.explosion_block)
 							dist += D.explosion_block
 
+			var/flame_dist = 0
 			var/throw_dist = dist
+
+			if(dist < flame_range)
+				flame_dist = 1
 
 			if(dist < devastation_range)		dist = 1
 			else if(dist < heavy_impact_range)	dist = 2
 			else if(dist < light_impact_range)	dist = 3
-			else								dist = 0
+			else 								dist = 0
+
+			//------- TURF FIRES -------
 
 			if(T)
 				for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 					var/atom/movable/AM = atom_movable
-					if(AM && AM.simulated)	AM.ex_act(dist)
-//				if(flame_dist && prob(40) && !istype(T, /turf/space) && !T.density)
-//					PoolOrNew(/obj/effect/hotspot, T) //Mostly for ambience!
+					if(AM)	AM.ex_act(dist)
+				if(flame_dist && prob(40) && !istype(T, /turf/space) && !T.density)
+					new/obj/effect/hotspot(T) //Mostly for ambience!
 				if(dist > 0)
 					T.ex_act(dist)
 
@@ -122,7 +147,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 		for(var/i,i<=doppler_arrays.len,i++)
 			var/obj/machinery/doppler_array/Array = doppler_arrays[i]
 			if(Array)
-				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took)
+				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took,orig_dev_range,orig_heavy_range,orig_light_range)
 
 		sleep(8)
 
@@ -136,7 +161,7 @@ proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impa
 
 
 
-proc/secondaryexplosion(turf/epicenter, range)
+/proc/secondaryexplosion(turf/epicenter, range)
 	for(var/turf/tile in trange(range, epicenter))
 		tile.ex_act(2)
 
@@ -145,8 +170,10 @@ proc/secondaryexplosion(turf/epicenter, range)
 	set category = "Debug"
 
 	var/newmode = alert("Use reactionary explosions?","Check Bomb Impact", "Yes", "No")
+	var/turf/epicenter = get_turf(mob)
+	if(!epicenter)
+		return
 
-	var/turf/epicenter = get_turf(usr)
 	var/dev = 0
 	var/heavy = 0
 	var/light = 0

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1293,14 +1293,14 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	if (ismob(loc))
 		var/mob/M = loc
-		M.show_message("\red Your [src] explodes!", 1)
+		M.show_message("<span class='danger'>Your [src] explodes!</span>", 1)
 
 	if(T)
 		T.hotspot_expose(700,125)
 
 		explosion(T, -1, -1, 2, 3)
 	JFLOG("Exploded")
-	del(src)
+	qdel(src)
 	return
 
 /obj/item/device/pda/Destroy()

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -134,6 +134,6 @@
 		if(1.0)
 			del(src)
 		if(2.0)
-			if(prob(50)) del(src)
+			if(prob(50)) qdel(src)
 		if(3.0)
-			if(prob(25)) del(src)
+			if(prob(25)) qdel(src)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -317,4 +317,4 @@
 	if(pai)
 		pai.ex_act(severity)
 	else
-		del(src)
+		qdel(src)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -35,7 +35,7 @@
 	return
 
 /obj/item/weapon/a_gift/ex_act()
-	del(src)
+	qdel(src)
 	return
 
 /obj/effect/spresent/relaymove(mob/user as mob)

--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -122,7 +122,7 @@
 
 /obj/item/weapon/grenade/iedcasing/prime() //Blowing that can up
 	update_mob()
-	explosion(src.loc,0,0,2,2) //explosion(src.loc,-1,-1,-1, flame_range = range)
+	explosion(src.loc,-1,-1,-1, flame_range = range)	// no explosive damage, only a large fireball.
 	qdel(src)
 
 /obj/item/weapon/grenade/iedcasing/examine(mob/user)

--- a/code/game/objects/items/weapons/grenades/syndieminibomb.dm
+++ b/code/game/objects/items/weapons/grenades/syndieminibomb.dm
@@ -9,5 +9,5 @@
 
 /obj/item/weapon/grenade/syndieminibomb/prime()
 	update_mob()
-	explosion(src.loc,1,2,4)
-	del(src)
+	explosion(src.loc,1,2,4,flame_range = 2)
+	qdel(src)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -248,13 +248,15 @@
 		air_contents.react()
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-		range = min(range, MAX_EXPLOSION_RANGE)		// was 8 - - - Changed to a configurable define -- TLE
 		var/turf/epicenter = get_turf(loc)
 
 		//world << "\blue Exploding Pressure: [pressure] kPa, intensity: [range]"
 
 		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
-		del(src)
+		if(istype(src.loc,/obj/item/device/transfer_valve))
+			qdel(src.loc)
+		else
+			qdel(src)
 
 	else if(pressure > TANK_RUPTURE_PRESSURE)
 		//world << "\blue[x],[y] tank is rupturing: [pressure] kPa, integrity [integrity]"
@@ -264,7 +266,7 @@
 				return
 			T.assume_air(air_contents)
 			playsound(src.loc, 'sound/effects/spray.ogg', 10, 1, -3)
-			del(src)
+			qdel(src)
 		else
 			integrity--
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -181,13 +181,13 @@
 	switch(severity)
 		if(1.0)
 			for(var/obj/O in src.contents)
-				del(O)
+				qdel(O)
 			qdel(src)
 			return
 		if(2.0)
 			for(var/obj/O in src.contents)
 				if(prob(50))
-					del(O)
+					qdel(O)
 			qdel(src)
 			return
 		if(3.0)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -101,7 +101,7 @@
 			getFromPool(/obj/item/weapon/shard, loc)
 			if (occupant)
 				dump()
-			del(src)
+			qdel(src)
 		if (2)
 			if (prob(50))
 				src.health -= 15

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -53,7 +53,6 @@
 	icon_state = "uranium0"
 	walltype = "uranium"
 	mineral = "uranium"
-	explosion_block = 0
 
 /turf/simulated/wall/mineral/uranium/proc/radiate()
 	if(!active)

--- a/code/game/vehicles/spacepods/spacepod.dm
+++ b/code/game/vehicles/spacepods/spacepod.dm
@@ -179,8 +179,8 @@
 				H2.forceMove(get_turf(src))
 				H2.ex_act(severity + 1)
 				H2 << "<span class='warning'>You are forcefully thrown from \the [src]!</span>"
-			del(ion_trail)
-			del(src)
+			qdel(ion_trail)
+			qdel(src)
 		if(2)
 			deal_damage(100)
 		if(3)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -402,7 +402,7 @@ var/list/admin_verbs_mentor = list(
 			var/flash_range = input("Flash range (in tiles):") as null|num
 			if(flash_range == null)
 				return
-			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
+			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, 1, 1)
 	message_admins("<span class='adminnotice'>[ckey] creating an admin explosion at [epicenter.loc].</span>")
 	feedback_add_details("admin_verb","DB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -384,17 +384,26 @@ var/list/admin_verbs_mentor = list(
 		if(null)
 			return 0
 		if("Small Bomb")
-			explosion(epicenter, 1, 2, 3)
+			explosion(epicenter, 1, 2, 3, 3)
 		if("Medium Bomb")
-			explosion(epicenter, 2, 3, 4)
+			explosion(epicenter, 2, 3, 4, 4)
 		if("Big Bomb")
-			explosion(epicenter, 3, 5, 7)
+			explosion(epicenter, 3, 5, 7, 5)
 		if("Custom Bomb")
-			var/devastation_range = input("Devastation range (in tiles):") as num
-			var/heavy_impact_range = input("Heavy impact range (in tiles):") as num
-			var/light_impact_range = input("Light impact range (in tiles):") as num
-			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range)
-	message_admins("\blue [ckey] creating an admin explosion at [epicenter.loc].")
+			var/devastation_range = input("Devastation range (in tiles):") as null|num
+			if(devastation_range == null)
+				return
+			var/heavy_impact_range = input("Heavy impact range (in tiles):") as null|num
+			if(heavy_impact_range == null)
+				return
+			var/light_impact_range = input("Light impact range (in tiles):") as null|num
+			if(light_impact_range == null)
+				return
+			var/flash_range = input("Flash range (in tiles):") as null|num
+			if(flash_range == null)
+				return
+			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range)
+	message_admins("<span class='adminnotice'>[ckey] creating an admin explosion at [epicenter.loc].</span>")
 	feedback_add_details("admin_verb","DB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/give_spell(mob/T as mob in mob_list) // -- Urist

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2332,18 +2332,22 @@
 			if("togglebombcap")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","BC")
-				switch(MAX_EXPLOSION_RANGE)
-					if(14)	MAX_EXPLOSION_RANGE = 16
-					if(16)	MAX_EXPLOSION_RANGE = 20
-					if(20)	MAX_EXPLOSION_RANGE = 28
-					if(28)	MAX_EXPLOSION_RANGE = 56
-					if(56)	MAX_EXPLOSION_RANGE = 128
-					else	MAX_EXPLOSION_RANGE = 14
-				var/range_dev = MAX_EXPLOSION_RANGE *0.25
-				var/range_high = MAX_EXPLOSION_RANGE *0.5
-				var/range_low = MAX_EXPLOSION_RANGE
-				message_admins("\red <b> [key_name_admin(usr)] changed the bomb cap to [range_dev], [range_high], [range_low]</b>", 1)
-				log_admin("[key_name_admin(usr)] changed the bomb cap to [MAX_EXPLOSION_RANGE]")
+
+				var/newBombCap = input(usr,"What would you like the new bomb cap to be. (entered as the light damage range (the 3rd number in common (1,2,3) notation)) Must be between 4 and 128)", "New Bomb Cap", MAX_EX_LIGHT_RANGE) as num|null
+				if (newBombCap < 4)
+					return
+				if (newBombCap > 128)
+					newBombCap = 128
+
+				MAX_EX_DEVESTATION_RANGE = round(newBombCap/4)
+				MAX_EX_HEAVY_RANGE = round(newBombCap/2)
+				MAX_EX_LIGHT_RANGE = newBombCap
+				//I don't know why these are their own variables, but fuck it, they are.
+				MAX_EX_FLASH_RANGE = newBombCap
+				MAX_EX_FLAME_RANGE = newBombCap
+
+				message_admins("<span class='boldannounce'>[key_name_admin(usr)] changed the bomb cap to [MAX_EX_DEVESTATION_RANGE], [MAX_EX_HEAVY_RANGE], [MAX_EX_LIGHT_RANGE]</span>")
+				log_admin("[key_name(usr)] changed the bomb cap to [MAX_EX_DEVESTATION_RANGE], [MAX_EX_HEAVY_RANGE], [MAX_EX_LIGHT_RANGE]")
 
 			if("flicklights")
 				feedback_inc("admin_secrets_fun_used",1)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -698,15 +698,17 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(light == null) return
 	var/flash = input("Range of flash. -1 to none", text("Input"))  as num|null
 	if(flash == null) return
+	var/flames = input("Range of flames. -1 to none", text("Input"))  as num|null
+	if(flames == null) return
 
-	if ((devastation != -1) || (heavy != -1) || (light != -1) || (flash != -1))
-		if ((devastation > 20) || (heavy > 20) || (light > 20))
+	if ((devastation != -1) || (heavy != -1) || (light != -1) || (flash != -1) || (flames != -1))
+		if ((devastation > 20) || (heavy > 20) || (light > 20) || (flames > 20))
 			if (alert(src, "Are you sure you want to do this? It will laaag.", "Confirmation", "Yes", "No") == "No")
 				return
 
-		explosion(O, devastation, heavy, light, flash)
-		log_admin("[key_name(usr)] created an explosion ([devastation],[heavy],[light],[flash]) at ([O.x],[O.y],[O.z])")
-		message_admins("[key_name_admin(usr)] created an explosion ([devastation],[heavy],[light],[flash]) at ([O.x],[O.y],[O.z])", 1)
+		explosion(O, devastation, heavy, light, flash, null, null,flames)
+		log_admin("[key_name(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at ([O.x],[O.y],[O.z])")
+		message_admins("[key_name_admin(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at ([O.x],[O.y],[O.z])")
 		feedback_add_details("admin_verb","EXPL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		return
 	else

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -192,15 +192,15 @@
 	ex_act(severity)
 		switch(severity)
 			if(1.0)
-				del(src)
+				qdel(src)
 				return
 			if(2.0)
 				if (prob(50))
-					del(src)
+					qdel(src)
 					return
 			if(3.0)
 				if (prob(25))
-					del(src)
+					qdel(src)
 					return
 		return
 

--- a/code/modules/computer3/computer.dm
+++ b/code/modules/computer3/computer.dm
@@ -217,11 +217,11 @@
 	ex_act(severity)
 		switch(severity)
 			if(1.0)
-				del(src)
+				qdel(src)
 				return
 			if(2.0)
 				if (prob(25))
-					del(src)
+					qdel(src)
 					return
 				if (prob(50))
 					for(var/x in verbs)

--- a/code/modules/events/tgevents/anomaly_flux.dm
+++ b/code/modules/events/tgevents/anomaly_flux.dm
@@ -12,6 +12,6 @@
 		newAnomaly = new /obj/effect/anomaly/flux(T.loc)
 
 /datum/event/anomaly/anomaly_flux/end()
-	if(newAnomaly)//If it hasn't been neutralized, it's time to blow up.
-		explosion(newAnomaly.loc, 0, 4, 6, 5)
+	if(newAnomaly.loc)//If it hasn't been neutralized, it's time to blow up.
+		explosion(newAnomaly, -1, 3, 5, 5)
 		qdel(newAnomaly)

--- a/code/modules/events/tgevents/anomaly_pyro.dm
+++ b/code/modules/events/tgevents/anomaly_pyro.dm
@@ -20,7 +20,7 @@
 
 /datum/event/anomaly/anomaly_pyro/end()
 	if(newAnomaly.loc)
-		explosion(get_turf(newAnomaly), -1,0,3)
+		explosion(get_turf(newAnomaly), -1,0,3, flame_range = 4)
 
 		var/mob/living/carbon/slime/S = new/mob/living/carbon/slime(get_turf(newAnomaly))
 		S.colour = pick("red", "orange")

--- a/code/modules/events/tgevents/brand_intelligence.dm
+++ b/code/modules/events/tgevents/brand_intelligence.dm
@@ -50,7 +50,7 @@
 				M.speak = rampant_speeches.Copy()
 				M.speak_chance = 15
 			else
-				explosion(upriser.loc, -1, 1, 2)
+				explosion(upriser.loc, -1, 1, 2, 4, 0)
 				qdel(upriser)
 
 		kill()

--- a/code/modules/events/tgevents/dust.dm
+++ b/code/modules/events/tgevents/dust.dm
@@ -99,5 +99,5 @@
 
 
 	ex_act(severity)
-		del(src)
+		qdel(src)
 		return

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -83,7 +83,7 @@
 					user << "<span class='danger'>The crate's anti-tamper system activates!</span>"
 					var/turf/T = get_turf(src.loc)
 					explosion(T, 0, 0, 0, 1)
-					del(src)
+					qdel(src)
 					return
 		else
 			user << "<span class='notice'>You attempt to interact with the device using a hand gesture, but it appears this crate is from before the DECANECT came out.</span>"

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -82,7 +82,7 @@
 				if (attempts == 0)
 					user << "<span class='danger'>The crate's anti-tamper system activates!</span>"
 					var/turf/T = get_turf(src.loc)
-					explosion(T, 0, 0, 0, 1)
+					explosion(T, -1, -1, 1, 1)
 					qdel(src)
 					return
 		else

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -264,7 +264,7 @@
 	s.set_up(5, 1, src)
 	s.start()
 	if(prob(50 / severity) && severity < 3)
-		del(src)
+		qdel(src)
 
 /**********************Mining Equipment Locker Items**************************/
 

--- a/code/modules/mining/manufacturing.dm
+++ b/code/modules/mining/manufacturing.dm
@@ -43,7 +43,7 @@
 
 	ex_act(severity)
 		switch(severity)
-			if(1.0) del(src)
+			if(1.0) qdel(src)
 			if(2.0)
 				if (prob(60)) stat |= BROKEN
 			if(3.0)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1236,7 +1236,7 @@ var/list/robot_verbs_default = list(
 	if(emagged)
 		if(mmi)
 			qdel(mmi)
-		explosion(src.loc,1,2,4)
+		explosion(src.loc,1,2,4,flame_range = 2)
 	else
 		explosion(src.loc,-1,0,2)
 	gib()

--- a/code/modules/mob/living/simple_animal/tribbles.dm
+++ b/code/modules/mob/living/simple_animal/tribbles.dm
@@ -140,7 +140,7 @@ var/global/totaltribbles = 0   //global variable so it updates for all tribbles,
 		if (1)
 			new /obj/item/weapon/shard( src.loc )
 			Break()
-			del(src)
+			qdel(src)
 		if (2)
 			if (prob(50))
 				src.health -= 15

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -132,10 +132,10 @@
 /obj/machinery/photocopier/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			del(src)
+			qdel(src)
 		if(2.0)
 			if(prob(50))
-				del(src)
+				qdel(src)
 			else
 				if(toner > 0)
 					new /obj/effect/decal/cleanable/blood/oil(get_turf(src))
@@ -149,7 +149,7 @@
 
 /obj/machinery/photocopier/blob_act()
 	if(prob(50))
-		del(src)
+		qdel(src)
 	else
 		if(toner > 0)
 			new /obj/effect/decal/cleanable/blood/oil(get_turf(src))

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -110,9 +110,7 @@
 	message_admins("LOG: Rigged power cell explosion, last touched by [fingerprintslast]")
 
 	explosion(T, devastation_range, heavy_impact_range, light_impact_range, flash_range)
-
-	spawn(1)
-		del(src)
+	qdel(src)
 
 /obj/item/weapon/stock_parts/cell/proc/corrupt()
 	charge /= 2

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -148,6 +148,6 @@
 
 /obj/item/weapon/gun/magic/wand/fireball/zap_self(mob/living/user as mob)
 	if(alert(user, "Zapping yourself with a wand of fireball is probably a bad idea, do it anyway?",, "Yes", "No") == "Yes" && charges && user.get_active_hand() == src && isliving(user))
-		explosion(user.loc, -1, 0, 2, 3, 0)
+		explosion(user.loc, -1, 0, 2, 3, 0, flame_range = 2)
 		charges--
 		..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -24,7 +24,7 @@
 
 /obj/item/projectile/magic/fireball/on_hit(var/target)
 	var/turf/T = get_turf(target)
-	explosion(T, -1, 0, 2, 3, 0)
+	explosion(T, -1, 0, 2, 3, 0, flame_range = 2)
 	if(ismob(target)) //multiple flavors of pain
 		var/mob/living/M = target
 		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -38,7 +38,8 @@
 	flag = "bullet"
 
 /obj/item/projectile/bullet/a40mm/on_hit(atom/target, blocked = 0)
-	explosion(target, -1, 0, 2, 1, 0)
+	..()
+	explosion(target, -1, 0, 2, 1, 0, flame_range = 3)
 	return 1
 
 /obj/item/projectile/temp
@@ -217,6 +218,7 @@ obj/item/projectile/kinetic/New()
 	weaken = 5
 
 /obj/item/projectile/bullet/frag12/on_hit(atom/target, blocked = 0)
+	..()
 	explosion(target, -1, 0, 1)
 	return 1
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -103,7 +103,7 @@
 				explode()
 
 	blob_act()
-		explode()
+		explosion(src.loc,0,1,5,7,10, flame_range = 5)
 
 	ex_act()
 		explode()
@@ -150,14 +150,13 @@
 		return ..()
 
 /obj/structure/reagent_dispensers/fueltank/proc/explode()
-	explosion(src.loc,0,1,4)
+	explosion(src.loc,-1,0,2, flame_range = 2)
 	if(src)
-		del(src)
+		qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/fire_act(datum/gas_mixture/air, temperature, volume)
-	if(temperature > T0C+500)
-		explode()
-	return ..()
+	blob_act() //saving a few lines of copypasta
+
 
 /obj/structure/reagent_dispensers/fueltank/Move()
 	..()
@@ -219,7 +218,7 @@
 
 /obj/structure/reagent_dispensers/beerkeg/blob_act()
 	explosion(src.loc,0,3,5,7,10)
-	del(src)
+	qdel(src)
 
 /obj/structure/reagent_dispensers/virusfood
 	name = "Virus Food Dispenser"

--- a/code/modules/research/xenoarchaeology/machinery/coolant.dm
+++ b/code/modules/research/xenoarchaeology/machinery/coolant.dm
@@ -56,4 +56,4 @@ datum/chemical_reaction/coolant
 
 	sleep(10)
 	if(src)
-		del(src)
+		qdel(src)

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -54,6 +54,24 @@ ALIEN_DELAY 0
 METROID_DELAY 0
 ANIMAL_DELAY 0
 
+
+//Comment for "normal" explosions, which ignore obstacles
+//Uncomment for explosions that react to doors and walls
+REACTIONARY_EXPLOSIONS
+
+### Configure the bomb cap
+## This caps all explosions to the specified range. Used for both balance reasons and to prevent overloading the server and lagging the game out.
+## This is given as the 3rd number(light damage) in the standard (1,2,3) explosion notation. The other numbers are derived by dividing by 2 and 4.
+## eg: If you give the number 20. The bomb cap will be 5,10,20.
+## Can be any number between 4 and 128, some examples are provided below.
+
+## Default (3,7,14)
+BOMBCAP 14
+## One 'step' up (4,8,16) (recommended if you enable REACTIONARY_EXPLOSIONS above)
+#BOMBCAP 16
+## LagHell (7,14,28)
+#BOMBCAP 28
+
 ### ROUNDSTART SILICON LAWS ###
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented for "off", silicons will just start with Asimov.

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -66,9 +66,9 @@ REACTIONARY_EXPLOSIONS
 ## Can be any number between 4 and 128, some examples are provided below.
 
 ## Default (3,7,14)
-BOMBCAP 14
-## One 'step' up (4,8,16) (recommended if you enable REACTIONARY_EXPLOSIONS above)
-#BOMBCAP 16
+#BOMBCAP 14
+## One 'step' up (5,10,20) (recommended if you enable REACTIONARY_EXPLOSIONS above)
+BOMBCAP 20
 ## LagHell (7,14,28)
 #BOMBCAP 28
 


### PR DESCRIPTION
This comes almost exclusively from TG.

For the most part, players probably won't notice much difference with explosions, aside explosion sounds being a bit quieter.

In any event, some things you will notice: 

- Some explosions now produce flames in their range; this is particularly evident with some things like the Syndicate Minibomb, Syndicate Bomb, IED's, fuel tanks, and wizard fireballs.

- The Tachyon Doppler Array will now display the THEORETICAL size of the bomb you made; while you may not be able to enjoy the fruits of making a 15/20/40 explosion, at least you can gloat about your superior bomb making skills beyond 3/7/14

Coders:
 - Did a passthrough of ex_act; utilized qdel wherever possible
  - Should help make explosions a teensy tiny bit faster in processing.

Admins:
~~- All explosions are capped at 5/10/20 unless the bomb cap is changed; yes, even drop bomb~~
 ~~- No more lag inducing "oops, I didn't mean to make a size 1000 explosion!"~~
- Admins can be as irresponsible as ever with drop bomb.


Host/Administration
- Game Option added to use reactionary explosions
 - We added this feature a while back, but it's not even enabled.

- Game Option added to easily adjust the bomb cap in game options
 - BOMB CAP HAS BEEN RAISED TO 5/10/20 since we're using reactionary explosions! (consulted with TG administration/coders about this).

IF MERGED THIS WILL REQUIRE GAME_OPTIONS.TXT TO BE UPDATED!!