### PR TITLE
Disables Sarin Reaction

### DIFF
--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -511,6 +511,7 @@ datum/reagent/sarin
 	metabolization_rate = 0.1
 	penetrates_skin = 1
 
+/* Disabled, on account of being a bit too deadly for how easy it was to make.
 /datum/chemical_reaction/sarin
 	name = "sarin"
 	id = "sarin"
@@ -519,6 +520,7 @@ datum/reagent/sarin
 	result_amount = 3
 	mix_message = "The mixture yields a colorless, odorless liquid."
 	required_temp = 374
+*/
 
 datum/reagent/sarin/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom


### PR DESCRIPTION
**EDIT**: There is now [a thread on the forums](http://nanotrasen.se/phpBB3/viewtopic.php?f=12&t=5046) for discussion of the removal of the sarin recipe.

It turns out that sarin is *so deadly*, it's considered too dangerous to make the recipe publicly-available knowledge. Since nothing in-game should be severe enough that we need to censor information about it, this is the simplest alternative - removing the recipe entirely, thus making it unavailable to everyone with the know-how and a chem dispenser. Adjustments to the recipe or sarin itself may see it returned at some point in the future.

Sarin is still available as one of the random poisons in the job-locked traitor uplink poison bottles, as well as the main component of the nuke-ops sarin gas grenades. The effect of the chemical itself is unchanged.

Pinging @FalseIncarnate, @Earthdivine, and @Fox-McCloud due to their involvement in the discussion about this change.