### PR TITLE
Fixes Changeling's Regenerative Stasis

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -34,8 +34,12 @@
 		H.shock_stage = 0
 		spawn(1)
 			H.fixblood()
+		H.species.create_organs(H)
+		// Now that recreating all organs is necessary, the rest of this organ stuff probably
+		//  isn't, but I don't want to remove it, just in case.
 		for(var/organ_name in H.organs_by_name)
 			var/obj/item/organ/external/O = H.organs_by_name[organ_name]
+			if(!O) continue
 			for(var/obj/item/weapon/shard/shrapnel/s in O.implants)
 				if(istype(s))
 					O.implants -= s


### PR DESCRIPTION
Yet another changeling fix! This time, it's regenerative stasis (**again**), which wouldn't regenerate fully-missing organs, then promptly runtime when it tried to heal a limb that didn't exist because it didn't regenerate it. This would leave the changeling stuck in their fake-death state until some confused admin shrugged and rejuvenated them. This one's probably been an issue ever since the organ overhaul!

Regenerative stasis now recreates literally all of the user's organs and limbs. I'm not actually sure if that's really the best way to handle regenerating them, but it was the most convenient method I could find (it's how admin rejuvenating does it!), so it's probably fine.