### PR TITLE
Hardsuit Attachment Changes

### DIFF
--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -214,82 +214,54 @@
 
 	if(!istype(user,/mob/living)) return
 
-	if(user.a_intent == "help")
 
-		if(istype(src.loc,/mob/living))
-			user << "How do you propose to modify a hardsuit while it is being worn?"
+	if(istype(src.loc,/mob/living))
+		user << "How do you propose to modify a hardsuit while it is being worn?"
+		return
+
+	if(istype(W,/obj/item/weapon/screwdriver))
+		if(!helmet)
+			user << "\The [src] does not have a helmet installed."
+		else
+			user << "You detach \the [helmet] from \the [src]'s helmet mount."
+			helmet.loc = get_turf(src)
+			src.helmet = null
+			return
+		if(!boots)
+			user << "\The [src] does not have any boots installed."
+		else
+			user << "You detatch \the [boots] from \the [src]'s boot mounts."
+			boots.loc = get_turf(src)
+			boots = null
+		return
+
+	else if(istype(W,/obj/item/clothing/head/helmet/space))
+		if(!attached_helmet)
+			user << "\The [src] does not have a helmet mount."
+			return
+		if(helmet)
+			user << "\The [src] already has a helmet installed."
+		else
+			user << "You attach \the [W] to \the [src]'s helmet mount."
+			user.drop_item()
+			W.loc = src
+			src.helmet = W
+		return
+
+	else if(istype(W,/obj/item/clothing/shoes/magboots))
+		if(!attached_boots)
+			user << "\The [src] does not have boot mounts."
 			return
 
-		var/target_zone = user.zone_sel.selecting
-
-		if(target_zone == "head")
-
-			//Installing a component into or modifying the contents of the helmet.
-			if(!attached_helmet)
-				user << "\The [src] does not have a helmet mount."
-				return
-
-			if(istype(W,/obj/item/weapon/screwdriver))
-				if(!helmet)
-					user << "\The [src] does not have a helmet installed."
-				else
-					user << "You detach \the [helmet] from \the [src]'s helmet mount."
-					helmet.loc = get_turf(src)
-					src.helmet = null
-				return
-			else if(istype(W,/obj/item/clothing/head/helmet/space))
-				if(helmet)
-					user << "\The [src] already has a helmet installed."
-				else
-					user << "You attach \the [W] to \the [src]'s helmet mount."
-					user.drop_item()
-					W.loc = src
-					src.helmet = W
-				return
-			else
-				return ..()
-
-		else if(target_zone == "l_leg" || target_zone == "r_leg" || target_zone == "l_foot" || target_zone == "r_foot")
-
-			//Installing a component into or modifying the contents of the feet.
-			if(!attached_boots)
-				user << "\The [src] does not have boot mounts."
-				return
-
-			if(istype(W,/obj/item/weapon/screwdriver))
-				if(!boots)
-					user << "\The [src] does not have any boots installed."
-				else
-					user << "You detatch \the [boots] from \the [src]'s boot mounts."
-					boots.loc = get_turf(src)
-					boots = null
-				return
-			else if(istype(W,/obj/item/clothing/shoes/magboots))
-				if(boots)
-					user << "\The [src] already has magboots installed."
-				else
-					user << "You attach \the [W] to \the [src]'s boot mounts."
-					user.drop_item()
-					W.loc = src
-					boots = W
-			else
-				return ..()
-
-		/*
-		else if(target_zone == "l_arm" || target_zone == "r_arm" || target_zone == "l_hand" || target_zone == "r_hand")
-
-			//Installing a component into or modifying the contents of the hands.
-
-		else if(target_zone == "torso" || target_zone == "groin")
-
-			//Modifying the cell or mounted devices
-
-			if(!mounted_devices)
-				return
-		*/
-
-		else //wat
-			return ..()
+		if(boots)
+			user << "\The [src] already has magboots installed."
+		else
+			user << "You attach \the [W] to \the [src]'s boot mounts."
+			user.drop_item()
+			W.loc = src
+			boots = W
+	else
+		return ..()
 
 	..()
 


### PR DESCRIPTION
- Makes it so you don't have to be on help intent, or targeting the head to attach a helmet onto a hardsuit.
 - Same deal for attaching magboots to a hardsuit.
- Using a screwdriver on a hardsuit will attempt to remove the helmet first, further use will then remove the magboots.
- You still can't modify a hardsuit while wearing it.