### PR TITLE
Pet Collar Bug Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -14,6 +14,7 @@
 		user << "<span class='notice'>You put the [P] around [src]'s neck.</span>"
 		if(P.tagname)
 			name = P.tagname
+			real_name = P.tagname
 		qdel(P)
 		return
 	if(istype(O, /obj/item/weapon/newspaper))


### PR DESCRIPTION
If you had Ian with a pet collar name like spot, and you gave him say a wizard name, then he would deafault to his real_name over his name, and making it impossible to restore the name on the collar.