### PR TITLE
Admin-freeze refactor and fixes.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -80,7 +80,5 @@
 
 	var/lastFart = 0 // Toxic fart cooldown.
 
-	var/frozen = 0 //used for preventing attacks on admin-frozen people
-
 	var/fire_dmi = 'icons/mob/OnFire.dmi'
 	var/fire_sprite = "Standing"


### PR DESCRIPTION
Admin freezing is now based on mob procs, instead of a lengthy else-if
change.

Other changes:
 - No longer depends on paralysis, instead uses sleeping.
  - No more frozen mobs setting off bombs.
 - Simple animals and slimes override the default proc to make freezing
   affect them as one would expect.
 - Frozen var has been moved from human defines to living defines, no use
   yet.
 - Mobs frozen are added to a global 'admin_frozen_mobs' list.
  - List is used to determine if the freeze verb should freeze or unfreze.
 - Moved mob freeze-related vars to freeze file.