### PR TITLE
Slapping now hurts if you slap someone with a helmet

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -692,14 +692,14 @@
 				if (M)
 					var/mob/living/carbon/human/H = M
 					if(ishuman(H) && H.head && (H.head.flags & HEADCOVERSMOUTH))
-						message = "<span class='danger'>[src] tries to slap [H] across the face, but hits their [H.head] instead! Ouch!"
+						message = "<span class='danger'>[src] tries to slap [H] across the face, but hits their [H.head] instead! Ouch!</span>"
 						playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 						src.adjustBruteLoss(4)
 					else
-						message = "<span class = 'danger'>[src] slaps [M] across the face. Ouch!"
+						message = "<span class='danger'>[src] slaps [M] across the face. Ouch!</span>"
 						playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 				else
-					message = "<span class = 'danger'>[src] slaps themselves!"
+					message = "<span class='danger'>[src] slaps themselves!</span>"
 					playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 					src.adjustFireLoss(4)
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -699,7 +699,7 @@
 						message = "<span class='danger'>[src] slaps [M] across the face. Ouch!</span>"
 						playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 				else
-					message = "<span class='danger'>[src] slaps themselves!</span>"
+					message = "<span class='danger'>[src] slaps \himself!</span>"
 					playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 					src.adjustFireLoss(4)
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -690,10 +690,16 @@
 							M = A
 							break
 				if (M)
-					message = "\red <B>[src]</B> slaps [M] across the face. Ouch!"
-					playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
+					var/mob/living/carbon/human/H = M
+					if(ishuman(H) && H.head && (H.head.flags & HEADCOVERSMOUTH))
+						message = "<span class='danger'>[src] tries to slap [H] across the face, but hits their [H.head] instead! Ouch!"
+						playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
+						src.adjustBruteLoss(4)
+					else
+						message = "<span class = 'danger'>[src] slaps [M] across the face. Ouch!"
+						playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 				else
-					message = "\red <B>[src]</B> slaps \himself!"
+					message = "<span class = 'danger'>[src] slaps themselves!"
 					playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
 					src.adjustFireLoss(4)
 


### PR DESCRIPTION
What the title says, basically, slapping someone with a helmet that has
HEADCOVERSMOUTH flag will give the slapper brute damage, because that
would hurt. Also changes the slap message type.
![12090a0b7f](https://cloud.githubusercontent.com/assets/11361525/8337870/351ea6c6-1ab6-11e5-97d6-8cbae07409d1.png)
