### PR TITLE
MTTS: Tram stops.

### DIFF
--- a/code/modules/tram/tram.dm
+++ b/code/modules/tram/tram.dm
@@ -74,9 +74,13 @@
 	var/stored_rail = null
 	for(var/obj/tram/rail/RT in get_turf(src))
 		if(RT.godir)
+			if(RT.stop_duration)
+				sleep(RT.stop_duration)
 			handle_move(RT.godir)
 			last_played_rail = RT
 			return
+		if(RT.stop_duration)
+			sleep(RT.stop_duration)
 		stored_rail = RT
 	for(var/cdir in cardinal)
 		for(var/obj/tram/rail/R in get_step(src,cdir))

--- a/code/modules/tram/tram_rail.dm
+++ b/code/modules/tram/tram_rail.dm
@@ -4,4 +4,5 @@
 	icon = 'icons/obj/tram/tram_rail.dmi'
 	icon_state = "rail"
 	var/godir = null
+	var/stop_duration = null
 	layer = TURF_LAYER + 0.1


### PR DESCRIPTION
This commit adds a new feature to the MTTS system: Tram stops. If a rail
has it's stop_duration set, the tram rail follow loop will sleep for the
duration in tenth-seconds.