### PR TITLE
Fixes an unreported issue that caused lights to get stuck.

### DIFF
--- a/code/modules/lighting/lighting_process.dm
+++ b/code/modules/lighting/lighting_process.dm
@@ -1,4 +1,3 @@
-
 /datum/controller/process/lighting/setup()
 	name = "lighting"
 	schedule_interval = LIGHTING_INTERVAL
@@ -6,7 +5,10 @@
 	create_lighting_overlays()
 
 /datum/controller/process/lighting/doWork()
-	for(var/datum/light_source/L in lighting_update_lights)
+	var/list/lighting_update_lights_old = lighting_update_lights //We use a different list so any additions to the update lists during a delay from scheck() don't cause things to be cut from the list without being updated.
+	lighting_update_lights = list()
+
+	for(var/datum/light_source/L in lighting_update_lights_old)
 		if(L.needs_update)
 			if(L.destroyed || L.check() || L.force_update)
 				L.remove_lum()
@@ -16,13 +18,12 @@
 
 		scheck()
 
-	lighting_update_lights.Cut()
+	var/list/lighting_update_overlays_old = lighting_update_overlays //Same as above.
+	lighting_update_overlays = list()
 
-	for(var/atom/movable/lighting_overlay/O in lighting_update_overlays)
+	for(var/atom/movable/lighting_overlay/O in lighting_update_overlays_old)
 		if(O.needs_update)
 			O.update_overlay()
 			O.needs_update = 0
 
 		scheck()
-
-	lighting_update_overlays.Cut()


### PR DESCRIPTION
Essentially, there was an issue where lights didn't update if they got added to the update lists during a pause from the lighting controller's scheck().

Due to some optimizations I made earlier, this then got worse.