### PR TITLE
Chainsaw Tweaks

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -368,14 +368,14 @@ obj/item/weapon/twohanded/
 	icon_override = 'icons/mob/in-hand/swords.dmi'
 	icon_state = "chainsaw0"
 	name = "Chainsaw"
-	desc = "Perfect for felling trees or fellow spaceman."
+	desc = "Perfect for felling trees or fellow spacemen."
 	force = 15
 	throwforce = 15
 	throw_speed = 1
 	throw_range = 5
 	w_class = 4.0 // can't fit in backpacks
 	force_unwielded = 15 //still pretty robust
-	force_wielded = 50  //you'll gouge their eye out! Or a limb...maybe even their entire body!
+	force_wielded = 40  //you'll gouge their eye out! Or a limb...maybe even their entire body!
 	wieldsound = 'sound/weapons/chainsawstart.ogg'
 	hitsound = null
 	flags = NOSHIELD
@@ -409,11 +409,14 @@ obj/item/weapon/twohanded/
 		playsound(loc, "swing_hit", 50, 1, -1)
 		return ..()
 
-/obj/item/weapon/twohanded/chainsaw/IsShield() //Disarming someone with a chainsaw should be difficult.
-	if(wielded)
-		return 1
-	else
-		return 0
+/obj/item/weapon/twohanded/chainsaw/wield() //you can't disarm an active chainsaw, you crazy person.
+	..()
+	flags |= NODROP
+
+/obj/item/weapon/twohanded/chainsaw/unwield()
+	..()
+	flags &= ~NODROP
+
 
 // SINGULOHAMMER
 


### PR DESCRIPTION
So, after DZD brought up to me some math on how shields with dual-wielded weapons work..yeah, bad idea for the chainsaw.

Either case, this tweaks the chainsaw a bit. Further balancing in the future may be required, but for now, this is all that's going to be done.

- Lowers damage from 50 to 40.
- Removes Shield Attribute
- Gives it NODROP when wielded (no disarming chainsaws from people, silly)

Should make dropping them with ranged weaponry wayyyy easier and increase the amount of time someone has to spend hacking people up for each person they kill.