### PR TITLE
[Chemistry] Adds in Ether

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -206,9 +206,9 @@
 	dir = 8
 	var/orient = "LEFT" // "RIGHT" changes the dir suffix to "-r"
 	var/mob/living/carbon/human/occupant = null
-	var/possible_chems = list(list("epinephrine", "morphine", "salbutamol", "styptic_powder"),
-								   list("epinephrine", "morphine", "salbutamol", "styptic_powder", "oculine"),
-								   list("epinephrine", "morphine", "salbutamol", "styptic_powder", "oculine", "charcoal", "mutadone", "mannitol"))
+	var/possible_chems = list(list("epinephrine", "ether", "salbutamol", "styptic_powder"),
+								   list("epinephrine", "ether", "salbutamol", "styptic_powder", "oculine"),
+								   list("epinephrine", "ether", "salbutamol", "styptic_powder", "oculine", "charcoal", "mutadone", "mannitol"))
 	var/amounts = list(5, 10)
 	var/obj/item/weapon/reagent_containers/glass/beaker = null
 	var/filtering = 0

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -410,7 +410,7 @@
 							dat += text("[]\tBlood Level %: [] ([] units)</FONT><BR>", (blood_volume > 448 ?"<font color='blue'>" : "<font color='red'>"), blood_percent, blood_volume)
 						if(occupant.reagents)
 							dat += text("Epinephrine units: [] units<BR>", occupant.reagents.get_reagent_amount("Epinephrine"))
-							dat += text("Morphine: [] units<BR>", occupant.reagents.get_reagent_amount("morphine"))
+							dat += text("Ether: [] units<BR>", occupant.reagents.get_reagent_amount("ether"))
 							dat += text("[]\tSilver Sulfadiazine: [] units</FONT><BR>", (occupant.reagents.get_reagent_amount("silver_sulfadiazine") < 30 ? "<font color='black'>" : "<font color='red'>"), occupant.reagents.get_reagent_amount("silver_sulfadiazine"))
 							dat += text("[]\tStyptic Powder: [] units<BR>", (occupant.reagents.get_reagent_amount("styptic_powder") < 30 ? "<font color='black'>" : "<font color='red'>"), occupant.reagents.get_reagent_amount("styptic_powder"))
 							dat += text("[]\tsalbutamol: [] units<BR>", (occupant.reagents.get_reagent_amount("salbutamol") < 30 ? "<font color='black'>" : "<font color='red'>"), occupant.reagents.get_reagent_amount("salbutamol"))

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -170,8 +170,8 @@
 						if(O.reagents.get_reagent_amount("water") < 50)
 							O.reagents.add_reagent("water", 2 * coeff)
 					if(istype(O,/obj/item/weapon/reagent_containers/spray/alien/stun))
-						if(O.reagents.get_reagent_amount("morphine") < 250)
-							O.reagents.add_reagent("morphine", 2 * coeff)
+						if(O.reagents.get_reagent_amount("ether") < 250)
+							O.reagents.add_reagent("ether", 2 * coeff)
 
 
 				if(R)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -886,7 +886,7 @@
 	icon_deny = "med-deny"
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
 	req_access_txt = "5"
-	products = list(/obj/item/weapon/reagent_containers/glass/bottle/charcoal = 4,/obj/item/weapon/reagent_containers/glass/bottle/morphine = 4,/obj/item/weapon/reagent_containers/glass/bottle/epinephrine = 4,
+	products = list(/obj/item/weapon/reagent_containers/glass/bottle/charcoal = 4,/obj/item/weapon/reagent_containers/glass/bottle/morphine = 4,/obj/item/weapon/reagent_containers/glass/bottle/ether = 4,/obj/item/weapon/reagent_containers/glass/bottle/epinephrine = 4,
 					/obj/item/weapon/reagent_containers/glass/bottle/toxin = 4,/obj/item/weapon/reagent_containers/syringe/antiviral = 4,/obj/item/weapon/reagent_containers/syringe/insulin = 4,
 					/obj/item/weapon/reagent_containers/syringe = 12,/obj/item/device/healthanalyzer = 5,/obj/item/device/healthupgrade = 5,/obj/item/weapon/reagent_containers/glass/beaker = 4,
 					/obj/item/weapon/reagent_containers/dropper = 2,/obj/item/stack/medical/advanced/bruise_pack = 3, /obj/item/stack/medical/advanced/ointment = 3,

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -140,7 +140,7 @@
 		sleep(2)
 		new /obj/item/clothing/suit/straight_jacket(src)
 		new /obj/item/weapon/reagent_containers/syringe(src)
-		new /obj/item/weapon/reagent_containers/glass/bottle/morphine(src)
+		new /obj/item/weapon/reagent_containers/glass/bottle/ether(src)
 		new /obj/item/weapon/storage/pill_bottle/psychiatrist(src)
 
 		return

--- a/code/modules/events/tgevents/vent_clog.dm
+++ b/code/modules/events/tgevents/vent_clog.dm
@@ -22,7 +22,7 @@
 
 		var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
 							"atrazine","banana","charcoal","space_drugs","methamphetamine","holywater","ethanol","hot_coco","facid",
-							"blood","morphine","fluorine","mutadone","mutagen","hydrocodone","fuel",
+							"blood","morphine","ether","fluorine","mutadone","mutagen","hydrocodone","fuel",
 							"haloperidol","lsd","nanites","lipolicide","frostoil","salglu_solution","beepskysmash",
 							"omnizine", "amanitin", "adminordrazine", "neurotoxin", "synaptizine")
 		var/datum/reagents/R = new/datum/reagents(50)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -450,7 +450,8 @@
 			"slimejelly",
 			"cyanide",
 			"lsd",
-			"morphine"
+			"morphine",
+			"ether"
 			)
 
 		for(var/x=1;x<=additional_chems;x++)

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -499,7 +499,7 @@
 	seed_name = "liberty cap"
 	display_name = "liberty cap mushrooms"
 	mutants = null
-	chems = list("plantmatter" = list(1), "ether" = list(3,3), "space_drugs" = list(1,25))
+	chems = list("plantmatter" = list(1), "morphine" = list(3,3), "space_drugs" = list(1,25))
 	kitchen_tag = "libertycap"
 
 /datum/seed/mushroom/hallucinogenic/strong/New()

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -499,7 +499,7 @@
 	seed_name = "liberty cap"
 	display_name = "liberty cap mushrooms"
 	mutants = null
-	chems = list("plantmatter" = list(1), "morphine" = list(3,3), "space_drugs" = list(1,25))
+	chems = list("plantmatter" = list(1), "ether" = list(3,3), "space_drugs" = list(1,25))
 	kitchen_tag = "libertycap"
 
 /datum/seed/mushroom/hallucinogenic/strong/New()
@@ -1190,7 +1190,7 @@
 	name = "gelthi"
 	seed_name = "gelthi"
 	display_name = "gelthi plant"
-	chems = list("morphine" = list(1,5),"capsaicin" = list(1,5),"plantmatter" = list(1,5))
+	chems = list("ether" = list(1,5),"capsaicin" = list(1,5),"plantmatter" = list(1,5))
 
 /datum/seed/gelthi/New()
 	..()

--- a/code/modules/jungle/jungle_plants.dm
+++ b/code/modules/jungle/jungle_plants.dm
@@ -58,7 +58,7 @@
 //*******************************//
 
 var/list/fruit_icon_states = list("badrecipe","kudzupod","reishi","lime","grapes","boiledrorocore","chocolateegg")
-var/list/reagent_effects = list("toxin","charcoal","morphine","space_drugs","lsd","haloperidol")
+var/list/reagent_effects = list("toxin","charcoal","ether","space_drugs","lsd","haloperidol")
 var/jungle_plants_init = 0
 
 /proc/init_jungle_plants()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -947,7 +947,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				adjustStaminaLoss(-10)
 				adjustHalLoss(-3)
 				if (mind)
-					//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of morphine or similar.
+					//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of ether or similar.
 					if(player_logged)
 						sleeping = max(sleeping-1, 2)
 					else

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -373,7 +373,7 @@
 		src.modules += new /obj/item/device/flash/cyborg/alien(src)
 		src.modules += new /obj/item/borg/sight/thermal/alien(src)
 		var/obj/item/weapon/reagent_containers/spray/alien/stun/S = new /obj/item/weapon/reagent_containers/spray/alien/stun(src)
-		S.reagents.add_reagent("morphine",250) //nerfed to sleeptoxin to make it less instant drop.
+		S.reagents.add_reagent("ether",250) //nerfed to sleeptoxin to make it less instant drop.
 		src.modules += S
 		var/obj/item/weapon/reagent_containers/spray/alien/smoke/A = new /obj/item/weapon/reagent_containers/spray/alien/smoke(src)
 		S.reagents.add_reagent("water",50) //Water is used as a dummy reagent for the smoke bombs. More of an ammo counter.

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -65,7 +65,7 @@
 	melee_damage_upper = 10
 	poison_per_bite = 10
 	var/atom/cocoon_target
-	poison_type = "morphine"
+	poison_type = "ether"
 	var/fed = 0
 
 //hunters have the most poison and move the fastest, so they can find prey

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1463,7 +1463,7 @@ datum
 			name = "Neurotoxin"
 			id = "neurotoxin"
 			result = "neurotoxin"
-			required_reagents = list("gargleblaster" = 1, "morphine" = 1)
+			required_reagents = list("gargleblaster" = 1, "ether" = 1)
 			result_amount = 2
 
 		snowwhite

--- a/code/modules/reagents/dartgun.dm
+++ b/code/modules/reagents/dartgun.dm
@@ -297,7 +297,7 @@
 	starting_chems = list("silver_sulfadiazine","styptic_powder","charcoal")
 
 /obj/item/weapon/gun/dartgun/vox/raider
-	starting_chems = list("space_drugs","morphine","haloperidol")
+	starting_chems = list("space_drugs","ether","haloperidol")
 
 /obj/effect/syringe_gun_dummy //moved this shitty thing here
 	name = ""

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -913,6 +913,36 @@ datum/reagent/haloperidol/on_mob_life(var/mob/living/M as mob)
 	result_amount = 4
 	mix_message = "The chemicals mix into an odd pink slush."
 
+
+/datum/reagent/ether
+	name = "Ether"
+	id = "ether"
+	description = "A strong anesthetic and sedative."
+	reagent_state = LIQUID
+	color = "#96DEDE"
+
+/datum/reagent/ether/on_mob_life(var/mob/living/M as mob)
+	if(!M) M = holder.my_atom
+	switch(current_cycle)
+		if(0 to 15)
+			if(prob(5))
+				M.emote("yawn")
+		if(16 to 35)
+			M.drowsyness = max(M.drowsyness, 10)
+		if(36 to INFINITY)
+			M.Paralyse(10)
+			M.drowsyness = max(M.drowsyness, 15)
+	..()
+	return
+
+/datum/chemical_reaction/ether
+	name = "Ether"
+	id = "ether"
+	result = "ether"
+	required_reagents = list("sacid" = 1, "ethanol" = 1, "oxygen" = 1)
+	result_amount = 1
+	mix_message = "The mixture yields a pungent odor, which makes you tired."
+
 //////////////////////////////
 //		Synth-Meds			//
 //////////////////////////////

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -675,7 +675,7 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 12)
-		reagents.add_reagent("morphine", 3)
+		reagents.add_reagent("ether", 3)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/stuffing
@@ -3116,7 +3116,7 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 12)
-		reagents.add_reagent("morphine", 3)
+		reagents.add_reagent("ether", 3)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/stuffing

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -150,6 +150,15 @@
 		..()
 		reagents.add_reagent("morphine", 30)
 
+/obj/item/weapon/reagent_containers/glass/bottle/ether
+	name = "Ether Bottle"
+	desc = "A small bottle. Contains ether."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle17"
+	New()
+		..()
+		reagents.add_reagent("ether", 30)
+
 /obj/item/weapon/reagent_containers/glass/bottle/charcoal
 	name = "Charcoal Bottle"
 	desc = "A small bottle. Contains charcoal."


### PR DESCRIPTION
Got this from a closed PR on TG.

- Adds in Ether
 - Ether is pretty much like morphine only it's (1)not addictive (2) doesn't give you a speedboost (3)has a recipe.

Related
- Replaces *most* instances of morphine with ether (exceptions morphine bottles in nanomeds and supply packs).


This gives medical a way to knock people out without getting the the patient high as a kite or repeatedly taking damage from addiction; it also means that various things that use morphine for knockout purposes don't have the side effect of inducing crippling OD/addictions (ie: spiders, vox dart guns, etc). It can also be produced, so there's no fear of it running out in the middle of the shift.

