### PR TITLE
Lights Use Power

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -256,7 +256,7 @@
 		use_power = 1
 		set_light(0)
 
-	active_power_usage = ((light_range + light_power) * 10)
+	active_power_usage = brightness_range * 10
 	if(on != on_gs)
 		on_gs = on
 
@@ -564,11 +564,11 @@
 
 #define LIGHTING_POWER_FACTOR 20		//20W per unit luminosity
 
-/*
+
 /obj/machinery/light/process()//TODO: remove/add this from machines to save on processing as needed ~Carn PRIORITY
 	if(on)
-		use_power(light_range * LIGHTING_POWER_FACTOR, LIGHT)
-*/
+		use_power(brightness_range * LIGHTING_POWER_FACTOR, LIGHT)
+
 
 // called when area power state changes
 /obj/machinery/light/power_change()


### PR DESCRIPTION
Fixes: https://github.com/ParadiseSS13/Paradise/issues/1371

Lights will use power, once again.

Made a few tweaks to how much power light uses based on the luminosity of the bulb as opposed to "light_range".

This most definitely increases the power consumption of the station by a significant margin; will be closely monitoring drain rates post implementation.