### PR TITLE
Fixes Away Mission Lighting

### DIFF
--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -43,6 +43,7 @@ proc/createRandomZlevel()
 			// Initialize air for the away mission's turfs
 			if(air_master)
 				air_master.setup_allturfs(block(locate(1, 1, world.maxz), locate(world.maxx, world.maxy, world.maxz)))
+			create_lighting_overlays(world.maxz)
 			world.log << "away mission loaded: [map]"
 
 		for(var/obj/effect/landmark/L in landmarks_list)


### PR DESCRIPTION
The lighting overlays simply weren't being generated.

They probably *should* have been getting generated automatically with the turfs, and the fact that they apparently aren't probably has other terrible consequences that I'm sure we'll notice eventually, buuut I'm too lazy to look into why that's not working, so this will have to do.