### PR TITLE
Update mob holder code to bay's modular system.

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -24,7 +24,7 @@
 			mob_container.forceMove(get_turf(src))
 			M.reset_view()
 
-		del(src)
+		qdel(src)
 
 /obj/item/weapon/holder/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	for(var/mob/M in src.contents)
@@ -33,6 +33,23 @@
 /obj/item/weapon/holder/proc/show_message(var/message, var/m_type)
 	for(var/mob/living/M in contents)
 		M.show_message(message,m_type)
+
+//Mob procs and vars for scooping up
+/mob/living/var/holder_type
+
+/mob/living/proc/get_scooped(var/mob/living/carbon/grabber)
+	if(!holder_type)	return
+
+	var/obj/item/weapon/holder/H = new holder_type(loc)
+	src.forceMove(H)
+	H.name = name
+	if(desc)	H.desc = desc
+	H.attack_hand(grabber)
+
+	grabber << "<span class='notice'>You scoop up \the [src]."
+	src << "<span class='notice'>\The [grabber] scoops you up.</span>"
+	grabber.status_flags |= PASSEMOTES
+	return
 
 //Mob specific holders.
 

--- a/code/modules/mob/living/carbon/primitive/dionaold.dm
+++ b/code/modules/mob/living/carbon/primitive/dionaold.dm
@@ -13,6 +13,7 @@
 	var/ready_evolve = 0
 	ventcrawler = 1
 	var/environment_smash = 0 // This is a sloppy way to solve attack_animal runtimes. Stupid nymphs...
+	holder_type = /obj/item/weapon/holder/diona
 
 /mob/living/carbon/primitive/diona/New()
 
@@ -30,16 +31,9 @@
 			src << "You feel your being twine with that of [M] as you merge with its biomass."
 			src.verbs += /mob/living/carbon/primitive/diona/proc/split
 			src.verbs -= /mob/living/carbon/primitive/diona/proc/merge
-			src.loc = M
+			src.forceMove(M)
 		else
-			var/obj/item/weapon/holder/diona/D = new(loc)
-			src.loc = D
-			D.name = loc.name
-			D.attack_hand(M)
-			M << "You scoop up [src]."
-			src << "[M] scoops you up."
-		M.status_flags |= PASSEMOTES
-		return
+			get_scooped(M)
 
 	..()
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -25,6 +25,8 @@
 
 	//Used for self-mailing.
 	var/mail_destination = 0
+
+	holder_type = /obj/item/weapon/holder/drone
 //	var/sprite[0]
 
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -45,14 +45,7 @@
 
 //Actual picking-up event.
 /mob/living/silicon/robot/drone/attack_hand(mob/living/carbon/human/M as mob)
-
 	if(M.a_intent == "help")
-		var/obj/item/weapon/holder/drone/D = new(loc)
-		src.loc = D
-		D.attack_hand(M)
-		M << "You scoop up [src]."
-		src << "[M] scoops you up."
-		M.status_flags |= PASSEMOTES
-		return
+		get_scooped(M)
 
 	..()


### PR DESCRIPTION
This commit updates the mob holder code to a more modular system, from this PR Baystation12/Baystation12#5355

A few things changed from that:
 - Used forceMove instead of a direct loc setting
 - Changed a del to qdel
 - Holders will adopt the name and description of whatever you pick up, so examining them will make a bit more sense.