### PR TITLE
Removes/Replaces some instances of locs

### DIFF
--- a/code/LINDA/LINDA_system.dm
+++ b/code/LINDA/LINDA_system.dm
@@ -211,8 +211,8 @@ turf/CanPass(atom/movable/mover, turf/target, height=1.5,air_group=0)
 /atom/movable/proc/air_update_turf(var/command = 0)
 	if(!istype(loc,/turf) && command)
 		return
-	for(var/turf/T in locs) // used by double wide doors and other nonexistant multitile structures
-		T.air_update_turf(command)
+	var/turf/T = get_turf(loc)
+	T.air_update_turf(command)
 
 /turf/proc/air_update_turf(var/command = 0)
 	if(command)

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -66,9 +66,7 @@
 /atom/movable/Adjacent(var/atom/neighbor)
 	if(neighbor == loc) return 1
 	if(!isturf(loc)) return 0
-	for(var/turf/T in locs)
-		if(isnull(T)) continue
-		if(T.Adjacent(neighbor,src)) return 1
+	if(loc.Adjacent(neighbor,src)) return 1
 	return 0
 
 // This is necessary for storage items not on your person.

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -425,9 +425,9 @@
 
 	var/obj/item/weapon/folder/syndicate/folder
 	if(owner == exchange_red)
-		folder = new/obj/item/weapon/folder/syndicate/red(mob.locs)
+		folder = new/obj/item/weapon/folder/syndicate/red(mob.loc)
 	else
-		folder = new/obj/item/weapon/folder/syndicate/blue(mob.locs)
+		folder = new/obj/item/weapon/folder/syndicate/blue(mob.loc)
 
 	var/list/slots = list (
 		"backpack" = slot_in_backpack,

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -886,14 +886,11 @@ About the new airlock wires panel:
 	if(operating || welded || locked)
 		return
 	if(!forced)
-		//despite the name, this wire is for general door control.
-		//Bolts are already covered by the check for locked, above
 		if( !arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_OPEN_DOOR) )
 			return
 	if(safe)
-		for(var/turf/turf in locs)
-			if(locate(/mob/living) in turf)
-			//	playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)	//THE BUZZING IT NEVER STOPS	-Pete
+		for(var/atom/movable/M in get_turf(src))
+			if(M.density && M != src) //something is blocking the door
 				spawn (60)
 					autoclose()
 				return

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -283,6 +283,8 @@
 		var/turf/location = src.loc
 		if(istype(location, /turf/simulated)) //add_blood doesn't work for borgs/xenos, but add_blood_floor does.
 			location.add_blood(L)
+	for(var/obj/mecha/M in get_turf(src))
+		M.take_damage(DOOR_CRUSH_DAMAGE)
 
 /obj/machinery/door/proc/requiresID()
 	return 1


### PR DESCRIPTION
Removes a few instances of "locs", which is prone to leaks.

*technically speaking* this has been fixed in a beta version of BYOND (and in the most recent stable version, I believe).

Related

This technically also makes it so that dense objects prevent doors from auto-closing unless their safety is over-ridden. As this was done, I went ahead and implemented this: https://github.com/tgstation/-tg-station/pull/8302