### PR TITLE
Black Powder Balance

### DIFF
--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -197,6 +197,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	blackpowder_detonate(holder, created_volume)
 	return
 
+/*
 /datum/reagent/blackpowder/on_ex_act()
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
@@ -205,7 +206,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	sleep(rand(10,15))
 	blackpowder_detonate(holder, volume)
 	holder.remove_reagent("blackpowder", volume)
-	return
+	return */
 
 /proc/blackpowder_detonate(var/datum/reagents/holder, var/created_volume)
 	var/turf/simulated/T = get_turf(holder.my_atom)


### PR DESCRIPTION
Nerfs black powder a bit

- Black powder will no longer detonate when impacted by explosions
 - Should also help cut down on lag generated by black powder usage, as well.

on_ex_act() code is left intact in case we want to utilize it for anything else, but for now, this nerf needs to happen; Black Powder is simply too powerful in its current state.