### PR TITLE
Status Display Font Size Increase

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -1,4 +1,4 @@
-#define FONT_SIZE "4pt"
+#define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
 #define FONT_STYLE "Arial Black"
 #define SCROLL_SPEED 2
@@ -35,7 +35,7 @@
 	var/ignore_friendc = 0
 
 	var/spookymode = 0
-	
+
 	maptext_height = 26
 	maptext_width = 32
 
@@ -222,7 +222,7 @@
 	density = 0
 
 	var/spookymode = 0
-	
+
 	var/mode = 0	// 0 = Blank
 					// 1 = AI emoticon
 					// 2 = Blue screen of death


### PR DESCRIPTION
Increases the status display font size by 1 point so you can actually read it.

![readable](http://i.gyazo.com/1f0c80464e08b6666fe0a7702d64e74d.png)

This change was made a long time ago and it pretty much made the status displays unreadable.