### PR TITLE
Tweaks a Few Destroy()'s

### DIFF
--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -36,6 +36,7 @@
 	..()
 
 /obj/item/weapon/shard/Destroy()
+	..()
 	return QDEL_HINT_PUTINPOOL
 
 /obj/item/weapon/shard/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -37,6 +37,7 @@
 	icon='icons/fence-ns.dmi'
 
 /obj/structure/grille/Destroy()
+	..()
 	return QDEL_HINT_PUTINPOOL //pool grilles
 
 /obj/structure/grille/ex_act(severity)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -76,6 +76,7 @@
 	return //don't want the emitters to miss
 
 /obj/item/projectile/beam/emitter/Destroy()
+	..()
 	return QDEL_HINT_PUTINPOOL
 
 /obj/item/projectile/lasertag


### PR DESCRIPTION
Ensures that Destroy()'s with hints call the parent proc to better clear all references.

I'm sure @Krausus will appreciate this one.