### PR TITLE
Adjusts Character Setup and Job Selection Menus

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -407,11 +407,11 @@ datum/preferences
 		dat += "</center></body></html>"
 
 //		user << browse(dat, "window=preferences;size=560x580")
-		var/datum/browser/popup = new(user, "preferences", "<div align='center'>Character Setup</div>", 610, 650)
+		var/datum/browser/popup = new(user, "preferences", "<div align='center'>Character Setup</div>", 640, 750)
 		popup.set_content(dat)
 		popup.open(0)
 
-	proc/SetChoices(mob/user, limit = 14, list/splitJobs = list("Chief Engineer","Research Director","Captain"), width = 1025, height = 800)
+	proc/SetChoices(mob/user, limit = 12, list/splitJobs = list("Civilian","Research Director","AI","Bartender"), width = 755, height = 780)
 		if(!job_master)
 			return
 
@@ -443,7 +443,6 @@ datum/preferences
 					//the last job's selection color. Creating a rather nice effect.
 					for(var/i = 0, i < (limit - index), i += 1)
 						HTML += "<tr bgcolor='[lastJob.selection_color]'><td width='60%' align='right'>&nbsp</td><td>&nbsp</td></tr>"
-				HTML += "</table></td><td width='20%'><table width='100%' cellpadding='1' cellspacing='0'>"
 				HTML += "</table></td><td width='20%'><table width='100%' cellpadding='1' cellspacing='0'>"
 				index = 0
 


### PR DESCRIPTION
So, with all the jobs we've had added, we haven't done a good job of adjusting the job selection so it looks better...it it's current state it's rather awkward and quite a mess in how it's presented to players. This improves it a bit; it's still not perfect, but it's considerably better, in my opinion. Pic:

![jobs](http://i.gyazo.com/364bad00b84374cabab9a90bffe8584f.png)


Related
- Slightly increases size of player setup screen so as to eliminate scroll bars/the need to re-size