### PR TITLE
MrBarrelrolll Fluff Item

### DIFF
--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -75,6 +75,16 @@
 	icon_state = "zeldacrowbar"
 	item_state = "crowbar"
 
+/obj/item/weapon/claymore/fluff //MrBarrelrolll: Maximus Greenwood
+	name = "Greenwood's Blade"
+	desc = "A replica claymore with strange markings scratched into the blade."
+	force = 5
+	sharp = 0
+	edge = 0
+
+/obj/item/weapon/claymore/fluff/IsShield()
+	return 0
+
 //////////////////////////////////
 //////////// Clothing ////////////
 //////////////////////////////////


### PR DESCRIPTION
- Adds in fluff item for MrBarrelrolll, a replica claymore. It is in most aspects identical to the toy katana, has a force of 5, does not act as a shield, and has both sharp and edge vars set to 0. 