### PR TITLE
Cinematics Don't Delay Round End

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -339,10 +339,9 @@ var/global/datum/controller/gameticker/ticker
 						M.death()//No mercy
 		//If its actually the end of the round, wait for it to end.
 		//Otherwise if its a verb it will continue on afterwards.
-		sleep(300)
-
-		if(cinematic)	del(cinematic)		//end the cinematic
-		if(temp_buckle)	del(temp_buckle)	//release everybody
+		spawn(300)
+			if(cinematic)	del(cinematic)		//end the cinematic
+			if(temp_buckle)	del(temp_buckle)	//release everybody
 		return
 
 


### PR DESCRIPTION
Basically this PR: https://github.com/tgstation/-tg-station/pull/10374

Ever notice that when the nuke goes off it takes forever for the round to end? Also notice that round end stats aren't displayed until much later? This fixes that.

No more waiting around forever when the game is very clearly over.