### PR TITLE
Fix remaining non-returning Destroys()

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -195,4 +195,4 @@ obj/machinery/atmospherics/proc/check_connect_types_construction(obj/machinery/a
 
 /obj/machinery/atmospherics/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)
-		Destroy()
+		qdel(src)

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -57,7 +57,7 @@ obj/machinery/atmospherics/binary
 		node1 = null
 		node2 = null
 
-		..()
+		return ..()
 
 	initialize()
 		if(node1 && node2) return
@@ -85,7 +85,7 @@ obj/machinery/atmospherics/binary
 
 		update_icon()
 		update_underlays()
-		
+
 	build_network()
 		if(!network1 && node1)
 			network1 = new /datum/pipe_network()
@@ -135,7 +135,7 @@ obj/machinery/atmospherics/binary
 		else if(reference==node2)
 			del(network2)
 			node2 = null
-			
+
 		update_icon()
 		update_underlays()
 

--- a/code/ATMOSPHERICS/components/unary/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary/unary_base.dm
@@ -37,7 +37,7 @@
 
 		node = null
 
-		..()
+		return ..()
 
 	initialize()
 		if(node) return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -625,7 +625,7 @@ datum/mind
 					for(var/obj/item/weapon/implant/loyalty/I in H.contents)
 						for(var/obj/item/organ/external/organs in H.organs)
 							if(I in organs.implants)
-								I.Destroy()
+								qdel(I)
 					H << "\blue <Font size =3><B>Your loyalty implant has been deactivated.</B></FONT>"
 				if("add")
 					var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -25,8 +25,7 @@
 		if(overmind)
 			del(overmind)
 		processing_objects.Remove(src)
-		..()
-		return
+		return ..()
 
 	update_icon()
 		if(health <= 0)

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -14,8 +14,7 @@
 	Destroy()
 		blob_nodes -= src
 		processing_objects.Remove(src)
-		..()
-		return
+		return ..()
 
 	Life()
 		for(var/i = 1; i < 8; i += i)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -25,8 +25,7 @@
 
 	Destroy()
 		blobs -= src
-		..()
-		return
+		return ..()
 
 
 	CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/game/gamemodes/events/biomass.dm
+++ b/code/game/gamemodes/events/biomass.dm
@@ -18,7 +18,7 @@
 		if(master)
 			master.vines -= src
 			master.growth_queue -= src
-		..()
+		return ..()
 
 /obj/effect/biomass/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if (!W || !user || !W.type) return

--- a/code/game/machinery/Beacon.dm
+++ b/code/game/machinery/Beacon.dm
@@ -24,8 +24,8 @@
 
 	Destroy()
 		if(Beacon)
-			del(Beacon)
-		..()
+			qdel(Beacon)
+		return ..()
 
 	// update the invisibility and icon
 	hide(var/intact)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -37,7 +37,7 @@
 	Destroy()
 		del(air_contents)
 
-		..()
+		return ..()
 
 	update_icon()
 		return null

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -453,9 +453,9 @@
 		f2.set_opacity(opacity)
 
 	Destroy()
-		del f1
-		del f2
-		..()
+		qdel(f1)
+		qdel(f2)
+		return ..()
 
 /obj/machinery/door/poddoor/two_tile_ver
 	var/obj/machinery/door/poddoor/filler_object/f1
@@ -472,9 +472,9 @@
 		f2.set_opacity(opacity)
 
 	Destroy()
-		del f1
-		del f2
-		..()
+		qdel(f1)
+		qdel(f2)
+		return ..()
 
 /obj/machinery/door/poddoor/three_tile_hor
 	var/obj/machinery/door/poddoor/filler_object/f1
@@ -495,10 +495,10 @@
 		f3.set_opacity(opacity)
 
 	Destroy()
-		del f1
-		del f2
-		del f3
-		..()
+		qdel(f1)
+		qdel(f2)
+		qdel(f3)
+		return ..()
 
 /obj/machinery/door/poddoor/three_tile_ver
 	var/obj/machinery/door/poddoor/filler_object/f1
@@ -519,10 +519,10 @@
 		f3.set_opacity(opacity)
 
 	Destroy()
-		del f1
-		del f2
-		del f3
-		..()
+		qdel(f1)
+		qdel(f2)
+		qdel(f3)
+		return ..()
 
 /obj/machinery/door/poddoor/four_tile_hor
 	var/obj/machinery/door/poddoor/filler_object/f1
@@ -547,11 +547,11 @@
 		f4.set_opacity(opacity)
 
 	Destroy()
-		del f1
-		del f2
-		del f3
-		del f4
-		..()
+		qdel(f1)
+		qdel(f2)
+		qdel(f3)
+		qdel(f4)
+		return ..()
 
 /obj/machinery/door/poddoor/four_tile_ver
 	var/obj/machinery/door/poddoor/filler_object/f1
@@ -576,11 +576,11 @@
 		f4.set_opacity(opacity)
 
 	Destroy()
-		del f1
-		del f2
-		del f3
-		del f4
-		..()
+		qdel(f1)
+		qdel(f2)
+		qdel(f3)
+		qdel(f4)
+		return ..()
 
 /obj/machinery/door/poddoor/filler_object
 	name = ""

--- a/code/game/machinery/doors/spacepod.dm
+++ b/code/game/machinery/doors/spacepod.dm
@@ -7,23 +7,18 @@
 	density = 0
 	anchored = 1
 
-	New() //set the turf below the flaps to block air
-		var/turf/T = get_turf(loc)
-		if(T)
-			T.blocks_air = 1
-		..()
+/obj/structure/spacepoddoor/New()
+	..()
+	air_update_turf(1)
 
-	Destroy() //lazy hack to set the turf to allow air to pass if it's a simulated floor
-		var/turf/T = get_turf(loc)
-		if(T)
-			if(istype(T, /turf/simulated/floor))
-				T.blocks_air = 0
-		..()
+/obj/structure/spacepoddoor/CanAtmosPass(turf/T)
+	return 0
 
+/obj/structure/spacepoddoor/Destroy()
+	air_update_turf(1)
+	return ..()
 
-
-/obj/structure/spacepoddoor/CanPass(atom/A, turf/T)
+/obj/structure/spacepoddoor/CanPass(atom/movable/A, turf/T)
 	if(istype(A, /obj/spacepod))
 		return ..()
 	else return 0
-

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1079,10 +1079,9 @@ steam.start() -- spawns the effect
 		air_update_turf(1)
 
 	Destroy()
-
 		density = 0
 		air_update_turf(1)
-		..()
+		return ..()
 
 	Move()
 		var/turf/T = loc

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -65,7 +65,7 @@
 		processing_objects.Remove(src)
 //		attached.attached = null
 		attached = null
-		..()
+		return ..()
 
 
 	attack_ai()

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -16,7 +16,7 @@
 				T.pinned_target = null
 				T.density = 1
 				break
-		..() // delete target
+		return ..() // delete target
 
 	Move()
 		..()

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -47,7 +47,7 @@
 	Destroy()
 		if(part)
 			part.implants.Remove(src)
-		..()
+		return ..()
 
 /obj/item/weapon/implant/tracking
 	name = "tracking"

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -84,4 +84,4 @@
 
 /obj/structure/lattice/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FOUR)
-		Destroy()
+		qdel(src)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -24,7 +24,7 @@
 
 	Destroy()
 		air_update_turf(1)
-		..()
+		return ..()
 
 	Move()
 		var/turf/T = loc

--- a/code/game/objects/structures/segway.dm
+++ b/code/game/objects/structures/segway.dm
@@ -112,7 +112,7 @@
 	if(health <= 0)
 		if(buckled_mob)
 			buckled_mob << "The [src.name] was destroyed!"
-		Destroy()
+		qdel(src)
 
 /obj/item/sec_seg_key
 	name = "security segway key"

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -87,18 +87,16 @@ var/list/mechtoys = list(
 	name = "\improper Airtight plastic flaps"
 	desc = "Heavy duty, airtight, plastic flaps."
 
-	New() //set the turf below the flaps to block air
-		var/turf/T = get_turf(loc)
-		if(T)
-			T.blocks_air = 1
+	New()
+		air_update_turf(1)
 		..()
 
-	Destroy() //lazy hack to set the turf to allow air to pass if it's a simulated floor
-		var/turf/T = get_turf(loc)
-		if(T)
-			if(istype(T, /turf/simulated/floor))
-				T.blocks_air = 0
-		..()
+	Destroy()
+		air_update_turf(1)
+		return ..()
+
+	CanAtmosPass(turf/T)
+		return 0
 
 /obj/machinery/computer/supplycomp
 	name = "Supply Shuttle Console"

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -70,8 +70,8 @@
 			else if(A.a_right == src)
 				A.a_right = null
 			src.holder = null
-		..()
-			
+		return ..()
+
 	pulsed(var/radio = 0)
 		if(holder && (wires & WIRE_RECEIVE))
 			activate()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -29,7 +29,7 @@
 			a_left.holder = null
 		if(a_right)
 			a_right.holder = null
-		..()
+		return ..()
 
 	attach(var/obj/item/device/D, var/obj/item/device/D2, var/mob/user)
 		if((!D)||(!D2))	return 0

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -20,7 +20,7 @@
 			if(stat!=DEAD)	//If not dead.
 				death(1)	//Brains can die again. AND THEY SHOULD AHA HA HA HA HA HA
 			ghostize()		//Ghostize checks for key so nothing else is necessary.
-		..()
+		return ..()
 
 	say_understands(var/other)//Goddamn is this hackish, but this say code is so odd
 		if (istype(other, /mob/living/silicon/ai))

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -216,8 +216,8 @@
 	held_item = null
 
 	robogibs(src.loc, viruses)
-	src.Destroy()
-	return
+	qdel(src)
+
 //Cannibalized from the parrot mob. ~Zuhayr
 
 /mob/living/simple_animal/spiderbot/verb/drop_held_item()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -201,7 +201,7 @@
 
 /obj/structure/cable/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)
-		Destroy()
+		qdel(src)
 
 // the cable coil object, used for laying cable
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -135,7 +135,7 @@ obj/item/weapon/gun/energy/laser/retro
 
 	Destroy()
 		processing_objects.Remove(src)
-		..()
+		return ..()
 
 
 	process()
@@ -172,7 +172,7 @@ obj/item/weapon/gun/energy/laser/retro
 
 	Destroy()
 		processing_objects.Remove(src)
-		..()
+		return ..()
 
 
 	process()

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -54,7 +54,7 @@
 
 	Destroy()
 		processing_objects.Remove(src)
-		..()
+		return ..()
 
 
 	process()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -109,7 +109,7 @@
 
 	Destroy()
 		processing_objects.Remove(src)
-		..()
+		return ..()
 
 	process()
 		charge_tick++

--- a/code/modules/projectiles/guns/projectile/crossbow.dm
+++ b/code/modules/projectiles/guns/projectile/crossbow.dm
@@ -45,7 +45,7 @@
 		user  << "[src] shatters into a scattering of overstressed metal shards as it leaves the crossbow."
 		var/obj/item/weapon/shard/shrapnel/S = new()
 		S.loc = get_turf(src)
-		src.Destroy()
+		qdel(src)
 
 /obj/item/weapon/arrow/baguette
 	name = "baguette"

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -637,7 +637,7 @@ atom/proc/create_reagents(var/max_vol)
 
 /datum/reagents/Destroy()
 	for(var/datum/reagent/reagent in reagent_list)
-		reagent.Destroy()
+		qdel(reagent)
 
 	if(my_atom)
 		my_atom = null

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -166,7 +166,7 @@ datum
 				if(src.data["virus"])
 					var/datum/disease/D = src.data["virus"]
 					D.cure(0)
-				..()
+				return ..()
 */
 
 /*

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -190,16 +190,16 @@
 	if(istype(target, /obj/item/weapon/reagent_containers/food/snacks))
 		if(!reagents.total_volume)
 			user << "<span class='warning'>You tear open [src], but there's nothing in it.</span>"
-			Destroy()
+			qdel(src)
 			return
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			user << "<span class='warning'>You tear open [src], but [target] is stacked so high that it just drips off!</span>" //Not sure if food can ever be full, but better safe than sorry.
-			Destroy()
+			qdel(src)
 			return
 		else
 			user << "<span class='notice'>You tear open [src] above [target] and the condiments drip onto it.</span>"
 			src.reagents.trans_to(target, amount_per_transfer_from_this)
-			Destroy()
+			qdel(src)
 
 /obj/item/weapon/reagent_containers/food/condiment/pack/on_reagent_change()
 	if(reagents.reagent_list.len > 0)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -481,7 +481,7 @@
 
 	singularity_pull(S, current_size)
 		if(current_size >= STAGE_FIVE)
-			Destroy()
+			qdel(src)
 
 // virtual disposal object
 // travels through pipes in lieu of actual items
@@ -685,11 +685,11 @@
 			// otherwise, do normal expel from turf
 			if(H)
 				expel(H, T, 0)
-		..()
+		return ..()
 
 	singularity_pull(S, current_size)
 		if(current_size >= STAGE_FIVE)
-			Destroy()
+			qdel(src)
 
 	// returns the direction of the next pipe object, given the entrance dir
 	// by default, returns the bitmask of remaining directions


### PR DESCRIPTION
Plus a little refactor to mining flaps and spacepod doors- they now use
CanAtmosPass instead of manually setting the turf to no-atmos-passing