### PR TITLE
Makes Cables GC Better

### DIFF
--- a/code/_globalvars/station.dm
+++ b/code/_globalvars/station.dm
@@ -1,7 +1,5 @@
 var/global/obj/effect/datacore/data_core = null
 
-var/global/defer_powernet_rebuild = 0		// true if net rebuild will be called manually after an event
-
 var/CELLRATE = 0.002  // multiplier for watts per tick <> cell storage (eg: .002 means if there is a load of 1000 watts, 20 units will be taken from a cell per second)
 var/CHARGELEVEL = 0.0005 // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)
 

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -17,7 +17,6 @@
 
 
 /datum/game_mode/meteor/post_setup()
-	defer_powernet_rebuild = 2//Might help with the lag
 	spawn (rand(waittime_l, waittime_h))
 		send_intercept()
 	spawn(initialmeteordelay)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -78,10 +78,6 @@
 		var/datum/controller/process/lighting = processScheduler.getProcess("lighting")
 		lighting.disable()
 
-		var/powernet_rebuild_was_deferred_already = defer_powernet_rebuild
-		if(defer_powernet_rebuild != 2)
-			defer_powernet_rebuild = 1
-
 		if(heavy_impact_range > 1)
 			var/datum/effect/system/explosion/E = new/datum/effect/system/explosion()
 			E.set_up(epicenter)
@@ -152,10 +148,6 @@
 		sleep(8)
 
 		lighting.enable()
-
-		if(!powernet_rebuild_was_deferred_already)
-			if(defer_powernet_rebuild != 2)
-				defer_powernet_rebuild = 0
 
 	return 1
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -86,18 +86,9 @@
 
 
 /obj/structure/cable/Destroy()						// called when a cable is deleted
-	if(!defer_powernet_rebuild)					// set if network will be rebuilt manually
-		if(powernet)
-			powernet.cut_cable(src)				// update the powernets
+	if(powernet)
+		powernet.cut_cable(src)				// update the powernets
 	cable_list -= src
-/*	if(istype(attached))
-		attached.set_light(0)
-		attached.icon_state = "powersink0"
-		attached.mode = 0
-		processing_objects.Remove(attached)
-		attached.anchored = 0
-		attached.attached = null
-	attached = null*/
 	return ..()													// then go ahead and delete the cable
 
 /obj/structure/cable/hide(var/i)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -139,13 +139,9 @@
 
 /obj/singularity/narsie/wizard/eat()
 	set background = BACKGROUND_ENABLED
-//	if(defer_powernet_rebuild != 2)
-//		defer_powernet_rebuild = 1
 	for(var/atom/X in orange(consume_range,src))
 		if(isturf(X) || istype(X, /atom/movable))
 			consume(X)
-//	if(defer_powernet_rebuild != 2)
-//		defer_powernet_rebuild = 0
 	return
 
 


### PR DESCRIPTION
defer_powernet_rebuilt is basically a global var that can be used in some situations to hypothetically cut down on lag during load events (namely explosions or meteor)....problem is it can also prevent cables from GC'ing during those same high load events, meaning the cables are del()'d instead, so...it's kinda shooting yourself in the foot.