### PR TITLE
Shard Runtime Fix

### DIFF
--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -67,6 +67,8 @@
 
 			if( !H.shoes && ( !H.wear_suit || !(H.wear_suit.body_parts_covered & FEET) ) )
 				var/obj/item/organ/external/affecting = H.get_organ(pick("l_foot", "r_foot"))
+				if(!affecting)
+					return
 				if(affecting.status & ORGAN_ROBOT)
 					return
 				H.Weaken(3)


### PR DESCRIPTION
Fixes a runtime involving crossing a shard when you don't have any feet...which in turn generates something like 20+ runtimes for relay_move if you're in a wheelchair or someone is pulling the person with no feet.