### PR TITLE
Tweaks Explosion Throwing

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -110,7 +110,7 @@
 				if(A.density && !A.throwpass)	// **TODO: Better behaviour for windows which are dense, but shouldn't always stop movement
 					src.throw_impact(A,speed)
 
-/atom/movable/proc/throw_at(atom/target, range, speed, thrower)
+/atom/movable/proc/throw_at(atom/target, range, speed, thrower, no_spin)
 	if(!target || !src || (flags & NODROP))
 		return 0
 	//use a modified version of Bresenham's algorithm to get from the atom's current position to that of the target
@@ -119,7 +119,7 @@
 	src.thrower = thrower
 	src.throw_source = get_turf(src)	//store the origin turf
 	if(target.allow_spin) // turns out 1000+ spinning objects being thrown at the singularity creates lag - Iamgoofball
-		if(!no_spin_thrown)
+		if(!no_spin_thrown && !no_spin)
 			SpinAnimation(5, 1)
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)
@@ -140,9 +140,6 @@
 	var/area/a = get_area(src.loc)
 	if(dist_x > dist_y)
 		var/error = dist_x/2 - dist_y
-
-
-
 		while(src && target &&((((src.x < target.x && dx == EAST) || (src.x > target.x && dx == WEST)) && dist_travelled < range) || (a && a.has_gravity == 0)  || istype(src.loc, /turf/space)) && src.throwing && istype(src.loc, /turf))
 			// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 			if(error < 0)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -103,7 +103,7 @@
 							dist += D.explosion_block
 
 			var/flame_dist = 0
-			var/throw_dist = dist
+			var/throw_dist = max_range - dist
 
 			if(dist < flame_range)
 				flame_dist = 1
@@ -126,14 +126,16 @@
 
 			//--- THROW ITEMS AROUND ---
 
-			var/throw_dir = get_dir(epicenter,T)
-			for(var/obj/item/I in T)
-				spawn(0) //Simultaneously not one at a time
-					if(I && !I.anchored)
-						var/throw_range = rand(throw_dist, max_range)
-						var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-						I.throw_speed = 4 //Temporarily change their throw_speed for embedding purposes (Reset when it finishes throwing, regardless of hitting anything)
-						I.throw_at(throw_at, throw_range, 2)//Throw it at 2 speed, this is purely visual anyway.
+			if(throw_dist > 0)
+				var/throw_dir = get_dir(epicenter,T)
+				for(var/obj/item/I in T)
+					spawn(0) //Simultaneously not one at a time
+						if(I && !I.anchored)
+							var/throw_mult = 0.5 + (0.5 * rand()) // Between 0.5 and 1.0
+							var/throw_range = round((throw_dist + 1) * throw_mult) // Roughly 50% to 100% of throw_dist
+							if(throw_range > 0)
+								var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
+								I.throw_at(throw_at, throw_range, 2, no_spin = 1)//Throw it at 2 speed, this is purely visual anyway.
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare


### PR DESCRIPTION
As Fox pointed out in #1486, a lot of the time spent processing an explosion is actually spent throwing stuff around. I decided to take a look at what the code was doing, do some profiling, and see if things could be improved without simply disabling the throwing. Here's what I found:
* Making hundreds of things spin is surprisingly expensive.
* The further something is away from the epicenter of an explosion, the further it is likely to be thrown.
  * Things at the very epicenter may not be thrown at all; things at the very edge are guaranteed to be thrown the distance they are from the epicenter.
* Explosions will throw things that are technically unaffected by the explosion (and throw them as far as possible).
  * Reactionary explosions actually make this _worse,_ due to the throw distance calculation being entirely wrong. The increased bombcap exacerbated the problem even further.

So, I made some changes:
* Things thrown by explosions no longer spin.
* The closer something is to the epicenter, and the bigger the explosion, the further it will be thrown.
  * Something beyond the very edge of an explosion's range won't be thrown.
  * Things near the very edge of an explosion will get thrown very little, if at all.
  * The exact distance is how far something is, inward, from the edge of the explosion, randomized between 50% and 100% of that distance.
* Explosions will no longer permanently change the speed something will travel when you throw it by hand.
  * I can only assume this worked correctly and did something useful at some point in the past. It no longer does, so it has been removed.

As mentioned, I did some profiling. I dropped bombcap explosions (currently 5/10/20) on a few spots across the map, rebooting after each, and measured the results:

**Before**
* Bridge: Explosion took 5.4 seconds. Spent 46.4 seconds (1.15 in-game seconds) throwing 427 objects a combined total of 2456 tiles. Furthest distance was 19.
* Engineering: Explosion took 7.3 seconds. Spent 63.2 seconds (1.15 in-game seconds) throwing 467 objects a combined total of 2488 tiles. Furthest distance was 19.
* Medbay: Explosion took 6.1 seconds. Spent 78.3 seconds (1.3 in-game seconds) throwing 437 objects a combined total of 2513 tiles. Furthest distance was 17.

**After**
* Bridge: Explosion took 4.4 seconds. Spent 12.4 seconds (0.95 in-game seconds) throwing 305 objects a combined total of 1500 tiles. Furthest distance was 14.
* Engineering: Explosion took 7.1 seconds. Spent 15.1 seconds (0.7 in-game seconds) throwing 378 objects a combined total of 1796 tiles. Furthest distance was 12.
* Medbay: Explosion took 5.4 seconds. Spent 22.5 seconds (1.05 in-game seconds) throwing 353 objects a combined total of 2062 tiles. Furthest distance was 14.

Major improvements, even though I totally forgot to enable reactionary explosions, which actually make the difference even larger (17.7s in the Medbay). And these are specifically for bombs at the bomb cap, which should be fairly uncommon. This should make explosions tolerable, without significantly altering their functionality.