### PR TITLE
Explosion Sound and Performance Tweaks

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -73,10 +73,12 @@
 							far_volume += (dist <= far_dist * 0.5 ? 50 : 0) // add 50 volume if the mob is pretty close to the explosion
 							M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
 
-
-		//Pause the lighting updates for a bit
-		var/datum/controller/process/lighting = processScheduler.getProcess("lighting")
-		lighting.disable()
+			var/close = range(world.view+round(devastation_range,1), epicenter)
+			// to all distanced mobs play a different sound
+			for(var/mob/M in world) if(M.z == epicenter.z) if(!(M in close))
+				// check if the mob can hear
+				if(M.ear_deaf <= 0 || !M.ear_deaf) if(!istype(M.loc,/turf/space))
+					M << 'sound/effects/explosionfar.ogg'
 
 		if(heavy_impact_range > 1)
 			var/datum/effect/system/explosion/E = new/datum/effect/system/explosion()
@@ -135,7 +137,7 @@
 							var/throw_range = round((throw_dist + 1) * throw_mult) // Roughly 50% to 100% of throw_dist
 							if(throw_range > 0)
 								var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
-								I.throw_at(throw_at, throw_range, 2, no_spin = 1)//Throw it at 2 speed, this is purely visual anyway.
+								I.throw_at(throw_at, throw_range, 2, no_spin = 1) //Throw it at 2 speed, this is purely visual anyway; don't spin the thrown items, it's very costly.
 
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
@@ -146,10 +148,6 @@
 			var/obj/machinery/doppler_array/Array = doppler_arrays[i]
 			if(Array)
 				Array.sense_explosion(x0,y0,z0,devastation_range,heavy_impact_range,light_impact_range,took,orig_dev_range,orig_heavy_range,orig_light_range)
-
-		sleep(8)
-
-		lighting.enable()
 
 	return 1
 


### PR DESCRIPTION
Explosion tweaks

- Re-enables global explosion sound (this uh...kinda got wiped in the explosion rework...oops).

- Axes the light disabling and re-enabling; this doesn't appear to do anything and actually seems to make explosions take a hair bit longer.

- Updates a comment in the code so people know what the whole no_spin thing is for.