### PR TITLE
Auto-Toggling OOC

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -100,6 +100,9 @@
 	var/revival_cloning = 1
 	var/revival_brain_life = -1
 
+
+	var/ooc_during_round = 0
+
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
 	var/run_speed = 0
@@ -534,6 +537,8 @@
 					config.revival_cloning = value
 				if("revival_brain_life")
 					config.revival_brain_life = value
+				if("ooc_during_round")
+					config.ooc_during_round			= 1
 				if("run_speed")
 					config.run_speed = value
 				if("walk_speed")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -101,7 +101,7 @@
 	var/revival_brain_life = -1
 
 
-	var/ooc_during_round = 0
+	var/auto_toggle_ooc_during_round = 0
 
 	//Used for modifying movement speed for mobs.
 	//Unversal modifiers
@@ -537,8 +537,8 @@
 					config.revival_cloning = value
 				if("revival_brain_life")
 					config.revival_brain_life = value
-				if("ooc_during_round")
-					config.ooc_during_round			= 1
+				if("auto_toggle_ooc_during_round")
+					config.auto_toggle_ooc_during_round	= 1
 				if("run_speed")
 					config.run_speed = value
 				if("walk_speed")

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -219,6 +219,7 @@ var/global/datum/controller/gameticker/ticker
 			admins_number++
 	if(admins_number == 0)
 		send2adminirc("Round has started with no admins online.")
+	auto_toggle_ooc(0) // Turn it off
 
 	/* DONE THROUGH PROCESS SCHEDULER
 	supply_controller.process() 		//Start the supply shuttle regenerating points -- TLE
@@ -250,6 +251,7 @@ var/global/datum/controller/gameticker/ticker
 	proc/station_explosion_cinematic(var/station_missed=0, var/override = null)
 		if( cinematic )	return	//already a cinematic in progress!
 
+		auto_toggle_ooc(1) // Turn it on
 		//initialise our cinematic screen object
 		cinematic = new(src)
 		cinematic.icon = 'icons/effects/station_explosion.dmi'
@@ -400,7 +402,7 @@ var/global/datum/controller/gameticker/ticker
 
 		if(!mode.explosion_in_progress && game_finished && (mode_finished || post_game))
 			current_state = GAME_STATE_FINISHED
-
+			auto_toggle_ooc(1) // Turn it on
 			spawn
 				declare_completion()
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -75,6 +75,17 @@ var/global/normal_ooc_colour = "#002eb8"
 				C << "<font color='[normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[src.key]:</EM> <span class='message'>[msg]</span></span></font>"
 			*/
 
+/proc/toggle_ooc()
+	ooc_allowed = !( ooc_allowed )
+	if (ooc_allowed)
+		world << "<B>The OOC channel has been globally enabled!</B>"
+	else
+		world << "<B>The OOC channel has been globally disabled!</B>"
+
+/proc/auto_toggle_ooc(var/on)
+	if(!config.ooc_during_round && ooc_allowed != on)
+		toggle_ooc()
+
 /client/proc/set_ooc(newColor as color)
 	set name = "Set Player OOC Colour"
 	set desc = "Set to yellow for eye burning goodness."

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -83,7 +83,7 @@ var/global/normal_ooc_colour = "#002eb8"
 		world << "<B>The OOC channel has been globally disabled!</B>"
 
 /proc/auto_toggle_ooc(var/on)
-	if(!config.ooc_during_round && ooc_allowed != on)
+	if(config.auto_toggle_ooc_during_round && ooc_allowed != on)
 		toggle_ooc()
 
 /client/proc/set_ooc(newColor as color)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -629,11 +629,7 @@ var/global/nologevent = 0
 	set category = "Server"
 	set desc="Globally Toggles OOC"
 	set name="Toggle OOC"
-	ooc_allowed = !( ooc_allowed )
-	if (ooc_allowed)
-		world << "<B>The OOC channel has been globally enabled!</B>"
-	else
-		world << "<B>The OOC channel has been globally disabled!</B>"
+	toggle_ooc()
 	log_admin("[key_name(usr)] toggled OOC.")
 	message_admins("[key_name_admin(usr)] toggled OOC.", 1)
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -33,6 +33,9 @@ REVIVAL_CLONING 1
 REVIVAL_BRAIN_LIFE -1
 
 
+### OOC DURING ROUND ###
+#Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
+OOC_DURING_ROUND
 
 ### MOB MOVEMENT ###
 

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -33,9 +33,9 @@ REVIVAL_CLONING 1
 REVIVAL_BRAIN_LIFE -1
 
 
-### OOC DURING ROUND ###
-#Comment this out if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
-OOC_DURING_ROUND
+### AUTO TOGGLE OOC DURING ROUND ###
+#Uncomment this if you want OOC to be automatically disabled during the round, it will be enabled during the lobby and after the round end results.
+#AUTO_TOGGLE_OOC_DURING_ROUND
 
 ### MOB MOVEMENT ###
 


### PR DESCRIPTION
Adds in auto-toggling of OOC: https://github.com/tgstation/-tg-station/pull/3333

Simply put, if this config option is enabled then OOC will *automatically* be shut off at round start and re-enabled when the round ends--this gives players a time to speak in OOC during pre-round setup and during the last 60 seconds of the game.

THIS WILL REQUIRE GAME_OPTIONS.TXT TO BE UPDATED! 

This feature is pretty much up to the headmins to decide if they want OOC to be auto-toggled or not. The feature is here if we or our downstreams utilize it. @melandor0's server comes to mind for a downstream that would make excellent use of this without having to resort to permanent disabling of OOC.