### PR TITLE
Re-adds Security Helmets to Officer's Lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -188,6 +188,7 @@
 		new /obj/item/weapon/storage/belt/security/sec(src)
 		new /obj/item/clothing/mask/gas/sechailer(src)
 		new /obj/item/clothing/glasses/sunglasses/sechud(src)
+		new /obj/item/clothing/head/helmet(src)
 		new /obj/item/weapon/melee/baton/loaded(src)
 		new /obj/item/taperoll/police(src)
 		return


### PR DESCRIPTION
Re-adds helmets to security officer's lockers.

Simply put, lockers should start off with helmets; new recruits shouldn't have to go without their armor, nor should they be dependent on the Warden/HoS for basic protection. Likewise, helmets not being available in lockers HEAVILY discourages the roboticists from building more securitrons or constructing an ED-209, as it requires a full cargo order to get more.

