### PR TITLE
Makes log viewing use ftp() instead of run()

### DIFF
--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -52,7 +52,7 @@
 		return
 
 	message_admins("[key_name_admin(src)] accessed file: [path]")
-	src << run( file(path) )
+	src << ftp( file(path) )
 	src << "Attempting to send file, this may take a fair few minutes if the file is very large."
 	return
 
@@ -72,7 +72,7 @@
 		return
 
 	message_admins("[key_name_admin(src)] accessed file: [path]")
-	src << run( file(path) )
+	src << ftp( file(path) )
 	src << "Attempting to send file, this may take a fair few minutes if the file is very large."
 	return
 
@@ -87,7 +87,7 @@
 
 	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")].log"
 	if( fexists(path) )
-		src << run( file(path) )
+		src << ftp( file(path) )
 	else
 		src << "<font color='red'>Error: view_txt_log(): File not found/Invalid path([path]).</font>"
 		return
@@ -102,7 +102,7 @@
 
 	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM-Month/DD-Day")] Attack.log"
 	if( fexists(path) )
-		src << run( file(path) )
+		src << ftp( file(path) )
 	else
 		src << "<font color='red'>Error: view_atk_log(): File not found/Invalid path([path]).</font>"
 		return


### PR DESCRIPTION
Carbon copy of tgstation/-tg-station#10467.
This should fix not being able to retrieve logs, because BYOND 508 broke run() again. The main difference is that instead of directly opening a log, a prompt will come up asking to save the file to a location.