### PR TITLE
Changeling Sting Nerfs/changes/tweaks

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -9,7 +9,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	config_tag = "changeling"
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Brig Physician", "Internal Affairs Agent")
-	protected_species = list("Machine", "Slime People")
+	protected_species = list("Machine", "Slime People", "Plasmaman")
 	required_players = 2
 	required_players_secret = 10
 	required_enemies = 1
@@ -302,6 +302,10 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 	if(T.species.flags & NO_SCAN)
 		user << "<span class='warning'>We do not know how to parse this creature's DNA!</span>"
+		return
+
+	if(T.species.flags & NO_BLOOD)
+		user << "<span class='warning'>We are not able to use the DNA of a creature without a circulatory system.</span>"
 		return
 
 	if(has_dna(target.dna))


### PR DESCRIPTION
- Prevents transform sting from working on species with NO_BLOOD.
- Prevents DNA extraction sting from working on species with NO_BLOOD.
- Prevents Plasma Men from being changelings, largely for the same reason Slime People can't be changelings, horribly mutilating people with transform sting. (Alternative way to do this would be for a species check in the DNA sting's Click() proc, which is horrendous because DNA does not contain a species datum, just a string with the species' name.)
- Ported some nerfs from tgstation/-tg-station#10482, transform stinging somebody is no longer silent. It won't point you out specifically, but it will create a visible message for everyone in view range, and will make the person jittery. Also forces a cooldown on the use of all changeling powers. Does not port the damage on sting nor the increase in cost to unlock DNA sting.
- Re-enables cryo sting. This should now be working since mob temperatures were fixed a while ago.

Yes, this fixes the problem with Changelings DNA stinging people with Plasmaman DNA.