### PR TITLE
More Explosion Optimizaitons

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -45,6 +45,11 @@
 
 	return heard
 
+//We used to use linear regression to approximate the answer, but Mloc realized this was actually faster.
+//And lo and behold, it is, and it's more accurate to boot.
+/proc/cheap_hypotenuse(Ax,Ay,Bx,By)
+	return sqrt(abs(Ax - Bx)**2 + abs(Ay - By)**2) //A squared + B squared = C squared
+
 /proc/circlerange(center=usr,radius=3)
 
 	var/turf/centerturf = get_turf(center)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -1,11 +1,5 @@
 //TODO: Flash range does nothing currently
 
-//A very crude linear approximatiaon of pythagoras theorem.
-/proc/cheap_pythag(var/dx, var/dy)
-	dx = abs(dx); dy = abs(dy);
-	if(dx>=dy)	return dx + (0.5*dy)	//The longest side add half the shortest side approximates the hypotenuse
-	else		return dy + (0.5*dx)
-
 /proc/trange(var/Dist=0,var/turf/Center=null)//alternative to range (ONLY processes turfs and thus less intensive)
 	if(Center==null) return
 
@@ -91,7 +85,7 @@
 
 		for(var/turf/T in trange(max_range, epicenter))
 
-			var/dist = cheap_pythag(T.x - x0,T.y - y0)
+			var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
 
 			if(config.reactionary_explosions)
 				var/turf/Trajectory = T
@@ -105,7 +99,7 @@
 							dist += D.explosion_block
 
 			var/flame_dist = 0
-			var/throw_dist = max_range - dist
+//			var/throw_dist = max_range - dist
 
 			if(dist < flame_range)
 				flame_dist = 1
@@ -127,7 +121,7 @@
 					T.ex_act(dist)
 
 			//--- THROW ITEMS AROUND ---
-
+/*
 			if(throw_dist > 0)
 				var/throw_dir = get_dir(epicenter,T)
 				for(var/obj/item/I in T)
@@ -138,7 +132,7 @@
 							if(throw_range > 0)
 								var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
 								I.throw_at(throw_at, throw_range, 2, no_spin = 1) //Throw it at 2 speed, this is purely visual anyway; don't spin the thrown items, it's very costly.
-
+*/
 		var/took = (world.timeofday-start)/10
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
 		if(Debug2)	world.log << "## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds."
@@ -197,7 +191,7 @@
 	var/list/wipe_colours = list()
 	for(var/turf/T in trange(max_range, epicenter))
 		wipe_colours += T
-		var/dist = cheap_pythag(T.x - x0, T.y - y0)
+		var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
 
 		if(newmode == "Yes")
 			var/turf/TT = T


### PR DESCRIPTION
- Re-adds the the original calculation for explosion range added in the lighting update (as a proc instead of a formula only utilized by explosions; can probably be utilized in lighting, somewhere).
 - Depending on the number of calls, this outperforms cheap_pythag.

- Comments out explosions throwing around items.
 - Recent optimizations dramatically improved this, but it's still pretty bad when a decent explosion goes off in a populated area or area rich in players/items. It still incurs wayyy too much lag. It's a nice visual effect, but it just isn't worth it for the intense amount of lag it generates.