### PR TITLE
Double Solar Output

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -1,5 +1,5 @@
 #define SOLAR_MAX_DIST 40
-#define SOLARGENRATE 1500
+#define SOLARGENRATE 3000
 
 var/list/solars_list = list()
 


### PR DESCRIPTION
This PR is straightforward: Solars will produce twice as much power - a maximum of 180kW per array, for 720kW if all four are wired and powered (hypothetically, in practice it does fluctuate).

What this means:
-Three solar arrays can power the station completely. Currently, even all four can't run it forever - the APC's starve, albeit slowly.
-Four active solar arrays can power the station + produce enough excess to start up and maintain singularity containment. Ergo, an engineering borg dragging a cable coil around can power the station all by itself, as can maintenance drones, in a reasonable amount of time, no hands required.

I did a bit of local testing with the changes made. One solar array, with the Engineering SMES entirely off and the array wired directly into the grid, will buy about 15 or 20 minutes before the APC's start dying off. Wiring in a second buys you another half hour to an hour, depending on what's being done. Three solars wired will power the whole station, and a fourth solar wired gives you some extra juice to charge SMES with or fire up the singularity.

TL;DR: Solars are an actual valid power source with a reasonable setup time now, as they should have been forever ago. Praise the Sun.