### PR TITLE
Heavily Optimizes Lighting

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -85,7 +85,8 @@
 		if(item && item != src) // It's possible that the item is deleted in temperature_expose
 			item.fire_act(null, temperature, volume)
 
-	animate(src, color = heat2color(temperature), 5)
+//	animate(src, color = heat2color(temperature), 5)
+	color = heat2color(temperature)
 	set_light(l_color = color)
 
 	return 0

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -1,9 +1,9 @@
 #define LIGHTING_INTERVAL 5 // frequency, in 1/10ths of a second, of the lighting process
 
 #define LIGHTING_FALLOFF 1 // type of falloff to use for lighting; 1 for circular, 2 for square
-#define LIGHTING_LAMBERTIAN 1 // use lambertian shading for light sources
+#define LIGHTING_LAMBERTIAN 0 // use lambertian shading for light sources
 #define LIGHTING_HEIGHT 1 // height off the ground of light sources on the pseudo-z-axis, you should probably leave this alone
-#define LIGHTING_TRANSITIONS 1 // smooth, animated transitions, similar to /tg/station
+#define LIGHTING_TRANSITIONS 0 // smooth, animated transitions, similar to /tg/station
 
 #define LIGHTING_LAYER 10 // drawing layer for lighting overlays
 #define LIGHTING_ICON 'icons/effects/lighting_overlay.dmi' // icon used for lighting shading effects


### PR DESCRIPTION
So, it's no secret that lighting has and does continue to cause issues. In any event, after some discussion and information hunting with @PJB3005 and some testing, well...one of the big culprits of a performance hit has been found and corrected. This should hopefully help out performance without fully gutting the current lighting system and reverting back to our old lighting system, DAL.

What does this PR Do?

- Disables Lambertian Lighting (VG did this)
- Disables Lighting Transitions (VG did this and Bay completely killed off transitions)
- Disables Hotspot transitions 

Um What? I'm not a coder, talk sense you moron!
 - Sorry, ok, here goes...


Lambertian Lighting

-  This is an alternate way to calculate how lighting falls off; it incurs a performance hit by utilize it though. Disabling this will have impacts though, namely the station will be much, *much* brighter; kinda like how you were used to things with old lighting system. See images below


Lighting Transitions 

- Remember how lights used to be when you had your PDA on and moved? That is, they didn't trail behind you much? This is like that. Lighting transitions use a proc called animate() to make a "smooth" transition from one tile to another or one stage to another.

- There's just one problem. Animate()....to my understanding, despite setting variables directly and instantly, renders, *SERVER SIDE* each frame then pushes them out to all clients in the world...which..doesn't incur much of a cost if you have something that only occurs every now and again...but when you have something that uses this proc hundreds of thousands of times, well ,it can be problematic (this is probably also one reason why our lag problems seem to scale with population...more moving lights more often).

- Lighting transitions have been responsible, in the past (and still are depending on your BYOND version), for causing client crashes; this could potentially help alleviate that, as well.

Hotspot Transitions 

- Hotspots also call animate() to smoothly transition their color from one color to the next, just like lights. Disabling this will still allow hotspots to be different colors and emit different color lights, but it them existing shouldn't create as much of a performance impact. When you have hundreds of these little guys being created during a plasma fire and them adjusting their color with animate? well..you get the idea. 


Performance Stats 

- Here's some stats on performance with these changes. Columns on the left are on live server nad the column on the right are with the changes implemented here (click to enlarge):
![eww](http://i.gyazo.com/09611235e78492f32144a922d3d0cd6f.png)

- With the exception of remove_lum() the cost of everything, per call has gone done....of note in particular is the insanely massive drop of update_overlays (guess what uses animate?). Lambertian mostly impacts apply_lum, falloff(), and, and the overall processing of lighting.


Personal Testing

- I set a good portion of the station on fire with plasma and it didn't really incur that much of a performance hit--where as before, it would lug the game down to a crawl.


Pictures
- Ohhh pretty.


Lambertian Lighting:
![ugh](http://i.gyazo.com/4f46c0adf6f1937265173b6e42ac524f.png)

Non-Lambertian Lighting (disabled)
![ugh2](http://i.gyazo.com/f163d7857c07ac5346498c3361cebfc2.png)




