### PR TITLE
Middle Click Override

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -193,12 +193,19 @@
 	A.point()
 	return
 
+// See click_override.dm
+/mob/living/MiddleClickOn(var/atom/A)
+ if(src.middleClickOverride)
+ 	middleClickOverride.onClick(A, src)
+ else
+ 	..()
+
 /mob/living/carbon/MiddleClickOn(var/atom/A)
 	if(!src.stat && src.mind && src.mind.changeling && src.mind.changeling.chosen_sting && (istype(A, /mob/living/carbon)) && (A != src))
 		next_click = world.time + 5
 		mind.changeling.chosen_sting.try_to_sting(src, A)
 	else
-		A.point()
+		..()
 
 // In case of use break glass
 /*
@@ -241,6 +248,13 @@
 /mob/proc/AltClickOn(var/atom/A)
 	A.AltClick(src)
 	return
+
+// See click_override.dm
+/mob/living/AltClickOn(var/atom/A)
+ if(src.middleClickOverride)
+ 	middleClickOverride.onClick(A, src)
+ else
+ 	..()
 
 /mob/living/carbon/AltClickOn(var/atom/A)
 	if(!src.stat && src.mind && src.mind.changeling && src.mind.changeling.chosen_sting && (istype(A, /mob/living/carbon)) && (A != src))

--- a/code/_onclick/click_override.dm
+++ b/code/_onclick/click_override.dm
@@ -1,0 +1,43 @@
+/*
+ Click Overrides
+
+ These are overrides for a living mob's middle and alt clicks.
+ If the mob in question has their middleClickOverride var set to one of these datums, when they middle or alt click the onClick proc for the datum their clickOverride var is
+ set equal to will be called.
+ See click.dm 251 and 196.
+
+ If you have any questions, contact me on the Paradise forums.
+ - DaveTheHeacrab
+ */
+
+/datum/middleClickOverride/
+
+/datum/middleClickOverride/proc/onClick(var/atom/A, var/mob/living/user)
+	user.middleClickOverride = null
+	return 1
+	/* Note, when making a new click override it is ABSOLUTELY VITAL that you set the source's clickOverride to null at some point if you don't want them to be stuck with it forever.
+	Calling the super will do this for you automatically, but if you want a click override to NOT clear itself after the first click, you must do it at some other point in the code*/
+
+/obj/item/weapon/badminBook/
+	name = "old book"
+	desc = "An old, leather bound tome."
+	icon = 'icons/obj/library.dmi'
+	icon_state = "book"
+	var/datum/middleClickOverride/clickBehavior = new /datum/middleClickOverride/badminClicker
+
+/obj/item/weapon/badminBook/attack_self(mob/living/user as mob)
+	if(user.middleClickOverride)
+		user<< "<span class='warning'>You try to draw power from the [src], but you cannot hold the power at this time!</span>"
+		return
+	user.middleClickOverride = clickBehavior
+	user << "<span class='notice'>You draw a bit of power from the [src], you can use <b>middle click</b> or <b>alt click</b> to release the power!</span>"
+
+/datum/middleClickOverride/badminClicker
+	var/summon_path = /obj/item/weapon/reagent_containers/food/snacks/cookie
+
+/datum/middleClickOverride/badminClicker/onClick(var/atom/A, var/mob/living/user)
+	var/atom/movable/newObject = new summon_path
+	newObject.loc = get_turf(A)
+	user << "<span class='notice'>You release the power you had stored up, summoning \a [newObject.name]! </span>"
+	usr.loc.visible_message("<span class='notice'>[user] waves \his hand and summons \a [newObject.name]</span>")
+	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,5 +1,6 @@
 mob/living
 	var/canEnterVentWith = "/obj/item/weapon/implant=0&/obj/item/clothing/mask/facehugger=0&/obj/item/device/radio/borg=0&/obj/machinery/camera=0"
+	var/datum/middleClickOverride/middleClickOverride = null
 
 /mob/living/carbon/Login()
 	..()

--- a/paradise.dme
+++ b/paradise.dme
@@ -72,6 +72,7 @@
 #include "code\_onclick\adjacent.dm"
 #include "code\_onclick\ai.dm"
 #include "code\_onclick\click.dm"
+#include "code\_onclick\click_override.dm"
 #include "code\_onclick\cyborg.dm"
 #include "code\_onclick\drag_drop.dm"
 #include "code\_onclick\item_attack.dm"


### PR DESCRIPTION
 - Adds a functionality for overriding middle click and alt click behavior on mobs.
 - To override this, simply change the mob's middleClickOverride variable to a child of /datum/middleClickOverride. Their middle and alt click behavior will now follow the onClick() proc of the datum in their middleClickOverride var. 
- It is important to note, you must *always* call super or otherwise reset the person's middleClickOverride var or they will be stuck with it forever. This should be self explanatory, but you never know.

- Adds the badmin book, a proof of concept. When clicked on in the active hand, the user will absorb a small portion of the book's power, gaining the ability to summon whatever it specified in the override datum stored in the book (A cookie by default) with a middle click. The power absorbed will go away after the first click, returning the user's click functionality to default.