### PR TITLE
Fixes Unlimited Bullets

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -197,7 +197,7 @@
 		return 0
 	if(targloc == curloc)			//Fire the projectile
 		user.bullet_act(in_chamber)
-		qdel(in_chamber)
+		del(in_chamber)
 		update_icon()
 		return 1
 
@@ -285,7 +285,7 @@
 			else
 				user << "<span class = 'notice'>Ow...</span>"
 				user.apply_effect(110,AGONY,0)
-			qdel(in_chamber)
+			del(in_chamber)
 			mouthshoot = 0
 			return
 		else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -80,7 +80,7 @@
 
 	proc/on_range() //if we want there to be effects when they reach the end of their range
 		proj_hit = 1
-		qdel(src)
+		del(src)
 
 	proc/on_hit(var/atom/target, var/blocked = 0, var/hit_zone)
 		if(!isliving(target))	return 0
@@ -97,7 +97,7 @@
 		in_chamber.pass_flags = pass_flags //And the pass flags to that of the real projectile...
 		in_chamber.firer = user
 		var/output = in_chamber.process() //Test it!
-		qdel(in_chamber) //No need for it anymore
+		del(in_chamber) //No need for it anymore
 		return output //Send it back to the gun!
 
 	Bump(atom/A as mob|obj|turf|area)
@@ -168,7 +168,7 @@
 			if(!istype(src, /obj/item/projectile/beam/lightning))
 				density = 0
 				invisibility = 101
-			qdel(src)
+			del(src)
 		return 1
 
 
@@ -187,7 +187,7 @@
 			spawn() //New projectile system
 				while(loc)
 					if(kill_count < 1)
-						qdel(src)
+						del(src)
 						return
 					kill_count--
 					if((!( current ) || loc == current))
@@ -262,7 +262,7 @@
 			spawn() //Old projectile system
 				while(loc)
 					if(kill_count < 1)
-						qdel(src)
+						del(src)
 						return
 					kill_count--
 					if((!( current ) || loc == current))


### PR DESCRIPTION
SImply put, a LOT of projectiles don't GC well, at all. Some do, some don't--it's hugely inconsistent.

End result? When they don't, some projectiles weapons will effectively allow you to fire unlimited shots for 30 seconds.

I'm not sure of the exact proper way to de-reference most projectiles, at the moment, hence why I'm submitting this now, considering how gamebreaking this is.