### PR TITLE
Computer Fixes

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -2055,7 +2055,7 @@
 "aNA" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor{dir = 4; icon_state = "arrival"},/area/hallway/secondary/entry)
 "aNB" = (/obj/machinery/camera{c_tag = "Security Checkpoint"; dir = 1},/obj/machinery/alarm{dir = 4; icon_state = "alarm0"; pixel_x = -22},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor{icon_state = "red"; dir = 10},/area/security/checkpoint2)
 "aNC" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor{icon_state = "red"},/area/security/checkpoint2)
-"aND" = (/obj/structure/table/reinforced,/obj/machinery/computer/skills{icon_state = "medlaptop"},/turf/simulated/floor{icon_state = "red"},/area/security/checkpoint2)
+"aND" = (/obj/structure/table/reinforced,/obj/machinery/computer/skills,/turf/simulated/floor{icon_state = "red"},/area/security/checkpoint2)
 "aNE" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin{pixel_x = 1; pixel_y = 9},/obj/item/weapon/pen,/turf/simulated/floor{icon_state = "red"},/area/security/checkpoint2)
 "aNF" = (/obj/machinery/recharger{pixel_y = 4},/obj/structure/table/reinforced,/turf/simulated/floor{icon_state = "red"},/area/security/checkpoint2)
 "aNG" = (/obj/item/device/radio/intercom{name = "Station Intercom (General)"; pixel_y = -29},/obj/item/device/radio,/turf/simulated/floor{icon_state = "red"; dir = 6},/area/security/checkpoint2)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -73,7 +73,8 @@
 	var/overlay_layer = LIGHTING_LAYER+0.1
 
 	if(stat & NOPOWER)
-		overlays += image(icon,"[icon_keyboard]_off",overlay_layer)
+		if(icon_keyboard)
+			overlays += image(icon,"[icon_keyboard]_off",overlay_layer)
 		return
 	overlays += image(icon, icon_keyboard ,overlay_layer)
 	if(stat & BROKEN)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -21,6 +21,7 @@
 
 /obj/machinery/computer/teleporter/initialize()
 	link_power_station()
+	update_icon()
 
 /obj/machinery/computer/teleporter/Destroy()
 	if (power_station)


### PR DESCRIPTION
 - Fixes #1527. This also applied to arcade machines.
 - Fixes the laptop in arrivals not having a frame.
 - Fixes teleporters not updating icons upon init.