### PR TITLE
Minor Uplink Cost Adjustments

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -586,7 +586,7 @@ var/list/uplink_items = list()
 	name = "Syndicate Encryption Key"
 	desc = "A key, that when inserted into a radio headset, allows you to listen to all station department channels as well as talk on an encrypted Syndicate channel."
 	item = /obj/item/device/encryptionkey/syndicate
-	cost = 5
+	cost = 2 //Nowhere near as useful as the Binary Key!
 	surplus = 75
 
 /datum/uplink_item/device_tools/hacked_module
@@ -679,7 +679,7 @@ var/list/uplink_items = list()
 	name = "Uplink Implant"
 	desc = "An implant injected into the body, and later activated using a bodily gesture to open an uplink with 5 telecrystals. The ability for an agent to open an uplink after their posessions have been stripped from them makes this implant excellent for escaping confinement."
 	item = /obj/item/weapon/implanter/uplink
-	cost = 20
+	cost = 14
 	surplus = 0
 
 /datum/uplink_item/implants/explosive


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/pull/10478

Just a minor tweak to a couple of highly unused uplink items.

- Cypher Key (one that allows you to listen in on all channels and talk on the Syndichannel) is now 2 TC instead of 5
- Uplink Implant is now 14 TC instead of 20.