### PR TITLE
Reduces Blob's Lag

### DIFF
--- a/code/game/gamemodes/blob/blobs/factory.dm
+++ b/code/game/gamemodes/blob/blobs/factory.dm
@@ -20,18 +20,12 @@
 	spores = null
 	return ..()
 
-/obj/effect/blob/factory/PulseAnimation(var/activate = 0)
-	if(activate)
-		..()
-	return
-
 /obj/effect/blob/factory/run_action()
 	if(spores.len >= max_spores)
 		return 0
 	if(spore_delay > world.time)
 		return 0
 	spore_delay = world.time + 100 // 10 seconds
-	PulseAnimation(1)
 	var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore(src.loc, src)
 	BS.color = color
 	BS.overmind = overmind

--- a/code/game/gamemodes/blob/blobs/resource.dm
+++ b/code/game/gamemodes/blob/blobs/resource.dm
@@ -11,17 +11,10 @@
 	if(health <= 0)
 		qdel(src)
 
-/obj/effect/blob/resource/PulseAnimation(var/activate = 0)
-	if(activate)
-		..()
-	return
-
 /obj/effect/blob/resource/run_action()
 
 	if(resource_delay > world.time)
 		return 0
-
-	PulseAnimation(1)
 
 	resource_delay = world.time + 40 // 4 seconds
 

--- a/code/game/gamemodes/blob/blobs/storage.dm
+++ b/code/game/gamemodes/blob/blobs/storage.dm
@@ -11,11 +11,6 @@
 		overmind.max_blob_points -= 50
 		qdel(src)
 
-/obj/effect/blob/storage/PulseAnimation(var/activate = 0)
-	if(activate)
-		..()
-	return
-
 /obj/effect/blob/storage/proc/update_max_blob_points(var/new_point_increase)
 	if(overmind)
 		overmind.max_blob_points += new_point_increase

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -48,11 +48,6 @@
 /obj/effect/blob/proc/Life()
 	return
 
-/obj/effect/blob/proc/PulseAnimation()
-	if(!istype(src, /obj/effect/blob/core) || !istype(src, /obj/effect/blob/node))
-		flick("[icon_state]_glow", src)
-	return
-
 /obj/effect/blob/proc/RegenHealth()
 	// All blobs heal over time when pulsed, but it has a cool down
 	if(health_timestamp > world.time)
@@ -66,8 +61,6 @@
 /obj/effect/blob/proc/Pulse(var/pulse = 0, var/origin_dir = 0, var/a_color)//Todo: Fix spaceblob expand
 
 	set background = BACKGROUND_ENABLED
-
-	PulseAnimation()
 
 	RegenHealth()
 


### PR DESCRIPTION
Marked as high priority because blob can really lug the server at times.

- Disables blob's visual pulsing animation


I have no idea why it's taking up so much processing power, but it is. 

If I fill the admin testing area with nothing but blob, it lugs the server to an absolute crawl. If I perform the same, exact, test on a local server, everything handles just fine and I don't see PulseAnimation going out of control.

In any event, I can only guess it has something to do with flick() and perhaps the number of clients connected? Still doesn't really make much sense, to be honest. 
