### PR TITLE
I think I just managed to fix all lighting lag.

### DIFF
--- a/code/modules/lighting/light_source.dm
+++ b/code/modules/lighting/light_source.dm
@@ -11,13 +11,16 @@
 	var/lum_g
 	var/lum_b
 
-	var/list/effect_r
-	var/list/effect_g
-	var/list/effect_b
+	var/tmp/old_lum_r
+	var/tmp/old_lum_g
+	var/tmp/old_lum_b
+
+	var/list/effect_str
 	var/list/effect_turf
 
 	var/applied
 
+	var/vis_update		//Whetever we should smartly recalculate visibility. and then only update tiles that became (in) visible to us
 	var/needs_update
 	var/destroyed
 	var/force_update
@@ -38,9 +41,7 @@
 
 	parse_light_color()
 
-	effect_r = list()
-	effect_g = list()
-	effect_b = list()
+	effect_str = list()
 	effect_turf = list()
 
 	update()
@@ -71,6 +72,13 @@
 		needs_update = 1
 		lighting_update_lights += src
 
+/datum/light_source/proc/vis_update()
+	if(!needs_update)
+		needs_update = 1
+		lighting_update_lights += src
+
+	vis_update = 1
+
 /datum/light_source/proc/check()
 	if(!source_atom || !light_range || !light_power)
 		destroy()
@@ -96,12 +104,17 @@
 		light_range = source_atom.light_range
 		. = 1
 
+	if(light_range && light_power && !applied)
+		. = 1
+
+	if(. || source_atom.light_color != light_color)//Save the old lumcounts if we need to update, if the colour changed DO IT BEFORE we parse the colour and LOSE the old lumcounts!
+		old_lum_r = lum_r
+		old_lum_g = lum_g
+		old_lum_b = lum_b
+
 	if(source_atom.light_color != light_color)
 		light_color = source_atom.light_color
 		parse_light_color()
-		. = 1
-
-	if(light_range && light_power && !applied)
 		. = 1
 
 /datum/light_source/proc/parse_light_color()
@@ -139,24 +152,24 @@
 	if(istype(source_turf))
 		for(var/turf/T in dview(light_range, source_turf, INVISIBILITY_LIGHTING))
 			if(T.lighting_overlay)
+
 				var/strength = light_power * falloff(T.lighting_overlay)
+
 				if(!strength) //Don't add turfs that aren't affected to the affected turfs.
 					continue
 
-				effect_r += round(lum_r * strength, LIGHTING_ROUND_VALUE)
-				effect_g += round(lum_g * strength, LIGHTING_ROUND_VALUE)
-				effect_b += round(lum_b * strength, LIGHTING_ROUND_VALUE)
+				strength = round(strength, LIGHTING_ROUND_VALUE)	//Screw sinking points.
+
+				effect_str += strength
 
 				T.lighting_overlay.update_lumcount(
-					round(lum_r * strength, LIGHTING_ROUND_VALUE),
-					round(lum_g * strength, LIGHTING_ROUND_VALUE),
-					round(lum_b * strength, LIGHTING_ROUND_VALUE)
+					lum_r * strength,
+					lum_g * strength,
+					lum_b * strength
 				)
 
 			else
-				effect_r += 0
-				effect_g += 0
-				effect_b += 0
+				effect_str += 0
 
 			if(!T.affecting_lights)
 				T.affecting_lights = list()
@@ -172,11 +185,60 @@
 			T.affecting_lights -= src
 
 		if(T.lighting_overlay)
-			T.lighting_overlay.update_lumcount(-effect_r[i], -effect_g[i], -effect_b[i])
+			var/str = effect_str[i]
+			T.lighting_overlay.update_lumcount(-str * old_lum_r, -str * old_lum_g, -str * old_lum_b)
 
 		i++
 
-	effect_r.Cut()
-	effect_g.Cut()
-	effect_b.Cut()
+	effect_str.Cut()
 	effect_turf.Cut()
+
+//Smartly updates the lighting, only removes lum from and adds lum to turfs that actually got changed.
+//This is for lights that need to reconsider due to nearby opacity changes.
+//Stupid dumb copy pasta because BYOND and speed.
+/datum/light_source/proc/smart_vis_update()
+	var/list/view[0]
+	for(var/turf/T in dview(light_range, source_turf, INVISIBILITY_LIGHTING))
+		view += T	//Filter out turfs.
+
+	//This is the part where we calculate new turfs (if any)
+	var/list/new_turfs = view - effect_turf //This will result with all the tiles that are added.
+	for(var/turf/T in new_turfs)
+		//Big huge copy paste from apply_lum() incoming because screw unreadable defines and screw proc call overhead.
+		if(T.lighting_overlay)
+			. = light_power * falloff(T.lighting_overlay)
+			if(!.) //Don't add turfs that aren't affected to the affected turfs.
+				continue
+
+			. = round(., LIGHTING_ROUND_VALUE)
+
+			effect_str += .
+
+			T.lighting_overlay.update_lumcount(
+				lum_r * .,
+				lum_g * .,
+				lum_b * .
+			)
+
+		else
+			effect_str += 0
+
+		if(!T.affecting_lights)
+			T.affecting_lights = list()
+
+		T.affecting_lights += src
+		effect_turf += T
+
+	var/list/old_turfs = effect_turf - view
+	for(var/turf/T in old_turfs)
+		//Insert not-so-huge copy paste from remove_lum().
+		var/idx = effect_turf.Find(T) //Get the index, luckily Find() is cheap in small lists like this. (with small I mean under a couple thousand len)
+		if(T.affecting_lights)
+			T.affecting_lights -= src
+
+		if(T.lighting_overlay)
+			var/str = effect_str[idx]
+			T.lighting_overlay.update_lumcount(-str * lum_r, -str * lum_g, -str * lum_b)
+
+		effect_turf.Cut(idx, idx + 1)
+		effect_str.Cut(idx, idx + 1)

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -104,9 +104,5 @@
 	var/turf/T = loc
 	if(istype(T))
 		T.lighting_overlay = null
-		for(var/datum/light_source/D in T.affecting_lights) //Remove references to us on the light sources affecting us.
-			D.effect_r -= src
-			D.effect_g -= src
-			D.effect_b -= src
 
 	return ..()

--- a/code/modules/lighting/lighting_process.dm
+++ b/code/modules/lighting/lighting_process.dm
@@ -2,31 +2,37 @@ var/global/datum/controller/process/lighting/lighting_controller
 
 /datum/controller/process/lighting/setup()
 	name = "lighting"
-	schedule_interval = LIGHTING_INTERVAL
 	lighting_controller = src
+	schedule_interval = LIGHTING_INTERVAL
 
 	create_lighting_overlays()
 
 /datum/controller/process/lighting/doWork()
 	var/list/lighting_update_lights_old = lighting_update_lights //We use a different list so any additions to the update lists during a delay from scheck() don't cause things to be cut from the list without being updated.
+	lighting_update_lights = null //Nulling it first because of http://www.byond.com/forum/?post=1854520
 	lighting_update_lights = list()
 
 	for(var/datum/light_source/L in lighting_update_lights_old)
-		if(L.needs_update)
-			if(L.destroyed || L.check() || L.force_update)
-				L.remove_lum()
-				if(!L.destroyed) L.apply_lum()
-				L.force_update = 0
-			L.needs_update = 0
+		if(L.destroyed || L.check() || L.force_update)
+			L.remove_lum()
+			if(!L.destroyed)
+				L.apply_lum()
+
+		else if(L.vis_update)	//We smartly update only tiles that became (in) visible to use.
+			L.smart_vis_update()
+
+		L.vis_update = 0
+		L.force_update = 0
+		L.needs_update = 0
 
 		scheck()
 
 	var/list/lighting_update_overlays_old = lighting_update_overlays //Same as above.
+	lighting_update_overlays = null //Same as above
 	lighting_update_overlays = list()
 
 	for(var/atom/movable/lighting_overlay/O in lighting_update_overlays_old)
-		if(O.needs_update)
-			O.update_overlay()
-			O.needs_update = 0
+		O.update_overlay()
+		O.needs_update = 0
 
 		scheck()

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -4,7 +4,7 @@
 
 /turf/proc/reconsider_lights()
 	for(var/datum/light_source/L in affecting_lights)
-		L.force_update()
+		L.vis_update()
 
 /turf/proc/lighting_clear_overlays()
 	if(lighting_overlay)


### PR DESCRIPTION
It pretty goddamn seemed to testing on /vg/

### Changes:
* Simplifies `effect_r, effect_g, effect_b` into `effect_str`, this is to cut down on list lookups.
* Adds `smart_vis_update()`, which is used to recalculate changes in the case of things like nearby opacity changes, it does it a whole lot faster and only affects things that get affected by the light.
  * This is the goddamn powerhouse of this optimization PR.

Here's a couple profiles to see the effect of this:
 * Profiles taken on /vg/, optimizations are the same.
   * Tick lag of 0.3.
   * Test was a conveyor running through the middle of central primary hallway around the bridge on box. Around the walls of the bridge there were flares every other tiles, there were also opaque bananas on the conveyor, every other time, conveyor running, this was profiled for 5 minutes.

 * [Before](http://pastebin.com/r364dsmj)
   * Averag CPU usage from task manager was ~9%

 * [After](http://pastebin.com/SupnMb8T)
   * Averag CPU usage from task manager was ~5.5%
