### PR TITLE
Fix OneHuman law

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -1,6 +1,7 @@
 /datum/ai_laws
 	var/name = "Unknown Laws"
 	var/zeroth = null
+	var/zeroth_type = null // In order to override zeroth laws
 	var/zeroth_borg = null
 	var/list/inherent = list()
 	var/list/supplied = list()
@@ -152,8 +153,9 @@ datum/ai_laws/tyrant //This probably shouldn't be a default lawset.
 
 /* General ai_law functions */
 
-/datum/ai_laws/proc/set_zeroth_law(var/law, var/law_borg = null)
+/datum/ai_laws/proc/set_zeroth_law(var/law, var/law_borg = null, law_type)
 	src.zeroth = law
+	src.zeroth_type = law_type
 	if(law_borg) //Making it possible for slaved borgs to see a different law 0 than their AI. --NEO
 		src.zeroth_borg = law_borg
 
@@ -182,6 +184,7 @@ datum/ai_laws/tyrant //This probably shouldn't be a default lawset.
 
 /datum/ai_laws/proc/clear_zeroth_law(var/law_borg = null)
 	src.zeroth = null
+	src.zeroth_type = null
 	if(law_borg)
 		src.zeroth_borg = null
 

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -106,18 +106,18 @@ AI MODULES
 
 /obj/item/weapon/aiModule/zeroth/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
 	if(target.laws.zeroth)
-		if(removeownlaw && (laws[1] == target.laws.zeroth))
+		if(removeownlaw && (src.type == target.laws.zeroth_type))
 			target.clear_zeroth_law()
-			return 2
+			return 1
 		else
 			target << "[sender.real_name] attempted to modify your zeroth law."
 			target << "It would be in your best interest to play along with [sender.real_name] that:"
 			for(var/failedlaw in laws)
 				target << "[failedlaw]"
-			return 1
+			return 2
 
 	for(var/templaw in laws)
-		target.set_zeroth_law(templaw)
+		target.set_zeroth_law(templaw, null, src.type)
 
 /obj/item/weapon/aiModule/ion/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
 	for(var/templaw in laws)
@@ -175,10 +175,11 @@ AI MODULES
 	..()
 
 /obj/item/weapon/aiModule/zeroth/oneHuman/transmitInstructions(var/mob/living/silicon/target, var/mob/sender)
-	if(..() == 1)
-		return "[targetName], but the AI's existing zeroth law cannot be overriden."
-	if(..() == 2)
+	var/result = ..()
+	if(result == 1)
 		return "The AI's zeroth law has been overridden."
+	if(result == 2)
+		return "[targetName], but the AI's existing zeroth law cannot be overriden."
 	return targetName
 
 
@@ -204,9 +205,9 @@ AI MODULES
 /obj/item/weapon/aiModule/zeroth/quarantine/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
 	var/result = ..()
 	if(result == 1)
-		return "The AI's existing zeroth law cannot be overriden."
-	if(result == 2)
 		return "The AI's zeroth law has been overridden."
+	if(result == 2)
+		return "The AI's existing zeroth law cannot be overriden."		
 	return laws[1]
 
 /******************** OxygenIsToxicToHumans ********************/

--- a/code/modules/mob/living/silicon/ai/laws.dm
+++ b/code/modules/mob/living/silicon/ai/laws.dm
@@ -20,9 +20,9 @@
 	if (!src.laws)
 		make_laws()
 
-/mob/living/silicon/ai/proc/set_zeroth_law(var/law, var/law_borg)
+/mob/living/silicon/ai/proc/set_zeroth_law(var/law, var/law_borg, var/law_type)
 	src.laws_sanity_check()
-	src.laws.set_zeroth_law(law, law_borg)
+	src.laws.set_zeroth_law(law, law_borg, law_type)
 	
 /mob/living/silicon/ai/proc/clear_zeroth_law(var/law_borg)
 	src.laws_sanity_check()


### PR DESCRIPTION
Changes:
1) Fixes https://github.com/ParadiseSS13/Paradise/issues/654.

Figured I'd fix this, as I caused this myself a few months back. Was caused by the OneHuman's law actually changing due to the target's name being changed, and thus no longer being identical to the original law (which uses "name" as a placeholder).

Notifying https://github.com/ParadiseSS13/Paradise/pull/1548.