### PR TITLE
Added a new admin panel, called the stationbuse panel.

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -100,7 +100,8 @@ var/list/admin_verbs_event = list(
 	/client/proc/response_team, // Response Teams admin verb
 	/client/proc/cmd_admin_create_centcom_report,
 	/client/proc/fax_panel,
-	/client/proc/event_manager_panel
+	/client/proc/event_manager_panel,
+	/client/proc/station_panel
 	)
 
 var/list/admin_verbs_spawn = list(

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2982,6 +2982,74 @@
 				Secrets(usr)
 				return 1
 
+	/*
+
+		STATION-BUSE PANEL
+
+	*/
+
+	if(href_list["stationPanel"])
+
+		var/stpsignoff = "<font color='#5522cc'>(stationPanel)</font>" //shortener, instead of including a signoff in every msg_admins, just uses a var
+
+		switch(href_list["stationPanel"])
+			//DOOR SUBSECTION
+			if("lockdoors")
+				//BOLTING DOORS CODE
+
+				var/check = alert(usr,"Are you sure you want to bolt every door on the station?", "Confirmation", "Yes", "No")
+				if(check == "No")	return
+
+				message_admins("[key_name(usr)] has bolted every door on-station. [stpsignoff]")
+				log_admin("[key_name(usr)] has bolted every door on-station. (stationPanel)")
+
+				for(var/obj/machinery/door/airlock/AL in airlocks)
+					if(AL.z == ZLEVEL_STATION)
+						AL.lock(1)
+
+				//BOLTING DOORS CODE END
+
+
+			if("opendoors")
+				//OPENING ALL DOORS CODE
+
+				var/check = alert(usr,"Are you sure you want to unbolt & open every door on the station, including external airlocks?", "Confirmation: Dangerous", "Yes", "No")
+				if(check == "No")	return
+
+				message_admins("[key_name(usr)] has unbolted, opened, and disabled autoclose for every door on-station, including external airlocks. [stpsignoff]")
+				log_admin("[key_name(usr)] has unbolted, opened, and disabled autoclose for every door on-station, including external airlocks. (stationPanel)")
+
+				for(var/obj/machinery/door/airlock/AL in airlocks)
+					if(AL.z == ZLEVEL_STATION)
+						spawn(-1) //airlocks have a tendency to sometimes sleep in these procs, spamming threads ensures they all open around the same time as intended
+							AL.unlock(1)
+							AL.autoclose = 0
+							AL.open()
+
+				//OPENING ALL DOORS CODE END
+			//END DOOR SUBSECTION
+
+			//ALARM SUBSECTION
+			if("firedrill")
+
+				var/check = alert(usr, "Are you sure you want to trigger every fire alarm on the station?", "Confirmation", "Yes", "No")
+				if(check == "No")	return
+
+				message_admins("[key_name(usr)] has triggered every fire-alarm on-station. [stpsignoff]")
+				log_admin("[key_name(usr)] has triggered every fire alarm on-station. (stationPanel)")
+
+				for(var/obj/machinery/firealarm/FA in world) //in world is heresy, but in machines wasn't working
+					if(FA.z == ZLEVEL_STATION)
+						spawn(-1)
+							FA.alarm()
+
+
+	/*
+
+		END STATION-BUSE PANEL
+
+	*/
+
 /proc/admin_jump_link(var/atom/target, var/source)
 	if(!target) return
 	// The way admin jump links handle their src is weirdly inconsistent...

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2994,11 +2994,13 @@
 
 		switch(href_list["stationPanel"])
 			//DOOR SUBSECTION
+
+			//BOLTING SUB-SUBSECTION
 			if("lockdoors")
 				//BOLTING DOORS CODE
 
 				var/check = alert(usr,"Are you sure you want to bolt every door on the station?", "Confirmation", "Yes", "No")
-				if(check == "No")	return
+				if(check != "Yes")	return
 
 				message_admins("[key_name(usr)] has bolted every door on-station. [stpsignoff]")
 				log_admin("[key_name(usr)] has bolted every door on-station. (stationPanel)")
@@ -3009,12 +3011,27 @@
 
 				//BOLTING DOORS CODE END
 
+			if("unlockdoors") //SISTER TO LOCKDOORS
+				//UNLOCKING DOORS CODE
 
+				var/check = alert(usr,"Are you sure you want to <b>un</b>-bolt every door on the station?", "Confirmation", "Yes", "No")
+				if(check != "Yes")	return
+
+				message_admins("[key_name(usr)] has <b>un</b>-bolted every door on-station. [stpsignoff]")
+				log_admin("[key_name(usr)] has un-bolted every door on-station. (stationPanel)")
+
+				for(var/obj/machinery/door/airlock/AL in airlocks)
+					if(AL.z == ZLEVEL_STATION)
+						spawn(-1)
+							AL.unlock(1)
+			//END BOLTING SUB-SUBSECTION
+
+			//OPENCLOSE SUB-SUBSECTION
 			if("opendoors")
 				//OPENING ALL DOORS CODE
 
 				var/check = alert(usr,"Are you sure you want to unbolt & open every door on the station, including external airlocks?", "Confirmation: Dangerous", "Yes", "No")
-				if(check == "No")	return
+				if(check != "Yes")	return
 
 				message_admins("[key_name(usr)] has unbolted, opened, and disabled autoclose for every door on-station, including external airlocks. [stpsignoff]")
 				log_admin("[key_name(usr)] has unbolted, opened, and disabled autoclose for every door on-station, including external airlocks. (stationPanel)")
@@ -3025,15 +3042,32 @@
 							AL.unlock(1)
 							AL.autoclose = 0
 							AL.open()
-
 				//OPENING ALL DOORS CODE END
+
+			if("closedoors") //SISTER TO OPENDOORS
+				//CLOSING ALL DOORS CODE
+
+				var/check = alert(usr, "Are you sure you want to close every door on the station, and re-enable automatic closing?", "Confirmation", "Yes", "No")
+				if(check != "Yes")	return
+
+				message_admins("[key_name(usr)] has closed every door on-station, and re-enabled autoclose. [stpsignoff]")
+				log_admin("[key_name(usr)] has closed every door on-station, and re-enabled autoclose. (stationPanel)")
+
+				for(var/obj/machinery/door/airlock/AL in airlocks)
+					if(AL.z == ZLEVEL_STATION)
+						spawn(-1)
+							AL.autoclose = 1
+							AL.close()
+				//CLOSING ALL DOORS CODE END
+			//END OPENCLOSE SUB-SUBSECTION
+
 			//END DOOR SUBSECTION
 
 			//ALARM SUBSECTION
 			if("firedrill")
 
 				var/check = alert(usr, "Are you sure you want to trigger every fire alarm on the station?", "Confirmation", "Yes", "No")
-				if(check == "No")	return
+				if(check != "Yes")	return
 
 				message_admins("[key_name(usr)] has triggered every fire-alarm on-station. [stpsignoff]")
 				log_admin("[key_name(usr)] has triggered every fire alarm on-station. (stationPanel)")
@@ -3043,6 +3077,19 @@
 						spawn(-1)
 							FA.alarm()
 
+			if("stopfiredrill")
+
+				var/check = alert(usr, "Are you sure you want to reset every fire alarm on the station?", "Confirmation", "Yes", "No")
+				if(check != "Yes")	return
+
+				message_admins("[key_name(usr)] has reset every fire-alarm on-station. [stpsignoff]")
+				log_admin("[key_name(usr)] has reset every fire alarm on-station. (stationPanel)")
+
+
+				for(var/obj/machinery/firealarm/FA in world)
+					if(FA.z == ZLEVEL_STATION)
+						spawn(-1)
+							FA.reset()
 
 	/*
 

--- a/code/modules/admin/verbs/station_panel.dm
+++ b/code/modules/admin/verbs/station_panel.dm
@@ -19,11 +19,15 @@ This is an admin verb specifically for station-wide effects.
 	var/dat = "<center>"
 
 	//DOORS
-	dat += "<p><b>Doors:</b> <a href='?src=\ref[src];stationPanel=lockdoors'>Bolt all doors on station-Z.</a>"
-	dat += "[TAB][TAB]<a href='?src=\ref[src];stationPanel=opendoors'>Open all doors on station-Z.</a></p>"
+	dat += "<p><b>Doors:</b> "
+	dat += "<a href='?src=\ref[src];stationPanel=lockdoors'>Bolt all doors on station-Z.</a>"
+	dat += "[TAB]<a href='?src=\ref[src];stationPanel=unlockdoors'>Unbolt all doors on station-Z</a></br>"
+	dat += "[TAB]<a href='?src=\ref[src];stationPanel=opendoors'>Open all doors on station-Z.</a>"
+	dat += "[TAB]<a href='?src=\ref[src];stationPanel=closedoors'>Close all doors on station-Z.</a></p>"
 
 	//ALARMS
-	dat += "<p><b>Alarm:</b> <a href='?src=\ref[src];stationPanel=firedrill'>Start a fire drill (Turn on all fire-alarms).</a></p>"
+	dat += "<p><b>Alarm:</b> <a href='?src=\ref[src];stationPanel=firedrill'>Start a fire drill (Turn on all fire-alarms).</a>"
+	dat += "[TAB]<a href='?src=\ref[src];stationPanel=stopfiredrill'>Reset every fire alarm</a></p>"
 
 	dat += "</center>"
 

--- a/code/modules/admin/verbs/station_panel.dm
+++ b/code/modules/admin/verbs/station_panel.dm
@@ -1,0 +1,32 @@
+/* Stationbuse panel
+This is an admin verb specifically for station-wide effects.
+*/
+
+
+/client/proc/station_panel()
+	set name = "Stationbuse Panel"
+	set desc = "Abuse the station!"
+	set category = "Event"
+
+	if(!check_rights(R_SERVER|R_EVENT))	return
+
+	if(holder)
+		holder.station_buse_panel()
+
+/datum/admins/proc/station_buse_panel()
+	if(!check_rights(R_SERVER|R_EVENT))	return
+
+	var/dat = "<center>"
+
+	//DOORS
+	dat += "<p><b>Doors:</b> <a href='?src=\ref[src];stationPanel=lockdoors'>Bolt all doors on station-Z.</a>"
+	dat += "[TAB][TAB]<a href='?src=\ref[src];stationPanel=opendoors'>Open all doors on station-Z.</a></p>"
+
+	//ALARMS
+	dat += "<p><b>Alarm:</b> <a href='?src=\ref[src];stationPanel=firedrill'>Start a fire drill (Turn on all fire-alarms).</a></p>"
+
+	dat += "</center>"
+
+	var/datum/browser/popup = new(usr, "stationbuse", "<div align='center'>Station-abusing panel!</div>", 500, 600)
+	popup.set_content(dat)
+	popup.open(0)

--- a/paradise.dme
+++ b/paradise.dme
@@ -929,6 +929,7 @@
 #include "code\modules\admin\verbs\possess.dm"
 #include "code\modules\admin\verbs\pray.dm"
 #include "code\modules\admin\verbs\randomverbs.dm"
+#include "code\modules\admin\verbs\station_panel.dm"
 #include "code\modules\admin\verbs\striketeam.dm"
 #include "code\modules\admin\verbs\striketeam_syndicate.dm"
 #include "code\modules\admin\verbs\ticklag.dm"


### PR DESCRIPTION
This new panel is specifically intended for station-wide events, such as
all doors being bolted or opened, or a full fire-drill, those such things.

It is restricted to requiring +EVENT or +SERVER to even open.

Bit feature lacking at the moment, but relatively easy to add new buttons
Current buttons:
 - Bolt every door on-station
 - Unbolt every door on-station, disable autoclose, and open them.

 - Trigger every firealarm on-station.

Screenshot:
![screenie](http://puu.sh/ja2Da/150188c37c.png)

For admins: This logs with a special purple font at the end, to more easily identify actions used with it. Anything in this panel can be considered game-changing.