### PR TITLE
Syndicate Bomb Buff

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -19,7 +19,7 @@
 
 /obj/machinery/syndicatebomb/process()
 	if(active && !defused && (timer > 0)) 	//Tick Tock
-		var/volume = (timer <= 10 ? 30 : 5) // Tick louder when the bomb is closer to being detonated.
+		var/volume = (timer <= 10 ? 40 : 10) // Tick louder when the bomb is closer to being detonated.
 		playsound(loc, beepsound, volume, 0)
 		timer--
 	if(active && !defused && (timer <= 0))	//Boom
@@ -187,7 +187,7 @@
 	if(adminlog)
 		message_admins(adminlog)
 		log_game(adminlog)
-	explosion(get_turf(src),2,5,11, flame_range = 11)
+	explosion(get_turf(src),3,9,17, flame_range = 17)
 	if(src.loc && istype(src.loc,/obj/machinery/syndicatebomb/))
 		qdel(src.loc)
 	qdel(src)


### PR DESCRIPTION
Buffs the Syndicate Bomb a bit: https://github.com/tgstation/-tg-station/pull/10548

Since explosions were nerfed with reactionary explosions, this buffs syndicate bombs a bit to bring them in line with the new explosion paradigm.

- Ups blast radius from 2-5-11 to 3-9-17
- makes the beeping timer a bit louder as it gets closer to 0.