### PR TITLE
Round End Attack Log Disabling

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -465,6 +465,7 @@ var/global/datum/controller/gameticker/ticker
 
 /datum/controller/gameticker/proc/declare_completion()
 
+	nologevent = 1 //end of round murder and shenanigans are legal; there's no need to jam up attack logs past this point.
 	//Round statistics report
 	var/datum/station_state/end_state = new /datum/station_state()
 	end_state.count()


### PR DESCRIPTION
This is an administrative feature.

Some expressed the general sense of wanting to keep end of round 'griff', but also expressed frustration at the sheer amount of attack logs they get from it.

This disables attack logs for all admins when the round ends---there's really no point to the mass spam they receive once the round ends, as all violence is legal/allowed from that point forward. This should also help establish a legal cut off point for when something is/isn't legitimate grief.

Please note: Logs for attacks are still stored, server side; this just prevents them from spamming up admin's chat windows. 