### PR TITLE
Hostile Lockdown Nerf

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -117,7 +117,8 @@ rcd light flash thingy on matter drain
 	command_announcement.Announce("Hostile runtime detected in door controllers. Isolation Lockdown protocols are now in effect. Please remain calm.","Network Alert:", 'sound/misc/notice1.ogg')
 	src << "<span class = 'warning'>Lockdown Initiated. Network reset in 90 seconds.</span>"
 	spawn(900) //90 Seconds.
-		disablelockdown() //Reset the lockdown after 90 seconds.
+		if(src && src.stat != DEAD)
+			disablelockdown() //Reset the lockdown after 90 seconds.
 
 /mob/living/silicon/ai/proc/disablelockdown()
 	set category = "Malfunction"

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -79,8 +79,8 @@ rcd light flash thingy on matter drain
 /datum/AI_Module/large/lockdown
 	module_name = "Hostile Station Lockdown"
 	mod_pick_name = "lockdown"
-	description = "Take control of the airlock, blast door and fire control networks, locking them down. Caution! This command also electrifies all airlocks."
-	cost = 20
+	description = "Overload the airlock, blast door and fire control networks, locking them down. Caution! This command also electrifies all airlocks. The networks will automatically reset after 90 seconds."
+	cost = 30
 	one_time = 1
 
 	power_type = /mob/living/silicon/ai/proc/lockdown
@@ -89,16 +89,13 @@ rcd light flash thingy on matter drain
 	set category = "Malfunction"
 	set name = "Initiate Hostile Lockdown"
 
-	if(src.stat == 2)
+	if(src.stat == DEAD)
 		src <<"You cannot begin a lockdown because you are dead!"
-		return
-
-	if(malf_cooldown)
 		return
 
 	var/obj/machinery/door/airlock/AL
 	for(var/obj/machinery/door/D in airlocks)
-		if(!(D.z in config.contact_levels))
+		if(D.z != ZLEVEL_STATION && D.z != ZLEVEL_ASTEROID)
 			continue
 		spawn()
 			if(istype(D, /obj/machinery/door/airlock))
@@ -108,7 +105,6 @@ rcd light flash thingy on matter drain
 					AL.safe = 0 //DOOR CRUSH
 					AL.close()
 					AL.locked = 1 //Bolt it!
-					AL.lights = 0 //Stealth bolt for a classic AI door trap.
 					AL.electrified_until = -1  //Shock it!
 			else if(!D.stat) //So that only powered doors are closed.
 				D.close() //Close ALL the doors!
@@ -117,21 +113,15 @@ rcd light flash thingy on matter drain
 	if(C)
 		C.post_status("alert", "lockdown")
 
-	src.verbs += /mob/living/silicon/ai/proc/disablelockdown
-	src << "<span class = 'warning'>Lockdown Initiated.</span>"
-	malf_cooldown = 1
-	spawn(30)
-	malf_cooldown = 0
+	verbs -= /mob/living/silicon/ai/proc/lockdown
+	command_announcement.Announce("Hostile runtime detected in door controllers. Isolation Lockdown protocols are now in effect. Please remain calm.","Network Alert:", 'sound/misc/notice1.ogg')
+	src << "<span class = 'warning'>Lockdown Initiated. Network reset in 90 seconds.</span>"
+	spawn(900) //90 Seconds.
+		disablelockdown() //Reset the lockdown after 90 seconds.
 
 /mob/living/silicon/ai/proc/disablelockdown()
 	set category = "Malfunction"
 	set name = "Disable Lockdown"
-
-	if(src.stat == 2)
-		src <<"You cannot disable lockdown because you are dead!"
-		return
-	if(malf_cooldown)
-		return
 
 	var/obj/machinery/door/airlock/AL
 	for(var/obj/machinery/door/D in airlocks)
@@ -143,14 +133,10 @@ rcd light flash thingy on matter drain
 					AL.electrified_until = 0
 					AL.open()
 					AL.safe = 1
-					AL.lights = 1 //Essentially reset the airlock to normal.
 			else if(!D.stat) //Opens only powered doors.
 				D.open() //Open everything!
 
-	src << "<span class = 'notice'>Lockdown Lifted.</span>"
-	malf_cooldown = 1
-	spawn(30)
-	malf_cooldown = 0
+	command_announcement.Announce("Automatic system reboot complete. Have a secure day.","Network reset:", 'sound/misc/notice2.ogg')
 
 /datum/AI_Module/large/disable_rcd
 	module_name = "RCD disable"


### PR DESCRIPTION
This is a nerf to hostile lockdown, plain and simple. 

- Hostile Lockdown is now a SINGLE use ability as opposed to a multi-use one
- The lockdown costs 30 CPU instead of 20.
- The lockdown automatically lifts after 90 seconds 
- AI cannot manually lift the lockdown itself
- Announcements are made when the lockdown is initiated and when it clears

This doesn't resolve the lag caused by the initial lockdown (I'll be honest, I'm not sure where this came from as this literally didn't exist when this was first implemented. That said, it does mean that even if you spam the button, you're only going to get one lockdown off--it *shouldn't* paralyze the server for goodness knows how long now.