### PR TITLE
Updates Nuke Disk Spawning

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -170,20 +170,8 @@
 	return 1
 
 /datum/teleport/instant/science/teleportChecks()
-	if(istype(teleatom, /obj/item/weapon/disk/nuclear)) // Don't let nuke disks get teleported --NeoFite
-		teleatom.visible_message("<span class='warning'>The portal rejects [teleatom]!</span>")
-		return 0
-
 	if(istype(teleatom, /obj/item/flag/nation)) // Don't let nation's flags get teleported either --Fox
 		teleatom.visible_message("<span class='warning'>The portal rejects [teleatom]!</span>")
-		return 0
-
-	if(!isemptylist(teleatom.search_contents_for(/obj/item/weapon/disk/nuclear)))
-		if(istype(teleatom, /mob/living))
-			var/mob/living/MM = teleatom
-			MM.visible_message("<span class='warning'>The portal rejects [MM]!","<span class='warning'>The nuclear disk that you're carrying seems to be unable to pass through the portal. Better drop it if you want to go through.</span>")
-		else
-			teleatom.visible_message("<span class='warning'>The portal rejects [teleatom]!</span>")
 		return 0
 
 	if(!isemptylist(teleatom.search_contents_for(/obj/item/flag/nation)))

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -449,9 +449,34 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user as mob)
 				return
 	return
 
+
+//==========DAT FUKKEN DISK===============
+/obj/item/weapon/disk/nuclear
+	name = "nuclear authentication disk"
+	desc = "Better keep this safe."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "nucleardisk"
+	item_state = "card-id"
+	w_class = 1.0
+
+/obj/item/weapon/disk/nuclear/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/item/weapon/disk/nuclear/process()
+	var/turf/disk_loc = get_turf(src)
+	if(disk_loc.z > ZLEVEL_CENTCOMM)
+		get(src, /mob) << "<span class='danger'>You can't help but feel that you just lost something back there...</span>"
+		qdel(src)
+
 /obj/item/weapon/disk/nuclear/Destroy()
 	if(blobstart.len > 0)
-		var/obj/D = new /obj/item/weapon/disk/nuclear(pick(blobstart))
-		message_admins("[src] has been destroyed. Spawning [D] at ([D.x], [D.y], [D.z]).")
-		log_game("[src] has been destroyed. Spawning [D] at ([D.x], [D.y], [D.z]).")
-	return ..()
+		var/obj/item/weapon/disk/nuclear/NEWDISK = new(pick(blobstart))
+		transfer_fingerprints_to(NEWDISK)
+		var/turf/diskturf = get_turf(src)
+		message_admins("[src] has been destroyed in ([diskturf.x], [diskturf.y] ,[diskturf.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[diskturf.x];Y=[diskturf.y];Z=[diskturf.z]'>JMP</a>). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[NEWDISK.x];Y=[NEWDISK.y];Z=[NEWDISK.z]'>JMP</a>).")
+		log_game("[src] has been destroyed in ([diskturf.x], [diskturf.y] ,[diskturf.z]). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z]).")
+		return QDEL_HINT_HARDDEL_NOW
+	else
+		error("[src] was supposed to be destroyed, but we were unable to locate a blobstart landmark to spawn a new one.")
+	return QDEL_HINT_LETMELIVE // Cancel destruction.

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -92,7 +92,7 @@ var/const/SAFETY_COOLDOWN = 100
 
 /obj/machinery/recycler/proc/recycle(var/obj/item/I, var/sound = 1)
 	I.loc = src.loc
-	if(!istype(I, /obj/item/weapon/disk/nuclear) && !istype(I,/obj/item/flag/nation))
+	if(!istype(I,/obj/item/flag/nation))
 		qdel(I)
 		if(prob(15))
 			new /obj/item/stack/sheet/metal(loc)

--- a/code/game/objects/items/weapons/disks.dm
+++ b/code/game/objects/items/weapons/disks.dm
@@ -1,15 +1,3 @@
 /obj/item/weapon/disk
 	name = "disk"
 	icon = 'icons/obj/items.dmi'
-
-/obj/item/weapon/disk/nuclear
-	name = "nuclear authentication disk"
-	desc = "Better keep this safe."
-	icon_state = "nucleardisk"
-	item_state = "card-id"
-	w_class = 1.0
-
-/*
-/obj/item/weapon/disk/nuclear/pickup(mob/living/user as mob)
-	if(issyndicate(user))
-		set_security_level(3)*/     //Nuke Ops rework makes stealth approach significantly harder; this makes it damn near impossible; besides, it's horrendously meta.

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -318,9 +318,6 @@
 			return
 
 	else
-		if(!isemptylist(search_contents_for(/obj/item/weapon/disk/nuclear)))
-			usr << "You get the feeling that you shouldn't cremate one of the items in the cremator."
-			return
 		if(!isemptylist(search_contents_for(/obj/item/flag/nation)))
 			usr << "You get the feeling that you shouldn't cremate one of the items in the cremator."
 			return

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -106,31 +106,11 @@
 		if(destination_y)
 			A.y = destination_y
 
-		var/mob/living/MM = null
-		var/fukkendisk = A.GetTypeInAllContents(/obj/item/weapon/disk/nuclear)
 		var/obj/item/flag/nation/fukkenflag = A.GetTypeInAllContents(/obj/item/flag/nation)
 		if(fukkenflag)
 			fukkenflag.loc = fukkenflag.startloc
 			if(isliving(A))
 				A << "<span class='warning'>The flag you were carrying was just returned to it's base. Nice try.</span>"
-		if(fukkendisk)
-			if(isliving(A))
-				MM = A
-				if(MM.client && !MM.stat)
-					MM << "<span class='warning'>Something you are carrying is preventing you from leaving. Don't play stupid; you know exactly what it is.</span>"
-					if(MM.x <= TRANSITIONEDGE)
-						MM.inertia_dir = 4
-					else if(MM.x >= world.maxx -TRANSITIONEDGE)
-						MM.inertia_dir = 8
-					else if(MM.y <= TRANSITIONEDGE)
-						MM.inertia_dir = 1
-					else if(MM.y >= world.maxy -TRANSITIONEDGE)
-						MM.inertia_dir = 2
-				else
-					qdel(fukkendisk)//Make the disk respawn if it is on a clientless mob or corpse
-			else
-				qdel(fukkendisk)//Make the disk respawn if it is floating on its own
-			return
 
 		A.z =  text2num(transition)
 


### PR DESCRIPTION
Soooo after noticing players exploit getting the nuke disk off station by utilizing alternate methods, I figured it was nigh time to go ahead and implement this fix.

This alters how nuke disk respawning works; if it's destroyed it'll still respawn elsewhere as it currently does. That said the way the disk checks for leaving the z-level is far more robust now; instead of having snowflake checks everywhere for leaving the z-level by alternate means, it just automatically destroys the disk if you do so (which causes it to respawn elsewhere).

Tested and works; wasn't able to notice any strange behaviors.