### PR TITLE
Kitchen Overhaul 2: Table Edition

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -6,7 +6,13 @@
 	var/time = 30 //time in deciseconds
 	var/parts[] = list() //type paths of items that will be placed in the result
 	var/chem_catalists[] = list() //like tools but for reagents
+	var/fruit[] = list()	//grown products required by the recipe
 
+/datum/table_recipe/proc/AdjustChems(var/obj/resultobj as obj)
+	//This proc is to replace the make_food proc of recipes from microwaves and such that are being converted to table crafting recipes.
+	//Use it to handle the removal of reagents after the food has been created (like removing toxins from a salad made with ambrosia)
+	//If a recipe does not require it's chems adjusted, don't bother declaring this for the recipe, as it will call this placeholder
+	return
 
 /datum/table_recipe/IED
 	name = "IED"

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -327,19 +327,11 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/fishandchips
 
-/datum/recipe/microwave/sandwich
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/meatsteak,
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/sandwich
-
 /datum/recipe/microwave/toastedsandwich
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/sandwich
 	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/toastedsandwich
 
 /datum/recipe/microwave/tomatosoup
 	reagents = list("water" = 10)
@@ -453,20 +445,6 @@
 	fruit = list("apple" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candiedapple
 
-/datum/recipe/microwave/slimeburger
-	reagents = list("slimejelly" = 5)
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/bun
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/jellyburger/slime
-
-/datum/recipe/microwave/jellyburger
-	reagents = list("cherryjelly" = 5)
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/bun
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/jellyburger/cherry
-
 /datum/recipe/microwave/twobread
 	reagents = list("wine" = 5)
 	items = list(
@@ -474,22 +452,6 @@
 		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/twobread
-
-/datum/recipe/microwave/slimesandwich
-	reagents = list("slimejelly" = 5)
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/slime
-
-/datum/recipe/microwave/cherrysandwich
-	reagents = list("cherryjelly" = 5)
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/cherry
 
 /datum/recipe/microwave/bloodsoup
 	reagents = list("blood" = 10)
@@ -556,38 +518,7 @@
 	fruit = list("whitebeet" = 1, "cabbage" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/beetsoup
 
-/datum/recipe/microwave/herbsalad
-	fruit = list("ambrosia" = 3, "apple" = 1)
-	result = /obj/item/weapon/reagent_containers/food/snacks/herbsalad
-	make_food(var/obj/container as obj)
-		var/obj/item/weapon/reagent_containers/food/snacks/herbsalad/being_cooked = ..(container)
-		being_cooked.reagents.del_reagent("toxin")
-		return being_cooked
-
-/datum/recipe/microwave/aesirsalad
-	fruit = list("ambrosiadeus" = 3, "goldapple" = 1)
-	result = /obj/item/weapon/reagent_containers/food/snacks/aesirsalad
-
-/datum/recipe/microwave/validsalad
-	fruit = list("ambrosia" = 3, "potato" = 1)
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/meatball,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/validsalad
-	make_food(var/obj/container as obj)
-		var/obj/item/weapon/reagent_containers/food/snacks/validsalad/being_cooked = ..(container)
-		being_cooked.reagents.del_reagent("toxin")
-		return being_cooked
-
 ////////////////////////////FOOD ADDITTIONS///////////////////////////////
-
-/datum/recipe/microwave/wrap
-	reagents = list("soysauce" = 10)
-	fruit = list("cabbage" = 1)
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/friedegg,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/wrap
 
 /datum/recipe/microwave/beans
 	reagents = list("ketchup" = 5)
@@ -617,14 +548,6 @@
 		/obj/item/weapon/reagent_containers/food/snacks/icecream,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich
-
-/datum/recipe/microwave/notasandwich
-	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
-		/obj/item/clothing/mask/fakemoustache,
-	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/notasandwich
 
 /datum/recipe/microwave/friedbanana
 	reagents = list("sugar" = 10, "cornoil" = 5)

--- a/code/modules/food/recipes_table.dm
+++ b/code/modules/food/recipes_table.dm
@@ -1,0 +1,96 @@
+/* Example for reference when defining recipes
+/datum/table_recipe/food
+	name = ""			//in-game display name
+	reqs[] = list()		//type paths of items/reagents consumed associated with how many are needed (equivalent to var/list/items and var/list/reagents combined)
+	result				//type path of item resulting from this craft
+	tools[] = list()	//type paths of items needed but not consumed
+	time = 30			//time in deciseconds
+	parts[] = list()	//type paths of items that will be placed in the result
+	fruit[] = list()	//grown products required by the recipe
+*/
+
+/datum/table_recipe/sandwich
+	name = "Sandwich"
+	reqs = list(
+		/obj/item/weapon/reagent_containers/food/snacks/meatsteak = 1,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice = 2,
+		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge = 1,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sandwich
+
+/datum/table_recipe/slimesandwich
+	name = "Slime Jelly Sandwich"
+	reqs = list(
+		/datum/reagent/slimejelly = 5,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice = 2,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/slime
+
+/datum/table_recipe/cherrysandwich
+	name = "Cherry Jelly Sandwich"
+	reqs = list(
+		/datum/reagent/cherryjelly = 5,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice = 2,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/cherry
+
+/datum/table_recipe/slimeburger
+	name = "Slime Jelly Burger"
+	reqs = list(
+		/datum/reagent/slimejelly = 5,
+		/obj/item/weapon/reagent_containers/food/snacks/bun = 1,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellyburger/slime
+
+/datum/table_recipe/jellyburger
+	name = "Cherry Jelly Burger"
+	reqs = list(
+		/datum/reagent/cherryjelly = 5,
+		/obj/item/weapon/reagent_containers/food/snacks/bun = 1,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellyburger/cherry
+
+/datum/table_recipe/herbsalad
+	name = "herb salad"
+	fruit = list("ambrosia" = 3, "apple" = 1)
+	result = /obj/item/weapon/reagent_containers/food/snacks/herbsalad
+
+/datum/table_recipe/herbsalad/AdjustChems(var/obj/resultobj as obj)
+	if(istype(resultobj, /obj/item/weapon/reagent_containers))
+		var/obj/item/weapon/reagent_containers/RC = resultobj
+		RC.reagents.del_reagent("toxin")
+
+/datum/table_recipe/aesirsalad
+	name = "Aesir salad"
+	fruit = list("ambrosiadeus" = 3, "goldapple" = 1)
+	result = /obj/item/weapon/reagent_containers/food/snacks/aesirsalad
+
+/datum/table_recipe/validsalad
+	name = "valid salad"
+	fruit = list("ambrosia" = 3, "potato" = 1)
+	reqs = list(
+		/obj/item/weapon/reagent_containers/food/snacks/meatball = 1,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/validsalad
+
+/datum/table_recipe/validsalad/AdjustChems(var/obj/resultobj as obj)
+	if(istype(resultobj, /obj/item/weapon/reagent_containers))
+		var/obj/item/weapon/reagent_containers/RC = resultobj
+		RC.reagents.del_reagent("toxin")
+
+/datum/table_recipe/notasandwich
+	name = "not-a-sandwich"
+	reqs = list(
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice = 2,
+		/obj/item/clothing/mask/fakemoustache = 1,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/notasandwich
+
+/datum/table_recipe/wrap
+	name = "egg wrap"
+	fruit = list("cabbage" = 1)
+	reqs = list(
+		/datum/reagent/soysauce = 10,
+		/obj/item/weapon/reagent_containers/food/snacks/friedegg = 1,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/wrap

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -144,33 +144,35 @@
 		..() // -> item/attackby(, params)
 
 	if(istype(W,/obj/item/weapon/kitchen/utensil))
+		//This will allow forks/spoons/plastic cutlery to pick up sliceables, but requires it to be unsliceable for the knife to pick it up
+		if((istype(W, /obj/item/weapon/kitchen/utensil/knife) && !slice_path) || !istype(W, /obj/item/weapon/kitchen/utensil/knife))
 
-		var/obj/item/weapon/kitchen/utensil/U = W
+			var/obj/item/weapon/kitchen/utensil/U = W
 
-		if(!U.reagents)
-			U.create_reagents(5)
+			if(!U.reagents)
+				U.create_reagents(5)
 
-		if (U.reagents.total_volume > 0)
-			user << "\red You already have something on your [U]."
+			if (U.reagents.total_volume > 0)
+				user << "\red You already have something on your [U]."
+				return
+
+			user.visible_message( \
+				"[user] scoops up some [src] with \the [U]!", \
+				"\blue You scoop up some [src] with \the [U]!" \
+			)
+
+			src.bitecount++
+			U.overlays.Cut()
+			U.loaded = "[src]"
+			var/image/I = new(U.icon, "loadedfood")
+			I.color = src.filling_color
+			U.overlays += I
+
+			reagents.trans_to(U,min(reagents.total_volume,5))
+
+			if (reagents.total_volume <= 0)
+				qdel(src)
 			return
-
-		user.visible_message( \
-			"[user] scoops up some [src] with \the [U]!", \
-			"\blue You scoop up some [src] with \the [U]!" \
-		)
-
-		src.bitecount++
-		U.overlays.Cut()
-		U.loaded = "[src]"
-		var/image/I = new(U.icon, "loadedfood")
-		I.color = src.filling_color
-		U.overlays += I
-
-		reagents.trans_to(U,min(reagents.total_volume,5))
-
-		if (reagents.total_volume <= 0)
-			qdel(src)
-		return
 
 	if((slices_num <= 0 || !slices_num) || !slice_path)
 		return 0

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -10,7 +10,12 @@
 		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if(istype(W,/obj/item/weapon/kitchen/utensil/knife))
+	if( \
+			istype(W, /obj/item/weapon/kitchenknife) || \
+			istype(W, /obj/item/weapon/butch) || \
+			istype(W, /obj/item/weapon/scalpel) || \
+			istype(W, /obj/item/weapon/kitchen/utensil/knife) \
+		)
 		new /obj/item/weapon/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/rawcutlet(src)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1150,6 +1150,7 @@
 #include "code\modules\food\recipes_grill.dm"
 #include "code\modules\food\recipes_microwave.dm"
 #include "code\modules\food\recipes_oven.dm"
+#include "code\modules\food\recipes_table.dm"
 #include "code\modules\garbage collection\garbage_collector.dm"
 #include "code\modules\garbage collection\gc_testing.dm"
 #include "code\modules\genetics\side_effects.dm"


### PR DESCRIPTION
Moves a number of kitchen recipes to utilize table-crafting!
- Instead of dumping the ingredients in the microwave, simply collect them on the table to assemble your dish via the table-crafting menu
 - The option to assemble the dish will only appear if all the ingredients are present on the SAME table section.

Table-crafted foods:
- Sandwich
- Slime Jelly Sandwich
- Cherry Jelly Sandwich
- Slime Jelly Burger
- Cherry Jelly Burger
- Not-a-sandwich
- Egg Wrap
- Herb Salad
- Aesir Salad
- Valid Salad
 - Ingredients are unchanged

Standardizes the chef's knife usage!
- Now the chef can use the Cutlet knife (knife utensil), kitchen knife, butcher knife, or scalpel to cut meat into cutlets!
- Now the Cutlet Knife (knife utensil) can be properly used to slice cakes, pizza, bread, flat dough, and so forth instead of scooping up a bit onto the knife.
 - If a food object cannot be sliced (no slice_path defined), it will scoop up a bit as before. Forks, spoons, and plastic knives will always scoop, regardless of slice_path.

Fixes the Toasted Sandwich microwave recipe not working.
- It was missing a result, meaning it was not being loaded as an acceptable recipe and causing the microwave to reject sandwiches.

BACKEND CODER CRAP:
- Tablecrafting recipes now can support botany produce and adjusting chems in the result item.
 - New fruit list var is used for botany produce
 - New AdjustChems proc is used to handle final chem adjustments, such as removing or adding chems from the finished product.