### PR TITLE
Diona Amputation Fix

### DIFF
--- a/code/modules/organs/organ_alien.dm
+++ b/code/modules/organs/organ_alien.dm
@@ -37,6 +37,7 @@
 	health = 100
 	min_broken_damage = 50
 	body_part = LOWER_TORSO
+	vital = 1
 	parent_organ = "chest"
 
 /obj/item/organ/external/diona/arm
@@ -117,6 +118,7 @@
 	health = 50
 	min_broken_damage = 25
 	body_part = HEAD
+	vital = 1
 	parent_organ = "chest"
 
 /obj/item/organ/external/diona/head/removed()


### PR DESCRIPTION
So, our Diona are a bit different than Bay's--they don't get a free infinite respawn mechanic. Normally when you cut off certain Diona organs they're meant to become a new Diona or something similar.

Either case, this fixes it so that cutting off a Diona's groin or head properly kills them instead of them walking around without their heads or surviving without half their body.