### PR TITLE
Turf/Entered() Optimizations

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -43,7 +43,7 @@
 	tracks.AddTracks(bloodDNA,comingdir,goingdir,bloodcolor)
 
 /turf/simulated/Entered(atom/A, atom/OL)
-
+	..()
 	if(ishuman(A))
 		var/mob/living/carbon/human/M = A
 		if(M.lying)	return
@@ -147,8 +147,6 @@
 				else
 					M.inertia_dir = 0
 					return
-
-	..()
 
 //returns 1 if made bloody, returns 0 otherwise
 /turf/simulated/add_blood(mob/living/carbon/human/M as mob)


### PR DESCRIPTION
Plucked from TG. Turf/Entered optimizations.

Um...yeah....

Before:
![ohno](http://i.gyazo.com/03e2d9f6306007870e27ad7f942e8b3b.png)
After:
![ohno2](http://i.gyazo.com/70136787ff9b87550f0264f8faef74b2.png)

This doesn't just help day to day entered, but uh...when things explode/gib/etc it calls hundreds of Entered() calls....so yeah, this is a big big reason that the singularity and explosions and such cause so much lag at times (especially explosions gibbing people).