### PR TITLE
Candy Fixes, Juicer Fix

### DIFF
--- a/code/modules/food/recipes_candy.dm
+++ b/code/modules/food/recipes_candy.dm
@@ -54,7 +54,7 @@
 // Base Candy Recipes (unflavored / plain)
 // ***********************************************************
 
-/datum/recipe/candy/cotton
+/datum/recipe/candy/cottoncandy
 	reagents = list("sugar" = 15)
 	items = list(
 		/obj/item/weapon/c_tube,
@@ -99,7 +99,7 @@
 		/obj/item/weapon/kitchen/mould/cane,
 		/obj/item/weapon/reagent_containers/food/snacks/mint,
 		)
-	result = /obj/item/weapon/reagent_containers/food/snacks/mint
+	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candycane
 	byproduct = /obj/item/weapon/kitchen/mould/cane
 
 /datum/recipe/candy/gum
@@ -115,7 +115,6 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar
 
 /datum/recipe/candy/cash
-	reagents = list()
 	items = list(
 		/obj/item/weapon/kitchen/mould/cash,
 		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar,
@@ -124,7 +123,6 @@
 	byproduct = /obj/item/weapon/kitchen/mould/cash
 
 /datum/recipe/candy/coin
-	reagents = list()
 	items = list(
 		/obj/item/weapon/kitchen/mould/coin,
 		/obj/item/weapon/reagent_containers/food/snacks/chocolatebar,
@@ -144,63 +142,63 @@
 // Cotton Candy Recipes (flavored)
 // ***********************************************************
 
-/datum/recipe/candy/cotton/red
+/datum/recipe/candy/cottoncandy_red
 	reagents = list("cherryjelly" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/red
 
-/datum/recipe/candy/cotton/blue
+/datum/recipe/candy/cottoncandy_blue
 	reagents = list("berryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/blue
 
-/datum/recipe/candy/cotton/poison
+/datum/recipe/candy/cottoncandy_poison
 	reagents = list("poisonberryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/poison
 
-/datum/recipe/candy/cotton/green
+/datum/recipe/candy/cottoncandy_green
 	reagents = list("limejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/green
 
-/datum/recipe/candy/cotton/yellow
+/datum/recipe/candy/cottoncandy_yellow
 	reagents = list("lemonjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/yellow
 
-/datum/recipe/candy/cotton/orange
+/datum/recipe/candy/cottoncandy_orange
 	reagents = list("orangejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/orange
 
-/datum/recipe/candy/cotton/purple
+/datum/recipe/candy/cottoncandy_purple
 	reagents = list("grapejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/purple
 
-/datum/recipe/candy/cotton/pink
+/datum/recipe/candy/cottoncandy_pink
 	reagents = list("watermelonjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/pink
 
-/datum/recipe/candy/cotton/rainbow
+/datum/recipe/candy/cottoncandy_rainbow
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/red,
@@ -213,7 +211,7 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/rainbow
 
-/datum/recipe/candy/cotton/rainbow2
+/datum/recipe/candy/cottoncandy_rainbow2
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/red,
@@ -230,67 +228,67 @@
 // Gummy Bear Recipes (flavored)
 // ***********************************************************
 
-/datum/recipe/candy/gummybear/red
+/datum/recipe/candy/gummybear_red
 	reagents = list("cherryjelly" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/red
 
-/datum/recipe/candy/gummybear/blue
+/datum/recipe/candy/gummybear_blue
 	reagents = list("berryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/blue
 
-/datum/recipe/candy/gummybear/poison
+/datum/recipe/candy/gummybear_poison
 	reagents = list("poisonberryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/poison
 
-/datum/recipe/candy/gummybear/green
+/datum/recipe/candy/gummybear_green
 	reagents = list("limejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/green
 
-/datum/recipe/candy/gummybear/yellow
+/datum/recipe/candy/gummybear_yellow
 	reagents = list("lemonjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/yellow
 
-/datum/recipe/candy/gummybear/orange
+/datum/recipe/candy/gummybear_orange
 	reagents = list("orangejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/orange
 
-/datum/recipe/candy/gummybear/purple
+/datum/recipe/candy/gummybear_purple
 	reagents = list("grapejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/purple
 
-/datum/recipe/candy/gummybear/wtf
+/datum/recipe/candy/gummybear_wtf
 	reagents = list("space_drugs" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/wtf
 
-/datum/recipe/candy/gummybear/wtf2
+/datum/recipe/candy/gummybear_wtf2
 	reagents = list()
+	fruit = list("ambrosia" = 1)
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear,
-		/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris
+		/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/wtf
 
@@ -298,67 +296,66 @@
 // Gummy Worm Recipes (flavored)
 // ***********************************************************
 
-/datum/recipe/candy/gummyworm/red
+/datum/recipe/candy/gummyworm_red
 	reagents = list("cherryjelly" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/red
 
-/datum/recipe/candy/gummyworm/blue
+/datum/recipe/candy/gummyworm_blue
 	reagents = list("berryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/blue
 
-/datum/recipe/candy/gummyworm/poison
+/datum/recipe/candy/gummyworm_poison
 	reagents = list("poisonberryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/poison
 
-/datum/recipe/candy/gummyworm/green
+/datum/recipe/candy/gummyworm_green
 	reagents = list("limejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/green
 
-/datum/recipe/candy/gummyworm/yellow
+/datum/recipe/candy/gummyworm_yellow
 	reagents = list("lemonjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/yellow
 
-/datum/recipe/candy/gummyworm/orange
+/datum/recipe/candy/gummyworm_orange
 	reagents = list("orangejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/orange
 
-/datum/recipe/candy/gummyworm/purple
+/datum/recipe/candy/gummyworm_purple
 	reagents = list("grapejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/purple
 
-/datum/recipe/candy/gummyworm/wtf
+/datum/recipe/candy/gummyworm_wtf
 	reagents = list("space_drugs" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/wtf
 
-/datum/recipe/candy/gummyworm/wtf2
-	reagents = list()
+/datum/recipe/candy/gummyworm_wtf2
+	fruit = list("ambrosia" = 1)
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm,
-		/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris
+		/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/wtf
 
@@ -366,56 +363,56 @@
 // Jelly Bean Recipes (flavored)
 // ***********************************************************
 
-/datum/recipe/candy/jellybean/red
+/datum/recipe/candy/jellybean_red
 	reagents = list("cherryjelly" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/red
 
-/datum/recipe/candy/jellybean/blue
+/datum/recipe/candy/jellybean_blue
 	reagents = list("berryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/blue
 
-/datum/recipe/candy/jellybean/poison
+/datum/recipe/candy/jellybean_poison
 	reagents = list("poisonberryjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/poison
 
-/datum/recipe/candy/jellybean/green
+/datum/recipe/candy/jellybean_green
 	reagents = list("limejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/green
 
-/datum/recipe/candy/jellybean/yellow
+/datum/recipe/candy/jellybean_yellow
 	reagents = list("lemonjuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/yellow
 
-/datum/recipe/candy/jellybean/orange
+/datum/recipe/candy/jellybean_orange
 	reagents = list("orangejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/orange
 
-/datum/recipe/candy/jellybean/purple
+/datum/recipe/candy/jellybean_purple
 	reagents = list("grapejuice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/purple
 
-/datum/recipe/candy/jellybean/chocolate
+/datum/recipe/candy/jellybean_chocolate
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
@@ -423,47 +420,45 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/chocolate
 
-/datum/recipe/candy/jellybean/cola
+/datum/recipe/candy/jellybean_cola
 	reagents = list("cola" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola
 
-/datum/recipe/candy/jellybean/popcorn
+/datum/recipe/candy/jellybean_popcorn
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/popcorn,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/popcorn
 
-/datum/recipe/candy/jellybean/coffee
+/datum/recipe/candy/jellybean_coffee
 	reagents = list("coffee" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola
 
-/datum/recipe/candy/jellybean/drgibb
+/datum/recipe/candy/jellybean_drgibb
 	reagents = list("dr_gibb" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola
 
-
-/datum/recipe/candy/jellybean/wtf
+/datum/recipe/candy/jellybean_wtf
 	reagents = list("space_drugs" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/wtf
 
-/datum/recipe/candy/jellybean/wtf2
-	reagents = list()
+/datum/recipe/candy/jellybean_wtf2
+	fruit = list("ambrosia" = 1)
 	items = list(
-		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean,
-		/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris
+		/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/wtf
 
@@ -471,7 +466,7 @@
 // Candybar Recipes (flavored)
 // ***********************************************************
 
-/datum/recipe/candy/candybar/caramel
+/datum/recipe/candy/malper
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
@@ -479,7 +474,7 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/caramel
 
-/datum/recipe/candy/candybar/nougat
+/datum/recipe/candy/toolerone
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
@@ -487,7 +482,7 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/nougat
 
-/datum/recipe/candy/candybar/toffee
+/datum/recipe/candy/yumbaton
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
@@ -495,14 +490,14 @@
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/toffee
 
-/datum/recipe/candy/candybar/rice
+/datum/recipe/candy/crunch
 	reagents = list("rice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
 		)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/rice
 
-/datum/recipe/candy/candybar/caramel_nougat
+/datum/recipe/candy/toxinstest
 	reagents = list()
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -938,7 +938,7 @@
 			return blend_items[i]
 
 /obj/machinery/reagentgrinder/proc/get_allowed_juice_by_id(var/obj/item/weapon/reagent_containers/food/snacks/O)
-	for(var/i in juice_tags)
+	for(var/i in juice_items)
 		if(istype(O, i))
 			return juice_items[i]
 

--- a/code/modules/reagents/reagent_containers/food/snacks/candy.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/candy.dm
@@ -168,18 +168,18 @@
 
 	New()
 		..()
-		reagents.add_reagent("sugar" = 10)
+		reagents.add_reagent("sugar", 10)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin."
 	icon_state = "gworm"
 	filling_color = "#FFFFFF"
 
 	New()
 		..()
-		reagents.add_reagent("sugar" = 10)
+		reagents.add_reagent("sugar", 10)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean
@@ -190,7 +190,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("sugar" = 10)
+		reagents.add_reagent("sugar", 10)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jawbreaker
@@ -201,7 +201,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("sugar" = 10)
+		reagents.add_reagent("sugar", 10)
 		bitesize = 0.1	//this is gonna take a while, you'll be working at this all shift.
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cash
@@ -239,7 +239,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("sugar" = 5)
+		reagents.add_reagent("sugar", 5)
 		bitesize = 0.2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/sucker
@@ -250,7 +250,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("sugar" = 10)
+		reagents.add_reagent("sugar", 10)
 		bitesize = 1
 
 // ***********************************************************
@@ -265,7 +265,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("cherryjelly" = 2)
+		reagents.add_reagent("cherryjelly", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/blue
@@ -276,7 +276,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("berryjuice" = 2)
+		reagents.add_reagent("berryjuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/poison
@@ -287,7 +287,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("poisonberryjuice" = 12)
+		reagents.add_reagent("poisonberryjuice", 12)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
 		bitesize = 3
@@ -301,7 +301,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("limejuice" = 2)
+		reagents.add_reagent("limejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/yellow
@@ -312,7 +312,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("lemonjuice" = 2)
+		reagents.add_reagent("lemonjuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/orange
@@ -323,7 +323,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("orangejuice" = 2)
+		reagents.add_reagent("orangejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/purple
@@ -334,7 +334,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("grapejuice" = 2)
+		reagents.add_reagent("grapejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/wtf
@@ -345,7 +345,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("space_drugs" = 2)
+		reagents.add_reagent("space_drugs", 2)
 		bitesize = 3
 
 
@@ -354,93 +354,93 @@
 // ***********************************************************
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/red
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's red!"
 	icon_state = "gworm_red"
 	filling_color = "#801E28"
 
 	New()
 		..()
-		reagents.add_reagent("cherryjelly" = 2)
+		reagents.add_reagent("cherryjelly", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/blue
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's blue!"
 	icon_state = "gworm_blue"
 	filling_color = "#863333"
 
 	New()
 		..()
-		reagents.add_reagent("berryjuice" = 2)
+		reagents.add_reagent("berryjuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/poison
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's blue!"
 	icon_state = "gworm_blue"
 	filling_color = "#863353"
 
 	New()
 		..()
-		reagents.add_reagent("poisonberryjuice" = 12)
+		reagents.add_reagent("poisonberryjuice", 12)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/green
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's green!"
 	icon_state = "gworm_green"
 	filling_color = "#365E30"
 
 	New()
 		..()
-		reagents.add_reagent("limejuice" = 10)
+		reagents.add_reagent("limejuice", 10)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/yellow
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's yellow!"
 	icon_state = "gworm_yellow"
 	filling_color = "#863333"
 
 	New()
 		..()
-		reagents.add_reagent("lemonjuice" = 2)
+		reagents.add_reagent("lemonjuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/orange
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's orange!"
 	icon_state = "gworm_orange"
 	filling_color = "#E78108"
 
 	New()
 		..()
-		reagents.add_reagent("orangejuice" = 2)
+		reagents.add_reagent("orangejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/purple
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's purple!"
 	icon_state = "gworm_purple"
 	filling_color = "#993399"
 
 	New()
 		..()
-		reagents.add_reagent("grapejuice" = 2)
+		reagents.add_reagent("grapejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/wtf
-	name = "gummy bear"
+	name = "gummy worm"
 	desc = "An edible worm. Did it just move?"
 	icon_state = "gworm_wtf"
 	filling_color = "#60A584"
 
 	New()
 		..()
-		reagents.add_reagent("space_drugs" = 2)
+		reagents.add_reagent("space_drugs", 2)
 		bitesize = 3
 
 
@@ -456,7 +456,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("cherryjelly" = 2)
+		reagents.add_reagent("cherryjelly", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/blue
@@ -467,7 +467,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("berryjuice" = 2)
+		reagents.add_reagent("berryjuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/poison
@@ -478,7 +478,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("poisonberryjuice" = 12)
+		reagents.add_reagent("poisonberryjuice", 12)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
 		bitesize = 3
@@ -491,7 +491,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("limejuice" = 10)
+		reagents.add_reagent("limejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/yellow
@@ -502,7 +502,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("lemonjuice" = 2)
+		reagents.add_reagent("lemonjuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/orange
@@ -513,7 +513,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("orangejuice" = 2)
+		reagents.add_reagent("orangejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/purple
@@ -524,7 +524,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("grapejuice" = 2)
+		reagents.add_reagent("grapejuice", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/chocolate
@@ -546,7 +546,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("nutriment" = 2)
+		reagents.add_reagent("nutriment", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola
@@ -557,7 +557,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("cola" = 2)
+		reagents.add_reagent("cola", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/drgibb
@@ -568,7 +568,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("dr_gibb" = 2)
+		reagents.add_reagent("dr_gibb", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/coffee
@@ -579,7 +579,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("coffee" = 2)
+		reagents.add_reagent("coffee", 2)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/wtf
@@ -590,7 +590,7 @@
 
 	New()
 		..()
-		reagents.add_reagent("space_drugs" = 2)
+		reagents.add_reagent("space_drugs", 2)
 		bitesize = 3
 
 // ***********************************************************


### PR DESCRIPTION
Fixes a number of New() procs for candies that would runtime
- Issue was caused by incorrect arguments for the add_reagent proc

Fixes gummy worms being incorrectly named gummy bears

Fixes the candy cane recipe resulting in a mint rather than a candy cane

Re-paths recipes for flavored candies to not be subtypes of the plain version to fix the generation of candy moulds from recipes that don't require the mould.
- Also applied this to candybars so the recipe path better communicates
the end-result

Updates the recipes for the WTF (druggy) gummy bears and worms to work with the botany update ambrosia
- Previously checked for the hardcoded path rather than the kitchen_tag which the rest of the kitchen was updated to use

Fixes the juicer failing to juice watermelon slices