### PR TITLE
Subtypesof Helper Proc

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -7,7 +7,7 @@
 	var/list/paths
 
 	//Hair - Initialise all /datum/sprite_accessory/hair into an list indexed by hair-style name
-	paths = typesof(/datum/sprite_accessory/hair) - /datum/sprite_accessory/hair
+	paths = subtypesof(/datum/sprite_accessory/hair)
 	for(var/path in paths)
 		var/datum/sprite_accessory/hair/H = new path()
 		hair_styles_list[H.name] = H
@@ -19,7 +19,7 @@
 				hair_styles_female_list += H.name
 
 	//Facial Hair - Initialise all /datum/sprite_accessory/facial_hair into an list indexed by facialhair-style name
-	paths = typesof(/datum/sprite_accessory/facial_hair) - /datum/sprite_accessory/facial_hair
+	paths = subtypesof(/datum/sprite_accessory/facial_hair)
 	for(var/path in paths)
 		var/datum/sprite_accessory/facial_hair/H = new path()
 		facial_hair_styles_list[H.name] = H
@@ -31,30 +31,30 @@
 				facial_hair_styles_female_list += H.name
 
 	//Surgery Steps - Initialize all /datum/surgery_step into a list
-	paths = typesof(/datum/surgery_step)-/datum/surgery_step
+	paths = subtypesof(/datum/surgery_step)
 	for(var/T in paths)
 		var/datum/surgery_step/S = new T
 		surgery_steps += S
 	sort_surgeries()
 
 	//List of job. I can't believe this was calculated multiple times per tick!
-	paths = typesof(/datum/job) -list(/datum/job,/datum/job/ai,/datum/job/cyborg)
+	paths = subtypesof(/datum/job) -list(/datum/job/ai,/datum/job/cyborg)
 	for(var/T in paths)
 		var/datum/job/J = new T
 		joblist[J.title] = J
 
-	paths = typesof(/datum/nations)-/datum/nations
+	paths = subtypesof(/datum/nations)
 	for(var/T in paths)
 		var/datum/nations/N = new T
 		all_nations[N.name] = N
 
-	paths = typesof(/datum/superheroes)-/datum/superheroes
+	paths = subtypesof(/datum/superheroes)
 	for(var/T in paths)
 		var/datum/superheroes/S = new T
 		all_superheroes[S.name] = S
 
 	//Languages and species.
-	paths = typesof(/datum/language)-/datum/language
+	paths = subtypesof(/datum/language)
 	for(var/T in paths)
 		var/datum/language/L = new T
 		all_languages[L.name] = L
@@ -67,7 +67,7 @@
 			language_keys["#[lowertext(L.key)]"] = L
 
 	var/rkey = 0
-	paths = typesof(/datum/species)-/datum/species
+	paths = subtypesof(/datum/species)
 	for(var/T in paths)
 		rkey++
 		var/datum/species/S = new T

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -31,7 +31,7 @@
 		return "[output][and_text][input[index]]"
 
 //Returns list element or null. Should prevent "index out of bounds" error.
-proc/listgetindex(var/list/list,index)
+/proc/listgetindex(var/list/list,index)
 	if(istype(list) && list.len)
 		if(isnum(index))
 			if(InRange(index,1,list.len))
@@ -40,19 +40,19 @@ proc/listgetindex(var/list/list,index)
 			return list[index]
 	return
 
-proc/islist(list/list)
+/proc/islist(list/list)
 	if(istype(list))
 		return 1
 	return 0
 
 //Return either pick(list) or null if list is not of type /list or is empty
-proc/safepick(list/list)
+/proc/safepick(list/list)
 	if(!islist(list) || !list.len)
 		return
 	return pick(list)
 
 //Checks if the list is empty
-proc/isemptylist(list/list)
+/proc/isemptylist(list/list)
 	if(!list.len)
 		return 1
 	return 0
@@ -65,13 +65,13 @@ proc/isemptylist(list/list)
 	return 0
 
 //Empties the list by setting the length to 0. Hopefully the elements get garbage collected
-proc/clearlist(list/list)
+/proc/clearlist(list/list)
 	if(istype(list))
 		list.len = 0
 	return
 
 //Removes any null entries from the list
-proc/listclearnulls(list/list)
+/proc/listclearnulls(list/list)
 	if(istype(list))
 		while(null in list)
 			list -= null
@@ -504,7 +504,7 @@ proc/dd_sortedObjectList(list/incoming)
 	return sorted_list
 */
 
-proc/dd_sortedtextlist(list/incoming, case_sensitive = 0)
+/proc/dd_sortedtextlist(list/incoming, case_sensitive = 0)
 	// Returns a new list with the text values sorted.
 	// Use binary search to order by sortValue.
 	// This works by going to the half-point of the list, seeing if the node in question is higher or lower cost,
@@ -563,12 +563,16 @@ proc/dd_sortedtextlist(list/incoming, case_sensitive = 0)
 	return sorted_text
 
 
-proc/dd_sortedTextList(list/incoming)
+/proc/dd_sortedTextList(list/incoming)
 	var/case_sensitive = 1
 	return dd_sortedtextlist(incoming, case_sensitive)
 
+/proc/subtypesof(var/path) //Returns a list containing all subtypes of the given path, but not the given path itself.
+	if(!path || !ispath(path))
+		return
+	return (typesof(path) - path)
 
-datum/proc/dd_SortValue()
+/datum/proc/dd_SortValue()
 	return "[src]"
 
 /obj/machinery/dd_SortValue()

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -569,7 +569,7 @@ proc/dd_sortedObjectList(list/incoming)
 
 /proc/subtypesof(var/path) //Returns a list containing all subtypes of the given path, but not the given path itself.
 	if(!path || !ispath(path))
-		return
+		CRASH("Invalid path, failed to fetch subtypes of \"[path]\".)")
 	return (typesof(path) - path)
 
 /datum/proc/dd_SortValue()

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -569,7 +569,7 @@ proc/dd_sortedObjectList(list/incoming)
 
 /proc/subtypesof(var/path) //Returns a list containing all subtypes of the given path, but not the given path itself.
 	if(!path || !ispath(path))
-		CRASH("Invalid path, failed to fetch subtypes of \"[path]\".)")
+		CRASH("Invalid path, failed to fetch subtypes of \"[path]\".")
 	return (typesof(path) - path)
 
 /datum/proc/dd_SortValue()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -407,7 +407,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 					search_pda = 0
 
 		//Fixes renames not being reflected in objective text
-		var/list/O = (typesof(/datum/objective)  - /datum/objective)
+		var/list/O = subtypesof(/datum/objective)
 		var/length
 		var/pos
 		for(var/datum/objective/objective in O)

--- a/code/controllers/ProcessScheduler/core/processScheduler.dm
+++ b/code/controllers/ProcessScheduler/core/processScheduler.dm
@@ -57,7 +57,7 @@ var/global/datum/controller/processScheduler/processScheduler
 
 	var/process
 	// Add all the processes we can find, except for the ticker
-	for (process in typesof(/datum/controller/process) - /datum/controller/process)
+	for (process in subtypesof(/datum/controller/process))
 		if (!(process in deferredSetupList))
 			addProcess(new process(src))
 

--- a/code/controllers/Processes/event.dm
+++ b/code/controllers/Processes/event.dm
@@ -35,7 +35,7 @@ var/global/datum/controller/holiday/holiday_master //This has to be defined befo
 	var/MM = text2num(time2text(world.timeofday, "MM")) 	// get the current month
 	var/DD = text2num(time2text(world.timeofday, "DD")) 	// get the current day
 
-	for(var/H in typesof(/datum/holiday) - /datum/holiday)
+	for(var/H in subtypesof(/datum/holiday))
 		var/datum/holiday/holiday = new H()
 		if(holiday.shouldCelebrate(DD, MM, YY))
 			holiday.celebrate()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -161,7 +161,7 @@
 	var/list/overflow_whitelist = list() //whitelist for overflow
 
 /datum/configuration/New()
-	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
+	var/list/L = subtypesof(/datum/game_mode)
 	for (var/T in L)
 		// I wish I didn't have to instance the game modes in order to look up
 		// their information, but it is the only way (at least that I know of).
@@ -688,7 +688,7 @@
 /datum/configuration/proc/pick_mode(mode_name)
 	// I wish I didn't have to instance the game modes in order to look up
 	// their information, but it is the only way (at least that I know of).
-	for (var/T in (typesof(/datum/game_mode) - /datum/game_mode))
+	for (var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = new T()
 		if (M.config_tag && M.config_tag == mode_name)
 			return M
@@ -697,7 +697,7 @@
 
 /datum/configuration/proc/get_runnable_modes()
 	var/list/datum/game_mode/runnable_modes = new
-	for (var/T in (typesof(/datum/game_mode) - /datum/game_mode))
+	for (var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = new T()
 		//world << "DEBUG: [T], tag=[M.config_tag], prob=[probabilities[M.config_tag]]"
 		if (!(M.config_tag in modes))

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -125,7 +125,7 @@ datum/ai_laws/tyrant //This probably shouldn't be a default lawset.
 				add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
 				add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 		if(2)
-			var/datum/ai_laws/lawtype = pick(typesof(/datum/ai_laws/default) - /datum/ai_laws/default)
+			var/datum/ai_laws/lawtype = pick(subtypesof(/datum/ai_laws/default))
 			var/datum/ai_laws/templaws = new lawtype()
 			inherent = templaws.inherent
 	set_zeroth_law("\red ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK#*´&110010")

--- a/code/datums/periodic_news.dm
+++ b/code/datums/periodic_news.dm
@@ -122,7 +122,7 @@ proc/process_newscaster()
 
 var/global/tmp/announced_news_types = list()
 proc/check_for_newscaster_updates(type)
-	for(var/subtype in typesof(type)-type)
+	for(var/subtype in subtypesof(type))
 		var/datum/news_announcement/news = new subtype()
 		if(news.round_time * 10 <= world.time && !(subtype in announced_news_types))
 			announced_news_types += subtype

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -154,7 +154,7 @@ Obviously, requires DNA2.
 	M.s_tone =  -M.s_tone + 35
 
 	// hair
-	var/list/all_hairs = typesof(/datum/sprite_accessory/hair) - /datum/sprite_accessory/hair
+	var/list/all_hairs = subtypesof(/datum/sprite_accessory/hair)
 	var/list/hairs = list()
 
 	// loop through potential hairs
@@ -170,7 +170,7 @@ Obviously, requires DNA2.
 		M.h_style = new_style
 
 	// facial hair
-	var/list/all_fhairs = typesof(/datum/sprite_accessory/facial_hair) - /datum/sprite_accessory/facial_hair
+	var/list/all_fhairs = subtypesof(/datum/sprite_accessory/facial_hair)
 	var/list/fhairs = list()
 
 	for(var/x in all_fhairs)

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -25,7 +25,7 @@
 	real_name = new_name
 	last_attack = world.time
 	var/list/possible_reagents = list()
-	for(var/type in (typesof(/datum/reagent/blob) - /datum/reagent/blob))
+	for(var/type in subtypesof(/datum/reagent/blob))
 		possible_reagents.Add(new type)
 	blob_reagent_datum = pick(possible_reagents)
 	if(blob_core)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -394,8 +394,7 @@
 	if(!can_buy(50))
 		return
 
-	var/list/excluded = list(/datum/reagent/blob, blob_reagent_datum.type) //guaranteed new chemical
-	var/datum/reagent/blob/B = pick((typesof(/datum/reagent/blob) - excluded))
+	var/datum/reagent/blob/B = pick((subtypesof(/datum/reagent/blob) - blob_reagent_datum.type))
 	blob_reagent_datum = new B
 
 	for(var/obj/effect/blob/BL in blobs)

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -166,8 +166,8 @@ var/global/datum/controller/gameticker/ticker
 				world << "<h4>[holiday.greet()]</h4>"
 
 	spawn(0) // Forking dynamic room selection
-		var/list/area/dynamic/source/available_source_candidates = typesof(/area/dynamic/source) - /area/dynamic/source
-		var/list/area/dynamic/destination/available_destination_candidates = typesof(/area/dynamic/destination) - /area/dynamic/destination
+		var/list/area/dynamic/source/available_source_candidates = subtypesof(/area/dynamic/source)
+		var/list/area/dynamic/destination/available_destination_candidates = subtypesof(/area/dynamic/destination)
 
 		for (var/area/dynamic/destination/current_destination_candidate in available_destination_candidates)
 			var/area/dynamic/destination/current_destination = locate(current_destination_candidate)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -393,7 +393,7 @@ rcd light flash thingy on matter drain
 	var/list/possible_modules = list()
 
 /datum/module_picker/New()
-	for(var/type in typesof(/datum/AI_Module))
+	for(var/type in subtypesof(/datum/AI_Module))
 		var/datum/AI_Module/AM = new type
 		if(AM.power_type != null)
 			src.possible_modules += AM

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -89,7 +89,7 @@ datum/game_mode/mutiny
 
 	proc/get_directive_candidates()
 		var/list/candidates[0]
-		for(var/T in (typesof(/datum/directive) - /datum/directive))
+		for(var/T in subtypesof(/datum/directive))
 			var/datum/directive/D = new T(src)
 //			world << D.name
 			if (D.meets_prerequisites())

--- a/code/game/gamemodes/newobjective.dm
+++ b/code/game/gamemodes/newobjective.dm
@@ -12,11 +12,10 @@
 /proc/GenerateTheft(var/job,var/datum/mind/traitor)
 	var/list/datum/objective/objectives = list()
 
-	for(var/o in typesof(/datum/objective/steal))
-		if(o != /datum/objective/steal)		//Make sure not to get a blank steal objective.
-			var/datum/objective/target = new o(null,job)
-			objectives += target
-			objectives[target] = target.weight
+	for(var/o in subtypesof(/datum/objective/steal))
+		var/datum/objective/target = new o(null,job)
+		objectives += target
+		objectives[target] = target.weight
 	return objectives
 
 /proc/GenerateAssassinate(var/job,var/datum/mind/traitor)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1,8 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 var/global/list/all_objectives = list()
 
-var/list/potential_theft_objectives=typesof(/datum/theft_objective) \
-	- /datum/theft_objective \
+var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 	- /datum/theft_objective/special \
 	- /datum/theft_objective/number \
 	- /datum/theft_objective/number/special \
@@ -722,7 +721,7 @@ datum/objective/destroy
 		survivecult
 			var/num_cult
 			var/cult_needed = 4 + round((num_players_started() / 10))
-			
+
 			explanation_text = "Our knowledge must live on. Make sure at least [cult_needed] acolytes escape on the shuttle to spread their work on an another station."
 
 			check_completion()
@@ -747,11 +746,11 @@ datum/objective/destroy
 			proc/find_target() //I don't know how to make it work with the rune otherwise, so I'll do it via a global var, sacrifice_target, defined in rune15.dm
 				var/datum/game_mode/cult/C = ticker.mode
 				var/list/possible_targets = C.get_unconvertables()
-				
+
 				if(!possible_targets.len)
 					for(var/mob/living/carbon/human/player in player_list)
 						if(player.mind && !(player.mind in cult))
-							possible_targets += player.mind				
+							possible_targets += player.mind
 
 				if(possible_targets.len > 0)
 					sacrifice_target = pick(possible_targets)

--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -107,7 +107,7 @@ datum/hSB
 					hsb.loc = usr.loc
 					usr << "<b>Sandbox:  Created an airlock."
 				if("hsbcanister")
-					var/list/hsbcanisters = typesof(/obj/machinery/portable_atmospherics/canister/) - /obj/machinery/portable_atmospherics/canister/
+					var/list/hsbcanisters = subtypesof(/obj/machinery/portable_atmospherics/canister/)
 					var/hsbcanister = input(usr, "Choose a canister to spawn.", "Sandbox:") in hsbcanisters + "Cancel"
 					if(!(hsbcanister == "Cancel"))
 						new hsbcanister(usr.loc)

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -366,7 +366,7 @@
 
 /obj/item/weapon/spellbook/New()
 	..()
-	var/entry_types = typesof(/datum/spellbook_entry) - /datum/spellbook_entry - /datum/spellbook_entry/item - /datum/spellbook_entry/summon
+	var/entry_types = subtypesof(/datum/spellbook_entry) - /datum/spellbook_entry/item - /datum/spellbook_entry/summon
 	for(var/T in entry_types)
 		var/datum/spellbook_entry/E = new T
 		if(E.IsAvailible())

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -485,8 +485,8 @@
 
 /proc/get_all_jobs()
 	var/list/all_jobs = list()
-	var/list/all_datums = typesof(/datum/job)
-	all_datums.Remove(list(/datum/job,/datum/job/ai,/datum/job/cyborg))
+	var/list/all_datums = subtypesof(/datum/job)
+	all_datums.Remove(list(/datum/job/ai,/datum/job/cyborg))
 	var/datum/job/jobdatum
 	for(var/jobtype in all_datums)
 		jobdatum = new jobtype

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -16,7 +16,7 @@ var/global/datum/controller/occupations/job_master
 	proc/SetupOccupations(var/list/faction = list("Station"))
 		if(no_synthetic)
 			occupations = list()
-			var/list/all_jobs = typesof(/datum/job) -list(/datum/job,/datum/job/ai,/datum/job/cyborg)
+			var/list/all_jobs = subtypesof(/datum/job) -list(/datum/job/ai,/datum/job/cyborg)
 			if(!all_jobs.len)
 				world << "\red \b Error setting up jobs, no job datums found"
 				return 0
@@ -27,7 +27,7 @@ var/global/datum/controller/occupations/job_master
 				occupations += job
 		else
 			occupations = list()
-			var/list/all_jobs = typesof(/datum/job) -/datum/job
+			var/list/all_jobs = subtypesof(/datum/job)
 			if(!all_jobs.len)
 				world << "\red \b Error setting up jobs, no job datums found"
 				return 0
@@ -231,8 +231,8 @@ var/global/datum/controller/occupations/job_master
 				AssignRole(mAI.current, "AI")
 				ai_selected++
 			if(ai_selected)	return 1
-			return 0		
-		
+			return 0
+
 		for(var/i = job.total_positions, i > 0, i--)
 			for(var/level = 1 to 3)
 				var/list/candidates = list()

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -57,7 +57,7 @@
 
 /obj/machinery/computer/arcade/New()
 	..()
-	var/choice = pick(typesof(/obj/machinery/computer/arcade) - /obj/machinery/computer/arcade)
+	var/choice = pick(subtypesof(/obj/machinery/computer/arcade))
 	new choice(loc)
 	qdel(src)
 

--- a/code/game/machinery/kitchen/kitchen_machine.dm
+++ b/code/game/machinery/kitchen/kitchen_machine.dm
@@ -38,7 +38,7 @@
 		available_recipes = new
 		acceptable_items = new
 		acceptable_reagents = new
-		for (var/type in (typesof(recipe_type)-recipe_type))
+		for (var/type in subtypesof(recipe_type))
 			var/datum/recipe/recipe = new type
 			if(recipe.result) // Ignore recipe subtypes that lack a result
 				available_recipes += recipe

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -109,7 +109,7 @@
 //END RECIPE DATUMS
 
 /obj/machinery/processor/proc/select_recipe(var/X)
-	for (var/Type in typesof(/datum/food_processor_process) - /datum/food_processor_process - /datum/food_processor_process/mob)
+	for (var/Type in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
 		var/datum/food_processor_process/P = new Type()
 		if(istype(X, /obj/item/weapon/reagent_containers/food/snacks/grown))
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/G = X

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -5,7 +5,7 @@
 	name = "Random Toy"
 	New()
 		..()
-		var/list/types = list(/obj/item/toy/crossbow,/obj/item/toy/balloon,/obj/item/toy/spinningtoy,/obj/item/weapon/reagent_containers/spray/waterflower) + typesof(/obj/item/toy/prize) - /obj/item/toy/prize
+		var/list/types = list(/obj/item/toy/crossbow,/obj/item/toy/balloon,/obj/item/toy/spinningtoy,/obj/item/weapon/reagent_containers/spray/waterflower) + subtypesof(/obj/item/toy/prize)
 		var/T = pick(types)
 		new T(loc)
 		spawn(1)
@@ -19,7 +19,7 @@
 	name = "Random Mess"
 	New()
 		..()
-		var/list/list = typesof(/obj/effect/decal/cleanable) - list(/obj/effect/decal/cleanable,/obj/effect/decal/cleanable/random,/obj/effect/decal/cleanable/cobweb,/obj/effect/decal/cleanable/cobweb2)
+		var/list/list = subtypesof(/obj/effect/decal/cleanable) - list(/obj/effect/decal/cleanable/random,/obj/effect/decal/cleanable/cobweb,/obj/effect/decal/cleanable/cobweb2)
 		var/T = pick(list)
 		new T(loc)
 		spawn(0)

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -20,7 +20,7 @@
 
 
 //filling the barsigns list
-	for(var/bartype in typesof(/datum/barsign) - /datum/barsign)
+	for(var/bartype in subtypesof(/datum/barsign))
 		var/datum/barsign/signinfo = new bartype
 		if(!signinfo.hidden)
 			barsigns += signinfo

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -160,7 +160,7 @@ var/list/mechtoys = list(
 
 	//Supply shuttle ticker - handles supply point regeneration and shuttle travelling between centcomm and the station
 	proc/process()
-		for(var/typepath in (typesof(/datum/supply_packs) - /datum/supply_packs))
+		for(var/typepath in subtypesof(/datum/supply_packs))
 			var/datum/supply_packs/P = new typepath()
 			if(P.name == "HEADER")
 				qdel(P)

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -179,7 +179,7 @@
 					if("turf-reference")
 						master.buildmode.valueholder = input(usr,"Enter variable value:" ,"Value") as turf in world
 			if(AREA_BUILDMODE)
-				var/list/gen_paths = typesof(/datum/mapGenerator) - /datum/mapGenerator
+				var/list/gen_paths = subtypesof(/datum/mapGenerator)
 
 				var/type = input(usr,"Select Generator Type","Type") as null|anything in gen_paths
 				if(!type)	return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -395,8 +395,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	set name = "Del-All"
 
 	// to prevent REALLY stupid deletions
-	var/blocked = list(/obj, /mob, /mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
-	var/hsbitem = input(usr, "Choose an object to delete.", "Delete:") as null|anything in typesof(/obj) + typesof(/mob) - blocked
+	var/blocked = list(/mob/living, /mob/living/carbon, /mob/living/carbon/human, /mob/dead, /mob/dead/observer, /mob/living/silicon, /mob/living/silicon/robot, /mob/living/silicon/ai)
+	var/hsbitem = input(usr, "Choose an object to delete.", "Delete:") as null|anything in subtypesof(/obj) + subtypesof(/mob) - blocked
 	if(hsbitem)
 		for(var/atom/O in world)
 			if(istype(O, hsbitem))

--- a/code/modules/atmos_automation/statements.dm
+++ b/code/modules/atmos_automation/statements.dm
@@ -1,4 +1,4 @@
-var/global/automation_types=typesof(/datum/automation) - /datum/automation
+var/global/automation_types = subtypesof(/datum/automation)
 
 #define AUTOM_RT_NULL    0
 #define AUTOM_RT_NUM     1

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -2,7 +2,7 @@ var/list/spawntypes = list()
 
 /proc/populate_spawn_points()
 	spawntypes = list()
-	for(var/type in typesof(/datum/spawnpoint)-/datum/spawnpoint)
+	for(var/type in subtypesof(/datum/spawnpoint))
 		var/datum/spawnpoint/S = new type()
 		spawntypes[S.display_name] = S
 

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -11,11 +11,11 @@
 
 	New()
 		..()
-		for(var/U in typesof(/obj/item/clothing/under/color)-(/obj/item/clothing/under/color))
+		for(var/U in subtypesof(/obj/item/clothing/under/color))
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
 
-		for(var/U in typesof(/obj/item/clothing/under/rank)-(/obj/item/clothing/under/rank))
+		for(var/U in subtypesof(/obj/item/clothing/under/rank))
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
 		return

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -3,8 +3,8 @@
 
 /obj/item/clothing/under/color/random/New()
 	..()
-	var/list/excluded = list(/obj/item/clothing/under/color/random, /obj/item/clothing/under/color, /obj/item/clothing/under/color/blackf, /obj/item/clothing/under/color/blue/dodgeball, /obj/item/clothing/under/color/orange/prison, /obj/item/clothing/under/color/red/dodgeball, /obj/item/clothing/under/color/red/jersey, /obj/item/clothing/under/color/blue/jersey)
-	var/obj/item/clothing/under/color/C = pick(typesof(/obj/item/clothing/under/color) - excluded)
+	var/list/excluded = list(/obj/item/clothing/under/color/random, /obj/item/clothing/under/color/blackf, /obj/item/clothing/under/color/blue/dodgeball, /obj/item/clothing/under/color/orange/prison, /obj/item/clothing/under/color/red/dodgeball, /obj/item/clothing/under/color/red/jersey, /obj/item/clothing/under/color/blue/jersey)
+	var/obj/item/clothing/under/color/C = pick(subtypesof(/obj/item/clothing/under/color) - excluded)
 	name = initial(C.name)
 	icon_state = initial(C.icon_state)
 	item_state = initial(C.item_state)

--- a/code/modules/computer3/test_machines.dm
+++ b/code/modules/computer3/test_machines.dm
@@ -82,5 +82,5 @@
 /obj/item/weapon/storage/box/testing_disks
 	New()
 		..()
-		for(var/typekey in typesof(/obj/item/weapon/disk/file) - /obj/item/weapon/disk/file)
+		for(var/typekey in subtypesof(/obj/item/weapon/disk/file))
 			new typekey(src)

--- a/code/modules/economy/Economy.dm
+++ b/code/modules/economy/Economy.dm
@@ -89,7 +89,7 @@ var/setup_economy = 0
 	newChannel.is_admin_channel = 1
 	news_network.network_channels += newChannel
 
-	for(var/loc_type in typesof(/datum/trade_destination) - /datum/trade_destination)
+	for(var/loc_type in subtypesof(/datum/trade_destination))
 		var/datum/trade_destination/D = new loc_type
 		weighted_randomevent_locations[D] = D.viable_random_events.len
 		weighted_mundaneevent_locations[D] = D.viable_mundane_events.len

--- a/code/modules/events/event_manager.dm
+++ b/code/modules/events/event_manager.dm
@@ -22,7 +22,7 @@
 	var/datum/event_meta/new_event = new
 
 /datum/event_manager/New()
-	allEvents = typesof(/datum/event) - /datum/event
+	allEvents = subtypesof(/datum/event)
 
 /datum/event_manager/proc/process()
 	for(var/datum/event/E in event_manager.active_events)

--- a/code/modules/food/oven.dm
+++ b/code/modules/food/oven.dm
@@ -58,7 +58,7 @@
 /obj/machinery/cooking/oven/updatefood()
 	for(var/U in food_choices)
 		food_choices.Remove(U)
-	for(var/U in typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable/cook)-(/obj/item/weapon/reagent_containers/food/snacks/customizable/cook))
+	for(var/U in subtypesof(/obj/item/weapon/reagent_containers/food/snacks/customizable/cook))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/V = new U
 		src.food_choices += V
 	return
@@ -73,7 +73,7 @@
 /obj/machinery/cooking/candy/updatefood()
 	for(var/U in food_choices)
 		food_choices.Remove(U)
-	for(var/U in typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable/candy)-(/obj/item/weapon/reagent_containers/food/snacks/customizable/candy))
+	for(var/U in subtypesof(/obj/item/weapon/reagent_containers/food/snacks/customizable/candy))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/V = new U
 		src.food_choices += V
 	return

--- a/code/modules/genetics/side_effects.dm
+++ b/code/modules/genetics/side_effects.dm
@@ -77,7 +77,7 @@
 proc/trigger_side_effect(mob/living/carbon/human/H)
 	spawn
 		if(!istype(H)) return
-		var/tp = pick(typesof(/datum/genetics/side_effect) - /datum/genetics/side_effect)
+		var/tp = pick(subtypesof(/datum/genetics/side_effect))
 		var/datum/genetics/side_effect/S = new tp
 
 		S.start(H)

--- a/code/modules/genetics2/genetree.dm
+++ b/code/modules/genetics2/genetree.dm
@@ -9,7 +9,7 @@
 /datum/genetree/New(var/obj/machinery/networked/biomass_controller/holder)
 	biomass = holder
 	// Build list of all sectors
-	for(var/typepath in typesof(/datum/genetic_sector) - /datum/genetic_sector)
+	for(var/typepath in subtypesof(/datum/genetic_sector))
 		var/datum/genetic_sector/sector = new typepath
 		sectors[sector.id]=sector
 

--- a/code/modules/holiday/holiday.dm
+++ b/code/modules/holiday/holiday.dm
@@ -328,7 +328,7 @@
 	if(!check_rights(R_SERVER))	return
 
 	var/list/choice = list()
-	for(var/H in typesof(/datum/holiday) - /datum/holiday)
+	for(var/H in subtypesof(/datum/holiday))
 		choice += "[H]"
 
 	choice += "--CANCEL--"

--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -71,7 +71,7 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 			plant_product_sprites |= copytext(icostate,1,split)
 
 	// Populate the global seed datum list.
-	for(var/type in typesof(/datum/seed)-/datum/seed)
+	for(var/type in subtypesof(/datum/seed))
 		var/datum/seed/S = new type
 		seeds[S.name] = S
 		S.uid = "[seeds.len]"

--- a/code/modules/jungle/jungle_animals.dm
+++ b/code/modules/jungle/jungle_animals.dm
@@ -8,7 +8,7 @@
 
 /obj/effect/landmark/animal_spawner/New()
 	if(!spawn_type)
-		var/new_type = pick(typesof(/obj/effect/landmark/animal_spawner) - /obj/effect/landmark/animal_spawner)
+		var/new_type = pick(subtypesof(/obj/effect/landmark/animal_spawner))
 		new new_type(get_turf(src))
 		qdel(src)
 

--- a/code/modules/jungle/jungle_temple.dm
+++ b/code/modules/jungle/jungle_temple.dm
@@ -95,7 +95,7 @@
 					var/amount = rand(2,6)
 					var/quantity = rand(10,50)
 					var/list/possible_spawns = list()
-					for(var/bar_type in typesof(/obj/item/stack/sheet/mineral) - /obj/item/stack/sheet/mineral - /obj/item/stack/sheet/mineral/enruranium)
+					for(var/bar_type in subtypesof(/obj/item/stack/sheet/mineral) - /obj/item/stack/sheet/mineral/enruranium)
 						possible_spawns += bar_type
 
 					var/bar_type = pick(possible_spawns)

--- a/code/modules/mining/materials.dm
+++ b/code/modules/mining/materials.dm
@@ -13,7 +13,7 @@
 	var/list/datum/material/storage[0]
 
 /datum/materials/New()
-	for(var/matdata in typesof(/datum/material) - /datum/material)
+	for(var/matdata in subtypesof(/datum/material))
 		var/datum/material/mat = new matdata
 		storage[mat.id]=mat
 

--- a/code/modules/mining/minerals.dm
+++ b/code/modules/mining/minerals.dm
@@ -2,7 +2,7 @@ var/list/name_to_mineral
 
 proc/SetupMinerals()
 	name_to_mineral = list()
-	for(var/type in typesof(/mineral) - /mineral)
+	for(var/type in subtypesof(/mineral))
 		var/mineral/new_mineral = new type
 		if(!new_mineral.name)
 			continue

--- a/code/modules/mining/surprise.dm
+++ b/code/modules/mining/surprise.dm
@@ -3,7 +3,7 @@
 
 #define TURF_FLOOR 0
 #define TURF_WALL 1
-var/global/list/mining_surprises = typesof(/mining_surprise)-/mining_surprise
+var/global/list/mining_surprises = subtypesof(/mining_surprise)
 
 /surprise_turf_info
 	var/list/types[0]

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -15,7 +15,7 @@ var/global/list/pai_software_by_key = list()
 var/global/list/default_pai_software = list()
 /hook/startup/proc/populate_pai_software_list()
 	var/r = 1 // I would use ., but it'd sacrifice runtime detection
-	for(var/type in typesof(/datum/pai_software) - /datum/pai_software)
+	for(var/type in subtypesof(/datum/pai_software))
 		var/datum/pai_software/P = new type()
 		if(pai_software_by_key[P.id])
 			var/datum/pai_software/O = pai_software_by_key[P.id]

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -110,7 +110,7 @@
 		if(0)  laws = new /datum/ai_laws/asimov()
 		if(1)  laws = new /datum/ai_laws/custom()
 		if(2)
-			var/datum/ai_laws/lawtype = pick(typesof(/datum/ai_laws/default) - /datum/ai_laws/default)
+			var/datum/ai_laws/lawtype = pick(subtypesof(/datum/ai_laws/default))
 			laws = new lawtype()
 
 /mob/living/silicon/robot/proc/statelaws() // -- TLE
@@ -200,4 +200,4 @@
 
 	list += {"<br><br><A href='byond://?src=\ref[src];laws=1'>State Laws</A>"}
 
-	usr << browse(list, "window=laws")			
+	usr << browse(list, "window=laws")

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -18,7 +18,7 @@ datum
 			//I dislike having these here but map-objects are initialised before world/New() is called. >_>
 			if(!chemical_reagents_list)
 				//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
-				var/paths = typesof(/datum/reagent) - /datum/reagent
+				var/paths = subtypesof(/datum/reagent)
 				chemical_reagents_list = list()
 				for(var/path in paths)
 					var/datum/reagent/D = new path()
@@ -29,7 +29,7 @@ datum
 				// For example:
 				// chemical_reaction_list["plasma"] is a list of all reactions relating to plasma
 
-				var/paths = typesof(/datum/chemical_reaction) - /datum/chemical_reaction
+				var/paths = subtypesof(/datum/chemical_reaction)
 				chemical_reactions_list = list()
 
 				for(var/path in paths)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -555,7 +555,7 @@ datum
 			required_other = 1
 			on_reaction(var/datum/reagents/holder)
 
-				var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - /obj/item/weapon/reagent_containers/food/snacks
+				var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/snacks)
 				// BORK BORK BORK
 
 				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -582,7 +582,7 @@ datum
 			required_other = 1
 			on_reaction(var/datum/reagents/holder)
 
-				var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/drinks) - /obj/item/weapon/reagent_containers/food/drinks
+				var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
 				// BORK BORK BORK
 
 				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -888,7 +888,7 @@ datum
 			required_other = 1
 			on_reaction(var/datum/reagents/holder)
 				feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-				var/list/paints = typesof(/obj/item/weapon/reagent_containers/glass/paint) - /obj/item/weapon/reagent_containers/glass/paint
+				var/list/paints = subtypesof(/obj/item/weapon/reagent_containers/glass/paint)
 				var/chosen = pick(paints)
 				var/obj/P = new chosen
 				if(P)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -57,7 +57,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 /obj/machinery/computer/rdconsole/proc/CallTechName(var/ID) //A simple helper proc to find the name of a tech with a given ID.
 	var/datum/tech/check_tech
 	var/return_name = null
-	for(var/T in typesof(/datum/tech) - /datum/tech)
+	for(var/T in subtypesof(/datum/tech))
 		check_tech = null
 		check_tech = new T()
 		if(check_tech.id == ID)
@@ -91,7 +91,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if("clown")
 				return_name = "Bananium"
 	else
-		for(var/R in typesof(/datum/reagent) - /datum/reagent)
+		for(var/R in subtypesof(/datum/reagent))
 			temp_reagent = null
 			temp_reagent = new R()
 			if(temp_reagent.id == ID)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -53,9 +53,9 @@ research holder datum.
 	var/list/known_designs = list()			//List of available designs (at base reliability).
 
 /datum/research/New()		//Insert techs into possible_tech here. Known_tech automatically updated.
-	for(var/T in typesof(/datum/tech) - /datum/tech)
+	for(var/T in subtypesof(/datum/tech))
 		possible_tech += new T(src)
-	for(var/D in typesof(/datum/design) - /datum/design)
+	for(var/D in subtypesof(/datum/design))
 		possible_designs += new D(src)
 	RefreshResearch()
 
@@ -140,7 +140,7 @@ research holder datum.
 						D.reliability = min(100, D.reliability + rand(1,3))
 						if(I.crit_fail)
 							D.reliability = min(100, D.reliability + rand(3, 5))
-							
+
 /datum/research/proc/FindDesignByID(var/id)
 	for(var/datum/design/D in known_designs)
 		if(D.id == id)
@@ -148,9 +148,9 @@ research holder datum.
 
 //Autolathe files
 /datum/research/autolathe/New()
-	for(var/T in (typesof(/datum/tech) - /datum/tech))
+	for(var/T in subtypesof(/datum/tech))
 		possible_tech += new T(src)
-	for(var/path in typesof(/datum/design) - /datum/design)
+	for(var/path in subtypesof(/datum/design))
 		var/datum/design/D = new path(src)
 		possible_designs += D
 		if((D.build_type & AUTOLATHE) && ("initial" in D.category))  //autolathe starts without hacked designs
@@ -278,7 +278,7 @@ datum/tech/robotics
 /obj/item/weapon/disk/tech_disk/New()
 	src.pixel_x = rand(-5.0, 5)
 	src.pixel_y = rand(-5.0, 5)
-	
+
 /obj/item/weapon/disk/design_disk
 	name = "Component Design Disk"
 	desc = "A disk for storing device design data for construction in lathes."

--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -72,12 +72,12 @@ var/list/valid_secondary_effect_types = list(\
 	..()
 
 	//setup primary effect - these are the main ones (mixed)
-	var/effecttype = pick(typesof(/datum/artifact_effect) - /datum/artifact_effect)
+	var/effecttype = pick(subtypesof(/datum/artifact_effect))
 	my_effect = new effecttype(src)
 
 	//75% chance to have a secondary stealthy (and mostly bad) effect
 	if(prob(75))
-		effecttype = pick(typesof(/datum/artifact_effect) - /datum/artifact_effect)
+		effecttype = pick(subtypesof(/datum/artifact_effect))
 		secondary_effect = new effecttype(src)
 		if(prob(75))
 			secondary_effect.ToggleActivate(0)

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -324,8 +324,7 @@
 			apply_image_decorations = 0
 			apply_material_decorations = 0
 		if(24)
-			var/list/possible_spawns = typesof(/obj/item/weapon/stock_parts)
-			possible_spawns -= /obj/item/weapon/stock_parts
+			var/list/possible_spawns = subtypesof(/obj/item/weapon/stock_parts)
 			possible_spawns -= /obj/item/weapon/stock_parts/subspace
 
 			var/new_type = pick(possible_spawns)

--- a/code/modules/store/store.dm
+++ b/code/modules/store/store.dm
@@ -25,7 +25,7 @@ var/global/datum/store/centcomm_store=new
 	var/obj/machinery/account_database/linked_db
 
 /datum/store/New()
-	for(var/itempath in typesof(/datum/storeitem) - /datum/storeitem/)
+	for(var/itempath in subtypesof(/datum/storeitem))
 		items += new itempath()
 
 /datum/store/proc/charge(var/datum/mind/mind,var/amount,var/datum/storeitem/item)

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -15,7 +15,7 @@
 
 /datum/disease2/effectholder/proc/getrandomeffect(var/badness = 1)
 	var/list/datum/disease2/effect/list = list()
-	for(var/e in (typesof(/datum/disease2/effect) - /datum/disease2/effect))
+	for(var/e in subtypesof(/datum/disease2/effect))
 		var/datum/disease2/effect/f = new e
 		if (f.badness > badness)	//we don't want such strong effects
 			continue


### PR DESCRIPTION
It returns a list containing all subtypes of the object path given to it, but not the object path itself. This only exists because typesof(/obj/item/thing) - /obj/item/thing is ugly as sin, and is used often for objects that have a base type which is abstract, but have non-abstract children.

Also adds a "/" to the start of a lot of the list helper procs that did not start with one.

DNM, planning to go through and look for instances that this can replace.