### PR TITLE
Removes explosion immunity from chameleon projector

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -115,9 +115,10 @@
 		M << "<span class='danger'>Your chameleon-projector deactivates.</span>"
 	master.disrupt()
 
-/obj/effect/dummy/chameleon/ex_act() //ok now THATS some serious protection against explosions right here
+/obj/effect/dummy/chameleon/ex_act(var/severity) //no longer bomb-proof
 	for(var/mob/M in src)
 		M << "<span class='danger'>Your chameleon-projector deactivates.</span>"
+		M.ex_act(severity)
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/bullet_act()

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -118,7 +118,8 @@
 /obj/effect/dummy/chameleon/ex_act(var/severity) //no longer bomb-proof
 	for(var/mob/M in src)
 		M << "<span class='danger'>Your chameleon-projector deactivates.</span>"
-		M.ex_act(severity)
+		spawn()
+			M.ex_act(severity)
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/bullet_act()


### PR DESCRIPTION
Being disguised via chameleon projector will no longer cause the user to shrug off even the nastiest of explosions. The explosion will now break the illusion AND cause the appropriate strength ex_act on the user.
- All other functionality is unchanged, so it still lets you dodge bullets and so forth.