### PR TITLE
Changes CMO Hypospray on red team to combat stims

### DIFF
--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -479,7 +479,7 @@ var/send_emergency_team
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/surgery(M), slot_in_backpack)
 			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun(M), slot_in_backpack)
 
-			M.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/hypospray/CMO(M), slot_l_store)
+			M.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/hypospray/combat/nanites(src), slot_l_store)
 			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
 
 		if("Commander")


### PR DESCRIPTION
The hypospray is unable to be used on the other ERT members, this usually results in them getting destroyed then yelling at the medic for healing, all the while the medic is useless because of hardsuits.