### PR TITLE
Fix xeno icons getting stuck due to impossible check

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -45,7 +45,7 @@
 		icon_state = "alien[caste]_leap"
 		pixel_x = -32
 		pixel_y = -32
-	else if(icon == 'icons/mob/alienleap.dmi' && icon_state == "alien[caste]_leap" && pixel_x == -32 && pixel_y == -32)
+	else if(icon == 'icons/mob/alienleap.dmi' && pixel_x == -32 && pixel_y == -32)
 		icon = initial(icon)// ^ this looks odd, but in theory it will prevent the icon and pixel_xy from being reset unless it needs to be
 		pixel_x = initial(pixel_x)
 		pixel_y = initial(pixel_y)


### PR DESCRIPTION
The icon_state check here was too much, because icon_state is handled and set already before it gets to this check.

Should fix invisible xenos after leaping.