### PR TITLE
Process Scheduler Tweaks

### DIFF
--- a/code/controllers/Processes/air.dm
+++ b/code/controllers/Processes/air.dm
@@ -32,30 +32,32 @@ var/global/datum/controller/process/air_system/air_master
 	current_cycle++
 	process_active_turfs()
 	process_excited_groups()
-	scheck()
 	process_high_pressure_delta()
 	process_hotspots()
 	process_super_conductivity()
-	scheck()
 	return 1
 
 /datum/controller/process/air_system/proc/process_hotspots()
 	for(var/obj/effect/hotspot/H in hotspots)
 		H.process()
+		scheck()
 
 /datum/controller/process/air_system/proc/process_super_conductivity()
 	for(var/turf/simulated/T in active_super_conductivity)
 		T.super_conduct()
+		scheck()
 
 /datum/controller/process/air_system/proc/process_high_pressure_delta()
 	for(var/turf/T in high_pressure_delta)
 		T.high_pressure_movements()
 		T.pressure_difference = 0
+		scheck()
 	high_pressure_delta.len = 0
 
 /datum/controller/process/air_system/proc/process_active_turfs()
 	for(var/turf/simulated/T in active_turfs)
 		T.process_cell()
+		scheck()
 
 /datum/controller/process/air_system/proc/remove_from_active(var/turf/simulated/T)
 	if(istype(T))
@@ -104,9 +106,11 @@ var/global/datum/controller/process/air_system/air_master
 		EG.breakdown_cooldown ++
 		if(EG.breakdown_cooldown == 10)
 			EG.self_breakdown()
+			scheck()
 			return
 		if(EG.breakdown_cooldown > 20)
 			EG.dismantle()
+		scheck()
 
 /datum/controller/process/air_system/proc/setup_overlays()
 	plmaster = new /obj/effect/overlay()

--- a/code/controllers/Processes/garbage.dm
+++ b/code/controllers/Processes/garbage.dm
@@ -7,4 +7,3 @@
 
 /datum/controller/process/garbage/doWork()
 	garbageCollector.process()
-	scheck()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -11,7 +11,8 @@ obj/machinery/door/airlock
 obj/machinery/door/airlock/process()
 	..()
 	if (arePowerSystemsOn())
-		execute_current_command()
+		spawn()
+			execute_current_command()
 
 obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 	if (!arePowerSystemsOn()) return //no power
@@ -30,7 +31,7 @@ obj/machinery/door/airlock/proc/execute_current_command()
 
 	if (!cur_command)
 		return
-	
+
 	do_command(cur_command)
 	if (command_completed(cur_command))
 		cur_command = null
@@ -63,7 +64,7 @@ obj/machinery/door/airlock/proc/do_command(var/command)
 
 			lock()
 			sleep(2)
-	
+
 	send_status()
 
 obj/machinery/door/airlock/proc/command_completed(var/command)
@@ -85,7 +86,7 @@ obj/machinery/door/airlock/proc/command_completed(var/command)
 
 		if("secure_close")
 			return (locked && density)
-	
+
 	return 1	//Unknown command. Just assume it's completed.
 
 obj/machinery/door/airlock/proc/send_status(var/bumped = 0)
@@ -97,7 +98,7 @@ obj/machinery/door/airlock/proc/send_status(var/bumped = 0)
 
 		signal.data["door_status"] = density?("closed"):("open")
 		signal.data["lock_status"] = locked?("locked"):("unlocked")
-		
+
 		if (bumped)
 			signal.data["bumped_with_access"] = 1
 


### PR DESCRIPTION
@Krausus  has been inactive of late, so I'm plucking a few things from this PR:https://github.com/ParadiseSS13/Paradise/pull/1540 especially with the strong possiblity of btime changes being slotted in in the near future.

What this PR does:

- Makes LINDA properly scheck()
- Removes useless GC scheck()
- Fixes sleeping airlocks