### PR TITLE
Baton Fixes and Cattleprod Buff

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -68,7 +68,8 @@
 			if(C.maxcharge < hitcost)
 				user << "<span class='notice'>[src] requires a higher capacity cell.</span>"
 				return
-			user.drop_item()
+			if(!user.unEquip(W))
+				return
 			W.loc = src
 			bcell = W
 			user << "<span class='notice'>You install a cell in [src].</span>"
@@ -125,9 +126,9 @@
 							"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
 			return
 	else
-		..()
 		if(status)
 			baton_stun(L, user)
+		..()
 
 
 /obj/item/weapon/melee/baton/proc/baton_stun(mob/living/L, mob/user)
@@ -184,7 +185,6 @@
 	stunforce = 5
 	hitcost = 3750
 	slot_flags = null
-	w_class = 4
 
 /obj/item/weapon/melee/baton/cattleprod/update_icon()
 	if(status)


### PR DESCRIPTION
- fixes a rare runtime with batons
- adds some sanity to dropping a cell with batons
- returns the cattleprod to its original status (can fit in backpacks)

Poll:
![stunem](http://i.gyazo.com/bc61372f7a33b8dc4b379258853d8601.png)