### PR TITLE
Fixes Hologram Runtime

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -115,7 +115,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/proc/clear_holo()
 //	hologram.set_light(0)//Clear lighting.	//handled by the lighting controller when its ower is deleted
-	qdel(hologram)//Get rid of hologram.
+	del(hologram)//Get rid of hologram.
 	if(master.holo == src)
 		master.holo = null
 	master = null//Null the master, since no-one is using it now.


### PR DESCRIPTION
Not the ideal fix, but....our holopad code is ancient and needs to be updated from either Bay or TG---right now qdel'ing this will fill up the runtime log in no time flat.
