### PR TITLE
Shadowling Surgery and Fixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -261,7 +261,7 @@ datum/mind
 			else
 				text += "<a href='?src=\ref[src];vampire=vampire'>yes</a>|<b>NO</b>"
 
-			if(src in ticker.mode.enthralled)
+			if(src in ticker.mode.vampire_enthralled)
 				text += "<b><font color='#FF0000'>YES</font></b>|no"
 			else
 				text += "yes|<font color='#00FF00'>NO</font></b>"

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -166,9 +166,9 @@ Made by Xhuis
 		return 1
 
 /datum/game_mode/proc/remove_thrall(datum/mind/thrall_mind, var/kill = 0)
-	if(!istype(thrall_mind) || !(thrall_mind in thralls) || !isliving(thrall_mind.current))
+	if(!istype(thrall_mind) || !(thrall_mind in shadowling_thralls) || !isliving(thrall_mind.current))
 		return 0 //If there is no mind, the mind isn't a thrall, or the mind's mob isn't alive, return
-	thralls.Remove(thrall_mind)
+	shadowling_thralls.Remove(thrall_mind)
 	thrall_mind.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Dethralled</span>"
 	thrall_mind.special_role = null
 	update_shadow_icons_removed(thrall_mind)
@@ -315,7 +315,7 @@ Made by Xhuis
 						if((I.icon_state == "thrall" || I.icon_state == "shadowling") && I.loc == shadow_mind.current)
 							qdel(I)
 
-		for(var/datum/mind/thrall in thralls)
+		for(var/datum/mind/thrall in shadowling_thralls)
 			if(thrall.current)
 				if(thrall.current.client)
 					for(var/image/I in thrall.current.client.images)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -240,8 +240,8 @@
 
 /obj/effect/proc_holder/spell/wizard/targeted/enthrall/cast(list/targets)
 	var/mob/living/carbon/human/user = usr
-	listclearnulls(ticker.mode.thralls)
-	if(ticker.mode.thralls.len >= 5 && (!istype(user.species, /datum/species/shadow/ling)))
+	listclearnulls(ticker.mode.shadowling_thralls)
+	if(ticker.mode.shadowling_thralls.len >= 5 && (!istype(user.species, /datum/species/shadow/ling)))
 		user << "<span class='warning'>With your telepathic abilities suppressed, your human form will not allow you to enthrall any others. Hatch first.</span>"
 		charge_counter = charge_max
 		return

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -2,8 +2,8 @@
 //They get a traitor objective and a blood sucking objective
 /datum/game_mode
 	var/list/datum/mind/vampires = list()
-	var/list/datum/mind/enthralled = list() //those controlled by a vampire
-	var/list/thralls = list() //vammpires controlling somebody
+	var/list/datum/mind/vampire_enthralled = list() //those controlled by a vampire
+	var/list/vampire_thralls = list() //vammpires controlling somebody
 /datum/game_mode/vampire
 	name = "vampire"
 	config_tag = "vampire"
@@ -124,9 +124,9 @@
 	return 1
 
 /datum/game_mode/proc/auto_declare_completion_enthralled()
-	if(enthralled.len)
+	if(vampire_enthralled.len)
 		var/text = "<FONT size = 2><B>The Enthralled were:</B></FONT>"
-		for(var/datum/mind/Mind in enthralled)
+		for(var/datum/mind/Mind in vampire_enthralled)
 			text += "<br>[Mind.key] was [Mind.name] ("
 			if(Mind.current)
 				if(Mind.current.stat == DEAD)
@@ -386,13 +386,13 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 //prepare for copypaste
 /datum/game_mode/proc/update_vampire_icons_added(datum/mind/vampire_mind)
 	var/ref = "\ref[vampire_mind]"
-	if(ref in thralls)
+	if(ref in vampire_thralls)
 		if(vampire_mind.current)
 			if(vampire_mind.current.client)
 				var/I = image('icons/mob/mob.dmi', loc = vampire_mind.current, icon_state = "vampire")
 				vampire_mind.current.client.images += I
-	for(var/headref in thralls)
-		for(var/datum/mind/t_mind in thralls[headref])
+	for(var/headref in vampire_thralls)
+		for(var/datum/mind/t_mind in vampire_thralls[headref])
 			var/datum/mind/head = locate(headref)
 			if(head)
 				if(head.current)
@@ -409,9 +409,9 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 						t_mind.current.client.images += I
 
 /datum/game_mode/proc/update_vampire_icons_removed(datum/mind/vampire_mind)
-	for(var/headref in thralls)
+	for(var/headref in vampire_thralls)
 		var/datum/mind/head = locate(headref)
-		for(var/datum/mind/t_mind in thralls[headref])
+		for(var/datum/mind/t_mind in vampire_thralls[headref])
 			if(t_mind.current)
 				if(t_mind.current.client)
 					for(var/image/I in t_mind.current.client.images)
@@ -437,9 +437,9 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	if(!istype(head))
 		head = vampire_mind //workaround for removing a thrall's control over the enthralled
 	var/ref = "\ref[head]"
-	if(ref in thralls)
-		thralls[ref] -= vampire_mind
-	enthralled -= vampire_mind
+	if(ref in vampire_thralls)
+		vampire_thralls[ref] -= vampire_mind
+	vampire_enthralled -= vampire_mind
 	vampire_mind.special_role = null
 	update_vampire_icons_removed(vampire_mind)
 	//world << "Removed [vampire_mind.current.name] from vampire shit"

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -305,7 +305,7 @@
 	if(!C.mind)
 		src << "\red [C.name]'s mind is not there for you to enthrall."
 		return 0
-	if(enthrall_safe || ( C.mind in ticker.mode.vampires )||( C.mind.vampire )||( C.mind in ticker.mode.enthralled ))
+	if(enthrall_safe || ( C.mind in ticker.mode.vampires )||( C.mind.vampire )||( C.mind in ticker.mode.vampire_enthralled ))
 		C.visible_message("\red [C] seems to resist the takeover!", "\blue You feel a familiar sensation in your skull that quickly dissipates.")
 		return 0
 	if(!C.vampire_affected(mind))
@@ -320,12 +320,12 @@
 		src << "<b>\red SOMETHING WENT WRONG, YELL AT POMF OR NEXIS</b>"
 		return 0
 	var/ref = "\ref[src.mind]"
-	if(!(ref in ticker.mode.thralls))
-		ticker.mode.thralls[ref] = list(H.mind)
+	if(!(ref in ticker.mode.vampire_thralls))
+		ticker.mode.vampire_thralls[ref] = list(H.mind)
 	else
-		ticker.mode.thralls[ref] += H.mind
-	ticker.mode.enthralled.Add(H.mind)
-	ticker.mode.enthralled[H.mind] = src.mind
+		ticker.mode.vampire_thralls[ref] += H.mind
+	ticker.mode.vampire_enthralled.Add(H.mind)
+	ticker.mode.vampire_enthralled[H.mind] = src.mind
 	H.mind.special_role = "VampThrall"
 	H << "<b>\red You have been Enthralled by [name]. Follow their every command.</b>"
 	src << "\red You have successfully Enthralled [H.name]. <i>If they refuse to do as you say just adminhelp.</i>"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -20,7 +20,7 @@
 	var/mess = 0 //Need to clean out it if it's full of exploded clone.
 	var/attempting = 0 //One clone attempt at a time thanks
 	var/eject_wait = 0 //Don't eject them as soon as they are created fuckkk
-	var/biomass = 0 
+	var/biomass = 0
 	var/speed_coeff
 	var/efficiency
 
@@ -31,7 +31,7 @@
 			set_light(2)
 		else
 			set_light(0)
-		
+
 /obj/machinery/clonepod/biomass
 	biomass = CLONE_BIOMASS
 
@@ -48,7 +48,7 @@
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	RefreshParts()
 	update_icon()
-	
+
 /obj/machinery/clonepod/upgraded/New()
 	..()
 	component_parts = list()
@@ -62,7 +62,7 @@
 	component_parts += new /obj/item/stack/cable_coil(null, 1)
 	biomass = CLONE_BIOMASS
 	RefreshParts()
-	
+
 /obj/machinery/clonepod/Destroy()
 	if(connected)
 		connected.pods -= src
@@ -254,7 +254,7 @@
 		ticker.mode.update_all_cult_icons() //So the icon actually appears
 	if(("\ref[H.mind]" in ticker.mode.implanter) || (H.mind in ticker.mode.implanted))
 		ticker.mode.update_traitor_icons_added(H.mind) //So the icon actually appears
-	if(("\ref[H.mind]" in ticker.mode.thralls) || (H.mind in ticker.mode.enthralled))
+	if(("\ref[H.mind]" in ticker.mode.vampire_thralls) || (H.mind in ticker.mode.vampire_enthralled))
 		ticker.mode.update_vampire_icons_added(H.mind)
 
 	// -- End mode specific stuff
@@ -280,7 +280,7 @@
 		H.h_style = pick("Bedhead", "Bedhead 2", "Bedhead 3") */
 
 	H.set_species(R.dna.species)
-	
+
 	update_icon()
 
 	for(var/datum/language/L in R.languages)
@@ -356,7 +356,7 @@
 		if(panel_open)
 			default_deconstruction_crowbar(W)
 		return
-		
+
 	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
 		if (!src.check_access(W))
 			user << "\red Access Denied."
@@ -399,7 +399,7 @@
 		return
 	else
 		..()
-		
+
 /obj/machinery/clonepod/emag_act(user as mob)
 	if (isnull(src.occupant))
 		return
@@ -466,7 +466,7 @@
 		spawn(5)
 			qdel(src.occupant)
 	return
-	
+
 /obj/machinery/clonepod/update_icon()
 	..()
 	icon_state = "pod_0"

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -256,6 +256,8 @@
 		ticker.mode.update_traitor_icons_added(H.mind) //So the icon actually appears
 	if(("\ref[H.mind]" in ticker.mode.vampire_thralls) || (H.mind in ticker.mode.vampire_enthralled))
 		ticker.mode.update_vampire_icons_added(H.mind)
+ 	if(("\ref[H.mind]" in ticker.mode.shadowling_thralls) || (H.mind in ticker.mode.shadows))
+ 		ticker.mode.update_shadow_icons_added(H.mind)
 
 	// -- End mode specific stuff
 

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -534,8 +534,8 @@
 		if(ticker.mode.vampires.len)
 			dat += check_role_table("Vampires", ticker.mode.vampires, src)
 
-		if(ticker.mode.enthralled.len)
-			dat += check_role_table("Vampire Thralls", ticker.mode.enthralled, src)
+		if(ticker.mode.vampire_enthralled.len)
+			dat += check_role_table("Vampire Thralls", ticker.mode.vampire_enthralled, src)
 
 		if(ticker.mode.xenos.len)
 			dat += check_role_table("Xenos", ticker.mode.xenos, src)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -31,7 +31,7 @@
 				if(mode)
 					mode.update_all_icons()
 			if("vampire")
-				if((ref in ticker.mode.thralls) || (mind in ticker.mode.enthralled))
+				if((ref in ticker.mode.vampire_thralls) || (mind in ticker.mode.vampire_enthralled))
 					ticker.mode.update_vampire_icons_added(mind)
 			if("shadowling")
 				if((mind in ticker.mode.shadowling_thralls) || (mind in ticker.mode.shadows))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -50,7 +50,7 @@
 								 "<span class='warning'><b>You fumble and tear out [target]'s tumor!</span>")
 			ticker.mode.remove_thrall(target.mind,1)
 		else
-			user.visible_message("<span class='warning'>[user] screws up!</span>")
+			user.visible_message("<span class='warning'>[user]'s hand slips and fumbles! Luckily, they didn't damage anything!</span>")
 
 //////////////////////////////////////////////////////////////////
 //					ALIEN EMBRYO SURGERY						//

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -13,6 +13,46 @@
 	return affected && affected.open == (affected.encased ? 3 : 2)
 
 //////////////////////////////////////////////////////////////////
+//					Dethrall Shadowling 						//
+//////////////////////////////////////////////////////////////////
+/datum/surgery_step/internal/dethrall
+	allowed_tools = list(
+	/obj/item/weapon/hemostat = 100,	\
+	/obj/item/weapon/wirecutters = 75,	\
+	/obj/item/weapon/kitchen/utensil/fork = 20
+	)
+
+	min_duration = 120
+	max_duration = 120
+
+	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		if (!hasorgans(target))
+			return
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		return ..() && affected && is_thrall(target) && affected.open == 3 && target_zone == "head"
+
+	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		user.visible_message("[user] begins looking around in [target]'s head.", "<span class='notice'>You begin looking for foreign influences on [target]'s brain...")
+		user << "<span class='warning'>You locate a small, pulsing black tumor on the side of [target]'s brain and begin to remove it.</span>"
+		target << "<span class='boldannounce'>A small part of your head pulses with agony as the light impacts it.</span>"
+		user.visible_message("[user] begins removing something from [target]'s head.</span>", \
+							 "<span class='notice'>You begin carefully extracting the tumor...</span>")
+		..()
+
+	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		user.visible_message("<span class='notice'>[user] carefully extracts the tumor from [target]'s brain!</span>", \
+							 "<span class='notice'>You extract the black tumor from [target]'s head. It quickly shrivels and burns away.</span>")
+		ticker.mode.remove_thrall(target.mind,0)
+
+	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		if(prob(50))
+			user.visible_message("<span class='warning'>[user] slips and rips the tumor out from [target]'s head!</span>", \
+								 "<span class='warning'><b>You fumble and tear out [target]'s tumor!</span>")
+			ticker.mode.remove_thrall(target.mind,1)
+		else
+			user.visible_message("<span class='warning'>[user] screws up!</span>")
+
+//////////////////////////////////////////////////////////////////
 //					ALIEN EMBRYO SURGERY						//
 //////////////////////////////////////////////////////////////////
 /datum/surgery_step/internal/remove_embryo


### PR DESCRIPTION
I don't think it's necessary for this to wait 24 hours, TBH; it can effectively be considered an extension of this: https://github.com/ParadiseSS13/Paradise/pull/1603 Only reason it wasn't implemented there was because @TheDZD was unsure how/if it was even possible under Bay surgery and not because of balance concerns--the feature itself has been mentioned, hand in hand, with that PR, with staff, for quite some time. Another reasoning is that it includes a number of highly critical fixes.

- Adds in shadowling dethralling surgery
 - A long winded surgery that can remove thrall status from a person. The process goes like this:
 - (targeting the head): scalpel->hemostat->retractor->saw->retractor->hemostat (last step takes a long time)
 - If you mess up, there's a 50% chance you'll dethrall the person, but kill them in the process; the other half the time, it'll just inform you that you screwed up.

Fixes

- Fixes not being able to dethrall shadowlings (via admin or IC means)
- Fixes being able to enthrall past the limit without hatching
- Fixes shadowling HUD's not being updated properly when cloned.
- Fixes some other issues with vampire thralls and shadowling thralls sharing the same list
 - I went through and made sure all "thralls" were clearly divided between "vampire_thralls" and "shadowling_thralls" so this isn't as confusing and won't cause problems in the future.

Requesting review by @TheDZD 