### PR TITLE
Removes Away Missions

### DIFF
--- a/_maps/map_files/RandomZLevels/fileList.txt
+++ b/_maps/map_files/RandomZLevels/fileList.txt
@@ -8,16 +8,16 @@
 #DO tick the associated code file for the away mission you are enabling. Otherwise, the map will be trying to reference objects which do not exist, which will cause runtime errors!
 
 #_maps/map_files/RandomZLevels/academy.dmm
-_maps/map_files/RandomZLevels/beach.dmm
+#_maps/map_files/RandomZLevels/beach.dmm
 #_maps/map_files/RandomZLevels/blackmarketpackers.dmm
-_maps/map_files/RandomZLevels/challenge.dmm
+#_maps/map_files/RandomZLevels/challenge.dmm
 #_maps/map_files/RandomZLevels/centcomAway.dmm
 #_maps/map_files/RandomZLevels/clownplanet.dmm
 #_maps/map_files/RandomZLevels/example.dmm
-_maps/map_files/RandomZLevels/listeningpost.dmm
-_maps/map_files/RandomZLevels/moonoutpost19.dmm
+#_maps/map_files/RandomZLevels/listeningpost.dmm
+#_maps/map_files/RandomZLevels/moonoutpost19.dmm
 #_maps/map_files/RandomZLevels/spacebattle.dmm
 #_maps/map_files/RandomZLevels/spacehotel.dmm
 #_maps/map_files/RandomZLevels/stationCollision.dmm
-_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
+#_maps/map_files/RandomZLevels/undergroundoutpost45.dmm
 #_maps/map_files/RandomZLevels/wildwest.dmm

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -40,10 +40,10 @@ datum/controller/game_controller/New()
 
 datum/controller/game_controller/proc/setup()
 	world.tick_lag = config.Ticklag
-
+/*
 	spawn(20)
 		createRandomZlevel()
-
+*/
 	setup_objects()
 	setup_starlight()
 	setupgenetics()


### PR DESCRIPTION
As requested by @Necaladun 

Disables away missions to encourage players to stay on the station more and cut down on powergaming.

Performance standpoint: 
- Cuts down on total instances by roughly 15%, which we were recently poked at by Volundr to address (less processing of atmos/object/etc).
- Game loads up significantly faster

My own two cents? Eh...slightly mixed feelings,but I'm really not sad to see these go.

Side note: 60 days streak for contributing to SS13; I've been doing this way too much.