### PR TITLE
Dismemberment Tweaks

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -29,8 +29,6 @@
 #define ORGAN_ASSISTED   4096
 
 #define DROPLIMB_EDGE 0
-#define DROPLIMB_BLUNT 1
-#define DROPLIMB_BURN 2
 
 #define AGE_MIN 17			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -315,7 +315,7 @@
 				return
 			usr.visible_message("\red [usr] [pick("chomps","bites")] off [the_item]'s [limb]!")
 			playsound(usr.loc, 'sound/items/eatfood.ogg', 50, 0)
-			var/obj/limb_obj=limb.droplimb(0,DROPLIMB_BLUNT)
+			var/obj/limb_obj=limb.droplimb(0,DROPLIMB_EDGE)
 			if(limb_obj)
 				var/obj/item/organ/external/chest=usr:get_organ("chest")
 				chest.implants += limb_obj

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -25,7 +25,7 @@
 		// Only make the limb drop if it's not too damaged
 		if(prob(100 - E.get_damage()))
 			// Override the current limb status and don't cause an explosion
-			E.droplimb(1,pick(DROPLIMB_EDGE,DROPLIMB_BLUNT))
+			E.droplimb(1,DROPLIMB_EDGE)
 
 	if(!(species.flags & IS_SYNTHETIC))
 		flick("gibbed-h", animation)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -208,17 +208,10 @@
 	var/mob/living/carbon/owner_old = owner //Need to update health, but need a reference in case the below check cuts off a limb.
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner)
-		if(!cannot_amputate && config.limbs_can_break && (brute_dam + burn_dam) >= (max_damage * config.organ_health_multiplier))
-			var/dropped
-			if(burn >= 20 && prob(burn / 2))
-				if(body_part == HEAD) return
-				dropped = 1
-				droplimb(0,DROPLIMB_BURN)
-			if(!dropped && prob(brute / 2))
+		if(!cannot_amputate && config.limbs_can_break && (brute_dam) >= (max_damage * config.organ_health_multiplier))
+			if(prob(brute / 2))
 				if(edge)
 					droplimb(0,DROPLIMB_EDGE)
-				else
-					droplimb(0,DROPLIMB_BLUNT)
 
 	if(owner_old) owner_old.updatehealth()
 	return update_icon()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -603,16 +603,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 					"<span class='danger'>\The [owner]'s [src.name] flies off in an arc!</span>",\
 					"<span class='moderate'><b>Your [src.name] goes flying off!</b></span>",\
 					"<span class='danger'>You hear a terrible sound of ripping tendons and flesh.</span>")
-		if(DROPLIMB_BURN)
-			owner.visible_message(
-				"<span class='danger'>\The [owner]'s [src.name] flashes away into ashes!</span>",\
-				"<span class='moderate'><b>Your [src.name] flashes away into ashes!</b></span>",\
-				"<span class='danger'>You hear the crackling sound of burning flesh.</span>")
-		if(DROPLIMB_BLUNT)
-			owner.visible_message(
-				"<span class='danger'>\The [owner]'s [src.name] explodes in a shower of gore!</span>",\
-				"<span class='moderate'><b>Your [src.name] explodes in a shower of gore!</b></span>",\
-				"<span class='danger'>You hear the sickening splatter of gore.</span>")
 
 	var/mob/living/carbon/human/victim = owner //Keep a reference for post-removed().
 	removed(null, ignore_children)
@@ -656,24 +646,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 					throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
 				dir = 2
 			return
-		if(DROPLIMB_BURN)
-			new /obj/effect/decal/cleanable/ash(get_turf(victim))
-			qdel(src)
-		if(DROPLIMB_BLUNT)
-			var/obj/effect/decal/cleanable/blood/gibs/gore = new victim.species.single_gib_type(get_turf(victim))
-			if(victim.species.flesh_color)
-				gore.fleshcolor = victim.species.flesh_color
-			if(victim.species.blood_color)
-				gore.basecolor = victim.species.blood_color
-			gore.update_icon()
-			gore.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
-
-			for(var/obj/item/organ/I in contents)
-				I.loc = loc
-				if(istype(loc,/turf))
-					I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),30)
-			qdel(src)
-
 
 /****************************************************
 			   HELPERS

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -325,7 +325,7 @@
 				if(ishuman(mob))
 					for (var/obj/item/organ/external/E in H.organs)
 						if(pick(1,0))
-							E.droplimb(0,DROPLIMB_BLUNT)
+							E.droplimb(0,DROPLIMB_EDGE)
 			if(3)
 				if(ishuman(mob))
 					if(H.species.name != "Skellington")


### PR DESCRIPTION
After having viewed this for quite a few months and after receiving quite a few complaints about it, going to finally make a PR for this: 

- Removes blunt force trauma dismemberment
 - This is being abused to no end; it makes stealing a brain overly trivial, taking a player out the round (permanently) nothing more than a few whacks, and leads to a lot of incredibly bad RNG scenarios where a light tap insta-kills the other person (punch to the head, for instance) merely because the RNG gods frowned. It also completely screws over IPCs, in a lot of cases.

- Removes burn dismemberment
 - We've all been there; touch a door/get shocked by a vending machine and lose your hand or even your entire arm, then spend the next 15-20 minutes waiting for medbay to replace your arm because of it---similar occurs with getting hit by a laser gun.


Should help reduce the overall RNG nature of high-level combat, while still keeping dismemberment mechanic in-tact where it typically matters (edged things, like knifes and eswords); it should also mean less lucky one-shot kills by bullets that hit the head, as well.