### PR TITLE
Removes Brain Eating

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -14,6 +14,9 @@
 	parent_organ = "head"
 	vital = 1
 
+/obj/item/organ/brain/attack_self(mob/user as mob)
+	return  //let's not have players taken out of the round as easily as a click, once you have their brain.
+
 /obj/item/organ/brain/xeno
 	name = "thinkpan"
 	desc = "It looks kind of like an enormous wad of purple bubblegum."


### PR DESCRIPTION
Disables the ability to convert a brain from an organ to a food container with just a click.

This is just too easy to do, quite frankly---taking a player out of the round, permanently, shouldn't be quite this easy.
