### PR TITLE
Adds Redtext Spans Classes to Staff of Animation

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -262,7 +262,8 @@ proc/wabbajack(mob/living/M)
 				S.icon = change.icon
 				if(H.mind)
 					H.mind.transfer_to(S)
-					S << "You are an animated statue. You cannot move when monitored, but are nearly invincible and deadly when unobserved! Do not harm [firer.name], your creator."
+					S << "<span class='warning'>You are an animated statue. You cannot move when monitored, but are nearly invincible and deadly when unobserved!</span>"
+					S << "<span class='userdanger'>Do not harm [firer.name], your creator.</span>"
 				H = change
 				H.loc = S
 				qdel(src)


### PR DESCRIPTION
Basically, makes sure that people who are turned into a weeping angel because of flesh to stone + staff of animation have no right to use the "I didn't see the message" excuse when they grudgekill the wizard, because the text is now large and red.

tgstation/-tg-station#9569