### PR TITLE
Lightning Bolt Buff

### DIFF
--- a/code/datums/spells/lightning.dm
+++ b/code/datums/spells/lightning.dm
@@ -70,26 +70,17 @@ obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 
 	user.Beam(target,icon_state="lightning",icon='icons/effects/effects.dmi',time=5)
 
-	switch(energy)
-		if(0 to 25)
-			target.electrocute_act(10,"Lightning Bolt")
-			playsound(get_turf(target), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-		if(25 to 75)
-			target.electrocute_act(25,"Lightning Bolt")
-			playsound(get_turf(target), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-		if(75 to 100)
-			//CHAIN LIGHTNING
-			Bolt(user,target,energy,user)
+	Bolt(user,target,max(15,energy/2),5,user) //5 bounces for energy/2 burn
 	Reset(user)
 
-/obj/effect/proc_holder/spell/targeted/lightning/proc/Bolt(mob/origin,mob/target,bolt_energy,mob/user = usr)
+/obj/effect/proc_holder/spell/targeted/lightning/proc/Bolt(mob/origin, mob/target, bolt_energy, bounces, mob/user = usr)
 	origin.Beam(target,icon_state="lightning",icon='icons/effects/effects.dmi',time=5)
 	var/mob/living/carbon/current = target
-	if(bolt_energy < 75)
-		current.electrocute_act(25,"Lightning Bolt")
+	if(bounces < 1)
+		current.electrocute_act(bolt_energy,"Lightning Bolt", def_zone = "chest")
 		playsound(get_turf(current), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 	else
-		current.electrocute_act(25,"Lightning Bolt")
+		current.electrocute_act(bolt_energy,"Lightning Bolt", def_zone = "chest")
 		playsound(get_turf(current), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 		var/list/possible_targets = new
 		for(var/mob/living/M in view_or_range(range,target,"view"))
@@ -100,4 +91,4 @@ obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 			return
 		var/mob/living/next = pick(possible_targets)
 		if(next)
-			Bolt(current,next,bolt_energy-6,user) // 5 max bounces
+			Bolt(current,next,bolt_energy,bounces-1,user) // 5 max bounces

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -72,7 +72,7 @@
 		apply_effect(STUTTER, agony_amount/10)
 		apply_effect(EYE_BLUR, agony_amount/10)
 
-/mob/living/proc/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0)
+/mob/living/proc/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/def_zone = null)
 	  return 0 //only carbon liveforms have this proc
 
 /mob/living/emp_act(severity)


### PR DESCRIPTION
- Now always bounces 5 times (for a total of 6 hits).
- Now always does at least 15 damage per hit, with a maximum of 50 depending on how close to maximum charge it is released.
- Now affects people wearing insulated gloves, tough luck if they're wearing an fully insulated chest-covering armor though.
- Did not port the charge bar, as that requires /tg/'s progress bars for do_mob and do_after.

Partial port of tgstation/-tg-station#10578