### PR TITLE
Explosion Performance Fix

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -118,8 +118,7 @@
 				if(flame_dist && prob(40) && !istype(T, /turf/space) && !T.density)
 					PoolOrNew(/obj/effect/hotspot, T) //Mostly for ambience!
 				if(dist > 0)
-					spawn(0)
-						T.ex_act(dist)
+					T.ex_act(dist)
 
 			//--- THROW ITEMS AROUND ---
 /*


### PR DESCRIPTION
I suspected this would happen, but I wanted to give it a shot.


Either case, spawn(0) does prevent explosions from being lopsided, but it means explosions incur massive massive amounts of lag when they occur.

We'll have to figure out a better way to resolve this. Performance is more important, right now, than explosions being a bit lopsided.