### PR TITLE
Forcibly Enable Hardware-Accelerated Graphics

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -266,6 +266,13 @@
 		add_admin_verbs()
 		admin_memo_show()
 
+	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
+	// (but turn them off first, since sometimes BYOND doesn't turn them on properly otherwise)
+	spawn(5) // And wait a half-second, since it sounds like you can do this too fast.
+		if(src)
+			winset(src, null, "command=\".configure graphics-hwmode off\"")
+			winset(src, null, "command=\".configure graphics-hwmode on\"")
+
 	log_client_to_db()
 
 	send_resources()


### PR DESCRIPTION
The lighting system we use requires hardware-accelerated graphics to be enabled; if they aren't, the lighting overlays appear as opaque blocks, covering their tile completely. This has, for some time now, resulted in players having to ask what's up with the colored squares, and get told to enable hardware acceleration.

Turns out, you can just force clients to turn it on. This PR forces it on a half second after a client connects.

Due to BYOND quirkiness, simply turning it on doesn't always work, but it does if you turn it _off_ first, so that's what this does. This causes the lighting overlays to flicker for a brief moment, so I do it in client/New(), instead of Login() (which seems to be the recommend place to do it), so they won't flicker every time a player moves into a new mob. This seems to work fine with a short delay.