### PR TITLE
Fixes Floragun for Security Bots

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -44,7 +44,8 @@
 		/obj/item/weapon/gun/energy/laser/redtag,\
 		/obj/item/weapon/gun/energy/laser/practice,\
 		/obj/item/weapon/melee/classic_baton/telescopic,\
-		/obj/item/weapon/gun/energy/kinetic_accelerator)
+		/obj/item/weapon/gun/energy/kinetic_accelerator,\
+		/obj/item/weapon/gun/energy/floragun)
 
 
 /obj/item/weapon/ed209_assembly

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -37,7 +37,8 @@
 		/obj/item/weapon/gun/energy/laser/redtag,\
 		/obj/item/weapon/gun/energy/laser/practice,\
 		/obj/item/weapon/melee/classic_baton/telescopic,\
-		/obj/item/weapon/gun/energy/kinetic_accelerator)
+		/obj/item/weapon/gun/energy/kinetic_accelerator,\
+		/obj/item/weapon/gun/energy/floragun)
 
 
 /obj/machinery/bot/secbot/beepsky


### PR DESCRIPTION
Botanists really shouldn't be stun-cuffed or detained by beepsky for having a floragun; it wastes their time and officer's time, as well.