### PR TITLE
Spacewind Tweaks

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -50,7 +50,7 @@ turf/simulated
 	var/obj/effect/hotspot/active_hotspot
 
 	var/temperature_archived //USED ONLY FOR SOLIDS
-	
+
 	var/atmos_overlay_type = "" //current active overlay
 
 turf/simulated/New()
@@ -293,7 +293,7 @@ atom/movable/var/last_forced_movement = 0
 atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 	if(last_forced_movement >= air_master.current_cycle)
 		return 0
-	else if(!anchored)
+	else if(!anchored && !pulledby)
 		if(pressure_difference > pressure_resistance)
 			last_forced_movement = air_master.current_cycle
 			spawn step(src, direction)


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/pull/11124

Spacewind will no longer push things that are being pulled by someone.

We've all been there; trying to pull a corpse into an area that's depressurized; moving a potted plant---trying to move the nuke back into the station, getting a mining crate into the airlock, etc. It's hugely annoying and doesn't really serve to do much except induce frustration.