### PR TITLE
Assorted Botany Fixes and Returns Accidentally Removed Features

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -107,7 +107,7 @@
 			descriptors |= "sweet-sour"
 		if(reagents.has_reagent("radium") || reagents.has_reagent("uranium"))
 			descriptors |= "radioactive"
-		if(reagents.has_reagent("amanitin") || reagents.has_reagent("toxin"))
+		if(reagents.has_reagent("amanitin") || reagents.has_reagent("toxin") || reagents.has_reagent("carpotoxin"))
 			descriptors |= "poisonous"
 		if(reagents.has_reagent("lsd") || reagents.has_reagent("space_drugs") || reagents.has_reagent("psilocybin"))
 			descriptors |= "hallucinogenic"
@@ -119,6 +119,10 @@
 			descriptors |= "slippery"
 		if(reagents.has_reagent("facid") || reagents.has_reagent("sacid"))
 			descriptors |= "acidic"
+		if(reagents.has_reagent("fuel"))
+			descriptors |= "flammable"
+		if(reagents.has_reagent("moonshine"))
+			descriptors |= "intoxicating"
 		if(seed.get_trait(TRAIT_JUICY))
 			descriptors |= "juicy"
 		if(seed.get_trait(TRAIT_STINGS))

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -733,8 +733,9 @@
 			else
 				product = new /obj/item/weapon/reagent_containers/food/snacks/grown(get_turf(user),name)
 			if(get_trait(TRAIT_PRODUCT_COLOUR))
-				if(!has_mob_product || (has_mob_product && has_mob_product != /mob/living/carbon/primitive/diona))
-					product.color = get_trait(TRAIT_PRODUCT_COLOUR)
+				if(modular_icon == 1)
+					if(!has_mob_product || (has_mob_product && has_mob_product != /mob/living/carbon/primitive/diona))
+						product.color = get_trait(TRAIT_PRODUCT_COLOUR)
 				if(istype(product,/obj/item/weapon/reagent_containers/food))
 					var/obj/item/weapon/reagent_containers/food/food = product
 					food.filling_color = get_trait(TRAIT_PRODUCT_COLOUR)
@@ -775,6 +776,8 @@
 	if(chems)          new_seed.chems = chems.Copy()
 	if(consume_gasses) new_seed.consume_gasses = consume_gasses.Copy()
 	if(exude_gasses)   new_seed.exude_gasses = exude_gasses.Copy()
+	new_seed.modular_icon = modular_icon
+	new_seed.preset_icon = preset_icon
 
 	new_seed.seed_name =            "[(roundstart ? "[(modified ? "modified" : "mutant")] " : "")][seed_name]"
 	new_seed.display_name =         "[(roundstart ? "[(modified ? "modified" : "mutant")] " : "")][display_name]"

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -4,7 +4,7 @@
 	seed_name = "chili"
 	display_name = "chili plants"
 	chems = list("capsaicin" = list(3,5), "plantmatter" = list(1,25))
-	mutants = list("icechili")
+	mutants = list("icechili", "ghostchili")
 	kitchen_tag = "chili"
 	preset_icon = "chilipepper"
 
@@ -27,6 +27,21 @@
 	chems = list("frostoil" = list(3,5), "plantmatter" = list(1,50))
 	kitchen_tag = "icechili"
 	preset_icon = "icepepper"
+
+/datum/seed/chili/ice/New()
+	..()
+	set_trait(TRAIT_MATURATION,4)
+	set_trait(TRAIT_PRODUCTION,4)
+	set_trait(TRAIT_PRODUCT_COLOUR,"#00EDC6")
+
+/datum/seed/chili/ghost
+	name = "ghostchili"
+	seed_name = "ghost pepper"
+	display_name = "ghost pepper plants"
+	mutants = null
+	chems = list("capsaicin" = list(8,2), "condensedcapsaicin" = list(4,4), "plantmatter" = list(1,50))
+	kitchen_tag = "ghostchili"
+	preset_icon = "ghostchilipepper"
 
 /datum/seed/chili/ice/New()
 	..()
@@ -671,9 +686,11 @@
 	set_trait(TRAIT_PRODUCT_COLOUR,"#B33715")
 	set_trait(TRAIT_PLANT_ICON,"flower3")
 
+//Sunflowers/varieties
 /datum/seed/flower/sunflower
 	name = "sunflowers"
 	seed_name = "sunflower"
+	mutants = list("moonflowers", "novaflowers")
 	display_name = "sunflowers"
 	preset_icon = "sunflower"
 
@@ -682,6 +699,36 @@
 	set_trait(TRAIT_MATURATION,6)
 	set_trait(TRAIT_PRODUCT_ICON,"flower2")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#FFF700")
+	set_trait(TRAIT_PLANT_ICON,"flower2")
+
+/datum/seed/flower/moonflower
+	name = "moonflowers"
+	seed_name = "moonflowers"
+	chems = list("plantmatter" = list(1,50), "moonshine" = list(1,10))
+	mutants = null
+	display_name = "moonflowers"
+	preset_icon = "moonflower"
+
+/datum/seed/flower/moonflower/New()
+	..()
+	set_trait(TRAIT_MATURATION,6)
+	set_trait(TRAIT_PRODUCT_ICON,"flower2")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#B5ABDD")
+	set_trait(TRAIT_PLANT_ICON,"flower2")
+
+/datum/seed/flower/novaflower
+	name = "novaflowers"
+	seed_name = "novaflower"
+	mutants = null
+	chems = list("fuel" = list(1,10))
+	display_name = "novaflowers"
+	preset_icon = "novaflower"
+
+/datum/seed/flower/novaflower/New()
+	..()
+	set_trait(TRAIT_MATURATION,6)
+	set_trait(TRAIT_PRODUCT_ICON,"flower2")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#E2A932")
 	set_trait(TRAIT_PLANT_ICON,"flower2")
 
 //Grapes/varieties
@@ -716,6 +763,47 @@
 /datum/seed/grapes/green/New()
 	..()
 	set_trait(TRAIT_PRODUCT_COLOUR,"42ed2f")
+
+//Soybeans/varieties
+/datum/seed/soybean
+	name = "soybean"
+	seed_name = "soybean"
+	display_name = "soybeans"
+	chems = list("plantmatter" = list(1,20), "soybeanoil" = list(1,20))
+	mutants = list("koibean")
+	kitchen_tag = "soybeans"
+	preset_icon = "soybeans"
+
+/datum/seed/soybean/New()
+	..()
+	set_trait(TRAIT_HARVEST_REPEAT,1)
+	set_trait(TRAIT_MATURATION,4)
+	set_trait(TRAIT_PRODUCTION,4)
+	set_trait(TRAIT_YIELD,3)
+	set_trait(TRAIT_POTENCY,5)
+	set_trait(TRAIT_PRODUCT_ICON,"bean")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#EBE7C0")
+	set_trait(TRAIT_PLANT_ICON,"stalk")
+
+/datum/seed/soybean/koi
+	name = "koibean"
+	seed_name = "koibean"
+	display_name = "koi beans"
+	chems = list("plantmatter" = list(1,30), "carpotoxin" = list(1,20))
+	mutants = null
+	kitchen_tag = "koibean"
+	preset_icon = "koibeans"
+
+/datum/seed/soybean/koi/New()
+	..()
+	set_trait(TRAIT_HARVEST_REPEAT,1)
+	set_trait(TRAIT_MATURATION,4)
+	set_trait(TRAIT_PRODUCTION,4)
+	set_trait(TRAIT_YIELD,3)
+	set_trait(TRAIT_POTENCY,5)
+	set_trait(TRAIT_PRODUCT_ICON,"bean")
+	set_trait(TRAIT_PRODUCT_COLOUR,"#EBE7C0")
+	set_trait(TRAIT_PLANT_ICON,"stalk")
 
 //Everything else
 /datum/seed/peanuts
@@ -814,25 +902,6 @@
 	set_trait(TRAIT_PRODUCT_ICON,"potato")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#D4CAB4")
 	set_trait(TRAIT_PLANT_ICON,"bush2")
-
-/datum/seed/soybean
-	name = "soybean"
-	seed_name = "soybean"
-	display_name = "soybeans"
-	chems = list("plantmatter" = list(1,20), "soybeanoil" = list(1,20))
-	kitchen_tag = "soybeans"
-	preset_icon = "soybeans"
-
-/datum/seed/soybean/New()
-	..()
-	set_trait(TRAIT_HARVEST_REPEAT,1)
-	set_trait(TRAIT_MATURATION,4)
-	set_trait(TRAIT_PRODUCTION,4)
-	set_trait(TRAIT_YIELD,3)
-	set_trait(TRAIT_POTENCY,5)
-	set_trait(TRAIT_PRODUCT_ICON,"bean")
-	set_trait(TRAIT_PRODUCT_COLOUR,"#EBE7C0")
-	set_trait(TRAIT_PLANT_ICON,"stalk")
 
 /datum/seed/wheat
 	name = "wheat"

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -324,6 +324,10 @@
 		seed.harvest(user,yield_mod)
 	else
 		seed.harvest(get_turf(src),yield_mod)
+	//Increases harvest count for round-end score
+	//Currently per-plant (not per-item) harvested
+	// --FalseIncarnate
+	score_stuffharvested++
 
 	// Reset values.
 	harvest = 0

--- a/code/modules/mob/living/carbon/primitive/dionaold.dm
+++ b/code/modules/mob/living/carbon/primitive/dionaold.dm
@@ -237,3 +237,25 @@
 /mob/living/carbon/primitive/diona/put_in_active_hand(obj/item/W)
 	src << "\red You don't have any hands!"
 	return
+
+/mob/living/carbon/primitive/diona/say(var/message)
+	if(client)
+		if(client.prefs.muted & MUTE_IC)
+			src << "\red You cannot speak in IC (Muted)."
+			return
+
+	message = trim_strip_html_properly(message)
+
+	if(stat)
+		if(stat == 2)
+			return say_dead(message)
+		return
+
+	if (is_muzzled())
+		src << "<span class='danger'>You're muzzled and cannot speak!</span>"
+		return
+
+	if(copytext(message,1,2) == "*")
+		return emote(copytext(message,2))
+
+	..(message)

--- a/code/modules/mob/living/carbon/primitive/emote.dm
+++ b/code/modules/mob/living/carbon/primitive/emote.dm
@@ -1,0 +1,182 @@
+/mob/living/carbon/primitive/emote(var/act,var/m_type=1,var/message = null)
+
+	var/param = null
+	if (findtext(act, "-", 1, null))
+		var/t1 = findtext(act, "-", 1, null)
+		param = copytext(act, t1 + 1, length(act) + 1)
+		act = copytext(act, 1, t1)
+
+	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
+		act = copytext(act,1,length(act))
+
+	var/muzzled = is_muzzled()
+
+	//Emote Cooldown System (it's so simple!)
+	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
+	var/on_CD = 0
+	switch(act)
+		//Cooldown-inducing emotes
+		if("chirp")
+			if(istype(src,/mob/living/carbon/primitive/diona))		//Only Diona Nymphs can chirp
+				on_CD = handle_emote_CD()								//proc located in code\modules\mob\emote.dm
+			else													//Everyone else fails, skip the emote attempt
+				return
+		if("flip")
+			on_CD = handle_emote_CD()				//proc located in code\modules\mob\emote.dm
+		//Everything else, including typos of the above emotes
+		else
+			on_CD = 0	//If it doesn't induce the cooldown, we won't check for the cooldown
+
+	if(on_CD == 1)		// Check if we need to suppress the emote attempt.
+		return			// Suppress emote, you're still cooling off.
+	//--FalseIncarnate
+
+	switch(act)
+		if ("me")
+			if(silent)
+				return
+			if (src.client)
+				if (client.prefs.muted & MUTE_IC)
+					src << "\red You cannot send IC messages (muted)."
+					return
+				if (src.client.handle_spam_prevention(message,MUTE_IC))
+					return
+			if (stat)
+				return
+			if(!(message))
+				return
+			return custom_emote(m_type, message)
+
+
+		if ("custom")
+			return custom_emote(m_type, message)
+
+		if ("chirp")
+			message = "<B>The [src.name]</B> chirps!"
+			playsound(src.loc, 'sound/misc/nymphchirp.ogg', 50, 0)
+			m_type = 2
+		if("sign")
+			if (!src.restrained())
+				message = text("<B>The [src.name]</B> signs[].", (text2num(param) ? text(" the number []", text2num(param)) : null))
+				m_type = 1
+		if("scratch")
+			if (!src.restrained())
+				message = "<B>The [src.name]</B> scratches."
+				m_type = 1
+		if("whimper")
+			if (!muzzled)
+				message = "<B>The [src.name]</B> whimpers."
+				m_type = 2
+		if("roar")
+			if (!muzzled)
+				message = "<B>The [src.name]</B> roars."
+				m_type = 2
+		if("tail")
+			message = "<B>The [src.name]</B> waves his tail."
+			m_type = 1
+		if("gasp")
+			message = "<B>The [src.name]</B> gasps."
+			m_type = 2
+		if("shiver")
+			message = "<B>The [src.name]</B> shivers."
+			m_type = 2
+		if("drool")
+			message = "<B>The [src.name]</B> drools."
+			m_type = 1
+		if("paw")
+			if (!src.restrained())
+				message = "<B>The [src.name]</B> flails his paw."
+				m_type = 1
+		if("scretch")
+			if (!muzzled)
+				message = "<B>The [src.name]</B> scretches."
+				m_type = 2
+		if("choke")
+			message = "<B>The [src.name]</B> chokes."
+			m_type = 2
+		if("moan")
+			message = "<B>The [src.name]</B> moans!"
+			m_type = 2
+		if("nod")
+			message = "<B>The [src.name]</B> nods his head."
+			m_type = 1
+		if("sit")
+			message = "<B>The [src.name]</B> sits down."
+			m_type = 1
+		if("sway")
+			message = "<B>The [src.name]</B> sways around dizzily."
+			m_type = 1
+		if("sulk")
+			message = "<B>The [src.name]</B> sulks down sadly."
+			m_type = 1
+		if("twitch")
+			message = "<B>The [src.name]</B> twitches violently."
+			m_type = 1
+		if("dance")
+			if (!src.restrained())
+				message = "<B>The [src.name]</B> dances around happily."
+				m_type = 1
+		if("roll")
+			if (!src.restrained())
+				message = "<B>The [src.name]</B> rolls."
+				m_type = 1
+		if("shake")
+			message = "<B>The [src.name]</B> shakes his head."
+			m_type = 1
+		if("gnarl")
+			if (!muzzled)
+				message = "<B>The [src.name]</B> gnarls and shows his teeth.."
+				m_type = 2
+		if("jump")
+			message = "<B>The [src.name]</B> jumps!"
+			m_type = 1
+		if("collapse")
+			Paralyse(2)
+			message = "<B>[src.name]</B> collapses!"
+			m_type = 2
+		if("deathgasp")
+			message = "<B>The [src.name]</B> lets out a faint chimper as it collapses and stops moving..."
+			m_type = 1
+		if ("flip")
+			m_type = 1
+			if (!src.restrained())
+				var/M = null
+				if (param)
+					for (var/mob/A in view(1, null))
+						if (param == A.name)
+							M = A
+							break
+				if (M == src)
+					M = null
+				if (M)
+					if(src.lying || src.weakened)
+						message = "<B>[src]</B> flops and flails around on the floor."
+					else
+						message = "<B>[src]</B> flips in [M]'s general direction."
+						src.SpinAnimation(5,1)
+				else
+					if(src.lying || src.weakened)
+						message = "<B>[src]</B> flops and flails around on the floor."
+					else
+						message = "<B>[src]</B> does a flip!"
+						src.SpinAnimation(5,1)
+		if("help")
+			var/text = "choke, "
+			if(istype(src,/mob/living/carbon/primitive/diona))
+				text += "chirp, "
+			text += "flip, collapse, dance, deathgasp, drool, gasp, shiver, gnarl, jump, paw, moan, nod, roar, roll, scratch,\nscretch, shake, sign-#, sit, sulk, sway, tail, twitch, whimper"
+			src << text
+		else
+			src << text("Invalid Emote: []", act)
+	if ((message && src.stat == 0))
+		if(src.client)
+			log_emote("[name]/[key] : [message]")
+		if (m_type & 1)
+			for(var/mob/O in viewers(src, null))
+				O.show_message(message, m_type)
+				//Foreach goto(703)
+		else
+			for(var/mob/O in hearers(src, null))
+				O.show_message(message, m_type)
+				//Foreach goto(746)
+	return

--- a/paradise.dme
+++ b/paradise.dme
@@ -1351,6 +1351,7 @@
 #include "code\modules\mob\living\carbon\metroid\subtypes.dm"
 #include "code\modules\mob\living\carbon\metroid\update_icons.dm"
 #include "code\modules\mob\living\carbon\primitive\dionaold.dm"
+#include "code\modules\mob\living\carbon\primitive\emote.dm"
 #include "code\modules\mob\living\silicon\death.dm"
 #include "code\modules\mob\living\silicon\login.dm"
 #include "code\modules\mob\living\silicon\say.dm"


### PR DESCRIPTION
Fixes mutant plants not properly inheriting preset icons
- This would cause the mutant plant to not look anything like the original

Fixes preset icons incorrectly having a color overlay applied
- This was most noticeable on berries, as the color overlay would render most of the icon black or red, instead of the intended multi-color icon

Returns emote capabilities to diona nymphs
- Accidentally removed by #1171

Returns Moonflowers, Novaflowers, Ghost Peppers, and Koi Beans
- Accidentally removed by #980
- Sunflowers can mutate into Moonflowers or Novaflowers
 - Novaflowers contain pure welding fuel
 - Moonflowers contain plantmatter and moonshine
- Chili peppers can mutate into Ghost Peppers or Ice Peppers
 - Ghost Peppers contain plantmatter, capsaicin, and condensed capsaicin
- Soybeans can mutate into Koi Beans
 - Koi Beans contain plantmatter and carpotoxin

Returns Hydroponics Harvests tracking for End-of-Round score
- Accidentally removed by #980

Updated the descriptions for plants to account for moonshine, welder fuel, and carpotoxin
- This is to maintain consistency with other reagent-based descriptions for the plants