### PR TITLE
Fixes Disappearing Disposal Gas Datums

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -345,9 +345,6 @@
 	if(stat & BROKEN)			// nothing can happen if broken
 		return
 
-	if(!air_contents) // Potentially causes a runtime otherwise (if this is really shitty, blame pete //Donkie)
-		air_contents = new()		// new empty gas resv.
-
 	flush_count++
 	if( flush_count >= flush_every_ticks )
 		if( contents.len )
@@ -412,9 +409,6 @@
 	if(wrapcheck == 1)
 		H.tomail = 1
 
-
-	air_contents = new()		// new empty gas resv.
-
 	sleep(10)
 	if(last_sound < world.time + 1)
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, 0, 0)
@@ -423,7 +417,7 @@
 
 
 	H.init(src)	// copy the contents of disposer to holder
-
+	air_contents = new() // The holder just took our gas; replace it
 	H.start(src) // start the holder processing movement
 	flushing = 0
 	// now reset disposal state


### PR DESCRIPTION
Disposals are supposed to replace their gas datum after handing it off to the disposal holder object, but were instead doing it before. This meant the holder ended up with a reference to the disposal's new gas datum, and eventually deleted it, breaking the disposal.

* Fixes disposals creating a new gas datum too soon.
  * Fixes runtimes associated with this gas datum later getting deleted.
* Removes the previous sanity check for `air_contents` - it shouldn't cease existing now.