### PR TITLE
Removes Unnecessary Relaymove

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -160,8 +160,6 @@ obj/machinery/atmospherics/proc/check_connect_types_construction(obj/machinery/a
 /obj/machinery/atmospherics/relaymove(mob/living/user, direction)
 	if(!(direction & initialize_directions)) //can't go in a way we aren't connecting to
 		return
-	if(user.machine == src) //temporary fix until we overhaul movement code
-		return
 
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction)
 	if(target_move)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -286,10 +286,6 @@
 		if(istype(mob.buckled, /obj/vehicle) || istype(mob.buckled, /obj/structure/stool/bed/chair/cart))
 			return mob.buckled.relaymove(mob,direct)
 
-		if(istype(mob.machine, /obj/machinery))
-			if(mob.machine.relaymove(mob,direct))
-				return
-
 		if(mob.pulledby || mob.buckled) // Wheelchair driving!
 			if(istype(mob.loc, /turf/space))
 				return // No wheelchair driving in space


### PR DESCRIPTION
For some reason, relaymove was being called on a mob's set machine when that mob tried to move. Presumably, this served some purpose at some point, but as far as I can tell, no machinery expects this sort of relaymove, so it's only causing problems.

* Removes relaymove being called on a mob's set machine when it tries to move.
  * Fixes teleporting to disposals you have recently interacted with. (Fixes #1718)
  * Fixes people popping out of cryo cells you have recently interacted with.
  * Fixes people popping out of body scanners you have recently interacted with.
  * Probably doesn't break anything.
* Removes a sanity check that was added to atmospherics machinery's relaymove to deal with this unusual call.