### PR TITLE
Fixes "Disable Away Missions" Config Option

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -520,7 +520,7 @@
 					config.overflow_server_url = value
 					
 				if("disable_away_missions")
-					config.disable_away_missions = value
+					config.disable_away_missions = 1
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -285,4 +285,4 @@ PLAYER_REROUTE_CAP 0
 #OVERFLOW_SERVER_URL byond://example.org:1111
 
 ## Disable the loading of away missions
-DISABLE_AWAY_MISSIONS 0
+# DISABLE_AWAY_MISSIONS


### PR DESCRIPTION
As coded, with the updated default config, this is set to the value of "0" (a string which evaluates to true) rather than 0. This results in away missions being disabled by default.

Since the setting is binary anyway, this changes the `DISABLE_AWAY_MISSIONS` setting to require uncommenting to enable.