### PR TITLE
You can now click on an inventory slot instead of a specific item

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -165,6 +165,7 @@
 
 	if(display_contents_with_number)
 		for(var/datum/numbered_display/ND in display_contents)
+			ND.sample_object.mouse_opacity = 2
 			ND.sample_object.screen_loc = "[cx]:16,[cy]:16"
 			ND.sample_object.maptext = "<font color='white'>[(ND.number > 1)? "[ND.number]" : ""]</font>"
 			ND.sample_object.layer = 20
@@ -174,6 +175,7 @@
 				cy--
 	else
 		for(var/obj/O in contents)
+			O.mouse_opacity = 2 //This is here so storage items that spawn with contents correctly have the "click around item to equip"
 			O.screen_loc = "[cx]:16,[cy]:16"
 			O.maptext = ""
 			O.layer = 20
@@ -310,6 +312,7 @@
 		src.orient2hud(usr)
 		if(usr.s_active)
 			usr.s_active.show_to(usr)
+	W.mouse_opacity = 2 //So you can click on the area around the item to equip it, instead of having to pixel hunt
 	update_icon()
 	return 1
 
@@ -345,6 +348,7 @@
 		W.maptext = ""
 	W.on_exit_storage(src)
 	update_icon()
+	W.mouse_opacity = initial(W.mouse_opacity)
 	return 1
 
 //This proc is called when you want to place an item into the storage item.
@@ -442,6 +446,9 @@
 	return
 
 /obj/item/weapon/storage/Destroy()
+	for(var/obj/O in contents)
+		O.mouse_opacity = initial(O.mouse_opacity)
+
 	qdel(boxes)
 	qdel(closer)
 	return ..()

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -12,6 +12,7 @@
 	if(!O)
 		return 0
 
+	O.mouse_opacity = 2	
 	if(istype(O,/obj/item/borg/sight))
 		var/obj/item/borg/sight/S = O
 		sight_mode &= ~S.sight_mode
@@ -44,6 +45,7 @@
 		src << "Already activated"
 		return
 	if(!module_state_1)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_1 = O
 		O.layer = 20
 		O.screen_loc = inv1.screen_loc
@@ -51,6 +53,7 @@
 		if(istype(module_state_1,/obj/item/borg/sight))
 			sight_mode |= module_state_1:sight_mode
 	else if(!module_state_2)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_2 = O
 		O.layer = 20
 		O.screen_loc = inv2.screen_loc
@@ -58,6 +61,7 @@
 		if(istype(module_state_2,/obj/item/borg/sight))
 			sight_mode |= module_state_2:sight_mode
 	else if(!module_state_3)
+		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_3 = O
 		O.layer = 20
 		O.screen_loc = inv3.screen_loc

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -30,6 +30,15 @@
 	src.modules += new /obj/item/device/flash/cyborg(src)
 	src.emag = new /obj/item/toy/sword(src)
 	src.emag.name = "Placeholder Emag Item"
+	
+
+/obj/item/weapon/robot_module/proc/fix_modules()
+	for(var/obj/item/I in modules)
+		I.flags |= NODROP
+		I.mouse_opacity = 2
+	if(emag)
+		emag.flags |= NODROP
+		emag.mouse_opacity = 2
 
 /obj/item/weapon/robot_module/proc/respawn_consumable(var/mob/living/silicon/robot/R)
 	if(!stacktypes || !stacktypes.len) return
@@ -85,15 +94,16 @@
 	name = "standard robot module"
 
 
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/weapon/melee/baton/loaded(src)
-		src.modules += new /obj/item/weapon/extinguisher(src)
-		src.modules += new /obj/item/weapon/wrench(src)
-		src.modules += new /obj/item/weapon/crowbar(src)
-		src.modules += new /obj/item/device/healthanalyzer(src)
-		src.emag = new /obj/item/weapon/melee/energy/sword/cyborg(src)
-		return
+/obj/item/weapon/robot_module/standard/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/weapon/melee/baton/loaded(src)
+	src.modules += new /obj/item/weapon/extinguisher(src)
+	src.modules += new /obj/item/weapon/wrench(src)
+	src.modules += new /obj/item/weapon/crowbar(src)
+	src.modules += new /obj/item/device/healthanalyzer(src)
+	src.emag = new /obj/item/weapon/melee/energy/sword/cyborg(src)
+	
+	fix_modules()
 
 /obj/item/weapon/robot_module/medical
 	name = "medical robot module"
@@ -105,36 +115,37 @@
 		/obj/item/stack/nanopaste = 5
 		)
 	
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/device/healthanalyzer/advanced(src)
-		src.modules += new /obj/item/device/reagent_scanner/adv(src)
-		src.modules += new /obj/item/weapon/borg_defib(src)
-		src.modules += new /obj/item/roller_holder(src)
-		src.modules += new /obj/item/weapon/reagent_containers/borghypo(src)
-		src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
-		src.modules += new /obj/item/weapon/reagent_containers/dropper(src)
-		src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
-		src.modules += new /obj/item/weapon/extinguisher/mini(src)
-		src.modules += new /obj/item/stack/medical/advanced/bruise_pack(src)
-		src.modules += new /obj/item/stack/medical/advanced/ointment(src)
-		src.modules += new /obj/item/stack/medical/splint(src)
-		src.modules += new /obj/item/stack/nanopaste(src)
-		src.modules += new /obj/item/weapon/scalpel(src)
-		src.modules += new /obj/item/weapon/hemostat(src)
-		src.modules += new /obj/item/weapon/retractor(src)
-		src.modules += new /obj/item/weapon/cautery(src)
-		src.modules += new /obj/item/weapon/bonegel(src)
-		src.modules += new /obj/item/weapon/FixOVein(src)
-		src.modules += new /obj/item/weapon/bonesetter(src)
-		src.modules += new /obj/item/weapon/circular_saw(src)
-		src.modules += new /obj/item/weapon/surgicaldrill(src)
+/obj/item/weapon/robot_module/medical/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/device/healthanalyzer/advanced(src)
+	src.modules += new /obj/item/device/reagent_scanner/adv(src)
+	src.modules += new /obj/item/weapon/borg_defib(src)
+	src.modules += new /obj/item/roller_holder(src)
+	src.modules += new /obj/item/weapon/reagent_containers/borghypo(src)
+	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
+	src.modules += new /obj/item/weapon/reagent_containers/dropper(src)
+	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
+	src.modules += new /obj/item/weapon/extinguisher/mini(src)
+	src.modules += new /obj/item/stack/medical/advanced/bruise_pack(src)
+	src.modules += new /obj/item/stack/medical/advanced/ointment(src)
+	src.modules += new /obj/item/stack/medical/splint(src)
+	src.modules += new /obj/item/stack/nanopaste(src)
+	src.modules += new /obj/item/weapon/scalpel(src)
+	src.modules += new /obj/item/weapon/hemostat(src)
+	src.modules += new /obj/item/weapon/retractor(src)
+	src.modules += new /obj/item/weapon/cautery(src)
+	src.modules += new /obj/item/weapon/bonegel(src)
+	src.modules += new /obj/item/weapon/FixOVein(src)
+	src.modules += new /obj/item/weapon/bonesetter(src)
+	src.modules += new /obj/item/weapon/circular_saw(src)
+	src.modules += new /obj/item/weapon/surgicaldrill(src)
 
-		src.emag = new /obj/item/weapon/reagent_containers/spray(src)
+	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 
-		src.emag.reagents.add_reagent("facid", 250)
-		src.emag.name = "Polyacid spray"
-		return
+	src.emag.reagents.add_reagent("facid", 250)
+	src.emag.name = "Polyacid spray"
+	
+	fix_modules()
 
 /obj/item/weapon/robot_module/medical/respawn_consumable(var/mob/living/silicon/robot/R)
 	if(src.emag)
@@ -155,115 +166,113 @@
 		/obj/item/stack/tile/plasteel = 15
 		)
 
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/borg/sight/meson(src)
-		src.modules += new /obj/item/weapon/rcd/borg(src)
-		src.modules += new /obj/item/weapon/extinguisher(src)
-		src.modules += new /obj/item/weapon/weldingtool/largetank(src)
-		src.modules += new /obj/item/weapon/screwdriver(src)
-		src.modules += new /obj/item/weapon/wrench(src)
-		src.modules += new /obj/item/weapon/crowbar(src)
-		src.modules += new /obj/item/weapon/wirecutters(src)
-		src.modules += new /obj/item/device/multitool(src)
-		src.modules += new /obj/item/device/t_scanner(src)
-		src.modules += new /obj/item/device/analyzer(src)
-		src.modules += new /obj/item/taperoll/engineering(src)
-		src.modules += new /obj/item/weapon/gripper(src)
-		src.modules += new /obj/item/weapon/matter_decompiler(src)
+/obj/item/weapon/robot_module/engineering/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/borg/sight/meson(src)
+	src.modules += new /obj/item/weapon/rcd/borg(src)
+	src.modules += new /obj/item/weapon/extinguisher(src)
+	src.modules += new /obj/item/weapon/weldingtool/largetank(src)
+	src.modules += new /obj/item/weapon/screwdriver(src)
+	src.modules += new /obj/item/weapon/wrench(src)
+	src.modules += new /obj/item/weapon/crowbar(src)
+	src.modules += new /obj/item/weapon/wirecutters(src)
+	src.modules += new /obj/item/device/multitool(src)
+	src.modules += new /obj/item/device/t_scanner(src)
+	src.modules += new /obj/item/device/analyzer(src)
+	src.modules += new /obj/item/taperoll/engineering(src)
+	src.modules += new /obj/item/weapon/gripper(src)
+	src.modules += new /obj/item/weapon/matter_decompiler(src)
 
-		src.emag = new /obj/item/borg/stun(src)
+	src.emag = new /obj/item/borg/stun(src)
 
-		var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
-		M.amount = 50
-		src.modules += M
+	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
+	M.amount = 50
+	src.modules += M
 
-		var/obj/item/stack/sheet/rglass/cyborg/R = new /obj/item/stack/sheet/rglass/cyborg(src)
-		R.amount = 50
-		src.modules += R
+	var/obj/item/stack/sheet/rglass/cyborg/R = new /obj/item/stack/sheet/rglass/cyborg(src)
+	R.amount = 50
+	src.modules += R
 
-		var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src)
-		G.amount = 50
-		src.modules += G
+	var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src)
+	G.amount = 50
+	src.modules += G
 
-		var/obj/item/stack/cable_coil/cyborg/W = new /obj/item/stack/cable_coil/cyborg(src)
-		W.amount = 50
-		src.modules += W
+	var/obj/item/stack/cable_coil/cyborg/W = new /obj/item/stack/cable_coil/cyborg(src)
+	W.amount = 50
+	src.modules += W
 
-		var/obj/item/stack/rods/Q = new /obj/item/stack/rods(src)
-		Q.amount = 15
-		src.modules += Q
+	var/obj/item/stack/rods/Q = new /obj/item/stack/rods(src)
+	Q.amount = 15
+	src.modules += Q
 
-		var/obj/item/stack/tile/plasteel/F = new /obj/item/stack/tile/plasteel(src) //floor tiles not regular plasteel, calm down
-		F.amount = 15
-		src.modules += F
+	var/obj/item/stack/tile/plasteel/F = new /obj/item/stack/tile/plasteel(src) //floor tiles not regular plasteel, calm down
+	F.amount = 15
+	src.modules += F
 
-		return
+	fix_modules()
 
 /obj/item/weapon/robot_module/security
 	name = "security robot module"
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 
-
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg(src)
-		src.modules += new /obj/item/weapon/melee/baton/loaded/robot(src)
-		src.modules += new /obj/item/weapon/gun/energy/disabler/cyborg(src)
-		src.modules += new /obj/item/taperoll/police(src)
-		src.modules += new /obj/item/clothing/mask/gas/sechailer/cyborg(src)
-		src.emag = new /obj/item/weapon/gun/energy/laser/cyborg(src)
-		return
+/obj/item/weapon/robot_module/security/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg(src)
+	src.modules += new /obj/item/weapon/melee/baton/loaded/robot(src)
+	src.modules += new /obj/item/weapon/gun/energy/disabler/cyborg(src)
+	src.modules += new /obj/item/taperoll/police(src)
+	src.modules += new /obj/item/clothing/mask/gas/sechailer/cyborg(src)
+	src.emag = new /obj/item/weapon/gun/energy/laser/cyborg(src)
+	
+	fix_modules()
 
 
 /obj/item/weapon/robot_module/janitor
 	name = "janitorial robot module"
 
+/obj/item/weapon/robot_module/janitor/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
+	src.modules += new /obj/item/weapon/storage/bag/trash/cyborg(src)
+	src.modules += new /obj/item/weapon/mop(src)
+	src.modules += new /obj/item/device/lightreplacer(src)
+	src.modules += new /obj/item/weapon/holosign_creator(src)
+	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
 
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/weapon/soap/nanotrasen(src)
-		src.modules += new /obj/item/weapon/storage/bag/trash/cyborg(src)
-		src.modules += new /obj/item/weapon/mop(src)
-		src.modules += new /obj/item/device/lightreplacer(src)
-		src.modules += new /obj/item/weapon/holosign_creator(src)
-		src.emag = new /obj/item/weapon/reagent_containers/spray(src)
-
-		src.emag.reagents.add_reagent("lube", 250)
-		src.emag.name = "Lube spray"
-		return
-
-
+	src.emag.reagents.add_reagent("lube", 250)
+	src.emag.name = "Lube spray"
+	
+	fix_modules()
 
 /obj/item/weapon/robot_module/butler
 	name = "service robot module"
 
+/obj/item/weapon/robot_module/butler/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
+	src.modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
+	src.modules += new /obj/item/weapon/pen(src)
+	src.modules += new /obj/item/weapon/razor(src)
+	src.modules += new /obj/item/device/violin(src)
+	src.modules += new /obj/item/device/guitar(src)
 
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
-		src.modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
-		src.modules += new /obj/item/weapon/pen(src)
-		src.modules += new /obj/item/weapon/razor(src)
-		src.modules += new /obj/item/device/violin(src)
-		src.modules += new /obj/item/device/guitar(src)
+	var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf(src)
+	M.matter = 30
+	src.modules += M
 
-		var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf(src)
-		M.matter = 30
-		src.modules += M
+	src.modules += new /obj/item/weapon/reagent_containers/robodropper(src)
+	src.modules += new /obj/item/weapon/lighter/zippo(src)
+	src.modules += new /obj/item/weapon/storage/bag/tray/cyborg(src)
+	src.modules += new /obj/item/weapon/reagent_containers/food/drinks/shaker(src)
+	src.emag = new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
 
-		src.modules += new /obj/item/weapon/reagent_containers/robodropper(src)
-		src.modules += new /obj/item/weapon/lighter/zippo(src)
-		src.modules += new /obj/item/weapon/storage/bag/tray/cyborg(src)
-		src.modules += new /obj/item/weapon/reagent_containers/food/drinks/shaker(src)
-		src.emag = new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
-
-		var/datum/reagents/R = new/datum/reagents(50)
-		src.emag.reagents = R
-		R.my_atom = src.emag
-		R.add_reagent("beer2", 50)
-		src.emag.name = "Mickey Finn's Special Brew"
-		return
+	var/datum/reagents/R = new/datum/reagents(50)
+	src.emag.reagents = R
+	R.my_atom = src.emag
+	R.add_reagent("beer2", 50)
+	src.emag.name = "Mickey Finn's Special Brew"
+	
+	fix_modules()
 
 /obj/item/weapon/robot_module/butler/respawn_consumable(var/mob/living/silicon/robot/R)
 	var/obj/item/weapon/reagent_containers/food/condiment/enzyme/E = locate() in src.modules
@@ -307,19 +316,19 @@
 /obj/item/weapon/robot_module/miner
 	name = "miner robot module"
 
-
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/borg/sight/meson(src)
-		src.modules += new /obj/item/weapon/wrench(src)
-		src.modules += new /obj/item/weapon/screwdriver(src)
-		src.modules += new /obj/item/device/t_scanner/adv_mining_scanner/cyborg(src)
-		src.modules += new /obj/item/weapon/storage/bag/ore/cyborg(src)
-		src.modules += new /obj/item/weapon/pickaxe/drill/cyborg(src)
-		src.modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
-		src.modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)
-		src.emag = new /obj/item/borg/stun(src)
-		return
+/obj/item/weapon/robot_module/miner/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/borg/sight/meson(src)
+	src.modules += new /obj/item/weapon/wrench(src)
+	src.modules += new /obj/item/weapon/screwdriver(src)
+	src.modules += new /obj/item/device/t_scanner/adv_mining_scanner/cyborg(src)
+	src.modules += new /obj/item/weapon/storage/bag/ore/cyborg(src)
+	src.modules += new /obj/item/weapon/pickaxe/drill/cyborg(src)
+	src.modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
+	src.modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)
+	src.emag = new /obj/item/borg/stun(src)
+		
+	fix_modules()
 
 /obj/item/weapon/robot_module/deathsquad
 	name = "NT advanced combat module"
@@ -332,7 +341,8 @@
 	src.modules += new /obj/item/weapon/tank/jetpack/carbondioxide(src)
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.emag = null
-	return
+	
+	fix_modules()
 
 /obj/item/weapon/robot_module/syndicate
 	name = "syndicate robot module"
@@ -347,38 +357,42 @@
 	src.modules += new /obj/item/weapon/crowbar(src)
 	src.modules += new /obj/item/weapon/pinpointer/operative(src)
 	src.emag = null
-	return
+	
+	fix_modules()
 
 /obj/item/weapon/robot_module/combat
 	name = "combat robot module"
 
-	New()
-		src.modules += new /obj/item/device/flash/cyborg(src)
-		src.modules += new /obj/item/borg/sight/thermal(src)
-		src.modules += new /obj/item/weapon/gun/energy/laser/cyborg(src)
-		src.modules += new /obj/item/weapon/gun/energy/plasmacutter(src)
-		src.modules += new /obj/item/borg/combat/shield(src)
-		src.modules += new /obj/item/borg/combat/mobility(src)
-		src.modules += new /obj/item/weapon/wrench(src) //Is a combat android really going to be stopped by a chair?
-		src.emag = new /obj/item/weapon/gun/energy/lasercannon/cyborg(src)
-		return
+/obj/item/weapon/robot_module/combat/New()
+	src.modules += new /obj/item/device/flash/cyborg(src)
+	src.modules += new /obj/item/borg/sight/thermal(src)
+	src.modules += new /obj/item/weapon/gun/energy/laser/cyborg(src)
+	src.modules += new /obj/item/weapon/gun/energy/plasmacutter(src)
+	src.modules += new /obj/item/borg/combat/shield(src)
+	src.modules += new /obj/item/borg/combat/mobility(src)
+	src.modules += new /obj/item/weapon/wrench(src) //Is a combat android really going to be stopped by a chair?
+	src.emag = new /obj/item/weapon/gun/energy/lasercannon/cyborg(src)
+	
+	fix_modules()
 
 /obj/item/weapon/robot_module/alien/hunter
 	name = "alien hunter module"
 
-	New()
-		src.modules += new /obj/item/weapon/melee/energy/alien/claws(src)
-		src.modules += new /obj/item/device/flash/cyborg/alien(src)
-		src.modules += new /obj/item/borg/sight/thermal/alien(src)
-		var/obj/item/weapon/reagent_containers/spray/alien/stun/S = new /obj/item/weapon/reagent_containers/spray/alien/stun(src)
-		S.reagents.add_reagent("ether",250) //nerfed to sleeptoxin to make it less instant drop.
-		src.modules += S
-		var/obj/item/weapon/reagent_containers/spray/alien/smoke/A = new /obj/item/weapon/reagent_containers/spray/alien/smoke(src)
-		S.reagents.add_reagent("water",50) //Water is used as a dummy reagent for the smoke bombs. More of an ammo counter.
-		src.modules += A
-		src.emag = new /obj/item/weapon/reagent_containers/spray/alien/acid(src)
-		src.emag.reagents.add_reagent("facid", 125)
-		src.emag.reagents.add_reagent("sacid", 125)
+/obj/item/weapon/robot_module/alien/hunter/New()
+	src.modules += new /obj/item/weapon/melee/energy/alien/claws(src)
+	src.modules += new /obj/item/device/flash/cyborg/alien(src)
+	src.modules += new /obj/item/borg/sight/thermal/alien(src)
+	var/obj/item/weapon/reagent_containers/spray/alien/stun/S = new /obj/item/weapon/reagent_containers/spray/alien/stun(src)
+	S.reagents.add_reagent("ether",250) //nerfed to sleeptoxin to make it less instant drop.
+	src.modules += S
+	var/obj/item/weapon/reagent_containers/spray/alien/smoke/A = new /obj/item/weapon/reagent_containers/spray/alien/smoke(src)
+	S.reagents.add_reagent("water",50) //Water is used as a dummy reagent for the smoke bombs. More of an ammo counter.
+	src.modules += A
+	src.emag = new /obj/item/weapon/reagent_containers/spray/alien/acid(src)
+	src.emag.reagents.add_reagent("facid", 125)
+	src.emag.reagents.add_reagent("sacid", 125)
+
+	fix_modules()
 
 /obj/item/weapon/robot_module/alien/hunter/add_languages(var/mob/living/silicon/robot/R)
 	..()
@@ -398,27 +412,27 @@
 		/obj/item/stack/cable_coil/cyborg = 30
 		)
 
-	New()
-		src.modules += new /obj/item/weapon/weldingtool(src)
-		src.modules += new /obj/item/weapon/screwdriver(src)
-		src.modules += new /obj/item/weapon/wrench(src)
-		src.modules += new /obj/item/weapon/crowbar(src)
-		src.modules += new /obj/item/weapon/wirecutters(src)
-		src.modules += new /obj/item/device/multitool(src)
-		src.modules += new /obj/item/device/lightreplacer(src)
-		src.modules += new /obj/item/weapon/gripper(src)
-		src.modules += new /obj/item/weapon/matter_decompiler(src)
-		src.modules += new /obj/item/weapon/reagent_containers/spray/cleaner/drone(src)
-		src.modules += new /obj/item/weapon/soap(src)
+/obj/item/weapon/robot_module/drone/New()
+	src.modules += new /obj/item/weapon/weldingtool(src)
+	src.modules += new /obj/item/weapon/screwdriver(src)
+	src.modules += new /obj/item/weapon/wrench(src)
+	src.modules += new /obj/item/weapon/crowbar(src)
+	src.modules += new /obj/item/weapon/wirecutters(src)
+	src.modules += new /obj/item/device/multitool(src)
+	src.modules += new /obj/item/device/lightreplacer(src)
+	src.modules += new /obj/item/weapon/gripper(src)
+	src.modules += new /obj/item/weapon/matter_decompiler(src)
+	src.modules += new /obj/item/weapon/reagent_containers/spray/cleaner/drone(src)
+	src.modules += new /obj/item/weapon/soap(src)
 
-		src.emag = new /obj/item/weapon/pickaxe/drill/cyborg/diamond(src)
+	src.emag = new /obj/item/weapon/pickaxe/drill/cyborg/diamond(src)
 
-		for(var/T in stacktypes)
-			var/obj/item/stack/sheet/W = new T(src)
-			W.amount = stacktypes[T]
-			src.modules += W
+	for(var/T in stacktypes)
+		var/obj/item/stack/sheet/W = new T(src)
+		W.amount = stacktypes[T]
+		src.modules += W
 
-		return
+	fix_modules()
 
 /obj/item/weapon/robot_module/drone/respawn_consumable(var/mob/living/silicon/robot/R)
 	var/obj/item/weapon/reagent_containers/spray/cleaner/C = locate() in src.modules


### PR DESCRIPTION
Changes:
1) You can now click anywhere in a storage item to take an item, rather than having to click on the specific item itself. Also works for cyborgs.

Full credit to RemieRichards: https://github.com/tgstation/-tg-station/pull/10990.