### PR TITLE
New proc to replace world.log <<, log_to_dd()

### DIFF
--- a/code/__DEFINES/btime.dm
+++ b/code/__DEFINES/btime.dm
@@ -10,8 +10,8 @@ var/global/__btime__libName = "btime.[world.system_type==MS_WINDOWS?"dll":"so"]"
 		// This will always return 1 unless the btime library cannot be accessed
 		if(TimeOfHour || 1) return 1
 	catch(var/exception/e)
-		world.log << "PRECISE_TIMER_AVAILABLE is defined in btime.dm, but calling the btime library failed: [e]"
-		world.log << "This is a fatal error. The world will now shut down."
+		log_to_dd("PRECISE_TIMER_AVAILABLE is defined in btime.dm, but calling the btime library failed: [e]")
+		log_to_dd("This is a fatal error. The world will now shut down.")
 		del(world)
 #else
 #define TimeOfHour (world.timeofday % 36000)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -137,7 +137,7 @@
 			if(sight_check && !isInSight(A, O))
 				continue
 			L |= M
-			//world.log << "[recursion_limit] = [M] - [get_turf(M)] - ([M.x], [M.y], [M.z])"
+			//log_to_dd("[recursion_limit] = [M] - [get_turf(M)] - ([M.x], [M.y], [M.z])")
 
 		else if(include_radio && istype(A, /obj/item/device/radio))
 			if(sight_check && !isInSight(A, O))
@@ -167,7 +167,7 @@
 			var/mob/M = A
 			if(M.client)
 				hear += M
-			//world.log << "Start = [M] - [get_turf(M)] - ([M.x], [M.y], [M.z])"
+			//log_to_dd("Start = [M] - [get_turf(M)] - ([M.x], [M.y], [M.z])")
 		else if(istype(A, /obj/item/device/radio))
 			hear += A
 

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -370,7 +370,7 @@
 
 //Don't use this on lists larger than half a dozen or so
 /proc/insertion_sort_numeric_list_ascending(var/list/L)
-	//world.log << "ascending len input: [L.len]"
+	//log_to_dd("ascending len input: [L.len]")
 	var/list/out = list(pop(L))
 	for(var/entry in L)
 		if(isnum(entry))
@@ -383,13 +383,13 @@
 			if(!success)
 				out.Add(entry)
 
-	//world.log << "	output: [out.len]"
+	//log_to_dd("	output: [out.len]")
 	return out
 
 /proc/insertion_sort_numeric_list_descending(var/list/L)
-	//world.log << "descending len input: [L.len]"
+	//log_to_dd("descending len input: [L.len]")
 	var/list/out = insertion_sort_numeric_list_ascending(L)
-	//world.log << "	output: [out.len]"
+	//log_to_dd("	output: [out.len]")
 	return reverselist(out)
 
 /proc/dd_sortedObjectList(var/list/L, var/cache=list())
@@ -583,4 +583,3 @@ proc/dd_sortedObjectList(list/incoming)
 
 /datum/alarm/dd_SortValue()
 	return "[sanitize(last_name)]"
-	

--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -8,16 +8,16 @@
 
 
 /proc/error(msg)
-	world.log << "## ERROR: [msg]"
+	log_to_dd("## ERROR: [msg]")
 
 #define WARNING(MSG) warning("[MSG] in [__FILE__] at line [__LINE__] src: [src] usr: [usr].")
 //print a warning message to world.log
 /proc/warning(msg)
-	world.log << "## WARNING: [msg]"
+	log_to_dd("## WARNING: [msg]")
 
 //print a testing-mode debug message to world.log
 /proc/testing(msg)
-	world.log << "## TESTING: [msg]"
+	log_to_dd("## TESTING: [msg]")
 
 /proc/log_admin(text)
 	admin_log.Add(text)
@@ -80,3 +80,8 @@
 
 /proc/log_misc(text)
 	diary << "\[[time_stamp()]]MISC: [text][log_end]"
+
+/proc/log_to_dd(text)
+	world.log << text //this comes before the config check because it can't possibly runtime
+	if(config.log_world_output)
+		diary << "\[[time_stamp()]]DD_OUTPUT: [text][log_end]"

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -248,7 +248,7 @@ proc/tg_text2list(text, glue=",", assocglue=";")
 		if(4.0) return EAST
 		if(8.0) return WEST
 		else
-			world.log << "UNKNOWN DIRECTION: [direction]"
+			log_to_dd("UNKNOWN DIRECTION: [direction]")
 
 /proc/dir2text(direction)
 	switch(direction)

--- a/code/_hooks/hooks.dm
+++ b/code/_hooks/hooks.dm
@@ -32,21 +32,21 @@ var/global/list/hooks = list()
 	for (var/hook_path in typesof(/hook))
 		var/hook/hook = new hook_path
 		hooks[hook.name] = hook
-//		world.log << "Found hook: " + hook.name
+//		log_to_dd("Found hook: " + hook.name)
 	for (var/hook_path in typesof(/hook_handler))
 		var/hook_handler/hook_handler = new hook_path
 		for (var/name in hooks)
 			if (hascall(hook_handler, "On" + name))
 				var/hook/hook = hooks[name]
 				hook.handlers += hook_handler
-//				world.log << "Found hook handler for: " + name
+//				log_to_dd("Found hook handler for: " + name)
 	for (var/hook/hook in hooks)
 		hook.Setup()
 
 /proc/CallHook(var/name as text, var/list/args)
 	var/hook/hook = hooks[name]
 	if (!hook)
-		//world.log << "WARNING: Hook with name " + name + " does not exist"
+		//log_to_dd("WARNING: Hook with name " + name + " does not exist")
 		return
 	if (hook.Called(args))
 		return

--- a/code/controllers/ProcessScheduler/core/process.dm
+++ b/code/controllers/ProcessScheduler/core/process.dm
@@ -360,9 +360,9 @@
 		if(istype(thrower, /atom))
 			var/atom/A = thrower
 			ptext += " ([A]) ([A.x],[A.y],[A.z])"
-	world.log << "\[[time_stamp()]\] Process [name] caught exception[ptext]: [etext]"
+	log_to_dd("\[[time_stamp()]\] Process [name] caught exception[ptext]: [etext]")
 	if(exceptions[eid] >= 10)
-		world.log << "This exception will now be ignored for ten minutes."
+		log_to_dd("This exception will now be ignored for ten minutes.")
 		spawn(6000)
 			exceptions[eid] = 0
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -17,6 +17,7 @@
 	var/log_adminchat = 0				// log admin chat messages
 	var/log_adminwarn = 0				// log warnings admins get about bomb construction and such
 	var/log_pda = 0						// log pda messages
+	var/log_world_output = 0			// log world.log << messages
 	var/log_runtimes = 0                // Logs all runtimes.
 	var/log_hrefs = 0					// logs all links clicked in-game. Could be used for debugging and tracking down exploits
 	var/log_runtime = 0					// logs world.log to a file
@@ -159,7 +160,7 @@
 	var/allow_holidays = 0
 	var/player_overflow_cap = 0 //number of players before the server starts rerouting
 	var/list/overflow_whitelist = list() //whitelist for overflow
-	
+
 	var/disable_away_missions = 0 // disable away missions
 
 /datum/configuration/New()
@@ -266,6 +267,9 @@
 
 				if ("log_pda")
 					config.log_pda = 1
+
+				if ("log_world_output")
+					config.log_world_output = 1
 
 				if ("log_hrefs")
 					config.log_hrefs = 1
@@ -518,7 +522,7 @@
 
 				if("overflow_server_url")
 					config.overflow_server_url = value
-					
+
 				if("disable_away_missions")
 					config.disable_away_missions = 1
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -71,7 +71,7 @@ datum/mind
 
 	proc/transfer_to(mob/living/new_character)
 		if(!istype(new_character))
-			world.log << "## DEBUG: transfer_to(): Some idiot has tried to transfer_to() a non mob/living mob. Please inform Carn"
+			log_to_dd("## DEBUG: transfer_to(): Some idiot has tried to transfer_to() a non mob/living mob. Please inform Carn")
 		if(current)					//remove ourself from our old body's mind variable
 			current.mind = null
 

--- a/code/game/asteroid.dm
+++ b/code/game/asteroid.dm
@@ -203,6 +203,6 @@ var/global/max_secret_rooms = 6
 				new garbage(T)
 				areapoints -= 5
 				emptyturfs -= T
-			//world.log << "The [theme] themed [T.loc] has been created!"
+			//log_to_dd("The [theme] themed [T.loc] has been created!")
 
 	return 1

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -96,7 +96,7 @@
 		sleep(150)
 		command_announcement.Announce("Gr3y.T1d3 virus detected in [station_name()] imprisonment subroutines. Recommend station AI involvement.", "Security Alert")
 	else
-		world.log << "ERROR: Could not initate grey-tide virus. Unable find prison or brig area."
+		log_to_dd("ERROR: Could not initate grey-tide virus. Unable find prison or brig area.")
 
 /proc/carp_migration() // -- Darem
 	for(var/obj/effect/landmark/C in landmarks_list)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -374,15 +374,15 @@
 				if(t_mind.current.client)
 					for(var/image/I in t_mind.current.client.images)
 						if((I.icon_state == "greytide" || I.icon_state == "greytide_head") && I.loc == traitor_mind.current)
-							//world.log << "deleting [traitor_mind] overlay"
+							//log_to_dd("deleting [traitor_mind] overlay")
 							qdel(I)
 		if(head)
-			//world.log << "found [head.name]"
+			//log_to_dd("found [head.name]")
 			if(head.current)
 				if(head.current.client)
 					for(var/image/I in head.current.client.images)
 						if((I.icon_state == "greytide" || I.icon_state == "greytide_head") && I.loc == traitor_mind.current)
-							//world.log << "deleting [traitor_mind] overlay"
+							//log_to_dd("deleting [traitor_mind] overlay")
 							qdel(I)
 	if(traitor_mind.current)
 		if(traitor_mind.current.client)

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -416,15 +416,15 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 				if(t_mind.current.client)
 					for(var/image/I in t_mind.current.client.images)
 						if((I.icon_state == "vampthrall" || I.icon_state == "vampire") && I.loc == vampire_mind.current)
-							//world.log << "deleting [vampire_mind] overlay"
+							//log_to_dd("deleting [vampire_mind] overlay")
 							qdel(I)
 		if(head)
-			//world.log << "found [head.name]"
+			//log_to_dd("found [head.name]")
 			if(head.current)
 				if(head.current.client)
 					for(var/image/I in head.current.client.images)
 						if((I.icon_state == "vampthrall" || I.icon_state == "vampire") && I.loc == vampire_mind.current)
-							//world.log << "deleting [vampire_mind] overlay"
+							//log_to_dd("deleting [vampire_mind] overlay")
 							qdel(I)
 	if(vampire_mind.current)
 		if(vampire_mind.current.client)

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -11,7 +11,7 @@
 	var/datum/vampire/vampire = src.mind.vampire
 
 	if(!vampire)
-		world.log << "[src] has vampire verbs but isn't a vampire."
+		log_to_dd("[src] has vampire verbs but isn't a vampire.")
 		return 0
 
 	var/fullpower = (VAMP_FULL in vampire.powers)
@@ -300,7 +300,7 @@
 			enthrall_safe = 1
 			break
 	if(!C)
-		world.log << "something bad happened on enthralling a mob src is [src] [src.key] \ref[src]"
+		log_to_dd("something bad happened on enthralling a mob src is [src] [src.key] \ref[src]")
 		return 0
 	if(!C.mind)
 		src << "\red [C.name]'s mind is not there for you to enthrall."

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -43,7 +43,7 @@
 	for(var/obj/machinery/camera/C in cameranet.cameras)
 		var/list/tempnetwork = C.network&src.network
 		if(C != src && C.c_tag == src.c_tag && tempnetwork.len)
-			world.log << "[src.c_tag] [src.x] [src.y] [src.z] conflicts with [C.c_tag] [C.x] [C.y] [C.z]"
+			log_to_dd("[src.c_tag] [src.x] [src.y] [src.z] conflicts with [C.c_tag] [C.x] [C.y] [C.z]")
 	*/
 	..()
 

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -637,7 +637,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	if(do_sleep)
 		sleep(rand(10,25))
 
-	//world.log << "Level: [signal.data["level"]] - Done: [signal.data["done"]]"
+	//log_to_dd("Level: [signal.data["level"]] - Done: [signal.data["done"]]")
 
 	return signal
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -1226,7 +1226,7 @@ steam.start() -- spawns the effect
 	var/r = rand(0,255)
 	var/g = rand(0,255)
 	var/b = rand(0,255)
-	world.log << "Colour , [r],[g],[b]"
+	log_to_dd("Colour , [r],[g],[b]")
 	I.Blend(rgb(r,g,b),ICON_MULTIPLY)
 	src.icon = I
 	playsound(src.loc, "sparks", 100, 1)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -144,7 +144,7 @@
 		var/timeofhour = TimeOfHour
 		var/took = round((start <= timeofhour) ? ((timeofhour-start)/10) : ((timeofhour-(start-36000))/10), 0.01)
 		//You need to press the DebugGame verb to see these now....they were getting annoying and we've collected a fair bit of data. Just -test- changes  to explosion code using this please so we can compare
-		if(Debug2)	world.log << "## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds."
+		if(Debug2)	log_to_dd("## DEBUG: Explosion([x0],[y0],[z0])(d[devastation_range],h[heavy_impact_range],l[light_impact_range]): Took [took] seconds.")
 
 		//Machines which report explosions.
 		for(var/i,i<=doppler_arrays.len,i++)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -60,7 +60,7 @@
 			frequency = sanitize_frequency(frequency, maxf)
 	// The max freq is higher than a regular headset to decrease the chance of people listening in, if you use the higher channels.
 	else if (frequency < 1441 || frequency > maxf)
-		//world.log << "[src] ([type]) has a frequency of [frequency], sanitizing."
+		//log_to_dd("[src] ([type]) has a frequency of [frequency], sanitizing.")
 		frequency = sanitize_frequency(frequency, maxf)
 
 	set_frequency(frequency)

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -530,11 +530,11 @@ var/list/mechtoys = list(
 
 /obj/machinery/computer/supplycomp/Topic(href, href_list)
 	if(!supply_controller)
-		world.log << "## ERROR: Eek. The supply_controller controller datum is missing somehow."
+		log_to_dd("## ERROR: Eek. The supply_controller controller datum is missing somehow.")
 		return
 	var/datum/shuttle/ferry/supply/shuttle = supply_controller.shuttle
 	if (!shuttle)
-		world.log << "## ERROR: Eek. The supply/shuttle datum is missing somehow."
+		log_to_dd("## ERROR: Eek. The supply/shuttle datum is missing somehow.")
 		return
 	if(..())
 		return

--- a/code/modules/DetectiveWork/detective_work.dm
+++ b/code/modules/DetectiveWork/detective_work.dm
@@ -17,19 +17,19 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 	if(M.wear_suit)
 		fibertext = "Material from \a [M.wear_suit]."
 		if(prob(10*item_multiplier) && !(fibertext in suit_fibers))
-			//world.log << "Added fibertext: [fibertext]"
+			//log_to_dd("Added fibertext: [fibertext]")
 			suit_fibers += fibertext
 		if(!(M.wear_suit.body_parts_covered & UPPER_TORSO))
 			if(M.w_uniform)
 				fibertext = "Fibers from \a [M.w_uniform]."
 				if(prob(12*item_multiplier) && !(fibertext in suit_fibers)) //Wearing a suit means less of the uniform exposed.
-					//world.log << "Added fibertext: [fibertext]"
+					//log_to_dd("Added fibertext: [fibertext]")
 					suit_fibers += fibertext
 		if(!(M.wear_suit.body_parts_covered & HANDS))
 			if(M.gloves)
 				fibertext = "Material from a pair of [M.gloves.name]."
 				if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
-					//world.log << "Added fibertext: [fibertext]"
+					//log_to_dd("Added fibertext: [fibertext]")
 					suit_fibers += fibertext
 	else if(M.w_uniform)
 		fibertext = "Fibers from \a [M.w_uniform]."
@@ -39,10 +39,10 @@ atom/proc/add_fibers(mob/living/carbon/human/M)
 		if(M.gloves)
 			fibertext = "Material from a pair of [M.gloves.name]."
 			if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
-				//world.log << "Added fibertext: [fibertext]"
+				//log_to_dd("Added fibertext: [fibertext]")
 				suit_fibers += "Material from a pair of [M.gloves.name]."
 	else if(M.gloves)
 		fibertext = "Material from a pair of [M.gloves.name]."
 		if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
-			//world.log << "Added fibertext: [fibertext]"
+			//log_to_dd("Added fibertext: [fibertext]")
 			suit_fibers += "Material from a pair of [M.gloves.name]."

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -34,7 +34,7 @@ world/IsBanned(key,address,computer_id)
 		var/ckeytext = ckey(key)
 
 		if(!establish_db_connection())
-			world.log << "Ban database connection failure. Key [ckeytext] not checked"
+			log_to_dd("Ban database connection failure. Key [ckeytext] not checked")
 			diary << "Ban database connection failure. Key [ckeytext] not checked"
 			return
 

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -102,7 +102,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 
 		establish_db_connection()
 		if(!dbcon.IsConnected())
-			world.log << "Failed to connect to database in load_admins(). Reverting to legacy system."
+			log_to_dd("Failed to connect to database in load_admins(). Reverting to legacy system.")
 			diary << "Failed to connect to database in load_admins(). Reverting to legacy system."
 			config.admin_legacy_system = 1
 			load_admins()
@@ -122,7 +122,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 			//find the client for a ckey if they are connected and associate them with the new admin datum
 			D.associate(directory[ckey])
 		if(!admin_datums)
-			world.log << "The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system."
+			log_to_dd("The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system.")
 			diary << "The database query in load_admins() resulted in no admins being added to the list. Reverting to legacy system."
 			config.admin_legacy_system = 1
 			load_admins()

--- a/code/modules/admin/banappearance.dm
+++ b/code/modules/admin/banappearance.dm
@@ -52,7 +52,7 @@ DEBUG
 			log_admin("appearance_keylist was empty")
 	else
 		if(!establish_db_connection())
-			world.log << "Database connection failed. Reverting to the legacy ban system."
+			log_to_dd("Database connection failed. Reverting to the legacy ban system.")
 			diary << "Database connection failed. Reverting to the legacy ban system."
 			config.ban_legacy_system = 1
 			appearance_loadbanfile()

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -64,7 +64,7 @@ DEBUG
 			log_admin("jobban_keylist was empty")
 	else
 		if(!establish_db_connection())
-			world.log << "Database connection failed. Reverting to the legacy ban system."
+			log_to_dd("Database connection failed. Reverting to the legacy ban system.")
 			diary << "Database connection failed. Reverting to the legacy ban system."
 			config.ban_legacy_system = 1
 			jobban_loadbanfile()

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -546,7 +546,7 @@ var/list/forbidden_varedit_object_types = list(
 		if("marked datum")
 			O.vars[variable] = holder.marked_datum
 
-	world.log << "### VarEdit by [src]: [O.type] [variable]=[html_encode("[O.vars[variable]]")]"
+	log_to_dd("### VarEdit by [src]: [O.type] [variable]=[html_encode("[O.vars[variable]]")]")
 	log_admin("[key_name(src)] modified [original_name]'s [variable] to [O.vars[variable]]")
 	message_admins("[key_name_admin(src)] modified [original_name]'s [variable] to [O.vars[variable]]", 1)
 

--- a/code/modules/awaymissions/maploader/swapmaps.dm
+++ b/code/modules/awaymissions/maploader/swapmaps.dm
@@ -585,7 +585,7 @@ proc/SwapMaps_CreateFromTemplate(template_id)
 	else if(swapmaps_mode!=SWAPMAPS_TEXT && fexists("map_[template_id].txt"))
 		text=1
 	else
-		world.log << "SwapMaps error in SwapMaps_CreateFromTemplate(): map_[template_id] file not found."
+		log_to_dd("SwapMaps error in SwapMaps_CreateFromTemplate(): map_[template_id] file not found.")
 		return
 	if(text)
 		S=new
@@ -612,7 +612,7 @@ proc/SwapMaps_LoadChunk(chunk_id,turf/locorner)
 	else if(swapmaps_mode!=SWAPMAPS_TEXT && fexists("map_[chunk_id].txt"))
 		text=1
 	else
-		world.log << "SwapMaps error in SwapMaps_LoadChunk(): map_[chunk_id] file not found."
+		log_to_dd("SwapMaps error in SwapMaps_LoadChunk(): map_[chunk_id] file not found.")
 		return
 	if(text)
 		S=new
@@ -630,9 +630,9 @@ proc/SwapMaps_LoadChunk(chunk_id,turf/locorner)
 
 proc/SwapMaps_SaveChunk(chunk_id,turf/corner1,turf/corner2)
 	if(!corner1 || !corner2)
-		world.log << "SwapMaps error in SwapMaps_SaveChunk():"
-		if(!corner1) world.log << "  corner1 turf is null"
-		if(!corner2) world.log << "  corner2 turf is null"
+		log_to_dd("SwapMaps error in SwapMaps_SaveChunk():")
+		if(!corner1) log_to_dd("  corner1 turf is null")
+		if(!corner2) log_to_dd("  corner2 turf is null")
 		return
 	var/swapmap/M=new
 	M.id=chunk_id
@@ -659,7 +659,7 @@ proc/SwapMaps_GetSize(id)
 	else if(swapmaps_mode!=SWAPMAPS_TEXT && fexists("map_[id].txt"))
 		text=1
 	else
-		world.log << "SwapMaps error in SwapMaps_GetSize(): map_[id] file not found."
+		log_to_dd("SwapMaps error in SwapMaps_GetSize(): map_[id] file not found.")
 		return
 	if(text)
 		S=new

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -44,7 +44,7 @@ proc/createRandomZlevel()
 			if(air_master)
 				air_master.setup_allturfs(block(locate(1, 1, world.maxz), locate(world.maxx, world.maxy, world.maxz)))
 			create_lighting_overlays(world.maxz)
-			world.log << "away mission loaded: [map]"
+			log_to_dd("away mission loaded: [map]")
 
 		for(var/obj/effect/landmark/L in landmarks_list)
 			if (L.name != "awaystart")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -31,7 +31,7 @@
 
 	//search the href for script injection
 	if( findtext(href,"<script",1,0) )
-		world.log << "Attempted use of scripts within a topic call, by [src]"
+		log_to_dd("Attempted use of scripts within a topic call, by [src]")
 		message_admins("Attempted use of scripts within a topic call, by [src]")
 		//del(usr)
 		return

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -4,7 +4,7 @@
 
 	var/releaseWhen = 60
 	var/list/area/areas = list()		//List of areas to affect. Filled by start()
-	
+
 	var/eventDept = "Security"			//Department name in announcement
 	var/list/areaName = list("Brig")	//Names of areas mentioned in AI and Engineering announcements
 	var/list/areaType = list(/area/security/prison, /area/security/brig, /area/security/permabrig)	//Area types to include.
@@ -54,7 +54,7 @@
 			A << "<span class='danger'>Malicious program detected in the [english_list(areaName)] lighting and airlock control systems by [my_department].</span>"
 
 	else
-		world.log << "ERROR: Could not initate grey-tide. Unable to find suitable containment area."
+		log_to_dd("ERROR: Could not initate grey-tide. Unable to find suitable containment area.")
 		kill()
 
 

--- a/code/modules/garbage collection/garbage_collector.dm
+++ b/code/modules/garbage collection/garbage_collector.dm
@@ -166,4 +166,4 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 	return ..()
 
 /proc/gcwarning(msg)
-	world.log << "## GC WARNING: [msg]"
+	log_to_dd("## GC WARNING: [msg]")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -136,7 +136,7 @@
 	tod = worldtime2text()		//weasellos time of death patch
 	if(mind)	mind.store_memory("Time of death: [tod]", 0)
 	if(ticker && ticker.mode)
-//		world.log << "k"
+//		log_to_dd("k")
 		sql_report_death(src)
 		ticker.mode.check_win()		//Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 	return ..(gibbed)

--- a/code/modules/mob/living/silicon/robot/wires.dm
+++ b/code/modules/mob/living/silicon/robot/wires.dm
@@ -21,7 +21,7 @@
 			BorgIndexToWireColor[flagIndex] = colorIndex
 			BorgWireColorToIndex[colorIndex] = flagIndex
 			colorIndexList -= colorIndex // Shortens the list.
-		//world.log << "Flag: [flag], CIndex: [colorIndex], FIndex: [flagIndex]"
+		//log_to_dd("Flag: [flag], CIndex: [colorIndex], FIndex: [flagIndex]")
 		flagIndex+=1
 	return Borgwires
 

--- a/code/modules/nano/nanomapgen.dm
+++ b/code/modules/nano/nanomapgen.dm
@@ -19,42 +19,42 @@
 /client/proc/nanomapgen_DumpImage()
 	set name = "Generate NanoUI Map"
 	set category = "Mapping"
-	
+
 	if(holder)
-		nanomapgen_DumpTile(1, 1, text2num(input(usr,"Enter the Z level to generate")))	
+		nanomapgen_DumpTile(1, 1, text2num(input(usr,"Enter the Z level to generate")))
 
 /client/proc/nanomapgen_DumpTile(var/startX = 1, var/startY = 1, var/currentZ = 1, var/endX = -1, var/endY = -1)
 
 	if (endX < 0 || endX > world.maxx)
 		endX = world.maxx
-		
+
 	if (endY < 0 || endY > world.maxy)
 		endY = world.maxy
-		
+
 	if (currentZ < 0 || currentZ > world.maxz)
 		usr << "NanoMapGen: <B>ERROR: currentZ ([currentZ]) must be between 1 and [world.maxz]</B>"
-		
+
 		sleep(3)
 		return NANOMAP_TERMINALERR
-		
+
 	if (startX > endX)
 		usr << "NanoMapGen: <B>ERROR: startX ([startX]) cannot be greater than endX ([endX])</B>"
-		
+
 		sleep(3)
 		return NANOMAP_TERMINALERR
-		
+
 	if (startY > endX)
 		usr << "NanoMapGen: <B>ERROR: startY ([startY]) cannot be greater than endY ([endY])</B>"
 		sleep(3)
 		return NANOMAP_TERMINALERR
-		
+
 	var/icon/Tile = icon(file("nano/mapbase1024.png"))
 	if (Tile.Width() != NANOMAP_MAX_ICON_DIMENSION || Tile.Height() != NANOMAP_MAX_ICON_DIMENSION)
-		world.log << "NanoMapGen: <B>ERROR: BASE IMAGE DIMENSIONS ARE NOT [NANOMAP_MAX_ICON_DIMENSION]x[NANOMAP_MAX_ICON_DIMENSION]</B>"
+		log_to_dd("NanoMapGen: <B>ERROR: BASE IMAGE DIMENSIONS ARE NOT [NANOMAP_MAX_ICON_DIMENSION]x[NANOMAP_MAX_ICON_DIMENSION]</B>")
 		sleep(3)
 		return NANOMAP_TERMINALERR
-		
-	world.log << "NanoMapGen: <B>GENERATE MAP ([startX],[startY],[currentZ]) to ([endX],[endY],[currentZ])</B>"	
+
+	log_to_dd("NanoMapGen: <B>GENERATE MAP ([startX],[startY],[currentZ]) to ([endX],[endY],[currentZ])</B>")
 	usr << "NanoMapGen: <B>GENERATE MAP ([startX],[startY],[currentZ]) to ([endX],[endY],[currentZ])</B>"
 
 	var/count = 0;
@@ -62,26 +62,26 @@
 		for(var/WorldY = startY, WorldY <= endY, WorldY++)
 
 			var/atom/Turf = locate(WorldX, WorldY, currentZ)
-			
+
 			var/icon/TurfIcon = new(Turf.icon, Turf.icon_state)
 			TurfIcon.Scale(NANOMAP_ICON_SIZE, NANOMAP_ICON_SIZE)
-			
+
 			Tile.Blend(TurfIcon, ICON_OVERLAY, ((WorldX - 1) * NANOMAP_ICON_SIZE), ((WorldY - 1) * NANOMAP_ICON_SIZE))
-			
+
 			count++
-			
+
 			if (count % 8000 == 0)
-				world.log << "NanoMapGen: <B>[count] tiles done</B>"
+				log_to_dd("NanoMapGen: <B>[count] tiles done</B>")
 				sleep(1)
-				
+
 	var/mapFilename = "nanomap_z[currentZ]-new.png"
-	
-	world.log << "NanoMapGen: <B>sending [mapFilename] to client</B>"
+
+	log_to_dd("NanoMapGen: <B>sending [mapFilename] to client</B>")
 
 	usr << browse(Tile, "window=picture;file=[mapFilename];display=0")
-	
-	world.log << "NanoMapGen: <B>Done.</B>"
-	
+
+	log_to_dd("NanoMapGen: <B>Done.</B>")
+
 	usr << "NanoMapGen: <B>Done. File [mapFilename] uploaded to your cache.</B>"
 
 	if (Tile.Width() != NANOMAP_MAX_ICON_DIMENSION || Tile.Height() != NANOMAP_MAX_ICON_DIMENSION)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -234,7 +234,7 @@
 
 //remove the old powernet and replace it with a new one throughout the network.
 /proc/propagate_network(var/obj/O, var/datum/powernet/PN)
-	//world.log << "propagating new network"
+	//log_to_dd("propagating new network")
 	var/list/worklist = list()
 	var/list/found_machines = list()
 	var/index = 1
@@ -282,7 +282,7 @@
 	//merge net2 into net1
 	for(var/obj/structure/cable/Cable in net2.cables) //merge cables
 		net1.add_cable(Cable)
-		
+
 	if(!net2) return net1
 
 	for(var/obj/machinery/power/Node in net2.nodes) //merge power machines

--- a/code/world.dm
+++ b/code/world.dm
@@ -30,7 +30,7 @@ var/global/datum/global_init/init = new ()
 	diaryofmeanpeople << "\n\nStarting up. [time2text(world.timeofday, "hh:mm.ss")]\n---------------------"
 
 	if(byond_version < RECOMMENDED_VERSION)
-		world.log << "Your server's byond version does not meet the recommended requirements for this code. Please update BYOND"
+		log_to_dd("Your server's byond version does not meet the recommended requirements for this code. Please update BYOND")
 
 	if(config && config.log_runtimes)
 		log = file("data/logs/runtime/[time2text(world.realtime,"YYYY-MM-DD-(hh-mm-ss)")]-runtime.log")
@@ -42,8 +42,8 @@ var/global/datum/global_init/init = new ()
 		// dumb and hardcoded but I don't care~
 		config.server_name += " #[(world.port % 1000) / 100]"
 
-	timezoneOffset = text2num(time2text(0,"hh")) * 36000	
-		
+	timezoneOffset = text2num(time2text(0,"hh")) * 36000
+
 	if(config && config.log_runtime)
 		log = file("data/logs/runtime/[time2text(world.realtime,"YYYY-MM-DD-(hh-mm-ss)")]-runtime.log")
 
@@ -412,9 +412,9 @@ var/failed_old_db_connections = 0
 
 /hook/startup/proc/connectDB()
 	if(!setup_database_connection())
-		world.log << "Your server failed to establish a connection with the feedback database."
+		log_to_dd("Your server failed to establish a connection with the feedback database.")
 	else
-		world.log << "Feedback database connection established."
+		log_to_dd("Feedback database connection established.")
 	return 1
 
 proc/setup_database_connection()
@@ -437,7 +437,7 @@ proc/setup_database_connection()
 		failed_db_connections = 0	//If this connection succeeded, reset the failed connections counter.
 	else
 		failed_db_connections++		//If it failed, increase the failed connections counter.
-		world.log << dbcon.ErrorMsg()
+		log_to_dd(dbcon.ErrorMsg())
 
 	return .
 
@@ -454,9 +454,9 @@ proc/establish_db_connection()
 
 /hook/startup/proc/connectOldDB()
 	if(!setup_old_database_connection())
-		world.log << "Your server failed to establish a connection with the SQL database."
+		log_to_dd("Your server failed to establish a connection with the SQL database.")
 	else
-		world.log << "SQL database connection established."
+		log_to_dd("SQL database connection established.")
 	return 1
 
 //These two procs are for the old database, while it's being phased out. See the tgstation.sql file in the SQL folder for more information.
@@ -480,7 +480,7 @@ proc/setup_old_database_connection()
 		failed_old_db_connections = 0	//If this connection succeeded, reset the failed connections counter.
 	else
 		failed_old_db_connections++		//If it failed, increase the failed connections counter.
-		world.log << dbcon.ErrorMsg()
+		log_to_dd(dbcon.ErrorMsg())
 
 	return .
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -54,6 +54,9 @@ LOG_PDA
 ## log world.log and runtime errors to a file
 LOG_RUNTIME
 
+## log world.log messages
+# LOG_WORLD_OUTPUT
+
 ## log all Topic() calls (for use by coders in tracking down Topic issues)
 # LOG_HREFS
 


### PR DESCRIPTION
This commit changes every 'world.log <<' message with a loggable proc-
log_to_dd().

This is adjustable in the config; If LOG_WORLD_OUTPUT is present, all
things sent to world.log will show up in the standard /data/logs/ logs.

These logs will contain the following (in order):
 - Timestamp
 - "DD_OUTPUT:"
 - The message.

The config option for this, by default, is turned off.


Edit:
Example log: [18:17:19]DD_OUTPUT: Feedback database connection established.