### PR TITLE
Fixes Bad PDA Message Entries and Ringtone Consistency

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -134,12 +134,7 @@
 						useMS.send_pda_message("[P.owner]", "[command_name()] Payroll", msg)
 
 						// BUT NOPE, NEED TO DO THIS BULLSHIT.
-						P.tnote += "<i><b>&larr; From [command_name()] (Payroll):</b></i><br>[msg]<br>"
-
-						if (!P.silent)
-							playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
-						for (var/mob/O in hearers(3, P.loc))
-							if(!P.silent) O.show_message(text("\icon[P] *[P.ttone]*"))
+						P.play_ringtone()
 						//Search for holder of the PDA.
 						var/mob/living/L = null
 						if(P.loc && isliving(P.loc))

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -105,10 +105,7 @@ datum/game_mode/mutiny
 		if (!pda)
 			return 0
 
-		if (!pda.silent)
-			playsound(pda.loc, 'sound/machines/twobeep.ogg', 50, 1)
-			for (var/mob/O in hearers(3, pda.loc))
-				O.show_message(text("\icon[pda] *[pda.ttone]*"))
+		pda.play_ringtone()
 
 		head_mutineer.current << fluff.get_pda_body()
 		return 1

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -446,16 +446,13 @@
 						//Sender isn't faking as someone who exists
 						if(isnull(PDARec))
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[customsender]","[custommessage]")
-							if (!customrecepient.silent)
-								playsound(customrecepient.loc, 'sound/machines/twobeep.ogg', 50, 1)
-								for (var/mob/O in hearers(3, customrecepient.loc))
-									O.show_message(text("\icon[customrecepient] *[customrecepient.ttone]*"))
-								if( customrecepient.loc && ishuman(customrecepient.loc) )
-									var/mob/living/carbon/human/H = customrecepient.loc
-									H << "\icon[customrecepient] <b>Message from [customsender] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)"
-								log_pda("[usr] (PDA: [customsender]) sent \"[custommessage]\" to [customrecepient.owner]")
-								customrecepient.overlays.Cut()
-								customrecepient.overlays += image('icons/obj/pda.dmi', "pda-r")
+							customrecepient.play_ringtone()
+							if( customrecepient.loc && ishuman(customrecepient.loc) )
+								var/mob/living/carbon/human/H = customrecepient.loc
+								H << "\icon[customrecepient] <b>Message from [customsender] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[src];choice=Message;skiprefresh=1;target=\ref[src]'>Reply</a>)"
+							log_pda("[usr] (PDA: [customsender]) sent \"[custommessage]\" to [customrecepient.owner]")
+							customrecepient.overlays.Cut()
+							customrecepient.overlays += image('icons/obj/pda.dmi', "pda-r")
 						//Sender is faking as someone who exists
 						else
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[PDARec.owner]","[custommessage]")
@@ -464,16 +461,13 @@
 							if(!customrecepient.conversations.Find("\ref[PDARec]"))
 								customrecepient.conversations.Add("\ref[PDARec]")
 
-							if (!customrecepient.silent)
-								playsound(customrecepient.loc, 'sound/machines/twobeep.ogg', 50, 1)
-								for (var/mob/O in hearers(3, customrecepient.loc))
-									O.show_message(text("\icon[customrecepient] *[customrecepient.ttone]*"))
-								if( customrecepient.loc && ishuman(customrecepient.loc) )
-									var/mob/living/carbon/human/H = customrecepient.loc
-									H << "\icon[customrecepient] <b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[customrecepient];choice=Message;skiprefresh=1;target=\ref[PDARec]'>Reply</a>)"
-								log_pda("[usr] (PDA: [PDARec.owner]) sent \"[custommessage]\" to [customrecepient.owner]")
-								customrecepient.overlays.Cut()
-								customrecepient.overlays += image('icons/obj/pda.dmi', "pda-r")
+							customrecepient.play_ringtone()
+							if( customrecepient.loc && ishuman(customrecepient.loc) )
+								var/mob/living/carbon/human/H = customrecepient.loc
+								H << "\icon[customrecepient] <b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[customrecepient];choice=Message;skiprefresh=1;target=\ref[PDARec]'>Reply</a>)"
+							log_pda("[usr] (PDA: [PDARec.owner]) sent \"[custommessage]\" to [customrecepient.owner]")
+							customrecepient.overlays.Cut()
+							customrecepient.overlays += image('icons/obj/pda.dmi', "pda-r")
 						//Finally..
 						ResetMessage()
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -921,14 +921,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					ai.show_message("<i>Intercepted message from <b>[who]</b>: [t]</i>")
 */
 
-		if (!P.silent)
-			var/sound/S = sound('sound/machines/twobeep.ogg')
-
-			if(P.ttone in ttone_sound)
-				S = ttone_sound[P.ttone]
-			playsound(P.loc, S, 50, 1)
-		for (var/mob/O in hearers(3, P.loc))
-			if(!P.silent) O.show_message(text("\icon[P] *[P.ttone]*"))
+		P.play_ringtone()
 		//Search for holder of the PDA.
 		var/mob/living/L = null
 		if(P.loc && isliving(P.loc))
@@ -951,6 +944,15 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		U << "<span class='notice'>ERROR: Messaging server is not responding.</span>"
 
+/obj/item/device/pda/proc/play_ringtone()
+	if (!silent)
+		var/sound/S = sound('sound/machines/twobeep.ogg')
+
+		if(ttone in ttone_sound)
+			S = ttone_sound[ttone]
+		playsound(loc, S, 50, 1)
+	for (var/mob/O in hearers(3, loc))
+		if(!silent) O.show_message(text("\icon[src] *[ttone]*"))
 
 /obj/item/device/pda/verb/verb_remove_id()
 	set category = null

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -104,10 +104,7 @@
 			//Commented out because we don't send messages like this anymore.  Instead it will just popup in their chat window.
 			//P.tnote += "<i><b>&larr; From [sender] (Unknown / spam?):</b></i><br>[message]<br>"
 
-			if (!P.silent)
-				playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
-			for (var/mob/O in hearers(3, P.loc))
-				if(!P.silent) O.show_message(text("\icon[P] *[P.ttone]*"))
+			P.play_ringtone()
 			//Search for holder of the PDA.
 			var/mob/living/L = null
 			if(P.loc && isliving(P.loc))

--- a/code/modules/ninja/suit/SpiderOS.dm
+++ b/code/modules/ninja/suit/SpiderOS.dm
@@ -216,10 +216,17 @@
 				display_to << "<span class='danger'>Error: unable to deliver message.</span>"
 				display_spideros()
 				return
-			P.tnote += "<i><b>&larr; From an unknown source:</b></i><br>[t]<br>"
-			if (!P.silent)
-				playsound(P.loc, 'sound/machines/twobeep.ogg', 50, 1)
-				P.audible_message("\icon[P] *[P.ttone]*", null, 3)
+			//Search for holder of the PDA.
+			var/mob/living/L = null
+			if(P.loc && isliving(P.loc))
+				L = P.loc
+			//Maybe they are a pAI!
+			else
+				L = get(P, /mob/living/silicon)
+
+			if(L)
+				L << "\icon[P] <b>Message from unknown source: </b>\"[t]\" (Unable to Reply)"
+			P.play_ringtone()
 			P.overlays.Cut()
 			P.overlays += image('icons/obj/pda.dmi', "pda-r")
 


### PR DESCRIPTION
When PDAs were transitioned to NanoUI, the way they stored messages became more complicated. Unfortunately, a couple things that added messages to PDAs weren't updated, the main offender being job objective completion. If you complete a job objective, it adds a bad entry to your PDA's message list, and entering the messenger will make your PDA non-functional. This PR fixes that.

I looked into finding a way to make messages without a proper sender show up in the PDA's messenger, but it turns out the way messages are handled is _really_ convoluted. It would require either drastically changing the way messages are handled, or generating fake PDAs. Not worth the trouble.

While I was looking at PDA code, I noticed ringtones weren't handled consistently, making the recent ringtone changes not work quite right for non-standard messages. Ringtone handling has been moved into a new `play_ringtone` proc, and everything uses that to play a PDA's ringtone.

* Fixes completing job objectives adding an invalid tnote entry to PDAs, breaking them when you try to view your messages.
* Fixes PDA ringtones not being handled consistently.
* Fixes the message monitor console not properly displaying faked messages to people whose PDAs are silent.
* Does not touch the unused message monitor computer program, but does fix a bad tnote entry in the unused SpiderOS UI, since I forgot it's not used anymore.