### PR TITLE
Spawn panel improvements

### DIFF
--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -10,7 +10,7 @@ var/list/create_object_forms = list(/obj, /obj/structure, /obj/machinery, /obj/e
 
 	user << browse(replacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=425x475")
 
-/datum/admins/proc/quick_create_object(mob/user)
+/datum/admins/proc/quick_create_object(var/mob/user)
 	var/path = input("Select the path of the object you wish to create.", "Path", /obj) in create_object_forms
 	var/html_form = create_object_forms[path]
 

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -1,4 +1,5 @@
-/var/create_object_html = null
+var/create_object_html = null
+var/list/create_object_forms = list(/obj, /obj/structure, /obj/machinery, /obj/effect, /obj/item, /obj/mecha, /obj/item/weapon, /obj/item/clothing, /obj/item/stack, /obj/item/device, /obj/item/weapon/reagent_containers, /obj/item/weapon/gun)
 
 /datum/admins/proc/create_object(var/mob/user)
 	if (!create_object_html)
@@ -9,20 +10,14 @@
 
 	user << browse(replacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=425x475")
 
+/datum/admins/proc/quick_create_object(mob/user)
+	var/path = input("Select the path of the object you wish to create.", "Path", /obj) in create_object_forms
+	var/html_form = create_object_forms[path]
 
-/datum/admins/proc/quick_create_object(var/mob/user)
+	if (!html_form)
+		var/objectjs = list2text(typesof(path), ";")
+		html_form = file2text('html/create_object.html')
+		html_form = replacetext(html_form, "null /* object types */", "\"[objectjs]\"")
+		create_object_forms[path] = html_form
 
-	var/quick_create_object_html = null
-	var/pathtext = null
-
-	pathtext = input("Select the path of the object you wish to create.", "Path", "/obj") in list("/obj","/obj/structure","/obj/item","/obj/item/weapon","/obj/item/clothing","/obj/machinery","/obj/mecha")
-
-	var path = text2path(pathtext)
-
-	if (!quick_create_object_html)
-		var/objectjs = null
-		objectjs = list2text(typesof(path), ";")
-		quick_create_object_html = file2text('html/create_object.html')
-		quick_create_object_html = replacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
-
-	user << browse(replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=425x475")
+	user << browse(replacetext(html_form, "/* ref src */", "\ref[src]"), "window=qco[path];size=425x475")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2020,6 +2020,7 @@
 										I.loc = R.module
 										R.module.rebuild()
 										R.activate_module(I)
+										R.module.fix_modules()
 
 		if (number == 1)
 			log_admin("[key_name(usr)] created a [english_list(paths)]")

--- a/html/create_object.html
+++ b/html/create_object.html
@@ -27,7 +27,7 @@
 	<form name="spawner" action="byond://?src=/* ref src */" method="get">
 		<input type="hidden" name="src" value="/* ref src */">
 		
-		Type <input type="text" name="filter" value="" onkeypress="submitFirst(event)" style="width:350px"> <input type = "button" value = "Search" onclick = "updateSearch()" /><br>
+		Type <input type="text" name="filter" value="" onkeypress="submitFirst(event)" style="width:280px;height:25"> <input type = "button" value = "Search" onclick = "updateSearch()" /><br>
 		Offset: <input type="text" name="offset" value="x,y,z" style="width:250px">
 		
 		A <input type="radio" name="offset_type" value="absolute">
@@ -39,12 +39,12 @@
 		Where: 
 			<select name='object_where' style="width:320px">
 				<option value='onfloor'>On floor below own mob</option>
-				<!-- <option value='inhand'>In own mob's hand</option> -->
+				<option value='inhand'>In own mob's hand</option>
 				<option value='inmarked'>In marked object</option>
 			</select>
 		<br><br>
 		<select name="object_list" id="object_list" size="18" multiple style="width:98%"></select><br>
-		<input type="submit" value="Spawn">
+		<input type="submit" value="spawn">
 	</form>
 	
 	<script language="JavaScript">
@@ -54,7 +54,6 @@
 		var objects = object_paths == null ? new Array() : object_paths.split(";");
 		
 		document.spawner.filter.focus();
-		populateList(objects);
 		
 		function populateList(from_list)
 		{
@@ -74,10 +73,12 @@
 		{
 			old_search = document.spawner.filter.value;
 			
+			
 			var filtered = new Array();
-			for(var i in objects)
+			var i;
+			for (i in objects)
 			{
-				if(objects[i].indexOf(old_search) < 0)
+				if(objects[i].search(old_search) < 0)
 				{
 					continue;
 				}


### PR DESCRIPTION
Changes:
1) Improves the spawn panel. The "in-hand" option now works (also for cyborgs), adds way more options for the base path of the item you can spawn, and the spawn panel starts empty so you don't have to load it twice and lag twice (click "Search" to fill it with all paths). Ported from https://github.com/tgstation/-tg-station/pull/11221.