### PR TITLE
Admin teleport update, further admin message fixes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -867,7 +867,7 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 /proc/hasvar(var/datum/A, var/varname)
 	if(A.vars.Find(lowertext(varname))) return 1
 	else return 0
-
+	
 //Returns: all the areas in the world
 /proc/return_areas()
 	var/list/area/areas = list()
@@ -877,8 +877,8 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 
 //Returns: all the areas in the world, sorted.
 /proc/return_sorted_areas()
-	return sortAtom(return_areas())
-
+	return sortAtom(return_areas())	
+	
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all areas of that type in the world.
 /proc/get_areas(var/areatype)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -605,56 +605,6 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		return M
 	if(M < 0)
 		return -M
-
-
-/proc/key_name(var/whom, var/include_link = null, var/include_name = 1, var/type = null)
-	var/mob/M
-	var/client/C
-	var/key
-
-	if(!whom)	return "*null*"
-	if(istype(whom, /client))
-		C = whom
-		M = C.mob
-		key = C.key
-	else if(ismob(whom))
-		M = whom
-		C = M.client
-		key = M.key
-	else if(istype(whom, /datum))
-		var/datum/D = whom
-		return "*invalid:[D.type]*"
-	else
-		return "*invalid*"
-
-	. = ""
-
-	if(key)
-		if(include_link && C)
-			. += "<a href='?priv_msg=\ref[C];type=[type]'>"
-
-		if(C && C.holder && C.holder.fakekey && !include_name)
-			. += "Administrator"
-		else
-			. += key
-
-		if(include_link)
-			if(C)	. += "</a>"
-			else	. += " (DC)"
-	else
-		. += "*no key*"
-
-	if(include_name && M)
-		if(M.real_name)
-			. += "/([M.real_name])"
-		else if(M.name)
-			. += "/([M.name])"
-
-	return .
-
-/proc/key_name_admin(var/whom, var/include_name = 1)
-	var/message = "[key_name(whom, 1, include_name)](<A HREF='?_src_=holder;adminmoreinfo=\ref[whom]'>?</A>)[isAntag(whom) ? " (ANTAG)" : ""] ([admin_jump_link(whom, "holder")])"
-	return message
 	
 /proc/get_mob_by_ckey(key)
 	if(!key)

--- a/code/_globalvars/mapping.dm
+++ b/code/_globalvars/mapping.dm
@@ -51,5 +51,5 @@ var/list/blobstart = list()
 var/list/ninjastart = list()
 var/list/carplist = list() //list of all carp-spawn landmarks
 
-	//away missions
+//away missions
 var/list/awaydestinations = list()	//a list of landmarks that the warpgate can take you to

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -1,7 +1,57 @@
-proc/log_and_message_admins(var/message as text)
+/proc/key_name(var/whom, var/include_link = null, var/include_name = 1, var/type = null)
+	var/mob/M
+	var/client/C
+	var/key
+
+	if(!whom)	return "*null*"
+	if(istype(whom, /client))
+		C = whom
+		M = C.mob
+		key = C.key
+	else if(ismob(whom))
+		M = whom
+		C = M.client
+		key = M.key
+	else if(istype(whom, /datum))
+		var/datum/D = whom
+		return "*invalid:[D.type]*"
+	else
+		return "*invalid*"
+
+	. = ""
+
+	if(key)
+		if(include_link && C)
+			. += "<a href='?priv_msg=\ref[C];type=[type]'>"
+
+		if(C && C.holder && C.holder.fakekey && !include_name)
+			. += "Administrator"
+		else
+			. += key
+
+		if(include_link)
+			if(C)	. += "</a>"
+			else	. += " (DC)"
+	else
+		. += "*no key*"
+
+	if(include_name && M)
+		if(M.real_name)
+			. += "/([M.real_name])"
+		else if(M.name)
+			. += "/([M.name])"
+
+	return .
+
+/proc/key_name_admin(var/whom, var/include_name = 1)
+	var/message = "[key_name(whom, 1, include_name)](<A HREF='?_src_=holder;adminmoreinfo=\ref[whom]'>?</A>)[isAntag(whom) ? "(A)" : ""] ([admin_jump_link(whom, "holder")])"
+	return message
+
+/proc/log_and_message_admins(var/message as text)
 	log_admin("[usr]([usr.ckey]) " + message)
 	message_admins("[usr]([usr.ckey]) " + message)
 
-proc/admin_log_and_message_admins(var/message as text)
+/proc/admin_log_and_message_admins(var/message as text)
 	log_admin("[key_name(usr)] " + message)
 	message_admins("[key_name_admin(usr)] " + message, 1)
+	

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -54,14 +54,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/air_doors_activated = 0
 
 	var/tele_proof = 0
-
+	
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 var/list/teleportlocs = list()
-
-/hook/startup/proc/setupTeleportLocs()
+/proc/process_teleport_locs()
 	for(var/area/AR in world)
-		if(istype(AR, /area/shuttle) || istype(AR, /area/syndicate_station) || istype(AR, /area/wizard_station)) continue
 		if(teleportlocs.Find(AR.name)) continue
 		var/list/turfs = get_area_turfs(AR.type)
 		if(turfs.len)
@@ -73,21 +71,15 @@ var/list/teleportlocs = list()
 	teleportlocs = sortAssoc(teleportlocs)
 
 	return 1
-
+	
 var/list/ghostteleportlocs = list()
-
-/hook/startup/proc/setupGhostTeleportLocs()
+/proc/process_ghost_teleport_locs()
 	for(var/area/AR in world)
 		if(ghostteleportlocs.Find(AR.name)) continue
-		if(istype(AR, /area/tdome))
-			ghostteleportlocs += AR.name
-			ghostteleportlocs[AR.name] = AR
 		var/list/turfs = get_area_turfs(AR.type)
 		if(turfs.len)
-			var/turf/picked = pick(turfs)
-			if ((picked.z in config.player_levels))
-				ghostteleportlocs += AR.name
-				ghostteleportlocs[AR.name] = AR
+			ghostteleportlocs += AR.name
+			ghostteleportlocs[AR.name] = AR
 
 	ghostteleportlocs = sortAssoc(ghostteleportlocs)
 

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -58,7 +58,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
 var/list/teleportlocs = list()
-/proc/process_teleport_locs()
+/hook/startup/proc/process_teleport_locs()
 	for(var/area/AR in world)
 		if(teleportlocs.Find(AR.name)) continue
 		var/list/turfs = get_area_turfs(AR.type)
@@ -73,7 +73,7 @@ var/list/teleportlocs = list()
 	return 1
 	
 var/list/ghostteleportlocs = list()
-/proc/process_ghost_teleport_locs()
+/hook/startup/proc/process_ghost_teleport_locs()
 	for(var/area/AR in world)
 		if(ghostteleportlocs.Find(AR.name)) continue
 		var/list/turfs = get_area_turfs(AR.type)

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -82,7 +82,7 @@ Obviously, requires DNA2.
 	M.update_mutations()		//update our mutation overlays
 	M.update_body()
 	//M.say(pick("",";")+pick("HULK MAD","YOU MADE HULK ANGRY")) // Just a note to security.
-	message_admins("[key_name(usr)] has hulked out! ([formatJumpTo(usr)])")
+	message_admins("[key_name_admin(usr)] has hulked out! ([formatJumpTo(usr)])")
 	return
 */
 

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -125,13 +125,13 @@ var/list/blob_nodes = list()
 			if(location.z != ZLEVEL_STATION || istype(location, /turf/space))
 				if(!warned)
 					C << "<span class='userdanger'>You feel ready to burst, but this isn't an appropriate place!  You must return to the station!</span>"
-					message_admins("[key_name(C)] was in space when the blobs burst, and will die if he doesn't return to the station.")
+					message_admins("[key_name_admin(C)] was in space when the blobs burst, and will die if he doesn't return to the station.")
 					spawn(300)
 						burst_blob(blob, 1)
 				else
 					burst ++
 					log_admin("[key_name(C)] was in space when attempting to burst as a blob.")
-					message_admins("[key_name(C)] was in space when attempting to burst as a blob.")
+					message_admins("[key_name_admin(C)] was in space when attempting to burst as a blob.")
 					C.gib()
 					make_blobs(1)
 					check_finished() //Still needed in case we can't make any blobs

--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -133,7 +133,7 @@ var/global/Holiday = null
 	world.update_status()
 	Holiday_Game_Start()
 
-	message_admins("\blue ADMIN: Event: [key_name(src)] force-set Holiday to \"[Holiday]\"")
+	message_admins("\blue ADMIN: Event: [key_name_admin(src)] force-set Holiday to \"[Holiday]\"")
 	log_admin("[key_name(src)] force-set Holiday to \"[Holiday]\"")
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -479,7 +479,7 @@ proc/display_roundstart_logout_report()
 				if(L.suiciding)	//Suicider
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (<font color='red'><b>Suicide</b></font>)\n"
 					job_master.FreeRole(L.job)
-					message_admins("<b>[L.name]</b> ([L.ckey]), the [L.job] has been freed due to (<font color='#ffcc00'><b>Early Round Suicide</b></font>)\n")
+					message_admins("<b>[key_name_admin(L)]</b>, the [L.job] has been freed due to (<font color='#ffcc00'><b>Early Round Suicide</b></font>)\n")
 					continue //Disconnected client
 				if(L.stat == UNCONSCIOUS)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dying)\n"
@@ -505,7 +505,7 @@ proc/display_roundstart_logout_report()
 					else
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] (<font color='red'><b>Ghosted</b></font>)\n"
 						job_master.FreeRole(L.job)
-						message_admins("<b>[L.name]</b> ([L.ckey]), the [L.job] has been freed due to (<font color='#ffcc00'><b>Early Round Ghosted While Alive</b></font>)\n")
+						message_admins("<b>[key_name_admin(L)]</b>, the [L.job] has been freed due to (<font color='#ffcc00'><b>Early Round Ghosted While Alive</b></font>)\n")
 						continue //Ghosted while alive
 
 

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -332,8 +332,8 @@ datum/game_mode/mutiny
 
 	if (M)
 		src << "Attempting to recruit [M]..."
-		log_admin("[src]([src.ckey]) attempted to recruit [M] as a loyalist.")
-		message_admins("\red [src]([src.ckey]) attempted to recruit [M] as a loyalist.")
+		log_admin("[key_name(src)] attempted to recruit [M] as a loyalist.")
+		message_admins("\red [key_name_admin(src)] attempted to recruit [M] as a loyalist.")
 
 		var/choice = alert(M, "Asked by [src]: Will you help me complete Directive X?", "Loyalist recruitment", "Yes", "No")
 		if(choice == "Yes")
@@ -369,8 +369,8 @@ datum/game_mode/mutiny
 
 	if (M)
 		src << "Attempting to recruit [M]..."
-		log_admin("[src]([src.ckey]) attempted to recruit [M] as a mutineer.")
-		message_admins("\red [src]([src.ckey]) attempted to recruit [M] as a mutineer.")
+		log_admin("[key_name(src)] attempted to recruit [M] as a mutineer.")
+		message_admins("\red [key_name_admin(src)] attempted to recruit [M] as a mutineer.")
 
 		var/choice = alert(M, "Asked by [src]: Will you help me stop Directive X?", "Mutineer recruitment", "Yes", "No")
 		if(choice == "Yes")

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -428,9 +428,9 @@ datum/game_mode/nations
 			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
 			return 1
 		else
-			message_admins("[H.name] with [H.mind.assigned_role] could not find any nation to assign!")
+			message_admins("[key_name_admin(H)] with [H.mind.assigned_role] could not find any nation to assign!")
 			return 1
-	message_admins("[H.name] latejoined with no mind.")
+	message_admins("[key_name_admin(H)] latejoined with no mind.")
 	return 1
 
 /proc/get_nations_mode()

--- a/code/game/gamemodes/revolution/rp-revolution.dm
+++ b/code/game/gamemodes/revolution/rp-revolution.dm
@@ -294,8 +294,8 @@ mob/living/carbon/human/proc
 					src << "\red Wait five seconds before reconversion attempt."
 					return
 				src << "\red Attempting to convert [M]..."
-				log_admin("[src]([src.ckey]) attempted to convert [M].")
-				message_admins("\red [src]([src.ckey]) attempted to convert [M].")
+				log_admin("[key_name(src)] attempted to convert [M].")
+				message_admins("\red [key_name_admin(src)] attempted to convert [M].")
 				var/choice = alert(M,"Asked by [src]: Do you want to join the revolution?","Align Thyself with the Revolution!","No!","Yes!")
 				if(choice == "Yes!")
 					ticker.mode:add_revolutionary(M.mind)

--- a/code/game/gamemodes/wizard/rightandwrong.dm
+++ b/code/game/gamemodes/wizard/rightandwrong.dm
@@ -5,7 +5,7 @@
 	var/list/magiclist = list("fireball","smoke","blind","mindswap","forcewall","knock","horsemask","charge", "summonitem", "wandnothing", "wanddeath", "wandresurrection", "wandpolymorph", "wandteleport", "wanddoor", "wandfireball", "staffhealing", "armor", "scrying", "staffdoor", "special")
 	var/list/magicspeciallist = list("staffchange","staffanimation", "wandbelt", "contract", "staffchaos")
 	usr << "<B>You summoned [summon_type ? "magic" : "guns"]!</B>"
-	message_admins("[key_name_admin(usr, 1)] summoned [summon_type ? "magic" : "guns"]!")
+	message_admins("[key_name_admin(usr)] summoned [summon_type ? "magic" : "guns"]!")
 	for(var/mob/living/carbon/human/H in player_list)
 		if(H.stat == 2 || !(H.client)) continue
 		if(H.mind)

--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -46,7 +46,6 @@ Growing it to term with nothing injected will grab a ghost from the observers. *
 			if(!source.client && source.mind)
 				for(var/mob/O in respawnable_list)
 					if(O.mind == source.mind && config.revival_pod_plants)
-						message_admins("Found mind, asking for respawn")
 						switch(alert(O,"Your corpse has been placed into a pod plant. Do you want to be resurrected/cloned? Please note if you select 'No', you will still be able to be cloned or borged again this round.","Pod Alert","Yes","No"))
 							if("Yes")
 								source.key = O.key

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -213,8 +213,8 @@
 	var/pressure = air_contents.return_pressure()
 	if(pressure > TANK_FRAGMENT_PRESSURE)
 		if(!istype(src.loc,/obj/item/device/transfer_valve))
-			message_admins("Explosive tank rupture! last key to touch the tank was [src.fingerprintslast].")
-			log_game("Explosive tank rupture! last key to touch the tank was [src.fingerprintslast].")
+			message_admins("Explosive tank rupture! last key to touch the tank was [src.fingerprintslast] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
+			log_game("Explosive tank rupture! last key to touch the tank was [src.fingerprintslast] at [x], [y], [z]")
 		//world << "\blue[x],[y] tank is exploding: [pressure] kPa"
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react()

--- a/code/modules/admin/admin_memo.dm
+++ b/code/modules/admin/admin_memo.dm
@@ -27,7 +27,8 @@
 		if( findtext(memo,"<script",1,0) )
 			return
 		F[ckey] << "[key] on [time2text(world.realtime,"(DDD) DD MMM hh:mm")]<br>[memo]"
-		message_admins("[key] set an admin memo:<br>[memo]")
+		log_admin("[key_name(usr)] set an admin memo:<br>[memo]")
+		message_admins("[key_name_admin(usr)] set an admin memo:<br>[memo]")
 
 //show all memos
 /client/proc/admin_memo_show()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -444,7 +444,7 @@ var/list/admin_verbs_mentor = list(
 			if(flash_range == null)
 				return
 			explosion(epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, 1, 1)
-	message_admins("<span class='adminnotice'>[ckey] creating an admin explosion at [epicenter.loc].</span>")
+	message_admins("<span class='adminnotice'>[key_name_admin(usr)] creating an admin explosion at [epicenter.loc].</span>")
 	feedback_add_details("admin_verb","DB") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/give_spell(mob/T as mob in mob_list) // -- Urist
@@ -569,8 +569,8 @@ var/list/admin_verbs_mentor = list(
 	set category = "Admin"
 
 	if(holder)
-		log_admin("[src] deadmined themself.")
-		message_admins("[src] deadmined themself.")
+		log_admin("[key_name(usr)] deadmined themself.")
+		message_admins("[key_name_admin(usr)] deadmined themself.")
 		deadmin()
 		verbs += /client/proc/readmin
 		deadmins += ckey
@@ -614,8 +614,8 @@ var/list/admin_verbs_mentor = list(
 		D = new(rank,admin_ranks[rank],ckey)
 		var/client/C = directory[ckey]
 		D.associate(C)
-		message_admins("[src] re-adminned themselves.")
-		log_admin("[src] re-adminned themselves.")
+		message_admins("[key_name_admin(usr)] re-adminned themselves.")
+		log_admin("[key_name(usr)] re-adminned themselves.")
 		deadmins -= ckey
 		feedback_add_details("admin_verb","RAS")
 		return

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -17,7 +17,7 @@
 				if(H.cl == M.client)
 					qdel(H)
 		else
-			message_admins("[key_name(usr)] has entered build mode.")
+			message_admins("[key_name_admin(usr)] has entered build mode.")
 			log_admin("[key_name(usr)] has entered build mode.")
 			M.client.buildmode = 1
 			M.client.show_popup_menus = 0

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3,7 +3,7 @@
 
 	if(usr.client != src.owner || !check_rights(0))
 		log_admin("[key_name(usr)] tried to use the admin panel without authorization.")
-		message_admins("[usr.key] has attempted to override the admin panel!")
+		message_admins("[key_name_admin(usr)] has attempted to override the admin panel!")
 		return
 
 	if(ticker.mode && ticker.mode.check_antagonists_topic(href, href_list))
@@ -124,7 +124,7 @@
 			if(bancid)
 				banreason = "[banreason] (CUSTOM CID)"
 		else
-			message_admins("Ban process: A mob matching [playermob.ckey] was found at location [playermob.x], [playermob.y], [playermob.z]. Custom ip and computer id fields replaced with the ip and computer id from the located mob")
+			message_admins("Ban process: A mob matching [playermob.ckey] was found at location [playermob.x], [playermob.y], [playermob.z]. Custom IP and computer id fields replaced with the IP and computer id from the located mob")
 
 		DB_ban_record(bantype, playermob, banduration, banreason, banjob, null, banckey, banip, bancid )
 
@@ -280,7 +280,7 @@
 
 		ticker.delay_end = !ticker.delay_end
 		log_admin("[key_name(usr)] [ticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
-		message_admins("\blue [key_name(usr)] [ticker.delay_end ? "delayed the round end" : "has made the round end normally"].", 1)
+		message_admins("\blue [key_name_admin(usr)] [ticker.delay_end ? "delayed the round end" : "has made the round end normally"].", 1)
 		href_list["secretsadmin"] = "check_antagonist"
 
 	else if(href_list["simplemake"])
@@ -1002,8 +1002,8 @@
 					M << "\red To try to resolve this matter head to [config.banappeals]"
 				else
 					M << "\red No ban appeals URL has been set."
-				log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
-				message_admins("\blue[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
+				log_admin("[key_name(usr)] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
+				message_admins("\blue [key_name_admin(usr)] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
 
 				del(M.client)
 				//del(M)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.
@@ -1024,8 +1024,8 @@
 				else
 					M << "\red No ban appeals URL has been set."
 				ban_unban_log_save("[usr.client.ckey] has permabanned [M.ckey]. - Reason: [reason] - This is a permanent ban.")
-				log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.")
-				message_admins("\blue[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.")
+				log_admin("[key_name(usr)] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.")
+				message_admins("\blue[key_name_admin(usr)] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.")
 				feedback_inc("ban_perma",1)
 				DB_ban_record(BANTYPE_PERMA, M, -1, reason)
 
@@ -1260,7 +1260,7 @@
 			return
 
 		log_admin("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
-		message_admins("[key_name(usr)] has sent [key_name(M)] back to the Lobby.")
+		message_admins("[key_name_admin(usr)] has sent [key_name_admin(M)] back to the Lobby.")
 
 		var/mob/new_player/NP = new()
 		NP.ckey = M.ckey
@@ -1412,7 +1412,7 @@
 
 		L.revive()
 		message_admins("\red Admin [key_name_admin(usr)] healed / revived [key_name_admin(L)]!", 1)
-		log_admin("[key_name(usr)] healed / Revived [key_name(L)]")
+		log_admin("[key_name(usr)] healed / revived [key_name(L)]")
 
 	else if(href_list["makeai"])
 		if(!check_rights(R_SPAWN))	return
@@ -1604,14 +1604,14 @@
 			H.equip_to_slot_or_del( new /obj/item/weapon/reagent_containers/food/snacks/cookie(H), slot_r_hand )
 			if(!(istype(H.r_hand,/obj/item/weapon/reagent_containers/food/snacks/cookie)))
 				log_admin("[key_name(H)] has their hands full, so they did not receive their cookie, spawned by [key_name(src.owner)].")
-				message_admins("[key_name(H)] has their hands full, so they did not receive their cookie, spawned by [key_name(src.owner)].")
+				message_admins("[key_name_admin(H)] has their hands full, so they did not receive their cookie, spawned by [key_name_admin(src.owner)].")
 				return
 			else
 				H.update_inv_r_hand()//To ensure the icon appears in the HUD
 		else
 			H.update_inv_l_hand()
 		log_admin("[key_name(H)] got their cookie, spawned by [key_name(src.owner)]")
-		message_admins("[key_name(H)] got their cookie, spawned by [key_name(src.owner)]")
+		message_admins("[key_name_admin(H)] got their cookie, spawned by [key_name_admin(src.owner)]")
 		feedback_inc("admin_cookies_spawned",1)
 		H << "\blue Your prayers have been answered!! You received the <b>best cookie</b>!"
 
@@ -1635,8 +1635,8 @@
 			BSACooldown = 0
 
 		M << "You've been hit by bluespace artillery!"
-		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
-		message_admins("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
+		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [key_name(src.owner)]")
+		message_admins("[key_name_admin(M)] has been hit by Bluespace Artillery fired by [key_name_admin(src.owner)]")
 
 		var/obj/effect/stop/S
 		S = new /obj/effect/stop
@@ -1674,8 +1674,8 @@
 		if(!input)	return
 
 		src.owner << "You sent [input] to [H] via a secure channel."
-		log_admin("[src.owner] replied to [key_name(H)]'s Centcomm message with the message [input].")
-		message_admins("[src.owner] replied to [key_name(H)]'s Centcom message with: \"[input]\"")
+		log_admin("[key_name(src.owner)] replied to [key_name(H)]'s Centcomm message with the message [input].")
+		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)]'s Centcom message with: \"[input]\"")
 		H << "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. [input].  Message ends.\""
 
 	else if(href_list["SyndicateReply"])
@@ -2392,11 +2392,11 @@
 
 					S.long_jump(origin_area, destination_area, transition_area, move_duration)
 					message_admins("\blue [key_name_admin(usr)] has initiated a jump from [origin_area] to [destination_area] lasting [move_duration] seconds for the [shuttle_tag] shuttle", 1)
-					log_admin("[key_name_admin(usr)] has initiated a jump from [origin_area] to [destination_area] lasting [move_duration] seconds for the [shuttle_tag] shuttle")
+					log_admin("[key_name(usr)] has initiated a jump from [origin_area] to [destination_area] lasting [move_duration] seconds for the [shuttle_tag] shuttle")
 				else
 					S.short_jump(origin_area, destination_area)
 					message_admins("\blue [key_name_admin(usr)] has initiated a jump from [origin_area] to [destination_area] for the [shuttle_tag] shuttle", 1)
-					log_admin("[key_name_admin(usr)] has initiated a jump from [origin_area] to [destination_area] for the [shuttle_tag] shuttle")
+					log_admin("[key_name(usr)] has initiated a jump from [origin_area] to [destination_area] for the [shuttle_tag] shuttle")
 
 			if("moveshuttle")
 

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -26,8 +26,8 @@ var/global/list/frozen_mob_list = list()
 
 /mob/living/proc/admin_Freeze(var/client/admin)
 	if(istype(admin))
-		src << "<b><font color= red>You have been frozen by <a href='?priv_msg=\ref[admin]'>[admin.key]</a></b></font>"
-		message_admins("\blue [key_name_admin(admin)] froze [key_name(src)]")
+		src << "<b><font color= red>You have been frozen by [key_name(admin)]</b></font>"
+		message_admins("<span class='notice'>[key_name_admin(admin)]</span> froze [key_name_admin(src)]")
 		log_admin("[key_name(admin)] froze [key_name(src)]")
 
 	var/obj/effect/overlay/adminoverlay/AO = new
@@ -42,8 +42,8 @@ var/global/list/frozen_mob_list = list()
 
 /mob/living/proc/admin_unFreeze(var/client/admin)
 	if(istype(admin))
-		src << "<b><font color= red>You have been unfrozen by <a href='?priv_msg=\ref[usr.client]'>[key]</a></b></font>"
-		message_admins("\blue [key_name_admin(admin)] unfroze [key_name(src)]")
+		src << "<b><font color= red>You have been unfrozen by [key_name(admin)]</b></font>"
+		message_admins("\blue [key_name_admin(admin)] unfroze [key_name_admin(src)]")
 		log_admin("[key_name(admin)] unfroze [key_name(src)]")
 
 	update_icons()

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -11,10 +11,10 @@
 
 	if(T)
 		log_admin("[key_name(usr)] has possessed [O] ([O.type]) at ([T.x], [T.y], [T.z])")
-		message_admins("[key_name(usr)] has possessed [O] ([O.type]) at ([T.x], [T.y], [T.z])", 1)
+		message_admins("[key_name_admin(usr)] has possessed [O] ([O.type]) at ([T.x], [T.y], [T.z])", 1)
 	else
 		log_admin("[key_name(usr)] has possessed [O] ([O.type]) at an unknown location")
-		message_admins("[key_name(usr)] has possessed [O] ([O.type]) at an unknown location", 1)
+		message_admins("[key_name_admin(usr)] has possessed [O] ([O.type]) at an unknown location", 1)
 
 	if(!usr.control_object) //If you're not already possessing something...
 		usr.name_archive = usr.real_name

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -107,7 +107,7 @@
 		return
 	world << "[msg]"
 	log_admin("GlobalNarrate: [key_name(usr)] : [msg]")
-	message_admins("\blue \bold GlobalNarrate: [key_name_admin(usr)] : [msg]<BR>", 1)
+	message_admins("\blue \bold GlobalNarrate: [key_name_admin(usr)]: [msg]<BR>", 1)
 	feedback_add_details("admin_verb","GLN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_direct_narrate(var/mob/M)	// Targetted narrate -- TLE
@@ -128,8 +128,8 @@
 		return
 
 	M << msg
-	log_admin("DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]): [msg]")
-	message_admins("\blue \bold DirectNarrate: [key_name(usr)] to ([M.name]/[M.key]): [msg]<BR>", 1)
+	log_admin("DirectNarrate: [key_name(usr)] to ([key_name(M)]): [msg]")
+	message_admins("\blue \bold DirectNarrate: [key_name_admin(usr)] to ([key_name_admin(M)]): [msg]<BR>", 1)
 	feedback_add_details("admin_verb","DIRN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_godmode(mob/M as mob in mob_list)
@@ -472,10 +472,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	If they don't have a mind, they obviously don't have a special role.
 	*/
 
-	//Two variables to properly announce later on.
-	var/admin = key_name_admin(src)
-	var/player_key = G_found.key
-
 	//Now for special roles and equipment.
 	switch(new_character.mind.special_role)
 		if("traitor")
@@ -519,7 +515,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			if(alert(new_character,"Would you like an active AI to announce this character?",,"No","Yes")=="Yes")
 				call(/mob/new_player/proc/AnnounceArrival)(new_character, new_character.mind.assigned_role)
 
-	message_admins("\blue [admin] has respawned [player_key] as [new_character.real_name].", 1)
+	message_admins("\blue [key_name_admin(usr)] has respawned [key_name_admin(G_found)] as [new_character.real_name].", 1)
 
 	new_character << "You have been fully respawned. Enjoy the game."
 
@@ -728,8 +724,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if (heavy || light)
 
 		empulse(O, heavy, light)
-		log_admin("[key_name(usr)] created an EM Pulse ([heavy],[light]) at ([O.x],[O.y],[O.z])")
-		message_admins("[key_name_admin(usr)] created an EM PUlse ([heavy],[light]) at ([O.x],[O.y],[O.z])", 1)
+		log_admin("[key_name(usr)] created an EM pulse ([heavy], [light]) at ([O.x],[O.y],[O.z])")
+		message_admins("[key_name_admin(usr)] created an EM pulse ([heavy], [light]) at ([O.x],[O.y],[O.z])", 1)
 		feedback_add_details("admin_verb","EMP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 		return

--- a/code/modules/admin/verbs/ticklag.dm
+++ b/code/modules/admin/verbs/ticklag.dm
@@ -11,7 +11,7 @@
 	//I've used ticks of 2 before to help with serious singulo lags
 	if(newtick && newtick <= 2 && newtick > 0)
 		log_admin("[key_name(src)] has modified world.tick_lag to [newtick]", 0)
-		message_admins("[key_name(src)] has modified world.tick_lag to [newtick]", 0)
+		message_admins("[key_name_admin(src)] has modified world.tick_lag to [newtick]", 0)
 		world.tick_lag = newtick
 		feedback_add_details("admin_verb","TICKLAG") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1532,7 +1532,7 @@ datum/preferences
 		//Debugging report to track down a bug, which randomly assigned the plural gender to people.
 		if(character.gender in list(PLURAL, NEUTER))
 			if(isliving(src)) //Ghosts get neuter by default
-				message_admins("[character] ([character.ckey]) has spawned with their gender as plural or neuter. Please notify coders.")
+				message_admins("[key_name_admin(character)] has spawned with their gender as plural or neuter. Please notify coders.")
 				character.gender = MALE
 
 	proc/open_load_dialog(mob/user)

--- a/code/modules/garbage collection/gc_testing.dm
+++ b/code/modules/garbage collection/gc_testing.dm
@@ -11,7 +11,7 @@
 	garbageCollector.del_everything = !garbageCollector.del_everything
 	// world << "<b>GC: qdel turned [garbageCollector.del_everything ? "off" : "on"].</b>"
 	log_admin("[key_name(usr)] turned qdel [garbageCollector.del_everything ? "off" : "on"].")
-	message_admins("\blue [key_name(usr)] turned qdel [garbageCollector.del_everything ? "off" : "on"].", 1)
+	message_admins("\blue [key_name_admin(usr)] turned qdel [garbageCollector.del_everything ? "off" : "on"].", 1)
 
 /client/proc/gc_toggle_profiling()
 	set name = "(GC) Toggle Profiling"
@@ -23,7 +23,7 @@
 
 	del_profiling = !del_profiling
 	log_admin("[key_name(usr)] turned deletion profiling [del_profiling ? "on" : "off"].")
-	message_admins("\blue [key_name(usr)] turned deletion profiling [del_profiling ? "on" : "off"].", 1)
+	message_admins("\blue [key_name_admin(usr)] turned deletion profiling [del_profiling ? "on" : "off"].", 1)
 
 /client/proc/gc_show_del_report()
 	set name = "(GC) Show Del Report"

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -352,7 +352,7 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 							usr << query.ErrorMsg()
 						else
 							log_game("[usr.name]/[usr.key] has uploaded the book titled [scanner.cache.name], [length(scanner.cache.dat)] signs")
-							message_admins("[usr.name]/[usr.key] has uploaded the book titled [scanner.cache.name], [length(scanner.cache.dat)] signs")
+							message_admins("[key_name_admin(usr)] has uploaded the book titled [scanner.cache.name], [length(scanner.cache.dat)] signs")
 							alert("Upload Complete.")
 
 	if(href_list["targetid"])

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -330,9 +330,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set category = "Ghost"
 	set name = "Teleport"
 	set desc= "Teleport to a location"
-	if(!istype(usr, /mob/dead/observer))
+	
+	if(!isobserver(usr))
 		usr << "Not when you're not dead!"
 		return
+		
 	usr.verbs -= /mob/dead/observer/proc/dead_tele
 	spawn(30)
 		usr.verbs += /mob/dead/observer/proc/dead_tele
@@ -348,7 +350,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(!L || !L.len)
 		usr << "No area available."
 
-	usr.loc = pick(L)
+	usr.forceMove(pick(L))
 
 /mob/dead/observer/verb/follow()
 	set category = "Ghost"

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -62,6 +62,14 @@
 
 /mob/living/carbon/brain/blob_act()
 	return
+	
+
+/mob/living/carbon/brain/on_forcemove(atom/newloc)
+	if(container)
+		container.loc = newloc
+	else //something went very wrong.
+		CRASH("Brainmob without container.")
+	loc = container
 
 /mob/living/carbon/brain/binarycheck()
 	return istype(loc, /obj/item/device/mmi/posibrain)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -115,7 +115,7 @@
 						//we're good to suck the blood, blaah
 						M.handle_bloodsucking(src)
 						add_logs(src, M, "vampirebit")
-						message_admins("[M.name] ([M.ckey]) vampirebit [src.name] ([src.ckey])")
+						msg_admin_attack("[key_name_admin(M)] vampirebit [key_name_admin(src)]")
 						return
 				//end vampire codes
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -522,3 +522,10 @@
 // No binary for pAIs.
 /mob/living/silicon/pai/binarycheck()
 	return 0
+	
+/mob/living/silicon/pai/on_forcemove(atom/newloc)
+	if(card)
+		card.loc = newloc
+	else //something went very wrong.
+		CRASH("pAI without card")
+	loc = card

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -6,7 +6,7 @@
 		if (ticker && ticker.current_state == GAME_STATE_PLAYING) //Only report this stuff if we are currently playing.
 			var/admins_number = admins.len
 
-			message_admins("Admin logout: [key_name(src)]")
+			message_admins("Admin logout: [key_name_admin(src)]")
 			if(admins_number == 0) //Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
 				send2adminirc("[key_name(src)] logged out - no more admins online.")
 	..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -333,8 +333,8 @@
 		for(var/bad in paper_blacklist)
 			if(findtext(t,bad))
 				usr << "\blue You think to yourself, \"Hm.. this is only paper...\""
-				log_admin("PAPER: [usr] ([usr.ckey]) tried to use forbidden word in [src]: [bad].")
-				message_admins("PAPER: [usr] ([usr.ckey]) tried to use forbidden word in [src]: [bad].")
+				log_admin("PAPER: [key_name(usr)] tried to use forbidden word in [src]: [bad].")
+				message_admins("PAPER: [key_name_admin(usr)] tried to use forbidden word in [src]: [bad].")
 				return
 */
 		t = html_encode(t)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -215,10 +215,17 @@ var/const/GRAV_NEEDS_WRENCH = 3
 /obj/machinery/gravity_generator/main/attack_hand(mob/user as mob)
 	if(!..())
 		return interact(user)
+		
+/obj/machinery/gravity_generator/main/attack_ai(mob/user as mob)
+	return 1
+	
+/obj/machinery/gravity_generator/main/attack_ghost(mob/user as mob)
+	return interact(user)
 
 /obj/machinery/gravity_generator/main/interact(mob/user as mob)
 	if(stat & BROKEN)
 		return
+		
 	var/dat = "Gravity Generator Breaker: "
 	if(breaker)
 		dat += "<span class='linkOn'>ON</span> <A href='?src=\ref[src];gentoggle=1'>OFF</A>"
@@ -241,9 +248,8 @@ var/const/GRAV_NEEDS_WRENCH = 3
 
 
 /obj/machinery/gravity_generator/main/Topic(href, href_list)
-
 	if(..())
-		return
+		return 1
 
 	if(href_list["gentoggle"])
 		breaker = !breaker

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -113,7 +113,7 @@
 /obj/singularity/proc/admin_investigate_setup()
 	last_warning = world.time
 	var/count = locate(/obj/machinery/containment_field) in orange(30, src)
-	if(!count)	message_admins("A singulo has been created without containment fields active ([x],[y],[z])",1)
+	if(!count)	message_admins("A singularity has been created without containment fields active at [x], [y], [z] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 	investigate_log("was created. [count?"":"<font color='red'>No containment fields were active</font>"]","singulo")
 
 /obj/singularity/proc/dissipate()

--- a/code/world.dm
+++ b/code/world.dm
@@ -66,10 +66,7 @@ var/global/datum/global_init/init = new ()
 		processScheduler.setup()
 
 		master_controller.setup()
-
-	process_teleport_locs()			//Sets up the wizard teleport locations
-	process_ghost_teleport_locs()	//Sets up ghost teleport locations.
-
+		
 	#ifdef MAP_NAME
 	map_name = "[MAP_NAME]"
 	#else

--- a/code/world.dm
+++ b/code/world.dm
@@ -67,6 +67,9 @@ var/global/datum/global_init/init = new ()
 
 		master_controller.setup()
 
+	process_teleport_locs()			//Sets up the wizard teleport locations
+	process_ghost_teleport_locs()	//Sets up ghost teleport locations.
+
 	#ifdef MAP_NAME
 	map_name = "[MAP_NAME]"
 	#else
@@ -265,13 +268,13 @@ var/world_topic_spam_protect_time = world.timeofday
 					sleep(600)
 					if(!C.client && C.stat != DEAD && C.brain_op_stage!=4.0)
 						job_master.FreeRole(C.job)
-						message_admins("<b>[C.name]</b> ([C.ckey]), the [C.job] has been freed due to (<font color='#ffcc00'><b>Client disconnect for 10 minutes</b></font>)\n")
+						message_admins("[key_name_admin(C)], the [C.job] has been freed due to (<font color='#ffcc00'><b>Client disconnect for 10 minutes</b></font>)\n")
 						for(var/obj/item/W in C)
 							C.unEquip(W)
 						del(C)
 					else if(!C.key && C.stat != DEAD && C.brain_op_stage!=4.0)
 						job_master.FreeRole(C.job)
-						message_admins("<b>[C.name]</b> ([C.ckey]), the [C.job] has been freed due to (<font color='#ffcc00'><b>Client quit BYOND</b></font>)\n")
+						message_admins("[key_name_admin(C)], the [C.job] has been freed due to (<font color='#ffcc00'><b>Client quit BYOND</b></font>)\n")
 						for(var/obj/item/W in C)
 							C.unEquip(W)
 						del(C)


### PR DESCRIPTION
Changes:
1) Fixes a bunch of missing key_name's.
2) Admin ghosts can now access the gravity generator.
3) Brings our teleporting up-to-speed with /tg/: it's not perfect (you'll still spawn in grilles), but you will no longer spawn in walls when teleporting.
4) Shortens (ANTAG) to (A) due to lengthier admin logs because of FLW commands.