### PR TITLE
Coffee jitter fix, changeling revive fix

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -28,6 +28,7 @@
 	user.germ_level = 0
 	user.next_pain_time = 0
 	user.traumatic_shock = 0
+	user.timeofdeath = 0
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.restore_blood()

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2231,15 +2231,22 @@ datum
 				adj_drowsy = -3
 				adj_sleepy = -2
 				adj_temp = 25
+				overdose_threshold = 45
 
 				on_mob_life(var/mob/living/M as mob)
-					M.Jitter(5)
 					if(adj_temp > 0 && holder.has_reagent("frostoil"))
 						holder.remove_reagent("frostoil", 10*REAGENTS_METABOLISM)
 					if(prob(50))
 						M.AdjustParalysis(-1)
 						M.AdjustStunned(-1)
 						M.AdjustWeakened(-1)
+					..()
+					return
+					
+				overdose_process(var/mob/living/M as mob)
+					if(volume > 45)
+						M.Jitter(5)
+						
 					..()
 					return
 


### PR DESCRIPTION
Changes:
1) Coffee no longer makes you jitter like a crack addict. Now requires at least 45 units in your blood to start jittering (about two cups).
2) Fixes changelings not reviving properly. Fixes https://github.com/ParadiseSS13/Paradise/issues/1783.

From https://github.com/Baystation12/Baystation12/pull/10649.