### PR TITLE
Detective Scanner Protolathe Production

### DIFF
--- a/code/modules/DetectiveWork/scanner.dm
+++ b/code/modules/DetectiveWork/scanner.dm
@@ -10,6 +10,7 @@
 	item_state = "electronic"
 	flags = CONDUCT | NOBLUDGEON
 	slot_flags = SLOT_BELT
+	origin_tech = "magnets=4;biotech=2"
 	var/scanning = 0
 	var/list/log = list()
 

--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -100,3 +100,14 @@
 	materials = list("$metal" = 4000, "$glass" = 1000)
 	build_path = /obj/item/clothing/mask/gas/welding
 	category = list("Equipment")
+
+/datum/design/detective_scanner
+	name = "Forensic Scanner"
+	desc = "A high tech scanner designed for forensic evidence collection, DNA recovery, and fiber analysis."
+	id = "detectivescanner"
+	req_tech = list("biotech" = 2, "magnets" = 4)
+	build_type = PROTOLATHE
+	materials = list("$metal" = 6000, "$glass" = 2000)
+	build_path = /obj/item/device/detective_scanner
+	locked = 1      //no validhunting scientists.
+	category = list("Equipment")


### PR DESCRIPTION
Utilizing R&D, you can now produce forensic/detective scanners in the Protolathe.

They're a middle end tech item (biotech 2 and magnets 4) and are relatively expensive (metal+glass wise) for a single item. They're locked away in lockboxes; their purpose is largely to replace scanners if the one in the detective's locker disappears or both scanners end up destroyed. It's also in a lockbox to discourage validhunting on scientist's part.

