### PR TITLE
Add option to reject adminhelps

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -9,6 +9,22 @@
 	if(ticker.mode && ticker.mode.check_antagonists_topic(href, href_list))
 		check_antagonists()
 		return
+		
+	if(href_list["rejectadminhelp"])
+		if(!check_rights(R_MOD))
+			return
+		var/client/C = locate(href_list["rejectadminhelp"])
+		if(!C)
+			return
+
+		C << 'sound/effects/adminhelp.ogg'
+
+		C << "<font color='red' size='4'><b>- AdminHelp Rejected! -</b></font>"
+		C << "<font color='red'><b>Your admin help was rejected.</b></font>"
+		C << "Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting. If you asked a question, please ensure it was clear what you were asking."
+
+		message_admins("[key_name_admin(usr)] rejected [key_name_admin(C.mob)]'s admin help")
+		log_admin("[key_name(usr)] rejected [key_name(C.mob)]'s admin help")
 
 	if(href_list["makeAntag"])
 		switch(href_list["makeAntag"])

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -14,12 +14,6 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 
 	adminhelped = 1 //Determines if they get the message to reply by clicking the name.
 
-	/**src.verbs -= /client/verb/adminhelp
-
-	spawn(1200)
-		src.verbs += /client/verb/adminhelp	// 2 minute cool-down for adminhelps
-		src.verbs += /client/verb/adminhelp	// 2 minute cool-down for adminhelps//Go to hell
-	**/
 	var/msg
 	var/list/type = list("Question","Player Complaint")
 	var/selected_type = input("Pick a category.", "Admin Help", null, null) as null|anything in type
@@ -35,8 +29,6 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 	if(!msg)	return
 	var/original_msg = msg
-
-
 
 	//explode the input msg into a list
 	var/list/msglist = text2list(msg, " ")
@@ -94,7 +86,8 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 	if(!mob)	return						//this doesn't happen
 
 	var/ref_mob = "\ref[mob]"
-	msg = "\blue <b><font color=red>[selected_type]: </font>[key_name(src, 1, 1, selected_type)] (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) ([admin_jump_link(mob, "holder")]) (<A HREF='?_src_=holder;check_antagonist=1'>CA</A>) [ai_found ? " (<A HREF='?_src_=holder;adminchecklaws=[ref_mob]'>CL</A>)" : ""]:</b> [msg]"
+	var/ref_client = "\ref[src]"
+	msg = "\blue <b><font color=red>[selected_type]: </font>[key_name(src, 1, 1, selected_type)] (<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) ([admin_jump_link(mob, "holder")]) (<A HREF='?_src_=holder;check_antagonist=1'>CA</A>) (<A HREF='?_src_=holder;rejectadminhelp=[ref_client]'>REJT</A>) [ai_found ? " (<A HREF='?_src_=holder;adminchecklaws=[ref_mob]'>CL</A>)" : ""]:</b> [msg]"
 
 	//send this msg to all admins
 	var/admin_number_afk = 0

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -12,19 +12,8 @@
 /obj/machinery/the_singularitygen/process()
 	var/turf/T = get_turf(src)
 	if(src.energy >= 200)
-		var/admin_message = "New singularity made"
-		if(fingerprintshidden && length(fingerprintshidden))
-			admin_message +=  "touched by: "
-			if(islist(fingerprintshidden))
-				for(var/fp in fingerprintshidden)
-					admin_message += "[fp], "
-				admin_message += " - Last touched by [fingerprintslast]. at [x],[y],[z]"
-			else
-				admin_message += fingerprintshidden
-
-			log_admin(admin_message)
-		message_admins("[admin_message] at [x],[y],[z]",1)
-		investigate_log("[admin_message] at [x],[y],[z]","singulo")
+		message_admins("A singularity has been created at [x], [y], [z] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
+		investigate_log("A singularity has been created at [x], [y], [z]","singulo")
 
 		new /obj/singularity/(T, 50)
 		if(src) qdel(src)
@@ -38,9 +27,6 @@
 				"You secure the [src.name] to the floor.", \
 				"You hear a ratchet")
 			src.add_hiddenprint(user)
-
-
-
 		else
 			user.visible_message("[user.name] unsecures [src.name] from the floor.", \
 				"You unsecure the [src.name] from the floor.", \

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -122,7 +122,7 @@
 		confirmed = 0
 		trigger_event(event)
 		log_game("[key_name(event_triggered_by)] triggered and [key_name(event_confirmed_by)] confirmed event [event]")
-		message_admins("[key_name_admin(event_triggered_by)] ([admin_jump_link(event_triggered_by, "holder")]) triggered and [key_name_admin(event_confirmed_by)] ([admin_jump_link(event_confirmed_by, "holder")]) confirmed event [event]", 1)
+		message_admins("[key_name_admin(event_triggered_by)] triggered and [key_name_admin(event_confirmed_by)] confirmed event [event]", 1)
 	reset()
 
 /obj/machinery/keycard_auth/proc/receive_request(var/obj/machinery/keycard_auth/source)


### PR DESCRIPTION
Changes:
1) Mods and up can now reject adminhelps through the "REJT" button. This will send a clear message to the player that their adminhelp has been rejected and that they will have to try again. Ported from /tg/.
2) Clears up the singularity log message, which had a message that never triggered. 