### PR TITLE
Updates Quarantine module, requiring the AI to allow the crew to remove the law

### DIFF
--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -199,7 +199,7 @@ AI MODULES
 	name = "'Quarantine' AI Module"
 	desc = "A 'quarantine' AI module: 'The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, organics from leaving. It is impossible to harm an organic while preventing them from leaving.' This module adds a zeroth law, which can only be removed by uploading this board again."
 	origin_tech = "programming=3;biotech=2;materials=4"
-	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, organics from leaving. It is impossible to harm an organic while preventing them from leaving.")
+	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, organics from leaving. It is impossible to harm an organic while preventing them from leaving. NOTE: Attempting to remove this law does not constitute an attempt to leave the station.")
 	removeownlaw = 1
 
 /obj/item/weapon/aiModule/zeroth/quarantine/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -199,7 +199,7 @@ AI MODULES
 	name = "'Quarantine' AI Module"
 	desc = "A 'quarantine' AI module: 'The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, organics from leaving. It is impossible to harm an organic while preventing them from leaving.' This module adds a zeroth law, which can only be removed by uploading this board again."
 	origin_tech = "programming=3;biotech=2;materials=4"
-	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, organics from leaving. It is impossible to harm an organic while preventing them from leaving. NOTE: Attempting to remove this law does not constitute an attempt to leave the station.")
+	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, organics from leaving. It is impossible to harm an organic while preventing them from leaving. Attempting to remove this law does not constitute an attempt to leave the station.")
 	removeownlaw = 1
 
 /obj/item/weapon/aiModule/zeroth/quarantine/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)


### PR DESCRIPTION
A few days ago we had a situation where Quarantine was put on the AI by a traitor. It took the crew some time to restore the AI, because it choose to attempt to kill anyone entering the AI upload under the prefix that by removing the law, we were attempting to leave the station. While in this situation, it's debatable if this was reasonable or not, but it made me realize that with this interpretation of the law out there, its basically impossible to use the quarantine board for fear that it murders everyone attempting to remove it after the situation is resolved. In my mind, the purpose of the Quarantine board was to be used during random events like blob or viruses, to prevent spread in accordance with directive 7-10. This means that once the situation is resolved, the crew should be able to remove the law and leave. If the crew can't remove the law after the situation is resolved, it kinda defeats the point (and also creates a null-point in the round where the AI can prevent the round from ending). This PR specifies that the AI must allow the crew to remove the law to prevent this situation. 

If this PR is not accepted, then I suggest we move the Quarantine module to High-Risk, as that is basically what it has become if this doesn't go through.

If anyone has any other suggestions on how to fix specifically this situation, I'm all ears, as I imagine you could also prevent it through other means.