### PR TITLE
Re-add proper IPC reviving, let IPC's change their monitor

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1517,10 +1517,32 @@
 
 		W.add_fingerprint(src)
 
+// Allows IPC's to change their monitor display		
+/mob/living/carbon/human/proc/change_monitor()
+	set category = "IC"	
+	set name = "Change Monitor Display"
+	set desc = "Change the display on your monitor."
+	
+	if(stat || paralysis || stunned || weakened)
+		src << "<span class='warning'>You cannot change your monitor display in your current state.</span>"
+		return	
+		
+	var/list/hair = list()
+	for(var/i in hair_styles_list)
+		var/datum/sprite_accessory/hair/tmp_hair = hair_styles_list[i]
+		if(species.name in tmp_hair.species_allowed)
+			hair += i
 
+	var/new_style = input(src, "Select a monitor display", "Monitor Display")  as null|anything in hair
+	if(stat || paralysis || stunned || weakened)
+		return
+	if(new_style)
+		h_style = new_style
+
+	update_hair()
+		
 //Putting a couple of procs here that I don't know where else to dump.
 //Mostly going to be used for Vox and Vox Armalis, but other human mobs might like them (for adminbuse).
-
 /mob/living/carbon/human/proc/leap()
 	set category = "Abilities"
 	set name = "Leap"

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -13,6 +13,11 @@
 	//TODO: fix husking
 	if( (((100 - total_burn) < config.health_threshold_dead) && stat == DEAD))//100 only being used as the magic human max health number, feel free to change it if you add a var for it -- Urist
 		ChangeToHusk()
+	if(species.can_revive_by_healing)
+		var/obj/item/organ/brain/B = internal_organs_by_name["brain"]
+		if(B)
+			if((health >= (config.health_threshold_dead/100*75)) && stat == DEAD) 
+				update_revive()
 	if (stat == CONSCIOUS && (src in dead_mob_list)) //Defib fix
 		update_revive()
 	return

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -61,8 +61,8 @@
 	var/has_fine_manipulation = 1 // Can use small items.
 
 	var/flags = 0       // Various specific features.
-	var/bloodflags=0
-	var/bodyflags=0
+	var/bloodflags = 0
+	var/bodyflags = 0
 	var/dietflags  = 0	// Make sure you set this, otherwise it won't be able to digest a lot of foods
 
 	var/list/abilities = list()	// For species-derived or admin-given powers
@@ -77,9 +77,11 @@
 	//Used in icon caching.
 	var/race_key = 0
 	var/icon/icon_template
+	
 	var/is_small
 	var/show_ssd = 1
 	var/virus_immune
+	var/can_revive_by_healing				// Determines whether or not this species can be revived by simply healing them
 
 	// Language/culture vars.
 	var/default_language = "Galactic Common" // Default language is used when 'say' is used without modifiers.

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -471,6 +471,7 @@
 	blood_color = "#1F181F"
 	flesh_color = "#AAAAAA"
 	virus_immune = 1
+	can_revive_by_healing = 1
 	reagent_tag = PROCESS_SYN
 	
 	has_organ = list(
@@ -499,3 +500,6 @@
 	spawn(100)
 		if(H) H.update_hair()
 	
+/datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
+	..()
+	H.verbs += /mob/living/carbon/human/proc/change_monitor


### PR DESCRIPTION
Changes:
1) IPC's can once again be properly revived by simply healing them, as long as they have their brain.
2) IPC's can now change their monitor display through the IC verb "Change Monitor Display". Added due to IPC's getting a black screen upon death.