### PR TITLE
Make mysql save queries readable

### DIFF
--- a/code/modules/client/preferences_mysql.dm
+++ b/code/modules/client/preferences_mysql.dm
@@ -1,6 +1,20 @@
 /datum/preferences/proc/load_preferences(client/C)
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT ooccolor,UI_style,UI_style_color,UI_style_alpha,be_special,default_slot,toggles,sound,randomslot,volume FROM [format_table_name("player")] WHERE ckey='[C.ckey]'")
+	var/DBQuery/query = dbcon.NewQuery({"SELECT
+					ooccolor,
+					UI_style,
+					UI_style_color,
+					UI_style_alpha,
+					be_special,
+					default_slot,
+					toggles,
+					sound,
+					randomslot,
+					volume
+					FROM [format_table_name("player")]
+					WHERE ckey='[C.ckey]'"}
+					)
+
 	if(!query.Execute())
 		var/err = query.ErrorMsg()
 		log_game("SQL ERROR during loading player preferences. Error : \[[err]\]\n")
@@ -37,7 +51,21 @@
 
 /datum/preferences/proc/save_preferences(client/C)
 
-	var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET ooccolor='[ooccolor]',UI_style='[UI_style]',UI_style_color='[UI_style_color]',UI_style_alpha='[UI_style_alpha]',be_special='[be_special]',default_slot='[default_slot]',toggles='[toggles]',sound='[sound]',randomslot='[randomslot]',volume='[volume]' WHERE ckey='[C.ckey]'")
+	var/DBQuery/query = dbcon.NewQuery({"UPDATE [format_table_name("player")]
+				SET
+					ooccolor='[ooccolor]',
+					UI_style='[UI_style]',
+					UI_style_color='[UI_style_color]',
+					UI_style_alpha='[UI_style_alpha]',
+					be_special='[be_special]',
+					default_slot='[default_slot]',
+					toggles='[toggles]',
+					sound='[sound]',
+					randomslot='[randomslot]',
+					volume='[volume]'
+					WHERE ckey='[C.ckey]'"}
+					)
+
 	if(!query.Execute())
 		var/err = query.ErrorMsg()
 		log_game("SQL ERROR during saving player preferences. Error : \[[err]\]\n")
@@ -190,14 +218,104 @@
 	firstquery.Execute()
 	while(firstquery.NextRow())
 		if(text2num(firstquery.item[1]) == default_slot)
-			var/DBQuery/query = dbcon.NewQuery("UPDATE characters SET OOC_Notes='[sql_sanitize_text(metadata)]',real_name='[sql_sanitize_text(real_name)]',name_is_always_random='[be_random_name]',gender='[gender]',age='[age]',species='[sql_sanitize_text(species)]',language='[sql_sanitize_text(language)]',hair_red='[r_hair]',hair_green='[g_hair]',hair_blue='[b_hair]',facial_red='[r_facial]',facial_green='[g_facial]',facial_blue='[b_facial]',skin_tone='[s_tone]',skin_red='[r_skin]',skin_green='[g_skin]',skin_blue='[b_skin]',hair_style_name='[sql_sanitize_text(h_style)]',facial_style_name='[sql_sanitize_text(f_style)]',eyes_red='[r_eyes]',eyes_green='[g_eyes]',eyes_blue='[b_eyes]',underwear='[underwear]',undershirt='[undershirt]',backbag='[backbag]',b_type='[b_type]',alternate_option='[alternate_option]',job_support_high='[job_support_high]',job_support_med='[job_support_med]',job_support_low='[job_support_low]',job_medsci_high='[job_medsci_high]',job_medsci_med='[job_medsci_med]',job_medsci_low='[job_medsci_low]',job_engsec_high='[job_engsec_high]',job_engsec_med='[job_engsec_med]',job_engsec_low='[job_engsec_low]',job_karma_high='[job_karma_high]',job_karma_med='[job_karma_med]',job_karma_low='[job_karma_low]',flavor_text='[sql_sanitize_text(flavor_text)]',med_record='[sql_sanitize_text(med_record)]',sec_record='[sql_sanitize_text(sec_record)]',gen_record='[sql_sanitize_text(gen_record)]',player_alt_titles='[playertitlelist]',be_special='[be_special]',disabilities='[disabilities]',organ_data='[organlist]',rlimb_data='[rlimblist]',nanotrasen_relation='[nanotrasen_relation]', speciesprefs='[speciesprefs]' WHERE ckey='[C.ckey]' AND slot='[default_slot]'")
+			var/DBQuery/query = dbcon.NewQuery({"UPDATE characters SET OOC_Notes='[sql_sanitize_text(metadata)]',
+												real_name='[sql_sanitize_text(real_name)]',
+												name_is_always_random='[be_random_name]',
+												gender='[gender]',
+												age='[age]',
+												species='[sql_sanitize_text(species)]',
+												language='[sql_sanitize_text(language)]',
+												hair_red='[r_hair]',
+												hair_green='[g_hair]',
+												hair_blue='[b_hair]',
+												facial_red='[r_facial]',
+												facial_green='[g_facial]',
+												facial_blue='[b_facial]',
+												skin_tone='[s_tone]',
+												skin_red='[r_skin]',
+												skin_green='[g_skin]',
+												skin_blue='[b_skin]',
+												hair_style_name='[sql_sanitize_text(h_style)]',
+												facial_style_name='[sql_sanitize_text(f_style)]',
+												eyes_red='[r_eyes]',
+												eyes_green='[g_eyes]',
+												eyes_blue='[b_eyes]',
+												underwear='[underwear]',
+												undershirt='[undershirt]',
+												backbag='[backbag]',
+												b_type='[b_type]',
+												alternate_option='[alternate_option]',
+												job_support_high='[job_support_high]',
+												job_support_med='[job_support_med]',
+												job_support_low='[job_support_low]',
+												job_medsci_high='[job_medsci_high]',
+												job_medsci_med='[job_medsci_med]',
+												job_medsci_low='[job_medsci_low]',
+												job_engsec_high='[job_engsec_high]',
+												job_engsec_med='[job_engsec_med]',
+												job_engsec_low='[job_engsec_low]',
+												job_karma_high='[job_karma_high]',
+												job_karma_med='[job_karma_med]',
+												job_karma_low='[job_karma_low]',
+												flavor_text='[sql_sanitize_text(flavor_text)]',
+												med_record='[sql_sanitize_text(med_record)]',
+												sec_record='[sql_sanitize_text(sec_record)]',
+												gen_record='[sql_sanitize_text(gen_record)]',
+												player_alt_titles='[playertitlelist]',
+												be_special='[be_special]',
+												disabilities='[disabilities]',
+												organ_data='[organlist]',
+												rlimb_data='[rlimblist]',
+												nanotrasen_relation='[nanotrasen_relation]',
+												speciesprefs='[speciesprefs]'
+												WHERE ckey='[C.ckey]'
+												AND slot='[default_slot]'"}
+												)
+
 			if(!query.Execute())
 				var/err = query.ErrorMsg()
 				log_game("SQL ERROR during character slot saving. Error : \[[err]\]\n")
 				message_admins("SQL ERROR during character slot saving. Error : \[[err]\]\n")
 				return
 			return 1
-	var/DBQuery/query = dbcon.NewQuery("INSERT INTO characters (ckey,slot,OOC_Notes,real_name,name_is_always_random,gender,age,species,language,hair_red,hair_green,hair_blue,facial_red,facial_green,facial_blue,skin_tone,skin_red,skin_green,skin_blue,hair_style_name,facial_style_name,eyes_red,eyes_green,eyes_blue,underwear,undershirt,backbag,b_type,alternate_option,job_support_high,job_support_med,job_support_low,job_medsci_high,job_medsci_med,job_medsci_low,job_engsec_high,job_engsec_med,job_engsec_low,job_karma_high,job_karma_med,job_karma_low,flavor_text,med_record,sec_record,gen_record,player_alt_titles,be_special,disabilities,organ_data,rlimb_data,nanotrasen_relation, speciesprefs) VALUES ('[C.ckey]','[default_slot]','[sql_sanitize_text(metadata)]','[sql_sanitize_text(real_name)]','[be_random_name]','[gender]','[age]','[sql_sanitize_text(species)]','[sql_sanitize_text(language)]','[r_hair]','[g_hair]','[b_hair]','[r_facial]','[g_facial]','[b_facial]','[s_tone]','[r_skin]','[g_skin]','[b_skin]','[sql_sanitize_text(h_style)]','[sql_sanitize_text(f_style)]','[r_eyes]','[g_eyes]','[b_eyes]','[underwear]','[undershirt]','[backbag]','[b_type]','[alternate_option]','[job_support_high]','[job_support_med]','[job_support_low]','[job_medsci_high]','[job_medsci_med]','[job_medsci_low]','[job_engsec_high]','[job_engsec_med]','[job_engsec_low]','[job_karma_high]','[job_karma_med]','[job_karma_low]','[sql_sanitize_text(flavor_text)]','[sql_sanitize_text(med_record)]','[sql_sanitize_text(sec_record)]','[sql_sanitize_text(gen_record)]','[playertitlelist]','[be_special]','[disabilities]','[organlist]','[rlimblist]','[nanotrasen_relation]', '[speciesprefs]')")
+
+	var/DBQuery/query = dbcon.NewQuery({"
+					INSERT INTO characters (ckey, slot, OOC_Notes, real_name, name_is_always_random, gender,
+											age, species, language,
+											hair_red, hair_green, hair_blue,
+											facial_red, facial_green, facial_blue,
+											skin_tone, skin_red, skin_green, skin_blue,
+											hair_style_name, facial_style_name,
+											eyes_red, eyes_green, eyes_blue,
+											underwear, undershirt,
+											backbag, b_type, alternate_option,
+											job_support_high, job_support_med, job_support_low,
+											job_medsci_high, job_medsci_med, job_medsci_low,
+											job_engsec_high, job_engsec_med, job_engsec_low,
+											job_karma_high, job_karma_med, job_karma_low,
+											flavor_text, med_record, sec_record, gen_record,
+											player_alt_titles, be_special,
+											disabilities, organ_data, rlimb_data, nanotrasen_relation, speciesprefs)
+					VALUES
+											('[C.ckey]', '[default_slot]', '[sql_sanitize_text(metadata)]', '[sql_sanitize_text(real_name)]', '[be_random_name]','[gender]',
+											'[age]', '[sql_sanitize_text(species)]', '[sql_sanitize_text(language)]',
+											'[r_hair]', '[g_hair]', '[b_hair]',
+											'[r_facial]', '[g_facial]', '[b_facial]',
+											'[s_tone]', '[r_skin]', '[g_skin]', '[b_skin]',
+											'[sql_sanitize_text(h_style)]', '[sql_sanitize_text(f_style)]',
+											'[r_eyes]', '[g_eyes]', '[b_eyes]',
+											'[underwear]', '[undershirt]',
+											'[backbag]', '[b_type]', '[alternate_option]',
+											'[job_support_high]', '[job_support_med]', '[job_support_low]',
+											'[job_medsci_high]', '[job_medsci_med]', '[job_medsci_low]',
+											'[job_engsec_high]', '[job_engsec_med]', '[job_engsec_low]',
+											'[job_karma_high]', '[job_karma_med]', '[job_karma_low]',
+											'[sql_sanitize_text(flavor_text)]', '[sql_sanitize_text(med_record)]', '[sql_sanitize_text(sec_record)]', '[sql_sanitize_text(gen_record)]',
+											'[playertitlelist]', '[be_special]',
+											'[disabilities]', '[organlist]', '[rlimblist]', '[nanotrasen_relation]', '[speciesprefs]')
+"}
+)
+
 	if(!query.Execute())
 		var/err = query.ErrorMsg()
 		log_game("SQL ERROR during character slot saving. Error : \[[err]\]\n")


### PR DESCRIPTION
This reformats the preferences_mysql.dm queries to take advantage of multi-line text.

This means that it is actually readable, and not a giant long line.

Should make it a little bit less hellish to do SQL updates.