### PR TITLE
Readmin fix, antag age update

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -49,7 +49,7 @@ var/list/be_special_flags = list(
 	"vampire" = BE_VAMPIRE,
 	"mutineer" = BE_MUTINEER,
 	"blob" = BE_BLOB,
-	"shadowling" = BE_SHADOWLING
+	"shadowling" = BE_SHADOWLING,
 	"revenant" = BE_REVENANT
 )
 

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -49,7 +49,8 @@ var/list/be_special_flags = list(
 	"vampire" = BE_VAMPIRE,
 	"mutineer" = BE_MUTINEER,
 	"blob" = BE_BLOB,
-	"Revenant" = BE_REVENANT
+	"shadowling" = BE_SHADOWLING
+	"revenant" = BE_REVENANT
 )
 
 //Random event stuff, apparently used


### PR DESCRIPTION
Changes:
1) Fixes readmin - it's now fully compatible with our MySQL admin system. Rather than looking for a rank, it'll now properly pull the admin's flags from the database.
2) Fixes the revenant/shadowling age requirements not working properly. Fixes https://github.com/ParadiseSS13/Paradise/issues/1823.