### PR TITLE
IPC damage update

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -452,8 +452,8 @@
 	unarmed_type = /datum/unarmed_attack/punch
 	
 	eyes = "blank_eyes"
-	brute_mod = 1.5
-	burn_mod = 1.5
+	brute_mod = 2.5 // 100% * 2.5 * 0.6 (robolimbs) ~= 150%
+	burn_mod = 2.5  // So they take 50% extra damage from brute/burn overall.
 
 	cold_level_1 = 50
 	cold_level_2 = -1


### PR DESCRIPTION
Changes:
1) IPC's are back to their old damage levels and are no longer walking tanks.