### PR TITLE
Producible Emitter Boards

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -22,6 +22,16 @@
 	build_path = /obj/item/weapon/circuitboard/smes
 	category = list ("Engineering Machinery")
 
+/datum/design/emitter
+	name = "Machine Board (Emitter)"
+	desc = "The circuit board for an emitter."
+	id = "emitter"
+	req_tech = list("programming" = 4, "powerstorage" = 5, "engineering" = 5)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000, "sacid" = 20)
+	build_path = /obj/item/weapon/circuitboard/emitter
+	category = list ("Engineering Machinery")
+
 /datum/design/telepad
 	name = "Machine Board (Telepad Board)"
 	desc = "Allows for the construction of circuit boards used to build a Telepad."


### PR DESCRIPTION
Currently you can produce any circuit board in R&D that you can acquire in day to day machines....with one glaring exception: Emitter boards.

This corrects that and allows emitter boards to be able to be produced in R&D.

Tech level requirements for them (matches the boards origin tech):
- Engineering: 5
- Programming: 4
- Power storage: 5