### PR TITLE
Let players modify access of individual turrets

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -86,6 +86,9 @@ var/shuttle_call/shuttle_calls[0]
 		return 1
 		
 	if(href_list["login"])
+		if(!ishuman(usr))
+			usr << "<span class='warning'>Access denied.</span>" 
+			return
 		var/mob/living/carbon/human/M = usr
 		var/obj/item/card = M.get_active_hand()
 		var/obj/item/weapon/card/id/I = (card && card.GetID())||M.wear_id||M.wear_pda

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -54,6 +54,9 @@
 	var/wrenching = 0
 	var/last_target //last target fired at, prevents turrets from erratically firing at all valid targets in range
 	
+	var/screen = 0 // Screen 0: main control, screen 1: access levels
+	var/one_access = 0 // Determines if access control is set to req_one_access or req_access
+	
 /obj/machinery/porta_turret/centcom
 	enabled = 0
 	ailock = 1
@@ -74,7 +77,8 @@
 	if(req_access && req_access.len)
 		req_access.Cut()
 	req_one_access = list(access_security, access_heads)
-
+	one_access = 1
+	
 	//Sets up a spark system
 	spark_system = new /datum/effect/effect/system/spark_spread
 	spark_system.set_up(5, 0, src)
@@ -87,6 +91,7 @@
 	if(req_one_access && req_one_access.len)
 		req_one_access.Cut()
 	req_access = list(access_cent_specops)
+	one_access = 0
 
 /obj/machinery/porta_turret/proc/setup()
 	var/obj/item/weapon/gun/energy/E = installation	//All energy-based weapons are applicable
@@ -106,15 +111,8 @@
 			iconholder = 1
 			eprojectile = /obj/item/projectile/beam
 
-//			if(/obj/item/weapon/gun/energy/laser/practice/sc_laser)
-//				iconholder = 1
-//				eprojectile = /obj/item/projectile/beam
-
 		if(/obj/item/weapon/gun/energy/laser/retro)
 			iconholder = 1
-
-//			if(/obj/item/weapon/gun/energy/retro/sc_retro)
-//				iconholder = 1
 
 		if(/obj/item/weapon/gun/energy/laser/captain)
 			iconholder = 1
@@ -198,6 +196,7 @@ var/list/turret_icons
 /obj/machinery/porta_turret/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
 	data["access"] = !isLocked(user)
+	data["screen"] = screen
 	data["locked"] = locked
 	data["enabled"] = enabled
 	data["is_lethal"] = 1
@@ -212,10 +211,23 @@ var/list/turret_icons
 		settings[++settings.len] = list("category" = "Check Access Authorization", "setting" = "check_access", "value" = check_access)
 		settings[++settings.len] = list("category" = "Check Misc. Lifeforms", "setting" = "check_anomalies", "value" = check_anomalies)
 		data["settings"] = settings
-
+		
+	data["one_access"] = one_access
+	var/accesses[0]
+	var/list/access_list = get_all_accesses()
+	for (var/access in access_list)
+		var/name = get_access_desc(access)
+		var/active
+		if(one_access)
+			active = (access in req_one_access)
+		else
+			active = (access in req_access)
+		accesses[++accesses.len] = list("name" = name, "active" = active, "number" = access)
+	data["accesses"] = accesses
+					
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "turret_control.tmpl", "Turret Controls", 500, 300)
+		ui = new(user, src, ui_key, "turret_control.tmpl", "Turret Controls", 500, 320)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
@@ -246,6 +258,8 @@ var/list/turret_icons
 		var/value = text2num(href_list["value"])
 		if(href_list["command"] == "enable")
 			enabled = value
+		else if(href_list["command"] == "screen")
+			screen = value
 		else if(href_list["command"] == "lethal")
 			lethal = value
 		else if(href_list["command"] == "check_synth")
@@ -261,8 +275,40 @@ var/list/turret_icons
 		else if(href_list["command"] == "check_anomalies")
 			check_anomalies = value
 
-		return 1
+	if(href_list["one_access"])
+		toggle_one_access(href_list["one_access"])
+			
+	if(href_list["access"])
+		toggle_access(href_list["access"])
 
+	return 1
+	
+/obj/machinery/porta_turret/proc/toggle_one_access(var/access)
+	one_access = text2num(access)
+
+	if(one_access == 1)
+		req_one_access = req_access.Copy()
+		req_access.Cut()
+	else if(one_access == 0)
+		req_access = req_one_access.Copy()
+		req_one_access.Cut()
+	
+/obj/machinery/porta_turret/proc/toggle_access(var/access)
+	var/required = text2num(access)
+	if(!(required in get_all_accesses()))
+		return
+
+	if(one_access)
+		if((required in req_one_access))
+			req_one_access -= required
+		else
+			req_one_access += required
+	else
+		if((required in req_access))
+			req_access -= required
+		else
+			req_access += required	
+	
 /obj/machinery/porta_turret/power_change()
 	if(powered())
 		stat &= ~NOPOWER
@@ -325,8 +371,7 @@ var/list/turret_icons
 				update_icon()
 		wrenching = 0
 
-	else if(istype(I, /obj/item/weapon/card/id)||istype(I, /obj/item/device/pda))
-		//Behavior lock/unlock mangement
+	else if(istype(I, /obj/item/weapon/card/id) || istype(I, /obj/item/device/pda))
 		if(allowed(user))
 			locked = !locked
 			user << "<span class='notice'>Controls are now [locked ? "locked" : "unlocked"].</span>"

--- a/nano/templates/turret_control.tmpl
+++ b/nano/templates/turret_control.tmpl
@@ -1,41 +1,72 @@
 <div class="item">
-	<div class="itemLabelWide">
-		Behaviour controls are {{:data.locked ? "locked" : "unlocked"}}.
-	</div>
+	Behaviour controls are {{:data.locked ? "locked" : "unlocked"}}.
 </div>
 <br>
 {{if data.access}}
-    <div class="item">
-		<div class="itemLabelWide">
-			Turret Status:
+	{{if !data.screen}}
+		<div class="item">
+			<div class="itemLabelWide">
+				Turret Status:
+			</div>
+			<div class="itemContentNarrow">
+				{{:helper.link('Enabled', null, {'command' : 'enable', 'value' : 1}, data.enabled ?'redButton' : null)}}
+				{{:helper.link('Disabled',null, {'command' : 'enable', 'value' : 0}, !data.enabled ? 'selected' : null)}}
+			</div>
+		</div>	
+		{{if data.accesses}}
+			<div class="item">
+				<div class="itemLabelWide">
+					Required Access:
+				</div>
+				<div class="itemContentNarrow">
+					{{:helper.link('Modify', null, {'command' : 'screen', 'value' : 1})}}
+				</div>
+			</div>	
+		{{/if}}
+		{{if data.is_lethal}}
+			<div class="item">
+				<div class="itemLabelWide">
+					Lethal Mode:
+				</div>
+				<div class="itemContentNarrow">
+					{{:helper.link('On', null, {'command' : 'lethal', 'value' : 1}, data.lethal ?'redButton' : null)}}
+					{{:helper.link('Off',null, {'command' : 'lethal', 'value' : 0}, !data.lethal ? 'selected' : null)}}
+				</div>
+			</div>	
+		{{/if}}
+		
+		{{for data.settings}}
+			<div class="item">
+				<div class="itemLabelWide">
+					{{:value.category}}
+				</div>
+				<div class="itemContentNarrow">
+					{{:helper.link('On', null, {'command' : value.setting, 'value' : 1}, value.value ? 'selected' : null)}}
+					{{:helper.link('Off',null, {'command' : value.setting, 'value' : 0}, !value.value ? 'selected' : null)}}
+				</div>
+			</div>
+		{{/for}}
+	{{else}}
+		<div class="item">
+			<div class="itemLabelWide">
+				Turret Settings:
+			</div>
+			<div class="itemContentNarrow">
+				{{:helper.link('Modify', null, {'command' : 'screen', 'value' : 0})}}
+			</div>
 		</div>
-		<div class="itemContentNarrow">
-			{{:helper.link('Enabled', null, {'command' : 'enable', 'value' : 1}, data.enabled ?'redButton' : null)}}
-			{{:helper.link('Disabled',null, {'command' : 'enable', 'value' : 0}, !data.enabled ? 'selected' : null)}}
-		</div>
-	</div>	
-
-    {{if data.is_lethal}}
-        <div class="item">
-            <div class="itemLabelWide">
-                Lethal Mode:
-            </div>
-            <div class="itemContentNarrow">
-                {{:helper.link('On', null, {'command' : 'lethal', 'value' : 1}, data.lethal ?'redButton' : null)}}
-                {{:helper.link('Off',null, {'command' : 'lethal', 'value' : 0}, !data.lethal ? 'selected' : null)}}
-            </div>
-        </div>	
-    {{/if}}
-    
-    {{for data.settings}}
-        <div class="item">
-            <div class="itemLabelWide">
-                {{:value.category}}
-            </div>
-            <div class="itemContentNarrow">
-                {{:helper.link('On', null, {'command' : value.setting, 'value' : 1}, value.value ? 'selected' : null)}}
-                {{:helper.link('Off',null, {'command' : value.setting, 'value' : 0}, !value.value ? 'selected' : null)}}
-            </div>
-        </div>
-    {{/for}}
+		<div class="item">
+			<div class="itemLabelWide">
+				Access Type:
+			</div>
+			<div class="itemContentNarrow">
+				{{:helper.link('All', null, {'one_access' : 0}, !data.one_access ? 'selected' : null)}}
+				{{:helper.link('One', null, {'one_access' : 1}, data.one_access ? 'selected' : null)}}
+			</div>
+		</div>	
+		<h3>Select Access</h3>
+		{{for data.accesses}}
+			{{:helper.link(value.name, null, {'access' : value.number}, null, value.active ? 'selected' : null)}}
+		{{/for}}
+	{{/if}}
 {{/if}}


### PR DESCRIPTION
Changes:
1) Players can now modify the req_access/req_one_access on turrets that aren't connected to a turret controller. This allows players to set up turrets for specific areas such as the armory.
2) Fixes a runtime with communication computers when an AI tries to log in.