### PR TITLE
Gutter Language Update

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -246,7 +246,7 @@
 	key = "5"
 	flags = RESTRICTED | WHITELISTED
 	syllables = list("02011","01222","10100","10210","21012","02011","21200","1002","2001","0002","0012","0012","000","120","121","201","220","10","11","0")
-	
+
 /datum/language/machine/get_random_name()
 	if(prob(70))
 		name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[rand(100, 999)]"
@@ -333,6 +333,8 @@
 	name = "Gutter"
 	desc = "Much like Standard, this crude pidgin tongue descended from numerous languages and serves as Tradeband for criminal elements."
 	speech_verb = "growls"
+	ask_verb = "gnarls"
+	exclaim_verb = "snarls"
 	colour = "rough"
 	key = "3"
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -85,7 +85,7 @@ h1.alert, h2.alert		{color: #000000;}
 .clown					{color: #ff0000;}
 .shadowling				{color: #3b2769;}
 .vulpkanin				{color: #B97A57;}
-.rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
+.rough					{color: #7092BE; font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
 .sans					{font-family: "Comic Sans MS", cursive, sans-serif; font-weight: bold;}
 


### PR DESCRIPTION
Just a minor update to the Gutter Language.

Simply put, this language is difficult to notice unless you're talking one on one.

Over public comms, you won't notice it all, as the font is barely different and the ask and exclaim verbs are the same as common.

This PR:
- Gives gutter its own color (a slate greyish/blue color)
- Gives Gutter its own unique ask and exclaim verbs

This should make it way easier to pick out, in a crowd, someone speaking it, and it should make picking it out, on the radio, at a glance, infinitely easier.