### PR TITLE
Pants Fix

### DIFF
--- a/code/modules/clothing/under/pants.dm
+++ b/code/modules/clothing/under/pants.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/under/pants
 	gender = PLURAL
 	body_parts_covered = LOWER_TORSO|LEGS
+	displays_id = 0
 
 /obj/item/clothing/under/pants/classicjeans
 	name = "classic jeans"

--- a/code/modules/clothing/under/shorts.dm
+++ b/code/modules/clothing/under/shorts.dm
@@ -3,6 +3,7 @@
 	desc = "95% Polyester, 5% Spandex!"
 	gender = PLURAL
 	body_parts_covered = LOWER_TORSO
+	displays_id = 0
 
 /obj/item/clothing/under/shorts/red
 	icon_state = "redshorts"


### PR DESCRIPTION
If you're wearing shorts or pants, your ID will not be displayed on your mob's sprite.

Simply put, the tiny sprite ID icon is designed for jumpsuit usage; when utilized with pants, it makes the ID float in a rather odd manner, on the sprite itself; this should fix that tiny issue.