### PR TITLE
Disables Challenge Map

### DIFF
--- a/_maps/map_files/RandomZLevels/fileList.txt
+++ b/_maps/map_files/RandomZLevels/fileList.txt
@@ -10,7 +10,7 @@
 #_maps/map_files/RandomZLevels/academy.dmm
 _maps/map_files/RandomZLevels/beach.dmm
 #_maps/map_files/RandomZLevels/blackmarketpackers.dmm
-_maps/map_files/RandomZLevels/challenge.dmm
+#_maps/map_files/RandomZLevels/challenge.dmm
 #_maps/map_files/RandomZLevels/centcomAway.dmm
 #_maps/map_files/RandomZLevels/clownplanet.dmm
 #_maps/map_files/RandomZLevels/example.dmm


### PR DESCRIPTION
See title.

The challenge map is poorly designed and makes for a pretty shitty away mission. The only ways people really get through the emitter area are by burn patch spam, slowly walking past the lasers while surrounded by un-anchored airlocks, or by going around the emitters on the side. Most other attempts to do this away mission end in death because it is simply a hallway of death.

Then there is the issue with the syndicate NPCs. Due to the fact that the mob AI is braindead, they often end up killing themselves by breaking the windows and walking into space. And then comes the gear available, nuke ops weapons and armor... Yeaaaaaaah, no, that's not the kind of reward you give people for being able to cheese an away mission.