### PR TITLE
Make transit tubes less shit

### DIFF
--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -49,6 +49,22 @@ obj/structure/transit_tube/ex_act(severity)
 		init_dirs()
 
 
+/obj/structure/transit_tube/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover) && mover.checkpass(PASSGLASS))
+		return 1
+
+	if(istype(mover, /obj/spacepod))//spacepods get an exception because they otherwise could get completely stuck
+		return 1
+
+	if(locate(/obj/structure/transit_tube) in mover.loc)
+		mover << "<span class='warning'>\The [src]'s support pylons block your way.</span>"
+		return 0
+
+	else
+		mover << "<span class='notice'>You slip under \the [src].</span>"
+		return 1
+
+
 // Called to check if a pod should stop upon entering this tube.
 /obj/structure/transit_tube/proc/should_stop_pod(pod, from_dir)
 	return 0


### PR DESCRIPTION
You can now pass under transit tubes, so long as you are not trying to
follow the line- you have to pass from unoccupied space to tube to
unoccupied space.

Spacepods can just fly through them any way, because their 64x64 bounding
box had the potential to just get stuck between diagonals.

Objects will also fly under tubes.

Oh. And PASSGLASS will let anything pass under it in any direction, too.