### PR TITLE
Makes Sinta'Unathi Easier to See

### DIFF
--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -74,7 +74,7 @@ h1.alert, h2.alert		{color: #000000;}
 .tajaran				{color: #803B56;}
 .tajaran_signlang		{color: #941C1C;}
 .skrell					{color: #00CED1;}
-.soghun					{color: #228B22;}
+.soghun					{color: #145314;}
 .solcom					{color: #22228B;}
 .changeling				{color: #800080;}
 .vox					{color: #AA00AA;}


### PR DESCRIPTION
Made the text colour of the Unathi native language Sinta'Unathi 3 shades darker, a lot easier to tell apart from the standard radio.

First PR first time messing around but it was such a simple change that I figured I should just go for it

If any of you higher-ups want a different colour instead shoot your suggestions and it could be changed no problem

Fixes https://github.com/ParadiseSS13/Paradise/issues/1840.