### PR TITLE
Fixes #1776, Vox Welding Helmet now Visible

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -29,7 +29,7 @@
 	loose = 4
 	species_fit = list("Vox")
 	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/eyes.dmi'
+		"Vox" = 'icons/mob/species/vox/head.dmi'
 		)
 
 /obj/item/clothing/head/welding/attack_self()


### PR DESCRIPTION
Title explains the whole PR, for whatever reason it was looking for the sprite in the eyes section instead of the head section.

However, this turned up another issue. The mask's UP state is (pretty much) the exact same sprite as Human-- which is just odd on Vox. I'll look further into it.

EDIT: Turns out that the Human welding helmet's up state is the Vox helmet up state except the Vox one's east facing sprite is moved right somewhat and its west facing sprite is moved a left by the same amount as the east facing was moved right when compared to the Human sprite.
tl;dr - not a problem as I first thought

Here's some pics:
Helmet up > http://i.imgur.com/OnpOAsb.png
Helmet down > http://i.imgur.com/CBrE8LC.png

Fixes #1776.