### PR TITLE
Reduces Powernet Lag

### DIFF
--- a/code/modules/garbage collection/garbage_collector.dm
+++ b/code/modules/garbage collection/garbage_collector.dm
@@ -140,6 +140,15 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 				// world << "WARNING GC DID NOT GET A RETURN VALUE FOR [D], [D.type]!"
 				garbageCollector.addTrash(D)
 
+
+// Returns 1 if the object has been queued for deletion.
+/proc/qdeleted(var/datum/D)
+	if (!istype(D))
+		return 0
+	if (!isnull(D.gcDestroyed))
+		return 1
+	return 0
+
 /*
  * Like Del(), but for qdel.
  * Called BEFORE qdel moves shit.

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -432,12 +432,15 @@ obj/structure/cable/proc/cableColor(var/colorC)
 				P.disconnect_from_network() //remove from current network (and delete powernet)
 		return
 
+	var/obj/O = P_list[1]
 	// remove the cut cable from its turf and powernet, so that it doesn't get count in propagate_network worklist
 	loc = null
 	powernet.remove_cable(src) //remove the cut cable from its powernet
 
-	var/datum/powernet/newPN = new()// creates a new powernet...
-	propagate_network(P_list[1], newPN)//... and propagates it to the other side of the cable
+	spawn(0) //so we don't rebuild the network X times when singulo/explosion destroys a line of X cables
+		if(O && !qdeleted(O))
+			var/datum/powernet/newPN = new()// creates a new powernet...
+			propagate_network(O, newPN)//... and propagates it to the other side of the cable
 
 	// Disconnect machines connected to nodes
 	if(d1 == 0) // if we cut a node (O-X) cable
@@ -501,9 +504,9 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
-		
-		if(!S) 
-			return		
+
+		if(!S)
+			return
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != "help" || S.open == 2)
 			return ..()
 
@@ -892,4 +895,4 @@ obj/structure/cable/proc/cableColor(var/colorC)
 /obj/item/stack/cable_coil/cyborg/attack_self(mob/user)
 	var/cablecolor = input(user,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
 	color = cablecolor
-	update_icon()	
+	update_icon()


### PR DESCRIPTION
Reduces powernet lag when multiple cables are destroyed at once--this particularly impacts explosions and the singularity.

Things done in this PR:

- Ports over TG's qdeleted proc: https://github.com/tgstation/-tg-station/pull/10083 (please double check me on this one).
- Implements some powernet optimizations plucked from here: https://github.com/tgstation/-tg-station/pull/11392

Results:

Before
![old](https://i.gyazo.com/17265abc1993f283bd6f7578cba91e3b.png)

After
![new](https://i.gyazo.com/01d92e49bbe66c2be2e52f810815c564.png)