### PR TITLE
R&D Lockbox Origintech

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -31,6 +31,7 @@
 				else
 					src.icon_state = src.icon_closed
 					user << "\red You unlock the [src.name]!"
+					origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
 					return
 			else
 				user << "\red Access Denied"
@@ -58,6 +59,7 @@
 		desc = "It appears to be broken."
 		icon_state = src.icon_broken
 		user << "<span class='notice'>You unlock \the [src].</span>"
+		origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
 		return
 
 /obj/item/weapon/storage/lockbox/loyalty
@@ -89,7 +91,7 @@
 	item_state = "syringe_kit"
 	w_class = 3
 	max_w_class = 2
-	max_combined_w_class = 20 
+	max_combined_w_class = 20
 	storage_slots = 12
 	req_access = list(access_captain)
 	icon_locked = "medalbox+l"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -442,6 +442,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 									var/obj/item/weapon/storage/lockbox/L = new/obj/item/weapon/storage/lockbox(linked_lathe.loc)
 									new_item.loc = L
 									L.name += " ([new_item.name])"
+									L.origin_tech = new_item.origin_tech
 								else
 									new_item.loc = linked_lathe.loc
 						linked_lathe.busy = 0


### PR DESCRIPTION
As there hasn't been a decision or thought put into if we want to use firing pins or not, this is an interim solution to allow scientists to max R&D without bugging the Captain or HoS to unlock a lockbox or two.

Any lockbox that is produced at R&D will contain the tech levels of the item that was created inside it.

For example, the plasma pistol lockbox will have the same origin tech levels as the plasma pistol itself.

Caveat: if you unlock or emag the lockbox, all tech levels will be wiped from the lockbox; this is here to prevent people from unlocking the lockbox and deconstructing both the box and the item inside for double-dipped tech levels.

It's a bit hacky of a way to handle origin_tech wiping for lockboxes, but ehhh.