### PR TITLE
Fixes Vox Grey Jumpsuit

### DIFF
--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -49,6 +49,9 @@
 	_color = "grey"
 	flags = ONESIZEFITSALL
 	species_fit = list("Vox")
+	sprite_sheets = list(
+		"Vox" = 'icons/mob/species/vox/uniform.dmi'
+		)
 
 /obj/item/clothing/under/color/grey/greytide
 	flags = ONESIZEFITSALL | NODROP


### PR DESCRIPTION
Previously the only way you'd ever see the correct Vox grey jumpsuit sprite was if you were holding it in-game or looking at the sprite in vox/uniform.dmi.

No longer! Now if a Vox player wears this jumpsuit it will look in the correct location for the sprite instead of giving them an ill-fitting human one.

Fixes part of #1130.
To fix the rest of that issue report, unfortunately-- as I'd not figured out then-- sprites for all the other colours of uniforms will need to be made and lines 51-54 copypasted to each jumpsuit code block that gets a sprite added in.

I'll rewrite #1130 accordingly and see if I can work out those sprites some other time.
I think this PR actually turns #1130 from an issue report to a feature request

Before PR: [Picture Goes Here]
AFTER PR: http://i.imgur.com/phSVZpK.png