### PR TITLE
Fixes Max Research Levels

### DIFF
--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -223,7 +223,7 @@ datum/tech/magnets
 	name = "Electromagnetic Spectrum Research"
 	desc = "Research into the electromagnetic spectrum. No clue how they actually work, though."
 	id = "magnets"
-	max_level = 5
+	max_level = 6
 
 datum/tech/programming
 	name = "Data Theory Research"


### PR DESCRIPTION
Fixes max tech levels.

Max tech levels are defined by the highest level that yields a new design/board/item, where as the levels above it does not (bluespace is an exception as the bluespace mech teleporter has an unobtainable bluespace level of 10).

Currently, magnets is incorrectly too low: a magnet level of 6 yields a phazon board and two bluespace stock part items.