### PR TITLE
Fix ghosts triggering glass

### DIFF
--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -55,8 +55,8 @@
 	..()
 
 /obj/item/weapon/shard/Crossed(AM as mob|obj)
-	if(ismob(AM))
-		var/mob/M = AM
+	if(isliving(AM))
+		var/mob/living/M = AM
 		M << "\red <B>You step on \the [src]!</B>"
 		playsound(src.loc, 'sound/effects/glass_step.ogg', 50, 1) // not sure how to handle metal shards with sounds
 		if(ishuman(M))

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -552,7 +552,6 @@ var/list/mechtoys = list(
 		ui = new(user, src, ui_key, "supply_console.tmpl", name, COMP_SCREEN_WIDTH, COMP_SCREEN_HEIGHT)
 		ui.set_initial_data(data)
 		ui.open()
-		ui.set_auto_update(1)
 		
 /obj/machinery/computer/supplycomp/proc/is_authorized(user)
 	if(allowed(user))


### PR DESCRIPTION
Changes:
1) As observers now use forceMove(), they will now properly trigger Entered(), Crossed() and other procs on objects. Glass was checking for any mob crossing it (rather than living mobs), causing it to play the sound and message when an observer crossed it.
2) Gets rid of the auto updating on the cargo supply computer to stop it from scrolling up on long lists.

Fixes https://github.com/ParadiseSS13/Paradise/issues/1863.