### PR TITLE
Watchlist/admin updates

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -446,10 +446,13 @@ DROP TABLE IF EXISTS `erro_watch`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `erro_watch` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
   `ckey` varchar(32) NOT NULL,
   `reason` text NOT NULL,
-  PRIMARY KEY (`id`)
+  `timestamp` datetime NOT NULL,
+  `adminckey` varchar(32) NOT NULL,
+  `last_editor` varchar(32),
+  `edits` text,
+  PRIMARY KEY (`ckey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -51,22 +51,26 @@ var/global/nologevent = 0
 	else
 		body += " \[<A href='?src=\ref[src];revive=\ref[M]'>Heal</A>\] "
 
-	body += {"
-		<br><br>\[
-		<a href='?_src_=vars;Vars=\ref[M]'>VV</a> -
-		<a href='?src=\ref[src];traitor=\ref[M]'>TP</a> -
-		<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a> -
-		<a href='?src=\ref[src];subtlemessage=\ref[M]'>SM</a> -
-		[admin_jump_link(M, src)]\] </b><br>
-		<b>Mob type</b> = [M.type]<br><br>
-		<A href='?src=\ref[src];boot2=\ref[M]'>Kick</A> |
-		<A href='?_src_=holder;warn=[M.ckey]'>Warn</A> |
-		<A href='?src=\ref[src];newban=\ref[M]'>Ban</A> |
-		<A href='?src=\ref[src];jobban2=\ref[M]'>Jobban</A> |
-		<A href='?src=\ref[src];appearanceban=\ref[M]'>Appearance Ban</A> |
-		<A href='?src=\ref[src];notes=show;mob=\ref[M]'>Notes</A> |
-		<A href='?_src_=holder;watchlist=\ref[M]'>Watchlist Flag</A>
-	"}
+		body += "<br><br>\[ "
+		body += "<a href='?_src_=vars;Vars=\ref[M]'>VV</a> - "
+		body += "<a href='?src=\ref[src];traitor=\ref[M]'>TP</a> -"
+		body += "<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a> -"
+		body += "<a href='?src=\ref[src];subtlemessage=\ref[M]'>SM</a> -"
+		body += "[admin_jump_link(M, src)]\] </b><br>"
+		
+		body += "<b>Mob type</b> = [M.type]<br><br>"
+		
+		body += "<A href='?src=\ref[src];boot2=\ref[M]'>Kick</A> | "
+		body += "<A href='?_src_=holder;warn=[M.ckey]'>Warn</A> | "
+		body += "<A href='?src=\ref[src];newban=\ref[M]'>Ban</A> | "
+		body += "<A href='?src=\ref[src];jobban2=\ref[M]'>Jobban</A> | "
+		body += "<A href='?src=\ref[src];appearanceban=\ref[M]'>Appearance Ban</A> | "
+		body += "<A href='?src=\ref[src];notes=show;mob=\ref[M]'>Notes</A> | "
+		if(M.client.check_watchlist(M.client.ckey))
+			body += "<A href='?_src_=holder;watchremove=[M.ckey]'>Remove from Watchlist</A> | "
+			body += "<A href='?_src_=holder;watchedit=[M.ckey]'>Edit Watchlist Reason</A> "
+		else
+			body += "<A href='?_src_=holder;watchadd=\ref[M.ckey]'>Add to Watchlist</A> "
 
 	if(M.client)
 		body += "| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -26,7 +26,7 @@
 	F << "<small>[time_stamp()] \ref[src] ([x],[y],[z])</small> || [src] [message]<br>"
 
 //ADMINVERBS
-/client/proc/investigate_show( subject in list("hrefs","pda","singulo","atmos","ntsl","gold core","cult") )
+/client/proc/investigate_show( subject in list("hrefs","pda","singulo","atmos","watchlist","ntsl","gold core","cult") )
 	set name = "Investigate"
 	set category = "Admin"
 	if(!holder)	return
@@ -76,3 +76,6 @@
 				src << "<font color='red'>Error: admin_investigate: [INVESTIGATE_DIR][subject] is an invalid path or cannot be accessed.</font>"
 				return
 			src << browse(F,"window=investigate[subject];size=800x300")
+			
+		if("watchlist")
+			watchlist_show()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -386,12 +386,12 @@
 				mins = min(525599,mins)
 				minutes = CMinutes + mins
 				duration = GetExp(minutes)
-				reason = input(usr,"Reason?","reason",reason2) as text|null
+				reason = input(usr,"Please state the reason","Reason",reason2) as message|null
 				if(!reason)	return
 			if("No")
 				temp = 0
 				duration = "Perma"
-				reason = input(usr,"Reason?","reason",reason2) as text|null
+				reason = input(usr,"Please state the reason","Reason",reason2) as message|null
 				if(!reason)	return
 
 		log_admin("[key_name(usr)] edited [banned_key]'s ban. Reason: [reason] Duration: [duration]")
@@ -437,7 +437,7 @@
 
 		else switch(alert("Appearance ban [M.ckey]?",,"Yes","No", "Cancel"))
 			if("Yes")
-				var/reason = input(usr,"Reason?","reason","Metafriender") as text|null
+				var/reason = input(usr,"Please state the reason","Reason") as message|null
 				if(!reason)
 					return
 				ban_unban_log_save("[key_name(usr)] appearance banned [key_name(M)]. reason: [reason]")
@@ -870,7 +870,7 @@
 					var/mins = input(usr,"How long (in minutes)?","Ban time",1440) as num|null
 					if(!mins)
 						return
-					var/reason = input(usr,"Reason?","Please State Reason","") as text|null
+					var/reason = input(usr,"Please state the reason","Reason","") as message|null
 					if(!reason)
 						return
 
@@ -894,7 +894,7 @@
 					href_list["jobban2"] = 1 // lets it fall through and refresh
 					return 1
 				if("No")
-					var/reason = input(usr,"Reason?","Please State Reason","") as text|null
+					var/reason = input(usr,"Please state the reason","Reason","") as message|null
 					if(reason)
 						var/msg
 						for(var/job in notbannedlist)
@@ -1004,7 +1004,7 @@
 				if(!mins)
 					return
 				if(mins >= 525600) mins = 525599
-				var/reason = input(usr,"Reason?","reason","Griefer") as text|null
+				var/reason = input(usr,"Please state the reason","Reason") as message|null
 				if(!reason)
 					return
 				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 1, mins)
@@ -1024,7 +1024,7 @@
 				del(M.client)
 				//del(M)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.
 			if("No")
-				var/reason = input(usr,"Reason?","reason","Griefer") as text|null
+				var/reason = input(usr,"Please state the reason","Reason") as message|null
 				if(!reason)
 					return
 				switch(alert(usr,"IP ban?",,"Yes","No","Cancel"))
@@ -1050,62 +1050,50 @@
 			if("Cancel")
 				return
 
+
 	//Watchlist
-	else if(href_list["watchlist"])
-		if(!check_rights(R_ADMIN))	return
-		var/mob/M = locate(href_list["watchlist"])
-		if(!dbcon.IsConnected())
-			usr << "<span class='danger'>Failed to establish database connection.</span>"
+	else if(href_list["watchadd"])
+		var/target_ckey = locate(href_list["watchadd"])
+		usr.client.watchlist_add(target_ckey)
+
+	else if(href_list["watchremove"])
+		var/target_ckey = href_list["watchremove"]
+		var/confirm = alert("Are you sure you want to remove [target_ckey] from the watchlist?", "Confirm Watchlist Removal", "Yes", "No")
+		if(confirm == "Yes")	
+			usr.client.watchlist_remove(target_ckey)
+
+	else if(href_list["watchedit"])
+		var/target_ckey = href_list["watchedit"]
+		usr.client.watchlist_edit(target_ckey)
+
+	else if(href_list["watchaddbrowse"])
+		usr.client.watchlist_add(null, 1)
+
+	else if(href_list["watchremovebrowse"])
+		var/target_ckey = href_list["watchremovebrowse"]
+		usr.client.watchlist_remove(target_ckey, 1)
+
+	else if(href_list["watcheditbrowse"])
+		var/target_ckey = href_list["watcheditbrowse"]
+		usr.client.watchlist_edit(target_ckey, 1)
+
+	else if(href_list["watchsearch"])
+		var/target_ckey = href_list["watchsearch"]
+		usr.client.watchlist_show(target_ckey)
+
+	else if(href_list["watchshow"])
+		usr.client.watchlist_show()
+
+	else if(href_list["watcheditlog"])
+		var/target_ckey = sanitizeSQL("[href_list["watcheditlog"]]")
+		var/DBQuery/query_watchedits = dbcon.NewQuery("SELECT edits FROM [format_table_name("watch")] WHERE ckey = '[target_ckey]'")
+		if(!query_watchedits.Execute())
+			var/err = query_watchedits.ErrorMsg()
+			log_game("SQL ERROR obtaining edits from watch table. Error : \[[err]\]\n")
 			return
-		if(!ismob(M))
-			usr << "This can only be used on instances of type /mob"
-			return
-		if(!M.ckey)
-			usr << "This mob has no ckey"
-			return
-		var/sql_ckey = sanitizeSQL(M.ckey)
-		var/DBQuery/query = dbcon.NewQuery("SELECT ckey FROM [format_table_name("watch")] WHERE (ckey = '[sql_ckey]')")
-		query.Execute()
-		if(query.NextRow())
-			switch(alert(usr, "Ckey already flagged", "[sql_ckey] is already on the watchlist, do you want to:", "Remove", "Edit reason", "Cancel"))
-				if("Cancel")
-					return
-				if("Remove")
-					var/DBQuery/query_watchdel = dbcon.NewQuery("DELETE FROM [format_table_name("watch")] WHERE ckey = '[sql_ckey]'")
-					if(!query_watchdel.Execute())
-						var/err = query_watchdel.ErrorMsg()
-						log_game("SQL ERROR during removing watch entry. Error : \[[err]\]\n")
-						return
-					log_admin("[key_name_admin(usr)] has removed [key_name_admin(M)] from the watchlist")
-					message_admins("[key_name_admin(usr)] has removed [key_name_admin(M)] from the watchlist", 1)
-				if("Edit reason")
-					var/DBQuery/query_reason = dbcon.NewQuery("SELECT ckey, reason FROM [format_table_name("watch")] WHERE (ckey = '[sql_ckey]')")
-					query_reason.Execute()
-					if(query_reason.NextRow())
-						var/watch_reason = query_reason.item[2]
-						var/new_reason = input("Insert new reason", "New Reason", "[watch_reason]", null) as null|text
-						new_reason = sanitizeSQL(new_reason)
-						if(!new_reason)
-							return
-						var/DBQuery/update_query = dbcon.NewQuery("UPDATE [format_table_name("watch")] SET reason = '[new_reason]' WHERE (ckey = '[sql_ckey]')")
-						if(!update_query.Execute())
-							var/err = update_query.ErrorMsg()
-							log_game("SQL ERROR during edit watch entry reason. Error : \[[err]\]\n")
-							return
-						log_admin("[key_name_admin(usr)] has edited [sql_ckey]'s reason from [watch_reason] to [new_reason]",1)
-						message_admins("[key_name_admin(usr)] has edited [sql_ckey]'s reason from [watch_reason] to [new_reason]",1)
-		else
-			var/reason = input(usr,"Reason?","reason","Metagaming") as text|null
-			if(!reason)
-				return
-			reason = sanitizeSQL(reason)
-			var/DBQuery/query_watchadd = dbcon.NewQuery("INSERT INTO [format_table_name("watch")] (ckey, reason) VALUES ('[sql_ckey]', '[reason]')")
-			if(!query_watchadd.Execute())
-				var/err = query_watchadd.ErrorMsg()
-				log_game("SQL ERROR during adding new watch entry. Error : \[[err]\]\n")
-				return
-			log_admin("[key_name_admin(usr)] has added [key_name_admin(M)] to the watchlist - Reason: [reason]")
-			message_admins("[key_name_admin(usr)] has added [key_name_admin(M)] to the watchlist - Reason: [reason]", 1)				
+		if(query_watchedits.NextRow())
+			var/edit_log = query_watchedits.item[1]
+			usr << browse(edit_log,"window=watchedits")		
 				
 	else if(href_list["mute"])
 		if(!check_rights(R_MOD))

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -168,7 +168,7 @@
 			return .(O.vars[variable])
 
 		if("text")
-			var/new_value = input("Enter new text:","Text",O.vars[variable]) as text|null
+			var/new_value = input("Enter new text:","Text",O.vars[variable]) as message|null
 			if(new_value == null) return
 			O.vars[variable] = new_value
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -44,7 +44,7 @@ var/list/forbidden_varedit_object_types = list(
 	switch(class)
 
 		if("text")
-			var_value = input("Enter new text:","Text") as null|text
+			var_value = input("Enter new text:","Text") as null|message
 
 		if("num")
 			var_value = input("Enter new number:","Num") as null|num
@@ -93,7 +93,7 @@ var/list/forbidden_varedit_object_types = list(
 	switch(class)
 
 		if("text")
-			var_value = input("Enter new text:","Text") as text
+			var_value = input("Enter new text:","Text") as message|null
 
 		if("num")
 			var_value = input("Enter new number:","Num") as num
@@ -494,7 +494,7 @@ var/list/forbidden_varedit_object_types = list(
 			return .(O.vars[variable])
 
 		if("text")
-			var/var_new = input("Enter new text:","Text",O.vars[variable]) as null|text
+			var/var_new = input("Enter new text:","Text",O.vars[variable]) as null|message
 			if(var_new==null) return
 			O.vars[variable] = var_new
 

--- a/code/modules/admin/watchlist.dm
+++ b/code/modules/admin/watchlist.dm
@@ -1,0 +1,118 @@
+client/proc/watchlist_add(target_ckey, browse = 0)
+	if(!target_ckey)
+		var/new_ckey = ckey(input(usr,"Who would you like to add to the watchlist?","Enter a ckey",null) as text)
+		if(!new_ckey)
+			return
+		new_ckey = sanitizeSQL(new_ckey)
+		var/DBQuery/query_watchfind = dbcon.NewQuery("SELECT ckey FROM [format_table_name("player")] WHERE ckey = '[new_ckey]'")
+		if(!query_watchfind.Execute())
+			var/err = query_watchfind.ErrorMsg()
+			log_game("SQL ERROR obtaining ckey from player table. Error : \[[err]\]\n")
+			return
+		if(!query_watchfind.NextRow())
+			usr << "<span class='redtext'>[new_ckey] has not been seen before, you can only add known players.</span>"
+			return
+		else
+			target_ckey = new_ckey
+	var/target_sql_ckey = sanitizeSQL(target_ckey)
+	if(check_watchlist(target_sql_ckey))
+		usr << "<span class='redtext'>[target_sql_ckey] is already on the watchlist.</span>"
+		return
+	var/reason = input(usr,"Please state the reason","Reason") as message|null
+	if(!reason)
+		return
+	reason = sanitizeSQL(reason)
+	var/timestamp = SQLtime()
+	var/adminckey = usr.ckey
+	if(!adminckey)
+		return
+	var/admin_sql_ckey = sanitizeSQL(adminckey)
+	var/DBQuery/query_watchadd = dbcon.NewQuery("INSERT INTO [format_table_name("watch")] (ckey, reason, adminckey, timestamp) VALUES ('[target_sql_ckey]', '[reason]', '[admin_sql_ckey]', '[timestamp]')")
+	if(!query_watchadd.Execute())
+		var/err = query_watchadd.ErrorMsg()
+		log_game("SQL ERROR during adding new watch entry. Error : \[[err]\]\n")
+		return
+	log_admin("[key_name(usr)] has added [target_ckey] to the watchlist - Reason: [reason]")
+	message_admins("[key_name_admin(usr)] has added [target_ckey] to the watchlist - Reason: [reason]", 1)
+	if(browse)
+		watchlist_show(target_sql_ckey)
+
+client/proc/watchlist_remove(target_ckey, browse = 0)
+	var/target_sql_ckey = sanitizeSQL(target_ckey)
+	var/DBQuery/query_watchdel = dbcon.NewQuery("DELETE FROM [format_table_name("watch")] WHERE ckey = '[target_sql_ckey]'")
+	if(!query_watchdel.Execute())
+		var/err = query_watchdel.ErrorMsg()
+		log_game("SQL ERROR during removing watch entry. Error : \[[err]\]\n")
+		return
+	log_admin("[key_name(usr)] has removed [target_ckey] from the watchlist")
+	message_admins("[key_name_admin(usr)] has removed [target_ckey] from the watchlist", 1)
+	if(browse)
+		watchlist_show()
+
+client/proc/watchlist_edit(target_ckey, browse = 0)
+	var/target_sql_ckey = sanitizeSQL(target_ckey)
+	var/DBQuery/query_watchreason = dbcon.NewQuery("SELECT reason FROM [format_table_name("watch")] WHERE ckey = '[target_sql_ckey]'")
+	if(!query_watchreason.Execute())
+		var/err = query_watchreason.ErrorMsg()
+		log_game("SQL ERROR obtaining reason from watch table. Error : \[[err]\]\n")
+		return
+	if(query_watchreason.NextRow())
+		var/watch_reason = query_watchreason.item[1]
+		var/new_reason = input("Input the new reason", "New Reason", "[watch_reason]") as message|null
+		new_reason = sanitizeSQL(new_reason)
+		if(!new_reason || new_reason == watch_reason)
+			return
+		var/sql_ckey = sanitizeSQL(usr.ckey)
+		var/edit_text = "Edited by [sql_ckey] on [SQLtime()] from \"[watch_reason]\" to \"[new_reason]\""
+		edit_text = sanitizeSQL(edit_text)
+		var/DBQuery/query_watchupdate = dbcon.NewQuery("UPDATE [format_table_name("watch")] SET reason = '[new_reason]', last_editor = '[sql_ckey]', edits = CONCAT(IFNULL(edits,''),'[edit_text]') WHERE ckey = '[target_sql_ckey]'")
+		if(!query_watchupdate.Execute())
+			var/err = query_watchupdate.ErrorMsg()
+			log_game("SQL ERROR editing watchlist reason. Error : \[[err]\]\n")
+			return
+		log_admin("[key_name(usr)] has edited [target_ckey]'s watchlist reason from \"[watch_reason]\" to \"[new_reason]\"")
+		message_admins("[key_name_admin(usr)] has edited [target_ckey]'s watchlist reason from \"[watch_reason]\" to \"[new_reason]\"")
+		if(browse)
+			watchlist_show(target_sql_ckey)
+
+client/proc/watchlist_show(search)
+	var/output
+	output += "<form method='GET' name='search' action='?'>\
+	<input type='hidden' name='_src_' value='holder'>\
+	<input type='text' name='watchsearch' value='[search]'>\
+	<input type='submit' value='Search'></form>"
+	output += "<a href='?_src_=holder;watchshow=1'>\[Clear Search\]</a> <a href='?_src_=holder;watchaddbrowse=1'>\[Add Ckey\]</a>"
+	output += "<hr style='background:#000000; border:0; height:3px'>"
+	if(search)
+		search = "^[search]"
+	else
+		search = "^."
+	search = sanitizeSQL(search)
+	var/DBQuery/query_watchlist = dbcon.NewQuery("SELECT ckey, reason, adminckey, timestamp, last_editor FROM [format_table_name("watch")] WHERE ckey REGEXP '[search]' ORDER BY ckey")
+	if(!query_watchlist.Execute())
+		var/err = query_watchlist.ErrorMsg()
+		log_game("SQL ERROR obtaining ckey, reason, adminckey, timestamp, last_editor from watch table. Error : \[[err]\]\n")
+		return
+	while(query_watchlist.NextRow())
+		var/ckey = query_watchlist.item[1]
+		var/reason = query_watchlist.item[2]
+		var/adminckey = query_watchlist.item[3]
+		var/timestamp = query_watchlist.item[4]
+		var/last_editor = query_watchlist.item[5]
+		output += "<b>[ckey]</b> | Added by <b>[adminckey]</b> on <b>[timestamp]</b> <a href='?_src_=holder;watchremovebrowse=[ckey]'>\[Remove\]</a> <a href='?_src_=holder;watcheditbrowse=[ckey]'>\[Edit Reason\]</a>"
+		if(last_editor)
+			output += " <font size='2'>Last edit by [last_editor] <a href='?_src_=holder;watcheditlog=[ckey]'>(Click here to see edit log)</a></font>"
+		output += "<br>[reason]<hr style='background:#000000; border:0; height:1px'>"
+	usr << browse(output, "window=watchwin;size=900x500")
+
+client/proc/check_watchlist(target_ckey)
+	var/target_sql_ckey = sanitizeSQL(target_ckey)
+	var/DBQuery/query_watch = dbcon.NewQuery("SELECT reason FROM [format_table_name("watch")] WHERE ckey = '[target_sql_ckey]'")
+	if(!query_watch.Execute())
+		var/err = query_watch.ErrorMsg()
+		log_game("SQL ERROR obtaining reason from watch table. Error : \[[err]\]\n")
+		return
+	if(query_watch.NextRow())
+		return query_watch.item[1]
+	else
+		return 0

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -330,11 +330,10 @@
 	if(related_accounts_cid.len)
 		log_access("Alts: [key_name(src)]:[list2text(related_accounts_cid, " - ")]")
 
-	var/DBQuery/query_watch = dbcon.NewQuery("SELECT ckey, reason FROM [format_table_name("watch")] WHERE (ckey = '[sql_ckey]')")
-	query_watch.Execute()
-	if(query_watch.NextRow())
-		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is flagged for watching and has just connected - Reason: [query_watch.item[2]]</font>")
-		send2irc_adminless_only("Watchlist", "[key_name_admin(src)] is flagged for watching and has just connected - Reason: [query_watch.item[2]]")		
+	var/watchreason = check_watchlist(sql_ckey)
+	if(watchreason)
+		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is on the watchlist and has just connected - Reason: [watchreason]</font>")
+		send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")	
 		
 	//Just the standard check to see if it's actually a number
 	if(sql_id)

--- a/paradise.dme
+++ b/paradise.dme
@@ -913,6 +913,7 @@
 #include "code\modules\admin\secrets.dm"
 #include "code\modules\admin\topic.dm"
 #include "code\modules\admin\ToRban.dm"
+#include "code\modules\admin\watchlist.dm"
 #include "code\modules\admin\DB ban\functions.dm"
 #include "code\modules\admin\permissionverbs\permissionedit.dm"
 #include "code\modules\admin\verbs\adminhelp.dm"


### PR DESCRIPTION
Changes:
1) Replaces certain text inputs (ban reasons, text varedits) with message inputs, making it easier to format them. 
2) Adds an interface for viewing watchlist entires (accessed through Investigate --> Watchlist).

Ported from https://github.com/tgstation/-tg-station/pull/11418.

SQL change required:
ALTER TABLE `erro_watch` DROP COLUMN `id`, ADD COLUMN `timestamp` datetime NOT NULL AFTER `reason`, ADD COLUMN `adminckey` varchar(32) NOT NULL AFTER `timestamp`, ADD COLUMN `last_editor` varchar(32) NULL AFTER `adminckey`, ADD COLUMN `edits` text NULL AFTER `last_editor`, DROP PRIMARY KEY, ADD PRIMARY KEY (`ckey`)
