### PR TITLE
Adds Blind and Mute as Disabilities in Character Creation

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -7,6 +7,8 @@
 #define DISABILITY_FLAG_FAT         2
 #define DISABILITY_FLAG_EPILEPTIC   4
 #define DISABILITY_FLAG_DEAF        8
+#define DISABILITY_FLAG_BLIND       16
+#define DISABILITY_FLAG_MUTE        32
 
 ///////////////////////////////////////
 // MUTATIONS

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -670,6 +670,8 @@ datum/preferences
 		HTML += ShowDisabilityState(user,DISABILITY_FLAG_FAT,"Obese")
 		HTML += ShowDisabilityState(user,DISABILITY_FLAG_EPILEPTIC,"Seizures")
 		HTML += ShowDisabilityState(user,DISABILITY_FLAG_DEAF,"Deaf")
+		HTML += ShowDisabilityState(user,DISABILITY_FLAG_BLIND,"Blind")
+		HTML += ShowDisabilityState(user,DISABILITY_FLAG_MUTE,"Mute")
 
 
 		// AUTOFIXED BY fix_string_idiocy.py

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -505,6 +505,14 @@
 			new_character.dna.SetSEState(DEAFBLOCK,1,1)
 			new_character.sdisabilities |= DEAF
 
+		if(client.prefs.disabilities & DISABILITY_FLAG_BLIND)
+			new_character.dna.SetSEState(BLINDBLOCK,1,1)
+			new_character.sdisabilities |= BLIND
+			
+		if(client.prefs.disabilities & DISABILITY_FLAG_MUTE)
+			new_character.dna.SetSEState(MUTEBLOCK,1,1)
+			new_character.sdisabilities |= MUTE
+			
 		chosen_species.handle_dna(new_character)
 
 		domutcheck(new_character)


### PR DESCRIPTION
Been playing long enough to hear quite a few people bring this up-- and I admit, I was quite interested in it myself. So I went ahead and added the two disabilities that were most mentioned.

Just adds **blind** and **mute** to the bottom of the list when you click *disabilities* in the character creation screen.

Tested on local, worked as intended. Selecting 'blind' only spawned me in blind, selecting 'mute' only spawned me in as a mute, selecting both did both.

Nervous/stuttering and accents were also mentioned but I didn't bother adding them in this PR. I figured that'd be bound to meet more opposition than adding genuine disabilities like blind and mute.