### PR TITLE
Assorted Fixes

### DIFF
--- a/code/modules/fish/fish_items.dm
+++ b/code/modules/fish/fish_items.dm
@@ -143,6 +143,7 @@ var/global/list/fish_items_list = list("goldfish" = /obj/item/weapon/fish/goldfi
 /obj/item/weapon/fish/toothless_shark
 	name = "toothless shark"
 	desc = "Looks like someone ripped it's teeth out!"
+	icon_state = "shark"
 	hitsound = 'sound/effects/snap.ogg'
 
 /obj/item/weapon/shard/shark_teeth
@@ -153,6 +154,10 @@ var/global/list/fish_items_list = list("goldfish" = /obj/item/weapon/fish/goldfi
 	force = 2.0
 	throwforce = 5.0
 	g_amt = 0
+
+/obj/item/weapon/shard/shark_teeth/New()
+	src.pixel_x = rand(-5,5)
+	src.pixel_y = rand(-5,5)
 
 /obj/item/weapon/fish/catfish
 	name = "catfish"

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -10,22 +10,22 @@
 	icon_living = "nymph"
 	icon_dead = "nymph_dead"
 	icon_resting = "nymph_sleep"
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSMOB
 	small = 1
 	ventcrawler = 2
-	
+
 	maxHealth = 50
-	health = 50	
-	
+	health = 50
+
 	voice_name = "diona nymph"
-	speak_emote = list("chirrups")	
+	speak_emote = list("chirrups")
 	emote_hear = list("chirrups")
 	emote_see = list("chirrups")
-	
+
 	response_help  = "pets"
 	response_disarm = "pushes"
 	response_harm   = "kicks"
-	
+
 	melee_damage_lower = 5
 	melee_damage_upper = 8
 	attacktext = "bites"
@@ -34,8 +34,7 @@
 	speed = 0
 	stop_automated_movement = 0
 	turns_per_move = 4
-	status_flags = 0
-	
+
 	var/list/donors = list()
 	var/ready_evolve = 0
 	holder_type = /obj/item/weapon/holder/diona
@@ -45,7 +44,7 @@
 	if(name == initial(name)) //To stop Pun-Pun becoming generic.
 		name = "[name] ([rand(1, 1000)])"
 		real_name = name
-		
+
 	add_language("Rootspeak")
 	src.verbs += /mob/living/simple_animal/diona/proc/merge
 
@@ -248,7 +247,7 @@
 /mob/living/simple_animal/diona/put_in_active_hand(obj/item/W)
 	src << "<span class='warning'>You don't have any hands!</span>"
 	return
-	
+
 
 /mob/living/simple_animal/diona/say(var/message)
 	if(client)
@@ -270,7 +269,7 @@
 
 	if(copytext(message,1,2) == "*")
 		return emote(copytext(message,2))
-		
+
 	//parse the language code and consume it
 	var/datum/language/speaking = parse_language(message)
 	if(speaking)

--- a/code/modules/reagents/reagent_containers/food/snacks/seafood.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/seafood.dm
@@ -160,7 +160,7 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protien", 1)
+		reagents.add_reagent("protein", 1)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Sake
@@ -216,19 +216,19 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protien", 1)
+		reagents.add_reagent("protein", 1)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tobiko
-	name = "Ikura Sushi"
+	name = "Tobiko Sushi"
 	desc = "A simple sushi consisting of shark roe."
 	icon = 'icons/obj/food/seafood.dmi'
-	icon_state = "sushi_Tobiko"
+	icon_state = "sushi_Masago"
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protien", 1)
+		reagents.add_reagent("protein", 1)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_TobikoEgg
@@ -240,7 +240,7 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protien", 1)
+		reagents.add_reagent("protein", 1)
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tai


### PR DESCRIPTION
Fixes toothless shark item using the placeholder fish sprite.

Fixes shark teeth being invisible
- Also slightly randomizes their position like with normal glass shards

Fixes Tobiko Sushi incorrectly being named Ikura Sushi and having an
invisible sprite

Fixes runtimes due to protein being misspelled as "protien" in 4 sushi
defines.

Fixes #1872
- This was caused by diona nymphs lacking the CANPUSH status_flag, which is required to pass grab checks.
 - Gave diona nymphs the PASSMOB pass_flag, should avoid them pushing people everywhere, and also prevent them from being trapped by other nymphs/people/Ian.
 - CANPUSH and PASSMOB are both flags possessed by mice, so this change effectively makes the nymph mobs closer to mice than monkeys.