### PR TITLE
Minor bluespace artillery interface update

### DIFF
--- a/nano/templates/bluespace_artillery.tmpl
+++ b/nano/templates/bluespace_artillery.tmpl
@@ -4,8 +4,8 @@ Used In File(s): \code\modules\awaymissions\bluespaceartillery.dm
 -->
 <h2>Bluespace Artillery Control</h2>
 <div class="item">
-	<div class="itemLabel">Status</div>
-	<div class="itemContent">Locked on</div>
+	<div class="itemLabel">Target Lock</div>
+	<div class="itemContent">{{:data.target}}</div>
 </div>
 <div class="item">
 	<div class="itemLabel">Fire Cooldown</div>
@@ -18,6 +18,7 @@ Used In File(s): \code\modules\awaymissions\bluespaceartillery.dm
 	</div>
 </div>
 <div class="item">
+	{{:helper.link('Select Target', 'alert', { 'area' : 1 })}}
 	{{:helper.link('Fire', 'alert', { 'fire' : 1 }, data.reloadtime_mins > 0 || data.reloadtime_mins == 0 && data.reloadtime_secs > 0 ? 'disabled' : '')}}
 </div>
 <hr>


### PR DESCRIPTION
Changes:
1) Minor update to the bluespace artillery interface to make it a little less confusing (and makes it possible to cancel strikes). Also lets you target any area, instead of just station areas.