### PR TITLE
Remove arbitrary w_class restriction for xenos

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -170,7 +170,7 @@
 	if(isalien(user)) // -- TLE
 		var/mob/living/carbon/alien/A = user
 
-		if(!A.has_fine_manipulation || w_class >= 4)
+		if(!A.has_fine_manipulation)
 			if(src in A.contents) // To stop Aliens having items stuck in their pockets
 				A.unEquip(src)
 			user << "Your claws aren't capable of such fine manipulation."
@@ -197,7 +197,7 @@
 /obj/item/attack_alien(mob/user as mob)
 	var/mob/living/carbon/alien/A = user
 
-	if(!A.has_fine_manipulation || w_class >= 4)
+	if(!A.has_fine_manipulation)
 		if(src in A.contents) // To stop Aliens having items stuck in their pockets
 			A.unEquip(src)
 		user << "Your claws aren't capable of such fine manipulation."
@@ -705,6 +705,6 @@
 		if(current_size >= STAGE_FOUR)
 			throw_at(S,14,3)
 		else ..()
-		
+
 /obj/item/proc/pwr_drain()
-	return 0 // Process Kill 
+	return 0 // Process Kill


### PR DESCRIPTION
has_fine_manipulation can only be set by admins. Adminbuse doesn't need arbitrary w_class limits.