### PR TITLE
Reboot improvements, player panel fix, IsBanned fix

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -167,12 +167,7 @@ datum/controller/vote
 
 
 		if(restart)
-			world << "World restarting due to vote..."
-			feedback_set_details("end_error","restart vote")
-			if(blackbox)	blackbox.save_all_data_to_sql()
-			sleep(50)
-			log_game("Rebooting due to restart vote")
-			world.Reboot()
+			world.Reboot("Restart vote successful.", "end_error", "restart vote")
 
 		return .
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -404,26 +404,9 @@ var/global/datum/controller/gameticker/ticker
 				callHook("roundend")
 
 				if (mode.station_was_nuked)
-					feedback_set_details("end_proper","nuke")
-					if(!delay_end)
-						world << "\blue <B>Rebooting due to destruction of station in [restart_timeout/10] seconds</B>"
+					world.Reboot("Station destroyed by Nuclear Device.", "end_proper", "nuke")
 				else
-					feedback_set_details("end_proper","proper completion")
-					if(!delay_end)
-						world << "\blue <B>Restarting in [restart_timeout/10] seconds</B>"
-
-
-				if(blackbox)
-					blackbox.save_all_data_to_sql()
-
-				if(!delay_end)
-					sleep(restart_timeout)
-					if(!delay_end)
-						world.Reboot()
-					else
-						world << "\blue <B>An admin has delayed the round end</B>"
-				else
-					world << "\blue <B>An admin has delayed the round end</B>"
+					world.Reboot("Round ended.", "end_proper", "proper completion")
 
 		else if (mode_finished)
 			post_game = 1

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -62,15 +62,7 @@
 /datum/game_mode/malfunction/post_setup()
 	for(var/datum/mind/AI_mind in malf_ai)
 		if(malf_ai.len < 1)
-			world << {"Uh oh, its malfunction and there is no AI! Please report this.<br />
-				Rebooting world in 5 seconds."}
-
-			feedback_set_details("end_error","malf - no AI")
-
-			if(blackbox)
-				blackbox.save_all_data_to_sql()
-			sleep(50)
-			world.Reboot()
+			world.Reboot("No AI during Malfunction.", "end_error", "malf - no AI", 50)
 			return
 		AI_mind.current.verbs += /mob/living/silicon/ai/proc/choose_modules
 		AI_mind.current:laws = new /datum/ai_laws/malfunction
@@ -83,11 +75,6 @@
 
 		AI_mind.current.verbs += /datum/game_mode/malfunction/proc/takeover
 
-/*		AI_mind.current.icon_state = "ai-malf"
-		spawn(10)
-			if(alert(AI_mind.current,"Do you want to use an alternative sprite for your real core?",,"Yes","No")=="Yes")
-				AI_mind.current.icon_state = "ai-malf2"
-*/
 	if(emergency_shuttle)
 		emergency_shuttle.auto_recall = 1
 	spawn (rand(waittime_l, waittime_h))

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -380,15 +380,7 @@ var/bomb_set
 															//kinda shit but I couldn't  get permission to do what I wanted to do.
 
 			if(!ticker.mode.check_finished())//If the mode does not deal with the nuke going off so just reboot because everyone is stuck as is
-				world << "<B>Resetting in 30 seconds!</B>"
-
-				feedback_set_details("end_error","nuke - unhandled ending")
-
-				if(blackbox)
-					blackbox.save_all_data_to_sql()
-				sleep(300)
-				log_game("Rebooting due to nuclear detonation.")
-				world.Reboot()
+				world.Reboot("Station destroyed by Nuclear Device.", "end_error", "nuke - unhandled ending")
 				return
 	return
 

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -1,5 +1,8 @@
 //Blocks an attempt to connect before even creating our client datum thing.
 world/IsBanned(key,address,computer_id)
+	if (!key || !address || !computer_id)
+		log_access("Failed Login (invalid data): [key] [address]-[computer_id]")
+		return list("reason"="invalid login data", "desc"="Your computer provided invalid or blank information to the server on connection (byond username, IP, and Computer ID.) Provided information for reference: Username:'[key]' IP:'[address]' Computer ID:'[computer_id]' If you continue to get this error, please restart byond or contact byond support.")
 	if(ckey(key) in admin_datums)
 		return ..()
 
@@ -38,17 +41,12 @@ world/IsBanned(key,address,computer_id)
 			diary << "Ban database connection failure. Key [ckeytext] not checked"
 			return
 
-		var/failedcid = 1
-		var/failedip = 1
-
 		var/ipquery = ""
 		var/cidquery = ""
 		if(address)
-			failedip = 0
 			ipquery = " OR ip = '[address]' "
 
 		if(computer_id)
-			failedcid = 0
 			cidquery = " OR computerid = '[computer_id]' "
 
 		var/DBQuery/query = dbcon.NewQuery("SELECT ckey, ip, computerid, a_ckey, reason, expiration_time, duration, bantime, bantype FROM [format_table_name("ban")] WHERE (ckey = '[ckeytext]' [ipquery] [cidquery]) AND (bantype = 'PERMABAN'  OR (bantype = 'TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)")
@@ -79,8 +77,4 @@ world/IsBanned(key,address,computer_id)
 
 			return list("reason"="[bantype]", "desc"="[desc]")
 
-		if (failedcid)
-			message_admins("[key] has logged in with a blank computer id in the ban check.")
-		if (failedip)
-			message_admins("[key] has logged in with a blank ip in the ban check.")
 		return ..()	//default pager ban stuff

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -597,7 +597,7 @@ var/global/nologevent = 0
 /datum/admins/proc/restart()
 	set category = "Server"
 	set name = "Restart"
-	set desc="Restarts the world immediately"
+	set desc = "Restarts the world."
 	
 	if(!check_rights(R_ADMIN))	return
 		

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -66,11 +66,12 @@ var/global/nologevent = 0
 		body += "<A href='?src=\ref[src];jobban2=\ref[M]'>Jobban</A> | "
 		body += "<A href='?src=\ref[src];appearanceban=\ref[M]'>Appearance Ban</A> | "
 		body += "<A href='?src=\ref[src];notes=show;mob=\ref[M]'>Notes</A> | "
-		if(M.client.check_watchlist(M.client.ckey))
-			body += "<A href='?_src_=holder;watchremove=[M.ckey]'>Remove from Watchlist</A> | "
-			body += "<A href='?_src_=holder;watchedit=[M.ckey]'>Edit Watchlist Reason</A> "
-		else
-			body += "<A href='?_src_=holder;watchadd=\ref[M.ckey]'>Add to Watchlist</A> "
+		if(M.client)
+			if(M.client.check_watchlist(M.client.ckey))
+				body += "<A href='?_src_=holder;watchremove=[M.ckey]'>Remove from Watchlist</A> | "
+				body += "<A href='?_src_=holder;watchedit=[M.ckey]'>Edit Watchlist Reason</A> "
+			else
+				body += "<A href='?_src_=holder;watchadd=\ref[M.ckey]'>Add to Watchlist</A> "
 
 	if(M.client)
 		body += "| <A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
@@ -596,31 +597,32 @@ var/global/nologevent = 0
 /datum/admins/proc/restart()
 	set category = "Server"
 	set name = "Restart"
-	set desc="Restarts the world"
-	if (!usr.client.holder)
-		return
+	set desc="Restarts the world immediately"
+	
+	if(!check_rights(R_ADMIN))	return
+		
 	var/confirm = alert("Restart the game world?", "Restart", "Yes", "Cancel")
 	if(confirm == "Cancel")
 		return
 	if(confirm == "Yes")
-		world << "\red <b>Restarting world!</b> \blue Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key]!"
-		log_admin("[key_name(usr)] initiated a reboot.")
-
-		feedback_set_details("end_error","admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]")
+		var/delay = input("What delay should the restart have (in seconds)?", "Restart Delay", 5) as num
+		if(!delay)
+			delay = 50
+		else
+			delay = delay * 10
+		message_admins("[key_name_admin(usr)] has initiated a server restart with a delay of [delay/10] seconds")
+		log_admin("[key_name(usr)] has initiated a server restart with a delay of [delay/10] seconds")
+		ticker.delay_end = 0
 		feedback_add_details("admin_verb","R") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-		if(blackbox)
-			blackbox.save_all_data_to_sql()
-
-		sleep(50)
-		world.Reboot()
+		world.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "end_error", "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", delay)
 
 
 /datum/admins/proc/announce()
 	set category = "Special Verbs"
 	set name = "Announce"
 	set desc="Announce your desires to the world"
-	if(!check_rights(0))	return
+	
+	if(!check_rights(R_ADMIN))	return
 
 	var/message = input("Global message to send:", "Admin Announce", null, null)  as message
 	if(message)
@@ -758,24 +760,6 @@ var/global/nologevent = 0
 		world << "<b>The game will start soon.</b>"
 		log_admin("[key_name(usr)] removed the delay.")
 	feedback_add_details("admin_verb","DELAY") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/datum/admins/proc/immreboot()
-	set category = "Server"
-	set desc="Reboots the server post haste"
-	set name="Immediate Reboot"
-	if(!usr.client.holder)	return
-	if( alert("Reboot server?",,"Yes","No") == "No")
-		return
-	world << "\red <b>Rebooting world!</b> \blue Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key]!"
-	log_admin("[key_name(usr)] initiated an immediate reboot.")
-
-	feedback_set_details("end_error","immediate admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]")
-	feedback_add_details("admin_verb","IR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-	if(blackbox)
-		blackbox.save_all_data_to_sql()
-
-	world.Reboot()
 
 /datum/admins/proc/unprison(var/mob/M in mob_list)
 	set category = "Admin"
@@ -997,6 +981,21 @@ proc/formatLocation(var/location)
 proc/formatPlayerPanel(var/mob/U,var/text="PP")
 	return "<A HREF='?_src_=holder;adminplayeropts=\ref[U]'>[text]</A>"
 
+//Kicks all the clients currently in the lobby. The second parameter (kick_only_afk) determins if an is_afk() check is ran, or if all clients are kicked
+//defaults to kicking everyone (afk + non afk clients in the lobby)
+//returns a list of ckeys of the kicked clients
+/proc/kick_clients_in_lobby(message, kick_only_afk = 0)
+	var/list/kicked_client_names = list()
+	for(var/client/C in clients)
+		if(istype(C.mob, /mob/new_player))
+			if(kick_only_afk && !C.is_afk())	//Ignore clients who are not afk
+				continue
+			if(message)
+				C << message
+			kicked_client_names.Add("[C.ckey]")
+			del(C)
+	return kicked_client_names	
+	
 //returns 1 to let the dragdrop code know we are trapping this event
 //returns 0 if we don't plan to trap the event
 /datum/admins/proc/cmd_ghost_drag(var/mob/dead/observer/frommob, var/mob/living/tomob)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -118,7 +118,6 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/delay,
 	/datum/admins/proc/toggleaban,
 	/client/proc/toggle_log_hrefs,
-	/datum/admins/proc/immreboot,
 	/client/proc/everyone_random,
 	/datum/admins/proc/toggleAI,
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -197,7 +197,7 @@
 			<tr id='title_tr'>
 				<td align='center'>
 					<font size='5'><b>Player panel</b></font><br>
-					Hover over a line to see more information - [check_rights(R_ADMIN,0) ? "<a href='?src=\ref[src];check_antagonist=1'>Check antagonists</a> | " : "" ]
+					Hover over a line to see more information | [check_rights(R_ADMIN,0) ? "<a href='?src=\ref[src];check_antagonist=1'>Check antagonists</a> | Kick <a href='?_src_=holder;kick_all_from_lobby=1;afkonly=0'>everyone</a>/<a href='?_src_=holder;kick_all_from_lobby=1;afkonly=1'>AFKers</a> in lobby" : "" ]
 					<p>
 				</td>
 			</tr>

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2109,6 +2109,23 @@
 					message_admins("[key_name_admin(usr)] created [number]ea [english_list(paths)]")
 					break
 		return
+		
+	else if(href_list["kick_all_from_lobby"])
+		if(!check_rights(R_ADMIN))
+			return
+		if(ticker && ticker.current_state == GAME_STATE_PLAYING)
+			var/afkonly = text2num(href_list["afkonly"])
+			if(alert("Are you sure you want to kick all [afkonly ? "AFK" : ""] clients from the lobby?","Confirmation","Yes","Cancel") != "Yes")
+				return
+			var/list/listkicked = kick_clients_in_lobby("<span class='danger'>You were kicked from the lobby by an Administrator.</span>", afkonly)
+
+			var/strkicked = ""
+			for(var/name in listkicked)
+				strkicked += "[name], "
+			message_admins("[key_name_admin(usr)] has kicked [afkonly ? "all AFK" : "all"] clients from the lobby. [length(listkicked)] clients kicked: [strkicked ? strkicked : "--"]")
+			log_admin("[key_name(usr)] has kicked [afkonly ? "all AFK" : "all"] clients from the lobby. [length(listkicked)] clients kicked: [strkicked ? strkicked : "--"]")
+		else
+			usr << "You may only use this when the game is running."
 
 	else if(href_list["secretsfun"])
 		if(!check_rights(R_SERVER|R_EVENT))	return

--- a/code/world.dm
+++ b/code/world.dm
@@ -215,20 +215,39 @@ var/world_topic_spam_protect_time = world.timeofday
 
 
 
-/world/Reboot(var/reason)
+/world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
+	if (reason == 1) //special reboot, do none of the normal stuff
+		spawn(0)
+			world << "<span class='boldannounce'>Rebooting world immediately due to host request</span>"
+		return ..(1)
+	var/delay
+	if(time)
+		delay = time
+	else
+		delay = ticker.restart_timeout
+	if(ticker.delay_end)
+		world << "<span class='boldannounce'>An admin has delayed the round end.</span>"
+		return
+	world << "<span class='boldannounce'>Rebooting world in [delay/10] [delay > 10 ? "seconds" : "second"]. [reason]</span>"
+	sleep(delay)
+	if(blackbox)
+		blackbox.save_all_data_to_sql()
+	if(ticker.delay_end)
+		world << "<span class='boldannounce'>Reboot was cancelled by an admin.</span>"
+		return
+	feedback_set_details("[feedback_c]","[feedback_r]")
+	log_game("<span class='boldannounce'>Rebooting world. [reason]</span>")
+	kick_clients_in_lobby("<span class='boldannounce'>The round came to an end with you in the lobby.</span>", 1) //second parameter ensures only afk clients are kicked
+
 	spawn(0)
 		world << sound(pick('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg')) // random end sounds!! - LastyBatsy
-
+	
 	processScheduler.stop()
-
+			
 	for(var/client/C in clients)
 		if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
 			C << link("byond://[config.server]")
-		else
-			C << link("byond://[world.address]:[world.port]")
-
-	..(reason)
-
+	..(0)
 
 #define INACTIVITY_KICK	6000	//10 minutes in ticks (approx.)
 /world/proc/KickInactiveClients()

--- a/code/world.dm
+++ b/code/world.dm
@@ -211,12 +211,11 @@ var/world_topic_spam_protect_time = world.timeofday
 
 		return show_player_info_irc(input["notes"])
 
-
-
-
-
 /world/Reboot(var/reason, var/feedback_c, var/feedback_r, var/time)
 	if (reason == 1) //special reboot, do none of the normal stuff
+		if(usr)
+			message_admins("[key_name_admin(usr)] has requested an immediate world restart via client side debugging tools")
+			log_admin("[key_name(usr)] has requested an immediate world restart via client side debugging tools")
 		spawn(0)
 			world << "<span class='boldannounce'>Rebooting world immediately due to host request</span>"
 		return ..(1)

--- a/code/world.dm
+++ b/code/world.dm
@@ -237,7 +237,7 @@ var/world_topic_spam_protect_time = world.timeofday
 		return
 	feedback_set_details("[feedback_c]","[feedback_r]")
 	log_game("<span class='boldannounce'>Rebooting world. [reason]</span>")
-	kick_clients_in_lobby("<span class='boldannounce'>The round came to an end with you in the lobby.</span>", 1) //second parameter ensures only afk clients are kicked
+	//kick_clients_in_lobby("<span class='boldannounce'>The round came to an end with you in the lobby.</span>", 1)
 
 	spawn(0)
 		world << sound(pick('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg')) // random end sounds!! - LastyBatsy


### PR DESCRIPTION
Changes:
1) Improves and consolidates the Reboot() proc. The "Immediate Reboot" proc has been removed, and replaced with the option to enter a delay time in the Restart proc: https://github.com/tgstation/-tg-station/pull/9735/https://github.com/tgstation/-tg-station/pull/11507.
2) IsBanned() now rejects blank ckeys/IP's/CID's: https://github.com/tgstation/-tg-station/pull/8177.
3) The player panel will now work again on clientless mobs.
4) Adds an option to kick all (AFK) clients from the lobby to the player panel.