### PR TITLE
Adds minor brain damage to holywater

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -471,10 +471,10 @@ datum
 			process_flags = ORGANIC | SYNTHETIC
 
 			on_mob_life(var/mob/living/M as mob)
-					if(prob(70))
-						M.adjustBrainLoss(1)
-						M << "<span class = 'danger'>You feel your belief in religion bolstering</span>"
-					if(ishuman(M))
+				if(prob(70))
+					M.adjustBrainLoss(1)
+					M << "<span class = 'danger'>You feel your belief in religion bolstering</span>"
+				if(ishuman(M))
 					if((M.mind in ticker.mode.cult) && prob(10))
 						M << "\blue A cooling sensation from inside you brings you an untold calmness."
 						ticker.mode.remove_cultist(M.mind)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -471,13 +471,10 @@ datum
 			process_flags = ORGANIC | SYNTHETIC
 
 			on_mob_life(var/mob/living/M as mob)
-				if(!M) M = holder.my_atom
-				if(prob(70))
-					M.adjustBrainLoss(1)
-				..()
-
-			on_mob_life(var/mob/living/M as mob)
-				if(ishuman(M))
+					if(prob(70))
+						M.adjustBrainLoss(1)
+						M << "<span class = 'danger'>You feel your belief in religion bolstering</span>"
+					if(ishuman(M))
 					if((M.mind in ticker.mode.cult) && prob(10))
 						M << "\blue A cooling sensation from inside you brings you an untold calmness."
 						ticker.mode.remove_cultist(M.mind)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -471,6 +471,12 @@ datum
 			process_flags = ORGANIC | SYNTHETIC
 
 			on_mob_life(var/mob/living/M as mob)
+				if(!M) M = holder.my_atom
+				if(prob(70))
+					M.adjustBrainLoss(1)
+				..()
+
+			on_mob_life(var/mob/living/M as mob)
 				if(ishuman(M))
 					if((M.mind in ticker.mode.cult) && prob(10))
 						M << "\blue A cooling sensation from inside you brings you an untold calmness."
@@ -2242,11 +2248,11 @@ datum
 						M.AdjustWeakened(-1)
 					..()
 					return
-					
+
 				overdose_process(var/mob/living/M as mob)
 					if(volume > 45)
 						M.Jitter(5)
-						
+
 					..()
 					return
 


### PR DESCRIPTION
Because it's made from mercury, and to stop people from just creating
"validhunt smoke"
Adds a notice when you take brain damage from holywater as well.