### PR TITLE
Gives Blueshield access to all the heads offices

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -159,7 +159,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_blueshield,
 			            access_captain, access_hop, access_hos, access_ce, access_cmo, access_rd, access_ntrep, access_magistrate)
 	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_construction, access_engine, access_maint_tunnels, access_research,
-			            access_RC_announce, access_keycard_auth, access_heads, access_blueshield, access_weapons)
+			            access_RC_announce, access_keycard_auth, access_heads, access_blueshield, access_weapons, access_captain, access_hop, access_hos,
+			            access_ce, access_cmo, access_rd, access_ntrep, access_magistrate)
 
 	equip(var/mob/living/carbon/human/H)
 		if(!H)	return 0

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -156,7 +156,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_blueshield)
+			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_blueshield,
+			            access_captain, access_hop, access_hos, access_ce, access_cmo, access_rd, access_ntrep, access_magistrate)
 	minimal_access = list(access_forensics_lockers, access_sec_doors, access_medical, access_construction, access_engine, access_maint_tunnels, access_research,
 			            access_RC_announce, access_keycard_auth, access_heads, access_blueshield, access_weapons)
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -120,7 +120,6 @@ var/list/security_positions = list(
 	"Warden",
 	"Detective",
 	"Security Officer",
-	"Blueshield",
 	"Brig Physician",
 	"Security Pod Pilot"
 )


### PR DESCRIPTION
No more sitting around for 20 minutes asking the HoP to open his door!
Fixes: #1821

other changes:
Removes blueshield from being classified under Security, as he is not security. I wasn't sure where to put him other than that, so I left him unclassified (similar to the NT rep).