### PR TITLE
Cult Tweaks

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -349,6 +349,12 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 		if(!iscultist(user))
 			return ..()
 		if(iscultist(M))
+			if(M.reagents && M.reagents.has_reagent("holywater")) //allows cultists to be rescued from the clutches of ordained religion
+				user << "<span class='notice'>You remove the taint from [M].</span>"
+				var/holy2unholy = M.reagents.get_reagent_amount("holywater")
+				M.reagents.del_reagent("holywater")
+				M.reagents.add_reagent("unholywater",holy2unholy)
+				add_logs(M, user, "smacked", src, " removing the holy water from them")
 			return
 		M.take_organ_damage(0,rand(5,20)) //really lucky - 5 hits for a crit
 		for(var/mob/O in viewers(M, null))

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -558,14 +558,14 @@ var/list/sacrificed = list()
 	else
 		usr.whisper("[input]")
 
-	log_say("Cult Message: [key_name(usr)]: [input]")	
+	log_say("Cult Message: [key_name(usr)]: [input]")
 	for(var/datum/mind/H in ticker.mode.cult)
 		if (H.current)
 			H.current << "<span class='cultspeech'><span class='name'>[cultName]: </span><span class='message'>[input]</span></span>"
 
 	for(var/mob/spirit/spirit in spirits)
 		spirit << "<span class='cultspeech'><span class='name'><a href='byond://?src=\ref[spirit];track2=\ref[spirit];track=\ref[usr]'>[displayName]: </a></span><span class='message'>[input]</span></span>"
-		
+
 	for(var/mob/dead/observer/G in player_list)
 		G.show_message("<span class='cultspeech'><span class='name'>[displayName] ([cultName]) ([ghost_follow_link(usr, ghost=G)]): </span><span class='message'>[input]</span></span>")
 
@@ -699,7 +699,7 @@ var/list/sacrificed = list()
 	if (istype(W,/obj/item/weapon/paper/talisman))
 		rad = 4
 		go = 1
-	if (istype(W,/obj/item/weapon/nullrod))
+	if (istype(W,/obj/item/weapon/storage/bible))
 		rad = 1
 		go = 1
 	if(go)
@@ -708,7 +708,7 @@ var/list/sacrificed = list()
 				R:visibility=15
 			S=1
 	if(S)
-		if(istype(W,/obj/item/weapon/nullrod))
+		if(istype(W,/obj/item/weapon/storage/bible))
 			usr << "\red Arcane markings suddenly glow from underneath a thin layer of dust!"
 			return
 		if(istype(W,/obj/effect/rune))

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -94,24 +94,24 @@
 	return
 
 /obj/item/weapon/storage/bible/afterattack(atom/A, mob/user as mob, proximity)
-	if(!proximity) return
-/*	if (istype(A, /turf/simulated/floor))
-		user << "\blue You hit the floor with the bible."
+	if(!proximity)
+		return
+	if (istype(A, /turf/simulated/floor))
+		user << "<span class='notice'>You hit the floor with the bible.</span>"
 		if(user.mind && (user.mind.assigned_role == "Chaplain"))
-			call(/obj/effect/rune/proc/revealrunes)(src)*/
+			call(/obj/effect/rune/proc/revealrunes)(src)
 	if(user.mind && (user.mind.assigned_role == "Chaplain"))
 		if(A.reagents && A.reagents.has_reagent("water")) //blesses all the water in the holder
-			user << "\blue You bless [A]."
+			user << "<span class='notice'>You bless [A].</span>"
 			var/water2holy = A.reagents.get_reagent_amount("water")
 			A.reagents.del_reagent("water")
 			A.reagents.add_reagent("holywater",water2holy)
+		if(A.reagents && A.reagents.has_reagent("unholywater")) //yeah yeah, copy pasted code - sue me
+			user << "<span class='notice'>You purify [A].</span>"
+			var/unholy2clean = A.reagents.get_reagent_amount("unholywater")
+			A.reagents.del_reagent("unholywater")
+			A.reagents.add_reagent("holywater",unholy2clean)
 
 /obj/item/weapon/storage/bible/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	playsound(src.loc, "rustle", 50, 1, -5)
 	..()
-
-	if(W.reagents && W.reagents.has_reagent("water"))
-		user << "<span class='notice'>You feel [deity_name] blessing \the [W] as you insert it into \the [src].</span>"
-		var/water2holy = W.reagents.get_reagent_amount("water")
-		W.reagents.del_reagent("water")
-		W.reagents.add_reagent("holywater",water2holy)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -57,12 +57,6 @@
 					M.mind.vampire.nullified = max(5, M.mind.vampire.nullified + 2)
 	..()
 
-
-/obj/item/weapon/nullrod/afterattack(atom/A, mob/user as mob)
-	if (istype(A, /turf/simulated/floor))
-		user << "\blue You hit the floor with the [src]."
-		call(/obj/effect/rune/proc/revealrunes)(src)
-
 /obj/item/weapon/sord
 	name = "\improper SORD"
 	desc = "This thing is so unspeakably shitty you are having a hard time even holding it."

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1076,6 +1076,7 @@ datum
 				name = "Unholy Water"
 				id = "unholywater"
 				description = "Something that shouldn't exist on this plane of existance."
+				process_flags = ORGANIC | SYNTHETIC //ethereal means everything processes it.
 
 				on_mob_life(mob/living/M)
 					M.adjustBrainLoss(3)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1064,22 +1064,33 @@ datum
 				if(method == TOUCH)
 					M.adjust_fire_stacks(volume / 10)
 				return
-			/*
-			reaction_obj(var/obj/O, var/volume)
-				var/turf/the_turf = get_turf(O)
-				if(!the_turf)
-					return //No sense trying to start a fire if you don't have a turf to set on fire. --NEO
-				new /obj/effect/decal/cleanable/liquid_fuel(the_turf, volume)
-			reaction_turf(var/turf/T, var/volume)
-				new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
-				return
-			*/
+			..()
+
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom
 				M.adjustToxLoss(1)
 				..()
 				return
 
+			unholywater		//if you somehow managed to extract this from someone, dont splash it on yourself and have a smoke
+				name = "Unholy Water"
+				id = "unholywater"
+				description = "Something that shouldn't exist on this plane of existance."
+
+				on_mob_life(mob/living/M)
+					M.adjustBrainLoss(3)
+					if(iscultist(M))
+						M.status_flags |= GOTTAGOFAST
+						M.drowsyness = max(M.drowsyness-5, 0)
+						M.AdjustParalysis(-2)
+						M.AdjustStunned(-2)
+						M.AdjustWeakened(-2)
+					else
+						M.adjustToxLoss(2)
+						M.adjustFireLoss(2)
+						M.adjustOxyLoss(2)
+						M.adjustBruteLoss(2)
+					holder.remove_reagent(src.id, 1)
 
 		incendiary_fuel //copy-pasta of welding fuel; allow incendiary grenades to function better without the headache of people spraying fuel everywhere with regular welding fuel.
 			name = "Incendiary fuel"
@@ -2242,11 +2253,11 @@ datum
 						M.AdjustWeakened(-1)
 					..()
 					return
-					
+
 				overdose_process(var/mob/living/M as mob)
 					if(volume > 45)
 						M.Jitter(5)
-						
+
 					..()
 					return
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1063,8 +1063,8 @@ datum
 					return
 				if(method == TOUCH)
 					M.adjust_fire_stacks(volume / 10)
-				return
-			..()
+					return
+				..()
 
 			on_mob_life(var/mob/living/M as mob)
 				if(!M) M = holder.my_atom


### PR DESCRIPTION
This is meant to technically go along with: https://github.com/ParadiseSS13/Paradise/pull/1942

Just some cult tweaks to address a few things with cult (this game mode really needs to be updated, badly). Plucked from TG's updated cult mode:

- Adds in unholy water
 - Unholy water deals various damage types to non-cultists. Cultists take no damage from it and are more difficult to stun in addition to boosting their movement speed. Cultists and non-cultists alike take brain damage from it.
- Adds in the ability to convert holy water to unholy water with a cult tome (only inside a mob)
 - Simply put if you get holy water in you as a cultist, you can hit yourself with a tome to turn it into unholy water. This allows holy water to deconvert, but actually gives cultists an *advantage* if someone goes around trying to force feed them holy water or holy-water bombs everyone (as they'll just convert it over to unholy water with their tomes).
- Removes Blessing of containers by inserting them into a Bible (this converts water to holy water).
 - Blessing containers that have water isn't removed.
- Revealing runes moved to the Bible itself (which checks if you're a Chaplain).
 - The above two are to help cut down a bit on regular crew doing the "hunting" during cult rounds and instead putting it on who should be: the Chaplain.
- Bible can convert unholy water BACK into holy water