### PR TITLE
Fix mobs being unable to eat other mobs

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -391,7 +391,7 @@
 			var/mob/living/carbon/attacker = user
 			user.visible_message("<span class='danger'>[user] is attempting to devour \the [affecting]!</span>")
 
-			if(!do_mob(user, affecting) || !do_after(user, checktime(user, affecting, target = affecting))) return
+			if(!do_after(user, checktime(user, affecting), target = affecting)) return
 
 			user.visible_message("<span class='danger'>[user] devours \the [affecting]!</span>")
 


### PR DESCRIPTION
fixes #1945 

Two things were wrong:
First, target was not set on do_after.
Second, do_mob is no longer compatible with do_after- do_after has the features of do_mob in it anyways.