### PR TITLE
Brain Damage Fix

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -1,6 +1,7 @@
 /obj/item/organ/brain
 	name = "brain"
 	health = 400 //They need to live awhile longer than other organs.
+	max_damage = 200
 	icon_state = "brain2"
 	force = 1.0
 	w_class = 2.0


### PR DESCRIPTION
Basically, ever since brain damage was tied to the brain item, brain damage has been capped at 60---meaning that there's absolute no threat of ever dying from brain damage and the ill effects of brain damage are more or less negligible. The bug also causes someone who hits 60 brain damage to "die", but instantly revive.

This PR increases the brain organ's max damage to 200, allowing for a total damage counter of 200.

This meas that Meth and other sources of brain damage should be a threat, once again and prevent odd quick-death-revives.