### PR TITLE
Space Cleaner Feature: Color Removal

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1118,13 +1118,18 @@ datum
 			color = "#61C2C2"
 
 			reaction_obj(var/obj/O, var/volume)
+				if(O)
+					O.color = initial(O.color)
 				if(istype(O,/obj/effect/decal/cleanable))
 					qdel(O)
 				else
 					if(O)
 						O.clean_blood()
+
 			reaction_turf(var/turf/T, var/volume)
 				if(volume >= 1)
+					if(T)
+						T.color = initial(T.color)
 					T.overlays.Cut()
 					T.clean_blood()
 					for(var/obj/effect/decal/cleanable/C in src)
@@ -1132,9 +1137,10 @@ datum
 
 					for(var/mob/living/carbon/slime/M in T)
 						M.adjustToxLoss(rand(5,10))
-			reaction_turf(var/turf/simulated/S, var/volume)
-				if(volume >= 1)
-					S.dirt = 0
+					if(istype(T,/turf/simulated))
+						var/turf/simulated/S = T
+						S.dirt = 0
+
 			reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
 				if(iscarbon(M))
 					var/mob/living/carbon/C = M
@@ -2242,11 +2248,11 @@ datum
 						M.AdjustWeakened(-1)
 					..()
 					return
-					
+
 				overdose_process(var/mob/living/M as mob)
 					if(volume > 45)
 						M.Jitter(5)
-						
+
 					..()
 					return
 


### PR DESCRIPTION
Space cleaner can now reset/clean object's and turf's colors. 
- Simply put someone going on a colorful reagent rampage is annoying as hell because you literally can't clear off the color in any way; this allows space cleaner to reset an item's color back to its original state.

Related
- Cleans up space cleaner's `reaction_turf` so there aren't two, by putting a typecheck into the original `reaction_turf`.

Labeled fix, because there always should have been away to clear off that gosh damn paint.