### PR TITLE
Misc. -tg- xeno tweaks

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -191,21 +191,14 @@
 		qdel(src)
 		return
 
-	direction_loop:
-		for(var/dirn in cardinal)
-			var/turf/T = get_step(src, dirn)
+	if(!linked_node || get_dist(linked_node, src) > linked_node.node_range)
+		return
 
-			if (!istype(T) || T.density || locate(/obj/structure/alien/weeds) in T || istype(T, /turf/space))
-				continue
+	for(var/turf/T in U.GetAtmosAdjacentTurfs())
+		if(locate(/obj/structure/alien/weeds) in T || istype(T, /turf/space))
+			continue
 
-			if(!linked_node || get_dist(linked_node, src) > linked_node.node_range)
-				return
-
-			for(var/obj/O in T)
-				if(O.density)
-					continue direction_loop
-
-			new /obj/structure/alien/weeds(T, linked_node)
+		new /obj/structure/alien/weeds(T, linked_node)
 
 
 /obj/structure/alien/weeds/ex_act(severity)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -393,6 +393,13 @@ var/global/list/rockTurfEdgeCache
 		gets_drilled()
 	..()
 
+/turf/simulated/mineral/attack_alien(var/mob/living/carbon/alien/M)
+	M << "<span class='notice'>You start digging into the rock...</span>"
+	playsound(src, 'sound/effects/break_stone.ogg', 50, 1)
+	if(do_after(M, 40, target = src))
+		M << "<span class='notice'>You tunnel into the rock.</span>"
+		gets_drilled()
+
 /turf/simulated/mineral/Bumped(AM as mob|obj)
 	. = ..()
 	if(istype(AM,/mob/living/carbon/human))


### PR DESCRIPTION
tgstation/-tg-station#11518
tgstation/-tg-station#10870

This commit does the following:
 - Allows xenomorphs to mine through mineral turfs (the asteroid)
 - Changes weed spreading to use atmos procs; It will spread like gas, not
   just checking "oh, dense object, no pass for me!"
  - No, this doesn't mean it will spread infinitely or quicker, just
    changes where it can spread.

Screenshots:
![spreading](https://puu.sh/k0MEA/8562819b88.png)
![mining nest](https://puu.sh/k0MYe/7438fdfb29.png)