### PR TITLE
Unknown Language Fix, Shrimp Recipe Tweak

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -583,4 +583,3 @@ proc/dd_sortedObjectList(list/incoming)
 
 /datum/alarm/dd_SortValue()
 	return "[sanitize(last_name)]"
-	

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -183,8 +183,8 @@
 	if(!prefs.unlock_content)
 		src << "Become a BYOND member to access member-perks and features, as well as support the engine that makes this game possible. <a href='http://www.byond.com/membership'>Click here to find out more</a>."
 		return 0
-	return 1	
-	
+	return 1
+
 /client/proc/handle_spam_prevention(var/message, var/mute_type)
 	if(config.automute_on && !holder && src.last_message == message)
 		src.last_message_count++
@@ -330,8 +330,8 @@
 	related_accounts_cid = list()
 	while(query_cid.NextRow())
 		if(ckey != query_cid.item[1])
-			related_accounts_cid.Add("[query_cid.item[1]]")			
-			
+			related_accounts_cid.Add("[query_cid.item[1]]")
+
 	//Log all the alts
 	if(related_accounts_cid.len)
 		log_access("Alts: [key_name(src)]:[list2text(related_accounts_cid, " - ")]")
@@ -339,8 +339,8 @@
 	var/watchreason = check_watchlist(sql_ckey)
 	if(watchreason)
 		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is on the watchlist and has just connected - Reason: [watchreason]</font>")
-		send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")	
-		
+		send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
+
 	//Just the standard check to see if it's actually a number
 	if(sql_id)
 		if(istext(sql_id))
@@ -389,6 +389,15 @@
 		'html/search.js', // Used in various non-NanoUI HTML windows for search functionality
 		'html/panels.css' // Used for styling certain panels, such as in the new player panel
 	)
-		
+
 	// Send NanoUI resources to this client
 	spawn nanomanager.send_resources(src)
+
+//For debugging purposes
+/client/proc/list_all_languages()
+	for(var/L in all_languages)
+		var/datum/language/lang = all_languages[L]
+		var/message = "[lang.name] : [lang.type]"
+		if(lang.flags & RESTRICTED)
+			message += " (RESTRICTED)"
+		world << "[message]"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -185,17 +185,17 @@ datum/preferences
 
 	// jukebox volume
 	var/volume = 100
-	
+
 	// BYOND membership
 	var/unlock_content = 0
-	
+
 /datum/preferences/New(client/C)
 	b_type = pick(4;"O-", 36;"O+", 3;"A-", 28;"A+", 1;"B-", 20;"B+", 1;"AB-", 5;"AB+")
 	if(istype(C))
 		if(!IsGuestKey(C.key))
 			unlock_content = C.IsByondMember()
 			if(unlock_content)
-				max_save_slots = MAX_SAVE_SLOTS_MEMBER 
+				max_save_slots = MAX_SAVE_SLOTS_MEMBER
 	var/loaded_preferences_successfully = load_preferences(C)
 	if(loaded_preferences_successfully)
 		if(load_character(C))
@@ -385,7 +385,7 @@ datum/preferences
 				dat += "<b>Ghost radio:</b> <a href='?_src_=prefs;preference=ghost_radio'><b>[(toggles & CHAT_GHOSTRADIO) ? "Nearest Speakers" : "All Chatter"]</b></a><br>"
 				if(config.allow_Metadata)
 					dat += "<b>OOC notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'><b>Edit</b></a><br>"
-				
+
 				if(user.client)
 					if(user.client.holder)
 						dat += "<b>Adminhelp sound:</b> "
@@ -393,7 +393,7 @@ datum/preferences
 
 					if(check_rights(R_ADMIN,0))
 						dat += "<b>OOC:</b> <span style='border: 1px solid #161616; background-color: [ooccolor ? ooccolor : normal_ooc_colour];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=ooccolor;task=input'><b>Change</b></a><br>"
-						
+
 					if(unlock_content)
 						dat += "<b>BYOND Membership Publicity:</b> <a href='?_src_=prefs;preference=publicity'><b>[(toggles & MEMBER_PUBLIC) ? "Public" : "Hidden"]</b></a><br>"
 
@@ -1125,6 +1125,9 @@ datum/preferences
 */
 						for(var/L in all_languages)
 							var/datum/language/lang = all_languages[L]
+							if(lang.name == "an unknown language")
+								//don't add the parent type language as an option
+								continue
 							if(!(lang.flags & RESTRICTED))
 								new_languages += lang.name
 
@@ -1360,7 +1363,7 @@ datum/preferences
 					if("publicity")
 						if(unlock_content)
 							toggles ^= MEMBER_PUBLIC
-							
+
 					if("gender")
 						if(gender == MALE)
 							gender = FEMALE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1125,9 +1125,6 @@ datum/preferences
 */
 						for(var/L in all_languages)
 							var/datum/language/lang = all_languages[L]
-							if(lang.name == "an unknown language")
-								//don't add the parent type language as an option
-								continue
 							if(!(lang.flags & RESTRICTED))
 								new_languages += lang.name
 

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -632,7 +632,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/mint
 
 /datum/recipe/microwave/boiled_shrimp
-	reagents = list("water" = 1)
+	reagents = list("water" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/shrimp
 	)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -19,6 +19,7 @@
 	var/list/syllables               // Used when scrambling text for a non-speaker.
 	var/list/space_chance = 55       // Likelihood of getting a space in the random scramble string.
 	var/follow = 0					 // Applies to HIVEMIND languages - should a follow link be included for dead mobs?
+	var/list/scramble_cache = list()
 
 /datum/language/proc/get_random_name(var/gender, name_count=2, syllable_count=4)
 	if(!syllables || !syllables.len)
@@ -37,9 +38,6 @@
 		full_name += " [capitalize(lowertext(new_name))]"
 
 	return "[trim(full_name)]"
-
-/datum/language
-	var/list/scramble_cache = list()
 
 /datum/language/proc/scramble(var/input)
 
@@ -247,7 +245,7 @@
 	flags = RESTRICTED | WHITELISTED
 	syllables = list("02011","01222","10100","10210","21012","02011","21200","1002","2001","0002","0012","0012","000","120","121","201","220","10","11","0")
 
-/datum/language/machine/get_random_name()
+/datum/language/trinary/get_random_name()
 	var/new_name
 	if(prob(70))
 		new_name = "[pick(list("PBU","HIU","SINA","ARMA","OSI"))]-[rand(100, 999)]"


### PR DESCRIPTION
Removes "an unknown language" from selectable options in character creation
- Fixes #1940

Tweaks the recipe for Cooked Shrimp to be more in-line with similar recipes
- Previously required 1 unit of water, now requires 5 units of water

Fixed IPC random names being random strings of 0's, 1's, and the occasional 2.
- This was caused by source of the "an unknown language" bug (#1940)
- IPC random names will now be things like PBU-117 or SINA-999

Re-consolidated the vars for the /datum/language define to be in a single code block

Adds a new proc for clients that lists all language names, their path, and whether they are restricted.
- Can only be called via proc-call
 - For debugging purposes only, please do not use on live server as it will spam chat due to sending the messages to world.