### PR TITLE
Respawn as NPC Tweak: Xeno Removal

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -470,11 +470,7 @@
 		return 1
 
 //Antag Creatures!
-/*	if(ispath(MP, /mob/living/simple_animal/hostile/carp) && !jobban_isbanned(src, "Syndicate"))
-		return 1 */
 	if(ispath(MP, /mob/living/simple_animal/borer) && !jobban_isbanned(src, "alien") && !jobban_isbanned(src, "Syndicate"))
-		return 1
-	if(ispath(MP, /mob/living/carbon/alien) && !jobban_isbanned(src, "alien") && !jobban_isbanned(src, "Syndicate"))
 		return 1
 	if(ispath(MP, /mob/living/simple_animal/hostile/statue) && !jobban_isbanned(src, "Syndicate"))
 		return 1


### PR DESCRIPTION
Removes Xenomorphs from the "respawn as NPC" list. 

Why? Simply put, our Xeno system was reworked to pull from ghost candidates--we don't/can't have empty larva anymore, so this system is no longer necessary.

Additionally, it creates issues for admins who aghost as Xenos and end up getting their Xeno possesed by a ghost who respawned as a Xeno.