### PR TITLE
R&D Update and Fix & Cargo Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	w_class = 3
-	origin_tech = "engineering=4;materials=4;bluespace=2;programming=4"
+	origin_tech = "biotech=3;programming=2"
 
 	var/searching = 0
 	var/askDelay = 10 * 60 * 1

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -22,7 +22,7 @@ The currently supporting non-reagent materials:
 Don't add new keyword/IDs if they are made from an existing one (such as rods which are made from metal). Only add raw materials.
 
 Design Guidlines
-- The reliability formula for all R&D built items is reliability_base (a fixed number) + total tech levels required to make it +
+- The reliability formula for all R&D built items is reliability (a fixed number) + total tech levels required to make it +
 reliability_mod (starts at 0, gets improved through experimentation). Example: PACMAN generator. 79 base reliablity + 6 tech
 (3 plasmatech, 3 powerstorage) + 0 (since it's completely new) = 85% reliability. Reliability is the chance it works CORRECTLY.
 - When adding new designs, check rdreadme.dm to see what kind of things have already been made and where new stuff is needed.
@@ -38,8 +38,6 @@ other types of metals and chemistry for reagents).
 	var/desc = "Desc"					//Description of the created object.
 	var/id = "id"						//ID of the created object for easy refernece. Alphanumeric, lower-case, no symbols
 	var/list/req_tech = list()			//IDs of that techs the object originated from and the minimum level requirements.
-	var/reliability_mod = 0				//Reliability modifier of the device at it's starting point.
-	var/reliability_base = 100			//Base reliability of a device before modifiers.
 	var/reliability = 100				//Reliability of the device.
 	var/build_type = null				//Flag as to what kind machine the design is built in. See defines.
 	var/list/materials = list()			//List of materials. Format: "id" = amount.

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -8,7 +8,7 @@
 	req_tech = list("bluespace" = 4, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_DIAMOND = 1500, MAT_PLASMA = 1500)
-	reliability_base = 100
+	reliability = 100
 	build_path = /obj/item/bluespace_crystal/artificial
 	category = list("Bluespace")
 
@@ -19,7 +19,7 @@
 	req_tech = list("bluespace" = 4, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 3000, MAT_DIAMOND = 1500, MAT_URANIUM = 250)
-	reliability_base = 80
+	reliability = 80
 	build_path = /obj/item/weapon/storage/backpack/holding
 	category = list("Bluespace")
 
@@ -30,7 +30,7 @@
 	req_tech = list("bluespace" = 4, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_GOLD = 1500, MAT_DIAMOND = 3000, MAT_URANIUM = 1000)
-	reliability_base = 80
+	reliability = 80
 	build_path = /obj/item/weapon/storage/belt/bluespace
 	category = list("Bluespace")
 
@@ -41,7 +41,7 @@
 	req_tech = list("bluespace" = 2, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_PLASMA = 3000, MAT_DIAMOND = 500)
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/bluespace
 	category = list("Medical")
 

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -8,7 +8,7 @@
 	req_tech = list("biotech" = 2, "magnets" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	reliability_base = 74
+	reliability = 74
 	build_path = "/obj/item/device/mass_spectrometer/adv"
 	category = list("Medical")
 
@@ -19,7 +19,7 @@
 	req_tech = list("biotech" = 2, "magnets" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	reliability_base = 74
+	reliability = 74
 	build_path = /obj/item/device/reagent_scanner/adv
 	category = list("Medical")
 
@@ -30,7 +30,7 @@
 	req_tech = list("materials" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000)
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/weapon/reagent_containers/glass/beaker/noreact
 	category = list("Medical")
 
@@ -41,7 +41,7 @@
 	req_tech = list("programming" = 2, "biotech" = 2, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/device/robotanalyzer
 	category = list("Medical")
 
@@ -84,7 +84,7 @@
 	req_tech = list("biotech" = 4, "magnets" = 3, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/device/sensor_device
 	category = list("Medical")
 
@@ -96,7 +96,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
 	construction_time = 75
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/device/mmi
 	category = list("Misc","Medical")
 
@@ -107,17 +107,19 @@
 	req_tech = list("biotech" = 2, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/device/mass_spectrometer
 	category = list("Medical")
 
 /datum/design/posibrain
 	name = "Positronic Brain"
-	desc = "Allows for the construction of a positronic brain"
-	id = "posibrain"
-	req_tech = list("engineering" = 4, "materials" = 6, "bluespace" = 2, "programming" = 4)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000, MAT_SILVER = 1000, MAT_GOLD = 500, MAT_PLASMA = 500, MAT_DIAMOND = 100)
+	desc = "The latest in Artificial Intelligences."
+	id = "mmi_posi"
+	req_tech = list("programming" = 5, "biotech" = 4)
+	build_type = PROTOLATHE | MECHFAB
+	materials = list(MAT_METAL = 1700, MAT_GLASS = 1350, MAT_GOLD = 500) //Gold, because SWAG.
+	reliability = 74
+	construction_time = 75
 	build_path = /obj/item/device/mmi/posibrain
 	category = list("Misc","Medical")
 
@@ -129,7 +131,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 1200, MAT_GLASS = 500)
 	construction_time = 75
-	reliability_base = 74
+	reliability = 74
 	build_path = /obj/item/device/mmi/radio_enabled
 	category = list("Misc","Medical")
 
@@ -150,7 +152,7 @@
 	req_tech = list("biotech" = 2, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/device/reagent_scanner
 	category = list("Medical")
 
@@ -162,7 +164,7 @@
 	build_type = MECHFAB
 	materials = list(MAT_METAL = 750, MAT_GLASS = 750)
 	construction_time = 100
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/device/flash/synthetic
 	category = list("Misc")
 

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -8,7 +8,7 @@
 	req_tech = list("materials" = 6, "powerstorage" = 4, "engineering" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_DIAMOND = 3750) //Yes, a whole diamond is needed.
-	reliability_base = 79
+	reliability = 79
 	build_path = /obj/item/weapon/pickaxe/drill/diamonddrill
 	category = list("Mining")
 
@@ -39,7 +39,7 @@
 	req_tech = list("materials" = 2, "plasmatech" = 2, "engineering" = 2, "combat" = 1, "magnets" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 1500, MAT_GLASS = 500, MAT_GOLD = 500, MAT_PLASMA = 500)
-	reliability_base = 79
+	reliability = 79
 	build_path = /obj/item/weapon/gun/energy/plasmacutter
 	category = list("Mining")
 
@@ -50,7 +50,7 @@
 	req_tech = list("materials" = 4, "plasmatech" = 3, "engineering" = 3, "combat" = 3, "magnets" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 500)
-	reliability_base = 79
+	reliability = 79
 	build_path = /obj/item/weapon/gun/energy/plasmacutter/adv
 	category = list("Mining")
 

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -29,7 +29,7 @@
 	desc = "A power cell that holds 30000 units of energy"
 	id = "hyper_cell"
 	req_tech = list("powerstorage" = 5, "materials" = 4)
-	reliability_base = 70
+	reliability = 70
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 400, MAT_GOLD = 150, MAT_SILVER = 150, MAT_GLASS = 70)
 	construction_time=100
@@ -41,7 +41,7 @@
 	desc = "A power cell that holds 20000 units of energy"
 	id = "super_cell"
 	req_tech = list("powerstorage" = 3, "materials" = 2)
-	reliability_base = 75
+	reliability = 75
 	build_type = PROTOLATHE | MECHFAB | PODFAB
 	materials = list(MAT_METAL = 700, MAT_GLASS = 70)
 	construction_time=100
@@ -53,7 +53,7 @@
 	desc = "A power cell that holds 40000 units of energy."
 	id = "bluespace_cell"
 	req_tech = list("powerstorage" = 6, "materials" = 5)
-	reliability_base = 70
+	reliability = 70
 	build_type = PROTOLATHE | MECHFAB
 	materials = list(MAT_METAL = 800, MAT_GOLD = 300, MAT_SILVER = 300, MAT_GLASS = 160, MAT_DIAMOND = 160)
 	construction_time=100
@@ -66,7 +66,7 @@
 	id = "pacman"
 	req_tech = list("programming" = 3, "plasmatech" = 3, "powerstorage" = 3, "engineering" = 3)
 	build_type = IMPRINTER
-	reliability_base = 79
+	reliability = 79
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/pacman
 	category = list("Engineering Machinery")
@@ -77,7 +77,7 @@
 	id = "mrspacman"
 	req_tech = list("programming" = 3, "powerstorage" = 5, "engineering" = 5)
 	build_type = IMPRINTER
-	reliability_base = 74
+	reliability = 74
 	materials = list(MAT_GLASS = 2000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/pacman/mrs
 	category = list("Engineering Machinery")
@@ -88,7 +88,7 @@
 	id = "superpacman"
 	req_tech = list("programming" = 3, "powerstorage" = 4, "engineering" = 4)
 	build_type = IMPRINTER
-	reliability_base = 76
+	reliability = 76
 	materials = list(MAT_GLASS = 1000, "sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/pacman/super
 	category = list("Engineering Machinery")

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -108,7 +108,7 @@
 	id = "super_capacitor"
 	req_tech = list("powerstorage" = 5, "materials" = 4)
 	build_type = PROTOLATHE
-	reliability_base = 71
+	reliability = 71
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50, MAT_GOLD = 20)
 	build_path = /obj/item/weapon/stock_parts/capacitor/super
 	category = list("Stock Parts")
@@ -120,7 +120,7 @@
 	req_tech = list("magnets" = 5, "materials" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 20, MAT_SILVER = 10)
-	reliability_base = 72
+	reliability = 72
 	build_path = /obj/item/weapon/stock_parts/scanning_module/phasic
 	category = list("Stock Parts")
 
@@ -131,7 +131,7 @@
 	req_tech = list("materials" = 5, "programming" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 30)
-	reliability_base = 73
+	reliability = 73
 	build_path = /obj/item/weapon/stock_parts/manipulator/pico
 	category = list("Stock Parts")
 
@@ -142,7 +142,7 @@
 	req_tech = list("magnets" = 5, "materials" = 5)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 10, MAT_GLASS = 20, MAT_URANIUM = 10)
-	reliability_base = 70
+	reliability = 70
 	build_path = /obj/item/weapon/stock_parts/micro_laser/ultra
 	category = list("Stock Parts")
 
@@ -153,7 +153,7 @@
 	req_tech = list("materials" = 5)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 80)
-	reliability_base = 75
+	reliability = 75
 	build_path = /obj/item/weapon/stock_parts/matter_bin/super
 	category = list("Stock Parts")
 
@@ -163,7 +163,7 @@
 	id = "quadratic_capacitor"
 	req_tech = list("powerstorage" = 6, "materials" = 5)
 	build_type = PROTOLATHE
-	reliability_base = 71
+	reliability = 71
 	materials = list(MAT_METAL = 100, MAT_GLASS = 100, MAT_DIAMOND = 40)
 	build_path = /obj/item/weapon/stock_parts/capacitor/quadratic
 	category = list("Stock Parts")
@@ -175,7 +175,7 @@
 	req_tech = list("magnets" = 6, "materials" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 100, MAT_GLASS = 40, MAT_DIAMOND = 20)
-	reliability_base = 72
+	reliability = 72
 	build_path = /obj/item/weapon/stock_parts/scanning_module/triphasic
 	category = list("Stock Parts")
 
@@ -186,7 +186,7 @@
 	req_tech = list("materials" = 6, "programming" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 60, MAT_DIAMOND = 30)
-	reliability_base = 73
+	reliability = 73
 	build_path = /obj/item/weapon/stock_parts/manipulator/femto
 	category = list("Stock Parts")
 
@@ -197,7 +197,7 @@
 	req_tech = list("magnets" = 6, "materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 20, MAT_GLASS = 40, MAT_URANIUM = 20, MAT_DIAMOND = 20)
-	reliability_base = 70
+	reliability = 70
 	build_path = /obj/item/weapon/stock_parts/micro_laser/quadultra
 	category = list("Stock Parts")
 
@@ -208,7 +208,7 @@
 	req_tech = list("materials" = 6)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 160, MAT_DIAMOND = 200)
-	reliability_base = 75
+	reliability = 75
 	build_path = /obj/item/weapon/stock_parts/matter_bin/bluespace
 	category = list("Stock Parts")
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -9,7 +9,7 @@
 	req_tech = list("combat" = 4, "materials" = 5, "powerstorage" = 3)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 5000, MAT_GLASS = 1000, MAT_URANIUM = 2000)
-	reliability_base = 76
+	reliability = 76
 	build_path = /obj/item/weapon/gun/energy/gun/nuclear
 	locked = 1
 	category = list("Weapons")
@@ -35,6 +35,7 @@
 	build_path = /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow/large
 	locked = 1
 	category = list("Weapons")
+	reliability = 76
 
 /datum/design/flora_gun
 	name = "Floral Somatoray"
@@ -64,7 +65,7 @@
 	req_tech = list("combat" = 3, "materials" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 3000)
-	reliability_base = 79
+	reliability = 79
 	build_path = /obj/item/weapon/grenade/chem_grenade/large
 	category = list("Weapons")
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -434,7 +434,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 								var/obj/item/new_item = new P(src)
 								if( new_item.type == /obj/item/weapon/storage/backpack/holding )
 									new_item.investigate_log("built by [key]","singulo")
-								new_item.reliability = R
+								new_item.reliability = 100
 								new_item.materials[MAT_METAL] /= coeff
 								new_item.materials[MAT_GLASS] /= coeff
 								if(linked_lathe.hacked)
@@ -497,7 +497,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					spawn(16)
 						if(g2g)
 							var/obj/item/new_item = new P(src)
-							new_item.reliability = R
+							new_item.reliability = 100
 							new_item.loc = linked_imprinter.loc
 						linked_imprinter.busy = 0
 						screen = old_screen

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -101,8 +101,8 @@ research holder datum.
 /datum/research/proc/AddDesign2Known(var/datum/design/D)
 	for(var/datum/design/known in known_designs)
 		if(D.id == known.id)
-			if(D.reliability_mod > known.reliability_mod)
-				known.reliability_mod = D.reliability_mod
+			if(D.reliability > known.reliability)
+				known.reliability = D.reliability
 			return
 	known_designs += D
 	return
@@ -117,7 +117,7 @@ research holder datum.
 		if(DesignHasReqs(PD))
 			AddDesign2Known(PD)
 	for(var/datum/tech/T in known_tech)
-		T = between(1,T.level,20)
+		T = Clamp(T.level, 1, 20)
 	for(var/datum/design/D in known_designs)
 		D.CalcReliability(known_tech)
 	return
@@ -127,7 +127,8 @@ research holder datum.
 /datum/research/proc/UpdateTech(var/ID, var/level)
 	for(var/datum/tech/KT in known_tech)
 		if(KT.id == ID)
-			if(KT.level <= level) KT.level = max((KT.level + 1), (level - 1))
+			if(KT.level <= level)
+				KT.level = max((KT.level + 1), (level - 1))
 	return
 
 /datum/research/proc/UpdateDesigns(var/obj/item/I, var/list/temp_tech)
@@ -172,6 +173,7 @@ datum/tech	//Datum of individual technologies.
 	var/id = "id"						//An easily referenced ID. Must be alphanumeric, lower-case, and no symbols.
 	var/level = 1						//A simple number scale of the research level. Level 0 = Secret tech.
 	var/max_level = 1          // Maximum level this can be at (for job objectives)
+	var/rare = 1						//How much CentCom wants to get that tech. Used in supply shuttle tech cost calculation.
 	var/list/req_tech = list()			//List of ids associated values of techs required to research this tech. "id" = #
 
 
@@ -194,6 +196,7 @@ datum/tech/plasmatech
 	desc = "Research into the mysterious substance colloqually known as 'plasma'."
 	id = "plasmatech"
 	max_level = 4
+	rare = 3
 
 datum/tech/powerstorage
 	name = "Power Manipulation Technology"
@@ -206,6 +209,7 @@ datum/tech/bluespace
 	desc = "Research into the sub-reality known as 'blue-space'"
 	id = "bluespace"
 	max_level = 6
+	rare = 2
 
 datum/tech/biotech
 	name = "Biological Technology"
@@ -236,6 +240,7 @@ datum/tech/syndicate
 	desc = "The study of technologies that violate standard Nanotrasen regulations."
 	id = "syndicate"
 	max_level = 0 // Don't count towards maxed research, since it's illegal.
+	rare = 4
 
 /*
 datum/tech/arcane
@@ -263,6 +268,23 @@ datum/tech/robotics
 	id = "robotics"
 	req_tech = list("materials" = 3, "programming" = 3)
 */
+
+/datum/tech/proc/getCost(var/current_level = null)
+	// Calculates tech disk's supply points sell cost
+	if(!current_level)
+		current_level = initial(level)
+
+	if(current_level >= level)
+		return 0
+
+	var/cost = 0
+	var/i
+	for(i=current_level+1, i<=level, i++)
+		if(i == initial(level))
+			continue
+		cost += i*5*rare
+
+	return cost
 
 /obj/item/weapon/disk/tech_disk
 	name = "Technology Disk"

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -23,7 +23,7 @@
 	component_parts += new /obj/item/stack/cable_coil(null,1)
 	RefreshParts()
 	initialize(); //Agouri
-	
+
 /obj/machinery/r_n_d/server/upgraded/New()
 	..()
 	component_parts = list()
@@ -63,16 +63,20 @@
 		if(0 to T0C)
 			health = min(100, health + 1)
 		if(T0C to (T20C + 20))
-			health = between(0, health, 100)
+			health = Clamp(health, 0, 100)
 		if((T20C + 20) to (T0C + 70))
 			health = max(0, health - 1)
 	if(health <= 0)
-		griefProtection() //I dont like putting this in process() but it's the best I can do without re-writing a chunk of rd servers.
+		/*griefProtection() This seems to get called twice before running any code that deletes/damages the server or it's files anwyay.
+							refreshParts and the hasReq procs that get called by this are laggy and do not need to be called by every server on the map every tick */
+		var/updateRD = 0
 		files.known_designs = list()
 		for(var/datum/tech/T in files.known_tech)
 			if(prob(1))
+				updateRD++
 				T.level--
-		files.RefreshResearch()
+		if(updateRD)
+			files.RefreshResearch()
 	if(delay)
 		delay--
 	else
@@ -244,7 +248,7 @@
 			temp_server.id_with_download += num
 
 	else if(href_list["reset_tech"])
-		var/choice = alert("Technology Data Rest", "Are you sure you want to reset this technology to its default data? Data lost cannot be recovered.", "Continue", "Cancel")
+		var/choice = alert("Technology Data Reset", "Are you sure you want to reset this technology to its default data? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
 			for(var/datum/tech/T in temp_server.files.known_tech)
 				if(T.id == href_list["reset_tech"])
@@ -257,7 +261,6 @@
 		if(choice == "Continue")
 			for(var/datum/design/D in temp_server.files.known_designs)
 				if(D.id == href_list["reset_design"])
-					D.reliability_mod = 0
 					temp_server.files.known_designs -= D
 					break
 		temp_server.files.RefreshResearch()
@@ -279,7 +282,7 @@
 				if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
 					continue
 				dat += "[S.name] || "
-				dat += "<A href='?src=\ref[src];access=[S.server_id]'> Access Rights</A> | "
+				dat += "<A href='?src=\ref[src];access=[S.server_id]'>Access Rights</A> | "
 				dat += "<A href='?src=\ref[src];data=[S.server_id]'>Data Management</A>"
 				if(badmin) dat += " | <A href='?src=\ref[src];transfer=[S.server_id]'>Server-to-Server Transfer</A>"
 				dat += "<BR>"

--- a/code/modules/shuttles/shuttle_supply.dm
+++ b/code/modules/shuttles/shuttle_supply.dm
@@ -1,12 +1,12 @@
 /datum/shuttle/ferry/supply
 	var/away_location = 1	//the location to hide at while pretending to be in-transit
-	var/late_chance = 80
+	var/late_chance = 0
 	var/max_late_time = 300
 
 /datum/shuttle/ferry/supply/short_jump(var/area/origin,var/area/destination)
-	if(moving_status != SHUTTLE_IDLE) 
+	if(moving_status != SHUTTLE_IDLE)
 		return
-	
+
 	if(isnull(location))
 		return
 
@@ -17,18 +17,18 @@
 
 	if (!at_station())	//at centcom
 		supply_controller.buy()
-	
+
 	//it would be cool to play a sound here
 	moving_status = SHUTTLE_WARMUP
 	spawn(warmup_time*10)
-		if (moving_status == SHUTTLE_IDLE) 
+		if (moving_status == SHUTTLE_IDLE)
 			return	//someone cancelled the launch
-		
+
 		if (at_station() && forbidden_atoms_check())
 			//cancel the launch because of forbidden atoms. announce over supply channel?
 			moving_status = SHUTTLE_IDLE
 			return
-		
+
 		//We pretend it's a long_jump by making the shuttle stay at centcom for the "in-transit" period.
 		var/area/away_area = get_location_area(away_location)
 		if (origin == away_area)
@@ -45,11 +45,11 @@
 			//late
 			if (prob(late_chance))
 				sleep(rand(0,max_late_time))
-		
+
 			move(away_area, destination)
-		
+
 		moving_status = SHUTTLE_IDLE
-		
+
 		if (!at_station())	//at centcom
 			supply_controller.sell()
 
@@ -57,7 +57,7 @@
 /datum/shuttle/ferry/supply/proc/forbidden_atoms_check()
 	if (!at_station())
 		return 0	//if badmins want to send mobs or a nuke on the supply shuttle from centcom we don't care
-	
+
 	return supply_controller.forbidden_atoms_check(get_location_area())
 
 /datum/shuttle/ferry/supply/proc/at_station()


### PR DESCRIPTION
These changes come from TG--they were originally going to be simple, but I encountered a fairly major bug along the way. First, however, features.

Cargo
- Can sell syndicate documents for a whopping 250 supply points
- Can sell R&D tech levels for points (plasma, bluespace, and especially syndicate tech are worth more)
- Can sell 100% reliable component designs for points
- The Cargo shuttle will no longer randomly be late (this could make the shuttle take up to 25% longer to arrive!)

R&D
- When you put something in the destructive analyzer it will now show the item's tech level and the CURRENT research level you're currently at
- Changes the access requirements for the R&D console to access_tox
 - Should slow down roboticists a bit, prevent them from stealing materials and parts, while still giving them access to the R&D lab--this is also what TG had on their R&D Console.
- Reduces the cost  and tech levels of the positronic brain; it can also be produced in mechfabs. That said, is origin tech has been nerfed to compensate
- All items produced by R&D will be 100% reliable, 100% of the time.

Bugfix
- Fixed a bug where items were 100% reliable at all times (I know this seems strange given what's said above).
 - This is pretty major; it allowed R&D to advance faster through their research levels and it also meant that there were no upsides to making things more reliable (like advanced energy guns). 
 - This means that you're probably going to have to upgrade your R&D machines now if you want to finish out R&D without mining---it also means you'll be exposed to a new mechanic: making items more reliable via "research"...which is as stupidly simple as deconstructing and item over and over and over again.
- Some small changes here and there to other R&D equipment, like the server.