### PR TITLE
Hijack Objective Rework+Fix

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -327,7 +327,7 @@ datum/objective/protect//The opposite of killing a dude.
 
 
 datum/objective/hijack
-	explanation_text = "Hijack the emergency shuttle by escaping alone."
+	explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive."
 
 	check_completion()
 		if(!owner.current || owner.current.stat)
@@ -337,9 +337,9 @@ datum/objective/hijack
 		if(issilicon(owner.current))
 			return 0
 		var/area/shuttle = locate(/area/shuttle/escape/centcom)
-		var/list/protected_mobs = list(/mob/living/silicon/ai, /mob/living/silicon/pai)
 		for(var/mob/living/player in player_list)
-			if(player.type in protected_mobs)	continue
+			if(istype(player, /mob/living/silicon) || istype(player, /mob/living/simple_animal) || player.mind.special_role)
+				continue
 			if (player.mind && (player.mind != owner))
 				if(player.stat != DEAD)			//they're not dead!
 					if(get_turf(player) in shuttle)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -338,7 +338,7 @@ datum/objective/hijack
 			return 0
 		var/area/shuttle = locate(/area/shuttle/escape/centcom)
 		for(var/mob/living/player in player_list)
-			if(istype(player, /mob/living/silicon) || istype(player, /mob/living/simple_animal) || player.mind.special_role && !player.mind.special_role = "Response Team")
+			if(istype(player, /mob/living/silicon) || istype(player, /mob/living/simple_animal) || player.mind.special_role && !player.mind.special_role == "Response Team")
 				continue
 			if (player.mind && (player.mind != owner))
 				if(player.stat != DEAD)			//they're not dead!

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -338,7 +338,7 @@ datum/objective/hijack
 			return 0
 		var/area/shuttle = locate(/area/shuttle/escape/centcom)
 		for(var/mob/living/player in player_list)
-			if(istype(player, /mob/living/silicon) || istype(player, /mob/living/simple_animal) || player.mind.special_role)
+			if(istype(player, /mob/living/silicon) || istype(player, /mob/living/simple_animal) || player.mind.special_role && !player.mind.special_role = "Response Team")
 				continue
 			if (player.mind && (player.mind != owner))
 				if(player.stat != DEAD)			//they're not dead!


### PR DESCRIPTION
Hijack objective rework

Rework
- Hijack objective no longer counts ANY silicons 
 - They're technically dead/never alive to begin with, and definitely not "crew".
- Hijack objective no longer counts simple animals 
 - Not crew, and a mouse hiding under a table shouldn't make a hijacker fail.
- Hijack objective no longer counts other antags.
 - Simply put this means that antags can work *together* to hijack the shuttle without causing a failure for the hijacker---it also means that your own mindslaves can assist in your endeavors.

Fix
- Pretty sure it wasn't actually overlooking AI's and PAI's to begin with; that's fixed now