### PR TITLE
Rad Laser Fix

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -130,7 +130,7 @@ effective or pretty fucking useless.
 	popup.open()
 
 /obj/item/device/rad_laser/Topic(href, href_list)
-	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
+	if(..())
 		return 1
 
 	usr.set_machine(src)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -80,21 +80,20 @@ effective or pretty fucking useless.
 	desc = "A hand-held body scanner able to distinguish vital signs of the subject. A strange microlaser is hooked on to the scanning end."
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
-	discrete = 1 // Makes the item not give an attack log message for viewers.
 	throwforce = 3
 	w_class = 1.0
-	throw_speed = 5
-	throw_range = 10
+	throw_speed = 3
+	throw_range = 7
 	materials = list(MAT_METAL=400)
 	origin_tech = "magnets=3;biotech=5;syndicate=3"
 	var/intensity = 5 // how much damage the radiation does
 	var/wavelength = 10 // time it takes for the radiation to kick in, in seconds
 	var/used = 0 // is it cooling down?
 
-/obj/item/device/rad_laser/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/device/rad_laser/attack(mob/living/M, mob/living/user)
 	if(!used)
-		..()
-		user.visible_message("<span class='notice'> [user] has analyzed [M]'s vitals.","<span class='notice'> You have analyzed [M]'s vitals.")
+		add_logs(M, user, "irradiated", src)
+		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>")
 		var/cooldown = round(max(100,(((intensity*8)-(wavelength/2))+(intensity*2))*10))
 		used = 1
 		icon_state = "health1"
@@ -105,18 +104,18 @@ effective or pretty fucking useless.
 					M.apply_effect(round(intensity/1.5), PARALYZE)
 				M.apply_effect(intensity*10, IRRADIATE)
 	else
-		user << "<span class='danger'>The radioactive microlaser is still recharging.</span>"
+		user << "<span class='warning'>The radioactive microlaser is still recharging.</span>"
 
-/obj/item/device/rad_laser/proc/handle_cooldown(var/cooldown)
+/obj/item/device/rad_laser/proc/handle_cooldown(cooldown)
 	spawn(cooldown)
 		used = 0
 		icon_state = "health2"
 
-/obj/item/device/rad_laser/attack_self(mob/user as mob)
+/obj/item/device/rad_laser/attack_self(mob/user)
 	..()
 	interact(user)
 
-/obj/item/device/rad_laser/interact(mob/user as mob)
+/obj/item/device/rad_laser/interact(mob/user)
 	user.set_machine(src)
 
 	var/cooldown = round(max(10,((intensity*8)-(wavelength/2))+(intensity*2)))
@@ -131,7 +130,7 @@ effective or pretty fucking useless.
 	popup.open()
 
 /obj/item/device/rad_laser/Topic(href, href_list)
-	if(!in_range(src, usr) || issilicon(usr) || !usr.canmove || usr.restrained())
+	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
 		return 1
 
 	usr.set_machine(src)
@@ -146,7 +145,6 @@ effective or pretty fucking useless.
 		amount += wavelength
 		wavelength = max(1,(min(120,amount)))
 
-	//updateUsrDialog()
-	interact(usr)
+	attack_self(usr)
 	add_fingerprint(usr)
 	return

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -98,6 +98,7 @@
 		"/obj/item/clothing/mask/surgical",
 		"/obj/item/clothing/gloves/color/latex",
         "/obj/item/weapon/reagent_containers/hypospray/autoinjector",
+        "/obj/item/device/rad_laser",
 		"/obj/item/device/sensor_device"
 	)
 

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -450,7 +450,7 @@
 	desc = "A special helmet designed for work in a hazardous, low pressure environment. Built with lightweight materials for extra comfort."
 	item_state = "medical_hardsuit"
 	slowdown = 1
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/firstaid,/obj/item/device/healthanalyzer,/obj/item/stack/medical,/obj/item/device/rad_laser)
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 50)
 
 	//Security

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -8,7 +8,7 @@
 	icon_state = "paramedic-vest"
 	item_state = "paramedic-vest"
 	allowed = list(/obj/item/stack/medical, /obj/item/weapon/reagent_containers/dropper, /obj/item/weapon/reagent_containers/hypospray, /obj/item/weapon/reagent_containers/syringe, \
-	/obj/item/device/healthanalyzer, /obj/item/device/antibody_scanner, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/weapon/tank/emergency_oxygen)
+	/obj/item/device/healthanalyzer, /obj/item/device/antibody_scanner, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/weapon/tank/emergency_oxygen,/obj/item/device/rad_laser)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 10)
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -23,7 +23,7 @@
 	item_state = "brigphysician-vest"
 	allowed = list(/obj/item/stack/medical, /obj/item/weapon/reagent_containers/dropper, /obj/item/weapon/reagent_containers/hypospray, /obj/item/weapon/reagent_containers/syringe, \
 	/obj/item/device/healthanalyzer, /obj/item/device/antibody_scanner, /obj/item/device/flashlight, \
-	/obj/item/device/radio, /obj/item/weapon/tank/emergency_oxygen)
+	/obj/item/device/radio, /obj/item/weapon/tank/emergency_oxygen,/obj/item/device/rad_laser)
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
 
 //Botonist
@@ -278,7 +278,7 @@
 	item_state = "fr_jacket"
 	blood_overlay_type = "armor"
 	allowed = list(/obj/item/stack/medical, /obj/item/weapon/reagent_containers/dropper, /obj/item/weapon/reagent_containers/hypospray, /obj/item/weapon/reagent_containers/syringe, \
-	/obj/item/device/healthanalyzer, /obj/item/device/antibody_scanner, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/weapon/tank/emergency_oxygen)
+	/obj/item/device/healthanalyzer, /obj/item/device/antibody_scanner, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/weapon/tank/emergency_oxygen,/obj/item/device/rad_laser)
 
 	verb/toggle()
 		set name = "Toggle Jacket Buttons"

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -5,7 +5,7 @@
 	item_state = "labcoat"
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	allowed = list(/obj/item/device/analyzer,/obj/item/device/antibody_scanner,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/weapon/reagent_containers/glass/bottle,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/storage/pill_bottle,/obj/item/weapon/paper)
+	allowed = list(/obj/item/device/analyzer,/obj/item/device/antibody_scanner,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/weapon/reagent_containers/glass/bottle,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/storage/pill_bottle,/obj/item/weapon/paper,/obj/item/device/rad_laser)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0)
 	species_fit = list("Vox")
 	sprite_sheets = list(


### PR DESCRIPTION
Fixes up the Rad Laser

- Rad laser no longer makes the user do an attack animation when it's used on someone
- Rad laser can be stored wherever a health analyzer can be stored
 - RIP Metaing it being a rad laser based on how it behaves or where you can put it.



Related
- Fixes up proper restrictions for topic.
- Adds in logging for the rad laser.