### PR TITLE
Space Cleaner Lighting Fix

### DIFF
--- a/code/modules/reagents/oldchem/reagents/reagents_water.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_water.dm
@@ -110,7 +110,7 @@
 	color = "#61C2C2"
 
 /datum/reagent/space_cleaner/reaction_obj(var/obj/O, var/volume)
-	if(O)
+	if(O && !istype(O, /atom/movable/lighting_overlay))
 		O.color = initial(O.color)
 	if(istype(O,/obj/effect/decal/cleanable))
 		qdel(O)


### PR DESCRIPTION
Ensures that space cleaner can't clean lighting overlay's color, thus making them appear black.

Why overlays' colors were being reset is beyond me; they're not objects---they're atoms...

Fixes: https://github.com/ParadiseSS13/Paradise/issues/1995