### PR TITLE
Blob Rebalance

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -101,12 +101,12 @@
 	var/turf/location = get_turf(src)
 
 	// Create the reagents to put into the air
-	create_reagents(25)
+	create_reagents(8)
 
 	if(overmind && overmind.blob_reagent_datum)
-		reagents.add_reagent(overmind.blob_reagent_datum.id, 25)
+		reagents.add_reagent(overmind.blob_reagent_datum.id, 8)
 	else
-		reagents.add_reagent("spores", 25)
+		reagents.add_reagent("spores", 8)
 
 	// Attach the smoke spreader and setup/start it.
 	S.attach(location)

--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -276,7 +276,10 @@
 	last_attack = world.time
 	OB.expand(T, 0, blob_reagent_datum.color)
 	for(var/mob/living/L in T)
-		blob_reagent_datum.reaction_mob(L, TOUCH, 25)
+		if("blob" in L.faction) //no friendly fire
+			continue
+		var/mob_protection = L.get_permeability_protection()
+		blob_reagent_datum.reaction_mob(L, TOUCH, 25, 1, mob_protection)
 		blob_reagent_datum.send_message(L)
 	OB.color = blob_reagent_datum.color
 	return

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -356,3 +356,6 @@ In all, this is a lot like the monkey code. /N
 		return custom_pixel_x_offset
 	else
 		return initial(pixel_x)
+
+/mob/living/carbon/alien/humanoid/get_permeability_protection()
+	return 0.8

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1760,3 +1760,23 @@
 	if(!silent)
 		src << "<span class='warning'>You don't have the dexterity to use that!<span>"
 	return 0
+
+/mob/living/carbon/human/get_permeability_protection()
+	var/list/prot = list("hands"=0, "chest"=0, "groin"=0, "legs"=0, "feet"=0, "arms"=0, "head"=0)
+	for(var/obj/item/I in get_equipped_items())
+		if(I.body_parts_covered & HANDS)
+			prot["hands"] = max(1 - I.permeability_coefficient, prot["hands"])
+		if(I.body_parts_covered & UPPER_TORSO)
+			prot["chest"] = max(1 - I.permeability_coefficient, prot["chest"])
+		if(I.body_parts_covered & LOWER_TORSO)
+			prot["groin"] = max(1 - I.permeability_coefficient, prot["groin"])
+		if(I.body_parts_covered & LEGS)
+			prot["legs"] = max(1 - I.permeability_coefficient, prot["legs"])
+		if(I.body_parts_covered & FEET)
+			prot["feet"] = max(1 - I.permeability_coefficient, prot["feet"])
+		if(I.body_parts_covered & ARMS)
+			prot["arms"] = max(1 - I.permeability_coefficient, prot["arms"])
+		if(I.body_parts_covered & HEAD)
+			prot["head"] = max(1 - I.permeability_coefficient, prot["head"])
+	var/protection = (prot["head"] + prot["arms"] + prot["feet"] + prot["legs"] + prot["groin"] + prot["chest"] + prot["hands"])/7
+	return protection

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -937,3 +937,7 @@
 
 /mob/living/proc/spawn_dust()
 	new /obj/effect/decal/cleanable/ash(loc)
+
+//used in datum/reagents/reaction() proc
+/mob/living/proc/get_permeability_protection()
+	return 0

--- a/code/modules/reagents/newchem/Blob-Reagents.dm
+++ b/code/modules/reagents/newchem/Blob-Reagents.dm
@@ -1,188 +1,149 @@
 // These can only be applied by blobs. They are what blobs are made out of.
 // The 4 damage
 /datum/reagent/blob
+	description = ""
 	var/message = "The blob strikes you" //message sent to any mob hit by the blob
 	var/message_living = null //extension to first mob sent to only living mobs i.e. silicons have no skin to be burnt
 
-/datum/reagent/blob/boiling_oil
+/datum/reagent/blob/reaction_mob(mob/living/M, method=TOUCH, volume, show_message, touch_protection)
+	return round(volume * min(1.5 - touch_protection, 1), 0.1) //full touch protection means 50% volume, any prot below 0.5 means 100% volume.
+
+/datum/reagent/blob/ripping_tendrils //does brute and a little stamina damage
+	name = "Ripping Tendrils"
+	id = "ripping_tendrils"
+	color = "#7F0000"
+	message_living = ", and you feel your skin ripping and tearing off"
+
+/datum/reagent/blob/ripping_tendrils/reaction_mob(mob/living/M, method=TOUCH, volume)
+	if(method == TOUCH)
+		volume = ..()
+		M.apply_damage(0.6*volume, BRUTE)
+		M.adjustStaminaLoss(0.4*volume)
+		if(iscarbon(M))
+			M.emote("scream")
+
+/datum/reagent/blob/boiling_oil //sets you on fire, does burn damage
 	name = "Boiling Oil"
 	id = "boiling_oil"
-	description = ""
 	color = "#B68D00"
 	message = "The blob splashes you with burning oil"
+	message_living = ", and you feel your skin char and melt"
 
 /datum/reagent/blob/boiling_oil/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
 	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(15*ratio, BURN)
-		M.adjust_fire_stacks(2*ratio)
+		M.adjust_fire_stacks(round(volume/12))
+		volume = ..()
+		M.apply_damage(0.6*volume, BURN)
 		M.IgniteMob()
 		if(isliving(M))
 			M.emote("scream")
 
-/datum/reagent/blob/toxic_goop
-	name = "Toxic Goop"
-	id = "toxic_goop"
-	description = ""
-	color = "#008000"
+/datum/reagent/blob/envenomed_filaments //toxin, hallucination, and some bonus spore toxin
+	name = "Envenomed Filaments"
+	id = "envenomed_filaments"
+	color = "#9ACD32"
 	message_living = ", and you feel sick and nauseated"
 
-/datum/reagent/blob/toxic_goop/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
+/datum/reagent/blob/envenomed_filaments/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(20*ratio, TOX)
+		volume = ..()
+		M.apply_damage(0.6*volume, TOX)
+		M.hallucination += 0.6*volume
+		M.reagents.add_reagent("spores", 0.4*volume)
 
-/datum/reagent/blob/skin_ripper
-	name = "Skin Ripper"
-	id = "skin_ripper"
-	description = ""
-	color = "#FF4C4C"
-	message_living = ", and you feel your skin ripping and tearing off"
-
-/datum/reagent/blob/skin_ripper/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
-	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(20*ratio, BRUTE)
-		if(iscarbon(M))
-			M.emote("scream")
-
-// Combo Reagents
-
-/datum/reagent/blob/skin_melter
-	name = "Skin Melter"
-	id = "skin_melter"
-	description = ""
-	color = "#7F0000"
-	message_living = ", and you feel your skin char and melt"
-
-/datum/reagent/blob/skin_melter/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
-	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(10*ratio, BRUTE)
-		M.apply_damage(10*ratio, BURN)
-		M.adjust_fire_stacks(2*ratio)
-		M.IgniteMob()
-		if(iscarbon(M))
-			M.emote("scream")
-
-/datum/reagent/blob/lung_destroying_toxin
-	name = "Lung Destroying Toxin"
-	id = "lung_destroying_toxin"
-	description = ""
+/datum/reagent/blob/lexorin_jelly //does tons of oxygen damage and a little brute
+	name = "Lexorin Jelly"
+	id = "lexorin_jelly"
 	color = "#00FFC5"
 	message_living = ", and your lungs feel heavy and weak"
 
-/datum/reagent/blob/lung_destroying_toxin/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
+/datum/reagent/blob/lexorin_jelly/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(20* ratio, OXY)
-		M.losebreath += 15*ratio
-		M.apply_damage(20*ratio, TOX)
+		volume = ..()
+		M.apply_damage(0.4*volume, BRUTE)
+		M.apply_damage(1*volume, OXY)
+		M.losebreath += round(0.3*volume)
 
-// Special Reagents
 
-/datum/reagent/blob/radioactive_liquid
-	name = "Radioactive Liquid"
-	id = "radioactive_liquid"
-	description = ""
-	color = "#00EE00"
-	message_living = ", and your skin feels papery and everything hurts"
+/datum/reagent/blob/kinetic //does semi-random brute damage
+	name = "Kinetic Gelatin"
+	id = "kinetic"
+	color = "#FFA500"
+	message = "The blob pummels you"
 
-/datum/reagent/blob/radioactive_liquid/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
+/datum/reagent/blob/kinetic/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(10*ratio, BRUTE)
-		if(istype(M, /mob/living/carbon/human))
-			M.apply_effect(40*ratio,IRRADIATE,0)
-			if(prob(33*ratio))
-				randmuti(M)
-				if(prob(98))
-					randmutb(M)
-				domutcheck(M, null)
-				M.UpdateAppearance()
+		volume = ..()
+		var/damage = rand(5, 35)/25
+		M.apply_damage(damage*volume, BRUTE)
+
+/datum/reagent/blob/cryogenic_liquid //does low burn damage and stamina damage and cools targets down
+	name = "Cryogenic Liquid"
+	id = "cryogenic_liquid"
+	color = "#8BA6E9"
+	message = "The blob splashes you with an icy liquid"
+	message_living = ", and you feel cold and tired"
+
+/datum/reagent/blob/cryogenic_liquid/reaction_mob(mob/living/M, method=TOUCH, volume)
+	if(method == TOUCH)
+		volume = ..()
+		M.apply_damage(0.4*volume, BURN)
+		M.adjustStaminaLoss(0.4*volume)
+		M.reagents.add_reagent("frostoil", 0.4*volume)
 
 /datum/reagent/blob/dark_matter
 	name = "Dark Matter"
 	id = "dark_matter"
-	description = ""
 	color = "#61407E"
 	message = "You feel a thrum as the blob strikes you, and everything flies at you"
 
 /datum/reagent/blob/dark_matter/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
 	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(15*ratio, BRUTE)
-		reagent_vortex(M, 0)
+		reagent_vortex(M, 0, volume)
+		volume = ..()
+		M.apply_damage(0.6*volume, BRUTE)
 
 
 /datum/reagent/blob/b_sorium
 	name = "Sorium"
 	id = "b_sorium"
-	description = ""
 	color = "#808000"
 	message = "The blob slams into you, and sends you flying"
 
 /datum/reagent/blob/b_sorium/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
 	if(method == TOUCH)
-		var/ratio = volume/25
-		M.apply_damage(15*ratio, BRUTE)
-		reagent_vortex(M, 1)
+		reagent_vortex(M, 1, volume)
+		volume = ..()
+		M.apply_damage(0.6*volume, BRUTE)
 
-
-/datum/reagent/blob/explosive // I'm gonna burn in hell for this one
-	name = "Explosive Gelatin"
-	id = "explosive"
-	description = ""
-	color = "#FFA500"
-	message = "The blob strikes you, and its tendrils explode"
-
-/datum/reagent/blob/explosive/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
-	if(method == TOUCH)
-		var/ratio = volume/25
-		if(prob(75*ratio))
-			explosion(M.loc, 0, 0, 1, 0, 0)
-
-/datum/reagent/blob/omnizine
-	name = "Omnizine"
-	id = "b_omnizine"
-	description = ""
-	color = "#C8A5DC"
-	message = "The blob squirts something at you"
-	message_living = ", and you feel great"
-
-/datum/reagent/blob/omnizine/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
-	if(method == TOUCH)
-		var/ratio = volume/25
-		M.reagents.add_reagent("omnizine", 11*ratio)
-
-/datum/reagent/blob/spacedrugs
-	name = "Space drugs"
-	id = "b_space_drugs"
-	description = ""
-	color = "#60A584"
-	message = "The blob squirts something at you"
-	message_living = ", and you feel funny"
-
-/datum/reagent/blob/spacedrugs/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume)
-	if(method == TOUCH)
-		var/ratio = volume/25
-		M.hallucination += 20*ratio
-		M.reagents.add_reagent("space_drugs", 15*ratio)
-		M.apply_damage(10*ratio, TOX)
-
-
-/datum/reagent/blob/proc/reagent_vortex(var/mob/living/M as mob, var/setting_type)
+/datum/reagent/blob/proc/reagent_vortex(mob/living/M, setting_type, volume)
 	var/turf/pull = get_turf(M)
-	for(var/atom/movable/X in range(4,pull))
-		if(istype(X, /atom/movable))
-			if((X) && !X.anchored)
-				if(setting_type)
-					step_away(X,pull)
-					step_away(X,pull)
-					step_away(X,pull)
-					step_away(X,pull)
+	var/range_power = Clamp(round(volume/5, 1), 1, 5)
+	for(var/atom/movable/X in range(range_power,pull))
+		if(istype(X, /obj/effect))
+			continue
+		if(!X.anchored)
+			var/distance = get_dist(X, pull)
+			var/moving_power = max(range_power - distance, 1)
+			spawn(0)
+				if(moving_power > 2) //if the vortex is powerful and we're close, we get thrown
+					if(setting_type)
+						var/atom/throw_target = get_edge_target_turf(X, get_dir(X, get_step_away(X, pull)))
+						var/throw_range = 5 - distance
+						X.throw_at(throw_target, throw_range, 1)
+					else
+						X.throw_at(pull, distance, 1)
 				else
-					X.throw_at(pull)
+					if(setting_type)
+						for(var/i = 0, i < moving_power, i++)
+							sleep(2)
+							if(!step_away(X, pull))
+								break
+					else
+						for(var/i = 0, i < moving_power, i++)
+							sleep(2)
+							if(!step_towards(X, pull))
+								break
 
 /datum/reagent/blob/proc/send_message(var/mob/living/M as mob)
 	var/totalmessage = message

--- a/code/modules/reagents/oldchem/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_toxin.dm
@@ -405,7 +405,7 @@
 	color = "#9ACD32"
 
 /datum/reagent/spores/on_mob_life(var/mob/living/M as mob)
-	M.adjustToxLoss(0.5)
+	M.adjustToxLoss(1)
 	M.damageoverlaytemp = 60
 	M.eye_blurry = max(M.eye_blurry, 3)
 	..()
@@ -564,7 +564,7 @@
 	id = "frostoil"
 	description = "A special oil that noticably chills the body. Extraced from Icepeppers."
 	reagent_state = LIQUID
-	color = "#B31008" // rgb: 139, 166, 233
+	color = "#8BA6E9" // rgb: 139, 166, 233
 	process_flags = ORGANIC | SYNTHETIC
 
 /datum/reagent/frostoil/on_mob_life(var/mob/living/M as mob)


### PR DESCRIPTION
Rebalances blob. This all comes from TG.

This should go a long way to making blob less of a faceroll and far easier to deal with.

Floating Blob Mob

- Reduces total reagents from 25 to 8.
 - This seems huge, and it is; simply put, TG's smoke is vastttttly different from ours, thus having 25 reagents in smoke on TG will not yield the same results as on our server; having 8 total reagents in these mobs is roughly the same as having 20 in theirs. As an example of how dramatic this is, instead of a reagent dealing, say, 20 brute, the same one will now deal around ~4-5. When I initially ported new blob, I forgot to factor in our dramatically different smoke systems...which skewed volume quite a bit and made them wayyyyy too strong to fight against.

Regular Blob

- Changes a number of blob reagents
 - Some have been renamed, others rebalanced, and still others removed.
 - Omnizine, space drugs, and explosive gelatin have been removed
 - Some of the nastier reagents have had their numbers altered or reduced or they will deal stamina damage now instead of a pure damage type
 - Wearing biosuits/spacesuits/anything with a lower permeability coefficient will reduce the amount of damage a blob's reagent attacks will do to you, up to half.