### PR TITLE
Phazon Construction Nerf

### DIFF
--- a/code/game/mecha/mecha_construction_paths.dm
+++ b/code/game/mecha/mecha_construction_paths.dm
@@ -1167,95 +1167,99 @@
 /datum/construction/reversible/mecha/phazon
 	result = "/obj/mecha/combat/phazon"
 	steps = list(
-					//1
+ 					//1
+					list("key"=/obj/item/device/assembly/signaler/anomaly,
+						 "backkey"=null, //Cannot remove the anomaly core once it's in
+						 "desc"="Anomaly core socket is open and awaiting connection."),
+					//2
 					list("key"=/obj/item/weapon/weldingtool,
 							"backkey"=/obj/item/weapon/wrench,
 							"desc"="External armor is wrenched."),
-					 //2
+					 //3
 					 list("key"=/obj/item/weapon/wrench,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="External armor is installed."),
-					 //3
+					 //4
 					 list("key"=/obj/item/mecha_parts/part/phazon_armor,
 					 		"backkey"=/obj/item/weapon/weldingtool,
 					 		"desc"="Phase armor is welded."),
-					 //4
+					 //5
 					 list("key"=/obj/item/weapon/weldingtool,
 					 		"backkey"=/obj/item/weapon/wrench,
 					 		"desc"="Phase armor is wrenched."),
-					 //5
+					 //6
 					 list("key"=/obj/item/weapon/wrench,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Phase armor is installed."),
-					 //6
+					 //7
 					 list("key"=/obj/item/stack/sheet/plasteel,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="The bluespace crystal is engaged."),
-					 //7
+					 //8
 					 list("key"=/obj/item/weapon/screwdriver,
 					 		"backkey"=/obj/item/weapon/wirecutters,
 					 		"desc"="The bluespace crystal is connected."),
-					 //8
+					 //9
 					 list("key"=/obj/item/stack/cable_coil,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="The bluespace crystal is installed."),
-					 //9
+					 //10
 					 list("key"=/obj/item/bluespace_crystal,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Super capacitor is secured."),
-					 //10
+					 //11
 					 list("key"=/obj/item/weapon/screwdriver,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Super capacitor is installed."),
-					 //11
+					 //12
 					 list("key"=/obj/item/weapon/stock_parts/capacitor/super,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Phasic scanner module is secured."),
-					 //12
+					 //13
 					 list("key"=/obj/item/weapon/screwdriver,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Phasic scanner module is installed."),
-					 //13
+					 //14
 					 list("key"=/obj/item/weapon/stock_parts/scanning_module/phasic,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Scanning module is secured."),
-					 //14
+					 //15
 					 list("key"=/obj/item/weapon/screwdriver,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Scanning module is installed."),
-					 //15
+					 //16
 					 list("key"=/obj/item/weapon/circuitboard/mecha/phazon/targeting,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Peripherals control module is secured."),
-					 //16
+					 //17
 					 list("key"=/obj/item/weapon/screwdriver,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Peripherals control module is installed"),
-					 //17
+					 //18
 					 list("key"=/obj/item/weapon/circuitboard/mecha/phazon/peripherals,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="Central control module is secured."),
-					 //18
+					 //19
 					 list("key"=/obj/item/weapon/screwdriver,
 					 		"backkey"=/obj/item/weapon/crowbar,
 					 		"desc"="Central control module is installed."),
-					 //19
+					 //20
 					 list("key"=/obj/item/weapon/circuitboard/mecha/phazon/main,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="The wiring is adjusted."),
-					 //20
+					 //21
 					 list("key"=/obj/item/weapon/wirecutters,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="The wiring is added."),
-					 //21
+					 //22
 					 list("key"=/obj/item/stack/cable_coil,
 					 		"backkey"=/obj/item/weapon/screwdriver,
 					 		"desc"="The hydraulic systems are active."),
-					 //22
+					 //23
 					 list("key"=/obj/item/weapon/screwdriver,
 					 		"backkey"=/obj/item/weapon/wrench,
 					 		"desc"="The hydraulic systems are connected."),
-					 //23
+					 //24
 					 list("key"=/obj/item/weapon/wrench,
 					 		"desc"="The hydraulic systems are disconnected.")
 					)
@@ -1270,24 +1274,24 @@
 
 	//TODO: better messages.
 	switch(index)
-		if(23)
+		if(24)
 			user.visible_message("[user] connects the [holder] hydraulic systems", "You connect the [holder] hydraulic systems.")
 			holder.icon_state = "phazon1"
-		if(22)
+		if(23)
 			if(diff==FORWARD)
 				user.visible_message("[user] activates the [holder] hydraulic systems.", "You activate the [holder] hydraulic systems.")
 				holder.icon_state = "phazon2"
 			else
 				user.visible_message("[user] disconnects the [holder] hydraulic systems", "You disconnect the [holder] hydraulic systems.")
 				holder.icon_state = "phazon0"
-		if(21)
+		if(22)
 			if(diff==FORWARD)
 				user.visible_message("[user] adds the wiring to the [holder].", "You add the wiring to the [holder].")
 				holder.icon_state = "phazon3"
 			else
 				user.visible_message("[user] deactivates the [holder] hydraulic systems.", "You deactivate the [holder] hydraulic systems.")
 				holder.icon_state = "phazon1"
-		if(20)
+		if(21)
 			if(diff==FORWARD)
 				user.visible_message("[user] adjusts the wiring of the [holder].", "You adjust the wiring of the [holder].")
 				holder.icon_state = "phazon4"
@@ -1296,7 +1300,7 @@
 				var/obj/item/stack/cable_coil/coil = new /obj/item/stack/cable_coil(get_turf(holder))
 				coil.amount = 4
 				holder.icon_state = "phazon2"
-		if(19)
+		if(20)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the central control module into the [holder].", "You install the central computer mainboard into the [holder].")
 				qdel(used_atom)
@@ -1304,7 +1308,7 @@
 			else
 				user.visible_message("[user] disconnects the wiring of the [holder].", "You disconnect the wiring of the [holder].")
 				holder.icon_state = "phazon3"
-		if(18)
+		if(19)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the mainboard.", "You secure the mainboard.")
 				holder.icon_state = "phazon6"
@@ -1312,7 +1316,7 @@
 				user.visible_message("[user] removes the central control module from the [holder].", "You remove the central computer mainboard from the [holder].")
 				new /obj/item/weapon/circuitboard/mecha/phazon/main(get_turf(holder))
 				holder.icon_state = "phazon4"
-		if(17)
+		if(18)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the peripherals control module into the [holder].", "You install the peripherals control module into the [holder].")
 				qdel(used_atom)
@@ -1320,7 +1324,7 @@
 			else
 				user.visible_message("[user] unfastens the mainboard.", "You unfasten the mainboard.")
 				holder.icon_state = "phazon5"
-		if(16)
+		if(17)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the peripherals control module.", "You secure the peripherals control module.")
 				holder.icon_state = "phazon8"
@@ -1328,7 +1332,7 @@
 				user.visible_message("[user] removes the peripherals control module from the [holder].", "You remove the peripherals control module from the [holder].")
 				new /obj/item/weapon/circuitboard/mecha/phazon/peripherals(get_turf(holder))
 				holder.icon_state = "phazon6"
-		if(15)
+		if(16)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the weapon control module into the [holder].", "You install the weapon control module into the [holder].")
 				qdel(used_atom)
@@ -1336,7 +1340,7 @@
 			else
 				user.visible_message("[user] unfastens the peripherals control module.", "You unfasten the peripherals control module.")
 				holder.icon_state = "phazon7"
-		if(14)
+		if(15)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the weapon control module.", "You secure the weapon control module.")
 				holder.icon_state = "phazon10"
@@ -1344,7 +1348,7 @@
 				user.visible_message("[user] removes the weapon control module from the [holder].", "You remove the weapon control module from the [holder].")
 				new /obj/item/weapon/circuitboard/mecha/phazon/targeting(get_turf(holder))
 				holder.icon_state = "phazon8"
-		if(13)
+		if(14)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs phasic scanner module to the [holder].", "You install phasic scanner module to the [holder].")
 				qdel(used_atom)
@@ -1352,7 +1356,7 @@
 			else
 				user.visible_message("[user] unfastens the weapon control module.", "You unfasten the weapon control module.")
 				holder.icon_state = "phazon9"
-		if(12)
+		if(13)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the phasic scanner module.", "You secure the phasic scanner module.")
 				holder.icon_state = "phazon12"
@@ -1360,7 +1364,7 @@
 				user.visible_message("[user] removes the phasic scanner module from the [holder].", "You remove the phasic scanner module from the [holder].")
 				new /obj/item/weapon/stock_parts/scanning_module/phasic(get_turf(holder))
 				holder.icon_state = "phazon10"
-		if(11)
+		if(12)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs super capacitor to the [holder].", "You install super capacitor to the [holder].")
 				qdel(used_atom)
@@ -1368,7 +1372,7 @@
 			else
 				user.visible_message("[user] unfastens the phasic scanner module.", "You unfasten the phasic scanner module.")
 				holder.icon_state = "phazon11"
-		if(10)
+		if(11)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the super capacitor.", "You secure the super capacitor.")
 				holder.icon_state = "phazon14"
@@ -1376,7 +1380,7 @@
 				user.visible_message("[user] removes the super capacitor from the [holder].", "You remove the super capacitor from the [holder].")
 				new /obj/item/weapon/stock_parts/capacitor/super(get_turf(holder))
 				holder.icon_state = "phazon12"
-		if(9)
+		if(10)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the bluespace crystal.", "You install the bluespace crystal.")
 				qdel(used_atom)
@@ -1384,7 +1388,7 @@
 			else
 				user.visible_message("[user] unsecures the super capacitor from the [holder].", "You unsecure the super capacitor from the [holder].")
 				holder.icon_state = "phazon13"
-		if(8)
+		if(9)
 			if(diff==FORWARD)
 				user.visible_message("[user] connects the bluespace crystal.", "You connect the bluespace crystal.")
 				holder.icon_state = "phazon16"
@@ -1392,21 +1396,21 @@
 				user.visible_message("[user] removes the bluespace crystal from the [holder].", "You remove the bluespace crystal from the [holder].")
 				new /obj/item/bluespace_crystal(get_turf(holder))
 				holder.icon_state = "phazon14"
-		if(7)
+		if(8)
 			if(diff==FORWARD)
 				user.visible_message("[user] engages the bluespace crystal.", "You engage the bluespace crystal.")
 				holder.icon_state = "phazon17"
 			else
 				user.visible_message("[user] disconnects the bluespace crystal from the [holder].", "You disconnect the bluespace crystal from the [holder].")
 				holder.icon_state = "phazon15"
-		if(6)
+		if(7)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs the phase armor layer to the [holder].", "You install the phase armor layer to the [holder].")
 				holder.icon_state = "phazon18"
 			else
 				user.visible_message("[user] disengages the bluespace crystal.", "You disengage the bluespace crystal.")
 				holder.icon_state = "phazon16"
-		if(5)
+		if(6)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures the phase armor layer.", "You secure the phase armor layer.")
 				holder.icon_state = "phazon19"
@@ -1415,14 +1419,14 @@
 				var/obj/item/stack/sheet/plasteel/MS = new /obj/item/stack/sheet/plasteel(get_turf(holder))
 				MS.amount = 5
 				holder.icon_state = "phazon17"
-		if(4)
+		if(5)
 			if(diff==FORWARD)
 				user.visible_message("[user] welds the phase armor layer to the [holder].", "You weld the phase armor layer to the [holder].")
 				holder.icon_state = "phazon20"
 			else
 				user.visible_message("[user] unfastens the phase armor layer.", "You unfasten the phase armor layer.")
 				holder.icon_state = "phazon18"
-		if(3)
+		if(4)
 			if(diff==FORWARD)
 				user.visible_message("[user] installs Phazon Armor Plates to the [holder].", "You install Phazon Armor Plates to the [holder].")
 				qdel(used_atom)
@@ -1430,7 +1434,7 @@
 			else
 				user.visible_message("[user] cuts phase armor layer from the [holder].", "You cut the phase armor layer from the [holder].")
 				holder.icon_state = "phazon19"
-		if(2)
+		if(3)
 			if(diff==FORWARD)
 				user.visible_message("[user] secures Phazon Armor Plates.", "You secure Phazon Armor Plates.")
 				holder.icon_state = "phazon22"
@@ -1438,12 +1442,16 @@
 				user.visible_message("[user] pries Phazon Armor Plates from the [holder].", "You pry Phazon Armor Plates from the [holder].")
 				new /obj/item/mecha_parts/part/phazon_armor(get_turf(holder))
 				holder.icon_state = "phazon20"
-		if(1)
+		if(2)
 			if(diff==FORWARD)
 				user.visible_message("[user] welds Phazon Armor Plates to the [holder].", "You weld Phazon Armor Plates to the [holder].")
 			else
 				user.visible_message("[user] unfastens Phazon Armor Plates.", "You unfasten Phazon Armor Plates.")
 				holder.icon_state = "phazon21"
+		if(1)
+			if(diff==FORWARD)
+				user.visible_message("[user] carefully inserts the anomaly core into \the [holder] and secures it.", "You slowly place the anomaly core into its socket and close its chamber.")
+				qdel(used_atom)
 	return 1
 
 /datum/construction/reversible/mecha/phazon/spawn_result()


### PR DESCRIPTION
port of: https://github.com/tgstation/-tg-station/pull/8635

Simply put, I firmly believe this will address most of the early game mechs issues that some feel is problematic.

Phazon Construction nerf:
- Phazons now require an anomally core to finish construction of

This means that they're going to be quite rare, and only likely to show up during the latter half of the round (or later) and cannot be mass produced. Phazons weren't originally really meant to be constructed, in large part due to their ability to pretty much forego any and all access or location requirements on pretty much ANYTHING.

This also means that the only mechs you're likely to see stomping around will bet he ultra slow Durands, or the insanely insanely expensive Gygaxes (which require diamonds at every step of the way).