### PR TITLE
pAIs can no longer force people on help intent to pick them up.

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -553,7 +553,7 @@
 
 /mob/living/silicon/pai/MouseDrop(atom/over_object)
 	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H)) return ..()
+	if(!istype(H) || !Adjacent(H) || usr != src) return ..()
 	switch(alert(H,"[src] wants you to pick them up. Do it?",,"Yes","No"))
 		if("Yes")
 			if(Adjacent(H))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -554,11 +554,14 @@
 /mob/living/silicon/pai/MouseDrop(atom/over_object)
 	var/mob/living/carbon/H = over_object
 	if(!istype(H) || !Adjacent(H)) return ..()
-	if(H.a_intent == I_HELP)
-		get_scooped(H)
-		//return
-	else
-		return ..()
+	switch(alert(H,"[src] wants you to pick them up. Do it?",,"Yes","No"))
+		if("Yes")
+			if(Adjacent(H))
+				get_scooped(H)
+			else
+				src << "<span class='warning'>You need to stay in reaching distance to be picked up.</span>"
+		if("No")
+			src << "<span class='warning'>[H] decided not to pick you up.</span>"
 
 /mob/living/silicon/pai/on_forcemove(atom/newloc)
 	if(card)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -552,22 +552,22 @@
 	return H
 
 /mob/living/silicon/pai/MouseDrop(atom/over_object)
-  var/mob/living/carbon/H = over_object
-  if(!istype(H) || !Adjacent(H))  return ..()
-  if(usr == src)
-    switch(alert(H, "[src] wants you to pick them up. Do it?",,"Yes","No"))
-      if("Yes")
-        if(Adjacent(H))
-          get_scooped(H)
-        else
-          src << "<span class='warning'>You need to stay in reaching distance to be picked up.</span>"
-      if("No")
-        src << "<span class='warning'>[H] decided not to pick you up.</span>"
-  else
-    if(Adjacent(H))
-      get_scooped(H)
-    else
-      return ..()
+	var/mob/living/carbon/human/H = over_object //changed to human to avoid stupid issues like xenos holding pAIs.
+	if(!istype(H) || !Adjacent(H))  return ..()
+	if(usr == src)
+		switch(alert(H, "[src] wants you to pick them up. Do it?",,"Yes","No"))
+			if("Yes")
+				if(Adjacent(H))
+					get_scooped(H)
+				else
+					src << "<span class='warning'>You need to stay in reaching distance to be picked up.</span>"
+			if("No")
+				src << "<span class='warning'>[H] decided not to pick you up.</span>"
+	else
+		if(Adjacent(H))
+			get_scooped(H)
+		else
+			return ..()
 
 /mob/living/silicon/pai/on_forcemove(atom/newloc)
 	if(card)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -552,16 +552,22 @@
 	return H
 
 /mob/living/silicon/pai/MouseDrop(atom/over_object)
-	var/mob/living/carbon/H = over_object
-	if(!istype(H) || !Adjacent(H) || usr != src) return ..()
-	switch(alert(H,"[src] wants you to pick them up. Do it?",,"Yes","No"))
-		if("Yes")
-			if(Adjacent(H))
-				get_scooped(H)
-			else
-				src << "<span class='warning'>You need to stay in reaching distance to be picked up.</span>"
-		if("No")
-			src << "<span class='warning'>[H] decided not to pick you up.</span>"
+  var/mob/living/carbon/H = over_object
+  if(!istype(H) || !Adjacent(H))  return ..()
+  if(usr == src)
+    switch(alert(H, "[src] wants you to pick them up. Do it?",,"Yes","No"))
+      if("Yes")
+        if(Adjacent(H))
+          get_scooped(H)
+        else
+          src << "<span class='warning'>You need to stay in reaching distance to be picked up.</span>"
+      if("No")
+        src << "<span class='warning'>[H] decided not to pick you up.</span>"
+  else
+    if(Adjacent(H))
+      get_scooped(H)
+    else
+      return ..()
 
 /mob/living/silicon/pai/on_forcemove(atom/newloc)
 	if(card)


### PR DESCRIPTION
Apparently, pAIs could force people to pick them up by dragging themselves onto a person with help intent, which was a bit odd.
This adds a yes/no alert, similar to the give verb, which makes it a bit more clear what's happening, and requires the person to agree.

Stupid branch name, I didn't checkout a new branch. If it's a huge issue I can always remake the PR.