### PR TITLE
Fixes

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -1579,7 +1579,7 @@
 "aEs" = (/obj/item/stack/tile/wood,/turf/simulated/floor/plating,/area/maintenance/abandonedbar)
 "aEt" = (/obj/structure/stool/bed/chair/wood/wings{tag = "icon-wooden_chair_wings (EAST)"; icon_state = "wooden_chair_wings"; dir = 4},/turf/simulated/floor/wood,/area/maintenance/abandonedbar)
 "aEu" = (/obj/structure/table/woodentable,/obj/item/trash/candle,/turf/simulated/floor/plating,/area/maintenance/abandonedbar)
-"aEv" = (/obj/effect/spawner/window,/turf/simulated/floor/plating,/area/hallway/secondary/construction{name = "\improper Garden"})
+"aEv" = (/obj/effect/spawner/window/reinforced,/turf/simulated/floor/plating,/area/hallway/secondary/construction{name = "\improper Garden"})
 "aEw" = (/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/hallway/secondary/entry)
 "aEx" = (/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{frequency = 1380; id_tag = "escape_pod_1_berth"; pixel_x = -25; pixel_y = 30; tag_door = "escape_pod_1_berth_hatch"},/turf/simulated/floor{dir = 1; icon_state = "warning"},/area/hallway/secondary/entry)
 "aEy" = (/obj/structure/disposalpipe/segment{dir = 4},/obj/item/device/radio/intercom{broadcasting = 0; listening = 1; name = "station intercom (General)"; pixel_y = 25},/obj/structure/closet/lasertag/blue,/turf/simulated/floor,/area/crew_quarters/fitness)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -978,9 +978,9 @@
 		var/max_temperature = min(selected.max1 - T0C, MAX_TEMPERATURE)
 		var/min_temperature = max(selected.min1 - T0C, MIN_TEMPERATURE)
 		var/input_temperature = input("What temperature would you like the system to maintain? (Capped between [min_temperature]C and [max_temperature]C)", "Thermostat Controls") as num|null
-		if(input_temperature==null || ..(href, href_list, nowindow, state))
+		if(isnull(input_temperature) || ..(href, href_list, nowindow, state))
 			return
-		if(!input_temperature || input_temperature > max_temperature || input_temperature < min_temperature)
+		if(input_temperature > max_temperature || input_temperature < min_temperature)
 			usr << "Temperature must be between [min_temperature]C and [max_temperature]C"
 		else
 			target_temperature = input_temperature + T0C

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -39,7 +39,8 @@
 
 		for(var/i = 0, i < 10, i++)
 			for(var/mob/living/carbon/human/H in living_mob_list)
-				if(H.species.flags & NO_DNA_RAD) // Leave synthetics completely unaffected
+				var/armor = H.getarmor(attack_flag = "rad")
+				if((H.species.flags & NO_DNA_RAD) || armor >= 100) // Leave DNA-less species/fully rad armored players completely unaffected
 					continue
 				var/turf/T = get_turf(H)
 				if(!T)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -142,18 +142,10 @@ Works together with spawning an observer, noted above.
 	var/client/C = U.client
 	for(var/mob/living/carbon/human/target in target_list)
 		C.images += target.hud_list[SPECIALROLE_HUD]
-		C.images += target.hud_list[NATIONS_HUD]
+		C.images += target.hud_list[NATIONS_HUD] // ??? THE SNOWFLAKE IS KILLING ME
+	for(var/mob/living/silicon/target in target_list)
+		C.images += target.hud_list[SPECIALROLE_HUD]
 
-
-/*
-		else//If the silicon mob has no law datum, no inherent laws, or a law zero, add them to the hud.
-			var/mob/living/silicon/silicon_target = target
-			if(!silicon_target.laws||(silicon_target.laws&&(silicon_target.laws.zeroth||!silicon_target.laws.inherent.len))||silicon_target.mind.special_role=="traitor")
-				if(isrobot(silicon_target))//Different icons for robutts and AI.
-					U.client.images += image(tempHud,silicon_target,"hudmalborg")
-				else
-					U.client.images += image(tempHud,silicon_target,"hudmalai")
-*/
 	return 1
 
 /mob/proc/ghostize(var/flags = GHOST_CAN_REENTER)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -59,7 +59,7 @@
 			halloss += effect // Useful for objects that cause "subdual" damage. PAIN!
 		if(IRRADIATE)
 			var/rad_damage = effect
-			if(negate_armor) // Setting negate_armor overrides radiation armor checks, which are automatic otherwise
+			if(!negate_armor) // Setting negate_armor overrides radiation armor checks, which are automatic otherwise
 				rad_damage = max(effect * ((100-run_armor_check(null, "rad", "Your clothes feel warm.", "Your clothes feel warm."))/100),0)
 			radiation += rad_damage
 		if(SLUR)


### PR DESCRIPTION
Changes:
1) Atmospherics alarm temperatures can now be set to 0. Fixes part of https://github.com/ParadiseSS13/Paradise/issues/1402.
2) Fixes observers being unable to see silicon antag status: https://github.com/Baystation12/Baystation12/pull/11077.
3) Fixes me being a derp (rad suits will now protect from radiation damage in radiation events). Fixes https://github.com/ParadiseSS13/Paradise/issues/2016. Players with full radiation armor will also no longer get mutations during the radiation event.
4) Replaces a regular window with a reinforced window at arrivals botany for consistency.