### PR TITLE
Rnd materials

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -58,10 +58,6 @@
 #define MAX_STACK_AMOUNT_GLASS	50
 #define MAX_STACK_AMOUNT_RODS	60
 
-#define CC_PER_SHEET_METAL 3750
-#define CC_PER_SHEET_GLASS 3750
-#define CC_PER_SHEET_MISC 2000
-
 //some colors
 #define COLOR_RED 		"#FF0000"
 #define COLOR_GREEN 	"#00FF00"

--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -48,10 +48,10 @@
 	if(amt > 0 && has_space(amt))
 		var/total_amount_saved = total_amount
 		if(material_type)
-			for(var/datum/material/M in materials)
-				if(M.material_type == material_type)
-					M.amount += amt
-					total_amount += amt
+			var/datum/material/M = materials[material_type]
+			if(M)
+				M.amount += amt
+				total_amount += amt
 		else
 			for(var/datum/material/M in materials)
 				M.amount += amt
@@ -93,21 +93,21 @@
 
 //For consuming material
 //mats is a list of types of material to use and the corresponding amounts, example: list(MAT_METAL=100, MAT_GLASS=200)
-/datum/material_container/proc/use_amount(list/mats)
+/datum/material_container/proc/use_amount(list/mats, multiplier=1)
 	if(!mats || !mats.len)
 		return 0
 
 	var/datum/material/M
 	for(var/MAT in materials)
 		M = materials[MAT]
-		if(M.amount < mats[MAT])
+		if(M.amount < (mats[MAT] * multiplier))
 			return 0
 
 	var/total_amount_save = total_amount
 	for(var/MAT in materials)
 		M = materials[MAT]
-		M.amount -= mats[MAT]
-		total_amount -= mats[MAT]
+		M.amount -= mats[MAT] * multiplier
+		total_amount -= mats[MAT] * multiplier
 
 	return total_amount_save - total_amount
 
@@ -124,7 +124,9 @@
 
 //For spawning mineral sheets; internal use only
 /datum/material_container/proc/retrieve(sheet_amt, datum/material/M)
-	if(sheet_amt > 0 && M.amount >= (sheet_amt * MINERAL_MATERIAL_AMOUNT))
+	if(sheet_amt > 0)
+		if(M.amount < (sheet_amt * MINERAL_MATERIAL_AMOUNT))
+			sheet_amt = round(M.amount / MINERAL_MATERIAL_AMOUNT)
 		var/count = 0
 
 		while(sheet_amt > MAX_STACK_SIZE)
@@ -159,6 +161,17 @@
 /datum/material_container/proc/has_space(amt = 0)
 	return (total_amount + amt) <= max_amount
 
+/datum/material_container/proc/has_materials(list/mats, multiplier=1)
+	if(!mats || !mats.len)
+		return 0
+
+	var/datum/material/M
+	for(var/MAT in mats)
+		M = materials[MAT]
+		if(M.amount < (mats[MAT] * multiplier))
+			return 0
+	return 1
+
 /datum/material_container/proc/amount2sheet(amt)
 	if(amt >= MINERAL_MATERIAL_AMOUNT)
 		return round(amt / MINERAL_MATERIAL_AMOUNT)
@@ -172,9 +185,6 @@
 /datum/material_container/proc/amount(material_type)
 	var/datum/material/M = materials[material_type]
 	return M ? M.amount : 0
-
-/datum/material_container/proc/can_insert(obj/item/I)
-	return get_item_material_amount(I)
 
 //returns the amount of material relevant to this container;
 //if this container does not support glass, any glass in 'I' will not be taken into account

--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -60,9 +60,14 @@
 	return 0
 
 /datum/material_container/proc/insert_stack(obj/item/stack/S, amt = 0)
-	if(!amt)
+	if(amt <= 0)
+		return 0
+	if(amt > S.amount)
 		amt = S.amount
 	var/material_amt = get_item_material_amount(S)
+	if(!material_amt)
+		return 0
+
 	amt = min(amt, round(((max_amount - total_amount) / material_amt)))
 	if(!amt)
 		return 0

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -121,7 +121,7 @@
 	if (stat)
 		return 1
 
-	var/material_amount = materials.can_insert(O)
+	var/material_amount = materials.get_item_material_amount(O)
 	if(!material_amount)
 		user << "<span class='warning'>This object does not contain sufficient amounts of metal or glass to be accepted by the autolathe.</span>"
 		return 1

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -126,7 +126,7 @@ var/const/SAFETY_COOLDOWN = 100
 
 	if(sound)
 		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-	var/material_amount = materials.can_insert(I)
+	var/material_amount = materials.get_item_material_amount(I)
 	if(!material_amount)
 		qdel(I)
 		return

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -6,7 +6,7 @@
 	icon_state = "tile"
 	w_class = 3.0
 	force = 6.0
-	materials = list(MAT_METAL=937.5)
+	materials = list(MAT_METAL=500)
 	throwforce = 10.0
 	throw_speed = 3
 	throw_range = 7

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -12,7 +12,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/items.dmi'
 	icon_state = "table_parts"
-	materials = list(MAT_METAL=3750)
+	materials = list(MAT_METAL=4000)
 	flags = CONDUCT
 	attack_verb = list("slammed", "bashed", "battered", "bludgeoned", "thrashed", "whacked")
 
@@ -21,7 +21,7 @@
 	desc = "Hard table parts. Well...harder..."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "reinf_tableparts"
-	materials = list(MAT_METAL=7500)
+	materials = list(MAT_METAL=8000)
 	flags = CONDUCT
 
 /obj/item/weapon/table_parts/wood
@@ -42,7 +42,7 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "rack_parts"
 	flags = CONDUCT
-	materials = list(MAT_METAL=3750)
+	materials = list(MAT_METAL=2000)
 
 /*
  * Table Parts

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -152,7 +152,7 @@ obj/item/weapon/wirerod
 	force = 9
 	throwforce = 10
 	w_class = 3
-	materials = list(MAT_METAL=1875)
+	materials = list(MAT_METAL=1000)
 	attack_verb = list("hit", "bludgeoned", "whacked", "bonked")
 
 obj/item/weapon/wirerod/attackby(var/obj/item/I, mob/user as mob, params)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -58,7 +58,7 @@
 	throwforce = 10.0
 	item_state = "pickaxe"
 	w_class = 4.0
-	materials = list(MAT_METAL=3750) //one sheet, but where can you make them?
+	materials = list(MAT_METAL=2000) //one sheet, but where can you make them?
 	var/digspeed = 40 //moving the delay to an item var so R&D can make improved picks. --NEO
 	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("hit", "pierced", "sliced", "attacked")

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -26,7 +26,7 @@ Design Guidlines
 reliability_mod (starts at 0, gets improved through experimentation). Example: PACMAN generator. 79 base reliablity + 6 tech
 (3 plasmatech, 3 powerstorage) + 0 (since it's completely new) = 85% reliability. Reliability is the chance it works CORRECTLY.
 - When adding new designs, check rdreadme.dm to see what kind of things have already been made and where new stuff is needed.
-- A single sheet of anything is 3750 units of material. Materials besides metal/glass require help from other jobs (mining for
+- A single sheet of anything is 2000 units of material. Materials besides metal/glass require help from other jobs (mining for
 other types of metals and chemistry for reagents).
 - Add the AUTOLATHE tag to
 

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -45,7 +45,7 @@ other types of metals and chemistry for reagents).
 	var/build_path = ""					//The file path of the object that gets created
 	var/locked = 0						//If true it will spawn inside a lockbox with currently sec access
 	var/category = null //Primarily used for Mech Fabricators, but can be used for anything
-
+	var/reagents
 
 //A proc to calculate the reliability of a design based on tech levels and innate modifiers.
 //Input: A list of /datum/tech; Output: The new reliabilty.

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -947,7 +947,7 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/ddrill
 	req_tech = list("engineering" = 5, "materials" = 5)
-	materials = list(MAT_METAL=10000, MAT_DIAMOND=3750)
+	materials = list(MAT_METAL=10000, MAT_DIAMOND=2000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -7,7 +7,7 @@
 	id = "drill_diamond"
 	req_tech = list("materials" = 6, "powerstorage" = 4, "engineering" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_DIAMOND = 3750) //Yes, a whole diamond is needed.
+	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_DIAMOND = 2000) //Yes, a whole diamond is needed.
 	reliability = 79
 	build_path = /obj/item/weapon/pickaxe/drill/diamonddrill
 	category = list("Mining")

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -123,10 +123,12 @@ Note: Must be placed west/left of and R&D console to function.
 		return
 	if (stat)
 		return 1
-	if(istype(O,/obj/item/stack/sheet))
-		if(!materials.has_space( materials.get_item_material_amount(O) ))
-			user << "<span class='warning'>The [src.name]'s material bin is full. Please remove material before adding more.</span>"
-			return 1
+	if(!istype(O,/obj/item/stack/sheet))
+		return 1
+
+	if(!materials.has_space( materials.get_item_material_amount(O) ))
+		user << "<span class='warning'>The [src.name]'s material bin is full! Please remove material before adding more.</span>"
+		return 1
 
 	var/obj/item/stack/sheet/stack = O
 	var/amount = round(input("How many sheets do you want to add?") as num)//No decimals
@@ -134,14 +136,14 @@ Note: Must be placed west/left of and R&D console to function.
 		return
 	var/amount_inserted = materials.insert_stack(O,amount)
 	if(!amount_inserted)
-		user << "<span class='warning'>You could not insert [O], it has no usable materials.</span>"
 		return 1
 	else
 		busy = 1
 		use_power(max(1000, (MINERAL_MATERIAL_AMOUNT*amount_inserted/10)))
 		user << "<span class='notice'>You add [amount_inserted] sheets to the [src.name].</span>"
-		overlays += "protolathe_[stack.name]"
+		var/stackname = stack.name
+		src.overlays += "protolathe_[stackname]"
 		sleep(10)
-		overlays -= "protolathe_[stack.name]"
+		src.overlays -= "protolathe_[stackname]"
 		busy = 0
 	updateUsrDialog()

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -13,15 +13,7 @@ Note: Must be placed west/left of and R&D console to function.
 	icon_state = "protolathe"
 	flags = OPENCONTAINER
 
-	var/max_material_storage = 100000 //All this could probably be done better with a list but meh.
-	var/m_amount = 0.0
-	var/g_amount = 0.0
-	var/gold_amount = 0.0
-	var/silver_amount = 0.0
-	var/plasma_amount = 0.0
-	var/uranium_amount = 0.0
-	var/diamond_amount = 0.0
-	var/clown_amount = 0.0
+	var/datum/material_container/materials
 	var/efficiency_coeff
 
 	var/list/categories = list(
@@ -49,6 +41,7 @@ Note: Must be placed west/left of and R&D console to function.
 	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker/large(null)
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker/large(null)
+	materials = new(src, list(MAT_METAL=1, MAT_GLASS=1, MAT_SILVER=1, MAT_GOLD=1, MAT_DIAMOND=1, MAT_PLASMA=1, MAT_URANIUM=1, MAT_BANANIUM=1))
 	RefreshParts()
 
 	reagents.my_atom = src
@@ -67,8 +60,9 @@ Note: Must be placed west/left of and R&D console to function.
 
 	reagents.my_atom = src
 
-/obj/machinery/r_n_d/protolathe/proc/TotalMaterials() //returns the total of all the stored materials. Makes code neater.
-	return m_amount + g_amount + gold_amount + silver_amount + plasma_amount + uranium_amount + diamond_amount + clown_amount
+/obj/machinery/r_n_d/protolathe/Destroy()
+	qdel(materials)
+	return ..()
 
 /obj/machinery/r_n_d/protolathe/RefreshParts()
 	var/T = 0
@@ -76,33 +70,16 @@ Note: Must be placed west/left of and R&D console to function.
 		G.reagents.trans_to(src, G.reagents.total_volume)
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating
-	max_material_storage = T * 75000
+	materials.max_amount = T * 75000
 	T = 0
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		T += (M.rating/3)
 	efficiency_coeff = max(T, 1)
 
 /obj/machinery/r_n_d/protolathe/proc/check_mat(datum/design/being_built, var/M)	// now returns how many times the item can be built with the material
-	var/A = 0
-	switch(M)
-		if(MAT_METAL)
-			A = m_amount
-		if(MAT_GLASS)
-			A = g_amount
-		if(MAT_GOLD)
-			A = gold_amount
-		if(MAT_SILVER)
-			A = silver_amount
-		if(MAT_PLASMA)
-			A = plasma_amount
-		if(MAT_URANIUM)
-			A = uranium_amount
-		if(MAT_DIAMOND)
-			A = diamond_amount
-		if(MAT_BANANIUM)
-			A = clown_amount
-		else
-			A = reagents.get_reagent_amount(M)
+	var/A = materials.amount(M)
+	if(!A)
+		A = reagents.get_reagent_amount(M)
 	A = A / max(1, (being_built.materials[M]/efficiency_coeff))
 	return A
 
@@ -128,30 +105,7 @@ Note: Must be placed west/left of and R&D console to function.
 				I.loc = src.loc
 			for(var/obj/item/weapon/reagent_containers/glass/G in component_parts)
 				reagents.trans_to(G, G.reagents.maximum_volume)
-			if(m_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/metal/G = new /obj/item/stack/sheet/metal(src.loc)
-				G.amount = round(m_amount / G.perunit)
-			if(g_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src.loc)
-				G.amount = round(g_amount / G.perunit)
-			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/plasma/G = new /obj/item/stack/sheet/mineral/plasma(src.loc)
-				G.amount = round(plasma_amount / G.perunit)
-			if(silver_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/silver/G = new /obj/item/stack/sheet/mineral/silver(src.loc)
-				G.amount = round(silver_amount / G.perunit)
-			if(gold_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/gold/G = new /obj/item/stack/sheet/mineral/gold(src.loc)
-				G.amount = round(gold_amount / G.perunit)
-			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/uranium/G = new /obj/item/stack/sheet/mineral/uranium(src.loc)
-				G.amount = round(uranium_amount / G.perunit)
-			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/diamond/G = new /obj/item/stack/sheet/mineral/diamond(src.loc)
-				G.amount = round(diamond_amount / G.perunit)
-			if(clown_amount >= MINERAL_MATERIAL_AMOUNT)
-				var/obj/item/stack/sheet/mineral/bananium/G = new /obj/item/stack/sheet/mineral/bananium(src.loc)
-				G.amount = round(clown_amount / G.perunit)
+			materials.retrieve_all()
 			default_deconstruction_crowbar(O)
 			return 1
 		else
@@ -167,55 +121,27 @@ Note: Must be placed west/left of and R&D console to function.
 		return 1
 	if (O.is_open_container())
 		return
-	if (!istype(O, /obj/item/stack/sheet) || istype(O, /obj/item/stack/sheet/wood))
-		user << "<span class='warning'>You cannot insert this item into the [src.name]!</span>"
-		return 1
 	if (stat)
 		return 1
 	if(istype(O,/obj/item/stack/sheet))
-		var/obj/item/stack/sheet/S = O
-		if (TotalMaterials() + S.perunit > max_material_storage)
+		if(!materials.has_space( materials.get_item_material_amount(O) ))
 			user << "<span class='warning'>The [src.name]'s material bin is full. Please remove material before adding more.</span>"
 			return 1
 
 	var/obj/item/stack/sheet/stack = O
 	var/amount = round(input("How many sheets do you want to add?") as num)//No decimals
-	if(!stack || stack.amount <= 0 || amount <= 0)
+	if(!in_range(src, stack) || !user.Adjacent(src))
 		return
-	if(amount > stack.amount)
-		amount = stack.amount
-	if(max_material_storage - TotalMaterials() < (amount*stack.perunit))//Can't overfill
-		amount = min(stack.amount, round((max_material_storage-TotalMaterials())/stack.perunit))
-
-	icon_state = "protolathe"
-	busy = 1
-	use_power(max(1000, (MINERAL_MATERIAL_AMOUNT*amount/10)))
-	user << "<span class='notice'>You add [amount] sheets to the [src.name].</span>"
-	icon_state = "protolathe"
-	if(istype(stack, /obj/item/stack/sheet/metal))
-		m_amount += amount * MINERAL_MATERIAL_AMOUNT
-	else if(istype(stack, /obj/item/stack/sheet/glass))
-		g_amount += amount * MINERAL_MATERIAL_AMOUNT
-	else if(istype(stack, /obj/item/stack/sheet/mineral/gold))
-		gold_amount += amount * MINERAL_MATERIAL_AMOUNT
-	else if(istype(stack, /obj/item/stack/sheet/mineral/silver))
-		silver_amount += amount * MINERAL_MATERIAL_AMOUNT
-	else if(istype(stack, /obj/item/stack/sheet/mineral/plasma))
-		plasma_amount += amount * MINERAL_MATERIAL_AMOUNT
-	else if(istype(stack, /obj/item/stack/sheet/mineral/uranium))
-		uranium_amount += amount * MINERAL_MATERIAL_AMOUNT
-	else if(istype(stack, /obj/item/stack/sheet/mineral/diamond))
-		diamond_amount += amount * MINERAL_MATERIAL_AMOUNT
-	else if(istype(stack, /obj/item/stack/sheet/mineral/bananium))
-		clown_amount += amount * MINERAL_MATERIAL_AMOUNT
-	stack.use(amount)
-	busy = 0
-	src.updateUsrDialog()
-
-	if(stack)
-		var/stackname = stack.name
-		src.overlays += "protolathe_[stackname]"
+	var/amount_inserted = materials.insert_stack(O,amount)
+	if(!amount_inserted)
+		user << "<span class='warning'>You could not insert [O], it has no usable materials.</span>"
+		return 1
+	else
+		busy = 1
+		use_power(max(1000, (MINERAL_MATERIAL_AMOUNT*amount_inserted/10)))
+		user << "<span class='notice'>You add [amount_inserted] sheets to the [src.name].</span>"
+		overlays += "protolathe_[stack.name]"
 		sleep(10)
-		src.overlays -= "protolathe_[stackname]"
-
-	return
+		overlays -= "protolathe_[stack.name]"
+		busy = 0
+	updateUsrDialog()

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -297,8 +297,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 							else                                                                   //Same design always gain quality
 								screen = 2.3                                                       //Crit fail gives the same design a lot of reliability, like really a lot
 							if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
-								linked_lathe.m_amount += min((linked_lathe.max_material_storage - linked_lathe.TotalMaterials()), (linked_destroy.loaded_item.materials[MAT_METAL]*(linked_destroy.decon_mod/10)))
-								linked_lathe.g_amount += min((linked_lathe.max_material_storage - linked_lathe.TotalMaterials()), (linked_destroy.loaded_item.materials[MAT_GLASS]*(linked_destroy.decon_mod/10)))
+								for(var/material in linked_destroy.loaded_item.materials)
+									linked_lathe.materials.insert_amount(min((linked_lathe.materials.max_amount - linked_lathe.materials.total_amount), (linked_destroy.loaded_item.materials[material]*(linked_destroy.decon_mod/10))), material)
 							linked_destroy.loaded_item = null
 						else
 							screen = 1.0
@@ -397,33 +397,17 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					flick("protolathe_n",linked_lathe)
 					use_power(power)
 
-					for(var/M in being_built.materials)
-						if(linked_lathe.check_mat(being_built, M) < amount)
-							src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough materials to complete prototype.\"</span>")
-							enough_materials = 0
-							g2g = 0
-							break
+					var/list/efficient_mats = list()
+					for(var/MAT in being_built.materials)
+						efficient_mats[MAT] = being_built.materials[MAT] / coeff
+
+					if(!linked_lathe.materials.has_materials(efficient_mats, amount))
+						src.visible_message("<span class='notice'>The [src.name] beeps, \"Not enough materials to complete prototype.\"</span>")
+						enough_materials = 0
+						g2g = 0
+
 					if(enough_materials)
-						for(var/M in being_built.materials)
-							switch(M)
-								if(MAT_METAL)
-									linked_lathe.m_amount = max(0, (linked_lathe.m_amount-(being_built.materials[M]/coeff * amount)))
-								if(MAT_GLASS)
-									linked_lathe.g_amount = max(0, (linked_lathe.g_amount-(being_built.materials[M]/coeff * amount)))
-								if(MAT_GOLD)
-									linked_lathe.gold_amount = max(0, (linked_lathe.gold_amount-(being_built.materials[M]/coeff * amount)))
-								if(MAT_SILVER)
-									linked_lathe.silver_amount = max(0, (linked_lathe.silver_amount-(being_built.materials[M]/coeff * amount)))
-								if(MAT_PLASMA)
-									linked_lathe.plasma_amount = max(0, (linked_lathe.plasma_amount-(being_built.materials[M]/coeff * amount)))
-								if(MAT_URANIUM)
-									linked_lathe.uranium_amount = max(0, (linked_lathe.uranium_amount-(being_built.materials[M]/coeff * amount)))
-								if(MAT_DIAMOND)
-									linked_lathe.diamond_amount = max(0, (linked_lathe.diamond_amount-(being_built.materials[M]/coeff * amount)))
-								if(MAT_BANANIUM)
-									linked_lathe.clown_amount = max(0, (linked_lathe.clown_amount-(being_built.materials[M]/coeff * amount)))
-								else
-									linked_lathe.reagents.remove_reagent(M, being_built.materials[M]/coeff * amount)
+						linked_lathe.materials.use_amount(efficient_mats, amount)
 
 					var/P = being_built.build_path //lets save these values before the spawn() just in case. Nobody likes runtimes.
 					var/O = being_built.locked
@@ -513,40 +497,26 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	else if(href_list["lathe_ejectsheet"] && linked_lathe) //Causes the protolathe to eject a sheet of material
 		var/desired_num_sheets = text2num(href_list["lathe_ejectsheet_amt"])
-		var/res_amount, type
+		var/MAT
 		switch(href_list["lathe_ejectsheet"])
 			if("metal")
-				type = /obj/item/stack/sheet/metal
-				res_amount = "m_amount"
+				MAT = MAT_METAL
 			if("glass")
-				type = /obj/item/stack/sheet/glass
-				res_amount = "g_amount"
+				MAT = MAT_GLASS
 			if("gold")
-				type = /obj/item/stack/sheet/mineral/gold
-				res_amount = "gold_amount"
+				MAT = MAT_GOLD
 			if("silver")
-				type = /obj/item/stack/sheet/mineral/silver
-				res_amount = "silver_amount"
+				MAT = MAT_SILVER
 			if("plasma")
-				type = /obj/item/stack/sheet/mineral/plasma
-				res_amount = "plasma_amount"
+				MAT = MAT_PLASMA
 			if("uranium")
-				type = /obj/item/stack/sheet/mineral/uranium
-				res_amount = "uranium_amount"
+				MAT = MAT_URANIUM
 			if("diamond")
-				type = /obj/item/stack/sheet/mineral/diamond
-				res_amount = "diamond_amount"
+				MAT = MAT_DIAMOND
 			if("clown")
-				type = /obj/item/stack/sheet/mineral/bananium
-				res_amount = "clown_amount"
-		if(ispath(type) && hasvar(linked_lathe, res_amount))
-			var/obj/item/stack/sheet/sheet = new type(linked_lathe.loc)
-			var/available_num_sheets = round(linked_lathe.vars[res_amount]/sheet.perunit)
-			if(available_num_sheets>0)
-				sheet.amount = min(available_num_sheets, desired_num_sheets)
-				linked_lathe.vars[res_amount] = max(0, (linked_lathe.vars[res_amount]-sheet.amount * sheet.perunit))
-			else
-				qdel(sheet)
+				MAT = MAT_BANANIUM
+		linked_lathe.materials.retrieve_sheets(desired_num_sheets, MAT)
+
 	else if(href_list["imprinter_ejectsheet"] && linked_imprinter) //Causes the protolathe to eject a sheet of material
 		var/desired_num_sheets = text2num(href_list["imprinter_ejectsheet_amt"])
 		var/res_amount, type
@@ -836,7 +806,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=3.2'>Material Storage</A>"
 			dat += "<A href='?src=\ref[src];menu=3.3'>Chemical Storage</A><div class='statusDisplay'>"
 			dat += "<h3>Protolathe Menu:</h3><BR>"
-			dat += "<B>Material Amount:</B> [linked_lathe.TotalMaterials()] / [linked_lathe.max_material_storage]<BR>"
+			dat += "<B>Material Amount:</B> [linked_lathe.materials.total_amount] / [linked_lathe.materials.max_amount]<BR>"
 			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] / [linked_lathe.reagents.maximum_volume]<BR>"
 
 			dat += "<form name='search' action='?src=\ref[src]'> \
@@ -854,7 +824,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A>"
 			dat += "<div class='statusDisplay'><h3>Browsing [selected_category]:</h3><BR>"
-			dat += "<B>Material Amount:</B> [linked_lathe.TotalMaterials()] / [linked_lathe.max_material_storage]<BR>"
+			dat += "<B>Material Amount:</B> [linked_lathe.materials.total_amount] / [linked_lathe.materials.max_amount]<BR>"
 			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] / [linked_lathe.reagents.maximum_volume]<HR>"
 
 			var/coeff = linked_lathe.efficiency_coeff
@@ -891,7 +861,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A>"
 			dat += "<div class='statusDisplay'><h3>Search results:</h3><BR>"
-			dat += "<B>Material Amount:</B> [linked_lathe.TotalMaterials()] / [linked_lathe.max_material_storage]<BR>"
+			dat += "<B>Material Amount:</B> [linked_lathe.materials.total_amount] / [linked_lathe.materials.max_amount]<BR>"
 			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] / [linked_lathe.reagents.maximum_volume]<HR>"
 
 			var/coeff = linked_lathe.efficiency_coeff
@@ -925,52 +895,60 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A><div class='statusDisplay'>"
 			dat += "<h3>Material Storage:</h3><BR><HR>"
 			//Metal
-			dat += "* [linked_lathe.m_amount] of Metal: "
-			if(linked_lathe.m_amount >= 3750) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.m_amount >= 18750) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.m_amount >= 3750) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=50'>All</A>"
+			var/m_amount = linked_lathe.materials.amount(MAT_METAL)
+			dat += "* [m_amount] of Metal: "
+			if(m_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(m_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=5'>5x</A> "
+			if(m_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Glass
-			dat += "* [linked_lathe.g_amount] of Glass: "
-			if(linked_lathe.g_amount >= 3750) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.g_amount >= 18750) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.g_amount >= 3750) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=50'>All</A>"
+			var/g_amount = linked_lathe.materials.amount(MAT_GLASS)
+			dat += "* [g_amount] of Glass: "
+			if(g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(g_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=5'>5x</A> "
+			if(g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Gold
-			dat += "* [linked_lathe.gold_amount] of Gold: "
-			if(linked_lathe.gold_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.gold_amount >= 10000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.gold_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=50'>All</A>"
+			var/gold_amount = linked_lathe.materials.amount(MAT_GOLD)
+			dat += "* [gold_amount] of Gold: "
+			if(gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(gold_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=5'>5x</A> "
+			if(gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Silver
-			dat += "* [linked_lathe.silver_amount] of Silver: "
-			if(linked_lathe.silver_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.silver_amount >= 10000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.silver_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=50'>All</A>"
+			var/silver_amount = linked_lathe.materials.amount(MAT_SILVER)
+			dat += "* [silver_amount] of Silver: "
+			if(silver_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(silver_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=5'>5x</A> "
+			if(silver_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Plasma
-			dat += "* [linked_lathe.plasma_amount] of Solid Plasma: "
-			if(linked_lathe.plasma_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.plasma_amount >= 10000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.plasma_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasmalathe_ejectsheet_amt=50'>All</A>"
+			var/plasma_amount = linked_lathe.materials.amount(MAT_PLASMA)
+			dat += "* [plasma_amount] of Solid Plasma: "
+			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=5'>5x</A> "
+			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasmalathe_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Uranium
-			dat += "* [linked_lathe.uranium_amount] of Uranium: "
-			if(linked_lathe.uranium_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.uranium_amount >= 10000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.uranium_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=50'>All</A>"
+			var/uranium_amount = linked_lathe.materials.amount(MAT_URANIUM)
+			dat += "* [uranium_amount] of Uranium: "
+			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=5'>5x</A> "
+			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Diamond
-			dat += "* [linked_lathe.diamond_amount] of Diamond: "
-			if(linked_lathe.diamond_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.diamond_amount >= 10000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.diamond_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=50'>All</A>"
+			var/diamond_amount = linked_lathe.materials.amount(MAT_DIAMOND)
+			dat += "* [diamond_amount] of Diamond: "
+			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=5'>5x</A> "
+			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Bananium
-			dat += "* [linked_lathe.clown_amount] of Bananium: "
-			if(linked_lathe.clown_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=1'>Eject</A> "
-			if(linked_lathe.clown_amount >= 10000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=5'>5x</A> "
-			if(linked_lathe.clown_amount >= 2000) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=50'>All</A>"
+			var/bananium_amount = linked_lathe.materials.amount(MAT_BANANIUM)
+			dat += "* [bananium_amount] of Bananium: "
+			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=1'>Eject</A> "
+			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=5'>5x</A> "
+			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=50'>All</A>"
 			dat += "</div>"
 
 		if(3.3)
@@ -1072,21 +1050,21 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "<h3>Material Storage:</h3><BR><HR>"
 			//Glass
 			dat += "* [linked_imprinter.g_amount]  glass: "
-			if(linked_imprinter.g_amount >= 3750) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=1'>Eject</A> "
-			if(linked_imprinter.g_amount >= 18750) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.g_amount >= 3750) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=50'>All</A>"
+			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=1'>Eject</A> "
+			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=5'>5x</A> "
+			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Gold
 			dat += "* [linked_imprinter.gold_amount] gold: "
-			if(linked_imprinter.gold_amount >= 2000) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=1'>Eject</A> "
-			if(linked_imprinter.gold_amount >= 10000) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.gold_amount >= 2000) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=50'>All</A>"
+			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=1'>Eject</A> "
+			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=5'>5x</A> "
+			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=50'>All</A>"
 			dat += "<BR>"
 			//Diamond
 			dat += "* [linked_imprinter.diamond_amount] diamond: "
-			if(linked_imprinter.diamond_amount >= 2000) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=1'>Eject</A> "
-			if(linked_imprinter.diamond_amount >= 10000) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.diamond_amount >= 2000) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=50'>All</A>"
+			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=1'>Eject</A> "
+			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=5'>5x</A> "
+			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=50'>All</A>"
 			dat += "</div>"
 
 	var/datum/browser/popup = new(user, "rndconsole", name, 700, 550)


### PR DESCRIPTION
Ports over datumizing materials for the Protolathe

- https://github.com/tgstation/-tg-station/pull/11580
- https://github.com/tgstation/-tg-station/pull/11734
 - The runtime is not present on our server.
- https://github.com/tgstation/-tg-station/pull/11731
 - Yes, I'm porting my own PR, hush.

Basically this allows the protolathe to deconstruct items and reclaim more than just metal and glass; it can now reclaim all materials. Not particularly useful now, but likely will be, in the future.

This also fixes an instance where the RD console thought that sheets contained 3750 materials as opposed to 2000, therefore cheating/wasting resources.

Lastly, adjust the materials of a few items to ensure that there aren't any exploits that can be done with the protolathe/autolathe/recycler. This also ensure that items that say they contain one sheet of materials actually contain one sheet of materials. 