### PR TITLE
Lightning Bolt Spell Progress Bar

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -321,8 +321,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Ensure the frequency is within bounds of what it should be sending/recieving at
 /proc/sanitize_frequency(var/f, var/low = PUBLIC_LOW_FREQ, var/high = PUBLIC_HIGH_FREQ)
 	f = round(f)
-	f = max(low, f) 
-	f = min(high, f) 
+	f = max(low, f)
+	f = min(high, f)
 	if ((f % 2) == 0) //Ensure the last digit is an odd number
 		f += 1
 	return f
@@ -778,7 +778,7 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 
 	else return get_step(ref, base_dir)
 
-/proc/do_mob(var/mob/user , var/mob/target, var/time = 30, numticks = 5, var/stealth = 0) //This is quite an ugly solution but i refuse to use the old request system.
+/proc/do_mob(var/mob/user , var/mob/target, var/time = 30, numticks = 5, var/uninterruptible = 0) //This is quite an ugly solution but i refuse to use the old request system.
 	if(!user || !target)
 		return 0
 	if(numticks == 0)
@@ -797,7 +797,7 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 			if(user && user.client)
 				user.client.images -= progbar
 			return 0
-		if ( user.loc != user_loc || target.loc != target_loc || user.get_active_hand() != holding || user.stat || user.stunned || user.weakened || user.paralysis || user.lying)
+		if (!uninterruptible && (user.loc != user_loc || target.loc != target_loc || user.get_active_hand() != holding || user.stat || user.stunned || user.weakened || user.paralysis || user.lying))
 			if(user && user.client)
 				user.client.images -= progbar
 			return 0

--- a/code/datums/spells/lightning.dm
+++ b/code/datums/spells/lightning.dm
@@ -10,7 +10,7 @@
 	cooldown_min = 30
 	selection_type = "view"
 	random_target = 1
-	var/energy = 0
+	var/start_time = 0
 	var/ready = 0
 	var/image/halo = null
 	action_icon_state = "lightning"
@@ -20,11 +20,11 @@
 	invocation_type = "none"
 
 /obj/effect/proc_holder/spell/targeted/lightning/Click()
-	if(!ready)
+	if(!ready && start_time==0)
 		if(cast_check())
 			StartChargeup()
 	else
-		if(cast_check(skipcharge=1))
+		if(ready && cast_check(skipcharge=1))
 			choose_targets()
 	return 1
 
@@ -33,16 +33,14 @@
 	user << "<span class='notice'>You start gathering the power.</span>"
 	halo = image("icon"='icons/effects/effects.dmi',"icon_state" ="electricity","layer" = EFFECTS_LAYER)
 	user.overlays.Add(halo)
-	spawn(0)
-		while(ready)
-			sleep(1)
-			energy++
-			if(energy >= 100 && ready)
-				Discharge()
+	start_time = world.time
+	if(do_mob(user,user,100,uninterruptible=1))
+		if(ready)
+			Discharge()
 
 obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 	ready = 0
-	energy = 0
+	start_time = 0
 	if(halo)
 		user.overlays.Remove(halo)
 
@@ -53,16 +51,14 @@ obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 
 /obj/effect/proc_holder/spell/targeted/lightning/proc/Discharge(mob/user = usr)
 	var/mob/living/M = user
-	//M.electrocute_act(25,"Lightning Bolt")
 	M << "<span class='danger'>You lose control over the spell.</span>"
 	Reset(user)
 	start_recharge()
 
 
 /obj/effect/proc_holder/spell/targeted/lightning/cast(list/targets, mob/user = usr)
-
+	ready = 0
 	var/mob/living/carbon/target = targets[1]
-
 	if(get_dist(user,target)>range)
 		user << "<span class='notice'>They are too far away!</span>"
 		Reset(user)
@@ -70,6 +66,7 @@ obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 
 	user.Beam(target,icon_state="lightning",icon='icons/effects/effects.dmi',time=5)
 
+	var/energy = min(world.time - start_time,100)
 	Bolt(user,target,max(15,energy/2),5,user) //5 bounces for energy/2 burn
 	Reset(user)
 


### PR DESCRIPTION
Adds a progress bar to the wizard's lightning bolt spell, which I didn't include when originally porting the  buffs from /tg/ because we did not have progress bars. Having the progress bar means that wizards no longer have to try and time their spell casting based off of how many times the lightning animation has played over them.