### PR TITLE
Mech Balance Tweaks

### DIFF
--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -3,7 +3,7 @@
 	name = "H.O.N.K"
 	icon_state = "honker"
 	initial_icon = "honker"
-	step_in = 2
+	step_in = 3
 	health = 140
 	deflect_chance = 60
 	internal_damage_threshold = 60

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -3,7 +3,7 @@
 	name = "Odysseus"
 	icon_state = "odysseus"
 	initial_icon = "odysseus"
-	step_in = 2
+	step_in = 3
 	max_temperature = 15000
 	health = 120
 	wreckage = /obj/effect/decal/mecha_wreckage/odysseus

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -8,7 +8,8 @@
 	health = 200
 	lights_power = 7
 	deflect_chance = 15
-	damage_absorption = list("brute"=0.6,"bomb"=0.2)
+	damage_absorption = list("brute"=0.6,"fire"=1,"bullet"=0.8,"laser"=0.9,"energy"=1,"bomb"=0.6)
+	max_equip = 6
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley
 	var/list/cargo = new
 	var/cargo_capacity = 15
@@ -64,14 +65,15 @@
 	max_temperature = 65000
 	health = 250
 	lights_power = 7
-	damage_absorption = list("fire"=0.5,"bullet"=0.8,"bomb"=0.5)
+	damage_absorption = list("brute"=0.6,"fire"=0.5,"bullet"=0.7,"laser"=0.7,"energy"=1,"bomb"=0.4)
+	max_equip = 5 // More armor, less tools
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/firefighter
 
 /obj/mecha/working/ripley/deathripley
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE"
 	name = "DEATH-RIPLEY"
 	icon_state = "deathripley"
-	step_in = 2
+	step_in = 3
 	opacity=0
 	lights_power = 7
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/deathripley
@@ -97,11 +99,22 @@
 		var/obj/item/mecha_parts/mecha_equipment/tool/drill/D = new /obj/item/mecha_parts/mecha_equipment/tool/drill
 		D.attach(src)
 
+	//Add possible plasma cutter
+	if(prob(25))
+		var/obj/item/mecha_parts/mecha_equipment/M = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
+		M.attach(src)
+
+	//Add ore box to cargo
+	cargo.Add(new /obj/structure/ore_box(src))
+
 	//Attach hydrolic clamp
 	var/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp/HC = new /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp
 	HC.attach(src)
 	for(var/obj/item/mecha_parts/mecha_tracking/B in src.contents)//Deletes the beacon so it can't be found easily
 		qdel(B)
+
+	var/obj/item/mecha_parts/mecha_equipment/tool/mining_scanner/scanner = new /obj/item/mecha_parts/mecha_equipment/tool/mining_scanner
+	scanner.attach(src)
 
 /obj/mecha/working/ripley/Exit(atom/movable/O)
 	if(O in cargo)

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -73,9 +73,12 @@
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE"
 	name = "DEATH-RIPLEY"
 	icon_state = "deathripley"
-	step_in = 3
+	step_in = 2
 	opacity=0
+	max_temperature = 65000
+	health = 300
 	lights_power = 7
+	damage_absorption = list("brute"=0.6,"fire"=0.4,"bullet"=0.6,"laser"=0.6,"energy"=1,"bomb"=0.3)
 	wreckage = /obj/effect/decal/mecha_wreckage/ripley/deathripley
 	step_energy_drain = 0
 


### PR DESCRIPTION
Just a few mech balancing tweaks from TG

- Slightly lowers the speed of the Oddy
- Slightly lowers the speed of the HONKER
- Mining RIPLEY starts off with a mining scanner and ore box--has a chance to start off with a plasma cutter.
 - This is the RIPLEY that's a prize for miners in some artifact rooms.
- Increases the amount of tool slots for the RIPLEY and firefighter RIPLEY
- Updates the armor values for the RIPLEY and firefighter RIPLEY (generally an increase, though the regular RIPLEY's initial bomb armor is lower).
 - Maybe people will actually spend the extra time and resources for firefighter RIPLEY's now.
- Increases the health, armor, and temperature resist of the Death RIPLEY.