### PR TITLE
Materials Consistency Fix/Update

### DIFF
--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -25,43 +25,43 @@
 /obj/item/weapon/coin/gold
 	cmineral = "gold"
 	icon_state = "coin_gold_heads"
-	materials = list(MAT_GOLD = 200)
+	materials = list(MAT_GOLD = 400)
 	credits = 160
 
 /obj/item/weapon/coin/silver
 	cmineral = "silver"
 	icon_state = "coin_silver_heads"
-	materials = list(MAT_SILVER = 200)
+	materials = list(MAT_SILVER = 400)
 	credits = 40
 
 /obj/item/weapon/coin/diamond
 	cmineral = "diamond"
 	icon_state = "coin_diamond_heads"
-	materials = list(MAT_DIAMOND = 200)
+	materials = list(MAT_DIAMOND = 400)
 	credits = 120
 
 /obj/item/weapon/coin/iron
 	cmineral = "iron"
 	icon_state = "coin_iron_heads"
-	materials = list(MAT_METAL = 200)
+	materials = list(MAT_METAL = 400)
 	credits = 20
 
 /obj/item/weapon/coin/plasma
 	cmineral = "plasma"
 	icon_state = "coin_plasma_heads"
-	materials = list(MAT_PLASMA = 200)
+	materials = list(MAT_PLASMA = 400)
 	credits = 80
 
 /obj/item/weapon/coin/uranium
 	cmineral = "uranium"
 	icon_state = "coin_uranium_heads"
-	materials = list(MAT_URANIUM = 200)
+	materials = list(MAT_URANIUM = 400)
 	credits = 160
 
 /obj/item/weapon/coin/clown
 	cmineral = "bananium"
 	icon_state = "coin_bananium_heads"
-	materials = list(MAT_BANANIUM = 200)
+	materials = list(MAT_BANANIUM = 400)
 	credits = 600 //makes the clown cri
 
 /obj/item/weapon/coin/adamantine

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -175,7 +175,7 @@
 	force = 14
 	throwforce = 10
 	amount_per_transfer_from_this = 20
-	materials = list(MAT_GOLD=800)
+	materials = list(MAT_GOLD=1000)
 	possible_transfer_amounts = null
 	volume = 150
 	flags = CONDUCT | OPENCONTAINER
@@ -358,14 +358,14 @@
 	name = "Captain's Flask"
 	desc = "A metal flask belonging to the captain"
 	icon_state = "flask"
-	materials = list(MAT_SILVER=300)
+	materials = list(MAT_SILVER=500)
 	volume = 60
 
 /obj/item/weapon/reagent_containers/food/drinks/flask/detflask
 	name = "Detective's Flask"
 	desc = "A metal flask with a leather band and golden badge belonging to the detective."
 	icon_state = "detflask"
-	materials = list(MAT_METAL=200)
+	materials = list(MAT_METAL=250)
 	volume = 60
 
 /obj/item/weapon/reagent_containers/food/drinks/flask/barflask


### PR DESCRIPTION
A fix as far as I'm concerned, but eh.

https://github.com/tgstation/-tg-station/pull/11487
This PR got updated before it got merged, and I didn't update my port of that PR.

Either case, this fixes a consistency issue where coins cost 1/5 of a sheet of materials, but only have 1/10th of the actual materials in them.

Also adjusts some other numbers to be consistent with that PR.