### PR TITLE
Add Sergeant Araneus

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -204,7 +204,7 @@
 "adV" = (/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/machinery/power/apc{dir = 8; name = "Head of Security APC"; pixel_x = -24},/turf/simulated/floor{icon_state = "dark"},/area/security/hos)
 "adW" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0; tag = ""},/turf/simulated/floor/carpet,/area/security/hos)
 "adX" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"; tag = ""},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; tag = ""},/obj/structure/cable{d1 = 2; d2 = 4; icon_state = "2-4"; tag = ""},/turf/simulated/floor/carpet,/area/security/hos)
-"adY" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0; tag = ""},/turf/simulated/floor/carpet,/area/security/hos)
+"adY" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0; tag = ""},/mob/living/simple_animal/hostile/retaliate/araneus,/turf/simulated/floor/carpet,/area/security/hos)
 "adZ" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0; tag = ""},/turf/simulated/floor{icon_state = "dark"},/area/security/hos)
 "aea" = (/obj/structure/table/woodentable,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"; pixel_x = 0; tag = ""},/obj/item/device/radio,/turf/simulated/floor{icon_state = "dark"},/area/security/hos)
 "aeb" = (/obj/machinery/space_heater,/obj/machinery/light_switch{pixel_x = -25},/obj/effect/decal/warning_stripes/east,/turf/simulated/floor,/area/security/podbay)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/pet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/pet.dm
@@ -1,0 +1,23 @@
+/mob/living/simple_animal/hostile/retaliate/araneus
+	name = "Sergeant Araneus"
+	real_name = "Sergeant Araneus"
+	voice_name = "unidentifiable voice"
+	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine."
+	faction = list("spiders")
+	icon_state = "guard"
+	icon_living = "guard"
+	icon_dead = "guard_dead"
+	icon_gib = "guard_dead"
+	turns_per_move = 8
+	response_help = "pets"
+	emote_hear = list("chitters")
+	maxHealth = 250
+	health = 200
+	harm_intent_damage = 3
+	melee_damage_lower = 15
+	melee_damage_upper = 20
+
+	min_oxy = 5
+	max_tox = 2
+	max_co2 = 5
+

--- a/paradise.dme
+++ b/paradise.dme
@@ -1462,6 +1462,7 @@
 #include "code\modules\mob\living\simple_animal\hostile\tree.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\clown.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\drone.dm"
+#include "code\modules\mob\living\simple_animal\hostile\retaliate\pet.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\retaliate.dm"
 #include "code\modules\mob\living\simple_animal\hostile\retaliate\undead.dm"
 #include "code\modules\mob\living\simple_animal\revenant\revenant.dm"


### PR DESCRIPTION
Changes:
1) Ports over Sergeant Araneus from /tg/'s Metastation (except that ours isn't defined on the map, but in the code).

Araneus is the Head of Security's pet Guard spider, and friendly until you attack him. Naturally he's in the head of security's office.