### PR TITLE
Accounts database fixes

### DIFF
--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -92,8 +92,9 @@ var/global/list/all_money_accounts = list()
 		P.wrapped = R
 		R.name = "Account information: [M.owner_name]"
 
-		// AUTOFIXED BY fix_string_idiocy.py
-		// C:\Users\Rob\Documents\Projects\vgstation13\code\WorkInProgress\Cael_Aislinn\Economy\Accounts.dm:94: R.info = "<b>Account details (confidential)</b><br><hr><br>"
+		var/overseer = "Unknown"
+		if(source_db.held_card)
+			overseer = source_db.held_card.registered_name
 		R.info = {"<b>Account details (confidential)</b><br><hr><br>
 			<i>Account holder:</i> [M.owner_name]<br>
 			<i>Account number:</i> [M.account_number]<br>
@@ -101,7 +102,7 @@ var/global/list/all_money_accounts = list()
 			<i>Starting balance:</i> $[M.money]<br>
 			<i>Date and time:</i> [worldtime2text()], [current_date_string]<br><br>
 			<i>Creation terminal ID:</i> [source_db.machine_id]<br>
-			<i>Authorised NT officer overseeing creation:</i> [source_db.held_card.registered_name]<br>"}
+			<i>Authorised NT officer overseeing creation:</i> [overseer]<br>"}
 		// END AUTOFIX
 		//stamp the paper
 		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -131,9 +131,9 @@
 	if(..())
 		return 1
 		
-	if("insert_card")
+	if(href_list["insert_card"])
 		if(held_card)
-			held_card.loc = src.loc
+			held_card.forceMove(loc)
 
 			if(ishuman(usr) && !usr.get_active_hand())
 				usr.put_in_hands(held_card)
@@ -144,7 +144,7 @@
 			if (istype(I, /obj/item/weapon/card/id))
 				var/obj/item/weapon/card/id/C = I
 				usr.drop_item()
-				C.loc = src
+				C.forceMove(src)
 				held_card = C		
 		
 	if(!get_access_level(usr))

--- a/nano/templates/accounts_terminal.tmpl
+++ b/nano/templates/accounts_terminal.tmpl
@@ -23,9 +23,35 @@
   {{:helper.link('New Account', 'gear', {'choice' : 'create_account'}, data.creating_new_account ? 'disabled' : null, 'fixedLeft')}}
   {{:helper.link('Print', 'print', {'choice' : 'print'}, data.creating_new_account ? 'disabled' : null, 'fixedLeft')}}
 
+   {{if data.creating_new_account}}
+    <div class='item'>
+      <h2>Create Account</h2>
+    </div>
 
-
-  {{if data.detailed_account_view}}
+    <form name='create_account' action='?src={{:data.src}}' method='get'>
+      <input type='hidden' name='src' value='{{:data.src}}'>
+      <input type='hidden' name='choice' value='finalise_create_account'>
+      <div class='item'>
+        <div class='itemLabel'>
+          <b>Account Holder</b>:
+        </div>
+        <div class='itemContent'>
+          <input type='text' id='holder_name' name='holder_name'>
+        </div>
+      </div>
+      <div class='item'>
+        <div class='itemLabel'>
+          <b>Initial Deposit</b>:
+        </div>
+        <div class='itemContent'>
+          <input type='text' id='starting_funds' name='starting_funds'>
+        </div>
+      </div>
+      <div class='item'>
+        <input type='submit' value='Create'>
+      </div>
+    </form>
+  {{else data.detailed_account_view}}  
     <div class='item'>
       <h2>Account Details</h2>
     </div>
@@ -100,7 +126,6 @@
       {{/if}}
     </div>
   {{else}}
-
     <div class='item'>
       <h2>Nanotrasen Accounts</h2>
     </div>


### PR DESCRIPTION
Changes:
1) Admins can now create accounts in the accounts DB without it runtiming.
2) The accounts database will no longer always eject the ID inside of it, effectively breaking it.
3) Fixes being unable to create new accounts.