### PR TITLE
Backpack Storage Rework

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -12,6 +12,7 @@
 	slot_flags = SLOT_BACK	//ERROOOOO
 	max_w_class = 3
 	max_combined_w_class = 21
+	storage_slots = 21
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	playsound(src.loc, "rustle", 50, 1, -5)
@@ -73,7 +74,6 @@
 	icon_state = "giftbag0"
 	item_state = "giftbag"
 	w_class = 4.0
-	storage_slots = 20
 	max_w_class = 3
 	max_combined_w_class = 400 // can store a ton of shit!
 
@@ -197,7 +197,6 @@
 	desc = "A very slim satchel that can easily fit into tight spaces."
 	icon_state = "satchel-flat"
 	w_class = 3 //Can fit in backpacks itself.
-	storage_slots = 5
 	max_combined_w_class = 15
 	level = 1
 	cant_hold = list(/obj/item/weapon/storage/backpack/satchel_flat) //muh recursive backpacks
@@ -227,8 +226,7 @@
 	icon_override = 'icons/mob/in-hand/duffelbag.dmi'
 	icon_state = "duffel"
 	item_state = "duffel"
-	storage_slots = 9 // Duffelbags can hold more items.
-	max_combined_w_class = 27
+	max_combined_w_class = 30
 	slowdown = 1
 
 /obj/item/weapon/storage/backpack/duffel/syndie
@@ -272,7 +270,6 @@
 	desc = "A suspicious looking dufflebag for holding surgery tools."
 	icon_state = "duffel-syndimed"
 	item_state = "duffle-syndimed"
-	storage_slots = 12
 
 /obj/item/weapon/storage/backpack/duffel/syndie/surgery/New()
 	..()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -235,7 +235,7 @@
 		return 0 //Means the item is already in the storage item
 	if(contents.len >= storage_slots)
 		if(!stop_messages)
-			usr << "<span class='notice'>[src] is full, make some space.</span>"
+			usr << "<span class='warning'>[W] won't fit in [src], make some space!</span>"
 		return 0 //Storage item is full
 
 	if(can_hold.len)


### PR DESCRIPTION
Port of: https://github.com/tgstation/-tg-station/pull/10975/files

Simply put, this makes backpacks function more logically. Instead of backpacks being limited by the amount of *slots* they have, they'll be limited by the total weight class of the items contained within the backpack.

This means that 7 coins won't fill up your backpack anymore; you'd be able to place up to 21 of them in your backpack.

This doesn't mean you'll be able to cram in a ton more guns into your backpack; the weight class limit of regular backpacks is still 3, and with a max weight class of 21, that still means you're only going to get 7 moderate sized items in your inventory.