### PR TITLE
Autohiss + Baydev language update.

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -1,0 +1,95 @@
+
+#define AUTOHISS_OFF 0
+#define AUTOHISS_BASIC 1
+#define AUTOHISS_FULL 2
+
+#define AUTOHISS_NUM 3
+
+
+/mob/living/proc/handle_autohiss(message, datum/language/L)
+	return message // no autohiss at this level
+
+/mob/living/carbon/human/handle_autohiss(message, datum/language/L)
+	if(!client || client.autohiss_mode == AUTOHISS_OFF) // no need to process if there's no client or they have autohiss off
+		return message
+	return species.handle_autohiss(message, L, client.autohiss_mode)
+
+/client
+	var/autohiss_mode = AUTOHISS_OFF
+
+/client/verb/toggle_autohiss()
+	set name = "Toggle Auto-Hiss"
+	set desc = "Toggle automatic hissing as Unathi and r-rolling as Taj"
+	set category = "OOC"
+
+	autohiss_mode = (autohiss_mode + 1) % AUTOHISS_NUM
+	switch(autohiss_mode)
+		if(AUTOHISS_OFF)
+			src << "Auto-hiss is now OFF."
+		if(AUTOHISS_BASIC)
+			src << "Auto-hiss is now BASIC."
+		if(AUTOHISS_FULL)
+			src << "Auto-hiss is now FULL."
+		else
+			autohiss_mode = AUTOHISS_OFF
+			src << "Auto-hiss is now OFF."
+
+/datum/species
+	var/list/autohiss_basic_map = null
+	var/list/autohiss_extra_map = null
+	var/list/autohiss_exempt = null
+
+/datum/species/unathi
+	autohiss_basic_map = list(
+			"s" = list("ss", "sss", "ssss")
+		)
+	autohiss_extra_map = list(
+			"x" = list("ks", "kss", "ksss")
+		)
+	autohiss_exempt = list("Sinta'unathi")
+
+/datum/species/tajaran
+	autohiss_basic_map = list(
+			"r" = list("rr", "rrr", "rrrr")
+		)
+	autohiss_exempt = list("Siik'tajr")
+
+
+/datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
+	if(!autohiss_basic_map)
+		return message
+	if(autohiss_exempt && (lang.name in autohiss_exempt))
+		return message
+
+	var/map = autohiss_basic_map.Copy()
+	if(mode == AUTOHISS_FULL && autohiss_extra_map)
+		map |= autohiss_extra_map
+
+	. = list()
+
+	while(length(message))
+		var/min_index = 10000 // if the message is longer than this, the autohiss is the least of your problems
+		var/min_char = null
+		for(var/char in map)
+			var/i = findtext(message, char)
+			if(!i) // no more of this character anywhere in the string, don't even bother searching next time
+				map -= char
+			else if(i < min_index)
+				min_index = i
+				min_char = char
+		if(!min_char) // we didn't find any of the mapping characters
+			. += message
+			break
+		. += copytext(message, 1, min_index)
+		if(copytext(message, min_index, min_index+1) == uppertext(min_char))
+			. += capitalize(pick(map[min_char]))
+		else
+			. += pick(map[min_char])
+		message = copytext(message, min_index + 1)
+
+	return list2text(.)
+
+#undef AUTOHISS_OFF
+#undef AUTOHISS_BASIC
+#undef AUTOHISS_FULL
+#undef AUTOHISS_NUM

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -18,8 +18,8 @@
 	var/autohiss_mode = AUTOHISS_OFF
 
 /client/verb/toggle_autohiss()
-	set name = "Toggle Auto-Hiss"
-	set desc = "Toggle automatic hissing as Unathi and r-rolling as Taj"
+	set name = "Toggle Auto-Accent"
+	set desc = "Toggle automatic accents for your species"
 	set category = "OOC"
 
 	autohiss_mode = (autohiss_mode + 1) % AUTOHISS_NUM

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -54,6 +54,21 @@
 		)
 	autohiss_exempt = list("Siik'tajr")
 
+/datum/species/plasmaman
+	autohiss_basic_map = list(
+			"s" = list("ss", "sss", "ssss")
+		)
+
+/datum/species/kidan
+	autohiss_basic_map = list(
+			"z" = list("zz", "zzz", "zzzz"),
+			"v" = list("vv", "vvv", "vvvv")
+		)
+	autohiss_extra_map = list(
+			"s" = list("z", "zs", "zzz", "zzsz")
+		)
+	autohiss_exempt = list("Chittin")
+
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
 	if(!autohiss_basic_map)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,152 +1,10 @@
 /mob/living/carbon/human/say(var/message)
-
-	var/verb = "says"
 	var/alt_name = ""
-	var/message_range = world.view
-	var/italics = 0
-
-	if(client)
-		if(client.prefs.muted & MUTE_IC)
-			src << "\red You cannot speak in IC (Muted)."
-			return
-
-	message = trim_strip_html_properly(message)
-
-	if(stat)
-		if(stat == 2)
-			return say_dead(message)
-		return
-
-	if (is_muzzled())
-		src << "<span class='danger'>You're muzzled and cannot speak!</span>"
-		return
-
-	var/message_mode = parse_message_mode(message, "headset")
-
-	if(copytext(message,1,2) == "*")
-		return emote(copytext(message,2))
 
 	if(name != GetVoice())
 		alt_name = " (as [get_id_name("Unknown")])"
 
-	//parse the radio code and consume it
-	if (message_mode)
-		if (message_mode == "headset")
-			message = copytext(message,2)	//it would be really nice if the parse procs could do this for us.
-		else
-			message = copytext(message,3)
-
-	//parse the language code and consume it
-	var/datum/language/speaking = parse_language(message)
-	if(speaking)
-		message = copytext(message,2+length(speaking.key))
-	else
-		speaking = get_default_language()
-
-	var/ending = copytext(message, length(message))
-	if (speaking)
-		// This is broadcast to all mobs with the language,
-		// irrespective of distance or anything else.
-		if(speaking.flags & HIVEMIND)
-			speaking.broadcast(src,trim(message))
-			return
-		//If we've gotten this far, keep going!
-		verb = speaking.get_spoken_verb(ending)
-	else
-		if(ending=="!")
-			verb=pick("exclaims","shouts","yells")
-		if(ending=="?")
-			verb="asks"
-
-	message = trim(message)
-
-	if(speech_problem_flag)
-		var/list/handle_r = handle_speech_problems(message)
-		message = handle_r[1]
-		verb = handle_r[2]
-		speech_problem_flag = handle_r[3]
-
-	if(!message || message == "")
-		return
-
-	var/list/obj/item/used_radios = new
-
-	switch (message_mode)
-		if("headset")
-			if(l_ear && istype(l_ear,/obj/item/device/radio))
-				var/obj/item/device/radio/R = l_ear
-				R.talk_into(src,message,null,verb,speaking)
-				used_radios += l_ear
-			else if(r_ear && istype(r_ear,/obj/item/device/radio))
-				var/obj/item/device/radio/R = r_ear
-				R.talk_into(src,message,null,verb,speaking)
-				used_radios += r_ear
-
-		if("right ear")
-			var/obj/item/device/radio/R
-			var/has_radio = 0
-			if(r_ear && istype(r_ear,/obj/item/device/radio))
-				R = r_ear
-				has_radio = 1
-			if(r_hand && istype(r_hand, /obj/item/device/radio))
-				R = r_hand
-				has_radio = 1
-			if(has_radio)
-				R.talk_into(src,message,null,verb,speaking)
-				used_radios += R
-
-
-		if("left ear")
-			var/obj/item/device/radio/R
-			var/has_radio = 0
-			if(l_ear && istype(l_ear,/obj/item/device/radio))
-				R = l_ear
-				has_radio = 1
-			if(l_hand && istype(l_hand,/obj/item/device/radio))
-				R = l_hand
-				has_radio = 1
-			if(has_radio)
-				R.talk_into(src,message,null,verb,speaking)
-				used_radios += R
-
-		if("intercom")
-			for(var/obj/item/device/radio/intercom/I in view(1, null))
-				I.talk_into(src, message, verb, speaking)
-				used_radios += I
-		if("whisper")
-			whisper_say(message, speaking, alt_name)
-			return
-		else
-			if(message_mode)
-				if(l_ear && istype(l_ear,/obj/item/device/radio))
-					l_ear.talk_into(src,message, message_mode, verb, speaking)
-					used_radios += l_ear
-				else if(r_ear && istype(r_ear,/obj/item/device/radio))
-					r_ear.talk_into(src,message, message_mode, verb, speaking)
-					used_radios += r_ear
-
-	var/sound/speech_sound
-	var/sound_vol
-	if(species.speech_sounds && prob(species.speech_chance))
-		speech_sound = sound(pick(species.speech_sounds))
-		sound_vol = 50
-
-	//speaking into radios
-	if(used_radios.len)
-		italics = 1
-		message_range = 1
-		if(speaking)
-			message_range = speaking.get_talkinto_msg_range(message)
-		var/msg
-		if(!speaking || !(speaking.flags & NO_TALK_MSG))
-			msg = "<span class='notice'>\The [src] talks into \the [used_radios[1]]</span>"
-		for(var/mob/living/M in hearers(5, src))
-			if((M != src) && msg)
-				M.show_message(msg)
-			if (speech_sound)
-				sound_vol *= 0.5
-
-	..(message, speaking, verb, alt_name, italics, message_range, speech_sound, sound_vol)	//ohgod we should really be passing a datum here.
+	..(message, alt_name = alt_name)	//ohgod we should really be passing a datum here.
 
 /mob/living/carbon/human/proc/forcesay(list/append)
 	if(stat == CONSCIOUS)
@@ -207,7 +65,7 @@
 	//	return 0
 
 	return ..()
-	
+
 /mob/living/carbon/human/proc/HasVoiceChanger()
 	for(var/obj/item/gear in list(wear_mask,wear_suit,head))
 		if(!gear)
@@ -216,7 +74,7 @@
 		if(changer && changer.active && changer.voice)
 			return changer.voice
 	return 0
-		
+
 /mob/living/carbon/human/GetVoice()
 	var/has_changer = HasVoiceChanger()
 	if(has_changer)
@@ -240,15 +98,6 @@
 	return special_voice
 
 
-/*
-   ***Deprecated***
-   let this be handled at the hear_say or hear_radio proc
-   This is left in for robot speaking when humans gain binary channel access until I get around to rewriting
-   robot_talk() proc.
-   There is no language handling build into it however there is at the /mob level so we accept the call
-   for it but just ignore it.
-*/
-
 /mob/living/carbon/human/say_quote(var/message, var/datum/language/speaking = null)
 	var/verb = "says"
 	var/ending = copytext(message, length(message))
@@ -257,27 +106,27 @@
 		verb = speaking.get_spoken_verb(ending)
 	else
 		if(ending == "!")
-			verb = "exclaims"
-		else if(ending == "?")
-			verb = "asks"
+			return pick("exclaims", "shouts", "yells")
+		if(ending == "?")
+			return "asks"
 
 	return verb
 
-/mob/living/carbon/human/proc/handle_speech_problems(var/message)
 
+/mob/living/carbon/human/handle_speech_problems(var/message, var/verb)
 	var/list/returns[3]
-	var/verb = "says"
-	var/handled = 0
+	var/speech_problem_flag = 0
+
 	if(silent || (sdisabilities & MUTE))
 		message = ""
-		handled = 1
+		speech_problem_flag = 1
+
 	if(istype(wear_mask, /obj/item/clothing/mask/horsehead))
 		var/obj/item/clothing/mask/horsehead/hoers = wear_mask
 		if(hoers.voicechange)
-			if(mind && mind.changeling && department_radio_keys[copytext(message, 1, 3)] != "changeling")
-				message = pick("NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!")
-				verb = pick("whinnies","neighs", "says")
-				handled = 1
+			message = pick("NEEIIGGGHHHH!", "NEEEIIIIGHH!", "NEIIIGGHH!", "HAAWWWWW!", "HAAAWWW!")
+			verb = pick("whinnies","neighs", "says")
+			speech_problem_flag = 1
 
 	if(dna)
 		for(var/datum/dna/gene/gene in dna_genes)
@@ -285,25 +134,18 @@
 				continue
 			if(gene.is_active(src))
 				message = gene.OnSay(src,message)
-				handled = 1
+				speech_problem_flag = 1
 
 	if(message != "")
-		if((HULK in mutations) && health >= 25 && length(message))
-			message = "[uppertext(message)]!!!"
-			verb = pick("yells","roars","hollers")
-			handled = 1
-		if(slurring)
-			message = slur(message)
-			verb = "slurs"
-			handled = 1
-		if(stuttering)
-			message = stutter(message)
-			verb = "stammers"
-			handled = 1
+		var/list/parent = ..()
+		message = parent[1]
+		verb = parent[2]
+		if(parent[3])
+			speech_problem_flag = 1
 
 		var/braindam = getBrainLoss()
 		if(braindam >= 60)
-			handled = 1
+			speech_problem_flag = 1
 			if(prob(braindam/4))
 				message = stutter(message)
 				verb = "gibbers"
@@ -311,9 +153,70 @@
 				message = uppertext(message)
 				verb = "yells loudly"
 
-		if(COMIC in mutations)
-			message = "<span class='sans'>[message]</span>"
 	returns[1] = message
 	returns[2] = verb
-	returns[3] = handled
+	returns[3] = speech_problem_flag
+	return returns
+
+/mob/living/carbon/human/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios, var/alt_name)
+	switch(message_mode)
+		if("intercom")
+			for(var/obj/item/device/radio/intercom/I in view(1, null))
+				I.talk_into(src, message, verb, speaking)
+				used_radios += I
+
+		if("headset")
+			if(l_ear && istype(l_ear,/obj/item/device/radio))
+				var/obj/item/device/radio/R = l_ear
+				R.talk_into(src,message,null,verb,speaking)
+				used_radios += l_ear
+			else if(r_ear && istype(r_ear,/obj/item/device/radio))
+				var/obj/item/device/radio/R = r_ear
+				R.talk_into(src,message,null,verb,speaking)
+				used_radios += r_ear
+
+		if("right ear")
+			var/obj/item/device/radio/R
+			var/has_radio = 0
+			if(r_ear && istype(r_ear,/obj/item/device/radio))
+				R = r_ear
+				has_radio = 1
+			if(r_hand && istype(r_hand, /obj/item/device/radio))
+				R = r_hand
+				has_radio = 1
+			if(has_radio)
+				R.talk_into(src,message,null,verb,speaking)
+				used_radios += R
+
+
+		if("left ear")
+			var/obj/item/device/radio/R
+			var/has_radio = 0
+			if(l_ear && istype(l_ear,/obj/item/device/radio))
+				R = l_ear
+				has_radio = 1
+			if(l_hand && istype(l_hand,/obj/item/device/radio))
+				R = l_hand
+				has_radio = 1
+			if(has_radio)
+				R.talk_into(src,message,null,verb,speaking)
+				used_radios += R
+
+		if("whisper")
+			whisper_say(message, speaking, alt_name)
+			return 1
+		else
+			if(message_mode)
+				if(l_ear && istype(l_ear,/obj/item/device/radio))
+					l_ear.talk_into(src,message, message_mode, verb, speaking)
+					used_radios += l_ear
+				else if(r_ear && istype(r_ear,/obj/item/device/radio))
+					r_ear.talk_into(src,message, message_mode, verb, speaking)
+					used_radios += r_ear
+
+/mob/living/carbon/human/handle_speech_sound()
+	var/list/returns[2]
+	if(species.speech_sounds && prob(species.speech_chance))
+		returns[1] = sound(pick(species.speech_sounds))
+		returns[2] = 50
 	return returns

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -67,7 +67,123 @@ proc/get_radio_key_from_channel(var/channel)
 /mob/living/proc/get_default_language()
 	return default_language
 
-/mob/living/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", var/italics=0, var/message_range = world.view, var/sound/speech_sound, var/sound_vol)
+/mob/living/proc/handle_speech_problems(var/message, var/verb)
+	var/list/returns[3]
+	var/speech_problem_flag = 0
+
+	if((HULK in mutations) && health >= 25 && length(message))
+		message = "[uppertext(message)]!!!"
+		verb = pick("yells","roars","hollers")
+		speech_problem_flag = 1
+
+	if(COMIC in mutations)
+		message = "<span class='sans'>[message]</span>"
+
+	if(slurring)
+		message = slur(message)
+		verb = "slurs"
+		speech_problem_flag = 1
+	if(stuttering)
+		message = stutter(message)
+		verb = "stammers"
+		speech_problem_flag = 1
+
+	returns[1] = message
+	returns[2] = verb
+	returns[3] = speech_problem_flag
+	return returns
+
+/mob/living/proc/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	return 0
+
+/mob/living/proc/handle_speech_sound()
+	var/list/returns[2]
+	returns[1] = null
+	returns[2] = null
+	return returns
+
+
+/mob/living/say(var/message, var/datum/language/speaking = null, var/verb = "says", var/alt_name="")
+	if(client)
+		if(client.prefs.muted & MUTE_IC)
+			src << "\red You cannot speak in IC (Muted)."
+			return
+
+	message = trim_strip_html_properly(message)
+
+	if(stat)
+		if(stat == 2)
+			return say_dead(message)
+		return
+
+	var/message_mode = parse_message_mode(message, "headset")
+
+	if(copytext(message,1,2) == "*")
+		return emote(copytext(message,2))
+
+	//parse the radio code and consume it
+	if (message_mode)
+		if (message_mode == "headset")
+			message = copytext(message,2)	//it would be really nice if the parse procs could do this for us.
+		else
+			message = copytext(message,3)
+
+	message = trim_left(message)
+
+	//parse the language code and consume it
+	if(!speaking)
+		speaking = parse_language(message)
+	if(speaking)
+		message = copytext(message, 2 + length(speaking.key))
+	else
+		speaking = get_default_language()
+
+	// This is broadcast to all mobs with the language,
+	// irrespective of distance or anything else.
+	if(speaking && (speaking.flags & HIVEMIND))
+		speaking.broadcast(src,trim(message))
+		return 1
+
+	verb = say_quote(message, speaking)
+
+	if(is_muzzled())
+		src << "<span class='danger'>You're muzzled and cannot speak!</span>"
+		return
+
+	message = trim_left(message)
+
+	var/list/handle_s = handle_speech_problems(message, verb)
+	message = handle_s[1]
+	verb = handle_s[2]
+
+	if(!message || message == "")
+		return 0
+
+	var/list/obj/item/used_radios = new
+	if(handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name))
+		return 1
+
+	var/list/handle_v = handle_speech_sound()
+	var/sound/speech_sound = handle_v[1]
+	var/sound_vol = handle_v[2]
+
+	var/italics = 0
+	var/message_range = world.view
+
+	//speaking into radios
+	if(used_radios.len)
+		italics = 1
+		message_range = 1
+		if(speaking)
+			message_range = speaking.get_talkinto_msg_range(message)
+		var/msg
+		if(!speaking || !(speaking.flags & NO_TALK_MSG))
+			msg = "<span class='notice'>\The [src] talks into \the [used_radios[1]]</span>"
+		for(var/mob/living/M in hearers(5, src))
+			if((M != src) && msg)
+				M.show_message(msg)
+			if (speech_sound)
+				sound_vol *= 0.5
 
 	var/turf/T = get_turf(src)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -152,6 +152,8 @@ proc/get_radio_key_from_channel(var/channel)
 
 	message = trim_left(message)
 
+	message = handle_autohiss(message, speaking)
+
 	var/list/handle_s = handle_speech_problems(message, verb)
 	message = handle_s[1]
 	verb = handle_s[2]

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -1,0 +1,40 @@
+/mob/living/silicon/robot/drone/say(var/message)
+	if(local_transmit)
+		if (src.client)
+			if(client.prefs.muted & MUTE_IC)
+				src << "You cannot send IC messages (muted)."
+				return 0
+			if (src.client.handle_spam_prevention(message,MUTE_IC))
+				return 0
+
+		message = sanitize(message)
+
+		if (stat == 2)
+			return say_dead(message)
+
+		if(copytext(message,1,2) == "*")
+			return emote(copytext(message,2))
+
+		if(copytext(message,1,2) == ";")
+			var/datum/language/L = all_languages["Drone Talk"]
+			if(istype(L))
+				return L.broadcast(src,trim(copytext(message,2)))
+
+		//Must be concious to speak
+		if (stat)
+			return 0
+
+		var/list/listeners = hearers(5,src)
+		listeners |= src
+
+		for(var/mob/living/silicon/D in listeners)
+			if(D.client && D.local_transmit)
+				D << "<b>[src]</b> transmits, \"[message]\""
+
+		for (var/mob/M in player_list)
+			if (istype(M, /mob/new_player))
+				continue
+			else if(M.stat == 2 &&  M.client.prefs.toggles & CHAT_GHOSTEARS)
+				if(M.client) M << "<b>[src]</b> transmits, \"[message]\""
+		return 1
+	return ..(message, 0)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,3 +1,38 @@
+/mob/living/silicon/say(var/message, var/sanitize = 1)
+	return ..(sanitize ? sanitize(message) : message)
+
+/mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	log_say("[key_name(src)] : [message]")
+
+/mob/living/silicon/robot/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	..()
+	if(message_mode)
+		if(!is_component_functioning("radio"))
+			src << "<span class='warning'>Your radio isn't functional at this time.</span>"
+			return 0
+		if(message_mode == "general")
+			message_mode = null
+		return radio.talk_into(src,message,message_mode,verb,speaking)
+
+/mob/living/silicon/ai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	..()
+	if(message_mode == "department")
+		return holopad_talk(message, verb, speaking)
+	else if(message_mode)
+		if (aiRadio.disabledAi || aiRestorePowerRoutine || stat)
+			src << "<span class='danger'>System Error - Transceiver Disabled.</span>"
+			return 0
+		if(message_mode == "general")
+			message_mode = null
+		return aiRadio.talk_into(src,message,message_mode,verb,speaking)
+
+/mob/living/silicon/pai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+	..()
+	if(message_mode)
+		if(message_mode == "general")
+			message_mode = null
+		return radio.talk_into(src,message,message_mode,verb,speaking)
+
 /mob/living/silicon/say_quote(var/text)
 	var/ending = copytext(text, length(text))
 
@@ -22,137 +57,6 @@
 		if (istype(other, /mob/living/carbon/brain))
 			return 1
 	return ..()
-
-/mob/living/silicon/say(var/message)
-	if (!message)
-		return 0
-
-	if (src.client)
-		if(client.prefs.muted & MUTE_IC)
-			src << "You cannot send IC messages (muted)."
-			return 0
-		if (src.client.handle_spam_prevention(message,MUTE_IC))
-			return 0
-
-	message = trim_strip_html_properly(message)
-
-	if (stat == 2)
-		return say_dead(message)
-
-	if(copytext(message,1,2) == "*")
-		return emote(copytext(message,2))
-
-	var/bot_type = 0			//Let's not do a fuck ton of type checks, thanks.
-	if(istype(src, /mob/living/silicon/ai))
-		bot_type = IS_AI
-	else if(istype(src, /mob/living/silicon/robot))
-		bot_type = IS_ROBOT
-	else if(istype(src, /mob/living/silicon/pai))
-		bot_type = IS_PAI
-
-	var/mob/living/silicon/ai/AI = src		//and let's not declare vars over and over and over for these guys.
-	var/mob/living/silicon/robot/R = src
-	var/mob/living/silicon/pai/P = src
-
-	//Must be concious to speak
-	if (stat)
-		return 0
-
-	var/verb = say_quote(message)
-
-	//parse radio key and consume it
-	var/message_mode = parse_message_mode(message, "general")
-	if (message_mode)
-		if (message_mode == "general")
-			message = trim(copytext(message,2))
-		else
-			message = trim(copytext(message,3))
-
-	//parse language key and consume it
-	var/datum/language/speaking = parse_language(message)
-	if (speaking)
-
-		message = trim(copytext(message,2+length(speaking.key)))
-	else
-		speaking = get_default_language()
-
-	if (speaking)
-		verb = speaking.speech_verb
-		// This is broadcast to all mobs with the language,
-		// irrespective of distance or anything else.
-		if(speaking.flags & HIVEMIND)
-			speaking.broadcast(src,trim(message))
-			return 1
-
-	// Currently used by drones.
-	if(local_transmit)
-		var/list/listeners = hearers(5,src)
-		listeners |= src
-
-		for(var/mob/living/silicon/D in listeners)
-			if(D.client && istype(D,src.type))
-				D << "<b>[src]</b> transmits, \"[message]\""
-
-		for (var/mob/M in player_list)
-			if (istype(M, /mob/new_player))
-				continue
-			else if(M.stat == 2 &&  M.client.prefs.toggles & CHAT_GHOSTEARS)
-				if(M.client) M << "<b>[src]</b> transmits, \"[message]\""
-		return 1
-
-	if(message_mode && bot_type == IS_ROBOT && !R.is_component_functioning("radio"))
-		src << "\red Your radio isn't functional at this time."
-		return 0
-
-	switch(message_mode)
-		if("department")
-			switch(bot_type)
-				if(IS_AI)
-					return AI.holopad_talk(message, verb, speaking)
-				if(IS_ROBOT)
-					log_say("[key_name(src)] : [message]")
-					return R.radio.talk_into(src,message,message_mode,verb,speaking)
-				if(IS_PAI)
-					log_say("[key_name(src)] : [message]")
-					return P.radio.talk_into(src,message,message_mode,verb,speaking)
-			return 0
-
-		if("general")
-			switch(bot_type)
-				if(IS_AI)
-					if (AI.aiRadio.disabledAi || AI.aiRestorePowerRoutine || AI.stat)
-						src << "\red System Error - Transceiver Disabled"
-						return 0
-					else
-						log_say("[key_name(src)] : [message]")
-						return AI.aiRadio.talk_into(src,message,null,verb,speaking)
-				if(IS_ROBOT)
-					log_say("[key_name(src)] : [message]")
-					return R.radio.talk_into(src,message,null,verb,speaking)
-				if(IS_PAI)
-					log_say("[key_name(src)] : [message]")
-					return P.radio.talk_into(src,message,null,verb,speaking)
-			return 0
-
-		else
-			if(message_mode)
-				switch(bot_type)
-					if(IS_AI)
-						if (AI.aiRadio.disabledAi || AI.aiRestorePowerRoutine || AI.stat)
-							src << "\red System Error - Transceiver Disabled"
-							return 0
-						else
-							log_say("[key_name(src)] : [message]")
-							return AI.aiRadio.talk_into(src,message,message_mode,verb,speaking)
-					if(IS_ROBOT)
-						log_say("[key_name(src)] : [message]")
-						return R.radio.talk_into(src,message,message_mode,verb,speaking)
-					if(IS_PAI)
-						log_say("[key_name(src)] : [message]")
-						return P.radio.talk_into(src,message,message_mode,verb,speaking)
-				return 0
-
-	return ..(message,speaking,verb)
 
 //For holopads only. Usable by AI.
 /mob/living/silicon/ai/proc/holopad_talk(var/message, verb, datum/language/speaking)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -544,21 +544,10 @@
 	gib()
 	return
 
-/mob/living/simple_animal/say(var/message,var/datum/language/speaking,var/verb)
-	if(stat)
-		return
-
-	if(copytext(message,1,2) == "*")
-		return emote(copytext(message,2))
-
-	if(stat)
-		return
-
-	verb = "says"
+/mob/living/simple_animal/say(var/message)
+	var/verb = "says"
 
 	if(speak_emote.len)
 		verb = pick(speak_emote)
 
-	message = capitalize(trim_left(message))
-
-	..(message, speaking, verb)
+	..(message, null, verb)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -81,14 +81,6 @@
 
 	return 0
 
-/*
-   ***Deprecated***
-   let this be handled at the hear_say or hear_radio proc
-   This is left in for robot speaking when humans gain binary channel access until I get around to rewriting
-   robot_talk() proc.
-   There is no language handling build into it however there is at the /mob level so we accept the call
-   for it but just ignore it.
-*/
 
 /mob/proc/say_quote(var/message, var/datum/language/speaking = null)
         var/verb = "says"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1270,6 +1270,7 @@
 #include "code\modules\mob\dead\observer\observer.dm"
 #include "code\modules\mob\dead\observer\say.dm"
 #include "code\modules\mob\dead\observer\spells.dm"
+#include "code\modules\mob\living\autohiss.dm"
 #include "code\modules\mob\living\bloodcrawl.dm"
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\default_language.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1415,6 +1415,7 @@
 #include "code\modules\mob\living\silicon\robot\drone\drone_damage.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_items.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_manufacturer.dm"
+#include "code\modules\mob\living\silicon\robot\drone\drone_say.dm"
 #include "code\modules\mob\living\simple_animal\bees.dm"
 #include "code\modules\mob\living\simple_animal\borer.dm"
 #include "code\modules\mob\living\simple_animal\constructs.dm"


### PR DESCRIPTION
First off, this PR updates most of language code to baystation code. See 11aeb63 for more details. This is necessary for autohiss to work.

Secondly, this adds a new "auto-hiss" system.
Baystation12/Baystation12#10980
>This commit adds a system (fully client-toggled) to allow unathi and
tajaran to "auto-hiss". This means that, for unathi, "S" will be
automatically extended to "Ss", "Sss", or "Ssss". Which one it changes is
based on a random pick().

>There are three modes, off, basic, full.
Off, is obviously, off. It does nothing. This is the default setting.
Basic, for unathi, enables the S extensions, and for tajaran, enables the
"R" extending.
Full, for unathi, enables the S extensions, alongside replacing "X" with
"Ks". It does not currently do anything extra for Tajaran.

>Sinta'Unathi is unaffected for Unathi, Siik'Tajr is unaffected for
Tajaran.

>On baystation, NO_STUTTER languages would also be unaffected (the noise
language). However, we do not have NO_STUTTER languages. So it hilariously
does affect the noise language. "Zartulnal Hharar dancess."

Basically, it allows players to <i>choose</i> to have the automatic purring or S extending, for convenience. 