### PR TITLE
Botany Fixes

### DIFF
--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -148,3 +148,10 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 
 /datum/controller/plants/proc/remove_plant(var/obj/effect/plant/plant)
 	plant_queue -= plant
+
+/client/proc/list_plant_sprites()
+	if(!plant_controller || !plant_controller.plant_sprites || !plant_controller.plant_sprites.len)
+		world << "Cannot list plant sprites, plant controller or plant sprites list may not be initialized."
+
+	for(var/base in plant_controller.plant_sprites)
+		world << "[base] : [plant_controller.plant_sprites[base]] growth states"

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -43,10 +43,11 @@
 	kitchen_tag = "ghostchili"
 	preset_icon = "ghostchilipepper"
 
-/datum/seed/chili/ice/New()
+/datum/seed/chili/ghost/New()
 	..()
-	set_trait(TRAIT_MATURATION,4)
-	set_trait(TRAIT_PRODUCTION,4)
+	set_trait(TRAIT_MATURATION,10)
+	set_trait(TRAIT_PRODUCTION,10)
+	set_trait(TRAIT_YIELD,3)
 	set_trait(TRAIT_PRODUCT_COLOUR,"#00EDC6")
 
 // Berry plants/variants.

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -133,6 +133,8 @@
 		)
 	//--FalseIncarnate
 
+	var/last_plant_ikey		//This is for debugging reference, and is otherwise useless. --FalseIncarnate
+
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
 	if(mechanical && !usr.stat && !usr.lying && Adjacent(usr))
 		close_lid(usr)

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -36,7 +36,9 @@
 			if(age >= seed.get_trait(TRAIT_MATURATION))
 				overlay_stage = seed.growth_stages
 			else
-				var/maturation = round(seed.get_trait(TRAIT_MATURATION)/seed.growth_stages)
+				var/maturation = seed.get_trait(TRAIT_MATURATION)/seed.growth_stages
+				if(maturation < 1)
+					maturation = 1
 				overlay_stage = maturation ? max(1,round(age/maturation)) : 1
 			var/ikey = "[seed.get_trait(TRAIT_PLANT_ICON)]-[overlay_stage]"
 			var/image/plant_overlay = plant_controller.plant_icon_cache["[ikey]-[seed.get_trait(TRAIT_PLANT_COLOUR)]"]
@@ -45,6 +47,7 @@
 				plant_overlay.color = seed.get_trait(TRAIT_PLANT_COLOUR)
 				plant_controller.plant_icon_cache["[ikey]-[seed.get_trait(TRAIT_PLANT_COLOUR)]"] = plant_overlay
 			overlays |= plant_overlay
+			last_plant_ikey = ikey
 
 			if(harvest && overlay_stage == seed.growth_stages)
 				ikey = "[seed.get_trait(TRAIT_PRODUCT_ICON)]"


### PR DESCRIPTION
Fixes invisible plant sprites
- Fixes #1970 
- Was caused by overly-rounded math resulting in the plant overlay attempting to use growth states that did not exist.

Fixes Ghost Peppers missing their New() proc
- Fixes #1987 
- Ghost Peppers now have maturation 10 (was 4), production 10 (was 4), and yield 3 (was 4)

==== BORING CODER STUFF BEYOND THIS POINT! ====

Adds a new var to hydroponics trays: last_plant_ikey
- Useful for debugging by listing the name of the last plant sprite used for the overlay

Adds a new client proc (accessible via advanced proc call only) : list_plant_sprites
- Prints all the plant sprites and the number of growth states each has (excluding dead state)
 - For debugging purposes only, prints to world, meaning it spams everyone (don't use on live code!)