### PR TITLE
Reagents Performance and Garbage Collection

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -628,6 +628,7 @@ atom/proc/create_reagents(var/max_vol)
 	reagents.my_atom = src
 
 /datum/reagents/Destroy()
+	..()
 	processing_objects.Remove(src)
 	for(var/datum/reagent/R in reagent_list)
 		qdel(R)
@@ -635,4 +636,4 @@ atom/proc/create_reagents(var/max_vol)
 	reagent_list = null
 	if(my_atom && my_atom.reagents == src)
 		my_atom.reagents = null
-	return ..()
+	return QDEL_HINT_QUEUE

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -214,11 +214,12 @@
 		on_reaction(var/datum/reagents/holder)
 			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 				O.show_message(text("\red The slime extract begins to vibrate violently !"), 1)
-			sleep(50)
-			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
-			for(var/mob/living/M in range (get_turf(holder.my_atom), 7))
-				M.bodytemperature -= 140
-				M << "\blue You feel a chill!"
+			spawn(50)
+				if(holder && holder.my_atom)
+					playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+					for(var/mob/living/M in range (get_turf(holder.my_atom), 7))
+						M.bodytemperature -= 140
+						M << "\blue You feel a chill!"
 
 //Orange
 	slimecasp
@@ -242,10 +243,11 @@
 			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
 			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 				O.show_message(text("\red The slime extract begins to vibrate violently !"), 1)
-			sleep(50)
-			var/turf/simulated/T = get_turf(holder.my_atom)
-			if(istype(T))
-				T.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 50)
+			spawn(50)
+				if(holder && holder.my_atom)
+					var/turf/simulated/T = get_turf(holder.my_atom)
+					if(istype(T))
+						T.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 50)
 
 //Yellow
 	slimeoverload
@@ -387,8 +389,9 @@
 		on_reaction(var/datum/reagents/holder)
 			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
 				O.show_message(text("\red The slime extract begins to vibrate violently !"), 1)
-			sleep(50)
-			explosion(get_turf(holder.my_atom), 1 ,3, 6)
+			spawn(50)
+				if(holder && holder.my_atom)
+					explosion(get_turf(holder.my_atom), 1 ,3, 6)
 //Light Pink
 	slimepotion2
 		name = "Slime Potion 2"

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -78,5 +78,6 @@
 	return
 
 /datum/reagent/Destroy()
+	..()
 	holder = null
-	return ..()
+	return QDEL_HINT_QUEUE


### PR DESCRIPTION
Alright, so, I've been working on a side project from TG---on TG it performs and handles just 100% fine; it doesn't lag the server or anything.

On our server, however, it freezes the server for like 20+ seconds....either case, this was unacceptable---still, I wanted to figure out what was causing it.

In any event, everything checked out except one thing: Reagents. Turns out Del()'ing them is incredibly expensive (not surprising). In any event, I tried making them actually be attempted to be soft GC'd as opposed to hard Del()'d and well, the project I was working on became buttery smooth.

Krausus always warned us that we should assume that GC'ing datums is unsafe, by default, but that if we were to attempt to GC them, we should only pass *specific* datums through the GC.

That's what this PR does; I've tested GC'ing *ALL* datums before, and generally speaking, atmos datums don't play nice, but reagents play VERY nice and I haven't noticed them *not* GC.

We really can't get accurate data on this without at least demoing it for a little while and keeping an eye on any odd reagent behaviors in addition to routinely checking the GC profiler for failures of reagents to GC.

Why is this so important? Well, lots of things have reagents in them and clear those reagents when they themselves are qdel()'d---meaning that a lot of objects are actually decently expensive to delete because of how costly it is to delete reagents (even if they, themselves, GC just fine and very quickly, reagents aside).

Performance Stats (Del() first, then qdel() of reagents):

http://hastebin.com/ayeradanix.vhdl

Full Reports
Del()ing Reagents: http://hastebin.com/kopehodera.pl
qdel()ing Reagents: http://hastebin.com/aqerusewoy.vhdl

Notice how Del()ing reagents cascades through everything.

This isn't a completely realistic simulation (as this created+deleted every object in the game, quickly, but this performance impact would still hold true when played out over hundreds of items being deleted across a round).


Other:
- Some slime reagents now use spawn()'s and sanity as opposed to sleeps.

Would like @tigercat2000 to review this before merging it in.

