### PR TITLE
Tech Shells: Silver Removal

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -190,7 +190,7 @@
 	id = "techshotshell"
 	req_tech = list("combat" = 3, "materials" = 3, "powerstorage" = 4, "magnets" = 3)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 200, MAT_SILVER = 300)
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 200)
 	build_path = /obj/item/ammo_casing/shotgun/techshell
 	category = list("Weapons")
 


### PR DESCRIPTION
Ports: https://github.com/tgstation/-tg-station/pull/11735

Simply put, even with the removal of silver, this really doesn't give that much of a boost to tech shells; most of the shells R&D and cargo can already produce in the protolathe and autolathe are better than the tech shells you can create that don't require rare resources.