### PR TITLE
Display case update

### DIFF
--- a/code/controllers/Processes/alarm.dm
+++ b/code/controllers/Processes/alarm.dm
@@ -1,6 +1,7 @@
 // We manually initialize the alarm handlers instead of looping over all existing types
 // to make it possible to write: camera.triggerAlarm() rather than alarm_manager.managers[datum/alarm_handler/camera].triggerAlarm() or a variant thereof.
 /var/global/datum/alarm_handler/atmosphere/atmosphere_alarm	= new()
+/var/global/datum/alarm_handler/burglar/burglar_alarm		= new()
 /var/global/datum/alarm_handler/camera/camera_alarm			= new()
 /var/global/datum/alarm_handler/fire/fire_alarm				= new()
 /var/global/datum/alarm_handler/motion/motion_alarm			= new()
@@ -15,7 +16,7 @@ var/datum/controller/process/alarm/alarm_manager
 /datum/controller/process/alarm/setup()
 	name = "alarm"
 	schedule_interval = 20 // every 2 seconds
-	all_handlers = list(atmosphere_alarm, camera_alarm, fire_alarm, motion_alarm, power_alarm)
+	all_handlers = list(atmosphere_alarm, burglar_alarm, camera_alarm, fire_alarm, motion_alarm, power_alarm)
 	alarm_manager = src
 
 /datum/controller/process/alarm/doWork()

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -92,3 +92,10 @@
  * Parameters: var/obj/structure/closet/crate/sold, var/area/shuttle
  */
 /hook/sell_crate
+
+/**
+ * Captain spawned hook.
+ * Called in supervisor.dm when a captain spawns
+ * Parameters: var/mob/living/carbon/human/captain
+ */
+/hook/captain_spawned

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -108,6 +108,31 @@
 		updateicon()
 		mouse_opacity = 0
 		air_doors_open()
+		
+	return
+
+/area/proc/burglaralert(var/obj/trigger)
+	if(always_unpowered == 1) //no burglar alarms in space/asteroid
+		return
+
+	//Trigger alarm effect
+	set_fire_alarm_effect()
+	
+	//Lockdown airlocks
+	for(var/obj/machinery/door/airlock/A in src)
+		spawn(0)
+			A.close()
+			if(A.density)
+				A.lock()
+
+	burglar_alarm.triggerAlarm(src, trigger)
+	spawn(600)
+		burglar_alarm.clearAlarm(src, trigger)
+				
+/area/proc/set_fire_alarm_effect()
+	fire = 1
+	updateicon()
+	mouse_opacity = 0
 					
 /area/proc/readyalert()
 	if(!eject)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -342,7 +342,7 @@ its easier to just keep the beam vertical.
 			fingerprints = list()
 
 		//Hash this shit.
-		var/full_print = md5(H.dna.uni_identity)
+		var/full_print = H.get_full_print()
 
 		// Add the fingerprints
 		fingerprints[full_print] = full_print

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -42,6 +42,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 		var/obj/item/organ/external/affected = H.organs_by_name["head"]
 		affected.implants += L
 		L.part = affected
+		callHook("captain_spawned", list("captain" = H))
 		return 1
 
 	get_access()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -238,6 +238,7 @@ FIRE ALARM
 	if (!( src.working ))
 		return
 	var/area/A = get_area(src)
+	A.fire_reset()
 	for(var/obj/machinery/firealarm/FA in A)
 		fire_alarm.clearAlarm(loc, FA)
 	return

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -186,7 +186,7 @@ var/global/list/captain_display_cases = list()
 	if(burglar_alarm)
 		var/area/alarmed = get_area(src)
 		alarmed.burglaralert(src)
-		visible_message("<span class='notice'>The burglar alarm goes off!</span>")
+		visible_message("<span class='danger'>The burglar alarm goes off!</span>")
 		return 1
 	return 0
 			

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -63,7 +63,7 @@
 	handle_rotation()
 	if(pulling) // Driver
 		if(pulling.loc == src.loc) // We moved onto the wheelchair? Revert!
-			pulling.loc = T
+			pulling.forceMove(T)
 		else
 			spawn(0)
 			if(get_dist(src, pulling) > 1) // We are too far away? Losing control.
@@ -95,7 +95,7 @@
 				pulling = null
 		else
 			if (occupant && (src.loc != occupant.loc))
-				src.loc = occupant.loc // Failsafe to make sure the wheelchair stays beneath the occupant after driving
+				forceMove(occupant.loc) // Failsafe to make sure the wheelchair stays beneath the occupant after driving
 	handle_rotation()
 
 /obj/structure/stool/bed/chair/wheelchair/attack_hand(mob/user as mob)

--- a/code/modules/alarm/burglar_alarm.dm
+++ b/code/modules/alarm/burglar_alarm.dm
@@ -1,0 +1,2 @@
+/datum/alarm_handler/burglar
+	category = "Burglar Alarms"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -27,7 +27,7 @@
 	if(!istype(W))
 		return 0
 	if(!l_hand)
-		W.loc = src		//TODO: move to equipped?
+		W.forceMove(src)		//TODO: move to equipped?
 		l_hand = W
 		W.layer = 20	//TODO: move to equipped?
 //		l_hand.screen_loc = ui_lhand
@@ -45,7 +45,7 @@
 	if(!istype(W))
 		return 0
 	if(!r_hand)
-		W.loc = src
+		W.forceMove(src)
 		r_hand = W
 		W.layer = 20
 //		r_hand.screen_loc = ui_rhand
@@ -71,7 +71,7 @@
 //This is probably the main one you need to know :)
 //Just puts stuff on the floor for most mobs, since all mobs have hands but putting stuff in the AI/corgi/ghost hand is VERY BAD.
 /mob/proc/put_in_hands(obj/item/W)
-	W.loc = get_turf(src)
+	W.forceMove(get_turf(src))
 	W.layer = initial(W.layer)
 	W.dropped()
 
@@ -114,7 +114,7 @@
 	if(I)
 		if(client)
 			client.screen -= I
-		I.loc = loc
+		I.forceMove(loc)
 		I.dropped(src)
 		if(I)
 			I.layer = initial(I.layer)
@@ -249,13 +249,13 @@
 			if (src.back && istype(src.back, /obj/item/weapon/storage/backpack))
 				var/obj/item/weapon/storage/backpack/B = src.back
 				if(B.contents.len < B.storage_slots && W.w_class <= B.max_w_class)
-					W.loc = B
+					W.forceMove(B)
 					equipped = 1
 
 	if(equipped)
 		W.layer = 20
 		if(src.back && W.loc != src.back)
-			W.loc = src
+			W.forceMove(src)
 	else
 		if (del_on_fail)
 			qdel(W)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1781,7 +1781,7 @@
 	var/protection = (prot["head"] + prot["arms"] + prot["feet"] + prot["legs"] + prot["groin"] + prot["chest"] + prot["hands"])/7
 	return protection
 	
-/mob/living/carbon/human/proc/get_print()
-	if(!dna)
-		return 0
+/mob/living/carbon/human/proc/get_full_print()
+	if(!dna || !dna.uni_identity)
+		return
 	return md5(dna.uni_identity)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1780,3 +1780,8 @@
 			prot["head"] = max(1 - I.permeability_coefficient, prot["head"])
 	var/protection = (prot["head"] + prot["arms"] + prot["feet"] + prot["legs"] + prot["groin"] + prot["chest"] + prot["hands"])/7
 	return protection
+	
+/mob/living/carbon/human/proc/get_print()
+	if(!dna)
+		return 0
+	return md5(dna.uni_identity)

--- a/code/modules/mob/living/silicon/subsystems.dm
+++ b/code/modules/mob/living/silicon/subsystems.dm
@@ -41,7 +41,7 @@
 	if(!register_alarms)
 		return
 
-	var/list/register_to = list(atmosphere_alarm, camera_alarm, fire_alarm, motion_alarm, power_alarm)
+	var/list/register_to = list(atmosphere_alarm, burglar_alarm, camera_alarm, fire_alarm, motion_alarm, power_alarm)
 	for(var/datum/alarm_handler/AH in register_to)
 		AH.register(src, /mob/living/silicon/proc/receive_alarm)
 		queued_alarms[AH] = list()	// Makes sure alarms remain listed in consistent order

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1235,7 +1235,7 @@ mob/proc/yank_out_object()
 			var/mob/living/carbon/human/human_user = U
 			human_user.bloody_hands(H)
 
-	selection.loc = get_turf(src)
+	selection.forceMove(get_turf(src))
 	if(!(U.l_hand && U.r_hand))
 		U.put_in_hands(selection)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -170,7 +170,7 @@
 			if(!mob.control_object)	return
 			mob.control_object.dir = direct
 		else
-			mob.control_object.loc = get_step(mob.control_object,direct)
+			mob.control_object.forceMove(get_step(mob.control_object,direct))
 	return
 
 
@@ -391,7 +391,7 @@
 	var/mob/living/L = mob
 	switch(L.incorporeal_move)
 		if(1)
-			L.loc = get_step(L, direct)
+			L.forceMove(get_step(L, direct))
 			L.dir = direct
 		if(2)
 			if(prob(50))
@@ -420,7 +420,7 @@
 							return
 					else
 						return
-				L.loc = locate(locx,locy,mobloc.z)
+				L.forceMove(locate(locx,locy,mobloc.z))
 				spawn(0)
 					var/limit = 2//For only two trailing shadows.
 					for(var/turf/T in getline(mobloc, L.loc))
@@ -431,7 +431,7 @@
 			else
 				spawn(0)
 					anim(mobloc,mob,'icons/mob/mob.dmi',,"shadow",,L.dir)
-				L.loc = get_step(L, direct)
+				L.forceMove(get_step(L, direct))
 			L.dir = direct
 		if(3) //Incorporeal move, but blocked by holy-watered tiles
 			var/turf/simulated/floor/stepTurf = get_step(L, direct)
@@ -441,7 +441,7 @@
 				spawn(2)
 					L.notransform = 0
 			else
-				L.loc = get_step(L, direct)
+				L.forceMove(get_step(L, direct))
 				L.dir = direct
 	return 1
 

--- a/code/modules/nano/modules/alarm_monitor.dm
+++ b/code/modules/nano/modules/alarm_monitor.dm
@@ -5,7 +5,7 @@
 
 /datum/nano_module/alarm_monitor/all/New()
 	..()
-	alarm_handlers = list(atmosphere_alarm, camera_alarm, fire_alarm, motion_alarm, power_alarm)
+	alarm_handlers = list(atmosphere_alarm, burglar_alarm, camera_alarm, fire_alarm, motion_alarm, power_alarm)
 
 /datum/nano_module/alarm_monitor/engineering/New()
 	..()
@@ -13,7 +13,7 @@
 
 /datum/nano_module/alarm_monitor/security/New()
 	..()
-	alarm_handlers = list(camera_alarm, motion_alarm)
+	alarm_handlers = list(burglar_alarm, camera_alarm, motion_alarm)
 
 /datum/nano_module/alarm_monitor/proc/register(var/object, var/procName)
 	for(var/datum/alarm_handler/AH in alarm_handlers)

--- a/paradise.dme
+++ b/paradise.dme
@@ -953,6 +953,7 @@
 #include "code\modules\alarm\alarm.dm"
 #include "code\modules\alarm\alarm_handler.dm"
 #include "code\modules\alarm\atmosphere_alarm.dm"
+#include "code\modules\alarm\burglar_alarm.dm"
 #include "code\modules\alarm\camera_alarm.dm"
 #include "code\modules\alarm\fire_alarm.dm"
 #include "code\modules\alarm\motion_alarm.dm"


### PR DESCRIPTION
Changes:
1) Implements /tg/'s display case burglar alarm: if you break a display case by hitting it, a burglar alarm will trigger in the area of the display case. This will cause a fire alarm effect in the area and bolt down all doors, and will send an alarm message to all alarm consoles/AI's/cyborgs similar to motion alarms. This should make stealing the captain's antique laser gun a bit more tricky.
2) The captain's display case will now automatically have its fingerprints set to the captain when they spawn.
3) Also adds some forceMove()s based on Bay.