### PR TITLE
Reduce computer lights, air alarm fix

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -164,7 +164,7 @@
 				"plasma"         = new/datum/tlv(-1.0, -1.0, 0.2, 0.5), // Partial pressure, kpa
 				"other"          = new/datum/tlv(-1.0, -1.0, 0.5, 1.0), // Partial pressure, kpa
 				"pressure"       = new/datum/tlv(ONE_ATMOSPHERE*0.80,ONE_ATMOSPHERE*0.90,ONE_ATMOSPHERE*1.50,ONE_ATMOSPHERE*1.60), /* kpa */
-				"temperature"    = new/datum/tlv(T0C-40, T0C-20, T0C, T20C), // K
+				"temperature"    = new/datum/tlv(T0C-50, T0C-20, T0C, T20C), // K
 			)
 		if(AALARM_PRESET_SERVER)
 			TLV = list(

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -11,8 +11,8 @@
 	var/processing = 0
 	var/icon_keyboard = "generic_key"
 	var/icon_screen = "generic"
-	var/light_range_on = 3
-	var/light_power_on = 2
+	var/light_range_on = 2
+	var/light_power_on = 1
 	var/overlay_layer
 	atom_say_verb = "beeps"
 


### PR DESCRIPTION
Changes:
1) Reduces the light on computers back to their pre-https://github.com/ParadiseSS13/Paradise/pull/2048 state. That change brought them back to the level where they emit their colored lighting *way* too brightly, which looks terrible.
2) Adjusts the min2 of the server room atmosphere alarm so the server room doesn't jump into caution.