### PR TITLE
Update additional law channel handling, debug fix

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -30,7 +30,7 @@
 		diary << "\[[time_stamp()]]DEBUG: [text]"
 
 	for(var/client/C in admins)
-		if(C.prefs.toggles & CHAT_DEBUGLOGS)
+		if(check_rights(R_DEBUG, 0, C.mob) && (C.prefs.toggles & CHAT_DEBUGLOGS))
 			C << "DEBUG: [text]"
 
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -130,8 +130,8 @@ var/list/ai_verbs_default = list(
 	aiRadio = new(src)
 	common_radio = aiRadio
 	aiRadio.myAi = src
-	additional_law_channels += "Binary"
-	additional_law_channels += "Holopad"
+	additional_law_channels["Binary"] = ":b"
+	additional_law_channels["Holopad"] = ":h"
 
 	aiCamera = new/obj/item/device/camera/siliconcam/ai_camera(src)
 

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon
 	var/datum/ai_laws/laws = null
-	var/list/additional_law_channels = list("State")
+	var/list/additional_law_channels = list("State" = "")
 
 /mob/living/silicon/proc/laws_sanity_check()
 	if (!src.laws)
@@ -59,11 +59,12 @@
 
 /mob/living/silicon/proc/statelaws(var/datum/ai_laws/laws)
 	var/prefix = ""
-	switch(lawchannel)
-		if(MAIN_CHANNEL) prefix = ";"
-		if("Binary") prefix = ":b "
-		else
-			prefix = get_radio_key_from_channel(lawchannel == "Holopad" ? "department" : lawchannel) + " "
+	if(MAIN_CHANNEL == lawchannel)
+		prefix = ";"
+	else if(lawchannel in additional_law_channels)
+		prefix = additional_law_channels[lawchannel]
+	else
+		prefix = get_radio_key_from_channel(lawchannel)
 
 	dostatelaws(lawchannel, prefix, laws)
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -75,6 +75,8 @@
 	connected_ai = null
 
 	aiCamera = new/obj/item/device/camera/siliconcam/drone_camera(src)
+	additional_law_channels["Drone"] = ":d"
+	
 	playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 0)
 
 //Redefining some robot procs...

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -152,7 +152,7 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/proc/init(var/alien=0)
 	aiCamera = new/obj/item/device/camera/siliconcam/robot_camera(src)
 	make_laws()
-	additional_law_channels += "Binary"
+	additional_law_channels["Binary"] = ":b"
 	var/new_ai = select_active_ai_with_fewest_borgs()
 	if(new_ai)
 		lawupdate = 1


### PR DESCRIPTION
Changes:
1) Makes additional law channel handling more flexible. Ported from Bay (by PsiOmegaDelta): https://github.com/Baystation12/Baystation12/pull/11124.
2) Adds a rights check to the debug messaging, so only admins with R_DEBUG can view it. Fixes https://github.com/ParadiseSS13/Paradise/issues/1958.