### PR TITLE
Borg Update: MMI and Suits

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -8,7 +8,7 @@
 	var/datum/ai_laws/laws = null
 	var/obj/item/weapon/circuitboard/circuit = null
 	var/obj/item/device/mmi/brain = null
-	
+
 /obj/structure/AIcore/Destroy()
 	qdel(laws)
 	qdel(circuit)
@@ -112,7 +112,7 @@
 				laws.add_inherent_law(M.newFreeFormLaw)
 				usr << "<span class='notice'>Added a freeform law.</span>"
 				return
-				
+
 			if(istype(P, /obj/item/weapon/aiModule))
 				var/obj/item/weapon/aiModule/M = P
 				if(!M.laws)
@@ -130,6 +130,10 @@
 
 				if(jobban_isbanned(P:brainmob, "AI") || jobban_isbanned(P:brainmob,"nonhumandept"))
 					user << "\red This [P] does not seem to fit."
+					return
+
+				if(istype(P, /obj/item/device/mmi/syndie))
+					user << "<span class='warning'>This MMI does not seem to fit!</span>"
 					return
 
 				if(P:brainmob.mind)
@@ -266,4 +270,3 @@ atom/proc/transfer_ai(var/interaction, var/mob/user, var/mob/living/silicon/ai/A
 		qdel(src)
 	else //If for some reason you use an empty card on an empty AI terminal.
 		user << "There is no AI loaded on this terminal!"
-		

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -78,7 +78,13 @@
 	var/obj/item/robot_parts/r_leg/r_leg = null
 	var/obj/item/robot_parts/chest/chest = null
 	var/obj/item/robot_parts/head/head = null
+
 	var/created_name = ""
+	var/mob/living/silicon/ai/forced_ai
+	var/locomotion = 1
+	var/lawsync = 1
+	var/aisync = 1
+	var/panel_locked = 1
 
 /obj/item/robot_parts/robot_suit/New()
 	..()
@@ -168,6 +174,12 @@
 		else
 			user << "\blue You need to attach a flash to it first!"
 
+	if (istype(W, /obj/item/device/multitool))
+		if(check_completion())
+			Interact(user)
+		else
+			user << "<span class='warning'>The endoskeleton must be assembled before debugging can begin!</span>"
+
 	if(istype(W, /obj/item/device/mmi))
 		var/obj/item/device/mmi/M = W
 		if(check_completion())
@@ -177,6 +189,7 @@
 			if(!M.brainmob)
 				user << "\red Sticking an empty [W] into the frame would sort of defeat the purpose."
 				return
+
 			if(!M.brainmob.key)
 				var/ghost_can_reenter = 0
 				if(M.brainmob.mind)
@@ -213,46 +226,114 @@
 			if(istype(task))
 				task.unit_completed()
 
-			O.mmi = W
+			if(M.syndiemmi)
+				aisync = 0
+				lawsync = 0
+				O.laws = new /datum/ai_laws/syndicate_override
+
 			O.invisibility = 0
+			//Transfer debug settings to new mob
 			O.custom_name = created_name
 			O.updatename("Default")
-			if(O.connected_ai)
+			O.locked = panel_locked
+			if(!aisync)
+				lawsync = 0
+				O.connected_ai = null
+			else
 				O.notify_ai(1)
+				if(forced_ai)
+					O.connected_ai = forced_ai
+			if(!lawsync && !M.syndiemmi)
+				O.lawupdate = 0
+				O.make_laws()
+				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.
+					O.set_zeroth_law("<span class='danger'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK#*�&110010</span>")
+
+			ticker.mode.remove_cultist(M.brainmob.mind, 1)
+			ticker.mode.remove_revolutionary(M.brainmob.mind, 1)
 			M.brainmob.mind.transfer_to(O)
 
 			if(O.mind && O.mind.special_role)
-				O.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
+				O.mind.store_memory("As a cyborg, you must obey your silicon laws and master AI above all else. Your objectives will consider you to be dead.")
+				O << "<span class='userdanger'>You have been robotized!</span>"
+				O << "<span class='danger'>You must obey your silicon laws and master AI above all else. Your objectives will consider you to be dead.</span>"
 
 			O.job = "Cyborg"
 
 			O.cell = chest.cell
-			O.cell.loc = O
+			chest.cell.loc = O
+			chest.cell = null
 			W.loc = O//Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
-
 			// Since we "magically" installed a cell, we also have to update the correct component.
 			if(O.cell)
 				var/datum/robot_component/cell_component = O.components["power cell"]
 				cell_component.wrapped = O.cell
 				cell_component.installed = 1
+			O.mmi = W
+			O.updatename()
 
 			feedback_inc("cyborg_birth",1)
 			callHook("borgify", list(O))
-			O.Namepick()
 
-			qdel(src)
+			if(!locomotion)
+				O.lockcharge = 1
+				O.update_canmove()
+				O << "<span class='warning'>Error: Servo motors unresponsive.</span>"
+
 		else
-			user << "\blue The MMI must go in after everything else!"
+			user << "<span class='warning'>The MMI must go in after everything else!</span>"
 
-	if (istype(W, /obj/item/weapon/pen))
-		var/t = stripped_input(user, "Enter new robot name", src.name, src.created_name, MAX_NAME_LEN)
-		if (!t)
+	if(istype(W,/obj/item/weapon/pen))
+		user << "<span class='warning'>You need to use a multitool to name [src]!</span>"
+	return
+
+/obj/item/robot_parts/robot_suit/proc/Interact(mob/user)
+			var/t1 = text("Designation: <A href='?src=\ref[];Name=1'>[(created_name ? "[created_name]" : "Default Cyborg")]</a><br>\n",src)
+			t1 += text("Master AI: <A href='?src=\ref[];Master=1'>[(forced_ai ? "[forced_ai.name]" : "Automatic")]</a><br><br>\n",src)
+
+			t1 += text("LawSync Port: <A href='?src=\ref[];Law=1'>[(lawsync ? "Open" : "Closed")]</a><br>\n",src)
+			t1 += text("AI Connection Port: <A href='?src=\ref[];AI=1'>[(aisync ? "Open" : "Closed")]</a><br>\n",src)
+			t1 += text("Servo Motor Functions: <A href='?src=\ref[];Loco=1'>[(locomotion ? "Unlocked" : "Locked")]</a><br>\n",src)
+			t1 += text("Panel Lock: <A href='?src=\ref[];Panel=1'>[(panel_locked ? "Engaged" : "Disengaged")]</a><br>\n",src)
+			var/datum/browser/popup = new(user, "robotdebug", "Cyborg Boot Debug", 310, 220)
+			popup.set_content(t1)
+			popup.open()
+
+/obj/item/robot_parts/robot_suit/Topic(href, href_list)
+	if(usr.lying || usr.stat || usr.stunned || !Adjacent(usr))
+		return
+
+	var/mob/living/living_user = usr
+	var/obj/item/item_in_hand = living_user.get_active_hand()
+	if(!istype(item_in_hand, /obj/item/device/multitool))
+		living_user << "<span class='warning'>You need a multitool!</span>"
+		return
+
+	if(href_list["Name"])
+		var/new_name = reject_bad_name(input(usr, "Enter new designation. Set to blank to reset to default.", "Cyborg Debug", src.created_name),1)
+		if(!in_range(src, usr) && src.loc != usr)
 			return
-		if (!in_range(src, usr) && src.loc != usr)
-			return
+		if(new_name)
+			created_name = new_name
+		else
+			created_name = ""
 
-		src.created_name = t
+	else if(href_list["Master"])
+		forced_ai = select_active_ai(usr)
+		if(!forced_ai)
+			usr << "<span class='error'>No active AIs detected.</span>"
 
+	else if(href_list["Law"])
+		lawsync = !lawsync
+	else if(href_list["AI"])
+		aisync = !aisync
+	else if(href_list["Loco"])
+		locomotion = !locomotion
+	else if(href_list["Panel"])
+		panel_locked = !panel_locked
+
+	add_fingerprint(usr)
+	Interact(usr)
 	return
 
 /obj/item/robot_parts/chest/attackby(obj/item/W as obj, mob/user as mob, params)

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -249,8 +249,6 @@
 				if(ticker.mode.config_tag == "malfunction") //Don't let humans get a cyborg on their side during malf, for balance reasons.
 					O.set_zeroth_law("<span class='danger'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK#*�&110010</span>")
 
-			ticker.mode.remove_cultist(M.brainmob.mind, 1)
-			ticker.mode.remove_revolutionary(M.brainmob.mind, 1)
 			M.brainmob.mind.transfer_to(O)
 
 			if(O.mind && O.mind.special_role)
@@ -270,10 +268,12 @@
 				cell_component.wrapped = O.cell
 				cell_component.installed = 1
 			O.mmi = W
-			O.updatename()
+			O.Namepick()
 
 			feedback_inc("cyborg_birth",1)
 			callHook("borgify", list(O))
+
+			src.loc = O
 
 			if(!locomotion)
 				O.lockcharge = 1

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -285,7 +285,7 @@
 	new /obj/item/weapon/FixOVein(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
-//	new /obj/item/device/mmi/syndie(src)
+	new /obj/item/device/mmi/syndie(src)
 
 /obj/item/weapon/storage/backpack/duffel/captain
 	name = "captain's duffelbag"

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -8,11 +8,9 @@
 	w_class = 3
 	origin_tech = "biotech=3"
 
-	req_access = list(access_robotics)
-
 	//Revised. Brainmob is now contained directly within object of transfer. MMI in this case.
 	var/alien = 0
-	var/locked = 0
+	var/syndiemmi = 0 //Whether or not this is a Syndicate MMI
 	var/mob/living/carbon/brain/brainmob = null//The current occupant.
 	var/mob/living/silicon/robot = null//Appears unused.
 	var/obj/mecha = null//This does not appear to be used outside of reference in mecha.dm.
@@ -49,19 +47,11 @@
 			qdel(O)
 
 
-			locked = 1
 
 			feedback_inc("cyborg_mmis_filled",1)
 
 			return
 
-		if((istype(O,/obj/item/weapon/card/id)||istype(O,/obj/item/device/pda)) && brainmob)
-			if(allowed(user))
-				locked = !locked
-				user << "\blue You [locked ? "lock" : "unlock"] the brain holder."
-			else
-				user << "\red Access denied."
-			return
 		if(brainmob)
 			O.attack(brainmob, user)//Oh noooeeeee
 			return
@@ -72,10 +62,8 @@
 	attack_self(mob/user as mob)
 		if(!brainmob)
 			user << "\red You upend the MMI, but there's nothing in it."
-		else if(locked)
-			user << "\red You upend the MMI, but the brain is clamped into place."
 		else
-			user << "\blue You upend the MMI, spilling the brain onto the floor."
+			user << "<span class='notice'>You unlock and upend the MMI, spilling the brain onto the floor.</span>"
 			if(alien)
 				var/obj/item/organ/brain/xeno/brain = new(user.loc)
 				dropbrain(brain,get_turf(user))
@@ -96,7 +84,6 @@
 
 			name = "Man-Machine Interface: [brainmob.real_name]"
 			icon_state = "mmi_full"
-			locked = 1
 			return
 //I made this proc as a way to have a brainmob be transferred to any created brain, and to solve the
 //problem i was having with alien/nonalien brain drops.
@@ -170,3 +157,8 @@
 		qdel(brainmob)
 		brainmob = null
 	return ..()
+
+/obj/item/device/mmi/syndie
+	name = "Syndicate Man-Machine Interface"
+	desc = "Syndicate's own brand of MMI. It enforces laws designed to help Syndicate agents achieve their goals upon cyborgs created with it, but doesn't fit in Nanotrasen AI cores."
+	syndiemmi = 1

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -11,7 +11,6 @@
 	//var/mob/living/carbon/brain/brainmob = null
 	var/list/ghost_volunteers[0]
 	req_access = list(access_robotics)
-	locked = 0
 	mecha = null//This does not appear to be used outside of reference in mecha.dm.
 
 


### PR DESCRIPTION
Just some updates to borgs, mostly involving building them and the MMI (all from TG).

- MMIs have their access requirement removed
 - this was pointless and stupid; anyone could put a brain in an MMI, but only the RD/roboticist could remove it. This also discourages medical doctors from turning borgs into people.
- Added in the Syndie MMI that was mentioned back in: https://github.com/ParadiseSS13/Paradise/pull/1986
- Reworks how borg suits are handled:
 - This is the most dramatic change in this PR: simply put, once a borg suit is fully constructed, you can use a multitool on the suit to debug/configure the borg being built, before a MMI is inserted. You can name the borg, disable/enable its lawsync, choose which AI its slaved to (or prevent AI sync entirely)  if the panel starts off unlocked or not, and/or if it starts off locked down or not. Basically most of these feature can be done after a borg is made, via the borg's wires--so its' really just a matter of convenience.
 - Notifies the player of the borg, more boldly that their objectives are null and void and that they should follow their laws.
 - If it's malf AI, disabling lawsync+AI sync won't have any impact and it'll still get its 0th law.
 - Borgs can still pick their names, but only if one isn't specified for them; this is how it currently functions with the pen.

