### PR TITLE
LOOC overhaul, stealthmin fixes

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -8,9 +8,6 @@ var/changelog_hash = ""
 var/game_year = (text2num(time2text(world.realtime, "YYYY")) + 544)
 
 var/aliens_allowed = 1
-var/ooc_allowed = 1
-var/dsay_allowed = 1
-var/dooc_allowed = 1
 var/traitor_scaling = 1
 //var/goonsay_allowed = 0
 var/dna_ident = 1

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -10,6 +10,7 @@ var/list/clients = list()							//list of all clients
 var/list/admins = list()							//list of all clients whom are admins
 var/list/deadmins = list()							//list of all clients who have used the de-admin verb.
 var/list/directory = list()							//list of all ckeys with associated client
+var/list/stealthminID = list()						//reference list with IDs that store ckeys, for stealthmins
 
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -164,6 +164,11 @@
 	var/disable_away_missions = 0 // disable away missions
 	
 	var/autoconvert_notes = 0 //if all connecting player's notes should attempt to be converted to the database
+	
+	var/ooc_allowed = 1
+	var/looc_allowed = 1
+	var/dooc_allowed = 1
+	var/dsay_allowed = 1
 
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
@@ -341,6 +346,16 @@
 
 				if ("guest_ban")
 					guests_allowed = 0
+					
+				if ("disable_ooc")
+					config.ooc_allowed = 0
+					config.looc_allowed = 0
+		
+				if ("disable_dead_ooc")
+					config.dooc_allowed = 0
+
+				if ("disable_dsay")
+					config.dsay_allowed = 0
 
 				if ("usewhitelist")
 					config.usewhitelist = 1

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -59,9 +59,9 @@ datum/controller/vote
 		voting.Cut()
 		current_votes.Cut()
 
-		if(auto_muted && !ooc_allowed)
+		if(auto_muted && !config.ooc_allowed)
 			auto_muted = 0
-			ooc_allowed = !( ooc_allowed )
+			config.ooc_allowed = !( config.ooc_allowed )
 			world << "<b>The OOC channel has been automatically enabled due to vote end.</b>"
 			log_admin("OOC was toggled automatically due to vote end.")
 			message_admins("OOC has been toggled on automatically.")
@@ -239,21 +239,21 @@ datum/controller/vote
 			if(mode == "gamemode" && going)
 				going = 0
 				world << "<font color='red'><b>Round start has been delayed.</b></font>"
-			if(mode == "crew_transfer" && ooc_allowed)
+			if(mode == "crew_transfer" && config.ooc_allowed)
 				auto_muted = 1
-				ooc_allowed = !( ooc_allowed )
+				config.ooc_allowed = !( config.ooc_allowed )
 				world << "<b>The OOC channel has been automatically disabled due to a crew transfer vote.</b>"
 				log_admin("OOC was toggled automatically due to crew_transfer vote.")
 				message_admins("OOC has been toggled off automatically.")
-			if(mode == "gamemode" && ooc_allowed)
+			if(mode == "gamemode" && config.ooc_allowed)
 				auto_muted = 1
-				ooc_allowed = !( ooc_allowed )
+				config.ooc_allowed = !( config.ooc_allowed )
 				world << "<b>The OOC channel has been automatically disabled due to the gamemode vote.</b>"
 				log_admin("OOC was toggled automatically due to gamemode vote.")
 				message_admins("OOC has been toggled off automatically.")
-			if(mode == "custom" && ooc_allowed)
+			if(mode == "custom" && config.ooc_allowed)
 				auto_muted = 1
-				ooc_allowed = !( ooc_allowed )
+				config.ooc_allowed = !( config.ooc_allowed )
 				world << "<b>The OOC channel has been automatically disabled due to a custom vote.</b>"
 				log_admin("OOC was toggled automatically due to custom vote.")
 				message_admins("OOC has been toggled off automatically.")

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -21,12 +21,13 @@
 	. = ""
 
 	if(key)
-		if(include_link && C)
-			. += "<a href='?priv_msg=\ref[C];type=[type]'>"
-
 		if(C && C.holder && C.holder.fakekey && !include_name)
+			if(include_link)
+				. += "<a href='?priv_msg=[C.findStealthKey()];type=[type]'>"
 			. += "Administrator"
 		else
+			if(include_link)
+				. += "<a href='?priv_msg=\ref[C];type=[type]'>"
 			. += key
 
 		if(include_link)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -5,32 +5,34 @@ var/global/moderator_ooc_colour = "#184880"
 var/global/admin_ooc_colour = "#b82e00"
 
 /client/verb/ooc(msg as text)
-	set name = "OOC" //Gave this shit a shorter name so you only have to time out "ooc" rather than "ooc message" to use it --NeoFite
+	set name = "OOC" 
 	set category = "OOC"
 
-	if(!mob)	return
+	if(!mob)	
+		return
 	if(IsGuestKey(key))
-		src << "Guests may not use OOC."
+		src << "<span class='danger'>Guests may not use OOC.</span>"
 		return
 
 	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
-	if(!msg)	return
+	if(!msg)	
+		return
 
 	if(!(prefs.toggles & CHAT_OOC))
-		src << "\red You have OOC muted."
+		src << "<span class='danger'>You have OOC muted.</span>"
 		return
 
 	if(!check_rights(R_MOD,0))
-		if(!ooc_allowed)
-			src << "\red OOC is globally muted"
+		if(!config.ooc_allowed)
+			src << "<span class='danger'>OOC is globally muted.</span>"
 			return
-		if(!dooc_allowed && (mob.stat == DEAD))
-			usr << "\red OOC for dead mobs has been turned off."
+		if(!config.dooc_allowed && (mob.stat == DEAD))
+			usr << "<span class='danger'>OOC for dead mobs has been turned off.</span>"
 			return
 		if(prefs.muted & MUTE_OOC)
-			src << "\red You cannot use OOC (muted)."
+			src << "<span class='danger'>You cannot use OOC (muted).</span>"
 			return
-		if(handle_spam_prevention(msg,MUTE_OOC))
+		if(handle_spam_prevention(msg, MUTE_OOC))
 			return
 		if(findtext(msg, "byond://"))
 			src << "<B>Advertising other servers is not allowed.</B>"
@@ -71,14 +73,14 @@ var/global/admin_ooc_colour = "#b82e00"
 			C << "<font color='[display_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
 
 /proc/toggle_ooc()
-	ooc_allowed = !( ooc_allowed )
-	if (ooc_allowed)
+	config.ooc_allowed = ( !config.ooc_allowed )
+	if (config.ooc_allowed)
 		world << "<B>The OOC channel has been globally enabled!</B>"
 	else
-		world << "<B>The OOC channel has been globally disabled!</B>"
-
+		world << "<B>The OOC channel has been globally disabled!</B>"			
+			
 /proc/auto_toggle_ooc(var/on)
-	if(config.auto_toggle_ooc_during_round && ooc_allowed != on)
+	if(config.auto_toggle_ooc_during_round && config.ooc_allowed != on)
 		toggle_ooc()
 
 /client/proc/set_ooc(newColor as color)
@@ -137,31 +139,33 @@ var/global/admin_ooc_colour = "#b82e00"
 	feedback_add_details("admin_verb","ROC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/looc(msg as text)
-	set name = "LOOC" //Gave this shit a shorter name so you only have to time out "ooc" rather than "ooc message" to use it --NeoFite
+	set name = "LOOC" 
 	set desc = "Local OOC, seen only by those in view."
 	set category = "OOC"
 
-	if(!mob)	return
+	if(!mob)	
+		return
 	if(IsGuestKey(key))
-		src << "Guests may not use OOC."
+		src << "<span class='danger'>Guests may not use OOC.</span>"
 		return
 
 	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
-	if(!msg)	return
+	if(!msg)	
+		return
 
 	if(!(prefs.toggles & CHAT_LOOC))
-		src << "\red You have LOOC muted."
+		src << "<span class='danger'>You have LOOC muted.</span>"
 		return
 
 	if(!check_rights(R_MOD,0))
-		if(!ooc_allowed)
-			src << "\red LOOC is globally muted"
+		if(!config.looc_allowed)
+			src << "<span class='danger'>LOOC is globally muted.</span>"
 			return
-		if(!dooc_allowed && (mob.stat == DEAD))
-			usr << "\red LOOC for dead mobs has been turned off."
+		if(!config.dooc_allowed && (mob.stat == DEAD))
+			usr << "<span class='danger'>LOOC for dead mobs has been turned off.</span>"
 			return
 		if(prefs.muted & MUTE_OOC)
-			src << "\red You cannot use LOOC (muted)."
+			src << "<span class='danger'>You cannot use LOOC (muted).</span>"
 			return
 		if(handle_spam_prevention(msg,MUTE_OOC))
 			return
@@ -172,39 +176,52 @@ var/global/admin_ooc_colour = "#b82e00"
 			return
 
 	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
-	var/list/heard = get_mobs_in_view(7, src.mob)
-	var/mob/S = src.mob
+	
+	var/mob/source = mob.get_looc_source()	
+	var/list/heard = get_mobs_in_view(7, source)
 
-	var/display_name = S.key
-	if(S.stat != DEAD)
-		display_name = S.name
+	var/display_name = key
+	if(holder && holder.fakekey)
+		display_name = holder.fakekey
+	if(mob.stat != DEAD)
+		display_name = mob.name
 
-	// Handle non-admins
-	for(var/mob/M in heard)
-		if(!M.client)
-			continue
-		var/client/C = M.client
-		if(check_rights(R_MOD,0,M))
-			continue //they are handled after that
+	for(var/client/target in clients)		
+		if(target.prefs.toggles & CHAT_LOOC)
+			var/prefix = ""
+			var/admin_stuff = ""
+			var/send = 0
 
-		if(C.prefs.toggles & CHAT_LOOC)
-			if(holder)
-				if(holder.fakekey)
-					if(C.holder)
-						display_name = "[holder.fakekey]/([src.key])"
-					else
-						display_name = holder.fakekey
-			C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+			if(target in admins)
+				if(check_rights(R_MOD,0,target.mob))
+					admin_stuff += "/([key])"
+					if(target != src)
+						admin_stuff += "([admin_jump_link(mob, target.holder)])"
 
-	// Now handle admins
-	display_name = S.key
-	if(S.stat != DEAD)
-		display_name = "[S.name]/([S.key])"
+			if(target.mob in heard)
+				send = 1
+				if(isAI(target.mob))
+					prefix = " (Core)"
 
-	for(var/client/C in admins)
-		if(check_rights(R_MOD,0,C.mob))
-			if(C.prefs.toggles & CHAT_LOOC)
-				var/prefix = "(R)LOOC"
-				if (C.mob in heard)
-					prefix = "LOOC"
-				C << "<font color='#6699CC'><span class='ooc'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>"
+			else if(isAI(target.mob)) // Special case
+				var/mob/living/silicon/ai/A = target.mob
+				if(A.eyeobj in hearers(7, source))
+					send = 1
+					prefix = " (Eye)"
+
+			if(!send && (target in admins))
+				if(check_rights(R_MOD,0,target.mob))
+					send = 1
+					prefix = "(R)"
+
+			if(send)
+				target << "<span class='ooc'><span class='looc'>LOOC<span class='prefix'>[prefix]: </span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"		
+				
+/mob/proc/get_looc_source()
+	return src
+
+/mob/living/silicon/ai/get_looc_source()
+	if(eyeobj)
+		return eyeobj
+	return src
+	

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -553,18 +553,40 @@ var/global/nologevent = 0
 	set category = "Server"
 	set desc="Globally Toggles OOC"
 	set name="Toggle OOC"
+
+	if(!check_rights(R_ADMIN))
+		return
+
 	toggle_ooc()
-	log_admin("[key_name(usr)] toggled OOC.")
-	message_admins("[key_name_admin(usr)] toggled OOC.", 1)
+	log_and_message_admins("toggled OOC.")
 	feedback_add_details("admin_verb","TOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/togglelooc()
+	set category = "Server"
+	set desc="Globally Toggles LOOC"
+	set name="Toggle LOOC"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.looc_allowed = !(config.looc_allowed)
+	if (config.looc_allowed)
+		world << "<B>The LOOC channel has been globally enabled!</B>"
+	else
+		world << "<B>The LOOC channel has been globally disabled!</B>"
+	log_and_message_admins("toggled LOOC.")
+	feedback_add_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggledsay()
 	set category = "Server"
 	set desc="Globally Toggles DSAY"
 	set name="Toggle DSAY"
-	dsay_allowed = !( dsay_allowed )
-	if (dsay_allowed)
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.dsay_allowed = !(config.dsay_allowed)
+	if (config.dsay_allowed)
 		world << "<B>Deadchat has been globally enabled!</B>"
 	else
 		world << "<B>Deadchat has been globally disabled!</B>"
@@ -574,11 +596,14 @@ var/global/nologevent = 0
 
 /datum/admins/proc/toggleoocdead()
 	set category = "Server"
-	set desc="Toggle dis bitch"
+	set desc="Toggle Dead OOC."
 	set name="Toggle Dead OOC"
-	dooc_allowed = !( dooc_allowed )
 
-	log_admin("[key_name(usr)] toggled OOC.")
+	if(!check_rights(R_ADMIN))
+		return
+
+	config.dooc_allowed = !( config.dooc_allowed )
+	log_admin("[key_name(usr)] toggled Dead OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.", 1)
 	feedback_add_details("admin_verb","TDOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -49,6 +49,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/toggle_hear_radio,     /*toggles whether we hear the radio*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
+	/datum/admins/proc/togglelooc,		/*toggles looc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggledsay,		/*toggles dsay on/off for everyone*/
 	/client/proc/game_panel,			/*game panel, allows to change game-mode etc*/
@@ -347,6 +348,25 @@ var/list/admin_verbs_mentor = list(
 		holder.Secrets()
 	feedback_add_details("admin_verb","S") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
+	
+/client/proc/findStealthKey(txt)
+	if(txt)
+		for(var/P in stealthminID)
+			if(stealthminID[P] == txt)
+				return P
+	txt = stealthminID[ckey]
+	return txt
+
+/client/proc/createStealthKey()
+	var/num = (rand(0,1000))
+	var/i = 0
+	while(i == 0)
+		i = 1
+		for(var/P in stealthminID)
+			if(num == stealthminID[P])
+				num++
+				i = 0
+	stealthminID["[ckey]"] = "@[num2text(num)]"	
 
 /client/proc/stealth()
 	set category = "Admin"
@@ -360,6 +380,7 @@ var/list/admin_verbs_mentor = list(
 			if(length(new_key) >= 26)
 				new_key = copytext(new_key, 1, 26)
 			holder.fakekey = new_key
+			createStealthKey()
 		log_admin("[key_name(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]")
 		message_admins("[key_name_admin(usr)] has turned stealth mode [holder.fakekey ? "ON" : "OFF"]", 1)
 	feedback_add_details("admin_verb","SM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -35,6 +35,9 @@
 	if (!msg)
 		return
 
-	say_dead_direct("<span class='name'>[stafftype] ([src.holder.fakekey ? src.holder.fakekey : src.key])</span> says, <span class='message'>\"[msg]\"</span>")
+	var/prefix = "[stafftype] ([src.key])"
+	if(holder.fakekey)
+		prefix = "Administrator"
+	say_dead_direct("<span class='name'>[prefix]</span> says, <span class='message'>\"[msg]\"</span>")
 
 	feedback_add_details("admin_verb","D") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -93,7 +93,7 @@
 		return
 
 	if(!src.client.holder)
-		if(!dsay_allowed)
+		if(!config.dsay_allowed)
 			src << "\red Deadchat is globally muted"
 			return
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -40,7 +40,7 @@
 
 /mob/proc/say_dead(var/message)
 	if(!src.client.holder)
-		if(!dsay_allowed)
+		if(!config.dsay_allowed)
 			src << "<span class='danger'>Deadchat is globally muted.</span>"
 			return
 

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -14,6 +14,7 @@ em						{font-style: normal;	font-weight: bold;}
 .prefix					{					font-weight: bold;}
 
 .ooc					{					font-weight: bold;}
+.looc					{color: #6699CC;}
 .adminobserverooc		{color: #0099cc;	font-weight: bold;}
 .adminooc				{color: #b82e00;	font-weight: bold;}
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -292,3 +292,12 @@ PLAYER_REROUTE_CAP 0
 
 ## Uncomment this out if you still use the old .sav file based notes system and haven't used the mass conversion proc
 #AUTOCONVERT_NOTES
+
+## Uncomment to disable the OOC/LOOC channel by default.
+#DISABLE_OOC
+
+## Uncomment to disable the dead OOC channel by default.
+#DISABLE_DEAD_OOC
+
+## Uncomment to disable ghost chat by default.
+#DISABLE_DSAY


### PR DESCRIPTION
Changes:
1) Turns OOC/LOOC/DOOC/Deadsay toggles into configuration options.
2) AI now hears LOOC both around its eye and its core, and speaks in LOOC around its eye: by Kelenius (https://github.com/Baystation12/Baystation12/pull/9502).
3) Admins can now toggle OOC and LOOC separately from each other: by PsiOmegaDelta (https://github.com/Baystation12/Baystation12/pull/9040)
4) Stealthmins using dsay (but not talking while dead) will now show up as "Administrator". Fixes https://github.com/ParadiseSS13/Paradise/issues/1961.
5) Admin PM's will now properly hide the ckey of the admin if they're stealthminned: by Aranclanos (https://github.com/tgstation/-tg-station/pull/9572)