### PR TITLE
Point Rework

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -190,7 +190,7 @@
 	Only used for swapping hands
 */
 /mob/proc/MiddleClickOn(var/atom/A)
-	A.point()
+	pointed(A)
 	return
 
 // See click_override.dm

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -111,7 +111,7 @@
 	if(istype(src, /mob/living/silicon/robot/drone))
 		// Drones cannot point.
 		return
-	A.point()
+	pointed(A)
 	return
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -5,7 +5,7 @@
 	icon_state = "arrow"
 	layer = 16.0
 	anchored = 1
-
+	mouse_opacity = 0
 
 // Used for spray that you spray at walls, tables, hydrovats etc
 /obj/effect/decal/spraystill

--- a/code/game/verbs/atom_verbs.dm
+++ b/code/game/verbs/atom_verbs.dm
@@ -6,31 +6,3 @@
 	if(Adjacent(usr))
 		usr.start_pulling(src)
 	return
-
-/atom/verb/point()
-	set name = "Point To"
-	set category = null
-	set popup_menu = 0
-	set src in oview()
-	var/atom/this = src//detach proc from src
-	src = null
-
-	if(!usr || !isturf(usr.loc))
-		return
-	if(usr.stat || usr.restrained())
-		return
-	if(usr.status_flags & FAKEDEATH)
-		return
-	if(usr.next_move > world.time)
-		return
-
-	var/tile = get_turf(this)
-	if (!tile)
-		return
-
-	var/P = new /obj/effect/decal/point(tile)
-	usr.changeNext_move(CLICK_CD_POINT)
-	spawn (20)
-		if(P)	qdel(P)
-
-	usr.visible_message("<b>[usr]</b> points to [this]")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -631,3 +631,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/can_admin_interact()
 	return check_rights(R_ADMIN, 0, src)
+
+//this is a mob verb instead of atom for performance reasons
+//see /mob/verb/examinate() in mob.dm for more info
+//overriden here and in /mob/living for different point span classes and sanity checks
+/mob/dead/observer/pointed(atom/A as mob|obj|turf in view())
+	if(!..())
+		return 0
+	usr.visible_message("<span class='deadsay'><b>[src]</b> points to [A].</span>")
+	return 1

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -518,9 +518,9 @@
 
 		if ("point")
 			if (!src.restrained())
-				var/mob/M = null
+				var/atom/M = null
 				if (param)
-					for (var/atom/A as mob|obj|turf|area in view(null, null))
+					for (var/atom/A as mob|obj|turf in view())
 						if (param == A.name)
 							M = A
 							break
@@ -528,11 +528,7 @@
 				if (!M)
 					message = "<B>[src]</B> points."
 				else
-					M.point()
-
-				if (M)
-					message = "<B>[src]</B> points to [M]."
-				else
+					pointed(M)
 			m_type = 1
 
 		if ("raise")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -25,6 +25,18 @@
 					special_role = null
 					current << "\red <FONT size = 3><B>The fog clouding your mind clears. You remember nothing from the moment you were implanted until now..(You don't remember who enslaved you)</B></FONT>"
 				*/
+
+//same as above
+/mob/living/pointed(atom/A as mob|obj|turf in view())
+	if(src.stat || !src.canmove || src.restrained())
+		return 0
+	if(src.status_flags & FAKEDEATH)
+		return 0
+	if(!..())
+		return 0
+	visible_message("<b>[src]</b> points to [A]")
+	return 1
+
 /mob/living/verb/succumb()
 	set hidden = 1
 	if (InCritical())

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -46,11 +46,6 @@
 	set src = usr.contents
 	return 0
 
-/mob/aiEye/point()
-	set popup_menu = 0
-	set src = usr.contents
-	return 0
-
 // Use this when setting the aiEye's location.
 // It will also stream the chunk that the new loc is in.
 /mob/aiEye/setLoc(var/T, var/cancel_tracking = 1)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -504,6 +504,8 @@ var/list/slot_equipment_priority = list( \
 	set name = "Point To"
 	set category = "Object"
 
+	if(next_move >= world.time)
+		return
 	if(!src || !isturf(src.loc))
 		return 0
 	if(istype(A, /obj/effect/decal/point))
@@ -513,6 +515,7 @@ var/list/slot_equipment_priority = list( \
 	if (!tile)
 		return 0
 
+	changeNext_move(CLICK_CD_POINT)
 	var/obj/P = new /obj/effect/decal/point(tile)
 	P.invisibility = invisibility
 	spawn (20)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -73,6 +73,8 @@
 
 /mob/visible_message(var/message, var/self_message, var/blind_message)
 	for(var/mob/M in viewers(src))
+		if(M.see_invisible < invisibility)
+			continue //can't view the invisible
 		var/msg = message
 		if(self_message && M==src)
 			msg = self_message
@@ -493,6 +495,31 @@ var/list/slot_equipment_priority = list( \
 
 	face_atom(A)
 	A.examine(src)
+
+//same as above
+//note: ghosts can point, this is intended
+//visible_message will handle invisibility properly
+//overriden here and in /mob/dead/observer for different point span classes and sanity checks
+/mob/verb/pointed(atom/A as mob|obj|turf in view())
+	set name = "Point To"
+	set category = "Object"
+
+	if(!src || !isturf(src.loc))
+		return 0
+	if(istype(A, /obj/effect/decal/point))
+		return 0
+
+	var/tile = get_turf(A)
+	if (!tile)
+		return 0
+
+	var/obj/P = new /obj/effect/decal/point(tile)
+	P.invisibility = invisibility
+	spawn (20)
+		if(P)
+			qdel(P)
+
+	return 1
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L as obj, flag)
 	if ((!( istype(l_hand, /obj/item/weapon/grab) ) && !( istype(r_hand, /obj/item/weapon/grab) )))


### PR DESCRIPTION
Refactors point to be a mob verb instead of an atom verb--this is much like the examine PR.

What does this do for me as a player? 

- Nothing, really, day to day---you can still point and still see its visual impact and text
- Pointing is now back in the right-click menu, just like examining
 - Middle mouse button still points
- Observers can now point
 - Only observers can see other observer-originted points.

Fixes
- Fixes arrows having mouse opacity

DNM, because i need to figure out how to properly set the click cooldown--this is a bit baffling to me; it's something very simple, but simply isn't being applied for some reason.