### PR TITLE
Chemistry: Patch Balance

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -593,7 +593,7 @@
 				if (href_list["createpatch_multiple"]) count = isgoodnumber(input("Select the number of patches to make.", 10, patchamount) as num)
 				if (count > 20) count = 20	//Pevent people from creating huge stacks of patches easily. Maybe move the number to defines?
 				var/amount_per_patch = reagents.total_volume/count
-				if (amount_per_patch > 50) amount_per_patch = 50
+				if (amount_per_patch > 40) amount_per_patch = 40
 				var/name = reject_bad_text(input(usr,"Name:","Name your patch!","[reagents.get_master_reagent_name()] ([amount_per_patch] units)"))
 				while (count--)
 					var/obj/item/weapon/reagent_containers/pill/patch/P = new/obj/item/weapon/reagent_containers/pill/patch(src.loc)
@@ -699,7 +699,7 @@
 		if(!condi)
 			dat += "<HR><BR><A href='?src=\ref[src];createpill=1'>Create pill (50 units max)</A><a href=\"?src=\ref[src]&change_pill=1\"><img src=\"pill[pillsprite].png\" /></a><BR>"
 			dat += "<A href='?src=\ref[src];createpill_multiple=1'>Create multiple pills</A><BR>"
-			dat += "<HR><BR><A href='?src=\ref[src];createpatch=1'>Create patch (50 units max)</A><BR>"
+			dat += "<HR><BR><A href='?src=\ref[src];createpatch=1'>Create patch (40 units max)</A><BR>"
 			dat += "<A href='?src=\ref[src];createpatch_multiple=1'>Create multiple patches</A><BR>"
 			dat += "<A href='?src=\ref[src];createbottle=1'>Create bottle (30 units max)</A>"
 		else

--- a/code/modules/reagents/newchem/patch.dm
+++ b/code/modules/reagents/newchem/patch.dm
@@ -5,9 +5,10 @@
 	icon_state = "bandaid"
 	item_state = "bandaid"
 	possible_transfer_amounts = null
-	volume = 50
+	volume = 40
 	apply_type = TOUCH
 	apply_method = "apply"
+	transfer_efficiency = 0.5 //patches aren't as effective at getting chemicals into the bloodstream.
 
 /obj/item/weapon/reagent_containers/pill/patch/New()
 	..()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -11,6 +11,7 @@
 	volume = 50
 	var/apply_type = INGEST
 	var/apply_method = "swallow"
+	var/transfer_efficiency = 1.0
 
 	New()
 		..()
@@ -32,7 +33,7 @@
 			if(reagents.total_volume)
 				reagents.reaction(M, apply_type)
 				spawn(0)
-					reagents.trans_to_ingest(M, reagents.total_volume)
+					reagents.trans_to_ingest(M, reagents.total_volume*transfer_efficiency)
 					qdel(src)
 			else
 				qdel(src)
@@ -66,7 +67,7 @@
 			if(reagents.total_volume)
 				reagents.reaction(M, apply_type)
 				spawn(0)
-					reagents.trans_to_ingest(M, reagents.total_volume)
+					reagents.trans_to_ingest(M, reagents.total_volume*transfer_efficiency)
 					qdel(src)
 			else
 				qdel(src)


### PR DESCRIPTION
So, simply put, there's not really a point or reason to use pills over patches; they hold the same amount of chemicals and apply special reactions for a small subset of those chemicals...while still adding the reagents to directly to someone's bloodstream.

This nerfs and adjusts them a bit--the idea was inspired by Goon.

- Patches max volume is now 40 as opposed to the standard pill's 50.
- Patches transfer reagents to the person at half the efficiency of pills
 - This makes sense, from a realistic perspective, too; something you ingest is going to get a LOT more chemicals into you than something that transfers through the skin.