### PR TITLE
Fixes Utensil Feeding

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -49,15 +49,16 @@
 			return ..()
 
 	if (reagents.total_volume > 0)
-		reagents.trans_to_ingest(M, reagents.total_volume)
 		if(M == user)
-			for(var/mob/O in viewers(M, null))
-				O.show_message(text("\blue [] eats some [] from \the [].", user, loaded, src), 1)
-				M.reagents.add_reagent("nutriment", 1)
+			M.visible_message("<span class='notice'>\The [user] eats some [loaded] from \the [src].</span>")
+			reagents.trans_to_ingest(M, reagents.total_volume)
 		else
-			for(var/mob/O in viewers(M, null))
-				O.show_message(text("\blue [] feeds [] some [] from \the []", user, M, loaded, src), 1)
-				M.reagents.add_reagent("nutriment", 1)
+			M.visible_message("<span class='warning'>\The [user] attempts to feed some [loaded] to \the [M] with \the [src].</span>")
+			if(!do_mob(user, M)) return
+			M.visible_message("<span class='warning'>\The [user] feeds some [loaded] to \the [M] with \the [src].</span>")
+			reagents.trans_to_ingest(M, reagents.total_volume)
+			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been utensil fed by [user.name] ([user.ckey]) with [src.name]</font>")
+			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Utensil fed [M.name] ([M.ckey]) with [src.name]</font>")
 		playsound(M.loc,'sound/items/eatfood.ogg', rand(10,40), 1)
 		overlays.Cut()
 		return


### PR DESCRIPTION
Fixes up utensil feeding.

- Fixes spanssss
- Fixes it so that feeding someone else with a utensil requires you to obey a cooldown, just like patches, pills, and food.
- Fixes it so that eating with a utensil doesn't magically give you more nutriment than the food on the utensil had.
- Adds in attack logs for utensil feeding