### PR TITLE
Spray Bottle Nerf

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -62,7 +62,7 @@
 /obj/item/weapon/reagent_containers/spray/proc/spray(var/atom/A)
 	var/obj/effect/decal/chempuff/D = new /obj/effect/decal/chempuff(get_turf(src))
 	D.create_reagents(amount_per_transfer_from_this)
-	reagents.trans_to(D, amount_per_transfer_from_this)
+	reagents.trans_to(D, amount_per_transfer_from_this, 1/spray_currentrange)
 	D.icon += mix_color_from_reagents(D.reagents.reagent_list)
 	spawn(0)
 		for(var/i=0, i<spray_currentrange, i++)


### PR DESCRIPTION
Spray Bottle nerf

So, this used to be in, but I removed it and didn't really consider the ramifications of it....

Currently on live, spraybottles multiply reagents.

For example, you have a spray bottle with styptic in it and spray 5 units of it. It hits a person and heals them for 5 brute--seems good, right? Well, here's the problem. The spray travels 3 times....only if you click on the same turf, it'll travel 3 times---to the same turf. This means that if you have something like styptic and spray the same tile you're standing on, it'll proc *three* times and heal you for a whopping 15 brute, despite only using 5 units from your bottle.

There's two ways of addressing this:

- Make the amount of reagents in the puff scale with the maximum range (what this PR does) so that if you puff it on the same tile as yourself and it procs all 3 times, it'll be equal to 5 units
- Make the puff delete itself when it hits a mob. 

We'll see how this goes, we may end up combining the two together (or some form of them).