### PR TITLE
Tweaks Brain Damage Messages

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -16,7 +16,7 @@
 	if(species.can_revive_by_healing)
 		var/obj/item/organ/brain/B = internal_organs_by_name["brain"]
 		if(B)
-			if((health >= (config.health_threshold_dead/100*75)) && stat == DEAD) 
+			if((health >= (config.health_threshold_dead/100*75)) && stat == DEAD)
 				update_revive()
 	if (stat == CONSCIOUS && (src in dead_mob_list)) //Defib fix
 		update_revive()
@@ -37,7 +37,7 @@
 	if(species && species.has_organ["brain"])
 		var/obj/item/organ/brain/sponge = internal_organs_by_name["brain"]
 		if(sponge)
-			sponge.take_damage(amount)
+			sponge.take_damage(amount, 1)
 			brainloss = sponge.damage
 		else
 			brainloss = 200
@@ -55,8 +55,8 @@
 		else
 			brainloss = 200
 	else
-		brainloss = 0	
-	
+		brainloss = 0
+
 /mob/living/carbon/human/getBrainLoss()
 	if(status_flags & GODMODE)	return 0	//godmode
 
@@ -143,7 +143,7 @@
 
 /mob/living/carbon/human/adjustCloneLoss(var/amount)
 	..()
-	
+
 	if(species.flags & (NO_SCAN))
 		cloneloss = 0
 		return
@@ -177,7 +177,7 @@
 				O.unmutate()
 				src << "<span class = 'notice'>Your [O.name] is shaped normally again.</span>"
 	hud_updateflag |= 1 << HEALTH_HUD
-	
+
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/getOxyLoss()
 	if(species.flags & NO_BREATHE)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -119,6 +119,8 @@ mob/living/carbon/human/proc/handle_pain()
 
 	// Damage to internal organs hurts a lot.
 	for(var/obj/item/organ/I in internal_organs)
+		if(istype(I, /obj/item/organ/brain)) //the brain has no pain receptors, and brain damage is meant to be a stealthy damage type.
+			continue
 		if(I.damage > 2) if(prob(2))
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
 			src.custom_pain("You feel a sharp pain in your [parent.name]", 1)

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -204,7 +204,7 @@
 			var/mob/living/carbon/human/H = mob
 			var/obj/item/organ/brain/B = H.internal_organs_by_name["brain"]
 			if (B.damage < B.min_broken_damage)
-				B.take_damage(5)
+				B.take_damage(5, 1)
 		else
 			mob.setBrainLoss(50)
 
@@ -425,7 +425,7 @@
 			var/mob/living/carbon/human/H = mob
 			var/obj/item/organ/brain/B = H.internal_organs_by_name["brain"]
 			if (B.damage < B.min_broken_damage)
-				B.take_damage(1)
+				B.take_damage(1, 1)
 		else
 			mob.setBrainLoss(10)
 
@@ -687,7 +687,7 @@ var/list/compatible_mobs = list(/mob/living/carbon/human)
 			var/mob/living/carbon/human/H = mob
 			var/obj/item/organ/brain/B = H.internal_organs_by_name["brain"]
 			if (B.damage < B.min_broken_damage)
-				B.take_damage(0.5)
+				B.take_damage(0.5, 1)
 		else
 			mob.setBrainLoss(5)
 


### PR DESCRIPTION
So, brain damage was always meant to be a stealth damage type---you wouldn't notice it until you had 60+ brain damage and were shouting out random gibberish. It's also realistic, as the brain has no pain receptors.

When brain damage was changed to be intertwined with the actual organ, that inevitably meant that several new messages would be displayed if you had brain damage. This fixes that.

- Taking brain damage will no longer incur a message when you initially take the damage.
- You won't be notified that you have a 'sharp pain in your head' periodically if you have brain damage.

