### PR TITLE
Make DI tab readable

### DIFF
--- a/code/controllers/ProcessScheduler/core/process.dm
+++ b/code/controllers/ProcessScheduler/core/process.dm
@@ -340,7 +340,7 @@
 	var/averageRunTime = round(getAverageRunTime(), 0.1)/10
 	var/lastRunTime = round(getLastRunTime(), 0.1)/10
 	var/highestRunTime = round(getHighestRunTime(), 0.1)/10
-	stat("[name]", "T#[getTicks()]|AR [averageRunTime]|LR [lastRunTime]|HR [highestRunTime]|D [cpu_defer_count]")
+	stat("[name]", "T#[getTicks()] | AR [averageRunTime] | LR [lastRunTime] | HR [highestRunTime] | D [cpu_defer_count]")
 
 /datum/controller/process/proc/catchException(var/exception/e, var/thrower)
 	var/etext = "[e]"

--- a/code/controllers/ProcessScheduler/core/processScheduler.dm
+++ b/code/controllers/ProcessScheduler/core/processScheduler.dm
@@ -98,7 +98,7 @@ var/global/datum/controller/processScheduler/processScheduler
 
 /datum/controller/processScheduler/proc/process()
 	updateCurrentTickData()
-	
+
 	for(var/i=world.tick_lag,i<world.tick_lag*50,i+=world.tick_lag)
 		spawn(i) updateCurrentTickData()
 	while(isRunning)
@@ -252,7 +252,7 @@ var/global/datum/controller/processScheduler/processScheduler
 		last_start[process] = time
 	else
 		last_queued[process] = (time == 0 ? 0 : world.time)
-		last_start[process] = time	
+		last_start[process] = time
 
 /datum/controller/processScheduler/proc/recordEnd(var/datum/controller/process/process, var/time = null)
 	if (isnull(time))
@@ -376,7 +376,7 @@ var/global/datum/controller/processScheduler/processScheduler
 	if(!isRunning)
 		stat("Processes", "Scheduler not running")
 		return
-	stat("Processes", "[processes.len] (R[running.len]/Q[queued.len]/I[idle.len])")
+	stat("Processes", "[processes.len] (R [running.len] / Q [queued.len] / I [idle.len])")
 	stat(null, "[round(cpuAverage, 0.1)] CPU, [round(timeAllowance, 0.1)/10] TA")
 	for(var/datum/controller/process/p in processes)
 		p.statProcess()

--- a/code/controllers/Processes/air.dm
+++ b/code/controllers/Processes/air.dm
@@ -27,7 +27,7 @@ var/global/datum/controller/process/air_system/air_master
 	schedule_interval = 20 // every 2 seconds
 	start_delay = 4
 	air_master = src
-	
+
 	var/watch = start_watch()
 	log_startup_progress("Processing geometry...")
 	setup_allturfs() // Get all currently active tiles that need processing each atmos tick.
@@ -48,7 +48,7 @@ var/global/datum/controller/process/air_system/air_master
 /datum/controller/process/air_system/statProcess()
 	..()
 	stat(null, "[last_active] active")
-	stat(null, "[last_excited] EG|[last_hpd] HPD|[last_asc] ASC|[last_hotspots] Hot")
+	stat(null, "[last_excited] EG | [last_hpd] HPD | [last_asc] ASC | [last_hotspots] Hot")
 
 /datum/controller/process/air_system/proc/process_hotspots()
 	last_hotspots = hotspots.len


### PR DESCRIPTION
The process scheduler section of the DI tab is nearly unreadable as-is,
due to having precisely 0 spaces in the statistics. This fixes that.

Old | New
------------ | -------------
![old](https://puu.sh/ki6V1/3a38490b31.png) | ![new](https://puu.sh/ki6rY/6cba6bebf3.png)
