### PR TITLE
Add Araneus to simple mob blacklist

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -48,7 +48,8 @@ var/global/list/blocked_mobs = list(/mob/living/simple_animal/hostile,
 			/mob/living/simple_animal/hostile/spaceWorm,
 			/mob/living/simple_animal/hostile/spaceWorm/wormHead,
 			/mob/living/simple_animal/ascendant_shadowling,
-			/mob/living/simple_animal/slaughter
+			/mob/living/simple_animal/slaughter,
+			/mob/living/simple_animal/hostile/retaliate/araneus
 			)
 
 var/global/list/med_hud_users = list()


### PR DESCRIPTION
Changes:
1) Adds Sergeant Araneus to the simple mob blacklist, meaning it won't spawn as a result of gold slime extracts or interdimensional tears.