### PR TITLE
Borg Transformation Virus Symptom

### DIFF
--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -15,7 +15,7 @@
 
 /datum/disease2/effectholder/proc/getrandomeffect(var/badness = 1)
 	var/list/datum/disease2/effect/list = list()
-	for(var/e in subtypesof(/datum/disease2/effect))
+	for(var/e in subtypesof(/datum/disease2/effect) - /datum/disease2/effect/organs/vampire)
 		var/datum/disease2/effect/f = new e
 		if (f.badness > badness)	//we don't want such strong effects
 			continue
@@ -103,6 +103,25 @@
 
 
 ////////////////////////STAGE 4/////////////////////////////////
+
+/datum/disease2/effect/borg
+	name = "Borgification Disorder"
+	stage = 4
+	badness = 2
+	activate(var/mob/living/carbon/mob,var/multiplier)
+		mob << "<span class = 'warning'>You feel like beeping and booping...</span>"
+		mob.adjustBruteLoss(10)
+		mob.updatehealth()
+		if(prob(40))
+			if(mob.client)
+				if(!jobban_isbanned(mob, "Cyborg") || !jobban_isbanned(mob,"nonhumandept"))
+					var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(mob.loc))
+					mob.mind.transfer_to(O)
+			else
+				new/mob/living/silicon/robot(get_turf(mob.loc))
+			var/datum/disease2/disease/D = mob.virus2
+			mob.gib()
+			qdel(D)
 
 /datum/disease2/effect/omnizine
 	name = "Panacea Effect"

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -114,7 +114,7 @@
 		mob.updatehealth()
 		if(prob(40))
 			if(mob.client)
-				if(!jobban_isbanned(mob, "Cyborg") || !jobban_isbanned(mob,"nonhumandept"))
+				if(!jobban_isbanned(mob, "Cyborg") && !jobban_isbanned(mob,"nonhumandept"))
 					var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(mob.loc))
 					mob.mind.transfer_to(O)
 			else


### PR DESCRIPTION
Alright, so I made a PR for this before; there was some support form it, some neutrality, and some opposition---I would like to see what people have to say about it now.

Adds in a stage 4 symptom that transforms you into a borg.
 - If you're job-banned from borg, then you're just going to gib, like with the GBS symptom.

This is a fully fledged disease on TG with it's own reagent; that's not practical, feasible, or balanced here due to the differences between TG diseases and Bay virology-----that said, we can add the end effect of it (like how GBS, magnitis, clowning around, and a few others are replication of TG style diseases) as a stage 4 symptom.

I think this is a better/more interesting symptom than plain old Gibbingtons, as it still keeps the person in the round and potentially an active player, rather than "lol, you're paste on the floor."

Other

- Fixes the vampire virus effect showing up in random virus effects the Virologist can get.