### PR TITLE
Rejuvinate Fixup

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -314,7 +314,7 @@
 		if(C.reagents)
 			for(var/datum/reagent/R in C.reagents.reagent_list)
 				C.reagents.clear_reagents()
-			C.reagents.addiction_list = list()
+			C.reagents.addiction_list.Cut()
 	hud_updateflag |= 1 << HEALTH_HUD
 	hud_updateflag |= 1 << STATUS_HUD
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -311,6 +311,10 @@
 		if (C.legcuffed && !initial(C.legcuffed))
 			C.unEquip(C.legcuffed)
 		C.legcuffed = initial(C.legcuffed)
+		if(C.reagents)
+			for(var/datum/reagent/R in C.reagents.reagent_list)
+				C.reagents.clear_reagents()
+			C.reagents.addiction_list = list()
 	hud_updateflag |= 1 << HEALTH_HUD
 	hud_updateflag |= 1 << STATUS_HUD
 
@@ -322,10 +326,16 @@
 	setCloneLoss(0)
 	setBrainLoss(0)
 	setStaminaLoss(0)
+	SetSleeping(0)
 	setHalLoss(0)
 	SetParalysis(0)
 	SetStunned(0)
 	SetWeakened(0)
+	losebreath = 0
+	dizziness = 0
+	jitteriness = 0
+	confused = 0
+	drowsyness = 0
 	radiation = 0
 	nutrition = 400
 	bodytemperature = 310
@@ -337,6 +347,7 @@
 	ear_deaf = 0
 	ear_damage = 0
 	heal_overall_damage(1000, 1000)
+	ExtinguishMob()
 	fire_stacks = 0
 	on_fire = 0
 	suiciding = 0


### PR DESCRIPTION
For admins who don't have var edit enabled, but can access rejuv...there's a few things they just can't fix--this addresses that:

- rejuvenate will now set sleeping, losebreath, dizziness, confusion, jitteriness, and drowsiness to 0.
- If the mob is a carbon mob, it will clear it of any/all reagents in its system and get rid of any addictions it has.

This should go a long way towards making rejuvinate truly reset someone's status back to the way they were.