### PR TITLE
Changes a Chemistry Transfer Proc

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -51,12 +51,12 @@
 	if (reagents.total_volume > 0)
 		if(M == user)
 			M.visible_message("<span class='notice'>\The [user] eats some [loaded] from \the [src].</span>")
-			reagents.trans_to_ingest(M, reagents.total_volume)
+			reagents.trans_to(M, reagents.total_volume)
 		else
 			M.visible_message("<span class='warning'>\The [user] attempts to feed some [loaded] to \the [M] with \the [src].</span>")
 			if(!do_mob(user, M)) return
 			M.visible_message("<span class='warning'>\The [user] feeds some [loaded] to \the [M] with \the [src].</span>")
-			reagents.trans_to_ingest(M, reagents.total_volume)
+			reagents.trans_to(M, reagents.total_volume)
 			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been utensil fed by [user.name] ([user.ckey]) with [src.name]</font>")
 			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Utensil fed [M.name] ([M.ckey]) with [src.name]</font>")
 		playsound(M.loc,'sound/items/eatfood.ogg', rand(10,40), 1)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -118,32 +118,6 @@ var/const/INGEST = 2
 	src.handle_reactions()
 	return amount
 
-/datum/reagents/proc/trans_to_ingest(var/obj/target, var/amount=1, var/multiplier=1, var/preserve_data=1)//For items ingested. A delay is added between ingestion and addition of the reagents
-	if (!target )
-		return
-	if (!target.reagents || src.total_volume<=0)
-		return
-
-	var/obj/item/weapon/reagent_containers/glass/beaker/noreact/B = new /obj/item/weapon/reagent_containers/glass/beaker/noreact //temporary holder
-	B.volume = 1000
-
-	var/datum/reagents/BR = B.reagents
-	var/datum/reagents/R = target.reagents
-
-	amount = min(min(amount, src.total_volume), R.maximum_volume-R.total_volume)
-
-	src.trans_to(B, amount)
-
-	spawn(-1)
-		src = null // Survive through deletion of the reagent holder
-		sleep(100)
-		if(!target)
-			return
-		BR.trans_to(target, BR.total_volume)
-		qdel(B)
-
-	return amount
-
 /datum/reagents/proc/copy_to(var/obj/target, var/amount=1, var/multiplier=1, var/preserve_data=1, var/safety = 0)
 	if(!target)
 		return

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -36,7 +36,7 @@
 		if(reagents.total_volume)
 			reagents.reaction(M, INGEST)
 			spawn(0)
-				reagents.trans_to_ingest(M, 10)
+				reagents.trans_to(M, 10)
 
 		playsound(M.loc,'sound/items/drink.ogg', rand(10,50), 1)
 		return 1

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -38,7 +38,7 @@
 			if(reagents.total_volume)
 				reagents.reaction(M, INGEST)
 				spawn(0)
-					reagents.trans_to_ingest(M, gulp_size)
+					reagents.trans_to(M, gulp_size)
 
 			playsound(M.loc,'sound/items/drink.ogg', rand(10,50), 1)
 			return 1
@@ -66,7 +66,7 @@
 			if(reagents.total_volume)
 				reagents.reaction(M, INGEST)
 				spawn(0)
-					reagents.trans_to_ingest(M, gulp_size)
+					reagents.trans_to(M, gulp_size)
 
 			if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 				var/mob/living/silicon/robot/bro = user

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -108,9 +108,9 @@
 						var/temp_bitesize =  max(reagents.total_volume /2, bitesize)
 						reagents.trans_to(M, temp_bitesize)
 						*/
-						reagents.trans_to_ingest(M, bitesize)
+						reagents.trans_to(M, bitesize)
 					else
-						reagents.trans_to_ingest(M, reagents.total_volume)
+						reagents.trans_to(M, reagents.total_volume)
 					bitecount++
 					On_Consume(M)
 			return 1

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -33,7 +33,7 @@
 			if(reagents.total_volume)
 				reagents.reaction(M, apply_type)
 				spawn(0)
-					reagents.trans_to_ingest(M, reagents.total_volume*transfer_efficiency)
+					reagents.trans_to(M, reagents.total_volume*transfer_efficiency)
 					qdel(src)
 			else
 				qdel(src)
@@ -67,7 +67,7 @@
 			if(reagents.total_volume)
 				reagents.reaction(M, apply_type)
 				spawn(0)
-					reagents.trans_to_ingest(M, reagents.total_volume*transfer_efficiency)
+					reagents.trans_to(M, reagents.total_volume*transfer_efficiency)
 					qdel(src)
 			else
 				qdel(src)


### PR DESCRIPTION
@Iamgoofball  reminded me of this.

Removes the transfer to ingest proc and replaces it with transfer to.

What does this proc do? Simply put, when you utilize this proc (currently patches, pills, some snacks, and drinks) it will transfer the reagents to a no-react beaker in nullspace---then, 10 seconds later it transfer those reagents to the actual mob.

This incurs a needless wait for when doctors are treating patients, particualrly during emergencies; there's already a wait for treating with pills and such--metabolization of reagents is already handled directly on the reagent datums themselves, so delaying it is unrealistic and silly.

Even Bay did away with this proc.

From a technical spandpoint, problems I have with it: it needlessly makes reagent transfer more expensive with creation, deletion, and spawning off a new thread just to delay reagents by 10 seconds. Furthermore, if the mob is deleted before the reagent is transferred to the actual intended mob...the beaker and its reagents just sits there---forever, in nullspace--it never gets deleted, never GC's, etc---just a new item in the object processing queue to be processed, and a datum that never GC's.

