### PR TITLE
Telegun Refactor

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -381,19 +381,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	update_icon()
 	return 1
 
-// Telegun for Tator RDs
-
-/obj/item/weapon/gun/energy/telegun
-	name = "Teleporter Gun"
-	desc = "An extremely high-tech bluespace energy gun capable of teleporting targets to far off locations."
-	icon_state = "telegun"
-	item_state = "ionrifle"
-	fire_sound = 'sound/weapons/wave.ogg'
-	origin_tech = "combat=6;materials=7;powerstorage=5;bluespace=5;syndicate=4"
-	cell_type = "/obj/item/weapon/stock_parts/cell/crap"
-	projectile_type = "/obj/item/projectile/energy/teleport"
-	charge_cost = 1250
-
 /* 3d printer 'pseudo guns' for borgs */
 
 /obj/item/weapon/gun/energy/printer

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -1,0 +1,39 @@
+// Telegun for Tator RDs
+
+/obj/item/weapon/gun/energy/telegun
+	name = "Teleporter Gun"
+	desc = "An extremely high-tech bluespace energy gun capable of teleporting targets to far off locations."
+	icon_state = "telegun"
+	item_state = "ionrifle"
+	fire_sound = 'sound/weapons/wave.ogg'
+	origin_tech = "combat=6;materials=7;powerstorage=5;bluespace=5;syndicate=4"
+	cell_type = "/obj/item/weapon/stock_parts/cell/crap"
+	projectile_type = "/obj/item/projectile/energy/teleport"
+	charge_cost = 1250
+	var/teleport_target = null
+
+/obj/item/weapon/gun/energy/telegun/Destroy()
+	teleport_target = null
+	return ..()
+
+/obj/item/weapon/gun/energy/telegun/attack_self(mob/living/user as mob)
+	var/list/L = list()
+	var/list/areaindex = list()
+
+	for(var/obj/item/device/radio/beacon/R in beacons)
+		var/turf/T = get_turf(R)
+		if (!T)
+			continue
+		if((T.z in config.admin_levels) || T.z > 7)
+			continue
+		if(R.syndicate == 1)
+			continue
+		var/tmpname = T.loc.name
+		if(areaindex[tmpname])
+			tmpname = "[tmpname] ([++areaindex[tmpname]])"
+		else
+			areaindex[tmpname] = 1
+		L[tmpname] = R
+
+	var/desc = input("Please select a location to lock in.", "Telegun Target Interface") in L
+	teleport_target = L[desc]

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -269,15 +269,17 @@ obj/item/projectile/kinetic/New()
 	icon_state = "bluespace"
 	damage = 0
 	nodamage = 1
+	var/obj/item/weapon/gun/energy/telegun/T = null
+	var/teleport_target = null
+
+	OnFired()
+		T = shot_from
+		teleport_target = T.teleport_target
 
 /obj/item/projectile/energy/teleport/on_hit(var/atom/target, var/blocked = 0)
 	if(isliving(target))
-		var/obj/item/device/radio/beacon/teletarget = null
-		for(var/obj/machinery/computer/teleporter/com in machines)
-			if(com.target)
-				teletarget = com.target
-		if(teletarget)
-			do_teleport(target, teletarget, 0)//teleport what's in the tile to the beacon
+		if(teleport_target)
+			do_teleport(target, teleport_target, 0)//teleport what's in the tile to the beacon
 		else
 			do_teleport(target, target, 15) //Otherwise it just warps you off somewhere.
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -1608,6 +1608,7 @@
 #include "code\modules\projectiles\guns\energy\pulse.dm"
 #include "code\modules\projectiles\guns\energy\special.dm"
 #include "code\modules\projectiles\guns\energy\stun.dm"
+#include "code\modules\projectiles\guns\energy\telegun.dm"
 #include "code\modules\projectiles\guns\energy\temperature.dm"
 #include "code\modules\projectiles\guns\magic\staff.dm"
 #include "code\modules\projectiles\guns\magic\wand.dm"


### PR DESCRIPTION
Refactors the telegun to not be shit.

You can now select the target beacon you'd like the telegun to teleport someone to; the projectile will now base its target off of the telegun it's shot from. You can set the target as easy as clicking on the gun itself.

This is important as it allows multiple teleguns to exist on the field at once, all with different targets. This contrasts to how it currently opperates; all teleport *projectiles* sending people to the same location. It also means the gun's functionality isn't dependent on the existence of a teleporter hub.

The only downside of this is you won't be able to point-blank shoot yourself  or someone else to teleport to a location, due to where OnFired() is processed, so it'll just teleport to a tuf in a random 15 turf radius...but eh, that's not what this gun was designed for anyway.