### PR TITLE
Laser Scalpel Damage Nerf

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -96,7 +96,6 @@
 	icon_state = "scalpel_laser2_on"
 	item_state = "scalpel"
 	damtype = "fire"
-	force = 12.0
 	hitsound = 'sound/weapons/sear.ogg'
 
 /obj/item/weapon/scalpel/laser3
@@ -105,7 +104,6 @@
 	icon_state = "scalpel_laser3_on"
 	item_state = "scalpel"
 	damtype = "fire"
-	force = 15.0
 	hitsound = 'sound/weapons/sear.ogg'
 
 /obj/item/weapon/scalpel/manager
@@ -114,7 +112,6 @@
 	icon_state = "scalpel_manager_on"
 	item_state = "scalpel"
 	damtype = "fire"
-	force = 18.0
 	hitsound = 'sound/weapons/sear.ogg'
 
 /obj/item/weapon/circular_saw


### PR DESCRIPTION
I should have known better than to give these crazy damage values when I ported them.

- reduces the damage on the laser scalpels to a universal 10.
 - Still do fire damage instead of brute and have a custom hitsound.

People are asking and wanting these from R&D because they're good weapons for self-defense that do insane amounts of damage and have no fuel requirement---not to mention they can be kept in your pocket.
