### PR TITLE
Make EXPERI-Mentor SetTypeReactions() way more efficient

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -57,30 +57,27 @@
 /obj/machinery/r_n_d/experimentor/proc/SetTypeReactions()
 	var/probWeight = 0
 	for(var/I in typesof(/obj/item))
-		if(istype(I,/obj/item/weapon/relic))
+		if(istype(I,/obj/item/weapon/relic)) //does istype even work here
 			item_reactions["[I]"] = SCANTYPE_DISCOVER
 		else
 			item_reactions["[I]"] = pick(SCANTYPE_POKE,SCANTYPE_IRRADIATE,SCANTYPE_GAS,SCANTYPE_HEAT,SCANTYPE_COLD,SCANTYPE_OBLITERATE)
 		if(ispath(I,/obj/item/weapon/stock_parts) || ispath(I,/obj/item/weapon/grenade/chem_grenade) || ispath(I,/obj/item/weapon/kitchen))
-			var/obj/item/tempCheck = new I()
-			if(tempCheck.icon_state != null) //check it's an actual usable item, in a hacky way
+			var/obj/item/tempCheck = I
+			if(initial(tempCheck.icon_state) != null) //check it's an actual usable item, in a hacky way
 				valid_items += 15
 				valid_items += I
 				probWeight++
-			qdel(tempCheck)
 
 		if(ispath(I,/obj/item/weapon/reagent_containers/food))
-			var/obj/item/tempCheck = new I()
-			if(tempCheck.icon_state != null) //check it's an actual usable item, in a hacky way
+			var/obj/item/tempCheck = I
+			if(initial(tempCheck.icon_state) != null) //check it's an actual usable item, in a hacky way
 				valid_items += rand(1,max(2,35-probWeight))
 				valid_items += I
-			qdel(tempCheck)
 
 		if(ispath(I,/obj/item/weapon/rcd) || ispath(I,/obj/item/weapon/grenade) || ispath(I,/obj/item/device/aicard) || ispath(I,/obj/item/weapon/storage/backpack/holding) || ispath(I,/obj/item/slime_extract) || ispath(I,/obj/item/device/onetankbomb) || ispath(I,/obj/item/device/transfer_valve))
-			var/obj/item/tempCheck = new I()
-			if(tempCheck.icon_state != null)
+			var/obj/item/tempCheck = I
+			if(initial(tempCheck.icon_state) != null)
 				critical_items += I
-			qdel(tempCheck)
 
 
 /obj/machinery/r_n_d/experimentor/New()


### PR DESCRIPTION
Thanks, Redbook.

Basically, this used to spawn a shitload of instances and then qdel them;
Just so it could check their icon_state and see if it's not null. However,
spawning so many instances is quite intensive. An undocumented feature
(documented in the [redbook](https://docs.google.com/document/pub?id=1HGkCp4eQU8Jp14Srh8Isuv_liehzV_XB6IcSUbVFFiY&embedded=true&revision=latest%22%22#h.d403aw6sdp8s), a list of undocumented features); You can
directly access a compile-time variable with just it's path by using
initial().