### PR TITLE
EXPERI-Mentor Bandaid Fix

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -346,7 +346,7 @@
 			throwSmoke(src.loc)
 		if(prob(EFFECT_PROB_MEDIUM-badThingCoeff))
 			visible_message("<span class='warning'>[src] melts [exp_on], ionizing the air around it!</span>")
-			empulse(src.loc, 4, 6)
+			empulse(src.loc, 4, 0) //change this to 4,6 once the EXPERI-Mentor is moved.
 			investigate_log("Experimentor has generated an Electromagnetic Pulse.", "experimentor")
 			ejectItem(TRUE)
 	////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I'd eventually like to move the EXPERI-Mentor, but this will do for now.

This keeps the EMP pulse on the machine as large as possible without it negatively impacting genetics or the psychologist's office.

You can still EMP the RND servers, but, thus far, I've noticed no negative effects of this; I EMP'd the servers until the entire room ran out of power, and I still had my research levels at R&D and robotics--even after I destroyed+rebuilt the consoles and resync'd.

You're still going to get wrecked if you're doing research in this room as an IPC, if this EMP triggers--that's part of the risk of this; organic players have to deal with other problems with this machine.