### PR TITLE
-tg- buckling system

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -24,12 +24,12 @@ Pipelines + Other Objects -> Pipe network
 	var/icon_connect_type = "" //"-supply" or "-scrubbers"
 
 	var/initialize_directions = 0
-	
+
 	var/pipe_color
 	var/obj/item/pipe/stored
 	var/image/pipe_image
 	var/global/datum/pipe_icon_manager/icon_manager
-	
+
 /obj/machinery/atmospherics/New()
 	if(!icon_manager)
 		icon_manager = new()
@@ -40,10 +40,10 @@ Pipelines + Other Objects -> Pipe network
 
 	if(!pipe_color_check(pipe_color))
 		pipe_color = null
-	
+
 	if(can_unwrench)
 		stored = new(src, make_from = src)
-	
+
 	..()
 
 /obj/machinery/atmospherics/Destroy()
@@ -54,10 +54,10 @@ Pipelines + Other Objects -> Pipe network
 		del(pipe_image) //we have to del it, or it might keep a ref somewhere else
 	return ..()
 
-// Icons/overlays/underlays	
+// Icons/overlays/underlays
 /obj/machinery/atmospherics/update_icon()
 	return null
-	
+
 /obj/machinery/atmospherics/proc/check_icon_cache(var/safety = 0)
 	if(!istype(icon_manager))
 		if(!safety) //to prevent infinite loops
@@ -92,7 +92,7 @@ Pipelines + Other Objects -> Pipe network
 	else
 		return 0
 
-// Connect types	
+// Connect types
 /obj/machinery/atmospherics/proc/check_connect_types(obj/machinery/atmospherics/atmos1, obj/machinery/atmospherics/atmos2)
 	var/i
 	var/list1[] = atmos1.connect_types
@@ -117,7 +117,7 @@ Pipelines + Other Objects -> Pipe network
 				return n
 	return 0
 
-// Pipenet related functions	
+// Pipenet related functions
 /obj/machinery/atmospherics/proc/returnPipenet()
 	return
 
@@ -135,8 +135,8 @@ Pipelines + Other Objects -> Pipe network
 	return
 
 /obj/machinery/atmospherics/proc/disconnect(obj/machinery/atmospherics/reference)
-	return	
-	
+	return
+
 /obj/machinery/atmospherics/proc/nullifyPipenet(datum/pipeline/P)
 	if(P)
 		P.other_atmosmch -= src
@@ -151,7 +151,7 @@ Pipelines + Other Objects -> Pipe network
 		var/datum/gas_mixture/int_air = return_air()
 		var/datum/gas_mixture/env_air = loc.return_air()
 		add_fingerprint(user)
-		
+
 		var/unsafe_wrenching = FALSE
 		var/internal_pressure = int_air.return_pressure()-env_air.return_pressure()
 
@@ -160,21 +160,21 @@ Pipelines + Other Objects -> Pipe network
 		if (internal_pressure > 2*ONE_ATMOSPHERE)
 			user << "<span class='warning'>As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?</span>"
 			unsafe_wrenching = TRUE //Oh dear oh dear
-		
+
 		if (do_after(user, 40, target = src) && isnull(gcDestroyed))
 			user.visible_message( \
 				"[user] unfastens \the [src].", \
 				"<span class='notice'>You have unfastened \the [src].</span>", \
 				"<span class='italics'>You hear ratchet.</span>")
 			investigate_log("was <span class='warning'>REMOVED</span> by [key_name(usr)]", "atmos")
-			
+
 			//You unwrenched a pipe full of pressure? let's splat you into the wall silly.
 			if(unsafe_wrenching)
-				unsafe_pressure_release(user,internal_pressure)			
+				unsafe_pressure_release(user,internal_pressure)
 			Deconstruct()
 	else
 		return ..()
-	
+
 //Called when an atmospherics object is unwrenched while having a large pressure difference
 //with it's locs air contents.
 /obj/machinery/atmospherics/proc/unsafe_pressure_release(var/mob/user,var/pressures)
@@ -191,7 +191,7 @@ Pipelines + Other Objects -> Pipe network
 	user.visible_message("<span class='danger'>[user] is sent flying by pressure!</span>","<span class='userdanger'>The pressure sends you flying!</span>")
 	//Values based on 2*ONE_ATMOS (the unsafe pressure), resulting in 20 range and 4 speed
 	user.throw_at(general_direction,pressures/10,pressures/50)
-	
+
 /obj/machinery/atmospherics/proc/Deconstruct()
 	if(can_unwrench)
 		var/turf/T = get_turf(src)
@@ -203,7 +203,7 @@ Pipelines + Other Objects -> Pipe network
 					new /obj/item/pipe_meter(T)
 					qdel(meter)
 		qdel(src)
-	
+
 /obj/machinery/atmospherics/construction(D, P, C)
 	if(C)
 		color = C
@@ -217,7 +217,7 @@ Pipelines + Other Objects -> Pipe network
 		A.initialize()
 		A.addMember(src)
 	build_network()
-	
+
 // Find a connecting /obj/machinery/atmospherics in specified direction.
 /obj/machinery/atmospherics/proc/findConnecting(var/direction)
 	for(var/obj/machinery/atmospherics/target in get_step(src,direction))
@@ -225,10 +225,13 @@ Pipelines + Other Objects -> Pipe network
 		if(can_connect && (target.initialize_directions & get_dir(target,src)))
 			return target
 
-// Ventcrawling		
+// Ventcrawling
 #define VENT_SOUND_DELAY 30
 /obj/machinery/atmospherics/relaymove(mob/living/user, direction)
 	if(!(direction & initialize_directions)) //can't go in a way we aren't connecting to
+		return
+
+	if(buckled_mob == user)
 		return
 
 	var/obj/machinery/atmospherics/target_move = findConnecting(direction)
@@ -263,7 +266,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/proc/can_crawl_through()
 	return 1
-	
+
 /obj/machinery/atmospherics/proc/change_color(var/new_color)
 	//only pass valid pipe colors please ~otherwise your pipe will turn invisible
 	if(!pipe_color_check(new_color))
@@ -272,7 +275,7 @@ Pipelines + Other Objects -> Pipe network
 	pipe_color = new_color
 	update_icon()
 
-// Additional icon procs	
+// Additional icon procs
 /obj/machinery/atmospherics/proc/universal_underlays(var/obj/machinery/atmospherics/node, var/direction)
 	var/turf/T = get_turf(src)
 	if(!istype(T)) return
@@ -303,8 +306,7 @@ Pipelines + Other Objects -> Pipe network
 			underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "intact" + icon_connect_type)
 	else
 		underlays += icon_manager.get_atmos_icon("underlay", direction, color_cache_name(node), "retracted" + icon_connect_type)
-	
+
 /obj/machinery/atmospherics/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)
-		Deconstruct()	
-		
+		Deconstruct()

--- a/code/ATMOSPHERICS/pipes/pipe.dm
+++ b/code/ATMOSPHERICS/pipes/pipe.dm
@@ -7,13 +7,19 @@
 	use_power = 0
 	can_unwrench = 1
 	var/alert_pressure = 80*ONE_ATMOSPHERE //minimum pressure before check_pressure(...) should be called
-		
+
+	//Buckling
+	can_buckle = 1
+	buckle_requires_restraints = 1
+	buckle_lying = -1
+
+
 /obj/machinery/atmospherics/pipe/New()
 	..()
 	//so pipes under walls are hidden
 	if(istype(get_turf(src), /turf/simulated/wall) || istype(get_turf(src), /turf/simulated/shuttle/wall) || istype(get_turf(src), /turf/unsimulated/wall))
 		level = 1
-		
+
 /obj/machinery/atmospherics/pipe/Destroy()
 	releaseAirToTurf()
 	qdel(air_temporary)
@@ -39,7 +45,7 @@
 	//Return null if parent should stop checking other pipes. Recall: del(src) will by default return null
 
 	return 1
-	
+
 /obj/machinery/atmospherics/pipe/proc/releaseAirToTurf()
 	if(air_temporary)
 		var/turf/T = loc
@@ -55,7 +61,7 @@
 	if(!parent)
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
-		
+
 /obj/machinery/atmospherics/pipe/setPipenet(datum/pipeline/P)
 	parent = P
 
@@ -69,4 +75,3 @@
 		return node.pipe_color
 	else
 		return pipe_color
-		

--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple_he.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple_he.dm
@@ -9,23 +9,55 @@
 	minimum_temperature_difference = 20
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 
+	color = "#404040"
+	buckle_lying = 1
+	var/icon_temperature = T20C //stop small changes in temperature causing icon refresh
+
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/process()
 	var/environment_temperature = 0
-	if(istype(loc, /turf/simulated))
-		if(loc:blocks_air)
-			environment_temperature = loc:temperature
+	var/datum/gas_mixture/pipe_air = return_air()
+
+	var/turf/simulated/T = loc
+	if(istype(T))
+		if(T.blocks_air)
+			environment_temperature = T.temperature
 		else
-			var/datum/gas_mixture/environment = loc.return_air()
+			var/datum/gas_mixture/environment = T.return_air()
 			environment_temperature = environment.temperature
 	else
-		environment_temperature = loc:temperature
-	var/datum/gas_mixture/pipe_air = return_air()
+		environment_temperature = T.temperature
+
 	if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
-		parent.temperature_interact(loc, volume, thermal_conductivity)
+		parent.temperature_interact(T, volume, thermal_conductivity)
+
+	//Heat causes pipe to glow
+	if(pipe_air.temperature && (icon_temperature > 500 || pipe_air.temperature > 500)) //glow starts at 500K
+		if(abs(pipe_air.temperature - icon_temperature) > 10)
+			icon_temperature = pipe_air.temperature
+
+			var/h_r = heat2color_r(icon_temperature)
+			var/h_g = heat2color_g(icon_temperature)
+			var/h_b = heat2color_b(icon_temperature)
+
+			if(icon_temperature < 2000)//scale glow until 2000K
+				var/scale = (icon_temperature - 500) / 1500
+				h_r = 64 + (h_r - 64) * scale
+				h_g = 64 + (h_g - 64) * scale
+				h_b = 64 + (h_b - 64) * scale
+
+			animate(src, color = rgb(h_r, h_g, h_b), time = 20, easing = SINE_EASING)
+
+	//burn any mobs buckled based on temperature
+	if(buckled_mob)
+		var/heat_limit = 1000
+		if(pipe_air.temperature > heat_limit + 1)
+			buckled_mob.apply_damage(4 * log(pipe_air.temperature - heat_limit), BURN, "chest")
+
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/New()
 	..()
 	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
+	color = "#404040"
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/initialize()
 	normalize_dir()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -385,16 +385,16 @@
 // Simple helper to face what you clicked on, in case it should be needed in more than one place
 /mob/proc/face_atom(var/atom/A)
 
-	// Snowflake for space vines.
+/*	// Snowflake for space vines. //Are you fucking kidding me?
 	var/is_buckled = 0
 	if(buckled)
 		if(istype(buckled))
 			if(!buckled.movable)
 				is_buckled = 1
 		else
-			is_buckled = 0
+			is_buckled = 0*/
 
-	if( stat || is_buckled || !A || !x || !y || !A.x || !A.y ) return
+	if( stat || buckled || !A || !x || !y || !A.x || !A.y ) return
 	var/dx = A.x - x
 	var/dy = A.y - y
 	if(!dx && !dy) return
@@ -407,6 +407,7 @@
 		if(dx > 0)	direction = EAST
 		else		direction = WEST
 	usr.dir = direction
-	if(buckled && buckled.movable)
+
+/*	if(buckled && buckled.movable)
 		buckled.dir = direction
-		buckled.handle_rotation()
+		buckled.handle_rotation()*/

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -124,7 +124,7 @@
 	if(isliving(teleatom))
 		var/mob/living/L = teleatom
 		if(L.buckled)
-			L.buckled.unbuckle()
+			L.buckled.unbuckle_mob()
 
 	destarea.Entered(teleatom)
 

--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -46,7 +46,7 @@
 			return
 
 		if(target && target.buckled)
-			target.buckled.unbuckle()
+			target.buckled.unbuckle_mob()
 
 		var/list/tempL = L
 		var/attempt = null

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -23,7 +23,7 @@
 
 			if(target.buckled)
 				var/obj/structure/stool/bed/buckled_to = target.buckled.
-				buckled_to.unbuckle()
+				buckled_to.unbuckle_mob()
 
 			var/mobloc = get_turf(target.loc)
 			var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( mobloc )
@@ -37,7 +37,7 @@
 			animation.master = holder
 			target.ExtinguishMob()
 			if(target.buckled)
-				target.buckled.unbuckle()
+				target.buckled.unbuckle_mob()
 			if(phaseshift == 1)
 				animation.dir = target.dir
 				flick("phase_shift",animation)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -448,6 +448,9 @@ its easier to just keep the beam vertical.
 	else
 		return 0
 
+/atom/proc/handle_fall()
+	return
+
 /atom/proc/singularity_act()
 	return
 

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -139,7 +139,7 @@
 		user.incorporeal_move = 1
 		user.alpha = 0
 		if(user.buckled)
-			user.buckled.unbuckle()
+			user.buckled.unbuckle_mob()
 		sleep(40) //4 seconds
 		user.visible_message("<span class='warning'>[user] suddenly manifests!</span>", "<span class='shadowling'>The pressure becomes too much and you vacate the interdimensional darkness.</span>")
 		user.incorporeal_move = 0

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -372,7 +372,7 @@
 	if(!M) return
 
 	if(M.current.vampire_power(30, 0))
-		if(M.current.buckled) M.current.buckled.unbuckle()
+		if(M.current.buckled) M.current.buckled.unbuckle_mob()
 		spawn(0)
 			var/originalloc = get_turf(M.current.loc)
 			var/obj/effect/dummy/spell_jaunt/holder = new /obj/effect/dummy/spell_jaunt( originalloc )
@@ -386,7 +386,7 @@
 			animation.master = holder
 			M.current.ExtinguishMob()
 			if(M.current.buckled)
-				M.current.buckled.unbuckle()
+				M.current.buckled.unbuckle_mob()
 			flick("liquify",animation)
 			M.current.loc = holder
 			M.current.client.eye = holder
@@ -436,7 +436,7 @@
 	var/max_lum = 1
 
 	if(M.current.vampire_power(30, 0))
-		if(M.current.buckled) M.current.buckled.unbuckle()
+		if(M.current.buckled) M.current.buckled.unbuckle_mob()
 		spawn(0)
 			var/list/turfs = new/list()
 			for(var/turf/T in range(usr,outer_tele_radius))
@@ -463,7 +463,7 @@
 				return
 			M.current.ExtinguishMob()
 			if(M.current.buckled)
-				M.current.buckled.unbuckle()
+				M.current.buckled.unbuckle_mob()
 			var/atom/movable/overlay/animation = new /atom/movable/overlay( get_turf(usr) )
 			animation.name = usr.name
 			animation.density = 0

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -1,0 +1,100 @@
+
+
+/obj
+	var/can_buckle = 0
+	var/buckle_lying = -1 //bed-like behaviour, forces mob.lying = buckle_lying if != -1
+	var/buckle_requires_restraints = 0 //require people to be handcuffed before being able to buckle. eg: pipes
+	var/mob/living/buckled_mob = null
+
+
+//Interaction
+/obj/attack_hand(mob/living/user)
+	. = ..()
+	if(can_buckle && buckled_mob)
+		return user_unbuckle_mob(user)
+
+/obj/MouseDrop_T(mob/living/M, mob/living/user)
+	. = ..()
+	if(can_buckle && istype(M))
+		return user_buckle_mob(M, user)
+
+
+//Cleanup
+/obj/Destroy()
+	. = ..()
+	unbuckle_mob()
+
+//procs that handle the actual buckling and unbuckling
+/obj/proc/buckle_mob(mob/living/M)
+	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || (buckle_requires_restraints && !M.restrained()))
+		return 0
+
+	if (isslime(M) || isAI(M))
+		if(M == usr)
+			M << "<span class='warning'>You are unable to buckle yourself to the [src]!</span>"
+		else
+			usr << "<span class='warning'>You are unable to buckle [M] to the [src]!</span>"
+		return 0
+
+	M.buckled = src
+	M.dir = dir
+	buckled_mob = M
+	M.update_canmove()
+	post_buckle_mob(M)
+	return 1
+
+/obj/proc/unbuckle_mob()
+	if(buckled_mob && buckled_mob.buckled == src)
+		. = buckled_mob
+		buckled_mob.buckled = null
+		buckled_mob.anchored = initial(buckled_mob.anchored)
+		buckled_mob.update_canmove()
+		buckled_mob = null
+
+		post_buckle_mob(.)
+
+
+//Handle any extras after buckling/unbuckling
+//Called on buckle_mob() and unbuckle_mob()
+/obj/proc/post_buckle_mob(mob/living/M)
+	return
+
+
+//Wrapper procs that handle sanity and user feedback
+/obj/proc/user_buckle_mob(mob/living/M, mob/user)
+	if(!in_range(user, src) || user.stat || user.restrained())
+		return 0
+
+	add_fingerprint(user)
+	unbuckle_mob()
+
+	if(buckle_mob(M))
+		if(M == user)
+			M.visible_message(\
+				"<span class='notice'>[M] buckles themself to [src].</span>",\
+				"<span class='notice'>You buckle yourself to [src].</span>",\
+				"<span class='italics'>You hear metal clanking.</span>")
+		else
+			M.visible_message(\
+				"<span class='warning'>[user] buckles [M] to [src]!</span>",\
+				"<span class='warning'>[user] buckles you to [src]!</span>",\
+				"<span class='italics'>You hear metal clanking.</span>")
+		return 1
+
+/obj/proc/user_unbuckle_mob(mob/user)
+	var/mob/living/M = unbuckle_mob()
+	if(M)
+		if(M != user)
+			M.visible_message(\
+				"<span class='notice'>[user] unbuckles [M] from [src].</span>",\
+				"<span class='notice'>[user] unbuckles you from [src].</span>",\
+				"<span class='italics'>You hear metal clanking.</span>")
+		else
+			M.visible_message(\
+				"<span class='notice'>[M] unbuckles themselves from [src].</span>",\
+				"<span class='notice'>You unbuckle yourself from [src].</span>",\
+				"<span class='italics'>You hear metal clanking.</span>")
+		add_fingerprint(user)
+	return M
+
+

--- a/code/game/objects/items/weapons/implants/implantfreedom.dm
+++ b/code/game/objects/items/weapons/implants/implantfreedom.dm
@@ -23,6 +23,8 @@
 			if (source.handcuffed)
 				var/obj/item/weapon/W = source.handcuffed
 				source.handcuffed = null
+				if(source.buckled && source.buckled.buckle_requires_restraints)
+					source.buckled.unbuckle_mob()
 				source.update_inv_handcuffed()
 				if (source.client)
 					source.client.screen -= W

--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -74,7 +74,7 @@
 		return
 
 	if(user && user.buckled)
-		user.buckled.unbuckle()
+		user.buckled.unbuckle_mob()
 
 	var/list/tempL = L
 	var/attempt = null

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -125,6 +125,8 @@
 			"You cut \the [C]'s restraints with \the [src]!",\
 			"You hear cable being cut.")
 			C.handcuffed = null
+			if(C.buckled && C.buckled.buckle_requires_restraints)
+				C.buckled.unbuckle_mob()
 			C.update_inv_handcuffed()
 			return
 	else
@@ -168,15 +170,15 @@
 	reagents.add_reagent("fuel", max_fuel)
 	update_icon()
 	return
-	
+
 /obj/item/weapon/weldingtool/examine(mob/user)
 	if(!..(user, 0))
 		user << "It contains [get_fuel()] unit\s of fuel out of [max_fuel]."
-	
+
 /obj/item/weapon/weldingtool/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] welds \his every orifice closed! It looks like \he's trying to commit suicide..</span>")
 	return (FIRELOSS)
-	
+
 /obj/item/weapon/weldingtool/proc/update_torch()
 	overlays.Cut()
 	if(welding)
@@ -235,7 +237,7 @@
 		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
 		if (!S)
 			return
-			
+
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != I_HELP || S.open == 2)
 			return ..()
 
@@ -254,7 +256,7 @@
 		else if(S.open != 2)
 			user << "<span class='notice'>Nothing to fix!</span>"
 	else
-		return ..()		
+		return ..()
 
 /obj/item/weapon/weldingtool/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(!proximity) return
@@ -388,7 +390,7 @@
 				spawn(100)
 					user.disabilities &= ~NEARSIGHTED
 	return
-	
+
 /obj/item/weapon/weldingtool/proc/flamethrower_screwdriver(obj/item/I, mob/user)
 	if(welding)
 		user << "<span class='warning'>Turn it off first!</span>"
@@ -428,7 +430,7 @@
 
 /obj/item/weapon/weldingtool/largetank/flamethrower_screwdriver()
 	return
-	
+
 /obj/item/weapon/weldingtool/mini
 	name = "emergency welding tool"
 	desc = "A miniature welder used during emergencies."
@@ -439,8 +441,8 @@
 	change_icons = 0
 
 /obj/item/weapon/weldingtool/mini/flamethrower_screwdriver()
-	return	
-	
+	return
+
 /obj/item/weapon/weldingtool/hugetank
 	name = "Upgraded Welding Tool"
 	desc = "An upgraded welder based of the industrial welder."

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -20,11 +20,6 @@
 		if(3.0)
 			return
 
-/obj/structure/Destroy()
-	if(hascall(src, "unbuckle"))
-		src:unbuckle()
-	return ..()
-
 /obj/structure/mech_melee_attack(obj/mecha/M)
 	if(M.damtype == "brute")
 		M.occupant_message("<span class='danger'>You hit [src].</span>")
@@ -47,6 +42,8 @@
 	do_climb(usr)
 
 /obj/structure/MouseDrop_T(var/atom/movable/C, mob/user as mob)
+	if(..())
+		return
 	if(C == user)
 		do_climb(user)
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -11,32 +11,40 @@
 	name = "bed"
 	desc = "This is used to lie in, sleep in or strap on."
 	icon_state = "bed"
-	var/mob/living/buckled_mob
+	can_buckle = 1
+	buckle_lying = 1
 	var/movable = 0 // For mobility checks
+
+/obj/structure/stool/bed/MouseDrop(atom/over_object)
+	..(over_object, 1)
 
 /obj/structure/stool/psychbed
 	name = "psych bed"
 	desc = "For prime comfort during psychiatric evaluations."
 	icon_state = "psychbed"
-	var/mob/living/buckled_mob
+	can_buckle = 1
+	buckle_lying = 1
 
 /obj/structure/stool/bed/alien
 	name = "resting contraption"
 	desc = "This looks similar to contraptions from earth. Could aliens be stealing our technology?"
 	icon_state = "abed"
 
-/obj/structure/stool/bed/Destroy()
-	unbuckle()
+/obj/structure/stool/bed/Move(atom/newloc, direct) //Some bed children move
+	. = ..()
+	if(buckled_mob)
+		if(!buckled_mob.Move(loc, direct))
+			loc = buckled_mob.loc //we gotta go back
+			last_move = buckled_mob.last_move
+			buckled_mob.inertia_dir = last_move
+			. = 0
+
+/obj/structure/stool/bed/CanPass(atom/movable/mover, turf/target, height=1.5)
+	if(mover == buckled_mob)
+		return 1
 	return ..()
 
-/obj/structure/stool/bed/attack_hand(mob/user as mob)
-	manual_unbuckle(user)
-	return
-
 /obj/structure/stool/bed/proc/handle_rotation()
-	return
-
-/obj/structure/stool/bed/MouseDrop(atom/over_object)
 	return
 
 /obj/structure/stool/bed/attack_animal(var/mob/living/simple_animal/M)//No more buckling hostile mobs to chairs to render them immobile forever
@@ -44,77 +52,6 @@
 		new /obj/item/stack/sheet/metal(src.loc)
 		qdel(src)
 
-
-/obj/structure/stool/bed/MouseDrop_T(mob/M as mob, mob/user as mob)
-	if(!istype(M)) return
-	buckle_mob(M, user)
-	return
-
-/obj/structure/stool/bed/proc/afterbuckle(mob/M as mob) //Called after somebody buckled / unbuckled
-	return
-
-/obj/structure/stool/bed/proc/unbuckle()
-	if(buckled_mob)
-		if(buckled_mob.buckled == src)	//this is probably unneccesary, but it doesn't hurt
-			buckled_mob.buckled = null
-			buckled_mob.anchored = initial(buckled_mob.anchored)
-			buckled_mob.update_canmove()
-
-			var/M = buckled_mob
-			buckled_mob = null
-
-			afterbuckle(M)
-	return
-
-/obj/structure/stool/bed/proc/manual_unbuckle(mob/user as mob)
-	if(buckled_mob)
-		if(buckled_mob.buckled == src)
-			if(buckled_mob != user)
-				buckled_mob.visible_message(\
-					"\blue [buckled_mob.name] was unbuckled by [user.name]!",\
-					"You were unbuckled from [src] by [user.name].",\
-					"You hear metal clanking")
-			else
-				buckled_mob.visible_message(\
-					"\blue [buckled_mob.name] unbuckled \himself!",\
-					"You unbuckle yourself from [src].",\
-					"You hear metal clanking")
-			unbuckle()
-			src.add_fingerprint(user)
-			return 1
-
-	return 0
-
-/obj/structure/stool/bed/proc/buckle_mob(mob/M as mob, mob/user as mob)
-	if (!ticker)
-		user << "You can't buckle anyone in before the game starts."
-	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.stunned || user.stat || M.buckled || istype(user, /mob/living/silicon/pai) )
-		return
-
-	if (istype(M, /mob/living/carbon/slime))
-		user << "The [M] is too squishy to buckle in."
-		return
-
-	unbuckle()
-
-	if (M == usr)
-		M.visible_message(\
-			"\blue [M.name] buckles in!",\
-			"You buckle yourself to [src].",\
-			"You hear metal clanking")
-	else
-		M.visible_message(\
-			"\blue [M.name] is buckled in to [src] by [user.name]!",\
-			"You are buckled in to [src] by [user.name].",\
-			"You hear metal clanking")
-	M.buckled = src
-	M.loc = src.loc
-	M.dir = src.dir
-	M.update_canmove()
-	src.buckled_mob = M
-	src.add_fingerprint(user)
-	afterbuckle(M)
-	return
 
 /*
  * Roller beds
@@ -125,41 +62,44 @@
 	icon_state = "down"
 	anchored = 0
 
-/obj/structure/stool/bed/roller/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if(istype(W,/obj/item/roller_holder))
-		if(buckled_mob)
-			manual_unbuckle()
-		else
-			visible_message("[user] collapses \the [src.name].")
-			new/obj/item/roller(get_turf(src))
-			spawn(0)
-				qdel(src)
-		return
-	..()
+/obj/structure/stool/bed/roller/post_buckle_mob(mob/living/M)
+	if(M == buckled_mob)
+		density = 1
+		icon_state = "up"
+		M.pixel_y = initial(M.pixel_y)
+	else
+		density = 0
+		icon_state = "down"
+		M.pixel_x = M.get_standard_pixel_x_offset(M.lying)
+		M.pixel_y = M.get_standard_pixel_y_offset(M.lying)
+
 
 /obj/item/roller
 	name = "roller bed"
 	desc = "A collapsed roller bed that can be carried around."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
-	w_class = 4.0 // Can't be put in backpacks. Oh well.
+	w_class = 4 // Can't be put in backpacks.
+
 
 /obj/item/roller/attack_self(mob/user)
-		var/obj/structure/stool/bed/roller/R = new /obj/structure/stool/bed/roller(user.loc)
-		R.add_fingerprint(user)
-		qdel(src)
+	var/obj/structure/stool/bed/roller/R = new /obj/structure/stool/bed/roller(user.loc)
+	R.add_fingerprint(user)
+	qdel(src)
 
-/obj/item/roller/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-
-	if(istype(W,/obj/item/roller_holder))
-		var/obj/item/roller_holder/RH = W
-		if(!RH.held)
-			user << "\blue You collect the roller bed."
-			src.loc = RH
-			RH.held = src
-			return
-
+/obj/structure/stool/bed/roller/MouseDrop(over_object, src_location, over_location)
 	..()
+	if(over_object == usr && Adjacent(usr) && (in_range(src, usr) || usr.contents.Find(src)))
+		if(!ishuman(usr))
+			return
+		if(buckled_mob)
+			return 0
+		usr.visible_message("[usr] collapses \the [src.name].", "<span class='notice'>You collapse \the [src.name].</span>")
+		new/obj/item/roller(get_turf(src))
+		qdel(src)
+		return
+
+
 
 /obj/item/roller_holder
 	name = "roller bed rack"
@@ -173,7 +113,6 @@
 	held = new /obj/item/roller(src)
 
 /obj/item/roller_holder/attack_self(mob/user as mob)
-
 	if(!held)
 		user << "\blue The rack is empty."
 		return
@@ -183,45 +122,3 @@
 	R.add_fingerprint(user)
 	qdel(held)
 	held = null
-
-
-/obj/structure/stool/bed/roller/Move()
-	..()
-	if(buckled_mob)
-		if(buckled_mob.buckled == src)
-			buckled_mob.loc = src.loc
-		else
-			buckled_mob = null
-
-/obj/structure/stool/bed/roller/buckle_mob(mob/M as mob, mob/user as mob)
-	if ( !ismob(M) || (get_dist(src, user) > 1) || (M.loc != src.loc) || user.restrained() || user.lying || user.stat || M.buckled || istype(usr, /mob/living/silicon/pai) )
-		return
-	M.pixel_y = 6
-	density = 1
-	icon_state = "up"
-	..()
-	return
-
-/obj/structure/stool/bed/roller/manual_unbuckle(mob/user as mob)
-	if(buckled_mob)
-		if(buckled_mob.buckled == src)	//this is probably unneccesary, but it doesn't hurt
-			buckled_mob.pixel_y = 0
-			buckled_mob.anchored = initial(buckled_mob.anchored)
-			buckled_mob.buckled = null
-			buckled_mob.update_canmove()
-			buckled_mob = null
-	density = 0
-	icon_state = "down"
-	..()
-	return
-
-/obj/structure/stool/bed/roller/MouseDrop(over_object, src_location, over_location)
-	..()
-	if((over_object == usr && (in_range(src, usr) || usr.contents.Find(src))))
-		if(!ishuman(usr))	return
-		if(buckled_mob)	return 0
-		visible_message("[usr] collapses \the [src.name]")
-		new/obj/item/roller(get_turf(src))
-		spawn(0)
-			qdel(src)
-		return

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -2,11 +2,9 @@
 	name = "chair"
 	desc = "You sit in this. Either by will or force."
 	icon_state = "chair"
+	buckle_lying = 0 //you sit in a chair, not lay
 
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
-
-/obj/structure/stool/MouseDrop(atom/over_object)
-	return
 
 /obj/structure/stool/bed/chair/New()
 	if(anchored)
@@ -66,11 +64,6 @@
 		handle_rotation()
 		return
 
-/obj/structure/stool/bed/chair/MouseDrop_T(mob/M as mob, mob/user as mob)
-	if(!istype(M)) return
-	buckle_mob(M, user)
-	return
-
 // Chair types
 /obj/structure/stool/bed/chair/wood
 	// TODO:  Special ash subtype that looks like charred chair legs
@@ -106,7 +99,7 @@
 
 	return ..()
 
-/obj/structure/stool/bed/chair/comfy/afterbuckle()
+/obj/structure/stool/bed/chair/comfy/post_buckle_mob(mob/living/M)
 	if(buckled_mob)
 		overlays += armrest
 	else
@@ -143,29 +136,13 @@
 	anchored = 0
 	movable = 1
 
-/obj/structure/stool/bed/chair/office/Move()
-	..()
-	if(buckled_mob)
-		var/mob/living/occupant = buckled_mob
-		occupant.buckled = null
-		occupant.Move(src.loc)
-		occupant.buckled = src
-		if (occupant && (src.loc != occupant.loc))
-			if (propelled)
-				for (var/mob/O in src.loc)
-					if (O != occupant)
-						Bump(O)
-			else
-				unbuckle()
-	handle_rotation()
-
 /obj/structure/stool/bed/chair/office/Bump(atom/A)
 	..()
 	if(!buckled_mob)	return
 
 	if(propelled)
 		var/mob/living/occupant = buckled_mob
-		unbuckle()
+		unbuckle_mob()
 		occupant.throw_at(A, 3, propelled)
 		occupant.apply_effect(6, STUN, 0)
 		occupant.apply_effect(6, WEAKEN, 0)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -32,7 +32,9 @@
 		qdel(src)
 	return
 
-/obj/structure/stool/MouseDrop(atom/over_object)
+/obj/structure/stool/MouseDrop(atom/over_object, skip_fucking_stool_shit = 0)
+	if(skip_fucking_stool_shit)
+		return ..(over_object)
 	if (istype(over_object, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = over_object
 		if (H==usr && !H.restrained() && !H.stat && in_range(src, over_object))

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -42,6 +42,16 @@
 		user << "\red You cannot drive while being pushed."
 		return
 
+	if(istype(user.loc, /turf/space))
+		return
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/driver = user
+		var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
+		var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
+		if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
+			return // No hands to drive your chair? Tough luck!
+
 	// Let's roll
 	driving = 1
 	var/turf/T = null
@@ -88,7 +98,7 @@
 						if (O != occupant)
 							Bump(O)
 				else
-					unbuckle()
+					unbuckle_mob()
 			if (pulling && (get_dist(src, pulling) > 1))
 				pulling.pulledby = null
 				pulling << "\red You lost your grip!"
@@ -102,7 +112,7 @@
 	if (pulling)
 		MouseDrop(usr)
 	else
-		manual_unbuckle(user)
+		user_unbuckle_mob(user, user)
 	return
 
 /obj/structure/stool/bed/chair/wheelchair/MouseDrop(over_object, src_location, over_location)
@@ -135,7 +145,7 @@
 
 	if(propelled || (pulling && (pulling.a_intent == I_HARM)))
 		var/mob/living/occupant = buckled_mob
-		unbuckle()
+		unbuckle_mob()
 
 		if (pulling && (pulling.a_intent == "hurt"))
 			occupant.throw_at(A, 3, 3, pulling)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -387,6 +387,13 @@
 
 ////////////////////////////////////////////////////
 
+/turf/handle_fall(mob/faller, forced)
+	faller.lying = pick(90, 270)
+	if(!forced)
+		return
+	if(has_gravity(src))
+		playsound(src, "bodyfall", 50, 1)
+
 /turf/singularity_act()
 	if(intact)
 		for(var/obj/O in contents) //this is for deleting things like wires contained in the turf

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -83,7 +83,7 @@
 		phaseanim.master = user
 		user.ExtinguishMob()
 		if(user.buckled)
-			user.buckled.unbuckle()
+			user.buckled.unbuckle_mob()
 		user.loc = holder
 		flick("chronophase", phaseanim)
 		spawn(7)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -71,13 +71,13 @@
 
 /obj/effect/plant/Destroy()
 	if(buckled_mob)
-		unbuckle()
+		unbuckle_mob()
 	if(plant_controller)
 		plant_controller.remove_plant(src)
 	for(var/obj/effect/plant/neighbor in range(1,src))
 		plant_controller.add_plant(neighbor)
 	return ..()
-	
+
 /obj/effect/plant/single
 	spread_chance = 0
 

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -67,7 +67,6 @@
 	var/last_tick = 0
 	var/obj/machinery/portable_atmospherics/hydroponics/soil/invisible/plant
 
-	var/mob/living/buckled_mob = null
 	var/movable = 0
 
 /obj/effect/plant/Destroy()

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -15,7 +15,7 @@
 
 /obj/effect/plant/attack_hand(mob/user as mob)
 	// Todo, cause damage.
-	manual_unbuckle(user)
+	user_unbuckle_mob(user, user)
 
 /obj/effect/plant/proc/trodden_on(var/mob/living/victim)
 	if(!is_mature())
@@ -26,37 +26,6 @@
 	seed.do_thorns(victim,src)
 	seed.do_sting(victim,src,pick("r_foot","l_foot","r_leg","l_leg"))
 
-/obj/effect/plant/proc/unbuckle()
-	if(buckled_mob)
-		if(buckled_mob.buckled == src)
-			buckled_mob.buckled = null
-			buckled_mob.anchored = initial(buckled_mob.anchored)
-			buckled_mob.update_canmove()
-		buckled_mob = null
-	return
-
-/obj/effect/plant/proc/manual_unbuckle(mob/user as mob)
-	if(buckled_mob)
-		if(prob(seed ? min(max(0,100 - seed.get_trait(TRAIT_POTENCY)/2),100) : 50))
-			if(buckled_mob.buckled == src)
-				if(buckled_mob != user)
-					buckled_mob.visible_message(\
-						"<span class='notice'>[user.name] frees [buckled_mob.name] from \the [src].</span>",\
-						"<span class='notice'>[user.name] frees you from \the [src].</span>",\
-						"<span class='warning'>You hear shredding and ripping.</span>")
-				else
-					buckled_mob.visible_message(\
-						"<span class='notice'>[buckled_mob.name] struggles free of \the [src].</span>",\
-						"<span class='notice'>You untangle \the [src] from around yourself.</span>",\
-						"<span class='warning'>You hear shredding and ripping.</span>")
-			unbuckle()
-		else
-			var/text = pick("rip","tear","pull")
-			user.visible_message(\
-				"<span class='notice'>[user.name] [text]s at \the [src].</span>",\
-				"<span class='notice'>You [text] at \the [src].</span>",\
-				"<span class='warning'>You hear shredding and ripping.</span>")
-	return
 
 /obj/effect/plant/proc/entangle(var/mob/living/victim)
 
@@ -79,7 +48,6 @@
 
 	//entangling people
 	if(victim.loc == src.loc)
-		victim.buckled = src
-		victim.update_canmove()
-		buckled_mob = victim
 		victim << "<span class='danger'>Tendrils [pick("wind", "tangle", "tighten")] around you!</span>"
+		can_buckle = 1
+		buckle_mob(victim)

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -24,7 +24,7 @@
 
 			src.ExtinguishMob()
 			if(src.buckled)
-				src.buckled.unbuckle()
+				src.buckled.unbuckle_mob()
 			if(src.pulling && src.bloodcrawl == BLOODCRAWL_EAT)
 				if(istype(src.pulling, /mob/living/))
 					var/mob/living/victim = src.pulling

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -529,6 +529,8 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		update_inv_wear_mask(0)
 	else if(I == handcuffed)
 		handcuffed = null
+		if(buckled && buckled.buckle_requires_restraints)
+			buckled.unbuckle_mob()
 		update_inv_handcuffed(1)
 	else if(I == legcuffed)
 		legcuffed = null
@@ -677,6 +679,9 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 /mob/living/carbon/proc/canBeHandcuffed()
 	return 0
 
+/mob/living/carbon/fall(forced)
+    loc.handle_fall(src, forced)//it's loc so it doesn't call the mob's handle_fall which does nothing
+
 /mob/living/carbon/is_muzzled()
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
 
@@ -686,7 +691,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		return -6
 	else
 		return initial(pixel_y)
-		
+
 /mob/living/carbon/get_all_slots()
 	return list(l_hand,
 				r_hand,

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -397,22 +397,3 @@ This function restores all organs.
 	updatehealth()
 	hud_updateflag |= 1 << HEALTH_HUD
 	return 1
-
-
-
-// incredibly important stuff follows
-/mob/living/carbon/human/fall(var/forced)
-	..()
-	if(forced)
-		playsound(loc, "bodyfall", 50, 1, -1)
-/*	if(head)
-		var/multiplier = 1
-		if(stat || (status_flags & FAKEDEATH))
-			multiplier = 2
-		var/obj/item/clothing/head/H = head
-		if(!istype(H) || prob(H.loose * multiplier))
-			unEquip(H)
-			if(prob(60))
-				step_rand(H)
-			if(!stat)
-				src << "<span class='warning'>Your [H] fell off!</span>" */

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -193,7 +193,7 @@ emp_act
 			var/turf/picked = pick(turfs)
 			if(!isturf(picked)) return
 			if(buckled)
-				buckled.unbuckle()
+				buckled.unbuckle_mob()
 			src.loc = picked
 			return 1
 	return 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -400,8 +400,11 @@
 	return
 
 /mob/living/Move(a, b, flag)
-	if (buckled)
-		return
+	if (buckled && buckled.loc != a)
+		if (!buckled.anchored)
+			return buckled.Move(a, b)
+		else
+			return 0
 
 	if (restrained())
 		stop_pulling()
@@ -639,10 +642,10 @@
 					for(var/mob/O in viewers(C))
 						O.show_message("\red <B>[usr] manages to unbuckle themself!</B>", 1)
 					C << "\blue You successfully unbuckle yourself."
-					C.buckled.manual_unbuckle(C)
+					C.buckled.user_unbuckle_mob(C,C)
 
 	else
-		L.buckled.manual_unbuckle(L)
+		L.buckled.user_unbuckle_mob(L,L)
 
 /* resist_closet() allows a mob to break out of a welded/locked closet
 */////
@@ -779,6 +782,8 @@
 				CM.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 				qdel(CM.handcuffed)
 				CM.handcuffed = null
+				if(CM.buckled && CM.buckled.buckle_requires_restraints)
+					CM.buckled.unbuckle_mob()
 				CM.update_inv_handcuffed()
 				return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -12,7 +12,7 @@
 */
 /mob/living/proc/run_armor_check(var/def_zone = null, var/attack_flag = "melee", var/absorb_text = null, var/soften_text = null, armour_penetration, penetrated_text)
 	var/armor = getarmor(def_zone, attack_flag)
-	
+
 	//the if "armor" check is because this is used for everything on /living, including humans
 	if(armor && armor < 100 && armour_penetration) // Armor with 100+ protection can not be penetrated for admin items
 		armor = max(0, armor - armour_penetration)
@@ -368,3 +368,7 @@
 	else*///This is an example of how you can make special types of grabs simply based on direction.
 	if(!supress_message)
 		visible_message("<span class='warning'>[user] has grabbed [src] passively!</span>")
+
+/mob/living/incapacitated()
+	if(stat || paralysis || stunned || weakened || restrained())
+		return 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -135,6 +135,9 @@
 /mob/proc/restrained()
 	return
 
+/mob/proc/incapacitated()
+	return
+
 //This proc is called whenever someone clicks an inventory ui slot.
 /mob/proc/attack_ui(slot)
 	var/obj/item/W = get_active_hand()
@@ -989,76 +992,29 @@ var/list/slot_equipment_priority = list( \
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 /mob/proc/update_canmove()
 	var/ko = weakened || paralysis || stat || (status_flags & FAKEDEATH)
-	if(ko || resting || buckled)
-		canmove = 0
-		if(!lying)
-			if(resting) //Presuming that you're resting on a bed, which would look goofy lying the wrong way
-				lying = 90
-			else
-				lying = pick(90, 270) //180 looks like shit since BYOND inverts rather than turns in that case
-	else if(stunned)
-		drop_l_hand()
+	var/buckle_lying = !(buckled && !buckled.buckle_lying)
+	if(ko || resting || stunned)
 		drop_r_hand()
-		canmove = 0
+		drop_l_hand()
 	else
 		lying = 0
 		canmove = 1
-	var/is_movable
-	if(buckled && istype(buckled))
-		is_movable = buckled.movable
-
-	if(istype(buckled, /obj/vehicle))
-		var/obj/vehicle/V = buckled
-		if(stat || weakened || paralysis || resting || sleeping || (status_flags & FAKEDEATH))
-			lying = 90
-			canmove = 0
-			pixel_y = V.mob_offset_y - 5
-		else
-			lying = 0
-			canmove = 1
-			pixel_y = V.mob_offset_y
-	else if(buckled && (!buckled.movable))
-		anchored = 1
-		canmove = 0
-		if( istype(buckled,/obj/structure/stool/bed/chair) )
-			lying = 0
-		else
-			lying = 90
-	else if(buckled && is_movable)
-		anchored = 0
-		canmove = 1
-		lying = 0
-	else if( stat || weakened || paralysis || resting || sleeping || (status_flags & FAKEDEATH))
-		lying = 90
-		canmove = 0
-	else if( stunned )
-		drop_l_hand()
-		drop_r_hand()
-		canmove = 0
+	if(buckled)
+		lying = 90 * buckle_lying
 	else
-		lying = 0
-		canmove = 1
-
-	if(lying)
-		density = 0
-		drop_l_hand()
-		drop_r_hand()
-	else
-		density = 1
-
-	//Temporarily moved here from the various life() procs
-	//I'm fixing stuff incrementally so this will likely find a better home.
-	//It just makes sense for now. ~Carn
-
-	if(lying != lying_prev)
-		if(lying && !lying_prev)
+		if((ko || resting) && !lying)
 			fall(ko)
 
-	if(update_icon)	//forces a full overlay update
-		update_icon = 0
-		regenerate_icons()
+	canmove = !(ko || resting || stunned || buckled)
+	density = !lying
+	if(lying)
+		if(layer == initial(layer))
+			layer = MOB_LAYER - 0.2
+	else
+		if(layer == MOB_LAYER - 0.2)
+			layer = initial(layer)
+
 	update_transform()
-	lying_prev = lying
 	return canmove
 
 /mob/proc/fall(var/forced)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -225,13 +225,15 @@
 
 	if(Process_Grab())	return
 
+	if(mob.buckled)							//if we're buckled to something, tell it we moved.
+		return mob.buckled.relaymove(mob, direct)
 
 	if(mob.remote_control)					//we're controlling something, our movement is relayed to it
 		return mob.remote_control.relaymove(mob, direct)
 
 	if(isAI(mob))
-		return AIMove(n,direct,mob)		
-		
+		return AIMove(n,direct,mob)
+
 	if(!mob.canmove)
 		return
 
@@ -279,24 +281,6 @@
 			move_delay -= 1.3
 			var/tickcomp = ((1/(world.tick_lag))*1.3)
 			move_delay = move_delay + tickcomp
-
-		if(istype(mob.buckled, /obj/vehicle) || istype(mob.buckled, /obj/structure/stool/bed/chair/cart))
-			return mob.buckled.relaymove(mob,direct)
-
-		if(mob.pulledby || mob.buckled) // Wheelchair driving!
-			if(istype(mob.loc, /turf/space))
-				return // No wheelchair driving in space
-			if(istype(mob.pulledby, /obj/structure/stool/bed/chair/wheelchair))
-				return mob.pulledby.relaymove(mob, direct)
-			else if(istype(mob.buckled, /obj/structure/stool/bed/chair/wheelchair))
-				if(ishuman(mob.buckled))
-					var/mob/living/carbon/human/driver = mob.buckled
-					var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
-					var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
-					if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
-						return // No hands to drive your chair? Tough luck!
-				move_delay += 2
-				return mob.buckled.relaymove(mob,direct)
 
 		//We are now going to move
 		moving = 1

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_teleport.dm
@@ -8,7 +8,7 @@
 	if(prob(100 * weakness))
 		user << "\red You are suddenly zapped away elsewhere!"
 		if (user.buckled)
-			user.buckled.unbuckle()
+			user.buckled.unbuckle_mob()
 
 		var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 		sparks.set_up(3, 0, get_turf(user))
@@ -27,7 +27,7 @@
 			if(prob(100 * weakness))
 				M << "\red You are displaced by a strange force!"
 				if(M.buckled)
-					M.buckled.unbuckle()
+					M.buckled.unbuckle_mob()
 
 				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 				sparks.set_up(3, 0, get_turf(M))
@@ -46,7 +46,7 @@
 			if(prob(100 * weakness))
 				M << "\red You are displaced by a strange force!"
 				if(M.buckled)
-					M.buckled.unbuckle()
+					M.buckled.unbuckle_mob()
 
 				var/datum/effect/effect/system/spark_spread/sparks = new /datum/effect/effect/system/spark_spread()
 				sparks.set_up(3, 0, get_turf(M))

--- a/code/modules/vehicle/train/train.dm
+++ b/code/modules/vehicle/train/train.dm
@@ -36,6 +36,15 @@
 			unattach()
 		return 0
 
+/obj/vehicle/train/can_move()
+	if(!is_train_head())
+		return 1 //towed objects do not need power to Move()
+
+	if(!..())
+		return 0
+	return 1
+
+
 /obj/vehicle/train/Bump(atom/Obstacle)
 	if(!istype(Obstacle, /atom/movable))
 		return

--- a/code/modules/vehicle/train/trains/ambulance.dm
+++ b/code/modules/vehicle/train/trains/ambulance.dm
@@ -53,10 +53,11 @@
 	if(is_train_head() && !on)
 		return 0
 
+	. = ..()
+
 	handle_rotation()
 	update_mob()
 
-	return ..()
 
 /obj/vehicle/train/ambulance/trolley/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(open && istype(W, /obj/item/weapon/wirecutters))

--- a/code/modules/vehicle/train/trains/ambulance.dm
+++ b/code/modules/vehicle/train/trains/ambulance.dm
@@ -44,20 +44,9 @@
 	key = new()
 
 /obj/vehicle/train/ambulance/engine/Move()
-	if(on && cell.charge < charge_use)
-		turn_off()
-		update_stats()
-		if(load && is_train_head())
-			load << "The drive motor briefly whines, then drones to a stop."
-
-	if(is_train_head() && !on)
-		return 0
-
 	. = ..()
-
 	handle_rotation()
 	update_mob()
-
 
 /obj/vehicle/train/ambulance/trolley/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(open && istype(W, /obj/item/weapon/wirecutters))
@@ -177,7 +166,7 @@
 		return 0
 
 	if(is_train_head())
-		if(direction == reverse_direction(dir))
+		if(direction == reverse_direction(dir) && tow) //can reverse with no tow
 			return 0
 		if(Move(get_step(src, direction)))
 			return 1

--- a/code/modules/vehicle/train/trains/cargo/cargo_train.dm
+++ b/code/modules/vehicle/train/trains/cargo/cargo_train.dm
@@ -47,18 +47,6 @@
 	overlays += I
 	turn_off()	//so engine verbs are correctly set
 
-/obj/vehicle/train/cargo/engine/Move()
-	if(on && cell.charge < charge_use)
-		turn_off()
-		update_stats()
-		if(load && is_train_head())
-			load << "The drive motor briefly whines, then drones to a stop."
-
-	if(is_train_head() && !on)
-		return 0
-
-	return ..()
-
 /obj/vehicle/train/cargo/trolley/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(open && istype(W, /obj/item/weapon/wirecutters))
 		passenger_allowed = !passenger_allowed

--- a/code/modules/vehicle/train/trains/janicart.dm
+++ b/code/modules/vehicle/train/trains/janicart.dm
@@ -51,19 +51,9 @@
 	R.my_atom = src
 
 /obj/vehicle/train/janitor/engine/Move()
-	if(on && cell.charge < charge_use)
-		turn_off()
-		update_stats()
-		if(load && is_train_head())
-			load << "The drive motor briefly whines, then drones to a stop."
-
-	if(is_train_head() && !on)
-		return 0
-
+	. = ..()
 	handle_rotation()
 	update_mob()
-
-	return ..()
 
 /obj/vehicle/train/janitor/trolley/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(openTop)

--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -42,10 +42,7 @@
 	//spawn the cell you want in each vehicle
 
 /obj/vehicle/Move()
-	if(world.time > l_move_time + move_delay)
-		if(on && powered && cell.charge < charge_use)
-			turn_off()
-
+	if(can_move())
 		var/init_anc = anchored
 		anchored = 0
 		if(!..())
@@ -64,6 +61,23 @@
 		return 1
 	else
 		return 0
+
+/obj/vehicle/proc/can_move()
+	if(world.time <= l_move_time + move_delay)
+		return 0
+
+	if(!on || !powered)
+		return 0
+
+	if(on && powered && cell.charge < charge_use)
+		turn_off()
+		return 0
+
+	if(istype(loc, /turf/space))
+		return 0
+
+	return 1
+
 
 /obj/vehicle/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/weapon/hand_labeler))
@@ -224,19 +238,19 @@
 
 /obj/vehicle/proc/powercheck()
 	if(!cell && !powered)
-		return
+		return 0
 
 	if(!cell && powered)
 		turn_off()
-		return
+		return 0
 
 	if(cell.charge < charge_use)
 		turn_off()
-		return
+		return 0
 
 	if(cell && powered)
 		turn_on()
-		return
+		return 1
 
 /obj/vehicle/proc/insert_cell(var/obj/item/weapon/stock_parts/cell/C, var/mob/living/carbon/human/H)
 	if(cell)

--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -7,6 +7,8 @@
 	animate_movement=1
 	light_range = 3
 
+	buckle_lying = 0
+
 	var/attack_log = null
 	var/on = 0
 	var/health = 0	//do not forget to set health for your vehicle!

--- a/paradise.dme
+++ b/paradise.dme
@@ -569,6 +569,7 @@
 #include "code\game\mecha\medical\odysseus.dm"
 #include "code\game\mecha\working\ripley.dm"
 #include "code\game\mecha\working\working.dm"
+#include "code\game\objects\buckling.dm"
 #include "code\game\objects\empulse.dm"
 #include "code\game\objects\explosion.dm"
 #include "code\game\objects\items.dm"


### PR DESCRIPTION
This commit overhauls a bunch of systems so that buckling works for
any subtype of /obj. This means that space vines and chairs and beds all
use the same system. A lot of stuff has been touched.

Also included in this PR:
 - Buckling people to pipes!
  - Heat exchange pipes will burn/freeze people cuffed to them.
    - Bonus feature: Heat exchange pipes glow based on the temperature of air inside of them!
  - You have to be cuffed to be buckled to a pipe.
 - update_canmove update; Gets rid of shitcode.
  - Lying due to weakened/resting/etc is now handled based on turfs
 - Fixes the segway, and structure based janicart/ambulance.