### PR TITLE
Spacemove Fixup

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -80,10 +80,10 @@
 		last_move = 0
 		return
 
+	last_move = direct
 	src.move_speed = world.timeofday - src.l_move_time
 	src.l_move_time = world.timeofday
 
-	last_move = direct
 
 
 	spawn(5)	// Causes space drifting. /tg/station has no concept of speed, we just use 5
@@ -154,7 +154,7 @@
 	if(pulledby)
 		return 1
 
-	if(locate(/obj/structure/lattice) in orange(1, get_turf(src))) //Not realistic but makes pushing things in space easier
+	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
 		return 1
 
 	return 0

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -60,6 +60,9 @@
 	consume(user)
 	return 1
 
+/obj/singularity/Process_Spacemove() //The singularity stops drifting for no man!
+	return 0
+
 /obj/singularity/blob_act(severity)
 	return
 
@@ -268,8 +271,6 @@
 
 	step(src, movement_dir)
 
-/obj/singularity/Process_Spacemove() //The singularity stops drifting for no man!
-	return 0
 
 /obj/singularity/proc/check_turfs_in(var/direction = 0, var/step = 0)
 	if(!direction)
@@ -360,18 +361,13 @@
 
 /obj/singularity/proc/toxmob()
 	var/toxrange = 10
-	var/toxdamage = 4
 	var/radiation = 15
 	var/radiationmin = 3
-	if (src.energy>200)
-		toxdamage = round(((src.energy-150)/50)*4,1)
-		radiation = round(((src.energy-150)/50)*5,1)
-		radiationmin = round((radiation/5),1)//
+	if (energy>200)
+		radiation += round((energy-150)/10,1)
+		radiationmin = round((radiation/5),1)
 	for(var/mob/living/M in view(toxrange, src.loc))
 		M.apply_effect(rand(radiationmin,radiation), IRRADIATE)
-		toxdamage = (toxdamage - (toxdamage*M.getarmor(null, "rad")))
-		M.apply_effect(toxdamage, TOX)
-	return
 
 
 /obj/singularity/proc/combust_mobs()
@@ -381,6 +377,7 @@
 		C.adjust_fire_stacks(5)
 		C.IgniteMob()
 	return
+
 
 /obj/singularity/proc/mezzer()
 	for(var/mob/living/carbon/M in oviewers(8, src))


### PR DESCRIPTION
- fixes it so that you don't get stuck on one tile of lattice:
- moves `last_move = direct`
- re-arranges singulo code a bit
- Singulo applies purely radiation damage instead of dealing tox damage directly.

@tigercat2000 