### PR TITLE
Fix blank-text bug, with an angry comment.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -45,6 +45,10 @@
 	//--FalseIncarnate
 
 	switch(act)
+		if("me")									//OKAY SO RANT TIME, THIS FUCKING HAS TO BE HERE OR A SHITLOAD OF THINGS BREAK
+			return custom_emote(m_type, message)	//DO YOU KNOW WHY SHIT BREAKS? BECAUSE SO MUCH OLDCODE CALLS mob.emote("me",1,"whatever_the_fuck_it_wants_to_emote")
+													//WHO THE FUCK THOUGHT THAT WAS A GOOD FUCKING IDEA!?!?
+
 		if("ping")
 			var/M = null
 			if(param)


### PR DESCRIPTION
So. Basically, this happened a lot.

'&nbsp;&nbsp;is sweating profusely!'

You know why this happens?
Because the thing that tries to make the emote 'is swearing profusely' is formatted like this:
`mob.emote("me", 1, "is sweating profusely!")`

SO IF THE ME EMOTE IS NOT AVAILABLE, IT BREAKS ENTIRELY.
I fucking hate saycode.