### PR TITLE
Death Alarm Implant Kit change

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -258,8 +258,8 @@
 		new /obj/item/weapon/implantcase/death_alarm(src)
 		new /obj/item/weapon/implantcase/death_alarm(src)
 		new /obj/item/weapon/implantcase/death_alarm(src)
+		new /obj/item/weapon/implantcase/death_alarm(src)
 		new /obj/item/weapon/implanter(src)
-		new /obj/item/weapon/implantpad(src)
 
 
 /obj/item/weapon/storage/box/rxglasses


### PR DESCRIPTION
Add's a sixth implant, and removes the implantpad, as the implantpad serves no purpose for death alarm implants.