### PR TITLE
Gives a special *deathgasp text to IPC's.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -334,8 +334,12 @@
 					m_type = 2
 
 		if ("deathgasp")
-			message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
-			m_type = 1
+			if (species.name == "Machine")
+				message = "<B>[src]</B> gives one shrill beep before falling lifeless..."
+				m_type = 1
+			else
+				message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
+				m_type = 1
 
 		if ("giggle")
 			if(miming)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -335,7 +335,7 @@
 
 		if ("deathgasp")
 			if (species.name == "Machine")
-				message = "<B>[src]</B> gives one shrill beep before falling lifeless..."
+				message = "<B>[src]</B> gives one shrill beep before falling limp, screen quickly flashing blue before shutting off entirely."
 				m_type = 1
 			else
 				message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."


### PR DESCRIPTION
-Gives IPC's a different *deathgasp text. Idea taken from Baystation.
~Was also going to add a special text for when they get knocked out ("[name] encounters a hardware fault and suddenly reboots!"[an idea also taken from Baystation]) but the way we handle our emote code is different from Bay, apparently.
~Tested and works, both when using the emote manually and when killed.
