### PR TITLE
Nuke wheelchair snowflake shit, fix the delay

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -83,14 +83,6 @@
 			else
 				flick("door_deny", src)
 		return
-	if(istype(AM, /obj/structure/stool/bed/chair/wheelchair))
-		var/obj/structure/stool/bed/chair/wheelchair/wheel = AM
-		if(density)
-			if(wheel.pulling && (src.allowed(wheel.pulling)))
-				open()
-			else
-				flick("door_deny", src)
-		return
 	return
 
 

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -74,9 +74,6 @@ var/global/list/image/splatter_cache=list()
 		if(!perp.feet_blood_DNA)
 			perp.feet_blood_DNA = list()
 		perp.feet_blood_DNA |= blood_DNA.Copy()
-	else if (perp.buckled && istype(perp.buckled, /obj/structure/stool/bed/chair/wheelchair))
-		var/obj/structure/stool/bed/chair/wheelchair/W = perp.buckled
-		W.bloodiness = 4
 
 	perp.update_inv_shoes(1)
 	amount--

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -5,10 +5,7 @@
 	anchored = 0
 	movable = 1
 
-	var/driving = 0
-	var/mob/living/pulling = null
-	var/bloodiness
-
+	var/move_delay = null
 
 /obj/structure/stool/bed/chair/wheelchair/handle_rotation()
 	overlays = null
@@ -18,139 +15,57 @@
 		buckled_mob.dir = dir
 
 /obj/structure/stool/bed/chair/wheelchair/relaymove(mob/user, direction)
-	if(user.stat || user.stunned || user.weakened || user.paralysis || user.lying || user.restrained())
-		if(user==pulling)
-			pulling = null
-			user.pulledby = null
-			user << "\red You lost your grip!"
-		return
-	if(user.pulling && (user == pulling))
-		pulling = null
-		user.pulledby = null
-		return
 	if(propelled)
-		return
-	if(pulling && (get_dist(src, pulling) > 1))
-		pulling = null
-		user.pulledby = null
-		if(user==pulling)
-			return
-	if(pulling && (get_dir(src.loc, pulling.loc) == direction))
-		user << "\red You cannot go there."
-		return
-	if(pulling && buckled_mob && (buckled_mob == user))
-		user << "\red You cannot drive while being pushed."
+		return 0
+
+	if(!Process_Spacemove(direction) || !has_gravity(src.loc) || !isturf(loc))
+		return 0
+
+	if(world.time < move_delay)
 		return
 
-	if(istype(user.loc, /turf/space))
-		return
+	move_delay = world.time
+	move_delay += 2 //wheelchairs are not infact sport bikes
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/driver = user
-		var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
-		var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
-		if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
-			return // No hands to drive your chair? Tough luck!
-
-	// Let's roll
-	driving = 1
-	var/turf/T = null
-	//--1---Move occupant---1--//
 	if(buckled_mob)
-		buckled_mob.buckled = null
-		step(buckled_mob, direction)
-		buckled_mob.buckled = src
-	//--2----Move driver----2--//
-	if(pulling)
-		T = pulling.loc
-		if(get_dist(src, pulling) >= 1)
-			step(pulling, get_dir(pulling.loc, src.loc))
-	//--3--Move wheelchair--3--//
-	step(src, direction)
-	if(buckled_mob) // Make sure it stays beneath the occupant
-		Move(buckled_mob.loc)
-	dir = direction
-	handle_rotation()
-	if(pulling) // Driver
-		if(pulling.loc == src.loc) // We moved onto the wheelchair? Revert!
-			pulling.forceMove(T)
-		else
-			spawn(0)
-			if(get_dist(src, pulling) > 1) // We are too far away? Losing control.
-				pulling = null
-				user.pulledby = null
-			pulling.dir = get_dir(pulling, src) // When everything is right, face the wheelchair
-	if(bloodiness)
-		create_track()
-	driving = 0
+		if(buckled_mob.incapacitated())
+			return 0
 
-/obj/structure/stool/bed/chair/wheelchair/Move()
-	..()
-	if(buckled_mob)
-		var/mob/living/occupant = buckled_mob
-		if(!driving)
-			occupant.buckled = null
-			occupant.Move(src.loc)
-			occupant.buckled = src
-			if (occupant && (src.loc != occupant.loc))
-				if (propelled)
-					for (var/mob/O in src.loc)
-						if (O != occupant)
-							Bump(O)
-				else
-					unbuckle_mob()
-			if (pulling && (get_dist(src, pulling) > 1))
-				pulling.pulledby = null
-				pulling << "\red You lost your grip!"
-				pulling = null
-		else
-			if (occupant && (src.loc != occupant.loc))
-				forceMove(occupant.loc) // Failsafe to make sure the wheelchair stays beneath the occupant after driving
-	handle_rotation()
+		if(ishuman(buckled_mob))
+			var/mob/living/carbon/human/driver = user
+			var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
+			var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
+			if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
+				return 0 // No hands to drive your chair? Tough luck!
 
-/obj/structure/stool/bed/chair/wheelchair/attack_hand(mob/user as mob)
-	if (pulling)
-		MouseDrop(usr)
-	else
-		user_unbuckle_mob(user, user)
-	return
+			for(var/organ_name in list("l_hand","r_hand","l_arm","r_arm"))
+				var/obj/item/organ/external/E = driver.get_organ(organ_name)
+				if(!E || (E.status & ORGAN_DESTROYED))
+					move_delay += 4
+				else if(E.status & ORGAN_SPLINTED)
+					move_delay += 0.5
+				else if(E.status & ORGAN_BROKEN)
+					move_delay += 1.5
 
-/obj/structure/stool/bed/chair/wheelchair/MouseDrop(over_object, src_location, over_location)
-	..()
-	if(over_object == usr && in_range(src, usr))
-		if(!ishuman(usr))	return
-		if(usr == buckled_mob)
-			usr << "\red You realize you are unable to push the wheelchair you sit in."
-			return
-		if(!pulling)
-			pulling = usr
-			usr.pulledby = src
-			if(usr.pulling)
-				usr.stop_pulling()
-			usr.dir = get_dir(usr, src)
-			usr << "You grip \the [name]'s handles."
+		if(!buckled_mob.Move(get_step(buckled_mob, direction), direction))
+			loc = buckled_mob.loc //we gotta go back
+			last_move = buckled_mob.last_move
+			inertia_dir = last_move
+			buckled_mob.inertia_dir = last_move
+			. = 0
+
 		else
-			if(usr != pulling)
-				for(var/mob/O in viewers(pulling, null))
-					O.show_message("\red [usr] breaks [pulling]'s grip on the wheelchair.", 1)
-			else
-				usr << "You let go of \the [name]'s handles."
-			pulling.pulledby = null
-			pulling = null
-		return
+			. = 1
 
 /obj/structure/stool/bed/chair/wheelchair/Bump(atom/A)
 	..()
 	if(!buckled_mob)	return
 
-	if(propelled || (pulling && (pulling.a_intent == I_HARM)))
+	if(propelled)
 		var/mob/living/occupant = buckled_mob
 		unbuckle_mob()
 
-		if (pulling && (pulling.a_intent == "hurt"))
-			occupant.throw_at(A, 3, 3, pulling)
-		else if (propelled)
-			occupant.throw_at(A, 3, propelled)
+		occupant.throw_at(A, 3, propelled)
 
 		occupant.apply_effect(6, STUN, 0)
 		occupant.apply_effect(6, WEAKEN, 0)
@@ -162,31 +77,5 @@
 			victim.apply_effect(6, WEAKEN, 0)
 			victim.apply_effect(6, STUTTER, 0)
 			victim.take_organ_damage(10)
-		if(pulling)
-			occupant.visible_message("<span class='danger'>[pulling] has thrusted \the [name] into \the [A], throwing \the [occupant] out of it!</span>")
 
-			pulling.attack_log += "\[[time_stamp()]\]<font color='red'> Crashed [key_name(occupant)] [name] into \a [A]</font>"
-			occupant.attack_log += "\[[time_stamp()]\]<font color='orange'> Thrusted into \a [A] by [key_name(pulling)] with \the [name]</font>"
-			msg_admin_attack("[key_name_admin(pulling)] has thrusted [key_name_admin(occupant)] [name] into \a [A]")
-		else
-			occupant.visible_message("<span class='danger'>[occupant] crashed into \the [A]!</span>")
-
-/obj/structure/stool/bed/chair/wheelchair/proc/create_track()
-	var/obj/effect/decal/cleanable/blood/tracks/B = new(loc)
-	var/newdir = get_dir(get_step(loc, dir), loc)
-	if(newdir == dir)
-		B.dir = newdir
-	else
-		newdir = newdir | dir
-		if(newdir == 3)
-			newdir = 1
-		else if(newdir == 12)
-			newdir = 4
-		B.dir = newdir
-	bloodiness--
-
-/obj/structure/stool/bed/chair/wheelchair/buckle_mob(mob/M as mob, mob/user as mob)
-	if(M == pulling)
-		pulling = null
-		usr.pulledby = null
-	..()
+		occupant.visible_message("<span class='danger'>[occupant] crashed into \the [A]!</span>")

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -24,19 +24,9 @@
 	if(wear_suit)
 		tally += wear_suit.slowdown
 
-	if(!buckled || (buckled && !istype(buckled, /obj/structure/stool/bed/chair/wheelchair)))
+	if(!buckled)
 		if(shoes)
 			tally += shoes.slowdown
-
-	if(buckled && istype(buckled, /obj/structure/stool/bed/chair/wheelchair))
-		for(var/organ_name in list("l_hand","r_hand","l_arm","r_arm"))
-			var/obj/item/organ/external/E = get_organ(organ_name)
-			if(!E || (E.status & ORGAN_DESTROYED))
-				tally += 4
-			else if(E.status & ORGAN_SPLINTED)
-				tally += 0.5
-			else if(E.status & ORGAN_BROKEN)
-				tally += 1.5
 
 	if(shock_stage >= 10) tally += 3
 


### PR DESCRIPTION
This commit nukes half of the shitty wheelchair system (since it was broken and I'm not snowflaking it back into mob movement to fix it) and makes the delays all work again.
No more light-speed wheelchairs with both arms.

Might be a bit slower than it was before, can't be bothered to play with the numbers. 