### PR TITLE
Makes *deathgasp less snowflakey

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -337,12 +337,8 @@
 					m_type = 2
 
 		if ("deathgasp")
-			if (species.name == "Machine")
-				message = "<B>[src]</B> gives one shrill beep before falling limp, screen quickly flashing blue before shutting off entirely."
-				m_type = 1
-			else
-				message = "<B>[src]</B> seizes up and falls limp, \his eyes dead and lifeless..."
-				m_type = 1
+			message = "<B>[src]</B> [species.death_message]"	
+			m_type = 1
 
 		if ("giggle")
 			if(miming)

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -17,6 +17,7 @@
 	ventcrawler = 1
 	show_ssd = 0
 	eyes = "blank_eyes"
+	death_message = "lets out a faint chimper as it collapses and stops moving..."
 
 	tail = "chimptail"
 	bodyflags = FEET_PADDED | HAS_TAIL

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -84,6 +84,9 @@
 	var/virus_immune
 	var/can_revive_by_healing				// Determines whether or not this species can be revived by simply healing them
 
+	//Death vars.
+	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
+
 	// Language/culture vars.
 	var/default_language = "Galactic Common" // Default language is used when 'say' is used without modifiers.
 	var/language = "Galactic Common"         // Default racial language, if any.

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -486,6 +486,7 @@
 	eyes = "blank_eyes"
 	brute_mod = 2.5 // 100% * 2.5 * 0.6 (robolimbs) ~= 150%
 	burn_mod = 2.5  // So they take 50% extra damage from brute/burn overall.
+	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."
 
 	cold_level_1 = 50
 	cold_level_2 = -1


### PR DESCRIPTION
After fucking around with the code for half an hour, I de-snowflaked my original *deathgasp code idea, based on @SamCroswell 's suggestion to turn it into a variable and poking around Baystation's code.
Tested and works.
Changes nothing gamewise, IPC's still give the same message that I gave them in the prior PR.
@Iamgoofball look better to you?