### PR TITLE
Fix Beaker Fix so Robots can Wire Machines Again

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -149,11 +149,12 @@
 					circuit.loc = null
 					new_machine.RefreshParts()
 					qdel(src)
+					return
 
 			if(istype(P, /obj/item))
 				var/success
 				for(var/I in req_components)
-					if(istype(P, I) && (req_components[I] > 0) && !(P.flags & NODROP))
+					if(istype(P, I) && (req_components[I] > 0) && (!(P.flags & NODROP) || istype(P, /obj/item/stack)))
 						success=1
 						playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 						if(istype(P, /obj/item/stack/cable_coil))


### PR DESCRIPTION
Giving the constructable frame a second look I realized I had accidentally axed the cases when a robot was adding cable to the machine.

I also took care of the "You can't add this!" message when finishing a machine with a screwdriver.