### PR TITLE
Gives engineering more power at start

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -481,7 +481,7 @@
 	..()
 
 /obj/machinery/power/smes/engineering
-	charge = 3e6 // Engineering starts with some charge for singulo	
+	charge = 2e6 // Engineering starts with some charge for singulo	
 
 /obj/machinery/power/smes/magical
 	name = "magical power storage unit"

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -8,7 +8,7 @@
 
 
 /obj/machinery/power/smes
-	name = "power storage unit"
+	name = "SMES"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit."
 	icon_state = "smes"
 	density = 1
@@ -481,7 +481,7 @@
 	..()
 
 /obj/machinery/power/smes/engineering
-	charge = 1e6 // Engineering starts with some charge for singulo	
+	charge = 3e6 // Engineering starts with some charge for singulo	
 
 /obj/machinery/power/smes/magical
 	name = "magical power storage unit"

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -8,7 +8,7 @@
 
 
 /obj/machinery/power/smes
-	name = "SMES"
+	name = "power storage unit"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit."
 	icon_state = "smes"
 	density = 1
@@ -484,7 +484,7 @@
 	charge = 2e6 // Engineering starts with some charge for singulo	
 
 /obj/machinery/power/smes/magical
-	name = "magical SMES"
+	name = "magical power storage unit"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Magically produces power."
 	capacity = 9000000
 	output_level = 250000

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -484,7 +484,7 @@
 	charge = 2e6 // Engineering starts with some charge for singulo	
 
 /obj/machinery/power/smes/magical
-	name = "magical power storage unit"
+	name = "magical SMES"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. Magically produces power."
 	capacity = 9000000
 	output_level = 250000


### PR DESCRIPTION
Very often now, this is how the round starts, power starts going out, engineers does nothing, nobody does anything, and there are so many rounds where the power runs out station wide, i.e it takes an hour to set up power, this will buff the starting power of engineering, so that power does not start running out during the first half hour of the shift.

Also, fixes the name back to SMES.

This can be considered a somewhat controversial pull.