### PR TITLE
Remove remaining arbitrary restrictions

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -18,8 +18,8 @@
 
 /obj/machinery/computer/New()
 	overlay_layer = layer
-	..()	
-	
+	..()
+
 /obj/machinery/computer/initialize()
 	power_change()
 	update_icon()
@@ -79,7 +79,7 @@
 		overlays += image(icon,"[icon_state]_broken",overlay_layer)
 	else
 		overlays += image(icon,icon_screen,overlay_layer)
-	
+
 	if(icon_keyboard)
 		overlays += image(icon, icon_keyboard ,overlay_layer)
 
@@ -134,6 +134,11 @@
 	return
 
 /obj/machinery/computer/attack_alien(mob/living/user)
+	if(isalien(user) && user.a_intent == I_HELP)
+		var/mob/living/carbon/alien/humanoid/xeno = user
+		if(xeno.has_fine_manipulation)
+			return attack_hand(user)
+
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src)
 	if(circuit)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -341,10 +341,11 @@ Class Procs:
 		return 1
 	if(user.lying || user.stat)
 		return 1
-	if ( ! (istype(usr, /mob/living/carbon/human) || \
-			istype(usr, /mob/living/silicon)))
-		usr << "\red You don't have the dexterity to do this!"
+
+	if(!user.IsAdvancedToolUser())
+		user << "\red You don't have the dexterity to do this!"
 		return 1
+
 /*
 	//distance checks are made by atom/proc/DblClick
 	if ((get_dist(src, user) > 1 || !istype(src.loc, /turf)) && !istype(user, /mob/living/silicon))

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -343,7 +343,7 @@ Class Procs:
 		return 1
 
 	if(!user.IsAdvancedToolUser())
-		user << "\red You don't have the dexterity to do this!"
+		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return 1
 
 /*
@@ -354,10 +354,10 @@ Class Procs:
 	if (ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.getBrainLoss() >= 60)
-			visible_message("\red [H] stares cluelessly at [src] and drools.")
+			visible_message("<span class='warning'>[H] stares cluelessly at [src] and drools.</span>")
 			return 1
 		else if(prob(H.getBrainLoss()))
-			user << "\red You momentarily forget how to use [src]."
+			user << "<span class='warning'>You momentarily forget how to use [src].</span>"
 			return 1
 
 	src.add_fingerprint(user)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -183,7 +183,7 @@ obj/item/device/flashlight/lamp/bananalamp
 		update_brightness(U)
 	else
 		update_brightness(null)
-		
+
 /obj/item/device/flashlight/flare/update_brightness(var/mob/user = null)
 	..()
 	if(on)
@@ -207,7 +207,7 @@ obj/item/device/flashlight/lamp/bananalamp
 		src.force = on_damage
 		src.damtype = "fire"
 		processing_objects += src
-		
+
 /obj/item/device/flashlight/flare/torch
 	name = "torch"
 	desc = "A torch fashioned from some leaves and a log."

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -384,7 +384,7 @@ REAGENT SCANNER
 	if (crit_fail)
 		user << "\red This device has critically failed and is no longer functional!"
 		return
-	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		user << "\red You don't have the dexterity to do this!"
 		return
 	if(reagents.total_volume)
@@ -441,7 +441,7 @@ REAGENT SCANNER
 /obj/item/device/reagent_scanner/afterattack(obj/O, mob/user as mob)
 	if (user.stat)
 		return
-	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		user << "\red You don't have the dexterity to do this!"
 		return
 	if(!istype(O))

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -382,17 +382,17 @@ REAGENT SCANNER
 	if (user.stat)
 		return
 	if (crit_fail)
-		user << "\red This device has critically failed and is no longer functional!"
+		user << "<span class='warning'>This device has critically failed and is no longer functional!</span>"
 		return
 	if (!user.IsAdvancedToolUser())
-		user << "\red You don't have the dexterity to do this!"
+		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return
 	if(reagents.total_volume)
 		var/list/blood_traces = list()
 		for(var/datum/reagent/R in reagents.reagent_list)
 			if(R.id != "blood")
 				reagents.clear_reagents()
-				user << "\red The sample was contaminated! Please insert another sample"
+				user << "<span class='warning'>The sample was contaminated! Please insert another sample.</span>"
 				return
 			else
 				blood_traces = params2list(R.data["trace_chem"])
@@ -442,12 +442,12 @@ REAGENT SCANNER
 	if (user.stat)
 		return
 	if (!user.IsAdvancedToolUser())
-		user << "\red You don't have the dexterity to do this!"
+		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return
 	if(!istype(O))
 		return
 	if (crit_fail)
-		user << "\red This device has critically failed and is no longer functional!"
+		user << "<span class='warning'>This device has critically failed and is no longer functional!</span>"
 		return
 
 	if(!isnull(O.reagents))
@@ -456,7 +456,7 @@ REAGENT SCANNER
 			var/one_percent = O.reagents.total_volume / 100
 			for (var/datum/reagent/R in O.reagents.reagent_list)
 				if(prob(reliability))
-					dat += "\n \t \blue [R][details ? ": [R.volume / one_percent]%" : ""]"
+					dat += "<br>[TAB]<span class='notice'>[R][details ? ": [R.volume / one_percent]%" : ""]</span>"
 					recent_fail = 0
 				else if(recent_fail)
 					crit_fail = 1
@@ -465,11 +465,11 @@ REAGENT SCANNER
 				else
 					recent_fail = 1
 		if(dat)
-			user << "\blue Chemicals found: [dat]"
+			user << "<span class='notice'>Chemicals found: [dat]</span>"
 		else
-			user << "\blue No active chemical agents found in [O]."
+			user << "<span class='notice'>No active chemical agents found in [O].</span>"
 	else
-		user << "\blue No significant chemical agents found in [O]."
+		user << "<span class='notice'>No significant chemical agents found in [O].</span>"
 
 	return
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -15,7 +15,7 @@
 		user << "<span class='danger'>\The [src] cannot be applied to [M]!</span>"
 		return 1
 
-	if (!(istype(user, /mob/living/carbon/human) || istype(user, /mob/living/silicon)))
+	if (!user.IsAdvancedToolUser())
 		user << "<span class='danger'>You don't have the dexterity to do this!</span>"
 		return 1
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -169,8 +169,8 @@
 	afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
 		if (flag)
 			return
-		if (!(istype(usr, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
-			usr << "\red You don't have the dexterity to do this!"
+		if (!user.IsAdvancedToolUser())
+			user << "\red You don't have the dexterity to do this!"
 			return
 		src.add_fingerprint(user)
 		if (src.bullets < 1)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -170,17 +170,16 @@
 		if (flag)
 			return
 		if (!user.IsAdvancedToolUser())
-			user << "\red You don't have the dexterity to do this!"
+			user << "<span class='warning'>You don't have the dexterity to do this!</span>"
 			return
 		src.add_fingerprint(user)
 		if (src.bullets < 1)
-			user.show_message("\red *click* *click*", 2)
+			user.show_message("<span class='alert'>*click* *click*</span>", 2)
 			playsound(user, 'sound/weapons/empty.ogg', 100, 1)
 			return
 		playsound(user, 'sound/weapons/Gunshot.ogg', 100, 1)
 		src.bullets--
-		for(var/mob/O in viewers(user, null))
-			O.show_message(text("\red <B>[] fires a cap gun at []!</B>", user, target), 1, "\red You hear a gunshot", 2)
+		user.visible_message("<span class='danger'>[user] fires a cap gun at [target]!</span>", null, "You hear a gunshot.")
 
 /obj/item/toy/ammo/gun
 	name = "ammo-caps"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -287,7 +287,7 @@
 
 /turf/simulated/wall/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return
 

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -36,7 +36,7 @@
 
 /turf/simulated/wall/r_wall/attackby(obj/item/W as obj, mob/user as mob, params)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if (!(istype(user, /mob/living/carbon/human) || ticker) && ticker.mode.name != "monkey")
+	if (!user.IsAdvancedToolUser())
 		user << "<span class='warning'>You don't have the dexterity to do this!</span>"
 		return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1758,11 +1758,9 @@
 	return (health <= config.health_threshold_crit && stat == UNCONSCIOUS)
 
 
-/mob/living/carbon/human/IsAdvancedToolUser(var/silent)
+/mob/living/carbon/human/IsAdvancedToolUser()
 	if(species.has_fine_manipulation)
 		return 1
-	if(!silent)
-		src << "<span class='warning'>You don't have the dexterity to use that!<span>"
 	return 0
 
 /mob/living/carbon/human/get_permeability_protection()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -18,23 +18,23 @@
 	var/speak_exclamation = "declares"
 	var/speak_query = "queries"
 	var/pose //Yes, now AIs can pose too.
-	
+
 	var/sensor_mode = 0 //Determines the current HUD.
-	
+
 	var/next_alarm_notice
 	var/list/datum/alarm/queued_alarms = new()
-	
+
 	#define SEC_HUD 1 //Security HUD mode
 	#define MED_HUD 2 //Medical HUD mode
 	var/local_transmit //If set, can only speak to others of the same type within a short range.
 	var/obj/item/device/radio/common_radio
-	
+
 /mob/living/silicon/New()
 	silicon_mob_list |= src
 	..()
 	add_language("Galactic Common")
 	init_subsystems()
-	
+
 /mob/living/silicon/Destroy()
 	silicon_mob_list -= src
 	for(var/datum/alarm_handler/AH in alarm_handlers)
@@ -43,8 +43,8 @@
 
 /mob/living/silicon/proc/SetName(pickedName as text)
 	real_name = pickedName
-	name = real_name	
-	
+	name = real_name
+
 /mob/living/silicon/proc/show_laws()
 	return
 
@@ -267,9 +267,6 @@
 			sensor_mode = 0
 			src << "Sensor augmentations disabled."
 
-/mob/living/silicon/IsAdvancedToolUser()
-	return 1
-
 /mob/living/silicon/proc/receive_alarm(var/datum/alarm_handler/alarm_handler, var/datum/alarm/alarm, was_raised)
 	if(!next_alarm_notice)
 		next_alarm_notice = world.time + SecondsToTicks(10)
@@ -310,7 +307,7 @@
 						reported = 1
 						src << "<span class='notice'>--- [AH.category] Cleared ---</span>"
 					src << "\The [A.alarm_name()]."
-					
+
 		if(alarm_raised)
 			src << "<A HREF=?src=\ref[src];showalerts=1>\[Show Alerts\]</A>"
 
@@ -326,4 +323,3 @@
 	for(var/obj/machinery/camera/C in A.cameras())
 		cameratext += "[(cameratext == "")? "" : "|"]<A HREF=?src=\ref[src];switchcamera=\ref[C]>[C.c_tag]</A>"
 	src << "[A.alarm_name()]! ([(cameratext)? cameratext : "No Camera"])"
-	

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -102,3 +102,10 @@
 		. = min(., shared_living_nano_distance(src_object))
 		if(. == STATUS_UPDATE && (TK in mutations))	// If we have telekinesis and remain close enough, allow interaction.
 			return STATUS_INTERACTIVE
+
+/mob/living/carbon/alien/default_can_use_topic(var/src_object)
+	. = shared_nano_interaction(src_object)
+	if(. != STATUS_CLOSE)
+		. = min(., shared_living_nano_distance(src_object))
+		if(!IsAdvancedToolUser())
+			. = STATUS_UPDATE

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -108,4 +108,4 @@
 	if(. != STATUS_CLOSE)
 		. = min(., shared_living_nano_distance(src_object))
 		if(!IsAdvancedToolUser())
-			. = STATUS_UPDATE
+			. = STATUS_CLOSE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -65,7 +65,7 @@
 		send_asset_list(user.client, S.assets)
 
 	var/data
-	if((!(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/dead/observer) || istype(usr, /mob/living/silicon)) && !forceshow) || forcestars)
+	if(!(user.say_understands(null, all_languages["Galactic Common"]) && !forceshow) || forcestars) //assuming all paper is written in common is better than hardcoded type checks
 		data = "<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(info)][stamps]</BODY></HTML>"
 		if(view)
 			usr << browse(data, "window=[name]")


### PR DESCRIPTION
This commit removes all (most) of the remaining code limiting xenomorphs
that have has_fine_manipulation on an entirely arbitrary basis. Xenomorphs
with has_fine_manipulation may now interact with NanoUI, and will only
break computers on non-help intent. The can also tear down walls, since
walls used an ishuman check in place of an isAdvancedToolUser check as
they should have.

Minor refactor to machinery.dm as well; Instead of the slightly
(completely) insane attack_hand restriction to humans and silicons (it was
a multi-line IF, why), it now checks user.IsAdvancedToolUser(); This means
restrictions on monkies will actually function properly now.

Also changed:
 - Paper now works on a say_understands basis.
  - This means that anything with universal speak/understand, or anything with Galactic Common can read papers. Technically allows simple_animals to read paper when they could not before, but whatever.

@Markolie You know nanoUI pretty well; Going to request a review to make sure I didn't fuck anything up too badly.