### PR TITLE
Move buckling to /atom/movable, can now buckle to mobs if adminbooze

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -91,6 +91,9 @@
 			if(loc == newloc) //Remove this check and people can accelerate. Not opening that can of worms just yet.
 				newtonian_move(last_move)
 
+	if(. && buckled_mob && !handle_buckled_mob_movement(loc, direct)) //movement failed due to buckled mob
+		. = 0
+
 
 // Previously known as Crossed()
 // This is automatically called when something enters your square
@@ -303,3 +306,17 @@
 
 /atom/movable/proc/water_act(var/volume, var/temperature, var/source) //amount of water acting : temperature of water in kelvin : object that called it (for shennagins)
 	return 1
+
+/atom/movable/proc/handle_buckled_mob_movement(newloc,direct)
+	if(!buckled_mob.Move(newloc, direct))
+		loc = buckled_mob.loc
+		last_move = buckled_mob.last_move
+		inertia_dir = last_move
+		buckled_mob.inertia_dir = last_move
+		return 0
+	return 1
+
+/atom/movable/CanPass(atom/movable/mover, turf/target, height=1.5)
+	if(buckled_mob == mover)
+		return 1
+	return ..()

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -12,6 +12,7 @@
 	var/strapped = 0.0
 
 	var/obj/machinery/computer/operating/computer = null
+	buckle_lying = 90
 
 /obj/machinery/optable/New()
 	..()
@@ -129,9 +130,9 @@
 	if(src.victim && get_turf(victim) == get_turf(src) && victim.lying)
 		usr << "<span class='notice'>The table is already occupied!</span>"
 		return 0
-		
+
 	if(patient.buckled)
 		usr << "<span class='notice'>Unbuckle first!</span>"
 		return 0
-		
+
 	return 1

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -1,32 +1,32 @@
 
 
-/obj
+/atom/movable
 	var/can_buckle = 0
-	var/buckle_lying = -1 //bed-like behaviour, forces mob.lying = buckle_lying if != -1
+	var/buckle_lying = -1 //bed-like behaviour, forces mob.lying = buckle_lying if != -1 //except -1 actually means "rotate 90 degrees to the left" as it is used by 1*buckle_lying.
 	var/buckle_requires_restraints = 0 //require people to be handcuffed before being able to buckle. eg: pipes
 	var/mob/living/buckled_mob = null
 
 
 //Interaction
-/obj/attack_hand(mob/living/user)
+/atom/movable/attack_hand(mob/living/user)
 	. = ..()
 	if(can_buckle && buckled_mob)
 		return user_unbuckle_mob(user)
 
-/obj/MouseDrop_T(mob/living/M, mob/living/user)
+/atom/movable/MouseDrop_T(mob/living/M, mob/living/user)
 	. = ..()
 	if(can_buckle && istype(M))
 		return user_buckle_mob(M, user)
 
 
 //Cleanup
-/obj/Destroy()
+/atom/movable/Destroy()
 	. = ..()
 	unbuckle_mob()
 
 //procs that handle the actual buckling and unbuckling
-/obj/proc/buckle_mob(mob/living/M)
-	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || (buckle_requires_restraints && !M.restrained()))
+/atom/movable/proc/buckle_mob(mob/living/M)
+	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || M.buckled_mob || (buckle_requires_restraints && !M.restrained()) || M == src)
 		return 0
 
 	if (isslime(M) || isAI(M))
@@ -43,8 +43,8 @@
 	post_buckle_mob(M)
 	return 1
 
-/obj/proc/unbuckle_mob()
-	if(buckled_mob && buckled_mob.buckled == src)
+/atom/movable/proc/unbuckle_mob()
+	if(buckled_mob && buckled_mob.buckled == src && buckled_mob.can_unbuckle(usr))
 		. = buckled_mob
 		buckled_mob.buckled = null
 		buckled_mob.anchored = initial(buckled_mob.anchored)
@@ -56,17 +56,16 @@
 
 //Handle any extras after buckling/unbuckling
 //Called on buckle_mob() and unbuckle_mob()
-/obj/proc/post_buckle_mob(mob/living/M)
+/atom/movable/proc/post_buckle_mob(mob/living/M)
 	return
 
 
 //Wrapper procs that handle sanity and user feedback
-/obj/proc/user_buckle_mob(mob/living/M, mob/user)
+/atom/movable/proc/user_buckle_mob(mob/living/M, mob/user)
 	if(!in_range(user, src) || user.stat || user.restrained())
-		return 0
+		return
 
 	add_fingerprint(user)
-	unbuckle_mob()
 
 	if(buckle_mob(M))
 		if(M == user)
@@ -79,9 +78,8 @@
 				"<span class='warning'>[user] buckles [M] to [src]!</span>",\
 				"<span class='warning'>[user] buckles you to [src]!</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
-		return 1
 
-/obj/proc/user_unbuckle_mob(mob/user)
+/atom/movable/proc/user_unbuckle_mob(mob/user)
 	var/mob/living/M = unbuckle_mob()
 	if(M)
 		if(M != user)
@@ -96,5 +94,3 @@
 				"<span class='italics'>You hear metal clanking.</span>")
 		add_fingerprint(user)
 	return M
-
-

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -30,26 +30,6 @@
 	desc = "This looks similar to contraptions from earth. Could aliens be stealing our technology?"
 	icon_state = "abed"
 
-/obj/structure/stool/bed/Move(atom/newloc, direct) //Some bed children move
-	. = ..()
-	if(buckled_mob)
-		if(!buckled_mob.Move(loc, direct))
-			loc = buckled_mob.loc //we gotta go back
-			last_move = buckled_mob.last_move
-			inertia_dir = last_move
-			buckled_mob.inertia_dir = last_move
-			. = 0
-
-/obj/structure/stool/bed/Process_Spacemove(movement_dir = 0)
-	if(buckled_mob)
-		return buckled_mob.Process_Spacemove(movement_dir)
-	return ..()
-
-/obj/structure/stool/bed/CanPass(atom/movable/mover, turf/target, height=1.5)
-	if(mover == buckled_mob)
-		return 1
-	return ..()
-
 /obj/structure/stool/bed/proc/handle_rotation()
 	return
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -309,6 +309,10 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		src << "You can't vent crawl while you're stunned!"
 		return
 
+	if(buckled_mob)
+		src << "You can't vent crawl with [buckled_mob] on you!"
+		return
+
 	var/obj/machinery/atmospherics/unary/vent_found
 
 	if(clicked_on)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -185,7 +185,7 @@
 			return
 
 		//BubbleWrap: people in handcuffs are always switched around as if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
-		if((tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || src.restrained()) && tmob.canmove && !tmob.buckled && canmove) // mutual brohugs all around!
+		if((tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || restrained()) && tmob.canmove && canmove && !tmob.buckled && !tmob.buckled_mob) // mutual brohugs all around!
 			var/turf/oldloc = loc
 			loc = tmob.loc
 			tmob.loc = oldloc

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -317,7 +317,7 @@
 			C.reagents.addiction_list.Cut()
 	hud_updateflag |= 1 << HEALTH_HUD
 	hud_updateflag |= 1 << STATUS_HUD
-	
+
 /mob/living/proc/update_revive() // handles revival through other means than cloning or adminbus (defib, IPC repair)
 	stat = CONSCIOUS
 	dead_mob_list -= src
@@ -406,7 +406,7 @@
 	return
 
 /mob/living/Move(atom/newloc, direct)
-	if (buckled && buckled.loc != newloc)
+	if (buckled && buckled.loc != newloc) //not updating position
 		if (!buckled.anchored)
 			return buckled.Move(newloc, direct)
 		else

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1019,9 +1019,6 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/facedir(var/ndir)
 	if(!canface())	return 0
 	dir = ndir
-	if(buckled && buckled.movable)
-		buckled.dir = ndir
-		buckled.handle_rotation()
 	client.move_delay += movement_delay()
 	return 1
 
@@ -1398,3 +1395,30 @@ mob/proc/yank_out_object()
 
 /mob/proc/handle_ventcrawl()
 	return // Only living mobs can ventcrawl
+
+//You can buckle on mobs if you're next to them since most are dense
+/mob/buckle_mob(mob/living/M)
+	if(M.buckled)
+		return 0
+	var/turf/T = get_turf(src)
+	if(M.loc != T)
+		var/old_density = density
+		density = 0
+		var/can_step = step_towards(M, T)
+		density = old_density
+		if(!can_step)
+			return 0
+	return ..()
+
+//Default buckling shift visual for mobs
+/mob/post_buckle_mob(mob/living/M)
+	if(M == buckled_mob) //post buckling
+		M.pixel_y = initial(M.pixel_y) + 9
+		if(M.layer < layer)
+			M.layer = layer + 0.1
+	else //post unbuckling
+		M.layer = initial(M.layer)
+		M.pixel_y = initial(M.pixel_y)
+
+/mob/proc/can_unbuckle(mob/user)
+	return 1

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -118,7 +118,7 @@
 	var/m_int = null//Living
 	var/m_intent = "run"//Living
 	var/lastKnownIP = null
-	var/obj/structure/stool/bed/buckled = null//Living
+	var/atom/movable/buckled = null//Living
 	var/obj/item/l_hand = null//Living
 	var/obj/item/r_hand = null//Living
 	var/obj/item/weapon/back = null//Human/Monkey

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -1,16 +1,19 @@
-/mob/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
-	if(air_group || (height==0)) return 1
-
-	if(istype(mover) && mover.checkpass(PASSMOB))
+/mob/CanPass(atom/movable/mover, turf/target, height=0)
+	if(height==0)
+		return 1
+	if(istype(mover, /obj/item/projectile) || mover.throwing)
+		return (!density || lying)
+	if(mover.checkpass(PASSMOB))
+		return 1
+	if(buckled == mover)
 		return 1
 	if(ismob(mover))
 		var/mob/moving_mob = mover
 		if ((other_mobs && moving_mob.other_mobs))
 			return 1
-		return (!mover.density || !density || lying)
-	else
-		return (!mover.density || !density || lying)
-	return
+		if (mover == buckled_mob)
+			return 1
+	return (!mover.density || !density || lying)
 
 
 /client/North()


### PR DESCRIPTION
Port of tgstation/-tg-station#11922
Also changed:
 - Comment clarifying what buckle_lying = -1 means
 - Changes direction of lying on operating tables, somehow missed it
 - Fixes the mob buckled var still being var/obj/structure/stool/bed/buckled. It's now var/atom/movable/buckled.