### PR TITLE
Make darkness clickable

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1808,3 +1808,15 @@ var/mob/dview/dview_mob = new
 			return 0
 	return 1
 	
+/proc/screen_loc2turf(scr_loc, turf/origin)
+	var/tX = text2list(scr_loc, ",")
+	var/tY = text2list(tX[2], ":")
+	var/tZ = origin.z
+	tY = tY[1]
+	tX = text2list(tX[1], ":")
+	tX = tX[1]
+	tX = max(1, min(world.maxx, origin.x + (text2num(tX) - (world.view + 1))))
+	tY = max(1, min(world.maxy, origin.y + (text2num(tY) - (world.view + 1))))
+	return locate(tX, tY, tZ)
+
+	

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -411,3 +411,20 @@
 /*	if(buckled && buckled.movable)
 		buckled.dir = direction
 		buckled.handle_rotation()*/
+		
+/obj/screen/click_catcher
+	icon = 'icons/mob/screen1_full.dmi'
+	icon_state = "passage0"
+	layer = 0
+	mouse_opacity = 2
+	screen_loc = "CENTER-7,CENTER-7"
+
+/obj/screen/click_catcher/Click(location, control, params)
+	var/list/modifiers = params2list(params)
+	if(modifiers["middle"] && istype(usr, /mob/living/carbon))
+		var/mob/living/carbon/C = usr
+		C.swap_hand()
+	else
+		var/turf/T = screen_loc2turf(modifiers["screen-loc"], get_turf(usr))
+		T.Click(location, control, params)
+	return 1

--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -153,6 +153,7 @@
 	mymob.blind.name = " "
 	mymob.blind.screen_loc = "CENTER-7,CENTER-7"
 	mymob.blind.layer = 0
+	mymob.blind.mouse_opacity = 0
 
 	mymob.flash = new /obj/screen()
 	mymob.flash.icon = 'icons/mob/screen1_alien.dmi'
@@ -166,7 +167,8 @@
 	mymob.zone_sel.overlays.Cut()
 	mymob.zone_sel.overlays += image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]")
 
-	mymob.client.screen = null
+	mymob.client.screen = list()
 
 	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.oxygen, mymob.toxin, mymob.fire, mymob.healths, nightvisionicon, mymob.pullin, alien_plasma_display, mymob.pullin, mymob.blind, mymob.flash) //, mymob.hands, mymob.rest, mymob.sleep, mymob.mach )
 	mymob.client.screen += src.adding + src.other
+	mymob.client.screen += mymob.client.void 

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -68,7 +68,8 @@
 	mymob.blind.name = " "
 	mymob.blind.screen_loc = "CENTER-7,CENTER-7"
 	mymob.blind.layer = 0
-
+	mymob.blind.mouse_opacity = 0
+	
 	mymob.flash = new /obj/screen()
 	mymob.flash.icon = 'icons/mob/screen1_alien.dmi'
 	mymob.flash.icon_state = "blank"
@@ -81,7 +82,8 @@
 	mymob.zone_sel.overlays.Cut()
 	mymob.zone_sel.overlays += image("icon" = 'icons/mob/zone_sel.dmi', "icon_state" = text("[]", mymob.zone_sel.selecting))
 
-	mymob.client.screen = null
+	mymob.client.screen = list()
 
 	mymob.client.screen += list( mymob.zone_sel, mymob.oxygen, mymob.toxin, mymob.fire, mymob.healths, nightvisionicon, mymob.pullin, mymob.blind, mymob.flash) //, mymob.rest, mymob.sleep, mymob.mach )
 	mymob.client.screen += src.adding + src.other
+	mymob.client.screen += mymob.client.void

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -483,10 +483,11 @@
 			mymob.gun_setting_icon.dir = 2
 
 
-	mymob.client.screen = null
+	mymob.client.screen = list()
 
 	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.oxygen, mymob.pressure, mymob.toxin, mymob.bodytemp, mymob.internals, mymob.fire, mymob.healths, mymob.healthdoll, mymob.nutrition_icon, mymob.pullin, mymob.blind, mymob.flash, mymob.damageoverlay, mymob.gun_setting_icon) //, mymob.hands, mymob.rest, mymob.sleep) //, mymob.mach )
 	mymob.client.screen += src.adding + src.hotkeybuttons
+	mymob.client.screen += mymob.client.void
 	inventory_shown = 0;
 
 	return

--- a/code/_onclick/hud/monkey.dm
+++ b/code/_onclick/hud/monkey.dm
@@ -247,6 +247,7 @@
 	mymob.blind.screen_loc = "CENTER-7,CENTER-7"
 	mymob.blind.mouse_opacity = 0
 	mymob.blind.layer = 0
+	mymob.blind.mouse_opacity = 0
 
 	mymob.damageoverlay = new /obj/screen()
 	mymob.damageoverlay.icon = 'icons/mob/screen1_full.dmi'
@@ -294,9 +295,10 @@
 			mymob.gun_setting_icon.dir = 2
 
 
-	mymob.client.screen = null
+	mymob.client.screen = list()
 
 	mymob.client.screen += list( mymob.throw_icon, mymob.zone_sel, mymob.oxygen, mymob.pressure, mymob.toxin, mymob.bodytemp, mymob.internals, mymob.fire, mymob.healths, mymob.healthdoll, mymob.nutrition_icon, mymob.pullin, mymob.blind, mymob.flash, mymob.damageoverlay, mymob.gun_setting_icon) //, mymob.hands, mymob.rest, mymob.sleep) //, mymob.mach )
 	mymob.client.screen += src.adding + src.hotkeybuttons
+	mymob.client.screen += mymob.client.void 
 
 	return

--- a/code/_onclick/hud/other_mobs.dm
+++ b/code/_onclick/hud/other_mobs.dm
@@ -47,6 +47,7 @@
 	mymob.blind.name = " "
 	mymob.blind.screen_loc = "CENTER-7,CENTER-7"
 	mymob.blind.layer = 0
+	mymob.blind.mouse_opacity = 0
 
 
 /datum/hud/proc/blob_hud(ui_style = 'icons/mob/screen1_Midnight.dmi')
@@ -63,6 +64,7 @@
 	blobhealthdisplay.screen_loc = ui_internal
 	blobhealthdisplay.layer = 20
 
-	mymob.client.screen = null
+	mymob.client.screen = list()
 
 	mymob.client.screen += list(blobpwrdisplay, blobhealthdisplay)
+	mymob.client.screen += mymob.client.void 

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -137,6 +137,7 @@
 	mymob.blind.name = " "
 	mymob.blind.screen_loc = "CENTER-7,CENTER-7"
 	mymob.blind.layer = 0
+	mymob.blind.mouse_opacity = 0
 
 	mymob.flash = new /obj/screen()
 	mymob.flash.icon = 'icons/mob/screen1_robot.dmi'
@@ -170,11 +171,11 @@
 				src.adding += mymob.gun_run_icon
 			src.adding += mymob.gun_move_icon*/
 
-	mymob.client.screen = null
+	mymob.client.screen = list()
 
 	mymob.client.screen += list(mymob.zone_sel, mymob.oxygen, mymob.fire, mymob.hands, mymob.healths, mymob:cells, mymob.pullin, mymob.blind, mymob.flash, mymob.gun_setting_icon, mymob:lamp_button) //, mymob.rest, mymob.sleep, mymob.mach )
 	mymob.client.screen += src.adding + src.other
-
+	mymob.client.screen += mymob.client.void
 	return
 
 

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -47,7 +47,8 @@
 
 	preload_rsc = 1 // This is 0 so we can set it to an URL once the player logs in and have them download the resources from a different server.
 
-
+	var/global/obj/screen/click_catcher/void
+	
 	var/karma = 0
 	var/karma_spent = 0
 	var/karma_tab = 0

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -292,6 +292,11 @@
 		convert_notes_sql(ckey)	
 	
 	send_resources()
+	
+	if(!void)
+		void = new()
+	
+	screen += void
 
 //////////////
 //DISCONNECT//

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -80,7 +80,8 @@
 
 /mob/living/simple_animal/Login()
 	if(src && src.client)
-		src.client.screen = null
+		src.client.screen = list()
+		client.screen += client.void
 	..()
 
 /mob/living/simple_animal/updatehealth()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -29,7 +29,7 @@
 	world.update_status()
 
 	client.images = null				//remove the images such as AIs being unable to see runes
-	client.screen = null				//remove hud items just in case
+	client.screen = list()				//remove hud items just in case
 	if(hud_used)	del(hud_used)		//remove the hud objects
 	hud_used = new /datum/hud(src)
 
@@ -46,9 +46,9 @@
 
 
 	if(ckey in deadmins)
-		verbs += /client/proc/readmin		
-		
-//Clear ability list and update from mob.
+		verbs += /client/proc/readmin	
+
+	//Clear ability list and update from mob.
 	client.verbs -= ability_verbs
 
 	if(abilities)
@@ -58,5 +58,8 @@
 		var/mob/living/carbon/human/H = src
 		if(H.species && H.species.abilities)
 			client.verbs |= H.species.abilities
+	
+		client.screen += client.void
+		
 
 	CallHook("Login", list("client" = src.client, "mob" = src))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -667,12 +667,13 @@ var/list/slot_equipment_priority = list( \
 
 	log_game("[key_name(usr)] has respawned.")
 
-	usr << "\blue <B>Make sure to play a different character, and please roleplay correctly!</B>"
+	usr << "<span class='boldnotice'>Make sure to play a different character, and please roleplay correctly!</span>"
 
 	if(!client)
 		log_game("[key_name(usr)] respawn failed due to disconnect.")
 		return
 	client.screen.Cut()
+	client.screen += client.void
 
 	if(!client)
 		log_game("[key_name(usr)] respawn failed due to disconnect.")


### PR DESCRIPTION
Changes:
1) Makes darkness clickable, so you can (for instance) throw items into the void. Ports https://github.com/tgstation/-tg-station/pull/10272 by Razharas.

In loving memory of Shadeykins, who died with a syndibomb in hand.