### PR TITLE
Reinserted positronic brains are now properly robotic

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -386,7 +386,7 @@
 			return 2
 
 		if(!(affected.status & ORGAN_ROBOT))
-			user << "<span class='danger'>You cannot install a computer brain into a meat skull.</span>"
+			user << "<span class='danger'>You cannot install a computer brain into a meat enclosure.</span>"
 			return 2
 
 		if(!target.species)
@@ -416,6 +416,9 @@
 
 		var/obj/item/device/mmi/M = tool
 		var/obj/item/organ/mmi_holder/holder = new(target, 1)
+		if (istype(M, /obj/item/device/mmi/posibrain))
+			holder.robotize()
+
 		target.internal_organs_by_name["brain"] = holder
 		user.unEquip(tool)
 		tool.forceMove(holder)


### PR DESCRIPTION
I found that positronic brains, when reinserted, didn't show on a cyborg analyzer. This was due to the code for creating a new MMI holder not robotizing it upon creation, except if it was specifically a posibrain MMI holder. The surgery now robotizes the MMI holder if using a positronic brain, to match this.