### PR TITLE
Disable job completion

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -492,7 +492,7 @@ var/global/datum/controller/gameticker/ticker
 		if (findtext("[handler]","auto_declare_completion_"))
 			call(mode, handler)()
 
-	mode.declare_job_completion()
+	//mode.declare_job_completion()
 
 	scoreboard()
 	karmareminder()


### PR DESCRIPTION
Changes:
1) Disables the job completion blurb in the end of round report. It serves very little purpose (as the job completion system was implemented by a certain someone and then abandoned, as is tradition). There's no need to list the entire science department every round, and it just pushes away antag's hard earned greentexts.