### PR TITLE
GC Gas Mixtures

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -1,17 +1,17 @@
 
 
-turf
+/turf
 	var/pressure_difference = 0
 	var/pressure_direction = 0
 	var/atmos_adjacent_turfs = 0
 	var/atmos_adjacent_turfs_amount = 0
 	var/atmos_supeconductivity = 0
 
-turf/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
-	del(giver)
+/turf/assume_air(datum/gas_mixture/giver) //use this for machines to adjust air
+	qdel(giver)
 	return 0
 
-turf/return_air()
+/turf/return_air()
 	//Create gas mixture to hold data for passing
 	var/datum/gas_mixture/GM = new
 
@@ -24,7 +24,7 @@ turf/return_air()
 
 	return GM
 
-turf/remove_air(amount as num)
+/turf/remove_air(amount as num)
 	var/datum/gas_mixture/GM = new
 
 	var/sum = oxygen + carbon_dioxide + nitrogen + toxins
@@ -39,7 +39,7 @@ turf/remove_air(amount as num)
 	return GM
 
 
-turf/simulated
+/turf/simulated
 	var/datum/excited_group/excited_group
 	var/excited = 0
 	var/recently_active = 0
@@ -53,7 +53,7 @@ turf/simulated
 
 	var/atmos_overlay_type = "" //current active overlay
 
-turf/simulated/New()
+/turf/simulated/New()
 	..()
 
 	if(!blocks_air)
@@ -66,12 +66,12 @@ turf/simulated/New()
 
 		air.temperature = temperature
 
-turf/simulated/Del()
+/turf/simulated/Del()
 	if(active_hotspot)
 		qdel(active_hotspot)
 	..()
 
-turf/simulated/assume_air(datum/gas_mixture/giver)
+/turf/simulated/assume_air(datum/gas_mixture/giver)
 	if(!giver)	return 0
 	var/datum/gas_mixture/receiver = air
 	if(istype(receiver))
@@ -84,22 +84,22 @@ turf/simulated/assume_air(datum/gas_mixture/giver)
 
 	else return ..()
 
-turf/simulated/proc/copy_air_with_tile(turf/simulated/T)
+/turf/simulated/proc/copy_air_with_tile(turf/simulated/T)
 	if(istype(T) && T.air && air)
 		air.copy_from(T.air)
 
-turf/simulated/proc/copy_air(datum/gas_mixture/copy)
+/turf/simulated/proc/copy_air(datum/gas_mixture/copy)
 	if(air && copy)
 		air.copy_from(copy)
 
-turf/simulated/return_air()
+/turf/simulated/return_air()
 	if(air)
 		return air
 
 	else
 		return ..()
 
-turf/simulated/remove_air(amount as num)
+/turf/simulated/remove_air(amount as num)
 	if(air)
 		var/datum/gas_mixture/removed = null
 
@@ -112,7 +112,7 @@ turf/simulated/remove_air(amount as num)
 	else
 		return ..()
 
-turf/simulated/proc/mimic_temperature_solid(turf/model, conduction_coefficient)
+/turf/simulated/proc/mimic_temperature_solid(turf/model, conduction_coefficient)
 	var/delta_temperature = (temperature_archived - model.temperature)
 	if((heat_capacity > 0) && (abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER))
 
@@ -120,7 +120,7 @@ turf/simulated/proc/mimic_temperature_solid(turf/model, conduction_coefficient)
 			(heat_capacity*model.heat_capacity/(heat_capacity+model.heat_capacity))
 		temperature -= heat/heat_capacity
 
-turf/simulated/proc/share_temperature_mutual_solid(turf/simulated/sharer, conduction_coefficient)
+/turf/simulated/proc/share_temperature_mutual_solid(turf/simulated/sharer, conduction_coefficient)
 	var/delta_temperature = (temperature_archived - sharer.temperature_archived)
 	if(abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER && heat_capacity && sharer.heat_capacity)
 
@@ -287,10 +287,10 @@ turf/simulated/proc/share_temperature_mutual_solid(turf/simulated/sharer, conduc
 
 
 
-atom/movable/var/pressure_resistance = 5
-atom/movable/var/last_forced_movement = 0
+/atom/movable/var/pressure_resistance = 5
+/atom/movable/var/last_forced_movement = 0
 
-atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
+/atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 	if(last_forced_movement >= air_master.current_cycle)
 		return 0
 	else if(!anchored && !pulledby)

--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -53,6 +53,10 @@ What are the archived variables for?
 
 	var/tmp/fuel_burnt = 0
 
+/datum/gas_mixture/Destroy()
+	..()
+	return QDEL_HINT_QUEUE
+
 	//PV=nRT - related procedures
 /datum/gas_mixture/proc/heat_capacity()
 	var/heat_capacity = HEAT_CAPACITY_CALCULATION(oxygen,carbon_dioxide,nitrogen,toxins)
@@ -319,7 +323,7 @@ What are the archived variables for?
 				trace_gases += corresponding
 			corresponding.moles += trace_gas.moles
 
-//	del(giver)
+//	qdel(giver)
 	return 1
 
 /datum/gas_mixture/remove(amount)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -42,6 +42,7 @@
 	return
 
 /atom/proc/assume_air(datum/gas_mixture/giver)
+	qdel(giver)
 	return null
 
 /atom/proc/remove_air(amount)


### PR DESCRIPTION
Garbage collect's gas mixtures.

This should help LINDA perform a hair bit better--initial tests show that gas mixtures GC very very well.

- Adds in a missing qdel to gas mixtures on the atom level.

This doesn't mean that all of a sudden the 750,000 gas mixture datums generated each shift are all going to be GC'd--most gas mixture datums are created then abandoned--it's hard to know which ones are truly directly deleted and which ones just GC naturally--either case, this will make the ones that *are* directly qdel'd (still thousands) GC.