### PR TITLE
Scoreboard refactor, move job objectives to scoreboard

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -48,6 +48,7 @@ var/score_allarrested = 0 // did the crew catch all the enemies alive?
 var/score_opkilled = 0 // used during nuke mode, how many operatives died?
 var/score_disc = 0 // is the disc safe and secure?
 var/score_nuked = 0 // was the station blown into little bits?
+var/score_nuked_penalty = 0 //penalty for getting blown to bits
 
 	// these ones are mainly for the stat panel
 var/score_powerbonus = 0 // if all APCs on the station are running optimally, big bonus

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -222,7 +222,7 @@ var/global/datum/controller/gameticker/ticker
 	*/
 
 	processScheduler.start()
-	
+
 	if(config.sql_enabled)
 		spawn(3000)
 			statistic_cycle() // Polls population totals regularly and stores them in an SQL DB
@@ -486,13 +486,11 @@ var/global/datum/controller/gameticker/ticker
 		world << "<b>There [dronecount>1 ? "were" : "was"] [dronecount] industrious maintenance [dronecount>1 ? "drones" : "drone"] this round."
 
 	mode.declare_completion()//To declare normal completion.
-	
+
 	//calls auto_declare_completion_* for all modes
 	for(var/handler in typesof(/datum/game_mode/proc))
 		if (findtext("[handler]","auto_declare_completion_"))
 			call(mode, handler)()
-
-	mode.declare_job_completion()
 
 	scoreboard()
 	karmareminder()

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -20,126 +20,92 @@
 	// Score Calculation and Display
 
 	// Who is alive/dead, who escaped
-	for (var/mob/living/silicon/ai/I in mob_list)
-		if (I.stat == 2 && (I.z in config.station_levels))
-			score_deadaipenalty = 1
-			score_deadcrew += 1
-	for (var/mob/living/carbon/human/I in mob_list)
-//		for (var/datum/ailment/disease/V in I.ailments)
-//			if (!V.vaccine && !V.spread != "Remissive") score_disease++
-		if (I.stat == 2 && (I.z in config.station_levels)) score_deadcrew += 1
-		if (I.job == "Clown")
-			for(var/thing in I.attack_log)
-				if(findtext(thing, "<font color='orange'>")) score_clownabuse++
+	for(var/mob/living/silicon/ai/I in mob_list)
+		if(I.stat == DEAD && (I.z in config.station_levels))
+			score_deadaipenalty++
+			score_deadcrew++
+
+	for(var/mob/living/carbon/human/I in mob_list)
+		if(I.stat == DEAD && (I.z in config.station_levels))
+			score_deadcrew++
+
+		if(I && I.mind)
+			if(I.mind.assigned_role == "Clown")
+				for(var/thing in I.attack_log)
+					if(findtext(thing, "<font color='orange'>")) //This has to be the hackiest fucking way _ever_ to see attacks.
+						score_clownabuse++
 
 
 	for(var/mob/living/player in mob_list)
-		if (player.client)
-			if (player.stat != 2)
+		if(player.client)
+			if (player.stat != DEAD)
 				var/turf/location = get_turf(player.loc)
 				var/area/escape_zone = locate(/area/shuttle/escape/centcom)
-				if (location in escape_zone)
-					score_escapees += 1
-//					player.unlock_medal("100M Dash", 1)
-//				player.unlock_medal("Survivor", 1)
-//				for (var/obj/item/weapon/gnomechompski/G in player.get_contents())
-//					player.unlock_medal("Guardin' gnome", 1)
+				if(location in escape_zone)
+					score_escapees++
 
 
-	var/cashscore = 0
-	var/dmgscore = 0
+
+	var/cash_score = 0
+	var/dmg_score = 0
 	for(var/mob/living/carbon/human/E in mob_list)
-		cashscore = 0
-		dmgscore = 0
+		cash_score = 0
+		dmg_score = 0
 		var/turf/location = get_turf(E.loc)
 		var/area/escape_zone = locate(/area/shuttle/escape/centcom)
-		if(E.stat != 2 && location in escape_zone) // Escapee Scores
-			for (var/obj/item/weapon/card/id/C1 in E.contents) cashscore += C1.money
-			for (var/obj/item/weapon/spacecash/C2 in E.contents) cashscore += C2.worth
-			for (var/obj/item/weapon/storage/S in E.contents)
-				for (var/obj/item/weapon/card/id/C3 in S.contents) cashscore += C3.money
-				for (var/obj/item/weapon/spacecash/C4 in S.contents) cashscore += C4.worth
-//			for(var/datum/data/record/Ba in data_core.bank)
-//				if(Ba.fields["name"] == E.real_name) cashscore += Ba.fields["current_money"]
-			if (cashscore > score_richestcash)
-				score_richestcash = cashscore
+
+		if(E.stat != DEAD && location in escape_zone) // Escapee Scores
+			for(var/obj/item/weapon/card/id/C1 in E.contents)
+				cash_score += C1.money
+			for(var/obj/item/weapon/spacecash/C2 in E.contents)
+				cash_score += C2.worth
+			for(var/obj/item/weapon/storage/S in E.contents)
+				for(var/obj/item/weapon/card/id/C3 in S.contents)
+					cash_score += C3.money
+				for(var/obj/item/weapon/spacecash/C4 in S.contents)
+					cash_score += C4.worth
+
+			if(cash_score > score_richestcash)
+				score_richestcash = cash_score
 				score_richestname = E.real_name
 				score_richestjob = E.job
 				score_richestkey = E.key
-			dmgscore = E.bruteloss + E.fireloss + E.toxloss + E.oxyloss
-			if (dmgscore > score_dmgestdamage)
-				score_dmgestdamage = dmgscore
+
+			dmg_score = E.bruteloss + E.fireloss + E.toxloss + E.oxyloss
+			if(dmg_score > score_dmgestdamage)
+				score_dmgestdamage = dmg_score
 				score_dmgestname = E.real_name
 				score_dmgestjob = E.job
 				score_dmgestkey = E.key
 
-	var/nukedpenalty = 1000
-	if (ticker.mode.config_tag == "nuclear")
-		var/foecount = 0
-		for(var/datum/mind/M in ticker.mode:syndicates)
-			foecount++
-			if (!M || !M.current)
-				score_opkilled++
-				continue
-			var/turf/T = M.current.loc
-			if (T && istype(T.loc, /area/security/brig)) score_arrested += 1
-			else if (M.current.stat == 2) score_opkilled++
-		if(foecount == score_arrested) score_allarrested = 1
+	if(ticker && ticker.mode)
+		ticker.mode.set_scoreboard_gvars()
 
-/*
-		score_disc = 1
-		for(var/obj/item/weapon/disk/nuclear/A in world)
-			if(A.loc != /mob/living/carbon) continue
-			var/turf/location = get_turf(A.loc)
-			var/area/bad_zone1 = locate(/area)
-			var/area/bad_zone2 = locate(/area/syndicate_station)
-			var/area/bad_zone3 = locate(/area/wizard_station)
-			if (location in bad_zone1) score_disc = 0
-			if (location in bad_zone2) score_disc = 0
-			if (location in bad_zone3) score_disc = 0
-			if (!(A.loc.z in config.station_levels)) score_disc = 0
-*/
-		if (score_nuked)
-			for (var/obj/machinery/nuclearbomb/NUKE in machines)
-				if (NUKE.r_code == "Nope") continue
-				var/turf/T = NUKE.loc
-				if (istype(T,/area/syndicate_station) || istype(T,/area/wizard_station) || istype(T,/area/solar)) nukedpenalty = 1000
-				else if (istype(T,/area/security/main) || istype(T,/area/security/brig) || istype(T,/area/security/armoury) || istype(T,/area/security/checkpoint2)) nukedpenalty = 50000
-				else if (istype(T,/area/engine)) nukedpenalty = 100000
-				else nukedpenalty = 10000
-
-	if (ticker.mode.config_tag == "revolution")
-		var/foecount = 0
-		for(var/datum/mind/M in ticker.mode:head_revolutionaries)
-			foecount++
-			if (!M || !M.current)
-				score_opkilled++
-				continue
-			var/turf/T = M.current.loc
-			if (istype(T.loc, /area/security/brig)) score_arrested += 1
-			else if (M.current.stat == 2) score_opkilled++
-		if(foecount == score_arrested) score_allarrested = 1
-		for(var/mob/living/carbon/human/player in world)
-			if(player.mind)
-				var/role = player.mind.assigned_role
-				if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director"))
-					if (player.stat == 2) score_deadcommand++
 
 	// Check station's power levels
-	for (var/obj/machinery/power/apc/A in machines)
-		if (!(A.z in config.station_levels)) continue
-		for (var/obj/item/weapon/stock_parts/cell/C in A.contents)
-			if (C.charge < 2300) score_powerloss += 1 // 200 charge leeway
+	for(var/obj/machinery/power/apc/A in machines)
+		if(!(A.z in config.station_levels)) continue
+
+		for(var/obj/item/weapon/stock_parts/cell/C in A.contents)
+			if(C.charge < 2300)
+				score_powerloss++ //200 charge leeway
+
 
 	// Check how much uncleaned mess is on the station
-	for (var/obj/effect/decal/cleanable/M in world)
-		if (!(M.z in config.station_levels)) continue
-		if (istype(M, /obj/effect/decal/cleanable/blood/gibs/)) score_mess += 3
-		if (istype(M, /obj/effect/decal/cleanable/blood/)) score_mess += 1
-//		if (istype(M, /obj/effect/decal/cleanable/greenpuke)) score_mess += 1
-		if (istype(M, /obj/effect/decal/cleanable/poop)) score_mess += 1
-//		if (istype(M, /obj/decal/cleanable/urine)) score_mess += 1
-		if (istype(M, /obj/effect/decal/cleanable/vomit)) score_mess += 1
+	for(var/obj/effect/decal/cleanable/M in world)
+		if(!(M.z in config.station_levels)) continue
+		if(istype(M, /obj/effect/decal/cleanable/blood/gibs))
+			score_mess += 3
+
+		if(istype(M, /obj/effect/decal/cleanable/blood))
+			score_mess += 1
+
+		if(istype(M, /obj/effect/decal/cleanable/poop))
+			score_mess += 1
+
+		if(istype(M, /obj/effect/decal/cleanable/vomit))
+			score_mess += 1
+
 
 	// Bonus Modifiers
 	//var/traitorwins = score_traitorswon
@@ -153,26 +119,10 @@
 	var/meals = score_meals * 5 //done, but this only counts cooked meals, not drinks served
 	var/power = score_powerloss * 20
 	var/messpoints
-	if (score_mess != 0) messpoints = score_mess //done
+	if(score_mess != 0)
+		messpoints = score_mess //done
 	var/plaguepoints = score_disease * 30
 
-	// Mode Specific
-	if (ticker.mode.config_tag == "nuclear")
-		if (score_disc) score_crewscore += 500
-		var/killpoints = score_opkilled * 250
-		var/arrestpoints = score_arrested * 1000
-		score_crewscore += killpoints
-		score_crewscore += arrestpoints
-		if (score_nuked) score_crewscore -= nukedpenalty
-
-	if (ticker.mode.config_tag == "revolution")
-		var/arrestpoints = score_arrested * 1000
-		var/killpoints = score_opkilled * 500
-		var/comdeadpts = score_deadcommand * 500
-		if (score_traitorswon) score_crewscore -= 10000
-		score_crewscore += arrestpoints
-		score_crewscore += killpoints
-		score_crewscore -= comdeadpts
 
 	// Good Things
 	score_crewscore += shipping
@@ -182,23 +132,26 @@
 	score_crewscore += eventpoints
 	score_crewscore += escapoints
 
-	if (power == 0)
+	if(power == 0)
 		score_crewscore += 2500
 		score_powerbonus = 1
-	if (score_mess == 0)
+
+	if(score_mess == 0)
 		score_crewscore += 3000
 		score_messbonus = 1
-	score_crewscore += meals
-	if (score_allarrested) score_crewscore *= 3 // This needs to be here for the bonus to be applied properly
 
-	// Bad Things
+
+	score_crewscore += meals
+	if(score_allarrested)
+		score_crewscore *= 3 // This needs to be here for the bonus to be applied properly
+
+
 	score_crewscore -= deathpoints
-	if (score_deadaipenalty) score_crewscore -= 250
+	if(score_deadaipenalty)
+		score_crewscore -= 250
 	score_crewscore -= power
-	//if (score_crewscore != 0) // Dont divide by zero!
-	//	while (traitorwins > 0)
-	//		score_crewscore /= 2
-	//		traitorwins -= 1
+
+
 	score_crewscore -= messpoints
 	score_crewscore -= plaguepoints
 
@@ -209,124 +162,60 @@
 		if(E.client)
 			if(E.client.prefs && !(E.client.prefs.toggles & DISABLE_SCOREBOARD))
 				E.scorestats()
-	return
 
 
+/datum/game_mode/proc/get_scoreboard_stats()
+	return null
+
+/datum/game_mode/proc/set_scoreboard_gvars()
+	return null
 
 /mob/proc/scorestats()
-	var/dat = {"<B>Round Statistics and Score</B><BR><HR>"}
-	if (ticker.mode.name == "nuclear emergency")
-		var/foecount = 0
-		var/crewcount = 0
-		var/diskdat = ""
-		var/bombdat = null
-		for(var/datum/mind/M in ticker.mode:syndicates)
-			foecount++
-		for(var/mob/living/C in world)
-			if (!istype(C,/mob/living/carbon/human) || !istype(C,/mob/living/silicon/robot) || !istype(C,/mob/living/silicon/ai)) continue
-			if (C.stat == 2) continue
-			if (!C.client) continue
-			crewcount++
+	var/dat = "<b>Round Statistics and Score</b><br><hr>"
+	if(ticker && ticker.mode)
+		dat += ticker.mode.get_scoreboard_stats()
 
-		for(var/obj/item/weapon/disk/nuclear/N in world)
-			if(!N) continue
-			var/atom/disk_loc = N.loc
-			while(!istype(disk_loc, /turf))
-				if(istype(disk_loc, /mob))
-					var/mob/M = disk_loc
-					diskdat += "Carried by [M.real_name] "
-				if(istype(disk_loc, /obj))
-					var/obj/O = disk_loc
-					diskdat += "in \a [O.name] "
-				disk_loc = disk_loc.loc
-			diskdat += "in [disk_loc.loc]"
-			break // Should only need one go-round, probably
-		var/nukedpenalty = 0
-		for(var/obj/machinery/nuclearbomb/NUKE in world)
-			if (NUKE.r_code == "Nope") continue
-			var/turf/T = NUKE.loc
-			bombdat = T.loc
-			if (istype(T,/area/syndicate_station) || istype(T,/area/wizard_station) || istype(T,/area/solar/) || istype(T,/area)) nukedpenalty = 1000
-			else if (istype(T,/area/security/main) || istype(T,/area/security/brig) || istype(T,/area/security/armoury) || istype(T,/area/security/checkpoint2)) nukedpenalty = 50000
-			else if (istype(T,/area/engine)) nukedpenalty = 100000
-			else nukedpenalty = 10000
-			break
-		if (!diskdat) diskdat = "Uh oh. Something has fucked up! Report this."
-		dat += {"<B><U>MODE STATS</U></B><BR>
-		<B>Number of Operatives:</B> [foecount]<BR>
-		<B>Number of Surviving Crew:</B> [crewcount]<BR>
-		<B>Final Location of Nuke:</B> [bombdat]<BR>
-		<B>Final Location of Disk:</B> [diskdat]<BR><BR>
-		<B>Operatives Arrested:</B> [score_arrested] ([score_arrested * 1000] Points)<BR>
-		<B>Operatives Killed:</B> [score_opkilled] ([score_opkilled * 250] Points)<BR>
-		<B>Station Destroyed:</B> [score_nuked ? "Yes" : "No"] (-[nukedpenalty] Points)<BR>
-		<B>All Operatives Arrested:</B> [score_allarrested ? "Yes" : "No"] (Score tripled)<BR>
-		<HR>"}
-//		<B>Nuclear Disk Secure:</B> [score_disc ? "Yes" : "No"] ([score_disc * 500] Points)<BR>
-	if (ticker.mode.name == "revolution")
-		var/foecount = 0
-		var/comcount = 0
-		var/revcount = 0
-		var/loycount = 0
-		for(var/datum/mind/M in ticker.mode:head_revolutionaries)
-			if (M.current && M.current.stat != 2) foecount++
-		for(var/datum/mind/M in ticker.mode:revolutionaries)
-			if (M.current && M.current.stat != 2) revcount++
-		for(var/mob/living/carbon/human/player in world)
-			if(player.mind)
-				var/role = player.mind.assigned_role
-				if(role in list("Captain", "Head of Security", "Head of Personnel", "Chief Engineer", "Research Director"))
-					if (player.stat != 2) comcount++
-				else
-					if(player.mind in ticker.mode:revolutionaries) continue
-					loycount++
-		for(var/mob/living/silicon/X in world)
-			if (X.stat != 2) loycount++
-		var/revpenalty = 10000
-		dat += {"<B><U>MODE STATS</U></B><BR>
-		<B>Number of Surviving Revolution Heads:</B> [foecount]<BR>
-		<B>Number of Surviving Command Staff:</B> [comcount]<BR>
-		<B>Number of Surviving Revolutionaries:</B> [revcount]<BR>
-		<B>Number of Surviving Loyal Crew:</B> [loycount]<BR><BR>
-		<B>Revolution Heads Arrested:</B> [score_arrested] ([score_arrested * 1000] Points)<BR>
-		<B>Revolution Heads Slain:</B> [score_opkilled] ([score_opkilled * 500] Points)<BR>
-		<B>Command Staff Slain:</B> [score_deadcommand] (-[score_deadcommand * 500] Points)<BR>
-		<B>Revolution Successful:</B> [score_traitorswon ? "Yes" : "No"] (-[score_traitorswon * revpenalty] Points)<BR>
-		<B>All Revolution Heads Arrested:</B> [score_allarrested ? "Yes" : "No"] (Score tripled)<BR>
-		<HR>"}
-//	var/totalfunds = wagesystem.station_budget + wagesystem.research_budget + wagesystem.shipping_budget
-	dat += {"<B><U>GENERAL STATS</U></B><BR>
-	<U>THE GOOD:</U><BR>
-	<B>Useful Items Shipped:</B> [score_stuffshipped] ([score_stuffshipped * 5] Points)<BR>
-	<B>Hydroponics Harvests:</B> [score_stuffharvested] ([score_stuffharvested * 5] Points)<BR>
-	<B>Ore Mined:</B> [score_oremined] ([score_oremined * 2] Points)<BR>
-	<B>Refreshments Prepared:</B> [score_meals] ([score_meals * 5] Points)<BR>
-	<B>Research Completed:</B> [score_researchdone] ([score_researchdone * 30] Points)<BR>"}
-	if (!emergency_shuttle.location()) dat += "<B>Shuttle Escapees:</B> [score_escapees] ([score_escapees * 25] Points)<BR>"
-	dat += {"<B>Random Events Endured:</B> [score_eventsendured] ([score_eventsendured * 50] Points)<BR>
-	<B>Whole Station Powered:</B> [score_powerbonus ? "Yes" : "No"] ([score_powerbonus * 2500] Points)<BR>
-	<B>Ultra-Clean Station:</B> [score_mess ? "No" : "Yes"] ([score_messbonus * 3000] Points)<BR><BR>
-	<U>THE BAD:</U><BR>
-	<B>Dead Bodies on Station:</B> [score_deadcrew] (-[score_deadcrew * 25] Points)<BR>
-	<B>Uncleaned Messes:</B> [score_mess] (-[score_mess] Points)<BR>
-	<B>Station Power Issues:</B> [score_powerloss] (-[score_powerloss * 20] Points)<BR>
-	<B>Rampant Diseases:</B> [score_disease] (-[score_disease * 30] Points)<BR>
-	<B>AI Destroyed:</B> [score_deadaipenalty ? "Yes" : "No"] (-[score_deadaipenalty * 250] Points)<BR><BR>
-	<U>THE WEIRD</U><BR>"}
-/*	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"}
-	var/profit = totalfunds - 100000
-	if (profit > 0) dat += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
-	else if (profit < 0) dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"}*/
-	dat += {"<B>Food Eaten:</b> [score_foodeaten]<BR>
-	<B>Times a Clown was Abused:</B> [score_clownabuse]<BR><BR>"}
+	dat += {"
+	<b><u>General Statistics</u></b><br>
+	<u>The Good:</u><br>
+
+	<b>Useful Items Shipped:</b> [score_stuffshipped] ([score_stuffshipped * 5] Points)<br>
+	<b>Hydroponics Harvests:</b> [score_stuffharvested] ([score_stuffharvested * 5] Points)<br>
+	<b>Ore Mined:</b> [score_oremined] ([score_oremined * 2] Points)<br>
+	<b>Refreshments Prepared:</b> [score_meals] ([score_meals * 5] Points)<br>
+	<b>Research Completed:</b> [score_researchdone] ([score_researchdone * 30] Points)<br>"}
+	if (!emergency_shuttle.location()) dat += "<b>Shuttle Escapees:</b> [score_escapees] ([score_escapees * 25] Points)<br>"
+	dat += {"<b>Random Events Endured:</b> [score_eventsendured] ([score_eventsendured * 50] Points)<br>
+	<b>Whole Station Powered:</b> [score_powerbonus ? "Yes" : "No"] ([score_powerbonus * 2500] Points)<br>
+	<b>Ultra-Clean Station:</b> [score_mess ? "No" : "Yes"] ([score_messbonus * 3000] Points)<br><br>
+	<U>The bad:</U><br>
+
+	<b>Dead bodies on Station:</b> [score_deadcrew] (-[score_deadcrew * 25] Points)<br>
+	<b>Uncleaned Messes:</b> [score_mess] (-[score_mess] Points)<br>
+	<b>Station Power Issues:</b> [score_powerloss] (-[score_powerloss * 20] Points)<br>
+	<b>Rampant Diseases:</b> [score_disease] (-[score_disease * 30] Points)<br>
+	<b>AI Destroyed:</b> [score_deadaipenalty ? "Yes" : "No"] (-[score_deadaipenalty * 250] Points)<br><br>
+	<U>The Weird</U><br>
+
+	<b>Food Eaten:</b> [score_foodeaten]<br>
+	<b>Times a Clown was Abused:</b> [score_clownabuse]<br><br>
+	"}
 	if (score_escapees)
-		dat += {"<B>Richest Escapee:</B> [score_richestname], [score_richestjob]: $[num2text(score_richestcash,50)] ([score_richestkey])<BR>
-		<B>Most Battered Escapee:</B> [score_dmgestname], [score_dmgestjob]: [score_dmgestdamage] damage ([score_dmgestkey])<BR>"}
+		dat += {"<b>Richest Escapee:</b> [score_richestname], [score_richestjob]: $[num2text(score_richestcash,50)] ([score_richestkey])<br>
+		<b>Most Battered Escapee:</b> [score_dmgestname], [score_dmgestjob]: [score_dmgestdamage] damage ([score_dmgestkey])<br>"}
 	else
-		if (emergency_shuttle.location()) dat += "The station wasn't evacuated!<BR>"
-		else dat += "No-one escaped!<BR>"
-	dat += {"<HR><BR>
-	<B><U>FINAL SCORE: [score_crewscore]</U></B><BR>"}
+		if(emergency_shuttle.location())
+			dat += "The station wasn't evacuated!<br>"
+		else
+			dat += "No-one escaped!<br>"
+
+	dat += ticker.mode.declare_job_completion()
+
+	dat += {"
+	<hr><br>
+	<b><u>FINAL SCORE: [score_crewscore]</u></b><br>
+	"}
+
 	var/score_rating = "The Aristocrats!"
 	switch(score_crewscore)
 		if(-99999 to -50000) score_rating = "Even the Singularity Deserves Better"
@@ -345,6 +234,6 @@
 		if(5000 to 9999) score_rating = "Ambassadors of Discovery"
 		if(10000 to 49999) score_rating = "The Pride of Science Itself"
 		if(50000 to INFINITY) score_rating = "Nanotrasen's Finest"
-	dat += "<B><U>RATING:</U></B> [score_rating]"
+
+	dat += "<b><u>RATING:</u></b> [score_rating]"
 	src << browse(dat, "window=roundstats;size=500x600")
-	return

--- a/code/game/jobs/job_objective.dm
+++ b/code/game/jobs/job_objective.dm
@@ -1,12 +1,12 @@
-/datum/mind/var/list/job_objectives=list()
+/datum/mind/var/list/job_objectives = list()
 
 #define FINDJOBTASK_DEFAULT_NEW 1 // Make a new task of this type if one can't be found.
-/datum/mind/proc/findJobTask(var/typepath,var/options=0)
-	var/datum/job_objective/task = locate(typepath) in src.job_objectives
+/datum/mind/proc/findJobTask(var/typepath, var/options = 0)
+	var/datum/job_objective/task = locate(typepath) in job_objectives
 	if(!istype(task,typepath))
 		if(options & FINDJOBTASK_DEFAULT_NEW)
 			task = new typepath()
-			src.job_objectives += task
+			job_objectives += task
 	return task
 
 /datum/job_objective
@@ -19,13 +19,13 @@
 	var/completion_payment = 0			// Credits paid to owner when completed
 
 /datum/job_objective/New(var/datum/mind/new_owner)
-	owner=new_owner
+	owner = new_owner
 	owner.job_objectives += src
 
-/datum/job_objective/Destroy()
 
 /datum/job_objective/proc/get_description()
-	return "Placeholder objective."
+	var/desc = "Placeholder Objective"
+	return desc
 
 /datum/job_objective/proc/unit_completed(var/count=1)
 	units_completed += count
@@ -36,47 +36,41 @@
 	return completed
 
 /datum/job_objective/proc/check_for_completion()
-	return per_unit && units_completed > 0
+	if(per_unit)
+		if(units_completed > 0)
+			return 1
+	return 0
 
 /datum/game_mode/proc/declare_job_completion()
-	var/text = "<FONT size = 2><B>Job Completion:</B></FONT>"
-	var/numEmployees=0
+	var/text = "<hr><b><u>Job Completion</u></b>"
+
 	for(var/datum/mind/employee in ticker.minds)
+
 		if(!employee.job_objectives.len)//If the employee had no objectives, don't need to process this.
 			continue
+
 		if(!employee.assigned_role=="MODE")//If the employee is a gamemode thing, skip.
 			continue
-		numEmployees++
+
 		var/tasks_completed=0
 
-		//text += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job]:\n"
-		text += "<br>[employee.key] was [employee.name], the [employee.assigned_role] ("
-		if(employee.current)
-			if(employee.current.stat == DEAD)
-				text += "died"
-			else
-				text += "survived"
-			if(employee.current.real_name != employee.name)
-				text += " as [employee.current.real_name]"
-		else
-			text += "body destroyed"
-		text += ")"
+		text += "<br>[employee.name] was a [employee.assigned_role]:"
 
 		var/count = 1
 		for(var/datum/job_objective/objective in employee.job_objectives)
 			if(objective.is_completed(1))
-				text += "<br><B>Task #[count]</B>: [objective.get_description()] <font color='green'><B>Completed!</B></font>"
+				text += "<br>&nbsp;-&nbsp;<B>Task #[count]</B>: [objective.get_description()] <font color='green'><B>Completed!</B></font>"
 				feedback_add_details("employee_objective","[objective.type]|SUCCESS")
 				tasks_completed++
 			else
+				text += "<br>&nbsp;-&nbsp;<B>Task #[count]</B>: [objective.get_description()] <font color='red'><b>Failed.</b></font>"
 				feedback_add_details("employee_objective","[objective.type]|FAIL")
 			count++
 
-		if(tasks_completed>=1)
-			text += "<br><font color='green'><B>The [employee.assigned_role] did their fucking job!</B></font>"
+		if(tasks_completed >= 1)
+			text += "<br>&nbsp;<font color='green'><B>[employee.name] did their fucking job!</B></font>"
 			feedback_add_details("employee_success","SUCCESS")
 		else
 			feedback_add_details("employee_success","FAIL")
-	if(numEmployees>0)
-		world << text
-	return 1
+
+	return text

--- a/code/game/jobs/job_objectives/science.dm
+++ b/code/game/jobs/job_objectives/science.dm
@@ -4,21 +4,21 @@
 
 // MAXIMUM SCIENCE
 /datum/job_objective/maximize_research
-	completion_payment=1000
+	completion_payment = 1000
 
 /datum/job_objective/maximize_research/get_description()
-	return "Maximize all legal research tech levels."
+	var/desc = "Maximize all legal research tech levels."
+	return desc
 
 /datum/job_objective/maximize_research/check_for_completion()
 	var/obj/machinery/r_n_d/server/server = null
 	for(var/obj/machinery/r_n_d/server/serber in machines)
 		if(serber.name == "Core R&D Server")
-			server=serber
+			server = serber
 			break
 	if(!server)
-		// This was just used for testing.
-		//world << "UNABLE TO FIND A GODDAMN RND SERVER. FUCK."
-		return
+		return 0
+
 	for(var/datum/tech/T in server.files.possible_tech)
 		if(T.max_level==0) // Ignore illegal tech, etc
 			continue
@@ -33,28 +33,24 @@
 // Robotics
 /////////////////////////////////////////////////////////////////////////////////////////
 
-// Mek cyburg
+//Cyborgs
 /datum/job_objective/make_cyborg
-	completion_payment=100
-	per_unit=1
+	completion_payment = 100
+	per_unit = 1
 
 /datum/job_objective/make_cyborg/get_description()
-	return "Make a cyborg. ([units_completed] created.)"
-/*
-// Mek MoMMI
-/datum/job_objective/make_mommi
-	completion_payment=150
-	per_unit=1
+	var/desc = "Make a cyborg."
+	desc += "([units_completed] created.)"
+	return desc
 
-/datum/job_objective/make_mommi/get_description()
-	return "Make a Mobile MMI. ([units_completed] created.)"
-*/
-// Mek Ripley
+
+
+//RIPLEY's
 /datum/job_objective/make_ripley
-	completion_payment=600
-	per_unit=1
+	completion_payment = 600
+	per_unit = 1
 
 /datum/job_objective/make_ripley/get_description()
-	return "Make a Ripley. ([units_completed] created.)"
-
-
+	var/desc = "Make a Ripley."
+	desc += "([units_completed] created.)"
+	return desc


### PR DESCRIPTION
Alternative to #2298 
This commit does the following:
 - Refactors scoreboard code to get rid of, at least, some of the
   snowflakiness.
 - Removes world << job objectives, puts them in the scoreboard.

Addendum: Nukeops and Rev are untested, due to the near-impossibility of
testing them alone. They _probably_ work.

![screenshot](https://puu.sh/kzRko/326baf9d81.png)