### PR TITLE
Ammo update fixes

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -24,7 +24,7 @@
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
 	projectile_type = "/obj/item/projectile/bullet/weakbullet3"
-	
+
 /obj/item/ammo_casing/c9mmap
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
@@ -63,6 +63,14 @@
 	pellets = 5
 	deviation = 30
 
+/obj/item/ammo_casing/shotgun/rubbershot
+	name = "rubber shot"
+	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
+	icon_state = "bshell"
+	projectile_type = "/obj/item/projectile/bullet/rpellet"
+	pellets = 5
+	deviation = 30
+	materials = list(MAT_METAL=4000)
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -71,7 +71,7 @@
 /obj/item/ammo_box/magazine/internal/shotriot
 	name = "riot shotgun internal magazine"
 	desc = "Oh god, this shouldn't be here"
-	ammo_type = "/obj/item/ammo_casing/shotgun/beanbag"
+	ammo_type = "/obj/item/ammo_casing/shotgun/rubbershot"
 	caliber = "shotgun"
 	max_ammo = 6
 	multiload = 0
@@ -125,26 +125,30 @@
 
 /obj/item/ammo_box/magazine/uzim9mm/update_icon()
 	..()
-	icon_state = "uzi9mm-[round(ammo_count(),4)]"	
-	
+	icon_state = "uzi9mm-[round(ammo_count(),4)]"
+
 /obj/item/ammo_box/magazine/smgm9mm
 	name = "SMG magazine (9mm)"
 	icon_state = "smg9mm"
 	ammo_type = "/obj/item/ammo_casing/c9mm"
 	caliber = "9mm"
-	max_ammo = 30
-	
+	max_ammo = 42
+	materials = list(MAT_METAL = 2000)
+
 /obj/item/ammo_box/magazine/smgm9mm/ap
 	name = "SMG magazine (Armour Piercing 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mmap
+	materials = list(MAT_METAL = 3000)
 
 /obj/item/ammo_box/magazine/smgm9mm/toxin
 	name = "SMG magazine (Toxin Tipped 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mmtox
+	materials = list(MAT_METAL = 3000)
 
 /obj/item/ammo_box/magazine/smgm9mm/fire
 	name = "SMG Magazine (Incendiary 9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mminc
+	materials = list(MAT_METAL = 3000)
 
 /obj/item/ammo_box/magazine/smgm9mm/update_icon()
 	..()

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -132,7 +132,7 @@
 	icon_state = "smg9mm"
 	ammo_type = "/obj/item/ammo_casing/c9mm"
 	caliber = "9mm"
-	max_ammo = 42
+	max_ammo = 30
 	materials = list(MAT_METAL = 2000)
 
 /obj/item/ammo_box/magazine/smgm9mm/ap

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -27,7 +27,7 @@
 
 /obj/item/projectile/bullet/weakbullet3
 	damage = 20
-	
+
 
 /obj/item/projectile/bullet/toxinbullet
 	damage = 15
@@ -67,6 +67,9 @@
 /obj/item/projectile/bullet/heavybullet
 	damage = 35
 
+/obj/item/projectile/bullet/rpellet
+	damage = 3
+	stamina = 25
 
 /obj/item/projectile/bullet/stunshot//taser slugs for shotguns, nothing special
 	name = "stunshot"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -418,6 +418,14 @@
 	build_path = /obj/item/ammo_casing/shotgun/beanbag
 	category = list("initial", "Security")
 
+/datum/design/rubbershot
+	name = "Rubber shot"
+	id = "rubber_shot"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/rubbershot
+	category = list("initial", "Security")
+
 /datum/design/c38
 	name = "Speed Loader (.38)"
 	id = "c38"


### PR DESCRIPTION
- Updates some ammo values to TG's current standard
 - SABR mags now have 42 ammo instead of 30
- Adds in rubbershot (basically stamina damage version of buckshot)
 - Can get this in the autolathe; riot shotguns have it by default
- Fixes https://github.com/ParadiseSS13/Paradise/issues/2308
 - Metal duplication exploit involving SABR Magazines