### PR TITLE
Removes the Rest of Pooled Objects

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -30,7 +30,7 @@
 		if(air_contents.oxygen < 0.5 || air_contents.toxins < 0.5)
 			return 0
 
-		active_hotspot = PoolOrNew(/obj/effect/hotspot, src)
+		active_hotspot = new /obj/effect/hotspot(src)
 		active_hotspot.temperature = exposed_temperature
 		active_hotspot.volume = exposed_volume
 
@@ -160,8 +160,7 @@
 		var/turf/simulated/T = loc
 		if(T.active_hotspot == src)
 			T.active_hotspot = null
-	..()
-	return QDEL_HINT_PUTINPOOL
+	return ..()
 
 /obj/effect/hotspot/proc/DestroyTurf()
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -121,7 +121,7 @@
 
 			if(T)
 				if(flame_dist && prob(40) && !istype(T, /turf/space) && !T.density)
-					PoolOrNew(/obj/effect/hotspot, T) //Mostly for ambience!
+					new /obj/effect/hotspot(T) //Mostly for ambience!
 				if(dist > 0)
 					for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 						var/atom/movable/AM = atom_movable

--- a/code/modules/pooling/pool.dm
+++ b/code/modules/pooling/pool.dm
@@ -16,7 +16,7 @@ To put a object back in the pool, call PlaceInPool(object)
 This will call destroy on the object, set its loc to null,
 and reset all of its vars to their default
 
-You can override your object's destroy to return QDEL_HINT_PLACEINPOOL
+You can override your object's destroy to return QDEL_HINT_PUTINPOOL
 to ensure its always placed in this pool (this will only be acted on if qdel calls destroy, and destroy will not get called twice)
 
 */

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -191,7 +191,7 @@
 			src.fire_delay = rand(minimum_fire_delay,maximum_fire_delay)
 			src.shot_number = 0
 
-		var/obj/item/projectile/beam/emitter/A = PoolOrNew(/obj/item/projectile/beam/emitter,src.loc)
+		var/obj/item/projectile/beam/emitter/A = new /obj/item/projectile/beam/emitter(src.loc)
 
 		A.dir = src.dir
 		playsound(get_turf(src), 'sound/weapons/emitter.ogg', 25, 1)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -75,10 +75,6 @@
 /obj/item/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss
 
-/obj/item/projectile/beam/emitter/Destroy()
-	..()
-	return QDEL_HINT_PUTINPOOL
-
 /obj/item/projectile/lasertag
 	name = "laser tag beam"
 	icon_state = "omnilaser"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -119,7 +119,7 @@
 /obj/item/projectile/bullet/incendiary/shell/Move()
 	..()
 	var/turf/location = get_turf(src)
-	PoolOrNew(/obj/effect/hotspot, location)
+	new /obj/effect/hotspot(location)
 	location.hotspot_expose(700, 50, 1)
 
 /obj/item/projectile/bullet/incendiary/shell/dragonsbreath

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -95,7 +95,7 @@
 /datum/chemical_reaction/crank/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(1,T))
-		PoolOrNew(/obj/effect/hotspot, turf)
+		new /obj/effect/hotspot(turf)
 	explosion(T,0,0,2)
 	return
 

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -46,7 +46,7 @@
 /datum/chemical_reaction/clf3/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(1,T))
-		PoolOrNew(/obj/effect/hotspot, turf)
+		new /obj/effect/hotspot(turf)
 	return
 
 /datum/reagent/clf3/reaction_turf(var/turf/simulated/T, var/volume)
@@ -59,13 +59,13 @@
 		if(prob(volume/10))
 			F.make_plating()
 		if(istype(F, /turf/simulated/floor/))
-			PoolOrNew(/obj/effect/hotspot, F)
+			new /obj/effect/hotspot(F)
 	if(istype(T, /turf/simulated/wall/))
 		var/turf/simulated/wall/W = T
 		if(prob(volume/10))
 			W.ChangeTurf(/turf/simulated/floor)
 	if(istype(T, /turf/simulated/shuttle/))
-		PoolOrNew(/obj/effect/hotspot, T)
+		new /obj/effect/hotspot(T)
 	return
 
 /datum/reagent/clf3/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume)
@@ -429,7 +429,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 		return
 	var/turf/simulated/T = get_turf(holder.my_atom)
 	for(var/turf/simulated/turf in range(created_volume/10,T))
-		PoolOrNew(/obj/effect/hotspot, turf)
+		new /obj/effect/hotspot(turf)
 	return
 
 /datum/reagent/phlogiston/on_mob_life(var/mob/living/M as mob)


### PR DESCRIPTION
Alright, did some more profiling....sadly, pooling in its current state just can't keep up with BYOND's built in `new` and garbage collection (shocker, truly).

In any event, hotspots were the 'best' candidates for pooling as they're created often and deleted a lot---ie: short lived.

That said, here:

Not pooling hotspots: http://hastebin.com/aruvivabot.vhdl
Pooling hotspots: http://hastebin.com/tenejenufu.vhdl

It's mildly cheaper to `PoolOrNew` them than to straight up `new` them---that said, it's WAY more expensive to place them into a pool than to let them GC---even if `ResetVars` (the biggest cost of putting them into the pool) were somehow *costless* (impossible), it would still be more expensive, overall than GCing.

Went ahead and removed emitter pooling---for one, bullets are not `qdel`'d (causes infinite bullets for projectile guns) so these aren't actually being placed in the pool anyway---andddd I have no reason to believe these would also be cheaper than just `new`+GCing---just like shards and hotspots.

This isn't even factoring in potentially odd behaviors from pooling hotspots that still have dangling references (insanely rare, but still technically possible).

NOTE: This does NOT remove pooling from the code itself; in the future, if it happens to be improved upon, then we can re-explore pooling of objects, again...but for now, this is faster/costs less.

Sad times---I really wanted a pool =p


Fixes
- Fixes duplicate hotspot/New()'s