### PR TITLE
Last Few Destroy Fixes

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -14,6 +14,10 @@
 	crew_monitor = new(src)
 	..()
 
+/obj/machinery/computer/crew/Destroy()
+	qdel(crew_monitor)
+	crew_monitor = null
+	return ..()
 
 /obj/machinery/computer/crew/attack_ai(mob/user)
 	attack_hand(user)

--- a/code/game/machinery/computer/power.dm
+++ b/code/game/machinery/computer/power.dm
@@ -15,30 +15,32 @@
 	..()
 	power_monitors += src
 	power_monitors = sortAtom(power_monitors)
-	power_monitor = new(src)	
-	powermonitor_repository.update_cache()	
+	power_monitor = new(src)
+	powermonitor_repository.update_cache()
 	powernet = find_powernet()
-	
+
 /obj/machinery/computer/monitor/Destroy()
 	power_monitors -= src
-	powermonitor_repository.update_cache()	
-	return ..()	
-	
+	powermonitor_repository.update_cache()
+	qdel(power_monitor)
+	power_monitor = null
+	return ..()
+
 /obj/machinery/computer/monitor/power_change()
 	..()
-	powermonitor_repository.update_cache()	
-	
-/obj/machinery/computer/monitor/proc/find_powernet() 
+	powermonitor_repository.update_cache()
+
+/obj/machinery/computer/monitor/proc/find_powernet()
 	var/obj/structure/cable/attached = null
 	var/turf/T = loc
 	if(isturf(T))
 		attached = locate() in T
 	if(attached)
 		return attached.get_powernet()
-			
+
 /obj/machinery/computer/monitor/attack_ai(mob/user)
 	attack_hand(user)
-	
+
 /obj/machinery/computer/monitor/attack_hand(mob/user)
 	add_fingerprint(user)
 	if(stat & (BROKEN|NOPOWER))
@@ -52,4 +54,3 @@
 
 /obj/machinery/computer/monitor/interact(mob/user)
 	power_monitor.ui_interact(user)
-	

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -86,6 +86,11 @@
 
 	setup()
 
+/obj/machinery/porta_turret/Destroy()
+	qdel(spark_system)
+	spark_system = null
+	return ..()
+
 /obj/machinery/porta_turret/centcom/New()
 	..()
 	if(req_one_access && req_one_access.len)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -454,6 +454,11 @@ steam.start() -- spawns the effect
 	var/direction
 	var/obj/chemholder
 
+	Destroy()
+		qdel(chemholder)
+		chemholder = null
+		return ..()
+
 	New()
 		..()
 		chemholder = new/obj()
@@ -547,35 +552,6 @@ steam.start() -- spawns the effect
 				spawn(150+rand(10,30))
 					if(smoke) smoke.delete()
 					src.total_smoke--
-
-// Goon compat.
-/datum/effect/effect/system/chem_smoke_spread/fart
-
-	set_up(var/mob/M, n = 5, c = 0, loca, direct)
-		if(n > 20)
-			n = 20
-		number = n
-		cardinals = c
-
-		chemholder.reagents.add_reagent("space_drugs", rand(1,10))
-
-		if(istype(loca, /turf/))
-			location = loca
-		else
-			location = get_turf(loca)
-		if(direct)
-			direction = direct
-
-		var/contained = "\[[chemholder.reagents.get_reagent_ids()]\]"
-		var/area/A = get_area(location)
-
-		var/where = "[A.name] | [location.x], [location.y]"
-		var/whereLink=formatJumpTo(location,where)
-
-		var/more = "(<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</a>)"
-		message_admins("[M][more] produced a toxic fart in ([whereLink])[contained].", 0, 1)
-		log_game("[M][more] produced a toxic fart in ([where])[contained].")
-
 
 /////////////////////////////////////////////
 // Sleep smoke
@@ -777,6 +753,10 @@ steam.start() -- spawns the effect
 	var/processing = 1
 	var/on = 1
 
+/datum/effect/effect/system/ion_trail_follow/Destroy()
+	oldposition = null
+	return ..()
+
 /datum/effect/effect/system/ion_trail_follow/set_up(atom/atom)
 	attach(atom)
 
@@ -810,6 +790,12 @@ steam.start() -- spawns the effect
 /datum/effect/effect/system/ion_trail_follow/space_trail
 	var/turf/oldloc // secondary ion trail loc
 	var/turf/currloc
+
+/datum/effect/effect/system/ion_trail_follow/space_trail/Destroy()
+	oldloc = null
+	currloc = null
+	return ..()
+
 /datum/effect/effect/system/ion_trail_follow/space_trail/start()
 	if(!src.on)
 		src.on = 1
@@ -869,6 +855,10 @@ steam.start() -- spawns the effect
 	var/turf/oldposition
 	var/processing = 1
 	var/on = 1
+
+	Destroy()
+		oldposition = null
+		return ..()
 
 	set_up(atom/atom)
 		attach(atom)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -114,6 +114,10 @@
 	radio = new /obj/item/radio/integrated/signal(src)
 	..()
 
+/obj/item/weapon/cartridge/signal/Destroy()
+	qdel(radio)
+	return ..()
+
 /obj/item/weapon/cartridge/quartermaster
 	name = "Space Parts & Space Vendors Cartridge"
 	desc = "Perfect for the Quartermaster on the go!"

--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -10,6 +10,10 @@
 	verbs -= /obj/item/verb/verb_pickup	//make sure this is never picked up.
 	..()
 
+/obj/item/weapon/storage/internal/Destroy()
+	master_item = null
+	return ..()
+
 /obj/item/weapon/storage/internal/attack_hand()
 	return		//make sure this is never picked up
 

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -19,6 +19,10 @@
 	src.ion_trail.set_up(src)
 	return
 
+/obj/item/weapon/tank/jetpack/Destroy()
+	qdel(ion_trail)
+	ion_trail = null
+	return ..()
 
 /obj/item/weapon/tank/jetpack/examine(mob/user)
 	if(!..(user, 0))

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -50,6 +50,12 @@
 	icon = 'icons/misc/buildmode.dmi'
 	var/obj/effect/bmode/buildholder/master = null
 
+/obj/effect/bmode/Destroy()
+	if(master && master.cl)
+		master.cl.screen -= src
+	master = null
+	return ..()
+
 /obj/effect/bmode/builddir
 	icon_state = "build"
 	screen_loc = "NORTH,WEST"
@@ -132,6 +138,19 @@
 	var/turf/cornerA = null
 	var/turf/cornerB = null
 	var/generator_path = null
+
+/obj/effect/bmode/buildholder/Destroy()
+	qdel(builddir)
+	builddir = null
+	qdel(buildhelp)
+	buildhelp = null
+	qdel(buildmode)
+	buildmode = null
+	qdel(buildquit)
+	buildquit = null
+	throw_atom = null
+	cl = null
+	return ..()
 
 /obj/effect/bmode/buildmode
 	icon_state = "buildmode1"

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -8,6 +8,11 @@
 	pockets.max_w_class = 2		//fit only pocket sized items
 	pockets.max_combined_w_class = 4
 
+/obj/item/clothing/suit/storage/Destroy()
+	qdel(pockets)
+	pockets = null
+	return ..()
+
 /obj/item/clothing/suit/storage/attack_hand(mob/user as mob)
 	if (pockets.handle_attack_hand(user))
 		..(user)

--- a/code/modules/computer3/laptop.dm
+++ b/code/modules/computer3/laptop.dm
@@ -52,7 +52,7 @@
 					O.forceMove(loc)
 			usr << "\The [src] crumbles to pieces."
 			spawn(5)
-				qdel(src) 
+				qdel(src)
 			return
 
 		if(!stored_computer.manipulating)
@@ -65,7 +65,7 @@
 
 			spawn(5)
 				stored_computer.manipulating = 0
-				qdel(src) 
+				qdel(src)
 		else
 			usr << "\red You are already opening the computer!"
 
@@ -73,8 +73,9 @@
 	AltClick()
 		if(Adjacent(usr))
 			open_computer()
-		
+
 	Destroy()
+		..()
 		return QDEL_HINT_HARDDEL_NOW // Warning: GC'ing will cause the laptop to vanish when it next closes
 
 //Quickfix until Snapshot works out how he wants to redo power. ~Z

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -32,8 +32,13 @@
 	src.emag.name = "Placeholder Emag Item"
 
 /obj/item/weapon/robot_module/Destroy()
+	for(var/module in modules)
+		qdel(module)
 	modules.Cut()
+	qdel(emag)
 	emag = null
+	qdel(jetpack)
+	jetpack = null
 	return ..()
 
 /obj/item/weapon/robot_module/proc/fix_modules()


### PR DESCRIPTION
- Fixes laptop/Destroy() not calling parent
- Adds in a few Destroy's for effect datums
- Removes unused goon fart smoke spread datum

I couldn't resist...added more Destroy()'s
- things with internal storage now GC
- suits with pockets now GC
- Power monitors now GC
- Crew monitors now GC
- Build mode icons now GC
- Porta Turrets now GC
- Robot modules now  GC
- jetpacks now GC (Bay and TG both haven't managed this yet....come on guys, this one was easy).

Some of these were taken from Bay.

I probably shouldn't say "last"...there's always more stuff to de-reference.
