### PR TITLE
More Garbage Collection Fixes

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -35,9 +35,11 @@
 		update_icon()
 
 /obj/machinery/portable_atmospherics/Destroy()
+	disconnect()
 	qdel(air_contents)
+	air_contents = null
 	qdel(holding)
-	
+	holding = null
 	return ..()
 
 /obj/machinery/portable_atmospherics/update_icon()
@@ -71,7 +73,7 @@
 	connected_port = null
 
 	return 1
-	
+
 /obj/machinery/portable_atmospherics/portableConnectorReturnAir()
 	return air_contents
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -141,7 +141,8 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/proc/clear_holo()
 //	hologram.set_light(0)//Clear lighting.	//handled by the lighting controller when its ower is deleted
-	del(hologram)//Get rid of hologram.
+	qdel(hologram)//Get rid of hologram.
+	hologram = null
 	if(master.holo == src)
 		master.holo = null
 	master = null//Null the master, since no-one is using it now.
@@ -222,9 +223,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	qdel(src)
 	return
 
-/obj/machinery/hologram/Destroy()
+/obj/machinery/hologram/holopad/Destroy()
 	if(hologram)
-		src:clear_holo()
+		clear_holo()
 	return ..()
 
 /*

--- a/code/game/vehicles/spacepods/spacepod.dm
+++ b/code/game/vehicles/spacepods/spacepod.dm
@@ -85,6 +85,12 @@
 	pr_give_air = null
 	qdel(ion_trail)
 	ion_trail = null
+	if(occupant)
+		occupant.forceMove(get_turf(src))
+		occupant = null
+	if(occupant2)
+		occupant2.forceMove(get_turf(src))
+		occupant2 = null
 	spacepods_list -= src
 	return ..()
 

--- a/code/game/vehicles/spacepods/spacepod.dm
+++ b/code/game/vehicles/spacepods/spacepod.dm
@@ -71,6 +71,20 @@
 	spacepods_list += src
 
 /obj/spacepod/Destroy()
+	qdel(equipment_system)
+	equipment_system = null
+	qdel(battery)
+	battery = null
+	qdel(cabin_air)
+	cabin_air = null
+	qdel(internal_tank)
+	internal_tank = null
+	qdel(pr_int_temp_processor)
+	pr_int_temp_processor = null
+	qdel(pr_give_air)
+	pr_give_air = null
+	qdel(ion_trail)
+	ion_trail = null
 	spacepods_list -= src
 	return ..()
 


### PR DESCRIPTION
Makes portable atmospherics (canisters, pumps, and scrubbers) GC far far better

This should help resolve some gas mixture datums hard deleting along with instance of canisters/scrubbers/pumps....in addition to if they're holding any tank.

This also makes spacepods properly GC, as well---not only is this faster, but it resolves an issue with deleting a spacepod throwing a ton of runtimes.
 - side note, screw pods, but at least these were a hair bit easier to de-reference than mechs.

Holograms now GC without runtiming out the butt.

Fixes part of: https://github.com/ParadiseSS13/Paradise/issues/2322