### PR TITLE
PDA CSS, to make it look like the old PDAs.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -62,6 +62,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	var/ownrank = null // this one is rank, never alt title
 
 	var/obj/item/device/paicard/pai = null	// A slot for a personal AI device
+	var/retro_mode = 0
 
 /obj/item/device/pda/medical
 	default_cartridge = /obj/item/weapon/cartridge/medical
@@ -401,6 +402,8 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	data["idInserted"] = (id ? 1 : 0)
 	data["idLink"] = (id ? text("[id.registered_name], [id.assignment]") : "--------")
 
+	data["useRetro"] = retro_mode
+
 	data["cart_loaded"] = cartridge ? 1:0
 	if(cartridge)
 		var/cartdata[0]
@@ -574,6 +577,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					mode = 0
 				else if(mode >= 40 && mode <= 49)//Fix for cartridges. Redirects to refresh the menu.
 					cartridge.mode = mode
+		if("Retro")
+			retro_mode = !retro_mode
+			ui_interact(user)
 		if ("Authenticate")//Checks for ID
 			id_check(U, 1)
 		if("UpdateInfo")
@@ -1138,7 +1144,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				if(T.ptank) atmosanalyzer_scan(T.ptank.air_contents, user, T)
 			else if (istype(A, /obj/machinery/portable_atmospherics/scrubber/huge))
 				var/obj/machinery/portable_atmospherics/scrubber/huge/T = A
-				atmosanalyzer_scan(T.air_contents, user, T)	
+				atmosanalyzer_scan(T.air_contents, user, T)
 			else if (istype(A, /obj/machinery/atmospherics/unary/tank))
 				var/obj/machinery/atmospherics/unary/tank/T = A
 				atmosanalyzer_scan(T.air_contents, user, T)
@@ -1276,4 +1282,3 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/emp_act(severity)
 	for(var/atom/A in src)
 		A.emp_act(severity)
-		

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -445,6 +445,11 @@ div.notice {
     white-space: nowrap;
 }
 
+.pdanote {
+    color: #cd6500;
+    font-weight: bold;
+}
+
 /* DNA Modifier styling */
 .dnaBlock {
     float: left;

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -3,6 +3,39 @@
 Title: PDA UI
 Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
  -->
+<head>
+<style type="text/css">
+html {
+	height: 100%; 
+	overflow: hidden;
+}
+
+body {
+	background: #808000;
+}
+
+.itemLabelNarrow, .itemLabel, .itemLabelWide, .itemLabelWider, .itemLabelWidest {
+	color: #444400;
+}
+
+.average {
+	color: #554300
+}
+
+.link, .linkOn, .linkOff, .selected, .disabled, .yellowButton, .redButton {
+    color: #000000;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: #000000;
+}
+
+.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest {
+	color: #000000;
+}
+
+</style>
+</head>
 {{if data.owner}}
 	<div class="item">
 		<div class="itemLabelNarrow">

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -78,7 +78,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 ID:
             </div>
             <div class="itemContent">
-                {{:helper.link(data.idLink, 'eject', {'choice' : "Authenticate"}, data.idInserted ? null : 'disabled', data.idInserted ? 'fixedLeftWidest' : 'fixedLeft')}}
+                {{:helper.link(data.idLink, 'eject', {'choice' : "Authenticate"}, data.idInserted ? null : 'disabled', data.idInserted ? 'link fixedLeftWidest' : 'link fixedLeft')}}
             </div>
         </div>
         <br>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -8,7 +8,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 		<style type="text/css">
 			html {
 				height: 100%; 
-				overflow: hidden;
+				overflow: auto;
 			}
 
 			body {
@@ -20,6 +20,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				font-weight: bold;
 			}
 
+			.good {
+				color: #76ae3d;
+			}
+			
 			.average {
 				color: #222222;
 			}
@@ -33,12 +37,36 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				background: #565D4B;
 			}
 
+			.pdalink {
+				min-width: 15px;
+				height: 16px;
+				text-align: center;
+				color: #000000;
+				text-decoration: none;
+				background: #565D4B;
+				border: 1px solid #161616;
+				padding: 0px 4px 4px 4px;
+				margin: 0 2px 2px 0;
+				cursor: default;
+				white-space: nowrap;
+			}
+			
 			h1, h2, h3, h4, h5, h6 {
 				color: #000000;
 			}
 
 			.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest, .floatRight {
 				color: #000000;
+			}
+			
+			.floatRight {
+				min-width: 15px;
+				height: 16px;
+				text-align: center;
+				background: #565D4B;
+				border: 1px solid #161616;
+				padding: 0px 4px 4px 4px;
+				margin: 0 2px 2px 0;
 			}
 			
 			#uiTitleText {
@@ -54,10 +82,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 			 <b>Functions</b>:
         </div>
         <div class="itemContent">
-			<!--{{:helper.link('Refresh', 'refresh', {'choice' : "Refresh"}, null, 'fixedLeft')}}-->
-			{{:helper.link('Close', 'gear', {'choice' : "Close"}, null, 'fixedLeft')}}
-			{{if data.idInserted}} {{:helper.link('Update PDA Info', 'eject', {'choice' : "UpdateInfo"}, null, 'fixedLeftWide')}} {{/if}}
-			{{if data.mode != 0}} {{:helper.link('Return', 'arrowreturn-1-w', {'choice' : "Return"}, null, 'fixedLeft')}} {{/if}}
+			<!--{{:helper.link('Refresh', 'refresh', {'choice' : "Refresh"}, null, 'pdalink fixedLeft')}}-->
+			{{:helper.link('Close', 'gear', {'choice' : "Close"}, null, 'pdalink fixedLeft')}}
+			{{if data.idInserted}} {{:helper.link('Update PDA Info', 'eject', {'choice' : "UpdateInfo"}, null, 'pdalink fixedLeftWide')}} {{/if}}
+			{{if data.mode != 0}} {{:helper.link('Return', 'arrowreturn-1-w', {'choice' : "Return"}, null, 'pdalink fixedLeft')}} {{/if}}
 			{{:helper.link('Toggle R.E.T.R.O. mode', 'gear', {'choice': "Retro"}, null, 'floatRight')}}
 		</div>
 	</div>
@@ -112,9 +140,9 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <b>General</b>:
             </div>
             <div class="itemContent">
-                {{:helper.link('Notekeeper', 'note', {'choice' : "1"}, null, 'fixedLeftWide')}}
-                {{:helper.link('Messenger', data.newMessage ? 'mail-closed' : 'mail-open', {'choice' : "2"}, null, 'fixedLeftWide')}}
-                {{:helper.link('Crew Manifest', 'contact', {'choice' : "41"}, null, 'fixedLeftWide')}}
+                {{:helper.link('Notekeeper', 'note', {'choice' : "1"}, null, 'pdalink fixedLeftWide')}}
+                {{:helper.link('Messenger', data.newMessage ? 'mail-closed' : 'mail-open', {'choice' : "2"}, null, 'pdalink fixedLeftWide')}}
+                {{:helper.link('Crew Manifest', 'contact', {'choice' : "41"}, null, 'pdalink fixedLeftWide')}}
             </div>
         </div>
         <br>
@@ -125,7 +153,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <b>Clown</b>:
                     </div>
                     <div class="itemContent">
-                        {{:helper.link('Honk Synthesizer', 'gear', {'choice' : "Honk"}, null, 'fixedLeftWide')}}
+                        {{:helper.link('Honk Synthesizer', 'gear', {'choice' : "Honk"}, null, 'pdalink fixedLeftWide')}}
                     </div>
                 </div>
                 <br>
@@ -136,7 +164,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <b>Engineering</b>:
                     </div>
                     <div class="itemContent">
-                        {{:helper.link('Power Monitor', 'alert', {'choice' : "43"}, null, 'fixedLeftWide')}}
+                        {{:helper.link('Power Monitor', 'alert', {'choice' : "43"}, null, 'pdalink fixedLeftWide')}}
                     </div>
                 </div>
                  <br>
@@ -147,8 +175,8 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                             <b>Medical</b>:
                     </div>
                     <div class="itemContent">
-                            {{:helper.link('Medical Records', 'gear', {'choice' : "44"}, null, 'fixedLeftWide')}}
-                            {{:helper.link(data.scanmode == 1 ? 'Disable Med Scanner' : 'Enable Med Scanner', 'gear', {'choice' : "Medical Scan"}, null , 'fixedLeftWide')}}
+                            {{:helper.link('Medical Records', 'gear', {'choice' : "44"}, null, 'pdalink fixedLeftWide')}}
+                            {{:helper.link(data.scanmode == 1 ? 'Disable Med Scanner' : 'Enable Med Scanner', 'gear', {'choice' : "Medical Scan"}, null , 'pdalink fixedLeftWide')}}
                     </div>
                 </div>
                 <br>
@@ -159,8 +187,8 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                             <b>Security</b>:
                     </div>
                     <div class="itemContent">
-                        {{:helper.link('Security Records', 'gear', {'choice' : "45"}, null, 'fixedLeftWide')}}
-                        {{if data.cartridge.radio ==1}} {{:helper.link('Security Bot Access', 'gear', {'choice' : "46"}, null, 'fixedLeftWide')}} {{/if}}
+                        {{:helper.link('Security Records', 'gear', {'choice' : "45"}, null, 'pdalink fixedLeftWide')}}
+                        {{if data.cartridge.radio ==1}} {{:helper.link('Security Bot Access', 'gear', {'choice' : "46"}, null, 'pdalink fixedLeftWide')}} {{/if}}
                         <br>
                     </div>
                 </div>
@@ -172,8 +200,8 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                         <b>Quartermaster</b>:
                     </div>
                     <div class="itemContent">
-                        {{:helper.link('Supply Records', 'gear', {'choice' : "47"}, null, 'fixedLeftWide')}}
-                        {{if data.cartridge.radio == 3}} {{:helper.link('Delivery Bot Control', 'gear', {'choice' : "48"}, null, 'fixedLeftWide')}} {{/if}}
+                        {{:helper.link('Supply Records', 'gear', {'choice' : "47"}, null, 'pdalink fixedLeftWide')}}
+                        {{if data.cartridge.radio == 3}} {{:helper.link('Delivery Bot Control', 'gear', {'choice' : "48"}, null, 'pdalink fixedLeftWide')}} {{/if}}
                          <br>
                     </div>
                 </div>
@@ -188,29 +216,29 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             <div class = "itemContent">
                 {{if data.cartridge}}
                     {{if data.cartridge.access.access_status_display == 1}}
-                        {{:helper.link('Status Display', 'gear', {'choice' : "42"}, null, 'fixedLeftWide')}}
+                        {{:helper.link('Status Display', 'gear', {'choice' : "42"}, null, 'pdalink fixedLeftWide')}}
                     {{/if}}
                     {{if data.cartridge.access.access_janitor==1}}
-                        {{:helper.link('Custodial Locator', 'gear', {'choice' : "49"}, null, 'fixedLeftWide')}}
+                        {{:helper.link('Custodial Locator', 'gear', {'choice' : "49"}, null, 'pdalink fixedLeftWide')}}
                     {{/if}}
                     {{if data.cartridge.radio == 2}}
-                        {{:helper.link('Signaler System', 'gear', {'choice' : "40"}, null, 'fixedLeftWide')}}
+                        {{:helper.link('Signaler System', 'gear', {'choice' : "40"}, null, 'pdalink fixedLeftWide')}}
                     {{/if}}
                     {{if data.cartridge.access.access_reagent_scanner==1}}
-                        {{:helper.link(data.scanmode == 3 ? 'Disable Reagent Scanner' : 'Enable Reagent Scanner', 'gear', {'choice' : "Reagent Scan"}, null, 'fixedLeftWider')}}
+                        {{:helper.link(data.scanmode == 3 ? 'Disable Reagent Scanner' : 'Enable Reagent Scanner', 'gear', {'choice' : "Reagent Scan"}, null, 'pdalink fixedLeftWider')}}
                     {{/if}}
                     {{if data.cartridge.access.access_engine==1}}
-                        {{:helper.link(data.scanmode == 4 ? 'Disable Halogen Counter' : 'Enable Halogen Counter', 'gear', {'choice' : "Halogen Counter"}, null, 'fixedLeftWider')}}
+                        {{:helper.link(data.scanmode == 4 ? 'Disable Halogen Counter' : 'Enable Halogen Counter', 'gear', {'choice' : "Halogen Counter"}, null, 'pdalink fixedLeftWider')}}
                     {{/if}}
                     {{if data.cartridge.access.access_atmos==1}}
-                        {{:helper.link(data.scanmode == 5 ? 'Disable Gas Scanner' : 'Enable Gas Scanner', 'gear', {'choice' : "Gas Scan"}, null, 'fixedLeftWide')}}
+                        {{:helper.link(data.scanmode == 5 ? 'Disable Gas Scanner' : 'Enable Gas Scanner', 'gear', {'choice' : "Gas Scan"}, null, 'pdalink fixedLeftWide')}}
                     {{/if}}
                     {{if data.cartridge.access.access_remote_door==1}}
-                        {{:helper.link('Toggle Door', 'gear', {'choice' : "Toggle Door"}, null, 'fixedLeftWide')}}
+                        {{:helper.link('Toggle Door', 'gear', {'choice' : "Toggle Door"}, null, 'pdalink fixedLeftWide')}}
                     {{/if}}
                 {{/if}}
-                {{:helper.link('Atmospheric Scan', 'gear', {'choice' : "3"}, null, 'fixedLeftWide')}}
-                {{:helper.link(data.fon==1 ? 'Disable Flashlight' : 'Enable Flashlight', 'lightbulb', {'choice' : "Light"}, null,'fixedLeftWide')}}
+                {{:helper.link('Atmospheric Scan', 'gear', {'choice' : "3"}, null, 'pdalink fixedLeftWide')}}
+                {{:helper.link(data.fon==1 ? 'Disable Flashlight' : 'Enable Flashlight', 'lightbulb', {'choice' : "Light"}, null,'pdalink fixedLeftWide')}}
             </div>
         </div>
         {{if data.pai}}
@@ -219,8 +247,8 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                     <b>PAI Utilities</b>:
                 </div>
                 <div class = "itemContent">
-                    {{:helper.link('Configuration', 'gear', {'choice' : "pai", 'option' : "1"}, null, 'fixedLeft')}}
-                    {{:helper.link('Eject pAI', 'eject', {'choice' : "pai", 'option' : "2"}, null, 'fixedLeft')}}
+                    {{:helper.link('Configuration', 'gear', {'choice' : "pai", 'option' : "1"}, null, 'pdalink fixedLeft')}}
+                    {{:helper.link('Eject pAI', 'eject', {'choice' : "pai", 'option' : "2"}, null, 'pdalink fixedLeft')}}
                 </div>
             </div>
         {{/if}}
@@ -241,7 +269,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
         </div>
         <div class="item">
             <div class="itemLabel">
-                {{:helper.link('Edit Notes', 'gear', {'choice' : "Edit"}, null, 'fixedLeft')}}
+                {{:helper.link('Edit Notes', 'gear', {'choice' : "Edit"}, null, 'pdalink fixedLeft')}}
             </div>
         </div>
 
@@ -253,10 +281,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <b>Messenger Functions</b>:
             </div>
             <div class ="itemContent">
-                {{:helper.link(data.silent==1 ? 'Ringer: Off' : 'Ringer: On', data.silent==1 ? 'volume-off' : 'volume-on', {'choice' : "Toggle Ringer"}, null, 'fixedLeftWide')}}
-                {{:helper.link(data.toff==1 ? 'Messenger: Off' : 'Messenger: On',data.toff==1 ? 'close':'check', {'choice' : "Toggle Messenger"}, null, 'fixedLeftWide')}}
-                {{:helper.link('Set Ringtone', 'comment', {'choice' : "Ringtone"}, null, 'fixedLeftWide')}}
-                {{:helper.link('Delete all Conversations', 'trash', {'choice' : "Clear", 'option' : "All"}, null, 'fixedLeftWider')}}
+                {{:helper.link(data.silent==1 ? 'Ringer: Off' : 'Ringer: On', data.silent==1 ? 'volume-off' : 'volume-on', {'choice' : "Toggle Ringer"}, null, 'pdalink fixedLeftWide')}}
+                {{:helper.link(data.toff==1 ? 'Messenger: Off' : 'Messenger: On',data.toff==1 ? 'close':'check', {'choice' : "Toggle Messenger"}, null, 'pdalink fixedLeftWide')}}
+                {{:helper.link('Set Ringtone', 'comment', {'choice' : "Ringtone"}, null, 'pdalink fixedLeftWide')}}
+                {{:helper.link('Delete all Conversations', 'trash', {'choice' : "Clear", 'option' : "All"}, null, 'pdalink fixedLeftWider')}}
             </div>
         </div>
         {{if data.toff == 0}}
@@ -279,16 +307,16 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <H3>Current Conversations</H3>
                 {{for data.convopdas}}
                     <div class="item">
-                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Select Conversation", 'convo' : value.Reference } , null, value.fixedLeftWider)}}
+                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Select Conversation", 'convo' : value.Reference } , null, 'pdalink fixedLeftWider')}}
                         {{if data.cartridge}}
                             {{if data.cartridge.access.access_detonate_pda && value.Detonate}}
-                                {{:helper.link('*Detonate*', 'radiation', {'choice' : "Detonate", 'target' : value.Reference}, null, 'fixedLeft')}}
+                                {{:helper.link('*Detonate*', 'radiation', {'choice' : "Detonate", 'target' : value.Reference}, null, 'pdalink fixedLeft')}}
                             {{/if}}
                             {{if data.cartridge.access.access_clown}}
-                                {{:helper.link('*Send Virus*', 'star', {'choice' : "Send Honk", 'target' : value.Reference}, null, 'fixedLeft')}}
+                                {{:helper.link('*Send Virus*', 'star', {'choice' : "Send Honk", 'target' : value.Reference}, null, 'pdalink fixedLeft')}}
                             {{/if}}
                             {{if data.cartridge.access.access_mime}}
-                                {{:helper.link('*Send Virus*', 'circle-arrow-s', {'choice' : "Send Silence", 'target' : value.Reference}, null, 'fixedLeft')}}
+                                {{:helper.link('*Send Virus*', 'circle-arrow-s', {'choice' : "Send Silence", 'target' : value.Reference}, null, 'pdalink fixedLeft')}}
                             {{/if}}
                         {{/if}}
                     </div>
@@ -296,11 +324,11 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <H3>Other PDAs</H3>
                 {{for data.pdas}}
                     <div class="item">
-                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Message", 'target' : value.Reference}, null, value.fixedLeftWider)}}
+                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Message", 'target' : value.Reference}, null, 'pdalink fixedLeftWider')}}
                         {{if data.cartridge}}
-                            {{if data.cartridge.access.access_detonate_pda && value.Detonate}} {{:helper.link('*Detonate*', 'radiation', {'choice' : "Detonate", 'target' : value.Reference}, null, 'fixedLeft')}} {{/if}}
-                            {{if data.cartridge.access.access_clown}} {{:helper.link('*Send Virus*', 'star', {'choice' : "Send Honk", 'target' : value.Reference}, null, 'fixedLeft')}} {{/if}}
-                            {{if data.cartridge.access.access_mime}} {{:helper.link('*Send Virus*', 'circle-arrow-s', {'choice' : "Send Silence", 'target' : value.Reference}, null, 'fixedLeft')}} {{/if}}
+                            {{if data.cartridge.access.access_detonate_pda && value.Detonate}} {{:helper.link('*Detonate*', 'radiation', {'choice' : "Detonate", 'target' : value.Reference}, null, 'pdalink fixedLeft')}} {{/if}}
+                            {{if data.cartridge.access.access_clown}} {{:helper.link('*Send Virus*', 'star', {'choice' : "Send Honk", 'target' : value.Reference}, null, 'pdalink fixedLeft')}} {{/if}}
+                            {{if data.cartridge.access.access_mime}} {{:helper.link('*Send Virus*', 'circle-arrow-s', {'choice' : "Send Silence", 'target' : value.Reference}, null, 'pdalink fixedLeft')}} {{/if}}
                         {{/if}}
                     </div>
                 {{/for}}
@@ -315,7 +343,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <b>Messenger Functions</b>:
             </div>
             <div class ="itemContent">
-                {{:helper.link('Delete Conversation', 'trash', {'choice' : "Clear", 'option' : "Convo"}, null, 'fixedLeftWide')}}
+                {{:helper.link('Delete Conversation', 'trash', {'choice' : "Clear", 'option' : "Convo"}, null, 'pdalink fixedLeftWide')}}
             </div>
         </div>
         <br>
@@ -336,7 +364,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 </div>
             </div>
         </div>
-        {{:helper.link('Reply', 'comment', {'choice' : "Message", 'target': data.active_conversation}, null, 'fixedLeft')}}
+        {{:helper.link('Reply', 'comment', {'choice' : "Message", 'target': data.active_conversation}, null, 'pdalink fixedLeft')}}
 
 
 	{{else data.mode== 41}} <!-- Manifest -->
@@ -428,38 +456,38 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             <div class="item">
                 {{if data.aircontents.reading == 1}}
                     <div class="itemLabel">
-                        Pressure:
+                        <span class="pdanote">Pressure:</span>
                     </div>
                     <div class = "itemContent">
 				        {{:helper.string('<span class="{0}">{1} kPa</span>', data.aircontents.pressure < 80 || data.aircontents.pressure > 120 ? 'bad' : data.aircontents.pressure < 95 || data.aircontents.pressure > 110 ? 'average' : 'good' , data.aircontents.pressure)}}
                     </div>
                     <div class="itemLabel">
-                        Temperature:
+                        <span class="pdanote">Temperature:</span>
                     </div>
                     <div class = "itemContent">
 				        {{:helper.string('<span class="{0}">{1} &deg;C</span>', data.aircontents.temp < 5 || data.aircontents.temp > 35 ? 'bad' : data.aircontents.temp < 15 || data.aircontents.temp > 25 ? 'average' : 'good' , data.aircontents.temp)}}
                     </div>
                     <br>
                     <div class="itemLabel">
-                        Oxygen:
+                        <span class="pdanote">Oxygen:</span>
                     </div>
                     <div class = "itemContent">
                         {{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.oxygen < 17 ? 'bad' : data.aircontents.oxygen < 19 ? 'average' : 'good' , data.aircontents.oxygen)}}
                     </div>
                     <div class="itemLabel">
-                        Nitrogen:
+                        <span class="pdanote">Nitrogen:</span>
                     </div>
                     <div class = "itemContent">
                         {{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.nitrogen > 82 ? 'bad' : data.aircontents.nitrogen > 80 ? 'average' : 'good' , data.aircontents.nitrogen)}}
                     </div>
                     <div class="itemLabel">
-                        Carbon Dioxide:
+                        <span class="pdanote">Carbon Dioxide:</span>
                     </div>
                     <div class = "itemContent">
                         {{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.carbon_dioxide > 5 ? 'bad' : 'good' , data.aircontents.carbon_dioxide)}}
                     </div>
                     <div class="itemLabel">
-                        Plasma:
+                        <span class="pdanote">Plasma:</span>
                     </div>
                     <div class = "itemContent">
                         {{:helper.string('<span class="{0}">{1}%</span>', data.aircontents.plasma  > 0 ? 'bad' : 'good' , data.aircontents.plasma)}}
@@ -467,7 +495,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                     </div>
                     {{if data.aircontents.other > 0}}
                         <div class="itemLabel">
-                            Unknown:
+                            <span class="pdanote">Unknown:</span>
                         </div>
                         <div class = "itemContent">
                             <span class="bad">{{:data.aircontents.other}}%</span>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -12,29 +12,39 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 			}
 
 			body {
-				background: #808000;
+				background: #6F7961;
 			}
 
 			.itemLabelNarrow, .itemLabel, .itemLabelWide, .itemLabelWider, .itemLabelWidest {
-				color: #444400;
+				color: #000000;
+				font-weight: bold;
 			}
 
 			.average {
-				color: #ABAB00;
+				color: #222222;
+			}
+			
+			.pdanote {
+				color: #555555;
 			}
 
 			.link, .linkOn, .linkOff, .selected, .disabled, .yellowButton, .redButton {
 				color: #000000;
-				background: #ACAC50;
+				background: #565D4B;
 			}
 
 			h1, h2, h3, h4, h5, h6 {
 				color: #000000;
 			}
 
-			.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest, floatRight {
+			.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest, .floatRight {
 				color: #000000;
 			}
+			
+			#uiTitleText {
+				color: #000000;
+			}
+			
 		</style>
 	</head>
 {{/if}}
@@ -225,7 +235,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
         <div class="statusDisplayRecords">
             <div class="item">
                 <div class="itemContent" style="width: 100%;">
-                        <span class="average">{{:data.note}}</span>
+                        <span class="pdanote">{{:data.note}}</span>
                 </div>
             </div>
         </div>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -3,39 +3,41 @@
 Title: PDA UI
 Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
  -->
-<head>
-<style type="text/css">
-html {
-	height: 100%; 
-	overflow: hidden;
-}
+{{if data.useRetro}}
+	<head>
+		<style type="text/css">
+			html {
+				height: 100%; 
+				overflow: hidden;
+			}
 
-body {
-	background: #808000;
-}
+			body {
+				background: #808000;
+			}
 
-.itemLabelNarrow, .itemLabel, .itemLabelWide, .itemLabelWider, .itemLabelWidest {
-	color: #444400;
-}
+			.itemLabelNarrow, .itemLabel, .itemLabelWide, .itemLabelWider, .itemLabelWidest {
+				color: #444400;
+			}
 
-.average {
-	color: #554300
-}
+			.average {
+				color: #ABAB00;
+			}
 
-.link, .linkOn, .linkOff, .selected, .disabled, .yellowButton, .redButton {
-    color: #000000;
-}
+			.link, .linkOn, .linkOff, .selected, .disabled, .yellowButton, .redButton {
+				color: #000000;
+				background: #ACAC50;
+			}
 
-h1, h2, h3, h4, h5, h6 {
-    color: #000000;
-}
+			h1, h2, h3, h4, h5, h6 {
+				color: #000000;
+			}
 
-.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest {
-	color: #000000;
-}
-
-</style>
-</head>
+			.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest {
+				color: #000000;
+			}
+		</style>
+	</head>
+{{/if}}
 {{if data.owner}}
 	<div class="item">
 		<div class="itemLabelNarrow">
@@ -46,6 +48,7 @@ h1, h2, h3, h4, h5, h6 {
 			{{:helper.link('Close', 'gear', {'choice' : "Close"}, null, 'fixedLeft')}}
 			{{if data.idInserted}} {{:helper.link('Update PDA Info', 'eject', {'choice' : "UpdateInfo"}, null, 'fixedLeftWide')}} {{/if}}
 			{{if data.mode != 0}} {{:helper.link('Return', 'arrowreturn-1-w', {'choice' : "Return"}, null, 'fixedLeft')}} {{/if}}
+			{{:helper.link('Toggle R.E.T.R.O. mode', 'gear', {'choice': "Retro"}, null, 'floatRight')}}
 		</div>
 	</div>
 	<br>

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -32,7 +32,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				color: #000000;
 			}
 
-			.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest {
+			.fixedLeft, .fixedLeftWide, .fixedLeftWider, .fixedLeftWidest, floatRight {
 				color: #000000;
 			}
 		</style>


### PR DESCRIPTION
Alright, so, things changed:
 - New retromode button added to PDA's, allows you to switch to a color scheme reminiscent of GoonStation PDA's.
 - New CSS class for PDA notes, because flat-out using 'average' was getting in my way.
 - ID link button will now be consistent with it's link style.

![oldwithbutton](https://puu.sh/kHYyp/a4aab8bfbf.png)
![prettier](https://puu.sh/kI0YS/aa0ac5bb6e.png)
![prettier](https://puu.sh/kI17f/abcc76456e.png)
![prettier](https://puu.sh/kI1ap/21e13ae4a8.png)