### PR TITLE
Garbage Collect Everything

### DIFF
--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -22,8 +22,7 @@ var/global/list/datum/pipeline/pipe_networks = list()
 		P.parent = null
 	for(var/obj/machinery/atmospherics/A in other_atmosmch)
 		A.nullifyPipenet(src)
-	..()
-	return QDEL_HINT_QUEUE
+	return ..()
 
 /datum/pipeline/proc/process()//This use to be called called from the pipe networks
 	if(update)

--- a/code/datums/gas_mixture.dm
+++ b/code/datums/gas_mixture.dm
@@ -53,10 +53,6 @@ What are the archived variables for?
 
 	var/tmp/fuel_burnt = 0
 
-/datum/gas_mixture/Destroy()
-	..()
-	return QDEL_HINT_QUEUE
-
 	//PV=nRT - related procedures
 /datum/gas_mixture/proc/heat_capacity()
 	var/heat_capacity = HEAT_CAPACITY_CALCULATION(oxygen,carbon_dioxide,nitrogen,toxins)

--- a/code/datums/material_container.dm
+++ b/code/datums/material_container.dm
@@ -41,8 +41,7 @@
 
 /datum/material_container/Destroy()
 	owner = null
-	..()
-	return QDEL_HINT_QUEUE
+	return ..()
 
 //For inserting an amount of material
 /datum/material_container/proc/insert_amount(amt, material_type = null)

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -48,8 +48,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 
 /datum/wires/Destroy()
 	holder = null
-	..()
-	return QDEL_HINT_QUEUE
+	return ..()
 
 /datum/wires/proc/GenerateWires()
 	var/list/colours_to_pick = wireColours.Copy() // Get a copy, not a reference.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -33,8 +33,7 @@
 		if (pulledby.pulling == src)
 			pulledby.pulling = null
 		pulledby = null
-	..()
-	return QDEL_HINT_QUEUE
+	return ..()
 
 /atom/movable/proc/initialize()
 	return

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -22,8 +22,7 @@
 
 /datum/song/Destroy()
 	instrumentObj = null
-	..()
-	return QDEL_HINT_QUEUE
+	return ..()
 
 // note is a number from 1-7 for A-G
 // acc is either "b", "n", or "#"
@@ -69,7 +68,7 @@
 
 /datum/song/proc/shouldStopPlaying(mob/user)
 	if(instrumentObj)
-		//if(!user.canUseTopic(instrumentObj)) 
+		//if(!user.canUseTopic(instrumentObj))
 			//return 1
 		return !instrumentObj.anchored		// add special cases to stop in subclasses
 	else
@@ -281,7 +280,7 @@
 
 /datum/song/proc/sanitize_tempo(new_tempo)
 	new_tempo = abs(new_tempo)
-	return max(round(new_tempo, world.tick_lag), world.tick_lag)	
+	return max(round(new_tempo, world.tick_lag), world.tick_lag)
 
 // subclass for handheld instruments, like violin
 /datum/song/handheld
@@ -324,7 +323,7 @@
 	qdel(song)
 	song = null
 	return ..()
-	
+
 /obj/structure/piano/initialize()
 	song.tempo = song.sanitize_tempo(song.tempo) // tick_lag isn't set when the map is loaded
 	..()

--- a/code/modules/garbage_collection/garbage_collector.dm
+++ b/code/modules/garbage_collection/garbage_collector.dm
@@ -160,7 +160,7 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
  */
 /datum/proc/Destroy()
 	tag = null
-	return QDEL_HINT_HARDDEL_NOW // By default, assume that queueing any given datum is unsafe
+	return QDEL_HINT_QUEUE // Garbage Collect everything.
 
 // If something gets deleted directly, make sure its Destroy proc is still called
 /datum/Del()
@@ -181,4 +181,3 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 
 /proc/gcwarning(msg)
 	log_to_dd("## GC WARNING: [msg]")
-	

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -29,8 +29,7 @@
 		M.powernet = null
 
 	powernets -= src
-	..()
-	return QDEL_HINT_QUEUE
+	return ..()
 
 //Returns the amount of excess power (before refunding to SMESs) from last tick.
 //This is for machines that might adjust their power consumption using this data.

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -602,7 +602,7 @@ atom/proc/create_reagents(var/max_vol)
 	reagents.my_atom = src
 
 /datum/reagents/Destroy()
-	..()
+	. = ..()
 	processing_objects.Remove(src)
 	for(var/datum/reagent/R in reagent_list)
 		qdel(R)
@@ -610,4 +610,3 @@ atom/proc/create_reagents(var/max_vol)
 	reagent_list = null
 	if(my_atom && my_atom.reagents == src)
 		my_atom.reagents = null
-	return QDEL_HINT_QUEUE

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -76,6 +76,5 @@
 	return
 
 /datum/reagent/Destroy()
-	..()
+	. = ..()
 	holder = null
-	return QDEL_HINT_QUEUE


### PR DESCRIPTION
Garbage Collects absolutely anything and everything that is a datum. This include images, icons, etc.

I've been working on de-referencing and keeping an eye on datums for a while now; the datums that we currently do GC do so something like 99% of the time.

Why enable this? Isn't this unsafe? Shouldn't we assume that datums are unsafe to GC by default?

Yes, technically, it's a bit on the unsafe side--that said, there's also no way to know what does and does not GC well until we try it out in a *live* environment. This will also allow us to see what datums do not GC well and address those, specifically (or hard delete those specific datums).

Assume they're unsafe? Well, we assume atoms are safe to GC--when they're not, we address them by either hard deleting them or clearing their references properly in the code.

A datum that was particularly troublesome was HUD datums---that's since been addressed in some previous PRs.

As to why? Performance gains, as per usual; soft deleting things (GCing them) incurs FAR less of a cost than hard deleting them.

if this proves to make far too many new instances of things that fail to GC or other odd behaviors, this can be super super easily reverted.