### PR TITLE
Fixes Pipes not GCing

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -50,6 +50,9 @@ Pipelines + Other Objects -> Pipe network
 		stored = new(src, make_from = src)
 
 /obj/machinery/atmospherics/Destroy()
+	if(stored)
+		qdel(stored)
+		stored = null
 	for(var/mob/living/M in src) //ventcrawling is serious business
 		M.remove_ventcrawl()
 		M.forceMove(loc)


### PR DESCRIPTION
so, the stored pipe *item* in atmos pipes/machines wasn't properly being cleared, meaning the pipe item will fail to GC---considering each atmos pipe has one of these, this can add up to a significant performance cost during singulo releases and explosions.