### PR TITLE
Supply Controller Refactor

### DIFF
--- a/code/controllers/Processes/supply.dm
+++ b/code/controllers/Processes/supply.dm
@@ -1,6 +1,6 @@
 /datum/controller/process/supply/setup()
 	name = "supply"
-	schedule_interval = 300 // every 30 seconds
+	schedule_interval = 10 // every second
 
 /datum/controller/process/supply/doWork()
 	supply_controller.process()

--- a/code/game/gamemodes/mutiny/key_pinpointer.dm
+++ b/code/game/gamemodes/mutiny/key_pinpointer.dm
@@ -33,17 +33,3 @@
 			user << "It is calibrated for the Emergency Secondary Authentication Key."
 		else
 			user << "It is switched off."
-
-/datum/supply_packs/key_pinpointer
-	name = "Authentication Key Pinpointer crate"
-	contains = list(/obj/item/weapon/pinpointer/advpinpointer/auth_key)
-	cost = 250
-	containertype = /obj/structure/closet/crate
-	containername = "Authentication Key Pinpointer crate"
-	access = access_heads
-	group = "Operations"
-
-	New()
-		// This crate is only accessible during mutiny rounds
-		if (istype(ticker.mode,/datum/game_mode/mutiny))
-			..()

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -146,7 +146,7 @@ var/list/mechtoys = list(
 	//processing_interval = 300
 	//supply points
 	var/points = 50
-	var/points_per_process = 1
+	var/points_per_process = 0.05
 	var/points_per_slip = 2
 	var/points_per_crate = 5
 	var/points_per_plasma = 5
@@ -168,21 +168,14 @@ var/list/mechtoys = list(
 /datum/controller/supply/New()
 	ordernum = rand(1,9000)
 
-//Supply shuttle ticker - handles supply point regeneration and shuttle travelling between centcomm and the station
-/datum/controller/supply/proc/process()
 	for(var/typepath in subtypesof(/datum/supply_packs))
 		var/datum/supply_packs/P = new typepath()
-		if(P.name == "HEADER")
-			qdel(P)
-			continue
+		if(P.name == "HEADER") continue
 		supply_packs[P.name] = P
 
-	spawn(0)
-		if(processing)
-			iteration++
-			points += points_per_process
-
-			//sleep(processing_interval)
+//Supply shuttle ticker - handles supply point regeneration and shuttle travelling between centcomm and the station
+/datum/controller/supply/proc/process()
+	points += points_per_process
 
 //To stop things being sent to centcomm which should not be sent to centcomm. Recursively checks for these types.
 /datum/controller/supply/proc/forbidden_atoms_check(atom/A)


### PR DESCRIPTION
Minor refactor of the supply controller.

- Supply controller generates the supply crate datums ONCE at round-start instead of generating the entire damn set every time the supply controller fires
 - seriously, who did this? It's a waste of resources; the supply datums aren't even altered in any way, shape or form EVER, nor are they touched or interacted with--why would you want to re-create them every time the supply controller fires? *grumble*

- Makes the supply controller fire once every second, instead of once every 30
 - supply points gained per fire is now 0.05
 - The above firing interval and point rate is identical to TG, which should work out since we have TG's supply packs+cost and well, TG mining.
 - This should make ordering at regular intervals a bit better instead of waiting once every half a minute to get more points---the additional processing/firing isn't costly either as the only thing the supply controller does is add supply points; nothing else is really being processed.

- Removes the mutiny supply pack
 - this threw runtimes because of moving supply pack generation into the actual creation of the supply controller....andddd mutiny is completely unused on Para (Bay axed the game mode to boot), not to mention this crate never got ordered anyway on the insanely rare times the game mode was actually played.