### PR TITLE
Radio NanoUI improvements

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -144,7 +144,7 @@ var/global/list/default_medbay_channels = list(
 		var/chan_stat = channels[ch_name]
 		var/listening = !!(chan_stat & FREQ_LISTENING) != 0
 
-		dat.Add(list(list("chan" = ch_name, "display_name" = ch_name, "secure_channel" = 1, "sec_channel_listen" = !listening)))
+		dat.Add(list(list("chan" = ch_name, "display_name" = ch_name, "secure_channel" = 1, "sec_channel_listen" = !listening, "chan_span" = frequency_span_class(radiochannels[ch_name]))))
 
 	return dat
 
@@ -152,7 +152,7 @@ var/global/list/default_medbay_channels = list(
 	var/dat[0]
 	for(var/internal_chan in internal_channels)
 		if(has_channel_access(user, internal_chan))
-			dat.Add(list(list("chan" = internal_chan, "display_name" = get_frequency_name(text2num(internal_chan)))))
+			dat.Add(list(list("chan" = internal_chan, "display_name" = get_frequency_name(text2num(internal_chan)), "chan_span" = frequency_span_class(text2num(internal_chan)))))
 
 	return dat
 

--- a/nano/templates/radio_basic.tmpl
+++ b/nano/templates/radio_basic.tmpl
@@ -26,10 +26,10 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 {{/if}}
 
 <div class="item">
-	<div class="itemLabel">
+	<div class="itemLabelWide">
 		Microphone
 	</div>
-	<div class="itemContent">
+	<div class="itemContentMedium">
 		{{if data.mic_cut}}
 			{{:helper.link('On', null, null, 'disabled')}}
 			{{:helper.link('Off', null, null, 'disabled')}}
@@ -41,10 +41,10 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 </div>
 
 <div class="item">
-	<div class="itemLabel">
+	<div class="itemLabelWide">
 		Speaker
 	</div>
-	<div class="itemContent">
+	<div class="itemContentMedium">
 		{{if data.spk_cut}}
 			{{:helper.link('On', null, null, 'disabled')}}
 			{{:helper.link('Off', null, null, 'disabled')}}
@@ -56,30 +56,34 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 </div>
 
 {{if data.has_subspace}}
-	<div class="itemLabel">
-		Subspace Transmission:
-	</div>
-	<div class="itemContent">
-		{{:helper.link('On', null, {'mode' : 1}, data.subspace ? 'selected' : null)}}
-		{{:helper.link('Off', null, {'mode' : 0}, data.subspace ? null : 'selected')}}
+	<div class="item">
+		<div class="itemLabelWide">
+			Subspace Transmission:
+		</div>
+		<div class="itemContentMedium">
+			{{:helper.link('On', null, {'mode' : 1}, data.subspace ? 'selected' : null)}}
+			{{:helper.link('Off', null, {'mode' : 0}, data.subspace ? null : 'selected')}}
+		</div>
 	</div>
 {{/if}}
 		
 {{if data.has_loudspeaker}}
-	<div class="itemLabel">
-		Loudspeaker:
-	</div>
-	<div class="itemContent">
-		{{:helper.link('On', null, {'shutup' : 0}, data.loudspeaker ? 'selected' : null)}}
-		{{:helper.link('Off', null, {'shutup' : 1}, data.loudspeaker ? null : 'selected')}}
+	<div class="item">
+		<div class="itemLabelWide">
+			Loudspeaker:
+		</div>
+		<div class="itemContentMedium">
+			{{:helper.link('On', null, {'shutup' : 0}, data.loudspeaker ? 'selected' : null)}}
+			{{:helper.link('Off', null, {'shutup' : 1}, data.loudspeaker ? null : 'selected')}}
+		</div>
 	</div>
 {{/if}}
 
 <div class="item">
-	<div class="itemLabel">
+	<div class="itemLabelWide">
 		Frequency: {{:data.freq}}
 	</div>
-	<div class="itemContent">
+	<div class="itemContentMedium">
 		{{:helper.link('--', null, {'freq' : -10})}}
 		{{:helper.link('-', null, {'freq' : -2})}}
 		{{:helper.link('+', null, {'freq' : 2})}}
@@ -91,10 +95,10 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 	<h3>Channels</h3>
 	<div class="item">
 	{{for data.chan_list}}
-		<div class="itemLabel">
-			<span class="{{:value.chan_span}}">{{:value.display_name}}</span>
+		<div class="itemLabelWide">
+			<span class='{{:value.chan_span}}'>&#9724</span>{{:value.display_name}}
 		</div>
-		<div class="itemContent">
+		<div class="itemContentMedium">
 			{{if value.secure_channel}}
 				{{:helper.link('On', null, {'ch_name' : value.chan, 'listen' : value.sec_channel_listen}, value.sec_channel_listen ? null : 'selected')}}
 				{{:helper.link('Off', null, {'ch_name' : value.chan, 'listen' : value.sec_channel_listen}, value.sec_channel_listen ? 'selected' : null)}}

--- a/nano/templates/radio_basic.tmpl
+++ b/nano/templates/radio_basic.tmpl
@@ -6,7 +6,7 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 	<style type="text/css">
 		.radio					{color: #008000;}
 		.deptradio				{color: #993399;}
-		.comradio				{color: #193A7A;}
+		.comradio				{color: #395A9A;}
 		.syndradio				{color: #6D3F40;}
 		.centradio				{color: #5C5C8A;}
 		.airadio				{color: #FF00FF;}
@@ -14,7 +14,7 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 		.engradio				{color: #A66300;}
 		.medradio				{color: #008160;}
 		.sciradio				{color: #993399;}
-		.supradio				{color: #5F4519;}
+		.supradio				{color: #7F6539;}
 		.srvradio				{color: #6eaa2c;}
 	</style>
 </head>

--- a/nano/templates/radio_basic.tmpl
+++ b/nano/templates/radio_basic.tmpl
@@ -2,6 +2,25 @@
 Title: Basic Radio UI
 Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 -->
+<head>
+	<style type="text/css">
+		.radio					{color: #008000;}
+		.deptradio				{color: #993399;}
+		.comradio				{color: #193A7A;}
+		.syndradio				{color: #6D3F40;}
+		.centradio				{color: #5C5C8A;}
+		.airadio				{color: #FF00FF;}
+		.secradio				{color: #A30000;}
+		.engradio				{color: #A66300;}
+		.medradio				{color: #008160;}
+		.sciradio				{color: #993399;}
+		.supradio				{color: #5F4519;}
+		.srvradio				{color: #6eaa2c;}
+	</style>
+</head>
+
+
+
 {{if data.useSyndMode}}
 	{{:helper.syndicateMode()}}
 {{/if}}
@@ -73,11 +92,10 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 	<div class="item">
 	{{for data.chan_list}}
 		<div class="itemLabel">
-			{{:value.display_name}}
+			<span class="{{:value.chan_span}}">{{:value.display_name}}</span>
 		</div>
 		<div class="itemContent">
 			{{if value.secure_channel}}
-				Speaker:&nbsp;
 				{{:helper.link('On', null, {'ch_name' : value.chan, 'listen' : value.sec_channel_listen}, value.sec_channel_listen ? null : 'selected')}}
 				{{:helper.link('Off', null, {'ch_name' : value.chan, 'listen' : value.sec_channel_listen}, value.sec_channel_listen ? 'selected' : null)}}
 			{{else}}


### PR DESCRIPTION
This commit does the following:
 - Adds radio coloring to squares next to the channel names, ex, security is red, service
   is green.
 - Removes the broken "Speaker:" part of headsets channel selection. If the purpose of
   on-off buttons is not clear enough, they shouldn't be using radios in
   the first place! And I can't get the damn thing to cooperate, so.

## Final pics:
Headset
![headset](https://puu.sh/kMHsZ/317d0c8286.png)
Intercom
![icom](https://puu.sh/kMHrX/addc2b5758.png)
Borgy borg
![blahg](https://puu.sh/kMHv4/1c14913cb8.png)
Syndiborg
![borgbutt](https://puu.sh/kMHAp/7edb585594.png)