### PR TITLE
Dwarf Mutation Changes

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -96,7 +96,8 @@
 
 /datum/dna/gene/basic/midget
 	name="Midget"
-	activation_messages=list("Your skin feels rubbery.")
+	activation_messages=list("Everything around you seems bigger now...")
+	deactivation_messages = list("Everything around you seems to shrink...")
 	mutation=DWARF
 	instability=1
 
@@ -111,8 +112,13 @@
 
 	activate(var/mob/M, var/connected, var/flags)
 		..(M,connected,flags)
-		M.pass_flags |= 1
+		M.pass_flags |= PASSTABLE
+		M.resize = 0.8
 
+	deactivate(var/mob/M, var/connected, var/flags)
+		..()
+		M.pass_flags &= ~PASSTABLE
+		M.resize = 1.25
 
 // OLD HULK BEHAVIOR
 /datum/dna/gene/basic/hulk


### PR DESCRIPTION
After seeing TG's dwarf mutation, I figured this would be amusing to add, as their mutation does the same exact thing.

- Makes the dwarf mutation actually make your mob size smaller

Pics:
![tiny](https://i.gyazo.com/7c3b18f335e74aad4f78191a7d743239.png)
I am so small, eez funny to me.

Fix
- Fixes a bug where you could still crawl over tables when losing the dwarf mutation