### PR TITLE
LINDA Fixup, Pass II

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -29,24 +29,36 @@
 // find the attached trunk (if present) and init gas resvr.
 /obj/machinery/disposal/New()
 	..()
-	spawn(5)
-		trunk = locate() in src.loc
-		if(!trunk)
-			mode = 0
-			flush = 0
-		else
-			trunk.linked = src	// link the pipe trunk to self
+	trunk_check()
 
-		air_contents = new/datum/gas_mixture()
-		//gas.volume = 1.05 * CELLSTANDARD
-		update()
+	air_contents = new/datum/gas_mixture()
+	//gas.volume = 1.05 * CELLSTANDARD
+	update()
 
+/obj/machinery/disposal/proc/trunk_check()
+	trunk = locate() in src.loc
+	if(!trunk)
+		mode = 0
+		flush = 0
+	else
+		mode = initial(mode)
+		flush = initial(flush)
+		trunk.linked = src	// link the pipe trunk to self
 
 /obj/machinery/disposal/Destroy()
 	eject()
 	if(trunk)
 		trunk.linked = null
 	return ..()
+
+/obj/machinery/disposal/initialize()
+	// this will get a copy of the air turf and take a SEND PRESSURE amount of air from it
+	var/atom/L = loc
+	var/datum/gas_mixture/env = new
+	env.copy_from(L.return_air())
+	var/datum/gas_mixture/removed = env.remove(SEND_PRESSURE + 1)
+	air_contents.merge(removed)
+	trunk_check()
 
 // attack by item places it in to disposal
 /obj/machinery/disposal/attackby(var/obj/item/I, var/mob/user, params)


### PR DESCRIPTION
Makes disposals start out fully charged at round-start.

- This reduces the immediate post-start active turfs from about 600-700 down to about 70. It'll jump up, a bit, to 70, but not the ridiculous 700; the turfs settle down to 20-35ish in no time at all.

This means disposals start off fully charged, of course.

Technically, there's a bit more work that needs to be done with LINDA--mostly editing away mission maps (the one with atmospheric quirks on it is AWFUL for this), and attempting to figure out a quirk with transit tubes (that only appears if I move around initiailizations).

That said, once this PR goes live, it resolves 99% of the round-start turf activation problems with LINDA for all maps that aren't away missions.