### PR TITLE
Pipe Deconstruction Fix

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -203,12 +203,13 @@ Pipelines + Other Objects -> Pipe network
 		var/turf/T = get_turf(src)
 		stored.loc = T
 		transfer_fingerprints_to(stored)
+		stored = null
 		if(istype(src, /obj/machinery/atmospherics/pipe))
 			for(var/obj/machinery/meter/meter in T)
 				if(meter.target == src)
 					new /obj/item/pipe_meter(T)
 					qdel(meter)
-		qdel(src)
+	qdel(src)
 
 /obj/machinery/atmospherics/construction(D, P, C)
 	if(C)


### PR DESCRIPTION
The pipe item stored in atmospherics pipes wasn't properly being de-referenced, therefore, when a pipe was unwrenched, it WOULD put the pipe on the turf...then immediately delete it.

Even prior to the addition of Pipe GC fixups, I'm sure this caused quite a few unseen issues

Also, qdel(src) was indented one tab too far.