### PR TITLE
Fixes Egg Runtime

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -551,9 +551,10 @@
 
 	throw_impact(atom/hit_atom)
 		..()
-		new/obj/effect/decal/cleanable/egg_smudge(src.loc)
-		src.reagents.reaction(hit_atom, TOUCH)
-		src.visible_message("\red [src.name] has been squashed.","\red You hear a smack.")
+		var/turf/T = get_turf(hit_atom)
+		new/obj/effect/decal/cleanable/egg_smudge(T)
+		if(reagents)
+			reagents.reaction(hit_atom, TOUCH)
 		qdel(src)
 
 	attackby(obj/item/weapon/W as obj, mob/user as mob, params)


### PR DESCRIPTION
Fixes a runtime with thrown eggs. Removes the awkward visible message

I dunno how players are getting reagentless eggs so frequently, but this is popping up nearly every round or so.

