### PR TITLE
Reagent Scanner/Seeing

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -243,10 +243,8 @@ its easier to just keep the beam vertical.
 				for(var/datum/reagent/R in reagents.reagent_list)
 					user << "[R.volume] units of [R.name]"
 			else //Otherwise, just show the total volume
-				var/total_volume = 0
-				for(var/datum/reagent/R in reagents.reagent_list)
-					total_volume += R.volume
-				user << "[total_volume] units of various reagents"
+				if(reagents && reagents.reagent_list.len)
+					user << "[reagents.total_volume] units of various reagents."
 		else
 			user << "Nothing."
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -236,6 +236,20 @@ its easier to just keep the beam vertical.
 	user << "\icon[src] That's [f_name] [suffix]"
 	user << desc
 
+	if(reagents && is_open_container()) //is_open_container() isn't really the right proc for this, but w/e
+		user << "It contains:"
+		if(reagents.reagent_list.len)
+			if(user.can_see_reagents()) //Show each individual reagent
+				for(var/datum/reagent/R in reagents.reagent_list)
+					user << "[R.volume] units of [R.name]"
+			else //Otherwise, just show the total volume
+				var/total_volume = 0
+				for(var/datum/reagent/R in reagents.reagent_list)
+					total_volume += R.volume
+				user << "[total_volume] units of various reagents"
+		else
+			user << "Nothing."
+
 	return distance == -1 || (get_dist(src, user) <= distance) || isobserver(user) //observers do not have a range limit
 
 /atom/proc/relaymove()

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -124,6 +124,7 @@
 			if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_chem(H), slot_back)
 			if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_med(H), slot_l_ear)
+		H.equip_or_collect(new /obj/item/clothing/glasses/science(H), slot_glasses)
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chemist(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/device/pda/chemist(H), slot_wear_pda)

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -18,6 +18,7 @@
 			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
 			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new /obj/item/device/radio/headset/headset_service(H), slot_l_ear)
+		H.equip_or_collect(new /obj/item/clothing/glasses/sunglasses/reagent(H), slot_glasses)
 		H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
 		H.equip_or_collect(new /obj/item/clothing/suit/armor/vest(H), slot_wear_suit)
 		H.equip_or_collect(new /obj/item/clothing/under/rank/bartender(H), slot_w_uniform)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -2,6 +2,7 @@
 	name = "clothing"
 	var/list/species_restricted = null //Only these species can wear this kit.
 	var/rig_restrict_helmet = 0 // Stops the user from equipping a rig helmet without attaching it to the suit first.
+	var/scan_reagents = 0 //Can the wearer see reagents while it's equipped?
 
 	/*
 		Sprites used when the clothing item is refit. This is done by setting icon_override.

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -78,11 +78,12 @@
 	prescription_upgradable = 0
 
 /obj/item/clothing/glasses/science
-	name = "Science Goggles"
-	desc = "A pair of snazzy goggles used to protect against chemical spills. Fitted with an analyzer for scanning items."
+	name = "science goggles"
+	desc = "A pair of snazzy goggles used to protect against chemical spills. Fitted with an analyzer for scanning items and reagents."
 	icon_state = "purple"
 	item_state = "glasses"
 	prescription_upgradable = 0
+	scan_reagents = 1 //You can see reagents while wearing science goggles
 
 /obj/item/clothing/glasses/science/equipped(mob/user, slot)
 	if(slot == slot_glasses)
@@ -193,6 +194,11 @@
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
 		)
+
+/obj/item/clothing/glasses/sunglasses/reagent
+	name = "sunscanners"
+	desc = "Strangely ancient technology used to help provide rudimentary eye color. Outfitted with apparatus to scan individual reagents."
+	scan_reagents = 1
 
 /obj/item/clothing/glasses/virussunglasses
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -37,14 +37,14 @@
 	on = !on
 	icon_state = "rig[on]-[item_color]"
 
-	if(on)	
+	if(on)
 		set_light(brightness_on)
-	else	
+	else
 		set_light(0)
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
-		H.update_inv_head()	
+		H.update_inv_head()
 
 /obj/item/clothing/suit/space/rig
 	name = "hardsuit"
@@ -135,13 +135,13 @@
 				boots.flags &= ~NODROP
 				H.unEquip(boots)
 				boots.forceMove(src)
-				
+
 /obj/item/clothing/suit/space/rig/verb/toggle_helmet()
 	set name = "Toggle Helmet"
 	set category = "Object"
 	set src in usr
 
-	if(!isliving(usr)) 
+	if(!isliving(usr))
 		return
 
 	if(!helmet)
@@ -300,7 +300,7 @@
 	if(!isturf(user.loc))
 		user << "You cannot toggle your helmet while in this [user.loc]." //To prevent some lighting anomalities.
 		return
-		
+
 	on = !on
 	if(on)
 		user << "<span class='notice'>You switch your helmet to travel mode. It will allow you to stand in zero pressure environments, at the cost of speed and armor.</span>"
@@ -404,6 +404,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 50)
 	flash_protect = 0
+	scan_reagents = 1 //Generally worn by the CMO, so they'd get utility off of seeing reagents
 
 /obj/item/clothing/suit/space/rig/medical
 	icon_state = "rig-medical"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1820,3 +1820,8 @@
 	if(!dna || !dna.uni_identity)
 		return
 	return md5(dna.uni_identity)
+
+/mob/living/carbon/human/can_see_reagents()
+	for(var/obj/item/clothing/C in src) //If they have some clothing equipped that lets them see reagents, they can see reagents
+		if(C.scan_reagents)
+			return 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1447,9 +1447,4 @@ mob/proc/yank_out_object()
 
 //Can the mob see reagents inside of containers?
 /mob/proc/can_see_reagents()
-	if(ishuman(src))
-		var/mob/living/carbon/human/H = src
-		for(var/obj/item/clothing/C in H) //If they have some clothing equipped that lets them see reagents, they can see reagents
-			if(C.scan_reagents)
-				return 1
 	return 0

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1443,3 +1443,13 @@ mob/proc/yank_out_object()
 
 /mob/proc/can_unbuckle(mob/user)
 	return 1
+
+
+//Can the mob see reagents inside of containers?
+/mob/proc/can_see_reagents()
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		for(var/obj/item/clothing/C in H) //If they have some clothing equipped that lets them see reagents, they can see reagents
+			if(C.scan_reagents)
+				return 1
+	return 0

--- a/code/modules/reagents/reagent_containers/drugs.dm
+++ b/code/modules/reagents/reagent_containers/drugs.dm
@@ -18,15 +18,6 @@
 		src.pixel_y = rand(-10.0, 10)
 		base_name = name
 
-
-	examine(mob/user)
-		if(..(user, 2))
-			user << "\blue It contains:"
-			if(reagents && reagents.reagent_list.len)
-				user << "\blue [src.reagents.total_volume] units of powder."
-			else
-				user << "\blue Nothing."
-
 	afterattack(obj/target, mob/user, proximity)
 		if(!proximity) return
 

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -156,7 +156,7 @@
 		else if (reagents.total_volume<=src.volume/4)
 			user << "\blue \The [src] is almost empty!"
 		else if (reagents.total_volume<=src.volume*0.66)
-			user << "\blue \The [src] is half full!"
+			user << "\blue \The [src] is half empty!" // Pessimism is the real order of the day.
 		else if (reagents.total_volume<=src.volume*0.90)
 			user << "\blue \The [src] is almost full!"
 		else

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -49,11 +49,6 @@
 	examine(mob/user)
 		if(!..(user, 2))
 			return
-		user << "\blue It contains:"
-		if(reagents && reagents.reagent_list.len)
-			user << "\blue [src.reagents.total_volume] units of liquid."
-		else
-			user << "\blue Nothing."
 		if (!is_open_container())
 			user << "\blue Airtight lid seals it completely."
 


### PR DESCRIPTION
A port of: https://github.com/tgstation/-tg-station/pull/12460

A big thanks to @Xhuis for actually doing this; been wanting something like this for over a year now.

Either case, on our codebase, reagents are already obfuscated; you can only see the total amount of units of a container. That said, there's no way to seeing just what's in a container without a reagent scanner.

What this PR does:

Makes it so that having clothing that has the scan_reagents var set to 1 will allow you to see just what reagents are in an OPEN reagent container (beakers, glasses, hyposprays, etc). If you don't have such an article of clothing, then you can only see the total volume, as it currently is, on live.

Which pieces of clothing let you see reagents?

- Science Goggles
- Special Reagent sunglasses
- Medical Hardsuit helmets

Job Equipment Changes
- Chemists start out with a pair of science glasses
- Bartender starts off with a pair of sunglasses with built in reagent scanning capabilities