### PR TITLE
Say Bubble Refactor+Fix

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -325,9 +325,9 @@ proc/isInSight(var/atom/A, var/atom/B)
 /proc/flick_overlay(image/I, list/show_to, duration)
 	for(var/client/C in show_to)
 		C.images += I
-	sleep(duration)
-	for(var/client/C in show_to)
-		C.images -= I
+	spawn(duration)
+		for(var/client/C in show_to)
+			C.images -= I
 
 /proc/get_active_player_count()
 	// Get active players who are playing in the round
@@ -427,7 +427,7 @@ proc/isInSight(var/atom/A, var/atom/B)
 
 /proc/SecondsToTicks(var/seconds)
 	return seconds * 10
-	
+
 proc/pollCandidates(var/Question, var/jobbanType, var/antag_age_check = 0, var/be_special_flag = 0, var/poll_time = 300)
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
@@ -469,4 +469,3 @@ proc/pollCandidates(var/Question, var/jobbanType, var/antag_age_check = 0, var/b
 			candidates.Remove(G)
 
 	return candidates
-	

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -243,13 +243,15 @@ proc/get_radio_key_from_channel(var/channel)
 			if(M.loc && M.locs[1] in hearturfs)
 				listening |= M
 
+	var/list/speech_bubble_recipients = list()
 	var/speech_bubble_test = say_test(message)
-	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"h[speech_bubble_test]")
-	spawn(30) qdel(speech_bubble)
 
 	for(var/mob/M in listening)
-		M << speech_bubble
 		M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+		if(M.client)
+			speech_bubble_recipients.Add(M.client)
+	spawn(0)
+		flick_overlay(image('icons/mob/talk.dmi', src, "h[speech_bubble_test]",MOB_LAYER+1), speech_bubble_recipients, 30)
 
 	for(var/obj/O in listening_obj)
 		spawn(0)
@@ -399,19 +401,23 @@ proc/get_radio_key_from_channel(var/channel)
 	watching  -= eavesdropping
 
 	//now mobs
+	var/list/speech_bubble_recipients = list()
 	var/speech_bubble_test = say_test(message)
-	var/image/speech_bubble = image('icons/mob/talk.dmi',src,"h[speech_bubble_test]")
-	spawn(30) qdel(speech_bubble)
 
 	for(var/mob/M in listening)
-		M << speech_bubble
 		M.hear_say(message, verb, speaking, alt_name, italics, src)
+		if(M.client)
+			speech_bubble_recipients.Add(M.client)
 
 	if(eavesdropping.len)
 		var/new_message = stars(message)	//hopefully passing the message twice through stars() won't hurt... I guess if you already don't understand the language, when they speak it too quietly to hear normally you would be able to catch even less.
 		for(var/mob/M in eavesdropping)
-			M << speech_bubble
 			M.hear_say(new_message, verb, speaking, alt_name, italics, src)
+			if(M.client)
+				speech_bubble_recipients.Add(M.client)
+
+	spawn(0)
+		flick_overlay(image('icons/mob/talk.dmi', src, "h[speech_bubble_test]",MOB_LAYER+1), speech_bubble_recipients, 30)
 
 	if(watching.len)
 		var/rendered = "<span class='game say'><span class='name'>[src.name]</span> [not_heard].</span>"


### PR DESCRIPTION
So, for whatever reason, qdel()ing speech bubbles doesn't work out too well--it's a bit unclear as to why; they're definitely being qdel'd, but they're not failing to GC either, nor are they being directly deleted...as a result, they hang for a long time.

Either case, this should fix speech bubbles so they properly clear after the allotted time---it also makes them function more like how other image creation/removal is handled.

Tested and seems to work very well.

Still requesting review by @Markolie and @tigercat2000 as they're far more familiar with saycode than I am.
