### PR TITLE
Lights and Static Power: Machine Processing Optimization

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -1,8 +1,11 @@
 // channel numbers for power
-#define EQUIP	1
-#define LIGHT	2
-#define ENVIRON	3
-#define TOTAL	4	//for total power used only
+#define EQUIP           1
+#define LIGHT           2
+#define ENVIRON         3
+#define TOTAL           4	//for total power used only
+#define STATIC_EQUIP    5
+#define STATIC_LIGHT    6
+#define STATIC_ENVIRON  7
 
 //computer3 error codes, move lower in the file when it passes dev -Sayu
  #define PROG_CRASH      1  // Generic crash

--- a/code/controllers/Processes/machinery.dm
+++ b/code/controllers/Processes/machinery.dm
@@ -20,15 +20,11 @@
 	if(machinery_sort_required)
 		machinery_sort_required = 0
 		machines = dd_sortedObjectList(machines)
-	
+
 /datum/controller/process/machinery/proc/process_machines()
 	for(last_object in machines)
 		var/obj/machinery/M = last_object
 		if(istype(M) && isnull(M.gcDestroyed))
-			#ifdef PROFILE_MACHINES
-			var/time_start = world.timeofday
-			#endif
-
 			try
 				if(M.process() == PROCESS_KILL)
 					machines.Remove(M)
@@ -38,15 +34,6 @@
 					M.auto_use_power()
 			catch(var/exception/e)
 				catchException(e, M)
-
-			#ifdef PROFILE_MACHINES
-			var/time_end = world.timeofday
-
-			if(!(M.type in machine_profiling))
-				machine_profiling[M.type] = 0
-
-			machine_profiling[M.type] += (time_end - time_start)
-			#endif
 		else
 			catchBadType(M)
 			machines -= M
@@ -63,9 +50,9 @@
 				catchException(e, powerNetwork)
 			SCHECK
 			continue
-			
+
 		powernets.Remove(powerNetwork)
-		
+
 /datum/controller/process/machinery/proc/process_power_drain()
 	// Currently only used by powersinks. These items get priority processed before machinery
 	for(var/obj/item/I in processing_power_items)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -45,6 +45,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/used_equip = 0
 	var/used_light = 0
 	var/used_environ = 0
+	var/static_equip
+	var/static_light = 0
+	var/static_environ
 
 	var/has_gravity = 1
 	var/list/apc = list()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -43,7 +43,7 @@
 	for (var/obj/machinery/camera/C in src)
 		cameras += C
 	return cameras
-	
+
 
 /area/proc/atmosalert(danger_level, var/alarm_source)
 	if (danger_level == 0)
@@ -66,7 +66,7 @@
 		atmosalm = danger_level
 		for (var/obj/machinery/alarm/AA in src)
 			AA.update_icon()
-			
+
 		air_alarm_repository.update_cache(src)
 		return 1
 	air_alarm_repository.update_cache(src)
@@ -108,7 +108,7 @@
 		updateicon()
 		mouse_opacity = 0
 		air_doors_open()
-		
+
 	return
 
 /area/proc/burglaralert(var/obj/trigger)
@@ -117,7 +117,7 @@
 
 	//Trigger alarm effect
 	set_fire_alarm_effect()
-	
+
 	//Lockdown airlocks
 	for(var/obj/machinery/door/airlock/A in src)
 		spawn(0)
@@ -128,12 +128,12 @@
 	burglar_alarm.triggerAlarm(src, trigger)
 	spawn(600)
 		burglar_alarm.clearAlarm(src, trigger)
-				
+
 /area/proc/set_fire_alarm_effect()
 	fire = 1
 	updateicon()
 	mouse_opacity = 0
-					
+
 /area/proc/readyalert()
 	if(!eject)
 		eject = 1
@@ -251,8 +251,22 @@
 			used += used_environ
 		if(TOTAL)
 			used += used_light + used_equip + used_environ
-
+		if(STATIC_EQUIP)
+			used += static_equip
+		if(STATIC_LIGHT)
+			used += static_light
+		if(STATIC_ENVIRON)
+			used += static_environ
 	return used
+
+/area/proc/addStaticPower(value, powerchannel)
+	switch(powerchannel)
+		if(STATIC_EQUIP)
+			static_equip += value
+		if(STATIC_LIGHT)
+			static_light += value
+		if(STATIC_ENVIRON)
+			static_environ += value
 
 /area/proc/clear_usage()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1123,9 +1123,12 @@
 	if(!area.requires_power)
 		return
 
-	lastused_light = area.usage(LIGHT)
+	lastused_light = area.usage(STATIC_LIGHT)
+	lastused_light += area.usage(LIGHT)
 	lastused_equip = area.usage(EQUIP)
+	lastused_equip += area.usage(STATIC_EQUIP)
 	lastused_environ = area.usage(ENVIRON)
+	lastused_environ += area.usage(STATIC_ENVIRON)
 	area.clear_usage()
 
 	lastused_total = lastused_light + lastused_equip + lastused_environ

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -44,7 +44,7 @@
 		return powernet.avail
 	else
 		return 0
-		
+
 /obj/machinery/power/proc/load()
 	if(powernet)
 		return powernet.load
@@ -76,6 +76,15 @@
 	if(chan == -1)
 		chan = power_channel
 	A.use_power(amount, chan)
+
+/obj/machinery/proc/addStaticPower(value, powerchannel)
+	var/area/A = get_area(src)
+	if(!A)
+		return
+	A.addStaticPower(value, powerchannel)
+
+/obj/machinery/proc/removeStaticPower(value, powerchannel)
+	addStaticPower(-value, powerchannel)
 
 /obj/machinery/proc/power_change()		// called whenever the power settings of the containing area change
 										// by default, check equipment channel & set flag


### PR DESCRIPTION
Right so, all lights are technically in machine processing...and they're processed....each cycle.

This is surprisingly costly to process each tick.

This implements TG's "static power" system that adds power drain to APCs on a static level so each individual thing that uses static power doesn't have to be processed each tick. Currently, only lights use static power.

Before: http://hastebin.com/gimilutumo.mel

After: http://hastebin.com/jodomotixu.mel

This technically makes every search "in machines" faster too, as the machines list is now something like 800 objects shorter.

- Removes unused machine profiling
 - We don't have the lists, backend, or anything at all related to this, I have no idea why it's even there.

@PsiOmegaDelta 

You may be interested in this, as it's very simple and has a relatively high impact.