### PR TITLE
Fixed the item examine problem.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -136,7 +136,7 @@
 		if(5.0)
 			size = "huge"
 
-	..(user, distance, "", "It is a [size] item.")
+	. = ..(user, distance, "", "It is a [size] item.")
 
 	if(user.research_scanner) //Mob has a research scanner active.
 		var/msg = "*--------* <BR>"


### PR DESCRIPTION
This was a silly bug where /obj/item/examine() clobbered the return value of atom/examine(), thus causing all custom item examine procs to think that the item is always out of range.

Fixes #2401
Fixes #2371
Fixes #2358
Fixes #2334
(and possibly more that I didn't find)

It is possible that other examine proc implementations also need this fix, but this solves all the known problem items at least.