### PR TITLE
Dead humans are now no longer able to emote

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -84,6 +84,9 @@
 	if(stat == DEAD)	return
 	if(healths)		healths.icon_state = "health5"
 
+	if(!gibbed)
+		emote("deathgasp") //let the world KNOW WE ARE DEAD
+
 	stat = DEAD
 	dizziness = 0
 	jitteriness = 0
@@ -128,8 +131,6 @@
 			H.mind.kills += "[name] ([ckey])"
 
 	if(!gibbed)
-		emote("deathgasp") //let the world KNOW WE ARE DEAD
-
 		update_canmove()
 		if(client) blind.layer = 0
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1,4 +1,8 @@
 /mob/living/carbon/human/emote(var/act,var/m_type=1,var/message = null,var/force)
+
+	if (stat == DEAD)
+		return // No screaming bodies
+
 	var/param = null
 	if (findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)


### PR DESCRIPTION
With this fix, there's now a check at the beginning to make sure that dead humans aren't doing any emotes. I wasn't sure, however, if I should have taken precedent from the simple_animal code for emotes, which only lets them do so when conscious. To keep it safe, I left it so that unconscious humans could still emote.

There isn't anything that needs a dead body to do an emote, right? I'll leave this here while I do a search to make sure that's the case.