### PR TITLE
Can pick up mobs in closets

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -21,9 +21,6 @@
 		if(!action_checks(target)) return
 		if(!cargo_holder) return
 		if(istype(target, /obj/structure/stool)) return
-		for(var/M in target.contents)
-			if(istype(M, /mob/living))
-				return
 
 		if(istype(target,/obj))
 			var/obj/O = target


### PR DESCRIPTION
Not sure why this was changed at all, as this allowed ripley to act as an improvised Odysseus if it got a clamp. Among other things it also allows collecting mining mobs for later use in an easy manner.