### PR TITLE
Sleeper NanoUI

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -232,11 +232,11 @@
 			if (src.connected)
 				if (src.connected.occupant)
 					if (src.connected.occupant.stat == DEAD)
-						usr << "\red \b This person has no life for to preserve anymore. Take them to a department capable of reanimating them."
+						usr << "<span class='danger'>This person has no life for to preserve anymore. Take them to a department capable of reanimating them.</span>"
 					else if(src.connected.occupant.health > src.connected.min_health || (href_list["chemical"] in connected.emergency_chems))
 						src.connected.inject_chemical(usr,href_list["chemical"],text2num(href_list["amount"]))
 					else
-						usr << "\red \b This person is not in good enough condition for sleepers to be effective! Use another means of treatment, such as cryogenics!"
+						usr << "<span class='danger'>This person is not in good enough condition for sleepers to be effective! Use another means of treatment, such as cryogenics!</span>"
 		if (href_list["removebeaker"])
 			src.connected.remove_beaker()
 		if (href_list["togglefilter"])
@@ -269,7 +269,7 @@
 	var/filtering = 0
 	var/max_chem
 	var/initial_bin_rating = 1
-	var/min_health = 25
+	var/min_health = -25
 	var/injection_chems = list()
 	idle_power_usage = 1250
 	active_power_usage = 2500
@@ -361,7 +361,7 @@
 			return
 
 		else
-			user << "\red The sleeper has a beaker already."
+			user << "<span class='warning'>The sleeper has a beaker already.</span>"
 			return
 
 	if (istype(G, /obj/item/weapon/screwdriver))
@@ -393,12 +393,12 @@
 
 	if(istype(G, /obj/item/weapon/grab))
 		if(panel_open)
-			user << "\blue <b>Close the maintenance panel first.</b>"
+			user << "<span class='boldnotice'>Close the maintenance panel first.</span>"
 			return
 		if(!ismob(G:affecting))
 			return
 		if(src.occupant)
-			user << "\blue <B>The sleeper is already occupied!</B>"
+			user << "<span class='boldnotice'>The sleeper is already occupied!</span>"
 			return
 		for(var/mob/living/carbon/slime/M in range(1,G:affecting))
 			if(M.Victim == G:affecting)
@@ -409,7 +409,7 @@
 
 		if(do_after(user, 20, target = G:affecting))
 			if(src.occupant)
-				user << "\blue <B>The sleeper is already occupied!</B>"
+				user << "<span class='boldnotice'>The sleeper is already occupied!</span>"
 				return
 			if(!G || !G:affecting) return
 			var/mob/M = G:affecting
@@ -419,7 +419,7 @@
 			M.forceMove(src)
 			src.occupant = M
 			src.icon_state = "sleeper"
-			M << "\blue <b>You feel cool air surround you. You go numb as your senses turn inward.</b>"
+			M << "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>"
 
 			src.add_fingerprint(user)
 			qdel(G)
@@ -464,6 +464,7 @@
 	..(severity)
 
 // ???
+// This looks cool, although mildly broken, should it be included again?
 /obj/machinery/sleeper/alter_health(mob/living/M as mob)
 	if (M.health > 0)
 		if (M.getOxyLoss() >= 10)
@@ -518,36 +519,6 @@
 		user << "There's no occupant in the sleeper!"
 		return
 
-
-/obj/machinery/sleeper/proc/check(mob/living/user as mob)
-	if(src.occupant)
-		user << text("\blue <B>Occupant ([]) Statistics:</B>", src.occupant)
-		var/t1
-		switch(src.occupant.stat)
-			if(0.0)
-				t1 = "Conscious"
-			if(1.0)
-				t1 = "Unconscious"
-			if(2.0)
-				t1 = "*dead*"
-			else
-		user << text("[]\t Health %: [] ([])", (src.occupant.health > 50 ? "\blue " : "\red "), src.occupant.health, t1)
-		user << text("[]\t -Core Temperature: []&deg;C ([]&deg;F)</FONT><BR>", (src.occupant.bodytemperature > 50 ? "<font color='blue'>" : "<font color='red'>"), src.occupant.bodytemperature-T0C, src.occupant.bodytemperature*1.8-459.67)
-		user << text("[]\t -Brute Damage %: []", (src.occupant.getBruteLoss() < 60 ? "\blue " : "\red "), src.occupant.getBruteLoss())
-		user << text("[]\t -Respiratory Damage %: []", (src.occupant.getOxyLoss() < 60 ? "\blue " : "\red "), src.occupant.getOxyLoss())
-		user << text("[]\t -Toxin Content %: []", (src.occupant.getToxLoss() < 60 ? "\blue " : "\red "), src.occupant.getToxLoss())
-		user << text("[]\t -Burn Severity %: []", (src.occupant.getFireLoss() < 60 ? "\blue " : "\red "), src.occupant.getFireLoss())
-		user << "\blue Expected time till occupant can safely awake: (note: If health is below 20% these times are inaccurate)"
-		user << text("\blue \t [] second\s (if around 1 or 2 the sleeper is keeping them asleep.)", src.occupant.paralysis / 5)
-		if(src.beaker)
-			user << text("\blue \t Dialysis Output Beaker has [] of free space remaining.", src.beaker.reagents.maximum_volume - src.beaker.reagents.total_volume)
-		else
-			user << "\blue No Dialysis Output Beaker loaded."
-	else
-		user << "\blue There is no one inside!"
-	return
-
-
 /obj/machinery/sleeper/verb/eject()
 	set name = "Eject Sleeper"
 	set category = "Object"
@@ -590,10 +561,10 @@
 	if(!istype(user.loc, /turf) || !istype(O.loc, /turf)) // are you in a container/closet/pod/etc?
 		return
 	if(panel_open)
-		user << "\blue <B>Close the maintenance panel first.</B>"
+		user << "<span class='boldnotice'>Close the maintenance panel first.</span>"
 		return
 	if(occupant)
-		user << "\blue <B>The sleeper is already occupied!</B>"
+		user << "<span class='boldnotice'>The sleeper is already occupied!</span>"
 		return
 /*	if(isrobot(user))
 		if(!istype(user:module, /obj/item/weapon/robot_module/medical))
@@ -603,7 +574,7 @@
 	if(!istype(L) || L.buckled)
 		return
 	if(L.abiotic())
-		user << "\blue <B>Subject cannot have abiotic items on.</B>"
+		user << "<span class='boldnotice'>Subject cannot have abiotic items on.</span>"
 		return
 	for(var/mob/living/carbon/slime/M in range(1,L))
 		if(M.Victim == L)
@@ -616,7 +587,7 @@
 
 	if(do_after(user, 20, target = L))
 		if(src.occupant)
-			user << "\blue <B>The sleeper is already occupied!</B>"
+			user << "<span class='boldnotice'>>The sleeper is already occupied!</span>"
 			return
 		if(!L) return
 
@@ -626,7 +597,7 @@
 		L.forceMove(src)
 		src.occupant = L
 		src.icon_state = "sleeper"
-		L << "\blue <b>You feel cool air surround you. You go numb as your senses turn inward.</b>"
+		L << "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>"
 		src.add_fingerprint(user)
 		if(user.pulling == L)
 			user.pulling = null
@@ -643,10 +614,10 @@
 	if(usr.stat != 0 || !(ishuman(usr)))
 		return
 	if(src.occupant)
-		usr << "\blue <B>The sleeper is already occupied!</B>"
+		usr << "<span class='boldnotice'>The sleeper is already occupied!</span>"
 		return
 	if (panel_open)
-		usr << "\blue <B>Close the maintenance panel first.</B>"
+		usr << "<span class='boldnotice'>Close the maintenance panel first.</span>"
 		return
 	if(usr.restrained() || usr.stat || usr.weakened || usr.stunned || usr.paralysis || usr.resting) //are you cuffed, dying, lying, stunned or other
 		return
@@ -657,7 +628,7 @@
 	visible_message("[usr] starts climbing into the sleeper.")
 	if(do_after(usr, 20, target = usr))
 		if(src.occupant)
-			usr << "\blue <B>The sleeper is already occupied!</B>"
+			usr << "<span class='boldnotice'>The sleeper is already occupied!</span>"
 			return
 		usr.stop_pulling()
 		usr.client.perspective = EYE_PERSPECTIVE

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -73,6 +73,7 @@
 	var/mob/remoteview_target = null
 	var/meatleft = 3 //For chef item
 	var/decaylevel = 0 // For rotting bodies
+	var/max_blood = 560 // For stuff in the vessel
 	var/slime_color = "blue" //For slime people this defines their color, it's blue by default to pay tribute to the old icons
 
 	var/check_mutations=0 // Check mutations on next life tick

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -98,6 +98,9 @@ About the Holder:
 			Returns the amount of the matching reagent inside the
 			holder. Returns 0 if the reagent is missing.
 
+		overdose_list()
+			Returns a list of all the chemical IDs in the reagent holder that are overdosing
+
 		Important variables:
 
 			total_volume

--- a/code/modules/reagents/newchem/newchem_procs.dm
+++ b/code/modules/reagents/newchem/newchem_procs.dm
@@ -82,6 +82,14 @@ datum/reagents/proc/metabolize(var/mob/M)
 	addiction_tick++
 	update_total()
 
+/datum/reagents/proc/overdose_list()
+	var/od_chems[0]
+	for(var/datum/reagent/R in reagent_list)
+		if(R.overdosed)
+			od_chems.Add(R.id)
+	return od_chems
+
+
 datum/reagents/proc/reagent_on_tick()
 	for(var/datum/reagent/R in reagent_list)
 		R.on_tick()

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -607,3 +607,28 @@ th.misc {
 .Pearl {
     color: #C6CACB;
 }
+
+/* Status bar colors for sleeper temperatures */
+.cold1 {
+	color: #94B8FF;
+}
+
+.cold2 {
+	color: #6699FF;
+}
+
+.cold3 {
+	color: #293D66;
+}
+
+.hot1 {
+	color: #FF9966;
+}
+
+.hot2 {
+	color: #993D00;
+}
+
+.hot3 {
+	color: #FF6600;
+}

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -63,50 +63,50 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 				<div class="statusLabel">Patient Temperature:</div>
 				{{if data.occupant.temperatureSuitability == -3}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'cold3')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == -2}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'cold2')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == -1}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'cold1')}}
-				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 0}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'good')}}
-				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 1}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'hot1')}}
-				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 2}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'hot2')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 3}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'hot3')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{/if}}
 				If you can get the changing temperature bars to work right, congratulations
 				-->
 				<div class="statusLabel">Patient Temperature:</div>
 				{{if data.occupant.temperatureSuitability == -3}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'bad')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == -2}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == -1}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
-				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 0}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'good')}}
-				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 1}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
-				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 2}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{else data.occupant.temperatureSuitability == 3}}
 				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'bad')}}
-				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}&deg;C, {{:helper.round(data.occupant.btFaren)}}&deg;F</div>
 				{{/if}}
 			</div>
 			

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -56,9 +56,67 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 				{{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad')}}
 				<div class="statusValue">{{:helper.round(data.occupant.fireLoss)}}</div>
 			</div>
+			
+			<br>
+			<div class="line">
+			<!--
+				<div class="statusLabel">Patient Temperature:</div>
+				{{if data.occupant.temperatureSuitability == -3}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'cold3')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == -2}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'cold2')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == -1}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'cold1')}}
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 0}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'good')}}
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 1}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'hot1')}}
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 2}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'hot2')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 3}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'hot3')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{/if}}
+				If you can get the changing temperature bars to work right, congratulations
+				-->
+				<div class="statusLabel">Patient Temperature:</div>
+				{{if data.occupant.temperatureSuitability == -3}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'bad')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == -2}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == -1}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 0}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'good')}}
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 1}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
+				<div class="statusValue">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 2}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'average')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{else data.occupant.temperatureSuitability == 3}}
+				{{:helper.displayBar(data.occupant.bodyTemperature, 0, data.occupant.maxTemp, 'bad')}}
+				<div class="statusValue bad">{{:helper.round(data.occupant.btCelsius)}}C, {{:helper.round(data.occupant.btFaren)}}F</div>
+				{{/if}}
+			</div>
+			
+			
 			{{if data.occupant.hasBlood}}
 			
 			<br>
+			<div class="line">
+				<div class="statusLabel">Pulse:</div> <div class="statusValue">{{:data.occupant.pulse}} bpm</div>
+			</div>
 			<div class="line">
 				<div class="statusLabel">Blood Level:</div>
 				{{if data.occupant.bloodPercent <= 60}}

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -1,0 +1,104 @@
+<!-- 
+Title: Sleeper Status UI 
+Used In File(s): \code\game\machinery\Sleeper.dm
+ -->
+<h3>Sleeper Status</h3>
+
+<div class="statusDisplay">
+	{{if !data.hasOccupant}}
+		<div class="line">Sleeper Unoccupied</div>
+	{{else}}
+		<div class="line">
+			{{:data.occupant.name}}&nbsp;=>&nbsp;
+			{{if data.occupant.stat == 0}}
+				<span class="good">Conscious</span>
+			{{else data.occupant.stat == 1}}
+				<span class="average">Unconscious</span>
+			{{else}}
+				<span class="bad">DEAD</span>
+			{{/if}}
+		</div>
+	
+		{{if data.occupant.stat < 2}}
+			<div class="line">
+				<div class="statusLabel">Health:</div>
+				{{if data.occupant.health >= 0}}
+					{{:helper.displayBar(data.occupant.health, 0, data.occupant.maxHealth, 'good')}}
+				{{else}}
+					{{:helper.displayBar(data.occupant.health, 0, data.occupant.minHealth, 'average alignRight')}}
+				{{/if}}
+				<div class="statusValue">{{:helper.round(data.occupant.health)}}</div>
+			</div>
+		
+			<div class="line">
+				<div class="statusLabel">=&gt; Brute Damage:</div>
+				{{:helper.displayBar(data.occupant.bruteLoss, 0, data.occupant.maxHealth, 'bad')}}
+				<div class="statusValue">{{:helper.round(data.occupant.bruteLoss)}}</div>
+			</div>
+		
+			<div class="line">
+				<div class="statusLabel">=&gt; Resp. Damage:</div>
+				{{:helper.displayBar(data.occupant.oxyLoss, 0, data.occupant.maxHealth, 'bad')}}
+				<div class="statusValue">{{:helper.round(data.occupant.oxyLoss)}}</div>
+			</div>
+		
+			<div class="line">
+				<div class="statusLabel">=&gt; Toxin Damage:</div>
+				{{:helper.displayBar(data.occupant.toxLoss, 0, data.occupant.maxHealth, 'bad')}}
+				<div class="statusValue">{{:helper.round(data.occupant.toxLoss)}}</div>
+			</div>
+		
+			<div class="line">
+				<div class="statusLabel">=&gt; Burn Severity:</div>
+				{{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad')}}
+				<div class="statusValue">{{:helper.round(data.occupant.fireLoss)}}</div>
+			</div>
+		{{/if}}
+	{{/if}}
+</div>
+
+<h3>Sleeper Operation</h3>
+<div class="item">
+	<div class="itemLabel">
+		Sleeper Status:
+	</div>
+	<div class="itemContent" style="width: 26%;">
+		{{:helper.link('Eject Occupant', 'arrowreturnthick-1-s', {'ejectify' : 1}, data.hasOccupant ? null : 'disabled')}}
+	</div>
+</div>
+<div class="item">&nbsp;</div>
+<div class="item">
+	<div class="itemLabel">
+		Beaker:
+	</div>
+	<div class="itemContent" style="width: 40%;">
+		{{if data.isBeakerLoaded}}		
+			{{:data.beakerLabel ? data.beakerLabel : '<span class="average">No label</span>'}}<br>
+			{{if data.beakerVolume}}
+				<span class="highlight">{{:data.beakerVolume}} units remaining</span><br>
+			{{else}}
+				<span class="bad">Beaker is empty</span>
+			{{/if}}
+		{{else}}
+			<span class="average"><i>No beaker loaded</i></span>
+		{{/if}}
+	</div>
+	<div class="itemContent" style="width: 26%;">
+		{{:helper.link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
+	</div>
+</div>
+<div class="item">
+    {{if data.hasOccupant}}
+    <div class="itemLabel">
+        Chemicals:
+    </div>
+    {{for data.chemicals}}
+        <b>&nbsp;{{:value.title}}&nbsp;:</b>
+            {{:helper.displayBar(value.occ_amount, 0, data.maxchem, 'good')}}
+        <div class="statusValue">{{:helper.round(value.occ_amount)}}/{{:data.maxchem}}</div>
+        <div class="itemContent">
+        {{:helper.link('5', 'gear', {'chemical' : value.id, 'amount' : 5}, (value.occ_amount + 5 > data.maxchem) ? 'disabled' : null)}}
+        {{:helper.link('10', 'gear', {'chemical' : value.id, 'amount' : 10}, ((value.occ_amount + 10) > data.maxchem) ? 'disabled' : null)}}
+    {{/for}}
+    {{/if}}
+</div>

--- a/nano/templates/sleeper.tmpl
+++ b/nano/templates/sleeper.tmpl
@@ -19,13 +19,16 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 			{{/if}}
 		</div>
 	
-		{{if data.occupant.stat < 2}}
 			<div class="line">
 				<div class="statusLabel">Health:</div>
-				{{if data.occupant.health >= 0}}
+				{{if data.occupant.health >= data.occupant.maxHealth}}
 					{{:helper.displayBar(data.occupant.health, 0, data.occupant.maxHealth, 'good')}}
-				{{else}}
+				{{else data.occupant.health > 0}}
+					{{:helper.displayBar(data.occupant.health, 0, data.occupant.maxHealth, 'average')}}
+				{{else data.occupant.health >= data.minhealth}}
 					{{:helper.displayBar(data.occupant.health, 0, data.occupant.minHealth, 'average alignRight')}}
+				{{else}}
+					{{:helper.displayBar(data.occupant.health, 0, data.occupant.minHealth, 'bad alignRight')}}
 				{{/if}}
 				<div class="statusValue">{{:helper.round(data.occupant.health)}}</div>
 			</div>
@@ -53,7 +56,29 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 				{{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad')}}
 				<div class="statusValue">{{:helper.round(data.occupant.fireLoss)}}</div>
 			</div>
-		{{/if}}
+			{{if data.occupant.hasBlood}}
+			
+			<br>
+			<div class="line">
+				<div class="statusLabel">Blood Level:</div>
+				{{if data.occupant.bloodPercent <= 60}}
+					{{:helper.displayBar(data.occupant.bloodLevel, 0, data.occupant.bloodMax, 'bad')}}
+				<div class="statusValue">
+					{{:data.occupant.bloodPercent}}%, {{:data.occupant.bloodLevel}}cl
+				</div>
+				{{else data.occupant.bloodPercent <= 90}}
+					{{:helper.displayBar(data.occupant.bloodLevel, 0, data.occupant.bloodMax, 'average')}}
+				<div class="statusValue">
+					{{:data.occupant.bloodPercent}}%, {{:data.occupant.bloodLevel}}cl
+				</div>
+				{{else}}
+					{{:helper.displayBar(data.occupant.bloodLevel, 0, data.occupant.bloodMax, 'good')}}
+				<div class="statusValue">
+					{{:data.occupant.bloodPercent}}%, {{:data.occupant.bloodLevel}}cl
+				</div>
+				{{/if}}
+			</div>
+			{{/if}}
 	{{/if}}
 </div>
 
@@ -69,36 +94,50 @@ Used In File(s): \code\game\machinery\Sleeper.dm
 <div class="item">&nbsp;</div>
 <div class="item">
 	<div class="itemLabel">
-		Beaker:
+		Dialysis Beaker:
 	</div>
 	<div class="itemContent" style="width: 40%;">
-		{{if data.isBeakerLoaded}}		
-			{{:data.beakerLabel ? data.beakerLabel : '<span class="average">No label</span>'}}<br>
-			{{if data.beakerVolume}}
-				<span class="highlight">{{:data.beakerVolume}} units remaining</span><br>
-			{{else}}
-				<span class="bad">Beaker is empty</span>
-			{{/if}}
+		{{if data.isBeakerLoaded}}
+			<span class="highlight">{{:helper.round(data.beakerFreeSpace)}} units of space remaining</span><br>
 		{{else}}
-			<span class="average"><i>No beaker loaded</i></span>
+			<span class="average"><i>No Dialysis Output Beaker Loaded</i></span>
 		{{/if}}
 	</div>
 	<div class="itemContent" style="width: 26%;">
-		{{:helper.link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
+		{{:helper.link('Eject Beaker', 'eject', {'removebeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
+		{{if data.isBeakerLoaded}}
+		<div class="line">
+			<div class="itemContent">
+				{{:helper.link('On', 'power', {'togglefilter' : 1}, data.occupant.hasBlood ? (data.dialysis ? 'selected' : null) : 'disabled')}}{{:helper.link('Off', 'close', {'togglefilter' : 1}, data.dialysis ? null : 'selected')}}
+			</div>
+		</div>
+		{{/if}}
 	</div>
 </div>
 <div class="item">
-    {{if data.hasOccupant}}
     <div class="itemLabel">
         Chemicals:
     </div>
+	
     {{for data.chemicals}}
-        <b>&nbsp;{{:value.title}}&nbsp;:</b>
+	<div class="line">
+        <b>{{:value.title}}:</b>
+		{{if value.overdosing}}
+            {{:helper.displayBar(value.occ_amount, 0, data.maxchem, 'bad')}}
+		{{else value.od_warning}}
+            {{:helper.displayBar(value.occ_amount, 0, data.maxchem, 'average')}}
+		{{else}}
             {{:helper.displayBar(value.occ_amount, 0, data.maxchem, 'good')}}
-        <div class="statusValue">{{:helper.round(value.occ_amount)}}/{{:data.maxchem}}</div>
-        <div class="itemContent">
-        {{:helper.link('5', 'gear', {'chemical' : value.id, 'amount' : 5}, (value.occ_amount + 5 > data.maxchem) ? 'disabled' : null)}}
-        {{:helper.link('10', 'gear', {'chemical' : value.id, 'amount' : 10}, ((value.occ_amount + 10) > data.maxchem) ? 'disabled' : null)}}
+		{{/if}}
+        <div class="statusValue">{{:value.pretty_amount}}/{{:data.maxchem}}</div>
+		<br>
+	</div>
+		<div class="line>
+		<div class="itemContent">
+			{{:helper.link('5', 'gear', {'chemical' : value.id, 'amount' : 5}, (!value.injectable || ((value.occ_amount + 5) > data.maxchem)) ? 'disabled' : null)}}
+			{{:helper.link('10', 'gear', {'chemical' : value.id, 'amount' : 10}, (!value.injectable || ((value.occ_amount + 10) > data.maxchem)) ? 'disabled' : null)}}
+		</div>
+	</div>
     {{/for}}
-    {{/if}}
 </div>
+


### PR DESCRIPTION
Also cuts out a few points of weirdness; No dialysis on bloodless races
like IPCs, and dialysis on simple_animals is no longer possible through
the interface or through href twiddling, as that caused a runtime.

Also, prevents href tweaking to dispense chemicals the sleeper doesn't
have.

Alright, now for some pictures!
A healthy human:

![sleeper_chems](https://cloud.githubusercontent.com/assets/5661700/10716940/b0ca3cf4-7b05-11e5-9a3f-40b77065edcb.png)

Hey, watch it on the drugs:
![overdose_warning](https://cloud.githubusercontent.com/assets/5661700/10716942/c322a986-7b05-11e5-8ffa-daefaf8131cd.png)

Now you've done it:
![overdosing](https://cloud.githubusercontent.com/assets/5661700/10716943/d34dc08e-7b05-11e5-9b44-7df8ba58f2f8.png)

You've put a cat in the sleeper. Why did you put a cat in there?:
![sleeper_runtime](https://cloud.githubusercontent.com/assets/5661700/10716948/e5153df6-7b05-11e5-90ab-1cd635d9db4d.png)

Patient is critical! The sleeper is not the tool for the job here!
![critical_patient](https://cloud.githubusercontent.com/assets/5661700/10716952/fc759f72-7b05-11e5-8e6c-2b22c4055e23.png)

Robots don't have blood, silly:
![ipc_dialysis](https://cloud.githubusercontent.com/assets/5661700/10716953/04ed0c76-7b06-11e5-97e8-b10deee71b79.png)

Patient is hurt, but can still be treated here:
![bleeding_patient](https://cloud.githubusercontent.com/assets/5661700/10716954/13098460-7b06-11e5-93de-817b23b6af5b.png)

A readout still exists, for dead patients:
![dead_patient](https://cloud.githubusercontent.com/assets/5661700/10716955/2b615bd2-7b06-11e5-8a0c-b43a048b1949.png)
