### PR TITLE
Clean up mob code a bit

### DIFF
--- a/code/controllers/Processes/mob.dm
+++ b/code/controllers/Processes/mob.dm
@@ -1,12 +1,16 @@
+var/global/datum/controller/process/mob/mob_master
+
 /datum/controller/process/mob
+	var/current_cycle
 
 /datum/controller/process/mob/setup()
 	name = "mob"
 	schedule_interval = 20 // every 2 seconds
 	start_delay = 16
-	if(!mob_master)
-		mob_master = new
-		mob_master.Setup()
+	log_startup_progress("Mob ticker starting up.")
+	if(mob_master)
+		qdel(mob_master) //only one mob master
+	mob_master = src
 
 /datum/controller/process/mob/started()
 	..()
@@ -29,17 +33,4 @@
 		else
 			catchBadType(M)
 			mob_list -= M
-	mob_master.process()
-
-var/global/datum/controller/mob_system/mob_master
-
-/datum/controller/mob_system
-	var/current_cycle
-	var/starttime
-
-/datum/controller/mob_system/proc/Setup()
-	log_startup_progress("Mob ticker starting up.")
-	starttime = world.timeofday
-
-/datum/controller/mob_system/proc/process()
 	current_cycle++

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -105,7 +105,7 @@
 		var/mob/O = M
 		if(!O.lastarea)
 			O.lastarea = get_area(O.loc)
-		O.update_gravity(O.mob_has_gravity(src))
+//		O.update_gravity(O.mob_has_gravity(src))
 
 	var/loopsanity = 100
 	for(var/atom/A in range(1))

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -85,7 +85,7 @@
 		return
 	health = maxHealth - getOxyLoss() - getFireLoss() - getBruteLoss() - getCloneLoss()
 
-/mob/living/carbon/alien/proc/handle_environment(var/datum/gas_mixture/environment)
+/mob/living/carbon/alien/handle_environment(var/datum/gas_mixture/environment)
 
 	//If there are alien weeds on the ground then heal if needed or give some toxins
 	if(locate(/obj/structure/alien/weeds) in loc)
@@ -136,7 +136,7 @@
 					fire_alert = max(fire_alert, 2)
 	return
 
-/mob/living/carbon/alien/proc/handle_mutations_and_radiation()
+/mob/living/carbon/alien/handle_mutations_and_radiation()
 	if(getFireLoss())
 		if((RESIST_HEAT in mutations) || prob(5))
 			adjustFireLoss(-1)
@@ -169,11 +169,6 @@
 	if(..())
 		return
 	bodytemperature += BODYTEMP_HEATING_MAX //If you're on fire, you heat up!
-	return
-
-/mob/living/carbon/alien/proc/handle_wetness()
-	if(mob_master.current_cycle%20==2) //dry off a bit once every 20 ticks or so
-		wetlevel = max(wetlevel - 1,0)
 	return
 
 /mob/living/carbon/alien/IsAdvancedToolUser()

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -9,70 +9,12 @@
 
 
 /mob/living/carbon/alien/humanoid/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
-
-	..()
-
-	var/datum/gas_mixture/environment = loc.return_air()
-
-	if (stat != DEAD) //still breathing
-
-		//First, resolve location and get a breath
-
-		if(mob_master.current_cycle%4==2)
-			//Only try to take a breath every 4 seconds, unless suffocating
-			spawn(0) breathe()
-
-		else //Still give containing object the chance to interact
-			if(istype(loc, /obj/))
-				var/obj/location_as_object = loc
-				location_as_object.handle_internal_lifeform(src, 0)
-
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-		//Disabilities
-		handle_disabilities()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-	blinded = null
-
-	//Handle temperature/pressure differences between body and environment
-	handle_environment(environment)
-
-	//stuff in the stomach
-	handle_stomach()
-
-	//Handle being on fire
-	handle_fire()
-
-	//Decrease wetness over time
-	handle_wetness()
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
-
-	handle_actions()
-
-	update_canmove()
+	. = ..()
 	update_icons()
 
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
-
-	if(client)
-		handle_regular_hud_updates()
 
 
-/mob/living/carbon/alien/humanoid/proc/handle_disabilities()
+/mob/living/carbon/alien/humanoid/handle_disabilities()
 	if (disabilities & EPILEPSY)
 		if ((prob(1) && paralysis < 10))
 			src << "<span class='danger'>You have a seizure!</span>"
@@ -110,7 +52,7 @@
 	temp_change = (temperature - current)
 	return temp_change
 
-/mob/living/carbon/alien/humanoid/proc/handle_regular_status_updates()
+/mob/living/carbon/alien/humanoid/handle_regular_status_updates()
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
@@ -191,7 +133,7 @@
 	return 1
 
 
-/mob/living/carbon/alien/humanoid/proc/handle_regular_hud_updates()
+/mob/living/carbon/alien/humanoid/handle_regular_hud_updates()
 
 	if (stat == 2 || (XRAY in mutations))
 		sight |= SEE_TURFS

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -3,61 +3,16 @@
 /mob/living/carbon/alien/larva
 	var/temperature_alert = 0
 
-
 /mob/living/carbon/alien/larva/Life()
-	set invisibility = 0
-	set background = BACKGROUND_ENABLED
-
-	..()
-	var/datum/gas_mixture/enviroment = loc.return_air()
-	if (stat != DEAD) //still breathing
-
+	if(..()) //still breathing
 		// GROW!
 		if(amount_grown < max_grown)
 			amount_grown++
 
-		//First, resolve location and get a breath
-		if(mob_master.current_cycle%4==2)
-			//Only try to take a breath every 4 seconds, unless suffocating
-			spawn(0) breathe()
-		else //Still give containing object the chance to interact
-			if(istype(loc, /obj/))
-				var/obj/location_as_object = loc
-				location_as_object.handle_internal_lifeform(src, 0)
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-	blinded = null
-
-	//Handle temperature/pressure differences between body and environment
-	handle_environment(enviroment)
-
-	//stuff in the stomach
-	//handle_stomach()
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
-	update_canmove()
-
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
-
 	//some kind of bug in canmove() isn't properly calling update_icons, so this is here as a placeholder
 	update_icons()
 
-	if(client)
-		handle_regular_hud_updates()
-
-/mob/living/carbon/alien/larva/proc/handle_regular_status_updates()
+/mob/living/carbon/alien/larva/handle_regular_status_updates()
 	updatehealth()
 
 	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
@@ -133,7 +88,7 @@
 	return 1
 
 
-/mob/living/carbon/alien/larva/proc/handle_regular_hud_updates()
+/mob/living/carbon/alien/larva/handle_regular_hud_updates()
 
 	if (stat == 2 || (XRAY in mutations))
 		sight |= SEE_TURFS
@@ -211,6 +166,3 @@
 				reset_view(null)
 
 	return 1
-
-/mob/living/carbon/alien/larva/proc/handle_random_events()
-	return

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,4 +1,17 @@
-/mob/living/carbon/alien/proc/handle_chemicals_in_body()
+/mob/living/carbon/alien/Life()
+	if(..())
+		//First, resolve location and get a breath
+		if(mob_master.current_cycle%4==2)
+			//Only try to take a breath every 4 seconds, unless suffocating
+			spawn(0) breathe()
+
+		else //Still give containing object the chance to interact
+			if(istype(loc, /obj/))
+				var/obj/location_as_object = loc
+				location_as_object.handle_internal_lifeform(src, 0)
+		return 1
+
+/mob/living/carbon/alien/handle_chemicals_in_body()
 	if(reagents)
 		reagents.metabolize(src)
 
@@ -103,20 +116,3 @@
 	//Temporary fixes to the alerts.
 
 	return 1
-
-/mob/living/carbon/alien/proc/handle_stomach()
-	spawn(0)
-		for(var/mob/living/M in stomach_contents)
-			if(M.loc != src)
-				stomach_contents.Remove(M)
-				continue
-			if(istype(M, /mob/living/carbon) && stat != 2)
-				if(M.stat == 2)
-					M.death(1)
-					stomach_contents.Remove(M)
-					qdel(M)
-					continue
-				if(mob_master.current_cycle%3==1)
-					if(!(M.status_flags & GODMODE))
-						M.adjustBruteLoss(5)
-					nutrition += 10

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -1,39 +1,5 @@
-/mob/living/carbon/brain/Life()
-	set invisibility = 0
-	//set background = 1
-	..()
-
-	if(stat != DEAD)
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-	var/datum/gas_mixture/environment // Added to prevent null location errors-- TLE
-	if(loc)
-		environment = loc.return_air()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-	blinded = null
-
-	//Handle temperature/pressure differences between body and environment
-	if(environment)	// More error checking -- TLE
-		handle_environment(environment)
-
-	//Status updates, death etc.
-	handle_regular_status_updates()
-	update_canmove()
-
-	if(client)
-		handle_regular_hud_updates()
-
-
 /mob/living/carbon/brain/
-	proc/handle_mutations_and_radiation()
+	handle_mutations_and_radiation()
 
 		if (radiation)
 			if (radiation > 100)
@@ -68,7 +34,7 @@
 					adjustToxLoss(3)
 					updatehealth()
 
-	proc/handle_environment(datum/gas_mixture/environment)
+	handle_environment(datum/gas_mixture/environment)
 		if(!environment)
 			return
 		var/environment_heat_capacity = environment.heat_capacity()
@@ -104,7 +70,7 @@
 
 
 
-	proc/handle_chemicals_in_body()
+	handle_chemicals_in_body()
 
 		if(reagents) reagents.metabolize(src)
 
@@ -120,7 +86,7 @@
 		return //TODO: DEFERRED
 
 
-	proc/handle_regular_status_updates()	//TODO: comment out the unused bits >_>
+	handle_regular_status_updates()	//TODO: comment out the unused bits >_>
 		updatehealth()
 
 		if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
@@ -191,7 +157,7 @@
 		return 1
 
 
-	proc/handle_regular_hud_updates()
+	handle_regular_hud_updates()
 
 		if (stat == 2 || (XRAY in src.mutations))
 			sight |= SEE_TURFS

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -43,26 +43,9 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	var/tinttotal = 0				// Total level of visually impairing items
 
 /mob/living/carbon/human/Life()
-	set invisibility = 0
-	//set background = 1
-
-	if (notransform)	return
-	if(!loc)			return	// Fixing a null error that occurs when the mob isn't found in the world -- TLE
-
-	..()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-	blinded = null
 	fire_alert = 0 //Reset this here, because both breathe() and handle_environment() have a chance to set it.
 	tinttotal = tintcheck() //here as both hud updates and status updates call it
-
-	//TODO: seperate this out
-	// update the current life tick, can be used to e.g. only do something every 4 ticks
 	life_tick++
-	var/datum/gas_mixture/environment = loc.return_air()
 
 	in_stasis = 0
 	if(istype(loc, /obj/structure/closet/body_bag/cryobag))
@@ -71,13 +54,12 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			loc_as_cryobag.used++
 			in_stasis = 1
 
-	if(life_tick % 30 == 15)
+	if(mob_master.current_cycle % 30 == 15)
 		hud_updateflag = 1022
 
 	voice = GetVoice()
 
-	//No need to update all of these procs if the guy is dead.
-	if(stat != DEAD && !in_stasis)
+	if(..() && !in_stasis)
 		if(mob_master.current_cycle % 4 == 2 || failed_last_breath) 	//First, resolve location and get a breath
 			breathe() 				//Only try to take a breath every 4 ticks, unless suffocating
 
@@ -87,43 +69,15 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				location_as_object.handle_internal_lifeform(src, 0)
 
 		if(check_mutations)
-//			testing("Updating [src.real_name]'s mutations: "+english_list(mutations))
 			domutcheck(src,null)
 			update_mutations()
 			check_mutations=0
 
-		//Updates the number of stored chemicals for powers
-		handle_changeling()
-
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
-		//Disabilities
-		handle_disabilities()
-
-		//Random events (vomiting etc)
-		handle_random_events()
-
 		handle_virus_updates()
 
-		//Check if we're on fire
-		handle_fire()
-
-		//Decrease wetness over time
-		handle_wetness()
-
-		//stuff in the stomach
-		handle_stomach()
-
 		handle_shock()
-
 		handle_pain()
-
 		handle_heartbeat()
-
 		handle_heartattack()
 
 		if(!client)
@@ -137,27 +91,11 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000))	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 
-
-	//Handle temperature/pressure differences between body and environment
-	handle_environment(environment)		//Optimized a good bit.
-
-	//Status updates, death etc.
-	handle_regular_status_updates()		//Optimized a bit
-
 	handle_actions()
-
-	update_canmove()
 
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
-
-	handle_regular_hud_updates()
-
 	pulse = handle_pulse()
-
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
 
 	if(mind && mind.vampire)
 		handle_vampire()
@@ -180,7 +118,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		return ONE_ATMOSPHERE - pressure_difference
 
 
-/mob/living/carbon/human/proc/handle_disabilities()
+/mob/living/carbon/human/handle_disabilities()
 	if (disabilities & EPILEPSY)
 		if ((prob(1) && paralysis < 1))
 			visible_message("<span class='danger'>[src] starts having a seizure!</span>","<span class='alert'>You have a seizure!</span>")
@@ -245,7 +183,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		// as cloneloss
 		adjustCloneLoss(0.1)
 
-/mob/living/carbon/human/proc/handle_mutations_and_radiation()
+/mob/living/carbon/human/handle_mutations_and_radiation()
 	if(getFireLoss())
 		if((RESIST_HEAT in mutations) || (prob(1)))
 			heal_organ_damage(0,1)
@@ -450,7 +388,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 	return species.handle_breath(breath, src)
 
-/mob/living/carbon/human/proc/handle_environment(datum/gas_mixture/environment)
+/mob/living/carbon/human/handle_environment(datum/gas_mixture/environment)
 	if(!environment)
 		return
 
@@ -558,11 +496,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		bodytemperature += BODYTEMP_HEATING_MAX
 	return
 //END FIRE CODE
-
-/mob/living/carbon/human/proc/handle_wetness()
-	if(mob_master.current_cycle%20==2) //dry off a bit once every 20 ticks or so
-		wetlevel = max(wetlevel - 1,0)
-	return
 
 	/*
 /mob/living/carbon/human/proc/adjust_body_temperature(current, loc_temp, boost)
@@ -736,7 +669,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 	return covered
 
-/mob/living/carbon/human/proc/handle_chemicals_in_body()
+/mob/living/carbon/human/handle_chemicals_in_body()
 
 	if(reagents)
 		reagents.metabolize(src)
@@ -850,7 +783,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/human/proc/handle_regular_status_updates()
+/mob/living/carbon/human/handle_regular_status_updates()
 
 	if(status_flags & GODMODE)	return 0
 
@@ -958,7 +891,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			if(halloss > 0)
 				adjustHalLoss(-1)
 
-		if(embedded_flag && !(life_tick % 10))
+		if(embedded_flag && !(mob_master.current_cycle % 10))
 			var/list/E
 			E = get_visible_implants(0)
 			if(!E.len)
@@ -1062,7 +995,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 	return 1
 
-/mob/living/carbon/human/proc/handle_regular_hud_updates()
+/mob/living/carbon/human/handle_regular_hud_updates()
 	if(hud_updateflag)
 		handle_hud_list()
 
@@ -1388,7 +1321,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				reset_view(null)
 	return 1
 
-/mob/living/carbon/human/proc/handle_random_events()
+/mob/living/carbon/human/handle_random_events()
 	// Puke if toxloss is too high
 	if(!stat)
 		if (getToxLoss() >= 45 && nutrition > 20)
@@ -1433,7 +1366,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		for (var/ID in virus2)
 			var/datum/disease2/disease/V = virus2[ID]
 			V.cure(src)
-	if(life_tick % 3) //don't spam checks over all objects in view every tick.
+	if(mob_master.current_cycle % 3) //don't spam checks over all objects in view every tick.
 		for(var/obj/effect/decal/cleanable/O in view(1,src))
 			if(istype(O,/obj/effect/decal/cleanable/blood))
 				var/obj/effect/decal/cleanable/blood/B = O
@@ -1464,24 +1397,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			V.dead = 1
 	return
 
-/mob/living/carbon/human/proc/handle_stomach()
-	spawn(0)
-		for(var/mob/living/M in stomach_contents)
-			if(M.loc != src)
-				stomach_contents.Remove(M)
-				continue
-			if(isliving(M) && stat != 2)
-				if(M.stat == 2)
-					M.death(1)
-					stomach_contents.Remove(M)
-					qdel(M)
-					continue
-				if(mob_master.current_cycle%3==1)
-					if(!(M.status_flags & GODMODE))
-						M.adjustBruteLoss(5)
-					nutrition += 10
-
-/mob/living/carbon/human/proc/handle_changeling()
+/mob/living/carbon/human/handle_changeling()
 	if(mind && mind.changeling)
 		mind.changeling.regenerate()
 
@@ -1537,7 +1453,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 /mob/living/carbon/human/proc/handle_pulse()
 
-	if(life_tick % 5) return pulse	//update pulse every 5 life ticks (~1 tick/sec, depending on server load)
+	if(mob_master.current_cycle % 5) return pulse	//update pulse every 5 life ticks (~1 tick/sec, depending on server load)
 
 	if(species && species.flags & NO_BLOOD) return PULSE_NONE //No blood, no pulse.
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -91,8 +91,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000))	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 
-	handle_actions()
-
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
 	pulse = handle_pulse()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -12,3 +12,114 @@
 			if (internals)
 				internals.icon_state = "internal0"
 	return
+
+/mob/living/carbon/Life()
+	set invisibility = 0
+	set background = BACKGROUND_ENABLED
+
+	if(notransform)
+		return
+	if(!loc)
+		return
+	var/datum/gas_mixture/environment = loc.return_air()
+
+	//Handle temperature/pressure differences between body and environment
+	handle_environment(environment)
+
+	//Apparently, the person who wrote this code designed it so that
+	//blinded get reset each cycle and then get activated later in the
+	//code. Very ugly. I dont care. Moving this stuff here so its easy
+	//to find it.
+	blinded = null
+
+	handle_regular_status_updates() // Status updates, death etc.
+
+	if(stat != DEAD)
+
+		//Updates the number of stored chemicals for powers
+		handle_changeling()
+
+		//Mutations and radiation
+		handle_mutations_and_radiation()
+
+		//Chemicals in the body
+		handle_chemicals_in_body()
+
+		//Disabilities
+		handle_disabilities()
+
+		//Random events (vomiting etc)
+		handle_random_events()
+
+		. = 1
+
+	handle_fire()
+
+	//Decrease wetness over time
+	handle_wetness()
+
+	//stuff in the stomach
+	handle_stomach()
+
+	update_canmove()
+
+	update_gravity(mob_has_gravity())
+
+	for(var/obj/item/weapon/grab/G in src)
+		G.process()
+
+	handle_actions()
+
+	if(client)
+		handle_regular_hud_updates()
+
+	return .
+
+
+
+//remember to remove the "proc" of the child procs of these.
+
+/mob/living/carbon/proc/handle_changeling()
+	return
+
+/mob/living/carbon/proc/handle_mutations_and_radiation()
+	return
+
+/mob/living/carbon/proc/handle_chemicals_in_body()
+	return
+
+/mob/living/carbon/proc/handle_disabilities()
+	return
+
+/mob/living/carbon/proc/handle_random_events()
+	return
+
+/mob/living/carbon/proc/handle_environment(var/datum/gas_mixture/environment)
+	return
+
+/mob/living/carbon/proc/handle_regular_status_updates()
+	return
+
+/mob/living/carbon/proc/handle_wetness()
+	if(mob_master.current_cycle%20==2) //dry off a bit once every 20 ticks or so
+		wetlevel = max(wetlevel - 1,0)
+
+/mob/living/carbon/proc/handle_stomach()
+	spawn(0)
+		for(var/mob/living/M in stomach_contents)
+			if(M.loc != src)
+				stomach_contents.Remove(M)
+				continue
+			if(istype(M, /mob/living/carbon) && stat != 2)
+				if(M.stat == 2)
+					M.death(1)
+					stomach_contents.Remove(M)
+					qdel(M)
+					continue
+				if(mob_master.current_cycle%3==1)
+					if(!(M.status_flags & GODMODE))
+						M.adjustBruteLoss(5)
+					nutrition += 10
+
+/mob/living/carbon/proc/handle_regular_hud_updates()
+	return

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -6,45 +6,11 @@
 	var/SStun = 0 // stun variable
 
 /mob/living/carbon/slime/Life()
-	set invisibility = 0
-	//set background = 1
-
-	if (src.notransform)
-		return
-
-	..()
-
-	if(stat != DEAD)
-		//Chemicals in the body
-		handle_chemicals_in_body()
-
+	if(..())
 		handle_nutrition()
-
 		handle_targets()
-
 		if (!ckey)
 			handle_speech_and_mood()
-
-	var/datum/gas_mixture/environment
-	if(src.loc)
-		environment = loc.return_air()
-
-	//Apparently, the person who wrote this code designed it so that
-	//blinded get reset each cycle and then get activated later in the
-	//code. Very ugly. I dont care. Moving this stuff here so its easy
-	//to find it.
-	src.blinded = null
-
-	regular_hud_updates() // Basically just deletes any screen objects :<
-
-	if(environment)
-		handle_environment(environment) // Handle temperature/pressure differences between body and environment
-
-	handle_regular_status_updates() // Status updates, death etc.
-
-	handle_actions()
-
-	handle_wetness()
 
 /mob/living/carbon/slime/proc/AIprocess()  // the master AI process
 
@@ -126,7 +92,7 @@
 
 	AIproc = 0
 
-/mob/living/carbon/slime/proc/handle_environment(datum/gas_mixture/environment)
+/mob/living/carbon/slime/handle_environment(datum/gas_mixture/environment)
 	if(!environment)
 		adjustToxLoss(rand(10,20))
 		return
@@ -141,7 +107,7 @@
 		loc_temp = loc:air_contents.temperature
 	else
 		loc_temp = environment.temperature
-	
+
 	//Account for massive pressure differences
 	if(bodytemperature < (T0C + 5)) // start calculating temperature damage etc
 		if(bodytemperature <= (T0C - 40)) // stun temperature
@@ -154,7 +120,7 @@
 				adjustToxLoss(round(sqrt(bodytemperature)) * 2)
 	else
 		Tempstun = 0
-	
+
 
 	/*moved after the temperature damage code so freeze beams can instantly kill slimes -Deity Link*/
 	if(loc_temp < 310.15) // a cold place
@@ -183,7 +149,7 @@
 	temp_change = (temperature - current)
 	return temp_change
 
-/mob/living/carbon/slime/proc/handle_chemicals_in_body()
+/mob/living/carbon/slime/handle_chemicals_in_body()
 
 	if(reagents) reagents.metabolize(src)
 	if (reagents.get_reagent_amount("plasma")>=5)
@@ -196,7 +162,7 @@
 
 	return //TODO: DEFERRED
 
-/mob/living/carbon/slime/proc/handle_regular_status_updates()
+/mob/living/carbon/slime/handle_regular_status_updates()
 
 	if(is_adult)
 		health = 200 - (getOxyLoss() + getToxLoss() + getFireLoss() + getBruteLoss() + getCloneLoss())
@@ -289,10 +255,6 @@
 		else
 			Evolve()
 
-/mob/living/carbon/slime/proc/handle_wetness()
-	if(mob_master.current_cycle%20==2) //dry off a bit once every 20 ticks or so
-		wetlevel = max(wetlevel - 1,0)
-	return
 
 /mob/living/carbon/slime/proc/handle_targets()
 	if(Tempstun)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -890,11 +890,15 @@
 /mob/living/proc/float(on)
 	if(throwing)
 		return
-	if(on && !floating)
-		animate(src, pixel_y = 2, time = 10, loop = -1)
+	var/fixed = 0
+	if(anchored || (buckled && buckled.anchored))
+		fixed = 1
+	if(on && !floating && !fixed)
+		animate(src, pixel_y = pixel_y + 2, time = 10, loop = -1)
 		floating = 1
-	else if(!on && floating)
-		animate(src, pixel_y = initial(pixel_y), time = 10)
+	else if(((!on || fixed) && floating))
+		var/final_pixel_y = get_standard_pixel_y_offset(lying)
+		animate(src, pixel_y = final_pixel_y, time = 10)
 		floating = 0
 
 /mob/living/proc/can_use_vents()

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -12,6 +12,8 @@
 
 		src.updatehealth()
 
+		update_gravity(mob_has_gravity())
+
 		if (src.malfhack)
 			if (src.malfhack.aidisabled)
 				src << "\red ERROR: APC access disabled, hack attempt canceled."
@@ -174,7 +176,7 @@
 							sleep(50)
 							theAPC = null
 
-	process_queued_alarms()						
+	process_queued_alarms()
 	regular_hud_updates()
 	switch(src.sensor_mode)
 		if (SEC_HUD)
@@ -191,12 +193,12 @@
 			health = 100 - getOxyLoss() - getToxLoss() - getBruteLoss()
 		else
 			health = 100 - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss()
-			
+
 /mob/living/silicon/ai/proc/lacks_power()
 	var/turf/T = get_turf(src)
 	var/area/A = get_area(src)
 	return ((!A.power_equip) && A.requires_power == 1 || istype(T, /turf/space)) && !istype(src.loc,/obj/item)
-	
+
 /mob/living/silicon/ai/rejuvenate()
 	..()
 	add_ai_verbs(src)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -88,10 +88,9 @@
 	return
 
 /mob/living/simple_animal/Life()
-	if(paralysis || stunned || weakened || buckled || resting)
-		canmove = 0
-	else
-		canmove = 1
+
+	update_gravity(mob_has_gravity())
+	update_canmove()
 
 	//Health
 	if(stat == DEAD)
@@ -555,3 +554,27 @@
 		verb = pick(speak_emote)
 
 	return verb
+
+/mob/living/simple_animal/update_canmove()
+	if(paralysis || stunned || weakened || stat || resting)
+		drop_r_hand()
+		drop_l_hand()
+		canmove = 0
+	else if(buckled)
+		canmove = 0
+	else
+		canmove = 1
+	update_transform()
+	return canmove
+
+/mob/living/simple_animal/update_transform()
+	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
+	var/changed = 0
+
+	if(resize != RESIZE_DEFAULT_SIZE)
+		changed++
+		ntransform.Scale(resize)
+		resize = RESIZE_DEFAULT_SIZE
+
+	if(changed)
+		animate(src, transform = ntransform, time = 2, easing = EASE_IN|EASE_OUT)


### PR DESCRIPTION
Does the following:
 - Cleans up how gravity works, a little bit
 - Pushes duplicated procs for slimes/xenos/humans up to carbon/Life()
 - carbon/Life() is now a thing, it handles the non-special stuff for all
   carbons
 - Mob controller no longer ticks a seperate entity, mob_master is now
   just a reference to the mob process, which ticks.