### PR TITLE
PDA Fixes & Retro Tweaks

### DIFF
--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -69,6 +69,14 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				margin: 0 2px 2px 0;
 			}
 			
+			.uiIcon16 {
+				background-image: none;
+				float: left;
+				width: auto;
+				height: auto;
+				margin: 0 0 0 0;
+			}
+			
 			#uiTitleText {
 				color: #000000;
 			}
@@ -307,7 +315,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <H3>Current Conversations</H3>
                 {{for data.convopdas}}
                     <div class="item">
-                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Select Conversation", 'convo' : value.Reference } , null, 'pdalink fixedLeftWider')}}
+                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Select Conversation", 'convo' : value.Reference } , null, 'pdalink')}}
                         {{if data.cartridge}}
                             {{if data.cartridge.access.access_detonate_pda && value.Detonate}}
                                 {{:helper.link('*Detonate*', 'radiation', {'choice' : "Detonate", 'target' : value.Reference}, null, 'pdalink fixedLeft')}}
@@ -324,7 +332,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <H3>Other PDAs</H3>
                 {{for data.pdas}}
                     <div class="item">
-                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Message", 'target' : value.Reference}, null, 'pdalink fixedLeftWider')}}
+                        {{:helper.link(value.Name, 'circle-arrow-s', {'choice' : "Message", 'target' : value.Reference}, null, 'pdalink')}}
                         {{if data.cartridge}}
                             {{if data.cartridge.access.access_detonate_pda && value.Detonate}} {{:helper.link('*Detonate*', 'radiation', {'choice' : "Detonate", 'target' : value.Reference}, null, 'pdalink fixedLeft')}} {{/if}}
                             {{if data.cartridge.access.access_clown}} {{:helper.link('*Send Virus*', 'star', {'choice' : "Send Honk", 'target' : value.Reference}, null, 'pdalink fixedLeft')}} {{/if}}


### PR DESCRIPTION
Fixes #2417

So, this basically removes the UI icons from the retro mode, and makes the messenger menu behave sanely with long names.
Sidenote: I fucking hate the fixedX classes.

![screenshotville](https://puu.sh/kYVEL/d907b4138a.png)
![screenshotville](https://puu.sh/kYVF9/563dcb04a2.png)
![screenshotville](https://puu.sh/kYVFG/73251b235b.png)
![screenshotville](https://puu.sh/kYVHK/eaa0e63cd5.png)

For comparison, old retro messenger screen and icons:
![yah](https://camo.githubusercontent.com/80b704b160ca7094631687917af2e3261c12ea15/68747470733a2f2f7075752e73682f6b577139582f343561653831313262312e706e67)