### PR TITLE
Adds the ability to access game preferences while not in lobby

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -905,7 +905,6 @@ datum/preferences
 	proc/process_link(mob/user, list/href_list)
 		if(!user)	return
 
-		if(!istype(user, /mob/new_player))	return
 		if(href_list["preference"] == "job")
 			switch(href_list["task"])
 				if("close")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -178,7 +178,7 @@
 		src << sound(null, repeat = 0, wait = 0, volume = 0, channel = 1)
 		src << sound(null, repeat = 0, wait = 0, volume = 0, channel = 2)
 	feedback_add_details("admin_verb","Thb") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	
+
 // This needs a toggle because you people are awful and spammed terrible music
 /client/verb/toggle_instruments()
 	set name = "Hear/Silence Instruments"
@@ -191,56 +191,6 @@
 	else
 		src << "You will no longer hear musical instruments."
 	feedback_add_details("admin_verb","TInstru") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-//be special
-/client/verb/toggle_be_special(role in be_special_flags)
-	set name = "Toggle Special Role Candidacy"
-	set category = "Preferences"
-	set desc = "Toggles which special roles you would like to be a candidate for, during events."
-	var/role_flag = be_special_flags[role]
-	if(!role_flag)	return
-	if(!player_old_enough_antag(src,be_special_flags[role]))
-		var/available_in_days_antag = available_in_days_antag(src,be_special_flags[role])
-		src << "<span class='warning'>This role is not yet available to you. You need to wait another [available_in_days_antag] days.</span>"
-		return
-	prefs.be_special ^= role_flag
-	prefs.save_preferences(src)
-	src << "You will [(prefs.be_special & role_flag) ? "now" : "no longer"] be considered for [role] events (where possible)."
-	feedback_add_details("admin_verb","TBeSpecial") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/verb/change_ui()
-	set name = "Change UI"
-	set category = "Preferences"
-	set desc = "Configure your user interface"
-
-	if(!ishuman(usr))
-		usr << "This only for human"
-		return
-
-	var/UI_style_new = input(usr, "Select a style, we recommend White for customization") in list("White", "Midnight", "Orange", "old")
-	if(!UI_style_new) return
-
-	var/UI_style_alpha_new = input(usr, "Select a new alpha (transparency) parameter for UI, between 50 and 255") as num
-	if(!UI_style_alpha_new | !(UI_style_alpha_new <= 255 && UI_style_alpha_new >= 50)) return
-
-	var/UI_style_color_new = input(usr, "Choose your UI color. Dark colors are not recommended!") as color|null
-	if(!UI_style_color_new) return
-
-	//update UI
-	var/list/icons = usr.hud_used.adding + usr.hud_used.other +usr.hud_used.hotkeybuttons
-	icons.Add(usr.zone_sel)
-
-	for(var/obj/screen/I in icons)
-		I.icon = ui_style2icon(UI_style_new)
-		I.color = UI_style_color_new
-		I.alpha = UI_style_alpha_new
-
-	if(alert("Like it? Save changes?",,"Yes", "No") == "Yes")
-		prefs.UI_style = UI_style_new
-		prefs.UI_style_alpha = UI_style_alpha_new
-		prefs.UI_style_color = UI_style_color_new
-		prefs.save_preferences(src)
-		usr << "UI was saved"
 
 /client/verb/toggle_media()
 	set name = "Hear/Silence Streaming"
@@ -255,12 +205,10 @@
 		media.update_music()
 	else
 		media.stop_music()
-		
-/client/verb/toggle_member_publicity()
-	set name = "Toggle Membership Publicity"
+
+/client/verb/setup_character()
+	set name = "Game Preferences"
 	set category = "Preferences"
-	set desc = "Toggles whether other players can see that you are a BYOND member (OOC blag icon/colours)."
-	
-	prefs.toggles ^= MEMBER_PUBLIC
-	prefs.save_preferences(src)
-	src << "Others can[(prefs.toggles & MEMBER_PUBLIC) ? "" : " not"] see whether you are a BYOND member."
+	set desc = "Allows you to access the Setup Character screen. Changes to your character won't take effect until next round, but other changes will."
+	prefs.current_tab = 1
+	prefs.ShowChoices(usr)


### PR DESCRIPTION
tgstation/-tg-station#12672
> Also removed a few preferences_toggles verbs that are no longer needed.

> Haven't tested this too much yet, but from what I can tell, no ill effects of doing this have been observed.

Basically, allows you to access the lobby menu in-game; It's probably fine.
![way](https://puu.sh/kZA8C/66232d9322.png)

More from the -tg- PR;
> Changes to your character won't take effect until after you've respawned (if admins enable it) or round restarts.

> Changes to the ui scheme take effect next time you change mobs or reconnect.

> Changes to your ghost sprite won't take effect until the next time you reconnect or you re-enter/re-leave body.

> Everything else takes effect immediately