### PR TITLE
Removes Slime Blood Slipping

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -182,7 +182,6 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 	if(src.species.bloodflags &BLOOD_SLIME)
 		vessel.remove_reagent("water",amm)
-		vessel.reaction(T, TOUCH, amm)
 		return
 
 	else

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -178,7 +178,6 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 		return
 
 	var/amm = 0.1 * amt
-	var/turf/T = get_turf(src)
 
 	if(src.species.bloodflags &BLOOD_SLIME)
 		vessel.remove_reagent("water",amm)


### PR DESCRIPTION
Removes slime's dripping actual water onto turfs.

It's frustrating when slimes slip on their own blood when they're being attacked and it's just as frustrating when fighting against a slime---either case it can generated very very one-sided fights for both sides as the slip pretty much means death.

Giving slimes slip immunity to everything (or even just water), but lube just because of this is feature would be a massive powerspike for slime people, so that's not a good way to balance this feature out.