### PR TITLE
Critical fix: Simple_animal invincibility.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -69,7 +69,7 @@
 		health = maxHealth
 		stat = CONSCIOUS
 		return
-	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - halloss
+	health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss()
 
 
 //This proc is used for mobs which are affected by pressure to calculate the amount of pressure that actually

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -87,9 +87,11 @@
 	..()
 
 /mob/living/simple_animal/updatehealth()
-	return
+	..()
+	health = Clamp(health, 0, maxHealth)
 
 /mob/living/simple_animal/Life()
+	updatehealth()
 
 	update_gravity(mob_has_gravity())
 	update_canmove()
@@ -106,9 +108,6 @@
 
 	if(health < 1)
 		Die()
-
-	if(health > maxHealth)
-		health = maxHealth
 
 	if(resting && icon_resting && stat != DEAD)
 		icon_state = icon_resting


### PR DESCRIPTION
Also removes Halloss from updatehealth() calculations, it doesn't belong
there, and halloss is deprecated regardless.

Fixes #2463 