### PR TITLE
Bloody Mess Fix

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -158,9 +158,9 @@
 
 					M.take_organ_damage(power)
 					if (prob(33)) // Added blood for whacking non-humans too
-						var/turf/location = M.loc
+						var/turf/simulated/location = M.loc
 						if (istype(location, /turf/simulated))
-							location:add_blood_floor(M)
+							location.add_blood_floor(M)
 			if("fire")
 				if (!(RESIST_COLD in M.mutations))
 					M.take_organ_damage(0, power)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -266,9 +266,9 @@
 			L.Weaken(5)
 		else //for simple_animals & borgs
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-		var/turf/location = src.loc
+		var/turf/simulated/location = src.loc
 		if(istype(location, /turf/simulated)) //add_blood doesn't work for borgs/xenos, but add_blood_floor does.
-			location.add_blood(L)
+			location.add_blood_floor(L)
 
 /obj/machinery/door/proc/requiresID()
 	return 1

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -149,6 +149,8 @@
 
 // Only adds blood on the floor -- Skie
 /turf/simulated/proc/add_blood_floor(mob/living/carbon/M as mob)
+	if(ishuman(M))
+		blood_splatter(src,M,1)
 	if( istype(M, /mob/living/carbon/alien ))
 		var/obj/effect/decal/cleanable/blood/xeno/this = new /obj/effect/decal/cleanable/blood/xeno(src)
 		this.blood_DNA["UNKNOWN BLOOD"] = "X*"


### PR DESCRIPTION
So...I wondered why not very much blood was actually being generated in fights--particularly those involving items...turns out, well...something was changed.

Basically when blood was overhauled to be species based, bloodying turfs was generally moved from add_blood_floor to add_blood. *generally* this was fine, but there were a few exceptions to this that caused issue:

- Hitting someone with items
- Getting door crushed
- Getting hit by a nettle

These all generally involve more than just humans...2 of them used add_blood_floor(), meaning that using those items didn't generate blood when utilized with humans (items and nettles), and one of them uses add_blood(), meaning xenos and borgs were left out of mess making (door crushing).