### PR TITLE
Adds a t-ray scanner to the drone's equipment set

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -471,6 +471,7 @@
 	src.modules += new /obj/item/weapon/matter_decompiler(src)
 	src.modules += new /obj/item/weapon/reagent_containers/spray/cleaner/drone(src)
 	src.modules += new /obj/item/weapon/soap(src)
+	src.modules += new /obj/item/device/t_scanner(src)
 
 	src.emag = new /obj/item/weapon/pickaxe/drill/cyborg/diamond(src)
 


### PR DESCRIPTION
Without a scanner, drones were limited to finding wiring problems with just a crowbar and wild guessing. Now they have a t-ray scanner, so they know where to find broken parts of the station.