### PR TITLE
Swarmer Event Hotfix

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -170,7 +170,7 @@ var/list/event_last_fired = list()
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Flux Anomaly",				/datum/event/anomaly/anomaly_flux,		50,		list(ASSIGNMENT_ENGINEER = 50)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Gravitational Anomaly",	/datum/event/anomaly/anomaly_grav,		200),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Revenant", 				/datum/event/revenant, 					150),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Swarmer Spawn", 			/datum/event/spawn_swarmer, 			150, list(ASSIGNMENT_ANY = 100), 1)
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Swarmer Spawn", 			/datum/event/spawn_swarmer, 			150, is_one_shot = 1)
 	)
 
 /datum/event_container/major


### PR DESCRIPTION
Makes it so that the swarmer event doesn't have a weight of `150+(100*number of players)` (yes, this meant that if there were 80 players, the weight of having swarmers was 8150).

This was an oversight; @Aurorablade intended for it to have the same weight as Revenants, but only occur once.

That said, the event manager is obtuse as hell and how to properly use and configure it with the proper arguments and such is effectively scattered over 3-4 different files, so...can't really blame you, @Aurorablade.

