### PR TITLE
Fixes #2474

### DIFF
--- a/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
@@ -227,6 +227,9 @@
 /obj/item/stack/cable_coil/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)//Wiring would be too effective as a resource
 	S << "<span class='warning'>This object does not contain enough materials to work with.</span>"
 
+/obj/item/weapon/circuitboard/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	S << "<span class='warning'>This object does not contain enough materials to work with.</span>"
+
 /obj/machinery/porta_turret/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	S << "<span class='warning'>Attempting to dismantle this machine would result in an immediate counterattack. Aborting.</span>"
 
@@ -324,7 +327,8 @@
 			var/obj/machinery/computer/C = target
 			if(C.circuit)
 				var/obj/item/weapon/circuitboard/circuit = text2path(C.circuit)
-				new circuit(get_turf(M))
+				if(circuit != null)
+					new circuit(get_turf(M))
 		qdel(target)
 
 


### PR DESCRIPTION
fixes https://github.com/ParadiseSS13/Paradise/issues/2474
Swarmers cannot eat circuits now
Also added a null check on making circuits as a few computers on the bridge were run timing on me about the circuit being a null object.
If your interested heres the list:
Station Alert (all/bridge)
Bridge power monitor
Mining shuttle control
ID computer
Research shuttle
Supply
Engie Shuttle