### PR TITLE
Adds Custom Strip Delays

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -124,7 +124,8 @@
 	icon_state = "earmuffs"
 	item_state = "earmuffs"
 	flags = EARBANGPROTECT
-
+	strip_delay = 15
+	put_on_delay = 25
 
 //Glasses
 /obj/item/clothing/glasses
@@ -139,7 +140,8 @@
 	var/invisa_view = 0
 	var/flash_protect = 0		//Mal: What level of bright light protection item has. 1 = Flashers, Flashes, & Flashbangs | 2 = Welding | -1 = OH GOD WELDING BURNT OUT MY RETINAS
 	var/tint = 0				//Mal: Sets the item's level of visual impairment tint, normally set to the same as flash_protect
-								//	   but seperated to allow items to protect but not impair vision, like space helmets
+	strip_delay = 20			//	   but seperated to allow items to protect but not impair vision, like space helmets
+	put_on_delay = 25
 	species_restricted = list("exclude","Kidan")
 /*
 SEE_SELF  // can see self, no matter what
@@ -165,6 +167,8 @@ BLIND     // can't see anything
 	var/transfer_prints = FALSE
 	var/pickpocket = 0 //Master pickpocket?
 	var/clipped = 0
+	strip_delay = 20
+	put_on_delay = 40
 	species_restricted = list("exclude","Unathi","Tajaran","Wryn")
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -264,6 +268,8 @@ BLIND     // can't see anything
 	var/adjusted_flags = null
 	var/flash_protect = 0
 	var/tint = 0
+	strip_delay = 40
+	put_on_delay = 40
 
 //Proc that moves gas/breath masks out of the way
 /obj/item/clothing/mask/proc/adjustmask(var/mob/user)
@@ -347,6 +353,8 @@ BLIND     // can't see anything
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude","Diona","Vox","Wryn")
 	flash_protect = 2
+	strip_delay = 50
+	put_on_delay = 50
 
 /obj/item/clothing/suit/space
 	name = "Space suit"
@@ -366,6 +374,8 @@ BLIND     // can't see anything
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	heat_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
+	strip_delay = 80
+	put_on_delay = 80
 	siemens_coefficient = 0.9
 	species_restricted = list("exclude","Diona","Vox","Wryn")
 

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -3,6 +3,7 @@
 	desc = "Because you really needed another excuse to punch your crewmates."
 	icon_state = "boxing"
 	item_state = "boxing"
+	put_on_delay = 60
 	species_restricted = null
 
 /obj/item/clothing/gloves/boxing/green

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -167,3 +167,4 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	strip_delay = 60

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -8,6 +8,8 @@
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	species_restricted = null
+	strip_delay = 40
+	put_on_delay = 20
 
 /obj/item/clothing/gloves/cyborg
 	desc = "beep boop borp"
@@ -23,6 +25,7 @@
 	item_state = "swat_gl"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
+	strip_delay = 80
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -10,6 +10,7 @@
 	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
+	strip_delay = 60
 	siemens_coefficient = 0.7
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -65,6 +66,7 @@
 	armor = list(melee = 82, bullet = 15, laser = 5,energy = 5, bomb = 5, bio = 2, rad = 0)
 	flags_inv = HIDEEARS
 	siemens_coefficient = 0.7
+	strip_delay = 80
 
 /obj/item/clothing/head/helmet/swat
 	name = "\improper SWAT helmet"
@@ -79,6 +81,7 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	siemens_coefficient = 0.5
+	strip_delay = 80
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/head.dmi'
@@ -102,6 +105,7 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	siemens_coefficient = 1
+	strip_delay = 80
 
 /obj/item/clothing/head/helmet/roman
 	name = "roman helmet"
@@ -110,6 +114,7 @@
 	armor = list(melee = 25, bullet = 0, laser = 25, energy = 10, bomb = 10, bio = 0, rad = 0)
 	icon_state = "roman"
 	item_state = "roman"
+	strip_delay = 100
 
 /obj/item/clothing/head/helmet/roman/legionaire
 	name = "roman legionaire helmet"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -7,6 +7,8 @@
 	item_state = "chef"
 	desc = "The commander in chef's head wear."
 	siemens_coefficient = 0.9
+	strip_delay = 10
+	put_on_delay = 10
 
 //Captain
 /obj/item/clothing/head/caphat
@@ -16,6 +18,7 @@
 	item_state = "caphat"
 	siemens_coefficient = 0.9
 	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
+	strip_delay = 60
 
 //Captain: no longer space-worthy
 /obj/item/clothing/head/caphat/parade
@@ -75,6 +78,7 @@
 	desc = "The robust standard-issue cap of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
 	armor = list(melee = 80, bullet = 60, laser = 50, energy = 10, bomb = 25, bio = 10, rad = 0)
+	strip_delay = 80
 
 /obj/item/clothing/head/HoS/beret
 	name = "head of security beret"
@@ -86,6 +90,7 @@
 	desc = "It's a special armored hat issued to the Warden of a security force. Protects the head from impacts."
 	icon_state = "policehelm"
 	armor = list(melee = 60, bullet = 5, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)
+	strip_delay = 60
 
 /obj/item/clothing/head/customs
 	name = "customs officer's hat"
@@ -99,6 +104,7 @@
 	desc = "A beret with the security insignia emblazoned on it. For officers that are more inclined towards style than safety."
 	icon_state = "beret_badge"
 	armor = list(melee = 30, bullet = 25, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
+	strip_delay = 60
 
 /obj/item/clothing/head/beret/sec/warden
 	name = "warden's beret"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -7,6 +7,7 @@
 	item_state = "centhat"
 	armor = list(melee = 50, bullet = 15, laser = 50, energy = 10, bomb = 25, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
+	strip_delay = 80
 
 /obj/item/clothing/head/hairflower
 	name = "hair flower pin"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -92,6 +92,7 @@
 	icon_state = "secsoft"
 	item_color = "sec"
 	armor = list(melee = 30, bullet = 25, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
+	strip_delay = 60
 
 /obj/item/clothing/head/soft/sec/corp
 	name = "corporate security cap"

--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -25,6 +25,7 @@
 	icon_state = "medical"
 	item_state = "medical"
 	permeability_coefficient = 0.01
+	put_on_delay = 10
 	species_fit = list("Vox")
 
 /obj/item/clothing/mask/breath/vox

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -92,6 +92,7 @@
 	desc = "A close-fitting tactical mask that can be connected to an air supply."
 	icon_state = "swat"
 	siemens_coefficient = 0.7
+	strip_delay = 60
 	species_fit = list("Vox")
 
 /obj/item/clothing/mask/gas/clown_hat
@@ -219,7 +220,7 @@
 	icon_state = "officermask"
 	aggressiveness = 3
 	ignore_maskadjust = 1
-	
+
 /obj/item/clothing/mask/gas/sechailer/blue
 	name = "\improper blue SWAT mask"
 	desc = "A neon blue swat mask, used for demoralizing Greytide in the wild."

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -6,6 +6,7 @@
 	flags = MASKCOVERSMOUTH
 	w_class = 2
 	gas_transfer_coefficient = 0.90
+	put_on_delay = 20
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/mask.dmi'

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -6,6 +6,8 @@
 	var/magpulse = 0
 	var/slowdown_active = 2
 	action_button_name = "Toggle Magboots"
+	strip_delay = 70
+	put_on_delay = 70
 	species_restricted = null
 
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -25,6 +25,7 @@
 	armor = list(melee = 50, bullet = 50, laser = 50, energy = 25, bomb = 50, bio = 10, rad = 0)
 	species_restricted = null //Syndicate tech means even Tajarans can kick ass with these
 	siemens_coefficient = 0.6
+	strip_delay = 70
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "\improper SWAT shoes"
@@ -37,6 +38,8 @@
 	desc = "A pair of rather plain, wooden sandals."
 	name = "sandals"
 	icon_state = "wizard"
+	strip_delay = 50
+	put_on_delay = 50
 	species_restricted = null
 
 /obj/item/clothing/shoes/sandal/marisa
@@ -51,6 +54,8 @@
 	permeability_coefficient = 0.05
 	flags = NOSLIP
 	slowdown = SHOES_SLOWDOWN+1
+	strip_delay = 50
+	put_on_delay = 50
 	species_restricted = null
 
 /obj/item/clothing/shoes/clown_shoes
@@ -82,6 +87,8 @@
 	item_state = "jackboots"
 	item_color = "hosred"
 	siemens_coefficient = 0.7
+	strip_delay = 50
+	put_on_delay = 50
 	var/footstep = 1
 
 /obj/item/clothing/shoes/jackboots/step_action(var/mob/living/carbon/human/H)
@@ -139,12 +146,15 @@
 	name = "laceup shoes"
 	desc = "The height of fashion, and they're pre-polished!"
 	icon_state = "laceups"
+	put_on_delay = 50
 
 /obj/item/clothing/shoes/roman
 	name = "roman sandals"
 	desc = "Sandals with buckled leather straps on it."
 	icon_state = "roman"
 	item_state = "roman"
+	strip_delay = 100
+	put_on_delay = 100
 	species_restricted = null
 
 /obj/item/clothing/shoes/centcom

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -8,6 +8,7 @@
 	siemens_coefficient = 0.6
 	rig_restrict_helmet = 0 // ERT helmets can be taken on and off at will.
 	var/obj/machinery/camera/camera
+	strip_delay = 130
 
 /obj/item/clothing/head/helmet/space/rig/ert/attack_self(mob/user)
 	if(camera)
@@ -37,6 +38,7 @@
 	/obj/item/device/radio, /obj/item/device/analyzer, /obj/item/weapon/gun/energy/laser, /obj/item/weapon/gun/energy/pulse_rifle, \
 	/obj/item/weapon/gun/energy/advtaser, /obj/item/weapon/melee/baton, /obj/item/weapon/gun/energy/gun)
 	siemens_coefficient = 0.6
+	strip_delay = 130
 
 //Commander
 /obj/item/clothing/head/helmet/space/rig/ert/commander

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -48,6 +48,7 @@
 	vision_flags = SEE_MOBS
 	see_darkness = 0
 	HUDType = MEDHUD
+	strip_delay = 130
 
 /obj/item/clothing/suit/space/deathsquad
 	name = "deathsquad suit"
@@ -59,6 +60,7 @@
 	slowdown = 1
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	unacidable = 1
+	strip_delay = 130
 
 /obj/item/clothing/head/helmet/space/deathsquad/beret
 	name = "officer's beret"
@@ -103,6 +105,8 @@
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	flags = HEADCOVERSEYES | BLOCKHAIR | STOPSPRESSUREDMAGE
 	siemens_coefficient = 0.9
+	strip_delay = 40
+	put_on_delay = 20
 
 /obj/item/clothing/suit/space/pirate
 	name = "pirate coat"
@@ -114,7 +118,8 @@
 	slowdown = 0
 	armor = list(melee = 60, bullet = 50, laser = 30,energy = 15, bomb = 30, bio = 30, rad = 30)
 	siemens_coefficient = 0.9
-
+	strip_delay = 40
+	put_on_delay = 20
 
 //Paramedic EVA suit
 /obj/item/clothing/head/helmet/space/eva/paramedic
@@ -174,7 +179,7 @@
 	desc = "An EVA suit specifically designed for the clown. SPESSHONK!"
 	icon_state = "spaceclown_suit"
 	item_state = "spaceclown_items"
-	
+
 /obj/item/clothing/head/helmet/space/freedom
 	name = "eagle helmet"
 	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle."
@@ -183,6 +188,7 @@
 	armor = list(melee = 40, bullet = 40, laser = 30, energy = 25, bomb = 100, bio = 100, rad = 100)
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	unacidable = 1
+	strip_delay = 130
 
 /obj/item/clothing/suit/space/freedom
 	name = "eagle suit"
@@ -194,3 +200,4 @@
 	slowdown = 1
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	unacidable = 1
+	strip_delay = 130

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -7,6 +7,8 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	siemens_coefficient = 0.6
+	strip_delay = 60
+	put_on_delay = 40
 
 /obj/item/clothing/suit/armor/vest
 	name = "armor"
@@ -38,13 +40,13 @@
 	desc = "An armored vest that protects against some damage. This one has Nanotrasen corporate badge."
 	icon_state = "armorsec"
 	item_state = "armor"
-	
+
 /obj/item/clothing/suit/armor/vest/blueshield
 	name = "blueshield security armor"
 	desc = "An armored vest with the badge of a Blueshield Lieutenant."
 	icon_state = "blueshield"
 	item_state = "blueshield"
-	
+
 /obj/item/clothing/suit/armor/vest/bloody
 	name = "bloodied security armor"
 	desc = "A vest drenched in the blood of Greytide. It has seen better days."
@@ -62,6 +64,7 @@
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	siemens_coefficient = 0.6
+	strip_delay = 80
 
 /obj/item/clothing/suit/armor/hos/alt
 	name = "armored trenchoat"
@@ -103,6 +106,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|HANDS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|HANDS
+	strip_delay = 70
 
 /obj/item/clothing/suit/armor/vest/warden/alt
 	name = "warden's jacket"
@@ -129,7 +133,8 @@
 	armor = list(melee = 80, bullet = 10, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 	siemens_coefficient = 0.5
-
+	strip_delay = 80
+	put_on_delay = 60
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "Bulletproof Vest"
@@ -139,6 +144,8 @@
 	blood_overlay_type = "armor"
 	armor = list(melee = 25, bullet = 80, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
 	siemens_coefficient = 0.7
+	strip_delay = 70
+	put_on_delay = 50
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "Ablative Armor Vest"

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -24,7 +24,8 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	siemens_coefficient = 0.9
-
+	strip_delay = 70
+	put_on_delay = 70
 
 //Standard biosuit, orange stripe
 /obj/item/clothing/head/bio_hood/general
@@ -80,3 +81,5 @@
 	desc = "It protected doctors from the Black Death, back then. You bet your arse it's gonna help you against viruses."
 	icon_state = "plaguedoctor"
 	item_state = "bio_suit"
+	strip_delay = 40
+	put_on_delay = 20

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -241,6 +241,7 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	flags = ONESIZEFITSALL
+	strip_delay = 60
 
 /obj/item/clothing/suit/ianshirt
 	name = "worn shirt"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -26,7 +26,8 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-
+	strip_delay = 60
+	put_on_delay = 60
 
 /obj/item/clothing/suit/fire/firefighter
 	icon_state = "firesuit"
@@ -63,7 +64,8 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-
+	strip_delay = 70
+	put_on_delay = 70
 
 /obj/item/clothing/suit/bomb_suit
 	name = "bomb suit"
@@ -83,7 +85,8 @@
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
 	siemens_coefficient = 0
-
+	strip_delay = 70
+	put_on_delay = 70
 
 /obj/item/clothing/head/bomb_hood/security
 	icon_state = "bombsuitsec"
@@ -104,6 +107,8 @@
 	desc = "A hood with radiation protective properties. Label: Made with lead, do not eat insulation"
 	flags = HEADCOVERSEYES|HEADCOVERSMOUTH|BLOCKHAIR|THICKMATERIAL
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 100)
+	strip_delay = 60
+	put_on_delay = 60
 
 /obj/item/clothing/suit/radiation
 	name = "Radiation suit"
@@ -119,3 +124,5 @@
 	slowdown = 1.5
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 60, rad = 100)
 	flags_inv = HIDEJUMPSUIT|HIDETAIL
+	strip_delay = 60
+	put_on_delay = 60

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -8,6 +8,8 @@
 	unacidable = 1
 	//Not given any special protective value since the magic robes are full-body protection --NEO
 	siemens_coefficient = 0.8
+	strip_delay = 50
+	put_on_delay = 50
 
 /obj/item/clothing/head/wizard/red
 	name = "red wizard hat"
@@ -62,6 +64,8 @@
 	flags_inv = HIDEJUMPSUIT
 	unacidable = 1
 	siemens_coefficient = 0.8
+	strip_delay = 50
+	put_on_delay = 50
 
 /obj/item/clothing/suit/wizrobe/red
 	name = "red wizard robe"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -18,6 +18,7 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags = ONESIZEFITSALL
 	siemens_coefficient = 0.9
+	strip_delay = 50
 
 /obj/item/clothing/under/rank/security
 	name = "security officer's jumpsuit"
@@ -28,6 +29,7 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags = ONESIZEFITSALL
 	siemens_coefficient = 0.9
+	strip_delay = 50
 
 /obj/item/clothing/under/rank/dispatch
 	name = "dispatcher's uniform"
@@ -71,6 +73,7 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags = ONESIZEFITSALL
 	siemens_coefficient = 0.9
+	strip_delay = 50
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/uniform.dmi'
@@ -88,6 +91,7 @@
 	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	flags = ONESIZEFITSALL
 	siemens_coefficient = 0.8
+	strip_delay = 60
 
 /obj/item/clothing/under/rank/head_of_security/corp
 	icon_state = "hos_corporate"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -11,7 +11,7 @@
 	icon_state = "blue_pyjamas"
 	item_color = "blue_pyjamas"
 	item_state = "w_suit"
-	
+
 /obj/item/clothing/under/patriotsuit
 	name = "Patriotic Suit"
 	desc = "Motorcycle not included."
@@ -466,6 +466,7 @@
 	icon_state = "roman"
 	item_color = "roman"
 	item_state = "armor"
+	strip_delay = 100
 
 /obj/item/clothing/under/maid
 	name = "maid costume"


### PR DESCRIPTION
I intended to do this shortly after the TG inventory port, but never got around to it.

Basically, TG's inventory port allows you to set custom strip times for items, as well as put on delays.


This ports over TG's strip and put on values for items.

Generally speaking, the more bulky, armored, and complex a piece of clothing is, the longer it takes to strip off of and put on someone.