### PR TITLE
Singularity does not throw items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -499,10 +499,7 @@
 			A.blood_overlay = image(I)
 
 /obj/item/singularity_pull(S, current_size)
-	spawn(0) //this is needed or multiple items will be thrown sequentially and not simultaneously
-		if(current_size >= STAGE_FOUR)
-			throw_at(S,14,3)
-		else ..()
+	return
 
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -498,7 +498,7 @@
 		if(A.type == type && !A.blood_overlay)
 			A.blood_overlay = image(I)
 
-/obj/item/singularity_pull(S, current_size)
+/obj/item/singularity_pull()
 	return
 
 /obj/item/proc/pwr_drain()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -498,9 +498,6 @@
 		if(A.type == type && !A.blood_overlay)
 			A.blood_overlay = image(I)
 
-/obj/item/singularity_pull()
-	return
-
 /obj/item/proc/pwr_drain()
 	return 0 // Process Kill
 


### PR DESCRIPTION
While I loved the concept, i hate the fact that it's the most resource intensive part of the singularity, just 2 rounds ago, a supermatter singularity was born, and then it ate at 40 chickens, before throwing 10-20 items at them. So yes, remove this to make singularity less resource intensive.