### PR TITLE
Fixes broken hunter pounce caused by armor change

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -96,7 +96,11 @@
 		if(istype(A, /mob/living))
 			var/mob/living/L = A
 			L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
-			apply_effect(5, WEAKEN, run_armor_check("chest", "melee"))
+			if(ishuman(L))
+				var/mob/living/carbon/human/H = L
+				H.apply_effect(5, WEAKEN, H.run_armor_check(null, "melee"))
+			else
+				L.Weaken(5)
 			sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 			step_towards(src,L)
 


### PR DESCRIPTION
- Fixes pounce not stunning people (introduced in #2487).
- Makes pounce use the target's average armor rather than their chest armor. As a result, sec officers only wearing an armored vest and helmet won't block over half of the stun (should be around 20% now), and also slightly decreases (by about 5%) the armor mitigation a person in a full suit of riot armor has.