### PR TITLE
Food Recipe Changes

### DIFF
--- a/code/modules/food/recipes_grill.dm
+++ b/code/modules/food/recipes_grill.dm
@@ -154,3 +154,65 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Unagi
 
+/datum/recipe/grill/sushi_Ebi
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/weapon/reagent_containers/food/snacks/boiled_shrimp,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Ebi
+
+/datum/recipe/grill/sushi_Ikura
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/fish_eggs/salmon,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Ikura
+
+/datum/recipe/grill/sushi_Inari
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/weapon/reagent_containers/food/snacks/fried_tofu,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Inari
+
+/datum/recipe/grill/sushi_Sake
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/weapon/reagent_containers/food/snacks/salmonmeat,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Sake
+
+/datum/recipe/grill/sushi_SmokedSalmon
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/weapon/reagent_containers/food/snacks/salmonsteak,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_SmokedSalmon
+
+/datum/recipe/grill/sushi_Masago
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/fish_eggs/goldfish,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Masago
+
+/datum/recipe/grill/sushi_Tobiko
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/fish_eggs/shark,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Tobiko
+
+/datum/recipe/grill/sushi_TobikoEgg
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/sushi_Tobiko,
+		/obj/item/weapon/reagent_containers/food/snacks/egg,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_TobikoEgg
+
+/datum/recipe/grill/sushi_Tai
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/boiledrice,
+		/obj/item/weapon/reagent_containers/food/snacks/catfishmeat,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sushi_Tai

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -327,6 +327,15 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/fishandchips
 
+/datum/recipe/microwave/sandwich
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/meatsteak,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+		/obj/item/weapon/reagent_containers/food/snacks/cheesewedge,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/sandwich
+
 /datum/recipe/microwave/toastedsandwich
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/sandwich
@@ -445,6 +454,20 @@
 	fruit = list("apple" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candiedapple
 
+/datum/recipe/microwave/slimeburger
+	reagents = list("slimejelly" = 5)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/bun
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellyburger/slime
+
+/datum/recipe/microwave/jellyburger
+	reagents = list("cherryjelly" = 5)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/bun
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellyburger/cherry
+
 /datum/recipe/microwave/twobread
 	reagents = list("wine" = 5)
 	items = list(
@@ -452,6 +475,22 @@
 		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/twobread
+
+datum/recipe/microwave/slimesandwich
+	reagents = list("slimejelly" = 5)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/slime
+
+/datum/recipe/microwave/cherrysandwich
+	reagents = list("cherryjelly" = 5)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/cherry
 
 /datum/recipe/microwave/bloodsoup
 	reagents = list("blood" = 10)
@@ -518,7 +557,38 @@
 	fruit = list("whitebeet" = 1, "cabbage" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/beetsoup
 
+/datum/recipe/microwave/herbsalad
+	fruit = list("ambrosia" = 3, "apple" = 1)
+	result = /obj/item/weapon/reagent_containers/food/snacks/herbsalad
+	make_food(var/obj/container as obj)
+		var/obj/item/weapon/reagent_containers/food/snacks/herbsalad/being_cooked = ..(container)
+		being_cooked.reagents.del_reagent("toxin")
+		return being_cooked
+
+/datum/recipe/microwave/aesirsalad
+	fruit = list("ambrosiadeus" = 3, "goldapple" = 1)
+	result = /obj/item/weapon/reagent_containers/food/snacks/aesirsalad
+
+/datum/recipe/microwave/validsalad
+	fruit = list("ambrosia" = 3, "potato" = 1)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/meatball,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/validsalad
+	make_food(var/obj/container as obj)
+		var/obj/item/weapon/reagent_containers/food/snacks/validsalad/being_cooked = ..(container)
+		being_cooked.reagents.del_reagent("toxin")
+		return being_cooked
+
 ////////////////////////////FOOD ADDITTIONS///////////////////////////////
+
+/datum/recipe/microwave/wrap
+	reagents = list("soysauce" = 10)
+	fruit = list("cabbage" = 1)
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/friedegg,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/wrap
 
 /datum/recipe/microwave/beans
 	reagents = list("ketchup" = 5)
@@ -548,6 +618,14 @@
 		/obj/item/weapon/reagent_containers/food/snacks/icecream,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich
+
+/datum/recipe/microwave/notasandwich
+	items = list(
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+		/obj/item/clothing/mask/fakemoustache,
+	)
+	result = /obj/item/weapon/reagent_containers/food/snacks/notasandwich
 
 /datum/recipe/microwave/friedbanana
 	reagents = list("sugar" = 10, "cornoil" = 5)


### PR DESCRIPTION
@FalseIncarnate 

Adds all the table recipes to either the microwave or the grill. Table recipes will still remain, but they won't be the only way to make something.

Why do this? Pretty simple really; time and resources.

Simply put, a chef's life is a pretty hard one--it's difficult enough to keep up with food production of a 40-50-100 crew station....then you have tablecrafting. While I won't deny it's more realistic and neat, it's insanely time consuming, and you can never get more than one item off of production, like you can the microwave...likewise, you can't exactly...upgrade tables, anyway.

Either cases, this re-adds a number of the recipes (mostly sandwhiches) to the microwave and adds the sushi recipes to the grill.

This allows for more efficient use of time (not just standing at the table and clicking repeatedly to make the table recipe), but also allows it to benefit from upgraded kitchen equipment.