### PR TITLE
Decloner Tweak

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -44,9 +44,9 @@
 /obj/item/projectile/energy/declone
 	name = "declone"
 	icon_state = "declone"
-	damage = 40
+	damage = 20
 	damage_type = CLONE
-	irradiate = 40
+	irradiate = 10
 
 
 /obj/item/projectile/energy/dart


### PR DESCRIPTION
So, a very long time ago when we went from old style energy beams with super long cooldown between shots to what we currently have....a lot of damage values got lowered so they weren't completely ridiculous.

Either case, this was forgotten; the decloner.

Right now it deals an insane 40 clone damage, which is only curable by cryo, but can also disable limbs and irradiates for 40 rads. Two to three shots from this, and you're dead. 

This tweaks it to have damage in line with laser guns and its irradate values lowered. it'll still be insanely good, by virtue of its damage type and crowd control.