### PR TITLE
Fixed buckling problems

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -31,7 +31,7 @@
 
 //procs that handle the actual buckling and unbuckling
 /atom/movable/proc/buckle_mob(mob/living/M)
-	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || M.buckled_mob || (buckle_requires_restraints && !M.restrained()) || M == src)
+	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || buckled_mob || (buckle_requires_restraints && !M.restrained()) || M == src)
 		return 0
 
 	if (isslime(M) || isAI(M))
@@ -83,6 +83,7 @@
 				"<span class='warning'>[user] buckles [M] to [src]!</span>",\
 				"<span class='warning'>[user] buckles you to [src]!</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
+		return 1
 
 /atom/movable/proc/user_unbuckle_mob(mob/user)
 	var/mob/living/M = unbuckle_mob()


### PR DESCRIPTION
This fixes a couple issues that buckling was having.
* Being able to buckle multiple people, there being no way to unbuckle if you weren't the last person.
 * This was due to the buckle_mob proc checking if the *mob* had a mob buckled to it, instead of the furniture.
* The user buckling themself and getting "You need your hands and legs free for this." afterward.
 * This was due to user_buckle_mob not returning true on success, despite the caller assuming as such. Thus, the structure code thought you were trying to climb it or something.

Fixes #2418