### PR TITLE
A change to the buckling fix

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -31,7 +31,7 @@
 
 //procs that handle the actual buckling and unbuckling
 /atom/movable/proc/buckle_mob(mob/living/M)
-	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || buckled_mob || (buckle_requires_restraints && !M.restrained()) || M == src)
+	if(!can_buckle || !istype(M) || (M.loc != loc) || M.buckled || M.buckled_mob || buckled_mob || (buckle_requires_restraints && !M.restrained()) || M == src)
 		return 0
 
 	if (isslime(M) || isAI(M))


### PR DESCRIPTION
I didn't realize in #2505 that mobs can be buckled to other mobs. Thus, I added the other check to also see if the mob, that is being buckled, and also has a mob buckled to it.
Apparently that's a thing.