### PR TITLE
Dwarf Exploit Fix

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -113,12 +113,10 @@
 	activate(var/mob/M, var/connected, var/flags)
 		..(M,connected,flags)
 		M.pass_flags |= PASSTABLE
-		M.resize = 0.8
 
 	deactivate(var/mob/M, var/connected, var/flags)
 		..()
 		M.pass_flags &= ~PASSTABLE
-		M.resize = 1.25
 
 // OLD HULK BEHAVIOR
 /datum/dna/gene/basic/hulk


### PR DESCRIPTION
Alright so, I'm not rightfully sure how to fix the overlay issue with this, but to say the least, this is a pretty nasty exploit that should be addressed ASAP. Basically people are actively utilizing the dwarf mutation to hide their overlays---hulk, TK, etc. 

This has gone beyond just "yeah, oops, the overlay isn't showing up" to an active strategy to seek an advantage.