### PR TITLE
Fixed problems with media machines (ie jukebox)

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -16,6 +16,8 @@
 		return A
 
 /proc/get_area(O)
+	if(isarea(O))
+		return O
 	var/turf/loc = get_turf(O)
 	if(loc)
 		var/area/res = loc.loc

--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -30,25 +30,12 @@ function SetMusic(url, time, volume) {
 	vlc.playlist.playItem(id);
 
 	vlc.input.time = time*1000; // VLC takes milliseconds.
-	vlc.audio.volume = volume*100; // \[0-200]
+	// for whatever reason, VLC plugin requires a delay between playing and setting volume
+	// also scaling it log-wise so that it's a more useful range
+	setTimeout(function() { vlc.audio.volume = Math.log(volume) / Math.LN10 * 50 }, 100); // volume ranges from 0-200
 }
 	</script>
 "}
-
-/* OLD, DO NOT USE.  CONTROLS.CURRENTPOSITION IS BROKEN.
-var/const/PLAYER_HTML={"
-	<OBJECT id='player' CLASSID='CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6' type='application/x-oleobject'></OBJECT>
-	<script>
-function noErrorMessages () { return true; }
-window.onerror = noErrorMessages;
-function SetMusic(url, time, volume) {
-	var player = document.getElementById('player');
-	player.URL = url;
-	player.Controls.currentPosition = time;
-	player.Settings.volume = volume;
-}
-	</script>"}
-*/
 
 // Hook into the events we desire.
 /hook_handler/soundmanager


### PR DESCRIPTION
Fixed a couple of problems with media machines

* Fixed the `Set Volume` preference.
 * The VLC object used to play the music apparently requires a nontrivial delay (at least 50 ms, I made it 100 ms for reliability) between starting a playlist, and the volume being set, no idea why. Figured this out via breakpointing the javascript.
* Fixed the music not updating for people standing in the room (without leaving and reentering), which for some reason was never posted as an issue, despite it making the jukebox appear to not work at all naively.
 * The global proc `mobs_in_area()` assumed that one could pass an area into `get_area_master()` and get it back, which was not the case. It seems `alone_in_area()` also made this assumption and possibly other esoteric procs, so I made `get_area()` return the argument if it's an area already.

As a side note, it was amazing how much time and effort it took to even get the media module stuff locally testable, ugh. I can see why it was so buggy.

Fixes #1573