### PR TITLE
Fix Vision code weirdness

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -53,6 +53,7 @@
 	vision_flags = SEE_TURFS
 	prescription_upgradable = 1
 	species_fit = list("Vox")
+	see_darkness = 0 //don't render darkness while wearing mesons
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
 		)
@@ -63,7 +64,6 @@
 	icon_state = "nvgmeson"
 	item_state = "glasses"
 	darkness_view = 8
-	see_darkness = 0
 	prescription_upgradable = 0
 
 /obj/item/clothing/glasses/meson/prescription

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -376,18 +376,25 @@
 	else
 		H.sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)
 
+		H.see_in_dark = darksight //set their variables to default, modify them later
+		H.see_invisible = SEE_INVISIBLE_LIVING
+
 		if(H.mind && H.mind.vampire)
 			if(VAMP_VISION in H.mind.vampire.powers && !(VAMP_FULL in H.mind.vampire.powers))
 				H.sight |= SEE_MOBS
+
 			else if(VAMP_FULL in H.mind.vampire.powers)
 				H.sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
 				H.see_in_dark = 8
-				if(!H.druggy)		H.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+				H.see_invisible = SEE_INVISIBLE_MINIMUM
+
 
 		if(XRAY in H.mutations)
 			H.sight |= SEE_TURFS|SEE_MOBS|SEE_OBJS
 			H.see_in_dark = 8
-			if(!H.druggy)		H.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+
+			H.see_invisible = SEE_INVISIBLE_MINIMUM
+
 
 		if(H.seer == 1)
 			var/obj/effect/rune/R = locate() in H.loc
@@ -397,11 +404,7 @@
 				H.see_invisible = SEE_INVISIBLE_LIVING
 				H.seer = 0
 
-		else if(!H.seer)
-			H.see_in_dark = darksight
-			H.see_invisible = SEE_INVISIBLE_LIVING
-
-		//	This checks how much the mob's eyewear impairs their vision
+		//This checks how much the mob's eyewear impairs their vision
 		if(H.tinttotal >= TINT_IMPAIR)
 			if(tinted_weldhelh)
 				if(H.tinttotal >= TINT_BLIND)
@@ -413,7 +416,9 @@
 			if(istype(H.glasses, /obj/item/clothing/glasses))
 				var/obj/item/clothing/glasses/G = H.glasses
 				H.sight |= G.vision_flags
-				H.see_in_dark = G.darkness_view
+
+				if(G.darkness_view)
+					H.see_in_dark = G.darkness_view
 
 				if(!G.see_darkness)
 					H.see_invisible = SEE_INVISIBLE_MINIMUM
@@ -441,6 +446,14 @@
 						process_med_hud(H,1)
 					if(ANTAGHUD)
 						process_antag_hud(H)
+
+
+		if(H.vision_type)
+			H.see_in_dark = max(H.see_in_dark, H.vision_type.see_in_dark, darksight)
+			H.see_invisible = H.vision_type.see_invisible
+			if(H.vision_type.light_sensitive)
+				H.weakeyes = 1
+			H.sight |= H.vision_type.sight_flags
 
 		if(H.see_override)	//Override all
 			H.see_invisible = H.see_override


### PR DESCRIPTION
Fixes #2526, Fixes #2523 

Okay, I have to start off with things this does, because remembering how things are *supposed* to work is not my strong suit, and I can't confirm things via git history.

This does:
 - XRAY and full vampire vision make darkness overlays go away and gives you see_In_dark 8
 - Mesons do not render darkness, but do not change your see_in_dark.
 - Humans will, by default, have their species darksight and SEE_INVISIBLE_LIVING, unless something purposely changes it.