### PR TITLE
Allows you to Gut Baby Carp

### DIFF
--- a/code/modules/fish/fish_items.dm
+++ b/code/modules/fish/fish_items.dm
@@ -165,7 +165,7 @@ var/global/list/fish_items_list = list("goldfish" = /obj/item/weapon/fish/goldfi
 	icon_state = "catfish"
 
 /obj/item/weapon/fish/catfish/attackby(var/obj/item/O, var/mob/user as mob)
-	if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch) || istype(O, /obj/item/weapon/scalpel) || istype(O, /obj/item/weapon/kitchen/utensil/knife))
+	if(is_sharp(O))
 		user << "You carefully clean and gut \the [src.name]."
 		new /obj/item/weapon/reagent_containers/food/snacks/catfishmeat(get_turf(src))
 		new /obj/item/weapon/reagent_containers/food/snacks/catfishmeat(get_turf(src))
@@ -184,7 +184,7 @@ var/global/list/fish_items_list = list("goldfish" = /obj/item/weapon/fish/goldfi
 	icon_state = "salmon"
 
 /obj/item/weapon/fish/salmon/attackby(var/obj/item/O, var/mob/user as mob)
-	if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch) || istype(O, /obj/item/weapon/scalpel) || istype(O, /obj/item/weapon/kitchen/utensil/knife))
+	if(is_sharp(O))
 		user << "You carefully clean and gut \the [src.name]."
 		new /obj/item/weapon/reagent_containers/food/snacks/salmonmeat(get_turf(src))
 		new /obj/item/weapon/reagent_containers/food/snacks/salmonmeat(get_turf(src))
@@ -200,7 +200,7 @@ var/global/list/fish_items_list = list("goldfish" = /obj/item/weapon/fish/goldfi
 	force = 3
 
 /obj/item/weapon/fish/babycarp/attackby(var/obj/item/O, var/mob/user as mob)
-	if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch) || istype(O, /obj/item/weapon/scalpel) || istype(O, /obj/item/weapon/kitchen/utensil/knife))
+	if(is_sharp(O))
 		user << "You carefully clean and gut \the [src.name]."
 		new /obj/item/weapon/reagent_containers/food/snacks/carpmeat(get_turf(src)) //just one fillet; this is a baby, afterall.
 		qdel(src)

--- a/code/modules/fish/fish_items.dm
+++ b/code/modules/fish/fish_items.dm
@@ -199,6 +199,15 @@ var/global/list/fish_items_list = list("goldfish" = /obj/item/weapon/fish/goldfi
 	hitsound = 'sound/weapons/bite.ogg'
 	force = 3
 
+/obj/item/weapon/fish/babycarp/attackby(var/obj/item/O, var/mob/user as mob)
+	if(istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch) || istype(O, /obj/item/weapon/scalpel) || istype(O, /obj/item/weapon/kitchen/utensil/knife))
+		user << "You carefully clean and gut \the [src.name]."
+		new /obj/item/weapon/reagent_containers/food/snacks/carpmeat(get_turf(src)) //just one fillet; this is a baby, afterall.
+		qdel(src)
+		return
+	..()
+
+
 /obj/item/weapon/bananapeel/clownfish
 	name = "clown fish"
 	desc = "Even underwater, you cannot escape HONKing."


### PR DESCRIPTION
Allows you to gut baby carp and aquire 1 carp meat from them.

Currently it's useless to acquire these; they literally do nothing other than allow you to say "heee, look, baby carpppppp". 

Refactors the fish cutting code to use the helper proc is_sharp.