### PR TITLE
Fixes Stamina

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -277,7 +277,7 @@
 /mob/living/carbon/proc/CheckStamina()
 	if(staminaloss)
 		var/total_health = (health - staminaloss)
-		if(total_health <= config.health_threshold_crit && !stat)
+		if(total_health <= config.health_threshold_softcrit && !stat)
 			src << "<span class='notice'>You're too exhausted to keep going...</span>"
 			Weaken(5)
 			setStaminaLoss(health - 2)


### PR DESCRIPTION
Fixes stamina damage not weakening you until you had a total of 150 stamina damage.


Happened in the TG life refactor patch--easy to miss.