### PR TITLE
Lets parrots speak on Common radio, as code intended.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -709,9 +709,8 @@
 
 	message = capitalize(trim_left(message))
 	if(message_mode)
-		if(message_mode in radiochannels)
-			if(ears && istype(ears,/obj/item/device/radio))
-				ears.talk_into(src, message, message_mode, verb, null)
+		if(ears && istype(ears,/obj/item/device/radio))
+			ears.talk_into(src, message, message_mode, verb, null)
 
 	..(message)
 


### PR DESCRIPTION
The parrot speaking code was checking the `message_mode` against `radiochannels`, however:
1. `radiochannels` doesn't include `"headset"` which is the proper mode name for the unencrypted channel you're tuned into (ie Common).
2. `message_mode` is already derived from controlled values, so it was a pointless check as it was.