### PR TITLE
Made jukebox volume update work more reliably when buffering is slow

### DIFF
--- a/code/modules/media/mediamanager.dm
+++ b/code/modules/media/mediamanager.dm
@@ -10,13 +10,18 @@
 // Converted to VLC for cross-platform and ogg support. - N3X
 var/const/PLAYER_HTML={"
 <embed type="application/x-vlc-plugin" pluginspage="http://www.videolan.org" />
-<object classid="clsid:9BE31822-FDAD-461B-AD51-BE1D1C159921" codebase="http://download.videolan.org/pub/videolan/vlc/last/win32/axvlc.cab" id="player"></object>
+<object classid="clsid:9BE31822-FDAD-461B-AD51-BE1D1C159921" codebase="http://download.videolan.org/pub/videolan/vlc/last/win32/axvlc.cab" version="VideoLAN.VLCPlugin.2" id="player"></object>
 	<script>
+var _volume = 50;
+var vlc = document.getElementById('player');
+
 function noErrorMessages () { return true; }
 window.onerror = noErrorMessages;
-function SetMusic(url, time, volume) {
-	var vlc = document.getElementById('player');
 
+function SetMusic(url, time, volume) {
+	// scaling volume log-wise so that it's a more useful range
+	_volume = Math.log(volume) / Math.LN10 * 50; // volume ranges from 0-200
+	
 	// Stop playing
 	vlc.playlist.stop();
 
@@ -30,9 +35,17 @@ function SetMusic(url, time, volume) {
 	vlc.playlist.playItem(id);
 
 	vlc.input.time = time*1000; // VLC takes milliseconds.
-	// for whatever reason, VLC plugin requires a delay between playing and setting volume
-	// also scaling it log-wise so that it's a more useful range
-	setTimeout(function() { vlc.audio.volume = Math.log(volume) / Math.LN10 * 50 }, 100); // volume ranges from 0-200
+}
+
+function UpdateVolume() {
+	vlc.audio.volume = _volume;
+}
+
+// volume must be set after song already playing
+if(vlc.attachEvent) {
+	vlc.attachEvent("MediaPlayerBuffering", UpdateVolume);
+} else {
+	vlc.addEventListener("MediaPlayerBuffering", UpdateVolume, false);
 }
 	</script>
 "}


### PR DESCRIPTION
I discovered my changes in #2510 completely break if the audio stream buffers slowly (hooray for server load-dependent bugs).
* I also discovered that the VLC plugin actually supports event callbacks. Unfortunately they somehow neglected an event in their long list of choices for detecting if the stream has actually fully started playing (`MediaPlayerPlaying` and many other just fire when it starts prebuffering; who designed this plugin?). 
* Thus, I had to use the `MediaPlayerBuffering` event, even though that inefficiently fires several times when playing a stream over the internet. I don't know of a way (if there is one) to reliably know if the song has started enough to satisfy whatever blob of broken logic makes volume control not work yet, so I'm just going to let it fire the several times. The callback just has to set a single variable on the client side, and only when hearing the jukebox, thankfully.