### PR TITLE
Wheelchair Speedfix

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -25,12 +25,12 @@
 		return
 
 	move_delay = world.time
-	move_delay += 2 //wheelchairs are not infact sport bikes
+	move_delay += 5 //wheelchairs are not infact sport bikes
 
 	if(buckled_mob)
 		if(buckled_mob.incapacitated())
 			return 0
-			
+
 		var/mob/living/thedriver = user
 		var/mob_delay = thedriver.movement_delay()
 		if(mob_delay > 0)


### PR DESCRIPTION
Changes the wheelchair's slowdown from 2 to 5.

Overall effect: wheelchairs are now about the same speed as wearing a hardsuit.

You're still slip immune (and that's a problem), but you're not super fast anymore.

Fixes part of https://github.com/ParadiseSS13/Paradise/issues/2548 
