### PR TITLE
Fixed battle arcade circuit board type

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -102,7 +102,7 @@
 	desc = "Does not support Pinball."
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "arcade"
-	circuit = /obj/item/weapon/circuitboard/arcade
+	circuit = /obj/item/weapon/circuitboard/arcade/battle
 	var/enemy_name = "Space Villian"
 	var/temp = "Winners Don't Use Spacedrugs" //Temporary message, for attack messages, etc
 	var/player_hp = 30 //Player health/attack points


### PR DESCRIPTION
Battle Arcade had the wrong circuit board path set.
Fixes #2559