### PR TITLE
IPCs now heal in an upgraded cyborg recharger

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -8,7 +8,7 @@
 	idle_power_usage = 5
 	active_power_usage = 1000
 	var/mob/occupant = null
-	var/circuitboard = "/obj/item/weapon/circuitboard/cyborgrecharger"
+	var/circuitboard = /obj/item/weapon/circuitboard/cyborgrecharger
 	var/recharge_speed
 	var/recharge_speed_nutrition
 	var/repairs
@@ -44,7 +44,9 @@
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		repairs += M.rating - 1
 	for(var/obj/item/weapon/stock_parts/cell/C in component_parts)
-		recharge_speed *= C.maxcharge / 10000
+		var/multiplier = C.maxcharge / 10000
+		recharge_speed *= multiplier
+		recharge_speed_nutrition *= multiplier
 
 /obj/machinery/recharge_station/process()
 	if(!(NOPOWER|BROKEN))
@@ -116,8 +118,7 @@
 			if(!isnull(H.internal_organs_by_name["cell"]) && H.nutrition < 450)
 				H.nutrition = min(H.nutrition+recharge_speed_nutrition, 450)
 				if(repairs)
-					H.adjustBruteLoss(-(repairs))
-					H.adjustFireLoss(-(repairs))
+					H.heal_overall_damage(repairs, repairs, 0, 1)
 					H.updatehealth()
 
 /obj/machinery/recharge_station/proc/go_out()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -252,7 +252,7 @@
 
 
 //Heal MANY external organs, in random order
-/mob/living/carbon/human/heal_overall_damage(var/brute, var/burn)
+/mob/living/carbon/human/heal_overall_damage(var/brute, var/burn, var/internal=0, var/robotic=0)
 	var/list/obj/item/organ/external/parts = get_damaged_organs(brute,burn)
 
 	var/update = 0
@@ -262,7 +262,7 @@
 		var/brute_was = picked.brute_dam
 		var/burn_was = picked.burn_dam
 
-		update |= picked.heal_damage(brute,burn)
+		update |= picked.heal_damage(brute,burn, internal, robotic)
 
 		brute -= (brute_was-picked.brute_dam)
 		burn -= (burn_was-picked.burn_dam)


### PR DESCRIPTION
Upgrading the recharger cell will also increase how fast IPCs recharge.

It didn't work before because the adjustBruteLoss proc called heal_overall damage set to the corresponding damage type, but heal_overall_damage calls organ.heal_damage without the variable to fix robotic limbs. This adjusts this so that the cyborg recharger will now fix robot limbs.