### PR TITLE
Laser Scalpel Price Tweaks

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -174,7 +174,7 @@
 	id = "scalpel_laser1"
 	req_tech = list("biotech" = 2, "materials" = 2, "magnets" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 12500, MAT_GLASS = 7500)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500)
 	build_path = /obj/item/weapon/scalpel/laser1
 	category = list("Medical")
 
@@ -184,7 +184,7 @@
 	id = "scalpel_laser2"
 	req_tech = list("biotech" = 3, "materials" = 4, "magnets" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 12500, MAT_GLASS = 7500, MAT_SILVER = 2500)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_SILVER = 1000)
 	build_path = /obj/item/weapon/scalpel/laser2
 	category = list("Medical")
 
@@ -194,7 +194,7 @@
 	id = "scalpel_laser3"
 	req_tech = list("biotech" = 4, "materials" = 6, "magnets" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 12500, MAT_GLASS = 7500, MAT_SILVER = 2000, MAT_GOLD = 1500)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1500, MAT_SILVER = 1000, MAT_GOLD = 1000)
 	build_path = /obj/item/weapon/scalpel/laser3
 	category = list("Medical")
 
@@ -204,7 +204,7 @@
 	id = "scalpel_manager"
 	req_tech = list("biotech" = 4, "materials" = 7, "magnets" = 5, "programming" = 4)
 	build_type = PROTOLATHE
-	materials = list (MAT_METAL = 12500, MAT_GLASS = 7500, MAT_SILVER = 1500, MAT_GOLD = 1500, MAT_DIAMOND = 750)
+	materials = list (MAT_METAL = 2000, MAT_GLASS = 1500, MAT_SILVER = 1000, MAT_GOLD = 1000, MAT_DIAMOND = 1000)
 	build_path = /obj/item/weapon/scalpel/manager
 	category = list("Medical")
 


### PR DESCRIPTION
Laser scalpels and the Incision Management System are wayyyyy too expensive; a base scalpel costs more than an Rapid Part Exachange Device; it used up 6.25 sheets of metal for a single scalpel; that's insane; that's more metal than is in a wall.

Cost Changes:

- Metal cost lowered from 12,500 to 2,000 and standardized.
- Glass cost lowered from 7,500 to 1,500 and standardized.
- For those with silver/gold/diamond:
 - Silver cost lowered and standardized to 1,000
 - Gold cost lowered and standardized to 1,000
 - Diamond cost increased from 750 to 1,000