### PR TITLE
Overdose Change, Reagent Tweaks and Fixes, IPC Damage Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -499,7 +499,7 @@
 
 	passive_temp_gain = 10 //this should cause IPCs to stabilize at ~80 C in a 20 C environment.
 
-	flags = IS_WHITELISTED | NO_BREATHE | NO_SCAN | NO_BLOOD | NO_PAIN | NO_DNA_RAD
+	flags = IS_WHITELISTED | NO_BREATHE | NO_SCAN | NO_BLOOD | NO_PAIN | NO_DNA_RAD | NO_POISON
 	clothing_flags = HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR
 	dietflags = 0		//IPCs can't eat, so no diet

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -5,14 +5,14 @@
 	max_damage = 50 //made same as arm, since it is not vital
 	min_broken_damage = 30
 	encased = null
-	
+
 /obj/item/organ/external/head/ipc/New()
 	robotize("Morpheus Cyberkinetics")
 	..()
 
 /obj/item/organ/external/chest/ipc
 	encased = null
-	
+
 /obj/item/organ/external/chest/ipc/New()
 	robotize("Morpheus Cyberkinetics")
 	..()
@@ -91,6 +91,7 @@
 	organ_tag = "brain"
 	parent_organ = "chest"
 	vital = 1
+	max_damage = 200
 	var/obj/item/device/mmi/stored_mmi
 
 /obj/item/organ/mmi_holder/proc/update_from_mmi()

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -521,7 +521,7 @@
 			M.drop_item()
 	..()
 	if(prob(50))
-		M.adjustToxLoss(10)
+		M.adjustFireLoss(10)
 	M.adjustBrainLoss(pick(0.5, 0.6, 0.7, 0.8, 0.9, 1))
 	return
 
@@ -551,7 +551,7 @@
 /datum/reagent/lube/ultra/addiction_act_stage4(var/mob/living/carbon/human/M as mob)
 	M.Jitter(20)
 	M.Dizzy(20)
-	M.adjustToxLoss(5)
+	M.adjustBrainLoss(2)
 	if(prob(50))
 		M.emote(pick("twitch","buzz","moan"))
 	..()
@@ -605,7 +605,7 @@
 
 /datum/reagent/surge/addiction_act_stage1(var/mob/living/M as mob)
 	M.adjustBrainLoss(rand(1,5)*REM)
-	M.adjustToxLoss(rand(1,5)*REM)
+	M.hallucination += rand(1,5)
 	..()
 	return
 /datum/reagent/surge/addiction_act_stage2(var/mob/living/M as mob)

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -987,7 +987,7 @@ datum/reagent/haloperidol/on_mob_life(var/mob/living/M as mob)
 //		Synth-Meds			//
 //////////////////////////////
 
-//Degreaser: Anti-toxin / Lube Remover
+//Degreaser: Mild Purgative / Lube Remover
 /datum/reagent/degreaser
 	name = "Degreaser"
 	id = "degreaser"
@@ -1016,7 +1016,11 @@ datum/reagent/haloperidol/on_mob_life(var/mob/living/M as mob)
 
 /datum/reagent/degreaser/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
-	M.adjustToxLoss(-1.5*REM)
+	if(prob(50))		//Same effects as coffee, to help purge ill effects like paralysis
+		M.AdjustParalysis(-1)
+		M.AdjustStunned(-1)
+		M.AdjustWeakened(-1)
+		M.confused -= 5
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
 			if(R.id == "ultralube" || R.id == "lube")

--- a/code/modules/reagents/newchem/newchem_procs.dm
+++ b/code/modules/reagents/newchem/newchem_procs.dm
@@ -47,6 +47,8 @@ datum/reagents/proc/metabolize(var/mob/M)
 				R.overdosed = 1
 				M << "<span class = 'userdanger'>You feel like you took too much [R.name]!</span>"
 				R.overdose_start(M)
+			if(R.volume < R.overdose_threshold && R.overdosed)
+				R.overdosed = 0
 			if(R.volume >= R.addiction_threshold && !is_type_in_list(R, addiction_list) && R.addiction_threshold > 0)
 				var/datum/reagent/new_reagent = new R.type()
 				addiction_list.Add(new_reagent)

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_med.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_med.dm
@@ -87,5 +87,5 @@
 		name = "Sterilizine"
 		id = "sterilizine"
 		result = "sterilizine"
-		required_reagents = list("ethanol" = 1, "charcoal" = 1, "chlorine" = 1)
+		required_reagents = list("antihol" = 2, "chlorine" = 1)
 		result_amount = 3


### PR DESCRIPTION
Adjusts how Overdosing works
- Overdose effects now stop if you have less than the overdose threshold for the given reagent in your system
 - Previously, overdose effects would continue until all of the reagent was removed from the body
- After dropping below the overdose threshold, reagents will process as normal as long as they do not surpass the threshold again.

Tweaked some Synthetic-oriented reagents
- Synthetic drugs no longer will cause Toxins damage
 - The toxins damage for these has been replaced with either another form of damage or side-effect
- Degreaser no longer cures Toxins Damage in Synthetics
 - Degreaser still acts as a chemical purgative and lube cleaner, but helps cure certain side-effects much like Coffee does for organics.

Sterlizine recipe changed to require antihol and chlorine
- Effectively the same as the old recipe, except actually mixable
- Fixes #2030

Increases max_damage of MMI Holders to 200 (from 60)
- Now matches the max_damage for organic brains
 - Should make IPC brain damage more consistent with organic brain damage

Gives IPCs the NO_POISON flag
- This should make IPCs immune to toxins damage again, as originally intended.
- Fixes #2151.