### PR TITLE
Fixed placing down bent pipes, (un)fastening HE pipes

### DIFF
--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
@@ -43,31 +43,32 @@
 		if(SOUTHWEST)
 			initialize_directions = SOUTH|WEST
 		
-/obj/machinery/atmospherics/pipe/simple/initialize()
+/obj/machinery/atmospherics/pipe/simple/initialize(initPipe = 1)
 	..()
-	normalize_dir()
-	var/N = 2
-	for(var/D in cardinal)
-		if(D & initialize_directions)
-			N--
-			for(var/obj/machinery/atmospherics/target in get_step(src, D))
-				if(target.initialize_directions & get_dir(target,src))
-					var/c = check_connect_types(target,src)
-					if(!c)
-						continue
-					if(!node1 && N == 1)
-						target.connected_to = c
-						connected_to = c
-						node1 = target
-						break
-					if(!node2 && N == 0)
-						target.connected_to = c
-						connected_to = c
-						node2 = target
-						break
-	var/turf/T = loc			// hide if turf is not intact
-	hide(T.intact)
-	update_icon()
+	if(initPipe)
+		normalize_dir()
+		var/N = 2
+		for(var/D in cardinal)
+			if(D & initialize_directions)
+				N--
+				for(var/obj/machinery/atmospherics/target in get_step(src, D))
+					if(target.initialize_directions & get_dir(target,src))
+						var/c = check_connect_types(target,src)
+						if(!c)
+							continue
+						if(!node1 && N == 1)
+							target.connected_to = c
+							connected_to = c
+							node1 = target
+							break
+						if(!node2 && N == 0)
+							target.connected_to = c
+							connected_to = c
+							node2 = target
+							break
+		var/turf/T = loc			// hide if turf is not intact
+		hide(T.intact)
+		update_icon()
 
 /obj/machinery/atmospherics/pipe/simple/check_pressure(pressure)
 	var/datum/gas_mixture/environment = loc.return_air()

--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple_he.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple_he.dm
@@ -59,21 +59,23 @@
 	initialize_directions_he = initialize_directions	// The auto-detection from /pipe is good enough for a simple HE pipe
 	color = "#404040"
 
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/initialize()
-	normalize_dir()
-	var/N = 2
-	for(var/D in cardinal)
-		if(D & initialize_directions_he)
-			N--
-			for(var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/target in get_step(src, D))
-				if(target.initialize_directions_he & get_dir(target,src))
-					if(!node1 && N == 1)
-						node1 = target
-						break
-					if(!node2 && N == 0)
-						node2 = target
-						break
-	update_icon()
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/initialize(initPipe = 1)
+	..(0)
+	if(initPipe)
+		normalize_dir()
+		var/N = 2
+		for(var/D in cardinal)
+			if(D & initialize_directions_he)
+				N--
+				for(var/obj/machinery/atmospherics/pipe/simple/heat_exchanging/target in get_step(src, D))
+					if(target.initialize_directions_he & get_dir(target,src))
+						if(!node1 && N == 1)
+							node1 = target
+							break
+						if(!node2 && N == 0)
+							node2 = target
+							break
+		update_icon()
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/hidden
 	level=1
@@ -107,6 +109,7 @@
 			initialize_directions_he = WEST
 
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction/initialize()
+	..(0)
 	for(var/obj/machinery/atmospherics/target in get_step(src,initialize_directions))
 		if(target.initialize_directions & get_dir(target,src))
 			node1 = target
@@ -115,10 +118,6 @@
 		if(target.initialize_directions_he & get_dir(target,src))
 			node2 = target
 			break
-
-	if(!node1 && !node2)
-		qdel(src)
-		return
 
 	update_icon()
 	return

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -262,9 +262,15 @@
 	if(istype(triP) && triP.flipped)
 		icon_state = "m_[icon_state]"
 
-//called when a turf is attacked with a pipe item
-// place the pipe on the turf, setting pipe level to 1 (underfloor) if the turf is not intact
-
+// called by turf to know if should treat as bent or not on placement
+/obj/item/pipe/proc/is_bent_pipe()
+	return pipe_type in list( \
+		PIPE_SIMPLE_BENT, \
+		PIPE_HE_BENT, \
+		PIPE_INSULATED_BENT, \
+		PIPE_SUPPLY_BENT, \
+		PIPE_SCRUBBERS_BENT)
+		
 // rotate the pipe item clockwise
 
 /obj/item/pipe/verb/rotate()
@@ -305,7 +311,7 @@
 
 /obj/item/pipe/Move()
 	..()
-	if ((pipe_type in list (PIPE_SIMPLE_BENT, PIPE_SUPPLY_BENT, PIPE_SCRUBBERS_BENT, PIPE_HE_BENT, PIPE_INSULATED_BENT)) \
+	if (is_bent_pipe() \
 		&& (src.dir in cardinal))
 		src.dir = src.dir|turn(src.dir, 90)
 	else if (pipe_type in list (PIPE_SIMPLE_STRAIGHT, PIPE_SUPPLY_STRAIGHT, PIPE_SCRUBBERS_STRAIGHT, PIPE_UNIVERSAL, PIPE_HE_STRAIGHT, PIPE_INSULATED_STRAIGHT, PIPE_MVALVE, PIPE_DVALVE))

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -578,16 +578,14 @@ var/list/wood_icons = list("wood","wood-broken")
 					user << "<span class='notice'>You need more welding fuel to complete this task.</span>"
 
 	if(istype(C,/obj/item/pipe))
-		var/obj/item/pipe/V = C
-		if(V.pipe_type != -1) // ANY PIPE
-			var/obj/item/pipe/P = C
-
+		var/obj/item/pipe/P = C
+		if(P.pipe_type != -1) // ANY PIPE
 			user.visible_message( \
 				"[user] starts sliding [P] along \the [src].", \
 				"<span class='notice'>You slide [P] along \the [src].</span>", \
 				"You hear the scrape of metal against something.")
 			user.drop_item()
-			if (P.pipe_type in list (1,3,12))  // bent pipe rotation fix see construction.dm
+			if (P.is_bent_pipe())  // bent pipe rotation fix see construction.dm
 				P.dir = 5
 				if (user.dir == 1)
 					P.dir = 6
@@ -595,8 +593,6 @@ var/list/wood_icons = list("wood","wood-broken")
 					P.dir = 9
 				if (user.dir == 4)
 					P.dir = 10
-				if (user.dir == 5)
-					P.dir = 8
 			else
 				P.dir = user.dir
 			P.x = src.x


### PR DESCRIPTION
Supply/scrubber bent pipes were becoming straight when clicking them on the floor.
* This was because that code was never updated to be aware of supply and scrubber pipes. There is a helper proc now that lists all of the bent types so it's more standardized.
 * The fact that `floor/attackby()` and all of the `item/pipe` code is gross is out of the scope of this PR.
* Fixes #2573 

Unfastening HE pipes and HE junction pipes didn't work at all.
* HE pipes weren't calling their superclass's `initialize()`, so `stored` wasn't being set. (`stored` is the pipe item object that should be dropped when unwrenched.) Since they perform incompatible logic for connecting to neighbors, I added an argument to `pipe/simple/initialize()` to make it skip doing anything pipe-specific and just calling `..()` instead.
* Fixes #2517 

Fastening HE junctions that were going to be orphans just qdel()'d.
* The report in #2517 was partially wrong because orphaned pipes are supposed to immediately drop back as an item, so normal HE pipes were working correctly, but the junction was `qdel()`'ing because of a rogue `if(...) qdel()` check that is not supposed to be done in `initialize()`. (The atmos machinery code drops the pipe for you if connecting on all ends fails.)