### PR TITLE
Crew Transfer No Longer Blocked by Security Level

### DIFF
--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -206,8 +206,6 @@ datum/controller/vote
 						question = "End the shift?"
 						choices.Add("Initiate Crew Transfer", "Continue The Round")
 					else
-						if (security_level > SEC_LEVEL_BLUE)
-							return 0
 						if(ticker.current_state <= 2)
 							return 0
 						question = "End the shift?"


### PR DESCRIPTION
Having a security level higher than blue will no longer prevent the auto-transfer vote from occurring.

While I can kinda understand this, it effectively lets command keep the shift going for far longer than it really should--even if the vast majority of players want it to end--likewise, there's a LOT of times perfectly competent command just plain forget to lower the security level and the crew ends up having to wait longer than they otherwise would.