### PR TITLE
Spiderling and Factions

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -77,6 +77,7 @@
 	icon_state = "eggs"
 	var/amount_grown = 0
 	var/player_spiders = 0
+	var/faction = list()
 
 /obj/effect/spider/eggcluster/New()
 	pixel_x = rand(3,-3)
@@ -89,6 +90,7 @@
 		var/num = rand(3,12)
 		for(var/i=0, i<num, i++)
 			var/obj/effect/spider/spiderling/S = new /obj/effect/spider/spiderling(src.loc)
+			S.faction = faction
 			if(player_spiders)
 				S.player_spiders = 1
 		qdel(src)
@@ -105,6 +107,7 @@
 	var/obj/machinery/atmospherics/unary/vent_pump/entry_vent
 	var/travelling_in_vent = 0
 	var/player_spiders = 0
+	var/faction = list()
 
 /obj/effect/spider/spiderling/New()
 	pixel_x = rand(6,-6)
@@ -189,6 +192,7 @@
 			if(!grow_as)
 				grow_as = pick(typesof(/mob/living/simple_animal/hostile/poison/giant_spider))
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(src.loc)
+			S.faction = faction
 			if(player_spiders)
 				var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 				var/client/C = null

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -256,6 +256,7 @@
 				E = locate() in get_turf(src)
 				if(!E)
 					var/obj/effect/spider/eggcluster/C = new /obj/effect/spider/eggcluster(src.loc)
+					C.faction = faction
 					if(ckey)
 						C.player_spiders = 1
 					fed--


### PR DESCRIPTION
Spider eggs laid will now inherit the faction of the egg layer. This means if the spider who laid the eggs is neutral, then all the spiderlings of from that egg clutch will also be neutral (instead of hostile, as they currently are)...likewise, when those spiderlings fully grow up, then the fully grown spiders will also have the same faction.

Could allow for xenobio to produce spiders that are able to be dealt with, for the chef or something like that.

