### PR TITLE
Fixes Health HUD Icon

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -506,7 +506,7 @@
 					if(2)	H.healths.icon_state = "health7"
 					if(5)	H.healths.icon_state = "health0"
 					else
-						switch(H.health - ((flags & NO_PAIN) ? 0 : H.traumatic_shock) - H.staminaloss)
+						switch(100 - ((flags & NO_PAIN) ? 0 : H.traumatic_shock) - H.staminaloss)
 							if(100 to INFINITY)		H.healths.icon_state = "health0"
 							if(80 to 100)			H.healths.icon_state = "health1"
 							if(60 to 80)			H.healths.icon_state = "health2"


### PR DESCRIPTION
fixes https://github.com/ParadiseSS13/Paradise/issues/2575

Dunno why H.health causes it to effectively be counted twice, but it does---@Tigercat2000 even designed a solution to this, but it had the same problem, so...until we can figure this out, this will have to do.
