### PR TITLE
Painkillers and Movement Speed

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -14,6 +14,10 @@
 
 
 	var/health_deficiency = (100 - health + staminaloss)
+	if(reagents)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			if(R.shock_reduction)
+				health_deficiency -= R.shock_reduction
 	if(health_deficiency >= 40)
 		tally += (health_deficiency / 25)
 

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -278,7 +278,7 @@ datum/reagent/sal_acid
 	description = "This is a is a standard salicylate pain reliever and fever reducer."
 	reagent_state = LIQUID
 	color = "#B3B3B3"
-	shock_reduction = 40
+	shock_reduction = 25
 	overdose_threshold = 25
 
 datum/reagent/sal_acid/on_mob_life(var/mob/living/M as mob)
@@ -444,7 +444,7 @@ datum/reagent/morphine
 	color = "#C8A5DC"
 	overdose_threshold = 30
 	addiction_threshold = 25
-	shock_reduction = 60
+	shock_reduction = 50
 
 datum/reagent/morphine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom


### PR DESCRIPTION
Makes it so that painkillers will actually reduce the slowdown impact of damage when you take them (meant to do this a long time ago, as it's a thing on Goon, as well).

The amount of movement slow you can ignore is directly equal to how much damage they mask.

- Lowered the pain reduction on salicylic from 40 to 25 (1 level)
- Lower the pain reduction of morphine from 60 to 50 (2 levels)
- Hydrocodone unchanged (ignores all damage)
 - May have to nerf Hydrocodone, dunno; it's useless aside from its pain reduction effects.

Keep in mind, this doesn't mean you can become immune to stamina damage (like you could with halloss); you can only ignore parts of the *slowdown* from stamina damage, but you're still going to get stunned.