### PR TITLE
Re-Adds Portaseeder

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -165,23 +165,44 @@
 	w_class = 1
 	can_hold = list("/obj/item/weapon/reagent_containers/food/snacks/grown","/obj/item/seeds","/obj/item/weapon/grown", "/obj/item/stack/tile/grass")
 
-/*
+
 /obj/item/weapon/storage/bag/plants/portaseeder
-	name = "Portable Seed Extractor"
+	name = "portable seed extractor"
 	desc = "For the enterprising botanist on the go. Less efficient than the stationary model, it creates one seed per plant."
 	icon_state = "portaseeder"
-	origin_tech = "materials=2;biotech=2"
 
-	verb/dissolve_contents()
-		set name = "Activate Seed Extraction"
-		set category = "Object"
-		set desc = "Activate to convert your plants into plantable seeds."
-		for(var/obj/item/O in contents)
-			seedify(O, 1)
-		for(var/mob/M in range(1))
-			if (M.s_active == src)
-				src.close(M)
-*/
+/obj/item/weapon/storage/bag/plants/portaseeder/verb/dissolve_contents()
+	set name = "Activate Seed Extraction"
+	set category = "Object"
+	set desc = "Activate to convert your plants into plantable seeds."
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	for(var/obj/item/O in contents)
+		if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown) || istype(O, /obj/item/weapon/grown))
+
+			var/datum/seed/new_seed_type
+			if(istype(O, /obj/item/weapon/grown))
+				var/obj/item/weapon/grown/F = O
+				new_seed_type = plant_controller.seeds[F.plantname]
+			else
+				var/obj/item/weapon/reagent_containers/food/snacks/grown/F = O
+				new_seed_type = plant_controller.seeds[F.plantname]
+
+			if(new_seed_type)
+				var/obj/item/seeds/seeds = new(O.loc, O)
+				seeds.seed_type = new_seed_type.name
+				seeds.update_seed()
+			qdel(O)
+
+		if(istype(O, /obj/item/stack/tile/grass))
+			var/obj/item/stack/tile/grass/S = O
+			S.use(1)
+			new /obj/item/seeds/grassseed(O.loc, O)
+
+	for(var/mob/M in range(1))
+		if (M.s_active == src)
+			src.close(M)
+
 
 // -----------------------------
 //        Sheet Snatcher

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -17,7 +17,7 @@
 				new /obj/item/clothing/suit/apron(src)
 			if(2)
 				new /obj/item/clothing/suit/apron/overalls(src)
-		new /obj/item/weapon/storage/bag/plants(src)
+		new /obj/item/weapon/storage/bag/plants/portaseeder(src)
 		new /obj/item/clothing/under/rank/hydroponics(src)
 		new /obj/item/device/analyzer/plant_analyzer(src)
 		new /obj/item/device/radio/headset/headset_service(src)


### PR DESCRIPTION
Re-adds TG's portaseeder plant bag.

This got killed off a very very long time ago (even before the Zuhayr botany update).

In any event, this re-adds it.

For those who don't know what it does, it's basically just a fancy looking plant bag that can also convert its contents into seeds, just not at as good of a radio as the machine based seed extractor (basically 1 grown/grass tile will be only a single seed).

- replaces the plant bags in the Botanists' lockers with portaseeders

