### PR TITLE
Soy Sauce Recipe Change

### DIFF
--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_food.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_food.dm
@@ -42,8 +42,8 @@
 		name = "Soy Sauce"
 		id = "soysauce"
 		result = "soysauce"
-		required_reagents = list("soymilk" = 2, "flour" = 1, "sodiumchloride" = 1, "water" = 3)
-		result_amount = 7
+		required_reagents = list("soymilk" = 1,"sodiumchloride" = 1, "water" = 8)
+		result_amount = 10
 
 	cheesewheel
 		name = "Cheesewheel"


### PR DESCRIPTION
Changes the soy sauce recipe.

Simply put, the current recipe is annoying as hell to make and ends up using up quite a bit of flour, in the process of things, not to mention the ratios are really inconvenient to mix.

This simplifies it quite a bit.

Before:
- 2 soy milk, 1 flour, 1 salt, 3 water = 7 soy sauce

After:
- 1 soy milk, 1 salt, 8 water = 10 soy sauce