### PR TITLE
Bunch of robutt stuff

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -111,15 +111,15 @@
 	else if(issilicon(M))
 		if(isrobot(M))
 			var/mob/living/silicon/robot/R = M
-			if(R.activated(/obj/item/borg/combat/shield))
-				add_logs(M, user, "flashed", object="[src.name]")
-				user.visible_message("<span class='disarm'>[user] tries to overloads [M]'s sensors with the [src.name], but if blocked by [M]'s shield!</span>", "<span class='danger'>You try to overload [M]'s sensors with the [src.name], but are blocked by his shield!</span>")
-				return 1
-		else
-			M.Weaken(rand(5,10))
-			add_logs(M, user, "flashed", object="[src.name]")
-			user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the [src.name]!</span>", "<span class='danger'>You overload [M]'s sensors with the [src.name]!</span>")
-			return 1
+			for(var/obj/item/borg/combat/shield/S in R.module.modules)
+				if(R.activated(S))
+					add_logs(M, user, "flashed", object="[src.name]")
+					user.visible_message("<span class='disarm'>[user] tries to overloads [M]'s sensors with the [src.name], but if blocked by [M]'s shield!</span>", "<span class='danger'>You try to overload [M]'s sensors with the [src.name], but are blocked by his shield!</span>")
+					return 1
+		M.Weaken(rand(5,10))
+		add_logs(M, user, "flashed", object="[src.name]")
+		user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the [src.name]!</span>", "<span class='danger'>You overload [M]'s sensors with the [src.name]!</span>")
+		return 1
 
 	user.visible_message("<span class='disarm'>[user] fails to blind [M] with the [src.name]!</span>", "<span class='warning'>You fail to blind [M] with the [src.name]!</span>")
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -45,6 +45,13 @@
 	if(activated(O))
 		src << "Already activated"
 		return
+	if (is_component_functioning("power cell") && cell)
+		if(istype(O, /obj/item/borg))
+			var/obj/item/borg/B = O
+			if(B.powerneeded)
+				if((cell.charge * 100 / cell.maxcharge) < B.powerneeded)
+					src << "Not enough power to activate [B.name]!"
+					return
 	if(!module_state_1)
 		O.mouse_opacity = initial(O.mouse_opacity)
 		module_state_1 = O

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -29,6 +29,11 @@
 
 /mob/living/silicon/robot/proc/use_power()
 	if (is_component_functioning("power cell") && cell)
+		for(var/obj/item/borg/B in module.modules)
+			if(B.powerneeded)
+				if((cell.charge * 100 / cell.maxcharge) < B.powerneeded)
+					src << "Deactivating [B.name] due to lack of power!"
+					unEquip(B)
 		if(src.cell.charge <= 0)
 			uneq_all()
 			update_headlamp(1)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -72,11 +72,15 @@
 
 
 //Personal shielding for the combat module.
+/obj/item/borg
+	var/powerneeded // Percentage of power remaining required to run item
+
 /obj/item/borg/combat/shield
 	name = "personal shielding"
 	desc = "A powerful experimental module that turns aside or absorbs incoming attacks at the cost of charge."
 	icon = 'icons/obj/decals.dmi'
 	icon_state = "shock"
+	powerneeded = 25
 	var/shield_level = 0.5 //Percentage of damage absorbed by the shield.
 
 /obj/item/borg/combat/shield/verb/set_shield_level()
@@ -93,3 +97,4 @@
 	desc = "By retracting limbs and tucking in its head, a combat android can roll at high speeds."
 	icon = 'icons/obj/decals.dmi'
 	icon_state = "shock"
+	powerneeded = 25


### PR DESCRIPTION
- Fixes #2660 not being able to flash any robutt. Now you can only NOT flash robutts with shields up as intended.
- Balances borg shield/mobility to compensante for being able to pewpew or zoom with shield up: If your cell power is below 25%, the shield/mobility will automatically deactivate and be unactivatable until you get moar power.