### PR TITLE
Ports over TG Sentience Potion

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -52,7 +52,8 @@ var/global/list/blocked_mobs = list(/mob/living/simple_animal,
 			/mob/living/simple_animal/ascendant_shadowling,
 			/mob/living/simple_animal/slaughter,
 			/mob/living/simple_animal/hostile/retaliate/araneus,
-			/mob/living/simple_animal/hostile/syndicate/ranged/orion
+			/mob/living/simple_animal/hostile/syndicate/ranged/orion,
+			/mob/living/simple_animal/hostile/statue
 			)
 
 var/global/list/med_hud_users = list()

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -722,43 +722,11 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
+	w_class = 1
+	origin_tech = "biotech=4"
 
 	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
 		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-			user << "<span class='warning'> The potion only works on baby slimes!</span>"
-			return ..()
-		if(M.is_adult) //Can't tame adults
-			user << "<span class='warning'> Only baby slimes can be tamed!</span>"
-			return..()
-		if(M.stat)
-			user << "<span class='warning'> The slime is dead!</span>"
-			return..()
-		if(M.mind)
-			user << "<span class='warning'> The slime resists!</span>"
-			return ..()
-		var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
-		pet.icon_state = "[M.colour] baby slime"
-		pet.icon_living = "[M.colour] baby slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		user <<"You feed the slime the potion, removing it's powers and calming it."
-		qdel(M)
-		var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
-
-		if (!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
-		qdel(src)
-
-/obj/item/weapon/slimepotion2
-	name = "advanced docility potion"
-	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame. This one is meant for adult slimes"
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle19"
-
-	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime/))//If target is not a slime.
 			user << "<span class='warning'> The potion only works on slimes!</span>"
 			return ..()
 		if(M.stat)
@@ -767,20 +735,104 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		if(M.mind)
 			user << "<span class='warning'> The slime resists!</span>"
 			return ..()
-		var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
-		pet.icon_state = "[M.colour] adult slime"
-		pet.icon_living = "[M.colour] adult slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		user <<"You feed the slime the potion, removing it's powers and calming it."
-		qdel(M)
-		var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
+		if(M.is_adult)
+			var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
+			pet.icon_state = "[M.colour] adult slime"
+			pet.icon_living = "[M.colour] adult slime"
+			pet.icon_dead = "[M.colour] baby slime dead"
+			pet.colour = "[M.colour]"
+			var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
 
-		if (!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
+			if (!newname)
+				newname = "pet slime"
+			pet.name = newname
+			pet.real_name = newname
+			qdel(M)
+			qdel(src)
+		else
+			var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
+			pet.icon_state = "[M.colour] baby slime"
+			pet.icon_living = "[M.colour] baby slime"
+			pet.icon_dead = "[M.colour] baby slime dead"
+			pet.colour = "[M.colour]"
+			var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
+
+			if (!newname)
+				newname = "pet slime"
+			pet.name = newname
+			pet.real_name = newname
+			qdel(M)
+			qdel(src)
+		user <<"You feed the slime the potion, removing it's powers and calming it."
+
+/obj/item/weapon/sentience_potion
+	name = "sentience potion"
+	desc = "A miraculous chemical mix that can raise the intelligence of creatures to human levels. Unlike normal slime potions, it can be absorbed by any nonsentient being."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle19"
+	origin_tech = "biotech=5"
+	var/list/not_interested = list()
+	var/being_used = 0
+	w_class = 1
+
+
+/obj/item/weapon/sentience_potion/afterattack(mob/living/M, mob/user)
+	if(being_used || !ismob(M))
+		return
+	if(!isslime(M) && !isanimal(M) || M.ckey) //only works on animals that aren't player controlled
+		user << "<span class='warning'>[M] is already too intelligent for this to work!</span>"
+		return ..()
+	if(M.stat)
+		user << "<span class='warning'>[M] is dead!</span>"
+		return..()
+
+	user << "<span class='notice'>You offer the sentience potion to [M]...</span>"
+	being_used = 1
+
+	var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
+
+	shuffle(candidates)
+
+	var/time_passed = world.time
+	var/list/consenting_candidates = list()
+
+	for(var/candidate in candidates)
+
+		if(candidate in not_interested)
+			continue
+
+		spawn(0)
+			switch(alert(candidate, "Would you like to play as [M.name]? Please choose quickly!","Confirmation","Yes","No"))
+				if("Yes")
+					if((world.time-time_passed)>=50 || !src)
+						return
+					consenting_candidates += candidate
+				if("No")
+					if(!src)
+						return
+					not_interested += candidate
+
+	sleep(50)
+
+	if(!src)
+		return
+
+	listclearnulls(consenting_candidates) //some candidates might have left during sleep(50)
+
+	if(consenting_candidates.len)
+		var/client/C = null
+		C = pick(consenting_candidates)
+		M.key = C.key
+		M.universal_speak = 1
+		M.faction -= "neutral"
+		M << "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>"
+		M << "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>"
+		user << "<span class='notice'>[M] accepts the potion and suddenly becomes attentive and aware. It worked!</span>"
 		qdel(src)
+	else
+		user << "<span class='notice'>[M] looks interested for a moment, but then looks back down. Maybe you should try again later.</span>"
+		being_used = 0
+		..()
 
 
 /obj/item/weapon/slimesteroid
@@ -788,6 +840,9 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	desc = "A potent chemical mix that will cause a slime to generate more extract."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle16"
+	w_class = 1
+	origin_tech = "biotech=4"
+
 
 	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
 		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
@@ -812,6 +867,8 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	desc = "A potent chemical mix that will give a slime extract three uses."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle17"
+	w_class = 1
+	origin_tech = "biotech=4"
 
 
 /obj/item/weapon/slimespeed
@@ -819,6 +876,8 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	desc = "A potent chemical mix that will remove the slowdown from any item."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle3"
+	w_class = 1
+	origin_tech = "biotech=4"
 
 /obj/item/weapon/slimespeed/afterattack(obj/item/C, mob/user)
 	..()
@@ -839,6 +898,9 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle17"
 	var/uses = 3
+	w_class = 1
+	origin_tech = "biotech=4"
+
 
 /obj/item/weapon/slimefireproof/afterattack(obj/item/clothing/C, mob/user)
 	..()

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -741,13 +741,13 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			pet.icon_living = "[M.colour] adult slime"
 			pet.icon_dead = "[M.colour] baby slime dead"
 			pet.colour = "[M.colour]"
+			qdel(M)
 			var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
 
 			if (!newname)
 				newname = "pet slime"
 			pet.name = newname
 			pet.real_name = newname
-			qdel(M)
 			qdel(src)
 		else
 			var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
@@ -755,13 +755,13 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 			pet.icon_living = "[M.colour] baby slime"
 			pet.icon_dead = "[M.colour] baby slime dead"
 			pet.colour = "[M.colour]"
+			qdel(M)
 			var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
 
 			if (!newname)
 				newname = "pet slime"
 			pet.name = newname
 			pet.real_name = newname
-			qdel(M)
 			qdel(src)
 		user <<"You feed the slime the potion, removing it's powers and calming it."
 

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -433,7 +433,7 @@
 		required_reagents = list("plasma" = 5)
 		required_other = 1
 		on_reaction(var/datum/reagents/holder)
-			var/obj/item/weapon/slimepotion2/P = new /obj/item/weapon/slimepotion2
+			var/obj/item/weapon/sentience_potion/P = new /obj/item/weapon/sentience_potion
 			P.loc = get_turf(holder.my_atom)
 //Adamantine
 	slimegolem


### PR DESCRIPTION
Ports over TG's Xenobio sentience potion

- Sentience potion can be used on any simple animal or slime; when it's used on them, it will gather all current alien candidates and ask them if they want to be the mob you're feeding the potion to---it will then randomly select one of yes-answerers and put them in control of that mob; that mob is then bound to the person who used the potion.
 - This replaces the light pink "adult slime" taming potion. Ie: this is what light pink slimes will now do.
- pink slime potion now works on adult slimes and baby slimes
- Slime potions now have the proper origin tech and weight class

- Blocks statues from gold slime and life reactions (for lock up reasons and sentience potion reasons)
 - Player controlled statues can actively disobey the lighting and vision requirements that normally are *meant* to bind them, likewise, these have been spawning when no admins are on or no one is on that can delete them, and it causes the scheduler to lock up.