### PR TITLE
Rev 2.0

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -20,7 +20,7 @@
 
 /obj/item/device/flash/proc/clown_check(mob/user)
 	if(user && (CLUMSY in user.mutations) && prob(50))
-		flash_carbon(user, user, 15, 0)
+		flash_carbon(user, user, 15)
 		return 0
 	return 1
 
@@ -75,7 +75,7 @@
 	return 1
 
 
-/obj/item/device/flash/proc/flash_carbon(var/mob/living/carbon/M, var/mob/user = null, var/power = 5, convert = 1)
+/obj/item/device/flash/proc/flash_carbon(var/mob/living/carbon/M, var/mob/user = null, var/power = 5)
 	add_logs(M, user, "flashed", object="[src.name]")
 	if(M.weakeyes)
 		M.Weaken(3) //quick weaken bypasses eye protection but has no eye flash
@@ -83,8 +83,7 @@
 	if(safety <= 0)
 		M.confused += power
 		flick("e_flash", M.flash)
-		if(user && convert)
-			terrible_conversion_proc(M, user)
+		if(user)
 			M.Stun(1)
 			user.visible_message("<span class='disarm'>[user] blinds [M] with the [src.name]!</span>")
 			if(M.weakeyes)
@@ -101,7 +100,7 @@
 		return 0
 
 	if(iscarbon(M))
-		flash_carbon(M, user, 5, 1)
+		flash_carbon(M, user, 5)
 		if(overcharged)
 			M.adjust_fire_stacks(6)
 			M.IgniteMob()
@@ -129,38 +128,16 @@
 		return 0
 	user.visible_message("<span class='disarm'>[user]'s [src.name] emits a blinding light!</span>", "<span class='danger'>Your [src.name] emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in oviewers(3, null))
-		flash_carbon(M, user, 3, 0)
+		flash_carbon(M, user, 3)
 
 
 /obj/item/device/flash/emp_act(severity)
 	if(!try_use_flash())
 		return 0
 	for(var/mob/living/carbon/M in viewers(3, null))
-		flash_carbon(M, null, 10, 0)
+		flash_carbon(M, null, 10)
 	burn_out()
 	..()
-
-
-/obj/item/device/flash/proc/terrible_conversion_proc(var/mob/M, var/mob/user)
-	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
-		if(user.mind && (user.mind in ticker.mode.head_revolutionaries))
-			if(M.client)
-				if(M.stat == CONSCIOUS)
-					M.mind_initialize() //give them a mind datum if they don't have one.
-					var/resisted
-					if(!isloyal(M))
-						if(user.mind in ticker.mode.head_revolutionaries)
-							if(!ticker.mode.add_revolutionary(M.mind))
-								resisted = 1
-					else
-						resisted = 1
-
-					if(resisted)
-						user << "<span class='warning'>This mind seems resistant to the [src.name]!</span>"
-				else
-					user << "<span class='warning'>They must be conscious before you can convert them!</span>"
-			else
-				user << "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>"
 
 
 /obj/item/device/flash/cyborg

--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -154,7 +154,7 @@
 		if(ticker.mode.greyshirts.len >= 3)
 			usr << "<span class='warning'>You have already recruited the maximum number of henchmen.</span>"
 		if(!in_range(usr, target))
-			usr << "<span class='warning'>You need to be closer to enthrall [target].</span>"
+			usr << "<span class='warning'>You need to be closer to recruit [target].</span>"
 			charge_counter = charge_max
 			return
 		if(!target.ckey)
@@ -171,6 +171,7 @@
 			return
 		if(target.mind.assigned_role != "Civilian")
 			usr << "<span class='warning'>You can only recruit Civilians.</span>"
+			return
 		if(recruiting)
 			usr << "<span class='danger'>You are already recruiting!</span>"
 			charge_counter = charge_max
@@ -188,7 +189,6 @@
 					usr << "<span class='notice'>You begin the recruitment of [target].</span>"
 					usr.visible_message("<span class='danger'>[usr] leans over towards [target], whispering excitedly as he gives a speech.</span>")
 					target << "<span class='danger'>You feel yourself agreeing with [usr], and a surge of loyalty begins building.</span>"
-					target.Weaken(12)
 					sleep(20)
 					if(isloyal(target))
 						usr << "<span class='notice'>They are enslaved by Nanotrasen. You feel their interest in your cause wane and disappear.</span>"


### PR DESCRIPTION
- Replaces Headrev lolflash ability with a targeted spell that takes ~30+ seconds of being next to someone to convert.

Since this spell has no stuns and the Headrev must remain next to the crewmember for the whole duration, this forces headrevs to either RP convincing a crewmember to join before initiating the spell, OR forces them to kidnap and restrain someone for the recruitment process to work.

- Spell also has a 45 second cooldown. adjustable as needed for balance.
- Fixes a few bugs/typos with Griffon recruitment spell.
- Headrevs no longer spawn with flashes.

The goal of this PR is to slow down the recruitment process and encourage more RP or at least interaction between Headrevs and the crew.

I am open to suggestions for ideas on how to code mechanics 'encourage' the command staff to abandon the station rather than fighting to the death or getting ambushed out of the blue.