### PR TITLE
fixed nanoui maps positioning stuff wrong, atmos control having any alarms

### DIFF
--- a/code/modules/nano/modules/atmos_control.dm
+++ b/code/modules/nano/modules/atmos_control.dm
@@ -3,7 +3,7 @@
 	var/obj/access = new()
 	var/emagged = 0
 	var/ui_ref
-	var/list/monitored_alarms = list()
+	var/list/monitored_alarms = null
 
 /datum/nano_module/atmos_control/New(atmos_computer, req_access, req_one_access, monitored_alarm_ids)
 	..()
@@ -23,7 +23,7 @@
 
 	if(href_list["alarm"])
 		if(ui_ref)
-			var/obj/machinery/alarm/alarm = locate(href_list["alarm"]) in (monitored_alarms.len ? monitored_alarms : machines)
+			var/obj/machinery/alarm/alarm = locate(href_list["alarm"]) in (monitored_alarms ? monitored_alarms : machines)
 			if(alarm)
 				var/datum/topic_state/TS = generate_state(alarm)
 				alarm.ui_interact(usr, master_ui = ui_ref, state = TS)

--- a/nano/css/layout_default.css
+++ b/nano/css/layout_default.css
@@ -87,7 +87,7 @@ body {
 
 #uiMapContent {
     position: absolute;
-    bottom: 0px;
+    bottom: -13.5px;
     left: 0px;
     width: 256px;
     height: 256px;

--- a/nano/templates/atmos_control_map_content.tmpl
+++ b/nano/templates/atmos_control_map_content.tmpl
@@ -1,6 +1,6 @@
 {{for data.alarms}}
 	{{if value.z == 1}}
-		<div class="linkActive mapIcon mapIcon16 icon-airalarm {{:helper.dangerToClass(value.danger)}}" style="left: {{:(value.x)}}px; bottom: {{:(value.y)}}px;" unselectable="on" data-href="{{:NanoUtility.generateHref({"alarm":value.ref, "showMap":0})}}">
+		<div class="linkActive mapIcon mapIcon16 icon-airalarm {{:helper.dangerToClass(value.danger)}}" style="left: {{:(value.x)}}px; bottom: {{:(value.y - 1)}}px;" unselectable="on" data-href="{{:NanoUtility.generateHref({"alarm":value.ref, "showMap":0})}}">
 			<div class="tooltip hidden">
 				{{:value.name}} ({{:helper.dangerToSpan(value.danger)}}, {{:value.area}}: {{:value.x}}, {{:value.y}})
 			</div>


### PR DESCRIPTION
* All of the nanoui maps (crew monitor, sec cams, atmos alerts) were showing icons higher than they should.
 * I analyzed the output html DOM and there's no sensible reason that was the case, must be some weird ie8 render bug.
 * Thus, I shoved the icon overlay layer up such that it's aligned.
* The atmos computer wasn't showing anything most of the time, because it was hardwired to show a filtered list of 0 alarms.
 * Inconsistency in meaning of variable fixed.
* Fixes #2571 