### PR TITLE
Nations 2.2 -- Bookkeeping Boogaloo

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -20,7 +20,7 @@
 
 	init_datum_subtypes(/datum/job, joblist, list(/datum/job/ai, /datum/job/cyborg), "title")
 	init_datum_subtypes(/datum/superheroes, all_superheroes, null, "name")
-	init_datum_subtypes(/datum/nations, all_nations, null, "name")
+	init_datum_subtypes(/datum/nations, all_nations, null, "default_name")
 	init_datum_subtypes(/datum/language, all_languages, null, "name")
 
 	for (var/language_name in all_languages)

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -179,7 +179,8 @@ datum/game_mode/nations
 			N.current_leader = pick(N.membership)
 			N.current_leader << "You have been chosen to lead the nation of [N.current_name]!"
 		var/mob/living/carbon/human/H = N.current_leader
-		H.verbs += /mob/living/carbon/human/proc/set_nation_name
+		H.verbs += /datum/game_mode/nations/proc/set_nation_name
+		H.verbs += /datum/game_mode/nations/proc/set_ranks
 
 /**
  * LateSpawn hook.

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -181,6 +181,7 @@ datum/game_mode/nations
 		var/mob/living/carbon/human/H = N.current_leader
 		H.verbs += /datum/game_mode/nations/proc/set_nation_name
 		H.verbs += /datum/game_mode/nations/proc/set_ranks
+		N.update_nation_id()
 
 /**
  * LateSpawn hook.

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -181,6 +181,7 @@ datum/game_mode/nations
 		var/mob/living/carbon/human/H = N.current_leader
 		H.verbs += /datum/game_mode/nations/proc/set_nation_name
 		H.verbs += /datum/game_mode/nations/proc/set_ranks
+		H.verbs += /datum/game_mode/nations/proc/choose_heir
 		N.update_nation_id()
 
 /**

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -13,9 +13,9 @@ datum/game_mode/nations
 		kickoff=1
 		send_intercept()
 		split_teams()
+		assign_leaders()
 		set_ai()
 //		remove_access()
-		assign_leaders()
 		for(var/mob/M in player_list)
 			if(!istype(M,/mob/new_player))
 				M << sound('sound/effects/purge_siren.ogg')
@@ -178,6 +178,8 @@ datum/game_mode/nations
 		if(!N.current_leader)
 			N.current_leader = pick(N.membership)
 			N.current_leader << "You have been chosen to lead the nation of [N.current_name]!"
+		var/mob/living/carbon/human/H = N.current_leader
+		H.verbs += /mob/living/carbon/human/proc/set_nation_name
 
 /**
  * LateSpawn hook.

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -15,6 +15,7 @@ datum/game_mode/nations
 		split_teams()
 		set_ai()
 //		remove_access()
+		assign_leaders()
 		for(var/mob/M in player_list)
 			if(!istype(M,/mob/new_player))
 				M << sound('sound/effects/purge_siren.ogg')
@@ -39,7 +40,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudatmosia")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in medical_positions)
@@ -47,7 +53,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudmedistan")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in science_positions)
@@ -55,7 +66,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudscientopia")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in security_positions)
@@ -63,7 +79,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudbrigston")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in cargonians)
@@ -71,7 +92,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudcargonia")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in servicion)
@@ -79,7 +105,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudservice")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in support_positions)
@@ -87,7 +118,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudcommand")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in command_positions)
@@ -95,7 +131,12 @@ datum/game_mode/nations
 				H.hud_updateflag |= 1 << NATIONS_HUD
 				var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudcommand")
 				H.client.images += I
-				H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+				H.mind.nation.membership += H.mind.current
+				if(H.mind.assigned_role == H.mind.nation.default_leader)
+					H.mind.nation.current_leader = H.mind.current
+					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					continue
+				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
 
 			if(H.mind.assigned_role in civilian_positions)
@@ -129,6 +170,15 @@ datum/game_mode/nations
 		if(W.z in config.station_levels)
 			W.req_access = list()
 
+
+/datum/game_mode/nations/proc/assign_leaders()
+	for(var/datum/nations/N in all_nations)
+		if(!N.current_name)
+			N.current_name = N.default_name
+		if(!N.current_leader)
+			N.current_leader = pick(N.membership)
+			N.current_leader << "You have been chosen to lead the nation of [N.current_name]!"
+
 /**
  * LateSpawn hook.
  * Called in newplayer.dm when a humanoid character joins the round after it started.
@@ -148,7 +198,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudatmosia")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in medical_positions)
@@ -156,7 +207,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudmedistan")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in science_positions)
@@ -164,7 +216,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudscientopia")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in security_positions)
@@ -172,7 +225,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudbrigston")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in cargonians)
@@ -180,7 +234,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudcargonia")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in servicion)
@@ -188,7 +243,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudservice")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in support_positions)
@@ -196,7 +252,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudcommand")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in command_positions)
@@ -204,7 +261,8 @@ datum/game_mode/nations
 			H.hud_updateflag |= 1 << NATIONS_HUD
 			var/I = image('icons/mob/hud.dmi', loc = H.mind.current, icon_state = "hudcommand")
 			H.client.images += I
-			H << "You are now part of the great sovereign nation of [H.mind.nation.name]!"
+			H.mind.nation.membership += H.mind.current
+			H << "You are now part of the great sovereign nation of [H.mind.nation.current_name]!"
 			return 1
 
 		if(H.mind.assigned_role in civilian_positions)

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -43,7 +43,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
@@ -56,7 +56,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
@@ -69,7 +69,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
@@ -82,7 +82,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
@@ -95,7 +95,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
@@ -108,7 +108,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
@@ -121,7 +121,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue
@@ -134,7 +134,7 @@ datum/game_mode/nations
 				H.mind.nation.membership += H.mind.current
 				if(H.mind.assigned_role == H.mind.nation.default_leader)
 					H.mind.nation.current_leader = H.mind.current
-					H << "You have been chosent to lead the nation of [H.mind.nation.default_name]!"
+					H << "You have been chosen to lead the nation of [H.mind.nation.default_name]!"
 					continue
 				H << "You are now part of the great sovereign nation of [H.mind.nation.default_name]!"
 				continue

--- a/code/game/gamemodes/nations/nationsdatums.dm
+++ b/code/game/gamemodes/nations/nationsdatums.dm
@@ -4,6 +4,8 @@
 	var/default_leader
 	var/current_leader
 	var/list/membership = list()
+	var/leader_rank
+	var/member_rank
 
 /datum/nations/atmosia
 	default_name = "Atmosia"

--- a/code/game/gamemodes/nations/nationsdatums.dm
+++ b/code/game/gamemodes/nations/nationsdatums.dm
@@ -6,6 +6,7 @@
 	var/list/membership = list()
 	var/leader_rank = "Leader"
 	var/member_rank = "Member"
+	var/heir
 
 /datum/nations/atmosia
 	default_name = "Atmosia"

--- a/code/game/gamemodes/nations/nationsdatums.dm
+++ b/code/game/gamemodes/nations/nationsdatums.dm
@@ -1,23 +1,34 @@
 /datum/nations
-	var/name
+	var/default_name
+	var/current_name
+	var/default_leader
+	var/current_leader
+	var/list/membership = list()
 
 /datum/nations/atmosia
-	name = "Atmosia"
+	default_name = "Atmosia"
+	default_leader = "Chief Engineer"
 
 /datum/nations/brigston
-	name = "Brigston"
+	default_name = "Brigston"
+	default_leader = "Head of Security"
 
 /datum/nations/cargonia
-	name = "Cargonia"
+	default_name = "Cargonia"
+	default_leader = "Quartermaster"
 
 /datum/nations/command
-	name = "People's Republic of Commandzakstan"
+	default_name = "People's Republic of Commandzakstan"
+	default_leader = "Captain"
 
 /datum/nations/medistan
-	name = "Medistan"
+	default_name = "Medistan"
+	default_leader = "Chief Medical Officer"
 
 /datum/nations/scientopia
-	name = "Scientopia"
+	default_name = "Scientopia"
+	default_leader = "Research Director"
 
 /datum/nations/service
-	name = "Servicion"
+	default_name = "Servicion"
+	default_leader = "Bartender"

--- a/code/game/gamemodes/nations/nationsdatums.dm
+++ b/code/game/gamemodes/nations/nationsdatums.dm
@@ -4,8 +4,8 @@
 	var/default_leader
 	var/current_leader
 	var/list/membership = list()
-	var/leader_rank
-	var/member_rank
+	var/leader_rank = "Leader"
+	var/member_rank = "Member"
 
 /datum/nations/atmosia
 	default_name = "Atmosia"

--- a/code/game/gamemodes/nations/nationsprocs.dm
+++ b/code/game/gamemodes/nations/nationsprocs.dm
@@ -1,18 +1,46 @@
-/mob/living/carbon/human/proc/set_nation_name()
+/datum/game_mode/nations/proc/set_nation_name()
 	set name = "Rename Nation"
 	set category = "Nations"
 	set desc = "Click to rename your nation. You are only able to do this once."
 
+	if(!kickoff) return 1
 
-	var/datum/game_mode/nations/mode = get_nations_mode()
-	if (!mode) return 1
-	if(!mode.kickoff) return 1
+	if(ishuman(usr))
+		var/mob/living/carbon/human/H = usr
+		if(H.mind && H.mind.nation && H.mind.nation.current_leader == H)
+			var/input = stripped_input(H,"What do you want to name your nation?", ,"", MAX_NAME_LEN)
 
-	if(mind && mind.nation && mind.nation.current_leader == src)
-		var/input = stripped_input(src,"What do you want to name your nation?", ,"", MAX_NAME_LEN)
+			if(input)
+				H.mind.nation.current_name = input
+				H << "You rename your nation to [input]."
+				H.verbs -= /datum/game_mode/nations/proc/set_nation_name
+				return 1
 
-		if(input)
-			mind.nation.current_name = input
-			src << "You rename your nation to [input]."
-			verbs -= /mob/living/carbon/human/proc/set_nation_name
-			return 1
+
+/datum/game_mode/nations/proc/set_ranks()
+	set name = "Set Ranks"
+	set category = "Nations"
+	set desc = "Click to set a rank for Leaders and Members."
+
+	if(!kickoff) return 1
+
+	if(ishuman(usr))
+		var/mob/living/carbon/human/H = usr
+		if(H.mind && H.mind.nation && H.mind.nation.current_leader == H)
+			var/type = input(H, "What rank do you want to change?", "Rename Rank", "") in list("Leader","Member")
+			var/input = stripped_input(H,"What rank do you want?", ,"", MAX_NAME_LEN)
+			if(input)
+				if(type == "Leader")
+					H.mind.nation.leader_rank = input
+					for(var/obj/item/weapon/card/id/I in H)
+						if(I.registered_name == H.real_name)
+							I.update_label(I.registered_name, input)
+				if(type == "Member")
+					H.mind.nation.member_rank = input
+					for(var/mob/living/carbon/human/M in H.mind.nation.membership)
+						if(M == H) continue
+						for(var/obj/item/weapon/card/id/I in M)
+							if(I.registered_name == M.real_name)
+								I.update_label(I.registered_name, input)
+				H << "You changed the [type] rank of your nation to [input]."
+				return 1

--- a/code/game/gamemodes/nations/nationsprocs.dm
+++ b/code/game/gamemodes/nations/nationsprocs.dm
@@ -1,0 +1,18 @@
+/mob/living/carbon/human/proc/set_nation_name()
+	set name = "Rename Nation"
+	set category = "Nations"
+	set desc = "Click to rename your nation. You are only able to do this once."
+
+
+	var/datum/game_mode/nations/mode = get_nations_mode()
+	if (!mode) return 1
+	if(!mode.kickoff) return 1
+
+	if(mind && mind.nation && mind.nation.current_leader == src)
+		var/input = stripped_input(src,"What do you want to name your nation?", ,"", MAX_NAME_LEN)
+
+		if(input)
+			mind.nation.current_name = input
+			src << "You rename your nation to [input]."
+			verbs -= /mob/living/carbon/human/proc/set_nation_name
+			return 1

--- a/code/game/gamemodes/nations/nationsprocs.dm
+++ b/code/game/gamemodes/nations/nationsprocs.dm
@@ -12,6 +12,7 @@
 
 			if(input)
 				H.mind.nation.current_name = input
+				H.mind.nation.update_nation_id()
 				H << "You rename your nation to [input]."
 				H.verbs -= /datum/game_mode/nations/proc/set_nation_name
 				return 1
@@ -32,15 +33,23 @@
 			if(input)
 				if(type == "Leader")
 					H.mind.nation.leader_rank = input
-					for(var/obj/item/weapon/card/id/I in H)
-						if(I.registered_name == H.real_name)
-							I.update_label(I.registered_name, input)
+					H.mind.nation.update_nation_id()
+
 				if(type == "Member")
 					H.mind.nation.member_rank = input
-					for(var/mob/living/carbon/human/M in H.mind.nation.membership)
-						if(M == H) continue
-						for(var/obj/item/weapon/card/id/I in M)
-							if(I.registered_name == M.real_name)
-								I.update_label(I.registered_name, input)
+					H.mind.nation.update_nation_id()
 				H << "You changed the [type] rank of your nation to [input]."
 				return 1
+
+
+/datum/nations/proc/update_nation_id()
+	for(var/mob/living/carbon/human/M in membership)
+		for(var/obj/item/weapon/card/id/I in M.contents)
+			if(I.registered_name == M.real_name)
+				if(M == current_leader)
+					I.name = "[I.registered_name]'s ID Card ([current_name] [leader_rank])"
+					I.assignment = "[current_name] [leader_rank]"
+				else
+					I.name = "[I.registered_name]'s ID Card ([current_name] [member_rank])"
+					I.assignment = "[current_name] [member_rank]"
+

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -245,6 +245,9 @@
 
 	stat(null, "Intent: [a_intent]")
 	stat(null, "Move Mode: [m_intent]")
+
+	stat(null, "Station Time: [worldtime2text()]")
+
 	if(ticker && ticker.mode && ticker.mode.name == "AI malfunction")
 		if(ticker.mode:malf_mode_declared)
 			stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
@@ -275,7 +278,11 @@
 			if(mind.changeling)
 				stat("Chemical Storage", "[mind.changeling.chem_charges]/[mind.changeling.chem_storage]")
 				stat("Absorbed DNA", mind.changeling.absorbedcount)
-		stat(null, "Station Time: [worldtime2text()]")
+
+			if(mind.nation)
+				stat("Nation Name", mind.nation.current_name)
+				stat("Nation Leader", mind.nation.current_leader)
+
 
 	if(istype(loc, /obj/spacepod)) // Spacdpods!
 		var/obj/spacepod/S = loc

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -280,7 +280,7 @@
 				stat("Absorbed DNA", mind.changeling.absorbedcount)
 
 			if(mind.nation)
-				stat("Nation Name", "[mind.nation.current_name ? "[mind.nation.current_name]" : "mind.nation.default_name"]")
+				stat("Nation Name", "[mind.nation.current_name ? "[mind.nation.current_name]" : "[mind.nation.default_name]"]")
 				stat("Nation Leader", "[mind.nation.current_leader ? "[mind.nation.current_leader]" : "None"]")
 				stat("Nation Heir", "[mind.nation.heir ? "[mind.nation.heir]" : "None"]")
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -280,8 +280,9 @@
 				stat("Absorbed DNA", mind.changeling.absorbedcount)
 
 			if(mind.nation)
-				stat("Nation Name", mind.nation.current_name)
-				stat("Nation Leader", mind.nation.current_leader)
+				stat("Nation Name", "[mind.nation.current_name ? "[mind.nation.current_name]" : "mind.nation.default_name"]")
+				stat("Nation Leader", "[mind.nation.current_leader ? "[mind.nation.current_leader]" : "None"]")
+				stat("Nation Heir", "[mind.nation.heir ? "[mind.nation.heir]" : "None"]")
 
 
 	if(istype(loc, /obj/spacepod)) // Spacdpods!

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1488,7 +1488,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		holder.icon_state = "hudblank"
 
 		if(mind && mind.nation)
-			switch(mind.nation.name)
+			switch(mind.nation.default_name)
 				if("Atmosia")
 					holder.icon_state = "hudatmosia"
 				if("Brigston")

--- a/paradise.dme
+++ b/paradise.dme
@@ -354,6 +354,7 @@
 #include "code\game\gamemodes\mutiny\directives\vox_heist.dm"
 #include "code\game\gamemodes\nations\nations.dm"
 #include "code\game\gamemodes\nations\nationsdatums.dm"
+#include "code\game\gamemodes\nations\nationsprocs.dm"
 #include "code\game\gamemodes\nuclear\nuclear.dm"
 #include "code\game\gamemodes\nuclear\nuclearbomb.dm"
 #include "code\game\gamemodes\nuclear\pinpointer.dm"


### PR DESCRIPTION
- Leaders get picked for nations at kickoff. If default leader isn't available, select a random member of the nation to be leader.
- Leaders get one-time ability to rename nation. This new nation name will appear to all latejoiners to the nation and on ID cards.
- Leaders get the ability to set rank titles for themselves and their members. These titles automatically appear on ID cards and should show up on NTSL radio scripts.
- Leaders can name a heir who can take over AT ANY TIME. Leaders can also replace their heirs at anytime.
- Heirs get ability to take over leadership, relegating current leader to regular member.

Possibility for Nations 2.3 -- A variety of end-game possibilities including peaceful victories, diplomatic victories and domination victories.

Possibility for Nations 2.x -- Government forms (Democracy, Despotism, Communism, etc), Internal political factions, internal faction voting system, coups, etc.