### PR TITLE
More character setup changes

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -1,20 +1,38 @@
-/proc/random_underwear(var/gender)
+proc/random_underwear(gender, species = "Human")
+	var/list/pick_list = list()
 	switch(gender)
-		if(MALE)	return pick(underwear_m)
-		if(FEMALE)	return pick(underwear_f)
-		else		return pick(underwear_list)
+		if(MALE)	pick_list = underwear_m
+		if(FEMALE)	pick_list = underwear_f
+		else		pick_list = underwear_list
+	return pick_species_allowed_underwear(pick_list, species)
 
-/proc/random_undershirt(var/gender)
+proc/random_undershirt(gender, species = "Human")
+	var/list/pick_list = list()
 	switch(gender)
-		if(MALE)	return pick(undershirt_m)
-		if(FEMALE)	return pick(undershirt_f)
-		else		return pick(undershirt_list)
+		if(MALE)	pick_list = undershirt_m
+		if(FEMALE)	pick_list = undershirt_f
+		else		pick_list = undershirt_list
+	return pick_species_allowed_underwear(pick_list, species)
 
-/proc/random_socks(gender)
+proc/random_socks(gender, species = "Human")
+	var/list/pick_list = list()
 	switch(gender)
-		if(MALE)	return pick(socks_m)
-		if(FEMALE)	return pick(socks_f)
-		else		return pick(socks_list)
+		if(MALE)	pick_list = socks_m
+		if(FEMALE)	pick_list = socks_f
+		else		pick_list = socks_list
+	return pick_species_allowed_underwear(pick_list, species)
+
+proc/pick_species_allowed_underwear(list/all_picks, species)
+	var/list/valid_picks = list()
+	for(var/test in all_picks)
+		var/datum/sprite_accessory/S = all_picks[test]
+		if(!(species in S.species_allowed))
+			continue
+		valid_picks += test
+
+	if(!valid_picks.len) valid_picks += "Nude"
+
+	return pick(valid_picks)
 
 proc/random_hair_style(var/gender, species = "Human")
 	var/h_style = "Bald"
@@ -35,7 +53,7 @@ proc/random_hair_style(var/gender, species = "Human")
 
 	return h_style
 
-/proc/GetOppositeDir(var/dir)
+proc/GetOppositeDir(var/dir)
 	switch(dir)
 		if(NORTH)     return SOUTH
 		if(SOUTH)     return NORTH

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1108,6 +1108,19 @@ datum/preferences
 								//this shouldn't happen
 								f_style = facial_hair_styles_list["Shaved"]
 
+							// Don't wear another species' underwear!
+							var/datum/sprite_accessory/S = underwear_list[underwear]
+							if(!(species in S.species_allowed))
+								underwear = random_underwear(gender, species)
+
+							S = undershirt_list[undershirt]
+							if(!(species in S.species_allowed))
+								undershirt = random_undershirt(gender, species)
+
+							S = socks_list[socks]
+							if(!(species in S.species_allowed))
+								socks = random_socks(gender, species)
+
 							//reset hair colour and skin colour
 							r_hair = 0//hex2num(copytext(new_hair, 2, 4))
 							g_hair = 0//hex2num(copytext(new_hair, 4, 6))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1040,7 +1040,7 @@ datum/preferences
 			if("input")
 				switch(href_list["preference"])
 					if("name")
-						var/raw_name = input(user, "Choose your character's name:", "Character Preference")  as text|null
+						var/raw_name = input(user, "Choose your character's name:", "Character Preference") as text|null
 						if (!isnull(raw_name)) // Check to ensure that the user entered text (rather than cancel.)
 							var/new_name = reject_bad_name(raw_name)
 							if(new_name)
@@ -1156,7 +1156,7 @@ datum/preferences
 							var/input = "Choose your character's hair colour:"
 							if(species == "Machine")
 								input = "Choose your character's frame colour:"
-							var/new_hair = input(user, input, "Character Preference") as color|null
+							var/new_hair = input(user, input, "Character Preference", rgb(r_hair, g_hair, b_hair)) as color|null
 							if(new_hair)
 								r_hair = hex2num(copytext(new_hair, 2, 4))
 								g_hair = hex2num(copytext(new_hair, 4, 6))
@@ -1193,7 +1193,7 @@ datum/preferences
 							body_accessory = (new_body_accessory == "None") ? null : new_body_accessory
 
 					if("facial")
-						var/new_facial = input(user, "Choose your character's facial-hair colour:", "Character Preference") as color|null
+						var/new_facial = input(user, "Choose your character's facial-hair colour:", "Character Preference", rgb(r_facial, g_facial, b_facial)) as color|null
 						if(new_facial)
 							r_facial = hex2num(copytext(new_facial, 2, 4))
 							g_facial = hex2num(copytext(new_facial, 4, 6))
@@ -1255,7 +1255,7 @@ datum/preferences
 							socks = new_socks
 
 					if("eyes")
-						var/new_eyes = input(user, "Choose your character's eye colour:", "Character Preference") as color|null
+						var/new_eyes = input(user, "Choose your character's eye colour:", "Character Preference", rgb(r_eyes, g_eyes, b_eyes)) as color|null
 						if(new_eyes)
 							r_eyes = hex2num(copytext(new_eyes, 2, 4))
 							g_eyes = hex2num(copytext(new_eyes, 4, 6))
@@ -1270,7 +1270,7 @@ datum/preferences
 
 					if("skin")
 						if((species in list("Unathi", "Tajaran", "Skrell", "Slime People", "Vulpkanin", "Machine")) || body_accessory_by_species[species] || check_rights(R_ADMIN, 0, user))
-							var/new_skin = input(user, "Choose your character's skin colour: ", "Character Preference") as color|null
+							var/new_skin = input(user, "Choose your character's skin colour: ", "Character Preference", rgb(r_skin, g_skin, b_skin)) as color|null
 							if(new_skin)
 								r_skin = hex2num(copytext(new_skin, 2, 4))
 								g_skin = hex2num(copytext(new_skin, 4, 6))
@@ -1278,7 +1278,7 @@ datum/preferences
 
 
 					if("ooccolor")
-						var/new_ooccolor = input(user, "Choose your OOC colour:", "Game Preference") as color|null
+						var/new_ooccolor = input(user, "Choose your OOC colour:", "Game Preference", ooccolor) as color|null
 						if(new_ooccolor)
 							ooccolor = new_ooccolor
 
@@ -1423,7 +1423,7 @@ datum/preferences
 								UI_style = "Midnight"
 
 					if("UIcolor")
-						var/UI_style_color_new = input(user, "Choose your UI color, dark colors are not recommended!") as color|null
+						var/UI_style_color_new = input(user, "Choose your UI color, dark colors are not recommended!", UI_style_color) as color|null
 						if(!UI_style_color_new) return
 						UI_style_color = UI_style_color_new
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -5,9 +5,9 @@ datum/preferences
 			gender = gender_override
 		else
 			gender = pick(MALE, FEMALE)
-		underwear = random_underwear(gender)
-		undershirt = random_undershirt(gender)
-		socks = random_socks(gender)
+		underwear = random_underwear(gender, species)
+		undershirt = random_undershirt(gender, species)
+		socks = random_socks(gender, species)
 		if(species == "Human")
 			s_tone = random_skin_tone()
 		h_style = random_hair_style(gender, species)

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -28,11 +28,11 @@
 		L[D.name] = D
 
 		switch(D.gender)
-			if(MALE)	male += D.name
-			if(FEMALE)	female += D.name
+			if(MALE)	male[D.name] = D
+			if(FEMALE)	female[D.name] = D
 			else
-				male += D.name
-				female += D.name
+				male[D.name] = D
+				female[D.name] = D
 	return L
 
 /datum/sprite_accessory
@@ -1019,7 +1019,7 @@
 /datum/sprite_accessory/underwear
 	icon = 'icons/mob/underwear.dmi'
 
-	species_allowed = list("Human","Unathi","Vox","Diona","Kidan","Grey","Plasmaman","Skellington")
+	species_allowed = list("Human","Unathi","Vox","Diona","Vulpkanin","Kidan","Grey","Plasmaman","Skellington")
 
 	nude
 		name = "Nude"
@@ -1092,7 +1092,7 @@
 /datum/sprite_accessory/undershirt
 	icon = 'icons/mob/underwear.dmi'
 
-	species_allowed = list("Human","Unathi","Vox","Diona","Kidan","Grey","Plasmaman","Skellington")
+	species_allowed = list("Human","Unathi","Vox","Diona","Vulpkanin","Kidan","Grey","Plasmaman","Skellington")
 
 /datum/sprite_accessory/undershirt/nude
 	name = "Nude"
@@ -1331,6 +1331,7 @@
 ///////////////////////
 /datum/sprite_accessory/socks
 	icon = 'icons/mob/underwear.dmi'
+	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 /datum/sprite_accessory/socks/nude
 	name = "Nude"
@@ -1343,111 +1344,95 @@
 	name = "Normal White"
 	icon_state = "white_norm"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/black_norm
 	name = "Normal Black"
 	icon_state = "black_norm"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/white_short
 	name = "Short White"
 	icon_state = "white_short"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/black_short
 	name = "Short Black"
 	icon_state = "black_short"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/white_knee
 	name = "Knee-high White"
 	icon_state = "white_knee"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/black_knee
 	name = "Knee-high Black"
 	icon_state = "black_knee"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/thin_knee
 	name = "Knee-high Thin"
 	icon_state = "thin_knee"
 	gender = FEMALE
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/striped_knee
 	name = "Knee-high Striped"
 	icon_state = "striped_knee"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/rainbow_knee
 	name = "Knee-high Rainbow"
 	icon_state = "rainbow_knee"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/white_thigh
 	name = "Thigh-high White"
 	icon_state = "white_thigh"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 /datum/sprite_accessory/socks/black_thigh
 	name = "Thigh-high Black"
 	icon_state = "black_thigh"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/thin_thigh
 	name = "Thigh-high Thin"
 	icon_state = "thin_thigh"
 	gender = FEMALE
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/striped_thigh
 	name = "Thigh-high Striped"
 	icon_state = "striped_thigh"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/rainbow_thigh
 	name = "Thigh-high Rainbow"
 	icon_state = "rainbow_thigh"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/pantyhose
 	name = "Pantyhose"
 	icon_state = "pantyhose"
 	gender = FEMALE
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 
 /datum/sprite_accessory/socks/black_fishnet
 	name = "Black Fishnet"
 	icon_state = "black_fishnet"
 	gender = NEUTER
-	species_allowed = list("Human","Unathi","Diona","Grey","Machine","Tajaran","Vulpkanin","Slime People","Skellington")
 
 /datum/sprite_accessory/socks/vox_white
 	name = "Vox White"


### PR DESCRIPTION
* "Choose color" dialogs in character setup open with the current color as default (C.M.A. already does this).
* Random underwear/undershirt/socks generation now filters by allowed species.
* Added a check for allowed species for underwear/undershirt/socks when switching species in character setup; randomly generates a new one (or "Nude" if not applicable) if it doesn't pass.
* Added Vulpkanin to default species_allowed for underwear and undershirts (a rude oversight!).
* Moved redundant species_allowed lists in non-Vox-exclusive socks datums to the parent type.