### PR TITLE
Rad Sickness Fix

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -37,7 +37,7 @@
 		block=RADBLOCK
 
 	OnMobLife(var/mob/living/owner)
-		owner.apply_effect(max(owner.radiation, 5), IRRADIATE)
+		owner.apply_effect(5, IRRADIATE)
 		for(var/mob/living/L in range(1, owner))
 			if(L == owner)
 				continue

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -37,7 +37,8 @@
 		block=RADBLOCK
 
 	OnMobLife(var/mob/living/owner)
-		owner.apply_effect(5, IRRADIATE)
+		var/radiation_amount = abs(min(owner.radiation - 20,0))
+		owner.apply_effect(radiation_amount, IRRADIATE)
 		for(var/mob/living/L in range(1, owner))
 			if(L == owner)
 				continue

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -37,9 +37,9 @@
 		block=RADBLOCK
 
 	OnMobLife(var/mob/living/owner)
-		owner.apply_effect(max(owner.radiation, 20), IRRADIATE)
+		owner.apply_effect(max(owner.radiation, 5), IRRADIATE)
 		for(var/mob/living/L in range(1, owner))
-			if(L == owner) 
+			if(L == owner)
 				continue
 			L << "<span class='danger'>You are enveloped by a soft green glow emanating from [owner].</span>"
 			L.apply_effect(5, IRRADIATE)


### PR DESCRIPTION
Fixes the rad mutation so it keeps your rads at 20, like it originally did.

When this was changed so that it wasn't setting radiation, directly, it had the unintended consequences of making the radiation keep applying past the threshold; this fixes that so that your radiation levels will always be at 20 if you have this gene.