### PR TITLE
Borg death fixes, human cleanup, carbon life tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -821,112 +821,67 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	return //TODO: DEFERRED
 
 /mob/living/carbon/human/handle_regular_status_updates()
-
 	if(status_flags & GODMODE)
 		return 0
+
+	. = ..()
 
 	//SSD check, if a logged player is awake put them back to sleep!
 	if(player_logged && sleeping < 2)
 		sleeping = 2
 
-	if(stat == DEAD)	//DEAD. BROWN BREAD. SWIMMING WITH THE SPESS CARP
-		blinded = 1
-		silent = 0
-	else				//ALIVE. LIGHTS ARE ON
-
+	if(.) //alive
 		if(REGEN in mutations)
 			if(nutrition)
 				if(prob(10))
-					var/randumb = rand(1,5)
+					var/randumb = rand(1, 5)
 					nutrition -= randumb
-					heal_overall_damage(randumb,randumb)
+					heal_overall_damage(randumb, randumb)
 				if(nutrition < 0)
 					nutrition = 0
 
-		// Sobering multiplier.
-		// Sober block grants quadruple the alcohol metabolism.
-//			var/sober_str=!(SOBER in mutations)?1:4
-
-		updatehealth()	//TODO
 		if(!in_stasis)
-			handle_organs()	//Optimized.
+			handle_organs()
 			handle_blood()
 
-		if(health <= config.health_threshold_dead || brain_op_stage == 4.0)
-			death()
-			blinded = 1
-			silent = 0
-			return 1
-
-		// the analgesic effect wears off slowly
+		//the analgesic effect wears off slowly
 		analgesic = max(0, analgesic - 1)
 
-		//UNCONSCIOUS. NO-ONE IS HOME
-		if( (getOxyLoss() > 50) || (config.health_threshold_crit >= health) )
-			Paralyse(3)
-
-			/* Done by handle_breath()
-			if( health <= 20 && prob(1) )
-				spawn(0)
-					emote("gasp")
-			if(!reagents.has_reagent("epinephrine"))
-				adjustOxyLoss(1)*/
-
 		if(hallucination && !(species.flags & NO_DNA_RAD))
-			spawn handle_hallucinations()
+			spawn()
+				handle_hallucinations()
 
-			if(hallucination<=2)
+			if(hallucination <= 2)
 				hallucination = 0
 				halloss = 0
 			else
 				hallucination -= 2
 
-
-		if(halloss > 100)
-			src << "<span class='notice'>You're in too much pain to keep going...</span>"
-			for(var/mob/O in oviewers(src, null))
-				O.show_message("<B>[src]</B> slumps to the ground, too weak to continue fighting.", 1)
-			Paralyse(10)
-			setHalLoss(99)
-
 		if(paralysis)
 			blinded = 1
 			stat = UNCONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-3)
+
 		else if(sleeping)
 			speech_problem_flag = 1
-			handle_dreams()
-			adjustStaminaLoss(-10)
-			adjustHalLoss(-3)
-			if (mind)
+
+			if(mind)
 				//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of ether or similar.
 				if(player_logged)
-					sleeping = max(sleeping-1, 2)
-				else
-					sleeping = max(sleeping-1, 0)
+					sleeping = max(sleeping - 1, 2)
+
 			blinded = 1
 			stat = UNCONSCIOUS
-			if( prob(2) && health && !hal_crit )
-				spawn(0)
-					emote("snore")
+
 			if(mind)
 				if(mind.vampire)
 					if(istype(loc, /obj/structure/closet/coffin))
 						adjustBruteLoss(-1)
 						adjustFireLoss(-1)
 						adjustToxLoss(-1)
+
 		else if(status_flags & FAKEDEATH)
 			blinded = 1
 			stat = UNCONSCIOUS
-		else if(resting)
-			if(halloss > 0)
-				adjustHalLoss(-3)
-		//CONSCIOUS
-		else
-			stat = CONSCIOUS
-			if(halloss > 0)
-				adjustHalLoss(-1)
 
 		if(embedded_flag && !(mob_master.current_cycle % 10))
 			var/list/E
@@ -934,7 +889,8 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			if(!E.len)
 				embedded_flag = 0
 
-		//Vision
+
+		//Vision //god knows why this is here
 		var/obj/item/organ/vision
 		if(species.vision_organ)
 			vision = internal_organs_by_name[species.vision_organ]
@@ -943,17 +899,21 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			eye_blind =  0
 			blinded =    0
 			eye_blurry = 0
+
 		else if(!vision || vision.is_broken())   // Vision organs cut out or broken? Permablind.
 			eye_blind =  1
 			blinded =    1
 			eye_blurry = 1
+
 		else
 			//blindness
 			if(sdisabilities & BLIND) // Disabled-blind, doesn't get better on its own
 				blinded =    1
+
 			else if(eye_blind)		       // Blindness, heals slowly over time
 				eye_blind =  max(eye_blind-1,0)
 				blinded =    1
+
 			else if(istype(glasses, /obj/item/clothing/glasses/sunglasses/blindfold))	//resting your eyes with a blindfold heals blurry eyes faster
 				eye_blurry = max(eye_blurry-3, 0)
 				blinded =    1
@@ -961,59 +921,26 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 			//blurry sight
 			if(vision.is_bruised())   // Vision organs impaired? Permablurry.
 				eye_blurry = 1
+
 			if(eye_blurry)	           // Blurry eyes heal slowly
 				eye_blurry = max(eye_blurry-1, 0)
+
 
 		//Ears
 		if(sdisabilities & DEAF)	//disabled-deaf, doesn't get better on its own
 			ear_deaf = max(ear_deaf, 1)
+
 		else if(ear_deaf)			//deafness, heals slowly over time
-			ear_deaf = max(ear_deaf-1, 0)
+			ear_deaf = max(ear_deaf - 1, 0)
+
 		else if(istype(l_ear, /obj/item/clothing/ears/earmuffs) || istype(r_ear, /obj/item/clothing/ears/earmuffs))	//resting your ears with earmuffs heals ear damage faster
-			ear_damage = max(ear_damage-0.15, 0)
+			ear_damage = max(ear_damage - 0.15, 0)
 			ear_deaf = max(ear_deaf, 1)
+
 		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
-			ear_damage = max(ear_damage-0.05, 0)
+			ear_damage = max(ear_damage - 0.05, 0)
 
-		//Dizziness
-		if(dizziness)
-			var/client/C = client
-			var/pixel_x_diff = 0
-			var/pixel_y_diff = 0
-			var/temp
-			var/saved_dizz = dizziness
-			dizziness = max(dizziness-1, 0)
-			if(C)
-				var/oldsrc = src
-				var/amplitude = dizziness*(sin(dizziness * 0.044 * world.time) + 1) / 70 // This shit is annoying at high strength
-				src = null
-				spawn(0)
-					if(C)
-						temp = amplitude * sin(0.008 * saved_dizz * world.time)
-						pixel_x_diff += temp
-						C.pixel_x += temp
-						temp = amplitude * cos(0.008 * saved_dizz * world.time)
-						pixel_y_diff += temp
-						C.pixel_y += temp
-						sleep(3)
-						if(C)
-							temp = amplitude * sin(0.008 * saved_dizz * world.time)
-							pixel_x_diff += temp
-							C.pixel_x += temp
-							temp = amplitude * cos(0.008 * saved_dizz * world.time)
-							pixel_y_diff += temp
-							C.pixel_y += temp
-						sleep(3)
-						if(C)
-							C.pixel_x -= pixel_x_diff
-							C.pixel_y -= pixel_y_diff
-				src = oldsrc
 
-		//Jitteryness
-		if(jitteriness)
-			do_jitter_animation(jitteriness)
-
-		//Flying
 		if(flying)
 			spawn()
 				animate(src, pixel_y = pixel_y + 5 , time = 10, loop = 1, easing = SINE_EASING)
@@ -1025,9 +952,11 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		if(gloves && germ_level > gloves.germ_level && prob(10))
 			gloves.germ_level += 1
 
-		CheckStamina()
 
-	return 1
+	else //dead
+		blinded = 1
+		silent = 0
+
 
 /mob/living/carbon/human/handle_vision()
 	client.screen.Remove(global_hud.blurry, global_hud.druggy, global_hud.vimpaired, global_hud.darkMask)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -296,8 +296,8 @@
 	if(sleeping)
 		handle_dreams()
 		adjustStaminaLoss(-10)
-		sleeping = max(sleeping-1, 0)
-		if( prob(10) && health && !hal_crit )
+		sleeping = max(sleeping - 1, 0)
+		if(prob(10) && health && !hal_crit)
 			spawn(0)
 				emote("snore")
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -19,38 +19,35 @@
 	SetWeakened(min(weakened, 20))
 	sleeping = 0
 	ear_deaf = 0
-	adjustBruteLoss(0)
-	adjustToxLoss(0)
-	adjustOxyLoss(0)
-	adjustFireLoss(0)
+
 
 /mob/living/silicon/robot/proc/use_power()
-	if (is_component_functioning("power cell") && cell)
+	if(is_component_functioning("power cell") && cell)
 		for(var/obj/item/borg/B in module.modules)
 			if(B.powerneeded)
 				if((cell.charge * 100 / cell.maxcharge) < B.powerneeded)
 					src << "Deactivating [B.name] due to lack of power!"
 					unEquip(B)
-		if(src.cell.charge <= 0)
+		if(cell.charge <= 0)
 			uneq_all()
 			update_headlamp(1)
-			src.stat = UNCONSCIOUS
+			stat = UNCONSCIOUS
 			has_power = 0
 			for(var/V in components)
 				var/datum/robot_component/C = components[V]
 				if(C.name == "actuator") // Let drained robots move, disable the rest
 					continue
 				C.consume_power()
-		else if (src.cell.charge <= 100)
+		else if(cell.charge <= 100)
 			uneq_all()
-			src.cell.use(1)
+			cell.use(1)
 		else
-			if(src.module_state_1)
-				src.cell.use(4)
-			if(src.module_state_2)
-				src.cell.use(4)
-			if(src.module_state_3)
-				src.cell.use(4)
+			if(module_state_1)
+				cell.use(4)
+			if(module_state_2)
+				cell.use(4)
+			if(module_state_3)
+				cell.use(4)
 
 			for(var/V in components)
 				var/datum/robot_component/C = components[V]
@@ -61,130 +58,116 @@
 
 			if(!is_component_functioning("actuator"))
 				Paralyse(3)
-			src.eye_blind = 0
-			src.stat = 0
+			eye_blind = 0
+			stat = 0
 			has_power = 1
 	else
 		uneq_all()
-		src.stat = UNCONSCIOUS
+		stat = UNCONSCIOUS
 		update_headlamp(1)
 		Paralyse(3)
 
-/mob/living/silicon/robot/handle_regular_status_updates()
-
-	if(src.camera && !scrambledcodes)
-		if(src.stat == 2 || wires.IsCameraCut())
-			src.camera.status = 0
-		else
-			src.camera.status = 1
-
+/mob/living/silicon/robot/updatehealth()
+	if(status_flags & GODMODE)
+		health = maxHealth
+		stat = CONSCIOUS
+		return
 	health = maxHealth - (getOxyLoss() + getFireLoss() + getBruteLoss())
 
-	if(getOxyLoss() > 50) Paralyse(3)
+/mob/living/silicon/robot/handle_regular_status_updates()
 
-	if(src.sleeping)
+	. = ..()
+
+	if(camera && !scrambledcodes)
+		if(stat == DEAD || wires.IsCameraCut())
+			camera.status = 0
+		else
+			camera.status = 1
+
+	if(getOxyLoss() > 50)
 		Paralyse(3)
-		src.sleeping--
 
-	if(src.resting)
+	if(sleeping)
+		Paralyse(3)
+		sleeping--
+
+	if(resting)
 		Weaken(5)
 
-	if(health <= config.health_threshold_dead && src.stat != 2) //die only once
-		death()
+	if(.) //alive
+		if(health <= config.health_threshold_dead)
+			death()
+			return
 
-	if (src.stat != 2) //Alive.
-		if(!istype(src,/mob/living/silicon/robot/drone))
+		if(!istype(src, /mob/living/silicon/robot/drone))
 			if(health < 50) //Gradual break down of modules as more damage is sustained
 				if(uneq_module(module_state_3))
 					src << "<span class='warning'>SYSTEM ERROR: Module 3 OFFLINE.</span>"
+
 				if(health < 0)
 					if(uneq_module(module_state_2))
 						src << "<span class='warning'>SYSTEM ERROR: Module 2 OFFLINE.</span>"
+
 					if(health < -50)
 						if(uneq_module(module_state_1))
 							src << "<span class='warning'>CRITICAL ERROR: All modules OFFLINE.</span>"
 
-		if (src.paralysis || src.stunned || src.weakened) //Stunned etc.
-			src.stat = 1
-			if (src.stunned > 0)
-				AdjustStunned(-1)
-			if (src.weakened > 0)
-				AdjustWeakened(-1)
-			if (src.paralysis > 0)
-				AdjustParalysis(-1)
-				src.eye_blind = max(eye_blind, 1)
-			else
-				src.eye_blind = 0
+		if(paralysis || stunned || weakened)
+			stat = UNCONSCIOUS
 
-		else	//Not stunned.
-			src.stat = 0
+			if(!paralysis > 0)
+				eye_blind = 0
 
-	else //Dead.
-		src.eye_blind = 1
+		else
+			stat = CONSCIOUS
 
-	if (src.stuttering) src.stuttering--
-
-	if (src.eye_blind)
-		src.eye_blind--
-
-	src.density = !( src.lying )
-
-	if (src.disabilities & BLIND)
-		src.eye_blind = max(1, eye_blind)
-
-	if (src.eye_blurry > 0)
-		src.eye_blurry--
-		src.eye_blurry = max(0, src.eye_blurry)
-
-	if (src.druggy > 0)
-		src.druggy--
-		src.druggy = max(0, src.druggy)
+	else //dead
+		eye_blind = 1
 
 	//update the state of modules and components here
-	if (src.stat != 0)
+	if(stat != CONSCIOUS)
 		uneq_all()
 
-	if(!is_component_functioning("radio") || src.stat == 1)
+	if(!is_component_functioning("radio") || stat == UNCONSCIOUS)
 		radio.on = 0
 	else
 		radio.on = 1
 
-	if(is_component_functioning("camera") && src.stat == 0)
-		src.blinded = 0
+	if(is_component_functioning("camera") && stat == CONSCIOUS)
+		blinded = 0
 	else
-		src.blinded = 1
+		blinded = 1
 
 	if(!is_component_functioning("actuator"))
-		src.Paralyse(3)
+		Paralyse(3)
 
 	return 1
 
 /mob/living/silicon/robot/update_sight()
-
-	if (src.stat == 2 || src.sight_mode & BORGXRAY)
-		src.sight |= SEE_TURFS
-		src.sight |= SEE_MOBS
-		src.sight |= SEE_OBJS
-		src.see_in_dark = 8
-		src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+	if(stat == DEAD || sight_mode & BORGXRAY)
+		sight |= SEE_TURFS
+		sight |= SEE_MOBS
+		sight |= SEE_OBJS
+		see_in_dark = 8
+		see_invisible = SEE_INVISIBLE_LEVEL_TWO
 	else
-		src.see_in_dark = 8
-		if (src.sight_mode & BORGMESON && src.sight_mode & BORGTHERM)
-			src.sight |= SEE_TURFS
-			src.sight |= SEE_MOBS
-			src.see_invisible = SEE_INVISIBLE_MINIMUM
-		else if (src.sight_mode & BORGMESON)
-			src.sight |= SEE_TURFS
-			src.see_invisible = SEE_INVISIBLE_MINIMUM
-			src.see_in_dark = 1
-		else if (src.sight_mode & BORGTHERM)
-			src.sight |= SEE_MOBS
-			src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
-		else if (src.stat != 2)
-			src.sight &= ~SEE_MOBS
-			src.sight &= ~SEE_TURFS
-			src.sight &= ~SEE_OBJS
-			src.see_invisible = SEE_INVISIBLE_LEVEL_TWO
+		see_in_dark = 8
+		if(sight_mode & BORGMESON && sight_mode & BORGTHERM)
+			sight |= SEE_TURFS
+			sight |= SEE_MOBS
+			see_invisible = SEE_INVISIBLE_MINIMUM
+		else if(sight_mode & BORGMESON)
+			sight |= SEE_TURFS
+			see_invisible = SEE_INVISIBLE_MINIMUM
+			see_in_dark = 1
+		else if(sight_mode & BORGTHERM)
+			sight |= SEE_MOBS
+			see_invisible = SEE_INVISIBLE_LEVEL_TWO
+		else if(stat != DEAD)
+			sight &= ~SEE_MOBS
+			sight &= ~SEE_TURFS
+			sight &= ~SEE_OBJS
+			see_invisible = SEE_INVISIBLE_LEVEL_TWO
 		if(see_override)
 			see_invisible = see_override
 
@@ -198,11 +181,11 @@
 		if(stat != DEAD)
 			if(health >= maxHealth)
 				healths.icon_state = "health0"
-			else if(health > maxHealth*0.5)
+			else if(health > maxHealth * 0.5)
 				healths.icon_state = "health2"
 			else if(health > 0)
 				healths.icon_state = "health3"
-			else if(health > -maxHealth*0.5)
+			else if(health > -maxHealth * 0.5)
 				healths.icon_state = "health4"
 			else if(health > -maxHealth)
 				healths.icon_state = "health5"


### PR DESCRIPTION
fixes #2692 

The problem actually was that borgs called death() without returning
therefore the rest of Life() would run, and reset stat

More halloss implementations in human/Life() have been removed, halloss basically does nothing at all now, since it's unused. 