### PR TITLE
Phlog Nerf/Balance

### DIFF
--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -428,7 +428,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	if(holder.has_reagent("stabilizing_agent"))
 		return
 	var/turf/simulated/T = get_turf(holder.my_atom)
-	for(var/turf/simulated/turf in range(created_volume/10,T))
+	for(var/turf/simulated/turf in range(min(created_volume/10,4),T))
 		new /obj/effect/hotspot(turf)
 	return
 


### PR DESCRIPTION
I forgot to put a limiter on this, meaning that Phlog reactions scale as large as you can get a container.

End results is two bluespace beakers will generate a 91x91 grid fireball.

This caps the grid size to 9x9, which is still very large, but not totally and completely ridiculous.