### PR TITLE
Player Spider Fixes

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -78,6 +78,7 @@
 	var/amount_grown = 0
 	var/player_spiders = 0
 	var/faction = list()
+	var/master_commander = null
 
 /obj/effect/spider/eggcluster/New()
 	pixel_x = rand(3,-3)
@@ -91,6 +92,7 @@
 		for(var/i=0, i<num, i++)
 			var/obj/effect/spider/spiderling/S = new /obj/effect/spider/spiderling(src.loc)
 			S.faction = faction
+			S.master_commander = master_commander
 			if(player_spiders)
 				S.player_spiders = 1
 		qdel(src)
@@ -108,6 +110,7 @@
 	var/travelling_in_vent = 0
 	var/player_spiders = 0
 	var/faction = list()
+	var/master_commander = null
 
 /obj/effect/spider/spiderling/New()
 	pixel_x = rand(6,-6)
@@ -193,6 +196,7 @@
 				grow_as = pick(typesof(/mob/living/simple_animal/hostile/poison/giant_spider))
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(src.loc)
 			S.faction = faction
+			S.master_commander = master_commander
 			if(player_spiders)
 				var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 				var/client/C = null
@@ -200,6 +204,8 @@
 				if(candidates.len)
 					C = pick(candidates)
 					S.key = C.key
+					if(master_commander)
+						S << "<span class='userdanger'>You are a spider who is loyal to [master_commander], obey [master_commander]'s every order and assist them in completing their goals at any cost.</span>"
 			qdel(src)
 
 /obj/effect/decal/cleanable/spiderling_remains

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -828,6 +828,9 @@ mob/living/carbon/slime/var/temperature_resistance = T0C+75
 		M << "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>"
 		M << "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>"
 		user << "<span class='notice'>[M] accepts the potion and suddenly becomes attentive and aware. It worked!</span>"
+		if(isanimal(M))
+			var/mob/living/simple_animal/S = M
+			S.master_commander = user
 		qdel(src)
 	else
 		user << "<span class='notice'>[M] looks interested for a moment, but then looks back down. Maybe you should try again later.</span>"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -257,6 +257,7 @@
 				if(!E)
 					var/obj/effect/spider/eggcluster/C = new /obj/effect/spider/eggcluster(src.loc)
 					C.faction = faction
+					C.master_commander = master_commander
 					if(ckey)
 						C.player_spiders = 1
 					fed--

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -72,6 +72,8 @@
 	var/scan_ready = 1
 	var/simplespecies //Sorry, no spider+corgi buttbabies.
 
+	var/master_commander = null //holding var for determining who own/controls a sentient simple animal (for sentience potions).
+
 
 /mob/living/simple_animal/New()
 	..()


### PR DESCRIPTION
Maybe a feature? It's a fix, IMO.

Makes it so that player spiders who are spawned in via sentience potions get a notification very similar to the sentience potion; it notifies them that the original user of the sentience potion (on the original spider) is their master and that they should obey+protect them.

If badmins make player spiders, this notification does *NOT* pop up, meaning you can go full ham, technically (if in doubt, ahelp!)

Basically--if you see this notification as a spider, don't go around attacking everyone on sight unless your master or your fellow spiders (who got orders from the master) tells them to.

Code Wise

- Added a new master_commander var, which can be used for things like sentience options; this has a side effects of making it much easier to track who created sentient mobs, as well.