### PR TITLE
Mecha mmi Tweaks and Fix

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -794,7 +794,16 @@
 		else if(state==3)
 			state=2
 			user << "You close the hatch to the power unit"
+		else if(state==4 && pilot_is_mmi())
+			// Since having maint protocols available is controllable by the MMI, I see this as a consensual way to remove an MMI without destroying the mech
+			user.visible_message("[user] begins levering out the MMI from the [src].", "You begin to lever out the MMI from the [src].")
+			occupant << "<span class='warning'>[user] is prying you out of the exosuit!</span>"
+			if(do_after(user,80,target=src))
+				user.visible_message("<span class='notice'>[user] pries the MMI out of the [src]!</span>", "<span class='notice'>You finish removing the MMI from the [src]!</span>")
+				go_out()
 		return
+
+			
 	else if(istype(W, /obj/item/stack/cable_coil))
 		if(state == 3 && hasInternalDamage(MECHA_INT_SHORT_CIRCUIT))
 			var/obj/item/stack/cable_coil/CC = W
@@ -1264,6 +1273,18 @@
 		return 1
 	else
 		return 0
+
+/obj/mecha/proc/pilot_is_mmi()
+	var/atom/movable/mob_container
+	if(istype(occupant, /mob/living/carbon/brain))
+		var/mob/living/carbon/brain/brain = occupant
+		mob_container = brain.container
+	if(istype(mob_container, /obj/item/device/mmi))
+		return 1
+	return 0
+
+/obj/mecha/proc/pilot_mmi_hud(var/mob/living/carbon/brain/pilot)
+	return
 
 /obj/mecha/verb/view_stats()
 	set name = "View Stats"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -323,6 +323,7 @@
 		move_result = mechstep(direction)
 	if(move_result)
 		can_move = 0
+		use_power(step_energy_drain)
 		if(mecha_do_after(step_in))
 			can_move = 1
 		return 1
@@ -803,7 +804,7 @@
 				go_out()
 		return
 
-			
+
 	else if(istype(W, /obj/item/stack/cable_coil))
 		if(state == 3 && hasInternalDamage(MECHA_INT_SHORT_CIRCUIT))
 			var/obj/item/stack/cable_coil/CC = W
@@ -1250,7 +1251,7 @@
 			return 0
 		if(!user.unEquip(mmi_as_oc))
 			user << "<span class='notice'>\the [mmi_as_oc] is stuck to your hand, you cannot put it in \the [src]</span>"
-			return
+			return 0
 		var/mob/brainmob = mmi_as_oc.brainmob
 		brainmob.reset_view(src)
 	/*

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -34,9 +34,17 @@
 	if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		if(salvage_num <= 0)
-			user << "You don't see anything that can be cut with [W]."
+			user.visible_message("[user] begins to slice apart the now completely stripped [src].", "You begin to slice apart the [src].", "You hear the sound of a welder nearby.")
+			if(do_after(user,80,target=src))
+				user.visible_message("The now-dilapidated [src] falls apart in a clatter.", "As you slice apart the final support structures, the [src] falls apart in a heap.", "You hear metal clanking to the floor.")
+				new /obj/item/stack/sheet/metal(src.loc)
+				var/obj/item/stack/rods/rods = new /obj/item/stack/rods(src.loc)
+				rods.amount = 2
+				qdel(src)
 			return
-		if (!isemptylist(welder_salvage) && WT.remove_fuel(0,user))
+		if (isemptylist(welder_salvage))
+			user << "<span class='warning'>What's left on the [src] cannot be removed with a welder, besides the frame itself</span>"
+		else if(WT.remove_fuel(0,user))
 			var/type = prob(70)?pick(welder_salvage):null
 			if(type)
 				var/N = new type(get_turf(user))

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -38,7 +38,8 @@
 			if(WT.remove_fuel(0,user) && do_after(user,80,target=src))
 				user.visible_message("The now-dilapidated [src] falls apart in a clatter.", "As you slice apart the final support structures, the [src] falls apart in a heap.", "You hear metal clanking to the floor.")
 				new /obj/item/stack/sheet/metal(src.loc)
-				new /obj/item/stack/rods { amount = 2 } (src.loc)
+				var/obj/item/stack/rods/rods = new /obj/item/stack/rods(src.loc)
+				rods.amount = 2
 				qdel(src)
 		else
 			if (isemptylist(welder_salvage))

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -38,8 +38,7 @@
 			if(WT.remove_fuel(0,user) && do_after(user,80,target=src))
 				user.visible_message("The now-dilapidated [src] falls apart in a clatter.", "As you slice apart the final support structures, the [src] falls apart in a heap.", "You hear metal clanking to the floor.")
 				new /obj/item/stack/sheet/metal(src.loc)
-				var/obj/item/stack/rods/rods = new /obj/item/stack/rods(src.loc)
-				rods.amount = 2
+				new /obj/item/stack/rods { amount = 2 } (src.loc)
 				qdel(src)
 		else
 			if (isemptylist(welder_salvage))

--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -35,29 +35,28 @@
 		var/obj/item/weapon/weldingtool/WT = W
 		if(salvage_num <= 0)
 			user.visible_message("[user] begins to slice apart the now completely stripped [src].", "You begin to slice apart the [src].", "You hear the sound of a welder nearby.")
-			if(do_after(user,80,target=src))
+			if(WT.remove_fuel(0,user) && do_after(user,80,target=src))
 				user.visible_message("The now-dilapidated [src] falls apart in a clatter.", "As you slice apart the final support structures, the [src] falls apart in a heap.", "You hear metal clanking to the floor.")
 				new /obj/item/stack/sheet/metal(src.loc)
 				var/obj/item/stack/rods/rods = new /obj/item/stack/rods(src.loc)
 				rods.amount = 2
 				qdel(src)
-			return
-		if (isemptylist(welder_salvage))
-			user << "<span class='warning'>What's left on the [src] cannot be removed with a welder, besides the frame itself</span>"
-		else if(WT.remove_fuel(0,user))
-			var/type = prob(70)?pick(welder_salvage):null
-			if(type)
-				var/N = new type(get_turf(user))
-				user.visible_message("[user] cuts [N] from [src]", "You cut [N] from [src]", "You hear a sound of welder nearby")
-				if(istype(N, /obj/item/mecha_parts/part))
-					welder_salvage -= type
-				salvage_num--
-			else
-				user << "You failed to salvage anything valuable from [src]."
 		else
-			user << "\blue You need more welding fuel to complete this task."
-			return
-	if(istype(W, /obj/item/weapon/wirecutters))
+			if (isemptylist(welder_salvage))
+				user << "<span class='warning'>What's left on the [src] cannot be removed with a welder, besides the frame itself</span>"
+			else if(WT.remove_fuel(0,user))
+				var/type = prob(70)?pick(welder_salvage):null
+				if(type)
+					var/N = new type(get_turf(user))
+					user.visible_message("[user] cuts [N] from [src]", "You cut [N] from [src]", "You hear a sound of welder nearby")
+					if(istype(N, /obj/item/mecha_parts/part))
+						welder_salvage -= type
+					salvage_num--
+				else
+					user << "You failed to salvage anything valuable from [src]."
+			else
+				user << "\blue You need more welding fuel to complete this task."
+	else if(istype(W, /obj/item/weapon/wirecutters))
 		if(salvage_num <= 0)
 			user << "You don't see anything that can be cut with [W]."
 			return
@@ -69,14 +68,13 @@
 				salvage_num--
 			else
 				user << "You failed to salvage anything valuable from [src]."
-	if(istype(W, /obj/item/weapon/crowbar))
+	else if(istype(W, /obj/item/weapon/crowbar))
 		if(!isemptylist(crowbar_salvage))
 			var/obj/S = pick(crowbar_salvage)
 			if(S)
 				S.loc = get_turf(user)
 				crowbar_salvage -= S
 				user.visible_message("[user] pries [S] from [src].", "You pry [S] from [src].")
-			return
 		else
 			user << "You don't see anything that can be pried with [W]."
 	else

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -27,6 +27,11 @@
 		else
 			return 0
 
+	pilot_mmi_hud(var/mob/living/carbon/brain/pilot)
+		pilot.regular_hud_updates()
+		process_med_hud(pilot, 1)
+		return ..()
+
 	go_out()
 		if(ishuman(occupant))
 			var/mob/living/carbon/human/H = occupant
@@ -34,29 +39,6 @@
 				H.glasses = null
 		..()
 		return
-/*
-	verb/set_perspective()
-		set name = "Set client perspective."
-		set category = "Exosuit Interface"
-		set src = usr.loc
-		var/perspective = input("Select a perspective type.",
-                      "Client perspective",
-                      occupant.client.perspective) in list(MOB_PERSPECTIVE,EYE_PERSPECTIVE)
-		world << "[perspective]"
-		occupant.client.perspective = perspective
-		return
-
-	verb/toggle_eye()
-		set name = "Toggle eye."
-		set category = "Exosuit Interface"
-		set src = usr.loc
-		if(occupant.client.eye == occupant)
-			occupant.client.eye = src
-		else
-			occupant.client.eye = occupant
-		world << "[occupant.client.eye]"
-		return
-*/
 
 //TODO - Check documentation for client.eye and client.perspective...
 /obj/item/clothing/glasses/hud/health/mech

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -890,7 +890,10 @@
 	return src
 
 /mob/living/carbon/human/get_rig()
-	return back
+	if(istype(back,/obj/item/weapon/rig))
+		return back
+	else
+		return null
 
 #undef ONLY_DEPLOY
 #undef ONLY_RETRACT

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -12,8 +12,9 @@
 	var/alien = 0
 	var/syndiemmi = 0 //Whether or not this is a Syndicate MMI
 	var/mob/living/carbon/brain/brainmob = null//The current occupant.
-	var/mob/living/silicon/robot = null//Appears unused.
-	var/obj/mecha = null//This does not appear to be used outside of reference in mecha.dm.
+	var/mob/living/silicon/robot/robot = null//Appears unused.
+	var/obj/mecha/mecha = null//This does not appear to be used outside of reference in mecha.dm.
+// I'm using this for mechs giving MMIs HUDs now
 
 	attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 		if(istype(O, /obj/item/organ/brain/crystal ))

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -55,6 +55,7 @@
 
 		if(brainmob)
 			O.attack(brainmob, user)//Oh noooeeeee
+			// Brainmobs can take damage, but they can't actually die. Maybe should fix.
 			return
 		..()
 
@@ -111,18 +112,6 @@
 		radio.broadcasting = 1//So it's broadcasting from the start.
 
 	verb//Allows the brain to toggle the radio functions.
-		Toggle_Broadcasting()
-			set name = "Toggle Broadcasting"
-			set desc = "Toggle broadcasting channel on or off."
-			set category = "MMI"
-			set src = usr.loc//In user location, or in MMI in this case.
-			set popup_menu = 0//Will not appear when right clicking.
-
-			if(brainmob.stat)//Only the brainmob will trigger these so no further check is necessary.
-				brainmob << "Can't do that while incapacitated or dead."
-
-			radio.broadcasting = radio.broadcasting==1 ? 0 : 1
-			brainmob << "\blue Radio is [radio.broadcasting==1 ? "now" : "no longer"] broadcasting."
 
 		Toggle_Listening()
 			set name = "Toggle Listening"

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -64,10 +64,34 @@
 /mob/living/carbon/brain/blob_act()
 	return
 
-
 /mob/living/carbon/brain/on_forcemove(atom/newloc)
 	if(container)
 		container.loc = newloc
 	else //something went very wrong.
 		CRASH("Brainmob without container.")
 	loc = container
+
+/*
+This will return true if the brain has a container that leaves it less helpless than a naked brain
+
+I'm using this for Stat to give it a more nifty interface to work with
+*/
+/mob/living/carbon/brain/proc/has_synthetic_assistance()
+	return (container && istype(container, /obj/item/device/mmi)) || in_contents_of(/obj/mecha)
+
+/mob/living/carbon/brain/Stat()
+	..()
+	if(has_synthetic_assistance())
+		statpanel("Status")
+		stat(null, "Station Time: [worldtime2text()]")
+
+		if(emergency_shuttle)
+			var/eta_status = emergency_shuttle.get_status_panel_eta()
+			if(eta_status)
+				stat(null, eta_status)
+		if(client.statpanel == "Status")
+			//Knowing how well-off your mech is doing is really important as an MMI
+			if(istype(src.loc, /obj/mecha))
+				var/obj/mecha/M = src.loc
+				stat("Exosuit Charge:", "[istype(M.cell) ? "[M.cell.charge] / [M.cell.maxcharge]" : "No cell detected"]")
+				stat("Exosuit Integrity", "[!M.health ? "0" : "[(M.health / initial(M.health)) * 100]"]%")

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -54,7 +54,7 @@
 	if(in_contents_of(/obj/mecha))
 		canmove = 1
 		use_me = 1 //If it can move, let it emote
-	if(istype(loc, /obj/item/device/mmi))	canmove = 1 //mmi won't move anyways so whatever
+	else if(istype(loc, /obj/item/device/mmi))	canmove = 1 //mmi won't move anyways so whatever
 	else							canmove = 0
 	return canmove
 

--- a/code/modules/mob/living/carbon/brain/life.dm
+++ b/code/modules/mob/living/carbon/brain/life.dm
@@ -93,5 +93,10 @@
 		sight &= ~SEE_OBJS
 		see_in_dark = 2
 		see_invisible = SEE_INVISIBLE_LIVING
+	if (container && istype(container, /obj/item/device/mmi))
+		var/obj/item/device/mmi/mmi = container
+		if (mmi.mecha)
+			var/obj/mecha/piloted = mmi.mecha
+			piloted.pilot_mmi_hud(src)
 
 	handle_hud_icons_health()

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -12,26 +12,35 @@
 			else
 				message = Gibberish(message, (emp_damage*6))//scrambles the message, gets worse when emp_damage is higher
 
-		if(istype(container, /obj/item/device/mmi/radio_enabled))
-			var/radio_MMI_message = message //split off so the MMI can get a trimmed message without fucking up living/say()
-			if(!speaking)
-				speaking = parse_language(message)
-			if(speaking)
-				radio_MMI_message = copytext(message, 2 + length(speaking.key))
-			else
-				speaking = get_default_language()
-
-			var/obj/item/device/mmi/radio_enabled/R = container
-			if(R.radio)
-				spawn(0) R.radio.hear_talk(src, trim(sanitize(radio_MMI_message)), say_quote(radio_MMI_message), speaking)
-
 		..(message)
 
 /mob/living/carbon/brain/can_speak(var/datum/language/speaking)
-	if(speaking == all_languages["Robot Talk"] && istype(loc, /obj/item/device/mmi/posibrain)) //so posibrains can speak binary; less messy than adding the language
+	if(speaking == all_languages["Robot Talk"] && (container && istype(container, /obj/item/device/mmi/posibrain))) //so posibrains can speak binary; less messy than adding the language
 		return 1
 
 	else return ..()
 
 /mob/living/carbon/brain/binarycheck()
-	return istype(loc, /obj/item/device/mmi/posibrain)
+	return (container && istype(container, /obj/item/device/mmi/posibrain))
+
+/mob/living/carbon/brain/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios, var/alt_name)
+	switch(message_mode)
+		if("headset")
+			var/radio_worked = 0 // If any of the radios our brainmob could use functioned, this is set true so that we don't use any others
+			// I'm doing it this way so that if the mecha radio fails for some reason, a radio MMI still has the built-in fallback
+			if (container && istype(container,/obj/item/device/mmi))
+				var/obj/item/device/mmi/c = container
+				if (!radio_worked && c.mecha)
+					var/obj/mecha/metalgear = c.mecha
+					if(metalgear.radio)
+						radio_worked = metalgear.radio.talk_into(src, message, message_mode, verb, speaking)
+
+				else if(!radio_worked && istype(c, /obj/item/device/mmi/radio_enabled))
+					var/obj/item/device/mmi/radio_enabled/R = c
+					if(R.radio)
+						radio_worked = R.radio.talk_into(src, message, message_mode, verb, speaking)
+			return radio_worked
+		if ("whisper")
+			whisper_say(message, speaking, alt_name)
+			return 1
+		else return 0


### PR DESCRIPTION
* MMIs should now be able to move when in mechs again; a change in the baystation rigsuit port #2278 accidentally hijacked the else clause in brain.dm, which cut mech MMIs from moving
* MMI mechs can now have the MMI removed by removing the cell and using a crowbar. Since a pilot can restrict maintenance protocols, I see this as a consensual way to remove the MMI without trashing the exosuit. NOTE: Having used this a bit, I've noted that it might be possible to do on accident if you try to close the power hatch without screwing the cell in first. Should the tool be changed? The delay is currently 8 seconds, hopefully that's enough to note the error, and perhaps even serve as a good way to show the process exists to those who don't read changelogs
* MMIs in Oddyseus' now have a medical HUD
* You can cut apart mecha wreckage with a welding tool after all other components are removed
* Radio-enabled MMI's, and MMIs in a mech, can now use the built-in radio seamlessly with the standard "; [message]" format used by humans. This has removed the "broadcasting" verb from radio-enabled MMIs, as it is now obviated
* Mechs moving around now takes power again; the lack of which was introduced in #2171
* Posibrains inside of a mech can now continue to use and listen to Binary Chat
* Brains inside of an MMI or mech will now show station time and time to evac in the status panel, and MMI mechas will be shown their power level and suit integrity in the status screen as well.
* Fixes some annoying "hit by" messages that showed up when taking apart mecha wreckage
* MMIs that try to move while in someone's grasp no longer cause a runtime related to RIGsuits

Fixes #2708