### PR TITLE
Adds newlines to keep item titles aligned in Smartfridge

### DIFF
--- a/nano/templates/smartfridge.tmpl
+++ b/nano/templates/smartfridge.tmpl
@@ -15,7 +15,7 @@
     {{for data.contents}}
       <div class='item'>
         <span class='highlight'>{{:value.display_name}} ({{:value.quantity}} available)</span>
-        <div style="float: left;">Vend:&nbsp;</div> {{:helper.link('x1', 'circle-arrow-s', { "vend" : value.vend, "amount" : 1 }, null, 'statusValue')}}
+        <div class='line' style="float: left;">Vend:&nbsp;</div> {{:helper.link('x1', 'circle-arrow-s', { "vend" : value.vend, "amount" : 1 }, null, 'statusValue')}}
 		{{if value.quantity >= 5}}
 			{{:helper.link('x5', 'circle-arrow-s', { "vend" : value.vend, "amount" : 5 }, null, 'statusValue')}}
 		{{/if}}


### PR DESCRIPTION
Here's how it looks:
![nice_smartfridge](https://cloud.githubusercontent.com/assets/5661700/11585189/0a2966fc-9a1f-11e5-9f85-576fe9602ed1.png)
