### PR TITLE
Some fixes to robotics surgery

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -366,8 +366,8 @@
 						for(var/obj/item/organ/external/O in H.organs)
 							total_brute	+= O.brute_dam
 							total_burn	+= O.burn_dam
-						if(H.health <= config.health_threshold_dead && total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
-							tobehealed = health + threshold
+						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
+							tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 							tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 							H.adjustOxyLoss(tobehealed)
 							H.adjustToxLoss(tobehealed)
@@ -475,8 +475,8 @@
 						for(var/obj/item/organ/external/O in H.organs)
 							total_brute	+= O.brute_dam
 							total_burn	+= O.burn_dam
-						if(H.health <= config.health_threshold_dead && total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
-							tobehealed = health + threshold
+						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
+							tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 							tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 							H.adjustOxyLoss(tobehealed)
 							H.adjustToxLoss(tobehealed)

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -63,6 +63,9 @@
 		overlays.Cut()
 		return
 
+	if (can_operate(M))
+		do_surgery(M, user, src)
+
 /obj/item/weapon/kitchen/utensil/fork
 	name = "fork"
 	desc = "It's a fork. Sure is pointy."

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -150,3 +150,14 @@
 	var/list/all_bits = internal_organs|organs
 	for(var/obj/item/organ/O in all_bits)
 		O.set_dna(dna)
+
+/*
+Given the name of an organ, returns the external organ it's contained in
+I use this to standardize shadowling dethrall code
+-- Crazylemon
+*/
+/mob/living/carbon/human/proc/named_organ_parent(var/organ_name)
+	if (!(organ_name in internal_organs_by_name))
+		return null
+	var/obj/item/organ/O = internal_organs_by_name[organ_name]
+	return O.parent_organ

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -139,6 +139,9 @@
 	//robot limbs take reduced damage
 	brute_mod = 0.66
 	burn_mod = 0.66
+	// Robot parts also lack bones
+	// This is so surgery isn't kaput, let's see how this does
+	encased = null
 
 /****************************************************
 			   DAMAGE PROCS
@@ -819,6 +822,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/mob/living/H = W.loc
 		H.drop_item()
 	W.loc = owner
+
+/obj/item/organ/external/proc/open_enough_for_surgery()
+	return (encased ? (open == 3) : (open == 2))
 
 /obj/item/organ/external/removed(var/mob/living/user, var/ignore_children)
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -10,7 +10,7 @@
 		return 0
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.open == (affected.encased ? 3 : 2)
+	return affected && affected.open_enough_for_surgery()
 
 //////////////////////////////////////////////////////////////////
 //					Dethrall Shadowling 						//
@@ -29,25 +29,29 @@
 		if (!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return ..() && affected && is_thrall(target) && affected.open == 3 && target_zone == "head"
+		return ..() && affected && is_thrall(target) && affected.open_enough_for_surgery() && target_zone == target.named_organ_parent("brain")
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		user.visible_message("[user] begins looking around in [target]'s head.", "<span class='notice'>You begin looking for foreign influences on [target]'s brain...")
+		var/braincase = target.named_organ_parent("brain")
+		user.visible_message("[user] begins looking around in [target]'s [braincase].", "<span class='notice'>You begin looking for foreign influences on [target]'s brain...")
 		user << "<span class='warning'>You locate a small, pulsing black tumor on the side of [target]'s brain and begin to remove it.</span>"
-		target << "<span class='boldannounce'>A small part of your head pulses with agony as the light impacts it.</span>"
-		user.visible_message("[user] begins removing something from [target]'s head.</span>", \
+		target << "<span class='boldannounce'>A small part of your [braincase] pulses with agony as the light impacts it.</span>"
+		user.visible_message("[user] begins removing something from [target]'s [braincase].</span>", \
 							 "<span class='notice'>You begin carefully extracting the tumor...</span>")
 		..()
 
 	end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/braincase = target.named_organ_parent("brain")
 		user.visible_message("<span class='notice'>[user] carefully extracts the tumor from [target]'s brain!</span>", \
-							 "<span class='notice'>You extract the black tumor from [target]'s head. It quickly shrivels and burns away.</span>")
+							 "<span class='notice'>You extract the black tumor from [target]'s [braincase]. It quickly shrivels and burns away.</span>")
 		ticker.mode.remove_thrall(target.mind,0)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+		var/braincase = target.named_organ_parent("brain")
 		if(prob(50))
-			user.visible_message("<span class='warning'>[user] slips and rips the tumor out from [target]'s head!</span>", \
+			user.visible_message("<span class='warning'>[user] slips and rips the tumor out from [target]'s [braincase]!</span>", \
 								 "<span class='warning'><b>You fumble and tear out [target]'s tumor!</span>")
+			target.adjustBrainLoss(150) // This is so you can't just defib'n go
 			ticker.mode.remove_thrall(target.mind,1)
 		else
 			user.visible_message("<span class='warning'>[user]'s hand slips and fumbles! Luckily, they didn't damage anything!</span>")
@@ -75,7 +79,7 @@
 		if (!hasorgans(target))
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return ..() && affected && embryo && affected.open == 3 && target_zone == "chest"
+		return ..() && affected && embryo && affected.open_enough_for_surgery() && target_zone == "chest"
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/msg = "[user] starts to pull something out from [target]'s ribcage with \the [tool]."
@@ -113,7 +117,7 @@
 			return
 		var/is_organ_damaged = 0
 		for(var/obj/item/organ/I in affected.internal_organs)
-			if(I.damage > 0)
+			if(I.damage > 0 && I.robotic < 2)
 				is_organ_damaged = 1
 				break
 		return ..() && is_organ_damaged

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -51,7 +51,7 @@
 		if(prob(50))
 			user.visible_message("<span class='warning'>[user] slips and rips the tumor out from [target]'s [braincase]!</span>", \
 								 "<span class='warning'><b>You fumble and tear out [target]'s tumor!</span>")
-			target.adjustBrainLoss(150) // This is so you can't just defib'n go
+			target.adjustBrainLoss(110) // This is so you can't just defib'n go
 			ticker.mode.remove_thrall(target.mind,1)
 		else
 			user.visible_message("<span class='warning'>[user]'s hand slips and fumbles! Luckily, they didn't damage anything!</span>")

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -3,25 +3,34 @@
 //						COMMON STEPS							//
 //////////////////////////////////////////////////////////////////
 
-/datum/surgery_step/robotics/
+/datum/surgery_step/robotics
 	can_infect = 0
-	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		if (isslime(target))
-			return 0
-		if (target_zone == "eyes")	//there are specific steps for eye surgery
-			return 0
-		if (!hasorgans(target))
-			return 0
-		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		if (affected == null)
-			return 0
-		if (affected.status & ORGAN_DESTROYED)
-			return 0
-		if (!(affected.status & ORGAN_ROBOT))
-			return 0
-		return 1
 
-/datum/surgery_step/robotics/unscrew_hatch
+/datum/surgery_step/robotics/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if (isslime(target))
+		return 0
+	if (target_zone == "eyes")	//there are specific steps for eye surgery
+		return 0
+	if (!hasorgans(target))
+		return 0
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if (affected == null)
+		return 0
+	if (affected.status & ORGAN_DESTROYED)
+		return 0
+	return 1
+
+/datum/surgery_step/robotics/external
+
+/datum/surgery_step/robotics/external/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	if (!..())
+		return 0
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	if (!(affected.status & ORGAN_ROBOT))
+		return 0
+	return 1
+
+/datum/surgery_step/robotics/external/unscrew_hatch
 	allowed_tools = list(
 		/obj/item/weapon/screwdriver = 100,
 		/obj/item/weapon/coin = 50,
@@ -53,7 +62,7 @@
 		user.visible_message("\red [user]'s [tool.name] slips, failing to unscrew [target]'s [affected.name].", \
 		"\red Your [tool] slips, failing to unscrew [target]'s [affected.name].")
 
-/datum/surgery_step/robotics/open_hatch
+/datum/surgery_step/robotics/external/open_hatch
 	allowed_tools = list(
 		/obj/item/weapon/retractor = 100,
 		/obj/item/weapon/crowbar = 100,
@@ -85,7 +94,7 @@
 		user.visible_message("\red [user]'s [tool.name] slips, failing to open the hatch on [target]'s [affected.name].",
 		"\red Your [tool] slips, failing to open the hatch on [target]'s [affected.name].")
 
-/datum/surgery_step/robotics/close_hatch
+/datum/surgery_step/robotics/external/close_hatch
 	allowed_tools = list(
 		/obj/item/weapon/retractor = 100,
 		/obj/item/weapon/crowbar = 100,
@@ -118,7 +127,7 @@
 		user.visible_message("\red [user]'s [tool.name] slips, failing to close the hatch on [target]'s [affected.name].",
 		"\red Your [tool.name] slips, failing to close the hatch on [target]'s [affected.name].")
 
-/datum/surgery_step/robotics/repair_brute
+/datum/surgery_step/robotics/external/repair_brute
 	allowed_tools = list(
 		/obj/item/weapon/weldingtool = 100,
 		/obj/item/weapon/gun/energy/plasmacutter = 50
@@ -154,7 +163,7 @@
 		"\red Your [tool.name] slips, damaging the internal structure of [target]'s [affected.name].")
 		target.apply_damage(rand(5,10), BURN, affected)
 
-/datum/surgery_step/robotics/repair_burn
+/datum/surgery_step/robotics/external/repair_burn
 	allowed_tools = list(
 		/obj/item/stack/cable_coil = 100
 	)
@@ -215,7 +224,7 @@
 			if(I.damage > 0 && I.robotic >= 2)
 				is_organ_damaged = 1
 				break
-		return affected.open == 2 && is_organ_damaged
+		return affected.open_enough_for_surgery() && is_organ_damaged
 
 	begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 
@@ -276,7 +285,7 @@
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(!(affected && (affected.status & ORGAN_ROBOT)))
 			return 0
-		if(affected.open != 2)
+		if(!affected.open_enough_for_surgery())
 			return 0
 
 		target.op_stage.current_organ = null
@@ -325,7 +334,7 @@
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(!(affected && (affected.status & ORGAN_ROBOT)))
 			return 0
-		if(affected.open != 2)
+		if(!affected.open_enough_for_surgery())
 			return 0
 
 		target.op_stage.current_organ = null
@@ -375,7 +384,7 @@
 
 		var/obj/item/device/mmi/M = tool
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		if(!(affected && affected.open == 2))
+		if(!(affected && affected.open_enough_for_surgery()))
 			return 0
 
 		if(!istype(M))


### PR DESCRIPTION
* Internal organ fixing surgery will now work correctly on robotic organs in meaty people, using nanopaste in place of trauma kits

* Defibs also don't need the body to be past the point of deadness to work

* Kitchen utensils should now properly work as surgery tools where given in code

* IPC thralls can now be dethralled by performing the surgery on where their brain is, in this case their chest. This will also work for any species that has a brain anywhere else in their body.

* Failing to do a dethrall surgery now does 150 points of brain damage on top of the death, so that the new defibrillator change doesn't make messing up pointless. (This might be a bit high, but I think it will work; you've torn out a chunk of their brain after all)

Fixes #2413 
Fixes #2577 
Fixes #2731 

And finally, a gem from testing:
![itsperfectlysafe](https://cloud.githubusercontent.com/assets/5661700/11607181/997c66ba-9af1-11e5-86e7-496b2ace0deb.png)
