### PR TITLE
Pull no longer works bad with medical machines

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -239,6 +239,11 @@
 	qdel(G)
 	return
 
+/obj/machinery/sleeper/relaymove(mob/user as mob)
+	if(user.incapacitated())
+		return 0 //maybe they should be able to get out with cuffs, but whatever
+	go_out()
+
 /obj/machinery/dna_scannernew/proc/put_in(var/mob/M)
 	if(M.client)
 		M.client.perspective = EYE_PERSPECTIVE

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -174,10 +174,6 @@
 	if(occupant)
 		user << "\blue <B>The DNA Scanner is already occupied!</B>"
 		return
-/*	if(isrobot(user))
-		if(!istype(user:module, /obj/item/weapon/robot_module/medical))
-			user << "<span class='warning'>You do not have the means to do this!</span>"
-			return*/
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
 		return
@@ -193,7 +189,7 @@
 	visible_message("[user] puts [L.name] into the DNA Scanner.")
 	put_in(L)
 	if(user.pulling == L)
-		user.pulling = null
+		user.stop_pulling()
 
 /obj/machinery/dna_scannernew/attackby(var/obj/item/weapon/item as obj, var/mob/user as mob, params)
 	if(istype(item, /obj/item/weapon/screwdriver))

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -98,6 +98,8 @@
 		C.client.eye = src
 	C.resting = 1
 	C.loc = src.loc
+	if (user.pulling == C)
+		user.stop_pulling()
 	for(var/obj/O in src)
 		O.loc = src.loc
 	src.add_fingerprint(user)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -322,6 +322,11 @@
 	max_chem = E * 20
 	min_health = -E * 25
 
+/obj/machinery/sleeper/relaymove(mob/user as mob)
+	if(user.incapacitated())
+		return 0 //maybe they should be able to get out with cuffs, but whatever
+	go_out()
+
 /obj/machinery/sleeper/process()
 	if(filtering > 0)
 		if(beaker)
@@ -566,10 +571,6 @@
 	if(occupant)
 		user << "<span class='boldnotice'>The sleeper is already occupied!</span>"
 		return
-/*	if(isrobot(user))
-		if(!istype(user:module, /obj/item/weapon/robot_module/medical))
-			user << "<span class='warning'>You do not have the means to do this!</span>"
-			return*/
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
 		return
@@ -600,7 +601,7 @@
 		L << "<span class='boldnotice'>You feel cool air surround you. You go numb as your senses turn inward.</span>"
 		src.add_fingerprint(user)
 		if(user.pulling == L)
-			user.pulling = null
+			user.stop_pulling()
 		return
 	return
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -97,10 +97,6 @@
 	if(occupant)
 		user << "\blue <B>The cryo cell is already occupied!</B>"
 		return
-/*	if(isrobot(user))
-		if(!istype(user:module, /obj/item/weapon/robot_module/medical))
-			user << "<span class='warning'>You do not have the means to do this!</span>"
-			return*/
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
 		return
@@ -117,7 +113,7 @@
 		else
 			visible_message("[user] puts [L.name] into the cryo cell.")
 			if(user.pulling == L)
-				user.pulling = null
+				user.stop_pulling()
 
 /obj/machinery/atmospherics/unary/cryo_cell/process()
 	..()


### PR DESCRIPTION
Mousedropping mobs into them now cancels your pull, so you don't, forexample, start pulling around your surgery patient on accident, or have a funny pull that you need to use on something else, for sleepers.

The following machines now cancel your pull when you mousedrop things into them:

* Sleeper
* DNA Modifier
* Cryo Tube
* Surgery Table

Walking while inside of a sleeper will also let you exit it easily.