### PR TITLE
Fixes Records

### DIFF
--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -23,6 +23,9 @@
 	size = 5.0
 	var/list/fields = list(  )
 
+/datum/data/record/Destroy()
+	..()
+	return QDEL_HINT_HARDDEL_NOW
 
 /datum/data/text
 	name = "text"


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/2677

I'm almost positive this is a qdel() issues; namely because, officers will have problems clearing out arrest statuses, but if they wait a bit, then everything is ok---this is indicative of records failing to GC and having to be hard deleted.

There is a small chance this may not actually fix the issue, but nothing has changed with records aside from qdel()'ing them.

This is very hard to test, locally, as it involves a lot of stuff that's difficult to track or pin down when it's happening or where.