### PR TITLE
Fixed num2hex for large numbers.

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -50,16 +50,14 @@
 
 	var/hex = ""
 	while(num)
-		var/val = num & 15
-		num >>= 4
+		var/val = num % 16
+		num = round(num / 16)
 
 		if(val > 9)
 			val = ascii2text(55 + val) // 65 - 70 correspond to "A" - "F"
 		hex = "[val][hex]"
-
 	while(length(hex) < placeholder)
 		hex = "0[hex]"
-
 	return hex || "0"
 
 // Concatenates a list of strings into a single string.  A seperator may optionally be provided.


### PR DESCRIPTION
ID numbers are larger than the bitwise operators allow, which gave everyone one of about sixteen ID #s.
Not sure what else this touches mechanically, but ID #s are pretty again.

I started in on this to fix the ID bug pointed out in #2677, but I don't really have the volume of people to test it. All I can say regarding the  is that when respawning and assigning security levels via sechud and checking them on the security records computer, the only issues I ran into were when I didn't change to a new character before respawning.