### PR TITLE
Cyborgs only die once when dead, and don't break binary talk

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -22,7 +22,9 @@
 
 
 /mob/living/silicon/robot/proc/use_power()
-	if (is_component_functioning("power cell") && cell)
+	if (stat == DEAD)
+		return
+	else if (is_component_functioning("power cell") && cell)
 		if(module)
 			for(var/obj/item/borg/B in module.modules)
 				if(B.powerneeded)
@@ -60,20 +62,15 @@
 			if(!is_component_functioning("actuator"))
 				Paralyse(3)
 			eye_blind = 0
-			stat = 0
+			// Please, PLEASE be careful with statements like this - make sure they're not
+			// dead beforehand, for example -- Crazylemon
+			stat = CONSCIOUS
 			has_power = 1
 	else
 		uneq_all()
 		stat = UNCONSCIOUS
 		update_headlamp(1)
 		Paralyse(3)
-
-/mob/living/silicon/robot/updatehealth()
-	if(status_flags & GODMODE)
-		health = maxHealth
-		stat = CONSCIOUS
-		return
-	health = maxHealth - (getOxyLoss() + getFireLoss() + getBruteLoss())
 
 /mob/living/silicon/robot/handle_regular_status_updates()
 

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -4,7 +4,14 @@
 		stat = CONSCIOUS
 		return
 	health = maxHealth - (getBruteLoss() + getFireLoss())
+	if (stat == DEAD && health > 0)
+		update_revive()
+		var/mob/dead/observer/ghost = get_ghost()
+		if(ghost)
+			ghost << "<span class='ghostalert'>Your cyborg shell has been repaired, re-enter if you want to continue!</span> (Verbs -> Ghost -> Re-enter corpse)"
+			ghost << sound('sound/effects/genetics.ogg')
 	return
+
 
 /mob/living/silicon/robot/getBruteLoss()
 	var/amount = 0

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -1,4 +1,4 @@
-mob/living/silicon/robot/updatehealth()
+/mob/living/silicon/robot/updatehealth()
 	if(status_flags & GODMODE)
 		health = maxHealth
 		stat = CONSCIOUS

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -1,9 +1,9 @@
-/mob/living/silicon/robot/updatehealth()
+mob/living/silicon/robot/updatehealth()
 	if(status_flags & GODMODE)
 		health = maxHealth
 		stat = CONSCIOUS
 		return
-	health = maxHealth - (getBruteLoss() + getFireLoss())
+	health = maxHealth - (getOxyLoss() + getFireLoss() + getBruteLoss())
 	if (stat == DEAD && health > 0)
 		update_revive()
 		var/mob/dead/observer/ghost = get_ghost()


### PR DESCRIPTION
Sure, it was a quick enough fix
BE CAREFUL WHEN SETTING `stat`!
Fixes #2747 
Fixes #2616 