### PR TITLE
Changes Laser gun energy consumption

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -4,7 +4,7 @@
 	icon_state = "laser"
 	item_state = "laser"
 	fire_sound = 'sound/weapons/Laser.ogg'
-	charge_cost = 830
+	charge_cost = 760
 	w_class = 3.0
 	materials = list(MAT_METAL=2000)
 	origin_tech = "combat=3;magnets=2"


### PR DESCRIPTION
Decreases laser gun energy consumption from 830 to 760. If it has a charge of 10000 like i assume, then it will get to fire 13 shots instead of 12, so it will actually have a bit more of an advantage over the energy gun, which is mostly superior because it can switch between disable and stun, and it can fire 10 laser shots.