### PR TITLE
Fixed pipes being captured by photo cameras

### DIFF
--- a/code/ATMOSPHERICS/datum_icon_manager.dm
+++ b/code/ATMOSPHERICS/datum_icon_manager.dm
@@ -186,9 +186,9 @@ var/global/list/pipe_colors = list("grey" = PIPE_COLOR_GREY, "red" = PIPE_COLOR_
 		var/cache_name = state
 
 		for(var/D in cardinal)
-			var/image/I = image('icons/atmos/pipe_underlays.dmi', icon_state = state, dir = D)
+			var/image/I = image(icon('icons/atmos/pipe_underlays.dmi', icon_state = state, dir = D))
 			underlays[cache_name + "[D]"] = I
 			for(var/pipe_color in pipe_colors)
-				I = image('icons/atmos/pipe_underlays.dmi', icon_state = state, dir = D)
+				I = image(icon('icons/atmos/pipe_underlays.dmi', icon_state = state, dir = D))
 				I.color = pipe_colors[pipe_color]
 				underlays[state + "[D]" + "[pipe_colors[pipe_color]]"] = I


### PR DESCRIPTION
* This fixes pipe connectors being rendered correctly in photographs.
 * The reason *why* this fixes it is convoluted, but basically boils down to that getFlatIcon() expects overlays and underlays to not actually change their appearance when rotated, if the object is also rotated. This is most notably an issue with 3-way manifolds.
 * Ideally getFlatIcon() would be fixed, but it is a convoluted recursive nightmare and just doing this is far simpler (and more efficient cpu-wise than what I think would have to be done in order to get getFlatIcon() to work right).

##### Before -> After
![Before & After](http://i.imgur.com/9OVXVJj.png)