### PR TITLE
Roboconsole gives loc and health, Drones now flash right

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -217,6 +217,15 @@
 		else
 			robot["cell"] = 0
 
+		var/turf/pos = get_turf(R)
+		var/area/bot_area = get_area(R)
+		robot["xpos"] = pos.x
+		robot["ypos"] = pos.y
+		robot["zpos"] = pos.z
+		robot["area"] = format_text(bot_area.name)
+
+		robot["health"] = round(R.health * 100 / R.maxHealth,0.1)
+
 		robot["module"] = R.module ? R.module.name : "None"
 		robot["master_ai"] = R.connected_ai ? R.connected_ai.name : "None"
 		robot["hackable"] = 0

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -111,11 +111,13 @@
 	else if(issilicon(M))
 		if(isrobot(M))
 			var/mob/living/silicon/robot/R = M
-			for(var/obj/item/borg/combat/shield/S in R.module.modules)
-				if(R.activated(S))
-					add_logs(M, user, "flashed", object="[src.name]")
-					user.visible_message("<span class='disarm'>[user] tries to overloads [M]'s sensors with the [src.name], but if blocked by [M]'s shield!</span>", "<span class='danger'>You try to overload [M]'s sensors with the [src.name], but are blocked by his shield!</span>")
-					return 1
+
+			if (R.module) // Perhaps they didn't choose a module yet
+				for(var/obj/item/borg/combat/shield/S in R.module.modules)
+					if(R.activated(S))
+						add_logs(M, user, "flashed", object="[src.name]")
+						user.visible_message("<span class='disarm'>[user] tries to overloads [M]'s sensors with the [src.name], but if blocked by [M]'s shield!</span>", "<span class='danger'>You try to overload [M]'s sensors with the [src.name], but are blocked by his shield!</span>")
+						return 1
 		M.Weaken(rand(5,10))
 		add_logs(M, user, "flashed", object="[src.name]")
 		user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the [src.name]!</span>", "<span class='danger'>You overload [M]'s sensors with the [src.name]!</span>")

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -211,12 +211,12 @@
 //Drones killed by damage will gib.
 /mob/living/silicon/robot/drone/handle_regular_status_updates()
 
-	if(health <= -35 && src.stat != 2)
+	if(health <= -35 && src.stat != DEAD)
 		timeofdeath = world.time
 		death() //Possibly redundant, having trouble making death() cooperate.
 		gib()
 		return
-	..()
+	return ..() // If you don't return anything here, you won't update status effects, like weakening
 
 /mob/living/silicon/robot/drone/death(gibbed)
 

--- a/nano/templates/robot_control.tmpl
+++ b/nano/templates/robot_control.tmpl
@@ -28,6 +28,18 @@
 				{{:value.status}}
 			</span>
 			<span class="itemLabel">
+				System Integrity:
+			</span>
+			<span class="itemContent">
+				{{:value.health}} %
+			</span>
+			<span class="itemLabel">
+				Location:
+			</span>
+			<span class="itemContent">
+				({{:value.xpos}}, {{:value.ypos}}, {{:value.zpos}}): {{:value.area}}
+			</span>
+			<span class="itemLabel">
 				Master AI: 
 			</span>
 			<span class="itemContent">


### PR DESCRIPTION
* Adds health and location readings to the robot control console

* Drones now update status effects, so that flashes don't last forever

* Fixes a runtime on flashing a cyborg that hadn't chosen a module yet

Fixes #2727