### PR TITLE
Maintenance Drone Vent Crawling

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -14,6 +14,7 @@
 	density = 0
 	req_access = list(access_engine, access_robotics)
 	local_transmit = 1
+	ventcrawler = 2
 
 	// We need to keep track of a few module items so we don't need to do list operations
 	// every time we need them. These get set in New() after the module is chosen.


### PR DESCRIPTION
Allows Maintenance Drones to vent crawl around the station. 
Made a suggestion on the forums a while back and everyone was fine with it, it was a matter of finding some one to do it.
I finally went through the code and found the correct code for this change.