### PR TITLE
Made the hand-rolled cigarettes use the normal cigarretes on-mob icon…

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -219,10 +219,6 @@ LIGHTERS ARE IN LIGHTERS.DM
 /obj/item/clothing/mask/cigarette/handroll
 	name = "hand-rolled cigarette"
 	desc = "A roll of tobacco and nicotine, freshly rolled by hand."
-	icon_state = "hr_cigoff"
-	item_state = "hr_cigoff"
-	icon_on = "hr_cigon"  //Note - these are in masks.dmi not in cigarette.dmi
-	icon_off = "hr_cigoff"
 	type_butt = /obj/item/weapon/cigbutt
 	chem_volume = 50
 


### PR DESCRIPTION
Made the hand-rolled cigarettes use the normal cigarretes on-mob icon, as they don't have any of their own. Fixes #2427