### PR TITLE
Death Nettle Fix

### DIFF
--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -92,8 +92,7 @@
 			user.Paralyse(5)
 			user << "<span class='userdanger'>You are stunned by the Deathnettle when you try picking it up!</span>"
 
-/obj/item/weapon/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
-	if(!..()) return
+/obj/item/weapon/grown/nettle/death/afterattack(mob/living/carbon/M, mob/user)
 	if(istype(M, /mob/living))
 		M << "<span class='danger'>You are stunned by the powerful acid of the Deathnettle!</span>"
 		add_logs(M, user, "attacked", src)
@@ -103,6 +102,7 @@
 			M.Paralyse(force / 6)
 			M.Weaken(force / 15)
 		M.drop_item()
+	..()
 
 /obj/item/weapon/corncob
 	name = "corn cob"


### PR DESCRIPTION
For whatever reason

`if(!..()) return` will not call parent, and as such, everything below it is not properly executing, despite the fact it should--not sure why--for now though, this allows death nettles to function properly/correctly until the deeper problem is resolved.

I'm really not int he mood to fix up the horrendous nightmare that is obj/item/proc/attack() so this will have to do for now.