### PR TITLE
Made slot machine have reactive ui, use bank correctly

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -9,41 +9,48 @@ var/datum/announcement/minor/slotmachine_announcement = new(do_log = 0)
 	density = 1
 	var/plays = 0
 	var/working = 0
-	var/balance=0
+	var/datum/money_account/account = null
+	var/result = null
+	var/resultlvl = null
 
-/obj/machinery/slot_machine/attack_hand(var/mob/user as mob)
-	if(user.mind)
-		if(user.mind.initial_account)
-			balance = user.mind.initial_account.money
-	user.machine = src
-	if (working)
-		var/dat = {"<B>Slot Machine</B><BR>
-		<HR><BR>
-		<B>Please wait!</B><BR>"}
-		user << browse(dat, "window=slotmachine;size=450x500")
-		onclose(user, "slotmachine")
-	else
-		var/dat = {"<B>Slot Machine</B><BR>
-		<HR><BR>
-		Five credits to play!<BR>
-		<B>Credits Remaining:</B> [balance]<BR>
-		[plays] players have tried their luck today!<BR>
-		<HR><BR>
-		<A href='?src=\ref[src];ops=1'>Play!<BR>"}
-		user << browse(dat, "window=slotmachine;size=400x500")
-		onclose(user, "slotmachine")
+/obj/machinery/slot_machine/attack_hand(mob/user as mob)
+	account = user.get_worn_id_account()
+	if(!account)
+		if(istype(user.get_active_hand(), /obj/item/weapon/card/id))
+			account = get_card_account(user.get_active_hand())
+		else
+			account = null
+
+	ui_interact(user)
+
+/obj/machinery/slot_machine/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+	var/data[0]
+
+	data["working"] = working
+	data["money"] = account ? account.money : null
+	data["plays"] = plays
+	data["result"] = result
+	data["resultlvl"] = resultlvl
+
+	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "slotmachine.tmpl", name, 350, 200)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
 
 /obj/machinery/slot_machine/Topic(href, href_list)
+	add_fingerprint(usr)
+
 	if(href_list["ops"])
 		var/operation = text2num(href_list["ops"])
 		if(operation == 1) // Play
 			if (working == 1)
-				usr << "<span class='warning'>You need to wait until the machine stops spinning!</span>"
 				return
-			if (balance < 5)
-				usr << "<span class='warning'>Insufficient money to play!</span>"
+			if (!account || account.money < 5)
 				return
-			usr.mind.initial_account.money -= 5
+			if(!account.charge(5, transaction_purpose = "Bet", dest_name = name))
+				return
 			plays += 1
 			working = 1
 			icon_state = "slots-on"
@@ -54,23 +61,41 @@ var/datum/announcement/minor/slotmachine_announcement = new(do_log = 0)
 					playsound(src.loc, 'sound/effects/engine_alert2.ogg', 50, 0)
 					visible_message("<b>[src]</b> says, 'JACKPOT! [usr.name] has won two hundred and fifty thousand credits!'")
 					slotmachine_announcement.Announce("Congratulations to [usr.name] on winning the jackpot of two hundred and fifty thousand credits!", "Jackpot Winner")
-					usr.mind.initial_account.money += 250000
+					result = "JACKPOT! You win two hundred and fifty thousand credits!"
+					resultlvl = "highlight"
+					win_money(250000, 0)
 				else if (roll > 1 && roll <= 10)
-					playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 					visible_message("<b>[src]</b> says, 'Big Winner! [usr.name] has won five thousand credits!'")
-					usr.mind.initial_account.money += 5000
+					result = "Big Winner! You win five thousand credits!"
+					resultlvl = "good"
+					win_money(5000)
 				else if (roll > 10 && roll <= 100)
-					playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
-					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won win five hundred credits!'")
-					usr.mind.initial_account.money += 500
+					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won five hundred credits!'")
+					result = "You win five hundred credits!"
+					resultlvl = "good"
+					win_money(500)
 				else if (roll > 100 && roll <= 1000)
-					playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
-					usr << "<span class='notice'>You win 5 credits!</span>"
-					usr.mind.initial_account.money += 5
+					result = "You win 5 credits!"
+					resultlvl = "good"
+					win_money(5)
 				else
-					usr << "<span class='warning'>No luck!</span>"
+					result = "<span class='warning'>No luck!</span>"
+					resultlvl = "average"
 				working = 0
 				icon_state = "slots-off"
-	add_fingerprint(usr)
-	updateUsrDialog()
-	return
+
+/obj/machinery/slot_machine/proc/win_money(amt, playsnd=1)
+	if(playsnd)
+		playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
+
+	if(!account)
+		return
+	account.money += amt
+
+	var/datum/transaction/T = new()
+	T.target_name = account.owner_name
+	T.purpose = "Slot Winnings"
+	T.amount = "[amt]"
+	T.date = current_date_string
+	T.time = worldtime2text()
+	account.transaction_log.Add(T)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -58,12 +58,11 @@ var/datum/announcement/minor/slotmachine_announcement = new(do_log = 0)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			spawn(30)
 				if (roll == 1)
-					playsound(src.loc, 'sound/effects/engine_alert2.ogg', 50, 0)
 					visible_message("<b>[src]</b> says, 'JACKPOT! [usr.name] has won two hundred and fifty thousand credits!'")
 					slotmachine_announcement.Announce("Congratulations to [usr.name] on winning the jackpot of two hundred and fifty thousand credits!", "Jackpot Winner")
 					result = "JACKPOT! You win two hundred and fifty thousand credits!"
 					resultlvl = "highlight"
-					win_money(250000, 0)
+					win_money(250000, 'sound/effects/engine_alert2.ogg')
 				else if (roll > 1 && roll <= 10)
 					visible_message("<b>[src]</b> says, 'Big Winner! [usr.name] has won five thousand credits!'")
 					result = "Big Winner! You win five thousand credits!"
@@ -84,9 +83,9 @@ var/datum/announcement/minor/slotmachine_announcement = new(do_log = 0)
 				working = 0
 				icon_state = "slots-off"
 
-/obj/machinery/slot_machine/proc/win_money(amt, playsnd=1)
-	if(playsnd)
-		playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
+/obj/machinery/slot_machine/proc/win_money(amt, sound='sound/machines/ping.ogg')
+	if(sound)
+		playsound(loc, sound, 50)
 
 	if(!account)
 		return

--- a/code/modules/economy/utils.dm
+++ b/code/modules/economy/utils.dm
@@ -31,6 +31,8 @@
 	if(ishuman(src))
 		var/mob/living/carbon/human/H=src
 		var/obj/item/weapon/card/id/I=H.get_idcard()
+		if(!I || !istype(I))
+			return null
 		var/attempt_pin=0
 		var/datum/money_account/D = get_money_account(I.associated_account_number)
 		if(require_pin && user)

--- a/nano/templates/slotmachine.tmpl
+++ b/nano/templates/slotmachine.tmpl
@@ -11,10 +11,10 @@ Used In File(s): /code/game/machinery/slotmachine.dm
 		{{:helper.string("<div class='statusValue {0}'>{1}</div>", data.money >= 5 ? "" : "bad", data.money)}}
 	</div>
 	<div class="item">
-		<div class="itemLabel">
+		<div class="statusLabel">
 			Five credits to play!
 		</div>
-		<div class="itemContent">
+		<div class="statusValue">
 			{{:helper.link('SPIN!', 'arrowrefresh-1-s', {'ops' : 1}, data.money >= 5 && !data.working ? null : 'disabled')}}
 		</div>
 	</div>

--- a/nano/templates/slotmachine.tmpl
+++ b/nano/templates/slotmachine.tmpl
@@ -1,0 +1,34 @@
+<!-- 
+Title: Slot Machine UI
+Used In File(s): /code/game/machinery/slotmachine.dm
+-->
+{{if data.money != null}}
+	<div class="line">
+		{{:data.plays}} players have tried their luck today!
+	</div>
+	<div class="line">
+		<div class="statusLabel">Credits Remaining:</div>
+		{{:helper.string("<div class='statusValue {0}'>{1}</div>", data.money >= 5 ? "" : "bad", data.money)}}
+	</div>
+	<div class="item">
+		<div class="itemLabel">
+			Five credits to play!
+		</div>
+		<div class="itemContent">
+			{{:helper.link('SPIN!', 'arrowrefresh-1-s', {'ops' : 1}, data.money >= 5 && !data.working ? null : 'disabled')}}
+		</div>
+	</div>
+	{{if data.result}}
+		<div class="line {{:data.resultlvl}}">
+			{{:data.result}}
+		</div>
+	{{/if}}
+	{{if data.working}}
+		<div class="notice">Spinning!</div>
+	{{/if}}
+{{else}}
+	<div class="notice">
+		Could not scan your card or could not find account!<br>
+		Please wear or hold your ID and try again.
+	</div>
+{{/if}}


### PR DESCRIPTION
#### Follow up to Fox's #2772.
* Made it use nanoui so that it cleanly updates its state instead of..not at all, makes it far more usable now that you can't spam the button forever.
 * @FalseIncarnate is free to make a prettier UI, this is just for functionality's sake.
* Also uses id card and bank transactions correctly instead of not at all (heck, before you could potentially put yourself in the red if your account was used for anything else while the window was open).

##### Hilarity/sadness factor of bank statement more interesting that the nanoui.
![preview](http://i.imgur.com/TCi2VdP.png)