### PR TITLE
Reagent Fixes and Tweaks

### DIFF
--- a/code/modules/reagents/newchem/food.dm
+++ b/code/modules/reagents/newchem/food.dm
@@ -199,6 +199,7 @@ datum/reagent/fungus/reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
 	description = "An old household remedy for mild illnesses."
 	reagent_state = LIQUID
 	color = "#B4B400"
+	metabolization_rate = 0.2
 
 /datum/reagent/chicken_soup/on_mob_life(var/mob/living/M as mob)
 	M.nutrition += 2

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -278,6 +278,7 @@ datum/reagent/sal_acid
 	description = "This is a is a standard salicylate pain reliever and fever reducer."
 	reagent_state = LIQUID
 	color = "#B3B3B3"
+	metabolization_rate = 0.1
 	shock_reduction = 25
 	overdose_threshold = 25
 

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -794,7 +794,7 @@ datum/reagent/antihol/on_mob_life(var/mob/living/M as mob)
 	M.drowsyness = 0
 	M.slurring = 0
 	M.confused = 0
-	M.reagents.remove_reagent("ethanol", 8)
+	M.reagents.remove_all_type(/datum/reagent/ethanol, 8, 0, 1)
 	if(M.health < 25)
 		M.adjustToxLoss(-2.0)
 	..()

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -285,6 +285,10 @@ datum/reagent/sal_acid/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	if(prob(55))
 		M.adjustBruteLoss(-2*REM)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.traumatic_shock < 100)
+			H.shock_stage = 0
 	..()
 	return
 
@@ -458,6 +462,10 @@ datum/reagent/morphine/on_mob_life(var/mob/living/M as mob)
 		if(36 to INFINITY)
 			M.Paralyse(10)
 			M.drowsyness = max(M.drowsyness, 15)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.traumatic_shock < 100)
+			H.shock_stage = 0
 	..()
 	return
 

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -454,6 +454,7 @@ datum/reagent/lipolicide
 	description = "A compound found in many seedy dollar stores in the form of a weight-loss tonic."
 	reagent_state = SOLID
 	color = "#D1DED1"
+	metabolization_rate = 0.2
 
 /datum/chemical_reaction/lipolicide
 	name = "lipolicide"
@@ -465,7 +466,8 @@ datum/reagent/lipolicide
 datum/reagent/lipolicide/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	if(!holder.has_reagent("nutriment"))
-		M.adjustToxLoss(1)
+		if(prob(30))
+			M.adjustToxLoss(1)
 	M.nutrition -= 10 * REAGENTS_METABOLISM
 	M.overeatduration = 0
 	if(M.nutrition < 0)//Prevent from going into negatives.

--- a/code/modules/reagents/oldchem/reagents/reagents_med.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_med.dm
@@ -102,27 +102,22 @@
 /datum/reagent/rezadone
 	name = "Rezadone"
 	id = "rezadone"
-	description = "A powder derived from fish toxin, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
+	description = "A powder derived from fish toxin, Rezadone can effectively treat genetic damage as well as restoring minor wounds. Overdose will cause intense nausea and minor toxin damage."
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
+	overdose_threshold = 30
 
-/datum/reagent/rezadone/on_mob_life(var/mob/living/M as mob)
-	if(!M) M = holder.my_atom
-	if(!data) data = 1
-	data++
-	switch(data)
-		if(1 to 15)
-			M.adjustCloneLoss(-1)
-			M.heal_organ_damage(1,1)
-		if(15 to 35)
-			M.adjustCloneLoss(-2)
-			M.heal_organ_damage(2,1)
-			M.status_flags &= ~DISFIGURED
-		if(35 to INFINITY)
-			M.adjustToxLoss(1)
-			M.Dizzy(5)
-			M.Jitter(5)
+/datum/reagent/rezadone/on_mob_life(mob/living/M)
+	M.setCloneLoss(0) //Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
+	M.heal_organ_damage(1,1)
+	M.status_flags &= ~DISFIGURED
+	..()
+	return
 
+/datum/reagent/rezadone/overdose_process(mob/living/M)
+	M.adjustToxLoss(1)
+	M.Dizzy(5)
+	M.Jitter(5)
 	..()
 	return
 

--- a/code/modules/reagents/oldchem/reagents/reagents_med.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_med.dm
@@ -9,6 +9,10 @@
 
 /datum/reagent/hydrocodone/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.traumatic_shock < 100)
+			H.shock_stage = 0
 	..()
 	return
 

--- a/code/modules/reagents/oldchem/reagents/reagents_med.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_med.dm
@@ -131,6 +131,7 @@
 	description = "An all-purpose antibiotic agent extracted from space fungus."
 	reagent_state = LIQUID
 	color = "#0AB478"
+	metabolization_rate = 0.2
 
 /datum/reagent/spaceacillin/on_mob_life(var/mob/living/M as mob)
 	..()


### PR DESCRIPTION
- Fixes antihol so it properly purges *all* types of ethanol and not just ethanol the base reagent.
- Painkillers will now reset your shock stage to 0 if your traumatic shock is less than 100.
 - Often times someone would be healed up and have no damage, but still slow, largely because of them still having a high shock stage; this should allow doctors to give someone painkiller to alleviate that.
- ports over TG's tweaks to rezadone
 - It'll now heal all cloneloss instead of just 1 cloneloness per cycle.
 - Now properly uses new chem procs and such
 - This chem is very difficult to get ahold of due to requiring carpotoxin, so it needs a massive advantage over Cryox.
- Harmonizes some metabolization rates with Goon
 - Spaceacillin, Salicylic Acid, Chicken Soup, and Lipolicide all lowered
- Lipolicide now has a 30% chance of causing 1 tox instead of always doing so.