### PR TITLE
Corrects Cloner Loc

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -451,7 +451,7 @@
 	if (src.occupant.client)
 		src.occupant.client.eye = src.occupant.client.mob
 		src.occupant.client.perspective = MOB_PERSPECTIVE
-	src.occupant.loc = src.loc
+	src.occupant.forceMove(get_turf(src))
 	src.eject_wait = 0 //If it's still set somehow.
 	domutcheck(src.occupant) //Waiting until they're out before possible notransform.
 	src.occupant = null


### PR DESCRIPTION
The cloner sets loc directly--on a mob, which you really shouldn't do---corrects the cloner so it properly calls forcemove() and ensures no one will get spawned in nullspace.