### PR TITLE
Aranesp Tweak

### DIFF
--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -374,7 +374,7 @@
 	if(prob(90))
 		M.adjustToxLoss(1)
 	if(prob(5))
-		M << "<span class = 'danger'>You cannot breathe!</span>"
+		M << "<span class='danger'>You cannot breathe!</span>"
 		M.losebreath += 1
 		M.adjustOxyLoss(15)
 		M.Stun(1)

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -370,11 +370,14 @@
 	var/high_message = pick("You feel like you're made of steel!", "You feel invigorated!", "You feel really buff!", "You feel on top of the world!", "You feel full of energy!")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
-	M.adjustStaminaLoss(-35)
-	M.adjustToxLoss(1)
-	if(prob(3))
-		M.losebreath += 2
-		M.Stun(2)
+	M.adjustStaminaLoss(-40)
+	if(prob(90))
+		M.adjustToxLoss(1)
+	if(prob(5))
+		M << "<span class = 'danger'>You cannot breathe!</span>"
+		M.losebreath += 1
+		M.adjustOxyLoss(15)
+		M.Stun(1)
 	..()
 	return
 


### PR DESCRIPTION
Just some more reagent harmonization

Adjusts Aranesp a little:
- has 90% chance to cause 1 tox instead of guaranteed
- causes 1 losebreath, a super-short stun, and 15 oxygen damage instead of just a medium stun and losebreath
- Stamina regeneration upped from 35 to 40