### PR TITLE
Added voice analyzer & Entertainment monitor supporting audible emotes

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -123,6 +123,13 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 			rendered = "<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> [verb], <span class='message'>\"[text]\"</span></span></i>"
 		master.show_message(rendered, 2)
 	return
+	
+/obj/machinery/hologram/holopad/hear_message(mob/living/M, text)
+	if(M&&hologram&&master)//Master is mostly a safety in case lag hits or something.
+		var/name_used = M.GetVoice()
+		var/rendered = "<i><span class='game say'>Holopad received, <span class='name'>[name_used]</span> [text]</span></i>"
+		master.show_message(rendered, 2)
+	return
 
 /obj/machinery/hologram/holopad/proc/create_holo(mob/living/silicon/ai/A, turf/T = loc)
 	hologram = new(T)//Spawn a blank effect at the location.

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -25,27 +25,33 @@
 	if(spamcheck)
 		user << "\red \The [src] needs to recharge!"
 		return
-
-	var/message = sanitize(copytext(input(user, "Shout a message?", "Megaphone", null) as text,1,MAX_MESSAGE_LEN))
+	
+	var/message = input(user, "Shout a message:", "Megaphone") as text|null
+	if(!message)
+		return
+	message = sanitize(copytext(message, 1, MAX_MESSAGE_LEN))
 	if(!message)
 		return
 	message = capitalize(message)
 	if ((src.loc == user && usr.stat == 0))
 		if(emagged)
 			if(insults)
-				for(var/mob/O in (viewers(user)))
-					O.show_message("<B>[user]</B> broadcasts, <FONT size=3>\"[pick(insultmsg)]\"</FONT>",2) // 2 stands for hearable message
+				saymsg(user, pick(insultmsg))
 				insults--
 			else
 				user << "\red *BZZZZzzzzzt*"
 		else
-			for(var/mob/O in (viewers(user)))
-				O.show_message("<B>[user]</B> broadcasts, <FONT size=3>\"[message]\"</FONT>",2) // 2 stands for hearable message
+			saymsg(user, message)
 
 		spamcheck = 1
 		spawn(20)
 			spamcheck = 0
 		return
+
+/obj/item/device/megaphone/proc/saymsg(mob/living/user as mob, message)
+	audible_message("<span class='game say'><span class='name'>[user]</span> broadcasts, <FONT size=3>\"[message]\"</FONT></span>", hearing_distance = 14)
+	for(var/obj/O in oview(14, get_turf(src)))
+		O.hear_talk(user, "<FONT size=3>[message]</FONT>")
 
 /obj/item/device/megaphone/emag_act(user as mob)
 	if(!emagged)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -478,11 +478,6 @@ var/global/list/default_medbay_channels = list(
 		if(get_dist(src, M) <= canhear_range)
 			talk_into(M, msg,null,verb,speaking)
 
-/obj/item/device/radio/hear_message(mob/M as mob, msg)
-	if (broadcasting)
-		if(get_dist(src, M) <= canhear_range)
-			talk_into(M, msg, speaking = new /datum/language/noise)
-			
 
 /*
 /obj/item/device/radio/proc/accept_rad(obj/item/device/radio/R as obj, message)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -478,6 +478,11 @@ var/global/list/default_medbay_channels = list(
 		if(get_dist(src, M) <= canhear_range)
 			talk_into(M, msg,null,verb,speaking)
 
+/obj/item/device/radio/hear_message(mob/M as mob, msg)
+	if (broadcasting)
+		if(get_dist(src, M) <= canhear_range)
+			talk_into(M, msg, speaking = new /datum/language/noise)
+			
 
 /*
 /obj/item/device/radio/proc/accept_rad(obj/item/device/radio/R as obj, message)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -93,7 +93,11 @@
 			mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [M.name] exclaims, \"[msg]\""
 			return
 		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [M.name] says, \"[msg]\""
-
+		
+/obj/item/device/taperecorder/hear_message(mob/living/M as mob, msg)
+	if(mytape && recording)
+		mytape.timestamp += mytape.used_capacity
+		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [M.name] [msg]"
 
 /obj/item/device/taperecorder/verb/record()
 	set name = "Start Recording"

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -68,6 +68,11 @@
 	for(var/obj/O in contents)
 		O.hear_talk(M, msg)
 
+/obj/item/device/transfer_valve/hear_message(mob/living/M as mob, msg)
+	..()
+	for(var/obj/O in contents)
+		O.hear_message(M, msg)
+
 /obj/item/device/transfer_valve/attack_self(mob/user as mob)
 	ui_interact(user)
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -235,6 +235,10 @@
 	if(nadeassembly)
 		nadeassembly.hear_talk(M, msg)
 
+/obj/item/weapon/grenade/chem_grenade/hear_message(mob/living/M, msg)
+	if(nadeassembly)
+		nadeassembly.hear_message(M, msg)
+
 /obj/item/weapon/grenade/chem_grenade/Bump()
 	..()
 	if(nadeassembly)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -149,7 +149,6 @@
 
 
 /obj/proc/hear_talk(mob/M as mob, text)
-
 	if(talking_atom)
 		talking_atom.catchMessage(text, M)
 
@@ -159,8 +158,8 @@
 		var/rendered = "<span class='game say'><span class='name'>[M.name]: </span> <span class='message'>[text]</span></span>"
 		mo.show_message(rendered, 2)
 */
-	return
 
+/obj/proc/hear_message(mob/M as mob, text)
 
 /obj/proc/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)
 	return "<b>NO MULTITOOL_MENU!</b>"

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -85,6 +85,9 @@
 	if(bombassembly)
 		bombassembly.hear_talk(M, msg)
 
+/obj/item/device/onetankbomb/hear_message(mob/living/M as mob, msg)
+	if(bombassembly)
+		bombassembly.hear_message(M, msg)
 
 // ---------- Procs below are for tanks that are used exclusively in 1-tank bombs ----------
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -100,6 +100,12 @@
 			a_left.hear_talk(M, msg)
 		if(a_right)
 			a_right.hear_talk(M, msg)
+	
+	hear_message(mob/living/M as mob, msg)
+		if(a_left)
+			a_left.hear_message(M, msg)
+		if(a_right)
+			a_right.hear_message(M, msg)
 
 	proc/process_movement() // infrared beams and prox sensors
 		if(a_left && a_right)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -6,6 +6,7 @@
 	origin_tech = "magnets=1"
 	var/listening = 0
 	var/recorded = null	//the activation message
+	var/recorded_type = 0 // 0 for say, 1 for emote
 
 	bomb_name = "voice-activated bomb"
 
@@ -16,15 +17,22 @@
 			return "[src] is deactivated."
 
 	hear_talk(mob/living/M as mob, msg)
+		hear_input(M, msg, 0)
+	
+	hear_message(mob/living/M as mob, msg)
+		hear_input(M, msg, 1)
+		
+	proc/hear_input(mob/living/M as mob, msg, type)
 		if(!istype(M,/mob/living))
 			return
 		if(listening)
 			recorded = msg
+			recorded_type = type
 			listening = 0
 			var/turf/T = get_turf(src)	//otherwise it won't work in hand
-			T.visible_message("\icon[src] beeps, \"Activation message is '[recorded]'.\"")
+			T.visible_message("\icon[src] beeps, \"Activation message is [type ? "the sound when one [recorded]" : "'[recorded]'."]\"")
 		else
-			if(findtext(msg, recorded))
+			if(findtext(msg, recorded) && type == recorded_type)
 				pulse(0)
 				var/turf/T = get_turf(src)  //otherwise it won't work in hand
 				T.visible_message("\icon[src] \red beeps!")

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -33,6 +33,10 @@
 	pockets.hear_talk(M, msg)
 	..()
 
+/obj/item/clothing/suit/storage/hear_message(mob/M, var/msg)
+	pockets.hear_message(M, msg)
+	..()
+
 /obj/item/clothing/suit/storage/proc/return_inv()
 
 	var/list/L = list(  )

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -40,6 +40,10 @@
 	hold.hear_talk(M, msg, verb, speaking)
 	..()
 
+/obj/item/clothing/accessory/storage/hear_message(mob/M, var/msg, verb, datum/language/speaking)
+	hold.hear_message(M, msg)
+	..()
+
 /obj/item/clothing/accessory/storage/proc/return_inv()
 
 	var/list/L = list(  )

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -106,7 +106,21 @@
 	for(var/mob/M in get_mobs_in_view(range, src))
 		if(self_message && M==src)
 			msg = self_message
-		M.show_message( msg, 2, deaf_message, 1)
+		M.show_message(msg, 2, deaf_message, 1)
+	
+	// based on say code
+	var/omsg = replacetext(message, "<B>[src]</B> ", "")
+	var/list/listening_obj = new
+	for(var/atom/movable/A in view(range, src))
+		if(istype(A, /mob))
+			var/mob/M = A
+			for(var/obj/O in M.contents)
+				listening_obj |= O
+		else if(istype(A, /obj))
+			var/obj/O = A
+			listening_obj |= O
+	for(var/obj/O in listening_obj)
+		O.hear_message(src, omsg)
 
 // Show a message to all mobs in earshot of this atom
 // Use for objects performing audible actions

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -526,13 +526,13 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 	if (camera && on)
 		if(get_dist(src, M) <= canhear_range)
 			talk_into(M, msg)
-		for(var/obj/machinery/computer/security/telescreen/T in world)
+		for(var/obj/machinery/computer/security/telescreen/T in machines)
 			if(T.current == camera)
 				T.audible_message("<span class='game radio'><span class='name'>(Newscaster) [M]</span> says, '[msg]'", hearing_distance = 2)
 
 /obj/item/device/videocam/hear_message(mob/M as mob, msg)
 	if (camera && on)
-		for(var/obj/machinery/computer/security/telescreen/T in world)
+		for(var/obj/machinery/computer/security/telescreen/T in machines)
 			if(T.current == camera)
 				T.audible_message("<span class='game radio'><span class='name'>(Newscaster) [M]</span> [msg]", hearing_distance = 2)
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -497,7 +497,6 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 	var/icon_on = "videocam_on"
 	var/icon_off = "videocam"
 	var/canhear_range = 7
-	var/watcherslist = list()
 
 /obj/item/device/videocam/attack_self(mob/user)
 	on = !on
@@ -523,14 +522,19 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 	if(..(user, 1))
 		user << "This video camera can send live feeds to the entertainment network. It's [camera ? "" : "in"]active."
 
-
 /obj/item/device/videocam/hear_talk(mob/M as mob, msg)
 	if (camera && on)
 		if(get_dist(src, M) <= canhear_range)
 			talk_into(M, msg)
-		for(var/mob/living/carbon/human/H in watcherslist)
-			H.show_message(text("\blue (Newscaster) [] says, '[]'",M,msg), 1)
+		for(var/obj/machinery/computer/security/telescreen/T)
+			if(T.current == camera)
+				T.audible_message("<span class='game radio'><span class='name'>(Newscaster) [M]</span> says, '[msg]'", hearing_distance = 2)
 
+/obj/item/device/videocam/hear_message(mob/M as mob, msg)
+	if (camera && on)
+		for(var/obj/machinery/computer/security/telescreen/T)
+			if(T.current == camera)
+				T.audible_message("<span class='game radio'><span class='name'>(Newscaster) [M]</span> [msg]", hearing_distance = 2)
 
 
 ///hauntings, like hallucinations but more spooky

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -526,13 +526,13 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 	if (camera && on)
 		if(get_dist(src, M) <= canhear_range)
 			talk_into(M, msg)
-		for(var/obj/machinery/computer/security/telescreen/T)
+		for(var/obj/machinery/computer/security/telescreen/T in world)
 			if(T.current == camera)
 				T.audible_message("<span class='game radio'><span class='name'>(Newscaster) [M]</span> says, '[msg]'", hearing_distance = 2)
 
 /obj/item/device/videocam/hear_message(mob/M as mob, msg)
 	if (camera && on)
-		for(var/obj/machinery/computer/security/telescreen/T)
+		for(var/obj/machinery/computer/security/telescreen/T in world)
 			if(T.current == camera)
 				T.audible_message("<span class='game radio'><span class='name'>(Newscaster) [M]</span> [msg]", hearing_distance = 2)
 

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -266,6 +266,10 @@
 	if(assembly)
 		assembly.hear_talk(M, msg)
 
+/obj/item/weapon/reagent_containers/glass/beaker/hear_message(mob/living/M, msg)
+	if(assembly)
+		assembly.hear_message(M, msg)
+
 /obj/item/weapon/reagent_containers/glass/beaker/large
 	name = "large beaker"
 	desc = "A large beaker. Can hold up to 100 units."

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -176,6 +176,10 @@
 	if(rig)
 		rig.hear_talk(M, msg)
 
+/obj/structure/reagent_dispensers/fueltank/hear_message(mob/living/M, msg)
+	if(rig)
+		rig.hear_message(M, msg)
+
 /obj/structure/reagent_dispensers/fueltank/Bump()
 	..()
 	if(rig)


### PR DESCRIPTION
There wasn't actually a standard way to do this before, so...
* I added a new proc `/atom/proc/hear_message(mob, message)` that is used like `hear_talk()`, but is for hearing audible emotes.

##### This is noticably used by...
* The Voice Analyzer
 * Fixes #2815 
* Video Camera -> Entertainment Monitor
* Tape Recorder
* AI Hologram thing
* More objects could probably use this, but I'm going to consider that outside the scope of this PR unless there's a major omission I'm not thinking of.

Also made megaphone slightly less broken.