### PR TITLE
Removes the self-dna-scanner-insertion guard

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -184,8 +184,6 @@
 		if(M.Victim == L)
 			usr << "[L.name] will not fit into the DNA Scanner because they have a slime latched onto their head."
 			return
-	if(L == user)
-		return
 	visible_message("[user] puts [L.name] into the DNA Scanner.")
 	put_in(L)
 	if(user.pulling == L)


### PR DESCRIPTION
You can drag yourself into a dna machine now.

Fixes #2829... Pinging @ZomgPonies because they made it this way <a href=https://github.com/ParadiseSS13/Paradise/commit/fe0a3a2dcd35f58c24c52e4e5f49718604130cf2#diff-66d421a82b64ef03ab9dfc4602a5a56fR159>way back when or whatever</a>, though they've likely long forgotten what's gone on there by now.

One potential concern that I see is potentially putting like, a cat, in there? Not sure how well things will turn into a fiery mass of destruction, but here we go.