### PR TITLE
Makes girders spawn on top of any turf effects.

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -2,7 +2,7 @@
 	icon_state = "girder"
 	anchored = 1
 	density = 1
-	layer = 2
+	layer = TURF_LAYER + 0.9
 	var/state = 0
 	var/health = 200
 


### PR DESCRIPTION
- Since girders are vertical structures, they should stick out of any kind of turf effect happening on the turf itself, like ice.