### PR TITLE
Gib Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -15,7 +15,7 @@
 
 	for(var/obj/item/organ/I in internal_organs)
 		if(istype(loc,/turf))
-			I.removed(src)
+			I.removed()
 			spawn()
 				I.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)
 


### PR DESCRIPTION
The organs removed under human/gib() had `src` in `removed()` thus saying that the person who gibbed removed their own organs.

This doesn't need to be here and generates extra logs that shouldn't exist.