### PR TITLE
Guardian Mining Tweak

### DIFF
--- a/code/game/asteroid.dm
+++ b/code/game/asteroid.dm
@@ -97,7 +97,7 @@ var/global/max_secret_rooms = 6
 			theme = "xenoden"
 			walltypes = list(/turf/simulated/mineral/random/high_chance=1)
 			floortypes = list(/turf/simulated/floor/plating/airless/asteroid, /turf/simulated/floor/beach/sand)
-			treasureitems = list(/obj/item/clothing/mask/facehugger=1,/obj/item/stack/sheet/animalhide/xeno=2,/obj/item/clothing/suit/xenos=2,/obj/item/clothing/head/xenos=2,/obj/item/weapon/guardiancreator/biological=1)
+			treasureitems = list(/obj/item/clothing/mask/facehugger=1,/obj/item/stack/sheet/animalhide/xeno=2,/obj/item/clothing/suit/xenos=2,/obj/item/clothing/head/xenos=2,/obj/item/weapon/guardiancreator/biological/choose=1)
 			fluffitems = list(/obj/effect/decal/remains/human=1,/obj/effect/decal/cleanable/blood/xeno=5)
 
 		if("hitech")


### PR DESCRIPTION
Makes it so the guardian creator spawned in mining is a "choose" type instead of fully random.