### PR TITLE
Adjusts Meteor Required Players

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -3,7 +3,8 @@
 	config_tag = "meteor"
 	var/const/initialmeteordelay = 6000
 	var/wave = 1
-	required_players = 0
+	required_players = 35
+	required_players_secret = 35
 
 	uplink_welcome = "EVIL METEOR Uplink Console:"
 	uplink_uses = 10


### PR DESCRIPTION
It's literally impossible for a small crew to deal with meteors, nor is it fun for them; it's just getting pelted endlessly until the crew inevitably calls the shuttle.

During higher population rounds construction/rebuilding can be engaged it, but lower crew rounds just doesn't afford this luxury.

Required players: 35