### PR TITLE
Ports Rapid Construction for Part Replacer

### DIFF
--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -34,7 +34,6 @@
 	name = "bluespace rapid part exchange device"
 	desc = "A version of the RPED that allows for replacement of parts and scanning from a distance, along with higher capacity for parts."
 	icon_state = "BS_RPED"
-	item_state = "BS_RPED"
 	w_class = 3
 	storage_slots = 400
 	max_w_class = 3


### PR DESCRIPTION
Ports over TG's rapid construction with a part replacer.

Basically if you have a machine frame, with a circuit board in it, you can click on the frame with the part replacer to load all the parts at the same time instead of constructing them piece by piece.

Differences from TG: TG has a list sorting feature that allows you to sort lists based on criterion--its utilized for the part replacer to sort the parts from high rating to low rating--I did not port this as this isn't something that I could do in short order.

End result of the sorting difference: when you rapid construct something, it's just going to grab the first part of that type, even if it's a lower rating--this just means you'll have to manually upgrade after you rapidly construct the device (if you have different tiered parts of the same type). It's not ideal, but rapid construction vs no rapid-construction? I think players will take the minor inconvenience of having to re-upgrade in some instances.

Fixes:
- Fixes the bluespace part replacer not having an in-hand icon.