### PR TITLE
Fixes Cryopods Being Overly Attached to Crew

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -250,7 +250,9 @@
 	find_control_computer()
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent=0)
-	control_computer = locate(/obj/machinery/computer/cryopod) in get_area(src)
+	for(var/obj/machinery/computer/cryopod/C in areaMaster.contents) //locate() is shit, this actually works, and there's a decent chance it's faster than locate()
+		control_computer = C
+		break
 
 	// Don't send messages unless we *need* the computer, and less than five minutes have passed since last time we messaged
 	if(!control_computer && urgent && last_no_computer_message + 5*60*10 < world.time)


### PR DESCRIPTION
Ice-olating this bug was a bit annoying, but it turns out locate() is particularly uncool. This should make the cryopods chill out and actually despawn players now.

Fixes #2898