### PR TITLE
RnD Console Permissions are more Persistent

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -149,6 +149,7 @@
 // RD console circuits, so that {de,re}constructing one of the special consoles doesn't ruin everything forever
 /obj/item/weapon/circuitboard/rdconsole
 	name = "Circuit Board (RD Console)"
+	desc = "Swipe a Research Director level ID or higher to reconfigure."
 	build_path = /obj/machinery/computer/rdconsole/core
 	req_access = list(access_rd) // This is for adjusting the type of computer we're building - in case something messes up the pre-existing robotics or mechanics consoles
 	var/access_types = list("R&D Core", "Robotics", "E.X.P.E.R.I-MENTOR", "Mechanics")

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -144,9 +144,29 @@
 /obj/item/weapon/circuitboard/prisoner
 	name = "Circuit board (Prisoner Management)"
 	build_path = /obj/machinery/computer/prisoner
+
+
+// RD console circuits, so that {de,re}constructing one of the special consoles doesn't ruin everything forever
 /obj/item/weapon/circuitboard/rdconsole
 	name = "Circuit Board (RD Console)"
 	build_path = /obj/machinery/computer/rdconsole/core
+	req_access = list(access_rd) // This is for adjusting the type of computer we're building - in case something messes up the pre-existing robotics or mechanics consoles
+	var/access_types = list("R&D Core", "Robotics", "E.X.P.E.R.I-MENTOR", "Mechanics")
+	id = 1
+/obj/item/weapon/circuitboard/rdconsole/robotics
+	name = "Circuit Board (RD Console - Robotics)"
+	build_path = /obj/machinery/computer/rdconsole/robotics
+	id = 2
+/obj/item/weapon/circuitboard/rdconsole/experiment
+	name = "Circuit Board (RD Console - E.X.P.E.R.I-MENTOR)"
+	build_path = /obj/machinery/computer/rdconsole/experiment
+	id = 3
+/obj/item/weapon/circuitboard/rdconsole/mechanics
+	name = "Circuit Board (RD Console - Mechanics)"
+	build_path = /obj/machinery/computer/rdconsole/mechanics
+	id = 4
+
+
 /obj/item/weapon/circuitboard/mecha_control
 	name = "Circuit Board (Exosuit Control Console)"
 	build_path = /obj/machinery/computer/mecha
@@ -285,16 +305,33 @@
 	return
 
 /obj/item/weapon/circuitboard/rdconsole/attackby(obj/item/I as obj, mob/user as mob, params)
-	if(istype(I,/obj/item/weapon/screwdriver))
-		user.visible_message("\blue \the [user] adjusts the jumper on the [src]'s access protocol pins.", "\blue You adjust the jumper on the access protocol pins.")
-		if(src.build_path == "/obj/machinery/computer/rdconsole/core")
-			src.name = "Circuit Board (RD Console - Robotics)"
-			src.build_path = /obj/machinery/computer/rdconsole/robotics
-			user << "\blue Access protocols set to robotics."
+	if(istype(I,/obj/item/weapon/card/id)||istype(I, /obj/item/device/pda))
+		if(allowed(user))
+			user.visible_message("<span class='notice'>\the [user] waves their ID past the [src]'s access protocol scanner.</span>", "<span class='notice'>You swipe your ID past the [src]'s access protocol scanner.</span>")
+			var/console_choice = input(user, "What do you want to configure the access to?", "Configuration Modification", "R&D Core") as null|anything in access_types
+			if(console_choice == null)
+				return
+			switch(console_choice)
+				if("R&D Core")
+					name = "Circuit Board (RD Console)"
+					build_path = /obj/machinery/computer/rdconsole/core
+					id = 1
+				if("Robotics")
+					name = "Circuit Board (RD Console - Robotics)"
+					build_path = /obj/machinery/computer/rdconsole/robotics
+					id = 2
+				if("E.X.P.E.R.I-MENTOR")
+					name = "Circuit Board (RD Console - E.X.P.E.R.I-MENTOR)"
+					build_path = /obj/machinery/computer/rdconsole/experiment
+					id = 3
+				if("Mechanics")
+					name = "Circuit Board (RD Console - Mechanics)"
+					build_path = /obj/machinery/computer/rdconsole/mechanics
+					id = 4
+
+			user << "<span class='notice'>Access protocols set to [console_choice].</span>"
 		else
-			src.name = "Circuit Board (RD Console)"
-			src.build_path = /obj/machinery/computer/rdconsole/core
-			user << "\blue Access protocols set to default."
+			user << "<span class='warning'>Access Denied</span>"
 	return
 
 /obj/structure/computerframe/attackby(obj/item/P as obj, mob/user as mob, params)

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -152,7 +152,7 @@
 	desc = "Swipe a Research Director level ID or higher to reconfigure."
 	build_path = /obj/machinery/computer/rdconsole/core
 	req_access = list(access_rd) // This is for adjusting the type of computer we're building - in case something messes up the pre-existing robotics or mechanics consoles
-	var/access_types = list("R&D Core", "Robotics", "E.X.P.E.R.I-MENTOR", "Mechanics")
+	var/access_types = list("R&D Core", "Robotics", "E.X.P.E.R.I-MENTOR", "Mechanics", "Public")
 	id = 1
 /obj/item/weapon/circuitboard/rdconsole/robotics
 	name = "Circuit Board (RD Console - Robotics)"
@@ -166,6 +166,10 @@
 	name = "Circuit Board (RD Console - Mechanics)"
 	build_path = /obj/machinery/computer/rdconsole/mechanics
 	id = 4
+/obj/item/weapon/circuitboard/rdconsole/public
+	name = "Circuit Board (RD Console - Public)"
+	build_path = /obj/machinery/computer/rdconsole/public
+	id = 5
 
 
 /obj/item/weapon/circuitboard/mecha_control
@@ -309,7 +313,7 @@
 	if(istype(I,/obj/item/weapon/card/id)||istype(I, /obj/item/device/pda))
 		if(allowed(user))
 			user.visible_message("<span class='notice'>\the [user] waves their ID past the [src]'s access protocol scanner.</span>", "<span class='notice'>You swipe your ID past the [src]'s access protocol scanner.</span>")
-			var/console_choice = input(user, "What do you want to configure the access to?", "Configuration Modification", "R&D Core") as null|anything in access_types
+			var/console_choice = input(user, "What do you want to configure the access to?", "Access Modification", "R&D Core") as null|anything in access_types
 			if(console_choice == null)
 				return
 			switch(console_choice)
@@ -329,6 +333,10 @@
 					name = "Circuit Board (RD Console - Mechanics)"
 					build_path = /obj/machinery/computer/rdconsole/mechanics
 					id = 4
+				if("Public")
+					name = "Circuit Board (RD Console - Public)"
+					build_path = /obj/machinery/computer/rdconsole/public
+					id = 5
 
 			user << "<span class='notice'>Access protocols set to [console_choice].</span>"
 		else

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -169,8 +169,6 @@ proc/CallMaterialName(ID)
 			return
 		D.loc = src
 		user << "<span class='notice'>You add the disk to the machine!</span>"
-	if(istype(D, /obj/item/weapon/screwdriver) && islocked() && !(stat & BROKEN))
-		user << "<span class='warning'>This console is locked; Unlock it first</span>"
 	else
 		..()
 	src.updateUsrDialog()
@@ -325,12 +323,6 @@ proc/CallMaterialName(ID)
 									linked_destroy.icon_state = "d_analyzer"
 						use_power(250)
 						updateUsrDialog()
-
-	else if(href_list["lock"]) //Lock the console from use by anyone without access.
-		if(src.allowed(usr))
-			screen = text2num(href_list["lock"])
-		else
-			usr << "Unauthorized Access."
 
 	else if(href_list["sync"]) //Sync the research holder with all the R&D consoles in the game that aren't sync protected.
 		screen = 0.0
@@ -658,10 +650,6 @@ proc/CallMaterialName(ID)
 
 		if(0.1) dat += "<div class='statusDisplay'>Processing and Updating Database...</div>"
 
-		if(0.2)
-			dat += "<div class='statusDisplay'>SYSTEM LOCKED</div>"
-			dat += "<A href='?src=\ref[src];lock=1.6'>Unlock</A>"
-
 		if(0.3)
 			dat += "<div class='statusDisplay'>Constructing Prototype. Please Wait...</div>"
 
@@ -774,7 +762,6 @@ proc/CallMaterialName(ID)
 				dat += "<A href='?src=\ref[src];togglesync=1'>Connect to Research Network</A><BR>"
 				dat += "<span class='linkOn'>Disconnect from Research Network</span><BR>"
 			dat += "<A href='?src=\ref[src];menu=1.7'>Device Linkage Menu</A><BR>"
-			dat += "<A href='?src=\ref[src];lock=0.2'>Lock Console</A><BR>"
 			if(check_rights(R_ADMIN,0))
 				dat += "<A href='?src=\ref[src];maxresearch=1'>\[ADMIN\] Maximize Research Levels</A><BR>"
 			dat += "<A href='?src=\ref[src];reset=1'>Reset R&D Database</A></div>"
@@ -1155,11 +1142,6 @@ proc/CallMaterialName(ID)
 
 	dat += "</tr></table></div>"
 	return dat
-
-// This check here is silly but the reason I made it a proc is so that if a better criterion is made
-// you can just change it here and you'll be good to go
-/obj/machinery/computer/rdconsole/proc/islocked()
-	return screen == 0.2
 
 /obj/machinery/computer/rdconsole/core
 	name = "core R&D console"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -1164,14 +1164,17 @@ proc/CallMaterialName(ID)
 	desc = "A console used to interface with R&D tools."
 	id = 2
 	req_access = list(access_robotics)
+	circuit = /obj/item/weapon/circuitboard/rdconsole/robotics
 
 /obj/machinery/computer/rdconsole/experiment
 	name = "\improper E.X.P.E.R.I-MENTOR R&D console"
 	desc = "A console used to interface with R&D tools."
 	id = 3
+	circuit = /obj/item/weapon/circuitboard/rdconsole/experiment
 
 /obj/machinery/computer/rdconsole/mechanics
 	name = "mechanics R&D console"
 	desc = "A console used to interface with R&D tools."
 	id = 4
 	req_access = list(access_mechanic)
+	circuit = /obj/item/weapon/circuitboard/rdconsole/mechanics

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -169,6 +169,8 @@ proc/CallMaterialName(ID)
 			return
 		D.loc = src
 		user << "<span class='notice'>You add the disk to the machine!</span>"
+	if(istype(D, /obj/item/weapon/screwdriver) && islocked())
+		user << "<span class='warning'>This console is locked; Unlock it first</span>"
 	else
 		..()
 	src.updateUsrDialog()
@@ -1153,6 +1155,11 @@ proc/CallMaterialName(ID)
 
 	dat += "</tr></table></div>"
 	return dat
+
+// This check here is silly but the reason I made it a proc is so that if a better criterion is made
+// you can just change it here and you'll be good to go
+/obj/machinery/computer/rdconsole/proc/islocked()
+	return screen == 0.2
 
 /obj/machinery/computer/rdconsole/core
 	name = "core R&D console"

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -1167,3 +1167,10 @@ proc/CallMaterialName(ID)
 	id = 4
 	req_access = list(access_mechanic)
 	circuit = /obj/item/weapon/circuitboard/rdconsole/mechanics
+
+/obj/machinery/computer/rdconsole/public
+	name = "public R&D console"
+	desc = "A console used to interface with R&D tools."
+	id = 5
+	req_access = list()
+	circuit = /obj/item/weapon/circuitboard/rdconsole/public

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -169,7 +169,7 @@ proc/CallMaterialName(ID)
 			return
 		D.loc = src
 		user << "<span class='notice'>You add the disk to the machine!</span>"
-	if(istype(D, /obj/item/weapon/screwdriver) && islocked())
+	if(istype(D, /obj/item/weapon/screwdriver) && islocked() && !(stat & BROKEN))
 		user << "<span class='warning'>This console is locked; Unlock it first</span>"
 	else
 		..()


### PR DESCRIPTION
Screwdrivering the robotics console twice won't lock them out forever, and if something happens the RD can now swipe their ID past the console board to adjust its permissions between the four presets that already exist on the map. I've now also added a public console type if the RD wants to give a research console to a department that isn't one of the 4 existing types, or something.

* R&D console permissions don't vanish with a sneeze anymore; You can deconstruct the console, grab the board, and put it elsewhere and have it keep the same permissions
* The RD or equivalent can use their ID to reconfigure an existing R&D console board between the 4 pre-existing presets
* Locking an R&D console is obsolete, and thus I've made it superded to avoid confusion
* The RD swiping on the console board can now also create a public R&D console, for if they feel generous during nations or something