### PR TITLE
Voxtest2.ogg

### DIFF
--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -579,6 +579,7 @@
 		if(isliving(held))
 			data["holder"] = held
 			data["health"] = "[held.stat > 1 ? "dead" : "[held.health]% healthy"]"
+			data["brute"] = "[held.getBruteLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getBruteLoss()]</font>"
 			data["oxy"] = "[held.getOxyLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getOxyLoss()]</font>"
 			data["tox"] = "[held.getToxLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getToxLoss()]</font>"
 			data["burn"] = "[held.getFireLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getFireLoss()]</font>"

--- a/nano/templates/pai_bioscan.tmpl
+++ b/nano/templates/pai_bioscan.tmpl
@@ -10,6 +10,9 @@ code/modules/mob/living/silicon/pai/software_modules.dm
 		<div class="itemContent">
 			Health Status : 	{{:data.health}}
 		</div>
+
+		<div class="itemContent">
+			Brute Damage : 		{{:data.brute}}
 		<div class="itemContent">
 			Oxygen Content : 	{{:data.oxy}}
 		<div class="itemContent">


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/2945

pAIs can now see how much brute damage thier holder has..and laugh at them.

HUD Fixes:
Ghost medhud is now a three way toggle and will switch between Basic Sec hud, med hud, and robot diagnostic display.

People with antagHud ON can now see ai laws.

There is an alert to the above mentioned toggle for med/sec/diag huds.

sec hud is now no long displayed with the antagHud

Barring any findings of i dun fucked up this PR is tested and mergeable.