### PR TITLE
Research Lockbox Access Change and Wormhole Projector Lockboxing

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -44,6 +44,7 @@ other types of metals and chemistry for reagents).
 	var/construction_time				//Amount of time required for building the object
 	var/build_path = ""					//The file path of the object that gets created
 	var/locked = 0						//If true it will spawn inside a lockbox with currently sec access
+	var/access_requirement = list(access_armory) //What special access requirements will the lockbox have? Defaults to armory.
 	var/category = null //Primarily used for Mech Fabricators, but can be used for anything
 	var/list/reagents = list()			//List of reagents. Format: "id" = amount.
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -68,6 +68,8 @@
 	build_type = PROTOLATHE
 	materials = list(MAT_SILVER = 1000, MAT_METAL = 5000, MAT_DIAMOND = 3000)
 	build_path = /obj/item/weapon/gun/energy/wormhole_projector
+	locked = 1
+	access_requirement = list(access_rd) //screw you, HoS, this aint yours; this is only for a man of science---and trouble.
 	category = list("Weapons")
 
 /datum/design/large_grenade

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -437,6 +437,11 @@ proc/CallMaterialName(ID)
 									new_item.loc = L
 									L.name += " ([new_item.name])"
 									L.origin_tech = new_item.origin_tech
+									L.req_access = being_built.access_requirement
+									var/lockbox_access = null
+									for(var/A in L.req_access)
+										lockbox_access = get_access_desc(A)
+									L.desc = "A locked box. It is locked to [lockbox_access] access."
 								else
 									new_item.loc = linked_lathe.loc
 						linked_lathe.busy = 0

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -438,10 +438,10 @@ proc/CallMaterialName(ID)
 									L.name += " ([new_item.name])"
 									L.origin_tech = new_item.origin_tech
 									L.req_access = being_built.access_requirement
-									var/lockbox_access = null
+									var/list/lockbox_access
 									for(var/A in L.req_access)
-										lockbox_access = get_access_desc(A)
-									L.desc = "A locked box. It is locked to [lockbox_access] access."
+										lockbox_access += "[get_access_desc(A)] "
+									L.desc = "A locked box. It is locked to [lockbox_access]access."
 								else
 									new_item.loc = linked_lathe.loc
 						linked_lathe.busy = 0


### PR DESCRIPTION
An alternative to: https://github.com/ParadiseSS13/Paradise/pull/2974

Ironically, I thought of specific lockbox access based on datums earlier, before it was even suggested there---seems I wasn't the only one who had that idea.

In any event, this PR does a few things:

- Gives the ability for specific designs to have different access requirements on them (if locked)
- The lockboxes now have a description on them that states the access requirement they require to be unlocked
- Wormhole projector is lockboxed and locked to the RD.
 - This isn't meant for security, this is the RD's thing.