### PR TITLE
EMP Fixes

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -162,7 +162,8 @@
 
 /obj/machinery/door/emp_act(severity)
 	if(prob(20/severity) && (istype(src,/obj/machinery/door/airlock) || istype(src,/obj/machinery/door/window)) )
-		open()
+		spawn(0)
+			open()
 	..()
 
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -477,9 +477,9 @@ var/list/turret_icons
 			emagged = 1
 
 		enabled=0
-		sleep(rand(60,600))
-		if(!enabled)
-			enabled=1
+		spawn(rand(60,600))
+			if(!enabled)
+				enabled=1
 
 	..()
 

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -73,7 +73,7 @@
 		return 1
 
 	return 0
-	
+
 /obj/machinery/turretid/CanUseTopic(mob/user)
 	if(isLocked(user))
 		return STATUS_CLOSE
@@ -107,7 +107,7 @@
 		return
 
 	ui_interact(user)
-	
+
 /obj/machinery/turretid/attack_ghost(mob/user as mob)
 	ui_interact(user)
 
@@ -224,9 +224,9 @@
 		enabled=0
 		updateTurrets()
 
-		sleep(rand(60,600))
-		if(!enabled)
-			enabled=1
-			updateTurrets()
+		spawn(rand(60,600))
+			if(!enabled)
+				enabled=1
+				updateTurrets()
 
 	..()

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -51,7 +51,7 @@
 /obj/effect/overlay/temp/emp/pulse
 	name = "emp pulse"
 	icon_state = "emp pulse"
-	duration = 20
+	duration = 8
 	randomdir = 0
 
 /obj/effect/overlay/palmtree_r

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -1,4 +1,4 @@
-proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
+/proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
 	if(!epicenter) return
 
 	if(!istype(epicenter, /turf))

--- a/code/modules/media/broadcast/transmitters/broadcast.dm
+++ b/code/modules/media/broadcast/transmitters/broadcast.dm
@@ -88,22 +88,6 @@
 	return screen
 */
 
-
-/obj/machinery/light_switch/power_change()
-	if(powered(LIGHT))
-		stat &= ~NOPOWER
-	else
-		stat |= NOPOWER
-
-	updateicon()
-
-/obj/machinery/light_switch/emp_act(severity)
-	if(stat & (BROKEN|NOPOWER))
-		..(severity)
-		return
-	power_change()
-	..(severity)
-
 /obj/machinery/media/transmitter/broadcast/update_icon()
 	overlays = 0
 	if(stat & (NOPOWER|BROKEN))

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -142,7 +142,7 @@
 
 	emp_act(severity)
 		..()
-		reliability -= round(15/severity)
+		reliability = max(reliability - round(15/severity), 0) //Do not allow it to go negative!
 
 
 	update_icon()


### PR DESCRIPTION
So, in working with the Tesla, I noticed it would freeze object processing---but I was never sure why.

I'm really not sure if this will fix that or not (time will well), buttt...

DON'T BUT A SLEEP IN AN EMP_ACT, EX_ACT() OR SOMETHING ELSE THAT CAN GET MASS CALLED!

Also, light_switch/power_change() and emp_act() were defined twice....the second time in VG's shitty media equipment...what the ever loving shit.

I tested this by releasing a mega cluster-cluster EMP grenade---while it lagged the server (understandable at something like 100+ EMPs going off continuously), it didn't appear to lock anything up, and things processed normally.

I've seen EMP effects and grenades mess up before, in testing--it was one of the things that tipped me off that it may be EMPs that are locking up things.

edit: seems TG had this same exact problem: https://github.com/tgstation/-tg-station/pull/5389