### PR TITLE
Removes EMP shriek from changeling

### DIFF
--- a/code/game/gamemodes/changeling/powers/shriek.dm
+++ b/code/game/gamemodes/changeling/powers/shriek.dm
@@ -29,18 +29,5 @@
 	feedback_add_details("changeling_powers","RS")
 	return 1
 
-/obj/effect/proc_holder/changeling/dissonant_shriek
-	name = "Dissonant Shriek"
-	desc = "We shift our vocal cords to release a high-frequency sound that overloads nearby electronics."
-	chemical_cost = 30
-	dna_cost = 1
-
-//A flashy ability, good for crowd control and sewing chaos.
-/obj/effect/proc_holder/changeling/dissonant_shriek/sting_action(var/mob/user)
-	for(var/obj/machinery/light/L in range(5, usr))
-		L.on = 1
-		L.broken()
-	empulse(get_turf(user), 2, 4, 1)
-	return 1
 
 


### PR DESCRIPTION
EMP is one of the most powerfull tools in the game, having a way to use it unlimited is bad, the main problem comes from the fact that this power originates from /tg/, but unlike /tg/ we have IPC's.