### PR TITLE
EMPs now do what they stand for, Extreme Machine Patching

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -34,6 +34,7 @@
 		handle_environment(environment)
 
 	handle_fire()
+	empulse(get_turf(src), 2, 4, 1)
 
 	//stuff in the stomach
 	handle_stomach()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -281,12 +281,15 @@ var/list/organ_cache = list()
 	switch (severity)
 		if (1.0)
 			take_damage(0,20)
+			rejuvenate()
 			return
 		if (2.0)
 			take_damage(0,7)
+			rejuvenate()
 			return
 		if(3.0)
 			take_damage(0,3)
+			rejuvenate()
 
 /obj/item/organ/proc/removed(var/mob/living/user)
 	if(!istype(owner))


### PR DESCRIPTION
So, clearly, we are at an extreme misunderstanding of what EMPs are supposed to do, they make my character dead all the time. We are clearly misparsing the acronym here - it's got magnets in it, and robots and computers run on magnetism or something or other, so CLEARLY it must be good for them! Yes!

Now, enjoy eating all the ions you want, because it's good for you!

Oh yes and because of bioelectricity everything emits an EMP every second