### PR TITLE
Bodyscanner ui

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -315,6 +315,7 @@
 			occupantData["name"] = H.name
 			occupantData["stat"] = H.stat
 			occupantData["health"] = H.health
+			occupantData["maxHealth"] = H.maxHealth
 
 			occupantData["hasVirus"] = H.virus2.len
 
@@ -338,7 +339,9 @@
 				var/blood_volume = round(H.vessel.get_reagent_amount("blood"))
 				bloodData["volume"] = blood_volume
 				bloodData["percent"] = round(((blood_volume / 560)*100))
-
+				bloodData["pulse"] = H.get_pulse(GETPULSE_TOOL)
+				bloodData["bloodLevel"] = round(H.vessel.get_reagent_amount("blood"))
+				bloodData["bloodMax"] = H.max_blood
 			occupantData["blood"] = bloodData
 
 			var/reagentData[0]
@@ -426,6 +429,9 @@
 /obj/machinery/body_scanconsole/Topic(href, href_list)
 	if(..())
 		return 1
+
+	if (href_list["ejectify"])
+		src.connected.eject()
 
 	if (href_list["print_p"])
 		generate_printing_text()

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -344,16 +344,6 @@
 				bloodData["bloodMax"] = H.max_blood
 			occupantData["blood"] = bloodData
 
-			var/reagentData[0]
-			if(H.reagents)
-				reagentData["epinephrine"] = H.reagents.get_reagent_amount("Epinephrine")
-				reagentData["ether"] = H.reagents.get_reagent_amount("ether")
-				reagentData["silver_sulfadiazine"] = H.reagents.get_reagent_amount("silver_sulfadiazine")
-				reagentData["styptic_powder"] = H.reagents.get_reagent_amount("styptic_powder")
-				reagentData["salbutamol"] = H.reagents.get_reagent_amount("salbutamol")
-
-			occupantData["reagents"] = reagentData
-
 			var/extOrganData[0]
 			for(var/obj/item/organ/external/E in H.organs)
 				var/organData[0]

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -93,7 +93,7 @@
 		qdel(G)
 
 
-/obj/machinery/bodyscanner/MouseDrop_T(mob/living/carbon/O, mob/user as mob)
+/obj/machinery/bodyscanner/MouseDrop_T(mob/living/carbon/human/O, mob/user as mob)
 	if(!istype(O))
 		return 0 //not a mob
 	if(user.incapacitated())
@@ -310,7 +310,7 @@
 		data["occupied"] = connected.occupant ? 1 : 0
 
 		var/occupantData[0]
-		if(connected.occupant && ishuman(connected.occupant))
+		if(connected.occupant)
 			var/mob/living/carbon/human/H = connected.occupant
 			occupantData["name"] = H.name
 			occupantData["stat"] = H.stat
@@ -335,8 +335,10 @@
 			occupantData["hasBorer"] = H.has_brain_worms()
 
 			var/bloodData[0]
-			if(H.vessel)
+			bloodData["hasBlood"] = 0
+			if(ishuman(H) && H.vessel && !(H.species && H.species.flags & NO_BLOOD))
 				var/blood_volume = round(H.vessel.get_reagent_amount("blood"))
+				bloodData["hasBlood"] = 1
 				bloodData["volume"] = blood_volume
 				bloodData["percent"] = round(((blood_volume / 560)*100))
 				bloodData["pulse"] = H.get_pulse(GETPULSE_TOOL)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -354,6 +354,10 @@
 				organData["germ_level"] = E.germ_level
 				organData["bruteLoss"] = E.brute_dam
 				organData["fireLoss"] = E.burn_dam
+				organData["totalLoss"] = E.brute_dam + E.burn_dam
+				organData["maxHealth"] = E.max_damage
+				organData["bruised"] = E.min_bruised_damage
+				organData["broken"] = E.min_broken_damage
 
 				var/implantData[0]
 				for(var/obj/I in E.implants)
@@ -400,6 +404,9 @@
 				organData["desc"] = I.desc
 				organData["germ_level"] = I.germ_level
 				organData["damage"] = I.damage
+				organData["maxHealth"] = I.max_damage
+				organData["bruised"] = I.min_broken_damage
+				organData["broken"] = I.min_bruised_damage
 
 				intOrganData.Add(list(organData))
 

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -560,6 +560,11 @@ th.misc {
     color: #ffffff;
 }
 
+/* Table styling for Med Scanner */
+.striped tr:nth-child(even) {
+    background-color: #404040
+}
+
 /* Damage colors for crew monitoring computer */
 .burn {
     color: orange;

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -371,6 +371,11 @@ div.notice {
     background: #4f7529;
 }
 
+.displayBarFill.notgood {
+    color: #ffffff;
+    background: #ffb400;
+}
+
 .displayBarFill.average {
     color: #ffffff;
     background: #cd6500;

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -144,7 +144,7 @@ Used In File(s): \code\game\machinery\adv_med.dm
 		<tbody class="striped">
 			{{for data.occupant.extOrgan}}
 				<tr>
-					<td>{{:value.name}} </td>
+					<td> {{:value.name}} </td>
 					<td> {{if value.bruteLoss> 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.bruteLoss}} </span> </td>
 					<td> {{if value.fireLoss> 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.fireLoss}} </span> 	</td>
 					<td>
@@ -197,7 +197,7 @@ Used In File(s): \code\game\machinery\adv_med.dm
 		<tbody class="striped">
 			{{for data.occupant.intOrgan}}
 				<tr>
-					<td> {{:value.name}} <br> {{:value.desc != null ? value.desc : ""}} </td>
+					<td> {{:value.name}} <br> </td>
 					<td> {{if value.damage > 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.damage}} </span> </td>
 					<td>
 						{{if value.germ_level > 100}}

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -105,31 +105,34 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			</tr>
 		</tbody>
 	</table>
-	<br>
-	<b>Blood:</b>
-	<div class="line">
-		<div class="statusLabel">Pulse:</div> <div class="statusValue">{{:data.occupant.blood.pulse}} bpm</div>
-	</div>
 
-	<div class="line">
-		<div class="statusLabel">Blood Level:</div>
-		{{if data.occupant.blood.percent <= 60}}
-			{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'bad')}}
-		<div class="statusValue">
-			{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
+	{{if data.occupant.blood.hasBlood}}
+		<br>
+		<b>Blood:</b>
+		<div class="line">
+			<div class="statusLabel">Pulse:</div> <div class="statusValue">{{:data.occupant.blood.pulse}} bpm</div>
 		</div>
-		{{else data.occupant.blood.percent <= 90}}
-			{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'average')}}
-		<div class="statusValue">
-			{{:data.occupant.blood.percent}}%, {{:data.occupant.bloodLevel}}cl
+
+		<div class="line">
+			<div class="statusLabel">Blood Level:</div>
+			{{if data.occupant.blood.percent <= 60}}
+				{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'bad')}}
+			<div class="statusValue">
+				{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
+			</div>
+			{{else data.occupant.blood.percent <= 90}}
+				{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'average')}}
+			<div class="statusValue">
+				{{:data.occupant.blood.percent}}%, {{:data.occupant.bloodLevel}}cl
+			</div>
+			{{else}}
+				{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'good')}}
+			<div class="statusValue">
+				{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
+			</div>
+			{{/if}}
 		</div>
-		{{else}}
-			{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'good')}}
-		<div class="statusValue">
-			{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
-		</div>
-		{{/if}}
-	</div>
+	{{/if}}
 	<br> <br>
 
 	<b>External Organs</b>

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -132,58 +132,6 @@ Used In File(s): \code\game\machinery\adv_med.dm
 	</div>
 	<br> <br>
 
-	<table>
-		<tbody>
-			<tr>
-				<td>
-					Epinephrine:
-				</td>
-				<td>
-					Ether:
-				</td>
-			</tr>
-			<tr>
-				<td>
-					{{:helper.displayBar(data.occupant.reagents.epinephrine, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.epinephrine )}}
-				</td>
-				<td>
-					{{:helper.displayBar(data.occupant.reagents.ether, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.ether)}}
-				</td>
-			</tr>
-			<tr>
-				<td>
-					Silver Sulfadiazine:
-				</td>
-				<td>
-					Styptic Powder:
-				</td>
-			</tr>
-			<tr>
-				<td>
-					{{:helper.displayBar(data.occupant.reagents.silver_sulfadiazine, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.silver_sulfadiazine)}}
-				</td>
-				<td>
-					{{:helper.displayBar(data.occupant.reagents.styptic_powder, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.styptic_powder)}}
-				</td>
-			</tr>
-			<tr>
-				<td>
-					Salbutamol:
-				</td>
-				<td> </td>
-			</tr>
-			<tr>
-				<td>
-					{{:helper.displayBar(data.occupant.reagents.salbutamol, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.salbutamol)}}
-				</td>
-				<td>
-				</td>
-			</tr>
-		</tbody>
-	</table>
-
-	<br>
-
 	<b>External Organs</b>
 	<table> <thead>
 			<tr>

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -70,73 +70,41 @@ Used In File(s): \code\game\machinery\adv_med.dm
 	<br> <br>
 
 	<b>Damage: </b>
-	<table>
-		<tbody>
+	<table> <tbody>
 			<tr>
-				<td>
-					Brute Damage:
-				</td>
-				<td>
-					Brain Damage:
-				</td>
+				<td> Brute Damage: </td>
+				<td> Brain Damage: </td>
 			</tr>
 			<tr>
-				<td>
-					{{:helper.displayBar(data.occupant.bruteLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.bruteLoss) }}
-				</td>
-				<td>
-					{{:helper.displayBar(data.occupant.brainLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.brainLoss)}}
-				</td>
+				<td> {{:helper.displayBar(data.occupant.bruteLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.bruteLoss) }} </td>
+				<td> {{:helper.displayBar(data.occupant.brainLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.brainLoss)}}  </td>
 			</tr>
 			<tr>
-				<td>
-					Resp. Damage:
-				</td>
-				<td>
-					Radiation Level:
-				</td>
+				<td> Resp. Damage: </td>
+				<td> Radiation Level: </td>
 			</tr>
 			<tr>
-				<td>
-					{{:helper.displayBar(data.occupant.oxyLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.oxyLoss)}}
-				</td>
-				<td>
-					{{:helper.displayBar(data.occupant.radLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.radLoss)}}
-				</td>
+				<td> {{:helper.displayBar(data.occupant.oxyLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.oxyLoss)}} </td>
+				<td> {{:helper.displayBar(data.occupant.radLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.radLoss)}}  </td>
 			</tr>
 			<tr>
-				<td>
-					Toxin Damage:
-				</td>
-				<td>
-					Genetic Damage:
-				</td>
+				<td> Toxin Damage: </td>
+				<td> Genetic Damage: </td>
 			</tr>
 			<tr>
-				<td>
-					{{:helper.displayBar(data.occupant.toxLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.toxLoss)}}
-				</td>
-				<td>
-					{{:helper.displayBar(data.occupant.cloneLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.cloneLoss)}}
-				</td>
+				<td> {{:helper.displayBar(data.occupant.toxLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.toxLoss)}} </td>
+				<td> {{:helper.displayBar(data.occupant.cloneLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.cloneLoss)}} </td>
 			</tr>
 			<tr>
-				<td>
-					Burn Severity:
-				</td>
-				<td>
-					Paralysis %: ({{:data.occupant.paralysisSeconds}} seconds left)
-				</td>
+				<td> Burn Severity: </td>
+				<td> Paralysis %: ({{:data.occupant.paralysisSeconds}} seconds left) </td>
 			</tr>
 			<tr>
-				<td>
-					{{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.fireLoss)}}
-				</td>
-				<td>
-					{{:helper.displayBar(data.occupant.paralysis, 0, data.occupant.maxHealth, 'bad', data.occupant.paralysis)}}
-				</td>
+				<td> {{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.fireLoss)}} </td>
+				<td> {{:helper.displayBar(data.occupant.paralysis, 0, data.occupant.maxHealth, 'bad', data.occupant.paralysis)}} </td>
 			</tr>
-		</table>
+		</tbody>
+	</table>
 	<br>
 	<b>Blood:</b>
 	<div class="line">
@@ -217,8 +185,7 @@ Used In File(s): \code\game\machinery\adv_med.dm
 	<br>
 
 	<b>External Organs</b>
-	<table>
-		<thead>
+	<table> <thead>
 			<tr>
 				<th style="width: 20%"> Name </th>
 				<th style="width: 20%"> Brute damage </th>
@@ -230,14 +197,8 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			{{for data.occupant.extOrgan}}
 				<tr>
 					<td>{{:value.name}} </td>
-					<td>
-						{{if value.bruteLoss> 0}} <span class='average'> {{else}} <span> {{/if}}
-						{{:value.bruteLoss}} </span>
-					</td>
-					<td>
-						{{if value.fireLoss> 0}} <span class='average'> {{else}} <span> {{/if}}
-						{{:value.fireLoss}} </span>
-					</td>
+					<td> {{if value.bruteLoss> 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.bruteLoss}} </span> </td>
+					<td> {{if value.fireLoss> 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.fireLoss}} </span> 	</td>
 					<td>
 						<span class='average'>
 						{{if value.status.destroyed}} DESTROYED <br> {{/if}}
@@ -278,8 +239,7 @@ Used In File(s): \code\game\machinery\adv_med.dm
 	</table>
 	<br>
 	<b>Internal Organs</b>
-	<table>
-		<thead>
+	<table>	<thead>
 			<tr>
 				<th width=25%> Name </th>
 				<th width=25%> Brute damage </th>
@@ -290,10 +250,7 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			{{for data.occupant.intOrgan}}
 				<tr>
 					<td> {{:value.name}} <br> {{:value.desc != null ? value.desc : ""}} </td>
-					<td>
-						{{if value.damage > 0}} <span class='average'> {{else}} <span> {{/if}}
-						{{:value.damage}} </td>
-						</span>
+					<td> {{if value.damage > 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.damage}} </span> </td>
 					<td>
 						{{if value.germ_level > 100}}
 							{{if value.germ_level < 300}}

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -1,14 +1,15 @@
-<!-- 
+<!--
 Title: Body Scanner UI
 Used In File(s): \code\game\machinery\adv_med.dm
  -->
+
 {{if !data.occupied}}
 	<h3>No occupant detected.</h3>
 {{else}}
 	<h4><b>Occupant Data:</b></h4>
 	<div class="item">
 		<div class="itemLabelNarrow">
-			Name: 
+			Name:
 		</div>
 		<div class="itemContent">
 			{{:data.occupant.name}}
@@ -22,324 +23,298 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			<div class="itemContent" style="width: 60px">
 				{{:helper.round(data.occupant.health*10)/10}}%
 			</div>
+	</div>
 	<div class="item">
 		<div class="itemLabelNarrow">
 			Status:
 		</div>
 		<div class="itemContent">
 			{{if data.occupant.stat==0}}
-				Alive
+				<span class="good"> Alive </span>
 			{{else data.occupant.stat==1}}
-				Critical
+				<span class="average"> Critical </span>
 			{{else}}
-				Dead
+				<span class="bad"> Dead </span>
 			{{/if}}
 		</div>
 	</div>
-	{{:helper.link('Print', 'document', {'print_p' : 1, 'name' : data.occupant.name})}}
+
 	<div class="item">
-		<h4><b>Damage:</b></h4>
-		<div class="itemLabelWide">
-			Brute: 
+		<div class="itemLabelNarrow">
+			Temperature:
 		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.bruteLoss}}
-		</div><br>
-		<div class="itemLabelWide">
-			Burn: 
-		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.fireLoss}}
-		</div><br>
-		<div class="itemLabelWide">
-			Oxygen: 
-		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.oxyLoss}}
-		</div><br>
-		<div class="itemLabelWide">
-			Toxins: 
-		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.toxLoss}}
-		</div><br>
-		<div class="itemLabelWide">
-			Brain:
-		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.brainLoss}}
-		</div><br>
-		<div class="itemLabelWide">
-			Radiation Level:
-		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.radLoss}}
-		</div><br>
-		<div class="itemLabelWide">
-			Genetic:
-		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.cloneLoss}}
-		</div><br>
-		<div class="itemLabelWide">
-			Paralysis:
-		</div>
-		<div class="itemContentMedium">
-			{{:data.occupant.paralysis}}% ({{:data.occupant.paralysisSeconds}} seconds left!)
-		</div><br>
-	</div>
-	<div class="item">
-		<div class="itemLabelWide">
-			Body Temperature:
-		</div>
-		<div class="itemContentMedium">
+		<div class="itemContent">
 			{{:data.occupant.bodyTempC}}&deg;C, {{:data.occupant.bodyTempF}}&deg;F
 		</div>
 	</div>
+
 	{{if data.occupant.hasVirus}}
-		<div class="notice">
+		<span class="bad">
 			Viral pathogen detected in blood stream.
-		</div>
+		</span> <br>
 	{{/if}}
 	{{if data.occupant.hasBorer}}
-		<div class="notice">
-			Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.
-		</div>
+		<span class="bad">
+			Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended. </span> <br>
 	{{/if}}
 	{{if data.occupant.blind}}
-		<span class="bad">Pupils unresponsive.</span><br>
+		<span class="average">Pupils unresponsive.</span><br>
 	{{/if}}
 	{{if data.occupant.nearsighted}}
-		<span class="bad">Retinal Misalignment Detected</span>
+		<span class="average">Retinal misalignment detected</span> <br>
 	{{/if}}
 
 	<br>
+	{{:helper.link('Print', 'document', {'print_p' : 1, 'name' : data.occupant.name})}}
+	{{:helper.link('Eject Occupant', 'arrowreturnthick-1-s', {'ejectify' : 1}, data.occupied ? null : 'disabled')}}
+	<br> <br>
 
-	<div style="width: 70%">
-		<div style="width: 50%; text-align:center;"><b>Blood</b></div>
-		<div class="item">
-			<div class="itemLabelWide">
-				Volume
-			</div>
-			<div class="itemContentMedium">
-				{{:data.occupant.blood.volume}}
-			</div>
-		</div>
-		<div class="item">
-			<div class="itemLabelWide">
-				Percent
-			</div>
-			<div class="itemContentMedium">
-				{{:data.occupant.blood.percent}}%
-			</div>
-		</div>
-	</div>
-
+	<b>Damage: </b>
+	<table>
+		<tbody>
+			<tr>
+				<td>
+					Brute Damage:
+				</td>
+				<td>
+					Brain Damage:
+				</td>
+			</tr>
+			<tr>
+				<td>
+					{{:helper.displayBar(data.occupant.bruteLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.bruteLoss) }}
+				</td>
+				<td>
+					{{:helper.displayBar(data.occupant.brainLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.brainLoss)}}
+				</td>
+			</tr>
+			<tr>
+				<td>
+					Resp. Damage:
+				</td>
+				<td>
+					Radiation Level:
+				</td>
+			</tr>
+			<tr>
+				<td>
+					{{:helper.displayBar(data.occupant.oxyLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.oxyLoss)}}
+				</td>
+				<td>
+					{{:helper.displayBar(data.occupant.radLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.radLoss)}}
+				</td>
+			</tr>
+			<tr>
+				<td>
+					Toxin Damage:
+				</td>
+				<td>
+					Genetic Damage:
+				</td>
+			</tr>
+			<tr>
+				<td>
+					{{:helper.displayBar(data.occupant.toxLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.toxLoss)}}
+				</td>
+				<td>
+					{{:helper.displayBar(data.occupant.cloneLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.cloneLoss)}}
+				</td>
+			</tr>
+			<tr>
+				<td>
+					Burn Severity:
+				</td>
+				<td>
+					Paralysis %: ({{:data.occupant.paralysisSeconds}} seconds left)
+				</td>
+			</tr>
+			<tr>
+				<td>
+					{{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.fireLoss)}}
+				</td>
+				<td>
+					{{:helper.displayBar(data.occupant.paralysis, 0, data.occupant.maxHealth, 'bad', data.occupant.paralysis)}}
+				</td>
+			</tr>
+		</table>
 	<br>
-
-	<div style="width: 70%;">
-		<div style="width: 50%; text-align:center;"><b>Reagents</b></div>
-		<div class="item">
-			<div class="itemLabelWide">
-				Epinephrine
-			</div>
-			<div class="itemContentMedium">
-				{{:data.occupant.reagents.epinephrine}}
-			</div>
-		</div>
-		<div class="item">
-			<div class="itemLabelWide">
-				Ether
-			</div>
-			<div class="itemContentMedium">
-				{{:data.occupant.reagents.ether}}
-			</div>
-		</div>
-		<div class="item">
-			<div class="itemLabelWide">
-				<span class="{{:data.occupant.reagents.silver_sulfadiazine < 30 ? "average" : "bad"}}">
-				Silver Sulfadiazine
-				</span>
-			</div>
-			<div class="itemContentMedium">
-				<span class="{{:data.occupant.reagents.silver_sulfadiazine < 30 ? "average" : "bad"}}">
-				{{:data.occupant.reagents.silver_sulfadiazine}}
-				</span>
-			</div>
-		</div>
-		<div class="item">
-			<div class="itemLabelWide">
-				<span class="{{:data.occupant.reagents.styptic_powder < 30 ? "average" : "bad"}}">
-				Styptic Powder
-				</span>
-			</div>
-			<div class="itemContentMedium">
-				<span class="{{:data.occupant.reagents.styptic_powder < 30 ? "average" : "bad"}}">
-				{{:data.occupant.reagents.styptic_powder}}
-				</span>
-			</div>
-		</div>
-		<div class="item">
-			<div class="itemLabelWide">
-				<span class="{{:data.occupant.reagents.salbutamol < 30 ? "average" : "bad"}}">
-				Salbutamol
-				</span>
-			</div>
-			<div class="itemContentMedium">
-				<span class="{{:data.occupant.reagents.salbutamol < 30 ? "average" : "bad"}}">
-				{{:data.occupant.reagents.salbutamol}}
-				</span>
-			</div>
-		</div>
+	<b>Blood:</b>
+	<div class="line">
+		<div class="statusLabel">Pulse:</div> <div class="statusValue">{{:data.occupant.blood.pulse}} bpm</div>
 	</div>
+
+	<div class="line">
+		<div class="statusLabel">Blood Level:</div>
+		{{if data.occupant.blood.percent <= 60}}
+			{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'bad')}}
+		<div class="statusValue">
+			{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
+		</div>
+		{{else data.occupant.blood.percent <= 90}}
+			{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'average')}}
+		<div class="statusValue">
+			{{:data.occupant.blood.percent}}%, {{:data.occupant.bloodLevel}}cl
+		</div>
+		{{else}}
+			{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'good')}}
+		<div class="statusValue">
+			{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
+		</div>
+		{{/if}}
+	</div>
+	<br> <br>
+
+	<table>
+		<tbody>
+			<tr>
+				<td>
+					Epinephrine:
+				</td>
+				<td>
+					Ether:
+				</td>
+			</tr>
+			<tr>
+				<td>
+					{{:helper.displayBar(data.occupant.reagents.epinephrine, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.epinephrine )}}
+				</td>
+				<td>
+					{{:helper.displayBar(data.occupant.reagents.ether, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.ether)}}
+				</td>
+			</tr>
+			<tr>
+				<td>
+					Silver Sulfadiazine:
+				</td>
+				<td>
+					Styptic Powder:
+				</td>
+			</tr>
+			<tr>
+				<td>
+					{{:helper.displayBar(data.occupant.reagents.silver_sulfadiazine, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.silver_sulfadiazine)}}
+				</td>
+				<td>
+					{{:helper.displayBar(data.occupant.reagents.styptic_powder, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.styptic_powder)}}
+				</td>
+			</tr>
+			<tr>
+				<td>
+					Salbutamol:
+				</td>
+				<td> </td>
+			</tr>
+			<tr>
+				<td>
+					{{:helper.displayBar(data.occupant.reagents.salbutamol, 0, data.occupant.maxHealth, 'bad', data.occupant.reagents.salbutamol)}}
+				</td>
+				<td>
+				</td>
+			</tr>
+		</tbody>
+	</table>
 
 	<br>
 
 	<b>External Organs</b>
-	<div class="itemGroup">
-	{{for data.occupant.extOrgan}}
-		{{if value.status.destroyed}}
-			<div class="item">
-				<div class="itemLabelWide">
-					<b>{{:value.name}}</b><span class="bad"> - DESTROYED</span>
-				</div>
-			</div>
-		{{else}}
-			<div class="item">
-				<div class="itemLabelWide">
-					<b>{{:value.name}}</b>
-				</div>
-				<div class="itemContentNarrow">
-					{{if value.status.broken}}
-						{{:value.status.broken}}
-					{{else value.status.splinted}}
-						Splinted
-					{{else value.status.robotic}}
-						Robotic
-					{{/if}}
-				</div>
-			</div>
-			<div class="item">
-				<div class="itemLabelWide">
-					&nbsp;Brute/Burn
-				</div>
-				<div class="itemContentNarrow">
-					{{:value.bruteLoss}}/{{:value.fireLoss}}
-				</div>
-			</div>
-			<div class="item">
-				<div class="itemLabelWide">
-					&nbsp;Injuries
-				</div>
-				<div class="itemContentNarrow">
-					{{if !value.status.bleeding}}
-						{{if !value.status.internalBleeding}}
-							No Injuries Detected
-						{{else}}
-							<span class="bad">Internal Bleeding Detected</span>
+	<table>
+		<thead>
+			<tr>
+				<th style="width: 20%"> Name </th>
+				<th style="width: 20%"> Brute damage </th>
+				<th style="width: 20%"> Burn damage </th>
+				<th style="width: 40%"> Injuries </th>
+			</tr>
+		</thead>
+		<tbody class="striped">
+			{{for data.occupant.extOrgan}}
+				<tr>
+					<td>{{:value.name}} </td>
+					<td>
+						{{if value.bruteLoss> 0}} <span class='average'> {{else}} <span> {{/if}}
+						{{:value.bruteLoss}} </span>
+					</td>
+					<td>
+						{{if value.fireLoss> 0}} <span class='average'> {{else}} <span> {{/if}}
+						{{:value.fireLoss}} </span>
+					</td>
+					<td>
+						<span class='average'>
+						{{if value.status.destroyed}} DESTROYED <br> {{/if}}
+						{{if value.status.bleeding}} external bleeding <br> {{/if}}
+						{{if value.internalBleeding}} internal bleeding <br> {{/if}}
+						{{if value.lungRuptured}} lung ruptured <br> {{/if}}
+						{{if value.status.broken}} {{:value.status.broken}} <br> {{/if}}
+						{{if value.germ_level > 100}}
+							{{if value.germ_level < 300}}
+								mild infection <br>
+							{{else value.germ_level < 400}}
+								mild infection+ <br>
+							{{else value.germ_level < 500}}
+								mild infection++ <br>
+							{{else value.germ_level < 700}}
+								acute infection <br>
+							{{else value.germ_level < 800}}
+								acute infection+ <br>
+							{{else value.germ_level < 900}}
+								acute infection++ <br>
+							{{else value.germ_level >= 900}}
+								septic <br>
+							{{/if}}
 						{{/if}}
-					{{else}}
-						{{if value.status.internalBleeding}}
-							<div class='notice'>Internal Bleeding Detected. External Bleeding Detected.</div>
-						{{else}}
-							<span class="average">External Bleeding Detected</span>
+						{{if value.open}}	open incision <br> {{/if}}
+						</span>
+						{{if value.status.splinted}} splinted <br> {{/if}}
+						{{if value.status.robotic}} robotic <br> {{/if}}
+						{{if value.implants_len}}
+							{{for value.implants : impValue:impindex}}
+								{{:impValue.known ? impValue.name : "unknown object"}} <br>
+							{{/for}}
 						{{/if}}
-					{{/if}}
-				</div>
-			</div>
-			{{if value.germ_level > 100}}
-				<div class="item">
-					<div class="itemLabelWide">
-						&nbsp;Infection
-					</div>
-					<div class="itemContentNarrow">
-						{{if value.germ_level < 300}}
-							Mild Infection
-						{{else value.germ_level < 400}}
-							Mild Infection+
-						{{else value.germ_level < 500}}
-							Mild Infection++
-						{{else value.germ_level < 700}}
-							Acute Infection
-						{{else value.germ_level < 800}}
-							Acute Infection+
-						{{else value.germ_level < 900}}
-							Acute Infection++
-						{{else value.germ_level >= 900}}
-							Septic
-						{{/if}}
-					</div>
-				</div>
-			{{/if}}
-			{{if value.open}}
-				<div class="item">
-					<div class="itemLabelWider">
-						&nbsp;Operation Status
-					</div>
-					<div class="itemContentNarrow">
-						Open Incision
-					</div>
-				</div>
-			{{/if}}
-			{{if value.implants_len}}
-				<div class="item">
-					<div class="itemLabelWide">
-						&nbsp;Implants
-					</div><br>
-					{{for value.implants :impValue:impindex}}
-						<div class="itemContentNarrow">
-							&nbsp;&nbsp;{{:impValue.known ? impValue.name : "Unknown"}}
-						</div><br>
-					{{/for}}
-				</div>
-			{{/if}}
-		{{/if}}
+					</td>
+				</tr>
+			{{/for}}
+		</tbody>
+	</table>
 	<br>
-	{{/for}}
-	</div>
 	<b>Internal Organs</b>
-	<div class="itemGroup">
-	{{for data.occupant.intOrgan}}
-		<div class="item">
-			<div class="itemLabelWide">
-				<b>{{:value.name}}</b>
-			</div>
-			<div class="itemContentNarrow">
-				{{:value.desc != null ? value.desc : ""}}
-			</div>
-		</div>
-		{{if value.germ_level > 100}}
-			<div class="item">
-				<div class="itemLabelWide">
-					&nbsp;Infection
-				</div>
-				<div class="itemContentNarrow">
-					{{if value.germ_level < 300}}
-						Mild Infection
-					{{else value.germ_level < 400}}
-						Mild Infection+
-					{{else value.germ_level < 500}}
-						Mild Infection++
-					{{else value.germ_level < 700}}
-						Acute Infection
-					{{else value.germ_level < 800}}
-						Acute Infection+
-					{{else value.germ_level < 900}}
-						Acute Infection++
-					{{else value.germ_level >= 900}}
-						Septic
-					{{/if}}
-				</div>
-			</div>
-		{{/if}}
-		<div class="item">
-			<div class="itemLabelWide">
-				&nbsp;Damage
-			</div>
-			<div class="itemContentNarrow">
-				{{:value.damage}}
-			</div>
-		</div>
-	{{/for}}
-	</div>
+	<table>
+		<thead>
+			<tr>
+				<th width=25%> Name </th>
+				<th width=25%> Brute damage </th>
+				<th widht=50%> Injuries </th>
+			</tr>
+		</thead>
+		<tbody class="striped">
+			{{for data.occupant.intOrgan}}
+				<tr>
+					<td> {{:value.name}} <br> {{:value.desc != null ? value.desc : ""}} </td>
+					<td>
+						{{if value.damage > 0}} <span class='average'> {{else}} <span> {{/if}}
+						{{:value.damage}} </td>
+						</span>
+					<td>
+						{{if value.germ_level > 100}}
+							{{if value.germ_level < 300}}
+								mild infection <br>
+							{{else value.germ_level < 400}}
+								mild infection+ <br>
+							{{else value.germ_level < 500}}
+								mild infection++ <br>
+							{{else value.germ_level < 700}}
+								acute Infection <br>
+							{{else value.germ_level < 800}}
+								acute Infection+ <br>
+							{{else value.germ_level < 900}}
+								acute Infection++ <br>
+							{{else value.germ_level >= 900}}
+								septic <br>
+							{{/if}}
+						{{/if}}
+					</td>
+				</tr>
+			{{/for}}
+		</tbody>
+	</table>
 {{/if}}

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -19,7 +19,7 @@ Used In File(s): \code\game\machinery\adv_med.dm
 		<div class="itemLabelNarrow">
 			Health:
 		</div>
-		{{:helper.displayBar(data.occupant.health, 0, 100, (data.occupant.health >= 50) ? 'good' : (data.occupant.health >= 25) ? 'average' : 'bad')}}
+		{{:helper.displayBar(data.occupant.health, -100, 100, (data.occupant.health >= 50) ? 'good' : (data.occupant.health >= 0) ? 'average' : 'bad')}}
 			<div class="itemContent" style="width: 60px">
 				{{:helper.round(data.occupant.health*10)/10}}%
 			</div>
@@ -47,12 +47,6 @@ Used In File(s): \code\game\machinery\adv_med.dm
 			{{:data.occupant.bodyTempC}}&deg;C, {{:data.occupant.bodyTempF}}&deg;F
 		</div>
 	</div>
-
-	{{if data.occupant.hasVirus}}
-		<span class="bad">
-			Viral pathogen detected in blood stream.
-		</span> <br>
-	{{/if}}
 	{{if data.occupant.hasBorer}}
 		<span class="bad">
 			Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended. </span> <br>
@@ -76,32 +70,32 @@ Used In File(s): \code\game\machinery\adv_med.dm
 				<td> Brain Damage: </td>
 			</tr>
 			<tr>
-				<td> {{:helper.displayBar(data.occupant.bruteLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.bruteLoss) }} </td>
-				<td> {{:helper.displayBar(data.occupant.brainLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.brainLoss)}}  </td>
+				<td> {{:helper.displayBar(data.occupant.bruteLoss, 0, data.occupant.maxHealth+100, (data.occupant.bruteLoss < 15) ? 'notgood' : (data.occupant.bruteLoss < 40) ? 'average' : 'bad', data.occupant.bruteLoss) }} </td>
+				<td> {{:helper.displayBar(data.occupant.brainLoss, 0, data.occupant.maxHealth+100, (data.occupant.brainLoss < 15) ? 'notgood' : (data.occupant.brainLoss < 40) ? 'average' : 'bad', data.occupant.brainLoss)}}  </td>
 			</tr>
 			<tr>
 				<td> Resp. Damage: </td>
 				<td> Radiation Level: </td>
 			</tr>
 			<tr>
-				<td> {{:helper.displayBar(data.occupant.oxyLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.oxyLoss)}} </td>
-				<td> {{:helper.displayBar(data.occupant.radLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.radLoss)}}  </td>
+				<td> {{:helper.displayBar(data.occupant.oxyLoss, 0, data.occupant.maxHealth+100, (data.occupant.oxyLoss < 15) ? 'notgood' : (data.occupant.oxyLoss < 40) ? 'average' : 'bad', data.occupant.oxyLoss)}} </td>
+				<td> {{:helper.displayBar(data.occupant.radLoss, 0, data.occupant.maxHealth+100, (data.occupant.radLoss < 15) ? 'notgood' : (data.occupant.radLoss < 40) ? 'average' : 'bad', data.occupant.radLoss)}}  </td>
 			</tr>
 			<tr>
 				<td> Toxin Damage: </td>
 				<td> Genetic Damage: </td>
 			</tr>
 			<tr>
-				<td> {{:helper.displayBar(data.occupant.toxLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.toxLoss)}} </td>
-				<td> {{:helper.displayBar(data.occupant.cloneLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.cloneLoss)}} </td>
+				<td> {{:helper.displayBar(data.occupant.toxLoss, 0, data.occupant.maxHealth+100, (data.occupant.toxLoss < 15) ? 'notgood' : (data.occupant.toxLoss < 40) ? 'average' : 'bad', data.occupant.toxLoss)}} </td>
+				<td> {{:helper.displayBar(data.occupant.cloneLoss, 0, data.occupant.maxHealth+100, (data.occupant.cloneLoss < 15) ? 'notgood' : (data.occupant.cloneLoss < 40) ? 'average' : 'bad', data.occupant.cloneLoss)}} </td>
 			</tr>
 			<tr>
 				<td> Burn Severity: </td>
 				<td> Paralysis %: ({{:data.occupant.paralysisSeconds}} seconds left) </td>
 			</tr>
 			<tr>
-				<td> {{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth, 'bad', data.occupant.fireLoss)}} </td>
-				<td> {{:helper.displayBar(data.occupant.paralysis, 0, data.occupant.maxHealth, 'bad', data.occupant.paralysis)}} </td>
+				<td> {{:helper.displayBar(data.occupant.fireLoss, 0, data.occupant.maxHealth+100, (data.occupant.fireLoss < 15) ? 'notgood' : (data.occupant.fireLoss < 40) ? 'average' : 'bad', data.occupant.fireLoss)}} </td>
+				<td> {{:helper.displayBar(data.occupant.paralysis, 0, 100, (data.occupant.paralysis < 25) ? 'notgood' : (data.occupant.paralysis < 50) ? 'average' : 'bad', data.occupant.paralysis)}} </td>
 			</tr>
 		</tbody>
 	</table>
@@ -112,42 +106,34 @@ Used In File(s): \code\game\machinery\adv_med.dm
 		<div class="line">
 			<div class="statusLabel">Pulse:</div> <div class="statusValue">{{:data.occupant.blood.pulse}} bpm</div>
 		</div>
-
 		<div class="line">
 			<div class="statusLabel">Blood Level:</div>
-			{{if data.occupant.blood.percent <= 60}}
-				{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'bad')}}
-			<div class="statusValue">
-				{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
-			</div>
-			{{else data.occupant.blood.percent <= 90}}
-				{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'average')}}
-			<div class="statusValue">
-				{{:data.occupant.blood.percent}}%, {{:data.occupant.bloodLevel}}cl
-			</div>
-			{{else}}
-				{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, 'good')}}
-			<div class="statusValue">
-				{{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl
-			</div>
-			{{/if}}
+			{{:helper.displayBar(data.occupant.blood.bloodLevel, 0, data.occupant.blood.bloodMax, (data.occupant.blood.percent <= 60) ? 'bad' : (data.occupant.blood.percent <= 90) ? 'average' : 'good' )}}
+			<div class="statusValue"> {{:data.occupant.blood.percent}}%, {{:data.occupant.blood.bloodLevel}}cl </div>
 		</div>
-	{{/if}}
-	<br> <br>
 
+	{{/if}}
+	<br>
+	{{if data.occupant.hasVirus}}
+		<span class="bad">
+			Viral pathogen detected in blood stream.
+		</span> <br>
+	{{/if}}
 	<b>External Organs</b>
 	<table> <thead>
 			<tr>
-				<th style="width: 20%"> Name </th>
-				<th style="width: 20%"> Brute damage </th>
-				<th style="width: 20%"> Burn damage </th>
-				<th style="width: 40%"> Injuries </th>
+				<th style="width: 25%"> Name </th>
+				<th style='width: 15%'> Total damage </th>
+				<th style="width: 15%"> Brute damage </th>
+				<th style="width: 15%"> Burn damage </th>
+				<th style="width: 30%"> Injuries </th>
 			</tr>
 		</thead>
 		<tbody class="striped">
 			{{for data.occupant.extOrgan}}
 				<tr>
 					<td> {{:value.name}} </td>
+					<td> {{:helper.displayBar(value.totalLoss, 0, value.maxHealth, (value.totalLoss < value.bruised) ? 'notgood' : (value.totalLoss < value.broken) ? 'average' : 'bad', value.totalLoss) }} </td>
 					<td> {{if value.bruteLoss> 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.bruteLoss}} </span> </td>
 					<td> {{if value.fireLoss> 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.fireLoss}} </span> 	</td>
 					<td>
@@ -193,31 +179,31 @@ Used In File(s): \code\game\machinery\adv_med.dm
 	<table>	<thead>
 			<tr>
 				<th width=25%> Name </th>
-				<th width=25%> Brute damage </th>
-				<th widht=50%> Injuries </th>
+				<th width=35%> Brute damage </th>
+				<th widht=40%> Injuries </th>
 			</tr>
 		</thead>
 		<tbody class="striped">
 			{{for data.occupant.intOrgan}}
 				<tr>
 					<td> {{:value.name}} <br> </td>
-					<td> {{if value.damage > 0}} <span class='average'> {{else}} <span> {{/if}} {{:value.damage}} </span> </td>
-					<td>
-						{{if value.germ_level > 100}}
-							{{if value.germ_level < 300}}
-								mild infection <br>
-							{{else value.germ_level < 400}}
-								mild infection+ <br>
-							{{else value.germ_level < 500}}
-								mild infection++ <br>
-							{{else value.germ_level < 700}}
-								acute Infection <br>
-							{{else value.germ_level < 800}}
-								acute Infection+ <br>
-							{{else value.germ_level < 900}}
-								acute Infection++ <br>
-							{{else value.germ_level >= 900}}
-								septic <br>
+					<td> {{:helper.displayBar(value.damage, 0, value.maxHealth, (value.damage < value.bruised) ? 'notgood' : (value.damage < value.broken) ? 'average' : 'bad', value.damage) }} </td>
+					<td class="average">
+							{{if value.germ_level > 100}}
+								{{if value.germ_level < 300}}
+									mild infection <br>
+								{{else value.germ_level < 400}}
+									mild infection+ <br>
+								{{else value.germ_level < 500}}
+									mild infection++ <br>
+								{{else value.germ_level < 700}}
+									acute Infection <br>
+								{{else value.germ_level < 800}}
+									acute Infection+ <br>
+								{{else value.germ_level < 900}}
+									acute Infection++ <br>
+								{{else value.germ_level >= 900}}
+									septic <br>
 							{{/if}}
 						{{/if}}
 					</td>


### PR DESCRIPTION
This PR attempts to make the bodyscanner nano ui easier to read and to reduce scrolling need. 

![bodyscanner_screen1](https://cloud.githubusercontent.com/assets/13683223/12008081/11682ee0-ac25-11e5-8a5e-e96625ab7612.png)

![bodyscanner_screen2](https://cloud.githubusercontent.com/assets/13683223/12008080/1167fcc2-ac25-11e5-8f38-e77f75f85e50.png)

- Added status bars to overall damage types, blood percentage, and reagants
- Added an eject occupant button
- Added a table for organ damage to reduce it's length (less scrolling)
- Color coded all damage/problems to make them stand out more
- Removed '0/0' and 'No Injuries detected' to make problems stand out more
- Fixes a bug with internal bleeding not appearing in the list