### PR TITLE
Evil Santa Fixes/Tweaks

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -61,7 +61,12 @@ var/global/list/blocked_mobs = list(/mob/living/simple_animal,
 			/mob/living/simple_animal/hostile/guardian/punch/sealpunch,
 			/mob/living/simple_animal/hostile/guardian/healer/sealhealer,
 			/mob/living/simple_animal/hostile/guardian/ranged,
-			/mob/living/simple_animal/hostile/guardian/bomb
+			/mob/living/simple_animal/hostile/guardian/bomb,
+			/mob/living/simple_animal/hostile/winter/santa,
+			/mob/living/simple_animal/hostile/winter/santa/stage_1,
+			/mob/living/simple_animal/hostile/winter/santa/stage_2,
+			/mob/living/simple_animal/hostile/winter/santa/stage_3,
+			/mob/living/simple_animal/hostile/winter/santa/stage_4
 			)
 
 var/global/list/med_hud_users = list()

--- a/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
@@ -43,6 +43,8 @@
 
 
 /mob/living/simple_animal/hostile/winter/snowman/death()
+	if(weapon1 && prob(50))		//50% chance to drop weapon on death, if it has one to drop
+		new weapon1(get_turf(src))
 	if(prob(20))	//chance to become a stationary snowman structure instead of a corpse
 		new /obj/structure/snowman(get_turf(src))
 		visible_message("<span class='notice'>The [src.name] shimmers as its animating magic fades away!</span>")
@@ -121,12 +123,12 @@
 /mob/living/simple_animal/hostile/winter/santa/stage_4		//stage 4: fast spinebreaker
 	name = "Final Form Santa"
 	desc = "WHAT THE HELL IS HE!?! WHY WON'T HE STAY DEAD!?!"
-	ranged = 0
-	rapid = 0
+	maxHealth = 200
+	health = 200
 	speed = 0	//he's lost some weight from the fighting
 
 	environment_smash = 2		//naughty walls must be punished too
-	melee_damage_lower = 10
+	melee_damage_lower = 15
 	melee_damage_upper = 25		//that's gonna leave a mark, for sure
 
 /mob/living/simple_animal/hostile/winter/santa/stage_4/death()


### PR DESCRIPTION
Adds all Santa mobs to the global blocked_mobs list
- Will prevent gold cores and rifts from spawning stage 2 santas

Gives Final Form Santa (Stage 4) a small buff to health and minimum damage. He seemed a little disappointing after you beat stage 3 Santa.
- All other stages left unchanged, Stage 4 was just a bit lackluster for a "final form"

Fixes melee snowmen not ever dropping the brand new CANDY SWORD. They now will have a 50% chance.
- It's a sharpened candy cane. Festive and painful.
- Ranged snowmen do not drop the candy sword, as they don't carry a weapon.

These are fixes for oversights, and a small buff based on observations of how the fight typically went.