### PR TITLE
Add darkness_view to Helmets

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -264,6 +264,7 @@ BLIND     // can't see anything
 	var/flash_protect = 0
 	var/tint = 0
 	var/HUDType = null
+	var/darkness_view = 0
 	var/vision_flags = 0
 	var/see_darkness = 1
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -413,6 +413,7 @@
 				if(H.client)
 					H.client.screen += global_hud.darkMask
 
+		var/minimum_darkness_view = INFINITY
 		if(H.glasses)
 			if(istype(H.glasses, /obj/item/clothing/glasses))
 				var/obj/item/clothing/glasses/G = H.glasses
@@ -420,6 +421,7 @@
 
 				if(G.darkness_view)
 					H.see_in_dark = G.darkness_view
+					minimum_darkness_view = G.darkness_view
 
 				if(!G.see_darkness)
 					H.see_invisible = SEE_INVISIBLE_MINIMUM
@@ -436,6 +438,9 @@
 			if(istype(H.head, /obj/item/clothing/head))
 				var/obj/item/clothing/head/hat = H.head
 				H.sight |= hat.vision_flags
+
+				if(hat.darkness_view && hat.darkness_view < minimum_darkness_view) // Pick the lowest of the two darkness_views between the glasses and helmet.
+					H.see_in_dark = hat.darkness_view
 
 				if(!hat.see_darkness)
 					H.see_invisible = SEE_INVISIBLE_MINIMUM


### PR DESCRIPTION
Helmets have a see_darkness and allow for vision flags but, for whatever reason, do not support darkness_view.

This PR fixes that.

In the case of conflicting darkness_views on the helmet and glasses it will pick the lower value of the two (IE wearing a night-vision helmet and sunglasses would limit your visibility in the darkness according to the sunglass' darkness_view, but you would still see perfectly within the range you are able to see)