### PR TITLE
Adds Invisibility/Alpha Exceptions for HUDS

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -49,6 +49,12 @@
 /datum/atom_hud/data/diagnostic
 	hud_icons = list (DIAG_HUD, DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD)
 
+/mob/proc/hud_detection_check(image/holder)
+    if(invisibility > 25 || alpha < 127)
+        holder.icon_state = null
+        return 0
+    return 1
+
 /* MED/SEC/DIAG HUD HOOKS */
 
 /*
@@ -97,13 +103,11 @@
 	var/datum/atom_hud/data/human/medical/basic/B = huds[DATA_HUD_MEDICAL_BASIC]
 	B.update_suit_sensors(src)
 
-
 //called when a carbon changes health
 /mob/living/carbon/proc/med_hud_set_health()
 	var/image/holder = hud_list[HEALTH_HUD]
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
+	if(!hud_detection_check(holder)) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
 		return 0
 
 	if(stat == 2)
@@ -117,8 +121,7 @@
 	var/image/holder = hud_list[STATUS_HUD]
 	//var/image/holder2 = hud_list[STATUS_HUD_OOC]
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
+	if(!hud_detection_check(holder)) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
 		return 0
 
 	if(stat == 2)
@@ -150,10 +153,6 @@
 /mob/living/carbon/human/proc/sec_hud_set_ID()
 	var/image/holder = hud_list[ID_HUD]
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
-		return 0
-
 	holder.icon_state = "hudunknown"
 	if(wear_id)
 		holder.icon_state = "hud[ckey(wear_id.GetJobName())]"
@@ -164,8 +163,7 @@
 /mob/living/carbon/human/proc/sec_hud_set_implants()
 	var/image/holder
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
+	if(!hud_detection_check(holder)) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
 		return 0
 
 	for(var/i in list(IMPTRACK_HUD, IMPLOYAL_HUD, IMPCHEM_HUD))
@@ -187,8 +185,7 @@
 /mob/living/carbon/human/proc/sec_hud_set_security_status()
 	var/image/holder = hud_list[WANTED_HUD]
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
+	if(!hud_detection_check(holder)) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
 		return 0
 
 	var/perpname = get_face_name(get_id_name(""))
@@ -238,8 +235,7 @@
 /mob/living/silicon/proc/diag_hud_set_health()
 	var/image/holder = hud_list[DIAG_HUD]
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
+	if(!hud_detection_check(holder)) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
 		return 0
 
 	if(stat == DEAD)
@@ -261,8 +257,7 @@
 /mob/living/silicon/robot/proc/diag_hud_set_borgcell()
 	var/image/holder = hud_list[DIAG_BATT_HUD]
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
+	if(!hud_detection_check(holder)) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
 		return 0
 
 	if (cell)
@@ -287,10 +282,6 @@
 /obj/mecha/proc/diag_hud_set_mechcell()
 	var/image/holder = hud_list[DIAG_BATT_HUD]
 
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
-		return 0
-
 	if (cell)
 		var/chargelvl = cell.charge/cell.maxcharge
 		holder.icon_state = "hudbatt[RoundDiagBar(chargelvl)]"
@@ -300,10 +291,6 @@
 
 /obj/mecha/proc/diag_hud_set_mechstat()
 	var/image/holder = hud_list[DIAG_STAT_HUD]
-
-	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
-		holder.icon_state = null
-		return 0
 
 	holder.icon_state = null
 	if(internal_damage)

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -4,6 +4,9 @@
  * Update the HUD icons when needed with the appropriate hook. (see below)
  */
 
+#define HUD_ALPHA_LIMIT		127 // The point at which a user's alpha stops a HUD from recognizing them.
+#define HUD_INVIS_LIMIT		25 // The point at which a user's invisibility level stops a HUD from recognizing them.
+
 /* DATA HUD DATUMS */
 
 /atom/proc/add_to_all_human_data_huds()
@@ -98,6 +101,11 @@
 //called when a carbon changes health
 /mob/living/carbon/proc/med_hud_set_health()
 	var/image/holder = hud_list[HEALTH_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	if(stat == 2)
 		holder.icon_state = "hudhealth-100"
 	else
@@ -105,8 +113,14 @@
 
 //called when a carbon changes stat, virus or XENO_HOST
 /mob/living/carbon/proc/med_hud_set_status()
+
 	var/image/holder = hud_list[STATUS_HUD]
 	//var/image/holder2 = hud_list[STATUS_HUD_OOC]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	if(stat == 2)
 		holder.icon_state = "huddead"
 		//holder2.icon_state = "huddead"
@@ -135,6 +149,11 @@
 
 /mob/living/carbon/human/proc/sec_hud_set_ID()
 	var/image/holder = hud_list[ID_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	holder.icon_state = "hudunknown"
 	if(wear_id)
 		holder.icon_state = "hud[ckey(wear_id.GetJobName())]"
@@ -144,6 +163,11 @@
 
 /mob/living/carbon/human/proc/sec_hud_set_implants()
 	var/image/holder
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	for(var/i in list(IMPTRACK_HUD, IMPLOYAL_HUD, IMPCHEM_HUD))
 		holder = hud_list[i]
 		holder.icon_state = null
@@ -162,6 +186,11 @@
 
 /mob/living/carbon/human/proc/sec_hud_set_security_status()
 	var/image/holder = hud_list[WANTED_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	var/perpname = get_face_name(get_id_name(""))
 	if(!ticker) return //wait till the game starts or the monkeys runtime....
 	if(perpname)
@@ -208,6 +237,11 @@
 //Sillycone hooks
 /mob/living/silicon/proc/diag_hud_set_health()
 	var/image/holder = hud_list[DIAG_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	if(stat == DEAD)
 		holder.icon_state = "huddiagdead"
 	else
@@ -226,6 +260,11 @@
 //Borgie battery tracking!
 /mob/living/silicon/robot/proc/diag_hud_set_borgcell()
 	var/image/holder = hud_list[DIAG_BATT_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	if (cell)
 		var/chargelvl = (cell.charge/cell.maxcharge)
 		holder.icon_state = "hudbatt[RoundDiagBar(chargelvl)]"
@@ -237,11 +276,21 @@
 ~~~~~~~~~~~~~~~~~~~~~*/
 /obj/mecha/proc/diag_hud_set_mechhealth()
 	var/image/holder = hud_list[DIAG_MECH_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	holder.icon_state = "huddiag[RoundDiagBar(health/initial(health))]"
 
 
 /obj/mecha/proc/diag_hud_set_mechcell()
 	var/image/holder = hud_list[DIAG_BATT_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	if (cell)
 		var/chargelvl = cell.charge/cell.maxcharge
 		holder.icon_state = "hudbatt[RoundDiagBar(chargelvl)]"
@@ -251,6 +300,11 @@
 
 /obj/mecha/proc/diag_hud_set_mechstat()
 	var/image/holder = hud_list[DIAG_STAT_HUD]
+
+	if(invisibility > HUD_INVIS_LIMIT || alpha < HUD_ALPHA_LIMIT) // If the person is above the normal invisibility level the HUD cannot detect them. Or if their alpha is below half of fully visible.
+		holder.icon_state = null
+		return 0
+
 	holder.icon_state = null
 	if(internal_damage)
 		holder.icon_state = "hudwarn"


### PR DESCRIPTION
On all player-acquirable HUDs a person/mech will now not show up if their invisibility is above the standard 25 or if their alpha is below 127, which is half of the standard 'Fully visible' alpha.

Note that this will only fully work (Specifically with security HUDs) if whatever is cloaking the person updates the huds after they're cloaked. As far as I could see there was no way around this due to how HUDs handle updating.