### PR TITLE
Material usage fixes

### DIFF
--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -51,6 +51,7 @@
 	..()
 	if (istype(W, /obj/item/weapon/wrench))
 		new /obj/item/stack/sheet/metal( user.loc )
+		new /obj/item/stack/sheet/metal( user.loc )
 		//SN src = null
 		qdel(src)
 	if (istype(W, /obj/item/stack/rods))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -5,6 +5,11 @@
 	layer = TURF_LAYER + 0.9
 	var/state = 0
 	var/health = 200
+	var/metalUsed = 2 //used to determine amount returned in deconstruction
+
+/obj/structure/girder/proc/refundMetal(metalAmount) //refunds metal used in construction when deconstructed
+	for(var/i=0;i < metalAmount;i++)
+		new /obj/item/stack/sheet/metal(get_turf(src))
 
 /obj/structure/girder/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/weapon/wrench) && state == 0)
@@ -14,7 +19,7 @@
 			if(do_after(user,40, target = src))
 				if(!src) return
 				user << "\blue You dissasembled the girder!"
-				new /obj/item/stack/sheet/metal(get_turf(src))
+				refundMetal(metalUsed)
 				qdel(src)
 		else if(!anchored)
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
@@ -29,18 +34,18 @@
 		if(do_after(user,30, target = src))
 			if(!src) return
 			user << "\blue You slice apart the girder!"
-			new /obj/item/stack/sheet/metal(get_turf(src))
+			refundMetal(metalUsed)
 			qdel(src)
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/diamonddrill))
 		user << "\blue You drill through the girder!"
-		new /obj/item/stack/sheet/metal(get_turf(src))
+		refundMetal(metalUsed)
 		qdel(src)
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
 		playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 100, 1)
 		user << "<span class='notice'>You Disintegrate the girder!</span>"
-		new /obj/item/stack/sheet/metal(get_turf(src))
+		refundMetal(metalUsed)
 		qdel(src)
 
 	else if(istype(W, /obj/item/weapon/screwdriver) && state == 2 && istype(src,/obj/structure/girder/reinforced))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -566,7 +566,8 @@
 /obj/structure/table/woodentable/attackby(obj/item/I as obj, mob/user as mob, params)
 
 	if (istype(I, /obj/item/stack/tile/grass))
-		qdel(I)
+		var/obj/item/stack/tile/grass/gr = I
+		gr.use(1)
 		new /obj/structure/table/woodentable/poker( src.loc )
 		qdel(src)
 		visible_message("<span class='notice'>[user] adds the grass to the wooden table</span>")
@@ -610,7 +611,7 @@
 		qdel(src)
 		return
 
-	if(!(I.flags & ABSTRACT))
+	if(!(I.flags & ABSTRACT) && !(istype(I, /obj/item/stack/tile/grass)))
 		if(user.drop_item())
 			I.Move(loc)
 			var/list/click_params = params2list(params)
@@ -620,6 +621,7 @@
 			//Clamp it so that the icon never moves more than 16 pixels in either direction (thus leaving the table turf)
 			I.pixel_x = Clamp(text2num(click_params["icon-x"]) - 16, -(world.icon_size/2), world.icon_size/2)
 			I.pixel_y = Clamp(text2num(click_params["icon-y"]) - 16, -(world.icon_size/2), world.icon_size/2)
+
 
 	return 1
 


### PR DESCRIPTION
- Creating gambling tables no longer uses up entire stack of grass
- Dismantling girders now returns the same amount of metal as was used in construction
- Dismantling metal table parts now returns the same amount of metal as was used in construction