### PR TITLE
Electrocution Refactor+Electric Reagents

### DIFF
--- a/code/datums/spells/lightning.dm
+++ b/code/datums/spells/lightning.dm
@@ -74,10 +74,10 @@ obj/effect/proc_holder/spell/targeted/lightning/proc/Reset(mob/user = usr)
 	origin.Beam(target,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
 	var/mob/living/carbon/current = target
 	if(bounces < 1)
-		current.electrocute_act(bolt_energy,"Lightning Bolt", def_zone = "chest")
+		current.electrocute_act(bolt_energy,"Lightning Bolt",safety=1)
 		playsound(get_turf(current), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 	else
-		current.electrocute_act(bolt_energy,"Lightning Bolt", def_zone = "chest")
+		current.electrocute_act(bolt_energy,"Lightning Bolt",safety=1)
 		playsound(get_turf(current), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 		var/list/possible_targets = new
 		for(var/mob/living/M in view_or_range(range,target,"view"))

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -706,8 +706,9 @@ datum/reagent/shadowling_blindness_smoke/on_mob_life(var/mob/living/M as mob)
 			if(is_shadow_or_thrall(target))
 				continue
 			target << "<span class='userdanger'>You are struck by a bolt of lightning!</span>"
-			playsound(target, 'sound/effects/eleczap.ogg', 50, 1)
-			target.electrocute_act(80, "lightning bolt", def_zone = "chest")
+			playsound(target, 'sound/magic/LightningShock.ogg', 50, 1)
+			target.Weaken(8)
+			target.take_organ_damage(0,50)
 			usr.Beam(target,icon_state="red_lightning",icon='icons/effects/effects.dmi',time=1)
 
 /obj/effect/proc_holder/spell/targeted/shadowlingAscendantTransmit

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -114,8 +114,7 @@ mob/living
 			return
 	return
 
-/mob/living/carbon/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/def_zone = null,var/override = 0, tesla_shock = 0)
-
+/mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, override = 0, tesla_shock = 0)
 	if(status_flags & GODMODE)	//godmode
 		return 0
 	if(NO_SHOCK in mutations) //shockproof
@@ -124,42 +123,32 @@ mob/living
 	shock_damage *= siemens_coeff
 	if(shock_damage<1 && !override)
 		return 0
-
-	src.apply_damage(shock_damage, BURN, def_zone, used_weapon="Electrocution")
-
-	if(heart_attack && prob(25))
-		heart_attack = 0
-	playsound(loc, "sparks", 50, 1, -1)
-	if (shock_damage < 10)
-		src.visible_message(
-			"\red [src] was mildly shocked by the [source].", \
-			"\red You feel a mild shock course through your body.", \
-			"\red You hear a light zapping." \
-		)
-		jitteriness += (rand(2,4))//mostly for the swarmer trap
-		do_jitter_animation(jitteriness)
-	if (shock_damage > 10)
-		if (shock_damage < 200)
-			src.visible_message(
-				"\red [src] was shocked by the [source]!", \
-				"\red <B>You feel a powerful shock course through your body!</B>", \
-				"\red You hear a heavy electrical crack." \
-			)
-		jitteriness += 1000 //High numbers for violent convulsions
-		do_jitter_animation(jitteriness)
-		stuttering += 2
+	if(reagents.has_reagent("teslium"))
+		shock_damage *= 1.5 //If the mob has teslium in their body, shocks are 50% more damaging!
+	take_overall_damage(0,shock_damage)
+	//src.burn_skin(shock_damage)
+	//src.adjustFireLoss(shock_damage) //burn_skin will do this for us
+	//src.updatehealth()
+	visible_message(
+		"<span class='danger'>[src] was shocked by \the [source]!</span>", \
+		"<span class='userdanger'>You feel a powerful shock coursing through your body!</span>", \
+		"<span class='italics'>You hear a heavy electrical crack.</span>" \
+	)
+	jitteriness += 1000 //High numbers for violent convulsions
+	do_jitter_animation(jitteriness)
+	stuttering += 2
+	if(!tesla_shock || (tesla_shock && siemens_coeff > 0.5))
+		Stun(2)
+	spawn(20)
+		jitteriness = max(jitteriness - 990, 10) //Still jittery, but vastly less
 		if(!tesla_shock || (tesla_shock && siemens_coeff > 0.5))
-			Stun(2)
-		spawn(20)
-			jitteriness = max(jitteriness - 990, 10) //Still jittery, but vastly less
-			if(!tesla_shock || (tesla_shock && siemens_coeff > 0.5))
-				Stun(3)
-				Weaken(3)
+			Stun(3)
+			Weaken(3)
 	if (shock_damage > 200)
 		src.visible_message(
-			"\red [src] was arc flashed by the [source]!", \
-			"\red <B>The [source] arc flashes and electrocutes you!</B>", \
-			"\red You hear a lightning-like crack!" \
+			"<span class='danger'>[src] was arc flashed by the [source]!</span>", \
+			"<span class='userdanger'>The [source] arc flashes and electrocutes you!</span>", \
+			"<span class='italics'>You hear a lightning-like crack!</span>" \
 		)
 		playsound(loc, "sound/effects/eleczap.ogg", 50, 1, -1)
 		explosion(src.loc,-1,0,2,2)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -245,6 +245,9 @@
 		else
 			msg += "[t_He] [t_is] quite chubby.\n"
 
+	if(reagents.has_reagent("teslium"))
+		msg += "[t_He] is emitting a gentle blue glow!\n"
+
 	msg += "</span>"
 
 	if(getBrainLoss() >= 60)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -772,7 +772,7 @@
 			heart_attack = 0
 			if(stat == CONSCIOUS)
 				src << "<span class='notice'>You feel your heart beating again!</span>"
-	. = ..(shock_damage,source,siemens_coeff,safety,override,tesla_shock)
+	. = ..()
 
 
 /mob/living/carbon/human/Topic(href, href_list)

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -12,7 +12,7 @@
 
 	blood_color = "#515573"
 	flesh_color = "#137E8F"
-
+	siemens_coeff = 0
 
 	has_organ = list(
 		"brain" = /obj/item/organ/brain/golem

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -42,6 +42,8 @@
 	var/passive_temp_gain = 0			//IS_SYNTHETIC species will gain this much temperature every second
 	var/reagent_tag                 //Used for metabolizing reagents.
 
+	var/siemens_coeff = 1 //base electrocution coefficient
+
 	var/darksight = 2
 	var/hazard_high_pressure = HAZARD_HIGH_PRESSURE   // Dangerously high pressure.
 	var/warning_high_pressure = WARNING_HIGH_PRESSURE // High pressure warning.

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -65,7 +65,7 @@
 		apply_damage(P.damage, P.damage_type, def_zone, armor)
 	return P.on_hit(src, armor, def_zone)
 
-/mob/living/proc/electrocute_act(var/shock_damage, var/obj/source, var/siemens_coeff = 1.0, var/def_zone = null, tesla_shock = 0)
+/mob/living/proc/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, safety = 0, tesla_shock = 0)
 	  return 0 //only carbon liveforms have this proc
 
 /mob/living/emp_act(severity)

--- a/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
@@ -434,8 +434,7 @@
 		var/mob/living/L = AM
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
-			L.Stun(1) //i am doing this here instead of electrocute act
-			L.electrocute_act(0, src, 1, "l_foot", 1)
+			L.electrocute_act(0, src, 1, 1)
 			if(isrobot(L) || L.isSynthetic())
 				L.Weaken(5)
 			qdel(src)

--- a/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant_abilities.dm
@@ -105,7 +105,7 @@
 							if(M == user)
 								return
 							M.Beam(L,icon_state="purple_lightning",icon='icons/effects/effects.dmi',time=5)
-							M.electrocute_act(shock_damage, "[L.name]")
+							M.electrocute_act(shock_damage, "[L.name]", safety=1)
 							var/datum/effect/system/spark_spread/z = new /datum/effect/system/spark_spread/
 							z.set_up(4, 0, M)
 							z.start()

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -608,3 +608,21 @@ datum/reagent/firefighting_foam/reaction_obj(var/obj/O, var/volume)
 	var/location = get_turf(holder.my_atom)
 	explosion(location,0,0,3)
 	return
+
+/datum/chemical_reaction/shock_explosion
+	name = "shock_explosion"
+	id = "shock_explosion"
+	result = null
+	required_reagents = list("teslium" = 5, "uranium" = 5) //uranium to this so it can't be spammed like no tomorrow without mining help.
+	result_amount = 1
+	mix_message = "<span class='danger'>The reaction releases an electrical blast!</span>"
+	mix_sound = 'sound/magic/lightningbolt.ogg'
+
+/datum/chemical_reaction/shock_explosion/on_reaction(var/datum/reagents/holder, var/created_volume)
+	var/turf/T = get_turf(holder.my_atom)
+	for(var/mob/living/carbon/C in view(6, T))
+		C.Beam(T,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5) //What? Why are we beaming from the mob to the turf? Turf to mob generates really odd results.
+		C.electrocute_act(1, "electrical blast")
+	holder.del_reagent("teslium") //Clear all remaining Teslium and Uranium, but leave all other reagents untouched.
+	holder.del_reagent("uranium")
+	return

--- a/code/modules/reagents/newchem/toxins.dm
+++ b/code/modules/reagents/newchem/toxins.dm
@@ -745,3 +745,37 @@ datum/reagent/ants/on_mob_life(var/mob/living/M as mob)
 	M.adjustBruteLoss(2)
 	..()
 	return
+
+/datum/reagent/teslium //Teslium. Causes periodic shocks, and makes shocks against the target much more effective.
+	name = "Teslium"
+	id = "teslium"
+	description = "An unstable, electrically-charged metallic slurry. Increases the conductance of living things."
+	reagent_state = LIQUID
+	color = "#20324D" //RGB: 32, 50, 77
+	metabolization_rate = 0.2
+	var/shock_timer = 0
+
+/datum/reagent/teslium/on_mob_life(mob/living/M)
+	shock_timer++
+	if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
+		shock_timer = 0
+		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
+		playsound(M, "sparks", 50, 1)
+	..()
+
+/datum/chemical_reaction/teslium
+	name = "Teslium"
+	id = "teslium"
+	result = "teslium"
+	required_reagents = list("plasma" = 1, "silver" = 1, "blackpowder" = 1)
+	result_amount = 3
+	mix_message = "<span class='danger'>A jet of sparks flies from the mixture as it merges into a flickering slurry.</span>"
+	min_temp = 400
+	mix_sound = null
+
+/datum/chemical_reaction/teslium/on_reaction(var/datum/reagents/holder, var/created_volume)
+	var/location = get_turf(holder.my_atom)
+	var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
+	s.set_up(6, 1, location)
+	s.start()
+	return


### PR DESCRIPTION
This PR does a few things:

- Refactors electrocute_act() to TG's standards
 - Why? Well, Bay's electrocute act was causing issues...for one, it gave unfair and strong advantage to IPCs and anyone with robotic limbs against shock damage; it would hit their hand and cap out on damage then blow off that limb off, leaving the rest of them unharmed (even if they were meant to take 200+ damage). Another problem was that all hardsuits were giving complete immunity to shocks, even if the wearer wasn't wearing insulated gloves.
 - This also adds support for species siemens' coefficients---maybe we can make Skrell and Slimes conduct better in a future PR (ZAP!). For now, this only impacts Golems.

Reagent related

- Ports over Teslium from TG: This reagent increases the amount of damage a shock will do to a person; it also will cause periodic random shocks to the person while it's in their body. It has a semi-low depletion rate, so it's a fairly long-acting poison. While it's inside someone, they have a unique examine text.
 - Made with Black Powder+Plasma+Silver+Heat
- Adds in an AoE shock reaction. I was inspired by the Tesla engine for this one, due to its Beam() code and shock animations---basically, on reaction it arcs a blast of electricity to everyone in a 6 tile range. Damage is very very very low, but it's still enough to stun people. I really hope I'm not stepping on any toes with this one due to its similarities with Goon's Voltagen.
 - Made with Teslium+Uranium