### PR TITLE
Makes footstep sounds check if we actually moved

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -90,7 +90,7 @@
 
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()
-	if(shoes)
+	if(shoes && .) // did we actually move?
 		if(!lying && !buckled)
 			if(!has_gravity(loc))
 				return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -477,8 +477,9 @@
 	if (s_active && !( s_active in contents ) && get_turf(s_active) != get_turf(src))	//check !( s_active in contents ) first so we hopefully don't have to call get_turf() so much.
 		s_active.close(src)
 
-	handle_footstep(loc)
-	step_count++
+	if(.) // did we actually move?
+		handle_footstep(loc)
+		step_count++
 
 	if(update_slimes)
 		for(var/mob/living/carbon/slime/M in view(1,src))


### PR DESCRIPTION
Fixes both @tigercat2000's turf-specific sounds and the tg shoe-specific sounds making noise even if you didn't actually move (ie hit a dense thing).
* Was referenced in #2786 and #3067 in the comments, although I don't believe this was ever a separate issue ticket.