### PR TITLE
Fixes Fast Crew Transfers

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -437,7 +437,10 @@
 			user << "Under directive 7-10, [station_name()] is quarantined until further notice."
 			return
 
-	shuttle_master.emergency.request(null, 1, null, " Automatic Crew Transfer", 0)
+	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
+		shuttle_master.emergency.request(null, 0.5, null, " Automatic Crew Transfer", 1)
+	else
+		shuttle_master.emergency.request(null, 1, null, " Automatic Crew Transfer", 0)
 	if(user)
 		log_game("[key_name(user)] has called the shuttle.")
 		message_admins("[key_name_admin(user)] has called the shuttle - [formatJumpTo(user)].", 1)


### PR DESCRIPTION
Fixes it so that the Crew Transfer shuttle properly has its travel time halved (and displays the correct message) if it's code red.