### PR TITLE
Bugfix for atmos monitor

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -119,7 +119,7 @@
 
 /obj/machinery/alarm/monitor
 	report_danger_level = 0
-	
+
 /obj/machinery/alarm/monitor/server
 	preset = AALARM_PRESET_SERVER
 
@@ -763,7 +763,8 @@
 	data["name"] = sanitize(name)
 	data["ref"] = "\ref[src]"
 	data["danger"] = max(danger_level, alarm_area.atmosalm)
-	data["area"] = sanitize(get_area(src))
+	var/area/Area = get_area(src)
+	data["area"] = sanitize(Area.name)
 	var/turf/pos = get_turf(src)
 	data["x"] = pos.x
 	data["y"] = pos.y


### PR DESCRIPTION
Sanitizes area data used in the atmos monitor computer. It generated errors locally, and I couldn't access the detailed list. Both are fixed with this patch.

This is also a potential fix for issue #2806, although the crew monitor worked fine for me, and I could see the map. The error generated was identical however.



