### PR TITLE
Fixed using :i to speak into intercoms

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -150,8 +150,9 @@
 /mob/living/carbon/human/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios, var/alt_name)
 	switch(message_mode)
 		if("intercom")
-			for(var/obj/item/device/radio/intercom/I in view(1, null))
-				I.talk_into(src, message, verb, speaking)
+			for(var/obj/item/device/radio/intercom/I in view(1, src))
+				spawn(0)
+					I.talk_into(src, message, null, verb, speaking)
 				used_radios += I
 
 		if("headset")


### PR DESCRIPTION
The code to handle intercoms had a fundamental bug so it could never work, and a weird technically wrong call to view().
* The `spawn()` is there because non-substation radios contain a delay in the code that handles broadcasting before returning, for whatever reason. If the `spawn()` were removed, it would be broadcasted, and then half a second later, you would talk locally, which is obviously wrong.
* Fixes #3095