### PR TITLE
Fixes Shock Explosion Oversight

### DIFF
--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -622,7 +622,7 @@ datum/reagent/firefighting_foam/reaction_obj(var/obj/O, var/volume)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/mob/living/carbon/C in view(6, T))
 		C.Beam(T,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5) //What? Why are we beaming from the mob to the turf? Turf to mob generates really odd results.
-		C.electrocute_act(1, "electrical blast")
+		C.electrocute_act(3.5, "electrical blast")
 	holder.del_reagent("teslium") //Clear all remaining Teslium and Uranium, but leave all other reagents untouched.
 	holder.del_reagent("uranium")
 	return


### PR DESCRIPTION
Fixes it so that only insulated gloves properly fully protect against a shock explosion.


I had totally forgotten than all gloves reduce shock damage and that latex reduces it even more.

This is the lowest amount which is enough to still shock latex glove wearers.