### PR TITLE
Fixes a flipped conditional that made welders unreadable

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -172,7 +172,7 @@
 	return
 
 /obj/item/weapon/weldingtool/examine(mob/user)
-	if(!..(user, 0))
+	if(..(user, 0))
 		user << "It contains [get_fuel()] unit\s of fuel out of [max_fuel]."
 
 /obj/item/weapon/weldingtool/suicide_act(mob/user)


### PR DESCRIPTION
Actually fixes #2334 
I think the fix from #2404 conflicted with a hacky fix to get the welder examining to work. But it's better now!