### PR TITLE
Restores a Few Object Verbs

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -955,7 +955,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		if(!silent) O.show_message(text("\icon[src] *[ttone]*"))
 
 /obj/item/device/pda/verb/verb_remove_id()
-	set category = null
+	set category = "Object"
 	set name = "Remove id"
 	set src in usr
 
@@ -972,7 +972,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 
 /obj/item/device/pda/verb/verb_remove_pen()
-	set category = null
+	set category = "Object"
 	set name = "Remove pen"
 	set src in usr
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -49,7 +49,7 @@
 
 /obj/structure/stool/bed/chair/verb/rotate()
 	set name = "Rotate Chair"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(config.ghost_interaction)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -273,7 +273,7 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 
 /obj/structure/window/verb/rotate()
 	set name = "Rotate Window Counter-Clockwise"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(anchored)
@@ -289,7 +289,7 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 
 /obj/structure/window/verb/revrotate()
 	set name = "Rotate Window Clockwise"
-	set category = null
+	set category = "Object"
 	set src in oview(1)
 
 	if(anchored)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -276,30 +276,37 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	set category = "Object"
 	set src in oview(1)
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+
 	if(anchored)
-		usr << "It is fastened to the floor therefore you can't rotate it!"
+		usr << "<span class='warning'>It is fastened to the floor therefore you can't rotate it!</span>"
 		return 0
 
 	dir = turn(dir, 90)
 //	updateSilicate()
 	air_update_turf(1)
 	ini_dir = dir
+	add_fingerprint(usr)
 	return
-
 
 /obj/structure/window/verb/revrotate()
 	set name = "Rotate Window Clockwise"
 	set category = "Object"
 	set src in oview(1)
 
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+
 	if(anchored)
-		usr << "It is fastened to the floor therefore you can't rotate it!"
+		usr << "<span class='warning'>It is fastened to the floor therefore you can't rotate it!</span>"
 		return 0
 
 	dir = turn(dir, 270)
 //	updateSilicate()
 	air_update_turf(1)
 	ini_dir = dir
+	add_fingerprint(usr)
 	return
 
 


### PR DESCRIPTION
Restores a few commonly used object verbs:

- Rotating chairs
- Rotating windows
 - Better incapacitation checks for this and it adds a fingerprint now.
- Ejecting IDs/Pens from PDA's


It's particularly annoying to have to right-click to use the first two and typing in the verb, manually, is just as much of a pain in the butt.