### PR TITLE
Add 96x96 icons option

### DIFF
--- a/html/changelogs/tigerbutt-pr-31something.yml
+++ b/html/changelogs/tigerbutt-pr-31something.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: Tigercat2000
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added 96x96 (3x) res option to icons menu"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1410,6 +1410,15 @@ menu "menu"
 		group = "size"
 		is-disabled = false
 		saved-params = "is-checked"
+	elem "icon96"
+		name = "&96x96 (3x)"
+		command = ".winset \"mapwindow.map.icon-size=96\""
+		category = "&Icons"
+		is-checked = false
+		can-check = true
+		group = "size"
+		is-disabled = false
+		saved-params = "is-checked"
 	elem "icon64"
 		name = "&64x64 (2x)"
 		command = ".winset \"mapwindow.map.icon-size=64\""
@@ -1420,7 +1429,7 @@ menu "menu"
 		is-disabled = false
 		saved-params = "is-checked"
 	elem "icon48"
-		name = "&48x48"
+		name = "&48x48 (1.5x)"
 		command = ".winset \"mapwindow.map.icon-size=48\""
 		category = "&Icons"
 		is-checked = false


### PR DESCRIPTION
1080p examples:
32x32
![32x32](http://puu.sh/ml75y/49340fa09b.png)
48x48
![48x48](http://puu.sh/ml75J/74f8e2d078.png)
64x64
![64x64](http://puu.sh/ml77B/9c477dab5e.png)
96x96
![96x96](http://puu.sh/ml77P/5f56d30104.png)