### PR TITLE
Plant Age, Weeds, and Pest Tweaks

### DIFF
--- a/code/modules/hydroponics/trays/tray_process.dm
+++ b/code/modules/hydroponics/trays/tray_process.dm
@@ -19,7 +19,7 @@
 
 	// Weeds like water and nutrients, there's a chance the weed population will increase.
 	// Bonus chance if the tray is unoccupied.
-	if(waterlevel > 10 && nutrilevel > 2 && prob(isnull(seed) ? 5 : 1))
+	if(waterlevel > 10 && nutrilevel > 2 && prob(isnull(seed) ? 6 : 3))
 		weedlevel += 1 * HYDRO_SPEED_MULTIPLIER
 
 	// There's a chance for a weed explosion to happen if the weeds take over.
@@ -110,6 +110,11 @@
 			health -= HYDRO_SPEED_MULTIPLIER
 
 	// Handle life and death.
+	// If the plant gets too old, begin killing it each cycle
+	var/lifespan = 5 * seed.get_trait(TRAIT_MATURATION)
+	if(age > lifespan)
+		health -= rand(5,10) * HYDRO_SPEED_MULTIPLIER
+
 	// When the plant dies, weeds thrive and pests die off.
 	check_health()
 
@@ -120,8 +125,8 @@
 		harvest = 1
 		lastproduce = age
 
-	if(prob(3))  // On each tick, there's a chance the pest population will increase
-		pestlevel += 0.1 * HYDRO_SPEED_MULTIPLIER
+	if(prob(5))  // On each tick, there's a chance the pest population will increase
+		pestlevel += 0.5 * HYDRO_SPEED_MULTIPLIER
 
 	// Some seeds will self-harvest if you don't keep a lid on them.
 	if(seed && seed.can_self_harvest && harvest && !closed_system && prob(5))

--- a/html/changelogs/FalseIncarnate-PR.yml
+++ b/html/changelogs/FalseIncarnate-PR.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: FalseIncarnate
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Plants will now begin to die over time if their age exceeds 5 times their TRAIT_MATURATION value."
+  - tweak: "Weed growth chance per process in trays has been slightly increased (Previously: 5% chance if no seed, 1% otherwise;Now: 6% / 3%)."
+  - tweak: "Pest growth in trays has been slightly buffed. (Previously: 3% chance to increase by 0.1; Now: 5% chance to increase by 0.5)"


### PR DESCRIPTION
Makes plants die when they get old again.
- Plants begin dying once they age past 5 times their TRAIT_MATURATION value.
 - This means a plant with TRAIT_MATURATION 5 will begin dying when it reaches age 26 and higher
- Plant death will occur over time as it loses health each process.
 - Can be slightly deferred with health restoring reagents, but is unavoidable in the long run.

Weed growth in trays has been returned to pre-#980 chances.
- Chance for weedLevel to increase is 6% if no seed planted, 3% otherwise
 - With #980, this was unintentionally dropped to 5% / 1%

Pest growth in trays has received a buff
- Now a 5% chance per process to increase pestLevel by 0.5
 - Previously was 3% chance to increase by 0.1
 - Pre-#980, this was a 3% chance to increase by 1.0