### PR TITLE
Tweaks .38 Rubber Bullet Damage

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -19,7 +19,7 @@
 /obj/item/projectile/bullet/weakbullet2  //detective revolver instastuns, but multiple shots are better for keeping punks down
 	damage = 5
 	weaken = 3
-	stamina = 50
+	stamina = 60
 
 /obj/item/projectile/bullet/weakbullet2/rubber //detective's bullets that don't embed
 	embed = 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -17,7 +17,7 @@
 	sharp = 0
 
 /obj/item/projectile/bullet/weakbullet2  //detective revolver instastuns, but multiple shots are better for keeping punks down
-	damage = 15
+	damage = 5
 	weaken = 3
 	stamina = 50
 

--- a/html/changelogs/davetheheadcrab-PR-revolvernerf.yml
+++ b/html/changelogs/davetheheadcrab-PR-revolvernerf.yml
@@ -1,0 +1,11 @@
+author: Dave The Headcrab
+
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Nerfs the damage the Detective's revolver does from 15 brute to 5 brute."


### PR DESCRIPTION
As of right now the Detective's revolver loaded with standard, easy to get .38 rounds will deal 15 brute damage per bullet, plus 50 stamina damage, and a weaken (stun) of length 3 per hit.

For reference:
 - A laser/energy will deal 20 burn damage per shot, is not easily reloadable, and does not incur broken bones, internal organ damage, or bleeding like the detective's revolver does.

 - A disabler beam will deal 36 stamina damage per shot.

 - A stun baton will weaken someone with a length of 7 per whack.

So what does this mean? 6 shots from the revolver will total 90 brute damage in a very short amount of time, plus bleeding, fractures, and internal organ damage. The first shot will down you which means essentially guaranteed follow up shots, and by the time all 6 chambers are empty you'll have plenty of stamina damage racked up to give the detective all the time he'll need to load another set of bullets and put you into hard crit with another 90 brute.

This PR simply adjusts the damage of these bullets from 15 to 5, reducing the chance of fractures and serious long-lasting damage while maintaining the weapon's viability for what it was always meant to do: Aid in self defense. Appropriate changelogging included.

In short:
Revulver op, pls nerf.