### PR TITLE
Balances the Tesla

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -264,7 +264,7 @@ a {
 
 /obj/proc/tesla_act(var/power)
 	being_shocked = 1
-	var/power_bounced = power * 0.76923
-	tesla_zap(src, 5, power_bounced)
+	var/power_bounced = power * 0.5
+	tesla_zap(src, 3, power_bounced)
 	spawn(10)
 		being_shocked = 0

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -44,7 +44,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 		move_the_basket_ball(amount_to_move)
 		pixel_x = 0
 		pixel_y = 0
-		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 5)
+		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 15)
 		tesla_zap(src, 7, what_does_the_scouter_say_about_the_balls_power_level)
 		pixel_x = -32
 		pixel_y = -32
@@ -69,7 +69,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 /obj/singularity/energy_ball/proc/handle_energy()
 	if(energy >= 300)
 		energy -= 300
-		playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 5)
+		playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 15)
 		spawn(100)
 			var/obj/singularity/energy_ball/EB = new(loc)
 			orbiting_balls.Add(EB)
@@ -113,7 +113,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 	return closest_atom
 
 /proc/tesla_zap(var/atom/source, zap_range = 3, power)
-	if(power < 500)
+	if(power < 1000)
 		return
 	var/list/tesla_coils = list()
 	var/list/grounding_rods = list()

--- a/html/changelogs/tesla-tweak-fox-mccloud.yml
+++ b/html/changelogs/tesla-tweak-fox-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Reduces the amount shock damage and bounces for the Tesla engine."


### PR DESCRIPTION
Port of: https://github.com/tgstation/-tg-station/pull/14347

- Reduces the amount of energy/shock damage that the Tesla has when its arcs bounce
- Increases the range at which the Tesla's bolts can be heard.

Should help reduces the effect of getting one-stop by a lighting arc that wasn't even on your screen when it fired.