### PR TITLE
Hulk Balance

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -155,15 +155,13 @@
 
 	OnMobLife(var/mob/living/carbon/human/M)
 		if(!istype(M)) return
-		if ((HULK in M.mutations) && M.health <= 25)
+		if ((HULK in M.mutations) && M.health <= 0)
 			M.mutations.Remove(HULK)
 			M.dna.SetSEState(HULKBLOCK,0)
 			M.update_mutations()		//update our mutation overlays
 			M.update_body()
 			M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH //temporary fix until the problem can be solved.
 			M << "<span class='danger'>You suddenly feel very weak.</span>"
-			M.Weaken(3)
-			M.emote("collapse")
 
 /datum/dna/gene/basic/xray
 	name="X-Ray Vision"

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -42,15 +42,13 @@ Obviously, requires DNA2.
 		if(!istype(M)) return
 		if(HULK in M.mutations)
 			var/timeleft=M.hulk_time - world.time
-			if(M.health <= 25 || timeleft <= 0)
+			if(M.health <= 0 || timeleft <= 0)
 				M.hulk_time=0 // Just to be sure.
 				M.mutations.Remove(HULK)
 				//M.dna.SetSEState(HULKBLOCK,0)
 				M.update_mutations()		//update our mutation overlays
 				M.update_body()
 				M << "\red You suddenly feel very weak."
-				M.Weaken(3)
-				M.emote("collapse")
 
 /obj/effect/proc_holder/spell/targeted/hulk
 	name = "Hulk Out"

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -207,7 +207,7 @@
 			var/damage = rand(1, 9)
 			if (prob(90))
 				if (HULK in M.mutations)//HULK SMASH
-					damage += 14
+					damage = 15
 					spawn(0)
 						Paralyse(1)
 						step_away(src,M,15)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -151,8 +151,7 @@
 				var/armor_block = run_armor_check(affecting, "melee")
 
 				if(HULK in M.mutations)
-					damage += 5
-					Weaken(4)
+					adjustBruteLoss(15)
 
 				playsound(loc, attack.attack_sound, 25, 1, -1)
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -47,8 +47,6 @@
 
 	if(RUN in mutations)
 		tally = -1
-	if(HULK in mutations)
-		tally += 1
 	if(status_flags & IGNORESLOWDOWN) // make sure this is always at the end so we don't have ignore slowdown getting ignored itself
 		tally = -1
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -379,7 +379,7 @@
 			attacked += 10
 			if (prob(90))
 				if (HULK in M.mutations)
-					damage += 5
+					damage += 15
 					if(Victim || Target)
 						Victim = null
 						Target = null

--- a/html/changelogs/hulk-balance-fox-mccloud.yml
+++ b/html/changelogs/hulk-balance-fox-mccloud.yml
@@ -1,0 +1,9 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Removes Hulk instant stun."
+  - tweak: "Hulk damage increased."
+  - tweak: "Hulk wears off at a lower health threshold."


### PR DESCRIPTION
Hulk is a huge pain in the butt to deal with, even in their nerfed state where they're slowed down. They're still insanely difficult to deal with, largely because they have a never-depleting instant stun.

Either case, this implements some of TG's balance to hulk:

https://github.com/tgstation/-tg-station/pull/13604
https://github.com/tgstation/-tg-station/pull/13672

- Removes hulk instant stun
- Removes the slowdown from Hulk
- Hulk punches now just do +15 damage against humans and slimes
- Hulk punches against Xeno's do a flat 15 damage at all times
- Hulk wears off when you take 100 damage as opposed to 75 and they're no longer weakened.

They'll still be dangerous damage dealers, but they won't be "GG, you're dead" if they get in range of you.