### PR TITLE
Fixes Take Overall Damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -291,17 +291,22 @@
 	var/update = 0
 	while(parts.len && (brute>0 || burn>0) )
 		var/obj/item/organ/external/picked = pick(parts)
+		var/brute_per_part = brute/parts.len
+		var/burn_per_part = burn/parts.len
 
 		var/brute_was = picked.brute_dam
 		var/burn_was = picked.burn_dam
 
-		update |= picked.take_damage(brute,burn,sharp,edge,used_weapon)
+
+		update |= picked.take_damage(brute_per_part,burn_per_part,sharp,edge,used_weapon)
+
 		brute	-= (picked.brute_dam - brute_was)
 		burn	-= (picked.burn_dam - burn_was)
 
 		parts -= picked
 
 	updatehealth()
+
 	if(update)
 		UpdateDamageIcon()
 

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -518,11 +518,7 @@
 			visible_message("<span class='warning'>[src] improves [exp_on], drawing the life essence of those nearby!</span>")
 			for(var/mob/living/m in view(4,src))
 				m << "<span class='danger'>You feel your flesh being torn from you, mists of blood drifting to [src]!</span>"
-				m.apply_damage(10,"brute","head")
-				m.apply_damage(10,"brute","chest")
-				m.apply_damage(10,"brute","groin")
-				m.apply_damage(10,"brute","r_leg")
-				m.apply_damage(10,"brute","l_leg")
+				m.take_overall_damage(50)
 				investigate_log("Experimentor has taken 50 brute a blood sacrifice from [m]", "experimentor")
 			var/list/reqs = ConvertReqString2List(exp_on.origin_tech)
 			for(var/T in reqs)

--- a/html/changelogs/damage-fix-fox-mccloud.yml
+++ b/html/changelogs/damage-fix-fox-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - bugfix: "fixes a bug relating to some brute/burn damage being dealt to human mobs."


### PR DESCRIPTION
Fixes a bug where` take_overall_damage` (and thereby `adjustFiresLoss`/`adjustBruteloss`) was apply all of the specified damage to a single organ instead of the damage being equally distributed around all the external organs on the mob.

Related:
- uses take_overall_damage for the experimentor, since a work-around is no longer necessary.