### PR TITLE
Positronic Brain Balance

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -12,6 +12,7 @@
 	var/list/ghost_volunteers[0]
 	req_access = list(access_robotics)
 	mecha = null//This does not appear to be used outside of reference in mecha.dm.
+	var/silenced = 0 //if set to 1, they can't talk.
 
 
 /obj/item/device/mmi/posibrain/attack_self(mob/user as mob)
@@ -28,6 +29,13 @@
 				if(check_observer(O))
 					transfer_personality(O)
 			reset_search()
+	else
+		if(silenced)
+			silenced = 0
+			user << "<span class='notice'>You toggle the speaker to 'on', on the [src].</span>"
+		else
+			silenced = 1
+			user << "<span class='notice'>You toggle the speaker to 'off', on the [src].</span>"
 
 /obj/item/device/mmi/posibrain/proc/request_player()
 	for(var/mob/dead/observer/O in player_list)
@@ -184,3 +192,6 @@
 		var/turf/T = get_turf_or_move(src.loc)
 		for (var/mob/M in viewers(T))
 			M.show_message("\blue The positronic brain pings softly.")
+
+/obj/item/device/mmi/posibrain/ipc
+	silenced = 1

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -1,6 +1,6 @@
 /obj/item/device/mmi/posibrain
 	name = "positronic brain"
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves."
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. The speaker switch is set to 'on'."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain"
 	w_class = 3
@@ -33,9 +33,15 @@
 		if(silenced)
 			silenced = 0
 			user << "<span class='notice'>You toggle the speaker to 'on', on the [src].</span>"
+			desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. The speaker switch is set to 'on'."
+			if(brainmob && brainmob.key)
+				brainmob << "<span class='warning'>Your internal speaker has been toggled to 'on'.</span>"
 		else
 			silenced = 1
 			user << "<span class='notice'>You toggle the speaker to 'off', on the [src].</span>"
+			desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. The speaker switch is set to 'off'."
+			if(brainmob && brainmob.key)
+				brainmob << "<span class='warning'>Your internal speaker has been toggled to 'off'.</span>"
 
 /obj/item/device/mmi/posibrain/proc/request_player()
 	for(var/mob/dead/observer/O in player_list)
@@ -193,4 +199,5 @@
 			M.show_message("\blue The positronic brain pings softly.")
 
 /obj/item/device/mmi/posibrain/ipc
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. The speaker switch is set to 'off'."
 	silenced = 1

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -177,7 +177,6 @@
 	src.brainmob.real_name = src.brainmob.name
 	src.brainmob.loc = src
 	src.brainmob.container = src
-	src.brainmob.robot_talk_understand = 1
 	src.brainmob.stat = 0
 	src.brainmob.silent = 0
 	src.brainmob.brain_op_stage = 4.0

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -9,6 +9,7 @@
 		if(container && istype(container, /obj/item/device/mmi/posibrain))
 			var/obj/item/device/mmi/posibrain/P = container
 			if(P && P.silenced)
+				usr << "<span class='warning'>You cannot speak, as your internal speaker has been toggled to 'off'.</span>"
 				return
 		if(prob(emp_damage*4))
 			if(prob(10))//10% chane to drop the message entirely

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -3,9 +3,13 @@
 	if (silent)
 		return
 
-	if(!(container && (istype(container, /obj/item/device/mmi) || istype(container, /obj/item/device/mmi/posibrain))))
+	if(!(container && istype(container, /obj/item/device/mmi)))
 		return //No MMI, can't speak, bucko./N
 	else
+		if(container && istype(container, /obj/item/device/mmi/posibrain))
+			var/obj/item/device/mmi/posibrain/P = container
+			if(P && P.silenced)
+				return
 		if(prob(emp_damage*4))
 			if(prob(10))//10% chane to drop the message entirely
 				return
@@ -13,15 +17,6 @@
 				message = Gibberish(message, (emp_damage*6))//scrambles the message, gets worse when emp_damage is higher
 
 		..(message)
-
-/mob/living/carbon/brain/can_speak(var/datum/language/speaking)
-	if(speaking == all_languages["Robot Talk"] && (container && istype(container, /obj/item/device/mmi/posibrain))) //so posibrains can speak binary; less messy than adding the language
-		return 1
-
-	else return ..()
-
-/mob/living/carbon/brain/binarycheck()
-	return (container && istype(container, /obj/item/device/mmi/posibrain))
 
 /mob/living/carbon/brain/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios, var/alt_name)
 	switch(message_mode)

--- a/code/modules/organs/subtypes/machine.dm
+++ b/code/modules/organs/subtypes/machine.dm
@@ -124,7 +124,7 @@
 
 /obj/item/organ/mmi_holder/posibrain/New()
 	robotize()
-	stored_mmi = new /obj/item/device/mmi/posibrain(src)
+	stored_mmi = new /obj/item/device/mmi/posibrain/ipc(src)
 	..()
 	spawn(1)
 		if(owner)

--- a/html/changelogs/posibrain-nerf-fox-mccloud.yml
+++ b/html/changelogs/posibrain-nerf-fox-mccloud.yml
@@ -1,0 +1,9 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Positronic brains can no longer speak binary."
+  - tweak: "Positronic brains can be prevented from speaking (or allowed) by toggling their speaker on/off."
+  - tweak: "IPC's positronic brains start off toggled off."


### PR DESCRIPTION
Balances the Positronic Brain

- Positronic brains can no longer speak or hear binary
- Positronic brains can be prevented (or allowed) to be able to speak by using the item
- IPC's starting positronic brain will not be allowed to speak until toggled
 - This is consistent with how brains are; Android's positronic brains will still be able to talk