### PR TITLE
Uplink and Syndicate Cyborg Fix

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -51,17 +51,11 @@
 				return
 
 			if("implant")
-				var/obj/item/weapon/implanter/O = new /obj/item/weapon/implanter(src)
-				O.imp = new /obj/item/weapon/implant/freedom(O)
-				var/obj/item/weapon/implanter/U = new /obj/item/weapon/implanter(src)
-				U.imp = new /obj/item/weapon/implant/uplink(U)
-				var/obj/item/weapon/implanter/C = new /obj/item/weapon/implanter(src)
-				C.imp = new /obj/item/weapon/implant/emp(C)
-				var/obj/item/weapon/implanter/K = new /obj/item/weapon/implanter(src)
-				K.imp = new /obj/item/weapon/implant/adrenalin(K)
-				var/obj/item/weapon/implanter/S = new /obj/item/weapon/implanter(src)
-				S.imp = new /obj/item/weapon/implant/explosive(S)
-				S.name += " (explosive)"
+				new /obj/item/weapon/implanter/freedom(src)
+				new /obj/item/weapon/implanter/uplink(src)
+				new /obj/item/weapon/implanter/emp(src)
+				new /obj/item/weapon/implanter/adrenalin(src)
+				new /obj/item/weapon/implanter/explosive(src)
 				return
 
 			if("hacker")

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -357,6 +357,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	use_external_power = 1
 	recharge_time = 5
 
+/obj/item/weapon/gun/energy/printer/update_icon()
+	return
+
 /obj/item/weapon/gun/energy/wormhole_projector
 	name = "bluespace wormhole projector"
 	desc = "A projector that emits high density quantum-coupled bluespace beams."

--- a/html/changelogs/uplink-fix-fox-mccloud.yml
+++ b/html/changelogs/uplink-fix-fox-mccloud.yml
@@ -1,0 +1,9 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes Syndicate Cyborg's LMG being invisible."
+  - bugfix: "Fixes the uplink kit having implanters that were both nameless and looked as if they had been used."
+


### PR DESCRIPTION
- Fixes the Syndicate Cyborg's LMG being invisible
- Fixes the uplink kit giving nameless implanters that look like they've already been injected