### PR TITLE
Fixes Tails Overlaying Arms

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -140,13 +140,13 @@ proc/get_id_photo(var/mob/living/carbon/human/H)
 	temp = new /icon(icobase, "head_[g]")
 	preview_icon.Blend(temp, ICON_OVERLAY)
 
-	for(var/obj/item/organ/external/E in H.organs)
-		preview_icon.Blend(E.get_icon(), ICON_OVERLAY)
-
 	//Tail
 	if(H.species.tail && H.species.flags & HAS_TAIL)
 		temp = new/icon("icon" = 'icons/effects/species.dmi', "icon_state" = "[H.species.tail]_s")
 		preview_icon.Blend(temp, ICON_OVERLAY)
+
+	for(var/obj/item/organ/external/E in H.organs)
+		preview_icon.Blend(E.get_icon(), ICON_OVERLAY)
 
 	// Skin tone
 	if(H.species.bodyflags & HAS_SKIN_TONE)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -106,7 +106,7 @@ Please contact me on #coderbus IRC. ~Carn x
 
 //Human Overlays Indexes/////////
 #define MUTANTRACE_LAYER		1
-#define TAIL_LAYER				2		//bs12 specific. this hack is probably gonna come back to haunt me
+#define TAIL_UNDERLIMBS_LAYER	2		//bs12 specific. this hack is probably gonna come back to haunt me
 #define LIMBS_LAYER				3
 #define MARKINGS_LAYER			4 //2
 #define MUTATIONS_LAYER			5 //3
@@ -119,22 +119,22 @@ Please contact me on #coderbus IRC. ~Carn x
 #define SUIT_LAYER				12 //10
 #define GLASSES_LAYER			13 //11
 #define BELT_LAYER				14 //12		//Possible make this an overlay of somethign required to wear a belt?
-//#define TAIL_LAYER				13		//bs12 specific. this hack is probably gonna come back to haunt me
-#define SUIT_STORE_LAYER		15 //14
-#define BACK_LAYER				16 //15
-#define HAIR_LAYER				17 //16		//TODO: make part of head layer?
-#define HEAD_ACCESSORY_LAYER	18 //17
-#define FHAIR_LAYER				19 //18
-#define FACEMASK_LAYER			20 //19
-#define HEAD_LAYER				21 //20
-#define COLLAR_LAYER			22 //21
-#define HANDCUFF_LAYER			23 //22
-#define LEGCUFF_LAYER			24 //23
-#define L_HAND_LAYER			25 //24
-#define R_HAND_LAYER			26 //25
-#define TARGETED_LAYER			27 //26		//BS12: Layer for the target overlay from weapon targeting system
-#define FIRE_LAYER				28 //27    //If you're on fire
-#define TOTAL_LAYERS			28 //27
+#define TAIL_LAYER				15 //13		//bs12 specific. this hack is probably gonna come back to haunt me
+#define SUIT_STORE_LAYER		16 //14
+#define BACK_LAYER				17 //15
+#define HAIR_LAYER				18 //16		//TODO: make part of head layer?
+#define HEAD_ACCESSORY_LAYER	19 //17
+#define FHAIR_LAYER				20 //18
+#define FACEMASK_LAYER			21 //19
+#define HEAD_LAYER				22 //20
+#define COLLAR_LAYER			23 //21
+#define HANDCUFF_LAYER			24 //22
+#define LEGCUFF_LAYER			25 //23
+#define L_HAND_LAYER			26 //24
+#define R_HAND_LAYER			27 //25
+#define TARGETED_LAYER			28 //26		//BS12: Layer for the target overlay from weapon targeting system
+#define FIRE_LAYER				29 //27    //If you're on fire
+#define TOTAL_LAYERS			29 //27
 
 
 
@@ -1012,6 +1012,7 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/proc/update_tail_layer(var/update_icons=1)
+	overlays_standing[TAIL_UNDERLIMBS_LAYER] = null
 	overlays_standing[TAIL_LAYER] = null
 
 	if(body_accessory)
@@ -1019,7 +1020,14 @@ var/global/list/damage_icon_parts = list()
 			var/icon/accessory_s = new/icon("icon" = body_accessory.icon, "icon_state" = body_accessory.icon_state)
 			accessory_s.Blend(rgb(r_skin, g_skin, b_skin), body_accessory.blend_mode)
 
-			overlays_standing[TAIL_LAYER]	= image(accessory_s, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
+			overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(accessory_s, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
+
+			for(var/obj/item/organ/external/part in organs)
+				var/icon/temp = accessory_s
+				if(part.icon_position&(NORTH))
+					var/icon/temp2 = new('icons/mob/human.dmi',"blank")
+					temp2.Insert(new/icon(temp,dir=NORTH),dir=NORTH)
+					overlays_standing[TAIL_LAYER]	= image(temp2, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
 
 
 	else if(species.tail && species.bodyflags & HAS_TAIL) //no tailless tajaran
@@ -1027,26 +1035,48 @@ var/global/list/damage_icon_parts = list()
 			var/icon/tail_s = new/icon("icon" = 'icons/effects/species.dmi', "icon_state" = "[species.tail]_s")
 			tail_s.Blend(rgb(r_skin, g_skin, b_skin), ICON_ADD)
 
-			overlays_standing[TAIL_LAYER]	= image(tail_s)
+			overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(tail_s)
+
+			for(var/obj/item/organ/external/part in organs)
+				var/icon/temp = tail_s
+				if(part.icon_position&(NORTH))
+					var/icon/temp2 = new('icons/mob/human.dmi',"blank")
+					temp2.Insert(new/icon(temp,dir=NORTH),dir=NORTH)
+					overlays_standing[TAIL_LAYER]	= image(temp2)
 
 	if(update_icons)
 		update_icons()
 
 
 /mob/living/carbon/human/proc/start_tail_wagging(var/update_icons=1)
+	overlays_standing[TAIL_UNDERLIMBS_LAYER] = null
 	overlays_standing[TAIL_LAYER] = null
 
 	if(body_accessory)
 		var/icon/accessory_s = new/icon("icon" = body_accessory.get_animated_icon(), "icon_state" = body_accessory.get_animated_icon_state())
 		accessory_s.Blend(rgb(r_skin, g_skin, b_skin), body_accessory.blend_mode)
 
-		overlays_standing[TAIL_LAYER]	= image(accessory_s, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
+		overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(accessory_s, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
+
+		for(var/obj/item/organ/external/part in organs)
+			var/icon/temp = accessory_s
+			if(part.icon_position&(NORTH))
+				var/icon/temp2 = new('icons/mob/human.dmi',"blank")
+				temp2.Insert(new/icon(temp,dir=NORTH),dir=NORTH)
+				overlays_standing[TAIL_LAYER]	= image(temp2, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
 
 	else if(species.tail && species.bodyflags & HAS_TAIL)
 		var/icon/tailw_s = new/icon("icon" = 'icons/effects/species.dmi', "icon_state" = "[species.tail]w_s")
 		tailw_s.Blend(rgb(r_skin, g_skin, b_skin), ICON_ADD)
 
-		overlays_standing[TAIL_LAYER]	= image(tailw_s)
+		overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(tailw_s)
+
+		for(var/obj/item/organ/external/part in organs)
+			var/icon/temp = tailw_s
+			if(part.icon_position&(NORTH))
+				var/icon/temp2 = new('icons/mob/human.dmi',"blank")
+				temp2.Insert(new/icon(temp,dir=NORTH),dir=NORTH)
+				overlays_standing[TAIL_LAYER]	= image(temp2)
 
 	if(update_icons)
 		update_icons()
@@ -1117,13 +1147,13 @@ var/global/list/damage_icon_parts = list()
 
 //Human Overlays Indexes/////////
 #undef MUTANTRACE_LAYER
-#undef TAIL_LAYER
+#undef TAIL_UNDERLIMBS_LAYER
 #undef LIMBS_LAYER
 #undef MARKINGS_LAYER
 #undef MUTATIONS_LAYER
 #undef DAMAGE_LAYER
 #undef UNIFORM_LAYER
-//#undef TAIL_LAYER
+#undef TAIL_LAYER
 #undef ID_LAYER
 #undef SHOES_LAYER
 #undef GLOVES_LAYER

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -106,33 +106,35 @@ Please contact me on #coderbus IRC. ~Carn x
 
 //Human Overlays Indexes/////////
 #define MUTANTRACE_LAYER		1
-#define MARKINGS_LAYER			2
-#define MUTATIONS_LAYER			3
-#define DAMAGE_LAYER			4
-#define UNIFORM_LAYER			5
-#define ID_LAYER				6
-#define SHOES_LAYER				7
-#define GLOVES_LAYER			8
-#define EARS_LAYER				9
-#define SUIT_LAYER				10
-#define GLASSES_LAYER			11
-#define BELT_LAYER				12		//Possible make this an overlay of somethign required to wear a belt?
-#define TAIL_LAYER				13		//bs12 specific. this hack is probably gonna come back to haunt me
-#define SUIT_STORE_LAYER		14
-#define BACK_LAYER				15
-#define HAIR_LAYER				16		//TODO: make part of head layer?
-#define HEAD_ACCESSORY_LAYER	17
-#define FHAIR_LAYER				18
-#define FACEMASK_LAYER			19
-#define HEAD_LAYER				20
-#define COLLAR_LAYER			21
-#define HANDCUFF_LAYER			22
-#define LEGCUFF_LAYER			23
-#define L_HAND_LAYER			24
-#define R_HAND_LAYER			25
-#define TARGETED_LAYER			26		//BS12: Layer for the target overlay from weapon targeting system
-#define FIRE_LAYER				27    //If you're on fire
-#define TOTAL_LAYERS			27
+#define TAIL_LAYER				2		//bs12 specific. this hack is probably gonna come back to haunt me
+#define LIMBS_LAYER				3
+#define MARKINGS_LAYER			4 //2
+#define MUTATIONS_LAYER			5 //3
+#define DAMAGE_LAYER			6 //4
+#define UNIFORM_LAYER			7 //5
+#define ID_LAYER				8 //6
+#define SHOES_LAYER				9 //7
+#define GLOVES_LAYER			10 //8
+#define EARS_LAYER				11 //9
+#define SUIT_LAYER				12 //10
+#define GLASSES_LAYER			13 //11
+#define BELT_LAYER				14 //12		//Possible make this an overlay of somethign required to wear a belt?
+//#define TAIL_LAYER				13		//bs12 specific. this hack is probably gonna come back to haunt me
+#define SUIT_STORE_LAYER		15 //14
+#define BACK_LAYER				16 //15
+#define HAIR_LAYER				17 //16		//TODO: make part of head layer?
+#define HEAD_ACCESSORY_LAYER	18 //17
+#define FHAIR_LAYER				19 //18
+#define FACEMASK_LAYER			20 //19
+#define HEAD_LAYER				21 //20
+#define COLLAR_LAYER			22 //21
+#define HANDCUFF_LAYER			23 //22
+#define LEGCUFF_LAYER			24 //23
+#define L_HAND_LAYER			25 //24
+#define R_HAND_LAYER			26 //25
+#define TARGETED_LAYER			27 //26		//BS12: Layer for the target overlay from weapon targeting system
+#define FIRE_LAYER				28 //27    //If you're on fire
+#define TOTAL_LAYERS			28 //27
 
 
 
@@ -296,6 +298,7 @@ var/global/list/damage_icon_parts = list()
 				if(!(part.icon_position & RIGHT))
 					temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
 				base_icon.Blend(temp2, ICON_OVERLAY)
+				overlays_standing[LIMBS_LAYER]	= image(base_icon)
 				if(part.icon_position & LEFT)
 					temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
 				if(part.icon_position & RIGHT)
@@ -1114,11 +1117,13 @@ var/global/list/damage_icon_parts = list()
 
 //Human Overlays Indexes/////////
 #undef MUTANTRACE_LAYER
+#undef TAIL_LAYER
+#undef LIMBS_LAYER
 #undef MARKINGS_LAYER
 #undef MUTATIONS_LAYER
 #undef DAMAGE_LAYER
 #undef UNIFORM_LAYER
-#undef TAIL_LAYER
+//#undef TAIL_LAYER
 #undef ID_LAYER
 #undef SHOES_LAYER
 #undef GLOVES_LAYER

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -106,35 +106,35 @@ Please contact me on #coderbus IRC. ~Carn x
 
 //Human Overlays Indexes/////////
 #define MUTANTRACE_LAYER		1
-#define TAIL_UNDERLIMBS_LAYER	2		//bs12 specific. this hack is probably gonna come back to haunt me
+#define TAIL_UNDERLIMBS_LAYER	2
 #define LIMBS_LAYER				3
-#define MARKINGS_LAYER			4 //2
-#define MUTATIONS_LAYER			5 //3
-#define DAMAGE_LAYER			6 //4
-#define UNIFORM_LAYER			7 //5
-#define ID_LAYER				8 //6
-#define SHOES_LAYER				9 //7
-#define GLOVES_LAYER			10 //8
-#define EARS_LAYER				11 //9
-#define SUIT_LAYER				12 //10
-#define GLASSES_LAYER			13 //11
-#define BELT_LAYER				14 //12		//Possible make this an overlay of somethign required to wear a belt?
-#define TAIL_LAYER				15 //13		//bs12 specific. this hack is probably gonna come back to haunt me
-#define SUIT_STORE_LAYER		16 //14
-#define BACK_LAYER				17 //15
-#define HAIR_LAYER				18 //16		//TODO: make part of head layer?
-#define HEAD_ACCESSORY_LAYER	19 //17
-#define FHAIR_LAYER				20 //18
-#define FACEMASK_LAYER			21 //19
-#define HEAD_LAYER				22 //20
-#define COLLAR_LAYER			23 //21
-#define HANDCUFF_LAYER			24 //22
-#define LEGCUFF_LAYER			25 //23
-#define L_HAND_LAYER			26 //24
-#define R_HAND_LAYER			27 //25
-#define TARGETED_LAYER			28 //26		//BS12: Layer for the target overlay from weapon targeting system
-#define FIRE_LAYER				29 //27    //If you're on fire
-#define TOTAL_LAYERS			29 //27
+#define MARKINGS_LAYER			4
+#define MUTATIONS_LAYER			5
+#define DAMAGE_LAYER			6
+#define UNIFORM_LAYER			7
+#define ID_LAYER				8
+#define SHOES_LAYER				9
+#define GLOVES_LAYER			10
+#define EARS_LAYER				11
+#define SUIT_LAYER				12
+#define GLASSES_LAYER			13
+#define BELT_LAYER				14	//Possible make this an overlay of somethign required to wear a belt?
+#define TAIL_LAYER				15	//bs12 specific. this hack is probably gonna come back to haunt me
+#define SUIT_STORE_LAYER		16
+#define BACK_LAYER				17
+#define HAIR_LAYER				18	//TODO: make part of head layer?
+#define HEAD_ACCESSORY_LAYER	19
+#define FHAIR_LAYER				20
+#define FACEMASK_LAYER			21
+#define HEAD_LAYER				22
+#define COLLAR_LAYER			23
+#define HANDCUFF_LAYER			24
+#define LEGCUFF_LAYER			25
+#define L_HAND_LAYER			26
+#define R_HAND_LAYER			27
+#define TARGETED_LAYER			28	//BS12: Layer for the target overlay from weapon targeting system
+#define FIRE_LAYER				29	//If you're on fire
+#define TOTAL_LAYERS			29
 
 
 
@@ -298,7 +298,7 @@ var/global/list/damage_icon_parts = list()
 				if(!(part.icon_position & RIGHT))
 					temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
 				base_icon.Blend(temp2, ICON_OVERLAY)
-				overlays_standing[LIMBS_LAYER]	= image(base_icon)
+				overlays_standing[LIMBS_LAYER]	= image(base_icon) // Diverts limbs to their own layer so they can overlay things (i.e. tails).
 				if(part.icon_position & LEFT)
 					temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
 				if(part.icon_position & RIGHT)
@@ -1012,16 +1012,20 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/proc/update_tail_layer(var/update_icons=1)
-	overlays_standing[TAIL_UNDERLIMBS_LAYER] = null
-	overlays_standing[TAIL_LAYER] = null
+	overlays_standing[TAIL_UNDERLIMBS_LAYER] = null // NSEW direction icons, overlayed by LIMBS_LAYER
+	overlays_standing[TAIL_LAYER] = null // Only N direction icon so tails can still appear on the outside of uniforms and such.
 
 	if(body_accessory)
 		if(body_accessory.try_restrictions(src))
 			var/icon/accessory_s = new/icon("icon" = body_accessory.icon, "icon_state" = body_accessory.icon_state)
 			accessory_s.Blend(rgb(r_skin, g_skin, b_skin), body_accessory.blend_mode)
 
+			// Gives the underlimbs layer NSEW direction icons since it's overlayed by limbs and just about everything else anyway.
+			// No special treatment.
 			overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(accessory_s, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
 
+			// Creates a blank icon, and copies accessory_s' north direction sprite into it
+			// before passing that to the tail layer that overlays uniforms and such.
 			for(var/obj/item/organ/external/part in organs)
 				var/icon/temp = accessory_s
 				if(part.icon_position&(NORTH))
@@ -1035,8 +1039,12 @@ var/global/list/damage_icon_parts = list()
 			var/icon/tail_s = new/icon("icon" = 'icons/effects/species.dmi', "icon_state" = "[species.tail]_s")
 			tail_s.Blend(rgb(r_skin, g_skin, b_skin), ICON_ADD)
 
+			// Gives the underlimbs layer NSEW direction icons since it's overlayed by limbs and just about everything else anyway.
+			// No special treatment.
 			overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(tail_s)
 
+			// Creates a blank icon, and copies accessory_s' north direction sprite into it
+			// before passing that to the tail layer that overlays uniforms and such.
 			for(var/obj/item/organ/external/part in organs)
 				var/icon/temp = tail_s
 				if(part.icon_position&(NORTH))
@@ -1049,15 +1057,19 @@ var/global/list/damage_icon_parts = list()
 
 
 /mob/living/carbon/human/proc/start_tail_wagging(var/update_icons=1)
-	overlays_standing[TAIL_UNDERLIMBS_LAYER] = null
-	overlays_standing[TAIL_LAYER] = null
+	overlays_standing[TAIL_UNDERLIMBS_LAYER] = null // NSEW direction icons, overlayed by LIMBS_LAYER
+	overlays_standing[TAIL_LAYER] = null // Only N direction icon so tails can still appear on the outside of uniforms and such.
 
 	if(body_accessory)
 		var/icon/accessory_s = new/icon("icon" = body_accessory.get_animated_icon(), "icon_state" = body_accessory.get_animated_icon_state())
 		accessory_s.Blend(rgb(r_skin, g_skin, b_skin), body_accessory.blend_mode)
 
+		// Gives the underlimbs layer NSEW direction icons since it's overlayed by limbs and just about everything else anyway.
+		// No special treatment.
 		overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(accessory_s, "pixel_x" = body_accessory.pixel_x_offset, "pixel_y" = body_accessory.pixel_y_offset)
 
+		// Creates a blank icon, and copies accessory_s' north direction sprite into it
+		// before passing that to the tail layer that overlays uniforms and such.
 		for(var/obj/item/organ/external/part in organs)
 			var/icon/temp = accessory_s
 			if(part.icon_position&(NORTH))
@@ -1069,8 +1081,13 @@ var/global/list/damage_icon_parts = list()
 		var/icon/tailw_s = new/icon("icon" = 'icons/effects/species.dmi', "icon_state" = "[species.tail]w_s")
 		tailw_s.Blend(rgb(r_skin, g_skin, b_skin), ICON_ADD)
 
+
+		// Gives the underlimbs layer NSEW direction icons since it's overlayed by limbs and just about everything else anyway.
+		// No special treatment.
 		overlays_standing[TAIL_UNDERLIMBS_LAYER]	= image(tailw_s)
 
+		// Creates a blank icon, and copies accessory_s' north direction sprite into it
+		// before passing that to the tail layer that overlays uniforms and such.
 		for(var/obj/item/organ/external/part in organs)
 			var/icon/temp = tailw_s
 			if(part.icon_position&(NORTH))

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -211,16 +211,6 @@ datum/preferences
 		preview_icon.Blend(new /icon(icobase, "groin_[g]"), ICON_OVERLAY)
 		preview_icon.Blend(new /icon(icobase, "head_[g]"), ICON_OVERLAY)
 
-		for(var/name in list("r_arm","r_hand","r_leg","r_foot","l_leg","l_foot","l_arm","l_hand"))
-			if(organ_data[name] == "amputated") continue
-			if(organ_data[name] == "cyborg")
-				var/datum/robolimb/R
-				if(rlimb_data[name]) R = all_robolimbs[rlimb_data[name]]
-				if(!R) R = basic_robolimb
-				preview_icon.Blend(icon(R.icon, "[name]"), ICON_OVERLAY) // This doesn't check gendered_icon. Not an issue while only limbs can be robotic.
-				continue
-			preview_icon.Blend(new /icon(icobase, "[name]"), ICON_OVERLAY)
-
 		//Tail
 		if(current_species && (current_species.bodyflags & HAS_TAIL))
 			var/tail_icon
@@ -236,6 +226,16 @@ datum/preferences
 
 			var/icon/temp = new /icon("icon" = tail_icon, "icon_state" = tail_icon_state)
 			preview_icon.Blend(temp, ICON_OVERLAY)
+
+		for(var/name in list("r_arm","r_hand","r_leg","r_foot","l_leg","l_foot","l_arm","l_hand"))
+			if(organ_data[name] == "amputated") continue
+			if(organ_data[name] == "cyborg")
+				var/datum/robolimb/R
+				if(rlimb_data[name]) R = all_robolimbs[rlimb_data[name]]
+				if(!R) R = basic_robolimb
+				preview_icon.Blend(icon(R.icon, "[name]"), ICON_OVERLAY) // This doesn't check gendered_icon. Not an issue while only limbs can be robotic.
+				continue
+			preview_icon.Blend(new /icon(icobase, "[name]"), ICON_OVERLAY)
 
 		// Skin color
 		if(current_species && (current_species.bodyflags & HAS_SKIN_COLOR))

--- a/html/changelogs/KasparoVy-PR-3166.yml
+++ b/html/changelogs/KasparoVy-PR-3166.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: KasparoVy
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes tails overlapping arms/limbs + gloves, etc. when facing EAST or WEST."
+  - bugfix: "Ensures tails will overlap stuff as normal only when facing NORTH so as to avoid unwanted interference with the base sprite."
+  - bugfix: "Tails now appear in ID cards, overlays things correctly."
+  - bugfix: "Tails now overlay and are overlayed by things correctly in preview icons."
+  - tweak: "Modifies the positioning of tail icon generation in the ID card preview icon generation file."
+  - tweak: "Modifies the positioning of tail icon generation in the player preferences preview icon generation file."
+  - tweak: "Breaks limb generation into its own layer, breaks tail generation into a second layer that can be overlayed by limbs."
+  - tweak: "TAIL_LAYER will now overlay the NORTH direction sprite of a tail now, while TAIL_UNDERLIMBS_LAYER gets all directions."


### PR DESCRIPTION
Discovered to be an issue after #3107 was merged, reported in #3138.

**FIXES:**
- Tails overlapping arms(+ gloves, etc.) when facing east/west.
- Ensures tails will overlap stuff as normal only when facing north so as to avoid unwanted interference with the base sprite.
- The above still works even when tails are wagging, while starting to wag and stopping wagging as well.

**COMMENTS:**
While this does not fix the body colour issue for Vox tails, this does completely fix the tail layering issue with tails overlaying arms and gloves and such as reported in #3138.

What I did was I split limbs into their own layer and left it to be generated with the base icons in update_icons as per usual.

I split tails into two layers: One that could be overlaid by the new limb layer, and one that remained in the regular position, so tails could continue to work as intended while not covering arms and other things when viewed from the side.

What this did in the end was allow tails, wagging and not wagging, to be overlapped by arms and such when the player is facing east or west. But, as soon as they face NORTH, the tail overlays like it used to: Overlapping the body, clothes, etc.

With Vox as an example, where now their tail overlaps their arms and everything, after this PR it will look exactly the same as it did pre-#3107, except Vox tail wagging still works just fine.

In the long run, what this means is that if other races get implemented with limbs that hang over their tails or whatever, it won't look janky.

**EXAMPLE PHOTOS:**
*Character Creation - Please disregard the non-Vox name.*
![tailfixpoc3](https://cloud.githubusercontent.com/assets/12377767/12211585/3e661ece-b630-11e5-91f4-33008df98a52.PNG)

*ID Card - Please disregard the non-Vox name.*
![tailfixpoc2](https://cloud.githubusercontent.com/assets/12377767/12211589/4b01113e-b630-11e5-97a4-092fb13ade10.PNG)

*Player Icons - Top row: No gloves, middle row: Gloves on, bottom row: Facing north and south.*
![tailfixpoc1](https://cloud.githubusercontent.com/assets/12377767/12211594/53d9673e-b630-11e5-95ff-15a817366998.PNG)



