### PR TITLE
Supermatter Fix

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -98,7 +98,7 @@
 			var/stability = num2text(round((damage / explosion_point) * 100))
 
 			if(damage > emergency_point)
-				radio.autosay("[emergency_alert] Instability: [stability]%", src)
+				radio.autosay("[emergency_alert] Instability: [stability]%", src.name)
 				lastwarning = world.timeofday
 				if(!has_reached_emergency)
 					investigate_log("has reached the emergency point for the first time.", "supermatter")
@@ -106,11 +106,11 @@
 					has_reached_emergency = 1
 
 			else if(damage >= damage_archived) // The damage is still going up
-				radio.autosay("[warning_alert] Instability: [stability]%", src)
+				radio.autosay("[warning_alert] Instability: [stability]%", src.name)
 				lastwarning = world.timeofday - 150
 
 			else                                                 // Phew, we're safe
-				radio.autosay("[safe_alert]", src)
+				radio.autosay("[safe_alert]", src.name)
 				lastwarning = world.timeofday
 
 		if(damage > explosion_point)

--- a/html/changelogs/supermatter-fix-mccloud.yml
+++ b/html/changelogs/supermatter-fix-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes the supermatter announcement causing massive amounts of server lag."


### PR DESCRIPTION
So, remember those times where the PDA list would fill up with a neverending amount of AI names and the server would eventually lag to absolute hell and back? Well, this is the reason why.

Basically, the way `autosay` works is that it creates a temporary AI to make the announcement then kills it; probably was, it was attempting to do so with an improper argument, which caused a runtime...which...prevents the AI from ever getting deleted....which incidentally also meant the supermatter would also not behave properly.

This not only prevents that from happening but also means that the supermatter will not properly explode an announce its damage levels.

