### PR TITLE
Fixes Mutadone Causing Massive Performance Issues

### DIFF
--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -760,12 +760,11 @@ proc/chemical_mob_spawn(var/datum/reagents/holder, var/amount_to_spawn, var/reac
 
 /datum/reagent/mutadone/on_mob_life(var/mob/living/carbon/human/M as mob)
 	M.jitteriness = 0
-	var/needs_update = 1 //M.mutations.len > 0
+	var/needs_update = M.mutations.len > 0
 
 	for(var/block=1;block<=DNA_SE_LENGTH;block++)
 		M.dna.SetSEState(block,0)
 		genemutcheck(M,block,null,MUTCHK_FORCED)
-		M.update_mutations()
 
 	M.dna.struc_enzymes = M.dna.struc_enzymes_original
 

--- a/html/changelogs/mutadone-fix-mccloud.yml
+++ b/html/changelogs/mutadone-fix-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes Mutadone incurring a massive cost on the server."


### PR DESCRIPTION
`update_mutations` was getting called for every single gene that a mob has----every life cycle--in addition, it would then call `update_mutations` yet another time after all of this.

`update_mutations` calls update_icons for human mobs--one of the single most expensive procs in all of SS13.

This fixes it so that `update_mutations` is only ever called if there are actual mutations that need to be updated...

Put mutadone in a few mobs and it will literally crush the server.