### PR TITLE
Bomb guardians notify their master when they ready a bomb

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -564,17 +564,19 @@
 	if(!istype(A))
 		return
 	if(src.loc == summoner)
-		src << "<span class='danger'><B>You must be manifested to create bombs!</span></B>"
+		src << "<span class='danger'><B>You must be manifested to create bombs!</B></span>"
 		return
 	if(istype(A, /obj/))
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/item/weapon/guardian_bomb/B = new /obj/item/weapon/guardian_bomb(get_turf(A))
-			src << "<span class='danger'><B>Success! Bomb armed!</span></B>"
+			src << "<span class='danger'><B>Success! Bomb on \the [A] armed!</B></span>"
+			if(summoner)
+				summoner << "<span class='warning'>Your guardian has primed \the [A] to explode!</span>"
 			bomb_cooldown = world.time + 200
 			B.spawner = src
 			B.disguise (A)
 		else
-			src << "<span class='danger'><B>Your powers are on cooldown! You must wait 20 seconds between bombs.</span></B>"
+			src << "<span class='danger'><B>Your powers are on cooldown! You must wait 20 seconds between bombs.</B></span>"
 
 /obj/item/weapon/guardian_bomb
 	name = "bomb"
@@ -590,13 +592,21 @@
 	density = A.density
 	appearance = A.appearance
 	spawn(600)
-		stored_obj.loc = get_turf(src.loc)
-		spawner << "<span class='danger'><B>Failure! Your trap didn't catch anyone this time.</span></B>"
-		qdel(src)
+		if(src)
+			stored_obj.loc = get_turf(src.loc)
+			spawner << "<span class='danger'><B>Failure! Your trap on \the [stored_obj] didn't catch anyone this time.</B></span>"
+			qdel(src)
 
 /obj/item/weapon/guardian_bomb/proc/detonate(var/mob/living/user)
-	user << "<span class='danger'><B>The [src] was boobytrapped!</span></B>"
-	spawner << "<span class='danger'><B>Success! Your trap caught [user]</span></B>"
+	user << "<span class='danger'><B>The [src] was boobytrapped!</B></span>"
+	if(istype(spawner, /mob/living/simple_animal/hostile/guardian))
+		var/mob/living/simple_animal/hostile/guardian/G = spawner
+		if(user == G.summoner)
+			user << "<span class='danger'>You knew this because of your link with your guardian, so you smartly defuse the bomb.</span>"
+			stored_obj.loc = get_turf(src.loc)
+			qdel(src)
+			return
+	spawner << "<span class='danger'><B>Success! Your trap on \the [src] caught [user]!</B></span>"
 	stored_obj.loc = get_turf(src.loc)
 	playsound(get_turf(src),'sound/effects/Explosion2.ogg', 200, 1)
 	user.ex_act(2)

--- a/html/changelogs/crazylemon-poorcommskill.yml
+++ b/html/changelogs/crazylemon-poorcommskill.yml
@@ -1,0 +1,7 @@
+author: Crazylemon
+delete-after: True
+changes: 
+  - rscadd: "Bomb guardians now automatically notify their master when they've set something to boom, so there's less accidental friendly fire"
+  - bugfix: "Bomb guardians are only notified that their trap failed, if it ACTUALLY FAILED."
+  - rscadd: "Bomb guardians now are more aware of what is primed to explode."
+  - rscadd: "Bomb guardian summoners can now defuse their guardian's bombs without harm."


### PR DESCRIPTION
I thought of this during my rampage with Halogen; there were a few close calls where I nearly bombed her by trapping the entrance to where she was hiding, but forgetting to notify her that it would blow up.
FORTUNATELY, someone else triggered the bomb there, but that was a close call. Guardians in and of themselves shouldn't pose a liability, hence this PR.