### PR TITLE
Clone Damage Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -142,7 +142,7 @@
 /mob/living/carbon/human/adjustCloneLoss(var/amount)
 	..()
 
-	if(species.flags & (NO_SCAN))
+	if(species.flags & (NO_DNA_RAD))
 		cloneloss = 0
 		return
 

--- a/code/modules/reagents/oldchem/reagents/reagents_med.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_med.dm
@@ -113,6 +113,7 @@
 
 /datum/reagent/rezadone/on_mob_life(mob/living/M)
 	M.setCloneLoss(0) //Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
+	M.adjustCloneLoss(-1) //What? We just set cloneloss to 0. Why? Simple; this is so external organs properly unmutate.
 	M.heal_organ_damage(1,1)
 	M.status_flags &= ~DISFIGURED
 	..()

--- a/html/changelogs/clone-damage-mccloud.yml
+++ b/html/changelogs/clone-damage-mccloud.yml
@@ -1,0 +1,8 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes Rezadone not clearing mutated organs."
+  - tweak: "Clone damage immunity removed from Slime People, Shadowlings, Golems, and Vox" 


### PR DESCRIPTION
Clone Damage related fixes:

- Rezadone now properly unmutates organs
- Apparently clone damage checked for "NO_SCAN", and set clonedamage to 0 if a species had this; this doesn't make much sense when most things with NO_SCAN still have DNA, can alter their DNA, and can heal clone damage (Shadowlings specifically have abilities that heal clone damage to boot!); this flag is changed to NO_DNA_RAD, instead, which IPCs currently have. This also ensure that Guardians properly deal damage to certain species when they're low on health.

Technically balance? I Guess? I dunno, this comes across as more of an oversight/lack of a properly implemented species flag than anything else.