### PR TITLE
Explosion Overhaul

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -132,14 +132,14 @@
 							affecting_level = 1
 						else
 							affecting_level = S.is_shielded() ? 2 : (S.intact ? 2 : 1)
-						for(var/atom_movable in S.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
-							var/atom/movable/AM = atom_movable
+						for(var/atom in S.contents)	//bypass type checking since only atom can be contained by turfs anyway
+							var/atom/AM = atom
 							if(AM && AM.simulated)
 								if(AM.level >= affecting_level)
 									AM.ex_act(dist)
 					else
-						for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
-							var/atom/movable/AM = atom_movable
+						for(var/atom in T.contents)	//see above
+							var/atom/AM = atom
 							if(AM && AM.simulated)
 								AM.ex_act(dist)
 					T.ex_act(dist)

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -87,7 +87,8 @@
 		var/list/affected_turfs = trange(max_range, epicenter)
 
 		if(config.reactionary_explosions)
-			for(var/turf/T in affected_turfs) // we cache the explosion block rating of every turf in the explosion area
+			for(var/A in affected_turfs) // we cache the explosion block rating of every turf in the explosion area
+				var/turf/T = A
 				cached_exp_block[T] = 0
 				if(T.density && T.explosion_block)
 					cached_exp_block[T] += T.explosion_block
@@ -96,7 +97,8 @@
 					if(D.density && D.explosion_block)
 						cached_exp_block[T] += D.explosion_block
 
-		for(var/turf/T in affected_turfs)
+		for(var/A in affected_turfs)
+			var/turf/T = A
 
 			var/dist = cheap_hypotenuse(T.x, T.y, x0, y0)
 

--- a/code/game/objects/structures/fullwindow.dm
+++ b/code/game/objects/structures/fullwindow.dm
@@ -1,6 +1,7 @@
 /obj/structure/window/full
 	sheets = 2
 	dir=SOUTHWEST
+	level = 3
 
 /obj/structure/window/full/CheckExit(atom/movable/O as mob|obj, target as turf)
 	return 1

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -10,6 +10,7 @@
 	layer = 2.9
 	var/health = 10
 	var/destroyed = 0
+	level = 3
 
 
 /obj/structure/grille/fence/

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -168,3 +168,5 @@
 /turf/simulated/ChangeTurf(var/path)
 	. = ..()
 	smooth_icon_neighbors(src)
+
+/turf/simulated/proc/is_shielded()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -64,7 +64,8 @@ var/list/wood_icons = list("wood","wood-broken")
 //	return ..()
 
 /turf/simulated/floor/ex_act(severity)
-	//set src in oview(1)
+	if(is_shielded())
+		return
 	switch(severity)
 		if(1.0)
 			src.ChangeTurf(/turf/space)
@@ -99,6 +100,11 @@ var/list/wood_icons = list("wood","wood-broken")
 	for(var/obj/structure/window/W in src)
 		if(W.dir == dir_to || W.is_fulltile()) //Same direction or diagonal (full tile)
 			W.fire_act(adj_air, adj_temp, adj_volume)
+
+/turf/simulated/floor/is_shielded()
+	for(var/obj/structure/A in contents)
+		if(A.level == 3)
+			return 1
 
 /turf/simulated/floor/blob_act()
 	return
@@ -217,4 +223,4 @@ var/list/wood_icons = list("wood","wood-broken")
 		ChangeTurf(/turf/simulated/floor/engine/cult)
 
 /turf/simulated/floor/can_have_cabling()
-	return !burnt & !broken
+	return !burnt && !broken

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -198,3 +198,6 @@
 
 /turf/space/singularity_act()
 	return
+
+/turf/space/can_have_cabling()
+	return 0

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -170,6 +170,10 @@
 
 	W.levelupdate()
 	W.CalculateAdjacentTurfs()
+
+	if(!can_have_cabling())
+		for(var/obj/structure/cable/C in contents)
+			qdel(C)
 	return W
 
 //////Assimilate Air//////

--- a/html/changelogs/explosion-tweak-mccloud.yml
+++ b/html/changelogs/explosion-tweak-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Explosions will no longer destroy things underneath turfs until the turf is exposed." 


### PR DESCRIPTION
A port (more or less) of: https://github.com/tgstation/-tg-station/pull/14487

What does this do?

Floors will now protect things underneath them, meaning that if you set off a bomb onto the turf then the things under it (cables, disposals, and pipes) will NOT be damaged unless the tile is already exposed (ie: plating/space).

This makes things a bit easier to repair for engineers and makes things behave a bit more logically--for those who want pictures:

Current:
![img1](https://i.gyazo.com/f3818d74572a90b0a9be300da295f575.png)

This PR:
![img2](https://i.gyazo.com/2776cb84018926dc9e1775e3e4458a74.png)

As you can see, object and turf level destruction are the same, but you don't wind up with destroyed disposals, pipes, and cables underneath intact floors.

What impact on performance does this have? Depends on how many pipes/disposals/cables are in the area...but on the whole? Huge:

Current:
![boom1](https://i.gyazo.com/b02b964c1cbad3195220b07467779113.png)

This PR:
![boom2](https://i.gyazo.com/ba94c1525440e3ecbd9e577f90c62162.png)

Explosion 1: 5-10-20 at Bridge
Explosion 2: 5-10-20 at Medical Bay
Explosion 3: 5-10-20 at Research

Coder Stuffs:
- Makes the explosion proc, itself (which is incredibly cheap), slightly cheaper by not having it perform trange() as many times.