### PR TITLE
fix for monkeycube expand related lag.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1649,6 +1649,7 @@
 			baconbeacon.digest_delay()
 
 
+var/lastmonkeycubeexpand = 0
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube
 	name = "monkey cube"
 	desc = "Just add water!"
@@ -1656,6 +1657,7 @@
 	bitesize = 12
 	filling_color = "#ADAC7F"
 	var/monkey_type = "Monkey"
+	var/expanding = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/New()
 	..()
@@ -1663,6 +1665,8 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/afterattack(obj/O, mob/user, proximity)
 	if(!proximity) return
+	if (expanding == 1)
+		return ..()
 	if(istype(O,/obj/structure/sink) && !wrapped)
 		user << "<span class='notice'>You place [src] under a stream of water...</span>"
 		user.drop_item()
@@ -1675,14 +1679,22 @@
 		Unwrap(user)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/water_act(volume, temperature)
+	if (expanding == 1)
+		return
 	if(volume >= 5)
 		return Expand()
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
-	visible_message("<span class='notice'>[src] expands!</span>")
-	var/mob/living/carbon/human/H = new (get_turf(src))
-	H.set_species(monkey_type)
-	qdel(src)
+	if (expanding == 1)
+		return
+	expanding = 1
+	spawn(0)
+		while (world.time - lastmonkeycubeexpand < 2) //do at most one monkeycube every 0.2sec
+			sleep(world.time - lastmonkeycubeexpand)
+		lastmonkeycubeexpand = world.time
+		visible_message("<span class='notice'>[src] expands!</span>")
+		new/mob/living/carbon/human(get_turf(src),monkey_type)
+		qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Unwrap(mob/user)
 	icon_state = "monkeycube"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1649,7 +1649,6 @@
 			baconbeacon.digest_delay()
 
 
-var/lastmonkeycubeexpand = 0
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube
 	name = "monkey cube"
 	desc = "Just add water!"
@@ -1657,7 +1656,6 @@ var/lastmonkeycubeexpand = 0
 	bitesize = 12
 	filling_color = "#ADAC7F"
 	var/monkey_type = "Monkey"
-	var/expanding = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/New()
 	..()
@@ -1665,8 +1663,6 @@ var/lastmonkeycubeexpand = 0
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/afterattack(obj/O, mob/user, proximity)
 	if(!proximity) return
-	if (expanding == 1)
-		return ..()
 	if(istype(O,/obj/structure/sink) && !wrapped)
 		user << "<span class='notice'>You place [src] under a stream of water...</span>"
 		user.drop_item()
@@ -1679,22 +1675,13 @@ var/lastmonkeycubeexpand = 0
 		Unwrap(user)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/water_act(volume, temperature)
-	if (expanding == 1)
-		return
 	if(volume >= 5)
 		return Expand()
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
-	if (expanding == 1)
-		return
-	expanding = 1
-	spawn(0)
-		while (world.time - lastmonkeycubeexpand < 2) //do at most one monkeycube every 0.2sec
-			sleep(world.time - lastmonkeycubeexpand)
-		lastmonkeycubeexpand = world.time
-		visible_message("<span class='notice'>[src] expands!</span>")
-		new/mob/living/carbon/human(get_turf(src),monkey_type)
-		qdel(src)
+	visible_message("<span class='notice'>[src] expands!</span>")
+	new/mob/living/carbon/human(get_turf(src),monkey_type)
+	qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Unwrap(mob/user)
 	icon_state = "monkeycube"

--- a/html/changelogs/Jey-monkeycubefix.yml
+++ b/html/changelogs/Jey-monkeycubefix.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: Jey
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed lag from expanding multiple monkeycubes at once."


### PR DESCRIPTION
This is a fix for the large lag that occur whenever someone decide to throw water on a bunch of monkeycube (and all alternate version of the item)

changed the new human call instead of using set_species incidently dropping the number of delete from ~50 to ~10 per monkey cube.

added a limit to monkeycube expand to only expand one every 0.2 second instead of doing them all at once in the event of a mass expand.