### PR TITLE
APC Overcharge now uses Tesla Engine Lightning

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1256,16 +1256,9 @@
 
 		if(excess >= 5000000 && !shock_proof) //If there's more than 5,000,000 watts in the grid, start arcing and shocking people.
 			if(prob(5))
-				var/list/shock_mobs = list()
-				for(var/C in view(get_turf(src), 5)) //We only want to shock a single random mob in range, not every one.
-					if(iscarbon(C))
-						shock_mobs +=C
-				if(shock_mobs.len)
-					var/mob/living/carbon/S = pick(shock_mobs)
-					S.electrocute_act(rand(5,25), "electrical arc")
-					playsound(get_turf(S), 'sound/effects/eleczap.ogg', 75, 1)
-					Beam(S,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
-
+				tesla_zap(src, 5, excess)
+				draw_power(excess)
+				playsound(get_turf(S), 'sound/effects/eleczap.ogg', 75, 1)
 	else // no cell, switch everything off
 
 		charging = 0


### PR DESCRIPTION
:cl: Iamgoofball
experimental: APC overcharge arcs are now using Tesla Engine zap logic.
experimental: APCs will now drain 5,000,000 watts of energy when they overcharge, which is shot into the lighting arc it emits. This should help balance the above effect.
/:cl: