### PR TITLE
Monkey Cube Lag

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1679,9 +1679,10 @@
 		return Expand()
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Expand()
-	visible_message("<span class='notice'>[src] expands!</span>")
-	new/mob/living/carbon/human(get_turf(src),monkey_type)
-	qdel(src)
+	if(isnull(gcDestroyed))
+		visible_message("<span class='notice'>[src] expands!</span>")
+		new/mob/living/carbon/human(get_turf(src),monkey_type)
+		qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/proc/Unwrap(mob/user)
 	icon_state = "monkeycube"

--- a/html/changelogs/monkey-creation-fox-mccloud.yml
+++ b/html/changelogs/monkey-creation-fox-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixes/cuts down on the lag caused by monkey cubes."


### PR DESCRIPTION
Stops multiple monkies from spawning in nullspace.

I suspect that @tigercat2000 water thing is screwing shit up somewhere and proccing `expand` more than it needs to, causing this, but in any event, it may also be the GC not properly processing it in time andddd causing issues.

Either case, this resolves the issue--there's still lag from creating a ton of monkies, of course, but this should help out, a lot.