### PR TITLE
Increases Nuclear Challenge Time Limit

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,4 +1,4 @@
-#define CHALLENGE_TIME_LIMIT 3000
+#define CHALLENGE_TIME_LIMIT 6000
 #define MIN_CHALLENGE_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 //25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 

--- a/html/changelogs/PPI-patch-1.yml
+++ b/html/changelogs/PPI-patch-1.yml
@@ -32,5 +32,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscdel: "Removes two minute limite for activate Nuclear Challenge as Nuke Ops Commander, after spawn."
-  - rscadd: "Adds a 7 minute time limit to activate the Nuclear Challenge as Nuke Ops Commander, after spawn."
+  - tweak: "Modifies the effective time limit to activate the Nuclear Challenge as Nukeops from two minutes to seven minutes"

--- a/html/changelogs/PPI-patch-1.yml
+++ b/html/changelogs/PPI-patch-1.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: PPI
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Removes two minute limite for activate Nuclear Challenge as Nuke Ops Commander, after spawn."
+  - rscadd: "Adds a 7 minute time limit to activate the Nuclear Challenge as Nuke Ops Commander, after spawn."


### PR DESCRIPTION
Time begins counting as soon as the server starts from 12:00, players spawn in at 12:03 followed by a small delay.

This doubles the time to 12:10 from 12:05 as a time limit to call the challenge. 

Less then 2 minutes of actual time is kinda little.