### PR TITLE
Added printing crew photo from security records

### DIFF
--- a/html/changelogs/Tastyfish-wanted-photo.yml
+++ b/html/changelogs/Tastyfish-wanted-photo.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: Tastyfish
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added the ability to print the records photo of a crew member from a security records console. Useful for Wanted notices!"


### PR DESCRIPTION
This adds the ability to print the file photos of a crew member, for the sake of Wanted Issues, etc.
##### The button is beneath the photos.
![Preview](http://i.imgur.com/Z80yqE2.png)
##### Hey, a wanted issue with a picture for once!
![Preview](http://i.imgur.com/JNMzCEh.png)

In implementing this, I discovered that the code for the security records computer is horrible, super-old code that doesn't even follow the standards of most pre-NanoUI interfaces, despite being updated several times over the years. Maybe in another PR, I'll NanoUI-ize this mess.