### PR TITLE
Raw Telecrystal on Uplink Implants

### DIFF
--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -10,6 +10,14 @@
 	flags = NOBLUDGEON
 	origin_tech = "materials=6;syndicate=1"
 
+/obj/item/stack/telecrystal/attack(mob/target as mob, mob/user as mob)
+	if(target == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.
+		for(var/obj/item/weapon/implant/uplink/I in target)
+			if(I && I.implanted)
+				I.hidden_uplink.uses +=1
+				use(1)
+				user << "<span class='notice'>You press the [src] onto yourself and charge your hidden uplink.</span>"
+
 /obj/item/stack/telecrystal/afterattack(var/obj/item/I as obj, mob/user as mob, proximity)
 	if(!proximity)
 		return

--- a/html/changelogs/telecrystal-change-fox-mccloud.yml
+++ b/html/changelogs/telecrystal-change-fox-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - rscadd: "Raw telecrystal can now be used to charge uplink implants."


### PR DESCRIPTION
Raw telecrystal can now be used to charge hidden uplink implants
 -Simply hit yourself with a telecrystal to do so (obviously only charges it if you actually have one).

But Fox! Won't this charge multiple implants if you have more than one?
 - Outside of hacky as hell adminbus, no, that won't happen with how implants work now.