### PR TITLE
Cigarette Pack Functionality

### DIFF
--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -9,7 +9,7 @@
 	item_state = "lighter-g"
 	var/icon_on = "lighter-g-on"
 	var/icon_off = "lighter-g"
-	w_class = 1
+	w_class = 2
 	throwforce = 4
 	flags = CONDUCT
 	slot_flags = SLOT_BELT

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -158,13 +158,17 @@
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cigpacket"
 	item_state = "cigpacket"
-	w_class = 1
+	w_class = 2
 	throwforce = 2
 	slot_flags = SLOT_BELT
 	storage_slots = 6
-	can_hold = list("/obj/item/clothing/mask/cigarette")
+	max_combined_w_class = 6
+	can_hold = list("/obj/item/clothing/mask/cigarette",
+		"/obj/item/weapon/lighter",
+		"/obj/item/weapon/match")
 	cant_hold = list("/obj/item/clothing/mask/cigarette/cigar",
-		"/obj/item/clothing/mask/cigarette/pipe")
+		"/obj/item/clothing/mask/cigarette/pipe",
+		"/obj/item/weapon/lighter/zippo")
 	icon_type = "cigarette"
 	var/list/unlaced_cigarettes = list() // Cigarettes that haven't received reagents yet
 	var/default_reagents = list("nicotine" = 15) // List of reagents to pre-generate for each cigarette
@@ -206,14 +210,37 @@
 		return
 
 	if(istype(M) && M == user && user.zone_sel.selecting == "mouth" && contents.len > 0 && !user.wear_mask)
-		var/obj/item/clothing/mask/cigarette/C = contents[contents.len]
-		if(!istype(C)) return
-		lace_cigarette(C)
-		user.equip_to_slot_if_possible(C, slot_wear_mask)
-		user << "<span class='notice'>You take a cigarette out of the pack.</span>"
-		update_icon()
+		var/got_cig = 0
+		for(var/num=1, num <= contents.len, num++)
+			var/obj/item/I = contents[num]
+			if(istype(I, /obj/item/clothing/mask/cigarette))
+				var/obj/item/clothing/mask/cigarette/C = I
+				lace_cigarette(C)
+				user.equip_to_slot_if_possible(C, slot_wear_mask)
+				user << "<span class='notice'>You take \a [C.name] out of the pack.</span>"
+				update_icon()
+				got_cig = 1
+				break
+		if(!got_cig)
+			user << "<span class='warning'>There are no smokables in the pack!</span>"
 	else
 		..()
+
+/obj/item/weapon/storage/fancy/cigarettes/can_be_inserted(obj/item/W as obj, stop_messages = 0)
+	if(istype(W, /obj/item/weapon/match))
+		var/obj/item/weapon/match/M = W
+		if(M.lit == 1)
+			if(!stop_messages)
+				usr << "<span class='notice'>Putting a lit [W] in [src] probably isn't a good idea.</span>"
+			return 0
+	if(istype(W, /obj/item/weapon/lighter))
+		var/obj/item/weapon/lighter/L = W
+		if(L.lit == 1)
+			if(!stop_messages)
+				usr << "<span class='notice'>Putting [W] in [src] while lit probably isn't a good idea.</span>"
+			return 0
+	//if we get this far, handle the insertion checks as normal
+	.=..()
 
 /obj/item/weapon/storage/fancy/cigarettes/dromedaryco
 	name = "\improper DromedaryCo packet"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -330,6 +330,21 @@ BLIND     // can't see anything
 		"Vox" = 'icons/mob/species/vox/shoes.dmi'
 		)
 
+/obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/match) && src.loc == user)
+		var/obj/item/weapon/match/M = I
+		if(M.lit == 0)
+			M.lit = 1
+			M.icon_state = "match_lit"
+			processing_objects.Add(M)
+			M.update_icon()
+			user << "<span class='notice'>You strike the [M] along your [src] to light it.</span>"
+		else if(M.lit == 1)
+			M.dropped()
+			user << "<span class='notice'>You crush the [M] into the bottom of your [src], extinguishing it.</span>"
+		return
+	else
+		..()
 
 /obj/item/proc/negates_gravity()
 	return 0

--- a/html/changelogs/FalseIncarnate.yml
+++ b/html/changelogs/FalseIncarnate.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: FalseIncarnate
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Allowed cheap lighters and individual matches to be put into cigarette packages at the cost of cigarette space."
+  - rscadd: "Matches can now be lit and put out by striking the match on your shoes. Good for if you lose that matchbox, or want to just feel cool."


### PR DESCRIPTION
Adds the ability to put cheap lighters and individual matches into cigarette packs at the cost of cigarette slots.
- A cheap lighter takes up the space of 2 cigarettes.
 - Zippos won't fit, they are too boxy.
- A match takes up the space of 1 cigarette.

Increases the w_class of all lighters (cheap, zippo, and special zippos) and cigarette packages
- Previously 1, now 2
 - Still fits in pockets, just can't shove as many into a box as they take up more space

Adds the ability to light and put out matches on your shoes.
- Good for when you lose that matchbox (or shove matches into a cig pack) and need a light.
- Works on all shoes, from the humble brown shoes to the devious syndicate magboots, and even the clown shoes.

Based on the suggestion from:
http://nanotrasen.se/phpbb3/viewtopic.php?f=12&t=6880