### PR TITLE
pAI Cooldown Reduction

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -6,7 +6,7 @@
 	w_class = 2.0
 	slot_flags = SLOT_BELT
 	origin_tech = "programming=2"
-	var/request_cooldown = 60 // one minute
+	var/request_cooldown = 5 // five seconds
 	var/last_request
 	var/obj/item/device/radio/radio
 	var/looking_for_personality = 0

--- a/html/changelogs/pai-cooldown-fox-mccloud.yml
+++ b/html/changelogs/pai-cooldown-fox-mccloud.yml
@@ -1,0 +1,7 @@
+
+author: Fox McCloud
+
+delete-after: True
+
+changes: 
+  - tweak: "Lowers the pAI cooldown from 60 seconds to 5 seconds."


### PR DESCRIPTION
Lowers the pAI cooldown from 60 seconds to 5 seconds.

Now that pAI is completely separate from holoparasites, I don't see any reason not to do this; the problem was with people spamming the thing endlessly.

It also meant that even if you got a pAI, you had to wait a full minute before you could actually select it.