### PR TITLE
Fixed ID computer access report

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -372,17 +372,20 @@ var/time_last_changed_position = 0
 					else if (modify && !mode)
 						P.name = "access report"
 						P.info = {"<h4>Access Report</h4>
-							<u>Prepared By:</u> [scan.registered_name ? scan.registered_name : "Unknown"]<br>
+							<u>Prepared By:</u> [scan && scan.registered_name ? scan.registered_name : "Unknown"]<br>
 							<u>For:</u> [modify.registered_name ? modify.registered_name : "Unregistered"]<br>
 							<hr>
 							<u>Assignment:</u> [modify.assignment]<br>
 							<u>Account Number:</u> #[modify.associated_account_number]<br>
 							<u>Blood Type:</u> [modify.blood_type]<br><br>
-							<u>Access:</u><br>
+							<u>Access:</u><div style="margin-left:1em">
 						"}
 
+						var/first = 1
 						for(var/A in modify.access)
-							P.info += "  [get_access_desc(A)]"
+							P.info += "[first ? "" : ", "][get_access_desc(A)]"
+							first = 0
+						P.info += "</div>"
 
 		if ("terminate")
 			if (is_authenticated(usr))


### PR DESCRIPTION
* Seperates the access list in the ID computer's Access Report printout with commas instead of spaces. 
 * Who thought that was a good idea with a list where most of the items are multiple words?
* Fixes #3290 

:cl:
tweak: The ID computer Access Report printout now separates the access list with commas so it's actually readable.
bugfix: The ID computer Access Report printout isn't blank if you don't have an authorization card in anymore.
/:cl: