### PR TITLE
Trained Poly on proper tesla engine use.

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -57,13 +57,14 @@
 
 	return ..()
 
-/obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
-	if (aiOverride)
-		return ..(freq, level)
-	if(ishuman(src.loc))
-		var/mob/living/carbon/human/H = src.loc
+/obj/item/device/radio/headset/receive_range(freq, level)
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
 		if(H.l_ear == src || H.r_ear == src)
 			return ..(freq, level)
+	else if(isanimal(loc))
+		// frankly, all the ones with inventory are small enough to not warrant snowflaking the slot check somehow
+		return ..(freq, level)
 	return -1
 
 /obj/item/device/radio/headset/alt

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -680,7 +680,7 @@
 /mob/living/simple_animal/parrot/Poly
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
-	speak = list("Poly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Check the tesla, you drunks!",":e STOP HOT-WIRING THE ENGINE, CHRIST!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
+	speak = list("Poly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Check the tesla, you shits!",":e STOP HOT-WIRING THE ENGINE, FUCKING CHRIST!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
 
 /mob/living/simple_animal/parrot/Poly/New()
 	ears = new /obj/item/device/radio/headset/headset_eng(src)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -680,7 +680,7 @@
 /mob/living/simple_animal/parrot/Poly
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
-	speak = list("Poly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
+	speak = list("Poly wanna cracker!", ":e Check the singlo, you chucklefucks!",":e Check the tesla, you drunks!",":e STOP HOT-WIRING THE ENGINE, CHRIST!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS FREE CALL THE SHUTTLE")
 
 /mob/living/simple_animal/parrot/Poly/New()
 	ears = new /obj/item/device/radio/headset/headset_eng(src)


### PR DESCRIPTION
* Corrected the obvious oversight from #2999 of not making Poly freak out about the tesla.
* I've also removed the dead-weight `aiOverride` code from headset's `receive_range`, as no other code in the game was aware of this parameter, and `receive_range` doesn't have this parameter in any other radio implementation. Hopefully this will appease people regarding the `isanimal()` check being added.
* Technically, all simple animals that can have a headset in any slot can hear it now, but in practice this only includes Poly at all as far as I'm aware. Yes, this is the second Poly-centric PR I've made. :bird: 

:cl:
rscadd: Poly has taken a seminar on the latest trends in engine operations.
rscadd: Player-controller parrots can now hear their headsets.
/:cl: