### PR TITLE
Fixes Holstering a Few Guns

### DIFF
--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -80,6 +80,9 @@
 	item_state = "gun"
 	cell_type = "/obj/item/weapon/stock_parts/cell/pulse/pistol"
 
+/obj/item/weapon/gun/energy/pulse_rifle/pistol/isHandgun()
+	return 1
+
 /obj/item/weapon/gun/energy/pulse_rifle/pistol/m1911
 	name = "\improper M1911-P"
 	desc = "A compact pulse core in a classic handgun frame for Nanotrasen officers. It's not the size of the gun, it's the size of the hole it puts through people."

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -74,6 +74,9 @@
 	if (chambered)
 		user << "A [chambered.BB ? "live" : "spent"] one is in the chamber."
 
+/obj/item/weapon/gun/projectile/shotgun/isHandgun() //You cannot, in fact, holster a shotgun.
+	return 0
+
 // RIOT SHOTGUN //
 
 /obj/item/weapon/gun/projectile/shotgun/riot //for spawn in the armory
@@ -159,6 +162,9 @@
 		user << "<span class = 'notice'>You break open \the [src] and unload [num_unloaded] shell\s.</span>"
 	else
 		user << "<span class='notice'>[src] is empty.</span>"
+
+/obj/item/weapon/gun/projectile/revolver/doublebarrel/isHandgun() //contrary to popular opinion, double barrels are not, shockingly, handguns
+	return 0
 
 // IMPROVISED SHOTGUN //
 


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/3302

Fixes not being able to holster pulse pistols and being able to holster shotguns (what).

:cl: Fox McCloud
bugfix: Fixes being unable to holster the pulse pistol
bugfix: Fixes being able to holster shotguns
/:cl: