### PR TITLE
Fixes Blood Death Redundancy

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -138,10 +138,6 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 					var/word = pick("dizzy","woosey","faint")
 					src << "\red You feel extremely [word]"
 			if(0 to BLOOD_VOLUME_SURVIVE)
-				// There currently is a strange bug here. If the mob is not below -100 health
-				// when death() is called, apparently they will be just fine, and this way it'll
-				// spam deathgasp. Adjusting toxloss ensures the mob will stay dead.
-				toxloss += 300 // just to be safe!
 				death()
 
 		// Without enough blood you slowly go hungry.


### PR DESCRIPTION
When someone bleeds out, it would arbitrarily deal 300 tox damage to them "just in case". Maybe, in the distant past, this was necessary, but with current code, just calling 'death' is not problematic and the person will stay dead.

Was tested with regular mobs and slimes; works for both.

:cl: Fox McCloud
bugfix: Fixes unnecessary toxin damage being dealt on severe bloodloss
/:cl: