### PR TITLE
Fixes Random Names on Human Mob Creation

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -19,10 +19,11 @@
 	var/list/syllables               // Used when scrambling text for a non-speaker.
 	var/list/space_chance = 55       // Likelihood of getting a space in the random scramble string.
 	var/follow = 0					 // Applies to HIVEMIND languages - should a follow link be included for dead mobs?
+	var/english_names = 0			 // Do we want English names by default, no matter what?
 	var/list/scramble_cache = list()
 
 /datum/language/proc/get_random_name(var/gender, name_count=2, syllable_count=4)
-	if(!syllables || !syllables.len)
+	if(!syllables || !syllables.len || english_names)
 		if(gender==FEMALE)
 			return capitalize(pick(first_names_female)) + " " + capitalize(pick(last_names))
 		else
@@ -283,6 +284,7 @@
 	key = "9"
 	flags = RESTRICTED
 	syllables = list("blah","blah","blah","bleh","meh","neh","nah","wah")
+	english_names = 1
 
 //TODO flag certain languages to use the mob-type specific say_quote and then get rid of these.
 /datum/language/common/get_spoken_verb(var/msg_end)
@@ -302,6 +304,7 @@
 	key = "1"
 	flags = RESTRICTED
 	syllables = list("tao","shi","tzu","yi","com","be","is","i","op","vi","ed","lec","mo","cle","te","dis","e")
+	english_names = 1
 
 /datum/language/human/get_spoken_verb(var/msg_end)
 	switch(msg_end)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -23,7 +23,10 @@
 			set_species(delay_icon_update = 1)
 
 	if(species)
-		name = species.get_random_name(gender)
+		real_name = species.get_random_name(gender)
+		name = real_name
+		if(mind)
+			mind.name = real_name
 
 	var/datum/reagents/R = new/datum/reagents(330)
 	reagents = R

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -44,6 +44,11 @@
 /datum/species/monkey/get_random_name()
 	return "[lowertext(name)] ([rand(100,999)])"
 
+/datum/species/monkey/handle_post_spawn(var/mob/living/carbon/human/H)
+	H.real_name = "[lowertext(name)] ([rand(100,999)])"
+	H.name = H.real_name
+	..()
+
 /datum/species/monkey/handle_dna(var/mob/living/carbon/human/H)
 	H.dna.SetSEState(MONKEYBLOCK,1)
 

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -41,13 +41,8 @@
 	if(prob(1))
 		H.emote(pick("scratch","jump","roll","tail"))
 
-datum/species/monkey/get_random_name(var/gender)
-	return
-
-/datum/species/monkey/handle_post_spawn(var/mob/living/carbon/human/H)
-	H.real_name = "[lowertext(name)] ([rand(100,999)])"
-	H.name = H.real_name
-	..()
+/datum/species/monkey/get_random_name()
+	return "[lowertext(name)] ([rand(100,999)])"
 
 /datum/species/monkey/handle_dna(var/mob/living/carbon/human/H)
 	H.dna.SetSEState(MONKEYBLOCK,1)


### PR DESCRIPTION
Just some name fixes for newly created mobs.

- Fixes it so that when a new human mob is created, it'll receive a proper random name instead of just "unknown".
- Ensures that species without a language will pull from English names lists.
 - This should bix the "blahblawahneh Blahwehwehblehhhh" names you see

:cl: Fox McCloud
bugfix: Fixes human mobs not receiving proper random names
/:cl: