### PR TITLE
Fixes #3301

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -274,6 +274,8 @@ var/global/list/damage_icon_parts = list()
 			icon_key += "[part.dna.GetUIValue(DNA_UI_SKIN_TONE)]"
 			if(part.s_col)
 				icon_key += "[rgb(part.s_col[1], part.s_col[2], part.s_col[3])]"
+			if(part.s_tone)
+				icon_key += "[part.s_tone]"
 
 	icon_key = "[icon_key][husk ? 1 : 0][fat ? 1 : 0][hulk ? 1 : 0][skeleton ? 1 : 0]"
 


### PR DESCRIPTION
For some reason, the s_tone of limbs was left out of the icon_key,
therefore making update_body use a cached image (I still question if these
actually help performance or worsen it) when it is not supposed to.