### PR TITLE
Fixes placing a table next to a flipped table.

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -314,6 +314,7 @@
 	if(dir != NORTH)
 		layer = 5
 	flipped = 1
+	smooth = SMOOTH_FALSE
 	flags |= ON_BORDER
 	for(var/D in list(turn(direction, 90), turn(direction, -90)))
 		if(locate(/obj/structure/table,get_step(src,D)))
@@ -339,6 +340,7 @@
 
 	layer = initial(layer)
 	flipped = 0
+	smooth = initial(smooth)
 	flags &= ~ON_BORDER
 	for(var/D in list(turn(dir, 90), turn(dir, -90)))
 		if(locate(/obj/structure/table,get_step(src,D)))


### PR DESCRIPTION
Something I forgot to fix in #3299, placing new tables adjacent to flipped tables was making them render as smooth again, oops.
The upright table still visually starts to connect to the flipped table because fixing that would require rewriting the smoothing system or making fixed tables a different object something horrible.