### PR TITLE
Fixes Hulk Not Properly Being Removed

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -158,6 +158,7 @@
 		if ((HULK in M.mutations) && M.health <= 0)
 			M.mutations.Remove(HULK)
 			M.dna.SetSEState(HULKBLOCK,0)
+			genemutcheck(M, HULKBLOCK,null,MUTCHK_FORCED)
 			M.update_mutations()		//update our mutation overlays
 			M.update_body()
 			M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH //temporary fix until the problem can be solved.


### PR DESCRIPTION
Fixes hulk not properly being removed when you lose the gene

Similar to monkies, you had to fiddle with it by activating+detactivating it to get it back again.

:cl: Fox McCloud
bugfix: Fixes Hulk not properly being removed when your health drops below a threshold
/:cl: