### PR TITLE
"Fixes" Mecha Mining Scanner

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1088,9 +1088,7 @@
 			return
 		var/list/occupant = list()
 		occupant |= mecha.occupant
-		mecha.occupant.sight |= SEE_TURFS
 		scanning = 1
 		mineral_scan_pulse(occupant,get_turf(loc))
 		spawn(equip_cooldown)
 			scanning = 0
-			mecha.occupant.sight -= SEE_TURFS


### PR DESCRIPTION
Fixes/removes shimmery vision when in a mech with a mining scanner.

Downside? You'll have tor wear mesons again.


:cl: Fox McCloud
bugfix: Fixes flickering vision in a mining mech
/:cl: