### PR TITLE
Fixed borg items spamming user chat every mob tick when on low power

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -26,11 +26,11 @@
 		return
 	else if (is_component_functioning("power cell") && cell)
 		if(module)
-			for(var/obj/item/borg/B in module.modules)
+			for(var/obj/item/borg/B in get_all_slots())
 				if(B.powerneeded)
 					if((cell.charge * 100 / cell.maxcharge) < B.powerneeded)
 						src << "Deactivating [B.name] due to lack of power!"
-						unEquip(B)
+						uneq_module(B)
 		if(cell.charge <= 0)
 			uneq_all()
 			update_headlamp(1)


### PR DESCRIPTION
When low on power, the life() code was trying to deactivate (using the wrong proc) the power-sucking the modules every mob tick, regardless of whether they were activated or not, creating as much spam for the user as you'd imagine. This was especially obvious for peacekeepers/combat borgs who have 2 `item/borg` modules.
* Fixes #2728 

:cl:
bugfix: Passively power-consuming borg modules, such as the peacekeeper movement and shield module, won't spam the user infinitely if they're low on power anymore.
/:cl: