### PR TITLE
[s]Portable Turret Fixes

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -547,6 +547,9 @@ var/list/turret_icons
 	if(!istype(L))
 		return TURRET_NOT_TARGET
 
+	if(get_turf(L) == get_turf(src))
+		return TURRET_NOT_TARGET
+
 	if(L.invisibility >= INVISIBILITY_LEVEL_ONE) // Cannot see him. see_invisible is a mob-var
 		return TURRET_NOT_TARGET
 

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -434,8 +434,8 @@
 		P.failchance = 0
 		P.icon_state = "anom"
 		P.name = "wormhole"
-		message_admins("[key_name_admin(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[chassis.occupant]'>FLW</A>) used a Wormhole Generator in ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",0,1)
-		log_game("[key_name(chassis.occupant)] used a Wormhole Generator in ([T.x],[T.y],[T.z])")
+		message_admins("[key_name_admin(chassis.occupant, chassis.occupant.client)](<A HREF='?_src_=holder;adminmoreinfo=\ref[chassis.occupant]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[chassis.occupant]'>FLW</A>) used a Wormhole Generator in ([loc.x],[loc.y],[loc.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>JMP</a>)",0,1)
+		log_game("[key_name(chassis.occupant)] used a Wormhole Generator in ([loc.x],[loc.y],[loc.z])")
 		do_after_cooldown()
 		src = null
 		spawn(rand(150,300))


### PR DESCRIPTION
- Fixes infinite loop caused by porta_turrets when trying to target something on the same tile as the turret.
- Also fixes a miscellaneous runtime with the mecha wormhole projector.

I was originally going to rip out aim mode code completely with this, because it's horrible and I don't know who the fuck thought it would be a good idea to have turrets use it, but that's going to be a bit more controversial, and this fix is fairly urgent.