### PR TITLE
Removes Fun and Memes (Not a Changelog this Time)

### DIFF
--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -144,8 +144,7 @@ var/global/sent_syndicate_strike_team = 0
 	equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal(src), slot_glasses)
 
 	equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/security(src), slot_back)
-	equip_to_slot_or_del(new /obj/item/ammo_box/magazine/m762/buckshot, slot_in_backpack)
-	equip_to_slot_or_del(new /obj/item/ammo_box/magazine/m762/he, slot_in_backpack)
+	equip_to_slot_or_del(new /obj/item/ammo_box/magazine/m762, slot_in_backpack)
 
 	equip_to_slot_or_del(new /obj/item/ammo_box/magazine/m45(src), slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/hypospray/combat/nanites(src), slot_in_backpack)
@@ -163,7 +162,7 @@ var/global/sent_syndicate_strike_team = 0
 	equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen/double/full(src), slot_s_store)
 	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/pistol/m2411(src), slot_belt)
 
-	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/l6_saw/devastator(src), slot_r_hand)
+	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/l6_saw(src), slot_r_hand)
 
 	var/obj/item/weapon/card/id/syndicate/W = new(src) //Untrackable by AI
 	W.name = "[real_name]'s ID Card"


### PR DESCRIPTION
Partial revert of #3149. Makes Syndicate Strike Teams reasonable again by removing their HE and buckshot magazines, and giving them back their single spare L6 SAW magazine.

:cl:
del: Due to budget cuts and reports of operatives accidentally firing enough bullets to reach a state of what our scientists refer to as "enough dakka," Syndicate High Command has decided to restore the Syndicate Strike Team arsenal to using standard-issue L6 SAW ammunition.
/:cl: