### PR TITLE
Hydroponics Reagent Refactor

### DIFF
--- a/code/modules/hydroponics/hydro_reagents.dm
+++ b/code/modules/hydroponics/hydro_reagents.dm
@@ -1,0 +1,126 @@
+
+/obj/item/weapon/plantspray
+	icon = 'icons/obj/hydroponics_machines.dmi'
+	item_state = "spray"
+	flags = OPENCONTAINER | NOBLUDGEON
+	slot_flags = SLOT_BELT
+	throwforce = 4
+	w_class = 2.0
+	throw_speed = 2
+	throw_range = 10
+	var/toxicity = 4
+	var/pest_kill_str = 0
+	var/weed_kill_str = 0
+
+/obj/item/weapon/plantspray/weeds // -- Skie
+
+	name = "weed-spray"
+	desc = "It's a toxic mixture, in spray form, to kill small weeds."
+	icon_state = "weedspray"
+	weed_kill_str = 6
+
+/obj/item/weapon/plantspray/pests
+	name = "pest-spray"
+	desc = "It's some pest eliminator spray! <I>Do not inhale!</I>"
+	icon_state = "pestspray"
+	pest_kill_str = 6
+
+/obj/item/weapon/plantspray/pests/old
+	name = "bottle of pestkiller"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle16"
+
+/obj/item/weapon/plantspray/pests/old/carbaryl
+	name = "bottle of carbaryl"
+	icon_state = "bottle16"
+	toxicity = 4
+	pest_kill_str = 2
+
+/obj/item/weapon/plantspray/pests/old/lindane
+	name = "bottle of lindane"
+	icon_state = "bottle18"
+	toxicity = 6
+	pest_kill_str = 4
+
+/obj/item/weapon/plantspray/pests/old/phosmet
+	name = "bottle of phosmet"
+	icon_state = "bottle15"
+	toxicity = 8
+	pest_kill_str = 7
+
+
+// *************************************
+// Weedkiller defines for hydroponics
+// *************************************
+
+/obj/item/weedkiller
+	name = "bottle of weedkiller"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle16"
+	flags = OPENCONTAINER | NOBLUDGEON
+	var/toxicity = 0
+	var/weed_kill_str = 0
+
+/obj/item/weedkiller/triclopyr
+	name = "bottle of glyphosate"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle16"
+	toxicity = 4
+	weed_kill_str = 2
+
+/obj/item/weedkiller/lindane
+	name = "bottle of triclopyr"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle18"
+	toxicity = 6
+	weed_kill_str = 4
+
+/obj/item/weedkiller/D24
+	name = "bottle of 2,4-D"
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle15"
+	toxicity = 8
+	weed_kill_str = 7
+
+// *************************************
+// Nutrient defines for hydroponics
+// *************************************
+
+/obj/item/weapon/reagent_containers/glass/fertilizer
+	name = "fertilizer bottle"
+	desc = "A small glass bottle. Can hold up to 10 units."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle16"
+	flags = OPENCONTAINER
+	possible_transfer_amounts = null
+	w_class = 2.0
+
+	var/fertilizer //Reagent contained, if any.
+
+	//Like a shot glass!
+	amount_per_transfer_from_this = 10
+	volume = 10
+
+/obj/item/weapon/reagent_containers/glass/fertilizer/New()
+	..()
+
+	src.pixel_x = rand(-5.0, 5)
+	src.pixel_y = rand(-5.0, 5)
+
+	if(fertilizer)
+		reagents.add_reagent(fertilizer,10)
+
+/obj/item/weapon/reagent_containers/glass/fertilizer/ez
+	name = "bottle of E-Z-Nutrient"
+	icon_state = "bottle16"
+	fertilizer = "eznutrient"
+
+/obj/item/weapon/reagent_containers/glass/fertilizer/l4z
+	name = "bottle of Left 4 Zed"
+	icon_state = "bottle18"
+	fertilizer = "left4zed"
+
+/obj/item/weapon/reagent_containers/glass/fertilizer/rh
+	name = "bottle of Robust Harvest"
+	icon_state = "bottle15"
+	fertilizer = "robustharvest"

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -771,7 +771,7 @@
 // When the seed in this machine mutates/is modified, the tray seed value
 // is set to a new datum copied from the original. This datum won't actually
 // be put into the global datum list until the product is harvested, though.
-/datum/seed/proc/diverge(var/modified)
+/datum/seed/proc/diverge(var/modified = 0)
 
 	if(get_trait(TRAIT_IMMUTABLE) > 0) return
 
@@ -793,8 +793,17 @@
 	new_seed.modular_icon = modular_icon
 	new_seed.preset_icon = preset_icon
 
-	new_seed.seed_name =            "[(roundstart ? "[(modified ? "modified" : "mutant")] " : "")][seed_name]"
-	new_seed.display_name =         "[(roundstart ? "[(modified ? "modified" : "mutant")] " : "")][display_name]"
+	switch(modified)
+		if(0)	//Mutant (default)
+			new_seed.seed_name = "mutant [seed_name]"
+			new_seed.display_name = "mutant [seed_name]"
+		if(1)	//Modified
+			new_seed.seed_name = "modified [seed_name]"
+			new_seed.display_name = "modified [seed_name]"
+		if(2)	//Enhanced
+			new_seed.seed_name = "enhanced [seed_name]"
+			new_seed.display_name = "enhanced [seed_name]"
+
 	new_seed.seed_noun =            seed_noun
 	new_seed.traits = traits.Copy()
 	new_seed.update_growth_stages()

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -47,100 +47,13 @@
 	// Construction
 	var/unwrenchable = 1
 
-	// Reagent information for process(), consider moving this to a controller along
-	// with cycle information under 'mechanical concerns' at some point.
-	var/global/list/toxic_reagents = list(
-		"charcoal" =       -2,
-		"toxin" =			2,
-		"fluorine" =        2.5,
-		"chlorine" =        1.5,
-		"sacid" =           1.5,
-		"facid" =           3,
-		"atrazine" =     	3,
-		"cryoxadone" =     -3,
-		"radium" =          2
-		)
-	var/global/list/nutrient_reagents = list(
-		"milk" =            0.1,
-		"beer" =            0.25,
-		"phosphorus" =      0.1,
-		"sugar" =           0.1,
-		"sodawater" =       0.1,
-		"ammonia" =         1,
-		"diethylamine" =    2,
-		"nutriment" =       1,
-		"protein" =       	1.75,
-		"plantmatter" =     1.25,
-		"adminordrazine" =  1,
-		"eznutrient" =      1,
-		"robustharvest" =   1,
-		"left4zed" =        1,
-		"fishwater" =		0.75,
-		)
-	var/global/list/weedkiller_reagents = list(
-		"fluorine" =       -4,
-		"chlorine" =       -3,
-		"phosphorus" =     -2,
-		"sugar" =           2,
-		"sacid" =          -2,
-		"facid" =          -4,
-		"atrazine" =       -8,
-		"adminordrazine" = -5
-		)
-	var/global/list/pestkiller_reagents = list(
-		"sugar" =           2,
-		"diethylamine" =   -2,
-		"adminordrazine" = -5
-		)
-	var/global/list/water_reagents = list(
-		"water" =           list(1,    0),
-		"adminordrazine" =  list(1,    0),
-		"milk" =            list(0.9,  0),
-		"beer" =            list(0.7,  0),
-		"fluorine" =        list(-0.5, 0),
-		"chlorine" =        list(-0.5, 0),
-		"phosphorus" =      list(-0.5, 0),
-		"water" =           list(1,	   0),
-		"sodawater" =       list(1,    0),
-		"fishwater" =		list(1,    0),
-		"holywater" =		list(1,    0.1),
-		)
-
-	// Beneficial reagents also have values for modifying yield_mod and mut_mod (in that order).
-	var/global/list/beneficial_reagents = list(
-	//	"reagent" =			list(health, yield_Mod, mut_mod, production, potency),
-		"beer" =			list( -0.05,	0,		0,		  0,		0),
-		"fluorine" =		list( -2,		0,		0,		  0,		0),
-		"chlorine" =		list( -1,		0,		0,		  0,		0),
-		"phosphorus" =		list( -0.75,	0,		0,		  0,		0),
-		"sodawater" =		list(  0.1,		0,		0,		  0,		0),
-		"sacid" =			list( -1,		0,		0,		  0,		0),
-		"facid" =			list( -2,		0,		0,		  0,		0),
-		"atrazine" =		list( -2,		0,		0.2,	  0,		0),
-		"cryoxadone" =		list(  3,		0,		0,		  0,		0),
-		"ammonia" =			list(  0.5,		0,		0,	  	  0,		0),
-		"diethylamine" =	list(  1,		0,		0,	      0,		0),
-		"nutriment" =		list(  0.25,	0.15,	0,	      0,		0),
-		"protein" =			list(  0.25,	0.15,	0,		  0,		0),
-		"plantmatter" =		list(  0.25,	0.15,	0,		  0,		0),
-		"radium" =			list( -1.5,		0,		0.2,      0,		0),
-		"adminordrazine" =	list(  1,		1,		1,		  0,		0),
-		"robustharvest" =	list(  0,		0.2,	0,		  0,		0),
-		"left4zed" =		list(  0,		0,		0.2,	  0,		0),
-		"saltpetre" =		list(  0.25,	0,		0,	  	 -0.02,		0.01),
-		)
-
-	//--FalseIncarnate
-	// Mutagen list specifies reagent_min_value and reagent_step
-	// Reagent_min_value (value 1) is the minimum number of units needed to begin mutations
-	// Reagent_step (value 2) is the number of units between each mutation threshold
-	var/global/list/mutagenic_reagents = list(
-		"radium" =  list(10,10),
-		"mutagen" = list(1,5)
-		)
-	//--FalseIncarnate
-
 	var/last_plant_ikey		//This is for debugging reference, and is otherwise useless. --FalseIncarnate
+
+/*
+*	process() can be found in \code\modules\hydroponics\tray\tray_process.dm
+*	reagent handling can be found in \code\modules\hydroponics\tray\tray_reagents.dm
+*	icon handling can be found in \code\modules\hydroponics\tray\tray_update_icons.dm
+*/
 
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
 	if(mechanical && !usr.stat && !usr.lying && Adjacent(usr))
@@ -241,86 +154,6 @@
 	harvest = 0
 	weedlevel += 1 * HYDRO_SPEED_MULTIPLIER
 	pestlevel = 0
-
-//Process reagents being input into the tray.
-/obj/machinery/portable_atmospherics/hydroponics/proc/process_reagents()
-
-	if(!reagents) return
-
-	if(reagents.total_volume <= 0)
-		return
-
-/*	I have plans for this at a later date, so it's just being commented out for now --FalseIncarnate
-
-	reagents.trans_to(temp_chem_holder, min(reagents.total_volume,rand(1,3)))
-
-	for(var/datum/reagent/R in temp_chem_holder.reagents.reagent_list)
-
-		var/reagent_total = temp_chem_holder.reagents.get_reagent_amount(R.id)
-*/
-
-	for(var/datum/reagent/R in reagents.reagent_list)
-
-		var/reagent_total = reagents.get_reagent_amount(R.id)
-
-		if(seed && !dead)
-			//Handle some general level adjustments.
-			if(toxic_reagents[R.id])
-				toxins += toxic_reagents[R.id]         * reagent_total
-			if(weedkiller_reagents[R.id])
-				weedlevel -= weedkiller_reagents[R.id] * reagent_total
-			if(pestkiller_reagents[R.id])
-				pestlevel += pestkiller_reagents[R.id] * reagent_total
-
-			// Beneficial reagents have a few impacts along with health buffs.
-			if(beneficial_reagents[R.id])
-				health += beneficial_reagents[R.id][1] * reagent_total
-				yield_mod = min(100, yield_mod + (beneficial_reagents[R.id][2] * reagent_total))
-				mutation_mod += beneficial_reagents[R.id][3] * reagent_total
-				if(seed.get_trait(TRAIT_PRODUCTION) > 1)
-					seed.set_trait(TRAIT_PRODUCTION, max(2, seed.get_trait(TRAIT_PRODUCTION) + beneficial_reagents[R.id][4] * reagent_total))
-				seed.set_trait(TRAIT_POTENCY, min(100, seed.get_trait(TRAIT_POTENCY) + beneficial_reagents[R.id][5] * reagent_total))
-
-			// Mutagen is distinct from the previous types and mostly has a chance of proccing a mutation.
-
-			//--FalseIncarnate
-			// Mutation rework, will now use "thresholds" for proccing types of mutations and their respective chances.
-			// This should make it easier to avoid species shifts when trying to only affect stats like potency.
-			// Additionally, the chance of mutations will vary depending on the amount of mutagenic reagents added.
-			if(mutagenic_reagents[R.id])
-				var/reagent_min_value = mutagenic_reagents[R.id][1]					//10 for radium, 1 for unstable mutagen
-				var/reagent_step =     mutagenic_reagents[R.id][2]					//10 for radium, 5 for unstable mutagen
-
-				if(reagent_total >= reagent_min_value + (3 * reagent_step))			//31+ for radium, 16+ for unstable mutagen
-					mutate(4)
-				else if(reagent_total >= reagent_min_value + (2 * reagent_step))	//21-30 for radium, 11-15 for unstable mutagen
-					mutate(3)
-				else if(reagent_total >= reagent_min_value + reagent_step)			//11-20 for radium, 6-10 for unstable mutagen
-					mutate(2)
-				else if(reagent_total >= reagent_min_value)							//1-10 for radium, 1-5 for unstable mutagen
-					mutate(1)
-
-			//--FalseIncarnate
-
-		// Handle nutrient refilling.
-		if(nutrient_reagents[R.id])
-			nutrilevel += nutrient_reagents[R.id]  * reagent_total
-
-		// Handle water and water refilling.
-		var/water_added = 0
-		if(water_reagents[R.id])
-			var/water_input = water_reagents[R.id][1] * reagent_total
-			water_added += water_input
-			waterlevel += water_input
-			health += water_reagents[R.id][2] * reagent_total
-
-		// Water dilutes toxin level.
-		if(water_added > 0)
-			toxins -= round(water_added/4)
-
-//	temp_chem_holder.reagents.clear_reagents()
-	reagents.clear_reagents()
-	check_health()
 
 //Harvests the product of a plant.
 /obj/machinery/portable_atmospherics/hydroponics/proc/harvest(var/mob/user)
@@ -528,11 +361,12 @@
 		health = 0
 		dead = 0
 
-	nutrilevel =     max(0,min(nutrilevel,maxnutri))
-	waterlevel =     max(0,min(waterlevel,maxwater))
-	pestlevel =      max(0,min(pestlevel,10))
-	weedlevel =      max(0,min(weedlevel,10))
-	toxins =         max(0,min(toxins,10))
+	nutrilevel =	max(0,min(nutrilevel,maxnutri))
+	waterlevel =	max(0,min(waterlevel,maxwater))
+	pestlevel =		max(0,min(pestlevel,10))
+	weedlevel =		max(0,min(weedlevel,10))
+	toxins =		max(0,min(toxins,10))
+	yield_mod =		min(100, yield_mod)
 
 /obj/machinery/portable_atmospherics/hydroponics/proc/mutate_species()
 

--- a/code/modules/hydroponics/trays/tray_reagents.dm
+++ b/code/modules/hydroponics/trays/tray_reagents.dm
@@ -1,126 +1,213 @@
 
-/obj/item/weapon/plantspray
-	icon = 'icons/obj/hydroponics_machines.dmi'
-	item_state = "spray"
-	flags = OPENCONTAINER | NOBLUDGEON
-	slot_flags = SLOT_BELT
-	throwforce = 4
-	w_class = 2.0
-	throw_speed = 2
-	throw_range = 10
-	var/toxicity = 4
-	var/pest_kill_str = 0
-	var/weed_kill_str = 0
+//Process reagents being put into the tray.
+/obj/machinery/portable_atmospherics/hydroponics/proc/process_reagents()
 
-/obj/item/weapon/plantspray/weeds // -- Skie
+	if(!reagents) return
 
-	name = "weed-spray"
-	desc = "It's a toxic mixture, in spray form, to kill small weeds."
-	icon_state = "weedspray"
-	weed_kill_str = 6
+	if(reagents.total_volume <= 0)
+		return
 
-/obj/item/weapon/plantspray/pests
-	name = "pest-spray"
-	desc = "It's some pest eliminator spray! <I>Do not inhale!</I>"
-	icon_state = "pestspray"
-	pest_kill_str = 6
+	for(var/datum/reagent/R in reagents.reagent_list)
 
-/obj/item/weapon/plantspray/pests/old
-	name = "bottle of pestkiller"
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
+		var/reagent_total = reagents.get_reagent_amount(R.id)
 
-/obj/item/weapon/plantspray/pests/old/carbaryl
-	name = "bottle of carbaryl"
-	icon_state = "bottle16"
-	toxicity = 4
-	pest_kill_str = 2
-
-/obj/item/weapon/plantspray/pests/old/lindane
-	name = "bottle of lindane"
-	icon_state = "bottle18"
-	toxicity = 6
-	pest_kill_str = 4
-
-/obj/item/weapon/plantspray/pests/old/phosmet
-	name = "bottle of phosmet"
-	icon_state = "bottle15"
-	toxicity = 8
-	pest_kill_str = 7
+		//These are here because they have checks that would clutter up the switch statement cases, and thus get handled after the switch (readability)
+		var/water_value = 0
+		var/health_value = 0
+		var/production_stat_value = 0
+		var/potency_stat_value = 0
 
 
-// *************************************
-// Weedkiller defines for hydroponics
-// *************************************
+		switch(R.id)
+		/* EXAMPLE:
+		*
+		*	if("example")
+		*		//Nutrients
+		*		nutrilevel += reagent_total * <nutrient value>
+		*
+		*		//Water
+		*		water_value = <water value>
+		*
+		*		//Toxins
+		*		toxins += reagent_total * <toxin value>
+		*
+		*		//Weeds and Pests
+		*		weedlevel += reagent_total * <weed value>
+		*		pestlevel += reagent_total * <pest value>
+		*
+		*		//Mutagens
+		*		handle_mutagens(reagent_total, <min_value>, <step_value>)
+		*
+		*		//Modifiers
+		*		yield_mod += reagent_total * <yield_mod value>
+		*		mutation_mod += reagent_total * <mutation_mod vlaue>
+		*
+		*		//Health
+		*		health_value = <health value>
+		*
+		*		//Production Stat
+		*		production_stat_value = <production stat value>
+		*
+		*		//Potency Stat
+		*		potency_stat_value = <potency stat value>
+		*
+		*/
 
-/obj/item/weedkiller
-	name = "bottle of weedkiller"
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
-	flags = OPENCONTAINER | NOBLUDGEON
-	var/toxicity = 0
-	var/weed_kill_str = 0
+			if("adminordrazine")
+				nutrilevel += reagent_total * 1
+				water_value = 1
+				weedlevel += reagent_total * -5
+				pestlevel += reagent_total * -5
+				yield_mod += reagent_total * 1
+				mutation_mod += reagent_total * 1
+				health_value = 1
+			if("ammonia")
+				nutrilevel += reagent_total * 1
+				health_value = 0.5
+			if("atrazine")
+				toxins += reagent_total * 3
+				weedlevel += reagent_total * -8
+				mutation_mod += reagent_total * 0.2
+				health_value = -2
+			if("beer")
+				nutrilevel += reagent_total * 0.25
+				water_value = 0.7
+				health_value = -0.05
+			if("charcoal")
+				toxins += reagent_total * -2
+			if("chlorine")
+				water_value = -0.5
+				toxins += reagent_total * 1.5
+				weedlevel += reagent_total * -3
+				health_value = -1
+			if("cryoxadone")
+				toxins += reagent_total * -3
+				if(seed && !dead)
+					health += reagent_total * 3
+			if("diethylamine")
+				nutrilevel += reagent_total * 2
+				pestlevel += reagent_total * -2
+				health_value = 1
+			if("eznutrient")
+				nutrilevel += reagent_total * 1
+			if("facid")
+				toxins += reagent_total * 3
+				weedlevel += reagent_total * -4
+				health_value = -2
+			if("fishwater")
+				nutrilevel += reagent_total * 0.75
+				water_value = 1
+			if("fluorine")
+				water_value = -0.5
+				toxins = reagent_total * 2.5
+				weedlevel += reagent_total * -4
+				health_value = -2
+			if("holywater")
+				water_value = 1
+				health_value = 0.1
+			if("left4zed")
+				nutrilevel += reagent_total * 1
+				mutation_mod += reagent_total * 0.2
+			if("milk")
+				nutrilevel += reagent_total * 0.1
+				water_value = 0.9
+			if("mutagen")
+				handle_mutagens(reagent_total, 1, 5)
+			if("nutriment")
+				nutrilevel += reagent_total * 1
+				yield_mod += reagent_total * 0.15
+				health_value = 0.25
+			if("phosphorus")
+				nutrilevel += reagent_total * 0.1
+				water_value = -0.5
+				weedlevel += reagent_total * -2
+				health_value = -0.75
+			if("plantmatter")
+				nutrilevel += reagent_total * 1.25
+				yield_mod += reagent_total * 0.15
+				health_value = 0.25
+			if("protein")
+				nutrilevel += reagent_total * 1.75
+				yield_mod += reagent_total * 0.15
+				health_value = 0.25
+			if("radium")
+				toxins += reagent_total * 2
+				handle_mutagens(reagent_total, 10, 10)
+				mutation_mod += reagent_total * 0.2
+				health_value = -1.5
+			if("robustharvest")
+				nutrilevel += reagent_total * 1
+				yield_mod += reagent_total * 0.2
+			if("sacid")
+				toxins += reagent_total * 1.5
+				weedlevel += reagent_total * -2
+				health_value = -1
+			if("saltpetre")
+				health_value = 0.25
+				production_stat_value = -0.02
+				potency_stat_value = 0.01
+			if("sodawater")
+				nutrilevel += reagent_total * 0.1
+				water_value = 1
+				health_value = 0.1
+			if("sugar")
+				nutrilevel += reagent_total * 0.1
+				weedlevel += reagent_total * 2
+				pestlevel += reagent_total * 2
+			if("toxin")
+				toxins += reagent_total * 2
+			if("water")
+				water_value = 1
 
-/obj/item/weedkiller/triclopyr
-	name = "bottle of glyphosate"
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
-	toxicity = 4
-	weed_kill_str = 2
+		//END SWITCH
 
-/obj/item/weedkiller/lindane
-	name = "bottle of triclopyr"
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle18"
-	toxicity = 6
-	weed_kill_str = 4
+		//Handle water changes
+		if(water_value)
+			var/water_change = 0
+			water_change = reagent_total * water_value
+			waterlevel += water_change
+			if(water_value > 0)		//adding water dilutes toxins
+				toxins -= round(water_change/4)
 
-/obj/item/weedkiller/D24
-	name = "bottle of 2,4-D"
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle15"
-	toxicity = 8
-	weed_kill_str = 7
+		//Handle health and stat changes (these require a non-dead seed to be present)
+		if(seed && !dead)
+			//Health
+			if(health_value)
+				health += reagent_total * health_value
+			//Stats
+			if(seed.get_trait(TRAIT_IMMUTABLE) <= 0)
+				//Production
+				if(production_stat_value && seed.get_trait(TRAIT_PRODUCTION) > 2)
+					if(!isnull(plant_controller.seeds[seed.name]))	//This is so we don't affect plants in other trays unintentionally
+						seed = seed.diverge(2)						//ENHANCE!
+					var/new_production = seed.get_trait(TRAIT_PRODUCTION) + (reagent_total * production_stat_value)
+					seed.set_trait(TRAIT_PRODUCTION, max(2, new_production))		//can't drop below 2 with this method
+				//Potency
+				if(potency_stat_value)
+					if(!isnull(plant_controller.seeds[seed.name]))	//This is so we don't affect plants in other trays unintentionally
+						seed = seed.diverge(2)						//ENHANCE!
+					var/new_potency = seed.get_trait(TRAIT_POTENCY) + (reagent_total * potency_stat_value)
+					seed.set_trait(TRAIT_POTENCY, max(0, min(100, new_potency)))		//can't go above 100 or below 0 with this method
 
-// *************************************
-// Nutrient defines for hydroponics
-// *************************************
+	//END FOR LOOP
 
-/obj/item/weapon/reagent_containers/glass/fertilizer
-	name = "fertilizer bottle"
-	desc = "A small glass bottle. Can hold up to 10 units."
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle16"
-	flags = OPENCONTAINER
-	possible_transfer_amounts = null
-	w_class = 2.0
+	reagents.clear_reagents()
+	check_health()		//This calls check_level_sanity, which is why it's not called from here directly
 
-	var/fertilizer //Reagent contained, if any.
+/obj/machinery/portable_atmospherics/hydroponics/proc/handle_mutagens(var/amount, var/min_amount, var/step_amount)
+	//shouldn't be getting called without having reagent values supplied
+	if(!amount || !step_amount || !step_amount)
+		return
+	//shouldn't be getting called with negative values
+	if(amount < 0 || min_amount < 0 || step_amount < 0)
+		return
 
-	//Like a shot glass!
-	amount_per_transfer_from_this = 10
-	volume = 10
-
-/obj/item/weapon/reagent_containers/glass/fertilizer/New()
-	..()
-
-	src.pixel_x = rand(-5.0, 5)
-	src.pixel_y = rand(-5.0, 5)
-
-	if(fertilizer)
-		reagents.add_reagent(fertilizer,10)
-
-/obj/item/weapon/reagent_containers/glass/fertilizer/ez
-	name = "bottle of E-Z-Nutrient"
-	icon_state = "bottle16"
-	fertilizer = "eznutrient"
-
-/obj/item/weapon/reagent_containers/glass/fertilizer/l4z
-	name = "bottle of Left 4 Zed"
-	icon_state = "bottle18"
-	fertilizer = "left4zed"
-
-/obj/item/weapon/reagent_containers/glass/fertilizer/rh
-	name = "bottle of Robust Harvest"
-	icon_state = "bottle15"
-	fertilizer = "robustharvest"
+	if(amount > min_amount)
+		if(amount >= min_amount + (3 * step_amount))
+			mutate(4)
+		else if(amount >= min_amount + (2 * step_amount))
+			mutate(3)
+		else if(amount >= min_amount + step_amount)
+			mutate(2)
+		else if(amount >= min_amount)
+			mutate(1)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1236,6 +1236,7 @@
 #include "code\modules\hydroponics\grown.dm"
 #include "code\modules\hydroponics\grown_inedible.dm"
 #include "code\modules\hydroponics\grown_predefined.dm"
+#include "code\modules\hydroponics\hydro_reagents.dm"
 #include "code\modules\hydroponics\seed.dm"
 #include "code\modules\hydroponics\seed_controller.dm"
 #include "code\modules\hydroponics\seed_datums.dm"


### PR DESCRIPTION
Move the hydroponics reagent items (plant sprays, fertilizer bottles, etc) into a new file: hydro_reagents.dm
- Re-used old file, see next line

Refactors the reagent handling of hydroponics trays
- Now located in tray_reagents.dm (formerly in tray.dm)
 - No longer relies on global lists that weren't global and were on all trays' variables lists.
- Reagent effects are now grouped together rather than spread across multiple lists of values with little to no meaning
 - Far more readable if you are looking for everything a reagent does in hydroponics trays
 - Included an example entry for future coders who want to add new reagent interactions to hydro trays

Fixes saltpetre affecting the entire seed datum when added to a single tray
- Now diverges and makes a new line of "enhanced" products, which is then modified
 - More consistent with how mutagens handle affecting stats, but "enhanced"

Moved the yield_mod capping to check_sanity_levels() instead of the reagent interaction
- Cap unchanged, this just moves it to a more standard location in the code

Small tweak to stat-affecting reagent interaction
- Now checks for a production value of over 2 before attempting to adjust (previously looked for > 1)
 - Couldn't be dropped below 2 anyways, so it was a waste of time to try lowering it and then resetting it to 2 when it was there already
- Now caps the potency value between 0 and 100, as a negative potency makes no sense.
 - Currently no reagents lower potency, so this is more of a future-proofing than a correction

:cl:
tweak: Allows plants to be identified as enhanced*. Enhancing plants results from using reagents (like saltpetre) that affect the stats of a seed instead of using mutagens/machines. *May not meet standards for being classified as "organic produce". (This was already possible, just renames enhanced plants for easier differentiation)
/:cl: