### PR TITLE
Ais can now hear their radio again

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -57,7 +57,9 @@
 
 	return ..()
 
-/obj/item/device/radio/headset/receive_range(freq, level)
+/obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
+	if(aiOverride)
+		return ..(freq, level)
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(H.l_ear == src || H.r_ear == src)


### PR DESCRIPTION
Fixes #3391 
If only there were a neater way to skip a level of parent calls, but alas, this code must stay, lest we have deaf AIs
:cl:
bugfix: For a short while, there was a clerical error where all AI communications equipment was replaced with bananas. This has now been fixed.
/:cl: