### PR TITLE
Ghosts can now see additional machines

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -249,6 +249,9 @@
 /obj/machinery/smartfridge/attack_ai(mob/user as mob)
 	return 0
 
+/obj/machinery/smartfridge/attack_ghost(mob/user as mob)
+	return src.attack_hand(user)
+
 /obj/machinery/smartfridge/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN))
 		return

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -23,6 +23,13 @@
 		user << "\red Access denied."
 		return
 
+	interact(user)
+
+/obj/machinery/computer/drone_control/attack_ghost(mob/user as mob)
+	interact(user)
+
+/obj/machinery/computer/drone_control/interact(mob/user)
+
 	user.set_machine(src)
 	var/dat
 	dat += "<B>Maintenance Units</B><BR>"


### PR DESCRIPTION
Let me know of any other machines ghosts can't look at, that they should!

:cl:
tweak: Ghosts can now see the contents of smartfridges and look at the drone console
/:cl: