### PR TITLE
No more duplicate shake messages on SSD people

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -261,10 +261,11 @@ mob/living
 				AdjustStunned(-3)
 				AdjustWeakened(-3)
 				playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-				M.visible_message( \
-					"\blue [M] shakes [src] trying to wake [t_him] up!", \
-					"\blue You shake [src] trying to wake [t_him] up!", \
-					)
+				if(!player_logged)
+					M.visible_message( \
+						"\blue [M] shakes [src] trying to wake [t_him] up!", \
+						"\blue You shake [src] trying to wake [t_him] up!", \
+						)
 			// BEGIN HUGCODE - N3X
 			else
 				if (istype(src,/mob/living/carbon/human) && src:w_uniform)


### PR DESCRIPTION
:cl:
tweak: Humans now only produce one message when shaken while SSD
/:cl: