### PR TITLE
Brainmobs can no longer ethereal jaunt

### DIFF
--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -19,6 +19,9 @@
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/cast(list/targets) //magnets, so mostly hardcoded
 	for(var/mob/living/target in targets)
+		if(!target.can_safely_leave_loc()) // No more brainmobs hopping out of their brains
+			target << "<span class='warning'>You are somehow too bound to your current location to abandon it.</span>"
+			continue
 		spawn(0)
 
 			if(target.buckled)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -96,3 +96,6 @@ I'm using this for Stat to give it a more nifty interface to work with
 				var/obj/mecha/M = src.loc
 				stat("Exosuit Charge:", "[istype(M.cell) ? "[M.cell.charge] / [M.cell.maxcharge]" : "No cell detected"]")
 				stat("Exosuit Integrity", "[!M.health ? "0" : "[(M.health / initial(M.health)) * 100]"]%")
+
+/mob/living/carbon/brain/can_safely_leave_loc()
+	return 0 //You're not supposed to be ethereal jaunting, brains

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1437,3 +1437,7 @@ mob/proc/yank_out_object()
 //Can the mob see reagents inside of containers?
 /mob/proc/can_see_reagents()
 	return 0
+
+//Can this mob leave its location without breaking things terrifically?
+/mob/proc/can_safely_leave_loc()
+	return 1 // Yes, you can


### PR DESCRIPTION
Fixes #3401 
:cl:
bugfix: Brains are no longer able to escape their brain by being a sorcerer.
/:cl: