### PR TITLE
Fixes Kahlua, Silencer, and BananaHonk

### DIFF
--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -663,40 +663,6 @@
 	..()
 	return
 
-/datum/reagent/ethanol/bananahonk
-	name = "Banana Mama"
-	id = "bananahonk"
-	description = "A drink from Clown Heaven."
-	nutriment_factor = 1 * FOOD_METABOLISM
-	color = "#664300" // rgb: 102, 67, 0
-
-/datum/reagent/ethanol/bananahonk/on_mob_life(var/mob/living/M as mob)
-	M.nutrition += nutriment_factor
-	if(istype(M, /mob/living/carbon/human) && M.job in list("Clown"))
-		if(!M) M = holder.my_atom
-		M.heal_organ_damage(1,1)
-		M.nutrition += nutriment_factor
-		..()
-		return
-	..()
-
-/datum/reagent/ethanol/silencer
-	name = "Silencer"
-	id = "silencer"
-	description = "A drink from Mime Heaven."
-	nutriment_factor = 1 * FOOD_METABOLISM
-	color = "#664300" // rgb: 102, 67, 0
-
-/datum/reagent/ethanol/silencer/on_mob_life(var/mob/living/M as mob)
-	M.nutrition += nutriment_factor
-	if(istype(M, /mob/living/carbon/human) && M.job in list("Mime"))
-		if(!M) M = holder.my_atom
-		M.heal_organ_damage(1,1)
-		M.nutrition += nutriment_factor
-		..()
-		return
-	..()
-
 /datum/reagent/ethanol/changelingsting
 	name = "Changeling Sting"
 	id = "changelingsting"
@@ -753,4 +719,18 @@
 		M.confused = max(M.confused+15,15)
 	..()
 
+	return
+
+/datum/reagent/ethanol/kahlua
+	name = "Kahlua"
+	id = "kahlua"
+	description = "A widely known, Mexican coffee-flavoured liqueur. In production since 1936!"
+	color = "#664300" // rgb: 102, 67, 0
+
+/datum/reagent/ethanol/kahlua/on_mob_life(var/mob/living/M as mob)
+	M.dizziness = max(0,M.dizziness-5)
+	M.drowsyness = max(0,M.drowsyness-3)
+	M.sleeping = max(0,M.sleeping-2)
+	M.Jitter(5)
+	..()
 	return

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
@@ -264,16 +264,36 @@
 	color = "#104038" // rgb: 16, 64, 56
 	adj_temp = -5
 
-/datum/reagent/drink/kahlua
-	name = "Kahlua"
-	id = "kahlua"
-	description = "A widely known, Mexican coffee-flavoured liqueur. In production since 1936!"
+/datum/reagent/drink/bananahonk
+	name = "Banana Mama"
+	id = "bananahonk"
+	description = "A drink from Clown Heaven."
+	nutriment_factor = 1 * FOOD_METABOLISM
 	color = "#664300" // rgb: 102, 67, 0
-	adj_dizzy = -5
-	adj_drowsy = -3
-	adj_sleepy = -2
 
-/datum/reagent/drink/kahlua/on_mob_life(var/mob/living/M as mob)
+/datum/reagent/drink/bananahonk/on_mob_life(var/mob/living/M as mob)
+	M.nutrition += nutriment_factor
+	if(istype(M, /mob/living/carbon/human) && M.job in list("Clown"))
+		if(!M) M = holder.my_atom
+		M.heal_organ_damage(1,1)
+		M.nutrition += nutriment_factor
+		..()
+		return
 	..()
-	M.Jitter(5)
-	return
+
+/datum/reagent/drink/silencer
+	name = "Silencer"
+	id = "silencer"
+	description = "A drink from Mime Heaven."
+	nutriment_factor = 1 * FOOD_METABOLISM
+	color = "#664300" // rgb: 102, 67, 0
+
+/datum/reagent/drink/silencer/on_mob_life(var/mob/living/M as mob)
+	M.nutrition += nutriment_factor
+	if(istype(M, /mob/living/carbon/human) && M.job in list("Mime"))
+		if(!M) M = holder.my_atom
+		M.heal_organ_damage(1,1)
+		M.nutrition += nutriment_factor
+		..()
+		return
+	..()


### PR DESCRIPTION
Fixes banana honk and silencer so they're no longer alcoholic
 - Something with cream+sugar+<signature non-alcoholic reagent> shouldn't be alcoholic 

Fixes Kahlua so it's actually alcoholic

:cl: Fox McCloud
bugfix: Fixes banana honk and silencer being alcoholic
bugfix: Fixes Kahlua being non-alcoholic
/:cl: