### PR TITLE
Fixes Unlimited Boxes

### DIFF
--- a/code/modules/store/store.dm
+++ b/code/modules/store/store.dm
@@ -26,7 +26,9 @@ var/global/datum/store/centcomm_store=new
 
 /datum/store/New()
 	for(var/itempath in subtypesof(/datum/storeitem))
-		items += new itempath()
+		var/datum/storeitem/s = new itempath
+		if(s.name == "Thing") continue //for some reason this is the only thing that works.
+		items += s
 
 /datum/store/proc/charge(var/datum/mind/mind,var/amount,var/datum/storeitem/item)
 	if(!mind.initial_account)


### PR DESCRIPTION
Fixes being able to purchase free, unlimited boxes from the merchandise store.

If anyone else has a better way of fixing this, please, let me know, because this is hacky as shit and I hate it.

:cl: Fox McCloud
bugfix: Fixes being able to purchase free unlimited boxes from the merchandise store
/:cl: