### PR TITLE
Makes the DNA scanner less stupid

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -518,7 +518,7 @@
 		occupantData["structuralEnzymes"] = null
 		occupantData["radiationLevel"] = null
 	else
-		occupantData["name"] = connected.occupant.name
+		occupantData["name"] = connected.occupant.dna.real_name
 		occupantData["stat"] = connected.occupant.stat
 		occupantData["isViableSubject"] = 1
 		if ((NOCLONE in connected.occupant.mutations && connected.scan_level < 3) || !src.connected.occupant.dna)
@@ -853,7 +853,7 @@
 				databuf.types = DNA2_BUF_UI|DNA2_BUF_UE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.real_name=connected.occupant.dna.real_name
 				databuf.name = "Unique Identifier + Unique Enzymes"
 				src.buffers[bufferId] = databuf
 			return 1
@@ -864,7 +864,7 @@
 				databuf.types = DNA2_BUF_SE
 				databuf.dna = src.connected.occupant.dna.Clone()
 				if(ishuman(connected.occupant))
-					databuf.dna.real_name=connected.occupant.name
+					databuf.dna.real_name=connected.occupant.dna.real_name
 				databuf.name = "Structural Enzymes"
 				src.buffers[bufferId] = databuf
 			return 1

--- a/html/changelogs/crazylemon-dnascanner_fix.yml
+++ b/html/changelogs/crazylemon-dnascanner_fix.yml
@@ -1,0 +1,4 @@
+author: Crazylemon
+delete-after: True
+changes: 
+  - bugfix: "The DNA scanner has now undergone a seminar to recognize fake identities; It will now scan the actual person's identity, rather than their disguise (read: wearing a mask with or without someone else's ID)."


### PR DESCRIPTION
For some bizarre reason, the DNA scanner worked off of the occupant's `name`, rather than the `real_name` of their actual DNA, causing it to read the identities of people differently depending on whether they wore a mask or not.

Fixes #3419 