### PR TITLE
Adds a brain scan mode to the cloning system

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -196,7 +196,7 @@
 			loading = 0
 			nanomanager.update_uis(src)
 
-	if (href_list["scan_brain"] && scanner && scanner.occupant)
+	if (href_list["scan_brain"] && scanner && scanner.occupant && scanner.scan_level > 3)
 		scantemp = "Scanner ready."
 
 		loading = 1
@@ -390,9 +390,15 @@
 
 	var/datum/dna2/record/R = new /datum/dna2/record()
 	R.ckey = subject.ckey
+	var/extra_info = ""
 	if(scan_brain)
 		var/obj/item/organ/B = subject.internal_organs_by_name["brain"]
+		B.dna.check_integrity()
 		R.dna=B.dna.Clone()
+		var/datum/species/S = all_species[R.dna.species]
+		if(S.flags & NO_SCAN)
+			extra_info = "Proper genetic interface not found, defaulting to genetic data of the body."
+			R.dna.species = subject.species.name
 		R.id= copytext(md5(B.dna.real_name), 2, 6)
 		R.name=B.dna.real_name
 	else
@@ -416,7 +422,7 @@
 		R.mind = "\ref[subject.mind]"
 
 	src.records += R
-	scantemp = "Subject successfully scanned."
+	scantemp = "Subject successfully scanned. " + extra_info
 	nanomanager.update_uis(src)
 
 //Find a specific record by key.

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -361,6 +361,14 @@
 		scantemp = "<span class=\"bad\">Error: Unable to locate valid genetic data.</span>"
 		nanomanager.update_uis(src)
 		return
+	if("brain" in subject.internal_organs_by_name)
+		var/obj/item/organ/brain/Brn = subject.internal_organs_by_name["brain"]
+		if(istype(Brn))
+			var/datum/species/S = all_species[Brn.dna.species] // stepladder code wooooo
+			if(S.flags & NO_SCAN)
+				scantemp = "<span class=\"bad\">Error: Subject's brain is incompatible.</span>"
+				nanomanager.update_uis(src)
+				return
 	if (subject.brain_op_stage == 4.0)
 		scantemp = "<span class=\"bad\">Error: No signs of intelligence detected.</span>"
 		nanomanager.update_uis(src)

--- a/html/changelogs/crazylemon-cloning_brain_scan.yml
+++ b/html/changelogs/crazylemon-cloning_brain_scan.yml
@@ -1,4 +1,0 @@
-author: Crazylemon
-delete-after: True
-changes: 
-  - rscadd: "A cloner with a tier-4 scanner will now be able to scan the brains of bodies within it, giving a chance for people who've otherwise lost their original corpse and identity."

--- a/html/changelogs/crazylemon-cloning_brain_scan.yml
+++ b/html/changelogs/crazylemon-cloning_brain_scan.yml
@@ -1,0 +1,4 @@
+author: Crazylemon
+delete-after: True
+changes: 
+  - rscadd: "A cloner with a tier-4 scanner will now be able to scan the brains of bodies within it, giving a chance for people who've otherwise lost their original corpse and identity."

--- a/nano/templates/cloning_console.tmpl
+++ b/nano/templates/cloning_console.tmpl
@@ -57,16 +57,18 @@ Used In File(s): \code\game\machinery\computer\cloning.dm
 			<div class="itemLabelNarrow">Scan Occupant</div>
 			<div class="itemContentWide">{{:helper.link('Scan', 'search', {'scan' : 1}, !data.occupant ? 'disabled' : '')}}</div>
 		</div>
-		{{if data.can_brainscan}}
-		<div class="item">
-			<div class="itemLabelNarrow">Scan Brain</div>
-			<div class="itemContentWide">{{:helper.link('Scan', 'search', {'scan_brain' : 1}, !data.occupant ? 'disabled' : '')}}</div>
-		</div>
-		{{/if}}
 		<div class="item">
 			<div class="itemLabelNarrow">Scanner Lock</div>
 			<div class="itemContentWide">{{if data.occupant}}{{:helper.link('Engaged', 'lock', {'lock' : 1}, data.locked ? 'selected' : '')}}{{else}} {{:helper.link('Engaged', 'lock', null, 'disabled')}}{{/if}}{{:helper.link('Disengaged', 'unlock', {'lock' : 1}, !data.locked ? 'selected' : '')}}</div>
 		</div>
+		{{if data.can_brainscan}}
+		<div class="item">
+			<div class="itemLabelNarrow">Scan Mode</div>
+			<div class="itemContentWide">
+				{{:helper.link('Brain', null, {'toggle_mode' : 1}, !data.scan_mode ? '' : 'selected')}}{{:helper.link('Body', null, {'toggle_mode' : 1}, data.scan_mode ? '' : 'selected')}}
+			</div>
+		</div>
+		{{/if}}
 	{{/if}}
 	{{if data.numberofpods}}
 		<h2>Pods</h2>

--- a/nano/templates/cloning_console.tmpl
+++ b/nano/templates/cloning_console.tmpl
@@ -56,11 +56,17 @@ Used In File(s): \code\game\machinery\computer\cloning.dm
 		<div class="item">
 			<div class="itemLabelNarrow">Scan Occupant</div>
 			<div class="itemContentWide">{{:helper.link('Scan', 'search', {'scan' : 1}, !data.occupant ? 'disabled' : '')}}</div>
-		</div>		
+		</div>
+		{{if data.can_brainscan}}
+		<div class="item">
+			<div class="itemLabelNarrow">Scan Brain</div>
+			<div class="itemContentWide">{{:helper.link('Scan', 'search', {'scan_brain' : 1}, !data.occupant ? 'disabled' : '')}}</div>
+		</div>
+		{{/if}}
 		<div class="item">
 			<div class="itemLabelNarrow">Scanner Lock</div>
 			<div class="itemContentWide">{{if data.occupant}}{{:helper.link('Engaged', 'lock', {'lock' : 1}, data.locked ? 'selected' : '')}}{{else}} {{:helper.link('Engaged', 'lock', null, 'disabled')}}{{/if}}{{:helper.link('Disengaged', 'unlock', {'lock' : 1}, !data.locked ? 'selected' : '')}}</div>
-		</div>	
+		</div>
 	{{/if}}
 	{{if data.numberofpods}}
 		<h2>Pods</h2>


### PR DESCRIPTION
A tier-4 DNA scanner will now allow you to scan from the DNA of the brain of a corpse, in event of the original body getting gibbed, and will also allow a possible return route for non-standard races that doesn't involve them being "Monkey (387)" forever, anymore.
:cl:
tweak: The cloner now checks for NO_SCAN on the brain when scanning - unclonable species are now truly unclonable. You are still able to revive them with a brain transplant and a defib, however.
rscadd: A tier-4 DNA scanner linked to a cloning system will now be able to reproduce a body from a brain's DNA, in event of the original corpse being gibbed or similar.
/:cl: