### PR TITLE
Re-adds remote syndicate borg access to places

### DIFF
--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -30,21 +30,6 @@
 		return STATUS_INTERACTIVE	// interactive (green visibility)
 	return STATUS_DISABLED			// no updates, completely disabled (red visibility)
 
-/mob/living/silicon/robot/syndicate/default_can_use_topic(var/src_object)
-	. = ..()
-	if(. != STATUS_INTERACTIVE)
-		return
-
-	if(z in config.admin_levels)						// Syndicate borgs can interact with everything on the admin level
-		return STATUS_INTERACTIVE
-	if(istype(get_area(src), /area/syndicate_station))	// If elsewhere, they can interact with everything on the syndicate shuttle
-		return STATUS_INTERACTIVE
-	if(istype(src_object, /obj/machinery))				// Otherwise they can only interact with emagged machinery
-		var/obj/machinery/Machine = src_object
-		if(Machine.emagged)
-			return STATUS_INTERACTIVE
-	return STATUS_UPDATE
-
 /mob/living/silicon/ai/default_can_use_topic(var/src_object)
 	. = shared_nano_interaction()
 	if(. != STATUS_INTERACTIVE)


### PR DESCRIPTION
Syndicate cyborgs can now interact with doors and machines again
:cl:
bugfix: Syndicate borgs can now interact with station machinery
/:cl: