### PR TITLE
Skrell's alcohol weakness is tracked on the liver

### DIFF
--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -36,7 +36,8 @@
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species && (H.species.name == "Skrell" || H.species.name =="Neara"))	 //Skrell and Neara get very drunk very quickly.
+		var/obj/item/organ/liver/L = H.internal_organs_by_name["liver"]
+		if(!L || (istype(L) && L.dna.species in list("Skrell", "Neara")))
 			d*=5
 
 	M.dizziness += dizzy_adj.


### PR DESCRIPTION
Since aurorablade told me to stop waiting

:cl:
tweak: Skrell's vulnerability to alcohol is checked on their liver, now - a liver transplant will let them take alcohol like a champ - lacking a liver will have the same effect as being a skrell, when drinking
/:cl: