### PR TITLE
Fixes AI not being able to call the shuttle

### DIFF
--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -221,7 +221,7 @@
 	adding += using
 
 //Shuttle
-	using = new /obj/screen/ai/announcement()
+	using = new /obj/screen/ai/call_shuttle()
 	using.name = "Call Emergency Shuttle"
 	using.icon = 'icons/mob/screen_ai.dmi'
 	using.icon_state = "call_shuttle"


### PR DESCRIPTION
The AI was previously unable to call the shuttle. When clicked, the button would bring up the announcement input box instead of the shuttle reason