### PR TITLE
Fixes #3425

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -882,8 +882,8 @@ About the new airlock wires panel:
 		src.closeOther.close()
 	return ..()
 
-/obj/machinery/door/airlock/close(var/forced=0)
-	if(operating || welded || locked)
+/obj/machinery/door/airlock/close(var/forced=0, var/override = 0)
+	if((operating & !override) || welded || locked)
 		return
 	if(!forced)
 		//despite the name, this wire is for general door control.
@@ -918,11 +918,11 @@ About the new airlock wires panel:
 	operating = 1
 	do_animate("closing")
 	src.layer = 3.1
-	sleep(5)
+	if (!override) sleep(5)
 	src.density = 1
 	if(!safe)
 		crush()
-	sleep(5)
+	if(!override) sleep(5)
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -402,12 +402,14 @@
 					var/obj/machinery/door/Door = O
 					spawn(-1)
 						if(Door)
-							Door.close()
 							if(istype(Door, /obj/machinery/door/airlock))
 								var/obj/machinery/door/airlock/A = Door
+								A.close(0,1)
 								if(A.id_tag == "s_docking_airlock")
 									A.lock()
 									door_unlock_list += A
+							else
+								Door.close()
 			else if (istype(AM,/mob))
 				var/mob/M = AM
 				if(!M.move_on_shuttle)


### PR DESCRIPTION
There were a couple of things going on... the spawn(-1) which should
have meant that the door shut straight away was being negated by the
sleeps. Also, If the door had just been used, it would still be marked
as operating and so wouldn't shut