### PR TITLE
Fixed continuous rounds

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -36,7 +36,7 @@
 	var/feature_object_spell_system = 0 //spawns a spellbook which gives object-type spells instead of verb-type spells for the wizard
 	var/traitor_scaling = 0 			//if amount of traitors scales based on amount of players
 	var/protect_roles_from_antagonist = 0// If security and such can be tratior/cult/other
-	var/continous_rounds = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
+	var/continuous_rounds = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
 	var/allow_Metadata = 0				// Metadata is supported.
 	var/popup_admin_pm = 0				//adminPMs to non-admins show in a pop-up 'reply' window when set to 1.
 	var/Ticklag = 0.9
@@ -449,7 +449,7 @@
 					config.gateway_delay = text2num(value)
 
 				if("continuous_rounds")
-					config.continous_rounds = 1
+					config.continuous_rounds = 1
 
 				if("ghost_interaction")
 					config.ghost_interaction = 1

--- a/code/datums/spells/lichdom.dm
+++ b/code/datums/spells/lichdom.dm
@@ -20,9 +20,9 @@
 	action_icon_state = "skeleton"
 
 /obj/effect/proc_holder/spell/targeted/lichdom/New()
-	if(!config.continous_rounds)
+	if(!config.continuous_rounds)
 		existence_stops_round_end = 1
-		config.continous_rounds = 1
+		config.continuous_rounds = 1
 	..()
 
 /obj/effect/proc_holder/spell/targeted/lichdom/Destroy()
@@ -31,7 +31,7 @@
 			if(istype(S,/obj/effect/proc_holder/spell/targeted/lichdom) && S != src)
 				return ..()
 	if(existence_stops_round_end)
-		config.continous_rounds = 0
+		config.continuous_rounds = 0
 	return ..()
 
 /obj/effect/proc_holder/spell/targeted/lichdom/cast(list/targets,mob/user = usr)

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -148,7 +148,7 @@
 	if (station_captured && !to_nuke_or_not_to_nuke)
 		return 1
 	if (is_malf_ai_dead())
-		if(config.continous_rounds)
+		if(config.continuous_rounds)
 			if(shuttle_master && shuttle_master.emergencyNoEscape)
 				shuttle_master.emergencyNoEscape = 0
 			malf_mode_declared = 0

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -203,15 +203,11 @@
 //Checks if the round is over//
 ///////////////////////////////
 /datum/game_mode/revolution/check_finished()
-	if(config.continous_rounds)
+	if(config.continuous_rounds)
 		if(finished != 0)
 			if(shuttle_master && shuttle_master.emergencyNoEscape)
 				shuttle_master.emergencyNoEscape = 0
-		return ..()
-	if(finished != 0)
-		return 1
-	else
-		return 0
+	return finished != 0
 
 ///////////////////////////////////////////////////
 //Deals with converting players to the revolution//

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -203,10 +203,6 @@
 
 
 /datum/game_mode/wizard/check_finished()
-
-	if(config.continous_rounds)
-		return ..()
-
 	var/wizards_alive = 0
 	var/traitors_alive = 0
 	for(var/datum/mind/wizard in wizards)

--- a/code/game/gamemodes/xenos/xenos.dm
+++ b/code/game/gamemodes/xenos/xenos.dm
@@ -135,15 +135,7 @@
 		return ..()
 
 /datum/game_mode/xenos/check_finished()
-	if(config.continous_rounds)
-		if(result)
-			return ..()
-	if(shuttle_master && shuttle_master.emergency.mode >= SHUTTLE_ESCAPE)
-		return ..()
-	if(result || station_was_nuked)
-		return 1
-	else
-		return 0
+	return result != 0
 
 /datum/game_mode/xenos/proc/xenos_alive()
 	var/list/livingxenos = list()


### PR DESCRIPTION
* Renamed the var to actually be spelled correctly
* Game modes no longer need to be `continuous_round` aware, and in fact cannot jam the game from ending due to shuttle arriving at centcom (although some are still continuous_round aware to allow the shuttle to leave again, if they prevented it).
* Hopefully, this doesn't break any game modes, as I only tested wizard (the canonical round-ending gamemode).
* Fixes #3450 