### PR TITLE
Shuttle fixes

### DIFF
--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -27,12 +27,6 @@
 #define SHUTTLE_TRANSIT_DURATION		300	// 5 minutes = 300 seconds - how long it takes for the shuttle to get to the station
 #define SHUTTLE_TRANSIT_DURATION_RETURN 120	// 2 minutes = 120 seconds - for some reason it takes less time to come back, go figure.
 
-//Shuttle moving status
-#define SHUTTLE_IDLE		0
-#define SHUTTLE_WARMUP		1
-#define SHUTTLE_INTRANSIT	2
-#define SHUTTLE_STRANDED	3
-
 //Ferry shuttle processing status
 #define IDLE_STATE		0
 #define WAIT_LAUNCH		1

--- a/code/controllers/Processes/shuttles.dm
+++ b/code/controllers/Processes/shuttles.dm
@@ -120,7 +120,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 
 	var/area/signal_origin = get_area(user)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
-	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
 		emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1)
 	else
 		emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
@@ -142,7 +142,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 		return
 	if(ticker.mode.name == "meteor")
 		return
-	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED)
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED)
 		if(emergency.timeLeft(1) < emergencyCallTime * 0.25)
 			return
 	else

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -111,10 +111,7 @@
 	..()
 	statpanel("Status")
 
-	if(shuttle_master.emergency.mode >= SHUTTLE_RECALL)
-		var/timeleft = shuttle_master.emergency.timeLeft()
-		if(timeleft > 0)
-			stat(null, "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]")
+	show_stat_emergency_shuttle_eta()
 
 	if (client.statpanel == "Status")
 		stat("Chemicals", chemicals)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -437,7 +437,7 @@
 			user << "Under directive 7-10, [station_name()] is quarantined until further notice."
 			return
 
-	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
 		shuttle_master.emergency.request(null, 0.5, null, " Automatic Crew Transfer", 1)
 	else
 		shuttle_master.emergency.request(null, 1, null, " Automatic Crew Transfer", 0)

--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -57,13 +57,6 @@
 		else
 			integrated_ai.get_rig_stats = 0
 
-/mob/living/Stat()
-	. = ..()
-	if(. && get_rig_stats)
-		var/obj/item/weapon/rig/rig = get_rig()
-		if(rig)
-			SetupStat(rig)
-
 /obj/item/rig_module/ai_container/proc/update_verb_holder()
 	if(!verb_holder)
 		verb_holder = new(src)

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -225,13 +225,6 @@
 /obj/item/rig_module/proc/accepts_item(var/obj/item/input_device)
 	return 0
 
-/mob/living/carbon/human/Stat()
-	. = ..()
-
-	if(. && istype(back,/obj/item/weapon/rig))
-		var/obj/item/weapon/rig/R = back
-		SetupStat(R)
-
 /mob/proc/SetupStat(var/obj/item/weapon/rig/R)
 	if(R && (R.flags & NODROP) && R.installed_modules.len && statpanel("Hardsuit Modules"))
 		var/cell_status = R.cell ? "[R.cell.charge]/[R.cell.maxcharge]" : "ERROR"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -210,7 +210,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	..()
 	statpanel("Status")
 	if (client.statpanel == "Status")
-		stat(null, "Station Time: [worldtime2text()]")
+		show_stat_station_time()
 		if(ticker)
 			if(ticker.mode)
 				//world << "DEBUG: ticker not null"
@@ -218,10 +218,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					//world << "DEBUG: malf mode ticker test"
 					if(ticker.mode:malf_mode_declared)
 						stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
-		if(shuttle_master.emergency.mode >= SHUTTLE_RECALL)
-			var/timeleft = shuttle_master.emergency.timeLeft()
-			if(timeleft > 0)
-				stat(null, "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]")
+		show_stat_emergency_shuttle_eta()
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -181,10 +181,7 @@
 	if (client.statpanel == "Status")
 		stat(null, "Plasma Stored: [getPlasma()]/[max_plasma]")
 
-	if(shuttle_master.emergency.mode >= SHUTTLE_RECALL)
-		var/timeleft = shuttle_master.emergency.timeLeft()
-		if(timeleft > 0)
-			stat(null, "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]")
+	show_stat_emergency_shuttle_eta()
 
 /mob/living/carbon/alien/Stun(amount)
 	if(status_flags & CANSTUN)

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -83,12 +83,8 @@ I'm using this for Stat to give it a more nifty interface to work with
 	..()
 	if(has_synthetic_assistance())
 		statpanel("Status")
-		stat(null, "Station Time: [worldtime2text()]")
-
-		if(shuttle_master.emergency.mode >= SHUTTLE_RECALL)
-			var/timeleft = shuttle_master.emergency.timeLeft()
-			if(timeleft > 0)
-				stat(null, "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]")
+		show_stat_station_time()
+		show_stat_emergency_shuttle_eta()
 
 		if(client.statpanel == "Status")
 			//Knowing how well-off your mech is doing is really important as an MMI

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -252,15 +252,13 @@
 	stat(null, "Intent: [a_intent]")
 	stat(null, "Move Mode: [m_intent]")
 
-	stat(null, "Station Time: [worldtime2text()]")
+	show_stat_station_time()
 
 	if(ticker && ticker.mode && ticker.mode.name == "AI malfunction")
 		if(ticker.mode:malf_mode_declared)
 			stat(null, "Time left: [max(ticker.mode:AI_win_timeleft/(ticker.mode:apcs/3), 0)]")
-	if(shuttle_master.emergency.mode >= SHUTTLE_RECALL)
-		var/timeleft = shuttle_master.emergency.timeLeft()
-		if(timeleft > 0)
-			stat(null, "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]")
+
+	show_stat_emergency_shuttle_eta()
 
 	if(client.statpanel == "Status")
 		if(locate(/obj/item/device/assembly/health) in src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2,6 +2,13 @@
 /mob/living/Destroy()
 	..()
 	return QDEL_HINT_HARDDEL_NOW
+	
+/mob/living/Stat()
+	. = ..()
+	if(. && get_rig_stats)
+		var/obj/item/weapon/rig/rig = get_rig()
+		if(rig)
+			SetupStat(rig)
 
 //mob verbs are a lot faster than object verbs
 //for more info on why this is not atom/pull, see examinate() in mob.dm

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -142,25 +142,11 @@
 	return 0
 
 
-// this function displays the station time in the status panel
-/mob/living/silicon/proc/show_station_time()
-	stat(null, "Station Time: [worldtime2text()]")
-
-
-// this function displays the shuttles ETA in the status panel if the shuttle has been called
-/mob/living/silicon/proc/show_emergency_shuttle_eta()
-	if(shuttle_master.emergency.mode >= SHUTTLE_RECALL)
-		var/timeleft = shuttle_master.emergency.timeLeft()
-		if(timeleft > 0)
-			stat(null, "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]")
-
-
-
 // This adds the basic clock, shuttle recall timer, and malf_ai info to all silicon lifeforms
 /mob/living/silicon/Stat()
 	if(statpanel("Status"))
-		show_station_time()
-		show_emergency_shuttle_eta()
+		show_stat_station_time()
+		show_stat_emergency_shuttle_eta()
 		show_system_integrity()
 		show_malf_ai()
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -990,6 +990,36 @@ var/list/slot_equipment_priority = list( \
 
 	statpanel("Status") // Switch to the Status panel again, for the sake of the lazy Stat procs
 
+// this function displays the station time in the status panel
+/mob/proc/show_stat_station_time()
+	stat(null, "Station Time: [worldtime2text()]")
+
+// this function displays the shuttles ETA in the status panel if the shuttle has been called
+/mob/proc/show_stat_emergency_shuttle_eta()
+	var/obj/docking_port/mobile/emergency/E = shuttle_master.emergency
+
+	if(E.mode >= SHUTTLE_RECALL)
+		var/message = ""
+
+		var/timeleft = E.timeLeft()
+		message = "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
+
+		switch(E.mode)
+			if(SHUTTLE_RECALL, SHUTTLE_ESCAPE)
+				message = "ETR-[message]"
+			if(SHUTTLE_CALL)
+				message = "ETA-[message]"
+			if(SHUTTLE_DOCKED)
+				if(timeleft < 5)
+					message = "Departing..."
+				else
+					message = "ETD-[message]"
+			if(SHUTTLE_STRANDED)
+				message = "ETA-ERR"
+			if(SHUTTLE_ENDGAME)
+				return
+
+		stat(null, message)
 
 /mob/proc/add_stings_to_statpanel(var/list/stings)
 	for(var/obj/effect/proc_holder/changeling/S in stings)


### PR DESCRIPTION
I assume _all_ security levels above red should have the 5 minute shuttle time, if it comes at all. Arguably the shuttle time should be comically slow for Epsilon, but I like the cleanness of just changing the operator.
* Fixes #3454

I restored the old ETA- / ETD- shuttle status label. I made it be ETR- for when it's returning to CentCom because it always bugged me that it moving in either direction was labelled the same way. 
* I'm going to avoid the magic cløsing words, but this was a line in #2883.
* There was also some pre-tg-shuttle constants that actively conflict and are overridden 10 lines down.

:cl:
rscadd: The emergency shuttle status in the Status tab now has ETA/ETD/etc like before.
tweak: Code Gamma+ now has a 5 minute emergency shuttle call, like Red.
/:cl: