### PR TITLE
Better species suicide support

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -1,5 +1,54 @@
 /mob/var/suiciding = 0
 
+/mob/living/carbon/human/proc/do_suicide(damagetype, byitem)
+	var/threshold = (config.health_threshold_crit + config.health_threshold_dead) / 2
+	var/dmgamt = maxHealth - threshold
+	
+	var/damage_mod = 1
+	switch(damagetype) //Sorry about the magic numbers.
+					   //brute = 1, burn = 2, tox = 4, oxy = 8
+		if(15) //4 damage types
+			damage_mod = 4
+
+		if(6, 11, 13, 14) //3 damage types
+			damage_mod = 3
+
+		if(3, 5, 7, 9, 10, 12) //2 damage types
+			damage_mod = 2
+
+		if(1, 2, 4, 8) //1 damage type
+			damage_mod = 1
+
+		else //This should not happen, but if it does, everything should still work
+			damage_mod = 1
+
+	//Do dmgamt damage divided by the number of damage types applied.
+	if(damagetype & BRUTELOSS)
+		adjustBruteLoss(dmgamt / damage_mod)
+
+	if(damagetype & FIRELOSS)
+		adjustFireLoss(dmgamt / damage_mod)
+
+	if(damagetype & TOXLOSS)
+		adjustToxLoss(dmgamt / damage_mod)
+
+	if(damagetype & OXYLOSS)
+		adjustOxyLoss(dmgamt / damage_mod)
+
+	// Failing that...
+	if(!(damagetype & BRUTELOSS) && !(damagetype & FIRELOSS) && !(damagetype & TOXLOSS) && !(damagetype & OXYLOSS))
+		if(species.flags & NO_BREATHE)
+			// the ultimate fallback
+			take_overall_damage(max(dmgamt - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0), 0)
+		else
+			adjustOxyLoss(max(dmgamt - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
+
+	var/obj/item/organ/external/affected = get_organ("head")
+	if(affected)
+		affected.add_autopsy_data(byitem ? "Suicide by [byitem]" : "Suicide", dmgamt)
+
+	updatehealth()
+
 /mob/living/carbon/human/verb/suicide()
 	set hidden = 1
 
@@ -24,56 +73,11 @@
 		if(held_item)
 			var/damagetype = held_item.suicide_act(src)
 			if(damagetype)
-				var/damage_mod = 1
-				switch(damagetype) //Sorry about the magic numbers.
-								   //brute = 1, burn = 2, tox = 4, oxy = 8
-					if(15) //4 damage types
-						damage_mod = 4
-
-					if(6, 11, 13, 14) //3 damage types
-						damage_mod = 3
-
-					if(3, 5, 7, 9, 10, 12) //2 damage types
-						damage_mod = 2
-
-					if(1, 2, 4, 8) //1 damage type
-						damage_mod = 1
-
-					else //This should not happen, but if it does, everything should still work
-						damage_mod = 1
-
-				//Do 175 damage divided by the number of damage types applied.
-				if(damagetype & BRUTELOSS)
-					adjustBruteLoss(175/damage_mod)
-
-				if(damagetype & FIRELOSS)
-					adjustFireLoss(175/damage_mod)
-
-				if(damagetype & TOXLOSS)
-					adjustToxLoss(175/damage_mod)
-
-				if(damagetype & OXYLOSS)
-					adjustOxyLoss(175/damage_mod)
-
-				//If something went wrong, just do normal oxyloss
-				if(!(damagetype | BRUTELOSS) && !(damagetype | FIRELOSS) && !(damagetype | TOXLOSS) && !(damagetype | OXYLOSS))
-					adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-
-				var/obj/item/organ/external/affected = get_organ("head")
-				affected.add_autopsy_data("Suicide by [held_item]", 175)
-
-				updatehealth()
+				do_suicide(damagetype, held_item)
 				return
 
-
-		viewers(src) << pick("\red <b>[src] is attempting to bite \his tongue off! It looks like \he's trying to commit suicide.</b>", \
-							"\red <b>[src] is jamming \his thumbs into \his eye sockets! It looks like \he's trying to commit suicide.</b>", \
-							"\red <b>[src] is twisting \his own neck! It looks like \he's trying to commit suicide.</b>", \
-							"\red <b>[src] is holding \his breath! It looks like \he's trying to commit suicide.</b>")
-		adjustOxyLoss(max(175 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
-
-		var/obj/item/organ/external/affected = get_organ("head")
-		affected.add_autopsy_data("Suicide", 175)
+		viewers(src) << "<span class=danger>[src] [pick(species.suicide_messages)] It looks like they're trying to commit suicide.</span>"
+		do_suicide(0)
 
 		updatehealth()
 

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -17,6 +17,9 @@
 	has_organ = list(
 		"brain" = /obj/item/organ/brain/golem
 		)
+	suicide_messages = list(
+		"is crumbling into dust!",
+		"is smashing their body apart!")
 
 /datum/species/golem/handle_post_spawn(var/mob/living/carbon/human/H)
 	if(H.mind)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -20,6 +20,11 @@
 	bodyflags = FEET_NOSLIP
 	dietflags = DIET_OMNI		//the mutation process allowed you to now digest all foods regardless of initial race
 	reagent_tag = PROCESS_ORG
+	suicide_messages = list(
+		"is attempting to bite their tongue off!",
+		"is jamming their claws into their eye sockets!",
+		"is twisting their own neck!",
+		"is staring into the closest light source!")
 
 /datum/species/shadow/handle_death(var/mob/living/carbon/human/H)
 	H.dust()

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -31,3 +31,8 @@
 	heat_level_2 = 999999999
 	heat_level_3 = 999999999
 	heat_level_3_breathe = 999999999
+	
+	suicide_messages = list(
+		"is snapping their own bones!",
+		"is collapsing into a pile!",
+		"is twisting their skull off!")

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -88,6 +88,11 @@
 
 	//Death vars.
 	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
+	var/list/suicide_messages = list(
+		"is attempting to bite their tongue off!",
+		"is jamming their thumbs into their eye sockets!",
+		"is twisting their own neck!",
+		"is holding their breath!")
 
 	// Language/culture vars.
 	var/default_language = "Galactic Common" // Default language is used when 'say' is used without modifiers.

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -55,6 +55,12 @@
 	flesh_color = "#34AF10"
 	reagent_tag = PROCESS_ORG
 	base_color = "#066000"
+	
+	suicide_messages = list(
+		"is attempting to bite their tongue off!",
+		"is jamming their claws into their eye sockets!",
+		"is twisting their own neck!",
+		"is holding their breath!")
 
 /datum/species/unathi/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
@@ -100,6 +106,12 @@
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
+	
+	suicide_messages = list(
+		"is attempting to bite their tongue off!",
+		"is jamming their claws into their eye sockets!",
+		"is twisting their own neck!",
+		"is holding their breath!")
 
 /datum/species/tajaran/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
@@ -135,6 +147,12 @@
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#966464"
 	base_color = "#B43214"
+	
+	suicide_messages = list(
+		"is attempting to bite their tongue off!",
+		"is jamming their claws into their eye sockets!",
+		"is twisting their own neck!",
+		"is holding their breath!")
 
 /datum/species/vulpkanin/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
@@ -206,6 +224,13 @@
 	flesh_color = "#808D11"
 
 	reagent_tag = PROCESS_ORG
+	
+	suicide_messages = list(
+		"is attempting to bite their tongue off!",
+		"is jamming their claws into their eye sockets!",
+		"is twisting their own neck!",
+		"is holding their breath!",
+		"is deeply inhaling oxygen!")
 
 /datum/species/vox/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
@@ -292,6 +317,13 @@
 		"eyes" =     /obj/item/organ/eyes,
 		"stack" =    /obj/item/organ/stack/vox
 		)
+	
+	suicide_messages = list(
+		"is attempting to bite their tongue off!",
+		"is jamming their claws into their eye sockets!",
+		"is twisting their own neck!",
+		"is holding their breath!",
+		"is huffing oxygen!")
 
 /datum/species/kidan
 	name = "Kidan"
@@ -311,6 +343,12 @@
 	dietflags = DIET_HERB
 	blood_color = "#FB9800"
 	reagent_tag = PROCESS_ORG
+	
+	suicide_messages = list(
+		"is attempting to bite their antenna off!",
+		"is jamming their claws into their eye sockets!",
+		"is twisting their own neck!",
+		"is holding their breath!")
 
 /datum/species/slime
 	name = "Slime People"
@@ -333,6 +371,10 @@
 	has_organ = list(
 		"brain" = /obj/item/organ/brain/slime
 		)
+		
+	suicide_messages = list(
+		"is melting into a puddle!",
+		"is turning a dull, brown color and melting into a puddle!")
 
 /datum/species/grey
 	name = "Grey"
@@ -433,6 +475,10 @@
 		"l_foot" = list("path" = /obj/item/organ/external/diona/foot),
 		"r_foot" = list("path" = /obj/item/organ/external/diona/foot/right)
 		)
+		
+	suicide_messages = list(
+		"is losing branches!",
+		"is pulling themselves apart!")
 
 /datum/species/diona/can_understand(var/mob/other)
 	var/mob/living/simple_animal/diona/D = other
@@ -526,6 +572,12 @@
 		"l_foot" = list("path" = /obj/item/organ/external/foot/ipc),
 		"r_foot" = list("path" = /obj/item/organ/external/foot/right/ipc)
 		)
+	
+	suicide_messages = list(
+		"is powering down!",
+		"is smashing their own monitor!",
+		"is twisting their own neck!",
+		"is blocking their ventilation port!")
 
 /datum/species/machine/handle_death(var/mob/living/carbon/human/H)
 	H.h_style = ""


### PR DESCRIPTION
This was originally to address species that couldn't commit suicide due to `NO_BREATHE` (it's not just IPC's!), but turned into a refactor/cleanup of the `suicide` verb. Then, I decided to let the species datum change the open-hand suicide messages.
* Fixes #3452 
* suicide also acknowledges the config's damage threshold settings and the person's max health now.

:cl:
bugfix: Species that don't breathe can kill themselves now!
rscadd: Suicide messages are now catered to your species.
/:cl: