### PR TITLE
Species now can have reagent-specific reactions

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -609,3 +609,10 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	if(!(organ_slot in has_organ))
 		return null
 	return has_organ[organ_slot]
+
+// Do species-specific reagent handling here
+// Return 1 if it should do normal processing too
+// Return 0 if it shouldn't deplete and do its normal effect
+// Other return values will cause weird badness
+/datum/species/proc/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
+	return 1

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -139,6 +139,40 @@
 /datum/species/vulpkanin/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
+/datum/species/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
+	if(R.id in list("coco", "hot_coco", "chocolate_milk", "chocolate"))
+		// I have no idea if chocolate is THIS bad for dogs, but I guess this should get the point across
+		if(prob(20))
+			H.emote(pick("twitch","drool", "quiver"))
+		if(prob(10))
+			H.emote("scream")
+			H.drop_l_hand()
+			H.drop_r_hand()
+		if(prob(5))
+			H.confused = max(H.confused, 3)
+		if(prob(15))
+			H.fakevomit()
+		if(prob(2))
+			H.visible_message("<span class='danger'>[H] starts having a seizure!</span>", "<span class='danger'>You have a seizure!</span>")
+			H.Paralyse(5)
+			H.jitteriness = 1000
+		if(R.current_cycle >= 5)
+			H.jitteriness += 10
+		if(R.current_cycle >= 20)
+			if(prob(5))
+				H.emote("collapse")
+		switch(R.current_cycle)
+			if(0 to 60)
+				H.adjustBrainLoss(1)
+				H.adjustToxLoss(1)
+			if(61 to INFINITY)
+				H.adjustBrainLoss(2)
+				H.adjustToxLoss(2)
+				H.Paralyse(5)
+				H.losebreath += 5
+		return 1
+	return ..()
+
 /datum/species/skrell
 	name = "Skrell"
 	name_plural = "Skrell"

--- a/code/modules/reagents/newchem/newchem_procs.dm
+++ b/code/modules/reagents/newchem/newchem_procs.dm
@@ -32,9 +32,14 @@ datum/reagents/proc/metabolize(var/mob/M)
 				//Species with PROCESS_DUO are only affected by reagents that affect both organics and synthetics, like acid and hellwater
 				if((R.process_flags & ORGANIC) && (R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_DUO))
 					can_process = 1
+
+			//If handle_reagents returns 0, it's doing the reagent removal on its own
+			var/species_handled = !(H.species.handle_reagents(H, R))
+			can_process = can_process && !species_handled
 			//If the mob can't process it, remove the reagent at it's normal rate without doing any addictions, overdoses, or on_mob_life() for the reagent
 			if(can_process == 0)
-				R.holder.remove_reagent(R.id, R.metabolization_rate)
+				if(!species_handled)
+					R.holder.remove_reagent(R.id, R.metabolization_rate)
 				continue
 		//We'll assume that non-human mobs lack the ability to process synthetic-oriented reagents (adjust this if we need to change that assumption)
 		else


### PR DESCRIPTION
This is a first go of a system to give each species the ability to react uniquely to each reagent!

For demonstration purposes, chocolate-type reagents act as tabun to Vulpkanin - this might be a bit too intense. Let me know your thoughts!

:cl:
tweak: Species can now respond uniquely to reagents
rscadd: Chocolate reagents are now terrible for Vulpkanin
/:cl: