### PR TITLE
Enhances symbiosis of Borers

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -243,6 +243,8 @@
 	set name = "Secrete Chemicals (30)"
 	set desc = "Push some chemicals into your host's bloodstream."
 
+	var/injection_amount = 9
+	var/chem_cost = 30
 	if(!host)
 		src << "You are not inside a host body."
 		return
@@ -254,17 +256,24 @@
 		src << "\blue You are feeling far too docile to do that."
 		return
 
-	if(chemicals < 30)
+	if(chemicals < chem_cost)
 		src << "You don't have enough chemicals!"
 
-	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("mannitol","styptic_powder","methamphetamine","sal_acid")
 
-	if(!chem || chemicals < 30 || !host || controlling || !src || stat) //Sanity check.
+	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("mannitol","salglu_solution","methamphetamine","sal_acid", "hydrocodone", "spaceacillin", "mitocholide", "charcoal")
+
+	if(!chem || chemicals < chem_cost || !host || controlling || !src || stat) //Sanity check.
 		return
 
-	src << "\red <B>You squirt a measure of [chem] from your reservoirs into [host]'s bloodstream.</B>"
-	host.reagents.add_reagent(chem, 9)
-	chemicals -= 30
+	var/chem_amount = host.reagents.get_reagent_amount(chem)
+	var/datum/reagent/R = chemical_reagents_list[chem]
+	if(R.overdose_threshold && chem_amount + injection_amount > R.overdose_threshold)
+		src << "<span class='warning'>Doing so would cause grievous harm to your host, reducing ability to reproduce. Aborting.</span>"
+		return
+
+	src << "<span class='notice'>You squirt a measure of [chem] from your reservoirs into [host]'s bloodstream.</span>"
+	host.reagents.add_reagent(chem, injection_amount)
+	chemicals -= chem_cost
 
 /mob/living/simple_animal/borer/verb/release_host()
 	set category = "Alien"

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -260,7 +260,7 @@
 		src << "You don't have enough chemicals!"
 
 
-	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("mannitol","salglu_solution","methamphetamine","sal_acid", "hydrocodone", "spaceacillin", "mitocholide", "charcoal", "salbutamol", "capulettium_plus")
+	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("mannitol","salglu_solution","methamphetamine", "hydrocodone", "spaceacillin", "mitocholide", "charcoal", "salbutamol", "capulettium_plus")
 
 	if(!chem || chemicals < chem_cost || !host || controlling || !src || stat) //Sanity check.
 		return

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -260,7 +260,7 @@
 		src << "You don't have enough chemicals!"
 
 
-	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("mannitol","salglu_solution","methamphetamine","sal_acid", "hydrocodone", "spaceacillin", "mitocholide", "charcoal")
+	var/chem = input("Select a chemical to secrete.", "Chemicals") as null|anything in list("mannitol","salglu_solution","methamphetamine","sal_acid", "hydrocodone", "spaceacillin", "mitocholide", "charcoal", "salbutamol", "capulettium_plus")
 
 	if(!chem || chemicals < chem_cost || !host || controlling || !src || stat) //Sanity check.
 		return

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -60,6 +60,10 @@
 		src << "You can't commit suicide before the game starts!"
 		return
 
+	// No more borergrief, one way or the other
+	if(has_brain_worms())
+		src << "You try to bring yourself to commit suicide, but - something prevents you!"
+		return
 
 	if (suiciding)
 		src << "You're already committing suicide! Be patient!"


### PR DESCRIPTION
Prevents borers and borer hosts from directly suiciding.
Also prevents borers from deliberately OD'ing their host.
Adds the listed chems below to the injection list, and removes styptic powder - 9u of styptic heals only 6 points of brute, which is about the amount of damage you'd take from a stiff breeze.

:cl:
tweak: People with borers cannot commit suicide - this applies to a controlling borer, too.
tweak: Borers can no longer overdose their hosts.
tweak: Borers can now inject Saline-Glucose, Spaceacillin, Hydrocodone, Mitocholide, Salbutamol, Capulettium+, and Charcoal. Styptic was removed, as it's pathetic at healing when directly injected. Salicyclic acid was removed too, as its functionality is duplicated by both hydrocodone and saline-glucose.
/:cl:
Perhaps the chems bit needs a bit of tweaking, but this should help improve human-borer relations.