### PR TITLE
Buckets and set transfer amount improvement

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -12,9 +12,13 @@
 	set name = "Set transfer amount"
 	set category = "Object"
 	set src in range(0)
+
 	if(usr.stat || !usr.canmove || usr.restrained())
 		return
-	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
+	var/default = null
+	if(amount_per_transfer_from_this in possible_transfer_amounts)
+		default = amount_per_transfer_from_this
+	var/N = input("Amount per transfer from this:", "[src]", default) as null|anything in possible_transfer_amounts
 	if (N)
 		amount_per_transfer_from_this = N
 

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -336,7 +336,7 @@
 	materials = list(MAT_METAL=200)
 	w_class = 3.0
 	amount_per_transfer_from_this = 20
-	possible_transfer_amounts = list(5,10,15,25,30,50,80,100,120)
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,80,100,120)
 	volume = 120
 	flags = OPENCONTAINER
 


### PR DESCRIPTION
You can now set a bucket's transfer amount to 20, which is its default.
* Fixes #3491 

I also made it so the Set Tranfer Amount `input` uses the current value as the default.