### PR TITLE
Loyalty Implants protects against Shadowling thralling

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -305,6 +305,11 @@
 					target << "<span class='danger'>Your gaze is forcibly drawn into a blinding red light. You fall to the floor as conscious thought is wiped away.</span>"
 					target.Weaken(12)
 					sleep(20)
+					if(isloyal(target))
+						usr << "<span class='notice'>They are enslaved by Nanotrasen.</span>"
+						usr.visible_message("<span class='boldannounce'>[usr] stops, failing to subvert [target]'s loyalty implant.</span>")
+						target << "<span class='boldannounce'>You feel your loyalties holding true!</span>"
+						return
 				if(3)
 					usr << "<span class='notice'>You begin rearranging [target]'s memories.</span>"
 					usr.visible_message("<span class='danger'>[usr]'s eyes flare brightly.</span>")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -305,17 +305,6 @@
 					target << "<span class='danger'>Your gaze is forcibly drawn into a blinding red light. You fall to the floor as conscious thought is wiped away.</span>"
 					target.Weaken(12)
 					sleep(20)
-					if(isloyal(target))
-						usr << "<span class='notice'>They are enslaved by Nanotrasen. You begin to shut down the nanobot implant - this will take some time.</span>"
-						usr.visible_message("<span class='boldannounce'>[usr] halts for a moment, then begins passing its hand over [target]'s body.</span>")
-						target << "<span class='boldannounce'>You feel your loyalties begin to weaken!</span>"
-						sleep(150) //15 seconds - not spawn() so the enthralling takes longer
-						usr << "<span class='notice'>The nanobots composing the loyalty implant have been rendered inert. Now to continue.</span>"
-						usr.visible_message("<span class='danger'>[usr] halts thier hand and resumes staring into [target]'s face.</span>")
-						for(var/obj/item/weapon/implant/loyalty/L in target)
-							if(L && L.implanted)
-								qdel(L)
-								target << "<span class='boldannounce'>Your unwavering loyalty to Nanotrasen falters, dims, dies.</span>"
 				if(3)
 					usr << "<span class='notice'>You begin rearranging [target]'s memories.</span>"
 					usr.visible_message("<span class='danger'>[usr]'s eyes flare brightly.</span>")


### PR DESCRIPTION
Loyalty implants are supposed to do one thing, protect against brainwashing, not sure why it was snowflaked in here, but it is extremely broken, how is even adding 15 seconds to the time it takes looked upon as a big enough of a negative side that it balances out. If you want the implant removed, ya gotta do it like everyone else, surgery, or cloning.

As soon as you get an officer, or the blueshield, or hos or warden, then the game is already won.

:cl: PPI
rscdel: Removes the shadowlings ability to destroy Loyalty Implants
/:cl: