### PR TITLE
Fixes a startup runtime regarding the wizard's 2 summon spells

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -413,7 +413,7 @@
 	log_name = "SG"
 
 /datum/spellbook_entry/summon/guns/IsAvailible()
-	if(ticker.mode.name == "ragin' mages")
+	if(ticker && ticker.mode.name == "ragin' mages")
 		return 0
 	else
 		return 1
@@ -434,7 +434,7 @@
 	log_name = "SU"
 
 /datum/spellbook_entry/summon/magic/IsAvailible()
-	if(ticker.mode.name == "ragin' mages")
+	if(ticker && ticker.mode.name == "ragin' mages")
 		return 0
 	else
 		return 1


### PR DESCRIPTION
Not really anything players will notice, but I'll sure notice it.
Happens because the ticker's not created yet, but those two procs are being called for one reason or another.