### PR TITLE
Removes Mindswap Suiciding

### DIFF
--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -42,6 +42,10 @@ Also, you never added distance checking after target is selected. I've went ahea
 		user << "They appear to be catatonic. Not even magic can affect their vacant mind."
 		return
 
+	if(user.suiciding)
+		user << "<span class='warning'>You're killing yourself! You can't concentrate enough to do this!</span>"
+		return
+
 	if(target.mind.special_role in protected_roles)
 		user << "Their mind is resisting your spell."
 		return


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/pull/15038

Removes being able to suicide-mindswap people.

It's a dumb, lame tactic that someone is never going to come back from in a wizard round--worse than even Ei 'nath.