### PR TITLE
Sink and Toilet Fixes+Refactor

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -63,7 +63,7 @@
 			return
 		var/obj/item/weapon/reagent_containers/RG = I
 		if(RG.is_open_container())
-			RG.reagents.add_reagent("water", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
+			RG.reagents.add_reagent("toiletwater", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
 			user << "<span class='notice'>You fill [RG] from [src]. Gross.</span>"
 			return
 

--- a/code/modules/reagents/oldchem/reagents/reagents_water.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_water.dm
@@ -223,9 +223,18 @@
 			M.fakevomit(1)
 		else
 			M.fakevomit(0)
-		..()
+	..()
 	return
 
+/datum/reagent/fishwater/toiletwater
+	name = "Toilet Water"
+	id = "toiletwater"
+	description = "Filthy water scoured from a nasty toilet bowl. Absolutely disgusting."
+	reagent_state = LIQUID
+	color = "#757547"
+
+/datum/reagent/fishwater/toiletwater/reaction_mob(var/mob/M, var/method=TOUCH, var/volume) //For shennanigans
+	return
 
 /datum/reagent/holywater
 	name = "Water"

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -23,6 +23,7 @@
 		/obj/structure/table,
 		/obj/structure/closet,
 		/obj/structure/sink,
+		/obj/structure/toilet,
 		/obj/item/weapon/storage,
 		/obj/machinery/atmospherics/unary/cryo_cell,
 		/obj/machinery/dna_scannernew,


### PR DESCRIPTION
Fixes up sinks and toilets+Refactors them

Most changes from TG

Toilets/Urinals
- Can no longer spam click someone to death using the toilet; standard cooldowns are incurred. Fixes https://github.com/ParadiseSS13/Paradise/issues/3519 
- Damage slightly lowered for toilet head slamming (8->5)
- Sound plays when headslamming someone into a toilet/urinal
- Can fill up open reagent containers with a toilet (ewww).
 - This adds "toilet water" to your reagent container, which functions nearly identically to fishwater.
- Ensures you can't put NO_DROP items in a toilet

Sinks
- No more visible message spam for filling up a container by a sink
- can wash your face or hands in a sink
 - Washing your face makes you less drowsy and washes off lipstick
- Fixes it so you cannot wash abstract items, like grabs
- Can fill up a mop using a sink
- Washing will now use progress bars

:cl: Fox McCloud
bugfix: Can no longer spamclick someone to death using headslamming on a toilet/urimal
tweak: Toilet/urinal headslamming now plays a sound
tweak: Toilet headslamming damage reduced slightly
rscadd: Can now fill open reagent containers in a toilet to receive "toilet water".
tweak: No more message spam when someone fills a container using a sink
rscadd: Can now wash your face using a sink, which washes away lipstick and wakes you up slightly
tweak: Washing things will now use progress bars
/:cl: