### PR TITLE
Tweaks Syndicate Donk Pockets

### DIFF
--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -165,6 +165,10 @@
 	addiction_threshold = 10
 	metabolization_rate = 0.6
 
+/datum/reagent/methamphetamine/meth2 //for donk pockets
+	id = "methamphetamine2"
+	addiction_threshold = 20
+
 /datum/reagent/methamphetamine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	var/high_message = pick("You feel hyper.", "You feel like you need to go faster.", "You feel like you can run the world.")

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -834,7 +834,7 @@
 		reagents.add_reagent("synaptizine", 15)
 		reagents.add_reagent("salglu_solution", 15)
 		reagents.add_reagent("salbutamol", 15)
-		reagents.add_reagent("methamphetamine", 15)
+		reagents.add_reagent("methamphetamine2", 15)
 
 /obj/item/weapon/reagent_containers/food/snacks/brainburger
 	name = "brainburger"


### PR DESCRIPTION
Tweaks Syndicate donk pockets so you don't get addicted to meth from consuming a single one.

This was an oversight on my behalf; this tweaks it so that syndidonks behave the same, but won't get you addicted (unless you scarf more than one, at once).

:cl: Fox McCloud
tweak: Ensures consuming a single syndicate donk pocket won't get you addicted to meth
/:cl: