### PR TITLE
Fixed succumb for weird living mobs and maxHealth

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -441,8 +441,7 @@
 /mob/living/carbon/human/attack_slime(mob/living/carbon/slime/M as mob)
 	if(M.Victim) return // can't attack while eating!
 
-	if (health > -100)
-
+	if(stat != DEAD)
 		M.do_attack_animation(src)
 		visible_message("<span class='danger'>The [M.name] glomps [src]!</span>", \
 				"<span class='userdanger'>The [M.name] glomps [src]!</span>")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -1,7 +1,7 @@
 //Updates the mob's health from organs and mob damage variables
 /mob/living/carbon/human/updatehealth()
 	if(status_flags & GODMODE)
-		health = 100
+		health = maxHealth
 		stat = CONSCIOUS
 		return
 
@@ -12,15 +12,15 @@
 		total_brute += O.brute_dam //calculates health based on organ brute and burn
 		total_burn += O.burn_dam
 
-	health = 100 - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
+	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
 
 	//TODO: fix husking
-	if(((100 - total_burn) < config.health_threshold_dead) && stat == DEAD) //100 is the magic human max health number
-		ChangeToHusk()                                                      //BECAUSE NO ONE THOUGHT TO USE LIVING/VAR/MAXHEALTH I GUESS
+	if(((maxHealth - total_burn) < config.health_threshold_dead) && stat == DEAD)
+		ChangeToHusk()
 	if(species.can_revive_by_healing)
 		var/obj/item/organ/brain/B = internal_organs_by_name["brain"]
 		if(B)
-			if((health >= (config.health_threshold_dead / 100 * 75)) && stat == DEAD)
+			if((health >= (config.health_threshold_dead + config.health_threshold_crit) / 2) && stat == DEAD)
 				update_revive()
 	if(stat == CONSCIOUS && (src in dead_mob_list)) //Defib fix
 		update_revive()

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -20,7 +20,7 @@
 	if(species.can_revive_by_healing)
 		var/obj/item/organ/brain/B = internal_organs_by_name["brain"]
 		if(B)
-			if((health >= (config.health_threshold_dead + config.health_threshold_crit) / 2) && stat == DEAD)
+			if((health >= (config.health_threshold_dead + config.health_threshold_crit) * 0.5) && stat == DEAD)
 				update_revive()
 	if(stat == CONSCIOUS && (src in dead_mob_list)) //Defib fix
 		update_revive()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -13,7 +13,7 @@
 		handle_embedded_objects() //Moving with objects stuck in you can cause bad times.
 
 
-	var/health_deficiency = (100 - health + staminaloss)
+	var/health_deficiency = (maxHealth - health + staminaloss)
 	if(reagents)
 		for(var/datum/reagent/R in reagents.reagent_list)
 			if(R.shock_reduction)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2,7 +2,7 @@
 /mob/living/Destroy()
 	..()
 	return QDEL_HINT_HARDDEL_NOW
-	
+
 /mob/living/Stat()
 	. = ..()
 	if(. && get_rig_stats)
@@ -34,11 +34,17 @@
 /mob/living/verb/succumb()
 	set hidden = 1
 	if (InCritical())
-		src.attack_log += "[src] has ["succumbed to death"] with [round(health, 0.1)] points of health!"
-		src.adjustOxyLoss(src.health - config.health_threshold_dead)
+		attack_log += "[src] has ["succumbed to death"] with [round(health, 0.1)] points of health!"
+		adjustOxyLoss(health - config.health_threshold_dead)
 		updatehealth()
+		// super check for weird mobs, including ones that adjust hp
+		// we don't want to go overboard and gib them, though
+		for(var/i = 1 to 5)
+			if(health < config.health_threshold_dead)
+				break
+			take_overall_damage(max(5, health - config.health_threshold_dead), 0)
+			updatehealth()
 		src << "<span class='notice'>You have given up life and succumbed to death.</span>"
-		death()
 
 /mob/living/proc/InCritical()
 	return (src.health < 0 && src.health > -95.0 && stat == UNCONSCIOUS)


### PR DESCRIPTION
Succumb now makes super sure you've actually taken enough damage to die. It's possible that this fixes succumbing for more than NO_BREATH humanoid species, since it's entirely a `mob/living` level thing.
* Fixes #3537 

I also fixed a few core points in the human code that made `maxHealth` meaningless for humans. Now the species can set their `total_health` and have it actually affect the game.