### PR TITLE
Revamps that weird dialog about hacking the nearest APC to actually work

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -71,7 +71,6 @@ var/list/ai_verbs_default = list(
 
 	var/mob/living/silicon/ai/parent = null
 
-	var/apc_override = 0 //hack for letting the AI use its APC even when visionless
 	var/camera_light_on = 0	//Defines if the AI toggled the light on the camera it's looking through.
 	var/datum/trackable/track = null
 	var/last_paper_seen = null

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -135,10 +135,8 @@
 								src << "Receiving control information from APC."
 								sleep(2)
 								//bring up APC dialog
-								apc_override = 1
-								theAPC.attack_ai(src)
-								apc_override = 0
 								aiRestorePowerRoutine = 3
+								theAPC.attack_ai(src)
 								src << "Here are your current laws:"
 								src.show_laws() //WHY THE FUCK IS THIS HERE
 						sleep(50)

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -32,6 +32,9 @@
 
 /mob/living/silicon/ai/default_can_use_topic(var/src_object)
 	. = shared_nano_interaction()
+	// Fix the weird hacking blurb to actually let them restore power
+	if(aiRestorePowerRoutine == 3 && istype(src_object, /obj/machinery/power/apc))
+		return STATUS_INTERACTIVE
 	if(. != STATUS_INTERACTIVE)
 		return
 


### PR DESCRIPTION
As for whether this should actually STAY, I'm not so sure, but as it was it was defunct from an update from a while ago.
:cl:Crazylemon
bugfix: Fixes the dialog that occurs when the AI shuts off to actually do what it says it does
/:cl: