### PR TITLE
Ports TG's Timer Controller

### DIFF
--- a/code/controllers/Processes/timer.dm
+++ b/code/controllers/Processes/timer.dm
@@ -17,7 +17,8 @@ var/global/datum/controller/process/timer/PStimer
 	if(!processing_timers.len)
 		disabled = 1 //nothing to do, lets stop firing.
 		return
-	for(var/datum/timedevent/event in processing_timers)
+	for(last_object in processing_timers)
+		var/datum/timedevent/event = last_object
 		if(!event.thingToCall || qdeleted(event.thingToCall))
 			qdel(event)
 		if(event.timeToRun <= world.time)

--- a/code/controllers/Processes/timer.dm
+++ b/code/controllers/Processes/timer.dm
@@ -1,0 +1,77 @@
+var/global/datum/controller/process/timer/PStimer
+
+/datum/controller/process/timer
+	var/list/processing_timers = list()
+	var/list/hashes = list()
+
+/datum/controller/process/timer/setup()
+	name = "timer"
+	schedule_interval = 5 //every 0.5 seconds
+	PStimer = src
+
+/datum/controller/process/timer/statProcess()
+	..()
+	stat(null, "[processing_timers.len] timers")
+
+/datum/controller/process/timer/doWork()
+	if(!processing_timers.len)
+		disabled = 1 //nothing to do, lets stop firing.
+		return
+	for(var/datum/timedevent/event in processing_timers)
+		if(!event.thingToCall || qdeleted(event.thingToCall))
+			qdel(event)
+		if(event.timeToRun <= world.time)
+			spawn(-1)
+				call(event.thingToCall, event.procToCall)(arglist(event.argList))
+			qdel(event)
+		SCHECK
+
+/datum/timedevent
+	var/thingToCall
+	var/procToCall
+	var/timeToRun
+	var/argList
+	var/id
+	var/hash
+	var/static/nextid = 1
+
+/datum/timedevent/New()
+	id = nextid
+	nextid++
+
+/datum/timedevent/Destroy()
+	PStimer.processing_timers -= src
+	PStimer.hashes -= hash
+	return QDEL_HINT_IWILLGC
+
+/proc/addtimer(thingToCall, procToCall, wait, unique = FALSE, ...)
+	if(!PStimer) //can't run timers before the mc has been created
+		return
+	if(!thingToCall || !procToCall || wait <= 0)
+		return
+	if(PStimer.disabled)
+		PStimer.disabled = 0
+
+	var/datum/timedevent/event = new()
+	event.thingToCall = thingToCall
+	event.procToCall = procToCall
+	event.timeToRun = world.time + wait
+	event.hash = list2text(args)
+	if(args.len > 4)
+		event.argList = args.Copy(5)
+
+	// Check for dupes if unique = 1.
+	if(unique)
+		if(event.hash in PStimer.hashes)
+			return
+	// If we are unique (or we're not checking that), add the timer and return the id.
+	PStimer.processing_timers += event
+	PStimer.hashes += event.hash
+	return event.id
+
+/proc/deltimer(id)
+	for(var/datum/timedevent/event in PStimer.processing_timers)
+		if(event.id == id)
+			qdel(event)
+			return 1
+	return 0

--- a/code/controllers/Processes/timer.dm
+++ b/code/controllers/Processes/timer.dm
@@ -22,10 +22,13 @@ var/global/datum/controller/process/timer/PStimer
 		if(!event.thingToCall || qdeleted(event.thingToCall))
 			qdel(event)
 		if(event.timeToRun <= world.time)
-			spawn(-1)
-				call(event.thingToCall, event.procToCall)(arglist(event.argList))
+			runevent(event)
 			qdel(event)
 		SCHECK
+
+/datum/controller/process/timer/proc/runevent(datum/timedevent/event)
+	set waitfor = 0
+	call(event.thingToCall, event.procToCall)(arglist(event.argList))
 
 /datum/timedevent
 	var/thingToCall

--- a/paradise.dme
+++ b/paradise.dme
@@ -167,6 +167,7 @@
 #include "code\controllers\Processes\shuttles.dm"
 #include "code\controllers\Processes\sun.dm"
 #include "code\controllers\Processes\ticker.dm"
+#include "code\controllers\Processes\timer.dm"
 #include "code\controllers\Processes\vote.dm"
 #include "code\controllers\Processes\shuttles\emergency.dm"
 #include "code\controllers\Processes\shuttles\supply.dm"


### PR DESCRIPTION
Ports Timer Controller in: https://github.com/tgstation/-tg-station/pull/10083

Basically it's a controller purely dedidcated to timed events. This can be useful for things like how long something should be delayed for, such as with door's autoclose/open/electrified time.

The basic functionality of it is primarily with the proc `addtimer` which lets you specify where the timer comes from, what proc to call when the timer expires, how long the timer is, and if the timer is to be unique or not (meaning can multiple instances of it exist or not). You can use this in place of things like `spawn(50)` followed by `gib()` or other similar scenarios.

When no timers are running the controller disables itself; the controller is re-activated when a new timer is added to its queue.

Word of warning: this is meant for <b>larger times</b> (ie: times greater than 1 second) that do <b>NOT</b> require precision; this controller will <b>NOT</b> function accurately for precise timings or things that aren't in intervals of 0.5 seconds.


tested out; it works quite well and is generally accurate for uses where it's helpful--its events all GC well, too.


Currently unused; could technically be used, in the future, for refactors to wires/doors/other such things.

