### PR TITLE
Unarmed Attack+Martial Arts Update+Golem Refactor

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -5,6 +5,8 @@
 	var/current_target = null
 	var/temporary = 0
 	var/datum/martial_art/base = null // The permanent style
+	var/deflection_chance = 0 //Chance to deflect projectiles
+	var/help_verb = null
 
 /datum/martial_art/proc/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	return 0
@@ -25,29 +27,32 @@
 	return
 
 /datum/martial_art/proc/basic_hit(var/mob/living/carbon/human/A,var/mob/living/carbon/human/D)
-	add_logs(D, A, "punched")
-	A.do_attack_animation(D)
-	var/damage = rand(0,9)
 
-	var/atk_verb = "punch"
+	A.do_attack_animation(D)
+	var/damage = rand(A.species.punchdamagelow, A.species.punchdamagehigh)
+	var/datum/unarmed_attack/attack = A.species.unarmed
+
+	var/atk_verb = "[pick(attack.attack_verb)]"
 	if(D.lying)
 		atk_verb = "kick"
 
 	if(!damage)
-		playsound(D.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+		playsound(D.loc, attack.miss_sound, 25, 1, -1)
 		D.visible_message("<span class='warning'>[A] has attempted to [atk_verb] [D]!</span>")
 		return 0
 
 	var/obj/item/organ/external/affecting = D.get_organ(ran_zone(A.zone_sel.selecting))
 	var/armor_block = D.run_armor_check(affecting, "melee")
 
-	playsound(D.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)
-
+	playsound(D.loc, attack.attack_sound, 25, 1, -1)
 	D.visible_message("<span class='danger'>[A] has [atk_verb]ed [D]!</span>", \
 								"<span class='userdanger'>[A] has [atk_verb]ed [D]!</span>")
 
 	D.apply_damage(damage, BRUTE, affecting, armor_block)
-	if((D.stat != DEAD) && damage >= 9)
+
+	add_logs(D, A, "punched")
+
+	if((D.stat != DEAD) && damage >= A.species.punchstunthreshold)
 		D.visible_message("<span class='danger'>[A] has weakened [D]!!</span>", \
 								"<span class='userdanger'>[A] has weakened [D]!</span>")
 		D.apply_effect(4, WEAKEN, armor_block)
@@ -57,6 +62,8 @@
 	return 1
 
 /datum/martial_art/proc/teach(var/mob/living/carbon/human/H,var/make_temporary=0)
+	if(help_verb)
+		H.verbs += help_verb
 	if(make_temporary)
 		temporary = 1
 	if(H.martial_art && H.martial_art.temporary)
@@ -71,30 +78,31 @@
 	if(H.martial_art != src)
 		return
 	H.martial_art = base
-
+	if(help_verb)
+		H.verbs -= help_verb
 
 /datum/martial_art/boxing
 	name = "Boxing"
 
 /datum/martial_art/boxing/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	A << "<span class='warning'> Can't disarm while boxing!</span>"
+	A << "<span class='warning'>Can't disarm while boxing!</span>"
 	return 1
 
 /datum/martial_art/boxing/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	A << "<span class='warning'> Can't grab while boxing!</span>"
+	A << "<span class='warning'>Can't grab while boxing!</span>"
 	return 1
 
 /datum/martial_art/boxing/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(D, A, "punched")
+
 	A.do_attack_animation(D)
 
 	var/atk_verb = pick("left hook","right hook","straight punch")
 
-	var/damage = rand(5,8)
-
+	var/damage = rand(5, 8) + A.species.punchdamagelow
 	if(!damage)
 		playsound(D.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		D.visible_message("<span class='warning'>[A] has attempted to hit [D] with a [atk_verb]!</span>")
+		add_logs(D, A, "attempted to hit", atk_verb)
 		return 0
 
 
@@ -103,11 +111,11 @@
 
 	playsound(D.loc, 'sound/weapons/punch1.ogg', 25, 1, -1)
 
-
 	D.visible_message("<span class='danger'>[A] has hit [D] with a [atk_verb]!</span>", \
 								"<span class='userdanger'>[A] has hit [D] with a [atk_verb]!</span>")
 
 	D.apply_damage(damage, STAMINA, affecting, armor_block)
+	add_logs(D, A, "punched")
 	if(D.getStaminaLoss() > 50)
 		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
 		if((D.stat != DEAD) && prob(knockout_prob))
@@ -182,6 +190,12 @@
 
 /datum/martial_art/wrestling
 	name = "Wrestling"
+	help_verb = /mob/living/carbon/human/proc/wrestling_help
+
+//	combo refence since wrestling uses a different format to sleeping carp and plasma fist.
+//	Clinch "G"
+//	Suplex "GD"
+//	Advanced grab "G"
 
 /datum/martial_art/wrestling/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	D.grabbedby(A,1)
@@ -197,13 +211,15 @@
 
 
 /datum/martial_art/wrestling/proc/Suplex(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(D, A, "suplexed")
+
 	D.visible_message("<span class='danger'>[A] suplexes [D]!</span>", \
 								"<span class='userdanger'>[A] suplexes [D]!</span>")
 	D.forceMove(A.loc)
 	var/armor_block = D.run_armor_check(null, "melee")
 	D.apply_damage(30, BRUTE, null, armor_block)
 	D.apply_effect(6, WEAKEN, armor_block)
+	add_logs(D, A, "suplexed")
+
 	A.SpinAnimation(10,1)
 
 	D.SpinAnimation(10,1)
@@ -230,12 +246,24 @@
 	D.apply_damage(10, STAMINA, affecting, armor_block)
 	return 1
 
+/mob/living/carbon/human/proc/wrestling_help()
+	set name = "Recall Teachings"
+	set desc = "Remember how to wrestle."
+	set category = "Wrestling"
+
+	usr << "<b><i>You flex your muscles and have a revelation...</i></b>"
+	usr << "<span class='notice'>Clinch</span>: Grab. Passively gives you a chance to immediately aggressively grab someone. Not always successful."
+	usr << "<span class='notice'>Suplex</span>: Disarm someone you are grabbing. Suplexes your target to the floor. Greatly injures them and leaves both you and your target on the floor."
+	usr << "<span class='notice'>Advanced grab</span>: Grab. Passively causes stamina damage when grabbing someone."
+
 #define TORNADO_COMBO "HHD"
 #define THROWBACK_COMBO "DHD"
 #define PLASMA_COMBO "HDDDH"
 
 /datum/martial_art/plasma_fist
 	name = "Plasma Fist"
+	help_verb = /mob/living/carbon/human/proc/plasma_fist_help
+
 
 /datum/martial_art/plasma_fist/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(findtext(streak,TORNADO_COMBO))
@@ -271,7 +299,7 @@
 								"<span class='userdanger'>[A] has hit [D] with Plasma Punch!</span>")
 	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, 1, -1)
 	var/atom/throw_target = get_edge_target_turf(D, get_dir(D, get_step_away(D, A)))
-	D.throw_at(throw_target, 200, 4)
+	D.throw_at(throw_target, 200, 4,A)
 	A.say("HYAH!")
 	return
 
@@ -285,26 +313,37 @@
 	return
 
 /datum/martial_art/plasma_fist/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_to_streak("H")
+	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return 1
 	basic_hit(A,D)
 	return 1
 
 /datum/martial_art/plasma_fist/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_to_streak("D")
+	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return 1
 	basic_hit(A,D)
 	return 1
 
 /datum/martial_art/plasma_fist/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_to_streak("G")
+	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return 1
 	basic_hit(A,D)
 	return 1
 
+/mob/living/carbon/human/proc/plasma_fist_help()
+	set name = "Recall Teachings"
+	set desc = "Remember the martial techniques of the Plasma Fist."
+	set category = "Plasma Fist"
+
+	usr << "<b><i>You clench your fists and have a flashback of knowledge...</i></b>"
+	usr << "<span class='notice'>Tornado Sweep</span>: Harm Harm Disarm. Repulses target and everyone back."
+	usr << "<span class='notice'>Throwback</span>: Disarm Harm Disarm. Throws the target and an item at them."
+	usr << "<span class='notice'>The Plasma Fist</span>: Harm Disarm Disarm Disarm Harm. Knocks the brain out of the opponent and gibs their body."
+
+//Used by the gang of the same name. Uses combos. Basic attacks bypass armor and never miss
 #define WRIST_WRENCH_COMBO "DD"
 #define BACK_KICK_COMBO "HG"
 #define STOMACH_KNEE_COMBO "GH"
@@ -312,6 +351,8 @@
 #define ELBOW_DROP_COMBO "HDHDH"
 /datum/martial_art/the_sleeping_carp
 	name = "The Sleeping Carp"
+	deflection_chance = 100
+	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(findtext(streak,WRIST_WRENCH_COMBO))
@@ -344,7 +385,7 @@
 		D.emote("scream")
 		D.drop_item()
 		D.apply_damage(5, BRUTE, pick("l_arm", "r_arm"))
-		D.Stun(1)
+		D.Stun(3)
 		return 1
 	return basic_hit(A,D)
 
@@ -375,7 +416,8 @@
 						  "<span class='userdanger'>[A] kicks you in the jaw!</span>")
 		D.apply_damage(20, BRUTE, "head")
 		D.drop_item()
-		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 75, 1, -1)
+		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
+		D.Stun(4)
 		return 1
 	return basic_hit(A,D)
 
@@ -386,12 +428,12 @@
 		if(D.stat)
 			D.death() //FINISH HIM!
 		D.apply_damage(50, BRUTE, "chest")
-		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 100, 1, -1)
+		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 75, 1, -1)
 		return 1
 	return basic_hit(A,D)
 
 /datum/martial_art/the_sleeping_carp/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_to_streak("G")
+	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return 1
 	..()
@@ -399,19 +441,23 @@
 	if(G)
 		G.state = GRAB_AGGRESSIVE //Instant aggressive grab
 
-/datum/martial_art/the_sleeping_carp/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_to_streak("H")
+/datum/martial_art/the_sleeping_carp/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return 1
-	D.visible_message("<span class='danger'>[A] [pick("punches", "kicks", "chops", "hits", "slams")] [D]!</span>", \
-					  "<span class='userdanger'>[A] hits you!</span>")
-	D.apply_damage(10, BRUTE)
-	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
+	var/atk_verb = pick("punches", "kicks", "chops", "hits", "slams")
+	D.visible_message("<span class='danger'>[A] [atk_verb] [D]!</span>", \
+					  "<span class='userdanger'>[A] [atk_verb] you!</span>")
+	D.apply_damage(rand(10,15), BRUTE)
+	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, 1, -1)
+	if(prob(D.getBruteLoss()) && !D.lying)
+		D.visible_message("<span class='warning'>[D] stumbles and falls!</span>", "<span class='userdanger'>The blow sends you to the ground!</span>")
+		D.Weaken(4)
 	return 1
 
 
 /datum/martial_art/the_sleeping_carp/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_to_streak("D")
+	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return 1
 	return ..()
@@ -422,6 +468,7 @@
 	set category = "Sleeping Carp"
 
 	usr << "<b><i>You retreat inward and recall the teachings of the Sleeping Carp...</i></b>"
+
 	usr << "<span class='notice'>Wrist Wrench</span>: Disarm Disarm. Forces opponent to drop item in hand."
 	usr << "<span class='notice'>Back Kick</span>: Harm Grab. Opponent must be facing away. Knocks down."
 	usr << "<span class='notice'>Stomach Knee</span>: Grab Harm. Knocks the wind out of opponent and stuns."
@@ -459,6 +506,7 @@
 	if(slot == slot_belt)
 		var/mob/living/carbon/human/H = user
 		style.teach(H,1)
+		user << "<span class='sciradio'>You have an urge to flex your muscles and get into a fight. You have the knowledge of a thousand wrestlers before you. You can remember more by using the Recall teaching verb in the wrestling tab.</span>"
 	return
 
 /obj/item/weapon/storage/belt/champion/wrestling/dropped(mob/user)
@@ -467,11 +515,12 @@
 	var/mob/living/carbon/human/H = user
 	if(H.get_item_by_slot(slot_belt) == src)
 		style.remove(H)
+		user << "<span class='sciradio'>You no longer have an urge to flex your muscles.</span>"
 	return
 
 /obj/item/weapon/plasma_fist_scroll
-	name = "Plasma Fist Scroll"
-	desc = "Teaches the traditional wizard martial art."
+	name = "frayed scroll"
+	desc = "An aged and frayed scrap of paper written in shifting runes. There are hand-drawn illustrations of pugilism."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state ="scroll2"
 	var/used = 0
@@ -483,9 +532,11 @@
 		var/mob/living/carbon/human/H = user
 		var/datum/martial_art/plasma_fist/F = new/datum/martial_art/plasma_fist(null)
 		F.teach(H)
-		H << "<span class='notice'>You learn the PLASMA FIST style.</span>"
+		H << "<span class='boldannounce'>You have learned the ancient martial art of Plasma Fist.</span>"
 		used = 1
-		desc += "It looks like it's magic was used up."
+		desc = "It's completely blank."
+		name = "empty scroll"
+		icon_state = "blankscroll"
 
 /obj/item/weapon/sleeping_carp_scroll
 	name = "mysterious scroll"
@@ -496,11 +547,8 @@
 /obj/item/weapon/sleeping_carp_scroll/attack_self(mob/living/carbon/human/user as mob)
 	if(!istype(user) || !user)
 		return
-	user << "<span class='notice'>You begin to read the scroll...</span>"
-	user << "<span class='sciradio'><i>And all at once the secrets of the Sleeping Carp fill your mind. The ancient clan's martial teachings have been imbued into this scroll. As you read through it, \
- 	these secrets flood into your mind and body. You now know the martial techniques of the Sleeping Carp. Your hand-to-hand combat has become much more effective, and you may now perform powerful \
- 	combination attacks. To learn more about these combos, use the Recall Teachings ability in the Sleeping Carp tab.</i></span>"
-	user.verbs += /mob/living/carbon/human/proc/sleeping_carp_help
+	user << "<span class='sciradio'>You have learned the ancient martial art of the Sleeping Carp! Your hand-to-hand combat has become much more effective, and you are now able to deflect any projectiles \
+	directed toward you. However, you are also unable to use any ranged weaponry. You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
 	var/datum/martial_art/the_sleeping_carp/theSleepingCarp = new(null)
 	theSleepingCarp.teach(user)
 	user.drop_item()
@@ -508,16 +556,16 @@
 	new /obj/effect/decal/cleanable/ash(get_turf(src))
 	qdel(src)
 
-
 /obj/item/weapon/twohanded/bostaff
 	name = "bo staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts. Can be wielded to both kill and incapacitate."
-	force = 8
+	force = 10
 	w_class = 4
 	slot_flags = SLOT_BACK
-	force_unwielded = 8
-	force_wielded = 18
+	force_unwielded = 10
+	force_wielded = 24
 	throwforce = 20
+	throw_speed = 2
 	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "bostaff0"
@@ -572,7 +620,7 @@
 				if(total_health <= config.health_threshold_crit && !H.stat)
 					H.visible_message("<span class='warning'>[user] delivers a heavy hit to [H]'s head, knocking them out cold!</span>", \
 										   "<span class='userdanger'>[user] knocks you unconscious!</span>")
-					H.sleeping += 30
+					H.SetSleeping(30)
 					H.adjustBrainLoss(25)
 			return
 		else

--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -436,7 +436,7 @@
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return 1
-	..()
+	D.grabbedby(A,1)
 	var/obj/item/weapon/grab/G = A.get_active_hand()
 	if(G)
 		G.state = GRAB_AGGRESSIVE //Instant aggressive grab

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -642,7 +642,7 @@ var/global/list/multiverse = list()
 	if(heresy)
 		spawnheresy(M)//oh god why
 	else
-		M.makeSkeleton()
+		M.set_species("Skeleton")
 		M.visible_message("<span class = 'warning'> A massive amount of flesh sloughs off [M] and a skeleton rises up!</span>")
 		M.revive()
 		equip_skeleton(M)

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -44,12 +44,6 @@
 	if(!proximity || target == user || !ismob(target) || !iscarbon(user) || user.lying || user.handcuffed) //exploding after touching yourself would be bad
 		return
 	var/mob/M = target
-	if(ishuman(M) || issmall(M))
-		var/mob/living/carbon/C_target = M
-		var/obj/item/organ/brain/B
-		if(C_target.brain_op_stage != 4) // Their brain is already taken out
-			B = new(C_target.loc)
-			B.transfer_identity(C_target)
 	var/datum/effect/system/spark_spread/sparks = new
 	sparks.set_up(4, 0, M.loc) //no idea what the 0 is
 	sparks.start()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -394,6 +394,15 @@
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
 	apply_damage(5, BRUTE, affecting, run_armor_check(affecting, "melee"))
 
+/mob/living/carbon/human/bullet_act()
+	if(martial_art && martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
+		if(!prob(martial_art.deflection_chance))
+			return ..()
+		if(!src.lying && !(HULK in mutations)) //But only if they're not lying down, and hulks can't do it
+			src.visible_message("<span class='warning'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+			return 0
+	..()
+
 /mob/living/carbon/human/attack_animal(mob/living/simple_animal/M as mob)
 	if(M.melee_damage_upper == 0)
 		M.custom_emote(1, "[M.friendly] [src]")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -139,7 +139,7 @@
 				else
 					LAssailant = M
 
-				var/damage = rand(0, M.species.max_hurt_damage)//BS12 EDIT
+				var/damage = rand(M.species.punchdamagelow, M.species.punchdamagehigh)
 				damage += attack.damage
 				if(!damage)
 					playsound(loc, attack.miss_sound, 25, 1, -1)
@@ -158,7 +158,7 @@
 				visible_message("\red <B>[M] [pick(attack.attack_verb)]ed [src]!</B>")
 
 				apply_damage(damage, BRUTE, affecting, armor_block, sharp=attack.sharp, edge=attack.edge) //moving this back here means Armalis are going to knock you down  70% of the time, but they're pure adminbus anyway.
-				if((stat != DEAD) && damage >= 9)
+				if((stat != DEAD) && damage >= M.species.punchstunthreshold)
 					visible_message("<span class='danger'>[M] has weakened [src]!</span>", \
 									"<span class='userdanger'>[M] has weakened [src]!</span>")
 					apply_effect(4, WEAKEN, armor_block)

--- a/code/modules/mob/living/carbon/human/species/apollo.dm
+++ b/code/modules/mob/living/carbon/human/species/apollo.dm
@@ -6,6 +6,8 @@
 	language = "Wryn Hivemind"
 	tail = "wryntail"
 	unarmed_type = /datum/unarmed_attack/punch/weak
+	punchdamagelow = 0
+	punchdamagehigh = 1
 	//primitive = /mob/living/carbon/monkey/wryn
 	darksight = 3
 	slowdown = 1

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -6,12 +6,33 @@
 	deform = 'icons/mob/human_races/r_golem.dmi'
 
 	default_language = "Galactic Common"
-	flags = NO_BREATHE | NO_PAIN | NO_BLOOD | NO_SCAN
+	flags = NO_BREATHE | NO_BLOOD | RADIMMUNE
+	virus_immune = 1
 	dietflags = DIET_OMNI		//golems can eat anything because they are magic or something
 	reagent_tag = PROCESS_ORG
 
+	unarmed_type = /datum/unarmed_attack/punch
+	punchdamagelow = 5
+	punchdamagehigh = 14
+	punchstunthreshold = 11 //about 40% chance to stun
+
+	warning_low_pressure = -1
+	hazard_low_pressure = -1
+	hazard_high_pressure = 999999999
+	warning_high_pressure = 999999999
+
+	cold_level_1 = -1
+	cold_level_2 = -1
+	cold_level_3 = -1
+
+	heat_level_1 = 999999999
+	heat_level_2 = 999999999
+	heat_level_3 = 999999999
+	heat_level_3_breathe = 999999999
+
 	blood_color = "#515573"
 	flesh_color = "#137E8F"
+	slowdown = 3
 	siemens_coeff = 0
 
 	has_organ = list(
@@ -45,62 +66,36 @@
 	item_color = "golem"
 	has_sensor = 0
 	flags = ABSTRACT | NODROP
-	armor = list(melee = 10, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
+	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/golem
 	name = "adamantine shell"
 	desc = "a golem's thick outter shell"
 	icon_state = "golem"
 	item_state = "golem"
-	w_class = 4//bulky item
-	gas_transfer_coefficient = 0.90
-	permeability_coefficient = 0.50
-	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS|HEAD
-	slowdown = 1.0
-	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	flags = ONESIZEFITSALL | STOPSPRESSUREDMAGE | ABSTRACT | NODROP
-	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS | HEAD
-	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
-	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS | HEAD
-	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
-	armor = list(melee = 80, bullet = 20, laser = 20, energy = 10, bomb = 0, bio = 0, rad = 0)
+	body_parts_covered = HEAD|UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	flags_inv = HIDEGLOVES|HIDESHOES
+	flags = ONESIZEFITSALL | ABSTRACT | NODROP | THICKMATERIAL
+	armor = list(melee = 55, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/shoes/golem
 	name = "golem's feet"
 	desc = "sturdy adamantine feet"
 	icon_state = "golem"
 	item_state = "golem"
-	flags = NOSLIP | ABSTRACT | AIRTIGHT | MASKCOVERSMOUTH | NODROP
-	slowdown = SHOES_SLOWDOWN+1
-
+	flags = ABSTRACT | NODROP
 
 /obj/item/clothing/mask/gas/golem
 	name = "golem's face"
 	desc = "the imposing face of an adamantine golem"
 	icon_state = "golem"
 	item_state = "golem"
-	siemens_coefficient = 0
 	unacidable = 1
 	flags = ABSTRACT | NODROP
-
 
 /obj/item/clothing/gloves/golem
 	name = "golem's hands"
 	desc = "strong adamantine hands"
 	icon_state = "golem"
 	item_state = null
-	siemens_coefficient = 0
 	flags = ABSTRACT | NODROP
-
-
-/obj/item/clothing/head/space/golem
-	icon_state = "golem"
-	item_state = "dermal"
-	item_color = "dermal"
-	name = "golem's head"
-	desc = "a golem's head"
-	unacidable = 1
-	flags = STOPSPRESSUREDMAGE | ABSTRACT | NODROP
-	heat_protection = HEAD
-	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
-	armor = list(melee = 80, bullet = 20, laser = 20, energy = 10, bomb = 0, bio = 0, rad = 0)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -57,7 +57,9 @@
 	var/light_effect_amp //If 0, takes/heals 1 burn and brute per tick. Otherwise, both healing and damage effects are amplified.
 
 	var/total_health = 100
-	var/max_hurt_damage = 9 // Max melee damage dealt + 5 if hulk
+	var/punchdamagelow = 0       //lowest possible punch damage
+	var/punchdamagehigh = 9      //highest possible punch damage
+	var/punchstunthreshold = 9	 //damage at which punches from this race will stun //yes it should be to the attacked race but it's not useful that way even if it's logical
 	var/list/default_genes = list()
 
 	var/ventcrawler = 0 //Determines if the mob can go through the vents.
@@ -345,7 +347,7 @@
 
 /datum/unarmed_attack
 	var/attack_verb = list("attack")	// Empty hand hurt intent verb.
-	var/damage = 0						// Extra empty hand attack damage.
+	var/damage = 0						// How much flat bonus damage an attack will do. This is a *bonus* guaranteed damage amount on top of the random damage attacks do.
 	var/attack_sound = "punch"
 	var/miss_sound = 'sound/weapons/punchmiss.ogg'
 	var/sharp = 0
@@ -356,7 +358,6 @@
 
 /datum/unarmed_attack/punch/weak
 	attack_verb = list("flail")
-	damage = 1
 
 /datum/unarmed_attack/diona
 	attack_verb = list("lash", "bludgeon")
@@ -370,7 +371,7 @@
 
 /datum/unarmed_attack/claws/armalis
 	attack_verb = list("slash", "claw")
-	damage = 6	//they're huge! they should do a little more damage, i'd even go for 15-20 maybe...
+	damage = 6
 
 /datum/species/proc/handle_can_equip(obj/item/I, slot, disable_warning = 0, mob/living/carbon/human/user)
 	return 0


### PR DESCRIPTION
Most of this is from various TG PRs: this is a case of one thing led to another--what was a simple golem refactor led me to updating the unarmed attacks to allow for that, which led to updating the martial arts datum because of the unarmed attack refactor impacting them...which led me to go ahead and update the rest of martial arts since it's simple....which led to me seeing how we handle plasma fist differently than TG, which reminded me of the double-brain Ei Nath bug.

Refactors Unarmed attacks
- Unarmed attacks now are based off of 3 specie's vars for damage: the lowest damage an attack can do, the highest, and the point at which it will weaken someone
 - No Species have been impacted by this, except Golems (more on that below)

Updates Martial Arts Datums
- Learning/unlearning martial arts will now give you specific help verbs which will tell you the combos for a martial arts style
- Basic attacks now factor in a species' attack sounds/damage/verbs in addition to the new unarmed attack refactor
- Fixes it so you can't attack yourself or others, then switch targets for a combo (no more storing plasma fist gibs)
- Rebalances the Bo Staff and Sleeping Carp martial arts datums
 - In general, the stuns are generally longer and the bo staff damage is more; keep in mind that this martial arts is for the Sleeping Carp gang, which is 100% melee oriented.
 - Sleeping Carp martial arts grants bullet immunity; anyone with it will not be hit by bullets unless they're already stunned or they have hulk

Golem Refactor
- Refactors Golems to push as many stats into the species as possible, in addition to making some balance adjustments (Again, from TG)
- now heat immune
- now cold immune
- now pressure immune
- now virus immune
- now radiation immune
- can be cloned now
- deals increased unarmed damage with increased chance to knock you down
- Golems are now immune to parapens and syringe guns attacks
- Golem armor adjusted to be 55 melee armor and nothing more
- Slip immunity removed
- Pain immunity removed (can now tell how much damage they have)
- Slightly slower than before (1 level)

Fixes
- Fixes Ei Nath generating two brains
- Fixes the necromatic stone making the aesthetic skeletons as opposed to actual real skeletons
- Fixes not being able to remove ID/PDA's from Golems (Fixes https://github.com/ParadiseSS13/Paradise/issues/3566)
- Fixes Wyrn attacks doing *extra* damage as opposed to being wimpy

:cl: Fox McCloud
tweak: Updates unarmed attacks to allow for more customization
tweak: Updates martial arts so they factor in specie's attack messages and sounds
tweak: Re-balances Sleeping Carp fighting style
tweak: Re-balances Bo Staff
tweak: Rebalances Golem: they should now be spaceproof, fire+cold proof, rad proof, virus immune, clonable, parapen+syringe gun immune, deal increased melee damage. Their armor has been reduced to 55 melee across the board, their slip immunity removed, pain immunity removed, and they're slightly slower
bugfix: Fixes Ei Nath generating two brains
bugfix: Ensures the Necromatic Stone generates actual skeletons
bugfix: Can now strip PDA/IDs from Golems
bugfix: Fixes sleeping carp grab not being an instant aggressive grab
/:cl:
