### PR TITLE
Tweaks Laser Eyes

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -319,16 +319,8 @@
 	LE.current = T
 	LE.yo = U.y - T.y
 	LE.xo = U.x - T.x
-	spawn( 1 )
+	spawn(1)
 		LE.process()
-
-/mob/living/carbon/human/LaserEyes()
-	if(nutrition>0)
-		..()
-		nutrition = max(nutrition - rand(1,5),0)
-		handle_regular_hud_updates()
-	else
-		src << "\red You're out of energy!  You need food!"
 
 /mob/proc/PowerGlove(atom/A)
 	return


### PR DESCRIPTION
Is it weird when you port your own PR? https://github.com/tgstation/-tg-station/pull/15475

Laser eyes no longer drains nutrition.

Laser eyes is an adminbus thing 9/10 times, and the times it's not, it's governed by a cooldown that limits its potential; having to factor nutrition into that is silly (especially when its random).

:cl: Fox McCloud
tweak: Laser eyes mutation no longer drains nutrition
/:cl: