### PR TITLE
prevents toxloss and oxyloss for silicons

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1456,3 +1456,7 @@ var/list/robot_verbs_default = list(
 	status_flags &= ~CANPUSH
 
 	notify_ai(2)
+
+/mob/living/silicon/robot/adjustOxyLoss(var/amount)
+	if (suiciding)
+		..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -344,6 +344,4 @@
 /mob/living/silicon/adjustToxLoss(var/amount)
 	return
 
-/mob/living/silicon/adjustOxyLoss(var/amount)
-	if (suiciding)
-		..()
+

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -340,3 +340,10 @@
 	for(var/obj/machinery/camera/C in A.cameras())
 		cameratext += "[(cameratext == "")? "" : "|"]<A HREF=?src=\ref[src];switchcamera=\ref[C]>[C.c_tag]</A>"
 	src << "[A.alarm_name()]! ([(cameratext)? cameratext : "No Camera"])"
+
+/mob/living/silicon/adjustToxLoss(var/amount)
+	return
+
+/mob/living/silicon/adjustOxyLoss(var/amount)
+	if (suiciding)
+		..()


### PR DESCRIPTION
fixes #3595
stops adjustToxLoss working on silicons, and only allows adjustOxyLoss
when suiciding

Have checked through, nowhere that shouldn't be is directly setting
toxloss and oxyloss, and the only place that uses the setters to set it
to anything other than 0 (statues) doesn't affect silicon based life, so
this will fix the found bug and any other situations it could happen in