### PR TITLE
Fixes Plump Helmet Biscuits being uncookable

### DIFF
--- a/code/modules/food/recipes_oven.dm
+++ b/code/modules/food/recipes_oven.dm
@@ -254,6 +254,11 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/plump_pie
 
+/datum/recipe/oven/plumphelmetbiscuit
+	fruit = list("plumphelmet" = 1)
+	reagents = list("water" = 5, "flour" = 5)
+	result = /obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit
+
 /datum/recipe/oven/creamcheesebread
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough,


### PR DESCRIPTION
The recipe for the plump helmet biscuit was mistakenly removed a while back (#535), this returns the recipe to the code
- One minor change, replaces the flour item ingredient with the flour reagent.

Oven Recipe: 5u water, 5u flour, 1 plump helmet cap mushroom.

:cl:
fix: Fixes accidental removal of plump helmet biscuit recipe.
/:cl: