### PR TITLE
EMP Kit Tweak

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -365,11 +365,12 @@ var/list/uplink_items = list()
 	surplus = 0
 
 /datum/uplink_item/dangerous/emp
-	name = "EMP Kit"
-	desc = "A box that contains two EMP grenades, an EMP implant and a short ranged recharging device disguised as a flashlight. Useful to disrupt communication and silicon lifeforms."
-	reference = "EMP"
+	name = "EMP Grenades and Implanter Kit"
+	desc = "A box that contains two EMP grenades and an EMP implant. Useful to disrupt communication, \
+			security's energy weapons, and silicon lifeforms when you're in a tight spot."
+	reference = "EMPK"
 	item = /obj/item/weapon/storage/box/syndie_kit/emp
-	cost = 5
+	cost = 2
 
 /datum/uplink_item/dangerous/syndicate_minibomb
 	name = "Syndicate Minibomb"
@@ -655,6 +656,15 @@ var/list/uplink_items = list()
 	desc = "This satchel is thin enough to be hidden in the gap between plating and tiling, great for stashing your stolen goods. Comes with a crowbar and a floor tile inside."
 	reference = "SMSA"
 	item = /obj/item/weapon/storage/backpack/satchel_flat
+	cost = 2
+	surplus = 30
+
+/datum/uplink_item/stealthy_tools/emplight
+	name = "EMP Flashlight"
+	desc = "A small, self-charging, short-ranged EMP device disguised as a flashlight. \
+		Useful for disrupting headsets, cameras, and borgs during stealth operations."
+	reference = "EMPL"
+	item = /obj/item/device/flashlight/emp
 	cost = 2
 	surplus = 30
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -144,12 +144,11 @@
 /obj/item/weapon/storage/box/syndie_kit/emp
 	name = "boxed EMP kit"
 
-	New()
-		..()
-		new /obj/item/weapon/grenade/empgrenade(src)
-		new /obj/item/weapon/grenade/empgrenade(src)
-		new /obj/item/weapon/implanter/emp/(src)
-		new /obj/item/device/flashlight/emp/(src)
+/obj/item/weapon/storage/box/syndie_kit/emp/New()
+	..()
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/grenade/empgrenade(src)
+	new /obj/item/weapon/implanter/emp/(src)
 
 /obj/item/weapon/storage/box/syndie_kit/tabun
 	name = "Tabun Gas Grenades"


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/pull/15370

Splits the EMP Kit into two things:

- standard EMP kit (2 TC)
 - Two EMP grenades and an EMP implant
- EMP Flashlight (2TC)

:cl: Fox McCloud
tweak: splits the EMP kit into two things: the standard EMP kit (2 grenades and an implant), and the EMP flashlight by itself
/:cl: