### PR TITLE
Removes Dirty Floors

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -21,9 +21,6 @@
 		var/turf/tile = loc
 		if(isturf(tile))
 			tile.clean_blood()
-			if (istype(tile, /turf/simulated/floor))
-				var/turf/simulated/floor/F = tile
-				F.dirt = 0
 			for(var/A in tile)
 				if(istype(A, /obj/effect))
 					if(is_cleanable(A))

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -8,8 +8,6 @@
 	nitrogen = MOLES_N2STANDARD
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed
 	var/max_fire_temperature_sustained = 0 //The max temperature of the fire which it was subjected to
-	var/dirt = 0
-	var/dirtoverlay = null
 
 /turf/simulated/New()
 	..()
@@ -52,18 +50,6 @@
 
 /turf/simulated/Entered(atom/A, atom/OL)
 	..()
-	if(ismob(A)) //only mobs make dirt
-		if(prob(80))
-			dirt++
-
-		var/obj/effect/decal/cleanable/dirt/dirtoverlay = locate(/obj/effect/decal/cleanable/dirt) in src
-		if(dirt >= 100)
-			if(!dirtoverlay)
-				dirtoverlay = new/obj/effect/decal/cleanable/dirt(src)
-				dirtoverlay.alpha = 10
-			else if(dirt > 100)
-				dirtoverlay.alpha = min(dirtoverlay.alpha + 10, 200)
-
 	if(ishuman(A))
 		var/mob/living/carbon/human/M = A
 		if(M.lying)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1178,9 +1178,6 @@ var/list/robot_verbs_default = list(
 			var/turf/tile = loc
 			if(isturf(tile))
 				tile.clean_blood()
-				if (istype(tile, /turf/simulated))
-					var/turf/simulated/S = tile
-					S.dirt = 0
 				for(var/A in tile)
 					if(istype(A, /obj/effect))
 						if(is_cleanable(A))

--- a/code/modules/reagents/oldchem/reagents/reagents_water.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_water.dm
@@ -106,9 +106,6 @@
 
 		for(var/mob/living/carbon/slime/M in T)
 			M.adjustToxLoss(rand(5,10))
-		if(istype(T,/turf/simulated))
-			var/turf/simulated/S = T
-			S.dirt = 0
 
 /datum/reagent/space_cleaner/reaction_mob(var/mob/M, var/method=TOUCH, var/volume)
 	if(iscarbon(M))


### PR DESCRIPTION
Removes dirty floors, simple as that.

While this could be fixed so that ghosts don't trigger the floors...I don't personally feel this adds much to the station--it just looks horrifically ugly and generates a ton of work for the janitor that he literally cannot complete...not to mention he already has enough to do with blood splats, vomit, blood streak/trails, gibs, chem-messes, ash, etc. Anddd I've received more than a couple complaints about it.

Fixes https://github.com/ParadiseSS13/Paradise/issues/3586

Well..kinda.

:cl: Fox McCloud
rscdel: Removes dirty floors
/:cl: