### PR TITLE
fixes #3615

### DIFF
--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -88,7 +88,7 @@
 		..()
 		var/list/additional_drinks = list()
 		if(prob(50))
-			additional_drinks += list("pancuronium","adminordrazine","lsd","omnizine","blood")
+			additional_drinks += list("pancuronium","lsd","omnizine","blood")
 
 		var/datum/reagent/R = pick(drinks + additional_drinks)
 		reagents.add_reagent(R,volume)

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -148,7 +148,7 @@
 		on_reaction(var/datum/reagents/holder)
 
 			var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/snacks)
-			borks = adminRegentCheck(borks)
+			borks = adminReagentCheck(borks)
 			// BORK BORK BORK
 
 			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -176,7 +176,7 @@
 		on_reaction(var/datum/reagents/holder)
 
 			var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
-			borks = adminRegentCheck(borks)
+			borks = adminReagentCheck(borks)
 			// BORK BORK BORK
 
 			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -148,6 +148,7 @@
 		on_reaction(var/datum/reagents/holder)
 
 			var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/snacks)
+			borks = adminRegentCheck(borks)
 			// BORK BORK BORK
 
 			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
@@ -175,6 +176,7 @@
 		on_reaction(var/datum/reagents/holder)
 
 			var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
+			borks = adminRegentCheck(borks)
 			// BORK BORK BORK
 
 			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -16,7 +16,7 @@
 	//Processing flags, defines the type of mobs the reagent will affect
 	//By default, all reagents will ONLY affect organics, not synthetics. Re-define in the reagent's definition if the reagent is meant to affect synths
 	var/process_flags = ORGANIC
-	var/adminOnly = 0
+	var/admin_only = 0
 
 /datum/reagent/proc/reaction_mob(var/mob/M, var/method=TOUCH, var/volume) //Some reagents transfer on touch, others don't; dependent on if they penetrate the skin or not.
 	if(!istype(M, /mob/living))	return 0

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -16,7 +16,7 @@
 	//Processing flags, defines the type of mobs the reagent will affect
 	//By default, all reagents will ONLY affect organics, not synthetics. Re-define in the reagent's definition if the reagent is meant to affect synths
 	var/process_flags = ORGANIC
-
+	var/adminOnly = 0
 
 /datum/reagent/proc/reaction_mob(var/mob/M, var/method=TOUCH, var/volume) //Some reagents transfer on touch, others don't; dependent on if they penetrate the skin or not.
 	if(!istype(M, /mob/living))	return 0

--- a/code/modules/reagents/oldchem/reagents/reagents_admin.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_admin.dm
@@ -57,7 +57,7 @@
 
 // For random item spawning. Takes a list of paths, and returns the same list without anything that contains admin only reagents
 
-/proc/adminRegentCheck(var/list/incoming)
+/proc/adminReagentCheck(var/list/incoming)
 	var/list/outgoing[0]
 	for(var/tocheck in incoming)
 		if(ispath(tocheck))

--- a/code/modules/reagents/oldchem/reagents/reagents_admin.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_admin.dm
@@ -5,6 +5,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	process_flags = ORGANIC | SYNTHETIC	//Adminbuse knows no bounds!
+	adminOnly=1
 
 /datum/reagent/adminordrazine/on_mob_life(var/mob/living/carbon/M as mob)
 	if(!M) M = holder.my_atom ///This can even heal dead people.
@@ -52,3 +53,23 @@
 	name = "Nanites"
 	id = "nanites"
 	description = "Nanomachines that aid in rapid cellular regeneration."
+
+
+// For random item spawning. Takes a list of paths, and returns the same list without anything that contains admin only reagents
+
+/proc/adminRegentCheck(var/list/incoming)
+	var/list/outgoing[0]
+	for(var/tocheck in incoming)
+		if(ispath(tocheck))
+			var/check = new tocheck
+			if (istype(check, /atom))
+				var/atom/reagentCheck = check
+				var/datum/reagents/reagents = reagentCheck.reagents
+				var/admin = 0
+				for(var/datum/reagent/reagent in reagents.reagent_list)
+					if(reagent.adminOnly)
+						admin = 1
+						break
+				if(!(admin))
+					outgoing += tocheck
+	return outgoing

--- a/code/modules/reagents/oldchem/reagents/reagents_admin.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_admin.dm
@@ -66,10 +66,13 @@
 				var/atom/reagentCheck = check
 				var/datum/reagents/reagents = reagentCheck.reagents
 				var/admin = 0
-				for(var/datum/reagent/reagent in reagents.reagent_list)
+				for(var/reag in reagents.reagent_list)
+					var/datum/reagent/reagent = reag
 					if(reagent.admin_only)
 						admin = 1
 						break
 				if(!(admin))
 					outgoing += tocheck
+			else
+				outgoing += tocheck
 	return outgoing

--- a/code/modules/reagents/oldchem/reagents/reagents_admin.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_admin.dm
@@ -5,7 +5,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	process_flags = ORGANIC | SYNTHETIC	//Adminbuse knows no bounds!
-	adminOnly=1
+	admin_only=1
 
 /datum/reagent/adminordrazine/on_mob_life(var/mob/living/carbon/M as mob)
 	if(!M) M = holder.my_atom ///This can even heal dead people.
@@ -67,7 +67,7 @@
 				var/datum/reagents/reagents = reagentCheck.reagents
 				var/admin = 0
 				for(var/datum/reagent/reagent in reagents.reagent_list)
-					if(reagent.adminOnly)
+					if(reagent.admin_only)
 						admin = 1
 						break
 				if(!(admin))


### PR DESCRIPTION
Reagents now have an admin only marker.
adminReagentCheck takes a list of paths and removes anything containing
admin only reagents
removed possibility of random drinks containing adminordrazine