### PR TITLE
Adds matrix and path editing to the variable viewer

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -425,3 +425,22 @@ proc/tg_text2list(text, glue=",", assocglue=";")
 			. = 0
 		else
 			. = max(0, min(255, 138.5177312231 * log(temp - 10) - 305.0447927307))
+
+//Argument: Give this a space-separated string consisting of 6 numbers. Returns null if you don't
+/proc/text2matrix(var/matrixtext)
+	var/list/matrixtext_list = text2list(matrixtext, " ")
+	var/list/matrix_list = list()
+	for(var/item in matrixtext_list)
+		var/entry = text2num(item)
+		if(entry == null)
+			return null
+		matrix_list += entry
+	if(matrix_list.len < 6)
+		return null
+	var/a = matrix_list[1]
+	var/b = matrix_list[2]
+	var/c = matrix_list[3]
+	var/d = matrix_list[4]
+	var/e = matrix_list[5]
+	var/f = matrix_list[6]
+	return matrix(a, b, c, d, e, f)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -1,434 +1,433 @@
 
 // reference: /client/proc/modify_variables(var/atom/O, var/param_var_name = null, var/autodetect_class = 0)
 
-client
-	proc/debug_variables(datum/D in world)
-		set category = "Debug"
-		set name = "View Variables"
-		//set src in world
+/client/proc/debug_variables(datum/D in world)
+	set category = "Debug"
+	set name = "View Variables"
+	//set src in world
 
 
-		if(!usr.client || !usr.client.holder)
-			usr << "\red You need to be an administrator to access this."
-			return
-
-
-		var/title = ""
-		var/body = ""
-
-		if(!D)	return
-		if(istype(D, /atom))
-			var/atom/A = D
-			title = "[A.name] (\ref[A]) = [A.type]"
-
-			#ifdef VARSICON
-			if (A.icon)
-				body += debug_variable("icon", new/icon(A.icon, A.icon_state, A.dir), 0)
-			#endif
-
-		var/icon/sprite
-
-		if(istype(D,/atom))
-			var/atom/AT = D
-			if(AT.icon && AT.icon_state)
-				sprite = new /icon(AT.icon, AT.icon_state)
-				usr << browse_rsc(sprite, "view_vars_sprite.png")
-
-		title = "[D] (\ref[D]) = [D.type]"
-
-		body += {"<script type="text/javascript">
-
-					function updateSearch(){
-						var filter_text = document.getElementById('filter');
-						var filter = filter_text.value.toLowerCase();
-
-						if(event.keyCode == 13){	//Enter / return
-							var vars_ol = document.getElementById('vars');
-							var lis = vars_ol.getElementsByTagName("li");
-							for ( var i = 0; i < lis.length; ++i )
-							{
-								try{
-									var li = lis\[i\];
-									if ( li.style.backgroundColor == "#ffee88" )
-									{
-										alist = lis\[i\].getElementsByTagName("a")
-										if(alist.length > 0){
-											location.href=alist\[0\].href;
-										}
-									}
-								}catch(err) {   }
-							}
-							return
-						}
-
-						if(event.keyCode == 38){	//Up arrow
-							var vars_ol = document.getElementById('vars');
-							var lis = vars_ol.getElementsByTagName("li");
-							for ( var i = 0; i < lis.length; ++i )
-							{
-								try{
-									var li = lis\[i\];
-									if ( li.style.backgroundColor == "#ffee88" )
-									{
-										if( (i-1) >= 0){
-											var li_new = lis\[i-1\];
-											li.style.backgroundColor = "white";
-											li_new.style.backgroundColor = "#ffee88";
-											return
-										}
-									}
-								}catch(err) {  }
-							}
-							return
-						}
-
-						if(event.keyCode == 40){	//Down arrow
-							var vars_ol = document.getElementById('vars');
-							var lis = vars_ol.getElementsByTagName("li");
-							for ( var i = 0; i < lis.length; ++i )
-							{
-								try{
-									var li = lis\[i\];
-									if ( li.style.backgroundColor == "#ffee88" )
-									{
-										if( (i+1) < lis.length){
-											var li_new = lis\[i+1\];
-											li.style.backgroundColor = "white";
-											li_new.style.backgroundColor = "#ffee88";
-											return
-										}
-									}
-								}catch(err) {  }
-							}
-							return
-						}
-
-						//This part here resets everything to how it was at the start so the filter is applied to the complete list. Screw efficiency, it's client-side anyway and it only looks through 200 or so variables at maximum anyway (mobs).
-						if(complete_list != null && complete_list != ""){
-							var vars_ol1 = document.getElementById("vars");
-							vars_ol1.innerHTML = complete_list
-						}
-
-						if(filter.value == ""){
-							return;
-						}else{
-							var vars_ol = document.getElementById('vars');
-							var lis = vars_ol.getElementsByTagName("li");
-
-							for ( var i = 0; i < lis.length; ++i )
-							{
-								try{
-									var li = lis\[i\];
-									if ( li.innerText.toLowerCase().indexOf(filter) == -1 )
-									{
-										vars_ol.removeChild(li);
-										i--;
-									}
-								}catch(err) {   }
-							}
-						}
-						var lis_new = vars_ol.getElementsByTagName("li");
-						for ( var j = 0; j < lis_new.length; ++j )
-						{
-							var li1 = lis\[j\];
-							if (j == 0){
-								li1.style.backgroundColor = "#ffee88";
-							}else{
-								li1.style.backgroundColor = "white";
-							}
-						}
-					}
-
-
-
-					function selectTextField(){
-						var filter_text = document.getElementById('filter');
-						filter_text.focus();
-						filter_text.select();
-
-					}
-
-					function loadPage(list) {
-
-						if(list.options\[list.selectedIndex\].value == ""){
-							return;
-						}
-
-						location.href=list.options\[list.selectedIndex\].value;
-
-					}
-				</script> "}
-
-		body += "<body onload='selectTextField(); updateSearch()' onkeyup='updateSearch()'>"
-
-		body += "<div align='center'><table width='100%'><tr><td width='50%'>"
-
-		if(sprite)
-			body += "<table align='center' width='100%'><tr><td><img src='view_vars_sprite.png'></td><td>"
-		else
-			body += "<table align='center' width='100%'><tr><td>"
-
-		body += "<div align='center'>"
-
-		if(istype(D,/atom))
-			var/atom/A = D
-			if(isliving(A))
-				body += "<a href='?_src_=vars;rename=\ref[D]'><b>[D]</b></a>"
-				if(A.dir)
-					body += "<br><font size='1'><a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=left'><<</a> <a href='?_src_=vars;datumedit=\ref[D];varnameedit=dir'>[dir2text(A.dir)]</a> <a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=right'>>></a></font>"
-				var/mob/living/M = A
-				body += "<br><font size='1'><a href='?_src_=vars;datumedit=\ref[D];varnameedit=ckey'>[M.ckey ? M.ckey : "No ckey"]</a> / <a href='?_src_=vars;datumedit=\ref[D];varnameedit=real_name'>[M.real_name ? M.real_name : "No real name"]</a></font>"
-				body += {"
-				<br><font size='1'>
-				BRUTE:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=brute'>[M.getBruteLoss()]</a>
-				FIRE:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=fire'>[M.getFireLoss()]</a>
-				TOXIN:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=toxin'>[M.getToxLoss()]</a>
-				OXY:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=oxygen'>[M.getOxyLoss()]</a>
-				CLONE:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=clone'>[M.getCloneLoss()]</a>
-				BRAIN:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=brain'>[M.getBrainLoss()]</a>
-				</font>
-
-
-				"}
-			else
-				body += "<a href='?_src_=vars;datumedit=\ref[D];varnameedit=name'><b>[D]</b></a>"
-				if(A.dir)
-					body += "<br><font size='1'><a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=left'><<</a> <a href='?_src_=vars;datumedit=\ref[D];varnameedit=dir'>[dir2text(A.dir)]</a> <a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=right'>>></a></font>"
-		else
-			body += "<b>[D]</b>"
-
-		body += "</div>"
-
-		body += "</tr></td></table>"
-
-		var/formatted_type = text("[D.type]")
-		if(length(formatted_type) > 25)
-			var/middle_point = length(formatted_type) / 2
-			var/splitpoint = findtext(formatted_type,"/",middle_point)
-			if(splitpoint)
-				formatted_type = "[copytext(formatted_type,1,splitpoint)]<br>[copytext(formatted_type,splitpoint)]"
-			else
-				formatted_type = "Type too long" //No suitable splitpoint (/) found.
-
-		body += "<div align='center'><b><font size='1'>[formatted_type]</font></b>"
-
-		if(src.holder && src.holder.marked_datum && src.holder.marked_datum == D)
-			body += "<br><font size='1' color='red'><b>Marked Object</b></font>"
-
-		body += "</div>"
-
-		body += "</div></td>"
-
-		body += "<td width='50%'><div align='center'><a href='?_src_=vars;datumrefresh=\ref[D]'>Refresh</a>"
-
-		//if(ismob(D))
-		//	body += "<br><a href='?_src_=vars;mob_player_panel=\ref[D]'>Show player panel</a></div></td></tr></table></div><hr>"
-
-		body += {"	<form>
-					<select name="file" size="1"
-					onchange="loadPage(this.form.elements\[0\])"
-					target="_parent._top"
-					onmouseclick="this.focus()"
-					style="background-color:#ffffff">
-				"}
-
-		body += {"	<option value>Select option</option>
-  					<option value> </option>
-				"}
-
-
-		body += "<option value='?_src_=vars;mark_object=\ref[D]'>Mark Object</option>"
-		body += "<option value='?_src_=vars;proc_call=\ref[D]'>Call Proc</option>"
-		if(ismob(D))
-			body += "<option value='?_src_=vars;mob_player_panel=\ref[D]'>Show player panel</option>"
-
-		body += "<option value>---</option>"
-
-		if(ismob(D))
-			body += "<option value='?_src_=vars;give_spell=\ref[D]'>Give Spell</option>"
-			body += "<option value='?_src_=vars;give_disease2=\ref[D]'>Give Disease</option>"
-			body += "<option value='?_src_=vars;godmode=\ref[D]'>Toggle Godmode</option>"
-			body += "<option value='?_src_=vars;build_mode=\ref[D]'>Toggle Build Mode</option>"
-
-			body += "<option value='?_src_=vars;make_skeleton=\ref[D]'>Make 2spooky</option>"
-
-			body += "<option value='?_src_=vars;direct_control=\ref[D]'>Assume Direct Control</option>"
-			body += "<option value='?_src_=vars;offer_control=\ref[D]'>Offer Control to Ghosts</option>"
-			body += "<option value='?_src_=vars;drop_everything=\ref[D]'>Drop Everything</option>"
-
-			body += "<option value='?_src_=vars;regenerateicons=\ref[D]'>Regenerate Icons</option>"
-			body += "<option value='?_src_=vars;addlanguage=\ref[D]'>Add Language</option>"
-			body += "<option value='?_src_=vars;remlanguage=\ref[D]'>Remove Language</option>"
-			body += "<option value='?_src_=vars;addorgan=\ref[D]'>Add Organ</option>"
-			body += "<option value='?_src_=vars;remorgan=\ref[D]'>Remove Organ</option>"
-
-			body += "<option value='?_src_=vars;fix_nano=\ref[D]'>Fix NanoUI</option>"
-
-			body += "<option value='?_src_=vars;addverb=\ref[D]'>Add Verb</option>"
-			body += "<option value='?_src_=vars;remverb=\ref[D]'>Remove Verb</option>"
-			if(ishuman(D))
-				body += "<option value>---</option>"
-				body += "<option value='?_src_=vars;setspecies=\ref[D]'>Set Species</option>"
-				body += "<option value='?_src_=vars;makeai=\ref[D]'>Make AI</option>"
-				body += "<option value='?_src_=vars;makemask=\ref[D]'>Make Mask of Nar'sie</option>"
-				body += "<option value='?_src_=vars;makerobot=\ref[D]'>Make cyborg</option>"
-				body += "<option value='?_src_=vars;makemonkey=\ref[D]'>Make monkey</option>"
-				body += "<option value='?_src_=vars;makealien=\ref[D]'>Make alien</option>"
-				body += "<option value='?_src_=vars;makeslime=\ref[D]'>Make slime</option>"
-				body += "<option value='?_src_=vars;makesuper=\ref[D]'>Make superhero</option>"
-			body += "<option value>---</option>"
-			body += "<option value='?_src_=vars;gib=\ref[D]'>Gib</option>"
-		if(isobj(D))
-			body += "<option value='?_src_=vars;delall=\ref[D]'>Delete all of type</option>"
-		if(isobj(D) || ismob(D) || isturf(D))
-			body += "<option value='?_src_=vars;addreagent=\ref[D]'>Add reagent</option>"
-			body += "<option value='?_src_=vars;explode=\ref[D]'>Trigger explosion</option>"
-			body += "<option value='?_src_=vars;emp=\ref[D]'>Trigger EM pulse</option>"
-
-		body += "</select></form>"
-
-		body += "</div></td></tr></table></div><hr>"
-
-		body += "<font size='1'><b>E</b> - Edit, tries to determine the variable type by itself.<br>"
-		body += "<b>C</b> - Change, asks you for the var type first.<br>"
-		body += "<b>M</b> - Mass modify: changes this variable for all objects of this type.</font><br>"
-
-		body += "<hr><table width='100%'><tr><td width='20%'><div align='center'><b>Search:</b></div></td><td width='80%'><input type='text' id='filter' name='filter_text' value='' style='width:100%;'></td></tr></table><hr>"
-
-		body += "<ol id='vars'>"
-
-		var/list/names = list()
-		for (var/V in D.vars)
-			names += V
-
-		names = sortList(names)
-
-		for (var/V in names)
-			body += debug_variable(V, D.vars[V], 0, D)
-
-		body += "</ol>"
-
-		var/html = "<html><head>"
-		if (title)
-			html += "<title>[title]</title>"
-		html += {"<style>
-	body
-	{
-		font-family: Verdana, sans-serif;
-		font-size: 9pt;
-	}
-	.value
-	{
-		font-family: "Courier New", monospace;
-		font-size: 8pt;
-	}
-	</style>"}
-		html += "</head><body>"
-		html += body
-
-		html += {"
-			<script type='text/javascript'>
-				var vars_ol = document.getElementById("vars");
-				var complete_list = vars_ol.innerHTML;
-			</script>
-		"}
-
-		html += "</body></html>"
-
-		usr << browse(html, "window=variables\ref[D];size=475x650")
-
+	if(!usr.client || !usr.client.holder)
+		usr << "\red You need to be an administrator to access this."
 		return
 
-	proc/debug_variable(name, value, level, var/datum/DA = null)
-		var/html = ""
 
-		if(DA)
-			html += "<li style='backgroundColor:white'>(<a href='?_src_=vars;datumedit=\ref[DA];varnameedit=[name]'>E</a>) (<a href='?_src_=vars;datumchange=\ref[DA];varnamechange=[name]'>C</a>) (<a href='?_src_=vars;datummass=\ref[DA];varnamemass=[name]'>M</a>) "
+	var/title = ""
+	var/body = ""
+
+	if(!D)	return
+	if(istype(D, /atom))
+		var/atom/A = D
+		title = "[A.name] (\ref[A]) = [A.type]"
+
+		#ifdef VARSICON
+		if (A.icon)
+			body += debug_variable("icon", new/icon(A.icon, A.icon_state, A.dir), 0)
+		#endif
+
+	var/icon/sprite
+
+	if(istype(D,/atom))
+		var/atom/AT = D
+		if(AT.icon && AT.icon_state)
+			sprite = new /icon(AT.icon, AT.icon_state)
+			usr << browse_rsc(sprite, "view_vars_sprite.png")
+
+	title = "[D] (\ref[D]) = [D.type]"
+
+	body += {"<script type="text/javascript">
+
+				function updateSearch(){
+					var filter_text = document.getElementById('filter');
+					var filter = filter_text.value.toLowerCase();
+
+					if(event.keyCode == 13){	//Enter / return
+						var vars_ol = document.getElementById('vars');
+						var lis = vars_ol.getElementsByTagName("li");
+						for ( var i = 0; i < lis.length; ++i )
+						{
+							try{
+								var li = lis\[i\];
+								if ( li.style.backgroundColor == "#ffee88" )
+								{
+									alist = lis\[i\].getElementsByTagName("a")
+									if(alist.length > 0){
+										location.href=alist\[0\].href;
+									}
+								}
+							}catch(err) {   }
+						}
+						return
+					}
+
+					if(event.keyCode == 38){	//Up arrow
+						var vars_ol = document.getElementById('vars');
+						var lis = vars_ol.getElementsByTagName("li");
+						for ( var i = 0; i < lis.length; ++i )
+						{
+							try{
+								var li = lis\[i\];
+								if ( li.style.backgroundColor == "#ffee88" )
+								{
+									if( (i-1) >= 0){
+										var li_new = lis\[i-1\];
+										li.style.backgroundColor = "white";
+										li_new.style.backgroundColor = "#ffee88";
+										return
+									}
+								}
+							}catch(err) {  }
+						}
+						return
+					}
+
+					if(event.keyCode == 40){	//Down arrow
+						var vars_ol = document.getElementById('vars');
+						var lis = vars_ol.getElementsByTagName("li");
+						for ( var i = 0; i < lis.length; ++i )
+						{
+							try{
+								var li = lis\[i\];
+								if ( li.style.backgroundColor == "#ffee88" )
+								{
+									if( (i+1) < lis.length){
+										var li_new = lis\[i+1\];
+										li.style.backgroundColor = "white";
+										li_new.style.backgroundColor = "#ffee88";
+										return
+									}
+								}
+							}catch(err) {  }
+						}
+						return
+					}
+
+					//This part here resets everything to how it was at the start so the filter is applied to the complete list. Screw efficiency, it's client-side anyway and it only looks through 200 or so variables at maximum anyway (mobs).
+					if(complete_list != null && complete_list != ""){
+						var vars_ol1 = document.getElementById("vars");
+						vars_ol1.innerHTML = complete_list
+					}
+
+					if(filter.value == ""){
+						return;
+					}else{
+						var vars_ol = document.getElementById('vars');
+						var lis = vars_ol.getElementsByTagName("li");
+
+						for ( var i = 0; i < lis.length; ++i )
+						{
+							try{
+								var li = lis\[i\];
+								if ( li.innerText.toLowerCase().indexOf(filter) == -1 )
+								{
+									vars_ol.removeChild(li);
+									i--;
+								}
+							}catch(err) {   }
+						}
+					}
+					var lis_new = vars_ol.getElementsByTagName("li");
+					for ( var j = 0; j < lis_new.length; ++j )
+					{
+						var li1 = lis\[j\];
+						if (j == 0){
+							li1.style.backgroundColor = "#ffee88";
+						}else{
+							li1.style.backgroundColor = "white";
+						}
+					}
+				}
+
+
+
+				function selectTextField(){
+					var filter_text = document.getElementById('filter');
+					filter_text.focus();
+					filter_text.select();
+
+				}
+
+				function loadPage(list) {
+
+					if(list.options\[list.selectedIndex\].value == ""){
+						return;
+					}
+
+					location.href=list.options\[list.selectedIndex\].value;
+
+				}
+			</script> "}
+
+	body += "<body onload='selectTextField(); updateSearch()' onkeyup='updateSearch()'>"
+
+	body += "<div align='center'><table width='100%'><tr><td width='50%'>"
+
+	if(sprite)
+		body += "<table align='center' width='100%'><tr><td><img src='view_vars_sprite.png'></td><td>"
+	else
+		body += "<table align='center' width='100%'><tr><td>"
+
+	body += "<div align='center'>"
+
+	if(istype(D,/atom))
+		var/atom/A = D
+		if(isliving(A))
+			body += "<a href='?_src_=vars;rename=\ref[D]'><b>[D]</b></a>"
+			if(A.dir)
+				body += "<br><font size='1'><a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=left'><<</a> <a href='?_src_=vars;datumedit=\ref[D];varnameedit=dir'>[dir2text(A.dir)]</a> <a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=right'>>></a></font>"
+			var/mob/living/M = A
+			body += "<br><font size='1'><a href='?_src_=vars;datumedit=\ref[D];varnameedit=ckey'>[M.ckey ? M.ckey : "No ckey"]</a> / <a href='?_src_=vars;datumedit=\ref[D];varnameedit=real_name'>[M.real_name ? M.real_name : "No real name"]</a></font>"
+			body += {"
+			<br><font size='1'>
+			BRUTE:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=brute'>[M.getBruteLoss()]</a>
+			FIRE:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=fire'>[M.getFireLoss()]</a>
+			TOXIN:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=toxin'>[M.getToxLoss()]</a>
+			OXY:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=oxygen'>[M.getOxyLoss()]</a>
+			CLONE:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=clone'>[M.getCloneLoss()]</a>
+			BRAIN:<font size='1'><a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=brain'>[M.getBrainLoss()]</a>
+			</font>
+
+
+			"}
 		else
-			html += "<li>"
+			body += "<a href='?_src_=vars;datumedit=\ref[D];varnameedit=name'><b>[D]</b></a>"
+			if(A.dir)
+				body += "<br><font size='1'><a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=left'><<</a> <a href='?_src_=vars;datumedit=\ref[D];varnameedit=dir'>[dir2text(A.dir)]</a> <a href='?_src_=vars;rotatedatum=\ref[D];rotatedir=right'>>></a></font>"
+	else
+		body += "<b>[D]</b>"
 
-		if (isnull(value))
-			html += "[name] = <span class='value'>null</span>"
+	body += "</div>"
 
-		else if (istext(value))
-			html += "[name] = <span class='value'>\"[value]\"</span>"
+	body += "</tr></td></table>"
 
-		else if (isicon(value))
-			#ifdef VARSICON
-			var/icon/I = new/icon(value)
-			var/rnd = rand(1,10000)
-			var/rname = "tmp\ref[I][rnd].png"
-			usr << browse_rsc(I, rname)
-			html += "[name] = (<span class='value'>[value]</span>) <img class=icon src=\"[rname]\">"
-			#else
-			html += "[name] = /icon (<span class='value'>[value]</span>)"
-			#endif
+	var/formatted_type = text("[D.type]")
+	if(length(formatted_type) > 25)
+		var/middle_point = length(formatted_type) / 2
+		var/splitpoint = findtext(formatted_type,"/",middle_point)
+		if(splitpoint)
+			formatted_type = "[copytext(formatted_type,1,splitpoint)]<br>[copytext(formatted_type,splitpoint)]"
+		else
+			formatted_type = "Type too long" //No suitable splitpoint (/) found.
+
+	body += "<div align='center'><b><font size='1'>[formatted_type]</font></b>"
+
+	if(src.holder && src.holder.marked_datum && src.holder.marked_datum == D)
+		body += "<br><font size='1' color='red'><b>Marked Object</b></font>"
+
+	body += "</div>"
+
+	body += "</div></td>"
+
+	body += "<td width='50%'><div align='center'><a href='?_src_=vars;datumrefresh=\ref[D]'>Refresh</a>"
+
+	//if(ismob(D))
+	//	body += "<br><a href='?_src_=vars;mob_player_panel=\ref[D]'>Show player panel</a></div></td></tr></table></div><hr>"
+
+	body += {"	<form>
+				<select name="file" size="1"
+				onchange="loadPage(this.form.elements\[0\])"
+				target="_parent._top"
+				onmouseclick="this.focus()"
+				style="background-color:#ffffff">
+			"}
+
+	body += {"	<option value>Select option</option>
+				<option value> </option>
+			"}
+
+
+	body += "<option value='?_src_=vars;mark_object=\ref[D]'>Mark Object</option>"
+	body += "<option value='?_src_=vars;proc_call=\ref[D]'>Call Proc</option>"
+	if(ismob(D))
+		body += "<option value='?_src_=vars;mob_player_panel=\ref[D]'>Show player panel</option>"
+
+	body += "<option value>---</option>"
+
+	if(ismob(D))
+		body += "<option value='?_src_=vars;give_spell=\ref[D]'>Give Spell</option>"
+		body += "<option value='?_src_=vars;give_disease2=\ref[D]'>Give Disease</option>"
+		body += "<option value='?_src_=vars;godmode=\ref[D]'>Toggle Godmode</option>"
+		body += "<option value='?_src_=vars;build_mode=\ref[D]'>Toggle Build Mode</option>"
+
+		body += "<option value='?_src_=vars;make_skeleton=\ref[D]'>Make 2spooky</option>"
+
+		body += "<option value='?_src_=vars;direct_control=\ref[D]'>Assume Direct Control</option>"
+		body += "<option value='?_src_=vars;offer_control=\ref[D]'>Offer Control to Ghosts</option>"
+		body += "<option value='?_src_=vars;drop_everything=\ref[D]'>Drop Everything</option>"
+
+		body += "<option value='?_src_=vars;regenerateicons=\ref[D]'>Regenerate Icons</option>"
+		body += "<option value='?_src_=vars;addlanguage=\ref[D]'>Add Language</option>"
+		body += "<option value='?_src_=vars;remlanguage=\ref[D]'>Remove Language</option>"
+		body += "<option value='?_src_=vars;addorgan=\ref[D]'>Add Organ</option>"
+		body += "<option value='?_src_=vars;remorgan=\ref[D]'>Remove Organ</option>"
+
+		body += "<option value='?_src_=vars;fix_nano=\ref[D]'>Fix NanoUI</option>"
+
+		body += "<option value='?_src_=vars;addverb=\ref[D]'>Add Verb</option>"
+		body += "<option value='?_src_=vars;remverb=\ref[D]'>Remove Verb</option>"
+		if(ishuman(D))
+			body += "<option value>---</option>"
+			body += "<option value='?_src_=vars;setspecies=\ref[D]'>Set Species</option>"
+			body += "<option value='?_src_=vars;makeai=\ref[D]'>Make AI</option>"
+			body += "<option value='?_src_=vars;makemask=\ref[D]'>Make Mask of Nar'sie</option>"
+			body += "<option value='?_src_=vars;makerobot=\ref[D]'>Make cyborg</option>"
+			body += "<option value='?_src_=vars;makemonkey=\ref[D]'>Make monkey</option>"
+			body += "<option value='?_src_=vars;makealien=\ref[D]'>Make alien</option>"
+			body += "<option value='?_src_=vars;makeslime=\ref[D]'>Make slime</option>"
+			body += "<option value='?_src_=vars;makesuper=\ref[D]'>Make superhero</option>"
+		body += "<option value>---</option>"
+		body += "<option value='?_src_=vars;gib=\ref[D]'>Gib</option>"
+	if(isobj(D))
+		body += "<option value='?_src_=vars;delall=\ref[D]'>Delete all of type</option>"
+	if(isobj(D) || ismob(D) || isturf(D))
+		body += "<option value='?_src_=vars;addreagent=\ref[D]'>Add reagent</option>"
+		body += "<option value='?_src_=vars;explode=\ref[D]'>Trigger explosion</option>"
+		body += "<option value='?_src_=vars;emp=\ref[D]'>Trigger EM pulse</option>"
+
+	body += "</select></form>"
+
+	body += "</div></td></tr></table></div><hr>"
+
+	body += "<font size='1'><b>E</b> - Edit, tries to determine the variable type by itself.<br>"
+	body += "<b>C</b> - Change, asks you for the var type first.<br>"
+	body += "<b>M</b> - Mass modify: changes this variable for all objects of this type.</font><br>"
+
+	body += "<hr><table width='100%'><tr><td width='20%'><div align='center'><b>Search:</b></div></td><td width='80%'><input type='text' id='filter' name='filter_text' value='' style='width:100%;'></td></tr></table><hr>"
+
+	body += "<ol id='vars'>"
+
+	var/list/names = list()
+	for (var/V in D.vars)
+		names += V
+
+	names = sortList(names)
+
+	for (var/V in names)
+		body += debug_variable(V, D.vars[V], 0, D)
+
+	body += "</ol>"
+
+	var/html = "<html><head>"
+	if (title)
+		html += "<title>[title]</title>"
+	html += {"<style>
+body
+{
+	font-family: Verdana, sans-serif;
+	font-size: 9pt;
+}
+.value
+{
+	font-family: "Courier New", monospace;
+	font-size: 8pt;
+}
+</style>"}
+	html += "</head><body>"
+	html += body
+
+	html += {"
+		<script type='text/javascript'>
+			var vars_ol = document.getElementById("vars");
+			var complete_list = vars_ol.innerHTML;
+		</script>
+	"}
+
+	html += "</body></html>"
+
+	usr << browse(html, "window=variables\ref[D];size=475x650")
+
+	return
+
+/client/proc/debug_variable(name, value, level, var/datum/DA = null)
+	var/html = ""
+
+	if(DA)
+		html += "<li style='backgroundColor:white'>(<a href='?_src_=vars;datumedit=\ref[DA];varnameedit=[name]'>E</a>) (<a href='?_src_=vars;datumchange=\ref[DA];varnamechange=[name]'>C</a>) (<a href='?_src_=vars;datummass=\ref[DA];varnamemass=[name]'>M</a>) "
+	else
+		html += "<li>"
+
+	if (isnull(value))
+		html += "[name] = <span class='value'>null</span>"
+
+	else if (istext(value))
+		html += "[name] = <span class='value'>\"[value]\"</span>"
+
+	else if (isicon(value))
+		#ifdef VARSICON
+		var/icon/I = new/icon(value)
+		var/rnd = rand(1,10000)
+		var/rname = "tmp\ref[I][rnd].png"
+		usr << browse_rsc(I, rname)
+		html += "[name] = (<span class='value'>[value]</span>) <img class=icon src=\"[rname]\">"
+		#else
+		html += "[name] = /icon (<span class='value'>[value]</span>)"
+		#endif
 
 /*		else if (istype(value, /image))
-			#ifdef VARSICON
-			var/rnd = rand(1, 10000)
-			var/image/I = value
+		#ifdef VARSICON
+		var/rnd = rand(1, 10000)
+		var/image/I = value
 
-			src << browse_rsc(I.icon, "tmp\ref[value][rnd].png")
-			html += "[name] = <img src=\"tmp\ref[value][rnd].png\">"
-			#else
-			html += "[name] = /image (<span class='value'>[value]</span>)"
-			#endif
+		src << browse_rsc(I.icon, "tmp\ref[value][rnd].png")
+		html += "[name] = <img src=\"tmp\ref[value][rnd].png\">"
+		#else
+		html += "[name] = /image (<span class='value'>[value]</span>)"
+		#endif
 */
-		else if (isfile(value))
-			html += "[name] = <span class='value'>'[value]'</span>"
+	else if (isfile(value))
+		html += "[name] = <span class='value'>'[value]'</span>"
 
-		else if (istype(value, /datum))
-			var/datum/D = value
-			html += "<a href='?_src_=vars;Vars=\ref[value]'>[name] \ref[value]</a> = [D.type]"
+	else if (istype(value, /datum))
+		var/datum/D = value
+		html += "<a href='?_src_=vars;Vars=\ref[value]'>[name] \ref[value]</a> = [D.type]"
 
-		else if (istype(value, /client))
-			var/client/C = value
-			html += "<a href='?_src_=vars;Vars=\ref[value]'>[name] \ref[value]</a> = [C] [C.type]"
-	//
-		else if (istype(value, /list))
-			var/list/L = value
-			html += "[name] = /list ([L.len])"
+	else if (istype(value, /client))
+		var/client/C = value
+		html += "<a href='?_src_=vars;Vars=\ref[value]'>[name] \ref[value]</a> = [C] [C.type]"
+//
+	else if (istype(value, /list))
+		var/list/L = value
+		html += "[name] = /list ([L.len])"
 
-			if (L.len > 0 && !(name == "underlays" || name == "overlays" || name == "vars" || L.len > 500))
-				// not sure if this is completely right...
-				if(0)   //(L.vars.len > 0)
-					html += "<ol>"
-					html += "</ol>"
-				else
-					html += "<ul>"
-					var/index = 1
-					for (var/entry in L)
-						if(istext(entry))
-							html += debug_variable(entry, L[entry], level + 1)
-						//html += debug_variable("[index]", L[index], level + 1)
-						else
-							html += debug_variable(index, L[index], level + 1)
-						index++
-					html += "</ul>"
+		if (L.len > 0 && !(name == "underlays" || name == "overlays" || name == "vars" || L.len > 500))
+			// not sure if this is completely right...
+			if(0)   //(L.vars.len > 0)
+				html += "<ol>"
+				html += "</ol>"
+			else
+				html += "<ul>"
+				var/index = 1
+				for (var/entry in L)
+					if(istext(entry))
+						html += debug_variable(entry, L[entry], level + 1)
+					//html += debug_variable("[index]", L[index], level + 1)
+					else
+						html += debug_variable(index, L[index], level + 1)
+					index++
+				html += "</ul>"
 
-		else
-			html += "[name] = <span class='value'>[value]</span>"
-			/*
-			// Bitfield stuff
-			if(round(value)==value) // Require integers.
-				var/idx=0
-				var/bit=0
-				var/bv=0
-				html += "<div class='value binary'>"
-				for(var/block=0;block<8;block++)
-					html += " <span class='block'>"
-					for(var/i=0;i<4;i++)
-						idx=(block*4)+i
-						bit=1 << idx
-						bv=value & bit
-						html += "<a href='?_src_=vars;togbit=[idx];var=[name];subject=\ref[DA]' title='bit [idx] ([bit])'>[bv?1:0]</a>"
-					html += "</span>"
-				html += "</div>"
-			*/
-		html += "</li>"
+	else
+		html += "[name] = <span class='value'>[value]</span>"
+		/*
+		// Bitfield stuff
+		if(round(value)==value) // Require integers.
+			var/idx=0
+			var/bit=0
+			var/bv=0
+			html += "<div class='value binary'>"
+			for(var/block=0;block<8;block++)
+				html += " <span class='block'>"
+				for(var/i=0;i<4;i++)
+					idx=(block*4)+i
+					bit=1 << idx
+					bv=value & bit
+					html += "<a href='?_src_=vars;togbit=[idx];var=[name];subject=\ref[DA]' title='bit [idx] ([bit])'>[bv?1:0]</a>"
+				html += "</span>"
+			html += "</div>"
+		*/
+	html += "</li>"
 
-		return html
+	return html
 
 /client/proc/view_var_Topic(href, href_list, hsrc)
 	//This should all be moved over to datum/admins/Topic() or something ~Carn

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -499,7 +499,7 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/destructive_analyzer
 	name = "Circuit board (Destructive Analyzer)"
-	build_path = "/obj/machinery/r_n_d/destructive_analyzer"
+	build_path = /obj/machinery/r_n_d/destructive_analyzer
 	board_type = "machine"
 	origin_tech = "magnets=2;engineering=2;programming=2"
 	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, and 1 Micro-Laser."
@@ -510,7 +510,7 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/autolathe
 	name = "Circuit board (Autolathe)"
-	build_path = "/obj/machinery/autolathe"
+	build_path = /obj/machinery/autolathe
 	board_type = "machine"
 	origin_tech = "engineering=2;programming=2"
 	frame_desc = "Requires 3 Matter Bins, 1 Manipulator, and 1 Console Screen."
@@ -521,7 +521,7 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/protolathe
 	name = "Circuit board (Protolathe)"
-	build_path = "/obj/machinery/r_n_d/protolathe"
+	build_path = /obj/machinery/r_n_d/protolathe
 	board_type = "machine"
 	origin_tech = "engineering=2;programming=2"
 	frame_desc = "Requires 2 Matter Bins, 2 Manipulators, and 2 Beakers."
@@ -533,7 +533,7 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/circuit_imprinter
 	name = "Circuit board (Circuit Imprinter)"
-	build_path = "/obj/machinery/r_n_d/circuit_imprinter"
+	build_path = /obj/machinery/r_n_d/circuit_imprinter
 	board_type = "machine"
 	origin_tech = "engineering=2;programming=2"
 	frame_desc = "Requires 1 Matter Bin, 1 Manipulator, and 2 Beakers."
@@ -544,7 +544,7 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/pacman
 	name = "Circuit Board (PACMAN-type Generator)"
-	build_path = "/obj/machinery/power/port_gen/pacman"
+	build_path = /obj/machinery/power/port_gen/pacman
 	board_type = "machine"
 	origin_tech = "programming=3:powerstorage=3;plasmatech=3;engineering=3"
 	frame_desc = "Requires 1 Matter Bin, 1 Micro-Laser, 2 Pieces of Cable, and 1 Capacitor."
@@ -556,17 +556,17 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/pacman/super
 	name = "Circuit Board (SUPERPACMAN-type Generator)"
-	build_path = "/obj/machinery/power/port_gen/pacman/super"
+	build_path = /obj/machinery/power/port_gen/pacman/super
 	origin_tech = "programming=3;powerstorage=4;engineering=4"
 
 /obj/item/weapon/circuitboard/pacman/mrs
 	name = "Circuit Board (MRSPACMAN-type Generator)"
-	build_path = "/obj/machinery/power/port_gen/pacman/mrs"
+	build_path = /obj/machinery/power/port_gen/pacman/mrs
 	origin_tech = "programming=3;powerstorage=5;engineering=5"
 
 obj/item/weapon/circuitboard/rdserver
 	name = "Circuit Board (R&D Server)"
-	build_path = "/obj/machinery/r_n_d/server"
+	build_path = /obj/machinery/r_n_d/server
 	board_type = "machine"
 	origin_tech = "programming=3"
 	frame_desc = "Requires 2 pieces of cable, and 1 Scanning Module."
@@ -576,7 +576,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/mechfab
 	name = "Circuit board (Exosuit Fabricator)"
-	build_path = "/obj/machinery/mecha_part_fabricator"
+	build_path = /obj/machinery/mecha_part_fabricator
 	board_type = "machine"
 	origin_tech = "programming=3;engineering=3"
 	frame_desc = "Requires 2 Matter Bins, 1 Manipulator, 1 Micro-Laser and 1 Console Screen."
@@ -588,7 +588,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/podfab
 	name = "Circuit board (Spacepod Fabricator)"
-	build_path = "/obj/machinery/spod_part_fabricator" //ah fuck my life
+	build_path = /obj/machinery/spod_part_fabricator //ah fuck my life
 	board_type = "machine"
 	origin_tech = "programming=3;engineering=3"
 	frame_desc = "Requires 3 Matter Bins, 2 Manipulators, 2 Micro-Lasers, and 1 Console Screen."
@@ -601,7 +601,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/clonepod
 	name = "Circuit board (Clone Pod)"
-	build_path = "/obj/machinery/clonepod"
+	build_path = /obj/machinery/clonepod
 	board_type = "machine"
 	origin_tech = "programming=3;biotech=3"
 	frame_desc = "Requires 2 Manipulator, 2 Scanning Module, 2 pieces of cable and 1 Console Screen."
@@ -613,7 +613,7 @@ obj/item/weapon/circuitboard/rdserver
 
 /obj/item/weapon/circuitboard/clonescanner
 	name = "Circuit board (Cloning Scanner)"
-	build_path = "/obj/machinery/dna_scannernew"
+	build_path = /obj/machinery/dna_scannernew
 	board_type = "machine"
 	origin_tech = "programming=2;biotech=2"
 	frame_desc = "Requires 1 Scanning Module, 1 Manipulator, 1 Micro-Laser, 2 pieces of cable and 1 Console Screen."

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -26,13 +26,10 @@ var/list/forbidden_varedit_object_types = list(
 /client/proc/mod_list_add_ass() //haha
 
 	var/class = "text"
+	var/list/allowed_types = list("text", "num","type", "type from text","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
 	if(src.holder && src.holder.marked_datum)
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
-	else
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
-
+		allowed_types += "marked datum ([holder.marked_datum.type])"
+	class = input("What kind of variable?","Variable Type") as null|anything in allowed_types
 	if(!class)
 		return
 
@@ -51,6 +48,12 @@ var/list/forbidden_varedit_object_types = list(
 
 		if("type")
 			var_value = input("Enter type:","Type") as null|anything in typesof(/obj,/mob,/area,/turf)
+
+		if("type from text")
+			var/type_text = input("Enter type:", "Type") as null|message
+			var_value = text2path(type_text)
+			if(!var_value)
+				src << "<span class='warning'>[type_text] is not a valid path!</span>"
 
 		if("reference")
 			var_value = input("Select reference:","Reference") as null|mob|obj|turf|area in world
@@ -75,12 +78,10 @@ var/list/forbidden_varedit_object_types = list(
 /client/proc/mod_list_add(var/list/L)
 
 	var/class = "text"
+	var/list/allowed_types = list("text", "num","type", "type from text","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
 	if(src.holder && src.holder.marked_datum)
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
-	else
-		class = input("What kind of variable?","Variable Type") as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+		allowed_types += "marked datum ([holder.marked_datum.type])"
+	class = input("What kind of variable?","Variable Type") as null|anything in allowed_types
 
 	if(!class)
 		return
@@ -100,6 +101,12 @@ var/list/forbidden_varedit_object_types = list(
 
 		if("type")
 			var_value = input("Enter type:","Type") in typesof(/obj,/mob,/area,/turf)
+
+		if("type from text")
+			var/type_text = input("Enter type:", "Type") as null|message
+			var_value = text2path(type_text)
+			if(!var_value)
+				src << "<span class='warning'>[type_text] is not a valid path!</span>"
 
 		if("reference")
 			var_value = input("Select reference:","Reference") as mob|obj|turf|area in world
@@ -173,75 +180,21 @@ var/list/forbidden_varedit_object_types = list(
 	if(variable in locked)
 		if(!check_rights(R_DEBUG))	return
 
-	if(isnull(variable))
-		usr << "Unable to determine variable type."
-
-	else if(isnum(variable))
-		usr << "Variable appears to be <b>NUM</b>."
-		default = "num"
-		dir = 1
-
-	else if(istext(variable))
-		usr << "Variable appears to be <b>TEXT</b>."
-		default = "text"
-
-	else if(isloc(variable))
-		usr << "Variable appears to be <b>REFERENCE</b>."
-		default = "reference"
-
-	else if(isicon(variable))
-		usr << "Variable appears to be <b>ICON</b>."
-		variable = "\icon[variable]"
-		default = "icon"
-
-	else if(istype(variable,/atom) || istype(variable,/datum))
-		usr << "Variable appears to be <b>TYPE</b>."
-		default = "type"
-
-	else if(istype(variable,/list))
-		usr << "Variable appears to be <b>LIST</b>."
-		default = "list"
-
-	else if(istype(variable,/client))
-		usr << "Variable appears to be <b>CLIENT</b>."
-		default = "cancel"
-
-	else
-		usr << "Variable appears to be <b>FILE</b>."
-		default = "file"
+	default = variable_to_type(variable)
 
 	usr << "Variable contains: [variable]"
-	if(dir)
-		switch(variable)
-			if(1)
-				dir = "NORTH"
-			if(2)
-				dir = "SOUTH"
-			if(4)
-				dir = "EAST"
-			if(8)
-				dir = "WEST"
-			if(5)
-				dir = "NORTHEAST"
-			if(6)
-				dir = "SOUTHEAST"
-			if(9)
-				dir = "NORTHWEST"
-			if(10)
-				dir = "SOUTHWEST"
-			else
-				dir = null
+	if(default == "num")
+		dir = dir2text(variable)
 
 		if(dir)
 			usr << "If a direction, direction is: [dir]"
 
 	var/class = "text"
+	var/list/allowed_types = list("text", "num","type", "type from text", "reference","mob reference", "icon","file","list","edit referenced object","restore to default","DELETE FROM LIST")
 	if(src.holder && src.holder.marked_datum)
-		class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])", "DELETE FROM LIST")
-	else
-		class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-			"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default", "DELETE FROM LIST")
+		allowed_types += "marked datum ([holder.marked_datum.type])"
+
+	class = input("What kind of variable?","Variable Type",default) as null|anything in allowed_types
 
 	if(!class)
 		return
@@ -325,7 +278,7 @@ var/list/forbidden_varedit_object_types = list(
 		if( istype(O,p) )
 			usr << "<span class='warning'>It is forbidden to edit this object's variables.</span>"
 			return
-			
+
 	if(istype(O, /client) && (param_var_name == "ckey" || param_var_name == "key"))
 		usr << "<span class='warning'>You cannot edit ckeys on client objects.</span>"
 		return
@@ -347,44 +300,11 @@ var/list/forbidden_varedit_object_types = list(
 		var_value = O.vars[variable]
 
 		if(autodetect_class)
-			if(isnull(var_value))
-				usr << "Unable to determine variable type."
-				class = null
+			class = variable_to_type(var_value)
+			if(!class)
 				autodetect_class = null
-			else if(isnum(var_value))
-				usr << "Variable appears to be <b>NUM</b>."
-				class = "num"
+			else if(class == "num")
 				dir = 1
-
-			else if(istext(var_value))
-				usr << "Variable appears to be <b>TEXT</b>."
-				class = "text"
-
-			else if(isloc(var_value))
-				usr << "Variable appears to be <b>REFERENCE</b>."
-				class = "reference"
-
-			else if(isicon(var_value))
-				usr << "Variable appears to be <b>ICON</b>."
-				var_value = "\icon[var_value]"
-				class = "icon"
-
-			else if(istype(var_value,/atom) || istype(var_value,/datum))
-				usr << "Variable appears to be <b>TYPE</b>."
-				class = "type"
-
-			else if(istype(var_value,/list))
-				usr << "Variable appears to be <b>LIST</b>."
-				class = "list"
-
-			else if(istype(var_value,/client))
-				usr << "Variable appears to be <b>CLIENT</b>."
-				class = "cancel"
-
-			else
-				usr << "Variable appears to be <b>FILE</b>."
-				class = "file"
-
 	else
 
 		var/list/names = list()
@@ -404,73 +324,23 @@ var/list/forbidden_varedit_object_types = list(
 
 		var/dir
 		var/default
-		if(isnull(var_value))
-			usr << "Unable to determine variable type."
-
-		else if(isnum(var_value))
-			usr << "Variable appears to be <b>NUM</b>."
-			default = "num"
+		default = variable_to_type(var_value)
+		if(default == "num")
 			dir = 1
-
-		else if(istext(var_value))
-			usr << "Variable appears to be <b>TEXT</b>."
-			default = "text"
-
-		else if(isloc(var_value))
-			usr << "Variable appears to be <b>REFERENCE</b>."
-			default = "reference"
-
-		else if(isicon(var_value))
-			usr << "Variable appears to be <b>ICON</b>."
+		else if(default == "icon")
 			var_value = "\icon[var_value]"
-			default = "icon"
-
-		else if(istype(var_value,/atom) || istype(var_value,/datum))
-			usr << "Variable appears to be <b>TYPE</b>."
-			default = "type"
-
-		else if(istype(var_value,/list))
-			usr << "Variable appears to be <b>LIST</b>."
-			default = "list"
-
-		else if(istype(var_value,/client))
-			usr << "Variable appears to be <b>CLIENT</b>."
-			default = "cancel"
-
-		else
-			usr << "Variable appears to be <b>FILE</b>."
-			default = "file"
 
 		usr << "Variable contains: [var_value]"
 		if(dir)
-			switch(var_value)
-				if(1)
-					dir = "NORTH"
-				if(2)
-					dir = "SOUTH"
-				if(4)
-					dir = "EAST"
-				if(8)
-					dir = "WEST"
-				if(5)
-					dir = "NORTHEAST"
-				if(6)
-					dir = "SOUTHEAST"
-				if(9)
-					dir = "NORTHWEST"
-				if(10)
-					dir = "SOUTHWEST"
-				else
-					dir = null
+			dir = dir2text(var_value)
 			if(dir)
 				usr << "If a direction, direction is: [dir]"
 
+		var/list/allowed_types = list("text", "num","type","reference","mob reference", "path", "matrix", "icon","file","list","edit referenced object","restore to default")
 		if(src.holder && src.holder.marked_datum)
-			class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default","marked datum ([holder.marked_datum.type])")
-		else
-			class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-				"num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+			allowed_types += "marked datum ([holder.marked_datum.type])"
+
+		class = input("What kind of variable?","Variable Type",default) as null|anything in allowed_types
 
 		if(!class)
 			return
@@ -485,6 +355,7 @@ var/list/forbidden_varedit_object_types = list(
 	if(holder.marked_datum && class == "marked datum ([holder.marked_datum.type])")
 		class = "marked datum"
 
+	var/var_as_text = null
 	switch(class)
 
 		if("list")
@@ -507,13 +378,13 @@ var/list/forbidden_varedit_object_types = list(
 				var/var_new = input("Enter new number:","Num",O.vars[variable]) as null|num
 				if(var_new == null) return
 				O.set_light(var_new)
-			else if(variable=="stat")
+			else if(variable=="stat") // ow, but I guess I'm glad you're trying to prevent at least one kind of inconsistent state...? This is the VARIABLE EDITOR, I'm not sure we need to worry...?
 				var/var_new = input("Enter new number:","Num",O.vars[variable]) as null|num
 				if(var_new == null) return
-				if((O.vars[variable] == 2) && (var_new < 2))//Bringing the dead back to life
+				if((O.vars[variable] == DEAD) && (var_new < DEAD))//Bringing the dead back to life
 					dead_mob_list -= O
 					living_mob_list += O
-				if((O.vars[variable] < 2) && (var_new == 2))//Kill he
+				if((O.vars[variable] < DEAD) && (var_new == DEAD))//Kill he
 					living_mob_list -= O
 					dead_mob_list += O
 				O.vars[variable] = var_new
@@ -526,6 +397,23 @@ var/list/forbidden_varedit_object_types = list(
 			var/var_new = input("Enter type:","Type",O.vars[variable]) as null|anything in typesof(/obj,/mob,/area,/turf)
 			if(var_new==null) return
 			O.vars[variable] = var_new
+
+		if("path")
+			var/path_text = input("Enter path:", "Path",O.vars[variable]) as null|text
+			var/var_new = text2path(path_text)
+			if(!var_new && path_text != null) // So aborting doesn't bother the VVer
+				usr << "<span class='warning'>[path_text] does not appear to be a valid path.</span>"
+				return
+			O.vars[variable] = var_new
+
+		if("matrix")
+			var/matrix_text = input("Enter a, b, c, d, e, and f, separated by a space.", "Matrix", "1 0 0 0 1 0") as null|text
+			var/var_new = text2matrix(matrix_text)
+			if(!var_new && matrix_text != null)
+				usr << "<span class='warning'>[matrix_text] is not a valid matrix string.</span>"
+				return
+			O.vars[variable] = var_new
+			var_as_text = "matrix([matrix_text])"
 
 		if("reference")
 			var/var_new = input("Select reference:","Reference",O.vars[variable]) as null|mob|obj|turf|area in world
@@ -550,7 +438,62 @@ var/list/forbidden_varedit_object_types = list(
 		if("marked datum")
 			O.vars[variable] = holder.marked_datum
 
-	log_to_dd("### VarEdit by [src]: [O.type] [variable]=[html_encode("[O.vars[variable]]")]")
-	log_admin("[key_name(src)] modified [original_name]'s [variable] to [O.vars[variable]]")
-	message_admins("[key_name_admin(src)] modified [original_name]'s [variable] to [O.vars[variable]]", 1)
+	if(var_as_text == null)
+		var_as_text = "[O.vars[variable]]"
+	log_to_dd("### VarEdit by [src]: [O.type] [variable]=[html_encode("[var_as_text]")]")
+	log_admin("[key_name(src)] modified [original_name]'s [variable] to [var_as_text]")
+	message_admins("[key_name_admin(src)] modified [original_name]'s [variable] to [var_as_text]", 1)
 
+// Let's get this all in one place.
+// You'll need to take care of setting dir or iconizing the variable yourself once you've called this
+/proc/variable_to_type(var/variable)
+	var/class
+	if(isnull(variable))
+		usr << "Unable to determine variable type."
+		class = null
+	else if(isnum(variable))
+		usr << "Variable appears to be <b>NUM</b>."
+		class = "num"
+
+	else if(istext(variable))
+		usr << "Variable appears to be <b>TEXT</b>."
+		class = "text"
+
+	else if(isloc(variable))
+		usr << "Variable appears to be <b>REFERENCE</b>."
+		class = "reference"
+
+	else if(isicon(variable))
+		usr << "Variable appears to be <b>ICON</b>."
+		variable = "\icon[variable]"
+		class = "icon"
+
+	else if(istype(variable,/matrix))
+		usr << "Variable appears to be <b>MATRIX</b>"
+		class = "matrix"
+
+	else if(istype(variable,/atom) || istype(variable,/datum))
+		usr << "Variable appears to be <b>TYPE</b>."
+		class = "type"
+
+	else if(istype(variable,/list))
+		usr << "Variable appears to be <b>LIST</b>."
+		class = "list"
+
+	else if(istype(variable,/client))
+		usr << "Variable appears to be <b>CLIENT</b>."
+		class = "cancel"
+
+	else if(ispath(variable))
+		usr << "Variable appears to be <b>PATH</b>."
+		class = "path"
+
+	else if(isfile(variable))
+		usr << "Variable appears to be <b>FILE</b>."
+		class = "file"
+
+	else
+		usr << "Variable type is <b>UNKNOWN</b>."
+		class = null
+
+	return class


### PR DESCRIPTION
I wasn't able to find a method of simply VIEWING a matrix, however - info would be welcome!

- [ ] Add a means of actually viewing a matrix instead of just overwriting it
- [ ] Refactor variable editing code to separate out the special-case edits (`stat` and `luminosity`) into a different proc, and push special variable behavior there

:cl:Crazylemon
rscadd: People with VAREDIT can now write matrix variables
rscadd: People with VAREDIT can now modify path variables
tweak: Refactors the variable editor code somewhat.
/:cl: