### PR TITLE
New players no longer show up as dead under an admin's who

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -24,6 +24,8 @@
 							entry += " - <font color='gray'>Observing</font>"
 						else
 							entry += " - <font color='black'><b>DEAD</b></font>"
+					else if (istype(C.mob, /mob/new_player))
+						entry += " - <font color='green'>New Player</font>"
 					else
 						entry += " - <font color='black'><b>DEAD</b></font>"
 


### PR DESCRIPTION
:cl:Crazylemon
tweak: New players now show up properly under the "who" verb when used as an admin
/:cl: