### PR TITLE
Fixes genetics disks (#3657)

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -36,6 +36,18 @@
 			ser["type"] = "se"
 	return ser
 
+/datum/dna2/record/proc/copy()
+	var/datum/dna2/record/newrecord = new /datum/dna2/record
+	newrecord.dna = dna.Clone()
+	newrecord.types = types
+	newrecord.name = name
+	newrecord.mind = mind
+	newrecord.ckey = ckey
+	newrecord.languages = languages
+	newrecord.implant = implant
+	return newrecord
+
+
 /////////////////////////// DNA MACHINES
 /obj/machinery/dna_scannernew
 	name = "\improper DNA modifier"
@@ -955,7 +967,7 @@
 
 			var/datum/dna2/record/buf = src.buffers[bufferId]
 
-			src.disk.buf = buf
+			src.disk.buf = buf.copy()
 			src.disk.name = "data disk - '[buf.dna.real_name]'"
 			//src.temphtml = "Data saved."
 			return 1

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -278,7 +278,7 @@
 			return
 
 		// DNA2 makes things a little simpler.
-		src.diskette.buf=src.active_record
+		src.diskette.buf=src.active_record.copy()
 		src.diskette.buf.types=0
 		switch(href_list["save_disk"]) //Save as Ui/Ui+Ue/Se
 			if("ui")


### PR DESCRIPTION
The dna/record on the disk was a reference to the one in the buffer, not
a copy, so if you changed the one in the buffer, the one on the disk
changed.
Fixed it for cloning too

BTW, yes, I know I left in an implied src in one of the lines I changed.
This is because whoever created that file is obsessed with src, and
unless I fancied going through the file and stripping out hundreds of
them, taking out a few would actually detract from the readability of
the code