### PR TITLE
Exosuit beacons now fit in pockets and boxes

### DIFF
--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -71,6 +71,7 @@
 	desc = "Device used to transmit exosuit data."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "motion2"
+	w_class = 2
 	origin_tech = "programming=2;magnets=2"
 
 /obj/item/mecha_parts/mecha_tracking/proc/get_mecha_info()


### PR DESCRIPTION
:cl:Crazylemon
tweak: Exosuit tracking beacons now fit in boxes - prior, they were far too large for even a backpack, as they shared the same size as all other mecha equipment
/:cl: