### PR TITLE
Tweaks Heart Attacks

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -90,6 +90,7 @@
 	stat = DEAD
 	dizziness = 0
 	jitteriness = 0
+	heart_attack = 0
 
 	//Handle species-specific deaths.
 	if(species) species.handle_death(src)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1276,11 +1276,10 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 	if(!heart_attack)
 		return
 	else
-		losebreath += 5
-		adjustOxyLoss(10)
-		adjustBrainLoss(rand(4,10))
-		Paralyse(2)
-	return
+		if(losebreath < 3)
+			losebreath += 2
+		adjustOxyLoss(5)
+		adjustBruteLoss(1)
 
 
 


### PR DESCRIPTION
Tweaks/nerfs heart attacks.

Simply put, I altered heart attacks to be more in line with Goon heart attacks---that said, with @Aurorablade's organ PR coming up very quickly, that style of heart attack will absolutely not play nice with the new reviver implant, and some more upcoming changes to TG's organs, so I figured I might as well get this out of the way and update how heart attacks are handled to TG's standard.

Changes
- losebreath is capped at 3
- take 5 oxygen damage every cycles as opposed to 10
- no paralysis
- take 1 bruteloss instead of 4-10 brainloss

:cl: Fox McCloud
tweak: nerfs heart attacks so they do less damage
/:cl: