### PR TITLE
Tweaks Pickpocket Gloves

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -191,7 +191,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/pickpocketgloves
 	name = "Pickpocket's Gloves"
-	desc = "A pair of sleek gloves to aid in pickpocketing, while wearing these you can see inside the pockets of any unsuspecting mark, loot the ID or pockets without them knowing, and pickpocketing puts the item directly into your hand."
+	desc = "A pair of sleek gloves to aid in pickpocketing. While wearing these, you can loot your target without them knowing. Pickpocketing puts the item directly into your hand."
 	reference = "PG"
 	item = /obj/item/clothing/gloves/color/black/thief
 	cost = 6

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -765,6 +765,12 @@
 
 /mob/living/carbon/human/Topic(href, href_list)
 	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))
+		var/thief_mode = 0
+		if(ishuman(usr))
+			var/mob/living/carbon/human/H = usr
+			var/obj/item/clothing/gloves/G = H.gloves
+			if(G && G.pickpocket)
+				thief_mode = 1
 
 		if(href_list["item"])
 			var/slot = text2num(href_list["item"])
@@ -793,6 +799,8 @@
 				if(pocket_item)
 					if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
 						unEquip(pocket_item)
+						if(thief_mode)
+							usr.put_in_hands(pocket_item)
 				else
 					if(place_item)
 						usr.unEquip(place_item)
@@ -802,8 +810,9 @@
 				if(usr.machine == src && in_range(src, usr))
 					show_inv(usr)
 			else
-				// Display a warning if the user mocks up
-				src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
+				// Display a warning if the user mocks up if they don't have pickpocket gloves.
+				if(!thief_mode)
+					src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
 
 		if(href_list["set_sensor"])
 			if(istype(w_uniform, /obj/item/clothing/under))
@@ -815,12 +824,14 @@
 				var/obj/item/clothing/under/U = w_uniform
 				if(U.accessories.len)
 					var/obj/item/clothing/accessory/A = U.accessories[1]
-					usr.visible_message("<span class='danger'>\The [usr] starts to take off \the [A] from \the [src]'s [U]!</span>", \
-										"<span class='danger'>You start to take off \the [A] from \the [src]'s [U]!</span>")
+					if(!thief_mode)
+						usr.visible_message("<span class='danger'>\The [usr] starts to take off \the [A] from \the [src]'s [U]!</span>", \
+											"<span class='danger'>You start to take off \the [A] from \the [src]'s [U]!</span>")
 
 					if(do_mob(usr, src, 40) && A && U.accessories.len)
-						usr.visible_message("<span class='danger'>\The [usr] takes \the [A] off of \the [src]'s [U]!</span>", \
-											"<span class='danger'>You take \the [A] off of \the [src]'s [U]!</span>")
+						if(!thief_mode)
+							usr.visible_message("<span class='danger'>\The [usr] takes \the [A] off of \the [src]'s [U]!</span>", \
+												"<span class='danger'>You take \the [A] off of \the [src]'s [U]!</span>")
 						A.on_removed(usr)
 						U.accessories -= A
 						update_inv_w_uniform()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -807,6 +807,8 @@
 	if(do_mob(src, who, what.strip_delay))
 		if(what && what == who.get_item_by_slot(where) && Adjacent(who))
 			who.unEquip(what)
+			if(silent)
+				put_in_hands(what)
 			add_logs(who, src, "stripped", addition="of [what]")
 
 // The src mob is trying to place an item on someone


### PR DESCRIPTION
Tweaks it so pickpocket gloves are a bit more useful.

- pickpocket gloves will now silently strip accessories
- failing a pickpocket with the gloves on will not generate the "pockets being fumbled with" message
- Stripping an items/accessories/things from people's pockets will now put it in your active hand rather than on the ground below the person
- updates the uplink description to be more accurate.

:cl: Fox McCloud
tweak: Pickpocket gloves now put the item you strip into your hands as opposed to the floor
tweak: Picketpocket gloves can now silently strip accessories
tweak: Pickpocket gloves will no longer give a message for messing up a pickpocket
/:cl: