### PR TITLE
Fixes jukebox actually using preferences (Volume and Hear Streaming)

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -201,7 +201,7 @@
 	prefs.save_preferences(src)
 	usr << "You will [(prefs.sound & SOUND_STREAMING) ? "now" : "no longer"] hear streamed media."
 	if(!media) return
-	if(prefs.toggles & SOUND_STREAMING)
+	if(prefs.sound & SOUND_STREAMING)
 		media.update_music()
 	else
 		media.stop_music()


### PR DESCRIPTION
- Fixes a couple things I neglected when I made jukebox volume work at all, mainly in terms of correctly (ie at all) saving and loading the preferences.
- The Hear/Mute Streaming verb also works correctly now.
- Rejoining in the bar continues the music as expected, as well.