### PR TITLE
Fixes movement issues with opening and closing closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -55,10 +55,19 @@
 		I.forceMove(loc)
 
 	for(var/mob/M in src)
-		M.forceMove(loc)
+		moveMob(M, loc)
 		if(M.client)
 			M.client.eye = M.client.mob
 			M.client.perspective = MOB_PERSPECTIVE
+
+/obj/structure/closet/proc/moveMob(var/mob/M, var/atom/destination)
+	loc.Exited(M)
+	M.loc = destination
+	loc.Entered(M, ignoreRest = 1)
+	for (var/atom/movable/AM in loc)
+		if (istype(AM, /obj/item))
+			continue
+		AM.Crossed(M)
 
 /obj/structure/closet/proc/open()
 	if(src.opened)
@@ -112,7 +121,7 @@
 			M.client.perspective = EYE_PERSPECTIVE
 			M.client.eye = src
 
-		M.forceMove(src)
+		moveMob(M, src)
 		itemcount++
 
 	src.icon_state = src.icon_closed

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -50,65 +50,66 @@
 		tracks = new typepath(src)
 	tracks.AddTracks(bloodDNA,comingdir,goingdir,bloodcolor)
 
-/turf/simulated/Entered(atom/A, atom/OL)
+/turf/simulated/Entered(atom/A, atom/OL, ignoreRest = 0)
 	..()
-	if(ismob(A)) //only mobs make dirt
-		if(prob(80))
-			dirt++
+	if(!ignoreRest)
+		if(ismob(A)) //only mobs make dirt
+			if(prob(80))
+				dirt++
 
-		var/obj/effect/decal/cleanable/dirt/dirtoverlay = locate(/obj/effect/decal/cleanable/dirt) in src
-		if(dirt >= 100)
-			if(!dirtoverlay)
-				dirtoverlay = new/obj/effect/decal/cleanable/dirt(src)
-				dirtoverlay.alpha = 10
-			else if(dirt > 100)
-				dirtoverlay.alpha = min(dirtoverlay.alpha + 10, 200)
+			var/obj/effect/decal/cleanable/dirt/dirtoverlay = locate(/obj/effect/decal/cleanable/dirt) in src
+			if(dirt >= 100)
+				if(!dirtoverlay)
+					dirtoverlay = new/obj/effect/decal/cleanable/dirt(src)
+					dirtoverlay.alpha = 10
+				else if(dirt > 100)
+					dirtoverlay.alpha = min(dirtoverlay.alpha + 10, 200)
 
-	if(ishuman(A))
-		var/mob/living/carbon/human/M = A
-		if(M.lying)
-			return 1
+		if(ishuman(A))
+			var/mob/living/carbon/human/M = A
+			if(M.lying)
+				return 1
 
-		if(M.flying)
-			return ..()
+			if(M.flying)
+				return ..()
 
-		// Tracking blood
-		var/list/bloodDNA = null
-		var/bloodcolor = ""
-		if(M.shoes)
-			var/obj/item/clothing/shoes/S = M.shoes
-			if(S.track_blood && S.blood_DNA)
-				bloodDNA = S.blood_DNA
-				bloodcolor = S.blood_color
-				S.track_blood--
-		else
-			if(M.track_blood && M.feet_blood_DNA)
-				bloodDNA = M.feet_blood_DNA
-				bloodcolor = M.feet_blood_color
-				M.track_blood--
+			// Tracking blood
+			var/list/bloodDNA = null
+			var/bloodcolor = ""
+			if(M.shoes)
+				var/obj/item/clothing/shoes/S = M.shoes
+				if(S.track_blood && S.blood_DNA)
+					bloodDNA = S.blood_DNA
+					bloodcolor = S.blood_color
+					S.track_blood--
+			else
+				if(M.track_blood && M.feet_blood_DNA)
+					bloodDNA = M.feet_blood_DNA
+					bloodcolor = M.feet_blood_color
+					M.track_blood--
 
-		if (bloodDNA)
-			src.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints,bloodDNA,M.dir,0,bloodcolor) // Coming
-			var/turf/simulated/from = get_step(M,reverse_direction(M.dir))
-			if(istype(from) && from)
-				from.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints,bloodDNA,0,M.dir,bloodcolor) // Going
+			if (bloodDNA)
+				src.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints,bloodDNA,M.dir,0,bloodcolor) // Coming
+				var/turf/simulated/from = get_step(M,reverse_direction(M.dir))
+				if(istype(from) && from)
+					from.AddTracks(/obj/effect/decal/cleanable/blood/tracks/footprints,bloodDNA,0,M.dir,bloodcolor) // Going
 
-			bloodDNA = null
+				bloodDNA = null
 
-		switch (src.wet)
-			if(TURF_WET_WATER)
-				if (!(M.slip("wet floor", 4, 2, 0, 1)))
-					M.inertia_dir = 0
-					return
+			switch (src.wet)
+				if(TURF_WET_WATER)
+					if (!(M.slip("wet floor", 4, 2, 0, 1)))
+						M.inertia_dir = 0
+						return
 
-			if(TURF_WET_LUBE) //lube
-				if(M.slip("floor", 0, 7, 4, 0, 1))
-					M.take_organ_damage(2) // Was 5 -- TLE
+				if(TURF_WET_LUBE) //lube
+					if(M.slip("floor", 0, 7, 4, 0, 1))
+						M.take_organ_damage(2) // Was 5 -- TLE
 
 
-			if(TURF_WET_ICE) // Ice
-				if (!(prob(30) && M.slip("icy floor", 4, 2, 1, 1)))
-					M.inertia_dir = 0
+				if(TURF_WET_ICE) // Ice
+					if (!(prob(30) && M.slip("icy floor", 4, 2, 1, 1)))
+						M.inertia_dir = 0
 
 
 //returns 1 if made bloody, returns 0 otherwise

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -708,10 +708,6 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		return
 	if ((lying) && (!(tilesSlipped)))
 		return
-	if (istype(loc, /obj/structure/closet)) // for getting in a locker
-		return
-	for (var/obj/structure/closet/closet in loc.contents) // for getting out of a locker
-		return
 	if (!(slipAny))
 		if (istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src


### PR DESCRIPTION
Fixes #3687
Mobs no longer act as if they've moved when in a locker whilst it's
opened and closed.
The new proc does everything forceMove does except trigger /crossed on
/items and run the extra code in turfs\simulated\Entered (still makes
the parent call)
Also removed some now unneeded code from the /slip proc as this makes it
redundant