### PR TITLE
Tweaks Stamina Regeneration

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -285,7 +285,7 @@
 			Weaken(5)
 			setStaminaLoss(health - 2)
 			return
-		setStaminaLoss(max((staminaloss - 2), 0))
+		setStaminaLoss(max((staminaloss - 3), 0))
 
 //this updates all special effects: stunned, sleeping, weakened, druggy, stuttering, etc..
 /mob/living/carbon/handle_status_effects()


### PR DESCRIPTION
Port of: https://github.com/tgstation/-tg-station/pull/15614

Tweaks stamina regeneration a bit so it doesn't take forever and a day to wear off--regeneration is now 3 per life cycle, up from 2.

Time to go from 100 stamina damage to 0 is now 1 minute 6 seconds---down from 1 minute 40 seconds.

:cl: Fox McCloud
tweak: stamina damage now regenerates slightly faster
/:cl: