### PR TITLE
Jacket Adjustment Fixes/Tweaks

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -192,22 +192,24 @@
 /obj/item/clothing/suit/storage/lawyer/blackjacket
 	name = "black suit jacket"
 	desc = "A snappy dress jacket."
-	icon_state = "suitjacket_black"
-	item_state = "suitjacket_black"
+	icon_state = "suitjacket_black_open"
+	item_state = "suitjacket_black_open"
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	ignore_suitadjust = 0
+	suit_adjusted = 1
 	action_button_name = "Button/Unbutton Jacket"
 	adjust_flavour = "unbutton"
 
 /obj/item/clothing/suit/storage/lawyer/bluejacket
 	name = "blue suit jacket"
 	desc = "A snappy dress jacket."
-	icon_state = "suitjacket_blue"
-	item_state = "suitjacket_blue"
+	icon_state = "suitjacket_blue_open"
+	item_state = "suitjacket_blue_open"
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	ignore_suitadjust = 0
+	suit_adjusted = 1
 	action_button_name = "Button/Unbutton Jacket"
 	adjust_flavour = "unbutton"
 
@@ -223,11 +225,12 @@
 /obj/item/clothing/suit/storage/internalaffairs
 	name = "\improper Internal Affairs jacket"
 	desc = "A smooth black jacket."
-	icon_state = "ia_jacket"
+	icon_state = "ia_jacket_open"
 	item_state = "ia_jacket"
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	ignore_suitadjust = 0
+	suit_adjusted = 1
 	action_button_name = "Button/Unbutton Jacket"
 	adjust_flavour = "unbutton"
 
@@ -246,12 +249,13 @@
 /obj/item/clothing/suit/storage/fr_jacket
 	name = "first responder jacket"
 	desc = "A high-visibility jacket worn by medical first responders."
-	icon_state = "fr_jacket"
+	icon_state = "fr_jacket_open"
 	item_state = "fr_jacket"
 	blood_overlay_type = "armor"
 	allowed = list(/obj/item/stack/medical, /obj/item/weapon/reagent_containers/dropper, /obj/item/weapon/reagent_containers/hypospray, /obj/item/weapon/reagent_containers/syringe, \
 	/obj/item/device/healthanalyzer, /obj/item/device/antibody_scanner, /obj/item/device/flashlight, /obj/item/device/radio, /obj/item/weapon/tank/emergency_oxygen,/obj/item/device/rad_laser)
 	ignore_suitadjust = 0
+	suit_adjusted = 1
 	action_button_name = "Button/Unbutton Jacket"
 	adjust_flavour = "unbutton"
 

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/suit/storage/labcoat
 	name = "labcoat"
 	desc = "A suit that protects against minor chemical spills."
-	icon_state = "labcoat_open"
+	icon_state = "labcoat"
 	item_state = "labcoat"
 	ignore_suitadjust = 0
 	blood_overlay_type = "coat"
@@ -18,7 +18,7 @@
 /obj/item/clothing/suit/storage/labcoat/cmo
 	name = "chief medical officer's labcoat"
 	desc = "Bluer than the standard model."
-	icon_state = "labcoat_cmo_open"
+	icon_state = "labcoat_cmo"
 	item_state = "labcoat_cmo"
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -28,7 +28,7 @@
 /obj/item/clothing/suit/storage/labcoat/mad
 	name = "mad scientist's labcoat"
 	desc = "It makes you look capable of konking someone on the noggin and shooting them into space."
-	icon_state = "labcoat_green_open"
+	icon_state = "labcoat_green"
 	item_state = "labcoat_green"
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -38,7 +38,7 @@
 /obj/item/clothing/suit/storage/labcoat/genetics
 	name = "geneticist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a blue stripe on the shoulder."
-	icon_state = "labcoat_gen_open"
+	icon_state = "labcoat_gen"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -47,7 +47,7 @@
 /obj/item/clothing/suit/storage/labcoat/chemist
 	name = "chemist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has an orange stripe on the shoulder."
-	icon_state = "labcoat_chem_open"
+	icon_state = "labcoat_che"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -56,7 +56,7 @@
 /obj/item/clothing/suit/storage/labcoat/virologist
 	name = "virologist labcoat"
 	desc = "A suit that protects against minor chemical spills. Offers slightly more protection against biohazards than the standard model. Has a green stripe on the shoulder."
-	icon_state = "labcoat_vir_open"
+	icon_state = "labcoat_vir"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -65,7 +65,7 @@
 /obj/item/clothing/suit/storage/labcoat/science
 	name = "scientist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a purple stripe on the shoulder."
-	icon_state = "labcoat_tox_open"
+	icon_state = "labcoat_tox"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -74,7 +74,7 @@
 /obj/item/clothing/suit/storage/labcoat/mortician
 	name = "coroner labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a black stripe on the shoulder."
-	icon_state = "labcoat_mort_open"
+	icon_state = "labcoat_mort"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -1,9 +1,10 @@
 /obj/item/clothing/suit/storage/labcoat
 	name = "labcoat"
 	desc = "A suit that protects against minor chemical spills."
-	icon_state = "labcoat"
+	icon_state = "labcoat_open"
 	item_state = "labcoat"
 	ignore_suitadjust = 0
+	suit_adjusted = 1
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	allowed = list(/obj/item/device/analyzer,/obj/item/device/antibody_scanner,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/weapon/reagent_containers/glass/bottle,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/storage/pill_bottle,/obj/item/weapon/paper,/obj/item/device/rad_laser)
@@ -18,7 +19,7 @@
 /obj/item/clothing/suit/storage/labcoat/cmo
 	name = "chief medical officer's labcoat"
 	desc = "Bluer than the standard model."
-	icon_state = "labcoat_cmo"
+	icon_state = "labcoat_cmo_open"
 	item_state = "labcoat_cmo"
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -28,7 +29,7 @@
 /obj/item/clothing/suit/storage/labcoat/mad
 	name = "mad scientist's labcoat"
 	desc = "It makes you look capable of konking someone on the noggin and shooting them into space."
-	icon_state = "labcoat_green"
+	icon_state = "labcoat_green_open"
 	item_state = "labcoat_green"
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -38,7 +39,7 @@
 /obj/item/clothing/suit/storage/labcoat/genetics
 	name = "geneticist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a blue stripe on the shoulder."
-	icon_state = "labcoat_gen"
+	icon_state = "labcoat_gen_open"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -47,7 +48,7 @@
 /obj/item/clothing/suit/storage/labcoat/chemist
 	name = "chemist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has an orange stripe on the shoulder."
-	icon_state = "labcoat_che"
+	icon_state = "labcoat_chem_open"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -56,7 +57,7 @@
 /obj/item/clothing/suit/storage/labcoat/virologist
 	name = "virologist labcoat"
 	desc = "A suit that protects against minor chemical spills. Offers slightly more protection against biohazards than the standard model. Has a green stripe on the shoulder."
-	icon_state = "labcoat_vir"
+	icon_state = "labcoat_vir_open"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -65,7 +66,7 @@
 /obj/item/clothing/suit/storage/labcoat/science
 	name = "scientist labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a purple stripe on the shoulder."
-	icon_state = "labcoat_tox"
+	icon_state = "labcoat_tox_open"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -74,7 +75,7 @@
 /obj/item/clothing/suit/storage/labcoat/mortician
 	name = "coroner labcoat"
 	desc = "A suit that protects against minor chemical spills. Has a black stripe on the shoulder."
-	icon_state = "labcoat_mort"
+	icon_state = "labcoat_mort_open"
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -339,6 +339,7 @@
 	desc = "A canvas jacket styled after classical American military garb. Feels sturdy, yet comfortable."
 	icon_state = "militaryjacket"
 	item_state = "militaryjacket"
+	ignore_suitadjust = 1
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/toy,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/lighter,/obj/item/weapon/gun/projectile/automatic/pistol,/obj/item/weapon/gun/projectile/revolver,/obj/item/weapon/gun/projectile/revolver/detective)
 
 /obj/item/clothing/suit/xenos

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -137,6 +137,7 @@
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "kidosvest"
 	item_state = "kidosvest"
+	ignore_suitadjust = 1
 
 /obj/item/clothing/suit/fluff/kluys // Kluys: Cripty Pandaen
 	name = "Nano Fibre Jacket"
@@ -174,6 +175,7 @@
 	desc = "A suit that protects against minor chemical spills. Has a red stripe on the shoulders and rolled up sleeves."
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "labcoat_red_open"
+	ignore_suitadjust = 1
 
 /obj/item/clothing/suit/fluff/stobarico_greatcoat // Stobarico: F.U.R.R.Y
 	name = "\improper F.U.R.R.Y's Nanotrasen Greatcoat"
@@ -246,6 +248,7 @@
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "fox_jacket"
 	item_state = "fox_jacket"
+	ignore_suitadjust = 1
 
 /obj/item/clothing/under/fluff/fox
 	name = "Aeronautics Jumpsuit"


### PR DESCRIPTION
Fixes an issue where adjusting a labcoat caused them to use a sprite with the name suffix _open_open, since they start with _open already.

Labcoats start closed now and can be opened (and closed again) as appropriate now

:cl:
fix: Jackets that start open are recognized as actually being open already now. This fixes a bug with certain items that don't have an open state, or cases where it ended up giving an item the wrong icon (one that didn't exist)
/:cl: