### PR TITLE
Allows forceMove to move objects to nullspace

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -109,15 +109,14 @@
 	return
 
 /atom/movable/proc/forceMove(atom/destination)
+	if(loc)
+		loc.Exited(src)
+	loc = destination
 	if(destination)
-		if(loc)
-			loc.Exited(src)
-		loc = destination
 		loc.Entered(src)
 		for(var/atom/movable/AM in loc)
 			AM.Crossed(src)
-		return 1
-	return 0
+	return 1
 
 //called when src is thrown into hit_atom
 /atom/movable/proc/throw_impact(atom/hit_atom, var/speed)


### PR DESCRIPTION
as discussed with @tigercat2000 [here](https://github.com/ParadiseSS13/Paradise/pull/2903/files#r54054665)
forceMove now works when the destination is null