### PR TITLE
Fixes *yes and *no emotes not displaying a message in the chat.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -139,6 +139,8 @@
 				param = null
 
 			if (param)
+				message = "<B>[src]</B> emits an affirmative blip at [param]."
+			else
 				message = "<B>[src]</B> emits an affirmative blip."
 			playsound(src.loc, 'sound/machines/synth_yes.ogg', 50, 0)
 			m_type = 1
@@ -154,6 +156,8 @@
 				param = null
 
 			if (param)
+				message = "<B>[src]</B> emits a negative blip at [param]."
+			else
 				message = "<B>[src]</B> emits a negative blip."
 			playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
 			m_type = 1

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -86,6 +86,8 @@
 				param = null
 
 			if (param)
+				message = "<B>[src]</B> emits an affirmative blip at [param]."
+			else
 				message = "<B>[src]</B> emits an affirmative blip."
 			playsound(src.loc, 'sound/machines/synth_yes.ogg', 50, 0)
 			m_type = 1
@@ -101,6 +103,8 @@
 				param = null
 
 			if (param)
+				message = "<B>[src]</B> emits a negative blip at [param]."
+			else
 				message = "<B>[src]</B> emits a negative blip."
 			playsound(src.loc, 'sound/machines/synth_no.ogg', 50, 0)
 			m_type = 1


### PR DESCRIPTION
:cl:
bugfix: Fixes synthetics from giving off the proper message in the chat box when using the *yes and *no emotes.
/:cl:
Whoops.