### PR TITLE
Lets you point while buckled or lying

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -22,7 +22,7 @@
 
 //same as above
 /mob/living/pointed(atom/A as mob|obj|turf in view())
-	if(src.stat || !src.canmove || src.restrained())
+	if(incapacitated())
 		return 0
 	if(src.status_flags & FAKEDEATH)
 		return 0


### PR DESCRIPTION
Allows you to point while lying down or buckled.


As far as I know, this checks for every condition canmove does except buckling and lying.

I don't think there's really any negative balance implications for this.

:cl: Fox McCloud
tweak: Can now point while lying or buckled
/:cl: