### PR TITLE
Buildable Prize Counter Boards and Non-silent Rocks

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1361,6 +1361,7 @@ obj/item/toy/cards/deck/syndicate/black
 	force = 5
 	throwforce = 5
 	attack_verb = list("attacked", "bashed", "smashed", "stoned")
+	hitsound = "swing_hit"
 
 /obj/item/toy/pet_rock/fred
 	name = "fred"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -495,6 +495,7 @@
 /datum/design/prize_counter
 	name = "Machine Design (Prize Counter)"
 	desc = "The circuit board for an arcade Prize Counter."
+	id = "prize_counter"
 	req_tech = list("programming" = 2, "materials" = 2)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS=1000, "sacid"=20)


### PR DESCRIPTION
Fixes Prize Counter circuit boards not being listed in the circuit imprinter despite having the required research levels

Fixes #3694