### PR TITLE
Allows wheelchairs, janicarts, and ambulances to open doors

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -97,16 +97,15 @@
 /atom/movable/Crossed(atom/movable/AM)
 	return
 
-/atom/movable/Bump(var/atom/A as mob|obj|turf|area, yes)
+/atom/movable/Bump(var/atom/A as mob|obj|turf|area, sendBump)
 	if(src.throwing)
 		src.throw_impact(A)
 
-	if ((A && yes))
+	if (A && sendBump)
 		A.last_bumped = world.time
 		A.Bumped(src)
-		return
-	..()
-	return
+	else
+		..()
 
 /atom/movable/proc/forceMove(atom/destination)
 	if(destination)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -91,6 +91,10 @@
 			move_delay = 0
 	else
 		user << "<span class='notice'>You'll need the keys in one of your hands to drive this [callme].</span>"
+		
+/obj/structure/stool/bed/chair/janicart/Bump(atom/A)
+	if(buckled_mob && istype(A, /obj/machinery/door))
+		A.Bumped(buckled_mob)
 
 /obj/structure/stool/bed/chair/janicart/user_buckle_mob(mob/living/M, mob/user)
 	if(user.incapacitated()) //user can't move the mob on the janicart's turf if incapacitated

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -72,6 +72,9 @@
 	..()
 	if(!buckled_mob)	return
 
+	if(istype(A, /obj/machinery/door))
+		A.Bumped(buckled_mob)
+
 	if(propelled)
 		var/mob/living/occupant = buckled_mob
 		unbuckle_mob()
@@ -150,7 +153,7 @@
 		else
 			. = 1
 
-/obj/structure/stool/bed/chair/wheelchair/handle_rotation()
+/obj/structure/stool/bed/chair/wheelchair/bike/handle_rotation()
 	overlays = null
 	var/image/O = image(icon = 'icons/vehicles/motorcycle.dmi', icon_state = "motorcycle_overlay_4d", layer = FLY_LAYER, dir = src.dir)
 	overlays += O

--- a/code/modules/vehicle/train/train.dm
+++ b/code/modules/vehicle/train/train.dm
@@ -54,6 +54,9 @@
 		var/turf/T = get_step(A, dir)
 		if(isturf(T))
 			A.Move(T)	//bump things away when hit
+	
+	if(ismob(load) && istype(Obstacle, /obj/machinery/door))
+		Obstacle.Bumped(load)
 
 	if(emagged)
 		if(istype(A, /mob/living))


### PR DESCRIPTION
- Resolves #2620
- Also fixes a problem caused by #3601 in which all wheelchairs get a chunk of a bike overlayed on them.
- Also makes `/atom/movable/Bump()` less gross because it was bothering me.

:cl:
rscadd: Wheelchairs, janicarts, and ambulances can now go through doors according to the user's driver's access.
/:cl: