### PR TITLE
Disables canvas support on frames

### DIFF
--- a/code/modules/paperwork/frames.dm
+++ b/code/modules/paperwork/frames.dm
@@ -83,7 +83,7 @@
 				O.forceMove(user.loc)
 		displayed = null
 		qdel(src)
-	else if(istype(I, /obj/item/weapon/paper) || istype(I, /obj/item/weapon/photo) || istype(I, /obj/item/weapon/contraband/poster) || istype(I, /obj/item/weapon/canvas))
+	else if(istype(I, /obj/item/weapon/paper) || istype(I, /obj/item/weapon/photo) || istype(I, /obj/item/weapon/contraband/poster)/* || istype(I, /obj/item/weapon/canvas)*/)
 		if(!displayed)
 			user.unEquip(I)
 			insert(I)

--- a/code/modules/paperwork/frames.dm
+++ b/code/modules/paperwork/frames.dm
@@ -83,7 +83,7 @@
 				O.forceMove(user.loc)
 		displayed = null
 		qdel(src)
-	else if(istype(I, /obj/item/weapon/paper) || istype(I, /obj/item/weapon/photo) || istype(I, /obj/item/weapon/contraband/poster)/* || istype(I, /obj/item/weapon/canvas)*/)
+	else if(istype(I, /obj/item/weapon/paper) || istype(I, /obj/item/weapon/photo) || istype(I, /obj/item/weapon/contraband/poster))
 		if(!displayed)
 			user.unEquip(I)
 			insert(I)


### PR DESCRIPTION
I'm 99% sure it's causing the crashes, and for the same reason the byond server randomly stops sending the icon for people. It might be because of the rapid icon updates when the canvas is drawn, it's hard to be sure.