### PR TITLE
Fixes 'Yeah' and Noir Glasses

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -211,20 +211,38 @@
 /obj/item/clothing/glasses/sunglasses/noir
 	name = "noir sunglasses"
 	desc = "Somehow these seem even more out-of-date than normal sunglasses."
+	action_button_name = "Noir Mode"
+	var/noir_mode = 0
 	color_view = list(0.3, 0.3, 0.3, 0,\
 						0.3, 0.3, 0.3, 0,\
  						0.3, 0.3, 0.3, 0,\
  						0.0, 0.0, 0.0, 1,) //greyscale
 
-/obj/item/clothing/glasses/sunglasses/noir/equipped(mob/user, slot)
-	if(color_view && user.client && !user.client.color)
-		animate(user.client, color = color_view, time = 10)
+/obj/item/clothing/glasses/sunglasses/noir/attack_self()
+	if(is_equipped())
+		toggle_noir()
 
+/obj/item/clothing/glasses/sunglasses/noir/proc/toggle_noir()
+	if(!noir_mode)
+		if(color_view && usr.client && !usr.client.color)
+			animate(usr.client, color = color_view, time = 10)
+			noir_mode = 1
+	else
+		if(usr.client && usr.client.color)
+			animate(usr.client, color = null, time = 10)
+			noir_mode = 0
+
+/obj/item/clothing/glasses/sunglasses/noir/equipped(mob/user, slot)
+	if(slot == slot_glasses)
+		if(noir_mode)
+			if(color_view && user.client && !user.client.color)
+				animate(user.client, color = color_view, time = 10)
 	..(user, slot)
 
-/obj/item/clothing/glasses/sunglasses/noir/dropped(mob/user)
-	if(user.client && user.client.color)
-		animate(user.client, color = null, time = 10)
+/obj/item/clothing/glasses/sunglasses/noir/dropped(mob/living/carbon/human/user)
+	if(istype(user) && user.glasses == src)
+		if(user.client && user.client.color)
+			animate(user.client, color = null, time = 10)
 	..(user)
 
 /obj/item/clothing/glasses/sunglasses/yeah
@@ -244,7 +262,7 @@
 	if(!punused)//one per round
 		punused = 1
 		playsound(src.loc, 'sound/misc/yeah.ogg', 100, 0)
-		usr.visible_message("<span class = 'danger'>YEEEAAAAAHHHHHHHHHHHHH!!</span>")
+		usr.visible_message("<span class='biggerdanger'>YEEEAAAAAHHHHHHHHHHHHH!!</span>")
 	else
 		usr << "The moment is gone."
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -243,7 +243,8 @@
 	set src in usr
 	if(!punused)//one per round
 		punused = 1
-		playsound(src.loc, 'sound/misc/yeah.ogg', 100, 1)
+		playsound(src.loc, 'sound/misc/yeah.ogg', 100, 0)
+		usr.visible_message("<span class = 'danger'>YEEEAAAAAHHHHHHHHHHHHH!!</span>")
 	else
 		usr << "The moment is gone."
 


### PR DESCRIPTION
- Fixes the "YEAH" glasses so the sound played doesn't vary in frequency.
 - Adds in a visible message for those who don't have sound/have it muted.
- Fixes it so Noir mode now only applies if the glasses are equipped to your person
- Noir mode can be toggled on and off


:cl: Fox McCloud
bugfix: Fixes the "yeah" glasses so the sound doesn't vary and a message is displayed, on use
bugfix: Noir mode only activates when the glasses are equipped to your actual eyes
rscadd: Noir Glasses mode can be toggled on or off (defaults to off)
/:cl: