### PR TITLE
Prize Counter and Toy Fixes

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -49,15 +49,23 @@
 
 /obj/item/toy/balloon/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
 	if(!proximity) return
-	if (istype(A, /obj/structure/reagent_dispensers/watertank) && get_dist(src,A) <= 1)
+	if (istype(A, /obj/structure/reagent_dispensers) && get_dist(src,A) <= 1)
 		A.reagents.trans_to(src, 10)
 		user << "<span class='notice'>You fill the balloon with the contents of [A].</span>"
 		desc = "A translucent balloon with some form of liquid sloshing around in it."
 		update_icon()
 	return
 
+/obj/item/toy/balloon/wash(mob/user, atom/source)
+	if(reagents.total_volume < 10)
+		reagents.add_reagent("water", min(10-reagents.total_volume, 10))
+		user << "<span class='notice'>You fill the balloon from the [source].</span>"
+		desc = "A translucent balloon with some form of liquid sloshing around in it."
+		update_icon()
+	return
+
 /obj/item/toy/balloon/attackby(obj/O as obj, mob/user as mob, params)
-	if(istype(O, /obj/item/weapon/reagent_containers/glass))
+	if(istype(O, /obj/item/weapon/reagent_containers/glass) || istype(O, /obj/item/weapon/reagent_containers/food/drinks/drinkingglass))
 		if(O.reagents)
 			if(O.reagents.total_volume < 1)
 				user << "The [O] is empty."
@@ -200,7 +208,7 @@
 		return
 	else if (bullets == 0)
 		user.Weaken(5)
-		user.visible_message("<span class='danger'>[] realized they were out of ammo and starting scrounging for some!</span>")
+		user.visible_message("<span class='danger'>[user] realized they were out of ammo and starting scrounging for some!</span>")
 
 
 

--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -16,6 +16,7 @@ var/global/datum/prizes/global_prizes = new
 		return 0
 	if(prize_counter.tickets >= item.cost)
 		new item.typepath(prize_counter.loc)
+		prize_counter.tickets -= item.cost
 		prize_counter.visible_message("<span class='notice'>Enjoy your prize!</span>")
 		return 1
 	else


### PR DESCRIPTION
Prize counters now spend your tickets when you purchase something
- Had removed the ticket spending during my testing, forgot to re-add it before submit
- Fixes #3720 

Toy Crossbows now properly display the name of their user when they "start scrounging for ammo"
- Previously would just be blank for the name

Water balloons can now be filled from sinks, ANY reagent dispenser structure (not just watertanks), and drinking glasses in addition to beakers / buckets.
- This one is more of usability and consistency
- Watch out for security hurling pepper-spray balloons!

:cl:
tweak: Water Balloons can be filled from more sources than just beakers and watertanks.
/:cl: