### PR TITLE
Fixes stun code to not allow one get stuck stunned/paralyzed etc

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -354,18 +354,12 @@
 		return
 
 	if((istype(M,/mob/living/carbon/human/)) && (M.m_intent == "run")).
-		//M.AdjustStunned(5)
-		//M.AdjustWeakened(5)
-
-		if(M.stunned <= 5) M.stunned = 5
-		if(M.weakened <= 5) M.weakened = 5
+		M.Stun(5)
+		M.Weaken(5)
 
 	else if (istype(M,/mob/living/carbon/human/))
-		//M.AdjustStunned(2)
-		//M.AdjustWeakened(2)
-
-		if(M.stunned <= 2) M.stunned = 2
-		if(M.weakened <= 2) M.weakened = 2
+		M.Stun(2)
+		M.Weaken(2)
 
 
 	M << "Gravity!"

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -428,16 +428,16 @@
 		if (FAT in usr.mutations && prob(66))
 			usr.visible_message("\red <b>[usr.name]</b> crashes due to their heavy weight!")
 			//playsound(usr.loc, 'zhit.wav', 50, 1)
-			usr.weakened += 10
-			usr.stunned += 5
+			usr.AdjustWeakened(10)
+			usr.AdjustStunned(5)
 
 		usr.layer = prevLayer
 
 	if (istype(usr.loc,/obj/))
 		var/obj/container = usr.loc
 		usr << "\red You leap and slam your head against the inside of [container]! Ouch!"
-		usr.paralysis += 3
-		usr.weakened += 5
+		usr.AdjustParalysis(3)
+		usr.AdjustWeakened(5)
 		container.visible_message("\red <b>[usr.loc]</b> emits a loud thump and rattles a bit.")
 		playsound(usr.loc, 'sound/effects/bang.ogg', 50, 1)
 		var/wiggle = 6

--- a/code/game/dna/genes/monkey.dm
+++ b/code/game/dna/genes/monkey.dm
@@ -20,8 +20,8 @@
 		H.unEquip(W)
 		
 	H.regenerate_icons()
+	H.SetStunned(1)
 	H.canmove = 0
-	H.stunned = 1
 	H.icon = null
 	H.invisibility = 101
 	
@@ -33,8 +33,7 @@
 	sleep(22)
 	qdel(animation)
 	
-	H.stunned = 0
-	H.update_canmove()
+	H.SetStunned(0)
 	H.invisibility = initial(H.invisibility)
 
 	if(!H.species.primitive_form) //If the creature in question has no primitive set, this is going to be messy.
@@ -62,8 +61,8 @@
 			continue
 		H.unEquip(W)
 	H.regenerate_icons()
+	H.SetStunned(1)
 	H.canmove = 0
-	H.stunned = 1
 	H.icon = null
 	H.invisibility = 101
 	
@@ -75,8 +74,7 @@
 	sleep(22)
 	qdel(animation)
 
-	H.stunned = 0
-	H.update_canmove()
+	H.SetStunned(0)
 	H.invisibility = initial(H.invisibility)
 
 	if(!H.species.greater_form) //If the creature in question has no primitive set, this is going to be messy.

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -75,9 +75,9 @@
 	var/datum/mind/M = usr.mind
 	if(!M) return
 	if(M.current.vampire_power(0, 1))
-		M.current.weakened = 0
-		M.current.stunned = 0
-		M.current.paralysis = 0
+		M.current.SetWeakened(0)
+		M.current.SetStunned(0)
+		M.current.SetParalysis(0)
 		M.current.adjustStaminaLoss(-75)
 		//M.vampire.bloodusable -= 10
 		M.current << "\blue You flush your system with clean blood and remove any incapacitating effects."

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -352,8 +352,8 @@ About the new airlock wires panel:
 				return
 		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
 			user << "\red <B>You feel a powerful shock course through your body!</B>"
-			user.staminaloss += 50
-			user.stunned += 5
+			user.adjustStaminaLoss(50)
+			user.AdjustStunned(5)
 			return
 	..(user)
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -183,13 +183,11 @@
 
 	show_stat_emergency_shuttle_eta()
 
-/mob/living/carbon/alien/Stun(amount)
-	if(status_flags & CANSTUN)
-		stunned = max(max(stunned,amount),0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
-	else
+/mob/living/carbon/alien/SetStunned(amount)
+	..(amount)
+	if(!(status_flags & CANSTUN) && amount)
 		// add some movement delay
 		move_delay_add = min(move_delay_add + round(amount / 2), 10) // a maximum delay of 10
-	return
 
 /mob/living/carbon/alien/getDNA()
 	return null

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -127,12 +127,6 @@
 			O.heal_damage(0, -amount, internal=0, robo_repair=(O.status & ORGAN_ROBOT))
 
 
-/mob/living/carbon/human/Stun(amount)
-	..()
-
-/mob/living/carbon/human/Weaken(amount)
-	..()
-
 /mob/living/carbon/human/Paralyse(amount)
 	// Notify our AI if they can now control the suit.
 	if(wearing_rig && !stat && paralysis < amount) //We are passing out right this second.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -122,7 +122,7 @@
 
 /mob/living/proc/handle_weakened()
 	if(weakened)
-		weakened = max(weakened-1,0)	//before you get mad Rockdtben: I done this so update_canmove isn't called multiple times
+		AdjustWeakened(-1)
 		if(!weakened)
 			update_icons()
 	return weakened
@@ -147,14 +147,14 @@
 		slurring = max(slurring-1, 0)
 	return slurring
 
-/mob/living/proc/handle_paralysed() // Currently only used by simple_animal.dm, treated as a special case in other mobs
+/mob/living/proc/handle_paralysed()
 	if(paralysis)
 		AdjustParalysis(-1)
 	return paralysis
 
 /mob/living/proc/handle_sleeping()
 	if(sleeping)
-		sleeping = max(sleeping - 1, 0)
+		AdjustSleeping(-1)
 	return sleeping
 
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -110,11 +110,11 @@
 	if(!effect || (blocked >= 2))	return 0
 	switch(effecttype)
 		if(STUN)
-			stunned = max(stunned,(effect/(blocked+1)))
+			Stun(effect / (blocked + 1))
 		if(WEAKEN)
-			weakened = max(weakened,(effect/(blocked+1)))
+			Weaken(effect / (blocked + 1))
 		if(PARALYZE)
-			paralysis = max(paralysis,(effect/(blocked+1)))
+			Paralyse(effect / (blocked + 1))
 		if(IRRADIATE)
 			radiation += min((effect - (effect*getarmor(null, "rad"))), 0)//Rads auto check armor
 		if(STUTTER)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1121,94 +1121,72 @@ var/list/slot_equipment_priority = list( \
 
 
 /mob/proc/Jitter(amount)
-	jitteriness = max(jitteriness,amount,0)
+	jitteriness = max(jitteriness, amount, 0)
 
 /mob/proc/Dizzy(amount)
-	dizziness = max(dizziness,amount,0)
+	dizziness = max(dizziness, amount, 0)
 
 /mob/proc/Stun(amount)
-	if(status_flags & CANSTUN)
-		stunned = max(max(stunned,amount),0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
-		update_canmove()
-	return
+	SetStunned(max(stunned, amount))
 
 /mob/proc/SetStunned(amount) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
 	if(status_flags & CANSTUN)
-		stunned = max(amount,0)
+		stunned = max(amount, 0)
 		update_canmove()
-	return
+	else if(stunned)
+		stunned = 0
+		update_canmove()
 
 /mob/proc/AdjustStunned(amount)
-	if(status_flags & CANSTUN)
-		stunned = max(stunned + amount,0)
-		update_canmove()
-	return
+	SetStunned(stunned + amount)
 
 /mob/proc/Weaken(amount)
-	if(status_flags & CANWEAKEN)
-		weakened = max(max(weakened,amount),0)
-		update_canmove()	//updates lying, canmove and icons
-	return
+	SetWeakened(max(weakened, amount))
 
 /mob/proc/SetWeakened(amount)
 	if(status_flags & CANWEAKEN)
-		weakened = max(amount,0)
+		weakened = max(amount, 0)
 		update_canmove()	//updates lying, canmove and icons
-	return
+	else if(weakened)
+		weakened = 0
+		update_canmove()
 
 /mob/proc/AdjustWeakened(amount)
-	if(status_flags & CANWEAKEN)
-		weakened = max(weakened + amount,0)
-		update_canmove()	//updates lying, canmove and icons
-	return
+	SetWeakened(weakened + amount)
 
 /mob/proc/Paralyse(amount)
-	if(status_flags & CANPARALYSE)
-		paralysis = max(max(paralysis,amount),0)
-		update_canmove()
-	return
+	SetParalysis(max(paralysis, amount))
 
 /mob/proc/SetParalysis(amount)
 	if(status_flags & CANPARALYSE)
-		paralysis = max(amount,0)
+		paralysis = max(amount, 0)
 		update_canmove()
-	return
+	else if(paralysis)
+		paralysis = 0
+		update_canmove()
 
 /mob/proc/AdjustParalysis(amount)
-	if(status_flags & CANPARALYSE)
-		paralysis = max(paralysis + amount,0)
-		update_canmove()
-	return
+	SetParalysis(paralysis + amount)
 
 /mob/proc/Sleeping(amount)
-	sleeping = max(max(sleeping,amount),0)
-	update_canmove()
-	return
+	SetSleeping(max(sleeping, amount))
 
 /mob/proc/SetSleeping(amount)
-	sleeping = max(amount,0)
+	sleeping = max(amount, 0)
 	update_canmove()
-	return
 
 /mob/proc/AdjustSleeping(amount)
-	sleeping = max(sleeping + amount,0)
-	update_canmove()
-	return
+	SetSleeping(sleeping + amount)
 
 /mob/proc/Resting(amount)
-	resting = max(max(resting,amount),0)
-	update_canmove()
-	return
+	SetResting(max(resting, amount))
 
 /mob/proc/SetResting(amount)
-	resting = max(amount,0)
+	resting = max(amount, 0)
 	update_canmove()
-	return
 
 /mob/proc/AdjustResting(amount)
-	resting = max(resting + amount,0)
-	update_canmove()
-	return
+	SetResting(resting + amount)
 
 /mob/proc/get_species()
 	return ""

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -101,14 +101,14 @@
 		if(..(target, blocked))
 			var/mob/living/M = target
 			M.dizziness += 20
-			M:slurring += 20
+			M.slurring += 20
 			M.confused += 20
 			M.eye_blurry += 20
 			M.drowsyness += 20
 			for(var/datum/reagent/ethanol/A in M.reagents.reagent_list)
-				M.paralysis += 2
+				M.AdjustParalysis(2)
 				M.dizziness += 10
-				M:slurring += 10
+				M.slurring += 10
 				M.confused += 10
 				M.eye_blurry += 10
 				M.drowsyness += 10

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -22,7 +22,7 @@
 	// Sobering multiplier.
 	// Sober block makes it more difficult to get drunk
 	var/sober_str=!(SOBER in M.mutations)?1:2
-	M:nutrition += nutriment_factor
+	M.nutrition += nutriment_factor
 	if(!src.data) data = 1
 	src.data++
 
@@ -42,8 +42,8 @@
 
 	M.dizziness += dizzy_adj.
 	if(d >= slur_start && d < pass_out)
-		if (!M:slurring) M:slurring = 1
-		M:slurring += slurr_adj/sober_str
+		if (!M.slurring) M.slurring = 1
+		M.slurring += slurr_adj/sober_str
 	if(d >= brawl_start && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		F.teach(H,1)
@@ -51,17 +51,17 @@
 			if(H.martial_art == F)
 				F.remove(H)
 	if(d >= confused_start && prob(33))
-		if (!M:confused) M:confused = 1
-		M.confused = max(M:confused+(confused_adj/sober_str),0)
+		if (!M.confused) M.confused = 1
+		M.confused = max(M.confused+(confused_adj/sober_str),0)
 	if(d >= blur_start)
 		M.eye_blurry = max(M.eye_blurry, 10/sober_str)
-		M:drowsyness  = max(M:drowsyness, 0)
+		M.drowsyness  = max(M.drowsyness, 0)
 	if(d >= vomit_start)
 		if(prob(8))
 			M.fakevomit()
 	if(d >= pass_out)
-		M:paralysis = max(M:paralysis, 20/sober_str)
-		M:drowsyness  = max(M:drowsyness, 30/sober_str)
+		M.Paralyse(20 / sober_str)
+		M.drowsyness = max(M.drowsyness, 30/sober_str)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/liver/L = H.internal_organs_by_name["liver"]

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_hurt.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_hurt.dm
@@ -17,7 +17,7 @@
 			C.apply_effect(25 * weakness,IRRADIATE,0)
 			C.nutrition -= min(50 * weakness, C.nutrition)
 			C.Dizzy(6 * weakness)
-			C.weakened += 6 * weakness
+			C.AdjustWeakened(6 * weakness)
 
 /datum/artifact_effect/hurt/DoEffectAura()
 	if(holder)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -28,14 +28,14 @@
 		var/turf/T = get_turf(suspension_field)
 		if(field_type == "carbon")
 			for(var/mob/living/carbon/M in T)
-				M.weakened = max(M.weakened, 3)
+				M.Weaken(3)
 				cell.charge -= power_use
 				if(prob(5))
 					M << "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]"
 
 		if(field_type == "iron")
 			for(var/mob/living/silicon/M in T)
-				M.weakened = max(M.weakened, 3)
+				M.Weaken(3)
 				cell.charge -= power_use
 				if(prob(5))
 					M << "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]"
@@ -47,7 +47,7 @@
 			I.loc = suspension_field
 
 		for(var/mob/living/simple_animal/M in T)
-			M.weakened = max(M.weakened, 3)
+			M.Weaken(3)
 			cell.charge -= power_use
 			if(prob(5))
 				M << "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]"
@@ -247,7 +247,7 @@
 		if("carbon")
 			success = 1
 			for(var/mob/living/carbon/C in T)
-				C.weakened += 5
+				C.AdjustWeakened(5)
 				C.visible_message("\blue \icon[C] [C] begins to float in the air!","You feel tingly and light, but it is difficult to move.")
 		if("nitrogen")
 			success = 1
@@ -270,7 +270,7 @@
 		if("iron")
 			success = 1
 			for(var/mob/living/silicon/R in T)
-				R.weakened += 5
+				R.AdjustWeakened(5)
 				R.visible_message("\blue \icon[R] [R] begins to float in the air!","You feel tingly and light, but it is difficult to move.")
 			//
 	//in case we have a bad field type
@@ -279,7 +279,7 @@
 
 	for(var/mob/living/simple_animal/C in T)
 		C.visible_message("\blue \icon[C] [C] begins to float in the air!","You feel tingly and light, but it is difficult to move.")
-		C.weakened += 5
+		C.AdjustWeakened(5)
 
 	suspension_field = new(T)
 	suspension_field.field_type = field_type
@@ -306,7 +306,7 @@
 
 	for(var/mob/M in T)
 		M << "<span class='info'>You no longer feel like floating.</span>"
-		M.weakened = min(M.weakened, 3)
+		M.SetWeakened(min(M.weakened, 3))
 
 	src.visible_message("\blue \icon[src] [src] deactivates with a gentle shudder.")
 	qdel(suspension_field)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -385,7 +385,8 @@
 				var/mob/living/M = A
 				if(M in immune)
 					continue
-				M.stunned = 10
+				M.stunned += 10
+				M.canmove = 0
 				M.anchored = 1
 				if(istype(M, /mob/living/simple_animal/hostile))
 					var/mob/living/simple_animal/hostile/H = M
@@ -413,7 +414,7 @@
 	return
 
 /obj/effect/timestop/proc/unfreeze_mob(mob/living/M)
-	M.stunned = 0
+	M.AdjustStunned(-10)
 	M.anchored = 0
 	if(istype(M, /mob/living/simple_animal/hostile))
 		var/mob/living/simple_animal/hostile/H = M


### PR DESCRIPTION
- This is partially a code cleanup
- It also resets stunned, paralyzed, and weakened if they're non-zero, but their status_flag says they should be disabled
 - One previously could permanently stunlock a person by stunning them and then making them stun-immune really quickly.