### PR TITLE
Adds Sleeping Carp Scroll to Uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -518,6 +518,15 @@ var/list/uplink_items = list()
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy and Inconspicuous Weapons"
 
+/datum/uplink_item/stealthy_weapons/martialarts
+	name = "Martial Arts Scroll"
+	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
+			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry."
+	reference = "SCS"
+	item = /obj/item/weapon/sleeping_carp_scroll
+	cost = 17
+	excludefrom = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/stealthy_weapons/edagger
 	name = "Energy Dagger"
 	desc = "A dagger made of energy that looks and functions as a pen when off."

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -404,7 +404,7 @@
 		if(!prob(martial_art.deflection_chance))
 			return ..()
 		if(!src.lying && !(HULK in mutations)) //But only if they're not lying down, and hulks can't do it
-			src.visible_message("<span class='warning'>[src] deflects the projectile!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+			visible_message("<span class='danger'>[src] deflects the projectile; they can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
 			return 0
 	..()
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -105,20 +105,24 @@
 				return
 
 	if (!user.IsAdvancedToolUser() || istype(user, /mob/living/simple_animal/diona))
-		user << "\red You don't have the dexterity to do this!"
+		user << "<span class='danger'>You don't have the dexterity to do this!</span>"
 		return
 	if(istype(user, /mob/living))
 		var/mob/living/M = user
 		if (HULK in M.mutations)
-			M << "\red Your meaty finger is much too large for the trigger guard!"
+			M << "<span class='danger'>Your meaty finger is much too large for the trigger guard!</span>"
 			return
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.species.name == "Golem")
-			user << "\red Your metal fingers don't fit in the trigger guard!"
+		if(H.get_species() == "Golem")
+			user << "<span class='danger'>Your metal fingers don't fit in the trigger guard!</span>"
 			return
-		if(user.dna && user.dna.species == "Shadowling")
+		if(H.get_species() == "Shadowling")
 			user << "<span class='danger'>The muzzle flash would cause damage to your form!</span>"
+			return
+		if(H.martial_art && H.martial_art.name == "The Sleeping Carp") //great dishonor to famiry
+			user << "<span class='danger'>Use of ranged weaponry would bring dishonor to the clan.</span>"
+			return
 
 	add_fingerprint(user)
 


### PR DESCRIPTION
Port of: https://github.com/tgstation/-tg-station/pull/15696

Adds the Sleeping carp scroll to the uplink for 17 TC.
- Makes the sleeping carp deflection message more clear
 - This isn't the kind of deflection double-bladed energy swords have; this just absorbs the projectile

Fixes
- Fixes being able to use guns as a Shadowling
- Fixes being able to use guns while having the sleeping carp martial arts active
- Spansssss