### PR TITLE
Allows immolate to immolate people

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -329,8 +329,13 @@
 	action_icon_state = "genetic_incendiary"
 
 /obj/effect/proc_holder/spell/targeted/immolate/cast(list/targets)
-
-/*	if(!targets.len) Uncomment this to allow the power to be used on targets other than yourself. That said, if you uncomment this I will find you and hurt you. Uncounterable and untracable burn damage with a 60-second cooldown is fun for exactly one person, and that's the person who is using it.
+	if(nutrition>0)
+		..()
+		nutrition = max(nutrition - rand(10,50),0)
+	else
+		src << "\red You're out of energy!  You need food!"
+		
+	if(!targets.len) 
 		usr << "<span class='notice'>No target found in range.</span>"
 		return
 
@@ -339,14 +344,13 @@
 		usr.attack_log += text("\[[time_stamp()]\] <font color='red'>[usr.real_name] ([usr.ckey]) cast the spell [name] on [L.real_name] ([L.ckey]).</font>")
 		L.attack_log += text("\[[time_stamp()]\] <font color='red'>[usr.real_name] ([usr.ckey]) cast the spell [name] on [L.real_name] ([L.ckey]).</font>")
 		msg_admin_attack("[usr.real_name] ([usr.ckey]) has cast the spell [name] on  [L.real_name] ([L.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JM
-*/
 	var/mob/living/carbon/L = usr
 
 	if(L)
 		usr.attack_log += text("\[[time_stamp()]\] <font color='red'>[key_name(usr)] cast the spell [name] on [key_name(L)]</font>")
 		msg_admin_attack("[key_name_admin(usr)] has cast the spell [name] on [key_name_admin(L)]")
 
-	L.adjust_fire_stacks(0.5)
+	L.adjust_fire_stacks(1)
 	L.visible_message("\red <b>[L.name]</b> suddenly bursts into flames!")
 	L.IgniteMob()
 	playsound(L.loc, 'sound/effects/bamf.ogg', 50, 0)


### PR DESCRIPTION
:cl: ppi
tweak: The genetic powers immolate allows you to use the excess energy produces by your cells to light people on fire with your mind, you can now light other people then yourself on fire.
/:cl:
This was removed back when you could not resist when you where on fire, thus an entire firestack.
Unlike before, it now takes nutrition to use it, I mean, you can't create energy from nothing. 
*cough tesla cough*