### PR TITLE
Changes neurotoxin drink name because of name clash with supertoxin

### DIFF
--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -639,7 +639,7 @@
 
 
 /datum/reagent/ethanol/neurotoxin
-	name = "Neurotoxin"
+	name = "Neuro-toxin"
 	id = "neurotoxin"
 	description = "A strong neurotoxin that puts the subject into a death-like state."
 	reagent_state = LIQUID


### PR DESCRIPTION
There were issues with the ethanol drink that drugs you having the same name as [the reagent that self-duplicates and causes severe brainloss](https://github.com/ParadiseSS13/Paradise/blob/master/code/modules/reagents/newchem/toxins.dm#L114).

:cl:
tweak: The ethanol-based neurotoxin drink is now called Neuro-toxin to avoid being confused with the deadly toxin.
/:cl: