### PR TITLE
Removes Halloss

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -7,14 +7,12 @@
 #define TOX			"tox"
 #define OXY			"oxy"
 #define CLONE		"clone"
-#define HALLOSS		"halloss"
 #define STAMINA 	"stamina"
 
 #define STUN		"stun"
 #define WEAKEN		"weaken"
 #define PARALYZE	"paralize"
 #define IRRADIATE	"irradiate"
-#define AGONY		"agony" // Added in PAIN!
 #define STUTTER		"stutter"
 #define SLUR		"slur"
 #define EYE_BLUR	"eye_blur"

--- a/code/datums/cargoprofile.dm
+++ b/code/datums/cargoprofile.dm
@@ -771,7 +771,7 @@
 		playsound(master.loc, "punch", 25, 1, -1)
 		master.visible_message("\red <B>\The [src] has punched [M]!</B>")
 		if(!master.emagged)
-			M.apply_damage(damage, HALLOSS, affecting, armor_block) // Clean fight
+			M.apply_damage(damage, STAMINA, affecting, armor_block) // Clean fight
 		else
 			M.apply_damage(damage, BRUTE,   affecting, armor_block) // Foul!  Foooul!
 
@@ -789,7 +789,7 @@
 	inlet_reaction(var/atom/W,var/turf/S,var/remaining)
 		//stolen from boxing gloves code
 		var/mob/living/carbon/human/M = W
-		if((M.lying || (M.health - M.halloss < 25))&& !master.emagged)
+		if((M.lying || (M.health - M.staminaloss < 25))&& !master.emagged)
 			M << "\The [src] gives you a break."
 			master.sleep+=5
 			return 0 // Be polite

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -449,7 +449,7 @@ var/list/turret_icons
 
 /obj/machinery/porta_turret/bullet_act(obj/item/projectile/Proj)
 
-	if(Proj.damage_type == HALLOSS || Proj.damage_type == STAMINA)
+	if(Proj.damage_type == STAMINA)
 		return
 
 	if(enabled)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -157,7 +157,7 @@ REAGENT SCANNER
 		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
 		user.show_message("\blue Analyzing Results for [M]:\n\t Overall Status: dead")
 	else
-		user.show_message("\blue Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "dead" : "[M.health - M.halloss]% healthy"]")
+		user.show_message("\blue Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "dead" : "[M.health]% healthy"]")
 	user.show_message("\t Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>", 1)
 	user.show_message("\t Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>")
 	user.show_message("\blue Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)", 1)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -207,11 +207,6 @@ mob/living
 				var/status = ""
 				var/brutedamage = org.brute_dam
 				var/burndamage = org.burn_dam
-				if(halloss > 0)
-					if(prob(30))
-						brutedamage += halloss
-					if(prob(30))
-						burndamage += halloss
 
 				if(brutedamage > 0)
 					status = "bruised"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -244,7 +244,7 @@ emp_act
 	apply_damage(I.force, I.damtype, affecting, armor, sharp=weapon_sharp, edge=weapon_edge, used_weapon=I)
 
 	var/bloody = 0
-	if(((I.damtype == BRUTE) || (I.damtype == HALLOSS)) && prob(25 + (I.force * 2)))
+	if(I.damtype == BRUTE)
 		I.add_blood(src)	//Make the weapon bloody, not the person.
 //		if(user.hand)	user.update_inv_l_hand()	//updates the attacker's overlay for the (now bloodied) weapon
 //		else			user.update_inv_r_hand()	//removed because weapons don't have on-mob blood overlays

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -244,7 +244,7 @@ emp_act
 	apply_damage(I.force, I.damtype, affecting, armor, sharp=weapon_sharp, edge=weapon_edge, used_weapon=I)
 
 	var/bloody = 0
-	if(I.damtype == BRUTE)
+	if(((I.damtype == BRUTE) && I.force && prob(25 + (I.force * 2))))
 		I.add_blood(src)	//Make the weapon bloody, not the person.
 //		if(user.hand)	user.update_inv_l_hand()	//updates the attacker's overlay for the (now bloodied) weapon
 //		else			user.update_inv_r_hand()	//removed because weapons don't have on-mob blood overlays

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -244,7 +244,7 @@ emp_act
 	apply_damage(I.force, I.damtype, affecting, armor, sharp=weapon_sharp, edge=weapon_edge, used_weapon=I)
 
 	var/bloody = 0
-	if(((I.damtype == BRUTE) && I.force && prob(25 + (I.force * 2))))
+	if(I.damtype == BRUTE && I.force && prob(25 + I.force * 2))
 		I.add_blood(src)	//Make the weapon bloody, not the person.
 //		if(user.hand)	user.update_inv_l_hand()	//updates the attacker's overlay for the (now bloodied) weapon
 //		else			user.update_inv_r_hand()	//removed because weapons don't have on-mob blood overlays

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -851,7 +851,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 			if(hallucination <= 2)
 				hallucination = 0
-				halloss = 0
 			else
 				hallucination -= 2
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -8,8 +8,7 @@
 	1	* src.getToxLoss() + 		\
 	1	* src.getFireLoss() + 		\
 	1	* src.getBruteLoss() + 		\
-	1	* src.getCloneLoss() + 		\
-	1	* src.halloss
+	1	* src.getCloneLoss()
 
 	if(reagents)
 		for(var/datum/reagent/R in reagents.reagent_list)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -23,22 +23,19 @@
 			adjustOxyLoss(damage * blocked)
 		if(CLONE)
 			adjustCloneLoss(damage * blocked)
-		if(HALLOSS)
-			adjustHalLoss(damage * blocked)
 		if(STAMINA)
 			adjustStaminaLoss(damage * blocked)
 	updatehealth()
 	return 1
 
 
-/mob/living/proc/apply_damages(var/brute = 0, var/burn = 0, var/tox = 0, var/oxy = 0, var/clone = 0, var/halloss = 0, var/def_zone = null, var/blocked = 0, var/stamina = 0)
+/mob/living/proc/apply_damages(var/brute = 0, var/burn = 0, var/tox = 0, var/oxy = 0, var/clone = 0, var/def_zone = null, var/blocked = 0, var/stamina = 0)
 	if(blocked >= 100)	return 0
 	if(brute)	apply_damage(brute, BRUTE, def_zone, blocked)
 	if(burn)	apply_damage(burn, BURN, def_zone, blocked)
 	if(tox)		apply_damage(tox, TOX, def_zone, blocked)
 	if(oxy)		apply_damage(oxy, OXY, def_zone, blocked)
 	if(clone)	apply_damage(clone, CLONE, def_zone, blocked)
-	if(halloss) apply_damage(halloss, HALLOSS, def_zone, blocked)
 	if(stamina) apply_damage(stamina, STAMINA, def_zone, blocked)
 	return 1
 
@@ -55,8 +52,6 @@
 			Weaken(effect * blocked)
 		if(PARALYZE)
 			Paralyse(effect * blocked)
-		if(AGONY)
-			halloss += effect // Useful for objects that cause "subdual" damage. PAIN!
 		if(IRRADIATE)
 			var/rad_damage = effect
 			if(!negate_armor) // Setting negate_armor overrides radiation armor checks, which are automatic otherwise
@@ -82,7 +77,7 @@
 		return 0
 	return ..()
 
-/mob/living/proc/apply_effects(var/stun = 0, var/weaken = 0, var/paralyze = 0, var/irradiate = 0, var/slur = 0, var/stutter = 0, var/eyeblur = 0, var/drowsy = 0, var/agony = 0, var/blocked = 0, var/stamina = 0, var/jitter = 0)
+/mob/living/proc/apply_effects(var/stun = 0, var/weaken = 0, var/paralyze = 0, var/irradiate = 0, var/slur = 0, var/stutter = 0, var/eyeblur = 0, var/drowsy = 0, var/blocked = 0, var/stamina = 0, var/jitter = 0)
 	if(blocked >= 100)	return 0
 	if(stun)		apply_effect(stun, STUN, blocked)
 	if(weaken)		apply_effect(weaken, WEAKEN, blocked)
@@ -92,7 +87,6 @@
 	if(stutter)		apply_effect(stutter, STUTTER, blocked)
 	if(eyeblur)		apply_effect(eyeblur, EYE_BLUR, blocked)
 	if(drowsy)		apply_effect(drowsy, DROWSY, blocked)
-	if(agony)		apply_effect(agony, AGONY, blocked)
 	if(stamina)		apply_damage(stamina, STAMINA, null, blocked)
 	if(jitter) 		apply_effect(jitter, JITTER, blocked)
 	return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -181,17 +181,6 @@
 	if(status_flags & GODMODE)	return 0
 	staminaloss = amount
 
-/mob/living/proc/getHalLoss()
-	return halloss
-
-/mob/living/proc/adjustHalLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	halloss = min(max(halloss + amount, 0),(maxHealth*2))
-
-/mob/living/proc/setHalLoss(var/amount)
-	if(status_flags & GODMODE)	return 0	//godmode
-	halloss = amount
-
 /mob/living/proc/getMaxHealth()
 	return maxHealth
 
@@ -345,7 +334,6 @@
 	setBrainLoss(0)
 	setStaminaLoss(0)
 	SetSleeping(0)
-	setHalLoss(0)
 	SetParalysis(0)
 	SetStunned(0)
 	SetWeakened(0)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -13,7 +13,6 @@
 	var/fireloss = 0.0	//Burn damage caused by being way too hot, too cold or burnt.
 	var/cloneloss = 0	//Damage caused by being cloned or ejected from the cloner early. slimes also deal cloneloss damage to victims
 	var/brainloss = 0	//'Retardation' damage caused by someone hitting you in the head with a bible or being infected with brainrot.
-	var/halloss = 0		//Hallucination damage; utilize this largely for fake "pain" based damage. Sleeping should cause it to wear of
 	var/staminaloss = 0 //Stamina damage, or exhaustion. You recover it slowly naturally, and are stunned if it gets too high. Holodeck and hallucinations deal this.
 
 	var/hallucination = 0 //Directly affects how long a mob will hallucinate for

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -204,7 +204,7 @@
 		if("robot")
 			var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
 			var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
-			user << "<span class='notice'>Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "fully disabled" : "[M.health - M.halloss]% functional"]</span>"
+			user << "<span class='notice'>Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "fully disabled" : "[M.health]% functional"]</span>"
 			user << "\t Key: <font color='#FFA500'>Electronics</font>/<font color='red'>Brute</font>"
 			user << "\t Damage Specifics: <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>"
 			if(M.timeofdeath && M.stat == DEAD)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -847,7 +847,7 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/pull_damage()
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
-		if(H.health - H.halloss <= config.health_threshold_softcrit)
+		if(H.health <= config.health_threshold_softcrit)
 			for(var/name in H.organs_by_name)
 				var/obj/item/organ/external/e = H.organs_by_name[name]
 				if(e && H.lying)

--- a/code/modules/pda/utilities.dm
+++ b/code/modules/pda/utilities.dm
@@ -44,7 +44,7 @@
 	C.visible_message("<span class=warning>[user] has analyzed [C]'s vitals!</span>")
 
 	user.show_message("<span class=notice>Analyzing Results for [C]:</span>")
-	user.show_message("<span class=notice>\t Overall Status: [C.stat > 1 ? "dead" : "[C.health - C.halloss]% healthy"]</span>", 1)
+	user.show_message("<span class=notice>\t Overall Status: [C.stat > 1 ? "dead" : "[C.health]% healthy"]</span>", 1)
 	user.show_message("<span class=notice>\t Damage Specifics: [C.getOxyLoss() > 50 ? "</span><span class=warning>" : ""][C.getOxyLoss()]-[C.getToxLoss() > 50 ? "</span><span class=warning>" : "</span><span class=notice>"][C.getToxLoss()]-[C.getFireLoss() > 50 ? "</span><span class=warning>" : "</span><span class=notice>"][C.getFireLoss()]-[C.getBruteLoss() > 50 ? "</span><span class=warning>" : "</span><span class=notice>"][C.getBruteLoss()]</span>", 1)
 	user.show_message("<span class=notice>\t Key: Suffocation/Toxin/Burns/Brute</span>", 1)
 	user.show_message("<span class=notice>\t Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span>", 1)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -300,7 +300,7 @@
 				user.death()
 			else
 				user << "<span class = 'notice'>Ow...</span>"
-				user.apply_effect(110,AGONY,0)
+				user.apply_effect(110,STAMINA,0)
 			del(in_chamber)
 			mouthshoot = 0
 			return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -51,7 +51,6 @@
 	var/stutter = 0
 	var/eyeblur = 0
 	var/drowsy = 0
-	var/agony = 0
 	var/stamina = 0
 	var/jitter = 0
 	var/embed = 0 // whether or not the projectile can embed itself in the mob
@@ -87,7 +86,7 @@
 		if(!isliving(target))	return 0
 		if(isanimal(target))	return 0
 		var/mob/living/L = target
-		return L.apply_effects(stun, weaken, paralyze, irradiate, slur, stutter, eyeblur, drowsy, agony, blocked, stamina, jitter)
+		return L.apply_effects(stun, weaken, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
 
 	proc/OnFired()	//if assigned, allows for code when the projectile gets fired
 		return 1

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -404,9 +404,9 @@
 	name = "Phantom Pain Syndrome"
 	stage = 3
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.halloss < 100)
+		if (mob.staminaloss < 100)
 			mob << "<span class = 'warning'> You feel like your body is on fire. Make the pain stop!</span>"
-			mob.apply_effect(20,AGONY,0)
+			mob.apply_effect(20,STAMINA,0)
 
 // === burn brute toxin clone brain damage symptoms - Bone White ===
 
@@ -655,9 +655,9 @@ var/list/compatible_mobs = list(/mob/living/carbon/human)
 	name = "Acute Muscle Ache"
 	stage = 2
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.halloss < 50)
+		if (mob.staminaloss < 50)
 			mob << "<span class='warning'>You ache all over!</span>"
-			mob.apply_effect(10,AGONY,0)
+			mob.apply_effect(10,STAMINA,0)
 
 // === burn brute toxin clone brain damage symptoms - Bone White ===
 
@@ -844,9 +844,9 @@ var/list/compatible_mobs = list(/mob/living/carbon/human)
 	name = "Heightened Sensitivity"
 	stage = 1
 	activate(var/mob/living/carbon/mob,var/multiplier)
-		if (mob.halloss < 20)
+		if (mob.staminaloss < 20)
 			mob << "<span class='warning'>Your body aches.</span>"
-			mob.apply_effect(5,AGONY,0)
+			mob.apply_effect(5,STAMINA,0)
 
 /datum/disease2/effect/stimulant
 	name = "Adrenaline Extra"


### PR DESCRIPTION
Not considering this removal since staminaloss does everything Halloss does, only better and more balanced---and the there's only like 3 things that even use Halloss anymore.


Coders: please double check to make sure that the procs for applying damage/effects have the proper order of arguments, everywhere, if you can---as far as I can tell, the ones that have switches should be ok, and `apply_damages` and `apply_effects` are only used in a few spots, and I believe those arguments are in the proper order---still, please, double-check for me.

:cl: Fox McCloud
rscremove: Removes the now virtually unused Halloss
/:cl: