### PR TITLE
Surgery Tweaks

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -39,7 +39,7 @@
 	can_infect = 1
 	blood_level = 1
 
-	max_duration = 60
+	time = 24
 
 /datum/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -75,7 +75,7 @@
 	/obj/item/weapon/wrench = 75		\
 	)
 
-	max_duration = 70
+	time = 32
 
 /datum/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -115,7 +115,7 @@
 	/obj/item/weapon/wrench = 75		\
 	)
 
-	max_duration = 70
+	time = 32
 
 /datum/surgery_step/mend_skull/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -153,7 +153,7 @@
 	can_infect = 1
 	blood_level = 1
 
-	max_duration = 60
+	time = 24
 
 /datum/surgery_step/finish_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -24,7 +24,7 @@
 	/obj/item/weapon/hatchet = 75
 	)
 
-	max_duration = 70
+	time = 54
 
 /datum/surgery_step/open_encased/saw/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if (!hasorgans(target))
@@ -77,7 +77,7 @@
 	/obj/item/weapon/crowbar = 75
 	)
 
-	max_duration = 40
+	time = 24
 
 /datum/surgery_step/open_encased/retract/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if (!hasorgans(target))
@@ -109,10 +109,6 @@
 
 	affected.open = 3
 
-	// Whoops!
-	if(prob(10) && !isrobot(user))
-		affected.fracture()//WTF WHY?!
-
 	return 1
 
 /datum/surgery_step/open_encased/retract/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -138,7 +134,7 @@
 	/obj/item/weapon/crowbar = 75
 	)
 
-	max_duration = 40
+	time = 24
 
 /datum/surgery_step/open_encased/close/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
@@ -195,7 +191,7 @@
 	/obj/item/weapon/screwdriver = 75
 	)
 
-	max_duration = 40
+	time = 24
 
 /datum/surgery_step/open_encased/mend/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -43,7 +43,7 @@
 	/obj/item/weapon/shard = 50, 		\
 	)
 
-	max_duration = 110
+	time = 16
 
 /datum/surgery_step/generic/cut_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 		return ..() && target_zone == "mouth" //&& target.op_stage.face == 0//I NEED TO REPLACE THE OPSTAGE SHIT!
@@ -78,7 +78,7 @@
 	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
-	max_duration = 90
+	time = 24
 
 /datum/surgery_step/face/mend_vocal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 		return ..()// && target.op_stage.face == 1 //NO REALLY NED TO REPLACE, MAYBE WITH FUCKING istype(S.get_surgery_step(), /datum/surgery_step/cut_face)) OR SOMETHING
@@ -108,7 +108,7 @@
 	/obj/item/weapon/crowbar = 55,	\
 	/obj/item/weapon/kitchen/utensil/fork = 75)
 
-	max_duration = 100
+	time = 64
 
 /datum/surgery_step/face/fix_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 		return ..() //&& target.op_stage.face == 2//I NEED TO REPLACE THE OPSTAGE SHIT!
@@ -143,7 +143,7 @@
 	/obj/item/weapon/weldingtool = 25
 	)
 
-	max_duration = 100
+	time = 24
 
 /datum/surgery_step/face/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 		return ..()// && target.op_stage.face > 0//I NEED TO REPLACE THE OPSTAGE SHIT!

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -39,7 +39,7 @@
 	/obj/item/weapon/pen/edagger = 5,  \
 	)
 
-	max_duration = 60
+	time = 16
 
 /datum/surgery_step/generic/cut_open/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -58,9 +58,6 @@
 	"<span class='notice'> You have made an incision on [target]'s [affected.name] with \the [tool].</span>",)
 	affected.open = 1
 	affected.status |= ORGAN_BLEEDING
-	affected.createwound(CUT, 1)
-	//if (target_zone == "head")
-	//	target.brain_op_stage = 1
 	return 1
 
 /datum/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -83,7 +80,7 @@
 	/obj/item/device/assembly/mousetrap = 20
 	)
 
-	max_duration = 60
+	time = 24
 
 
 /datum/surgery_step/generic/clamp_bleeders/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -123,7 +120,7 @@
 	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
-	max_duration = 40
+	time = 24
 
 /datum/surgery_step/generic/retract_skin/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -185,7 +182,7 @@
 	/obj/item/weapon/weldingtool = 25
 	)
 
-	max_duration = 90
+	time = 24
 
 /datum/surgery_step/generic/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -225,7 +222,7 @@
 	/obj/item/weapon/melee/arm_blade = 60
 	)
 
-	max_duration = 110
+	time = 100
 
 /datum/surgery_step/generic/amputate/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if (target_zone == "eyes")	//there are specific steps for eye surgery

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -76,7 +76,7 @@
 	/obj/item/stack/rods = 50
 	)
 
-	max_duration = 80
+	time = 54
 
 /datum/surgery_step/cavity/make_space/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -110,7 +110,7 @@
 	/obj/item/weapon/weldingtool = 25
 	)
 
-	max_duration = 80
+	time = 24
 
 /datum/surgery_step/cavity/close_space/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -139,7 +139,7 @@
 	var/obj/item/IC = null
 	allowed_tools = list(/obj/item = 100)
 
-	max_duration = 100
+	time = 32
 
 
 /datum/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -236,7 +236,7 @@
 	/obj/item/weapon/kitchen/utensil/fork = 20
 	)
 	var/obj/item/weapon/implant/I = null
-	max_duration = 70
+	time = 64
 
 /datum/surgery_step/cavity/implant_removal/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -310,7 +310,7 @@
 
 /datum/surgery_step/remove_object
 	name = "remove embedded objects"
-	max_duration = 32
+	time = 32
 	accept_hand = 1
 	var/obj/item/organ/external/L = null
 

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -81,7 +81,7 @@
 	name = "attach limb"
 	allowed_tools = list(/obj/item/organ/external = 100)
 
-	max_duration = 70
+	time = 32
 
 /datum/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
@@ -123,7 +123,7 @@
 	)
 	can_infect = 1
 
-	max_duration = 120
+	time = 32
 
 /datum/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
@@ -161,7 +161,7 @@
 	name = "attach robotic limb"
 	allowed_tools = list(/obj/item/robot_parts = 100)
 
-	max_duration = 100
+	time = 32
 
 /datum/surgery_step/limb/mechanize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -67,7 +67,7 @@
 	var/current_type
 	var/obj/item/organ/internal/I = null
 	var/obj/item/organ/external/affected = null
-	max_duration = 90
+	time = 64
 
 /datum/surgery_step/internal/manipulate_organs/New()
 	..()
@@ -313,7 +313,7 @@
 	/obj/item/weapon/hatchet = 75
 	)
 
-	max_duration = 70
+	time = 54
 
 
 /datum/surgery_step/saw_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -351,7 +351,7 @@
 	/obj/item/weapon/pen/edagger = 5,  \
 	)
 
-	max_duration = 60
+	time = 16
 
 /datum/surgery_step/cut_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
@@ -381,7 +381,7 @@
 	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
-	max_duration = 40
+	time = 24
 
 /datum/surgery_step/retract_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/msg = "[user] starts to pry open the incision on [target]'s [target_zone] with \the [tool]."

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -30,7 +30,7 @@
 	can_infect = 1
 	blood_level = 1
 
-	max_duration = 90
+	time = 32
 
 /datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -83,7 +83,7 @@
 	can_infect = 1
 	blood_level = 1
 
-	max_duration = 160
+	time = 16
 
 /datum/surgery_step/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(!hasorgans(target))
@@ -132,7 +132,7 @@
 	can_infect = 0
 	blood_level = 0
 
-	max_duration = 60
+	time = 24
 
 /datum/surgery_step/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if (!istype(tool, /obj/item/weapon/reagent_containers))
@@ -221,7 +221,7 @@
 	name = "cleanse contamination"
 	allowed_tools = list(/obj/item/device/flash = 100, /obj/item/device/flashlight/pen = 80, /obj/item/device/flashlight = 40)
 
-	max_duration = 120
+	time = 30
 
 /datum/surgery_step/internal/dethrall/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if (!hasorgans(target))

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -79,7 +79,7 @@
 		/obj/item/weapon/kitchen/knife = 50
 	)
 
-	max_duration = 110
+	time = 16
 
 /datum/surgery_step/robotics/external/unscrew_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
@@ -113,7 +113,7 @@
 		/obj/item/weapon/kitchen/utensil/ = 50
 	)
 
-	max_duration = 40
+	time = 24
 
 /datum/surgery_step/robotics/external/open_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
@@ -147,7 +147,7 @@
 		/obj/item/weapon/kitchen/utensil = 50
 	)
 
-	max_duration = 100
+	time = 24
 
 /datum/surgery_step/robotics/external/close_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
@@ -181,7 +181,7 @@
 		/obj/item/weapon/gun/energy/plasmacutter = 50
 	)
 
-	max_duration = 60
+	time = 32
 
 /datum/surgery_step/robotics/external/repair_brute/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
@@ -222,7 +222,7 @@
 		/obj/item/stack/cable_coil = 100
 	)
 
-	max_duration = 60
+	time = 32
 
 /datum/surgery_step/robotics/external/repair_burn/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
@@ -270,7 +270,7 @@
 	var/current_type
 	var/obj/item/organ/internal/I = null
 	var/obj/item/organ/external/affected = null
-	max_duration = 90
+	time = 32
 
 /datum/surgery_step/robotics/manipulate_robotic_organs/New()
 	..()
@@ -500,7 +500,7 @@
 	/obj/item/device/mmi = 100
 	)
 
-	max_duration = 80
+	time = 64
 
 	can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
@@ -572,7 +572,7 @@
 	allowed_tools = list(
 	/obj/item/device/multitool = 100)
 
-	max_duration = 110
+	time = 100
 
 /datum/surgery_step/robotics/external/amputate/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/slime.dm
+++ b/code/modules/surgery/slime.dm
@@ -22,7 +22,7 @@
 	/obj/item/weapon/shard = 50, 		\
 	)
 
-	max_duration = 50
+	time = 16
 
 /datum/surgery_step/slime/cut_flesh/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 		return ..() && istype(target) && target.core_removal_stage == 0
@@ -50,7 +50,7 @@
 	/obj/item/weapon/shard = 50, 		\
 	)
 
-	max_duration = 50
+	time = 16
 
 /datum/surgery_step/slime/cut_innards/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 		return ..() && istype(target) && target.core_removal_stage == 1
@@ -76,7 +76,7 @@
 	/obj/item/weapon/hatchet = 75
 	)
 
-	max_duration = 70
+	time = 16
 
 /datum/surgery_step/slime/saw_core/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 		return ..() && (istype(target) && target.core_removal_stage == 2 && target.cores > 0) //This is being passed a human as target, unsure why.

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -56,7 +56,7 @@
 	var/implement_type = null
 
 	// duration of the step
-	var/max_duration = 0
+	var/time = 10
 
 	var/name
 	var/accept_hand = 0				//does the surgery step require an open hand? If true, ignores implements. Compatible with accept_any_item.
@@ -109,9 +109,9 @@
 	prob_chance *= get_location_modifier(target)
 
 	if(prob_chance > 100)//if we are using a super tool
-		max_duration = max_duration/prob_chance //PLACEHOLDER VALUES
+		time = time/prob_chance //PLACEHOLDER VALUES
 
-	if(do_after(user, max_duration, target = target))
+	if(do_after(user, time, target = target))
 
 
 		if(prob(prob_chance) || isrobot(user))


### PR DESCRIPTION
Just some surgery tweaks

- Renames the `max_duration` var to `time`
- Lowers surgery step times across the board to be in line with TG
 - This is for consistency and also, in part, to adjust for the fact you can't do multi-surgery
- Removes the damage caused by scalpels, even on a successful surgery
- Removes the random chance to fracture someone's bones, even on a successful surgery step


:cl: Fox McCloud
tweak: Lowers surgery times across the board
tweak: Removes scalpels causing 1 damage on successful surgery
tweak: Removes random chance to fracture ribs on a successful surgery
/:cl: