### PR TITLE
Change Watchlist to use send2adminirc instead of send2irc_adminless_only

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -373,7 +373,7 @@
 	var/watchreason = check_watchlist(sql_ckey)
 	if(watchreason)
 		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is on the watchlist and has just connected - Reason: [watchreason]</font>")
-		send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
+		send2adminirc("Watchlist - [key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
 
 	//Just the standard check to see if it's actually a number
 	if(sql_id)


### PR DESCRIPTION
Instead of only sending watchlist notifications to the IRC bot/s when 0 admins are online, the watchlist will now always send a notification to the IRC bot/s. 

I am pretty sure the command didn't work either, as the channel was set to "Watchlist".