### PR TITLE
Fixes several midround antag/creature assignments not asking ghosts first

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -463,6 +463,8 @@ proc/pollCandidates(var/Question, var/be_special_type, var/antag_age_check = 0, 
 		if(roletext)
 			if(jobban_isbanned(G, roletext) || jobban_isbanned(G, "Syndicate"))
 				continue
+		if(G.has_enabled_antagHUD)
+			continue
 		spawn(0)
 			G << 'sound/misc/notice2.ogg' //Alerting them to their consideration
 			switch(alert(G,Question,"Please answer in [poll_time/10] seconds!","Yes","No"))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -444,7 +444,8 @@ proc/isInSight(var/atom/A, var/atom/B)
 /proc/SecondsToTicks(var/seconds)
 	return seconds * 10
 
-proc/pollCandidates(var/Question, var/jobbanType, var/antag_age_check = 0, var/be_special_flag = 0, var/poll_time = 300)
+proc/pollCandidates(var/Question, var/be_special_type, var/antag_age_check = 0, var/poll_time = 300)
+	var/roletext = be_special_type ? get_roletext(be_special_type) : null
 	var/list/mob/dead/observer/candidates = list()
 	var/time_passed = world.time
 	if (!Question)
@@ -453,14 +454,14 @@ proc/pollCandidates(var/Question, var/jobbanType, var/antag_age_check = 0, var/b
 	for(var/mob/dead/observer/G in player_list)
 		if(!G.key || !G.client)
 			continue
-		if(be_special_flag)
-			if(!(G.client.prefs.be_special & be_special_flag))
+		if(be_special_type)
+			if(!(be_special_type in G.client.prefs.be_special))
 				continue
-		if (antag_age_check && be_special_flag)
-			if(!player_old_enough_antag(G.client,be_special_flag))
-				continue
-		if (jobbanType)
-			if(jobban_isbanned(G, jobbanType) || jobban_isbanned(G, "Syndicate"))
+			if(antag_age_check)
+				if(!player_old_enough_antag(G.client, be_special_type))
+					continue
+		if(roletext)
+			if(jobban_isbanned(G, roletext) || jobban_isbanned(G, "Syndicate"))
 				continue
 		spawn(0)
 			G << 'sound/misc/notice2.ogg' //Alerting them to their consideration

--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -36,7 +36,7 @@
 		return
 	checking = 1
 	user << "<span class='notice'>The device is now checking for possible borgs.</span>"
-	var/list/mob/dead/observer/borg_candidates = pollCandidates("Do you want to play as a Syndicate [borg_to_spawn] borg?", "operative", 1, ROLE_OPERATIVE, 300)
+	var/list/borg_candidates = pollCandidates("Do you want to play as a Syndicate [borg_to_spawn] borg?", ROLE_OPERATIVE, 1)
 	if(borg_candidates.len > 0 && !used)
 		checking = 0
 		used = 1
@@ -74,20 +74,28 @@
 	icon_state = "vial"
 
 /obj/item/weapon/antag_spawner/slaughter_demon/attack_self(mob/user as mob)
-	var/list/demon_candidates = get_candidates(ROLE_DEMON)
 	if(user.z == ZLEVEL_CENTCOMM)//this is to make sure the wizard does NOT summon a demon from the Den..
 		user << "<span class='notice'>You should probably wait until you reach the station.</span>"
 		return
-	if(demon_candidates.len > 0)
-		used = 1
-		var/client/C = pick(demon_candidates)
-		spawn_antag(C, get_turf(src.loc), "Slaughter Demon")
+
+	if(used)
+		user << "<span class='notice'>This bottle already has a broken seal.</span>"
+		return
+	used = 1
+	user << "<span class='notice'>You break the seal on the bottle, calling upon the dire spirits of the underworld...</span>"
+
+	var/list/candidates = pollCandidates("Do you want to play as a slaughter demon summoned by [user.real_name]?", ROLE_DEMON, 1, 100)
+
+	if(candidates.len > 0)
+		var/mob/C = pick(candidates)
+		spawn_antag(C, get_turf(src.loc), "Slaughter Demon", user)
 		user << "<span class='notice'>You shatter the bottle, no turning back now!</span>"
 		user << "<span class='notice'>You sense a dark presence lurking just beyond the veil...</span>"
 		playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
 		qdel(src)
 	else
-		user << "<span class='notice'>You can't seem to work up the nerve to shatter the bottle. Perhaps you should try again later.</span>"
+		used = 0
+		user << "<span class='notice'>The demons do not respond to your summon. Perhaps you should try again later.</span>"
 
 /obj/item/weapon/antag_spawner/slaughter_demon/spawn_antag(var/client/C, var/turf/T, var/type = "", mob/user as mob)
 	var /obj/effect/dummy/slaughter/holder = new /obj/effect/dummy/slaughter(T)

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -5,10 +5,11 @@
 	health = 200
 	fire_resist = 2
 	var/mob/camera/blob/overmind = null // the blob core's overmind
-	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 30 seconds
+	var/overmind_get_delay = 0 // we don't want to constantly try to find an overmind, do it every 5 minutes
 	var/resource_delay = 0
 	var/point_rate = 2
 	var/is_offspring = null
+	var/selecting = 0
 
 /obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring)
 	blob_cores += src
@@ -88,36 +89,33 @@
 
 
 /obj/effect/blob/core/proc/create_overmind(var/client/new_overmind, var/override_delay)
-
 	if(overmind_get_delay > world.time && !override_delay)
 		return
-
-	overmind_get_delay = world.time + 300 // 30 seconds
+	
+	overmind_get_delay = world.time + 3000 // 5 minutes
 
 	if(overmind)
 		qdel(overmind)
 
-	var/client/C = null
+	var/mob/C = null
 	var/list/candidates = list()
+	
+	spawn()
+		if(!new_overmind)
+			candidates = pollCandidates("Do you want to play as a blob?", ROLE_BLOB, 1)
+			if(candidates.len)
+				C = pick(candidates)
+		else
+			C = new_overmind
 
-	if(!new_overmind)
-		candidates = get_candidates(ROLE_BLOB)
-		if(candidates.len)
-			C = pick(candidates)
-	else
-		C = new_overmind
-
-	if(C)
-		var/mob/camera/blob/B = new(src.loc)
-		B.key = C.key
-		B.blob_core = src
-		src.overmind = B
-		color = overmind.blob_reagent_datum.color
-		if(B.mind && !B.mind.special_role)
-			B.mind.special_role = "Blob Overmind"
-		spawn(0)
-			if(is_offspring)
-				B.verbs -= /mob/camera/blob/verb/split_consciousness
-		return 1
-	return 0
-
+		if(C)
+			var/mob/camera/blob/B = new(src.loc)
+			B.key = C.key
+			B.blob_core = src
+			src.overmind = B
+			color = overmind.blob_reagent_datum.color
+			if(B.mind && !B.mind.special_role)
+				B.mind.special_role = "Blob Overmind"
+			spawn(0)
+				if(is_offspring)
+					B.verbs -= /mob/camera/blob/verb/split_consciousness

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -186,7 +186,7 @@
 		update_cult_icons_added(cult_mind)
 		cult_mind.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Has been converted to the cult!</span>"
 		if(jobban_isbanned(cult_mind.current, ROLE_CULTIST))
-			replace_jobbaned_player(cult_mind.current, ROLE_CULTIST, ROLE_CULTIST)
+			replace_jobbaned_player(cult_mind.current, ROLE_CULTIST)
 		return 1
 
 

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -6,25 +6,27 @@
 			if(temp_vent.parent.other_atmosmch.len > 50) // Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
 
-	var/list/candidates = get_candidates(ROLE_ALIEN,ALIEN_AFK_BRACKET)
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to play as an alien?", ROLE_ALIEN, 1)
 
-	if(prob(40)) spawncount++ //sometimes, have two larvae spawn instead of one
-	while((spawncount >= 1) && vents.len && candidates.len)
+		if(prob(40)) spawncount++ //sometimes, have two larvae spawn instead of one
+		while((spawncount >= 1) && vents.len && candidates.len)
 
-		var/obj/vent = pick(vents)
-		var/candidate = pick(candidates)
+			var/obj/vent = pick(vents)
+			var/mob/candidate = pick(candidates)
+			var/client/C = candidate.client
+			if(C)
+				var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
+				new_xeno.key = C
+				respawnable_list -= C
+				candidates -= C
+				vents -= vent
+				spawncount--
 
-		var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
-		new_xeno.key = candidate
-		respawnable_list -= candidate
-		candidates -= candidate
-		vents -= vent
-		spawncount--
-
-	spawn(rand(5000, 6000)) //Delayed announcements to keep the crew on their toes.
-		command_announcement.Announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
-		for(var/mob/M in player_list)
-			M << sound('sound/AI/aliens.ogg')
+		spawn(rand(5000, 6000)) //Delayed announcements to keep the crew on their toes.
+			command_announcement.Announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
+			for(var/mob/M in player_list)
+				M << sound('sound/AI/aliens.ogg')
 
 /proc/lightsout(isEvent = 0, lightsoutAmount = 1,lightsoutRange = 25) //leave lightsoutAmount as 0 to break ALL lights
 	if(isEvent)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -447,8 +447,8 @@ proc/get_nt_opposed()
 			nukecode = bomb.r_code
 	return nukecode
 
-/datum/game_mode/proc/replace_jobbaned_player(mob/living/M, role_type, pref)
-	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as a [role_type]?", "[role_type]", null, pref, 100)
+/datum/game_mode/proc/replace_jobbaned_player(mob/living/M, role_type)
+	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as a [role_type]?", role_type, 0, 100)
 	var/mob/dead/observer/theghost = null
 	if(candidates.len)
 		theghost = pick(candidates)

--- a/code/game/gamemodes/miniantags/borer/borer_event.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_event.dm
@@ -22,14 +22,15 @@
 			if(temp_vent.parent.other_atmosmch.len > 50)
 				vents += temp_vent
 
-	var/list/candidates = get_candidates(ROLE_BORER,ALIEN_AFK_BRACKET)
-	while(spawncount > 0 && vents.len && candidates.len)
-		var/obj/vent = pick_n_take(vents)
-		var/client/C = pick_n_take(candidates)
+	spawn(0)
+		var/list/candidates = pollCandidates("Do you want to play as a cortical borer?", ROLE_BORER, 1)
+		while(spawncount > 0 && vents.len && candidates.len)
+			var/obj/vent = pick_n_take(vents)
+			var/mob/C = pick_n_take(candidates)
 
-		var/mob/living/simple_animal/borer/new_borer = new(vent.loc)
-		new_borer.key = C.key
+			var/mob/living/simple_animal/borer/new_borer = new(vent.loc)
+			new_borer.key = C.key
 
-		spawncount--
-		successSpawn = 1
+			spawncount--
+			successSpawn = 1
 

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -186,7 +186,7 @@
 	src.verbs -= /mob/living/proc/guardian_reset
 	for(var/mob/living/simple_animal/hostile/guardian/G in mob_list)
 		if(G.summoner == src)
-			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [G.real_name]?", "pAI", null, FALSE, 100)
+			var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [G.real_name]?", ROLE_GUARDIAN, 0, 100)
 			var/mob/dead/observer/new_stand = null
 			if(candidates.len)
 				new_stand = pick(candidates)
@@ -197,7 +197,8 @@
 				G.key = new_stand.key
 			else
 				src << "There were no ghosts willing to take control. Looks like you're stuck with your Guardian for now."
-				verbs += /mob/living/proc/guardian_reset
+				spawn(3000)
+					verbs += /mob/living/proc/guardian_reset
 
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleLight()
@@ -656,7 +657,7 @@
 		return
 	used = TRUE
 	user << "[use_message]"
-	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as the [mob_name] of [user.real_name]?",ROLE_GUARDIAN, null, FALSE, 100)
+	var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as the [mob_name] of [user.real_name]?", ROLE_GUARDIAN, 0, 100)
 	var/mob/dead/observer/theghost = null
 
 	if(candidates.len)

--- a/code/game/gamemodes/miniantags/morph/morph_event.dm
+++ b/code/game/gamemodes/miniantags/morph/morph_event.dm
@@ -1,45 +1,32 @@
 /datum/event/spawn_morph
 	var/key_of_morph
 
-/datum/event/spawn_morph/proc/get_morph(end_if_fail = 0)
-	key_of_morph = null
-	if(!key_of_morph)
-		var/list/candidates = get_candidates(ROLE_MORPH)
+/datum/event/spawn_morph/proc/get_morph()
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to play as a morph?", ROLE_MORPH, 1)
 		if(!candidates.len)
-			if(end_if_fail)
-				return 0
-			return find_morph()
-		var/client/C = pick(candidates)
+			key_of_morph = null
+			return kill()
+		var/mob/C = pick(candidates)
 		key_of_morph = C.key
-	if(!key_of_morph)
-		if(end_if_fail)
-			return 0
-		return find_morph()
-	var/datum/mind/player_mind = new /datum/mind(key_of_morph)
-	player_mind.active = 1
-	if(!xeno_spawn)
-		return find_morph()
-	var/mob/living/simple_animal/hostile/morph/S = new /mob/living/simple_animal/hostile/morph(pick(xeno_spawn))
-	player_mind.transfer_to(S)
-	player_mind.assigned_role = "Morph"
-	player_mind.special_role = "Morph"
-	ticker.mode.traitors |= player_mind
-	S << S.playstyle_string
-	S << 'sound/magic/Mutate.ogg'
-	message_admins("[key_of_morph] has been made into morph by an event.")
-	log_game("[key_of_morph] was spawned as a morph by an event.")
-	return 1
+		
+		if(!key_of_morph)
+			return kill()
+
+		var/datum/mind/player_mind = new /datum/mind(key_of_morph)
+		player_mind.active = 1
+		if(!xeno_spawn)
+			return kill()
+		var/mob/living/simple_animal/hostile/morph/S = new /mob/living/simple_animal/hostile/morph(pick(xeno_spawn))
+		player_mind.transfer_to(S)
+		player_mind.assigned_role = "Morph"
+		player_mind.special_role = "Morph"
+		ticker.mode.traitors |= player_mind
+		S << S.playstyle_string
+		S << 'sound/magic/Mutate.ogg'
+		message_admins("[key_of_morph] has been made into morph by an event.")
+		log_game("[key_of_morph] was spawned as a morph by an event.")
+		return 1
 
 /datum/event/spawn_morph/start()
 	get_morph()
-
-
-/datum/event/spawn_morph/proc/find_morph()
-	message_admins("Attempted to spawn a morph but there was no players available. Will try again momentarily.")
-	spawn(50)
-		if(get_morph(1))
-			message_admins("Situation has been resolved, [key_of_morph] has been spawned as a morph.")
-			log_game("[key_of_morph] was spawned as a morph by an event.")
-			return 0
-		message_admins("Unfortunately, no candidates were available for becoming a morph. Shutting down.")
-	return kill()

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -402,11 +402,10 @@
 	reforming = 0
 	spawn(600) //1 minutes
 		if(src && reforming)
-			return reform()
+			reform()
 		else
 			inert = 1
 			visible_message("<span class='warning'>[src] settles down and seems lifeless.</span>")
-			return
 
 /obj/item/weapon/ectoplasm/revenant/attack_self(mob/user)
 	if(!reforming || inert)
@@ -443,33 +442,33 @@
 				R.client = client_to_revive
 				key_of_revenant = client_to_revive.key
 
-	if(!key_of_revenant)
-		message_admins("The new revenant's old client either could not be found or is in a new, living mob - grabbing a random candidate instead...")
-		var/list/candidates = get_candidates(ROLE_REVENANT)
-		if(!candidates.len)
-			qdel(R)
-			message_admins("No candidates were found for the new revenant. Oh well!")
-			inert = 1
-			visible_message("<span class='revenwarning'>[src] settles down and seems lifeless.</span>")
-			return 0
-		var/client/C = pick(candidates)
-		key_of_revenant = C.key
+	spawn()
 		if(!key_of_revenant)
-			qdel(R)
-			message_admins("No ckey was found for the new revenant. Oh well!")
+			message_admins("The new revenant's old client either could not be found or is in a new, living mob - grabbing a random candidate instead...")
+			var/list/candidates = pollCandidates("Do you want to play as a revenant?", ROLE_REVENANT, 1)
+			if(!candidates.len)
+				qdel(R)
+				message_admins("No candidates were found for the new revenant. Oh well!")
+				inert = 1
+				visible_message("<span class='revenwarning'>[src] settles down and seems lifeless.</span>")
+				return
+			var/mob/C = pick(candidates)
+			key_of_revenant = C.key
+			if(!key_of_revenant)
+				qdel(R)
+				message_admins("No ckey was found for the new revenant. Oh well!")
+				inert = 1
+				visible_message("<span class='revenwarning'>[src] settles down and seems lifeless.</span>")
+				return
+		var/datum/mind/player_mind = new /datum/mind(key_of_revenant)
+		player_mind.active = 1
+		player_mind.transfer_to(R)
+		player_mind.assigned_role = "revenant"
+		player_mind.special_role = "Revenant"
+		ticker.mode.traitors |= player_mind
+		message_admins("[key_of_revenant] has been [client_to_revive ? "re":""]made into a revenant by reforming ectoplasm.")
+		log_game("[key_of_revenant] was [client_to_revive ? "re":""]made as a revenant by reforming ectoplasm.")
+		visible_message("<span class='revenboldnotice'>[src] suddenly rises into the air before fading away.</span>")
+		qdel(src)
+		if(src) //Should never happen, but just in case
 			inert = 1
-			visible_message("<span class='revenwarning'>[src] settles down and seems lifeless.</span>")
-			return 0
-	var/datum/mind/player_mind = new /datum/mind(key_of_revenant)
-	player_mind.active = 1
-	player_mind.transfer_to(R)
-	player_mind.assigned_role = "revenant"
-	player_mind.special_role = "Revenant"
-	ticker.mode.traitors |= player_mind
-	message_admins("[key_of_revenant] has been [client_to_revive ? "re":""]made into a revenant by reforming ectoplasm.")
-	log_game("[key_of_revenant] was [client_to_revive ? "re":""]made as a revenant by reforming ectoplasm.")
-	visible_message("<span class='revenboldnotice'>[src] suddenly rises into the air before fading away.</span>")
-	qdel(src)
-	if(src) //Should never happen, but just in case
-		inert = 1
-	return 1

--- a/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
@@ -11,57 +11,45 @@
 	if(deadMobs < REVENANT_SPAWN_THRESHOLD)
 		message_admins("Random event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
 		return
-	key_of_revenant = null
-	if(!key_of_revenant)
-		var/list/candidates = get_candidates(ROLE_REVENANT)
+
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to play as a revenant?", ROLE_REVENANT, 1)
 		if(!candidates.len)
-			if(end_if_fail)
-				return 0
-			return find_revenant()
-		var/client/C = pick(candidates)
+			key_of_revenant = null
+			return kill()
+		var/mob/C = pick(candidates)
 		key_of_revenant = C.key
-	if(!key_of_revenant)
-		if(end_if_fail)
-			return 0
-		return find_revenant()
-	var/datum/mind/player_mind = new /datum/mind(key_of_revenant)
-	player_mind.active = 1
-	var/list/spawn_locs = list()
-	for(var/obj/effect/landmark/L in landmarks_list)
-		if(isturf(L.loc))
-			switch(L.name)
-				if("revenantspawn")
-					spawn_locs += L.loc
-	if(!spawn_locs) //If we can't find any revenant spawns, try the carp spawns
+
+		if(!key_of_revenant)
+			return kill()
+
+		var/datum/mind/player_mind = new /datum/mind(key_of_revenant)
+		player_mind.active = 1
+		var/list/spawn_locs = list()
 		for(var/obj/effect/landmark/L in landmarks_list)
 			if(isturf(L.loc))
 				switch(L.name)
-					if("carpspawn")
+					if("revenantspawn")
 						spawn_locs += L.loc
-	if(!spawn_locs) //If we can't find either, just spawn the revenant at the player's location
-		spawn_locs += get_turf(player_mind.current)
-	if(!spawn_locs) //If we can't find THAT, then just retry
-		return find_revenant()
-	var/mob/living/simple_animal/revenant/revvie = new /mob/living/simple_animal/revenant/(pick(spawn_locs))
-	player_mind.transfer_to(revvie)
-	player_mind.assigned_role = "revenant"
-	player_mind.special_role = "Revenant"
-	ticker.mode.traitors |= player_mind
-	message_admins("[key_of_revenant] has been made into a revenant by an event.")
-	log_game("[key_of_revenant] was spawned as a revenant by an event.")
-	return 1
+		if(!spawn_locs) //If we can't find any revenant spawns, try the carp spawns
+			for(var/obj/effect/landmark/L in landmarks_list)
+				if(isturf(L.loc))
+					switch(L.name)
+						if("carpspawn")
+							spawn_locs += L.loc
+		if(!spawn_locs) //If we can't find either, just spawn the revenant at the player's location
+			spawn_locs += get_turf(player_mind.current)
+		if(!spawn_locs) //If we can't find THAT, then just retry
+			return kill()
+		var/mob/living/simple_animal/revenant/revvie = new /mob/living/simple_animal/revenant/(pick(spawn_locs))
+		player_mind.transfer_to(revvie)
+		player_mind.assigned_role = "revenant"
+		player_mind.special_role = "Revenant"
+		ticker.mode.traitors |= player_mind
+		message_admins("[key_of_revenant] has been made into a revenant by an event.")
+		log_game("[key_of_revenant] was spawned as a revenant by an event.")
+		return 1
 
 
 /datum/event/revenant/start()
 	get_revenant()
-
-
-/datum/event/revenant/proc/find_revenant()
-	message_admins("An event failed to spawn a revenant. Retrying momentarily...")
-	spawn(50)
-		if(get_revenant(1))
-			message_admins("[key_of_revenant] has been spawned as a revenant.")
-			log_game("[key_of_revenant] was spawned as a revenant by an event.")
-			return 0
-		message_admins("No candidates were available for becoming a revenant.")
-	return kill()

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -226,7 +226,7 @@
 	rev_mind.special_role = "Revolutionary"
 	update_rev_icons_added(rev_mind)
 	if(jobban_isbanned(rev_mind.current, ROLE_REV))
-		replace_jobbaned_player(rev_mind.current, ROLE_REV, ROLE_REV)
+		replace_jobbaned_player(rev_mind.current, ROLE_REV)
 	return 1
 //////////////////////////////////////////////////////////////////////////////
 //Deals with players being converted from the revolution (Not a rev anymore)//  // Modified to handle borged MMIs.  Accepts another var if the target is being borged at the time  -- Polymorph.

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -156,7 +156,7 @@ Made by Xhuis
 		new_thrall_mind.current << "<span class='shadowling'>Though not nearly as powerful as your masters, you possess some weak powers. These can be found in the Thrall Abilities tab.</span>"
 		new_thrall_mind.current << "<span class='shadowling'>You may communicate with your allies by speaking in the Shadowling Hivemind (:8).</span>"
 		if(jobban_isbanned(new_thrall_mind.current, ROLE_SHADOWLING))
-			replace_jobbaned_player(new_thrall_mind.current, ROLE_SHADOWLING, ROLE_SHADOWLING)
+			replace_jobbaned_player(new_thrall_mind.current, ROLE_SHADOWLING)
 
 		return 1
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -111,6 +111,7 @@
 	var/player_spiders = 0
 	var/faction = list()
 	var/master_commander = null
+	var/selecting_player = 0
 
 /obj/effect/spider/spiderling/New()
 	pixel_x = rand(6,-6)
@@ -197,15 +198,16 @@
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(src.loc)
 			S.faction = faction
 			S.master_commander = master_commander
-			if(player_spiders)
-				var/list/candidates = get_candidates(ROLE_ALIEN, ALIEN_AFK_BRACKET)
-				var/client/C = null
+			if(player_spiders && !selecting_player)
+				selecting_player = 1
+				spawn()
+					var/list/candidates = pollCandidates("Do you want to play as a spider?", ROLE_ALIEN, 1)
 
-				if(candidates.len)
-					C = pick(candidates)
-					S.key = C.key
-					if(master_commander)
-						S << "<span class='userdanger'>You are a spider who is loyal to [master_commander], obey [master_commander]'s every order and assist them in completing their goals at any cost.</span>"
+					if(candidates.len)
+						var/mob/C = pick(candidates)
+						S.key = C.key
+						if(master_commander)
+							S << "<span class='userdanger'>You are a spider who is loyal to [master_commander], obey [master_commander]'s every order and assist them in completing their goals at any cost.</span>"
 			qdel(src)
 
 /obj/effect/decal/cleanable/spiderling_remains

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -21,16 +21,17 @@
 			if(temp_vent.parent.other_atmosmch.len > 50)	//Stops Aliens getting stuck in small networks. See: Security, Virology
 				vents += temp_vent
 
-	var/list/candidates = get_candidates(ROLE_ALIEN,ALIEN_AFK_BRACKET)
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to play as an alien?", ROLE_ALIEN, 1)
 
-	while(spawncount > 0 && vents.len && candidates.len)
-		var/obj/vent = pick_n_take(vents)
-		var/client/C = pick_n_take(candidates)
-		if(C)
-			respawnable_list -= C
-			var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
-			new_xeno.key = C.key
+		while(spawncount > 0 && vents.len && candidates.len)
+			var/obj/vent = pick_n_take(vents)
+			var/mob/C = pick_n_take(candidates)
+			if(C)
+				respawnable_list -= C.client
+				var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
+				new_xeno.key = C.key
 
-			spawncount--
-			successSpawn = 1
+				spawncount--
+				successSpawn = 1
 

--- a/code/modules/events/slaughterevent.dm
+++ b/code/modules/events/slaughterevent.dm
@@ -2,56 +2,44 @@
 	var/key_of_slaughter
 
 /datum/event/spawn_slaughter/proc/get_slaughter(var/end_if_fail = 0)
-	key_of_slaughter = null
-	if(!key_of_slaughter)
-		var/list/candidates = get_candidates(ROLE_DEMON)
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to play as a slaughter demon?", ROLE_DEMON, 1)
 		if(!candidates.len)
-			if(end_if_fail)
-				return 0
-			return find_slaughter()
-		var/client/C = pick(candidates)
+			key_of_slaughter = null
+			return kill()
+		var/mob/C = pick(candidates)
 		key_of_slaughter = C.key
-	if(!key_of_slaughter)
-		if(end_if_fail)
-			return 0
-		return find_slaughter()
-	var/datum/mind/player_mind = new /datum/mind(key_of_slaughter)
-	player_mind.active = 1
-	var/list/spawn_locs = list()
-	for(var/obj/effect/landmark/L in landmarks_list)
-		if(isturf(L.loc))
-			switch(L.name)
-				if("revenantspawn")
-					spawn_locs += L.loc
-	if(!spawn_locs) //If we can't find any revenant spawns, try the carp spawns
+
+		if(!key_of_slaughter)
+			return kill()
+
+		var/datum/mind/player_mind = new /datum/mind(key_of_slaughter)
+		player_mind.active = 1
+		var/list/spawn_locs = list()
 		for(var/obj/effect/landmark/L in landmarks_list)
 			if(isturf(L.loc))
 				switch(L.name)
-					if("carpspawn")
+					if("revenantspawn")
 						spawn_locs += L.loc
-	if(!spawn_locs) //If we can't find either, just spawn the revenant at the player's location
-		spawn_locs += get_turf(player_mind.current)
-	if(!spawn_locs) //If we can't find THAT, then just retry
-		return find_slaughter()
-	var /obj/effect/dummy/slaughter/holder = new /obj/effect/dummy/slaughter(pick(spawn_locs))
-	var/mob/living/simple_animal/slaughter/S = new /mob/living/simple_animal/slaughter/(holder)
-	S.holder = holder
-	player_mind.transfer_to(S)
-	player_mind.assigned_role = "Slaughter Demon"
-	player_mind.special_role = "Slaughter Demon"
-	message_admins("[key_of_slaughter] has been made into a Slaughter Demon by an event.")
-	log_game("[key_of_slaughter] was spawned as a Slaughter Demon by an event.")
-	return 1
+		if(!spawn_locs) //If we can't find any revenant spawns, try the carp spawns
+			for(var/obj/effect/landmark/L in landmarks_list)
+				if(isturf(L.loc))
+					switch(L.name)
+						if("carpspawn")
+							spawn_locs += L.loc
+		if(!spawn_locs) //If we can't find either, just spawn the revenant at the player's location
+			spawn_locs += get_turf(player_mind.current)
+		if(!spawn_locs) //If we can't find THAT, then just retry
+			return kill()
+		var /obj/effect/dummy/slaughter/holder = new /obj/effect/dummy/slaughter(pick(spawn_locs))
+		var/mob/living/simple_animal/slaughter/S = new /mob/living/simple_animal/slaughter/(holder)
+		S.holder = holder
+		player_mind.transfer_to(S)
+		player_mind.assigned_role = "Slaughter Demon"
+		player_mind.special_role = "Slaughter Demon"
+		message_admins("[key_of_slaughter] has been made into a Slaughter Demon by an event.")
+		log_game("[key_of_slaughter] was spawned as a Slaughter Demon by an event.")
+		return 1
 
 /datum/event/spawn_slaughter/start()
 	get_slaughter()
-
-/datum/event/spawn_slaughter/proc/find_slaughter()
-	message_admins("Attempted to spawn a Slaughter Demon but there was no players available. Will try again momentarily.")
-	spawn(50)
-		if(get_slaughter(1))
-			message_admins("Situation has been resolved, [key_of_slaughter] has been spawned as a Slaughter Demon.")
-			log_game("[key_of_slaughter] was spawned as a Slaughter Demon by an event.")
-			return 0
-		message_admins("Unfortunately, no candidates were available for becoming a Slaugter Demon. Shutting down.")
-	kill()

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -1,14 +1,13 @@
 // This is to replace the previous datum/disease/alien_embryo for slightly improved handling and maintainability
 // It functions almost identically (see code/datums/diseases/alien_embryo.dm)
-var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 
 /obj/item/organ/internal/body_egg/alien_embryo
 	name = "alien embryo"
 	desc = "All slimy and yuck."
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
-	var/mob/living/affected_mob
 	var/stage = 0
+	var/growing = 0
 
 /obj/item/organ/internal/body_egg/alien_embryo/on_find(mob/living/finder)
 	..()
@@ -53,63 +52,55 @@ var/const/ALIEN_AFK_BRACKET = 450 // 45 seconds
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/internal/body_egg/alien_embryo/egg_process()
-	if(!affected_mob)	return
-	if(loc != affected_mob)
-		affected_mob.status_flags &= ~(XENO_HOST)
-		if(istype(affected_mob,/mob/living/carbon))
-			var/mob/living/carbon/H = affected_mob
-			H.med_hud_set_status()
-		processing_objects.Remove(src)
-		spawn(0)
-			RemoveInfectionImages(affected_mob)
-			affected_mob = null
-		return
-
 	if(stage < 5 && prob(3))
 		stage++
 		spawn(0)
 			RefreshInfectionImage()
 
-
 	if(stage == 5 && prob(50))
 		AttemptGrow()
 
 /obj/item/organ/internal/body_egg/alien_embryo/proc/AttemptGrow(var/gib_on_success = 1)
-	var/list/candidates = get_candidates(ROLE_ALIEN,ALIEN_AFK_BRACKET,1)
-	var/client/C = null
-
-	// To stop clientless larva, we will check that our host has a client
-	// if we find no ghosts to become the alien. If the host has a client
-	// he will become the alien but if he doesn't then we will set the stage
-	// to 2, so we don't do a process heavy check everytime.
-
-	if(candidates.len)
-		C = pick(candidates)
-	else if(affected_mob.client)
-		C = affected_mob.client
-	else
-		stage = 4 // Let's try again later.
+	if(growing)
 		return
+	growing = 1
 
-	if(affected_mob.lying)
-		affected_mob.overlays += image('icons/mob/alien.dmi', loc = affected_mob, icon_state = "burst_lie")
-	else
-		affected_mob.overlays += image('icons/mob/alien.dmi', loc = affected_mob, icon_state = "burst_stand")
-	spawn(6)
-		var/mob/living/carbon/alien/larva/new_xeno = new(affected_mob.loc)
-		new_xeno.key = C.key
-		if(ticker && ticker.mode)
-			ticker.mode.xenos += new_xeno.mind
-		new_xeno.mind.name = new_xeno.name
-		new_xeno.mind.assigned_role = "MODE"
-		new_xeno.mind.special_role = "Alien"
-		new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)	//To get the player's attention
-		if(gib_on_success)
-			affected_mob.gib()
-		if(istype(new_xeno.loc,/mob/living/carbon))
-			var/mob/living/carbon/digester = new_xeno.loc
-			digester.stomach_contents += new_xeno
-		qdel(src)
+	spawn()
+		var/list/candidates = pollCandidates("Do you want to play as an alien?", ROLE_ALIEN, 0)
+		var/mob/C = null
+
+		// To stop clientless larva, we will check that our host has a client
+		// if we find no ghosts to become the alien. If the host has a client
+		// he will become the alien but if he doesn't then we will set the stage
+		// to 2, so we don't do a process heavy check everytime.
+
+		if(candidates.len)
+			C = pick(candidates)
+		else if(owner.client)
+			C = owner
+		else
+			stage = 4 // Let's try again later.
+			return
+
+		if(owner.lying)
+			owner.overlays += image('icons/mob/alien.dmi', loc = owner, icon_state = "burst_lie")
+		else
+			owner.overlays += image('icons/mob/alien.dmi', loc = owner, icon_state = "burst_stand")
+		spawn(6)
+			var/mob/living/carbon/alien/larva/new_xeno = new(owner.loc)
+			new_xeno.key = C.key
+			if(ticker && ticker.mode)
+				ticker.mode.xenos += new_xeno.mind
+			new_xeno.mind.name = new_xeno.name
+			new_xeno.mind.assigned_role = "MODE"
+			new_xeno.mind.special_role = "Alien"
+			new_xeno << sound('sound/voice/hiss5.ogg',0,0,0,100)	//To get the player's attention
+			if(gib_on_success)
+				owner.gib()
+			if(istype(new_xeno.loc,/mob/living/carbon))
+				var/mob/living/carbon/digester = new_xeno.loc
+				digester.stomach_contents += new_xeno
+			qdel(src)
 
 /*----------------------------------------
 Proc: RefreshInfectionImage()
@@ -126,7 +117,7 @@ Des: Adds the infection image to all aliens for this embryo
 /obj/item/organ/internal/body_egg/alien_embryo/AddInfectionImages()
 	for(var/mob/living/carbon/alien/alien in player_list)
 		if(alien.client)
-			var/I = image('icons/mob/alien.dmi', loc = affected_mob, icon_state = "infected[stage]")
+			var/I = image('icons/mob/alien.dmi', loc = owner, icon_state = "infected[stage]")
 			alien.client.images += I
 
 /*----------------------------------------
@@ -137,5 +128,5 @@ Des: Removes all images from the mob infected by this embryo
 	for(var/mob/living/carbon/alien/alien in player_list)
 		if(alien.client)
 			for(var/image/I in alien.client.images)
-				if(dd_hasprefix_case(I.icon_state, "infected") && I.loc == affected_mob)
+				if(dd_hasprefix_case(I.icon_state, "infected") && I.loc == owner)
 					qdel(I)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1355,7 +1355,7 @@ var/list/robot_verbs_default = list(
 	if(isnull(ckey) && !searching_for_ckey)
 		searching_for_ckey = 1
 		user << "<span class='notice'>Now checking for possible borgs.</span>"
-		var/list/borg_candidates = pollCandidates("Do you want to play as a Nanotrasen Combat borg?", poll_time = 300)
+		var/list/borg_candidates = pollCandidates("Do you want to play as a Nanotrasen Combat borg?")
 		if(borg_candidates.len > 0 && isnull(ckey))
 			searching_for_ckey = 0
 			var/mob/M = pick(borg_candidates)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -215,39 +215,13 @@
 	user << "<span class='notice'>You offer the sentience potion to [M]...</span>"
 	being_used = 1
 
-	var/list/candidates = get_candidates(ROLE_SENTIENT, ALIEN_AFK_BRACKET)
-
-	shuffle(candidates)
-
-	var/time_passed = world.time
-	var/list/consenting_candidates = list()
-
-	for(var/candidate in candidates)
-
-		if(candidate in not_interested)
-			continue
-
-		spawn(0)
-			switch(alert(candidate, "Would you like to play as [M.name]? Please choose quickly!","Confirmation","Yes","No"))
-				if("Yes")
-					if((world.time-time_passed)>=50 || !src)
-						return
-					consenting_candidates += candidate
-				if("No")
-					if(!src)
-						return
-					not_interested += candidate
-
-	sleep(50)
+	var/list/candidates = pollCandidates("Do you want to play as [M.name]?", ROLE_SENTIENT, 0, 100)
 
 	if(!src)
 		return
 
-	listclearnulls(consenting_candidates) //some candidates might have left during sleep(50)
-
-	if(consenting_candidates.len)
-		var/client/C = null
-		C = pick(consenting_candidates)
+	if(candidates.len)
+		var/mob/C = pick(candidates)
 		M.key = C.key
 		M.universal_speak = 1
 		M.faction |= "sentient"


### PR DESCRIPTION
- Fixes #2306
- For:
 - Xenomorphs
 - Borers
 - Revenants
 - Wizard Apprentices (Contract & Multiverse Sword)
 - Blobs
 - Slaughter Demons
 - Morphs
 - Sentient Slimes
- This also fixes facehugger egg organs, because they were completely broken, possibly due to an oversight we forgot in #2903.

:cl:
tweak: Mid-round selection for various creatures and antagonists now consistently asks permission.
/:cl: