### PR TITLE
Fix space pod transitions

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -69,10 +69,8 @@
 
 /turf/space/Entered(atom/movable/A as mob|obj)
 	..()
-	if ((!(A) || !(src in A.locs)))
-		return
-
-	if(destination_z)
+	
+	if(destination_z && A && (src in A.locs))
 		A.x = destination_x
 		A.y = destination_y
 		A.z = destination_z

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -69,7 +69,7 @@
 
 /turf/space/Entered(atom/movable/A as mob|obj)
 	..()
-	if ((!(A) || src != A.loc))
+	if ((!(A) || !(src in A.locs)))
 		return
 
 	if(destination_z)


### PR DESCRIPTION
Fixes #2230

The issue was that when the spacepod entered a turf, the `loc` var was not set to the turf, so the turf rejected it.

:cl: monster860
bugfix: Space pod transitions are now fixed.
/:cl: