### PR TITLE
Fixes ragin mages ending after 1 mage

### DIFF
--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -33,7 +33,7 @@
 /datum/game_mode/wizard/raginmages/check_finished()
 	var/wizards_alive = 0
 	// Accidental pun!
-	var/wizard_cap = (max_mages || (num_players() / players_per_mage))
+	var/wizard_cap = (max_mages || (num_players_started() / players_per_mage))
 	for(var/datum/mind/wizard in wizards)
 		if(isnull(wizard.current))
 			continue


### PR DESCRIPTION
`num_players()` is for round setup (it only counts ready new_players) and `num_players_started()` returns what you actually expect. This is dumb but here we are.