### PR TITLE
yet more organ fixes

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -67,8 +67,8 @@
 
 		if(borer)
 			borer.detatch() //Should remove borer if the brain is removed - RR
-
-		B.transfer_identity(user)
+		if(owner.mind)//don't transfer if the owner does not have a mind.
+			B.transfer_identity(user)
 
 	if(istype(owner,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = owner

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -34,9 +34,10 @@
 
 	d/=sober_str
 
+	var/obj/item/organ/internal/liver/L
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/internal/liver/L = H.get_int_organ(/obj/item/organ/internal/liver)
+		L = H.get_int_organ(/obj/item/organ/internal/liver)
 		if(!L || (istype(L) && L.dna.species in list("Skrell", "Neara")))
 			d*=5
 
@@ -64,8 +65,7 @@
 		M.drowsyness = max(M.drowsyness, 30/sober_str)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if (H.get_int_organ(/obj/item/organ/internal/liver))
-				var/obj/item/organ/internal/liver/L = H.get_int_organ(/obj/item/organ/internal/liver)
+			if (L)
 				L.take_damage(0.1, 1)
 			H.adjustToxLoss(0.1)
 	..()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -15,7 +15,6 @@
 	possible_transfer_amounts = null //list(5,10,15)
 	volume = 15
 	w_class = 1
-	sharp = 0
 	var/mode = SYRINGE_DRAW
 
 	on_reagent_change()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -15,7 +15,7 @@
 	possible_transfer_amounts = null //list(5,10,15)
 	volume = 15
 	w_class = 1
-	sharp = 1
+	sharp = 0
 	var/mode = SYRINGE_DRAW
 
 	on_reagent_change()

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -155,7 +155,9 @@
 		if(!istype(I, /obj/item/organ))
 			IC = I
 			break
-	if(tool)
+	if(istype(tool,/obj/item/weapon/cautery))
+		user << "you prepare to close the cavity wall."
+	else if(tool)
 		user.visible_message("[user] starts putting \the [tool] inside [target]'s [get_cavity(affected)] cavity.", \
 		"You start putting \the [tool] inside [target]'s [get_cavity(affected)] cavity." )
 	else if(IC)
@@ -181,8 +183,9 @@
 		user << "<span class='warning'>[tool] is stuck to your hand, you can't put it in [target]!</span>"
 		return 0
 
-
-	if(tool)
+	if(istype(tool,/obj/item/weapon/cautery))
+		return 1//god this is ugly....
+	else if(tool)
 		if(IC)
 			user << "<span class='notice'>There seems to be something in there already!</span>"
 			return 1

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -170,16 +170,21 @@
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
 
 	if(istype(tool, /obj/item/weapon/disk/nuclear))
-		user << "Central command would kill you if you implanted the disk into someone."
+		user << "<span class='warning'>Central command would kill you if you implanted the disk into someone.</span>"
 		return 0//fail
 
 	if(istype(tool,/obj/item/organ))
-		user << "This isn't the type of surgery for that!"
+		user << "<span class='warning'>This isn't the type of surgery for organ transplants!</span>"
 		return 0//fail
+
+	if(!user.canUnEquip(tool, 0))
+		user << "<span class='warning'>[tool] is stuck to your hand, you can't put it in [target]!</span>"
+		return 0
+
 
 	if(tool)
 		if(IC)
-			user << "There seems to be something in there already!"
+			user << "<span class='notice'>There seems to be something in there already!</span>"
 			return 1
 		else
 			user.visible_message("<span class='notice'> [user] puts \the [tool] inside [target]'s [get_cavity(affected)] cavity.</span>", \

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -897,7 +897,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				O.forceMove(src)
 
 	// Grab all the internal giblets too.
-	for(var/obj/item/organ/organ in internal_organs)
+	for(var/obj/item/organ/internal/organ in internal_organs)
 		organ.remove()
 		organ.forceMove(src)
 

--- a/code/modules/surgery/organs/subtypes/standard.dm
+++ b/code/modules/surgery/organs/subtypes/standard.dm
@@ -111,6 +111,11 @@
 /obj/item/organ/external/hand/remove()
 	if(owner.gloves)
 		owner.unEquip(owner.gloves)
+	if(owner.l_hand)
+		owner.unEquip(owner.l_hand,1)
+	if(owner.r_hand)
+		owner.unEquip(owner.r_hand,1)
+
 	..()
 
 /obj/item/organ/external/hand/right

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -143,7 +143,6 @@
 				return -1
 
 	else if(implement_type in implements_mend)
-		//todo Change message, make it heal the organs...
 		current_type = "mend"
 		var/tool_name = "\the [tool]"
 		if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
@@ -163,11 +162,11 @@
 						spread_germs_to_organ(I, user)
 					user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 					"You start treating damage to [target]'s [I.name] with [tool_name]." )
-				else if(I.robotic > 2 && istype(tool, /obj/item/stack/nanopaste))
+				else if(I.robotic >= 2 && istype(tool, /obj/item/stack/nanopaste))
 					user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 					"You start treating damage to [target]'s [I.name] with [tool_name]." )
 
-			user << "No organs appear to be damaged."
+			user << "[I] does not appear to be damaged."
 		H.custom_pain("The pain in your [affected.name] is living hell!",1)
 
 	else if(istype(tool, /obj/item/weapon/reagent_containers/food/snacks/organ))
@@ -195,7 +194,7 @@
 					user.visible_message("<span class='notice'> [user] treats damage to [target]'s [I.name] with [tool_name].</span>", \
 					"<span class='notice'> You treat damage to [target]'s [I.name] with [tool_name].</span>" )
 					I.damage = 0
-				else if(I.robotic > 2 && istype (tool, /obj/item/stack/nanopaste))
+				else if(I.robotic >= 2 && istype (tool, /obj/item/stack/nanopaste))
 					user.visible_message("<span class='notice'> [user] treats damage to [target]'s [I.name] with [tool_name].</span>", \
 					"<span class='notice'> You treat damage to [target]'s [I.name] with [tool_name].</span>" )
 					I.damage = 0
@@ -205,6 +204,10 @@
 		user.drop_item()
 		I.insert(target)
 		spread_germs_to_organ(I, user)
+		if(!user.canUnEquip(I, 0))
+			user << "<span class='warning'>[I] is stuck to your hand, you can't put it in [target]!</span>"
+			return 0
+
 		if(affected)
 			user.visible_message("<span class='notice'> [user] has transplanted \the [tool] into [target]'s [affected.name].</span>", \
 			"<span class='notice'> You have transplanted \the [tool] into [target]'s [affected.name].</span>")

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -265,7 +265,7 @@
 	allowed_tools = list(/obj/item/device/mmi = 100)
 	var/implements_extract = list(/obj/item/device/multitool = 100)
 	var/implements_mend = list(	/obj/item/stack/nanopaste = 100,/obj/item/weapon/bonegel = 30, /obj/item/weapon/screwdriver = 70)
-	var/implements_insert = list(/obj/item/weapon/screwdriver = 100)
+	var/implements_insert = list(/obj/item/organ/internal = 100)
 	var/implements_finish =list(/obj/item/weapon/retractor = 100,/obj/item/weapon/crowbar = 100,/obj/item/weapon/kitchen/utensil = 50)
 	var/current_type
 	var/obj/item/organ/internal/I = null
@@ -285,13 +285,11 @@
 	affected = target.get_organ(target_zone)
 	if(implement_type in implements_insert)
 		current_type = "insert"
-		//I = tool
-		var/off_tool = user.get_inactive_hand()
+		var/obj/item/organ/internal/I = tool
 
-		if(!off_tool || !istype(off_tool,/obj/item/organ/internal))
-			user << "<span class='notice'>You need a replacement internal part in your off hand.</span>"
-			return -1
-		I = off_tool //and please god let it be an organ...
+		if(I.status != ORGAN_ROBOT || I.robotic != 2)
+			user << "<span class='notice'>You can only implant cybernetic organs.</span>"
+
 		if(target_zone != I.parent_organ || target.get_organ_slot(I.slot))
 			user << "<span class='notice'>There is no room for [I] in [target]'s [parse_zone(target_zone)]!</span>"
 			return -1
@@ -304,8 +302,8 @@
 			user << "<span class='warning'> \The [target] already has [I].</span>"
 			return -1
 
-		user.visible_message("[user] begins reattaching [target]'s [off_tool] with \the [tool].", \
-		"You start reattaching [target]'s [off_tool] with \the [tool].")
+		user.visible_message("[user] begins reattaching [target]'s [tool].", \
+		"You start reattaching [target]'s [tool].")
 		target.custom_pain("Someone's rooting around in your [affected.name]!",1)
 	else if(istype(tool,/obj/item/device/mmi))
 		current_type = "install"
@@ -407,18 +405,19 @@
 					"<span class='notice'> You repair [target]'s [I.name] with [tool].</span>" )
 					I.damage = 0
 	else if(current_type == "insert")
-		var/obj/item/organ/internal/I = target.get_int_organ(surgery.current_organ)
+		var/obj/item/organ/internal/I = tool
 
-		var/off_tool = user.get_inactive_hand()
-		I = off_tool
-		//user.drop_item()
+		if(!user.canUnEquip(I, 0))
+			user << "<span class='warning'>[I] is stuck to your hand, you can't put it in [target]!</span>"
+			return 0
+
+		user.drop_item()
 		I.insert(target)
-		user.visible_message("<span class='notice'> [user] has reattached [target]'s [I] with \the [tool].</span>" , \
-		"<span class='notice'> You have reattached [target]'s [I] with \the [tool].</span>")
+		user.visible_message("<span class='notice'> [user] has reattached [target]'s [I].</span>" , \
+		"<span class='notice'> You have reattached [target]'s [I].</span>")
 
 		if(I && istype(I))
 			I.status &= ~ORGAN_CUT_AWAY
-		qdel(off_tool)
 	else if (current_type == "install")
 		user.visible_message("<span class='notice'> [user] has installed \the [tool] into [target]'s [affected.name].</span>", \
 		"<span class='notice'> You have installed \the [tool] into [target]'s [affected.name].</span>")


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/3807 
Fixes https://github.com/ParadiseSS13/Paradise/issues/3803
Fixes https://github.com/ParadiseSS13/Paradise/issues/3799
Fixes https://github.com/ParadiseSS13/Paradise/issues/3796
Fixes https://github.com/ParadiseSS13/Paradise/issues/3799

:cl: Fethas
 tweak: Syringes are no longer sharp
 bugfix: byond likes direct pathing so item/organ/internal not item/organ even if it shouldn't be in the internal_organs list. This was preventing the list from doing stuff correctly.
 tweak: fixed ipc organ manipulation surgery, you can now insert a replacment ipc organ directly instead of needing a screwdriver in your main hand
 bugfix: nanopaste now will repair organs with robotic >= 2 instead of > 2 cuase i am an idiot
 bugfix: Fix, hopefully, for a runtime for clientless mobs whos head are cut off...
/:cl: