### PR TITLE
Removes Goebbles from the last name list

### DIFF
--- a/config/names/last.txt
+++ b/config/names/last.txt
@@ -502,7 +502,6 @@ Stamos
 Sagan
 Hawking
 Dawkins
-Goebbles
 McShain
 McDonohugh
 Power


### PR DESCRIPTION
As requested by @necaladun