### PR TITLE
Quieter Drowning

### DIFF
--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -100,11 +100,11 @@
 
 		if(drownee.stat) //Mob is in critical.
 			drownee.losebreath -= 3		//You're gonna die here.
-			add_logs(drownee, src, "drowned")
+			add_logs(drownee, src, "drowned", null, null, 0)	//log it to their VV, but don't spam the admins' chats with the logs
 			drownee.visible_message("<span class='danger'>\The [drownee] appears to be drowning!</span>","<span class='userdanger'>You're quickly drowning!</span>") //inform them that they are fucked.
 		else
 			drownee.losebreath -= 2		//For every time you drown, you miss 2 breath attempts. Hope you catch on quick!
-			add_logs(drownee, src, "drowned")
+			add_logs(drownee, src, "drowned", null, null, 0)	//log it to their VV, but don't spam the admins' chats with the logs
 			if(prob(35)) //35% chance to tell them what is going on. They should probably figure it out before then.
 				drownee.visible_message("<span class='danger'>\The [drownee] flails, almost like they are drowning!</span>","<span class='userdanger'>You're lacking air!</span>") //*gasp* *gasp* *gasp* *gasp* *gasp*
 


### PR DESCRIPTION
Doesn't spam the chat of online admins anymore, but still logs the drowning on the mob's attack_log variable.
- This could get REALLY intrusive with even one person drowning