### PR TITLE
Slime people can now regrow their limbs at a lower nutrition cost

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -453,8 +453,8 @@
 	set name = "Regrow Limbs"
 	set desc = "Regrow one of your missing limbs at the cost of a large amount of hunger"
 
-#define SLIMEPERSON_HUNGERCOST 125
-#define SLIMEPERSON_MINHUNGER 300
+#define SLIMEPERSON_HUNGERCOST 50
+#define SLIMEPERSON_MINHUNGER 250
 #define SLIMEPERSON_REGROWTHDELAY 450 // 45 seconds
 
 	if(stat || paralysis || stunned)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -188,7 +188,7 @@
 	desc = "This implant will synthesize and pump into your bloodstream a small amount of nutriment when you are hungry."
 	icon_state = "chest_implant"
 	implant_color = "#006607"
-	hunger_threshold = 250
+	hunger_threshold = 300
 	poison_amount = 10
 	origin_tech = "materials=5;programming=3;biotech=5"
 


### PR DESCRIPTION
This also enhances the nutrition pump to allow them to reach a level of satiation where they can regrow a limb, if nothing is stressing them.

Since you lose 10 nutrition a life tick while your blood is depleted, down to 300 nutrition, this should let you get off at least one limb regrowth in case of brutal trauma.
:cl:Crazylemon
tweak: Slime people can now regrow limbs on a more lax nutrition requirement
tweak: Enhances the nutripump+ to let slime people regrow limbs with it active
/:cl: