### PR TITLE
Makes doors not process unless controlled by an airlock controller

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -30,6 +30,9 @@
 	var/electrified_until = 0	// World time when the door is no longer electrified. -1 if it is permanently electrified until someone fixes it.
 	var/main_power_lost_until = 0	 //World time when main power is restored.
 	var/backup_power_lost_until = -1 //World time when backup power is restored.
+	var/electrified_timer = null
+	var/main_power_timer = null
+	var/backup_power_timer = null
 	var/spawnPowerRestoreRunning = 0
 	var/welded = null
 	var/locked = 0
@@ -208,30 +211,17 @@
 	desc = "And they said I was crazy."
 	icon = 'icons/obj/doors/Dooruranium.dmi'
 	mineral = "uranium"
-	var/last_event = 0
+	var/event_step = 20
 
-/obj/machinery/door/airlock/process()
-	// Deliberate no call to parent.
-	if(main_power_lost_until > 0 && world.time >= main_power_lost_until)
-		regainMainPower()
-
-	if(backup_power_lost_until > 0 && world.time >= backup_power_lost_until)
-		regainBackupPower()
-
-	else if(electrified_until > 0 && world.time >= electrified_until)
-		electrify(0)
-
-/obj/machinery/door/airlock/uranium/process()
-	if(world.time > last_event+20)
-		if(prob(50))
-			radiate()
-		last_event = world.time
+/obj/machinery/door/airlock/uranium/New()
 	..()
+	addtimer(src, "radiate", event_step)
 
 /obj/machinery/door/airlock/uranium/proc/radiate()
-	for(var/mob/living/L in range (3,src))
-		L.apply_effect(15,IRRADIATE,0)
-	return
+	if(prob(50))
+		for(var/mob/living/L in range (3,src))
+			L.apply_effect(15,IRRADIATE,0)
+	addtimer(src, "radiate", event_step)
 
 /obj/machinery/door/airlock/plasma
 	name = "plasma airlock"
@@ -338,6 +328,15 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/Destroy()
 	qdel(wires)
 	wires = null
+	if(main_power_timer)
+		deltimer(main_power_timer)
+		main_power_timer = null
+	if(backup_power_timer)
+		deltimer(backup_power_timer)
+		backup_power_timer = null
+	if(electrified_timer)
+		deltimer(electrified_timer)
+		electrified_timer = null
 	return ..()
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user as mob) //Airlocks now zap you when you 'bump' them open when they're electrified. --NeoFite
@@ -399,10 +398,13 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/proc/loseMainPower()
 	main_power_lost_until = mainPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
+	if(main_power_lost_until > 0)
+		main_power_timer = addtimer(src, "regainMainPower", SecondsToTicks(60), 1)
 
 	// If backup power is permanently disabled then activate in 10 seconds if possible, otherwise it's already enabled or a timer is already running
 	if(backup_power_lost_until == -1 && !backupPowerCablesCut())
 		backup_power_lost_until = world.time + SecondsToTicks(10)
+		backup_power_timer = addtimer(src, "regainBackupPower", SecondsToTicks(10), 1)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
@@ -410,12 +412,16 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/proc/loseBackupPower()
 	backup_power_lost_until = backupPowerCablesCut() ? -1 : world.time + SecondsToTicks(60)
+	if(backup_power_lost_until > 0)
+		backup_power_timer = addtimer(src, "regainBackupPower", SecondsToTicks(60), 1)
 
 	// Disable electricity if required
 	if(electrified_until && isAllPowerLoss())
 		electrify(0)
 
 /obj/machinery/door/airlock/proc/regainMainPower()
+	main_power_timer = null
+
 	if(!mainPowerCablesCut())
 		main_power_lost_until = 0
 		// If backup power is currently active then disable, otherwise let it count down and disable itself later
@@ -424,22 +430,28 @@ About the new airlock wires panel:
 		update_icon()
 
 /obj/machinery/door/airlock/proc/regainBackupPower()
+	backup_power_timer = null
+
 	if(!backupPowerCablesCut())
 		// Restore backup power only if main power is offline, otherwise permanently disable
 		backup_power_lost_until = main_power_lost_until == 0 ? -1 : 0
 		update_icon()
 
 /obj/machinery/door/airlock/proc/electrify(var/duration, var/feedback = 0)
+	if(electrified_timer)
+		deltimer(electrified_timer)
+		electrified_timer = null
+	
 	var/message = ""
-	if(src.isWireCut(AIRLOCK_WIRE_ELECTRIFY) && arePowerSystemsOn())
+	if(isWireCut(AIRLOCK_WIRE_ELECTRIFY) && arePowerSystemsOn())
 		message = text("The electrification wire is cut - Door permanently electrified.")
-		src.electrified_until = -1
+		electrified_until = -1
 	else if(duration && !arePowerSystemsOn())
 		message = text("The door is unpowered - Cannot electrify the door.")
-		src.electrified_until = 0
+		electrified_until = 0
 	else if(!duration && electrified_until != 0)
 		message = "The door is now un-electrified."
-		src.electrified_until = 0
+		electrified_until = 0
 	else if(duration)	//electrify door for the given duration seconds
 		if(usr)
 			shockedby += text("\[[time_stamp()]\] - [usr](ckey:[usr.ckey])")
@@ -447,7 +459,8 @@ About the new airlock wires panel:
 		else
 			shockedby += text("\[[time_stamp()]\] - EMP)")
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
-		src.electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
+		electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
+		electrified_timer = addtimer(src, "electrify", SecondsToTicks(duration), 1, 0)
 
 	if(feedback && message)
 		usr << message
@@ -686,23 +699,23 @@ About the new airlock wires panel:
 				usr << text("The electrification wire is cut - Door permanently electrified.")
 			else if(!activate && electrified_until != 0)
 				usr << "The door is now un-electrified."
-				src.electrified_until = 0
+				electrify(0)
 			else if(activate)	//electrify door for 30 seconds
 				shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
 				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Electrified the [name] at [x] [y] [z]</font>")
 				usr << "The door is now electrified for thirty seconds."
-				src.electrified_until = world.time + SecondsToTicks(30)
+				electrify(30)
 		if("electrify_permanently")
 			if(src.isWireCut(AIRLOCK_WIRE_ELECTRIFY))
 				usr << text("The electrification wire is cut - Cannot electrify the door.")
 			else if(!activate && electrified_until != 0)
 				usr << "The door is now un-electrified."
-				src.electrified_until = 0
+				electrify(0)
 			else if(activate)
 				shockedby += text("\[[time_stamp()]\][usr](ckey:[usr.ckey])")
 				usr.attack_log += text("\[[time_stamp()]\] <font color='red'>Electrified the [name] at [x] [y] [z]</font>")
 				usr << "The door is now electrified."
-				electrified_until = -1
+				electrify(-1)
 		if("open")
 			if(src.welded)
 				usr << text("The airlock has been welded shut!")

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -9,10 +9,11 @@ obj/machinery/door/airlock
 	var/cur_command = null	//the command the door is currently attempting to complete
 
 obj/machinery/door/airlock/process()
-	..()
-	if (arePowerSystemsOn())
+	if(arePowerSystemsOn() && cur_command)
 		spawn()
 			execute_current_command()
+	else
+		return PROCESS_KILL
 
 obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 	if (!arePowerSystemsOn()) return //no power
@@ -33,8 +34,11 @@ obj/machinery/door/airlock/proc/execute_current_command()
 		return
 
 	do_command(cur_command)
-	if (command_completed(cur_command))
+	if(command_completed(cur_command))
 		cur_command = null
+	else
+		if(!(src in machines))
+			addAtProcessing()
 
 obj/machinery/door/airlock/proc/do_command(var/command)
 	switch(command)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -65,7 +65,6 @@
 // if it's less than 0, open door, reset timer
 // update the door_timer window and the icon
 /obj/machinery/door_timer/process()
-
 	if(stat & (NOPOWER|BROKEN))	return
 	if(timing)
 
@@ -73,22 +72,20 @@
 		// (no seriously there's gotta be a better way to do this)
 		var/timeleft = timeleft()
 		if(timeleft > 1e5)
-			src.releasetime = 0
+			releasetime = 0
 
 
-		if(world.timeofday > src.releasetime)
-			Radio.autosay("Timer has expired. Releasing prisoner.", src.name, "Security", list(src.z))
+		if(world.timeofday > releasetime)
+			Radio.autosay("Timer has expired. Releasing prisoner.", name, "Security", list(z))
 			timer_end() // open doors, reset timer, clear status screen
 			timing = 0
+			. = PROCESS_KILL
 
 		src.updateUsrDialog()
 		src.update_icon()
-
 	else
 		timer_end()
-
-	return
-
+		return PROCESS_KILL
 
 // has the door power situation changed, if so update icon.
 /obj/machinery/door_timer/power_change()
@@ -106,6 +103,8 @@
 
 	// Set releasetime
 	releasetime = world.timeofday + timetoset
+	if(!(src in machines))
+		addAtProcessing()
 
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
 		if(door.density)	continue

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -142,7 +142,7 @@ FIRE ALARM
 			alarm()
 			time = 0
 			timing = 0
-			processing_objects.Remove(src)
+			processing_objects -= src
 		updateDialog()
 	last_process = world.timeofday
 
@@ -244,9 +244,14 @@ FIRE ALARM
 	else if(href_list["alarm"])
 		alarm()
 	else if(href_list["time"])
+		var/oldTiming = timing
 		timing = text2num(href_list["time"])
 		last_process = world.timeofday
-		processing_objects.Add(src)
+		if(oldTiming != timing)
+			if(timing)
+				processing_objects += src
+			else
+				processing_objects -= src
 	else if(href_list["tp"])
 		var/tp = text2num(href_list["tp"])
 		time += tp


### PR DESCRIPTION
- This removes 800 or so objects from the machine process list.
 - They temporarily are re-added if they're on an airlock controller, and somebody is in the way of the door, then removed again when it's finally able to close.
- Security door timers also only process while ticking now.
- Also fixes a `processing_objects` leak in the fire alarm where if you clicked Stop, it would just add itself again to the list and only the last addition to the list would ever get removed.