### PR TITLE
Fixes fixing cameras

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -249,11 +249,6 @@
 	return
 
 /obj/machinery/camera/proc/deactivate(user as mob, var/choice = 1)
-	if(can_use())
-		cameranet.addCamera(src)
-	else
-		set_light(0)
-		cameranet.removeCamera(src)
 	if(choice==1)
 		invalidateCameraCache()
 		status = !( src.status )
@@ -274,6 +269,12 @@
 				visible_message("<span class='danger'>\The [src] reactivates!</span>")
 			playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
 			icon_state = initial(icon_state)
+
+	if(can_use())
+		cameranet.addCamera(src)
+	else
+		set_light(0)
+		cameranet.removeCamera(src)
 
 	// now disconnect anyone using the camera
 	//Apparently, this will disconnect anyone even if the camera was re-activated.


### PR DESCRIPTION
fixes #3846
This actually affected mending/breaking any camera, not just the
roundstart broken ones.
The check for whether a camera should be added/removed from the network
was being done before the status of the camera (whether it works or not)
was changed