### PR TITLE
Fixes "talks but you cannot hear them" message

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -67,7 +67,7 @@
 			if(speaker == src)
 				src << "<span class='warning'>You cannot hear yourself speak!</span>"
 			else
-				src << "<span class='name'>[speaker_name]</span>[alt_name] talks but you cannot hear \him."
+				src << "<span class='name'>[speaker_name]</span>[alt_name] talks but you cannot hear them."
 	else
 		if(language)
 			src << "<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][language.format_message(message, verb)]</span>"


### PR DESCRIPTION
It was rendering as "__X__ talks but you cannot hear ." because there's no way for `\him` to work in that context, since there's no atom reference anywhere.