### PR TITLE
Fix Eye Augment EMP

### DIFF
--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -59,14 +59,8 @@
 	if(severity > 1)
 		if(prob(10 * severity))
 			return
-	var/save_sight = owner.sight
-	owner.sight &= 0
-	owner.sdisabilities |= BLIND
 	owner << "<span class='warning'>Static obfuscates your vision!</span>"
-	spawn(60 / severity)
-		if(owner)
-			owner.sight |= save_sight
-			owner.sdisabilities ^= BLIND
+	flick("e_flash", owner.flash)
 
 
 


### PR DESCRIPTION
Fixes eye implants permanently blinding you.

Simply put, if you get EMP'd while still under the effects of a previous EMP, you will be permanently blind.

use flicking flash effectively does the same thing and is what TG decided to go with.

:cl: Fox McCloud
bugfix: Fixes EMPs causing eye implant users to be permanently blind
/:cl: