### PR TITLE
Bag of Holding Tweak

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -33,8 +33,8 @@
 	desc = "A backpack that opens into a localized pocket of Blue Space."
 	origin_tech = "bluespace=4"
 	icon_state = "holdingpack"
-	max_w_class = 4
-	max_combined_w_class = 28
+	max_w_class = 5
+	max_combined_w_class = 35
 
 	New()
 		..()


### PR DESCRIPTION
From TG

- Buffs the Bag of Holding's max weight class from 4 to 5
- Buffs the max combined weight class from 28 to 35 (default backpack is 21)

:cl: Fox McCloud
tweak: Increases bag of holding's storage capacity
/:cl: