### PR TITLE
Heart Tweaks

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -96,7 +96,7 @@
 	new /obj/effect/decal/cleanable/blood(loc)
 	new /obj/effect/gibspawner/generic(get_turf(src))
 	new /obj/effect/gibspawner/generic(get_turf(src))
-	new /obj/item/organ/internal/heart/demonheart(loc)
+	new /obj/item/organ/internal/heart/demon(loc)
 	playsound(get_turf(src),'sound/misc/demon_dies.ogg', 200, 1)
 	visible_message("<span class='danger'>[src] screams in anger as it collapses into a puddle of viscera, its most recent meals spilling out of it.</span>")
 	for(var/mob/living/M in consumed_mobs)
@@ -141,7 +141,7 @@
 //////////The Loot
 
 //The loot from killing a slaughter demon - can be consumed to allow the user to blood crawl
-/obj/item/organ/internal/heart/demonheart
+/obj/item/organ/internal/heart/demon
 	name = "demon heart"
 	desc = "Still it beats furiously, emanating an aura of utter hate."
 	icon = 'icons/obj/surgery.dmi'
@@ -151,7 +151,10 @@
 /obj/item/organ/internal/heart/demon/update_icon()
 	return //always beating visually
 
-/obj/item/organ/internal/heart/demonheart/attack_self(mob/living/user)
+/obj/item/organ/internal/heart/demon/prepare_eat()
+	return // Just so people don't accidentally waste it
+
+/obj/item/organ/internal/heart/demon/attack_self(mob/living/user)
 	user.visible_message("<span class='warning'>[user] raises [src] to their mouth and tears into it with their teeth!</span>", \
 						 "<span class='danger'>An unnatural hunger consumes you. You raise [src] to your mouth and devour it!</span>")
 	playsound(user, 'sound/misc/Demon_consume.ogg', 50, 1)
@@ -178,11 +181,14 @@
 	if(M.mind)
 		M.mind.AddSpell(new /obj/effect/proc_holder/spell/bloodcrawl(null))
 
-/obj/item/organ/internal/heart/demonheart/remove(mob/living/carbon/M, special = 0)
+/obj/item/organ/internal/heart/demon/remove(mob/living/carbon/M, special = 0)
 	..()
 	if(M.mind)
 		M.bloodcrawl = 0
 		M.mind.remove_spell(/obj/effect/proc_holder/spell/bloodcrawl)
+
+/obj/item/organ/internal/heart/demon/Stop()
+	return 0 // Always beating.
 
 //Objectives and helpers.
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -242,7 +242,7 @@ REAGENT SCANNER
 				user.show_message("\red <b>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl")
 			else
 				user.show_message("\blue Blood Level Normal: [blood_percent]% [blood_volume]cl")
-		if(H.heart_attack)
+		if(H.heart_attack && H.stat != DEAD)
 			user.show_message("<span class='userdanger'>Subject suffering from heart attack: Apply defibrillator immediately.</span>")
 		user.show_message("\blue Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font>")
 		var/implant_detect

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -122,31 +122,64 @@
 
 
 // Brain is defined in brain_item.dm.
+
 /obj/item/organ/internal/heart
 	name = "heart"
 	icon_state = "heart-on"
 	organ_tag = "heart"
 	parent_organ = "chest"
+	slot = "heart"
+	origin_tech = "biotech=3"
+	var/beating = 1
 	dead_icon = "heart-off"
-	vital = 1
-	var/beating = 0
+	var/icon_base = "heart"
 
 /obj/item/organ/internal/heart/update_icon()
 	if(beating)
-		icon_state = "heart-on"
+		icon_state = "[icon_base]-on"
 	else
-		icon_state = "heart-off"
-
-/obj/item/organ/internal/heart/insert(mob/living/carbon/M, special = 0)
-	..()
-	beating = 1
-	update_icon()
+		icon_state = "[icon_base]-off"
 
 /obj/item/organ/internal/heart/remove(mob/living/carbon/M, special = 0)
 	..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.stat == DEAD || H.heart_attack)
+			Stop()
+			return
+		if(!special)
+			H.heart_attack = 1
+
 	spawn(120)
-		beating = 0
-		update_icon()
+		if(!owner)
+			Stop()
+
+/obj/item/organ/internal/heart/attack_self(mob/user)
+	..()
+	if(!beating)
+		Restart()
+		spawn(80)
+			if(!owner)
+				Stop()
+
+
+/obj/item/organ/internal/heart/insert(mob/living/carbon/M, special = 0)
+	..()
+	if(ishuman(M) && beating)
+		var/mob/living/carbon/human/H = M
+		if(H.heart_attack)
+			H.heart_attack = 0
+			return
+
+/obj/item/organ/internal/heart/proc/Stop()
+	beating = 0
+	update_icon()
+	return 1
+
+/obj/item/organ/internal/heart/proc/Restart()
+	beating = 1
+	update_icon()
+	return 1
 
 /obj/item/organ/internal/heart/prepare_eat()
 	var/obj/S = ..()


### PR DESCRIPTION
a partial port of: https://github.com/tgstation/-tg-station/pull/15707

- Hearts are no longer vital organs and can be removed without instantly killing people
- Instead of killing people instantly, when a heart is removed, it will now induce a heart attack

Basically, you can remove someone's heart and keep them in a stable state using chems while you transplant a new heart into them; if we ever want to add in robotic hearts or heart transplants or other such things, now it's possible

Tips for heart transplants:
- After you yank a heart out, it will continue to beat for 12 seconds
- When inserting a new heart, it must be beating for it to ensure people don't continue to take damage
 - Using the heart in your hands will temporarily make it beat again
 - Alternatively, you can just shove in the non-beating heart and apply a defib

Fixes
- Fixes heart not having a slot
- Fixes demon hearts not working
- Tweaks it so you can't actually eat a demon heart (so you don't accidentally waste it)

:cl: Fox McCloud
rscadd: Removing a heart no longer kills the patient instantly, but induces a heart attack
bugfix: Demon hearts will not work
bugfix: Should now actually be able to re-insert hearts
/:cl: