### PR TITLE
Addiction Rework

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -1,3 +1,5 @@
+#define ADDICTION_SPEEDUP_TIME 1500 // 2.5 minutes
+
 /////////////////////////////////////////
 // SLEEPER CONSOLE
 /////////////////////////////////////////
@@ -340,7 +342,19 @@
 				for(var/datum/reagent/x in src.occupant.reagents.reagent_list)
 					src.occupant.reagents.trans_to(beaker, 3)
 					src.occupant.vessel.trans_to(beaker, 1)
-	src.updateDialog()
+
+	if(occupant)
+		for(var/A in occupant.reagents.addiction_list)
+			var/datum/reagent/R = A
+
+			var/addiction_removal_chance = 5
+			if(world.timeofday > (R.last_addiction_dose + ADDICTION_SPEEDUP_TIME)) // 2.5 minutes
+				addiction_removal_chance = 10
+			if(prob(addiction_removal_chance))
+				occupant << "<span class='notice'>You no longer feel reliant on [R.name]!</span>"
+				occupant.reagents.addiction_list.Remove(R)
+
+	updateDialog()
 	return
 
 
@@ -643,3 +657,5 @@
 		src.add_fingerprint(usr)
 		return
 	return
+
+#undef ADDICTION_SPEEDUP_TIME

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -105,7 +105,7 @@ REAGENT SCANNER
 			if(H.reagents.addiction_list.len)
 				user.show_message("<span class='danger'>Subject is addicted to the following reagents:</span>")
 				for(var/datum/reagent/R in H.reagents.addiction_list)
-					user.show_message("<span class='danger'>[R.name]</span>")
+					user.show_message("<span class='danger'>[R.name] Stage: [R.addiction_stage]/5</span>")
 			else
 				user.show_message("<span class='notice'>Subject is not addicted to any reagents.</span>")
 

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -174,8 +174,6 @@ LIGHTERS ARE IN LIGHTERS.DM
 	if(reagents && reagents.total_volume)	//	check if it has any reagents at all
 		if(is_being_smoked) // if it's being smoked, transfer reagents to the mob
 			var/mob/living/carbon/C = loc
-			if(prob(15)) // so it's not an instarape in case of acid
-				reagents.reaction(C, INGEST)
 			reagents.trans_to(C, REAGENTS_METABOLISM)
 			if(!reagents.total_volume) // There were reagents, but now they're gone
 				C << "<span class='notice'>Your [name] loses its flavor.</span>"

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -11,7 +11,7 @@
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 35
-	addiction_threshold = 30
+	addiction_chance = 70
 
 /datum/reagent/nicotine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
@@ -39,7 +39,7 @@
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 20
-	addiction_threshold = 10
+	addiction_chance = 50
 
 /datum/reagent/crank/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
@@ -69,24 +69,6 @@
 	..()
 	return
 
-/datum/reagent/crank/addiction_act_stage1(var/mob/living/M as mob)
-	M.adjustBrainLoss(rand(1,10)*REM)
-	..()
-	return
-/datum/reagent/crank/addiction_act_stage2(var/mob/living/M as mob)
-	M.adjustToxLoss(rand(1,10)*REM)
-	..()
-	return
-/datum/reagent/crank/addiction_act_stage3(var/mob/living/M as mob)
-	M.adjustBruteLoss(rand(1,10)*REM)
-	..()
-	return
-/datum/reagent/crank/addiction_act_stage4(var/mob/living/M as mob)
-	M.adjustBrainLoss(rand(1,10)*REM)
-	M.adjustToxLoss(rand(1,10)*REM)
-	M.adjustBruteLoss(rand(1,10)*REM)
-	..()
-	return
 /datum/chemical_reaction/crank
 	name = "Crank"
 	id = "crank"
@@ -111,7 +93,7 @@
 	reagent_state = LIQUID
 	color = "#0264B4"
 	overdose_threshold = 20
-	addiction_threshold = 15
+	addiction_chance = 50
 
 
 /datum/reagent/krokodil/on_mob_life(var/mob/living/M as mob)
@@ -145,30 +127,6 @@
 	..()
 	return
 
-
-/datum/reagent/krokodil/addiction_act_stage1(var/mob/living/M as mob)
-	M.adjustBrainLoss(rand(1,5)*REM)
-	M.adjustToxLoss(rand(1,5)*REM)
-	..()
-	return
-/datum/reagent/krokodil/addiction_act_stage2(var/mob/living/M as mob)
-	if(prob(25))
-		M << "<span class='danger'>Your skin feels loose...</span>"
-	..()
-	return
-/datum/reagent/krokodil/addiction_act_stage3(var/mob/living/M as mob)
-	if(prob(25))
-		M << "<span class='danger'>Your skin starts to peel away...</span>"
-	M.adjustBruteLoss(3*REM)
-	..()
-	return
-
-/datum/reagent/krokodil/addiction_act_stage4(var/mob/living/carbon/human/M as mob)
-	if(prob(25))
-		M << "<span class='userdanger'>Your skin falls off easily!</span>"
-	M.adjustBruteLoss(5*REM)
-	..()
-	return
 /datum/chemical_reaction/krokodil
 	name = "Krokodil"
 	id = "krokodil"
@@ -186,12 +144,12 @@
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 20
-	addiction_threshold = 10
+	addiction_chance = 60
 	metabolization_rate = 0.6
 
 /datum/reagent/methamphetamine/meth2 //for donk pockets
 	id = "methamphetamine2"
-	addiction_threshold = 20
+	addiction_chance = 0
 
 /datum/reagent/methamphetamine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
@@ -223,35 +181,6 @@
 	if(prob(50))
 		M.adjustToxLoss(10)
 	M.adjustBrainLoss(pick(0.5, 0.6, 0.7, 0.8, 0.9, 1))
-	return
-
-/datum/reagent/methamphetamine/addiction_act_stage1(var/mob/living/M as mob)
-	M.Jitter(5)
-	if(prob(20))
-		M.emote(pick("twitch","drool","moan"))
-	..()
-	return
-/datum/reagent/methamphetamine/addiction_act_stage2(var/mob/living/M as mob)
-	M.Jitter(10)
-	M.Dizzy(10)
-	if(prob(30))
-		M.emote(pick("twitch","drool","moan"))
-	..()
-	return
-/datum/reagent/methamphetamine/addiction_act_stage3(var/mob/living/M as mob)
-	M.Jitter(15)
-	M.Dizzy(15)
-	if(prob(40))
-		M.emote(pick("twitch","drool","moan"))
-	..()
-	return
-/datum/reagent/methamphetamine/addiction_act_stage4(var/mob/living/carbon/human/M as mob)
-	M.Jitter(20)
-	M.Dizzy(20)
-	M.adjustToxLoss(5)
-	if(prob(50))
-		M.emote(pick("twitch","drool","moan"))
-	..()
 	return
 
 /datum/chemical_reaction/methamphetamine
@@ -294,7 +223,7 @@
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
 	overdose_threshold = 20
-	addiction_threshold = 10
+	addiction_chance = 80
 	metabolization_rate = 0.6
 
 
@@ -337,55 +266,6 @@
 		var/obj/item/I = M.get_active_hand()
 		if(I)
 			M.drop_item()
-	..()
-	return
-
-/datum/reagent/bath_salts/addiction_act_stage1(var/mob/living/M as mob)
-	M.hallucination += 10
-	if(M.canmove && !istype(M.loc, /turf/space))
-		for(var/i = 0, i < 8, i++)
-			step(M, pick(cardinal))
-	M.Jitter(5)
-	M.adjustBrainLoss(10)
-	if(prob(20))
-		M.emote(pick("twitch","drool","moan"))
-	..()
-	return
-/datum/reagent/bath_salts/addiction_act_stage2(var/mob/living/M as mob)
-	M.hallucination += 20
-	if(M.canmove && !istype(M.loc, /turf/space))
-		for(var/i = 0, i < 8, i++)
-			step(M, pick(cardinal))
-	M.Jitter(10)
-	M.Dizzy(10)
-	M.adjustBrainLoss(10)
-	if(prob(30))
-		M.emote(pick("twitch","drool","moan"))
-	..()
-	return
-/datum/reagent/bath_salts/addiction_act_stage3(var/mob/living/M as mob)
-	M.hallucination += 30
-	if(M.canmove && !istype(M.loc, /turf/space))
-		for(var/i = 0, i < 12, i++)
-			step(M, pick(cardinal))
-	M.Jitter(15)
-	M.Dizzy(15)
-	M.adjustBrainLoss(10)
-	if(prob(40))
-		M.emote(pick("twitch","drool","moan"))
-	..()
-	return
-/datum/reagent/bath_salts/addiction_act_stage4(var/mob/living/carbon/human/M as mob)
-	M.hallucination += 40
-	if(M.canmove && !istype(M.loc, /turf/space))
-		for(var/i = 0, i < 16, i++)
-			step(M, pick(cardinal))
-	M.Jitter(50)
-	M.Dizzy(50)
-	M.adjustToxLoss(5)
-	M.adjustBrainLoss(10)
-	if(prob(50))
-		M.emote(pick("twitch","drool","moan"))
 	..()
 	return
 
@@ -453,6 +333,7 @@
 	metabolization_rate = 0.2
 	overdose_threshold = 15
 	process_flags = ORGANIC | SYNTHETIC		//Flipping for everyone!
+	addiction_chance = 10
 
 /datum/chemical_reaction/fliptonium
 	name = "fliptonium"
@@ -532,7 +413,7 @@
 
 	process_flags = SYNTHETIC
 	overdose_threshold = 20
-	addiction_threshold = 10
+	addiction_chance = 60
 	metabolization_rate = 0.6
 
 /datum/chemical_reaction/lube/ultra
@@ -577,38 +458,6 @@
 	M.adjustBrainLoss(pick(0.5, 0.6, 0.7, 0.8, 0.9, 1))
 	return
 
-/datum/reagent/lube/ultra/addiction_act_stage1(var/mob/living/M as mob)
-	M.Jitter(5)
-	if(prob(20))
-		M.emote(pick("twitch","buzz","moan"))
-	..()
-	return
-
-/datum/reagent/lube/ultra/addiction_act_stage2(var/mob/living/M as mob)
-	M.Jitter(10)
-	M.Dizzy(10)
-	if(prob(30))
-		M.emote(pick("twitch","buzz","moan"))
-	..()
-	return
-
-/datum/reagent/lube/ultra/addiction_act_stage3(var/mob/living/M as mob)
-	M.Jitter(15)
-	M.Dizzy(15)
-	if(prob(40))
-		M.emote(pick("twitch","buzz","moan"))
-	..()
-	return
-
-/datum/reagent/lube/ultra/addiction_act_stage4(var/mob/living/carbon/human/M as mob)
-	M.Jitter(20)
-	M.Dizzy(20)
-	M.adjustBrainLoss(2)
-	if(prob(50))
-		M.emote(pick("twitch","buzz","moan"))
-	..()
-	return
-
 //Surge: Krokodil
 /datum/reagent/surge
 	name = "Surge"
@@ -619,7 +468,7 @@
 
 	process_flags = SYNTHETIC
 	overdose_threshold = 20
-	addiction_threshold = 15
+	addiction_chance = 50
 
 
 /datum/reagent/surge/on_mob_life(var/mob/living/M as mob)
@@ -652,30 +501,6 @@
 		B.icon = I
 		M.adjustFireLoss(rand(1,5)*REM)
 		M.adjustBruteLoss(rand(1,5)*REM)
-	..()
-	return
-
-/datum/reagent/surge/addiction_act_stage1(var/mob/living/M as mob)
-	M.adjustBrainLoss(rand(1,5)*REM)
-	M.hallucination += rand(1,5)
-	..()
-	return
-/datum/reagent/surge/addiction_act_stage2(var/mob/living/M as mob)
-	if(prob(25))
-		M << "<span class='danger'>Your casing feels loose...</span>"
-	..()
-	return
-/datum/reagent/surge/addiction_act_stage3(var/mob/living/M as mob)
-	if(prob(25))
-		M << "<span class='danger'>Your casing starts to come apart...</span>"
-	M.adjustBruteLoss(3*REM)
-	..()
-	return
-
-/datum/reagent/surge/addiction_act_stage4(var/mob/living/carbon/human/M as mob)
-	if(prob(25))
-		M << "<span class='userdanger'>Your exposed wiring begins corroding!</span>"
-	M.adjustFireLoss(5*REM)
 	..()
 	return
 

--- a/code/modules/reagents/newchem/drugs.dm
+++ b/code/modules/reagents/newchem/drugs.dm
@@ -348,6 +348,7 @@
 		return
 	if(method == INGEST || method == TOUCH)
 		M.SpinAnimation(speed = 12, loops = -1)
+	..()
 
 /datum/reagent/fliptonium/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom

--- a/code/modules/reagents/newchem/food.dm
+++ b/code/modules/reagents/newchem/food.dm
@@ -284,6 +284,7 @@ datum/reagent/cheese/reaction_turf(var/turf/T, var/volume)
 	reagent_state = LIQUID
 	color = "#B2B139"
 	overdose_threshold = 50
+	addiction_chance = 10
 
 /datum/reagent/fake_cheese/overdose_process(var/mob/living/M as mob)
 	if(prob(8))
@@ -298,6 +299,7 @@ datum/reagent/cheese/reaction_turf(var/turf/T, var/volume)
 	reagent_state = SOLID
 	color = "#50FF00"
 	metabolization_rate = 0 //heheheh
+	addiction_chance = 5
 
 /datum/reagent/weird_cheese/on_mob_life(var/mob/living/M as mob)
 	if(prob(5))

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -168,6 +168,7 @@ datum/reagent/omnizine
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
 	overdose_threshold = 30
+	addiction_chance = 5
 
 datum/reagent/omnizine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
@@ -336,6 +337,7 @@ datum/reagent/perfluorodecalin
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
+	addiction_chance = 20
 
 datum/reagent/perfluorodecalin/on_mob_life(var/mob/living/carbon/human/M as mob)
 	if(!M) M = holder.my_atom
@@ -367,7 +369,7 @@ datum/reagent/ephedrine
 	color = "#C8A5DC"
 	metabolization_rate = 0.3
 	overdose_threshold = 45
-	addiction_threshold = 30
+	addiction_chance = 25
 
 datum/reagent/ephedrine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
@@ -393,31 +395,6 @@ datum/reagent/ephedrine/overdose_process(var/mob/living/M as mob)
 	..()
 	return
 
-datum/reagent/ephedrine/addiction_act_stage1(var/mob/living/M as mob)
-	if(prob(33))
-		M.adjustToxLoss(2*REM)
-		M.losebreath += 2
-	..()
-	return
-datum/reagent/ephedrine/addiction_act_stage2(var/mob/living/M as mob)
-	if(prob(33))
-		M.adjustToxLoss(3*REM)
-		M.losebreath += 3
-	..()
-	return
-datum/reagent/ephedrine/addiction_act_stage3(var/mob/living/M as mob)
-	if(prob(33))
-		M.adjustToxLoss(4*REM)
-		M.losebreath += 4
-	..()
-	return
-datum/reagent/ephedrine/addiction_act_stage4(var/mob/living/M as mob)
-	if(prob(33))
-		M.adjustToxLoss(5*REM)
-		M.losebreath += 5
-	..()
-	return
-
 /datum/chemical_reaction/ephedrine
 	name = "Ephedrine"
 	id = "ephedrine"
@@ -432,6 +409,7 @@ datum/reagent/diphenhydramine
 	description = "Anti-allergy medication. May cause drowsiness, do not operate heavy machinery while using this."
 	reagent_state = LIQUID
 	color = "#5BCBE1"
+	addiction_chance = 10
 
 datum/reagent/diphenhydramine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
@@ -463,7 +441,7 @@ datum/reagent/morphine
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
-	addiction_threshold = 25
+	addiction_chance = 50
 	shock_reduction = 50
 
 datum/reagent/morphine/on_mob_life(var/mob/living/M as mob)
@@ -492,46 +470,6 @@ datum/reagent/morphine/overdose_process(var/mob/living/M as mob)
 			M.drop_item()
 		M.Dizzy(1)
 		M.Jitter(1)
-	..()
-	return
-
-datum/reagent/morphine/addiction_act_stage1(var/mob/living/M as mob)
-	if(prob(33))
-		var/obj/item/I = M.get_active_hand()
-		if(I)
-			M.drop_item()
-		M.Dizzy(2)
-		M.Jitter(2)
-	..()
-	return
-datum/reagent/morphine/addiction_act_stage2(var/mob/living/M as mob)
-	if(prob(33))
-		var/obj/item/I = M.get_active_hand()
-		if(I)
-			M.drop_item()
-		M.adjustToxLoss(1*REM)
-		M.Dizzy(3)
-		M.Jitter(3)
-	..()
-	return
-datum/reagent/morphine/addiction_act_stage3(var/mob/living/M as mob)
-	if(prob(33))
-		var/obj/item/I = M.get_active_hand()
-		if(I)
-			M.drop_item()
-		M.adjustToxLoss(2*REM)
-		M.Dizzy(4)
-		M.Jitter(4)
-	..()
-	return
-datum/reagent/morphine/addiction_act_stage4(var/mob/living/M as mob)
-	if(prob(33))
-		var/obj/item/I = M.get_active_hand()
-		if(I)
-			M.drop_item()
-		M.adjustToxLoss(3*REM)
-		M.Dizzy(5)
-		M.Jitter(5)
 	..()
 	return
 
@@ -943,6 +881,7 @@ datum/reagent/teporone
 	description = "This experimental plasma-based compound seems to regulate body temperature."
 	reagent_state = LIQUID
 	color = "#D782E6"
+	addiction_chance = 20
 
 datum/reagent/teporone/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom

--- a/code/modules/reagents/newchem/newchem_procs.dm
+++ b/code/modules/reagents/newchem/newchem_procs.dm
@@ -1,15 +1,18 @@
-datum/reagent
+#define ADDICTION_TIME 4800 //8 minutes
+
+/datum/reagent
 	var/overdose_threshold = 0
-	var/addiction_threshold = 0
-	var/addiction_stage = 0
+	var/addiction_chance = 0
+	var/addiction_stage = 1
+	var/last_addiction_dose = 0
 	var/overdosed = 0 // You fucked up and this is now triggering it's overdose effects, purge that shit quick.
 	var/current_cycle = 1
-datum/reagents
+
+/datum/reagents
 	var/chem_temp = 300
-	var/addiction_tick = 1
 	var/list/datum/reagent/addiction_list = new/list()
 
-datum/reagents/proc/metabolize(var/mob/M)
+/datum/reagents/proc/metabolize(var/mob/M)
 	if(M)
 		if(!istype(M, /mob/living))		//Non-living mobs can't metabolize reagents, so don't bother trying (runtime safety check)
 			return
@@ -53,39 +56,29 @@ datum/reagents/proc/metabolize(var/mob/M)
 				R.overdose_start(M)
 			if(R.volume < R.overdose_threshold && R.overdosed)
 				R.overdosed = 0
-			if(R.volume >= R.addiction_threshold && !is_type_in_list(R, addiction_list) && R.addiction_threshold > 0)
-				var/datum/reagent/new_reagent = new R.type()
-				addiction_list.Add(new_reagent)
 			if(R.overdosed)
 				R.overdose_process(M)
-			if(is_type_in_list(R,addiction_list))
-				for(var/datum/reagent/addicted_reagent in addiction_list)
-					if(istype(R, addicted_reagent))
-						addicted_reagent.addiction_stage = -15 // you're satisfied for a good while.
 			R.on_mob_life(M)
-	if(addiction_tick == 6)
-		addiction_tick = 1
-		for(var/A in addiction_list)
-			var/datum/reagent/R = A
-			if(M && R)
-				if(R.addiction_stage <= 0)
+	for(var/A in addiction_list)
+		var/datum/reagent/R = A
+		if(M && R)
+			if(R.addiction_stage < 5)
+				if(prob(5))
 					R.addiction_stage++
-				if(R.addiction_stage > 0 && R.addiction_stage <= 10)
+			switch(R.addiction_stage)
+				if(1)
 					R.addiction_act_stage1(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 10 && R.addiction_stage <= 20)
+				if(2)
 					R.addiction_act_stage2(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 20 && R.addiction_stage <= 30)
+				if(3)
 					R.addiction_act_stage3(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 30 && R.addiction_stage <= 40)
+				if(4)
 					R.addiction_act_stage4(M)
-					R.addiction_stage++
-				if(R.addiction_stage > 40)
-					M << "<span class='notice'>You feel like you've gotten over your need for [R.name].</span>"
-					addiction_list.Remove(R)
-	addiction_tick++
+				if(5)
+					R.addiction_act_stage5(M)
+			if(prob(20) && (world.timeofday > (R.last_addiction_dose + ADDICTION_TIME))) //Each addiction lasts 8 minutes before it can end
+				M << "<span class='notice'>You no longer feel reliant on [R.name]!</span>"
+				addiction_list.Remove(R)
 	update_total()
 
 /datum/reagents/proc/overdose_list()
@@ -96,19 +89,19 @@ datum/reagents/proc/metabolize(var/mob/M)
 	return od_chems
 
 
-datum/reagents/proc/reagent_on_tick()
+/datum/reagents/proc/reagent_on_tick()
 	for(var/datum/reagent/R in reagent_list)
 		R.on_tick()
 	return
 
-datum/reagents/proc/check_gofast(var/mob/M)
+/datum/reagents/proc/check_gofast(var/mob/M)
 	if(istype(M, /mob))
 		if(M.reagents.has_reagent("unholywater")||M.reagents.has_reagent("nuka_cola")||M.reagents.has_reagent("stimulative_agent"))
 			return 1
 		else
 			M.status_flags &= ~GOTTAGOFAST
 
-datum/reagents/proc/check_goreallyfast(var/mob/M)
+/datum/reagents/proc/check_goreallyfast(var/mob/M)
 	if(istype(M, /mob))
 		if(M.reagents.has_reagent("methamphetamine"))
 			return 1
@@ -116,39 +109,61 @@ datum/reagents/proc/check_goreallyfast(var/mob/M)
 			M.status_flags &= ~GOTTAGOREALLYFAST
 
 // Called every time reagent containers process.
-datum/reagent/proc/on_tick(var/data)
+/datum/reagent/proc/on_tick(var/data)
 	return
 
 // Called when the reagent container is hit by an explosion
-datum/reagent/proc/on_ex_act(var/severity)
+/datum/reagent/proc/on_ex_act(var/severity)
 	return
 
 // Called if the reagent has passed the overdose threshold and is set to be triggering overdose effects
-datum/reagent/proc/overdose_process(var/mob/living/M as mob)
+/datum/reagent/proc/overdose_process(var/mob/living/M as mob)
 	return
 
-datum/reagent/proc/overdose_start(var/mob/living/M as mob)
+/datum/reagent/proc/overdose_start(var/mob/living/M as mob)
 	return
 
-datum/reagent/proc/addiction_act_stage1(var/mob/living/M as mob)
-	if(prob(30))
-		M << "<span class='notice'>You feel like some [name] right about now.</span>"
+/datum/reagent/proc/addiction_act_stage1(var/mob/living/M as mob)
 	return
 
-datum/reagent/proc/addiction_act_stage2(var/mob/living/M as mob)
-	if(prob(30))
-		M << "<span class='notice'>You feel like you need [name]. You just can't get enough.</span>"
-	return
+/datum/reagent/proc/addiction_act_stage2(var/mob/living/M as mob)
+	if(prob(8))
+		M.emote("shiver")
+	if(prob(8))
+		M.emote("sneeze")
+	if(prob(4))
+		M << "<span class='notice'>You feel a dull headache.</span>"
 
-datum/reagent/proc/addiction_act_stage3(var/mob/living/M as mob)
-	if(prob(30))
-		M << "<span class='danger'>You have an intense craving for [name].</span>"
-	return
+/datum/reagent/proc/addiction_act_stage3(var/mob/living/M as mob)
+	if(prob(8))
+		M.emote("twitch_s")
+	if(prob(8))
+		M.emote("shiver")
+	if(prob(4))
+		M << "<span class='warning'>You begin craving [name]!</span>"
 
-datum/reagent/proc/addiction_act_stage4(var/mob/living/M as mob)
-	if(prob(30))
-		M << "<span class='danger'>You're not feeling good at all! You really need some [name].</span>"
-	return
+/datum/reagent/proc/addiction_act_stage4(var/mob/living/M as mob)
+	if(prob(8))
+		M.emote("twitch")
+	if(prob(4))
+		M << "<span class='warning'>You have the strong urge for some [name]!</span>"
+	if(prob(4))
+		M << "<span class='warning'>You REALLY crave some [name]!</span>"
+
+/datum/reagent/proc/addiction_act_stage5(var/mob/living/M as mob)
+	if(prob(8))
+		M.emote("twitch")
+	if(prob(6))
+		M << "<span class='warning'>Your stomach lurches painfully!</span>"
+		M.visible_message("<span class='warning'>[M] gags and retches!</span>")
+		M.Stun(rand(2,4))
+		M.Weaken(rand(2,4))
+	if(prob(5))
+		M << "<span class='warning'>You feel like you can't live without [name]!</span>"
+	if(prob(5))
+		M << "<span class='warning'>You would DIE for some [name] right now!</span>"
 
 /datum/reagent/proc/reagent_deleted()
 	return
+
+#undef ADDICTION_TIME

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -35,18 +35,21 @@
 
 
 		if(method == INGEST) //Yes, even Xenos can get addicted to drugs.
-			if(prob(self.addiction_chance) && !is_type_in_list(self, M.reagents.addiction_list))
-				M << "<span class='danger'>You suddenly feel invigorated and guilty...</span>"
-				var/datum/reagent/new_reagent = new self.type()
-				new_reagent.last_addiction_dose = world.timeofday
-				M.reagents.addiction_list.Add(new_reagent)
-			else if(is_type_in_list(self, M.reagents.addiction_list))
-				M << "<span class='notice'>You feel slightly better, but for how long?</span>"
-				for(var/A in M.reagents.addiction_list)
-					var/datum/reagent/AD = A
-					if(AD && istype(AD, self))
-						AD.last_addiction_dose = world.timeofday
-						AD.addiction_stage = 1
+			var/can_become_addicted = M.reagents.reaction_check(M, self)
+
+			if(can_become_addicted)
+				if(prob(self.addiction_chance) && !is_type_in_list(self, M.reagents.addiction_list))
+					M << "<span class='danger'>You suddenly feel invigorated and guilty...</span>"
+					var/datum/reagent/new_reagent = new self.type()
+					new_reagent.last_addiction_dose = world.timeofday
+					M.reagents.addiction_list.Add(new_reagent)
+				else if(is_type_in_list(self, M.reagents.addiction_list))
+					M << "<span class='notice'>You feel slightly better, but for how long?</span>"
+					for(var/A in M.reagents.addiction_list)
+						var/datum/reagent/AD = A
+						if(AD && istype(AD, self))
+							AD.last_addiction_dose = world.timeofday
+							AD.addiction_stage = 1
 		return 1
 
 /datum/reagent/proc/reaction_obj(var/obj/O, var/volume) //By default we transfer a small part of the reagent to the object

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -33,18 +33,20 @@
 					if(amount >= 1)
 						L.reagents.add_reagent(self.id,amount)
 
-/*
-		if(method == INGEST && istype(M, /mob/living/carbon))
-			if(prob(self.addictiveness))
-				var/datum/disease/addiction/A = new /datum/disease/addiction
-				A.addicted_to = self
-				A.name = "[self.name] Addiction"
-				A.addiction ="[self.name]"
-				A.cure = self.id
-				M.viruses += A
-				A.affected_mob = M
-				A.holder = M
-*/
+
+		if(method == INGEST) //Yes, even Xenos can get addicted to drugs.
+			if(prob(self.addiction_chance) && !is_type_in_list(self, M.reagents.addiction_list))
+				M << "<span class='danger'>You suddenly feel invigorated and guilty...</span>"
+				var/datum/reagent/new_reagent = new self.type()
+				new_reagent.last_addiction_dose = world.timeofday
+				M.reagents.addiction_list.Add(new_reagent)
+			else if(is_type_in_list(self, M.reagents.addiction_list))
+				M << "<span class='notice'>You feel slightly better, but for how long?</span>"
+				for(var/A in M.reagents.addiction_list)
+					var/datum/reagent/AD = A
+					if(AD && istype(AD, self))
+						AD.last_addiction_dose = world.timeofday
+						AD.addiction_stage = 1
 		return 1
 
 /datum/reagent/proc/reaction_obj(var/obj/O, var/volume) //By default we transfer a small part of the reagent to the object

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -17,7 +17,6 @@
 	var/vomit_start = 180	//amount absorbed after which mob starts vomitting
 	var/blur_start = 260	//amount absorbed after which mob starts getting blurred vision
 	var/pass_out = 325	//amount absorbed after which mob starts passing out
-	addiction_chance = 4 //chance to become alcoholic
 
 /datum/reagent/ethanol/on_mob_life(var/mob/living/M as mob, var/alien)
 	// Sobering multiplier.

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -17,6 +17,7 @@
 	var/vomit_start = 180	//amount absorbed after which mob starts vomitting
 	var/blur_start = 260	//amount absorbed after which mob starts getting blurred vision
 	var/pass_out = 325	//amount absorbed after which mob starts passing out
+	addiction_chance = 4 //chance to become alcoholic
 
 /datum/reagent/ethanol/on_mob_life(var/mob/living/M as mob, var/alien)
 	// Sobering multiplier.

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
@@ -187,6 +187,7 @@
 	adj_sleepy = -2
 	adj_temp = 25
 	overdose_threshold = 45
+	addiction_chance = 5 // It's true.
 
 /datum/reagent/drink/coffee/on_mob_life(var/mob/living/M as mob)
 	if(holder.has_reagent("frostoil"))

--- a/code/modules/reagents/oldchem/reagents/reagents_drugs.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_drugs.dm
@@ -87,6 +87,7 @@
 	reagent_state = LIQUID
 	color = "#9087A2"
 	metabolization_rate = 0.2
+	addiction_chance = 65
 
 /datum/reagent/space_drugs/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom


### PR DESCRIPTION
This is very heavily inspired by Goon's addiction system.

Addictions are now based on probability on INGESTing a reagent rather than based on surpassing a particular threshold. 

Addictions still progress in stages, but stage advancement is based on probability every time a reagent tick. All addictive things now have the same impacts--at the final stage, you'll start gagging and falling on the floor; it's very debilitating. After 8 minutes has passed, you can start rolling for a chance to be relieved of your addiction to a particular chemical.

If you take more of a reagent you're addicted to it will reset your addiction stage back to 1, but it will also reset the 8 minute timer you must pass for you to be free of an addiction.

This should make addictions more realistic, in terms of behavior, while not impacting game balance horrendously, while this also differentiates addictions better from overdosing.

Related
- Health scanners will tell what stage of addiction a person is at for what they're addicted to
- Cigs don't proc INGEST (too much spam, otherwise)
- the follow reagents are addictive: meth, crank, krokodil, bath salts, space drugs, perfluoradecalin, omnizine, coffee, nicotine, fliptonium, ultra lube, surge, fake cheese, weird cheese, ephedrine, diphenhydramine, teporone, and morphine.
 - Sleepers help you recover from addiction faster

:cl: Fox McCloud
rscadd: Reworks addictions to bettter differentiate them betweeen overdosing and make them more realistic.
tweak: changes which chems are addictive, currently, the follow reagents are now addidctive: meth, crank, krokodil, bath salts, space drugs, perfluoradecalin, omnizine, coffee, nicotine, fliptonium, ultra lube, surge, fake cheese, weird cheese, ephedrine, diphenhydramine, teporone, and morphine
rscadd: sleepers help you recover from addiction faster
/:cl:

