### PR TITLE
Tweaks Regeneration Mutation

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -200,11 +200,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 		adjustCloneLoss(0.1)
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
-	if(getFireLoss())
-		if((RESIST_HEAT in mutations) || (prob(1)))
-			heal_organ_damage(0,1)
-
-
 	for(var/datum/dna/gene/gene in dna_genes)
 		if(!gene.block)
 			continue
@@ -833,13 +828,7 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 
 	if(.) //alive
 		if(REGEN in mutations)
-			if(nutrition)
-				if(prob(10))
-					var/randumb = rand(1, 5)
-					nutrition -= randumb
-					heal_overall_damage(randumb, randumb)
-				if(nutrition < 0)
-					nutrition = 0
+			heal_overall_damage(0.1, 0.1)
 
 		if(!in_stasis)
 			handle_organs()


### PR DESCRIPTION
Tweaks some regen stuff

- Remoes the random 1% chance to heal 1 fire damage and the passive regen from having the fire resist block
- Removes the passive hunger cost of regen and makes the heal happen every tick instead of being random--overall, the heal is 66% less, on average, but you can rely on it to heal every single cycle if you have the mutation.

:cl: Fox McCloud
tweak: Removes random 1% chance to heal fire damage
tweak: Removes passive healing from resist heat mutation
tweak: Regen mutation heals every cycle (albeit less, on average), but doesn't cost hunger
/:cl: