### PR TITLE
Makes DNA swapping methods more reliable and other appearance tweaks

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -219,9 +219,6 @@
 
 	body += "<td width='50%'><div align='center'><a href='?_src_=vars;datumrefresh=\ref[D]'>Refresh</a>"
 
-	//if(ismob(D))
-	//	body += "<br><a href='?_src_=vars;mob_player_panel=\ref[D]'>Show player panel</a></div></td></tr></table></div><hr>"
-
 	body += {"	<form>
 				<select name="file" size="1"
 				onchange="loadPage(this.form.elements\[0\])"

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -63,15 +63,24 @@
 /obj/item/weapon/dnainjector/proc/inject(mob/living/M as mob, mob/user as mob)
 	if(istype(M,/mob/living))
 		M.apply_effect(rand(10,25),IRRADIATE,0,1)
+	var/mob/living/carbon/human/H
+	if(istype(M, /mob/living/carbon/human))
+		H = M
 
-	if (!(NOCLONE in M.mutations)) // prevents drained people from having their DNA changed
+	if (!(NOCLONE in M.mutations) && !(H && (H.species.flags & NO_DNA))) // prevents drained people from having their DNA changed
+		var/prev_ue = M.dna.unique_enzymes
 		// UI in syringe.
 		if (buf.types & DNA2_BUF_UI)
 			if (!block) //isolated block?
-				M.UpdateAppearance(buf.dna.UI.Copy())
+				M.dna.UI = buf.dna.UI.Copy()
+				M.dna.UpdateUI()
+				M.UpdateAppearance()
 				if (buf.types & DNA2_BUF_UE) //unique enzymes? yes
+
 					M.real_name = buf.dna.real_name
 					M.name = buf.dna.real_name
+					M.dna.real_name = buf.dna.real_name
+					M.dna.unique_enzymes = buf.dna.unique_enzymes
 				uses--
 			else
 				M.dna.SetUIValue(block,src.GetValue())
@@ -86,6 +95,8 @@
 			domutcheck(M, null, block!=null)
 			uses--
 			M.update_mutations()
+		if(H)
+			H.sync_organ_dna(assimilate = 0, old_ue = prev_ue)
 
 	spawn(0)//this prevents the collapse of space-time continuum
 		if (user)

--- a/code/game/objects/items/weapons/dnascrambler.dm
+++ b/code/game/objects/items/weapons/dnascrambler.dm
@@ -38,7 +38,7 @@
 		target.generate_name()
 		if(istype(target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = target
-			H.sync_organ_dna(1)
+			H.sync_organ_dna(assimilate = 1)
 			H.update_body(0)
 			H.reset_hair() // No more winding up with hairstyles you're not supposed to have, and blowing your cover
 			H.dna.ResetUIFrom(H)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -139,6 +139,9 @@ var/global/nologevent = 0
 			else
 				body += "<A href='?_src_=holder;makeanimal=\ref[M]'>Animalize</A> | "
 
+			if(istype(M, /mob/dead/observer))
+				body += "<a href='?_src_=holder;incarn_ghost=\ref[M]'>Re-incarnate</a> | "
+
 			// DNA2 - Admin Hax
 			if(M.dna && iscarbon(M))
 				body += "<br><br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1523,6 +1523,14 @@
 
 		usr.client.cmd_admin_animalize(M)
 
+	else if(href_list["incarn_ghost"])
+		if(!check_rights(R_SPAWN)) return
+
+		var/mob/dead/observer/G = locate(href_list["incarn_ghost"])
+		if(!istype(G))
+			usr << "This will only work on /mob/dead/observer"
+		G.incarnate_ghost()
+
 	else if(href_list["togmutate"])
 		if(!check_rights(R_SPAWN))	return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1585,8 +1585,6 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 	character.real_name = real_name
 	character.name = character.real_name
-	if(character.dna)
-		character.dna.real_name = character.real_name
 
 	character.flavor_text = flavor_text
 	character.med_record = med_record
@@ -1695,6 +1693,9 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 		if(isliving(src)) //Ghosts get neuter by default
 			message_admins("[key_name_admin(character)] has spawned with their gender as plural or neuter. Please notify coders.")
 			character.change_gender(MALE)
+
+	character.dna.ready_dna(character)
+	character.sync_organ_dna(assimilate=1)
 
 /datum/preferences/proc/open_load_dialog(mob/user)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -636,3 +636,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return 0
 	usr.visible_message("<span class='deadsay'><b>[src]</b> points to [A].</span>")
 	return 1
+
+/mob/dead/observer/proc/incarnate_ghost()
+	if(!client)
+		return
+	var/mob/living/carbon/human/new_char = new(get_turf(src))
+	client.prefs.copy_to(new_char)
+	if(mind)
+		mind.transfer_to(new_char)
+	else
+		new_char.key = key

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -59,6 +59,8 @@
 
 /obj/item/organ/internal/brain/remove(var/mob/living/user,special = 0)
 
+	name = "[dna.real_name]'s [initial(name)]"
+
 	if(!owner) return ..() // Probably a redundant removal; just bail
 
 	var/obj/item/organ/internal/brain/B = src
@@ -77,7 +79,7 @@
 
 /obj/item/organ/internal/brain/insert(var/mob/living/target,special = 0)
 
-	name = "brain"
+	name = "[initial(name)]"
 	var/brain_already_exists = 0
 	if(istype(target,/mob/living/carbon/human)) // No more IPC multibrain shenanigans
 		if(target.get_int_organ(/obj/item/organ/internal/brain))

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -147,11 +147,14 @@
 /*
 When assimilate is 1, organs that have a different UE will still have their DNA overriden by that of the host
 Otherwise, this restricts itself to organs that share the UE of the host.
+
+old_ue: Set this to a UE string, and this proc will overwrite the dna of organs that have that UE, instead of the host's present UE
 */
-/mob/living/carbon/human/proc/sync_organ_dna(var/assimilate = 1)
+/mob/living/carbon/human/proc/sync_organ_dna(var/assimilate = 1, var/old_ue = null)
+	var/ue_to_compare = (old_ue) ? old_ue : dna.unique_enzymes
 	var/list/all_bits = internal_organs|organs
 	for(var/obj/item/organ/O in all_bits)
-		if(assimilate || O.dna.unique_enzymes == dna.unique_enzymes)
+		if(assimilate || O.dna.unique_enzymes == ue_to_compare)
 			O.set_dna(dna)
 
 /*

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -151,7 +151,7 @@
 	return 1
 
 /datum/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/E = tool
+	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='alert'>[user]'s hand slips, damaging [target]'s [E.amputation_point]!</span>", \
 	"<span class='alert'>Your hand slips, damaging [target]'s [E.amputation_point]!</span>")
 	target.apply_damage(10, BRUTE, null, sharp=1)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -57,7 +57,7 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/set_dna(var/datum/dna/new_dna)
 	if(new_dna)
 		dna = new_dna.Clone()
-		blood_DNA.Cut()
+		blood_DNA = list()
 		blood_DNA[dna.unique_enzymes] = dna.b_type
 
 /obj/item/organ/proc/die()

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -30,8 +30,9 @@
 	var/cannot_amputate
 	var/cannot_break
 	var/s_tone
-	var/list/s_col = list()
+	var/list/s_col = null // If this is instantiated, it should be a list of length 3
 	var/list/wounds = list()
+	var/list/child_icons = list()
 	var/number_wounds = 0 // cache the number of wounds, which is NOT wounds.len!
 	var/perma_injury = 0
 	// 0: Don't fail when at full damage
@@ -64,6 +65,7 @@
 	var/amputation_point // Descriptive string used in amputation.
 	var/can_grasp
 	var/can_stand
+	var/wound_cleanup_timer
 
 /obj/item/organ/external/Destroy()
 	if(parent && parent.children)
@@ -77,6 +79,10 @@
 	if(children)
 		for(var/obj/item/organ/external/C in children)
 			qdel(C)
+
+	if(wound_cleanup_timer)
+		deltimer(wound_cleanup_timer)
+		wound_cleanup_timer = null
 
 	return ..()
 
@@ -105,7 +111,7 @@
 						O.status |= ORGAN_CUT_AWAY
 						if(!O.sterile)
 							spread_germs_to_organ(O,user) // This wouldn't be any cleaner than the actual surgery
-						O.forceMove(src)
+						O.forceMove(get_turf(src))
 					if(!(user.l_hand && user.r_hand))
 						user.put_in_hands(removing)
 					user.visible_message("<span class='danger'><b>[user]</b> extracts [removing] from [src] with [W]!")
@@ -392,6 +398,11 @@ This function completely restores a damaged organ to perfect condition.
 		last_dam = brute_dam + burn_dam
 	if(germ_level)
 		return 1
+	if(!wound_cleanup_timer)
+		wound_cleanup_timer = addtimer(src, "cleanup_wounds", SecondsToTicks(600), 1, wounds)
+
+	if (update_icon())
+		owner.UpdateDamageIcon(1)
 	return 0
 
 /obj/item/organ/external/process()
@@ -525,11 +536,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return
 
 	for(var/datum/wound/W in wounds)
-		// wounds can disappear after 10 minutes at the earliest
-		if(W.damage <= 0 && W.created + 10 * 10 * 60 <= world.time)
-			wounds -= W
-			continue
-			// let the GC handle the deletion of the wound
 
 		// Internal wounds get worse over time. Low temperatures (cryo) stop them.
 		if(W.internal && !W.can_autoheal() && owner.bodytemperature >= 170)
@@ -892,13 +898,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 	// Attached organs also fly off.
 	if(!ignore_children)
 		for(var/obj/item/organ/external/O in children)
-			O.remove()
+			O.remove(victim)
 			if(O)
 				O.forceMove(src)
 
 	// Grab all the internal giblets too.
 	for(var/obj/item/organ/internal/organ in internal_organs)
-		organ.remove()
+		organ.remove(victim)
 		organ.forceMove(src)
 
 	release_restraints(victim)
@@ -941,3 +947,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if (!istype(O)) // You're not the primary organ of ANYTHING, bucko
 		return 0
 	return src == O.organs_by_name[limb_name]
+
+// The callback we use to remove wounds from an un-processed limb
+/obj/item/organ/external/proc/cleanup_wounds(var/list/slated_wounds)
+	wound_cleanup_timer = null
+	for(var/datum/wound/W in slated_wounds)
+		if(!W)
+			continue
+		if(W.damage > 0)
+			continue
+		wounds -= W
+		qdel(W)

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -1,34 +1,42 @@
 var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/proc/compile_icon()
-	overlays.Cut()
+	// I do this so the head's overlays don't get obliterated
+	for(var/child_i in child_icons)
+		overlays -= child_i
+	child_icons.Cut()
 	 // This is a kludge, only one icon has more than one generation of children though.
 	for(var/obj/item/organ/external/organ in contents)
 		if(organ.children && organ.children.len)
 			for(var/obj/item/organ/external/child in organ.children)
 				overlays += child.mob_icon
+				child_icons += child.mob_icon
 		overlays += organ.mob_icon
+		child_icons += organ.mob_icon
 
 /obj/item/organ/external/proc/sync_colour_to_human(var/mob/living/carbon/human/human)
-	s_tone = null
-	s_col = null
 	if(status & ORGAN_ROBOT && !(species && species.name == "Machine")) //machine people get skin color
 		return
 	if(species && human.species && species.name != human.species.name)
 		return
+	if(dna.unique_enzymes != human.dna.unique_enzymes) // This isn't MY arm
+		sync_colour_to_dna()
+		return
 	if(!isnull(human.s_tone) && (human.species.bodyflags & HAS_SKIN_TONE))
+		s_col = null
 		s_tone = human.s_tone
 	if(human.species.bodyflags & HAS_SKIN_COLOR)
+		s_tone = null
 		s_col = list(human.r_skin, human.g_skin, human.b_skin)
 
 /obj/item/organ/external/proc/sync_colour_to_dna()
-	s_tone = null
-	s_col = null
 	if(status & ORGAN_ROBOT)
 		return
 	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && (species.flags & HAS_SKIN_TONE))
+		s_col = null
 		s_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
 	if(species.flags & HAS_SKIN_COLOR)
+		s_tone = null
 		s_col = list(dna.GetUIValue(DNA_UI_SKIN_R), dna.GetUIValue(DNA_UI_SKIN_G), dna.GetUIValue(DNA_UI_SKIN_B))
 
 /obj/item/organ/external/head/sync_colour_to_human(var/mob/living/carbon/human/human)


### PR DESCRIPTION
:cl:Crazylemon
bugfix: Makes heads keep hair on removal
bugfix: Amputated limbs from a DNA-injected individual now will keep their appearance of the DNA-injected person
bugfix: Wounds will vanish on their own now
rscadd: Admins now have an "incarnate" option on the player panel when viewing ghosts for quick player instantiation
bugfix: Fixes a runtime regarding failing a limb reconnection surgery
bugfix: Copying a client's preferences now overrides the previous mob's DNA
bugfix: A DNA injector is now more thorough, and affects the DNA of mobs' limbs and organs
bugfix: DNA-lacking species can no longer be DNA-injected
bugfix: Brains are now labeled again
/:cl: