### PR TITLE
Refactor allowed() proc.

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -92,3 +92,5 @@
 
 #define DEFAULT_ITEM_STRIP_DELAY		40  //time taken (in deciseconds) to strip somebody
 #define DEFAULT_ITEM_PUTON_DELAY		20  //time taken (in deciseconsd) to reverse-strip somebody
+
+#define IGNORE_ACCESS -1

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -108,23 +108,21 @@
 
 //returns 1 if this mob has sufficient access to use this object
 /obj/proc/allowed(mob/M)
-	//check if it doesn't require any access at all
-	if(src.check_access(null))
+	generate_req_lists()
+	//check if we don't require any access at all
+	if(check_access())
 		return 1
-	if(istype(M, /mob/living/silicon))
-		//AI can do whatever he wants
-		return 1
-	else if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		//if they are holding or wearing a card that has access, that works
-		if(src.check_access(H.get_active_hand()) || src.check_access(H.wear_id))
-			return 1
-	else if(istype(M, /mob/living/carbon/alien/humanoid))
-		var/mob/living/carbon/george = M
-		//they can only hold things :(
-		if(src.check_access(george.get_active_hand()))
-			return 1
+
+	var/acc = M.get_access() //see mob.dm
+
+	if(acc == IGNORE_ACCESS)
+		return 1 //Mob ignores access
+
+	if(istype(acc, /obj/item))
+		return check_access(acc)
+
 	return 0
+
 
 /obj/item/proc/GetAccess()
 	return list()
@@ -132,39 +130,39 @@
 /obj/item/proc/GetID()
 	return null
 
-/obj/proc/check_access(obj/item/I)
+/obj/proc/generate_req_lists()
 	//These generations have been moved out of /obj/New() because they were slowing down the creation of objects that never even used the access system.
-	if(!src.req_access)
-		src.req_access = list()
-		if(src.req_access_txt)
-			var/list/req_access_str = text2list(req_access_txt,";")
+	if(!req_access)
+		req_access = list()
+		if(req_access_txt)
+			var/list/req_access_str = text2list(req_access_txt, ";")
 			for(var/x in req_access_str)
 				var/n = text2num(x)
 				if(n)
 					req_access += n
 
-	if(!src.req_one_access)
-		src.req_one_access = list()
-		if(src.req_one_access_txt)
+	if(!req_one_access)
+		req_one_access = list()
+		if(req_one_access_txt)
 			var/list/req_one_access_str = text2list(req_one_access_txt,";")
 			for(var/x in req_one_access_str)
 				var/n = text2num(x)
 				if(n)
 					req_one_access += n
 
-	if(!istype(src.req_access, /list)) //something's very wrong
+/obj/proc/check_access(obj/item/I)
+	if(!istype(req_access, /list))
 		return 1
 
-	var/list/L = src.req_access
-	if(!L.len && (!src.req_one_access || !src.req_one_access.len)) //no requirements
+	if(!req_access.len && (!req_one_access || !req_one_access.len))
 		return 1
 	if(!I)
 		return 0
 	for(var/req in src.req_access)
 		if(!(req in I.GetAccess())) //doesn't have this access
 			return 0
-	if(src.req_one_access && src.req_one_access.len)
-		for(var/req in src.req_one_access)
+	if(req_one_access && req_one_access.len)
+		for(var/req in req_one_access)
 			if(req in I.GetAccess()) //has an access from the single access list
 				return 1
 		return 0
@@ -172,10 +170,12 @@
 
 
 /obj/proc/check_access_list(var/list/L)
-	if(!req_access)		req_access = list()
-	if(!req_one_access)	req_one_access = list()
-	if(!L)	return 0
-	if(!istype(L, /list))	return 0
+	generate_req_lists()
+
+	if(!L)
+		return 0
+	if(!istype(L, /list))
+		return 0
 	return has_access(req_access, req_one_access, L)
 
 /proc/has_access(var/list/req_access, var/list/req_one_access, var/list/accesses)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -814,3 +814,10 @@ so that different stomachs can handle things in different ways VB*/
 				toEat.reagents.trans_to(src, toEat.bitesize*toEat.transfer_efficiency)
 			else
 				toEat.reagents.trans_to(src, toEat.reagents.total_volume*toEat.transfer_efficiency)
+
+/mob/living/carbon/get_access()
+	var/obj/item/I = get_active_hand()
+	if(istype(I))
+		return I
+
+	return null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1927,3 +1927,9 @@
 
 /mob/living/carbon/human/proc/get_age_pitch()
 	return 1.0 + 0.5*(30 - age)/80
+
+/mob/living/carbon/human/get_access()
+	. = ..() //objects in hand
+	if(!. && wear_id) //nothing in hand, try ID
+		return wear_id
+	//otherwise return hand/nothing

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -349,4 +349,5 @@
 /mob/living/silicon/adjustToxLoss(var/amount)
 	return
 
-
+/mob/living/silicon/get_access()
+	return IGNORE_ACCESS //silicons always have access

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1452,3 +1452,6 @@ mob/proc/yank_out_object()
 
 /mob/proc/IsVocal()
 	return 1
+
+/mob/proc/get_access()
+	return null //must return either IGNORE_ACCESS or an /obj/item


### PR DESCRIPTION
Mobs now handle returning an item for the `allowed()` proc.
You can also have a mob return `IGNORE_ACCESS` to have the allowed proc immediately succeed.
Currently only used for silicons.