### PR TITLE
Adds PDA chatroom app

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -137,18 +137,7 @@
 						useMS.send_pda_message("[P.owner]", "[command_name()] Payroll", msg)
 
 						var/datum/data/pda/app/messenger/PM = P.find_program(/datum/data/pda/app/messenger)
-						if(PM)
-							PM.play_ringtone()
-						//Search for holder of the PDA.
-						var/mob/living/L = null
-						if(P.loc && isliving(P.loc))
-							L = P.loc
-						//Maybe they are a pAI!
-						else
-							L = get(P, /mob/living/silicon)
-
-						if(L)
-							L << "\icon[P] <b>Message from [command_name()] (Payroll), </b>\"[msg]\" (<i>Unable to Reply</i>)"
+						PM.notify("<b>Message from [command_name()] (Payroll), </b>\"[msg]\" (<i>Unable to Reply</i>)", 0)
 					break
 
 /datum/game_mode/proc/check_finished() //to be called by ticker

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -107,9 +107,7 @@ datum/game_mode/mutiny
 
 		var/datum/data/pda/app/messenger/pdam = pda.find_program(/datum/data/pda/app/messenger)
 		if(pdam)
-			pdam.play_ringtone()
-
-		head_mutineer.current << fluff.get_pda_body()
+			pdam.notify(fluff.get_pda_body(), 0)
 		return 1
 
 	proc/get_equipment_slots()

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -22,17 +22,18 @@
 	var/defaultmsg = "<span class='notice'>Welcome. Please select an option.</span>"
 	var/rebootmsg = "<span class='warning'>%$&(£: Critical %$$@ Error // !RestArting! <lOadiNg backUp iNput ouTput> - ?pLeaSe wAit!</span>"
 	//Computer properties
-	var/screen = 0 		// 0 = Main menu, 1 = Message Logs, 2 = Hacked screen, 3 = Custom Message
+	var/screen = 0 		// 0 = Main menu, 1 = Message Logs, 2 = Hacked screen, 3 = Custom Message, 4 = chat room selection, 5 = chat room logs
 	var/hacking = 0		// Is it being hacked into by the AI/Cyborg
 	var/emag = 0		// When it is emagged.
 	var/message = "<span class='notice'>System bootup complete. Please select an option.</span>"	// The message that shows on the main menu.
 	var/auth = 0 // Are they authenticated?
-	var/optioncount = 7
+	var/optioncount = 8
 	// Custom Message Properties
 	var/customsender = "System Administrator"
 	var/obj/item/device/pda/customrecepient = null
 	var/customjob		= "Admin"
 	var/custommessage 	= "This is a test, please ignore."
+	var/datum/chatroom/current_chatroom = null
 
 	light_color = LIGHT_COLOR_DARKGREEN
 
@@ -130,6 +131,7 @@
 					dat += "<dd><A href='?src=\ref[src];clearr=1'>&#09;[++i]. Clear Request Console Logs</a><br></dd>"
 					dat += "<dd><A href='?src=\ref[src];pass=1'>&#09;[++i]. Set Custom Key</a><br></dd>"
 					dat += "<dd><A href='?src=\ref[src];msg=1'>&#09;[++i]. Send Admin Message</a><br></dd>"
+					dat += "<dd><A href='?src=\ref[src];chatroom=1'>&#09;[++i]. View Chatrooms</a><br></dd>"
 			else
 				for(var/n = ++i; n <= optioncount; n++)
 					dat += "<dd><font color='blue'>&#09;[n]. ---------------</font><br></dd>"
@@ -247,7 +249,41 @@
 				dat += {"<tr><td width = '5%'><center><A href='?src=\ref[src];deleter=\ref[rc]' style='color: rgb(255,0,0)'>X</a></center></td><td width='15%'>[rc.send_dpt]</td>
 				<td width='15%'>[rc.rec_dpt]</td><td width='300px'>[rc.message]</td><td width='15%'>[rc.stamp]</td><td width='15%'>[rc.id_auth]</td><td width='15%'>[rc.priority]</td></tr>"}
 			dat += "</table>"
-
+		//Chat room list
+		if(5)
+			dat += "<center><A href='?src=\ref[src];back=1'>Back</a> - <A href='?src=\ref[src];refresh=1'>Refresh</center><hr>"
+			dat += {"<table border='1' width='100%'>
+					<tr>
+					<th width='40%'>Room Name</th>
+					<th width='20%'>Users</th>
+					<th width='20%'>Invites</th>
+					<th width='20%'>Messages</th>
+					</tr>"}
+			for(var/datum/chatroom/C in chatrooms)
+				var/list/invites = (C.invites - C.users)
+				dat += {"<tr>
+					<td><a href='?src=\ref[src];viewroom=\ref[C]'>[C.name]</a></td>
+					<td>[C.users.len]</td>
+					<td>[invites.len]</td>
+					<td>[C.logs.len]</td>
+					</tr>"}
+			dat += "</table>"
+		//View chat room logs
+		if(6)
+			dat += "<center><A href='?src=\ref[src];chatroom=1'>Back</a> - <A href='?src=\ref[src];refresh=1'>Refresh</center><hr>"
+			dat += {"<table border='1' width='100%'>
+					<tr>
+					<th width='25%'>Name</th>
+					<th width='75%'>Message</th>
+					</tr>"}
+			if(current_chatroom)
+				for(var/M in current_chatroom.logs)
+					var/list/message = M
+					dat += {"<tr>
+						<td>[message["username"]]</td>
+						<td>[message["message"]]</td>
+						</tr>"}
+			dat += "</table>"
 
 	dat += "</body>"
 	message = defaultmsg
@@ -459,12 +495,8 @@
 						//Sender isn't faking as someone who exists
 						if(isnull(PDARec))
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[customsender]","[custommessage]")
-							recipient_messenger.play_ringtone()
-							if( customrecepient.loc && ishuman(customrecepient.loc) )
-								var/mob/living/carbon/human/H = customrecepient.loc
-								H << "\icon[customrecepient] <b>Message from [customsender] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[src];choice=Message;target=\ref[src]'>Reply</a>)"
+							recipient_messenger.notify("<b>Message from [customsender] ([customjob]), </b>\"[custommessage]\" (<a href='?src=\ref[src];choice=Message;target=\ref[src]'>Reply</a>)")
 							log_pda("[usr] (PDA: [customsender]) sent \"[custommessage]\" to [customrecepient.owner]")
-							recipient_messenger.set_new(1)
 						//Sender is faking as someone who exists
 						else
 							src.linkedServer.send_pda_message("[customrecepient.owner]", "[PDARec.owner]","[custommessage]")
@@ -473,12 +505,8 @@
 							if(!recipient_messenger.conversations.Find("\ref[PDARec]"))
 								recipient_messenger.conversations.Add("\ref[PDARec]")
 
-							recipient_messenger.play_ringtone()
-							if( customrecepient.loc && ishuman(customrecepient.loc) )
-								var/mob/living/carbon/human/H = customrecepient.loc
-								H << "\icon[customrecepient] <b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='byond://?src=\ref[recipient_messenger];choice=Message;target=\ref[PDARec]'>Reply</a>)"
+							recipient_messenger.notify("<b>Message from [PDARec.owner] ([customjob]), </b>\"[custommessage]\" (<a href='?src=\ref[recipient_messenger];choice=Message;target=\ref[PDARec]'>Reply</a>)")
 							log_pda("[usr] (PDA: [PDARec.owner]) sent \"[custommessage]\" to [customrecepient.owner]")
-							recipient_messenger.set_new(1)
 						//Finally..
 						ResetMessage()
 
@@ -494,6 +522,19 @@
 
 		if (href_list["back"])
 			src.screen = 0
+		// View chat room list
+		if (href_list["chatroom"])
+			if(!linkedServer || (linkedServer.stat & (NOPOWER|BROKEN)))
+				message = noserver
+			else if(auth)
+				screen = 5
+		if (href_list["viewroom"])
+			if(!linkedServer || (linkedServer.stat & (NOPOWER|BROKEN)))
+				message = noserver
+			else if(auth)
+				current_chatroom = locate(href_list["viewroom"])
+				if(current_chatroom)
+					screen = 6
 
 	return src.attack_hand(usr)
 

--- a/code/modules/events/money_spam.dm
+++ b/code/modules/events/money_spam.dm
@@ -103,17 +103,4 @@
 					if(ai.aiPDA != P && ai.aiPDA != src)
 						ai.show_message("<i>Intercepted message from <b>[sender]</b></i> (Unknown / spam?) <i>to <b>[P:owner]</b>: [message]</i>")
 
-			//Commented out because we don't send messages like this anymore.  Instead it will just popup in their chat window.
-			//P.tnote += "<i><b>&larr; From [sender] (Unknown / spam?):</b></i><br>[message]<br>"
-
-			PM.play_ringtone()
-			//Search for holder of the PDA.
-			var/mob/living/L = null
-			if(P.loc && isliving(P.loc))
-				L = P.loc
-			//Maybe they are a pAI!
-			else
-				L = get(P, /mob/living/silicon)
-
-			if(L)
-				L << "\icon[P] <b>Message from [sender] (Unknown / spam?), </b>\"[message]\" (Unable to Reply)"
+			PM.notify("<b>Message from [sender] (Unknown / spam?), </b>\"[message]\" (Unable to Reply)", 0)

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -149,7 +149,7 @@
 			return
 
 		data["receiver_off"] = M.toff
-		data["ringer_off"] = M.silent
+		data["ringer_off"] = M.notify_silent
 		data["current_ref"] = null
 		data["current_name"] = user.current_pda_messaging
 
@@ -205,7 +205,7 @@
 				M.toff = href_list["toggler"] != "1"
 				return 1
 			else if(href_list["ringer"])
-				M.silent = href_list["ringer"] != "1"
+				M.notify_silent = href_list["ringer"] != "1"
 				return 1
 			else if(href_list["select"])
 				var/s = href_list["select"]

--- a/code/modules/ninja/suit/SpiderOS.dm
+++ b/code/modules/ninja/suit/SpiderOS.dm
@@ -220,19 +220,9 @@
 				display_to << "<span class='danger'>Error: unable to deliver message.</span>"
 				display_spideros()
 				return
-			//Search for holder of the PDA.
-			var/mob/living/L = null
-			if(P.loc && isliving(P.loc))
-				L = P.loc
-			//Maybe they are a pAI!
-			else
-				L = get(P, /mob/living/silicon)
-
-			if(L)
-				L << "\icon[P] <b>Message from unknown source: </b>\"[t]\" (Unable to Reply)"
-			P.play_ringtone()
+			
 			var/datum/data/pda/app/messenger/M = P.find_program(/datum/data/pda/app/messenger)
-			M.set_new(1)
+			M.notify("<b>Message from unknown source: </b>\"[t]\" (Unable to Reply)", 0)
 
 		if("Inject")
 			if( (href_list["tag"]=="radium"? (reagents.get_reagent_amount("radium"))<=(a_boost*a_transfer) : !reagents.get_reagent_amount(href_list["tag"])) )//Special case for radium. If there are only a_boost*a_transfer radium units left.

--- a/code/modules/pda/ai.dm
+++ b/code/modules/pda/ai.dm
@@ -17,7 +17,7 @@
 	set category = "AI IM"
 	set name = "Send PDA Message"
 	set src in usr
-	
+
 	if(usr.stat == DEAD)
 		usr << "You can't send PDA messages because you are dead!"
 		return
@@ -36,7 +36,7 @@
 	set category = "AI IM"
 	set name = "Show Message Log"
 	set src in usr
-	
+
 	if(usr.stat == DEAD)
 		usr << "You can't do that because you are dead!"
 		return
@@ -56,7 +56,7 @@
 	set category = "AI IM"
 	set name = "Toggle Sender/Receiver"
 	set src in usr
-	
+
 	if(usr.stat == DEAD)
 		usr << "You can't do that because you are dead!"
 		return
@@ -69,13 +69,13 @@
 	set category = "AI IM"
 	set name = "Toggle Ringer"
 	set src in usr
-	
+
 	if(usr.stat == DEAD)
 		usr << "You can't do that because you are dead!"
 		return
 	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
-	M.silent = !M.silent
-	usr << "<span class='notice'>PDA ringer toggled [(M.silent ? "Off" : "On")]!</span>"
+	M.notify_silent = !M.notify_silent
+	usr << "<span class='notice'>PDA ringer toggled [(M.notify_silent ? "Off" : "On")]!</span>"
 
 /obj/item/device/pda/ai/can_use()
 	return 1

--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -1,6 +1,8 @@
 // Base class for anything that can show up on home screen
 /datum/data/pda
 	var/icon = "tasks"
+	var/notify_icon = "exclamation-circle"
+	var/notify_silent = 0
 	var/hidden = 0				// program not displayed in main menu
 	var/category = "General"	// the category to list it in on the main menu
 	var/obj/item/device/pda/pda	// if this is null, and the app is running code, something's gone wrong
@@ -11,6 +13,35 @@
 
 /datum/data/pda/proc/start()
 
+/datum/data/pda/proc/notify(message, blink = 1)
+	if(message)
+		//Search for holder of the PDA.
+		var/mob/living/L = null
+		if(pda.loc && isliving(pda.loc))
+			L = pda.loc
+		//Maybe they are a pAI!
+		else
+			L = get(pda, /mob/living/silicon)
+
+		if(L)
+			L << "\icon[pda] [message]"
+			nanomanager.update_user_uis(L, pda) // Update the receiving user's PDA UI so that they can see the new message
+
+	if(!notify_silent)
+		pda.play_ringtone()
+
+	if(blink && !(src in pda.notifying_programs))
+		pda.overlays.Cut()
+		pda.overlays += image('icons/obj/pda.dmi', "pda-r")
+		pda.notifying_programs |= src
+
+/datum/data/pda/proc/unnotify()
+	if(src in pda.notifying_programs)
+		pda.notifying_programs -= src
+		if(!pda.notifying_programs.len)
+			pda.overlays.Cut()
+
+/datum/data/pda/proc/
 
 // An app has a button on the home screen and its own UI
 /datum/data/pda/app

--- a/code/modules/pda/chatroom.dm
+++ b/code/modules/pda/chatroom.dm
@@ -1,16 +1,252 @@
-var/list/chatrooms = list()
+var/list/chatrooms = list(new /datum/chatroom("General Discussion"))
 
 /datum/chatroom
 	var/name = "Generic Chatroom"
-	var/list/logged_in = list()
+	var/list/users = list()
+	var/list/invites = list()
 	var/list/logs = list() // chat logs
-	var/list/banned = list() // banned users
-	var/list/whitelist = list() // whitelisted users
-	var/list/muted = list()
-	var/topic = "" // topic message for the chatroom
-	var/password = "" // blank for no password.
-	var/operator = "" // name of the operator
+	var/topic = "Discussion" // topic message for the chatroom
+	var/is_public = 1
+	var/announcer = "CyberiadAI"
 
-/datum/chatroom/proc/attempt_connect(var/obj/item/device/pda/device, var/obj/password)
-	if(!device)
+/datum/chatroom/New(n)
+	name = n
+
+/datum/chatroom/proc/post(user, message, username)
+	if(!user || !message)
 		return
+
+	if(!username)
+		if(istype(user, /datum/data/pda/app/chatroom))
+			var/datum/data/pda/app/chatroom/c = user
+			if(!c.pda.owner)
+				return
+			username = c.pda.owner
+		else
+			return
+
+	logs += list(list(username = username, message = message))
+
+	for(var/datum/data/pda/app/chatroom/u in users)
+		if(!u.toff && user != u)
+			u.notify("<b>Post from [username] in #[name], </b>\"[message]\" (<a href='?src=\ref[u];choice=Post;target=\ref[src]'>Post</a>)")
+
+/datum/chatroom/proc/announce(user, message)
+	post(user, "<span class='average'>[message]</span>", announcer)
+
+/datum/chatroom/proc/login(datum/data/pda/app/chatroom/user)
+	if(!user || !user.pda.owner)
+		return 0
+
+	if(user in users)
+		return 1
+
+	if(!is_public && !(user in invites))
+		return 0
+
+	users += user
+	announce(user, "[user.pda.owner] has entered #[name].")
+	return 1
+
+/datum/chatroom/proc/logout(datum/data/pda/app/chatroom/user)
+	if(!user || !user.pda.owner || !(user in users))
+		return
+
+	users -= user
+	invites -= user
+	announce(user, "[user.pda.owner] has left #[name].")
+
+/datum/data/pda/app/chatroom
+	name = "Chatbuddy"
+	icon = "hashtag"
+	notify_icon = "comments"
+	template = "pda_chatroom"
+	var/toff = 0
+	var/datum/chatroom/current_room = null
+	var/inviting = 0
+	var/channels_created = 0
+	var/max_channels_created = 3
+	var/latest_post = 0
+	var/auto_scroll = 1
+
+/datum/data/pda/app/chatroom/start()
+	. = ..()
+	unnotify()
+	latest_post = 0
+
+/datum/data/pda/app/chatroom/update_ui(mob/user as mob, list/data)
+	data["silent"] = notify_silent
+	data["toff"] = toff
+	if(!messaging_available())
+		data["no_server"] = 1
+		has_back = 0
+	else if(current_room)
+		data["room"] = current_room.name
+		data["topic"] = current_room.topic
+		if(inviting)
+			data["inviting"] = 1
+			var/list/pdas = list()
+			for(var/A in PDAs)
+				var/obj/item/device/pda/P = A
+				var/datum/data/pda/app/chatroom/C = P.find_program(/datum/data/pda/app/chatroom)
+				var/datum/data/pda/app/messenger/PM = P.find_program(/datum/data/pda/app/messenger)
+
+				if (!P.owner || P == pda || PM.m_hidden || (C in current_room.invites) || (C in current_room.users))
+					continue
+				pdas += list(list(name = "[P.owner] ([P.ownjob])", ref = "\ref[C]"))
+			data["people"] = pdas
+		else
+			data["history"] = current_room.logs
+			var/list/users[0]
+			for(var/U in current_room.users)
+				var/datum/data/pda/app/chatroom/ch = U
+				users += "<span class='good'>[ch.pda.owner]</span>"
+			for(var/U in (current_room.invites - current_room.users))
+				var/datum/data/pda/app/chatroom/ch = U
+				users += "<span class='average'>[ch.pda.owner]</span>"
+			data["users"] = users
+			data["auto_scroll"] = auto_scroll
+			data["latest_post"] = latest_post
+			latest_post = current_room.logs.len
+		has_back = 1
+	else
+		var/list/rooms[0]
+		for(var/datum/chatroom/c in chatrooms)
+			if((src in c.users) || (src in c.invites) || c.is_public)
+				rooms += list(list(name = "[c]", ref = "\ref[c]"))
+		data["rooms"] = rooms
+		has_back = 0
+
+/datum/data/pda/app/chatroom/proc/messaging_available()
+	if(message_servers)
+		for(var/A in message_servers)
+			var/obj/machinery/message_server/MS = A
+			if(MS.active)
+				return 1
+	return 0
+
+/datum/data/pda/app/chatroom/proc/check_messaging_available()
+	. = messaging_available()
+	if(!.)
+		usr << "<span class='notice'>ERROR: Messaging server is not responding.</span>"
+
+/datum/data/pda/app/chatroom/Topic(href, list/href_list)
+	unnotify()
+
+	switch(href_list["choice"])
+		if("Toggle Chatroom")
+			toff = !toff
+		if("Toggle Ringer")
+			notify_silent = !notify_silent
+		if("Back")
+			if(inviting)
+				inviting = 0
+			else
+				current_room = null
+				latest_post = 0
+		if("Join")
+			if(!check_messaging_available())
+				return
+
+			if(href_list["room"])
+				current_room = locate(href_list["room"])
+			if(!(src in current_room.users))
+				if(!current_room.login(src))
+					current_room = null
+			latest_post = 0
+		if("Post")
+			if(!check_messaging_available())
+				return
+
+			var/datum/chatroom/target
+			if(href_list["target"])
+				target = locate(href_list["target"])
+			else
+				target = current_room
+
+			if(!target)
+				return
+
+			var/t = input("Please enter message", target) as text|null
+			if(!t)
+				return
+			t = sanitize(copytext(t, 1, MAX_MESSAGE_LEN))
+			t = readd_quotes(t)
+			if (!t || (!in_range(pda, usr) && pda.loc != usr))
+				return
+
+			target.post(src, t)
+		if("Topic")
+			if(!check_messaging_available() || !current_room)
+				return
+
+			var/t = input("Enter new topic:", current_room, current_room.topic) as text|null
+			if(!t)
+				return
+			t = sanitize(copytext(t, 1, MAX_MESSAGE_LEN))
+			t = readd_quotes(t)
+			if (!t || (!in_range(pda, usr) && pda.loc != usr))
+				return
+
+			current_room.topic = t
+			current_room.announce(src, "Topic has been changed to '[t]' by [pda.owner].")
+		if("Leave")
+			if(!current_room)
+				return
+
+			current_room.logout(src)
+			current_room = null
+			latest_post = 0
+		if("Invite")
+			if(!check_messaging_available() || !current_room)
+				return
+
+			inviting = 1
+		if("Invite PDA")
+			if(!check_messaging_available() || !current_room || !href_list["user"])
+				return
+
+			var/datum/data/pda/app/chatroom/C = locate(href_list["user"])
+			if(C)
+				current_room.invites += C
+				if(!C.toff)
+					C.notify("<b>Invite to #[current_room]</b> (<a href='?src=\ref[C];choice=Join;room=\ref[current_room]'>Join</a>)")
+		if("New Room")
+			if(!check_messaging_available())
+				return
+
+			if(channels_created >= max_channels_created)
+				alert("This PDA has already reached its maximum channels created.", name)
+				return
+
+			var/t = input("Enter room name:", name) as text|null
+			if(!t)
+				return
+			t = sanitize(copytext(t, 1, MAX_NAME_LEN))
+			t = readd_quotes(t)
+
+			var/access = input("Room access?", current_room) as null|anything in list("Public", "Private")
+			if(!access)
+				return
+
+			if (!t || (!in_range(pda, usr) && pda.loc != usr))
+				return
+
+			// check if already taken
+			for(var/datum/chatroom/C in chatrooms)
+				if(C.name == t)
+					alert("Channel with that name already exists.", name)
+					return
+
+			channels_created++
+			current_room = new /datum/chatroom(t)
+			chatrooms += current_room
+			latest_post = 0
+
+			current_room.invites += src
+			current_room.is_public = access == "Public"
+			current_room.login(src)
+			if(!current_room.is_public)
+				current_room.announce(src, "Users must be invited to join this room.")
+		if("Autoscroll")
+			auto_scroll = !auto_scroll

--- a/code/modules/pda/core_apps.dm
+++ b/code/modules/pda/core_apps.dm
@@ -11,6 +11,11 @@
 	data["apps"] = pda.shortcut_cache
 	data["categories"] = pda.shortcut_cat_order
 	data["pai"] = !isnull(pda.pai)				// pAI inserted?
+	
+	var/list/notifying[0]
+	for(var/P in pda.notifying_programs)
+		notifying["\ref[P]"] = 1
+	data["notifying"] = notifying
 
 /datum/data/pda/app/main_menu/Topic(href, list/href_list)
 	switch(href_list["choice"])

--- a/code/modules/pda/messenger.dm
+++ b/code/modules/pda/messenger.dm
@@ -1,82 +1,76 @@
 /datum/data/pda/app/messenger
 	name = "Messenger"
 	icon = "comments-o"
-	title = "SpaceMessenger V4.0.1"
+	notify_icon = "comments"
+	title = "SpaceMessenger V4.1.0"
 	template = "pda_messenger"
 
-	var/silent = 0 //To beep or not to beep, that is the question
 	var/toff = 0 //If 1, messenger disabled
 	var/list/tnote[0]  //Current Texts
 	var/last_text //No text spamming
-	var/list/ttone_sound = list("beep" = 'sound/machines/twobeep.ogg',
-								"boom" = 'sound/effects/explosionfar.ogg',
-								"slip" = 'sound/misc/slip.ogg',
-								"honk" = 'sound/items/bikehorn.ogg',
-								"SKREE" = 'sound/voice/shriek1.ogg',
-								"holy" = 'sound/items/PDA/ambicha4-short.ogg',
-								"xeno" = 'sound/voice/hiss1.ogg')
 
 	var/m_hidden = 0 // Is the PDA hidden from the PDA list?
 	var/active_conversation = null // New variable that allows us to only view a single conversation.
 	var/list/conversations = list()    // For keeping up with who we have PDA messsages from.
+	var/latest_post = 0
+	var/auto_scroll = 1
 
 /datum/data/pda/app/messenger/start()
 	. = ..()
-	set_new(0)
+	unnotify()
+	latest_post = 0
 
 /datum/data/pda/app/messenger/update_ui(mob/user as mob, list/data)
-	data["silent"] = silent								// does the pda make noise when it receives a message?
+	data["silent"] = notify_silent						// does the pda make noise when it receives a message?
 	data["toff"] = toff									// is the messenger function turned off?
 	data["active_conversation"] = active_conversation	// Which conversation are we following right now?
 
-	var/convopdas[0]
-	var/pdas[0]
-	var/count = 0
-	for(var/A in PDAs)
-		var/obj/item/device/pda/P = A
-		var/datum/data/pda/app/messenger/PM = P.find_program(/datum/data/pda/app/messenger)
-
-		if (!P.owner || PM.toff || P == pda || PM.m_hidden)
-			continue
-		if(conversations.Find("\ref[P]"))
-			convopdas.Add(list(list("Name" = "[P]", "Reference" = "\ref[P]", "Detonate" = "[P.detonate]", "inconvo" = "1")))
-		else
-			pdas.Add(list(list("Name" = "[P]", "Reference" = "\ref[P]", "Detonate" = "[P.detonate]", "inconvo" = "0")))
-		count++
-
-	data["convopdas"] = convopdas
-	data["pdas"] = pdas
-	data["pda_count"] = count
-
-	data["messagescount"] = tnote.len
-	data["messages"] = tnote
-
 	has_back = active_conversation
 	if(active_conversation)
+		data["messages"] = tnote
 		for(var/c in tnote)
 			if(c["target"] == active_conversation)
 				data["convo_name"] = sanitize(c["owner"])
 				data["convo_job"] = sanitize(c["job"])
 				break
+		data["auto_scroll"] = auto_scroll
+		data["latest_post"] = latest_post
+		latest_post = tnote.len
+	else
+		var/convopdas[0]
+		var/pdas[0]
+		for(var/A in PDAs)
+			var/obj/item/device/pda/P = A
+			var/datum/data/pda/app/messenger/PM = P.find_program(/datum/data/pda/app/messenger)
 
-	var/list/plugins = list()
-	if(pda.cartridge)
-		for(var/A in pda.cartridge.messenger_plugins)
-			var/datum/data/pda/messenger_plugin/P = A
-			plugins += list(list(name = P.name, icon = P.icon, ref = "\ref[P]"))
-	data["plugins"] = plugins
+			if (!P.owner || PM.toff || P == pda || PM.m_hidden)
+				continue
+			if(conversations.Find("\ref[P]"))
+				convopdas.Add(list(list("Name" = "[P]", "Reference" = "\ref[P]", "Detonate" = "[P.detonate]", "inconvo" = "1")))
+			else
+				pdas.Add(list(list("Name" = "[P]", "Reference" = "\ref[P]", "Detonate" = "[P.detonate]", "inconvo" = "0")))
 
-	if(pda.cartridge)
-		data["charges"] = pda.cartridge.charges ? pda.cartridge.charges : 0
+		data["convopdas"] = convopdas
+		data["pdas"] = pdas
+
+		var/list/plugins = list()
+		if(pda.cartridge)
+			for(var/A in pda.cartridge.messenger_plugins)
+				var/datum/data/pda/messenger_plugin/P = A
+				plugins += list(list(name = P.name, icon = P.icon, ref = "\ref[P]"))
+		data["plugins"] = plugins
+
+		if(pda.cartridge)
+			data["charges"] = pda.cartridge.charges ? pda.cartridge.charges : 0
 
 /datum/data/pda/app/messenger/Topic(href, list/href_list)
-	set_new(0)
+	unnotify()
 
 	switch(href_list["choice"])
 		if("Toggle Messenger")
 			toff = !toff
 		if("Toggle Ringer")//If viewing texts then erase them, if not then toggle silent status
-			silent = !silent
+			notify_silent = !notify_silent
 		if("Clear")//Clears messages
 			if(href_list["option"] == "All")
 				tnote.Cut()
@@ -90,29 +84,19 @@
 				conversations.Remove(active_conversation)
 
 			active_conversation = null
-		if("Ringtone")
-			var/t = input("Please enter new ringtone", name, pda.ttone) as text
-			if (in_range(pda, usr) && pda.loc == usr)
-				if (t)
-					if(pda.hidden_uplink && pda.hidden_uplink.check_trigger(usr, lowertext(t), lowertext(pda.lock_code)))
-						usr << "The PDA softly beeps."
-						pda.close(usr)
-					else
-						t = sanitize(copytext(t, 1, 20))
-						pda.ttone = t
-			else
-				pda.close(usr)
-				return 0
+			latest_post = 0
 		if("Message")
 			var/obj/item/device/pda/P = locate(href_list["target"])
 			create_message(usr, P)
 			if(href_list["target"] in conversations)            // Need to make sure the message went through, if not welp.
 				active_conversation = href_list["target"]
+				latest_post = 0
 		if("Select Conversation")
 			var/P = href_list["convo"]
 			for(var/n in conversations)
 				if(P == n)
 					active_conversation = P
+					latest_post = 0
 		if("Messenger Plugin")
 			if(!href_list["target"] || !href_list["plugin"])
 				return
@@ -122,30 +106,14 @@
 				usr << "PDA not found."
 
 			var/datum/data/pda/messenger_plugin/plugin = locate(href_list["plugin"])
-			if(plugin && plugin in pda.cartridge.messenger_plugins)
+			if(plugin && (plugin in pda.cartridge.messenger_plugins))
 				plugin.messenger = src
 				plugin.user_act(usr, P)
 		if("Back")
 			active_conversation = null
-
-/datum/data/pda/app/messenger/proc/set_new(isnew)
-	if(pda.newmessage == isnew)
-		return
-
-	if(pda.newmessage)
-		//To clear message overlays.
-		pda.overlays.Cut()
-		pda.newmessage = 0
-
-		icon = "comments"
-		pda.update_shortcuts()
-	else
-		pda.overlays.Cut()
-		pda.overlays += image('icons/obj/pda.dmi', "pda-r")
-		pda.newmessage = 1
-
-		icon = "comments-o"
-		pda.update_shortcuts()
+			latest_post = 0
+		if("Autoscroll")
+			auto_scroll = !auto_scroll
 
 /datum/data/pda/app/messenger/proc/create_message(var/mob/living/U, var/obj/item/device/pda/P)
 	var/t = input(U, "Please enter message", name, null) as text|null
@@ -207,38 +175,11 @@
 		if(!PM.conversations.Find("\ref[pda]"))
 			PM.conversations.Add("\ref[pda]")
 
-		PM.play_ringtone()
-		//Search for holder of the PDA.
-		var/mob/living/L = null
-		if(P.loc && isliving(P.loc))
-			L = P.loc
-		//Maybe they are a pAI!
-		else
-			L = get(P, /mob/living/silicon)
-
-
-		if(L)
-			L << "\icon[P] <b>Message from [pda.owner] ([pda.ownjob]), </b>\"[t]\" (<a href='byond://?src=\ref[PM];choice=Message;target=\ref[pda]'>Reply</a>)"
-			nanomanager.update_user_uis(L, P) // Update the receiving user's PDA UI so that they can see the new message
-
 		nanomanager.update_user_uis(U, P) // Update the sending user's PDA UI so that they can see the new message
-		set_new(1)
+		PM.notify("<b>Message from [pda.owner] ([pda.ownjob]), </b>\"[t]\" (<a href='?src=\ref[PM];choice=Message;target=\ref[pda]'>Reply</a>)")
 		log_pda("[usr] (PDA: [src.name]) sent \"[t]\" to [P.name]")
 	else
 		U << "<span class='notice'>ERROR: Messaging server is not responding.</span>"
-
-/datum/data/pda/app/messenger/proc/play_ringtone()
-	if (!silent)
-		var/S
-
-		if(pda.ttone in ttone_sound)
-			S = ttone_sound[pda.ttone]
-		else
-			S = 'sound/machines/twobeep.ogg'
-		playsound(pda.loc, S, 50, 1)
-	for(var/mob/O in hearers(3, pda.loc))
-		if(!silent)
-			O.show_message(text("\icon[pda] *[pda.ttone]*"))
 
 /datum/data/pda/app/messenger/proc/available_pdas()
 	var/list/names = list()

--- a/code/modules/pda/messenger_plugins.dm
+++ b/code/modules/pda/messenger_plugins.dm
@@ -34,10 +34,13 @@
 	. = ..(user, P)
 	if(.)
 		user.show_message("<span class=notice>Virus sent!</span>", 1)
-		var/datum/data/pda/app/messenger/M = P.find_program(/datum/data/pda/app/messenger)
+		var/datum/data/pda/app/M = P.find_program(/datum/data/pda/app/messenger)
 		if(M)
-			M.silent = 1
-			P.ttone = "silence"
+			M.notify_silent = 1
+		M = P.find_program(/datum/data/pda/app/chatroom)
+		if(M)
+			M.notify_silent = 1
+		P.ttone = "silence"
 
 
 /datum/data/pda/messenger_plugin/virus/detonate

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -50,9 +50,12 @@
 
 /obj/item/device/pda/mime/New()
 	..()
-	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
+	var/datum/data/pda/app/M = find_program(/datum/data/pda/app/messenger)
 	if(M)
-		M.silent = 1
+		M.notify_silent = 1
+	M = find_program(/datum/data/pda/app/chatroom)
+	if(M)
+		M.notify_silent = 1
 
 /obj/item/device/pda/heads
 	default_cartridge = /obj/item/weapon/cartridge/head
@@ -142,9 +145,12 @@
 
 /obj/item/device/pda/librarian/New()
 	..()
-	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
+	var/datum/data/pda/app/M = find_program(/datum/data/pda/app/messenger)
 	if(M)
-		M.silent = 1 //Quiet in the library!
+		M.notify_silent = 1 //Quiet in the library!
+	M = find_program(/datum/data/pda/app/chatroom)
+	if(M)
+		M.notify_silent = 1 //Quiet in the library!
 
 /obj/item/device/pda/clear
 	icon_state = "pda-transp"

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -27,6 +27,10 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 				color: #222222;
 			}
 			
+			.bad {
+				color: #333333;
+			}
+			
 			.pdanote {
 				color: #777777;
 			}

--- a/nano/templates/pda_chatroom.tmpl
+++ b/nano/templates/pda_chatroom.tmpl
@@ -1,0 +1,84 @@
+<!--
+Title: PDA Chatroom UI
+Used In File(s): \code\game\objects\items\devices\PDA\chatroom.dm
+ -->
+<div id="chatroom-header" class="item">
+	<div class="itemLabelNarrow">
+		<b>Chat Functions</b>:
+	</div>
+	<div class ="itemContent">
+		{{:helper.link(data.silent==1 ? 'Ringer: Off' : 'Ringer: On', data.silent==1 ? 'volume-off' : 'volume-up', {'choice' : "Toggle Ringer"}, null, 'pdalink fixedLeftWide')}}
+		{{:helper.link(data.toff==1 ? 'Notifications: Off' : 'Notifications: On',data.toff==1 ? 'close' : 'check', {'choice' : "Toggle Chatroom"}, null, 'pdalink fixedLeftWide')}}
+		{{:helper.link('Set Ringtone', 'bell-o', {'choice' : "Ringtone"}, null, 'pdalink fixedLeftWide')}}
+		{{:helper.link('New Room', 'plus', {'choice' : "New Room"}, null, 'pdalink fixedLeftWide')}}
+	</div>
+</div>
+
+<div id="chatroom-body">
+	{{if data.no_server}}
+		<h3 class="bad">ERROR: Messaging server is not responding.</h3>
+	{{else data.room}}
+		{{if data.inviting}}
+			<h3>Invite whom to #{{:data.room}}?</h3>
+			{{for data.people}}
+				{{:helper.link(value.name, 'user-plus', {'choice': "Invite PDA", 'user': value.ref}, null, 'pdalink fixedLeftWidest')}}
+			{{empty}}
+				<b>No other people found.</b>
+			{{/for}}
+		{{else}}
+			<h3>#{{:data.room}}&nbsp;&ndash;&nbsp;<span class="average">{{:data.topic}}</span></h3>
+			<div class="item">
+				<div class="itemLabelNarrow">
+					<b>Room Functions</b>:
+				</div>
+				<div class="itemContent">
+					{{:helper.link('Invite', 'user-plus', {'choice' : "Invite"}, null, 'pdalink fixedLeftWide')}}
+					{{:helper.link('Change Topic', 'tag', {'choice' : "Topic"}, null, 'pdalink fixedLeftWide')}}
+					{{:helper.link('Leave Channel', 'user-times', {'choice' : "Leave"}, null, 'pdalink fixedLeftWide')}}
+					{{:helper.link(data.auto_scroll ? 'Autoscroll: On' : 'Autoscroll: Off', 'level-down', {'choice' : "Autoscroll"}, null, 'pdalink fixedLeftWide')}}
+				</div>
+			</div>
+			<div style="width: 75%; float: right; margin-left: 1em">
+				<div id="historyView" class="statusDisplay">
+					{{var prevName = "";}}
+					{{for data.history}}
+						<div class="item">
+							<div class="itemLabelNarrow">{{:value.username!=prevName ? value.username : "&nbsp;"}}</div>
+							<div class="itemContent">
+									{{:value.message}}
+							</div>
+						</div>
+						{{prevName = value.username;}}
+					{{/for}}
+				</div>
+				<div>
+					{{:helper.link('Post', 'comment', {'choice' : "Post"}, null, 'pdalink fixedLeftWidest')}}
+				</div>
+			</div>
+			<div id="userView" class="statusDisplay">
+				{{for data.users}}
+					<div class="item">
+						<div class="itemLabel" style="width: 100%">{{:value}}</div>
+					</div>
+				{{/for}}
+			</div>
+			<script>
+				$(function() {
+					{{if data.auto_scroll && data.latest_post != data.history.length}}
+						var body = document.body;
+						$('html,body').animate({scrollTop: body.scrollHeight}, "fast");
+					{{/if}}
+				});
+			</script>
+		{{/if}}
+	{{else}}
+		<h3>Rooms</h3>
+		{{for data.rooms}}
+			<div class="item">
+				{{:helper.link(value.name, 'arrow-circle-down', {'choice' : "Join", 'room' : value.ref}, null, 'pdalink fixedLeftWidest')}}
+			</div>
+		{{empty}}
+			<b>No rooms located.</b>
+		{{/for}}
+	{{/if}}
+</div>

--- a/nano/templates/pda_chatroom.tmpl
+++ b/nano/templates/pda_chatroom.tmpl
@@ -7,8 +7,8 @@ Used In File(s): \code\game\objects\items\devices\PDA\chatroom.dm
 		<b>Chat Functions</b>:
 	</div>
 	<div class ="itemContent">
-		{{:helper.link(data.silent==1 ? 'Ringer: Off' : 'Ringer: On', data.silent==1 ? 'volume-off' : 'volume-up', {'choice' : "Toggle Ringer"}, null, 'pdalink fixedLeftWide')}}
-		{{:helper.link(data.toff==1 ? 'Notifications: Off' : 'Notifications: On',data.toff==1 ? 'close' : 'check', {'choice' : "Toggle Chatroom"}, null, 'pdalink fixedLeftWide')}}
+		{{:helper.link(data.silent == 1 ? 'Ringer: Off' : 'Ringer: On', data.silent == 1 ? 'volume-off' : 'volume-up', {'choice' : "Toggle Ringer"}, null, 'pdalink fixedLeftWide')}}
+		{{:helper.link(data.toff == 1 ? 'Notifications: Off' : 'Notifications: On',data.toff == 1 ? 'close' : 'check', {'choice' : "Toggle Chatroom"}, null, 'pdalink fixedLeftWide')}}
 		{{:helper.link('Set Ringtone', 'bell-o', {'choice' : "Ringtone"}, null, 'pdalink fixedLeftWide')}}
 		{{:helper.link('New Room', 'plus', {'choice' : "New Room"}, null, 'pdalink fixedLeftWide')}}
 	</div>

--- a/nano/templates/pda_main_menu.tmpl
+++ b/nano/templates/pda_main_menu.tmpl
@@ -2,6 +2,25 @@
 Title: PDA Home UI
 Used In File(s): \code\game\objects\items\devices\PDA\core_apps.dm
  -->
+
+<script>
+	/* flash notify icons */
+	var notifications = [];
+	var noteTimer;
+	function mm_flashNotify() {
+		notifications.forEach(function(n) {
+			if(n.item.hasClass("fa-"+n.icon)) {
+				n.item.removeClass("fa-"+n.icon).addClass("fa-"+n.notifyIcon);
+			} else {
+				n.item.removeClass("fa-"+n.notifyIcon).addClass("fa-"+n.icon);
+			}
+		});
+	}
+	if(!noteTimer) {
+		noteTimer = window.setInterval(mm_flashNotify, 1000);
+	}
+</script>
+
 <div class="item">
 	<div class="itemLabelNarrow">
 		Owner:
@@ -29,7 +48,16 @@ Used In File(s): \code\game\objects\items\devices\PDA\core_apps.dm
 		</div>
 		<div class="itemContent">
 			{{for data.apps[cat]}}
-				{{:helper.link(value.name, value.icon, {'choice' : "StartProgram", 'program' : value.ref}, null, 'pdalink fixedLeftWide')}}
+				{{if value.ref in data.notifying}}
+					<div data-notify="{{:value.ref}}">
+						{{:helper.link(value.name, value.notify_icon, {'choice' : "StartProgram", 'program' : value.ref}, null, 'pdalink fixedLeftWide')}}
+					</div>
+					<script>
+						notifications.push({item: $("[data-notify='{{:value.ref}}'] i"), icon: '{{:value.icon}}', notifyIcon: '{{:value.notify_icon}}'});
+					</script>
+				{{else}}
+					{{:helper.link(value.name, value.icon, {'choice' : "StartProgram", 'program' : value.ref}, null, 'pdalink fixedLeftWide')}}
+				{{/if}}
 			{{/for}}
 		</div>
 	</div>

--- a/nano/templates/pda_messenger.tmpl
+++ b/nano/templates/pda_messenger.tmpl
@@ -9,6 +9,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\core_apps.dm
 		</div>
 		<div class ="itemContent">
 			{{:helper.link('Delete Conversation', 'trash', {'choice' : "Clear", 'option' : "Convo"}, null, 'pdalink fixedLeftWide')}}
+			{{:helper.link(data.auto_scroll ? 'Autoscroll: On' : 'Autoscroll: Off', 'level-down', {'choice' : "Autoscroll"}, null, 'pdalink fixedLeftWide')}}
 		</div>
 	</div>
 	<br>
@@ -29,7 +30,15 @@ Used In File(s): \code\game\objects\items\devices\PDA\core_apps.dm
 			</div>
 		</div>
 	</div>
-	{{:helper.link('Reply', 'comment', {'choice' : "Message", 'target': data.active_conversation}, null, 'pdalink fixedLeft')}}
+	{{:helper.link('Reply', 'comment', {'choice' : "Message", 'target': data.active_conversation}, null, 'pdalink fixedLeftWidest')}}
+	<script>
+		$(function() {
+			{{if data.auto_scroll && data.latest_post != data.messages.length}}
+				var body = document.body;
+				$('html,body').animate({scrollTop: body.scrollHeight}, "fast");
+			{{/if}}
+		});
+	</script>
 {{else}}
 	<div class="item">
 		<div class="itemLabelNarrow">
@@ -38,7 +47,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\core_apps.dm
 		<div class ="itemContent">
 			{{:helper.link(data.silent==1 ? 'Ringer: Off' : 'Ringer: On', data.silent==1 ? 'volume-off' : 'volume-up', {'choice' : "Toggle Ringer"}, null, 'pdalink fixedLeftWide')}}
 			{{:helper.link(data.toff==1 ? 'Messenger: Off' : 'Messenger: On',data.toff==1 ? 'close':'check', {'choice' : "Toggle Messenger"}, null, 'pdalink fixedLeftWide')}}
-			{{:helper.link('Set Ringtone', 'comment', {'choice' : "Ringtone"}, null, 'pdalink fixedLeftWide')}}
+			{{:helper.link('Set Ringtone', 'bell-o', {'choice' : "Ringtone"}, null, 'pdalink fixedLeftWide')}}
 			{{:helper.link('Delete all Conversations', 'trash', {'choice' : "Clear", 'option' : "All"}, null, 'pdalink fixedLeftWider')}}
 		</div>
 	</div>
@@ -51,7 +60,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\core_apps.dm
 			</div>
 		{{/if}}
 
-		{{if data.pda_count == 0}}
+		{{if !data.convopdas.length && !data.pdas.length}}
 			<b>No other PDAS located</b>
 		{{else}}
 			<H3>Current Conversations</H3>


### PR DESCRIPTION
I actually wanted to add this before, but then there was a suggestion thread, so I implemented it.
- You can have public channels everyone can see and join!
- You can have private channels that are invite-only!
 - Command can spy on either one via the messaging server terminal thing, so be careful what you say.
- Channels can have topics.
- People who have joined the channel (you can permanently leave them) will be notified of posts or other events via notifications in chat, like with Messenger messages. You can turn this feature off if people are being spammy.
 - You are also notified of channel invites.
- You can choose to make the chat UI automatically scroll to new messages or not.
 - This feature was also added to Messenger.
- Refactored PDA notifications so that any app can blink the PDA / play ringtones / etc.
- App icons now blink in the main menu when they notify.

### Screenshots
![Imgur](http://i.imgur.com/HOnf3NS.png)
![Imgur](http://i.imgur.com/U6iznvw.png)
![Imgur](http://i.imgur.com/Chx30tp.png)

### Changelog
:cl:
rscadd: Adds PDA chatrooms. Post memes! Talk to your fellow collaborators! Get caught!
tweak: You can now set the PDA messenger to automatically scroll down to new messages.
/:cl: