### PR TITLE
Fix my broken ass allowed() proc

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -118,8 +118,8 @@
 	if(acc == IGNORE_ACCESS)
 		return 1 //Mob ignores access
 
-	if(istype(acc, /obj/item))
-		return check_access(acc)
+	else
+		return check_access_list(acc)
 
 	return 0
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -816,8 +816,8 @@ so that different stomachs can handle things in different ways VB*/
 				toEat.reagents.trans_to(src, toEat.reagents.total_volume*toEat.transfer_efficiency)
 
 /mob/living/carbon/get_access()
-	var/obj/item/I = get_active_hand()
-	if(istype(I))
-		return I
+	. = ..()
 
-	return null
+	var/obj/item/I = get_active_hand()
+	if(I)
+		. |= I.GetAccess()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1929,7 +1929,7 @@
 	return 1.0 + 0.5*(30 - age)/80
 
 /mob/living/carbon/human/get_access()
-	. = ..() //objects in hand
-	if(!. && wear_id) //nothing in hand, try ID
-		return wear_id
-	//otherwise return hand/nothing
+	. = ..()
+
+	if(wear_id)
+		. |= wear_id.GetAccess()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1454,4 +1454,4 @@ mob/proc/yank_out_object()
 	return 1
 
 /mob/proc/get_access()
-	return null //must return either IGNORE_ACCESS or an /obj/item
+	return list() //must return list or IGNORE_ACCESS


### PR DESCRIPTION
mob.get_access() now returns a list of all the accesses a mob has in X
slots
.... basically it behaves the same as it used to.

@FalseIncarnate yes I could make a borg return get_absolutely_all_accesses() instead of the IGNORE_ACCESS flag, but I don't want to so there