### PR TITLE
Fixes Xeno Hive Node Languages

### DIFF
--- a/code/modules/surgery/organs/subtypes/xenos.dm
+++ b/code/modules/surgery/organs/subtypes/xenos.dm
@@ -133,9 +133,13 @@
 /obj/item/organ/internal/xenos/hivenode/insert(mob/living/carbon/M, special = 0)
 	..()
 	M.faction |= "alien"
+	M.add_language("Hivemind")
+	M.add_language("Xenomorph")
 
 /obj/item/organ/internal/xenos/hivenode/remove(mob/living/carbon/M, special = 0)
 	M.faction -= "alien"
+	M.remove_language("Hivemind")
+	M.remove_language("Xenomorph")
 	..()
 
 /obj/item/organ/internal/xenos/neurotoxin


### PR DESCRIPTION
Just an oversight in the organs overhaul PR, likely missed because of how much different TG handles languages than we do.

- Ensures that those with the hive node organ can properly speak Xeno common and speak over the hivemind.

:cl: Fox McCloud
fix: Fixes not being able to speak over xeno common or hivemind when you receive the Xeno hive node
/:cl: