### PR TITLE
Design Transfer Blueprints Protolathe->Autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -43,7 +43,8 @@
 							"Medical",
 							"Miscellaneous",
 							"Security",
-							"Tools"
+							"Tools",
+							"Imported"
 							)
 
 /obj/machinery/autolathe/New()
@@ -127,6 +128,18 @@
 			return 1
 	if (stat)
 		return 1
+
+	if(istype(O, /obj/item/weapon/disk/design_disk))
+		user.visible_message("[user] begins to load \the [O] in \the [src]...",
+			"You begin to load a design from \the [O]...",
+			"You hear the chatter of a floppy drive.")
+		busy = 1
+		var/obj/item/weapon/disk/design_disk/D = O
+		if(do_after(user, 14.4, target = src))
+			files.AddDesign2Known(D.blueprint)
+
+		busy = 0
+		return
 
 	var/material_amount = materials.get_item_material_amount(O)
 	if(!material_amount)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -246,6 +246,17 @@ proc/CallMaterialName(ID)
 	else if(href_list["copy_design"]) //Copy design data from the research holder to the design disk.
 		for(var/datum/design/D in files.known_designs)
 			if(href_list["copy_design_ID"] == D.id)
+				var/autolathe_friendly = 1
+				for(var/x in D.materials)
+					if( !(x in list(MAT_METAL, MAT_GLASS)))
+						autolathe_friendly = 0
+						D.category -= "Imported"
+				if(D.locked)
+					autolathe_friendly = 0
+					D.category -= "Imported"
+				if(D.build_type & (AUTOLATHE|PROTOLATHE|CRAFTLATHE)) // Specifically excludes circuit imprinter and mechfab
+					D.build_type = autolathe_friendly ? (D.build_type | AUTOLATHE) : D.build_type
+					D.category |= "Imported"
 				d_disk.blueprint = D
 				break
 		screen = 1.4


### PR DESCRIPTION
Adds the ability to transfer protolathe designs from disk to the autolathe. Port of: https://github.com/tgstation/-tg-station/pull/15349

This doesn't work for everything, it won't work for:

- Things that have something OTHER than metal/glass in the design (meaning if it requires mining materials, it's not going to transfer).
- Locked Designs (this only applies to a single design, the stun revolver, but obviously we don't want scientists walking around with them =p)

How do you do it?

- Simple, just upload a design to a component disk and use the disk on the autolathe. Simple as that.

:cl: Fox McCloud
add: Adds in the ability to transfer non-locked metal+glass only designs from the protolathe to autolathe
/:cl: