### PR TITLE
Fixes SDQL's CALL

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -91,7 +91,10 @@
 						// To stop any procs which sleep from executing slowly.
 						if(d)
 							if(hascall(d, v))
-								spawn() call(d, v)(arglist(args_list)) // Spawn in case the function sleeps.
+								var/list/arguments[0]
+								for(var/list/arg in args_list)
+									arguments += SDQL_expression(d, arg)
+								spawn() call(d, v)(arglist(arguments)) // Spawn in case the function sleeps.
 
 			if("delete")
 				for(var/datum/d in objs)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -397,16 +397,20 @@
 
 //call_function:	<function name> ['(' [arguments] ')']
 	call_function(i, list/node, list/arguments)
+		var/list/cur_argument = list()
 		if(length(tokenl(i)))
 			node += token(i++)
 			if(token(i) != "(")
 				parse_error("Expected ( but found '[token(i)]'")
 			else if(token(i + 1) != ")")
 				do
-					i = expression(i + 1, arguments)
+					i = expression(i + 1, cur_argument)
 					if(token(i) == ",")
+						arguments += list(cur_argument)
+						cur_argument = list()
 						continue
 				while(token(i) && token(i) != ")")
+				arguments += list(cur_argument)
 			else
 				i++
 		else


### PR DESCRIPTION
Fixes #3932 
It was broken in both the parsing and execution stage for the argument parsing.
You can now do, eg, 
```
SDQL2-query "CALL emote("scream") ON /mob/living/carbon/human
SDQL2-query "CALL emote("me", 1, "is a "+gender+" "+species.name) ON /mob/living/carbon/human
```