### PR TITLE
Adds src and usr to SDQL

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -367,6 +367,20 @@
 		v = object
 	else if(expression[start] == "usr")
 		v = usr
+	else if(expression[start] == "marked")
+		if(usr.client && usr.client.holder && usr.client.holder.marked_datum)
+			v = usr.client.holder.marked_datum
+		else
+			return null
+	else if(expression[start] == "\[" && start < expression.len)
+		if(lowertext(copytext(expression[start + 1], 1, 3)) != "0x")
+			usr << "<span class='danger'>Invalid ref syntax: [expression[start + 1]]</span>"
+			return null
+		v = locate("\[[expression[start + 1]]\]")
+		if(!v)
+			usr << "<span class='danger'>Invalid ref: [expression[start + 1]]</span>"
+			return null
+		start++
 	else
 		return null
 
@@ -378,7 +392,7 @@
 /proc/SDQL2_tokenize(query_text)
 
 	var/list/whitespace = list(" ", "\n", "\t")
-	var/list/single = list("(", ")", ",", "+", "-", ".", ";")
+	var/list/single = list("(", ")", ",", "+", "-", ".", ";", "\[", "\]")
 	var/list/multi = list(
 					"=" = list("", "="),
 					"<" = list("", "=", ">"),

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -360,17 +360,20 @@
 	return list("val" = val, "i" = i)
 
 /proc/SDQL_var(datum/object, list/expression, start = 1)
-
+	var/v
 	if(expression[start] in object.vars)
-
-		if(start < expression.len && expression[start + 1] == ".")
-			return SDQL_var(object.vars[expression[start]], expression[start + 2])
-
-		else
-			return object.vars[expression[start]]
-
+		v = object.vars[expression[start]]
+	else if(expression[start] == "src")
+		v = object
+	else if(expression[start] == "usr")
+		v = usr
 	else
 		return null
+
+	if(start < expression.len && expression[start + 1] == ".")
+		return SDQL_var(v, expression[start + 2])
+	else
+		return v
 
 /proc/SDQL2_tokenize(query_text)
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -25,7 +25,7 @@
 //
 //	assignments			:	assignment, [',' assignments]
 //	assignment			:	<variable name> '=' expression
-//	variable			:	<variable name> | <variable name> '.' variable
+//	variable			:	<variable name> | <variable name> '.' variable | '[' <hex number> ']' | '[' <hex number> ']' '.' variable
 //
 //	bool_expression		:	expression comparitor expression  [bool_operator bool_expression]
 //	expression			:	( unary_expression | '(' expression ')' | value ) [binary_operator expression]
@@ -336,6 +336,13 @@
 	variable(i, list/node)
 		var/list/L = list(token(i))
 		node[++node.len] = L
+		
+		if(token(i) == "\[")
+			L += token(i + 1)
+			i += 2
+
+			if(token(i) != "\]")
+				parse_error("Missing \] at end of reference.")
 
 		if(token(i + 1) == ".")
 			L += "."
@@ -519,7 +526,11 @@
 		if(token(i) == "null")
 			node += "null"
 			i++
-
+		
+		else if(lowertext(copytext(token(i), 1, 3)) == "0x" && isnum(hex2num(copytext(token(i), 3))))
+			node += hex2num(copytext(token(i), 3))
+			i++
+		
 		else if(isnum(text2num(token(i))))
 			node += text2num(token(i))
 			i++


### PR DESCRIPTION
Allows you to use src (the current object being acted on) and usr (usr) in SDQL.
```dm
SDQL2_query "UPDATE /mob SET loc = usr.loc
```
There is also marked (for the current marked datum in VV) and `\ref` style references, eg
```dm
SDQL2-query "UPDATE /mob SET name = [0x3000054].name WHERE src == marked
```
You can also use hex values (0xABCDEF) in general expressions now.
```dm
SDQL2-query "UPDATE /mob/living/carbon/human SET status_flags = 0x0F
```