### PR TITLE
ASAP Fix, Character Configuration - Prosthetic Typo

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1489,7 +1489,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 								if(second_limb)
 									organ_data[second_limb] = "amputated"
 									rlimb_data[second_limb] = null
-						if("Prothesis")
+						if("Prosthesis")
 							var/choice = input(user, "Which manufacturer do you wish to use for this limb?") as null|anything in chargen_robolimbs
 							if(!choice)
 								return


### PR DESCRIPTION
FUCK. I looked randomly and there it was. I knew there was something. I fixed a typo during my IPC-FBP port PR but I missed the other occurrence when I had to redo it the first time in order to resolve conflicts (the wrong way).

:cl:
fix: ASAP fix to what would've broken the ability to configure prostheses in character creation.
/:cl: