### PR TITLE
Shadowling Species Handling Refactor

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -1,3 +1,7 @@
+#define LIGHT_DAM_THRESHOLD 4
+#define LIGHT_HEAL_THRESHOLD 2
+#define LIGHT_DAMAGE_TAKEN 7
+
 /*
 
 SHADOWLING: A gamemode based on previously-run events
@@ -294,14 +298,34 @@ Made by Xhuis
 	icobase = 'icons/mob/human_races/r_shadowling.dmi'
 	deform = 'icons/mob/human_races/r_shadowling.dmi'
 
-	light_effect_amp = 1
 	blood_color = "#555555"
 	flesh_color = "#222222"
 
-	flags = NO_BLOOD | NO_BREATHE | NO_SCAN | NO_INTORGANS
+	flags = NO_BLOOD | NO_BREATHE | RADIMMUNE | NO_INTORGANS
 	burn_mod = 1.5 //1.5x burn damage, 2x is excessive
+	hot_env_multiplier = 1.5
 
 	silent_steps = 1
+
+/datum/species/shadow/ling/handle_life(var/mob/living/carbon/human/H)
+	if(!H.weakeyes) H.weakeyes = 1 //Makes them more vulnerable to flashes and flashbangs
+	var/light_amount = 0
+	H.nutrition = 450 //i aint never get hongry
+	if(isturf(H.loc))
+		var/turf/T = H.loc
+		light_amount = T.get_lumcount()*10
+		if(light_amount > LIGHT_DAM_THRESHOLD && !H.incorporeal_move) //Can survive in very small light levels. Also doesn't take damage while incorporeal, for shadow walk purposes
+			H.take_overall_damage(0, LIGHT_DAMAGE_TAKEN)
+			if(H.stat != DEAD)
+				H << "<span class='userdanger'>The light burns you!</span>" //Message spam to say "GET THE FUCK OUT"
+				H << 'sound/weapons/sear.ogg'
+		else if(light_amount < LIGHT_HEAL_THRESHOLD)
+			H.heal_overall_damage(5,5)
+			H.adjustToxLoss(-5)
+			H.adjustBrainLoss(-25) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"
+			H.adjustCloneLoss(-1)
+			H.SetWeakened(0)
+			H.SetStunned(0)
 
 /datum/game_mode/proc/update_shadow_icons_added(datum/mind/shadow_mind)
 	var/datum/atom_hud/antag/shadow_hud = huds[ANTAG_HUD_SHADOW]

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -308,7 +308,8 @@ Made by Xhuis
 	silent_steps = 1
 
 /datum/species/shadow/ling/handle_life(var/mob/living/carbon/human/H)
-	if(!H.weakeyes) H.weakeyes = 1 //Makes them more vulnerable to flashes and flashbangs
+	if(!H.weakeyes)
+		H.weakeyes = 1 //Makes them more vulnerable to flashes and flashbangs
 	var/light_amount = 0
 	H.nutrition = 450 //i aint never get hongry
 	if(isturf(H.loc))

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -82,8 +82,6 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H.undershirt = "None"
 				H.socks = "None"
 				H.faction |= "faithless"
-				if(!H.weakeyes)
-					H.weakeyes = 1
 
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/shadowling(usr), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/shadowling(usr), slot_shoes)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -731,32 +731,6 @@ var/global/list/brutefireloss_overlays = list("1" = image("icon" = 'icons/mob/sc
 				adjustOxyLoss(-(light_amount))
 				//TODO: heal wounds, heal broken limbs.
 
-	if(species.light_dam)
-		var/light_amount = 0
-		if(isturf(loc))
-			var/turf/T = loc
-			light_amount = T.get_lumcount()*10
-		if(light_amount > species.light_dam && !incorporeal_move) //if there's enough light, start dying
-			if(species.light_effect_amp)
-				adjustFireLoss(4.7) //This gets multiplied by 1.5 due to Shadowling's innate fire weakness, so it ends up being about 7.
-			else
-				adjustFireLoss(1)
-				adjustBruteLoss(1)
-			src << "<span class='userdanger'>The light burns you!</span>"
-			src << 'sound/weapons/sear.ogg'
-		else //heal in the dark
-			if(species.light_effect_amp)
-				adjustFireLoss(-5)
-				adjustBruteLoss(-5)
-				adjustBrainLoss(-25) //gibbering shadowlings are hilarious but also bad to have
-				adjustCloneLoss(-1)
-				SetWeakened(0)
-				SetStunned(0)
-			else
-				adjustFireLoss(-1)
-				adjustBruteLoss(-1)
-
-
 	//The fucking FAT mutation is the greatest shit ever. It makes everyone so hot and bothered.
 	if(species.flags & CAN_BE_FAT)
 		if(FAT in mutations)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -7,7 +7,6 @@
 
 	default_language = "Galactic Common"
 	unarmed_type = /datum/unarmed_attack/claws
-	light_dam = 2
 	darksight = 8
 
 	blood_color = "#CCCCCC"
@@ -16,8 +15,8 @@
 		"brain" = /obj/item/organ/internal/brain
 		)
 
-	flags = NO_BLOOD | NO_BREATHE | NO_SCAN
-	bodyflags = FEET_NOSLIP
+	flags = NO_BLOOD | NO_BREATHE | RADIMMUNE
+	virus_immune = 1
 	dietflags = DIET_OMNI		//the mutation process allowed you to now digest all foods regardless of initial race
 	reagent_tag = PROCESS_ORG
 	suicide_messages = list(
@@ -26,5 +25,13 @@
 		"is twisting their own neck!",
 		"is staring into the closest light source!")
 
-/datum/species/shadow/handle_death(var/mob/living/carbon/human/H)
-	H.dust()
+/datum/species/shadow/handle_life(var/mob/living/carbon/human/H)
+	var/light_amount = 0
+	if(isturf(H.loc))
+		var/turf/T = H.loc
+		light_amount = T.get_lumcount()*10
+
+		if(light_amount > 2) //if there's enough light, start dying
+			H.take_overall_damage(1,1)
+		else if (light_amount < 2) //heal in the dark
+			H.heal_overall_damage(1,1)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -55,9 +55,6 @@
 	var/brute_mod = null    // Physical damage reduction/malus.
 	var/burn_mod = null     // Burn damage reduction/malus.
 
-	var/light_dam //Light level above which species takes damage, and below which it heals.
-	var/light_effect_amp //If 0, takes/heals 1 burn and brute per tick. Otherwise, both healing and damage effects are amplified.
-
 	var/total_health = 100
 	var/punchdamagelow = 0       //lowest possible punch damage
 	var/punchdamagehigh = 9      //highest possible punch damage


### PR DESCRIPTION
Going to try to update Shadowling to what TG currently has--going to start slow by just refactoring how the species is handled so it's less snowflaked into human life() code.

- Shadowling healing/light damage nature is now moved into their species specific life loop
 - This also means we can eventually implement lessers shadowlings a bit easier
- Correct damage procs used for the light damage taken so it's not multiplified and is just a flat number

Shadow People Changes
- No slip removes
- Rad immunity added
- Can be cloned
- Doesn't dust on death

Shadowling Changes
- No slip removed from species (their shoes are still slip proof)
- Rad Immunity Added
- Doesn't Dust on death
- Still doesn't have a brain (this is to prevent exploits)
- Takes x1.5 heat damage
- Nutrition neither increases nor decreases

:cl: Fox McCloud
tweak: Shadow people no longer dust on death, are rad immune+virus immune, and can be cloned. Slip immunity removed
tweak: Shadowlings no longer get hungry or fat and no longer dust on death
/:cl: