### PR TITLE
Fixes roundstart real_name DNA, and mitocholide rejuv

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1769,6 +1769,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 	character.dna.ready_dna(character)
 	character.sync_organ_dna(assimilate=1)
+	character.UpdateAppearance()
 
 /datum/preferences/proc/open_load_dialog(mob/user)
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1658,6 +1658,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			real_name += "[pick(last_names)]"
 
 	character.real_name = real_name
+	character.dna.real_name = real_name
 	character.name = character.real_name
 
 	character.flavor_text = flavor_text

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -643,6 +643,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/mob/living/carbon/human/new_char = new(get_turf(src))
 	client.prefs.copy_to(new_char)
 	if(mind)
+		mind.active = 1
 		mind.transfer_to(new_char)
 	else
 		new_char.key = key

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -169,12 +169,6 @@
 	return valid_species
 
 /mob/living/carbon/human/proc/generate_valid_hairstyles()
-	var/mob/living/carbon/human/user
-	if(istype(usr, /mob/new_player))
-		user = usr
-	else
-		user = src
-
 	var/list/valid_hairstyles = new()
 	for(var/hairstyle in hair_styles_list)
 		var/datum/sprite_accessory/S = hair_styles_list[hairstyle]
@@ -184,14 +178,17 @@
 		if(gender == FEMALE && S.gender == MALE)
 			continue
 		if(species.flags & ALL_RPARTS) //If the user is a species who can have a robotic head...
+			var/obj/item/organ/external/head/H = organs_by_name["head"]
+			if(!H)
+				return
 			if(species.name in S.species_allowed) //If this is a hairstyle native to the user's species...
-				if(!user.client.prefs.rlimb_data["head"]) //Check to see if they have the default head.
+				if(H.model == "Morpheus Cyberkinetics") //Check to see if they have the default head.
 					valid_hairstyles += hairstyle //Give them their hairstyles if they do.
 					continue
 				else //If they don't have the default head, they shouldn't be getting any hairstyles they wouldn't normally.
 					continue
 			else
-				if(!user.client.prefs.rlimb_data["head"]) //If the hairstyle is not native to the user's species, and they're using the default head, don't let them access it.
+				if(H.model == "Morpheus Cyberkinetics") //If the hairstyle is not native to the user's species, and they're using the default head, don't let them access it.
 					continue
 				else
 					if("Human" in S.species_allowed) //If the user has a robotic head and the hairstyle can fit humans, let them use it as a wig for their humanoid robot head.
@@ -205,12 +202,6 @@
 	return valid_hairstyles
 
 /mob/living/carbon/human/proc/generate_valid_facial_hairstyles()
-	var/mob/living/carbon/human/user
-	if(istype(usr, /mob/new_player))
-		user = usr
-	else
-		user = src
-
 	var/list/valid_facial_hairstyles = new()
 	for(var/facialhairstyle in facial_hair_styles_list)
 		var/datum/sprite_accessory/S = facial_hair_styles_list[facialhairstyle]
@@ -220,14 +211,18 @@
 		if(gender == FEMALE && S.gender == MALE)
 			continue
 		if(species.flags & ALL_RPARTS) //If the user is a species who can have a robotic head...
+			var/obj/item/organ/external/head/H = organs_by_name["head"]
+			if(!H)
+				continue // No head, no hair
 			if(species.name in S.species_allowed) //If this is a facial hair style native to the user's species...
-				if(!user.client.prefs.rlimb_data["head"]) //Check to see if they have the default head.
+				if(H.model == "Morpheus Cyberkinetics") //Check to see if they have the default head.
 					valid_facial_hairstyles += facialhairstyle //Give them their facial hair styles if they do.
 					continue
 				else //If they don't have the default head, they shouldn't be getting any facial hair styles they wouldn't normally.
 					continue
 			else
-				if(!user.client.prefs.rlimb_data["head"]) //If the facial hair style is not native to the user's species, and they're using the default head, don't let them access it.
+
+				if(H.model == "Morpheus Cyberkinetics") //If the facial hair style is not native to the user's species, and they're using the default head, don't let them access it.
 					continue
 				else
 					if("Human" in S.species_allowed) //If the user has a robotic head and the facial hair style can fit humans, let them use it as a postiche for their humanoid robot head.

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -312,6 +312,7 @@ This function completely restores a damaged organ to perfect condition.
 		status = 128
 	else
 		status = 0
+	germ_level = 0
 	perma_injury = 0
 	brute_dam = 0
 	burn_dam = 0
@@ -320,6 +321,8 @@ This function completely restores a damaged organ to perfect condition.
 	for(var/obj/item/organ/internal/current_organ in internal_organs)
 		current_organ.rejuvenate()
 
+	for(var/obj/item/organ/external/EO in contents)
+		EO.rejuvenate()
 
 	// remove embedded objects and drop them on the floor
 	for(var/obj/implanted_object in implants)
@@ -329,6 +332,8 @@ This function completely restores a damaged organ to perfect condition.
 
 	owner.updatehealth()
 	update_icon()
+	if(!owner)
+		processing_objects |= src
 
 
 /obj/item/organ/external/proc/createwound(var/type = CUT, var/damage)


### PR DESCRIPTION
Fixes #3968

:cl:Crazylemon
bugfix: You now will actually have the correct `real_name` on your DNA.
bugfix: No more roundstart runtimes regarding IPC hair.
bugfix: Mitocholide rejuv will work more usefully now.
/:cl: