### PR TITLE
Improves rename_self() aka namepick

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -623,8 +623,9 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HARM)
 		var/newname
 
 		for(var/i=1,i<=3,i++)	//we get 3 attempts to pick a suitable name.
-			newname = input(src,"You are a [role]. Would you like to change your name to something else?", "Name change",oldname) as text
-			if((world.time-time_passed)>300)
+			newname = input(src, "You are a [role]. Would you like to change your name to something else? (You have 3 minutes to select a new name.)", "Name Change", oldname) as text
+			if((world.time - time_passed) > 1800)
+				alert(src, "Unfortunately, more than 3 minutes have passed for selecting your name. If you are a robot, use the Namepick verb; otherwise, adminhelp.", "Name Change")
 				return	//took too long
 			newname = reject_bad_name(newname,allow_numbers)	//returns null if the name doesn't meet some basic requirements. Tidies up a few other things like bad-characters.
 


### PR DESCRIPTION
- Ups `rename_self()`'s time limit to 3 minutes from 30 seconds, which was ridiculously short for eg robots that theme their name to their module, or indecisive players
- Makes the prompt & feedback less confusing