### PR TITLE
Fixes organs and cyborg upgrades popping up in your screen

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -957,7 +957,8 @@ var/global/list/damage_icon_parts = list()
 
 /mob/living/carbon/human/update_hud()	//TODO: do away with this if possible
 	if(client)
-		client.screen |= get_all_slots() // Items only please, no arms allowed
+		for(var/obj/item/I in get_all_slots())
+			client.screen |= I // Items only please, no arms allowed
 		if(hud_used)
 			hud_used.hidden_inventory_update() 	//Updates the screenloc of the items on the 'other' inventory bar
 			update_inv_handcuffed(0) // update handcuff overlay

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -957,7 +957,7 @@ var/global/list/damage_icon_parts = list()
 
 /mob/living/carbon/human/update_hud()	//TODO: do away with this if possible
 	if(client)
-		client.screen |= contents
+		client.screen |= get_all_slots() // Items only please, no arms allowed
 		if(hud_used)
 			hud_used.hidden_inventory_update() 	//Updates the screenloc of the items on the 'other' inventory bar
 			update_inv_handcuffed(0) // update handcuff overlay

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -241,3 +241,9 @@
 	if(I == module_active)
 		deselect_module(get_selected_module())
 	return ..()
+
+/mob/living/silicon/robot/proc/update_module_icon()
+	if(!module)
+		hands.icon_state = "nomod"
+	else
+		hands.icon_state = lowertext(module.module_type)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -261,10 +261,8 @@
 
 /mob/living/silicon/robot/proc/update_items()
 	if (src.client)
-		src.client.screen -= src.contents
-		for(var/obj/I in src.contents)
-			if(I && !(istype(I,/obj/item/weapon/stock_parts/cell) || istype(I,/obj/item/device/radio)  || istype(I,/obj/machinery/camera) || istype(I,/obj/item/device/mmi)))
-				src.client.screen += I
+		for(var/obj/I in get_all_slots())
+			client.screen |= I
 	if(src.module_state_1)
 		src.module_state_1:screen_loc = ui_inv1
 	if(src.module_state_2)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -353,13 +353,11 @@ var/list/robot_verbs_default = list(
 
 		if("Peacekeeper")
 			module = new /obj/item/weapon/robot_module/peacekeeper(src)
-			icon_state = "droidpeace"
 			module.channels = list()
 			icon_state = "droidpeace"
 
 		if("Hunter")
 			module = new /obj/item/weapon/robot_module/alien/hunter(src)
-			hands.icon_state = "standard"
 			icon = "icons/mob/alien.dmi"
 			icon_state = "xenoborg-state-a"
 			modtype = "Xeno-Hu"
@@ -375,7 +373,7 @@ var/list/robot_verbs_default = list(
 	if (custom_sprite == 1)
 		module_sprites["Custom"] = "[src.ckey]-[modtype]"
 
-	hands.icon_state = lowertext(modtype)
+	hands.icon_state = lowertext(module.module_type)
 	feedback_inc("cyborg_[lowertext(modtype)]",1)
 	rename_character(real_name, get_default_name())
 
@@ -824,6 +822,9 @@ var/list/robot_verbs_default = list(
 			if(src.module && istype(src.module, /obj/item/weapon/robot_module/medical))
 				for(var/obj/item/weapon/borg_defib/F in src.module.modules)
 					F.safety = 0
+			if(module)
+				module.module_type = "Malf" // For the cool factor
+				update_module_icon()
 			update_icons()
 		return
 
@@ -1276,6 +1277,9 @@ var/list/robot_verbs_default = list(
 
 	if(icontype)
 		icon_state = module_sprites[icontype]
+		if(icontype == "Bro")
+			module.module_type = "Brobot"
+			update_module_icon()
 		lockcharge = null
 	else
 		src << "Something is badly wrong with the sprite selection. Harass a coder."
@@ -1324,6 +1328,10 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/adjustOxyLoss(var/amount)
 	if (suiciding)
 		..()
+
+/mob/living/silicon/robot/regenerate_icons()
+	..()
+	update_module_icon()
 
 /mob/living/silicon/robot/deathsquad
 	base_icon = "nano_bloodhound"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -11,6 +11,8 @@
 	var/obj/item/borg/upgrade/jetpack = null
 	var/list/subsystems = list()
 
+	var/module_type = "NoMod" // For icon usage
+
 	var/list/stacktypes
 	var/channels = list()
 
@@ -101,7 +103,7 @@
 
 /obj/item/weapon/robot_module/standard
 	name = "standard robot module"
-
+	module_type = "Standard"
 
 /obj/item/weapon/robot_module/standard/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -116,6 +118,7 @@
 
 /obj/item/weapon/robot_module/medical
 	name = "medical robot module"
+	module_type = "Medical"
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	stacktypes = list(
 		/obj/item/stack/medical/advanced/bruise_pack = 5,
@@ -164,6 +167,7 @@
 
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
+	module_type = "Engineer"
 	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor)
 
 	stacktypes = list(
@@ -222,6 +226,7 @@
 
 /obj/item/weapon/robot_module/security
 	name = "security robot module"
+	module_type = "Security"
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 
 /obj/item/weapon/robot_module/security/New()
@@ -237,6 +242,7 @@
 
 /obj/item/weapon/robot_module/janitor
 	name = "janitorial robot module"
+	module_type = "Janitor"
 
 /obj/item/weapon/robot_module/janitor/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -254,6 +260,7 @@
 
 /obj/item/weapon/robot_module/butler
 	name = "service robot module"
+	module_type = "Service"
 
 /obj/item/weapon/robot_module/butler/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -324,6 +331,7 @@
 
 /obj/item/weapon/robot_module/miner
 	name = "miner robot module"
+	module_type = "Miner"
 
 /obj/item/weapon/robot_module/miner/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -341,6 +349,7 @@
 
 /obj/item/weapon/robot_module/deathsquad
 	name = "NT advanced combat module"
+	module_type = "Malf"
 
 /obj/item/weapon/robot_module/deathsquad/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -355,6 +364,7 @@
 
 /obj/item/weapon/robot_module/syndicate
 	name = "syndicate assault robot module"
+	module_type = "Malf" // cuz it looks cool
 
 /obj/item/weapon/robot_module/syndicate/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -371,6 +381,7 @@
 
 /obj/item/weapon/robot_module/syndicate_medical
 	name = "syndicate medical robot module"
+	module_type = "Malf"
 	stacktypes = list(
 		/obj/item/stack/medical/advanced/bruise_pack = 25,
 		/obj/item/stack/medical/advanced/ointment = 25,
@@ -409,6 +420,7 @@
 
 /obj/item/weapon/robot_module/combat
 	name = "combat robot module"
+	module_type = "Malf"
 
 /obj/item/weapon/robot_module/combat/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -425,6 +437,7 @@
 
 /obj/item/weapon/robot_module/peacekeeper
 	name = "peacekeeper robot module"
+	module_type = "Malf"
 
 /obj/item/weapon/robot_module/peacekeeper/New()
 	src.modules += new /obj/item/device/flash/cyborg(src)
@@ -440,6 +453,7 @@
 
 /obj/item/weapon/robot_module/alien/hunter
 	name = "alien hunter module"
+	module_type = "Standard"
 
 /obj/item/weapon/robot_module/alien/hunter/New()
 	src.modules += new /obj/item/weapon/melee/energy/alien/claws(src)
@@ -463,6 +477,7 @@
 
 /obj/item/weapon/robot_module/drone
 	name = "drone module"
+	module_type = "Engineer"
 	stacktypes = list(
 		/obj/item/stack/sheet/wood = 1,
 		/obj/item/stack/sheet/mineral/plastic = 1,


### PR DESCRIPTION
Fixes #2891
:cl:Crazylemon
bugfix: Limbs and cyborg modules will no longer appear in your screen.
bugfix: Cyborg module icons are now persistent throughout logging in and out.
bugfix: Various cyborg modules, like engineering, now use the proper icon.
/:cl: