### PR TITLE
Chem Fire+Brute Fixes

### DIFF
--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -384,7 +384,8 @@ datum/reagent/ephedrine/on_mob_life(var/mob/living/M as mob)
 		M.adjustOxyLoss(-1)
 	if(M.health < 0 || M.health > 0 && prob(33))
 		M.adjustToxLoss(-1)
-		M.heal_organ_damage(1,1)
+		M.adjustBruteLoss(-1)
+		M.adjustFireLoss(-1)
 	..()
 	return
 

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
@@ -17,7 +17,7 @@
 
 /datum/reagent/drink/tomatojuice/on_mob_life(var/mob/living/M as mob)
 	..()
-	if(M.getFireLoss() && prob(20)) M.heal_organ_damage(0,1)
+	if(M.getFireLoss() && prob(20)) M.adjustFireLoss(-1)
 	return
 
 /datum/reagent/drink/limejuice
@@ -110,7 +110,8 @@
 	M.nutrition += nutriment_factor
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Clown"))
 		if(!M) M = holder.my_atom
-		M.heal_organ_damage(1,1)
+		M.adjustBruteLoss(-1)
+		M.adjustFireLoss(-1)
 		M.nutrition += nutriment_factor
 		..()
 		return
@@ -125,7 +126,8 @@
 	M.nutrition += nutriment_factor
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Mime"))
 		if(!M) M = holder.my_atom
-		M.heal_organ_damage(1,1)
+		M.adjustBruteLoss(-1)
+		M.adjustFireLoss(-1)
 		M.nutrition += nutriment_factor
 		..()
 		return
@@ -145,7 +147,7 @@
 	color = "#DFDFDF" // rgb: 223, 223, 223
 
 /datum/reagent/drink/milk/on_mob_life(var/mob/living/M as mob)
-	if(M.getBruteLoss() && prob(20)) M.heal_organ_damage(1,0)
+	if(M.getBruteLoss() && prob(20)) M.adjustBruteLoss(-1)
 	if(holder.has_reagent("capsaicin"))
 		holder.remove_reagent("capsaicin", 2)
 	..()
@@ -224,7 +226,7 @@
 /datum/reagent/drink/coffee/soy_latte/on_mob_life(var/mob/living/M as mob)
 	..()
 	M.sleeping = 0
-	if(M.getBruteLoss() && prob(20)) M.heal_organ_damage(1,0)
+	if(M.getBruteLoss() && prob(20)) M.adjustBruteLoss(-1)
 	return
 
 /datum/reagent/drink/coffee/cafe_latte
@@ -239,7 +241,7 @@
 	..()
 	M.sleeping = 0
 	if(M.getBruteLoss() && prob(20))
-		M.heal_organ_damage(1,0)
+		M.adjustBruteLoss(-1)
 		return
 
 /datum/reagent/drink/tea
@@ -276,7 +278,8 @@
 	M.nutrition += nutriment_factor
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Clown"))
 		if(!M) M = holder.my_atom
-		M.heal_organ_damage(1,1)
+		M.adjustBruteLoss(-1)
+		M.adjustFireLoss(-1)
 		M.nutrition += nutriment_factor
 		..()
 		return
@@ -293,7 +296,8 @@
 	M.nutrition += nutriment_factor
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Mime"))
 		if(!M) M = holder.my_atom
-		M.heal_organ_damage(1,1)
+		M.adjustBruteLoss(-1)
+		M.adjustFireLoss(-1)
 		M.nutrition += nutriment_factor
 		..()
 		return

--- a/code/modules/reagents/oldchem/reagents/reagents_admin.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_admin.dm
@@ -15,7 +15,8 @@
 	M.setCloneLoss(0)
 	M.setOxyLoss(0)
 	M.radiation = 0
-	M.heal_organ_damage(5,5)
+	M.adjustBruteLoss(-5)
+	M.adjustFireLoss(-5)
 	M.adjustToxLoss(-5)
 	M.hallucination = 0
 	M.setBrainLoss(0)

--- a/code/modules/reagents/oldchem/reagents/reagents_food.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_food.dm
@@ -16,7 +16,7 @@
 			var/mob/living/carbon/human/H = M
 			if(H.can_eat())	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
 				H.nutrition += nutriment_factor	// For hunger and fatness
-				if(prob(50)) M.heal_organ_damage(1,0)
+				if(prob(50)) M.adjustBruteLoss(-1)
 		if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
 			if(prob(50)) M.heal_organ_damage(1,0)
 	..()
@@ -38,7 +38,7 @@
 			var/mob/living/carbon/human/H = M
 			if(H.can_eat(DIET_CARN | DIET_OMNI))	//Make sure that it is not a herbivore
 				H.nutrition += nutriment_factor	// For hunger and fatness
-				if(prob(50)) M.heal_organ_damage(1,0)
+				if(prob(50)) M.adjustBruteLoss(-1)
 		if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
 			if(prob(50)) M.heal_organ_damage(1,0)
 	..()
@@ -60,7 +60,7 @@
 			var/mob/living/carbon/human/H = M
 			if(H.can_eat(DIET_HERB | DIET_OMNI))	//Make sure that it is not a carnivore
 				H.nutrition += nutriment_factor	// For hunger and fatness
-				if(prob(50)) M.heal_organ_damage(1,0)
+				if(prob(50)) M.adjustBruteLoss(-1)
 		if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
 			if(prob(50)) M.heal_organ_damage(1,0)
 	..()
@@ -257,7 +257,8 @@
 	M.nutrition += nutriment_factor
 	if(istype(M, /mob/living/carbon/human) && M.job in list("Security Officer", "Head of Security", "Detective", "Warden"))
 		if(!M) M = holder.my_atom
-		M.heal_organ_damage(1,1)
+		M.adjustBruteLoss(-1)
+		M.adjustFireLoss(-1)
 		M.nutrition += nutriment_factor
 		..()
 		return

--- a/code/modules/reagents/oldchem/reagents/reagents_med.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_med.dm
@@ -105,7 +105,8 @@
 		M.adjustCloneLoss(-4)
 		M.adjustOxyLoss(-10)
 		M.adjustToxLoss(-3)
-		M.heal_organ_damage(12,12)
+		M.adjustBruteLoss(-12)
+		M.adjustFireLoss(-12)
 		M.status_flags &= ~DISFIGURED
 	..()
 	return
@@ -121,7 +122,8 @@
 /datum/reagent/rezadone/on_mob_life(mob/living/M)
 	M.setCloneLoss(0) //Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
 	M.adjustCloneLoss(-1) //What? We just set cloneloss to 0. Why? Simple; this is so external organs properly unmutate.
-	M.heal_organ_damage(1,1)
+	M.adjustBruteLoss(-1)
+	M.adjustFireLoss(-1)
 	M.status_flags &= ~DISFIGURED
 	..()
 	return

--- a/code/modules/reagents/oldchem/reagents/reagents_toxin.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_toxin.dm
@@ -67,7 +67,7 @@
 		M << "\red Your insides are burning!"
 		M.adjustToxLoss(rand(20,60)*REM)
 	else if(prob(40))
-		M.heal_organ_damage(5*REM,0)
+		M.adjustBruteLoss(-5*REM)
 	..()
 	return
 


### PR DESCRIPTION
For whatever reason `heal_organ_damage` produces very inconsistent results; sometimes it will heal and sometimes it won't (for human mobs anyway). `adjustBruteLoss` and `adjustFireLoss`, however, behave as intended and are completely reliable.

:cl: Fox McCloud
fix: Fixes several chems not properly healing brute/burn damage, consistently, as intended
/:cl: