### PR TITLE
Makes Coffee Less Addictive and Fake Cheese Non-addictive

### DIFF
--- a/code/modules/reagents/newchem/food.dm
+++ b/code/modules/reagents/newchem/food.dm
@@ -284,7 +284,6 @@ datum/reagent/cheese/reaction_turf(var/turf/T, var/volume)
 	reagent_state = LIQUID
 	color = "#B2B139"
 	overdose_threshold = 50
-	addiction_chance = 10
 
 /datum/reagent/fake_cheese/overdose_process(var/mob/living/M as mob)
 	if(prob(8))

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_drink.dm
@@ -189,7 +189,7 @@
 	adj_sleepy = -2
 	adj_temp = 25
 	overdose_threshold = 45
-	addiction_chance = 5 // It's true.
+	addiction_chance = 1 // It's true.
 
 /datum/reagent/drink/coffee/on_mob_life(var/mob/living/M as mob)
 	if(holder.has_reagent("frostoil"))


### PR DESCRIPTION
See: title.

The former because it was getting a bit excessive, yes caffeine is addictive, but the generic addiction effects are way overboard for something as fairly mundane as coffee. The latter because getting addicted to fake cheese after eating a bag of cheesy honkers to avoid starvation is bullshit. Fun/interesting gameplay before realism.

:cl:
tweak: NT has removed trace amounts of a highly-addictive substance from the "100% real" cheese used in cheese-flavored snacks. As a result, incidence rates of crewmembers becoming addicted to Cheesie Honkers should reduce to zero.
tweak: After receiving complaints about crewmembers often being unable to physically function without a back-mounted barrel of coffee, NT has replaced station all sources of coffee on the station, including coffee beans themselves with a largely decaffeinated version. It was funny the first time almost every crewmember aboard the NSS Cyberiad was lugging around their own oil barrel filled with coffee, it wasn't so funny, nor good for productivity the eighteenth.
/:cl: