### PR TITLE
Allows voice activators, etc to work in storage items

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -69,6 +69,10 @@
 		origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
 		return
 
+/obj/item/weapon/storage/lockbox/hear_talk(mob/living/M as mob, msg)
+
+/obj/item/weapon/storage/lockbox/hear_message(mob/living/M as mob, msg)
+
 /obj/item/weapon/storage/lockbox/large
 	name = "Large lockbox"
 	desc = "A large lockbox"

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -147,6 +147,9 @@
 		usr << "<span class='notice'>[src] is locked!</span>"
 	return 0
 
+/obj/item/weapon/storage/secure/hear_talk(mob/living/M as mob, msg)
+
+/obj/item/weapon/storage/secure/hear_message(mob/living/M as mob, msg)
 
 // -----------------------------
 //        Secure Briefcase

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -462,6 +462,16 @@
 			O.emp_act(severity)
 	..()
 
+/obj/item/weapon/storage/hear_talk(mob/living/M as mob, msg)
+	..()
+	for(var/obj/O in contents)
+		O.hear_talk(M, msg)
+
+/obj/item/weapon/storage/hear_message(mob/living/M as mob, msg)
+	..()
+	for(var/obj/O in contents)
+		O.hear_message(M, msg)
+
 // BubbleWrap - A box can be folded up to make card
 /obj/item/weapon/storage/attack_self(mob/user as mob)
 


### PR DESCRIPTION
Fixes #4001 
Going to make it _not_ work for lockboxes, safes, or secure briefcases, so we don't have secured explosives accidentally being triggered.