### PR TITLE
Fixes Timestop Spell

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -359,8 +359,7 @@
 				var/mob/living/M = A
 				if(M in immune)
 					continue
-				M.stunned += 10
-				M.canmove = 0
+				M.notransform = 1
 				M.anchored = 1
 				if(istype(M, /mob/living/simple_animal/hostile))
 					var/mob/living/simple_animal/hostile/H = M
@@ -388,7 +387,7 @@
 	return
 
 /obj/effect/timestop/proc/unfreeze_mob(mob/living/M)
-	M.AdjustStunned(-10)
+	M.notransform = 0
 	M.anchored = 0
 	if(istype(M, /mob/living/simple_animal/hostile))
 		var/mob/living/simple_animal/hostile/H = M


### PR DESCRIPTION
It uses `notransform` now which is basically for unconditional freezes like this.