### PR TITLE
Stops AI doing stuff while out of power or dead

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -985,6 +985,10 @@ var/list/ai_verbs_default = list(
 		usr << "<span class='warning'>You are dead!</span>"
 		return 1
 
+	if(lacks_power())
+		usr << "<span class='warning'>Power systems failure!</span>"
+		return 1
+
 	if((flags & AI_CHECK_WIRELESS) && src.control_disabled)
 		usr << "<span class='warning'>Wireless control is disabled!</span>"
 		return 1

--- a/code/modules/pda/ai.dm
+++ b/code/modules/pda/ai.dm
@@ -18,8 +18,7 @@
 	set name = "Send PDA Message"
 	set src in usr
 
-	if(usr.stat == DEAD)
-		usr << "You can't send PDA messages because you are dead!"
+	if(!can_use())
 		return
 	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
 	if(!M)
@@ -37,8 +36,7 @@
 	set name = "Show Message Log"
 	set src in usr
 
-	if(usr.stat == DEAD)
-		usr << "You can't do that because you are dead!"
+	if(!can_use())
 		return
 	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
 	if(!M)
@@ -57,8 +55,7 @@
 	set name = "Toggle Sender/Receiver"
 	set src in usr
 
-	if(usr.stat == DEAD)
-		usr << "You can't do that because you are dead!"
+	if(!can_use())
 		return
 	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
 	M.toff = !M.toff
@@ -70,16 +67,17 @@
 	set name = "Toggle Ringer"
 	set src in usr
 
-	if(usr.stat == DEAD)
-		usr << "You can't do that because you are dead!"
+	if(!can_use())
 		return
 	var/datum/data/pda/app/messenger/M = find_program(/datum/data/pda/app/messenger)
 	M.notify_silent = !M.notify_silent
 	usr << "<span class='notice'>PDA ringer toggled [(M.notify_silent ? "Off" : "On")]!</span>"
 
 /obj/item/device/pda/ai/can_use()
-	return 1
-
+	var/mob/living/silicon/ai/AI = usr
+	if(!istype(AI))
+		return 0
+	return ..() && !AI.check_unable(AI_CHECK_WIRELESS)
 
 /obj/item/device/pda/ai/attack_self(mob/user as mob)
 	if ((honkamt > 0) && (prob(60)))//For clown virus.


### PR DESCRIPTION
Resolves #1878
Resolves #3507 
Disables basically every AI function when the power is out, because that clearly was the original intended behavior, given the blindness, and _some_ things not working.