### PR TITLE
Allows Closing of Incisions Made in Embedded Object Removal Surgery

### DIFF
--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -307,7 +307,7 @@
 
 /datum/surgery/embedded_removal
 	name = "removal of embedded objects"
-	steps = list(/datum/surgery_step/generic/cut_open,/datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin,/datum/surgery_step/remove_object)
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/remove_object, /datum/surgery_step/generic/cauterize)
 	possible_locs = list("r_arm","l_arm","r_leg","l_leg","r_hand","r_foot","l_hand","l_foot","groin","chest","head")
 
 


### PR DESCRIPTION
Resolves #4012.

I must say, I really really like how modular the new system is, however my one criticism (at least with this particular surgery, embedded object removal) is that you should probably be using hemostats to remove smaller objects like bullet fragments-- but I think this surgery also encompasses the removal of potentially MUCH larger objects (like energy katanas), so I suppose my comments can be dismissed. Am I right in thinking that? Not too sure.

:cl:
fix: Incisions made at the beginning of embedded object removal surgery can now be closed in the same procedure.
/:cl:

Prior, where in every object removal surgery (regardless of location on the body) you'd be left at the end of the procedure with open incisions, now you can do the same surgical procedures and no longer have to worry about needing to start and finish a completely different surgical procedure (like infection removal) to close said incision.