### PR TITLE
Additions to Engineering Cyborg and Maintenance Drones

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -5,6 +5,7 @@ Mineral Sheets
 		- Diamond
 		- Uranium
 		- Plasma
+		- Plastic
 		- Gold
 		- Silver
 		- Bananium

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -132,6 +132,16 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	flags = CONDUCT
 	origin_tech = "materials=2"
 
+	/obj/item/stack/sheet/plasteel/cyborg
+		name = "plasteel"
+		singular_name = "plasteel sheet"
+		desc = "This sheet is an alloy of iron and plasma."
+		icon_state = "sheet-plasteel"
+		item_state = "sheet-metal"
+		materials = list()
+		throwforce = 10.0
+		flags = CONDUCT
+
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 	recipes = plasteel_recipes
 	return ..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -131,7 +131,7 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	throwforce = 10.0
 	flags = CONDUCT
 	origin_tech = "materials=2"
-
+/* Just in case we ever decide to use it
 /obj/item/stack/sheet/plasteel/cyborg
 	name = "plasteel"
 	singular_name = "plasteel sheet"
@@ -141,7 +141,7 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	materials = list()
 	throwforce = 10.0
 	flags = CONDUCT
-
+*/
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 	recipes = plasteel_recipes
 	return ..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -132,15 +132,15 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	flags = CONDUCT
 	origin_tech = "materials=2"
 
-	/obj/item/stack/sheet/plasteel/cyborg
-		name = "plasteel"
-		singular_name = "plasteel sheet"
-		desc = "This sheet is an alloy of iron and plasma."
-		icon_state = "sheet-plasteel"
-		item_state = "sheet-metal"
-		materials = list()
-		throwforce = 10.0
-		flags = CONDUCT
+/obj/item/stack/sheet/plasteel/cyborg
+	name = "plasteel"
+	singular_name = "plasteel sheet"
+	desc = "This sheet is an alloy of iron and plasma."
+	icon_state = "sheet-plasteel"
+	item_state = "sheet-metal"
+	materials = list()
+	throwforce = 10.0
+	flags = CONDUCT
 
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 	recipes = plasteel_recipes

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -131,17 +131,7 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	throwforce = 10.0
 	flags = CONDUCT
 	origin_tech = "materials=2"
-/* Just in case we ever decide to use it
-/obj/item/stack/sheet/plasteel/cyborg
-	name = "plasteel"
-	singular_name = "plasteel sheet"
-	desc = "This sheet is an alloy of iron and plasma."
-	icon_state = "sheet-plasteel"
-	item_state = "sheet-metal"
-	materials = list()
-	throwforce = 10.0
-	flags = CONDUCT
-*/
+
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 	recipes = plasteel_recipes
 	return ..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -107,7 +107,6 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	recipes = metal_recipes
 	return ..()
 
-
 /*
  * Plasteel
  */
@@ -116,8 +115,6 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 	new/datum/stack_recipe("Surgery Table", /obj/machinery/optable, 5, time = 50, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("Metal crate", /obj/structure/closet/crate, 10, time = 50, one_per_turf = 1), \
 	new/datum/stack_recipe("Mass Driver frame", /obj/machinery/mass_driver_frame, 3, time = 50, one_per_turf = 1), \
-//	new/datum/stack_recipe("RUST fuel assembly port frame", /obj/item/rust_fuel_assembly_port_frame, 12, time = 50, one_per_turf = 1), \
-//	new/datum/stack_recipe("RUST fuel compressor frame", /obj/item/rust_fuel_compressor_frame, 12, time = 50, one_per_turf = 1), \
 
 	)
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -34,10 +34,6 @@
 /obj/item/stack/attack_self(mob/user as mob)
 	list_recipes(user)
 
-/obj/item/stack/sheet/plasteel/cyborg/attack_self(mob/user as mob)
-	user << "<span class='warning'>You lack the subroutines necessary to build more complex structures with that material.</span>"
-	return
-
 /obj/item/stack/proc/list_recipes(mob/user as mob, recipes_sublist)
 	if (!recipes)
 		return

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -34,6 +34,10 @@
 /obj/item/stack/attack_self(mob/user as mob)
 	list_recipes(user)
 
+/obj/item/stack/sheet/plasteel/cyborg/attack_self(mob/user as mob)
+	user << "<span class='warning'>You lack the subroutines necessary to build more complex structures with that material.</span>"
+	return
+
 /obj/item/stack/proc/list_recipes(mob/user as mob, recipes_sublist)
 	if (!recipes)
 		return

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -15,10 +15,12 @@
 	req_access = list(access_engine, access_robotics)
 	local_transmit = 1
 	ventcrawler = 2
+	magpulse = 1
 
 	// We need to keep track of a few module items so we don't need to do list operations
 	// every time we need them. These get set in New() after the module is chosen.
 	var/obj/item/stack/sheet/metal/cyborg/stack_metal = null
+	var/obj/item/stack/sheet/plasteel/cyborg/stack_plasteel = null //does stack_plasteel work here?
 	var/obj/item/stack/sheet/wood/cyborg/stack_wood = null
 	var/obj/item/stack/sheet/glass/cyborg/stack_glass = null
 	var/obj/item/stack/sheet/mineral/plastic/cyborg/stack_plastic = null
@@ -60,6 +62,7 @@
 
 	//Grab stacks.
 	stack_metal = locate(/obj/item/stack/sheet/metal/cyborg) in src.module
+	stack_plasteel = locate(/obj/item/stack/sheet/plasteel/cyborg) in src.module
 	stack_wood = locate(/obj/item/stack/sheet/wood/cyborg) in src.module
 	stack_glass = locate(/obj/item/stack/sheet/glass/cyborg) in src.module
 	stack_plastic = locate(/obj/item/stack/sheet/mineral/plastic/cyborg) in src.module

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -20,7 +20,6 @@
 	// We need to keep track of a few module items so we don't need to do list operations
 	// every time we need them. These get set in New() after the module is chosen.
 	var/obj/item/stack/sheet/metal/cyborg/stack_metal = null
-	var/obj/item/stack/sheet/plasteel/cyborg/stack_plasteel = null //does stack_plasteel work here?
 	var/obj/item/stack/sheet/wood/cyborg/stack_wood = null
 	var/obj/item/stack/sheet/glass/cyborg/stack_glass = null
 	var/obj/item/stack/sheet/mineral/plastic/cyborg/stack_plastic = null
@@ -62,7 +61,6 @@
 
 	//Grab stacks.
 	stack_metal = locate(/obj/item/stack/sheet/metal/cyborg) in src.module
-	stack_plasteel = locate(/obj/item/stack/sheet/plasteel/cyborg) in src.module
 	stack_wood = locate(/obj/item/stack/sheet/wood/cyborg) in src.module
 	stack_glass = locate(/obj/item/stack/sheet/glass/cyborg) in src.module
 	stack_plastic = locate(/obj/item/stack/sheet/mineral/plastic/cyborg) in src.module

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -157,9 +157,10 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "decompiler"
 
-	//Metal, glass, wood, plastic.
+	//Metal, plasteel, glass, wood, plastic.
 	var/list/stored_comms = list(
 		"metal" = 0,
+		"plasteel" = 0,
 		"glass" = 0,
 		"wood" = 0,
 		"plastic" = 0
@@ -212,6 +213,7 @@
 			new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
 
 			stored_comms["metal"] += 15
+			stored_comms["plasteel"] += 15
 			stored_comms["glass"] += 15
 			stored_comms["wood"] += 5
 			stored_comms["plastic"] += 5
@@ -242,6 +244,7 @@
 			stored_comms["plastic"]++
 			stored_comms["plastic"]++
 			stored_comms["glass"]++
+			stored_comms["plasteel"]++
 		else if(istype(W,/obj/item/trash))
 			stored_comms["metal"]++
 			stored_comms["plastic"]++
@@ -251,6 +254,7 @@
 			stored_comms["metal"]++
 			stored_comms["glass"]++
 			stored_comms["glass"]++
+			stored_comms["plasteel"]++
 		else if(istype(W,/obj/item/ammo_casing))
 			stored_comms["metal"]++
 		else if(istype(W,/obj/item/weapon/shard/shrapnel))
@@ -357,6 +361,11 @@
 						stack_metal = new /obj/item/stack/sheet/metal/cyborg(src.module)
 						stack_metal.amount = 1
 					stack = stack_metal
+				if("plasteel")
+					if(!stack_plasteel)
+						stack_plasteel = new /obj/item/stack/sheet/plasteel/cyborg(src.module)
+						stack_plasteel.amount = 1
+					stack = stack_plasteel
 				if("glass")
 					if(!stack_glass)
 						stack_glass = new /obj/item/stack/sheet/glass/cyborg(src.module)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -157,7 +157,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "decompiler"
 
-	//Metal, plasteel, glass, wood, plastic.
+	//Metal, glass, wood, plastic.
 	var/list/stored_comms = list(
 		"metal" = 0,
 		"plasteel" = 0,
@@ -213,7 +213,6 @@
 			new/obj/effect/decal/cleanable/blood/oil(get_turf(src))
 
 			stored_comms["metal"] += 15
-			stored_comms["plasteel"] += 15
 			stored_comms["glass"] += 15
 			stored_comms["wood"] += 5
 			stored_comms["plastic"] += 5
@@ -244,7 +243,6 @@
 			stored_comms["plastic"]++
 			stored_comms["plastic"]++
 			stored_comms["glass"]++
-			stored_comms["plasteel"]++
 		else if(istype(W,/obj/item/trash))
 			stored_comms["metal"]++
 			stored_comms["plastic"]++
@@ -254,7 +252,6 @@
 			stored_comms["metal"]++
 			stored_comms["glass"]++
 			stored_comms["glass"]++
-			stored_comms["plasteel"]++
 		else if(istype(W,/obj/item/ammo_casing))
 			stored_comms["metal"]++
 		else if(istype(W,/obj/item/weapon/shard/shrapnel))
@@ -361,11 +358,6 @@
 						stack_metal = new /obj/item/stack/sheet/metal/cyborg(src.module)
 						stack_metal.amount = 1
 					stack = stack_metal
-				if("plasteel")
-					if(!stack_plasteel)
-						stack_plasteel = new /obj/item/stack/sheet/plasteel/cyborg(src.module)
-						stack_plasteel.amount = 1
-					stack = stack_plasteel
 				if("glass")
 					if(!stack_glass)
 						stack_glass = new /obj/item/stack/sheet/glass/cyborg(src.module)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -383,4 +383,4 @@
 					stack = stack_plastic
 
 			stack.amount++
-			decompiler.stored_comms[type]--;
+			decompiler.stored_comms[type]--

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -160,7 +160,6 @@
 	//Metal, glass, wood, plastic.
 	var/list/stored_comms = list(
 		"metal" = 0,
-		"plasteel" = 0,
 		"glass" = 0,
 		"wood" = 0,
 		"plastic" = 0

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -172,7 +172,7 @@
 
 	stacktypes = list(
 		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel/cyborg = 50
+		/obj/item/stack/sheet/plasteel/cyborg = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/rglass = 50,
 		/obj/item/stack/cable_coil/cyborg = 50,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -172,11 +172,12 @@
 
 	stacktypes = list(
 		/obj/item/stack/sheet/metal = 50,
+		/obj/item/stack/sheet/plasteel = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/rglass = 50,
-		/obj/item/stack/cable_coil/cyborg = 50,
-		/obj/item/stack/rods = 15,
-		/obj/item/stack/tile/plasteel = 15
+		/obj/item/stack/cable_coil/cyborg = 30,
+		/obj/item/stack/rods = 30,
+		/obj/item/stack/tile/plasteel = 20
 		)
 
 /obj/item/weapon/robot_module/engineering/New()
@@ -198,29 +199,10 @@
 
 	src.emag = new /obj/item/borg/stun(src)
 
-	var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
-	M.amount = 50
-	src.modules += M
-
-	var/obj/item/stack/sheet/rglass/cyborg/R = new /obj/item/stack/sheet/rglass/cyborg(src)
-	R.amount = 50
-	src.modules += R
-
-	var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src)
-	G.amount = 50
-	src.modules += G
-
-	var/obj/item/stack/cable_coil/cyborg/W = new /obj/item/stack/cable_coil/cyborg(src)
-	W.amount = 50
-	src.modules += W
-
-	var/obj/item/stack/rods/Q = new /obj/item/stack/rods(src)
-	Q.amount = 15
-	src.modules += Q
-
-	var/obj/item/stack/tile/plasteel/F = new /obj/item/stack/tile/plasteel(src) //floor tiles not regular plasteel, calm down
-	F.amount = 15
-	src.modules += F
+	for(var/G in stacktypes) //Attempt to unify Engi-Borg material stacks into fewer lines. See Line 492 for example. Variables changed out of paranoia.
+		var/obj/item/stack/sheet/M = new G(src)
+		M.amount = stacktypes[G]
+		src.modules += M
 
 	fix_modules()
 
@@ -479,14 +461,15 @@
 	name = "drone module"
 	module_type = "Engineer"
 	stacktypes = list(
-		/obj/item/stack/sheet/wood = 1,
-		/obj/item/stack/sheet/mineral/plastic = 1,
-		/obj/item/stack/sheet/rglass = 5,
-		/obj/item/stack/tile/wood = 5,
-		/obj/item/stack/rods = 15,
-		/obj/item/stack/tile/plasteel = 15,
-		/obj/item/stack/sheet/metal = 20,
-		/obj/item/stack/sheet/glass = 20,
+		/obj/item/stack/sheet/wood = 10,
+		/obj/item/stack/sheet/mineral/plastic = 10,
+		/obj/item/stack/sheet/rglass = 50,
+		/obj/item/stack/tile/wood = 20,
+		/obj/item/stack/rods = 30,
+		/obj/item/stack/tile/plasteel = 20,
+		/obj/item/stack/sheet/metal = 50,
+		/obj/item/stack/sheet/plasteel = 50,
+		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/cable_coil/cyborg = 30
 		)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -172,6 +172,7 @@
 
 	stacktypes = list(
 		/obj/item/stack/sheet/metal = 50,
+		/obj/item/stack/sheet/plasteel/cyborg = 50
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/rglass = 50,
 		/obj/item/stack/cable_coil/cyborg = 50,
@@ -467,7 +468,7 @@
 		/obj/item/stack/rods = 30,
 		/obj/item/stack/tile/plasteel = 20,
 		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel = 50,
+		/obj/item/stack/sheet/plasteel/cyborg = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/cable_coil/cyborg = 30
 		)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -172,10 +172,9 @@
 
 	stacktypes = list(
 		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/rglass = 50,
-		/obj/item/stack/cable_coil/cyborg = 30,
+		/obj/item/stack/cable_coil/cyborg = 50,
 		/obj/item/stack/rods = 30,
 		/obj/item/stack/tile/plasteel = 20
 		)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -171,9 +171,9 @@
 	subsystems = list(/mob/living/silicon/proc/subsystem_power_monitor)
 
 	stacktypes = list(
-		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/glass = 50,
-		/obj/item/stack/sheet/rglass = 50,
+		/obj/item/stack/sheet/metal/cyborg = 50,
+		/obj/item/stack/sheet/glass/cyborg = 50,
+		/obj/item/stack/sheet/rglass/cyborg = 50,
 		/obj/item/stack/cable_coil/cyborg = 50,
 		/obj/item/stack/rods = 30,
 		/obj/item/stack/tile/plasteel = 20
@@ -460,13 +460,13 @@
 	name = "drone module"
 	module_type = "Engineer"
 	stacktypes = list(
-		/obj/item/stack/sheet/wood = 10,
-		/obj/item/stack/sheet/rglass = 50,
+		/obj/item/stack/sheet/wood/cyborg = 10,
+		/obj/item/stack/sheet/rglass/cyborg = 50,
 		/obj/item/stack/tile/wood = 20,
 		/obj/item/stack/rods = 30,
 		/obj/item/stack/tile/plasteel = 20,
-		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/glass = 50,
+		/obj/item/stack/sheet/metal/cyborg = 50,
+		/obj/item/stack/sheet/glass/cyborg = 50,
 		/obj/item/stack/cable_coil/cyborg = 30
 		)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -172,7 +172,6 @@
 
 	stacktypes = list(
 		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel/cyborg = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/sheet/rglass = 50,
 		/obj/item/stack/cable_coil/cyborg = 50,
@@ -462,13 +461,11 @@
 	module_type = "Engineer"
 	stacktypes = list(
 		/obj/item/stack/sheet/wood = 10,
-		/obj/item/stack/sheet/mineral/plastic = 10,
 		/obj/item/stack/sheet/rglass = 50,
 		/obj/item/stack/tile/wood = 20,
 		/obj/item/stack/rods = 30,
 		/obj/item/stack/tile/plasteel = 20,
 		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel/cyborg = 50,
 		/obj/item/stack/sheet/glass = 50,
 		/obj/item/stack/cable_coil/cyborg = 30
 		)


### PR DESCRIPTION
My attempt to give maintenance drones magboots. I also increased some starting materials for drones and engineering cyborgs.

EDIT: Shit's fucked, yo. This went though a lot more than I expected.

:cl: ProperPants
rscadd: Maint drones have magboots.
rscdel: Removed plastic from maint drones. Literally useless for station maintenance.
tweak: Increased starting amounts of some materials for maint drones and engi borgs.
experiment: Reduced the number of lines taken by Engineering cyborgs calling on materials stacks.
/:cl:

I fixed some miscellaneous clerical errors that I came across as well.