### PR TITLE
Makes clicking a filled inventory slot's square be treated like clicking the item

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -174,6 +174,10 @@
 				equip_to_slot_if_possible(C, slot)
 		else
 			equip_to_slot_if_possible(W, slot)
+	else
+		W = get_item_by_slot(slot)
+		if(W)
+			W.attack_hand(src)
 
 	if(ishuman(src) && W == src:head)
 		src:update_hair()


### PR DESCRIPTION
Clicking an inventory slot's square now does whatever clicking the actual item's sprite does, if there is an item in the slot.
- For most items, this means you can now click anywhere in the slot to put the item in your hand.
 - Clicking the 5 pixel wide pen sprite sucks.
- For storage, clicking anywhere in the square opens the storage inventory popup.
- I think you get the idea.

The weird thing is that the storage popup's slots have worked like this for a while.

:cl:
tweak: Clicking a filled inventory slot's square with an open hand now clicks the item in the slot.
/:cl: