### PR TITLE
Operating Tables Can Be Destroyed

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -130,7 +130,7 @@
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		if(do_after(user, 20, target = src))
 			user << "<span class='notice'>You deconstruct the table.</span>"
-			new /obj/item/stack/sheet/plasteel( loc, 5)
+			new /obj/item/stack/sheet/plasteel(loc, 5)
 			qdel(src)
 
 

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -126,6 +126,12 @@
 			take_victim(W:affecting,usr)
 			qdel(W)
 			return
+	if(istype(W, /obj/item/weapon/wrench))
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		if(do_after(user, 20, target = src))
+			user << "<span class='notice'>You deconstruct the table.</span>"
+			new /obj/item/stack/sheet/plasteel( loc, 5)
+			qdel(src)
 
 
 /obj/machinery/optable/proc/check_table(mob/living/carbon/patient as mob)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -36,7 +36,7 @@
 				if(do_after(user, 20, target = src))
 					if(!src || !WT.remove_fuel(0, user)) return
 					user << "\blue You deconstruct the frame."
-					new /obj/item/stack/sheet/plasteel( loc, 4)
+					new /obj/item/stack/sheet/plasteel(loc, 4)
 					qdel(src)
 		if(1)
 			if(istype(P, /obj/item/weapon/wrench))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -86,7 +86,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 
 /obj/item/stack/sheet/metal
 	name = "metal"
-	desc = "Sheets made out off metal. It has been dubbed Metal Sheets."
+	desc = "Sheets made out of metal."
 	singular_name = "metal sheet"
 	icon_state = "sheet-metal"
 	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT)
@@ -96,7 +96,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 
 /obj/item/stack/sheet/metal/cyborg
 	name = "metal"
-	desc = "Sheets made out off metal. It has been dubbed Metal Sheets."
+	desc = "Sheets made out of metal."
 	singular_name = "metal sheet"
 	icon_state = "sheet-metal"
 	materials = list()


### PR DESCRIPTION
Title.
Use a wrench. They give back five plasteel upon destruction, in order to be rebuilt wherever. I can change the time from two seconds to one, if needed.

One possible cause for concern: The tables in arrivals maintenance, the assembly line, and xenobiology being stolen. People could do surgery on them before, and people could manage to acquire plasteel to make a table wherever they wanted before. I don't see how this is a big deal. If anything, remove those, because this is convenient for medical, brig, and robotics.

I also changed the description and fixed a typo for metal sheets because the old one was pretty dumb.

:cl: ProperPants
rscadd: Operating tables can be deconstructed with a wrench.
spellcheck: Fixed and shortened description of metal sheets.
/:cl: