### PR TITLE
Cleaning and Definition of Cyborg Stacks

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -22,13 +22,13 @@
 	icon_state = "rods"
 	item_state = "rods"
 	flags = CONDUCT
-	w_class = 3.0
-	force = 9.0
-	throwforce = 10.0
-	throw_speed = 3
-	throw_range = 7
+	w_class =
+	force =
+	throwforce =
+	throw_speed =
+	throw_range =
 	materials = list()
-	max_amount = 60
+	max_amount =
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -15,6 +15,23 @@
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 
+/obj/item/stack/rods/cyborg
+	name = "metal rod"
+	desc = "Some rods. Can be used for building, or something."
+	singular_name = "metal rod"
+	icon_state = "rods"
+	item_state = "rods"
+	flags = CONDUCT
+	w_class = 3.0
+	force = 9.0
+	throwforce = 10.0
+	throw_speed = 3
+	throw_range = 7
+	materials = list()
+	max_amount = 60
+	attack_verb = list("hit", "bludgeoned", "whacked")
+	hitsound = 'sound/weapons/grenadelaunch.ogg'
+
 /obj/item/stack/rods/New(var/loc, var/amount=null)
 	..()
 
@@ -41,11 +58,11 @@
 			if(new_item.get_amount() <= 0)
 				// stack was moved into another one on the pile
 				new_item = locate() in user.loc
-				
+
 			user.visible_message("<span class='warning'>[user.name] shaped [src] into metal with the weldingtool.</span>", \
 						 "<span class='notice'>You shaped [src] into metal with the weldingtool.</span>", \
 						 "<span class='warning'>You hear welding.</span>")
-			
+
 			var/replace = user.get_inactive_hand() == src
 			use(2)
 			if (get_amount() <= 0 && replace)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -16,21 +16,7 @@
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 
 /obj/item/stack/rods/cyborg
-	name = "metal rod"
-	desc = "Some rods. Can be used for building, or something."
-	singular_name = "metal rod"
-	icon_state = "rods"
-	item_state = "rods"
-	flags = CONDUCT
-	w_class =
-	force =
-	throwforce =
-	throw_speed =
-	throw_range =
 	materials = list()
-	max_amount =
-	attack_verb = list("hit", "bludgeoned", "whacked")
-	hitsound = 'sound/weapons/grenadelaunch.ogg'
 
 /obj/item/stack/rods/New(var/loc, var/amount=null)
 	..()

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -24,12 +24,7 @@
 	var/full_window = /obj/structure/window/full/basic
 
 /obj/item/stack/sheet/glass/cyborg
-	name = "glass"
-	desc = "HOLY SHEET! That is a lot of glass."
-	singular_name = "glass sheet"
-	icon_state = "sheet-glass"
 	materials = list()
-	created_window = /obj/structure/window/basic
 
 /obj/item/stack/sheet/glass/attack_self(mob/user as mob)
 	construct_window(user)
@@ -159,10 +154,6 @@
 	var/full_window = /obj/structure/window/full/reinforced
 
 /obj/item/stack/sheet/rglass/cyborg
-	name = "reinforced glass"
-	desc = "Glass which seems to have rods or something stuck in them."
-	singular_name = "reinforced glass sheet"
-	icon_state = "sheet-rglass"
 	materials = list()
 
 /obj/item/stack/sheet/rglass/attack_self(mob/user as mob)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -155,8 +155,6 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 	icon_state = "sheet-wood"
 	origin_tech = "materials=1;biotech=1"
 
-/obj/item/stack/sheet/wood/cyborg
-
 /obj/item/stack/sheet/wood/New(var/loc, var/amount=null)
 	recipes = wood_recipes
 	return ..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -96,13 +96,6 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	origin_tech = "materials=1"
 
 /obj/item/stack/sheet/metal/cyborg
-	name = "metal"
-	desc = "Sheets made out of metal."
-	singular_name = "metal sheet"
-	icon_state = "sheet-metal"
-	materials = list()
-	throwforce = 10.0
-	flags = CONDUCT
 
 /obj/item/stack/sheet/metal/New(var/loc, var/amount=null)
 	recipes = metal_recipes
@@ -162,10 +155,6 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 	origin_tech = "materials=1;biotech=1"
 
 /obj/item/stack/sheet/wood/cyborg
-	name = "wooden plank"
-	desc = "One can only guess that this is a bunch of wood."
-	singular_name = "wood plank"
-	icon_state = "sheet-wood"
 
 /obj/item/stack/sheet/wood/New(var/loc, var/amount=null)
 	recipes = wood_recipes

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -96,6 +96,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 	origin_tech = "materials=1"
 
 /obj/item/stack/sheet/metal/cyborg
+	materials = list()
 
 /obj/item/stack/sheet/metal/New(var/loc, var/amount=null)
 	recipes = metal_recipes

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -49,14 +49,6 @@
 	icon_state = "tile-wood"
 	turf_type = /turf/simulated/floor/wood
 
-/obj/item/stack/tile/wood/cyborg
-	name = "wood floor tiles"
-	gender = PLURAL
-	singular_name = "wood floor tile"
-	desc = "an easy to fit wood floor tile"
-	icon_state = "tile-wood"
-	turf_type = /turf/simulated/floor/wood
-
 /*
  * Carpets
  */
@@ -71,21 +63,6 @@
  * Plasteel
  */
 /obj/item/stack/tile/plasteel
-	name = "floor tiles"
-	gender = PLURAL
-	singular_name = "floor tile"
-	desc = "Those could work as a pretty decent throwing weapon."
-	icon_state = "tile"
-	force = 6
-	materials = list(MAT_METAL=500)
-	throwforce = 10
-	throw_speed = 3
-	throw_range = 7
-	flags = CONDUCT
-	turf_type = /turf/simulated/floor/plasteel
-	mineralType = "metal"
-
-/obj/item/stack/tile/plasteel/cyborg
 	name = "floor tiles"
 	gender = PLURAL
 	singular_name = "floor tile"

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -49,6 +49,14 @@
 	icon_state = "tile-wood"
 	turf_type = /turf/simulated/floor/wood
 
+/obj/item/stack/tile/wood/cyborg
+	name = "wood floor tiles"
+	gender = PLURAL
+	singular_name = "wood floor tile"
+	desc = "an easy to fit wood floor tile"
+	icon_state = "tile-wood"
+	turf_type = /turf/simulated/floor/wood
+
 /*
  * Carpets
  */
@@ -63,6 +71,21 @@
  * Plasteel
  */
 /obj/item/stack/tile/plasteel
+	name = "floor tiles"
+	gender = PLURAL
+	singular_name = "floor tile"
+	desc = "Those could work as a pretty decent throwing weapon."
+	icon_state = "tile"
+	force = 6
+	materials = list(MAT_METAL=500)
+	throwforce = 10
+	throw_speed = 3
+	throw_range = 7
+	flags = CONDUCT
+	turf_type = /turf/simulated/floor/plasteel
+	mineralType = "metal"
+
+/obj/item/stack/tile/plasteel/cyborg
 	name = "floor tiles"
 	gender = PLURAL
 	singular_name = "floor tile"

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -20,7 +20,7 @@
 	// We need to keep track of a few module items so we don't need to do list operations
 	// every time we need them. These get set in New() after the module is chosen.
 	var/obj/item/stack/sheet/metal/cyborg/stack_metal = null
-	var/obj/item/stack/sheet/wood/cyborg/stack_wood = null
+	var/obj/item/stack/sheet/wood/stack_wood = null
 	var/obj/item/stack/sheet/glass/cyborg/stack_glass = null
 	var/obj/item/stack/sheet/mineral/plastic/cyborg/stack_plastic = null
 	var/obj/item/weapon/matter_decompiler/decompiler = null

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -61,7 +61,7 @@
 
 	//Grab stacks.
 	stack_metal = locate(/obj/item/stack/sheet/metal/cyborg) in src.module
-	stack_wood = locate(/obj/item/stack/sheet/wood/cyborg) in src.module
+	stack_wood = locate(/obj/item/stack/sheet/wood) in src.module
 	stack_glass = locate(/obj/item/stack/sheet/glass/cyborg) in src.module
 	stack_plastic = locate(/obj/item/stack/sheet/mineral/plastic/cyborg) in src.module
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -364,7 +364,7 @@
 					stack = stack_glass
 				if("wood")
 					if(!stack_wood)
-						stack_wood = new /obj/item/stack/sheet/wood/cyborg(src.module)
+						stack_wood = new /obj/item/stack/sheet/wood(src.module)
 						stack_wood.amount = 1
 					stack = stack_wood
 				if("plastic")

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -175,8 +175,8 @@
 		/obj/item/stack/sheet/glass/cyborg = 50,
 		/obj/item/stack/sheet/rglass/cyborg = 50,
 		/obj/item/stack/cable_coil/cyborg = 50,
-		/obj/item/stack/rods = 30,
-		/obj/item/stack/tile/plasteel = 20
+		/obj/item/stack/rods/cyborg = 60,
+		/obj/item/stack/tile/plasteel/cyborg = 20
 		)
 
 /obj/item/weapon/robot_module/engineering/New()
@@ -462,9 +462,9 @@
 	stacktypes = list(
 		/obj/item/stack/sheet/wood/cyborg = 10,
 		/obj/item/stack/sheet/rglass/cyborg = 50,
-		/obj/item/stack/tile/wood = 20,
-		/obj/item/stack/rods = 30,
-		/obj/item/stack/tile/plasteel = 20,
+		/obj/item/stack/tile/wood/cyborg = 20,
+		/obj/item/stack/rods/cyborg/ = 60,
+		/obj/item/stack/tile/plasteel/cyborg = 20,
 		/obj/item/stack/sheet/metal/cyborg = 50,
 		/obj/item/stack/sheet/glass/cyborg = 50,
 		/obj/item/stack/cable_coil/cyborg = 30

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -460,7 +460,7 @@
 	name = "drone module"
 	module_type = "Engineer"
 	stacktypes = list(
-		/obj/item/stack/sheet/wood/cyborg = 10,
+		/obj/item/stack/sheet/wood = 10,
 		/obj/item/stack/sheet/rglass/cyborg = 50,
 		/obj/item/stack/tile/wood = 20,
 		/obj/item/stack/rods/cyborg = 60,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -176,7 +176,7 @@
 		/obj/item/stack/sheet/rglass/cyborg = 50,
 		/obj/item/stack/cable_coil/cyborg = 50,
 		/obj/item/stack/rods/cyborg = 60,
-		/obj/item/stack/tile/plasteel/cyborg = 20
+		/obj/item/stack/tile/plasteel = 20
 		)
 
 /obj/item/weapon/robot_module/engineering/New()
@@ -462,9 +462,9 @@
 	stacktypes = list(
 		/obj/item/stack/sheet/wood/cyborg = 10,
 		/obj/item/stack/sheet/rglass/cyborg = 50,
-		/obj/item/stack/tile/wood/cyborg = 20,
-		/obj/item/stack/rods/cyborg/ = 60,
-		/obj/item/stack/tile/plasteel/cyborg = 20,
+		/obj/item/stack/tile/wood = 20,
+		/obj/item/stack/rods/cyborg = 60,
+		/obj/item/stack/tile/plasteel = 20,
 		/obj/item/stack/sheet/metal/cyborg = 50,
 		/obj/item/stack/sheet/glass/cyborg = 50,
 		/obj/item/stack/cable_coil/cyborg = 30


### PR DESCRIPTION
Metal rods have a cyborg version now. Changed the old version to cyborg versions for drones and cyborgs. Increased the amount of metal rods synths start with to one full stack, which is 60 rods.

~~I'm praying that it's this easy, but I have a strong urge that I'll need to change other stuff related to rods, maybe. Let me know if that's the case.~~ It wasn't as easy as it should have been.

No changelog because this doesn't really affect anything from a gameplay standpoint. I could changelog the increased number of starting rods, but it doesn't matter that much since enough time in a charger will bring a cyborg to a full stack anyway.