### PR TITLE
Refactor of Simple Animal Eating

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -63,8 +63,8 @@
 
 	var/ventcrawler = 0 //Determines if the mob can go through the vents.
 	var/has_fine_manipulation = 1 // Can use small items.
-	var/can_consume_mobs = 0 //can it consume mobs?
-	var/list/allowed_consumed_mobs = list()
+
+	var/list/allowed_consumed_mobs = list() //If a species can consume mobs, put the type of mobs it can consume here.
 
 	var/flags = 0       // Various specific features.
 	var/clothing_flags = 0 // Underwear and socks.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -63,6 +63,8 @@
 
 	var/ventcrawler = 0 //Determines if the mob can go through the vents.
 	var/has_fine_manipulation = 1 // Can use small items.
+	var/can_consume_mobs = 0 //can it consume mobs?
+	var/list/allowed_consumed_mobs = list()
 
 	var/flags = 0       // Various specific features.
 	var/clothing_flags = 0 // Underwear and socks.

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -55,6 +55,9 @@
 	flesh_color = "#34AF10"
 	reagent_tag = PROCESS_ORG
 	base_color = "#066000"
+	can_consume_mobs = 1
+	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
+								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/tribble)
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
@@ -106,6 +109,9 @@
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
+	can_consume_mobs = 1
+	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/chick, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot,
+								 /mob/living/simple_animal/tribble)
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
@@ -147,6 +153,9 @@
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#966464"
 	base_color = "#B43214"
+	can_consume_mobs = 1
+	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
+								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/tribble)
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
@@ -354,6 +363,8 @@
 	dietflags = DIET_HERB
 	blood_color = "#FB9800"
 	reagent_tag = PROCESS_ORG
+	can_consume_mobs = 1
+	allowed_consumed_mobs = list(/mob/living/simple_animal/diona)
 
 	suicide_messages = list(
 		"is attempting to bite their antenna off!",

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -55,7 +55,7 @@
 	flesh_color = "#34AF10"
 	reagent_tag = PROCESS_ORG
 	base_color = "#066000"
-	can_consume_mobs = 1
+
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
 								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/tribble)
 
@@ -109,7 +109,7 @@
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#AFA59E"
 	base_color = "#333333"
-	can_consume_mobs = 1
+
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/chick, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot,
 								 /mob/living/simple_animal/tribble)
 
@@ -153,7 +153,7 @@
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#966464"
 	base_color = "#B43214"
-	can_consume_mobs = 1
+
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
 								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/tribble)
 
@@ -363,7 +363,7 @@
 	dietflags = DIET_HERB
 	blood_color = "#FB9800"
 	reagent_tag = PROCESS_ORG
-	can_consume_mobs = 1
+
 	allowed_consumed_mobs = list(/mob/living/simple_animal/diona)
 
 	suicide_messages = list(

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -245,7 +245,7 @@
 			if(M.loc != src)
 				stomach_contents.Remove(M)
 				continue
-			if(istype(M, /mob/living/carbon) && stat != 2)
+			if(istype(M, /mob/living) && stat != 2)
 				if(M.stat == 2)
 					M.death(1)
 					stomach_contents.Remove(M)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -6,7 +6,7 @@
 #define EAT_TIME_FAT 100
 
 //time it takes for a mob to be eaten (in deciseconds) (overrides mob eat time)
-#define EAT_TIME_MOUSE 30
+#define EAT_TIME_ANIMAL 30
 
 /obj/item/weapon/grab
 	name = "grab"
@@ -413,10 +413,8 @@
 	if(isalien(attacker) && iscarbon(prey)) //Xenomorphs eating carbon mobs
 		return 1
 
-	if(ishuman(attacker) && attacker.get_species() == "Kidan" && istype(prey,/mob/living/simple_animal/diona)) //Kidan eating nymphs
-		return 1
-
-	if(ishuman(attacker) && attacker.get_species() == "Tajaran"  && istype(prey,/mob/living/simple_animal/mouse)) //Tajaran eating mice. Meow!
+	var/mob/living/carbon/human/H = attacker
+	if(ishuman(H) && H.species.can_consume_mobs && is_type_in_list(prey,  H.species.allowed_consumed_mobs)) //species eating of other mobs
 		return 1
 
 	return 0
@@ -425,8 +423,8 @@
 	if(isalien(attacker))
 		return EAT_TIME_XENO //xenos get a speed boost
 
-	if(istype(prey,/mob/living/simple_animal/mouse)) //mice get eaten at xeno-eating-speed regardless
-		return EAT_TIME_MOUSE
+	if(istype(prey,/mob/living/simple_animal)) //simple animals get eaten at xeno-eating-speed regardless
+		return EAT_TIME_ANIMAL
 
 	return EAT_TIME_FAT //if it doesn't fit into the above, it's probably a fat guy, take EAT_TIME_FAT to do it
 
@@ -447,4 +445,4 @@
 #undef EAT_TIME_XENO
 #undef EAT_TIME_FAT
 
-#undef EAT_TIME_MOUSE
+#undef EAT_TIME_ANIMAL

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -414,7 +414,7 @@
 		return 1
 
 	var/mob/living/carbon/human/H = attacker
-	if(ishuman(H) && H.species.can_consume_mobs && is_type_in_list(prey,  H.species.allowed_consumed_mobs)) //species eating of other mobs
+	if(ishuman(H) && is_type_in_list(prey,  H.species.allowed_consumed_mobs)) //species eating of other mobs
 		return 1
 
 	return 0


### PR DESCRIPTION
What started off as someone poking me to allow Vulpkanin to eat chickens....turned into a refactor of eating of simple animals in relation to particular species.

Simple animal eating (or any mob, really) is now governed by a single var on each species. In addition to this, you can specify a list of "legal" mobs that that species can eat---yes, you can technically specify other non-simple animal mobs, but that's generally not a good idea. On the whole this means less snowflaking of mob checks in grab code and allows for much easier expansion in the future.

Changes
- Tajarans can now eat mice, chicks, parrots, and tribbles..generally smallish prey type animals
- Vulpkanin and Unathi can eat mice, chicks, lizards, chickens, crabs, parrots, and tribbles...due to their superior strength and strongest jaws, both these races can eat larger prey.
- Kidan can still only eat nymphs

Fixes
- Fixes simple animals never dying in your stomach, digesting, or giving you nutrition

:cl: Fox McCloud
add: Tajarans can now eat mice, chicks, parrots, and tribbles
add: Vulpkanin and Unathi can now eat mice, chicks, lizards, chickens, crabs, parrtos, and tribbles
/:cl: