### PR TITLE
Reagent Container Tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -215,9 +215,14 @@
 	use_to_pickup = 1
 	storage_slots = 14
 	display_contents_with_number = 1
+	var/base_name = ""
+	var/label_text = ""
+
+/obj/item/weapon/storage/pill_bottle/New()
+	..()
+	base_name = name
 
 /obj/item/weapon/storage/pill_bottle/MouseDrop(obj/over_object as obj) //Quick pillbottle fix. -Agouri
-
 	if (ishuman(usr)) //Can monkeys even place items in the pocket slots? Leaving this in just in case~
 		var/mob/M = usr
 		if (!( istype(over_object, /obj/screen) ))
@@ -238,6 +243,24 @@
 			src.show_to(usr)
 			return
 	return
+
+/obj/item/weapon/storage/pill_bottle/attackby(var/obj/item/I, mob/user as mob, params)
+	if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/flashlight/pen))
+		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
+		if(length(tmp_label) > MAX_NAME_LEN)
+			user << "<span class='warning'>The label can be at most [MAX_NAME_LEN] characters long.</span>"
+		else
+			user << "<span class='notice'>You set the label to \"[tmp_label]\".</span>"
+			label_text = tmp_label
+			update_name_label()
+	else
+		..()
+
+/obj/item/weapon/storage/pill_bottle/proc/update_name_label()
+	if(label_text == "")
+		name = base_name
+	else
+		name = "[base_name] ([label_text])"
 
 /obj/item/weapon/storage/pill_bottle/charcoal
 	name = "Pill bottle (Charcoal)"

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -79,7 +79,11 @@
 
 /obj/item/weapon/reagent_containers/wash(mob/user, atom/source)
 	if(is_open_container())
-		reagents.add_reagent("water", min(volume - reagents.total_volume, amount_per_transfer_from_this))
-		user << "<span class='notice'>You fill [src] from [source].</span>"
-		return
+		if(reagents.total_volume >= volume)
+			user << "span class='warning'>\The [src] is full.</span>"
+			return
+		else
+			reagents.add_reagent("water", min(volume - reagents.total_volume, amount_per_transfer_from_this))
+			user << "<span class='notice'>You fill [src] from [source].</span>"
+			return
 	..()

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -42,133 +42,137 @@
 		/obj/machinery/portable_atmospherics/hydroponics,
 		/obj/machinery/constructable_frame)
 
-	New()
-		..()
-		base_name = name
+/obj/item/weapon/reagent_containers/glass/New()
+	..()
+	base_name = name
 
-	examine(mob/user)
-		if(!..(user, 2))
+/obj/item/weapon/reagent_containers/glass/examine(mob/user)
+	if(!..(user, 2))
+		return
+	if (!is_open_container())
+		user << "<span class='notice'>Airtight lid seals it completely.</span>"
+
+/obj/item/weapon/reagent_containers/glass/attack_self()
+	..()
+	if (is_open_container())
+		usr << "<span class='notice'>You put the lid on \the [src].</span>"
+		flags ^= OPENCONTAINER
+	else
+		usr << "<span class='notice'>You take the lid off \the [src].</span>"
+		flags |= OPENCONTAINER
+	update_icon()
+
+/obj/item/weapon/reagent_containers/glass/afterattack(obj/target, mob/user, proximity)
+	if(!proximity) return
+	if (!is_open_container())
+		return
+
+	for(var/type in can_be_placed_into)
+		if(istype(target, type))
 			return
-		if (!is_open_container())
-			user << "\blue Airtight lid seals it completely."
 
-	attack_self()
-		..()
-		if (is_open_container())
-			usr << "<span class = 'notice'>You put the lid on \the [src]."
-			flags ^= OPENCONTAINER
+	if(ismob(target) && target.reagents && reagents.total_volume)
+		user << "<span class='notice'>You splash the solution onto [target].</span>"
+
+		var/mob/living/M = target
+		var/list/injected = list()
+		for(var/datum/reagent/R in reagents.reagent_list)
+			injected += R.name
+		var/contained = english_list(injected)
+		M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been splashed with [name] by [key_name(user)]. Reagents: [contained]</font>")
+		user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to splash [key_name(M)]. Reagents: [contained]</font>")
+		if(M.ckey)
+			msg_admin_attack("[key_name_admin(user)] splashed [key_name_admin(M)] with [name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)])")
+		if(!iscarbon(user))
+			M.LAssailant = null
 		else
-			usr << "<span class = 'notice'>You take the lid off \the [src]."
-			flags |= OPENCONTAINER
-		update_icon()
+			M.LAssailant = user
 
-	afterattack(obj/target, mob/user, proximity)
-		if(!proximity) return
-		if (!is_open_container())
+		for(var/mob/O in viewers(world.view, user))
+			O.show_message(text("<span class='warning'>[] has been splashed with something by []!</span>", target, user), 1)
+		reagents.reaction(target, TOUCH)
+		spawn(5) reagents.clear_reagents()
+		return
+	else if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
+
+		if(!target.reagents.total_volume && target.reagents)
+			user << "<span class='warning'>[target] is empty.</span>"
 			return
 
-		for(var/type in src.can_be_placed_into)
-			if(istype(target, type))
-				return
-
-		if(ismob(target) && target.reagents && reagents.total_volume)
-			user << "\blue You splash the solution onto [target]."
-
-			var/mob/living/M = target
-			var/list/injected = list()
-			for(var/datum/reagent/R in src.reagents.reagent_list)
-				injected += R.name
-			var/contained = english_list(injected)
-			M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been splashed with [src.name] by [key_name(user)]. Reagents: [contained]</font>")
-			user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to splash [key_name(M)]. Reagents: [contained]</font>")
-			if(M.ckey)
-				msg_admin_attack("[key_name_admin(user)] splashed [key_name_admin(M)] with [src.name]. Reagents: [contained] (INTENT: [uppertext(user.a_intent)])")
-			if(!iscarbon(user))
-				M.LAssailant = null
-			else
-				M.LAssailant = user
-
-			for(var/mob/O in viewers(world.view, user))
-				O.show_message(text("\red [] has been splashed with something by []!", target, user), 1)
-			src.reagents.reaction(target, TOUCH)
-			spawn(5) src.reagents.clear_reagents()
-			return
-		else if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
-
-			if(!target.reagents.total_volume && target.reagents)
-				user << "\red [target] is empty."
-				return
-
-			if(reagents.total_volume >= reagents.maximum_volume)
-				user << "\red [src] is full."
-				return
-
-			var/trans = target.reagents.trans_to(src, target:amount_per_transfer_from_this)
-			user << "\blue You fill [src] with [trans] units of the contents of [target]."
-
-		else if(target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
-			if(!reagents.total_volume)
-				user << "\red [src] is empty."
-				return
-
-			if(target.reagents.total_volume >= target.reagents.maximum_volume)
-				user << "\red [target] is full."
-				return
-
-			// /vg/: Logging transfers of bad things
-			if(target.reagents_to_log.len)
-				var/list/badshit=list()
-				for(var/bad_reagent in target.reagents_to_log)
-					if(reagents.has_reagent(bad_reagent))
-						badshit += reagents_to_log[bad_reagent]
-				if(badshit.len)
-					var/hl="\red <b>([english_list(badshit)])</b> \black"
-					message_admins("[key_name_admin(user)] added [reagents.get_reagent_ids(1)] to \a [target] with [src].[hl]")
-					log_game("[key_name(user)] added [reagents.get_reagent_ids(1)] to \a [target] with [src].")
-
-			var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
-			user << "\blue You transfer [trans] units of the solution to [target]."
-
-		/*else if(istype(target, /obj/machinery/bunsen_burner))
+		if(reagents.total_volume >= reagents.maximum_volume)
+			user << "<span class='warning'>[src] is full.</span>"
 			return
 
-		else if(istype(target, /obj/machinery/radiocarbon_spectrometer))
-			return*/
+		var/trans = target.reagents.trans_to(src, target:amount_per_transfer_from_this)
+		user << "<span class='notice'>You fill [src] with [trans] units of the contents of [target].</span>"
 
-		else if(istype(target, /obj/effect/decal/cleanable)) //stops splashing while scooping up fluids
+	else if(target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
+		if(!reagents.total_volume)
+			user << "<span class='warning'>[src] is empty.</span>"
 			return
 
-		else if(reagents.total_volume)
-			user << "\blue You splash the solution onto [target]."
-			src.reagents.reaction(target, TOUCH)
-			spawn(5) src.reagents.clear_reagents()
+		if(target.reagents.total_volume >= target.reagents.maximum_volume)
+			user << "<span class='warning'>[target] is full.</span>"
 			return
 
+		// /vg/: Logging transfers of bad things
+		if(target.reagents_to_log.len)
+			var/list/badshit=list()
+			for(var/bad_reagent in target.reagents_to_log)
+				if(reagents.has_reagent(bad_reagent))
+					badshit += reagents_to_log[bad_reagent]
+			if(badshit.len)
+				var/hl="\red <b>([english_list(badshit)])</b> \black"
+				message_admins("[key_name_admin(user)] added [reagents.get_reagent_ids(1)] to \a [target] with [src].[hl]")
+				log_game("[key_name(user)] added [reagents.get_reagent_ids(1)] to \a [target] with [src].")
 
-	attackby(var/obj/item/I, mob/user as mob, params)
-		if(istype(I, /obj/item/clothing/mask/cigarette)) //ciggies are weird
-			return
-		if(is_hot(I))
-			if(src.reagents)
-				src.reagents.chem_temp += 15
-				user << "<span class='notice'>You heat [src] with [I].</span>"
-				src.reagents.handle_reactions()
-		if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/flashlight/pen))
-			var/tmp_label = sanitize(input(user, "Enter a label for [src.name]","Label",src.label_text))
-			if(length(tmp_label) > 10)
-				user << "\red The label can be at most 10 characters long."
-			else
-				user << "\blue You set the label to \"[tmp_label]\"."
-				src.label_text = tmp_label
-				src.update_name_label()
-		if(istype(I,/obj/item/weapon/storage/bag))
-			..()
+		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
+		user << "<span class='notice'>You transfer [trans] units of the solution to [target].</span>"
 
-	proc/update_name_label()
-		if(src.label_text == "")
-			src.name = src.base_name
+	else if(istype(target, /obj/item/weapon/reagent_containers/glass) && !target.is_open_container())
+		user << "<span class='warning'>You cannot fill [target] while it is sealed.</span>"
+		return
+
+	/*else if(istype(target, /obj/machinery/bunsen_burner))
+		return
+
+	else if(istype(target, /obj/machinery/radiocarbon_spectrometer))
+		return*/
+
+	else if(istype(target, /obj/effect/decal/cleanable)) //stops splashing while scooping up fluids
+		return
+
+	else if(reagents.total_volume)
+		user << "<span class='notice'>You splash the solution onto [target].</span>"
+		reagents.reaction(target, TOUCH)
+		spawn(5) reagents.clear_reagents()
+		return
+
+
+/obj/item/weapon/reagent_containers/glass/attackby(var/obj/item/I, mob/user as mob, params)
+	if(istype(I, /obj/item/clothing/mask/cigarette)) //ciggies are weird
+		return
+	if(is_hot(I))
+		if(reagents)
+			reagents.chem_temp += 15
+			user << "<span class='notice'>You heat [src] with [I].</span>"
+			reagents.handle_reactions()
+	if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/flashlight/pen))
+		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
+		if(length(tmp_label) > 10)
+			user << "\red The label can be at most 10 characters long."
 		else
-			src.name = "[src.base_name] ([src.label_text])"
+			user << "<span class='notice'>You set the label to \"[tmp_label]\".</span>"
+			label_text = tmp_label
+			update_name_label()
+	if(istype(I,/obj/item/weapon/storage/bag))
+		..()
+
+/obj/item/weapon/reagent_containers/glass/proc/update_name_label()
+	if(label_text == "")
+		name = base_name
+	else
+		name = "[base_name] ([label_text])"
 
 /obj/item/weapon/reagent_containers/glass/beaker
 	name = "beaker"
@@ -179,45 +183,45 @@
 	materials = list(MAT_GLASS=500)
 	var/obj/item/device/assembly_holder/assembly = null
 
-	on_reagent_change()
-		update_icon()
-
-	pickup(mob/user)
-		..()
-		update_icon()
-
-	dropped(mob/user)
-		..()
-		update_icon()
-
-	attack_hand()
-		..()
-		update_icon()
-
+/obj/item/weapon/reagent_containers/glass/beaker/on_reagent_change()
 	update_icon()
-		overlays.Cut()
 
-		if(reagents.total_volume)
-			var/image/filling = image('icons/obj/reagentfillings.dmi', src, "[icon_state]10")
+/obj/item/weapon/reagent_containers/glass/beaker/pickup(mob/user)
+	..()
+	update_icon()
 
-			var/percent = round((reagents.total_volume / volume) * 100)
-			switch(percent)
-				if(0 to 9)		filling.icon_state = "[icon_state]-10"
-				if(10 to 24) 	filling.icon_state = "[icon_state]10"
-				if(25 to 49)	filling.icon_state = "[icon_state]25"
-				if(50 to 74)	filling.icon_state = "[icon_state]50"
-				if(75 to 79)	filling.icon_state = "[icon_state]75"
-				if(80 to 90)	filling.icon_state = "[icon_state]80"
-				if(91 to INFINITY)	filling.icon_state = "[icon_state]100"
+/obj/item/weapon/reagent_containers/glass/beaker/dropped(mob/user)
+	..()
+	update_icon()
 
-			filling.icon += mix_color_from_reagents(reagents.reagent_list)
-			overlays += filling
+/obj/item/weapon/reagent_containers/glass/beaker/attack_hand()
+	..()
+	update_icon()
 
-		if (!is_open_container())
-			var/image/lid = image(icon, src, "lid_[initial(icon_state)]")
-			overlays += lid
-		if(assembly)
-			overlays += "assembly"
+/obj/item/weapon/reagent_containers/glass/beaker/update_icon()
+	overlays.Cut()
+
+	if(reagents.total_volume)
+		var/image/filling = image('icons/obj/reagentfillings.dmi', src, "[icon_state]10")
+
+		var/percent = round((reagents.total_volume / volume) * 100)
+		switch(percent)
+			if(0 to 9)		filling.icon_state = "[icon_state]-10"
+			if(10 to 24) 	filling.icon_state = "[icon_state]10"
+			if(25 to 49)	filling.icon_state = "[icon_state]25"
+			if(50 to 74)	filling.icon_state = "[icon_state]50"
+			if(75 to 79)	filling.icon_state = "[icon_state]75"
+			if(80 to 90)	filling.icon_state = "[icon_state]80"
+			if(91 to INFINITY)	filling.icon_state = "[icon_state]100"
+
+		filling.icon += mix_color_from_reagents(reagents.reagent_list)
+		overlays += filling
+
+	if (!is_open_container())
+		var/image/lid = image(icon, src, "lid_[initial(icon_state)]")
+		overlays += lid
+	if(assembly)
+		overlays += "assembly"
 
 /obj/item/weapon/reagent_containers/glass/beaker/verb/remove_assembly()
 	set name = "Remove Assembly"
@@ -309,23 +313,20 @@
 	possible_transfer_amounts = list(5,10,15,25,30,50,100,300)
 	flags = OPENCONTAINER
 
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone
-	New()
-		..()
-		reagents.add_reagent("cryoxadone", 30)
-		update_icon()
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone/New()
+	..()
+	reagents.add_reagent("cryoxadone", 30)
+	update_icon()
 
-/obj/item/weapon/reagent_containers/glass/beaker/sulphuric
-	New()
-		..()
-		reagents.add_reagent("sacid", 50)
-		update_icon()
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric/New()
+	..()
+	reagents.add_reagent("sacid", 50)
+	update_icon()
 
-/obj/item/weapon/reagent_containers/glass/beaker/slime
-	New()
-		..()
-		reagents.add_reagent("slimejelly", 50)
-		update_icon()
+/obj/item/weapon/reagent_containers/glass/beaker/slime/New()
+	..()
+	reagents.add_reagent("slimejelly", 50)
+	update_icon()
 
 /obj/item/weapon/reagent_containers/glass/bucket
 	desc = "It's a bucket."
@@ -340,15 +341,15 @@
 	volume = 120
 	flags = OPENCONTAINER
 
-	attackby(var/obj/D, mob/user as mob, params)
-		if(isprox(D))
-			user << "You add [D] to [src]."
-			qdel(D)
-			user.put_in_hands(new /obj/item/weapon/bucket_sensor)
-			user.unEquip(src)
-			qdel(src)
-		else
-			..()
+/obj/item/weapon/reagent_containers/glass/bucket/attackby(var/obj/D, mob/user as mob, params)
+	if(isprox(D))
+		user << "You add [D] to [src]."
+		qdel(D)
+		user.put_in_hands(new /obj/item/weapon/bucket_sensor)
+		user.unEquip(src)
+		qdel(src)
+	else
+		..()
 
 /obj/item/weapon/reagent_containers/glass/beaker/vial
 	name = "vial"

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -160,7 +160,7 @@
 	if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/flashlight/pen))
 		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
 		if(length(tmp_label) > 10)
-			user << "\red The label can be at most 10 characters long."
+			user << "<span class='warning'>The label can be at most 10 characters long.</span>"
 		else
 			user << "<span class='notice'>You set the label to \"[tmp_label]\".</span>"
 			label_text = tmp_label

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -159,8 +159,8 @@
 			reagents.handle_reactions()
 	if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/flashlight/pen))
 		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
-		if(length(tmp_label) > 10)
-			user << "<span class='warning'>The label can be at most 10 characters long.</span>"
+		if(length(tmp_label) > MAX_NAME_LEN)
+			user << "<span class='warning'>The label can be at most [MAX_NAME_LEN] characters long.</span>"
 		else
 			user << "<span class='notice'>You set the label to \"[tmp_label]\".</span>"
 			label_text = tmp_label


### PR DESCRIPTION
Notifies the player when the container they are filling from a sink is full.
- Previously would just continue to show the "You fill <thing> from the sink." message indefinitely.

Prevents splashing the contents of a container onto a beaker/bucket that has a lid on it.
- Now displays a message about the lid and stops you from wasting all those chems.

Removed some relative pathing and color macros.

Added the ability to label pill bottles with pens.

Increased the acceptable length of pen labels on beakers/buckets and pill bottles to 26
- This value is defined by MAX_NAME_LEN, so it is more standardized through the code
 - For reference, this value is used by labeling food with pens

:cl:
tweak: Let's you know when your container is full when filling from sinks.
tweak: Prevents splashing containers onto beakers and buckets that have a lid on them.
rscadd: Pill bottles can now be labeled with a simple pen.
tweak: Beakers/buckets (and pill bottles) now accept 26 character labels from pens.
/:cl: