### PR TITLE
Fixes Overly Durable Mobs

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -94,3 +94,5 @@
 #define DEFAULT_ITEM_PUTON_DELAY		20  //time taken (in deciseconsd) to reverse-strip somebody
 
 #define IGNORE_ACCESS -1
+
+#define MOB_THRESHOLD_CRIT 0

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -67,7 +67,7 @@
 			return 1
 
 		//UNCONSCIOUS. NO-ONE IS HOME
-		if( (getOxyLoss() > 50) || (config.health_threshold_crit >= health) )
+		if( (getOxyLoss() > 50) || (MOB_THRESHOLD_CRIT >= health) )
 			if( health <= 20 && prob(1) )
 				spawn(0)
 					emote("gasp")

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -4,8 +4,8 @@
 	icon_state = "larva0"
 	pass_flags = PASSTABLE | PASSMOB
 
-	maxHealth = 30
-	health = 30
+	maxHealth = 25
+	health = 25
 	density = 0
 
 	var/amount_grown = 0

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -19,14 +19,14 @@
 		blinded = 1
 		silent = 0
 	else				//ALIVE. LIGHTS ARE ON
-		if(health < -25 || brain_op_stage == 4.0)
+		if(health <= -maxHealth|| brain_op_stage == 4.0)
 			death()
 			blinded = 1
 			silent = 0
 			return 1
 
 		//UNCONSCIOUS. NO-ONE IS HOME
-		if( (getOxyLoss() > 25) || (config.health_threshold_crit >= health) )
+		if( (getOxyLoss() > 25) || (MOB_THRESHOLD_CRIT >= health) )
 			//if( health <= 20 && prob(1) )
 			//	spawn(0)
 			//		emote("gasp")

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -173,7 +173,7 @@
 		death()
 		return
 
-	else if(src.health <= config.health_threshold_crit)
+	else if(src.health <= MOB_THRESHOLD_CRIT)
 
 		if(!src.reagents.has_reagent("epinephrine"))
 			src.adjustOxyLoss(10)


### PR DESCRIPTION
Fixes a longgg standing issue with a few mobs being overly durable.

Simply put, when Bay changed the critical threshold (largely for the intent of human mobs) from 0 to -50, they didn't even remotely factor in how it would impact other mobs. This PR corrects that.

This effectively means that xenos and slimes will go into crit 50 health sooner--which, IMO, is fine; human mobs are far less durable by virtue of being able to get broken bones, have internal damage, bleeding, and other deleterious effects that make the extra 50 health less of a "dig deal".

Lowers the larva health from 30 to 25 (This was only done due to a bug with immortal larva because of the wonky health threshold).

While this is technically a fix, as far as I'm concerned, it's big enough that I feel it warrants the balance tag and a 24 hour wait.

:cl: 
tweak: Slimes and Xenos will lapse into crit sooner
/:cl: