### PR TITLE
Fixes virus stealth to work as reported

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -199,7 +199,7 @@ var/list/advance_cures = 	list(
 
 	if(properties && properties.len)
 		switch(properties["stealth"])
-			if(2 to 3)
+			if(2)
 				visibility_flags = HIDDEN_SCANNER
 			if(3 to INFINITY)
 				visibility_flags = HIDDEN_SCANNER|HIDDEN_PANDEMIC

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -182,7 +182,7 @@ var/list/advance_cures = 	list(
 		CRASH("We did not have any symptoms before generating properties.")
 		return
 
-	var/list/properties = list("resistance" = 1, "stealth" = 1, "stage_rate" = 1, "transmittable" = 1, "severity" = 0)
+	var/list/properties = list("resistance" = 1, "stealth" = 0, "stage_rate" = 1, "transmittable" = 1, "severity" = 0)
 
 	for(var/datum/symptom/S in symptoms)
 


### PR DESCRIPTION
There was a base "1" being added to all advanced virus stealths, which caused wiki and code-inconsistent behavior, such as a virus with only spontaneous combustion (stealth of +1) being invisible to hand scanners (which requires a total stealth of 2).

:cl:Crazylemon
bugfix: Removes an offset from the advanced virus stealth calculation, causing viruses to be more stealthy than the sum of their symptoms.
/:cl: