### PR TITLE
Add inactive hand to carbon get_access

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -886,6 +886,10 @@ so that different stomachs can handle things in different ways VB*/
 /mob/living/carbon/get_access()
 	. = ..()
 
-	var/obj/item/I = get_active_hand()
-	if(I)
-		. |= I.GetAccess()
+	var/obj/item/RH = get_active_hand()
+	if(RH)
+		. |= RH.GetAccess()
+
+	var/obj/item/LH = get_inactive_hand()
+	if(LH)
+		. |= LH.GetAccess()


### PR DESCRIPTION
:cl:
rscadd: Items in your off hand will now count towards access.
/:cl:

Minor thing, probably useful.