### PR TITLE
Simple Animal Spawn Refactor

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -94,3 +94,7 @@
 #define DEFAULT_ITEM_PUTON_DELAY		20  //time taken (in deciseconsd) to reverse-strip somebody
 
 #define IGNORE_ACCESS -1
+
+#define CHEM_MOB_SPAWN_INVALID   0
+#define CHEM_MOB_SPAWN_HOSTILE   1
+#define CHEM_MOB_SPAWN_FRIENDLY  2

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -24,53 +24,6 @@ var/global/list/dead_mob_list = list()				//List of all dead mobs, including cli
 var/global/list/respawnable_list = list()				//List of all mobs, dead or in mindless creatures that still be respawned.
 var/global/list/simple_animal_list = list()			//List of all simple animals, including clientless
 
-//global var of unsafe-to-spawn-on-reaction mobs
-var/global/list/blocked_mobs = list(/mob/living/simple_animal,
-			/mob/living/simple_animal/hostile,
-			/mob/living/simple_animal/hostile/pirate,
-			/mob/living/simple_animal/hostile/pirate/ranged,
-			/mob/living/simple_animal/hostile/russian,
-			/mob/living/simple_animal/hostile/russian/ranged,
-			/mob/living/simple_animal/hostile/syndicate,
-			/mob/living/simple_animal/hostile/syndicate/melee,
-			/mob/living/simple_animal/hostile/syndicate/melee/space,
-			/mob/living/simple_animal/hostile/syndicate/ranged,
-			/mob/living/simple_animal/hostile/syndicate/ranged/space,
-			/mob/living/simple_animal/hostile/alien/queen/large,
-			/mob/living/simple_animal/hostile/retaliate,
-			/mob/living/simple_animal/hostile/retaliate/clown,
-			/mob/living/simple_animal/hostile/mushroom,
-			/mob/living/simple_animal/hostile/asteroid,
-			/mob/living/simple_animal/hostile/asteroid/basilisk,
-			/mob/living/simple_animal/hostile/asteroid/goldgrub,
-			/mob/living/simple_animal/hostile/asteroid/goliath,
-			/mob/living/simple_animal/hostile/asteroid/hivelord,
-			/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
-			/mob/living/simple_animal/hostile/carp/holocarp,
-			/mob/living/simple_animal/hostile/mining_drone,
-			/mob/living/simple_animal/hostile/spaceWorm,
-			/mob/living/simple_animal/hostile/spaceWorm/wormHead,
-			/mob/living/simple_animal/ascendant_shadowling,
-			/mob/living/simple_animal/slaughter,
-			/mob/living/simple_animal/hostile/retaliate/araneus,
-			/mob/living/simple_animal/hostile/syndicate/ranged/orion,
-			/mob/living/simple_animal/hostile/statue,
-			/mob/living/simple_animal/hostile/guardian,
-			/mob/living/simple_animal/hostile/guardian/fire,
-			/mob/living/simple_animal/hostile/guardian/healer,
-			/mob/living/simple_animal/hostile/guardian/punch,
-			/mob/living/simple_animal/hostile/guardian/punch/sealpunch,
-			/mob/living/simple_animal/hostile/guardian/healer/sealhealer,
-			/mob/living/simple_animal/hostile/guardian/ranged,
-			/mob/living/simple_animal/hostile/guardian/bomb,
-			/mob/living/simple_animal/hostile/winter/santa,
-			/mob/living/simple_animal/hostile/winter/santa/stage_1,
-			/mob/living/simple_animal/hostile/winter/santa/stage_2,
-			/mob/living/simple_animal/hostile/winter/santa/stage_3,
-			/mob/living/simple_animal/hostile/winter/santa/stage_4,
-			/mob/living/simple_animal/hostile/alien/maid
-			)
-
 var/global/list/med_hud_users = list()
 var/global/list/sec_hud_users = list()
 var/global/list/antag_hud_users = list()

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -40,7 +40,7 @@
 	var/obj/effect/blob/factory/factory = null
 	var/list/human_overlays = list()
 	var/is_zombie = 0
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/blob/blobspore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -161,7 +161,7 @@
 	maxbodytemp = 360
 	force_threshold = 10
 	environment_smash = 3
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -40,6 +40,7 @@
 	var/obj/effect/blob/factory/factory = null
 	var/list/human_overlays = list()
 	var/is_zombie = 0
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/blob/blobspore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -160,6 +161,7 @@
 	maxbodytemp = 360
 	force_threshold = 10
 	environment_smash = 3
+	gold_core_spawnable = 1
 
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -41,15 +41,17 @@
 		if(animation)	qdel(animation)
 
 	spawn(rand(30,120))
-		var/blocked = blocked_mobs //global variable for blocked mobs
+		var/list/tear_critters = list()
+		for(var/T in typesof(/mob/living/simple_animal))
+			var/mob/living/simple_animal/SA = T
+			if(initial(SA.gold_core_spawnable) == 1)
+				tear_critters += T
 
-		var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
-
-		for(var/i = 1, i <= 5, i++)
-			var/chosen = pick(critters)
-			var/mob/living/simple_animal/hostile/C = new chosen
-			C.faction = list("slimesummon")
-			C.loc = src.loc
+		for(var/i in 1 to 5)
+			var/chosen = pick(tear_critters)
+			var/mob/living/simple_animal/C = new chosen
+			C.faction |= "chemicalsummon"
+			C.forceMove(get_turf(src))
 			if(prob(50))
 				for(var/j = 1, j <= rand(1, 3), j++)
 					step(C, pick(NORTH,SOUTH,EAST,WEST))

--- a/code/modules/events/tear.dm
+++ b/code/modules/events/tear.dm
@@ -44,7 +44,7 @@
 		var/list/tear_critters = list()
 		for(var/T in typesof(/mob/living/simple_animal))
 			var/mob/living/simple_animal/SA = T
-			if(initial(SA.gold_core_spawnable) == 1)
+			if(initial(SA.gold_core_spawnable) == CHEM_MOB_SPAWN_HOSTILE)
 				tear_critters += T
 
 		for(var/i in 1 to 5)

--- a/code/modules/mob/living/simple_animal/friendly/butterfly.dm
+++ b/code/modules/mob/living/simple_animal/friendly/butterfly.dm
@@ -18,6 +18,7 @@
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	ventcrawler = 2
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat = 0)
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/butterfly/New()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/butterfly.dm
+++ b/code/modules/mob/living/simple_animal/friendly/butterfly.dm
@@ -18,7 +18,7 @@
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	ventcrawler = 2
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat = 0)
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/butterfly/New()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -20,6 +20,7 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
+	gold_core_spawnable = 2
 
 //RUNTIME IS ALIVE! SQUEEEEEEEE~
 /mob/living/simple_animal/pet/cat/Runtime
@@ -32,6 +33,7 @@
 	gender = FEMALE
 	var/turns_since_scan = 0
 	var/mob/living/simple_animal/mouse/movement_target
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/pet/cat/Runtime/handle_automated_action()
 	..()
@@ -97,3 +99,4 @@
 	faction = list("syndicate")
 	var/turns_since_scan = 0
 	var/mob/living/simple_animal/mouse/movement_target
+	gold_core_spawnable = 0

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -20,7 +20,7 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 //RUNTIME IS ALIVE! SQUEEEEEEEE~
 /mob/living/simple_animal/pet/cat/Runtime
@@ -33,7 +33,7 @@
 	gender = FEMALE
 	var/turns_since_scan = 0
 	var/mob/living/simple_animal/mouse/movement_target
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /mob/living/simple_animal/pet/cat/Runtime/handle_automated_action()
 	..()
@@ -99,4 +99,4 @@
 	faction = list("syndicate")
 	var/turns_since_scan = 0
 	var/mob/living/simple_animal/mouse/movement_target
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -26,6 +26,7 @@
 	var/obj/item/inventory_head
 	var/obj/item/inventory_back
 	var/facehugger
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/pet/corgi/New()
 	..()
@@ -397,6 +398,7 @@
 	response_help  = "pets"
 	response_disarm = "bops"
 	response_harm   = "kicks"
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/pet/corgi/Ian/process_ai()
 	..()
@@ -553,6 +555,7 @@
 	response_harm   = "kicks"
 	var/turns_since_scan = 0
 	var/puppies = 0
+	gold_core_spawnable = 0
 
 //Lisa already has a cute bow!
 /mob/living/simple_animal/pet/corgi/Lisa/Topic(href, href_list)

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -26,7 +26,7 @@
 	var/obj/item/inventory_head
 	var/obj/item/inventory_back
 	var/facehugger
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/pet/corgi/New()
 	..()
@@ -398,7 +398,7 @@
 	response_help  = "pets"
 	response_disarm = "bops"
 	response_harm   = "kicks"
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /mob/living/simple_animal/pet/corgi/Ian/process_ai()
 	..()
@@ -555,7 +555,7 @@
 	response_harm   = "kicks"
 	var/turns_since_scan = 0
 	var/puppies = 0
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 //Lisa already has a cute bow!
 /mob/living/simple_animal/pet/corgi/Lisa/Topic(href, href_list)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -22,7 +22,7 @@
 	var/obj/item/inventory_mask
 	can_hide = 1
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/crab/handle_automated_movement()
 	//CRAB movement
@@ -47,7 +47,7 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 //LOOK AT THIS - ..()??
 /*/mob/living/simple_animal/crab/attackby(var/obj/item/O as obj, var/mob/user as mob, params)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -22,6 +22,7 @@
 	var/obj/item/inventory_mask
 	can_hide = 1
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/crab/handle_automated_movement()
 	//CRAB movement
@@ -46,6 +47,7 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"
+	gold_core_spawnable = 0
 
 //LOOK AT THIS - ..()??
 /*/mob/living/simple_animal/crab/attackby(var/obj/item/O as obj, var/mob/user as mob, params)

--- a/code/modules/mob/living/simple_animal/friendly/deer.dm
+++ b/code/modules/mob/living/simple_animal/friendly/deer.dm
@@ -15,4 +15,4 @@
 	response_disarm = "gently pushes aside"
 	response_harm = "kicks"
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY

--- a/code/modules/mob/living/simple_animal/friendly/deer.dm
+++ b/code/modules/mob/living/simple_animal/friendly/deer.dm
@@ -15,3 +15,4 @@
 	response_disarm = "gently pushes aside"
 	response_harm = "kicks"
 	can_collar = 1
+	gold_core_spawnable = 2

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -111,7 +111,7 @@
 	health = 50
 	var/milk_content = 0
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/cow/New()
 	..()
@@ -179,7 +179,7 @@
 	small = 1
 	can_hide = 1
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/chick/New()
 	..()
@@ -222,7 +222,7 @@ var/global/chicken_count = 0
 	small = 1
 	can_hide = 1
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/chicken/New()
 	..()
@@ -300,7 +300,7 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/turkey
 	name = "turkey"
@@ -322,7 +322,7 @@ var/global/chicken_count = 0
 	attacktext = "pecks"
 	health = 50
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/goose
 	name = "goose"
@@ -344,7 +344,7 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/seal
 	name = "seal"
@@ -366,7 +366,7 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/walrus
 	name = "walrus"
@@ -388,4 +388,4 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -111,6 +111,7 @@
 	health = 50
 	var/milk_content = 0
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/cow/New()
 	..()
@@ -178,6 +179,7 @@
 	small = 1
 	can_hide = 1
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/chick/New()
 	..()
@@ -220,6 +222,7 @@ var/global/chicken_count = 0
 	small = 1
 	can_hide = 1
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/chicken/New()
 	..()
@@ -297,6 +300,7 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/turkey
 	name = "turkey"
@@ -318,6 +322,7 @@ var/global/chicken_count = 0
 	attacktext = "pecks"
 	health = 50
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/goose
 	name = "goose"
@@ -339,6 +344,7 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/seal
 	name = "seal"
@@ -360,6 +366,7 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/walrus
 	name = "walrus"
@@ -381,3 +388,4 @@ var/global/chicken_count = 0
 	attacktext = "kicks"
 	health = 50
 	can_collar = 1
+	gold_core_spawnable = 2

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -17,11 +17,13 @@
 	response_help = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm = "kicks"
+	gold_core_spawnable = 2
 
 //Captain fox
 /mob/living/simple_animal/pet/fox/Renault
 	name = "Renault"
 	desc = "Renault, the Captain's trustworthy fox. I wonder what it says?"
+	gold_core_spawnable = 0
 
 //Syndi fox
 /mob/living/simple_animal/pet/fox/Syndifox
@@ -33,3 +35,4 @@
 	icon_resting = "Syndifox_rest"
 	flags = NO_BREATHE
 	faction = list("syndicate")
+	gold_core_spawnable = 0

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -17,13 +17,13 @@
 	response_help = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm = "kicks"
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 //Captain fox
 /mob/living/simple_animal/pet/fox/Renault
 	name = "Renault"
 	desc = "Renault, the Captain's trustworthy fox. I wonder what it says?"
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 //Syndi fox
 /mob/living/simple_animal/pet/fox/Syndifox
@@ -35,4 +35,4 @@
 	icon_resting = "Syndifox_rest"
 	flags = NO_BREATHE
 	faction = list("syndicate")
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -22,3 +22,4 @@
 	can_hide = 1
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat = 1)
 	can_collar = 1
+	gold_core_spawnable = 2

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -22,4 +22,4 @@
 	can_hide = 1
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat = 1)
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -31,6 +31,7 @@
 	can_hide = 1
 	holder_type = /obj/item/weapon/holder/mouse
 	can_collar = 1
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/mouse/handle_automated_speech()
 	..()
@@ -144,3 +145,4 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "splats"
+	gold_core_spawnable = 0

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -31,7 +31,7 @@
 	can_hide = 1
 	holder_type = /obj/item/weapon/holder/mouse
 	can_collar = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/mouse/handle_automated_speech()
 	..()
@@ -145,4 +145,4 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "splats"
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID

--- a/code/modules/mob/living/simple_animal/friendly/pug.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pug.dm
@@ -17,7 +17,7 @@
 	response_disarm = "bops"
 	response_harm   = "kicks"
 	see_in_dark = 5
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/pet/pug/process_ai()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/pug.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pug.dm
@@ -17,6 +17,7 @@
 	response_disarm = "bops"
 	response_harm   = "kicks"
 	see_in_dark = 5
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/pet/pug/process_ai()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/tomato.dm
+++ b/code/modules/mob/living/simple_animal/friendly/tomato.dm
@@ -15,4 +15,4 @@
 	harm_intent_damage = 5
 	pass_flags = PASSTABLE
 	can_hide = 1
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY

--- a/code/modules/mob/living/simple_animal/friendly/tomato.dm
+++ b/code/modules/mob/living/simple_animal/friendly/tomato.dm
@@ -15,3 +15,4 @@
 	harm_intent_damage = 5
 	pass_flags = PASSTABLE
 	can_hide = 1
+	gold_core_spawnable = 2

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -29,7 +29,7 @@
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	heat_damage_per_tick = 20
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 
 /mob/living/simple_animal/hostile/alien/drone
@@ -128,7 +128,7 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /obj/item/projectile/neurotox
 	name = "neurotoxin"
@@ -153,7 +153,7 @@
 	icon_state = "maid"
 	icon_living = "maid"
 	icon_dead = "maid_dead"
-	gold_core_spawnable = 0 //no fun allowed
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID //no fun allowed
 
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()
 	if(istype(target, /atom/movable))

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -29,6 +29,7 @@
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	heat_damage_per_tick = 20
+	gold_core_spawnable = 1
 
 
 /mob/living/simple_animal/hostile/alien/drone
@@ -127,6 +128,7 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
+	gold_core_spawnable = 0
 
 /obj/item/projectile/neurotox
 	name = "neurotoxin"
@@ -151,6 +153,7 @@
 	icon_state = "maid"
 	icon_living = "maid"
 	icon_dead = "maid_dead"
+	gold_core_spawnable = 0 //no fun allowed
 
 /mob/living/simple_animal/hostile/alien/maid/AttackingTarget()
 	if(istype(target, /atom/movable))

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -29,6 +29,7 @@
 
 	faction = list("scarybat")
 	var/mob/living/owner
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/scarybat/New(loc, mob/living/L as mob)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -29,7 +29,7 @@
 
 	faction = list("scarybat")
 	var/mob/living/owner
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/scarybat/New(loc, mob/living/L as mob)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -31,6 +31,7 @@
 	var/stance_step = 0
 
 	faction = list("russian")
+	gold_core_spawnable = 1
 
 //SPACE BEARS! SQUEEEEEEEE~     OW! FUCK! IT BIT MY HAND OFF!!
 /mob/living/simple_animal/hostile/bear/Hudson

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -31,7 +31,7 @@
 	var/stance_step = 0
 
 	faction = list("russian")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 //SPACE BEARS! SQUEEEEEEEE~     OW! FUCK! IT BIT MY HAND OFF!!
 /mob/living/simple_animal/hostile/bear/Hudson

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -33,7 +33,7 @@
 
 	faction = list("carp")
 	flying = 1
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/carp/Process_Spacemove(var/movement_dir = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal
@@ -54,7 +54,7 @@
 	icon_state = "holocarp"
 	icon_living = "holocarp"
 	maxbodytemp = INFINITY
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /mob/living/simple_animal/hostile/carp/holocarp/death()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -33,6 +33,7 @@
 
 	faction = list("carp")
 	flying = 1
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/carp/Process_Spacemove(var/movement_dir = 0)
 	return 1	//No drifting in space for space carp!	//original comments do not steal
@@ -53,6 +54,7 @@
 	icon_state = "holocarp"
 	icon_living = "holocarp"
 	maxbodytemp = INFINITY
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/hostile/carp/holocarp/death()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -13,5 +13,5 @@
 	attacktext = "chomps"
 	attack_sound = 'sound/weapons/bite.ogg'
 	faction = list("creature")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 

--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -13,4 +13,5 @@
 	attacktext = "chomps"
 	attack_sound = 'sound/weapons/bite.ogg'
 	faction = list("creature")
+	gold_core_spawnable = 1
 

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -25,7 +25,7 @@
 	speed = 4
 
 	faction = list("faithless")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/faithless/Process_Spacemove(var/movement_dir = 0)
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -25,6 +25,7 @@
 	speed = 4
 
 	faction = list("faithless")
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/faithless/Process_Spacemove(var/movement_dir = 0)
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -49,6 +49,7 @@
 	move_to_delay = 6
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
+	gold_core_spawnable = 1
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -49,7 +49,7 @@
 	move_to_delay = 6
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,6 +21,7 @@
 	ventcrawler = 2
 	var/datum/mind/origin
 	var/egg_lain = 0
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,7 +21,7 @@
 	ventcrawler = 2
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -21,7 +21,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	speak_emote = list("states")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/hivebot/range
 	name = "Hivebot"

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -21,6 +21,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	speak_emote = list("states")
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/hivebot/range
 	name = "Hivebot"

--- a/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
@@ -30,6 +30,7 @@
 
 	layer = 3.1		//so they can stay hidde under the /obj/structure/bush
 	var/stalk_tick_delay = 3
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/panther/ListTargets()
 	var/list/targets = list()
@@ -87,6 +88,7 @@
 
 	layer = 3.1		//so they can stay hidde under the /obj/structure/bush
 	var/stalk_tick_delay = 3
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/snake/ListTargets()
 	var/list/targets = list()

--- a/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle_animals.dm
@@ -30,7 +30,7 @@
 
 	layer = 3.1		//so they can stay hidde under the /obj/structure/bush
 	var/stalk_tick_delay = 3
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/panther/ListTargets()
 	var/list/targets = list()
@@ -88,7 +88,7 @@
 
 	layer = 3.1		//so they can stay hidde under the /obj/structure/bush
 	var/stalk_tick_delay = 3
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/snake/ListTargets()
 	var/list/targets = list()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -30,7 +30,7 @@
 	move_to_delay = 9
 
 	var/is_electronic = 0
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/mimic/FindTarget()
 	. = ..()
@@ -140,7 +140,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	var/mob/living/creator = null // the creator
 	var/destroy_objects = 0
 	var/knockdown_people = 0
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /mob/living/simple_animal/hostile/mimic/copy/New(loc, var/obj/copy, var/mob/living/creator, var/destroy_original = 0)
 	..(loc)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -30,6 +30,7 @@
 	move_to_delay = 9
 
 	var/is_electronic = 0
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/mimic/FindTarget()
 	. = ..()
@@ -139,6 +140,7 @@ var/global/list/protected_objects = list(/obj/structure/table, /obj/structure/ca
 	var/mob/living/creator = null // the creator
 	var/destroy_objects = 0
 	var/knockdown_people = 0
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/hostile/mimic/copy/New(loc, var/obj/copy, var/mob/living/creator, var/destroy_original = 0)
 	..(loc)

--- a/code/modules/mob/living/simple_animal/hostile/poison_bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/poison_bees.dm
@@ -24,7 +24,7 @@
 	//Spaceborn beings don't get hurt by space
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/poison/bees/Process_Spacemove(var/check_drift = 0)
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/poison_bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/poison_bees.dm
@@ -24,6 +24,7 @@
 	//Spaceborn beings don't get hurt by space
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/poison/bees/Process_Spacemove(var/check_drift = 0)
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -132,7 +132,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	flying = 1
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/viscerator/death()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -132,6 +132,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	flying = 1
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/viscerator/death()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -28,6 +28,7 @@
 	minbodytemp = 0
 
 	faction = list("hostile", "winter")
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/tree/FindTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -28,7 +28,7 @@
 	minbodytemp = 0
 
 	faction = list("hostile", "winter")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/tree/FindTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
@@ -33,7 +33,7 @@
 	bodytemperature = 73.0		//it's made of snow and hatred, so it's pretty cold.
 	maxbodytemp = 280.15		//at roughly 7 C, these will start melting (dying) from the warmth. Mind over matter or something.
 	heat_damage_per_tick = 10	//Now With Rapid Thawing Action!
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 
 /mob/living/simple_animal/hostile/winter/snowman/death()
@@ -64,7 +64,7 @@
 
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/winter/santa
 	maxHealth = 150		//if this seems low for a "boss", it's because you have to fight him multiple times, with him fully healing between stages

--- a/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
@@ -33,6 +33,7 @@
 	bodytemperature = 73.0		//it's made of snow and hatred, so it's pretty cold.
 	maxbodytemp = 280.15		//at roughly 7 C, these will start melting (dying) from the warmth. Mind over matter or something.
 	heat_damage_per_tick = 10	//Now With Rapid Thawing Action!
+	gold_core_spawnable = 1
 
 
 /mob/living/simple_animal/hostile/winter/snowman/death()
@@ -63,6 +64,7 @@
 
 	melee_damage_lower = 5
 	melee_damage_upper = 10
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/winter/santa
 	maxHealth = 150		//if this seems low for a "boss", it's because you have to fight him multiple times, with him fully healing between stages

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -82,7 +82,7 @@
 
 	//Parrots are kleptomaniacs. This variable ... stores the item a parrot is holding.
 	var/obj/item/held_item = null
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 
 /mob/living/simple_animal/parrot/New()
@@ -683,7 +683,7 @@
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
 	speak = list("Poly wanna cracker!", ":eCheck the singlo, you chucklefucks!",":eCheck the tesla, you shits!",":eSTOP HOT-WIRING THE ENGINE, FUCKING CHRIST!",":eWire the solars, you lazy bums!",":eWHO TOOK THE DAMN HARDSUITS?",":eOH GOD ITS FREE CALL THE SHUTTLE")
-	gold_core_spawnable = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /mob/living/simple_animal/parrot/Poly/New()
 	ears = new /obj/item/device/radio/headset/headset_eng(src)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -82,6 +82,7 @@
 
 	//Parrots are kleptomaniacs. This variable ... stores the item a parrot is holding.
 	var/obj/item/held_item = null
+	gold_core_spawnable = 2
 
 
 /mob/living/simple_animal/parrot/New()
@@ -272,13 +273,13 @@
 
 	//Sprite and AI update for when a parrot gets pulled
 	if(pulledby && stat == CONSCIOUS)
-		icon_state = "parrot_fly"	
+		icon_state = "parrot_fly"
 
 /mob/living/simple_animal/parrot/process_ai()
 	if(pulledby)
 		parrot_state = PARROT_WANDER
 		return
-	
+
 	if(!isturf(src.loc) || !canmove || buckled)
 		return //If it can't move, dont let it move. (The buckled check probably isn't necessary thanks to canmove)
 
@@ -682,6 +683,7 @@
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
 	speak = list("Poly wanna cracker!", ":eCheck the singlo, you chucklefucks!",":eCheck the tesla, you shits!",":eSTOP HOT-WIRING THE ENGINE, FUCKING CHRIST!",":eWire the solars, you lazy bums!",":eWHO TOOK THE DAMN HARDSUITS?",":eOH GOD ITS FREE CALL THE SHUTTLE")
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/parrot/Poly/New()
 	ears = new /obj/item/device/radio/headset/headset_eng(src)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -67,6 +67,8 @@
 	var/scan_ready = 1
 	var/simplespecies //Sorry, no spider+corgi buttbabies.
 
+	var/gold_core_spawnable = 0 //if 1 can be spawned by plasma with gold core, 2 are 'friendlies' spawned with blood
+
 	var/master_commander = null //holding var for determining who own/controls a sentient simple animal (for sentience potions).
 	var/sentience_type = SENTIENCE_ORGANIC // Sentience type, for slime potions
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -67,7 +67,7 @@
 	var/scan_ready = 1
 	var/simplespecies //Sorry, no spider+corgi buttbabies.
 
-	var/gold_core_spawnable = 0 //if 1 can be spawned by plasma with gold core, 2 are 'friendlies' spawned with blood
+	var/gold_core_spawnable = CHEM_MOB_SPAWN_INVALID //if CHEM_MOB_SPAWN_HOSTILE can be spawned by plasma with gold core, CHEM_MOB_SPAWN_FRIENDLY are 'friendlies' spawned with blood
 
 	var/master_commander = null //holding var for determining who own/controls a sentient simple animal (for sentience potions).
 	var/sentience_type = SENTIENCE_ORGANIC // Sentience type, for slime potions

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -681,34 +681,6 @@ datum/reagent/life
 /datum/chemical_reaction/life/on_reaction(var/datum/reagents/holder, var/created_volume)
 	chemical_mob_spawn(holder, 1, "Life")
 
-proc/chemical_mob_spawn(var/datum/reagents/holder, var/amount_to_spawn, var/reaction_name, var/mob_faction = "chemicalsummon")
-	if(holder && holder.my_atom)
-		var/blocked =  blocked_mobs //global variable for blocked mobs
-
-		var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
-		var/atom/A = holder.my_atom
-		var/turf/T = get_turf(A)
-		var/area/my_area = get_area(T)
-		var/message = "A [reaction_name] reaction has occured in (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>[my_area.name]</A>)"
-		var/mob/M = get(A, /mob)
-		if(M)
-			message += " - carried by: [key_name_admin(M)]"
-		else
-			message += " - last fingerprint: [(A.fingerprintslast ? A.fingerprintslast : "N/A")]"
-
-		message_admins(message, 0, 1)
-
-		playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
-
-		for(var/i = 1, i <= amount_to_spawn, i++)
-			var/chosen = pick(critters)
-			var/mob/living/simple_animal/hostile/C = new chosen
-			C.faction |= mob_faction
-			C.loc = get_turf(holder.my_atom)
-			if(prob(50))
-				for(var/j = 1, j <= rand(1, 3), j++)
-					step(C, pick(NORTH,SOUTH,EAST,WEST))
-
 /datum/reagent/mannitol/on_mob_life(mob/living/M as mob)
 	M.adjustBrainLoss(-3)
 	..()

--- a/code/modules/reagents/newchem/newchem_procs.dm
+++ b/code/modules/reagents/newchem/newchem_procs.dm
@@ -166,4 +166,47 @@
 /datum/reagent/proc/reagent_deleted()
 	return
 
+var/list/chemical_mob_spawn_meancritters = list() // list of possible hostile mobs
+var/list/chemical_mob_spawn_nicecritters = list() // and possible friendly mobs
+/datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_faction = "chemicalsummon")
+	if(holder && holder.my_atom)
+		if(chemical_mob_spawn_meancritters.len <= 0 || chemical_mob_spawn_nicecritters.len <= 0)
+			for(var/T in typesof(/mob/living/simple_animal))
+				var/mob/living/simple_animal/SA = T
+				switch(initial(SA.gold_core_spawnable))
+					if(1)
+						chemical_mob_spawn_meancritters += T
+					if(2)
+						chemical_mob_spawn_nicecritters += T
+		var/atom/A = holder.my_atom
+		var/turf/T = get_turf(A)
+		var/area/my_area = get_area(T)
+		var/message = "A [reaction_name] reaction has occured in [my_area.name]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</A>)"
+		message += " (<A HREF='?_src_=vars;Vars=\ref[A]'>VV</A>)"
+
+		var/mob/M = get(A, /mob)
+		if(M)
+			message += " - Carried By: [key_name_admin(M)](<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[M]'>FLW</A>)"
+		else
+			message += " - Last Fingerprint: [(A.fingerprintslast ? A.fingerprintslast : "N/A")]"
+
+		message_admins(message, 0, 1)
+
+		playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+
+		for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
+			C.flash_eyes()
+		for(var/i = 1, i <= amount_to_spawn, i++)
+			var/chosen
+			if(reaction_name == "Friendly Gold Slime")
+				chosen = pick(chemical_mob_spawn_nicecritters)
+			else
+				chosen = pick(chemical_mob_spawn_meancritters)
+			var/mob/living/simple_animal/C = new chosen
+			C.faction |= mob_faction
+			C.forceMove(get_turf(holder.my_atom))
+			if(prob(50))
+				for(var/j = 1, j <= rand(1, 3), j++)
+					step(C, pick(NORTH,SOUTH,EAST,WEST))
+
 #undef ADDICTION_TIME

--- a/code/modules/reagents/newchem/newchem_procs.dm
+++ b/code/modules/reagents/newchem/newchem_procs.dm
@@ -174,9 +174,9 @@ var/list/chemical_mob_spawn_nicecritters = list() // and possible friendly mobs
 			for(var/T in typesof(/mob/living/simple_animal))
 				var/mob/living/simple_animal/SA = T
 				switch(initial(SA.gold_core_spawnable))
-					if(1)
+					if(CHEM_MOB_SPAWN_HOSTILE)
 						chemical_mob_spawn_meancritters += T
-					if(2)
+					if(CHEM_MOB_SPAWN_FRIENDLY)
 						chemical_mob_spawn_nicecritters += T
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -77,31 +77,16 @@
 		name = "Slime Crit"
 		id = "m_tele"
 		result = null
-		required_reagents = list("plasma" = 5)
+		required_reagents = list("plasma" = 1)
 		result_amount = 1
 		required_container = /obj/item/slime_extract/gold
 		required_other = 1
 		on_reaction(var/datum/reagents/holder)
-
-			var/blocked = blocked_mobs //global variable of blocked mobs
-
-			var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
-
-			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
-
-			for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
-				C.flash_eyes()
-
-			for(var/i = 1, i <= 5, i++)
-				var/chosen = pick(critters)
-				var/mob/living/simple_animal/hostile/C = new chosen
-				C.faction |= "slimesummon"
-				C.loc = get_turf(holder.my_atom)
-				if(prob(50))
-					for(var/j = 1, j <= rand(1, 3), j++)
-						step(C, pick(NORTH,SOUTH,EAST,WEST))
-//				for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-//					O.show_message(text("\red The slime core fizzles disappointingly,"), 1)
+			feedback_add_details("slime_cores_used","[type]")
+			var/turf/T = get_turf(holder.my_atom)
+			T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
+			spawn(50)
+				chemical_mob_spawn(holder, 5, "Gold Slime")
 
 
 	slimecritlesser
@@ -113,26 +98,28 @@
 		required_container = /obj/item/slime_extract/gold
 		required_other = 1
 		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-				O.show_message(text("<span class='danger'>The slime extract begins to vibrate violently!</span>"), 1)
+			feedback_add_details("slime_cores_used","[type]")
+			var/turf/T = get_turf(holder.my_atom)
+			T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
 			spawn(50)
+				chemical_mob_spawn(holder, 3, "Lesser Gold Slime", "neutral")
 
-			if(holder && holder.my_atom)
 
-				var/blocked = blocked_mobs
+	slimecritfriendly
+		name = "Slime Crit Friendly"
+		id = "m_tele5"
+		result = null
+		required_reagents = list("water" = 1)
+		result_amount = 1
+		required_container = /obj/item/slime_extract/gold
+		required_other = 1
+		on_reaction(datum/reagents/holder)
+			feedback_add_details("slime_cores_used","[type]")
+			var/turf/T = get_turf(holder.my_atom)
+			T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
+			spawn(50)
+				chemical_mob_spawn(holder, 1, "Friendly Gold Slime", "neutral")
 
-				var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
-
-				playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
-
-				for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
-					C.flash_eyes()
-
-				var/chosen = pick(critters)
-				var/mob/living/simple_animal/hostile/C = new chosen
-				C.faction |= "neutral"
-				C.loc = get_turf(holder.my_atom)
 
 //Silver
 	slimebork

--- a/code/modules/research/xenoarchaeology/genetics/prehistoric_animals.dm
+++ b/code/modules/research/xenoarchaeology/genetics/prehistoric_animals.dm
@@ -17,6 +17,7 @@
 	speak = list("Hruuugh!","Hrunnph")
 	emote_see = list("paws the ground","shakes its mane","stomps")
 	emote_hear = list("snuffles")
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/diyaab
 	name = "diyaab"
@@ -37,6 +38,7 @@
 	speak = list("Awrr?","Aowrl!","Worrl")
 	emote_see = list("sniffs the air cautiously","looks around")
 	emote_hear = list("snuffles")
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/hostile/shantak
 	name = "shantak"
@@ -56,6 +58,7 @@
 	speak_chance = 5
 	speak = list("Shuhn","Shrunnph?","Shunpf")
 	emote_see = list("scratches the ground","shakes out it's mane","tinkles gently")
+	gold_core_spawnable = 1
 
 /mob/living/simple_animal/yithian
 	name = "yithian"
@@ -63,6 +66,7 @@
 	icon_state = "yithian"
 	icon_living = "yithian"
 	icon_dead = "yithian_dead"
+	gold_core_spawnable = 2
 
 /mob/living/simple_animal/tindalos
 	name = "tindalos"
@@ -70,3 +74,4 @@
 	icon_state = "tindalos"
 	icon_living = "tindalos"
 	icon_dead = "tindalos_dead"
+	gold_core_spawnable = 2

--- a/code/modules/research/xenoarchaeology/genetics/prehistoric_animals.dm
+++ b/code/modules/research/xenoarchaeology/genetics/prehistoric_animals.dm
@@ -17,7 +17,7 @@
 	speak = list("Hruuugh!","Hrunnph")
 	emote_see = list("paws the ground","shakes its mane","stomps")
 	emote_hear = list("snuffles")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/diyaab
 	name = "diyaab"
@@ -38,7 +38,7 @@
 	speak = list("Awrr?","Aowrl!","Worrl")
 	emote_see = list("sniffs the air cautiously","looks around")
 	emote_hear = list("snuffles")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/hostile/shantak
 	name = "shantak"
@@ -58,7 +58,7 @@
 	speak_chance = 5
 	speak = list("Shuhn","Shrunnph?","Shunpf")
 	emote_see = list("scratches the ground","shakes out it's mane","tinkles gently")
-	gold_core_spawnable = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 
 /mob/living/simple_animal/yithian
 	name = "yithian"
@@ -66,7 +66,7 @@
 	icon_state = "yithian"
 	icon_living = "yithian"
 	icon_dead = "yithian_dead"
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
 /mob/living/simple_animal/tindalos
 	name = "tindalos"
@@ -74,4 +74,4 @@
 	icon_state = "tindalos"
 	icon_living = "tindalos"
 	icon_dead = "tindalos_dead"
-	gold_core_spawnable = 2
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY


### PR DESCRIPTION
Refactors handling of spawning gold core/life reactions of animals to be more OOP. Port of: https://github.com/tgstation/-tg-station/pull/11277

Instead of a global list of blocked simple animals that cannot be spawned by life/gold cores, there's now a single var on simple animals themselves---additionally, simple animal spawning is now handled via a single reagent proc rather than being copy-pasted everywhere. To say the least, this has been an issue that has repeatedly come up for us--now it's far easier to manage and maintain.

Gameplay Changes
- Gold core hostile slime mobs increased from 3 to 5
- Revenants, Morphs, and swarmers are now blacklisted (these were technically meant to be, to begin with)
- Ensures retaliate mobs are properly blacklisted (some were, some were not)
- Added in friendly-animal slime core reaction, which can spawn a single friendly animal; simply inject a gold slime core with water to generate (corgis, foxes, cats, lizards, etc).

Fixes
- Fixes being able to generate/spawn invisible mobs with life/gold cores
- Fixes spawning of tons of mobs in nullspace, apparently

:cl: Fox McCloud
add: Can spawn friendly animals with a new gold core reaction by injection with water
tweak: Hostile animal spawn increased from 3 to 5 for hostile gold cores
tweak: Swarmers, revenants, and morphs no longer gold core spawnable
fix: Fixes invisible animal spawns from gold core/life reactions
/:cl: