### PR TITLE
Tweaks/fixes some bot radio/language stuff, lazarus capsules

### DIFF
--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -90,8 +90,11 @@
 							race = "Artificial Life"
 
 						else if(isslime(M)) // NT knows a lot about slimes, but not aliens. Can identify slimes
-							race = "slime"
+							race = "Slime"
 							language = race
+
+						else if(isbot(M))
+							race = "Bot"
 
 						else if(isanimal(M))
 							race = "Domestic Animal"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -211,7 +211,7 @@
 	return ..()
 
 /obj/item/device/mobcapsule/attack(var/atom/A, mob/user, prox_flag)
-	if(!istype(A, /mob/living/simple_animal))
+	if(!istype(A, /mob/living/simple_animal) || isbot(A))
 		return ..()
 	capture(A, user)
 	return 1

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -53,6 +53,8 @@
 				return 1
 		if (istype(other, /mob/living/silicon))
 			return 1
+		if (istype(other, /mob/living/simple_animal/bot))
+			return 1
 		if (istype(other, /mob/living/carbon/brain))
 			return 1
 		if (istype(other, /mob/living/carbon/slime))

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -56,6 +56,8 @@
 			return 1
 		if (istype(other, /mob/living/silicon))
 			return 1
+		if (istype(other, /mob/living/simple_animal/bot))
+			return 1
 		if (istype(other, /mob/living/carbon/brain))
 			return 1
 	return ..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -132,6 +132,13 @@
 			radio_config["[radio_channel]"] = 1
 	Radio.config(radio_config)
 
+	add_language("Galactic Common", 1)
+	add_language("Sol Common", 1)
+	add_language("Tradeband", 1)
+	add_language("Gutter", 1)
+	add_language("Trinary", 1)
+	default_language = all_languages["Galactic Common"]
+
 	bot_core = new bot_core_type(src)
 	spawn(30)
 		if(radio_controller && bot_filter)


### PR DESCRIPTION
- Gives bots a list of languages to speak
- Makes sure the humans and silicons can reliably understand them over radio.
- Makes bots labelled better in the telecomms log.
- Makes it so you can't capture bots in a lazarus capsule.

:cl:
tweak: Beepsky is no longer a pokemon.
tweak: pAI-controlled Bots now reliably speak human-understandable languages over the radio.
/:cl: