### PR TITLE
Removes PAI Control of Security Bots

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -38,6 +38,7 @@
 	var/arrest_type = 0 //If true, don't handcuff
 	var/projectile = /obj/item/projectile/energy/electrode //Holder for projectile type
 	var/shoot_sound = 'sound/weapons/Taser.ogg'
+	allow_pai = 0
 
 
 /mob/living/simple_animal/bot/ed209/New(loc,created_name,created_lasercolor)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -33,6 +33,7 @@
 	var/harmbaton = 0 //If true, beat instead of stun
 	var/flashing_lights = 0 //If true, flash lights
 	var/prev_flashing_lights = 0
+	allow_pai = 0
 
 /mob/living/simple_animal/bot/secbot/beepsky
 	name = "Officer Beepsky"
@@ -40,7 +41,6 @@
 	idcheck = 0
 	weaponscheck = 0
 	auto_patrol = 1
-	allow_pai = 0
 
 /mob/living/simple_animal/bot/secbot/beepsky/explode()
 	var/turf/Tsec = get_turf(src)
@@ -54,7 +54,6 @@
 	name = "Officer Pingsky"
 	desc = "It's Officer Pingsky! Delegated to satellite guard duty for harbouring anti-human sentiment."
 	radio_channel = "AI Private"
-	allow_pai = 0
 
 /mob/living/simple_animal/bot/secbot/ofitser
 	name = "Prison Ofitser"
@@ -62,7 +61,6 @@
 	idcheck = 0
 	weaponscheck = 1
 	auto_patrol = 1
-	allow_pai = 0
 
 /mob/living/simple_animal/bot/secbot/buzzsky
 	name = "Officer Buzzsky"


### PR DESCRIPTION
I thought...maybe..just maybe our players were better than TG's when it comes to not being shitters and we could allow secbot control by PAI's.

Welp, I was wrong.

 It only took me witnessing 10 minutes of a round to see how ridiculously abusive this was--and no, this isn't an "I ded, pls nerf" thing; I wasn't even remotely on the receiving end of this.

PR:

Removes the ability to put a pAI into ANY security related bot---be it securitrons (beepsky's type), or ED-209's.

Don't worry about the sentience potions--they're next (in another PR).

:cl: Fox McCloud
tweak: Removes the ability to put a pAI into securitrons and ED-209's
/:cl: