### PR TITLE
Sentience Potion Changes

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -200,6 +200,7 @@
 	var/list/not_interested = list()
 	var/being_used = 0
 	w_class = 1
+	var/sentience_type = SENTIENCE_ORGANIC
 
 
 /obj/item/weapon/sentience_potion/afterattack(mob/living/M, mob/user)
@@ -210,27 +211,30 @@
 		return ..()
 	if(M.stat)
 		user << "<span class='warning'>[M] is dead!</span>"
-		return..()
+		return ..()
+	var/mob/living/simple_animal/SM = M
+	if(SM.sentience_type != sentience_type)
+		user << "<span class='warning'>The potion won't work on [SM].</span>"
+		return ..()
 
-	user << "<span class='notice'>You offer the sentience potion to [M]...</span>"
+	user << "<span class='notice'>You offer the sentience potion to [SM]...</span>"
 	being_used = 1
 
-	var/list/candidates = pollCandidates("Do you want to play as [M.name]?", ROLE_SENTIENT, 0, 100)
+	var/list/candidates = pollCandidates("Do you want to play as [SM.name]?", ROLE_SENTIENT, 0, 100)
 
 	if(!src)
 		return
 
 	if(candidates.len)
 		var/mob/C = pick(candidates)
-		M.key = C.key
-		M.universal_speak = 1
-		M.faction |= "sentient"
-		M << "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>"
-		M << "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>"
+		SM.key = C.key
+		SM.universal_speak = 1
+		SM.faction = user.faction
+		SM.master_commander = user
+		SM.sentience_act()
+		SM << "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>"
+		SM << "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>"
 		user << "<span class='notice'>[M] accepts the potion and suddenly becomes attentive and aware. It worked!</span>"
-		if(isanimal(M))
-			var/mob/living/simple_animal/S = M
-			S.master_commander = user
 		qdel(src)
 	else
 		user << "<span class='notice'>[M] looks interested for a moment, but then looks back down. Maybe you should try again later.</span>"


### PR DESCRIPTION
This just makes use of some vars that @Tastyfish implemented in the bot refactor.

Sentience potions can only be used on things that have the same sentience type as the potion itself.

End run is, you can't use sentience potions on bots and we have a system in place to make sentience potions that only work for very specific mobs, if we want to.

Also ensures that sentient mobs have the same faction as the user.

:cl: Fox McCloud
tweak: Can no longer use sentience potions on bots
/:cl: