### PR TITLE
TG Statue Fixes/Refactor

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -2,6 +2,7 @@
 	gender = NEUTER
 	robot_talk_understand = 1
 	voice_name = "synthesized voice"
+	has_unlimited_silicon_privilege = 1
 	var/syndicate = 0
 	var/const/MAIN_CHANNEL = "Main Frequency"
 	var/lawchannel = MAIN_CHANNEL // Default channel on which to state laws

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -11,6 +11,7 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+	has_unlimited_silicon_privilege = 1
 	sentience_type = SENTIENCE_ARTIFICIAL
 	status_flags = 0 //no default canpush
 	can_strip = 0

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -4,9 +4,9 @@
 	name = "statue" // matches the name of the statue with the flesh-to-stone spell
 	desc = "An incredibly lifelike marble carving. Its eyes seems to follow you.." // same as an ordinary statue with the added "eye following you" description
 	icon = 'icons/obj/statue.dmi'
-	icon_state = "angelseen"
-	icon_living = "angelseen"
-	icon_dead = "angelseen"
+	icon_state = "angel"
+	icon_living = "angel"
+	icon_dead = "angel"
 	gender = NEUTER
 	a_intent = I_HARM
 
@@ -14,12 +14,13 @@
 	response_disarm = "pushes"
 
 	speed = -1
-	maxHealth = 1250
-	health = 1250
+	maxHealth = 50000
+	health = 50000
+	healable = 0
 
-	harm_intent_damage = 35
-	melee_damage_lower = 34
-	melee_damage_upper = 42
+	harm_intent_damage = 70
+	melee_damage_lower = 68
+	melee_damage_upper = 83
 	attacktext = "claws"
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 
@@ -40,7 +41,9 @@
 
 	sight = SEE_SELF|SEE_MOBS|SEE_OBJS|SEE_TURFS
 	anchored = 1
-//	status_flags = GODMODE // Cannot push also
+	status_flags = GODMODE // Cannot push also
+
+	var/cannot_be_seen = 1
 	var/mob/living/creator = null
 
 
@@ -49,9 +52,9 @@
 /mob/living/simple_animal/hostile/statue/New(loc, var/mob/living/creator)
 	..()
 	// Give spells
-	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(src))
-	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/blindness(src))
-	AddSpell(new /obj/effect/proc_holder/spell/targeted/night_vision(src))
+	spell_list += new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(src)
+	spell_list += new /obj/effect/proc_holder/spell/aoe_turf/blindness(src)
+	spell_list += new /obj/effect/proc_holder/spell/targeted/night_vision(src)
 
 	// Give nightvision
 	see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING
@@ -60,136 +63,94 @@
 	if(creator)
 		src.creator = creator
 
-/mob/living/simple_animal/hostile/statue/Move(var/turf/NewLoc)
+/mob/living/simple_animal/hostile/statue/Move(turf/NewLoc)
 	if(can_be_seen(NewLoc))
-		icon_state = "angelseen"
 		if(client)
 			src << "<span class='warning'>You cannot move, there are eyes on you!</span>"
 		return 0
-	icon_state = "angel"
 	return ..()
 
-/mob/living/simple_animal/hostile/statue/process_ai()
-	. = ..()
-	if(!.)
-		return
-	spawn() //for saftey
-		checkTargets()
 
-/mob/living/simple_animal/hostile/statue/proc/checkTargets()
-	if(target)
+/mob/living/simple_animal/hostile/statue/process_ai()
+	..()
+	if(!client && target) // If we have a target and we're AI controlled
 		var/mob/watching = can_be_seen()
+		// If they're not our target
 		if(watching && watching != target)
+			// This one is closer.
 			if(get_dist(watching, src) > get_dist(target, src))
 				LoseTarget()
 				GiveTarget(watching)
 
 /mob/living/simple_animal/hostile/statue/AttackingTarget()
-	if(!can_be_seen())
-		icon_state = "angelattack"
+	if(can_be_seen(get_turf(loc)))
+		if(client)
+			src << "<span class='warning'>You cannot attack, there are eyes on you!</span>"
+			return
+	else
 		..()
 
 /mob/living/simple_animal/hostile/statue/DestroySurroundings()
-	if(!can_be_seen())
+	if(!can_be_seen(get_turf(loc)))
 		..()
 
 /mob/living/simple_animal/hostile/statue/face_atom()
-	if(!can_be_seen())
+	if(!can_be_seen(get_turf(loc)))
 		..()
 
-/mob/living/simple_animal/hostile/statue/UnarmedAttack()
-	if(can_be_seen())
-		icon_state = "angelseen"
-		if(client)
-			src << "<span class='warning'>You cannot attack, there are eyes on you!</span>"
-		return
-	icon_state = "angelattack"
-	..()
-
-/mob/living/simple_animal/hostile/statue/proc/can_be_seen(var/turf/destination)
+/mob/living/simple_animal/hostile/statue/proc/can_be_seen(turf/destination)
+	if(!cannot_be_seen)
+		return null
 	// Check for darkness
 	var/turf/T = get_turf(loc)
-
-	var/light_amount
-	var/DLlight_amount
-
-	if(T.dynamic_lighting)
-		light_amount = T.get_lumcount()
-	else
-		light_amount = 5
-
-	if(destination && destination.dynamic_lighting)
-		DLlight_amount = destination.get_lumcount()
-	else
-		DLlight_amount = 5
-
-	if(T && destination)
-		//Don't check it twice if our destination is the tile we are on or we can't even get to our destination
+	if(T && destination && T.lighting_overlay)
+		if(T.get_lumcount() * 10 < 1 && destination.get_lumcount() * 10 < 1) // No one can see us in the darkness, right?
+			return null
 		if(T == destination)
 			destination = null
-		else if(light_amount < 0.1 && DLlight_amount < 0.1) // No one can see us in the darkness, right?
-			return null
 
-	//We aren't in darkness, loop for viewers.
+	// We aren't in darkness, loop for viewers.
 	var/list/check_list = list(src)
 	if(destination)
 		check_list += destination
 
-	//This loop will, at most, loop twice.
+	// This loop will, at most, loop twice.
 	for(var/atom/check in check_list)
 		for(var/mob/living/M in viewers(world.view + 1, check) - src)
-			if(M.client && CanAttack(M))
-				if(M.blinded || (M.sdisabilities & BLIND))
-					return null
-
-				//calculates if any mobs are actually facing the statue
-				var/xdif = M.x - src.x
-				var/ydif = M.y - src.y
-
-				if(abs(xdif) < abs(ydif)) //mob is either above or below src
-					if(ydif < 0 && M.dir == NORTH) //mob is below src and looking up
-						return M
-					if(ydif > 0 && M.dir == SOUTH) //mob is above src and looking down
-						return M
-
-				else if(abs(xdif) > abs(ydif)) //mob is either left or right of src
-					if(xdif < 0 && M.dir == EAST) //mob is to the left of src and looking right
-						return M
-					if(xdif > 0 && M.dir == WEST) //mob is to the right of src and looking left
-						return M
-
-				else if(xdif == 0 && ydif == 0) //mob is on the same tile as src
+			if(M.client && CanAttack(M) && !M.has_unlimited_silicon_privilege)
+				if(!M.eye_blind)
 					return M
+		for(var/obj/mecha/M in view(world.view + 1, check)) //assuming if you can see them they can see you
+			if(M.occupant && M.occupant.client)
+				if(!M.occupant.eye_blind)
+					return M.occupant
+	return null
 
+// Cannot talk
 
-
-//Cannot talk
 /mob/living/simple_animal/hostile/statue/say()
 	return 0
 
-/mob/living/simple_animal/hostile/statue/death(gibbed)
-	if(!gibbed) //The looping ends here.
-		dust()
-		return
-	return ..()
+// Turn to dust when gibbed
 
-//Stop attacking clientless mobs
+/mob/living/simple_animal/hostile/statue/gib()
+	dust()
 
-/mob/living/simple_animal/hostile/statue/CanAttack(var/atom/the_target)
-	if(mind && mind.key && !ckey)
-		return 0
+
+// Stop attacking clientless mobs
+
+/mob/living/simple_animal/hostile/statue/CanAttack(atom/the_target)
 	if(isliving(the_target))
 		var/mob/living/L = the_target
 		if(!L.client && !L.ckey)
 			return 0
 	return ..()
 
+// Don't attack your creator if there is one
+
 /mob/living/simple_animal/hostile/statue/ListTargets()
 	. = ..()
 	return . - creator
-
-/mob/living/simple_animal/hostile/statue/sentience_act()
-	faction -= "neutral"
 
 // Statue powers
 
@@ -216,15 +177,15 @@
 	message = "<span class='notice'>You glare your eyes.</span>"
 	charge_max = 600
 	clothes_req = 0
-	range = 8
+	range = 10
 
 /obj/effect/proc_holder/spell/aoe_turf/blindness/cast(list/targets)
 	for(var/mob/living/L in living_mob_list)
+		if(L == usr)
+			continue
 		var/turf/T = get_turf(L.loc)
 		if(T && T in targets)
 			L.eye_blind = max(L.eye_blind, 4)
-			if(issilicon(L))
-				L.Weaken(4)
 	return
 
 //Toggle Night Vision
@@ -249,3 +210,12 @@
 			target.see_invisible = SEE_INVISIBLE_LIVING
 			name = "Toggle Nightvision \[OFF\]"
 	return
+
+
+/mob/living/simple_animal/hostile/statue/sentience_act()
+	faction -= "neutral"
+
+/mob/living/simple_animal/hostile/statue/restrained()
+	. = ..()
+	if(can_be_seen(loc))
+		return 1

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -52,9 +52,9 @@
 /mob/living/simple_animal/hostile/statue/New(loc, var/mob/living/creator)
 	..()
 	// Give spells
-	spell_list += new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(src)
-	spell_list += new /obj/effect/proc_holder/spell/aoe_turf/blindness(src)
-	spell_list += new /obj/effect/proc_holder/spell/targeted/night_vision(src)
+	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(src))
+	AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/blindness(src))
+	AddSpell(new /obj/effect/proc_holder/spell/targeted/night_vision(src))
 
 	// Give nightvision
 	see_invisible = SEE_INVISIBLE_OBSERVER_NOLIGHTING

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -203,6 +203,8 @@
 	var/digitalcamo = 0 // Can they be tracked by the AI?
 	var/weakeyes = 0 //Are they vulnerable to flashes?
 
+	var/has_unlimited_silicon_privilege = 0 // Can they interact with station electronics
+
 	var/list/radar_blips = list() // list of screen objects, radar blips
 	var/radar_open = 0 	// nonzero is radar is open
 


### PR DESCRIPTION
TG's Statue Fix/Refactor

Implement's TG's version of statues.

Basically, they have the same spells as our statues, but they're impervious to all damage (except gibbing). That said, they have a very very strict set of rules that governs if they can attack or not---if it's pitch black, then the statue can move/attack. If it's not, then the statue may only attack if everyone that has eyes on them (a mob with a client that is within vision range) is blinded. Again, if a mob is blinded, then that mob can be attacked, regardless of brightness.

Summary of changes

- Statues are now invincible to anything other than the most devastating of bombs
- Statues can no longer move or attack unless everyone around them is blind or in total darkness
- Statue light flicker range increased by 2
- Melee attack damage doubled
- Blindness spell no longer stuns silicons.

Fixes

- Fixes a bug where statues could typically disobey their lighting/blindness rules and just attack you anyway.
- Statues no long blind themselves with the blindness spell

Other
- Implements has_unlimited_silicon_privilege; largely unused for now, but can be utilized for other things later (only implemented it because ti was used in the statue PR).

:cl: Fox McCloud
tweak: Statues can no longer move/attack people unless they're in total darkness or all mobs viewing them are blinded
tweak: statues are invincible to anything other than full out gibbing.
tweak: Statues melee damaged doubled
tweak: Statues flicker lights spell range increased
tweak: Blind spell no longer impacts silicons
fix: Fixes statues being able to attack/move whenever they feel like it, regardless of client statues
fix: Fixes blind spell impacting the statue
/:cl: