### PR TITLE
Xenobio Refactor/Changes

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -6978,7 +6978,7 @@
 "cEj" = (/turf/simulated/wall/r_wall,/area/medical/patient_b)
 "cEk" = (/obj/structure/closet/l3closet/scientist,/obj/machinery/light{dir = 8},/turf/simulated/floor/plasteel{dir = 4; icon_state = "warning"},/area/toxins/xenobiology)
 "cEl" = (/obj/structure/table,/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/item/weapon/storage/box/monkeycubes,/obj/item/weapon/storage/box/monkeycubes,/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/xenobiology)
-"cEm" = (/obj/structure/table,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/item/stack/sheet/mineral/plasma{amount = 8; layer = 2.9},/obj/machinery/media/receiver/boombox,/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/xenobiology)
+"cEm" = (/obj/structure/table,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/item/stack/sheet/mineral/plasma{pixel_x = -2; pixel_y = -2},/obj/item/stack/sheet/mineral/plasma,/obj/item/stack/sheet/mineral/plasma{pixel_x = 2; pixel_y = 2},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/xenobiology)
 "cEn" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/xenobiology)
 "cEo" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/xenobiology)
 "cEp" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/obj/structure/extinguisher_cabinet{pixel_x = 27; pixel_y = 0},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/xenobiology)

--- a/code/game/machinery/kitchen/monkeyrecycler.dm
+++ b/code/game/machinery/kitchen/monkeyrecycler.dm
@@ -12,6 +12,8 @@
 	var/grinded = 0
 	var/required_grind = 5
 	var/cube_production = 1
+	var/cycle_through = 0
+	var/obj/item/weapon/reagent_containers/food/snacks/monkeycube/cube_type = /obj/item/weapon/reagent_containers/food/snacks/monkeycube
 
 /obj/machinery/monkey_recycler/New()
 	..()
@@ -43,6 +45,22 @@
 		return
 
 	default_deconstruction_crowbar(O)
+
+	if(istype(O, /obj/item/device/multitool))
+		cycle_through++
+		switch(cycle_through)
+			if(1)
+				cube_type = /obj/item/weapon/reagent_containers/food/snacks/monkeycube/farwacube
+			if(2)
+				cube_type = /obj/item/weapon/reagent_containers/food/snacks/monkeycube/wolpincube
+			if(3)
+				cube_type = /obj/item/weapon/reagent_containers/food/snacks/monkeycube/stokcube
+			if(4)
+				cube_type = /obj/item/weapon/reagent_containers/food/snacks/monkeycube/neaeracube
+			if(5)
+				cube_type = /obj/item/weapon/reagent_containers/food/snacks/monkeycube
+				cycle_through = 0
+		to_chat(user, "<span class='notice'>You change the monkeycube type to [cube_type.name].</span>")
 
 	if (src.stat != 0) //NOPOWER etc
 		return
@@ -80,7 +98,7 @@
 		playsound(src.loc, 'sound/machines/hiss.ogg', 50, 1)
 		grinded -= required_grind
 		for(var/i = 0, i < cube_production, i++) // Forgot to fix this bit the first time through
-			new /obj/item/weapon/reagent_containers/food/snacks/monkeycube(src.loc)
+			new cube_type(src.loc)
 		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded] monkey\s worth of material left.</span>")
 	else // I'm not sure if the \s macro works with a word in between; I'll play it safe
 		to_chat(user, "<span class='warning'>The machine needs at least [required_grind] monkey\s worth of material to compress [cube_production] monkey\s. It only has [grinded].</span>")

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -85,7 +85,7 @@
 		S.loc = loc
 		S.visible_message("<span class='notice'>[S] crawls free of the processor!</span>")
 		return
-	for(var/i = 1, i <= C + processor.rating_amount, i++)
+	for(var/i in 1 to (C+processor.rating_amount-1))
 		new S.coretype(loc)
 		feedback_add_details("slime_core_harvested","[replacetext(S.colour," ","_")]")
 	..()

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -115,14 +115,12 @@
 	minor_fault = 1
 
 
-/obj/item/weapon/stock_parts/cell/slime
+/obj/item/weapon/stock_parts/cell/high/slime
 	name = "charged slime core"
 	desc = "A yellow slime core infused with plasma, it crackles with power."
 	origin_tech = "powerstorage=2;biotech=4"
-	icon = 'icons/mob/slimes.dmi' //'icons/obj/harvest.dmi'
-	icon_state = "yellow slime extract" //"potato_battery"
-	maxcharge = 10000
-	rating = 3
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "yellow slime extract"
 	materials = list()
 
 /obj/item/weapon/stock_parts/cell/pulse/carbine

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -20,7 +20,7 @@
 	var/sheet_per_ore = 1
 	var/point_upgrade = 1
 	var/list/ore_values = list(("sand" = 1), ("iron" = 1), ("plasma" = 15), ("silver" = 16), ("gold" = 18), ("uranium" = 30), ("diamond" = 50), ("bananium" = 60), ("tranquillite" = 60))
-	var/list/supply_consoles = list("Science", "Robotics", "Research Director's Desk", "Mechanic", "Engineering" = list("metal", "glass", "plasma"), "Chief Engineer's Desk" = list("metal", "glass", "plasma"), "Atmospherics" = list("metal", "glass", "plasma"), "Bar" = list("uranium", "plasma"), "Virology" = list("uranium", "gold"))
+	var/list/supply_consoles = list("Science", "Robotics", "Research Director's Desk", "Mechanic", "Engineering" = list("metal", "glass", "plasma"), "Chief Engineer's Desk" = list("metal", "glass", "plasma"), "Atmospherics" = list("metal", "glass", "plasma"), "Bar" = list("uranium", "plasma"), "Virology" = list("plasma", "uranium", "gold"))
 
 /obj/machinery/mineral/ore_redemption/New()
 	..()

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -151,13 +151,8 @@
 
 /mob/living/carbon/slime/handle_chemicals_in_body()
 
-	if(reagents) reagents.metabolize(src)
-	if (reagents.get_reagent_amount("plasma")>=5)
-		mutation_chance = min(mutation_chance + 5,50) //Prevents mutation chance going >50%
-		reagents.remove_reagent("plasma", 5)
-	if (reagents.get_reagent_amount("epinephrine")>=5)
-		mutation_chance = max(mutation_chance - 5,0) //Prevents muation chance going <0%
-		reagents.remove_reagent("epinephrine", 5)
+	if(reagents)
+		reagents.metabolize(src)
 	src.updatehealth()
 
 	return //TODO: DEFERRED

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -207,15 +207,20 @@
 			var/new_powerlevel = round(powerlevel / 4)
 			for(var/i=1,i<=4,i++)
 				var/mob/living/carbon/slime/M = new /mob/living/carbon/slime/(loc)
-				if(prob(mutation_chance))
+				if(mutation_chance >= 100)
+					M.colour = "rainbow"
+				else if(prob(mutation_chance))
 					M.colour = slime_mutation[rand(1,4)]
 				else
 					M.colour = colour
-				if(ckey)	M.nutrition = new_nutrition //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
+				if(ckey)
+					M.nutrition = new_nutrition //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 				M.powerlevel = new_powerlevel
-				if(i != 1) step_away(M,src)
+				if(i != 1)
+					step_away(M,src)
 				M.Friends = Friends.Copy()
 				babies += M
+				M.mutation_chance = Clamp(mutation_chance+(rand(5,-5)),0,100)
 				feedback_add_details("slime_babies_born","slimebirth_[replacetext(M.colour," ","_")]")
 
 			var/mob/living/carbon/slime/new_slime = pick(babies)

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -46,6 +46,7 @@
 	var/is_adult = 0
 
 	var/core_removal_stage = 0 //For removing cores.
+	var/mutator_used = FALSE //So you can't shove a dozen mutators into a single slime
 
 	///////////TIME FOR SUBSPECIES
 
@@ -61,7 +62,6 @@
 		icon_state = "[colour] [is_adult ? "adult" : "baby"] slime"
 		real_name = name
 		slime_mutation = mutation_table(colour)
-		mutation_chance = rand(25, 35)
 		var/sanitizedcolour = replacetext(colour, " ", "")
 		coretype = text2path("/obj/item/slime_extract/[sanitizedcolour]")
 	..()

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -817,7 +817,7 @@
 	var/list/blend_items = list (
 
 		//Sheets
-		/obj/item/stack/sheet/mineral/plasma = list("plasma" = 20),
+		/obj/item/stack/sheet/mineral/plasma = list("plasma_dust" = 20),
 		/obj/item/stack/sheet/mineral/uranium = list("uranium" = 20),
 		/obj/item/stack/sheet/mineral/bananium = list("banana" = 20),
 		/obj/item/stack/sheet/mineral/tranquillite = list("nothing" = 20),

--- a/code/modules/reagents/newchem/disease.dm
+++ b/code/modules/reagents/newchem/disease.dm
@@ -106,13 +106,13 @@
 	description = "mutates blood"
 	color = "#D18AA5" // rgb: 209,138,165
 
-/datum/reagent/plasma/plasmavirusfood
+/datum/reagent/plasma_dust/plasmavirusfood
 	name = "virus plasma"
 	id = "plasmavirusfood"
 	description = "mutates blood"
 	color = "#A69DA9" // rgb: 166,157,169
 
-/datum/reagent/plasma/plasmavirusfood/weak
+/datum/reagent/plasma_dust/plasmavirusfood/weak
 	name = "weakened virus plasma"
 	id = "weakplasmavirusfood"
 	color = "#CEC3C6" // rgb: 206,195,198
@@ -143,7 +143,7 @@
 	name = "virus plasma"
 	id = "plasmavirusfood"
 	result = "plasmavirusfood"
-	required_reagents = list("plasma" = 1, "virusfood" = 1)
+	required_reagents = list("plasma_dust" = 1, "virusfood" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/virus_food_plasma_diphenhydramine
@@ -195,7 +195,7 @@
 /datum/chemical_reaction/mix_virus/mix_virus_3
 	name = "Mix Virus 3"
 	id = "mixvirus3"
-	required_reagents = list("plasma" = 1)
+	required_reagents = list("plasma_dust" = 1)
 	level_min = 4
 	level_max = 6
 

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -626,3 +626,33 @@ datum/reagent/firefighting_foam/reaction_obj(var/obj/O, var/volume)
 	holder.del_reagent("teslium") //Clear all remaining Teslium and Uranium, but leave all other reagents untouched.
 	holder.del_reagent("uranium")
 	return
+
+/datum/reagent/plasma_dust
+	name = "Plasma Dust"
+	id = "plasma_dust"
+	description = "A fine dust of plasma. This chemical has unusual mutagenic properties for viruses and slimes alike."
+	color = "#500064" // rgb: 80, 0, 100
+
+/datum/reagent/plasma_dust/on_mob_life(mob/living/M)
+	M.adjustToxLoss(3)
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		C.adjustPlasma(20)
+	..()
+
+/datum/reagent/plasma_dust/reaction_obj(obj/O, volume)
+	if((!O) || (!volume))
+		return 0
+	O.atmos_spawn_air(SPAWN_TOXINS|SPAWN_20C, volume)
+
+/datum/reagent/plasma_dust/reaction_turf(turf/simulated/T, volume)
+	if(istype(T))
+		T.atmos_spawn_air(SPAWN_TOXINS|SPAWN_20C, volume)
+
+/datum/reagent/plasma_dust/reaction_mob(mob/living/M, method=TOUCH, volume)//Splashing people with plasma dust is stronger than fuel!
+	if(!istype(M, /mob/living))
+		return
+	if(method == TOUCH)
+		M.adjust_fire_stacks(volume / 5)
+		return
+	..()

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -1,554 +1,664 @@
-/////////////////////////////////////////////NEW SLIME CORE REACTIONS/////////////////////////////////////////////
 
 //Grey
-/datum/chemical_reaction/
+/datum/chemical_reaction/slimespawn
+	name = "Slime Spawn"
+	id = "m_spawn"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/grey
+	required_other = 1
 
-	slimespawn
-		name = "Slime Spawn"
-		id = "m_spawn"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/grey
-		required_other = 1
+/datum/chemical_reaction/slimespawn/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/mob/living/carbon/slime/S = new /mob/living/carbon/slime
+	S.forceMove(get_turf(holder.my_atom))
+	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
 
-		on_reaction(var/datum/reagents/holder)
-			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-				O.show_message(text("\red Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!"), 1)
-			var/mob/living/carbon/slime/S = new /mob/living/carbon/slime
-			S.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimeinaprov
+	name = "Slime epinephrine"
+	id = "m_inaprov"
+	result = "epinephrine"
+	required_reagents = list("water" = 5)
+	result_amount = 3
+	required_other = 1
+	required_container = /obj/item/slime_extract/grey
 
+/datum/chemical_reaction/slimeinaprov/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
 
-	slimeinaprov
-		name = "Slime Epinephrine"
-		id = "m_epinephrine"
-		result = "epinephrine"
-		required_reagents = list("water" = 5)
-		result_amount = 3
-		required_other = 1
-		required_container = /obj/item/slime_extract/grey
+/datum/chemical_reaction/slimemonkey
+	name = "Slime Monkey"
+	id = "m_monkey"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/grey
+	required_other = 1
 
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-
-
-	slimemonkey
-		name = "Slime Monkey"
-		id = "m_monkey"
-		result = null
-		required_reagents = list("blood" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/grey
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			for(var/i = 1, i <= 3, i++)
-				var /obj/item/weapon/reagent_containers/food/snacks/monkeycube/M = new /obj/item/weapon/reagent_containers/food/snacks/monkeycube
-				M.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimemonkey/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	for(var/i = 1, i <= 3, i++)
+		var /obj/item/weapon/reagent_containers/food/snacks/monkeycube/M = new /obj/item/weapon/reagent_containers/food/snacks/monkeycube
+		M.forceMove(get_turf(holder.my_atom))
 
 //Green
-	slimemutate
-		name = "Mutation Toxin"
-		id = "mutationtoxin"
-		result = "mutationtoxin"
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_other = 1
-		required_container = /obj/item/slime_extract/green
+/datum/chemical_reaction/slimemutate
+	name = "Mutation Toxin"
+	id = "mutationtoxin"
+	result = "mutationtoxin"
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_other = 1
+	required_container = /obj/item/slime_extract/green
+
+/datum/chemical_reaction/slimemutate/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
 
 //Metal
-	slimemetal
-		name = "Slime Metal"
-		id = "m_metal"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/metal
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal
-			M.amount = 15
-			M.loc = get_turf(holder.my_atom)
-			var/obj/item/stack/sheet/plasteel/P = new /obj/item/stack/sheet/plasteel
-			P.amount = 5
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimemetal
+	name = "Slime Metal"
+	id = "m_metal"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/metal
+	required_other = 1
+
+/datum/chemical_reaction/slimemetal/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/stack/sheet/metal/M = new /obj/item/stack/sheet/metal
+	M.amount = 15
+	M.forceMove(get_turf(holder.my_atom))
+	var/obj/item/stack/sheet/plasteel/P = new /obj/item/stack/sheet/plasteel
+	P.amount = 5
+	P.forceMove(get_turf(holder.my_atom))
 
 //Gold
-	slimecrit
-		name = "Slime Crit"
-		id = "m_tele"
-		result = null
-		required_reagents = list("plasma" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/gold
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			var/turf/T = get_turf(holder.my_atom)
-			T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-			spawn(50)
-				chemical_mob_spawn(holder, 5, "Gold Slime")
+/datum/chemical_reaction/slimecrit
+	name = "Slime Crit"
+	id = "m_tele"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/gold
+	required_other = 1
 
+/datum/chemical_reaction/slimecrit/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
+	spawn(50)
+		chemical_mob_spawn(holder, 5, "Gold Slime")
 
-	slimecritlesser
-		name = "Slime Crit Lesser"
-		id = "m_tele3"
-		result = null
-		required_reagents = list("blood" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/gold
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			var/turf/T = get_turf(holder.my_atom)
-			T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
-			spawn(50)
-				chemical_mob_spawn(holder, 3, "Lesser Gold Slime", "neutral")
+/datum/chemical_reaction/slimecritlesser
+	name = "Slime Crit Lesser"
+	id = "m_tele3"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/gold
+	required_other = 1
 
+/datum/chemical_reaction/slimecritlesser/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
+	spawn(50)
+		chemical_mob_spawn(holder, 3, "Lesser Gold Slime", "neutral")
 
-	slimecritfriendly
-		name = "Slime Crit Friendly"
-		id = "m_tele5"
-		result = null
-		required_reagents = list("water" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/gold
-		required_other = 1
-		on_reaction(datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			var/turf/T = get_turf(holder.my_atom)
-			T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
-			spawn(50)
-				chemical_mob_spawn(holder, 1, "Friendly Gold Slime", "neutral")
+/datum/chemical_reaction/slimecritfriendly
+	name = "Slime Crit Friendly"
+	id = "m_tele5"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/gold
+	required_other = 1
 
+/datum/chemical_reaction/slimecritfriendly/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
+	spawn(50)
+		chemical_mob_spawn(holder, 1, "Friendly Gold Slime", "neutral")
 
 //Silver
-	slimebork
-		name = "Slime Bork"
-		id = "m_tele2"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/silver
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
+/datum/chemical_reaction/slimebork
+	name = "Slime Bork"
+	id = "m_tele2"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/silver
+	required_other = 1
 
-			var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/snacks)
-			borks = adminReagentCheck(borks)
-			// BORK BORK BORK
+/datum/chemical_reaction/slimebork/on_reaction(datum/reagents/holder)
 
-			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+	feedback_add_details("slime_cores_used","[type]")
+	var/list/blocked = list(/obj/item/weapon/reagent_containers/food/snacks,
+		/obj/item/weapon/reagent_containers/food/snacks/breadslice,
+		/obj/item/weapon/reagent_containers/food/snacks/sliceable,
+		/obj/item/weapon/reagent_containers/food/snacks/margheritaslice,
+		/obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice,
+		/obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice,
+		/obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice,
+		/obj/item/weapon/reagent_containers/food/snacks/meat,
+		/obj/item/weapon/reagent_containers/food/snacks/meat/slab,
+		/obj/item/weapon/reagent_containers/food/snacks/grown,
+		/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom,
+		)
+	blocked |= typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
 
-			for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
-				C.flash_eyes()
+	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked
+	// BORK BORK BORK
 
-			for(var/i = 1, i <= 4 + rand(1,2), i++)
-				var/chosen = pick(borks)
-				var/obj/B = new chosen
-				if(B)
-					B.loc = get_turf(holder.my_atom)
-					if(prob(50))
-						for(var/j = 1, j <= rand(1, 3), j++)
-							step(B, pick(NORTH,SOUTH,EAST,WEST))
-	slimedrinks
-		name = "Slime Drinks"
-		id = "m_tele3"
-		result = null
-		required_reagents = list("water" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/silver
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
+	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
-			var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
-			borks = adminReagentCheck(borks)
-			// BORK BORK BORK
+	for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
+		C.flash_eyes()
 
-			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+	for(var/i = 1, i <= 4 + rand(1,2), i++)
+		var/chosen = pick(borks)
+		var/obj/B = new chosen
+		if(B)
+			B.forceMove(get_turf(holder.my_atom))
+			if(prob(50))
+				for(var/j = 1, j <= rand(1, 3), j++)
+					step(B, pick(NORTH,SOUTH,EAST,WEST))
 
-			for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
-				C.flash_eyes()
 
-			for(var/i = 1, i <= 4 + rand(1,2), i++)
-				var/chosen = pick(borks)
-				var/obj/B = new chosen
-				if(B)
-					B.loc = get_turf(holder.my_atom)
-					if(prob(50))
-						for(var/j = 1, j <= rand(1, 3), j++)
-							step(B, pick(NORTH,SOUTH,EAST,WEST))
+/datum/chemical_reaction/slimebork2
+	name = "Slime Bork 2"
+	id = "m_tele4"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/silver
+	required_other = 1
+
+/datum/chemical_reaction/slimebork2/on_reaction(datum/reagents/holder)
+
+	feedback_add_details("slime_cores_used","[type]")
+	var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
+	// BORK BORK BORK
+
+	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+
+	for(var/mob/living/carbon/M in viewers(get_turf(holder.my_atom), null))
+		M.flash_eyes()
+
+	for(var/i = 1, i <= 4 + rand(1,2), i++)
+		var/chosen = pick(borks)
+		var/obj/B = new chosen
+		if(B)
+			B.forceMove(get_turf(holder.my_atom))
+			if(prob(50))
+				for(var/j = 1, j <= rand(1, 3), j++)
+					step(B, pick(NORTH,SOUTH,EAST,WEST))
 
 
 //Blue
-	slimefrost
-		name = "Slime Frost Oil"
-		id = "m_frostoil"
-		result = "frostoil"
-		required_reagents = list("plasma" = 5)
-		result_amount = 10
-		required_container = /obj/item/slime_extract/blue
-		required_other = 1
+/datum/chemical_reaction/slimefrost
+	name = "Slime Frost Oil"
+	id = "m_frostoil"
+	result = "frostoil"
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 10
+	required_container = /obj/item/slime_extract/blue
+	required_other = 1
+
+/datum/chemical_reaction/slimefrost/on_reaction(datum/reagents/holder)
+		feedback_add_details("slime_cores_used","[type]")
+
+
+/datum/chemical_reaction/slimestabilizer
+	name = "Slime Stabilizer"
+	id = "m_slimestabilizer"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/blue
+	required_other = 1
+
+/datum/chemical_reaction/slimestabilizer/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/stabilizer/P = new /obj/item/slimepotion/stabilizer
+	P.forceMove(get_turf(holder.my_atom))
+
+
 
 //Dark Blue
-	slimefreeze
-		name = "Slime Freeze"
-		id = "m_freeze"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/darkblue
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-				O.show_message(text("\red The slime extract begins to vibrate violently !"), 1)
-			spawn(50)
-				if(holder && holder.my_atom)
-					playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
-					for(var/mob/living/M in range (get_turf(holder.my_atom), 7))
-						M.bodytemperature -= 140
-						to_chat(M, "\blue You feel a chill!")
+/datum/chemical_reaction/slimefreeze
+	name = "Slime Freeze"
+	id = "m_freeze"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/darkblue
+	required_other = 1
+
+/datum/chemical_reaction/slimefreeze/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
+	spawn(50)
+		if(holder && holder.my_atom)
+			playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
+			for(var/mob/living/M in range (get_turf(holder.my_atom), 7))
+				M.bodytemperature -= 240
+				to_chat(M, "<span class='notice'>You feel a chill!</span>")
 
 
-	slimefireproof
-		name = "Slime Fireproof"
-		id = "m_fireproof"
-		result = null
-		required_reagents = list("water" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/darkblue
-		required_other = 1
+/datum/chemical_reaction/slimefireproof
+	name = "Slime Fireproof"
+	id = "m_fireproof"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/darkblue
+	required_other = 1
 
-		on_reaction(datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			var/obj/item/weapon/slimefireproof/P = new /obj/item/weapon/slimefireproof
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimefireproof/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/fireproof/P = new /obj/item/slimepotion/fireproof
+	P.forceMove(get_turf(holder.my_atom))
 
 //Orange
-	slimecasp
-		name = "Slime Capsaicin Oil"
-		id = "m_capsaicinoil"
-		result = "capsaicin"
-		required_reagents = list("blood" = 5)
-		result_amount = 10
-		required_container = /obj/item/slime_extract/orange
-		required_other = 1
+/datum/chemical_reaction/slimecasp
+	name = "Slime Capsaicin Oil"
+	id = "m_capsaicinoil"
+	result = "capsaicin"
+	required_reagents = list("blood" = 1)
+	result_amount = 10
+	required_container = /obj/item/slime_extract/orange
+	required_other = 1
 
-	slimefire
-		name = "Slime fire"
-		id = "m_fire"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/orange
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-				O.show_message(text("\red The slime extract begins to vibrate violently !"), 1)
-			spawn(50)
-				if(holder && holder.my_atom)
-					var/turf/simulated/T = get_turf(holder.my_atom)
-					if(istype(T))
-						T.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 50)
+/datum/chemical_reaction/slimecasp/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+
+/datum/chemical_reaction/slimefire
+	name = "Slime fire"
+	id = "m_fire"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/orange
+	required_other = 1
+
+/datum/chemical_reaction/slimefire/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/turf/TU = get_turf(holder.my_atom)
+	TU.visible_message("<span class='danger'>The slime extract begins to vibrate adorably !</span>")
+	spawn(50)
+		if(holder && holder.my_atom)
+			var/turf/simulated/T = get_turf(holder.my_atom)
+			if(istype(T))
+				T.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 50)
 
 //Yellow
-	slimeoverload
-		name = "Slime EMP"
-		id = "m_emp"
-		result = null
-		required_reagents = list("blood" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/yellow
-		required_other = 1
-		on_reaction(var/datum/reagents/holder, var/created_volume)
-			empulse(get_turf(holder.my_atom), 3, 7)
+
+/datum/chemical_reaction/slimeoverload
+	name = "Slime EMP"
+	id = "m_emp"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/yellow
+	required_other = 1
+
+/datum/chemical_reaction/slimeoverload/on_reaction(datum/reagents/holder, created_volume)
+	feedback_add_details("slime_cores_used","[type]")
+	empulse(get_turf(holder.my_atom), 3, 7)
 
 
-	slimecell
-		name = "Slime Powercell"
-		id = "m_cell"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/yellow
-		required_other = 1
-		on_reaction(var/datum/reagents/holder, var/created_volume)
-			var/obj/item/weapon/stock_parts/cell/slime/P = new /obj/item/weapon/stock_parts/cell/slime
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimecell
+	name = "Slime Powercell"
+	id = "m_cell"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/yellow
+	required_other = 1
 
-	slimeglow
-		name = "Slime Glow"
-		id = "m_glow"
-		result = null
-		required_reagents = list("water" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/yellow
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-				O.show_message(text("\red The contents of the slime core harden and begin to emit a warm, bright light."), 1)
-			var/obj/item/device/flashlight/slime/F = new /obj/item/device/flashlight/slime
-			F.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimecell/on_reaction(datum/reagents/holder, created_volume)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/weapon/stock_parts/cell/high/slime/P = new /obj/item/weapon/stock_parts/cell/high/slime
+	P.forceMove(get_turf(holder.my_atom))
+
+/datum/chemical_reaction/slimeglow
+	name = "Slime Glow"
+	id = "m_glow"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/yellow
+	required_other = 1
+
+/datum/chemical_reaction/slimeglow/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime begins to emit a soft light. Squeezing it will cause it to grow brightly.</span>")
+	var/obj/item/device/flashlight/slime/F = new /obj/item/device/flashlight/slime
+	F.forceMove(get_turf(holder.my_atom))
 
 //Purple
 
-	slimepsteroid
-		name = "Slime Steroid"
-		id = "m_steroid"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/purple
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			var/obj/item/weapon/slimesteroid/P = new /obj/item/weapon/slimesteroid
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimepsteroid
+	name = "Slime Steroid"
+	id = "m_steroid"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/purple
+	required_other = 1
 
+/datum/chemical_reaction/slimepsteroid/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/steroid/P = new /obj/item/slimepotion/steroid
+	P.forceMove(get_turf(holder.my_atom))
 
+/datum/chemical_reaction/slimejam
+	name = "Slime Jam"
+	id = "m_jam"
+	result = "slimejelly"
+	required_reagents = list("sugar" = 1)
+	result_amount = 10
+	required_container = /obj/item/slime_extract/purple
+	required_other = 1
 
-	slimejam
-		name = "Slime Jam"
-		id = "m_jam"
-		result = "slimejelly"
-		required_reagents = list("sugar" = 5)
-		result_amount = 10
-		required_container = /obj/item/slime_extract/purple
-		required_other = 1
+/datum/chemical_reaction/slimejam/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
 
 
 //Dark Purple
-	slimeplasma
-		name = "Slime Plasma"
-		id = "m_plasma"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/darkpurple
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			var/obj/item/stack/sheet/mineral/plasma/P = new /obj/item/stack/sheet/mineral/plasma
-			P.amount = 10
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimeplasma
+	name = "Slime Plasma"
+	id = "m_plasma"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/darkpurple
+	required_other = 1
+
+/datum/chemical_reaction/slimeplasma/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/stack/sheet/mineral/plasma/P = new /obj/item/stack/sheet/mineral/plasma
+	P.amount = 3
+	P.forceMove(get_turf(holder.my_atom))
 
 //Red
-	slimeglycerol
-		name = "Slime Glycerol"
-		id = "m_glycerol"
-		result = "glycerol"
-		required_reagents = list("plasma" = 5)
-		result_amount = 8
-		required_container = /obj/item/slime_extract/red
-		required_other = 1
+
+/datum/chemical_reaction/slimemutator
+	name = "Slime Mutator"
+	id = "m_slimemutator"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/red
+	required_other = 1
+
+/datum/chemical_reaction/slimemutator/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/mutator/P = new /obj/item/slimepotion/mutator
+	P.forceMove(get_turf(holder.my_atom))
+
+/datum/chemical_reaction/slimebloodlust
+	name = "Bloodlust"
+	id = "m_bloodlust"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/red
+	required_other = 1
+
+/datum/chemical_reaction/slimebloodlust/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	for(var/mob/living/carbon/slime/slime in viewers(get_turf(holder.my_atom), null))
+		slime.rabid = 1
+		slime.visible_message("<span class='danger'>The [slime] is driven into a frenzy!</span>")
 
 
-	slimebloodlust
-		name = "Bloodlust"
-		id = "m_bloodlust"
-		result = null
-		required_reagents = list("blood" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/red
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			for(var/mob/living/carbon/slime/slime in viewers(get_turf(holder.my_atom), null))
-				slime.rabid = 1
-				for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-					O.show_message(text("\red The [slime] is driven into a frenzy!."), 1)
+/datum/chemical_reaction/slimespeed
+	name = "Slime Speed"
+	id = "m_speed"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/red
+	required_other = 1
 
+/datum/chemical_reaction/slimespeed/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/speed/P = new /obj/item/slimepotion/speed
+	P.forceMove(get_turf(holder.my_atom))
 
-	slimespeed
-		name = "Slime Speed"
-		id = "m_speed"
-		result = null
-		required_reagents = list("water" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/red
-		required_other = 1
-
-		on_reaction(datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			var/obj/item/weapon/slimespeed/P = new /obj/item/weapon/slimespeed
-			P.loc = get_turf(holder.my_atom)
 
 //Pink
-	slimeppotion
-		name = "Slime Potion"
-		id = "m_potion"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/pink
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			var/obj/item/weapon/slimepotion/P = new /obj/item/weapon/slimepotion
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/docility
+	name = "Docility Potion"
+	id = "m_potion"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/pink
+	required_other = 1
+
+/datum/chemical_reaction/docility/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/docility/P = new /obj/item/slimepotion/docility
+	P.forceMove(get_turf(holder.my_atom))
 
 
 //Black
-	slimemutate2
-		name = "Advanced Mutation Toxin"
-		id = "mutationtoxin2"
-		result = "amutationtoxin"
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_other = 1
-		required_container = /obj/item/slime_extract/black
+/datum/chemical_reaction/slimemutate2
+	name = "Advanced Mutation Toxin"
+	id = "mutationtoxin2"
+	result = "amutationtoxin"
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_other = 1
+	required_container = /obj/item/slime_extract/black
+
+/datum/chemical_reaction/slimemutate2/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
 
 //Oil
-	slimeexplosion
-		name = "Slime Explosion"
-		id = "m_explosion"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/oil
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			for(var/mob/O in viewers(get_turf(holder.my_atom), null))
-				O.show_message(text("\red The slime extract begins to vibrate violently !"), 1)
-			spawn(50)
-				if(holder && holder.my_atom)
-					explosion(get_turf(holder.my_atom), 1 ,3, 6)
+/datum/chemical_reaction/slimeexplosion
+	name = "Slime Explosion"
+	id = "m_explosion"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/oil
+	required_other = 1
+
+/datum/chemical_reaction/slimeexplosion/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/turf/T = get_turf(holder.my_atom)
+	T.visible_message("<span class='danger'>The slime extract begins to vibrate violently !</span>")
+	spawn(50)
+		if(holder && holder.my_atom)
+			explosion(get_turf(holder.my_atom), 1 ,3, 6)
+
 //Light Pink
-	slimepotion2
-		name = "Slime Potion 2"
-		id = "m_potion2"
-		result = null
-		result_amount = 1
-		required_container = /obj/item/slime_extract/lightpink
-		required_reagents = list("plasma" = 5)
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			var/obj/item/weapon/sentience_potion/P = new /obj/item/weapon/sentience_potion
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimepotion2
+	name = "Slime Potion 2"
+	id = "m_potion2"
+	result = null
+	result_amount = 1
+	required_container = /obj/item/slime_extract/lightpink
+	required_reagents = list("plasma_dust" = 1)
+	required_other = 1
+
+/datum/chemical_reaction/slimepotion2/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/sentience/P = new /obj/item/slimepotion/sentience
+	P.forceMove(get_turf(holder.my_atom))
+
 //Adamantine
-	slimegolem
-		name = "Slime Golem"
-		id = "m_golem"
-		result = null
-		required_reagents = list("plasma" = 5)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/adamantine
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-			var/obj/effect/goleRUNe/Z = new /obj/effect/goleRUNe
-			Z.loc = get_turf(holder.my_atom)
-			Z.announce_to_ghosts()
+/datum/chemical_reaction/slimegolem
+	name = "Slime Golem"
+	id = "m_golem"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/adamantine
+	required_other = 1
+
+/datum/chemical_reaction/slimegolem/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/effect/golemrune/Z = new /obj/effect/golemrune
+	Z.forceMove(get_turf(holder.my_atom))
+	notify_ghosts("Golem rune created in [get_area(Z)].", 'sound/effects/ghost2.ogg')
+
 //Bluespace
-	slimefloor2
-		name = "Bluespace Floor"
-		id = "m_floor2"
-		result = null
-		required_reagents = list("blood" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/bluespace
-		required_other = 1
-		on_reaction(datum/reagents/holder, created_volume)
-			feedback_add_details("slime_cores_used","[type]")
-			var/obj/item/stack/tile/bluespace/P = new /obj/item/stack/tile/bluespace
-			P.amount = 25
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimefloor2
+	name = "Bluespace Floor"
+	id = "m_floor2"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/bluespace
+	required_other = 1
 
-	slimecrystal
-		name = "Slime Crystal"
-		id = "m_crystal"
-		result = null
-		required_reagents = list("plasma" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/bluespace
-		required_other = 1
-		on_reaction(var/datum/reagents/holder, var/created_volume)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-			if(holder.my_atom)
-				var/obj/item/weapon/ore/bluespace_crystal/BC = new(get_turf(holder.my_atom))
-				BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
+/datum/chemical_reaction/slimefloor2/on_reaction(datum/reagents/holder, created_volume)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/stack/tile/bluespace/P = new /obj/item/stack/tile/bluespace
+	P.amount = 25
+	P.forceMove(get_turf(holder.my_atom))
+
+
+/datum/chemical_reaction/slimecrystal
+	name = "Slime Crystal"
+	id = "m_crystal"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/bluespace
+	required_other = 1
+
+/datum/chemical_reaction/slimecrystal/on_reaction(datum/reagents/holder, created_volume)
+	feedback_add_details("slime_cores_used","[type]")
+	if(holder.my_atom)
+		var/obj/item/weapon/ore/bluespace_crystal/BC = new(get_turf(holder.my_atom))
+		BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
+
 //Cerulean
-	slimepsteroid2
-		name = "Slime Steroid 2"
-		id = "m_steroid2"
-		result = null
-		required_reagents = list("plasma" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/cerulean
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-			var/obj/item/weapon/slimesteroid2/P = new /obj/item/weapon/slimesteroid2
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimepsteroid2
+	name = "Slime Steroid 2"
+	id = "m_steroid2"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/cerulean
+	required_other = 1
 
-	slime_territory
-		name = "Slime Territory"
-		id = "s_territory"
-		result = null
-		required_reagents = list("blood" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/cerulean
-		required_other = 1
-		on_reaction(datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			var/obj/item/areaeditor/blueprints/slime/P = new /obj/item/areaeditor/blueprints/slime
-			P.forceMove(get_turf(holder.my_atom))
+/datum/chemical_reaction/slimepsteroid2/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/slimepotion/enhancer/P = new /obj/item/slimepotion/enhancer
+	P.forceMove(get_turf(holder.my_atom))
+
+
+
+/datum/chemical_reaction/slime_territory
+	name = "Slime Territory"
+	id = "s_territory"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/cerulean
+	required_other = 1
+
+/datum/chemical_reaction/slime_territory/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/areaeditor/blueprints/slime/P = new /obj/item/areaeditor/blueprints/slime
+	P.forceMove(get_turf(holder.my_atom))
 
 //Sepia
-	slimestop
-		name = "Slime Stop"
-		id = "m_stop"
-		result = null
-		required_reagents = list("plasma" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/sepia
-		required_other = 1
-		on_reaction(datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			spawn(0) //otherwise the reagent won't be used up until after the full timstop is gone through.
-				var/mob/mob = get_mob_by_key(holder.my_atom.fingerprintslast)
-				var/obj/effect/timestop/T = new (get_turf(holder.my_atom))
-				T.immune += mob
-				T.timestop()
+/datum/chemical_reaction/slimestop
+	name = "Slime Stop"
+	id = "m_stop"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/sepia
+	required_other = 1
+
+/datum/chemical_reaction/slimestop/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/mob/mob = get_mob_by_key(holder.my_atom.fingerprintslast)
+	var/obj/effect/timestop/T = new /obj/effect/timestop
+	T.forceMove(get_turf(holder.my_atom))
+	T.immune += mob
+	T.timestop()
 
 
-	slimecamera
-		name = "Slime Camera"
-		id = "m_camera"
-		result = null
-		required_reagents = list("water" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/sepia
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-			var/obj/item/device/camera/P = new /obj/item/device/camera
-			P.loc = get_turf(holder.my_atom)
-			var/obj/item/device/camera_film/Z = new /obj/item/device/camera_film
-			Z.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimecamera
+	name = "Slime Camera"
+	id = "m_camera"
+	result = null
+	required_reagents = list("water" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/sepia
+	required_other = 1
 
-	slimefloor
-		name = "Sepia Floor"
-		id = "m_floor"
-		result = null
-		required_reagents = list("blood" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/sepia
-		required_other = 1
-		on_reaction(datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[type]")
-			var/obj/item/stack/tile/sepia/P = new /obj/item/stack/tile/sepia
-			P.amount = 25
-			P.loc = get_turf(holder.my_atom)
+/datum/chemical_reaction/slimecamera/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/device/camera/P = new /obj/item/device/camera
+	P.forceMove(get_turf(holder.my_atom))
+	var/obj/item/device/camera_film/Z = new /obj/item/device/camera_film
+	Z.forceMove(get_turf(holder.my_atom))
+
+/datum/chemical_reaction/slimefloor
+	name = "Sepia Floor"
+	id = "m_floor"
+	result = null
+	required_reagents = list("blood" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/sepia
+	required_other = 1
+
+/datum/chemical_reaction/slimefloor/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/obj/item/stack/tile/sepia/P = new /obj/item/stack/tile/sepia
+	P.amount = 25
+	P.forceMove(get_turf(holder.my_atom))
+
 
 //Pyrite
-	slimepaint
-		name = "Slime Paint"
-		id = "s_paint"
-		result = null
-		required_reagents = list("plasma" = 1)
-		result_amount = 1
-		required_container = /obj/item/slime_extract/pyrite
-		required_other = 1
-		on_reaction(var/datum/reagents/holder)
-			feedback_add_details("slime_cores_used","[replacetext(name," ","_")]")
-			var/list/paints = subtypesof(/obj/item/weapon/reagent_containers/glass/paint)
-			var/chosen = pick(paints)
-			var/obj/P = new chosen
-			if(P)
-				P.loc = get_turf(holder.my_atom)
+
+
+/datum/chemical_reaction/slimepaint
+	name = "Slime Paint"
+	id = "s_paint"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_container = /obj/item/slime_extract/pyrite
+	required_other = 1
+
+/datum/chemical_reaction/slimepaint/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/list/paints = subtypesof(/obj/item/weapon/reagent_containers/glass/paint)
+	var/chosen = pick(paints)
+	var/obj/P = new chosen
+	if(P)
+		P.forceMove(get_turf(holder.my_atom))
+
+//Rainbow :o)
+/datum/chemical_reaction/slimeRNG
+	name = "Random Core"
+	id = "slimerng"
+	result = null
+	required_reagents = list("plasma_dust" = 1)
+	result_amount = 1
+	required_other = 1
+	required_container = /obj/item/slime_extract/rainbow
+
+/datum/chemical_reaction/slimeRNG/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	var/mob/living/carbon/slime/S = new /mob/living/carbon/slime
+	S.colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
+	S.forceMove(get_turf(holder.my_atom))
+	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")

--- a/code/modules/reagents/oldchem/reagents/reagents_flammable.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_flammable.dm
@@ -48,7 +48,7 @@
 		holder.remove_reagent("epinephrine", 2)
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		C.adjustPlasma(20)
+		C.adjustPlasma(10)
 	..()
 	return
 

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -303,10 +303,10 @@
 
 
 /obj/item/weapon/reagent_containers/glass/bottle/plasma
-	name = "liquid plasma bottle"
-	desc = "A small bottle of liquid plasma. Extremely toxic and reacts with micro-organisms inside blood."
+	name = "plasma dust bottle"
+	desc = "A small bottle of plasma in dust form. Extremely toxic and reacts with micro-organisms inside blood."
 	icon_state = "bottle8"
-	list_reagents = list("plasma" = 30)
+	list_reagents = list("plasma_dust" = 30)
 
 /obj/item/weapon/reagent_containers/glass/bottle/diphenhydramine
 	name = "diphenhydramine bottle"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -6,120 +6,95 @@
 	desc = "Goo extracted from a slime. Legends claim these to have \"magical powers\"."
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "grey slime extract"
-	force = 1.0
-	w_class = 1.0
+	force = 1
+	w_class = 1
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 6
-	origin_tech = "biotech=4"
-	item_color = "grey"
+	origin_tech = "biotech=3"
 	var/Uses = 1 // uses before it goes inert
-	var/enhanced = 0 //has it been enhanced before?
 
-	attackby(obj/item/O as obj, mob/user as mob, params)
-		if(istype(O, /obj/item/weapon/slimesteroid2))
-			if(enhanced == 1)
-				to_chat(user, "<span class='warning'> This extract has already been enhanced!</span>")
-				return ..()
-			if(Uses == 0)
-				to_chat(user, "<span class='warning'> You can't enhance a used extract!</span>")
-				return ..()
-			to_chat(user, "You apply the enhancer. It now has triple the amount of uses.")
-			Uses = 3
-			enhanced = 1
-			qdel(O)
-		if(istype(O,/obj/item/weapon/storage/bag))
-			..()
+/obj/item/slime_extract/attackby(obj/item/O, mob/user)
+	if(istype(O, /obj/item/slimepotion/enhancer))
+		if(Uses >= 5)
+			to_chat(user, "<span class='warning'>You cannot enhance this extract further!</span>")
+			return ..()
+		to_chat(user, "<span class='notice'>You apply the enhancer to the slime extract. It may now be reused one more time.</span>")
+		Uses++
+		qdel(O)
+	..()
 
 /obj/item/slime_extract/New()
 		..()
 		create_reagents(100)
 
-
 /obj/item/slime_extract/grey
 	name = "grey slime extract"
 	icon_state = "grey slime extract"
-	item_color = "grey"
 
 /obj/item/slime_extract/gold
 	name = "gold slime extract"
 	icon_state = "gold slime extract"
-	item_color = "gold"
 
 /obj/item/slime_extract/silver
 	name = "silver slime extract"
 	icon_state = "silver slime extract"
-	item_color = "silver"
 
 /obj/item/slime_extract/metal
 	name = "metal slime extract"
 	icon_state = "metal slime extract"
-	item_color = "metal"
 
 /obj/item/slime_extract/purple
 	name = "purple slime extract"
 	icon_state = "purple slime extract"
-	item_color = "purple"
 
 /obj/item/slime_extract/darkpurple
 	name = "dark purple slime extract"
 	icon_state = "dark purple slime extract"
-	item_color = "darkpurple"
 
 /obj/item/slime_extract/orange
 	name = "orange slime extract"
 	icon_state = "orange slime extract"
-	item_color = "orange"
 
 /obj/item/slime_extract/yellow
 	name = "yellow slime extract"
 	icon_state = "yellow slime extract"
-	item_color = "yellow"
 
 /obj/item/slime_extract/red
 	name = "red slime extract"
 	icon_state = "red slime extract"
-	item_color = "red"
 
 /obj/item/slime_extract/blue
 	name = "blue slime extract"
 	icon_state = "blue slime extract"
-	item_color = "blue"
 
 /obj/item/slime_extract/darkblue
 	name = "dark blue slime extract"
 	icon_state = "dark blue slime extract"
-	item_color = "darkblue"
 
 /obj/item/slime_extract/pink
 	name = "pink slime extract"
 	icon_state = "pink slime extract"
-	item_color = "pink"
 
 /obj/item/slime_extract/green
 	name = "green slime extract"
 	icon_state = "green slime extract"
-	item_color = "green"
 
 /obj/item/slime_extract/lightpink
 	name = "light pink slime extract"
 	icon_state = "light pink slime extract"
-	item_color = "lightpink"
 
 /obj/item/slime_extract/black
 	name = "black slime extract"
 	icon_state = "black slime extract"
-	item_color = "black"
 
 /obj/item/slime_extract/oil
 	name = "oil slime extract"
 	icon_state = "oil slime extract"
-	item_color = "oil"
 
 /obj/item/slime_extract/adamantine
 	name = "adamantine slime extract"
 	icon_state = "adamantine slime extract"
-	item_color = "adamantine"
 
 /obj/item/slime_extract/bluespace
 	name = "bluespace slime extract"
@@ -141,57 +116,66 @@
 	name = "rainbow slime extract"
 	icon_state = "rainbow slime extract"
 
-////Pet Slime Creation///
+////Slime-derived potions///
 
-/obj/item/weapon/slimepotion
-	name = "docility potion"
-	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame."
-	icon = 'icons/obj/chemical.dmi'
-	icon_state = "bottle19"
+/obj/item/slimepotion
+	name = "slime potion"
+	desc = "A hard yet gelatinous capsule excreted by a slime, containing mysterious substances."
 	w_class = 1
 	origin_tech = "biotech=4"
 
-	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-			to_chat(user, "<span class='warning'> The potion only works on slimes!</span>")
-			return ..()
-		if(M.stat)
-			to_chat(user, "<span class='warning'> The slime is dead!</span>")
-			return..()
-		if(M.mind)
-			to_chat(user, "<span class='warning'> The slime resists!</span>")
-			return ..()
-		if(M.is_adult)
-			var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
-			pet.icon_state = "[M.colour] adult slime"
-			pet.icon_living = "[M.colour] adult slime"
-			pet.icon_dead = "[M.colour] baby slime dead"
-			pet.colour = "[M.colour]"
-			qdel(M)
-			var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
+/obj/item/slimepotion/afterattack(obj/item/weapon/reagent_containers/target, mob/user , proximity)
+	if (istype(target))
+		to_chat(user, "<span class='notice'>You cannot transfer [src] to [target]! It appears the potion must be given directly to a slime to absorb.</span>") // le fluff faec
+		return
 
-			if (!newname)
-				newname = "pet slime"
-			pet.name = newname
-			pet.real_name = newname
-			qdel(src)
-		else
-			var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
-			pet.icon_state = "[M.colour] baby slime"
-			pet.icon_living = "[M.colour] baby slime"
-			pet.icon_dead = "[M.colour] baby slime dead"
-			pet.colour = "[M.colour]"
-			qdel(M)
-			var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
+/obj/item/slimepotion/docility
+	name = "docility potion"
+	desc = "A potent chemical mix that nullifies a slime's hunger, causing it to become docile and tame."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle19"
 
-			if (!newname)
-				newname = "pet slime"
-			pet.name = newname
-			pet.real_name = newname
-			qdel(src)
-		to_chat(user, "You feed the slime the potion, removing it's powers and calming it.")
+/obj/item/slimepotion/docility/attack(mob/living/carbon/slime/M, mob/user)
+	if(!isslime(M))
+		to_chat(user, "<span class='warning'> The potion only works on slimes!</span>")
+		return ..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'> The slime is dead!</span>")
+		return..()
+	if(M.mind)
+		to_chat(user, "<span class='warning'> The slime resists!</span>")
+		return ..()
+	if(M.is_adult)
+		var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
+		pet.icon_state = "[M.colour] adult slime"
+		pet.icon_living = "[M.colour] adult slime"
+		pet.icon_dead = "[M.colour] baby slime dead"
+		pet.colour = "[M.colour]"
+		qdel(M)
+		var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
 
-/obj/item/weapon/sentience_potion
+		if (!newname)
+			newname = "pet slime"
+		pet.name = newname
+		pet.real_name = newname
+		qdel(src)
+	else
+		var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
+		pet.icon_state = "[M.colour] baby slime"
+		pet.icon_living = "[M.colour] baby slime"
+		pet.icon_dead = "[M.colour] baby slime dead"
+		pet.colour = "[M.colour]"
+		qdel(M)
+		var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
+
+		if (!newname)
+			newname = "pet slime"
+		pet.name = newname
+		pet.real_name = newname
+		qdel(src)
+	to_chat(user, "You feed the slime the potion, removing it's powers and calming it.")
+
+/obj/item/slimepotion/sentience
 	name = "sentience potion"
 	desc = "A miraculous chemical mix that can raise the intelligence of creatures to human levels. Unlike normal slime potions, it can be absorbed by any nonsentient being."
 	icon = 'icons/obj/chemical.dmi'
@@ -199,11 +183,9 @@
 	origin_tech = "biotech=5"
 	var/list/not_interested = list()
 	var/being_used = 0
-	w_class = 1
 	var/sentience_type = SENTIENCE_ORGANIC
 
-
-/obj/item/weapon/sentience_potion/afterattack(mob/living/M, mob/user)
+/obj/item/slimepotion/sentience/afterattack(mob/living/M, mob/user)
 	if(being_used || !ismob(M))
 		return
 	if(!isanimal(M) || M.ckey) //only works on animals that aren't player controlled
@@ -242,51 +224,89 @@
 		..()
 
 
-/obj/item/weapon/slimesteroid
+/obj/item/slimepotion/steroid
 	name = "slime steroid"
-	desc = "A potent chemical mix that will cause a slime to generate more extract."
+	desc = "A potent chemical mix that will cause a baby slime to generate more extract."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle16"
-	w_class = 1
-	origin_tech = "biotech=4"
 
+/obj/item/slimepotion/steroid/attack(mob/living/carbon/slime/M, mob/user)
+	if(!isslime(M))//If target is not a slime.
+		to_chat(user, "<span class='warning'>The steroid only works on baby slimes!</span>")
+		return ..()
+	if(M.is_adult) //Can't steroidify adults
+		to_chat(user, "<span class='warning'>Only baby slimes can use the steroid!</span>")
+		return ..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'>The slime is dead!</span>")
+		return ..()
+	if(M.cores >= 5)
+		to_chat(user, "<span class='warning'>The slime already has the maximum amount of extract!</span>")
+		return ..()
 
-	attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-		if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-			to_chat(user, "<span class='warning'> The steroid only works on baby slimes!</span>")
-			return ..()
-		if(M.is_adult) //Can't tame adults
-			to_chat(user, "<span class='warning'> Only baby slimes can use the steroid!</span>")
-			return..()
-		if(M.stat)
-			to_chat(user, "<span class='warning'> The slime is dead!</span>")
-			return..()
-		if(M.cores == 3)
-			to_chat(user, "<span class='warning'> The slime already has the maximum amount of extract!</span>")
-			return..()
+	to_chat(user, "<span class='notice'>You feed the slime the steroid. It will now produce one more extract.</span>")
+	M.cores++
+	qdel(src)
 
-		to_chat(user, "You feed the slime the steroid. It now has triple the amount of extract.")
-		M.cores = 3
-		qdel(src)
-
-/obj/item/weapon/slimesteroid2
+/obj/item/slimepotion/enhancer
 	name = "extract enhancer"
-	desc = "A potent chemical mix that will give a slime extract three uses."
+	desc = "A potent chemical mix that will give a slime extract an additional use."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle17"
-	w_class = 1
-	origin_tech = "biotech=4"
 
+/obj/item/slimepotion/stabilizer
+	name = "slime stabilizer"
+	desc = "A potent chemical mix that will reduce the chance of a slime mutating."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle15"
 
-/obj/item/weapon/slimespeed
+/obj/item/slimepotion/stabilizer/attack(mob/living/carbon/slime/M, mob/user)
+	if(!isslime(M))
+		to_chat(user, "<span class='warning'>The stabilizer only works on slimes!</span>")
+		return ..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'>The slime is dead!</span>")
+		return ..()
+	if(M.mutation_chance == 0)
+		to_chat(user, "<span class='warning'>The slime already has no chance of mutating!</span>")
+		return ..()
+
+	to_chat(user, "<span class='notice'>You feed the slime the stabilizer. It is now less likely to mutate.</span>")
+	M.mutation_chance = Clamp(M.mutation_chance-15,0,100)
+	qdel(src)
+
+/obj/item/slimepotion/mutator
+	name = "slime mutator"
+	desc = "A potent chemical mix that will increase the chance of a slime mutating."
+	icon = 'icons/obj/chemical.dmi'
+	icon_state = "bottle3"
+
+/obj/item/slimepotion/mutator/attack(mob/living/carbon/slime/M, mob/user)
+	if(!isslime(M))
+		to_chat(user, "<span class='warning'>The mutator only works on slimes!</span>")
+		return ..()
+	if(M.stat)
+		to_chat(user, "<span class='warning'>The slime is dead!</span>")
+		return ..()
+	if(M.mutator_used)
+		to_chat(user, "<span class='warning'>This slime has already consumed a mutator, any more would be far too unstable!</span>")
+		return ..()
+	if(M.mutation_chance == 100)
+		to_chat(user, "<span class='warning'>The slime is already guaranteed to mutate!</span>")
+		return ..()
+
+	to_chat(user, "<span class='notice'>You feed the slime the mutator. It is now more likely to mutate.</span>")
+	M.mutation_chance = Clamp(M.mutation_chance+12,0,100)
+	M.mutator_used = TRUE
+	qdel(src)
+
+/obj/item/slimepotion/speed
 	name = "slime speed potion"
 	desc = "A potent chemical mix that will remove the slowdown from any item."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle3"
-	w_class = 1
-	origin_tech = "biotech=4"
 
-/obj/item/weapon/slimespeed/afterattack(obj/item/C, mob/user)
+/obj/item/slimepotion/speed/afterattack(obj/item/C, mob/user)
 	..()
 	if(!istype(C))
 		to_chat(user, "<span class='warning'>The potion can only be used on items!</span>")
@@ -299,17 +319,14 @@
 	C.slowdown = 0
 	qdel(src)
 
-/obj/item/weapon/slimefireproof
+/obj/item/slimepotion/fireproof
 	name = "slime chill potion"
 	desc = "A potent chemical mix that will fireproof any article of clothing. Has three uses."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle17"
 	var/uses = 3
-	w_class = 1
-	origin_tech = "biotech=4"
 
-
-/obj/item/weapon/slimefireproof/afterattack(obj/item/clothing/C, mob/user)
+/obj/item/slimepotion/fireproof/afterattack(obj/item/clothing/C, mob/user)
 	..()
 	if(!uses)
 		qdel(src)
@@ -319,7 +336,7 @@
 		return
 	if(C.max_heat_protection_temperature == FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
 		to_chat(user, "<span class='warning'>The [C] is already fireproof!</span>")
-		return..()
+		return ..()
 	to_chat(user, "<span class='notice'>You slather the blue gunk over the [C], fireproofing it.</span>")
 	C.name = "fireproofed [C.name]"
 	C.color = "#000080"
@@ -328,6 +345,78 @@
 	uses --
 	if(!uses)
 		qdel(src)
+
+////////Adamantine Golem stuff I dunno where else to put it
+
+/obj/effect/golemrune
+	anchored = 1
+	desc = "a strange rune used to create golems. It glows when spirits are nearby."
+	name = "rune"
+	icon = 'icons/obj/rune.dmi'
+	icon_state = "golem"
+	unacidable = 1
+	layer = TURF_LAYER
+	var/list/mob/dead/observer/ghosts[0]
+
+/obj/effect/golemrune/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/effect/golemrune/process()
+	if(ghosts.len>0)
+		icon_state = "golem2"
+	else
+		icon_state = "golem"
+
+/obj/effect/golemrune/attack_hand(mob/living/user as mob)
+	var/mob/dead/observer/ghost
+	for(var/mob/dead/observer/O in src.loc)
+		if(!check_observer(O))
+			to_chat(O, "\red You are not eligible to become a golem.")
+			continue
+		ghost = O
+		break
+	if(!ghost)
+		to_chat(user, "The rune fizzles uselessly. There is no spirit nearby.")
+		return
+	var/mob/living/carbon/human/golem/G = new /mob/living/carbon/human/golem
+	G.change_gender(pick(MALE,FEMALE))
+	G.loc = src.loc
+	G.key = ghost.key
+	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost.")
+	qdel(src)
+
+/obj/effect/golemrune/Topic(href,href_list)
+	if("signup" in href_list)
+		var/mob/dead/observer/O = locate(href_list["signup"])
+		volunteer(O)
+
+/obj/effect/golemrune/attack_ghost(var/mob/dead/observer/O)
+	if(!O) return
+	volunteer(O)
+
+/obj/effect/golemrune/proc/check_observer(var/mob/dead/observer/O)
+	if(!O)
+		return 0
+	if(!O.client)
+		return 0
+	if(O.mind && O.mind.current && O.mind.current.stat != DEAD)
+		return 0
+	if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+		return 0
+	return 1
+
+/obj/effect/golemrune/proc/volunteer(var/mob/dead/observer/O)
+	if(O in ghosts)
+		ghosts.Remove(O)
+		to_chat(O, "\red You are no longer signed up to be a golem.")
+	else
+		if(!check_observer(O))
+			to_chat(O, "\red You are not eligible to become a golem.")
+			return
+		ghosts.Add(O)
+		to_chat(O, "\blue You are signed up to be a golem.")
+
 
 
 
@@ -460,80 +549,3 @@
 	icon_state = "sepia"
 	desc = "Time seems to flow very slowly around these tiles."
 	floor_tile = /obj/item/stack/tile/sepia
-
-/obj/effect/goleRUNe
-	anchored = 1
-	desc = "a strange rune used to create golems. It glows when spirits are nearby."
-	name = "rune"
-	icon = 'icons/obj/rune.dmi'
-	icon_state = "golem"
-	unacidable = 1
-	layer = TURF_LAYER
-	var/list/mob/dead/observer/ghosts[0]
-
-	New()
-		..()
-		processing_objects.Add(src)
-
-	process()
-		if(ghosts.len>0)
-			icon_state = "golem2"
-		else
-			icon_state = "golem"
-
-	attack_hand(mob/living/user as mob)
-		var/mob/dead/observer/ghost
-		for(var/mob/dead/observer/O in src.loc)
-			if(!check_observer(O))
-				to_chat(O, "\red You are not eligible to become a golem.")
-				continue
-			ghost = O
-			break
-		if(!ghost)
-			to_chat(user, "The rune fizzles uselessly. There is no spirit nearby.")
-			return
-		var/mob/living/carbon/human/golem/G = new /mob/living/carbon/human/golem
-		G.change_gender(pick(MALE,FEMALE))
-		G.loc = src.loc
-		G.key = ghost.key
-		to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost.")
-		qdel(src)
-
-
-	proc/announce_to_ghosts()
-		for(var/mob/dead/observer/O in player_list)
-			if(O.client)
-				var/area/A = get_area(src)
-				if(A)
-					to_chat(O, "\blue <b>Golem rune created in [A.name]. (<a href='?src=\ref[O];jump=\ref[src]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</b>")
-
-	Topic(href,href_list)
-		if("signup" in href_list)
-			var/mob/dead/observer/O = locate(href_list["signup"])
-			volunteer(O)
-
-	attack_ghost(var/mob/dead/observer/O)
-		if(!O) return
-		volunteer(O)
-
-	proc/check_observer(var/mob/dead/observer/O)
-		if(!O)
-			return 0
-		if(!O.client)
-			return 0
-		if(O.mind && O.mind.current && O.mind.current.stat != DEAD)
-			return 0
-		if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
-			return 0
-		return 1
-
-	proc/volunteer(var/mob/dead/observer/O)
-		if(O in ghosts)
-			ghosts.Remove(O)
-			to_chat(O, "\red You are no longer signed up to be a golem.")
-		else
-			if(!check_observer(O))
-				to_chat(O, "\red You are not eligible to become a golem.")
-				return
-			ghosts.Add(O)
-			to_chat(O, "\blue You are signed up to be a golem.")


### PR DESCRIPTION
Re-upload of: https://github.com/ParadiseSS13/Paradise/pull/4110, because apparently the original had fatal errors when resolving extremelyyyy simple conflicts. Don't even understand...

Xenobio Refactor/Overhual, brought to you by TG.

This should help gate Xenobio's insane production rate while adding in some completely new and interesting reactions/mechanics to slimes. It also helps make more things, on station, dependent on plasma OR Xenobio, which should help encourage departmental interaction.

Feature Additiuons/Balance Changes/Removals
- Added in Plasma Dust
 - Plasma dust is acquired by grinding plasma sheets; it's more toxic than regular plasma and generates plasma gas when spilled onto turfs.
- Slime core reactions now require plasma dust as opposed to dispenser plasma
 - This is the way it was meant to be. Ever wonder why the sheets in Xenobio exist? It's because when we converted over to Goonchem we didn't make a new subtype of plasma and left it to be the one straight from the dispenser.
- Added in new Rainbow slime; inject its cores with plasma dust to get a random colored slime
 - Can acquire the rainbow slime by getting a mutation chance of 100 on a slime then having it split
- Epinephrine/plasma reagents changing mutation rate has been removed
- Mutation chance is inherited from slime generation to slime generation instead of just being a random value when slimes split.
- New reactions added for red and blue extracts: red generates mutator potion, which increases mutation chance on a slime, and blue generates stabilizer potion, which decreases mutation chance on a slime.
- Slime glycerol reaction removed
- Slime cells are now high capacity cells (more power than before)
- extract enhancer increases the slime core usage by 1 as opposed to setting it to three
 - No more unlimited extracts, effectively, with just a couple cerulean slimes.
- Slime enhancer now increases amount of cores by 1 (to a max of 5) as opposed to setting it to 3.
- Chill reaction lowers body temperature slightly more so it doesn't just wear off instantly
- Most slime reactions only need 1 unit of plasma/water/blood to react as opposed to 5
- Reduces Plasma sheet count from 8 to 3 and removes that damn boombox
- Can use a multitool on the monkey recycler to change the monkey cube type.
- I'm probably forgetting something. 


Virology Changes
- Virology Reactions use plasma dust as opposed to plasma
- Virology Plasma bottle now has plasma dust instead of plasma
- Virology now gets notified when plasma sheets are available

Codewise
- Removes relatively pathing from Xenobio objects
- Removes Relative Pathing from slime core react
- Object slime core spawning now uses forcemove
- Removes unused Golem rune proc
- Golem rune code path name isn't so stupid
- Unifies slime potions under a singular type

Fixes
- Fixes processors producing 1 more core than intended
- All slime core usage is now properly logged
- Shouldn't get quite as many empty/iconless food types from the silver core (there's still going to be some issues, but it'll be better)

:cl: Fox McCloud
add: Added in Plasma Dust reagent, acquired by grinding plasma sheets; it's more toxic than regular plasma and generates plasma gas when spilled onto turfs.
tweak: Slimecore reactions now require plasma dust as opposed to dispenser plasma
add: Added in new Rainbow slime; inject with plasma dust to get a random colored slime. Acquire by having 100 mutation chance on a slime when it splits.
add: Monkey Recycler can produce different types of monkey cubes; change the cube type by using a multitool on the recycler
tweak: Epinephrine/plasma reagents changing mutation rate has been removed
tweak: Mutation chance is inherited from slime generation to slime generation as opposed to being purely random.
tweak: New reactions added for red and blue extracts: red generates mutator, which increases mutation chance, and blue generates stabilizer, which decreases mutation chance.
tweak: Slime glycerol reaction removed
tweak: Slime cells are now high capacity cells (more power than before)
tweak: extract enhancer increases the slime core usage by 1 as oppose to setting it to three
tweak: slime enhancer increases slime cores by 1 as opposed to setting the core amount to 3
tweak: Chill reaction lowers body temperature slightly more so it doesn't just wear off instantly
tweak: Reduces Xenobio plasma sheets from 8 to 3 and removes that pesky boombox
fix: Processors no longer produce 1 more slime core than intended
fix: Less blank/spriteless/empty foods from the silver core reaction
tweak: Virology mix reactions now use plasma dust as opposed to plasma
/:cl: