### PR TITLE
TG Statue Fixes/Refactor

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -2,6 +2,7 @@
 	gender = NEUTER
 	robot_talk_understand = 1
 	voice_name = "synthesized voice"
+	has_unlimited_silicon_privilege = 1
 	var/syndicate = 0
 	var/const/MAIN_CHANNEL = "Main Frequency"
 	var/lawchannel = MAIN_CHANNEL // Default channel on which to state laws

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -11,6 +11,7 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+	has_unlimited_silicon_privilege = 1
 	sentience_type = SENTIENCE_ARTIFICIAL
 	status_flags = 0 //no default canpush
 	can_strip = 0

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -203,6 +203,8 @@
 	var/digitalcamo = 0 // Can they be tracked by the AI?
 	var/weakeyes = 0 //Are they vulnerable to flashes?
 
+	var/has_unlimited_silicon_privilege = 0 // Can they interact with station electronics
+
 	var/list/radar_blips = list() // list of screen objects, radar blips
 	var/radar_open = 0 	// nonzero is radar is open
 


### PR DESCRIPTION
TG's Statue Fix/Refactor re-upload of https://github.com/ParadiseSS13/Paradise/pull/4104 because same fatal errors...*sigh*

Things different from the re-uploaded PR:

- melee damage is not doubled
- No, it's still not gold-core spawnable

Implement's TG's version of statues.

Basically, they have the same spells as our statues, but they're impervious to all damage (except gibbing). That said, they have a very very strict set of rules that governs if they can attack or not---if it's pitch black, then the statue can move/attack. If it's not, then the statue may only attack if everyone that has eyes on them (a mob with a client that is within vision range) is blinded. Again, if a mob is blinded, then that mob can be attacked, regardless of brightness.

Summary of changes

- Statues are now invincible to anything other than the most devastating of bombs
- Statues can no longer move or attack unless everyone around them is blind or in total darkness
- Statue light flicker range increased by 2
- Blindness spell no longer stuns silicons.

Fixes

- Fixes a bug where statues could typically disobey their lighting/blindness rules and just attack you anyway.
- Statues no long blind themselves with the blindness spell

Other
- Implements has_unlimited_silicon_privilege; largely unused for now, but can be utilized for other things later (only implemented it because ti was used in the statue PR).

:cl: Fox McCloud
tweak: Statues can no longer move/attack people unless they're in total darkness or all mobs viewing them are blinded
tweak: statues are invincible to anything other than full out gibbing.
tweak: Statues flicker lights spell range increased
tweak: Blind spell no longer impacts silicons
fix: Fixes statues being able to attack/move whenever they feel like it, regardless of client statues
fix: Fixes blind spell impacting the statue
/:cl: