### PR TITLE
Add to_chat() guidelines to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,7 +38,7 @@ actual development.
  and why it changes it. We do not want to have to read all of you commit names to figure
  out what your pull request is about.
  - Any pull request that is not solely composed of fixes or non gameplay-affecting
- refactors must have a changelog. Inline changelogs are supported through the format 
+ refactors must have a changelog. Inline changelogs are supported through the format
  described [here](https://github.com/ParadiseSS13/Paradise/pull/3291#issuecomment-172950466)
  and should be used rather than manually edited .yml file changelogs.
  - Pull requests should not have any merge commits except in the case of fixing merge
@@ -58,6 +58,9 @@ actual development.
   be a  new proc that they both can use.
  - No magic numbers/strings. If you have a number or text that is important and used in
   your code, make a `#DEFINE` statement with a name that clearly indicates it's use.
+ - If you want to output a message to a player's chat
+  (this includes text sent to `world`), use `to_chat(mob/client/world, "message")`.
+  Do not use `mob/client/world << "message"`.
  - Do not use one-line control statements (if, else, for, while, etc). The space saved
   is not worth the decreased readability.
  - Control statements comparing a variable to a constant should be formatted `variable`,


### PR DESCRIPTION
Updates CONTRIBUTING.md to include "you must use to_chat() instead of
mob/client/world << "output"".