### PR TITLE
Fixes pulling person blood

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -484,11 +484,10 @@
 						var/atom/movable/t = M.pulling
 						M.stop_pulling()
 
-						//this is the gay blood on floor shit -- Added back -- Skie
 						if (M.lying && (prob(M.getBruteLoss() / 6)))
 							var/turf/location = M.loc
 							if (istype(location, /turf/simulated))
-								location.add_blood()
+								location.add_blood(M)
 						pulling.Move(T, get_dir(pulling, T))
 						if(M)
 							M.start_pulling(t)


### PR DESCRIPTION
The mob wasn't being passed to `add_blood()`.

:cl:
add: More floor blood for the blood gods. (Or rather, as much as there was supposed to be.)
/:cl: