### PR TITLE
Fixes refreshments prepared / food eaten scoreboard stats

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -102,6 +102,7 @@
 		O.reagents.trans_to(result_obj, O.reagents.total_volume)
 		qdel(O)
 	container.reagents.clear_reagents()
+	score_meals++
 	return result_obj
 
 // food-related
@@ -114,6 +115,7 @@
 			O.reagents.trans_to(result_obj, O.reagents.total_volume)
 		qdel(O)
 	container.reagents.clear_reagents()
+	score_meals++
 	return result_obj
 
 /proc/select_recipe(var/list/datum/recipe/avaiable_recipes, var/obj/obj as obj, var/exact = 1 as num)

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -205,7 +205,7 @@
 	<b>AI Destroyed:</b> [score_deadaipenalty ? "Yes" : "No"] (-[score_deadaipenalty * 250] Points)<br><br>
 	<U>The Weird</U><br>
 
-	<b>Food Eaten:</b> [score_foodeaten]<br>
+	<b>Food Eaten:</b> [score_foodeaten] bites/sips<br>
 	<b>Times a Clown was Abused:</b> [score_clownabuse]<br><br>
 	"}
 	if (score_escapees)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -827,6 +827,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		if(!forceFed(toEat, user, fullness))
 			return 0
 	consume(toEat)
+	score_foodeaten++
 	return 1
 
 /mob/living/carbon/proc/selfFeed(var/obj/item/weapon/reagent_containers/food/toEat, fullness)


### PR DESCRIPTION
Makes the `Refreshments Prepared` line display the number for recipes made.
Makes the `Food Eaten` line display the number of food bites / drink sips consumed.

There wasn't previously any code to actually set those score values.