### PR TITLE
Tweaks Nuke Ops Population Requirement

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -7,8 +7,8 @@ proc/issyndicate(mob/living/M as mob)
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 6
-	required_players_secret = 20 // 20 players - 5 players to be the nuke ops = 15 players remaining
+	required_players = 30
+	required_players_secret = 30 // 30 players - 5 players to be the nuke ops = 25 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
 


### PR DESCRIPTION
Following TG's lead on this one.

Ups nuke ops population requirement from 20 to 30.

:cl: Fox McCloud
tweak: ups nuke ops game mode population requirement from 20 to 30
/:cl: