### PR TITLE
This is why we can't have nice things

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,7 +21,7 @@
 	ventcrawler = 2
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,7 +21,6 @@
 	ventcrawler = 2
 	var/datum/mind/origin
 	var/egg_lain = 0
-	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)


### PR DESCRIPTION
I realize this might step on toes, but this has become an issue. I am unsure the exact tactic here but apprently you have people in Xenobio spamming gold cores for headslugs (thats supposed to only be on a hostile core reaction if i understand this code correctly), sentience potion them...and slowly make a nice changling army. Given the mobs are supposed to be hostile i am unsure if they are useing the xenobio cam consoles for this or what.

If so an solution would be to allow the xenobio cnsoles to interact with slimes/monkeys and them only..anything else you go do by hand.

I am sorry but I and a few other people disagree with this. I mean in concept..it would be cool, if it was abused to all hell.

Sorry fox. All do respect to you here.

:cl:Fethas
rscdel: Removes the !!FUN!! of having headslugs gold core spawnable.
/:cl:

