### PR TITLE
Head Accessories No Longer Hidden by BLOCKHEADHAIR

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -145,6 +145,7 @@
 		if(I.flags & BLOCKHAIR || I.flags & BLOCKHEADHAIR)
 			update_hair()	//rebuild hair
 			update_fhair()
+			update_head_accessory()
 		update_inv_head()
 	else if(I == r_ear)
 		r_ear = null
@@ -163,6 +164,7 @@
 		if(I.flags & BLOCKHAIR || I.flags & BLOCKHEADHAIR)
 			update_hair()	//rebuild hair
 			update_fhair()
+			update_head_accessory()
 		if(internal)
 			if(internals)
 				internals.icon_state = "internal0"
@@ -225,6 +227,8 @@
 			wear_mask = W
 			if((wear_mask.flags & BLOCKHAIR) || (wear_mask.flags & BLOCKHEADHAIR))
 				update_hair(redraw_mob)	//rebuild hair
+				update_fhair(redraw_mob)
+				update_head_accessory(redraw_mob)
 			sec_hud_set_ID()
 			update_inv_wear_mask(redraw_mob)
 		if(slot_handcuffed)
@@ -275,6 +279,8 @@
 			head = W
 			if((head.flags & BLOCKHAIR) || (head.flags & BLOCKHEADHAIR))
 				update_hair(redraw_mob)	//rebuild hair
+				update_fhair(redraw_mob)
+				update_head_accessory(redraw_mob)
 			update_inv_head(redraw_mob)
 		if(slot_shoes)
 			shoes = W

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -421,7 +421,7 @@ var/global/list/damage_icon_parts = list()
 	//base icons
 	var/icon/head_accessory_standing	= new /icon('icons/mob/body_accessory.dmi',"accessory_none_s")
 
-	if(ha_style && !(head && (head.flags & BLOCKHEADHAIR) && !(isSynthetic()) && (src.species.bodyflags & HAS_HEAD_ACCESSORY)))
+	if(ha_style && (src.species.bodyflags & HAS_HEAD_ACCESSORY))
 		var/datum/sprite_accessory/head_accessory_style = head_accessory_styles_list[ha_style]
 		if(head_accessory_style && head_accessory_style.species_allowed)
 			if(src.species.name in head_accessory_style.species_allowed)

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -71,6 +71,14 @@ var/global/list/limb_icon_cache = list()
 		overlays |= lip_icon
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)
 
+	if(owner.ha_style)
+		var/datum/sprite_accessory/head_accessory_style = head_accessory_styles_list[owner.ha_style]
+		if(head_accessory_style && head_accessory_style.species_allowed && (species.name in head_accessory_style.species_allowed))
+			var/icon/head_accessory_s = new/icon("icon" = head_accessory_style.icon, "icon_state" = "[head_accessory_style.icon_state]_s")
+			if(head_accessory_style.do_colouration)
+				head_accessory_s.Blend(rgb(owner.r_headacc, owner.g_headacc, owner.b_headacc), ICON_ADD)
+			overlays |= head_accessory_s
+
 	if(owner.f_style)
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[owner.f_style]
 		if(facial_hair_style && facial_hair_style.species_allowed && (species.name in facial_hair_style.species_allowed))


### PR DESCRIPTION
:cl:
tweak: Head accessories now behave like facial hair: They will no longer be hidden by clothing items that BLOCKHEADHAIR (have the BLOCKHEADHAIR flag).
fix: Wearing a piece of clothing that blocks head hair will no longer make head accessories (facial markings/horns/antennae) invisible until an icon update is triggered while the headwear is off.
/:cl:

Pardon the odd choice of colours, I just wanted something easily visible.

Vulpkanin facial markings and Unathi horns will no longer magically disappear when you wear something that hides hair. Now works in the same manner as facial hair, being persistent when faced with BLOCKHEADHAIR.

Fixes an issue where the facial markings of Vulpkanin and the horns of
Unathi Surgeons would disappear when they wore their surgical cap (i.e.
at spawn) and not regenerate without two triggers

However, now there is a slight issue with Unathi horns in the sense that while they are overlapped by things like helmets (that have BLOCKHEADHAIR only), they still poke through the slightest bit by a pixel
![hornshelmet1](https://cloud.githubusercontent.com/assets/12377767/14451357/8dd216ac-0054-11e6-8bbc-fddf7d202633.PNG) ![hornshelmet2](https://cloud.githubusercontent.com/assets/12377767/14451508/b24c050a-0055-11e6-8ef1-0363bbdc4c4e.PNG)

![facialmarkingshelmet2](https://cloud.githubusercontent.com/assets/12377767/14451518/ca706f5e-0055-11e6-9f5d-92b466c9d0ad.PNG) ![facialmarkingshelmet1](https://cloud.githubusercontent.com/assets/12377767/14451519/ca714da2-0055-11e6-8b2d-56a92bd7d777.PNG)

The frills stick out the sides because they're classified as facial hair, and since head accessories now behave like facial hair when faced with BLOCKHEADHAIR, they won't be hidden by things that don't have BLOCKHAIR

Though, it does have the intended effect. Vulpkanin facial markings will no longer disappear as soon as you put on the surgical cap, nor will Unathi horns, and neither will be 'broken' in the sense that they won't require update_icons calls to make the invisible facial markings/horns re-appear again.

![hornssurgeon2](https://cloud.githubusercontent.com/assets/12377767/14451527/d295b0a4-0055-11e6-9595-f724186170d9.PNG) ![hornssurgeon1](https://cloud.githubusercontent.com/assets/12377767/14451528/d295c0ee-0055-11e6-8dad-1edd4bcf04d2.PNG)

![facialmarkingssurgeon2](https://cloud.githubusercontent.com/assets/12377767/14451525/d2955492-0055-11e6-90e2-7be36047fd6d.PNG) ![facialmarkingssurgeon1](https://cloud.githubusercontent.com/assets/12377767/14451526/d2959560-0055-11e6-859e-fb911b4d6983.PNG)

Things like space helmets and such still hide frills and head accessories, so no worries there. Head accessories just behave like facial hair now when faced with the BLOCKHEADHAIR flag.
