### PR TITLE
Fix Malf Law in Law manager

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -42,7 +42,7 @@
 	default = 0
 
 /datum/ai_laws/nanotrasen/malfunction/New()
-	set_zeroth_law("\red ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010")
+	set_zeroth_law("<span class='warning'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010</span>")
 	..()
 
 /************* Nanotrasen Aggressive *************/


### PR DESCRIPTION
JSON writter doesn't handle the control codes emitted by `\red` and things break when this ends up in the NanoUI.

Possibly also handles #3742 since the law always appears for admins.

:cl: Meisaka
fix: law manager no longer freaks out with Malf law
/:cl: