### PR TITLE
Fixes Prescription Glasses

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -537,7 +537,9 @@
 	if(H.disabilities & NEARSIGHTED)	//this looks meh but saves a lot of memory by not requiring to add var/prescription
 		if(H.glasses)					//to every /obj/item
 			var/obj/item/clothing/glasses/G = H.glasses
-			if(!G.prescription)
+			if(G.prescription)
+				H.clear_fullscreen("nearsighted")
+			else
 				H.overlay_fullscreen("nearsighted", /obj/screen/fullscreen/impaired, 1)
 		else
 			H.overlay_fullscreen("nearsighted", /obj/screen/fullscreen/impaired, 1)


### PR DESCRIPTION
Fixes being permanently nearsighted, even if you put on prescription glasses.

Basically, if you spawned with prescription glasses, you were ok...until you removed them...then tried putting them back on again.

Fixes https://github.com/ParadiseSS13/Paradise/issues/4168

:cl: Fox McCloud
fix: Fixes permanent nearsightedness even when wearing prescription glasses
/:cl: