### PR TITLE
DNA Injector Partial Refactor and DNA Machine Exploit Fix

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -926,7 +926,7 @@
 			return 1
 
 		if (bufferOption == "createInjector")
-			if (src.injector_ready || waiting_for_user_input)
+			if(injector_ready && !waiting_for_user_input)
 
 				var/success = 1
 				var/obj/item/weapon/dnainjector/I = new /obj/item/weapon/dnainjector
@@ -938,11 +938,11 @@
 						selectedbuf=buf.dna.SE
 					else
 						selectedbuf=buf.dna.UI
-					var/blk = input(usr,"Select Block","Block") in all_dna_blocks(selectedbuf)
+					var/blk = input(usr,"Select Block","Block") as null|anything in all_dna_blocks(selectedbuf)
 					success = setInjectorBlock(I,blk,buf)
 				else
 					I.buf = buf.copy()
-				waiting_for_user_input=0
+				waiting_for_user_input = 0
 				if(success)
 					I.forceMove(src.loc)
 					I.name += " ([buf.name])"

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -946,6 +946,8 @@
 				if(success)
 					I.forceMove(src.loc)
 					I.name += " ([buf.name])"
+					if(connected)
+						I.damage_coeff = connected.damage_coeff
 					src.injector_ready = 0
 					spawn(300)
 						src.injector_ready = 1


### PR DESCRIPTION
DNA Injector behavior changed, heavily based on TG's injectors

- DNA Injectors no longer self-delete on use, but instead become "used", like auto-injectors
 - No sprites needed to be added for this; they already existed
- Injecting a DNA Injector only has a delay for trying to inject it into others; injecting it into yourself has no delay
- The amount of radiation an injector causes scales with how upgraded the DNA scanner is

Fixes
- Fixes being able to exploit the DNA console to get a whole bunch of injectors by bypassing the cooldown
- Can cancel block input if you accidentally select the wrong block (and not incur the cooldown)

Codewise
- Removes a bunch of unused vars from DNA injectors

:cl: Fox McCloud
tweak: DNA injectors no longer have a delay when used on yourself
tweak: DNA injectors no longer delete on use, but become used, much like auto-injectors
fix: Fixes a bug where you can exploit the genetic scanner to get multiple injectors
fix: Fixes not being able to cancel creating an DNA injector
/:cl: