### PR TITLE
Fixes Anomalies Not Neutralizing

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -16,7 +16,8 @@
 	aSignal = new(src)
 	aSignal.code = rand(1,100)
 
-	aSignal.frequency = sanitize_frequency(rand(PUBLIC_LOW_FREQ, PUBLIC_HIGH_FREQ))
+	var/new_frequency = sanitize_frequency(rand(PUBLIC_LOW_FREQ, PUBLIC_HIGH_FREQ))
+	aSignal.set_frequency(new_frequency)
 
 /obj/effect/anomaly/proc/anomalyEffect()
 	if(prob(50))

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -110,7 +110,7 @@
 
 	if(href_list["send"])
 		spawn( 0 )
-		signal()
+			signal()
 
 	if(usr)
 		attack_self(usr)
@@ -169,6 +169,7 @@
 	desc = "The neutralized core of an anomaly. It'd probably be valuable for research."
 	icon_state = "anomaly core"
 	item_state = "electronic"
+	receiving = 1
 
 /obj/item/device/assembly/signaler/anomaly/receive_signal(datum/signal/signal)
 	..()


### PR DESCRIPTION
Fixes #4167

:cl:
bugfix: Anomalies will now be properly neutralized by signals that match their code and frequency, instead of using the default frequency and their code.
/:cl: