### PR TITLE
Adds saline-glucose to sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -353,6 +353,9 @@
 			if(prob(addiction_removal_chance))
 				to_chat(occupant, "<span class='notice'>You no longer feel reliant on [R.name]!</span>")
 				occupant.reagents.addiction_list.Remove(R)
+			//because why the hell not
+		if (occupant.reagents.get_reagent_amount("salglu_solution") < 5)
+			occupant.reagents.add_reagent("salglu_solution", 5)
 
 	updateDialog()
 	return


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: sleepers will now inject small amounts of saline-glucose
/:cl:

So there's already this weird snippet about injecting saline in the code, but it does absolutely nothing as it's never called.

The sleeper will inject up to 10u of saline-glucose, making treating bloodloss and burns a bit more doable inside this beauty. Doesn't impact balance that much, but contributes to eradicating the "Fuck it, let's cryo" attitude.

Yay? Nay? Discuss.