### PR TITLE
Cleans up special role jobbans

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -36,6 +36,8 @@
 #define ROLE_POSIBRAIN			"positronic brain"
 #define ROLE_GUARDIAN			"guardian"
 #define ROLE_MORPH				"morph"
+#define ROLE_ERT				"emergency response team"
+#define ROLE_NYMPH				"Dionaea"
 
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.

--- a/code/__DEFINES/rolebans.dm
+++ b/code/__DEFINES/rolebans.dm
@@ -1,0 +1,31 @@
+// Bannable antag roles
+var/global/list/antag_roles = list(
+	ROLE_TRAITOR,
+	ROLE_OPERATIVE,
+	ROLE_CHANGELING,
+	ROLE_WIZARD,
+	ROLE_MALF,
+	ROLE_REV,
+	ROLE_ALIEN,
+	ROLE_CULTIST,
+	ROLE_BLOB,
+	ROLE_NINJA,
+	ROLE_SHADOWLING,
+	ROLE_RAIDER,
+	ROLE_VAMPIRE,
+	ROLE_MUTINEER,
+	ROLE_BORER,
+	ROLE_DEMON,
+	ROLE_REVENANT,
+	ROLE_GUARDIAN,
+	ROLE_MORPH,
+)
+
+// Bannable other roles
+var/global/list/other_roles = list(
+	ROLE_SENTIENT,
+	ROLE_NYMPH,
+	ROLE_ERT,
+	"AntagHUD",
+	"Records"
+)

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -82,7 +82,7 @@
 				traitorcount += 1
 			if (player.client && player.mind && !player.mind.special_role && player.stat != DEAD)
 				if (ishuman(player) || isrobot(player) || isAI(player))
-					if (player.client && (ROLE_TRAITOR in player.client.prefs.be_special) && !jobban_isbanned(player, "traitor") && !jobban_isbanned(player, "Syndicate"))
+					if (player.client && (ROLE_TRAITOR in player.client.prefs.be_special) && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
 						possible_traitors += player.mind
 		for(var/datum/mind/player in possible_traitors)
 			for(var/job in restricted_jobs)
@@ -159,7 +159,7 @@
 	if(shuttle_master.emergency.mode >= SHUTTLE_ESCAPE)
 		return
 	//message_admins("Late Join Check")
-	if(character.client && (ROLE_TRAITOR in character.client.prefs.be_special) && !jobban_isbanned(character, "traitor") && !jobban_isbanned(character, "Syndicate"))
+	if(character.client && (ROLE_TRAITOR in character.client.prefs.be_special) && !jobban_isbanned(character, ROLE_TRAITOR) && !jobban_isbanned(character, "Syndicate"))
 		//message_admins("Late Joiner has Be Syndicate")
 		//message_admins("Checking number of players")
 		var/playercount = 0

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -373,7 +373,7 @@ var/list/sacrificed = list()
 		break
 	if(!ghost)
 		return this_rune.fizzle()
-	if(jobban_isbanned(ghost, "cultist") || jobban_isbanned(ghost,"Syndicate"))
+	if(jobban_isbanned(ghost, ROLE_CULTIST) || jobban_isbanned(ghost,"Syndicate"))
 		return this_rune.fizzle()
 
 	usr.say("Gal'h'rfikk harfrandid mud[pick("'","`")]gib!")

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -625,7 +625,7 @@
 		if(jobban_isbanned(O, "Syndicate"))
 			continue
 		if(O.client)
-			if((ROLE_BORER in O.client.prefs.be_special) && !jobban_isbanned(O, "alien"))
+			if((ROLE_BORER in O.client.prefs.be_special) && !jobban_isbanned(O, ROLE_BORER))
 				question(O.client)
 
 /mob/living/simple_animal/borer/proc/question(var/client/C)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -30,19 +30,19 @@
 	if(user.mind)
 		if(user.mind.special_role)
 			var/role = lowertext(user.mind.special_role)
-			if(role == "traitor" || role == "syndicate" || role == "syndicate commando")
+			if(role == ROLE_TRAITOR || role == "syndicate" || role == "syndicate commando")
 				message_say = "FOR THE SYNDICATE!"
-			else if(role == "changeling")
+			else if(role == ROLE_CHANGELING)
 				message_say = "FOR THE HIVE!"
-			else if(role == "cultist")
+			else if(role == ROLE_CULTIST)
 				message_say = "FOR NARSIE!"
-			else if(role == "ninja")
+			else if(role == ROLE_NINJA)
 				message_say = "FOR THE CLAN!"
-			else if(role == "wizard")
+			else if(role == ROLE_WIZARD)
 				message_say = "FOR THE FEDERATION!"
-			else if(role =="revolutionary" || role == "head revolutionary")
+			else if(role == ROLE_REV || role == "head revolutionary")
 				message_say = "FOR THE REVOLOUTION!"
-			else if(role == "death commando" || role == "emergency response team")
+			else if(role == "death commando" || role == ROLE_ERT)
 				message_say = "FOR NANOTRASEN!"
 
 	user.say(message_say)

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -83,7 +83,7 @@ var/send_emergency_team
 		to_chat(usr, "No emergency response team is currently being sent.")
 		return
 
-	if(jobban_isbanned(usr, "Emergency Response Team"))
+	if(jobban_isbanned(usr, ROLE_ERT))
 		to_chat(usr, "<span class='warning'>You are jobbanned from the emergency reponse team!</span>")
 		return
 

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -90,7 +90,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 		a_ckey = src.owner:ckey
 		a_computerid = src.owner:computer_id
 		a_ip = src.owner:address
-		
+
 	if(blockselfban)
 		if(a_ckey == ckey)
 			to_chat(usr, "<span class='danger'>You cannot apply this ban type on yourself.</span>")
@@ -111,7 +111,7 @@ datum/admins/proc/DB_ban_record(var/bantype, var/mob/banned_mob, var/duration = 
 			adminwho += ", [C]"
 
 	reason = sql_sanitize_text(reason)
-	
+
 	if(maxadminbancheck)
 		var/DBQuery/adm_query = dbcon.NewQuery("SELECT count(id) AS num FROM [format_table_name("ban")] WHERE (a_ckey = '[a_ckey]') AND (bantype = 'ADMIN_PERMABAN'  OR (bantype = 'ADMIN_TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)")
 		adm_query.Execute()
@@ -362,11 +362,11 @@ datum/admins/proc/DB_ban_unban_by_id(var/id)
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in nonhuman_positions)
 		output += "<option value='[j]'>[j]</option>"
-	for(var/j in list("Dionaea","NPC","AntagHUD","Emergency Response Team"))
+	for(var/j in other_roles)
 		output += "<option value='[j]'>[j]</option>"
 	for(var/j in list("commanddept","securitydept","engineeringdept","medicaldept","sciencedept","supportdept","nonhumandept"))
 		output += "<option value='[j]'>[j]</option>"
-	for(var/j in list("Syndicate","traitor","changeling","operative","revolutionary","cultist","wizard","alien","ninja","raider","mutineer","blob"))
+	for(var/j in list("Syndicate") + antag_roles)
 		output += "<option value='[j]'>[j]</option>"
 	output += "</select></td></tr></table>"
 	output += "<b>Reason:<br></b><textarea name='dbbanreason' cols='50'></textarea><br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -650,120 +650,37 @@
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
 		jobs += "<tr bgcolor='ffeeaa'><th colspan='10'><a href='?src=\ref[src];jobban3=Syndicate;jobban4=\ref[M]'>Antagonist Positions</a></th></tr><tr align='center'>"
 
-		//Traitor
-		if(jobban_isbanned(M, "traitor") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=traitor;jobban4=\ref[M]'><font color=red>[replacetext("Traitor", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=traitor;jobban4=\ref[M]'>[replacetext("Traitor", " ", "&nbsp")]</a></td>"
+		counter = 0
+		for(var/role in antag_roles)
+			if(jobban_isbanned(M, role) || isbanned_dept)
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[role];jobban4=\ref[M]'><font color=red>[replacetext(role, " ", "&nbsp")]</font></a></td>"
+			else
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[role];jobban4=\ref[M]'>[replacetext(role, " ", "&nbsp")]</a></td>"
+			counter++
 
-		//Changeling
-		if(jobban_isbanned(M, "changeling") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=changeling;jobban4=\ref[M]'><font color=red>[replacetext("Changeling", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=changeling;jobban4=\ref[M]'>[replacetext("Changeling", " ", "&nbsp")]</a></td>"
-
-		//Nuclear Operative
-		if(jobban_isbanned(M, "operative") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=operative;jobban4=\ref[M]'><font color=red>[replacetext("Nuclear Operative", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=operative;jobban4=\ref[M]'>[replacetext("Nuclear Operative", " ", "&nbsp")]</a></td>"
-
-		//Revolutionary
-		if(jobban_isbanned(M, "revolutionary") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=revolutionary;jobban4=\ref[M]'><font color=red>[replacetext("Revolutionary", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=revolutionary;jobban4=\ref[M]'>[replacetext("Revolutionary", " ", "&nbsp")]</a></td>"
-
-		//Cultist
-		if(jobban_isbanned(M, "cultist") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=cultist;jobban4=\ref[M]'><font color=red>[replacetext("Cultist", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=cultist;jobban4=\ref[M]'>[replacetext("Cultist", " ", "&nbsp")]</a></td>"
-
-		//Shadowling
-		if(jobban_isbanned(M, "shadowling") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=shadowling;jobban4=\ref[M]'><font color=red>[replacetext("Shadowling", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=shadowling;jobban4=\ref[M]'>[replacetext("Shadowling", " ", "&nbsp")]</a></td>"
-
-		//Wizard
-		if(jobban_isbanned(M, "wizard") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'><font color=red>[replacetext("Wizard", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'>[replacetext("Wizard", " ", "&nbsp")]</a></td>"
-
-		jobs += "</tr><tr align='center'>" //Breaking it up so it fits nicer on the screen every 5 entries
-
-		//Malfunctioning AI
-		if(jobban_isbanned(M, "malf AI") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=malf AI;jobban4=\ref[M]'><font color=red>[replacetext("Malf AI", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=malf AI;jobban4=\ref[M]'>[replacetext("Malf AI", " ", "&nbsp")]</a></td>"
-
-		//Alien
-		if(jobban_isbanned(M, "alien") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=alien;jobban4=\ref[M]'><font color=red>[replacetext("Alien", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=alien;jobban4=\ref[M]'>[replacetext("Alien", " ", "&nbsp")]</a></td>"
-
-		//Ninja
-		if(jobban_isbanned(M, "ninja") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=ninja;jobban4=\ref[M]'><font color=red>[replacetext("Ninja", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=ninja;jobban4=\ref[M]'>[replacetext("Ninja", " ", "&nbsp")]</a></td>"
-
-		//Raider
-		if(jobban_isbanned(M, "raider") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=raider;jobban4=\ref[M]'><font color=red>[replacetext("Raider", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=raider;jobban4=\ref[M]'>[replacetext("Raider", " ", "&nbsp")]</a></td>"
-
-		//Mutineer
-		if(jobban_isbanned(M, "mutineer") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=mutineer;jobban4=\ref[M]'><font color=red>[replacetext("Mutineer", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=mutineer;jobban4=\ref[M]'>[replacetext("Mutineer", " ", "&nbsp")]</a></td>"
-
-		//Blob
-		if(jobban_isbanned(M, "blob") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=blob;jobban4=\ref[M]'><font color=red>[replacetext("Blob", " ", "&nbsp")]</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=blob;jobban4=\ref[M]'>[replacetext("Blob", " ", "&nbsp")]</a></td>"
-
+			if(counter >= 5) //So things dont get squiiiiished!
+				jobs += "</tr><tr align='center'>"
+				counter = 0
 		jobs += "</tr></table>"
 
-
-		//Other races  (BLUE, because I have no idea what other color to make this)
+	//Other races  (BLUE, because I have no idea what other color to make this)
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
-		jobs += "<tr bgcolor='ccccff'><th colspan='4'>Other</th></tr><tr align='center'>"
+		jobs += "<tr bgcolor='ccccff'><th colspan='10'>Other</th></tr><tr align='center'>"
 
-		//NYMPH
-		if(jobban_isbanned(M, "Dionaea"))
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Dionaea;jobban4=\ref[M]'><font color=red>Dionaea Nymph</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Dionaea;jobban4=\ref[M]'>Dionaea Nymph</a></td>"
+		counter = 0
+		for(var/role in other_roles)
+			if(jobban_isbanned(M, role) || isbanned_dept)
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[role];jobban4=\ref[M]'><font color=red>[replacetext(role, " ", "&nbsp")]</font></a></td>"
+			else
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[role];jobban4=\ref[M]'>[replacetext(role, " ", "&nbsp")]</a></td>"
+			counter++
 
-		//NPC
-		if(jobban_isbanned(M, "NPC"))
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=NPC;jobban4=\ref[M]'><font color=red>NPC</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=NPC;jobban4=\ref[M]'>NPC</a></td>"
-
-		//ANTAG HUD
-		if(jobban_isbanned(M, "AntagHUD"))
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=AntagHUD;jobban4=\ref[M]'><font color=red>AntagHUD</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=AntagHUD;jobban4=\ref[M]'>AntagHUD</a></td>"
-
-		//ERT
-		if(jobban_isbanned(M, "Emergency Response Team") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Emergency Response Team;jobban4=\ref[M]'><font color=red>Emergency Response Team</font></a></td>"
-		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=Emergency Response Team;jobban4=\ref[M]'>Emergency Response Team</a></td>"
-
+			if(counter >= 5) //So things dont get squiiiiished!
+				jobs += "</tr><tr align='center'>"
+				counter = 0
 		jobs += "</tr></table>"
 
-	//Support (Grey)
+	//Whitelisted positions
 		counter = 0
 		jobs += "<table cellpadding='1' cellspacing='0' width='100%'>"
 		jobs += "<tr bgcolor='dddddd'><th colspan='[length(whitelisted_positions)]'><a href='?src=\ref[src];jobban3=whitelistdept;jobban4=\ref[M]'>Whitelisted Positions</a></th></tr><tr align='center'>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1665,9 +1665,10 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	character.name = character.real_name
 
 	character.flavor_text = flavor_text
-	character.med_record = med_record
-	character.sec_record = sec_record
-	character.gen_record = gen_record
+	if(character.ckey && !jobban_isbanned(character, "Records"))
+		character.med_record = med_record
+		character.sec_record = sec_record
+		character.gen_record = gen_record
 
 	character.change_gender(gender)
 	character.age = age

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -354,7 +354,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 						to_chat(O, "\blue <b>A pAI card is looking for personalities. (<a href='?src=\ref[O];jump=\ref[P]'>Teleport</a> | <a href='?src=\ref[src];signup=\ref[O]'>Sign Up</a>)</b>")
 						//question(O.client)
 	proc/check_recruit(var/mob/dead/observer/O)
-		if(jobban_isbanned(O, "pAI") || jobban_isbanned(O,"nonhumandept"))
+		if(jobban_isbanned(O, ROLE_PAI) || jobban_isbanned(O,"nonhumandept"))
 			return 0
 		if(!player_old_enough_antag(O.client,ROLE_PAI))
 			return 0

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -300,6 +300,9 @@
 			if(!locked && !open)
 				var/obj/item/device/paicard/card = W
 				if(card.pai && card.pai.mind)
+					if(!card.pai.ckey || jobban_isbanned(card.pai, ROLE_SENTIENT))
+						to_chat(user, "<span class='warning'>[W] is unable to establish a connection to [src].</span>")
+						return
 					if(!user.drop_item())
 						return
 					W.forceMove(src)
@@ -316,7 +319,7 @@
 			else
 				to_chat(user, "<span class='warning'>The personality slot is locked.</span>")
 		else
-			to_chat(user, "<span class='warning'>[src] is not compatible with [W]</span>")
+			to_chat(user, "<span class='warning'>[src] is not compatible with [W].</span>")
 	else if(istype(W, /obj/item/weapon/hemostat) && paicard)
 		if(open)
 			to_chat(user, "<span class='warning'>Close the access panel before manipulating the personality slot!</span>")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1269,8 +1269,8 @@ mob/proc/yank_out_object()
 	set name = "Respawn as NPC"
 	set category = "Ghost"
 
-	if(jobban_isbanned(usr, "NPC"))
-		to_chat(usr, "<span class='warning'>You are banned from playing as NPC's.</span>")
+	if(jobban_isbanned(usr, ROLE_SENTIENT))
+		to_chat(usr, "<span class='warning'>You are banned from playing as sentient animals.</span>")
 		return
 
 	if(!ticker || ticker.current_state < 3)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -346,10 +346,10 @@
 	if(ispath(MP, /mob/living/simple_animal/butterfly))
 		return 1
 
-	if(ispath(MP, /mob/living/simple_animal/borer) && !jobban_isbanned(src, "alien") && !jobban_isbanned(src, "Syndicate"))
+	if(ispath(MP, /mob/living/simple_animal/borer) && !jobban_isbanned(src, ROLE_BORER) && !jobban_isbanned(src, "Syndicate"))
 		return 1
 
-	if(ispath(MP, /mob/living/simple_animal/diona) && !jobban_isbanned(src, "Dionaea"))
+	if(ispath(MP, /mob/living/simple_animal/diona) && !jobban_isbanned(src, ROLE_NYMPH))
 		return 1
 
 	return 0

--- a/paradise.dme
+++ b/paradise.dme
@@ -37,6 +37,7 @@
 #include "code\__DEFINES\process_scheduler.dm"
 #include "code\__DEFINES\qdel.dm"
 #include "code\__DEFINES\role_preferences.dm"
+#include "code\__DEFINES\rolebans.dm"
 #include "code\__DEFINES\sight.dm"
 #include "code\__DEFINES\snpc.dm"
 #include "code\__DEFINES\stat.dm"


### PR DESCRIPTION
- Makes all special roles that have jobban checks jobbannable.
 - Also makes it use clean lists in the code instead of hardcoding them.
- Makes borers have their own ban instead of using xeno bans which was weird.
- pAI's can no longer be put in bots if they've been `sentient animal` banned.
- There's apparently a `Records` ban which prevents people from setting their sec/med records in character creation, so I added that to the list so you can actually apply that one too.
- Merges `NPC` and `sentient animal` into `sentient animal` and makes it consistently an option; changes `alien` into `cortical borer` as described below.
 - :rotating_light: The following SQL will have to be done to ensure all the bans rollover. :rotating_light:
 - The former (sentient animal/NPC) previously split 2 different methods of becoming animal into separate bans.
 - The latter (alien) was a ban role that was probably intended to be for xenos but xenos actually used xenomorph, and borers used alien. Those bans are probably a mess because of that; who knows.
```sql
UPDATE `ban` SET job = "sentient animal" WHERE job = "NPC";
UPDATE `ban` SET job = "cortical borer" WHERE job = "alien";
```
![Jobban](http://i.imgur.com/vGwLyRo.png)
![Jobban 2](http://i.imgur.com/eK54NAE.png)

