### PR TITLE
Makes the game startup time significantly faster

### DIFF
--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -23,4 +23,5 @@ var/list/restricted_camera_networks = list( //Those networks can only be accesse
 	"Xeno"
 	)
 
-var/list/datum/map_template/map_templates = list()
+var/list/map_templates = list()
+var/list/mineral_turfs = list()

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -205,9 +205,13 @@ var/const/RADIO_MAGNETS = "radio_magnet"
 var/const/RADIO_LOGIC = "radio_logic"
 
 var/global/datum/controller/radio/radio_controller
+var/global/list/headsets[0]
 
 /hook/startup/proc/createRadioController()
 	radio_controller = new /datum/controller/radio()
+	for(var/A in headsets)
+		var/obj/item/device/radio/headset/H = A
+		H.initialize()
 	return 1
 
 //callback used by objects to react to incoming radio signals

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -19,11 +19,17 @@
 
 /obj/item/device/radio/headset/New()
 	..()
+	headsets += src
 	internal_channels.Cut()
+
+/obj/item/device/radio/headset/initialize()
+	..()
+
 	if(ks1type)
 		keyslot1 = new ks1type(src)
 	if(ks2type)
 		keyslot2 = new ks2type(src)
+
 	recalculateChannels(1)
 
 /obj/item/device/radio/headset/Destroy()
@@ -33,6 +39,7 @@
 		qdel(keyslot2)
 	keyslot1 = null
 	keyslot2 = null
+	headsets -= src
 	return ..()
 
 /obj/item/device/radio/headset/list_channels(var/mob/user)
@@ -383,8 +390,6 @@
 
 
 	for (var/ch_name in channels)
-		if(!radio_controller)
-			sleep(30) // Waiting for the radio_controller to be created.
 		if(!radio_controller)
 			src.name = "broken radio headset"
 			return

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -152,7 +152,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
 		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
 		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
@@ -169,7 +168,6 @@
 		new/obj/item/weapon/storage/pill_bottle/random_meds(src)
 		while(prob(25))
 			new/obj/item/weapon/storage/pill_bottle/random_meds(src)
-		return
 
 /obj/structure/closet/crate/secure/chemicals
 	name		= "chemical supply kit"
@@ -178,7 +176,6 @@
 
 	New()
 		..()
-		sleep(2)
 		for(var/chem in standard_chemicals)
 			var/obj/item/weapon/reagent_containers/glass/bottle/B = new(src)
 			B.reagents.add_reagent(chem,B.volume)
@@ -240,7 +237,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
 		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
 		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
@@ -248,7 +244,6 @@
 		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
 		while(prob(25))
 			new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_reagent(src)
-		return
 
 
 // -------------------------------------
@@ -276,8 +271,9 @@
 				while(prob(15))
 					new menace(get_step_rand(src.loc))
 				..()
+			return 1
 		else
-			..()
+			return ..()
 
 
 //
@@ -307,7 +303,7 @@
 				qdel(Cat1)
 			else
 				qdel(Cat2)
-		..()
+		return ..()
 
 // --------------------------------------
 //   Collen's box of wonder and mystery

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -108,7 +108,11 @@
 		to_chat(user, "<span class='warning'>Nothing interesting happens!</span>")
 		return
 	to_chat(user, "<span class='notice'>You emag the barsign. Takeover in progress...</span>")
-	sleep(100) //10 seconds
+	addtimer(src, "post_emag", 100)
+
+/obj/structure/sign/barsign/proc/post_emag()
+	if(broken || emagged)
+		return
 	set_sign(new /datum/barsign/hiddensigns/syndibarsign)
 	emagged = 1
 	req_access = list(access_syndicate)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -136,7 +136,6 @@
 /obj/structure/closet/proc/toggle(mob/user as mob)
 	if(!(src.opened ? src.close() : src.open()))
 		to_chat(user, "<span class='notice'>It won't budge!</span>")
-	return
 
 // this should probably use dump_contents()
 /obj/structure/closet/ex_act(severity)
@@ -169,7 +168,6 @@
 			for(var/atom/movable/A as mob|obj in src)
 				A.forceMove(loc)
 			qdel(src)
-	return
 
 /obj/structure/closet/attack_animal(mob/living/simple_animal/user as mob)
 	if(user.environment_smash)
@@ -291,7 +289,6 @@
 			M.show_message("<span class='warning'>[src] has been [welded?"welded shut":"unwelded"] by [user.name].</span>", 3, "You hear welding.", 2)
 	else
 		src.attack_hand(user)
-	return
 
 /obj/structure/closet/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 	..()
@@ -315,7 +312,6 @@
 	if(user != O)
 		user.show_viewers("<span class='danger'>[user] stuffs [O] into [src]!</span>")
 	src.add_fingerprint(user)
-	return
 
 /obj/structure/closet/attack_ai(mob/user)
 	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) //Robots can open/close it, but not the AI

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -193,7 +193,6 @@
 				to_chat(user, "\red Cabinet locked.")
 			else
 				to_chat(user, "\blue Cabinet unlocked.")
-			return
 
 	update_icon() //Template: fireaxe[has fireaxe][is opened][hits taken][is smashed]. If you want the opening or closing animations, add "opening" or "closing" right after the numbers
 		var/hasaxe = 0

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -6,7 +6,6 @@
 
 /obj/structure/closet/athletic_mixed/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/shorts/grey(src)
 	new /obj/item/clothing/under/shorts/black(src)
 	new /obj/item/clothing/under/shorts/red(src)
@@ -25,7 +24,6 @@
 
 /obj/structure/closet/boxinggloves/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/gloves/boxing/blue(src)
 	new /obj/item/clothing/gloves/boxing/green(src)
 	new /obj/item/clothing/gloves/boxing/yellow(src)
@@ -38,7 +36,6 @@
 
 /obj/structure/closet/masks/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/mask/luchador(src)
 	new /obj/item/clothing/mask/luchador/rudos(src)
 	new /obj/item/clothing/mask/luchador/tecnicos(src)
@@ -52,7 +49,6 @@
 
 /obj/structure/closet/lasertag/red/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/gun/energy/laser/redtag(src)
 	new /obj/item/weapon/gun/energy/laser/redtag(src)
 	new /obj/item/weapon/gun/energy/laser/redtag(src)
@@ -69,7 +65,6 @@
 
 /obj/structure/closet/lasertag/blue/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/gun/energy/laser/bluetag(src)
 	new /obj/item/weapon/gun/energy/laser/bluetag(src)
 	new /obj/item/weapon/gun/energy/laser/bluetag(src)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -36,7 +36,6 @@
 
 /obj/structure/closet/gimmick/russian/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
 	new /obj/item/clothing/head/ushanka(src)
@@ -58,7 +57,6 @@
 
 /obj/structure/closet/gimmick/tacticool/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/glasses/eyepatch(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/clothing/gloves/combat(src)
@@ -83,16 +81,11 @@
 	icon_opened = "syndicateopen"
 	anchored = 1
 
-/obj/structure/closet/thunderdome/New()
-	..()
-	sleep(2)
-
 /obj/structure/closet/thunderdome/tdred
 	name = "red-team Thunderdome closet"
 
 /obj/structure/closet/thunderdome/tdred/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
 	new /obj/item/clothing/suit/armor/tdome/red(src)
@@ -120,7 +113,6 @@
 
 /obj/structure/closet/thunderdome/tdgreen/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/armor/tdome/green(src)
 	new /obj/item/clothing/suit/armor/tdome/green(src)
 	new /obj/item/clothing/suit/armor/tdome/green(src)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -16,7 +16,6 @@
 
 /obj/structure/closet/gmcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/clothing/head/that(src)
 	new /obj/item/device/radio/headset/headset_service(src)
@@ -45,7 +44,6 @@
 
 /obj/structure/closet/chefcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/waiter(src)
 	new /obj/item/clothing/under/waiter(src)
 	new /obj/item/device/radio/headset/headset_service(src)
@@ -74,7 +72,6 @@
 
 /obj/structure/closet/jcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/janitor(src)
 	new /obj/item/device/radio/headset/headset_service(src)
 	new /obj/item/weapon/cartridge/janitor(src)
@@ -104,7 +101,6 @@
 
 /obj/structure/closet/lawcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/lawyer/female(src)
 	new /obj/item/clothing/under/lawyer/black(src)
 	new /obj/item/clothing/under/lawyer/red(src)

--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -7,7 +7,6 @@
 
 /obj/structure/closet/l3closet/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/storage/bag/bio( src )
 	new /obj/item/clothing/suit/bio_suit/general( src )
 	new /obj/item/clothing/head/bio_hood/general( src )
@@ -20,7 +19,6 @@
 
 /obj/structure/closet/l3closet/general/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/general( src )
 	new /obj/item/clothing/head/bio_hood/general( src )
@@ -33,7 +31,6 @@
 
 /obj/structure/closet/l3closet/virology/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/weapon/storage/bag/bio( src )
 	new /obj/item/clothing/suit/bio_suit/virology( src )
@@ -49,7 +46,6 @@
 
 /obj/structure/closet/l3closet/security/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/security( src )
 	new /obj/item/clothing/head/bio_hood/security( src )
@@ -62,7 +58,6 @@
 
 /obj/structure/closet/l3closet/janitor/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/clothing/suit/bio_suit/janitor( src )
 	new /obj/item/clothing/head/bio_hood/janitor( src )
@@ -75,7 +70,6 @@
 
 /obj/structure/closet/l3closet/scientist/New()
 	..()
-	sleep(2)
 	contents = list()
 	new /obj/item/weapon/storage/bag/bio( src )
 	new /obj/item/clothing/suit/bio_suit/scientist( src )

--- a/code/game/objects/structures/crates_lockers/closets/malfunction.dm
+++ b/code/game/objects/structures/crates_lockers/closets/malfunction.dm
@@ -7,7 +7,6 @@
 
 /obj/structure/closet/malf/suits/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/tank/jetpack/void(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/clothing/head/helmet/space/nasavoid(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -11,7 +11,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
@@ -22,7 +21,6 @@
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
 		new /obj/item/weapon/reagent_containers/food/drinks/cans/beer( src )
-		return
 
 /obj/structure/closet/secure_closet/bar/update_icon()
 	if(broken)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -10,14 +10,12 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/rank/cargotech(src)
 		new /obj/item/clothing/shoes/black(src)
 		new /obj/item/device/radio/headset/headset_cargo(src)
 		new /obj/item/clothing/gloves/fingerless(src)
 		new /obj/item/clothing/head/soft(src)
 //		new /obj/item/weapon/cartridge/quartermaster(src)
-		return
 
 /obj/structure/closet/secure_closet/quartermaster
 	name = "quartermaster's locker"
@@ -31,7 +29,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/rank/cargo(src)
 		new /obj/item/clothing/shoes/brown(src)
 		new /obj/item/device/radio/headset/headset_cargo(src)
@@ -43,4 +40,3 @@
 		new /obj/item/clothing/mask/gas(src)
 		new /obj/item/clothing/glasses/meson(src)
 		new /obj/item/clothing/head/soft(src)
-		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -11,7 +11,6 @@
 
 /obj/structure/closet/secure_closet/chaplain/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/chaplain(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/suit/nun(src)
@@ -30,4 +29,3 @@
 	new /obj/item/clothing/gloves/ring/silver(src)
 	new /obj/item/clothing/gloves/ring/gold(src)
 	new /obj/item/clothing/gloves/ring/gold(src)
-	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/industrial(src)
 		else
@@ -32,7 +31,6 @@
 		new /obj/item/device/flash(src)
 		new /obj/item/taperoll/engineering(src)
 		new /obj/item/clothing/head/beret/eng(src)
-		return
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"
@@ -47,7 +45,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/gloves/color/yellow(src)
 		new /obj/item/clothing/gloves/color/yellow(src)
 		new /obj/item/weapon/storage/toolbox/electrical(src)
@@ -60,7 +57,6 @@
 		new /obj/item/device/multitool(src)
 		new /obj/item/device/multitool(src)
 		new /obj/item/clothing/head/beret/eng
-		return
 
 
 
@@ -77,14 +73,12 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/head/welding(src)
 		new /obj/item/clothing/head/welding(src)
 		new /obj/item/clothing/head/welding(src)
 		new /obj/item/weapon/weldingtool/largetank(src)
 		new /obj/item/weapon/weldingtool/largetank(src)
 		new /obj/item/weapon/weldingtool/largetank(src)
-		return
 
 
 
@@ -101,7 +95,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/industrial(src)
 		else
@@ -116,7 +109,6 @@
 		new /obj/item/weapon/cartridge/engineering(src)
 		new /obj/item/taperoll/engineering(src)
 		new /obj/item/clothing/head/beret/eng(src)
-		return
 
 /obj/structure/closet/secure_closet/atmos_personal
 	name = "technician's locker"
@@ -131,7 +123,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/device/radio/headset/headset_eng(src)
 		new /obj/item/weapon/cartridge/atmos(src)
 		new /obj/item/weapon/storage/toolbox/mechanical(src)
@@ -148,5 +139,3 @@
 		new /obj/item/weapon/watertank/atmos(src)
 		new /obj/item/clothing/suit/fire/atmos(src)
 		new /obj/item/clothing/head/hardhat/atmos(src)
-
-		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -28,7 +28,7 @@
 
 	New()
 		..()
-		for(var/i = 0, i < 3, i++)
+		for(var/i in 1 to 3)
 			new /obj/item/weapon/reagent_containers/food/condiment/flour(src)
 		new /obj/item/weapon/reagent_containers/food/condiment/rice(src)
 		new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
@@ -52,7 +52,7 @@
 
 	New()
 		..()
-		for(var/i = 1 to 4)
+		for(var/i in 1 to 4)
 			new /obj/item/weapon/reagent_containers/food/snacks/meat/monkey(src)
 
 
@@ -69,10 +69,10 @@
 
 	New()
 		..()
-		for(var/i = 1 to 5)
+		for(var/i in 1 to 5)
 			new /obj/item/weapon/reagent_containers/food/drinks/milk(src)
 			new /obj/item/weapon/reagent_containers/food/drinks/soymilk(src)
-		for(var/i = 1 to 2)
+		for(var/i in 1 to 2)
 			new /obj/item/weapon/storage/fancy/egg_box(src)
 
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -21,7 +21,6 @@
 	var/list/bombs = search_contents_for(/obj/item/device/transfer_valve)
 	if(!isemptylist(bombs)) // You're fucked.
 		..(severity)
-	return
 
 /obj/structure/closet/secure_closet/freezer/kitchen
 	name = "kitchen cabinet"
@@ -29,7 +28,6 @@
 
 	New()
 		..()
-		sleep(2)
 		for(var/i = 0, i < 3, i++)
 			new /obj/item/weapon/reagent_containers/food/condiment/flour(src)
 		new /obj/item/weapon/reagent_containers/food/condiment/rice(src)
@@ -54,10 +52,8 @@
 
 	New()
 		..()
-		sleep(2)
-		for(var/i = 0, i < 4, i++)
+		for(var/i = 1 to 4)
 			new /obj/item/weapon/reagent_containers/food/snacks/meat/monkey(src)
-		return
 
 
 
@@ -73,14 +69,11 @@
 
 	New()
 		..()
-		sleep(2)
-		for(var/i = 0, i < 5, i++)
+		for(var/i = 1 to 5)
 			new /obj/item/weapon/reagent_containers/food/drinks/milk(src)
-		for(var/i = 0, i < 5, i++)
 			new /obj/item/weapon/reagent_containers/food/drinks/soymilk(src)
-		for(var/i = 0, i < 2, i++)
+		for(var/i = 1 to 2)
 			new /obj/item/weapon/storage/fancy/egg_box(src)
-		return
 
 
 
@@ -97,9 +90,7 @@
 
 	New()
 		..()
-		sleep(2)
-		dispense_cash(6700,src)
-		return
+		dispense_cash(6700, src)
 
 
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -11,7 +11,6 @@
 
 	New()
 		..()
-		sleep(2)
 		switch(rand(1,2))
 			if(1)
 				new /obj/item/clothing/suit/apron(src)
@@ -25,4 +24,3 @@
 		new /obj/item/clothing/mask/bandana/botany(src)
 		new /obj/item/weapon/minihoe(src)
 		new /obj/item/weapon/hatchet(src)
-		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -12,7 +12,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/box/autoinjectors(src)
 		new /obj/item/weapon/storage/box/syringes(src)
 		new /obj/item/weapon/reagent_containers/dropper(src)
@@ -23,7 +22,6 @@
 		new /obj/item/weapon/reagent_containers/glass/bottle/epinephrine(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/charcoal(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/charcoal(src)
-		return
 
 
 
@@ -41,14 +39,12 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/tank/anesthetic(src)
 		new /obj/item/weapon/tank/anesthetic(src)
 		new /obj/item/weapon/tank/anesthetic(src)
 		new /obj/item/clothing/mask/breath/medical(src)
 		new /obj/item/clothing/mask/breath/medical(src)
 		new /obj/item/clothing/mask/breath/medical(src)
-		return
 
 
 
@@ -64,7 +60,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/medic(src)
 		else
@@ -79,7 +74,6 @@
 		new /obj/item/weapon/storage/belt/medical(src)
 		new /obj/item/clothing/glasses/hud/health(src)
 		new /obj/item/clothing/shoes/sandal/white(src)
-		return
 
 //Exam Room
 /obj/structure/closet/secure_closet/exam
@@ -96,7 +90,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/box/syringes(src)
 		new /obj/item/weapon/reagent_containers/dropper(src)
 		new /obj/item/weapon/storage/belt/medical(src)
@@ -111,7 +104,6 @@
 		new /obj/item/weapon/storage/firstaid/fire(src)
 		new /obj/item/weapon/storage/firstaid/o2(src)
 		new /obj/item/weapon/storage/firstaid/toxin(src)
-		return
 
 
 // Psychiatrist's pill bottle
@@ -138,13 +130,10 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/suit/straight_jacket(src)
 		new /obj/item/weapon/reagent_containers/syringe(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/ether(src)
 		new /obj/item/weapon/storage/pill_bottle/psychiatrist(src)
-
-		return
 
 /obj/structure/closet/secure_closet/CMO
 	name = "chief medical officer's locker"
@@ -158,7 +147,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/medic(src)
 		else
@@ -187,7 +175,6 @@
 		new /obj/item/device/flash(src)
 		new /obj/item/weapon/reagent_containers/hypospray/CMO(src)
 		new /obj/item/organ/internal/cyberimp/eyes/hud/medical(src)
-		return
 
 
 
@@ -198,12 +185,10 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/device/assembly/signaler(src)
 		new /obj/item/device/radio/electropack(src)
 		new /obj/item/device/radio/electropack(src)
 		new /obj/item/device/radio/electropack(src)
-		return
 
 
 
@@ -221,10 +206,8 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/box/pillbottles(src)
 		new /obj/item/weapon/storage/box/pillbottles(src)
-		return
 
 /obj/structure/closet/secure_closet/medical_wall
 	name = "first aid closet"
@@ -266,12 +249,10 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/suit/space/eva/paramedic(src)
 		new /obj/item/clothing/head/helmet/space/eva/paramedic(src)
 		new /obj/item/clothing/head/helmet/space/eva/paramedic(src)
 		new /obj/item/device/sensor_device(src)
-		return
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"
@@ -287,11 +268,9 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/phenol(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/ammonia(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/oil(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/acetone(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/acid(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/diethylamine(src)
-		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -6,15 +6,13 @@
 
 /obj/structure/closet/secure_closet/personal/New()
 	..()
-	spawn(2)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack/duffel(src)
-		if(prob(50))
-			new /obj/item/weapon/storage/backpack(src)
-		else
-			new /obj/item/weapon/storage/backpack/satchel_norm(src)
-		new /obj/item/device/radio/headset( src )
-	return
+	if(prob(50))
+		new /obj/item/weapon/storage/backpack/duffel(src)
+	if(prob(50))
+		new /obj/item/weapon/storage/backpack(src)
+	else
+		new /obj/item/weapon/storage/backpack/satchel_norm(src)
+	new /obj/item/device/radio/headset( src )
 
 
 /obj/structure/closet/secure_closet/personal/patient
@@ -22,11 +20,9 @@
 
 /obj/structure/closet/secure_closet/personal/patient/New()
 	..()
-	spawn(4)
-		contents = list()
-		new /obj/item/clothing/under/color/white( src )
-		new /obj/item/clothing/shoes/white( src )
-	return
+	contents.Cut()
+	new /obj/item/clothing/under/color/white( src )
+	new /obj/item/clothing/shoes/white( src )
 
 
 
@@ -52,11 +48,9 @@
 
 /obj/structure/closet/secure_closet/personal/cabinet/New()
 	..()
-	spawn(4)
-		contents = list()
-		new /obj/item/weapon/storage/backpack/satchel/withwallet( src )
-		new /obj/item/device/radio/headset( src )
-	return
+	contents.Cut()
+	new /obj/item/weapon/storage/backpack/satchel/withwallet( src )
+	new /obj/item/device/radio/headset( src )
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if (src.opened)
@@ -91,4 +85,3 @@
 		emag_act(user)
 	else
 		to_chat(user, "\red Access Denied")
-	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/backpack/science(src)
 		new /obj/item/weapon/storage/backpack/satchel_tox(src)
 		new /obj/item/clothing/under/rank/scientist(src)
@@ -22,7 +21,6 @@
 		new /obj/item/weapon/tank/air(src)
 		new /obj/item/clothing/mask/gas(src)
 		new /obj/item/clothing/shoes/sandal/white(src)
-		return
 
 
 
@@ -38,7 +36,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/suit/bio_suit/scientist(src)
 		new /obj/item/clothing/head/bio_hood/scientist(src)
 		new /obj/item/clothing/under/rank/research_director(src)
@@ -52,7 +49,6 @@
 		new /obj/item/clothing/suit/armor/reactive(src)
 		new /obj/item/device/flash(src)
 		new /obj/item/device/laser_pointer(src)
-		return
 
 /obj/structure/closet/secure_closet/research_reagents
 	name = "research chemical storage closet"
@@ -68,7 +64,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/morphine(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/morphine(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/morphine(src)
@@ -83,4 +78,3 @@
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/acetone(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/acid(src)
 		new /obj/item/weapon/reagent_containers/glass/bottle/reagent/diethylamine(src)
-		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -10,7 +10,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/captain(src)
 		else
@@ -27,7 +26,6 @@
 		new /obj/item/device/radio/headset/heads/captain/alt(src)
 		new /obj/item/clothing/gloves/color/captain(src)
 		new /obj/item/weapon/gun/energy/gun(src)
-		return
 
 
 
@@ -43,7 +41,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/glasses/sunglasses(src)
 		new /obj/item/clothing/head/hopcap(src)
 		new /obj/item/weapon/cartridge/hop(src)
@@ -55,7 +52,6 @@
 		new /obj/item/device/flash(src)
 		new /obj/item/weapon/mining_voucher(src)
 		new /obj/item/clothing/accessory/petcollar(src)
-		return
 
 /obj/structure/closet/secure_closet/hop2
 	name = "head of personnel's attire"
@@ -69,7 +65,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/rank/head_of_personnel(src)
 		new /obj/item/clothing/under/dress/dress_hop(src)
 		new /obj/item/clothing/under/dress/dress_hr(src)
@@ -82,7 +77,6 @@
 		new /obj/item/clothing/shoes/leather(src)
 		new /obj/item/clothing/shoes/white(src)
 		new /obj/item/clothing/under/rank/head_of_personnel_whimsy(src)
-		return
 
 
 
@@ -98,7 +92,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
@@ -121,7 +114,6 @@
 		new /obj/item/weapon/storage/belt/security/sec(src)
 		new /obj/item/taperoll/police(src)
 		new /obj/item/weapon/gun/energy/hos(src)
-		return
 
 
 
@@ -138,7 +130,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
@@ -161,7 +152,6 @@
 		new /obj/item/weapon/gun/energy/advtaser(src)
 		new /obj/item/weapon/storage/belt/security/sec(src)
 		new /obj/item/weapon/storage/box/holobadge(src)
-		return
 
 
 
@@ -177,7 +167,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
@@ -194,7 +183,6 @@
 		new /obj/item/clothing/head/helmet(src)
 		new /obj/item/weapon/melee/baton/loaded(src)
 		new /obj/item/taperoll/police(src)
-		return
 
 /obj/structure/closet/secure_closet/brigdoc
 	name = "brig physician's locker"
@@ -208,7 +196,6 @@
 
 	New()
 		..()
-		sleep(2)
 		if(prob(50))
 			new /obj/item/weapon/storage/backpack/medic(src)
 		else
@@ -225,7 +212,6 @@
 		new /obj/item/clothing/shoes/white(src)
 		new /obj/item/device/radio/headset/headset_sec/alt(src)
 		new /obj/item/clothing/shoes/sandal/white(src)
-		return
 
 /obj/structure/closet/secure_closet/blueshield
 	name = "blueshield's locker"
@@ -239,7 +225,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/briefcase(src)
 		new	/obj/item/weapon/storage/firstaid/adv(src)
 		new /obj/item/weapon/storage/belt/security/sec(src)
@@ -257,7 +242,6 @@
 		new /obj/item/clothing/accessory/holster(src)
 		new /obj/item/clothing/accessory/blue(src)
 		new /obj/item/clothing/shoes/jackboots/jacksandals(src)
-		return
 
 /obj/structure/closet/secure_closet/ntrep
 	name = "\improper Nanotrasen Representative's locker"
@@ -271,7 +255,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/storage/briefcase(src)
 		new /obj/item/device/paicard(src)
 		new /obj/item/device/flash(src)
@@ -283,7 +266,6 @@
 		new /obj/item/clothing/under/lawyer/female(src)
 		new /obj/item/clothing/head/ntrep(src)
 		new /obj/item/clothing/shoes/sandal/fancy(src)
-		return
 
 
 /obj/structure/closet/secure_closet/security/cargo
@@ -292,7 +274,6 @@
 		..()
 		new /obj/item/clothing/accessory/armband/cargo(src)
 		new /obj/item/device/encryptionkey/headset_cargo(src)
-		return
 
 /obj/structure/closet/secure_closet/security/engine
 
@@ -300,7 +281,6 @@
 		..()
 		new /obj/item/clothing/accessory/armband/engine(src)
 		new /obj/item/device/encryptionkey/headset_eng(src)
-		return
 
 /obj/structure/closet/secure_closet/security/science
 
@@ -308,7 +288,6 @@
 		..()
 		new /obj/item/clothing/accessory/armband/science(src)
 		new /obj/item/device/encryptionkey/headset_sci(src)
-		return
 
 /obj/structure/closet/secure_closet/security/med
 
@@ -316,7 +295,6 @@
 		..()
 		new /obj/item/clothing/accessory/armband/medgreen(src)
 		new /obj/item/device/encryptionkey/headset_med(src)
-		return
 
 
 /obj/structure/closet/secure_closet/detective
@@ -331,7 +309,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/under/det(src)
 		new /obj/item/clothing/suit/storage/det_suit(src)
 		new /obj/item/clothing/suit/storage/forensics/blue(src)
@@ -351,7 +328,6 @@
 		new /obj/item/clothing/accessory/holster/armpit(src)
 		new /obj/item/clothing/glasses/sunglasses/yeah(src)
 		new /obj/item/device/flashlight/seclite(src)
-		return
 
 /obj/structure/closet/secure_closet/detective/update_icon()
 	if(broken)
@@ -372,10 +348,8 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/weapon/reagent_containers/ld50_syringe/lethal(src)
 		new /obj/item/weapon/reagent_containers/ld50_syringe/lethal(src)
-		return
 
 
 
@@ -386,9 +360,9 @@
 	var/id = null
 
 	New()
+		..()
 		new /obj/item/clothing/under/color/orange/prison( src )
 		new /obj/item/clothing/shoes/orange( src )
-		return
 
 
 
@@ -398,7 +372,6 @@
 
 	New()
 		..()
-		sleep(2)
 		new /obj/item/clothing/shoes/brown(src)
 		new /obj/item/weapon/paper/Court (src)
 		new /obj/item/weapon/paper/Court (src)
@@ -407,7 +380,6 @@
 		new /obj/item/clothing/suit/judgerobe (src)
 		new /obj/item/clothing/head/powdered_wig (src)
 		new /obj/item/weapon/storage/briefcase(src)
-		return
 
 /obj/structure/closet/secure_closet/wall
 	name = "wall locker"

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -108,8 +108,6 @@
 	health -= Proj.damage
 	check_health()
 
-	return
-
 /obj/structure/closet/statue/attack_animal(mob/living/simple_animal/user as mob)
 	if(user.environment_smash)
 		for(var/mob/M in src)

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -125,7 +125,7 @@
 		/obj/item/stack/rods
 		)
 
-		for(var/i = 1 to 2)
+		for(var/i in 1 to 2)
 			for(var/res in resources)
 				var/obj/item/stack/R = new res(src)
 				R.amount = R.max_amount

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -11,7 +11,6 @@
 
 /obj/structure/closet/syndicate/personal/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/syndicate(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
@@ -24,7 +23,6 @@
 
 /obj/structure/closet/syndicate/suits/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/head/helmet/space/rig/syndi(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/clothing/suit/space/rig/syndi(src)
@@ -35,7 +33,6 @@
 
 /obj/structure/closet/syndicate/nuclear/New()
 	..()
-	sleep(2)
 	new /obj/item/ammo_box/magazine/m10mm(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
@@ -55,7 +52,6 @@
 	new /obj/item/weapon/pinpointer/nukeop(src)
 	new /obj/item/weapon/pinpointer/nukeop(src)
 	new /obj/item/device/pda/syndicate(src)
-	return
 
 /obj/structure/closet/syndicate/resources/
 	desc = "An old, dusty locker."
@@ -66,9 +62,6 @@
 		var/common_max = 50 //Maximum amount of HONK in the stack for HONK common minerals
 		var/rare_min = 5  //Minimum HONK of HONK in the stack HONK HONK rare minerals
 		var/rare_max = 20 //Maximum HONK HONK HONK in the HONK for HONK rare HONK
-
-
-		sleep(2)
 
 		var/pickednum = rand(1, 50)
 
@@ -114,12 +107,11 @@
 		if(pickednum == 50)
 			new /obj/item/weapon/tank/jetpack/carbondioxide(src)
 
-		return
-
 /obj/structure/closet/syndicate/resources/everything
 	desc = "It's an emergency storage closet for repairs."
 
 	New()
+		..()
 		var/list/resources = list(
 		/obj/item/stack/sheet/metal,
 		/obj/item/stack/sheet/glass,
@@ -133,11 +125,7 @@
 		/obj/item/stack/rods
 		)
 
-		sleep(2)
-
-		for(var/i = 0, i<2, i++)
+		for(var/i = 1 to 2)
 			for(var/res in resources)
 				var/obj/item/stack/R = new res(src)
 				R.amount = R.max_amount
-
-		return

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -80,8 +80,7 @@
 
 /obj/structure/closet/firecloset/full/New()
 	..()
-	sleep(4)
-	contents = list()
+	contents.Cut()
 
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/mask/gas(src)
@@ -167,7 +166,6 @@
 
 /obj/structure/closet/bombcloset/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/bomb_suit( src )
 	new /obj/item/clothing/under/color/black( src )
 	new /obj/item/clothing/shoes/black( src )
@@ -183,7 +181,6 @@
 
 /obj/structure/closet/bombclosetsecurity/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/bomb_suit/security( src )
 	new /obj/item/clothing/under/rank/security( src )
 	new /obj/item/clothing/shoes/brown( src )
@@ -204,7 +201,6 @@
 
 /obj/structure/closet/hydrant/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/device/flashlight(src)

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -9,7 +9,6 @@
 
 /obj/structure/closet/wardrobe/generic/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/blue(src)
@@ -19,7 +18,6 @@
 	new /obj/item/clothing/shoes/brown(src)
 	new /obj/item/clothing/shoes/brown(src)
 	new /obj/item/clothing/shoes/brown(src)
-	return
 
 
 /obj/structure/closet/wardrobe/red
@@ -29,7 +27,6 @@
 
 /obj/structure/closet/wardrobe/red/New()
 	..()
-	sleep(2)
 	new /obj/item/weapon/storage/backpack/duffel/security(src)
 	new /obj/item/weapon/storage/backpack/duffel/security(src)
 	new /obj/item/clothing/mask/bandana/red(src)
@@ -53,8 +50,6 @@
 	new /obj/item/clothing/head/beret/sec(src)
 	new /obj/item/clothing/head/beret/sec(src)
 	new /obj/item/clothing/head/beret/sec(src)
-
-	return
 
 /obj/structure/closet/redcorp
 	name = "corporate security wardrobe"
@@ -63,7 +58,6 @@
 
 /obj/structure/closet/redcorp/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/security/corp(src)
 	new /obj/item/clothing/under/rank/security/corp(src)
 	new /obj/item/clothing/under/rank/security/corp(src)
@@ -78,14 +72,12 @@
 
 /obj/structure/closet/wardrobe/pink/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/under/color/pink(src)
 	new /obj/item/clothing/shoes/brown(src)
 	new /obj/item/clothing/shoes/brown(src)
 	new /obj/item/clothing/shoes/brown(src)
-	return
 
 /obj/structure/closet/wardrobe/black
 	name = "black wardrobe"
@@ -94,7 +86,6 @@
 
 /obj/structure/closet/wardrobe/black/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/color/black(src)
 	new /obj/item/clothing/under/color/black(src)
@@ -109,7 +100,6 @@
 	new /obj/item/clothing/head/soft/black(src)
 	new /obj/item/clothing/head/soft/black(src)
 	new /obj/item/clothing/head/soft/black(src)
-	return
 
 /obj/structure/closet/wardrobe/green
 	name = "green wardrobe"
@@ -118,14 +108,12 @@
 
 /obj/structure/closet/wardrobe/green/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/under/color/green(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/shoes/black(src)
-	return
 
 /obj/structure/closet/wardrobe/xenos
 	name = "xenos wardrobe"
@@ -134,13 +122,11 @@
 
 /obj/structure/closet/wardrobe/xenos/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/suit/unathi/mantle(src)
 	new /obj/item/clothing/suit/unathi/robe(src)
 	new /obj/item/clothing/shoes/sandal(src)
 	new /obj/item/clothing/shoes/sandal(src)
 	new /obj/item/clothing/shoes/sandal(src)
-	return
 
 
 /obj/structure/closet/wardrobe/orange
@@ -151,14 +137,12 @@
 
 /obj/structure/closet/wardrobe/orange/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/under/color/orange/prison(src)
 	new /obj/item/clothing/shoes/orange(src)
 	new /obj/item/clothing/shoes/orange(src)
 	new /obj/item/clothing/shoes/orange(src)
-	return
 
 
 /obj/structure/closet/wardrobe/yellow
@@ -168,14 +152,12 @@
 
 /obj/structure/closet/wardrobe/yellow/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/yellow(src)
 	new /obj/item/clothing/under/color/yellow(src)
 	new /obj/item/clothing/under/color/yellow(src)
 	new /obj/item/clothing/shoes/orange(src)
 	new /obj/item/clothing/shoes/orange(src)
 	new /obj/item/clothing/shoes/orange(src)
-	return
 
 
 /obj/structure/closet/wardrobe/atmospherics_yellow
@@ -185,7 +167,6 @@
 
 /obj/structure/closet/wardrobe/atmospherics_yellow/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/atmospheric_technician(src)
 	new /obj/item/clothing/under/rank/atmospheric_technician(src)
 	new /obj/item/clothing/under/rank/atmospheric_technician(src)
@@ -198,7 +179,6 @@
 	new /obj/item/clothing/head/beret/atmos(src)
 	new /obj/item/clothing/head/beret/atmos(src)
 	new /obj/item/clothing/head/beret/atmos(src)
-	return
 
 
 
@@ -209,7 +189,6 @@
 
 /obj/structure/closet/wardrobe/engineering_yellow/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
 	new /obj/item/clothing/under/rank/engineer(src)
@@ -222,7 +201,6 @@
 	new /obj/item/clothing/head/beret/eng(src)
 	new /obj/item/clothing/head/beret/eng(src)
 	new /obj/item/clothing/head/beret/eng(src)
-	return
 
 
 /obj/structure/closet/wardrobe/white
@@ -232,14 +210,12 @@
 
 /obj/structure/closet/wardrobe/white/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/under/color/white(src)
 	new /obj/item/clothing/shoes/white(src)
 	new /obj/item/clothing/shoes/white(src)
 	new /obj/item/clothing/shoes/white(src)
-	return
 
 /obj/structure/closet/wardrobe/medical_white
 	name = "medical doctor's wardrobe"
@@ -248,7 +224,6 @@
 
 /obj/structure/closet/wardrobe/medical_white/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/nursesuit (src)
 	new /obj/item/clothing/head/nursehat (src)
 	new /obj/item/clothing/under/rank/nurse(src)
@@ -265,7 +240,6 @@
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/shoes/black(src)
-	return
 
 /obj/structure/closet/wardrobe/pjs
 	name = "Pajama wardrobe"
@@ -274,7 +248,6 @@
 
 /obj/structure/closet/wardrobe/pjs/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/pj/red(src)
 	new /obj/item/clothing/under/pj/red(src)
 	new /obj/item/clothing/under/pj/blue(src)
@@ -283,7 +256,6 @@
 	new /obj/item/clothing/shoes/white(src)
 	new /obj/item/clothing/shoes/slippers(src)
 	new /obj/item/clothing/shoes/slippers(src)
-	return
 
 
 /obj/structure/closet/wardrobe/toxins_white
@@ -293,7 +265,6 @@
 
 /obj/structure/closet/wardrobe/toxins_white/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
 	new /obj/item/clothing/under/rank/scientist(src)
@@ -306,7 +277,6 @@
 	new /obj/item/clothing/shoes/slippers
 	new /obj/item/clothing/shoes/slippers
 	new /obj/item/clothing/shoes/slippers
-	return
 
 
 /obj/structure/closet/wardrobe/robotics_black
@@ -316,7 +286,6 @@
 
 /obj/structure/closet/wardrobe/robotics_black/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/glasses/hud/diagnostic(src)
 	new /obj/item/clothing/glasses/hud/diagnostic(src)
 	new /obj/item/clothing/under/rank/roboticist(src)
@@ -329,7 +298,6 @@
 	new /obj/item/clothing/gloves/fingerless(src)
 	new /obj/item/clothing/head/soft/black(src)
 	new /obj/item/clothing/head/soft/black(src)
-	return
 
 
 /obj/structure/closet/wardrobe/chemistry_white
@@ -339,7 +307,6 @@
 
 /obj/structure/closet/wardrobe/chemistry_white/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/under/rank/chemist(src)
 	new /obj/item/clothing/shoes/white(src)
@@ -354,7 +321,6 @@
 	new /obj/item/weapon/storage/bag/chemistry(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/clothing/mask/gas(src)
-	return
 
 
 /obj/structure/closet/wardrobe/genetics_white
@@ -364,7 +330,6 @@
 
 /obj/structure/closet/wardrobe/genetics_white/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/geneticist(src)
 	new /obj/item/clothing/under/rank/geneticist(src)
 	new /obj/item/clothing/shoes/white(src)
@@ -375,7 +340,6 @@
 	new /obj/item/weapon/storage/backpack/genetics(src)
 	new /obj/item/weapon/storage/backpack/satchel_gen(src)
 	new /obj/item/weapon/storage/backpack/satchel_gen(src)
-	return
 
 
 /obj/structure/closet/wardrobe/virology_white
@@ -385,7 +349,6 @@
 
 /obj/structure/closet/wardrobe/virology_white/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/under/rank/virologist(src)
 	new /obj/item/clothing/shoes/white(src)
@@ -398,7 +361,6 @@
 	new /obj/item/weapon/storage/backpack/virology(src)
 	new /obj/item/weapon/storage/backpack/satchel_vir(src)
 	new /obj/item/weapon/storage/backpack/satchel_vir(src)
-	return
 
 
 /obj/structure/closet/wardrobe/medic_white
@@ -408,7 +370,6 @@
 
 /obj/structure/closet/wardrobe/medic_white/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/rank/medical(src)
 	new /obj/item/clothing/under/rank/medical/blue(src)
@@ -420,7 +381,6 @@
 	new /obj/item/clothing/suit/storage/labcoat(src)
 	new /obj/item/clothing/mask/surgical(src)
 	new /obj/item/clothing/mask/surgical(src)
-	return
 
 
 /obj/structure/closet/wardrobe/grey
@@ -430,7 +390,6 @@
 
 /obj/structure/closet/wardrobe/grey/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/grey(src)
 	new /obj/item/clothing/under/color/grey(src)
 	new /obj/item/clothing/under/color/grey(src)
@@ -446,7 +405,6 @@
 		new /obj/item/clothing/under/assistantformal(src)
 	if(prob(40))
 		new /obj/item/clothing/under/assistantformal(src)
-	return
 
 
 /obj/structure/closet/wardrobe/mixed
@@ -456,7 +414,6 @@
 
 /obj/structure/closet/wardrobe/mixed/New()
 	..()
-	sleep(2)
 	new /obj/item/clothing/under/color/blue(src)
 	new /obj/item/clothing/under/color/yellow(src)
 	new /obj/item/clothing/under/color/green(src)
@@ -471,4 +428,3 @@
 	new /obj/item/clothing/shoes/orange(src)
 	new /obj/item/clothing/shoes/purple(src)
 	new /obj/item/clothing/shoes/leather(src)
-	return

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -212,7 +212,6 @@
 					return
 		src.add_fingerprint(user)
 		src.toggle(user)
-	return
 
 // Called when a crate is delivered by MULE at a location, for notifying purposes
 /obj/structure/closet/crate/proc/notifyRecipient(var/destination)
@@ -317,7 +316,6 @@
 		src.broken = 1
 		update_icon()
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
-		return
 
 /obj/structure/closet/crate/secure/emp_act(severity)
 	for(var/obj/O in src)
@@ -513,7 +511,6 @@
 				if(!M.anchored)
 					M.forceMove(src)
 					break
-	return
 
 /obj/structure/closet/crate/secure/large
 	name = "large crate"
@@ -541,7 +538,6 @@
 				if(!M.anchored)
 					M.forceMove(src)
 					break
-	return
 
 //fluff variant
 /obj/structure/closet/crate/secure/large/reinforced

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -1,10 +1,15 @@
 /**********************Mineral deposits**************************/
 
-var/global/list/rockTurfEdgeCache
 #define NORTH_EDGING	"north"
 #define SOUTH_EDGING	"south"
 #define EAST_EDGING		"east"
 #define WEST_EDGING		"west"
+
+var/global/list/rockTurfEdgeCache = list(
+	NORTH_EDGING = image('icons/turf/mining.dmi', "rock_side_n", layer = 6),
+	SOUTH_EDGING =  image('icons/turf/mining.dmi', "rock_side_s"),
+	EAST_EDGING = image('icons/turf/mining.dmi', "rock_side_e", layer = 6),
+	WEST_EDGING = image('icons/turf/mining.dmi', "rock_side_w", layer = 6))
 
 /turf/simulated/mineral //wall piece
 	name = "Rock"
@@ -50,32 +55,8 @@ var/global/list/rockTurfEdgeCache
 	return
 
 /turf/simulated/mineral/New()
-	if(!rockTurfEdgeCache || !rockTurfEdgeCache.len)
-		rockTurfEdgeCache = list()
-		rockTurfEdgeCache.len = 4
-		rockTurfEdgeCache[NORTH_EDGING] = image('icons/turf/mining.dmi', "rock_side_n", layer = 6)
-		rockTurfEdgeCache[SOUTH_EDGING] = image('icons/turf/mining.dmi', "rock_side_s")
-		rockTurfEdgeCache[EAST_EDGING] = image('icons/turf/mining.dmi', "rock_side_e", layer = 6)
-		rockTurfEdgeCache[WEST_EDGING] = image('icons/turf/mining.dmi', "rock_side_w", layer = 6)
-
-	spawn(1)
-		var/turf/T
-		if((istype(get_step(src, NORTH), /turf/simulated/floor)) || (istype(get_step(src, NORTH), /turf/space)))
-			T = get_step(src, NORTH)
-			if (T)
-				T.overlays += rockTurfEdgeCache[SOUTH_EDGING]
-		if((istype(get_step(src, SOUTH), /turf/simulated/floor)) || (istype(get_step(src, SOUTH), /turf/space)))
-			T = get_step(src, SOUTH)
-			if (T)
-				T.overlays += rockTurfEdgeCache[NORTH_EDGING]
-		if((istype(get_step(src, EAST), /turf/simulated/floor)) || (istype(get_step(src, EAST), /turf/space)))
-			T = get_step(src, EAST)
-			if (T)
-				T.overlays += rockTurfEdgeCache[WEST_EDGING]
-		if((istype(get_step(src, WEST), /turf/simulated/floor)) || (istype(get_step(src, WEST), /turf/space)))
-			T = get_step(src, WEST)
-			if (T)
-				T.overlays += rockTurfEdgeCache[EAST_EDGING]
+	..()
+	mineral_turfs += src
 
 	if (mineralType && mineralAmt && spread && spreadChance)
 		for(var/dir in cardinal)
@@ -85,7 +66,6 @@ var/global/list/rockTurfEdgeCache
 					Spread(T)
 
 	HideRock()
-	return
 
 /turf/simulated/mineral/proc/HideRock()
 	if(hidden)
@@ -95,6 +75,33 @@ var/global/list/rockTurfEdgeCache
 
 /turf/simulated/mineral/proc/Spread(var/turf/T)
 	new src.type(T)
+
+/hook/startup/proc/add_mineral_edges()
+	var/watch = start_watch()
+	log_startup_progress("Reticulating splines...")
+	for(var/turf/simulated/mineral/M in mineral_turfs)
+		M.add_edges()
+	log_startup_progress(" Splines reticulated in [stop_watch(watch)]s.")
+	return 1
+
+/turf/simulated/mineral/proc/add_edges()
+	var/turf/T
+	if((istype(get_step(src, NORTH), /turf/simulated/floor)) || (istype(get_step(src, NORTH), /turf/space)))
+		T = get_step(src, NORTH)
+		if (T)
+			T.overlays += rockTurfEdgeCache[SOUTH_EDGING]
+	if((istype(get_step(src, SOUTH), /turf/simulated/floor)) || (istype(get_step(src, SOUTH), /turf/space)))
+		T = get_step(src, SOUTH)
+		if (T)
+			T.overlays += rockTurfEdgeCache[NORTH_EDGING]
+	if((istype(get_step(src, EAST), /turf/simulated/floor)) || (istype(get_step(src, EAST), /turf/space)))
+		T = get_step(src, EAST)
+		if (T)
+			T.overlays += rockTurfEdgeCache[WEST_EDGING]
+	if((istype(get_step(src, WEST), /turf/simulated/floor)) || (istype(get_step(src, WEST), /turf/space)))
+		T = get_step(src, WEST)
+		if (T)
+			T.overlays += rockTurfEdgeCache[EAST_EDGING]
 
 /turf/simulated/mineral/random
 	name = "mineral deposit"

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -242,9 +242,9 @@
 	height = 4
 
 /obj/docking_port/mobile/pod/New()
+	..()
 	if(id == "pod")
 		WARNING("[type] id has not been changed from the default. Use the id convention \"pod1\" \"pod2\" etc.")
-	..()
 
 /obj/docking_port/mobile/pod/cancel()
 	return

--- a/code/world.dm
+++ b/code/world.dm
@@ -52,8 +52,6 @@ var/global/datum/global_init/init = new ()
 
 	. = ..()
 
-	sleep_offline = 1
-
 	plant_controller = new()
 	// Create robolimbs for chargen.
 	populate_robolimb_list()
@@ -67,6 +65,7 @@ var/global/datum/global_init/init = new ()
 		processScheduler.setup()
 
 		master_controller.setup()
+		sleep_offline = 1
 
 	#ifdef MAP_NAME
 	map_name = "[MAP_NAME]"


### PR DESCRIPTION
Basically I removed a huge number of completely unnecessary sleeps/spawns, although for mining turfs (the main culprit) & headsets, refactored the setup so that they didn't need to spawn/sleep to sync up with things.
I also moved setting `sleep_offline` to the end of game setup, where it should have always been.

On my computer, DD went from pressing `Go` to `Finished object initializations` & the roundstart timer ticking in 55 seconds.