### PR TITLE
Hemostat used again for embeded object removal

### DIFF
--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -329,7 +329,12 @@
 /datum/surgery_step/remove_object
 	name = "remove embedded objects"
 	time = 32
-	accept_hand = 1
+	allowed_tools = list(
+	/obj/item/weapon/scalpel/manager = 120, \
+	/obj/item/weapon/hemostat = 100,	\
+	/obj/item/stack/cable_coil = 75, 	\
+	/obj/item/device/assembly/mousetrap = 20
+	)
 	var/obj/item/organ/external/L = null
 
 


### PR DESCRIPTION
Reverts back to hemostat and alternatives for embeded object surgery.
Fixes #4217 
:cl:
 tweak: Embeded object removal is now done with hemostat again
 add: Borgs are able to do embeded object surgery
/:cl: