### PR TITLE
Removes unnecessary extra headset stuff I did, makes bot radios cleaner

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -205,13 +205,9 @@ var/const/RADIO_MAGNETS = "radio_magnet"
 var/const/RADIO_LOGIC = "radio_logic"
 
 var/global/datum/controller/radio/radio_controller
-var/global/list/headsets[0]
 
 /hook/startup/proc/createRadioController()
 	radio_controller = new /datum/controller/radio()
-	for(var/A in headsets)
-		var/obj/item/device/radio/headset/H = A
-		H.initialize()
 	return 1
 
 //callback used by objects to react to incoming radio signals

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -19,7 +19,6 @@
 
 /obj/item/device/radio/headset/New()
 	..()
-	headsets += src
 	internal_channels.Cut()
 
 /obj/item/device/radio/headset/initialize()
@@ -39,7 +38,6 @@
 		qdel(keyslot2)
 	keyslot1 = null
 	keyslot2 = null
-	headsets -= src
 	return ..()
 
 /obj/item/device/radio/headset/list_channels(var/mob/user)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -84,6 +84,20 @@
 
 	hud_possible = list(DIAG_STAT_HUD, DIAG_BOT_HUD, DIAG_HUD) //Diagnostic HUD views
 
+/obj/item/device/radio/headset/bot
+	subspace_transmission = 1
+	canhear_range = 0
+
+/obj/item/device/radio/headset/bot/recalculateChannels()
+	var/mob/living/simple_animal/bot/B = loc
+	if(istype(B))
+		if(!B.radio_config)
+			B.radio_config = list("AI Private" = 1)
+			if(!(B.radio_channel in B.radio_config)) // put it first so it's the :h channel
+				B.radio_config.Insert(1, "[B.radio_channel]")
+				B.radio_config["[B.radio_channel]"] = 1
+		config(B.radio_config)
+
 /mob/living/simple_animal/bot/proc/get_mode()
 	if(client) //Player bots do not have modes, thus the override. Also an easy way for PDA users/AI to know when a bot is a player.
 		if(paicard)
@@ -123,15 +137,7 @@
 //This access is so bots can be immediately set to patrol and leave Robotics, instead of having to be let out first.
 	access_card.access += access_robotics
 	set_custom_texts()
-	Radio = new/obj/item/device/radio/headset(src)
-	Radio.subspace_transmission = 1
-	Radio.canhear_range = 0 // anything greater will have the bot broadcast the channel as if it were saying it out loud.
-	if(!radio_config)
-		radio_config = list("AI Private" = 1)
-		if(!(radio_channel in radio_config)) // put it first so it's the :h channel
-			radio_config.Insert(1, "[radio_channel]")
-			radio_config["[radio_channel]"] = 1
-	Radio.config(radio_config)
+	Radio = new/obj/item/device/radio/headset/bot(src)
 
 	add_language("Galactic Common", 1)
 	add_language("Sol Common", 1)


### PR DESCRIPTION
- A couple of headset tweaks re: #4216
 - Just moving the `recalculateChannels()` to `initialize()` in the headsets removed the headset sleep requirement; running initialize in the radio startup hook was unnecessary, so I removed that.
 - Also bot fixup/cleanup because it was dependent on the old gross timing.
- Also forgot changelog for the speedup, so putting it here will be easier than injecting it seperately.

:cl:
tweak: Makes the server startup substantially faster.
/:cl:
