### PR TITLE
Ports TG's Improved Attack Animations

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -387,7 +387,6 @@ This function restores all organs.
 						dmgIcon.pixel_y = (!lying) ? rand(-11,9) : rand(-10,1)
 						flick_overlay(dmgIcon, attack_bubble_recipients, 9)
 
-			receive_damage()
 
 		if(BURN)
 			damageoverlaytemp = 20

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -387,6 +387,7 @@ This function restores all organs.
 						dmgIcon.pixel_y = (!lying) ? rand(-11,9) : rand(-10,1)
 						flick_overlay(dmgIcon, attack_bubble_recipients, 9)
 
+			receive_damage()
 
 		if(BURN)
 			damageoverlaytemp = 20

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -872,48 +872,71 @@
 	gib()
 	return
 
-/atom/movable/proc/do_attack_animation(atom/A)
+/atom/movable/proc/do_attack_animation(atom/A, end_pixel_y)
 	var/pixel_x_diff = 0
 	var/pixel_y_diff = 0
+	var/final_pixel_y = initial(pixel_y)
+	if(end_pixel_y)
+		final_pixel_y = end_pixel_y
+
 	var/direction = get_dir(src, A)
-	switch(direction)
-		if(NORTH)
-			pixel_y_diff = 8
-		if(SOUTH)
-			pixel_y_diff = -8
-		if(EAST)
-			pixel_x_diff = 8
-		if(WEST)
-			pixel_x_diff = -8
-		if(NORTHEAST)
-			pixel_x_diff = 8
-			pixel_y_diff = 8
-		if(NORTHWEST)
-			pixel_x_diff = -8
-			pixel_y_diff = 8
-		if(SOUTHEAST)
-			pixel_x_diff = 8
-			pixel_y_diff = -8
-		if(SOUTHWEST)
-			pixel_x_diff = -8
-			pixel_y_diff = -8
+	if(direction & NORTH)
+		pixel_y_diff = 8
+	else if(direction & SOUTH)
+		pixel_y_diff = -8
+
+	if(direction & EAST)
+		pixel_x_diff = 8
+	else if(direction & WEST)
+		pixel_x_diff = -8
+
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
-	animate(pixel_x = initial(pixel_x), pixel_y = initial(pixel_y), time = 2)
+	animate(pixel_x = initial(pixel_x), pixel_y = final_pixel_y, time = 2)
+
 
 /mob/living/do_attack_animation(atom/A)
-	..()
+	var/final_pixel_y = get_standard_pixel_y_offset(lying)
+	..(A, final_pixel_y)
 	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
 
+	// What icon do we use for the attack?
+	var/image/I
+	if(hand && l_hand) // Attacked with item in left hand.
+		I = image(l_hand.icon, A, l_hand.icon_state, A.layer + 1)
+	else if(!hand && r_hand) // Attacked with item in right hand.
+		I = image(r_hand.icon, A, r_hand.icon_state, A.layer + 1)
+	else // Attacked with a fist?
+		return
 
-/atom/movable/proc/receive_damage(atom/A)
-	var/pixel_x_diff = rand(-3,3)
-	var/pixel_y_diff = rand(-3,3)
-	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
-	animate(pixel_x = initial(pixel_x), pixel_y = initial(pixel_y), time = 2)
+	// Who can see the attack?
+	var/list/viewing = list()
+	for(var/mob/M in viewers(A))
+		if(M.client)
+			viewing |= M.client
+	flick_overlay(I, viewing, 5) // 5 ticks/half a second
 
-/mob/living/receive_damage(atom/A)
-	..()
-	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+	// Scale the icon.
+	I.transform *= 0.75
+	// The icon should not rotate.
+	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+
+	// Set the direction of the icon animation.
+	var/direction = get_dir(src, A)
+	if(direction & NORTH)
+		I.pixel_y = -16
+	else if(direction & SOUTH)
+		I.pixel_y = 16
+
+	if(direction & EAST)
+		I.pixel_x = -16
+	else if(direction & WEST)
+		I.pixel_x = 16
+
+	if(!direction) // Attacked self?!
+		I.pixel_z = 16
+
+	// And animate the attack!
+	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
 
 /mob/living/proc/do_jitter_animation(jitteriness)
 	var/amplitude = min(4, (jitteriness/100) + 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -938,6 +938,16 @@
 	// And animate the attack!
 	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
 
+/atom/movable/proc/receive_damage(atom/A)
+	var/pixel_x_diff = rand(-3,3)
+	var/pixel_y_diff = rand(-3,3)
+	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
+	animate(pixel_x = initial(pixel_x), pixel_y = initial(pixel_y), time = 2)
+
+/mob/living/receive_damage(atom/A)
+	..()
+	floating = 0 // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
+
 /mob/living/proc/do_jitter_animation(jitteriness)
 	var/amplitude = min(4, (jitteriness/100) + 1)
 	var/pixel_x_diff = rand(-amplitude, amplitude)


### PR DESCRIPTION
Ports TG's improved attack animations---these are in use, even on Baystation. @Neersighted @RemieRichards.

Port of: https://github.com/tgstation/-tg-station/pull/10314 and https://github.com/tgstation/-tg-station/pull/13298

Implemented better attack animations for when hitting people with an object in your hands. Often times, in the midst of battle, you don't have time to react to what you're being hit with by reading the chat; this rectifies that issue and also lets you know, better, who's doing the attacking. Not surprisingly, for this reason, even Bay utilizes this system, these days.

To that end, since things are far more clear who's doing the attacking and with what, the "hit twitching" has been removed, as its no longer necessary and just makes for visual clutter.

![img](https://i.gyazo.com/7c5e114d1a9364121c2bba5403e7c275.gif)
From @Neersighted's PR
![img2](https://camo.githubusercontent.com/92a9222618ac466e251a98f46a86856d1a9dcb31/68747470733a2f2f692e696d6775722e636f6d2f734f39556178632e676966)

:cl: Fox McCloud
add: Improves attack animations with items, making it more clear who's attacking you and with what
/:cl:
