### PR TITLE
Fix the light toggles on drones and guardians.

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -29,6 +29,8 @@
 	var/summoned = FALSE
 	var/cooldown = 0
 	var/damage_transfer = 1 //how much damage from each attack we transfer to the owner
+	var/light_on = 0
+	var/luminosity_on = 3
 	var/mob/living/summoner
 	var/range = 10 //how far from the user the spirit can be
 	var/playstyle_string = "You are a standard Guardian. You shouldn't exist!"
@@ -202,13 +204,13 @@
 
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleLight()
-	if(!luminosity)
-		set_light(3)
+	if(!light_on)
+		set_light(luminosity_on)
 		to_chat(src, "<span class='notice'>You activate your light.</span>")
 	else
 		set_light(0)
 		to_chat(src, "<span class='notice'>You deactivate your light.</span>")
-
+	light_on = !light_on
 
 //////////////////////////TYPES OF GUARDIANS
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -38,10 +38,9 @@
 	set desc = "Activate a low power omnidirectional LED. Toggled on or off."
 	set category = "Drone"
 
-	if(luminosity)
-		set_light(0)
-		return
-	set_light(2)
+	if(lamp_intensity)
+		lamp_intensity = lamp_max // setting this to lamp_max will make control_headlamp shutoff the lamp
+	control_headlamp()
 
 //Actual picking-up event.
 /mob/living/silicon/robot/drone/attack_hand(mob/living/carbon/human/M as mob)


### PR DESCRIPTION
Replaces outdated use of luminosity variable.
Fixes #3026 and should fix #4239 (haven't been able to test, but should work)

:cl: Meisaka
fix: The light on/off function for drones works again, toggling between lowest setting and off.
fix: Guardians can toggle their lights off and on again.
/:cl: