### PR TITLE
Make silicon/AI/robot/drone/pAI emotes sane again.

### DIFF
--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -5,9 +5,6 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
-
 	//Emote Cooldown System (it's so simple!)
 	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
@@ -15,7 +12,8 @@
 		//Cooldown-inducing emotes
 		if("scream", "screams")
 			on_CD = handle_emote_CD(50) //longer cooldown
-		if("ping","buzz","beep","yes","no")		//halt is exempt because it's used to stop criminal scum //WHOEVER THOUGHT THAT WAS A GOOD IDEA IS GOING TO GET SHOT.
+		if("ping","pings","buzz","buzzs","buzzes","beep","beeps","yes","no")
+			//halt is exempt because it's used to stop criminal scum //WHOEVER THOUGHT THAT WAS A GOOD IDEA IS GOING TO GET SHOT.
 			on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
 		//Everything else, including typos of the above emotes
 		else
@@ -26,7 +24,7 @@
 	//--FalseIncarnate
 
 	switch(act)
-		if("ping")
+		if("ping","pings")
 			var/M = null
 			if(param)
 				for (var/mob/A in view(null, null))
@@ -43,7 +41,7 @@
 			playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 			m_type = 2
 
-		if("buzz")
+		if("buzz","buzzs","buzzes")
 			var/M = null
 			if(param)
 				for (var/mob/A in view(null, null))
@@ -60,7 +58,7 @@
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			m_type = 2
 
-		if("beep")
+		if("beep","beeps")
 			var/M = null
 			if(param)
 				for (var/mob/A in view(null, null))
@@ -115,5 +113,8 @@
 			message = "<B>[src]</B> screams!"
 			playsound(src.loc, 'sound/goonstation/voice/robot_scream.ogg', 80, 0)
 			m_type = 2
+
+		if("help")
+			to_chat(src, "yes, no, beep, ping, buzz")
 
 	..(act, m_type, message)

--- a/code/modules/mob/living/silicon/pai/emote.dm
+++ b/code/modules/mob/living/silicon/pai/emote.dm
@@ -1,6 +1,2 @@
 /mob/living/silicon/pai/emote(var/act, var/m_type=1, var/message = null)
-	switch(act)
-		if ("help")
-			to_chat(src, "ping, beep, buzz.")
-
 	..(act, m_type, message)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -5,15 +5,12 @@
 		param = copytext(act, t1 + 1, length(act) + 1)
 		act = copytext(act, 1, t1)
 
-	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
-		act = copytext(act,1,length(act))
-
 	//Emote Cooldown System (it's so simple!)
 	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
 	switch(act)
 		//Cooldown-inducing emotes
-		if("law","flip","halt")		//halt is exempt because it's used to stop criminal scum //WHOEVER THOUGHT THAT WAS A GOOD IDEA IS GOING TO GET SHOT.
+		if("law","flip","flips","halt")		//halt is exempt because it's used to stop criminal scum //WHOEVER THOUGHT THAT WAS A GOOD IDEA IS GOING TO GET SHOT.
 			on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
 		//Everything else, including typos of the above emotes
 		else
@@ -25,7 +22,7 @@
 
 	switch(act)
 
-		if ("salute")
+		if ("salute","salutes")
 			if (!src.buckled)
 				var/M = null
 				if (param)
@@ -41,7 +38,7 @@
 				else
 					message = "<B>[src]</b> salutes."
 			m_type = 1
-		if ("bow")
+		if ("bow","bows")
 			if (!src.buckled)
 				var/M = null
 				if (param)
@@ -58,16 +55,16 @@
 					message = "<B>[src]</B> bows."
 			m_type = 1
 
-		if ("clap")
+		if ("clap","claps")
 			if (!src.restrained())
 				message = "<B>[src]</B> claps."
 				m_type = 2
-		if ("flap")
+		if ("flap","flaps")
 			if (!src.restrained())
 				message = "<B>[src]</B> flaps its wings."
 				m_type = 2
 
-		if ("aflap")
+		if ("aflap","aflaps")
 			if (!src.restrained())
 				message = "<B>[src]</B> flaps its wings ANGRILY!"
 				m_type = 2
@@ -76,11 +73,11 @@
 			message = "<B>[src]</B> twitches violently."
 			m_type = 1
 
-		if ("twitch_s")
+		if ("twitch_s","twitches")
 			message = "<B>[src]</B> twitches."
 			m_type = 1
 
-		if ("nod")
+		if ("nod","nods")
 			message = "<B>[src]</B> nods."
 			m_type = 1
 
@@ -88,7 +85,7 @@
 			message = "<B>[src]</B> shudders violently for a moment, then becomes motionless, its eyes slowly darkening."
 			m_type = 1
 
-		if ("glare")
+		if ("glare","glares")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(null, null))
@@ -103,7 +100,7 @@
 			else
 				message = "<B>[src]</B> glares."
 
-		if ("stare")
+		if ("stare","stares")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(null, null))
@@ -118,7 +115,7 @@
 			else
 				message = "<B>[src]</B> stares."
 
-		if ("look")
+		if ("look","looks")
 			var/M = null
 			if (param)
 				for (var/mob/A in view(null, null))
@@ -154,12 +151,12 @@
 			else
 				to_chat(src, "You are not security.")
 
-		if ("flip")
+		if ("flip","flips")
 			m_type = 1
 			message = "<B>[src]</B> does a flip!"
 			src.SpinAnimation(5,1)
 
 		if ("help")
-			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitch_s, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look, beep, ping, \nbuzz, law, halt")
+			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitches, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look,\n law, halt")
 
 	..(act, m_type, message)


### PR DESCRIPTION
Fixes #3950 
The emote code for silicons and robots (recursively) was stripping the s off the end of text.
Removed that and explicitly added the alternatives to the list. Guess someone was lazy.

:cl: Meisaka
fix: AI, pAI, robots and drones can now use *yes emote without extra ss on the end.
add: emote *help for silicons updated/added.
tweak: *twitch_s emote changed to *twitches, incorrect variations of some emotes can no longer be used.
/:cl: