### PR TITLE
Removes nanomachines from the roburger

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -855,7 +855,6 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("nanomachines", 10)
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/roburgerbig


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: Nanomachines are no longer obtainable by making a roburger.
/:cl:

The sooner the better.

Fixes [#4256](https://github.com/ParadiseSS13/Paradise/issues/4256)