### PR TITLE
Makes fridge boards be selectable

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -445,6 +445,45 @@ to destroy them and players will be able to make replacements.
 	origin_tech = "programming=1"
 	req_components = list(
 							/obj/item/weapon/stock_parts/matter_bin = 1)
+	var/list/fridge_names_paths = list(
+							"\improper SmartFridge" = /obj/machinery/smartfridge,
+							"\improper MegaSeed Servitor" = /obj/machinery/smartfridge/seeds,
+							"\improper Refrigerated Medicine Storage" = /obj/machinery/smartfridge/medbay,
+							"\improper Slime Extract Storage" = /obj/machinery/smartfridge/secure/extract,
+							"\improper Secure Refrigerated Medicine Storage" = /obj/machinery/smartfridge/secure/medbay,
+							"\improper Smart Chemical Storage" = /obj/machinery/smartfridge/secure/chemistry,
+							"smart virus storage" = /obj/machinery/smartfridge/secure/chemistry/virology,
+							"\improper Drink Showcase" = /obj/machinery/smartfridge/drinks
+	)
+
+
+/obj/item/weapon/circuitboard/smartfridge/New()
+	..()
+	if(build_path == /obj/machinery/smartfridge)			//If we spawn the base type board (determined by the base type machine as the build path), become a random fridge board
+		var/new_path = fridge_names_paths[pick(fridge_names_paths)]
+		set_type(new_path)
+
+
+/obj/item/weapon/circuitboard/smartfridge/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/screwdriver))
+		set_type(null, user)
+
+/obj/item/weapon/circuitboard/smartfridge/proc/set_type(typepath, mob/user)
+	var/new_name = ""
+	if(!typepath)
+		new_name = input("Circuit Setting", "What would you change the board setting to?") in fridge_names_paths
+		typepath = fridge_names_paths[new_name]
+	else
+		for(var/name in fridge_names_paths)
+			if(fridge_names_paths[name] == typepath)
+				new_name = name
+				break
+	build_path = typepath
+	name = new_name
+	if(findtextEx(new_name, "\improper"))
+		new_name = replacetext(new_name, "\improper", "")
+	if(user)
+		to_chat(user, "<span class='notice'>You set the board to [new_name].</span>")
 
 /obj/item/weapon/circuitboard/monkey_recycler
 	name = "circuit board (Monkey Recycler)"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -457,12 +457,6 @@ to destroy them and players will be able to make replacements.
 	)
 
 
-/obj/item/weapon/circuitboard/smartfridge/New()
-	..()
-	if(build_path == /obj/machinery/smartfridge)			//If we spawn the base type board (determined by the base type machine as the build path), become a random fridge board
-		var/new_path = fridge_names_paths[pick(fridge_names_paths)]
-		set_type(new_path)
-
 
 /obj/item/weapon/circuitboard/smartfridge/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/screwdriver))

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -152,10 +152,8 @@
 					  /obj/item/weapon/reagent_containers/glass/bottle/plasma = 1,
 					  /obj/item/weapon/reagent_containers/glass/bottle/diphenhydramine = 1)
 
-/obj/machinery/smartfridge/secure/chemistry/virology/accept_check(obj/item/O)
-	if(..(O))
-		return 1
-	if(istype(O, /obj/item/weapon/reagent_containers/syringe))
+/obj/machinery/smartfridge/secure/chemistry/virology/accept_check(var/obj/item/O as obj)
+	if(istype(O, /obj/item/weapon/reagent_containers/syringe) || istype(O, /obj/item/weapon/reagent_containers/glass/bottle) || istype(O, /obj/item/weapon/reagent_containers/glass/beaker))
 		return 1
 	return 0
 

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -26,7 +26,9 @@
 /obj/machinery/smartfridge/New()
 	..()
 	component_parts = list()
-	component_parts += new /obj/item/weapon/circuitboard/smartfridge(null)
+	var/obj/item/weapon/circuitboard/smartfridge/board = new(null)
+	board.set_type(type)
+	component_parts += board
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
 	RefreshParts()
 


### PR DESCRIPTION
Screwdrive the board to select what type of fridge board you want.

:cl: pinatacolada
tweak: Makes fridge boards be selectable by screwdriving them
fix: Virology fridge now accepts  syringes, beakers, and bottles
/:cl: