### PR TITLE
Updates Mining Loot Crates

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -144,19 +144,18 @@
 	sharp = 1
 	edge = 1
 	w_class = 3
+	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
-	suicide_act(mob/user)
-		to_chat(viewers(user), "<span class='suicide'>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</span>")
-		return(BRUTELOSS)
+/obj/item/weapon/katana/cursed
+	slot_flags = null
+
+/obj/item/weapon/katana/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</span>")
+	return(BRUTELOSS)
 
 /obj/item/weapon/katana/IsShield()
 		return 1
-
-/obj/item/weapon/katana/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
-	return ..()
-
 
 /obj/item/weapon/harpoon
 	name = "harpoon"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -202,9 +202,14 @@
 	desc = "Woof!"
 	icon_state = "corgihead"
 	item_state = "chickensuit"
+	flags = BLOCKHAIR
+
+/obj/item/clothing/head/corgi/super_hero
+	name = "super-hero corgi suit head"
+	desc = "Woof! This one seems to pulse with a strange power"
 	flags = BLOCKHAIR | NODROP
 
-/obj/item/clothing/head/corgi/en
+/obj/item/clothing/head/corgi/super_hero/en
 	name = "E-N suit head"
 	icon_state = "enhead"
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -152,17 +152,25 @@
 	item_state = "chickensuit"
 	body_parts_covered = UPPER_TORSO|ARMS|LOWER_TORSO|LEGS|FEET
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
+
+/obj/item/clothing/suit/corgisuit/super_hero
+	name = "super-hero corgi suit"
+	desc = "A suit made long ago by the ancient empire KFC. This one pulses with a strange power."
 	flags = NODROP
 
-/obj/item/clothing/suit/corgisuit/en
-	name = "\improper E-N suit"
+/obj/item/clothing/suit/corgisuit/super_hero/en
+	name = "\improper super-hero E-N suit"
 	icon_state = "ensuit"
 
-/obj/item/clothing/suit/corgisuit/en/New()
+/obj/item/clothing/suit/corgisuit/super_hero/en/New()
 	..()
 	processing_objects.Add(src)
 
-/obj/item/clothing/suit/corgisuit/en/process()
+/obj/item/clothing/suit/corgisuit/super_hero/en/Destroy()
+	processing_objects.Remove(src)
+	return ..()
+
+/obj/item/clothing/suit/corgisuit/super_hero/en/process()
 	if(prob(2))
 		for(var/obj/M in orange(2,src))
 			if(!M.anchored && (M.flags & CONDUCT))

--- a/code/modules/hydroponics/seed_packets.dm
+++ b/code/modules/hydroponics/seed_packets.dm
@@ -307,3 +307,6 @@ var/global/list/plant_seed_sprites = list()
 
 /obj/item/seeds/coffeerseed
 	seed_type = "coffeer"
+
+/obj/item/seeds/cash
+	seed_type = "cashtree"

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -1,114 +1,218 @@
+//Originally coded by ISaidNo, later modified by Kelenius. Ported from Baystation12.
+
 /obj/structure/closet/crate/secure/loot
 	name = "abandoned crate"
 	desc = "What could be inside?"
 	icon_state = "securecrate"
-	icon_opened = "securecrateopen"
-	icon_closed = "securecrate"
 	var/code = null
 	var/lastattempt = null
-	var/attempts = 3
-	locked = 1
-	var/min = 1
-	var/max = 10
+	var/attempts = 10
+	var/codelen = 4
 
 /obj/structure/closet/crate/secure/loot/New()
 	..()
-	code = rand(min,max)
-	var/loot = rand(1,30)
-	switch(loot)
-		if(1)
-			new/obj/item/weapon/reagent_containers/food/drinks/bottle/rum(src)
-			new/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiadeus(src)
-			new/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey(src)
-			new/obj/item/weapon/lighter/zippo(src)
-		if(2)
-			new/obj/item/weapon/pickaxe/drill(src)
-			new/obj/item/device/taperecorder(src)
-			new/obj/item/clothing/suit/space(src)
-			new/obj/item/clothing/head/helmet/space(src)
-		if(3)
-			return
-		if(4)
-			new/obj/item/weapon/reagent_containers/glass/beaker/bluespace(src)
-		if(5 to 6)
-			for(var/i = 0, i < 10, i++)
-				new/obj/item/weapon/ore/diamond(src)
-		if(7)
-			return
-		if(8)
-			return
-		if(9)
-			for(var/i = 0, i < 3, i++)
-				new/obj/machinery/portable_atmospherics/hydroponics(src)
-		if(10)
-			for(var/i = 0, i < 3, i++)
-				new/obj/item/weapon/reagent_containers/glass/beaker/noreact(src)
-		if(11 to 13)
-			new/obj/item/weapon/melee/classic_baton(src)
-		if(14)
-			return
-		if(15)
-			new/obj/item/clothing/under/chameleon(src)
-			for(var/i = 0, i < 7, i++)
-				new/obj/item/clothing/accessory/horrible(src)
-		if(16)
-			new/obj/item/clothing/under/shorts(src)
-			new/obj/item/clothing/under/shorts/red(src)
-			new/obj/item/clothing/under/shorts/blue(src)
-		//Dummy crates start here.
-		if(17 to 29)
-			return
-		//Dummy crates end here.
-		if(30)
-			new/obj/item/weapon/melee/baton(src)
+	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "z")
+	code = ""
+	for(var/i = 0, i < codelen, i++)
+		var/dig = pick(digits)
+		code += dig
+		digits -= dig  //Player can enter codes with matching digits, but there are never matching digits in the answer
 
-/obj/structure/closet/crate/secure/loot/togglelock(mob/user as mob)
+	var/loot = rand(1,100) //100 different crates with varying chances of spawning
+	switch(loot)
+		if(1 to 5) //5% chance
+			new /obj/item/weapon/reagent_containers/food/drinks/bottle/rum(src)
+			new /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiadeus(src)
+			new /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey(src)
+			new /obj/item/weapon/lighter(src)
+		if(6 to 10)
+			new /obj/item/weapon/bedsheet(src)
+			new /obj/item/weapon/kitchen/knife(src)
+			new /obj/item/weapon/wirecutters(src)
+			new /obj/item/weapon/screwdriver(src)
+			new /obj/item/weapon/weldingtool(src)
+			new /obj/item/weapon/hatchet(src)
+			new /obj/item/weapon/crowbar(src)
+		if(11 to 15)
+			new /obj/item/weapon/reagent_containers/glass/beaker/bluespace(src)
+		if(16 to 20)
+			for(var/i in 1 to 10)
+				new /obj/item/weapon/ore/diamond(src)
+		if(21 to 25)
+			for(var/i in 1 to 5)
+				new /obj/item/weapon/contraband/poster(src)
+		if(26 to 30)
+			for(var/i in 1 to 3)
+				new /obj/item/weapon/reagent_containers/glass/beaker/noreact(src)
+		if(31 to 35)
+			new /obj/item/seeds/cash(src)
+		if(36 to 40)
+			new /obj/item/weapon/melee/baton(src)
+		if(41 to 45)
+			new /obj/item/clothing/under/shorts/red(src)
+			new /obj/item/clothing/under/shorts/blue(src)
+		if(46 to 50)
+			new /obj/item/clothing/under/chameleon(src)
+			for(var/i in 1 to 7)
+				new /obj/item/clothing/accessory/horrible(src)
+		if(51 to 52) // 2% chance
+			new /obj/item/weapon/melee/classic_baton(src)
+		if(53 to 54)
+			new /obj/item/toy/balloon(src)
+		if(55 to 56)
+			var/newitem = pick(subtypesof(/obj/item/toy/prize))
+			new newitem(src)
+		if(57 to 58)
+			new /obj/item/toy/syndicateballoon(src)
+		if(59 to 60)
+			new /obj/item/weapon/gun/energy/kinetic_accelerator/hyper(src)
+			new /obj/item/clothing/suit/space(src)
+			new /obj/item/clothing/head/helmet/space(src)
+		if(61 to 62)
+			for(var/i in 1 to 5)
+				new /obj/item/clothing/head/kitty(src)
+				new /obj/item/clothing/accessory/petcollar(src)
+		if(63 to 64)
+			for(var/i in 1 to rand(4, 7))
+				var/newcoin = pick(/obj/item/weapon/coin/silver, /obj/item/weapon/coin/silver, /obj/item/weapon/coin/silver, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/iron, /obj/item/weapon/coin/gold, /obj/item/weapon/coin/diamond, /obj/item/weapon/coin/plasma, /obj/item/weapon/coin/uranium)
+				new newcoin(src)
+		if(65 to 66)
+			new /obj/item/clothing/suit/ianshirt(src)
+			new /obj/item/clothing/suit/corgisuit(src)
+			new /obj/item/clothing/head/corgi(src)
+		if(67 to 68)
+			for(var/i in 1 to rand(4, 7))
+				var /newitem = pick(subtypesof(/obj/item/weapon/stock_parts) - /obj/item/weapon/stock_parts/subspace)
+				new newitem(src)
+		if(69 to 70)
+			for(var/i in 1 to 5)
+				new /obj/item/weapon/ore/bluespace_crystal(src)
+		if(71 to 72)
+			new /obj/item/weapon/pickaxe/drill(src)
+		if(73 to 74)
+			new /obj/item/weapon/pickaxe/drill/jackhammer(src)
+		if(75 to 76)
+			new /obj/item/weapon/pickaxe/diamond(src)
+		if(77 to 78)
+			new /obj/item/weapon/pickaxe/drill/diamonddrill(src)
+		if(79 to 80)
+			new /obj/item/weapon/cane(src)
+			new /obj/item/clothing/head/collectable/tophat(src)
+		if(81 to 82)
+			new /obj/item/weapon/gun/energy/plasmacutter(src)
+		if(83 to 84)
+			new /obj/item/toy/katana(src)
+		if(85 to 86)
+			new /obj/item/weapon/defibrillator/compact(src)
+		if(87) //1% chance
+			new /obj/item/weed_extract(src)
+		if(88)
+			new /obj/item/organ/internal/brain(src)
+		if(89)
+			new /obj/item/organ/internal/brain/xeno(src)
+		if(90)
+			new /obj/item/organ/internal/heart(src)
+		if(91)
+			new /obj/item/device/soulstone(src)
+		if(92)
+			new /obj/item/weapon/katana(src)
+		if(93)
+			new /obj/item/weapon/dnainjector/xraymut(src)
+		if(94)
+			new /obj/item/weapon/storage/backpack/clown(src)
+			new /obj/item/clothing/under/rank/clown(src)
+			new /obj/item/clothing/shoes/clown_shoes(src)
+			new /obj/item/device/pda/clown(src)
+			new /obj/item/clothing/mask/gas/clown_hat(src)
+			new /obj/item/weapon/bikehorn(src)
+			new /obj/item/toy/crayon/rainbow(src)
+			new /obj/item/weapon/reagent_containers/spray/waterflower(src)
+		if(95)
+			new /obj/item/clothing/under/mime(src)
+			new /obj/item/clothing/shoes/black(src)
+			new /obj/item/device/pda/mime(src)
+			new /obj/item/clothing/gloves/color/white(src)
+			new /obj/item/clothing/mask/gas/mime(src)
+			new /obj/item/clothing/head/beret(src)
+			new /obj/item/clothing/suit/suspenders(src)
+			new /obj/item/toy/crayon/mime(src)
+			new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(src)
+		if(96)
+			new /obj/item/weapon/hand_tele(src)
+		if(97)
+			new /obj/item/clothing/mask/balaclava
+			new /obj/item/weapon/gun/projectile/automatic/pistol(src)
+			new /obj/item/ammo_box/magazine/m10mm(src)
+		if(98)
+			new /obj/item/weapon/katana/cursed(src)
+		if(99)
+			new /obj/item/weapon/storage/belt/champion(src)
+			new /obj/item/clothing/mask/luchador(src)
+		if(100)
+			new /obj/item/clothing/head/bearpelt(src)
+
+/obj/structure/closet/crate/secure/loot/attack_hand(mob/user)
 	if(locked)
-		to_chat(user, "<span class='notice'>The crate is locked with a Deca-code lock.</span>")
-		var/input = input(usr, "Enter digit from [min] to [max].", "Deca-Code Lock", "") as num
+		user << "<span class='notice'>The crate is locked with a Deca-code lock.</span>"
+		var/input = input(usr, "Enter [codelen] digits.", "Deca-Code Lock", "") as text
 		if(in_range(src, user))
-			input = Clamp(input, 0, 10)
 			if (input == code)
-				to_chat(user, "<span class='notice'>The crate unlocks!</span>")
+				user << "<span class='notice'>The crate unlocks!</span>"
 				locked = 0
 				overlays.Cut()
-				overlays += greenlight
-			else if (input == null || input > max || input < min)
-				to_chat(user, "<span class='notice'>You leave the crate alone.</span>")
+				overlays += "securecrateg"
+			else if (input == null || length(input) != codelen)
+				user << "<span class='notice'>You leave the crate alone.</span>"
 			else
-				to_chat(user, "<span class='warning'>A red light flashes.</span>")
-				lastattempt = input
+				user << "<span class='warning'>A red light flashes.</span>"
+				lastattempt = replacetext(input, 0, "z")
 				attempts--
-				if (attempts == 0)
-					to_chat(user, "<span class='danger'>The crate's anti-tamper system activates!</span>")
-					var/turf/T = get_turf(src.loc)
-					explosion(T, -1, -1, 1, 1)
-					qdel(src)
-					return
-		else
-			to_chat(user, "<span class='notice'>You attempt to interact with the device using a hand gesture, but it appears this crate is from before the DECANECT came out.</span>")
-			return
+				if(attempts == 0)
+					boom(user)
 	else
 		return ..()
 
-/obj/structure/closet/crate/secure/loot/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+/obj/structure/closet/crate/secure/loot/attack_animal(mob/user)
+	boom(user)
+
+/obj/structure/closet/crate/secure/loot/attackby(obj/item/weapon/W, mob/user)
 	if(locked)
-		if (istype(W, /obj/item/weapon/card/emag))
-			to_chat(user, "<span class='notice'>The crate unlocks!</span>")
-			locked = 0
-		if (istype(W, /obj/item/device/multitool))
-			to_chat(user, "<span class='notice'>DECA-CODE LOCK REPORT:</span>")
-			if (attempts == 1)
-				to_chat(user, "<span class='warning'>* Anti-Tamper Bomb will activate on next failed access attempt.</span>")
+		if(istype(W, /obj/item/weapon/card/emag))
+			boom(user)
+		if(istype(W, /obj/item/device/multitool))
+			user << "<span class='notice'>DECA-CODE LOCK REPORT:</span>"
+			if(attempts == 1)
+				user << "<span class='warning'>* Anti-Tamper Bomb will activate on next failed access attempt.</span>"
 			else
-				to_chat(user, "<span class='notice'>* Anti-Tamper Bomb will activate after [src.attempts] failed access attempts.</span>")
-			if (lastattempt == null)
-				to_chat(user, "<span class='notice'> has been made to open the crate thus far.</span>")
-				return
-			// hot and cold
-			if (code > lastattempt)
-				to_chat(user, "<span class='notice'>* Last access attempt lower than expected code.</span>")
-			else
-				to_chat(user, "<span class='notice'>* Last access attempt higher than expected code.</span>")
+				user << "<span class='notice'>* Anti-Tamper Bomb will activate after [src.attempts] failed access attempts.</span>"
+			if(lastattempt != null)
+				var/list/guess = list()
+				var/bulls = 0
+				var/cows = 0
+				for(var/i = 1, i < codelen + 1, i++)
+					var/a = copytext(lastattempt, i, i+1) //Stuff the code into the list
+					guess += a
+					guess[a] = i
+				for(var/i in guess) //Go through list and count matches
+					var/a = findtext(code, i)
+					if(a == guess[i])
+						++bulls
+					else if(a)
+						++cows
+				user << "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>"
 		else ..()
 	else ..()
+
+/obj/structure/closet/crate/secure/loot/togglelock(mob/user)
+	if(locked)
+		boom(user)
+	else
+		..()
+
+/obj/structure/closet/crate/secure/loot/proc/boom(mob/user)
+	user << "<span class='danger'>The crate's anti-tamper system activates!</span>"
+	for(var/atom/movable/AM in src)
+		qdel(AM)
+	var/turf/T = get_turf(src)
+	explosion(T, -1, -1, 1, 1)
+	qdel(src)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -153,18 +153,18 @@
 
 /obj/structure/closet/crate/secure/loot/attack_hand(mob/user)
 	if(locked)
-		user << "<span class='notice'>The crate is locked with a Deca-code lock.</span>"
+		to_chat(user, "<span class='notice'>The crate is locked with a Deca-code lock.</span>")
 		var/input = input(usr, "Enter [codelen] digits.", "Deca-Code Lock", "") as text
 		if(in_range(src, user))
 			if (input == code)
-				user << "<span class='notice'>The crate unlocks!</span>"
+				to_chat(user, "<span class='notice'>The crate unlocks!</span>")
 				locked = 0
 				overlays.Cut()
 				overlays += "securecrateg"
 			else if (input == null || length(input) != codelen)
-				user << "<span class='notice'>You leave the crate alone.</span>"
+				to_chat(user, "<span class='notice'>You leave the crate alone.</span>")
 			else
-				user << "<span class='warning'>A red light flashes.</span>"
+				to_chat(user, "<span class='warning'>A red light flashes.</span>")
 				lastattempt = replacetext(input, 0, "z")
 				attempts--
 				if(attempts == 0)
@@ -180,11 +180,11 @@
 		if(istype(W, /obj/item/weapon/card/emag))
 			boom(user)
 		if(istype(W, /obj/item/device/multitool))
-			user << "<span class='notice'>DECA-CODE LOCK REPORT:</span>"
+			to_chat(user, "<span class='notice'>DECA-CODE LOCK REPORT:</span>")
 			if(attempts == 1)
-				user << "<span class='warning'>* Anti-Tamper Bomb will activate on next failed access attempt.</span>"
+				to_chat(user, "<span class='warning'>* Anti-Tamper Bomb will activate on next failed access attempt.</span>")
 			else
-				user << "<span class='notice'>* Anti-Tamper Bomb will activate after [src.attempts] failed access attempts.</span>"
+				to_chat(user, "<span class='notice'>* Anti-Tamper Bomb will activate after [src.attempts] failed access attempts.</span>")
 			if(lastattempt != null)
 				var/list/guess = list()
 				var/bulls = 0
@@ -199,7 +199,7 @@
 						++bulls
 					else if(a)
 						++cows
-				user << "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>"
+				to_chat(user, "<span class='notice'>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</span>")
 		else ..()
 	else ..()
 
@@ -210,7 +210,7 @@
 		..()
 
 /obj/structure/closet/crate/secure/loot/proc/boom(mob/user)
-	user << "<span class='danger'>The crate's anti-tamper system activates!</span>"
+	to_chat(user, "<span class='danger'>The crate's anti-tamper system activates!</span>")
 	for(var/atom/movable/AM in src)
 		qdel(AM)
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -107,8 +107,8 @@
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/orange(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/color/brown(H), slot_w_uniform)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/corgisuit(H), slot_wear_suit)
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/corgi(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/corgisuit/super_hero(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/corgi/super_hero(H), slot_head)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/yellow(H), slot_gloves)
 	H.equip_to_slot_or_del(new /obj/item/weapon/bedsheet/orange(H), slot_back)
 
@@ -126,8 +126,8 @@
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black/greytide(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(H), slot_w_uniform)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/corgisuit/en(H), slot_wear_suit)
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/corgi/en(H), slot_head)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/corgisuit/super_hero/en(H), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/clothing/head/corgi/super_hero/en(H), slot_head)
 	H.equip_to_slot_or_del(new /obj/item/weapon/bedsheet/cult(H), slot_back)
 
 


### PR DESCRIPTION
Updates Mining Loot Crates to TG's versions.

Instead of being a simple 1 digit password to guess (and you get 3 chances), this is a 4 digit password that you get 10 tries to guess.

Loot from these is better and more diversified.

Related:
- Changes Ian costume to be normal, again---super hero variants are available which have NO_DROP on them still (regular Ian costume is crate loot) 
- Adds in cursed Katana, which has its slot flags removed (available in mining loot crates)
- Fixes up katana so its sound behavior is consistent with other weapons
- Cash seed can be admin spawned as an object

:cl: Fox McCloud
Add: Updates mining loot crates to feature far more actual loot
Tweak: Mining loot crates are now opened by inputting a 4 digit password and have 10 tries to guess the password string
/:cl: