### PR TITLE
Fix ERT teleport exploit with abductor

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
@@ -96,7 +96,7 @@
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
 	var/obj/machinery/abductor/pad/P = target
 
-	if(cameranet.checkTurfVis(remote_eye.loc))
+	if(cameranet.checkTurfVis(remote_eye.loc) && !(remote_eye.loc in config.admin_levels))
 		P.PadToLoc(remote_eye.loc)
 
 /datum/action/teleport_out
@@ -123,7 +123,7 @@
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
 	var/obj/machinery/abductor/pad/P = target
 
-	if(cameranet.checkTurfVis(remote_eye.loc))
+	if(cameranet.checkTurfVis(remote_eye.loc) && !(remote_eye.loc in config.admin_levels))
 		P.MobToLoc(remote_eye.loc,C)
 
 /datum/action/vest_mode_swap


### PR DESCRIPTION
https://www.youtube.com/watch?v=hWYtlSSp80A

This fixes the above exploit, in which you can teleport to the ERT area.