### PR TITLE
Makes a human's species visible on examine.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -52,16 +52,16 @@
 				t_his = "her"
 				t_him = "her"
 
-	msg += "<EM>[src.name]</EM>"
+	msg += "<EM>[name]</EM>"
 
 	var/list/nospecies = list("Abductor", "Shadowling", "Neara", "Monkey", "Stok", "Farwa", "Wolpin") //species that won't show their race no matter what
 
-	if (skipjumpsuit && skipface || (src.species.name in nospecies)) //either obscured or on the nospecies list
+	if (skipjumpsuit && skipface || (species.name in nospecies)) //either obscured or on the nospecies list
 		msg += "!\n"	//omit the species when examining
-	else if (src.species.name == "Slime People") //snowflakey because Slime People are defined as a plural
+	else if (species.name == "Slime People") //snowflakey because Slime People are defined as a plural
 		msg += ", a Slime Person!\n"
 	else
-		msg += ", a [src.species]!\n"
+		msg += ", \a [lowertext(species.name)]!\n"
 
 	//uniform
 	if(w_uniform && !skipjumpsuit)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -59,7 +59,7 @@
 	if (skipjumpsuit && skipface || (species.name in nospecies)) //either obscured or on the nospecies list
 		msg += "!\n"	//omit the species when examining
 	else if (species.name == "Slime People") //snowflakey because Slime People are defined as a plural
-		msg += ", a Slime Person!\n"
+		msg += ", a slime person!\n"
 	else
 		msg += ", \a [lowertext(species.name)]!\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -33,7 +33,7 @@
 
 	var/msg = "<span class='info'>*---------*\nThis is "
 
-	if( skipjumpsuit && skipface ) //big suits/masks/helmets make it hard to tell their gender
+	if(skipjumpsuit && skipface) //big suits/masks/helmets make it hard to tell their gender
 		t_He = "They"
 		t_his = "their"
 		t_him = "them"
@@ -52,7 +52,16 @@
 				t_his = "her"
 				t_him = "her"
 
-	msg += "<EM>[src.name]</EM>!\n"
+	msg += "<EM>[src.name]</EM>"
+
+	var/list/nospecies = list("Abductor", "Shadowling", "Neara", "Monkey", "Stok", "Farwa", "Wolpin") //species that won't show their race no matter what
+
+	if (skipjumpsuit && skipface || (src.species.name in nospecies)) //either obscured or on the nospecies list
+		msg += "!\n"	//omit the species when examining
+	else if (src.species.name == "Slime People") //snowflakey because Slime People are defined as a plural
+		msg += ", a Slime Person!\n"
+	else
+		msg += ", a [src.species]!\n"
 
 	//uniform
 	if(w_uniform && !skipjumpsuit)


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: a human's species is now visible on examination
/:cl:

As simple as it gets, a human's (this mean any playable species) species will now be visible on examination on the same conditions as their gender already is.

![wetskrell](https://i.gyazo.com/7f8c0dfe82d0d005002dd0794e81857c.png)

If the game doesn't refer to a person as "they", it will tell you their gender and species.

![nuu](https://i.gyazo.com/3d82e664632c5e9264c9dc4e033c8fdf.png)

A few species are excluded from this treatment: 
- all monkey types to avoid "neara (420), a neara!"
- Abductors, because nobody knows what the hell they are
- Shadowlings, because they're shadowy and stuff