### PR TITLE
Removes egg reagent from some foods, fixes reagent removal for foods

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -2206,6 +2206,9 @@
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("gold", 5)
+		spawn(1)
+			reagents.del_reagent("egg")
+			reagents.update_total()
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/dough_ball
@@ -2581,6 +2584,9 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
+		spawn(1)
+			reagents.del_reagent("egg")
+			reagents.update_total()
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice
@@ -3013,6 +3019,9 @@
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("sugar", 5)
+		spawn(1)
+			reagents.del_reagent("egg")
+			reagents.update_total()
 		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/friedbanana

--- a/code/modules/reagents/reagent_containers/food/snacks/candy.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/candy.dm
@@ -66,6 +66,9 @@
 	..()
 	reagents.add_reagent("nutriment", 3)
 	reagents.add_reagent("sugar", 3)
+	spawn(1)
+		reagents.del_reagent("egg")
+		reagents.update_total()
 	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/taffy
@@ -287,8 +290,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/poison/New()
 	..()
 	reagents.add_reagent("poisonberryjuice", 12)
-	reagents.del_reagent("sugar")
-	reagents.update_total()
+	spawn(1)
+		reagents.del_reagent("sugar")
+		reagents.update_total()
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/green
@@ -381,8 +385,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/poison/New()
 	..()
 	reagents.add_reagent("poisonberryjuice", 12)
-	reagents.del_reagent("sugar")
-	reagents.update_total()
+	spawn(1)
+		reagents.del_reagent("sugar")
+		reagents.update_total()
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/green
@@ -475,8 +480,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/poison/New()
 	..()
 	reagents.add_reagent("poisonberryjuice", 12)
-	reagents.del_reagent("sugar")
-	reagents.update_total()
+	spawn(1)
+		reagents.del_reagent("sugar")
+		reagents.update_total()
 	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/green
@@ -627,8 +633,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/poison/New()
 	..()
 	reagents.add_reagent("poisonberryjuice", 20)
-	reagents.del_reagent("sugar")
-	reagents.update_total()
+	spawn(1)
+		reagents.del_reagent("sugar")
+		reagents.update_total()
 	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/green
@@ -701,8 +708,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/rainbow/New()
 	..()
 	reagents.add_reagent("omnizine", 20)
-	reagents.del_reagent("sugar")
-	reagents.update_total()
+	spawn(1)
+		reagents.del_reagent("sugar")
+		reagents.update_total()
 	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/bad_rainbow
@@ -715,8 +723,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/bad_rainbow/New()
 	..()
 	reagents.add_reagent("sulfonal", 20)
-	reagents.del_reagent("sugar")
-	reagents.update_total()
+	spawn(1)
+		reagents.del_reagent("sugar")
+		reagents.update_total()
 	bitesize = 4
 
 // ***********************************************************

--- a/code/modules/reagents/reagent_containers/food/snacks/seafood.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/seafood.dm
@@ -63,6 +63,9 @@
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("carpotoxin", 3)
+		spawn(1)
+			reagents.del_reagent("egg")
+			reagents.update_total()
 		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/fishburger


### PR DESCRIPTION
Simply put, this removes the egg reagent from the following chef-produced food items:
- Bread
- Apple Tart
- Sugar Cookie
- Fish Fingers
- Nougat

Balance-wise, this really does very little (except make it so bread doesn't make you fart), and should generally impact just about nothing short of feeding people grilled cheese sandwiches to cause them to fart on a bible.

At the same time, this introduces a couple spawn(1) into the New() code for food items that are meant to clear certain reagents when made (like removing sugar from some candies or egg from bread), to make it so they actually remove the reagent.
- Since this was getting called before the reagents of the ingredients are passed into the food through the cooking process, you'd end up with sugar in your rainbow cotton candy when it wasn't meant to be there.