### PR TITLE
Fixes braindead IPC death message spam

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -20,7 +20,7 @@
 	if(species.can_revive_by_healing)
 		var/obj/item/organ/internal/brain/B = get_int_organ(/obj/item/organ/internal/brain)
 		if(B)
-			if((health >= (config.health_threshold_dead + config.health_threshold_crit) * 0.5) && stat == DEAD)
+			if((health >= (config.health_threshold_dead + config.health_threshold_crit) * 0.5) && stat == DEAD && getBrainLoss()<120)
 				update_revive()
 	if(stat == CONSCIOUS && (src in dead_mob_list)) //Defib fix
 		update_revive()


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/3695
Changes the can_revive_by_healing proc to check for brain death in addition to brain presence.
Now IPCs killed by severe EMPs (or who drink ludicrous amounts of synthohol) will not spam the chat.

:cl:HugoLuman
fix: Adds a check for brain death (brain damage of 120 or more) to the proc responsible for reviving IPCs
/:cl:
Signed-off-by: HugoLuman <qaggeler@uci.edu>