### PR TITLE
Plasma security now spawn with their gun in the bag

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -249,7 +249,7 @@
 		H.equip_or_collect(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
 		H.equip_or_collect(new /obj/item/device/pda/security(H), slot_wear_pda)
 		H.equip_or_collect(new /obj/item/clothing/gloves/color/black(H), slot_gloves)
-		H.equip_or_collect(new /obj/item/weapon/gun/energy/advtaser(H), slot_belt)
+		H.equip_or_collect(new /obj/item/weapon/gun/energy/advtaser(H), slot_s_store)
 		H.equip_or_collect(new /obj/item/device/flash(H), slot_l_store)
 		if(H.backbag == 1)
 			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -251,6 +251,15 @@
 	icon_state = "plasmaman_RD_helmet0"
 	base_state = "plasmaman_RD_helmet"
 
+//MAGISTRATE
+/obj/item/clothing/suit/space/eva/plasmaman/magistrate
+	name = "plasmaman magistrate suit"
+	icon_state = "plasmaman_HoS"
+
+/obj/item/clothing/head/helmet/space/eva/plasmaman/magistrate
+	name = "plasmaman magistrate helmet"
+	icon_state = "plasmaman_HoS_helmet0"
+	base_state = "plasmaman_HoS_helmet"
 
 //SECURITY
 

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -66,8 +66,8 @@
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/
 			H.equip_or_collect(new /obj/item/weapon/gun/energy/advtaser(H), slot_in_backpack)
 		if("Magistrate")
-			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/hos
-			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/hos
+			suit=/obj/item/clothing/suit/space/eva/plasmaman/magistrate
+			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/magistrate
 		if("Head of Security")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/hos
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/hos

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -58,12 +58,20 @@
 		if("Life Support Specialist")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/atmostech
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/atmostech
-		if("Warden","Detective","Security Officer","Security Pod Pilot")
+		if("Detective")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/
-		if("Head of Security", "Magistrate")
+		if("Warden","Security Officer","Security Pod Pilot")
+			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/
+			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/
+			H.equip_or_collect(new /obj/item/weapon/gun/energy/advtaser(H), slot_in_backpack)
+		if("Magistrate")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/hos
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/hos
+		if("Head of Security")
+			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/hos
+			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/hos
+			H.equip_or_collect(new /obj/item/weapon/gun/energy/gun(H), slot_in_backpack)
 		if("Captain", "Blueshield")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/captain
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/captain
@@ -73,6 +81,7 @@
 		if("Medical Doctor","Brig Physician")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/medical
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/medical
+			H.equip_or_collect(new /obj/item/device/flashlight/pen(H), slot_in_backpack)
 		if("Paramedic")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/medical/paramedic
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/medical/paramedic


### PR DESCRIPTION
Fixes #4071

Warden, officers, and pod pilot spawn with the taser in their bag.
Head of Security spawns with egun in the bag.
Brig physician spawns with pen light in their bag.
Also made other species pod pilots spawn with the taser in their bomber
jacket, since it now can hold it, and is more consistent with the rest
of the officers

magistrate looses his armor too, watch out for paper cuts

:cl: pinatacolada
fix: Plasmamen security now spawn with their suit slot items in their
bags
tweak: Pod pilots spawn with taser in the suit slot
tweak: removes armor from plasmamen magistrate suits
/:cl: