### PR TITLE
Nutrition Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -646,11 +646,11 @@
 					H.healthdoll.overlays += image('icons/mob/screen_gen.dmi',"[O.limb_name][icon_num]")
 
 	switch(H.nutrition)
-		if(450 to INFINITY)
+		if(NUTRITION_LEVEL_FULL to INFINITY)
 			H.throw_alert("nutrition", /obj/screen/alert/fat)
-		if(350 to 450)
+		if(NUTRITION_LEVEL_HUNGRY to NUTRITION_LEVEL_FULL)
 			H.clear_alert("nutrition")
-		if(250 to 350)
+		if(NUTRITION_LEVEL_STARVING to NUTRITION_LEVEL_HUNGRY)
 			H.throw_alert("nutrition", /obj/screen/alert/hungry)
 		else
 			H.throw_alert("nutrition", /obj/screen/alert/starving)


### PR DESCRIPTION
Fixes the nutrition alert kicking in too early.

Also uses defines instead of magicalllll numbers.

:cl: Fox McCloud
fix: Fixes nutrition alert icon kicking in too early
/:cl: