### PR TITLE
Fixes Unathi examine message.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -60,6 +60,8 @@
 		msg += "!\n"	//omit the species when examining
 	else if (species.name == "Slime People") //snowflakey because Slime People are defined as a plural
 		msg += ", a slime person!\n"
+	else if (species.name == "Unathi") //DAMN YOU, VOWELS
+		msg += ", a unathi!\n"
 	else
 		msg += ", \a [lowertext(species.name)]!\n"
 


### PR DESCRIPTION
HOW COULD THE VOWEL HAVE ELUDED MY THOROUGH TESTING!?

Examining a lizerd won't say "an Unathi" anymore.

P S Also, just to be sure, we did a quick [grammar check](http://www.strawpoll.me/10057847/r) and it is indeed "a" that should be there.