### PR TITLE
Fixes reviving/rejuvenating while restrained fully clearing restraint

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -327,10 +327,13 @@
 		if (C.handcuffed && !initial(C.handcuffed))
 			C.unEquip(C.handcuffed)
 		C.handcuffed = initial(C.handcuffed)
+		C.update_handcuffed()
 
 		if (C.legcuffed && !initial(C.legcuffed))
 			C.unEquip(C.legcuffed)
 		C.legcuffed = initial(C.legcuffed)
+		C.update_inv_legcuffed()
+		
 		if(C.reagents)
 			for(var/datum/reagent/R in C.reagents.reagent_list)
 				C.reagents.clear_reagents()


### PR DESCRIPTION
The revive code wasn't updating the handcuffed status after removing the cuffs. It probably got broken by the action button PR or something.