### PR TITLE
Adds a noisy deletion timer to autosay mobs

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -275,7 +275,7 @@ var/global/list/default_medbay_channels = list(
 	..()
 
 /mob/living/automatedannouncer/proc/autocleanup()
-	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)], Loc: [src.locs[1]]"
+	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)], Loc: [src.loc.loc]"
 	qdel(src)
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -275,7 +275,7 @@ var/global/list/default_medbay_channels = list(
 	..()
 
 /mob/living/automatedannouncer/proc/autocleanup()
-	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)]"
+	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)]")
 	qdel(src)
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -251,6 +251,7 @@ var/global/list/default_medbay_channels = list(
 	var/mob/living/automatedannouncer/A = new /mob/living/automatedannouncer(src)
 	A.name = from
 	A.role = role
+	A.message = message
 	Broadcast_Message(connection, A,
 						0, "*garbled automated announcement*", src,
 						message, from, "Automated Announcement", from, "synthesized voice",
@@ -263,6 +264,7 @@ var/global/list/default_medbay_channels = list(
 /mob/living/automatedannouncer
 	var/role = ""
 	var/lifetime_timer
+	var/message = ""
 	universal_speak = 1
 
 /mob/living/automatedannouncer/New()
@@ -275,7 +277,7 @@ var/global/list/default_medbay_channels = list(
 	..()
 
 /mob/living/automatedannouncer/proc/autocleanup()
-	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)]")
+	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)], Name: \"[name]\", Message: \"[message]\"")
 	qdel(src)
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -262,7 +262,21 @@ var/global/list/default_medbay_channels = list(
 // I'm not sure who thought that was a good idea. -- Crazylemon
 /mob/living/automatedannouncer
 	var/role = ""
+	var/lifetime_timer
 	universal_speak = 1
+
+/mob/living/automatedannouncer/New()
+	lifetime_timer = addtimer(src, "autocleanup", SecondsToTicks(10))
+	..()
+
+/mob/living/automatedannouncer/Destroy()
+	if(lifetime_timer)
+		deltimer(lifetime_timer)
+	..()
+
+/mob/living/automatedannouncer/proc/autocleanup()
+	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)], Loc: [src.locs[1]]"
+	qdel(src)
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum
 /obj/item/device/radio/proc/handle_message_mode(mob/living/M as mob, message, message_mode)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -275,7 +275,7 @@ var/global/list/default_medbay_channels = list(
 	..()
 
 /mob/living/automatedannouncer/proc/autocleanup()
-	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)], Loc: [src.loc.loc]"
+	log_debug("An announcer somehow managed to outlive the radio! Deleting! Area: [get_area(src)]"
 	qdel(src)
 
 // Interprets the message mode when talking into a radio, possibly returning a connection datum


### PR DESCRIPTION
This is to satisfy @Fox-McCloud - this way, it doesn't fail silently, and we have a rough idea of when it's going on.