### PR TITLE
Makes explosions not take forever, fixes some pipe deletion stuff

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -141,6 +141,9 @@ Pipelines + Other Objects -> Pipe network
 	// Called to build a network from this node
 	return
 
+/obj/machinery/atmospherics/proc/defer_build_network()
+	deferred_pipenet_rebuilds += src
+
 /obj/machinery/atmospherics/proc/disconnect(obj/machinery/atmospherics/reference)
 	return
 

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -8,7 +8,7 @@
 
 	var/obj/machinery/atmospherics/node1
 	var/obj/machinery/atmospherics/node2
-	
+
 	var/datum/pipeline/parent1
 	var/datum/pipeline/parent2
 
@@ -23,7 +23,7 @@
 			initialize_directions = EAST|WEST
 		if(WEST)
 			initialize_directions = EAST|WEST
-		
+
 	air1 = new
 	air2 = new
 
@@ -89,6 +89,8 @@
 
 /obj/machinery/atmospherics/binary/nullifyPipenet(datum/pipeline/P)
 	..()
+	if(!P)
+		return
 	if(P == parent1)
 		parent1.other_airs -= air1
 		parent1 = null
@@ -128,7 +130,7 @@
 		parent1 = New
 	else if(Old == parent2)
 		parent2 = New
-	
+
 /obj/machinery/atmospherics/binary/unsafe_pressure_release(var/mob/user,var/pressures)
 	..()
 
@@ -144,4 +146,7 @@
 		to_release.merge(air2.remove(shared_loss))
 		T.assume_air(to_release)
 		air_update_turf(1)
-	
+
+/obj/machinery/atmospherics/binary/process()
+	..()
+	return parent1 && parent2

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -48,7 +48,8 @@
 		return removed
 
 /obj/machinery/atmospherics/binary/circulator/process()
-	..()
+	if(!..())
+		return 0
 	if(last_worldtime_transfer < world.time - 50)
 		recent_moles_transferred = 0
 		update_icon()

--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -32,19 +32,19 @@
 	//1: Do not pass external_pressure_bound
 	//2: Do not pass input_pressure_min
 	//4: Do not pass output_pressure_max
-	
+
 /obj/machinery/atmospherics/binary/dp_vent_pump/New()
 	..()
 	if (!id_tag)
 		assign_uid()
 		id_tag = num2text(uid)
 	icon = null
-	
+
 /obj/machinery/atmospherics/binary/dp_vent_pump/initialize()
 	..()
 	if(frequency)
 		set_frequency(frequency)
-	
+
 /obj/machinery/atmospherics/binary/dp_vent_pump/high_volume
 	name = "large dual port air vent"
 
@@ -103,9 +103,7 @@
 				add_underlay(T, node2, dir)
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/process()
-	..()
-
-	if(!on)
+	if(!..() || !on)
 		return 0
 
 	var/datum/gas_mixture/environment = loc.return_air()
@@ -236,7 +234,7 @@
 	if(istype(W, /obj/item/device/multitool))
 		update_multitool_menu(user)
 		return 1
-		
+
 	return ..()
 
 /obj/machinery/atmospherics/binary/dp_vent_pump/multitool_menu(var/mob/user,var/obj/item/device/multitool/P)
@@ -254,5 +252,4 @@
 		return .
 	if("toggleadvcontrol" in href_list)
 		advcontrol = !advcontrol
-		return MT_UPDATE	
-		
+		return MT_UPDATE

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -6,7 +6,7 @@
 
 	name = "passive gate"
 	desc = "A one-way air valve that does not require power"
-	
+
 	can_unwrench = 1
 
 	var/on = 0
@@ -15,7 +15,7 @@
 	var/frequency = 0
 	var/id = null
 	var/datum/radio_frequency/radio_connection
-	
+
 /obj/machinery/atmospherics/binary/passive_gate/initialize()
 	..()
 	if(frequency)
@@ -34,8 +34,7 @@
 		add_underlay(T, node2, dir)
 
 /obj/machinery/atmospherics/binary/passive_gate/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
 
 	var/output_starting_pressure = air2.return_pressure()
@@ -60,6 +59,7 @@
 		parent1.update = 1
 
 		parent2.update = 1
+	return 1
 
 //Radio remote control
 /obj/machinery/atmospherics/binary/passive_gate/proc/set_frequency(new_frequency)
@@ -100,7 +100,7 @@
 /obj/machinery/atmospherics/binary/passive_gate/receive_signal(datum/signal/signal)
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return 0
-	
+
 	var/old_on = on //for logging
 
 	if("power" in signal.data)
@@ -115,7 +115,7 @@
 			text2num(signal.data["set_output_pressure"]),
 			ONE_ATMOSPHERE*50
 		)
-		
+
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", "atmos")
 
@@ -161,4 +161,3 @@
 		to_chat(user, "<span class='alert'>You cannot unwrench this [src], turn it off first.</span>")
 		return 1
 	return ..()
-	

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -15,10 +15,10 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/pump
 	icon = 'icons/atmos/pump.dmi'
 	icon_state = "map_off"
-	
+
 	name = "gas pump"
 	desc = "A pump"
-	
+
 	can_unwrench = 1
 
 	var/on = 0
@@ -54,10 +54,7 @@ Thus, the two variables affect pump operation are set in New():
 		add_underlay(T, node2, dir)
 
 /obj/machinery/atmospherics/binary/pump/process()
-//		..()
-	if(stat & (NOPOWER|BROKEN))
-		return
-	if(!on)
+	if(!..() || (stat & (NOPOWER|BROKEN)) || !on)
 		return 0
 
 	var/output_starting_pressure = air2.return_pressure()
@@ -123,7 +120,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/pump/receive_signal(datum/signal/signal)
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return 0
-	
+
 	var/old_on = on //for logging
 
 	if(signal.data["power"])
@@ -138,7 +135,7 @@ Thus, the two variables affect pump operation are set in New():
 			text2num(signal.data["set_output_pressure"]),
 			ONE_ATMOSPHERE*50
 		)
-		
+
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", "atmos")
 
@@ -164,7 +161,7 @@ Thus, the two variables affect pump operation are set in New():
 	return
 
 /obj/machinery/atmospherics/binary/pump/Topic(href,href_list)
-	if(..()) 
+	if(..())
 		return 1
 	if(href_list["power"])
 		on = !on

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -18,7 +18,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	name = "volumetric gas pump"
 	desc = "A volumetric pump"
-	
+
 	can_unwrench = 1
 
 	var/on = 0
@@ -31,7 +31,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/volume_pump/on
 	on = 1
 	icon_state = "map_on"
-	
+
 /obj/machinery/atmospherics/binary/volume_pump/initialize()
 	..()
 	set_frequency(frequency)
@@ -52,9 +52,7 @@ Thus, the two variables affect pump operation are set in New():
 		add_underlay(T, node2, dir)
 
 /obj/machinery/atmospherics/binary/volume_pump/process()
-	if(stat & (NOPOWER|BROKEN))
-		return
-	if(!on)
+	if(!..() || (stat & (NOPOWER|BROKEN)) || !on)
 		return 0
 
 	// Pump mechanism just won't do anything if the pressure is too high/too low
@@ -114,7 +112,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/volume_pump/receive_signal(datum/signal/signal)
 	if(!signal.data["tag"] || (signal.data["tag"] != id) || (signal.data["sigtype"]!="command"))
 		return 0
-	
+
 	var/old_on = on //for logging
 
 	if(signal.data["power"])
@@ -129,7 +127,7 @@ Thus, the two variables affect pump operation are set in New():
 			text2num(signal.data["set_transfer_rate"]),
 			air1.volume
 		)
-		
+
 	if(on != old_on)
 		investigate_log("was turned [on ? "on" : "off"] by a remote signal", "atmos")
 
@@ -154,7 +152,7 @@ Thus, the two variables affect pump operation are set in New():
 	return
 
 /obj/machinery/atmospherics/binary/volume_pump/Topic(href,href_list)
-	if(..()) 
+	if(..())
 		return 1
 	if(href_list["power"])
 		on = !on

--- a/code/ATMOSPHERICS/components/omni_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/filter.dm
@@ -43,12 +43,11 @@
 	return 0
 
 /obj/machinery/atmospherics/omni/filter/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
 
 	if(!input || !output)
-		return
+		return 0
 
 	var/datum/gas_mixture/output_air = output.air	//BYOND doesn't like referencing "output.air.return_pressure()" so we need to make a direct reference
 	var/datum/gas_mixture/input_air = input.air		// it's completely happy with them if they're in a loop though i.e. "P.air.return_pressure()"... *shrug*
@@ -56,10 +55,10 @@
 	var/output_pressure = output_air.return_pressure()
 
 	if(output_pressure >= target_pressure)
-		return
+		return 1
 	for(var/datum/omni_port/P in filters)
 		if(P.air.return_pressure() >= target_pressure)
-			return
+			return 1
 
 	var/pressure_delta = target_pressure - output_pressure
 
@@ -70,7 +69,7 @@
 		var/datum/gas_mixture/removed = input_air.remove(input.transfer_moles)
 
 		if(!removed)
-			return
+			return 1
 
 		for(var/datum/omni_port/P in filters)
 			var/datum/gas_mixture/filtered_out = new
@@ -107,7 +106,7 @@
 		input.transfer_moles = 0
 		input.parent.update = 1
 
-	return
+	return 1
 
 /obj/machinery/atmospherics/omni/filter/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null)
 	usr.set_machine(src)
@@ -177,7 +176,7 @@
 			return null
 
 /obj/machinery/atmospherics/omni/filter/Topic(href, href_list)
-	if(..()) 
+	if(..())
 		return 1
 	switch(href_list["command"])
 		if("power")
@@ -277,4 +276,3 @@
 			initialize_directions |= P.dir
 			P.connect()
 	P.update = 1
-	

--- a/code/ATMOSPHERICS/components/omni_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/mixer.dm
@@ -84,8 +84,7 @@
 	return 0
 
 /obj/machinery/atmospherics/omni/mixer/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
 
 	var/datum/gas_mixture/output_air = output.air
@@ -108,7 +107,7 @@
 
 	for(var/datum/omni_port/P in inputs)
 		if(!P.transfer_moles)
-			return
+			return 1
 		if(P.air.total_moles() < P.transfer_moles)
 			ratio_check = 1
 			continue
@@ -180,7 +179,7 @@
 	return data
 
 /obj/machinery/atmospherics/omni/mixer/Topic(href, href_list)
-	if(..()) 
+	if(..())
 		return 1
 
 	switch(href_list["command"])
@@ -295,4 +294,3 @@
 	for(var/datum/omni_port/P in inputs)
 		if(P.dir == port)
 			P.con_lock = !P.con_lock
-		

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -7,7 +7,7 @@
 	icon_state = "base"
 	use_power = 1
 	initialize_directions = 0
-	
+
 	can_unwrench = 1
 
 	var/on = 0
@@ -47,7 +47,7 @@
 		ports += new_port
 
 	build_icons()
-	
+
 /obj/machinery/atmospherics/omni/Destroy()
 	for(var/datum/omni_port/P in ports)
 		if(P.node)
@@ -234,13 +234,13 @@
 /obj/machinery/atmospherics/omni/proc/sort_ports()
 	return
 
-// Pipenet procs	
+// Pipenet procs
 /obj/machinery/atmospherics/omni/build_network()
 	for(var/datum/omni_port/P in ports)
 		if(!P.parent)
 			P.parent = new /datum/pipeline()
-			P.parent.build_pipeline(src)	
-	
+			P.parent.build_pipeline(src)
+
 /obj/machinery/atmospherics/omni/disconnect(obj/machinery/atmospherics/reference)
 	for(var/datum/omni_port/P in ports)
 		if(reference == P.node)
@@ -248,14 +248,16 @@
 				qdel(P.parent)
 			P.node = null
 	update_ports()
-	
+
 /obj/machinery/atmospherics/omni/nullifyPipenet(datum/pipeline/P)
 	..()
+	if(!P)
+		return
 	for(var/datum/omni_port/PO in ports)
 		if(P == PO.parent)
 			PO.parent.other_airs -= PO.air
 			PO.parent = null
-	
+
 /obj/machinery/atmospherics/omni/returnPipenetAir(datum/pipeline/P)
 	for(var/datum/omni_port/PO in ports)
 		if(P == PO.parent)
@@ -270,14 +272,14 @@
 		var/list/nodes = list()
 		for(var/datum/omni_port/PO in ports)
 			nodes += PO.node
-			
+
 		return nodes
-		
+
 /obj/machinery/atmospherics/omni/setPipenet(datum/pipeline/P, obj/machinery/atmospherics/A)
 	for(var/datum/omni_port/PO in ports)
 		if(A == PO.node)
 			PO.parent = P
-		
+
 /obj/machinery/atmospherics/omni/returnPipenet(obj/machinery/atmospherics/A)
 	for(var/datum/omni_port/P in ports)
 		if(A == P.node)
@@ -287,3 +289,11 @@
 	for(var/datum/omni_port/P in ports)
 		if(Old == P.parent)
 			P.parent = New
+
+
+/obj/machinery/atmospherics/omni/process()
+	..()
+	for(var/datum/omni_port/port in ports)
+		if(!port.parent)
+			return 0
+	return 1

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -3,7 +3,7 @@
 	icon_state = "map"
 
 	can_unwrench = 1
-	
+
 	name = "gas filter"
 
 	var/temp = null // -- TLE
@@ -23,7 +23,7 @@ Filter types:
 
 	var/frequency = 0
 	var/datum/radio_frequency/radio_connection
-	
+
 /obj/machinery/atmospherics/trinary/filter/flipped
 	icon_state = "mmap"
 	flipped = 1
@@ -71,8 +71,7 @@ Filter types:
 		update_icon()
 
 /obj/machinery/atmospherics/trinary/filter/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
 
 	var/output_starting_pressure = air3.return_pressure()
@@ -223,4 +222,3 @@ Filter types:
 			src.attack_hand(M)
 */
 	return
-	

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -3,7 +3,7 @@
 	icon_state = "map"
 
 	can_unwrench = 1
-	
+
 	name = "gas mixer"
 
 	var/target_pressure = ONE_ATMOSPHERE
@@ -11,15 +11,15 @@
 	var/node2_concentration = 0.5
 
 	//node 3 is the outlet, nodes 1 & 2 are intakes
-	
+
 /obj/machinery/atmospherics/trinary/mixer/flipped
 	icon_state = "mmap"
 	flipped = 1
 
 /obj/machinery/atmospherics/trinary/mixer/update_icon(var/safety = 0)
 	if(flipped)
-		icon_state = "m"	
-	else	
+		icon_state = "m"
+	else
 		icon_state = ""
 
 	if(!powered())
@@ -57,8 +57,7 @@
 	air3.volume = 300
 
 /obj/machinery/atmospherics/trinary/mixer/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
 
 	var/output_starting_pressure = air3.return_pressure()
@@ -141,7 +140,7 @@
 	return
 
 /obj/machinery/atmospherics/trinary/mixer/Topic(href,href_list)
-	if(..()) 
+	if(..())
 		return 1
 	if(href_list["power"])
 		on = !on

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -21,7 +21,7 @@
 
 /obj/machinery/atmospherics/trinary/New()
 	..()
-	
+
 	if(!flipped)
 		switch(dir)
 			if(NORTH)
@@ -41,8 +41,8 @@
 			if(EAST)
 				initialize_directions = WEST|EAST|NORTH
 			if(WEST)
-				initialize_directions = EAST|WEST|SOUTH		
-		
+				initialize_directions = EAST|WEST|SOUTH
+
 	air1 = new
 	air2 = new
 	air3 = new
@@ -65,7 +65,7 @@
 		node3 = null
 		nullifyPipenet(parent3)
 	return ..()
-	
+
 /obj/machinery/atmospherics/trinary/initialize()
 	..()
 	//Mixer:
@@ -134,6 +134,8 @@
 
 /obj/machinery/atmospherics/trinary/nullifyPipenet(datum/pipeline/P)
 	..()
+	if(!P)
+		return
 	if(P == parent1)
 		parent1.other_airs -= air1
 		parent1 = null
@@ -185,7 +187,7 @@
 		parent2 = New
 	else if(Old == parent3)
 		parent3 = New
-	
+
 /obj/machinery/atmospherics/trinary/unsafe_pressure_release(var/mob/user,var/pressures)
 	..()
 
@@ -203,4 +205,7 @@
 		to_release.merge(air3.remove(shared_loss))
 		T.assume_air(to_release)
 		air_update_turf(1)
-		
+
+/obj/machinery/atmospherics/trinary/process()
+	..()
+	return parent1 && parent2 && parent3

--- a/code/ATMOSPHERICS/components/unary_devices/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/cold_sink.dm
@@ -23,9 +23,9 @@
 	return
 
 /obj/machinery/atmospherics/unary/cold_sink/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
+	
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/combined_heat_capacity = current_heat_capacity + air_heat_capacity
 	var/old_temperature = air_contents.temperature

--- a/code/ATMOSPHERICS/components/unary_devices/heat_exchanger.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/heat_exchanger.dm
@@ -5,7 +5,7 @@
 
 	name = "heat exchanger"
 	desc = "Exchanges heat between two input gases. Setup for fast heat transfer"
-	
+
 	can_unwrench = 1
 
 	var/obj/machinery/atmospherics/unary/heat_exchanger/partner = null
@@ -32,7 +32,8 @@
 	..()
 
 /obj/machinery/atmospherics/unary/heat_exchanger/process()
-	..()
+	if(!..())
+		return 0
 	if(!partner)
 		return 0
 

--- a/code/ATMOSPHERICS/components/unary_devices/heat_source.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/heat_source.dm
@@ -23,8 +23,7 @@
 	return
 
 /obj/machinery/atmospherics/unary/heat_reservoir/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
 	var/air_heat_capacity = air_contents.heat_capacity()
 	var/combined_heat_capacity = current_heat_capacity + air_heat_capacity

--- a/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/outlet_injector.dm
@@ -5,7 +5,7 @@
 	layer = 3
 
 	can_unwrench = 1
-	
+
 	name = "air injector"
 	desc = "Has a valve and pump attached to it"
 
@@ -22,7 +22,7 @@
 	var/datum/radio_frequency/radio_connection
 	Mtoollink = 1
 	settagwhitelist = list("id_tag")
-	
+
 /obj/machinery/atmospherics/unary/outlet_injector/on
 	on = 1
 
@@ -52,7 +52,9 @@
 		update_icon()
 
 /obj/machinery/atmospherics/unary/outlet_injector/process()
-	..()
+	if(!..())
+		return 0
+	
 	injecting = 0
 
 	if(!on || stat & NOPOWER)

--- a/code/ATMOSPHERICS/components/unary_devices/oxygen_generator.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/oxygen_generator.dm
@@ -29,8 +29,7 @@
 	air_contents.volume = 50
 
 /obj/machinery/atmospherics/unary/oxygen_generator/process()
-	..()
-	if(!on)
+	if(!..() || !on)
 		return 0
 
 	var/total_moles = air_contents.total_moles()

--- a/code/ATMOSPHERICS/components/unary_devices/passive_vent.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/passive_vent.dm
@@ -6,38 +6,39 @@
 	desc = "A large air vent"
 
 	can_unwrench = 1
-	
+
 	var/volume = 250
 
 /obj/machinery/atmospherics/unary/passive_vent/high_volume
 	name = "large passive vent"
 	volume = 1000
-	
+
 /obj/machinery/atmospherics/unary/passive_vent/New()
 	..()
 	air_contents.volume = volume
 
 /obj/machinery/atmospherics/unary/passive_vent/process()
-	..()
-	
+	if(!..())
+		return 0
+
 	if(!node)
 		return 0
-	
+
 	var/datum/gas_mixture/environment = loc.return_air()
-	
+
 	var/pressure_delta = air_contents.return_pressure() - environment.return_pressure()
-	
+
 	// based on pressure_pump to equalize pressure
 	// already equalized
 	if(abs(pressure_delta) < 0.01)
 		return 1
-	
+
 	if(pressure_delta > 0)
 		// transfer from pipe air to environment
 		if((air_contents.total_moles() > 0) && (air_contents.temperature > 0))
 			var/transfer_moles = pressure_delta * environment.volume / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
 			transfer_moles = min(transfer_moles, volume)
-	
+
 			var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 			loc.assume_air(removed)
 			air_update_turf()
@@ -47,11 +48,11 @@
 		if((environment.total_moles() > 0) && (environment.temperature > 0))
 			var/transfer_moles = pressure_delta * air_contents.volume / (environment.temperature * R_IDEAL_GAS_EQUATION)
 			transfer_moles = min(transfer_moles, volume)
-	
+
 			var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)
 			air_contents.merge(removed)
 			air_update_turf()
-	
+
 	parent.update = 1
 	return 1
 

--- a/code/ATMOSPHERICS/components/unary_devices/portables_connector.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/portables_connector.dm
@@ -7,11 +7,11 @@
 
 	can_unwrench = 1
 	layer = 2.4
-	
+
 	var/obj/machinery/portable_atmospherics/connected_device
 
 	var/on = 0
-	
+
 /obj/machinery/atmospherics/unary/portables_connector/Destroy()
 	if(connected_device)
 		connected_device.disconnect()
@@ -29,8 +29,8 @@
 		add_underlay(T, node, dir)
 
 /obj/machinery/atmospherics/unary/portables_connector/process()
-	if(!connected_device)
-		return
+	if(!..() || !connected_device)
+		return 0
 	parent.update = 1
 
 /obj/machinery/atmospherics/unary/portables_connector/attackby(var/obj/item/weapon/W as obj, var/mob/user as mob, params)
@@ -39,7 +39,7 @@
 			to_chat(user, "<span class='danger'>You cannot unwrench this [src], detach [connected_device] first.</span>")
 			return 1
 	return ..()
-	
+
 /obj/machinery/atmospherics/unary/portables_connector/portableConnectorReturnAir()
 	return connected_device.portableConnectorReturnAir()
 

--- a/code/ATMOSPHERICS/components/unary_devices/thermal_plate.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/thermal_plate.dm
@@ -4,7 +4,7 @@
 //Transfers heat between a pipe system and environment, based on which has a greater thermal energy concentration
 	icon = 'icons/obj/atmospherics/cold_sink.dmi'
 	icon_state = "off"
-	
+
 	can_unwrench = 1
 
 	name = "thermal tansfer plate"
@@ -18,7 +18,8 @@
 	icon_state = "[prefix]off"
 
 /obj/machinery/atmospherics/unary/thermal_plate/process()
-	..()
+	if(!..())
+		return 0
 
 	var/datum/gas_mixture/environment = loc.return_air()
 

--- a/code/ATMOSPHERICS/components/unary_devices/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/unary_base.dm
@@ -64,8 +64,11 @@
 
 /obj/machinery/atmospherics/unary/nullifyPipenet(datum/pipeline/P)
 	..()
-	parent.other_airs -= air_contents
-	parent = null
+	if(!P)
+		return
+	if(P == parent)
+		parent.other_airs -= air_contents
+		parent = null
 
 /obj/machinery/atmospherics/unary/returnPipenetAir()
 	return air_contents
@@ -81,8 +84,8 @@
 
 /obj/machinery/atmospherics/unary/replacePipenet(datum/pipeline/Old, datum/pipeline/New)
 	if(Old == parent)
-		parent = New	
-	
+		parent = New
+
 /obj/machinery/atmospherics/unary/unsafe_pressure_release(var/mob/user,var/pressures)
 	..()
 
@@ -95,4 +98,7 @@
 		var/datum/gas_mixture/to_release = air_contents.remove(lost)
 		T.assume_air(to_release)
 		air_update_turf(1)
-		
+
+/obj/machinery/atmospherics/unary/process()
+	..()
+	return parent

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -119,9 +119,8 @@
 	update_underlays()
 
 /obj/machinery/atmospherics/unary/vent_pump/process()
-	..()
-	if(stat & (NOPOWER|BROKEN))
-		return
+	if(!..() || (stat & (NOPOWER|BROKEN)))
+		return 0
 	if (!node)
 		on = 0
 	//broadcast_status() // from now air alarm/control computer should request update purposely --rastaf0

--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -12,7 +12,7 @@
 	active_power_usage = 60
 
 	can_unwrench = 1
-	
+
 	var/area/initial_loc
 	var/id_tag = null
 	var/frequency = 1439
@@ -175,7 +175,8 @@
 	check_turfs()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/process()
-	..()
+	if(!..())
+		return 0
 
 	if (widenet)
 		check_turfs()
@@ -364,7 +365,7 @@
 		return MT_UPDATE
 
 	return ..()
-	
+
 /obj/machinery/atmospherics/unary/vent_scrubber/can_crawl_through()
 	return !welded
 

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -1,4 +1,5 @@
-var/global/list/datum/pipeline/pipe_networks = list()
+var/global/list/pipe_networks = list()
+var/global/list/deferred_pipenet_rebuilds = list()
 
 /datum/pipeline
 	var/datum/gas_mixture/air

--- a/code/ATMOSPHERICS/pipes/cap.dm
+++ b/code/ATMOSPHERICS/pipes/cap.dm
@@ -31,10 +31,11 @@
 	else
 		. = PROCESS_KILL
 /obj/machinery/atmospherics/pipe/cap/Destroy()
+	. = ..()
 	if(node)
 		node.disconnect(src)
-
-	return ..()
+		node.defer_build_network()
+		node = null
 
 /obj/machinery/atmospherics/pipe/cap/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node)

--- a/code/ATMOSPHERICS/pipes/manifold.dm
+++ b/code/ATMOSPHERICS/pipes/manifold.dm
@@ -26,12 +26,12 @@
 			initialize_directions = SOUTH|WEST|NORTH
 		if(WEST)
 			initialize_directions = NORTH|EAST|SOUTH
-			
+
 	..()
-	
+
 	alpha = 255
 	icon = null
-	
+
 /obj/machinery/atmospherics/pipe/manifold/initialize()
 	..()
 	for(var/D in cardinal)
@@ -74,23 +74,20 @@
 		. = PROCESS_KILL
 
 /obj/machinery/atmospherics/pipe/manifold/Destroy()
+	. = ..()
+
 	if(node1)
-		var/obj/machinery/atmospherics/A = node1
 		node1.disconnect(src)
+		node1.defer_build_network()
 		node1 = null
-		A.build_network()
 	if(node2)
-		var/obj/machinery/atmospherics/A = node2
 		node2.disconnect(src)
+		node2.defer_build_network()
 		node2 = null
-		A.build_network()
 	if(node3)
-		var/obj/machinery/atmospherics/A = node3
 		node3.disconnect(src)
+		node3.defer_build_network()
 		node3 = null
-		A.build_network()
-	releaseAirToTurf()
-	return ..()
 
 /obj/machinery/atmospherics/pipe/manifold/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)

--- a/code/ATMOSPHERICS/pipes/manifold4w.dm
+++ b/code/ATMOSPHERICS/pipes/manifold4w.dm
@@ -32,28 +32,24 @@
 		. = PROCESS_KILL
 
 /obj/machinery/atmospherics/pipe/manifold4w/Destroy()
+	. = ..()
+
 	if(node1)
-		var/obj/machinery/atmospherics/A = node1
 		node1.disconnect(src)
+		node1.defer_build_network()
 		node1 = null
-		A.build_network()
 	if(node2)
-		var/obj/machinery/atmospherics/A = node2
 		node2.disconnect(src)
+		node2.defer_build_network()
 		node2 = null
-		A.build_network()
 	if(node3)
-		var/obj/machinery/atmospherics/A = node3
 		node3.disconnect(src)
+		node3.defer_build_network()
 		node3 = null
-		A.build_network()
 	if(node4)
-		var/obj/machinery/atmospherics/A = node4
 		node4.disconnect(src)
+		node4.defer_build_network()
 		node4 = null
-		A.build_network()
-	releaseAirToTurf()
-	return ..()
 
 /obj/machinery/atmospherics/pipe/manifold4w/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)
@@ -174,9 +170,9 @@
 				else if(D == WEST)
 					target.connected_to = c
 					connected_to = c
-					node4 = target				
+					node4 = target
 				break
-			
+
 	var/turf/T = src.loc			// hide if turf is not intact
 	hide(T.intact)
 	update_icon()

--- a/code/ATMOSPHERICS/pipes/pipe.dm
+++ b/code/ATMOSPHERICS/pipes/pipe.dm
@@ -32,7 +32,8 @@
 			qdel(meter)
 	. = ..()
 
-	if(parent && isnull(parent.gcDestroyed))
+	// if we're somehow by ourself
+	if(parent && isnull(parent.gcDestroyed) && parent.members.len == 1 && parent.members[1] == src)
 		qdel(parent)
 	parent = null
 

--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
@@ -100,18 +100,16 @@
 		dir = 4
 
 /obj/machinery/atmospherics/pipe/simple/Destroy()
+	. = ..()
+
 	if(node1)
-		var/obj/machinery/atmospherics/A = node1
 		node1.disconnect(src)
+		node1.defer_build_network()
 		node1 = null
-		A.build_network()
 	if(node2)
-		var/obj/machinery/atmospherics/A = node2
 		node2.disconnect(src)
+		node2.defer_build_network()
 		node2 = null
-		A.build_network()
-	releaseAirToTurf()
-	return ..()
 
 /obj/machinery/atmospherics/pipe/simple/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)

--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple_he.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple_he.dm
@@ -16,6 +16,8 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/process()
 	var/environment_temperature = 0
 	var/datum/gas_mixture/pipe_air = return_air()
+	if(!pipe_air)
+		return
 
 	var/turf/simulated/T = loc
 	if(istype(T))

--- a/code/_globalvars/station.dm
+++ b/code/_globalvars/station.dm
@@ -4,6 +4,7 @@ var/CELLRATE = 0.002  // multiplier for watts per tick <> cell storage (eg: .002
 var/CHARGELEVEL = 0.0005 // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)
 
 var/list/powernets = list()
+var/list/deferred_powernet_rebuilds = list()
 
 // this is not strictly unused although the whole modules datum thing is unused
 // To remove this you need to remove that

--- a/code/controllers/Processes/machinery.dm
+++ b/code/controllers/Processes/machinery.dm
@@ -8,7 +8,7 @@
 /datum/controller/process/machinery/statProcess()
 	..()
 	stat(null, "[machines.len] machines")
-	stat(null, "[powernets.len] powernets")
+	stat(null, "[powernets.len] powernets, [deferred_powernet_rebuilds.len] deferred")
 
 /datum/controller/process/machinery/doWork()
 	process_sort()
@@ -41,6 +41,19 @@
 		SCHECK_EVERY(100)
 
 /datum/controller/process/machinery/proc/process_power()
+	for(last_object in deferred_powernet_rebuilds)
+		var/obj/O = last_object
+		if(istype(O) && isnull(O.gcDestroyed))
+			try
+				var/datum/powernet/newPN = new()// creates a new powernet...
+				propagate_network(O, newPN)//... and propagates it to the other side of the cable
+			catch(var/exception/e)
+				catchException(e, O)
+			SCHECK
+		else
+			catchBadType(O)
+		deferred_powernet_rebuilds -= O
+
 	for(last_object in powernets)
 		var/datum/powernet/powerNetwork = last_object
 		if(istype(powerNetwork) && isnull(powerNetwork.gcDestroyed))
@@ -49,9 +62,9 @@
 			catch(var/exception/e)
 				catchException(e, powerNetwork)
 			SCHECK
-			continue
-
-		powernets.Remove(powerNetwork)
+		else
+			catchBadType(powerNetwork)
+			powernets -= powerNetwork
 
 /datum/controller/process/machinery/proc/process_power_drain()
 	// Currently only used by powersinks. These items get priority processed before machinery

--- a/code/controllers/Processes/pipenet.dm
+++ b/code/controllers/Processes/pipenet.dm
@@ -5,9 +5,21 @@
 
 /datum/controller/process/pipenet/statProcess()
 	..()
-	stat(null, "[pipe_networks.len] pipe nets")
+	stat(null, "[pipe_networks.len] pipe nets, [deferred_pipenet_rebuilds.len] deferred")
 
 /datum/controller/process/pipenet/doWork()
+	for(last_object in deferred_pipenet_rebuilds)
+		var/obj/machinery/atmospherics/M = last_object
+		if(istype(M) && isnull(M.gcDestroyed))
+			try
+				M.build_network()
+			catch(var/exception/e)
+				catchException(e, M)
+			SCHECK
+		else
+			catchBadType(M)
+		deferred_pipenet_rebuilds -= M
+
 	for(last_object in pipe_networks)
 		var/datum/pipeline/pipeNetwork = last_object
 		if(istype(pipeNetwork) && isnull(pipeNetwork.gcDestroyed))
@@ -16,7 +28,6 @@
 			catch(var/exception/e)
 				catchException(e, pipeNetwork)
 			SCHECK
-			continue
 		else
 			catchBadType(pipeNetwork)
 			pipe_networks -= pipeNetwork

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -437,10 +437,8 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	loc = null
 	powernet.remove_cable(src) //remove the cut cable from its powernet
 
-	spawn(0) //so we don't rebuild the network X times when singulo/explosion destroys a line of X cables
-		if(O && !qdeleted(O))
-			var/datum/powernet/newPN = new()// creates a new powernet...
-			propagate_network(O, newPN)//... and propagates it to the other side of the cable
+	// queue it to rebuild
+	deferred_powernet_rebuilds += O
 
 	// Disconnect machines connected to nodes
 	if(d1 == 0) // if we cut a node (O-X) cable


### PR DESCRIPTION
Makes explosions faster by preventing the pipenets and powernets from rebuilding 1000 times on an explosion.
 - This is done by deferring the rebuilds to happen in the pipenet or machine process, respectively.
 - I also fixed a few places where atmos stuff sometimes runtimes due to rapid deletion of stuff. (Some of the runtimes happened even on master.)
  - This could incidentally fix some bugs but also cause new ones, who knows.

## Some maxcap explosion times
`113,135,1` is the bridge.
`131,77,1` is atmosia (where things really go on fire :wink:).
`143,108,1` is medbay.
### master
Explosion(113,135,1)(d5,h10,l20): Took 2.2 seconds.
Explosion(131,77,1)(d5,h10,l20): Took 3.5 seconds.
Explosion(143,108,1)(d5,h10,l20): Took 1.1 seconds.

Explosion(113,135,1)(d5,h10,l20): Took 1.8 seconds.
Explosion(131,77,1)(d5,h10,l20): Took 3.7 seconds.
Explosion(143,108,1)(d5,h10,l20): Took 1.1 seconds.

### this pr
Explosion(113,135,1)(d5,h10,l20): Took 0.6 seconds.
Explosion(131,77,1)(d5,h10,l20): Took 0.5 seconds.
Explosion(143,108,1)(d5,h10,l20): Took 0.5 seconds.

Explosion(113,135,1)(d5,h10,l20): Took 0.4 seconds.
Explosion(131,77,1)(d5,h10,l20): Took 0.5 seconds.
Explosion(143,108,1)(d5,h10,l20): Took 0.5 seconds.