### PR TITLE
Tesla Update/Rebalance

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1611,6 +1611,22 @@ var/mob/dview/dview_mob = new
 	tY = max(1, min(world.maxy, origin.y + (text2num(tY) - (world.view + 1))))
 	return locate(tX, tY, tZ)
 
+/proc/get_closest_atom(type, list, source)
+	var/closest_atom
+	var/closest_distance
+	for(var/A in list)
+		if(!istype(A, type))
+			continue
+		var/distance = get_dist(source, A)
+		if(!closest_distance)
+			closest_distance = distance
+			closest_atom = A
+		else
+			if(closest_distance > distance)
+				closest_distance = distance
+				closest_atom = A
+	return closest_atom
+
 /proc/pick_closest_path(value)
 	var/list/matches = get_fancy_list_of_types()
 	if (!isnull(value) && value!="")

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -19,13 +19,9 @@
 /datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=50,maxdistance=10,btype = /obj/effect/ebeam)
 	endtime = world.time+time
 	origin = beam_origin
-	origin_oldloc = origin.loc
-	if(isarea(origin_oldloc))
-		origin_oldloc = origin
+	origin_oldloc =	get_turf(origin)
 	target = beam_target
-	target_oldloc = target.loc
-	if(isarea(target_oldloc))
-		target_oldloc = target
+	target_oldloc = get_turf(target)
 	if(origin_oldloc == origin && target_oldloc == target)
 		static_beam = 1
 	max_distance = maxdistance
@@ -38,9 +34,11 @@
 /datum/beam/proc/Start()
 	Draw()
 	while(!finished && origin && target && world.time < endtime && get_dist(origin,target)<max_distance && origin.z == target.z)
-		if(!static_beam && (origin.loc != origin_oldloc || target.loc != target_oldloc))
-			origin_oldloc = origin.loc //so we don't keep checking against their initial positions, leading to endless Reset()+Draw() calls
-			target_oldloc = target.loc
+		var/origin_turf = get_turf(origin)
+		var/target_turf = get_turf(target)
+		if(!static_beam && (origin_turf != origin_oldloc || target_turf != target_oldloc))
+			origin_oldloc = origin_turf //so we don't keep checking against their initial positions, leading to endless Reset()+Draw() calls
+			target_oldloc = target_turf
 			Reset()
 			Draw()
 		sleep(sleep_time)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -846,8 +846,11 @@ var/list/uplink_items = list()
 	cost = 10
 
 /datum/uplink_item/device_tools/singularity_beacon
-	name = "Singularity Beacon"
-	desc = "When screwed to wiring attached to an electric grid, then activated, this large device pulls the singularity towards it. Does not work when the singularity is still in containment. A singularity beacon can cause catastrophic damage to a space station, leading to an emergency evacuation. Because of its size, it cannot be carried. Ordering this sends you a small beacon that will teleport the larger beacon to your location on activation."
+	name = "Power Beacon"
+	desc = "When screwed to wiring attached to an electric grid and activated, this large device pulls any \
+			active gravitational singularities or tesla balls towards it. This will not work when the engine is still \
+			in containment. Because of its size, it cannot be carried. Ordering this \
+			sends you a small beacon that will teleport the larger beacon to your location upon activation."
 	reference = "SNGB"
 	item = /obj/item/device/radio/beacon/syndicate
 	cost = 14

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -555,3 +555,14 @@ Class Procs:
 //called on machinery construction (i.e from frame to machinery) but not on initialization
 /obj/machinery/proc/construction()
 	return
+
+/obj/machinery/tesla_act(var/power)
+	..()
+	if(prob(85))
+		emp_act(2)
+	else if(prob(50))
+		ex_act(3)
+	else if(prob(90))
+		ex_act(2)
+	else
+		ex_act(1)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -272,8 +272,10 @@ a {
 	being_shocked = 1
 	var/power_bounced = power * 0.5
 	tesla_zap(src, 3, power_bounced)
-	spawn(10)
-		being_shocked = 0
+	addtimer(src, "reset_shocked", 10)
+
+/obj/proc/reset_shocked()
+	being_shocked = 0
 
 /obj/proc/CanAStarPass()
 	. = !density

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -29,7 +29,7 @@
 		if (istype(src.loc.loc, /obj/structure/reagent_dispensers/fueltank/))
 			var/obj/structure/reagent_dispensers/fueltank/tank = src.loc.loc
 			if (tank)
-				tank.explode()
+				tank.boom()
 		if (istype(src.loc.loc, /obj/item/weapon/reagent_containers/glass/beaker/))
 			var/obj/item/weapon/reagent_containers/glass/beaker/beakerbomb = src.loc.loc
 			if(beakerbomb)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -35,7 +35,10 @@
 			connect_to_network()
 		return
 
-	default_deconstruction_crowbar(W)
+	if(default_deconstruction_crowbar(W))
+		return
+
+	return ..()
 
 /obj/machinery/power/tesla_coil/tesla_act(var/power)
 	being_shocked = 1
@@ -44,8 +47,7 @@
 	flick("coilhit", src)
 	playsound(src.loc, 'sound/magic/LightningShock.ogg', 100, 1, extrarange = 5)
 	tesla_zap(src, 5, power_produced)
-	spawn(10)
-		being_shocked = 0
+	addtimer(src, "reset_shocked", 10)
 
 /obj/machinery/power/grounding_rod
 	name = "Grounding Rod"
@@ -72,7 +74,10 @@
 	if(default_unfasten_wrench(user, W))
 		return
 
-	default_deconstruction_crowbar(W)
+	if(default_deconstruction_crowbar(W))
+		return
+
+	return ..()
 
 /obj/machinery/power/grounding_rod/tesla_act(var/power)
 	flick("coil_shock_1", src)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -1,5 +1,5 @@
-#define TESLA_DEFAULT_POWER 3476520
-#define TESLA_MINI_POWER 1738260
+#define TESLA_DEFAULT_POWER 1738260
+#define TESLA_MINI_POWER 869130
 
 var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 										/obj/machinery/power/emitter,
@@ -13,7 +13,9 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 										/obj/structure/particle_accelerator/power_box,
 										/obj/structure/particle_accelerator/end_cap,
 										/obj/machinery/field/containment,
-										/obj/structure/disposalpipe)
+										/obj/structure/disposalpipe,
+										/obj/structure/sign,
+										/obj/machinery/gateway)
 
 /obj/singularity/energy_ball
 	name = "energy ball"
@@ -27,30 +29,44 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 	grav_pull = 0
 	contained = 0
 	density = 1
+	energy = 0
 	var/list/orbiting_balls = list()
 	var/produced_power
-	var/is_orbiting
+	var/energy_to_raise = 32
+	var/energy_to_lower = -20
 
 /obj/singularity/energy_ball/Destroy()
-	for(var/obj/singularity/energy_ball/EB in orbiting_balls)
+	if(orbiting && istype(orbiting, /obj/singularity/energy_ball))
+		var/obj/singularity/energy_ball/EB = orbiting
+		EB.orbiting_balls -= src
+		orbiting = null
+
+	for(var/ball in orbiting_balls)
+		var/obj/singularity/energy_ball/EB = ball
 		qdel(EB)
-	..()
+
+	return ..()
 
 /obj/singularity/energy_ball/process()
-	if(!is_orbiting)
+	if(!orbiting)
 		handle_energy()
-		var/amount_to_move = 2 + orbiting_balls.len * 2
-		var/what_does_the_scouter_say_about_the_balls_power_level = (TESLA_DEFAULT_POWER + (TESLA_MINI_POWER * orbiting_balls.len))
-		move_the_basket_ball(amount_to_move)
+
+		move_the_basket_ball(4 + orbiting_balls.len * 2)
+
+		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 30)
+
 		pixel_x = 0
 		pixel_y = 0
-		playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 15)
-		tesla_zap(src, 7, what_does_the_scouter_say_about_the_balls_power_level)
+
+		dir = tesla_zap(src, 7, TESLA_DEFAULT_POWER)
+
 		pixel_x = -32
 		pixel_y = -32
-		energy += rand(1,3) // ensure it generates energy without needing to be blasted by the PA too much due to its size, and that a tesla engine will always get bigger over time
+		for (var/ball in orbiting_balls)
+			tesla_zap(ball, rand(1, Clamp(orbiting_balls.len, 3, 7)), TESLA_MINI_POWER)
 	else
 		energy = 0 // ensure we dont have miniballs of miniballs
+
 	return
 
 /obj/singularity/energy_ball/examine(mob/user)
@@ -60,29 +76,45 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 
 /obj/singularity/energy_ball/proc/move_the_basket_ball(var/move_amount)
-	for(var/i = 0, i < move_amount, i++)
-		var/move_dir = pick(alldirs)
-		var/turf/T = get_step(src,move_dir)
+	//we face the last thing we zapped, so this lets us favor that direction a bit
+	var/first_move = dir
+	for(var/i in 0 to move_amount)
+		var/move_dir = pick(alldirs + first_move) //give the first move direction a bit of favoring.
+		if(target && prob(60))
+			move_dir = get_dir(src,target)
+		var/turf/T = get_step(src, move_dir)
 		if(can_move(T))
-			loc = get_step(src,move_dir)
+			loc = T
+
 
 /obj/singularity/energy_ball/proc/handle_energy()
-	if(energy >= 300)
-		energy -= 300
-		playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 15)
+	if(energy >= energy_to_raise)
+		energy_to_lower = energy_to_raise - 20
+		energy_to_raise = energy_to_raise * 1.5
+
+		playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 30)
 		spawn(100)
+			if (!loc)
+				return
 			var/obj/singularity/energy_ball/EB = new(loc)
-			orbiting_balls.Add(EB)
-			EB.transform *= pick(0.3,0.4,0.5,0.6,0.7)
-			EB.is_orbiting = 1
+
+			EB.transform *= pick(0.3, 0.4, 0.5, 0.6, 0.7)
 			var/icon/I = icon(icon,icon_state,dir)
 
-			var/orbitsize = (I.Width()+I.Height())*pick(0.5,0.6,0.7)
-			orbitsize -= (orbitsize/world.icon_size)*(world.icon_size*0.25)
-			spawn(1)
-				EB.orbit(src,orbitsize, pick(FALSE,TRUE), rand(10,25), pick(3,4,5,6,36))
+			var/orbitsize = (I.Width() + I.Height()) * pick(0.4, 0.5, 0.6, 0.7, 0.8)
+			orbitsize -= (orbitsize / world.icon_size) * (world.icon_size * 0.25)
 
+			EB.orbit(src, orbitsize, pick(FALSE, TRUE), rand(10, 25), pick(3, 4, 5, 6, 36))
 
+	else if(energy < energy_to_lower && orbiting_balls.len)
+		energy_to_raise = energy_to_raise / 1.5
+		energy_to_lower = (energy_to_raise / 1.5) - 20
+
+		var/Orchiectomy_target = pick(orbiting_balls)
+		qdel(Orchiectomy_target)
+
+	else if(orbiting_balls.len)
+		energy -= orbiting_balls.len * 0.5
 
 /obj/singularity/energy_ball/Bump(atom/A)
 	dust_mobs(A)
@@ -90,120 +122,119 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 /obj/singularity/energy_ball/Bumped(atom/A)
 	dust_mobs(A)
 
+/obj/singularity/energy_ball/orbit(obj/singularity/energy_ball/target)
+	if (istype(target))
+		target.orbiting_balls += src
+
+	. = ..()
+
+	if (istype(target))
+		target.orbiting_balls -= src
+	if (!loc)
+		qdel(src)
+
 /obj/singularity/energy_ball/proc/dust_mobs(atom/A)
 	if(istype(A, /mob/living/carbon))
 		var/mob/living/carbon/C = A
 		C.dust()
 	return
 
-/proc/get_closest_atom(type, list, source)
-	var/closest_atom
-	var/closest_distance
-	for(var/A in list)
-		if(!istype(A, type))
-			continue
-		var/distance = get_dist(source, A)
-		if(!closest_distance)
-			closest_distance = distance
-			closest_atom = A
-		else
-			if(closest_distance > distance)
-				closest_distance = distance
-				closest_atom = A
-	return closest_atom
-
 /proc/tesla_zap(var/atom/source, zap_range = 3, power)
+	. = source.dir
 	if(power < 1000)
 		return
-	var/list/tesla_coils = list()
-	var/list/grounding_rods = list()
-	var/list/potential_machine_zaps = list()
-	var/list/potential_mob_zaps = list()
-	var/list/potential_structure_zaps = list()
+
+	var/closest_dist = 0
 	var/closest_atom
-	for(var/atom/A in oview(source, zap_range))
+	var/obj/machinery/power/tesla_coil/closest_tesla_coil
+	var/obj/machinery/power/grounding_rod/closest_grounding_rod
+	var/mob/living/closest_mob
+	var/obj/machinery/closest_machine
+	var/obj/structure/closest_structure
+
+	for(var/A in oview(source, zap_range))
 		if(istype(A, /obj/machinery/power/tesla_coil))
+			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A
-			if(C.being_shocked)
-				continue
-			tesla_coils.Add(C)
+			if((dist < closest_dist || !closest_tesla_coil) && !C.being_shocked)
+				closest_dist = dist
+
+				//we use both of these to save on istype and typecasting overhead later on
+				//while still allowing common code to run before hand
+				closest_tesla_coil = C
+				closest_atom = C
+
+
+		else if(closest_tesla_coil)
+			continue //no need checking these other things
+
+		else if(istype(A, /obj/machinery/power/grounding_rod))
+			var/dist = get_dist(source, A)
+			if(dist < closest_dist || !closest_grounding_rod)
+				closest_grounding_rod = A
+				closest_atom = A
+				closest_dist = dist
+
+		else if(closest_grounding_rod || is_type_in_list(A, blacklisted_tesla_types))
 			continue
-		if(istype(A, /obj/machinery/power/grounding_rod))
-			var/obj/machinery/power/grounding_rod/R = A
-			grounding_rods.Add(R)
-			continue
-		if(istype(A, /obj/machinery))
-			var/obj/machinery/M = A
-			if(is_type_in_list(M, blacklisted_tesla_types))
-				continue
-			if(M.being_shocked)
-				continue
-			potential_machine_zaps.Add(M)
-			continue
-		if(istype(A, /obj/structure))
-			var/obj/structure/M = A
-			if(is_type_in_list(M, blacklisted_tesla_types))
-				continue
-			if(M.being_shocked)
-				continue
-			potential_structure_zaps.Add(M)
-			continue
-		if(istype(A, /mob/living))
+
+		else if(istype(A, /mob/living))
+			var/dist = get_dist(source, A)
 			var/mob/living/L = A
-			if(L.stat == DEAD)
-				continue
-			if(is_type_in_list(L, blacklisted_tesla_types))
-				continue
-			potential_mob_zaps.Add(L)
+			if((dist < closest_dist || !closest_mob) && L.stat != DEAD)
+				closest_mob = L
+				closest_atom = A
+				closest_dist = dist
+
+		else if(closest_mob)
 			continue
-	closest_atom = get_closest_atom(/obj/machinery/power/tesla_coil, tesla_coils, source)
-	if(closest_atom && istype(closest_atom, /obj/machinery/power/tesla_coil))
-		var/obj/machinery/power/tesla_coil/C = closest_atom
-		source.Beam(C,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
-		C.tesla_act(power)
-		return
-	if(!closest_atom)
-		closest_atom = get_closest_atom(/obj/machinery/power/grounding_rod, grounding_rods, source)
-		if(closest_atom && istype(closest_atom, /obj/machinery/power/grounding_rod))
-			var/obj/machinery/power/grounding_rod/R = closest_atom
-			source.Beam(R,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
-			R.tesla_act(power)
-			return
-	if(!closest_atom)
-		closest_atom = get_closest_atom(/mob/living, potential_mob_zaps, source)
-		if(closest_atom && istype(closest_atom, /mob/living))
-			var/mob/living/L = closest_atom
-			var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5,5)
-			source.Beam(L,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
-			L.electrocute_act(shock_damage, source, 1, tesla_shock = 1)
-			if(istype(L, /mob/living/silicon))
-				var/mob/living/silicon/S = L
-				S.emp_act(2)
-				tesla_zap(S, 7, power / 1.5) // metallic folks bounce it further
-			else
-				tesla_zap(L, 5, power / 1.5)
-			return
-	if(!closest_atom)
-		closest_atom = get_closest_atom(/obj/machinery, potential_machine_zaps, source)
-		if(closest_atom)
-			var/obj/machinery/M = closest_atom
-			source.Beam(M,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
-			M.tesla_act(power)
-			if(prob(85))
-				M.emp_act(2)
-			else
-				if(prob(50))
-					M.ex_act(3)
-				else
-					if(prob(90))
-						M.ex_act(2)
-					else
-						M.ex_act(1)
-			return
-	if(!closest_atom)
-		closest_atom = get_closest_atom(/obj/structure, potential_structure_zaps, source)
-		if(closest_atom)
-			var/obj/structure/S = closest_atom
-			source.Beam(S,icon_state="lightning[rand(1,12)]",icon='icons/effects/effects.dmi',time=5)
-			S.tesla_act(power)
-			return
+
+		else if(istype(A, /obj/machinery))
+			var/obj/machinery/M = A
+			var/dist = get_dist(source, A)
+			if((dist < closest_dist || !closest_machine) && !M.being_shocked)
+				closest_machine = M
+				closest_atom = A
+				closest_dist = dist
+
+		else if(closest_mob)
+			continue
+
+		else if(istype(A, /obj/structure))
+			var/obj/structure/S = A
+			var/dist = get_dist(source, A)
+			if((dist < closest_dist || !closest_tesla_coil) && !S.being_shocked)
+				closest_structure = S
+				closest_atom = A
+				closest_dist = dist
+
+	//Alright, we've done our loop, now lets see if was anything interesting in range
+	if(closest_atom)
+		//common stuff
+		source.Beam(closest_atom, icon_state="lightning[rand(1,12)]", icon='icons/effects/effects.dmi', time=5)
+		var/zapdir = get_dir(source, closest_atom)
+		if(zapdir)
+			. = zapdir
+
+	//per type stuff:
+	if(closest_tesla_coil)
+		closest_tesla_coil.tesla_act(power)
+
+	else if(closest_grounding_rod)
+		closest_grounding_rod.tesla_act(power)
+
+	else if(closest_mob)
+		var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5, 5)
+		closest_mob.electrocute_act(shock_damage, source, 1, tesla_shock = 1)
+		if(istype(closest_mob, /mob/living/silicon))
+			var/mob/living/silicon/S = closest_mob
+			S.emp_act(2)
+			tesla_zap(S, 7, power / 1.5) // metallic folks bounce it further
+		else
+			tesla_zap(closest_mob, 5, power / 1.5)
+
+	else if(closest_machine)
+		closest_machine.tesla_act(power)
+
+	else if(closest_structure)
+		closest_structure.tesla_act(power)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -98,18 +98,31 @@
 	..()
 	reagents.add_reagent("fuel",1000)
 
-/obj/structure/reagent_dispensers/fueltank/bullet_act(var/obj/item/projectile/Proj)
-	if(istype(Proj ,/obj/item/projectile/beam)||istype(Proj,/obj/item/projectile/bullet))
-		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
-			message_admins("[key_name_admin(Proj.firer)] triggered a fueltank explosion.")
-			log_game("[key_name(Proj.firer)] triggered a fueltank explosion.")
-			explode()
+/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/item/projectile/Proj)
+	..()
+	if(istype(Proj) && !Proj.nodamage && ((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE)))
+		message_admins("[key_name_admin(Proj.firer)] triggered a fueltank explosion.")
+		log_game("[key_name(Proj.firer)] triggered a fueltank explosion.")
+		boom()
 
-/obj/structure/reagent_dispensers/fueltank/blob_act()
+/obj/structure/reagent_dispensers/fueltank/proc/boom()
 	explosion(src.loc,0,1,5,7,10, flame_range = 5)
+	if(src)
+		qdel(src)
+
+/obj/structure/reagent_dispensers/fueltank/blob_act(obj/effect/blob/B)
+	boom()
+
 
 /obj/structure/reagent_dispensers/fueltank/ex_act()
-	explode()
+	boom()
+
+/obj/structure/reagent_dispensers/fueltank/fire_act()
+	boom()
+
+/obj/structure/reagent_dispensers/fueltank/tesla_act()
+	..() //extend the zap
+	boom()
 
 /obj/structure/reagent_dispensers/fueltank/examine(mob/user)
 	if(!..(user, 2))
@@ -150,15 +163,6 @@
 				overlays += test
 
 		return ..()
-
-/obj/structure/reagent_dispensers/fueltank/proc/explode()
-	explosion(src.loc,-1,0,2, flame_range = 2)
-	if(src)
-		qdel(src)
-
-/obj/structure/reagent_dispensers/fueltank/fire_act(datum/gas_mixture/air, temperature, volume)
-	blob_act() //saving a few lines of copypasta
-
 
 /obj/structure/reagent_dispensers/fueltank/Move()
 	..()


### PR DESCRIPTION
Updates and rebalances the Tesla to TG's current standard.


This fairly dramatically reduces the power output of the Tesla, putting it on par with the singulo (still possible to hit higher power output levels, but it'll take a lot longer). It will also start to lose energy balls if you don't keep on pumping power into it. Another important feature is that the the singularity beacon (now renamed power beacon) will attract the Tesla AND the Sinuglo.

It's generally more flashy too, with each of the smaller energy balls capable of shooting out zaps:

![img](https://i.gyazo.com/03d067d556e91d7937081b90b37246ee.png)

Code Related
- Tesla Zap is better on performance than it previously was
- Fixes some turf/area oddities with `Beam`
- Tesla shocked now uses a timer as opposed to `Spawn`

Semi-Related
- Updated the explosion for fuel tanks; it's stronger than before and capable of bouncing Tesla shocks even further

:cl: Fox McCloud
tweak: Updates the Tesla; it will now have to be "fed" or it can run out of energy; the rate at which it gains additional energy balls and power has been greatly lowered.
tweak: energy ball will now be drawn towards the singularity beacon
tweak: fuel tank explosions a bit stronger and will arc tesla blasts further
/:cl: