### PR TITLE
Fixes timer process runtimes

### DIFF
--- a/code/controllers/Processes/timer.dm
+++ b/code/controllers/Processes/timer.dm
@@ -28,7 +28,8 @@ var/global/datum/controller/process/timer/timer_master
 
 /datum/controller/process/timer/proc/runevent(datum/timedevent/event)
 	set waitfor = 0
-	call(event.thingToCall, event.procToCall)(arglist(event.argList))
+	if(event.thingToCall)
+		call(event.thingToCall, event.procToCall)(arglist(event.argList))
 
 /datum/timedevent
 	var/thingToCall


### PR DESCRIPTION
Fixes some corner case runtimes that were occuring when the `thingToCall` was being deleted between the earlier check and the `call()` actually being executed due to sleeping on the waitfor. This sounds like this would never happen, but it happens hundreds of times if you explode the entire map.