### PR TITLE
You can no longer insert beakers and syringes into cake

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -139,7 +139,7 @@
 				return 1
 		if(contents.len > 1)
 			// No more bluespace cake
-			to_chat(user, "<span class='warning'>Something is already in the [src]!</span>"
+			to_chat(user, "<span class='warning'>Something is already in the [src]!</span>")
 			return 1
 		if(!iscarbon(user))
 			return 1

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -137,7 +137,7 @@
 		for(var/type in uninsertable_types)
 			if(istype(W, type))
 				return 1
-		if(contents.len > 1)
+		if(contents.len >= 1)
 			// No more bluespace cake
 			to_chat(user, "<span class='warning'>Something is already in the [src]!</span>")
 			return 1

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -137,6 +137,10 @@
 		for(var/type in uninsertable_types)
 			if(istype(W, type))
 				return 1
+		if(contents.len > 1)
+			// No more bluespace cake
+			to_chat(user, "<span class='warning'>Something is already in the [src]!</span>"
+			return 1
 		if(!iscarbon(user))
 			return 1
 		if(!user.canUnEquip(W, 0))

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -131,9 +131,18 @@
 		)
 		inaccurate = 1
 	else if(W.w_class <= 2 && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
+		// ow this is bad
+		// In a nice world I'd have it check for things with an afterattack, but there's no way to detect that soooo
+		var/list/uninsertable_types = list(/obj/item/weapon/reagent_containers/syringe, /obj/item/weapon/reagent_containers/glass)
+		for(var/type in uninsertable_types)
+			if(istype(W, type))
+				return 1
 		if(!iscarbon(user))
 			return 1
-		to_chat(user, "\red You slip [W] inside [src].")
+		if(!user.canUnEquip(W, 0))
+			to_chat(user, "<span class='warning'>The [W] is stuck to your hand, you cannot insert it in the cake!</span>")
+			return
+		to_chat(user, "<span class='warning'>You slip [W] inside [src].</span>")
 		user.unEquip(W)
 		if ((user.client && user.s_active != src))
 			user.client.screen -= W


### PR DESCRIPTION
This being due to their after-attack being semi-co-opted by the cake's attackby - this prevents the insertion so usage of beakers and syringes doesn't do 2 actions at once, when you may have intended only 1.

Fixes #2583 (kind of)

:cl:Crazylemon
bugfix: Syringes now only inject/withdraw from cake, instead of being inserted in the cake in the process. Likewise, beakers will only splash, and not be inserted.
bugfix: Cake is no longer a bluespace container.
/:cl: