### PR TITLE
Makes slot machines less spammy

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -83,10 +83,12 @@
 					resultlvl = "good"
 					win_money(100, 'sound/goonstation/misc/bell.ogg')
 				else if (roll > 100 && roll <= 200)
+					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won fifty credits!'")
 					result = "You win fifty credits!"
 					resultlvl = "good"
 					win_money(50)
 				else if (roll > 200 && roll <= 500)
+					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won ten credits!'")
 					result = "You win ten credits!"
 					resultlvl = "good"
 					win_money(10)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -83,17 +83,14 @@
 					resultlvl = "good"
 					win_money(100, 'sound/goonstation/misc/bell.ogg')
 				else if (roll > 100 && roll <= 200)
-					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won fifty credits!'")
 					result = "You win fifty credits!"
 					resultlvl = "good"
 					win_money(50)
 				else if (roll > 200 && roll <= 500)
-					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won ten credits!'")
 					result = "You win ten credits!"
 					resultlvl = "good"
 					win_money(10)
 				else
-					visible_message("<b>[src]</b> says, 'No Luck!'")
 					result = "<span class='warning'>No luck!</span>"
 					resultlvl = "average"
 				working = 0


### PR DESCRIPTION
Slot machines will now only show a message to nearby people when someone wins something.

The person playing the slots is still notified via the slot machine window, and the sounds still play, but now it's possible to RP in the bar without having to sift through hundreds of "The slot machine says, 'No Luck!".