### PR TITLE
Fixes hostiles runtiming on targetting

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -104,7 +104,7 @@
 			var/possible_target_distance = get_dist(src, A)
 			if(target_dist < possible_target_distance)
 				Targets -= A
-	var/chosen_target = pick(Targets)//Pick the remaining targets (if any) at random
+	var/chosen_target = safepick(Targets)//Pick the remaining targets (if any) at random
 	return chosen_target
 
 /mob/living/simple_animal/hostile/CanAttack(var/atom/the_target)//Can we actually attack a possible target?


### PR DESCRIPTION
A hostile would runtime if it eliminated _all_ of its possible targets due to leaving range, then tried to pick one.