### PR TITLE
Game Mode Population Adjustments

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -11,7 +11,6 @@ var/list/blob_nodes = list()
 	config_tag = "blob"
 
 	required_players = 30
-	required_players_secret = 30
 	required_enemies = 1
 	recommended_enemies = 1
 	restricted_jobs = list("Cyborg", "AI")

--- a/code/game/gamemodes/borer/borer.dm
+++ b/code/game/gamemodes/borer/borer.dm
@@ -6,8 +6,7 @@
 /datum/game_mode/borer
 	name = "corticalborers"
 	config_tag = "borer"
-	required_players = 3
-	required_players_secret = 10
+	required_players = 10
 	restricted_jobs = list("AI", "Cyborg", "Mobile MMI")
 	recommended_enemies = 2 // need at least a borer and a host
 	votable = 0 // temporarily disable this mode for voting

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -10,8 +10,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Brig Physician", "Internal Affairs Agent")
 	protected_species = list("Machine", "Slime People", "Plasmaman")
-	required_players = 2
-	required_players_secret = 10
+	required_players = 15
+	required_players_secret = 15
 	required_enemies = 1
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -11,7 +11,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Brig Physician", "Internal Affairs Agent")
 	protected_species = list("Machine", "Slime People", "Plasmaman")
 	required_players = 15
-	required_players_secret = 15
 	required_enemies = 1
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -4,7 +4,6 @@
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 10
-	required_players_secret = 10
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	var/protected_species_changeling = list("Machine", "Slime People")

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -30,8 +30,8 @@
 	config_tag = "cult"
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Internal Affairs Agent", "Security Officer", "Warden", "Detective", "Security Pod Pilot", "Head of Security", "Captain", "Head of Personnel", "Blueshield", "Nanotrasen Representative", "Magistrate", "Brig Physician")
 	protected_jobs = list()
-	required_players = 5
-	required_players_secret = 15
+	required_players = 30
+	required_players_secret = 30
 	required_enemies = 3
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -31,7 +31,6 @@
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Internal Affairs Agent", "Security Officer", "Warden", "Detective", "Security Pod Pilot", "Head of Security", "Captain", "Head of Personnel", "Blueshield", "Nanotrasen Representative", "Magistrate", "Brig Physician")
 	protected_jobs = list()
 	required_players = 30
-	required_players_secret = 30
 	required_enemies = 3
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -25,9 +25,7 @@
 	var/list/protected_jobs = list()	// Jobs that can't be traitors
 	var/list/protected_species = list() // Species that can't be traitors
 	var/required_players = 0
-	var/required_players_secret = 0 //Minimum number of players for that game mode to be chose in Secret
 	var/required_enemies = 0
-	var/recommended_players = 0
 	var/recommended_enemies = 0
 	var/newscaster_announcements = null
 	var/ert_disabled = 0
@@ -49,12 +47,8 @@
 		if((player.client)&&(player.ready))
 			playerC++
 
-	if(master_mode=="secret")
-		if(playerC >= required_players_secret)
-			return 1
-	else
-		if(playerC >= required_players)
-			return 1
+	if(playerC >= required_players)
+		return 1
 	return 0
 
 //pre_pre_setup() For when you really don't want certain jobs ingame.

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -12,7 +12,7 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 /datum/game_mode/heist
 	name = "heist"
 	config_tag = "heist"
-	required_players = 15
+	required_players = 25
 	required_players_secret = 25
 	required_enemies = 4
 	recommended_enemies = 5

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -13,7 +13,6 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	name = "heist"
 	config_tag = "heist"
 	required_players = 25
-	required_players_secret = 25
 	required_enemies = 4
 	recommended_enemies = 5
 	votable = 0

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -5,7 +5,6 @@
 	name = "AI malfunction"
 	config_tag = "malfunction"
 	required_players = 25
-	required_players_secret = 25
 	required_enemies = 1
 	recommended_enemies = 1
 

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -4,8 +4,8 @@
 /datum/game_mode/malfunction
 	name = "AI malfunction"
 	config_tag = "malfunction"
-	required_players = 2
-	required_players_secret = 20
+	required_players = 25
+	required_players_secret = 25
 	required_enemies = 1
 	recommended_enemies = 1
 

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -4,7 +4,6 @@
 	var/const/initialmeteordelay = 6000
 	var/wave = 1
 	required_players = 35
-	required_players_secret = 35
 
 	uplink_welcome = "EVIL METEOR Uplink Console:"
 	uplink_uses = 10

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -8,7 +8,6 @@
 	config_tag = "abduction"
 	recommended_enemies = 2
 	required_players = 15
-	required_players_secret = 15
 	var/max_teams = 4
 	abductor_teams = 1
 	var/list/datum/mind/scientists = list()

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -17,7 +17,6 @@ datum/game_mode/mutiny
 	name = "mutiny"
 	config_tag = "mutiny"
 	required_players = 20
-	required_players_secret = 20
 	ert_disabled = 1
 
 	uplink_welcome = "Mutineers Uplink Console:"

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -16,7 +16,8 @@ datum/game_mode/mutiny
 
 	name = "mutiny"
 	config_tag = "mutiny"
-	required_players = 7
+	required_players = 20
+	required_players_secret = 20
 	ert_disabled = 1
 
 	uplink_welcome = "Mutineers Uplink Console:"

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -2,7 +2,6 @@ datum/game_mode/nations
 	name = "nations"
 	config_tag = "nations"
 	required_players = 25
-	required_players_secret = 25
 	var/kickoff = 0
 	var/victory = 0
 	var/list/cargonians = list("Quartermaster","Cargo Technician","Shaft Miner")

--- a/code/game/gamemodes/nations/nations.dm
+++ b/code/game/gamemodes/nations/nations.dm
@@ -1,6 +1,7 @@
 datum/game_mode/nations
 	name = "nations"
 	config_tag = "nations"
+	required_players = 25
 	required_players_secret = 25
 	var/kickoff = 0
 	var/victory = 0
@@ -221,7 +222,7 @@ datum/game_mode/nations
 			H.mind.nation.membership += H.mind.current
 			to_chat(H, "You are now part of the great sovereign nation of [H.mind.nation.current_name]!")
 			return 1
-			
+
 		if(H.mind.assigned_role in civilian_positions)
 			to_chat(H, "You do not belong to any nation and are free to sell your services to the highest bidder.")
 			return 1

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -7,8 +7,7 @@ proc/issyndicate(mob/living/M as mob)
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 30
-	required_players_secret = 30 // 30 players - 5 players to be the nuke ops = 25 players remaining
+	required_players = 30	// 30 players - 5 players to be the nuke ops = 25 players remaining
 	required_enemies = 5
 	recommended_enemies = 5
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -15,7 +15,6 @@
 	config_tag = "revolution"
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "Internal Affairs Agent", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Brig Physician")
 	required_players = 20
-	required_players_secret = 20
 	required_enemies = 1
 	recommended_enemies = 3
 

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -69,7 +69,6 @@ Made by Xhuis
 	name = "shadowling"
 	config_tag = "shadowling"
 	required_players = 30
-	required_players_secret = 30
 	required_enemies = 2
 	recommended_enemies = 2
 	restricted_jobs = list("AI", "Cyborg")

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -4,7 +4,6 @@
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 10
-	required_players_secret = 10
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	var/protected_species_vampire = list("Machine")

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -10,8 +10,8 @@
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent")
 	protected_species = list("Machine")
-	required_players = 2
-	required_players_secret = 10
+	required_players = 15
+	required_players_secret = 15
 	required_enemies = 1
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -11,7 +11,6 @@
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent")
 	protected_species = list("Machine")
 	required_players = 15
-	required_players_secret = 15
 	required_enemies = 1
 	recommended_enemies = 4
 

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -2,7 +2,6 @@
 	name = "ragin' mages"
 	config_tag = "raginmages"
 	required_players = 20
-	required_players_secret = 20
 	use_huds = 1
 	var/max_mages = 0
 	var/making_mage = 0

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -1,8 +1,8 @@
 /datum/game_mode/wizard/raginmages
 	name = "ragin' mages"
 	config_tag = "raginmages"
-	required_players = 1
-	required_players_secret = 15
+	required_players = 20
+	required_players_secret = 20
 	use_huds = 1
 	var/max_mages = 0
 	var/making_mage = 0

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -5,7 +5,6 @@
 	name = "wizard"
 	config_tag = "wizard"
 	required_players = 20
-	required_players_secret = 20
 	required_enemies = 1
 	recommended_enemies = 1
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -4,8 +4,8 @@
 /datum/game_mode/wizard
 	name = "wizard"
 	config_tag = "wizard"
-	required_players = 2
-	required_players_secret = 10
+	required_players = 20
+	required_players_secret = 20
 	required_enemies = 1
 	recommended_enemies = 1
 

--- a/code/game/gamemodes/xenos/xenos.dm
+++ b/code/game/gamemodes/xenos/xenos.dm
@@ -5,9 +5,9 @@
 /datum/game_mode/xenos
 	name = "xenos"
 	config_tag = "xenos"
-	required_players = 0
+	required_players = 30
 	recommended_players = 30
-	required_players_secret = 20
+	required_players_secret = 30
 	required_enemies = 3
 	recommended_enemies = 3
 	var/result = 0

--- a/code/game/gamemodes/xenos/xenos.dm
+++ b/code/game/gamemodes/xenos/xenos.dm
@@ -6,10 +6,7 @@
 	name = "xenos"
 	config_tag = "xenos"
 	required_players = 30
-	recommended_players = 30
-	required_players_secret = 30
 	required_enemies = 3
-	recommended_enemies = 3
 	var/result = 0
 	var/checkwin_counter = 0
 	var/xenos_list = list()
@@ -27,7 +24,7 @@
 
 	var/list/candidates = get_players_for_role(ROLE_ALIEN)
 	var/playersready = 0
-	var/xenos_num
+	var/xenos_num = required_enemies
 	for(var/mob/new_player/player in player_list)
 		if((player.client)&&(player.ready))
 			playersready += 1
@@ -35,10 +32,6 @@
 	//Check that we have enough alien candidates
 	if(candidates.len < required_enemies)
 		return 0
-	if (playersready < recommended_players)
-		xenos_num = required_enemies
-	if (playersready >= recommended_players)
-		xenos_num = recommended_enemies
 
 	//Grab candidates randomly until we have enough.
 	while(xenos_num > 0)


### PR DESCRIPTION
It's been a longgg time since these have been gone over.

Adjust some game-mode populations for better balance; numbers are similar/identical to TG.

- Changeling: 10->15 player minimum
- Cult: 15->30 player minimum
- Mutiny: 7->20 player minimum (unused)
- Vampire: 10->15 player minimum
- Malf: 20->25 player minimum
- Wizard: 10->20 player minimum
- Ragin' Mages: 15->20 player minimum
- Xenos: 20->30 player minimum (unused)

Code Wise
- Removed `required_players_secret`; game modes just go by `required_players` now.
- Removed the virtually unused `recommended_players` var

:cl: Fox McCloud
tweak: Tweaked some game mode population requirements to enhance general game mode balance and player experience.
/:cl: