### PR TITLE
Minor Rev Balance Tweaks

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -145,7 +145,7 @@
 	..()
 
 
-/obj/item/device/flash/proc/terrible_conversion_proc(var/mob/M, var/mob/user)
+/obj/item/device/flash/proc/terrible_conversion_proc(mob/M, mob/user)
 	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
 		if(user.mind && (user.mind in ticker.mode.head_revolutionaries))
 			if(M.client)
@@ -154,7 +154,9 @@
 					var/resisted
 					if(!isloyal(M))
 						if(user.mind in ticker.mode.head_revolutionaries)
-							if(!ticker.mode.add_revolutionary(M.mind))
+							if(ticker.mode.add_revolutionary(M.mind))
+								times_used -- //Flashes less likely to burn out for headrevs when used for conversion
+							else
 								resisted = 1
 					else
 						resisted = 1

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -262,12 +262,13 @@ emp_act
 		if(!stat)
 			switch(hit_area)
 				if("head")//Harder to score a stun but if you do it lasts a bit longer
-					if(stat == CONSCIOUS && prob(I.force) && armor < 50)
-						visible_message("<span class='danger'>[src] has been knocked down!</span>", \
-										"<span class='userdanger'>[src] has been knocked down!</span>")
-						apply_effect(5, WEAKEN, armor)
-						confused += 15
-						if(src != user && I.damtype == BRUTE)
+					if(stat == CONSCIOUS && armor < 50)
+						if(prob(I.force))
+							visible_message("<span class='danger'>[src] has been knocked down!</span>", \
+											"<span class='userdanger'>[src] has been knocked down!</span>")
+							apply_effect(5, WEAKEN, armor)
+							confused += 15
+						if(prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
 							ticker.mode.remove_revolutionary(mind)
 
 					if(bloody)//Apply blood


### PR DESCRIPTION
Minor Rev tweaks that I didn't include in the original Rev PR.

- Flashes used by rev heads are less likely to burn out
- Chances of deconversion by bonking a rev on the head increased as the rev's health drops