### PR TITLE
Gun_turret code cleanup, easier to add new kinds of turrets

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -402,6 +402,8 @@
 	var/scan_range = 9 //You will never see them coming
 	var/health = 200 //Because it lacks a cover, and is mostly to keep people from touching the syndie shuttle.
 	var/bullet_type = /obj/item/projectile/bullet
+	var/firing_sound = 'sound/weapons/Gunshot3.ogg'
+	var/base_icon = "syndieturret"
 	icon = 'icons/obj/turrets.dmi'
 	icon_state = "syndieturret0"
 
@@ -425,7 +427,7 @@
 /obj/machinery/gun_turret/update_icon()
 	if(state > 2 || state < 0) //someone fucked up the vars so fix them
 		take_damage(0)
-	icon_state = "syndieturret" + "[state]"
+	icon_state = "[base_icon]" + "[state]"
 	return
 
 
@@ -547,7 +549,7 @@
 		return
 	if (targloc == curloc)
 		return
-	playsound(get_turf(src), 'sound/weapons/Gunshot3.ogg', 60, 1)
+	playsound(get_turf(src), firing_sound, 60, 1)
 	var/obj/item/projectile/A = new bullet_type(curloc)
 	A.current = curloc
 	A.yo = targloc.y - curloc.y


### PR DESCRIPTION
Changes gun turret code to be more customizable.
It is now possible to specify new sprites and firing sounds, in addition to projectiles, stats, and faction.

Makes it much easier for modders who wish to add new kinds of turrets, eliminating the need for copypasta due to icon updating and firing sounds previously being defined within procs. Makes the code a bit cleaner, too.