### PR TITLE
Ports Accelerator Laser Cannon

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -56,20 +56,30 @@ obj/item/weapon/gun/energy/laser/retro
 
 
 /obj/item/weapon/gun/energy/lasercannon
-	name = "laser cannon"
-	desc = "With the L.A.S.E.R. cannon, the lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
+	name = "accelerator laser cannon"
+	desc = "An advanced laser cannon that does more damage the farther away the target is."
 	icon_state = "lasercannon"
 	item_state = "laser"
-	w_class = 4.0
+	w_class = 4
 	force = 10
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 	origin_tech = "combat=4;materials=3;powerstorage=3"
-	projectile_type = "/obj/item/projectile/beam/heavylaser"
+	projectile_type = "/obj/item/projectile/beam/laser/accelerator"
 
-	isHandgun()
-		return 0
+/obj/item/weapon/gun/energy/lasercannon/isHandgun()
+	return 0
+
+/obj/item/projectile/beam/laser/accelerator
+	name = "accelerator laser"
+	icon_state = "heavylaser"
+	range = 255
+	damage = 6
+
+/obj/item/projectile/beam/laser/accelerator/Range()
+	..()
+	damage += 7
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
 	name = "mounted laser cannon"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -79,7 +79,7 @@ obj/item/weapon/gun/energy/laser/retro
 
 /obj/item/projectile/beam/laser/accelerator/Range()
 	..()
-	damage += 7
+	damage = min(damage+7, 100)
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
 	name = "mounted laser cannon"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -94,8 +94,8 @@
 	category = list("Weapons")
 
 /datum/design/lasercannon
-	name = "Laser Cannon"
-	desc = "A heavy duty laser cannon."
+	name = "Accelerator Laser Cannon"
+	desc = "A heavy duty laser cannon. It does more damage the farther away the target is."
 	id = "lasercannon"
 	req_tech = list("combat" = 4, "materials" = 3, "powerstorage" = 3)
 	build_type = PROTOLATHE


### PR DESCRIPTION
Ports: https://github.com/tgstation/-tg-station/pull/16470 by @KorPhaeron

A rework of the laser cannon: The Accelerator Laser Cannon

Instead of the laser cannon being a super pew pew laser gun (that does 2x damage to , it now does a pitiful amount of damage, a point blank, but does more and more damage the further and further the projectile travels.

Things not impemented:
- The projectile getting bigger
 - Our pixel projectile system uses transform, which makes the projectile getting larger/smaller a no go for this...sadly

:cl: Fox McCloud
tweak: Updates the laser cannon to be range based: the further its projectile travels, the more damage it does. Base damage greatly reduced.
/:cl: