### PR TITLE
Adds unread changes notification

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -248,6 +248,7 @@ CREATE TABLE `player` (
   `volume` smallint(4) DEFAULT '100',
   `nanoui_fancy` smallint(4) DEFAULT '1',
   `show_ghostitem_attack` smallint(4) DEFAULT '1',
+  `lastchangelog` varchar(32) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`)
 ) ENGINE=InnoDB AUTO_INCREMENT=32446 DEFAULT CHARSET=latin1;

--- a/SQL/paradise_schema_prefixed.sql
+++ b/SQL/paradise_schema_prefixed.sql
@@ -248,6 +248,7 @@ CREATE TABLE `SS13_player` (
   `volume` smallint(4) DEFAULT '100',
   `nanoui_fancy` smallint(4) DEFAULT '1',
   `show_ghostitem_attack` smallint(4) DEFAULT '1',
+  `lastchangelog` varchar(32) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`)
 ) ENGINE=InnoDB AUTO_INCREMENT=32446 DEFAULT CHARSET=latin1;

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -4,7 +4,7 @@ var/host = null
 var/join_motd = null
 var/station_name = "NSS Cyberiad"
 var/game_version = "Custom ParaCode"
-var/changelog_hash = ""
+var/changelog_hash = md5('html/changelog.html') //used to check if the CL changed
 var/game_year = (text2num(time2text(world.realtime, "YYYY")) + 544)
 
 var/aliens_allowed = 1

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -308,6 +308,11 @@
 
 	send_resources()
 
+	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
+		winset(src, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
+		prefs.SetChangelog(src,changelog_hash)
+		src << "<span class='info'>Changelog has changed since your last visit.</span>"
+
 	if(!void)
 		void = new()
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -311,7 +311,7 @@
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
 		winset(src, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
 		prefs.SetChangelog(src,changelog_hash)
-		src << "<span class='info'>Changelog has changed since your last visit.</span>"
+		to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 
 	if(!void)
 		void = new()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -77,7 +77,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	var/last_id
 
 	//game-preferences
-//	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
+	var/lastchangelog = ""				//Saved changelog filesize to detect if there was a change
 	var/ooccolor = "#b82e00"
 	var/be_special = list()				//Special role selection
 	var/UI_style = "Midnight"

--- a/code/modules/client/preferences_mysql.dm
+++ b/code/modules/client/preferences_mysql.dm
@@ -12,7 +12,8 @@
 					randomslot,
 					volume,
 					nanoui_fancy,
-					show_ghostitem_attack
+					show_ghostitem_attack,
+					lastchangelog
 					FROM [format_table_name("player")]
 					WHERE ckey='[C.ckey]'"}
 					)
@@ -38,10 +39,10 @@
 		volume = text2num(query.item[10])
 		nanoui_fancy = text2num(query.item[11])
 		show_ghostitem_attack = text2num(query.item[12])
+		lastchangelog = query.item[13]
 
 	//Sanitize
 	ooccolor		= sanitize_hexcolor(ooccolor, initial(ooccolor))
-//	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	UI_style		= sanitize_inlist(UI_style, list("White", "Midnight"), initial(UI_style))
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
@@ -52,6 +53,7 @@
 	volume			= sanitize_integer(volume, 0, 100, initial(volume))
 	nanoui_fancy	= sanitize_integer(nanoui_fancy, 0, 1, initial(nanoui_fancy))
 	show_ghostitem_attack = sanitize_integer(show_ghostitem_attack, 0, 1, initial(show_ghostitem_attack))
+	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	return 1
 
 /datum/preferences/proc/save_preferences(client/C)
@@ -75,7 +77,8 @@
 					randomslot='[randomslot]',
 					volume='[volume]',
 					nanoui_fancy='[nanoui_fancy]',
-					show_ghostitem_attack='[show_ghostitem_attack]'
+					show_ghostitem_attack='[show_ghostitem_attack]',
+					lastchangelog='[lastchangelog]',
 					WHERE ckey='[C.ckey]'"}
 					)
 
@@ -450,3 +453,13 @@
 		return 0
 	load_character(C,pick(saves))
 	return 1*/
+
+/datum/preferences/proc/SetChangelog(client/C,hash)
+	lastchangelog=hash
+	var/DBQuery/query = dbcon.NewQuery("UPDATE client SET lastchangelog='[lastchangelog]' WHERE ckey='[C.ckey]'")
+	if(!query.Execute())
+		var/err = query.ErrorMsg()
+		log_game("SQL ERROR during lastchangelog updating. Error : \[[err]\]\n")
+		message_admins("SQL ERROR during lastchangelog updating. Error : \[[err]\]\n")
+		return
+	return 1

--- a/code/modules/client/preferences_mysql.dm
+++ b/code/modules/client/preferences_mysql.dm
@@ -78,7 +78,7 @@
 					volume='[volume]',
 					nanoui_fancy='[nanoui_fancy]',
 					show_ghostitem_attack='[show_ghostitem_attack]',
-					lastchangelog='[lastchangelog]',
+					lastchangelog='[lastchangelog]'
 					WHERE ckey='[C.ckey]'"}
 					)
 
@@ -456,7 +456,7 @@
 
 /datum/preferences/proc/SetChangelog(client/C,hash)
 	lastchangelog=hash
-	var/DBQuery/query = dbcon.NewQuery("UPDATE client SET lastchangelog='[lastchangelog]' WHERE ckey='[C.ckey]'")
+	var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET lastchangelog='[lastchangelog]' WHERE ckey='[C.ckey]'")
 	if(!query.Execute())
 		var/err = query.ErrorMsg()
 		log_game("SQL ERROR during lastchangelog updating. Error : \[[err]\]\n")

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -34,6 +34,10 @@
 		verbs += /client/proc/readmin
 	spawn(40)
 		if(client)
+			if(client.prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
+				winset(client, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
+				client.prefs.SetChangelog(client,changelog_hash)
+				to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 			client.playtitlemusic()
 
 	if(config.player_overflow_cap && config.overflow_server_url) //Overflow rerouting, if set, forces players to be moved to a different server once a player cap is reached. Less rough than a pure kick.
@@ -44,4 +48,3 @@
 			tally++
 		if(tally > config.player_overflow_cap)
 			src << link(config.overflow_server_url)
-

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -39,6 +39,11 @@
 		)
 	src << browse('html/changelog.html', "window=changes;size=675x650")
 
+	if(prefs.lastchangelog != changelog_hash) //if it's already opened, no need to tell them they have unread changes
+		prefs.lastchangelog = changelog_hash
+		prefs.save_preferences()
+		winset(src, "rpane.changelog", "background-color=none;font-style=")
+
 /client/verb/forum()
 	set name = "forum"
 	set desc = "Visit the forum."


### PR DESCRIPTION
As title. When there are new changes which the client hasn't already read, the changelog button will bold  and become reddish to note that you should check the changelog. Also, a note is displayed in the chat. 
![screenshot_28](https://cloud.githubusercontent.com/assets/9385129/15051225/c872c094-12f7-11e6-923d-f111f17eb715.png)
Note, this _should_ work, but I have no way of telling that because I don't have a SQL DB set up. I have checked for errors and other stuff to the extent I could. As such, maintainers, please review this thoroughly. 
:rotating_light: SQL change needed! :rotating_light: 
```
ALTER TABLE `player`
ADD `lastchangelog` varchar(32) NOT NULL
```

:cl: CrAzYPiLoT
rscadd: Adds an unread change notification.
/:cl: