### PR TITLE
Fixes using teleporter with a GPS

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -123,7 +123,7 @@
 		power_station.teleporter_hub.calibrated = 0
 		set_target(usr)
 		nanomanager.update_uis(src)
-	if(href_list["locked"])
+	if(href_list["lock"])
 		power_station.engaged = 0
 		power_station.teleporter_hub.update_icon()
 		power_station.teleporter_hub.calibrated = 0


### PR DESCRIPTION
The `Get target from memory` button on the teleporter console is supposed to set the target to the GPS's saved location. Unfortunately, while the button's href is `lock`, the code references the href `locked`. I honestly have no idea why it worked before. From the history of it, this part of the code has not been changed in ages, (Before I started playing on this server!), I clearly remember having made use of this feature. Now, on the live server, it doesn't work. In other words, this is confusing as hell.

TL;DR: It's always been broken, but for some reason it used to work while it was broken, and stopped working.