### PR TITLE
Ports holomap blueprints from tg/vg.

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -16,6 +16,7 @@ Pipelines + Other Objects -> Pipe network
 	idle_power_usage = 0
 	active_power_usage = 0
 	power_channel = ENVIRON
+	on_blueprints = TRUE
 	var/nodealert = 0
 	var/can_unwrench = 0
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -23,6 +23,19 @@
 	// Reagent ID => friendly name
 	var/list/reagents_to_log=list()
 
+	var/on_blueprints = FALSE //Are we visible on the station blueprints at roundstart?
+	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
+
+/obj/New()
+	. = ..()
+
+	if(on_blueprints && isturf(loc))
+		var/turf/T = loc
+		if(force_blueprints)
+			T.add_blueprints(src)
+		else
+			T.add_blueprints_preround(src)
+
 /obj/Topic(href, href_list, var/nowindow = 0, var/datum/topic_state/state = default_state)
 	// Calling Topic without a corresponding window open causes runtime errors
 	if(!nowindow && ..())

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -29,6 +29,8 @@
 
 	var/image/obscured	//camerachunks
 
+	var/list/blueprint_data //for the station blueprints, images of objects eg: pipes
+
 	var/list/footstep_sounds = list()
 	var/shoe_running_volume = 50
 	var/shoe_walking_volume = 20
@@ -161,6 +163,7 @@
 	var/old_dynamic_lighting = dynamic_lighting
 	var/list/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
+	var/old_blueprint_data = blueprint_data
 
 	if(air_master)
 		air_master.remove_from_active(src)
@@ -170,6 +173,7 @@
 	if(istype(W, /turf/simulated))
 		W:Assimilate_Air()
 		W.RemoveLattice()
+	W.blueprint_data = old_blueprint_data
 
 	for(var/turf/space/S in range(W,1))
 		S.update_starlight()
@@ -385,3 +389,19 @@
 
 /turf/proc/can_lay_cable()
 	return can_have_cabling() & !intact
+
+/turf/proc/add_blueprints(atom/movable/AM)
+	var/image/I = new
+	I.appearance = AM.appearance
+	I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
+	I.loc = src
+	I.dir = AM.dir
+	I.alpha = 128
+
+	if(!blueprint_data)
+		blueprint_data = list()
+	blueprint_data += I
+
+/turf/proc/add_blueprints_preround(atom/movable/AM)
+	if(!ticker || ticker.current_state != GAME_STATE_PLAYING)
+		add_blueprints(AM)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -25,6 +25,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable
 	level = 1
 	anchored =1
+	on_blueprints = TRUE
 	var/datum/powernet/powernet
 	name = "power cable"
 	desc = "A flexible superconducting cable for heavy-duty power transfer"

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -10,6 +10,7 @@
 	name = null
 	icon = 'icons/obj/power.dmi'
 	anchored = 1.0
+	on_blueprints = TRUE
 	var/datum/powernet/powernet = null
 	use_power = 0
 	idle_power_usage = 0

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -14,6 +14,7 @@
 	icon_state = "disposal"
 	anchored = 1
 	density = 1
+	on_blueprints = TRUE
 	var/datum/gas_mixture/air_contents	// internal reservoir
 	var/mode = 1	// item mode 0=off 1=charging 2=charged
 	var/flush = 0	// true if flush handle is pulled
@@ -656,6 +657,7 @@
 	anchored = 1
 	density = 0
 
+	on_blueprints = TRUE
 	level = 1			// underfloor only
 	var/dpdir = 0		// bitmask of pipe directions
 	dir = 0				// dir will contain dominant direction for junction pipes


### PR DESCRIPTION
https://github.com/tgstation/-tg-station/pull/16729
Changes:
 - Clicking "view structural data" in the station blueprints menu will
   show you ghost images of where things like disposal pipes, wires,
   atmospherics pipes, and other power machinery are originally supposed
   to go. Note, this will show you the ghost images over turfs even if the
   machinery is destroyed.

![](https://puu.sh/oHYFD/debc890371.png)
![](https://puu.sh/oHYH0/96e5434fa9.png)

:cl:
rscadd: The station blueprints can now show you where wires/pipes/disposal pipes are supposed to go.
/:cl: