### PR TITLE
Gamma armory exploit fix + CC control wand

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -239,6 +239,7 @@
 #define REGION_ENGINEERING	5
 #define REGION_SUPPLY		6
 #define REGION_COMMAND		7
+#define REGION_COMMAND		8
 
 //Matricies
 #define MATRIX_DEFAULT list(1, 0, 0, 0,\

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -239,7 +239,7 @@
 #define REGION_ENGINEERING	5
 #define REGION_SUPPLY		6
 #define REGION_COMMAND		7
-#define REGION_COMMAND		8
+#define REGION_CENTCOMM		8
 
 //Matricies
 #define MATRIX_DEFAULT list(1, 0, 0, 0,\

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -267,6 +267,8 @@
 			return list(access_mailsorting, access_mining, access_mining_station, access_mineral_storeroom, access_cargo, access_qm)
 		if(REGION_COMMAND) //command
 			return list(access_heads, access_RC_announce, access_keycard_auth, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_tcomsat, access_gateway, access_all_personal_lockers, access_heads_vault, access_blueshield, access_ntrep, access_hop, access_captain)
+		if(REGION_CENTCOMM) //because why the heck not
+			return get_all_centcom_access() + get_all_accesses()
 
 /proc/get_region_accesses_name(code)
 	switch(code)
@@ -286,6 +288,8 @@
 			return "Supply"
 		if(REGION_COMMAND) //command
 			return "Command"
+		if(REGION_CENTCOMM) //CC
+			return "CentComm"
 
 
 /proc/get_access_desc(A)
@@ -600,4 +604,3 @@ proc/get_all_job_icons() //For all existing HUD icons
 		return
 
 	return "Unknown" //Return unknown if none of the above apply
-

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -58,6 +58,7 @@
 	var/doorDeni = 'sound/machines/DeniedBeep.ogg' // i'm thinkin' Deni's
 	var/boltUp = 'sound/machines/BoltsUp.ogg'
 	var/boltDown = 'sound/machines/BoltsDown.ogg'
+	var/is_special = 0
 
 /obj/machinery/door/airlock/command
 	name = "Airlock"
@@ -126,6 +127,7 @@
 	hackProof = 1
 	aiControlDisabled = 1
 	unacidable = 1
+	is_special = 1
 
 /obj/machinery/door/airlock/maintenance_hatch
 	name = "Maintenance Hatch"
@@ -304,6 +306,7 @@
 	desc = "A mysterious alien airlock with a complicated opening mechanism."
 	hackProof = 1
 	icon = 'icons/obj/doors/Doorplasma.dmi'
+	is_special = 1
 
 /obj/machinery/door/airlock/alien/bumpopen(mob/living/user as mob)
 	if(istype(user,/mob/living/carbon/alien) || isrobot(user) || isAI(user))
@@ -799,7 +802,6 @@ About the new airlock wires panel:
 		else
 			return
 	else if(istype(C, /obj/item/weapon/screwdriver))
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
 		src.p_open = !( src.p_open )
 		src.update_icon()
 	else if(istype(C, /obj/item/weapon/wirecutters))

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -58,6 +58,8 @@
 				else
 					D.emergency = 1
 				D.update_icon()
+	else
+		to_chat(user, "<span class='danger'>[src] does not have access to this door.</span>")
 
 /obj/item/weapon/door_remote/omni
 	name = "omni door remote"

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -58,8 +58,6 @@
 				else
 					D.emergency = 1
 				D.update_icon()
-	else if(!(D.is_special)) //so we don't get double messages for special doors
-		to_chat(user, "<span class='danger'>[src] does not have access to this door.</span>")
 
 /obj/item/weapon/door_remote/omni
 	name = "omni door remote"

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -31,6 +31,9 @@
 /obj/item/weapon/door_remote/afterattack(obj/machinery/door/airlock/D, mob/user)
 	if(!istype(D))
 		return
+	if(D.is_special)
+		to_chat(user, "<span class='danger'>[src] cannot access this kind of door!</span>")
+		return
 	if(!(D.arePowerSystemsOn()))
 		to_chat(user, "<span class='danger'>[D] has no power!</span>")
 		return
@@ -55,7 +58,7 @@
 				else
 					D.emergency = 1
 				D.update_icon()
-	else
+	else if(!(D.is_special)) //so we don't get double messages for special doors
 		to_chat(user, "<span class='danger'>[src] does not have access to this door.</span>")
 
 /obj/item/weapon/door_remote/omni
@@ -98,6 +101,12 @@
 	name = "civillian door remote"
 	icon_state = "gangtool-white"
 	region_access = REGION_GENERAL
+
+/obj/item/weapon/door_remote/centcomm
+	name = "centcomm door remote"
+	desc = "High-ranking NT officials only."
+	icon_state = "gangtool-blue"
+	region_access = REGION_CENTCOMM
 
 #undef WAND_OPEN
 #undef WAND_BOLT


### PR DESCRIPTION
Fixes #4370.

:cl: CrAzYPiLoT
fix: Fixes potential exploits involving door remotes.
rscadd: Adds another type of remote door control.
/:cl: