### PR TITLE
Fixes a dumb involving Raging Mage creation

### DIFF
--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -118,8 +118,6 @@
 
 	if(making_mage || shuttle_master.emergency.mode >= SHUTTLE_ESCAPE)
 		return 0
-	if(mages_made >= max_mages)
-		return 0
 	making_mage = 1
 	var/list/candidates = list()
 	var/mob/dead/observer/harry = null


### PR DESCRIPTION
This check was redundant and forgot that I left `max_mages` at 0 by default anyways, to allow for variable numbers of players.

:cl:Crazylemon
bugfix: Ragin' Mage creation works correctly again.
/:cl: