### PR TITLE
Simple Animal Damage Fix+Change

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -97,8 +97,7 @@
 
 /mob/living/simple_animal/hostile/swarmer/emp_act()
 	if(health > 1)
-		health = 1
-		return
+		adjustHealth(health-1)
 	else
 		death()
 
@@ -515,7 +514,7 @@
 		return
 	to_chat(src, "<span class='info'>Attempting to repair damage to our body, stand by...</span>")
 	if(do_mob(src, src, 100))
-		adjustBruteLoss(-100)
+		adjustHealth(-100)
 		to_chat(src, "<span class='info'>We successfully repaired ourselves.</span>")
 
 /mob/living/simple_animal/hostile/swarmer/proc/ToggleLight()

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -86,7 +86,7 @@
 		hud_used.guardianhealthdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#efeeef'>[resulthealth]%</font></div>"
 
 
-/mob/living/simple_animal/hostile/guardian/adjustBruteLoss(amount) //The spirit is invincible, but passes on damage to the summoner
+/mob/living/simple_animal/hostile/guardian/adjustHealth(amount) //The spirit is invincible, but passes on damage to the summoner
 	var/damage = amount * damage_transfer
 	if (summoner)
 		if(loc == summoner)

--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -162,7 +162,7 @@
 		if(L.stat == DEAD)
 			if(do_after(src, 30, target = L))
 				if(eat(L))
-					heal_overall_damage(50,50)
+					adjustHealth(-50)
 			return
 	else if(istype(target,/obj/item)) // Eat items just to be annoying
 		var/obj/item/I = target

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -81,7 +81,7 @@
 /mob/living/simple_animal/revenant/narsie_act()
 	return //most humans will now be either bones or harvesters, but we're still un-alive.
 
-/mob/living/simple_animal/revenant/adjustBruteLoss(amount)
+/mob/living/simple_animal/revenant/adjustHealth(amount)
 	if(!revealed)
 		return
 	essence = max(0, essence-amount)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -811,7 +811,7 @@
 		O.forceMove(loc)
 	return
 
-/mob/living/simple_animal/hostile/mining_drone/adjustBruteLoss()
+/mob/living/simple_animal/hostile/mining_drone/adjustHealth()
 	if(search_objects)
 		SetOffenseBehavior()
 	..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -216,17 +216,10 @@
 	else
 		to_chat(user, "[src] is in pristine condition.")
 
-/mob/living/simple_animal/bot/adjustBruteLoss(amount)
-	. = ..()
-
+/mob/living/simple_animal/bot/adjustHealth(amount)
 	if(amount > 0 && prob(10))
 		new /obj/effect/decal/cleanable/blood/oil(loc)
-
-/mob/living/simple_animal/bot/adjustFireLoss(amount)
-	. = ..()
-
-	if(amount > 0 && prob(5))
-		new /obj/effect/decal/cleanable/blood/oil(loc)
+	return ..(amount)
 
 /mob/living/simple_animal/bot/updatehealth()
 	..()
@@ -346,9 +339,7 @@
 				return
 			var/obj/item/weapon/weldingtool/WT = W
 			if(WT.remove_fuel(0, user))
-				adjustBruteLoss(-10)
-				adjustFireLoss(-10)
-				updatehealth()
+				adjustHealth(-10)
 				add_fingerprint(user)
 				user.visible_message("[user] repairs [src]!","<span class='notice'>You repair [src].</span>")
 			else

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -21,6 +21,7 @@
 	attacktext = "kicks"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	health = 40
+	maxHealth = 40
 	melee_damage_lower = 1
 	melee_damage_upper = 2
 	stop_automated_movement_when_pulled = 1
@@ -109,6 +110,7 @@
 	attacktext = "kicks"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	health = 50
+	maxHealth = 50
 	var/milk_content = 0
 	can_collar = 1
 	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
@@ -172,7 +174,8 @@
 	response_disarm = "gently pushes aside the"
 	response_harm   = "kicks the"
 	attacktext = "kicks"
-	health = 1
+	health = 3
+	maxHealth = 3
 	ventcrawler = 2
 	var/amount_grown = 0
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
@@ -216,6 +219,7 @@ var/global/chicken_count = 0
 	response_harm   = "kicks the"
 	attacktext = "kicks"
 	health = 10
+	maxHealth = 10
 	var/eggsleft = 0
 	var/chicken_color
 	pass_flags = PASSTABLE | PASSMOB
@@ -299,6 +303,7 @@ var/global/chicken_count = 0
 	response_harm   = "kicks the"
 	attacktext = "kicks"
 	health = 50
+	maxHealth = 50
 	can_collar = 1
 	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
@@ -321,6 +326,7 @@ var/global/chicken_count = 0
 	response_harm   = "kicks the"
 	attacktext = "pecks"
 	health = 50
+	maxHealth = 50
 	can_collar = 1
 	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
@@ -343,6 +349,7 @@ var/global/chicken_count = 0
 	response_harm   = "kicks the"
 	attacktext = "kicks"
 	health = 50
+	maxHealth = 50
 	can_collar = 1
 	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
@@ -365,6 +372,7 @@ var/global/chicken_count = 0
 	response_harm   = "kicks the"
 	attacktext = "kicks"
 	health = 50
+	maxHealth = 50
 	can_collar = 1
 	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 
@@ -387,5 +395,6 @@ var/global/chicken_count = 0
 	response_harm   = "kicks the"
 	attacktext = "kicks"
 	health = 50
+	maxHealth = 50
 	can_collar = 1
 	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -38,6 +38,7 @@
 	icon_living = "aliend_running"
 	icon_dead = "aliend_l"
 	health = 60
+	maxHealth = 60
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	var/plant_cooldown = 30
@@ -59,6 +60,7 @@
 	icon_living = "aliens_running"
 	icon_dead = "aliens_l"
 	health = 120
+	maxHealth = 120
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	ranged = 1

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -41,6 +41,7 @@
 	name = "Strong Hivebot"
 	desc = "A robot, this one is armed and looks tough!"
 	health = 80
+	maxHealth = 80
 	ranged = 1
 
 /mob/living/simple_animal/hostile/hivebot/death()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -186,7 +186,7 @@
 /mob/living/simple_animal/hostile/proc/Goto(var/target, var/delay, var/minimum_distance)
 	walk_to(src, target, minimum_distance, delay)
 
-/mob/living/simple_animal/hostile/adjustBruteLoss(var/damage)
+/mob/living/simple_animal/hostile/adjustHealth(damage)
 	..(damage)
 	if(!stat && search_objects < 3)//Not unconscious, and we don't ignore mobs
 		if(search_objects)//Turn off item searching and ignore whatever item we were looking at, we're more concerned with fight or flight

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -99,7 +99,7 @@
 		visible_message("<b>[src]</b> starts to move!")
 		attempt_open = 1
 
-/mob/living/simple_animal/hostile/mimic/crate/adjustBruteLoss(var/damage)
+/mob/living/simple_animal/hostile/mimic/crate/adjustHealth(damage)
 	trigger()
 	..(damage)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -204,7 +204,7 @@
 	Reward()
 	..()
 
-/mob/living/simple_animal/hostile/asteroid/goldgrub/adjustBruteLoss(var/damage)
+/mob/living/simple_animal/hostile/asteroid/goldgrub/adjustHealth(damage)
 	idle_vision_range = 9
 	..()
 
@@ -403,7 +403,7 @@
 		pre_attack = 0
 	return
 
-/mob/living/simple_animal/hostile/asteroid/goliath/adjustBruteLoss(var/damage)
+/mob/living/simple_animal/hostile/asteroid/goliath/adjustHealth(damage)
 	ranged_cooldown--
 	handle_preattack()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -59,7 +59,7 @@
 	health = maxHealth
 	..()
 
-/mob/living/simple_animal/hostile/mushroom/adjustBruteLoss(var/damage)//Possibility to flee from a fight just to make it more visually interesting
+/mob/living/simple_animal/hostile/mushroom/adjustHealth(damage)//Possibility to flee from a fight just to make it more visually interesting
 	if(!retreat_distance && prob(33))
 		retreat_distance = 5
 		spawn(30)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -61,7 +61,7 @@
 			H.enemies |= enemies
 	return 0
 
-/mob/living/simple_animal/hostile/retaliate/adjustBruteLoss(var/damage)
+/mob/living/simple_animal/hostile/retaliate/adjustHealth(damage)
 	..(damage)
 	Retaliate()
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -71,7 +71,7 @@
 	if(!Proj)	return
 	if(prob(65))
 		if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
-			src.health -= Proj.damage
+			adjustHealth(Proj.damage)
 	else
 		visible_message("\red <B>[src] blocks [Proj] with its shield!</B>")
 	return 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -404,22 +404,18 @@
 			if(health < maxHealth)
 				if(MED.amount >= 1)
 					if(MED.heal_brute >= 1)
-						adjustBruteLoss(-MED.heal_brute)
-						MED.amount -= 1
-						if(MED.amount <= 0)
-							qdel(MED)
-						for(var/mob/M in viewers(src, null))
-							if ((M.client && !( M.blinded )))
-								M.show_message("\blue [user] applies [MED] on [src]")
+						heal_organ_damage((MED.heal_brute * 1.66), (MED.heal_burn * 1.66))
+						MED.use(1)
+						visible_message("<span class='notice'>[user] applies [MED] on [src]</span>")
 						return
 					else
-						to_chat(user, "\blue [MED] won't help at all.")
+						to_chat(user, "<span class='notice'>[MED] won't help at all.</span>")
 						return
 			else
-				to_chat(user, "\blue [src] is at full health.")
+				to_chat(user, "<span class='notice'>[src] is at full health.</span>")
 				return
 		else
-			to_chat(user, "\blue [src] is dead, medical items won't bring it back to life.")
+			to_chat(user, "<span class='notice'>[src] is dead, medical items won't bring it back to life.</span>")
 			return
 	else if(can_collar && !collar && istype(O, /obj/item/clothing/accessory/petcollar))
 		var/obj/item/clothing/accessory/petcollar/C = O

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -492,25 +492,31 @@
 		if(3.0)
 			adjustBruteLoss(30)
 
+/mob/living/simple_animal/proc/adjustHealth(amount)
+	if(status_flags & GODMODE)
+		return 0
+	bruteloss = Clamp(bruteloss + amount, 0, maxHealth)
+	handle_regular_status_updates()
+
 /mob/living/simple_animal/adjustBruteLoss(amount)
 	if(damage_coeff[BRUTE])
-		return ..(amount * damage_coeff[BRUTE])
+		adjustHealth(amount * damage_coeff[BRUTE])
 
 /mob/living/simple_animal/adjustFireLoss(amount)
 	if(damage_coeff[BURN])
-		return ..(amount * damage_coeff[BURN])
+		adjustHealth(amount * damage_coeff[BURN])
 
 /mob/living/simple_animal/adjustOxyLoss(amount)
 	if(damage_coeff[OXY])
-		return ..(amount * damage_coeff[OXY])
+		adjustHealth(amount * damage_coeff[OXY])
 
 /mob/living/simple_animal/adjustToxLoss(amount)
 	if(damage_coeff[TOX])
-		return ..(amount * damage_coeff[TOX])
+		adjustHealth(amount * damage_coeff[TOX])
 
 /mob/living/simple_animal/adjustCloneLoss(amount)
 	if(damage_coeff[CLONE])
-		return ..(amount * damage_coeff[CLONE])
+		adjustHealth(amount * damage_coeff[CLONE])
 
 /mob/living/simple_animal/adjustStaminaLoss(amount)
 	if(damage_coeff[STAMINA])


### PR DESCRIPTION
Fixes some improper handling of damage against simple animals in relation to brute resist vs other types of damage resists. https://github.com/tgstation/-tg-station/pull/14388 

Also fixes simple animal's not dying, immediately, once their health got low, making some mobs tougher to kill than usual  or them able to get off an extra attack (hivelords, in particular, were especially bad, because of this).

Other
- Slightly refactored usage of medical packs on simple animals to use proper procs, spans, etc.
- Buffed medical pack to they heal roughly the same as they do on TG.

:cl: Fox McCloud
bugfix: Fixes simple animals not dying right away when they reach zero health
bugfix: Fixes a few farm animals, simple xenos, and a hivebot from having incorrect health
tweak: Buffed health pack usage on simple animals (should heal roughly 20 damage on them, per use)
/:cl: