### PR TITLE
Emotes work when not in lowercase

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/emote.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/emote.dm
@@ -8,7 +8,7 @@
 //	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 //		act = copytext(act,1,length(act))	//seriously who the fuck wrote this
 	var/muzzled = is_muzzled()
-
+	act = lowertext(act)
 	switch(act)
 		if("sign")
 			if(!restrained())

--- a/code/modules/mob/living/carbon/alien/larva/emote.dm
+++ b/code/modules/mob/living/carbon/alien/larva/emote.dm
@@ -8,7 +8,7 @@
 	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 		act = copytext(act,1,length(act))
 	var/muzzled = is_muzzled()
-
+	act = lowertext(act)
 	switch(act)
 		if ("me")
 			if(silent)

--- a/code/modules/mob/living/carbon/brain/emote.dm
+++ b/code/modules/mob/living/carbon/brain/emote.dm
@@ -11,6 +11,7 @@
 
 	if(src.stat == DEAD)
 		return
+	act = lowertext(act)
 	switch(act)
 
 		if ("alarm")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -25,6 +25,7 @@
 	//Emote Cooldown System (it's so simple!)
 	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
+	act = lowertext(act)
 	switch(act)
 		//Cooldown-inducing emotes
 		if("ping", "pings", "buzz", "buzzes", "beep", "beeps", "yes", "no")

--- a/code/modules/mob/living/carbon/slime/emote.dm
+++ b/code/modules/mob/living/carbon/slime/emote.dm
@@ -7,6 +7,7 @@
 	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 		act = copytext(act,1,length(act))
 
+	act = lowertext(act)
 	switch(act) //Alphabetical please
 		if ("me")
 			if(silent)

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -8,6 +8,7 @@
 	//Emote Cooldown System (it's so simple!)
 	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
+	act = lowertext(act)
 	switch(act)
 		//Cooldown-inducing emotes
 		if("scream", "screams")

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -8,6 +8,7 @@
 	//Emote Cooldown System (it's so simple!)
 	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
+	act = lowertext(act)
 	switch(act)
 		//Cooldown-inducing emotes
 		if("law","flip","flips","halt")		//halt is exempt because it's used to stop criminal scum //WHOEVER THOUGHT THAT WAS A GOOD IDEA IS GOING TO GET SHOT.

--- a/code/modules/mob/living/simple_animal/bot/emote.dm
+++ b/code/modules/mob/living/simple_animal/bot/emote.dm
@@ -11,6 +11,7 @@
 	//Emote Cooldown System (it's so simple!)
 	// proc/handle_emote_CD() located in [code\modules\mob\emote.dm]
 	var/on_CD = 0
+	act = lowertext(act)
 	switch(act)
 		//Cooldown-inducing emotes
 		if("scream", "screams")

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -250,18 +250,19 @@
 	return
 
 /mob/living/simple_animal/diona/emote(var/act, var/m_type=1, var/message = null)
-	if(stat)	
+	if(stat)
 		return
-		
+
 	var/on_CD = 0
+	act = lowertext(act)
 	switch(act)
 		if("chirp")
-			on_CD = handle_emote_CD()			
+			on_CD = handle_emote_CD()
 		else
-			on_CD = 0	
+			on_CD = 0
 
 	if(on_CD == 1)
-		return			
+		return
 
 	switch(act) //IMPORTANT: Emotes MUST NOT CONFLICT anywhere along the chain.
 		if("chirp")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -269,8 +269,9 @@
 	return
 
 /mob/living/simple_animal/emote(var/act, var/m_type=1, var/message = null)
-	if(stat)	return
-
+	if(stat)
+		return
+	act = lowertext(act)
 	switch(act) //IMPORTANT: Emotes MUST NOT CONFLICT anywhere along the chain.
 		if("scream")
 			message = "<B>\The [src]</B> whimpers."


### PR DESCRIPTION

Emotes no longer needs to be purely lowercase to work. Meaning *flip, *Flip, *fLiP, etc will work for making you do the flip emote.

:cl: Fox McCloud
tweak: Emotes no longer need to be purely lowercase to work
/:cl: