### PR TITLE
Adds teleporter implant

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -280,6 +280,17 @@
 	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
 	category = list("Misc", "Medical")
 
+/datum/design/cyberimp_teleport
+	name = "Teleporter implant"
+	desc = "This implant will teleport you to a selected beacon when triggered."
+	id = "ci-teleporter"
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 6, "bluespace" = 5)
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_DIAMOND = 2000)
+	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
+	category = list("Misc", "Medical")
+
 /datum/design/cyberimp_nutriment
 	name = "Nutriment pump implant"
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are starving."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -288,7 +288,7 @@
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 60
 	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_DIAMOND = 2000)
-	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
+	build_path = /obj/item/organ/internal/cyberimp/brain/teleport
 	category = list("Misc", "Medical")
 
 /datum/design/cyberimp_nutriment

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -185,11 +185,11 @@
 		to_chat(owner, "<span class='warning'>\The [src] is still cooling down!")
 		return
 	playsound(owner.loc, 'sound/weapons/flash.ogg', 25, 1)
+	cooldown = world.time + 300
 	sleep(20)
 	if(owner.incapacitated())
 		return
 	do_teleport(owner, teleport_target, 1)
-	cooldown = world.time + 300
 
 //[[[[CHEST]]]]
 /obj/item/organ/internal/cyberimp/chest

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -177,6 +177,8 @@
 	teleport_target = L[desc]
 
 /obj/item/organ/internal/cyberimp/brain/teleport/ui_action_click()
+	if(owner.incapacitated())
+		return
 	if(world.time < cooldown)
 		to_chat(owner, "<span class='warning'>\The [src] is still cooling down!")
 		return

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -184,6 +184,10 @@
 	if(world.time < cooldown)
 		to_chat(owner, "<span class='warning'>\The [src] is still cooling down!")
 		return
+	playsound(owner.loc, 'sound/weapons/flash.ogg', 25, 1)
+	sleep(20)
+	if(owner.incapacitated())
+		return
 	do_teleport(owner, teleport_target, 1)
 	cooldown = world.time + 300
 

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -173,7 +173,9 @@
 			areaindex[tmpname] = 1
 		L[tmpname] = R
 
-	var/desc = input("Please select a location to lock in.", "[src]") in L
+	var/desc = input("Please select a location to lock in.", "[src]") as null|anything in L
+	if(!desc)
+		return
 	teleport_target = L[desc]
 
 /obj/item/organ/internal/cyberimp/brain/teleport/ui_action_click()

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -144,6 +144,45 @@
 	spawn(90 / severity)
 		crit_fail = 0
 
+/obj/item/organ/internal/cyberimp/brain/teleport
+	name = "teleporter implant"
+	desc = "Allows you to teleport yourself to a tracking beacon."
+	var/cooldown = 0
+	implant_color = "#007eDe"
+	organ_action_name = "Teleport"
+	slot = "brain_teleport"
+	origin_tech = "materials=5;programming=4;biotech=4;bluespace=5"
+	var/atom/teleport_target
+
+/obj/item/organ/internal/cyberimp/brain/teleport/attack_self(mob/living/user as mob) // Blatantly copy-pasted from teleguns.
+	var/list/L = list()
+	var/list/areaindex = list()
+
+	for(var/obj/item/device/radio/beacon/R in beacons)
+		var/turf/T = get_turf(R)
+		if (!T)
+			continue
+		if((T.z in config.admin_levels) || T.z > 7)
+			continue
+		if(R.syndicate == 1)
+			continue
+		var/tmpname = T.loc.name
+		if(areaindex[tmpname])
+			tmpname = "[tmpname] ([++areaindex[tmpname]])"
+		else
+			areaindex[tmpname] = 1
+		L[tmpname] = R
+
+	var/desc = input("Please select a location to lock in.", "[src]") in L
+	teleport_target = L[desc]
+
+/obj/item/organ/internal/cyberimp/brain/teleport/ui_action_click()
+	if(world.time < cooldown)
+		to_chat(owner, "<span class='warning'>\The [src] is still cooling down!")
+		return
+	do_teleport(owner, teleport_target, 1)
+	cooldown = world.time + 300
+
 //[[[[CHEST]]]]
 /obj/item/organ/internal/cyberimp/chest
 	name = "cybernetic torso implant"


### PR DESCRIPTION
Adds a teleporter implant item.

- Select a target to teleport to before implanting
- After implanting, click the ui icon at any time to teleport yourself to the tracking beacon.
- 30 second cooldown.
- No, you cannot select emagged targets.
- If you are incapacitated in any way, you can go fuck yourself.
- When teleporting, there is a sound and a 2 second delay. If you are incapacitated in any way after that 2 second delay, you can go fuck yourself.

If needed, I can lockbox it. Or anything. **ANYTHING TO QUIT MY DEPENDENCE ON THE HAND TELE!!!**

:cl: monster860
rscadd: Adds the teleporter implant.
/:cl: