### PR TITLE
TG Traitor Objectives Assignment

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -68,6 +68,8 @@
 	var/assistantlimit = 0 //enables assistant limiting
 	var/assistantratio = 2 //how many assistants to security members
 
+	var/traitor_objectives_amount = 2
+
 	var/max_maint_drones = 5				//This many drones can spawn,
 	var/allow_drone_spawn = 1				//assuming the admin allow them to.
 	var/drone_build_time = 1200				//A drone will become available every X ticks since last drone spawn. Default is 2 minutes.
@@ -598,6 +600,8 @@
 					config.limbs_can_break = value
 				if("shuttle_refuel_delay")
 					config.shuttle_refuel_delay     = text2num(value)
+				if("traitor_objectives_amount")
+					config.traitor_objectives_amount = text2num(value)
 				if("reactionary_explosions")
 					config.reactionary_explosions	= 1
 				if("bombcap")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -485,13 +485,13 @@
 			if(!def_value)//If it's a custom objective, it will be an empty string.
 				def_value = "custom"
 
-		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "blood", "debrain", "protect", "prevent", "harm", "brig", "hijack", "escape", "survive", "steal", "download", "nuclear", "capture", "absorb", "destroy", "maroon", "identity theft", "custom")
+		var/new_obj_type = input("Select objective type:", "Objective type", def_value) as null|anything in list("assassinate", "blood", "debrain", "protect", "prevent", "brig", "hijack", "escape", "survive", "steal", "download", "nuclear", "capture", "absorb", "destroy", "maroon", "identity theft", "custom")
 		if (!new_obj_type) return
 
 		var/datum/objective/new_objective = null
 
 		switch (new_obj_type)
-			if ("assassinate","protect","debrain", "harm", "brig", "maroon")
+			if ("assassinate","protect","debrain", "brig", "maroon")
 				//To determine what to name the objective in explanation text.
 				var/objective_type_capital = uppertext(copytext(new_obj_type, 1,2))//Capitalize first letter.
 				var/objective_type_text = copytext(new_obj_type, 2)//Leave the rest of the text.

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -177,6 +177,8 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 		return 1
 
 /datum/objective/debrain //I want braaaainssss
+	martyr_compatible = 0
+
 	find_target()
 		..()
 		if(target && target.current)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -128,6 +128,11 @@
 					destroy_objective.owner = traitor
 					destroy_objective.find_target()
 					traitor.objectives += destroy_objective
+				else if(prob(5))
+					var/datum/objective/debrain/debrain_objective = new
+					debrain_objective.owner = traitor
+					debrain_objective.find_target()
+					traitor.objectives += debrain_objective
 				else if(prob(30))
 					var/datum/objective/maroon/maroon_objective = new
 					maroon_objective.owner = traitor

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -54,6 +54,10 @@ ANIMAL_DELAY 0
 ## Uncomment for explosions that react to doors and walls
 REACTIONARY_EXPLOSIONS
 
+# The number of objectives traitors get.
+# Not including escaping/hijacking.
+TRAITOR_OBJECTIVES_AMOUNT 2
+
 ### Configure the bomb cap
 ## This caps all explosions to the specified range. Used for both balance reasons and to prevent overloading the server and lagging the game out.
 ## This is given as the 3rd number(light damage) in the standard (1,2,3) explosion notation. The other numbers are derived by dividing by 2 and 4.


### PR DESCRIPTION
Ports over TG's traitor assignment.

Without going into tons of details, basically this allows for the amount of traitor objectives to be customized, server side---it defaults to 2+hijack/escape/die a glorious death.

It also ensures that you can't get impossible combinations, like stealing an item then "die a glorious death" (as that doesn't make sense ICly and generates problems from a mechanics perspective).

This will introduce players to the "maroon" objective, which allows you to either kill *or* prevent them from getting off on the shuttle.

Objectives Removed from traitor
- Minimize casualties
 - Implied in server rules (even if it wasn't, this is pretty dull)
- Harm
 - This is just a conditional assassination, in practice; if the person gets their face fixed or their bones fixed, then this objective fails, so, in practice, you have to kill them.

Objectives out and out removed from the code:
- "harm". That is to say, the break someone's bones/disfigure their face
- Some old "anti revolution" objectives; no idea where these were even used at

:cl: Fox MCCloud
tweak: Removes "harm" traitor objective
tweak: Increases non-escape/hijack/die objectives from 1 to 2
tweak: Tweaks available objectives to traitors a bit
/:cl: