### PR TITLE
Fixes closets runtiming on some turf types, AStar on edges

### DIFF
--- a/code/defines/procs/AStar.dm
+++ b/code/defines/procs/AStar.dm
@@ -157,7 +157,7 @@ Actual Adjacent procs :
 
 	for(var/dir in cardinal)
 		T = get_step(src,dir)
-		if(simulated_only && !istype(T))
+		if(!T || (simulated_only && !istype(T)))
 			continue
 		if(!T.density && !LinkBlockedWithAccess(T,caller, ID))
 			L.Add(T)

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -2327,6 +2327,7 @@ area/security/podbay
 /area/awaymission
 	name = "\improper Strange Location"
 	icon_state = "away"
+	report_alerts = 0
 
 /area/awaymission/example
 	name = "\improper Strange Station"

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -22,7 +22,7 @@
 	recharging_mecha = null
 	return ..()
 
-/turf/simulated/floor/mech_bay_recharge_floor/Entered(var/obj/mecha/mecha)
+/turf/simulated/floor/mech_bay_recharge_floor/Entered(var/obj/mecha/mecha, atom/OL, ignoreRest = 0)
 	. = ..()
 	if(istype(mecha))
 		mecha.occupant_message("<b>Initializing power control devices.</b>")

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -67,7 +67,7 @@
 		else
 			to_chat(user, "<span class='warning'>The plating is going to need some support! Place metal rods first.</span>")
 
-/turf/space/Entered(atom/movable/A as mob|obj)
+/turf/space/Entered(atom/movable/A as mob|obj, atom/OL, ignoreRest = 0)
 	..()
 	
 	if(destination_z && A && (src in A.locs))

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -85,7 +85,7 @@
 /turf/space/transit/horizontal
 	dir = WEST
 
-/turf/space/transit/Entered(atom/movable/AM, atom/OldLoc)
+/turf/space/transit/Entered(atom/movable/AM, atom/OldLoc, ignoreRest = 0)
 	if(!AM)
 		return
 	if(istype(AM, /obj/docking_port) || !AM.simulated)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -121,7 +121,7 @@
 	return 1 //Nothing found to block so return success!
 
 
-/turf/Entered(atom/movable/M)
+/turf/Entered(atom/movable/M, atom/OL, ignoreRest = 0)
 	if(ismob(M))
 		var/mob/O = M
 		if(!O.lastarea)

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -19,9 +19,6 @@
  * Areas
  */
  //Gateroom gets its own APC specifically for the gate
- /area/awaymission
-	report_alerts = 0
-
  /area/awaymission/gateroom
 
  //Library, medbay, storage room


### PR DESCRIPTION
- Adds ignoreRest param to all implementation of the Entered() proc, as closets were throwing runtimes without it.
- Adds a check so that AStar doesn't throw a runtime if it reaches the edge of the map (arguably this normally shouldn't happen, but so that space-bound things, etc can astar around without crashing.
- Moves a single initial var assignment for `/area/awaymission` that was in a completely different file to the main definition, because that was weird.