### PR TITLE
Removes Players Ready From Lobby

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -88,13 +88,17 @@
 			stat("Time To Start:", "DELAYED")
 
 		if(ticker.current_state == GAME_STATE_PREGAME)
-			stat("Players: [totalPlayers]", "Players Ready: [totalPlayersReady]")
+			stat("Players:", "[totalPlayers]")
+			if(client.holder)
+				stat("Players Ready:", "[totalPlayersReady]")
 			totalPlayers = 0
 			totalPlayersReady = 0
 			for(var/mob/new_player/player in player_list)
-				stat("[player.key]", (player.ready)?("(Playing)"):(null))
+				if(client.holder)
+					stat("[player.key]", (player.ready)?("(Playing)"):(null))
 				totalPlayers++
-				if(player.ready)totalPlayersReady++
+				if(player.ready)
+					totalPlayersReady++
 
 /mob/new_player/Topic(href, href_list[])
 	if(!client)	return 0


### PR DESCRIPTION
The lobby button will now only display the total number of players on the server; it will no longer tell how many players have readied up or who has readied up. This is largely to help cut down on metagaming and guesstimating who is and is not an antag.

Admins are immune to this; they can still see the total number of readied up players and who has readied up.

note: This doesn't disallow you from seeing who is on the server; you can still use "who" for that.

:cl: Fox McCloud
tweak: Players can no longer see how many players have readied up or who has readied up
/:cl: