### PR TITLE
Makes borers not breathe so they can pipe

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -80,6 +80,7 @@
 	density = 0
 	pass_flags = PASSTABLE
 	ventcrawler = 2
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 
 	var/talk_inside_host = 0 				// So that borers don't accidentally give themselves away on a botched message
 	var/used_dominate


### PR DESCRIPTION
Resolves #4393 
Having to breathe and then suffocate in the scrubber pipes is somewhat silly for a creature that is partially based around initially crawling through the pipes, so they are now spaceworthy.