### PR TITLE
Refactors Species Gun Handling

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -43,11 +43,11 @@
 #define HAS_LIPS 		64
 #define IS_PLANT 		128
 #define CAN_BE_FAT 		256
-#define IS_RESTRICTED 	512
-#define NO_INTORGANS	1024
-#define NO_POISON		2048
-#define RADIMMUNE		4096
-#define ALL_RPARTS		8192
+#define NO_INTORGANS	512
+#define NO_POISON		1024
+#define RADIMMUNE		2048
+#define ALL_RPARTS		4096
+#define NOGUNS			8192
 
 //Species clothing flags
 #define HAS_UNDERWEAR 	1

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -301,7 +301,7 @@ Made by Xhuis
 	blood_color = "#555555"
 	flesh_color = "#222222"
 
-	flags = NO_BLOOD | NO_BREATHE | RADIMMUNE
+	flags = NO_BLOOD | NO_BREATHE | RADIMMUNE | NOGUNS //Can't use guns due to muzzle flash
 	burn_mod = 1.5 //1.5x burn damage, 2x is excessive
 	hot_env_multiplier = 1.5
 

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -77,6 +77,11 @@
 	if (!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if((HULK in H.mutations) || (H.species.flags & NOGUNS))
+			user << "<span class='warning'>Your fingers can't press the button!</span>"
+			return
 
 	add_fingerprint(user)
 

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -6,7 +6,7 @@
 	deform = 'icons/mob/human_races/r_golem.dmi'
 
 	default_language = "Galactic Common"
-	flags = NO_BREATHE | NO_BLOOD | RADIMMUNE
+	flags = NO_BREATHE | NO_BLOOD | RADIMMUNE | NOGUNS
 	virus_immune = 1
 	dietflags = DIET_OMNI		//golems can eat anything because they are magic or something
 	reagent_tag = PROCESS_ORG

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -34,8 +34,6 @@
 	brute_mod = 1.5
 	burn_mod = 1.5
 
-	flags = IS_RESTRICTED
-
 /datum/species/monkey/handle_npc(var/mob/living/carbon/human/H)
 	if(H.stat != CONSCIOUS)
 		return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -134,11 +134,8 @@
 			return
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.get_species() == "Golem")
-			to_chat(user, "<span class='danger'>Your metal fingers don't fit in the trigger guard!</span>")
-			return
-		if(H.get_species() == "Shadowling")
-			to_chat(user, "<span class='danger'>The muzzle flash would cause damage to your form!</span>")
+		if(H.species.flags & NOGUNS)
+			to_chat(user, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return
 		if(H.martial_art && H.martial_art.name == "The Sleeping Carp") //great dishonor to famiry
 			to_chat(user, "<span class='danger'>Use of ranged weaponry would bring dishonor to the clan.</span>")


### PR DESCRIPTION
From TG

Refactor's a species' ability to use guns based on a species flag rather than individual species checks.

Also makes it so hulks and NOGUNS species cannot use the laser pointer, in consistency with TG.

Code Wise
- Removes unused `IS_RESTRICTED` flag

:cl: Fox McCloud
tweak: Hulks, Shadowlings, and Golems can no longer use laserpointers
/:cl: