### PR TITLE
Adds pAIzing

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -142,6 +142,11 @@ var/global/nologevent = 0
 			if(istype(M, /mob/dead/observer))
 				body += "<a href='?_src_=holder;incarn_ghost=\ref[M]'>Re-incarnate</a> | "
 
+			if(ispAI(M))
+				body += "<B>Is a pAI</B> "
+			else
+				body += "<A href='?_src_=holder;makePAI=\ref[M]'>Make pAI</A> | "
+
 			// DNA2 - Admin Hax
 			if(M.dna && iscarbon(M))
 				body += "<br><br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1142,6 +1142,28 @@
 		message_admins("\blue [key_name_admin(usr)] attempting to corgize [key_name_admin(H)]", 1)
 		H.corgize()
 
+	else if(href_list["makePAI"])
+		if(!check_rights(R_SPAWN))	return
+
+		var/mob/living/carbon/human/H = locate(href_list["makePAI"])
+		if(!istype(H))
+			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+			return
+
+		var/painame = "Default"
+		var/name = ""
+		if(alert(usr, "Do you want to set their name or let them choose their own name?", "Name Choice", "Set Name", "Let them choose") == "Set Name")
+			name = sanitize(copytext(input(usr, "Enter a name for the new pAI. Default name is [painame].", "pAI Name", painame),1,MAX_NAME_LEN))
+		else
+			name = sanitize(copytext(input(H, "An admin wants to make you into a pAI. Choose a name. Default is [painame].", "pAI Name", painame),1,MAX_NAME_LEN))
+
+		if(!name)
+			name = painame
+
+		log_admin("[key_name(usr)] attempting to pAIze [key_name(H)]")
+		message_admins("\blue [key_name_admin(usr)] attempting to pAIze [key_name_admin(H)]", 1)
+		H.paize(name)
+
 	else if(href_list["forcespeech"])
 		if(!check_rights(R_SERVER|R_EVENT))	return
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -319,6 +319,35 @@
 
 	qdel(src)
 
+
+/mob/living/carbon/human/proc/paize(var/name)
+	if(notransform)
+		return
+	for(var/obj/item/W in src)
+		unEquip(W)
+	regenerate_icons()
+	notransform = 1
+	canmove = 0
+	icon = null
+	invisibility = 101
+	for(var/t in organs)	//this really should not be necessary
+		qdel(t)
+
+	var/obj/item/device/paicard/card = new(loc)
+	var/mob/living/silicon/pai/pai = new(card)
+	pai.key = key
+	card.setPersonality(pai)
+
+	pai.name = name
+	pai.real_name = name
+	card.name = name
+
+	to_chat(pai, "<B>You have become a pAI! Your name is [pai.name].</B>")
+	pai.update_pipe_vision()
+	spawn(0)//To prevent the proc from returning null.
+		qdel(src)
+	return
+
 /mob/proc/safe_respawn(var/MP)
 	if(!MP)
 		return 0


### PR DESCRIPTION
Adds making people into pAIs via player panel. This should have been added a long time ago, IMO. You can choose to let the future pAI choose their own name, or choose it yourself. The game _will_ set their job to N/A and their real_name to just 'pAI' and I found no way to remedy this.