### PR TITLE
Makes Load Slot dialog come up on top of Character Preferences

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1673,6 +1673,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				if("open_load_dialog")
 					if(!IsGuestKey(user.key))
 						open_load_dialog(user)
+						return 1
 
 				if("close_load_dialog")
 					close_load_dialog(user)


### PR DESCRIPTION
Make the Load Slot popup come up above the character preferences, instead of being immediately covered up by the Character Preferences popup due to pointless refresh.