### PR TITLE
Makes ceiling visible

### DIFF
--- a/code/game/turfs/ceiling.dm
+++ b/code/game/turfs/ceiling.dm
@@ -1,0 +1,7 @@
+/obj/effect/effect/ceiling
+	name = "ceiling"
+	icon = 'icons/turf/walls/silver_wall.dmi'
+	layer = 5.1
+	smooth = SMOOTH_TRUE
+	mouse_opacity = 0
+	alpha = 0xE0

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -29,6 +29,7 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	var/obj/item/stack/tile/builtin_tile = null //needed for performance reasons when the singularity rips off floor tiles
 	var/list/broken_states = list("damaged1", "damaged2", "damaged3", "damaged4", "damaged5")
 	var/list/burnt_states = list()
+	var/obj/effect/effect/ceiling/ceiling
 
 
 /turf/simulated/floor/New()
@@ -39,11 +40,13 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		icon_regular_floor = icon_state
 	if(floor_tile)
 		builtin_tile = new floor_tile
+	ceiling = new(src)
 
 /turf/simulated/floor/Destroy()
 	if(builtin_tile)
 		qdel(builtin_tile)
 		builtin_tile = null
+	qdel(ceiling)
 	return ..()
 
 

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -2,6 +2,15 @@
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "Floor3"
+	var/obj/effect/effect/ceiling/ceiling
+
+/turf/unsimulated/floor/New()
+	..()
+	ceiling = new(src)
+
+/turf/unsimulated/floor/Destroy()
+	qdel(ceiling)
+	return ..()
 
 /turf/unsimulated/floor/grass
 	icon_state = "grass1"

--- a/paradise.dme
+++ b/paradise.dme
@@ -958,6 +958,7 @@
 #include "code\game\objects\structures\transit_tubes\station.dm"
 #include "code\game\objects\structures\transit_tubes\transit_tube.dm"
 #include "code\game\objects\structures\transit_tubes\transit_tube_pod.dm"
+#include "code\game\turfs\ceiling.dm"
 #include "code\game\turfs\simulated.dm"
 #include "code\game\turfs\turf.dm"
 #include "code\game\turfs\unsimulated.dm"


### PR DESCRIPTION
For years, it has been an oversight that the ceiling of the station hasn't been rendered. This PR remedies that.
- Made it semitransparent and click-through to compromise with the pro-floorers.

:cl:
tweak: The ceiling is now visible.
/:cl:

## :rotating_light: Preview :rotating_light: 
![Imgur](http://i.imgur.com/h4U9mZ1.png)