### PR TITLE
Can Flip Over Someone

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -307,18 +307,28 @@
 				if (M == src)
 					M = null
 
-				if (M)
-					if(src.lying || src.weakened)
+				if(M)
+					if(lying || weakened)
 						message = "<B>[src]</B> flops and flails around on the floor."
 					else
 						message = "<B>[src]</B> flips in [M]'s general direction."
-						src.SpinAnimation(5,1)
+						SpinAnimation(5,1)
 				else
-					if(src.lying || src.weakened)
+					if(lying || weakened)
 						message = "<B>[src]</B> flops and flails around on the floor."
 					else
-						message = "<B>[src]</B> does a flip!"
-						src.SpinAnimation(5,1)
+						var/obj/item/weapon/grab/G = get_active_hand()
+						if(G && G.affecting)
+							var/turf/oldloc = loc
+							var/turf/newloc = G.affecting.loc
+							if(isturf(oldloc) && isturf(newloc))
+								SpinAnimation(5,1)
+								forceMove(newloc)
+								G.affecting.forceMove(oldloc)
+								message = "<B>[src]</B> flips over [G.affecting]!"
+						else
+							message = "<B>[src]</B> does a flip!"
+							SpinAnimation(5,1)
 
 		if ("aflap", "aflaps")
 			if (!src.restrained())


### PR DESCRIPTION
Inspired by Goon.

Allows you to flip over someone with the flip emote.

How do you do it? Simply have a grab on someone and use the *flip emote.

You'll trade spots with the person, do the flip animation, and it'll give a custom message of "`[you]` flips over `[person you're grabbing]`!"

Flippin' foxes.
![img](https://i.gyazo.com/6a3f63b56f1d97c66cec6183067a60c6.gif)

:cl: Fox McCloud
add: Adds in the ability to flip over someone with *flip
/:cl: