### PR TITLE
Fixes camerachunk problem

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -142,7 +142,7 @@
 		if(c.can_use())
 			cameras += c
 
-	for(var/turf/t in block(locate(x, y, z), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
+	for(var/turf/t in block(locate(max(x, 1), max(y, 1), max(z, 1)), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
 		turfs[t] = t
 
 	for(var/camera in cameras)


### PR DESCRIPTION
Fixes the bug where you can see the left 15 tiles of z-levels and bottom 15 tiles.

Turns out that whoever wrote this thing failed to account for the fact that the map's origin is 1,1 and not 0,0.

Here's a screenshot of the bug
![http://i.imgur.com/d9UmMEl.png](http://i.imgur.com/d9UmMEl.png)