### PR TITLE
Fixes a few runtimes

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -50,7 +50,8 @@
 			T.client.screen -= button
 		qdel(button)
 		button = null
-	T.actions.Remove(src)
+	if(T.actions)
+		T.actions.Remove(src)
 	T.update_action_buttons()
 	owner = null
 	return

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -31,7 +31,7 @@ Bonus
 		switch(A.stage)
 			if(2)
 				if(M.reagents.get_reagent_amount("oculine")<10)
-					M.reagents.add_reagent("oculine"=10)
+					M.reagents.add_reagent("oculine", 10)
 					to_chat(M, "<span class='notice'>Your hearing feels clearer and crisp.</span>")
 			if(3)
 				if(M.reagents.get_reagent_amount("antihol") < 10 && M.reagents.get_reagent_amount("oculine") < 10 )

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -520,7 +520,7 @@ var/global/list/default_medbay_channels = list(
 	// what the range is in which mobs will hear the radio
 	// returns: -1 if can't receive, range otherwise
 
-	if (wires.IsIndexCut(WIRE_RECEIVE))
+	if (!wires || wires.IsIndexCut(WIRE_RECEIVE))
 		return -1
 	if(!listening)
 		return -1


### PR DESCRIPTION
- The action and radio thing were `qdel`-related runtimes.
- The oculine thing was a weird conflation of `add_reagent` and `add_reagent_list`. Made it use `add_reagent` properly.