### PR TITLE
Foam Fixes+Changes

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -458,11 +458,11 @@
 	New()
 		..()
 		var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
-		var/obj/item/weapon/reagent_containers/glass/beaker/large/B2 = new(src)
+		var/obj/item/weapon/reagent_containers/glass/beaker/B2 = new(src)
 
 		B1.reagents.add_reagent("fluorosurfactant", 40)
-		B2.reagents.add_reagent("water", 40)
-		B2.reagents.add_reagent("cleaner", 60)
+		B2.reagents.add_reagent("cleaner", 10)
+		B2.reagents.add_reagent("water", 40) //when you make pre-designed foam reactions that carry the reagents, always add water last
 
 		beakers += B1
 		beakers += B2

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -492,7 +492,7 @@
 				if(reagent_id == "internal_beaker")
 					if(use_beaker && reagent_glass && reagent_glass.reagents.total_volume)
 						var/fraction = min(injection_amount/reagent_glass.reagents.total_volume, 1)
-						reagent_glass.reagents.reaction(patient, 2, fraction)
+						reagent_glass.reagents.reaction(patient, INGEST, fraction)
 						reagent_glass.reagents.trans_to(patient, injection_amount) //Inject from beaker instead.
 				else
 					patient.reagents.add_reagent(reagent_id,injection_amount)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -387,45 +387,48 @@ var/const/INGEST = 2
 			can_process = 1
 	return can_process
 
-/datum/reagents/proc/reaction(var/atom/A, var/method=TOUCH, var/volume_modifier=0)
-
+/datum/reagents/proc/reaction(atom/A, method=TOUCH, volume_modifier = 1)
 	switch(method)
 		if(TOUCH)
 			for(var/datum/reagent/R in reagent_list)
 				if(ismob(A))
-					spawn(0)
-						if(!R) return
-						var/check = reaction_check(A, R)
-						if(!check)
-							continue
-						else
-							R.reaction_mob(A, TOUCH, R.volume+volume_modifier)
+					if(!R)
+						return
+					var/check = reaction_check(A, R)
+					if(!check)
+						continue
+					else
+						R.reaction_mob(A, TOUCH, R.volume*volume_modifier)
 				if(isturf(A))
-					spawn(0)
-						if(!R) return
-						else R.reaction_turf(A, R.volume+volume_modifier)
+					if(!R)
+						return
+					else
+						R.reaction_turf(A, R.volume*volume_modifier)
 				if(isobj(A))
-					spawn(0)
-						if(!R) return
-						else R.reaction_obj(A, R.volume+volume_modifier)
+					if(!R)
+						return
+					else
+						R.reaction_obj(A, R.volume*volume_modifier)
 		if(INGEST)
 			for(var/datum/reagent/R in reagent_list)
 				if(ismob(A) && R)
-					spawn(0)
-						if(!R) return
-						var/check = reaction_check(A, R)
-						if(!check)
-							continue
-						else
-							R.reaction_mob(A, INGEST, R.volume+volume_modifier)
+					if(!R)
+						return
+					var/check = reaction_check(A, R)
+					if(!check)
+						continue
+					else
+						R.reaction_mob(A, INGEST, R.volume*volume_modifier)
 				if(isturf(A) && R)
-					spawn(0)
-						if(!R) return
-						else R.reaction_turf(A, R.volume+volume_modifier)
+					if(!R)
+						return
+					else
+						R.reaction_turf(A, R.volume*volume_modifier)
 				if(isobj(A) && R)
-					spawn(0)
-						if(!R) return
-						else R.reaction_obj(A, R.volume+volume_modifier)
+					if(!R)
+						return
+					else
+						R.reaction_obj(A, R.volume*volume_modifier)
 	return
 
 /datum/reagents/proc/add_reagent_list(list/list_reagents, list/data=null) // Like add_reagent but you can enter a list. Format it like this: list("toxin" = 10, "beer" = 15)

--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -293,7 +293,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	required_reagents = list("potassium" = 1, "sugar" = 1, "phosphorus" = 1)
 	result_amount = 1
 	mix_message = "The mixture quickly turns into a pall of smoke!"
-	var/forbidden_reagents = list("sugar", "phosphorus", "potassium") //Do not transfer this stuff through smoke.
+	var/forbidden_reagents = list("sugar", "phosphorus", "potassium", "stimulants") //Do not transfer this stuff through smoke.
 
 /datum/chemical_reaction/smoke/on_reaction(var/datum/reagents/holder, var/created_volume)
 	for(var/f_reagent in forbidden_reagents)
@@ -325,7 +325,7 @@ datum/reagent/blackpowder/reaction_turf(var/turf/T, var/volume) //oh shit
 	min_temp = 374
 	secondary = 1
 	result_amount = 1
-	forbidden_reagents = list()
+	forbidden_reagents = list("stimulants")
 	mix_sound = null
 
 /datum/reagent/sonic_powder

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -190,7 +190,9 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 	if(src.species.exotic_blood)
 		vessel.remove_reagent(species.exotic_blood,amm)
-		vessel.reaction(T, TOUCH, amm)
+		if(vessel.total_volume)
+			var/fraction = amm / vessel.total_volume
+			vessel.reaction(T, TOUCH, fraction)
 		return
 
 	else


### PR DESCRIPTION
Fixes up and improves foam. I've been meaning to do this since we transitioned to Goon-chem more than a year ago. I took a look at how all codebases handle foam (Goon/Bay/TG), and went with Goon's methodology.

Either case, this means foam actually...well, works as you would expect it to.

- Foam actually applies reagents to a turf (when it bursts)
- Slipping on foam will apply the reagent to you 
- Foam carries the temperature of reagents in its container
- Foam's color changes with the reagents that are in it (just like smoke)
- Janitor's grenades actually clean now!

After Mess:
![img1](https://i.gyazo.com/10ccdf647d798469a455e2c6dc5c0603.gif)
After cleaner foam applied:
![img2](https://i.gyazo.com/62e0e5da9a33ce38fb7b6221c78ef455.png)


Related Code changes
- Blacklists stimulants from smoke
- Removed some spawns from `reaction`.
 - Someone (@Tastyfish @TheDZD) please doublecheck me for the necessity of these spawns, but they seem to only cause issues and create a ton of overhead.
- Makes the volume modifier actually behave like a volume modifier--that is to say, it multiplies the reagents by the argument instead of making it add whatever the argument is
 - All of the other `reaction`'s in the code operate with the assumption this is a multiplier and on an addition anyway.
- The amount of exotic blood removed from a mob will now be the amount that is applied to the turf (instead of the mob's ENTIRE blood supply).
 - This will probably make slippery slime blood far less common

:cl: Fox McCloud
tweak: Fixes and improves foam to better interact with reagents
/:cl: