### PR TITLE
Add screwdriver sound when opening airlock panels

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -799,6 +799,7 @@ About the new airlock wires panel:
 		else
 			return
 	else if(istype(C, /obj/item/weapon/screwdriver))
+		playsound(src.loc, 'sound/items/Screwdriver.ogg', 25, 1)
 		src.p_open = !( src.p_open )
 		src.update_icon()
 	else if(istype(C, /obj/item/weapon/wirecutters))


### PR DESCRIPTION
Gives audible confirmation you closed the panel when you screwdriver the door when it's open. So being a #politedoorhacker is easier

:cl: AugRob
rscadd: Add screwdriver sound when opening/closing panels on airlocks
/:cl: