### PR TITLE
Adds permanent teleporter

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -698,6 +698,17 @@ obj/item/weapon/circuitboard/rdserver
 							/obj/item/weapon/stock_parts/capacitor = 2,
 							/obj/item/weapon/stock_parts/console_screen = 1)
 
+/obj/item/weapon/circuitboard/teleporter_perma
+	name = "circuit board (Permanent Teleporter)"
+	build_path = /obj/machinery/teleport/perma
+	board_type = "machine"
+	origin_tech = "programming=3;engineering=5;bluespace=5;materials=4"
+	frame_desc = "Requires 3 Bluespace Crystals and 1 Matter Bin."
+	req_components = list(
+							/obj/item/weapon/ore/bluespace_crystal = 3,
+							/obj/item/weapon/stock_parts/matter_bin = 1)
+	var/target
+
 /obj/item/weapon/circuitboard/telesci_pad
 	name = "Circuit board (Telepad)"
 	build_path = /obj/machinery/telepad

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -370,6 +370,70 @@
 	else
 		icon_state = "tele0"
 
+/obj/machinery/teleport/perma
+	name = "permanent teleporter"
+	desc = "A teleporter with the target pre-set on the circuit board."
+	icon_state = "tele0"
+	var/recalibrating = 0
+	use_power = 1
+	idle_power_usage = 10
+	active_power_usage = 2000
+	
+	var/target
+	var/tele_delay = 50
+
+/obj/machinery/teleport/perma/RefreshParts()
+	for(var/obj/item/weapon/circuitboard/teleporter_perma/C in component_parts)
+		target = C.target
+	var/A = 40
+	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
+		A -= M.rating * 10
+	tele_delay = max(A, 0)
+	update_icon()
+
+/obj/machinery/teleport/perma/Bumped(M as mob|obj)
+	if(stat & (BROKEN|NOPOWER))
+		return
+	if(z == ZLEVEL_CENTCOMM)
+		to_chat(M, "You can't use this here.")
+	if(target && !recalibrating && !panel_open)
+		//--FalseIncarnate
+		//Prevents AI cores from using the teleporter, prints out failure messages for clarity
+		if(istype(M, /mob/living/silicon/ai) || istype(M, /obj/structure/AIcore))
+			visible_message("\red The teleporter rejects the AI unit.")
+			if(istype(M, /mob/living/silicon/ai))
+				var/mob/living/silicon/ai/T = M
+				var/list/TPError = list("\red Firmware instructions dictate you must remain on your assigned station!",
+				"\red You cannot interface with this technology and get rejected!",
+				"\red External firewalls prevent you from utilizing this machine!",
+				"\red Your AI core's anti-bluespace failsafes trigger and prevent teleportation!")
+				to_chat(T, "[pick(TPError)]")
+			return
+		else
+			do_teleport(M, target)
+			use_power(5000)
+			
+			if(tele_delay)
+				recalibrating = 1
+				update_icon()
+				spawn(tele_delay)
+					recalibrating = 0
+					update_icon()
+		//--FalseIncarnate
+	return
+
+/obj/machinery/teleport/perma/power_change()
+	..()
+	update_icon()
+
+/obj/machinery/teleport/perma/update_icon()
+	if(panel_open)
+		icon_state = "tele-o"
+	else if(target && !recalibrating && !(stat & (BROKEN|NOPOWER)))
+		icon_state = "tele1"
+	else
+		icon_state = "tele0"
+
 /obj/machinery/teleport/station
 	name = "station"
 	desc = "The power control station for a bluespace teleporter."
@@ -456,6 +520,11 @@
 		if(istype(W, /obj/item/weapon/wirecutters))
 			link_console_and_hub()
 			to_chat(user, "<span class='caution'>You reconnect the station to nearby machinery.</span>")
+			return
+		if(istype(W, /obj/item/weapon/circuitboard/teleporter_perma))
+			var/obj/item/weapon/circuitboard/teleporter_perma/C = W
+			C.target = teleporter_console.target
+			to_chat(user, "<span class='caution'>You copy the targeting information from \the [src] to \the [W]</span>")
 			return
 
 /obj/machinery/teleport/station/attack_ai()

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -323,13 +323,13 @@
 		//--FalseIncarnate
 		//Prevents AI cores from using the teleporter, prints out failure messages for clarity
 		if(istype(M, /mob/living/silicon/ai) || istype(M, /obj/structure/AIcore))
-			visible_message("\red The teleporter rejects the AI unit.")
+			visible_message("<span class='warning'>The teleporter rejects the AI unit.</span>")
 			if(istype(M, /mob/living/silicon/ai))
 				var/mob/living/silicon/ai/T = M
-				var/list/TPError = list("\red Firmware instructions dictate you must remain on your assigned station!",
-				"\red You cannot interface with this technology and get rejected!",
-				"\red External firewalls prevent you from utilizing this machine!",
-				"\red Your AI core's anti-bluespace failsafes trigger and prevent teleportation!")
+				var/list/TPError = list("<span class='warning'>Firmware instructions dictate you must remain on your assigned station!</span>",
+				"<span class='warning'>You cannot interface with this technology and get rejected!</span>",
+				"<span class='warning'>External firewalls prevent you from utilizing this machine!</span>",
+				"<span class='warning'>Your AI core's anti-bluespace failsafes trigger and prevent teleportation!</span>")
 				to_chat(T, "[pick(TPError)]")
 			return
 		else
@@ -400,13 +400,13 @@
 		//--FalseIncarnate
 		//Prevents AI cores from using the teleporter, prints out failure messages for clarity
 		if(istype(M, /mob/living/silicon/ai) || istype(M, /obj/structure/AIcore))
-			visible_message("\red The teleporter rejects the AI unit.")
+			visible_message("<span class='warning'>The teleporter rejects the AI unit.</span>")
 			if(istype(M, /mob/living/silicon/ai))
 				var/mob/living/silicon/ai/T = M
-				var/list/TPError = list("\red Firmware instructions dictate you must remain on your assigned station!",
-				"\red You cannot interface with this technology and get rejected!",
-				"\red External firewalls prevent you from utilizing this machine!",
-				"\red Your AI core's anti-bluespace failsafes trigger and prevent teleportation!")
+				var/list/TPError = list("<span class='warning'>Firmware instructions dictate you must remain on your assigned station!</span>",
+				"<span class='warning'>You cannot interface with this technology and get rejected!</span>",
+				"<span class='warning'>External firewalls prevent you from utilizing this machine!</span>",
+				"<span class='warning'>Your AI core's anti-bluespace failsafes trigger and prevent teleportation!</span>")
 				to_chat(T, "[pick(TPError)]")
 			return
 		else

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -319,6 +319,7 @@
 /obj/machinery/teleport/hub/Bumped(M as mob|obj)
 	if(z == ZLEVEL_CENTCOMM)
 		to_chat(M, "You can't use this here.")
+		return
 	if(power_station && power_station.engaged && !panel_open)
 		//--FalseIncarnate
 		//Prevents AI cores from using the teleporter, prints out failure messages for clarity
@@ -396,6 +397,7 @@
 		return
 	if(z == ZLEVEL_CENTCOMM)
 		to_chat(M, "You can't use this here.")
+		return
 	if(target && !recalibrating && !panel_open)
 		//--FalseIncarnate
 		//Prevents AI cores from using the teleporter, prints out failure messages for clarity

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -92,6 +92,16 @@
 	build_path = /obj/item/weapon/circuitboard/teleporter_station
 	category = list ("Teleportation Machinery")
 
+/datum/design/teleport_perma
+	name = "Machine Board (Permanent Teleporter)"
+	desc = "Allows for the construction of circuit boards used to build a Permanent Teleporter."
+	id = "tele_perma"
+	req_tech = list("programming" = 3, "bluespace" = 5, "materials" = 4, "engineering" = 5)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000, "sacid" = 20)
+	build_path = /obj/item/weapon/circuitboard/teleporter_perma
+	category = list ("Teleportation Machinery")
+
 /datum/design/bodyscanner
 	name = "Machine Board (Body Scanner)"
 	desc = "Allows for the construction of circuit boards used to build a Body Scanner."


### PR DESCRIPTION
The permanent teleporter is a cheaper version of the teleporter that takes up less space. However, once you build it, you cannot change the target.

You set the target by using the circuit board on a teleporter station with the panel open. This will copy the targeting information over.

This could be used, for example, to build teleporters around the station that teleport people directly to the medbay, without worrying about them being abused.

:cl: monster860
rscadd: Adds the permanent teleporter. Use the circuitboard on a teleporter hub to set the target before constructing it.
/:cl: