### PR TITLE
Fix shuttle HREF exploit

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -688,7 +688,6 @@
 		if(!options.Find(href_list["move"])) //I see you're trying Href exploits, I see you're failing, I SEE ADMIN WARNING.
 			// Seriously, though, NEVER trust a Topic with something like this. Ever.
 			message_admins("move HREF ([src] attempted to move to: [href_list["move"]]) exploit attempted by [key_name_admin(usr)] on [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-			to_chat(usr, "<span class='userdanger'>Expect a ban. Soon.</span>")
 			return
 		switch(shuttle_master.moveShuttle(shuttleId, href_list["move"], 1))
 			if(0)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -683,7 +683,13 @@
 		to_chat(usr, "<span class='danger'>Access denied.</span>")
 		return
 
+	var/list/options = params2list(possible_destinations)
 	if(href_list["move"])
+		if(!options.Find(href_list["move"])) //I see you're trying Href exploits, I see you're failing, I SEE ADMIN WARNING.
+			// Seriously, though, NEVER trust a Topic with something like this. Ever.
+			message_admins("move HREF ([src] attempted to move to: [href_list["move"]]) exploit attempted by [key_name_admin(usr)] on [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
+			to_chat(usr, "<span class='userdanger'>Expect a ban. Soon.</span>")
+			return
 		switch(shuttle_master.moveShuttle(shuttleId, href_list["move"], 1))
 			if(0)
 				to_chat(usr, "<span class='notice'>Shuttle received message and will be sent shortly.</span>")


### PR DESCRIPTION
Because you should NEVER trust `Topic()`. Ever. It's laughably easy to put whatever you want in there.

But yeah, one could prevent the round from ending with this, simply by sticking their shuttle on the emergency docking port, and suddenly, the emergency shuttle won't dock, and you've got a major problem.

So yeah, gotta catch them all.