### PR TITLE
Fixes #4435, Refactors Rejuvenation, Fixes Flipping Runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -317,7 +317,9 @@
 					if(lying || weakened)
 						message = "<B>[src]</B> flops and flails around on the floor."
 					else
-						var/obj/item/weapon/grab/G = get_active_hand()
+						var/obj/item/weapon/grab/G
+						if(istype(get_active_hand(), /obj/item/weapon/grab))
+							G = get_active_hand()
 						if(G && G.affecting)
 							var/turf/oldloc = loc
 							var/turf/newloc = G.affecting.loc

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1314,6 +1314,14 @@
 	restore_all_organs() //Rejuvenate and reset all existing organs.
 	check_and_regenerate_organs(src) //Regenerate limbs and organs only if they're really missing.
 	surgeries.Cut() //End all surgeries.
+	update_revive()
+
+	if(species.name != "Skeleton" && (SKELETON in mutations))
+		mutations.Remove(SKELETON)
+	if(NOCLONE in mutations)
+		mutations.Remove(NOCLONE)
+	if(HUSK in mutations)
+		mutations.Remove(HUSK)
 
 	if(!client || !key) //Don't boot out anyone already in the mob.
 		for (var/obj/item/organ/internal/brain/H in world)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1256,9 +1256,9 @@
 		germ_level += n
 
 /mob/living/carbon/human/proc/check_and_regenerate_organs(var/mob/living/carbon/human/H) //Regenerates missing limbs/organs.
-	var/list/types_of_int_organs = list()
+	var/list/types_of_int_organs = list() //This will hold all the types of organs in the mob before rejuvenation.
 	for(var/obj/item/organ/internal/I in H.internal_organs)
-		types_of_int_organs |= I.type
+		types_of_int_organs |= I.type //Compiling the list of organ types. It is possible for organs to be missing from this list if they are absent from the mob.
 
 	//Removing stumps.
 	for(var/obj/item/organ/organ in H.contents)
@@ -1276,20 +1276,32 @@
 			H.organs_by_name -= organ_name //Making sure the list entry is removed.
 
 	//Replacing lost limbs with the species default.
+	var/mob/living/carbon/human/temp_holder
 	for(var/limb_type in H.species.has_limbs)
 		if(!(limb_type in H.organs_by_name))
 			var/list/organ_data = H.species.has_limbs[limb_type]
 			var/limb_path = organ_data["path"]
-			var/obj/item/organ/external/O = new limb_path(H)
-			O.owner = H
-			H.organs |= H.organs_by_name[O.limb_name]
+			var/obj/item/organ/external/O = new limb_path(temp_holder)
+			if(H.get_limb_by_name(O.name)) //Check to see if the user already has an limb with the same name as the 'missing limb'. If they do, skip regrowth.
+				continue				   //In an example, this will prevent duplication of the mob's right arm if the mob is a Human and they have a Diona right arm, since,
+										   //while the limb with the name 'right_arm' the mob has may not be listed in their species' bodyparts definition, it is still viable and has the appropriate limb name.
+			else
+				O = new limb_path(H) //Create the limb on the player.
+				O.owner = H
+				H.organs |= H.organs_by_name[O.limb_name]
 
 	//Replacing lost organs with the species default.
+	temp_holder = new /mob/living/carbon/human()
 	for(var/index in H.species.has_organ)
 		var/organ = H.species.has_organ[index]
-		if(!(organ in types_of_int_organs))
-			var/obj/item/organ/internal/I = new organ(H)
-			I.insert(H)
+		if(!(organ in types_of_int_organs)) //If the mob is missing this particular organ...
+			var/obj/item/organ/internal/I = new organ(temp_holder) //Create the organ inside our holder so we can check it before implantation.
+			if(H.get_organ_slot(I.slot)) //Check to see if the user already has an organ in the slot the 'missing organ' belongs to. If they do, skip implantation.
+				continue				 //In an example, this will prevent duplication of the mob's eyes if the mob is a Human and they have Nucleation eyes, since,
+										 //while the organ in the eyes slot may not be listed in the mob's species' organs definition, it is still viable and fits in the appropriate organ slot.
+			else
+				I = new organ(H) //Create the organ inside the player.
+				I.insert(H)
 
 /mob/living/carbon/human/revive()
 
@@ -1299,8 +1311,9 @@
 		fixblood()
 
 	//Fix up all organs and replace lost ones.
-	restore_all_organs()
-	check_and_regenerate_organs(src)
+	restore_all_organs() //Rejuvenate and reset all existing organs.
+	check_and_regenerate_organs(src) //Regenerate limbs and organs only if they're really missing.
+	surgeries.Cut() //End all surgeries.
 
 	if(!client || !key) //Don't boot out anyone already in the mob.
 		for (var/obj/item/organ/internal/brain/H in world)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1256,9 +1256,6 @@
 		germ_level += n
 
 /mob/living/carbon/human/proc/check_and_regenerate_organs(var/mob/living/carbon/human/H) //Regenerates missing limbs/organs.
-	var/datum/species/S = H.species
-	var/list/species_organs = S.has_organ
-	var/list/species_limbs = S.has_limbs
 	var/list/types_of_int_organs = list()
 	for(var/obj/item/organ/internal/I in H.internal_organs)
 		types_of_int_organs |= I.type
@@ -1274,22 +1271,22 @@
 			H.organs -= organ //Making sure the list entry is removed.
 	for(var/organ_name in H.organs_by_name)
 		var/obj/item/organ/organ = H.organs_by_name[organ_name]
-		if(istype(organ, /obj/item/organ/external/stump) || !organ) //The !organ is to account for mechanical limb losses, since those are handled in a way that creates indexed but null list entries instead of stumps.
+		if(istype(organ, /obj/item/organ/external/stump) || !organ) //The !organ check is to account for mechanical limb (prostheses) losses, since those are handled in a way that leaves indexed but null list entries instead of stumps.
 			qdel(organ)
 			H.organs_by_name -= organ_name //Making sure the list entry is removed.
 
 	//Replacing lost limbs with the species default.
-	for(var/limb_type in species_limbs)
+	for(var/limb_type in H.species.has_limbs)
 		if(!(limb_type in H.organs_by_name))
-			var/list/organ_data = species_limbs[limb_type]
+			var/list/organ_data = H.species.has_limbs[limb_type]
 			var/limb_path = organ_data["path"]
 			var/obj/item/organ/external/O = new limb_path(H)
 			O.owner = H
 			H.organs |= H.organs_by_name[O.limb_name]
 
 	//Replacing lost organs with the species default.
-	for(var/index in species_organs)
-		var/organ = species_organs[index]
+	for(var/index in H.species.has_organ)
+		var/organ = H.species.has_organ[index]
 		if(!(organ in types_of_int_organs))
 			var/obj/item/organ/internal/I = new organ(H)
 			I.insert(H)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1274,7 +1274,7 @@
 			H.organs -= organ //Making sure the list entry is removed.
 	for(var/organ_name in H.organs_by_name)
 		var/obj/item/organ/organ = H.organs_by_name[organ_name]
-		if(istype(organ, /obj/item/organ/external/stump) || !organ) //The !organ is for IPC limb losses, since those are handled in a way that creates null list entries instead of stumps.
+		if(istype(organ, /obj/item/organ/external/stump) || !organ) //The !organ is to account for mechanical limb losses, since those are handled in a way that creates indexed but null list entries instead of stumps.
 			qdel(organ)
 			H.organs_by_name -= organ_name //Making sure the list entry is removed.
 

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -265,6 +265,17 @@
 	male_scream_sound = 'sound/voice/shriek1.ogg'
 	female_scream_sound = 'sound/voice/shriek1.ogg'
 
+	has_organ = list(
+		"heart" =    /obj/item/organ/internal/heart,
+		"lungs" =    /obj/item/organ/internal/lungs,
+		"liver" =    /obj/item/organ/internal/liver,
+		"kidneys" =  /obj/item/organ/internal/kidneys,
+		"brain" =    /obj/item/organ/internal/brain,
+		"appendix" = /obj/item/organ/internal/appendix,
+		"eyes" =     /obj/item/organ/internal/eyes,
+		"stack" =    /obj/item/organ/internal/stack/vox //Not the same as the cortical stack implant Vox Raiders spawn with. The cortical stack implant is used
+		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.
+
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
 		"is jamming their claws into their eye sockets!",
@@ -355,8 +366,8 @@
 		"kidneys" =  /obj/item/organ/internal/kidneys,
 		"brain" =    /obj/item/organ/internal/brain,
 		"eyes" =     /obj/item/organ/internal/eyes,
-		"stack" =    /obj/item/organ/internal/stack/vox
-		)
+		"stack" =    /obj/item/organ/internal/stack/vox //Not the same as the cortical stack implant Vox Raiders spawn with. The cortical stack implant is used
+		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -574,6 +574,8 @@ var/global/list/damage_icon_parts = list()
 	UpdateDamageIcon()
 	update_icons()
 	update_fire()
+	force_update_limbs()
+	update_tail_layer(0)
 /* --------------------------------------- */
 //vvvvvv UPDATE_INV PROCS vvvvvv
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -379,7 +379,7 @@
 	fire_stacks = 0
 	on_fire = 0
 	suiciding = 0
-	if(buckled)
+	if(buckled) //Unbuckle the mob and clear the alerts.
 		buckled.buckled_mob = null
 		buckled = null
 		anchored = initial(src.anchored)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -347,6 +347,8 @@
 	timeofdeath = 0
 
 /mob/living/proc/rejuvenate()
+	var/mob/living/carbon/human/human_mob = null //Get this declared for use later.
+
 	// shut down various types of badness
 	setToxLoss(0)
 	setOxyLoss(0)
@@ -397,7 +399,7 @@
 
 		// restore all of the human's blood and reset their shock stage
 		if(ishuman(src))
-			var/mob/living/carbon/human/human_mob = src
+			human_mob = src
 			human_mob.restore_blood()
 			human_mob.shock_stage = 0
 			human_mob.decaylevel = 0
@@ -411,6 +413,9 @@
 	stat = CONSCIOUS
 	update_fire()
 	regenerate_icons()
+	if(human_mob)
+		human_mob.update_eyes()
+		human_mob.update_dna()
 	return
 
 /mob/living/proc/UpdateDamageIcon()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -405,6 +405,7 @@
 			human_mob.decaylevel = 0
 
 	restore_all_organs()
+	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
 		dead_mob_list -= src
 		living_mob_list += src

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -320,7 +320,6 @@
 
 /mob/living/proc/revive()
 	rejuvenate()
-	buckled = initial(src.buckled)
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src
 
@@ -380,7 +379,13 @@
 	fire_stacks = 0
 	on_fire = 0
 	suiciding = 0
-	buckled = initial(src.buckled)
+	if(buckled)
+		buckled.buckled_mob = null
+		buckled = null
+		anchored = initial(src.anchored)
+		update_canmove()
+		clear_alert("buckled")
+		post_buckle_mob(src)
 
 	if(iscarbon(src))
 		var/mob/living/carbon/C = src

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -367,6 +367,7 @@
 	drowsyness = 0
 	radiation = 0
 	druggy = 0
+	hallucination = 0
 	nutrition = 400
 	bodytemperature = 310
 	sdisabilities = 0

--- a/code/modules/surgery/organs/helpers.dm
+++ b/code/modules/surgery/organs/helpers.dm
@@ -41,3 +41,8 @@
 
 /proc/is_int_organ(atom/A)
 	return istype(A, /obj/item/organ/internal)
+
+/mob/living/carbon/human/proc/get_limb_by_name(limb_name) //Look for a limb with the given limb name in the source mob, and return it if found.
+	for(var/obj/item/organ/external/O in organs)
+		if(limb_name == O.limb_name)
+			return O

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -176,7 +176,12 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/rejuvenate()
 	damage = 0
 	germ_level = 0
-	status &= ~ORGAN_DEAD
+	if(status & ORGAN_ROBOT)	//Robotic organs stay robotic.
+		status = ORGAN_ROBOT
+	else if (status & ORGAN_ASSISTED) //Assisted organs stay assisted.
+		status = ORGAN_ASSISTED
+	else
+		status = 0
 	if(!owner)
 		processing_objects |= src
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -317,7 +317,7 @@ This function completely restores a damaged organ to perfect condition.
 	brute_dam = 0
 	burn_dam = 0
 	open = 0 //Closing all wounds.
-	wounds = list() //Clears all wounds! Good as new.
+	wounds.Cut() //Clears all wounds! Good as new.
 	if(istype(src, /obj/item/organ/external/head) && disfigured) //If their head's disfigured, refigure it.
 		disfigured = 0
 

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -308,7 +308,7 @@ This function completely restores a damaged organ to perfect condition.
 */
 /obj/item/organ/external/rejuvenate()
 	damage_state = "00"
-	if(status & 128)	//Robotic organs stay robotic.  Fix because right click rejuvinate makes IPC's organs organic.
+	if(status & 128)	//Robotic organs stay robotic. Fix because right click rejuvinate makes IPC's organs organic.
 		status = 128
 	else
 		status = 0
@@ -316,6 +316,7 @@ This function completely restores a damaged organ to perfect condition.
 	perma_injury = 0
 	brute_dam = 0
 	burn_dam = 0
+	wounds = list() //Clears all wounds! Good as new.
 
 	// handle internal organs
 	for(var/obj/item/organ/internal/current_organ in internal_organs)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -308,7 +308,7 @@ This function completely restores a damaged organ to perfect condition.
 */
 /obj/item/organ/external/rejuvenate()
 	damage_state = "00"
-	if(status & 128)	//Robotic organs stay robotic. Fix because right click rejuvinate makes IPC's organs organic.
+	if(status & 128)	//Robotic organs stay robotic.
 		status = 128
 	else
 		status = 0
@@ -316,7 +316,10 @@ This function completely restores a damaged organ to perfect condition.
 	perma_injury = 0
 	brute_dam = 0
 	burn_dam = 0
+	open = 0 //Closing all wounds.
 	wounds = list() //Clears all wounds! Good as new.
+	if(istype(src, /obj/item/organ/external/head) && disfigured) //If their head's disfigured, refigure it.
+		disfigured = 0
 
 	// handle internal organs
 	for(var/obj/item/organ/internal/current_organ in internal_organs)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -308,8 +308,10 @@ This function completely restores a damaged organ to perfect condition.
 */
 /obj/item/organ/external/rejuvenate()
 	damage_state = "00"
-	if(status & 128)	//Robotic organs stay robotic.
-		status = 128
+	if(status & ORGAN_ROBOT)	//Robotic organs stay robotic.
+		status = ORGAN_ROBOT
+	else if (status & ORGAN_ASSISTED) //Assisted organs stay assisted.
+		status = ORGAN_ASSISTED
 	else
 		status = 0
 	germ_level = 0


### PR DESCRIPTION
:cl:
fix: Rejuvenating a mob now unbuckles them correctly (if they're buckled to something).
fix: Rejuvenating a mob will no longer remove their hair.
fix: Rejuvenating a mob will no longer permanently blacken their eyes.
fix: Rejuvenating a mob will no longer remove their prostheses with fleshy limbs, it will just fix the prostheses.
fix: Rejuvenating a mob will not remove organs/limbs belonging to other species if said organs/limbs are in the same place(s) as the mob's default organs/limbs would be.
fix: Fixes a runtime when trying to flip with an object other than a grab in your hand.
fix: Doing a 'cybernetic repair' procedure on the head of a disfigured IPC will re-figure them.
tweak: Rejuvenating a mob will only regrow organs/limbs that are missing (by comparison to the standard organs for their species).
tweak: The regenerate_icons proc will now update skin tone and body accessories properly.
rscadd: Organ rejuvenation now clears disfigurement and closes open wounds.
rscadd: Rejuvenating a mob will end all in-progress surgeries.
rscadd: Vox get their cortical stacks back, since the non-implant ones don't interfere with the Heist game-mode.
rscadd: Rejuvenating a long-dead or husked mob will now clear the appropriate mutations.
/:cl:

This might also fix #4404 because of my changes to organ rejuvenation, _but I'm not sure and I haven't checked._

## DO NOT MERGE

I'm testing to see what strange behaviours this might have, if there are any bugs left, and how I can (if I can) condense and clean up the code, etc.

Please leave feedback where you think this can be improved, issues you see, etc. I'll deal with those as usual

I'll post pictures of this in action once I'm back home
 