### PR TITLE
Makes is_mechanical() use OOP, removes bizarre chain procs

### DIFF
--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -166,7 +166,7 @@ var/list/tape_roll_applications = list()
 
 /obj/item/tape/attack_hand(mob/user as mob)
 	if (user.a_intent == I_HELP && src.allowed(user))
-		user.show_viewers("\blue [user] lifts [src], allowing passage.")
+		user.visible_message("<span class=notice>[user] lifts [src], allowing passage.</span>", "<span class=notice>You lift [src], allowing passage.</span>")
 		src.density = 0
 		spawn(200)
 			src.density = 1
@@ -180,7 +180,7 @@ var/list/tape_roll_applications = list()
 	if(user.a_intent == I_HELP && ((!can_puncture(W) && src.allowed(user))))
 		to_chat(user, "You can't break the [src] with that!")
 		return
-	user.show_viewers("\blue [user] breaks the [src]!")
+	user.visible_message("<span class=warning>[user] breaks the [src]!</span>", "<span class=warning>You break the [src]!</span>")
 
 	var/dir[2]
 	var/icon_dir = src.icon_state

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -320,7 +320,7 @@
 		return
 	step_towards(O, src.loc)
 	if(user != O)
-		user.show_viewers("<span class='danger'>[user] stuffs [O] into [src]!</span>")
+		user.visible_message("<span class='danger'>[user] stuffs [O] into [src]!</span>", "<span class='danger'>You stuff [O] into [src]!</span>")
 	src.add_fingerprint(user)
 
 /obj/structure/closet/attack_ai(mob/user)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -192,7 +192,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 0
 
 /mob/dead/observer/can_use_hands()	return 0
-/mob/dead/observer/is_active()		return 0
 
 /mob/dead/observer/Stat()
 	..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1923,3 +1923,6 @@
 		if(U.accessories)
 			for(var/obj/item/clothing/accessory/A in U.accessories)
 				. |= A.GetAccess()
+
+/mob/living/carbon/human/is_mechanical()
+	return ..() || (species.flags & ALL_RPARTS) != 0

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -356,3 +356,6 @@
 /mob/living/silicon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash/noise)
 	if(affect_silicon)
 		return ..()
+
+/mob/living/silicon/is_mechanical()
+	return 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -903,13 +903,8 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/can_use_hands()
 	return
 
-/mob/proc/is_active()
-	return (0 >= usr.stat)
-
 /mob/proc/is_mechanical()
-	if(mind && (mind.assigned_role == "Cyborg" || mind.assigned_role == "AI"))
-		return 1
-	return istype(src, /mob/living/silicon) || get_species() == "Machine"
+	return mind && (mind.assigned_role == "Cyborg" || mind.assigned_role == "AI")
 
 /mob/proc/is_ready()
 	return client && !!mind
@@ -936,18 +931,8 @@ var/list/slot_equipment_priority = list( \
 /mob/proc/get_gender()
 	return gender
 
-/mob/proc/see(message)
-	if(!is_active())
-		return 0
-	to_chat(src, message)
-	return 1
-
 /mob/proc/is_muzzled()
 	return 0
-
-/mob/proc/show_viewers(message)
-	for(var/mob/M in viewers())
-		M.see(message)
 
 /mob/Stat()
 	..()

--- a/code/modules/mob/spirit/spirit.dm
+++ b/code/modules/mob/spirit/spirit.dm
@@ -25,7 +25,7 @@ mob/spirit
 	var/follow_target = null
 
 
-mob/spirit/is_active()
+mob/spirit/proc/is_active()
 	if (client && client.inactivity <= 10 * 60 * 10)
 		return TRUE
 	return FALSE


### PR DESCRIPTION
- Makes `is_mechanical()` use OOP instead of being a blob is istypes() and species checks
 - This is only used by the derelict mutiny code but just in case it's ever used by something else I cleaned it up. `¯\_(ツ)_/¯`
- Removes `show_visible()` which was just an inferior `visible_message()` and was only used 3 times in the code.
 - Also removes `see()` which was only used by `show_visible()` and had no use outside of it.
 - Also removes `/mob/is_active()` which hilariously checked if the usr was conscious, not the mob, which is literally useless. Thankfully it was only used by `see()`
 - As a side note, `/mob/spirit` previously overrode `is_active()` to mean something completely different.