### PR TITLE
Fixes a Horrible Diona Runtime [Probably Urgent]

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -664,17 +664,17 @@
 
 	vision_organ = /obj/item/organ/internal/diona_receptor
 	has_limbs = list(
-		"chest" =  list("path" = /obj/item/organ/external/diona/chest),
-		"groin" =  list("path" = /obj/item/organ/external/diona/groin),
-		"head" =   list("path" = /obj/item/organ/external/diona/head),
-		"l_arm" =  list("path" = /obj/item/organ/external/diona/arm),
-		"r_arm" =  list("path" = /obj/item/organ/external/diona/arm/right),
-		"l_leg" =  list("path" = /obj/item/organ/external/diona/leg),
-		"r_leg" =  list("path" = /obj/item/organ/external/diona/leg/right),
-		"l_hand" = list("path" = /obj/item/organ/external/diona/hand),
-		"r_hand" = list("path" = /obj/item/organ/external/diona/hand/right),
-		"l_foot" = list("path" = /obj/item/organ/external/diona/foot),
-		"r_foot" = list("path" = /obj/item/organ/external/diona/foot/right)
+		"chest" =  list("path" = /obj/item/organ/external/chest/diona),
+		"groin" =  list("path" = /obj/item/organ/external/groin/diona),
+		"head" =   list("path" = /obj/item/organ/external/head/diona),
+		"l_arm" =  list("path" = /obj/item/organ/external/arm/diona),
+		"r_arm" =  list("path" = /obj/item/organ/external/arm/right/diona),
+		"l_leg" =  list("path" = /obj/item/organ/external/leg/diona),
+		"r_leg" =  list("path" = /obj/item/organ/external/leg/right/diona),
+		"l_hand" = list("path" = /obj/item/organ/external/hand/diona),
+		"r_hand" = list("path" = /obj/item/organ/external/hand/right/diona),
+		"l_foot" = list("path" = /obj/item/organ/external/foot/diona),
+		"r_foot" = list("path" = /obj/item/organ/external/foot/right/diona)
 		)
 
 	suicide_messages = list(

--- a/code/modules/surgery/organs/subtypes/diona.dm
+++ b/code/modules/surgery/organs/subtypes/diona.dm
@@ -17,125 +17,81 @@
 					D.death()
 		return 1 */
 
-/obj/item/organ/external/diona
-	name = "tendril"
+/obj/item/organ/external/chest/diona
+	name = "core trunk"
+	max_damage = 200
+	min_broken_damage = 50
+	cannot_break = 1
+	amputation_point = "trunk"
+	encased = null
+	gendered_icon = 0
+
+/obj/item/organ/external/groin/diona
+	name = "fork"
+	min_broken_damage = 50
+	cannot_break = 1
+	amputation_point = "lower trunk"
+	gendered_icon = 0
+
+/obj/item/organ/external/arm/diona
+	name = "left upper tendril"
+	max_damage = 35
+	min_broken_damage = 20
+	cannot_break = 1
+	amputation_point = "upper left trunk"
+
+/obj/item/organ/external/arm/right/diona
+	name = "right upper tendril"
+	max_damage = 35
+	min_broken_damage = 20
+	cannot_break = 1
+	amputation_point = "upper right trunk"
+
+/obj/item/organ/external/leg/diona
+	name = "left lower tendril"
+	max_damage = 35
+	min_broken_damage = 20
+	cannot_break = 1
+	amputation_point = "lower left fork"
+
+/obj/item/organ/external/leg/right/diona
+	name = "right lower tendril"
+	max_damage = 35
+	min_broken_damage = 20
+	cannot_break = 1
+	amputation_point = "lower right fork"
+
+/obj/item/organ/external/foot/diona
+	name = "left foot"
+	max_damage = 20
+	min_broken_damage = 10
 	cannot_break = 1
 	amputation_point = "branch"
 
-/obj/item/organ/external/diona/chest
-	name = "core trunk"
-	limb_name = "chest"
-	icon_name = "torso"
-	max_damage = 200
-	min_broken_damage = 50
-	w_class = 5
-	body_part = UPPER_TORSO
-	vital = 1
-	cannot_amputate = 1
-	parent_organ = null
-
-/obj/item/organ/external/diona/groin
-	name = "fork"
-	limb_name = "groin"
-	icon_name = "groin"
-	max_damage = 100
-	min_broken_damage = 50
-	w_class = 4
-	body_part = LOWER_TORSO
-	parent_organ = "chest"
-
-/obj/item/organ/external/diona/arm
-	name = "left upper tendril"
-	limb_name = "l_arm"
-	icon_name = "l_arm"
-	max_damage = 35
-	min_broken_damage = 20
-	w_class = 3
-	body_part = ARM_LEFT
-	parent_organ = "chest"
-	can_grasp = 1
-
-/obj/item/organ/external/diona/arm/right
-	name = "right upper tendril"
-	limb_name = "r_arm"
-	icon_name = "r_arm"
-	body_part = ARM_RIGHT
-
-/obj/item/organ/external/diona/leg
-	name = "left lower tendril"
-	limb_name = "l_leg"
-	icon_name = "l_leg"
-	max_damage = 35
-	min_broken_damage = 20
-	w_class = 3
-	body_part = LEG_LEFT
-	icon_position = LEFT
-	parent_organ = "groin"
-	can_stand = 1
-
-/obj/item/organ/external/diona/leg/right
-	name = "right lower tendril"
-	limb_name = "r_leg"
-	icon_name = "r_leg"
-	body_part = LEG_RIGHT
-	icon_position = RIGHT
-
-/obj/item/organ/external/diona/foot
-	name = "left foot"
-	limb_name = "l_foot"
-	icon_name = "l_foot"
+/obj/item/organ/external/foot/right/diona
+	name = "right foot"
 	max_damage = 20
 	min_broken_damage = 10
-	w_class = 2
-	body_part = FOOT_LEFT
-	icon_position = LEFT
-	parent_organ = "l_leg"
-	can_stand = 1
+	cannot_break = 1
+	amputation_point = "branch"
 
-/obj/item/organ/external/diona/foot/right
-	name = "right foot"
-	limb_name = "r_foot"
-	icon_name = "r_foot"
-	body_part = FOOT_RIGHT
-	icon_position = RIGHT
-	parent_organ = "r_leg"
-	amputation_point = "right ankle"
-
-/obj/item/organ/external/diona/hand
+/obj/item/organ/external/hand/diona
 	name = "left grasper"
-	limb_name = "l_hand"
-	icon_name = "l_hand"
-	max_damage = 30
-	min_broken_damage = 15
-	w_class = 2
-	body_part = HAND_LEFT
-	parent_organ = "l_arm"
-	can_grasp = 1
+	cannot_break = 1
+	amputation_point = "branch"
 
-/obj/item/organ/external/diona/hand/right
+/obj/item/organ/external/hand/right/diona
 	name = "right grasper"
-	limb_name = "r_hand"
-	icon_name = "r_hand"
-	body_part = HAND_RIGHT
-	parent_organ = "r_arm"
+	cannot_break = 1
+	amputation_point = "branch"
 
-/obj/item/organ/external/diona/head
-	limb_name = "head"
-	icon_name = "head"
-	name = "head"
+/obj/item/organ/external/head/diona
 	max_damage = 50
 	min_broken_damage = 25
-	vital = 1
-	w_class = 3
-	body_part = HEAD
-	parent_organ = "chest"
-	var/can_intake_reagents = 1
-
-/obj/item/organ/external/diona/head/remove()
-	if(owner)
-		owner.unEquip(owner.head)
-		owner.unEquip(owner.l_ear)
-	..()
+	cannot_break = 1
+	encased = null
+	amputation_point = "upper trunk"
+	gendered_icon = 0
 
 //DIONA ORGANS.
 /* /obj/item/organ/external/diona/removed()


### PR DESCRIPTION
:cl:
fix: Fixes a runtime with Dioneae by repathing their limbs.
/:cl:

Repaths Diona bodyparts to fix a pretty terrible runtime. I've not made the habit of spawning in as a Diona or spawning Dioneae when I test my PRs so when I didn't test them in my head-hair refactor PR I also missed a really bad runtime associated with the species.

The root of the runtime was the way Diona limbs used to be pathed. :evergreen_tree: 
With that in mind, I used the way IPC limbs are pathed as a guide and repathed Diona limbs, modifying their species limbs definitions in station.dm accordingly.

This fixed the runtime.

I tested both with a Diona character I spawned in as, and by spawning in a Diona with the Admin game-panel.

### The runtime probably has the potential to be game-breaking, but...
After a bit of exploration it doesn't seem to do much more than throw some error messages and that's it.
However, if you try to spawn a Diona from the admin game-panel, they will have human icons due to the runtime. Furthermore, any interaction with the Diona involving their head organ and its hair style/colour whatever attributes will trigger the runtime again.

I'll swap over to my master branch and get a screenshot of it real quick.

Here's a picture of the runtime:
![dionaruntime](https://cloud.githubusercontent.com/assets/12377767/15351167/eb7d39da-1cab-11e6-94ab-7abccb173760.PNG)


Here's a picture of Dioneae working again after the fix, no more runtime:
![dionafix](https://cloud.githubusercontent.com/assets/12377767/15351084/504a8616-1cab-11e6-95d5-7baf87ee11dd.png)

**Diona 1 is the one I spawned in as. No runtimes, vars were set properly.**
**Diona 2 is the one I spawned in with the admin game-panel. Vars were set properly there, too.**