### PR TITLE
Standardizes behavior of a few reagents

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -197,6 +197,16 @@
 	default_hair = "Skrell Male Tentacles"
 	reagent_tag = PROCESS_ORG
 
+	has_organ = list(
+		"heart" =    /obj/item/organ/internal/heart,
+		"lungs" =    /obj/item/organ/internal/lungs,
+		"liver" =    /obj/item/organ/internal/liver/skrell,
+		"kidneys" =  /obj/item/organ/internal/kidneys,
+		"brain" =    /obj/item/organ/internal/brain,
+		"appendix" = /obj/item/organ/internal/appendix,
+		"eyes" =     /obj/item/organ/internal/eyes,
+		)
+
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
 		"is jamming their thumbs into their eye sockets!",

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -65,13 +65,6 @@
 /datum/reagent/proc/on_mob_life(var/mob/living/M as mob, var/alien)
 	if(!istype(M))
 		return
-	if(reagent_state == GAS && M.stat != DEAD && ishuman(M))
-		// make gas reagents affect people like the gasses
-		var/mob/living/carbon/human/H = M
-		if(id == H.species.breath_type)
-			M.adjustOxyLoss(-2*REM)
-		else if(id == H.species.poison_type)
-			M.adjustToxLoss(REAGENTS_METABOLISM)
 	if(holder)
 		holder.remove_reagent(id, metabolization_rate) //By default it slowly disappears.
 		current_cycle++

--- a/code/modules/reagents/oldchem/reagents/_reagent_base.dm
+++ b/code/modules/reagents/oldchem/reagents/_reagent_base.dm
@@ -63,13 +63,18 @@
 	return
 
 /datum/reagent/proc/on_mob_life(var/mob/living/M as mob, var/alien)
-	if(!istype(M, /mob/living)) // YOU'RE A FUCKING RETARD NEO WHY CAN'T YOU JUST FIX THE PROBLEM ON THE REAGENT - Iamgoofball
-		return //Noticed runtime errors from facid trying to damage ghosts, this should fix. --NEO
-				// Certain elements in too large amounts cause side-effects
+	if(!istype(M))
+		return
+	if(reagent_state == GAS && M.stat != DEAD && ishuman(M))
+		// make gas reagents affect people like the gasses
+		var/mob/living/carbon/human/H = M
+		if(id == H.species.breath_type)
+			M.adjustOxyLoss(-2*REM)
+		else if(id == H.species.poison_type)
+			M.adjustToxLoss(REAGENTS_METABOLISM)
 	if(holder)
-		holder.remove_reagent(src.id, metabolization_rate) //By default it slowly disappears.
+		holder.remove_reagent(id, metabolization_rate) //By default it slowly disappears.
 		current_cycle++
-	return
 
 // Called when two reagents of the same are mixing.
 /datum/reagent/proc/on_merge(var/data)

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -36,8 +36,7 @@
 	if(ishuman(M) && !M.isSynthetic())
 		var/mob/living/carbon/human/H = M
 		L = H.get_int_organ(/obj/item/organ/internal/liver)
-		if(!L || (istype(L) && L.dna.species in list("Skrell", "Neara")))
-			d*=5
+		d *= L ? L.alcohol_intensity : 5
 
 	M.dizziness += dizzy_adj.
 	if(d >= slur_start && d < pass_out)

--- a/code/modules/reagents/oldchem/reagents/reagents_misc.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_misc.dm
@@ -42,16 +42,6 @@
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 
-/datum/reagent/oxygen/on_mob_life(var/mob/living/M as mob, var/alien)
-	if(M.stat == 2) return
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.species && (H.species.name == "Vox" || H.species.name =="Vox Armalis"))
-			M.adjustToxLoss(REAGENTS_METABOLISM)
-			holder.remove_reagent(src.id, REAGENTS_METABOLISM) //By default it slowly disappears.
-			return
-	..()
-
 
 /datum/reagent/nitrogen
 	name = "Nitrogen"
@@ -59,16 +49,6 @@
 	description = "A colorless, odorless, tasteless gas."
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
-
-/datum/reagent/nitrogen/on_mob_life(var/mob/living/M as mob, var/alien)
-	if(M.stat == 2) return
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(H.species && (H.species.name == "Vox" || H.species.name =="Vox Armalis"))
-			M.adjustOxyLoss(-2*REM)
-			holder.remove_reagent(src.id, REAGENTS_METABOLISM) //By default it slowly disappears.
-			return
-	..()
 
 
 /datum/reagent/hydrogen

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -292,6 +292,7 @@
 	organ_tag = "liver"
 	parent_organ = "groin"
 	slot = "liver"
+	var/alcohol_intensity = 1
 
 /obj/item/organ/internal/liver/process()
 

--- a/code/modules/surgery/organs/subtypes/skrell.dm
+++ b/code/modules/surgery/organs/subtypes/skrell.dm
@@ -1,0 +1,2 @@
+/obj/item/organ/internal/liver/skrell
+	alcohol_intensity = 5

--- a/paradise.dme
+++ b/paradise.dme
@@ -2008,6 +2008,7 @@
 #include "code\modules\surgery\organs\subtypes\machine.dm"
 #include "code\modules\surgery\organs\subtypes\misc.dm"
 #include "code\modules\surgery\organs\subtypes\nucleation.dm"
+#include "code\modules\surgery\organs\subtypes\skrell.dm"
 #include "code\modules\surgery\organs\subtypes\standard.dm"
 #include "code\modules\surgery\organs\subtypes\unbreakable.dm"
 #include "code\modules\surgery\organs\subtypes\wryn.dm"


### PR DESCRIPTION
- Makes skrell liver behavior be based on a liver var instead of :snowflake: 
- Removes the o2 and n2 pill :snowflake:  thing that was only for voxes.

:cl:
rscdel: Removes n2 pills healing vox oxyloss, and o2 pills poisoning vox.
/:cl: