### PR TITLE
Makes photocopied butts use OOP

### DIFF
--- a/code/modules/mob/living/carbon/human/species/drask.dm
+++ b/code/modules/mob/living/carbon/human/species/drask.dm
@@ -52,6 +52,7 @@
 	reagent_tag = PROCESS_ORG
 	base_color = "#a3d4eb"
 	blood_color = "#a3d4eb"
+	butt_sprite = "drask"
 
 	has_organ = list(
 		"heart" =      				/obj/item/organ/internal/heart/drask,

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -12,6 +12,8 @@
 
 	//default_mutations=list(SKELETON) // This screws things up
 
+	butt_sprite = "plasma"
+
 	breath_type = "plasma"
 
 	heat_level_1 = 350  // Heat damage level 1 above this point.

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -16,6 +16,7 @@
 
 	var/eyes = "eyes_s"                                  // Icon for eyes.
 	var/blurb = "A completely nondescript species."      // A brief lore summary for use in the chargen screen.
+	var/butt_sprite = "human"
 
 	var/primitive_form            // Lesser form, if any (ie. monkey for humans)
 	var/greater_form              // Greater form, if any, ie. human for monkeys.

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -57,6 +57,7 @@
 	base_color = "#066000"
 	//Default styles for created mobs.
 	default_hair = "Unathi Horns"
+	butt_sprite = "unathi"
 
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
 								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/tribble)
@@ -113,6 +114,7 @@
 	base_color = "#333333"
 	//Default styles for created mobs.
 	default_headacc = "Tajaran Ears"
+	butt_sprite = "tajaran"
 
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/chick, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot,
 								 /mob/living/simple_animal/tribble)
@@ -157,6 +159,7 @@
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#966464"
 	base_color = "#B43214"
+	butt_sprite = "vulp"
 
 	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
 								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/tribble)
@@ -196,6 +199,7 @@
 	//Default styles for created mobs.
 	default_hair = "Skrell Male Tentacles"
 	reagent_tag = PROCESS_ORG
+	butt_sprite = "skrell"
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
@@ -259,6 +263,7 @@
 	flesh_color = "#808D11"
 	//Default styles for created mobs.
 	default_hair = "Short Vox Quills"
+	butt_sprite = "vox"
 
 	reagent_tag = PROCESS_ORG
 	scream_verb = "shrieks"
@@ -384,6 +389,7 @@
 	dietflags = DIET_HERB
 	blood_color = "#FB9800"
 	reagent_tag = PROCESS_ORG
+	butt_sprite = "kidan"
 
 	allowed_consumed_mobs = list(/mob/living/simple_animal/diona)
 
@@ -416,6 +422,7 @@
 	reagent_tag = PROCESS_ORG
 	exotic_blood = "water"
 	//ventcrawler = 1 //ventcrawling commented out
+	butt_sprite = "slime"
 
 	has_organ = list(
 		"brain" = /obj/item/organ/internal/brain/slime
@@ -586,6 +593,7 @@
 	unarmed_type = /datum/unarmed_attack/punch
 	darksight = 5 // BOOSTED from 2
 	eyes = "grey_eyes_s"
+	butt_sprite = "grey"
 
 	brute_mod = 1.25 //greys are fragile
 
@@ -650,6 +658,7 @@
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 	blood_color = "#004400"
 	flesh_color = "#907E4A"
+	butt_sprite = "diona"
 
 	reagent_tag = PROCESS_ORG
 
@@ -766,6 +775,7 @@
 	reagent_tag = PROCESS_SYN
 	male_scream_sound = 'sound/goonstation/voice/robot_scream.ogg'
 	female_scream_sound = 'sound/goonstation/voice/robot_scream.ogg'
+	butt_sprite = "machine"
 
 	has_organ = list(
 		"brain" = /obj/item/organ/internal/brain/mmi_holder/posibrain,

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -226,45 +226,18 @@
 
 /obj/machinery/photocopier/proc/copyass()
 	var/icon/temp_img
-	if(check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
-		if(ishuman(ass)) //Suit checks are in check_ass
-			var/mob/living/carbon/human/H = ass
-			switch(H.get_species())
-				if("Human")
-					temp_img = icon('icons/obj/butts.dmi', "human")
-				if("Tajaran")
-					temp_img = icon('icons/obj/butts.dmi', "tajaran")
-				if("Unathi")
-					temp_img = icon('icons/obj/butts.dmi', "unathi")
-				if("Skrell")
-					temp_img = icon('icons/obj/butts.dmi', "skrell")
-				if("Vox")
-					temp_img = icon('icons/obj/butts.dmi', "vox")
-				if("Kidan")
-					temp_img = icon('icons/obj/butts.dmi', "kidan")
-				if("Grey")
-					temp_img = icon('icons/obj/butts.dmi', "grey")
-				if("Diona")
-					temp_img = icon('icons/obj/butts.dmi', "diona")
-				if("Slime People")
-					temp_img = icon('icons/obj/butts.dmi', "slime")
-				if("Vulpkanin")
-					temp_img = icon('icons/obj/butts.dmi', "vulp")
-				if("Machine")
-					temp_img = icon('icons/obj/butts.dmi', "machine")
-				if("Plasmaman")
-					temp_img = icon('icons/obj/butts.dmi', "plasma")
-				if("Drask")
-					temp_img = icon('icons/obj/butts.dmi', "drask")
-				else
-					temp_img = icon('icons/obj/butts.dmi', "human")
-		else if(istype(ass,/mob/living/silicon/robot/drone))
-			temp_img = icon('icons/obj/butts.dmi', "drone")
-		else if(istype(ass,/mob/living/simple_animal/diona))
-			temp_img = icon('icons/obj/butts.dmi', "nymph")
-		else if(isalien(ass) || istype(ass,/mob/living/simple_animal/hostile/alien)) //Xenos have their own asses, thanks to Pybro.
-			temp_img = icon('icons/obj/butts.dmi', "xeno")
-		else return
+	if(!check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
+		return
+
+	if(ishuman(ass)) //Suit checks are in check_ass
+		var/mob/living/carbon/human/H = ass
+		temp_img = icon('icons/obj/butts.dmi', H.species.butt_sprite)
+	else if(istype(ass,/mob/living/silicon/robot/drone))
+		temp_img = icon('icons/obj/butts.dmi', "drone")
+	else if(istype(ass,/mob/living/simple_animal/diona))
+		temp_img = icon('icons/obj/butts.dmi', "nymph")
+	else if(isalien(ass) || istype(ass,/mob/living/simple_animal/hostile/alien)) //Xenos have their own asses, thanks to Pybro.
+		temp_img = icon('icons/obj/butts.dmi', "xeno")
 	else
 		return
 	var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (loc)


### PR DESCRIPTION
- Refactors butt photocopying to use a species var `butt_sprite` instead of a giant switch.