### PR TITLE
Mutant Plant De-spam-ification

### DIFF
--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -82,7 +82,7 @@
 		honey_frames += HF
 
 	for(var/i in 1 to get_max_bees())
-		var/mob/living/simple_animal/hostile/poison/bees/B = new(src)
+		var/mob/living/simple_animal/hostile/poison/bees/worker/B = new(src)
 		bees += B
 		B.beehome = src
 		B.assign_reagent(R)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -9,6 +9,7 @@
 	var/seed_name					// Plant name for seed packet.
 	var/seed_noun = "seeds"			// Descriptor for packet.
 	var/display_name				// Prettier name.
+	var/base_name					// Unchanging name for use with modified versions
 	var/roundstart					// If set, seed will not display variety number.
 	var/mysterious					// Only used for the random seed packets.
 	var/can_self_harvest = 0		// Mostly used for living mobs.
@@ -23,12 +24,13 @@
 	var/splat_type = /obj/effect/decal/cleanable/fruit_smudge // Graffiti decal.
 	var/preset_product
 	var/final_form = 1
+	var/last_diverge_type = -1		// Used to check if we need to change our name prefix when we are mutated/modified/enhanced
 	var/modular_icon = 0			// Dictates if the product uses a modular sprite. 0 = preset, 1 = modular
 	var/preset_icon = "undef"		// Name of the iconstate in icon/obj/harvest.dmi to use for preset sprite
 									//		Make sure to set this to the correct icon if not using a modular sprite
 
 /datum/seed/New()
-
+	base_name = seed_name
 	set_trait(TRAIT_IMMUTABLE,            0)            // If set, plant will never mutate. If -1, plant is highly mutable.
 	set_trait(TRAIT_HARVEST_REPEAT,       0)            // If 1, this plant will fruit repeatedly.
 	set_trait(TRAIT_PRODUCES_POWER,       0)            // Can be used to make a battery.
@@ -797,16 +799,8 @@
 	new_seed.modular_icon = modular_icon
 	new_seed.preset_icon = preset_icon
 
-	switch(modified)
-		if(0)	//Mutant (default)
-			new_seed.seed_name = "mutant [seed_name]"
-			new_seed.display_name = "mutant [seed_name]"
-		if(1)	//Modified
-			new_seed.seed_name = "modified [seed_name]"
-			new_seed.display_name = "modified [seed_name]"
-		if(2)	//Enhanced
-			new_seed.seed_name = "enhanced [seed_name]"
-			new_seed.display_name = "enhanced [seed_name]"
+	new_seed.base_name = base_name
+	new_seed.update_name_prefixes(modified)
 
 	new_seed.seed_noun =            seed_noun
 	new_seed.traits = traits.Copy()
@@ -818,3 +812,20 @@
 		growth_stages = plant_controller.plant_sprites[get_trait(TRAIT_PLANT_ICON)]
 	else
 		growth_stages = 0
+
+/datum/seed/proc/update_name_prefixes(var/modified = 0)
+	if(last_diverge_type == modified)
+		//We already match the new prefix, so we're not going to bother
+		return
+	//Since we don't match, set the last_diverge type to the modified value, then handle the new prefix
+	last_diverge_type = modified
+	switch(modified)
+		if(0)	//Mutant (default)
+			seed_name = "mutant [base_name]"
+			display_name = "mutant [base_name]"
+		if(1)	//Modified
+			seed_name = "modified [base_name]"
+			display_name = "modified [base_name]"
+		if(2)	//Enhanced
+			seed_name = "enhanced [base_name]"
+			display_name = "enhanced [base_name]"

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -260,12 +260,16 @@
 			if(prob(20+mutation_mod))							//Low chance of stat mutation
 				if(!isnull(plant_controller.seeds[seed.name]))
 					seed = seed.diverge()
+				else
+					seed.update_name_prefixes()
 				seed.mutate(1,get_turf(src))
 				return
 		if(2)		//Tier 2
 			if(prob(60+mutation_mod))							//Higher chance of stat mutation
 				if(!isnull(plant_controller.seeds[seed.name]))
 					seed = seed.diverge()
+				else
+					seed.update_name_prefixes()
 				seed.mutate(1,get_turf(src))
 				return
 		if(3)		//Tier 3
@@ -275,11 +279,15 @@
 				else											//No mutant species, mutate stats instead
 					if(!isnull(plant_controller.seeds[seed.name]))
 						seed = seed.diverge()
+					else
+						seed.update_name_prefixes()
 					seed.mutate(1,get_turf(src))
 				return
 			else												//Failed to shift, mutate stats instead
 				if(!isnull(plant_controller.seeds[seed.name]))
 					seed = seed.diverge()
+				else
+					seed.update_name_prefixes()
 				seed.mutate(1,get_turf(src))
 				return
 		if(4)		//Tier 4
@@ -289,19 +297,27 @@
 				else											//No mutant species, mutate stats instead
 					if(!isnull(plant_controller.seeds[seed.name]))
 						seed = seed.diverge()
+					else
+						seed.update_name_prefixes()
 					seed.mutate(1,get_turf(src))
 					if(prob(20+mutation_mod))					//Low chance for second stat mutation
 						if(!isnull(plant_controller.seeds[seed.name]))
 							seed = seed.diverge()
+						else
+							seed.update_name_prefixes()
 						seed.mutate(1,get_turf(src))
 				return
 			else												//Failed to shift, mutate stats instead
 				if(!isnull(plant_controller.seeds[seed.name]))
 					seed = seed.diverge()
+				else
+					seed.update_name_prefixes()
 				seed.mutate(1,get_turf(src))
 				if(prob(20+mutation_mod))						//Low chance for second stat mutation
 					if(!isnull(plant_controller.seeds[seed.name]))
 						seed = seed.diverge()
+					else
+						seed.update_name_prefixes()
 					seed.mutate(1,get_turf(src))
 				return
 		//Floral Somatoray Tiers
@@ -309,12 +325,16 @@
 			if(prob(80+mutation_mod))							//EVEN Higher chance of stat mutation
 				if(!isnull(plant_controller.seeds[seed.name]))
 					seed = seed.diverge()
+				else
+					seed.update_name_prefixes()
 				seed.mutate(1,get_turf(src))
 				return
 		if("F2")	//Yield Tier
 			if(prob(40+mutation_mod))							//Medium chance of Yield stat mutation
 				if(!isnull(plant_controller.seeds[seed.name]))
 					seed = seed.diverge()
+				else
+					seed.update_name_prefixes()
 				if(seed.get_trait(TRAIT_IMMUTABLE) <= 0 && seed.get_trait(TRAIT_YIELD) != -1)		//Check if the plant can be mutated and has a yield to mutate
 					seed.set_trait(TRAIT_YIELD, (seed.get_trait(TRAIT_YIELD) + rand(-2, 2)))		//Randomly adjust yield
 					if(seed.get_trait(TRAIT_YIELD) < 0)							//If yield would drop below 0 after adjustment, set to 0 to allow further attempts

--- a/code/modules/hydroponics/trays/tray_reagents.dm
+++ b/code/modules/hydroponics/trays/tray_reagents.dm
@@ -180,12 +180,16 @@
 				if(production_stat_value && seed.get_trait(TRAIT_PRODUCTION) > 2)
 					if(!isnull(plant_controller.seeds[seed.name]))	//This is so we don't affect plants in other trays unintentionally
 						seed = seed.diverge(2)						//ENHANCE!
+					else
+						seed.update_name_prefixes(2)
 					var/new_production = seed.get_trait(TRAIT_PRODUCTION) + (reagent_total * production_stat_value)
 					seed.set_trait(TRAIT_PRODUCTION, max(2, new_production))		//can't drop below 2 with this method
 				//Potency
 				if(potency_stat_value)
 					if(!isnull(plant_controller.seeds[seed.name]))	//This is so we don't affect plants in other trays unintentionally
 						seed = seed.diverge(2)						//ENHANCE!
+					else
+						seed.update_name_prefixes(2)
 					var/new_potency = seed.get_trait(TRAIT_POTENCY) + (reagent_total * potency_stat_value)
 					seed.set_trait(TRAIT_POTENCY, max(0, min(100, new_potency)))		//can't go above 100 or below 0 with this method
 

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -159,8 +159,8 @@
 /mob/living/simple_animal/hostile/poison/bees/worker/Found(atom/A)
 	if(istype(A, /obj/machinery/portable_atmospherics/hydroponics))
 		var/obj/machinery/portable_atmospherics/hydroponics/Hydro = A
-		if(Hydro.seed && !Hydro.dead && !Hydro.recent_bee_visit)
-			wanted_objects |= /obj/machinery/portable_atmospherics/hydroponics //so we only hunt them while they're alive/seeded/not visisted
+		if(Hydro.seed && !Hydro.dead && !Hydro.recent_bee_visit && !Hydro.closed_system)
+			wanted_objects |= /obj/machinery/portable_atmospherics/hydroponics //so we only hunt them while they're alive/seeded/not visisted and uncovered
 			return 1
 	..()
 
@@ -186,7 +186,7 @@
 		..()
 
 /mob/living/simple_animal/hostile/poison/bees/worker/proc/pollinate(obj/machinery/portable_atmospherics/hydroponics/Hydro)
-	if(!istype(Hydro) || !Hydro.seed || Hydro.dead || Hydro.recent_bee_visit)
+	if(!istype(Hydro) || !Hydro.seed || Hydro.dead || Hydro.recent_bee_visit || Hydro.closed_system)
 		target = null
 		return
 
@@ -205,11 +205,15 @@
 	if(prob(BEE_POLLINATE_YIELD_CHANCE)) //Yield mod is HELLA powerful, but quite rare
 		if(!isnull(plant_controller.seeds[Hydro.seed.name]))
 			Hydro.seed = Hydro.seed.diverge()
+		else
+			Hydro.seed.update_name_prefixes()
 		var/seed_yield = Hydro.seed.get_trait(TRAIT_YIELD)
 		Hydro.seed.set_trait(TRAIT_YIELD, seed_yield + 1, 10, 0)
 	if(prob(BEE_POLLINATE_POTENTCY_CHANCE))
 		if(!isnull(plant_controller.seeds[Hydro.seed.name]))
 			Hydro.seed = Hydro.seed.diverge()
+		else
+			Hydro.seed.update_name_prefixes()
 		var/seed_potency = Hydro.seed.get_trait(TRAIT_POTENCY)
 		Hydro.seed.set_trait(TRAIT_POTENCY, seed_potency + 1, 200, 0)
 


### PR DESCRIPTION
Mutated / Modified / Enhanced plants will no longer add new prefixes to their names resulting in obscenely long names like "mutant mutant mutant mutant mutant mutant enhanced mutant mutant modified wheat"
- Plants will now simply use a single "mutant", "modified", or "enhanced" prefix to their name, determined by the last type of modification used.
 - This means you can mutate a modified plant and then pass it off as merely "enhanced" if you do things in the right order

HAPPY SIDE EFFECT BONUS FUNTIME EXTRAVAGANZA!
- The chef's smartfridge will now compact ALL mutant, modified, or enhanced versions of a given plant into a single listing for that modification.
 - No longer will you have 50 listings of mutated wheat (with ever-longer names) because the botanist decided to raise a couple bees.

Bees also now can not affect hydroponics trays that have their lids up.
- Raise your strange plants in peace, knowing the bees won't make them stranger unless you want them to.

Premade beeboxes (and the random variant) now have the right kind of worker bees, instead of the generic "bee" type.
- This was a mistake / oversight on my part from the bee refactor in the Bee Briefcase PR.
- For reference, the premade (and random) beeboxes are admin spawn / mapper only. That's why this never was noticed this wasn't working right

:cl:
tweak: Mutant/Modified/Enhanced plants will no longer infinitely increase their name length, and instead will be simply "mutant", "modified", or "enhanced" plant as determined by the last type of modification they were subject to.
tweak: Bees can no longer phase through hydroponics lids, giving botanists a way to finally stem the tide of pollination.
bugfix: Premade beeboxes now spawn with the right type of bees, specifically of the worker caste.
/:cl: