### PR TITLE
All lazarus'd mobs can now be pet collared

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -916,6 +916,7 @@
 			if(M.stat == DEAD)
 				M.faction = list("neutral")
 				M.revive()
+				M.can_collar = 1
 				if(istype(target, /mob/living/simple_animal/hostile))
 					var/mob/living/simple_animal/hostile/H = M
 					if(malfunctioning)


### PR DESCRIPTION
If you revive a mob with a Lazarus injector, you will now be able to rename it with a pet collar if it couldn't be before.

:cl:HugoLuman
tweak: All lazarus revived mobs become valid for pet collaring
/:cl: