### PR TITLE
Adds admin names to world status topic

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -115,6 +115,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	else if ("status" in input)
 		var/list/s = list()
+		var/list/admins = list()
 		s["version"] = game_version
 		s["mode"] = master_mode
 		s["respawn"] = config ? abandon_allowed : 0
@@ -132,6 +133,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				if(C.holder.fakekey)
 					continue	//so stealthmins aren't revealed by the hub
 				admin_count++
+				admins += C.key
 			s["player[player_count]"] = C.key
 			player_count++
 		s["players"] = player_count
@@ -149,6 +151,9 @@ var/world_topic_spam_protect_time = world.timeofday
 				s["shuttle_mode"] = shuttle_master.emergency.mode
 				// Shuttle timer, in seconds
 				s["shuttle_timer"] = shuttle_master.emergency.timeLeft()
+
+			for(var/i in 1 to admins.len)
+				s["admin[i - 1]"] = admins[i]
 
 		return list2params(s)
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -133,7 +133,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				if(C.holder.fakekey)
 					continue	//so stealthmins aren't revealed by the hub
 				admin_count++
-				admins += C.key
+				admins += list(list(C.key, C.holder.rank))
 			s["player[player_count]"] = C.key
 			player_count++
 		s["players"] = player_count
@@ -153,7 +153,9 @@ var/world_topic_spam_protect_time = world.timeofday
 				s["shuttle_timer"] = shuttle_master.emergency.timeLeft()
 
 			for(var/i in 1 to admins.len)
-				s["admin[i - 1]"] = admins[i]
+				var/list/A = admins[i]
+				s["admin[i - 1]"] = A[1]
+				s["adminrank[i - 1]"] = A[2]
 
 		return list2params(s)
 


### PR DESCRIPTION
Adds the world/Topic's status text to include a list of admins, if the comms password is correct. For the bots so admins can see who's admining.

Like the `players`/`player0`/`player/1`... list, you use `admins` to know how many admins are on (as before) but also can get the names via `admin0`, `admin1`, etc.

@tigercat2000 @Regen1 