### PR TITLE
cryo multiplies cryoxadone/beaker reagents by much less

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -385,7 +385,7 @@
 				var/heal_fire = occupant.getFireLoss() ? min(efficiency, 20*(efficiency**2) / occupant.getFireLoss()) : 0
 				occupant.heal_organ_damage(heal_brute,heal_fire)
 		if(beaker && next_trans == 0)
-			beaker.reagents.trans_to(occupant, 1, 10)
+			beaker.reagents.trans_to(occupant, 1, 3)
 			beaker.reagents.reaction(occupant)
 	next_trans++
 	if(next_trans == 10)


### PR DESCRIPTION
I've never in my life seen the default 30 unit beaker of cryoxadone run out. So this is much more reasonable I think. On my server it's 1:1 but...


:cl: 
Cryo tubes inflate beaker reagents much less
/:cl: