### PR TITLE
Admin Tools Fixes and New Addition

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -125,6 +125,7 @@ var/list/admin_verbs_server = list(
 	/datum/admins/proc/toggleAI,
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
 	/client/proc/cmd_debug_del_all,
+	/client/proc/cmd_debug_del_sing,
 	/datum/admins/proc/toggle_aliens,
 	/client/proc/delbook,
 	/client/proc/view_flagged_books,
@@ -141,6 +142,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_debug_mob_lists,
 	/client/proc/cmd_admin_delete,
 	/client/proc/cmd_debug_del_all,
+	/client/proc/cmd_debug_del_sing,
 	/client/proc/reload_admins,
 	/client/proc/restart_controller,
 	/client/proc/enable_debug_verbs,

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -359,6 +359,26 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		message_admins("[key_name_admin(src)] has deleted all instances of [hsbitem].", 0)
 	feedback_add_details("admin_verb","DELA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/cmd_debug_del_sing()
+	set category = "Debug"
+	set name = "Del Singulo / Tesla"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	//This gets a confirmation check because it's way easier to accidentally hit this and delete things than it is with del-all
+	var/confirm = alert("This will delete ALL Singularities and Tesla orbs except for any that are on away mission z-levels or the centcomm z-level. Are you sure you want to delete them?", "Confirm Panic Button", "Yes", "No")
+	if(confirm != "Yes")
+		return
+
+	for(var/obj/singularity/S in world)
+		if(S.z == ZLEVEL_CENTCOMM  || S.z >= 8)
+			continue
+		qdel(S)
+	log_admin("[key_name(src)] has deleted all Singularities and Tesla orbs.")
+	message_admins("[key_name_admin(src)] has deleted all instances of Singularities and Tesla orbs.", 0)
+	feedback_add_details("admin_verb","DELS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/proc/cmd_debug_make_powernets()
 	set category = "Debug"
 	set name = "Make Powernets"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -371,7 +371,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if(confirm != "Yes")
 		return
 
-	for(var/obj/singularity/S in singularities)
+	for(var/I in singularities)
+		var/obj/singularity/S = I
 		if(S.z == ZLEVEL_CENTCOMM  || S.z >= MAX_Z)
 			continue
 		qdel(S)

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -3,7 +3,7 @@
 		alert("The game hasn't started yet!")
 		return
 
-	var/list/incompatible_species = list("Plasmaman")
+	var/list/incompatible_species = list("Plasmaman", "Vox")
 	for(var/mob/living/carbon/human/H in player_list)
 		if(H.stat == DEAD || !(H.client))
 			continue

--- a/code/modules/admin/verbs/onlyoneteam.dm
+++ b/code/modules/admin/verbs/onlyoneteam.dm
@@ -3,7 +3,8 @@
 		alert("The game hasn't started yet!")
 		return
 
-	var/list/incompatible_species = list("Plasmaman")
+	var/list/incompatible_species = list("Plasmaman", "Vox")
+	var/team_toggle = 0
 	for(var/mob/living/carbon/human/H in player_list)
 		if(H.stat == DEAD || !(H.client))
 			continue
@@ -27,7 +28,7 @@
 		H.equip_to_slot_or_del(new /obj/item/weapon/beach_ball/dodgeball(H), slot_r_hand)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), slot_shoes)
 
-		if(prob(50))
+		if(!team_toggle)
 			team_alpha += H
 
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/color/red/dodgeball(H), slot_w_uniform)
@@ -53,6 +54,7 @@
 			W.registered_name = H.real_name
 			H.equip_to_slot_or_del(W, slot_wear_id)
 
+		team_toggle = !team_toggle
 		H.species.equip(H)
 		H.regenerate_icons()
 


### PR DESCRIPTION
Highlander and Dodgeball will now view Vox as incompatible species and convert them into humans to avoid issues with deleting their much-needed internals
- Already does this for plasmamen

Adjusts team selection for Dodgeball to hopefully result in consistently "balanced" teams (in terms of numbers)
- Rather than relying on a if(prob(50)) check, it now just switches back and forth with each successful team addition

Adds a new admin panic button: "Del Singulo / Tesla"
- After a confirmation, deletes ALL singularities and tesla orbs across all z-levels (except away missions and cent-comm), regardless of containment

Not gonna changelog this since it's non-player stuff