### PR TITLE
Makes glass tables drop 2 glass

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -448,8 +448,9 @@
 /obj/structure/table/glass/destroy(dirty)
 	if(dirty)
 		new /obj/item/weapon/shard(loc)
+		new /obj/item/weapon/shard(loc)
 	else
-		new /obj/item/stack/sheet/glass(loc)
+		new /obj/item/stack/sheet/glass(loc, 2)
 	..()
 
 /obj/structure/table/glass/tablepush(obj/item/I, mob/user)


### PR DESCRIPTION
Fixes #4522 

:cl:
tweak: Deconstructing glass tables now gives a stack of 2 sheets of glass.
/:cl: