### PR TITLE
Fix some IPC surgeries not working

### DIFF
--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -23,7 +23,6 @@
 	name = "robotic cavity implant"
 	steps = list(/datum/surgery_step/robotics/external/unscrew_hatch,/datum/surgery_step/robotics/external/open_hatch,/datum/surgery_step/cavity/place_item,/datum/surgery_step/robotics/external/close_hatch)
 	possible_locs = list("chest","head","groin")
-	allowed_mob = list(/mob/living/carbon/human/machine)
 
 /datum/surgery/cavity_implant/can_start(mob/user, mob/living/carbon/target)
 	if(target.get_species() == "Machine")
@@ -231,7 +230,6 @@
 	name = "implant removal"
 	steps = list(/datum/surgery_step/robotics/external/unscrew_hatch,/datum/surgery_step/robotics/external/open_hatch,/datum/surgery_step/cavity/implant_removal,/datum/surgery_step/robotics/external/close_hatch)
 	possible_locs = list("chest")//head is for borers..i can put it elsewhere
-	allowed_mob = list(/mob/living/carbon/human/machine)
 
 /datum/surgery/cavity_implant_rem/can_start(mob/user, mob/living/carbon/target)
 	if(target.get_species() == "Machine")

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -40,7 +40,6 @@
 	name = "limb attachment"
 	steps = list(/datum/surgery_step/limb/attach)
 	possible_locs = list("head","l_arm", "l_hand","r_arm","r_hand","r_leg","r_foot","l_leg","l_foot","groin")
-	allowed_mob = list(/mob/living/carbon/human/machine)
 
 /datum/surgery/reattach_synth/can_start(mob/user, mob/living/carbon/target)
 	if(ishuman(target))


### PR DESCRIPTION
THE `/mob/living/carbon/human/machine` CLASS SHOULD NEVER BE USED TO CHECK IF THE PERSON IS AN IPC OR NOT. YOU USE FUCKING GET_SPECIES FOR THAT.

WHY THE FUCK DID YOU EVEN INCLUDE THAT? CAN_START ALREADY CHECKED IF ITS AN IPC OR NOT.