### PR TITLE
Wizard Rebalance

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -91,7 +91,7 @@
 
 	school = "abjuration"
 	charge_max = 20
-	clothes_req = 1
+	clothes_req = 0
 	invocation = "none"
 	invocation_type = "none"
 	range = -1
@@ -264,7 +264,7 @@
 	name = "Repulse"
 	desc = "This spell throws everything around the user away."
 	charge_max = 400
-	clothes_req = 1
+	clothes_req = 0
 	invocation = "GITTAH WEIGH"
 	invocation_type = "shout"
 	range = 5

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -116,25 +116,27 @@
 	name = "Disintegrate"
 	spell_type = /obj/effect/proc_holder/spell/targeted/touch/disintegrate
 	log_name = "DG"
+	cost = 3
 
 /datum/spellbook_entry/disabletech
 	name = "Disable Tech"
 	spell_type = /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech
 	log_name = "DT"
 	category = "Defensive"
-	cost = 1
 
 /datum/spellbook_entry/repulse
 	name = "Repulse"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/repulse
 	log_name = "RP"
 	category = "Defensive"
+	cost = 1
 
 /datum/spellbook_entry/timestop
 	name = "Time Stop"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	log_name = "TS"
 	category = "Defensive"
+	cost = 1
 
 /datum/spellbook_entry/smoke
 	name = "Smoke"
@@ -167,6 +169,7 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/turf_teleport/blink
 	log_name = "BL"
 	category = "Mobility"
+	cost = 1
 
 /datum/spellbook_entry/teleport
 	name = "Teleport"
@@ -184,6 +187,7 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/ethereal_jaunt
 	log_name = "EJ"
 	category = "Mobility"
+	cost = 3
 
 /datum/spellbook_entry/knock
 	name = "Knock"
@@ -209,6 +213,7 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
 	log_name = "LD"
 	category = "Defensive"
+	cost = 4
 
 /datum/spellbook_entry/lightningbolt
 	name = "Lightning Bolt"
@@ -219,7 +224,7 @@
 	name = "Lesser Summon Guns"
 	spell_type = /obj/effect/proc_holder/spell/targeted/infinite_guns
 	log_name = "IG"
-	cost = 4
+	cost = 3
 
 /datum/spellbook_entry/horseman
 	name = "Curse of The Horseman"
@@ -340,6 +345,7 @@
 	item_path = /obj/item/clothing/suit/space/rig/wizard
 	log_name = "HS"
 	category = "Defensive"
+	cost = 1
 
 /datum/spellbook_entry/item/armor/Buy(var/mob/living/carbon/human/user,var/obj/item/weapon/spellbook/book)
 	. = ..()

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -213,7 +213,7 @@
 	spell_type = /obj/effect/proc_holder/spell/targeted/lichdom
 	log_name = "LD"
 	category = "Defensive"
-	cost = 4
+	cost = 5
 
 /datum/spellbook_entry/lightningbolt
 	name = "Lightning Bolt"
@@ -224,7 +224,7 @@
 	name = "Lesser Summon Guns"
 	spell_type = /obj/effect/proc_holder/spell/targeted/infinite_guns
 	log_name = "IG"
-	cost = 3
+	cost = 4
 
 /datum/spellbook_entry/horseman
 	name = "Curse of The Horseman"


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: rebalances wizard spells
/:cl:

We have no hard data, so this is based on personal observation. Picking disintegrate, jaunt and lich shouldn't be a standard and it happens literally every single time there's a wizard. This PR aims to force wiznerds to make more diverse choices.

Full changes:

- Blink - doesn't require clothes, costs 1 less, now 1
- Repulse - doesn't require clothes, costs 1 less, now 1
- ~~Infinite Guns - costs 1 less, now 3 (why was this so expensive)~~ BAD IDEA, IT WAS MEANT TO BE THAT EXPENSIVE
- Armor Set - costs 1 less, now 1
- Stop Time - costs 1 less, now 1
- Disable Tech(EMP) - costs 1 more, now 2
- Disintegrate - costs 1 more, now 3
- Ethereal Jaunt - costs 1 more, now 3
- Lichdom - costs 3 more, now 5

(I bet you didn't know half of those existed)

Yes, being a wizard will be more challenging if you don't avoid confrontation, but it's not meant to be easy and lolteleport out of any sticky situation is just not the way it should be done EVERY SINGLE TIME.

Before anyone points this out: yes, a wizard round literally just ended, this falls under impulsive PRmanship.
