### PR TITLE
Removes Xenobio Ear Molestation

### DIFF
--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -510,7 +510,7 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/obj/effect/golemrune/Z = new /obj/effect/golemrune
 	Z.forceMove(get_turf(holder.my_atom))
-	notify_ghosts("Golem rune created in [get_area(Z)].", 'sound/effects/ghost2.ogg', source = Z)
+	notify_ghosts("Golem rune created in [get_area(Z)].", source = Z)
 
 //Bluespace
 /datum/chemical_reaction/slimefloor2


### PR DESCRIPTION
There's no reason for the xenobio runes to make that screeching sound to ALL GHOSTS GLOBALLY _EVERY TIME_ ONE IS MADE.

RIP GHOST EARS EVERYWHERE.

:cl:DaveTheHeadcrab
tweak: Removes xenobio golem rune creation sound
/:cl:
