### PR TITLE
Changelog notification tweak

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -316,8 +316,9 @@
 	send_resources()
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
+		if(!setup_database_connection())
+			return // if we have db problems, don't show anything
 		winset(src, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
-		prefs.SetChangelog(src,changelog_hash)
 		to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 
 	if(!void)

--- a/code/modules/client/preferences_mysql.dm
+++ b/code/modules/client/preferences_mysql.dm
@@ -456,10 +456,12 @@
 
 /datum/preferences/proc/SetChangelog(client/C,hash)
 	lastchangelog=hash
+	winset(C, "rpane.changelog", "background-color=none;font-style=")
 	var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET lastchangelog='[lastchangelog]' WHERE ckey='[C.ckey]'")
 	if(!query.Execute())
 		var/err = query.ErrorMsg()
 		log_game("SQL ERROR during lastchangelog updating. Error : \[[err]\]\n")
 		message_admins("SQL ERROR during lastchangelog updating. Error : \[[err]\]\n")
+		to_chat(C, "Couldn't update your last seen changelog, please try again later.")
 		return
 	return 1

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -34,10 +34,6 @@
 		verbs += /client/proc/readmin
 	spawn(40)
 		if(client)
-			if(client.prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
-				winset(client, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
-				client.prefs.SetChangelog(client,changelog_hash)
-				to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 			client.playtitlemusic()
 
 	if(config.player_overflow_cap && config.overflow_server_url) //Overflow rerouting, if set, forces players to be moved to a different server once a player cap is reached. Less rough than a pure kick.

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -40,9 +40,7 @@
 	src << browse('html/changelog.html', "window=changes;size=675x650")
 
 	if(prefs.lastchangelog != changelog_hash) //if it's already opened, no need to tell them they have unread changes
-		prefs.lastchangelog = changelog_hash
-		prefs.save_preferences()
-		winset(src, "rpane.changelog", "background-color=none;font-style=")
+		prefs.SetChangelog(src,changelog_hash)
 
 /client/verb/forum()
 	set name = "forum"


### PR DESCRIPTION
So, my system kinda worked illogically before, so I tweaked it. Earlier, it would check for lastchangelog on roundstart, and update it without you even seeing the changes. Now, it checks only when the db is connected and when the changelog window is opened.