### PR TITLE
Adds a check for twohanded items to cuffing

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -863,6 +863,12 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 //called when we get cuffed/uncuffed
 /mob/living/carbon/proc/update_handcuffed()
 	if(handcuffed)
+		//we don't want problems with nodrop shit if there ever is more than one nodrop twohanded
+		var/obj/item/I = get_active_hand()
+		if(istype(I, /obj/item/weapon/twohanded))
+			var/obj/item/weapon/twohanded/TH = I //FML
+			if(TH.wielded)
+				TH.unwield()
 		drop_r_hand()
 		drop_l_hand()
 		stop_pulling()


### PR DESCRIPTION
Fixes #2276. Now, I have two options here. Leave the fix as it is now, and have it check only for twohanded items. Or, have it check for NODROP, but implement an even snowflakier check for twohanded items, as they also have an offhand that has to be deleted and need a name change. Whatever suits the maintainers.
:cl: CrAzYPiLoT
fix: Fixed the long-lasting bug of handcuffed people keeping their chainsaws.
/:cl: