### PR TITLE
Fixes Poly again, why not

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -64,12 +64,6 @@
 			return 1
 	return 0
 
-//Empties the list by setting the length to 0. Hopefully the elements get garbage collected
-/proc/clearlist(list/list)
-	if(istype(list))
-		list.len = 0
-	return
-
 //Removes any null entries from the list
 /proc/listclearnulls(list/list)
 	if(istype(list))


### PR DESCRIPTION
- Makes Poly's speech picking code not constantly do weird stuff with physically adding and removing radio prefixes a million times, making weird assumptions. Only adds them once per change to the speech phrases.
- Also should handle headset being added and removed correctly regarding the prefixes.
- Kept Poly bawking in deadchat when you steal its headset after death because it's funny.