### PR TITLE
Adds comical implants

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -244,9 +244,14 @@
 		H.equip_or_collect(new /obj/item/toy/crayon/rainbow(H), slot_in_backpack)
 		H.equip_or_collect(new /obj/item/weapon/storage/fancy/crayons(H), slot_in_backpack)
 		H.equip_or_collect(new /obj/item/weapon/reagent_containers/spray/waterflower(H), slot_in_backpack)
-		H.mutations.Add(CLUMSY)
-		H.dna.SetSEState(COMICBLOCK,1,1)
-		genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
+		if(H.get_species() == "Machine")
+			var/obj/item/organ/internal/cyberimp/brain/clown_voice/implant
+			implant = new
+			implant.insert(H)
+		else
+			H.mutations.Add(CLUMSY)
+			H.dna.SetSEState(COMICBLOCK,1,1)
+			genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
 		return 1
 
 

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -248,10 +248,9 @@
 			var/obj/item/organ/internal/cyberimp/brain/clown_voice/implant
 			implant = new
 			implant.insert(H)
-		else
-			H.mutations.Add(CLUMSY)
-			H.dna.SetSEState(COMICBLOCK,1,1)
-			genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
+		H.mutations.Add(CLUMSY)
+		H.dna.SetSEState(COMICBLOCK,1,1)
+		genemutcheck(H,COMICBLOCK,null,MUTCHK_FORCED)
 		return 1
 
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -148,6 +148,9 @@
 			if(prob(braindam))
 				message = uppertext(message)
 				verb = "yells loudly"
+	
+	if(locate(/obj/item/organ/internal/cyberimp/brain/clown_voice) in internal_organs)
+		message = "<span class='sans'>[message]</span>"
 
 	returns[1] = message
 	returns[2] = verb

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -98,12 +98,6 @@ proc/get_radio_key_from_channel(var/channel)
 
 	else if(COMIC in mutations)
 		message = "<span class='sans'>[message]</span>"
-	
-	else
-		if(ishuman(src))
-			var/mob/living/carbon/human/H = src
-			if(locate(/obj/item/organ/internal/cyberimp/brain/clown_voice) in H.internal_organs)
-				message = "<span class='sans'>[message]</span>"
 
 	if(!IsVocal())
 		message = ""

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -98,6 +98,12 @@ proc/get_radio_key_from_channel(var/channel)
 
 	else if(COMIC in mutations)
 		message = "<span class='sans'>[message]</span>"
+	
+	else
+		if(ishuman(src))
+			var/mob/living/carbon/human/H = src
+			if(locate(/obj/item/organ/internal/cyberimp/brain/clown_voice) in H.internal_organs)
+				message = "<span class='sans'>[message]</span>"
 
 	if(!IsVocal())
 		message = ""

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -282,7 +282,7 @@
 
 /datum/design/cyberimp_clownvoice
 	name = "Comical implant"
-	desc = "Uh oh."
+	desc = "<span class='sans'>Uh oh.</span>"
 	id = "ci-clownvoice"
 	req_tech = list("materials" = 2, "biotech" = 2)
 	build_type = PROTOLATHE | MECHFAB

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -280,6 +280,17 @@
 	build_path = /obj/item/organ/internal/cyberimp/brain/anti_stun
 	category = list("Misc", "Medical")
 
+/datum/design/cyberimp_clownvoice
+	name = "Comical implant"
+	desc = "Uh oh."
+	id = "ci-clownvoice"
+	req_tech = list("materials" = 2, "biotech" = 2)
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
+	materials = list(MAT_METAL = 200, MAT_GLASS = 200, MAT_BANANIUM = 200)
+	build_path = /obj/item/organ/internal/cyberimp/brain/clown_voice
+	category = list("Misc", "Medical")
+
 /datum/design/cyberimp_nutriment
 	name = "Nutriment pump implant"
 	desc = "This implant with synthesize and pump into your bloodstream a small amount of nutriment when you are starving."

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -146,7 +146,7 @@
 
 /obj/item/organ/internal/cyberimp/brain/clown_voice
 	name = "Comical implant"
-	desc = "Uh oh."
+	desc = "<span class='sans'>Uh oh.</span>"
 	implant_color = "#DEDE00"
 	slot = "brain_clownvoice"
 	origin_tech = "materials=2;biotech=2"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -144,6 +144,13 @@
 	spawn(90 / severity)
 		crit_fail = 0
 
+/obj/item/organ/internal/cyberimp/brain/clown_voice
+	name = "Comical implant"
+	desc = "Uh oh."
+	implant_color = "#DEDE00"
+	slot = "brain_clownvoice"
+	origin_tech = "materials=2;biotech=2"
+
 //[[[[CHEST]]]]
 /obj/item/organ/internal/cyberimp/chest
 	name = "cybernetic torso implant"


### PR DESCRIPTION
HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK HONK 

:cl: monster860
rscadd: Adds comical implant. It is an implant that causes you to have a comic sans voice. It can be made in the protolathe using bananium.
rscadd: The comical implant now spawns by default inside IPC clowns
/:cl: