### PR TITLE
Fixes holsters and potentially other accessories's action buttons

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -217,10 +217,24 @@
 	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUNNED|AB_CHECK_LYING|AB_CHECK_ALIVE|AB_CHECK_INSIDE
 
 /datum/action/item_action/CheckRemoval(mob/living/user)
-	return !(target in user)
+	return get(target, /mob/living) != user
 
 /datum/action/item_action/hands_free
 	check_flags = AB_CHECK_ALIVE|AB_CHECK_INSIDE
+
+// for clothing accessories like holsters
+/datum/action/item_action/accessory
+	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUNNED|AB_CHECK_LYING|AB_CHECK_ALIVE
+
+/datum/action/item_action/accessory/Checks()
+	. = ..()
+	if(!.)
+		return 0
+	if(target.loc == owner)
+		return 1
+	if(istype(target.loc, /obj/item/clothing/under) && target.loc.loc == owner)
+		return 1
+	return 0
 
 ///prset for organ actions
 /datum/action/item_action/organ_action

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -14,7 +14,7 @@
 	origin_tech = "materials=5;biotech=4;powerstorage=5;abductor=3"
 	armor = list(melee = 15, bullet = 15, laser = 15, energy = 15, bomb = 15, bio = 15, rad = 15)
 	action_button_name = "Activate"
-	action_button_is_hands_free = 1
+	action_button_custom_type = /datum/action/item_action/hands_free
 	var/mode = VEST_STEALTH
 	var/stealth_active = 0
 	var/combat_cooldown = 10

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -31,7 +31,7 @@
 
 	//If this is set, The item will make an action button on the player's HUD when picked up.
 	var/action_button_name //It is also the text which gets displayed on the action button. If not set it defaults to 'Use [name]'. If it's not set, there'll be no button.
-	var/action_button_is_hands_free = 0 //If 1, bypass the restrained, lying, and stunned checks action buttons normally test for
+	var/action_button_custom_type = null
 	var/datum/action/item_action/action = null
 
 	var/list/materials = list()

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -2,7 +2,7 @@
 	name = "implant"
 	icon = 'icons/obj/implants.dmi'
 	icon_state = "generic" //Shows up as the action button icon
-	action_button_is_hands_free = 1
+	action_button_custom_type = /datum/action/item_action/hands_free
 	origin_tech = "materials=2;biotech=3;programming=2"
 
 	var/activated = 1 //1 for implant types that can be activated, 0 for ones that are "always on" like loyalty implants

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -10,6 +10,7 @@
 	var/slot = "decor"
 	var/obj/item/clothing/under/has_suit = null		//the suit the tie may be attached to
 	var/image/inv_overlay = null	//overlay used when attached to clothing.
+	action_button_custom_type = /datum/action/item_action/accessory
 
 /obj/item/clothing/accessory/New()
 	..()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -251,19 +251,17 @@
 /mob/living/proc/give_action_button(var/obj/item/I, recursive = 0)
 	if(I.action_button_name)
 		if(!I.action)
-			if(istype(I, /obj/item/organ/internal))
-				I.action = new/datum/action/item_action/organ_action
-			else if(I.action_button_is_hands_free)
-				I.action = new/datum/action/item_action/hands_free
+			if(I.action_button_custom_type)
+				I.action = new I.action_button_custom_type
 			else
-				I.action = new/datum/action/item_action
+				I.action = new /datum/action/item_action
 			I.action.name = I.action_button_name
 			I.action.target = I
 		I.action.Grant(src)
 
 	if(recursive)
 		for(var/obj/item/T in I)
-			give_action_button(I, recursive - 1)
+			give_action_button(T, recursive - 1)
 
 /mob/living/update_action_buttons()
 	if(!hud_used) return

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -10,6 +10,7 @@
 	vital = 0
 	var/organ_action_name = null
 	var/non_primary = 0
+	action_button_custom_type = /datum/action/item_action/organ_action
 
 /obj/item/organ/internal/New(var/mob/living/carbon/holder)
 	if(istype(holder))


### PR DESCRIPTION
- I cleaned up the item action button system by just letting them specify the action button type, instead of an arcane system of boolean variables and type checks.
- I also fixed the recursive action button checking so things inside of items now can get their action buttons again.
- The action buttons for accessories like holsters can now be used again while on clothing.
- As a result of the recursion check actually happening, things in your backpack now still have their action button visible (but greyed out). eh.

:cl:
bugfix: Holsters now have an action button while on your suit again.
/:cl: