### PR TITLE
Improve travis script error checker

### DIFF
--- a/dm.sh
+++ b/dm.sh
@@ -79,7 +79,7 @@ else
 	then
 		DreamMaker $dmepath.mdme 2>&1 | tee result.log
 		retval=$?
-		if ! grep '0 errors, 0 warnings' result.log
+		if ! grep '\- 0 errors, 0 warnings' result.log
 		then
 			retval=1 #hard fail, due to warnings or errors
 		fi


### PR DESCRIPTION
Builds should not pass when they have an error count that is a multiple of 10

dreammaker outputs the literal string

    {some other stuff }  - 0 errors and 0 warnings

on a successful build, so by including that in the grep as the literal character -, I eliminate the possibility of matching against

    {some other stuff } - 10 errors and 0 warnings

Which is of course obviously not what we wanted