### PR TITLE
Fixes Ice Reagent

### DIFF
--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_food.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_food.dm
@@ -109,16 +109,17 @@
 	max_temp = 273
 	mix_message = "Ice forms as the water freezes."
 	mix_sound = null
+
 /datum/chemical_reaction/water
 	name = "Water"
 	id = "water"
 	result = "water"
 	required_reagents = list("ice" = 1)
 	result_amount = 1
-	min_temp = 274
+	min_temp = 301 // In Space.....ice melts at 82F...don't ask
 	mix_message = "Water pools as the ice melts."
 	mix_sound = null
-	
+
 /datum/chemical_reaction/dough
 	name = "Dough"
 	id = "dough"


### PR DESCRIPTION
This is a case where immersion and game mechanics take precedence over realism.

Ice now melts at 301 Kelvin instead of 274.

Why? Because currently this screws over a lot of recipes for jobs that otherwise do not and should not require a chem heater, while still allowing ice to be converted to water.

:cl: Fox McCloud
fix: Fixes ice being unobtainable for the jobs that use it most
/:cl: