### PR TITLE
Prevents message spam on roundstart

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -452,7 +452,7 @@
 	var/datum/language/chosen_language
 	if(client.prefs.language)
 		chosen_language = all_languages[client.prefs.language]
-	if((chosen_language == null && chosen_language != "None") || (chosen_language && chosen_language.flags & RESTRICTED))
+	if((chosen_language == null && client.prefs.language != "None") || (chosen_language && chosen_language.flags & RESTRICTED))
 		log_debug("[src] had language [client.prefs.language], though they weren't supposed to. Setting to None.")
 		client.prefs.language = "None"
 


### PR DESCRIPTION
I did a comparison on the wrong object, so it always thought the language name was invalid

:cl:Crazylemon
bugfix: No more language message-spam on roundstart
/:cl: