### PR TITLE
Fixes Ghosts Not Following Unusual Movers

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -59,6 +59,8 @@
 	if(get_nations_mode())
 		process_nations()
 
+	..()
+
 /mob/living/proc/handle_breathing()
 	return
 


### PR DESCRIPTION
I come back to observe some spacemans, only to find a shiny new Follow verb that works great... except when it doesn't work at all. Turns out, it's been broken since November - followers are updated on normal movement and on life ticks, via `/mob/Life`, but `/mob/living/Life` never bothered calling its parent, so mobs that were moving in unusual ways (teleporting, moving through pipes, etc) wouldn't update their followers. Now it does, so they do, and we can all follow those sneaky aliens again. Fixes #4583

Let's see, how do these newfangled changelogs work...

:cl:
bugfix: Fixes ghosts failing to follow mobs that move in unusual ways
/:cl:

That seems right.