### PR TITLE
Adds Mind Batterer, an AOE Crowd Control Traitor-only device.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -410,6 +410,13 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/twohanded/chainsaw
 	cost = 13
 
+/datum/uplink_item/dangerous/batterer
+	name = "Mind Batterer"
+	desc = "A device that has a chance of knocking down people around you for a long amount of time.50% chance per person. The user is unaffected. Has only two charges."
+	reference = "BTR"
+	item = /obj/item/device/batterer
+	cost = 7
+
 /datum/uplink_item/dangerous/manhacks
 	name = "Viscerator Delivery Grenade"
 	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred any non-operatives in the area."
@@ -1016,7 +1023,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/implants/uplink
 	name = "Uplink Implant"
-	desc = "An implant injected into the body, and later activated using a bodily gesture to open an uplink with 5 telecrystals. The ability for an agent to open an uplink after their possessions have been stripped from them makes this implant excellent for escaping confinement."
+	desc = "An implant injected into the body, and later activated using a bodily gesture to open an uplink with 10 telecrystals. The ability for an agent to open an uplink after their possessions have been stripped from them makes this implant excellent for escaping confinement."
 	reference = "UI"
 	item = /obj/item/weapon/implanter/uplink
 	cost = 14

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -415,7 +415,7 @@ var/list/uplink_items = list()
 	desc = "A device that has a chance of knocking down people around you for a long amount of time.50% chance per person. The user is unaffected. Has only two charges."
 	reference = "BTR"
 	item = /obj/item/device/batterer
-	cost = 7
+	cost = 5
 
 /datum/uplink_item/dangerous/manhacks
 	name = "Viscerator Delivery Grenade"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -412,7 +412,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/dangerous/batterer
 	name = "Mind Batterer"
-	desc = "A device that has a chance of knocking down people around you for a long amount of time.50% chance per person. The user is unaffected. Has only two charges."
+	desc = "A device that has a chance of knocking down people around you for a long amount of time. 50% chance per person. The user is unaffected. Has 5 charges."
 	reference = "BTR"
 	item = /obj/item/device/batterer
 	cost = 5

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -44,7 +44,7 @@ effective or pretty fucking useless.
 		return
 
 
-	for(var/mob/living/carbon/human/M in oview(10, user))
+	for(var/mob/living/carbon/human/M in oview(7, user))
 		if(prob(50))
 			M.Weaken(rand(4,7))
 			add_logs(M, user, "stunned", src)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -30,32 +30,24 @@ effective or pretty fucking useless.
 	var/max_uses = 2
 
 
-/obj/item/device/batterer/attack_self(mob/living/carbon/user as mob, flag = 0, emp = 0)
+/obj/item/device/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user) 	return
 	if(times_used >= max_uses)
-		to_chat(user, "\red The mind batterer has been burnt out!")
+		to_chat(user, "<span class='danger>The mind batterer has been burnt out!</span>")
 		return
 
-	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used [src] to knock down people in the area.</font>")
 
 	for(var/mob/living/carbon/human/M in orange(10, user))
-		spawn()
-			if(prob(50))
+		if(prob(50))
+			M.Weaken(rand(3,6))
+			add_logs(M, user, "stunned", src)
+			to_chat(M, "<span class='danger'>You feel a tremendous, paralyzing wave flood your mind.</span>")
+		else
+			to_chat(M, "<span class='danger'>You feel a sudden, electric jolt travel through your head.</span>")
 
-				M.Weaken(rand(10,20))
-				if(prob(25))
-					M.Stun(rand(5,10))
-				to_chat(M, "\red <b>You feel a tremendous, paralyzing wave flood your mind.</b>")
-				if(!iscarbon(user))
-					M.LAssailant = null
-				else
-					M.LAssailant = user
-			else
-				to_chat(M, "\red <b>You feel a sudden, electric jolt travel through your head.</b>")
-
-	playsound(src.loc, 'sound/misc/interference.ogg', 50, 1)
-	to_chat(user, "\blue You trigger [src].")
-	times_used += 1
+	playsound(loc, 'sound/misc/interference.ogg', 50, 1)
+	to_chat(user, "<span class='notice'>You trigger [src].</span>")
+	times_used++
 	if(times_used >= max_uses)
 		icon_state = "battererburnt"
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -32,9 +32,9 @@ effective or pretty fucking useless.
 /obj/item/device/batterer/examine(mob/user)
 	..(user)
 	if(times_used >= max_uses)
-		to_chat(user, "<span class='notice'>The [src] is out of charge.</span>")
+		to_chat(user, "<span class='notice'>[src] is out of charge.</span>")
 	if(times_used < max_uses)
-		to_chat(user, "<span class='notice'>The [src] has [max_uses-times_used] charges left.</span>")
+		to_chat(user, "<span class='notice'>[src] has [max_uses-times_used] charges left.</span>")
 
 /obj/item/device/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user)
@@ -44,7 +44,7 @@ effective or pretty fucking useless.
 		return
 
 
-	for(var/mob/living/carbon/human/M in orange(10, user))
+	for(var/mob/living/carbon/human/M in oview(10, user))
 		if(prob(50))
 			M.Weaken(rand(4,7))
 			add_logs(M, user, "stunned", src)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -27,8 +27,14 @@ effective or pretty fucking useless.
 	origin_tech = "magnets=3;combat=3;syndicate=3"
 
 	var/times_used = 0 //Number of times it's been used.
-	var/max_uses = 2
+	var/max_uses = 5
 
+/obj/item/device/batterer/examine(mob/user)
+	..(user)
+	if(times_used >= max_uses)
+		to_chat(user, "<span class='notice'>The [src] is out of charge.</span>")
+	if(times_used < max_uses)
+		to_chat(user, "<span class='notice'>The [src] has [max_uses-times_used] charges left.</span>")
 
 /obj/item/device/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user)
@@ -40,15 +46,15 @@ effective or pretty fucking useless.
 
 	for(var/mob/living/carbon/human/M in orange(10, user))
 		if(prob(50))
-			M.Weaken(rand(3,6))
+			M.Weaken(rand(4,7))
 			add_logs(M, user, "stunned", src)
 			to_chat(M, "<span class='danger'>You feel a tremendous, paralyzing wave flood your mind.</span>")
 		else
 			to_chat(M, "<span class='danger'>You feel a sudden, electric jolt travel through your head.</span>")
 
 	playsound(loc, 'sound/misc/interference.ogg', 50, 1)
-	to_chat(user, "<span class='notice'>You trigger [src].</span>")
 	times_used++
+	to_chat(user, "<span class='notice'>You trigger [src]. It has [max_uses-times_used] charges left.</span>")
 	if(times_used >= max_uses)
 		icon_state = "battererburnt"
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -31,7 +31,8 @@ effective or pretty fucking useless.
 
 
 /obj/item/device/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
-	if(!user) 	return
+	if(!user)
+		return
 	if(times_used >= max_uses)
 		to_chat(user, "<span class='danger'>The mind batterer has been burnt out!</span>")
 		return

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -33,7 +33,7 @@ effective or pretty fucking useless.
 /obj/item/device/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(!user) 	return
 	if(times_used >= max_uses)
-		to_chat(user, "<span class='danger>The mind batterer has been burnt out!</span>")
+		to_chat(user, "<span class='danger'>The mind batterer has been burnt out!</span>")
 		return
 
 


### PR DESCRIPTION
Well, more like enables it.
How the batterer works: When activated, as shown in the vid, it goes through everyone in an area around the person and has a 50% chance of stunning them, the stun can vary between slightly shorter than a baton to slightly longer. It only has two uses, costs 7 TC. No equipment can stop it (not loyalty implants, not headsets, not helmets, nothing.)
https://vid.me/YKoQ

:cl: FreeStylaLT
add: Added (Enabled) Mind Batterer for Traitors
typo: Fixed uplink implant description (Said 5 when actually gave you 10 TCs)
/:cl: