### PR TITLE
Removes ability of bus to talk to another bus, thus fixing a server crash bug.

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -387,7 +387,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			src.receive_information(signal, src)
 
 		// Try sending it!
-		var/list/try_send = list("/obj/machinery/telecomms/server", "/obj/machinery/telecomms/hub", "/obj/machinery/telecomms/broadcaster", "/obj/machinery/telecomms/bus")
+		var/list/try_send = list("/obj/machinery/telecomms/server", "/obj/machinery/telecomms/hub", "/obj/machinery/telecomms/broadcaster")
 		var/i = 0
 		for(var/send in try_send)
 			if(i)


### PR DESCRIPTION
The following telecomms setup:

```
R
|
B - B

R = Receiver
B = Bus Mainframe
```

will crash the server by causing an infinite recursion loop (Broadcaster A sends signal to broadcaster B, which sends to broadcaster A, and to B, and to A......) This PR fixes that.