### PR TITLE
Prevents Telecrystal Duplication

### DIFF
--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -8,7 +8,7 @@
 	w_class = 1
 	max_amount = 50
 	flags = NOBLUDGEON
-	origin_tech = "materials=6;syndicate=1"
+	origin_tech = null
 
 /obj/item/stack/telecrystal/attack(mob/target as mob, mob/user as mob)
 	if(target == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.


### PR DESCRIPTION
It's amusing and hilarious, but it's also grossly overpowered.


Prevents duplication of telecrystals with the Experimentor, effectively leading to unlimited TC.

:cl: Fox McCloud
tweak: Removes duplicate of telecrystals
/:cl: