### PR TITLE
Defib oversights fixes

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -368,8 +368,26 @@
 								update_icon()
 								return
 					if(H.heart_attack)
-						H.heart_attack = 0
-					if(H.stat == 2)
+						if(!H.get_int_organ(/obj/item/organ/internal/heart)) //prevents defibing someone still alive suffering from a heart attack
+							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Failed to pick up any heart electrical activity.</span>")
+							playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
+							busy = 0
+							update_icon()
+							return
+						else
+							H.heart_attack = 0
+							user.visible_message("<span class='boldnotice'>[defib] pings: Cardiac arrhythmia corrected.</span>")
+							M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
+							playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
+							playsound(get_turf(src), "bodyfall", 50, 1)
+							playsound(get_turf(src), 'sound/machines/defib_success.ogg', 50, 0)
+							defib.deductcharge(revivecost)
+							busy = 0
+							cooldown = 1
+							update_icon()
+							defib.cooldowncheck(user)
+							return
+					if(H.stat == DEAD)
 						var/health = H.health
 						M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 						playsound(get_turf(src), "bodyfall", 50, 1)
@@ -377,7 +395,7 @@
 						for(var/obj/item/organ/external/O in H.organs)
 							total_brute	+= O.brute_dam
 							total_burn	+= O.burn_dam
-						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))
+						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && H.get_int_organ(/obj/item/organ/internal/heart))
 							tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 							tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 							H.adjustOxyLoss(tobehealed)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -368,7 +368,7 @@
 								update_icon()
 								return
 					if(H.heart_attack)
-						if(!H.get_int_organ(/obj/item/organ/internal/heart)) //prevents defibing someone still alive suffering from a heart attack
+						if(!H.get_int_organ(/obj/item/organ/internal/heart) || !H.get_int_organ(/obj/item/organ/internal/brain/slime)) //prevents defibing someone still alive suffering from a heart attack
 							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Failed to pick up any heart electrical activity.</span>")
 							playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
 							busy = 0
@@ -395,7 +395,7 @@
 						for(var/obj/item/organ/external/O in H.organs)
 							total_brute	+= O.brute_dam
 							total_burn	+= O.burn_dam
-						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && H.get_int_organ(/obj/item/organ/internal/heart))
+						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
 							tobehealed = min(health + threshold, 0) // It's HILARIOUS without this min statement, let me tell you
 							tobehealed -= 5 //They get 5 of each type of damage healed so excessive combined damage will not immediately kill them after they get revived
 							H.adjustOxyLoss(tobehealed)

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -368,7 +368,7 @@
 								update_icon()
 								return
 					if(H.heart_attack)
-						if(!H.get_int_organ(/obj/item/organ/internal/heart) || !H.get_int_organ(/obj/item/organ/internal/brain/slime)) //prevents defibing someone still alive suffering from a heart attack attack if they lack a heart
+						if(!H.get_int_organ(/obj/item/organ/internal/heart) && !H.get_int_organ(/obj/item/organ/internal/brain/slime)) //prevents defibing someone still alive suffering from a heart attack attack if they lack a heart
 							user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Failed to pick up any heart electrical activity.</span>")
 							playsound(get_turf(src), 'sound/machines/defib_failed.ogg', 50, 0)
 							busy = 0


### PR DESCRIPTION
Well, ripping someone's heart out causes them to have a heart attack
right? Well, if you applied a defib to said person before they died from
said heart attack, the heart attack would be stopped, and you would now
have  a heartless living person, spooky right? This prevents that.
Also fixes defibs saying they didn't work when you applied them to
someone with a heart attack, when they in fact did work. And removed a
magic number too.

:cl: pinatacolada
fix: Fixes defibing people without a heart
fix: Fixes defib saying it didn't work stopping a heart attack when they do
/:cl: