### PR TITLE
Experimentor Duplication Limit

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -9,6 +9,7 @@
 	var/mob/attacher = null
 	var/valve_open = 0
 	var/toggle = 1
+	origin_tech = "materials=1;engineering=1"
 
 /obj/item/device/transfer_valve/proc/process_activation(var/obj/item/device/D)
 
@@ -187,7 +188,7 @@
 			attacher_name = "[key_name_admin(attacher)]"
 
 		var/mob/mob = get_mob_by_key(src.fingerprintslast)
-		
+
 		bombers += "Bomb valve opened at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]) with [attached_device ? attached_device : "no device"], attached by [attacher_name]. Last touched by: [key_name(mob)]"
 		message_admins("Bomb valve opened at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name] (JMP)</a> with [attached_device ? attached_device : "no device"], attached by [attacher_name]. Last touched by: [key_name_admin(mob)]")
 		log_game("Bomb valve opened at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]) with [attached_device ? attached_device : "no device"], attached by [attacher_name]. Last touched by: [key_name(mob)]")

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -10,6 +10,7 @@
 	var/status = 0   //0 - not readied //1 - bomb finished with welder
 	var/obj/item/device/assembly_holder/bombassembly = null   //The first part of the bomb is an assembly holder, holding an igniter+some device
 	var/obj/item/weapon/tank/bombtank = null //the second part of the bomb is a plasma tank
+	origin_tech = "materials=1;engineering=1"
 
 /obj/item/device/onetankbomb/examine(mob/user)
 	..(user)

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -219,6 +219,7 @@
 			--cloneCount
 			if(cloneCount == 0)
 				cloneMode = FALSE
+			return
 		var/turf/dropturf = get_turf(pick(view(1,src)))
 		if(!dropturf) //Failsafe to prevent the object being lost in the void forever.
 			dropturf = get_turf(src)
@@ -492,7 +493,7 @@
 		ejectItem()
 
 	//Global reactions
-	
+
 	if(prob(EFFECT_PROB_VERYLOW) && prob(13))
 		visible_message("<span class='warning'>[src] improves [exp_on], drawing the life essence of those nearby!</span>")
 		for(var/mob/living/m in view(4,src))
@@ -504,7 +505,7 @@
 			reqs[T] = reqs[T] + 1
 		exp_on.origin_tech = list2params(reqs)
 		investigate_log("Experimentor has set the origin tech of [exp_on] to [exp_on.origin_tech]", "experimentor")
-	
+
 	if(prob(EFFECT_PROB_VERYLOW-badThingCoeff) && prob(87))
 		var/globalMalf = rand(1,87)
 		if(globalMalf < 15)


### PR DESCRIPTION
This is....abusive enough that I kinda think it should be warranted or counted as a fix.

Ends the ability to duplicate literally every single item with an origin tech.

No more HoS energy guns for the entirety of security or other nonsense like that.

You will be able to duplicate items that are a critical reaction type, but that's it.

Other tweaks: ensures trank transfer valves and one tank bombs can be used as a critical reaction item in the Experimentor.

:cl: Fox McCloud
fix: Fixes being able to duplicate just about anything in the Experimentor
fix: Fixes not being able to use tank transfer valves or one tank bombs in the Experimentor.
/:cl: