### PR TITLE
Fixes Excessive Database Reconnections

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -316,7 +316,7 @@
 	send_resources()
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
-		if(!setup_database_connection())
+		if(!establish_db_connection())
 			return // if we have db problems, don't show anything
 		winset(src, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
 		to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")


### PR DESCRIPTION
I'm *pretty sure* this wasn't having any meaningful impact on the server, but setting up a fresh connection to the database every time a player connects (i.e., dozens of times immediately after a server restart) is pretty silly.