### PR TITLE
Nerfs Tabling

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -208,7 +208,7 @@
 		if(!G.confirm())
 			return 0
 		G.affecting.forceMove(get_turf(src))
-		G.affecting.Weaken(5)
+		G.affecting.Weaken(2)
 		G.affecting.visible_message("<span class='danger'>[G.assailant] pushes [G.affecting] onto [src].</span>", \
 									"<span class='userdanger'>[G.assailant] pushes [G.affecting] onto [src].</span>")
 		add_logs(G.affecting, G.assailant, "pushed onto a table")


### PR DESCRIPTION
Nerfs tabling

Duration from 5 down to 2.

Pretty much turns tabling into a conditional push as opposed a highly effective permastun

:cl: Fox McCloud
tweak: Tabling duration reduced from 5 to 2
/:cl: