### PR TITLE
Makes RnD console use NanoUI

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -128,7 +128,7 @@
 //WT550 Mags
 
 /datum/design/mag_oldsmg
-	name = "WT-550 Auto Gun Magazine (4.6×30mm)"
+	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
 	desc = "A 20 round magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg"
 	req_tech = list("combat" = 1, "materials" = 1)
@@ -138,21 +138,21 @@
 	category = list("Weapons")
 
 /datum/design/mag_oldsmg/ap_mag
-	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6×30mm AP)"
+	name = "WT-550 Auto Gun Armour Piercing Magazine (4.6x30mm AP)"
 	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_ap"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
 
 /datum/design/mag_oldsmg/ic_mag
-	name = "WT-550 Auto Gun Incendiary Magazine (4.6×30mm IC)"
+	name = "WT-550 Auto Gun Incendiary Magazine (4.6x30mm IC)"
 	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_ic"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_GLASS = 1000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
 
 /datum/design/mag_oldsmg/tx_mag
-	name = "WT-550 Auto Gun Urnaium Magazine (4.6×30mm TX)"
+	name = "WT-550 Auto Gun Urnaium Magazine (4.6x30mm TX)"
 	desc = "A 20 round urnaium tipped magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_tx"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_URANIUM = 2000)

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -41,7 +41,7 @@ Note: Must be placed west/left of and R&D console to function.
 	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker/large(null)
 	component_parts += new /obj/item/weapon/reagent_containers/glass/beaker/large(null)
-	materials = new(src, list(MAT_METAL=1, MAT_GLASS=1, MAT_SILVER=1, MAT_GOLD=1, MAT_DIAMOND=1, MAT_PLASMA=1, MAT_URANIUM=1, MAT_BANANIUM=1))
+	materials = new(src, list(MAT_METAL=1, MAT_GLASS=1, MAT_SILVER=1, MAT_GOLD=1, MAT_DIAMOND=1, MAT_PLASMA=1, MAT_URANIUM=1, MAT_BANANIUM=1, MAT_TRANQUILLITE=1))
 	RefreshParts()
 
 	reagents.my_atom = src

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -46,6 +46,11 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/obj/machinery/r_n_d/circuit_imprinter/linked_imprinter = null	//Linked Circuit Imprinter
 
 	var/screen = 1.0	//Which screen is currently showing.
+	
+	var/menu = 0 // Current menu.
+	var/submenu = 0
+	var/wait_message = 0
+	
 	var/id = 0			//ID of the computer (for server restrictions).
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
 
@@ -173,7 +178,7 @@ proc/CallMaterialName(ID)
 		to_chat(user, "<span class='notice'>You add the disk to the machine!</span>")
 	else if(!(linked_destroy && linked_destroy.busy) && !(linked_lathe && linked_lathe.busy) && !(linked_imprinter && linked_imprinter.busy))
 		..()
-	src.updateUsrDialog()
+	nanomanager.update_uis(src)
 	return
 
 /obj/machinery/computer/rdconsole/emag_act(user as mob)
@@ -195,17 +200,36 @@ proc/CallMaterialName(ID)
 	usr.set_machine(src)
 	if(href_list["menu"]) //Switches menu screens. Converts a sent text string into a number. Saves a LOT of code.
 		var/temp_screen = text2num(href_list["menu"])
-		screen = temp_screen
+		menu = temp_screen
+	if(href_list["submenu"]) //Switches menu screens. Converts a sent text string into a number. Saves a LOT of code.
+		var/temp_screen = text2num(href_list["submenu"])
+		submenu = temp_screen
 
 	if(href_list["category"])
-		selected_category = href_list["category"]
+		var/compare
+
+		matching_designs.Cut()
+
+		if(menu == 4)
+			compare = PROTOLATHE
+		else
+			compare = IMPRINTER
+
+		for(var/datum/design/D in files.known_designs)
+			if(!(D.build_type & compare))
+				continue
+			if(href_list["category"] in D.category)
+				matching_designs.Add(D)
+		submenu = 1
+		
+		selected_category = "Viewing Category [href_list["category"]]"
 
 	else if(href_list["updt_tech"]) //Update the research holder with information from the technology disk.
-		screen = 0.0
+		wait_message = "Updating Database...."
 		spawn(50)
-			screen = 1.2
+			wait_message = 0
 			files.AddTech2Known(t_disk.stored)
-			updateUsrDialog()
+			nanomanager.update_uis(src)
 			griefProtection() //Update centcom too
 
 	else if(href_list["clear_tech"]) //Erase data on the technology disk.
@@ -216,21 +240,23 @@ proc/CallMaterialName(ID)
 		if(t_disk)
 			t_disk.loc = src.loc
 			t_disk = null
-		screen = 1.0
+		menu = 0
+		submenu = 0
 
 	else if(href_list["copy_tech"]) //Copy some technology data from the research holder to the disk.
 		for(var/datum/tech/T in files.known_tech)
 			if(href_list["copy_tech_ID"] == T.id)
 				t_disk.stored = T
 				break
-		screen = 1.2
+		menu = 2
+		submenu = 0
 
 	else if(href_list["updt_design"]) //Updates the research holder with design data from the design disk.
-		screen = 0.0
+		wait_message = "Updating Database...."
 		spawn(50)
-			screen = 1.4
+			wait_message = 0
 			files.AddDesign2Known(d_disk.blueprint)
-			updateUsrDialog()
+			nanomanager.update_uis(src)
 			griefProtection() //Update centcom too
 
 	else if(href_list["clear_design"]) //Erases data on the design disk.
@@ -241,7 +267,8 @@ proc/CallMaterialName(ID)
 		if(d_disk)
 			d_disk.loc = src.loc
 			d_disk = null
-		screen = 1.0
+		menu = 0
+		submenu = 0
 
 	else if(href_list["copy_design"]) //Copy design data from the research holder to the design disk.
 		for(var/datum/design/D in files.known_designs)
@@ -259,7 +286,8 @@ proc/CallMaterialName(ID)
 					D.category |= "Imported"
 				d_disk.blueprint = D
 				break
-		screen = 1.4
+		menu = 2
+		submenu = 0
 
 	else if(href_list["eject_item"]) //Eject the item inside the destructive analyzer.
 		if(linked_destroy)
@@ -270,20 +298,20 @@ proc/CallMaterialName(ID)
 				linked_destroy.loaded_item.loc = linked_destroy.loc
 				linked_destroy.loaded_item = null
 				linked_destroy.icon_state = "d_analyzer"
-				screen = 2.1
+				menu = 3
 
 	else if(href_list["maxresearch"]) //Eject the item inside the destructive analyzer.
 		if(!check_rights(R_ADMIN))
 			return
-		screen = 0.0
+		wait_message = "Updating Database...."
 		if(alert("Are you sure you want to maximize research levels?","Confirmation","Yes","No")=="No")
 			return
 		log_admin("[key_name(usr)] has maximized the research levels.")
 		message_admins("[key_name_admin(usr)] has maximized the research levels.")
 		spawn(30)
 			Maximize()
-			screen = 1.0
-			updateUsrDialog()
+			wait_message = ""
+			nanomanager.update_uis(src)
 			griefProtection() //Update centcomm too
 
 	else if(href_list["deconstruct"]) //Deconstruct the item in the destructive analyzer and update the research holder.
@@ -294,8 +322,8 @@ proc/CallMaterialName(ID)
 				var/choice = input("Proceeding will destroy loaded item.") in list("Proceed", "Cancel")
 				if(choice == "Cancel" || !linked_destroy) return
 				linked_destroy.busy = 1
-				screen = 0.1
-				updateUsrDialog()
+				wait_message = "Processing and Updating Database..."
+				nanomanager.update_uis(src)
 				flick("d_analyzer_process", linked_destroy)
 				spawn(24)
 					if(linked_destroy)
@@ -303,7 +331,9 @@ proc/CallMaterialName(ID)
 						if(!linked_destroy.hacked)
 							if(!linked_destroy.loaded_item)
 								to_chat(usr, "<span class='danger'>The destructive analyzer appears to be empty.</span>")
-								screen = 1.0
+								wait_message = 0
+								menu = 0
+								submenu = 0
 								return
 							if((linked_destroy.loaded_item.reliability >= 99 - (linked_destroy.decon_mod * 3)) || linked_destroy.loaded_item.crit_fail)
 								var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
@@ -311,15 +341,21 @@ proc/CallMaterialName(ID)
 									if(prob(linked_destroy.loaded_item.reliability))               //If deconstructed item is not reliable enough its just being wasted, else it is pocessed
 										files.UpdateTech(T, temp_tech[T])                          //Check if deconstructed item has research levels higher/same/one less than current ones
 								files.UpdateDesigns(linked_destroy.loaded_item, temp_tech, src)    //If if such reseach type found all the known designs are checked for having this research type in them
-								screen = 1.0                                                       //If design have it it gains some reliability
+								wait_message = 0                                                   //If design have it it gains some reliability
+								menu = 0
+								submenu = 0
 							else                                                                   //Same design always gain quality
-								screen = 2.3                                                       //Crit fail gives the same design a lot of reliability, like really a lot
+								wait_message = 0                                                   //Crit fail gives the same design a lot of reliability, like really a lot
+								menu = 2
+								submenu = 0
 							if(linked_lathe) //Also sends salvaged materials to a linked protolathe, if any.
 								for(var/material in linked_destroy.loaded_item.materials)
 									linked_lathe.materials.insert_amount(min((linked_lathe.materials.max_amount - linked_lathe.materials.total_amount), (linked_destroy.loaded_item.materials[material]*(linked_destroy.decon_mod/10))), material)
 							linked_destroy.loaded_item = null
 						else
-							screen = 1.0
+							wait_message = 0
+							menu = 0
+							submenu = 0
 						for(var/obj/I in linked_destroy.contents)
 							for(var/mob/M in I.contents)
 								M.death()
@@ -336,10 +372,10 @@ proc/CallMaterialName(ID)
 									qdel(I)
 									linked_destroy.icon_state = "d_analyzer"
 						use_power(250)
-						updateUsrDialog()
+						nanomanager.update_uis(src)
 
 	else if(href_list["sync"]) //Sync the research holder with all the R&D consoles in the game that aren't sync protected.
-		screen = 0.0
+		wait_message = "Updating Database...."
 		if(!sync)
 			to_chat(usr, "<span class='danger'>You must connect to the network first!</span>")
 		else
@@ -366,8 +402,8 @@ proc/CallMaterialName(ID)
 							server_processed = 1
 						if(!istype(S, /obj/machinery/r_n_d/server/centcom) && server_processed)
 							S.produce_heat(100)
-					screen = 1.6
-					updateUsrDialog()
+					wait_message = 0
+					nanomanager.update_uis(src)
 
 	else if(href_list["togglesync"]) //Prevents the console from being synced by other consoles. Can still send data.
 		sync = !sync
@@ -388,12 +424,11 @@ proc/CallMaterialName(ID)
 			if(being_built)
 				var/power = 2000
 				var/amount=text2num(href_list["amount"])
-				var/old_screen = screen
 				amount = max(1, min(10, amount))
 				for(var/M in being_built.materials)
 					power += round(being_built.materials[M] * amount / 5)
 				power = max(2000, power)
-				screen = 0.3
+				wait_message = "Constructing Prototype. Please Wait..."
 				if(linked_lathe.busy)
 					g2g = 0
 				var/key = usr.key	//so we don't lose the info during the spawn delay
@@ -453,8 +488,8 @@ proc/CallMaterialName(ID)
 								else
 									new_item.loc = linked_lathe.loc
 						linked_lathe.busy = 0
-						screen = old_screen
-						updateUsrDialog()
+						wait_message = 0
+						nanomanager.update_uis(src)
 
 	else if(href_list["imprint"]) //Causes the Circuit Imprinter to build something.
 		var/coeff = linked_imprinter.efficiency_coeff
@@ -467,11 +502,10 @@ proc/CallMaterialName(ID)
 					break
 			if(being_built)
 				var/power = 2000
-				var/old_screen = screen
 				for(var/M in being_built.materials)
 					power += round(being_built.materials[M] / 5)
 				power = max(2000, power)
-				screen = 0.4
+				wait_message = "Imprinting Circuit. Please Wait..."
 				if (linked_imprinter.busy)
 					g2g = 0
 				if (!(being_built.build_type & IMPRINTER))
@@ -505,8 +539,8 @@ proc/CallMaterialName(ID)
 							new_item.reliability = 100
 							new_item.loc = linked_imprinter.loc
 						linked_imprinter.busy = 0
-						screen = old_screen
-						updateUsrDialog()
+						wait_message = 0
+						nanomanager.update_uis(src)
 
 	else if(href_list["disposeI"] && linked_imprinter)  //Causes the circuit imprinter to dispose of a single reagent (all of it)
 		linked_imprinter.reagents.del_reagent(href_list["disposeI"])
@@ -530,27 +564,7 @@ proc/CallMaterialName(ID)
 			desired_num_sheets = round(desired_num_sheets) // No partial-sheet goofery
 		else
 			desired_num_sheets = text2num(href_list["lathe_ejectsheet_amt"])
-		var/MAT
-		switch(href_list["lathe_ejectsheet"])
-			if("metal")
-				MAT = MAT_METAL
-			if("glass")
-				MAT = MAT_GLASS
-			if("gold")
-				MAT = MAT_GOLD
-			if("silver")
-				MAT = MAT_SILVER
-			if("plasma")
-				MAT = MAT_PLASMA
-			if("uranium")
-				MAT = MAT_URANIUM
-			if("diamond")
-				MAT = MAT_DIAMOND
-			if("clown")
-				MAT = MAT_BANANIUM
-			if("mime")
-				MAT = "Tranquillite"
-		linked_lathe.materials.retrieve_sheets(desired_num_sheets, MAT)
+		linked_lathe.materials.retrieve_sheets(desired_num_sheets, href_list["lathe_ejectsheet"])
 
 	else if(href_list["imprinter_ejectsheet"] && linked_imprinter) //Causes the protolathe to eject a sheet of material
 		var/desired_num_sheets = text2num(href_list["imprinter_ejectsheet_amt"])
@@ -564,13 +578,13 @@ proc/CallMaterialName(ID)
 			desired_num_sheets = text2num(href_list["imprinter_ejectsheet_amt"])
 		var/res_amount, type
 		switch(href_list["imprinter_ejectsheet"])
-			if("glass")
+			if(MAT_GLASS)
 				type = /obj/item/stack/sheet/glass
 				res_amount = "g_amount"
-			if("gold")
+			if(MAT_GOLD)
 				type = /obj/item/stack/sheet/mineral/gold
 				res_amount = "gold_amount"
-			if("diamond")
+			if(MAT_DIAMOND)
 				type = /obj/item/stack/sheet/mineral/diamond
 				res_amount = "diamond_amount"
 		if(ispath(type) && hasvar(linked_imprinter, res_amount))
@@ -583,11 +597,11 @@ proc/CallMaterialName(ID)
 				qdel(sheet)
 
 	else if(href_list["find_device"]) //The R&D console looks for devices nearby to link up with.
-		screen = 0.0
+		wait_message = "Updating Database...."
 		spawn(20)
 			SyncRDevices()
-			screen = 1.7
-			updateUsrDialog()
+			wait_message = 0
+			nanomanager.update_uis(src)
 
 	else if(href_list["disconnect"]) //The R&D console disconnects with a specific device.
 		switch(href_list["disconnect"])
@@ -603,34 +617,35 @@ proc/CallMaterialName(ID)
 
 	else if(href_list["reset"]) //Reset the R&D console's database.
 		griefProtection()
-		var/choice = alert("R&D Console Database Reset", "Are you sure you want to reset the R&D console's database? Data lost cannot be recovered.", "Continue", "Cancel")
+		var/choice = alert("Are you sure you want to reset the R&D console's database? Data lost cannot be recovered.", "R&D Console Database Reset", "Continue", "Cancel")
 		if(choice == "Continue")
-			screen = 0.0
+			wait_message = "Updating Database...."
 			qdel(files)
 			files = new /datum/research(src)
 			spawn(20)
-				screen = 1.6
-				updateUsrDialog()
+				wait_message = 0
+				nanomanager.update_uis(src)
 
 	else if(href_list["search"]) //Search for designs with name matching pattern
 		var/compare
 
 		matching_designs.Cut()
 
-		if(href_list["type"] == "proto")
+		if(menu == 4)
 			compare = PROTOLATHE
-			screen = 3.17
 		else
 			compare = IMPRINTER
-			screen = 4.17
 
 		for(var/datum/design/D in files.known_designs)
 			if(!(D.build_type & compare))
 				continue
 			if(findtext(D.name,href_list["to_search"]))
 				matching_designs.Add(D)
+		submenu = 1
+		
+		selected_category = "Search Results for '[href_list["to_search"]]'"
 
-	updateUsrDialog()
+	nanomanager.update_uis(src)
 	return
 
 
@@ -640,530 +655,221 @@ proc/CallMaterialName(ID)
 	if(!allowed(user) && !isobserver(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return 1
-	interact(user)
+	ui_interact(user)
 
-/obj/machinery/computer/rdconsole/interact(mob/user)
-
+/obj/machinery/computer/rdconsole/ui_interact(mob/user, ui_key="main", var/datum/nanoui/ui = null, var/force_open = 1)
 	user.set_machine(src)
-	var/dat = ""
+	var/data = list()
+	
 	files.RefreshResearch()
-	switch(screen) //A quick check to make sure you get the right screen when a device is disconnected.
-		if(2 to 2.9)
-			if(screen == 2.3)
-				;
-			else if(linked_destroy == null)
-				screen = 2.0
-			else if(linked_destroy.loaded_item == null)
-				screen = 2.1
-			else
-				screen = 2.2
-		if(3 to 3.9)
-			if(linked_lathe == null)
-				screen = 3.0
-		if(4 to 4.9)
-			if(linked_imprinter == null)
-				screen = 4.0
-
-	switch(screen)
-
-		//////////////////////R&D CONSOLE SCREENS//////////////////
-		if(0.0) dat += "<div class='statusDisplay'>Updating Database....</div>"
-
-		if(0.1) dat += "<div class='statusDisplay'>Processing and Updating Database...</div>"
-
-		if(0.3)
-			dat += "<div class='statusDisplay'>Constructing Prototype. Please Wait...</div>"
-
-		if(0.4)
-			dat += "<div class='statusDisplay'>Imprinting Circuit. Please Wait...</div>"
-
-		if(1.0) //Main Menu
-			dat += "<div class='statusDisplay'>"
-			dat += "<h3>Main Menu:</h3><BR>"
-			dat += "<A href='?src=\ref[src];menu=1.1'>Current Research Levels</A><BR>"
-			if(t_disk)
-				dat += "<A href='?src=\ref[src];menu=1.2'>Disk Operations</A><BR>"
-			else if(d_disk)
-				dat += "<A href='?src=\ref[src];menu=1.4'>Disk Operations</A><BR>"
-			else
-				dat += "<span class='linkOff'>Disk Operations</span><BR>"
-			if(linked_destroy)
-				dat += "<A href='?src=\ref[src];menu=2.2'>Destructive Analyzer Menu</A><BR>"
-			else
-				dat += "<span class='linkOff'>Destructive Analyzer Menu</span><BR>"
-			if(linked_lathe)
-				dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Construction Menu</A><BR>"
-			else
-				dat += "<span class='linkOff'>Protolathe Construction Menu</span><BR>"
-			if(linked_imprinter)
-				dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Construction Menu</A><BR>"
-			else
-				dat += "<span class='linkOff'>Circuit Construction Menu</span><BR>"
-			dat += "<A href='?src=\ref[src];menu=1.6'>Settings</A>"
-			dat += "</div>"
-
-		if(1.1) //Research viewer
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<h3>Current Research Levels:</h3><BR><div class='statusDisplay'>"
+	
+	data["menu"] = menu
+	data["submenu"] = submenu
+	data["wait_message"] = wait_message
+	data["src_ref"] = "\ref[src]"
+	
+	data["linked_destroy"] = linked_destroy ? 1 : 0
+	data["linked_lathe"] = linked_lathe ? 1 : 0
+	data["linked_imprinter"] = linked_imprinter ? 1 : 0
+	data["sync"] = sync
+	data["admin"] = check_rights(R_ADMIN,0)
+	data["disk_type"] = d_disk ? 2 : (t_disk ? 1 : 0)
+	data["category"] = selected_category
+	
+	if(menu == 1)
+		var/list/tech_levels = list()
+		data["tech_levels"] = tech_levels
+		for(var/datum/tech/T in files.known_tech)
+			if(T.level <= 0)
+				continue
+			var/list/this_tech_list = list()
+			this_tech_list["name"] = T.name
+			this_tech_list["level"] = T.level
+			this_tech_list["desc"] = T.desc
+			tech_levels[++tech_levels.len] = this_tech_list
+	
+	if(menu == 2)
+		
+		if(t_disk != null && t_disk.stored != null && submenu == 0) //Technology Disk Menu
+			var/list/disk_data = list()
+			data["disk_data"] = disk_data
+			disk_data["name"] = t_disk.stored.name
+			disk_data["level"] = t_disk.stored.level
+			disk_data["desc"] = t_disk.stored.desc
+	
+		if(t_disk != null && submenu == 1)
+			var/list/to_copy = list()
+			data["to_copy"] = to_copy
 			for(var/datum/tech/T in files.known_tech)
+				var/list/item = list()
+				to_copy[++to_copy.len] = item
 				if(T.level <= 0)
 					continue
-				dat += "[T.name]<BR>"
-				dat +=  "* Level: [T.level]<BR>"
-				dat +=  "* Summary: [T.desc]<HR>"
-			dat += "</div>"
-
-		if(1.2) //Technology Disk Menu
-
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
-			dat += "<div class='statusDisplay'>Technology Data Disk Contents:<BR><BR>"
-			if(t_disk.stored == null)
-				dat += "The disk has no data stored on it.</div>"
-				dat += "Operations: "
-				dat += "<A href='?src=\ref[src];menu=1.3'>Load Tech to Disk</A>"
-			else
-				dat += "Name: [t_disk.stored.name]<BR>"
-				dat += "Level: [t_disk.stored.level]<BR>"
-				dat += "Description: [t_disk.stored.desc]</div>"
-				dat += "Operations: "
-				dat += "<A href='?src=\ref[src];updt_tech=1'>Upload to Database</A>"
-				dat += "<A href='?src=\ref[src];clear_tech=1'>Clear Disk</A>"
-			dat += "<A href='?src=\ref[src];eject_tech=1'>Eject Disk</A>"
-
-		if(1.3) //Technology Disk submenu
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=1.2'>Return to Disk Operations</A><div class='statusDisplay'>"
-			dat += "<h3>Load Technology to Disk:</h3><BR>"
-			for(var/datum/tech/T in files.known_tech)
-				if(T.level <= 0)
-					continue
-				dat += "[T.name] "
-				dat += "<A href='?src=\ref[src];copy_tech=1;copy_tech_ID=[T.id]'>Copy to Disk</A><BR>"
-			dat += "</div>"
-
-		if(1.4) //Design Disk menu.
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><div class='statusDisplay'>"
-			if(d_disk.blueprint == null)
-				dat += "The disk has no data stored on it.</div>"
-				dat += "Operations: "
-				dat += "<A href='?src=\ref[src];menu=1.5'>Load Design to Disk</A>"
-			else
-				dat += "Name: [d_disk.blueprint.name]<BR>"
-				dat += "Level: [d_disk.blueprint.reliability]<BR>"
-				var/b_type = d_disk.blueprint.build_type
-				if(b_type)
-					dat += "Lathe Types:<BR>"
-					if(b_type & IMPRINTER) dat += "Circuit Imprinter<BR>"
-					if(b_type & PROTOLATHE) dat += "Proto-lathe<BR>"
-					if(b_type & AUTOLATHE) dat += "Auto-lathe<BR>"
-					if(b_type & MECHFAB) dat += "Mech Fabricator<BR>"
-				dat += "Required Materials:<BR>"
-				for(var/M in d_disk.blueprint.materials)
-					if(copytext(M, 1, 2) == "$") dat += "* [copytext(M, 2)] x [d_disk.blueprint.materials[M]]<BR>"
-					else dat += "* [M] x [d_disk.blueprint.materials[M]]<BR>"
-				dat += "</div>Operations: "
-				dat += "<A href='?src=\ref[src];updt_design=1'>Upload to Database</A>"
-				dat += "<A href='?src=\ref[src];clear_design=1'>Clear Disk</A>"
-			dat += "<A href='?src=\ref[src];eject_design=1'>Eject Disk</A>"
-
-		if(1.5) //Technology disk submenu
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=1.4'>Return to Disk Operations</A><div class='statusDisplay'>"
-			dat += "<h3>Load Design to Disk:</h3><BR>"
+				item["name"] = T.name
+				item["id"] = T.id
+	
+		if(d_disk != null && d_disk.blueprint != null && submenu == 0)
+			var/list/disk_data = list()
+			data["disk_data"] = disk_data
+			disk_data["name"] = d_disk.blueprint.name
+			disk_data["reliability"] = d_disk.blueprint.reliability
+			var/b_type = d_disk.blueprint.build_type
+			var/list/lathe_types = list()
+			disk_data["lathe_types"] = lathe_types
+			if(b_type)
+				if(b_type & IMPRINTER) lathe_types += "Circuit Imprinter"
+				if(b_type & PROTOLATHE) lathe_types += "Protolathe"
+				if(b_type & AUTOLATHE) lathe_types += "Autolathe"
+				if(b_type & MECHFAB) lathe_types += "Mech Fabricator"
+				if(b_type & PODFAB) lathe_types += "Spacepod Fabricator"
+			var/list/materials = list()
+			disk_data["materials"] = materials
+			for(var/M in d_disk.blueprint.materials)
+				var/list/material = list()
+				materials[++materials.len] = material
+				material["name"] = CallMaterialName(M)
+				material["amount"] = d_disk.blueprint.materials[M]
+	
+		if(d_disk != null && submenu == 1)
+			var/list/to_copy = list()
+			data["to_copy"] = to_copy
 			for(var/datum/design/D in files.known_designs)
-				dat += "[D.name] "
-				dat += "<A href='?src=\ref[src];copy_design=1;copy_design_ID=[D.id]'>Copy to Disk</A><BR>"
-			dat += "</div>"
+				var/list/item = list()
+				to_copy[++to_copy.len] = item
+				item["name"] = D.name
+				item["id"] = D.id
 
-		if(1.6) //R&D console settings
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><div class='statusDisplay'>"
-			dat += "<h3>R&D Console Setting:</h3><BR>"
-			if(sync)
-				dat += "<A href='?src=\ref[src];sync=1'>Sync Database with Network</A><BR>"
-				dat += "<span class='linkOn'>Connect to Research Network</span><BR>"
-				dat += "<A href='?src=\ref[src];togglesync=1'>Disconnect from Research Network</A><BR>"
-			else
-				dat += "<span class='linkOff'>Sync Database with Network</span><BR>"
-				dat += "<A href='?src=\ref[src];togglesync=1'>Connect to Research Network</A><BR>"
-				dat += "<span class='linkOn'>Disconnect from Research Network</span><BR>"
-			dat += "<A href='?src=\ref[src];menu=1.7'>Device Linkage Menu</A><BR>"
-			if(check_rights(R_ADMIN,0))
-				dat += "<A href='?src=\ref[src];maxresearch=1'>\[ADMIN\] Maximize Research Levels</A><BR>"
-			dat += "<A href='?src=\ref[src];reset=1'>Reset R&D Database</A></div>"
-
-		if(1.7) //R&D device linkage
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=1.6'>Settings Menu</A><div class='statusDisplay'> "
-			dat += "<h3>R&D Console Device Linkage Menu:</h3><BR>"
-			dat += "<A href='?src=\ref[src];find_device=1'>Re-sync with Nearby Devices</A><BR><BR>"
-			dat += "<h3>Linked Devices:</h3><BR>"
-			if(linked_destroy)
-				dat += "* Destructive Analyzer <A href='?src=\ref[src];disconnect=destroy'>Disconnect</A><BR>"
-			else
-				dat += "* No Destructive Analyzer Linked<BR>"
-			if(linked_lathe)
-				dat += "* Protolathe <A href='?src=\ref[src];disconnect=lathe'>Disconnect</A><BR>"
-			else
-				dat += "* No Protolathe Linked<BR>"
-			if(linked_imprinter)
-				dat += "* Circuit Imprinter <A href='?src=\ref[src];disconnect=imprinter'>Disconnect</A><BR>"
-			else
-				dat += "* No Circuit Imprinter Linked<BR>"
-			dat += "</div>"
-
-		////////////////////DESTRUCTIVE ANALYZER SCREENS////////////////////////////
-		if(2.0)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<div class='statusDisplay'>NO DESTRUCTIVE ANALYZER LINKED TO CONSOLE</div>"
-
-		if(2.1)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<div class='statusDisplay'>No Item Loaded. Standing-by...</div>"
-
-		if(2.2)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><div class='statusDisplay'>"
-			dat += "<h3>Deconstruction Menu</h3><BR>"
-			dat += "Name: [linked_destroy.loaded_item.name]<BR>"
-			dat += "Reliability: [linked_destroy.loaded_item.reliability]<BR>"
-			dat += "Origin Tech:<BR>"
-			var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
-			for(var/T in temp_tech)
-				dat += "* [CallTechName(T)] [temp_tech[T]]"
-				for(var/datum/tech/F in files.known_tech)
-					if(F.name == CallTechName(T))
-						dat += " (Current: [F.level])"
-						break
-				dat += "<BR>"
-			dat += "</div>Options: "
-			dat += "<A href='?src=\ref[src];deconstruct=1'>Deconstruct Item</A>"
-			dat += "<A href='?src=\ref[src];eject_item=1'>Eject Item</A>"
-		if(2.3)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<div class='statusDisplay'>Item is neither reliable enough or broken enough to learn from.</div>"
-
-		/////////////////////PROTOLATHE SCREENS/////////////////////////
-		if(3.0)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
-			dat += "<div class='statusDisplay'>NO PROTOLATHE LINKED TO CONSOLE</div>"
-
-		if(3.1)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A> "
-			dat += "<A href='?src=\ref[src];menu=3.2'>Material Storage</A>"
-			dat += "<A href='?src=\ref[src];menu=3.3'>Chemical Storage</A><div class='statusDisplay'>"
-			dat += "<h3>Protolathe Menu:</h3><BR>"
-			dat += "<B>Material Amount:</B> [linked_lathe.materials.total_amount] / [linked_lathe.materials.max_amount]<BR>"
-			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] / [linked_lathe.reagents.maximum_volume]<BR>"
-
-			dat += "<form name='search' action='?src=\ref[src]'> \
-			<input type='hidden' name='src' value='\ref[src]'> \
-			<input type='hidden' name='search' value='to_search'> \
-			<input type='hidden' name='type' value='proto'> \
-			<input type='text' name='to_search'> \
-			<input type='submit' value='Search'> \
-			</form><HR>"
-
-			dat += list_categories(linked_lathe.categories, 3.15)
-
-		//Grouping designs by categories, to improve readability
-		if(3.15)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A>"
-			dat += "<div class='statusDisplay'><h3>Browsing [selected_category]:</h3><BR>"
-			dat += "<B>Material Amount:</B> [linked_lathe.materials.total_amount] / [linked_lathe.materials.max_amount]<BR>"
-			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] / [linked_lathe.reagents.maximum_volume]<HR>"
-
-			for(var/datum/design/D in files.known_designs)
-				if(!(selected_category in D.category)|| !(D.build_type & PROTOLATHE))
-					continue
-				var/temp_material
-				var/c = 50
-				var/t
-				for(var/M in D.materials)
-					t = linked_lathe.check_mat(D, M)
-					temp_material += " | "
-					if (t < 1)
-						temp_material += "<span class='bad'>[D.materials[M]] [CallMaterialName(M)]</span>"
-					else
-						temp_material += " [D.materials[M]] [CallMaterialName(M)]"
-					c = min(c,t)
-
-
-				for(var/R in D.reagents)
-					t = linked_lathe.check_mat(D, R)
-					temp_material += " | "
-					if (t < 1)
-						temp_material += "<span class='bad'>[D.reagents[R]] [CallMaterialName(R)]</span>"
-					else
-						temp_material += " [D.reagents[R]] [CallMaterialName(R)]"
-					c = min(c,t)
-
-				if (c >= 1)
-					dat += "<A href='?src=\ref[src];build=[D.id];amount=1'>[D.name]</A>"
-					if(c >= 5)
-						dat += "<A href='?src=\ref[src];build=[D.id];amount=5'>x5</A>"
-					if(c >= 10)
-						dat += "<A href='?src=\ref[src];build=[D.id];amount=10'>x10</A>"
-					dat += "[temp_material]"
-				else
-					dat += "<span class='linkOff'>[D.name]</span>[temp_material]"
-				if(D.locked)
-					dat += " | <span class='bad'>LOCKED</span>"
-				dat += "<BR>"
-			dat += "</div>"
-
-		if(3.17) //Display search result
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A>"
-			dat += "<div class='statusDisplay'><h3>Search results:</h3><BR>"
-			dat += "<B>Material Amount:</B> [linked_lathe.materials.total_amount] / [linked_lathe.materials.max_amount]<BR>"
-			dat += "<B>Chemical Volume:</B> [linked_lathe.reagents.total_volume] / [linked_lathe.reagents.maximum_volume]<HR>"
-
+	if(menu == 3 && linked_destroy && linked_destroy.loaded_item)
+		var/list/loaded_item_list = list()
+		data["loaded_item"] = loaded_item_list
+		loaded_item_list["name"] = linked_destroy.loaded_item.name
+		loaded_item_list["reliability"] = linked_destroy.loaded_item.reliability
+		var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
+		var/list/tech_list = list()
+		loaded_item_list["origin_tech"] = tech_list
+		for(var/T in temp_tech)
+			var/list/tech_item = list()
+			tech_list[++tech_list.len] = tech_item
+			tech_item["name"] = CallTechName(T)
+			tech_item["object_level"] = temp_tech[T]
+			for(var/datum/tech/F in files.known_tech)
+				if(F.name == CallTechName(T))
+					tech_item["current_level"] = F.level
+					break
+	
+	if(menu == 4 && linked_lathe)
+		data["total_materials"] = linked_lathe.materials.total_amount
+		data["max_materials"] = linked_lathe.materials.max_amount
+		data["total_chemicals"] = linked_lathe.reagents.total_volume
+		data["max_chemicals"] = linked_lathe.reagents.maximum_volume
+		data["categories"] = linked_lathe.categories
+		if(submenu == 1)
+			var/list/designs_list = list()
+			data["matching_designs"] = designs_list
 			for(var/datum/design/D in matching_designs)
-				var/temp_material
+				var/list/design_list = list()
+				designs_list[++designs_list.len] = design_list
+				var/list/materials_list = list()
+				design_list["materials"] = materials_list
+				design_list["id"] = D.id
+				design_list["name"] = sanitize(D.name)
 				var/c = 50
-				var/t
 				for(var/M in D.materials)
-					t = linked_lathe.check_mat(D, M)
-					temp_material += " | "
-					if (t < 1)
-						temp_material += "<span class='bad'>[D.materials[M]] [CallMaterialName(M)]</span>"
+					var/list/material_list = list()
+					materials_list[++materials_list.len] = material_list
+					material_list["name"] = CallMaterialName(M)
+					material_list["amount"] = D.materials[M]
+					var/t = linked_lathe.check_mat(D, M)
+					
+					if(t < 1)
+						material_list["is_red"] = 1
 					else
-						temp_material += " [D.materials[M]] [CallMaterialName(M)]"
-					c = min(c,t)
+						material_list["is_red"] = 0
+					c = min(c, t)
 
 				for(var/R in D.reagents)
-					t = linked_lathe.check_mat(D, R)
-					temp_material += " | "
-					if (t < 1)
-						temp_material += "<span class='bad'>[D.reagents[R]] [CallMaterialName(R)]</span>"
+					var/list/material_list = list()
+					materials_list[++materials_list.len] = material_list
+					material_list["name"] = CallMaterialName(R)
+					material_list["amount"] = D.reagents[R]
+					var/t = linked_lathe.check_mat(D, R)
+					
+					if(t < 1)
+						material_list["is_red"] = 1
 					else
-						temp_material += " [D.reagents[R]] [CallMaterialName(R)]"
-					c = min(c,t)
-
-				if (c >= 1)
-					dat += "<A href='?src=\ref[src];build=[D.id];amount=1'>[D.name]</A>"
-					if(c >= 5)
-						dat += "<A href='?src=\ref[src];build=[D.id];amount=5'>x5</A>"
-					if(c >= 10)
-						dat += "<A href='?src=\ref[src];build=[D.id];amount=10'>x10</A>"
-					dat += "[temp_material]"
-				else
-					dat += "<span class='linkOff'>[D.name]</span>[temp_material]"
-				dat += "<BR>"
-			dat += "</div>"
-
-		if(3.2) //Protolathe Material Storage Sub-menu
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A><div class='statusDisplay'>"
-			dat += "<h3>Material Storage:</h3><BR><HR>"
-			//Metal
-			var/m_amount = linked_lathe.materials.amount(MAT_METAL)
-			dat += "* [m_amount] of Metal, [round(m_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(m_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=custom'>C</A> "
-			if(m_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=5'>5x</A> "
-			if(m_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=metal;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Glass
-			var/g_amount = linked_lathe.materials.amount(MAT_GLASS)
-			dat += "* [g_amount] of Glass, [round(g_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(g_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=custom'>C</A> "
-			if(g_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=5'>5x</A> "
-			if(g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=glass;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Gold
-			var/gold_amount = linked_lathe.materials.amount(MAT_GOLD)
-			dat += "* [gold_amount] of Gold, [round(gold_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(gold_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=custom'>C</A> "
-			if(gold_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=5'>5x</A> "
-			if(gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=gold;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Silver
-			var/silver_amount = linked_lathe.materials.amount(MAT_SILVER)
-			dat += "* [silver_amount] of Silver, [round(silver_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(silver_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=custom'>C</A> "
-			if(silver_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=5'>5x</A> "
-			if(silver_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=silver;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Plasma
-			var/plasma_amount = linked_lathe.materials.amount(MAT_PLASMA)
-			dat += "* [plasma_amount] of Solid Plasma, [round(plasma_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=custom'>C</A> "
-			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasma;lathe_ejectsheet_amt=5'>5x</A> "
-			if(plasma_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=plasmalathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Uranium
-			var/uranium_amount = linked_lathe.materials.amount(MAT_URANIUM)
-			dat += "* [uranium_amount] of Uranium, [round(uranium_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=custom'>C</A> "
-			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=5'>5x</A> "
-			if(uranium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=uranium;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Diamond
-			var/diamond_amount = linked_lathe.materials.amount(MAT_DIAMOND)
-			dat += "* [diamond_amount] of Diamond, [round(diamond_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=custom'>C</A> "
-			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=5'>5x</A> "
-			if(diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=diamond;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Bananium
-			var/bananium_amount = linked_lathe.materials.amount(MAT_BANANIUM)
-			dat += "* [bananium_amount] of Bananium, [round(bananium_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=custom'>C</A> "
-			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=5'>5x</A> "
-			if(bananium_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=clown;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "</div>"
-			//Tranquillite
-			var/tranquillite_amount = linked_lathe.materials.amount(MAT_TRANQUILLITE)
-			dat += "* [tranquillite_amount] of Tranquillite, [round(tranquillite_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(tranquillite_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=mime;lathe_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];lathe_ejectsheet=mime;lathe_ejectsheet_amt=custom'>C</A> "
-			if(tranquillite_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];lathe_ejectsheet=mime;lathe_ejectsheet_amt=5'>5x</A> "
-			if(tranquillite_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];lathe_ejectsheet=mime;lathe_ejectsheet_amt=50'>All</A>"
-			dat += "</div>"
-
-		if(3.3)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=3.1'>Protolathe Menu</A>"
-			dat += "<A href='?src=\ref[src];disposeallP=1'>Disposal All Chemicals in Storage</A><div class='statusDisplay'>"
-			dat += "<h3>Chemical Storage:</h3><BR><HR>"
+						material_list["is_red"] = 0
+					c = min(c, t)
+				design_list["can_build"] = c
+		if(submenu == 2)
+			var/list/materials_list = list()
+			data["loaded_materials"] = materials_list
+			materials_list[++materials_list.len] = list("name" = "Metal", "id" = MAT_METAL, "amount" = linked_lathe.materials.amount(MAT_METAL))
+			materials_list[++materials_list.len] = list("name" = "Glass", "id" = MAT_GLASS, "amount" = linked_lathe.materials.amount(MAT_GLASS))
+			materials_list[++materials_list.len] = list("name" = "Gold", "id" = MAT_GOLD, "amount" = linked_lathe.materials.amount(MAT_GOLD))
+			materials_list[++materials_list.len] = list("name" = "Silver", "id" = MAT_SILVER, "amount" = linked_lathe.materials.amount(MAT_SILVER))
+			materials_list[++materials_list.len] = list("name" = "Plasma", "id" = MAT_PLASMA, "amount" = linked_lathe.materials.amount(MAT_PLASMA))
+			materials_list[++materials_list.len] = list("name" = "Uranium", "id" = MAT_URANIUM, "amount" = linked_lathe.materials.amount(MAT_URANIUM))
+			materials_list[++materials_list.len] = list("name" = "Diamond", "id" = MAT_DIAMOND, "amount" = linked_lathe.materials.amount(MAT_DIAMOND))
+			materials_list[++materials_list.len] = list("name" = "Bananium", "id" = MAT_BANANIUM, "amount" = linked_lathe.materials.amount(MAT_BANANIUM))
+			materials_list[++materials_list.len] = list("name" = "Tranquillite", "id" = MAT_TRANQUILLITE, "amount" = linked_lathe.materials.amount(MAT_TRANQUILLITE))
+		if(submenu == 3)
+			var/list/loaded_chemicals = list()
+			data["loaded_chemicals"] = loaded_chemicals
 			for(var/datum/reagent/R in linked_lathe.reagents.reagent_list)
-				dat += "[R.name]: [R.volume]"
-				dat += "<A href='?src=\ref[src];disposeP=[R.id]'>Purge</A><BR>"
-
-		///////////////////CIRCUIT IMPRINTER SCREENS////////////////////
-		if(4.0)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
-			dat += "<div class='statusDisplay'>NO CIRCUIT IMPRINTER LINKED TO CONSOLE</div>"
-
-		if(4.1)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=4.3'>Material Storage</A>"
-			dat += "<A href='?src=\ref[src];menu=4.2'>Chemical Storage</A><div class='statusDisplay'>"
-			dat += "<h3>Circuit Imprinter Menu:</h3><BR>"
-			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
-			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
-
-			dat += "<form name='search' action='?src=\ref[src]'> \
-			<input type='hidden' name='src' value='\ref[src]'> \
-			<input type='hidden' name='search' value='to_search'> \
-			<input type='hidden' name='type' value='imprint'> \
-			<input type='text' name='to_search'> \
-			<input type='submit' value='Search'> \
-			</form><HR>"
-
-			dat += list_categories(linked_imprinter.categories, 4.15)
-
-		if(4.15)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A>"
-			dat += "<div class='statusDisplay'><h3>Browsing [selected_category]:</h3><BR>"
-			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
-			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
-
-			var/coeff = linked_imprinter.efficiency_coeff
-			for(var/datum/design/D in files.known_designs)
-				if(!(selected_category in D.category) || !(D.build_type & IMPRINTER))
-					continue
-				var/temp_materials
-				var/check_materials = 1
-				for(var/M in D.materials)
-					temp_materials += " | "
-					if (!linked_imprinter.check_mat(D, M))
-						check_materials = 0
-						temp_materials += " <span class='bad'>[D.materials[M]/coeff] [CallMaterialName(M)]</span>"
-					else
-						temp_materials += " [D.materials[M]/coeff] [CallMaterialName(M)]"
-				if (check_materials)
-					dat += "<A href='?src=\ref[src];imprint=[D.id]'>[D.name]</A>[temp_materials]<BR>"
-				else
-					dat += "<span class='linkOff'>[D.name]</span>[temp_materials]<BR>"
-				if(D.locked)
-					dat += " | <span class='bad'>LOCKED</span>"
-			dat += "</div>"
-
-		if(4.17)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A>"
-			dat += "<div class='statusDisplay'><h3>Search results:</h3><BR>"
-			dat += "Material Amount: [linked_imprinter.TotalMaterials()]<BR>"
-			dat += "Chemical Volume: [linked_imprinter.reagents.total_volume]<HR>"
-
+				var/list/loaded_chemical = list()
+				loaded_chemicals[++loaded_chemicals.len] = loaded_chemical
+				loaded_chemical["name"] = R.name
+				loaded_chemical["volume"] = R.volume
+				loaded_chemical["id"] = R.id
+	
+	if(menu == 5 && linked_imprinter)
+		data["total_materials"] = linked_imprinter.TotalMaterials()
+		data["total_chemicals"] = linked_imprinter.reagents.total_volume
+		data["categories"] = linked_imprinter.categories
+		if(submenu == 1)
+			var/list/designs_list = list()
+			data["matching_designs"] = designs_list
 			var/coeff = linked_imprinter.efficiency_coeff
 			for(var/datum/design/D in matching_designs)
-				var/temp_materials
+				var/list/design_list = list()
+				designs_list[++designs_list.len] = design_list
+				var/list/materials_list = list()
+				design_list["materials"] = materials_list
+				design_list["id"] = D.id
+				design_list["name"] = sanitize(D.name)
 				var/check_materials = 1
 				for(var/M in D.materials)
-					temp_materials += " | "
+					var/list/material_list = list()
+					materials_list[++materials_list.len] = material_list
+					material_list["name"] = CallMaterialName(M)
+					material_list["amount"] = D.materials[M] / coeff
 					if (!linked_imprinter.check_mat(D, M))
 						check_materials = 0
-						temp_materials += " <span class='bad'>[D.materials[M]/coeff] [CallMaterialName(M)]</span>"
+						material_list["is_red"] = 1
 					else
-						temp_materials += " [D.materials[M]/coeff] [CallMaterialName(M)]"
-				if (check_materials)
-					dat += "<A href='?src=\ref[src];imprint=[D.id]'>[D.name]</A>[temp_materials]<BR>"
-				else
-					dat += "<span class='linkOff'>[D.name]</span>[temp_materials]<BR>"
-			dat += "</div>"
-
-		if(4.2)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=4.1'>Imprinter Menu</A>"
-			dat += "<A href='?src=\ref[src];disposeallI=1'>Disposal All Chemicals in Storage</A><div class='statusDisplay'>"
-			dat += "<h3>Chemical Storage:</h3><BR><HR>"
+						material_list["is_red"] = 0
+				design_list["can_build"] = check_materials
+		if(submenu == 2)
+			var/list/materials_list = list()
+			data["loaded_materials"] = materials_list
+			materials_list[++materials_list.len] = list("name" = "Glass", "id" = MAT_GLASS, "amount" = linked_imprinter.g_amount)
+			materials_list[++materials_list.len] = list("name" = "Gold", "id" = MAT_GOLD, "amount" = linked_imprinter.gold_amount)
+			materials_list[++materials_list.len] = list("name" = "Diamond", "id" = MAT_DIAMOND, "amount" = linked_imprinter.diamond_amount)
+		if(submenu == 3)
+			var/list/loaded_chemicals = list()
+			data["loaded_chemicals"] = loaded_chemicals
 			for(var/datum/reagent/R in linked_imprinter.reagents.reagent_list)
-				dat += "[R.name]: [R.volume]"
-				dat += "<A href='?src=\ref[src];disposeI=[R.id]'>Purge</A><BR>"
-
-		if(4.3)
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
-			dat += "<A href='?src=\ref[src];menu=4.1'>Circuit Imprinter Menu</A><div class='statusDisplay'>"
-			dat += "<h3>Material Storage:</h3><BR><HR>"
-			//Glass
-			dat += "* [linked_imprinter.g_amount]  glass, [round(linked_imprinter.g_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=custom'>C</A> "
-			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.g_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=glass;imprinter_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Gold
-			dat += "* [linked_imprinter.gold_amount] gold, [round(linked_imprinter.gold_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=custom'>C</A> "
-			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.gold_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=gold;imprinter_ejectsheet_amt=50'>All</A>"
-			dat += "<BR>"
-			//Diamond
-			dat += "* [linked_imprinter.diamond_amount] diamond, [round(linked_imprinter.diamond_amount / MINERAL_MATERIAL_AMOUNT,0.1)] sheets: "
-			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT)
-				dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=1'>Eject</A> "
-				dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=custom'>C</A> "
-			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT*5) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=5'>5x</A> "
-			if(linked_imprinter.diamond_amount >= MINERAL_MATERIAL_AMOUNT) dat += "<A href='?src=\ref[src];imprinter_ejectsheet=diamond;imprinter_ejectsheet_amt=50'>All</A>"
-			dat += "</div>"
-
-	var/datum/browser/popup = new(user, "rndconsole", name, 700, 550)
-	popup.set_content(dat)
-	popup.open()
-	return
+				var/list/loaded_chemical = list()
+				loaded_chemicals[++loaded_chemicals.len] = loaded_chemical
+				loaded_chemical["name"] = R.name
+				loaded_chemical["volume"] = R.volume
+				loaded_chemical["id"] = R.id
+	
+	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
+	if (!ui)
+		ui = new(user, src, ui_key, "r_n_d.tmpl", src.name, 700, 550)
+		ui.set_initial_data(data)
+		ui.open()
 
 //helper proc, which return a table containing categories
 /obj/machinery/computer/rdconsole/proc/list_categories(var/list/categories, var/menu_num as num)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -867,7 +867,7 @@ proc/CallMaterialName(ID)
 	
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "r_n_d.tmpl", src.name, 700, 550)
+		ui = new(user, src, ui_key, "r_n_d.tmpl", src.name, 800, 550)
 		ui.set_initial_data(data)
 		ui.open()
 

--- a/nano/templates/r_n_d.tmpl
+++ b/nano/templates/r_n_d.tmpl
@@ -1,0 +1,260 @@
+{{if data.menu > 0 && !data.wait_message}}
+	<div class='item'>
+		{{:helper.link('Main Menu', 'reply', {'menu': 0, 'submenu': 0})}}
+		{{if data.submenu > 0}}
+			{{if data.menu == 2}}
+				{{:helper.link('Disk Operations Menu', 'reply', {'submenu': 0})}}
+			{{else data.menu == 4}}
+				{{:helper.link('Protolathe Menu', 'reply', {'submenu': 0})}}
+			{{else data.menu == 5}}
+				{{:helper.link('Circuit Imprinter Menu', 'reply', {'submenu': 0})}}
+			{{else data.menu == 6}}
+				{{:helper.link('Settings Menu', 'reply', {'submenu': 0})}}
+			{{/if}}
+		{{else data.menu == 4 || data.menu == 5}}
+			{{:helper.link('Material Storage', 'arrow-up', {'submenu': 2})}}
+			{{:helper.link('Chemical Storage', 'arrow-up', {'submenu': 3})}}
+		{{/if}}
+	</div>
+{{/if}}
+<div class='statusDisplay'>
+	{{if data.wait_message}}
+		{{:data.wait_message}}
+	{{else data.menu == 0}}
+		<h3>Main Menu:</h3>
+		<div class='line'>{{:helper.link('Current Research Levels', 'folder-open', {'menu': 1, 'submenu': 0})}}</div>
+		<div class='line'>{{:helper.link('Disk Operations', 'save', {'menu': 2, 'submenu': 0}, data.disk_type ? null : 'disabled')}}</div>
+		<div class='line'>{{:helper.link('Destructive Analyzer Menu', 'chain-broken', {'menu': 3, 'submenu': 0}, data.linked_destroy ? null : 'disabled')}}</div>
+		<div class='line'>{{:helper.link('Protolathe Menu', 'print', {'menu': 4, 'submenu': 0}, data.linked_lathe ? null : 'disabled')}}</div>
+		<div class='line'>{{:helper.link('Circuit Imprinter Menu', 'print', {'menu': 5, 'submenu': 0}, data.linked_imprinter ? null : 'disabled')}}</div>
+		<div class='line'>{{:helper.link('Settings', 'gear', {'menu': 6, 'submenu': 0})}}</div>
+	{{else data.menu == 1}}
+		<h3>Current Research Levels:</h3>
+		{{for data.tech_levels}}
+			{{if index > 0}}
+				<hr>
+			{{/if}}
+			<div class='line'>{{:value.name}}</div>
+			<div class='line'>* Level: {{:value.level}}</div>
+			<div class='line'>* Summary: {{:value.desc}}</div>
+		{{/for}}
+	{{else data.menu == 2 && data.disk_type}}
+		{{if data.submenu == 0}}
+			<h3>Data Disk Contents:</h3>
+			{{if data.disk_data}}
+				{{if data.disk_type == 1}}
+					<div class='line'>Name: {{:data.disk_data.name}}</div>
+					<div class='line'>Level: {{:data.disk_data.level}}</div>
+					<div class='line'>Description: {{:data.disk_data.desc}}</div>
+					{{:helper.link('Upload to Database', 'arrow-up', {'updt_tech': 1})}}
+					{{:helper.link('Clear Disk', 'trash', {'clear_tech': 1})}}
+				{{else}}
+					<div class='line'>Name: {{:data.disk_data.name}}</div>
+					<div class='line'>Reliability: {{:data.disk_data.reliability}}</div>
+					<div class='line'>
+						{{for data.disk_data.lathe_types}}
+							{{if index == 0}}
+								Lathe Types: 
+							{{else}}
+								, 
+							{{/if}}
+							{{:value}}
+						{{/for}}
+					</div>
+					<div class'line'>Required Materials:</div>
+					{{for data.disk_data.materials}}
+						<div class='line'>{{:value.name}} x {{:value.amount}}</div>
+					{{/for}}
+					{{:helper.link('Upload to Database', 'arrow-up', {'updt_design': 1})}}
+					{{:helper.link('Clear Disk', 'trash', {'clear_design': 1})}}
+				{{/if}}
+			{{else}}
+				<div class='line'>This disk is empty.</div>
+				{{:helper.link(data.disk_type == 1 ? 'Load Tech to Disk' : 'Load Design to Disk', 'arrow-down', {'submenu': 1})}}
+			{{/if}}
+			{{:helper.link('Eject Disk', 'eject', data.disk_type == 1 ? {'eject_tech': 1} : {'eject_design': 1})}}
+		{{else data.submenu == 1}}
+			{{for data.to_copy}}
+				<div class='line'>
+					<div class='itemLabel'>{{:value.name}}</div>
+					{{:helper.link('Copy to Disk', 'arrow-down', data.disk_type == 1 ? {'copy_tech': 1, 'copy_tech_ID': value.id} : {'copy_design': 1, 'copy_design_ID': value.id})}}
+				</div>
+			{{/for}}
+		{{/if}}
+	{{else data.menu == 3 && !data.linked_destroy}}
+		NO DESTRUCTIVE ANALYZER LINKED TO CONSOLE
+	{{else data.menu == 4 && !data.linked_lathe}}
+		NO PROTOLATHE LINKED TO CONSOLE
+	{{else data.menu == 5 && !data.linked_imprinter}}
+		NO CIRCUIT IMPRITER LINKED TO CONSOLE
+	{{else data.menu == 3}}
+		{{if !data.loaded_item}}
+			No item loaded. Standing by...
+		{{else}}
+			<h3>Deconstruction Menu:</h3>
+			<div class='line'>Name: {{:data.loaded_item.name}}</div>
+			<div class='line'>Reliability: {{:data.loaded_item.reliability}}</div>
+			<h3>Origin Tech:</h3>
+			{{for data.loaded_item.origin_tech}}
+				<div class='item'>
+					<div class='itemLabelWide'>* {{:value.name}}:</div>
+					<div class='itemLabelNarrow'>
+						{{:value.object_level}} 
+						{{if value.current_level}}
+							(Current: {{:value.current_level}})
+						{{/if}}
+					</div>
+				</div>
+			{{/for}}
+			<h3>Options:</h3>
+			{{:helper.link('Deconstruct Item', 'chain-broken', {'deconstruct': 1})}}
+			{{:helper.link('Eject Item', 'eject', {'eject_item': 1})}}
+		{{/if}}
+	{{else data.menu == 4 || data.menu == 5}}
+		{{if data.submenu == 0}}
+			<h3>{{:(data.menu == 4 ? 'Protolathe' : 'Circuit Imprinter')}} Menu:</h3>
+		{{else data.submenu == 1}}
+			<h3>{{:data.category}}:</h3>
+		{{else data.submenu == 2}}
+			<h3>Material Storage:</h3>
+		{{else data.submenu == 3}}
+			<h3>Chemical Storage:</h3>
+		{{/if}}
+		
+		{{if data.submenu < 2}}
+			<div class='itemLabelWidest'><table>
+				<tr>
+					<td><b>Material Amount:</b></td><td>{{:data.total_materials}}</td>
+					{{if data.max_materials}}
+						<td> / {{:data.max_materials}}</td>
+					{{/if}}
+				</tr>
+				<tr>
+					<td><b>Chemical Amount:</b></td><td>{{:data.total_chemicals}}</td>
+					{{if data.max_chemicals}}
+						<td> / {{:data.max_chemicals}}</td>
+					{{/if}}
+				</tr>
+			</table></div>
+		{{/if}}
+		
+		{{if data.submenu == 0}}
+			<form action='byond://'>
+				<input type='hidden' name='src' value='{{:data.src_ref}}'>
+				<input type='hidden' name='search' value='1'>
+				<input type='text' name='to_search'>
+				<input type='submit' value='Search'>
+			</form>
+			
+			<hr>
+			<table class='item'><tr>
+				{{for data.categories}}
+					{{if (index & 1) == 0 && index != 0}}
+						</tr><tr>
+					{{/if}}
+					<td>{{:helper.link(value, 'arrow-right', {'category': value})}}</td>
+				{{/for}}
+			</tr></table>
+		{{else data.submenu == 1}}
+			<table>
+				{{for data.matching_designs}}
+					<tr>
+						<td>{{:helper.link(value.name, 'print', data.menu == 4 ? {'build': value.id, 'amount': 1} : {'imprint': value.id}, value.can_build ? null : 'disabled')}}</td>
+						<td>{{if value.can_build >= 5}}
+							{{:helper.link('x5', null, data.menu == 4 ? {'build': value.id, 'amount': 5} : {'imprint': value.id})}}
+						{{/if}}</td>
+						<td>{{if value.can_build >= 10}}
+							{{:helper.link('x10', null, data.menu == 4 ? {'build': value.id, 'amount': 10} : {'imprint': value.id})}}
+						{{/if}}</td>
+						<td>
+							{{for value.materials : material : i}}
+								 | 
+								{{if material.is_red}}
+									<span class='bad'>
+								{{/if}}
+								{{:material.amount}} {{:material.name}}
+								{{if material.is_red}}
+									</span>
+								{{/if}}
+							{{/for}}
+						</td>
+					</tr>
+				{{/for}}
+			</table>
+		{{else data.submenu == 2}}
+			{{for data.loaded_materials}}
+				<div class='item'>
+					<div class='itemLabel'>* {{:value.amount}} of {{:value.name}}</div> <div class='itemLabelNarrow'>({{:Math.round((value.amount / 2000) * 10) / 10}} sheets)</div>
+					{{if value.amount >= 2000}}
+						{{if data.menu == 4}}
+							{{:helper.link('1x', 'eject', {'lathe_ejectsheet': value.id, 'lathe_ejectsheet_amt': 1})}}
+							{{:helper.link('C', 'eject', {'lathe_ejectsheet': value.id, 'lathe_ejectsheet_amt': 'custom'})}}
+							{{if value.amount >= 2000*5}}
+								{{:helper.link('5x', 'eject', {'lathe_ejectsheet': value.id, 'lathe_ejectsheet_amt': 5})}}
+							{{/if}}
+							{{:helper.link('All', 'eject', {'lathe_ejectsheet': value.id, 'lathe_ejectsheet_amt': 50})}}
+						{{else}}
+							{{:helper.link('1x', 'eject', {'imprinter_ejectsheet': value.id, 'imprinter_ejectsheet_amt': 1})}}
+							{{:helper.link('C', 'eject', {'imprinter_ejectsheet': value.id, 'imprinter_ejectsheet_amt': 'custom'})}}
+							{{if value.amount >= 2000*5}}
+								{{:helper.link('5x', 'eject', {'imprinter_ejectsheet': value.id, 'imprinter_ejectsheet_amt': 5})}}
+							{{/if}}
+							{{:helper.link('All', 'eject', {'imprinter_ejectsheet': value.id, 'imprinter_ejectsheet_amt': 50})}}
+						{{/if}}
+					{{/if}}
+				</div>
+			{{/for}}
+		{{else data.submenu == 3}}
+			<div class='item'>
+				
+				{{:helper.link('Purge All', 'trash', data.menu == 4 ? {'disposeallP': 1} : {'disposeallI' : 1})}}
+			</div>
+			{{for data.loaded_chemicals}}
+				<div class='item'>
+					<div class='itemLabel'>* {{:value.volume}} of {{:value.name}}</div>
+					{{:helper.link('Purge', 'trash', data.menu == 4 ? {'disposeP': value.id} : {'disposeI': value.id})}}
+				</div>
+			{{/for}}
+		{{/if}}
+	{{else data.menu == 6}}
+		{{if data.submenu == 0}}
+			<h3>Settings:</h3>
+			<div class='line'>{{:helper.link('Sync Database with Network', 'refresh', {'sync': 1}, data.sync ? null : 'disabled')}}</div>
+			<div class='line'>{{:helper.link('Connect to Research Network', 'plug', {'togglesync': 1}, data.sync ? 'selected' : null)}}</div>
+			<div class='line'>{{:helper.link('Disconnect from Research Network', 'chain-broken', {'togglesync': 1}, data.sync ? null : 'selected')}}</div>
+			<div class='line'>{{:helper.link('Device Linkage Menu', 'chain', {'menu': 6, 'submenu': 1})}}</div>
+			{{if data.admin}}
+				<div class='line'>{{:helper.link('[ADMIN] Maximize Research Levels', 'exclamation', {'maxresearch': 1})}}</div>
+			{{/if}}
+			<div class='line'>{{:helper.link('Reset Database', 'trash-o', {'reset': 1})}}</div>
+		{{else data.submenu == 1}}
+			<h3>Device Linkage Menu:</h3>
+			<div class='item'>{{:helper.link('Re-sync with Nearby Devices', 'chain', {'find_device': 1})}}</div>
+			<h3>Linked Devices:</h3>
+			<div class='item'>
+				{{if data.linked_destroy}}
+					<div class='itemLabel'>* Destructive Analyzer</div>
+					{{:helper.link('Unlink', 'chain-broken', {'disconnect': 'destroy'})}}
+				{{else}}
+					<div class='itemLabel'>* No Destructive Analyzer Linked</div>
+				{{/if}}
+			</div>
+			<div class='item'>
+				{{if data.linked_lathe}}
+					<div class='itemLabel'>* Protolathe</div>
+					{{:helper.link('Unlink', 'chain-broken', {'disconnect': 'lathe'})}}
+				{{else}}
+					<div class='itemLabel'>* No Protolathe Linked</div>
+				{{/if}}
+			</div>
+			<div class='item'>
+				{{if data.linked_imprinter}}
+					<div class='itemLabel'>* Circuit Imprinter</div>
+					{{:helper.link('Unlink', 'chain-broken', {'disconnect': 'imprinter'})}}
+				{{else}}
+					<div class='itemLabel'>* No Circuit Imprinter Linked</div>
+				{{/if}}
+			</div>
+		{{/if}}
+	{{/if}}
+</div>


### PR DESCRIPTION
Sooooo.... I redid the RnD ui in NanoUI.

This removes some code duplication (Protolathe material lists, I'm looking at you...), and makes the interface look purdy.

![http://i.imgur.com/ZbjI7Yw.png](http://i.imgur.com/ZbjI7Yw.png)
![http://i.imgur.com/ZHPg8EB.png](http://i.imgur.com/ZHPg8EB.png)

:cl: monster860
tweak: RnD console now uses NanoUI! Sweet!
bugfix: Fixes tranquillite being outside the box in the materials list. Mimes are supposed to be trapped inside a box, not outside one.
tweak: Replaces the weird unicode "x" character in some design names with the actual letter "x" so that it doesn't fuck up NanoUI
/:cl: