### PR TITLE
Fixes Tape Moving Mobs Recklessly

### DIFF
--- a/code/game/objects/items/policetape.dm
+++ b/code/game/objects/items/policetape.dm
@@ -147,16 +147,13 @@ var/list/tape_roll_applications = list()
 			tape_roll_applications[F] |= direction
 		return
 
-/obj/item/tape/Bumped(M as mob)
-	if(src.allowed(M))
-		var/turf/T = get_turf(src)
-		M:loc = T
-
 /obj/item/tape/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(!density) return 1
 	if(air_group || (height==0)) return 1
 
 	if ((mover.pass_flags & PASSTABLE || istype(mover, /obj/effect/meteor) || mover.throwing == 1) )
+		return 1
+	else if(ismob(mover) && allowed(mover))
 		return 1
 	else
 		return 0


### PR DESCRIPTION
Bumping into placed police/engineering tape that you were allowed to pass would *teleport* you on top of the tape, regardless of what other dense objects should have been in your way. Whether this would actually let you ignore other objects depended on the order you bumped into things on a turf.

Now, instead of checking for bumps, access is checked in `CanPass`. Fixes #2337. Also fixes a runtime caused by non-mobs bumping into tape.

Supersedes #4542.

:cl:
bugfix: Fixed tape allowing mobs with sufficient access to move through solid objects.
/:cl: