### PR TITLE
Spacepod Fix - Equipment Modules

### DIFF
--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -30,11 +30,9 @@
 		var/obj/item/projectile/projone = new proj_type(firstloc)
 		var/obj/item/projectile/projtwo = new proj_type(secondloc)
 		projone.starting = get_turf(my_atom)
-		projone.shot_from = src
 		projone.firer = usr
 		projone.def_zone = "chest"
 		projtwo.starting = get_turf(my_atom)
-		projtwo.shot_from = src
 		projtwo.firer = usr
 		projtwo.def_zone = "chest"
 		spawn()

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -30,9 +30,11 @@
 		var/obj/item/projectile/projone = new proj_type(firstloc)
 		var/obj/item/projectile/projtwo = new proj_type(secondloc)
 		projone.starting = get_turf(my_atom)
+		projone.shot_from = src
 		projone.firer = usr
 		projone.def_zone = "chest"
 		projtwo.starting = get_turf(my_atom)
+		projtwo.shot_from = src
 		projtwo.firer = usr
 		projtwo.def_zone = "chest"
 		spawn()
@@ -44,7 +46,7 @@
 
 /datum/spacepod/equipment
 	var/obj/spacepod/my_atom
-	var/list/obj/item/device/spacepod_equipment/installed_modules // holds an easy to access list of installed modules
+	var/list/obj/item/device/spacepod_equipment/installed_modules = list() // holds an easy to access list of installed modules
 
 	var/obj/item/device/spacepod_equipment/weaponry/weapon_system // weapons system
 	var/obj/item/device/spacepod_equipment/misc/misc_system // misc system

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -73,6 +73,8 @@
 	pr_int_temp_processor = new /datum/global_iterator/pod_preserve_temp(list(src))
 	pr_give_air = new /datum/global_iterator/pod_tank_give_air(list(src))
 	equipment_system = new(src)
+	equipment_system.installed_modules = new/list()
+	equipment_system.installed_modules += battery
 	spacepods_list += src
 	cargo_hold = new/obj/item/weapon/storage/internal(src)
 	cargo_hold.w_class = 5	//so you can put bags in
@@ -491,21 +493,25 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	T.loc = equipment_system
 	equipment_system.weapon_system = T
 	equipment_system.weapon_system.my_atom = src
+	equipment_system.installed_modules += T
 	var/obj/item/device/spacepod_equipment/misc/tracker/L = new /obj/item/device/spacepod_equipment/misc/tracker
 	L.loc = equipment_system
 	equipment_system.misc_system = L
 	equipment_system.misc_system.my_atom = src
 	equipment_system.misc_system.enabled = 1
+	equipment_system.installed_modules += L
 	var/obj/item/device/spacepod_equipment/sec_cargo/chair/C = new /obj/item/device/spacepod_equipment/sec_cargo/chair
 	C.loc = equipment_system
 	equipment_system.sec_cargo_system = C
 	equipment_system.sec_cargo_system.my_atom = src
+	equipment_system.installed_modules += C
 	max_passengers = 1
 	var/obj/item/device/spacepod_equipment/lock/keyed/K = new /obj/item/device/spacepod_equipment/lock/keyed
 	K.loc = equipment_system
 	equipment_system.lock_system = K
 	equipment_system.lock_system.my_atom = src
 	equipment_system.lock_system.id = 100000
+	equipment_system.installed_modules += K
 
 /obj/spacepod/random/New()
 	..()

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -73,7 +73,7 @@
 	pr_int_temp_processor = new /datum/global_iterator/pod_preserve_temp(list(src))
 	pr_give_air = new /datum/global_iterator/pod_tank_give_air(list(src))
 	equipment_system = new(src)
-	equipment_system.installed_modules = new/list()
+	equipment_system.installed_modules = list()
 	equipment_system.installed_modules += battery
 	spacepods_list += src
 	cargo_hold = new/obj/item/weapon/storage/internal(src)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -73,7 +73,6 @@
 	pr_int_temp_processor = new /datum/global_iterator/pod_preserve_temp(list(src))
 	pr_give_air = new /datum/global_iterator/pod_tank_give_air(list(src))
 	equipment_system = new(src)
-	equipment_system.installed_modules = list()
 	equipment_system.installed_modules += battery
 	spacepods_list += src
 	cargo_hold = new/obj/item/weapon/storage/internal(src)


### PR DESCRIPTION
Changes the installed_module variable in equipment to a list, allowing
the rest of the code to read it correctly.  Now when equipment is added
and removed from the pod, it updates properly. Also adds any equipment
the pod starts with to the list.

Fixes https://github.com/ParadiseSS13/Paradise/issues/4599

:cl: Twinmold
Fix: Fixes space pod equipment variable. Can now properly install/uninstall equipment.
Fix: Check Seat verb no longer pulls out installed equipment. 
Fix: You can now have a passenger in your pod if you have a passenger seat.
/:cl: