### PR TITLE
Fixes Databaseless Operation Runtime

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -316,10 +316,9 @@
 	send_resources()
 
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
-		if(!establish_db_connection())
-			return // if we have db problems, don't show anything
-		winset(src, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
-		to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
+		if(establish_db_connection())
+			winset(src, "rpane.changelog", "background-color=#f4aa94;font-style=bold")
+			to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
 
 	if(!void)
 		void = new()


### PR DESCRIPTION
Fixes a runtime involving running the codebase without a database.


Basically, if no database was detected, the the rest of `Client/New` wouldn't run, and therefore the click-catch wouldn't be properly generate (or tooltips)

While there should always be a database on the live server, there's instances where running it, locally, there is not---not to mention that should the database fail in the middle of gameplay and all...