### PR TITLE
Clarified sentience potion message

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -202,7 +202,8 @@
 	to_chat(user, "<span class='notice'>You offer [src] sentience potion to [SM]...</span>")
 	being_used = 1
 
-	var/list/candidates = pollCandidates("Do you want to play as [SM.name]?", ROLE_SENTIENT, 0, 100)
+	var/ghostmsg = "Play as [SM.name], pet of [user.name]?"
+	var/list/candidates = pollCandidates(ghostmsg, ROLE_SENTIENT, 0, 100)
 
 	if(!src)
 		return


### PR DESCRIPTION
This PR changes the message given to ghosts when sentience potions are used, from the format "Do you want to play as alien hunter?" to the far clearer: "Play as alien hunter, pet of Joe Scientist?".

This change:
- Prevents people getting confused between being asked to play as a hostile mob (e.g: real xeno) and being asked to play as a tame mob (e.g: sentience potion pets).
- Makes it clear who your prospective owner would be. This matters to some people, and also makes it easier for admins to locate and PM people who are using sentience potions constantly and spamming ghosts with prompts as a result.
