### PR TITLE
Rermove "100" from the list of power options in telesci

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -24,7 +24,7 @@
 
 	// Based on the power used
 	var/teleport_cooldown = 0 // every index requires a bluespace crystal
-	var/list/power_options = list(5, 10, 20, 25, 30, 40, 50, 80, 100)
+	var/list/power_options = list(5, 10, 20, 25, 30, 40, 50, 80)
 	var/teleporting = 0
 	var/starting_crystals = 0
 	var/max_crystals = 4


### PR DESCRIPTION
It's completely impossible to get the power option, let's not have it sitting there taunting us.