### PR TITLE
Makes multiple adjustments to slipping

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -999,7 +999,7 @@ steam.start() -- spawns the effect
 
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		if(M.slip("foam", 3))
+		if(M.slip("foam", 3)) // Duration is ~5 seconds. ((x*2)-1)
 			if(reagents)
 				for(var/reagent_id in reagents.reagent_list)
 					var/amount = M.reagents.get_reagent_amount(reagent_id)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -999,7 +999,7 @@ steam.start() -- spawns the effect
 
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		if(M.slip("foam", 5, 2))
+		if(M.slip("foam", 3))
 			if(reagents)
 				for(var/reagent_id in reagents.reagent_list)
 					var/amount = M.reagents.get_reagent_amount(reagent_id)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -999,7 +999,7 @@ steam.start() -- spawns the effect
 
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		if(M.slip("foam", 3)) // Duration is ~5 seconds. ((x*2)-1)
+		if(M.slip("foam", 0, 3)) // Duration is ~5 seconds. ((x*2)-1)
 			if(reagents)
 				for(var/reagent_id in reagents.reagent_list)
 					var/amount = M.reagents.get_reagent_amount(reagent_id)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -23,7 +23,7 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		M.slip("banana peel", 4) // Duration is ~7 seconds. ((x*2)-1)
+		M.slip("banana peel", 0, 4) // Duration is ~7 seconds. ((x*2)-1)
 
 /*
  * Soap
@@ -31,7 +31,7 @@
 /obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		M.slip("soap", 4) // Duration is ~7 seconds. ((x*2)-1)
+		M.slip("soap", 0, 4) // Duration is ~7 seconds. ((x*2)-1)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -23,7 +23,7 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		M.slip("banana peel", 4, 2)
+		M.slip("banana peel", 4)
 
 /*
  * Soap
@@ -31,7 +31,7 @@
 /obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		M.slip("soap", 4, 2)
+		M.slip("soap", 4)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -23,7 +23,7 @@
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		M.slip("banana peel", 4)
+		M.slip("banana peel", 4) // Duration is ~7 seconds. ((x*2)-1)
 
 /*
  * Soap
@@ -31,7 +31,7 @@
 /obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		M.slip("soap", 4)
+		M.slip("soap", 4) // Duration is ~7 seconds. ((x*2)-1)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -73,7 +73,7 @@
 					M.take_overall_damage(0, max(0, (burned - 2)))
 
 			if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
-				M.slip("banana peel!", 7, 4) // Duration is ~13 seconds. ((x*2)-1)
+				M.slip("banana peel!", 0, 7, 4) // Duration is ~13 seconds. ((x*2)-1)
 				M.take_organ_damage(2)
 				M.take_overall_damage(0, burned)
 

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -73,7 +73,7 @@
 					M.take_overall_damage(0, max(0, (burned - 2)))
 
 			if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
-				M.slip("banana peel!", 0, 7, 4)
+				M.slip("banana peel!", 7, 4)
 				M.take_organ_damage(2) // Was 5 -- TLE
 				M.take_overall_damage(0, burned)
 

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -73,7 +73,7 @@
 					M.take_overall_damage(0, max(0, (burned - 2)))
 
 			if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
-				M.slip("banana peel!", 7, 4)
+				M.slip("banana peel!", 7, 4) // Duration is ~13 seconds. ((x*2)-1)
 				M.take_organ_damage(2) // Was 5 -- TLE
 				M.take_overall_damage(0, burned)
 

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -74,7 +74,7 @@
 
 			if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
 				M.slip("banana peel!", 7, 4) // Duration is ~13 seconds. ((x*2)-1)
-				M.take_organ_damage(2) // Was 5 -- TLE
+				M.take_organ_damage(2)
 				M.take_overall_damage(0, burned)
 
 	throw_impact(atom/hit_atom)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -99,17 +99,17 @@
 
 			switch (src.wet)
 				if(TURF_WET_WATER)
-					if (!(M.slip("wet floor", 4, 2, 0, 1)))
+					if (!(M.slip("wet floor", 3, 0, 1)))
 						M.inertia_dir = 0
 						return
 
 				if(TURF_WET_LUBE) //lube
-					if(M.slip("floor", 0, 7, 4, 0, 1))
+					if(M.slip("floor", 3, 3, 0, 1))
 						M.take_organ_damage(2) // Was 5 -- TLE
 
 
 				if(TURF_WET_ICE) // Ice
-					if (!(prob(30) && M.slip("icy floor", 4, 2, 1, 1)))
+					if (!(prob(30) && M.slip("icy floor", 3, 1, 1)))
 						M.inertia_dir = 0
 
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -99,17 +99,17 @@
 
 			switch (src.wet)
 				if(TURF_WET_WATER)
-					if (!(M.slip("wet floor", 3, 0, 1))) // Duration is ~5 seconds. ((x*2)-1)
+					if (!(M.slip("wet floor", 0, 3, 0, 1))) // Duration is ~5 seconds. ((x*2)-1)
 						M.inertia_dir = 0
 						return
 
 				if(TURF_WET_LUBE) //lube
-					if(M.slip("floor", 3, 3, 0, 1)) // Duration is ~5 seconds. ((x*2)-1)
+					if(M.slip("floor", 0, 3, 3, 0, 1)) // Duration is ~5 seconds. ((x*2)-1)
 						M.take_organ_damage(2)
 
 
 				if(TURF_WET_ICE) // Ice
-					if (!(prob(30) && M.slip("icy floor", 3, 1, 1))) // Duration is ~5 seconds. ((x*2)-1)
+					if (!(prob(30) && M.slip("icy floor", 0, 3, 1, 1))) // Duration is ~5 seconds. ((x*2)-1)
 						M.inertia_dir = 0
 
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -99,17 +99,17 @@
 
 			switch (src.wet)
 				if(TURF_WET_WATER)
-					if (!(M.slip("wet floor", 3, 0, 1)))
+					if (!(M.slip("wet floor", 3, 0, 1))) // Duration is ~5 seconds. ((x*2)-1)
 						M.inertia_dir = 0
 						return
 
 				if(TURF_WET_LUBE) //lube
-					if(M.slip("floor", 3, 3, 0, 1))
-						M.take_organ_damage(2) // Was 5 -- TLE
+					if(M.slip("floor", 3, 3, 0, 1)) // Duration is ~5 seconds. ((x*2)-1)
+						M.take_organ_damage(2)
 
 
 				if(TURF_WET_ICE) // Ice
-					if (!(prob(30) && M.slip("icy floor", 3, 1, 1)))
+					if (!(prob(30) && M.slip("icy floor", 3, 1, 1))) // Duration is ~5 seconds. ((x*2)-1)
 						M.inertia_dir = 0
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -915,7 +915,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 				W.layer = initial(W.layer)
 
 
-/mob/living/carbon/proc/slip(var/description, var/weaken, var/tilesSlipped, var/walkSafely, var/slipAny)
+/mob/living/carbon/proc/slip(var/description, var/slipduration, var/tilesSlipped, var/walkSafely, var/slipAny)
 	if (flying || buckled || (walkSafely && m_intent == "walk"))
 		return
 	if ((lying) && (!(tilesSlipped)))
@@ -931,7 +931,8 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	stop_pulling()
 	to_chat(src, "<span class='notice'>You slipped on the [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-	Weaken(weaken) // Duration is roughly ((x*2)-1) seconds.
+	Stun(slipduration) // Duration is roughly ((x*2)-1) seconds.
+	Weaken(round(slipduration/2,1)) // Applies weaken for half duration, rounded up.
 	return 1
 
 /mob/living/carbon/proc/can_eat(flags = 255)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -915,7 +915,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 				W.layer = initial(W.layer)
 
 
-/mob/living/carbon/proc/slip(var/description, var/slipDuration, var/tilesSlipped, var/walkSafely, var/slipAny)
+/mob/living/carbon/proc/slip(var/description, var/stun, var/weaken, var/tilesSlipped, var/walkSafely, var/slipAny)
 	if (flying || buckled || (walkSafely && m_intent == "walk"))
 		return
 	if ((lying) && (!(tilesSlipped)))
@@ -931,8 +931,9 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	stop_pulling()
 	to_chat(src, "<span class='notice'>You slipped on the [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-	Stun(slipDuration) // Duration is roughly ((x*2)-1) seconds.
-	Weaken(round(slipDuration/2,1)) // Applies weaken for half duration, rounded up.
+	if (stun)
+		Stun(stun) // Weaken does everything stun does. This would apply simultaneously.
+	Weaken(weaken) // Duration is roughly ((x*2)-1) seconds.
 	return 1
 
 /mob/living/carbon/proc/can_eat(flags = 255)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -915,7 +915,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 				W.layer = initial(W.layer)
 
 
-/mob/living/carbon/proc/slip(var/description, var/stun, var/weaken, var/tilesSlipped, var/walkSafely, var/slipAny)
+/mob/living/carbon/proc/slip(var/description, var/weaken, var/tilesSlipped, var/walkSafely, var/slipAny)
 	if (flying || buckled || (walkSafely && m_intent == "walk"))
 		return
 	if ((lying) && (!(tilesSlipped)))
@@ -931,8 +931,6 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	stop_pulling()
 	to_chat(src, "<span class='notice'>You slipped on the [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-	if (stun)
-		Stun(stun)
 	Weaken(weaken)
 	return 1
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -915,7 +915,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 				W.layer = initial(W.layer)
 
 
-/mob/living/carbon/proc/slip(var/description, var/slipduration, var/tilesSlipped, var/walkSafely, var/slipAny)
+/mob/living/carbon/proc/slip(var/description, var/slipDuration, var/tilesSlipped, var/walkSafely, var/slipAny)
 	if (flying || buckled || (walkSafely && m_intent == "walk"))
 		return
 	if ((lying) && (!(tilesSlipped)))
@@ -931,8 +931,8 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	stop_pulling()
 	to_chat(src, "<span class='notice'>You slipped on the [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-	Stun(slipduration) // Duration is roughly ((x*2)-1) seconds.
-	Weaken(round(slipduration/2,1)) // Applies weaken for half duration, rounded up.
+	Stun(slipDuration) // Duration is roughly ((x*2)-1) seconds.
+	Weaken(round(slipDuration/2,1)) // Applies weaken for half duration, rounded up.
 	return 1
 
 /mob/living/carbon/proc/can_eat(flags = 255)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -931,7 +931,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	stop_pulling()
 	to_chat(src, "<span class='notice'>You slipped on the [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-	Weaken(weaken)
+	Weaken(weaken) // Duration is roughly ((x*2)-1) seconds.
 	return 1
 
 /mob/living/carbon/proc/can_eat(flags = 255)

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -1,4 +1,4 @@
-f/obj/item/device/pda/medical
+/obj/item/device/pda/medical
 	default_cartridge = /obj/item/weapon/cartridge/medical
 	icon_state = "pda-medical"
 

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -1,4 +1,4 @@
-/obj/item/device/pda/medical
+f/obj/item/device/pda/medical
 	default_cartridge = /obj/item/weapon/cartridge/medical
 	icon_state = "pda-medical"
 
@@ -41,7 +41,7 @@
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		M.slip("pda", 4, 0, 1) // Duration is ~7 seconds. ((x*2)-1)
+		M.slip("pda", 0, 4, 0, 1) // Duration is ~7 seconds. ((x*2)-1)
 
 /obj/item/device/pda/mime
 	default_cartridge = /obj/item/weapon/cartridge/mime

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -41,7 +41,7 @@
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		M.slip("pda", 4, 0, 1)
+		M.slip("pda", 4, 0, 1) // Duration is ~7 seconds. ((x*2)-1)
 
 /obj/item/device/pda/mime
 	default_cartridge = /obj/item/weapon/cartridge/mime

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -41,7 +41,7 @@
 /obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
 	if (istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M =	AM
-		M.slip("pda", 8, 5, 0, 1)
+		M.slip("pda", 4, 0, 1)
 
 /obj/item/device/pda/mime
 	default_cartridge = /obj/item/weapon/cartridge/mime


### PR DESCRIPTION
This makes some adjustments to the slip durations. Some are the same, some are lower. The formula for the duration is roughly ((x*2)-1) so a 3 lasts ~5 seconds and a 4 lasts ~7 seconds.

The biggest changes were Water, which went from 7 seconds to 5 seconds, Space Lube, which went from 13 seconds to 5 seconds, and the Clown PDA, which went from 15 seconds to 7 seconds (which makes it the same as a banana peel or soap).

Additionally, tiles slipped on space lube went from 4 to 3.

Nothing here is final, everything is up to discussion, so no reason to vote for blanket disapproval just yet.