### PR TITLE
Secure Briefcase now On-Par with Regular Briefcase, Fixes #4678

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -156,14 +156,19 @@
 // -----------------------------
 /obj/item/weapon/storage/secure/briefcase
 	name = "secure briefcase"
+	desc = "A large briefcase with a digital locking system."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "secure"
 	item_state = "sec-case"
-	desc = "A large briefcase with a digital locking system."
+	flags = CONDUCT
+	hitsound = "swing_hit"
 	force = 8.0
-	throw_speed = 1
+	throw_speed = 2
 	throw_range = 4
 	w_class = 4.0
+	max_w_class = 3
+	max_combined_w_class = 21
+	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 
 	New()
 		..()


### PR DESCRIPTION
At least in terms of carrying capacity, flags, hitsound and attack verbs. Resolves #4678

See image below:
![securebriefcasepaperbin](https://cloud.githubusercontent.com/assets/12377767/16073227/ed60d2da-32b2-11e6-8521-edbc6c701350.png)

Yes, that is a paper bin inside a secure briefcase.

:cl:
fix: Secure briefcase now has the same flags, hitsounds, attack verbs, throw speed and carrying capacity as a regular briefcase. Yes, it can hold paper bins now.
/:cl: