### PR TITLE
Dethralling a Shadowling Thrall Clears Darksight if it's Activated, Fixes #4656

### DIFF
--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -264,6 +264,9 @@
 			playsound(S, 'sound/effects/bang.ogg', 50, 1)
 		return 0
 	user.visible_message("[user] shines light onto the tumor in [target]'s head!", "<span class='notice'>You cleanse the contamination from [target]'s brain!</span>")
+	if(target.vision_type) //Turns off their darksight if it's still active.
+		to_chat(target, "<span class='boldannounce'>Your eyes are suddenly wrought with immense pain as your darksight is forcibly dismissed!</span>")
+		target.vision_type = null
 	ticker.mode.remove_thrall(target.mind, 0)
 	target.visible_message("<span class='warning'>A strange black mass falls from [target]'s head!</span>")
 	new /obj/item/organ/internal/shadowtumor(get_turf(target))


### PR DESCRIPTION
:cl:
fix: Dethralling a Shadowling thrall that has darksight activated clears their darksight.
/:cl:

Resolves #4656.
Tested by spawning in as a human, setting myself to Shadowling thrall by traitorpanel, turning on darksight, teleporting to the OR, breaking all the lights and _getting dethralled*_. After dethralling, I found my vision had returned to normal as the room was dark. No darksight.

*Getting dethralled: Spawning in another mob and turning on debug verbs, then posessing that mob and conducting dethralling surgery on my old body. Once surgery is completed, I then re-posessed my old body.