### PR TITLE
Removes more boring steal objectives

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -43,11 +43,6 @@
 	typepath = /obj/item/weapon/hand_tele
 	protected_jobs = list("Captain", "Research Director")
 
-/datum/theft_objective/jetpack
-	name = "a jetpack"
-	typepath = /obj/item/weapon/tank/jetpack
-	protected_jobs = list("Chief Engineer")
-
 /datum/theft_objective/ai
 	name = "a functional AI"
 	typepath = /obj/item/device/aicard
@@ -73,22 +68,6 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/device/aicard/C)
 	name = "the station blueprints"
 	typepath = /obj/item/areaeditor/blueprints
 	protected_jobs = list("Chief Engineer")
-
-/datum/theft_objective/voidsuit
-	name = "a nasa voidsuit"
-	typepath = /obj/item/clothing/suit/space/nasavoid
-	protected_jobs = list("Research Director")
-
-/datum/theft_objective/slime_extract
-	name = "a sample of unused slime extract"
-	typepath = /obj/item/slime_extract
-	protected_jobs = list("Research Director","Scientist")
-
-/datum/theft_objective/slime_extract/check_special_completion(var/obj/item/slime_extract/E)
-	if(..())
-		if(E.Uses > 0)
-			return 1
-	return 0
 
 /datum/theft_objective/capmedal
 	name = "the medal of captaincy"
@@ -149,16 +128,6 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/device/aicard/C)
 
 /datum/theft_objective/number/proc/getAmountStolen(var/obj/item/I)
 	return I:amount
-
-/datum/theft_objective/number/plasma_gas
-	name = "moles of plasma (full tank)"
-	typepath = /obj/item/weapon/tank
-	min=28
-	max=28
-	protected_jobs = list("Chief Engineer", "Station Engineer", "Scientist", "Research Director", "Life Support Specialist")
-
-/datum/theft_objective/number/plasma_gas/getAmountStolen(var/obj/item/I)
-	return I:air_contents:toxins
 
 /datum/theft_objective/number/coins
 	name = "credits of coins (in bag)"


### PR DESCRIPTION
Based off feedback from #4652

Removes the following steal objectives:
Unused slime extract
Jetpack
Void Suit
Tank of Plasma

If you feel one of these is sufficiently challenging and shouldn't be removed, please comment below.