### PR TITLE
Gives Warden Krav Maga Gloves

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -124,6 +124,11 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/device/aicard/C)
 	typepath = /obj/item/clothing/suit/armor/laserproof
 	protected_jobs = list("Head of Security", "Warden")
 
+/datum/theft_objective/krav
+	name = "the warden's krav maga martial arts gloves"
+	typepath = /obj/item/clothing/gloves/color/black/krav_maga/sec
+	protected_jobs = list("Head Of Security", "Warden")
+
 /datum/theft_objective/number
 	var/min=0
 	var/max=0

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -155,6 +155,7 @@
 		new /obj/item/weapon/gun/energy/gun/advtaser(src)
 		new /obj/item/weapon/storage/belt/security/sec(src)
 		new /obj/item/weapon/storage/box/holobadge(src)
+		new /obj/item/clothing/gloves/color/black/krav_maga/sec(src)
 
 
 


### PR DESCRIPTION
Gives Warden a pair of Krava Maga gloves, just like on TG.

No, not giving this to the HoS; he already had plenty of unique and insanely powerful stuff.

This is also wayyyy too good for regular officers--the damage on it is crazy and the status effects are insanely powerful.

Also adds in a new steal objective: steal the warden's krav maga gloves.

:cl: Fox McCloud
add: Warden starts off with a pair of Krav Maga Gloves
add: New Steal objective: steal the warden's krav maga gloves
/:cl: