### PR TITLE
Adjustments to Revenant Abilities (Nerf)

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -238,7 +238,8 @@
 	action_icon_state = "defile"
 	var/stamdamage= 25
 	var/toxdamage = 5
-	var/confusion = 50
+	var/confusion = 20
+	var/maxconfusion = 30
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/defile/cast(list/targets, mob/living/simple_animal/revenant/user = usr)
 	if(attempt_cast(user))
@@ -251,7 +252,7 @@
 					to_chat(human, "<span class='warning'>You suddenly feel [pick("sick and tired", "tired and confused", "nauseated", "dizzy")].</span>")
 					human.adjustStaminaLoss(stamdamage)
 					human.adjustToxLoss(toxdamage)
-					human.confused += confusion
+					human.confused = min(human.confused+confusion, maxconfusion)
 					new/obj/effect/overlay/temp/revenant(human.loc)
 				if(!istype(T, /turf/simulated/shuttle) && !istype(T, /turf/simulated/wall/rust) && !istype(T, /turf/simulated/wall/r_wall) && istype(T, /turf/simulated/wall) && prob(15))
 					new/obj/effect/overlay/temp/revenant(T)
@@ -281,7 +282,7 @@
 	name = "Malfunction"
 	desc = "Corrupts and damages nearby machines and mechanical objects."
 	charge_max = 200
-	range = 4
+	range = 2
 	cast_amount = 45
 	unlock_amount = 150
 	action_icon_state = "malfunction"


### PR DESCRIPTION
Changes some variables in Revenant abilities. Not as extreme as
suggested by some people, but definitely a nerf to Revenants.

This change lowers the amount of confusion from Revenants from 50 to 20
per use of Defile.  This also adds in a maximum confusion of 30 that
Defile can give someone. Finally, this lowers the range of malfunction
from 4 tiles to 2 tiles, as it still uses an EMP function which makes it
an instant kill against IPCs, and greatly incapacitating anyone with
mechanical organs (especially heart).

The numbers for confusion also come out to about equal seconds.

:cl: Twinmold
Tweak: Lowers the range of Malfunction from 4 tiles to 2 tiles, due to
ability to insta-kill IPCs/incapacitate those with mechanical hearts.
Tweak: Lowers amount of confusion given from Revenants from 50 to 20 per
Defile.
Fix: Sets a maximum confused amount from the Revenant's Defile ability
(now 30).
/:cl: