### PR TITLE
Improved Fax Options (fax templates, borging paper, etc)

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1680,7 +1680,7 @@
 			return
 		var/etypes = list("borging","corgifying","firedeath","braindeath","honktumor","demotion")
 		var/eviltype = input(src.owner, "Which type of evil fax do you wish to send [H]?","Its good to be baaaad...", "") as null|anything in etypes
-		if (!(eviltype in etypes))
+		if(!(eviltype in etypes))
 			return
 		var/obj/item/weapon/paper/evilfax/P = new /obj/item/weapon/paper/evilfax(null)
 		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
@@ -1728,15 +1728,15 @@
 		var/stypes = list("handle it yourself","illegible","not signed","sorry, not right now","stop wasting our time")
 		var/stype = input(src.owner, "Which type of standard reply do you wish to send to [H]?","Choose your paperwork", "") as null|anything in stypes
 		var/tmsg = "<font face='Verdana' color='black'><center><img src = 'ntlogo.png'><BR><BR><BR><font size='4'><B>NanoTrasen Science Station Cyberiad</B></font><BR><BR><BR><font size='4'>NAS Trurl Communications Department Report</font></center><BR><BR>"
-		if (stype == "handle it yourself")
+		if(stype == "handle it yourself")
 			tmsg += "Greetings, esteemed crewmember. Your fax has been <B><I>DECLINED</I></B> automatically by NAS Trurl Fax Registration.<BR><BR>Please proceed in accordance with Standard Operating Procedure and/or Space Law. You are fully trained to handle this situation without Central Command intervention."
-		else if (stype == "illegible")
+		else if(stype == "illegible")
 			tmsg += "Greetings, esteemed crewmember. Your fax has been <B><I>DECLINED</I></B> automatically by NAS Trurl Fax Registration.<BR><BR>Your fax was too poorly written for our system to interpret."
-		else if (stype == "not signed")
+		else if(stype == "not signed")
 			tmsg += "Greetings, esteemed crewmember. Your fax has been <B><I>DECLINED</I></B> automatically by NAS Trurl Fax Registration.<BR><BR>Your fax was not properly signed and/or stamped."
-		else if (stype == "sorry, not right now")
+		else if(stype == "sorry, not right now")
 			tmsg += "Greetings, esteemed crewmember. Unfortunately, we are unable to spare the resources to assist you at this time."
-		else if (stype == "stop wasting our time")
+		else if(stype == "stop wasting our time")
 			tmsg += "Stop wasting our time."
 		else
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1678,7 +1678,7 @@
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		var/etypes = list("borging","corgifying","explosive","memetickillagent","honktumor","demotion")
+		var/etypes = list("borging","corgifying","firedeath","braindeath","honktumor","demotion")
 		var/eviltype = input(src.owner, "Which type of evil fax do you wish to send [H]?","Its good to be baaaad...", "") as null|anything in etypes
 		if (!(eviltype in etypes))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1671,6 +1671,40 @@
 		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)]'s Centcom message with: \"[input]\"")
 		to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. [input].  Message ends.\"")
 
+	else if(href_list["BorgingFax"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/mob/living/carbon/human/H = locate(href_list["BorgingFax"])
+		if(!istype(H))
+			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+			return
+		if(alert(src.owner, "Are you sure you want to send [key_name(H)] a demotion fax that will borg them when they read it?",  "Confirm?" , "Yes" , "No") != "Yes")
+			return
+		var/obj/item/weapon/paper/borging/P = new /obj/item/weapon/paper/borging(null)
+		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
+		P.name = "paper"
+		P.info = "<b>A reminder: per the terms of your contract, stupid faxes will get you demoted.</b>"
+		P.x = rand(-2, 0)
+		P.y = rand(-1, 2)
+		P.offset_x += P.x
+		P.offset_y += P.y
+		P.update_icon()
+		var/stampvalue = "cent"
+		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+		stampoverlay.icon_state = "paper_stamp-[stampvalue]"
+		P.stamped = list()
+		P.stamped += /obj/item/weapon/stamp/centcom
+		P.overlays += stampoverlay
+		P.stamps += "<HR><img src=large_stamp-[stampvalue].png>"
+		P.borgtarget = H
+		P.update_icon()
+		P.loc = fax.loc
+		//fax.receivefax(P)
+		if(istype(H) && H.stat == CONSCIOUS && (istype(H.l_ear, /obj/item/device/radio/headset) || istype(H.r_ear, /obj/item/device/radio/headset)))
+			to_chat(H, "Your headset pings, notifying you that a reply to your fax has arrived.")
+		to_chat(src.owner, "You sent a borging fax to [H]")
+		log_admin("[key_name(src.owner)] sent [key_name(H)] a borging fax")
+		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)] with a borging fax")
 	else if(href_list["SyndicateReply"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1671,19 +1671,25 @@
 		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)]'s Centcom message with: \"[input]\"")
 		to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. [input].  Message ends.\"")
 
-	else if(href_list["BorgingFax"])
+	else if(href_list["EvilFax"])
 		if(!check_rights(R_ADMIN))
 			return
-		var/mob/living/carbon/human/H = locate(href_list["BorgingFax"])
+		var/mob/living/carbon/human/H = locate(href_list["EvilFax"])
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		if(alert(src.owner, "Are you sure you want to send [key_name(H)] a demotion fax that will borg them when they read it?",  "Confirm?" , "Yes" , "No") != "Yes")
+		var/etypes = list("borging","corgifying","explosive","memetickillagent","honktumor","demotion")
+		var/eviltype = input(src.owner, "Which type of evil fax do you wish to send [H]?","Its good to be baaaad...", "") as null|anything in etypes
+		if (!(eviltype in etypes))
 			return
-		var/obj/item/weapon/paper/borging/P = new /obj/item/weapon/paper/borging(null)
+		var/obj/item/weapon/paper/evilfax/P = new /obj/item/weapon/paper/evilfax(null)
 		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
-		P.name = "paper"
-		P.info = "<b>A reminder: per the terms of your contract, stupid faxes will get you demoted.</b>"
+		P.name = "Central Command - paper"
+		P.info = "<b>A reminder: per the terms of your contract, stupid faxes will get you demoted, or worse.</b>"
+		P.myeffect = eviltype
+		P.mytarget = H
+		if(alert("Do you want the Evil Fax to activate automatically if [H] tries to ignore it?",,"Yes", "No") == "Yes")
+			P.activate_on_timeout = 1
 		P.x = rand(-2, 0)
 		P.y = rand(-1, 2)
 		P.offset_x += P.x
@@ -1692,23 +1698,78 @@
 		var/stampvalue = "cent"
 		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
 		stampoverlay.icon_state = "paper_stamp-[stampvalue]"
+		stampoverlay.pixel_x = P.x
+		stampoverlay.pixel_y = P.y
 		P.stamped = list()
 		P.stamped += /obj/item/weapon/stamp/centcom
+		if(!P.ico)
+			P.ico = new
+		P.ico += "paper_stamp-[stampvalue]"
 		P.overlays += stampoverlay
 		P.stamps += "<HR><img src=large_stamp-[stampvalue].png>"
-		P.borgtarget = H
 		P.update_icon()
+		//fax.receivefax(P) // this does not work, it does not preserve the type, we have to physically teleport the fax paper instead
 		P.loc = fax.loc
-		//fax.receivefax(P)
 		if(istype(H) && H.stat == CONSCIOUS && (istype(H.l_ear, /obj/item/device/radio/headset) || istype(H.r_ear, /obj/item/device/radio/headset)))
 			to_chat(H, "Your headset pings, notifying you that a reply to your fax has arrived.")
-		to_chat(src.owner, "You sent a borging fax to [H]")
-		log_admin("[key_name(src.owner)] sent [key_name(H)] a borging fax")
-		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)] with a borging fax")
+		to_chat(src.owner, "You sent a [eviltype] fax to [H]")
+		log_admin("[key_name(src.owner)] sent [key_name(H)] a [eviltype] fax")
+		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)] with a [eviltype] fax")
+	else if(href_list["FaxReplyTemplate"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/mob/living/carbon/human/H = locate(href_list["FaxReplyTemplate"])
+		if(!istype(H))
+			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
+			return
+		var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(null)
+		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
+		P.name = "Central Command - paper"
+		var/stypes = list("handle it yourself","illegible","not signed","sorry, not right now","stop wasting our time")
+		var/stype = input(src.owner, "Which type of standard reply do you wish to send to [H]?","Choose your paperwork", "") as null|anything in stypes
+		var/tmsg = "<font face='Verdana' color='black'><center><img src = 'ntlogo.png'><BR><BR><BR><font size='4'><B>NanoTrasen Science Station Cyberiad</B></font><BR><BR><BR><font size='4'>NAS Trurl Communications Department Report</font></center><BR><BR>"
+		if (stype == "handle it yourself")
+			tmsg += "Greetings, esteemed crewmember. Your fax has been <B><I>DECLINED</I></B> automatically by NAS Trurl Fax Registration.<BR><BR>Please proceed in accordance with Standard Operating Procedure and/or Space Law. You are fully trained to handle this situation without Central Command intervention."
+		else if (stype == "illegible")
+			tmsg += "Greetings, esteemed crewmember. Your fax has been <B><I>DECLINED</I></B> automatically by NAS Trurl Fax Registration.<BR><BR>Your fax was too poorly written for our system to interpret."
+		else if (stype == "not signed")
+			tmsg += "Greetings, esteemed crewmember. Your fax has been <B><I>DECLINED</I></B> automatically by NAS Trurl Fax Registration.<BR><BR>Your fax was not properly signed and/or stamped."
+		else if (stype == "sorry, not right now")
+			tmsg += "Greetings, esteemed crewmember. Unfortunately, we are unable to spare the resources to assist you at this time."
+		else if (stype == "stop wasting our time")
+			tmsg += "Stop wasting our time."
+		else
+			return
+		tmsg += "</font>"
+		P.info = tmsg
+		P.x = rand(-2, 0)
+		P.y = rand(-1, 2)
+		P.offset_x += P.x
+		P.offset_y += P.y
+		P.update_icon()
+		var/stampvalue = "cent"
+		var/image/stampoverlay = image('icons/obj/bureaucracy.dmi')
+		stampoverlay.icon_state = "paper_stamp-[stampvalue]"
+		stampoverlay.pixel_x = P.x
+		stampoverlay.pixel_y = P.y
+		P.stamped = list()
+		P.stamped += /obj/item/weapon/stamp/centcom
+		if(!P.ico)
+			P.ico = new
+		P.ico += "paper_stamp-[stampvalue]"
+		P.overlays += stampoverlay
+		P.stamps += "<HR><img src=large_stamp-[stampvalue].png>"
+		P.update_icon()
+		fax.receivefax(P)
+		if(istype(H) && H.stat == CONSCIOUS && (istype(H.l_ear, /obj/item/device/radio/headset) || istype(H.r_ear, /obj/item/device/radio/headset)))
+			to_chat(H, "Your headset pings, notifying you that a reply to your fax has arrived.")
+		to_chat(src.owner, "You sent a standard '[stype]' fax to [H]")
+		log_admin("[key_name(src.owner)] sent [key_name(H)] a standard '[stype]' fax")
+		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)] with a standard '[stype]' fax")
+
 	else if(href_list["SyndicateReply"])
 		if(!check_rights(R_ADMIN))
 			return
-
 		var/mob/living/carbon/human/H = locate(href_list["SyndicateReply"])
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
@@ -1719,10 +1780,9 @@
 		if(!istype(H.l_ear, /obj/item/device/radio/headset) && !istype(H.r_ear, /obj/item/device/radio/headset))
 			to_chat(usr, "The person you are trying to contact is not wearing a headset")
 			return
-
 		var/input = input(src.owner, "Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from The Syndicate", "")
-		if(!input)	return
-
+		if(!input)
+			return
 		to_chat(src.owner, "You sent [input] to [H] via a secure channel.")
 		log_admin("[src.owner] replied to [key_name(H)]'s Syndicate message with the message [input].")
 		to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from your benefactor.  Message as follows, agent. [input].  Message ends.\"")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1682,9 +1682,13 @@
 		var/eviltype = input(src.owner, "Which type of evil fax do you wish to send [H]?","Its good to be baaaad...", "") as null|anything in etypes
 		if(!(eviltype in etypes))
 			return
+		var/customname = input(src.owner, "Pick a title for the evil fax.", "Fax Title") as text|null
+		if(!customname)
+			customname = "paper"
 		var/obj/item/weapon/paper/evilfax/P = new /obj/item/weapon/paper/evilfax(null)
 		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
-		P.name = "Central Command - paper"
+
+		P.name = "Central Command - [customname]"
 		P.info = "<b>A reminder: per the terms of your contract, stupid faxes will get you demoted, or worse.</b>"
 		P.myeffect = eviltype
 		P.mytarget = H

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -18,8 +18,6 @@
 	for(var/client/X in admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
-			if(X.prefs.sound & SOUND_ADMINHELP)
-				X << 'sound/effects/adminhelp.ogg'
 	to_chat(usr, "Your prayers have been received by the gods.")
 
 	feedback_add_details("admin_verb","PR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -18,7 +18,8 @@
 	for(var/client/X in admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
-
+			if(X.prefs.sound & SOUND_ADMINHELP)
+				X << 'sound/effects/adminhelp.ogg'
 	to_chat(usr, "Your prayers have been received by the gods.")
 
 	feedback_add_details("admin_verb","PR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
@@ -27,41 +28,46 @@
 /proc/Centcomm_announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "\blue <b><font color=orange>CENTCOMM: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]"
-
 	for(var/client/X in admins)
 		if(R_EVENT & X.holder.rights)
 			to_chat(X, msg)
+			if(X.prefs.sound & SOUND_ADMINHELP)
+				X << 'sound/effects/adminhelp.ogg'
 
 /proc/Syndicate_announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "\blue <b><font color='#DC143C'>SYNDICATE: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;SyndicateReply=\ref[Sender]'>REPLY</A>):</b> [msg]"
-
 	for(var/client/X in admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
+			if(X.prefs.sound & SOUND_ADMINHELP)
+				X << 'sound/effects/adminhelp.ogg'
 
 /proc/HONK_announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "\blue <b><font color=pink>HONK: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;HONKReply=\ref[Sender]'>RPLY</A>):</b> [msg]"
-
 	for(var/client/X in admins)
 		if(R_EVENT & X.holder.rights)
 			to_chat(X, msg)
+			if(X.prefs.sound & SOUND_ADMINHELP)
+				X << 'sound/effects/adminhelp.ogg'
 
 /proc/ERT_Announce(var/text , var/mob/Sender)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "\blue <b><font color=orange>ERT REQUEST: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;ErtReply=\ref[Sender]'>REPLY</A>):</b> [msg]"
-
 	for(var/client/X in admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
+			if(X.prefs.sound & SOUND_ADMINHELP)
+				X << 'sound/effects/adminhelp.ogg'
 
 /proc/Nuke_request(text , mob/Sender)
 	var/nuke_code = get_nuke_code()
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
 	msg = "<span class='adminnotice'><b><font color=orange>NUKE CODE REQUEST: </font>[key_name(Sender)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;CentcommReply=\ref[Sender]'>RPLY</A>):</b> [msg]</span>"
-
 	for(var/client/X in admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)
 			to_chat(X, "<span class='adminnotice'><b>The nuke code is [nuke_code].</b></span>")
+			if(X.prefs.sound & SOUND_ADMINHELP)
+				X << 'sound/effects/adminhelp.ogg'

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -260,9 +260,10 @@ var/list/alldepartments = list()
 	visible_message("[src] beeps, \"Message transmitted successfully.\"")
 
 
-/obj/machinery/photocopier/faxmachine/proc/message_admins(var/mob/sender, var/faxname, var/faxtype, var/obj/item/sent, font_colour="#006100")
-	var/msg = "\blue <b><font color='[font_colour]'>[faxname]: </font>[key_name(sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) ([admin_jump_link(sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[sender]'>BSA</A>) (<A HREF='?_src_=holder;BorgingFax=\ref[sender];originfax=\ref[src]'>BP</A>) (<a href='?_src_=holder;AdminFaxCreate=\ref[sender];originfax=\ref[src];faxtype=[faxtype];replyto=\ref[sent]'>REPLY</a>)</b>: Receiving '[sent.name]' via secure connection... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
-
+/obj/machinery/photocopier/faxmachine/proc/message_admins(var/mob/sender, var/faxname, var/faxtype, var/obj/item/sent, font_colour="#9A04D1")
+	var/msg = "\blue <b><font color='[font_colour]'>[faxname]: </font>[key_name(sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[sender]'>VV</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) ([admin_jump_link(sender, "holder")]) | REPLY: (<A HREF='?_src_=holder;CentcommReply=\ref[sender]'>RADIO</A>) (<a href='?_src_=holder;AdminFaxCreate=\ref[sender];originfax=\ref[src];faxtype=[faxtype];replyto=\ref[sent]'>FAX</a>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) | REJECT: (<A HREF='?_src_=holder;FaxReplyTemplate=\ref[sender];originfax=\ref[src]'>TEMPLATE</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[sender]'>BSA</A>) (<A HREF='?_src_=holder;EvilFax=\ref[sender];originfax=\ref[src]'>EVILFAX</A>) </b>: Receiving '[sent.name]' via secure connection... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
 	for(var/client/C in admins)
 		if(R_EVENT & C.holder.rights)
 			to_chat(C, msg)
+			if(C.prefs.sound & SOUND_ADMINHELP)
+				C << 'sound/effects/adminhelp.ogg'

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -261,7 +261,7 @@ var/list/alldepartments = list()
 
 
 /obj/machinery/photocopier/faxmachine/proc/message_admins(var/mob/sender, var/faxname, var/faxtype, var/obj/item/sent, font_colour="#006100")
-	var/msg = "\blue <b><font color='[font_colour]'>[faxname]: </font>[key_name(sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) ([admin_jump_link(sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[sender]'>BSA</A>) (<a href='?_src_=holder;AdminFaxCreate=\ref[sender];originfax=\ref[src];faxtype=[faxtype];replyto=\ref[sent]'>REPLY</a>)</b>: Receiving '[sent.name]' via secure connection... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
+	var/msg = "\blue <b><font color='[font_colour]'>[faxname]: </font>[key_name(sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) ([admin_jump_link(sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[sender]'>BSA</A>) (<A HREF='?_src_=holder;BorgingFax=\ref[sender];originfax=\ref[src]'>BP</A>) (<a href='?_src_=holder;AdminFaxCreate=\ref[sender];originfax=\ref[src];faxtype=[faxtype];replyto=\ref[sent]'>REPLY</a>)</b>: Receiving '[sent.name]' via secure connection... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
 
 	for(var/client/C in admins)
 		if(R_EVENT & C.holder.rights)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -674,35 +674,30 @@
 	return
 
 /obj/item/weapon/paper/evilfax/proc/evilpaper_specialaction(var/mob/living/carbon/target)
-	if (myeffect == "borging")
-		target.ForceContractDisease(new /datum/disease/transformation/robot(0))
-	else if (myeffect == "corgifying")
-		target.ForceContractDisease(new /datum/disease/transformation/corgi(0))
-	else if (myeffect == "explosive")
-		var/turf/simulated/floor/T = get_turf(target)
-		if (istype(T))
-			T.break_tile_to_plating()
-		var/obj/effect/stop/S
-		S = new /obj/effect/stop
-		S.victim = target
-		S.loc = target.loc
-		spawn(20)
-			qdel(S)
-		target.adjustBruteLoss(target.health)
-	else if (myeffect == "memetickillagent")
-		to_chat(target,"<span class='userdanger'>A series of bright lights flash across your vision: MEMETIC KILL AGENT YHWH-3 ACTIVATED</span>")
-		target.mutations.Add(NOCLONE)
-		target.adjustBrainLoss(125)
-	else if (myeffect == "honktumor")
-		if(!target.get_int_organ(/obj/item/organ/internal/honktumor))
-			new /obj/item/organ/internal/honktumor(target)
-	else if (myeffect == "demotion")
-		command_announcement.Announce("[mytarget] is hereby demoted to the rank of Civilian. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
-	else
-		message_admins("Evil paper [src] was activated without a proper effect set! This is a bug.")
-	used = 1
-	evilpaper_selfdestruct()
+	spawn(30)
+		if (istype(target,/mob/living/carbon))
+			if (myeffect == "borging")
+				target.ForceContractDisease(new /datum/disease/transformation/robot(0))
+			else if (myeffect == "corgifying")
+				target.ForceContractDisease(new /datum/disease/transformation/corgi(0))
+			else if (myeffect == "firedeath")
+				var/turf/simulated/T = get_turf(target)
+				new /obj/effect/hotspot(T)
+				target.adjustFireLoss(target.health)
+			else if (myeffect == "braindeath")
+				to_chat(target,"<span class='userdanger'>A series of bright lights flash across your vision: COGNITOHAZARD YHWH-3 ACTIVATED</span>")
+				target.mutations.Add(NOCLONE)
+				target.adjustBrainLoss(125)
+			else if (myeffect == "honktumor")
+				if(!target.get_int_organ(/obj/item/organ/internal/honktumor))
+					new /obj/item/organ/internal/honktumor(target)
+			else if (myeffect == "demotion")
+				command_announcement.Announce("[mytarget] is hereby demoted to the rank of Civilian. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
+			else
+				message_admins("Evil paper [src] was activated without a proper effect set! This is a bug.")
+		used = 1
+		evilpaper_selfdestruct()
 
 /obj/item/weapon/paper/evilfax/proc/evilpaper_selfdestruct()
-	visible_message("[src] spontaneously catches fire, and burns up!")
+	visible_message("<span class='danger'>[src] spontaneously catches fire, and burns up!</span>")
 	qdel(src)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -637,4 +637,4 @@
 			used = 1
 			..()
 	else
-		to_chat(user,"<span class='notice'>This page appears to be covered in some sort of bizzare code. Perhaps [borgtarget] can make sense of it.")
+		to_chat(user,"<span class='notice'>This page appears to be covered in some sort of bizzare code. Perhaps [borgtarget] can make sense of it.</span>")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -646,11 +646,11 @@
 
 /obj/item/weapon/paper/evilfax/New()
 	..()
-	processing_objects += src
+	processing_objects.Add(src)
 
 
 /obj/item/weapon/paper/evilfax/Destroy()
-	processing_objects -= src
+	processing_objects.Remove(src)
 	if(mytarget && !used)
 		var/mob/living/carbon/target = mytarget
 		target.ForceContractDisease(new /datum/disease/transformation/corgi(0))
@@ -658,7 +658,7 @@
 
 
 /obj/item/weapon/paper/evilfax/process()
-	if(countdown == 0)
+	if(!countdown)
 		if(mytarget)
 			if(activate_on_timeout)
 				evilpaper_specialaction(mytarget)
@@ -681,7 +681,7 @@
 			else if(myeffect == "firedeath")
 				var/turf/simulated/T = get_turf(target)
 				new /obj/effect/hotspot(T)
-				target.adjustFireLoss(target.health)
+				target.adjustFireLoss(150) // hard crit, the burning takes care of the rest.
 			else if(myeffect == "braindeath")
 				to_chat(target,"<span class='userdanger'>A series of bright lights flash across your vision: COGNITOHAZARD YHWH-3 ACTIVATED</span>")
 				target.mutations.Add(NOCLONE)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -629,8 +629,8 @@
 	var/activate_on_timeout = 0
 
 /obj/item/weapon/paper/evilfax/show_content(var/mob/user, var/forceshow = 0, var/forcestars = 0, var/infolinks = 0, var/view = 1)
-	if (user == mytarget)
-		if (istype(user, /mob/living/carbon))
+	if(user == mytarget)
+		if(istype(user, /mob/living/carbon))
 			var/mob/living/carbon/C = user
 			evilpaper_specialaction(C)
 			..()
@@ -638,7 +638,7 @@
 			// This should never happen, but just in case someone is adminbussing
 			evilpaper_selfdestruct()
 	else
-		if (mytarget)
+		if(mytarget)
 			to_chat(user,"<span class='notice'>This page appears to be covered in some sort of bizzare code. The only bit you recognize is the name of [mytarget]. Perhaps [mytarget] can make sense of it?</span>")
 		else
 			evilpaper_selfdestruct()
@@ -651,16 +651,16 @@
 
 /obj/item/weapon/paper/evilfax/Destroy()
 	processing_objects -= src
-	if (mytarget && !used)
+	if(mytarget && !used)
 		var/mob/living/carbon/target = mytarget
 		target.ForceContractDisease(new /datum/disease/transformation/corgi(0))
 	return ..()
 
 
 /obj/item/weapon/paper/evilfax/process()
-	if (countdown == 0)
-		if (mytarget)
-			if (activate_on_timeout)
+	if(countdown == 0)
+		if(mytarget)
+			if(activate_on_timeout)
 				evilpaper_specialaction(mytarget)
 			else
 				message_admins("[mytarget] ignored an evil fax until it timed out.")
@@ -673,24 +673,24 @@
 
 /obj/item/weapon/paper/evilfax/proc/evilpaper_specialaction(var/mob/living/carbon/target)
 	spawn(30)
-		if (istype(target,/mob/living/carbon))
-			if (myeffect == "borging")
+		if(istype(target,/mob/living/carbon))
+			if(myeffect == "borging")
 				target.ForceContractDisease(new /datum/disease/transformation/robot(0))
-			else if (myeffect == "corgifying")
+			else if(myeffect == "corgifying")
 				target.ForceContractDisease(new /datum/disease/transformation/corgi(0))
-			else if (myeffect == "firedeath")
+			else if(myeffect == "firedeath")
 				var/turf/simulated/T = get_turf(target)
 				new /obj/effect/hotspot(T)
 				target.adjustFireLoss(target.health)
-			else if (myeffect == "braindeath")
+			else if(myeffect == "braindeath")
 				to_chat(target,"<span class='userdanger'>A series of bright lights flash across your vision: COGNITOHAZARD YHWH-3 ACTIVATED</span>")
 				target.mutations.Add(NOCLONE)
 				target.adjustBrainLoss(125)
-			else if (myeffect == "honktumor")
+			else if(myeffect == "honktumor")
 				if(!target.get_int_organ(/obj/item/organ/internal/honktumor))
 					var/obj/item/organ/internal/organ = new /obj/item/organ/internal/honktumor
 					organ.insert(target)
-			else if (myeffect == "demotion")
+			else if(myeffect == "demotion")
 				command_announcement.Announce("[mytarget] is hereby demoted to the rank of Civilian. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
 			else
 				message_admins("Evil paper [src] was activated without a proper effect set! This is a bug.")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -618,3 +618,23 @@
 
 /obj/item/weapon/paper/crumpled/bloody
 	icon_state = "scrap_bloodied"
+
+/obj/item/weapon/paper/borging
+	name = "Centcomm Reply"
+	info = "<b>You're Fired.</b>"
+	var/borgtarget = null
+	var/used = 0
+
+/obj/item/weapon/paper/borging/show_content(var/mob/user, var/forceshow = 0, var/forcestars = 0, var/infolinks = 0, var/view = 1)
+	if (used)
+		to_chat(user,"<span class='danger'>The paper disintegrates in your hands!")
+		qdel(src)
+	else if (user == borgtarget)
+		if (istype(user, /mob/living/carbon))
+			var/mob/living/carbon/C = user
+			C.ForceContractDisease(new /datum/disease/transformation/robot(0))
+			to_chat(C,"<span class='danger'>The paper appears to be covered in red goo!")
+			used = 1
+			..()
+	else
+		to_chat(user,"<span class='notice'>This page appears to be covered in some sort of bizzare code. Perhaps [borgtarget] can make sense of it.")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -671,8 +671,6 @@
 	else
 		countdown--
 
-	return
-
 /obj/item/weapon/paper/evilfax/proc/evilpaper_specialaction(var/mob/living/carbon/target)
 	spawn(30)
 		if (istype(target,/mob/living/carbon))
@@ -690,7 +688,8 @@
 				target.adjustBrainLoss(125)
 			else if (myeffect == "honktumor")
 				if(!target.get_int_organ(/obj/item/organ/internal/honktumor))
-					new /obj/item/organ/internal/honktumor(target)
+					var/obj/item/organ/internal/organ = new /obj/item/organ/internal/honktumor
+					organ.insert(target)
 			else if (myeffect == "demotion")
 				command_announcement.Announce("[mytarget] is hereby demoted to the rank of Civilian. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
 			else


### PR DESCRIPTION
Goals:
1) Make it quicker and easier for admins to reply to faxes.
2) Give more feedback to players as to why faxes are ignored/rejected, guiding them towards creating better faxes.
3) Give admins more options for responding to buttfaxes, and other suicidal faxes.

Changes made:
1) Admins now hear a boink sound when faxed, just as we hear boinks when someone ahelps.
2) Admins can now reply to faxes via RADIO, which goes direct to the sender’s headset, and requires no formatting. This is *far* faster than having to compose a well-formatted reply fax.
3) Admins can now send one of several pre-written TEMPLATE responses to faxes. These templates are designed to cover common reasons that faxes are rejected, and educate the sender as to how to use the fax machine more effectively.
4) Finally, admins can now respond to the worst faxes with an EVILFAX. These are special faxes laden with demotion orders, explosive ink, honktumor spores, borgifying nanomachines, corgification viruses, or good old-fashioned  memetic kill agents. Only the intended recipient of these evil faxes can read them and suffer their effects.

Pre-written templates include:
1) A “handle it yourself” option, for situations where the faxer should be able to handle whatever it is by working with other crew, without admin intervention.
2) A “illegible” option, for situations where the fax is so horribly formatted/worded that we can’t decipher what the faxer is talking about.
3) A “not signed/stamped” option.
4) A “sorry, all resources are busy” option, for situations where the fax is legit, but for OOC reasons admins are not going to intervene.
5) A “stop wasting our time” option, for situations where someone is faxing about super-trivial matters, like an IAA faxing us about someone punching them in the bar.

:cl: Kyep
rscadd: Admins now hear boink sound when faxed, command sends ERT request, etc
rscadd: Admins can reply to faxes via radio
rscadd: Admins can reply to faxes with pre-written fax templates
rscadd: Admins can reply to faxes with 'evil faxes', special faxes that have negative effects on their intended recipient (and nobody else)
/:cl:
