### PR TITLE
Telsa Power Adjustments

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -92,10 +92,6 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 
 /obj/singularity/energy_ball/proc/handle_energy()
-	if(energy<=0)
-		investigate_log("collapsed.","singulo")
-		qdel(src)
-		return 0
 	if(energy >= energy_to_raise)
 		energy_to_lower = energy_to_raise - 20
 		energy_to_raise = energy_to_raise * 1.5
@@ -123,8 +119,6 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 	else if(orbiting_balls.len)
 		energy -= orbiting_balls.len * 0.5
-	else
-		energy -= 0.5
 	return 1
 
 /obj/singularity/energy_ball/Bump(atom/A)
@@ -152,7 +146,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 /proc/tesla_zap(var/atom/source, zap_range = 3, power)
 	. = source.dir
-	if(power < 1000)
+	if(power < 100)
 		return
 
 	var/closest_dist = 0
@@ -235,7 +229,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 		closest_grounding_rod.tesla_act(power)
 
 	else if(closest_mob)
-		var/shock_damage = Clamp(round(power/400), 10, 90) + rand(-5, 5)
+		var/shock_damage = Clamp(round(power/40), 10, 90) + rand(-5, 5)
 		closest_mob.electrocute_act(shock_damage, source, 1, tesla_shock = 1)
 		if(istype(closest_mob, /mob/living/silicon))
 			var/mob/living/silicon/S = closest_mob

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -88,6 +88,10 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 
 /obj/singularity/energy_ball/proc/handle_energy()
+	if(energy<=0)
+		investigate_log("collapsed.","singulo")
+		qdel(src)
+		return 0
 	if(energy >= energy_to_raise)
 		energy_to_lower = energy_to_raise - 20
 		energy_to_raise = energy_to_raise * 1.5
@@ -115,6 +119,9 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 	else if(orbiting_balls.len)
 		energy -= orbiting_balls.len * 0.5
+	else
+		energy -= 0.5
+	return 1
 
 /obj/singularity/energy_ball/Bump(atom/A)
 	dust_mobs(A)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -1,5 +1,5 @@
-#define TESLA_DEFAULT_POWER 1738260
-#define TESLA_MINI_POWER 869130
+#define TESLA_DEFAULT_POWER 173826
+#define TESLA_MINI_POWER 86913
 
 var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 										/obj/machinery/power/emitter,
@@ -31,7 +31,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 	density = 1
 	energy = 0
 	var/list/orbiting_balls = list()
-	var/produced_power
+	var/produced_power = 0
 	var/energy_to_raise = 32
 	var/energy_to_lower = -20
 
@@ -58,7 +58,11 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 		pixel_x = 0
 		pixel_y = 0
 
-		dir = tesla_zap(src, 7, TESLA_DEFAULT_POWER)
+		produced_power = TESLA_DEFAULT_POWER
+		for (var/ball in orbiting_balls)
+			produced_power += TESLA_MINI_POWER
+
+		dir = tesla_zap(src, 7, produced_power)
 
 		pixel_x = -32
 		pixel_y = -32

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -59,14 +59,14 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 		pixel_y = 0
 
 		produced_power = TESLA_DEFAULT_POWER
-		for (var/ball in orbiting_balls)
+		for(var/ball in orbiting_balls)
 			produced_power += TESLA_MINI_POWER
 
 		dir = tesla_zap(src, 7, produced_power)
 
 		pixel_x = -32
 		pixel_y = -32
-		for (var/ball in orbiting_balls)
+		for(var/ball in orbiting_balls)
 			tesla_zap(ball, rand(1, Clamp(orbiting_balls.len, 3, 7)), TESLA_MINI_POWER)
 	else
 		energy = 0 // ensure we dont have miniballs of miniballs


### PR DESCRIPTION
This reduces the amount of power generated from the tesla baselines by
one tenth. This also fixes a bug in tesla code where additional
miniballs do not increase the actual energy output of tesla.

This adjustment means that a base tesla engine, without energy balls,
will only generate 173,826 watts of power. Each energy ball increases
that generated power by 86,913 watts of power. A tesla with 13 miniballs
will produce roughly 1.3 million watts of power.

Current Paradise Live code gives the 1.7 million watts for the base
engine. Due to how the engine calculates additional power, additional
coils do not generate additional power, nor do miniballs, since all
calculations happen at the exact same time. However, that's still 1.7 million watts from the second the tesla activates, regardless of number of energy balls.

This makes it so additional energy balls still increases the number of
shocks that get shot off, but fixes the actual generation of power.

https://i.imgur.com/ruSTx05.png

Taking the 50,000 from the SMES into account on this network, you can see from before I increased the energy of the tesla (which optimizing containment to make it only get caught in the PA will allow levels even higher than 5,000), I was getting about 650,000 watts. That's about 5 or 6 energy miniballs. Once I increased it to 5,000 energy in the tesla (which is about 13 energy miniballs), I was getting around 1.3 million+ watts.

Notice: Until further reasons to add dissipation to tesla are added (such as making tesla more dangerous), dissipation has been removed.

:cl: Twinmold
Tweak: Lowers default power output for tesla and miniballs.
Tweak: Lowers the divisional factors of things to match the change in power levels for tesla, so that the actual effects from tesla (number of jumps, damage) are the same as before the change.
Fix: Makes it so additional miniballs actually give more power like they
are supposed to.
/:cl:

