### PR TITLE
Adds a Station Time different from the Current Time

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -26,9 +26,25 @@
 /proc/worldtime2text(time = world.time)
 	return "[round(time / 36000)+12]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
 
+/proc/shifttime2text(time = world.time)
+	return "[round(time / 36000)]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
+
+/proc/currenttime()
+	var/hours = round(world.timeofday/36000)
+	var/minutes = (world.timeofday / 600 % 60) < 10 ? add_zero(world.timeofday / 600 % 60, 1) : world.timeofday / 600 % 60
+	if(hours == 0)
+		return "[hours+12]:[minutes]am"
+	else if(hours < 12 && hours > 0)
+		return "[hours]:[minutes]am"
+	else if(hours == 12)
+		return "[hours]:[minutes]pm"
+	else
+		return "[hours-12]:[minutes]pm"
+
+
 /proc/time_stamp()
 	return time2text(world.timeofday, "hh:mm:ss")
-	
+
 /proc/gameTimestamp(format = "hh:mm:ss") // Get the game time in text
 	return time2text(world.time - timezoneOffset + 432000, format)
 
@@ -60,6 +76,6 @@ proc/isDay(var/month, var/day)
  */
 /proc/stop_watch(wh)
 	return round(0.1 * (TimeOfGame - wh), 0.1)
-	
+
 /proc/month2number(month)
 	return month_names.Find(month)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -976,7 +976,8 @@ var/list/slot_equipment_priority = list( \
 
 // this function displays the station time in the status panel
 /mob/proc/show_stat_station_time()
-	stat(null, "Station Time: [worldtime2text()]")
+	stat(null, "Current Time: [currenttime()]")
+	stat(null, "Shift Time: [shifttime2text()]")
 
 // this function displays the shuttles ETA in the status panel if the shuttle has been called
 /mob/proc/show_stat_emergency_shuttle_eta()


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: The station is no longer suspended in one point in time. Look at your watch!
/:cl:

Okay, this is something I've been considering for a while, but only now have gotten around to trying to code it. It was laughably easy to make work, thanks to @TheDZD.

There are now two times shown on the status tab. First one refers to GMT ~~+1~~ time of the REAL WORLD, but also the time of the ss13 universe. The second one shows you how much time there has been since the beginning of the shift.
Really not much of a functional change in any way, since nothing really depends on time on Paradise, but it will be applicable during RP.

![nobody reads this](https://i.gyazo.com/4092f0dad9e0fa0364ca1ba178c1557f.png)

I am 99% sure this doesn't break anything.

Also, considering all shifts begin at 12:03 with the current code this makes it absolutely possible to be correct about the current time being HIGH NOON.

![](http://66.media.tumblr.com/83eff6256387d72b9fae6a104fbf7208/tumblr_o54q8rYGFr1rokb0vo1_1280.png)

*I'm sorry*