### PR TITLE
Mimic Gun and Gun Fixes

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -31,9 +31,9 @@
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
 	desc = "[initial(desc)][BB ? "" : " This one is spent"]"
 
-/obj/item/ammo_casing/proc/newshot() //For energy weapons, shotgun shells and wands (!).
+/obj/item/ammo_casing/proc/newshot(params) //For energy weapons, shotgun shells and wands (!).
 	if (!BB)
-		BB = new projectile_type(src)
+		BB = new projectile_type(src, params)
 	return
 
 /obj/item/ammo_casing/attackby(obj/item/I as obj, mob/user as mob, params)

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -104,14 +104,16 @@
 
 /obj/item/ammo_casing/energy/temp
 	projectile_type = /obj/item/projectile/temp
-	var/temperature = 300
 	e_cost = 100
 	fire_sound = 'sound/weapons/pulse3.ogg'
 
-/obj/item/ammo_casing/energy/temp/newshot()
+/obj/item/ammo_casing/energy/temp/New()
 	..()
-	var/obj/item/projectile/temp/T = BB
-	T.temperature = temperature
+	BB = null
+
+/obj/item/ammo_casing/energy/temp/newshot(shot_temp, shot_cost)
+	e_cost = shot_cost
+	..(shot_temp)
 
 /obj/item/ammo_casing/energy/meteor
 	projectile_type = /obj/item/projectile/meteor
@@ -225,7 +227,21 @@
 	select_name = "teleport beam"
 	var/teleport_target
 
-/obj/item/ammo_casing/energy/teleport/newshot()
+/obj/item/ammo_casing/energy/teleport/New()
 	..()
-	var/obj/item/projectile/energy/teleport/T = BB
-	T.teleport_target = teleport_target
+	BB = null
+
+/obj/item/ammo_casing/energy/teleport/newshot(teleport_target)
+	..()
+
+/obj/item/ammo_casing/energy/mimic
+	projectile_type = /obj/item/projectile/mimic
+	fire_sound = 'sound/weapons/bite.ogg'
+	select_name = "gun mimic"
+
+/obj/item/ammo_casing/energy/mimic/New()
+	..()
+	BB = null
+
+/obj/item/ammo_casing/energy/mimic/newshot(mimic_type)
+	..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -161,7 +161,7 @@
 		return 0
 	return 1
 
-obj/item/weapon/gun/proc/newshot()
+obj/item/weapon/gun/proc/newshot(params)
 	return
 
 /obj/item/weapon/gun/proc/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params, zone_override)

--- a/code/modules/projectiles/guns/alien.dm
+++ b/code/modules/projectiles/guns/alien.dm
@@ -80,7 +80,7 @@
 	recoil = 1
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/sonic)
-	cell_type = "/obj/item/weapon/stock_parts/cell/super"
+	cell_type = /obj/item/weapon/stock_parts/cell/super
 	restricted_species = list("Vox Armalis")
 
 /obj/item/weapon/gun/energy/noisecannon/update_icon()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -80,13 +80,13 @@
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	return power_supply.charge >= shot.e_cost
 
-/obj/item/weapon/gun/energy/newshot()
+/obj/item/weapon/gun/energy/newshot(params)
 	if (!ammo_type || !power_supply)
 		return
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	if(power_supply.charge >= shot.e_cost) //if there's enough power in the power_supply cell...
 		chambered = shot //...prepare a new shot based on the current ammo type selected
-		chambered.newshot()
+		chambered.newshot(params)
 	return
 
 /obj/item/weapon/gun/energy/process_chamber()

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -8,7 +8,7 @@
 	flags =  CONDUCT
 	slot_flags = SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse, /obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser)
-	cell_type = "/obj/item/weapon/stock_parts/cell/pulse"
+	cell_type = /obj/item/weapon/stock_parts/cell/pulse
 
 /obj/item/weapon/gun/energy/pulse/emp_act(severity)
 	return
@@ -29,7 +29,7 @@
 	slot_flags = SLOT_BELT
 	icon_state = "pulse_carbine"
 	item_state = "pulse"
-	cell_type = "/obj/item/weapon/stock_parts/cell/pulse/carbine"
+	cell_type = /obj/item/weapon/stock_parts/cell/pulse/carbine
 	can_flashlight = 1
 	flight_x_offset = 18
 	flight_y_offset = 12
@@ -41,7 +41,7 @@
 	slot_flags = SLOT_BELT
 	icon_state = "pulse_pistol"
 	item_state = "gun"
-	cell_type = "/obj/item/weapon/stock_parts/cell/pulse/pistol"
+	cell_type = /obj/item/weapon/stock_parts/cell/pulse/pistol
 	can_charge = 0
 
 /obj/item/weapon/gun/energy/pulse/pistol/isHandgun()
@@ -50,7 +50,7 @@
 /obj/item/weapon/gun/energy/pulse/destroyer
 	name = "pulse destroyer"
 	desc = "A heavy-duty, pulse-based energy weapon."
-	cell_type = "/obj/item/weapon/stock_parts/cell/infinite"
+	cell_type = /obj/item/weapon/stock_parts/cell/infinite
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse)
 
 /obj/item/weapon/gun/energy/pulse/destroyer/attack_self(mob/living/user)
@@ -66,7 +66,7 @@
 	desc = "A compact pulse core in a classic handgun frame for Nanotrasen officers. It's not the size of the gun, it's the size of the hole it puts through people."
 	icon_state = "m1911"
 	item_state = "gun"
-	cell_type = "/obj/item/weapon/stock_parts/cell/infinite"
+	cell_type = /obj/item/weapon/stock_parts/cell/infinite
 
 /obj/item/weapon/gun/energy/pulse/pistol/m1911/isHandgun()
 	return 1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -62,7 +62,7 @@
 	item_state = "c20r"
 	w_class = 4
 	ammo_type = list(/obj/item/ammo_casing/energy/meteor)
-	cell_type = "/obj/item/weapon/stock_parts/cell/potato"
+	cell_type = /obj/item/weapon/stock_parts/cell/potato
 	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
 	selfcharge = 1
 
@@ -324,7 +324,7 @@
 	desc = "A machinegun that fires 3d-printed flachettes slowly regenerated using a cyborg's internal power source."
 	icon_state = "l6closed0"
 	icon = 'icons/obj/guns/projectile.dmi'
-	cell_type = "/obj/item/weapon/stock_parts/cell/secborg"
+	cell_type = /obj/item/weapon/stock_parts/cell/secborg
 	ammo_type = list(/obj/item/ammo_casing/energy/c3dbullet)
 	can_charge = 0
 
@@ -368,6 +368,7 @@
 	icon_state = "disabler"
 	ammo_type = list(/obj/item/ammo_casing/energy/clown)
 	clumsy_check = 0
+	ammo_x_offset = 3
 
 /obj/item/weapon/gun/energy/toxgun
 	name = "plasma pistol"
@@ -406,7 +407,7 @@
 	origin_tech = "combat=3;materials=4;powerstorage=3;magnets=2"
 
 	ammo_type = list(/obj/item/ammo_casing/energy/temp)
-	cell_type = "/obj/item/weapon/stock_parts/cell"
+	cell_type = /obj/item/weapon/stock_parts/cell
 
 	var/powercost = ""
 	var/powercostcolor = ""
@@ -425,11 +426,7 @@
 	return ..()
 
 /obj/item/weapon/gun/energy/temperature/newshot()
-	..()
-	var/obj/item/ammo_casing/energy/temp/T = chambered
-	if(T)
-		T.temperature = temperature
-		T.e_cost = e_cost
+	..(temperature, e_cost)
 
 /obj/item/weapon/gun/energy/temperature/attack_self(mob/living/user as mob)
 	user.set_machine(src)
@@ -572,3 +569,16 @@
 		if(2000 to 3000)			overlays += "200"
 		if(1000 to 2002)			overlays += "100"
 		if(-INFINITY to 1000)	overlays += "0"
+
+/obj/item/weapon/gun/energy/mimicgun
+	name = "mimic gun"
+	desc = "A self-defense weapon that exhausts organic targets, weakening them until they collapse. Why does this one have teeth?"
+	icon_state = "disabler"
+	ammo_type = list(/obj/item/ammo_casing/energy/mimic)
+	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
+	selfcharge = 1
+	ammo_x_offset = 3
+	var/mimic_type = /obj/item/weapon/gun/projectile/automatic/pistol //Setting this to the mimicgun type does exactly what you think it will.
+
+/obj/item/weapon/gun/energy/mimicgun/newshot()
+	..(mimic_type)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -5,7 +5,7 @@
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 3
-	cell_type = "/obj/item/weapon/stock_parts/cell/crap"
+	cell_type = /obj/item/weapon/stock_parts/cell/crap
 
 /obj/item/weapon/gun/energy/taser/mounted
 	name = "mounted taser gun"
@@ -16,7 +16,7 @@
 	name = "taser gun"
 	desc = "A small, low capacity gun used for non-lethal takedowns."
 	icon_state = "taser"
-	cell_type = "/obj/item/weapon/stock_parts/cell/secborg"
+	cell_type = /obj/item/weapon/stock_parts/cell/secborg
 
 /obj/item/weapon/gun/energy/disabler/cyborg/newshot()
 	..()

--- a/code/modules/projectiles/guns/energy/telegun.dm
+++ b/code/modules/projectiles/guns/energy/telegun.dm
@@ -6,7 +6,7 @@
 	icon_state = "telegun"
 	item_state = "ionrifle"
 	origin_tech = "combat=6;materials=7;powerstorage=5;bluespace=5;syndicate=4"
-	cell_type = "/obj/item/weapon/stock_parts/cell/crap"
+	cell_type = /obj/item/weapon/stock_parts/cell/crap
 	ammo_type = list(/obj/item/ammo_casing/energy/teleport)
 	shaded_charge = 1
 	var/teleport_target = null
@@ -38,6 +38,4 @@
 	teleport_target = L[desc]
 
 /obj/item/weapon/gun/energy/telegun/newshot()
-	..()
-	var/obj/item/ammo_casing/energy/teleport/T = chambered
-	T.teleport_target = teleport_target
+	..(teleport_target)

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -36,9 +36,9 @@
 /obj/item/weapon/gun/magic/can_shoot()
 	return charges
 
-/obj/item/weapon/gun/magic/newshot()
+/obj/item/weapon/gun/magic/newshot(params)
 	if (charges && chambered)
-		chambered.newshot()
+		chambered.newshot(params)
 	return
 
 /obj/item/weapon/gun/magic/process_chamber()

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -50,42 +50,44 @@
 	damage_type = BURN
 	nodamage = 1
 	flag = "energy"
-	var/temperature = null
+	var/temperature = 300
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
-/obj/item/projectile/temp/New()
-	spawn(1)
-		switch(temperature)
-			if(501 to INFINITY)
-				name = "searing beam"	//if emagged
-				icon_state = "temp_8"
-			if(400 to 500)
-				name = "burning beam"	//temp at which mobs start taking HEAT_DAMAGE_LEVEL_2
-				icon_state = "temp_7"
-			if(360 to 400)
-				name = "hot beam"		//temp at which mobs start taking HEAT_DAMAGE_LEVEL_1
-				icon_state = "temp_6"
-			if(335 to 360)
-				name = "warm beam"		//temp at which players get notified of their high body temp
-				icon_state = "temp_5"
-			if(295 to 335)
-				name = "ambient beam"
-				icon_state = "temp_4"
-			if(260 to 295)
-				name = "cool beam"		//temp at which players get notified of their low body temp
-				icon_state = "temp_3"
-			if(200 to 260)
-				name = "cold beam"		//temp at which mobs start taking COLD_DAMAGE_LEVEL_1
-				icon_state = "temp_2"
-			if(120 to 260)
-				name = "ice beam"		//temp at which mobs start taking COLD_DAMAGE_LEVEL_2
-				icon_state = "temp_1"
-			if(-INFINITY to 120)
-				name = "freeze beam"	//temp at which mobs start taking COLD_DAMAGE_LEVEL_3
-				icon_state = "temp_0"
-			else
-				name = "temperature beam"//failsafe
-				icon_state = "temp_4"
+/obj/item/projectile/temp/New(loc, shot_temp)
+	..(loc)
+	if(shot_temp)
+		temperature = shot_temp
+	switch(temperature)
+		if(501 to INFINITY)
+			name = "searing beam"	//if emagged
+			icon_state = "temp_8"
+		if(400 to 500)
+			name = "burning beam"	//temp at which mobs start taking HEAT_DAMAGE_LEVEL_2
+			icon_state = "temp_7"
+		if(360 to 400)
+			name = "hot beam"		//temp at which mobs start taking HEAT_DAMAGE_LEVEL_1
+			icon_state = "temp_6"
+		if(335 to 360)
+			name = "warm beam"		//temp at which players get notified of their high body temp
+			icon_state = "temp_5"
+		if(295 to 335)
+			name = "ambient beam"
+			icon_state = "temp_4"
+		if(260 to 295)
+			name = "cool beam"		//temp at which players get notified of their low body temp
+			icon_state = "temp_3"
+		if(200 to 260)
+			name = "cold beam"		//temp at which mobs start taking COLD_DAMAGE_LEVEL_1
+			icon_state = "temp_2"
+		if(120 to 260)
+			name = "ice beam"		//temp at which mobs start taking COLD_DAMAGE_LEVEL_2
+			icon_state = "temp_1"
+		if(-INFINITY to 120)
+			name = "freeze beam"	//temp at which mobs start taking COLD_DAMAGE_LEVEL_3
+			icon_state = "temp_0"
+		else
+			name = "temperature beam"//failsafe
+			icon_state = "temp_4"
 	..()
 
 
@@ -342,6 +344,11 @@ obj/item/projectile/kinetic/New()
 	nodamage = 1
 	var/teleport_target = null
 
+/obj/item/projectile/energy/teleport/New(loc, tele_target)
+	..(loc)
+	if(tele_target)
+		teleport_target = tele_target
+
 /obj/item/projectile/energy/teleport/on_hit(var/atom/target, var/blocked = 0)
 	if(isliving(target))
 		if(teleport_target)
@@ -382,3 +389,30 @@ obj/item/projectile/kinetic/New()
 	var/throwdir = get_dir(firer,target)
 	T.throw_at(get_edge_target_turf(target, throwdir),10,10)
 	return 1
+
+/obj/item/projectile/mimic
+	name = "googly-eyed gun"
+	hitsound = 'sound/weapons/genhit1.ogg'
+	damage = 0
+	nodamage = 1
+	damage_type = BURN
+	flag = "melee"
+	var/obj/item/weapon/gun/stored_gun
+
+/obj/item/projectile/mimic/New(loc, mimic_type)
+	..(loc)
+	if(mimic_type)
+		stored_gun = new mimic_type(src)
+		icon = stored_gun.icon
+		icon_state = stored_gun.icon_state
+		SpinAnimation(20, -1)
+
+/obj/item/projectile/mimic/on_hit(atom/target)
+	..()
+	var/turf/T = get_turf(src)
+	var/obj/item/weapon/gun/G = stored_gun
+	stored_gun = null
+	G.forceMove(T)
+	var/mob/living/simple_animal/hostile/mimic/copy/ranged/R = new /mob/living/simple_animal/hostile/mimic/copy/ranged(T, G, firer)
+	if(ismob(target))
+		R.target = target

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -405,6 +405,7 @@ obj/item/projectile/kinetic/New()
 		stored_gun = new mimic_type(src)
 		icon = stored_gun.icon
 		icon_state = stored_gun.icon_state
+		overlays = stored_gun.overlays
 		SpinAnimation(20, -1)
 
 /obj/item/projectile/mimic/on_hit(atom/target)


### PR DESCRIPTION
:cl:
add: Adds an adminbuse gun that fires gun mimics, you can varedit the gun's `mimic_type` var to any gun path, and it'll fire that gun as mimics. By default it fires stetchkin pistol mimics.
fix: Fixes minor issues caused by some guns having text paths for power cells.
fix: Fixes some runtimes and inconsistencies with the telegun and temperature gun.
/:cl: