### PR TITLE
Makes Clonepods and Slime Processors Suck

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -292,6 +292,15 @@
 
 //Grow clones to maturity then kick them out.  FREELOADERS
 /obj/machinery/clonepod/process()
+	var/show_message = 0
+	for(var/obj/item/weapon/reagent_containers/food/snacks/meat/meat in range(1, src))
+		if(meat)
+			qdel(meat)
+			biomass += 50
+			show_message = 1
+	if(show_message)
+		visible_message("[src] sucks in and processes the nearby biomass.")
+		show_message = 0
 
 	if(stat & NOPOWER) //Autoeject if power is lost
 		if (occupant)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -4,6 +4,7 @@
 //Potential replacement for genetics revives or something I dunno (?)
 
 #define CLONE_BIOMASS 150
+#define BIOMASS_MEAT_AMOUNT 50
 
 /obj/machinery/clonepod
 	anchored = 1
@@ -294,13 +295,11 @@
 /obj/machinery/clonepod/process()
 	var/show_message = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/meat/meat in range(1, src))
-		if(meat)
-			qdel(meat)
-			biomass += 50
-			show_message = 1
+		qdel(meat)
+		biomass += BIOMASS_MEAT_AMOUNT
+		show_message = 1
 	if(show_message)
-		visible_message("[src] sucks in and processes the nearby biomass.")
-		show_message = 0
+		visible_message("\The [src] sucks in and processes the nearby biomass.")
 
 	if(stat & NOPOWER) //Autoeject if power is lost
 		if (occupant)
@@ -382,7 +381,7 @@
 //Removing cloning pod biomass
 	else if (istype(W, /obj/item/weapon/reagent_containers/food/snacks/meat))
 		to_chat(user, "\blue \The [src] processes \the [W].")
-		biomass += 50
+		biomass += BIOMASS_MEAT_AMOUNT
 		user.drop_item()
 		qdel(W)
 		return

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -36,20 +36,19 @@
 	if(processing)
 		return
 	var/mob/living/carbon/slime/picked_slime
-	for(var/mob/living/carbon/slime/slime in range(1,src))
+	for(var/mob/living/carbon/slime/slime in range(1, src))
 		if(slime.loc == src)
 			continue
-		if(istype(slime, /mob/living/carbon/slime))
-			if(slime.stat)
-				picked_slime = slime
-				break
+		if(slime.stat)
+			picked_slime = slime
+			break
 	if(!picked_slime)
 		return
 	var/datum/food_processor_process/P = select_recipe(picked_slime)
 	if (!P)
 		return
 
-	visible_message("[picked_slime] is sucked into [src].")
+	visible_message("[picked_slime] is sucked into \the [src].")
 	picked_slime.forceMove(src)
 
 //RECIPE DATUMS

--- a/code/game/machinery/kitchen/processor.dm
+++ b/code/game/machinery/kitchen/processor.dm
@@ -29,6 +29,29 @@
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		rating_speed = M.rating
 
+/obj/machinery/processor/process()
+	..()
+	// The irony
+	// To be clear, if it's grinding, then it can't suck them up
+	if(processing)
+		return
+	var/mob/living/carbon/slime/picked_slime
+	for(var/mob/living/carbon/slime/slime in range(1,src))
+		if(slime.loc == src)
+			continue
+		if(istype(slime, /mob/living/carbon/slime))
+			if(slime.stat)
+				picked_slime = slime
+				break
+	if(!picked_slime)
+		return
+	var/datum/food_processor_process/P = select_recipe(picked_slime)
+	if (!P)
+		return
+
+	visible_message("[picked_slime] is sucked into [src].")
+	picked_slime.forceMove(src)
+
 //RECIPE DATUMS
 /datum/food_processor_process
 	var/input


### PR DESCRIPTION
Makes clonepods and and slime processors suck...well, more.

Slime processor comes from TG: https://github.com/tgstation/tgstation/pull/16773 @Iamgoofball 

- Clonepods will automatically suck in nearby meat, giving the cloner biomass+deleting the meat
- Slime Processors will automatically, one at a time, suck in dead slimes (you still have to manually start the processor, of course)

:cl: Fox McCloud
Add: Clonepods will automatically suck in nearby meat
Add: Slime processors will automatically suck in nearby dead slimes
/:cl: