### PR TITLE
Lockers are No Longer Safe from Lord Teslaloth's Fury

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -419,3 +419,8 @@
 				var/obj/structure/bigDelivery/BD = src.loc
 				BD.attack_hand(usr)
 			open()
+
+/obj/structure/closet/tesla_act(var/power)
+	..()
+	visible_message("<span class='danger'>[src] is blown apart by the bolt of electricity!</span>", "<span class='danger'>You hear a metallic screeching sound.</span>")
+	qdel(src)


### PR DESCRIPTION
In other words, tesla bolts can now destroy lockers, meaning you can't hide in lockers to avoid being horribly murdered by it. This PR should probably be considered a fix, but I know some people will get uppity about it, despite the fact that there are constant complaints about the Tesla being too safe.

:cl:
tweak: The Tesla engine has acquired a grudge for lockers, and will now smite any in its path.
/:cl: