### PR TITLE
Bug Fixes

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -3,6 +3,7 @@
 	desc = "A sturdy metal ladder."
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "ladder11"
+	anchored = 1
 	var/id = null
 	var/height = 0							//the 'height' of the ladder. higher numbers are considered physically higher
 	var/obj/structure/ladder/down = null	//the ladder below this one

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -63,8 +63,11 @@
 			return
 		var/obj/item/weapon/reagent_containers/RG = I
 		if(RG.is_open_container())
-			RG.reagents.add_reagent("toiletwater", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
-			to_chat(user, "<span class='notice'>You fill [RG] from [src]. Gross.</span>")
+			if(RG.reagents.total_volume >= RG.volume)
+				to_chat(user, "<span class='warning'>\The [RG] is full.</span>")
+			else
+				RG.reagents.add_reagent("toiletwater", min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
+				to_chat(user, "<span class='notice'>You fill [RG] from [src]. Gross.</span>")
 			return
 
 	if(istype(I, /obj/item/weapon/grab))

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -76,6 +76,10 @@
 
 /mob/proc/death(gibbed)
 
+	//Makes it so gib/dust/melt all unbuckle their victims from anything they may be buckled to to avoid breaking beds/chairs/etc
+	if(gibbed && buckled)
+		buckled.unbuckle_mob()
+
 	//Quick fix for corpses kept propped up in chairs. ~Z
 	drop_r_hand()
 	drop_l_hand()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -12,6 +12,8 @@
 	for(var/mob/dead/observer/M in following_mobs)
 		M.following = null
 	following_mobs = null
+	if(buckled)
+		buckled.unbuckle_mob()
 	return ..()
 
 /mob/New()


### PR DESCRIPTION
Fixes #4616
- All ladders are now anchored and cannot be dragged, including dive points.

Fixes #4663
- Trying to fill a full container from a toilet will inform you the container is full, and thus fail.

Fixes #4705
- Being gibbed/dusted/melted will unbuckle the victim prior to their gruesome fate, allowing their spirit freedom to no longer haunt* the buckles that bound their mortal form and render them unusable to their former comrades.
 - *Not guaranteed to result in decreased spectral activity near chairs,