### PR TITLE
Adds a Sysadmin Alt Title for the RD

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -17,6 +17,7 @@
 			            access_research, access_robotics, access_xenobiology, access_ai_upload,
 			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_minisat, access_maint_tunnels, access_mineral_storeroom)
 	minimal_player_age = 21
+	alt_titles = list("Sysadmin")
 
 	// All science-y guys get bonuses for maxing out their tech.
 	required_objectives=list(


### PR DESCRIPTION
Idea I had as an alternative to #4684. Not particularly attached to this idea, and generally heads don't have alt titles, but here it is anyway.