### PR TITLE
Vox raiders will now have Vox breath masks instead of the regular ones

### DIFF
--- a/code/modules/admin/verbs/vox_raiders.dm
+++ b/code/modules/admin/verbs/vox_raiders.dm
@@ -48,7 +48,7 @@ var/global/vox_tick = 1
 			equip_to_slot_or_del(new /obj/item/weapon/circular_saw(src), slot_l_store)
 			equip_to_slot_or_del(new /obj/item/weapon/gun/dartgun/vox/medical, slot_r_hand)
 
-	equip_to_slot_or_del(new /obj/item/clothing/mask/breath(src), slot_wear_mask)
+	equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vox(src), slot_wear_mask)
 	equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(src), slot_back)
 	equip_to_slot_or_del(new /obj/item/device/flashlight(src), slot_r_store)
 


### PR DESCRIPTION
You know, the Vox breath masks that Vox crew members use