### PR TITLE
Fixes Resisting Borers

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -33,7 +33,7 @@
 		return 0
 	return B.host.say_understands(other, speaking)
 
-/mob/living/captive_brain/resist_borer()
+/mob/living/captive_brain/resist()
 	var/mob/living/simple_animal/borer/B = loc
 
 	to_chat(src, "<span class='danger'>You begin doggedly resisting the parasite's control (this will take approximately sixty seconds).</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -588,9 +588,6 @@
 		visible_message("<span class='danger'>[src] resists!</span>")
 		return 1
 
-/mob/living/proc/resist_borer()
-	return
-
 /mob/living/proc/resist_buckle()
 	spawn(0)
 		resist_muzzle()


### PR DESCRIPTION
This changes the captive brain's resist connection back to resist() from
resist_borer() (an invalid verb). Makes it so you can once again resist
borers.

Reposted due to number of files adjusted from merging of conflicting
files and inconsistencies to prevent breaking other code.

:cl: Twinmold
Fix: You can once again resist borer control with the Resist verb.
/:cl: