### PR TITLE
Fixes Bee Briefcase killing traitors regularly

### DIFF
--- a/code/game/objects/items/weapons/bee_briefcase.dm
+++ b/code/game/objects/items/weapons/bee_briefcase.dm
@@ -27,7 +27,6 @@
 
 /obj/item/weapon/bee_briefcase/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/reagent_containers/syringe))
-
 		var/obj/item/weapon/reagent_containers/syringe/S = I
 		if(!bees_left)
 			to_chat(user, "<span class='warning'>The briefcase is empty, so there is no point in injecting something into it.</span>")
@@ -46,7 +45,6 @@
 						to_chat(user, "<span class='warning'>The buzzing inside the briefcase swells momentarily, then returns to normal. Guess it was too cramped...</span>")
 				S.reagents.clear_reagents()
 				S.update_icon()
-
 	else if(istype(I, /obj/item/weapon/plantspray))
 		var/obj/item/weapon/plantspray/PS = I
 		user.drop_item(PS)
@@ -56,7 +54,9 @@
 		qdel(PS)
 
 /obj/item/weapon/bee_briefcase/attack_self(mob/user as mob)
-	if(!bees_left)
+	if (!blood_list.len && user.mind && user.mind.special_role)
+		to_chat(user, "<span class='danger'>You must inject some of your blood into this briefcase, using a syringe, to train the bees not to attack you. Only then can the briefcase be opened.</span>")
+	else if(!bees_left)
 		to_chat(user, "<span class='danger'>The lack of all and any bees at this event has been somewhat of a let-down...</span>")
 		return
 	else

--- a/code/game/objects/items/weapons/bee_briefcase.dm
+++ b/code/game/objects/items/weapons/bee_briefcase.dm
@@ -2,6 +2,7 @@
 /obj/item/weapon/bee_briefcase
 	name = "briefcase"
 	desc = "This briefcase has easy-release clasps and smells vaguely of honey and blood..."
+	description_antag = "A briefcase filled with deadly bees, you should inject this with a syringe of your own blood before opening it."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "briefcase"
 	item_state = "briefcase"
@@ -54,9 +55,7 @@
 		qdel(PS)
 
 /obj/item/weapon/bee_briefcase/attack_self(mob/user as mob)
-	if (!blood_list.len && user.mind && user.mind.special_role)
-		to_chat(user, "<span class='danger'>You must inject some of your blood into this briefcase, using a syringe, to train the bees not to attack you. Only then can the briefcase be opened.</span>")
-	else if(!bees_left)
+	if(!bees_left)
 		to_chat(user, "<span class='danger'>The lack of all and any bees at this event has been somewhat of a let-down...</span>")
 		return
 	else


### PR DESCRIPTION
Prior to this PR, traitors double-clicking a bee briefcase without first injecting it with blood, will spawn 5 syndiebees that then immediately kill them. This might be fair for people who explicitly order the bee briefcase as botanists, and thus *hopefully* know how the bees work. It is definitely not fair, though, for the traitors who get the bee briefcase in surplus crates, bundles, etc. These traitors have no idea what the briefcase is, have probably never used it before (its botanist-only normally) and nothing about the briefcase itself tells them. They only find out when they go to open it, curiously... and die horribly as a result.

With this PR, traitors attempting to open the briefcase will get a warning about what they must do to open it safely. Non-antags won't get this warning - for them, opening it will still likely be fatal.

For traitors trying to open the briefcase without first training the bees, the warning is: "You must inject some of your blood into this briefcase, using a syringe, to train the bees not to attack you. Only then can the briefcase be opened."

:cl: Kyep
fix: Safeties added to Bee Briefcase, to prevent it accidentally killing traitors get it in bundles and crates.
/:cl: