### PR TITLE
Makes jump actually jump

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -410,13 +410,16 @@
 								"<span class='notice'>You hear the flexing of powerful muscles and suddenly a crash as a body hits the floor.</span>")
 			return 0
 		var/prevLayer = usr.layer
+		var/prevFlying = usr.flying
 		usr.layer = 9
 
+		usr.flying = 1
 		for(var/i=0, i<10, i++)
 			step(usr, usr.dir)
 			if(i < 5) usr.pixel_y += 8
 			else usr.pixel_y -= 8
 			sleep(1)
+		usr.flying = prevFlying
 
 		if (FAT in usr.mutations && prob(66))
 			usr.visible_message("\red <b>[usr.name]</b> crashes due to their heavy weight!")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -900,12 +900,9 @@
 		else if(ear_damage < 25)	//ear damage heals slowly under this threshold. otherwise you'll need earmuffs
 			ear_damage = max(ear_damage - 0.05, 0)
 
-
 		if(flying)
-			spawn()
-				animate(src, pixel_y = pixel_y + 5 , time = 10, loop = 1, easing = SINE_EASING)
-			spawn(10)
-				animate(src, pixel_y = pixel_y - 5, time = 10, loop = 1, easing = SINE_EASING)
+			animate(src, pixel_y = pixel_y + 5 , time = 10, loop = 1, easing = SINE_EASING)
+			animate(pixel_y = pixel_y - 5, time = 10, loop = 1, easing = SINE_EASING)
 
 		// If you're dirty, your gloves will become dirty, too.
 		if(gloves && germ_level > gloves.germ_level && prob(10))

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -905,8 +905,7 @@
 			spawn()
 				animate(src, pixel_y = pixel_y + 5 , time = 10, loop = 1, easing = SINE_EASING)
 			spawn(10)
-				if(flying)
-					animate(src, pixel_y = pixel_y - 5, time = 10, loop = 1, easing = SINE_EASING)
+				animate(src, pixel_y = pixel_y - 5, time = 10, loop = 1, easing = SINE_EASING)
 
 		// If you're dirty, your gloves will become dirty, too.
 		if(gloves && germ_level > gloves.germ_level && prob(10))


### PR DESCRIPTION
fixes #4707
sets flying to 1 for the duration of the jump. Means you can jump over
anything you can fly over.

Also fixes a bug with flying that could leave you visually floating
(pixel_y = 5) when you stop flying

:cl: VampyrBytes
add: Leap genetics ability lets you jump over things
/ :cl: 