### PR TITLE
Makes cryo tube, sleeper, and body scanner eject dropped items

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -520,15 +520,17 @@
 /obj/machinery/sleeper/proc/go_out()
 	if(filtering)
 		toggle_filter()
-	if(!src.occupant)
+	if(!occupant)
 		return
-	if(src.occupant.client)
-		src.occupant.client.eye = src.occupant.client.mob
-		src.occupant.client.perspective = MOB_PERSPECTIVE
-	src.occupant.forceMove(src.loc)
-	src.occupant = null
+	if(occupant.client)
+		occupant.client.eye = occupant.client.mob
+		occupant.client.perspective = MOB_PERSPECTIVE
+	occupant.forceMove(loc)
+	occupant = null
 	icon_state = "sleeper-open"
-	return
+	// eject trash the occupant dropped
+	for(var/atom/movable/A in contents - component_parts - list(beaker))
+		A.forceMove(loc)
 
 /obj/machinery/sleeper/proc/inject_chemical(mob/living/user as mob, chemical, amount)
 	if (!(chemical in injection_chems))

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -157,15 +157,17 @@
 	add_fingerprint(usr)
 
 /obj/machinery/bodyscanner/proc/go_out()
-	if ((!( src.occupant ) || src.locked))
+	if(!occupant || locked)
 		return
-	if (src.occupant.client)
-		src.occupant.client.eye = src.occupant.client.mob
-		src.occupant.client.perspective = MOB_PERSPECTIVE
-	src.occupant.loc = src.loc
-	src.occupant = null
-	src.icon_state = "body_scanner_0"
-	return
+	if(occupant.client)
+		occupant.client.eye = occupant.client.mob
+		occupant.client.perspective = MOB_PERSPECTIVE
+	occupant.forceMove(loc)
+	occupant = null
+	icon_state = "body_scanner_0"
+	// eject trash the occupant dropped
+	for(var/atom/movable/A in contents - component_parts)
+		A.forceMove(loc)
 
 /obj/machinery/bodyscanner/ex_act(severity)
 	switch(severity)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -411,9 +411,9 @@
 	air_update_turf()
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/go_out()
-	if(!( occupant ))
+	if(!occupant)
 		return
-	if (occupant.client)
+	if(occupant.client)
 		occupant.client.eye = occupant.client.mob
 		occupant.client.perspective = MOB_PERSPECTIVE
 	occupant.forceMove(get_step(loc, SOUTH))	//this doesn't account for walls or anything, but i don't forsee that being a problem.
@@ -421,7 +421,10 @@
 		occupant.bodytemperature = 261
 	occupant = null
 	update_icon()
-	return
+	// eject trash the occupant dropped
+	for(var/atom/movable/A in contents - component_parts - list(beaker))
+		A.forceMove(get_step(loc, SOUTH))
+
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M as mob)
 	if (!istype(M))
 		to_chat(usr, "\red <B>The cryo cell cannot handle such a lifeform!</B>")


### PR DESCRIPTION
Fixes #4701 

:cl:
bugfix: Cryo tubes, sleepers, and body scanners now eject random items the occupant dropped, upon the occupant being ejected.
/:cl: