### PR TITLE
Adds /obj to load in map templates in away missions, etc

### DIFF
--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -61,7 +61,7 @@
 
 
 /proc/preloadTemplates(path = "_maps/map_files/templates/") //see master controller setup
-	var/list/filelist = flist(path)
-	for(var/map in filelist)
-		var/datum/map_template/T = new(path = "[path][map]", rename = "[map]")
-		map_templates[T.name] = T
+	for(var/map in flist(path))
+		if(cmptext(copytext(map, length(map) - 3), ".dmm"))
+			var/datum/map_template/T = new(path = "[path][map]", rename = "[map]")
+			map_templates[T.name] = T

--- a/code/modules/awaymissions/map_rng.dm
+++ b/code/modules/awaymissions/map_rng.dm
@@ -1,0 +1,38 @@
+/obj/effect/landmark/map_loader
+	name = "map loader"
+	icon = 'icons/mob/screen_gen.dmi'
+	icon_state = "x2"
+	invisibility = 101
+	anchored = 1
+	density = 0
+	opacity = 0
+	var/template_name = null
+	var/datum/map_template/template = null
+	var/centered = 1
+
+/obj/effect/landmark/map_loader/New(loc, tname)
+	..()
+	if(tname)
+		template_name = tname
+	if(template_name)
+		template = map_templates[template_name]
+	if(template)
+		load(template)
+
+/obj/effect/landmark/map_loader/proc/load(datum/map_template/t)
+	spawn(1)
+		if(!t)
+			return
+		t.load(get_turf(src), centered = centered)
+		t.loaded++
+		qdel(src)
+
+/obj/effect/landmark/map_loader/random
+	var/template_list = ""
+
+/obj/effect/landmark/map_loader/random/New()
+	..()
+	if(template_list)
+		template_name = safepick(splittext(template_list, ";"))
+		template = map_templates[template_name]
+		load(template)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1093,6 +1093,7 @@
 #include "code\modules\awaymissions\exile.dm"
 #include "code\modules\awaymissions\gateway.dm"
 #include "code\modules\awaymissions\loot.dm"
+#include "code\modules\awaymissions\map_rng.dm"
 #include "code\modules\awaymissions\pamphlet.dm"
 #include "code\modules\awaymissions\trigger.dm"
 #include "code\modules\awaymissions\zlevel.dm"


### PR DESCRIPTION
- This was generic enough that I'm splitting it out of my hotel PR.
- Can be immediately used to...
 - Load a predetermined template by placing a `/obj/effect/landmark/map_loader` and setting `template_name` to the name. Place in the center of where the template will be, set `centered` to `0` and put at the bottom-left.
 - Or in the form of `/obj/effect/landmark/map_loader/random` where you set `template_list` to a `;` seperated list of map template names for it to choose from. The behavior of `centered` still applies, and is more critical, if you want to control what happens for different sized templates.
- Also template loader bugfix for folders in the template folder.