### PR TITLE
Emote Fixes and "Me" Tweak

### DIFF
--- a/code/datums/Emote_system/emote.dm
+++ b/code/datums/Emote_system/emote.dm
@@ -281,7 +281,7 @@ VampyrBytes
 		var/end = start + lentext(startText) + 1
 		message = copytext(message, 1, start) + copytext(message, end, lentext(message) + 1)
 
-	message = replaceMobWithYou(user, message)
+	message = replaceMobWithYou(user, message, user)
 
 	return message
 
@@ -298,21 +298,21 @@ VampyrBytes
 		visualOrAudible = 1
 
 	log_emote("[user.name]/[user.key] : [message]")
-	sendToDead(message)
+	sendToDead(user, message)
 	for(var/mob/M in getRecipients(getLoc(user, message), visualOrAudible))
 		var/msg = ""
 
 		if(M==user)
 			msg = createSelfMessage(user, params, message)
 			if(msg)
-				outputMessage(M, msg)
+				outputMessage(M, msg, user)
 				continue
 
 		if(M.stat == UNCONSCIOUS || (M.sleeping && M.stat != DEAD))
 			if(!visualOrAudible == 2)
 				continue
 			msg = "<span class='italics'>... You can almost hear someone talking ...</span>"
-			outputMessage(M, msg)
+			outputMessage(M, msg, user)
 			continue
 
 		if(M.sdisabilities & DEAF || M.ear_deaf)
@@ -325,7 +325,7 @@ VampyrBytes
 			if(!msg && visualOrAudible == 2)
 				continue
 			if(msg)
-				outputMessage(M, msg)
+				outputMessage(M, msg, user)
 				continue
 
 		if(M.sdisabilities & BLIND || M.blinded || M.paralysis || (M.see_invisible < user.invisibility && visualOrAudible == 2))
@@ -336,7 +336,7 @@ VampyrBytes
 			if(!msg && visualOrAudible == 1)
 				continue
 			if(msg)
-				outputMessage(M, msg)
+				outputMessage(M, msg, user)
 				continue
 
 		if(M.see_invisible < user.invisibility && visualOrAudible == 1)
@@ -406,12 +406,15 @@ VampyrBytes
 	message = addExtras(message)
 	return message
 
-/datum/emote/proc/sendToDead(var/message = "")
+/datum/emote/proc/sendToDead(var/mob/user, var/message = "", var/ghostEmote)
 	for(var/mob/M in dead_mob_list)
 		if(!M.client || istype(M, /mob/new_player))
 			continue //skip monkeys, leavers and new players
-		if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
-			M.show_message(message)
+		if(M.stat == DEAD)
+			if(ghostEmote && ((M.client.prefs.toggles & CHAT_GHOSTSIGHT) || (M in viewers(user))))
+				M.show_message(message)
+			else if((M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(user)))
+				M.show_message(message)
 
 /datum/emote/proc/playSound(var/mob/user, var/list/params)
 	if(!sound)
@@ -534,10 +537,10 @@ one is used in /datum/emote_handler/customEmote().
 /datum/emote/custom/proc/getMessage(var/mob/user)
 //	user.set_typing_indicator(1)
 //	user.hud_typing = 1
-	var/input = sanitize(copytext(input(user,"What do you want to emote?.", "Custom emote") as text|null,1,MAX_MESSAGE_LEN))
+	var/input = copytext(input(user,"What do you want to emote?", "Custom emote") as text|null,1,MAX_MESSAGE_LEN)
 //	user.hud_typing = 0
 //	user.set_typing_indicator(0)
-	input = strip_html_properly(input)
+	input = trim_strip_html_properly(input)
 	return input
 
 /datum/emote/custom/available(var/mob/user)
@@ -572,13 +575,13 @@ one is used in /datum/emote_handler/customEmote().
 			return "deadchat is globally muted"
 
 /datum/emote/custom/ghost/getMessage(var/mob/user)
-	var/input = sanitize(copytext(input(user,"What do you want to emote?.", "Custom emote") as text|null,1,MAX_MESSAGE_LEN))
-	input = strip_html_properly(input)
+	var/input = copytext(input(user,"What do you want to emote?", "Custom emote") as text|null,1,MAX_MESSAGE_LEN)
+	input = trim_strip_html_properly(input)
 	return input
 
 /datum/emote/custom/ghost/processMessage(var/mob/user, var/list/params, var/message = "")
 	if(!message)
 		return
 	log_emote("Ghost/[user.key] : [message]")
-	sendToDead(message)
+	sendToDead(user, message, ghostEmote = 1)
 

--- a/code/datums/Emote_system/emotes.dm
+++ b/code/datums/Emote_system/emotes.dm
@@ -594,7 +594,7 @@
 
 /datum/emote/flip/flipOver/doAction(var/mob/user, var/params, var/message)
 	var/obj/item/weapon/grab/G = user.get_active_hand()
-	if(G == params["target"])
+	if(istype(G) && (G.affecting == params["target"]) && !G.affecting.buckled)
 		var/turf/oldloc = user.loc
 		var/turf/newloc = G.affecting.loc
 		if(isturf(oldloc) && isturf(newloc))
@@ -1150,11 +1150,28 @@
 	name = "scream"
 	desc = "makes the mob scream"
 	commands = list("scream", "screams")
+	text = "screams!"
+	selfText = "scream!"
 	audible = 1
 	mimeText = "acts out a scream"
 	muzzledNoise = "very loud"
 	cooldown = 50
 	vol = 80
+
+/datum/emote/scream/createMessage(var/mob/user, var/list/params)
+	var/mob/living/carbon/human/H = user
+
+	if(istype(H))
+		return "<span class='[userSpanClass]'>\The [user]</span> [H.species.scream_verb]!"
+	else
+		return ..()
+
+/datum/emote/scream/replaceMobWithYou(var/mob/M, var/message = "", var/mob/user)
+	var/mob/living/carbon/human/H = user
+
+	if(istype(H) && (H.species.scream_verb != "screams"))
+		return message
+	return ..()
 
 /datum/emote/scream/machine
 	name = "machine scream"

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -28,12 +28,21 @@
 	usr.say(message)
 
 
-/mob/verb/me_verb()
+/mob/verb/me_verb(message as text)
 	set name = "Me"
 	set category = "Emotes"
+	set desc = "(action) Enter a custom emote."
+
+	if(!message)
+		return
+
+	message = trim_strip_html_properly(message)
+
+	if(message == "")
+		return
 
 	if(emoteHandler)
-		return emoteHandler.runEmote("me")
+		return emoteHandler.runEmote("me", message)
 
 
 /mob/proc/say_dead(var/message)


### PR DESCRIPTION
Some preemptive fixes for @VampyrBytes' new datumized emotes, which haven't yet hit the live server.

Also, this tweaks the "Me" verb so you can include the message directly in the chat box, rather than having to use `say "*me` or an input box. Efficiency!

- Tweaks "Me" verb to allow inclusion of the message when typing directly into chat box.
- Fixes ghosts, with ghostsight on, seeing emotes twice when near the emoter.
- Fixes *flip runtiming when used with no target and no grab.
- Fixes scream not displaying any message.
  - Non-standard screamers (monkeys and Vox) will see the same message others see instead of "You scream!", since I'm not gonna add an extra var for custom scream selftext.
- Fixes double sanitizing in custom emotes.
- Fixes several cases where `user` wasn't getting passed into proc calls.
  - It took me way too long to notice this was screwing up the scream fix.
  - Also, I'm pretty sure the Johnny emote's selftext wasn't working right before this.
- Removes a couple unnecessary periods from dialogs.