### PR TITLE
Fixes Clumsy Gun Check

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -140,7 +140,7 @@
 	//Exclude lasertag guns from the CLUMSY check.
 	if(clumsy_check)
 		if(istype(user))
-			if (user.disabilities & CLUMSY && prob(40))
+			if((CLUMSY in user.mutations) && prob(40))
 				to_chat(user, "<span class='userdanger'>You shoot yourself in the foot with \the [src]!</span>")
 				var/shot_leg = pick("l_foot", "r_foot")
 				process_fire(user, user, 0, params, zone_override = shot_leg)


### PR DESCRIPTION

Fixes clumsy check on guns not working properly, resulting in people with glasses shooting themselves in the foot

:cl: Fox McCloud
fix: Fixes clumsy check on guns not working properly, resulting in people with glasses shooting themselves in the foot
/:cl: