### PR TITLE
Actually fix the travis linux grep

### DIFF
--- a/dm.sh
+++ b/dm.sh
@@ -70,7 +70,7 @@ then
 	
 	"$dm" $dmepath.mdme 2>&1 | tee result.log
 	retval=$?
-	if ! grep '0 errors, 0 warnings' result.log
+	if ! grep '\- 0 errors, 0 warnings' result.log
 	then
 		retval=1 #hard fail, due to warnings or errors
 	fi


### PR DESCRIPTION
I don't know how I missed that there are two paths, but this brings the linux grep regex inline with the windows grep regex.

Previous: #4575