### PR TITLE
Species based min and max age

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -21,6 +21,8 @@
 #define AGE_MIN 17			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 
+#define AGE_MIN_E 0			//youngest a character with no age restriction (i.e. dionae, machine people, and grey) can be
+#define AGE_MAX_E 99		//oldest a character with no age restriction can be
 
 #define LEFT 1
 #define RIGHT 2

--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -21,8 +21,8 @@
 #define AGE_MIN 17			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 
-#define AGE_MIN_E 0			//youngest a character with no age restriction (i.e. dionae, machine people, and grey) can be
-#define AGE_MAX_E 99		//oldest a character with no age restriction can be
+#define AGE_MIN_E 1			//youngest a character with no age restriction (i.e. dionae, machine people, and grey) can be
+#define AGE_MAX_E 150		//oldest a character with no age restriction can be
 
 #define LEFT 1
 #define RIGHT 2

--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -21,7 +21,7 @@
 #define AGE_MIN 17			//youngest a character can be
 #define AGE_MAX 85			//oldest a character can be
 
-#define AGE_MIN_E 1			//youngest a character with no age restriction (i.e. dionae, machine people, and grey) can be
+#define AGE_MIN_E 0			//youngest a character with no age restriction (i.e. dionae, machine people, and grey) can be
 #define AGE_MAX_E 150		//oldest a character with no age restriction can be
 
 #define LEFT 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1036,9 +1036,14 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
 				if("age")
-					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
-					if(new_age)
-						age = max(min(round(text2num(new_age)), AGE_MAX),AGE_MIN)
+					if(species in list("Machine", "Diona", "Grey"))
+						var/new_age = input(user, "Choose your character's age:\n(No limit)", "Character Preference") as num|null
+						if(new_age)
+							age = max(min(round(text2num(new_age)), AGE_MAX_E),AGE_MIN_E)
+					else
+						var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
+						if(new_age)
+							age = max(min(round(text2num(new_age)), AGE_MAX),AGE_MIN)
 				if("species")
 
 					var/list/new_species = list("Human", "Tajaran", "Skrell", "Unathi", "Diona", "Vulpkanin")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1036,14 +1036,14 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
 				if("age")
+					var/min = AGE_MIN
+					var/max = AGE_MAX
 					if(species in list("Machine", "Diona", "Grey"))
-						var/new_age = input(user, "Choose your character's age:\n([AGE_MIN_E]-[AGE_MAX_E])", "Character Preference") as num|null
-						if(new_age)
-							age = max(min(round(text2num(new_age)), AGE_MAX_E),AGE_MIN_E)
-					else
-						var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
-						if(new_age)
-							age = max(min(round(text2num(new_age)), AGE_MAX),AGE_MIN)
+						min = AGE_MIN_E
+						max = AGE_MAX_E
+					var/new_age = input(user, "Choose your character's age:\n([min]-[max])", "Character Preference") as num|null
+					if(new_age)
+						age = max(min(round(text2num(new_age)), max),min)
 				if("species")
 
 					var/list/new_species = list("Human", "Tajaran", "Skrell", "Unathi", "Diona", "Vulpkanin")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1037,7 +1037,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 				if("age")
 					if(species in list("Machine", "Diona", "Grey"))
-						var/new_age = input(user, "Choose your character's age:\n(No limit)", "Character Preference") as num|null
+						var/new_age = input(user, "Choose your character's age:\n([AGE_MIN_E]-[AGE_MAX_E])", "Character Preference") as num|null
 						if(new_age)
 							age = max(min(round(text2num(new_age)), AGE_MAX_E),AGE_MIN_E)
 					else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1997,7 +1997,7 @@
 	return ..()
 
 /mob/living/carbon/human/proc/get_age_pitch()
-	return 1.0 + 0.5*(30 - age)/80
+	return 1.0 + 0.5*(30 - max(min(age, 85),18))/80
 
 /mob/living/carbon/human/get_access()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1997,7 +1997,7 @@
 	return ..()
 
 /mob/living/carbon/human/proc/get_age_pitch()
-	return 1.0 + 0.5*(30 - max(min(age, 85),18))/80
+	return 1.0 + 0.5*(30 - max(min(age, 85),17))/80
 
 /mob/living/carbon/human/get_access()
 	. = ..()


### PR DESCRIPTION
Machines, Grey, and Dionae can now be anywhere from 0 to 150 years old. All other species still have the normal 17 to 85 restriction.
Ages are rounded down to 85 and up to 17 when calculating the pitch of screams. In case I just completely failed to write a coherent sentence, a 1-16 year old person will have the same scream as a 17 year old, and a 86-150 year old will have the same scream as an 85 year old person.
I would like for min and max age to be depended on something like a var in /datum/species, but that doesn't seem to be possible.

:cl:
tweak: IPCs, Grey, and Dionae can now be between 0-150 years old.
/:cl: