### PR TITLE
Fixes the contract and blood bottle only refunding for 1 point

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -490,14 +490,14 @@
 		else
 			to_chat(user, "<span class='notice'>You feed the contract back into the spellbook, refunding your points.</span>")
 
-			uses++
+			uses+=2
 
 			qdel(O)
 
 	if(istype(O, /obj/item/weapon/antag_spawner/slaughter_demon))
 		to_chat(user, "<span class='notice'>On second thought, maybe summoning a demon is a bad idea. You refund your points.</span>")
 
-		uses++
+		uses+=2
 		for(var/datum/spellbook_entry/item/bloodbottle/BB in entries)
 			if(!isnull(BB.limit))
 				BB.limit++


### PR DESCRIPTION
The apprenticeship contract and blood bottle cost 2 points, but you only
get 1 point when feeding them back into your spellbook.