### PR TITLE
Allow silicons to shift-click to examine

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -131,7 +131,7 @@
 		Topic(src, list("src"= "\ref[src]", "command"="emergency", "activate" = "0"), 1)
 	return
 
-/atom/proc/AIShiftClick()
+/atom/proc/AIShiftClick(var/mob/user)
 	if(user.client)
 		user.examinate(src)
 	return

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -132,6 +132,8 @@
 	return
 
 /atom/proc/AIShiftClick()
+	if(user.client)
+		user.examinate(src)
 	return
 
 /obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -139,7 +139,7 @@
 /obj/machinery/door/airlock/BorgAltShiftClick()  // Enables emergency override on doors! Forwards to AI code.
 	AIAltShiftClick()
 
-/atom/proc/BorgShiftClick()
+/atom/proc/BorgShiftClick(var/mob/user)
 	if(user.client && user.client.eye == user)
 		user.examinate(src)
 	return

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -140,6 +140,8 @@
 	AIAltShiftClick()
 
 /atom/proc/BorgShiftClick()
+	if(user.client && user.client.eye == user)
+		user.examinate(src)
 	return
 
 /obj/machinery/door/airlock/BorgShiftClick()  // Opens and closes doors! Forwards to AI code.


### PR DESCRIPTION
:cl: monster860
rscadd: You can now shift-click to examine as silicon, instead of ctrl-shift-clicking, which is something absolutely no one would guess.
/:cl: