### PR TITLE
Organs Start With Species, Fixes Limb Attachment Runtime

### DIFF
--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -95,6 +95,11 @@
 	E.replaced(target)
 	E.forceMove(target)
 	if(target.get_species() == "Machine")//as this is the only step needed for ipc put togethers
+		if(!(E.dna) && E.robotic == 2 && target.dna)
+			E.dna = target.dna.Clone()
+			if(!E.blood_DNA)
+				E.blood_DNA = list()
+			E.blood_DNA[target.dna.unique_enzymes] = target.dna.b_type
 		if(target_zone == "head")
 			var/obj/item/organ/external/head/H = target.get_organ("head")
 			var/datum/robolimb/robohead = all_robolimbs[H.model]

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -22,7 +22,7 @@ var/list/organ_cache = list()
 									  // links chemical IDs to number of ticks for which they'll stay in the blood
 	germ_level = 0
 	var/datum/dna/dna
-	var/datum/species/species
+	var/datum/species/species = "Human"
 
 	// Stuff for tracking if this is on a tile with an open freezer or not
 	var/last_freezer_update_time = 0
@@ -53,6 +53,9 @@ var/list/organ_cache = list()
 				if(!blood_DNA)
 					blood_DNA = list()
 				blood_DNA[dna.unique_enzymes] = dna.b_type
+	else
+		if(istext(species))
+			species = all_species[species]
 
 /obj/item/organ/proc/set_dna(var/datum/dna/new_dna)
 	if(new_dna)

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -112,18 +112,18 @@ var/global/list/limb_icon_cache = list()
 	return mob_icon
 
 /obj/item/organ/external/proc/get_icon(var/skeletal)
-
 	var/gender
+	if(istext(species))
+		species = all_species[species]
 	if(force_icon)
 		mob_icon = new /icon(force_icon, "[icon_name]")
-		if(species && species.name == "Machine")	//snowflake for IPC's, sorry.
+		if(species && species.name == "Machine") //snowflake for IPC's, sorry.
 			if(s_col && s_col.len >= 3)
 				mob_icon.Blend(rgb(s_col[1], s_col[2], s_col[3]), ICON_ADD)
 	else
 		if(!dna)
 			mob_icon = new /icon('icons/mob/human_races/r_human.dmi', "[icon_name][gendered_icon ? "_f" : ""]")
 		else
-
 			if(gendered_icon)
 				if(dna.GetUIState(DNA_UI_GENDER))
 					gender = "f"

--- a/code/modules/surgery/organs/subtypes/diona.dm
+++ b/code/modules/surgery/organs/subtypes/diona.dm
@@ -25,6 +25,7 @@
 	amputation_point = "trunk"
 	encased = null
 	gendered_icon = 0
+	species = "Diona"
 
 /obj/item/organ/external/groin/diona
 	name = "fork"
@@ -32,6 +33,7 @@
 	cannot_break = 1
 	amputation_point = "lower trunk"
 	gendered_icon = 0
+	species = "Diona"
 
 /obj/item/organ/external/arm/diona
 	name = "left upper tendril"
@@ -39,6 +41,7 @@
 	min_broken_damage = 20
 	cannot_break = 1
 	amputation_point = "upper left trunk"
+	species = "Diona"
 
 /obj/item/organ/external/arm/right/diona
 	name = "right upper tendril"
@@ -46,6 +49,7 @@
 	min_broken_damage = 20
 	cannot_break = 1
 	amputation_point = "upper right trunk"
+	species = "Diona"
 
 /obj/item/organ/external/leg/diona
 	name = "left lower tendril"
@@ -53,6 +57,7 @@
 	min_broken_damage = 20
 	cannot_break = 1
 	amputation_point = "lower left fork"
+	species = "Diona"
 
 /obj/item/organ/external/leg/right/diona
 	name = "right lower tendril"
@@ -60,6 +65,7 @@
 	min_broken_damage = 20
 	cannot_break = 1
 	amputation_point = "lower right fork"
+	species = "Diona"
 
 /obj/item/organ/external/foot/diona
 	name = "left foot"
@@ -67,6 +73,7 @@
 	min_broken_damage = 10
 	cannot_break = 1
 	amputation_point = "branch"
+	species = "Diona"
 
 /obj/item/organ/external/foot/right/diona
 	name = "right foot"
@@ -74,16 +81,19 @@
 	min_broken_damage = 10
 	cannot_break = 1
 	amputation_point = "branch"
+	species = "Diona"
 
 /obj/item/organ/external/hand/diona
 	name = "left grasper"
 	cannot_break = 1
 	amputation_point = "branch"
+	species = "Diona"
 
 /obj/item/organ/external/hand/right/diona
 	name = "right grasper"
 	cannot_break = 1
 	amputation_point = "branch"
+	species = "Diona"
 
 /obj/item/organ/external/head/diona
 	max_damage = 50
@@ -92,6 +102,7 @@
 	encased = null
 	amputation_point = "upper trunk"
 	gendered_icon = 0
+	species = "Diona"
 
 //DIONA ORGANS.
 /* /obj/item/organ/external/diona/removed()
@@ -113,6 +124,7 @@
 	origin_tech = "biotech=3"
 	parent_organ = "chest"
 	slot = "heart"
+	species = "Diona"
 
 /obj/item/organ/internal/brain/diona
 	name = "gas bladder"
@@ -122,6 +134,7 @@
 	organ_tag = "brain" // Turns into a nymph instantly, no transplanting possible.
 	origin_tech = "biotech=3"
 	slot = "brain"
+	species = "Diona"
 
 /obj/item/organ/internal/kidneys/diona
 	name = "polyp segment"
@@ -131,6 +144,7 @@
 	origin_tech = "biotech=3"
 	parent_organ = "groin"
 	slot = "kidneys"
+	species = "Diona"
 
 /obj/item/organ/internal/appendix/diona
 	name = "anchoring ligament"
@@ -140,6 +154,7 @@
 	origin_tech = "biotech=3"
 	parent_organ = "groin"
 	slot = "appendix"
+	species = "Diona"
 
 /obj/item/organ/internal/diona_receptor
 	name = "receptor node"
@@ -149,7 +164,7 @@
 	origin_tech = "biotech=3"
 	parent_organ = "head"
 	slot = "eyes"
-
+	species = "Diona"
 
 /obj/item/organ/internal/diona_receptor/surgeryize()
 	if(!owner)
@@ -170,6 +185,7 @@
 	icon_state = "claw"
 	slot = "liver"
 	alcohol_intensity = 0.5
+	species = "Diona"
 
 //TODO:Make absorb light on insert.
 

--- a/code/modules/surgery/organs/subtypes/drask.dm
+++ b/code/modules/surgery/organs/subtypes/drask.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/surgery_drask.dmi'
 	icon_state = "innards"
 	desc = "A greenish, slightly translucent organ. It is extremely cold."
+	species = "Drask"
 
 /obj/item/organ/internal/heart/drask
 	name = "drask heart"
@@ -13,6 +14,7 @@
 	organ_tag = "heart"
 	parent_organ = "head"
 	slot = "heart"
+	species = "Drask"
 
 /obj/item/organ/internal/lungs/drask
 	name = "lungs"
@@ -22,6 +24,7 @@
 	organ_tag = "lungs"
 	parent_organ = "chest"
 	slot = "lungs"
+	species = "Drask"
 
 /obj/item/organ/internal/liver/drask
 	name = "metabolic strainer"
@@ -32,6 +35,7 @@
 	parent_organ = "groin"
 	slot = "kidneys"
 	alcohol_intensity = 0.8
+	species = "Drask"
 
 /obj/item/organ/internal/brain/drask
 	name = "brain"
@@ -41,6 +45,7 @@
 	slot = "brain"
 	mmi_icon = 'icons/obj/surgery_drask.dmi'
 	mmi_icon_state = "mmi_full"
+	species = "Drask"
 
 /obj/item/organ/internal/eyes/drask
 	name = "eyes"
@@ -51,3 +56,4 @@
 	parent_organ = "head"
 	slot = "eyes"
 	desc = "Drask eyes. They look even stranger disembodied"
+	species = "Drask"

--- a/code/modules/surgery/organs/subtypes/grey.dm
+++ b/code/modules/surgery/organs/subtypes/grey.dm
@@ -1,2 +1,3 @@
 /obj/item/organ/internal/liver/grey
 	alcohol_intensity = 1.6
+	species = "Grey"

--- a/code/modules/surgery/organs/subtypes/kidan.dm
+++ b/code/modules/surgery/organs/subtypes/kidan.dm
@@ -1,2 +1,3 @@
 /obj/item/organ/internal/liver/kidan
 	alcohol_intensity = 0.5
+	species = "Kidan"

--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -6,6 +6,7 @@
 	min_broken_damage = 30
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/head/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -14,6 +15,7 @@
 /obj/item/organ/external/chest/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/chest/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -22,6 +24,7 @@
 /obj/item/organ/external/groin/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/groin/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -30,6 +33,7 @@
 /obj/item/organ/external/arm/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/arm/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -38,6 +42,7 @@
 /obj/item/organ/external/arm/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/arm/right/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -45,6 +50,7 @@
 /obj/item/organ/external/leg/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/leg/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -53,7 +59,7 @@
 /obj/item/organ/external/leg/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
-
+	species = "Machine"
 
 /obj/item/organ/external/leg/right/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -62,7 +68,7 @@
 /obj/item/organ/external/foot/ipc
 	encased = null
 	status = ORGAN_ROBOT
-
+	species = "Machine"
 
 /obj/item/organ/external/foot/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -71,7 +77,7 @@
 /obj/item/organ/external/foot/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
-
+	species = "Machine"
 
 /obj/item/organ/external/foot/right/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -80,6 +86,7 @@
 /obj/item/organ/external/hand/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/hand/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -88,6 +95,7 @@
 /obj/item/organ/external/hand/right/ipc
 	encased = null
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/external/hand/right/ipc/New()
 	robotize("Morpheus Cyberkinetics")
@@ -103,6 +111,7 @@
 	slot = "heart"
 	vital = 1
 	status = ORGAN_ROBOT
+	species = "Machine"
 
 /obj/item/organ/internal/cell/New()
 	robotize()
@@ -123,6 +132,7 @@
 	icon_state = "camera"
 	slot = "eyes"
 	status = ORGAN_ROBOT
+	species = "Machine"
 //	dead_icon = "camera_broken"
 
 /obj/item/organ/internal/optical_sensor/New()
@@ -154,6 +164,7 @@
 	max_damage = 200
 	slot = "brain"
 	status = ORGAN_ROBOT
+	species = "Machine"
 	var/obj/item/device/mmi/stored_mmi
 
 /obj/item/organ/internal/brain/mmi_holder/proc/update_from_mmi()

--- a/code/modules/surgery/organs/subtypes/nucleation.dm
+++ b/code/modules/surgery/organs/subtypes/nucleation.dm
@@ -3,6 +3,7 @@
 	name = "nucleation organ"
 	icon = 'icons/obj/surgery.dmi'
 	desc = "A crystalized human organ. /red It has a strangely iridescent glow."
+	species = "Nucleation"
 
 /obj/item/organ/internal/nucleation/resonant_crystal
 	name = "resonant crystal"
@@ -10,6 +11,7 @@
 	organ_tag = "resonant crystal"
 	parent_organ = "head"
 	slot = "res_crystal"
+	species = "Nucleation"
 
 /obj/item/organ/internal/nucleation/strange_crystal
 	name = "strange crystal"
@@ -17,7 +19,7 @@
 	organ_tag = "strange crystal"
 	parent_organ = "chest"
 	slot = "heart"
-
+	species = "Nucleation"
 
 /obj/item/organ/internal/eyes/luminescent_crystal
 	name = "luminescent eyes"
@@ -26,6 +28,7 @@
 	light_color = "#1C1C00"
 	parent_organ = "head"
 	slot = "eyes"
+	species = "Nucleation"
 
 /obj/item/organ/internal/eyes/luminescent_crystal/New()
 	set_light(2)
@@ -35,3 +38,4 @@
 	icon_state = "crystal-brain"
 	organ_tag = "crystalized brain"
 	slot = "brain"
+	species = "Nucleation"

--- a/code/modules/surgery/organs/subtypes/skrell.dm
+++ b/code/modules/surgery/organs/subtypes/skrell.dm
@@ -1,2 +1,3 @@
 /obj/item/organ/internal/liver/skrell
 	alcohol_intensity = 4
+	species = "Skrell"

--- a/code/modules/surgery/organs/subtypes/tajaran.dm
+++ b/code/modules/surgery/organs/subtypes/tajaran.dm
@@ -1,2 +1,3 @@
 /obj/item/organ/internal/liver/tajaran
 	alcohol_intensity = 1.4
+	species = "Tajaran"

--- a/code/modules/surgery/organs/subtypes/unathi.dm
+++ b/code/modules/surgery/organs/subtypes/unathi.dm
@@ -1,2 +1,3 @@
 /obj/item/organ/internal/liver/unathi
 	alcohol_intensity = 0.8
+	species = "Unathi"

--- a/code/modules/surgery/organs/subtypes/vox.dm
+++ b/code/modules/surgery/organs/subtypes/vox.dm
@@ -1,2 +1,3 @@
 /obj/item/organ/internal/liver/vox
 	alcohol_intensity = 1.6
+	species = "Vox"

--- a/code/modules/surgery/organs/subtypes/vulpkanin.dm
+++ b/code/modules/surgery/organs/subtypes/vulpkanin.dm
@@ -1,2 +1,3 @@
 /obj/item/organ/internal/liver/vulpkanin
 	alcohol_intensity = 1.4
+	species = "Vulpkanin"

--- a/code/modules/surgery/organs/subtypes/wryn.dm
+++ b/code/modules/surgery/organs/subtypes/wryn.dm
@@ -6,3 +6,4 @@
 	icon_state = "antennae"
 	parent_organ = "head"
 	slot = "hivenode"
+	species = "Wryn"


### PR DESCRIPTION
This fixes #4745. The issue was that icon generation for an IPC who got a head or whatever printed from the machine in robotics broke because of a runtime associated with limbs created without mob containers not having species or dna profiles.

All organs that have been specifically defined now start with defined species (that get turned from plaintext to actual datum vars in the organ new() and icon generation procs) and the dna profile is now handled for IPC limb attachment to eliminate the runtime.

Tested a bunch of limb-swapping surgical procedures on non-IPC mobs, checking the species of the limbs after amputation and before transplantation to make sure everything was mint and all, rejuvinated the mobs after the limbs were transplanted and the limbs didn't magically change species or anything unwanted, then I rock em sock em roboted an IPCs head off and replaced it with one printed from robotics and no runtime occurred. I even printed off a cyborg arm from the mechfab and put it on the IPC and then rejuvenated and it was still alright. Everything was :ok_hand:.

:cl:
fix: IPC parts from the mech fabricator won't turn IPCs invisible upon attachment anymore.
/:cl: