### PR TITLE
Renames Loyalty implants to Mindshield implants

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -150,9 +150,9 @@
 	if (istype(current, /mob/living/carbon/human))
 		/** Impanted**/
 		if(isloyal(H))
-			text = "Loyalty Implant:<a href='?src=\ref[src];implant=remove'>Remove</a>|<b>Implanted</b></br>"
+			text = "Mindshield Implant:<a href='?src=\ref[src];implant=remove'>Remove</a>|<b>Implanted</b></br>"
 		else
-			text = "Loyalty Implant:<b>No Implant</b>|<a href='?src=\ref[src];implant=add'>Implant him!</a></br>"
+			text = "Mindshield Implant:<b>No Implant</b>|<a href='?src=\ref[src];implant=add'>Implant him!</a></br>"
 		sections["implant"] = text
 		/** REVOLUTION ***/
 		text = "revolution"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -653,27 +653,27 @@
 					if(I && I.implanted)
 						I.removed(H)
 						qdel(I)
-				to_chat(H, "\blue <Font size =3><B>Your loyalty implant has been deactivated.</B></FONT>")
-				log_admin("[key_name(usr)] has deactivated [key_name(current)]'s loyalty implant")
-				message_admins("[key_name_admin(usr)] has deactivated [key_name_admin(current)]'s loyalty implant")
+				to_chat(H, "\blue <Font size =3><B>Your mindshield implant has been deactivated.</B></FONT>")
+				log_admin("[key_name(usr)] has deactivated [key_name(current)]'s mindshield implant")
+				message_admins("[key_name_admin(usr)] has deactivated [key_name_admin(current)]'s mindshield implant")
 			if("add")
 				var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(H)
 				L.imp_in = H
 				L.implanted = 1
 				H.sec_hud_set_implants()
 
-				log_admin("[key_name(usr)] has given [key_name(current)] a loyalty implant")
-				message_admins("[key_name_admin(usr)] has given [key_name_admin(current)] a loyalty implant")
+				log_admin("[key_name(usr)] has given [key_name(current)] a mindshield implant")
+				message_admins("[key_name_admin(usr)] has given [key_name_admin(current)] a mindshield implant")
 
-				to_chat(H, "\red <Font size =3><B>You somehow have become the recepient of a loyalty transplant, and it just activated!</B></FONT>")
+				to_chat(H, "\red <Font size =3><B>You somehow have become the recepient of a mindshield transplant, and it just activated!</B></FONT>")
 				if(src in ticker.mode.revolutionaries)
 					special_role = null
 					ticker.mode.revolutionaries -= src
-					to_chat(src, "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>")
+					to_chat(src, "\red <Font size = 3><B>The nanobots in the mindshield implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>")
 				if(src in ticker.mode.head_revolutionaries)
 					special_role = null
 					ticker.mode.head_revolutionaries -=src
-					to_chat(src, "\red <Font size = 3><B>The nanobots in the loyalty implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>")
+					to_chat(src, "\red <Font size = 3><B>The nanobots in the mindshield implant remove all thoughts about being a revolutionary.  Get back to work!</B></Font>")
 				if(src in ticker.mode.cult)
 					ticker.mode.cult -= src
 					ticker.mode.update_cult_icons_removed(src)
@@ -681,7 +681,7 @@
 					var/datum/game_mode/cult/cult = ticker.mode
 					if (istype(cult))
 						cult.memorize_cult_objectives(src)
-					to_chat(current, "\red <FONT size = 3><B>The nanobots in the loyalty implant remove all thoughts about being in a cult.  Have a productive day!</B></FONT>")
+					to_chat(current, "\red <FONT size = 3><B>The nanobots in the mindshield implant remove all thoughts about being in a cult.  Have a productive day!</B></FONT>")
 					memory = ""
 
 	else if (href_list["revolution"])

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -375,10 +375,10 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 /////// Implants & etc
 
 /datum/supply_packs/security/armory/loyalty
-	name = "Loyalty Implants Crate"
+	name = "Mindshield Implants Crate"
 	contains = list (/obj/item/weapon/storage/lockbox/loyalty)
 	cost = 40
-	containername = "loyalty implant crate"
+	containername = "mindshield implant crate"
 
 /datum/supply_packs/security/armory/trackingimp
 	name = "Tracking Implants Crate"

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -88,7 +88,7 @@
 			for(var/job in restricted_jobs)
 				if(player.assigned_role == job)
 					possible_traitors -= player
-			if(player.current) // Remove loyalty implanted mobs from the list
+			if(player.current) // Remove mindshield-implanted mobs from the list
 				if(ishuman(player.current))
 					var/mob/living/carbon/human/H = player.current
 					for(var/obj/item/weapon/implant/loyalty/I in H.contents)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -147,7 +147,7 @@
 	if (!where2)
 		to_chat(mob, "The Syndicate were unfortunately unable to get you a chameleon security HUD.")
 	else
-		to_chat(mob, "The chameleon security HUD in your [where2] will help you keep track of who is loyalty-implanted, and unable to be recruited.")
+		to_chat(mob, "The chameleon security HUD in your [where2] will help you keep track of who is mindshield-implanted, and unable to be recruited.")
 
 	if (!where)
 		to_chat(mob, "The Syndicate were unfortunately unable to get you a flash.")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -346,17 +346,17 @@
 						usr.visible_message("<span class='warning'>[usr] pauses, then dips their head in concentration!</span>")
 						to_chat(target, "<span class='boldannounce'>You feel your loyalties begin to weaken!</span>")
 						sleep(100) //10 seconds - not spawn() so the enthralling takes longer
-						to_chat(usr, "<span class='notice'>The nanobots composing the loyalty implant have been rendered inert. Now to continue.</span>")
+						to_chat(usr, "<span class='notice'>The nanobots composing the mindshield implant have been rendered inert. Now to continue.</span>")
 						usr.visible_message("<span class='warning'>[usr] relaxes again.</span>")
 						for(var/obj/item/weapon/implant/loyalty/L in target)
 							if(L && L.implanted)
 								qdel(L)
-						to_chat(target, "<span class='boldannounce'>Your unwavering loyalty to Nanotrasen unexpectedly falters, dims, dies.</span>")
+						to_chat(target, "<span class='boldannounce'>Your mental protection implant unexpectedly falters, dims, dies.</span>")
 				if(3)
 					to_chat(usr, "<span class='notice'>You begin planting the tumor that will control the new thrall...</span>")
 					usr.visible_message("<span class='warning'>A strange energy passes from [usr]'s hands into [target]'s head!</span>")
 					to_chat(target, "<span class='boldannounce'>You feel your memories twisting, morphing. A sense of horror dominates your mind.</span>")
-			if(!do_mob(usr, target, 70)) //around 21 seconds total for enthralling, 31 for someone with a loyalty implant
+			if(!do_mob(usr, target, 70)) //around 21 seconds total for enthralling, 31 for someone with a mindshield implant
 				to_chat(usr, "<span class='warning'>The enthralling has been interrupted - your target's mind returns to its previous state.</span>")
 				to_chat(target, "<span class='userdanger'>You wrest yourself away from [usr]'s hands and compose yourself</span>")
 				enthralling = 0

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -342,9 +342,9 @@
 					target.Weaken(12)
 					sleep(20)
 					if(isloyal(target))
-						to_chat(usr, "<span class='notice'>They are enslaved by Nanotrasen. You begin to shut down the nanobot implant - this will take some time.</span>")
+						to_chat(usr, "<span class='notice'>They have a mindshield implant. You begin to deactivate it - this will take some time.</span>")
 						usr.visible_message("<span class='warning'>[usr] pauses, then dips their head in concentration!</span>")
-						to_chat(target, "<span class='boldannounce'>You feel your loyalties begin to weaken!</span>")
+						to_chat(target, "<span class='boldannounce'>Your mindshield implant becomes hot as it comes under attack!</span>")
 						sleep(100) //10 seconds - not spawn() so the enthralling takes longer
 						to_chat(usr, "<span class='notice'>The nanobots composing the mindshield implant have been rendered inert. Now to continue.</span>")
 						usr.visible_message("<span class='warning'>[usr] relaxes again.</span>")

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -5,7 +5,7 @@
 	action_button_custom_type = /datum/action/item_action/hands_free
 	origin_tech = "materials=2;biotech=3;programming=2"
 
-	var/activated = 1 //1 for implant types that can be activated, 0 for ones that are "always on" like loyalty implants
+	var/activated = 1 //1 for implant types that can be activated, 0 for ones that are "always on" like mindshield implants
 	var/implanted = null
 	var/mob/living/imp_in = null
 	item_color = "b"

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -29,7 +29,7 @@
 		if(target.mind in ticker.mode.cult)
 			to_chat(target, "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		else
-			to_chat(target, "<span class='notice'>You mind feels hardened somehow.</span>")
+			to_chat(target, "<span class='notice'>Your mind feels hardened - more resistant to brainwashing.</span>")
 		return 1
 	return 0
 
@@ -42,7 +42,7 @@
 
 
 /obj/item/weapon/implanter/loyalty
-	name = "implanter (loyalty)"
+	name = "implanter (mindshield)"
 
 /obj/item/weapon/implanter/loyalty/New()
 	imp = new /obj/item/weapon/implant/loyalty(src)
@@ -51,7 +51,7 @@
 
 
 /obj/item/weapon/implantcase/loyalty
-	name = "implant case - 'Loyalty'"
+	name = "implant case - 'mindshield'"
 	desc = "A glass case containing a loyalty implant."
 
 /obj/item/weapon/implantcase/loyalty/New()

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/implant/loyalty
-	name = "loyalty implant"
-	desc = "Makes you loyal or such."
+	name = "mindshield implant"
+	desc = "Stops people messing with your mind."
 	origin_tech = "materials=2;biotech=4;programming=4"
 	activated = 0
 
@@ -8,11 +8,11 @@
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Nanotrasen Employee Management Implant<BR>
 				<b>Life:</b> Ten years.<BR>
-				<b>Important Notes:</b> Personnel injected with this device tend to be much more loyal to the company.<BR>
+				<b>Important Notes:</b> Personnel injected with this device can better resist mental compulsions.<BR>
 				<HR>
 				<b>Implant Details:</b><BR>
 				<b>Function:</b> Contains a small pod of nanobots that manipulate the host's mental functions.<BR>
-				<b>Special Features:</b> Will prevent and cure most forms of brainwashing.<BR>
+				<b>Special Features:</b> Will prevent most forms of brainwashing.<BR>
 				<b>Integrity:</b> Implant will last so long as the nanobots are inside the bloodstream."}
 	return dat
 
@@ -29,7 +29,7 @@
 		if(target.mind in ticker.mode.cult)
 			to_chat(target, "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 		else
-			to_chat(target, "<span class='notice'>You feel a surge of loyalty towards Nanotrasen.</span>")
+			to_chat(target, "<span class='notice'>You mind feels hardened somehow.</span>")
 		return 1
 	return 0
 

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -12,7 +12,7 @@
 				<HR>
 				<b>Implant Details:</b><BR>
 				<b>Function:</b> Contains a small pod of nanobots that manipulate the host's mental functions.<BR>
-				<b>Special Features:</b> Will prevent most forms of brainwashing.<BR>
+				<b>Special Features:</b> Will prevent and cure most forms of brainwashing.<BR>
 				<b>Integrity:</b> Implant will last so long as the nanobots are inside the bloodstream."}
 	return dat
 

--- a/code/game/objects/items/weapons/implants/implant_mindshield.dm
+++ b/code/game/objects/items/weapons/implants/implant_mindshield.dm
@@ -52,7 +52,7 @@
 
 /obj/item/weapon/implantcase/loyalty
 	name = "implant case - 'mindshield'"
-	desc = "A glass case containing a loyalty implant."
+	desc = "A glass case containing a mindshield implant."
 
 /obj/item/weapon/implantcase/loyalty/New()
 	imp = new /obj/item/weapon/implant/loyalty(src)

--- a/code/game/objects/items/weapons/implants/implantchair.dm
+++ b/code/game/objects/items/weapons/implants/implantchair.dm
@@ -1,8 +1,8 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
 
 /obj/machinery/implantchair
-	name = "loyalty implanter"
-	desc = "Used to implant occupants with loyalty implants."
+	name = "mindshield implanter"
+	desc = "Used to implant occupants with mindshield implants."
 	icon = 'icons/obj/machines/implantchair.dmi'
 	icon_state = "implantchair"
 	density = 1

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -809,7 +809,7 @@
 		</html>
 
 		"}
-		
+
 /obj/item/weapon/book/manual/security_space_law/black
 	name = "Space Law - Limited Edition"
 	desc = "A leather-bound, immaculately-written copy of JUSTICE."
@@ -1483,7 +1483,7 @@
                     <li>Attending Surgeon is to keep the Operating Room in an hygienic condition at all times, <b>again</b>, to prevent infection;</li>
                     <li>Attending Surgeon is to wash his/her hands between different patients, again, to prevent infection;</li>
                     <li>Attending Surgeon is to use either Anesthetics or Sedatives (for species that cannot breathe Anesthetics) during Surgical Procedures. Exception is made if the patient requests otherwise;</li>
-                    <li>Attending Surgeon is not to remove any legal Implants (such as Loyalty or Tracking Implants) from the patient, unless requested by Security;</li>
+                    <li>Attending Surgeon is not to remove any legal Implants (such as Mindshield or Tracking Implants) from the patient, unless requested by Security;</li>
                     <li>If a patient requests that a lost limb be replaced with an organic, rather than mechanical, substitute, said limb must be harvested from a compatible humanized Test Animal (such as Monkeys for Humans, or Farwas for Tajarans). Exception is made if the patient deliberately requests otherwise;</li>
                     <li>Attending Surgeon is not to bring any of the Surgical Tools outside of their respective Operating Room, and must in fact ensure the Operating Room maintains its proper inventory. This includes ensuring that the Anesthetics Equipment be kept inside the OR</li>
                 </ol>
@@ -2141,7 +2141,7 @@
                     <li>Prisoner must then be borged, fired into space via mass driver, cremated, or placed in the morgue with a DNR Notice, at the discretion of the Magistrate, Captain or Head of Security.</li>
 				</ol>
                 <br><br>
-                
+
                 <h1><a name="elec"><B>Execution: Lethal Injection</B></a></h1><BR>
 				<ol>
 					<li>Prisoner must be bucklecuffed to the electric chair or bed.</li>
@@ -2150,7 +2150,7 @@
                     <li>Prisoner must then be borged, fired into space via mass driver, cremated, or placed in the morgue with a DNR Notice, at the discretion of the Magistrate, Captain or Head of Security.</li>
 				</ol>
                 <br><br>
-                
+
                  <h1><a name="elec"><B>Execution: Firing Squad</B></a></h1><BR>
 				<ol>
 					<li>Prisoner must be brought to the Firing Range.</li>
@@ -2164,7 +2164,7 @@
 				</html>
 
 		"}
-        
+
 /obj/item/weapon/book/manual/sop_general
 	name = "Standard Operating Procedures"
 	desc = "A set of guidelines aiming at the safe conduct of all station activities."
@@ -2212,7 +2212,7 @@
 
 				<h1><a name="green"><B>Code Green</B></a></h1><BR>
                 <i>All clear.</i><br>
-                Default operating level. No immediate or clear threat to the station. All departments may carry out work as normal. 
+                Default operating level. No immediate or clear threat to the station. All departments may carry out work as normal.
                 This alert level can be set at the Communications Console with a Captain level ID.<br>
                 <i>All threats to the station have passed. All weapons need to be holstered and privacy laws are once again fully enforced.</i><br>
                 <br>
@@ -2230,10 +2230,10 @@
                 Crew:<br>
                 <ul>
                     <li>Crew members may freely walk in the hallways</li>
-                    <li>Suit sensors are not mandatory.</li>   
+                    <li>Suit sensors are not mandatory.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="blue"><B>Code Blue</B></a></h1><BR>
                 <i>There is a suspected threat.</i><br>
                 Raised alert level. Suspected threat to the station. Issued by Central Command, the Captain, or a Head of Staff vote. This alert level can be set at the Communications Console with a Captain level ID.<br>
@@ -2255,10 +2255,10 @@
                 Crew:<br>
                 <ul>
                     <li>Employees are recommended to comply with all security requests.</li>
-                    <li>Suit sensors are mandatory, but coordinate positions are not required.</li>   
+                    <li>Suit sensors are mandatory, but coordinate positions are not required.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="red"><B>Code Red</B></a></h1><BR>
                 <i>There is a confirmed threat.</i><br>
                 Maximum alert level. Confirmed threat to the station or severe damage. Issued by Central Command, the Captain, or a Head of Staff vote. This alert level can only be set via the Keycard Authentication Devices in each Heads of Staff office and by swiping two Heads of Staff ID cards simultaneously.<br>
@@ -2279,12 +2279,12 @@
                 Crew:<br>
                 <ul>
                     <li>Suit sensors and coordinate positions are mandatory.</li>
-                    <li>All crew members must remain in their departments.</li>   
-                    <li>Employees are required to comply with all security requests.</li>  
-                    <li>Emergency Response Team may be authorised. All crew are to comply with their direction.</li>  
+                    <li>All crew members must remain in their departments.</li>
+                    <li>Employees are required to comply with all security requests.</li>
+                    <li>Emergency Response Team may be authorised. All crew are to comply with their direction.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="gamma"><B>Code Gamma</B></a></h1><BR>
                 <i>Extremely hostile threat onboard the station.</i><br>
                 GAMMA Security level has been set by Centcom.<br>
@@ -2306,21 +2306,21 @@
                 Crew:<br>
                 <ul>
                     <li>Employees are required to comply with all security requests.</li>
-                    <li>All civilians are to seek their nearest head for transportation to a safe location.</li>   
+                    <li>All civilians are to seek their nearest head for transportation to a safe location.</li>
                     <li>All personnel are required to defend the station and help security with dealing with the threat. All crew must follow direct orders from Security Personell or Head of Staff.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="hiring"><B>Hiring Policies</B></a></h1><BR>
                 <ul>
                     <li>Authorisation from the relevant Department Head is required to be hired into a Department. If none exists, the HoP or Captain's authorisation is required.</li>
                     <li>Promotion to a Department Head requires authorisation from the Captain or Acting Captain.</li>
                     <li>CentComm Authorisation is required for hiring the following: Blueshield, Security Pod Pilot, Magistrate, Brig Physician, Nanotrasen Representative, Mechanic.</li>
                     <li>If no Department Head has yet been sent, any promotion to said position is on a temporary basis until one arrives. </li>
-                    <li>All Security personnel are to be loyalty implanted.</li>
+                    <li>All Security personnel are to be mindshield implanted.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="firing"><B>Firing Policies</B></a></h1><BR>
                 <ul>
                     <li>If a crew is to be dismissed, their ID is to be terminated.</li>
@@ -2329,7 +2329,7 @@
                     <li>Demotion or Dismissal must have due cause.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="causes"><B>Causes for Demotion and Dismissal</B></a></h1><BR>
                 <ul>
                     <li>A medium or higher crime may be grounds for dismissal, at the department head's discretion.</li>
@@ -2344,11 +2344,11 @@
                     <li>Failure or refusal to hand in any items, ID, etc, of their previous job, is to be considered theft.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="sit"><B>Situational SoP</B></a></h1><BR>
                 The following situations have specific SoP. Failure to follow these may result in demotion/dismissal, or detaining by security if failure to follow them presents a significant risk.
                 <br><br>
-                
+
                 <h1><a name="causes"><B>Evacuation</B></a></h1><BR>
                 <ul>
                     <li>All personnel are required to assist with evacuation. All crew must be evacuated, regardless of conscious state.</li>
@@ -2359,7 +2359,7 @@
                     <li>Shortening time to shuttle launch may be authorised if a clear threat to life, limb, or shuttle integrity is present.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="viral"><b>Viral Outbreak Procedures</b></a></h1><BR>
                 <i><b>Definition: </b>A Viral Outbreak is defined as a situation where a Viral Pathogen has infected a significant portion of the crew (>10%)</i>
 				<ol>
@@ -2376,7 +2376,7 @@
                     <li>Once the Viral Outbreak is over, all personnel are to return to regular duties.</li>
                 </ol>
                 <br><br>
-                
+
                 <h1><a name="evac"><B>Evacuation</B></a></h1><BR>
                 <ul>
                     <li>Immediate evacuation of all untrained personnel.</li>
@@ -2384,7 +2384,7 @@
                     <li>Atmospheric Technicians are to remove hazard.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="meteor"><B>Meteor Storm</B></a></h1><BR>
                 <ul>
                     <li>All crew to move to central parts of the station.</li>
@@ -2392,7 +2392,7 @@
                     <li>Personel that are doing EVA maintenance should seek shelter immediately.</li>
                 </ul>
                 <br><br>
-                
+
                 <h1><a name="sing"><B>Singularity Containment Failure</B></a></h1><BR>
                 <ul>
                     <li>Observation of Singularity movement.</li>

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -81,7 +81,7 @@
 	storage_slots = 1
 
 /obj/item/weapon/storage/lockbox/loyalty
-	name = "Lockbox (Loyalty Implants)"
+	name = "Lockbox (Mindshield Implants)"
 	req_access = list(access_security)
 
 	New()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -217,6 +217,7 @@
 		if(judgebot.check_for_weapons(r_hand))
 			threatcount += 4
 
+	//Mindshield implants imply trustworthyness
 	if(isloyal(src))
 		threatcount -= 1
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -217,7 +217,6 @@
 		if(judgebot.check_for_weapons(r_hand))
 			threatcount += 4
 
-	//Loyalty implants imply trustworthyness
 	if(isloyal(src))
 		threatcount -= 1
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1882,7 +1882,7 @@
 		threatcount += 2
 
 
-	//Loyalty implants imply trustworthyness
+	//Mindshield implants imply slight trustworthiness
 	if(isloyal(src))
 		threatcount -= 1
 

--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -191,7 +191,7 @@
 					if(isloyal(target))
 						to_chat(usr, "<span class='notice'>They are enslaved by Nanotrasen. You feel their interest in your cause wane and disappear.</span>")
 						usr.visible_message("<span class='danger'>[usr] stops talking for a moment, then moves back away from [target].</span>")
-						to_chat(target, "<span class='danger'>Your loyalty implant activates and a sharp pain reminds you of your loyalties to Nanotrasen.</span>")
+						to_chat(target, "<span class='danger'>Your mindshield implant activates and a sharp pain reminds you of your loyalties to Nanotrasen.</span>")
 						return
 				if(3)
 					to_chat(usr, "<span class='notice'>You begin filling out the application form with [target].</span>")

--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -191,14 +191,14 @@
 					if(isloyal(target))
 						to_chat(usr, "<span class='notice'>They are enslaved by Nanotrasen. You feel their interest in your cause wane and disappear.</span>")
 						usr.visible_message("<span class='danger'>[usr] stops talking for a moment, then moves back away from [target].</span>")
-						to_chat(target, "<span class='danger'>Your mindshield implant activates and a sharp pain reminds you of your loyalties to Nanotrasen.</span>")
+						to_chat(target, "<span class='danger'>Your mindshield implant activates, protecting you from conversion.</span>")
 						return
 				if(3)
 					to_chat(usr, "<span class='notice'>You begin filling out the application form with [target].</span>")
 					usr.visible_message("<span class='danger'>[usr] pulls out a pen and paper and begins filling an application form with [target].</span>")
 					to_chat(target, "<span class='danger'>You are being convinced by [usr] to fill out an application form to become a henchman.</span>")//Ow the edge
 
-			if(!do_mob(usr, target, 100)) //around 30 seconds total for enthralling, 45 for someone with a loyalty implant
+			if(!do_mob(usr, target, 100)) //around 30 seconds total for enthralling, 45 for someone with a mindshield implant
 				to_chat(usr, "<span class='danger'>The enrollment process has been interrupted - you have lost the attention of [target].</span>")
 				to_chat(target, "<span class='warning'>You move away and are no longer under the charm of [usr]. The application form is null and void.</span>")
 				recruiting = 0

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -22,7 +22,7 @@
 			return 0
 	return 1
 
-/proc/isloyal(A) //Checks to see if the person contains a loyalty implant, then checks that the implant is actually inside of them
+/proc/isloyal(A) //Checks to see if the person contains a mindshield implant, then checks that the implant is actually inside of them
 	for(var/obj/item/weapon/implant/loyalty/L in A)
 		if(L && L.implanted)
 			return 1

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -577,7 +577,7 @@
 
 /obj/item/weapon/paper/armory
 	name = "paper- 'Armory Inventory'"
-	info = "4 Deployable Barriers<br>4 Portable Flashers<br>1 Mechanical Toolbox<br>2 Boxes of Spare Handcuffs<br>1 Box of Flashbangs<br>1 Box of Spare R.O.B.U.S.T. Cartridges<br>1 Tracking Implant Kit<br>1 Chemical Implant Kit<br>1 Box of Tear Gas Grenades<br>1 Explosive Ordnance Disposal Suit<br>1 Biohazard Suit<br>6 Gas Masks<br>1 Lockbox of Loyalty Implants<br>1 Ion Rifle<br>3 Sets of Riot Equipment<br>2 Sets of Security Hardsuits<br>1 Ablative Armor Vest<br>3 Bulletproof Vests<br>3 Helmets<br><br>2 Riot Shotguns<br>2 Boxes of Beanbag Shells<br>3 Laser Guns<br>3 Energy Guns<br>3 Advanced Tasers"
+	info = "4 Deployable Barriers<br>4 Portable Flashers<br>1 Mechanical Toolbox<br>2 Boxes of Spare Handcuffs<br>1 Box of Flashbangs<br>1 Box of Spare R.O.B.U.S.T. Cartridges<br>1 Tracking Implant Kit<br>1 Chemical Implant Kit<br>1 Box of Tear Gas Grenades<br>1 Explosive Ordnance Disposal Suit<br>1 Biohazard Suit<br>6 Gas Masks<br>1 Lockbox of Mindshield Implants<br>1 Ion Rifle<br>3 Sets of Riot Equipment<br>2 Sets of Security Hardsuits<br>1 Ablative Armor Vest<br>3 Bulletproof Vests<br>3 Helmets<br><br>2 Riot Shotguns<br>2 Boxes of Beanbag Shells<br>3 Laser Guns<br>3 Energy Guns<br>3 Advanced Tasers"
 
 /obj/item/weapon/paper/firingrange
 	name = "paper- 'Firing Range Instructions'"

--- a/paradise.dme
+++ b/paradise.dme
@@ -854,7 +854,7 @@
 #include "code\game\objects\items\weapons\implants\implant_explosive.dm"
 #include "code\game\objects\items\weapons\implants\implant_freedom.dm"
 #include "code\game\objects\items\weapons\implants\implant_krav_maga.dm"
-#include "code\game\objects\items\weapons\implants\implant_loyality.dm"
+#include "code\game\objects\items\weapons\implants\implant_mindshield.dm"
 #include "code\game\objects\items\weapons\implants\implant_misc.dm"
 #include "code\game\objects\items\weapons\implants\implant_storage.dm"
 #include "code\game\objects\items\weapons\implants\implant_track.dm"


### PR DESCRIPTION
Exactly what it says on the tin.

Note: this change only affects player-visible references to loyalty implants. Not changing their names in the code to avoid map conflicts.

Reason: lots of ahelps like "does a loyalty implant make me loyal?"
No, it doesn't. It just prevents most forms of brainwashing.

:cl: Kyep
tweak: "Loyalty" implants are now known as "Mindshield" implants
/:cl: