### PR TITLE
Makes pulsing door wires non-blocking

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -107,7 +107,8 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 			A.autoclose = mended
 			if(mended)
 				if(!A.density)
-					A.close()
+					spawn(0)
+						A.close()
 
 		if(AIRLOCK_WIRE_LIGHT)
 			A.lights = mended
@@ -159,12 +160,16 @@ var/const/AIRLOCK_WIRE_LIGHT = 2048
 			//will succeed only if the ID wire is cut or the door requires no access and it's not emagged
 			if(A.emagged)	return
 			if(!A.requiresID() || A.check_access(null))
-				if(A.density)	A.open()
-				else		A.close()
+				spawn(0)
+					if(A.density)
+						A.open()
+					else
+						A.close()
 		if(AIRLOCK_WIRE_SAFETY)
 			A.safe = !A.safe
 			if(!A.density)
-				A.close()
+				spawn(0)
+					A.close()
 
 		if(AIRLOCK_WIRE_SPEED)
 			A.normalspeed = !A.normalspeed


### PR DESCRIPTION
:cl: monster860
bugfix: Pulsing multiple doors' "open door" wires at the same time using a remote signaller now actually opens them at the same time.
/:cl: