### PR TITLE
Fixes deathgasp and emote colour

### DIFF
--- a/code/datums/Emote_system/emote.dm
+++ b/code/datums/Emote_system/emote.dm
@@ -36,8 +36,8 @@ VampyrBytes
 	var/targetText = "at" // what goes inbetween user and target
 	var/takesNumber	= 0	// 1 if the emote uses a number parameter
 
-	var/emoteSpanClass = "notice"
-	var/userSpanClass = "em"
+	var/emoteSpanClass = "say"
+	var/userSpanClass = "bold"
 	var/baseLevel = 1
 	var/allowParent = 0			// 1 if you want the parent available as well as this one
 

--- a/code/datums/Emote_system/emotes.dm
+++ b/code/datums/Emote_system/emotes.dm
@@ -344,6 +344,10 @@
 	commands = list("deathgasp", "deathgasps")
 	audible = 1
 
+/datum/emote/deathgasp/prevented(var/mob/user)
+	if(user.stat == DEAD)
+		return "you are already dead!"
+
 /datum/emote/deathgasp/alien
 	text = "lets out a waning guttural screech, green blood bubbling from its maw..."
 	selfText = "let out a waning guttural screech, green blood bubbling from your maw..."


### PR DESCRIPTION
fixes some of the issues in #4776 

Deathgasp will now run properly on death.
Emotes are now black, and the user's name is in bold