### PR TITLE
Wormhole gun fixes and changes

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -10,17 +10,19 @@
 	var/creator = null
 	anchored = 1.0
 	var/precision = 1 // how close to the portal you will teleport. 0 = on the portal, 1 = adjacent
+	var/can_multitool_to_remove = 0
 
 /obj/effect/portal/Bumped(mob/M as mob|obj)
 	src.teleport(M)
 
-/obj/effect/portal/New(loc, turf/target, creator)
+/obj/effect/portal/New(loc, turf/target, creator, removal_delay=300)
 	portals += src
 	src.loc = loc
 	src.target = target
 	src.creator = creator
-	spawn(300)
-		qdel(src)
+	if(removal_delay)
+		spawn(removal_delay)
+			qdel(src)
 	return
 
 /obj/effect/portal/Destroy()
@@ -48,3 +50,7 @@
 			do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0)
 		else
 			do_teleport(M, target, precision) ///You will appear adjacent to the beacon
+
+/obj/effect/portal/attackby(obj/item/A, mob/user)
+	if(istype(A, /obj/item/device/multitool) && can_multitool_to_remove)
+		qdel(src)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -15,14 +15,13 @@
 /obj/effect/portal/Bumped(mob/M as mob|obj)
 	src.teleport(M)
 
-/obj/effect/portal/New(loc, turf/target, creator, removal_delay=300)
+/obj/effect/portal/New(loc, turf/target, creator)
 	portals += src
 	src.loc = loc
 	src.target = target
 	src.creator = creator
-	if(removal_delay)
-		spawn(removal_delay)
-			qdel(src)
+	spawn(300)
+		qdel(src)
 	return
 
 /obj/effect/portal/Destroy()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -279,13 +279,16 @@
 	desc = "A projector that emits high density quantum-coupled bluespace beams."
 	ammo_type = list(/obj/item/ammo_casing/energy/wormhole, /obj/item/ammo_casing/energy/wormhole/orange)
 	item_state = null
-	icon_state = "wormhole_projector100"
+	icon_state = "wormhole_projector1"
 	var/obj/effect/portal/blue
 	var/obj/effect/portal/orange
 
 
 /obj/item/weapon/gun/energy/wormhole_projector/update_icon()
-	icon_state = "[initial(icon_state)][select]"
+	if(select == "orange")
+		icon_state = "wormhole_projector2"
+	else
+		icon_state = "wormhole_projector1"
 	item_state = icon_state
 	return
 
@@ -304,8 +307,10 @@
 			blue.target = null
 
 /obj/item/weapon/gun/energy/wormhole_projector/proc/create_portal(obj/item/projectile/beam/wormhole/W)
-	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(W), null, src)
+	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(W), null, src, 0)
 	P.precision = 0
+	P.failchance = 0
+	P.can_multitool_to_remove = 1
 	if(W.name == "bluespace beam")
 		qdel(blue)
 		blue = P

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -285,10 +285,7 @@
 
 
 /obj/item/weapon/gun/energy/wormhole_projector/update_icon()
-	if(select == "orange")
-		icon_state = "wormhole_projector2"
-	else
-		icon_state = "wormhole_projector1"
+	icon_state = "wormhole_projector[select]"
 	item_state = icon_state
 	return
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -304,7 +304,7 @@
 			blue.target = null
 
 /obj/item/weapon/gun/energy/wormhole_projector/proc/create_portal(obj/item/projectile/beam/wormhole/W)
-	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(W), null, src, 0)
+	var/obj/effect/portal/P = new /obj/effect/portal(get_turf(W), null, src)
 	P.precision = 0
 	P.failchance = 0
 	P.can_multitool_to_remove = 1


### PR DESCRIPTION
On the 0 failchance thing:
The `failchance = 0` line was removed by DZD in the major gun refactor, however, he says it was unintentional, and it wasn't mentioned anywhere in the changelog, so I am reverting this.

If you want, I can also make hand tele portals multitool-able

:cl: monster860
bugfix: Fixes wormhole projector not having an icon.
tweak: Wormhole projector has 0 failchance now.
rscadd: Portals made by wormhole projectors can be removed via a multitool
/:cl: