### PR TITLE
Stops vehicles unintentionally being space vehicles

### DIFF
--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -13,7 +13,6 @@
 	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
 	var/auto_door_open = TRUE
 	var/needs_gravity = 0//To allow non-space vehicles to move in no gravity or not, mostly for adminbus
-
 	//Pixels
 	var/generic_pixel_x = 0 //All dirs show this pixel_x for the driver
 	var/generic_pixel_y = 0 //All dirs shwo this pixel_y for the driver
@@ -144,7 +143,7 @@
 	if(has_gravity(src))
 		return 1
 
-	if(pulledby)
+	if(pulledby && pulledby != buckled_mob)	// no pulling the vehicle you're driving through space!
 		return 1
 
 	if(needs_gravity)


### PR DESCRIPTION
So, it turns out you can be pulling a vehicle whilst riding it, and then
when you reach space the vehicle thinks it is being pulled through space
rather than ridden.

I would guess this is why it's been so hard to replicate... People have
pulled the vehicle, then got on it and not realised they're still
pulling it.

Ideally we'd be able to stop people pulling it when riding it, but that
would either mean snowflaking into the pull code (yuk) or refactoring
the pull code, which doesn't seem worth it for just this, so instead
I've just added a check to make sure if it's being pulled through space
it isn't the buckled mob doing it

fixes #4498 