### PR TITLE
Created "Send Teacher pAI" verb

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -11,7 +11,6 @@
 	var/obj/item/device/radio/radio
 	var/looking_for_personality = 0
 	var/mob/living/silicon/pai/pai
-	var/locked = 0 // if turned on, cannot be reconfigured, and wiping self-destructs it.
 
 /obj/item/device/paicard/relaymove(var/mob/user, var/direction)
 	if(user.stat || user.stunned)
@@ -149,14 +148,13 @@
 			</table>
 			<br>
 		"}
-		if (!locked)
-			dat += {"
-				<table>
-					<td class="button">
-						<a href='byond://?src=\ref[src];setlaws=1' class='button'>Configure Directives</a>
-					</td>
-				</table>
-			"}
+		dat += {"
+			<table>
+				<td class="button">
+					<a href='byond://?src=\ref[src];setlaws=1' class='button'>Configure Directives</a>
+				</td>
+			</table>
+		"}
 		if(pai && (!pai.master_dna || !pai.master))
 			dat += {"
 				<table>
@@ -168,43 +166,30 @@
 		dat += "<br>"
 		if(radio)
 			dat += "<b>Radio Uplink</b><br>"
-			if (locked)
-				dat += "Installed<br><br><br>"
-			else
-				dat += {"
-					<table class="request">
-						<tr>
-							<td class="radio">Transmit:</td>
-							<td><a href='byond://?src=\ref[src];wires=4'>[radio.broadcasting ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
-
+			dat += {"
+				<table class="request">
+					<tr>
+						<td class="radio">Transmit:</td>
+						<td><a href='byond://?src=\ref[src];wires=4'>[radio.broadcasting ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
 							</td>
-						</tr>
-						<tr>
-							<td class="radio">Receive:</td>
-							<td><a href='byond://?src=\ref[src];wires=2'>[radio.listening ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
-
+					</tr>
+					<tr>
+						<td class="radio">Receive:</td>
+						<td><a href='byond://?src=\ref[src];wires=2'>[radio.listening ? "<font color=#55FF55>En" : "<font color=#FF5555>Dis" ]abled</font></a>
 							</td>
-						</tr>
-					</table>
-					<br>
-				"}
+					</tr>
+				</table>
+				<br>
+			"}
 		else
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
-		if (locked)
-			dat += {"
-				<table>
-					<td class="button_red"><a href='byond://?src=\ref[src];wipe=1' class='button'>Self Destruct</a>
-					</td>
-				</table>
-			"}
-		else
-			dat += {"
-				<table>
-					<td class="button_red"><a href='byond://?src=\ref[src];wipe=1' class='button'>Wipe current pAI personality</a>
-					</td>
-				</table>
-			"}
+		dat += {"
+			<table>
+				<td class="button_red"><a href='byond://?src=\ref[src];wipe=1' class='button'>Wipe current pAI personality</a>
+				</td>
+			</table>
+		"}
 
 	else
 		if(looking_for_personality)
@@ -285,17 +270,13 @@
 						P.close_up()
 				M.death(0)
 			removePersonality()
-			if (locked)
-				to_chat(usr, "<span class'danger'>The device self-destructs!</span>")
-				qdel(src)
 	if(href_list["wires"])
-		if (!locked)
-			var/t1 = text2num(href_list["wires"])
-			switch(t1)
-				if(4)
-					radio.ToggleBroadcast()
-				if(2)
-					radio.ToggleReception()
+		var/t1 = text2num(href_list["wires"])
+		switch(t1)
+			if(4)
+				radio.ToggleBroadcast()
+			if(2)
+				radio.ToggleReception()
 	if(href_list["setlaws"])
 		var/newlaws = sanitize(copytext(input("Enter any additional directives you would like your pAI personality to follow. Note that these directives will not override the personality's allegiance to its imprinted master. Conflicting directives will be ignored.", "pAI Directive Configuration", pai.pai_laws) as message,1,MAX_MESSAGE_LEN))
 		if(newlaws)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -73,7 +73,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/change_human_appearance_self,	/* Allows the human-based mob itself change its basic appearance */
 	/client/proc/debug_variables,
 	/client/proc/show_snpc_verbs,
-	/client/proc/reset_all_tcs			/*resets all telecomms scripts*/
+	/client/proc/reset_all_tcs,			/*resets all telecomms scripts*/
+	/client/proc/cmd_admin_mentorpai
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -910,3 +910,82 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		to_chat(usr, "\red ERT has been <b>Disabled</b>.")
 		log_admin("Admin [key_name(src)] has disabled ERT calling.")
 		message_admins("Admin [key_name_admin(usr)] has disabled ERT calling.", 1)
+
+/client/proc/cmd_admin_mentorpai()
+	set category = "Admin"
+	set name = "Send Teacher pAI"
+	set desc = "Turns a ghost into a pAI that teaches a player"
+	if(!holder || !holder.rights || !holder.rights & R_ADMIN)
+		to_chat(usr, "<span class='warning'>Admin only.</span>")
+		return
+	var/list/tcandidates = list()
+	for(var/mob/living/carbon/human/H in player_list)
+		if (H.stat != DEAD)
+			tcandidates += H
+	if(!tcandidates.len)
+		to_chat(usr, "No human-type mobs found.")
+		return
+	var/mob/living/carbon/M = input(usr, "Choose player to recieve help.", "Choose Help Recipient") in tcandidates
+	if (M.stat == DEAD)
+		to_chat(usr, "Player [M] is dead.")
+		return
+	var/list/thecandidates = list()
+	for(var/mob/dead/observer/O in player_list)
+		if(!O.client)
+			continue
+		if(!player_old_enough_antag(O.client,ROLE_PAI))
+			continue
+		if(jobban_isbanned(O, "pAI") || jobban_isbanned(O,"nonhumandept") )
+			continue
+		if (O.has_enabled_antagHUD)
+			continue
+		thecandidates += O
+	if(!thecandidates.len)
+		to_chat(usr, "No suitable candidates to be pAI.")
+		return
+
+	var/choice = input("Hand-pick who will help [M]? If yes, you will pick from ghosts. If no, any ghost can volunteer.") in list ("Yes", "No")
+	var/mob/dead/observer/theguy = null
+	if(choice == "Yes")
+		theguy = input(usr, "Who will help [M]?", "Choose Player") in thecandidates
+		if(!theguy || !istype(theguy))
+			to_chat(usr, "Invalid candidate.")
+			return
+	else if(choice == "No")
+		var/list/hcandidates = pollCandidates("Play a Mentor pAI, sent to teach [M]?")
+		if (hcandidates.len)
+			theguy = pick(hcandidates)
+		else
+			to_chat(usr, "No ghosts volunteered to help teach [M].")
+			return
+	else
+		to_chat(usr, "Selection Error.")
+		return
+
+	var/obj/item/device/paicard/C = new /obj/item/device/paicard(M)
+	C.loc = M.loc
+	var/mob/living/silicon/pai/P = new /mob/living/silicon/pai(C)
+	var/chosen_name = input(theguy, "Enter your pAI name:", "pAI Name", "Personal AI") as text
+	if (chosen_name)
+		P.name = chosen_name
+	else
+		P.name = "H.E.L.P.E.R"
+	P.real_name = P.name
+	P.key = theguy.key
+	C.setPersonality(P)
+	C.looking_for_personality = 0
+	ticker.mode.update_cult_icons_removed(C.pai.mind)
+	ticker.mode.update_rev_icons_removed(C.pai.mind)
+	P.pai_law0 = "Guide and advise [M]"
+	var/datum/dna/dna = M.dna
+	P.master = M.real_name
+	P.master_dna = dna.unique_enzymes
+	to_chat(P,"<span class='notice'>You are a pAI sent to teach [M] about life on the Cyberiad. (IE: to help them learn the game)</span>")
+	to_chat(P,"<span class='notice'>You do not have to obey them, but should answer their questions, and give them good advice.</span>")
+	to_chat(P,"<span class='notice'>Don't do anything that would seriously interfere with the round - just focus on teaching [M] how to play their role.</span>")
+	C.visible_message("<span class='notice'>[M] finds [C]!</span>")
+	M.desc = "A personal AI unit, sent to help [M]."
+	C.radio.broadcasting = 1
+	C.locked = 1 // prevents the 'master' changing directives, disabling radio, etc.
+	P.locked = 1
+

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -915,7 +915,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set category = "Admin"
 	set name = "Send Teacher pAI"
 	set desc = "Turns a ghost into a pAI that teaches a player"
-	if(!holder || !holder.rights || !holder.rights & R_ADMIN)
+	if(!check_rights(R_ADMIN))
 		to_chat(usr, "<span class='warning'>Admin only.</span>")
 		return
 	var/list/tcandidates = list()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -915,8 +915,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set category = "Admin"
 	set name = "Send Teacher pAI"
 	set desc = "Turns a ghost into a pAI that teaches a player"
-	if(!check_rights(R_ADMIN))
-		to_chat(usr, "<span class='warning'>Admin only.</span>")
+	if(!check_rights(R_ADMIN, 1))
 		return
 	var/list/tcandidates = list()
 	for(var/mob/living/carbon/human/H in player_list)
@@ -926,9 +925,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		to_chat(usr, "No human-type mobs found.")
 		return
 	var/mob/living/carbon/M = input(usr, "Choose player to recieve help.", "Choose Help Recipient") in tcandidates
-	if (M.stat == DEAD)
-		to_chat(usr, "Player [M] is dead.")
-		return
 	var/list/thecandidates = list()
 	for(var/mob/dead/observer/O in player_list)
 		if(!O.client)
@@ -985,7 +981,3 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	to_chat(P,"<span class='notice'>Don't do anything that would seriously interfere with the round - just focus on teaching [M] how to play their role.</span>")
 	C.visible_message("<span class='notice'>[M] finds [C]!</span>")
 	M.desc = "A personal AI unit, sent to help [M]."
-	C.radio.broadcasting = 1
-	C.locked = 1 // prevents the 'master' changing directives, disabling radio, etc.
-	P.locked = 1
-

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -9,6 +9,7 @@
 	pass_flags = PASSTABLE
 	density = 0
 	holder_type = /obj/item/weapon/holder/pai
+	var/locked = 0 // immune to EMP if 1
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null
 
@@ -156,6 +157,10 @@
 	return
 
 /mob/living/silicon/pai/emp_act(severity)
+
+	if (locked)
+		return
+
 	// Silence for 2 minutes
 	// 20% chance to kill
 		// 33% chance to unbind

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -9,7 +9,6 @@
 	pass_flags = PASSTABLE
 	density = 0
 	holder_type = /obj/item/weapon/holder/pai
-	var/locked = 0 // immune to EMP if 1
 	var/network = "SS13"
 	var/obj/machinery/camera/current = null
 
@@ -157,10 +156,6 @@
 	return
 
 /mob/living/silicon/pai/emp_act(severity)
-
-	if (locked)
-		return
-
 	// Silence for 2 minutes
 	// 20% chance to kill
 		// 33% chance to unbind


### PR DESCRIPTION
Adds a "Send Teacher pAI" admin verb.

This verb enables admins to give a player a teacher pAI.
These are normal pAIs, with the following differences:
- Their goal is to teach/help/advise/guide their master, NOT simply to obey their orders.
- They won't be created unless there is a player to play them. Wiping their personality also destroys them.
- They cannot have their radios disabled, or their directives changed.
- They are immune to EMP.
- When a ghost selects to play a teacher pAI, it receives a message that its purpose is to guide/advise, not to overly influence the round.

Who would benefit from this?
- New players: this creates a new method for people to hang out with them, and teach them, without taking up job slots.
- Mentors: if a particular player is having lots of issues, a mentor can ask to be selected as their teacher pAI for the round, and use the round to guide them IC.
- Admins: admins can use this to give a specific newbie or recent migrant from another server a crash-course in playing on Paradise, or to have someone keep an eye on problematic players and steer them away from trouble.

:cl: Kyep
rscadd: "Send Teacher pAI" admin verb enabling admins to send an IC teacher (drawn from ghosts, or manually selected) to new players who need a bit of help.
/:cl: