### PR TITLE
Categorizes Late-Join Job List

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -419,22 +419,22 @@
 
 	var/list/activePlayers = list()
 	var/list/categorizedJobs = list(
-		"Miscellaneous" = list(jobs = list(), titles = list(), color = "#ffffff"),
 		"Command" = list(jobs = list(), titles = command_positions, color = "#aac1ee"),
-		"Synthetic" = list(jobs = list(), titles = nonhuman_positions, color = "#ccffcc"),
 		"Engineering" = list(jobs = list(), titles = engineering_positions, color = "#ffd699"),
-		"Medical" = list(jobs = list(), titles = medical_positions, color = "#99ffe6"),
-		"Science" = list(jobs = list(), titles = science_positions, color = "#e6b3e6"),
 		"Security" = list(jobs = list(), titles = security_positions, color = "#ff9999"),
+		"Miscellaneous" = list(jobs = list(), titles = list(), color = "#ffffff", colBreak = 1),
+		"Synthetic" = list(jobs = list(), titles = nonhuman_positions, color = "#ccffcc"),
+		"Support / Service" = list(jobs = list(), titles = service_positions, color = "#cccccc"),
+		"Medical" = list(jobs = list(), titles = medical_positions, color = "#99ffe6", colBreak = 1),
+		"Science" = list(jobs = list(), titles = science_positions, color = "#e6b3e6"),
 		"Supply" = list(jobs = list(), titles = supply_positions, color = "#ead4ae"),
-		"Support / Service" = list(jobs = list(), titles = service_positions, color = "#cccccc")
 		)
 	for(var/datum/job/job in job_master.occupations)
 		if(job && IsJobAvailable(job.title))
 			activePlayers[job] = 0
 			var/categorized = 0
 			// Only players with the job assigned and AFK for less than 10 minutes count as active
-			for(var/mob/M in player_list) if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)
+			for(var/mob/M in player_list) if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 MINUTES)
 				activePlayers[job]++
 			for(var/jobcat in categorizedJobs)
 				var/list/jobs = categorizedJobs[jobcat]["jobs"]
@@ -453,7 +453,10 @@
 			if(!categorized)
 				categorizedJobs["Miscellaneous"]["jobs"] += job
 
+	dat += "<table><tr><td valign='top'>"
 	for(var/jobcat in categorizedJobs)
+		if(categorizedJobs[jobcat]["colBreak"])
+			dat += "</td><td valign='top'>"
 		if(length(categorizedJobs[jobcat]["jobs"]) < 1)
 			continue
 		var/color = categorizedJobs[jobcat]["color"]
@@ -463,11 +466,11 @@
 			dat += "<a href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</a><br>"
 		dat += "</fieldset><br>"
 
-	dat += "</center>"
+	dat += "</td></tr></table></center>"
 	// Removing the old window method but leaving it here for reference
 //		src << browse(dat, "window=latechoices;size=300x640;can_close=1")
 	// Added the new browser window method
-	var/datum/browser/popup = new(src, "latechoices", "Choose Profession", 440, 500)
+	var/datum/browser/popup = new(src, "latechoices", "Choose Profession", 900, 600)
 	popup.add_stylesheet("playeroptions", 'html/browser/playeroptions.css')
 	popup.set_content(dat)
 	popup.open(0) // 0 is passed to open so that it doesn't use the onclose() proc


### PR DESCRIPTION
Currently, when you try to join a round that's already started, you're given an ugly list of every open position, sorted only by the order that the job datums happen to be defined. You've all seen it. It's *awful.*

This PR makes it non-awful, by organizing the jobs into appropriate categories. If there are no jobs available in a given category, it won't show up. And, it makes the window *real* big - big enough to fit *all* the jobs, so you don't have to scroll. I know how much you hate scrolling.

Also, in case you're wondering why the NT Rep, Blueshield, Magistrate, and IAAs are all lumped together with the service jobs, that just happens to be the list they're in. Not my fault.

#### Before ####
![2016-06-29_18-22-10](https://cloud.githubusercontent.com/assets/10916307/16470927/4c3c197a-3e27-11e6-809b-b66609bfa1f4.png)

#### After ####
![2016-06-29_22-03-24](https://cloud.githubusercontent.com/assets/10916307/16474855/339ae95c-3e48-11e6-8145-c78b3b41106e.png)

:cl:
tweak: The late-join job listing is now big enough to show all the jobs at once, and organizes them into labeled categories.
/:cl: