### PR TITLE
Fixes Sound/Debug Preferences

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -58,7 +58,7 @@
 	// and play
 	var/turf/source = get_turf(instrumentObj)
 	for(var/mob/M in hearers(15, source))
-		if(!M.client || !(M.client.prefs.toggles & SOUND_INSTRUMENTS))
+		if(!M.client || !(M.client.prefs.sound & SOUND_INSTRUMENTS))
 			continue
 		M.playsound_local(source, soundfile, 100, falloff = 5)
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -186,9 +186,9 @@
 	set name = "Hear/Silence Instruments"
 	set category = "Preferences"
 	set desc = "Toggles hearing musical instruments like the violin and piano"
-	prefs.toggles ^= SOUND_INSTRUMENTS
+	prefs.sound ^= SOUND_INSTRUMENTS
 	prefs.save_preferences(src)
-	if(prefs.toggles & SOUND_INSTRUMENTS)
+	if(prefs.sound & SOUND_INSTRUMENTS)
 		to_chat(src, "You will now hear people playing musical instruments.")
 	else
 		to_chat(src, "You will no longer hear musical instruments.")


### PR DESCRIPTION
I found you, you little shit.

Fixes https://github.com/ParadiseSS13/Paradise/issues/4722

Instruments were using a pref toggle as opposed to a pref sound.

Guess what bitflag instruments were using? 128. Guess what bitflag debug logs were using? You guessed it, 128. Now guess what debug log is? Yup...a pref toggle. So two things saving to the same column, essentially.

This should finally mean that debug log prefs and instrument prefs are two separate things.

Doesn't impact players, just admins.