### PR TITLE
Fixes Lack of to_chat in interface.dm

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -10,7 +10,7 @@
 		else
 			src << link(config.wikiurl)
 	else
-		src << "<span class='danger'>The wiki URL is not set in the server configuration.</span>"
+		to_chat(src, "<span class='danger'>The wiki URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/changes()
@@ -51,7 +51,7 @@
 			return
 		src << link(config.forumurl)
 	else
-		src << "<span class='danger'>The forum URL is not set in the server configuration.</span>"
+		to_chat(src, "<span class='danger'>The forum URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/rules()
@@ -63,7 +63,7 @@
 			return
 		src << link(config.rulesurl)
 	else
-		src << "<span class='danger'>The rules URL is not set in the server configuration.</span>"
+		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/donate()
@@ -75,7 +75,7 @@
 			return
 		src << link(config.donationsurl)
 	else
-		src << "<span class='danger'>The rules URL is not set in the server configuration.</span>"
+		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
 	return
 
 /client/verb/hotkeys_help()
@@ -94,7 +94,7 @@ Admin:
 	mob.hotkey_help()
 
 	if(check_rights(R_MOD|R_ADMIN,0))
-		src << adminhotkeys
+		to_chat(src, adminhotkeys)
 
 /mob/proc/hotkey_help()
 	var/hotkey_mode = {"<font color='purple'>
@@ -151,8 +151,8 @@ Any-Mode: (hotkey doesn't need to be on)
 \tF4 = Me
 </font>"}
 
-	src << hotkey_mode
-	src << other
+	to_chat(src, hotkey_mode)
+	to_chat(src, other)
 
 /mob/living/silicon/robot/hotkey_help()
 	var/hotkey_mode = {"<font color='purple'>
@@ -203,15 +203,15 @@ Any-Mode: (hotkey doesn't need to be on)
 \tF4 = Me
 </font>"}
 
-	src << hotkey_mode
-	src << other
+	to_chat(src, hotkey_mode)
+	to_chat(src, other)
 
 //adv. hotkey mode verbs, vars located in /code/modules/client/client defines.dm
 /client/verb/hotkey_toggle()//toggles hotkey mode between on and off, respects selected type
 	set name = ".Toggle Hotkey Mode"
 
 	hotkeyon = !hotkeyon//toggle the var
-	usr << (hotkeyon ? "Hotkey mode enabled." : "Hotkey mode disabled.")//feedback to the user
+	to_chat(usr, (hotkeyon ? "Hotkey mode enabled." : "Hotkey mode disabled."))//feedback to the user
 
 	if(hotkeyon)//using an if statement because I don't want to clutter winset() with ? operators
 		winset(usr, "mainwindow.hotkey_toggle", "is-checked=true")//checks the button
@@ -233,4 +233,4 @@ Any-Mode: (hotkey doesn't need to be on)
 	var/hotkeyname = hotkeys[hotkeyon ? "on" : "off"]//get the name of the hotkey, to not clutter winset() to much
 
 	winset(usr, "mainwindow", "macro=[hotkeyname]")//change the hotkey
-	usr << "Hotkey mode changed to [hotkeytype]."
+	to_chat(usr, "Hotkey mode changed to [hotkeytype].")


### PR DESCRIPTION
Turns out interface.dm isn't in the code folder, so it didn't get hit by the to_chat script. The only significant consequence of this is that it broke Hotkey Help.

:cl:
bugfix: Fixed Hotkey Help and hotkey mode toggle messages not appearing.
/:cl: