### PR TITLE
Adds Short Delay to Late-Join Job Selection

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -472,6 +472,7 @@
 	// Added the new browser window method
 	var/datum/browser/popup = new(src, "latechoices", "Choose Profession", 900, 600)
 	popup.add_stylesheet("playeroptions", 'html/browser/playeroptions.css')
+	popup.add_script("delay_interactivity", 'html/browser/delay_interactivity.js')
 	popup.set_content(dat)
 	popup.open(0) // 0 is passed to open so that it doesn't use the onclose() proc
 

--- a/html/browser/delay_interactivity.js
+++ b/html/browser/delay_interactivity.js
@@ -1,0 +1,24 @@
+// Disables all links for one second after the browser window opens.
+
+(function(){
+  // If there's already an onload, let's not clobber it
+  var oldonload = window.onload
+  window.onload = function(){
+    if(typeof oldonload == 'function')
+      oldonload();
+    var onclicks = Array();
+    var links = document.getElementsByTagName("a");
+    var returnfalse = function(){return false;};
+    for(var i = 0; i < links.length; i++){
+      onclicks.push(links[i].onclick);
+      links[i].onclick = returnfalse;
+    }
+    setTimeout(function(){
+      for(var i = 0; i < links.length; i++){
+        // Reset onclick, but only if something else hasn't already changed it
+        if(links[i].onclick == returnfalse)
+          links[i].onclick = onclicks[i];
+      }
+    }, 1000);
+  };
+})();

--- a/html/browser/delay_interactivity.js
+++ b/html/browser/delay_interactivity.js
@@ -2,10 +2,11 @@
 
 (function(){
   // If there's already an onload, let's not clobber it
-  var oldonload = window.onload
+  var oldonload = window.onload;
   window.onload = function(){
-    if(typeof oldonload == 'function')
+    if(typeof oldonload == 'function'){
       oldonload();
+    }
     var onclicks = Array();
     var links = document.getElementsByTagName("a");
     var returnfalse = function(){return false;};
@@ -16,8 +17,9 @@
     setTimeout(function(){
       for(var i = 0; i < links.length; i++){
         // Reset onclick, but only if something else hasn't already changed it
-        if(links[i].onclick == returnfalse)
+        if(links[i].onclick == returnfalse){
           links[i].onclick = onclicks[i];
+        }
       }
     }, 1000);
   };


### PR DESCRIPTION
Now that the late-join job list is significantly larger, I'm anticipating that more people will accidentally click where a job is a split second after it pops up. I *could* avoid this by adding a simple confirmation box to picking a job, but where's the fun in that?

This PR adds a simple bit of Javascript that disables all links for the first second after a window pops up, and includes it with the late-join job list. No more "Surprise! You're playing as the Head of Immediate Regret!"... unless you struggle to accurately click on the links anyway.

The script should actually be generic enough that it could be included in *any* window with potentially unsafe links, though this window is probably the worst one for a rogue click to happen in.

:cl:
tweak: The late-join job listing will now ignore (mis)clicks for the first second after popping up.
/:cl: