### PR TITLE
Fixes a Few Non-Respected Shields

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -409,6 +409,12 @@ Congratulations! You are now trained for xenobiology research!"}
 
 	user.do_attack_animation(L)
 
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(H.check_shields(0, "[user]'s [name]"))
+			playsound(L, 'sound/weapons/Genhit.ogg', 50, 1)
+			return 0
+
 	switch (mode)
 		if(BATON_STUN)
 			StunAttack(L,user)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -132,6 +132,11 @@
 
 
 /obj/item/weapon/melee/baton/proc/baton_stun(mob/living/L, mob/user)
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(H.check_shields(0, "[user]'s [name]")) //No message; check_shields() handles that
+			playsound(L, 'sound/weapons/Genhit.ogg', 50, 1)
+			return 0
 	user.lastattacked = L
 	L.lastattacker = user
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -136,7 +136,7 @@
 		var/mob/living/carbon/human/H = L
 		if(H.check_shields(0, "[user]'s [name]")) //No message; check_shields() handles that
 			playsound(L, 'sound/weapons/Genhit.ogg', 50, 1)
-			return 0
+			return
 	user.lastattacked = L
 	L.lastattacker = user
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -54,7 +54,7 @@
 				if(ishuman(target))
 					var/mob/living/carbon/human/H = target
 					if(H.check_shields(0, "[user]'s [name]"))
-						return
+						return 0
 				playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 				target.Weaken(3)
 				add_logs(target, user, "stunned", object="[src]")

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -51,6 +51,10 @@
 			if(!isrobot(target)) return
 		else
 			if(cooldown <= 0)
+				if(ishuman(target))
+					var/mob/living/carbon/human/H = target
+					if(H.check_shields(0, "[user]'s [name]"))
+						return
 				playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 				target.Weaken(3)
 				add_logs(target, user, "stunned", object="[src]")


### PR DESCRIPTION
I noticed this a while back, but forgot---then I remembered again and checked TG as well...

Fixes stun batons, telebatons, and abductor batons not respecting shields.

Because all of these either overloaded the `attack` proc *or* were based on an `afterattack` they would bypass shields...this isn't intentional as there's very clearly an entire flag (NOSHIELD) dedicated for this.

:cl: Fox McCloud
fix: Fixes stun batons, telebatons, and abductor batons piercing/bypassing shields
/:cl: