### PR TITLE
Fixes Very Early Logging Runtimes

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -82,8 +82,8 @@
 	diary << "\[[time_stamp()]]MISC: [text][log_end]"
 
 /proc/log_to_dd(text)
-	world.log << text //this comes before the config check because it can't possibly runtime
-	if(config.log_world_output)
+	world.log << text
+	if(config && config.log_world_output)
 		diary << "\[[time_stamp()]]DD_OUTPUT: [text][log_end]"
 
 /**

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -112,7 +112,8 @@ var/global/datum/ErrorViewer/ErrorCache/error_cache = null
 
 	// Show the error to admins with debug messages turned on, but only if one
 	//  from the same source hasn't been shown too recently
-	if(error_source.next_message_at <= world.time)
+	// (Also, make sure config is initialized, or log_debug will runtime)
+	if(config && error_source.next_message_at <= world.time)
 		var/const/viewtext = "\[view]" // Nesting these in other brackets went poorly
 		log_debug("Runtime in [e.file],[e.line]: [html_encode(e.name)] [error_entry.makeLink(viewtext)]")
 		error_source.next_message_at = world.time + ERROR_MSG_DELAY


### PR DESCRIPTION
Turns out, log_to_dd can runtime if it's called too early, despite it being the intended way to log to the lowest-level, always-available logging target. It even has a comment mentioning that it can runtime, despite the fact that all it needs to do is make sure config exists! Which it now does.

That was breaking the error handler, since it turns out it was logging errors earlier than I was expecting it to. The order globals are initialized in is weird. Another thing that breaks error handling: the error viewer trying to notify admins using a logging proc that depends on config existing. Now it checks config first, so if you're runtiming before config even gets a chance to initialize, you won't get *even more runtimes.*