### PR TITLE
Minor Bug / Exploit Fixes

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1061,6 +1061,8 @@
 				to_chat(user, "You start prying out the circuit.")
 				playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
 				if(do_after(user,20, target = src))
+					if(buildstage != 1)
+						return
 					to_chat(user, "You pry out the circuit!")
 					var/obj/item/weapon/airalarm_electronics/circuit = new /obj/item/weapon/airalarm_electronics()
 					circuit.loc = user.loc

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -110,7 +110,9 @@ FIRE ALARM
 				else if(istype(W, /obj/item/weapon/crowbar))
 					to_chat(user, "<span class='warning'>You pry out the circuit!</span>")
 					playsound(get_turf(src), 'sound/items/Crowbar.ogg', 50, 1)
-					spawn(20)
+					if(do_after(user, 20, target = src))
+						if(buildstage != 1)
+							return
 						var/obj/item/weapon/firealarm_electronics/circuit = new /obj/item/weapon/firealarm_electronics()
 						circuit.loc = user.loc
 						buildstage = 0

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -141,6 +141,8 @@
 				to_chat(user, "<span class='notice'>You cut out the intercoms wiring and disconnect its electronics.</span>")
 				playsound(get_turf(src), 'sound/items/Wirecutter.ogg', 50, 1)
 				if(do_after(user, 10, target = src))
+					if(buildstage != 3)
+						return
 					new /obj/item/stack/cable_coil(get_turf(src),5)
 					on = 0
 					b_stat = 1
@@ -178,6 +180,8 @@
 				to_chat(user, "<span class='notice'>You begin removing the electronics...</span>")
 				playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 				if(do_after(user, 10, target = src))
+					if(buildstage != 1)
+						return
 					new /obj/item/weapon/intercom_electronics(get_turf(src))
 					to_chat(user, "<span class='notice'>The circuitboard pops out!</span>")
 					buildstage = 0

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -194,7 +194,9 @@
 	if(.)
 		amount_grown += rand(1,2)
 		if(amount_grown >= 100)
-			new /mob/living/simple_animal/chicken(src.loc)
+			var/mob/living/simple_animal/chicken/C = new /mob/living/simple_animal/chicken(src.loc)
+			if(key)
+				C.key = key
 			qdel(src)
 
 var/const/MAX_CHICKENS = 50

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -194,9 +194,9 @@
 	if(.)
 		amount_grown += rand(1,2)
 		if(amount_grown >= 100)
-			var/mob/living/simple_animal/chicken/C = new /mob/living/simple_animal/chicken(src.loc)
-			if(key)
-				C.key = key
+			var/mob/living/simple_animal/chicken/C = new /mob/living/simple_animal/chicken(loc)
+			if(mind)
+				mind.transfer_to(C)
 			qdel(src)
 
 var/const/MAX_CHICKENS = 50


### PR DESCRIPTION
Fixes #4786
- Chicks that age up to chicken will retain their ghost (if any) into their adult stage.

Fixes #4836
- Intercoms now properly check their buildstage when removing cables and electronics to avoid being used to infinitely generate these objects
 - Fire alarms and air alarms now also have this exploit-protection. APCs already had a form of this protection.

:cl:
bugfix: Chicks no longer lose their souls (literally) when becoming adults.
bugfix: Intercoms, fire alarms, and air alarms no longer contain internal portals to a realm of infinite cables and circuit boards.
/:cl: