### PR TITLE
Loadout Points Config Option and Loadout Fixes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -177,6 +177,8 @@
 	var/disable_lobby_music = 0 // Disables the lobby music
 	var/disable_cid_warn_popup = 0 //disables the annoying "You have already logged in this round, disconnect or be banned" popup, because it annoys the shit out of me when testing.
 
+	var/max_loadout_points = 5 // How many points can be spent on extra items in character setup
+
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
 	for (var/T in L)
@@ -551,6 +553,9 @@
 
 				if("disable_cid_warn_popup")
 					config.disable_cid_warn_popup = 1
+
+				if("max_loadout_points")
+					config.max_loadout_points = text2num(value)
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -5,9 +5,9 @@
 	sort_category = "Uniforms and Casual Dress"
 
 /datum/gear/uniform/skirt
-	display_name = "skirt"
+	subtype_path = /datum/gear/uniform/skirt
 
-/datum/gear/uniform/skirt
+/datum/gear/uniform/skirt/blue
 	display_name = "plaid skirt, blue"
 	path = /obj/item/clothing/under/dress/plaid_blue
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -63,7 +63,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 #define MAX_SAVE_SLOTS 20 // Save slots for regular players
 #define MAX_SAVE_SLOTS_MEMBER 20 // Save slots for BYOND members
 
-#define MAX_GEAR_COST 5
+#define MAX_GEAR_COST config.max_loadout_points
 
 #define TAB_CHAR 0
 #define TAB_GAME 1
@@ -435,9 +435,9 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			var/fcolor =  "#3366CC"
 			if(total_cost < MAX_GEAR_COST)
 				fcolor = "#E67300"
-			dat += "<table align='center' width='820px'>"
-			dat += "<tr><td colspan=3><center><b><font color='[fcolor]'>[total_cost]/[MAX_GEAR_COST]</font> loadout points spent.</b> \[<a href='?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
-			dat += "<tr><td colspan=3><center><b>"
+			dat += "<table align='center' width='100%'>"
+			dat += "<tr><td colspan=4><center><b><font color='[fcolor]'>[total_cost]/[MAX_GEAR_COST]</font> loadout points spent.</b> \[<a href='?_src_=prefs;preference=gear;clear_loadout=1'>Clear Loadout</a>\]</center></td></tr>"
+			dat += "<tr><td colspan=4><center><b>"
 
 			var/firstcat = 1
 			for(var/category in loadout_categories)
@@ -452,22 +452,22 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			dat += "</b></center></td></tr>"
 
 			var/datum/loadout_category/LC = loadout_categories[gear_tab]
-			dat += "<tr><td colspan=3><hr></td></tr>"
-			dat += "<tr><td colspan=3><b><center>[LC.category]</center></b></td></tr>"
-			dat += "<tr><td colspan=3><hr></td></tr>"
+			dat += "<tr><td colspan=4><hr></td></tr>"
+			dat += "<tr><td colspan=4><b><center>[LC.category]</center></b></td></tr>"
+			dat += "<tr><td colspan=4><hr></td></tr>"
 			for(var/gear_name in LC.gear)
 				var/datum/gear/G = LC.gear[gear_name]
 				var/ticked = (G.display_name in gear)
 				dat += "<tr style='vertical-align:top;'><td width=15%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?_src_=prefs;preference=gear;toggle_gear=[G.display_name]'>[G.display_name]</a></td>"
-				dat += "<td width = 5% style='vertical-align:top'>[G.cost]</td>"
+				dat += "<td width = 5% style='vertical-align:top'>[G.cost]</td><td>"
 				if(G.allowed_roles)
-					dat += "<td><font size=2>Restrictions: "
+					dat += "<font size=2>Restrictions: "
 					for(var/role in G.allowed_roles)
 						dat += role + " "
-					dat += "</font></td>"
-				dat += "<td><font size=2><i>[G.description]</i></font></td></tr>"
+					dat += "</font>"
+				dat += "</td><td><font size=2><i>[G.description]</i></font></td></tr>"
 				if(ticked)
-					. += "<tr><td colspan=3>"
+					. += "<tr><td colspan=4>"
 					for(var/datum/gear_tweak/tweak in G.gear_tweaks)
 						. += " <a href='?_src_=prefs;preference=gear;gear=[G.display_name];tweak=\ref[tweak]'>[tweak.get_contents(get_tweak_metadata(G, tweak))]</a>"
 					. += "</td></tr>"

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -318,3 +318,6 @@ PLAYER_REROUTE_CAP 0
 
 ## Uncomment this if you want to disable the popup alert for people on the same CID
 #DISABLE_CID_WARN_POPUP
+
+## How many loadout points players may spend in character setup
+#MAX_LOADOUT_POINTS 5


### PR DESCRIPTION
- Adds a configuration option for loadout points, since deciding to change this probably shouldn't require a code change.
- Fixes the blue plaid skirt lacking its own unique type, causing runtimes due to the mismatch between its display_name and initial(display_name).
- Fixes the gear selection table having a fixed width, rather than matching the width of the window.
- Fixes the restrictions column not consistently being added, misaligning the table.
- Fixes the header and footer (which I think nothing uses yet?) lacking the proper column span to account for the restrictions column, misaligning them.