### PR TITLE
Fixes Player Transform Confirmation Dialogs

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1124,7 +1124,7 @@
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		if(alert(usr, "Confirm make monkey?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make monkey?",, "Yes", "No") != "Yes")
 			return
 
 		log_admin("[key_name(usr)] attempting to monkeyize [key_name(H)]")
@@ -1140,7 +1140,7 @@
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
 
-		if(alert(usr, "Confirm make corgi?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make corgi?",, "Yes", "No") != "Yes")
 			return
 
 		log_admin("[key_name(usr)] attempting to corgize [key_name(H)]")
@@ -1154,7 +1154,7 @@
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		if(alert(usr, "Confirm make pai?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make pai?",, "Yes", "No") != "Yes")
 			return
 
 		var/painame = "Default"
@@ -1414,7 +1414,7 @@
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
 
-		if(alert(usr, "Confirm make ai?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make ai?",, "Yes", "No") != "Yes")
 			return
 
 		message_admins("\red Admin [key_name_admin(usr)] AIized [key_name_admin(H)]!", 1)
@@ -1425,7 +1425,7 @@
 	else if(href_list["makemask"])
 		if(!check_rights(R_SPAWN))	return
 
-		if(alert(usr, "Confirm make mask?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make mask?",, "Yes", "No") != "Yes")
 			return
 
 		var/mob/currentMob = locate(href_list["makemask"])
@@ -1441,7 +1441,7 @@
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		if(alert(usr, "Confirm make alien?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make alien?",, "Yes", "No") != "Yes")
 			return
 
 		usr.client.cmd_admin_alienize(H)
@@ -1453,7 +1453,7 @@
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		if(alert(usr, "Confirm make slime?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make slime?",, "Yes", "No") != "Yes")
 			return
 
 		usr.client.cmd_admin_slimeize(H)
@@ -1466,7 +1466,7 @@
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
 
-		if(alert(usr, "Confirm make superhero?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make superhero?",, "Yes", "No") != "Yes")
 			return
 
 		usr.client.cmd_admin_super(H)
@@ -1478,7 +1478,7 @@
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		if(alert(usr, "Confirm make robot?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make robot?",, "Yes", "No") != "Yes")
 			return
 
 		usr.client.cmd_admin_robotize(H)
@@ -1490,7 +1490,7 @@
 		if(istype(M, /mob/new_player))
 			to_chat(usr, "This cannot be used on instances of type /mob/new_player")
 			return
-		if(alert(usr, "Confirm make animal?", "Yes", "No") != "Yes")
+		if(alert(usr, "Confirm make animal?",, "Yes", "No") != "Yes")
 			return
 
 		usr.client.cmd_admin_animalize(M)


### PR DESCRIPTION
None of these worked. You can't select "Yes" because it's where the title goes, so the **only** option is "No". They weren't tested at all.  :disappointed: