### PR TITLE
Changes the janiborg's mop into an advanced mop

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -227,6 +227,9 @@
 						var/i = 1
 						for(1, i <= coeff, i++)
 							LR.Charge(occupant)
+					if(istype(O,/obj/item/weapon/mop/advanced))
+						if(O.reagents.get_reagent_amount("water") < 40)
+							O.reagents.add_reagent("water", 0.5 * coeff)
 				if(R)
 					if(R.module)
 						R.module.respawn_consumable(R)

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -15,18 +15,13 @@
 	var/mopcount = 0
 	var/mopcap = 5
 	var/mopspeed = 30
-	var/cyborg = 0
 
 /obj/item/weapon/mop/New()
 	create_reagents(mopcap)
-	if(cyborg)
-		reagents.add_reagent("water", mopcap)
-	else
-		janitorial_equipment += src
+	janitorial_equipment += src
 
 /obj/item/weapon/mop/Destroy()
-	if(!cyborg)
-		janitorial_equipment -= src
+	janitorial_equipment -= src
 	return ..()
 
 /obj/item/weapon/mop/proc/clean(turf/simulated/A)
@@ -36,8 +31,7 @@
 			if(is_cleanable(O))
 				qdel(O)
 	reagents.reaction(A, TOUCH, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
-	if(!cyborg)
-		reagents.remove_any(1)			//reaction() doesn't use up the reagents
+	reagents.remove_any(1)			//reaction() doesn't use up the reagents
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
@@ -85,6 +79,14 @@
 	throwforce = 8
 	throw_range = 4
 	mopspeed = 20
-/obj/item/weapon/mop/advanced/cyborg/
-	cyborg = 1
-	mopcap = 1
+
+/obj/item/weapon/mop/advanced/cyborg
+	mopcap = 40
+
+/obj/item/weapon/mop/advanced/cyborg/New()
+	..()
+	reagents.add_reagent("water", mopcap)
+
+/obj/item/weapon/mop/advanced/cyborg/examine(mob/user)
+	..(user)
+	to_chat(user, "<span class='notice'>The mop's water tank has [round(reagents.get_reagent_amount("water"))] units of water left.</span>")

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -15,14 +15,18 @@
 	var/mopcount = 0
 	var/mopcap = 5
 	var/mopspeed = 30
-
+	var/cyborg = 0
 
 /obj/item/weapon/mop/New()
 	create_reagents(mopcap)
-	janitorial_equipment += src
+	if(cyborg)
+		reagents.add_reagent("water", mopcap)
+	else
+		janitorial_equipment += src
 
 /obj/item/weapon/mop/Destroy()
-	janitorial_equipment -= src
+	if(!cyborg)
+		janitorial_equipment -= src
 	return ..()
 
 /obj/item/weapon/mop/proc/clean(turf/simulated/A)
@@ -32,8 +36,8 @@
 			if(is_cleanable(O))
 				qdel(O)
 	reagents.reaction(A, TOUCH, 10)	//10 is the multiplier for the reaction effect. probably needed to wet the floor properly.
-	reagents.remove_any(1)			//reaction() doesn't use up the reagents
-
+	if(!cyborg)
+		reagents.remove_any(1)			//reaction() doesn't use up the reagents
 
 /obj/item/weapon/mop/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
@@ -81,3 +85,6 @@
 	throwforce = 8
 	throw_range = 4
 	mopspeed = 20
+/obj/item/weapon/mop/advanced/cyborg/
+	cyborg = 1
+	mopcap = 1

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -230,7 +230,7 @@
 	src.modules += new /obj/item/device/flash/cyborg(src)
 	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
 	src.modules += new /obj/item/weapon/storage/bag/trash/cyborg(src)
-	src.modules += new /obj/item/weapon/mop(src)
+	src.modules += new /obj/item/weapon/mop/advanced/cyborg(src)
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/weapon/holosign_creator(src)
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)


### PR DESCRIPTION
Now the mop is potentially actually useful. The mop holds 40u of water and can be refilled at a cyborg recharging station or by dunking it in a mop bucket like usual. Also, it shows the amount of water in it when examined (This only applies to the janiborg mops).