### PR TITLE
Minor Flag Refactor

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -78,3 +78,5 @@
 
 #define BLOCKHEADHAIR 			4		// temporarily removes the user's hair overlay. Leaves facial hair.
 #define BLOCKHAIR				32768	// temporarily removes the user's hair, facial and otherwise.
+
+#define ONESIZEFITSALL 			1		// determines if something can be worn by a fatty or not.

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -7,10 +7,7 @@
 #define NOSHIELD				32		// weapon not affected by shield
 #define CONDUCT					64		// conducts electricity (metal etc.)
 #define ABSTRACT				128		// for all things that are technically items but used for various different stuff, made it 128 because it could conflict with other flags other way
-#define ON_BORDER				512		// item has priority to check when entering or leaving
-#define NODELAY 				32768	// 1 second attackby delay skipped (Can be used once every 0.2s). Most objects have a 1s attackby delay, which doesn't require a flag.
-
-#define NOBLOODY				2048	// used to items if they don't want to get a blood overlay
+#define ON_BORDER				256		// item has priority to check when entering or leaving
 
 #define GLASSESCOVERSEYES		1024
 #define MASKCOVERSEYES			1024	// get rid of some of the other retardation in these flags
@@ -21,14 +18,13 @@
 #define HEADBANGPROTECT			4096
 #define EARBANGPROTECT			1024
 
-#define THICKMATERIAL 	1024			//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with NOSLIP)
 #define NOSLIP					1024 	//prevents from slipping on wet floors, in space etc
 
 #define OPENCONTAINER			4096	// is an open container for chemistry purposes
 
-#define BLOCK_GAS_SMOKE_EFFECT	8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY! (NOTE: flag shared with ONESIZEFITSALL)
-#define ONESIZEFITSALL 			8192
-#define PLASMAGUARD 			16384	//Does not get contaminated by plasma.
+#define BLOCK_GAS_SMOKE_EFFECT	8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY!
+#define THICKMATERIAL 			8192	//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
+
 
 #define	NOREACT					16384 	//Reagents dont' react inside this container.
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -352,9 +352,6 @@
 //returns 1 if made bloody, returns 0 otherwise
 /atom/proc/add_blood(mob/living/carbon/human/M as mob)
 
-	if(flags & NOBLOODY)
-		return 0
-
 	if(!blood_DNA || !istype(blood_DNA, /list))	//if our list of DNA doesn't exist yet (or isn't a list) initialise it.
 		blood_DNA = list()
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -55,6 +55,8 @@
 	var/put_on_delay = DEFAULT_ITEM_PUTON_DELAY
 	var/breakouttime = 0
 
+	var/flags_size = 0 //flag, primarily used for clothing to determine if a fatty can wear something or not.
+
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:
 	sprite_sheets = list(

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -5,7 +5,7 @@
 	anchored = 1
 	w_class = 4.0
 	canhear_range = 2
-	flags = CONDUCT | NOBLOODY
+	flags = CONDUCT
 	var/number = 0
 	var/circuitry_installed = 1
 	var/last_tick //used to delay the powercheck

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -99,7 +99,8 @@
 	icon_state = "santa"
 	item_state = "santa"
 	slowdown = 0
-	flags = ONESIZEFITSALL | STOPSPRESSUREDMAGE
+	flags = STOPSPRESSUREDMAGE
+	flags_size = ONESIZEFITSALL
 	allowed = list(/obj/item) //for stuffing exta special presents
 
 

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -11,7 +11,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	species_restricted = list("Plasmaman")
-	flags = STOPSPRESSUREDMAGE  | PLASMAGUARD
+	flags = STOPSPRESSUREDMAGE
 
 	icon_state = "plasmaman_suit"
 	item_state = "plasmaman_suit"
@@ -38,7 +38,7 @@
 /obj/item/clothing/head/helmet/space/eva/plasmaman
 	name = "plasmaman helmet"
 	desc = "A special containment helmet designed to protect a plasmaman's volatile body from outside exposure and quickly extinguish it in emergencies."
-	flags = STOPSPRESSUREDMAGE | PLASMAGUARD
+	flags = STOPSPRESSUREDMAGE
 	species_restricted = list("Plasmaman")
 
 	icon_state = "plasmaman_helmet0"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -15,7 +15,7 @@
 	icon_state = "armor"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	armor = list(melee = 25, bullet = 15, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/vest/jacket
@@ -31,7 +31,7 @@
 	icon_state = "armor-combat"
 	item_state = "bulletproof"
 	blood_overlay_type = "armor"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/suit/armor/vest/security
 	name = "security armor"
@@ -208,7 +208,7 @@
 	icon_state = "detective-armor"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	allowed = list(/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/device/flashlight,/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/lighter,/obj/item/device/detective_scanner,/obj/item/device/taperecorder)
 
 

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -16,7 +16,8 @@
 	w_class = 4//bulky item
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	flags = ONESIZEFITSALL | THICKMATERIAL
+	flags = THICKMATERIAL
+	flags_size = ONESIZEFITSALL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	slowdown = 1
 	allowed = list(/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/pen,/obj/item/device/flashlight/pen)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -48,7 +48,7 @@
 	item_state = "bio_suit"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	allowed = list(/obj/item/weapon/disk, /obj/item/weapon/stamp, /obj/item/weapon/reagent_containers/food/drinks/flask, /obj/item/weapon/melee, /obj/item/weapon/storage/lockbox/medal, /obj/item/device/flash, /obj/item/weapon/storage/box/matches, /obj/item/weapon/lighter, /obj/item/clothing/mask/cigarette, /obj/item/weapon/storage/fancy/cigarettes, /obj/item/weapon/tank/emergency_oxygen)
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -136,7 +136,7 @@
 	armor = list(melee = 25, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
@@ -173,7 +173,7 @@
 	armor = list(melee = 25, bullet = 10, laser = 25, energy = 10, bomb = 0, bio = 0, rad = 0)
 	cold_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 //Engineering
 /obj/item/clothing/suit/storage/hazardvest

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -272,7 +272,7 @@
 	item_state = "straight_jacket"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	strip_delay = 60
 
 /obj/item/clothing/suit/ianshirt
@@ -403,7 +403,7 @@
 	item_state = "xenos_helm"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 //swimsuit
 /obj/item/clothing/under/swimsuit/
@@ -446,7 +446,7 @@
 	w_class = 4//bulky item
 	gas_transfer_coefficient = 0.01
 	permeability_coefficient = 0.01
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/weapon/tank/emergency_oxygen,/obj/item/weapon/pen,/obj/item/device/flashlight/pen)
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 100, rad = 20)
@@ -487,7 +487,7 @@
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
 	strip_delay = 60
 	put_on_delay = 40
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	armor = list(melee = 25, bullet = 15, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)
 	//End of inheritance from Security armour.
 

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -16,7 +16,7 @@
 	icon_state = "black"
 	item_state = "bl_suit"
 	item_color = "black"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/blackf
 	name = "feminine black jumpsuit"
@@ -30,17 +30,18 @@
 	icon_state = "blue"
 	item_state = "b_suit"
 	item_color = "blue"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/blue/dodgeball
-	flags = ONESIZEFITSALL | NODROP
+	flags = NODROP
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/green
 	name = "green jumpsuit"
 	icon_state = "green"
 	item_state = "g_suit"
 	item_color = "green"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/grey
 	name = "grey jumpsuit"
@@ -48,10 +49,11 @@
 	icon_state = "grey"
 	item_state = "gy_suit"
 	item_color = "grey"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/grey/greytide
-	flags = ONESIZEFITSALL | NODROP
+	flags = NODROP
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/orange
 	name = "orange jumpsuit"
@@ -59,7 +61,7 @@
 	icon_state = "orange"
 	item_state = "o_suit"
 	item_color = "orange"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/orange/prison
 	name = "orange jumpsuit"
@@ -69,7 +71,7 @@
 	item_color = "orange"
 	has_sensor = 2
 	sensor_mode = 3
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/pink
 	name = "pink jumpsuit"
@@ -77,31 +79,32 @@
 	icon_state = "pink"
 	item_state = "p_suit"
 	item_color = "pink"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/red
 	name = "red jumpsuit"
 	icon_state = "red"
 	item_state = "r_suit"
 	item_color = "red"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/red/dodgeball
-	flags = ONESIZEFITSALL | NODROP
+	flags = NODROP
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/white
 	name = "white jumpsuit"
 	icon_state = "white"
 	item_state = "w_suit"
 	item_color = "white"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/yellow
 	name = "yellow jumpsuit"
 	icon_state = "yellow"
 	item_state = "y_suit"
 	item_color = "yellow"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/psyche
 	name = "psychedelic jumpsuit"
@@ -122,7 +125,7 @@
 	name = "aqua jumpsuit"
 	icon_state = "aqua"
 	item_color = "aqua"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/purple
 	name = "purple jumpsuit"
@@ -149,7 +152,7 @@
 	name = "light brown jumpsuit"
 	icon_state = "lightbrown"
 	item_color = "lightbrown"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/brown
 	name = "brown jumpsuit"
@@ -165,7 +168,7 @@
 	name = "dark blue jumpsuit"
 	icon_state = "darkblue"
 	item_color = "darkblue"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/lightred
 	name = "light red jumpsuit"
@@ -176,7 +179,7 @@
 	name = "dark red jumpsuit"
 	icon_state = "darkred"
 	item_color = "darkred"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/red/jersey
 	name = "red team jersey"
@@ -184,7 +187,7 @@
 	icon_state = "redjersey"
 	item_state = "r_suit"
 	item_color = "redjersey"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/color/blue/jersey
 	name = "blue team jersey"
@@ -192,4 +195,4 @@
 	icon_state = "bluejersey"
 	item_state = "b_suit"
 	item_color = "bluejersey"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -6,7 +6,7 @@
 	icon_state = "ba_suit"
 	item_state = "ba_suit"
 	item_color = "ba_suit"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/captain //Alright, technically not a 'civilian' but its better then giving a .dm file for a single define.
 	desc = "It's a blue jumpsuit with some gold markings denoting the rank of \"Captain\"."
@@ -14,7 +14,7 @@
 	icon_state = "captain"
 	item_state = "caparmor"
 	item_color = "captain"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/cargo
 	name = "quartermaster's jumpsuit"
@@ -22,7 +22,7 @@
 	icon_state = "qm"
 	item_state = "lb_suit"
 	item_color = "qm"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/cargo/skirt
 	name = "quartermaster's jumpskirt"
@@ -30,7 +30,7 @@
 	icon_state = "qmf"
 	item_color = "qmf"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/cargotech
 	name = "cargo technician's jumpsuit"
@@ -38,14 +38,14 @@
 	icon_state = "cargotech"
 	item_state = "lb_suit"
 	item_color = "cargo"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/cargotech/skirt
 	name = "cargo technician's jumpskirt"
 	desc = "Skirrrrrts! They're comfy and easy to wear!"
 	icon_state = "cargof"
 	item_color = "cargof"
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/chaplain
 	desc = "It's a black jumpsuit, often worn by religious folk."
@@ -53,14 +53,14 @@
 	icon_state = "chaplain"
 	item_state = "bl_suit"
 	item_color = "chapblack"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/chef
 	desc = "It's an apron which is given only to the most <b>hardcore</b> chefs in space."
 	name = "chef's uniform"
 	icon_state = "chef"
 	item_color = "chef"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/clown
 	name = "clown suit"
@@ -68,7 +68,7 @@
 	icon_state = "clown"
 	item_state = "clown"
 	item_color = "clown"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 
 /obj/item/clothing/under/rank/head_of_personnel
@@ -77,7 +77,7 @@
 	icon_state = "hop"
 	item_state = "b_suit"
 	item_color = "hop"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/head_of_personnel_whimsy
 	desc = "A blue jacket and red tie, with matching red cuffs! Snazzy. Wearing this makes you feel more important than your job title does."
@@ -94,7 +94,7 @@
 	item_state = "g_suit"
 	item_color = "hydroponics"
 	permeability_coefficient = 0.50
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/internalaffairs
 	desc = "The plain, professional attire of an Internal Affairs Agent. The collar is <i>immaculately</i> starched."
@@ -102,7 +102,7 @@
 	icon_state = "internalaffairs"
 	item_state = "internalaffairs"
 	item_color = "internalaffairs"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/ntrep
 	desc = "A well-ironed dress shirt and matching set of black pants."
@@ -110,7 +110,7 @@
 	icon_state = "internalaffairs"
 	item_state = "internalaffairs"
 	item_color = "internalaffairs"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/janitor
 	desc = "It's the official uniform of the station's janitor. It has minor protection from biohazards."
@@ -118,13 +118,13 @@
 	icon_state = "janitor"
 	item_color = "janitor"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 
 /obj/item/clothing/under/lawyer
 	desc = "Slick threads."
 	name = "Lawyer suit"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/lawyer/black
 	icon_state = "lawyer_black"
@@ -173,7 +173,7 @@
 	icon_state = "red_suit"
 	item_state = "red_suit"
 	item_color = "red_suit"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/mime
 	name = "mime's outfit"
@@ -181,7 +181,7 @@
 	icon_state = "mime"
 	item_state = "mime"
 	item_color = "mime"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 
 /obj/item/clothing/under/rank/miner
@@ -190,7 +190,7 @@
 	icon_state = "miner"
 	item_state = "miner"
 	item_color = "miner"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/barber
 	desc = "It's a barber's uniform."

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -6,14 +6,14 @@
 	item_state = "g_suit"
 	item_color = "chief"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 10)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/chief_engineer/skirt
 	desc = "It's a high visibility jumpskirt given to those engineers insane enough to achieve the rank of \"Chief engineer\". It has minor radiation shielding."
 	name = "chief engineer's jumpskirt"
 	icon_state = "chieff"
 	item_color = "chieff"
-	flags = null
+	flags_size = null
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /obj/item/clothing/under/rank/atmospheric_technician
@@ -22,14 +22,14 @@
 	icon_state = "atmos"
 	item_state = "atmos_suit"
 	item_color = "atmos"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/atmospheric_technician/skirt
 	desc = "It's a jumpskirt worn by atmospheric technicians."
 	name = "atmospheric technician's jumpskirt"
 	icon_state = "atmosf"
 	item_color = "atmosf"
-	flags = null
+	flags_size = null
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /obj/item/clothing/under/rank/engineer
@@ -39,7 +39,7 @@
 	item_state = "engi_suit"
 	item_color = "engine"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 10)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 
 /obj/item/clothing/under/rank/engineer/skirt
@@ -47,7 +47,7 @@
 	name = "engineer's jumpskirt"
 	icon_state = "enginef"
 	item_color = "enginef"
-	flags = null
+	flags_size = null
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /obj/item/clothing/under/rank/roboticist
@@ -56,14 +56,14 @@
 	icon_state = "robotics"
 	item_state = "robotics"
 	item_color = "robotics"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/roboticist/skirt
 	desc = "It's a slimming black jumpskirt with reinforced seams; great for industrial work."
 	name = "roboticist's jumpskirt"
 	icon_state = "roboticsf"
 	item_color = "roboticsf"
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/mechanic
 	desc = "It's a pair of overalls worn by mechanics."

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -8,7 +8,7 @@
 	item_state = "g_suit"
 	item_color = "director"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/scientist
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has markings that denote the wearer as a scientist."
@@ -18,14 +18,14 @@
 	item_color = "toxinswhite"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/scientist/skirt
 	name = "scientist's jumpskirt"
 	icon_state = "sciencewhitef"
 	item_color = "sciencewhitef"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/chemist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a chemist rank stripe on it."
@@ -35,14 +35,14 @@
 	item_color = "chemistrywhite"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/chemist/skirt
 	name = "chemist's jumpskirt"
 	icon_state = "chemistrywhitef"
 	item_color = "chemistrywhitef"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	flags = null
+	flags_size = null
 
 /*
  * Medical
@@ -55,7 +55,7 @@
 	item_color = "cmo"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/chief_medical_officer/skirt
 	desc = "It's a jumpskirt worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
@@ -63,7 +63,7 @@
 	icon_state = "cmof"
 	item_color = "cmof"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/geneticist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a genetics rank stripe on it."
@@ -73,14 +73,14 @@
 	item_color = "geneticswhite"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/geneticist/skirt
 	name = "geneticist's jumpskirt"
 	icon_state = "geneticswhitef"
 	item_color = "geneticswhitef"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/virologist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a virologist rank stripe on it."
@@ -90,14 +90,14 @@
 	item_color = "virologywhite"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/virologist/skirt
 	name = "virologist's jumpskirt"
 	icon_state = "virologywhitef"
 	item_color = "virologywhitef"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/nursesuit
 	desc = "It's a jumpsuit commonly worn by nursing staff in the medical department."
@@ -107,7 +107,7 @@
 	item_color = "nursesuit"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/nurse
 	desc = "A dress commonly worn by the nursing staff in the medical department."
@@ -117,7 +117,7 @@
 	item_color = "nurse"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/orderly
 	desc = "A white suit to be worn by orderly people who love orderly things."
@@ -127,7 +127,7 @@
 	item_color = "orderly"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/medical
 	desc = "It's made of a special fiber that provides minor protection against biohazards. It has a cross on the chest denoting that the wearer is trained medical personnel."
@@ -137,42 +137,42 @@
 	item_color = "medical"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/medical/skirt
 	name = "medical doctor's jumpskirt"
 	icon_state = "medicalf"
 	item_color = "medicalf"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/medical/blue
 	name = "medical scrubs"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in baby blue."
 	icon_state = "scrubsblue"
 	item_color = "scrubsblue"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/medical/green
 	name = "medical scrubs"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in dark green."
 	icon_state = "scrubsgreen"
 	item_color = "scrubsgreen"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/medical/purple
 	name = "medical scrubs"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in deep purple."
 	icon_state = "scrubspurple"
 	item_color = "scrubspurple"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/medical/mortician
 	name = "coroner's scrubs"
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is as dark as an emo's poetry."
 	icon_state = "scrubsblack"
 	item_color = "scrubsblack"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 //paramedic
 /obj/item/clothing/under/rank/medical/paramedic
@@ -183,7 +183,7 @@
 	item_color = "paramedic"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 10)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/psych
 	desc = "A basic white jumpsuit. It has turqouise markings that denote the wearer as a psychiatrist."
@@ -191,7 +191,7 @@
 	icon_state = "psych"
 	item_state = "w_suit"
 	item_color = "psych"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/psych/turtleneck
 	desc = "A turqouise turtleneck and a pair of dark blue slacks, belonging to a psychologist."
@@ -199,7 +199,7 @@
 	icon_state = "psychturtle"
 	item_state = "b_suit"
 	item_color = "psychturtle"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 
 /*
@@ -213,7 +213,7 @@
 	item_color = "genetics_new"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/chemist_new
 	desc = "It's made of a special fiber which provides minor protection against biohazards."
@@ -223,7 +223,7 @@
 	item_color = "chemist_new"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/scientist_new
 	desc = "Made of a special fiber that gives special protection against biohazards and small explosions."
@@ -233,7 +233,7 @@
 	item_color = "scientist_new"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/virologist_new
 	desc = "Made of a special fiber that gives increased protection against biohazards."
@@ -243,4 +243,4 @@
 	item_color = "virologist_new"
 	permeability_coefficient = 0.50
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -16,7 +16,7 @@
 	item_state = "r_suit"
 	item_color = "warden"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	strip_delay = 50
 
 /obj/item/clothing/under/rank/warden/skirt
@@ -25,7 +25,7 @@
 	icon_state = "wardenf"
 	item_state = "r_suit"
 	item_color = "wardenf"
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/security
 	name = "security officer's jumpsuit"
@@ -34,7 +34,7 @@
 	item_state = "r_suit"
 	item_color = "secred"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	strip_delay = 50
 
 /obj/item/clothing/under/rank/security/skirt
@@ -43,7 +43,7 @@
 	icon_state = "secredf"
 	item_state = "r_suit"
 	item_color = "secredf"
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/dispatch
 	name = "dispatcher's uniform"
@@ -52,7 +52,7 @@
 	item_state = "dispatch"
 	item_color = "dispatch"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/security2
 	name = "security officer's uniform"
@@ -61,7 +61,8 @@
 	item_state = "r_suit"
 	item_color = "redshirt2"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
+
 /obj/item/clothing/under/rank/security/corp
 	icon_state = "sec_corporate"
 	item_state = "sec_corporate"
@@ -82,7 +83,7 @@
 	item_state = "det"
 	item_color = "detective"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	strip_delay = 50
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -99,7 +100,7 @@
 	item_state = "r_suit"
 	item_color = "hosred"
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	strip_delay = 60
 
 /obj/item/clothing/under/rank/head_of_security/skirt
@@ -108,7 +109,7 @@
 	icon_state = "hosredf"
 	item_state = "r_suit"
 	item_color = "hosredf"
-	flags = null
+	flags_size = null
 
 /obj/item/clothing/under/rank/head_of_security/corp
 	icon_state = "hos_corporate"
@@ -122,7 +123,7 @@
 	icon_state = "jensen"
 	item_state = "jensen"
 	item_color = "jensen"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 //Paradise Station
 
@@ -179,4 +180,4 @@
 	item_color = "brig_phys"
 	permeability_coefficient = 0.50
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 10, rad = 0)
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -88,7 +88,7 @@
 	item_state = "g_suit"
 	item_color = "officer"
 	displays_id = 0
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/centcom/captain
 	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Captain\" and bears \"N.C.V. Fearless CV-286\" on the left shounder."
@@ -105,7 +105,7 @@
 	item_state = "g_suit"
 	item_color = "officer"
 	displays_id = 0
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/centcom/representative
 	desc = "Gold trim on space-black cloth, this uniform displays the rank of \"Ensign\" and bears \"N.S.S. Cyberiad\" on the left shounder."
@@ -114,7 +114,7 @@
 	item_state = "g_suit"
 	item_color = "officer"
 	displays_id = 0
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/rank/centcom/diplomatic
 	desc = "A very gaudy and official looking uniform of the Nanotrasen Diplomatic Corps."
@@ -231,7 +231,7 @@
 	icon_state = "red_suit"
 	item_state = "r_suit"
 	item_color = "red_suit"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 
 /obj/item/clothing/under/suit_jacket/navy
 	name = "navy suit"

--- a/code/modules/clothing/under/pants.dm
+++ b/code/modules/clothing/under/pants.dm
@@ -86,4 +86,4 @@
 	desc = "For those brave enough to weather the breeze."
 	icon_state = "chaps"
 	item_color = "chaps"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -410,7 +410,7 @@
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "chronx_robe"
 	item_state = "chronx_robe"
-	flags = ONESIZEFITSALL
+	flags_size = ONESIZEFITSALL
 	action_button_name = "Transform Robes"
 	adjust_flavour = "untransform"
 	ignore_suitadjust = 0

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -423,7 +423,7 @@
 	if(istype(I, /obj/item/clothing/under) || istype(I, /obj/item/clothing/suit))
 		if(FAT in mutations)
 			//testing("[M] TOO FAT TO WEAR [src]!")
-			if(!(I.flags & ONESIZEFITSALL))
+			if(!(I.flags_size & ONESIZEFITSALL))
 				if(!disable_warning)
 					to_chat(src, "<span class='alert'>You're too fat to wear the [I].</span>")
 				return 0

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -75,7 +75,8 @@
 	item_state = "golem"
 	body_parts_covered = HEAD|UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES
-	flags = ONESIZEFITSALL | ABSTRACT | NODROP | THICKMATERIAL
+	flags = ABSTRACT | NODROP | THICKMATERIAL
+	flags_size = ONESIZEFITSALL
 	armor = list(melee = 55, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/shoes/golem

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -600,7 +600,7 @@ var/global/list/damage_icon_parts = list()
 		var/image/standing	= image("icon_state" = "[t_color]_s")
 
 		if(FAT in mutations)
-			if(w_uniform.flags&ONESIZEFITSALL)
+			if(w_uniform.flags_size & ONESIZEFITSALL)
 				standing.icon	= 'icons/mob/uniform_fat.dmi'
 			else
 				to_chat(src, "\red You burst out of \the [w_uniform]!")
@@ -907,7 +907,7 @@ var/global/list/damage_icon_parts = list()
 		else if(wear_suit.sprite_sheets && wear_suit.sprite_sheets[species.name])
 			standing = image("icon" = wear_suit.sprite_sheets[species.name], "icon_state" = "[wear_suit.icon_state]")
 		else if(FAT in mutations)
-			if(wear_suit.flags&ONESIZEFITSALL)
+			if(wear_suit.flags_size & ONESIZEFITSALL)
 				standing = image("icon" = 'icons/mob/suit_fat.dmi', "icon_state" = "[wear_suit.icon_state]")
 			else
 				to_chat(src, "\red You burst out of \the [wear_suit]!")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -402,7 +402,7 @@ var/list/slot_equipment_priority = list( \
 			if(slot_w_uniform)
 				if( !(slot_flags & SLOT_ICLOTHING) )
 					return 0
-				if((FAT in H.mutations) && !(flags & ONESIZEFITSALL))
+				if((FAT in H.mutations) && !(flags_size & ONESIZEFITSALL))
 					return 0
 				if(H.w_uniform)
 					if(!(H.w_uniform.flags & NODROP))


### PR DESCRIPTION
Refactors/moves/removes some flags

- Removes PLASMAGUARD (unused)
- Removes NOBLOODY (only used for intercomms)...I don't think you can even get blood on intercomms
- Removes NODELAY (unused)
- ONESIZEFITSALL moved from `flags` to `flags_size`
- Changes some numbers for a few defines to cut down on conflicts/overlap

There still needs to be more flag changes (mostly for cover flags and what things block hair), but that's for a different PR.