### PR TITLE
Borer Fixes

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -97,8 +97,13 @@
 	set category = "Borer"
 	set name = "Converse with Host"
 	set desc = "Send a silent message to your host."
+
 	if(!host)
 		to_chat(src, "You do not have a host to communicate with!")
+		return
+
+	if(stat)
+		to_chat(src, "You cannot do that in your current state.")
 		return
 
 	var/input = stripped_input(src, "Please enter a message to tell your host.", "Borer", "")
@@ -207,6 +212,12 @@
 				if(prob(host.getBrainLoss()/20))
 					host.say("*[pick(list("blink","blink_r","choke","aflap","drool","twitch","twitch_s","gasp"))]")
 
+/mob/living/simple_animal/borer/handle_environment()
+	if(host)
+		return // Snuggled up, nice and warm, in someone's head
+	else
+		return ..()
+
 /mob/living/simple_animal/borer/New(var/by_gamemode=0)
 	..()
 	add_language("Cortical Link")
@@ -230,14 +241,6 @@
 		stat("Chemicals", chemicals)
 
 // VERBS!
-
-/mob/living/simple_animal/borer/proc/borer_speak(var/message)
-	if(!message)
-		return
-
-	for(var/mob/M in mob_list)
-		if(M.mind && (istype(M, /mob/living/simple_animal/borer) || istype(M, /mob/dead/observer)))
-			to_chat(M, "<i>Cortical link, <b>[truename]:</b> [copytext(message, 2)]</i>")
 
 /mob/living/simple_animal/borer/verb/dominate_victim()
 	set category = "Borer"
@@ -286,6 +289,10 @@
 
 	if(!host)
 		to_chat(src, "You are not inside a host body.")
+		return
+
+	if(host.stat == DEAD)
+		to_chat(src, "This host is in no condition to be controlled.")
 		return
 
 	if(src.stat)
@@ -405,6 +412,7 @@
 
 	if(stat)
 		to_chat(src, "You cannot leave your host in your current state.")
+		return
 
 	if(docile)
 		to_chat(src, "\blue You are feeling far too docile to do that.")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -111,7 +111,7 @@
 			if(istype(I,/mob/living/simple_animal/borer))
 				B = I
 	if(B)
-		if(!B.ckey && ckey && B.controlling)
+		if(B.controlling && B.host == src)
 			B.detatch()
 
 		verbs -= /mob/living/carbon/proc/release_control


### PR DESCRIPTION
Borers are probably still broken to some extent, but this should make them a fair bit *less* broken.

- Fixes borers dying to environmental damage while inside a host.
  - They're still sensitive to extreme heat/cold while not inside a host, meaning they still aren't space-worthy.
    - ... and will probably die in certain pipes.
- Fixes borers not releasing control of a host when it dies.
- Fixes borers being able to assume control of dead hosts.
- Fixes borers being able to talk to their host while dead.
- Fixes borers being told they can't leave their host while incapacitated/dead, but then trying to leave it anyway.
- Fixes borers having a proc that is totally unused.

Fixes #3995.

:cl:
bugfix: Fixed borers dying in hosts who happened to be somewhere cold, such as space. Even if their host was in a space suit.
bugfix: Fixed borers forgetting to detach from a host when it died.
bugfix: Fixed borers being able to assume control of a dead host.
bugfix: Fixed dead borers in a host being able to speak with the host and ghosts.
/:cl: