### PR TITLE
Fixes NTSpecOps Radios

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -133,6 +133,10 @@
 	name = "Nanotrasen ERT Radio Encryption Key"
 	channels = list("Response Team" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1)
 
+/obj/item/device/encryptionkey/centcom
+	name = "Centcom Radio Encryption Key"
+	channels = list("Response Team" = 1, "Special Ops" = 1, "Science" = 1, "Command" = 1, "Medical" = 1, "Engineering" = 1, "Security" = 1, "Supply" = 1, "Service" = 1)
+
 /obj/item/device/encryptionkey/heads/ai_integrated //ported from bay, this goes 'inside' the AI.
 	name = "AI Integrated Encryption Key"
 	desc = "Integrated encryption key"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -293,7 +293,7 @@
 	flags = EARBANGPROTECT
 	icon_state = "com_headset_alt"
 	item_state = "com_headset_alt"
-	ks2type = /obj/item/device/encryptionkey/ert
+	ks2type = /obj/item/device/encryptionkey/centcom
 
 /obj/item/device/radio/headset/heads/ai_integrated //No need to care about icons, it should be hidden inside the AI anyway.
 	name = "\improper AI subspace transceiver"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -28,7 +28,8 @@ var/list/department_radio_keys = list(
 	  ":T" = "Syndicate",	"#T" = "Syndicate",		".T" = "Syndicate",
 	  ":U" = "Supply",		"#U" = "Supply",		".U" = "Supply",
 	  ":Z" = "Service",		"#Z" = "Service",		".Z" = "Service",
-	  ":P" = "AI Private",	"#P" = "AI Private",	".P" = "AI Private"
+	  ":P" = "AI Private",	"#P" = "AI Private",	".P" = "AI Private",
+	  ":-" = "Special Ops",		"#-" = "Special Ops",		".-" = "Special Ops"
 )
 
 


### PR DESCRIPTION
- Changes NT Navy Officer / Special Ops Officer headsets to broadcast to
ERT radio by default, BUT also have the ability to talk to special ops
(deathsquad) radio by using .- (or :-, or #-).
- This fixes a bug where Special Ops Officers can't actually talk to
special ops teams because special ops teams are on a different frequency
to ERTs, and neither of the two channels (ERT or SpecOps) can be
selected with a :X/.X/#X style letter.

:cl: Kyep
Tweak: Fixes NT Special Ops Officer's headset so he can correctly hear, and talk on, the Special Ops (deathsquad) channel.
/:cl: