### PR TITLE
IT'S HIGH NOON

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -256,3 +256,6 @@
 #define TRIGGER_GUARD_ALLOW_ALL -1
 #define TRIGGER_GUARD_NONE 0
 #define TRIGGER_GUARD_NORMAL 1
+
+// Macro to get the current elapsed round time, rather than total world runtime
+#define ROUND_TIME (round_start_time ? (world.time - round_start_time) : 0)

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -23,7 +23,7 @@
 	return wtime + (time_offset + wusage) * world.tick_lag
 
 //Returns the world time in english
-/proc/worldtime2text(time = world.time)
+/proc/worldtime2text(time = ROUND_TIME)
 	return "[round(time / 36000)+12]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
 
 /proc/time_stamp()

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -23,7 +23,8 @@
 	return wtime + (time_offset + wusage) * world.tick_lag
 
 //Returns the world time in english
-/proc/worldtime2text(time = ROUND_TIME)
+/proc/worldtime2text(time = world.time)
+	time = (round_start_time ? (time - round_start_time) : (time - world.time))
 	return "[round(time / 36000)+12]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
 
 /proc/time_stamp()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -435,7 +435,7 @@ var/round_start_time = 0
 	end_state.count()
 	var/station_integrity = min(round( 100.0 *  start_state.score(end_state), 0.1), 100.0)
 
-	to_chat(world, "<BR>[TAB]Shift Duration: <B>[round(world.time / 36000)]:[add_zero("[world.time / 600 % 60]", 2)]:[world.time / 100 % 6][world.time / 100 % 10]</B>")
+	to_chat(world, "<BR>[TAB]Shift Duration: <B>[round(ROUND_TIME / 36000)]:[add_zero("[ROUND_TIME / 600 % 60]", 2)]:[ROUND_TIME / 100 % 6][ROUND_TIME / 100 % 10]</B>")
 	to_chat(world, "<BR>[TAB]Station Integrity: <B>[mode.station_was_nuked ? "<font color='red'>Destroyed</font>" : "[station_integrity]%"]</B>")
 	to_chat(world, "<BR>")
 

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -409,7 +409,7 @@
 	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 		var/dat = "<html><head><title>Round Status</title></head><body><h1><B>Round Status</B></h1>"
 		dat += "Current Game Mode: <B>[ticker.mode.name]</B><BR>"
-		dat += "Round Duration: <B>[round(world.time / 36000)]:[add_zero(num2text(world.time / 600 % 60), 2)]:[add_zero(num2text(world.time / 10 % 60), 2)]</B><BR>"
+		dat += "Round Duration: <B>[round(ROUND_TIME / 36000)]:[add_zero(num2text(ROUND_TIME / 600 % 60), 2)]:[add_zero(num2text(ROUND_TIME / 10 % 60), 2)]</B><BR>"
 		dat += "<B>Emergency shuttle</B><BR>"
 		if(shuttle_master.emergency.mode < SHUTTLE_CALL)
 			dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"


### PR DESCRIPTION
This is a 100% legitimate bug-fix PR, which fixes a 100% legitimate bug, and will have *no negative consequences.*

- Fixes the current round's duration being based on world start time.
  - It's now based on when the round actually started.
  - Which means all rounds will begin at noon, as they should.
    - I'm sure nobody will use this as an excuse to make McCree characters.
      - I accept no responsibility for when they inevitably do.
	    - I mean, technically, the rules *do* allow it.
		  - You guys brought this on yourselves~
- ~~Replaces the normal "welcome to the station" VO with McCree helpfully announcing the current time.~~

:cl:
bugfix: Fixed employees starting every shift at least 3 minutes late. You aren't getting paid to stand around, people!
/:cl: