### PR TITLE
Makes Janitors a 1-Slot Job Again

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -299,7 +299,7 @@
 	title = "Janitor"
 	flag = JANITOR
 	department_flag = SUPPORT
-	total_positions = 2
+	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"


### PR DESCRIPTION
After mulling it over, it kinda fell between either "Give Janitors another set of clothing", since the second Janitor to show up would get screwed out of legitimately valuable gear (such as galoshes or
holographic projectors), or just "Make the Janitor 1-Slot again".

I picked the latter for a couple of reasons:

1) Again, the game as is does not provide a second set of Janitor clothing. That means no galoshes, no gloves, and no (*gasp) purple cap;

2) The station is not that big that it requires two janitors. Unless there's literally blood EVERYWHERE, but that happens to be a rare occurrence, and Cleaner Grenades are a thing;

3) Cleanerbots;

4) The second janitor slot almost guarantees that both Janitors are going to be out of things to do for most of the round. It's the Atmos Argument: "Do your job right, and literally nothing happens. FUN!"

One Janitor can, with the tools at their disposal, efficiently clean the station. Two Janitors are just redundant, and get barely used anyway, even on high pop.