### PR TITLE
Allows You To Pet pAIs

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -466,10 +466,15 @@
 	return
 
 /mob/living/silicon/pai/attack_hand(mob/user as mob)
-	if(stat == 2) return
-	visible_message("<span class='danger'>[user.name] boops [src] on the head.</span>")
-	spawn(1)
-		close_up()
+	if(stat == DEAD)
+		return
+	if(user.a_intent == I_HELP)
+		user.visible_message("<span class='notice'>[user] pets [src].</span>")
+		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+	else
+		visible_message("<span class='danger'>[user.name] boops [src] on the head.</span>")
+		spawn(1)
+			close_up()
 
 //I'm not sure how much of this is necessary, but I would rather avoid issues.
 /mob/living/silicon/pai/proc/close_up()


### PR DESCRIPTION
You can now pet deployed pAI's. If you're on help intent you'll pet them; all other intents will boop them as it currently does.

:cl: Fox McCloud
add: Can now pet pAI's with help intent
/:cl: