### PR TITLE
Fixes Noisy Simple Animal Beatdowns

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -446,7 +446,6 @@
 				else
 					visible_message("<span class='danger'>[O] bounces harmlessly off of [src].</span>",\
 									"<span class='userdanger'>[O] bounces harmlessly off of [src].</span>")
-				playsound(loc, O.hitsound, 50, 1, -1)
 			else
 				user.visible_message("<span class='warning'>[user] gently taps [src] with [O].</span>",\
 									"<span class='warning'>This weapon is ineffective, it does no damage.</span>")


### PR DESCRIPTION
Hit sounds are handled in the item attack code, but simple animals were playing an extra hit sound inside their own special attack handling code, meaning they'd play twice on hit. This removes that extra hit sound.

:cl:
bugfix: Fixed animal beatdowns being twice as noisy as they should be.
/:cl: