### PR TITLE
You switch to semi-automatic. You switch to 1 round burst. You switch…

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -44,7 +44,7 @@
 /obj/item/weapon/gun/projectile/automatic/ui_action_click()
 	burst_select()
 
-/obj/item/weapon/gun/projectile/automatic/verb/burst_select()
+/obj/item/weapon/gun/projectile/automatic/proc/burst_select()
 	var/mob/living/carbon/human/user = usr
 	select = !select
 	if(!select)


### PR DESCRIPTION
… to semi-automatic. You switch to 1 round burst. You switch to semi-automatic. You switch to 1 round burst. You switch to semi-automatic. You switch to 1 round burst. You switch to semi-automatic. You switch to 1 round burst. You switch to semi-automatic. You switch to 1 round burst.

:eyes:

:cl:
fix: Burst fire selection is now a proc, as it was meant to be, rather than a verb.
/:cl: