### PR TITLE
Armless Cuffing and Legless Legcuffing Sense-Making

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -24,6 +24,12 @@
 		to_chat(user, "<span class='warning'>Uh... how do those things work?!</span>")
 		apply_cuffs(user,user)
 
+	if(ishuman(C))
+		var/mob/living/carbon/human/H = C
+		if(!(H.get_organ("l_hand") || H.get_organ("r_hand")))
+			to_chat(user, "<span class='warning'>How do you suggest handcuffing someone with no hands?</span>")
+			return
+
 	if(!C.handcuffed)
 		C.visible_message("<span class='danger'>[user] is trying to put [src.name] on [C]!</span>", \
 							"<span class='userdanger'>[user] is trying to put [src.name] on [C]!</span>")
@@ -117,6 +123,11 @@
 
 /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg/attack(mob/living/carbon/C, mob/user)
 	if(isrobot(user))
+		if(ishuman(C))
+			var/mob/living/carbon/human/H = C
+			if(!(H.get_organ("l_hand") || H.get_organ("r_hand")))
+				to_chat(user, "<span class='warning'>How do you suggest handcuffing someone with no hands?</span>")
+				return
 		if(!C.handcuffed)
 			playsound(loc, 'sound/weapons/cablecuff.ogg', 30, 1, -2)
 			C.visible_message("<span class='danger'>[user] is trying to put zipties on [C]!</span>", \

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -20,6 +20,9 @@
 	if(!user.IsAdvancedToolUser())
 		return
 
+	if(!istype(C))
+		return
+
 	if(CLUMSY in user.mutations && prob(50))
 		to_chat(user, "<span class='warning'>Uh... how do those things work?!</span>")
 		apply_cuffs(user,user)


### PR DESCRIPTION
Fixes #4873

This was entirely DZD's work. It has my name on it because it was a "learn-as-you-code" experience.

Regardless:

- Can now cuff people with two hands, or one hand;
- Can no longer cuff people with no hands
- Can no longer try to cuff non-carbon mobs and make the game freak out

:cl: TullyBBurnalot
tweak: Handless cuffing no longer possible. Can still cuff people with one hand
/:cl: