### PR TITLE
Fixes AIs removing beakers from IV Drips

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -132,7 +132,7 @@
 				update_icon()
 
 /obj/machinery/iv_drip/attack_hand(mob/user as mob)
-	if((get_dist(src, user) > 1))
+	if(get_dist(src, user) > 1)
 		return //stops the AI from removing beakers, still allows borgs
 	if(src.beaker)
 		src.beaker.loc = get_turf(src)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -131,9 +131,9 @@
 				beaker.reagents.handle_reactions()
 				update_icon()
 
-/obj/machinery/iv_drip/attack_hand(mob/user as mob)
-	if(get_dist(src, user) > 1)
-		return //stops the AI from removing beakers, still allows borgs
+/obj/machinery/iv_drip/attack_hand(mob/living/carbon/user)
+	if(!istype(user))
+		return
 	if(src.beaker)
 		src.beaker.loc = get_turf(src)
 		src.beaker = null

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -132,6 +132,8 @@
 				update_icon()
 
 /obj/machinery/iv_drip/attack_hand(mob/user as mob)
+	if((get_dist(src, user) > 1))
+		return //stops the AI from removing beakers, still allows borgs
 	if(src.beaker)
 		src.beaker.loc = get_turf(src)
 		src.beaker = null


### PR DESCRIPTION
Fixes #4898

AI Units and Cyborgs can no longer remove things from IV Drips.

:cl:
tweak: AI can no longer interact with IV Drips
tweak: Robots can no longer remove beakers/blood bags from IV Drips
/:cl: