### PR TITLE
Removes photos from medical and sec consoles

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -54,10 +54,6 @@
 				if(3.0)
 					dat += text("<B>Records Maintenance</B><HR>\n<A href='?src=\ref[];back=1'>Backup To Disk</A><BR>\n<A href='?src=\ref[];u_load=1'>Upload From disk</A><BR>\n<A href='?src=\ref[];del_all=1'>Delete All Records</A><BR>\n<BR>\n<A href='?src=\ref[];screen=1'>Back</A>", src, src, src, src)
 				if(4.0)
-					var/icon/front = new(active1.fields["photo"], dir = SOUTH)
-					var/icon/side = new(active1.fields["photo"], dir = WEST)
-					user << browse_rsc(front, "front.png")
-					user << browse_rsc(side, "side.png")
 					dat += "<CENTER><B>Medical Record</B></CENTER><BR>"
 					if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
 						dat += "<table><tr><td>Name: [active1.fields["name"]] \
@@ -66,8 +62,7 @@
 								Age: <A href='?src=\ref[src];field=age'>[active1.fields["age"]]</A><BR>\n	\
 								Fingerprint: <A href='?src=\ref[src];field=fingerprint'>[active1.fields["fingerprint"]]</A><BR>\n	\
 								Physical Status: <A href='?src=\ref[src];field=p_stat'>[active1.fields["p_stat"]]</A><BR>\n	\
-								Mental Status: <A href='?src=\ref[src];field=m_stat'>[active1.fields["m_stat"]]</A><BR></td><td align = center valign = top> \
-								Photo:<br><img src=front.png height=64 width=64 border=5><img src=side.png height=64 width=64 border=5></td></tr></table>"
+								Mental Status: <A href='?src=\ref[src];field=m_stat'>[active1.fields["m_stat"]]</A><BR></td><td align = center valign = top></td></tr></table>"
 					else
 						dat += "<B>General Record Lost!</B><BR>"
 					if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -165,10 +165,6 @@
 				if(3.0)
 					dat += "<CENTER><B>Security Record</B></CENTER><BR>"
 					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
-						var/icon/front = new(active1.fields["photo"], dir = SOUTH)
-						var/icon/side = new(active1.fields["photo"], dir = WEST)
-						user << browse_rsc(front, "front.png")
-						user << browse_rsc(side, "side.png")
 						dat += {"
 							<table><tr><td>
 								Name: <A href='?src=\ref[src];choice=Edit Field;field=name'>[active1.fields["name"]]</A><BR>
@@ -179,12 +175,6 @@
 								Fingerprint: <A href='?src=\ref[src];choice=Edit Field;field=fingerprint'>[active1.fields["fingerprint"]]</A><BR>
 								Physical Status: [active1.fields["p_stat"]]<BR>
 								Mental Status: [active1.fields["m_stat"]]<BR>
-							</td>
-							<td align = center valign = top>
-								Photo:<br>
-								<img src=front.png height=80 width=80 border=4>
-								<img src=side.png height=80 width=80 border=4><br>
-								<a href='?src=\ref[src];choice=Print Photo'>Print Photo</a>
 							</td></tr></table>"}
 					else
 						dat += "<B>General Record Lost!</B><BR>"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -107,7 +107,7 @@
 	var/icon/side
 	var/dat
 	var/stamped = 0
-	
+
 	var/obj/item/weapon/card/id/guest/guest_pass = null // Guest pass attached to the ID
 
 /obj/item/weapon/card/id/New()
@@ -178,8 +178,7 @@
 	dat += text("Fingerprint: []</A><BR>\n", fingerprint_hash)
 	dat += text("Blood Type: []<BR>\n", blood_type)
 	dat += text("DNA Hash: []<BR><BR>\n", dna_hash)
-	dat +="<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4>	\
-	<img src=side.png height=80 width=80 border=4></td></tr></table>"
+	dat +="</td></tr></table>"
 
 /obj/item/weapon/card/id/GetAccess()
 	if(!guest_pass)
@@ -244,10 +243,10 @@
 	set name = "Remove Guest Pass"
 	set category = "Object"
 	set src in range(0)
-	
+
 	if(usr.stat || !usr.canmove || usr.restrained())
 		return
-	
+
 	if(guest_pass)
 		to_chat(usr, "<span class='notice'>You remove the guest pass from this ID.</span>")
 		guest_pass.forceMove(get_turf(src))


### PR DESCRIPTION
Does as advertised.

:cl:Crazylemon
rscdel: Photos from medical and security consoles, as well as ID cards, have been removed, as they've got a knack for crashing clients.
/:cl: