### PR TITLE
Resisting out of cardboard boxes is now possible

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -388,6 +388,7 @@
 			L.forceMove(get_turf(src)) // Let's just be safe here
 		return //Door's open... wait, why are you in it's contents then?
 	if(!welded)
+		open() //for cardboard boxes
 		return //closed but not welded...
 	//	else Meh, lets just keep it at 2 minutes for now
 	//		breakout_time++ //Harder to get out of welded lockers than locked lockers


### PR DESCRIPTION
Fixes #4880. Sorta.

- Can now resist out of unwelded lockers instantaneously
- By association, can now resist out of closed cardboard boxes, even with both hands full

You can also use Toggle Open, this is just faster.