### PR TITLE
Fixes Sechud Flash Protection

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -73,7 +73,6 @@
 	desc = "A heads-up display that scans the humans in view and provides accurate data about their ID status and security records."
 	icon_state = "securityhud"
 	var/global/list/jobs[0]
-	flash_protect = 1
 	HUDType = DATA_HUD_SECURITY_ADVANCED
 	species_fit = list("Vox")
 	sprite_sheets = list(
@@ -84,11 +83,12 @@
 /obj/item/clothing/glasses/hud/security/chameleon
 	name = "Chamleon Security HUD"
 	desc = "A stolen security HUD integrated with Syndicate chameleon technology. Toggle to disguise the HUD. Provides flash protection."
+	flash_protect = 1
 
 /obj/item/clothing/glasses/hud/security/chameleon/attack_self(mob/user)
 	chameleon(user)
 
-/obj/item/clothing/glasses/hud/security/jensenshades
+/obj/item/clothing/glasses/hud/security/sunglasses/jensenshades
 	name = "augmented shades"
 	desc = "Polarized bioneural eyewear, designed to augment your vision."
 	icon_state = "jensenshades"
@@ -109,6 +109,7 @@
 	desc = "Sunglasses with a HUD."
 	icon_state = "sunhud"
 	darkness_view = 1
+	flash_protect = 1
 	tint = 1
 	prescription_upgradable = 1
 


### PR DESCRIPTION
Sechuds aren't meant to have flash protection--it as mistakenly added in a eye-check refactor PR.

Sorry science, you don't get to print sunglasses, and yes, night vision sechuds are meant to have a downside to them.

Also makes jensen glasses a child of sec sunglasses; another oversight.

:cl: Fox McCloud
fix: Fixes sechuds and nightvision sechuds having flash protection
/:cl: