### PR TITLE
Replaces File-Based ID Photos With Bicons

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -66,6 +66,8 @@
 		G.fields["sex"]			= capitalize(H.gender)
 		G.fields["species"]		= H.get_species()
 		G.fields["photo"]		= get_id_photo(H)
+		G.fields["photo-south"] = "'data:image/png;base64,[icon2base64(icon(G.fields["photo"], dir = SOUTH))]'"
+		G.fields["photo-west"] = "'data:image/png;base64,[icon2base64(icon(G.fields["photo"], dir = WEST))]'"
 		if(H.gen_record && !jobban_isbanned(H, "Records"))
 			G.fields["notes"] = H.gen_record
 		else

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -54,10 +54,6 @@
 				if(3.0)
 					dat += text("<B>Records Maintenance</B><HR>\n<A href='?src=\ref[];back=1'>Backup To Disk</A><BR>\n<A href='?src=\ref[];u_load=1'>Upload From disk</A><BR>\n<A href='?src=\ref[];del_all=1'>Delete All Records</A><BR>\n<BR>\n<A href='?src=\ref[];screen=1'>Back</A>", src, src, src, src)
 				if(4.0)
-					var/icon/front = new(active1.fields["photo"], dir = SOUTH)
-					var/icon/side = new(active1.fields["photo"], dir = WEST)
-					user << browse_rsc(front, "front.png")
-					user << browse_rsc(side, "side.png")
 					dat += "<CENTER><B>Medical Record</B></CENTER><BR>"
 					if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
 						dat += "<table><tr><td>Name: [active1.fields["name"]] \
@@ -67,7 +63,8 @@
 								Fingerprint: <A href='?src=\ref[src];field=fingerprint'>[active1.fields["fingerprint"]]</A><BR>\n	\
 								Physical Status: <A href='?src=\ref[src];field=p_stat'>[active1.fields["p_stat"]]</A><BR>\n	\
 								Mental Status: <A href='?src=\ref[src];field=m_stat'>[active1.fields["m_stat"]]</A><BR></td><td align = center valign = top> \
-								Photo:<br><img src=front.png height=64 width=64 border=5><img src=side.png height=64 width=64 border=5></td></tr></table>"
+								Photo:<br><img src=[active1.fields["photo-south"]] height=64 width=64 border=5> \
+								<img src=[active1.fields["photo-west"]] height=64 width=64 border=5></td></tr></table>"
 					else
 						dat += "<B>General Record Lost!</B><BR>"
 					if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -165,10 +165,6 @@
 				if(3.0)
 					dat += "<CENTER><B>Security Record</B></CENTER><BR>"
 					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
-						var/icon/front = new(active1.fields["photo"], dir = SOUTH)
-						var/icon/side = new(active1.fields["photo"], dir = WEST)
-						user << browse_rsc(front, "front.png")
-						user << browse_rsc(side, "side.png")
 						dat += {"
 							<table><tr><td>
 								Name: <A href='?src=\ref[src];choice=Edit Field;field=name'>[active1.fields["name"]]</A><BR>
@@ -182,8 +178,8 @@
 							</td>
 							<td align = center valign = top>
 								Photo:<br>
-								<img src=front.png height=80 width=80 border=4>
-								<img src=side.png height=80 width=80 border=4><br>
+								<img src=[active1.fields["photo-south"]] height=80 width=80 border=4>
+								<img src=[active1.fields["photo-west"]] height=80 width=80 border=4><br>
 								<a href='?src=\ref[src];choice=Print Photo'>Print Photo</a>
 							</td></tr></table>"}
 					else

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -87,10 +87,6 @@
 				if(3.0)
 					dat += "<CENTER><B>Employment Record</B></CENTER><BR>"
 					if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
-						var/icon/front = new(active1.fields["photo"], dir = SOUTH)
-						var/icon/side = new(active1.fields["photo"], dir = WEST)
-						user << browse_rsc(front, "front.png")
-						user << browse_rsc(side, "side.png")
 						dat += text("<table><tr><td>	\
 						Name: <A href='?src=\ref[src];choice=Edit Field;field=name'>[active1.fields["name"]]</A><BR> \
 						ID: <A href='?src=\ref[src];choice=Edit Field;field=id'>[active1.fields["id"]]</A><BR>\n	\
@@ -101,8 +97,8 @@
 						Physical Status: [active1.fields["p_stat"]]<BR>\n	\
 						Mental Status: [active1.fields["m_stat"]]<BR><BR>\n	\
 						Employment/skills summary:<BR> [active1.fields["notes"]]<BR></td>	\
-						<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4>	\
-						<img src=side.png height=80 width=80 border=4></td></tr></table>")
+						<td align = center valign = top>Photo:<br><img src=[active1.fields["photo-south"]] height=80 width=80 border=4>	\
+						<img src=[active1.fields["photo-west"]] height=80 width=80 border=4></td></tr></table>")
 					else
 						dat += "<B>General Record Lost!</B><BR>"
 					dat += text("\n<A href='?src=\ref[];choice=Delete Record (ALL)'>Delete Record (ALL)</A><BR><BR>\n<A href='?src=\ref[];choice=Print Record'>Print Record</A><BR>\n<A href='?src=\ref[];choice=Return'>Back</A><BR>", src, src, src)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -103,8 +103,6 @@
 	var/sex
 	var/age
 	var/photo
-	var/icon/front
-	var/icon/side
 	var/dat
 	var/stamped = 0
 	
@@ -137,12 +135,6 @@
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/paper)
 	assets.send(user)
 
-	if(!front)
-		front = new(photo, dir = SOUTH)
-	if(!side)
-		side = new(photo, dir = WEST)
-	user << browse_rsc(front, "front.png")
-	user << browse_rsc(side, "side.png")
 	var/datum/browser/popup = new(user, "idcard", name, 600, 400)
 	popup.set_content(dat)
 	popup.set_title_image(usr.browse_rsc_icon(src.icon, src.icon_state))
@@ -170,6 +162,9 @@
 	dna_hash = H.dna.unique_enzymes
 	fingerprint_hash = md5(H.dna.uni_identity)
 
+	var/photo_front = "'data:image/png;base64,[icon2base64(icon(photo, dir = SOUTH))]'"
+	var/photo_side = "'data:image/png;base64,[icon2base64(icon(photo, dir = WEST))]'"
+
 	dat = ("<table><tr><td>")
 	dat += text("Name: []</A><BR>", registered_name)
 	dat += text("Sex: []</A><BR>\n", sex)
@@ -178,8 +173,8 @@
 	dat += text("Fingerprint: []</A><BR>\n", fingerprint_hash)
 	dat += text("Blood Type: []<BR>\n", blood_type)
 	dat += text("DNA Hash: []<BR><BR>\n", dna_hash)
-	dat +="<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4>	\
-	<img src=side.png height=80 width=80 border=4></td></tr></table>"
+	dat +="<td align = center valign = top>Photo:<br><img src=[photo_front] height=80 width=80 border=4>	\
+	<img src=[photo_side] height=80 width=80 border=4></td></tr></table>"
 
 /obj/item/weapon/card/id/GetAccess()
 	if(!guest_pass)
@@ -341,7 +336,7 @@
 			if("Show")
 				return ..()
 			if("Edit")
-				switch(input(user,"What would you like to edit on \the [src]?") in list("Name","Photo","Appearance","Sex","Age","Occupation","Money Account","Blood Type","DNA Hash","Fingerprint Hash","Reset Card"))
+				switch(input(user,"What would you like to edit on \the [src]?") in list("Name","Appearance","Sex","Age","Occupation","Money Account","Blood Type","DNA Hash","Fingerprint Hash","Reset Card"))
 					if("Name")
 						var/new_name = reject_bad_name(input(user,"What name would you like to put on this card?","Agent Card Name", ishuman(user) ? user.real_name : user.name))
 						if(!Adjacent(user))
@@ -350,13 +345,15 @@
 						UpdateName()
 						to_chat(user, "<span class='notice'>Name changed to [new_name].</span>")
 
+					// This option is now disabled. I had to comment out the front/side lines.
+					// It didn't work anyway, so nothing of value was lost!
 					if("Photo")
 						if(!Adjacent(user))
 							return
 						photo = fake_id_photo(user)
 						var/icon/photoside = fake_id_photo(user,1)
-						front = new(photo)
-						side = new(photoside)
+						// front = new(photo)
+						// side = new(photoside)
 						if(photo && photoside)
 							to_chat(user, "<span class='notice'>Photo changed.</span>")
 

--- a/code/modules/computer3/computers/medical.dm
+++ b/code/modules/computer3/computers/medical.dm
@@ -86,10 +86,6 @@
 					if(3.0)
 						dat += text("<B>Records Maintenance</B><HR>\n<A href='?src=\ref[];back=1'>Backup To Disk</A><BR>\n<A href='?src=\ref[];u_load=1'>Upload From disk</A><BR>\n<A href='?src=\ref[];del_all=1'>Delete All Records</A><BR>\n<BR>\n<A href='?src=\ref[];screen=1'>Back</A>", src, src, src, src)
 					if(4.0)
-						var/icon/front = new(active1.fields["photo"], dir = SOUTH)
-						var/icon/side = new(active1.fields["photo"], dir = WEST)
-						usr << browse_rsc(front, "front.png")
-						usr << browse_rsc(side, "side.png")
 						dat += "<CENTER><B>Medical Record</B></CENTER><BR>"
 						if ((istype(src.active1, /datum/data/record) && data_core.general.Find(src.active1)))
 							dat += "<table><tr><td>Name: [active1.fields["name"]] \
@@ -99,7 +95,8 @@
 									Fingerprint: <A href='?src=\ref[src];field=fingerprint'>[active1.fields["fingerprint"]]</A><BR>\n	\
 									Physical Status: <A href='?src=\ref[src];field=p_stat'>[active1.fields["p_stat"]]</A><BR>\n	\
 									Mental Status: <A href='?src=\ref[src];field=m_stat'>[active1.fields["m_stat"]]</A><BR></td><td align = center valign = top> \
-									Photo:<br><img src=front.png height=64 width=64 border=5><img src=side.png height=64 width=64 border=5></td></tr></table>"
+									Photo:<br><img src=[active1.fields["photo-south"]] height=64 width=64 border=5> \
+									<img src=[active1.fields["photo-west"]] height=64 width=64 border=5></td></tr></table>"
 						else
 							dat += "<B>General Record Lost!</B><BR>"
 						if ((istype(src.active2, /datum/data/record) && data_core.medical.Find(src.active2)))

--- a/code/modules/computer3/computers/security.dm
+++ b/code/modules/computer3/computers/security.dm
@@ -127,10 +127,6 @@
 					if(3.0)
 						dat += "<CENTER><B>Security Record</B></CENTER><BR>"
 						if ((istype(active1, /datum/data/record) && data_core.general.Find(active1)))
-							var/icon/front = new(active1.fields["photo"], dir = SOUTH)
-							var/icon/side = new(active1.fields["photo"], dir = WEST)
-							usr << browse_rsc(front, "front.png")
-							usr << browse_rsc(side, "side.png")
 							dat += text("<table><tr><td>	\
 							Name: <A href='?src=\ref[src];choice=Edit Field;field=name'>[active1.fields["name"]]</A><BR> \
 							ID: <A href='?src=\ref[src];choice=Edit Field;field=id'>[active1.fields["id"]]</A><BR>\n	\
@@ -140,8 +136,8 @@
 							Fingerprint: <A href='?src=\ref[src];choice=Edit Field;field=fingerprint'>[active1.fields["fingerprint"]]</A><BR>\n	\
 							Physical Status: [active1.fields["p_stat"]]<BR>\n	\
 							Mental Status: [active1.fields["m_stat"]]<BR></td>	\
-							<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4>	\
-							<img src=side.png height=80 width=80 border=4></td></tr></table>")
+							<td align = center valign = top>Photo:<br><img src=[active1.fields["photo-south"]] height=80 width=80 border=4>	\
+							<img src=[active1.fields["photo-west"]] height=80 width=80 border=4></td></tr></table>")
 						else
 							dat += "<B>General Record Lost!</B><BR>"
 						if ((istype(active2, /datum/data/record) && data_core.security.Find(active2)))


### PR DESCRIPTION
Currently, ID photos are sent to viewers as files, which are then loaded by the HTML of the interface using them. For some reason, this method seems to cause a lot of crashes.

This PR replaces the file-sending with bicons, which are embedded straight into the HTML. In theory, this should stop the crashing.

The following interfaces have been biconized:
- ID cards
- Employment records console
- Security records console
- Security records laptop app
- Medical records console
- Medical records laptop app

As far as I can tell, these are all of the ones that used the technique that seems to be crashing people.

To cut down on bicon generation overhead (which doesn't seem to be too bad anyway), they're only generated when someone is added to the datacore, or when an ID gets initialized. These mostly happen at round start, so it shouldn't be a big deal.

Alternative to #4903. I'm going to go out on a limb and say this fixes #1963 and fixes #3046. If not, we can just reopen 'em.

Oh, and while getting agent ID cards' photos to update properly, I fixed the fact that nothing else you updated would get reflected in the examination pop-up. Their code is *still* atrocious, though.

:cl:
bugfix: Security and medical records should probably stop crashing people.
bugfix: Altering details on an Agent ID Card will now actually update what's seen when examining the card.
/:cl: