### PR TITLE
Makes Exile & Lethal Injection Viable

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -349,7 +349,7 @@
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections locker"
-	req_access = list(access_captain)
+	req_access = list(access_security)
 
 
 	New()

--- a/code/modules/awaymissions/exile.dm
+++ b/code/modules/awaymissions/exile.dm
@@ -32,7 +32,7 @@
 
 /obj/structure/closet/secure_closet/exile
 	name = "exile implants"
-	req_access = list(access_hos)
+	req_access = list(access_security)
 
 /obj/structure/closet/secure_closet/exile/New()
 	..()

--- a/code/modules/awaymissions/exile.dm
+++ b/code/modules/awaymissions/exile.dm
@@ -32,7 +32,7 @@
 
 /obj/structure/closet/secure_closet/exile
 	name = "exile implants"
-	req_access = list(access_security)
+	req_access = list(access_armory)
 
 /obj/structure/closet/secure_closet/exile/New()
 	..()


### PR DESCRIPTION
Currently:
- The Lethal Injection locker in sec prisoner transfer is locked to captain-level access, despite being right next to the electric chair, which requires no access beyond basic security officer to use. As such it is inconsistent, and very rarely used.
- The exile implant locker in the gateway is locked to hos-level access, despite the fact that exile is preferable to perma (more secure for sec, more fun / less confining for prisoner). Also, it makes no sense for any sec officer to have the access required to kill someone with the electric chair, yet not to carry out this non-lethal option.

This PR:
- Changes the lethal injection locker to have the same access requirements as the electric chair right next to it (ie: security access).
- Changes the exile implants locker in the gateway room to ~~have the same access requirements as the lethal options (ie: security access).~~ require armory access.

Note: this PR does not force anyone to use lethal injection, or exile. All it does is reduce the wide difference in access between the different options.

:cl: Kyep
tweak: Changed access requirement on lethal injection locker to sec access (same access required for the chair its right next to.
tweak: Changed access requirement on exile implant locker to armory access.
/:cl: