### PR TITLE
Fixes trialmin bug, adds ERT response reminder

### DIFF
--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -9,6 +9,7 @@ var/list/response_team_members = list()
 var/responseteam_age = 21 // Minimum account age to play as an ERT member
 var/datum/response_team/active_team = null
 var/send_emergency_team
+var/ert_request_answered = 0
 
 /client/proc/response_team()
 	set name = "Dispatch CentComm Response Team"
@@ -47,6 +48,7 @@ var/send_emergency_team
 	if(!ert_type)
 		return
 
+	ert_request_answered = 1
 	message_admins("[key_name_admin(usr)] is dispatching an Emergency Response Team", 1)
 	log_admin("[key_name(usr)] used Dispatch Emergency Response Team..")
 	trigger_armed_response_team(ert_type)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1854,7 +1854,7 @@
 
 			var/input = input(src.owner, "Please enter a reason for denying [key_name(H)]'s ERT request.","Outgoing message from CentComm", "")
 			if(!input)	return
-
+			ert_request_answered = 1
 			to_chat(src.owner, "You sent [input] to [H] via a secure channel.")
 			log_admin("[src.owner] denied [key_name(H)]'s ERT request with the message [input].")
 			to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Your ERT request has been denied for the following reasons: [input].  Message ends.\"")

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -50,9 +50,11 @@
 			if(X.prefs.sound & SOUND_ADMINHELP)
 				X << 'sound/effects/adminhelp.ogg'
 
-/proc/ERT_Announce(var/text , var/mob/Sender)
+/proc/ERT_Announce(var/text , var/mob/Sender, var/repeat_warning)
 	var/msg = sanitize(copytext(text, 1, MAX_MESSAGE_LEN))
-	msg = "\blue <b><font color=orange>ERT REQUEST: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;ErtReply=\ref[Sender]'>REPLY</A>):</b> [msg]"
+	msg = "<span class='adminnotice'><b><font color=orange>ERT REQUEST: </font>[key_name(Sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[Sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[Sender]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=\ref[Sender]'>SM</A>) ([admin_jump_link(Sender, "holder")]) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[Sender]'>BSA</A>) (<A HREF='?_src_=holder;ErtReply=\ref[Sender]'>RESPOND</A>):</b> [msg]</span>"
+	if (repeat_warning)
+		msg += "<BR><span class='adminnotice'><b>WARNING: ERT request has gone 5 minutes with no reply!</b></span>"
 	for(var/client/X in admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, msg)

--- a/code/modules/security_levels/keycard authentication.dm
+++ b/code/modules/security_levels/keycard authentication.dm
@@ -155,12 +155,21 @@
 			if(is_ert_blocked())
 				to_chat(usr, "\red All Emergency Response Teams are dispatched and can not be called at this time.")
 				return
-
 			to_chat(usr, "<span class = 'notice'>ERT request transmitted.</span>")
-			if(admins.len)
-				ERT_Announce(ert_reason , event_triggered_by)
+
+
+			var/fullmin_count = 0
+			for(var/client/C in admins)
+				if (check_rights(R_EVENT, 0, C.mob))
+					fullmin_count++
+			if(fullmin_count)
+				ert_request_answered = 0
+				ERT_Announce(ert_reason , event_triggered_by, 0)
 				ert_reason = "Reason for ERT"
 				feedback_inc("alert_keycard_auth_ert",1)
+				spawn(3000)
+					if (!ert_request_answered)
+						ERT_Announce(ert_reason , event_triggered_by, 1)
 			else
 				trigger_armed_response_team(new /datum/response_team/amber) // No admins? No problem. Automatically send a code amber ERT.
 


### PR DESCRIPTION
1) Fixes a bug with ERT requests and trialmins

Previously, if all admins online were trialmins, this made it impossible to get an ERT.
Trialmins can't approve ERTs, and you can't get an automated ERT either, because the current code assumes trialmins can see/answer the request, even though we can't.

With this PR, trialmins no longer count as admins for ERT-checking purposes, so requesting an ERT with only trialmins online generates an automated Amber ERT, just as if you requested one with no admins online.


2) Re-pings ERT requests 5 minutes later if no answer

If an ERT request goes 5 minutes with no answer, it is automatically re-sent to game admins, along with a note that the ERT request hasn't been answered. This only happens once, and should help out those times when the only admin online misses an ERT request because they were getting coffee/snacks/etc. 

:cl: Kyep
fix: Fixed oversight in keycard authentication devices that incorrectly treated trialmins like fullmins, resulting in situations where calling an ERT became impossible.
tweak: If an ERT request gets no answer for 5 minutes, admins now get a one time reminder that it was sent.
/:cl: