### PR TITLE
Bureaucracy Update

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1184,6 +1184,65 @@
 				</html>
 			"}
 
+/obj/item/weapon/book/manual/faxes
+	name = "A Guide to Faxes"
+	desc = "A NanoTrasen-approved guide to writing faxes"
+	icon_state = "book6"
+	author = "NanoTrasen"
+	title = "A Guide to Faxes"
+	dat = {"
+
+		<html>
+				<head>
+				<style>
+				h1 {font-size: 15px; margin: 15px 0px 5px;}
+				li {margin: 2px 0px 2px 15px;}
+				ul {list-style: none; margin: 5px; padding: 0px;}
+				ol {margin: 5px; padding: 0px 15px;}
+				</style>
+				</head>
+				<body>
+				<font face="Verdana" color=black>
+
+				<h1><a name="Contents">Contents</a></h1>
+				<ol>
+					<li><a href="#what">What's a Fax?</a></li>
+					<li><a href="#when">When to Fax?</a></li>
+					<li><a href="#how">How to Fax?</a></li>
+				</ol>
+				<br><BR>
+
+				<h1><a name="what"><U><B>What's a Fax?</B></U></a></h1><BR>
+				<li>Faxes are your main method of communicating with the NAS Trurl, better known as Central Command.</li>
+				<li>Faxes allow personnel on the station to maintain open lines of communication with the NAS Trurl, allowing for vital information to flow both ways.</li>
+				<li>Being written communications, proper grammar, syntax and typography is required, in addition to a signature and, if applicable, a stamp. Failure to sign faxes will lead to an automatic rejection.</li>
+				<li>We at NanoTrasen provide Fax Machines to every Head of Staff, in addition to the Magistrate, NanoTrasen Representative, and Internal Affairs Agents.</li>
+				<li>This means that we trust the recipients of these fax machines to only use them in the proper circumstances (see <B>When to Fax?</B>).</li>
+
+				<h1><a name="when"><B>When to Fax?</B></a></h1><BR>
+				<li>While it is up to the discretion of each individual person to decide when to fax Central Command, there are some simple guidelines on when to do this.</li>
+				<li>Firstly, any situation that can reasonably be solved on-site, <I>should</I> be handled on-site. Knowledge of Standard Operating Procedure is <B>mandatory</B> for everyone with access to a fax machine.</li>
+				<li>Resolving issues on-site not only leads to more expedient problem-solving, it also frees up company resources and provides valuable work experience for all parties involved.</li>
+				<li>This means that you should work with the Heads of Staff concerning personnel and workplace issues, and attempt to resolve situations with them. If, for whatever reason, the relevent Head of Staff is not available or receptive, consider speaking with the Captain and/or NanoTrasen Representative.</li>
+				<li>If, for whatever reason, these issues cannot be solved on-site, either due to incompetence or just plain refusal to cooperate, faxing Central Command becomes a viable option.</li>
+				<li>Secondly, station status reports should be sent occasionally, but never at the start of the shift. Remember, we assign personnel to the station. We do not need a repeat of what we just signed off on.</li>
+				<li>Thirdly, staff/departmental evaluations are always welcome, especially in cases of noticeable (in)competence. Just as a brilliant coworker can be rewarded, an incompetent one can be punished.</li>
+				<li>Fourthly, do not issue faxes asking for sentences. You have an entire Security department and an associated Detective, not to mention on-site Space Law manuals.</li>
+				<li>Lastly, please pay attention to context. If the station is facing a massive emergency, such as a Class 7-10 Blob Organism, most, if not all, non-relevant faxes will be duly ignored.</li>
+
+				<h1><a name="how"><B>How to Fax?</B></a></h1><BR>
+				<li>Sending a fax is simple. Simply insert your ID into the fax machine, then log in.</li>
+				<li>Once logged in, insert a piece of paper and select the destination from the provided list. Remember, you can rename your fax from within the fax machine's menu.</li>
+				<li>You can send faxes to any other fax machine on the station, which can be a very useful tool when you need to issue broad communications to all of the Heads of Staff.</li>
+				<li>To send a fax to Central Command, simply select the correct destination, and send the fax. Keep in mind, the communication arrays need to recharge after sending a fax to Central Command, so make sure you sent everything you need.</li>
+				<li>Lastly, paper bundles can also be faxed as a single item, so feel free to bundle up all relevant documentation and send it in at once.</li>
+
+				</ol><BR>
+				</body>
+				</html>
+
+		"}
+
 /obj/item/weapon/book/manual/sop_science
 	name = "Science Standard Operating Procedures"
 	desc = "A set of guidelines aiming at the safe conduct of all scientific activities."

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -261,6 +261,19 @@
 		new /obj/item/weapon/implantcase/death_alarm(src)
 		new /obj/item/weapon/implanter(src)
 
+/obj/item/weapon/storage/box/tapes
+	name = "Tape Box"
+	desc = "A box of spare recording tapes"
+	icon_state = "box"
+
+	New()
+		..()
+		new /obj/item/device/tape(src)
+		new /obj/item/device/tape(src)
+		new /obj/item/device/tape(src)
+		new /obj/item/device/tape(src)
+		new /obj/item/device/tape(src)
+		new /obj/item/device/tape(src)
 
 /obj/item/weapon/storage/box/rxglasses
 	name = "prescription glasses"

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -101,6 +101,8 @@
 
 /obj/structure/closet/lawcloset/New()
 	..()
+	new /obj/item/weapon/storage/box/tapes(src)
+	new /obj/item/weapon/book/manual/faxes(src)
 	new /obj/item/clothing/under/lawyer/female(src)
 	new /obj/item/clothing/under/lawyer/black(src)
 	new /obj/item/clothing/under/lawyer/red(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -14,6 +14,7 @@
 			new /obj/item/weapon/storage/backpack/captain(src)
 		else
 			new /obj/item/weapon/storage/backpack/satchel_cap(src)
+		new /obj/item/weapon/book/manual/faxes(src)
 		new /obj/item/weapon/storage/backpack/duffel/captain(src)
 		new /obj/item/clothing/suit/captunic(src)
 		new /obj/item/clothing/suit/captunic/capjacket(src)
@@ -42,6 +43,7 @@
 
 	New()
 		..()
+		new /obj/item/weapon/book/manual/faxes(src)
 		new /obj/item/clothing/glasses/sunglasses(src)
 		new /obj/item/clothing/head/hopcap(src)
 		new /obj/item/weapon/cartridge/hop(src)
@@ -98,6 +100,7 @@
 			new /obj/item/weapon/storage/backpack/security(src)
 		else
 			new /obj/item/weapon/storage/backpack/satchel_sec(src)
+		new /obj/item/weapon/book/manual/faxes(src)
 		new /obj/item/weapon/cartridge/hos(src)
 		new /obj/item/device/radio/headset/heads/hos/alt(src)
 		new /obj/item/clothing/under/rank/head_of_security(src)
@@ -261,6 +264,7 @@
 
 	New()
 		..()
+		new /obj/item/weapon/book/manual/faxes(src)
 		new /obj/item/weapon/storage/briefcase(src)
 		new /obj/item/device/paicard(src)
 		new /obj/item/device/flash(src)
@@ -272,6 +276,8 @@
 		new /obj/item/clothing/under/lawyer/female(src)
 		new /obj/item/clothing/head/ntrep(src)
 		new /obj/item/clothing/shoes/sandal/fancy(src)
+		new /obj/item/weapon/storage/box/tapes(src)
+		new /obj/item/device/taperecorder(src)
 
 
 /obj/structure/closet/secure_closet/security/cargo

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -309,7 +309,7 @@
 		return 0
 	else
 		visible_message("<span class='notice'>The Photocopier pings and a robotic voice speaks up:</span>")
-		playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
+		playsound(loc, 'sound/machines/ping.ogg', 50, 0)
 		visible_message("<span class='danger'>Attention: Posterior Placed on Printing Plaque!</span>")
 		return 1
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -308,9 +308,8 @@
 		updateUsrDialog()
 		return 0
 	else
-		visible_message("<span class='notice'>The Photocopier pings and a robotic voice speaks up:</span>")
 		playsound(loc, 'sound/machines/ping.ogg', 50, 0)
-		visible_message("<span class='danger'>Attention: Posterior Placed on Printing Plaque!</span>")
+		atom_say("<span class='danger'>Attention: Posterior Placed on Printing Plaque!</span>")
 		return 1
 
 /obj/item/device/toner

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -309,6 +309,7 @@
 		return 0
 	else
 		visible_message("<span class='notice'>The Photocopier pings and a robotic voice speaks up:</span>")
+		playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 		visible_message("<span class='danger'>Attention: Posterior Placed on Printing Plaque!</span>")
 		return 1
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -9,6 +9,7 @@
 	idle_power_usage = 30
 	active_power_usage = 200
 	power_channel = EQUIP
+	atom_say_verb = "bleeps"
 	var/obj/item/copyitem = null	//what's in the copier!
 	var/copies = 1	//how many copies to print!
 	var/toner = 60 //how much toner is left! woooooo~

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -309,7 +309,7 @@
 		return 0
 	else
 		visible_message("<span class='notice'>The Photocopier pings and a robotic voice speaks up:</span>")
-		visible_message("<span class='danger'>Attention: Posterior Placed on Printing Plaque</span>")
+		visible_message("<span class='danger'>Attention: Posterior Placed on Printing Plaque!</span>")
 		return 1
 
 /obj/item/device/toner

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -11,7 +11,7 @@
 	power_channel = EQUIP
 	var/obj/item/copyitem = null	//what's in the copier!
 	var/copies = 1	//how many copies to print!
-	var/toner = 30 //how much toner is left! woooooo~
+	var/toner = 60 //how much toner is left! woooooo~
 	var/maxcopies = 10	//how many copies can be copied at once- idea shamelessly stolen from bs12's copier!
 	var/mob/living/ass = null
 
@@ -308,6 +308,8 @@
 		updateUsrDialog()
 		return 0
 	else
+		visible_message("<span class='notice'>The Photocopier pings and a robotic voice speaks up:</span>")
+		visible_message("<span class='danger'>Attention: Posterior Placed on Printing Plaque</span>")
 		return 1
 
 /obj/item/device/toner


### PR DESCRIPTION
- Archaelogical expeditions allow on-site photocopiers to be retrofitted with ancient technology and print more than 30 pages by default

- State-of-the-art scanners allow photocopiers to alert nearby personnel when posteriors are scanned, with realistic *ping action!

- NanoTrasen-issue Fax Guide added to the Captain's, Head of Personnel's, Head of Security's, Nanotrasen Representative's and Internal Affairs Agent's lockers

- Box of spare recorder tapes added to the NanoTrasen Representative's and Internal Affairs Agent's lockers

- Universal Recorder added to the NanoTrasen Representative's locker

:cl:
add: Universal Recorder added to NT Rep Locker
add: Box of recorder tapes added to NT Rep and IAA Locker
add: Fax Guide added to Captain, HoS, HoP, NT Rep and IAA Lockers
add: Butt copy alert added to photocopiers
add: Butt copy alert comes with *ping noise
tweak: Photocopiers start with 60 toner
/:cl: