### PR TITLE
Adds disable_component() to Cyborgs - EMPs Disable Binary

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -126,9 +126,9 @@
 
 /mob/living/silicon/robot/proc/disable_component(module_name, duration)
 	var/datum/robot_component/D = get_component(module_name)
-	D.component_disabled = 1
+	D.component_disabled++
 	spawn(duration)
-		D.component_disabled = 0
+		D.component_disabled--
 
 // Returns component by it's string name
 /mob/living/silicon/robot/proc/get_component(var/component_name)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -128,7 +128,7 @@
 	 var/datum/robot_component/D = get_component(module_name)
 	 D.component_disabled = 1
 	 spawn(duration)
-	 		D.component_disabled = 0
+	 	D.component_disabled = 0
 
 // Returns component by it's string name
 /mob/living/silicon/robot/proc/get_component(var/component_name)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -96,7 +96,6 @@
 	external_type = /obj/item/robot_parts/robot_component/binary_communication_device
 	energy_consumption = 0
 	max_damage = 30
-	component_disabled = 0
 
 /datum/robot_component/camera
 	name = "camera"
@@ -125,10 +124,10 @@
 	var/datum/robot_component/C = components[module_name]
 	return C && C.installed == 1 && C.toggled && C.is_powered() && !C.component_disabled
 
-/mob/living/silicon/robot/proc/disable_component(module_name, emp_duration)
+/mob/living/silicon/robot/proc/disable_component(module_name, duration)
 	 var/datum/robot_component/D = get_component(module_name)
 	 D.component_disabled = 1
-	 spawn (emp_duration)
+	 spawn(duration)
 	 		D.component_disabled = 0
 
 // Returns component by it's string name

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -9,6 +9,7 @@
 	var/electronics_damage = 0
 	var/energy_consumption = 0
 	var/max_damage = 30
+	var/component_disabled = 0
 	var/mob/living/silicon/robot/owner
 
 // The actual device object that has to be installed for this.
@@ -95,6 +96,7 @@
 	external_type = /obj/item/robot_parts/robot_component/binary_communication_device
 	energy_consumption = 0
 	max_damage = 30
+	component_disabled = 0
 
 /datum/robot_component/camera
 	name = "camera"
@@ -121,7 +123,13 @@
 
 /mob/living/silicon/robot/proc/is_component_functioning(module_name)
 	var/datum/robot_component/C = components[module_name]
-	return C && C.installed == 1 && C.toggled && C.is_powered()
+	return C && C.installed == 1 && C.toggled && C.is_powered() && !C.component_disabled
+
+/mob/living/silicon/robot/proc/disable_component(module_name, emp_duration)
+	 var/datum/robot_component/D = get_component(module_name)
+	 D.component_disabled = 1
+	 spawn (emp_duration)
+	 		D.component_disabled = 0
 
 // Returns component by it's string name
 /mob/living/silicon/robot/proc/get_component(var/component_name)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -125,10 +125,10 @@
 	return C && C.installed == 1 && C.toggled && C.is_powered() && !C.component_disabled
 
 /mob/living/silicon/robot/proc/disable_component(module_name, duration)
-	 var/datum/robot_component/D = get_component(module_name)
-	 D.component_disabled = 1
-	 spawn(duration)
-	 		D.component_disabled = 0
+	var/datum/robot_component/D = get_component(module_name)
+	D.component_disabled = 1
+	spawn(duration)
+		D.component_disabled = 0
 
 // Returns component by it's string name
 /mob/living/silicon/robot/proc/get_component(var/component_name)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -128,7 +128,7 @@
 	 var/datum/robot_component/D = get_component(module_name)
 	 D.component_disabled = 1
 	 spawn(duration)
-	 	D.component_disabled = 0
+	 		D.component_disabled = 0
 
 // Returns component by it's string name
 /mob/living/silicon/robot/proc/get_component(var/component_name)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1473,7 +1473,8 @@ var/list/robot_verbs_default = list(
 
 /mob/living/silicon/robot/emp_act(severity)
 	..()
-	if(1)
-		disable_component("comms", 360)
-	if(2)
-		disable_component("comms", 60)
+	switch(severity)
+		if(1)
+			disable_component("comms", 160)
+		if(2)
+			disable_component("comms", 60)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1470,3 +1470,10 @@ var/list/robot_verbs_default = list(
 	status_flags &= ~CANPUSH
 
 	notify_ai(2)
+
+/mob/living/silicon/robot/emp_act(severity)
+	..()
+	if(1)
+		disable_component("comms", 360)
+	if(2)
+		disable_component("comms", 60)


### PR DESCRIPTION
Fixes #4782
-Allows the disabling of robot components for a timed duration.
-EMPs now disable binary for a period of time.

:cl: Chakirski
rscadd: Adds disabled_component() to cyborgs.
bugfix: EMPs now disable binary communication for as long as the stun time.
/:cl: