### PR TITLE
Alternate Appearance Fixes

### DIFF
--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -30,7 +30,7 @@
 		if(!M.viewing_alternate_appearances)
 			M.viewing_alternate_appearances = list()
 		viewers |= M
-		M.viewing_alternate_appearances[key] = src
+		M.viewing_alternate_appearances += src
 		if(M.client)
 			M.client.images |= img
 
@@ -48,9 +48,7 @@
 		if(M.client)
 			M.client.images -= img
 		if(M.viewing_alternate_appearances && M.viewing_alternate_appearances.len)
-			M.viewing_alternate_appearances -= key
-			if(!M.viewing_alternate_appearances.len)
-				M.viewing_alternate_appearances = null
+			M.viewing_alternate_appearances -= src
 		viewers -= M
 
 
@@ -61,8 +59,6 @@
 	hide()
 	if(owner && owner.alternate_appearances)
 		owner.alternate_appearances -= key
-		if(!owner.alternate_appearances.len)
-			owner.alternate_appearances = null
 
 
 /datum/alternate_appearance/Destroy()
@@ -74,7 +70,7 @@
 /atom
 	var/list/alternate_appearances //the alternate appearances we own
 	var/list/viewing_alternate_appearances //the alternate appearances we're viewing, stored here to reestablish them after Logout()s
-	//these lists are built/destroyed as necessary, so atoms aren't all lugging around lists full of datums
+	//these lists are built as necessary, so atoms aren't all lugging around empty lists
 
 /*
 	Builds an alternate_appearance datum for the supplied args, optionally displaying it straight away
@@ -102,6 +98,8 @@
 	AA.key = key
 	AA.owner = src
 
+	if(alternate_appearances[key])
+		qdel(alternate_appearances[key])
 	alternate_appearances[key] = AA
 	if(displayTo && displayTo.len)
 		display_alt_appearance(key, displayTo)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -74,10 +74,8 @@
 	add_click_catcher()
 
 	if(viewing_alternate_appearances && viewing_alternate_appearances.len)
-		for(var/aakey in viewing_alternate_appearances)
-			var/datum/alternate_appearance/AA = viewing_alternate_appearances[aakey]
-			if(AA)
-				AA.display_to(list(src))
+		for(var/datum/alternate_appearance/AA in viewing_alternate_appearances)
+			AA.display_to(list(src))
 
 	CallHook("Login", list("client" = src.client, "mob" = src))
 


### PR DESCRIPTION
I'm *pretty confident* that this fixes #4814, since it's probably caused by dangling references from inconsistent clobbering.

- Fixes similar alternate appearances clobbering each other in their owner's list.
  - An existing appearance with an identical key will now be deleted before storing the new one.
- Fixes similar alternate appearances clobbering each other in their viewers' lists.
  - They are now just shoved into the list, instead of shoved into a specific index.
- Removes the unnecessary empty list deletion. They're empty lists, @RemieRichards, not deadly cobras. It's safe to keep them around.

:cl:
bugfix: Players probably won't get stuck as plants forever anymore. Probably.
/:cl: