### PR TITLE
Prescription Upgrade to Green Glasses & Syndi-Mesons

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -220,6 +220,7 @@
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
 		)
+	prescription_upgradable = 1
 
 /obj/item/clothing/glasses/sunglasses
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
@@ -424,6 +425,7 @@
 	desc = "Used for seeing walls, floors, and stuff through anything."
 	icon_state = "meson"
 	origin_tech = "magnets=3;syndicate=4"
+	prescription_upgradable = 1
 
 /obj/item/clothing/glasses/thermal/monocle
 	name = "Thermoncle"


### PR DESCRIPTION
-Fixes #4913
-Syndicate thermal imaging glasses can now be prescription upgraded like normal mesons.
-Green glasses from the AutoDrobe can now be prescription upgraded.

:cl: Chakirski
tweak: Syndicate thermal imaging glasses (mesons) can now be prescription upgraded like normal mesons.
tweak: Green glasses from the AutoDrobe can now be prescription upgraded.
/:cl: