### PR TITLE
Photocopier Emagging and Toast

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -228,7 +228,18 @@
 	var/icon/temp_img
 	if(!check_ass()) //You have to be sitting on the copier and either be a xeno or a human without clothes on.
 		return
-
+	if(emagged)
+		if(ishuman(ass))
+			var/mob/living/carbon/human/H = ass
+			to_chat(ass,"<span class='notice'>Something smells toasty...</span>")
+			var/obj/item/organ/external/G = H.get_organ("groin")
+			G.take_damage(0, 20)
+			sleep(20)
+			ass.emote("scream")
+		if(!ishuman(ass))
+			var/mob/living/H = ass
+			to_chat(ass,"<span class='notice'>Something smells toasty...</span>")
+			H.apply_damage(20, BURN)
 	if(ishuman(ass)) //Suit checks are in check_ass
 		var/mob/living/carbon/human/H = ass
 		temp_img = icon('icons/obj/butts.dmi', H.species.butt_sprite)
@@ -309,6 +320,13 @@
 		return 0
 	else
 		return 1
+
+/obj/machinery/photocopier/emag_act(user as mob)
+	if(!emagged)
+		emagged = 1
+		to_chat(user,"<span class='notice'>You overload the photocopier's laser printing mechanism.</span>")
+	else
+		to_chat(user,"<span class='notice'>The photocopier's laser printing mechanism is already overloaded!</span>")
 
 /obj/item/device/toner
 	name = "toner cartridge"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -231,11 +231,11 @@
 	if(emagged)
 		if(ishuman(ass))
 			var/mob/living/carbon/human/H = ass
-			to_chat(ass,"<span class='notice'>Something smells toasty...</span>")
+			to_chat(H,"<span class='notice'>Something smells toasty...</span>")
 			var/obj/item/organ/external/G = H.get_organ("groin")
 			G.take_damage(0, 30)
 			spawn(20)
-				ass.emote("scream")
+				H.emote("scream")
 		else
 			to_chat(ass,"<span class='notice'>Something smells toasty...</span>")
 			ass.apply_damage(30, BURN)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -233,13 +233,12 @@
 			var/mob/living/carbon/human/H = ass
 			to_chat(ass,"<span class='notice'>Something smells toasty...</span>")
 			var/obj/item/organ/external/G = H.get_organ("groin")
-			G.take_damage(0, 20)
-			sleep(20)
-			ass.emote("scream")
-		if(!ishuman(ass))
-			var/mob/living/H = ass
+			G.take_damage(0, 30)
+			spawn(20)
+				ass.emote("scream")
+		else
 			to_chat(ass,"<span class='notice'>Something smells toasty...</span>")
-			H.apply_damage(20, BURN)
+			ass.apply_damage(30, BURN)
 	if(ishuman(ass)) //Suit checks are in check_ass
 		var/mob/living/carbon/human/H = ass
 		temp_img = icon('icons/obj/butts.dmi', H.species.butt_sprite)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -231,13 +231,13 @@
 	if(emagged)
 		if(ishuman(ass))
 			var/mob/living/carbon/human/H = ass
-			to_chat(H,"<span class='notice'>Something smells toasty...</span>")
+			to_chat(H, "<span class='notice'>Something smells toasty...</span>")
 			var/obj/item/organ/external/G = H.get_organ("groin")
 			G.take_damage(0, 30)
 			spawn(20)
 				H.emote("scream")
 		else
-			to_chat(ass,"<span class='notice'>Something smells toasty...</span>")
+			to_chat(ass, "<span class='notice'>Something smells toasty...</span>")
 			ass.apply_damage(30, BURN)
 	if(ishuman(ass)) //Suit checks are in check_ass
 		var/mob/living/carbon/human/H = ass
@@ -323,9 +323,9 @@
 /obj/machinery/photocopier/emag_act(user as mob)
 	if(!emagged)
 		emagged = 1
-		to_chat(user,"<span class='notice'>You overload the photocopier's laser printing mechanism.</span>")
+		to_chat(user, "<span class='notice'>You overload the photocopier's laser printing mechanism.</span>")
 	else
-		to_chat(user,"<span class='notice'>The photocopier's laser printing mechanism is already overloaded!</span>")
+		to_chat(user, "<span class='notice'>The photocopier's laser printing mechanism is already overloaded!</span>")
 
 /obj/item/device/toner
 	name = "toner cartridge"


### PR DESCRIPTION
- Hardware upgrade allows photocopiers to be emagged by Cryptographic Sequencers;
- Overloaded laser printing mechanism deals 30 units of Burn Damage to anyone that sits on the photocopier and attempts to copy their posterior. You can now efficiently (?) murder someone by restraining them on a photocopier and printing 6-7 pictures, in sequence;
- Posterior copying left intact. You will still get the picture. Just toasty

:cl:
add: Photocopiers can be emagged
add: Emagged photocopiers deal 30 burn damage to all mobs copying their butts
/:cl: