### PR TITLE
Fixes Comfy Chair Deconstruction

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -141,8 +141,8 @@
 	movable = 1
 
 /obj/structure/stool/bed/chair/comfy/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/weapon/wrench))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+	if(iswrench(W))
+		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 		new /obj/item/stack/sheet/metal(get_turf(src))
 		new /obj/item/stack/sheet/metal(get_turf(src))
 		qdel(src)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -140,6 +140,15 @@
 	anchored = 0
 	movable = 1
 
+/obj/structure/stool/bed/chair/comfy/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/weapon/wrench))
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		new /obj/item/stack/sheet/metal(get_turf(src))
+		new /obj/item/stack/sheet/metal(get_turf(src))
+		qdel(src)
+	else
+		..()
+
 /obj/structure/stool/bed/chair/office/Bump(atom/A)
 	..()
 	if(!buckled_mob)	return

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -140,7 +140,7 @@
 	anchored = 0
 	movable = 1
 
-/obj/structure/stool/bed/chair/comfy/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+/obj/structure/stool/bed/chair/comfy/attackby(obj/item/weapon/W, mob/user, params)
 	if(iswrench(W))
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 		new /obj/item/stack/sheet/metal(get_turf(src))


### PR DESCRIPTION
Fixes #4908.

- New wrench software update prevents one sheet of metal from vanishing into the aether on deconstructing a Comfy Chair

:cl:
tweak: Deconstructing Comfy Chairs yields 2 metal sheets
/:cl: