### PR TITLE
Fourth-Dimensional Box Tesseract Fix

### DIFF
--- a/code/modules/detective_work/evidence.dm
+++ b/code/modules/detective_work/evidence.dm
@@ -21,6 +21,10 @@
 	if(!istype(I) || I.anchored == 1)
 		return
 
+	if(istype(I, /obj/item/weapon/storage/box))
+		to_chat(user, "<span class='notice'>This box is too big to fit in the evidence bag.</span>")
+		return
+
 	if(istype(I, /obj/item/weapon/evidencebag))
 		to_chat(user, "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>")
 		return 1 //now this is podracing


### PR DESCRIPTION
Fixes #4528. Sorta?

In an effort to prevent boxes from going into themselves if contained in an evidence bag, boxes are no longer allowed in evidence bags.

:cl:
tweak: Boxes no longer allowed inside evidence bags to prevent them going into themselves
/:cl: