### PR TITLE
Prescription Monocles

### DIFF
--- a/code/modules/client/preference/loadout/loadout_cosmetics.dm
+++ b/code/modules/client/preference/loadout/loadout_cosmetics.dm
@@ -14,3 +14,7 @@
 /datum/gear/lipstick/red
 	display_name = "lipstick, red"
 	path = /obj/item/weapon/lipstick
+
+/datum/gear/monocle
+	display_name = "monocle"
+	path = /obj/item/clothing/glasses/monocle

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -158,6 +158,7 @@
 	desc = "Such a dapper eyepiece!"
 	icon_state = "monocle"
 	item_state = "headset" // lol
+	prescription_upgradable = 1
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',


### PR DESCRIPTION
Response to #4913.

- On-site monocles can now be magically retrofitted with prescription glasses to turn them into prescription monocles. SCIENCE!

- Monocles may now be selected in the Loadout screen

:cl:
tweak: Monocles are now prescription upgradable
add: Monocles added to Loadout selection
/:cl: