### PR TITLE
Grille  Inconsistency Fix

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -142,7 +142,10 @@
 	if(iswirecutter(W))
 		if(!shock(user, 100))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-			new /obj/item/stack/rods(loc, 2)
+			if(!destroyed)
+				new /obj/item/stack/rods(loc, 2)
+			else
+				new /obj/item/stack/rods(loc)
 			qdel(src)
 	else if((isscrewdriver(W)) && (istype(loc, /turf/simulated) || anchored))
 		if(!shock(user, 90))


### PR DESCRIPTION
This fixes an inconsistency when you use wirecutters on a destroyed
grille. Instead of giving 1 like it should, it gives two.

:cl: Twinmold
Fix: Fixes the inconsistency of getting 2 metal rods when you wirecutter
a destroyed grille down to 1.
/:cl: