### PR TITLE
Minor Goonchat Alert Fix

### DIFF
--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -31,7 +31,8 @@ var/list/chatResources = list(
 		return 0
 
 	if(!winexists(owner, "browseroutput"))
-		alert(owner.mob, "Updated chat window does not exist. If you are using a custom skin file please allow the game to update.")
+		spawn()
+			alert(owner.mob, "Updated chat window does not exist. If you are using a custom skin file please allow the game to update.")
 		broken = TRUE
 		return 0
 


### PR DESCRIPTION
If a client's chat browser control doesn't exist, they'll be alerted... which will freeze their client/New() proc until they dismiss the alert. Client initialization isn't expected to be delayed in this manner, which causes problems such as player_age temporarily being "--" instead of a number, and probably other, worse things.

This fixes that by simply spawning off the alert.