### PR TITLE
Revenant Death Fix

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -164,7 +164,7 @@
 
 /mob/living/simple_animal/revenant/death()
 	..()
-	if(!revealed || stat == DEAD) //Revenants cannot die if they aren't revealed //or are already dead
+	if(!revealed)
 		return
 	ghost_darkness_images -= ghostimage
 	updateallghostimages()
@@ -187,7 +187,6 @@
 	ghostize()
 	qdel(src)
 	return
-
 
 /mob/living/simple_animal/revenant/attackby(obj/item/W, mob/living/user, params)
 	if(istype(W, /obj/item/weapon/nullrod))


### PR DESCRIPTION
Fixes #4618

- Revenants no longer initiate infinite death denials on death, and can actually pass on to... wherever it is ghosts pass on to.

Courtesy of @AuroraBlade for finding out the particular inconsistency amidst the many candidates.

:cl:
tweak: Revenants can actually be killed now.
/:cl: