### PR TITLE
Borg Power Use Refactor

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -194,7 +194,7 @@
 				var/datum/robot_component/CO = borg.get_component("radio")
 				if(!CO)
 					continue //No radio component (Shouldn't happen)
-				if(!borg.is_component_functioning("radio") || !borg.use_power(CO.energy_consumption))
+				if(!borg.is_component_functioning("radio"))
 					continue //No power.
 
 			var/turf/speaker = get_turf(R)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -324,14 +324,13 @@ Class Procs:
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 
-/obj/machinery/attack_ai(var/mob/user as mob)
-	if(isrobot(user))
-		// For some reason attack_robot doesn't work
-		// This is to stop robots from using cameras to remotely control machines.
-		if(user.client && user.client.eye == user)
-			return src.attack_hand(user)
+/obj/machinery/attack_ai(mob/user)
+	if(isrobot(user))// For some reason attack_robot doesn't work
+		var/mob/living/silicon/robot/R = user
+		if(R.client && R.client.eye == R && !R.low_power_mode)// This is to stop robots from using cameras to remotely control machines; and from using machines when the borg has no power.
+			return attack_hand(user)
 	else
-		return src.attack_hand(user)
+		return attack_hand(user)
 
 /obj/machinery/attack_hand(mob/user as mob)
 	if(user.lying || user.stat)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -244,10 +244,12 @@
 /obj/item/attack_ai(mob/user as mob)
 	if(istype(src.loc, /obj/item/weapon/robot_module))
 		//If the item is part of a cyborg module, equip it
-		if(!isrobot(user)) return
+		if(!isrobot(user))
+			return
 		var/mob/living/silicon/robot/R = user
-		R.activate_module(src)
-		R.hud_used.update_robot_modules_display()
+		if(!R.low_power_mode) //can't equip modules with an empty cell.
+			R.activate_module(src)
+			R.hud_used.update_robot_modules_display()
 
 // Due to storage type consolidation this should get used more now.
 // I have cleaned it up a little, but it could probably use more.  -Sayu

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -631,13 +631,6 @@ var/global/list/default_medbay_channels = list(
 	..()
 	set_frequency(DTH_FREQ)
 
-/obj/item/device/radio/borg/talk_into()
-	. = ..()
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		var/datum/robot_component/C = R.components["radio"]
-		R.use_power(C.energy_consumption)
-
 /obj/item/device/radio/borg/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 //	..()
 	user.set_machine(src)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -530,12 +530,6 @@
 			continue
 		M.show_message("<i><span class='game say'><span class='name'>synthesised voice</span> <span class='message'>beeps, \"beep beep beep\"</span></span></i>",2)
 
-	//robot binary xmitter component power usage
-	if(isrobot(speaker))
-		var/mob/living/silicon/robot/R = speaker
-		var/datum/robot_component/C = R.components["comms"]
-		R.use_power(C.energy_consumption)
-
 /datum/language/binary/drone
 	name = "Drone Talk"
 	desc = "A heavily encoded damage control coordination stream."

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -7,7 +7,6 @@
 	var/toggled = 1
 	var/brute_damage = 0
 	var/electronics_damage = 0
-	var/energy_consumption = 0
 	var/max_damage = 30
 	var/component_disabled = 0
 	var/mob/living/silicon/robot/owner
@@ -52,28 +51,22 @@
 	electronics_damage = max(0, electronics_damage - electronics)
 
 /datum/robot_component/proc/is_powered()
-	return (installed == 1) && (brute_damage + electronics_damage < max_damage) && (!energy_consumption || powered)
+	return (installed == 1) && (brute_damage + electronics_damage < max_damage) && (powered)
 
 
 /datum/robot_component/proc/consume_power()
 	if(toggled == 0)
 		powered = 0
 		return
-	if(owner.cell.charge >= energy_consumption)
-		owner.cell.use(energy_consumption)
-		powered = 1
-	else
-		powered = 0
+	powered = 1
 
 /datum/robot_component/armour
 	name = "armour plating"
-	energy_consumption = 0
 	external_type = /obj/item/robot_parts/robot_component/armour
 	max_damage = 100
 
 /datum/robot_component/actuator
 	name = "actuator"
-	energy_consumption = 1
 	external_type = /obj/item/robot_parts/robot_component/actuator
 	max_damage = 50
 
@@ -88,24 +81,20 @@
 /datum/robot_component/radio
 	name = "radio"
 	external_type = /obj/item/robot_parts/robot_component/radio
-	energy_consumption = 1
 	max_damage = 40
 
 /datum/robot_component/binary_communication
 	name = "binary communication device"
 	external_type = /obj/item/robot_parts/robot_component/binary_communication_device
-	energy_consumption = 0
 	max_damage = 30
 
 /datum/robot_component/camera
 	name = "camera"
 	external_type = /obj/item/robot_parts/robot_component/camera
-	energy_consumption = 1
 	max_damage = 40
 
 /datum/robot_component/diagnosis_unit
 	name = "self-diagnosis unit"
-	energy_consumption = 1
 	external_type = /obj/item/robot_parts/robot_component/diagnosis_unit
 	max_damage = 30
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -344,7 +344,7 @@
 /mob/living/silicon/robot/drone/use_power()
 
 	..()
-	if(!src.has_power || !decompiler)
+	if(low_power_mode || !decompiler)
 		return
 
 	//The decompiler replenishes drone stores from hoovered-up junk each tick.

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -161,3 +161,14 @@
 			to_chat(src, "salute, bow-(none)/mob, clap, flap, aflap, twitch, twitches, nod, deathgasp, glare-(none)/mob, stare-(none)/mob, look,\n law, halt")
 
 	..(act, m_type, message)
+
+/mob/living/silicon/robot/verb/powerwarn()
+	set category = "Robot Commands"
+	set name = "Power Warning"
+
+	if(!is_component_functioning("power cell") || !cell || !cell.charge)
+		visible_message("The power warning light on <span class='name'>[src]</span> flashes urgently.",\
+						 "You announce you are operating in low power mode.")
+		playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
+	else
+		to_chat(src, "<span class='warning'>You can only use this emote when you're out of charge.</span>")

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -7,35 +7,40 @@
 	if(act_module)
 		msg += "It is holding [bicon(act_module)] \a [act_module].\n"
 	msg += "<span class='warning'>"
-	if(src.getBruteLoss())
-		if(src.getBruteLoss() < 75)
+	if(getBruteLoss())
+		if(getBruteLoss() < maxHealth*0.5)
 			msg += "It looks slightly dented.\n"
 		else
 			msg += "<B>It looks severely dented!</B>\n"
-	if(src.getFireLoss())
-		if(src.getFireLoss() < 75)
+	if(getFireLoss())
+		if(getFireLoss() < maxHealth*0.5)
 			msg += "It looks slightly charred.\n"
 		else
 			msg += "<B>It looks severely burnt and heat-warped!</B>\n"
-	if(src.fire_stacks < 0)
+	if(health < -maxHealth*0.5)
+		msg += "It looks barely operational.\n"
+	if(fire_stacks < 0)
 		msg += "It's covered in water.\n"
-	if(src.fire_stacks > 0)
+	else if(fire_stacks > 0)
 		msg += "It's coated in something flammable.\n"
 	msg += "</span>"
 
 	if(opened)
 		msg += "<span class='warning'>Its cover is open and the power cell is [cell ? "installed" : "missing"].</span>\n"
 	else
-		msg += "Its cover is closed.\n"
+		msg += "Its cover is closed[locked ? "" : ", and looks unlocked"].\n"
 
-	if(!has_power)
-		msg += "<span class='warning'>It appears to be running on backup power.</span>\n"
+	if(cell && cell.charge <= 0)
+		msg += "<span class='warning'>Its battery indicator is blinking red!</span>\n"
 
-	switch(src.stat)
+	switch(stat)
 		if(CONSCIOUS)
-			if(!src.client)	msg += "It appears to be in stand-by mode.\n" //afk
-		if(UNCONSCIOUS)		msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
-		if(DEAD)			msg += "<span class='deadsay'>It looks completely unsalvageable.</span>\n"
+			if(!client)
+				msg += "It appears to be in stand-by mode.\n" //afk
+		if(UNCONSCIOUS)
+			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
+		if(DEAD)
+			msg += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>\n"
 	msg += "*---------*</span>"
 
 	if(print_flavor_text()) msg += "\n[print_flavor_text()]\n"

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -22,6 +22,13 @@
 
 /mob/living/silicon/robot/proc/handle_robot_cell()
 	if(stat != DEAD)
+		if(!is_component_functioning("power cell") || !cell)
+			Paralyse(2)
+			uneq_all()
+			low_power_mode = 1
+			update_headlamp()
+			diag_hud_set_borgcell()
+			return
 		if(low_power_mode)
 			if(is_component_functioning("power cell") && cell && cell.charge)
 				low_power_mode = 0

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -61,7 +61,7 @@ var/list/robot_verbs_default = list(
 	var/datum/effect/system/ion_trail_follow/ion_trail = null
 	var/datum/effect/system/spark_spread/spark_system//So they can initialize sparks whenever/N
 	var/jeton = 0
-	var/has_power = 1
+	var/low_power_mode = 0 //whether the robot has no charge left.
 	var/weapon_lock = 0
 	var/weaponlock_time = 120
 	var/lawupdate = 1 //Cyborgs will sync their laws with their AI by default
@@ -231,8 +231,6 @@ var/list/robot_verbs_default = list(
 
 /mob/living/silicon/robot/binarycheck()
 	if(is_component_functioning("comms"))
-		var/datum/robot_component/RC = get_component("comms")
-		use_power(RC.energy_consumption)
 		return 1
 	return 0
 
@@ -413,7 +411,7 @@ var/list/robot_verbs_default = list(
 	var/dat = "<HEAD><TITLE>[src.name] Self-Diagnosis Report</TITLE></HEAD><BODY>\n"
 	for(var/V in components)
 		var/datum/robot_component/C = components[V]
-		dat += "<b>[C.name]</b><br><table><tr><td>Power consumption</td><td>[C.energy_consumption]</td></tr><tr><td>Brute Damage:</td><td>[C.brute_damage]</td></tr><tr><td>Electronics Damage:</td><td>[C.electronics_damage]</td></tr><tr><td>Powered:</td><td>[(!C.energy_consumption || C.is_powered()) ? "Yes" : "No"]</td></tr><tr><td>Toggled:</td><td>[ C.toggled ? "Yes" : "No"]</td></table><br>"
+		dat += "<b>[C.name]</b><br><table><tr><td>Brute Damage:</td><td>[C.brute_damage]</td></tr><tr><td>Electronics Damage:</td><td>[C.electronics_damage]</td></tr><tr><td>Powered:</td><td>[C.is_powered() ? "Yes" : "No"]</td></tr><tr><td>Toggled:</td><td>[ C.toggled ? "Yes" : "No"]</td></table><br>"
 
 	return dat
 
@@ -992,7 +990,7 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/update_icons()
 
 	overlays.Cut()
-	if(stat != DEAD && !(paralysis || stunned || weakened)) //Not dead, not stunned.
+	if(stat != DEAD && !(paralysis || stunned || weakened || low_power_mode)) //Not dead, not stunned.
 		overlays += "eyes-[icon_state]"
 	else
 		overlays -= "eyes"
@@ -1130,7 +1128,7 @@ var/list/robot_verbs_default = list(
 	radio.interact(src)//Just use the radio's Topic() instead of bullshit special-snowflake code
 
 /mob/living/silicon/robot/proc/control_headlamp()
-	if(stat || lamp_recharging)
+	if(stat || lamp_recharging || low_power_mode)
 		to_chat(src, "<span class='danger'>This function is currently offline.</span>")
 		return
 
@@ -1142,7 +1140,7 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/proc/update_headlamp(var/turn_off = 0, var/cooldown = 100)
 	set_light(0)
 
-	if(lamp_intensity && (turn_off || stat))
+	if(lamp_intensity && (turn_off || stat || low_power_mode))
 		to_chat(src, "<span class='danger'>Your headlamp has been deactivated.</span>")
 		lamp_intensity = 0
 		lamp_recharging = 1


### PR DESCRIPTION
Refactors Borg's power useage, largely in line with TG.

Considered balance because of how much this impacts borg's power useage and behavior without power.

- Individual component power useage for borgs has been removed
 - No more using up tons of power because the crew is chatty, for instance
- Borgs without power or a cell can move around/talk, but cannot interact with objects around them other than bumping into doors
- Additional borg power useage based upon which items are in which slots has been removed
- Gives borgs a special verb they can use when they have now cell, their cell is broken, or they have no power.

Overall, your primary power concerns should come from using equipment, not existing with base level equipment; things that use power will be things like stun batons, disablers, headlamps, etc. IE: active equipment the borg specifically chooses to use.

This also better paves the way for energy based resources modules--that is to say, moving away from "go to recharger to get X, Y, and Z replenished" and "replenishing X, Y, and Z is done on the fly and drains your cell directly; go to a recharger for purely battery purposes"

Fixes
- Fixed up some examines so they're more accurate and based upon borg's current health values
- Fixes not being able to enter a borg recharger if you run out of power (fixes https://github.com/ParadiseSS13/Paradise/issues/4950)

:cl: Fox McCloud
tweak: Overall borg power useage has been lowered
tweak: Borgs who have completely run out of power can now still move around/see/talk, but they will be unable to interact with machinery/doors around them; they can still bump open doors, however. Borgs with no cell are still completely paralyzed and can't do anything.
/:cl:
