### PR TITLE
Adds "salts" to the Say Verbs for Deadchat

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -51,7 +51,7 @@
 		to_chat(usr, "<span class='danger'>You have deadchat muted.</span>")
 		return
 
-	say_dead_direct("[pick("complains","moans","whines","laments","blubbers")], <span class='message'>\"[message]\"</span>", src)
+	say_dead_direct("[pick("complains", "moans", "whines", "laments", "blubbers", "salts")], <span class='message'>\"[message]\"</span>", src)
 
 /mob/proc/say_understands(var/mob/other,var/datum/language/speaking = null)
 


### PR DESCRIPTION
In addition to the current: "complains", "moans", "whines", "laments", and "blubbers".

:cl:
add: Adds "salts" as a say verb for deadchat ghosts.
/:cl: