### PR TITLE
Improves Cryoing

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -319,7 +319,7 @@
 		else if(O.target && istype(O.target,/datum/mind))
 			if(O.target == occupant.mind)
 				if(O.owner && O.owner.current)
-					to_chat(O.owner.current, "<span class='warning'>You get the feeling your target is no longer within your reach. Time for Plan [pick(list("A","B","C","D","X","Y","Z"))]...</span>")
+					to_chat(O.owner.current, "<span class='userdanger'>You get the feeling your target is no longer within reach. Time for Plan [pick("A","B","C","D","X","Y","Z")]. Objectives updated!</span>")
 				O.target = null
 				spawn(1) //This should ideally fire after the occupant is deleted.
 					if(!O) return
@@ -344,6 +344,7 @@
 
 	// Delete them from datacore.
 
+	var/announce_rank = null
 	if(PDA_Manifest.len)
 		PDA_Manifest.Cut()
 	for(var/datum/data/record/R in data_core.medical)
@@ -354,6 +355,7 @@
 			qdel(T)
 	for(var/datum/data/record/G in data_core.general)
 		if((G.fields["name"] == occupant.real_name))
+			announce_rank = G.fields["rank"]
 			qdel(G)
 
 	if(orient_right)
@@ -369,10 +371,15 @@
 		ailist += A
 	if(ailist.len)
 		var/mob/living/silicon/ai/announcer = pick(ailist)
-		announcer.say(";[occupant.real_name] [on_store_message]")
+		if (announce_rank)
+			announcer.say(";[occupant.real_name] ([announce_rank]) [on_store_message]")
+		else
+			announcer.say(";[occupant.real_name] [on_store_message]")
 	else
-		announce.autosay("[occupant.real_name] [on_store_message]", "[on_store_name]")
-
+		if (announce_rank)
+			announce.autosay("[occupant.real_name]  ([announce_rank]) [on_store_message]", "[on_store_name]")
+		else
+			announce.autosay("[occupant.real_name] [on_store_message]", "[on_store_name]")
 	visible_message("<span class='notice'>\The [src] hums and hisses as it moves [occupant.real_name] into storage.</span>")
 
 	// Delete the mob.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -72,7 +72,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 					name = capitalize(pick(first_names_female)) + " " + capitalize(pick(last_names))
 
 		mind = body.mind	//we don't transfer the mind but we keep a reference to it.
-	
+
 	ghostimage = image(icon = icon, loc = src, icon_state = icon_state)
 	ghostimage.overlays = overlays
 	ghostimage.dir = dir
@@ -157,13 +157,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		resting = 1
 		var/mob/dead/observer/ghost = ghostize(0)            //0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
-
 	var/obj/structure/morgue/Morgue = locate() in M.loc
 	if(istype(M.loc,/obj/structure/morgue))
 		Morgue = M.loc
 	if(Morgue)
 		Morgue.update()
-
+	if(istype(M.loc,/obj/machinery/cryopod))
+		var/obj/machinery/cryopod/P = M.loc
+		if(!P.control_computer)
+			P.find_control_computer(urgent=1)
+		if(P.control_computer)
+			P.despawn_occupant()
 	return
 
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -158,11 +158,11 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/mob/dead/observer/ghost = ghostize(0)            //0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
 	var/obj/structure/morgue/Morgue = locate() in M.loc
-	if(istype(M.loc,/obj/structure/morgue))
+	if(istype(M.loc, /obj/structure/morgue))
 		Morgue = M.loc
 	if(Morgue)
 		Morgue.update()
-	if(istype(M.loc,/obj/machinery/cryopod))
+	if(istype(M.loc, /obj/machinery/cryopod))
 		var/obj/machinery/cryopod/P = M.loc
 		if(!P.control_computer)
 			P.find_control_computer(urgent=1)


### PR DESCRIPTION
Changes:
- While in a cryopod, if you use OOC->Ghost and hit 'Yes', you will be instantly moved to long-term storage. 
- When someone enters long-term storage in a cryopod, the message that announces this now includes their rank. e.g: "John Doe (Captain) has entered long term storage"
- When an antag target cryos, the message that they get about 'Time for plan B' is now more obvious.

Please note:
- You cannot be cryoed against your will. Triggering the instant-storage requires you to deliberately enter a cryopod, choose 'Ghost' from the OOC menu, and then hit 'Yes' on the 'are you sure' prompt. By that point, it is pretty clear you want to leave the round. 
- On the other hand, moving you to long-term storage faster helps other people. It frees the job slot for others, reassigns antag targets, lets everyone know what happened, updates the manifest, etc.

:cl: Kyep
tweak: Entering a cryo pod, then deliberately selecting OOC->Ghost, and clicking yes on the prompt, will now instantly send you to long-term storage, removing you from the round, despawning your body, freeing your job slot, and giving a new objective to any antag that had you as a target.
tweak: Announcements about someone entering long-term storage via a cryopod now include that person's rank.
tweak: When an antag target cryos, the message the antag gets about their objectives changing is now clearer.
/:cl: