### PR TITLE
Remote View Bug Fix

### DIFF
--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -242,6 +242,8 @@
 	var/list/targets = living_mob_list
 	var/list/remoteviewers = new /list()
 	for(var/mob/M in targets)
+		if(PSY_RESIST in M.mutations)
+			continue
 		if(REMOTE_VIEW in M.mutations)
 			remoteviewers += M
 	if(!remoteviewers.len || remoteviewers.len == 1)
@@ -273,10 +275,6 @@
 		return
 
 	for(var/mob/living/L in targets)
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if(PSY_RESIST in H.mutations)
-				continue
 		target = L
 
 	if(target)

--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -239,9 +239,9 @@
 	action_icon_state = "genetic_view"
 
 /obj/effect/proc_holder/spell/targeted/remoteview/choose_targets(mob/user = usr)
-	var/list/targets = living_mob_list
+	var/list/targets = list()
 	var/list/remoteviewers = new /list()
-	for(var/mob/M in targets)
+	for(var/mob/M in living_mob_list)
 		if(PSY_RESIST in M.mutations)
 			continue
 		if(REMOTE_VIEW in M.mutations)


### PR DESCRIPTION
Fixes #4947

- In an effort to prevent telepathy from freaking out and sending Remote Viewers careening off into a random mob if they try to spy on someone that is both a Remote Viewer AND has Psychic Resistance, anyone with Psychic Resistance is automatically blacklisted from potential Remote View targets

- As a side effect, can no longer use Remote View on yourself. I'm afraid your eyes will have to suffice

:cl:
tweak: Mobs with PSY_RESISTANCE are no longer valid targets for REMOTE_VIEW
/:cl: