### PR TITLE
Makes a bunch of UI's use /datum/browser

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -94,7 +94,9 @@
 				[round(target_pressure,0.1)]kPa | <a href='?src=\ref[src];set_press=1'>Change</a>
 				"}
 
-	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_pump")
+	var/datum/browser/popup = new(user, "atmo_pump", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "atmo_pump")
 
 /obj/machinery/atmospherics/binary/passive_gate/receive_signal(datum/signal/signal)

--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -96,7 +96,7 @@
 
 	var/datum/browser/popup = new(user, "atmo_pump", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "atmo_pump")
 
 /obj/machinery/atmospherics/binary/passive_gate/receive_signal(datum/signal/signal)

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -111,7 +111,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	var/datum/browser/popup = new(user, "atmo_pump", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "atmo_pump")
 
 /obj/machinery/atmospherics/binary/pump/initialize()

--- a/code/ATMOSPHERICS/components/binary_devices/pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/pump.dm
@@ -109,7 +109,9 @@ Thus, the two variables affect pump operation are set in New():
 				[round(target_pressure,0.1)]kPa | <a href='?src=\ref[src];set_press=1'>Change</a>
 				"}
 
-	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_pump")
+	var/datum/browser/popup = new(user, "atmo_pump", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "atmo_pump")
 
 /obj/machinery/atmospherics/binary/pump/initialize()

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -105,7 +105,9 @@ Thus, the two variables affect pump operation are set in New():
 				[round(transfer_rate,1)]l/s | <a href='?src=\ref[src];set_transfer_rate=1'>Change</a>
 				"}
 
-	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_pump")
+	var/datum/browser/popup = new(user, "atmo_pump", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "atmo_pump")
 
 

--- a/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/volume_pump.dm
@@ -107,7 +107,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	var/datum/browser/popup = new(user, "atmo_pump", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "atmo_pump")
 
 

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -196,7 +196,9 @@ Filter types:
 	//else
 	//	src.on != src.on
 */
-	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_filter")
+	var/datum/browser/popup = new(user, "atmo_filter", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "atmo_filter")
 	return
 

--- a/code/ATMOSPHERICS/components/trinary_devices/filter.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/filter.dm
@@ -198,7 +198,7 @@ Filter types:
 */
 	var/datum/browser/popup = new(user, "atmo_filter", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "atmo_filter")
 	return
 

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -135,7 +135,9 @@
 				<a href='?src=\ref[src];node2_c=0.1'>+</a>
 				"}
 
-	user << browse("<HEAD><TITLE>[src.name] control</TITLE></HEAD><TT>[dat]</TT>", "window=atmo_mixer")
+	var/datum/browser/popup = new(user, "atmo_mixer", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "atmo_mixer")
 	return
 

--- a/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/mixer.dm
@@ -137,7 +137,7 @@
 
 	var/datum/browser/popup = new(user, "atmo_mixer", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "atmo_mixer")
 	return
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -160,7 +160,7 @@ obj/machinery/air_sensor
 		var/html=return_text()
 		var/datum/browser/popup = new(user, "gac", name, 400, 400)
 		popup.set_content(html)
-		popup.open()
+		popup.open(0)
 		user.set_machine(src)
 		onclose(user, "gac")
 

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -157,8 +157,10 @@ obj/machinery/air_sensor
 	attack_hand(mob/user)
 		if(..(user))
 			return
-		var/html=return_text()+"</body></html>"
-		user << browse(html,"window=gac")
+		var/html=return_text()
+		var/datum/browser/popup = new(user, "gac", name, 400, 400)
+		popup.set_content(html)
+		popup.open()
 		user.set_machine(src)
 		onclose(user, "gac")
 
@@ -220,16 +222,12 @@ obj/machinery/air_sensor
 			else
 				sensor_data = "<em>No sensors connected.</em>"
 
-		var/output = {"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-	<head>
-		<title>[name]</title>
+		var/output = {"
 		<style type="text/css">
 html,body {
 	font-family:sans-serif,verdana;
 	font-size:smaller;
-	color:#666;
+	color:#fff;
 }
 h1 {
 	border-bottom:1px solid maroon;
@@ -251,15 +249,12 @@ th {
 
 fieldset {
 	border:1px solid #ccc;
-	background: #efefef;
+	background: #333;
 }
 legend {
 	font-weight:bold;
 }
 		</style>
-	</head>
-	<body>
-		<h1>[name]</h1>
 		[show_sensors ? "<h2>Sensor Data:</h2>" + sensor_data : ""]
 		"}
 

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -85,7 +85,9 @@
 				<i>[zone]</i>
 			</body>
 		</html>"}
-		user << browse("[dat]", "window=miningshuttle;size=400x400")
+		var/datum/browser/popup = new(user, "area_atmos", name, 400, 400)
+		popup.set_content(dat)
+		popup.open()
 		status = ""
 
 	Topic(href, href_list)

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -87,7 +87,7 @@
 		</html>"}
 		var/datum/browser/popup = new(user, "area_atmos", name, 400, 400)
 		popup.set_content(dat)
-		popup.open()
+		popup.open(0)
 		status = ""
 
 	Topic(href, href_list)

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -58,7 +58,9 @@
 		dat += "<BR>"
 		dat += "Safety Protocols are <font color=green> ENABLED </font><BR>"
 
-	user << browse(dat, "window=computer;size=400x500")
+	var/datum/browser/popup = new(user, "holodeck_computer", name, 400, 500)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -60,7 +60,7 @@
 
 	var/datum/browser/popup = new(user, "holodeck_computer", name, 400, 500)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -117,7 +117,7 @@
 			dat += text("<A href='?src=\ref[];login=1'>{Log In}</A>", src)
 	var/datum/browser/popup = new(user, "med_rec", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "med_rec")
 	return
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -48,7 +48,7 @@
 					dat += "<B>Record List</B>:<HR>"
 					if(!isnull(data_core.general))
 						for(var/datum/data/record/R in sortRecord(data_core.general))
-							dat += text("<A href='?src=\ref[];d_rec=\ref[]'>[]: []<BR>", src, R, R.fields["id"], R.fields["name"])
+							dat += text("<A href='?src=\ref[];d_rec=\ref[]'>[]: []</A><BR>", src, R, R.fields["id"], R.fields["name"])
 							//Foreach goto(132)
 					dat += text("<HR><A href='?src=\ref[];screen=1'>Back</A>", src)
 				if(3.0)
@@ -115,7 +115,9 @@
 				else
 		else
 			dat += text("<A href='?src=\ref[];login=1'>{Log In}</A>", src)
-	user << browse(text("<HEAD><TITLE>Medical Records</TITLE></HEAD><TT>[]</TT>", dat), "window=med_rec")
+	var/datum/browser/popup = new(user, "med_rec", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "med_rec")
 	return
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -45,6 +45,39 @@
 		to_chat(user, "<span class='danger'>Unable to establish a connection</span>: You're too far away from the station!")
 		return
 	var/dat
+	
+	// search javascript
+	var/head_content = {"
+	<script src="libraries.min.js"></script>
+	<script type='text/javascript'>
+
+	function updateSearch(){
+		var filter_text = document.getElementById('filter');
+		var filter = filter_text.value.toLowerCase();
+
+		if(complete_list != null && complete_list != ""){
+			var mtbl = document.getElementById("maintable_data_archive");
+			mtbl.innerHTML = complete_list;
+		}
+
+		if(filter.value == ""){
+			return;
+		}else{
+			$("#maintable_data").children("tbody").children("tr").children("td").children("input").filter(function(index)
+			{
+				return $(this)\[0\].value.toLowerCase().indexOf(filter) == -1
+			}).parent("td").parent("tr").hide()
+		}
+	}
+
+	function selectTextField(){
+		var filter_text = document.getElementById('filter');
+		filter_text.focus();
+		filter_text.select();
+	}
+
+	</script>
+"}
 
 	if (temp)
 		dat = text("<TT>[]</TT><BR><BR><A href='?src=\ref[];choice=Clear Screen'>Clear Screen</A>", temp, src)
@@ -56,43 +89,7 @@
 
 					//body tag start + onload and onkeypress (onkeyup) javascript event calls
 					dat += "<body onload='selectTextField(); updateSearch();' onkeyup='updateSearch();'>"
-					//search bar javascript
-					dat += {"
-
-		<head>
-			<script src="libraries.min.js"></script>
-			<script type='text/javascript'>
-
-				function updateSearch(){
-					var filter_text = document.getElementById('filter');
-					var filter = filter_text.value.toLowerCase();
-
-					if(complete_list != null && complete_list != ""){
-						var mtbl = document.getElementById("maintable_data_archive");
-						mtbl.innerHTML = complete_list;
-					}
-
-					if(filter.value == ""){
-						return;
-					}else{
-						$("#maintable_data").children("tbody").children("tr").children("td").children("input").filter(function(index)
-						{
-							return $(this)\[0\].value.toLowerCase().indexOf(filter) == -1
-						}).parent("td").parent("tr").hide()
-					}
-				}
-
-				function selectTextField(){
-					var filter_text = document.getElementById('filter');
-					filter_text.focus();
-					filter_text.select();
-				}
-
-			</script>
-		</head>
-
-
-	"}
+					
 					dat += {"
 <p style='text-align:center;'>"}
 					dat += text("<A href='?src=\ref[];choice=New Record (General)'>New Record</A><BR>", src)
@@ -132,17 +129,17 @@
 							var/background
 							switch(crimstat)
 								if("*Arrest*")
-									background = "'background-color:#DC143C;'"
+									background = "'background-color:#890E26'"
 								if("Incarcerated")
-									background = "'background-color:#CD853F;'"
+									background = "'background-color:#743B03'"
 								if("Parolled")
-									background = "'background-color:#CD853F;'"
+									background = "'background-color:#743B03'"
 								if("Released")
-									background = "'background-color:#3BB9FF;'"
+									background = "'background-color:#216489'"
 								if("None")
-									background = "'background-color:#00FF7F;'"
+									background = "'background-color:#007f47'"
 								if("")
-									background = "'background-color:#FFFFFF;'"
+									background = "''"
 									crimstat = "No Record."
 							dat += "<tr style=[background]>"
 							dat += text("<td><input type='hidden' value='[] [] [] []'></input><A href='?src=\ref[];choice=Browse Record;d_rec=\ref[]'>[]</a></td>", R.fields["name"], R.fields["id"], R.fields["rank"], R.fields["fingerprint"], src, R, R.fields["name"])
@@ -203,7 +200,10 @@
 				else
 		else
 			dat += text("<A href='?src=\ref[];choice=Log In'>{Log In}</A>", src)
-	user << browse(text("<HEAD><TITLE>Security Records</TITLE></HEAD><TT>[]</TT>", dat), "window=secure_rec;size=600x400")
+	var/datum/browser/popup = new(user, "secure_rec", name, 600, 400)
+	popup.set_content(dat)
+	popup.add_head_content(head_content)
+	popup.open()
 	onclose(user, "secure_rec")
 	return
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -203,7 +203,7 @@
 	var/datum/browser/popup = new(user, "secure_rec", name, 600, 400)
 	popup.set_content(dat)
 	popup.add_head_content(head_content)
-	popup.open()
+	popup.open(0)
 	onclose(user, "secure_rec")
 	return
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -55,7 +55,7 @@
 
 		var/datum/browser/popup = new(user, "airlock_electronics", name, 400, 400)
 		popup.set_content(t1)
-		popup.open()
+		popup.open(0)
 		onclose(user, "airlock")
 
 	Topic(href, href_list)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -53,7 +53,9 @@
 
 		t1 += text("<p><a href='?src=\ref[];close=1'>Close</a></p>\n", src)
 
-		user << browse(t1, "window=airlock_electronics")
+		var/datum/browser/popup = new(user, "airlock_electronics", name, 400, 400)
+		popup.set_content(t1)
+		popup.open()
 		onclose(user, "airlock")
 
 	Topic(href, href_list)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -188,9 +188,7 @@
 	user.set_machine(src)
 
 	// dat
-	var/dat = "<HTML><BODY><TT>"
-
-	dat += "<HR>Timer System:</hr>"
+	var/dat = "<HR>Timer System:</hr>"
 	dat += " <b>Door [src.id] controls</b><br/>"
 
 	// Start/Stop timer
@@ -220,9 +218,10 @@
 			dat += "<br/><A href='?src=\ref[src];fc=1'>Activate Flash</A>"
 
 	dat += "<br/><br/><a href='?src=\ref[user];mach_close=computer'>Close</a>"
-	dat += "</TT></BODY></HTML>"
 
-	user << browse(dat, "window=computer;size=400x500")
+	var/datum/browser/popup = new(user, "door_timer", name, 400, 500)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -221,7 +221,7 @@
 
 	var/datum/browser/popup = new(user, "door_timer", name, 400, 500)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "computer")
 	return
 

--- a/code/game/machinery/guestpass.dm
+++ b/code/game/machinery/guestpass.dm
@@ -96,7 +96,7 @@
 
 	var/datum/browser/popup = new(user, "guestpass", name, 400, 520)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "guestpass")
 
 

--- a/code/game/machinery/guestpass.dm
+++ b/code/game/machinery/guestpass.dm
@@ -94,7 +94,9 @@
 				dat += "<a href='?src=\ref[src];choice=access;access=[A]'>[area]</a><br>"
 		dat += "<br><a href='?src=\ref[src];action=issue'>Issue pass</a><br>"
 
-	user << browse(dat, "window=guestpass;size=400x520")
+	var/datum/browser/popup = new(user, "guestpass", name, 400, 520)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "guestpass")
 
 

--- a/code/game/machinery/kitchen/icecream_vat.dm
+++ b/code/game/machinery/kitchen/icecream_vat.dm
@@ -89,7 +89,7 @@ var/list/ingredients_source = list(
 
 	var/datum/browser/popup = new(user, "icecreamvat", name, 600, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 
 /obj/machinery/icecream_vat/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if(istype(O, /obj/item/weapon/reagent_containers))

--- a/code/game/machinery/kitchen/icecream_vat.dm
+++ b/code/game/machinery/kitchen/icecream_vat.dm
@@ -87,7 +87,9 @@ var/list/ingredients_source = list(
 		dat += "No beaker inserted. "
 	dat += "<a href='?src=\ref[src];refresh=1'>Refresh</a> <a href='?src=\ref[src];close=1'>Close</a>"
 
-	user << browse(dat,"window=icecreamvat;size=600x400")
+	var/datum/browser/popup = new(user, "icecreamvat", name, 600, 400)
+	popup.set_content(dat)
+	popup.open()
 
 /obj/machinery/icecream_vat/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if(istype(O, /obj/item/weapon/reagent_containers))

--- a/code/game/machinery/kitchen/juicer.dm
+++ b/code/game/machinery/kitchen/juicer.dm
@@ -104,7 +104,7 @@
 		dat += "<A href='?src=\ref[src];action=detach'>Detach a beaker!<BR>"
 	var/datum/browser/popup = new(user, "juicer", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "juicer")
 	return
 

--- a/code/game/machinery/kitchen/juicer.dm
+++ b/code/game/machinery/kitchen/juicer.dm
@@ -102,7 +102,9 @@
 		dat += "<A href='?src=\ref[src];action=juice'>Turn on!<BR>"
 	if (beaker)
 		dat += "<A href='?src=\ref[src];action=detach'>Detach a beaker!<BR>"
-	user << browse("<HEAD><TITLE>Juicer</TITLE></HEAD><TT>[dat]</TT>", "window=juicer")
+	var/datum/browser/popup = new(user, "juicer", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "juicer")
 	return
 

--- a/code/game/machinery/kitchen/kitchen_machine.dm
+++ b/code/game/machinery/kitchen/kitchen_machine.dm
@@ -236,7 +236,7 @@
 
 	var/datum/browser/popup = new(user, name, name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "[src.name]")
 	return
 

--- a/code/game/machinery/kitchen/kitchen_machine.dm
+++ b/code/game/machinery/kitchen/kitchen_machine.dm
@@ -230,11 +230,13 @@
 		else
 			dat = {"<b>Ingredients:</b><br>[dat]"}
 		dat += {"<HR><BR>\
-<A href='?src=\ref[src];action=cook'>Turn on!<BR>\
-<A href='?src=\ref[src];action=dispose'>Eject ingredients!<BR>\
+<A href='?src=\ref[src];action=cook'>Turn on!</A><BR>\
+<A href='?src=\ref[src];action=dispose'>Eject ingredients!</A><BR>\
 "}
 
-	user << browse("<HEAD><TITLE>[src] Controls</TITLE></HEAD><TT>[dat]</TT>", "window=[src.name]")
+	var/datum/browser/popup = new(user, name, name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "[src.name]")
 	return
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -254,11 +254,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(6)
 				dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed story to Network.</B></FONT><HR><BR>"
 				if(src.channel_name=="")
-					dat+="<FONT COLOR='maroon'>�Invalid receiving channel name.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Invalid receiving channel name.</FONT><BR>"
 				if(src.scanned_user=="Unknown")
-					dat+="<FONT COLOR='maroon'>�Channel author unverified.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Channel author unverified.</FONT><BR>"
 				if(src.msg == "" || src.msg == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>�Invalid message body.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Invalid message body.</FONT><BR>"
 
 				dat+="<BR><A href='?src=\ref[src];setScreen=[3]'>Return</A><BR>"
 			if(7)
@@ -272,18 +272,18 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					else
 						existing_authors += FC.author
 				if(src.scanned_user in existing_authors)
-					dat+="<FONT COLOR='maroon'>�There already exists a Feed channel under your name.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>There already exists a Feed channel under your name.</FONT><BR>"
 				if(src.channel_name=="" || src.channel_name == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>�Invalid channel name.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Invalid channel name.</FONT><BR>"
 				var/check = 0
 				for(var/datum/feed_channel/FC in news_network.network_channels)
 					if(FC.channel_name == src.channel_name)
 						check = 1
 						break
 				if(check)
-					dat+="<FONT COLOR='maroon'>�Channel name already in use.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Channel name already in use.</FONT><BR>"
 				if(src.scanned_user=="Unknown")
-					dat+="<FONT COLOR='maroon'>�Channel author unverified.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Channel author unverified.</FONT><BR>"
 				dat+="<BR><A href='?src=\ref[src];setScreen=[2]'>Return</A><BR>"
 			if(8)
 				var/total_num=length(news_network.network_channels)
@@ -394,11 +394,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(16)
 				dat+="<B><FONT COLOR='maroon'>ERROR: Wanted Issue rejected by Network.</B></FONT><HR><BR>"
 				if(src.channel_name=="" || src.channel_name == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>�Invalid name for person wanted.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Invalid name for person wanted.</FONT><BR>"
 				if(src.scanned_user=="Unknown")
-					dat+="<FONT COLOR='maroon'>�Issue author unverified.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Issue author unverified.</FONT><BR>"
 				if(src.msg == "" || src.msg == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>�Invalid description.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>Invalid description.</FONT><BR>"
 				dat+="<BR><A href='?src=\ref[src];setScreen=[0]'>Return</A><BR>"
 			if(17)
 				dat+="<B>Wanted Issue successfully deleted from Circulation</B><BR>"
@@ -429,7 +429,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 		var/datum/browser/popup = new(user, "newscaster_main", name, 400, 600)
 		popup.set_content(dat)
-		popup.open()
+		popup.open(0)
 		onclose(human_or_robot_user, "newscaster_main")
 
 	/*if(src.isbroken) //debugging shit
@@ -796,7 +796,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		switch(screen)
 			if(0) //Cover
 				dat+="<DIV ALIGN='center'><B><FONT SIZE=6>The Griffon</FONT></B></div>"
-				dat+="<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasen� Space Facilities</FONT></div><HR>"
+				dat+="<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasen Space Facilities</FONT></div><HR>"
 				if(isemptylist(src.news_content))
 					if(src.important_message)
 						dat+="Contents:<BR><ul><B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [src.pages+2]\]</FONT><BR></ul>"

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -254,11 +254,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(6)
 				dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed story to Network.</B></FONT><HR><BR>"
 				if(src.channel_name=="")
-					dat+="<FONT COLOR='maroon'>•Invalid receiving channel name.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Invalid receiving channel name.</FONT><BR>"
 				if(src.scanned_user=="Unknown")
-					dat+="<FONT COLOR='maroon'>•Channel author unverified.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Channel author unverified.</FONT><BR>"
 				if(src.msg == "" || src.msg == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>•Invalid message body.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Invalid message body.</FONT><BR>"
 
 				dat+="<BR><A href='?src=\ref[src];setScreen=[3]'>Return</A><BR>"
 			if(7)
@@ -272,18 +272,18 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					else
 						existing_authors += FC.author
 				if(src.scanned_user in existing_authors)
-					dat+="<FONT COLOR='maroon'>•There already exists a Feed channel under your name.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½There already exists a Feed channel under your name.</FONT><BR>"
 				if(src.channel_name=="" || src.channel_name == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>•Invalid channel name.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Invalid channel name.</FONT><BR>"
 				var/check = 0
 				for(var/datum/feed_channel/FC in news_network.network_channels)
 					if(FC.channel_name == src.channel_name)
 						check = 1
 						break
 				if(check)
-					dat+="<FONT COLOR='maroon'>•Channel name already in use.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Channel name already in use.</FONT><BR>"
 				if(src.scanned_user=="Unknown")
-					dat+="<FONT COLOR='maroon'>•Channel author unverified.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Channel author unverified.</FONT><BR>"
 				dat+="<BR><A href='?src=\ref[src];setScreen=[2]'>Return</A><BR>"
 			if(8)
 				var/total_num=length(news_network.network_channels)
@@ -394,11 +394,11 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			if(16)
 				dat+="<B><FONT COLOR='maroon'>ERROR: Wanted Issue rejected by Network.</B></FONT><HR><BR>"
 				if(src.channel_name=="" || src.channel_name == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>•Invalid name for person wanted.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Invalid name for person wanted.</FONT><BR>"
 				if(src.scanned_user=="Unknown")
-					dat+="<FONT COLOR='maroon'>•Issue author unverified.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Issue author unverified.</FONT><BR>"
 				if(src.msg == "" || src.msg == "\[REDACTED\]")
-					dat+="<FONT COLOR='maroon'>•Invalid description.</FONT><BR>"
+					dat+="<FONT COLOR='maroon'>ï¿½Invalid description.</FONT><BR>"
 				dat+="<BR><A href='?src=\ref[src];setScreen=[0]'>Return</A><BR>"
 			if(17)
 				dat+="<B>Wanted Issue successfully deleted from Circulation</B><BR>"
@@ -427,7 +427,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="I'm sorry to break your immersion. This shit's bugged. Report this bug to Agouri, polyxenitopalidou@gmail.com"
 
 
-		human_or_robot_user << browse(dat, "window=newscaster_main;size=400x600")
+		var/datum/browser/popup = new(user, "newscaster_main", name, 400, 600)
+		popup.set_content(dat)
+		popup.open()
 		onclose(human_or_robot_user, "newscaster_main")
 
 	/*if(src.isbroken) //debugging shit
@@ -794,7 +796,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		switch(screen)
 			if(0) //Cover
 				dat+="<DIV ALIGN='center'><B><FONT SIZE=6>The Griffon</FONT></B></div>"
-				dat+="<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasen© Space Facilities</FONT></div><HR>"
+				dat+="<DIV ALIGN='center'><FONT SIZE=2>Nanotrasen-standard newspaper, for use on Nanotrasenï¿½ Space Facilities</FONT></div><HR>"
 				if(isemptylist(src.news_content))
 					if(src.important_message)
 						dat+="Contents:<BR><ul><B><FONT COLOR='red'>**</FONT>Important Security Announcement<FONT COLOR='red'>**</FONT></B> <FONT SIZE=2>\[page [src.pages+2]\]</FONT><BR></ul>"

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -61,7 +61,9 @@
 //What number the make points to is in the define # at the top of construction.dm in same folder
 //which for some reason couldn't just be left defined, so it could be used here, top kek
 
-	user << browse("<HEAD><TITLE>[src]</TITLE></HEAD><TT>[dat]</TT>", "window=pipedispenser")
+	var/datum/browser/popup = new(user, "pipedispenser", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "pipedispenser")
 	return
 
@@ -178,7 +180,9 @@ Nah
 <A href='?src=\ref[src];dmake=7'>Chute</A><BR>
 "}
 
-	user << browse("<HEAD><TITLE>[src]</TITLE></HEAD><TT>[dat]</TT>", "window=pipedispenser")
+	var/datum/browser/popup = new(user, "pipedispenser", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	return
 
 // 0=straight, 1=bent, 2=junction-j1, 3=junction-j2, 4=junction-y, 5=trunk

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -63,7 +63,7 @@
 
 	var/datum/browser/popup = new(user, "pipedispenser", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "pipedispenser")
 	return
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -182,7 +182,7 @@
 
 	var/datum/browser/popup = new(user, "suit_storage_unit", name, 400, 500)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "suit_storage_unit")
 	return
 
@@ -840,7 +840,7 @@
 
 	var/datum/browser/popup = new(user, "suit_cycler", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "suit_cycler")
 	return
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -134,10 +134,10 @@
 		return 0
 	if(src.panelopen) //The maintenance panel is open. Time for some shady stuff
 		dat+= "<HEAD><TITLE>Suit storage unit: Maintenance panel</TITLE></HEAD>"
-		dat+= "<Font color ='black'><B>Maintenance panel controls</B></font><HR>"
+		dat+= "<B>Maintenance panel controls</B><HR>"
 		dat+= "<font color ='grey'>The panel is ridden with controls, button and meters, labeled in strange signs and symbols that <BR>you cannot understand. Probably the manufactoring world's language.<BR> Among other things, a few controls catch your eye.<BR><BR>"
-		dat+= text("<font color ='black'>A small dial with a \"ë\" symbol embroidded on it. It's pointing towards a gauge that reads []</font>.<BR> <font color='blue'><A href='?src=\ref[];toggleUV=1'> Turn towards []</A><BR>",(src.issuperUV ? "15nm" : "185nm"),src,(src.issuperUV ? "185nm" : "15nm") )
-		dat+= text("<font color ='black'>A thick old-style button, with 2 grimy LED lights next to it. The [] LED is on.</font><BR><font color ='blue'><A href='?src=\ref[];togglesafeties=1'>Press button</a></font>",(src.safetieson? "<font color='green'><B>GREEN</B></font>" : "<font color='red'><B>RED</B></font>"),src)
+		dat+= text("A small dial with a \"ï¿½\" symbol embroidded on it. It's pointing towards a gauge that reads [].<BR> <font color='blue'><A href='?src=\ref[];toggleUV=1'> Turn towards []</A><BR>",(src.issuperUV ? "15nm" : "185nm"),src,(src.issuperUV ? "185nm" : "15nm") )
+		dat+= text("A thick old-style button, with 2 grimy LED lights next to it. The [] LED is on.<BR><font color ='blue'><A href='?src=\ref[];togglesafeties=1'>Press button</a></font>",(src.safetieson? "<font color='green'><B>GREEN</B></font>" : "<font color='red'><B>RED</B></font>"),src)
 		dat+= text("<HR><BR><A href='?src=\ref[];mach_close=suit_storage_unit'>Close panel</A>", user)
 		//user << browse(dat, "window=ssu_m_panel;size=400x500")
 		//onclose(user, "ssu_m_panel")
@@ -150,26 +150,24 @@
 
 	else
 		if(!src.isbroken)
-			dat+= "<HEAD><TITLE>Suit storage unit</TITLE></HEAD>"
-			dat+= "<font color='blue'><font size = 4><B>U-Stor-It Suit Storage Unit, model DS1900</B></FONT><BR>"
 			dat+= "<B>Welcome to the Unit control panel.</B><HR>"
-			dat+= text("<font color='black'>Helmet storage compartment: <B>[]</B></font><BR>",(src.HELMET ? HELMET.name : "</font><font color ='grey'>No helmet detected.") )
+			dat+= text("Helmet storage compartment: <B>[]</B><BR>",(src.HELMET ? HELMET.name : "</font><font color ='grey'>No helmet detected.") )
 			if(HELMET && src.isopen)
 				dat+=text("<A href='?src=\ref[];dispense_helmet=1'>Dispense helmet</A><BR>",src)
-			dat+= text("<font color='black'>Suit storage compartment: <B>[]</B></font><BR>",(src.SUIT ? SUIT.name : "</font><font color ='grey'>No exosuit detected.") )
+			dat+= text("Suit storage compartment: <B>[]</B><BR>",(src.SUIT ? SUIT.name : "</font><font color ='grey'>No exosuit detected.") )
 			if(SUIT && src.isopen)
 				dat+=text("<A href='?src=\ref[];dispense_suit=1'>Dispense suit</A><BR>",src)
-			dat+= text("<font color='black'>Breathmask storage compartment: <B>[]</B></font><BR>",(src.MASK ? MASK.name : "</font><font color ='grey'>No breathmask detected.") )
+			dat+= text("Breathmask storage compartment: <B>[]</B><BR>",(src.MASK ? MASK.name : "</font><font color ='grey'>No breathmask detected.") )
 			if(MASK && src.isopen)
 				dat+=text("<A href='?src=\ref[];dispense_mask=1'>Dispense mask</A><BR>",src)
 			if(src.OCCUPANT)
 				dat+= "<HR><B><font color ='red'>WARNING: Biological entity detected inside the Unit's storage. Please remove.</B></font><BR>"
 				dat+= "<A href='?src=\ref[src];eject_guy=1'>Eject extra load</A>"
-			dat+= text("<HR><font color='black'>Unit is: [] - <A href='?src=\ref[];toggle_open=1'>[] Unit</A></font> ",(src.isopen ? "Open" : "Closed"),src,(src.isopen ? "Close" : "Open"))
+			dat+= text("<HR>Unit is: [] - <A href='?src=\ref[];toggle_open=1'>[] Unit</A> ",(src.isopen ? "Open" : "Closed"),src,(src.isopen ? "Close" : "Open"))
 			if(src.isopen)
 				dat+="<HR>"
 			else
-				dat+= text(" - <A href='?src=\ref[];toggle_lock=1'><font color ='orange'>*[] Unit*</A></font><HR>",src,(src.islocked ? "Unlock" : "Lock") )
+				dat+= text(" - <A href='?src=\ref[];toggle_lock=1'>*[] Unit*</A><HR>",src,(src.islocked ? "Unlock" : "Lock") )
 			dat+= text("Unit status: []",(src.islocked? "<font color ='red'><B>**LOCKED**</B></font><BR>" : "<font color ='green'><B>**UNLOCKED**</B></font><BR>") )
 			dat+= text("<A href='?src=\ref[];start_UV=1'>Start Disinfection cycle</A><BR>",src)
 			dat += text("<BR><BR><A href='?src=\ref[];mach_close=suit_storage_unit'>Close control panel</A>", user)
@@ -182,7 +180,9 @@
 			//user << browse(dat, "window=suit_storage_unit;size=400x500")
 			//onclose(user, "suit_storage_unit")
 
-	user << browse(dat, "window=suit_storage_unit;size=400x500")
+	var/datum/browser/popup = new(user, "suit_storage_unit", name, 400, 500)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "suit_storage_unit")
 	return
 
@@ -838,7 +838,9 @@
 		dat += "The red light is [safeties ? "blinking" : "off"].<BR>"
 		dat += "The yellow light is [locked ? "on" : "off"].<BR>" */
 
-	user << browse(dat, "window=suit_cycler")
+	var/datum/browser/popup = new(user, "suit_cycler", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "suit_cycler")
 	return
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -316,7 +316,7 @@
 				</table>"}
 	var/datum/browser/popup = new(user, "mecha_fabricator", name, 1000, 490)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "mecha_fabricator")
 	return
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -289,9 +289,8 @@
 			if("parts")
 				left_part += output_parts_list(part_set)
 				left_part += "<hr><a href='?src=\ref[src];screen=main'>Return</a>"
-	dat = {"<html>
-			  <head>
-			  <title>[name]</title>
+	dat = {"
+			<title>[name]</title>
 				<style>
 				.res_name {font-weight: bold; text-transform: capitalize;}
 				.red {color: #f00;}
@@ -305,21 +304,19 @@
 				<script language='javascript' type='text/javascript'>
 				[js_byjax]
 				</script>
-				</head><body>
-				<body>
 				<table style='width: 100%;'>
 				<tr>
 				<td style='width: 65%; padding-right: 10px;'>
 				[left_part]
 				</td>
-				<td style='width: 35%; background: #ccc;' id='queue'>
+				<td style='width: 35%; background: #000;' id='queue'>
 				[list_queue()]
 				</td>
 				<tr>
-				</table>
-				</body>
-				</html>"}
-	user << browse(dat, "window=mecha_fabricator;size=1000x490")
+				</table>"}
+	var/datum/browser/popup = new(user, "mecha_fabricator", name, 1000, 490)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "mecha_fabricator")
 	return
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -44,7 +44,7 @@
 	if (recipes_sublist && recipe_list[recipes_sublist] && istype(recipe_list[recipes_sublist], /datum/stack_recipe_list))
 		var/datum/stack_recipe_list/srl = recipe_list[recipes_sublist]
 		recipe_list = srl.recipes
-	var/t1 = text("<HTML><HEAD><title>Constructions from []</title></HEAD><body><TT>Amount Left: []<br>", src, src.amount)
+	var/t1 = "Amount Left: [amount]<br>"
 	for(var/i=1;i<=recipe_list.len,i++)
 		var/E = recipe_list[i]
 		if (isnull(E))
@@ -93,8 +93,9 @@
 				if (!(max_multiplier in multipliers))
 					t1 += " <A href='?src=\ref[src];make=[i];multiplier=[max_multiplier]'>[max_multiplier*R.res_amount]x</A>"
 
-	t1 += "</TT></body></HTML>"
-	user << browse(t1, "window=stack")
+	var/datum/browser/popup = new(user, "stack", name, 400, 400)
+	popup.set_content(t1)
+	popup.open()
 	onclose(user, "stack")
 	return
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -95,7 +95,7 @@
 
 	var/datum/browser/popup = new(user, "stack", name, 400, 400)
 	popup.set_content(t1)
-	popup.open()
+	popup.open(0)
 	onclose(user, "stack")
 	return
 

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -76,7 +76,9 @@
 	var/dat = text("<TT><B>Health Sensor</B> <A href='?src=\ref[src];scanning=1'>[scanning?"On":"Off"]</A>")
 	if(scanning && health_scan)
 		dat += "<BR>Health: [health_scan]"
-	user << browse(dat, "window=hscan")
+	var/datum/browser/popup = new(user, "hscan", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "hscan")
 	return
 

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -78,7 +78,7 @@
 		dat += "<BR>Health: [health_scan]"
 	var/datum/browser/popup = new(user, "hscan", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "hscan")
 	return
 

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -141,7 +141,7 @@
 				<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
 	var/datum/browser/popup = new(user, "infra", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "infra")
 
 /obj/item/device/assembly/infra/Topic(href, href_list)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -139,7 +139,9 @@
 				</TT>
 				<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>
 				<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"}
-	user << browse(dat, "window=infra")
+	var/datum/browser/popup = new(user, "infra", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "infra")
 
 /obj/item/device/assembly/infra/Topic(href, href_list)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -116,7 +116,7 @@
 		dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
 		var/datum/browser/popup = new(user, "prox", name, 400, 400)
 		popup.set_content(dat)
-		popup.open()
+		popup.open(0)
 		onclose(user, "prox")
 		return
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -114,7 +114,9 @@
 		dat += "<BR><A href='?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)"
 		dat += "<BR><BR><A href='?src=\ref[src];refresh=1'>Refresh</A>"
 		dat += "<BR><BR><A href='?src=\ref[src];close=1'>Close</A>"
-		user << browse(dat, "window=prox")
+		var/datum/browser/popup = new(user, "prox", name, 400, 400)
+		popup.set_content(dat)
+		popup.open()
 		onclose(user, "prox")
 		return
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -81,7 +81,9 @@
 		[t1]
 		</TT>
 	"}
-	user << browse(dat, "window=radio")
+	var/datum/browser/popup = new(user, "radio", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "radio")
 	return
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -83,7 +83,7 @@
 	"}
 	var/datum/browser/popup = new(user, "radio", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "radio")
 	return
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -96,7 +96,9 @@
 		<A href='?src=\ref[src];refresh=1'>Refresh</A>
 		<BR><BR>
 		<A href='?src=\ref[src];close=1'>Close</A>"}
-		user << browse(dat, "window=timer")
+		var/datum/browser/popup = new(user, "timer", name, 400, 400)
+		popup.set_content(dat)
+		popup.open()
 		onclose(user, "timer")
 		return
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -98,7 +98,7 @@
 		<A href='?src=\ref[src];close=1'>Close</A>"}
 		var/datum/browser/popup = new(user, "timer", name, 400, 400)
 		popup.set_content(dat)
-		popup.open()
+		popup.open(0)
 		onclose(user, "timer")
 		return
 

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -211,7 +211,7 @@ log transactions
 
 		var/datum/browser/popup = new(user, "atm", name, 550, 650)
 		popup.set_content(dat)
-		popup.open()
+		popup.open(0)
 	else
 		user << browse(null,"window=atm")
 

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -209,7 +209,9 @@ log transactions
 			dat += "<span class='warning'>Unable to connect to accounts database, please retry and if the issue persists contact Nanotrasen IT support.</span>"
 			reconnect_database()
 
-		user << browse(dat,"window=atm;size=550x650")
+		var/datum/browser/popup = new(user, "atm", name, 550, 650)
+		popup.set_content(dat)
+		popup.open()
 	else
 		user << browse(null,"window=atm")
 

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -79,7 +79,9 @@
 		dat += text("Bluespace crystals: [amt_bluespace]<br>")
 
 	dat += text("<br><br><A href='?src=\ref[src];removeall=1'>Empty box</A>")
-	user << browse("[dat]", "window=orebox")
+	var/datum/browser/popup = new(user, "orebox", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	return
 
 /obj/structure/ore_box/Topic(href, href_list)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -81,7 +81,7 @@
 	dat += text("<br><br><A href='?src=\ref[src];removeall=1'>Empty box</A>")
 	var/datum/browser/popup = new(user, "orebox", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	return
 
 /obj/structure/ore_box/Topic(href, href_list)

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -62,7 +62,7 @@
 	dat += "</table></center>"
 	var/datum/browser/popup = new(user, "filingcabinet", name, 350, 300)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 
 	return
 

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -60,7 +60,9 @@
 	for(var/obj/item/P in src)
 		dat += "<tr><td><a href='?src=\ref[src];retrieve=\ref[P]'>[P.name]</a></td></tr>"
 	dat += "</table></center>"
-	user << browse("<html><head><title>[name]</title></head><body>[dat]</body></html>", "window=filingcabinet;size=350x300")
+	var/datum/browser/popup = new(user, "filingcabinet", name, 350, 300)
+	popup.set_content(dat)
+	popup.open()
 
 	return
 
@@ -83,7 +85,7 @@
 
 /obj/structure/filingcabinet/Topic(href, href_list)
 	if(href_list["retrieve"])
-		usr << browse("", "window=filingcabinet") // Close the menu
+		usr << browse(null, "window=filingcabinet") // Close the menu
 
 		//var/retrieveindex = text2num(href_list["retrieve"])
 		var/obj/item/P = locate(href_list["retrieve"])//contents[retrieveindex]

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -38,7 +38,7 @@
 		dat +="<BR>Please insert a new toner cartridge!"
 	var/datum/browser/popup = new(user, "copier", name, 400, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "copier")
 	return
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -36,7 +36,9 @@
 	dat += "Current toner level: [toner]"
 	if(!toner)
 		dat +="<BR>Please insert a new toner cartridge!"
-	user << browse(dat, "window=copier")
+	var/datum/browser/popup = new(user, "copier", name, 400, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "copier")
 	return
 

--- a/code/modules/reagents/pandemic.dm
+++ b/code/modules/reagents/pandemic.dm
@@ -267,7 +267,7 @@
 
 	var/datum/browser/popup = new(user, "pandemic", name, 575, 400)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "pandemic")
 	return
 

--- a/code/modules/reagents/pandemic.dm
+++ b/code/modules/reagents/pandemic.dm
@@ -265,7 +265,9 @@
 		dat += "<BR><A href='?src=\ref[src];eject=1'>Eject beaker</A>[((R.total_volume&&R.reagent_list.len) ? "-- <A href='?src=\ref[src];empty_beaker=1'>Empty beaker</A>":"")]<BR>"
 		dat += "<A href='?src=\ref[user];mach_close=pandemic'>Close</A>"
 
-	user << browse("<TITLE>[src.name]</TITLE><BR>[dat]", "window=pandemic;size=575x400")
+	var/datum/browser/popup = new(user, "pandemic", name, 575, 400)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "pandemic")
 	return
 

--- a/code/modules/spacepods/pod_fabricator.dm
+++ b/code/modules/spacepods/pod_fabricator.dm
@@ -319,9 +319,8 @@
 			if("parts")
 				left_part += output_parts_list(part_set)
 				left_part += "<hr><a href='?src=\ref[src];screen=main'>Return</a>"
-	dat = {"<html>
-			  <head>
-			  <title>[name]</title>
+	dat = {"
+			<title>[name]</title>
 				<style>
 				.res_name {font-weight: bold; text-transform: capitalize;}
 				.red {color: #f00;}
@@ -335,21 +334,19 @@
 				<script language='javascript' type='text/javascript'>
 				[js_byjax]
 				</script>
-				</head><body>
-				<body>
 				<table style='width: 100%;'>
 				<tr>
 				<td style='width: 65%; padding-right: 10px;'>
 				[left_part]
 				</td>
-				<td style='width: 35%; background: #ccc;' id='queue'>
+				<td style='width: 35%; background: #000;' id='queue'>
 				[list_queue()]
 				</td>
 				<tr>
-				</table>
-				</body>
-				</html>"}
-	user << browse(dat, "window=mecha_fabricator;size=1000x430")
+				</table>"}
+	var/datum/browser/popup = new(user, "mecha_fabricator", name, 1000, 430)
+	popup.set_content(dat)
+	popup.open()
 	onclose(user, "mecha_fabricator")
 	return
 

--- a/code/modules/spacepods/pod_fabricator.dm
+++ b/code/modules/spacepods/pod_fabricator.dm
@@ -346,7 +346,7 @@
 				</table>"}
 	var/datum/browser/popup = new(user, "mecha_fabricator", name, 1000, 430)
 	popup.set_content(dat)
-	popup.open()
+	popup.open(0)
 	onclose(user, "mecha_fabricator")
 	return
 


### PR DESCRIPTION
![http://i.imgur.com/N3rDG5Z.png](http://i.imgur.com/N3rDG5Z.png)
![http://i.imgur.com/UE1vYnd.png](http://i.imgur.com/UE1vYnd.png)
![http://i.imgur.com/UJkZECw.png](http://i.imgur.com/UJkZECw.png)
![http://i.imgur.com/eyAQTbX.png](http://i.imgur.com/eyAQTbX.png)

Here's the full list:

- Atmos devices
- Area Atmos Computer
- General atmos control
- Holodeck control
- Medical and sec records
- Airlock electronics
- Brig Timers
- Guest Pass
- Kitchen Machinery
- Newscaster
- Pipe Dispenser
- Suit Storage Unit
- Podfab and Mechfab
- Sheet construction
- Assemblies
- ATM
- Ore Box
- Filing Cabinet
- Photocopier
- Virology "pandemic" machine

Also fixes a few instances where people forgot to close an `<a>` tag

:cl: monster860
rscadd: A bunch of interfaces now use /datum/browser.
/:cl: