### PR TITLE
Actually Fixes Those Stupid Plants (By Fixing Alternate Appearances)

### DIFF
--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -30,7 +30,7 @@
 		if(!M.viewing_alternate_appearances)
 			M.viewing_alternate_appearances = list()
 		viewers |= M
-		M.viewing_alternate_appearances += src
+		M.viewing_alternate_appearances |= src
 		if(M.client)
 			M.client.images |= img
 
@@ -43,8 +43,7 @@
 	if(hideFrom)
 		hiding = hideFrom
 
-	for(var/m in hiding)
-		var/mob/M = m
+	for(var/mob/M in hiding)
 		if(M.client)
 			M.client.images -= img
 		if(M.viewing_alternate_appearances && M.viewing_alternate_appearances.len)
@@ -117,8 +116,7 @@
 /atom/proc/remove_alt_appearance(key)
 	if(alternate_appearances)
 		if(alternate_appearances[key])
-			var/datum/alternate_appearance/AA = alternate_appearances[key]
-			qdel(AA)
+			qdel(alternate_appearances[key])
 
 
 /*

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -43,7 +43,8 @@
 	if(hideFrom)
 		hiding = hideFrom
 
-	for(var/mob/M in hiding)
+	for(var/m in hiding)
+		var/mob/M = m
 		if(M.client)
 			M.client.images -= img
 		if(M.viewing_alternate_appearances && M.viewing_alternate_appearances.len)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -14,6 +14,10 @@
 	following_mobs = null
 	if(buckled)
 		buckled.unbuckle_mob()
+	if(viewing_alternate_appearances)
+		for(var/datum/alternate_appearance/AA in viewing_alternate_appearances)
+			AA.viewers -= src
+		viewing_alternate_appearances = null
 	return ..()
 
 /mob/New()


### PR DESCRIPTION
I can't believe I didn't notice this sooner. Alternate appearances store a list of the mobs they're visible to, but when they iterate through that list to hide the alternate appearance from them, they use a nice, fast, typeless for loop, which never bothers to check whether the mob is null before blindly trying to access mob vars on it. This means that, if an alternate appearance gets applied, a mob in the viewer list gets deleted, and then the alternate appearance is deleted, it'll runtime when it gets to the deleted mob, and not remove the alternate appearance from any others that came after it in the list. This is easily reproducible, and solved by ~~simply using a typed for loop~~ actually adding the missing code to make mobs remove themselves from the viewers list of alternate appearances they're viewing.

~~I did *not,* however, put a type in the `display_to` for loop; if someone makes the mistake of passing a non-mob in there, I *want* it to runtime.~~ I also did a couple other minor tweaks.

I'm sorry for making your immaculate alternate appearance code even slower, @RemieRichards. We're just tired of becoming stuck looking like plants forever. If it's any consolation, this is probably what was causing tgstation/tgstation#16860 and tgstation/tgstation#18941.

Oh by the way, fixes #4972.

:cl:
bugfix: Players will ALMOST DEFINITELY never get stuck as plants anymore. I mean it this time!
/:cl: