### PR TITLE
pAIs No Longer valid Gun Turret Targets

### DIFF
--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -512,6 +512,8 @@
 			continue
 		if(faction in M.faction)
 			continue
+		if(ispAI(M))
+			continue
 		pos_targets += M
 	for(var/obj/mecha/M in oview(scan_range, src))
 		if(M.occupant)


### PR DESCRIPTION
Not really sure what to count this as, so I'm just labeling it as a fix.

Gun turrets no longer consider pAIs as valid candidates for targetting.

Why? Turrets can't really hit them and even when they're in their card the turrets attempt to target them, leading to a lot of scenarios whereby the turrets are stuck shooting at a non-optimal target, a lot of the time indefinitely.

:cl: Fox McCloud
fix: pAIs are no longer valid targets for gun turrets (like on the syndicate ship)
/:cl: