### PR TITLE
Adds in Rathen's Secret

### DIFF
--- a/code/datums/spells/rathens.dm
+++ b/code/datums/spells/rathens.dm
@@ -1,0 +1,57 @@
+/obj/effect/proc_holder/spell/aoe_turf/rathens
+	name = "Rathen's Secret"
+	desc = "Summons a powerful shockwave around you that tears the appendix and limbs off of enemies."
+	charge_max = 500
+	clothes_req = 1
+	invocation = "ARSE NATH!"
+	invocation_type = "shout"
+	range = 7
+	cooldown_min = 200
+	selection_type = "view"
+	action_icon_state = "superfart"
+
+/obj/effect/proc_holder/spell/aoe_turf/rathens/cast(list/targets)
+	var/mob/user = usr
+	var/list/impacted_mobs = list()
+	for(var/turf/T in targets)
+		for(var/mob/living/carbon/human/H in T)
+			if(H == user)
+				continue
+			impacted_mobs  += H
+	if(!impacted_mobs.len)
+		to_chat(user, "<span class='danger'>There are no targets in range!</span>")
+		revert_cast()
+		return 0
+	playsound(get_turf(user), 'sound/goonstation/effects/superfart.ogg', 25, 1)
+	for(var/mob/living/carbon/human/H in impacted_mobs)
+		var/datum/effect/system/harmless_smoke_spread/s = new /datum/effect/system/harmless_smoke_spread
+		s.set_up(5, 0, H)
+		s.start()
+		var/obj/item/organ/internal/appendix/A = H.get_int_organ(/obj/item/organ/internal/appendix)
+		if(A)
+			A.remove(H)
+			A.forceMove(get_turf(H))
+			spawn()
+				A.throw_at(get_edge_target_turf(H, pick(alldirs)), rand(1, 10), 5)
+			H.visible_message("<span class='danger'>[H]'s [A.name] flies out their body in a magical explosion!</span>",\
+							  "<span class='danger'>Your [A.name] flies out your body in a magical explosion!</span>")
+			H.Weaken(2)
+		else
+			var/obj/effect/decal/cleanable/blood/gibs/G = new/obj/effect/decal/cleanable/blood/gibs(get_turf(H))
+			spawn()
+				G.throw_at(get_edge_target_turf(H, pick(alldirs)), rand(1, 10), 5)
+			H.apply_damage(10, BRUTE, "chest")
+			to_chat(H, "<span class='userdanger'>You have no [A.name], but something had to give! Holy shit, what was that?</span>")
+			H.Weaken(3)
+			for(var/obj/item/organ/external/E in H.organs)
+				if(istype(E, /obj/item/organ/external/head))
+					continue
+				if(istype(E, /obj/item/organ/external/chest))
+					continue
+				if(istype(E, /obj/item/organ/external/groin))
+					continue
+				if(prob(7))
+					to_chat(H, "<span class='userdanger'>Your [E] was severed by the explosion!</span>")
+					E.droplimb(1, DROPLIMB_EDGE, 0, 1)
+
+

--- a/code/datums/spells/rathens.dm
+++ b/code/datums/spells/rathens.dm
@@ -1,29 +1,19 @@
-/obj/effect/proc_holder/spell/aoe_turf/rathens
+/obj/effect/proc_holder/spell/targeted/rathens
 	name = "Rathen's Secret"
 	desc = "Summons a powerful shockwave around you that tears the appendix and limbs off of enemies."
 	charge_max = 500
 	clothes_req = 1
 	invocation = "ARSE NATH!"
 	invocation_type = "shout"
+	max_targets = 0
 	range = 7
 	cooldown_min = 200
 	selection_type = "view"
 	action_icon_state = "superfart"
 
-/obj/effect/proc_holder/spell/aoe_turf/rathens/cast(list/targets)
-	var/mob/user = usr
-	var/list/impacted_mobs = list()
-	for(var/turf/T in targets)
-		for(var/mob/living/carbon/human/H in T)
-			if(H == user)
-				continue
-			impacted_mobs  += H
-	if(!impacted_mobs.len)
-		to_chat(user, "<span class='danger'>There are no targets in range!</span>")
-		revert_cast()
-		return 0
+/obj/effect/proc_holder/spell/targeted/rathens/cast(list/targets, mob/user = usr)
 	playsound(get_turf(user), 'sound/goonstation/effects/superfart.ogg', 25, 1)
-	for(var/mob/living/carbon/human/H in impacted_mobs)
+	for(var/mob/living/carbon/human/H in targets)
 		var/datum/effect/system/harmless_smoke_spread/s = new /datum/effect/system/harmless_smoke_spread
 		s.set_up(5, 0, H)
 		s.start()
@@ -41,7 +31,7 @@
 			spawn()
 				G.throw_at(get_edge_target_turf(H, pick(alldirs)), rand(1, 10), 5)
 			H.apply_damage(10, BRUTE, "chest")
-			to_chat(H, "<span class='userdanger'>You have no [A.name], but something had to give! Holy shit, what was that?</span>")
+			to_chat(H, "<span class='userdanger'>You have no appendix, but something had to give! Holy shit, what was that?</span>")
 			H.Weaken(3)
 			for(var/obj/item/organ/external/E in H.organs)
 				if(istype(E, /obj/item/organ/external/head))

--- a/code/datums/spells/rathens.dm
+++ b/code/datums/spells/rathens.dm
@@ -33,8 +33,8 @@
 			A.forceMove(get_turf(H))
 			spawn()
 				A.throw_at(get_edge_target_turf(H, pick(alldirs)), rand(1, 10), 5)
-			H.visible_message("<span class='danger'>[H]'s [A.name] flies out their body in a magical explosion!</span>",\
-							  "<span class='danger'>Your [A.name] flies out your body in a magical explosion!</span>")
+			H.visible_message("<span class='danger'>[H]'s [A.name] flies out of their body in a magical explosion!</span>",\
+							  "<span class='danger'>Your [A.name] flies out of your body in a magical explosion!</span>")
 			H.Weaken(2)
 		else
 			var/obj/effect/decal/cleanable/blood/gibs/G = new/obj/effect/decal/cleanable/blood/gibs(get_turf(H))

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -130,6 +130,12 @@
 	log_name = "RP"
 	category = "Defensive"
 
+/datum/spellbook_entry/rathens
+	name = "Rathen's Secret"
+	spell_type = /obj/effect/proc_holder/spell/aoe_turf/rathens
+	log_name = "RS"
+	category = "Defensive"
+
 /datum/spellbook_entry/timestop
 	name = "Time Stop"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -132,7 +132,7 @@
 
 /datum/spellbook_entry/rathens
 	name = "Rathen's Secret"
-	spell_type = /obj/effect/proc_holder/spell/aoe_turf/rathens
+	spell_type = /obj/effect/proc_holder/spell/targeted/rathens
 	log_name = "RS"
 	category = "Defensive"
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -293,6 +293,7 @@
 #include "code\datums\spells\mime.dm"
 #include "code\datums\spells\mind_transfer.dm"
 #include "code\datums\spells\projectile.dm"
+#include "code\datums\spells\rathens.dm"
 #include "code\datums\spells\summonitem.dm"
 #include "code\datums\spells\touch_attacks.dm"
 #include "code\datums\spells\trigger.dm"


### PR DESCRIPTION
Credit to Goon for this one.

Implements Rathen's Secret, aka "Arse Nath".

We obviously don't have a butt organ..sooooo an appendix will have to do instead...

What does this spell do?

It weakens everyone on the screen for 2 cycles and knocks their appendix out of them.

If you don't have your appendix, however, it does 10 brute to the chest, weakens for 3 cycles and rolls a 7% chance for each non-chest/groin/head limb to be dismembered.


Considered a defensive spell similar to magic missile or repulse. Standard spell cost of 2.

:cl: Fox McCloud
add: Adds in Rathen's secret, a new spell for the wizard that AoE stuns
/:cl: