### PR TITLE
Adds Cluwne EvilFax

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1707,7 +1707,7 @@
 		if(!istype(H))
 			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
 			return
-		var/etypes = list("Borgification","Corgification","Death By Fire","Total Brain Death","Honk Tumor","Demotion Notice")
+		var/etypes = list("Borgification","Corgification","Death By Fire","Total Brain Death","Honk Tumor","Cluwne","Demotion Notice")
 		var/eviltype = input(src.owner, "Which type of evil fax do you wish to send [H]?","Its good to be baaaad...", "") as null|anything in etypes
 		if(!(eviltype in etypes))
 			return

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -696,6 +696,11 @@
 					var/obj/item/organ/internal/organ = new /obj/item/organ/internal/honktumor
 					to_chat(target,"<span class='userdanger'>Life seems funnier, somehow.</span>")
 					organ.insert(target)
+			else if(myeffect == "Cluwne")
+				if(istype(target, /mob/living/carbon/human))
+					var/mob/living/carbon/human/H = target
+					to_chat(H, "<span class='userdanger'>You feel surrounded by sadness. Sadness... and HONKS!</span>")
+					H.makeCluwne()
 			else if(myeffect == "Demotion Notice")
 				command_announcement.Announce("[mytarget] is hereby demoted to the rank of Civilian. Process this demotion immediately. Failure to comply with these orders is grounds for termination.","CC Demotion Order")
 			else


### PR DESCRIPTION
By popular request from Jay/Dave, this PR adds a new EvilFax option. Upon reading, it turns the reader into a Cluwne. 

Another alternative in the list of creative ways admins can respond to buttfaxes, other than a simple BSA.