### PR TITLE
Fixes pulse shot cost.

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -139,17 +139,17 @@
 
 /obj/item/weapon/stock_parts/cell/pulse //200 pulse shots
 	name = "pulse rifle power cell"
-	maxcharge = 40000
+	maxcharge = 400000
 	rating = 3
 	chargerate = 1500
 
 /obj/item/weapon/stock_parts/cell/pulse/carbine
 	name = "pulse carbine power cell"
-	maxcharge = 4000
+	maxcharge = 40000
 
 /obj/item/weapon/stock_parts/cell/pulse/pistol
 	name = "pulse pistol power cell"
-	maxcharge = 1600
+	maxcharge = 16000
 
 /obj/item/weapon/stock_parts/cell/ninja
 	name = "spider-clan power cell"

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -35,7 +35,7 @@
 
 /obj/item/ammo_casing/energy/laser/pulse
 	projectile_type = /obj/item/projectile/beam/pulse
-	e_cost = 200
+	e_cost = 2000
 	select_name = "DESTROY"
 	fire_sound = 'sound/weapons/pulse.ogg'
 


### PR DESCRIPTION
Turns out the values made no sense. You could shoot a pulse carbine on DESTROY twenty times, while on KILL you'd only get four shots.

This is now changed to the same values /tg/ uses.