### PR TITLE
AI Integrity Restorer EMP Rework

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -11,6 +11,16 @@
 	light_color = LIGHT_COLOR_PURPLE
 
 /obj/machinery/computer/aifixer/attackby(I as obj, user as mob, params)
+	if(occupant && istype(I, /obj/item/weapon/screwdriver))
+		if(stat & BROKEN)
+			..()
+		if(stat & NOPOWER)
+			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge.</span>")
+			return
+		else
+			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge and it emits a warning beep!.</span>")
+			return
+	else
 		..()
 
 /obj/machinery/computer/aifixer/attack_ai(var/mob/user as mob)

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -16,10 +16,8 @@
 			..()
 		if(stat & NOPOWER)
 			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge.</span>")
-			return
 		else
 			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge and it emits a warning beep!.</span>")
-			return
 	else
 		..()
 
@@ -138,6 +136,13 @@
 			to_chat(user, "<span class='boldannounce'>ERROR</span>: Reconstruction in progress.")
 		else if(!occupant)
 			to_chat(user, "<span class='boldannounce'>ERROR</span>: Unable to locate artificial intelligence.")
+
+/obj/machinery/computer/aifixer/Destroy()
+	if(occupant)
+		occupant.ghostize()
+		qdel(occupant)
+		occupant = null
+	return ..()
 
 /obj/machinery/computer/aifixer/emp_act()
 	if(occupant)

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -7,17 +7,11 @@
 	req_access = list(access_captain, access_robotics, access_heads)
 	var/mob/living/silicon/ai/occupant = null
 	var/active = 0
+	var/restoring = 0
 
 	light_color = LIGHT_COLOR_PURPLE
 
 /obj/machinery/computer/aifixer/attackby(I as obj, user as mob, params)
-	if(occupant && istype(I, /obj/item/weapon/screwdriver))
-		if(stat & (NOPOWER|BROKEN))
-			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge.</span>")
-		else
-			to_chat(user, "<span class='warning'>The screws on [name]'s screen won't budge and it emits a warning beep.</span>")
-		return
-	else
 		..()
 
 /obj/machinery/computer/aifixer/attack_ai(var/mob/user as mob)
@@ -62,7 +56,8 @@
 
 	if(href_list["fix"])
 		src.active = 1
-		while(src.occupant.health < 100)
+		restoring = 1
+		while(src.occupant.health < 100 && restoring)
 			src.occupant.adjustOxyLoss(-1)
 			src.occupant.adjustFireLoss(-1)
 			src.occupant.adjustToxLoss(-1)
@@ -74,6 +69,7 @@
 				dead_mob_list -= src.occupant
 				living_mob_list += src.occupant
 			sleep(10)
+		restoring = 0
 		src.active = 0
 		src.add_fingerprint(usr)
 
@@ -135,3 +131,10 @@
 			to_chat(user, "<span class='boldannounce'>ERROR</span>: Reconstruction in progress.")
 		else if(!occupant)
 			to_chat(user, "<span class='boldannounce'>ERROR</span>: Unable to locate artificial intelligence.")
+
+/obj/machinery/computer/aifixer/emp_act()
+	if(occupant)
+		restoring = 0
+		occupant.adjustBruteLoss(200)
+		return
+	..()

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -134,6 +134,5 @@
 		occupant.ghostize()
 		qdel(occupant)
 		occupant = null
-		return
 	else
 		..()

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -7,7 +7,6 @@
 	req_access = list(access_captain, access_robotics, access_heads)
 	var/mob/living/silicon/ai/occupant = null
 	var/active = 0
-	var/restoring = 0
 
 	light_color = LIGHT_COLOR_PURPLE
 
@@ -56,8 +55,7 @@
 
 	if(href_list["fix"])
 		src.active = 1
-		restoring = 1
-		while(src.occupant.health < 100 && restoring)
+		while(src.occupant.health < 100)
 			src.occupant.adjustOxyLoss(-1)
 			src.occupant.adjustFireLoss(-1)
 			src.occupant.adjustToxLoss(-1)
@@ -69,7 +67,6 @@
 				dead_mob_list -= src.occupant
 				living_mob_list += src.occupant
 			sleep(10)
-		restoring = 0
 		src.active = 0
 		src.add_fingerprint(usr)
 
@@ -134,7 +131,9 @@
 
 /obj/machinery/computer/aifixer/emp_act()
 	if(occupant)
-		restoring = 0
-		occupant.adjustBruteLoss(200)
+		occupant.ghostize()
+		qdel(occupant)
+		occupant = null
 		return
-	..()
+	else
+		..()


### PR DESCRIPTION
Fixes #4982

- Budget cuts have led to hardware downgrading, causing EMPs to destroy any AI stored inside an AI Integrity Restorer;

- AI Integrity Restorers that are broken via explosions can be deconstructed. This, of course, kills the AI

:cl:
tweak: AI Integrity Restorers now destroy any AIs inside if they get EMP'd
tweak: AI Integrity Restorers can be deconstructed if broken via explosions. This kills the AI inside
/:cl: