### PR TITLE
IPC Stethoscoping Fix

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -102,6 +102,9 @@
 	item_color = "stethoscope"
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
+	if(istype(M, /mob/living/carbon/human/machine))
+		user.visible_message("Somehow, you feel like doing this is pointless.")
+		return
 	if(ishuman(M) && isliving(user))
 		if(user.a_intent == I_HELP)
 			var/body_part = parse_zone(user.zone_sel.selecting)


### PR DESCRIPTION
Fixes #4051

- Stethoscopes can no longer detect magical, non-existing hearts and lungs in IPC personnel

:cl:
tweak: Stethoscoping IPCs no longer provides a heartbeat/breathing message
/:cl: