### PR TITLE
Makes Vampire preference appear on Traitor panel

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -268,6 +268,10 @@
 		else
 			text += "<a href='?src=\ref[src];vampire=vampire'>yes</a>|<b>NO</b>"
 
+		if(current && current.client && (ROLE_VAMPIRE in current.client.prefs.be_special))
+			text += "</b></i>|Enabled in Prefs<i><b>"
+		else
+			text += "</b></i>|Disabled in Prefs<i><b>"
 		/** Enthralled ***/
 		text += "<br><b>enthralled</b>"
 		text = "<i><b>[text]</b></i>: "


### PR DESCRIPTION

This PR makes the Vampire preference appear on Traitor Panel for admins.
It appears in exactly the same format as all other antag role preferences.

This PR is aimed at making it easier for admins to replace vamps who cryo/etc, because we can now tell if someone wants to be a vamp or not.