### PR TITLE
Actually Fixes Medical, Security, and Employment Records

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1844,10 +1844,9 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	character.name = character.real_name
 
 	character.flavor_text = flavor_text
-	if(character.ckey && !jobban_isbanned(character, "Records"))
-		character.med_record = med_record
-		character.sec_record = sec_record
-		character.gen_record = gen_record
+	character.med_record = med_record
+	character.sec_record = sec_record
+	character.gen_record = gen_record
 
 	character.change_gender(gender)
 	character.age = age


### PR DESCRIPTION
This *should* resolve the underlying problem with medical/sec/employment records not being displayed.

Not only are the records stored on the client's prefs datum its's also stored on the mob itself--that said, due to the way character creation is handled, the mob won't have a ckey yet, therefore the records never gets properly copied to the mob.

Also, records job-ban sounds like the most hilarious thing ever.

Mandatory picture:

![img](https://i.gyazo.com/1ef269d8d00836a83880b70db77e0ef4.png)

:cl: Fox McCloud
fix: Fixes medical, security, and employment records not being displayed
/:cl:

