### PR TITLE
Stethoscope fixes and additions

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -107,21 +107,26 @@
 			var/body_part = parse_zone(user.zone_sel.selecting)
 			if(body_part)
 				var/their = "their"
-				switch(M.gender)
-					if(MALE)	their = "his"
-					if(FEMALE)	their = "her"
+				if(user == M)
+					their = "your"
+				else
+					switch(M.gender)
+						if(MALE)	their = "his"
+						if(FEMALE)	their = "her"
 
 				var/sound = "pulse"
 				var/sound_strength
 
-				if(M.stat == DEAD || (M.status_flags&FAKEDEATH))
+				if(M.stat == DEAD || (M.status_flags&FAKEDEATH) || (!M.get_int_organ(/obj/item/organ/internal/heart) && !M.get_int_organ(/obj/item/organ/internal/lungs)))
 					sound_strength = "cannot hear"
 					sound = "anything"
 				else
 					sound_strength = "hear a weak"
 					switch(body_part)
 						if("chest")
-							if(M.oxyloss < 50)
+							if(M.heart_attack)
+								sound_strength = "hear an irregular"
+							else if(M.oxyloss < 50)
 								sound_strength = "hear a healthy"
 							sound = "pulse and respiration"
 						if("eyes","mouth")
@@ -130,7 +135,7 @@
 						else
 							sound_strength = "hear a weak"
 
-				user.visible_message("[user] places [src] against [M]'s [body_part] and listens attentively.", "You place [src] against [their] [body_part]. You [sound_strength] [sound].")
+				user.visible_message("[user] places \the [src] against [M]'s [body_part] and listens attentively.", "You place \the [src] against [their] [body_part]. You [sound_strength] [sound].")
 				return
 	return ..(M,user)
 

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -120,20 +120,29 @@
 				if(M.stat == DEAD || (M.status_flags&FAKEDEATH) || (!M.get_int_organ(/obj/item/organ/internal/heart) && !M.get_int_organ(/obj/item/organ/internal/lungs)))
 					sound_strength = "cannot hear"
 					sound = "anything"
-				else
+				else if(M.get_int_organ(/obj/item/organ/internal/heart))
+					if(M.get_int_organ(/obj/item/organ/internal/lungs))
+						sound = addtext(sound, "and respiration")
+					else
+						sound = addtext(sound, "but no respiration")
 					sound_strength = "hear a weak"
 					switch(body_part)
 						if("chest")
 							if(M.heart_attack)
 								sound_strength = "hear an irregular"
-							else if(M.oxyloss < 50)
+							else if(M.oxyloss < 20)
 								sound_strength = "hear a healthy"
-							sound = "pulse and respiration"
 						if("eyes","mouth")
 							sound_strength = "cannot hear"
 							sound = "anything"
 						else
 							sound_strength = "hear a weak"
+				else
+					if(M.oxyloss < 20)
+						sound_strength = "hear healthy"
+					else
+						sound_strength = "hear weak"
+					sound = "respiration, but no pulse"
 
 				user.visible_message("[user] places \the [src] against [M]'s [body_part] and listens attentively.", "You place \the [src] against [their] [body_part]. You [sound_strength] [sound].")
 				return

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -103,65 +103,45 @@
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/carbon/human/M, mob/living/user)
 	if(ishuman(M) && isliving(user))
-		if(user.a_intent == I_HELP)
-			var/their = "their"
-			var/target
-			if(user == M)
-				their = "your"
-				target = "their"
-			else
-				switch(M.gender)
-					if(MALE)	their = "his"
-					if(FEMALE)	their = "her"
-				target = M
-
-			var/heart_sound = "cannot"
-			var/lung_sound = "anything"
-			var/and = " and "
-
-			if(!(M.stat == DEAD) && !(M.status_flags&FAKEDEATH) && (M.get_int_organ(/obj/item/organ/internal/heart) || M.get_int_organ(/obj/item/organ/internal/lungs)))
-				if(M.get_int_organ(/obj/item/organ/internal/heart))
-					var/obj/item/organ/internal/H = M.get_int_organ(/obj/item/organ/internal/heart)
-					switch(H.damage)
-						if(0)
-							heart_sound = "hear a healthy pulse"
-						if(1 to 25)
-							heart_sound = "hear an offbeat pulse"
-						if(26 to 50)
-							heart_sound = "hear an uneven pulse"
-						if(50 to INFINITY)
-							heart_sound = "hear a weak, unhealthy pulse"
-				else
-					and = " but hear "
-					heart_sound = "cannot hear a pulse"
-				if(NO_BREATH in M.mutations || M.species.flags & NO_BREATH)
-					and = " but "
-					lung_sound = "cannot hear any respiration"
-				else
-					if(M.get_int_organ(/obj/item/organ/internal/lungs))
-						var/obj/item/organ/internal/L = M.get_int_organ(/obj/item/organ/internal/lungs)
-						if((M.oxyloss > 50) && L.damage < 26)
-							lung_sound = "labored respiration"
-						else
-							switch(L.damage)
-								if(0)
-									if(heart_sound == "hear a healthy pulse")
-										lung_sound = "respiration"
-									else
-										lung_sound = "healthy respiration"
-								if(1 to 25)
-									lung_sound = "labored respiration"
-								if(26 to 50)
-									lung_sound = "pained respiration"
-								if(51 to INFINITY)
-									lung_sound = "gurgling"
-					else
-						and = " but "
-						lung_sound = "cannot hear any respiration"
-			else
-				and = " hear "
-			user.visible_message("[user] places \the [src] against [target]'s chest and listens attentively.", "You place \the [src] against [their] chest. You [heart_sound][and][lung_sound].")
-			return
+		if(user == M)
+			user.visible_message("[user] places \the [src] against \his chest and listens attentively.", "You place \the [src] against your chest...")
+		else
+			user.visible_message("[user] places \the [src] against [M]'s chest and listens attentively.", "You place \the [src] against [M]'s chest...")
+		var/obj/item/organ/internal/H = M.get_int_organ(/obj/item/organ/internal/heart)
+		var/obj/item/organ/internal/L = M.get_int_organ(/obj/item/organ/internal/lungs)
+		if((H && M.pulse) || (L && !(NO_BREATH in M.mutations) && !(M.species.flags & NO_BREATH)))
+			var/color = "notice"
+			if(H)
+				var/heart_sound
+				switch(H.damage)
+					if(0 to 1)
+						heart_sound = "healthy"
+					if(1 to 25)
+						heart_sound = "offbeat"
+					if(25 to 50)
+						heart_sound = "uneven"
+						color = "warning"
+					if(50 to INFINITY)
+						heart_sound = "weak, unhealthy"
+						color = "warning"
+				to_chat(user, "<span class='[color]'>You hear \an [heart_sound] pulse.</span>")
+			if(L)
+				var/lung_sound
+				switch(L.damage)
+					if(0 to 1)
+						lung_sound = "healthy respiration"
+					if(1 to 25)
+						lung_sound = "labored respiration"
+					if(25 to 50)
+						lung_sound = "pained respiration"
+						color = "warning"
+					if(50 to INFINITY)
+						lung_sound = "gurgling"
+						color = "warning"
+				to_chat(user, "<span class='[color]'>You hear [lung_sound].</span>")
+		else
+			to_chat(user, "<span class='warning'>You don't hear anything.</span>")
+		return
 	return ..(M,user)
 
 


### PR DESCRIPTION
Now with less :snowflake:. At least, the species :snowflake: kind.
Fixes #4051
- Stethoscopes now check for a heart and lungs, and display a different message depending on damage to the organs, whether the organs exist at all, and oxyloss.
- You won't hear anything if the target doesn't have a heart or lungs, and you won't hear any respiration if the target has the no breathing power or is a member of a species that doesn't breathe.
- Using the stethoscope on yourself will display a message that uses 'your' instead of 'his' or 'her' to you and 'their' instead of repeating your name to nearby people.
- The messages displayed will properly use 'the'. ("[user] places the stethoscope" instead of "[user] places stethoscope")
- Which body part is targeted no longer matters.
I don't know why I'm bothering with this, no one uses stethoscopes for a
good reason.

:cl: LittleBigKid2000 and TullyBBurnalot
add: Stethoscopes can now be used to tell if a person's heart or lungs are damaged, or if they have any at all. Now they're actually useful instead of telling you the obvious in a vague way.
fix: Stethoscopes can no longer be used to hear the heartbeat and breathing of a person that doesn't have a heart or lungs.
/:cl: