### PR TITLE
Cigpacks Examine Fix

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -192,7 +192,6 @@
 
 /obj/item/weapon/storage/fancy/cigarettes/update_icon()
 	icon_state = "[initial(icon_state)][contents.len]"
-	desc = "There are [contents.len] cig\s left!"
 	return
 
 /obj/item/weapon/storage/fancy/cigarettes/proc/lace_cigarette(var/obj/item/clothing/mask/cigarette/C as obj)


### PR DESCRIPTION
Fixes #5033
Uh huh.

:cl: Chakirski
tweak: Cigarette packs no longer show near-duplicate messages when examined.
/:cl: