### PR TITLE
Improves Logging of Caught Runtimes

### DIFF
--- a/code/controllers/ProcessScheduler/core/process.dm
+++ b/code/controllers/ProcessScheduler/core/process.dm
@@ -327,9 +327,7 @@
 
 /datum/controller/process/proc/catchException(var/exception/e, var/thrower)
 	if(istype(e)) // Real runtimes go to the real error handler
-		// There are two newlines here, because handling desc sucks
-		e.desc = "  Caught by process: [name]\n\n" + e.desc
-		world.Error(e, e_src = thrower)
+		log_runtime(e, thrower, "Caught by process: [name]")
 		return
 	var/etext = "[e]"
 	var/eid = "[e]" // Exception ID, for tracking repeated exceptions

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -18,9 +18,8 @@
 	var/log_adminwarn = 0				// log warnings admins get about bomb construction and such
 	var/log_pda = 0						// log pda messages
 	var/log_world_output = 0			// log world.log << messages
-	var/log_runtimes = 0                // Logs all runtimes.
+	var/log_runtimes = 0                // logs world.log to a file
 	var/log_hrefs = 0					// logs all links clicked in-game. Could be used for debugging and tracking down exploits
-	var/log_runtime = 0					// logs world.log to a file
 	var/sql_enabled = 0					// for sql switching
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
 	var/allow_vote_restart = 0 			// allow votes to restart
@@ -288,7 +287,7 @@
 					config.log_hrefs = 1
 
 				if("log_runtime")
-					config.log_runtime = 1
+					config.log_runtimes = 1
 
 				if("mentors")
 					config.mods_are_mentors = 1

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -102,3 +102,17 @@ var/total_runtimes_skipped = 0
 		error_cache.logError(e, desclines, e_src = e_src)
 
 #endif
+
+/proc/log_runtime(exception/e, datum/e_src, extra_info)
+	if(!istype(e))
+		world.Error(e, e_src)
+		return
+
+	if(extra_info)
+		// Adding extra info adds two newlines, because parsing runtimes is funky
+		if(islist(extra_info))
+			e.desc = "  [jointext(extra_info, "\n  ")]\n\n" + e.desc
+		else
+			e.desc = "  [extra_info]\n\n" + e.desc
+
+	world.Error(e, e_src)

--- a/code/modules/garbage_collection/garbage_collector.dm
+++ b/code/modules/garbage_collection/garbage_collector.dm
@@ -109,7 +109,7 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 			hint = D.Destroy()
 		catch(var/exception/e)
 			if(istype(e))
-				gcwarning("qdel() caught runtime destroying [D.type]: [e] in [e.file], line [e.line]")
+				log_runtime(e, D, "Caught by qdel() destroying [D.type]")
 			else
 				gcwarning("qdel() caught runtime destroying [D.type]: [e]")
 			// Destroy runtimed? Panic! Hard delete!
@@ -169,7 +169,7 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 			Destroy()
 		catch(var/exception/e)
 			if(istype(e))
-				gcwarning("Del() caught runtime destroying [type]: [e] in [e.file], line [e.line]")
+				log_runtime(e, src, "Caught by Del() destroying [type]")
 			else
 				gcwarning("Del() caught runtime destroying [type]: [e]")
 		if(del_profiling)

--- a/code/modules/mob/living/carbon/human/interactive/functions.dm
+++ b/code/modules/mob/living/carbon/human/interactive/functions.dm
@@ -648,7 +648,7 @@
 			newSnack.name = "Synthetic [newSnack.name]"
 			custom_emote(2, "[pick("gibbers","drools","slobbers","claps wildly","spits")] as they vomit [newSnack] from their mouth!")
 	catch(var/exception/e)
-		log_to_dd("Cooking error: [e] in [e.file]:[e.line]")
+		log_runtime(e, src, "Caught in SNPC cooking module")
 	doing &= ~SNPC_SPECIAL
 // END COOKING MODULE
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -41,9 +41,6 @@ var/global/datum/global_init/init = new ()
 
 	timezoneOffset = text2num(time2text(0,"hh")) * 36000
 
-	if(config && config.log_runtime)
-		log = file("data/logs/runtime/[time2text(world.realtime,"YYYY-MM-DD-(hh-mm-ss)")]-runtime.log")
-
 	callHook("startup")
 
 	src.update_status()


### PR DESCRIPTION
This adds proper error handling to runtimes that occur during object deletion or SNPC cooking (which has a try/catch for some reason). For convenience, the logging of caught exceptions has been moved into a new `log_runtime` proc, including an argument for adding one or more extra lines of info to the output.

Our configuration datum had `log_runtime` and `log_runtimes` as two flags that did literally the same thing, but `log_runtime` was the only one set. I went ahead and refactored out `log_runtime` so its name won't conflict with the new proc.