### PR TITLE
Fixes the surgeon borg sprite being impossible to select.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -315,7 +315,7 @@ var/list/robot_verbs_default = list(
 			if(camera && "Robots" in camera.network)
 				camera.network.Add("Medical")
 			module_sprites["Basic"] = "Medbot"
-			module_sprites["Standard"] = "surgeon"
+			module_sprites["Surgeon"] = "surgeon"
 			module_sprites["Advanced Droid"] = "droid-medical"
 			module_sprites["Needles"] = "medicalrobot"
 			module_sprites["Standard"] = "robotMedi"


### PR DESCRIPTION
When the standard cyborg sprites were added by @Ar3nn in PR https://github.com/ParadiseSS13/Paradise/pull/4449, they didn't remember to give the mediborg's "standard" cyborg model (the surgeon icon sprite) a new name (A pretty easy thing to miss). Thus, the surgeon sprite could not be selected, and @Alex6511 shed many tears.
This fixes that.
:cl: 
fix: It's once again possible to select the surgeon mediborg sprite. Glory to Synthetica.
/:cl: