### PR TITLE
Prevents objectives targeting clientless mobs

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -31,7 +31,7 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 	proc/find_target()
 		var/list/possible_targets = list()
 		for(var/datum/mind/possible_target in ticker.minds)
-			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != DEAD))
+			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && possible_target.current.client)
 				possible_targets += possible_target
 		if(possible_targets.len > 0)
 			target = pick(possible_targets)
@@ -39,7 +39,7 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 	proc/find_target_by_role(role, role_type=0)//Option sets either to check assigned role or special role. Default to assigned.
 		var/list/possible_targets = list()
 		for(var/datum/mind/possible_target in ticker.minds)
-			if((possible_target != owner) && ishuman(possible_target.current) && ((role_type ? possible_target.special_role : possible_target.assigned_role) == role) && (possible_target.current.stat != DEAD) )
+			if((possible_target != owner) && ishuman(possible_target.current) && ((role_type ? possible_target.special_role : possible_target.assigned_role) == role) && (possible_target.current.stat != DEAD) && possible_target.current.client)
 				possible_targets += possible_target
 		if(possible_targets.len > 0)
 			target = pick(possible_targets)
@@ -48,7 +48,7 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 	proc/find_target_with_special_role(role)
 		var/list/possible_targets = list()
 		for(var/datum/mind/possible_target in ticker.minds)
-			if((possible_target != owner) && ishuman(possible_target.current) && (role && possible_target.special_role == role || !role && possible_target.special_role) && (possible_target.current.stat != DEAD) )
+			if((possible_target != owner) && ishuman(possible_target.current) && (role && possible_target.special_role == role || !role && possible_target.special_role) && (possible_target.current.stat != DEAD) && possible_target.current.client)
 				possible_targets += possible_target
 		if(possible_targets.len > 0)
 			target = pick(possible_targets)
@@ -376,7 +376,7 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 	find_target()
 		var/list/possible_targets = list() //Copypasta because NO_SCAN races, yay for snowflakes.
 		for(var/datum/mind/possible_target in ticker.minds)
-			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != DEAD))
+			if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && possible_target.current.client)
 				var/mob/living/carbon/human/H = possible_target.current
 				if(!(H.species.flags & NO_SCAN))
 					possible_targets += possible_target


### PR DESCRIPTION
Fixes bug where clientless mobs can sometimes be made into objective targets.

This happens most often with hotel gateway mission NPCs, but could happen with other mobs.

:cl:
fix: Prevented NPCs being made into objective targets.
/:cl: