### PR TITLE
Fixes Admin Log Runtime

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -9,7 +9,7 @@ var/global/nologevent = 0
 	log_adminwarn(msg)
 	for(var/client/C in admins)
 		if(R_ADMIN & C.holder.rights)
-			if(!(C.prefs.toggles & CHAT_NO_ADMINLOGS))
+			if(C.prefs && !(C.prefs.toggles & CHAT_NO_ADMINLOGS))
 				to_chat(C, msg)
 
 /proc/msg_admin_attack(var/text) //Toggleable Attack Messages


### PR DESCRIPTION
Turns out `message_admins` gets used for certain warnings that may occur during preferences datum creation, which means it can get called while an admin's prefs var is null and unusable, leading to runtimes. Thanks for catching this, @Fox-McCloud.