### PR TITLE
Makes Wizards get only a special "fuck their shit up" objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -846,3 +846,9 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 			target_amount = 6
 			itemname = "six flashes"
 	explanation_text = "We are running low on spare parts. Trade for [itemname]."
+
+//wizard
+
+/datum/objective/wizchaos
+	explanation_text = "Wreak havoc upon the station as much you can. Send those wandless Nanotrasen scum a message!"
+	completed = 1

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -67,59 +67,10 @@
 	set_antag_hud(wiz_mind.current, null)
 
 /datum/game_mode/proc/forge_wizard_objectives(var/datum/mind/wizard)
-	switch(rand(1,100))
-		if(1 to 30)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = wizard
-			kill_objective.find_target()
-			wizard.objectives += kill_objective
-
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = wizard
-			steal_objective.find_target()
-			wizard.objectives += steal_objective
-
-			if(!(locate(/datum/objective/escape) in wizard.objectives))
-				var/datum/objective/escape/escape_objective = new
-				escape_objective.owner = wizard
-				wizard.objectives += escape_objective
-		if(31 to 60)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = wizard
-			kill_objective.find_target()
-			wizard.objectives += kill_objective
-
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = wizard
-			steal_objective.find_target()
-			wizard.objectives += steal_objective
-
-			if(!(locate(/datum/objective/survive) in wizard.objectives))
-				var/datum/objective/survive/survive_objective = new
-				survive_objective.owner = wizard
-				wizard.objectives += survive_objective
-
-		if(61 to 85)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = wizard
-			kill_objective.find_target()
-			wizard.objectives += kill_objective
-
-			if(!(locate(/datum/objective/hijack) in wizard.objectives))
-				var/datum/objective/hijack/hijack_objective = new
-				hijack_objective.owner = wizard
-				wizard.objectives += hijack_objective
-
-		else
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = wizard
-			steal_objective.find_target()
-			wizard.objectives += steal_objective
-
-			if(!(locate(/datum/objective/hijack) in wizard.objectives))
-				var/datum/objective/hijack/hijack_objective = new
-				hijack_objective.owner = wizard
-				wizard.objectives += hijack_objective
+	if(!(locate(/datum/objective/hijack) in wizard.objectives))
+		var/datum/objective/hijack/hijack_objective = new
+		hijack_objective.owner = wizard
+		wizard.objectives += hijack_objective
 	return
 
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -67,10 +67,9 @@
 	set_antag_hud(wiz_mind.current, null)
 
 /datum/game_mode/proc/forge_wizard_objectives(var/datum/mind/wizard)
-	if(!(locate(/datum/objective/hijack) in wizard.objectives))
-		var/datum/objective/hijack/hijack_objective = new
-		hijack_objective.owner = wizard
-		wizard.objectives += hijack_objective
+	var/datum/objective/wizchaos/wiz_objective = new
+	wiz_objective.owner = wizard
+	wizard.objectives += wiz_objective
 	return
 
 


### PR DESCRIPTION
I personally don't enjoy the slow snail Wizard rounds when he gets far too many tools to go ape.

This should fix it, by preventing wizards from being all sneaky beaky and effectively turning a 1 vs Station round into a slow traitor round with some spells.

![img](http://i.imgur.com/VBuEWbs.png)
If the wizard dies - he fails, if he survives till round end - he succeeds.

Objective cannot be failed, is pretty open-ended, so Wizards can now go about causing chaos however they like, but no longer have an obligation to be sneaky to steal a gun or escape alive on the shuttle.