### PR TITLE
Abductor linkings work now

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
@@ -14,6 +14,10 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "camera"
 
+/obj/machinery/computer/camera_advanced/abductor/New()
+	abductor_equipment.Add(src)
+	..()
+
 /obj/machinery/computer/camera_advanced/abductor/CreateEye()
 	..()
 	eyeobj.visible_icon = 1

--- a/code/game/gamemodes/miniantags/abduction/machinery/console.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/console.dm
@@ -167,17 +167,17 @@
 
 /obj/machinery/abductor/console/proc/Link_Abduction_Equipment() // these must all be explicitly `in machines` or they will not properly link.
 
-	for(var/obj/machinery/abductor/pad/p in machines)
+	for(var/obj/machinery/abductor/pad/p in abductor_equipment)
 		if(p.team == team)
 			pad = p
 			break
 
-	for(var/obj/machinery/abductor/experiment/e in machines)
+	for(var/obj/machinery/abductor/experiment/e in abductor_equipment)
 		if(e.team == team)
 			experiment = e
 			e.console = src
 
-	for(var/obj/machinery/computer/camera_advanced/abductor/c in machines)
+	for(var/obj/machinery/computer/camera_advanced/abductor/c in abductor_equipment)
 		if(c.team == team)
 			camera = c
 			c.console = src


### PR DESCRIPTION
Fixes #5096 
:cl:Crazylemon
fix: Abductors consoles link correctly again
/:cl: