### PR TITLE
Fixes Doubled Sounds When Attacking Simple Animals

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -15,13 +15,8 @@
 
 /mob/living/attackby(obj/item/I, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
-	if(stat == DEAD && !isnull(butcher_results)) //can we butcher it?
-		if(istype(I, /obj/item/weapon/kitchen/knife))
-			to_chat(user, "<span class='notice'>You begin to butcher [src]...</span>")
-			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
-			if(do_mob(user, src, 80))
-				harvest(user)
-			return
+	if(attempt_harvest(I, user))
+		return
 	I.attack(src, user)
 
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -837,6 +837,15 @@
 /mob/living/proc/get_permeability_protection()
 	return 0
 
+/mob/living/proc/attempt_harvest(obj/item/I, mob/user)
+	if(stat == DEAD && !isnull(butcher_results)) //can we butcher it?
+		if(istype(I, /obj/item/weapon/kitchen/knife))
+			to_chat(user, "<span class='notice'>You begin to butcher [src]...</span>")
+			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
+			if(do_mob(user, src, 80))
+				harvest(user)
+			return 1
+
 /mob/living/proc/harvest(mob/living/user)
 	if(qdeleted(src))
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -434,6 +434,8 @@
 		return
 	else
 		user.changeNext_move(CLICK_CD_MELEE)
+		if(attempt_harvest(O, user))
+			return
 		user.do_attack_animation(src)
 		if(istype(O) && istype(user) && !O.attack(src, user))
 			var/damage = 0
@@ -451,7 +453,6 @@
 				user.visible_message("<span class='warning'>[user] gently taps [src] with [O].</span>",\
 									"<span class='warning'>This weapon is ineffective, it does no damage.</span>")
 			adjustBruteLoss(damage)
-	..()
 
 
 /mob/living/simple_animal/movement_delay()


### PR DESCRIPTION
Simple animal attack-by code is horrific snowflakery that will almost assuredly break again in the future, but for now, attacking a simple animal should no longer result in doubled sounds and attack logs. And yes, I claimed to have fixed this previously, but it turns out I had only fixed one of the **three** sounds getting played. I'm almost positive there isn't a fourth hiding somewhere.

I had to refactor the check for butchering into its own proc so I could do a special call for simple animals that avoids the second attack call in their `attackby`'s parent.

Also, since I forgot to add a changelog entry in #5057, I've gone ahead and put it in this PR.

:cl:
bugfix: Beating on simple animals will no longer be twice as noisy as intended.
bugfix: Emergency Response Teams are now usable again.
/:cl: