### PR TITLE
Fixes Laptop ID Card Removal

### DIFF
--- a/code/modules/computer3/laptop.dm
+++ b/code/modules/computer3/laptop.dm
@@ -101,14 +101,15 @@
 	var/obj/item/weapon/card/id/card
 	if(C.reader)
 		card = C.reader
+		C.remove_reader(usr)
 	else if(C.writer)
 		card = C.writer
+		C.remove_writer(usr)
 	else
 		to_chat(usr, "There is nothing to remove from the laptop card port.")
 		return
 
 	to_chat(usr, "You remove [card] from the laptop.")
-	C.remove(card)
 
 
 /obj/machinery/computer3/laptop


### PR DESCRIPTION
Fixes a bug with the removal of an ID card from laptops when you use the
Eject ID verb. Now, it will actually remove the ID card, not just say it
did.

:cl: Twinmold
Fix: Fixes removing ID cards from laptops with the Eject ID verb.
/:cl: