### PR TITLE
Fixes Performance Issue with Action buttons, removes redundant verbs

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -281,6 +281,7 @@
 	..()
 
 /datum/action/item_action/toggle_research_scanner/ApplyIcon(obj/screen/movable/action_button/current_button)
+	current_button.overlays.Cut()
 	if(button_icon && button_icon_state)
 		var/image/img = image(button_icon, current_button, "scan_mode")
 		current_button.overlays += img

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -374,6 +374,9 @@ Congratulations! You are now trained for xenobiology research!"}
 
 	to_chat(usr, "<span class='notice'>You switch the baton to [txt] mode.</span>")
 	update_icon()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /obj/item/weapon/abductor_baton/update_icon()
 	switch(mode)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -463,6 +463,9 @@ BLIND     // can't see anything
 						flavour = "[copytext(adjust_flavour, 3, lentext(adjust_flavour) + 1)] up" //Trims off the 'un' at the beginning of the word. unzip -> zip, unbutton->button.
 					to_chat(user, "You [flavour] \the [src].")
 					suit_adjusted = 0 //Suit is no longer adjusted.
+					for(var/X in actions)
+						var/datum/action/A = X
+						A.UpdateButtonIcon()
 				else
 					var/flavour = "open"
 					icon_state += "_open"
@@ -471,6 +474,9 @@ BLIND     // can't see anything
 						flavour = "[adjust_flavour]"
 					to_chat(user, "You [flavour] \the [src].")
 					suit_adjusted = 1 //Suit's adjusted.
+					for(var/X in actions)
+						var/datum/action/A = X
+						A.UpdateButtonIcon()
 			else
 				if(user.canUnEquip(src)) //Checks to see if the item can be unequipped. If so, lets shred. Otherwise, struggle and fail.
 					if(contents) //If the suit's got any storage capability...
@@ -501,16 +507,6 @@ BLIND     // can't see anything
 		else
 			if(!(initial(flags_inv) & HIDETAIL) && (flags_inv & HIDETAIL)) //Otherwise, remove the HIDETAIL flag if it wasn't already in the flags_inv to start with.
 				flags_inv &= ~HIDETAIL
-
-/obj/item/clothing/suit/verb/openjacket(var/mob/user) //The verb you can use to adjust jackets.
-	set name = "Open/Close Jacket"
-	set category = "Object"
-	set src in usr
-	if(!isliving(usr))
-		return
-	if(usr.stat)
-		return
-	adjustsuit(user)
 
 /obj/item/clothing/suit/ui_action_click(mob/user) //This is what happens when you click the HUD action button to adjust your suit.
 	if(!ignore_suitadjust)

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -348,7 +348,7 @@
 		tint = initial(tint) //better than istype
 	else
 		up = !up
-		flags &= ~HEADCOVERSEYES
+		flags &= ~GLASSESCOVERSEYES
 		flags_inv &= ~HIDEEYES
 		icon_state = "[initial(icon_state)]up"
 		to_chat(usr, "You push the [src] up out of your face.")

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -281,10 +281,7 @@
 /obj/item/clothing/glasses/sunglasses/yeah/attack_self()
 	pun()
 
-/obj/item/clothing/glasses/sunglasses/yeah/verb/pun()
-	set category = "Object"
-	set name = "YEAH!"
-	set src in usr
+/obj/item/clothing/glasses/sunglasses/yeah/proc/pun()
 	if(!punused)//one per round
 		punused = 1
 		playsound(src.loc, 'sound/misc/yeah.ogg', 100, 0)
@@ -340,31 +337,28 @@
 /obj/item/clothing/glasses/welding/attack_self()
 	toggle()
 
+/obj/item/clothing/glasses/welding/proc/toggle()
+	if(up)
+		up = !up
+		flags |= GLASSESCOVERSEYES
+		flags_inv |= HIDEEYES
+		icon_state = initial(icon_state)
+		to_chat(usr, "You flip the [src] down to protect your eyes.")
+		flash_protect = 2
+		tint = initial(tint) //better than istype
+	else
+		up = !up
+		flags &= ~HEADCOVERSEYES
+		flags_inv &= ~HIDEEYES
+		icon_state = "[initial(icon_state)]up"
+		to_chat(usr, "You push the [src] up out of your face.")
+		flash_protect = 0
+		tint = 0
+	usr.update_inv_glasses()
 
-/obj/item/clothing/glasses/welding/verb/toggle()
-	set category = "Object"
-	set name = "Adjust welding goggles"
-	set src in usr
-
-	if(usr.canmove && !usr.stat && !usr.restrained())
-		if(src.up)
-			src.up = !src.up
-			src.flags |= GLASSESCOVERSEYES
-			flags_inv |= HIDEEYES
-			icon_state = initial(icon_state)
-			to_chat(usr, "You flip the [src] down to protect your eyes.")
-			flash_protect = 2
-			tint = initial(tint) //better than istype
-		else
-			src.up = !src.up
-			src.flags &= ~HEADCOVERSEYES
-			flags_inv &= ~HIDEEYES
-			icon_state = "[initial(icon_state)]up"
-			to_chat(usr, "You push the [src] up out of your face.")
-			flash_protect = 0
-			tint = 0
-
-		usr.update_inv_glasses()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /obj/item/clothing/glasses/welding/superior
 	name = "superior welding goggles"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -355,14 +355,7 @@
 /obj/item/clothing/head/griffin/attack_self()
 	caw()
 
-/obj/item/clothing/head/griffin/verb/caw()
-
-	set category = "Object"
-	set name = "Caw"
-	set src in usr
-	if(!istype(usr, /mob/living)) return
-	if(usr.stat) return
-
+/obj/item/clothing/head/griffin/proc/caw()
 	if(cooldown < world.time - 20) // A cooldown, to stop people being jerks
 		playsound(src.loc, "sound/misc/caw.ogg", 50, 1)
 		cooldown = world.time

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -50,26 +50,28 @@
 	toggle()
 
 /obj/item/clothing/head/welding/proc/toggle()
-	set src in usr
+	if(up)
+		up = !up
+		flags |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
+		flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
+		icon_state = initial(icon_state)
+		to_chat(usr, "You flip the [src] down to protect your eyes.")
+		flash_protect = 2
+		tint = 2
+	else
+		up = !up
+		flags &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
+		flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
+		icon_state = "[initial(icon_state)]up"
+		to_chat(usr, "You push the [src] up out of your face.")
+		flash_protect = 0
+		tint = 0
+	usr.update_inv_head()	//so our mob-overlays update
 
-	if(usr.canmove && !usr.stat && !usr.restrained())
-		if(src.up)
-			src.up = !src.up
-			src.flags |= (HEADCOVERSEYES | HEADCOVERSMOUTH)
-			flags_inv |= (HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
-			icon_state = initial(icon_state)
-			to_chat(usr, "You flip the [src] down to protect your eyes.")
-			flash_protect = 2
-			tint = 2
-		else
-			src.up = !src.up
-			src.flags &= ~(HEADCOVERSEYES | HEADCOVERSMOUTH)
-			flags_inv &= ~(HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE)
-			icon_state = "[initial(icon_state)]up"
-			to_chat(usr, "You push the [src] up out of your face.")
-			flash_protect = 0
-			tint = 0
-		usr.update_inv_head()	//so our mob-overlays update
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
+
 
 
 /*

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -34,30 +34,28 @@
 /obj/item/clothing/mask/gas/welding/attack_self()
 	toggle()
 
+/obj/item/clothing/mask/gas/welding/proc/toggle()
+	if(up)
+		up = !src.up
+		flags |= (MASKCOVERSEYES)
+		flags_inv |= (HIDEEYES)
+		icon_state = initial(icon_state)
+		to_chat(usr, "You flip the [src] down to protect your eyes.")
+		flash_protect = 2
+		tint = 2
+	else
+		up = !up
+		flags &= ~(MASKCOVERSEYES)
+		flags_inv &= ~(HIDEEYES)
+		icon_state = "[initial(icon_state)]up"
+		to_chat(usr, "You push the [src] up out of your face.")
+		flash_protect = 0
+		tint = 0
+	usr.update_inv_wear_mask()	//so our mob-overlays update
 
-/obj/item/clothing/mask/gas/welding/verb/toggle()
-	set category = "Object"
-	set name = "Adjust welding mask"
-	set src in usr
-
-	if(usr.canmove && !usr.stat && !usr.restrained())
-		if(src.up)
-			src.up = !src.up
-			src.flags |= (MASKCOVERSEYES)
-			flags_inv |= (HIDEEYES)
-			icon_state = initial(icon_state)
-			to_chat(usr, "You flip the [src] down to protect your eyes.")
-			flash_protect = 2
-			tint = 2
-		else
-			src.up = !src.up
-			src.flags &= ~(MASKCOVERSEYES)
-			flags_inv &= ~(HIDEEYES)
-			icon_state = "[initial(icon_state)]up"
-			to_chat(usr, "You push the [src] up out of your face.")
-			flash_protect = 0
-			tint = 0
-		usr.update_inv_wear_mask()	//so our mob-overlays update
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 //Bane gas mask
 /obj/item/clothing/mask/banemask
@@ -171,14 +169,7 @@
 /obj/item/clothing/mask/gas/owl_mask/attack_self()
 	hoot()
 
-/obj/item/clothing/mask/gas/owl_mask/verb/hoot()
-
-	set category = "Object"
-	set name = "Hoot"
-	set src in usr
-	if(!istype(usr, /mob/living)) return
-	if(usr.stat) return
-
+/obj/item/clothing/mask/gas/owl_mask/proc/hoot()
 	if(cooldown < world.time - 35) // A cooldown, to stop people being jerks
 		playsound(src.loc, "sound/misc/hoot.ogg", 50, 1)
 		cooldown = world.time
@@ -270,13 +261,7 @@
 	else
 		return
 
-/obj/item/clothing/mask/gas/sechailer/verb/halt()
-	set category = "Object"
-	set name = "HALT"
-	set src in usr
-	if(!istype(usr, /mob/living)) return
-	if(usr.stat) return
-
+/obj/item/clothing/mask/gas/sechailer/proc/halt()
 	var/phrase = 0	//selects which phrase to use
 	var/phrase_text = null
 	var/phrase_sound = null

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -22,6 +22,9 @@
 	to_chat(user, "You [magpulse ? "enable" : "disable"] the mag-pulse traction system.")
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_gravity(user.mob_has_gravity())
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
 	return flags & NOSLIP

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -250,7 +250,6 @@
 	unacidable = 1
 	hit_reaction_chance = 50
 
-
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
 	active = !(active)
 	if(active)
@@ -263,6 +262,9 @@
 		item_state = "reactiveoff"
 		add_fingerprint(user)
 	user.update_inv_wear_suit()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /obj/item/clothing/suit/armor/reactive/emp_act(severity)
 	active = 0

--- a/code/modules/clothing/suits/hood.dm
+++ b/code/modules/clothing/suits/hood.dm
@@ -7,7 +7,6 @@
 
 /obj/item/clothing/suit/hooded/New()
 	MakeHood()
-	verbs -= /obj/item/clothing/suit/verb/openjacket //you can't unbutton those, deal with it
 	..()
 
 /obj/item/clothing/suit/hooded/Destroy()
@@ -46,16 +45,6 @@
 /obj/item/clothing/suit/hooded/dropped()
 	..()
 	RemoveHood()
-
-/obj/item/clothing/suit/hooded/verb/Hooderize(var/mob/user)
-	set name = "Adjust the hood"
-	set category = "Object"
-	set src in usr
-	if(!isliving(usr))
-		return
-	if(usr.stat)
-		return
-	ToggleHood()
 
 /obj/item/clothing/suit/hooded/proc/ToggleHood()
 	if(!suit_adjusted)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -800,6 +800,9 @@
 		icon_state = initial(icon_state)
 		item_state = initial(item_state)
 	usr.update_inv_wear_suit()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /obj/item/clothing/suit/lordadmiral
 	name = "Lord Admiral's Coat"

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -495,22 +495,21 @@
 /obj/item/clothing/head/fluff/chronx/ui_action_click()
 	adjust()
 
-/obj/item/clothing/head/fluff/chronx/verb/adjust()
-	set name = "Transform Hood"
-	set category = "Object"
-	set src in usr
-	if(isliving(usr) && !usr.incapacitated())
-		if(adjusted)
-			icon_state = initial(icon_state)
-			item_state = initial(item_state)
-			to_chat(usr, "You untransform \the [src].")
-			adjusted = 0
-		else
-			icon_state += "_open"
-			item_state += "_open"
-			to_chat(usr, "You transform \the [src].")
-			adjusted = 1
-		usr.update_inv_head()
+/obj/item/clothing/head/fluff/chronx/proc/adjust()
+	if(adjusted)
+		icon_state = initial(icon_state)
+		item_state = initial(item_state)
+		to_chat(usr, "You untransform \the [src].")
+		adjusted = 0
+	else
+		icon_state += "_open"
+		item_state += "_open"
+		to_chat(usr, "You transform \the [src].")
+		adjusted = 1
+	usr.update_inv_head()
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 
 /obj/item/clothing/suit/chaplain_hoodie/fluff/chronx //chronx100: Hughe O'Splash
 	name = "Cthulhu's Robes"
@@ -522,18 +521,6 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	adjust_flavour = "untransform"
 	ignore_suitadjust = 0
-
-/obj/item/clothing/suit/chaplain_hoodie/fluff/chronx/New()
-	..()
-	verbs -= /obj/item/clothing/suit/verb/openjacket
-
-/obj/item/clothing/suit/chaplain_hoodie/fluff/chronx/verb/adjust()
-	set name = "Transform Robes"
-	set category = "Object"
-	set src in usr
-	if(!istype(usr, /mob/living))
-		return
-	adjustsuit(usr)
 
 /obj/item/clothing/shoes/black/fluff/chronx //chronx100: Hughe O'Splash
 	name = "Cthulhu's Boots"

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -50,7 +50,7 @@
 		return ..()
 
 
-/mob/living/carbon/brain/update_canmove()
+/mob/living/carbon/brain/update_canmove(delay_action_updates = 0)
 	if(in_contents_of(/obj/mecha))
 		canmove = 1
 		use_me = 1 //If it can move, let it emote
@@ -59,7 +59,8 @@
 	else
 		canmove = 0
 
-	update_action_buttons_icon()
+	if(!delay_action_updates)
+		update_action_buttons_icon()
 	return canmove
 
 /mob/living/carbon/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -49,7 +49,7 @@
 		handle_disabilities() // eye, ear, brain damages
 		handle_status_effects() //all special effects, stunned, weakened, jitteryness, hallucination, sleeping, etc
 
-	update_canmove()
+	update_canmove(1) // set to 1 to not update icon action buttons; rip this argument out if Life is ever refactored to be non-stupid. -Fox
 
 	if(client)
 		//regular_hud_updates() //THIS DOESN'T FUCKING UPDATE SHIT

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -521,7 +521,7 @@
 		to_chat(src, "<span class='warning'>You are far too small to pull anything!</span>")
 	return
 
-/mob/living/silicon/pai/update_canmove()
+/mob/living/silicon/pai/update_canmove(delay_action_updates = 0)
 	. = ..()
 	density = 0 //this is reset every canmove update otherwise
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -337,7 +337,7 @@
 /mob/living/silicon/robot/drone/remove_robot_verbs()
 	src.verbs -= silicon_subsystems
 
-/mob/living/silicon/robot/drone/update_canmove()
+/mob/living/silicon/robot/drone/update_canmove(delay_action_updates = 0)
 	. = ..()
 	density = 0 //this is reset every canmove update otherwise
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -228,13 +228,14 @@
 			weapon_lock = 0
 			weaponlock_time = 120
 
-/mob/living/silicon/robot/update_canmove()
+/mob/living/silicon/robot/update_canmove(delay_action_updates = 0)
 	if(paralysis || stunned || weakened || buckled || lockcharge)
 		canmove = 0
 	else
 		canmove = 1
 	update_transform()
-	update_action_buttons_icon()
+	if(!delay_action_updates)
+		update_action_buttons_icon()
 	return canmove
 
 //Robots on fire

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -161,7 +161,7 @@
 	diag_hud.add_hud_to(src)
 	permanent_huds |= diag_hud
 
-/mob/living/simple_animal/bot/update_canmove()
+/mob/living/simple_animal/bot/update_canmove(delay_action_updates = 0)
 	. = ..()
 	if(!on)
 		. = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -617,7 +617,7 @@
 
 	return verb
 
-/mob/living/simple_animal/update_canmove()
+/mob/living/simple_animal/update_canmove(delay_action_updates = 0)
 	if(paralysis || stunned || weakened || stat || resting)
 		drop_r_hand()
 		drop_l_hand()
@@ -627,7 +627,8 @@
 	else
 		canmove = 1
 	update_transform()
-	update_action_buttons_icon()
+	if(!delay_action_updates)
+		update_action_buttons_icon()
 	return canmove
 
 /mob/living/simple_animal/update_transform()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1027,7 +1027,7 @@ var/list/slot_equipment_priority = list( \
 	return 1
 
 //Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
-/mob/proc/update_canmove()
+/mob/proc/update_canmove(delay_action_updates = 0)
 	var/ko = weakened || paralysis || stat || (status_flags & FAKEDEATH)
 	var/buckle_lying = !(buckled && !buckled.buckle_lying)
 	if(ko || resting || stunned)
@@ -1052,7 +1052,8 @@ var/list/slot_equipment_priority = list( \
 			layer = initial(layer)
 
 	update_transform()
-	update_action_buttons_icon()
+	if(!delay_action_updates)
+		update_action_buttons_icon()
 	return canmove
 
 /mob/proc/fall(var/forced)


### PR DESCRIPTION
- Fixes a few action buttons not updating
- Fixes action buttons getting updated every `Life`
 - Basically, TG's `Life` is superior to ours and doesn't spam certain procs like no tomorrow like ours does...because ours is so bad, our action buttons were being updated literally every 2 seconds--the culprit is `update_canmove`
- Removed the object verb of anything that had both a verb and an action button
 - Object verbs junk up the already heavily populated objects tab and there's no point to these with actions buttons.

:cl: Fox McCloud
del: removes redundant object verbs that have an action button
/:cl: