### PR TITLE
Pod Disabler, Grab, and Weapon Attack Fixes

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -130,7 +130,7 @@
 	light_color = icon_light_color[src.icon_state]
 
 /obj/spacepod/bullet_act(var/obj/item/projectile/P)
-	if(P.damage && !P.nodamage)
+	if(P.damage && !P.nodamage && P.damage_type != STAMINA)
 		deal_damage(P.damage)
 	else if(P.flag == "energy" && istype(P,/obj/item/projectile/ion)) //needed to make sure ions work properly
 		empulse(src, 1, 1)
@@ -370,7 +370,10 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 			if(do_after(user, 50, target = src))
 				target.forceMove(get_turf(src))
 				target.Stun(1)
-				passengers -= target
+				if(pilot)
+					pilot = null
+				else
+					passengers -= target
 				target.visible_message("<span class='warning'>[user] flings the door open and tears [target] out of the [src]</span>",
 					"<span class='warning'>The door flies open and you are thrown out of the [src] and to the ground!</span>")
 				return

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -130,7 +130,7 @@
 	light_color = icon_light_color[src.icon_state]
 
 /obj/spacepod/bullet_act(var/obj/item/projectile/P)
-	if(P.damage && !P.nodamage && P.damage_type != STAMINA)
+	if(P.damage_type == BRUTE || P.damage_type == BURN)
 		deal_damage(P.damage)
 	else if(P.flag == "energy" && istype(P,/obj/item/projectile/ion)) //needed to make sure ions work properly
 		empulse(src, 1, 1)
@@ -250,95 +250,99 @@
 			processing_objects.Add(src)
 
 /obj/spacepod/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(iscrowbar(W))
-		if(!equipment_system.lock_system || unlocked || hatch_open)
-			hatch_open = !hatch_open
-			playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-			to_chat(user, "<span class='notice'>You [hatch_open ? "open" : "close"] the maintenance hatch.</span>")
-		else
-			to_chat(user, "<span class='warning'>The hatch is locked shut!</span>")
-		return
-	if(istype(W, /obj/item/weapon/stock_parts/cell))
-		if(!hatch_open)
-			to_chat(user, "\red The maintenance hatch is closed!")
-			return
-		if(battery)
-			to_chat(user, "<span class='notice'>The pod already has a battery.</span>")
-			return
-		user.drop_item(W)
-		battery = W
-		W.forceMove(src)
-		return
-	if(istype(W, /obj/item/device/spacepod_equipment))
-		if(!hatch_open)
-			to_chat(user, "\red The maintenance hatch is closed!")
-			return
-		if(!equipment_system)
-			to_chat(user, "<span class='warning'>The pod has no equipment datum, yell at the coders</span>")
-			return
-		if(istype(W, /obj/item/device/spacepod_equipment/weaponry))
-			add_equipment(user, W, "weapon_system")
-			return
-		if(istype(W, /obj/item/device/spacepod_equipment/misc))
-			add_equipment(user, W, "misc_system")
-			return
-		if(istype(W, /obj/item/device/spacepod_equipment/cargo))
-			add_equipment(user, W, "cargo_system")
-			return
-		if(istype(W, /obj/item/device/spacepod_equipment/sec_cargo))
-			add_equipment(user, W, "sec_cargo_system")
-			return
-		if(istype(W, /obj/item/device/spacepod_equipment/lock))
-			add_equipment(user, W, "lock_system")
-			return
-
-	if(istype(W, /obj/item/device/spacepod_key) && istype(equipment_system.lock_system, /obj/item/device/spacepod_equipment/lock/keyed))
-		var/obj/item/device/spacepod_key/key = W
-		if(key.id == equipment_system.lock_system.id)
-			lock_pod()
-			return
-		else
-			to_chat(user, "<span class='warning'>This is the wrong key!</span>")
-			return
-
-	if(istype(W, /obj/item/weapon/weldingtool))
-		if(!hatch_open)
-			to_chat(user, "\red You must open the maintenance hatch before attempting repairs.")
-			return
-		var/obj/item/weapon/weldingtool/WT = W
-		if(!WT.isOn())
-			to_chat(user, "\red The welder must be on for this task.")
-			return
-		if(health < initial(health))
-			to_chat(user, "\blue You start welding the spacepod...")
-			playsound(loc, 'sound/items/Welder.ogg', 50, 1)
-			if(do_after(user, 20, target = src))
-				if(!src || !WT.remove_fuel(3, user)) return
-				repair_damage(10)
-				to_chat(user, "\blue You mend some [pick("dents","bumps","damage")] with \the [WT]")
-			return
-		to_chat(user, "\blue <b>\The [src] is fully repaired!</b>")
-		return
-
-	if(istype(W, /obj/item/device/lock_buster))
-		var/obj/item/device/lock_buster/L = W
-		if(L.on && equipment_system.lock_system)
-			user.visible_message(user, "<span class='warning'>[user] is drilling through the [src]'s lock!</span>",
-				"<span class='notice'>You start drilling through the [src]'s lock!</span>")
-			if(do_after(user, 100, target = src))
-				qdel(equipment_system.lock_system)
-				equipment_system.lock_system = null
-				user.visible_message(user, "<span class='warning'>[user] has destroyed the [src]'s lock!</span>",
-					"<span class='notice'>You destroy the [src]'s lock!</span>")
+	if(user.a_intent == I_HARM)
+		..()
+		deal_damage(W.force)
+	else
+		if(iscrowbar(W))
+			if(!equipment_system.lock_system || unlocked || hatch_open)
+				hatch_open = !hatch_open
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You [hatch_open ? "open" : "close"] the maintenance hatch.</span>")
 			else
-				user.visible_message(user, "<span class='warning'>[user] fails to break through the [src]'s lock!</span>",
-				"<span class='notice'>You were unable to break through the [src]'s lock!</span>")
+				to_chat(user, "<span class='warning'>The hatch is locked shut!</span>")
 			return
-		to_chat(user, "<span class='notice'>Turn the [L] on first.</span>")
-		return
+		if(istype(W, /obj/item/weapon/stock_parts/cell))
+			if(!hatch_open)
+				to_chat(user, "\red The maintenance hatch is closed!")
+				return
+			if(battery)
+				to_chat(user, "<span class='notice'>The pod already has a battery.</span>")
+				return
+			user.drop_item(W)
+			battery = W
+			W.forceMove(src)
+			return
+		if(istype(W, /obj/item/device/spacepod_equipment))
+			if(!hatch_open)
+				to_chat(user, "\red The maintenance hatch is closed!")
+				return
+			if(!equipment_system)
+				to_chat(user, "<span class='warning'>The pod has no equipment datum, yell at the coders</span>")
+				return
+			if(istype(W, /obj/item/device/spacepod_equipment/weaponry))
+				add_equipment(user, W, "weapon_system")
+				return
+			if(istype(W, /obj/item/device/spacepod_equipment/misc))
+				add_equipment(user, W, "misc_system")
+				return
+			if(istype(W, /obj/item/device/spacepod_equipment/cargo))
+				add_equipment(user, W, "cargo_system")
+				return
+			if(istype(W, /obj/item/device/spacepod_equipment/sec_cargo))
+				add_equipment(user, W, "sec_cargo_system")
+				return
+			if(istype(W, /obj/item/device/spacepod_equipment/lock))
+				add_equipment(user, W, "lock_system")
+				return
 
-	if(cargo_hold.storage_slots > 0 && !hatch_open && unlocked) // must be the last option as all items not listed prior will be stored
-		cargo_hold.attackby(W, user, params)
+		if(istype(W, /obj/item/device/spacepod_key) && istype(equipment_system.lock_system, /obj/item/device/spacepod_equipment/lock/keyed))
+			var/obj/item/device/spacepod_key/key = W
+			if(key.id == equipment_system.lock_system.id)
+				lock_pod()
+				return
+			else
+				to_chat(user, "<span class='warning'>This is the wrong key!</span>")
+				return
+
+		if(istype(W, /obj/item/weapon/weldingtool))
+			if(!hatch_open)
+				to_chat(user, "\red You must open the maintenance hatch before attempting repairs.")
+				return
+			var/obj/item/weapon/weldingtool/WT = W
+			if(!WT.isOn())
+				to_chat(user, "\red The welder must be on for this task.")
+				return
+			if(health < initial(health))
+				to_chat(user, "\blue You start welding the spacepod...")
+				playsound(loc, 'sound/items/Welder.ogg', 50, 1)
+				if(do_after(user, 20, target = src))
+					if(!src || !WT.remove_fuel(3, user)) return
+					repair_damage(10)
+					to_chat(user, "\blue You mend some [pick("dents","bumps","damage")] with \the [WT]")
+				return
+			to_chat(user, "\blue <b>\The [src] is fully repaired!</b>")
+			return
+
+		if(istype(W, /obj/item/device/lock_buster))
+			var/obj/item/device/lock_buster/L = W
+			if(L.on && equipment_system.lock_system)
+				user.visible_message(user, "<span class='warning'>[user] is drilling through the [src]'s lock!</span>",
+					"<span class='notice'>You start drilling through the [src]'s lock!</span>")
+				if(do_after(user, 100, target = src))
+					qdel(equipment_system.lock_system)
+					equipment_system.lock_system = null
+					user.visible_message(user, "<span class='warning'>[user] has destroyed the [src]'s lock!</span>",
+						"<span class='notice'>You destroy the [src]'s lock!</span>")
+				else
+					user.visible_message(user, "<span class='warning'>[user] fails to break through the [src]'s lock!</span>",
+					"<span class='notice'>You were unable to break through the [src]'s lock!</span>")
+				return
+			to_chat(user, "<span class='notice'>Turn the [L] on first.</span>")
+			return
+
+		if(cargo_hold.storage_slots > 0 && !hatch_open && unlocked) // must be the last option as all items not listed prior will be stored
+			cargo_hold.attackby(W, user, params)
 
 obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment/SPE, var/slot)
 	if(equipment_system.vars[slot])


### PR DESCRIPTION
Fixes the bug that lets you destroy pods with stamina damage weapons by adding in a check, as well as fixes the bug that makes it possible to pull someone out of a pod they are not in anymore.

When harm intent is on, you can now melee attack pods with weapons. Doesn't work for fists (you can't damage them with your fist, you know).

Fixes #5088

:cl: Twinmold
Fix: Can no longer destroy pods with anything other than brute and burn weapons.
Fix: Can no longer pull someone out of a pod when no one is actually in the pod.
Tweak: Can now melee attack pods with weapons when harm intent is on.
/:cl: