### PR TITLE
Adds a chameleon secHUD to traitor uplink store

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -752,6 +752,13 @@ var/list/uplink_items = list()
 	item = /obj/item/toy/carpplushie/dehy_carp
 	cost = 3
 
+/datum/uplink_item/stealthy_weapons/chamsechud
+	name = "Chameleon Security HUD"
+	desc = "A stolen Nanotrasen Security HUD with Syndicat chameleon technology implemented into it. The glasses can be morphed into various eyewear, while reatining the HUD qualities when worn."
+	reference = "CHHUD"
+	item = /obj/item/clothing/glasses/hud/security/chameleon
+	cost = 2
+
 // STEALTHY TOOLS
 
 /datum/uplink_item/stealthy_tools

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -754,7 +754,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_weapons/chamsechud
 	name = "Chameleon Security HUD"
-	desc = "A stolen Nanotrasen Security HUD with Syndicat chameleon technology implemented into it. The glasses can be morphed into various eyewear, while reatining the HUD qualities when worn."
+	desc = "A stolen Nanotrasen Security HUD with Syndicate chameleon technology implemented into it. Similarly to a chameleon jumpsuit, the HUD can be morphed into various other eyewear, while retaining the HUD qualities when worn."
 	reference = "CHHUD"
 	item = /obj/item/clothing/glasses/hud/security/chameleon
 	cost = 2

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -82,7 +82,7 @@
 		)
 
 /obj/item/clothing/glasses/hud/security/chameleon
-	name = "Chamleon Security HUD"
+	name = "Chameleon Security HUD"
 	desc = "A stolen security HUD integrated with Syndicate chameleon technology. Toggle to disguise the HUD. Provides flash protection."
 	flash_protect = 1
 


### PR DESCRIPTION
It's a SecHUD that is flashproof. 
If you use it, it can be morphed into one of many eyewear items:
![img](http://i.imgur.com/3sNJHox.png)
Costs 2 TC.
Originally intended for Rev, apparently, but I don't really see why Traitors shouldn't have access to something like this.
:cl: FreeStylaLT
rscadd: Added new syndicate item Chameleon SecHUD to uplink store, available for all antags. It can morph into various eyewear while being a flashproof sechud.
/:cl: