### PR TITLE
Slime people ventcrawl

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -523,7 +523,7 @@
 	dietflags = DIET_CARN
 	reagent_tag = PROCESS_ORG
 	exotic_blood = "water"
-	//ventcrawler = 1 //ventcrawling commented out
+	ventcrawler = 1
 	butt_sprite = "slime"
 
 	has_organ = list(


### PR DESCRIPTION
:cl:
rscadd: Slime people can now crawl through the vents if naked.
/:cl:

# REMEMBER CHILDREN: This was removed when ventcrawling brought up a list of places to literally instantly teleport to. With the new ventcrawling system, this isn't the case: They have to navigate the pipes, and they can be *seriously* injured by the air inside of them. 
Ventcrawler = 1 means they can only go through when naked.