### PR TITLE
Fixes Artificial Bluespace Crystal Exploit

### DIFF
--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -40,6 +40,8 @@
 	desc = "An artificially made bluespace crystal, it looks delicate."
 	origin_tech = "bluespace=2"
 	blink_range = 4 // Not as good as the organic stuff!
+	points = 0 // nice try
+	refined_type = null
 
 // Polycrystals, aka stacks
 


### PR DESCRIPTION
Fixes an exploit where you can convert artificial bluespace crystals into full bluespace crystals


:cl: Fox McCloud
fix: Fixes being able to exploit and turn artificial bluespace crystals into regular bluespace crystals
/:cl: