### PR TITLE
Fixes Camera Monitor Access Checking

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -49,11 +49,9 @@
 	return 1
 
 // Network configuration
-/obj/machinery/computer/security/attackby(I as obj, user as mob, params)
-	access = list()
-	if(istype(I,/obj/item/weapon/card/id)) // If hit by a regular ID card.
-		var/obj/item/weapon/card/id/E = I
-		access = E.access
+/obj/machinery/computer/security/attackby(obj/item/I, user as mob, params)
+	access = I.GetAccess()
+	if(access.len) // If hit by something with access.
 		ui_interact(user)
 	else
 		..()
@@ -172,10 +170,7 @@
 		user.set_machine(src)
 
 	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.wear_id)
-			var/obj/item/weapon/card/id/gold/C = H.wear_id
-			access = C.access
+		access = user.get_access()
 
 	ui_interact(user)
 


### PR DESCRIPTION
When checking what sort of access you should have, camera monitors were assuming that whatever you had in your ID slot was an ID card... and breaking if you happened to have something else in there, such as a wallet, or a PDA (oh dear). Now, they use the appropriate access-checking procs, to support whatever you happen to use for access.

The way access checking works for camera monitors is still horrifying, by the way. I'm pretty sure long-term exposure to it is harmful, so I'm leaving the rest as it is.