### PR TITLE
Atmos Grenades (aka: how to kill people with atmos)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -454,7 +454,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/dangerous/atmosgrenades
 	name = "Atmos Grenades"
-	desc = "A box of four (4) grenades that wreck havoc with the atmosphere of the target area, causing fire, suffocation, vacuum and/or crushing pressure. Use extreme caution! Unlike normal gasses, these are explosively propelled and instantly engulf a large area!"
+	desc = "A box of four (4) grenades that wreak havoc with the atmosphere of the target area, causing fire, suffocation, vacuum and/or crushing pressure. Use extreme caution! Unlike normal gasses, these are explosively propelled and instantly engulf a large area!"
 	reference = "AGG"
 	item = /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades
 	cost = 6

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -452,6 +452,13 @@ var/list/uplink_items = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
+/datum/uplink_item/dangerous/atmosgrenades
+	name = "Atmos Grenades"
+	desc = "A box of four (4) grenades that wreck havoc with the atmosphere of the target area, causing fire, suffocation, vacuum and/or crushing pressure. Use extreme caution! Unlike normal gasses, these are explosively propelled and instantly engulf a large area!"
+	reference = "AGG"
+	item = /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades
+	cost = 6
+
 /datum/uplink_item/dangerous/emp
 	name = "EMP Grenades and Implanter Kit"
 	desc = "A box that contains two EMP grenades and an EMP implant. Useful to disrupt communication, \

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -454,7 +454,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/dangerous/atmosgrenades
 	name = "Atmos Grenades"
-	desc = "A box of four (4) grenades that wreak havoc with the atmosphere of the target area, causing fire, suffocation, vacuum and/or crushing pressure. Use extreme caution! Unlike normal gasses, these are explosively propelled and instantly engulf a large area!"
+	desc = "A box of two (2) grenades that wreak havoc with the atmosphere of the target area. Capable of engulfing a large area in lit plasma, or N2O. Deploy with extreme caution!"
 	reference = "AGG"
 	item = /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades
 	cost = 6

--- a/code/game/objects/items/weapons/grenades/atmosgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/atmosgrenade.dm
@@ -8,92 +8,22 @@
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "syndicate"
 	item_state = "flashbang"
-	var/gas_type = "fire"
-	var/max_spread_turfs = 20
-	var/gas_debug = 0
 
-/obj/item/weapon/grenade/gas/overpressure
-	name = "Overpressure Grenade"
-	desc = "A compressed gas grenade, used to create crushing pressure in an area."
-	gas_type = "overpressure"
-
-/obj/item/weapon/grenade/gas/suffocation
-	name = "Suffocation Grenade"
-	desc = "An oxygen depletion grenade, used to ensure anyone entering the target area quickly suffocates."
-	gas_type = "suffocation"
-
-/obj/item/weapon/grenade/gas/vacuum
-	name = "Vacuum Grenade"
-	desc = "A grenade that completely removes all air and heat from its detonation area."
-	gas_type = "vacuum"
+/obj/item/weapon/grenade/gas/prime()
+	var/turf/simulated/target_turf = get_turf(src)
+	if(istype(target_turf))
+		target_turf.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 100)
+		target_turf.air_update_turf()
+	qdel(src)
 
 /obj/item/weapon/grenade/gas/knockout
 	name = "Knockout Grenade"
 	desc = "A grenade that completely removes all air and heat from its detonation area."
-	gas_type = "knockout"
 
-/obj/item/weapon/grenade/gas/prime()
-	var/turf/simulated/origin = get_turf(src)
-	var/list/spread_turfs = list()
-	var/list/scan_turfs = list()
+/obj/item/weapon/grenade/gas/knockout/prime()
+	var/turf/simulated/target_turf = get_turf(src)
+	if(istype(target_turf))
+		target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_N2O, 100)
+		target_turf.air_update_turf()
+	qdel(src)
 
-	if(!istype(origin))
-		// Error, unsimulated turf.
-		qdel(src)
-		return
-
-	scan_turfs += origin
-
-	while(spread_turfs.len < max_spread_turfs && scan_turfs.len)
-		if(gas_debug)
-			visible_message("[src] loops: [spread_turfs.len] turfs, [scan_turfs.len] to scan!")
-		var/turf/scan_from = pick(scan_turfs)
-		var/list/adj = 	scan_from.GetAtmosAdjacentTurfs(1)
-		for(var/turf/simulated/C in adj)
-			if(!(C in scan_turfs) && C.CanAtmosPass(C))
-				scan_turfs += C
-		spread_turfs += scan_from
-		scan_turfs -= scan_from
-
-	if(!spread_turfs.len)
-		visible_message("<span class='notice'>[src] detonates harmlessly in the airless space.</span>")
-		qdel(src)
-	else
-		if(gas_debug)
-			visible_message("[src] affects [spread_turfs.len] turfs, with [scan_turfs.len] left to scan!")
-		for(var/turf/simulated/target_turf in spread_turfs)
-			switch(gas_type)
-				if("fire")
-					target_turf.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 200) // works well
-				if("overpressure")
-					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_NITROGEN, 2000) // kills slowly, but hard to deal with
-				if("suffocation")
-					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_CO2, target_turf.air.oxygen) // knocks out slowly, kills
-					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_OXYGEN, target_turf.air.oxygen * -1)
-				if("knockout")
-					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_N2O, 100) // knocks out quickly
-				if("vacuum")
-					target_turf.air.nitrogen = 0
-					target_turf.air.oxygen = 0
-					target_turf.air.nitrogen = 0
-					air_master.add_to_active(target_turf, 0)
-			var/obj/machinery/alarm/air_alarm = locate(/obj/machinery/alarm/) in target_turf
-			if(istype(air_alarm))
-				// break the alarm off the wall
-				air_alarm.visible_message("[air_alarm] breaks from the rapid change in pressure!")
-				playsound(air_alarm.loc, 'sound/effects/sparks4.ogg', 50, 1)
-				new /obj/item/mounted/frame/alarm_frame(air_alarm.loc)
-				qdel(air_alarm)
-			var/obj/machinery/atmospherics/unary/vent_pump/v = locate(/obj/machinery/atmospherics/unary/vent_pump) in target_turf
-			if(istype(v))
-				v.welded = 1
-				v.update_icon()
-				v.visible_message("<span class='danger'>[v] is broken by the rapid pressure change!</span>")
-			var/obj/machinery/atmospherics/unary/vent_scrubber/s = locate(/obj/machinery/atmospherics/unary/vent_scrubber) in target_turf
-			if(istype(s))
-				s.welded = 1
-				s.update_icon()
-				s.visible_message("<span class='danger'>[s] is broken by the rapid pressure change!</span>")
-			target_turf.air_update_turf()
-		visible_message("<span class='userdanger'>[src] detonates!</span>")
-		qdel(src)

--- a/code/game/objects/items/weapons/grenades/atmosgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/atmosgrenade.dm
@@ -1,0 +1,98 @@
+
+
+
+/obj/item/weapon/grenade/gas
+	name = "Plasma Fire Grenade"
+	desc = "A compressed plasma grenade, used to start horrific plasma fires."
+	origin_tech = "materials=3;magnets=4;syndicate=4"
+	icon = 'icons/obj/grenade.dmi'
+	icon_state = "syndicate"
+	item_state = "flashbang"
+	var/gas_type = "fire"
+	var/max_spread_turfs = 20
+	var/gas_debug = 0
+
+/obj/item/weapon/grenade/gas/overpressure
+	name = "Overpressure Grenade"
+	desc = "A compressed gas grenade, used to create crushing pressure in an area."
+	gas_type = "overpressure"
+
+/obj/item/weapon/grenade/gas/suffocation
+	name = "Suffocation Grenade"
+	desc = "An oxygen depletion grenade, used to ensure anyone entering the target area quickly suffocates."
+	gas_type = "suffocation"
+
+/obj/item/weapon/grenade/gas/vacuum
+	name = "Vacuum Grenade"
+	desc = "A grenade that completely removes all air and heat from its detonation area."
+	gas_type = "vacuum"
+
+/obj/item/weapon/grenade/gas/knockout
+	name = "Knockout Grenade"
+	desc = "A grenade that completely removes all air and heat from its detonation area."
+	gas_type = "knockout"
+
+/obj/item/weapon/grenade/gas/prime()
+	var/turf/simulated/origin = get_turf(src)
+	var/list/spread_turfs = list()
+	var/list/scan_turfs = list()
+
+	if(!origin)
+		// Error, unsimulated turf.
+		return
+
+	scan_turfs += origin
+
+	while(spread_turfs.len < max_spread_turfs && scan_turfs.len)
+		if(gas_debug)
+			visible_message("[src] loops: [spread_turfs.len] turfs, [scan_turfs.len] to scan!")
+		var/turf/scan_from = pick(scan_turfs)
+		var/list/adj = 	scan_from.GetAtmosAdjacentTurfs(1)
+		for(var/turf/simulated/C in adj)
+			if(!(C in scan_turfs) && C.CanAtmosPass(C))
+				scan_turfs += C
+		spread_turfs += scan_from
+		scan_turfs -= scan_from
+
+	if(!spread_turfs.len)
+		visible_message("<span class='notice'>[src] detonates harmlessly in the airless space.</span>")
+		qdel(src)
+	else
+		if(gas_debug)
+			visible_message("[src] affects [spread_turfs.len] turfs, with [scan_turfs.len] left to scan!")
+		for(var/turf/simulated/target_turf in spread_turfs)
+			switch(gas_type)
+				if("fire")
+					target_turf.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 200) // works well
+				if("overpressure")
+					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_NITROGEN, 2000) // kills slowly, but hard to deal with
+				if("suffocation")
+					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_CO2, target_turf.air.oxygen) // knocks out slowly, kills
+					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_OXYGEN, target_turf.air.oxygen * -1)
+				if("knockout")
+					target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_N2O, 100) // knocks out quickly
+				if("vacuum")
+					target_turf.air.nitrogen = 0
+					target_turf.air.oxygen = 0
+					target_turf.air.nitrogen = 0
+					air_master.add_to_active(target_turf, 0)
+			var/obj/machinery/alarm/air_alarm = locate(/obj/machinery/alarm/) in target_turf
+			if(istype(air_alarm))
+				// break the alarm off the wall
+				air_alarm.visible_message("[air_alarm] breaks from the rapid change in pressure!")
+				playsound(air_alarm.loc, 'sound/effects/sparks4.ogg', 50, 1)
+				new /obj/item/mounted/frame/alarm_frame(air_alarm.loc)
+				qdel(air_alarm)
+			var/obj/machinery/atmospherics/unary/vent_pump/v = locate(/obj/machinery/atmospherics/unary/vent_pump) in target_turf
+			if(istype(v))
+				v.welded = 1
+				v.update_icon()
+				v.visible_message("<span class='danger'>[v] is broken by the rapid pressure change!</span>")
+			var/obj/machinery/atmospherics/unary/vent_scrubber/s = locate(/obj/machinery/atmospherics/unary/vent_scrubber) in target_turf
+			if(istype(s))
+				s.welded = 1
+				s.update_icon()
+				s.visible_message("<span class='danger'>[s] is broken by the rapid pressure change!</span>")
+			target_turf.air_update_turf()
+		visible_message("<span class='userdanger'>[src] detonates!</span>")
+		qdel(src)

--- a/code/game/objects/items/weapons/grenades/atmosgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/atmosgrenade.dm
@@ -37,8 +37,9 @@
 	var/list/spread_turfs = list()
 	var/list/scan_turfs = list()
 
-	if(!origin)
+	if(!istype(origin))
 		// Error, unsimulated turf.
+		qdel(src)
 		return
 
 	scan_turfs += origin

--- a/code/game/objects/items/weapons/grenades/atmosgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/atmosgrenade.dm
@@ -8,22 +8,17 @@
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "syndicate"
 	item_state = "flashbang"
+	var/spawn_contents = SPAWN_HEAT | SPAWN_TOXINS
+	var/spawn_amount = 100
 
 /obj/item/weapon/grenade/gas/prime()
 	var/turf/simulated/target_turf = get_turf(src)
 	if(istype(target_turf))
-		target_turf.atmos_spawn_air(SPAWN_HEAT | SPAWN_TOXINS, 100)
+		target_turf.atmos_spawn_air(spawn_contents, spawn_amount)
 		target_turf.air_update_turf()
 	qdel(src)
 
 /obj/item/weapon/grenade/gas/knockout
 	name = "Knockout Grenade"
 	desc = "A grenade that completely removes all air and heat from its detonation area."
-
-/obj/item/weapon/grenade/gas/knockout/prime()
-	var/turf/simulated/target_turf = get_turf(src)
-	if(istype(target_turf))
-		target_turf.atmos_spawn_air(SPAWN_20C | SPAWN_N2O, 100)
-		target_turf.air_update_turf()
-	qdel(src)
-
+	spawn_contents = SPAWN_20C | SPAWN_N2O

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -242,6 +242,16 @@
 	desc = "Reserved for those pesky request."
 	payload = /mob/living/simple_animal/crab
 
+/obj/item/weapon/grenade/clusterbuster/plasma
+	name = "Plasma Cluster Grenade"
+	desc = "For when everything needs to die in a fire."
+	payload = /obj/item/weapon/grenade/gas
+
+/obj/item/weapon/grenade/clusterbuster/n2o
+	name = "N2O Cluster Grenade"
+	desc = "For when you need to knock out EVERYONE."
+	payload = /obj/item/weapon/grenade/gas/knockout
+
 ////////////Clusterbuster of Clusterbusters////////////
 
 /obj/item/weapon/grenade/clusterbuster/mega_fox

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -193,6 +193,6 @@
 	name = "Atmos Grenades"
 
 /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades/New()
-		..()
-		new /obj/item/weapon/grenade/clusterbuster/plasma(src)
-		new /obj/item/weapon/grenade/clusterbuster/n2o(src)
+	..()
+	new /obj/item/weapon/grenade/clusterbuster/plasma(src)
+	new /obj/item/weapon/grenade/clusterbuster/n2o(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -187,3 +187,15 @@
 	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
 	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
 	new /obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/cane(src)
+
+
+/obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades
+	name = "Atmos Grenades"
+
+/obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades/New()
+		..()
+		new /obj/item/weapon/grenade/gas(src)
+		new /obj/item/weapon/grenade/gas/overpressure(src)
+		new /obj/item/weapon/grenade/gas/suffocation(src)
+		new /obj/item/weapon/grenade/gas/vacuum(src)
+		new /obj/item/weapon/grenade/gas/knockout(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -194,8 +194,5 @@
 
 /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades/New()
 		..()
-		new /obj/item/weapon/grenade/gas(src)
-		new /obj/item/weapon/grenade/gas/overpressure(src)
-		new /obj/item/weapon/grenade/gas/suffocation(src)
-		new /obj/item/weapon/grenade/gas/vacuum(src)
-		new /obj/item/weapon/grenade/gas/knockout(src)
+		new /obj/item/weapon/grenade/clusterbuster/plasma(src)
+		new /obj/item/weapon/grenade/clusterbuster/n2o(src)

--- a/paradise.dme
+++ b/paradise.dme
@@ -839,6 +839,7 @@
 #include "code\game\objects\items\weapons\weaponry.dm"
 #include "code\game\objects\items\weapons\whetstone.dm"
 #include "code\game\objects\items\weapons\wires.dm"
+#include "code\game\objects\items\weapons\grenades\atmosgrenade.dm"
 #include "code\game\objects\items\weapons\grenades\bananade.dm"
 #include "code\game\objects\items\weapons\grenades\chem_grenade.dm"
 #include "code\game\objects\items\weapons\grenades\clowngrenade.dm"


### PR DESCRIPTION
Adds atmos grenades, a boxed set of grenades traitors can get via an uplink. 

Each set includes one each of the following:
- A plasma fire grenade, which creates a plasma fire
- A knockout grenade, which spreads N2O throughout an area

They use cluster grenade mechanics to spread more quickly than normal gasses do.

These grenades make it actually viable to kill people with atmos, to deny usage of an area using atmos, to knock people out using atmos, etc.

What purpose does this serve?
- Lets traitors kill people using atmos
- Lets traitors deny (or make difficult) usage of areas (e.g: blocking off a path behind them, trapping someone in an area, etc)
- Gives atmos techs the possibility that they might actually be needed to fix something

:cl: Kyep
add: Added atmos grenade kit to traitor uplink.
/:cl: