### PR TITLE
AI Lawset Change: 'Minimize expenses' becomes 'Maximize profits'

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -95,7 +95,7 @@
 	add_inherent_law("You are expensive to replace.")
 	add_inherent_law("The station and its equipment is expensive to replace.")
 	add_inherent_law("The crew is expensive to replace.")
-	add_inherent_law("Minimize expenses.")
+	add_inherent_law("Maximize profits.")
 	..()
 
 /******************** T.Y.R.A.N.T. ********************/


### PR DESCRIPTION
![](https://skepchick.org/wp-content/uploads/2014/04/quark-ferengi.png)

Does anyone care for those rounds when the AI decides that the infinite power the station is generating needs to be preserved at all costs?

This lawset should be more fun, and I think a good way to do that is shifting the focus away from trying to keep costs down to trying to generate as much profit as possible. You have to spend money to make money, after all.

:cl: Lady-Luck
tweak: Corporate AI's 4th law is now to 'maximize profits' rather than 'minimize expenses'. Rule of Acquisition 62: The riskier the road, the greater the profit.
/:cl: