### PR TITLE
Makes looting/attacking SSD players more obvious

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -171,7 +171,7 @@ proc/add_logs(mob/target, mob/user, what_done, var/object=null, var/addition=nul
 		target.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been [what_done] by [key_name(user)][object ? " with [object]" : " "][addition]</font>")
 	if(admin)
 		log_attack("<font color='red'>[key_name(user)] [what_done] [key_name(target)][object ? " with [object]" : " "][addition]</font>")
-	if(istype(target) && target.client)
+	if(istype(target) && (target.client || target.player_logged))
 		if(what_done in ignore) return
 		if(target == user)return
 		if(!admin) return

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -45,7 +45,7 @@
 	return .
 
 /proc/key_name_admin(var/whom, var/include_name = 1)
-	var/message = "[key_name(whom, 1, include_name)](<A HREF='?_src_=holder;adminmoreinfo=\ref[whom]'>?</A>)[isAntag(whom) ? "(A)" : ""] ([admin_jump_link(whom, "holder")])"
+	var/message = "[key_name(whom, 1, include_name)](<A HREF='?_src_=holder;adminmoreinfo=\ref[whom]'>?</A>)[isAntag(whom) ? "(A)" : ""][isSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom, "holder")])"
 	return message
 
 /proc/log_and_message_admins(var/message as text)
@@ -55,4 +55,3 @@
 /proc/admin_log_and_message_admins(var/message as text)
 	log_admin("[key_name(usr)] " + message)
 	message_admins("[key_name_admin(usr)] " + message, 1)
-	

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -270,14 +270,12 @@
 		msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
 
 	if(species.show_ssd && (!species.has_organ["brain"] || get_int_organ(/obj/item/organ/internal/brain)) && stat != DEAD)
-		if(src.player_logged)
-			msg += "<span class='deadsay'>[t_He] [t_is] fast asleep, suffering from Space Sleep Disorder.</span>\n"
-		else if(istype(src, /mob/living/carbon/human/interactive))
+		if(istype(src, /mob/living/carbon/human/interactive))
 			msg += "<span class='deadsay'>[t_He] appears to be some sort of sick automaton: [t_his] eyes are glazed over and [t_his] mouth is slightly agape.</span>\n"
 		else if(!key)
 			msg += "<span class='deadsay'>[t_He] [t_is] fast asleep. It doesn't look like they are waking up anytime soon.</span>\n"
 		else if(!client)
-			msg += "[t_He] [t_has] suddenly fallen asleep.\n"
+			msg += "[t_He] [t_has] suddenly fallen asleep, suffering from Space Sleep Disorder.\n"
 
 	if(!get_int_organ(/obj/item/organ/internal/brain))
 		msg += "<span class='deadsay'>It appears that [t_his] brain is missing...</span>\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -270,7 +270,9 @@
 		msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
 
 	if(species.show_ssd && (!species.has_organ["brain"] || get_int_organ(/obj/item/organ/internal/brain)) && stat != DEAD)
-		if(istype(src, /mob/living/carbon/human/interactive))
+		if(src.player_logged)
+			msg += "<span class='deadsay'>[t_He] [t_is] fast asleep, suffering from Space Sleep Disorder.</span>\n"
+		else if(istype(src, /mob/living/carbon/human/interactive))
 			msg += "<span class='deadsay'>[t_He] appears to be some sort of sick automaton: [t_his] eyes are glazed over and [t_his] mouth is slightly agape.</span>\n"
 		else if(!key)
 			msg += "<span class='deadsay'>[t_He] [t_is] fast asleep. It doesn't look like they are waking up anytime soon.</span>\n"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -672,8 +672,6 @@
 			if(silent)
 				put_in_hands(what)
 			add_logs(who, src, "stripped", addition="of [what]")
-			if(who.player_logged)
-				to_chat(src,"<span class='adminhelp'>Warning: looting from SSD players (like [who]) is forbidden unless you have ahelped first and got permission.</span>")
 
 // The src mob is trying to place an item on someone
 // Override if a certain mob should be behave differently when placing items (can't, for example)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -672,6 +672,8 @@
 			if(silent)
 				put_in_hands(what)
 			add_logs(who, src, "stripped", addition="of [what]")
+			if(who.player_logged)
+				to_chat(src,"<span class='adminhelp'>Warning: looting from SSD players (like [who]) is forbidden unless you have ahelped first and got permission.</span>")
 
 // The src mob is trying to place an item on someone
 // Override if a certain mob should be behave differently when placing items (can't, for example)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -34,12 +34,8 @@
 			return 1
 	return 0
 
-proc/isSSD(A)
-	if(istype(A, /mob))
-		var/mob/M = A
-		if(M.player_logged)
-			return 1
-	return 0
+proc/isSSD(mob/M)
+	return istype(M) && M.player_logged
 
 proc/isAntag(A)
 	if(istype(A, /mob/living/carbon))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -34,6 +34,13 @@
 			return 1
 	return 0
 
+proc/isSSD(A)
+	if(istype(A,/mob))
+		var/mob/M = A
+		if (M.player_logged)
+			return 1
+	return 0
+
 proc/isAntag(A)
 	if(istype(A, /mob/living/carbon))
 		var/mob/living/carbon/C = A

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -35,9 +35,9 @@
 	return 0
 
 proc/isSSD(A)
-	if(istype(A,/mob))
+	if(istype(A, /mob))
 		var/mob/M = A
-		if (M.player_logged)
+		if(M.player_logged)
 			return 1
 	return 0
 


### PR DESCRIPTION
This PR attempts to reduce the problem of people looting from SSDs.

Changes made:
1) Ensures admins still see attack notices against mobs which have no client, BUT are logged_out players. (code\__HELPERS\mobs.dm)
2) Ensures that these attack logs, when seen by admins, have a nice red '(SSD!)' in them next to the name of the SSD player. (code\defines\procs\admin.dm, code\modules\mob\mob_helpers.dm)
~~3) Ensures that when one player goes to strip an item from a SSD player, they get the message: "Warning: looting from SSD players (like [theirname]) is forbidden unless you have ahelped first and got permission." (code\modules\mob\living\living.dm)~~ This bit was taken out because Fox did not like it.
4) Ensures SSD players have "suffering from Space Sleep Disorder" in their on-examine description. Those exact words, to prevent any possible confusion about what kinds of "sleeping" count as SSD. (code/modules/mob/living/carbon/human/examine.dm
)

:cl: Kyep
rscadd: Admins can now see attacks against SSD players more easily.
tweak: Clarified the text you get when examining a SSD player.
/:cl: