### PR TITLE
Fixes Brig Door Timers

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -31,15 +31,15 @@
 	maptext_height = 26
 	maptext_width = 32
 
-/obj/machinery/door_timer/New()
+/obj/machinery/door_timer/initialize()
 	..()
 
 	Radio = new /obj/item/device/radio(src)
 	Radio.listening = 0
 	Radio.config(list("Security" = 0))
 
-	pixel_x = ((src.dir & 3)? (0) : (src.dir == 4 ? 32 : -32))
-	pixel_y = ((src.dir & 3)? (src.dir ==1 ? 24 : -32) : (0))
+	pixel_x = ((dir & 3)? (0) : (dir == 4 ? 32 : -32))
+	pixel_y = ((dir & 3)? (dir ==1 ? 24 : -32) : (0))
 
 	spawn(20)
 		for(var/obj/machinery/door/window/brigdoor/M in airlocks)
@@ -53,7 +53,7 @@
 		for(var/obj/structure/closet/secure_closet/brig/C in world)
 			if(C.id == id)
 				targets += C
-		
+
 		for(var/obj/machinery/treadmill_monitor/T in machines)
 			if(T.id == id)
 				targets += T
@@ -61,15 +61,14 @@
 		if(targets.len==0)
 			stat |= BROKEN
 		update_icon()
-		return
-	return
 
 
 //Main door timer loop, if it's timing and time is >0 reduce time by 1.
 // if it's less than 0, open door, reset timer
 // update the door_timer window and the icon
 /obj/machinery/door_timer/process()
-	if(stat & (NOPOWER|BROKEN))	return
+	if(stat & (NOPOWER|BROKEN))
+		return
 	if(timing)
 		if(timeleft() <= 0)
 			Radio.autosay("Timer has expired. Releasing prisoner.", name, "Security", list(z))
@@ -77,8 +76,8 @@
 			timing = 0
 			. = PROCESS_KILL
 
-		src.updateUsrDialog()
-		src.update_icon()
+		updateUsrDialog()
+		update_icon()
 	else
 		timer_end()
 		return PROCESS_KILL
@@ -87,7 +86,6 @@
 /obj/machinery/door_timer/power_change()
 	..()
 	update_icon()
-	return
 
 
 // open/closedoor checks if door_timer has power, if so it checks if the
@@ -95,7 +93,8 @@
 
 // Closes and locks doors, power check
 /obj/machinery/door_timer/proc/timer_start()
-	if(stat & (NOPOWER|BROKEN))	return 0
+	if(stat & (NOPOWER|BROKEN))
+		return 0
 
 	// Set releasetime
 	releasetime = world.timeofday + timetoset
@@ -103,16 +102,19 @@
 		addAtProcessing()
 
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
-		if(door.density)	continue
+		if(door.density)
+			continue
 		spawn(0)
 			door.close()
 
 	for(var/obj/structure/closet/secure_closet/brig/C in targets)
-		if(C.broken)	continue
-		if(C.opened && !C.close())	continue
+		if(C.broken)
+			continue
+		if(C.opened && !C.close())
+			continue
 		C.locked = 1
 		C.icon_state = C.icon_locked
-		
+
 	for(var/obj/machinery/treadmill_monitor/T in targets)
 		T.total_joules = 0
 		T.on = 1
@@ -122,19 +124,23 @@
 
 // Opens and unlocks doors, power check
 /obj/machinery/door_timer/proc/timer_end()
-	if(stat & (NOPOWER|BROKEN))	return 0
+	if(stat & (NOPOWER|BROKEN))
+		return 0
 
 	// Reset releasetime
 	releasetime = 0
 
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
-		if(!door.density)	continue
+		if(!door.density)
+			continue
 		spawn(0)
 			door.open()
 
 	for(var/obj/structure/closet/secure_closet/brig/C in targets)
-		if(C.broken)	continue
-		if(C.opened)	continue
+		if(C.broken)
+			continue
+		if(C.opened)
+			continue
 		C.locked = 0
 		C.icon_state = C.icon_closed
 
@@ -156,7 +162,7 @@
 	return time / 10
 
 // Set timetoset
-/obj/machinery/door_timer/proc/timeset(var/seconds)
+/obj/machinery/door_timer/proc/timeset(seconds)
 	timetoset = seconds * 10
 
 	if(timetoset <= 0)
@@ -165,15 +171,15 @@
 	return
 
 //Allows AIs to use door_timer, see human attack_hand function below
-/obj/machinery/door_timer/attack_ai(var/mob/user as mob)
-	return src.attack_hand(user)
+/obj/machinery/door_timer/attack_ai(mob/user)
+	return attack_hand(user)
 
 
 //Allows humans to use door_timer
 //Opens dialog window when someone clicks on door timer
 // Allows altering timer and the timing boolean.
 // Flasher activation limited to 150 seconds
-/obj/machinery/door_timer/attack_hand(var/mob/user as mob)
+/obj/machinery/door_timer/attack_hand(mob/user)
 	if(..())
 		return
 
@@ -189,10 +195,10 @@
 
 	// dat
 	var/dat = "<HR>Timer System:</hr>"
-	dat += " <b>Door [src.id] controls</b><br/>"
+	dat += " <b>Door [id] controls</b><br/>"
 
 	// Start/Stop timer
-	if(src.timing)
+	if(timing)
 		dat += "<a href='?src=\ref[src];timing=0'>Stop Timer and open door</a><br/>"
 	else
 		dat += "<a href='?src=\ref[src];timing=1'>Activate Timer and close door</a><br/>"
@@ -202,7 +208,7 @@
 	dat += "<br/>"
 
 	// Set Timer display (uses timetoset)
-	if(src.timing)
+	if(timing)
 		dat += "Set Timer: [(setminute ? text("[setminute]:") : null)][setsecond]  <a href='?src=\ref[src];change=1'>Set</a><br/>"
 	else
 		dat += "Set Timer: [(setminute ? text("[setminute]:") : null)][setsecond]<br/>"
@@ -222,7 +228,6 @@
 	var/datum/browser/popup = new(user, "door_timer", name, 400, 500)
 	popup.set_content(dat)
 	popup.open()
-	return
 
 
 //Function for using door_timer dialog input, checks if user has permission
@@ -235,18 +240,18 @@
 /obj/machinery/door_timer/Topic(href, href_list)
 	if(..())
 		return
-	if(!src.allowed(usr))
+	if(!allowed(usr))
 		return
 
 	usr.set_machine(src)
 
 	if(href_list["timing"])
-		src.timing = text2num(href_list["timing"])
+		timing = text2num(href_list["timing"])
 
-		if(src.timing)
-			src.timer_start()
+		if(timing)
+			timer_start()
 		else
-			src.timer_end()
+			timer_end()
 
 	else
 		if(href_list["tp"])  //adjust timer, close door if not already closed
@@ -262,19 +267,11 @@
 				F.flash()
 
 		if(href_list["change"])
-			src.timer_start()
+			timer_start()
 
-	src.add_fingerprint(usr)
-	src.updateUsrDialog()
-	src.update_icon()
-
-	/* if(src.timing)
-		src.timer_start()
-
-	else
-		src.timer_end() */
-
-	return
+	add_fingerprint(usr)
+	updateUsrDialog()
+	update_icon()
 
 
 //icon update function
@@ -288,7 +285,7 @@
 	if(stat & (BROKEN))
 		set_picture("ai_bsod")
 		return
-	if(src.timing)
+	if(timing)
 		var/disp1 = id
 		var/timeleft = timeleft()
 		var/disp2 = "[add_zero(num2text((timeleft / 60) % 60),2)]~[add_zero(num2text(timeleft % 60), 2)]"
@@ -297,11 +294,10 @@
 		update_display(disp1, disp2)
 	else
 		if(maptext)	maptext = ""
-	return
 
 
 // Adds an icon in case the screen is broken/off, stolen from status_display.dm
-/obj/machinery/door_timer/proc/set_picture(var/state)
+/obj/machinery/door_timer/proc/set_picture(state)
 	picture_state = state
 	overlays.Cut()
 	overlays += image('icons/obj/status_display.dmi', icon_state=picture_state)
@@ -309,7 +305,7 @@
 
 //Checks to see if there's 1 line or 2, adds text-icons-numbers/letters over display
 // Stolen from status_display
-/obj/machinery/door_timer/proc/update_display(var/line1, var/line2)
+/obj/machinery/door_timer/proc/update_display(line1, line2)
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text
@@ -317,7 +313,7 @@
 
 //Actual string input to icon display for loop, with 5 pixel x offsets for each letter.
 //Stolen from status_display
-/obj/machinery/door_timer/proc/texticon(var/tn, var/px = 0, var/py = 0)
+/obj/machinery/door_timer/proc/texticon(tn, px = 0, py = 0)
 	var/image/I = image('icons/obj/status_display.dmi', "blank")
 	var/len = lentext(tn)
 


### PR DESCRIPTION
Fixes Brig cell timers not allowing you to flash people*

*note: manually flashing prisoners by the removing of processing officers close was never prevented by this bug, though effectiveness may vary.

fixes https://github.com/ParadiseSS13/Paradise/issues/5139

:cl: Fox McCloud
fix: Fixes brig cell timers not having the option to flash people
/:cl: