### PR TITLE
Vox Raider Check Kills for Inviolate

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -806,7 +806,7 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 
 		var/datum/game_mode/heist/H = ticker.mode
 		for(var/datum/mind/raider in H.raiders)
-			vox_total_kills = vox_total_kills + raider.kills.len // Kills are listed in the mind; uses this to calculate vox kills
+			vox_total_kills += raider.kills.len // Kills are listed in the mind; uses this to calculate vox kills
 
 		if(vox_total_kills > vox_allowed_kills) return 0
 		return 1

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -799,7 +799,17 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 
 /datum/objective/heist/inviolate_death
 	explanation_text = "Follow the Inviolate. Minimise death and loss of resources."
-	completed = 1
+
+	check_completion()
+		var/vox_allowed_kills = 3 // The number of people the vox can accidently kill. Mostly a counter to people killing themselves if a raider touches them to force fail.
+		var/vox_total_kills = 0
+
+		var/datum/game_mode/heist/H = ticker.mode
+		for(var/datum/mind/raider in H.raiders)
+			vox_total_kills = vox_total_kills + raider.kills.len // Kills are listed in the mind; uses this to calculate vox kills
+
+		if(vox_total_kills > vox_allowed_kills) return 0
+		return 1
 
 // Traders
 


### PR DESCRIPTION
Effectively, adds the check that makes it so you aren't allowed to kill (many, at least) under the Inviolate. Doesn't check for deaths in the server itself, only kills in the raiders minds, which the original code failed to do by adding all deaths to voxkills. As we currently have, it's a auto-complete objective, which is just a poor fix to the original issue.

```var/vox_allowed_kills = 3``` gives them a little leeway, but can easily be changed to any acceptable number.

:cl: Twinmold
Tweak: Vox Objective 4 now calculates the kills vox raiders actually have, instead of always complete.
/:cl: