### PR TITLE
Alt Click Madness

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -67,7 +67,6 @@
 		return
 
 /obj/structure/stool/bed/chair/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -66,6 +66,16 @@
 		handle_rotation()
 		return
 
+/obj/structure/stool/bed/chair/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user))
+		return
+	else
+		rotate()
+
 // Chair types
 /obj/structure/stool/bed/chair/wood
 	// TODO:  Special ash subtype that looks like charred chair legs

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -71,10 +71,9 @@
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
+	if(!Adjacent(user))
 		return
-	else
-		rotate()
+	rotate()
 
 // Chair types
 /obj/structure/stool/bed/chair/wood

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -323,7 +323,6 @@ obj/structure/windoor_assembly/Destroy()
 	return
 
 /obj/structure/windoor_assembly/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -322,6 +322,16 @@ obj/structure/windoor_assembly/Destroy()
 	update_icon()
 	return
 
+/obj/structure/windoor_assembly/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		user << "<span class='warning'>You can't do that right now!</span>"
+		return
+	if(!in_range(src, user))
+		return
+	else
+		revrotate()
+
 //Flips the windoor assembly, determines whather the door opens to the left or the right
 /obj/structure/windoor_assembly/verb/flip()
 	set name = "Flip Windoor Assembly"

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -325,12 +325,11 @@ obj/structure/windoor_assembly/Destroy()
 /obj/structure/windoor_assembly/AltClick(mob/user)
 	..()
 	if(user.incapacitated())
-		user << "<span class='warning'>You can't do that right now!</span>"
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
+	if(!Adjacent(user))
 		return
-	else
-		revrotate()
+	revrotate()
 
 //Flips the windoor assembly, determines whather the door opens to the left or the right
 /obj/structure/windoor_assembly/verb/flip()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -323,10 +323,9 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
+	if(!Adjacent(user))
 		return
-	else
-		revrotate()
+	revrotate()
 
 /*
 /obj/structure/window/proc/updateSilicate()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -318,6 +318,16 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	return
 
 
+/obj/structure/window/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user))
+		return
+	else
+		revrotate()
+
 /*
 /obj/structure/window/proc/updateSilicate()
 	if(silicateIcon && silicate)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -319,7 +319,6 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 
 
 /obj/structure/window/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -300,15 +300,16 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	else
 		to_chat(usr, "<span class='notice'>You cannot do this while restrained.</span>")
 
-/obj/item/device/pda/AltClick()
+/obj/item/device/pda/AltClick(mob/user)
+	..()
 	if(issilicon(usr))
 		return
 
-	if(can_use(usr))
+	if(can_use(user))
 		if(id)
 			remove_id()
 		else
-			usr << "<span class='warning'>This PDA does not have an ID in it!</span>"
+			to_chat(user, "<span class='warning'>This PDA does not have an ID in it!</span>")
 
 /obj/item/device/pda/proc/remove_id()
 	if(id)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -70,6 +70,16 @@
 	src.dir = turn(src.dir, 90)
 	return 1
 
+/obj/machinery/power/emitter/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user))
+		return
+	else
+		rotate()
+
 /obj/machinery/power/emitter/initialize()
 	..()
 	if(state == 2 && anchored)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -71,7 +71,6 @@
 	return 1
 
 /obj/machinery/power/emitter/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -75,10 +75,9 @@
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
+	if(!Adjacent(user))
 		return
-	else
-		rotate()
+	rotate()
 
 /obj/machinery/power/emitter/initialize()
 	..()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -102,7 +102,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	return 1
 
 /obj/structure/particle_accelerator/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -106,10 +106,9 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	if(user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
+	if(!Adjacent(user))
 		return
-	else
-		rotate()
+	rotate()
 
 /obj/structure/particle_accelerator/verb/rotateccw()
 	set name = "Rotate Counter Clockwise"

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -101,6 +101,16 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	src.dir = turn(src.dir, 270)
 	return 1
 
+/obj/structure/particle_accelerator/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user))
+		return
+	else
+		rotate()
+
 /obj/structure/particle_accelerator/verb/rotateccw()
 	set name = "Rotate Counter Clockwise"
 	set category = "Object"

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -101,10 +101,9 @@
 	if(user.incapacitated())
 		to_chat(user << "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user))
+	if(!Adjacent(user))
 		return
-	else
-		rotate()
+	rotate()
 
 /obj/structure/disposalconstruct/verb/flip()
 	set name = "Flip Pipe"

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -96,6 +96,16 @@
 	dir = turn(dir, -90)
 	update()
 
+/obj/structure/disposalconstruct/AltClick(mob/user)
+	..()
+	if(user.incapacitated())
+		to_chat(user << "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user))
+		return
+	else
+		rotate()
+
 /obj/structure/disposalconstruct/verb/flip()
 	set name = "Flip Pipe"
 	set src in view(1)

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -97,7 +97,6 @@
 	update()
 
 /obj/structure/disposalconstruct/AltClick(mob/user)
-	..()
 	if(user.incapacitated())
 		to_chat(user << "<span class='warning'>You can't do that right now!</span>")
 		return


### PR DESCRIPTION
Adds a number of alt click behaviors to some commonly used verbs (that are otherwise annoying to use).

- Adds AltClick rotating of:
 - Chairs
 - Disposal pipes
 - Windows
 - The PA
 - Emitters
 - Windoor Assemblies

Now you don't have to right click or rely on your crummy objects verb for some of these tasks

:cl: Fox McCloud
add: adds alt-click rotating of chairs, disposal pipes, windows, the PA, emitters, and windoor assemblies
/:cl: