### PR TITLE
Removes Cablecuffs...

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -65,8 +65,8 @@
 /obj/item/weapon/restraints/handcuffs/cable
 	name = "cable restraints"
 	desc = "Looks like some cables tied together. Could be used to tie something up."
-	icon_state = "cuff_white"
-	item_state = "coil_red"
+	icon_state = "cuff_red"
+	materials = list(MAT_METAL=150, MAT_GLASS=75)
 	breakouttime = 300 //Deciseconds = 30s
 	cuffsound = 'sound/weapons/cablecuff.ogg'
 
@@ -122,6 +122,7 @@
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
 	icon_state = "cuff_white"
 	breakouttime = 450 //Deciseconds = 45s
+	materials = list()
 	trashtype = /obj/item/weapon/restraints/handcuffs/cable/zipties/used
 
 /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg/attack(mob/living/carbon/C, mob/user)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -457,10 +457,15 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 #define MAXCOIL 30
 
+var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
+	new/datum/stack_recipe("cable restraints", /obj/item/weapon/restraints/handcuffs/cable, 15), \
+	)
+
 /obj/item/stack/cable_coil
 	name = "cable coil"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "coil"
+	item_state = "coil_red"
 	amount = MAXCOIL
 	max_amount = MAXCOIL
 	color = COLOR_RED
@@ -492,6 +497,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	pixel_x = rand(-2,2)
 	pixel_y = rand(-2,2)
 	update_icon()
+	recipes = cable_coil_recipes
 	update_wclass()
 
 ///////////////////////////////////
@@ -556,37 +562,12 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	else
 		to_chat(user, "A coil of power cable. There are [get_amount()] lengths of cable in the coil.")
 
-
-/obj/item/stack/cable_coil/verb/make_restraint()
-	set name = "Make Cable Restraints"
-	set category = "Object"
-	var/mob/M = usr
-
-	if(ishuman(M) && !M.restrained() && !M.stat && !M.paralysis && ! M.stunned)
-		if(!istype(usr.loc,/turf)) return
-		if(src.amount <= 14)
-			to_chat(usr, "<span class='warning'>You need at least 15 lengths to make restraints!</span>")
-			return
-		var/obj/item/weapon/restraints/handcuffs/cable/B = new /obj/item/weapon/restraints/handcuffs/cable(usr.loc)
-		B.color = color
-		to_chat(usr, "<span class='notice'>You wind some cable together to make some restraints.</span>")
-		src.use(15)
-	else
-		to_chat(usr, "<span class='warning'>You cannot do that.</span>")
-	..()
-
 // Items usable on a cable coil :
 //   - Wirecutters : cut them duh !
 //   - Cable coil : merge cables
 /obj/item/stack/cable_coil/attackby(obj/item/weapon/W, mob/user)
 	..()
-	if( istype(W, /obj/item/weapon/wirecutters) && src.amount > 1)
-		src.amount--
-		new/obj/item/stack/cable_coil(user.loc, 1,color)
-		to_chat(user, "You cut a piece off the cable coil.")
-		src.update_icon()
-		return
-	else if(istype(W, /obj/item/stack/cable_coil))
+	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
 		if(C.amount >= MAXCOIL)
 			to_chat(user, "The coil is too long, you cannot add any more cable to it.")


### PR DESCRIPTION
Object creation verb. :wink: 

Joke and shameless port of: https://github.com/tgstation/tgstation/pull/9821

- Removes wirecutter snipping of coils (you can just click it on your hand to accomplish this)
- Attack-selfing the cable stack will bring up a crafting menu where you can make cuffs
 - Greater consistency with all other stacks and one less stupid object verb
- Fixes cable coils not having an in-hand icon
- Fixes cable cuffs not having an in-hand icon
- All cablecuffs will now be red (oh well--there's no way to fix this)
- Fixes an unlimited metal exploit

:cl: Fox McCloud
tweak: Cablecuffs are now made by opening the cable stack's crafting menu by using it in your hand
Fix: Fixes cablecuffs not having a unique in-hand icon
Fixes: Fixes cable coils not having a unique in-hand icon
tweak: All cablecuffs will be red, regardless of what they're produced from
fix: Fixes an unlimited metal exploit
/:cl: