### PR TITLE
Voting System Improvements and Fixes

### DIFF
--- a/code/controllers/Processes/vote.dm
+++ b/code/controllers/Processes/vote.dm
@@ -1,7 +1,0 @@
-/datum/controller/process/vote/setup()
-	name = "vote"
-	schedule_interval = 10 // every second
-	log_startup_progress("Voting ticker starting up.")
-
-/datum/controller/process/vote/doWork()
-	vote.process()

--- a/code/controllers/verbs.dm
+++ b/code/controllers/verbs.dm
@@ -18,7 +18,7 @@
 	return
 
 
-/client/proc/debug_controller(controller in list("Master","failsafe","Ticker","Air","Lighting","Jobs","Sun","Radio","Configuration","pAI", "Cameras","Garbage", "Transfer Controller","Event","Alarm","Scheduler","Nano"))
+/client/proc/debug_controller(controller in list("Master","failsafe","Ticker","Air","Lighting","Jobs","Sun","Radio","Configuration","pAI", "Cameras","Garbage", "Transfer Controller","Event","Alarm","Scheduler","Nano","Vote"))
 	set category = "Debug"
 	set name = "Debug Controller"
 	set desc = "Debug the various periodic loop controllers for the game (be careful!)"
@@ -73,6 +73,9 @@
 		if("Nano")
 			debug_variables(nanomanager)
 			feedback_add_details("admin_verb","DNano")
+		if("Vote")
+			debug_variables(vote)
+			feedback_add_details("admin_verb","DVote")
 
 	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")
 	return

--- a/code/controllers/voting.dm
+++ b/code/controllers/voting.dm
@@ -2,7 +2,7 @@ var/datum/controller/vote/vote = new()
 
 var/global/list/round_voters = list() //Keeps track of the individuals voting for a given round, for use in forcedrafting.
 
-datum/controller/vote
+/datum/controller/vote
 	var/initiator = null
 	var/started_time = null
 	var/time_remaining = 0
@@ -14,340 +14,340 @@ datum/controller/vote
 	var/list/current_votes = list()
 	var/auto_muted = 0
 
-	New()
-		if(vote != src)
-			if(istype(vote))
-				qdel(vote)
-			vote = src
+/datum/controller/vote/New()
+	if(vote != src)
+		if(istype(vote))
+			qdel(vote)
+		vote = src
 
-	proc/process()	//called by master_controller
-		if(mode)
-			// No more change mode votes after the game has started.
-			// 3 is GAME_STATE_PLAYING, but that #define is undefined for some reason
-			if(mode == "gamemode" && ticker.current_state >= 2)
-				to_chat(world, "<b>Voting aborted due to game start.</b>")
-				src.reset()
-				return
+/datum/controller/vote/proc/process()	//called by master_controller
+	if(mode)
+		// No more change mode votes after the game has started.
+		// 3 is GAME_STATE_PLAYING, but that #define is undefined for some reason
+		if(mode == "gamemode" && ticker.current_state >= 2)
+			to_chat(world, "<b>Voting aborted due to game start.</b>")
+			src.reset()
+			return
 
-			// Calculate how much time is remaining by comparing current time, to time of vote start,
-			// plus vote duration
-			time_remaining = round((started_time + config.vote_period - world.time)/10)
+		// Calculate how much time is remaining by comparing current time, to time of vote start,
+		// plus vote duration
+		time_remaining = round((started_time + config.vote_period - world.time)/10)
 
-			if(time_remaining < 0)
-				result()
-				for(var/client/C in voting)
-					if(C)
-						C << browse(null,"window=vote;can_close=0")
-				reset()
-			else
-				for(var/client/C in voting)
-					if(C)
-						C << browse(vote.interface(C),"window=vote;can_close=0")
+		if(time_remaining < 0)
+			result()
+			for(var/client/C in voting)
+				if(C)
+					C << browse(null,"window=vote;can_close=0")
+			reset()
+		else
+			for(var/client/C in voting)
+				if(C)
+					C << browse(vote.interface(C),"window=vote;can_close=0")
 
-				voting.Cut()
+			voting.Cut()
 
-	proc/autotransfer()
-		initiate_vote("crew_transfer","the server")
+/datum/controller/vote/proc/autotransfer()
+	initiate_vote("crew_transfer","the server")
 
-	proc/reset()
-		initiator = null
-		time_remaining = 0
-		mode = null
-		question = null
-		choices.Cut()
-		voted.Cut()
-		voting.Cut()
-		current_votes.Cut()
+/datum/controller/vote/proc/reset()
+	initiator = null
+	time_remaining = 0
+	mode = null
+	question = null
+	choices.Cut()
+	voted.Cut()
+	voting.Cut()
+	current_votes.Cut()
 
-		if(auto_muted && !config.ooc_allowed)
-			auto_muted = 0
-			config.ooc_allowed = !( config.ooc_allowed )
-			to_chat(world, "<b>The OOC channel has been automatically enabled due to vote end.</b>")
-			log_admin("OOC was toggled automatically due to vote end.")
-			message_admins("OOC has been toggled on automatically.")
+	if(auto_muted && !config.ooc_allowed)
+		auto_muted = 0
+		config.ooc_allowed = !( config.ooc_allowed )
+		to_chat(world, "<b>The OOC channel has been automatically enabled due to vote end.</b>")
+		log_admin("OOC was toggled automatically due to vote end.")
+		message_admins("OOC has been toggled on automatically.")
 
 
-	proc/get_result()
-		//get the highest number of votes
-		var/greatest_votes = 0
-		var/total_votes = 0
+/datum/controller/vote/proc/get_result()
+	//get the highest number of votes
+	var/greatest_votes = 0
+	var/total_votes = 0
+	for(var/option in choices)
+		var/votes = choices[option]
+		total_votes += votes
+		if(votes > greatest_votes)
+			greatest_votes = votes
+	//default-vote for everyone who didn't vote
+	if(!config.vote_no_default && choices.len)
+		var/non_voters = (clients.len - total_votes)
+		if(non_voters > 0)
+			if(mode == "restart")
+				choices["Continue Playing"] += non_voters
+				if(choices["Continue Playing"] >= greatest_votes)
+					greatest_votes = choices["Continue Playing"]
+			else if(mode == "gamemode")
+				if(master_mode in choices)
+					choices[master_mode] += non_voters
+					if(choices[master_mode] >= greatest_votes)
+						greatest_votes = choices[master_mode]
+			else if(mode == "crew_transfer")
+				var/factor = 0.5
+				switch(world.time / (10 * 60)) // minutes
+					if(0 to 60)
+						factor = 0.5
+					if(61 to 120)
+						factor = 0.8
+					if(121 to 240)
+						factor = 1
+					if(241 to 300)
+						factor = 1.2
+					else
+						factor = 1.4
+				choices["Initiate Crew Transfer"] = round(choices["Initiate Crew Transfer"] * factor)
+				to_chat(world, "<font color='purple'>Crew Transfer Factor: [factor]</font>")
+				greatest_votes = max(choices["Initiate Crew Transfer"], choices["Continue The Round"])
+
+
+	//get all options with that many votes and return them in a list
+	. = list()
+	if(greatest_votes)
 		for(var/option in choices)
-			var/votes = choices[option]
-			total_votes += votes
-			if(votes > greatest_votes)
-				greatest_votes = votes
-		//default-vote for everyone who didn't vote
-		if(!config.vote_no_default && choices.len)
-			var/non_voters = (clients.len - total_votes)
-			if(non_voters > 0)
-				if(mode == "restart")
-					choices["Continue Playing"] += non_voters
-					if(choices["Continue Playing"] >= greatest_votes)
-						greatest_votes = choices["Continue Playing"]
-				else if(mode == "gamemode")
-					if(master_mode in choices)
-						choices[master_mode] += non_voters
-						if(choices[master_mode] >= greatest_votes)
-							greatest_votes = choices[master_mode]
-				else if(mode == "crew_transfer")
-					var/factor = 0.5
-					switch(world.time / (10 * 60)) // minutes
-						if(0 to 60)
-							factor = 0.5
-						if(61 to 120)
-							factor = 0.8
-						if(121 to 240)
-							factor = 1
-						if(241 to 300)
-							factor = 1.2
-						else
-							factor = 1.4
-					choices["Initiate Crew Transfer"] = round(choices["Initiate Crew Transfer"] * factor)
-					to_chat(world, "<font color='purple'>Crew Transfer Factor: [factor]</font>")
-					greatest_votes = max(choices["Initiate Crew Transfer"], choices["Continue The Round"])
+			if(choices[option] == greatest_votes)
+				. += option
+	return .
 
+/datum/controller/vote/proc/announce_result()
+	var/list/winners = get_result()
+	var/text
+	if(winners.len > 0)
+		if(winners.len > 1)
+			if(mode != "gamemode" || ticker.hide_mode == 0) // Here we are making sure we don't announce potential game modes
+				text = "<b>Vote Tied Between:</b>\n"
+				for(var/option in winners)
+					text += "\t[option]\n"
+		. = pick(winners)
 
-		//get all options with that many votes and return them in a list
-		. = list()
-		if(greatest_votes)
-			for(var/option in choices)
-				if(choices[option] == greatest_votes)
-					. += option
-		return .
-
-	proc/announce_result()
-		var/list/winners = get_result()
-		var/text
-		if(winners.len > 0)
-			if(winners.len > 1)
-				if(mode != "gamemode" || ticker.hide_mode == 0) // Here we are making sure we don't announce potential game modes
-					text = "<b>Vote Tied Between:</b>\n"
-					for(var/option in winners)
-						text += "\t[option]\n"
-			. = pick(winners)
-
-			for(var/key in current_votes)
-				if(choices[current_votes[key]] == .)
-					round_voters += key // Keep track of who voted for the winning round.
-			if((mode == "gamemode" && . == "extended") || ticker.hide_mode == 0) // Announce Extended gamemode, but not other gamemodes
+		for(var/key in current_votes)
+			if(choices[current_votes[key]] == .)
+				round_voters += key // Keep track of who voted for the winning round.
+		if((mode == "gamemode" && . == "extended") || ticker.hide_mode == 0) // Announce Extended gamemode, but not other gamemodes
+			text += "<b>Vote Result: [.]</b>"
+		else
+			if(mode != "gamemode")
 				text += "<b>Vote Result: [.]</b>"
 			else
-				if(mode != "gamemode")
-					text += "<b>Vote Result: [.]</b>"
-				else
-					text += "<b>The vote has ended.</b>" // What will be shown if it is a gamemode vote that isn't extended
+				text += "<b>The vote has ended.</b>" // What will be shown if it is a gamemode vote that isn't extended
 
-		else
-			text += "<b>Vote Result: Inconclusive - No Votes!</b>"
-		log_vote(text)
-		to_chat(world, "<font color='purple'>[text]</font>")
-		return .
+	else
+		text += "<b>Vote Result: Inconclusive - No Votes!</b>"
+	log_vote(text)
+	to_chat(world, "<font color='purple'>[text]</font>")
+	return .
 
-	proc/result()
-		. = announce_result()
-		var/restart = 0
-		if(.)
-			switch(mode)
-				if("restart")
-					if(. == "Restart Round")
-						restart = 1
-				if("gamemode")
-					if(master_mode != .)
-						world.save_mode(.)
-						if(ticker && ticker.mode)
-							restart = 1
-						else
-							master_mode = .
-					if(!going)
-						going = 1
-						to_chat(world, "<font color='red'><b>The round will start soon.</b></font>")
-				if("crew_transfer")
-					if(. == "Initiate Crew Transfer")
-						init_shift_change(null, 1)
-
-
-		if(restart)
-			world.Reboot("Restart vote successful.", "end_error", "restart vote")
-
-		return .
-
-	proc/submit_vote(var/ckey, var/vote)
-		if(mode)
-			if(config.vote_no_dead && usr.stat == DEAD && !usr.client.holder)
-				return 0
-			if(current_votes[ckey])
-				choices[choices[current_votes[ckey]]]--
-			if(vote && 1<=vote && vote<=choices.len)
-				voted += usr.ckey
-				choices[choices[vote]]++	//check this
-				current_votes[ckey] = vote
-				return vote
-		return 0
-
-	proc/initiate_vote(var/vote_type, var/initiator_key)
-		if(!mode)
-			if(started_time != null && !check_rights(R_ADMIN))
-				var/next_allowed_time = (started_time + config.vote_delay)
-				if(next_allowed_time > world.time)
-					return 0
-
-			reset()
-			switch(vote_type)
-				if("restart")
-					choices.Add("Restart Round","Continue Playing")
-				if("gamemode")
-					if(ticker.current_state >= 2)
-						return 0
-					choices.Add(config.votable_modes)
-				if("crew_transfer")
-					if(check_rights(R_ADMIN|R_MOD))
-						if(ticker.current_state <= 2)
-							return 0
-						question = "End the shift?"
-						choices.Add("Initiate Crew Transfer", "Continue The Round")
-					else
-						if(ticker.current_state <= 2)
-							return 0
-						question = "End the shift?"
-						choices.Add("Initiate Crew Transfer", "Continue The Round")
-				if("custom")
-					question = html_encode(input(usr,"What is the vote for?") as text|null)
-					if(!question)	return 0
-					for(var/i=1,i<=10,i++)
-						var/option = capitalize(html_encode(input(usr,"Please enter an option or hit cancel to finish") as text|null))
-						if(!option || mode || !usr.client)	break
-						choices.Add(option)
-				else			return 0
-			mode = vote_type
-			initiator = initiator_key
-			started_time = world.time
-			var/text = "[capitalize(mode)] vote started by [initiator]."
-			if(mode == "custom")
-				text += "\n[question]"
-
-			log_vote(text)
-			to_chat(world, "<font color='purple'><b>[text]</b>\nType vote to place your votes.\nYou have [config.vote_period/10] seconds to vote.</font>")
-			switch(vote_type)
-				if("crew_transfer")
-					world << sound('sound/ambience/alarm4.ogg')
-				if("gamemode")
-					world << sound('sound/ambience/alarm4.ogg')
-				if("custom")
-					world << sound('sound/ambience/alarm4.ogg')
-			if(mode == "gamemode" && going)
-				going = 0
-				to_chat(world, "<font color='red'><b>Round start has been delayed.</b></font>")
-			if(mode == "crew_transfer" && config.ooc_allowed)
-				auto_muted = 1
-				config.ooc_allowed = !( config.ooc_allowed )
-				to_chat(world, "<b>The OOC channel has been automatically disabled due to a crew transfer vote.</b>")
-				log_admin("OOC was toggled automatically due to crew_transfer vote.")
-				message_admins("OOC has been toggled off automatically.")
-			if(mode == "gamemode" && config.ooc_allowed)
-				auto_muted = 1
-				config.ooc_allowed = !( config.ooc_allowed )
-				to_chat(world, "<b>The OOC channel has been automatically disabled due to the gamemode vote.</b>")
-				log_admin("OOC was toggled automatically due to gamemode vote.")
-				message_admins("OOC has been toggled off automatically.")
-			if(mode == "custom" && config.ooc_allowed)
-				auto_muted = 1
-				config.ooc_allowed = !( config.ooc_allowed )
-				to_chat(world, "<b>The OOC channel has been automatically disabled due to a custom vote.</b>")
-				log_admin("OOC was toggled automatically due to custom vote.")
-				message_admins("OOC has been toggled off automatically.")
-
-
-
-
-			time_remaining = round(config.vote_period/10)
-			return 1
-		return 0
-
-	proc/interface(var/client/C)
-		if(!C)	return
-		var/admin = check_rights(R_ADMIN,0)
-		voting |= C
-
-		. = "<html><head><title>Voting Panel</title></head><body>"
-		if(mode)
-			if(question)	. += "<h2>Vote: '[question]'</h2>"
-			else			. += "<h2>Vote: [capitalize(mode)]</h2>"
-			. += "Time Left: [time_remaining] s<hr><ul>"
-			for(var/i = 1, i <= choices.len, i++)
-				var/votes = choices[choices[i]]
-				if(!votes)	votes = 0
-				if(current_votes[C.ckey] == i)
-					. += "<li><b><a href='?src=\ref[src];vote=[i]'>[choices[i]] ([votes] votes)</a></b></li>"
-				else
-					. += "<li><a href='?src=\ref[src];vote=[i]'>[choices[i]] ([votes] votes)</a></li>"
-
-			. += "</ul><hr>"
-			if(admin)
-				. += "(<a href='?src=\ref[src];vote=cancel'>Cancel Vote</a>) "
-		else
-			. += "<h2>Start a vote:</h2><hr><ul><li>"
-			//restart
-			if(admin || config.allow_vote_restart)
-				. += "<a href='?src=\ref[src];vote=restart'>Restart</a>"
-			else
-				. += "<font color='grey'>Restart (Disallowed)</font>"
-			. += "</li><li>"
-			if(admin || config.allow_vote_restart)
-				. += "<a href='?src=\ref[src];vote=crew_transfer'>Crew Transfer</a>"
-			else
-				. += "<font color='grey'>Crew Transfer (Disallowed)</font>"
-			if(admin)
-				. += "\t(<a href='?src=\ref[src];vote=toggle_restart'>[config.allow_vote_restart?"Allowed":"Disallowed"]</a>)"
-			. += "</li><li>"
-			//gamemode
-			if(admin || config.allow_vote_mode)
-				. += "<a href='?src=\ref[src];vote=gamemode'>GameMode</a>"
-			else
-				. += "<font color='grey'>GameMode (Disallowed)</font>"
-			if(admin)
-				. += "\t(<a href='?src=\ref[src];vote=toggle_gamemode'>[config.allow_vote_mode?"Allowed":"Disallowed"]</a>)"
-
-			. += "</li>"
-			//custom
-			if(admin)
-				. += "<li><a href='?src=\ref[src];vote=custom'>Custom</a></li>"
-			. += "</ul><hr>"
-		. += "<a href='?src=\ref[src];vote=close' style='position:absolute;right:50px'>Close</a></body></html>"
-		return .
-
-
-	Topic(href,href_list[],hsrc)
-		if(!usr || !usr.client)	return	//not necessary but meh...just in-case somebody does something stupid
-		var/admin = check_rights(R_ADMIN,0)
-		switch(href_list["vote"])
-			if("close")
-				voting -= usr.client
-				usr << browse(null, "window=vote")
-				return
-			if("cancel")
-				if(admin)
-					reset()
-			if("toggle_restart")
-				if(admin)
-					config.allow_vote_restart = !config.allow_vote_restart
-			if("toggle_gamemode")
-				if(admin)
-					config.allow_vote_mode = !config.allow_vote_mode
+/datum/controller/vote/proc/result()
+	. = announce_result()
+	var/restart = 0
+	if(.)
+		switch(mode)
 			if("restart")
-				if(config.allow_vote_restart || admin)
-					initiate_vote("restart",usr.key)
+				if(. == "Restart Round")
+					restart = 1
 			if("gamemode")
-				if(config.allow_vote_mode || admin)
-					initiate_vote("gamemode",usr.key)
+				if(master_mode != .)
+					world.save_mode(.)
+					if(ticker && ticker.mode)
+						restart = 1
+					else
+						master_mode = .
+				if(!going)
+					going = 1
+					to_chat(world, "<font color='red'><b>The round will start soon.</b></font>")
 			if("crew_transfer")
-				if(config.allow_vote_restart || admin)
-					initiate_vote("crew_transfer",usr.key)
+				if(. == "Initiate Crew Transfer")
+					init_shift_change(null, 1)
+
+
+	if(restart)
+		world.Reboot("Restart vote successful.", "end_error", "restart vote")
+
+	return .
+
+/datum/controller/vote/proc/submit_vote(var/ckey, var/vote)
+	if(mode)
+		if(config.vote_no_dead && usr.stat == DEAD && !usr.client.holder)
+			return 0
+		if(current_votes[ckey])
+			choices[choices[current_votes[ckey]]]--
+		if(vote && 1<=vote && vote<=choices.len)
+			voted += usr.ckey
+			choices[choices[vote]]++	//check this
+			current_votes[ckey] = vote
+			return vote
+	return 0
+
+/datum/controller/vote/proc/initiate_vote(var/vote_type, var/initiator_key)
+	if(!mode)
+		if(started_time != null && !check_rights(R_ADMIN))
+			var/next_allowed_time = (started_time + config.vote_delay)
+			if(next_allowed_time > world.time)
+				return 0
+
+		reset()
+		switch(vote_type)
+			if("restart")
+				choices.Add("Restart Round","Continue Playing")
+			if("gamemode")
+				if(ticker.current_state >= 2)
+					return 0
+				choices.Add(config.votable_modes)
+			if("crew_transfer")
+				if(check_rights(R_ADMIN|R_MOD))
+					if(ticker.current_state <= 2)
+						return 0
+					question = "End the shift?"
+					choices.Add("Initiate Crew Transfer", "Continue The Round")
+				else
+					if(ticker.current_state <= 2)
+						return 0
+					question = "End the shift?"
+					choices.Add("Initiate Crew Transfer", "Continue The Round")
 			if("custom")
-				if(admin)
-					initiate_vote("custom",usr.key)
+				question = html_encode(input(usr,"What is the vote for?") as text|null)
+				if(!question)	return 0
+				for(var/i=1,i<=10,i++)
+					var/option = capitalize(html_encode(input(usr,"Please enter an option or hit cancel to finish") as text|null))
+					if(!option || mode || !usr.client)	break
+					choices.Add(option)
+			else			return 0
+		mode = vote_type
+		initiator = initiator_key
+		started_time = world.time
+		var/text = "[capitalize(mode)] vote started by [initiator]."
+		if(mode == "custom")
+			text += "\n[question]"
+
+		log_vote(text)
+		to_chat(world, "<font color='purple'><b>[text]</b>\nType vote to place your votes.\nYou have [config.vote_period/10] seconds to vote.</font>")
+		switch(vote_type)
+			if("crew_transfer")
+				world << sound('sound/ambience/alarm4.ogg')
+			if("gamemode")
+				world << sound('sound/ambience/alarm4.ogg')
+			if("custom")
+				world << sound('sound/ambience/alarm4.ogg')
+		if(mode == "gamemode" && going)
+			going = 0
+			to_chat(world, "<font color='red'><b>Round start has been delayed.</b></font>")
+		if(mode == "crew_transfer" && config.ooc_allowed)
+			auto_muted = 1
+			config.ooc_allowed = !( config.ooc_allowed )
+			to_chat(world, "<b>The OOC channel has been automatically disabled due to a crew transfer vote.</b>")
+			log_admin("OOC was toggled automatically due to crew_transfer vote.")
+			message_admins("OOC has been toggled off automatically.")
+		if(mode == "gamemode" && config.ooc_allowed)
+			auto_muted = 1
+			config.ooc_allowed = !( config.ooc_allowed )
+			to_chat(world, "<b>The OOC channel has been automatically disabled due to the gamemode vote.</b>")
+			log_admin("OOC was toggled automatically due to gamemode vote.")
+			message_admins("OOC has been toggled off automatically.")
+		if(mode == "custom" && config.ooc_allowed)
+			auto_muted = 1
+			config.ooc_allowed = !( config.ooc_allowed )
+			to_chat(world, "<b>The OOC channel has been automatically disabled due to a custom vote.</b>")
+			log_admin("OOC was toggled automatically due to custom vote.")
+			message_admins("OOC has been toggled off automatically.")
+
+
+
+
+		time_remaining = round(config.vote_period/10)
+		return 1
+	return 0
+
+/datum/controller/vote/proc/interface(var/client/C)
+	if(!C)	return
+	var/admin = check_rights(R_ADMIN,0)
+	voting |= C
+
+	. = "<html><head><title>Voting Panel</title></head><body>"
+	if(mode)
+		if(question)	. += "<h2>Vote: '[question]'</h2>"
+		else			. += "<h2>Vote: [capitalize(mode)]</h2>"
+		. += "Time Left: [time_remaining] s<hr><ul>"
+		for(var/i = 1, i <= choices.len, i++)
+			var/votes = choices[choices[i]]
+			if(!votes)	votes = 0
+			if(current_votes[C.ckey] == i)
+				. += "<li><b><a href='?src=\ref[src];vote=[i]'>[choices[i]] ([votes] votes)</a></b></li>"
 			else
-				submit_vote(usr.ckey, round(text2num(href_list["vote"])))
-		usr.vote()
+				. += "<li><a href='?src=\ref[src];vote=[i]'>[choices[i]] ([votes] votes)</a></li>"
+
+		. += "</ul><hr>"
+		if(admin)
+			. += "(<a href='?src=\ref[src];vote=cancel'>Cancel Vote</a>) "
+	else
+		. += "<h2>Start a vote:</h2><hr><ul><li>"
+		//restart
+		if(admin || config.allow_vote_restart)
+			. += "<a href='?src=\ref[src];vote=restart'>Restart</a>"
+		else
+			. += "<font color='grey'>Restart (Disallowed)</font>"
+		. += "</li><li>"
+		if(admin || config.allow_vote_restart)
+			. += "<a href='?src=\ref[src];vote=crew_transfer'>Crew Transfer</a>"
+		else
+			. += "<font color='grey'>Crew Transfer (Disallowed)</font>"
+		if(admin)
+			. += "\t(<a href='?src=\ref[src];vote=toggle_restart'>[config.allow_vote_restart?"Allowed":"Disallowed"]</a>)"
+		. += "</li><li>"
+		//gamemode
+		if(admin || config.allow_vote_mode)
+			. += "<a href='?src=\ref[src];vote=gamemode'>GameMode</a>"
+		else
+			. += "<font color='grey'>GameMode (Disallowed)</font>"
+		if(admin)
+			. += "\t(<a href='?src=\ref[src];vote=toggle_gamemode'>[config.allow_vote_mode?"Allowed":"Disallowed"]</a>)"
+
+		. += "</li>"
+		//custom
+		if(admin)
+			. += "<li><a href='?src=\ref[src];vote=custom'>Custom</a></li>"
+		. += "</ul><hr>"
+	. += "<a href='?src=\ref[src];vote=close' style='position:absolute;right:50px'>Close</a></body></html>"
+	return .
+
+
+/datum/controller/vote/Topic(href,href_list[],hsrc)
+	if(!usr || !usr.client)	return	//not necessary but meh...just in-case somebody does something stupid
+	var/admin = check_rights(R_ADMIN,0)
+	switch(href_list["vote"])
+		if("close")
+			voting -= usr.client
+			usr << browse(null, "window=vote")
+			return
+		if("cancel")
+			if(admin)
+				reset()
+		if("toggle_restart")
+			if(admin)
+				config.allow_vote_restart = !config.allow_vote_restart
+		if("toggle_gamemode")
+			if(admin)
+				config.allow_vote_mode = !config.allow_vote_mode
+		if("restart")
+			if(config.allow_vote_restart || admin)
+				initiate_vote("restart",usr.key)
+		if("gamemode")
+			if(config.allow_vote_mode || admin)
+				initiate_vote("gamemode",usr.key)
+		if("crew_transfer")
+			if(config.allow_vote_restart || admin)
+				initiate_vote("crew_transfer",usr.key)
+		if("custom")
+			if(admin)
+				initiate_vote("custom",usr.key)
+		else
+			submit_vote(usr.ckey, round(text2num(href_list["vote"])))
+	usr.vote()
 
 
 /mob/verb/vote()

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -48,9 +48,7 @@ var/round_start_time = 0
 		to_chat(world, "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>")
 		to_chat(world, "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds")
 		while(current_state == GAME_STATE_PREGAME)
-			for(var/i=0, i<10, i++)
-				sleep(1)
-				vote.process()
+			sleep(10)
 			if(going)
 				pregame_timeleft--
 

--- a/paradise.dme
+++ b/paradise.dme
@@ -180,7 +180,6 @@
 #include "code\controllers\Processes\sun.dm"
 #include "code\controllers\Processes\ticker.dm"
 #include "code\controllers\Processes\timer.dm"
-#include "code\controllers\Processes\vote.dm"
 #include "code\controllers\Processes\weather.dm"
 #include "code\controllers\ProcessScheduler\core\process.dm"
 #include "code\controllers\ProcessScheduler\core\processScheduler.dm"


### PR DESCRIPTION
Initially, I only intended to add full results output to custom votes, but then things got out of hand...

- Makes custom votes show a sorted list of votes for each option upon completion, and others show total votes for the winning option.
  - ![dreamseeker_2016-07-23_01-24-22](https://cloud.githubusercontent.com/assets/10916307/17076165/bc5d1d26-5079-11e6-8b7f-95846081115a.png)
  - ![dreamseeker_2016-07-23_01-30-25](https://cloud.githubusercontent.com/assets/10916307/17076171/c97feff6-5079-11e6-8407-0ebb8c0cfb30.png)
- Makes the voting panel automatically update every second.
  - This used to be a feature of the voting panel, but it was done by constantly re-creating the window, which didn't work very well.
  - Now, it sends javascript-based updates, so excess updates will simply be ignored.
    - Also, updating the current vote results won't be all *clicky.*
- Makes the voting panel use the browser datum (pictured below).
  - In addition to looking nice, this has convenient support for detecting when a window closes, so we can stop sending vote updates.
- Turns the voting notice into a clickable link.
  - Players no longer have to type in or hunt for the `vote` verb.
- Fixes admin status not properly being checked when the voting panel is refreshed.
  - This is why the "cancel vote" link would almost immediately disappear from an active vote.
- Replaces vote process with a spawned loop in the vote controller.
  - We had a process dedicated to ticking this one, single datum, every second. The process didn't even start until the round did, despite votes being usable before round start.
- Removes vote processing from the pre-game game ticker.
  - I assume this was a sloppy work-around for the vote process not running during the pre-game. It was ticking the vote controller *so fast*, though.
- Removes relative pathing from vote controller, along with other minor refactoring.
- Adds logging of (player-made) votes being started, and logging+notification of votes being cancelled by an admin.
- Adds the vote controller to the "debug controller" list.

The voting panel now looks like this:
![2016-07-23_01-36-55](https://cloud.githubusercontent.com/assets/10916307/17076164/b612d6cc-5079-11e6-8292-0aff78b0c4ec.png)
:cl:
tweak: The voting panel now uses the browser datum, which means it looks nicer.
tweak: The voting panel now updates while a vote is in progress.
tweak: When a vote is started, it will now include a link to open the vote panel, as an alternative to typing in "vote".
tweak: Custom votes will now show full voting results upon completion.
bugfix: Admins should no longer lose the "cancel vote" link in the voting panel.
/:cl: