### PR TITLE
Trauma and Burn Kit Rework

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -894,7 +894,7 @@
 					/obj/item/weapon/reagent_containers/glass/bottle/toxin = 4,/obj/item/weapon/reagent_containers/syringe/antiviral = 6,/obj/item/weapon/reagent_containers/syringe/insulin = 4,
 					/obj/item/weapon/reagent_containers/syringe = 12,/obj/item/device/healthanalyzer = 5,/obj/item/device/healthupgrade = 5,/obj/item/weapon/reagent_containers/glass/beaker = 4,
 					/obj/item/weapon/reagent_containers/dropper = 2,/obj/item/stack/medical/bruise_pack/advanced = 3, /obj/item/stack/medical/ointment/advanced = 3,
-					/obj/item/stack/medical/bruise_pack = 3,/obj/item/stack/medical/splint = 2, /obj/item/device/sensor_device = 2)
+					/obj/item/stack/medical/bruise_pack = 3,/obj/item/stack/medical/splint = 4, /obj/item/device/sensor_device = 2)
 	contraband = list(/obj/item/weapon/reagent_containers/glass/bottle/pancuronium = 1,/obj/item/weapon/reagent_containers/glass/bottle/sulfonal = 1)
 
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -2,16 +2,19 @@
 	name = "medical pack"
 	singular_name = "medical pack"
 	icon = 'icons/obj/items.dmi'
-	amount = 5
-	max_amount = 5
+	amount = 6
+	max_amount = 6
 	w_class = 1
 	throw_speed = 3
 	throw_range = 7
 	var/heal_brute = 0
 	var/heal_burn = 0
+	var/self_delay = 20
+	var/stop_bleeding = 0   //does it stop bleeding or not?
+	var/unique_handling = 0 //some things give a special prompt, do we want to bypass some checks in parent?
 
-/obj/item/stack/medical/attack(mob/living/carbon/M, mob/user)
-	if(!istype(M))
+/obj/item/stack/medical/attack(mob/living/M, mob/user)
+	if(!iscarbon(M) && !isanimal(M))
 		to_chat(user, "<span class='danger'>[src] cannot be applied to [M]!</span>")
 		return 1
 
@@ -20,13 +23,12 @@
 		return 1
 
 
-	if(istype(M, /mob/living/carbon/human))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
-		if(isliving(M))
-			if(!M.can_inject(user, 1))
-				return 1
+		if(!H.can_inject(user, 1))
+			return 1
 
 		if(!affecting)
 			to_chat(user, "<span class='danger'>That limb is missing!</span>")
@@ -36,16 +38,36 @@
 			to_chat(user, "<span class='danger'>This can't be used on a robotic limb.</span>")
 			return 1
 
+		if(M == user && !unique_handling)
+			user.visible_message("<span class='notice'>[user] starts to apply [src] on [H]...</span>")
+			if(!do_mob(user, H, self_delay))
+				return 1
+		return
 
-		H.UpdateDamageIcon()
+	if(isanimal(M))
+		var/mob/living/simple_animal/critter = M
+		if(!(critter.healable))
+			to_chat(user, "<span class='notice'>You cannot use [src] on [critter]!</span>")
+			return
+		else if (critter.health == critter.maxHealth)
+			to_chat(user, "<span class='notice'>[critter] is at full health.</span>")
+			return
+		else if(heal_brute < 1)
+			to_chat(user, "<span class='notice'>[src] won't help [critter] at all.</span>")
+			return
 
-	else
-		M.heal_organ_damage(heal_brute/2, heal_burn/2)
-		user.visible_message("<span class='notice'>[M] has been applied with [src] by [user].</span>", \
-							 "<span class='notice'>You apply [src] to [M].</span>")
+		critter.heal_organ_damage(heal_brute, heal_burn)
+		user.visible_message("<span class='green'>[user] applies [src] on [critter].</span>", \
+							 "<span class='green'>You apply [src] on [critter].</span>")
+
 		use(1)
 
-	M.updatehealth()
+	else
+		M.heal_organ_damage(heal_brute, heal_burn)
+		M.updatehealth()
+		user.visible_message("<span class='green'>[user] applies [src] on [M].</span>", \
+							 "<span class='green'>You apply [src] on [M].</span>")
+		use(1)
 
 //Bruise Packs//
 
@@ -55,40 +77,28 @@
 	desc = "Some sterile gauze to wrap around bloody stumps."
 	icon_state = "gauze"
 	origin_tech = "biotech=1"
+	stop_bleeding = 1
 
-/obj/item/stack/medical/bruise_pack/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/bruise_pack/attack(mob/living/M, mob/user)
 	if(..())
 		return 1
 
-	if(istype(M, /mob/living/carbon/human))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
 		if(affecting.open == 0)
-			var/bandaged = affecting.bandage()
-			var/disinfected = affecting.disinfect()
+			if(stop_bleeding)
+				affecting.bandage()
+				affecting.disinfect()
+			user.visible_message("<span class='green'>[user] bandages the wounds on [H]'s [affecting.name].", \
+								 "<span class='green'>You bandage the wounds on [H]'s [affecting.name].</span>" )
 
-			if(!(bandaged || disinfected))
-				to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been bandaged.</span>")
-				return 1
-			else
-				for(var/datum/wound/W in affecting.wounds)
-					if(W.internal)
-						continue
-					if(W.current_stage <= W.max_bleeding_stage)
-						user.visible_message("<span class='notice'>[user] bandages \the [W.desc] on [M]'s [affecting.name].</span>", \
-											 "<span class='notice'>You bandage \the [W.desc] on [M]'s [affecting.name].</span>" )
-					else if(istype(W,/datum/wound/bruise))
-						user.visible_message("<span class='notice'>[user] places a bruise patch over \the [W.desc] on [M]'s [affecting.name].</span>", \
-											 "<span class='notice'>You place a bruise patch over \the [W.desc] on [M]'s [affecting.name].</span>" )
-					else
-						user.visible_message("<span class='notice'>[user] places a bandaid over \the [W.desc] on [M]'s [affecting.name].</span>", \
-											 "<span class='notice'>You place a bandaid over \the [W.desc] on [M]'s [affecting.name].</span>" )
-				if(bandaged)
-					affecting.heal_damage(heal_brute, heal_burn)
-				use(1)
+			affecting.heal_damage(heal_brute, heal_burn)
+			H.UpdateDamageIcon()
+			use(1)
 		else
-			to_chat(user, "<span class='notice'>[affecting] is cut open, you'll need more than a bandage!</span>")
+			to_chat(user, "<span class='warning'>[affecting] is cut open, you'll need more than a bandage!</span>")
 
 
 /obj/item/stack/medical/bruise_pack/advanced
@@ -96,7 +106,8 @@
 	singular_name = "advanced trauma kit"
 	desc = "An advanced trauma kit for severe injuries."
 	icon_state = "traumakit"
-	heal_brute = 12
+	heal_brute = 20
+	stop_bleeding = 0 // Heals, but doesn't stop bleeding
 
 
 
@@ -111,25 +122,24 @@
 	icon_state = "ointment"
 	origin_tech = "biotech=1"
 
-/obj/item/stack/medical/ointment/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/ointment/attack(mob/living/M, mob/user)
 	if(..())
 		return 1
 
-	if(istype(M, /mob/living/carbon/human))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
 		if(affecting.open == 0)
-			if(!affecting.salve())
-				to_chat(user, "<span class='warning'>The wounds on [M]'s [affecting.name] have already been salved.</span>")
-				return 1
-			else
-				user.visible_message("<span class='notice'>[user] salves the wounds on [M]'s [affecting.name].", \
-									 "<span class='notice'>You salve the wounds on [M]'s [affecting.name].</span>" )
-				affecting.heal_damage(heal_brute, heal_burn)
-				use(1)
+			affecting.salve()
+			user.visible_message("<span class='green'>[user] salves the wounds on [H]'s [affecting.name].", \
+								 "<span class='green'>You salve the wounds on [H]'s [affecting.name].</span>" )
+
+			affecting.heal_damage(heal_brute, heal_burn)
+			H.UpdateDamageIcon()
+			use(1)
 		else
-			to_chat(user, "<span class='notice'>[affecting] is cut open, you'll need more than some ointment!</span>")
+			to_chat(user, "<span class='warning'>[affecting] is cut open, you'll need more than some ointment!</span>")
 
 
 /obj/item/stack/medical/ointment/advanced
@@ -137,7 +147,7 @@
 	singular_name = "advanced burn kit"
 	desc = "An advanced treatment kit for severe burns."
 	icon_state = "burnkit"
-	heal_burn = 12
+	heal_burn = 20
 
 
 
@@ -151,7 +161,7 @@
 	icon = 'icons/obj/hydroponics_products.dmi'
 	icon_state = "alien3-product"
 	color = "#378C61"
-	heal_brute = 7
+	heal_brute = 12
 
 
 /obj/item/stack/medical/ointment/aloe
@@ -161,7 +171,7 @@
 	icon = 'icons/obj/hydroponics_products.dmi'
 	icon_state = "ambrosia-product"
 	color = "#4CC5C7"
-	heal_burn = 7
+	heal_burn = 12
 
 
 
@@ -172,51 +182,32 @@
 	name = "medical splints"
 	singular_name = "medical splint"
 	icon_state = "splint"
-	amount = 5
-	max_amount = 5
+	unique_handling = 1
 
-/obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/splint/attack(mob/living/M, mob/user)
 	if(..())
 		return 1
 
-	if(istype(M, /mob/living/carbon/human))
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 		var/limb = affecting.name
-		if(!(affecting.limb_name in list("l_arm", "r_arm", "l_hand", "r_hand", "l_leg", "r_leg", "l_foot", "r_foot")))
-			to_chat(user, "<span class='danger'>You can't apply a splint there!</span>")
-			return
 		if(affecting.status & ORGAN_SPLINTED)
-			to_chat(user, "<span class='danger'>[M]'s [limb] is already splinted!</span>")
-			if(alert(user, "Would you like to remove the splint from [M]'s [limb]?", "Removing.", "Yes", "No") == "Yes")
+			to_chat(user, "<span class='danger'>[H]'s [limb] is already splinted!</span>")
+			if(alert(user, "Would you like to remove the splint from [H]'s [limb]?", "Removing.", "Yes", "No") == "Yes")
 				affecting.status &= ~ORGAN_SPLINTED
-				to_chat(user, "<span class='notice'>You remove the splint from [M]'s [limb].</span>")
+				to_chat(user, "<span class='notice'>You remove the splint from [H]'s [limb].</span>")
 			return
-		if(M != user)
-			user.visible_message("<span class='notice'>[user] starts to apply [src] to [M]'s [limb].</span>", \
-								 "<span class='notice'>You start to apply [src] to [M]'s [limb].</span>", \
+		if(M == user)
+			user.visible_message("<span class='notice'>[user] starts to apply [src] to [H]'s [limb].</span>", \
+								 "<span class='notice'>You start to apply [src] to [H]'s [limb].</span>", \
 								 "<span class='notice'>You hear something being wrapped.</span>")
-		else
-			if((!user.hand && affecting.limb_name in list("r_arm", "r_hand")) || (user.hand && affecting.limb_name in list("l_arm", "l_hand")))
-				to_chat(user, "<span class='danger'>You can't apply a splint to the arm you're using!</span>")
+			if(!do_mob(user, H, self_delay))
 				return
-			user.visible_message("<span class='notice'>[user] starts to apply [src] to their [limb].</span>", \
-								 "<span class='notice'>You start to apply [src] to your [limb].</span>", \
-								 "<span class='notice'>You hear something being wrapped.</span>")
-		if(do_after(user, 50, target = M))
-			if(M != user)
-				user.visible_message("<span class='notice'>[user] finishes applying [src] to [M]'s [limb].</span>", \
-									"<span class='notice'>You finish applying [src] to [M]'s [limb].</span>", \
-									"<span class='notice'>You hear something being wrapped.</span>")
-			else
-				if(prob(25))
-					user.visible_message("<span class='notice'>[user] successfully applies [src] to their [limb].</span>", \
-										 "<span class='notice'>You successfully apply [src] to your [limb].</span>", \
-										 "<span class='notice'>You hear something being wrapped.</span>")
-				else
-					user.visible_message("<span class='warning'>[user] fumbles [src].</span>",
-										 "<span class='warning'>You fumble [src].</span>",
-										 "<span class='warning'>You hear something being wrapped.</span>")
-					return
-			affecting.status |= ORGAN_SPLINTED
-			use(1)
+		else
+			user.visible_message("<span class='green'>[user] applies [src] to their [limb].</span>", \
+								 "<span class='green'>You apply [src] to your [limb].</span>", \
+								 "<span class='green'>You hear something being wrapped.</span>")
+
+		affecting.status |= ORGAN_SPLINTED
+		use(1)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -138,15 +138,15 @@
 
 /obj/item/weapon/storage/firstaid/adv/New()
 	..()
-	if(empty) return
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector( src )
-	new /obj/item/stack/medical/bruise_pack/advanced(src)
+	if(empty)
+		return
+	new /obj/item/stack/medical/bruise_pack(src)
 	new /obj/item/stack/medical/bruise_pack/advanced(src)
 	new /obj/item/stack/medical/bruise_pack/advanced(src)
 	new /obj/item/stack/medical/ointment/advanced(src)
 	new /obj/item/stack/medical/ointment/advanced(src)
-	new /obj/item/stack/medical/splint(src)
-	return
+	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/device/healthanalyzer(src)
 
 /obj/item/weapon/storage/firstaid/adv/empty
 	empty = 1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -407,26 +407,7 @@
 	return
 
 /mob/living/simple_animal/attackby(var/obj/item/O as obj, var/mob/living/user as mob)  //Marker -Agouri
-	if(istype(O, /obj/item/stack/medical) && healable)
-		if(stat != DEAD)
-			var/obj/item/stack/medical/MED = O
-			if(health < maxHealth)
-				if(MED.amount >= 1)
-					if(MED.heal_brute >= 1)
-						heal_organ_damage((MED.heal_brute * 1.66), (MED.heal_burn * 1.66))
-						MED.use(1)
-						visible_message("<span class='notice'>[user] applies [MED] on [src]</span>")
-						return
-					else
-						to_chat(user, "<span class='notice'>[MED] won't help at all.</span>")
-						return
-			else
-				to_chat(user, "<span class='notice'>[src] is at full health.</span>")
-				return
-		else
-			to_chat(user, "<span class='notice'>[src] is dead, medical items won't bring it back to life.</span>")
-			return
-	else if(can_collar && !collar && istype(O, /obj/item/clothing/accessory/petcollar))
+	if(can_collar && !collar && istype(O, /obj/item/clothing/accessory/petcollar))
 		var/obj/item/clothing/accessory/petcollar/C = O
 		user.drop_item()
 		C.forceMove(src)

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -245,8 +245,8 @@ em						{font-style: normal;	font-weight: bold;}
 .deptradio				{color: #993399;}
 .comradio				{color: #193A7A;}
 .syndradio				{color: #6d3f40;}
-.dsquadradio			{color: #686868;}
-.resteamradio			{color: #18BC46;}
+.dsquadradio				{color: #686868;}
+.resteamradio				{color: #18BC46;}
 .airadio				{color: #FF00FF;}
 .centradio				{color: #5C5C8A;}
 .secradio				{color: #A30000;}
@@ -255,17 +255,17 @@ em						{font-style: normal;	font-weight: bold;}
 .sciradio				{color: #993399;}
 .supradio				{color: #5F4519;}
 .srvradio				{color: #6eaa2c;}
-.admin_channel			{color: #9A04D1;	font-weight: bold;}
-.mod_channel			{color: #402A14;	font-weight: bold;}
-.mod_channel_admin      {color: #402A14;	font-weight: bold;}
+.admin_channel				{color: #9A04D1;	font-weight: bold;}
+.mod_channel				{color: #402A14;	font-weight: bold;}
+.mod_channel_admin      		{color: #402A14;	font-weight: bold;}
 .djradio				{color: #663300;}
-.binaryradio			{color: #0B0050;	font-family: 'Courier New', Courier, monospace;}
+.binaryradio				{color: #0B0050;	font-family: 'Courier New', Courier, monospace;}
 .mommiradio				{color: navy;}
 .alert					{color: #ff0000;}
-h1.alert, h2.alert		{color: #000000;}
+h1.alert, h2.alert			{color: #000000;}
 .ghostalert				{color: #5c00e6;	font-style: italic; font-weight: bold;}
 .emote					{					font-style: italic;}
-.selecteddna			{color: #FFFFFF; 	background-color: #001B1B}
+.selecteddna				{color: #FFFFFF; 	background-color: #001B1B}
 
 .attack					{color: #ff0000;}
 .moderate				{color: #CC0000;}
@@ -276,20 +276,20 @@ h1.alert, h2.alert		{color: #000000;}
 .boldwarning				{color: #ff0000;	font-style: italic;	font-weight: bold}
 .danger					{color: #ff0000;	font-weight: bold;}
 .userdanger				{color: #ff0000;	font-weight: bold;	font-size: 120%;}
-.biggerdanger			{color: #ff0000;	font-weight: bold; font-size: 150%;}
+.biggerdanger				{color: #ff0000;	font-weight: bold; font-size: 150%;}
 
 .info					{color: #0000CC;}
 .notice					{color: #000099;}
 .bnotice				{color: #000099; 	font-weight: bold;}
-.boldnotice			{color: #000099;	font-weight: bold;}
+.boldnotice				{color: #000099;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
-
+.green					{color: #03ff39;}
 .announce 				{color: #228b22;	font-weight: bold;}
-.boldannounce			{color: #ff0000;	font-weight: bold;}
-.greenannounce			{color: #00ff00;	font-weight: bold;}
+.boldannounce				{color: #ff0000;	font-weight: bold;}
+.greenannounce				{color: #00ff00;	font-weight: bold;}
 
 .alien					{color: #543354;}
-.noticealien			{color: #00c000;}
+.noticealien				{color: #00c000;}
 .alertalien				{color: #00c000; font-weight: bold;}
 
 .sinister				{color: #800080;	font-weight: bold;	font-style: italic;} /* /vg/ */
@@ -334,12 +334,12 @@ h1.alert, h2.alert		{color: #000000;}
 .orangei				{color: #ffa500; font-style: italic;}
 .orangeb				{color: #ffa500; font-weight: bold;}
 
-.revennotice			{color: #1d2953;}
-.revenboldnotice		{color: #1d2953;	font-weight: bold;}
-.revenbignotice			{color: #1d2953;	font-weight: bold; font-size: 3;}
+.revennotice				{color: #1d2953;}
+.revenboldnotice			{color: #1d2953;	font-weight: bold;}
+.revenbignotice				{color: #1d2953;	font-weight: bold; font-size: 3;}
 .revenminor				{color: #823abb}
-.revenwarning			{color: #760fbb;	font-style: italic;}
-.revendanger			{color: #760fbb;	font-weight: bold; font-size: 3;}
+.revenwarning				{color: #760fbb;	font-style: italic;}
+.revendanger				{color: #760fbb;	font-weight: bold; font-size: 3;}
 
 /* /vg/ */
 .good					{color: green;}


### PR DESCRIPTION
Reworks how trauma an and burn kits work.

For the rest of this PR, when I say "medical stacks" I will be referring to trauma kits, burn kits, and splints

- Medical stacks now have 6 uses
- Medical stacks now heal 25 burn/brute (except splints)
- Applying a medical stack to others is instant, no matter what
- Applying a medical stack to yourself has a 2 second delay
- Splint application to yourself is now a 10 second delay
- No more RNG fumbling of putting splints on yourself
- Confirmation for applying medical stacks is now green

Fixes
- Fixes weird icon updates when getting healed by medical kits

Related
- Advanced Medkits now have 2 trauma kits, 2 burn kits, a health analyzer, 1 roll of gauze, and medipen.
- Amount of splints in medical vendors increased from 2 to 4

Code Wise
- Moved simple animal healing from `attackby` to medical stack's `attack`

Hopefully these kits will actually be *useful* now.

:cl: Fox McCloud
tweak: Medical stacks now have 6 uses
tweak: Medical stacks now heal 25 burn/brute
tweak: Applying a medical stack to others is instant, no matter what
tweak: Applying any medical stack to yourself has a 2 second delay
tweak: Applying a splint to yourself has a 10 second delay
tweak: No more RNG fumbling of putting splints to yourself
tweak: Confirmation for applying medical stacks is now green
tweak: Advanced Medkits now have 2 trauma kits, 2 burn kits, a health analyzer, 1 roll of gauze, and medipen.
tweak: Amount of splints in medical vendors increased from 2 to 4
fix: Fixes weird icon updates when getting healed by medical kits
/:cl: