### PR TITLE
Allows refunding unused holopara injectors

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -677,6 +677,7 @@
 	var/ling_failure = "The deck refuses to respond to a souless creature such as you."
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive")
 	var/random = TRUE
+	var/refundable = FALSE
 
 /obj/item/weapon/guardiancreator/attack_self(mob/living/user)
 	for(var/mob/living/simple_animal/hostile/guardian/G in living_mob_list)
@@ -700,6 +701,23 @@
 	else
 		to_chat(user, "[failure_message]")
 		used = FALSE
+
+/obj/item/weapon/guardiancreator/afterattack(var/obj/item/I as obj, mob/user as mob, proximity)
+	..()
+	if(!proximity)
+		return
+	if(!refundable)
+		return
+	if(istype(I, /obj/item))
+		if(I.hidden_uplink && I.hidden_uplink.active)
+			if(used == TRUE)
+				to_chat(user, "[used_message]")
+				return
+			var/datum/uplink_item/dangerous/guardian/D = new /datum/uplink_item/dangerous/guardian
+			I.hidden_uplink.uses += D.cost
+			to_chat(user, "<span class='notice'>You send [src] back, getting a refund for its TC.</span>")
+			qdel(D)
+			qdel(src)
 
 
 /obj/item/weapon/guardiancreator/proc/spawn_guardian(var/mob/living/user, var/key)
@@ -793,6 +811,7 @@
 	used_message = "The injector has already been used."
 	failure_message = "<B>...ERROR. BOOT SEQUENCE ABORTED. AI FAILED TO INTIALIZE. PLEASE CONTACT SUPPORT OR TRY AGAIN LATER.</B>"
 	ling_failure = "The holoparasites recoil in horror. They want nothing to do with a creature like you."
+	refundable = TRUE
 
 /obj/item/weapon/guardiancreator/tech/choose
 	random = FALSE

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -702,13 +702,13 @@
 		to_chat(user, "[failure_message]")
 		used = FALSE
 
-/obj/item/weapon/guardiancreator/afterattack(var/obj/item/I as obj, mob/user as mob, proximity)
+/obj/item/weapon/guardiancreator/afterattack(var/obj/item/I, var/mob/user, var/proximity)
 	..()
 	if(!proximity)
 		return
 	if(!refundable)
 		return
-	if(istype(I, /obj/item))
+	if(istype(I))
 		if(I.hidden_uplink && I.hidden_uplink.active)
 			if(used == TRUE)
 				to_chat(user, "[used_message]")

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -713,10 +713,10 @@
 			if(used == TRUE)
 				to_chat(user, "[used_message]")
 				return
-			var/datum/uplink_item/dangerous/guardian/D = new /datum/uplink_item/dangerous/guardian
-			I.hidden_uplink.uses += D.cost
+			var/datum/uplink_item/U = /datum/uplink_item/dangerous/guardian
+			I.hidden_uplink.uses += initial(U.cost)
 			to_chat(user, "<span class='notice'>You send [src] back, getting a refund for its TC.</span>")
-			qdel(D)
+			qdel(U)
 			qdel(src)
 
 

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -716,7 +716,6 @@
 			var/datum/uplink_item/U = /datum/uplink_item/dangerous/guardian
 			I.hidden_uplink.uses += initial(U.cost)
 			to_chat(user, "<span class='notice'>You send [src] back, getting a refund for its TC.</span>")
-			qdel(U)
 			qdel(src)
 
 

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -714,8 +714,8 @@
 				to_chat(user, "[used_message]")
 				return
 			var/datum/uplink_item/U = /datum/uplink_item/dangerous/guardian
-			I.hidden_uplink.uses += initial(U.cost)
-			to_chat(user, "<span class='notice'>You send [src] back, getting a refund for its TC.</span>")
+			I.hidden_uplink.uses += (initial(U.cost) - 4)
+			to_chat(user, "<span class='notice'>You send [src] back, getting a partial refund for its TC cost.</span>")
 			qdel(src)
 
 


### PR DESCRIPTION

Lets you use an unused holopara injector on a traitor's unlocked PDA uplink to get a refund for its TC cost.

Note:
1) Can only be used on holopara injectors. Cannot be used on scarab swarms, etc.
2) Can only be used on unused injectors. Once you use the injector, you cannot refund it.
3) Refunds the entire TC cost of the injector, then deletes it. Note: you're still left carrying its box, and paper. The fact you still have these two items for zero cost is balanced by the fact the box/paper aren't very useful, and you could be executed for having them given that they're evidence of you having a holopara (even though you don't).
4) Only works if the PDA uplink is unlocked. IE: you cannot use this to determine if a PDA is an uplink or not.

:cl: Kyep
tweak: Unused holopara injectors can be refunded by using them on your unlocked uplink PDA.
/:cl: