### PR TITLE
Fixes #4960, Newly Spawned Vox Won't Break Other Vox' Tails

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1508,7 +1508,10 @@
 
 		species.handle_pre_change(src)
 
-	species = all_species[new_species]
+	var/datum/species/S = all_species[new_species]
+
+	species = new S.type //Ensures each mob's species isn't on the same memory address, meaning changing the icobase/deform/tail of one mob's species won't affect that of all other mobs of the same species.
+	species.myhuman = src //Update species mob reference.
 
 	if(oldspecies)
 		if(oldspecies.default_genes.len)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -126,8 +126,8 @@
 	var/default_headacc = "None"	//Default head accessory style for newly created humans unless otherwise set.
 	var/default_headacc_colour
 
-	//Defining lists of icon skin tones for species that have them.
-	var/list/icon_skin_tones = list()
+	var/myhuman						//Mob reference.
+	var/list/icon_skin_tones = list()	//Defining lists of icon skin tones for species that have them.
 
                               // Determines the organs that the species spawns with and
 	var/list/has_organ = list(    // which required-organ checks are conducted.

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -357,10 +357,11 @@
 	H.update_internals_hud_icon(1)
 
 /datum/species/vox/handle_post_spawn(var/mob/living/carbon/human/H)
-	updatespeciescolor(H)
-	H.update_icons()
-	//H.verbs += /mob/living/carbon/human/proc/leap
-	..()
+	if(myhuman == H)
+		updatespeciescolor(H)
+		H.update_icons()
+		//H.verbs += /mob/living/carbon/human/proc/leap
+		..()
 
 /datum/species/vox/updatespeciescolor(var/mob/living/carbon/human/H) //Handling species-specific skin-tones for the Vox race.
 	if(H.species.name == "Vox") //Making sure we don't break Armalis.


### PR DESCRIPTION
:cl:
fix: Newly spawned Vox won't break other Vox' tails.
/:cl:

After a long while of thinking and trying to find what even caused this bug, I stumbled upon it after being reminded by a recent post on the issue report.

The reason why this bug existed is because with the way species are currently handled, every mob of the same species has.. Well, the exact same species. And by exact, I mean-- for example, every Vox has the exact same species **right down to the memory address**. What THAT means is that if a single Vox spawns in with their skin tone, all will be well. But then, if ANOTHER Vox were to spawn in, all hell would break loose because THAT SECOND VOX, when their skin tone is handled, will be changing the _icobase_, _deform_, and _tail_ for the ENTIRE SPECIES, not just for THEM specifically because they've all got a species with the same memory address, not their own version of the same species.
This could potentially affect any mobs with the same species. This can happen to any species.

It's just something I didn't think about when I first added this feature.

_Two Vox with the same memory address for their species. Before fix._
![speciesexample2](https://cloud.githubusercontent.com/assets/12377767/17085670/1512cbae-51ac-11e6-920c-163852fed593.PNG)

This fix changes species handling such that mobs will get their own 'version' of a species. Checking a mob's species will work the EXACT same as it did before because it evaluates a mob's species 'name', not the memory address. Now, you can change an individual mob's species icobase, deform and tail and not affect all other mobs of the same species.

_Two Vox with different memory addresses for their species. After fix._
![speciesexample](https://cloud.githubusercontent.com/assets/12377767/17085700/78f5e7d2-51ac-11e6-969b-0bc19c7750a1.PNG)

Resolves #4960