### PR TITLE
Adds admin button to remove vamp thrall status

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -276,10 +276,9 @@
 		text += "<br><b>enthralled</b>"
 		text = "<i><b>[text]</b></i>: "
 		if(src in ticker.mode.vampire_enthralled)
-			text += "<b><font color='#FF0000'>YES</font></b>|no"
+			text += "<b><font color='#FF0000'>YES</font></b>|<a href='?src=\ref[src];vampthrall=clear'>no</a>"
 		else
 			text += "yes|<font color='#00FF00'>NO</font></b>"
-
 
 		sections["vampire"] = text
 
@@ -948,6 +947,13 @@
 				log_admin("[key_name(usr)] has automatically forged objectives for [key_name(current)]")
 				message_admins("[key_name_admin(usr)] has automatically forged objectives for [key_name_admin(current)]")
 
+	else if(href_list["vampthrall"])
+		switch(href_list["vampthrall"])
+			if("clear")
+				if(src in ticker.mode.vampire_enthralled)
+					ticker.mode.remove_vampire_mind(src)
+					log_admin("[key_name(usr)] has de-vampthralled [key_name(current)]")
+					message_admins("[key_name_admin(usr)] has de-vampthralled [key_name_admin(current)]")
 
 	else if(href_list["nuclear"])
 		var/mob/living/carbon/human/H = current


### PR DESCRIPTION
Very simply, adds a button to the admin Traitor management Panel that allows admins to convert a vampire thrall back into a regular player.

Reasons:
- Consistency - almost every other type of antag has such a button, including full vampires. Vamp thralls, however, don't.
- It came up in a round today. There is another method for removing vamp thrall status, but it involves var editing and is cumbersome.

:cl: Kyep
fix: It is now possible for admins to remove a person's vamp thrall status.
/:cl: