### PR TITLE
Replaces RnD Console Wait Screens With a Full-Window Overlay

### DIFF
--- a/nano/templates/r_n_d.tmpl
+++ b/nano/templates/r_n_d.tmpl
@@ -1,4 +1,4 @@
-{{if data.menu > 0 && !data.wait_message}}
+{{if data.menu > 0}}
 	<div class='item'>
 		{{:helper.link('Main Menu', 'reply', {'menu': 0, 'submenu': 0})}}
 		{{if data.submenu > 0}}
@@ -18,9 +18,7 @@
 	</div>
 {{/if}}
 <div class='statusDisplay'>
-	{{if data.wait_message}}
-		{{:data.wait_message}}
-	{{else data.menu == 0}}
+	{{if data.menu == 0}}
 		<h3>Main Menu:</h3>
 		<div class='line'>{{:helper.link('Disk Operations', 'save', {'menu': 2, 'submenu': 0}, data.disk_type ? null : 'disabled')}}</div>
 		<div class='line'>{{:helper.link('Destructive Analyzer Menu', 'chain-broken', {'menu': 3, 'submenu': 0}, data.linked_destroy ? null : 'disabled')}}</div>
@@ -263,3 +261,11 @@
 		{{/if}}
 	{{/if}}
 </div>
+
+{{if data.wait_message}}
+	<div class="mask">
+		<div class="maskContent">
+			<h1>{{:data.wait_message}}</h1>
+		</div>
+	</div>
+{{/if}}


### PR DESCRIPTION
This is a fairly minor change to the way waiting works at the RnD console. Currently, it's like this:

![2016-07-24_23-44-42](https://cloud.githubusercontent.com/assets/10916307/17089920/7e172314-51f9-11e6-9906-9ad180075196.gif)

Replaces the entire UI, scrolls you back up to the top. Slightly inconvenient if you're making things near the bottom.

This PR replaces that with this:

![2016-07-24_23-47-58](https://cloud.githubusercontent.com/assets/10916307/17089948/b42812c4-51f9-11e6-8427-3ed6a809c226.gif)

Now, you stay on whatever screen you were on while you wait. This applies to everything that makes you wait, including syncing and deconstructing.

:cl:
tweak: The RnD console now shows an overlay while you're waiting for it to do work, rather than using a separate wait screen.
/:cl: