### PR TITLE
Fixes cardboard boxes confusion

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -184,7 +184,7 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
 	new/datum/stack_recipe("folder", /obj/item/weapon/folder), \
 	new/datum/stack_recipe("cardboard tube", /obj/item/weapon/c_tube), \
-	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4), \
+	new/datum/stack_recipe("cardboard box", /obj/structure/closet/cardboard, 4), \
 )
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap


### PR DESCRIPTION
Didn't really think about this when I first added them, and people have been confused by this many times. Sorry guys.
:cl:
fix: Cardboard boxes now have their own specific name in the cardboard sheets menu.
/:cl: