### PR TITLE
Assorted Admin Rights Check Fixes

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -873,8 +873,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set name = "Reset Telecomms Scripts"
 	set desc = "Blanks all telecomms scripts from all telecomms servers"
 
-	if(!holder || !holder.rights || !holder.rights & R_ADMIN)
-		to_chat(usr, "<span class='warning'>Admin only.</span>")
+	if(!check_rights(R_ADMIN, 1, src))
 		return
 
 	var/confirm = alert(src, "You sure you want to blank all NTSL scripts?", "Confirm", "Yes", "No")

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -126,7 +126,7 @@
 					var/author = CB.author
 					var/controls =  "<A href='?src=\ref[src];id=[CB.id]'>\[Order\]</A>"
 					controls += {" <A href="?src=\ref[src];flag=[CB.id]">\[Flag[CB.flagged ? "ged" : ""]\]</A>"}
-					if(check_rights(R_ADMIN, user = user))
+					if(check_rights(R_ADMIN, 0, user = user))
 						controls +=  " <A style='color:red' href='?src=\ref[src];del=[CB.id]'>\[Delete\]</A>"
 						author += " (<A style='color:red' href='?src=\ref[src];delbyckey=[ckey(CB.ckey)]'>[ckey(CB.ckey)])</A>)"
 					dat += {"<tr>
@@ -255,7 +255,6 @@
 		screenstate = 4
 	if(href_list["del"])
 		if(!check_rights(R_ADMIN))
-			to_chat(usr, "You aren't an admin, piss off.")
 			return
 		var/datum/cachedbook/target = getBookByID(href_list["del"]) // Sanitized in getBookByID
 		var/ans = alert(usr, "Are you sure you wish to delete \"[target.title]\", by [target.author]? This cannot be undone.", "Library System", "Yes", "No")
@@ -272,7 +271,6 @@
 
 	if(href_list["delbyckey"])
 		if(!check_rights(R_ADMIN))
-			to_chat(usr, "You aren't an admin, piss off.")
 			return
 		var/tckey = ckey(href_list["delbyckey"])
 		var/ans = alert(usr,"Are you sure you wish to delete all books by [tckey]? This cannot be undone.", "Library System", "Yes", "No")

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -374,7 +374,7 @@
 	var/list/valid_body_accessories = new()
 	for(var/B in body_accessory_by_name)
 		var/datum/body_accessory/A = body_accessory_by_name[B]
-		if(check_rights(R_ADMIN, 1, src))
+		if(check_rights(R_ADMIN, 0, src))
 			valid_body_accessories = body_accessory_by_name.Copy()
 		else
 			if(!istype(A))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -245,7 +245,7 @@
 	if(jobban_isbanned(src,rank))	return 0
 	if(!is_job_whitelisted(src, rank))	 return 0
 	if(!job.player_old_enough(src.client))	return 0
-	if(job.admin_only && !(check_rights(R_ADMIN, 0))) return 0
+	if(job.admin_only && !(check_rights(R_EVENT, 0))) return 0
 
 	if(config.assistantlimit)
 		if(job.title == "Civilian")


### PR DESCRIPTION
Fixes #4967.
Fixes #5149.

:cl:
fix: Admin-only jobs check for R_EVENT now, instead of R_ADMIN, as event-related tools should.
fix: Mentors should no longer get spammed by the library checkout computer on occasion.
fix: Mentors should no longer get spammed by mirrors due to body accessories.
/:cl: