### PR TITLE
Adds Admin Ghost Click Shortcuts

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -301,9 +301,12 @@ proc/add_logs(mob/target, mob/user, what_done, var/object=null, var/addition=nul
 		var/mob/living/L = M
 		var/status
 		switch(M.stat)
-			if(0) status = "Alive"
-			if(1) status = "<font color='orange'><b>Unconscious</b></font>"
-			if(2) status = "<font color='red'><b>Dead</b></font>"
+			if(CONSCIOUS) 
+				status = "Alive"
+			if(UNCONSCIOUS)
+				status = "<font color='orange'><b>Unconscious</b></font>"
+			if(DEAD)
+				status = "<font color='red'><b>Dead</b></font>"
 		health_description = "Status = [status]"
 		health_description += "<BR>Oxy: [L.getOxyLoss()] - Tox: [L.getToxLoss()] - Fire: [L.getFireLoss()] - Brute: [L.getBruteLoss()] - Clone: [L.getCloneLoss()] - Brain: [L.getBrainLoss()]"
 	else
@@ -311,8 +314,10 @@ proc/add_logs(mob/target, mob/user, what_done, var/object=null, var/addition=nul
 
 	//Gener
 	switch(M.gender)
-		if(MALE,FEMALE)	gender_description = "[M.gender]"
-		else			gender_description = "<font color='red'><b>[M.gender]</b></font>"
+		if(MALE, FEMALE)
+			gender_description = "[M.gender]"
+		else
+			gender_description = "<font color='red'><b>[M.gender]</b></font>"
 
 	to_chat(user, "<b>Info about [M.name]:</b> ")
 	to_chat(user, "Mob type = [M.type]; Gender = [gender_description] Damage = [health_description]")
@@ -320,3 +325,20 @@ proc/add_logs(mob/target, mob/user, what_done, var/object=null, var/addition=nul
 	to_chat(user, "Location = [location_description];")
 	to_chat(user, "[special_role_description]")
 	to_chat(user, "(<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a>) (<A HREF='?src=\ref[src];adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[M]'>VV</A>) (<A HREF='?src=\ref[src];subtlemessage=\ref[M]'>SM</A>) (<A HREF='?src=\ref[src];adminplayerobservefollow=\ref[M]'>FLW</A>) (<A HREF='?src=\ref[src];secretsadmin=check_antagonist'>CA</A>)")
+
+// Gets the first mob contained in an atom, and warns the user if there's not exactly one
+/proc/get_mob_in_atom_with_warning(atom/A, mob/user = usr)
+	if(!istype(A))
+		return null
+	if(ismob(A))
+		return A
+
+	. = null
+	for(var/mob/M in A)
+		if(!.)
+			. = M
+		else
+			to_chat(user, "<span class='warning'>Multiple mobs in [A], using first mob found...</span>")
+			break
+	if(!.)
+		to_chat(user, "<span class='warning'>No mob located in [A].</span>")

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -271,3 +271,52 @@ proc/add_logs(mob/target, mob/user, what_done, var/object=null, var/addition=nul
 				break
 	if(progress)
 		qdel(progbar)
+
+/proc/admin_mob_info(mob/M, mob/user = usr)
+	if(!ismob(M))
+		to_chat(user, "This can only be used on instances of type /mob")
+		return
+
+	var/location_description = ""
+	var/special_role_description = ""
+	var/health_description = ""
+	var/gender_description = ""
+	var/turf/T = get_turf(M)
+
+	//Location
+	if(isturf(T))
+		if(isarea(T.loc))
+			location_description = "([M.loc == T ? "at coordinates " : "in [M.loc] at coordinates "] [T.x], [T.y], [T.z] in area <b>[T.loc]</b>)"
+		else
+			location_description = "([M.loc == T ? "at coordinates " : "in [M.loc] at coordinates "] [T.x], [T.y], [T.z])"
+
+	//Job + antagonist
+	if(M.mind)
+		special_role_description = "Role: <b>[M.mind.assigned_role]</b>; Antagonist: <font color='red'><b>[M.mind.special_role]</b></font>; Has been rev: [(M.mind.has_been_rev)?"Yes":"No"]"
+	else
+		special_role_description = "Role: <i>Mind datum missing</i> Antagonist: <i>Mind datum missing</i>; Has been rev: <i>Mind datum missing</i>;"
+
+	//Health
+	if(isliving(M))
+		var/mob/living/L = M
+		var/status
+		switch(M.stat)
+			if(0) status = "Alive"
+			if(1) status = "<font color='orange'><b>Unconscious</b></font>"
+			if(2) status = "<font color='red'><b>Dead</b></font>"
+		health_description = "Status = [status]"
+		health_description += "<BR>Oxy: [L.getOxyLoss()] - Tox: [L.getToxLoss()] - Fire: [L.getFireLoss()] - Brute: [L.getBruteLoss()] - Clone: [L.getCloneLoss()] - Brain: [L.getBrainLoss()]"
+	else
+		health_description = "This mob type has no health to speak of."
+
+	//Gener
+	switch(M.gender)
+		if(MALE,FEMALE)	gender_description = "[M.gender]"
+		else			gender_description = "<font color='red'><b>[M.gender]</b></font>"
+
+	to_chat(user, "<b>Info about [M.name]:</b> ")
+	to_chat(user, "Mob type = [M.type]; Gender = [gender_description] Damage = [health_description]")
+	to_chat(user, "Name = <b>[M.name]</b>; Real_name = [M.real_name]; Mind_name = [M.mind?"[M.mind.name]":""]; Key = <b>[M.key]</b>;")
+	to_chat(user, "Location = [location_description];")
+	to_chat(user, "[special_role_description]")
+	to_chat(user, "(<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a>) (<A HREF='?src=\ref[src];adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[M]'>VV</A>) (<A HREF='?src=\ref[src];subtlemessage=\ref[M]'>SM</A>) (<A HREF='?src=\ref[src];adminplayerobservefollow=\ref[M]'>FLW</A>) (<A HREF='?src=\ref[src];secretsadmin=check_antagonist'>CA</A>)")

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -26,23 +26,19 @@
 
 	var/list/modifiers = params2list(params)
 	if(check_rights(R_ADMIN, 0)) // Admin click shortcuts
-		var/mob/M = A
-		if(!istype(M))
-			M = locate() in A
+		var/mob/M
 		if(modifiers["shift"] && modifiers["ctrl"])
 			client.debug_variables(A)
 			return
 		if(modifiers["ctrl"])
+			M = get_mob_in_atom_with_warning(A)
 			if(M)
 				client.holder.show_player_panel(M)
-			else
-				to_chat(src, "<span class='warning'>No mob was found in the atom you clicked on.</span>")
 			return
 		if(modifiers["shift"] && modifiers["middle"])
+			M = get_mob_in_atom_with_warning(A)
 			if(M)
 				admin_mob_info(M)
-			else
-				to_chat(src, "<span class='warning'>No mob was found in the atom you clicked on.</span>")
 			return
 	if(modifiers["shift"])
 		ShiftClickOn(A)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -25,6 +25,25 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if(check_rights(R_ADMIN, 0)) // Admin click shortcuts
+		var/mob/M = A
+		if(!istype(M))
+			M = locate() in A
+		if(modifiers["shift"] && modifiers["ctrl"])
+			client.debug_variables(A)
+			return
+		if(modifiers["ctrl"])
+			if(M)
+				client.holder.show_player_panel(M)
+			else
+				to_chat(src, "<span class='warning'>No mob was found in the atom you clicked on.</span>")
+			return
+		if(modifiers["shift"] && modifiers["middle"])
+			if(M)
+				admin_mob_info(M)
+			else
+				to_chat(src, "<span class='warning'>No mob was found in the atom you clicked on.</span>")
+			return
 	if(modifiers["shift"])
 		ShiftClickOn(A)
 		return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1565,53 +1565,7 @@
 
 	else if(href_list["adminmoreinfo"])
 		var/mob/M = locate(href_list["adminmoreinfo"])
-		if(!ismob(M))
-			to_chat(usr, "This can only be used on instances of type /mob")
-			return
-
-		var/location_description = ""
-		var/special_role_description = ""
-		var/health_description = ""
-		var/gender_description = ""
-		var/turf/T = get_turf(M)
-
-		//Location
-		if(isturf(T))
-			if(isarea(T.loc))
-				location_description = "([M.loc == T ? "at coordinates " : "in [M.loc] at coordinates "] [T.x], [T.y], [T.z] in area <b>[T.loc]</b>)"
-			else
-				location_description = "([M.loc == T ? "at coordinates " : "in [M.loc] at coordinates "] [T.x], [T.y], [T.z])"
-
-		//Job + antagonist
-		if(M.mind)
-			special_role_description = "Role: <b>[M.mind.assigned_role]</b>; Antagonist: <font color='red'><b>[M.mind.special_role]</b></font>; Has been rev: [(M.mind.has_been_rev)?"Yes":"No"]"
-		else
-			special_role_description = "Role: <i>Mind datum missing</i> Antagonist: <i>Mind datum missing</i>; Has been rev: <i>Mind datum missing</i>;"
-
-		//Health
-		if(isliving(M))
-			var/mob/living/L = M
-			var/status
-			switch(M.stat)
-				if(0) status = "Alive"
-				if(1) status = "<font color='orange'><b>Unconscious</b></font>"
-				if(2) status = "<font color='red'><b>Dead</b></font>"
-			health_description = "Status = [status]"
-			health_description += "<BR>Oxy: [L.getOxyLoss()] - Tox: [L.getToxLoss()] - Fire: [L.getFireLoss()] - Brute: [L.getBruteLoss()] - Clone: [L.getCloneLoss()] - Brain: [L.getBrainLoss()]"
-		else
-			health_description = "This mob type has no health to speak of."
-
-		//Gener
-		switch(M.gender)
-			if(MALE,FEMALE)	gender_description = "[M.gender]"
-			else			gender_description = "<font color='red'><b>[M.gender]</b></font>"
-
-		to_chat(src.owner, "<b>Info about [M.name]:</b> ")
-		to_chat(src.owner, "Mob type = [M.type]; Gender = [gender_description] Damage = [health_description]")
-		to_chat(src.owner, "Name = <b>[M.name]</b>; Real_name = [M.real_name]; Mind_name = [M.mind?"[M.mind.name]":""]; Key = <b>[M.key]</b>;")
-		to_chat(src.owner, "Location = [location_description];")
-		to_chat(src.owner, "[special_role_description]")
-		to_chat(src.owner, "(<a href='?src=\ref[usr];priv_msg=\ref[M]'>PM</a>) (<A HREF='?src=\ref[src];adminplayeropts=\ref[M]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[M]'>VV</A>) (<A HREF='?src=\ref[src];subtlemessage=\ref[M]'>SM</A>) (<A HREF='?src=\ref[src];adminplayerobservefollow=\ref[M]'>FLW</A>) (<A HREF='?src=\ref[src];secretsadmin=check_antagonist'>CA</A>)")
+		admin_mob_info(M)
 
 	else if(href_list["adminspawncookie"])
 		if(!check_rights(R_ADMIN|R_EVENT))	return

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -89,6 +89,11 @@ Admin:
 \tF7 = Player Panel
 \tF8 = Admin PM
 \tF9 = Invisimin
+
+Admin ghost:
+\tCtrl+Click = Player Panel
+\tCtrl+Shift+Click = View Variables
+\tShift+Middle Click = Mob Info
 </font>"}
 
 	mob.hotkey_help()


### PR DESCRIPTION
This adds a few convenient click shortcuts for ghosted admins, to cut down on tedious right-clicking:

- **Ctrl+Click**: Opens the player panel for the selected mob.
- **Shift+Middle Click**: Shows extra info for the selected mob.
  - This is the little burst of info you normally get when clicking a ? link. It looks like this:
    ![dreamseeker_2016-07-25_23-00-02](https://cloud.githubusercontent.com/assets/10916307/17125009/dee1f4f2-52bd-11e6-8d3a-ce65de355e88.png)
- **Ctrl+Shift+Click**: Views variables of the clicked atom.

These have also been added to the hotkey help output.

For the shortcuts that use "the selected mob", clicking on a non-mob atom will attempt to select a mob inside that atom. This includes a mob that's on a turf, in a locker, in a mech, in a spacepod, etc. However, this will be the **first** mob found, which may not necessarily be the most relevant (you could get the mob inside an Odysseus' sleeper instead of the pilot, for example). If in doubt, look at the variables.

This also refactors the extra mob info code out of the admin topic handler and into its own proc, so it can be used by other things, such as these click shortcuts.

:cl:
rscadd: Admins now have click shortcuts for opening a player panel, showing mob info, and viewing variables. Specifics are in Hotkey Help.
/:cl: