### PR TITLE
Virology Tweaks

### DIFF
--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -43,11 +43,11 @@ Bonus
 	return
 
 /datum/symptom/choking/proc/Choke_stage_3_4(mob/living/M, datum/disease/advance/A)
-	var/get_damage = (sqrt(20+A.totalStageSpeed())/2)+(sqrt(16+A.totalStealth())*1)
+	var/get_damage = sqrt(21+A.totalStageSpeed()*0.5)+sqrt(16+A.totalStealth())
 	M.adjustOxyLoss(get_damage)
 	return 1
 
 /datum/symptom/choking/proc/Choke(mob/living/M, datum/disease/advance/A)
-	var/get_damage = (sqrt(20+A.totalStageSpeed())/2)+(sqrt(16+A.totalStealth()*5))
+	var/get_damage = sqrt(21+A.totalStageSpeed()*0.5)+sqrt(16+A.totalStealth()*5)
 	M.adjustOxyLoss(get_damage)
 	return 1

--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -45,8 +45,10 @@ Bonus
 		if(!parts.len)
 			return
 
-		M.heal_overall_damage(get_damage, get_damage)
+		for(var/obj/item/organ/external/E in parts)
+			E.heal_damage(get_damage, get_damage, 0, 0)
 		M.adjustToxLoss(get_damage*parts.len)
+
 
 	else
 		if(M.getFireLoss() > 0 || M.getBruteLoss() > 0)

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -21,7 +21,7 @@ Bonus
 	resistance = -4
 	stage_speed = -4
 	transmittable = -3
-	level = 6
+	level = 5
 	severity = 0
 
 /datum/symptom/sensory_restoration/Activate(var/datum/disease/advance/A)
@@ -38,12 +38,12 @@ Bonus
 					M.reagents.add_reagent_list(list("antihol"=10, "oculine"=10))
 					to_chat(M, "<span class='notice'>You feel sober.</span>")
 			if(4)
-				if(M.reagents.get_reagent_amount("antihol") < 10 && M.reagents.get_reagent_amount("oculine") < 10 && M.reagents.get_reagent_amount("synaptizine") < 10)
-					M.reagents.add_reagent_list(list("antihol"=10, "oculine"=10, "synaptizine"=5))
+				if(M.reagents.get_reagent_amount("antihol") < 10 && M.reagents.get_reagent_amount("oculine") < 10 && M.reagents.get_reagent_amount("synaphydramine") < 10)
+					M.reagents.add_reagent_list(list("antihol"=10, "oculine"=10, "synaphydramine"=5))
 					to_chat(M, "<span class='notice'>You feel focused.</span>")
 			if(5)
-				if(M.reagents.get_reagent_amount("antihol") < 10 && M.reagents.get_reagent_amount("oculine") < 10 && M.reagents.get_reagent_amount("synaptizine") < 10 && M.reagents.get_reagent_amount("mannitol") < 10)
-					M.reagents.add_reagent_list(list("mannitol"=10, "antihol"=10, "oculine"=10, "synaptizine"=10))
+				if(M.reagents.get_reagent_amount("antihol") < 10 && M.reagents.get_reagent_amount("oculine") < 10 && M.reagents.get_reagent_amount("synaphydramine") < 10 && M.reagents.get_reagent_amount("mannitol") < 10)
+					M.reagents.add_reagent_list(list("mannitol"=10, "antihol"=10, "oculine"=10, "synaphydramine"=10))
 					to_chat(M, "<span class='notice'>Your mind feels relaxed.</span>")
 	return
 

--- a/code/modules/reagents/newchem/disease.dm
+++ b/code/modules/reagents/newchem/disease.dm
@@ -127,7 +127,7 @@
 /datum/reagent/synaphydramine
 	name = "Diphen-Synaptizine"
 	id = "synaphydramine"
-	description = "Reduces drowsiness, hallucinations, and Histamine from body."
+	description = "Reduces drowsiness and hallucinations while also purging histamine from the body."
 	color = "#EC536D" // rgb: 236, 83, 109
 
 /datum/reagent/synaphydramine/on_mob_life(mob/living/M)

--- a/code/modules/reagents/newchem/disease.dm
+++ b/code/modules/reagents/newchem/disease.dm
@@ -122,6 +122,25 @@
 				qdel(ate_heart)
 	..()
 
+//virus-specific symptom reagents
+
+/datum/reagent/synaphydramine
+	name = "Diphen-Synaptizine"
+	id = "synaphydramine"
+	description = "Reduces drowsiness, hallucinations, and Histamine from body."
+	color = "#EC536D" // rgb: 236, 83, 109
+
+/datum/reagent/synaphydramine/on_mob_life(mob/living/M)
+	M.drowsyness = max(M.drowsyness-5, 0)
+	if(holder.has_reagent("lsd"))
+		holder.remove_reagent("lsd", 5)
+	if(holder.has_reagent("histamine"))
+		holder.remove_reagent("histamine", 5)
+	M.hallucination = max(0, M.hallucination - 10)
+	if(prob(30))
+		M.adjustToxLoss(1)
+	..()
+
 //virus food
 /datum/reagent/virus_food
 	name = "Virus Food"


### PR DESCRIPTION
Just some viro tweaks from TG

- resolves potential runtime with choking
- Sensory restoration nerfed; it no longer has anti-stun properties and no longer heals brain damage, but has a lower acquisition level
- Damage converter heals specific limbs instead of healing overall damage (actual impact difference? Not so much)


:cl: Fox McCloud
tweak: Sensory restoration virology symptom no longer has anti-stun properties nor heals brain damage, but has a lower acquisition level
tweak: Damage convert heals individual limbs instead of healing overall damage (actual impact is low)
/:cl: