### PR TITLE
Librarian QoL---Bookbag

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -339,7 +339,8 @@
 
 
 	equip(var/mob/living/carbon/human/H)
-		if(!H)	return 0
+		if(!H)
+			return 0
 		switch(H.backbag)
 			if(2) H.equip_or_collect(new /obj/item/weapon/storage/backpack(H), slot_back)
 			if(3) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel_norm(H), slot_back)
@@ -348,12 +349,10 @@
 		H.equip_or_collect(new /obj/item/clothing/under/suit_jacket/red(H), slot_w_uniform)
 		H.equip_or_collect(new /obj/item/device/pda/librarian(H), slot_wear_pda)
 		H.equip_or_collect(new /obj/item/clothing/shoes/black(H), slot_shoes)
-		H.equip_or_collect(new /obj/item/weapon/barcodescanner(H), slot_l_hand)
+		H.equip_or_collect(new /obj/item/weapon/storage/bag/books(H), slot_l_hand)
+		H.equip_or_collect(new /obj/item/weapon/barcodescanner(H), slot_r_store)
 		H.equip_or_collect(new /obj/item/device/laser_pointer(H), slot_l_store)
-		if(H.backbag == 1)
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
-		else
-			H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
+		H.equip_or_collect(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 		return 1
 
 /datum/job/barber

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -375,7 +375,7 @@
 	max_combined_w_class = 21
 	max_w_class = 3
 	w_class = 4 //Bigger than a book because physics
-	can_hold = list("/obj/item/weapon/book", "/obj/item/weapon/spellbook") //No bibles, consistent with bookcase
+	can_hold = list("/obj/item/weapon/book", "/obj/item/weapon/storage/bible", "/obj/item/weapon/tome", "/obj/item/weapon/spellbook")
 
 /*
  * Trays - Agouri

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -20,24 +20,30 @@
 	opacity = 1
 	var/health = 50
 	var/tmp/busy = 0
-	var/list/valid_types = list(/obj/item/weapon/book, \
-								/obj/item/weapon/tome, \
-								/obj/item/weapon/spellbook, \
-								/obj/item/weapon/storage/bible)
+	var/list/allowed_books = list(/obj/item/weapon/book, /obj/item/weapon/spellbook, /obj/item/weapon/storage/bible, /obj/item/weapon/tome) //Things allowed in the bookcase
 
 /obj/structure/bookcase/initialize()
 	..()
 	for(var/obj/item/I in loc)
-		if(is_type_in_list(I, valid_types))
+		if(is_type_in_list(I, allowed_books))
 			I.forceMove(src)
 	update_icon()
 
 /obj/structure/bookcase/attackby(obj/O as obj, mob/user as mob, params)
 	if(busy) //So that you can't mess with it while deconstructing
 		return 1
-	if(is_type_in_list(O, valid_types))
-		user.drop_item()
+	if(is_type_in_list(O, allowed_books))
+		if(!user.drop_item())
+			return
 		O.forceMove(src)
+		update_icon()
+		return 1
+	else if(istype(O, /obj/item/weapon/storage/bag/books))
+		var/obj/item/weapon/storage/bag/books/B = O
+		for(var/obj/item/T in B.contents)
+			if(istype(T, /obj/item/weapon/book) || istype(T, /obj/item/weapon/spellbook) || istype(T, /obj/item/weapon/tome) || istype(T, /obj/item/weapon/storage/bible))
+				B.remove_from_storage(T, src)
+		to_chat(user, "<span class='notice'>You empty [O] into [src].</span>")
 		update_icon()
 		return 1
 	else if(istype(O, /obj/item/weapon/wrench))
@@ -51,8 +57,6 @@
 			user.visible_message("<span class='warning'>[user] disassembles \the [src].</span>", \
 			"<span class='notice'>You disassemble \the [src].</span>")
 			busy = 0
-			for(var/i = 1 to 5)
-				new /obj/item/stack/sheet/wood(get_turf(src))
 			density = 0
 			qdel(src)
 		else
@@ -72,9 +76,6 @@
 			else
 		if(health <= 0)
 			visible_message("<span class=warning>The bookcase is smashed apart!</span>")
-			new /obj/item/stack/sheet/wood(get_turf(src))
-			new /obj/item/stack/sheet/wood(get_turf(src))
-			new /obj/item/stack/sheet/wood(get_turf(src))
 			qdel(src)
 		return ..()
 
@@ -110,10 +111,10 @@
 	return
 
 /obj/structure/bookcase/Destroy()
-	for(var/i = 1 to 3)
+	for(var/i in 1 to 5)
 		new /obj/item/stack/sheet/wood(get_turf(src))
 	for(var/obj/item/I in contents)
-		if(is_type_in_list(I, valid_types))
+		if(is_type_in_list(I, allowed_books))
 			I.forceMove(get_turf(src))
 	return ..()
 


### PR DESCRIPTION

- Librarian now starts off with a book bag
- Bookbag can now hold Bibles, cult tomes, regular books, and spellbooks
- Can empty a bookbag into a bookshelf
- Fixes an exploit where you could generate wood out of thin air

![img](https://i.gyazo.com/7f642f57fe770fa225bde8c0e2641a85.png)

:cl: Fox McCloud
add: Librarian now starts off with a bookbag
tweak: Bookbag can now hold Bibles, cult tomes, books, and spellbooks
add: Can empty a bookbag into a bookshelf
fix: Fixes an exploit where you could generate wood out of thin air
/:cl: