### PR TITLE
Minor SQL Consistency Fix

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -249,7 +249,7 @@ CREATE TABLE `player` (
   `volume` smallint(4) DEFAULT '100',
   `nanoui_fancy` smallint(4) DEFAULT '1',
   `show_ghostitem_attack` smallint(4) DEFAULT '1',
-  `lastchangelog` varchar(32) NOT NULL,
+  `lastchangelog` varchar(32) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`)
 ) ENGINE=InnoDB AUTO_INCREMENT=32446 DEFAULT CHARSET=latin1;

--- a/SQL/paradise_schema_prefixed.sql
+++ b/SQL/paradise_schema_prefixed.sql
@@ -249,7 +249,7 @@ CREATE TABLE `SS13_player` (
   `volume` smallint(4) DEFAULT '100',
   `nanoui_fancy` smallint(4) DEFAULT '1',
   `show_ghostitem_attack` smallint(4) DEFAULT '1',
-  `lastchangelog` varchar(32) NOT NULL,
+  `lastchangelog` varchar(32) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`)
 ) ENGINE=InnoDB AUTO_INCREMENT=32446 DEFAULT CHARSET=latin1;


### PR DESCRIPTION
Update the SQL schema to match a minor change that was made to the server's SQL tables so the `lastchangelog` entry doesn't break the `players` table. Has no effect on the server itself, but is something that downstreams and people who host local servers with a database set up should know about.