### PR TITLE
Fixes Blob, Again

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -36,7 +36,6 @@
 	melee_damage_upper = 4
 	attacktext = "hits"
 	attack_sound = 'sound/weapons/genhit1.ogg'
-	del_on_death = 1
 	speak_emote = list("pulses")
 	var/obj/effect/blob/factory/factory = null
 	var/list/human_overlays = list()
@@ -92,6 +91,7 @@
 	loc.visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
+	..()
 	// On death, create a small smoke of harmful gas (s-Acid)
 	var/datum/effect/system/chem_smoke_spread/S = new
 	var/turf/location = get_turf(src)
@@ -108,7 +108,7 @@
 	S.attach(location)
 	S.set_up(reagents, 1, 1, location, 15, 1) // only 1-2 smoke cloud
 	S.start()
-	..()
+	qdel(src)
 
 /mob/living/simple_animal/hostile/blob/blobspore/Destroy()
 	if(factory)


### PR DESCRIPTION
Should prevent blobspores from insta-killing people and potentially stopping crashes again.

Apparently even calling parent *after* everything runs is enough to generate crashes.

Fixes https://github.com/ParadiseSS13/Paradise/issues/5221

:cl: Fox McCloud
fix: Fixes blobspores doing more damage than intended
/:cl: