### PR TITLE
Fix ChangeTurf permanently making obscured areas obscured for AI's

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -166,6 +166,7 @@
 	var/list/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
 	var/old_blueprint_data = blueprint_data
+	var/old_obscured = obscured
 
 	if(air_master)
 		air_master.remove_from_active(src)
@@ -188,6 +189,8 @@
 			lighting_build_overlays()
 		else
 			lighting_clear_overlays()
+	
+	obscured = old_obscured
 
 	return W
 


### PR DESCRIPTION
Exactly what it says on the tin. It's not noticable before, but it was *definitely* noticable on FTL13, because of having cameras on giant shuttles.