### PR TITLE
Fixes Weirdly Specific View Variables Crashes Somehow

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -161,7 +161,7 @@
 	body += "<div align='center'><table width='100%'><tr><td width='50%'>"
 
 	if(sprite)
-		body += "<table align='center' width='100%'><tr><td>[bicon(D)]</td><td>"
+		body += "<table align='center' width='100%'><tr><td>[bicon(D, use_class=0)]</td><td>"
 	else
 		body += "<table align='center' width='100%'><tr><td>"
 
@@ -350,14 +350,14 @@ body
 
 	else if(isicon(value))
 		#ifdef VARSICON
-		html += "[name] = /icon (<span class='value'>[value]</span>) [bicon(value)]"
+		html += "[name] = /icon (<span class='value'>[value]</span>) [bicon(value, use_class=0)]"
 		#else
 		html += "[name] = /icon (<span class='value'>[value]</span>)"
 		#endif
 
 	else if(istype(value, /image))
 		#ifdef VARSICON
-		html += "<a href='?_src_=vars;Vars=\ref[value]'>[name] \ref[value]</a> = /image (<span class='value'>[value]</span>) [bicon(value)]"
+		html += "<a href='?_src_=vars;Vars=\ref[value]'>[name] \ref[value]</a> = /image (<span class='value'>[value]</span>) [bicon(value, use_class=0)]"
 		#else
 		html += "<a href='?_src_=vars;Vars=\ref[value]'>[name] \ref[value]</a> = /image (<span class='value'>[value]</span>)"
 		#endif

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -197,10 +197,6 @@ var/list/chatResources = list(
 
 	return "<img [class] src='data:image/png;base64,[bicon_cache[key]]'>"
 
-//Aliases for bicon
-/proc/bi(obj)
-	bicon(obj)
-
 var/to_chat_filename
 var/to_chat_line
 var/to_chat_src

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -171,7 +171,8 @@ var/list/chatResources = list(
 	var/list/partial = splittext(iconData, "{")
 	return replacetext(copytext(partial[2], 3, -5), "\n", "")
 
-/proc/bicon(var/obj)
+/proc/bicon(var/obj, var/use_class = 1)
+	var/class = use_class ? "class='icon misc'" : null
 	if (!obj)
 		return
 
@@ -179,7 +180,7 @@ var/list/chatResources = list(
 		if (!bicon_cache["\ref[obj]"]) // Doesn't exist yet, make it.
 			bicon_cache["\ref[obj]"] = icon2base64(obj)
 
-		return "<img class='icon misc' src='data:image/png;base64,[bicon_cache["\ref[obj]"]]'>"
+		return "<img [class] src='data:image/png;base64,[bicon_cache["\ref[obj]"]]'>"
 
 	// Either an atom or somebody fucked up and is gonna get a runtime, which I'm fine with.
 	var/atom/A = obj
@@ -191,8 +192,10 @@ var/list/chatResources = list(
 			I = icon()
 			I.Insert(temp, dir = SOUTH)
 		bicon_cache[key] = icon2base64(I, key)
+	if(use_class)
+		class = "class='icon [A.icon_state]'"
 
-	return "<img class='icon [A.icon_state]' src='data:image/png;base64,[bicon_cache[key]]'>"
+	return "<img [class] src='data:image/png;base64,[bicon_cache[key]]'>"
 
 //Aliases for bicon
 /proc/bi(obj)


### PR DESCRIPTION
A few very specific items (some folder colors, the gavel block) are forcing Dream Seeker to reconnect when included as bicons in HTML browsed to a client. Only *some* folder colors are doing it, and the only meaningful difference I could see was the class, which includes the name of the icon state. I have no clue, whatsoever, why these would be causing the reconnects; the classes aren't even defined in the styles. But... excluding the classes from the HTML seems to fix it...

... so, that's what this PR does. Adds an argument to `bicon()` that lets you turn off the classy bit of the `img` tag, and uses that in the VV code. And it works. And I don't know why. Perhaps I-- perhaps *we,* all of us, are better off not knowing why.

Fixes #5247.

:cl:
bugfix: Probably fixed some very specific items messing up View Variables for no adequately explicable reason.
/:cl: