### PR TITLE
Fixes exploding backpacks

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -22,7 +22,7 @@
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	playsound(src.loc, "rustle", 50, 1, -5)
-	..()
+	return ..()
 
 /*
  * Backpack Types


### PR DESCRIPTION
Fixes issue with putting the X4 (issue #5140) into the backpack starts the activation. Thanks to CrazyLemon for helping me out with this.