### PR TITLE
Fixes Round-End Objective List Runtimes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -335,7 +335,7 @@
 		job_master.FreeRole(job)
 
 		if(occupant.mind.objectives.len)
-			qdel(occupant.mind.objectives)
+			occupant.mind.objectives.Cut()
 			occupant.mind.special_role = null
 		else
 			if(ticker.mode.name == "AutoTraitor")

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -34,7 +34,7 @@ var/global/list/empty_playable_ai_cores = list()
 	job_master.FreeRole(job)
 
 	if(mind.objectives.len)
-		qdel(mind.objectives)
+		mind.objectives.Cut()
 		mind.special_role = null
 	else
 		if(ticker.mode.name == "AutoTraitor")


### PR DESCRIPTION
The objectives list each mind has is never supposed to be nulled out, but was being nulled out by antagonists leaving the round through cryodorms or AI core wiping, which would then cause the round-end antagonist report to runtime, preventing any antagonists and their objectives from getting listed.

:cl:
bugfix: Fixed round-end antagonist report failing to print due to null objectives.
/:cl: