### PR TITLE
Fixes Hypospray Theft Objective

### DIFF
--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -111,7 +111,7 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/device/aicard/C)
 
 /datum/theft_objective/hypospray
 	name = "a hypospray"
-	typepath = /obj/item/weapon/reagent_containers/hypospray
+	typepath = /obj/item/weapon/reagent_containers/hypospray/CMO
 	protected_jobs = list("Chief Medical Officer")
 
 /datum/theft_objective/ablative

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -19,9 +19,6 @@
 	var/list/all_items = owner.current.get_contents()
 	for(var/obj/I in all_items) //Check for items
 		if(istype(I, typepath) && check_special_completion(I))
-			//Stealing the cheap autoinjector doesn't count
-			if(istype(I, /obj/item/weapon/reagent_containers/hypospray/autoinjector))
-				continue
 			return 1
 	return 0
 


### PR DESCRIPTION
Bug:
- Currently, advanced pinpointers inherit steal objectives as potential targets. This means they can start tracking other subtypes of /obj/item/weapon/reagent_containers/hypospray - such as autoinjectors.

This PR:
- This PR modifies the theft objective for the hypospray, such that it always targets the unique CMO hypospray.

:cl: Kyep
fix: Fixed bug with adv pinpointers and CMO hypospray theft objectives. Fixes #5232 
/:cl:

