### PR TITLE
Refactor stack recipes

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -10,80 +10,82 @@
 /*
  * Metal
  */
-var/global/list/datum/stack_recipe/metal_recipes = list ( \
-	new/datum/stack_recipe("stool", /obj/structure/stool, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("chair", /obj/structure/stool/bed/chair, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("sofa (middle)", /obj/structure/stool/bed/chair/sofa, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("sofa (left)", /obj/structure/stool/bed/chair/sofa/left, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("sofa (right)", /obj/structure/stool/bed/chair/sofa/right, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("sofa (corner)", /obj/structure/stool/bed/chair/sofa/corner, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("barber chair", /obj/structure/stool/bed/chair/barber, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("wheelchair", /obj/structure/stool/bed/chair/wheelchair, 15, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("bed", /obj/structure/stool/bed, 2, one_per_turf = 1, on_floor = 1), \
-	null, \
-	new/datum/stack_recipe_list("office chairs",list( \
-		new/datum/stack_recipe("dark office chair", /obj/structure/stool/bed/chair/office/dark, 5, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("light office chair", /obj/structure/stool/bed/chair/office/light, 5, one_per_turf = 1, on_floor = 1), \
-		), 5), \
-	new/datum/stack_recipe_list("comfy chairs", list( \
-		new/datum/stack_recipe("beige comfy chair", /obj/structure/stool/bed/chair/comfy/beige, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("black comfy chair", /obj/structure/stool/bed/chair/comfy/black, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("brown comfy chair", /obj/structure/stool/bed/chair/comfy/brown, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("lime comfy chair", /obj/structure/stool/bed/chair/comfy/lime, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("teal comfy chair", /obj/structure/stool/bed/chair/comfy/teal, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("red comfy chair", /obj/structure/stool/bed/chair/comfy/red, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("blue comfy chair", /obj/structure/stool/bed/chair/comfy/blue, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("purple comfy chair", /obj/structure/stool/bed/chair/comfy/purp, 2, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("green comfy chair", /obj/structure/stool/bed/chair/comfy/green, 2, one_per_turf = 1, on_floor = 1), \
-		), 2), \
-	null, \
-	new/datum/stack_recipe("table parts", /obj/item/weapon/table_parts, 2), \
-	new/datum/stack_recipe("glass table frame parts", /obj/item/weapon/table_parts/glass, 2), \
-	new/datum/stack_recipe("rack parts", /obj/item/weapon/rack_parts), \
-	new/datum/stack_recipe("closet", /obj/structure/closet, 2, time = 15, one_per_turf = 1, on_floor = 1), \
-	null, \
-	new/datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = 1, on_floor = 1), \
-	null, \
-	new/datum/stack_recipe("floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20), \
-	new/datum/stack_recipe("metal rod", /obj/item/stack/rods, 1, 2, 60), \
-	null, \
-	new/datum/stack_recipe("computer frame", /obj/structure/computerframe, 5, time = 25, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 50, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("machine frame", /obj/machinery/constructable_frame/machine_frame, 5, time = 25, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 25, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("meatspike frame", /obj/structure/kitchenspike_frame, 5, time = 25, one_per_turf = 1, on_floor = 1), \
-	null, \
-	new/datum/stack_recipe_list("airlock assemblies", list( \
-		new/datum/stack_recipe("standard airlock assembly", /obj/structure/door_assembly, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("command airlock assembly", /obj/structure/door_assembly/door_assembly_com, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("security airlock assembly", /obj/structure/door_assembly/door_assembly_sec, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("engineering airlock assembly", /obj/structure/door_assembly/door_assembly_eng, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("mining airlock assembly", /obj/structure/door_assembly/door_assembly_min, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("atmospherics airlock assembly", /obj/structure/door_assembly/door_assembly_atmo, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("research airlock assembly", /obj/structure/door_assembly/door_assembly_research, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-/*		new/datum/stack_recipe("science airlock assembly", /obj/structure/door_assembly/door_assembly_science, 4, time = 50, one_per_turf = 1, on_floor = 1), \ */
-		new/datum/stack_recipe("medical airlock assembly", /obj/structure/door_assembly/door_assembly_med, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("maintenance airlock assembly", /obj/structure/door_assembly/door_assembly_mai, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("external airlock assembly", /obj/structure/door_assembly/door_assembly_ext, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("freezer airlock assembly", /obj/structure/door_assembly/door_assembly_fre, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("airtight hatch assembly", /obj/structure/door_assembly/door_assembly_hatch, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("maintenance hatch assembly", /obj/structure/door_assembly/door_assembly_mhatch, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		new/datum/stack_recipe("multi-tile airlock assembly", /obj/structure/door_assembly/multi_tile, 4, time = 50, one_per_turf = 1, on_floor = 1), \
-		), 4), \
-	null, \
-	new/datum/stack_recipe("mass driver button frame", /obj/item/mounted/frame/driver_button, 1, time = 50, one_per_turf = 0, on_floor = 1), \
-	new/datum/stack_recipe("light switch frame", /obj/item/mounted/frame/light_switch, 1, time = 50, one_per_turf = 0, on_floor = 1), \
-	null, \
-	new/datum/stack_recipe("grenade casing", /obj/item/weapon/grenade/chem_grenade), \
-	new/datum/stack_recipe("light fixture frame", /obj/item/mounted/frame/light_fixture, 2), \
-	new/datum/stack_recipe("small light fixture frame", /obj/item/mounted/frame/light_fixture/small, 1), \
-	null, \
-	new/datum/stack_recipe("apc frame", /obj/item/mounted/frame/apc_frame, 2), \
-	new/datum/stack_recipe("air alarm frame", /obj/item/mounted/frame/alarm_frame, 2), \
-	new/datum/stack_recipe("fire alarm frame", /obj/item/mounted/frame/firealarm, 2), \
-	new/datum/stack_recipe("intercom frame", /obj/item/mounted/frame/intercom, 2), \
-	null, \
+var/global/list/datum/stack_recipe/metal_recipes = list(
+	new /datum/stack_recipe("stool", /obj/structure/stool, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("chair", /obj/structure/stool/bed/chair, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("sofa (middle)", /obj/structure/stool/bed/chair/sofa, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("sofa (left)", /obj/structure/stool/bed/chair/sofa/left, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("sofa (right)", /obj/structure/stool/bed/chair/sofa/right, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("sofa (corner)", /obj/structure/stool/bed/chair/sofa/corner, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("barber chair", /obj/structure/stool/bed/chair/barber, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("wheelchair", /obj/structure/stool/bed/chair/wheelchair, 15, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("bed", /obj/structure/stool/bed, 2, one_per_turf = 1, on_floor = 1),
+	null,
+	new /datum/stack_recipe_list("office chairs",list(
+		new /datum/stack_recipe("dark office chair", /obj/structure/stool/bed/chair/office/dark, 5, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("light office chair", /obj/structure/stool/bed/chair/office/light, 5, one_per_turf = 1, on_floor = 1),
+	), 5),
+
+	new /datum/stack_recipe_list("comfy chairs", list(
+		new /datum/stack_recipe("beige comfy chair", /obj/structure/stool/bed/chair/comfy/beige, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("black comfy chair", /obj/structure/stool/bed/chair/comfy/black, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("brown comfy chair", /obj/structure/stool/bed/chair/comfy/brown, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("lime comfy chair", /obj/structure/stool/bed/chair/comfy/lime, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("teal comfy chair", /obj/structure/stool/bed/chair/comfy/teal, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("red comfy chair", /obj/structure/stool/bed/chair/comfy/red, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("blue comfy chair", /obj/structure/stool/bed/chair/comfy/blue, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("purple comfy chair", /obj/structure/stool/bed/chair/comfy/purp, 2, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("green comfy chair", /obj/structure/stool/bed/chair/comfy/green, 2, one_per_turf = 1, on_floor = 1),
+	), 2),
+
+	null,
+	new /datum/stack_recipe("table parts", /obj/item/weapon/table_parts, 2),
+	new /datum/stack_recipe("glass table frame parts", /obj/item/weapon/table_parts/glass, 2),
+	new /datum/stack_recipe("rack parts", /obj/item/weapon/rack_parts),
+	new /datum/stack_recipe("closet", /obj/structure/closet, 2, time = 15, one_per_turf = 1, on_floor = 1),
+	null,
+	new /datum/stack_recipe("canister", /obj/machinery/portable_atmospherics/canister, 10, time = 15, one_per_turf = 1, on_floor = 1),
+	null,
+	new /datum/stack_recipe("floor tile", /obj/item/stack/tile/plasteel, 1, 4, 20),
+	new /datum/stack_recipe/rods("metal rod", /obj/item/stack/rods, 1, 2, 60),
+	null,
+	new /datum/stack_recipe("computer frame", /obj/structure/computerframe, 5, time = 25, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("wall girders", /obj/structure/girder, 2, time = 50, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("machine frame", /obj/machinery/constructable_frame/machine_frame, 5, time = 25, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("turret frame", /obj/machinery/porta_turret_construct, 5, time = 25, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("meatspike frame", /obj/structure/kitchenspike_frame, 5, time = 25, one_per_turf = 1, on_floor = 1),
+	null,
+	new /datum/stack_recipe_list("airlock assemblies", list(
+		new /datum/stack_recipe("standard airlock assembly", /obj/structure/door_assembly, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("command airlock assembly", /obj/structure/door_assembly/door_assembly_com, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("security airlock assembly", /obj/structure/door_assembly/door_assembly_sec, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("engineering airlock assembly", /obj/structure/door_assembly/door_assembly_eng, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("mining airlock assembly", /obj/structure/door_assembly/door_assembly_min, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("atmospherics airlock assembly", /obj/structure/door_assembly/door_assembly_atmo, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("research airlock assembly", /obj/structure/door_assembly/door_assembly_research, 4, time = 50, one_per_turf = 1, on_floor = 1),
+/*		new /datum/stack_recipe("science airlock assembly", /obj/structure/door_assembly/door_assembly_science, 4, time = 50, one_per_turf = 1, on_floor = 1), */
+		new /datum/stack_recipe("medical airlock assembly", /obj/structure/door_assembly/door_assembly_med, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("maintenance airlock assembly", /obj/structure/door_assembly/door_assembly_mai, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("external airlock assembly", /obj/structure/door_assembly/door_assembly_ext, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("freezer airlock assembly", /obj/structure/door_assembly/door_assembly_fre, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("airtight hatch assembly", /obj/structure/door_assembly/door_assembly_hatch, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("maintenance hatch assembly", /obj/structure/door_assembly/door_assembly_mhatch, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 50, one_per_turf = 1, on_floor = 1),
+		new /datum/stack_recipe("multi-tile airlock assembly", /obj/structure/door_assembly/multi_tile, 4, time = 50, one_per_turf = 1, on_floor = 1),
+	), 4),
+	null,
+	new /datum/stack_recipe("mass driver button frame", /obj/item/mounted/frame/driver_button, 1, time = 50, one_per_turf = 0, on_floor = 1),
+	new /datum/stack_recipe("light switch frame", /obj/item/mounted/frame/light_switch, 1, time = 50, one_per_turf = 0, on_floor = 1),
+	null,
+	new /datum/stack_recipe("grenade casing", /obj/item/weapon/grenade/chem_grenade),
+	new /datum/stack_recipe("light fixture frame", /obj/item/mounted/frame/light_fixture, 2),
+	new /datum/stack_recipe("small light fixture frame", /obj/item/mounted/frame/light_fixture/small, 1),
+	null,
+	new /datum/stack_recipe("apc frame", /obj/item/mounted/frame/apc_frame, 2),
+	new /datum/stack_recipe("air alarm frame", /obj/item/mounted/frame/alarm_frame, 2),
+	new /datum/stack_recipe("fire alarm frame", /obj/item/mounted/frame/firealarm, 2),
+	new /datum/stack_recipe("intercom frame", /obj/item/mounted/frame/intercom, 2),
+	null
 )
 
 /obj/item/stack/sheet/metal
@@ -106,13 +108,12 @@ var/global/list/datum/stack_recipe/metal_recipes = list ( \
 /*
  * Plasteel
  */
-var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
-	new/datum/stack_recipe("AI core", /obj/structure/AIcore, 4, time = 50, one_per_turf = 1), \
-	new/datum/stack_recipe("Surgery Table", /obj/machinery/optable, 5, time = 50, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("Metal crate", /obj/structure/closet/crate, 10, time = 50, one_per_turf = 1), \
-	new/datum/stack_recipe("Mass Driver frame", /obj/machinery/mass_driver_frame, 3, time = 50, one_per_turf = 1), \
-
-	)
+var/global/list/datum/stack_recipe/plasteel_recipes = list(
+	new /datum/stack_recipe("AI core", /obj/structure/AIcore, 4, time = 50, one_per_turf = 1),
+	new /datum/stack_recipe("Surgery Table", /obj/machinery/optable, 5, time = 50, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("Metal crate", /obj/structure/closet/crate, 10, time = 50, one_per_turf = 1),
+	new /datum/stack_recipe("Mass Driver frame", /obj/machinery/mass_driver_frame, 3, time = 50, one_per_turf = 1)
+)
 
 /obj/item/stack/sheet/plasteel
 	name = "plasteel"
@@ -132,21 +133,21 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list ( \
 /*
  * Wood
  */
-var/global/list/datum/stack_recipe/wood_recipes = list ( \
-	new/datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1), \
-	new/datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20), \
-	new/datum/stack_recipe("table parts", /obj/item/weapon/table_parts/wood, 2), \
-	new/datum/stack_recipe("wooden chair", /obj/structure/stool/bed/chair/wood/normal, 3, time = 10, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, 5, time = 50, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("bookcase", /obj/structure/bookcase, 5, time = 50, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("rifle stock", /obj/item/weaponcrafting/stock, 10, time = 40), \
-	new/datum/stack_recipe("wooden door", /obj/structure/mineral_door/wood, 10, time = 20, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("coffin", /obj/structure/closet/coffin, 5, time = 15, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("easel", /obj/structure/easel, 3, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("wooden buckler", /obj/item/weapon/shield/riot/buckler, 20, time = 40), \
-	new/datum/stack_recipe("apiary", /obj/structure/beebox, 40, time = 50),\
-	new/datum/stack_recipe("honey frame", /obj/item/honey_frame, 5, time = 10),\
-	)
+var/global/list/datum/stack_recipe/wood_recipes = list(
+	new /datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1),
+	new /datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20),
+	new /datum/stack_recipe("table parts", /obj/item/weapon/table_parts/wood, 2),
+	new /datum/stack_recipe("wooden chair", /obj/structure/stool/bed/chair/wood/normal, 3, time = 10, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, 5, time = 50, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("bookcase", /obj/structure/bookcase, 5, time = 50, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("rifle stock", /obj/item/weaponcrafting/stock, 10, time = 40),
+	new /datum/stack_recipe("wooden door", /obj/structure/mineral_door/wood, 10, time = 20, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("coffin", /obj/structure/closet/coffin, 5, time = 15, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("easel", /obj/structure/easel, 3, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("wooden buckler", /obj/item/weapon/shield/riot/buckler, 20, time = 40),
+	new /datum/stack_recipe("apiary", /obj/structure/beebox, 40, time = 50),
+	new /datum/stack_recipe("honey frame", /obj/item/honey_frame, 5, time = 10)
+)
 
 /obj/item/stack/sheet/wood
 	name = "wooden planks"
@@ -173,18 +174,18 @@ var/global/list/datum/stack_recipe/wood_recipes = list ( \
 /*
  * Cardboard
  */
-var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
-	new/datum/stack_recipe("box", /obj/item/weapon/storage/box), \
-	new/datum/stack_recipe("large box", /obj/item/weapon/storage/box/large, 4), \
-	new/datum/stack_recipe("light tubes", /obj/item/weapon/storage/box/lights/tubes), \
-	new/datum/stack_recipe("light bulbs", /obj/item/weapon/storage/box/lights/bulbs), \
-	new/datum/stack_recipe("mouse traps", /obj/item/weapon/storage/box/mousetraps), \
-	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3), \
-	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg), \
-	new/datum/stack_recipe("pizza box", /obj/item/pizzabox), \
-	new/datum/stack_recipe("folder", /obj/item/weapon/folder), \
-	new/datum/stack_recipe("cardboard tube", /obj/item/weapon/c_tube), \
-	new/datum/stack_recipe("cardboard box", /obj/structure/closet/cardboard, 4), \
+var/global/list/datum/stack_recipe/cardboard_recipes = list (
+	new /datum/stack_recipe("box", /obj/item/weapon/storage/box),
+	new /datum/stack_recipe("large box", /obj/item/weapon/storage/box/large, 4),
+	new /datum/stack_recipe("light tubes", /obj/item/weapon/storage/box/lights/tubes),
+	new /datum/stack_recipe("light bulbs", /obj/item/weapon/storage/box/lights/bulbs),
+	new /datum/stack_recipe("mouse traps", /obj/item/weapon/storage/box/mousetraps),
+	new /datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),
+	new /datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),
+	new /datum/stack_recipe("pizza box", /obj/item/pizzabox),
+	new /datum/stack_recipe("folder", /obj/item/weapon/folder),
+	new /datum/stack_recipe("cardboard tube", /obj/item/weapon/c_tube),
+	new /datum/stack_recipe("cardboard box", /obj/structure/closet/cardboard, 4),
 )
 
 /obj/item/stack/sheet/cardboard	//BubbleWrap
@@ -194,6 +195,6 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list ( \
 	icon_state = "sheet-card"
 	origin_tech = "materials=1"
 
-/obj/item/stack/sheet/cardboard/New(var/loc, var/amount=null)
-		recipes = cardboard_recipes
-		return ..()
+/obj/item/stack/sheet/cardboard/New(var/loc, var/amt = null)
+	recipes = cardboard_recipes
+	return ..()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -48,7 +48,7 @@
 		recipe_list = srl.recipes
 
 	var/t1 = "Amount Left: [amount]<br>"
-	for(var/i = 1, i <= recipe_list.len, i++)
+	for(var/i in 1 to recipe_list.len)
 		var/E = recipe_list[i]
 		if(isnull(E))
 			t1 += "<hr>"

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -10,156 +10,171 @@
  */
 /obj/item/stack
 	origin_tech = "materials=1"
-	var/list/datum/stack_recipe/recipes
+	var/list/recipes = list() // /datum/stack_recipe
 	var/singular_name
 	var/amount = 1
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 
-/obj/item/stack/New(var/loc, var/amount=null)
+/obj/item/stack/New(var/loc, var/amt = null)
 	..()
-	if(amount!=null)	//Allow for stacks with the amount=0
-		src.amount=amount
-	return
+	if(amt != null)	//Allow for stacks with the amount=0
+		amount = amt
 
 /obj/item/stack/Destroy()
-	if(usr && usr.machine==src)
+	if(usr && usr.machine == src)
 		usr << browse(null, "window=stack")
 	return ..()
 
 /obj/item/stack/examine(mob/user)
 	if(..(user, 1))
-		to_chat(user, "There are [src.amount] [src.singular_name]\s in the stack.")
+		to_chat(user, "There are [amount] [singular_name]\s in the stack.")
 
-
-/obj/item/stack/attack_self(mob/user as mob)
+/obj/item/stack/attack_self(mob/user)
 	list_recipes(user)
 
-/obj/item/stack/proc/list_recipes(mob/user as mob, recipes_sublist)
+/obj/item/stack/proc/list_recipes(mob/user, recipes_sublist)
 	if(!recipes)
 		return
-	if(!src || amount<=0)
+
+	if(amount <= 0)
 		user << browse(null, "window=stack")
+		return
+
 	user.set_machine(src) //for correct work of onclose
+
 	var/list/recipe_list = recipes
 	if(recipes_sublist && recipe_list[recipes_sublist] && istype(recipe_list[recipes_sublist], /datum/stack_recipe_list))
 		var/datum/stack_recipe_list/srl = recipe_list[recipes_sublist]
 		recipe_list = srl.recipes
+
 	var/t1 = "Amount Left: [amount]<br>"
-	for(var/i=1;i<=recipe_list.len,i++)
+	for(var/i = 1, i <= recipe_list.len, i++)
 		var/E = recipe_list[i]
 		if(isnull(E))
 			t1 += "<hr>"
 			continue
 
-		if(i>1 && !isnull(recipe_list[i-1]))
-			t1+="<br>"
+		if(i > 1 && !isnull(recipe_list[i - 1]))
+			t1 += "<br>"
 
 		if(istype(E, /datum/stack_recipe_list))
 			var/datum/stack_recipe_list/srl = E
-			if(src.amount >= srl.req_amount)
-				t1 += "<a href='?src=\ref[src];sublist=[i]'>[srl.title] ([srl.req_amount] [src.singular_name]\s)</a>"
+			if(amount >= srl.req_amount)
+				t1 += "<a href='?src=\ref[src];sublist=[i]'>[srl.title] ([srl.req_amount] [singular_name]\s)</a>"
 			else
-				t1 += "[srl.title] ([srl.req_amount] [src.singular_name]\s)<br>"
+				t1 += "[srl.title] ([srl.req_amount] [singular_name]\s)<br>"
 
 		if(istype(E, /datum/stack_recipe))
 			var/datum/stack_recipe/R = E
 			var/max_multiplier = round(src.amount / R.req_amount)
-			var/title as text
+			var/title
 			var/can_build = 1
-			can_build = can_build && (max_multiplier>0)
+			can_build = can_build && (max_multiplier > 0)
 			/*
 			if(R.one_per_turf)
 				can_build = can_build && !(locate(R.result_type) in usr.loc)
 			if(R.on_floor)
 				can_build = can_build && istype(usr.loc, /turf/simulated/floor)
 			*/
-			if(R.res_amount>1)
-				title+= "[R.res_amount]x [R.title]\s"
+			if(R.res_amount > 1)
+				title += "[R.res_amount]x [R.title]\s"
 			else
-				title+= "[R.title]"
-			title+= " ([R.req_amount] [src.singular_name]\s)"
+				title += "[R.title]"
+			title += " ([R.req_amount] [src.singular_name]\s)"
 			if(can_build)
-				t1 += text("<A href='?src=\ref[src];sublist=[recipes_sublist];make=[i]'>[title]</A>  ")
+				t1 += "<A href='?src=\ref[src];sublist=[recipes_sublist];make=[i]'>[title]</A>  "
 			else
-				t1 += text("[]", title)
+				t1 += "[title]"
 				continue
 			if(R.max_res_amount>1 && max_multiplier>1)
-				max_multiplier = min(max_multiplier, round(R.max_res_amount/R.res_amount))
+				max_multiplier = min(max_multiplier, round(R.max_res_amount / R.res_amount))
 				t1 += " |"
 				var/list/multipliers = list(5,10,25)
 				for(var/n in multipliers)
 					if(max_multiplier>=n)
-						t1 += " <A href='?src=\ref[src];make=[i];multiplier=[n]'>[n*R.res_amount]x</A>"
+						t1 += " <A href='?src=\ref[src];make=[i];multiplier=[n]'>[n * R.res_amount]x</A>"
 				if(!(max_multiplier in multipliers))
-					t1 += " <A href='?src=\ref[src];make=[i];multiplier=[max_multiplier]'>[max_multiplier*R.res_amount]x</A>"
+					t1 += " <A href='?src=\ref[src];make=[i];multiplier=[max_multiplier]'>[max_multiplier * R.res_amount]x</A>"
 
 	var/datum/browser/popup = new(user, "stack", name, 400, 400)
 	popup.set_content(t1)
 	popup.open(0)
 	onclose(user, "stack")
-	return
 
 /obj/item/stack/Topic(href, href_list)
 	..()
-	if((usr.restrained() || usr.stat || usr.get_active_hand() != src))
-		return
+	if(usr.incapacitated() || usr.get_active_hand() != src)
+		return 0
 
 	if(href_list["sublist"] && !href_list["make"])
 		list_recipes(usr, text2num(href_list["sublist"]))
 
 	if(href_list["make"])
-		if(src.amount < 1) del(src) //Never should happen
+		if(amount < 1)
+			del(src) //Never should happen
 
 		var/list/recipes_list = recipes
 		if(href_list["sublist"])
 			var/datum/stack_recipe_list/srl = recipes_list[text2num(href_list["sublist"])]
 			recipes_list = srl.recipes
+
 		var/datum/stack_recipe/R = recipes_list[text2num(href_list["make"])]
 		var/multiplier = text2num(href_list["multiplier"])
-		if(!multiplier) multiplier = 1
-		if(src.amount < R.req_amount*multiplier)
-			if(R.req_amount*multiplier>1)
-				to_chat(usr, "\red You haven't got enough [src] to build \the [R.req_amount*multiplier] [R.title]\s!")
+		if(!multiplier)
+			multiplier = 1
+
+		if(amount < R.req_amount * multiplier)
+			if(R.req_amount * multiplier>1)
+				to_chat(usr, "<span class='warning'>You haven't got enough [src] to build \the [R.req_amount * multiplier] [R.title]\s!</span>")
 			else
-				to_chat(usr, "\red You haven't got enough [src] to build \the [R.title]!")
-			return
+				to_chat(usr, "<span class='warning'>You haven't got enough [src] to build \the [R.title]!</span>")
+			return 0
+
 		if(R.one_per_turf && (locate(R.result_type) in usr.loc))
-			to_chat(usr, "\red There is another [R.title] here!")
-			return
+			to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
+			return 0
+
 		if(R.on_floor && !istype(usr.loc, /turf/simulated))
-			to_chat(usr, "\red \The [R.title] must be constructed on the floor!")
-			return
+			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
+			return 0
+
 		if(R.time)
-			to_chat(usr, "\blue Building [R.title] ...")
+			to_chat(usr, "<span class='notice'>Building [R.title] ...</span>")
 			if(!do_after(usr, R.time, target = usr))
-				return
-		if(src.amount < R.req_amount*multiplier)
+				return 0
+
+		if(amount < R.req_amount * multiplier)
 			return
-		var/atom/O = new R.result_type( usr.loc )
+
+		var/atom/O = new R.result_type(usr.loc)
 		O.dir = usr.dir
-		if(R.max_res_amount>1)
+		if(R.max_res_amount > 1)
 			var/obj/item/stack/new_item = O
-			new_item.amount = R.res_amount*multiplier
+			new_item.amount = R.res_amount * multiplier
 			//new_item.add_to_stacks(usr)
-		src.amount-=R.req_amount*multiplier
-		if(src.amount < 1) // Just in case a stack's amount ends up fractional somehow
+
+		R.post_build(src, O)
+
+		amount -= R.req_amount * multiplier
+		if(amount < 1) // Just in case a stack's amount ends up fractional somehow
 			var/oldsrc = src
 			src = null //dont kill proc after del()
 			usr.unEquip(oldsrc, 1)
 			del(oldsrc) // Not qdel, because qdel'd stacks act strange for cyborgs
-			if(istype(O,/obj/item))
+			if(istype(O, /obj/item))
 				usr.put_in_hands(O)
+
 		O.add_fingerprint(usr)
 		//BubbleWrap - so newly formed boxes are empty
-		if( istype(O, /obj/item/weapon/storage) )
+		if(istype(O, /obj/item/weapon/storage))
 			for(var/obj/item/I in O)
 				del(I)
 		//BubbleWrap END
-	if(src && usr.machine==src) //do not reopen closed window
-		spawn( 0 )
-			src.interact(usr)
+
+	if(src && usr.machine == src) //do not reopen closed window
+		spawn(0)
+			interact(usr)
 			return
-	return
 
 /obj/item/stack/proc/use(var/used)
 	if(amount < used)
@@ -173,15 +188,15 @@
 	update_icon()
 	return 1
 
-/obj/item/stack/proc/add_to_stacks(mob/usr as mob)
+/obj/item/stack/proc/add_to_stacks(mob/usr)
 	var/obj/item/stack/oldsrc = src
 	src = null
 	for(var/obj/item/stack/item in usr.loc)
-		if(item==oldsrc)
+		if(item == oldsrc)
 			continue
 		if(!istype(item, oldsrc.type))
 			continue
-		if(item.amount>=item.max_amount)
+		if(item.amount >= item.max_amount)
 			continue
 		oldsrc.attackby(item, usr)
 		to_chat(usr, "You add new [item.singular_name] to the stack. It now contains [item.amount] [item.singular_name]\s.")
@@ -204,7 +219,7 @@
 	use(amt)
 	return F
 
-/obj/item/stack/attack_hand(mob/user as mob)
+/obj/item/stack/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)
 		var/obj/item/stack/F = split(user, 1)
 		user.put_in_hands(F)
@@ -214,14 +229,15 @@
 	else
 		..()
 
-/obj/item/stack/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/stack/attackby(obj/item/W, mob/user, params)
 	..()
-	if(istype(W, src.type))
+	if(istype(W, type))
 		var/obj/item/stack/S = W
 		if(S.amount >= max_amount)
 			return 1
-		var/to_transfer as num
-		if(user.get_inactive_hand()==src)
+
+		var/to_transfer
+		if(user.get_inactive_hand() == src)
 			var/desired = input("How much would you like to transfer from this stack?", "How much?", 1) as null|num
 			if(!desired)
 				return
@@ -229,52 +245,22 @@
 			to_transfer = max(1,min(desired,S.max_amount-S.amount,src.amount))
 		else
 			to_transfer = min(src.amount, S.max_amount-S.amount)
-		S.amount+=to_transfer
-		if(S && usr.machine==S)
-			spawn(0) S.interact(usr)
-		src.use(to_transfer)
-		if(src && usr.machine==src)
-			spawn(0) src.interact(usr)
+
+		S.amount += to_transfer
+		if(S && usr.machine == S)
+			spawn(0)
+				S.interact(usr)
+		use(to_transfer)
+		if(src && usr.machine == src)
+			spawn(0)
+				interact(usr)
 		S.update_icon()
-	else return ..()
+	else
+		return ..()
 
-/obj/item/stack/proc/copy_evidences(obj/item/stack/from as obj)
-	src.blood_DNA = from.blood_DNA
-	src.fingerprints  = from.fingerprints
-	src.fingerprintshidden  = from.fingerprintshidden
-	src.fingerprintslast  = from.fingerprintslast
+/obj/item/stack/proc/copy_evidences(obj/item/stack/from)
+	blood_DNA			= from.blood_DNA
+	fingerprints		= from.fingerprints
+	fingerprintshidden	= from.fingerprintshidden
+	fingerprintslast	= from.fingerprintslast
 	//TODO bloody overlay
-
-/*
- * Recipe datum
- */
-/datum/stack_recipe
-	var/title = "ERROR"
-	var/result_type
-	var/req_amount = 1
-	var/res_amount = 1
-	var/max_res_amount = 1
-	var/time = 0
-	var/one_per_turf = 0
-	var/on_floor = 0
-	New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0)
-		src.title = title
-		src.result_type = result_type
-		src.req_amount = req_amount
-		src.res_amount = res_amount
-		src.max_res_amount = max_res_amount
-		src.time = time
-		src.one_per_turf = one_per_turf
-		src.on_floor = on_floor
-
-/*
- * Recipe list datum
- */
-/datum/stack_recipe_list
-	var/title = "ERROR"
-	var/list/recipes = null
-	var/req_amount = 1
-	New(title, recipes, req_amount = 1)
-		src.title = title
-		src.recipes = recipes
-		src.req_amount = req_amount

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -1,0 +1,55 @@
+
+/*
+ * Recipe datum
+ */
+/datum/stack_recipe
+	var/title = "ERROR"
+	var/result_type
+	var/req_amount = 1
+	var/res_amount = 1
+	var/max_res_amount = 1
+	var/time = 0
+	var/one_per_turf = 0
+	var/on_floor = 0
+
+/datum/stack_recipe/New(title, result_type, req_amount = 1, res_amount = 1, max_res_amount = 1, time = 0, one_per_turf = 0, on_floor = 0)
+	src.title = title
+	src.result_type = result_type
+	src.req_amount = req_amount
+	src.res_amount = res_amount
+	src.max_res_amount = max_res_amount
+	src.time = time
+	src.one_per_turf = one_per_turf
+	src.on_floor = on_floor
+
+/datum/stack_recipe/proc/post_build(var/obj/item/stack/S, var/obj/result)
+	return
+
+/* Special Recipes */
+
+/datum/stack_recipe/cable_restraints
+/datum/stack_recipe/cable_restraints/post_build(var/obj/item/stack/S, var/obj/result)
+	if(istype(result, /obj/item/weapon/restraints/handcuffs/cable))
+		result.color = S.color
+	..()
+
+/datum/stack_recipe/rods
+/datum/stack_recipe/rods/post_build(var/obj/item/stack/S, var/obj/result)
+	if(istype(result, /obj/item/stack/rods))
+		var/obj/item/stack/rods/R = result
+		R.update_icon()
+	..()
+
+/*
+ * Recipe list datum
+ */
+/datum/stack_recipe_list
+	var/title = "ERROR"
+	var/list/recipes = null
+	var/req_amount = 1
+
+/datum/stack_recipe_list/New(title, recipes, req_amount = 1)
+	src.title = title
+	src.recipes = recipes
+	src.req_amount = req_amount
+

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -65,7 +65,7 @@
 /obj/item/weapon/restraints/handcuffs/cable
 	name = "cable restraints"
 	desc = "Looks like some cables tied together. Could be used to tie something up."
-	icon_state = "cuff_red"
+	icon_state = "cuff_white"
 	materials = list(MAT_METAL=150, MAT_GLASS=75)
 	breakouttime = 300 //Deciseconds = 30s
 	cuffsound = 'sound/weapons/cablecuff.ogg'

--- a/code/modules/nano/interaction/base.dm
+++ b/code/modules/nano/interaction/base.dm
@@ -12,9 +12,9 @@
 	return STATUS_CLOSE
 
 /mob/proc/shared_nano_interaction()
-	if(src.stat || !client)
+	if(stat || !client)
 		return STATUS_CLOSE						// no updates, close the interface
-	else if(restrained() || lying || stat || stunned || weakened)
+	else if(restrained() || lying || stunned || weakened)
 		return STATUS_UPDATE					// update only (orange visibility)
 	return STATUS_INTERACTIVE
 	

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -24,7 +24,7 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/structure/cable
 	level = 1
-	anchored =1
+	anchored = 1
 	on_blueprints = TRUE
 	var/datum/powernet/powernet
 	name = "power cable"
@@ -457,12 +457,13 @@ obj/structure/cable/proc/cableColor(var/colorC)
 
 #define MAXCOIL 30
 
-var/global/list/datum/stack_recipe/cable_coil_recipes = list ( \
-	new/datum/stack_recipe("cable restraints", /obj/item/weapon/restraints/handcuffs/cable, 15), \
-	)
+var/global/list/datum/stack_recipe/cable_coil_recipes = list(
+	new /datum/stack_recipe/cable_restraints("cable restraints", /obj/item/weapon/restraints/handcuffs/cable, 15),
+)
 
 /obj/item/stack/cable_coil
 	name = "cable coil"
+	singular_name = "cable"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "coil"
 	item_state = "coil_red"

--- a/paradise.dme
+++ b/paradise.dme
@@ -764,6 +764,7 @@
 #include "code\game\objects\items\stacks\nanopaste.dm"
 #include "code\game\objects\items\stacks\rods.dm"
 #include "code\game\objects\items\stacks\stack.dm"
+#include "code\game\objects\items\stacks\stack_recipe.dm"
 #include "code\game\objects\items\stacks\telecrystal.dm"
 #include "code\game\objects\items\stacks\sheets\glass.dm"
 #include "code\game\objects\items\stacks\sheets\leather.dm"


### PR DESCRIPTION
 - Styling fixes
 - Added post_build() to stack recipes, for any recipes that need to do
   something special
   - Called with two arguments, the stack that it originated from, and the
     new object.
 - Moved stack recipes to their own file

Currently, only two things use post_build
 - Cablecuffs use it to color the cuffs the same as the wire they
   originated from
 - Metal rods use it to call update_icon, in order to display the correct
   sprite for whatever amount of rods you created.

:cl:
rscadd: Readded colored cable-cuffs.
tweak: Making stacks of metal rods now updates the icon correctly.
/:cl:

![https://i.imgur.com/tINOxK3.png](https://i.imgur.com/tINOxK3.png)