### PR TITLE
pAIs are No Longer Illusionists

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -566,6 +566,9 @@
 	var/obj/item/weapon/holder/H = ..()
 	if(!istype(H))
 		return
+	if(resting)
+		icon_state = "[chassis]"
+		resting = 0
 	H.icon_state = "pai-[icon_state]"
 	H.item_state = "pai-[icon_state]"
 	grabber.put_in_active_hand(H)//for some reason unless i call this it dosen't work


### PR DESCRIPTION
Fixes #5262

Mostly did this so I could fix @Aurorablade's broken changelog entries. Remember kids, you need a space after the tag.

:cl: Fethas
rscadd: Due to various complaints from tajarans having hand cramps, glove makers have removed plasteel from the fabric.
tweak: Plasmaman can no longer be vampires.
tweak: Removes the mask check on both victim AND vampire, also makes the message a bit more obscure, so it's up to your imagination of where you are biting them and with what.
/:cl: