### PR TITLE
Fixes wooden coffins deconstructing into metal sheets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -6,6 +6,7 @@
 	icon_opened = "coffin_open"
 	burn_state = FLAMMABLE
 	burntime = 20
+	material_drop = /obj/item/stack/sheet/wood
 
 /obj/structure/closet/coffin/update_icon()
 	if(!opened)
@@ -19,3 +20,4 @@
 	icon_closed = "sarc"
 	icon_opened = "sarc_open"
 	sound = 'sound/effects/stonedoor_openclose.ogg'
+	material_drop = /obj/item/stack/sheet/mineral/sandstone


### PR DESCRIPTION
Sure, I /could/ fix the messages and the fact that a wooden coffin is deconstructed with a welder, but just think of it as slicing the hinges apart because I'm too lazy.
Also makes sarcophagi deconstruct into sandstone, but I don't think I've ever seen those in-game.
Thanks to L0rd_English for reporting this.
:cl:
fix: Coffins will now deconstruct into wood instead of metal.
/:cl: