### PR TITLE
Massive Playsound() Performance Improvement

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -25,25 +25,28 @@ var/list/ricochet = list('sound/weapons/effects/ric1.ogg', 'sound/weapons/effect
 	var/turf/turf_source = get_turf(source)
 
  	// Looping through the player list has the added bonus of working for mobs inside containers
+	var/sound/S = sound(soundin)
+	var/maxdistance = (world.view + extrarange) * 3
 	for(var/P in player_list)
 		var/mob/M = P
 		if(!M || !M.client)
 			continue
-
 		var/distance = get_dist(M, turf_source)
-		if(distance <= (world.view + extrarange) * 3)
+
+		if(distance <= maxdistance)
 			var/turf/T = get_turf(M)
 
 			if(T && T.z == turf_source.z)
-				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global)
+				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, S)
 
 var/const/FALLOFF_SOUNDS = 0.5
 
-/mob/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global)
-	if(!src.client || ear_deaf > 0)	return
-	soundin = get_sfx(soundin)
+/mob/proc/playsound_local(var/turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, sound/S)
+	if(!src.client || ear_deaf > 0)
+		return
 
-	var/sound/S = sound(soundin)
+	if(!S)
+		S = sound(get_sfx(soundin))
 	S.wait = 0 //No queue
 	S.channel = 0 //Any channel
 	S.volume = vol

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -515,7 +515,7 @@
 	update()
 
 /obj/machinery/light/proc/broken(var/skip_sound_and_sparks = 0)
-	if(status == LIGHT_EMPTY)
+	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN)
 		return
 
 	if(!skip_sound_and_sparks)


### PR DESCRIPTION
As it turns out, making and deleting sound datums for a few dozen mobs all in the same tick, repeatedly was **unbelievably** bad for performance. Who could've guessed?

[Total CPU profile without changes](http://pastebin.com/Ccw09Jmu)
[Total CPU profile with changes](http://pastebin.com/9VVnjGn4)

The changes to playsound() alone reduce the CPU load to around 5% (per call) of what it was prior when using the "Destroy All Lights" button in the secrets panel while there are 100 players online (tested by removing client checks and using `mob_list` instead of `player_list`).

Credit to @PJB3005, @Krausus, and @Fox-McCloud, who all participated in bashing their heads against this issue for a few hours today.

Also makes it so broken lights don't rebreak upon broken() being called, which made the lag happen every time a sling ascended.
Fixes #5252 

:cl:
fix: Shadowling ascendance and badmins pressing the "Destroy All Lights" button should no longer bring the server to its knees.
fix: Broken lights will no longer re-break.
/:cl: