### PR TITLE
More Overload Lighting Performance

### DIFF
--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -54,7 +54,7 @@
 				apc.overload_lighting()
 
 	else
-		for(var/obj/machinery/power/apc/apc in machines)
+		for(var/obj/machinery/power/apc/apc in apcs)
 			apc.overload_lighting()
 
 	return

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -289,7 +289,7 @@ rcd light flash thingy on matter drain
 	for(var/datum/AI_Module/small/blackout/blackout in current_modules)
 		if(blackout.uses > 0)
 			blackout.uses --
-			for(var/obj/machinery/power/apc/apc in world)
+			for(var/obj/machinery/power/apc/apc in apcs)
 				if(prob(30*apc.overload))
 					apc.overload_lighting()
 				else

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -80,7 +80,7 @@
 
 
 	// Check station's power levels
-	for(var/obj/machinery/power/apc/A in machines)
+	for(var/obj/machinery/power/apc/A in apcs)
 		// TODO: Tie into space manager
 		if(!(A.z in config.station_levels)) continue
 

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -34,7 +34,7 @@
 		S.update_icon()
 		S.power_change()
 
-	for(var/obj/machinery/power/apc/C in world)
+	for(var/obj/machinery/power/apc/C in apcs)
 		var/area/current_area = get_area(C)
 		// TODO: Tie into space manager
 		if(current_area.type in skipped_areas_apc || !(C.z in config.station_levels))
@@ -48,7 +48,7 @@
 
 	if(announce)
 		command_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
-	for(var/obj/machinery/power/apc/C in machines)
+	for(var/obj/machinery/power/apc/C in apcs)
 		var/area/current_area = get_area(C)
 		// TODO: Tie into space manager
 		if(current_area.type in skipped_areas_apc || !(C.z in config.station_levels))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -977,8 +977,8 @@
 		return 0
 
 	else if(href_list["overload"])
-		if(istype(usr, /mob/living/silicon) && !aidisabled)
-			src.overload_lighting()
+		if(issilicon(usr) && !aidisabled)
+			overload_lighting()
 
 	else if(href_list["malfhack"])
 		var/mob/living/silicon/ai/malfai = usr
@@ -1383,17 +1383,17 @@
 
 // overload all the lights in this APC area
 
-/obj/machinery/power/apc/proc/overload_lighting(var/chance = 100)
-	if(/* !get_connection() || */ !operating || shorted)
+/obj/machinery/power/apc/proc/overload_lighting(chance = 100)
+	if(!operating || shorted)
 		return
-	if( cell && cell.charge>=20)
-		cell.use(20);
+	if(cell && cell.charge >= 20)
+		cell.use(20)
 		spawn(0)
 			for(var/obj/machinery/light/L in area)
 				if(prob(chance))
 					L.on = 1
 					L.broken()
-				sleep(1)
+					stoplag()
 
 /obj/machinery/power/apc/proc/setsubsystem(val)
 	if(cell && cell.charge > 0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -514,7 +514,7 @@
 	status = LIGHT_EMPTY
 	update()
 
-/obj/machinery/light/proc/broken(var/skip_sound_and_sparks = 0)
+/obj/machinery/light/proc/broken(skip_sound_and_sparks = 0)
 	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN)
 		return
 


### PR DESCRIPTION
A lot of APC loops still loop through machines or...worse, `in world`. This changes that.

Also follow's TG's lead and uses `stoplag` for the lighting loop as opposed to a sleep. I can use `CHECK_TICK`, but this means that the "one at a time" effect of blowing lights will be gone.

I tried `overload_lighting` both with a spawn and without it (and set waitfor = 0), but it wasn't clear if the set waitfor = 0 was a benefit or not, so I opted to keep the spawn--can change to set waitfor if needbe though.