### PR TITLE
Removed shuttle options from secrets menu

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -44,7 +44,7 @@
 						<A href='?src=\ref[src];secretsfun=forcelaunchshuttle'>Force launch a shuttle</A><BR>
 						<A href='?src=\ref[src];secretsfun=jumpshuttle'>Jump a shuttle</A>&nbsp;&nbsp;
 						<A href='?src=\ref[src];secretsfun=moveshuttle'>Move a shuttle</A><BR>
-						<BR></center> s
+						<BR></center>
 					"}
 
 			else if(check_rights(R_SERVER,0)) //only add this if admin secrets are unavailiable; otherwise, it's added inline
@@ -133,5 +133,3 @@
 	var/datum/browser/popup = new(usr, "secrets", "<div align='center'>Admin Secrets</div>", 630, 670)
 	popup.set_content(dat)
 	popup.open(0)
-
-

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -38,13 +38,7 @@
 						<A href='?src=\ref[src];secretsfun=power'>Make all areas powered</A>&nbsp;&nbsp;
 						<A href='?src=\ref[src];secretsfun=unpower'>Make all areas unpowered</A>&nbsp;&nbsp;
 						<A href='?src=\ref[src];secretsfun=quickpower'>Power all SMES</A><BR>
-						<BR>
-						<B>Shuttle options</b><br>
-						<A href='?src=\ref[src];secretsfun=launchshuttle'>Launch a shuttle</A>&nbsp;&nbsp;
-						<A href='?src=\ref[src];secretsfun=forcelaunchshuttle'>Force launch a shuttle</A><BR>
-						<A href='?src=\ref[src];secretsfun=jumpshuttle'>Jump a shuttle</A>&nbsp;&nbsp;
-						<A href='?src=\ref[src];secretsfun=moveshuttle'>Move a shuttle</A><BR>
-						<BR></center>
+						</center>
 					"}
 
 			else if(check_rights(R_SERVER,0)) //only add this if admin secrets are unavailiable; otherwise, it's added inline
@@ -133,3 +127,5 @@
 	var/datum/browser/popup = new(usr, "secrets", "<div align='center'>Admin Secrets</div>", 630, 670)
 	popup.set_content(dat)
 	popup.open(0)
+
+

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -44,7 +44,7 @@
 						<A href='?src=\ref[src];secretsfun=forcelaunchshuttle'>Force launch a shuttle</A><BR>
 						<A href='?src=\ref[src];secretsfun=jumpshuttle'>Jump a shuttle</A>&nbsp;&nbsp;
 						<A href='?src=\ref[src];secretsfun=moveshuttle'>Move a shuttle</A><BR>
-						<BR></center>
+						<BR></center> s
 					"}
 
 			else if(check_rights(R_SERVER,0)) //only add this if admin secrets are unavailiable; otherwise, it's added inline


### PR DESCRIPTION
This just removed the options, since the verbs were removed.

This is from issue #5196