### PR TITLE
Removed unused options in secrets menu

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -38,13 +38,7 @@
 						<A href='?src=\ref[src];secretsfun=power'>Make all areas powered</A>&nbsp;&nbsp;
 						<A href='?src=\ref[src];secretsfun=unpower'>Make all areas unpowered</A>&nbsp;&nbsp;
 						<A href='?src=\ref[src];secretsfun=quickpower'>Power all SMES</A><BR>
-						<BR>
-						<B>Shuttle options</b><br>
-						<A href='?src=\ref[src];secretsfun=launchshuttle'>Launch a shuttle</A>&nbsp;&nbsp;
-						<A href='?src=\ref[src];secretsfun=forcelaunchshuttle'>Force launch a shuttle</A><BR>
-						<A href='?src=\ref[src];secretsfun=jumpshuttle'>Jump a shuttle</A>&nbsp;&nbsp;
-						<A href='?src=\ref[src];secretsfun=moveshuttle'>Move a shuttle</A><BR>
-						<BR></center>
+						</center>
 					"}
 
 			else if(check_rights(R_SERVER,0)) //only add this if admin secrets are unavailiable; otherwise, it's added inline


### PR DESCRIPTION
Finally, this one should work. Don't use the desktop app kids, only
fucks you over.

Kind of for admins only, but it removes the options for the shuttle in
the secrets menu.

Related issue #5196

:cl: Yurivw
Fix: Condimaster now actually makes bottles.
Removed: Unused options in admin secret menu are now removed.
/:cl: