### PR TITLE
Small Telecomms Optimization

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -61,36 +61,12 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			if(long_range_link == 0 && machine.long_range_link == 0)
 				continue
 		// If we're sending a copy, be sure to create the copy for EACH machine and paste the data
-		var/datum/signal/copy = new
+		var/datum/signal/copy
 		if(copysig)
-
+			copy = new
 			copy.transmission_method = 2
 			copy.frequency = signal.frequency
-			// Copy the main data contents! Workaround for some nasty bug where the actual array memory is copied and not its contents.
-			copy.data = list(
-
-			"mob" = signal.data["mob"],
-			"mobtype" = signal.data["mobtype"],
-			"realname" = signal.data["realname"],
-			"name" = signal.data["name"],
-			"job" = signal.data["job"],
-			"key" = signal.data["key"],
-			"vmessage" = signal.data["vmessage"],
-			"vname" = signal.data["vname"],
-			"vmask" = signal.data["vmask"],
-			"compression" = signal.data["compression"],
-			"message" = signal.data["message"],
-			"connection" = signal.data["connection"],
-			"radio" = signal.data["radio"],
-			"slow" = signal.data["slow"],
-			"traffic" = signal.data["traffic"],
-			"type" = signal.data["type"],
-			"server" = signal.data["server"],
-			"reject" = signal.data["reject"],
-			"level" = signal.data["level"],
-			"verb" = signal.data["verb"],
-			"language" = signal.data["language"]
-			)
+			copy.data = signal.data.Copy()
 
 			// Keep the "original" signal constant
 			if(!signal.data["original"])
@@ -98,15 +74,11 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 			else
 				copy.data["original"] = signal.data["original"]
 
-		else
-			qdel(copy)
-
-
 		send_count++
 		if(machine.is_freq_listening(signal))
 			machine.traffic++
 
-		if(copysig && copy)
+		if(copysig)
 			machine.receive_information(copy, src)
 		else
 			machine.receive_information(signal, src)


### PR DESCRIPTION
telecomms no longer needlessly creates tons of signal datums then promptly deletes them, if they're unneeded; it will only create them when actually needed.

Also the copied signal's data is just copied directly instead of manually setting every bit of data.