### PR TITLE
Wormhole Event Fixup

### DIFF
--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -17,7 +17,7 @@
 		if((T.z in config.station_levels))
 			pick_turfs += T
 
-	for(var/i = 1, i <= number_of_wormholes, i++)
+	for(var/i in 1 to number_of_wormholes)
 		var/turf/T = pick(pick_turfs)
 		wormholes += new /obj/effect/portal/wormhole(T, null, null, -1)
 
@@ -31,9 +31,8 @@
 			if(T)	O.loc = T
 
 /datum/event/wormholes/end()
-	portals.Remove(wormholes)
 	for(var/obj/effect/portal/wormhole/O in wormholes)
-		O.loc = null
+		qdel(O)
 	wormholes.Cut()
 
 


### PR DESCRIPTION
Fixes up the wormholes event

- Faster loop for making the wormholes
- Properly `qdel`'s all wormholes when the event ends as opposed to setting their `loc` to null.