### PR TITLE
Fixes TK users being shocked for no reason when using shocked machinery

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -544,6 +544,8 @@ Class Procs:
 		return 0
 	if(!prob(prb))
 		return 0
+	if((TK in user.mutations) && !Adjacent(user))
+		return 0
 	var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 	s.set_up(5, 1, src)
 	s.start()


### PR DESCRIPTION
fixes #4706
There's probably a merge conflict, but I can't find it to fix it, so I'm hoping black magic occurs somehow. Yeah. Git is totally black magic. I believe it.

:cl: Ar3nn
fix: Telekinesis no longer is subject to meatspace problems
/:cl: