### PR TITLE
Reverts Instant Health Doll Due to Performance Reasons

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -26,7 +26,6 @@
 		update_revive()
 	med_hud_set_health()
 	med_hud_set_status()
-	handle_hud_icons()
 
 /mob/living/carbon/human/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)


### PR DESCRIPTION
Reverts instant health doll updates.

Instant health updates are still technically a problem (even with the instant health doll updates)..unfortunately our `Life` loop is just not efficient enough to allow for that yet--that said, in the mean time, this is going to have to go; it's profiling at insane levels at the moment, to the degree it's sometimes outpacing human `update_icons`, largely due to incessantly `Cut`ting and rebuilding of the overlays any time someone so much as take 0.1 brute damage. 

With 100 players, well, you get the idea.