### PR TITLE
Field Generator Cleanup, Singularity Fixes,

### DIFF
--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -673,7 +673,7 @@ steam.start() -- spawns the effect
 	for(var/mob/living/carbon/human/R in get_turf(src))
 		if(R.internal != null && usr.wear_mask && (R.wear_mask.flags & AIRTIGHT) && R.wear_suit != null && !istype(R.wear_suit, /obj/item/clothing/suit/storage/labcoat) && !istype(R.wear_suit, /obj/item/clothing/suit/straight_jacket) && !istype(R.wear_suit, /obj/item/clothing/suit/straight_jacket && !istype(R.wear_suit, /obj/item/clothing/suit/armor)))
 		else
-			R.burn_skin(0.75)
+			R.adjustFireLoss(0.75)
 			if(R.coughedtime != 1)
 				R.coughedtime = 1
 				R.emote("gasp")
@@ -687,7 +687,7 @@ steam.start() -- spawns the effect
 	if(istype(R, /mob/living/carbon/human))
 		if(R.internal != null && usr.wear_mask && (R.wear_mask.flags & AIRTIGHT) && R.wear_suit != null && !istype(R.wear_suit, /obj/item/clothing/suit/storage/labcoat) && !istype(R.wear_suit, /obj/item/clothing/suit/straight_jacket) && !istype(R.wear_suit, /obj/item/clothing/suit/straight_jacket && !istype(R.wear_suit, /obj/item/clothing/suit/armor)))
 			return
-		R.burn_skin(0.75)
+		R.adjustFireLoss(0.75)
 		if(R.coughedtime != 1)
 			R.coughedtime = 1
 			R.emote("gasp")

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -77,13 +77,10 @@
 	s.start()
 	visible_message("<span class='danger'>The electric chair went off!</span>", "<span class='danger'>You hear a deep sharp shock!</span>")
 	if(buckled_mob)
-		buckled_mob.burn_skin(90)
+		buckled_mob.electrocute_act(110, src, 1)
 		to_chat(buckled_mob, "<span class='danger'>You feel a deep shock course through your body!</span>")
-		sleep(1)
-		buckled_mob.burn_skin(90)
-		sleep(5)
-		buckled_mob.burn_skin(max(rand(5,20),rand(5,20),rand(5,20)))
-
+		spawn(1)
+			buckled_mob.electrocute_act(110, src, 1)
 	A.power_light = light
 	A.updateicon()
 	return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1371,19 +1371,25 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if(alert("Are you sure? This will start up the engine. Should only be used during debug!",,"Yes","No") != "Yes")
 		return
 
-	for(var/obj/machinery/power/emitter/E in world)
+	for(var/obj/machinery/power/emitter/E in machines)
 		if(E.anchored)
 			E.active = 1
 
-	for(var/obj/machinery/field/generator/F in world)
-		if(F.anchored)
-			F.Varedit_start = 1
+	for(var/obj/machinery/field/generator/F in machines)
+		if(F.active == 0)
+			F.active = 1
+			F.state = 2
+			F.power = 250
+			F.anchored = 1
+			F.warming_up = 3
+			F.start_fields()
+			F.update_icon()
+
 	spawn(30)
-		for(var/obj/machinery/the_singularitygen/G in world)
+		for(var/obj/machinery/the_singularitygen/G in machines)
 			if(G.anchored)
 				var/obj/singularity/S = new /obj/singularity(get_turf(G), 50)
-				spawn(0)
-					qdel(G)
+//				qdel(G)
 				S.energy = 1750
 				S.current_size = 7
 				S.icon = 'icons/effects/224x224.dmi'
@@ -1397,7 +1403,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 				//S.dissipate_track = 0
 				//S.dissipate_strength = 10
 
-	for(var/obj/machinery/power/rad_collector/Rad in world)
+	for(var/obj/machinery/power/rad_collector/Rad in machines)
 		if(Rad.anchored)
 			if(!Rad.P)
 				var/obj/item/weapon/tank/plasma/Plasma = new/obj/item/weapon/tank/plasma(Rad)
@@ -1409,7 +1415,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			if(!Rad.active)
 				Rad.toggle_power()
 
-	for(var/obj/machinery/power/smes/SMES in world)
+	for(var/obj/machinery/power/smes/SMES in machines)
 		if(SMES.anchored)
 			SMES.input_attempt = 1
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -92,22 +92,6 @@
 /mob/living/proc/calculate_affecting_pressure(var/pressure)
 	return 0
 
-
-//sort of a legacy burn method for /electrocute, /shock, and the e_chair
-/mob/living/proc/burn_skin(burn_amount)
-	if(istype(src, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = src	//make this damage method divide the damage to be done among all the body parts, then burn each body part for that much damage. will have better effect then just randomly picking a body part
-		var/divided_damage = (burn_amount)/(H.organs.len)
-		var/extradam = 0	//added to when organ is at max dam
-		for(var/obj/item/organ/external/affecting in H.organs)
-			if(!affecting)	continue
-			if(affecting.take_damage(0, divided_damage+extradam))	//TODO: fix the extradam stuff. Or, ebtter yet...rewrite this entire proc ~Carn
-				H.UpdateDamageIcon()
-		H.updatehealth()
-		return 1
-	else if(istype(src, /mob/living/silicon/ai))
-		return 0
-
 /mob/living/proc/adjustBodyTemp(actual, desired, incrementboost)
 	var/temperature = actual
 	var/difference = abs(actual-desired)	//get difference

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -15,10 +15,8 @@
 	var/obj/machinery/field/generator/FG2 = null
 
 /obj/machinery/field/containment/Destroy()
-	if(FG1 && !FG1.clean_up)
-		FG1.cleanup()
-	if(FG2 && !FG2.clean_up)
-		FG2.cleanup()
+	FG1.fields -= src
+	FG2.fields -= src
 	return ..()
 
 /obj/machinery/field/containment/attack_hand(mob/user)
@@ -67,35 +65,26 @@
 /obj/machinery/field
 	var/hasShocked = 0 //Used to add a delay between shocks. In some cases this used to crash servers by spawning hundreds of sparks every second.
 
-/obj/machinery/field/CanPass(mob/mover, turf/target, height=0)
+/obj/machinery/field/CanPass(atom/movable/mover, turf/target, height=0)
+	if(hasShocked)
+		return 0
 	if(isliving(mover)) // Don't let mobs through
 		shock_field(mover)
 		return 0
-	return ..()
-
-/obj/machinery/field/CanPass(obj/mover, turf/target, height=0)
-	if((istype(mover, /obj/machinery) && !istype(mover, /obj/singularity)) || \
-		istype(mover, /obj/structure) || \
-		istype(mover, /obj/mecha))
+	if(istype(mover, /obj/machinery) || istype(mover, /obj/structure) || istype(mover, /obj/mecha))
 		bump_field(mover)
 		return 0
 	return ..()
 
 /obj/machinery/field/proc/shock_field(mob/living/user)
-	if(hasShocked)
-		return 0
 	if(isliving(user))
-		hasShocked = 1
 		var/shock_damage = min(rand(30,40),rand(30,40))
 
 		if(iscarbon(user))
 			var/stun = min(shock_damage, 15)
 			user.Stun(stun)
 			user.Weaken(10)
-			user.burn_skin(shock_damage)
-			user.visible_message("<span class='danger'>[user.name] was shocked by the [src.name]!</span>", \
-			"<span class='userdanger'>You feel a powerful shock course through your body, sending you flying!</span>", \
-			"<span class='italics'>You hear a heavy electrical crack.</span>")
+			user.electrocute_act(shock_damage, src, 1)
 
 		else if(issilicon(user))
 			if(prob(20))
@@ -108,13 +97,14 @@
 		user.updatehealth()
 		bump_field(user)
 
-		spawn(5)
-			hasShocked = 0
-	return
-
 /obj/machinery/field/proc/bump_field(atom/movable/AM as mob|obj)
+	if(hasShocked)
+		return 0
+	hasShocked = 1
 	var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 	s.set_up(5, 1, AM.loc)
 	s.start()
 	var/atom/target = get_edge_target_turf(AM, get_dir(src, get_step_away(AM, src)))
 	AM.throw_at(target, 200, 4)
+	spawn(5)
+		hasShocked = 0

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -106,7 +106,7 @@ field_generator power level display
 		var/obj/item/weapon/weldingtool/WT = W
 		switch(state)
 			if(FG_UNSECURED)
-				user << "<span class='warning'>The [name] needs to be wrenched to the floor!</span>"
+				to_chat(user, "<span class='warning'>The [name] needs to be wrenched to the floor!</span>")
 
 			if(FG_SECURED)
 				if(WT.remove_fuel(0,user))

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -13,6 +13,15 @@ field_generator power level display
 */
 
 #define field_generator_max_power 250
+
+#define FG_UNSECURED 0
+#define FG_SECURED 1
+#define FG_WELDED 2
+
+#define FG_OFFLINE 0
+#define FG_CHARGING 1
+#define FG_ONLINE 2
+
 /obj/machinery/field/generator
 	name = "Field Generator"
 	desc = "A large thermal battery that projects a high amount of energy when powered."
@@ -22,16 +31,14 @@ field_generator power level display
 	density = 1
 	use_power = 0
 	var/const/num_power_levels = 6	// Total number of power level icon has
-	var/Varedit_start = 0
-	var/Varpower = 0
-	var/active = 0
+	var/power_level = 0
+	var/active = FG_OFFLINE
 	var/power = 20  // Current amount of power
-	var/state = 0
+	var/state = FG_UNSECURED
 	var/warming_up = 0
 	var/list/obj/machinery/field/containment/fields
 	var/list/obj/machinery/field/generator/connected_gens
 	var/clean_up = 0
-
 
 /obj/machinery/field/generator/update_icon()
 	overlays.Cut()
@@ -39,117 +46,94 @@ field_generator power level display
 		overlays += "+a[warming_up]"
 	if(fields.len)
 		overlays += "+on"
-	// Power level indicator
-	// Scale % power to % num_power_levels and truncate value
-	var/level = round(num_power_levels * power / field_generator_max_power)
-	// Clamp between 0 and num_power_levels for out of range power values
-	level = Clamp(level, 0, num_power_levels)
-	if(level)
-		overlays += "+p[level]"
-
-	return
+	if(power_level)
+		overlays += "+p[power_level]"
 
 
 /obj/machinery/field/generator/New()
 	..()
 	fields = list()
 	connected_gens = list()
-	return
 
 
 /obj/machinery/field/generator/process()
-	if(Varedit_start == 1)
-		if(active == 0)
-			active = 1
-			state = 2
-			power = field_generator_max_power
-			anchored = 1
-			warming_up = 3
-			start_fields()
-			update_icon()
-		Varedit_start = 0
-
-	if(src.active == 2)
+	if(active == FG_ONLINE)
 		calc_power()
-		update_icon()
-	return
-
 
 /obj/machinery/field/generator/attack_hand(mob/user)
-	if(state == 2)
+	if(state == FG_WELDED)
 		if(get_dist(src, user) <= 1)//Need to actually touch the thing to turn it on
-			if(src.active >= 1)
-				to_chat(user, "<span class='warning'>You are unable to turn off the [src.name] once it is online!</span>")
+			if(active >= FG_CHARGING)
+				to_chat(user, "<span class='warning'>You are unable to turn off the [name] once it is online!</span>")
 				return 1
 			else
-				user.visible_message("[user.name] turns on the [src.name].", \
-					"<span class='notice'>You turn on the [src.name].</span>", \
+				user.visible_message("[user.name] turns on the [name].", \
+					"<span class='notice'>You turn on the [name].</span>", \
 					"<span class='italics'>You hear heavy droning.</span>")
 				turn_on()
 				investigate_log("<font color='green'>activated</font> by [user.key].","singulo")
 
-				src.add_fingerprint(user)
+				add_fingerprint(user)
 	else
-		to_chat(user, "<span class='warning'>The [src] needs to be firmly secured to the floor first!</span>")
-		return
+		to_chat(user, "<span class='warning'>[src] needs to be firmly secured to the floor first!</span>")
 
 
 /obj/machinery/field/generator/attackby(obj/item/W, mob/user, params)
 	if(active)
-		to_chat(user, "<span class='warning'>The [src] needs to be off!</span>")
+		to_chat(user, "<span class='warning'>[src] needs to be off!</span>")
 		return
 	else if(istype(W, /obj/item/weapon/wrench))
 		switch(state)
-			if(0)
+			if(FG_UNSECURED)
 				if(isinspace()) return
-				state = 1
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				user.visible_message("[user.name] secures [src.name] to the floor.", \
+				state = FG_SECURED
+				playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
+				user.visible_message("[user.name] secures [name] to the floor.", \
 					"<span class='notice'>You secure the external reinforcing bolts to the floor.</span>", \
 					"<span class='italics'>You hear ratchet.</span>")
-				src.anchored = 1
-			if(1)
-				state = 0
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				user.visible_message("[user.name] unsecures [src.name] reinforcing bolts from the floor.", \
+				anchored = 1
+			if(FG_SECURED)
+				state = FG_UNSECURED
+				playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
+				user.visible_message("[user.name] unsecures [name] reinforcing bolts from the floor.", \
 					"<span class='notice'>You undo the external reinforcing bolts.</span>", \
 					"<span class='italics'>You hear ratchet.</span>")
-				src.anchored = 0
-			if(2)
-				to_chat(user, "<span class='warning'>The [src.name] needs to be unwelded from the floor!</span>")
-				return
+				anchored = 0
+			if(FG_WELDED)
+				to_chat(user, "<span class='warning'>The [name] needs to be unwelded from the floor!</span>")
+
 	else if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W
 		switch(state)
-			if(0)
-				to_chat(user, "<span class='warning'>The [src.name] needs to be wrenched to the floor!</span>")
-				return
-			if(1)
+			if(FG_UNSECURED)
+				user << "<span class='warning'>The [name] needs to be wrenched to the floor!</span>"
+
+			if(FG_SECURED)
 				if(WT.remove_fuel(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-					user.visible_message("[user.name] starts to weld the [src.name] to the floor.", \
+					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
+					user.visible_message("[user.name] starts to weld the [name] to the floor.", \
 						"<span class='notice'>You start to weld \the [src] to the floor...</span>", \
 						"<span class='italics'>You hear welding.</span>")
 					if(do_after(user,20, target = src))
-						if(!src || !WT.isOn()) return
-						state = 2
+						if(!src || !WT.isOn())
+							return
+						state = FG_WELDED
 						to_chat(user, "<span class='notice'>You weld the field generator to the floor.</span>")
-				else
-					return
-			if(2)
+
+			if(FG_WELDED)
 				if(WT.remove_fuel(0,user))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-					user.visible_message("[user.name] starts to cut the [src.name] free from the floor.", \
+					playsound(loc, 'sound/items/Welder2.ogg', 50, 1)
+					user.visible_message("[user.name] starts to cut the [name] free from the floor.", \
 						"<span class='notice'>You start to cut \the [src] free from the floor...</span>", \
 						"<span class='italics'>You hear welding.</span>")
 					if(do_after(user,20, target = src))
-						if(!src || !WT.isOn()) return
-						state = 1
+						if(!src || !WT.isOn())
+							return
+						state = FG_SECURED
 						to_chat(user, "<span class='notice'>You cut \the [src] free from the floor.</span>")
-				else
-					return
+
 	else
-		..()
+		return ..()
 
 
 /obj/machinery/field/generator/emp_act()
@@ -164,30 +148,35 @@ field_generator power level display
 
 /obj/machinery/field/generator/bullet_act(obj/item/projectile/Proj)
 	if(Proj.flag != "bullet")
-		power += Proj.damage
-		update_icon()
+		power = min(power + Proj.damage, field_generator_max_power)
+		check_power_level()
 	return 0
 
 
 /obj/machinery/field/generator/Destroy()
-	src.cleanup()
+	cleanup()
 	return ..()
 
 
+/obj/machinery/field/generator/proc/check_power_level()
+	var/new_level = round(num_power_levels * power / field_generator_max_power)
+	if(new_level != power_level)
+		power_level = new_level
+		update_icon()
 
 /obj/machinery/field/generator/proc/turn_off()
-	active = 0
+	active = FG_OFFLINE
 	spawn(1)
-		src.cleanup()
-		while(warming_up>0 && !active)
+		cleanup()
+		while(warming_up > 0 && !active)
 			sleep(50)
 			warming_up--
 			update_icon()
 
 /obj/machinery/field/generator/proc/turn_on()
-	active = 1
+	active = FG_CHARGING
 	spawn(1)
-		while(warming_up<3 && active)
+		while(warming_up < 3 && active)
 			sleep(50)
 			warming_up++
 			update_icon()
@@ -196,44 +185,35 @@ field_generator power level display
 
 
 /obj/machinery/field/generator/proc/calc_power()
-	if(Varpower)
-		return 1
+	var/power_draw = 2 + fields.len
 
-	update_icon()
-	if(src.power > field_generator_max_power)
-		src.power = field_generator_max_power
-
-	var/power_draw = 2
-	for(var/obj/machinery/field/containment/F in fields)
-		if(isnull(F))
-			continue
-		power_draw++
-	if(draw_power(round(power_draw/2,1)))
+	if(draw_power(round(power_draw/2, 1)))
+		check_power_level()
 		return 1
 	else
-		visible_message("<span class='danger'>The [src.name] shuts down!</span>", "<span class='italics'>You hear something shutting down.</span>")
+		visible_message("<span class='danger'>The [name] shuts down!</span>", "<span class='italics'>You hear something shutting down.</span>")
 		turn_off()
 		investigate_log("ran out of power and <font color='red'>deactivated</font>","singulo")
-		src.power = 0
+		power = 0
+		check_power_level()
 		return 0
 
 //This could likely be better, it tends to start loopin if you have a complex generator loop setup.  Still works well enough to run the engine fields will likely recode the field gens and fields sometime -Mport
 /obj/machinery/field/generator/proc/draw_power(draw = 0, failsafe = 0, obj/machinery/field/generator/G = null, obj/machinery/field/generator/last = null)
-	if(Varpower)
-		return 1
-	if((G && G == src) || (failsafe >= 8))//Loopin, set fail
+	if((G && (G == src)) || (failsafe >= 8))//Loopin, set fail
 		return 0
 	else
 		failsafe++
-	if(src.power >= draw)//We have enough power
-		src.power -= draw
+
+	if(power >= draw)//We have enough power
+		power -= draw
 		return 1
+
 	else//Need more power
-		draw -= src.power
-		src.power = 0
-		for(var/obj/machinery/field/generator/FG in connected_gens)
-			if(isnull(FG))
-				continue
+		draw -= power
+		power = 0
+		for(var/CG in connected_gens)
+			var/obj/machinery/field/generator/FG = CG
 			if(FG == last)//We just asked you
 				continue
 			if(G)//Another gen is askin for power and we dont have it
@@ -249,7 +229,7 @@ field_generator power level display
 
 
 /obj/machinery/field/generator/proc/start_fields()
-	if(!src.state == 2 || !anchored)
+	if(state != FG_WELDED || !anchored)
 		turn_off()
 		return
 	spawn(1)
@@ -260,82 +240,73 @@ field_generator power level display
 		setup_field(4)
 	spawn(4)
 		setup_field(8)
-	src.active = 2
+	spawn(5)
+		active = FG_ONLINE
 
 
 /obj/machinery/field/generator/proc/setup_field(NSEW)
-	var/turf/T = src.loc
-	var/obj/machinery/field/generator/G
+	var/turf/T = loc
+	if(!istype(T))
+		return 0
+
+	var/obj/machinery/field/generator/G = null
 	var/steps = 0
 	if(!NSEW)//Make sure its ran right
-		return
-	for(var/dist = 0, dist <= 9, dist += 1) // checks out to 8 tiles away for another generator
+		return 0
+	for(var/dist in 0 to 7) // checks out to 8 tiles away for another generator
 		T = get_step(T, NSEW)
 		if(T.density)//We cant shoot a field though this
 			return 0
-		for(var/atom/A in T.contents)
-			if(ismob(A))
-				continue
-			if(!istype(A,/obj/machinery/field/generator))
-				if((istype(A,/obj/machinery/door)||istype(A,/obj/machinery/the_singularitygen))&&(A.density))
-					return 0
-		steps += 1
+
 		G = locate(/obj/machinery/field/generator) in T
-		if(!isnull(G))
+		if(G)
 			steps -= 1
 			if(!G.active)
 				return 0
 			break
-	if(isnull(G))
-		return
-	T = src.loc
-	for(var/dist = 0, dist < steps, dist += 1) // creates each field tile
+
+		for(var/TC in T.contents)
+			var/atom/A = TC
+			if(ismob(A))
+				continue
+			if(A.density)
+				return 0
+
+		steps++
+
+	if(!G)
+		return 0
+
+	T = loc
+	for(var/dist in 0 to steps) // creates each field tile
 		var/field_dir = get_dir(T,get_step(G.loc, NSEW))
 		T = get_step(T, NSEW)
 		if(!locate(/obj/machinery/field/containment) in T)
 			var/obj/machinery/field/containment/CF = new/obj/machinery/field/containment()
 			CF.set_master(src,G)
-			fields += CF
-			G.fields += CF
 			CF.loc = T
 			CF.dir = field_dir
-			for(var/mob/living/L in CF.loc)
+			fields += CF
+			G.fields += CF
+			for(var/mob/living/L in T)
 				CF.Crossed(L)
-	var/listcheck = 0
-	for(var/obj/machinery/field/generator/FG in connected_gens)
-		if(isnull(FG))
-			continue
-		if(FG == G)
-			listcheck = 1
-			break
-	if(!listcheck)
-		connected_gens.Add(G)
-	listcheck = 0
-	for(var/obj/machinery/field/generator/FG2 in G.connected_gens)
-		if(isnull(FG2))
-			continue
-		if(FG2 == src)
-			listcheck = 1
-			break
-	if(!listcheck)
-		G.connected_gens.Add(src)
+
+	connected_gens |= G
+	G.connected_gens |= src
+	update_icon()
 
 
 /obj/machinery/field/generator/proc/cleanup()
 	clean_up = 1
-	for(var/obj/machinery/field/containment/F in fields)
-		if(isnull(F))
-			continue
+	for(var/F in fields)
 		qdel(F)
-	fields = list()
-	for(var/obj/machinery/field/generator/FG in connected_gens)
-		if(isnull(FG))
-			continue
-		FG.connected_gens.Remove(src)
+
+	for(var/CG in connected_gens)
+		var/obj/machinery/field/generator/FG = CG
+		FG.connected_gens -= src
 		if(!FG.clean_up)//Makes the other gens clean up as well
 			FG.cleanup()
-		connected_gens.Remove(FG)
-	connected_gens = list()
+		connected_gens -= FG
 	clean_up = 0
 	update_icon()
 
@@ -359,3 +330,11 @@ field_generator power level display
 /obj/machinery/field/generator/bump_field(atom/movable/AM as mob|obj)
 	if(fields.len)
 		..()
+
+#undef FG_UNSECURED
+#undef FG_SECURED
+#undef FG_WELDED
+
+#undef FG_OFFLINE
+#undef FG_CHARGING
+#undef FG_ONLINE

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -149,17 +149,18 @@
 			dissipate_delay = 10
 			dissipate_track = 0
 			dissipate_strength = 1
-		if(STAGE_TWO)//1 to 3 does not check for the turfs if you put the gens right next to a 1x1 then its going to eat them
-			current_size = STAGE_TWO
-			icon = 'icons/effects/96x96.dmi'
-			icon_state = "singularity_s3"
-			pixel_x = -32
-			pixel_y = -32
-			grav_pull = 6
-			consume_range = 1
-			dissipate_delay = 5
-			dissipate_track = 0
-			dissipate_strength = 5
+		if(STAGE_TWO)
+			if((check_turfs_in(1,1))&&(check_turfs_in(2,1))&&(check_turfs_in(4,1))&&(check_turfs_in(8,1)))
+				current_size = STAGE_TWO
+				icon = 'icons/effects/96x96.dmi'
+				icon_state = "singularity_s3"
+				pixel_x = -32
+				pixel_y = -32
+				grav_pull = 6
+				consume_range = 1
+				dissipate_delay = 5
+				dissipate_track = 0
+				dissipate_strength = 5
 		if(STAGE_THREE)
 			if((check_turfs_in(1,2))&&(check_turfs_in(2,2))&&(check_turfs_in(4,2))&&(check_turfs_in(8,2)))
 				current_size = STAGE_THREE
@@ -238,22 +239,22 @@
 
 /obj/singularity/proc/eat()
 	set background = BACKGROUND_ENABLED
-	for(var/tile in spiral_range_turfs(grav_pull, src, 1))
+	for(var/tile in spiral_range_turfs(grav_pull, src))
 		var/turf/T = tile
-		if(!T)
+		if(!T || !isturf(loc))
 			continue
 		if(get_dist(T, src) > consume_range)
 			T.singularity_pull(src, current_size)
 		else
 			consume(T)
 		for(var/thing in T)
-			var/atom/movable/X = thing
-			if(get_dist(X, src) > consume_range)
-				X.singularity_pull(src, current_size)
-			else
-				consume(X)
+			if(isturf(loc) && thing != src)
+				var/atom/movable/X = thing
+				if(get_dist(X, src) > consume_range)
+					X.singularity_pull(src, current_size)
+				else
+					consume(X)
 			CHECK_TICK
-	return
 
 /obj/singularity/proc/consume(var/atom/A)
 	var/gain = A.singularity_act(current_size)


### PR DESCRIPTION
Ports over TG's field generator cleanup PR.

Amongst other things, this resolves the performance issue with field generator `update_icons` being spammed every `process` (which was profiling quite high). Also uses defines and better methods for debug starting the singularity. Also resolves a server crash via infinite loop regarding shocking.

Also fixes a few issues with the singularity potentially escaping containment, eating itself, etc.

Removes the `burn_skin` proc; replaced the electric chair and field generator with `electrocute_act` (and adjustFireLoss for the unused mustard gas).

:cl: Fox McCloud
fix: Fixes a rare case where the singularity would escape containment when properly set up+contained
/:cl: