### PR TITLE
Fixes Cremation of Self-Deleting Mobs

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -361,6 +361,8 @@
 				user.attack_log +="\[[time_stamp()]\] <font color='red'>Cremated [M.name] ([M.ckey])</font>"
 				log_attack("[user.name] ([user.ckey]) cremated [M.name] ([M.ckey])")
 			M.death(1)
+			if(!M || !isnull(M.gcDestroyed))
+				continue // Re-check for mobs that delete themselves on death
 			M.ghostize()
 			qdel(M)
 


### PR DESCRIPTION
Some mobs are nice enough to delete themselves when they die. Unfortunately, the crematorium wasn't coded to handle this, so it would then try to ghostize the now non-existent mob. Now it double-checks to make sure the mob still exists after death.

Fixes #5290