### PR TITLE
Fixes Two Destroys

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -165,7 +165,7 @@ The box in your backpack has an oxygen tank and gas mask in it."
 	name = "Too Cold"
 	desc = "You're freezing cold! Get somewhere warmer and take off any insulating clothing like a space suit."
 	icon_state = "cold"
-	
+
 /obj/screen/alert/cold/drask
     name = "Cold"
     desc = "You're breathing supercooled gas! It's stimulating your metabolism to regenerate damaged tissue."
@@ -400,8 +400,7 @@ so as to remain in compliance with the most up-to-date laws."
 		return usr.client.Click(master, location, control, params)
 
 /obj/screen/alert/Destroy()
-	..()
 	severity = 0
 	master = null
 	screen_loc = ""
-	return QDEL_HINT_QUEUE
+	return ..()

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -63,9 +63,8 @@
 	var/severity = 0
 
 /obj/screen/fullscreen/Destroy()
-	..()
 	severity = 0
-	return QDEL_HINT_HARDDEL_NOW
+	return ..()
 
 /obj/screen/fullscreen/brute
 	icon_state = "brutedamageoverlay"


### PR DESCRIPTION
I'm pretty sure fullscreens are ok to GC--I suspect that this was a mistake made when @tigercat2000 ported TG's screens+HUDs--TG pools full screens, where as we do not.

Likewise for alerts, it should be return `..()` and not just putting it in the queue right then and there.