### PR TITLE
Ports Typecaches and Using One For Tesla Type Checks

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -58,11 +58,40 @@
 	return 0
 
 //Checks for specific types in a list
-/proc/is_type_in_list(var/atom/A, var/list/L)
+/proc/is_type_in_list(atom/A, list/L)
+	if(!L || !L.len || !A)
+		return 0
 	for(var/type in L)
 		if(istype(A, type))
 			return 1
 	return 0
+
+//Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
+/proc/is_type_in_typecache(atom/A, list/L)
+	if(!L || !L.len || !A)
+		return 0
+	return L[A.type]
+
+//Like typesof() or subtypesof(), but returns a typecache instead of a list
+/proc/typecacheof(path, ignore_root_path)
+	if(ispath(path))
+		var/list/types = ignore_root_path ? subtypesof(path) : typesof(path)
+		var/list/L = list()
+		for(var/T in types)
+			L[T] = TRUE
+		return L
+	else if(islist(path))
+		var/list/pathlist = path
+		var/list/L = list()
+		if(ignore_root_path)
+			for(var/P in pathlist)
+				for(var/T in subtypesof(P))
+					L[T] = TRUE
+		else
+			for(var/P in pathlist)
+				for(var/T in typesof(P))
+					L[T] = TRUE
+		return L
 
 //Removes any null entries from the list
 /proc/listclearnulls(list/list)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -1,7 +1,7 @@
 #define TESLA_DEFAULT_POWER 1738260
 #define TESLA_MINI_POWER 869130
 
-var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
+var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 										/obj/machinery/power/emitter,
 										/obj/machinery/field/generator,
 										/mob/living/simple_animal,
@@ -15,7 +15,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 										/obj/machinery/field/containment,
 										/obj/structure/disposalpipe,
 										/obj/structure/sign,
-										/obj/machinery/gateway)
+										/obj/machinery/gateway))
 
 /obj/singularity/energy_ball
 	name = "energy ball"
@@ -175,7 +175,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 				closest_atom = A
 				closest_dist = dist
 
-		else if(closest_grounding_rod || is_type_in_list(A, blacklisted_tesla_types))
+		else if(closest_grounding_rod || is_type_in_typecache(A, blacklisted_tesla_types))
 			continue
 
 		else if(istype(A, /mob/living))


### PR DESCRIPTION
This is pretty much a straight port of tgstation/tgstation#18068, including typecaches, the use of a typecache for the Tesla's type checks, and the minor sanity checks added to `is_type_in_list`.

Typecaches are basically lists of every type *and subtype* that matches a type list, which means you can directly check if a type is in them, instead of iterating over the list with `istype` checks. For long lists of types that get used frequently - for example, with the Tesla energy balls - this can make for a big performance improvement:
- Before: 501,725 calls to `is_type_in_list`, 1.658s CPU usage
- After: 502,228 calls to `is_type_in_typecache`, 0.328s CPU usage