### PR TITLE
Human Overlay Caching and Minor Overlay Fixes

### DIFF
--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -21,7 +21,7 @@ var/global/list/frozen_mob_list = list()
 
 ///mob freeze procs
 
-/mob/living/var/frozen = 0 //used for preventing attacks on admin-frozen mobs
+/mob/living/var/frozen = null //used for preventing attacks on admin-frozen mobs
 /mob/living/var/admin_prev_sleeping = 0 //used for keeping track of previous sleeping value with admin freeze
 
 /mob/living/proc/admin_Freeze(var/client/admin)
@@ -34,7 +34,7 @@ var/global/list/frozen_mob_list = list()
 	src.overlays += AO
 
 	anchored = 1
-	frozen = 1
+	frozen = AO
 	admin_prev_sleeping = sleeping
 	sleeping += 20000
 	if(!(src in frozen_mob_list))
@@ -46,14 +46,15 @@ var/global/list/frozen_mob_list = list()
 		message_admins("\blue [key_name_admin(admin)] unfroze [key_name_admin(src)]")
 		log_admin("[key_name(admin)] unfroze [key_name(src)]")
 
-	update_icons()
-
 	anchored = 0
-	frozen = 0
+	overlays -= frozen
+	frozen = null
 	sleeping = admin_prev_sleeping
 	admin_prev_sleeping = null
 	if(src in frozen_mob_list)
 		frozen_mob_list -= src
+
+	update_icons()
 
 
 /mob/living/carbon/slime/admin_Freeze(admin)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -2,7 +2,7 @@
 	var/obj/item/organ/internal/eyes/eyes = get_int_organ(/obj/item/organ/internal/eyes)
 	if(eyes)
 		eyes.update_colour()
-		regenerate_icons()
+		update_body()
 
 /mob/living/carbon/human/var/list/organs = list()
 /mob/living/carbon/human/var/list/organs_by_name = list() // map organ names to organs


### PR DESCRIPTION
Currently, any time any single overlay needs to be updated on a human, every existing overlay is thrown out - including many that probably didn't change - and then every single overlay is re-added. Adding and removing overlays is actually fairly expensive, and adding *and* removing *every* overlay, *every* time any one needs to change, gets very expensive very fast, making human overlay regeneration the single most expensive proc we've got.

Ideally, we'd be much more selective about what overlays are updated by what events. But that requires a lot of effort, so this PR adds a simple overlay cache that keeps track of which overlays existed previously, and compares against it when regenerating them, only removing the missing ones and adding the new ones. This speeds things up - often drastically - any time less than literally every overlay is updated.

How much does it speed things up? Let's look at some examples. Here's what happens when you spawn 100 captains (I don't recommend this; the "captain on deck" sound plays 100 times, simultaneously):

- Before: 1200 calls, 1.978s CPU time
- After: 1200 calls, 1.138s CPU time

Doesn't look too impressive so far, eh? The thing is, spawning in and equipping a human causes a lot of full icon regenerations, which forces all overlays to be rebuilt, skipping the efficiency of the cache. Still a decent little performance gain.

Now, let's look at something more typical of what happens throughout a round - what happens when 250 items get picked up and dropped by a captain (yes, this is relevant, since everything you're wearing increases your overlays):

- Before: 500 calls, 1.946s CPU time
- After: 500 calls, 0.062s CPU time

Now that's more like it - a 31x performance improvement. In this case, picking up and dropping an item only updates the in-hand overlay, but before, it was causing all overlays to be updated. Updating the single overlay that matters is *much* faster.

As a sanity check, the overlay cache is discarded and rebuilt from scratch if something touches the overlay list directly. This should ensure nobody gets stuck with permanent overlays because someone didn't know what they were doing.

There's also some other tweaks in here. Full list:

- Humans now cache their overlays between overlay updates, drastically reducing the cost of minor overlay changes.
- Fire is now properly layered atop everything else, rather than existing under your clothes.
  ![2016-08-03_23-05-48](https://cloud.githubusercontent.com/assets/10916307/17407308/c92ed00c-5a34-11e6-97e2-d7735fb5ab19.gif)
- Admin freeze overlays are now directly handled in `update_icons`, so they should stop vanishing before the person is unfrozen.
- Humans' `regenerate_icons` was performing some steps out of order. This has been corrected, and may result in certain overlays properly updating when they previously wouldn't.
- `update_fire` now uses `update_icons` like everything else, and only generates the fire image if you don't already have it.
  - The overlay procs that were ported specifically for it have been removed.
- Updating a human's eyes now updates the body (which is what they're part of), rather than completely regenerating all overlays.

:cl:
bugfix: Fire will now totally consume you, rather than timidly hiding under your clothes.
bugfix: Admin freeze overlays should no longer disappear from humans until they're actually unfrozen.
/:cl: