### PR TITLE
Personal lockers in the locker room are no longer randomized

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -6,12 +6,9 @@
 
 /obj/structure/closet/secure_closet/personal/New()
 	..()
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack/duffel(src)
-	if(prob(50))
-		new /obj/item/weapon/storage/backpack(src)
-	else
-		new /obj/item/weapon/storage/backpack/satchel_norm(src)
+	new /obj/item/weapon/storage/backpack/duffel(src)
+	new /obj/item/weapon/storage/backpack(src)
+	new /obj/item/weapon/storage/backpack/satchel_norm(src)
 	new /obj/item/device/radio/headset( src )
 
 
@@ -33,8 +30,6 @@
 	icon_opened = "cabinetdetective_open"
 	icon_broken = "cabinetdetective_broken"
 	icon_off = "cabinetdetective_broken"
-	burn_state = FLAMMABLE
-	burntime = 20
 
 /obj/structure/closet/secure_closet/personal/cabinet/update_icon()
 	if(broken)


### PR DESCRIPTION
So, one thing I am guilty of, and I know I'm not the only person who does this, is opening multiple personal lockers for the bag I want. Sometimes I need a satchel, sometimes I need a duffelbag.

In other words, if I open a locker and don't find the bag I want, I will open another, thus making it so there's less personal lockers for everyone else.

This just makes all the lockers have the same bags. Before it was either one or two, now it is always the standard 3: Backpack, duffelbag, satchel.

:cl: Lady-Luck
tweak: Personal lockers in the locker room are no longer randomized and have all the same bags.
/:cl: