### PR TITLE
Hopefully *Fixes* the God Damn Gas Overlay...

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -251,6 +251,7 @@
 	var/atmos_overlay = get_atmos_overlay_by_name(atmos_overlay_type)
 	if(atmos_overlay)
 		overlays -= atmos_overlay
+		mouse_opacity = 1
 
 	atmos_overlay = get_atmos_overlay_by_name(new_overlay_type)
 	if(atmos_overlay)
@@ -267,10 +268,12 @@
 
 /turf/simulated/proc/tile_graphic()
 	if(air.toxins > MOLES_PLASMA_VISIBLE)
+		mouse_opacity = 0
 		return "plasma"
 
 	var/datum/gas/sleeping_agent = locate(/datum/gas/sleeping_agent) in air.trace_gases
 	if(sleeping_agent && (sleeping_agent.moles > 1))
+		mouse_opacity = 0
 		return "sleeping_agent"
 	return null
 


### PR DESCRIPTION
Now, I can tell that some of you are going to want blood for me doing this, buuuuut the only other way I see to fix this is ripping gas overlays out entirely and making gas itself a new layer... easier said than done.

You can click on everything inside a gassy turf like normal and interact with the turf like normal, you just can't see the floor's name when you hover over it nor can you see it in the right click menu while a gas overlay is applied.

The plasma sprite was ported from Apollo originally, and Apollo does something similar in this manner.

Something something: #5195

:cl: Chakishreds
tweak: You can now click on objects in a gassy room at the expense of ninja floors.
/:cl: