### PR TITLE
Nerfs holy water.

### DIFF
--- a/code/modules/reagents/oldchem/reagents/reagents_water.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_water.dm
@@ -266,7 +266,7 @@
 /datum/reagent/holywater/on_mob_life(mob/living/M)
 	M.jitteriness = max(M.jitteriness-5,0)
 	if(current_cycle >= 30)		// 12 units, 60 seconds @ metabolism 0.4 units & tick rate 2.0 sec
-		M.stuttering += 4
+		M.stuttering = min(M.stuttering+4, 20)
 		M.Dizzy(5)
 		if(iscultist(M) && prob(5))
 			M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","Egkau'haom'nai en Chaous","Ho Diak'nos tou Ap'iron","R'ge Na'sie","Diabo us Vo'iscum","Si gn'um Co'nu"))


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: Holy Water will no longer make you stutter for ages if you're not a cultist
/:cl:

After we had to turn someone's stutter down from 20 minutes, this had to happen.
