### PR TITLE
Makes security records console emaggable.

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -35,11 +35,11 @@
 	..()
 
 /obj/machinery/computer/secure_data/emag_act(mob/user)
-	src.active1 = null
-	src.active2 = null
-	src.authenticated = "*ERROR*"
-	src.rank = "AI"
-	src.screen = 1
+	active1 = null
+	active2 = null
+	authenticated = "*ERROR*"
+	rank = "AI"
+	screen = 1
 
 /obj/machinery/computer/secure_data/attack_ai(mob/user as mob)
 	return attack_hand(user)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -34,6 +34,13 @@
 		to_chat(user, "You insert [O].")
 	..()
 
+/obj/machinery/computer/secure_data/emag_act(mob/user)
+	src.active1 = null
+	src.active2 = null
+	src.authenticated = "*ERROR*"
+	src.rank = "AI"
+	src.screen = 1
+
 /obj/machinery/computer/secure_data/attack_ai(mob/user as mob)
 	return attack_hand(user)
 
@@ -253,10 +260,11 @@ What a mess.*/
 						scan = I
 
 			if("Log Out")
-				authenticated = null
-				screen = null
-				active1 = null
-				active2 = null
+				if(!emagged)
+					authenticated = null
+					screen = null
+					active1 = null
+					active2 = null
 
 			if("Log In")
 				if(istype(usr, /mob/living/silicon/ai))


### PR DESCRIPTION
Right now, agent ID's are fucking useless. The only way to antag is to powergame. This is definitely *not* OP.

"But agent ID's need to have some vulnerability?"

Tators are underpowered as shit right now. This isn't the time to have drawbacks for identity-changing items.

:cl: monster860
rscadd: Security records console can now be emagged
/:cl: