### PR TITLE
Adds an explosive chameleon-flag for traitors

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -783,6 +783,13 @@ var/list/uplink_items = list()
 	reference = "CHHUD"
 	item = /obj/item/clothing/glasses/hud/security/chameleon
 	cost = 2
+	
+/datum/uplink_item/stealthy_weapons/chameleonflag
+	name = "Chameleon Flag"
+	desc = "A flag that can be disguised as any other known flag. There is a heat sensitive bomb loaded into the pole that will be detonated if the flag is lit on fire."
+	reference = "CHFLAG"
+	item = /obj/item/flag/chameleon
+	cost = 7
 
 // STEALTHY TOOLS
 

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -193,3 +193,4 @@
 			
 /obj/item/flag/chameleon/burn()
 	explosion(loc,1,2,4,4, flame_range = 4)
+	qdel(src)

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -156,3 +156,40 @@
 	name = "Nar'Sie Cultist flag"
 	desc = "A flag proudly boasting the logo of the cultists, sworn enemies of NT."
 	icon_state = "cultflag"
+	
+//Chameleon
+
+/obj/item/flag/chameleon
+	name = "Chameleon flag"
+	desc = "A poor recreation of the official NT flag. It seems to shimmer a little."
+	icon_state = "ntflag"
+	origin_tech = "materials=3;magnets=4;syndicate=4"
+	var/used = 0
+	
+/obj/item/flag/chameleon/attack_self(mob/user)
+	if(used)
+		return
+
+	var/list/flag_types = typesof(/obj/item/flag) - list(src.type, /obj/item/flag)
+	var/list/flag = list()
+
+	for(var/flag_type in flag_types)
+		var/obj/item/flag/F = new flag_type
+		flag[capitalize(F.name)] = F
+
+	var/list/show_flag = list("EXIT" = null) + sortList(flag)
+
+	var/input_flag = input(user, "Choose a flag to disguise as.", "Choose a flag.") in show_flag
+
+	if(user && src in user.contents)
+
+		var/obj/item/flag/chosen_flag = flag[input_flag]
+
+		if(chosen_flag)
+			name = chosen_flag.name
+			icon_state = chosen_flag.icon_state
+			desc = chosen_flag.desc
+			used = 1
+			
+/obj/item/flag/chameleon/burn()
+	explosion(loc,1,2,4,4, flame_range = 4)


### PR DESCRIPTION
This gives traitors a 7TC chameleon flag. It can be used once to be
disguised as any other flag on the station. It comes with an explosive
payload equivalent to a minibomb. It explodes once the flag finishes
burning. By default it looks like a standard NT flag that has a separate
name and description by default.

Would have re-opened #5281 instead but things went horribly wrong on my
local side.

:cl: IcyV
add: Adds an exploding chameleon flag for traitors.
/:cl: