### PR TITLE
Various grammar/spelling fixes

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -273,7 +273,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 	owner.attack_log += text("\[[time_stamp()]\] <font color='red'>Bit [H] ([H.ckey]) in the neck and draining their blood</font>")
 	H.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been bit in the neck by [owner] ([owner.ckey])</font>")
 	log_attack("[owner] ([owner.ckey]) bit [H] ([H.ckey]) in the neck")
-	owner.visible_message("<span class='danger'>[owner] grabs [H]'s harshly and sinks in thier fangs!</span>", "<span class='danger'>You sink your fangs into [H] and begin to drain their blood.</span>", "<span class='notice'>You hear a soft puncture and a wet sucking noise.</span>")
+	owner.visible_message("<span class='danger'>[owner] grabs [H]'s neck harshly and sinks in their fangs!</span>", "<span class='danger'>You sink your fangs into [H] and begin to drain their blood.</span>", "<span class='notice'>You hear a soft puncture and a wet sucking noise.</span>")
 	if(!iscarbon(owner))
 		H.LAssailant = null
 	else

--- a/code/modules/events/meaty_ops.dm
+++ b/code/modules/events/meaty_ops.dm
@@ -1,5 +1,5 @@
 /datum/event/meteor_wave/goreop/announce()
-	var/meteor_declaration = "MeteorOps have declared thier intent to utterly destroy [station_name()] with thier own bodies, and dares the crew to try and stop them."
+	var/meteor_declaration = "MeteorOps have declared their intent to utterly destroy [station_name()] with their own bodies, and dares the crew to try and stop them."
 	command_announcement.Announce(meteor_declaration, "Declaration of 'War'", 'sound/effects/siren.ogg')
 
 /datum/event/meteor_wave/goreop/setup()

--- a/code/modules/martial_arts/mimejutsu.dm
+++ b/code/modules/martial_arts/mimejutsu.dm
@@ -55,8 +55,8 @@
 
 /datum/martial_art/mimejutsu/proc/mimePalm(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(!D.stat && !D.stunned && !D.weakened)
-		D.visible_message("<span class='danger'>[A] has barely touched [D] with thier palm!</span>", \
-						"<span class='userdanger'>[A] hovers thier palm over your face!</span>")
+		D.visible_message("<span class='danger'>[A] has barely touched [D] with their palm!</span>", \
+						"<span class='userdanger'>[A] hovers their palm over your face!</span>")
 
 		var/atom/throw_target = get_edge_target_turf(D, get_dir(D, get_step_away(D, A)))
 		D.throw_at(throw_target, 200, 4,A)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -239,7 +239,7 @@
 
 /datum/surgery_step/internal/dethrall/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/braincase = target.named_organ_parent("brain")
-	user.visible_message("[user] reaches into [target]'s head with [tool].", "<span class='notice'>You begin aligning [tool]'s light to the tumor on [target]'s brain...</span>")
+	user.visible_message("[user] reaches into [target]'s head with \the [tool].", "<span class='notice'>You begin aligning \the [tool]'s light to the tumor on [target]'s brain...</span>")
 	to_chat(target, "<span class='boldannounce'>A small part of your [braincase] pulses with agony as the light impacts it.</span>")
 	..()
 

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -239,7 +239,7 @@
 
 /datum/surgery_step/internal/dethrall/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/braincase = target.named_organ_parent("brain")
-	user.visible_message("[user] reaches into [target]'s head with \the [tool].", "<span class='notice'>You begin aligning \the [tool]'s light to the tumor on [target]'s brain...</span>")
+	user.visible_message("[user] reaches into [target]'s head with [tool].", "<span class='notice'>You begin aligning [tool]'s light to the tumor on [target]'s brain...</span>")
 	to_chat(target, "<span class='boldannounce'>A small part of your [braincase] pulses with agony as the light impacts it.</span>")
 	..()
 


### PR DESCRIPTION
Fixes a missing word after the target's name and 'their' being spelled as 'thier' in the message seen by others when a vampire bites someone.
~~Fixes the light shining step of the dethralling surgery not properly using \the. I might possibly be killed by TheDZD for this.~~
Changes various instances of 'thier' to 'their'.