### PR TITLE
Atom Say Refactor

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -448,11 +448,10 @@
 /atom/proc/narsie_act()
 	return
 
-/atom/proc/atom_say(var/message)
-	if((!message))
+/atom/proc/atom_say(message)
+	if(!message)
 		return
-	for(var/mob/O in hearers(src, null))
-		O.show_message("<span class='game say'><span class='name'>[src]</span> [atom_say_verb], \"[message]\"</span>",2)
+	audible_message("<span class='game say'><span class='name'>[src]</span> [atom_say_verb], \"[message]\"</span>")
 
 /atom/proc/speech_bubble(var/bubble_state = "",var/bubble_loc = src, var/list/bubble_recipients = list())
 	return

--- a/code/game/gamemodes/mutiny/emergency_authentication_device.dm
+++ b/code/game/gamemodes/mutiny/emergency_authentication_device.dm
@@ -49,31 +49,31 @@
 		return
 
 	if(!mode.current_directive.directives_complete())
-		state("Command aborted. Communication with CentComm is prohibited until Directive X has been completed.")
+		atom_say("Command aborted. Communication with CentComm is prohibited until Directive X has been completed.")
 		return
 
 	check_key_existence()
 	if(captains_key && secondary_key)
 		activated = 1
 		to_chat(user, "\blue You activate \the [src]!")
-		state("Command acknowledged. Initiating quantum entanglement relay to Nanotrasen High Command.")
+		atom_say("Command acknowledged. Initiating quantum entanglement relay to Nanotrasen High Command.")
 		launch_shuttle()
 		return
 
 	if(!captains_key && !secondary_key)
-		state("Command aborted. Please present the authentication keys before proceeding.")
+		atom_say("Command aborted. Please present the authentication keys before proceeding.")
 		return
 
 	if(!captains_key)
-		state("Command aborted. Please present the Captain's Authentication Key.")
+		atom_say("Command aborted. Please present the Captain's Authentication Key.")
 		return
 
 	if(!secondary_key)
-		state("Command aborted. Please present the Emergency Secondary Authentication Key.")
+		atom_say("Command aborted. Please present the Emergency Secondary Authentication Key.")
 		return
 
 	// Impossible!
-	state("Command aborted. This unit is defective.")
+	atom_say("Command aborted. This unit is defective.")
 
 /obj/machinery/emergency_authentication_device/attackby(obj/item/weapon/O, mob/user, params)
 	if(activated)
@@ -81,7 +81,7 @@
 		return
 
 	if(!mode.current_directive.directives_complete())
-		state({"Command aborted. Communication with CentComm is prohibited until Directive X has been completed."})
+		atom_say("Command aborted. Communication with CentComm is prohibited until Directive X has been completed.")
 		return
 
 	check_key_existence()
@@ -90,9 +90,9 @@
 		user.drop_item()
 		O.loc = src
 
-		state("Key received. Thank you, Captain [mode.head_loyalist].")
+		atom_say("Key received. Thank you, Captain [mode.head_loyalist].")
 		spawn(5)
-			state(secondary_key ? "Your keys have been authenticated. Communication with CentComm is now authorized." : "Please insert the Emergency Secondary Authentication Key now.")
+			atom_say(secondary_key ? "Your keys have been authenticated. Communication with CentComm is now authorized." : "Please insert the Emergency Secondary Authentication Key now.")
 		return
 
 	if(istype(O, /obj/item/weapon/mutiny/auth_key/secondary) && !secondary_key)
@@ -100,9 +100,9 @@
 		user.drop_item()
 		O.loc = src
 
-		state("Key received. Thank you, Secondary Authenticator [mode.head_mutineer].")
+		atom_say("Key received. Thank you, Secondary Authenticator [mode.head_mutineer].")
 		spawn(5)
-			state(captains_key ? "Your keys have been authenticated. Communication with CentComm is now authorized." : "Please insert the Captain's Authentication Key now.")
+			atom_say(captains_key ? "Your keys have been authenticated. Communication with CentComm is now authorized." : "Please insert the Captain's Authentication Key now.")
 		return
 	..()
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -14,7 +14,6 @@
 	var/light_range_on = 2
 	var/light_power_on = 1
 	var/overlay_layer
-	atom_say_verb = "beeps"
 
 /obj/machinery/computer/New()
 	overlay_layer = layer

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -7,6 +7,7 @@ var/list/doppler_arrays = list()
 	icon_state = "tdoppler"
 	density = 1
 	anchored = 1
+	atom_say_verb = "states coldly"
 
 /obj/machinery/doppler_array/New()
 	..()
@@ -74,9 +75,8 @@ var/list/doppler_arrays = list()
 	if(devastation_range < orig_dev_range || heavy_impact_range < orig_heavy_range || light_impact_range < orig_light_range)
 		messages += "Theoretical: Epicenter radius: [orig_dev_range]. Outer radius: [orig_heavy_range]. Shockwave radius: [orig_light_range]."
 
-	for(var/mob/O in hearers(src, null))
-		for(var/message in messages)
-			O.show_message("<span class='game say'><span class='name'>[src]</span> states coldly, \"[message]\"",2)
+	for(var/message in messages)
+		atom_say(message)
 
 
 /obj/machinery/doppler_array/power_change()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -116,6 +116,7 @@ Class Procs:
 	var/interact_offline = 0 // Can the machine be interacted with while de-powered.
 	var/use_log = list()
 	var/list/settagwhitelist = list()//WHITELIST OF VARIABLES THAT THE set_tag HREF CAN MODIFY, DON'T PUT SHIT YOU DON'T NEED ON HERE, AND IF YOU'RE GONNA USE set_tag (format_tag() proc), ADD TO THIS LIST.
+	atom_say_verb = "beeps"
 
 /obj/machinery/initialize()
 	addAtProcessing()
@@ -417,17 +418,6 @@ Class Procs:
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return 1
 	return 0
-
-/obj/machinery/proc/state(var/msg)
-  for(var/mob/O in hearers(src, null))
-    O.show_message("[bicon(src)] <span class = 'notice'>[msg]</span>", 2)
-
-/obj/machinery/proc/ping(text=null)
-  if(!text)
-    text = "\The [src] pings."
-
-  state(text, "blue")
-  playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 
 /obj/machinery/proc/exchange_parts(mob/user, obj/item/weapon/storage/part_replacer/W)
 	var/shouldplaysound = 0

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -979,11 +979,9 @@ obj/item/weapon/newspaper/attackby(obj/item/weapon/W as obj, mob/user as mob, pa
 //	return                                  //bode well with a newscaster network of 10+ machines. Let's just return it, as it's added in the machines list.
 
 /obj/machinery/newscaster/proc/newsAlert(var/news_call)   //This isn't Agouri's work, for it is ugly and vile.
-	var/turf/T = get_turf(src)                      //Who the fuck uses spawn(600) anyway, jesus christ
 	if(news_call)
 
-		for(var/mob/O in hearers(world.view-1, T))
-			O.show_message("<span class='newscaster'><EM>[src.name]</EM> beeps, \"[news_call]\"</span>",2)
+		atom_say("Breaking news from [news_call]!")
 		src.alert = 1
 		src.update_icon()
 		spawn(300)
@@ -992,7 +990,6 @@ obj/item/weapon/newspaper/attackby(obj/item/weapon/W as obj, mob/user as mob, pa
 		if(!silence)
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 75, 1)
 	else
-		for(var/mob/O in hearers(world.view-1, T))
-			O.show_message("<span class='newscaster'><EM>[src.name]</EM> beeps, \"Attention! Wanted issue distributed!\"</span>",2)
+		atom_say("Attention! Wanted issue distributed!")
 		playsound(src.loc, 'sound/machines/warning-buzzer.ogg', 75, 1)
 	return

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -276,7 +276,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		update_icon()
 	if(!src.silent)
 		playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 1)
-		state(title)
+		atom_say(title)
 
 	switch(priority)
 		if(2) // High

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -602,16 +602,13 @@
 
 	return
 
-/obj/machinery/vending/proc/speak(var/message)
+/obj/machinery/vending/proc/speak(message)
 	if(stat & NOPOWER)
 		return
-
 	if(!message)
 		return
 
-	for(var/mob/O in hearers(src, null))
-		O.show_message("<span class='game say'><span class='name'>[src]</span> beeps, \"[message]\"",2)
-	return
+	atom_say(message)
 
 /obj/machinery/vending/power_change()
 	if(stat & BROKEN)

--- a/code/modules/awaymissions/mission_code/spacehotel.dm
+++ b/code/modules/awaymissions/mission_code/spacehotel.dm
@@ -92,7 +92,6 @@
 	icon = 'icons/obj/doors/Doorsand.dmi'
 	icon_state = "door_closed"
 	autoclose = 1
-	atom_say_verb = "beeps"
 	var/doorOpen = 'sound/machines/airlock.ogg'
 	var/doorClose = 'sound/machines/airlock.ogg'
 	var/doorDeni = 'sound/machines/DeniedBeep.ogg'

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -292,6 +292,6 @@
 					"}
 
 				P.info = text
-				state("The terminal prints out a report.")
+				visible_message("<span class='notice'>[src] prints out a report.</span>")
 
 	return 1

--- a/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_harvester.dm
@@ -142,7 +142,7 @@
 
 			else
 				if(articount > 1)
-					state("Cannot harvest. Too many artifacts on the pad.")
+					atom_say("Cannot harvest. Too many artifacts on the pad.")
 				else if(analysed)
 					cur_artifact = analysed
 


### PR DESCRIPTION
Refactors a lot of manually spoken statements by machines to use `atom_say` instead of using their own methods.


Code wise
- `atom_say` itself uses `audible_message` now, resolving a number of issues with invisible messages for things held in-hand (like with the Orion ship)

:cl: Fox McCloud
fix: Fixes Orion Ship message being unheard when held in-hand
/:cl: