### PR TITLE
Fixes Accidental Greentext for Maroon and Redtext for Assassination Objectives, Resolves #5306

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -78,7 +78,7 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 	check_completion()
 		if(target && target.current)
 			// TODO: Tie into space manager
-			if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > ZLEVEL_DERELICT || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
+			if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 				return 1
 			return 0
 		return 1
@@ -174,10 +174,10 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 	check_completion()
 		if(target && target.current)
 			// TODO: Tie into space manager
-			if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || target.current.z > ZLEVEL_DERELICT || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
+			if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 				return 1
 			// TODO: Tie into space manager
-			if((target.current.z in config.admin_levels))
+			if((target.current.z in config.admin_levels) || ((target.current.loc.type in typesof(/obj/structure/closet)) && (target.current.loc.z in config.admin_levels))) //No hiding in lockers and cheezing greentext.
 				return 0
 		return 1
 
@@ -342,16 +342,6 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 
 /datum/objective/escape
 	explanation_text = "Escape on the shuttle or an escape pod alive and free."
-	var/escape_areas = list(/area/shuttle/escape,
-		/area/shuttle/escape_pod1/centcom,
-		/area/shuttle/escape_pod1/transit,
-		/area/shuttle/escape_pod2/centcom,
-		/area/shuttle/escape_pod2/transit,
-		/area/shuttle/escape_pod3/centcom,
-		/area/shuttle/escape_pod3/transit,
-		/area/shuttle/escape_pod5/centcom,
-		/area/shuttle/escape_pod5/transit,
-		/area/centcom/evac)
 
 	check_completion()
 		if(issilicon(owner.current))

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -177,7 +177,8 @@ var/list/potential_theft_objectives=subtypesof(/datum/theft_objective) \
 			if(target.current.stat == DEAD || issilicon(target.current) || isbrain(target.current) || !target.current.ckey) //Borgs/brains/AIs count as dead for traitor objectives. --NeoFite
 				return 1
 			// TODO: Tie into space manager
-			if((target.current.z in config.admin_levels) || ((target.current.loc.type in typesof(/obj/structure/closet)) && (target.current.loc.z in config.admin_levels))) //No hiding in lockers and cheezing greentext.
+			var/turf/target_location = get_turf(target.current)
+			if(target_location.z in config.admin_levels) //No hiding in lockers and cheezing greentext.
 				return 0
 		return 1
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -63,9 +63,7 @@
 			M.client.perspective = MOB_PERSPECTIVE
 
 /obj/structure/closet/proc/moveMob(var/mob/M, var/atom/destination)
-	loc.Exited(M)
-	M.loc = destination
-	loc.Entered(M, ignoreRest = 1)
+	M.forceMove(destination)
 	for(var/atom/movable/AM in loc)
 		if(istype(AM, /obj/item))
 			continue

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -63,7 +63,9 @@
 			M.client.perspective = MOB_PERSPECTIVE
 
 /obj/structure/closet/proc/moveMob(var/mob/M, var/atom/destination)
-	M.forceMove(destination)
+	loc.Exited(M)
+	M.loc = destination
+	loc.Entered(M, ignoreRest = 1)
 	for(var/atom/movable/AM in loc)
 		if(istype(AM, /obj/item))
 			continue


### PR DESCRIPTION
If you had the maroon objective as a traitor and your target was in any sort of locker on the shuttle when it docked, it would give you green text.

**The completion check for Maroon objectives is no longer affected by targets hiding in lockers.**

If you had the assassination objective as a traitor and you killed/borged/debrained your target but they were on a Z-level greater than the Derelict, it would give you red text. It shouldn't matter where the target is as if they're dead when the objective's checked for completion.

**Assassination objectives are now location insensitive.**

:cl:
fix: Traitors with the Maroon objective will no longer succeed if their target is in a locker on the shuttle.
fix: Traitors with the Assassination objective will no longer fail if their target is assassinated/borged/debrained but on a Z-level greater than the derelict.
/:cl:

Tested by spawning in as a character, aghosting and respawning as another character, turning myself into a traitor and giving myself the objective to maroon my other body.

_Results:_
- Maroon target on station outside locker - **Objective success**.
- Maroon target on station inside locker - **Objective success**.
- Maroon target on emergency shuttle at CentComm outside locker - **Objective failure**.
- Maroon target on emergency shuttle at CentComm inside locker - **Objective failure**.

Fixes #5306 