### PR TITLE
Allows Accessories to Have Armor

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -30,6 +30,9 @@
 			var/mob/M = has_suit.loc
 			A.Grant(M)
 
+	for(var/armor_type in armor)
+		has_suit.armor[armor_type] += armor[armor_type]
+
 	if(user)
 		to_chat(user, "<span class='notice'>You attach [src] to [has_suit].</span>")
 	src.add_fingerprint(user)
@@ -45,6 +48,9 @@
 		if(ismob(has_suit.loc))
 			var/mob/M = has_suit.loc
 			A.Remove(M)
+
+	for(var/armor_type in armor)
+		has_suit.armor[armor_type] -= armor[armor_type]
 
 	has_suit = null
 	usr.put_in_hands(src)


### PR DESCRIPTION
plucked the armor portion of this PR: https://github.com/tgstation/tgstation/pull/19748

Allows accessories to hypothetically grant armor when worn. Not currently utilized by anything.

And yes, we already have a system in place for limiting the amount of accessories of a particular type that you can wear, so if we ever used this, armor stacking should be a non-issue.

:cl: Fox McCloud
tweak: Allows accessories to hypothetically grant armor to their wearer
/:cl: