### PR TITLE
Wormhole Event Fix, Portal GC Fix

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -8,21 +8,21 @@
 	var/failchance = 5
 	var/obj/item/target = null
 	var/creator = null
-	anchored = 1.0
+	anchored = 1
 	var/precision = 1 // how close to the portal you will teleport. 0 = on the portal, 1 = adjacent
 	var/can_multitool_to_remove = 0
 
 /obj/effect/portal/Bumped(mob/M as mob|obj)
-	src.teleport(M)
+	teleport(M)
 
-/obj/effect/portal/New(loc, turf/target, creator)
+/obj/effect/portal/New(loc, turf/target, creator=null, lifespan=300)
 	portals += src
 	src.loc = loc
 	src.target = target
 	src.creator = creator
-	spawn(300)
-		qdel(src)
-	return
+	if(lifespan > 0)
+		spawn(lifespan)
+			qdel(src)
 
 /obj/effect/portal/Destroy()
 	portals -= src
@@ -33,6 +33,7 @@
 		var/obj/item/weapon/gun/energy/wormhole_projector/P = creator
 		P.portal_destroyed(src)
 	creator = null
+	target = null
 	return ..()
 
 /obj/effect/portal/proc/teleport(atom/movable/M as mob|obj)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -544,7 +544,7 @@
 			to_chat(user, "<span class='notice'>The [src.name] failed to create a wormhole.</span>")
 			return
 		var/chosen_beacon = pick(L)
-		var/obj/effect/portal/wormhole/jaunt_tunnel/J = new /obj/effect/portal/wormhole/jaunt_tunnel(get_turf(src), chosen_beacon)
+		var/obj/effect/portal/wormhole/jaunt_tunnel/J = new /obj/effect/portal/wormhole/jaunt_tunnel(get_turf(src), chosen_beacon, lifespan=100)
 		try_move_adjacent(J)
 		playsound(src,'sound/effects/sparks4.ogg',50,1)
 		qdel(src)


### PR DESCRIPTION
I noticed the wormhole event was using up a lot of CPU--not enough to generally cause lag, but more than it should have been. Turns out the portals were being hard deleted.

Reason why is we didn't have the proper argument for portals that specified how long they could "live" for (Don't know why this didn't get updated from TG in all the various teleporter updates we did) ...so what was happening is...the wormhole event would make 400 portals---then, they'd delete themselves after 30 seconds (way before the event would normally end)---only the problem is, there would be a reference to each of those portals on the wormhole event, so they'd fail to GC and all 400 would end up being hard deleted, 30 seconds later.

:cl: Fox McCloud
fix: fixes the wormhole event being much shorter than intended
/:cl: