### PR TITLE
Adds config option to let players see their own notes.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -127,6 +127,7 @@
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
 	var/use_age_restriction_for_antags = 0 //Do antags use account age restrictions? --requires database
+	var/see_own_notes = 0 //Can players see their own admin notes (read-only)? Config option in config.txt
 
 	var/simultaneous_pm_warning_timeout = 100
 
@@ -563,6 +564,9 @@
 
 				if("round_abandon_penalty_period")
 					config.round_abandon_penalty_period = MinutesToTicks(text2num(value))
+
+				if("see_own_notes")
+					config.see_own_notes = 1
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -225,3 +225,14 @@ var/global/admin_ooc_colour = "#b82e00"
 	if(eyeobj)
 		return eyeobj
 	return src
+
+/client/proc/self_notes()
+	set name = "View Admin Notes"
+	set category = "OOC"
+	set desc = "View the notes that admins have written about you"
+	
+	if(!config.see_own_notes)
+		to_chat(usr, "<span class='notice'>Sorry, that function is not enabled on this server.</span>");
+		return
+	
+	see_own_notes()

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -178,6 +178,35 @@
 		output += ruler
 	usr << browse(output, "window=show_notes;size=900x500")
 
+/proc/show_note()
+	var/target_ckey = usr.client.ckey
+	if(!target_ckey)
+		return
+	
+	var/output
+	var/ruler
+	ruler = "<hr style='background:#000000; border:0; height:3px'>"
+	if(target_ckey)
+		var/target_sql_ckey = sanitizeSQL(target_ckey)
+		var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT id, timestamp, notetext, adminckey, last_editor, server FROM [format_table_name("notes")] WHERE ckey = '[target_sql_ckey]' ORDER BY timestamp")
+		if(!query_get_notes.Execute())
+			var/err = query_get_notes.ErrorMsg()
+			log_game("SQL ERROR obtaining ckey, notetext, adminckey, last_editor, server from notes table. Error : \[[err]\]\n")
+			return
+		output += "<h2><center>Notes of [target_ckey]</center></h2>"
+		output += ruler
+		while(query_get_notes.NextRow())
+			var/id = query_get_notes.item[1]
+			var/timestamp = query_get_notes.item[2]
+			var/notetext = query_get_notes.item[3]
+			var/adminckey = query_get_notes.item[4]
+			var/last_editor = query_get_notes.item[5]
+			var/server = query_get_notes.item[6]
+			output += "<b>[timestamp] | [server] | [adminckey]</b>"
+			output += "<br>[notetext]<hr style='background:#000000; border:0; height:1px'>"
+	usr << browse(output, "window=show_notes;size=900x500")
+
+
 /proc/show_player_info_irc(var/key as text)
 	var/target_sql_ckey = sanitizeSQL(key)
 	var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT timestamp, notetext, adminckey, server FROM [format_table_name("notes")] WHERE ckey = '[target_sql_ckey]' ORDER BY timestamp")

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -178,7 +178,7 @@
 		output += ruler
 	usr << browse(output, "window=show_notes;size=900x500")
 
-/proc/show_note()
+/proc/see_own_notes()
 	var/target_ckey = usr.client.ckey
 	if(!target_ckey)
 		return
@@ -196,11 +196,9 @@
 		output += "<h2><center>Notes of [target_ckey]</center></h2>"
 		output += ruler
 		while(query_get_notes.NextRow())
-			var/id = query_get_notes.item[1]
 			var/timestamp = query_get_notes.item[2]
 			var/notetext = query_get_notes.item[3]
 			var/adminckey = query_get_notes.item[4]
-			var/last_editor = query_get_notes.item[5]
 			var/server = query_get_notes.item[6]
 			output += "<b>[timestamp] | [server] | [adminckey]</b>"
 			output += "<br>[notetext]<hr style='background:#000000; border:0; height:1px'>"

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -310,6 +310,9 @@
 	if(holder)
 		add_admin_verbs()
 		admin_memo_output("Show", 0, 1)
+	
+	if(config.see_own_notes)
+		verbs += /client/proc/self_notes
 
 	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
 	// (but turn them off first, since sometimes BYOND doesn't turn them on properly otherwise)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -329,3 +329,6 @@ DISABLE_SPACE_RUINS
 # and still qualify for re-entering the round. Defaults to 30.
 # Setting this to 0 will disable the penalty period
 #ROUND_ABANDON_PENALTY_PERIOD 30
+
+## Uncomment this to let players see their own notes (they can still be set by admins only)
+#SEE_OWN_NOTES


### PR DESCRIPTION
It's a fucking config option, and it's not enabled by default
===

The salt is real
===

I'm 99% sure it says somewhere on my notes that I wrote a translator script in NTSL. By the way, I NEVER FUCKING WROTE THAT SCRIPT
===

There's literally no way to know if there's inaccurate data in your notes.
===

Okay, fine, I'll stop spamming the H1 text.....
===

Ported from tgstation/tgstation#6490

When enabled in config.txt, this allows players to see their own notes.

>Eh, at this point we've been making notes without the intent of showing it to any non-admin for years.
Can't exactly transfer to a different, more public method just at the snap of a finger.

-FreeStylaLT

And.. now you can.

:cl: monster860
rscadd: Adds a config option to allow players to see their own notes.
/:cl: