### PR TITLE
Deletes Orphaned Humans

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -423,8 +423,9 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
   /* ###### Prepare the radio connection ###### */
 
+	var/mob/living/carbon/human/H
 	if(!M)
-		var/mob/living/carbon/human/H = new
+		H = new
 		M = H
 
 	var/datum/radio_frequency/connection = radio_controller.return_frequency(frequency)
@@ -595,6 +596,9 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 			for(var/mob/R in heard_gibberish)
 				R.show_message(rendered, 2)
+
+	if(H)
+		qdel(H)
 
 //Use this to test if an obj can communicate with a Telecommunications Network
 

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -211,6 +211,7 @@
 			icobase = H.species.icobase
 			if(H.species.bodyflags & HAS_TAIL)
 				coloured_tail = H.species.tail
+			qdel(H)
 		else
 			icobase = current_species.icobase
 	else


### PR DESCRIPTION
Some humans are brought into existence, used for a brief moment, and then abandoned, left to rot in the void of nothingness, forever. They still technically live, if you can even call their hellish existence "living". It's certainly a little extra burden on our mob processing, anyway.

This PR ensures at least some of those humans are humanely erased from existence.