### PR TITLE
Virus Outbreak and Appendicitis Clientless Blacklist

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -16,6 +16,8 @@
 	for(var/mob/living/carbon/human/H in shuffle(living_mob_list))
 		if(issmall(H)) //don't infect monkies; that's a waste
 			continue
+		if(!H.client)
+			continue
 		if(H.species.virus_immune) //don't let virus immune things get diseases they're not supposed to get.
 			continue
 		var/turf/T = get_turf(H)

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -2,12 +2,14 @@
 	for(var/mob/living/carbon/human/H in shuffle(living_mob_list))
 		if(issmall(H)) //don't infect monkies; that's a waste.
 			continue
+		if(!H.client)
+			continue
 		if(H.species.virus_immune) //don't count things that are virus immune; they'll just get picked and auto-cure
 			continue
 		var/foundAlready = 0	//don't infect someone that already has the virus
 		for(var/datum/disease/D in H.viruses)
 			foundAlready = 1
-		if(H.stat == 2 || foundAlready)
+		if(H.stat == DEAD || foundAlready)
 			continue
 
 		var/datum/disease/D = new /datum/disease/appendicitis


### PR DESCRIPTION
Appendicitis and disease outbreak events will no longer target clientless mobs.

It's a waste of an event if this hits someone who's SSD or it just a humanized monkey.

:cl: Fox McCloud
fix: Appendicitis and Disease Outbreak events will no longer impact clientless mobs
/:cl: