### PR TITLE
Adds attack logs for golems being summoned.

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -384,7 +384,7 @@
 	G.change_gender(pick(MALE,FEMALE))
 	G.loc = src.loc
 	G.key = ghost.key
-	G.attack_log += "\[[time_stamp()]\] <font color='blue'>Has been summoned by [user.name] ([user.ckey])</font>"
+	add_log(G, user, "summoned", null, "as a golem")
 	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost.")
 	qdel(src)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -384,7 +384,7 @@
 	G.change_gender(pick(MALE,FEMALE))
 	G.loc = src.loc
 	G.key = ghost.key
-	add_log(G, user, "summoned", null, "as a golem")
+	add_logs(G, user, "summoned", null, "as a golem")
 	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost.")
 	qdel(src)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -215,6 +215,7 @@
 		SM.faction = user.faction
 		SM.master_commander = user
 		SM.sentience_act()
+		SM.attack_log += "\[[time_stamp()]\] <font color='blue'>Has been made sentient by [user.name] ([user.ckey])</font>"
 		to_chat(SM, "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>")
 		to_chat(SM, "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>")
 		to_chat(user, "<span class='notice'>[M] accepts the potion and suddenly becomes attentive and aware. It worked!</span>")
@@ -384,6 +385,7 @@
 	G.change_gender(pick(MALE,FEMALE))
 	G.loc = src.loc
 	G.key = ghost.key
+	G.attack_log += "\[[time_stamp()]\] <font color='blue'>Has been summoned by [user.name] ([user.ckey])</font>"
 	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost.")
 	qdel(src)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -215,7 +215,6 @@
 		SM.faction = user.faction
 		SM.master_commander = user
 		SM.sentience_act()
-		SM.attack_log += "\[[time_stamp()]\] <font color='blue'>Has been made sentient by [user.name] ([user.ckey])</font>"
 		to_chat(SM, "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>")
 		to_chat(SM, "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>")
 		to_chat(user, "<span class='notice'>[M] accepts the potion and suddenly becomes attentive and aware. It worked!</span>")


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: golems now have their master saved in attack logs
/:cl:

Easier to check attack logs than ask around for a golem's master in case they run around the brig chainsawing sec in half for no apparent reason.

Remember, kids, traitor responsibly.