### PR TITLE
Fixes Bandolier Sprite

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -314,6 +314,10 @@
 		"/obj/item/ammo_casing/shotgun"
 		)
 
+/obj/item/weapon/storage/belt/bandolier/New()
+	..()
+	update_icon()
+
 /obj/item/weapon/storage/belt/bandolier/full/New()
 	..()
 	new /obj/item/ammo_casing/shotgun/beanbag(src)


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/5303

Fixes the bandolier being invisible when spawned

:cl: Fox McCloud
fix: Fixes bandolier being invisible on spawn
/:cl: