### PR TITLE
Fixes centcom ferry requests being displayed to all admins and mentors

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -737,7 +737,9 @@
 			return
 		cooldown = 1
 		to_chat(usr, "<span class='notice'>Your request has been recieved by Centcom.</span>")
-		to_chat(admins, "<b>FERRY: <font color='blue'>[key_name_admin(usr)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) (<A HREF='?_src_=holder;secretsfun=moveferry'>Move Ferry</a>)</b> is requesting to move the transport ferry to Centcom.</font>")
+		for(var/client/A in admins)
+			if(check_rights(R_SERVER|R_EVENT, 0, A.mob))
+				to_chat(A, "<b>FERRY: <font color='blue'>[key_name_admin(usr)] (<A HREF='?_src_=holder;secretsfun=moveferry'>Move Ferry</a>)</b> is requesting to move the transport ferry to Centcom.</font>")
 		spawn(600) //One minute cooldown
 			cooldown = 0
 

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -737,9 +737,8 @@
 			return
 		cooldown = 1
 		to_chat(usr, "<span class='notice'>Your request has been recieved by Centcom.</span>")
-		for(var/client/A in admins)
-			if(check_rights(R_SERVER|R_EVENT, 0, A.mob))
-				to_chat(A, "<b>FERRY: <font color='blue'>[key_name_admin(usr)] (<A HREF='?_src_=holder;secretsfun=moveferry'>Move Ferry</a>)</b> is requesting to move the transport ferry to Centcom.</font>")
+		log_admin("[key_name(usr)] requested to move the transport ferry to Centcom.")
+		message_admins("<b>FERRY: <font color='blue'>[key_name_admin(usr)] (<A HREF='?_src_=holder;secretsfun=moveferry'>Move Ferry</a>)</b> is requesting to move the transport ferry to Centcom.</font>")
 		spawn(600) //One minute cooldown
 			cooldown = 0
 


### PR DESCRIPTION
Now ferry requests will only be displayed to admins who have at least
one of the permissions needed to actually move the ferry.
Also fixes the buttons (Such as  the follow button) being displayed
twice for ferry request messages.