### PR TITLE
Makes Fake Sunglasses Truly Cosmetic

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -237,7 +237,9 @@
 /obj/item/clothing/glasses/sunglasses/fake
 	desc = "Cheap, plastic sunglasses. They don't even have UV protection."
 	name = "cheap sunglasses"
+	darkness_view = 0
 	flash_protect = 0
+	tint = 0
 
 /obj/item/clothing/glasses/sunglasses/noir
 	name = "noir sunglasses"


### PR DESCRIPTION
Fake sunglasses are meant to be 100% cosmetic, but yet they set a few vision stats they shouldn't, given they're cosmetic