### PR TITLE
Fixes Start Singulo

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1387,20 +1387,9 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	spawn(30)
 		for(var/obj/machinery/the_singularitygen/G in machines)
 			if(G.anchored)
-				var/obj/singularity/S = new /obj/singularity(get_turf(G), 50)
-//				qdel(G)
-				S.energy = 1750
-				S.current_size = 7
-				S.icon = 'icons/effects/224x224.dmi'
-				S.icon_state = "singularity_s7"
-				S.pixel_x = -96
-				S.pixel_y = -96
-				S.grav_pull = 0
-				//S.consume_range = 3
-				S.dissipate = 0
-				//S.dissipate_delay = 10
-				//S.dissipate_track = 0
-				//S.dissipate_strength = 10
+				var/obj/singularity/S = new /obj/singularity(get_turf(G))
+				S.energy = 800
+				break
 
 	for(var/obj/machinery/power/rad_collector/Rad in machines)
 		if(Rad.anchored)


### PR DESCRIPTION
Fixes the start singulo verb so that it doesn't result in engineering immediately blowing up or a singularity release.

Fixes https://github.com/ParadiseSS13/Paradise/issues/3040