### PR TITLE
Adds Ctrl+Click-Self Shortcut to Stop Pulling

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -872,9 +872,12 @@ var/list/slot_equipment_priority = list( \
 
 //this and stop_pulling really ought to be /mob/living procs
 /mob/proc/start_pulling(atom/movable/AM)
-	if( !AM || !src || src==AM || !isturf(AM.loc) )	//if there's no person pulling OR the person is pulling themself OR the object being pulled is inside something: abort!
+	if(src == AM) // Trying to pull yourself is a shortcut to stop pulling
+		stop_pulling()
 		return
-	if(!( AM.anchored ))
+	if(!AM || !isturf(AM.loc))	//if there's no object or the object being pulled is inside something: abort!
+		return
+	if(!(AM.anchored))
 		AM.add_fingerprint(src)
 
 		// If we're pulling something then drop what we're currently pulling and pull this instead.


### PR DESCRIPTION
Once upon a time, ctrl+clicking an object would *toggle* pulling - it would start pulling something you weren't, and stop pulling something you were. It was a handy way to quickly stop pulling something that, unfortunately, got lost in a pulling refactor. Issues were opened for it, nobody fixed it, and it was forgotten.

Until now.

I considered making ctrl+click toggle pulling again, but then I remembered all the times I'd accidentally stop pulling something I forgot I was still pulling, and not notice until I was walking away without it. So, instead, this makes it so trying to pull yourself (by ctrl+clicking yourself) stops pulling, while ctrl+clicking an object still always pulls it. Almost always just as easy, but without the accidental toggling.

:cl:
tweak: You can now ctrl+click on yourself to stop pulling something.
/:cl: