### PR TITLE
Fixes Ghost Proximity Tripping

### DIFF
--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -248,7 +248,7 @@
 /obj/effect/beam/i_beam/Crossed(atom/movable/AM as mob|obj)
 	if(!isobj(AM) && !isliving(AM))
 		return
-	if(istype(AM, /obj/effect/beam))
+	if(istype(AM, /obj/effect))
 		return
 	hit()
 

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -174,7 +174,7 @@
 		return
 
 	dir = turn(dir, 90)
-	
+
 	if(usr.machine == src)
 		interact(usr)
 
@@ -246,7 +246,9 @@
 	hit()
 
 /obj/effect/beam/i_beam/Crossed(atom/movable/AM as mob|obj)
-	if(istype(AM, /obj/effect/beam) || !AM.density)
+	if(!isobj(AM) && !isliving(AM))
+		return
+	if(istype(AM, /obj/effect/beam))
 		return
 	hit()
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -42,6 +42,8 @@
 
 
 	HasProximity(atom/movable/AM as mob|obj)
+		if(!isobj(AM) && !isliving(AM))
+			return
 		if(istype(AM, /obj/effect/beam))	return
 		if(AM.move_speed < 12)	sense()
 		return

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -44,7 +44,7 @@
 	HasProximity(atom/movable/AM as mob|obj)
 		if(!isobj(AM) && !isliving(AM))
 			return
-		if(istype(AM, /obj/effect/beam))	return
+		if(istype(AM, /obj/effect))	return
 		if(AM.move_speed < 12)	sense()
 		return
 


### PR DESCRIPTION
Fixes #5443.

Fixes #2978.

- Bluespace hardening prevents ghosts from tripping Proximity Sensors and Infrared Sensors

- Sanity sensors prevent visual effects and hallucinations from triggering Proximity Sensors and Infrared Sensors

:cl:
fix: Ghosts can no longer trip Proximity Sensors
fix: Ghosts can no longer trip Infrared Sensors
fix: Effects (like hallucinations) can no longer trip Proximity and Infrared Sensors
/:cl: