### PR TITLE
Alt Click Tile viewing improvements

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -263,12 +263,13 @@
 
 /atom/proc/AltClick(var/mob/user)
 	var/turf/T = get_turf(src)
-	if(T && user.TurfAdjacent(T))
-		if(user.listed_turf == T)
-			user.listed_turf = null
-		else
+	if(T)
+		if(user.TurfAdjacent(T))
 			user.listed_turf = T
 			user.client.statpanel = T.name
+			// If we had a method to force a `Stat` update, it would go here
+		else
+			user.listed_turf = null
 	return
 
 /mob/proc/TurfAdjacent(var/turf/T)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -943,17 +943,7 @@ var/list/slot_equipment_priority = list( \
 /mob/Stat()
 	..()
 
-	if(listed_turf && client)
-		if(!TurfAdjacent(listed_turf))
-			listed_turf = null
-		else
-			statpanel(listed_turf.name, null, listed_turf)
-			for(var/atom/A in listed_turf)
-				if(A.invisibility > see_invisible)
-					continue
-				if(is_type_in_list(A, shouldnt_see))
-					continue
-				statpanel(listed_turf.name, null, A)
+	show_stat_turf_contents()
 
 	statpanel("Status") // We only want alt-clicked turfs to come before Status
 
@@ -989,6 +979,23 @@ var/list/slot_equipment_priority = list( \
 	var/ETA = shuttle_master.emergency.getModeStr()
 	if(ETA)
 		stat(null, "[ETA] [shuttle_master.emergency.getTimerStr()]")
+
+/mob/proc/show_stat_turf_contents()
+	if(listed_turf && client)
+		if(!TurfAdjacent(listed_turf))
+			listed_turf = null
+		else
+			statpanel(listed_turf.name, null, listed_turf)
+			var/list/statpanel_things = list()
+			for(var/foo in listed_turf)
+				var/atom/A = foo
+				if(A.invisibility > see_invisible)
+					continue
+				if(is_type_in_list(A, shouldnt_see))
+					continue
+				statpanel_things += A
+			statpanel(listed_turf.name, null, statpanel_things)
+
 
 /mob/proc/add_stings_to_statpanel(var/list/stings)
 	for(var/obj/effect/proc_holder/changeling/S in stings)


### PR DESCRIPTION
It can now read a turf containing 300 crowbars quickly, and will only disappear if you alt-click a turf far away from yourself.

However, without a means of calling `Stat` at any time, there will still be a slight delay as it takes a little time for `Stat`'s clock to come up, which updates the turf contents list.

:cl: Crazylemon
tweak: Alt+Click should be quicker now
tweak: The Alt+Click panel vanishes only when you alt click a turf distant from yourself
/:cl: