### PR TITLE
Fixes talking swords being unable to be understood by their wielders, or anyone

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -212,7 +212,7 @@
 
 	if(candidates.len)
 		theghost = pick(candidates)
-		var/mob/living/simple_animal/shade/S = new(src)
+		var/mob/living/simple_animal/shade/sword/S = new(src)
 		S.real_name = name
 		S.name = name
 		S.ckey = theghost.ckey
@@ -227,7 +227,7 @@
 		possessed = FALSE
 
 /obj/item/weapon/nullrod/scythe/talking/Destroy()
-	for(var/mob/living/simple_animal/shade/S in contents)
+	for(var/mob/living/simple_animal/shade/sword/S in contents)
 		to_chat(S, "You were destroyed!")
 		S.ghostize()
 		qdel(S)

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -47,3 +47,7 @@
 					if((M.client && !( M.blinded )))
 						M.show_message("\red [user] gently taps [src] with the [O]. ")
 		return
+
+/mob/living/simple_animal/shade/sword
+	universal_speak = 1
+	faction = list("neutral")


### PR DESCRIPTION
Fixes #5288
Also, the faction of the shade inside the sword will now be neutral instead of cult, if that affects anything.

:cl:
fix: Talking swords can now be understood by their wielders, and everyone else.
/:cl: