### PR TITLE
Clicky stat buttons

### DIFF
--- a/code/controllers/ProcessScheduler/core/process.dm
+++ b/code/controllers/ProcessScheduler/core/process.dm
@@ -326,7 +326,9 @@
 	var/averageRunTime = round(getAverageRunTime(), 0.1)/10
 	var/lastRunTime = round(getLastRunTime(), 0.1)/10
 	var/highestRunTime = round(getHighestRunTime(), 0.1)/10
-	stat("[name]", "T#[getTicks()] | AR [averageRunTime] | LR [lastRunTime] | HR [highestRunTime] | D [cpu_defer_count]")
+	if(!statclick)
+		statclick = new (src)
+	stat("[name]", statclick.update("T#[getTicks()] | AR [averageRunTime] | LR [lastRunTime] | HR [highestRunTime] | D [cpu_defer_count]"))
 
 /datum/controller/process/proc/catchException(var/exception/e, var/thrower)
 	if(istype(e)) // Real runtimes go to the real error handler

--- a/code/controllers/ProcessScheduler/core/processScheduler.dm
+++ b/code/controllers/ProcessScheduler/core/processScheduler.dm
@@ -368,7 +368,9 @@ var/global/datum/controller/processScheduler/processScheduler
 	if(!isRunning)
 		stat("Processes", "Scheduler not running")
 		return
-	stat("Processes", "[processes.len] (R [running.len] / Q [queued.len] / I [idle.len])")
+	if(!statclick)
+		statclick = new (src)
+	stat("Processes", statclick.update("[processes.len] (R [running.len] / Q [queued.len] / I [idle.len])"))
 	stat(null, "[round(cpuAverage, 0.1)] CPU, [round(timeAllowance, 0.1)/10] TA")
 	for(var/datum/controller/process/p in processes)
 		p.statProcess()

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -15,6 +15,9 @@ var/global/pipe_processing_killed = 0
 	var/iteration = 0
 	var/processing_interval = 0
 
+	// Dummy object to let us click it to debug while in the stat panel
+	var/obj/effect/statclick/debug/statclick
+
 /datum/controller/proc/recover() // If we are replacing an existing controller (due to a crash) we attempt to preserve as much as we can.
 
 /datum/controller/game_controller

--- a/code/datums/statclick.dm
+++ b/code/datums/statclick.dm
@@ -1,0 +1,39 @@
+// Not TECHNICALLY a datum, but this should never be instantiated
+// outside of the stat panel
+// Clickable stat() button
+/obj/effect/statclick
+  var/target
+
+/obj/effect/statclick/New(ntarget, text)
+  name = text
+  target = ntarget
+
+/obj/effect/statclick/proc/update(text)
+  name = text
+  return src
+
+/obj/effect/statclick/debug
+  var/class
+
+/obj/effect/statclick/debug/New(ntarget)
+  name = "Initializing..."
+  target = ntarget
+  if(istype(target, /datum/controller/process))
+    class = "process"
+  else if(istype(target, /datum/controller/processScheduler))
+    class = "scheduler"
+  else if(istype(target, /datum/controller))
+    class = "controller"
+  else if(istype(target, /datum))
+    class = "datum"
+  else
+    class = "unknown"
+
+// This bit is called when clicked in the stat panel
+/obj/effect/statclick/debug/Click()
+  if(!usr.client.holder)
+    return
+
+  usr.client.debug_variables(target)
+
+  message_admins("Admin [key_name_admin(usr)] is debugging the [target] [class].")

--- a/code/datums/statclick.dm
+++ b/code/datums/statclick.dm
@@ -2,38 +2,38 @@
 // outside of the stat panel
 // Clickable stat() button
 /obj/effect/statclick
-  var/target
+	var/target
 
 /obj/effect/statclick/New(ntarget, text)
-  name = text
-  target = ntarget
+	name = text
+	target = ntarget
 
 /obj/effect/statclick/proc/update(text)
-  name = text
-  return src
+	name = text
+	return src
 
 /obj/effect/statclick/debug
-  var/class
+	var/class
 
 /obj/effect/statclick/debug/New(ntarget)
-  name = "Initializing..."
-  target = ntarget
-  if(istype(target, /datum/controller/process))
-    class = "process"
-  else if(istype(target, /datum/controller/processScheduler))
-    class = "scheduler"
-  else if(istype(target, /datum/controller))
-    class = "controller"
-  else if(istype(target, /datum))
-    class = "datum"
-  else
-    class = "unknown"
+	name = "Initializing..."
+	target = ntarget
+	if(istype(target, /datum/controller/process))
+		class = "process"
+	else if(istype(target, /datum/controller/processScheduler))
+		class = "scheduler"
+	else if(istype(target, /datum/controller))
+		class = "controller"
+	else if(istype(target, /datum))
+		class = "datum"
+	else
+		class = "unknown"
 
 // This bit is called when clicked in the stat panel
 /obj/effect/statclick/debug/Click()
-  if(!usr.client.holder)
-    return
+	if(!usr.client.holder)
+		return
 
-  usr.client.debug_variables(target)
+	usr.client.debug_variables(target)
 
-  message_admins("Admin [key_name_admin(usr)] is debugging the [target] [class].")
+	message_admins("Admin [key_name_admin(usr)] is debugging the [target] [class].")

--- a/paradise.dme
+++ b/paradise.dme
@@ -207,6 +207,7 @@
 #include "code\datums\recipe.dm"
 #include "code\datums\ruins.dm"
 #include "code\datums\spell.dm"
+#include "code\datums\statclick.dm"
 #include "code\datums\supplypacks.dm"
 #include "code\datums\uplink_item.dm"
 #include "code\datums\vision_override.dm"


### PR DESCRIPTION
Ports the clicky stat buttons of tgstation/tgstation#13437

:cl: Crazylemon
rscadd: Admins can now click on the DI panel buttons to debug the corresponding controller in VV
/:cl: