### PR TITLE
ID Cryodorm Survival Fix

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -307,6 +307,7 @@
 			var/obj/item/device/pda/P = W
 			if(P.id)
 				qdel(P.id)
+				P.id = null
 			qdel(P)
 
 		if(!preserve)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -303,6 +303,12 @@
 				preserve = 1
 				break
 
+		if(istype(W,/obj/item/device/pda))
+			var/obj/item/device/pda/P = W
+			if(P.id)
+				qdel(P.id)
+			qdel(P)
+
 		if(!preserve)
 			qdel(W)
 		else

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -455,7 +455,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	PDAs -= src
 	var/T = get_turf(loc)
 	if(id)
-		qdel(id)
+		id.forceMove(T)
 	if(pai)
 		pai.forceMove(T)
 	current_app = null

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -455,7 +455,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	PDAs -= src
 	var/T = get_turf(loc)
 	if(id)
-		id.forceMove(T)
+		qdel(id)
 	if(pai)
 		pai.forceMove(T)
 	current_app = null


### PR DESCRIPTION
Fixes #5377.

- Recursive storage protection prevents IDs inside PDAs inside bags to survive the cryodorms storage system;

:cl:
fix: IDs are no longer dropped if their owner cryos with the ID inside a PDA inside a bag (very specific, yes)
/:cl: