### PR TITLE
Supermatter consume now properly spawns robot debris if a synthetic touches it 

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -26,6 +26,7 @@
 	var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
+	..()
 
 /obj/effect/decal/remains/slime
 	name = "You shouldn't see this"

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -23,10 +23,10 @@
 	anchored = 1
 
 /obj/effect/decal/remains/robot/New()
+	..()
 	var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	..()
 
 /obj/effect/decal/remains/slime
 	name = "You shouldn't see this"
@@ -36,6 +36,7 @@
 	anchored = 1
 
 /obj/effect/decal/remains/slime/New()
+	..()
 	var/datum/reagents/R = new/datum/reagents(5)
 	var/obj/effect/effect/water/W = new(get_turf(src))
 	W.reagents = R

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -22,6 +22,11 @@
 	icon_state = "remainsrobot"
 	anchored = 1
 
+/obj/effect/decal/remains/robot/New()
+	var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
+	s.set_up(3, 1, src)
+	s.start()
+
 /obj/effect/decal/remains/slime
 	name = "You shouldn't see this"
 	desc = "Noooooooooooooooooooooo"

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -1,7 +1,9 @@
+/obj/effect/decal/remains
+	gender = PLURAL
+
 /obj/effect/decal/remains/human
 	name = "remains"
 	desc = "They look like human remains. They have a strange aura about them."
-	gender = PLURAL
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "remains"
 	anchored = 1
@@ -9,7 +11,6 @@
 /obj/effect/decal/remains/xeno
 	name = "remains"
 	desc = "They look like the remains of something... alien. They have a strange aura about them."
-	gender = PLURAL
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "remainsxeno"
 	anchored = 1
@@ -17,7 +18,22 @@
 /obj/effect/decal/remains/robot
 	name = "remains"
 	desc = "They look like the remains of something mechanical. They have a strange aura about them."
-	gender = PLURAL
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "remainsrobot"
 	anchored = 1
+
+/obj/effect/decal/remains/slime
+	name = "You shouldn't see this"
+	desc = "Noooooooooooooooooooooo"
+	icon = 'icons/effects/blood.dmi'
+	icon_state = "remains"
+	anchored = 1
+
+/obj/effect/decal/remains/slime/New()
+  var/datum/reagents/R = new/datum/reagents(5)
+  var/obj/effect/effect/water/W = new(get_turf(src))
+  W.reagents = R
+  R.my_atom = W
+  R.add_reagent("water", 5)
+  R.reaction(get_turf(src))
+  qdel(src)

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -30,10 +30,10 @@
 	anchored = 1
 
 /obj/effect/decal/remains/slime/New()
-  var/datum/reagents/R = new/datum/reagents(5)
-  var/obj/effect/effect/water/W = new(get_turf(src))
-  W.reagents = R
-  R.my_atom = W
-  R.add_reagent("water", 5)
-  R.reaction(get_turf(src))
-  qdel(src)
+	var/datum/reagents/R = new/datum/reagents(5)
+	var/obj/effect/effect/water/W = new(get_turf(src))
+	W.reagents = R
+	R.my_atom = W
+	R.add_reagent("water", 5)
+	R.reaction(get_turf(src))
+	qdel(src)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -61,10 +61,8 @@
 	animation.master = src
 
 	flick("dust-h", animation)
-	if(!isSynthetic())
-		new /obj/effect/decal/remains/human(loc)
-	else
-		new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
+	new species.remains_type(get_turf(src))
+	if(isSynthetic())
 		var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 		s.set_up(3, 1, src)
 		s.start()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -38,7 +38,7 @@
 		flick("gibbed-h", animation)
 		hgibs(loc, viruses, dna)
 	else
-		new /obj/effect/decal/cleanable/blood/gibs/robot(src.loc)
+		new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
 		var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 		s.set_up(3, 1, src)
 		s.start()
@@ -61,7 +61,13 @@
 	animation.master = src
 
 	flick("dust-h", animation)
-	new /obj/effect/decal/remains/human(loc)
+	if(!isSynthetic())
+		new /obj/effect/decal/remains/human(loc)
+	else
+		new /obj/effect/decal/cleanable/blood/gibs/robot(loc)
+		var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
+		s.set_up(3, 1, src)
+		s.start()
 
 	spawn(15)
 		if(animation)	qdel(animation)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -62,10 +62,6 @@
 
 	flick("dust-h", animation)
 	new species.remains_type(get_turf(src))
-	if(isSynthetic())
-		var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
 
 	spawn(15)
 		if(animation)	qdel(animation)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -90,6 +90,7 @@
 	var/blood_color = "#A10808" //Red.
 	var/flesh_color = "#FFC896" //Pink.
 	var/single_gib_type = /obj/effect/decal/cleanable/blood/gibs
+	var/remains_type = /obj/effect/decal/remains/human //What sort of remains is left behind when the species dusts
 	var/base_color      //Used when setting species.
 
 	//Used in icon caching.

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -500,6 +500,7 @@
 	deform = 'icons/mob/human_races/r_slime.dmi'
 	path = /mob/living/carbon/human/slime
 	unarmed_type = /datum/unarmed_attack/punch
+	remains_type = /obj/effect/decal/remains/slime
 
 	// More sensitive to the cold
 	cold_level_1 = 280
@@ -730,6 +731,7 @@
 	unarmed_type = /datum/unarmed_attack/diona
 	//primitive_form = "Nymph"
 	slowdown = 5
+	remains_type = /obj/effect/decal/cleanable/ash
 
 	warning_low_pressure = 50
 	hazard_low_pressure = -1
@@ -844,6 +846,7 @@
 	default_language = "Galactic Common"
 	language = "Trinary"
 	unarmed_type = /datum/unarmed_attack/punch
+	remains_type = /obj/effect/decal/remains/robot
 
 	eyes = "blank_eyes"
 	brute_mod = 2.5 // 100% * 2.5 * 0.6 (robolimbs) ~= 150%


### PR DESCRIPTION
fixes #5456

:cl: Ar3nn
tweak: dusting playermobs now generates remains fitting for their race.
/:cl: