### PR TITLE
Reverts to the simpler VV list checker

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -384,16 +384,9 @@ body
 				html += "</ol>"
 			else
 				html += "<ul>"
-				// First loop to check for associativity
-				var/associative = FALSE
-				for(var/entry in L)
-					if(!(isnum(entry) || isnull(L[entry])))
-						associative = TRUE
-						break
-				// then we do it again! Except now with knowledge of associativity
 				var/index = 1
 				for(var/entry in L)
-					if(associative)
+					if(istext(entry))
 						html += debug_variable(entry, L[entry], level + 1)
 					else
 						html += debug_variable(index, L[index], level + 1)


### PR DESCRIPTION
The new version caused a bucket of runtimes, so I'm switching this back to the version BEFORE this whole mess. Associative lists view correctly as they did before I accidentally removed that when updating the map loader.