### PR TITLE
Crutch Refactor

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -565,3 +565,6 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	user.visible_message("<span class='notice'>[user] washes [src] using [source].</span>", \
 						"<span class='notice'>You wash [src] using [source].</span>")
 	return 1
+
+/obj/item/proc/is_crutch() //Does an item prop up a human mob and allow them to stand if they are missing a leg/foot?
+	return 0

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -34,6 +34,9 @@
 	materials = list(MAT_METAL=50)
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
 
+/obj/item/weapon/cane/is_crutch()
+	return 1
+
 /obj/item/weapon/c_tube
 	name = "cardboard tube"
 	desc = "A tube... of cardboard."

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -79,6 +79,9 @@
 	item_state = "cane_nt"
 	needs_permit = 0
 
+/obj/item/weapon/melee/classic_baton/ntcane/is_crutch()
+	return 1
+
 //Telescopic baton
 /obj/item/weapon/melee/classic_baton/telescopic
 	name = "telescopic baton"

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -78,9 +78,9 @@
 	// Canes and crutches help you stand (if the latter is ever added)
 	// One cane mitigates a broken leg+foot, or a missing foot.
 	// Two canes are needed for a lost leg. If you are missing both legs, canes aren't gonna help you.
-	if(l_hand && istype(l_hand, /obj/item/weapon/cane))
+	if(l_hand && l_hand.is_crutch())
 		stance_damage -= 2
-	if(r_hand && istype(r_hand, /obj/item/weapon/cane))
+	if(r_hand && r_hand.is_crutch())
 		stance_damage -= 2
 
 	if(stance_damage < 0)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -389,6 +389,9 @@
 	suppressed = 1
 	needs_permit = 0 //its just a cane beepsky.....
 
+/obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/cane/is_crutch()
+	return 1
+
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/improvised/cane/update_icon()
 	return
 


### PR DESCRIPTION
Alternative to: https://github.com/ParadiseSS13/Paradise/pull/5420

Refactors how crutches are handled--uses a proc `is_crutch` to return 1 or 0 on if it should help you out when missing limbs.

fixes https://github.com/ParadiseSS13/Paradise/issues/5362

:cl: Fox McCloud
fix: Cane Gun and NT Rep's cane now acts as actual canes
/:cl: