### PR TITLE
Fixes Gene De-activation Inconsistency

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -61,14 +61,6 @@ var/global/list/datum/dna/gene/dna_genes[0]
 var/global/list/good_blocks[0]
 var/global/list/bad_blocks[0]
 
-/////////////////
-// GENE DEFINES
-/////////////////
-
-// Skip checking if it's already active.
-// Used for genes that check for value rather than a binary on/off.
-#define GENE_ALWAYS_ACTIVATE 1
-
 /datum/dna
 	// READ-ONLY, GETS OVERWRITTEN
 	// DO NOT FUCK WITH THESE OR BYOND WILL EAT YOUR FACE

--- a/code/game/dna/dna2_domutcheck.dm
+++ b/code/game/dna/dna2_domutcheck.dm
@@ -31,15 +31,13 @@
 	if(!gene || !istype(gene))
 		return 0
 
+	// Current state
+	var/gene_active = M.dna.GetSEState(gene.block)
+
 	// Sanity checks, don't skip.
-	if(!gene.can_activate(M,flags))
+	if(!gene.can_activate(M,flags) && gene_active)
 		//testing("[M] - Failed to activate [gene.name] (can_activate fail).")
 		return 0
-
-	// Current state
-	var/gene_active = (gene.flags & GENE_ALWAYS_ACTIVATE)
-	if(!gene_active)
-		gene_active = M.dna.GetSEState(gene.block)
 
 	var/defaultgenes // Do not mutate inherent species abilities
 	if(ishuman(M))
@@ -51,12 +49,12 @@
 
 	// Prior state
 	var/gene_prior_status = (gene.type in M.active_genes)
-	var/changed = gene_active != gene_prior_status || (gene.flags & GENE_ALWAYS_ACTIVATE)
+	var/changed = gene_active != gene_prior_status
 
 	// If gene state has changed:
 	if(changed)
 		// Gene active (or ALWAYS ACTIVATE)
-		if(gene_active || (gene.flags & GENE_ALWAYS_ACTIVATE))
+		if(gene_active)
 			//testing("[gene.name] activated!")
 			gene.activate(M,connected,flags)
 			if(M)


### PR DESCRIPTION
- Fixes genes not always de-activating when someone is injected with a clean SE because they failed to roll the % chance for the gene to activate. Gene removal now always removes the gene, activation still rolls the % chance.
- Removes a deprecated genetics define.