### PR TITLE
You can now examine from inside an object

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -221,7 +221,7 @@
 	A.ShiftClick(src)
 	return
 /atom/proc/ShiftClick(var/mob/user)
-	if(user.client && user.client.eye == user)
+	if(user.client && get_turf(user.client.eye) == get_turf(user))
 		user.examinate(src)
 	return
 


### PR DESCRIPTION
Fixes #4035

This means pAIs, people in closets, people in mechs, and MMIs should now be able to examine their surroundings

:cl: Crazylemon
fix: Encased mobs can now examine
/:cl: