### PR TITLE
Non-turf inventory interaction overhaul

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -120,6 +120,9 @@
 	return
 
 /mob/proc/ClickInventory(var/atom/A, var/obj/item/W, var/params)
+	if(!isnull(loc))
+		if(!loc.allow_inventory())
+			return
 	if(W == A)
 		W.attack_self(src)
 		if(hand)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -182,6 +182,16 @@
 /datum/hud/proc/persistant_inventory_update()
 	return
 
+/datum/hud/proc/hide_inventory()
+	inventory_shown = 0
+	mymob.client.screen -= toggleable_inventory
+	hidden_inventory_update()
+
+/datum/hud/proc/show_inventory()
+	inventory_shown = 1
+	mymob.client.screen += toggleable_inventory
+	hidden_inventory_update()
+
 //Triggered when F12 is pressed (Unless someone changed something in the DMF)
 /mob/verb/button_pressed_F12()
 	set name = "F12"

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -6,14 +6,12 @@
 	icon_state = "toggle"
 
 /obj/screen/human/toggle/Click()
+	if(usr.loc && !usr.loc.allow_inventory())
+		return
 	if(usr.hud_used.inventory_shown)
-		usr.hud_used.inventory_shown = 0
-		usr.client.screen -= usr.hud_used.toggleable_inventory
+		usr.hud_used.hide_inventory()
 	else
-		usr.hud_used.inventory_shown = 1
-		usr.client.screen += usr.hud_used.toggleable_inventory
-
-	usr.hud_used.hidden_inventory_update()
+		usr.hud_used.show_inventory()
 
 /obj/screen/human/equip
 	name = "equip"

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -20,8 +20,6 @@
 	icon_state = "act_equip"
 
 /obj/screen/human/equip/Click()
-	if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
-		return 1
 	var/mob/living/carbon/human/H = usr
 	H.quick_equip()
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -257,8 +257,6 @@
 		return 1
 	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
 		return 1
-	if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
-		return 1
 	if(master)
 		var/obj/item/I = usr.get_active_hand()
 		if(I)
@@ -367,8 +365,6 @@
 		return 1
 	if(usr.incapacitated())
 		return 1
-	if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
-		return 1
 	if(usr.attack_ui(slot_id))
 		usr.update_inv_l_hand(0)
 		usr.update_inv_r_hand(0)
@@ -405,8 +401,6 @@
 	if(world.time <= usr.next_move)
 		return 1
 	if(usr.incapacitated())
-		return 1
-	if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 		return 1
 
 	if(ismob(usr))

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -116,6 +116,8 @@
 /datum/action/item_action/Trigger()
 	if(!..())
 		return 0
+	if(owner.loc && !owner.loc.allow_inventory())
+		return 0
 	if(target)
 		var/obj/item/I = target
 		I.ui_action_click(owner, type)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -140,9 +140,14 @@
 */
 
 
-
+// Default is to prevent dropping items when you can't touch your inventory
 /atom/proc/allow_drop()
-	return 1
+	return allow_inventory()
+
+// Whether or not mobs are allowed to twiddle with
+// their inventory while inside this atom
+/atom/proc/allow_inventory()
+	return TRUE
 
 /atom/proc/CheckExit()
 	return 1

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -137,7 +137,7 @@
 			AM.Uncrossed(src)
 
 	if(destination)
-		destination.Entered(src)
+		destination.Entered(src, old_loc)
 		for(var/atom/movable/AM in destination)
 			AM.Crossed(src)
 

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -103,9 +103,6 @@
 	for(var/obj/item/weapon/stock_parts/micro_laser/P in component_parts)
 		damage_coeff = P.rating
 
-/obj/machinery/dna_scannernew/allow_drop()
-	return 0
-
 /obj/machinery/dna_scannernew/relaymove(mob/user as mob)
 	if(user.stat)
 		return

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -532,9 +532,6 @@
 		return
 	return
 
-/obj/machinery/sleeper/allow_drop()
-	return 0
-
 /obj/machinery/sleeper/verb/move_inside()
 	set name = "Enter Sleeper"
 	set category = "Object"

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -143,10 +143,6 @@
 	return 1
 
 
-/obj/machinery/atmospherics/unary/cryo_cell/allow_drop()
-	return 0
-
-
 /obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user as mob)
 	if(user.stat)
 		return

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -163,6 +163,9 @@ Class Procs:
 /obj/machinery/proc/locate_machinery()
 	return
 
+/obj/machinery/allow_drop()
+	return 0
+
 /obj/machinery/process() // If you dont use process or power why are you here
 	return PROCESS_KILL
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -164,6 +164,9 @@ Class Procs:
 	return
 
 /obj/machinery/allow_inventory()
+	return TRUE
+
+/obj/machinery/allow_drop()
 	return FALSE
 
 /obj/machinery/process() // If you dont use process or power why are you here

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -163,8 +163,8 @@ Class Procs:
 /obj/machinery/proc/locate_machinery()
 	return
 
-/obj/machinery/allow_drop()
-	return 0
+/obj/machinery/allow_inventory()
+	return FALSE
 
 /obj/machinery/process() // If you dont use process or power why are you here
 	return PROCESS_KILL

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -109,9 +109,6 @@
 /obj/machinery/recharge_station/Bumped(var/mob/AM)
 	move_inside(AM)
 
-/obj/machinery/recharge_station/allow_drop()
-	return 0
-
 /obj/machinery/recharge_station/relaymove(mob/user as mob)
 	if(user.stat)
 		return

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -177,7 +177,7 @@ var/const/SAFETY_COOLDOWN = 100
 
 	// Remove and recycle the equipped items
 	if(eat_victim_items)
-		for(var/obj/item/I in L.get_equipped_items())
+		for(var/obj/item/I in L.get_all_slots())
 			if(L.unEquip(I))
 				eat(I, sound = 0)
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -41,7 +41,7 @@
 	var/inject_amount = 10
 	salvageable = 0
 
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/allow_drop()
+/obj/item/mecha_parts/mecha_equipment/medical/sleeper/allow_inventory()
 	return 0
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/Destroy()
@@ -520,4 +520,3 @@
 	for(var/reagent in processed_reagents)
 		reagents.add_reagent(reagent,amount)
 		chassis.use_power(energy_drain)
-

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1116,7 +1116,6 @@
 		if(true_contents.len > 0)
 			var/obj/I = pick(true_contents)
 			if(user.put_in_any_hand_if_possible(I))
-				src.contents -= I
 				to_chat(user, "<span class='notice'>You find \a [I] [pick("under the seat", "under the console")]!</span>")
 			else
 				to_chat(user, "<span class='notice'>You think you saw something shiny, but you can't reach it!</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -635,8 +635,8 @@
 	mechas_list -= src //global mech list
 	return ..()
 
-/obj/mecha/allow_drop()
-	return 0
+/obj/mecha/allow_inventory()
+	return FALSE
 
 /obj/mecha/ex_act(severity)
 	log_message("Affected by explosion of severity: [severity].",1)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1101,6 +1101,31 @@
 	return
 
 
+/obj/mecha/verb/checkSeat()
+	set name = "Check under Seat"
+	set category = "Exosuit Interface"
+	set src = usr.loc
+	set popup_menu = 0
+	if(usr != occupant)
+		return
+	var/mob/user = usr
+	to_chat(user, "<span class='notice'>You start rooting around under the seat for lost items</span>")
+	if(do_after(user, 40, target = src))
+		var/obj/badlist = get_intended_components()
+		var/list/true_contents = contents - badlist
+		if(true_contents.len > 0)
+			var/obj/I = pick(true_contents)
+			if(user.put_in_any_hand_if_possible(I))
+				src.contents -= I
+				to_chat(user, "<span class='notice'>You find \a [I] [pick("under the seat", "under the console")]!</span>")
+			else
+				to_chat(user, "<span class='notice'>You think you saw something shiny, but you can't reach it!</span>")
+				log_debug("There was a loose [I] in the mech at [atom_loc_line(src)]")
+		else
+			to_chat(user, "<span class='notice'>You fail to find anything of value.</span>")
+	else
+		to_chat(user, "<span class='notice'>You decide against searching the [src]</span>")
+
 /obj/mecha/MouseDrop_T(mob/M, mob/user)
 	if(user.incapacitated())
 		return
@@ -1233,6 +1258,10 @@
 
 /obj/mecha/proc/pilot_mmi_hud(var/mob/living/carbon/brain/pilot)
 	return
+
+// Stuff that belongs inside the mech, as opposed to stuff that fell while inside the mech
+/obj/mecha/proc/get_intended_components()
+	return list(cell, radio, internal_tank, occupant) + equipment
 
 /obj/mecha/verb/view_stats()
 	set name = "View Stats"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -636,6 +636,9 @@
 	return ..()
 
 /obj/mecha/allow_inventory()
+	return TRUE
+
+/obj/spacepod/allow_drop()
 	return FALSE
 
 /obj/mecha/ex_act(severity)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -635,6 +635,9 @@
 	mechas_list -= src //global mech list
 	return ..()
 
+/obj/mecha/allow_drop()
+	return 0
+
 /obj/mecha/ex_act(severity)
 	log_message("Affected by explosion of severity: [severity].",1)
 	if(prob(deflect_chance))
@@ -1099,31 +1102,6 @@
 	occupant_message("Now taking air from [use_internal_tank?"internal airtank":"environment"].")
 	log_message("Now taking air from [use_internal_tank?"internal airtank":"environment"].")
 	return
-
-
-/obj/mecha/verb/checkSeat()
-	set name = "Check under Seat"
-	set category = "Exosuit Interface"
-	set src = usr.loc
-	set popup_menu = 0
-	if(usr != occupant)
-		return
-	var/mob/user = usr
-	to_chat(user, "<span class='notice'>You start rooting around under the seat for lost items</span>")
-	if(do_after(user, 40, target = src))
-		var/obj/badlist = get_intended_components()
-		var/list/true_contents = contents - badlist
-		if(true_contents.len > 0)
-			var/obj/I = pick(true_contents)
-			if(user.put_in_any_hand_if_possible(I))
-				to_chat(user, "<span class='notice'>You find \a [I] [pick("under the seat", "under the console")]!</span>")
-			else
-				to_chat(user, "<span class='notice'>You think you saw something shiny, but you can't reach it!</span>")
-				log_debug("There was a loose [I] in the mech at [atom_loc_line(src)]")
-		else
-			to_chat(user, "<span class='notice'>You fail to find anything of value.</span>")
-	else
-		to_chat(user, "<span class='notice'>You decide against searching the [src]</span>")
 
 /obj/mecha/MouseDrop_T(mob/M, mob/user)
 	if(user.incapacitated())

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -55,6 +55,10 @@
 		overlays = null
 		overlays += image("icon" = "mecha.dmi", "icon_state" = "ripley-g-full")
 
+
+/obj/mecha/working/ripley/get_intended_components()
+	return ..() + cargo
+
 /obj/mecha/working/ripley/firefighter
 	desc = "Standart APLU chassis was refitted with additional thermal protection and cistern."
 	name = "APLU \"Firefighter\""

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -364,7 +364,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 		return 0
 
 	var/mob/M = loc
-	if(src in M.get_equipped_items())
+	if(src in M.get_worn_slots())
 		return 1
 	else
 		return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -180,6 +180,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 /obj/item/attack_hand(mob/user as mob)
 	if(!user) return 0
+	if(user.loc && !user.loc.allow_inventory())
+		to_chat(user, "<span class='warning'>You cannot use items in your current location.</span>")
+		return 0
 	if(hasorgans(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
@@ -280,6 +283,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 // Due to storage type consolidation this should get used more now.
 // I have cleaned it up a little, but it could probably use more.  -Sayu
 /obj/item/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	// This really should be in the `afterattack` of `item/weapon/storage` -- crazylemon
 	if(istype(W,/obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
 		if(S.use_to_pickup)
@@ -307,8 +311,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 			else if(S.can_be_inserted(src))
 				S.handle_item_insertion(src)
-
-	return
+	// allow afterattacks
+	return 0
 
 /obj/item/proc/hit_reaction(mob/living/carbon/human/owner, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(prob(final_block_chance))

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -82,6 +82,8 @@
 
 
 /obj/item/weapon/grenade/chem_grenade/attack_self(mob/user)
+	if(!isturf(user.loc)) // Gotta expose yourself to use these
+		return
 	if(stage == READY &&  !active)
 		var/turf/bombturf = get_turf(src)
 		var/area/A = get_area(bombturf)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -56,6 +56,8 @@
 			to_chat(user, "\The [src] is set for instant detonation.")
 
 /obj/item/weapon/grenade/attack_self(mob/user as mob)
+	if(!isturf(user.loc))
+		return
 	if(!active)
 		if(clown_check(user))
 			to_chat(user, "<span class='warning'>You prime the [name]! [det_time/10] seconds!</span>")

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -373,6 +373,12 @@
 		to_chat(user, "\blue You're a robot. No.")
 		return 1//Robots can't interact with storage items.
 
+	// This can be moved up to general `attackby` once storage pick-up is moved
+	// to its `afterattack`
+	if(user && user.loc && !user.loc.allow_inventory())
+		// no afterattack
+		return 1
+
 	if(!can_be_inserted(W))
 		return 0
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -630,6 +630,10 @@ BLIND     // can't see anything
 	..()
 
 /obj/item/clothing/under/MouseDrop(obj/over_object as obj)
+	if(usr.loc && !usr.loc.allow_inventory())
+		return
+	// ewwww
+	// This belongs on the `MouseDrop_T` of the hand HUD objects, not here
 	if(ishuman(usr))
 		//makes sure that the clothing is equipped so that we can't drag it into our hand from miles away.
 		if(!(src.loc == usr))

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -46,7 +46,7 @@
 	var/mob/M = src.loc                      //Get our mob holder (if any).
 
 	if(istype(M))
-		M.unEquip(src)
+		M.drop_specific_item(src)
 		to_chat(M, "[src] wriggles out of your grip!")
 		to_chat(L, "You wriggle out of [M]'s grip!")
 	else if(istype(loc,/obj/item))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -84,11 +84,11 @@
 
 //Drops the item in our left hand
 /mob/proc/drop_l_hand()
-	return drop_slot(slot_l_hand) //All needed checks are in unEquip
+	return drop_slot(slot_l_hand) //All needed checks are in drop_slot
 
 //Drops the item in our right hand
 /mob/proc/drop_r_hand()
-	return drop_slot(slot_r_hand) //Why was this not calling unEquip in the first place jesus fuck.
+	return drop_slot(slot_r_hand) //All needed checks are in drop_slot
 
 //Drops the item in our active hand.
 /mob/proc/drop_item() //THIS. DOES. NOT. NEED. AN. ARGUMENT.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -84,11 +84,11 @@
 
 //Drops the item in our left hand
 /mob/proc/drop_l_hand()
-	return unEquip(l_hand) //All needed checks are in unEquip
+	return drop_slot(slot_l_hand) //All needed checks are in unEquip
 
 //Drops the item in our right hand
 /mob/proc/drop_r_hand()
-	return unEquip(r_hand) //Why was this not calling unEquip in the first place jesus fuck.
+	return drop_slot(slot_r_hand) //Why was this not calling unEquip in the first place jesus fuck.
 
 //Drops the item in our active hand.
 /mob/proc/drop_item() //THIS. DOES. NOT. NEED. AN. ARGUMENT.
@@ -106,7 +106,7 @@
 		return 0
 	return 1
 
-/mob/proc/unEquip(obj/item/I, force) //Force overrides NODROP for things like wizarditis and admin undress.
+/mob/proc/unEquip(obj/item/I, force) //Force overrides NODROP and allow_drop() for things like wizarditis and admin undress.
 	if(!I) //If there's nothing to drop, the drop is automatically succesfull. If(unEquip) should generally be used to check for NODROP.
 		return 1
 
@@ -138,28 +138,26 @@
 	return 1
 
 
-//Outdated but still in use apparently. This should at least be a human proc.
-/mob/proc/get_equipped_items()
-	var/list/items = new/list()
 
-	if(hasvar(src,"back")) if(src:back) items += src:back
-	if(hasvar(src,"belt")) if(src:belt) items += src:belt
-	if(hasvar(src,"l_ear")) if(src:l_ear) items += src:l_ear
-	if(hasvar(src,"r_ear")) if(src:r_ear) items += src:r_ear
-	if(hasvar(src,"glasses")) if(src:glasses) items += src:glasses
-	if(hasvar(src,"gloves")) if(src:gloves) items += src:gloves
-	if(hasvar(src,"head")) if(src:head) items += src:head
-	if(hasvar(src,"shoes")) if(src:shoes) items += src:shoes
-	if(hasvar(src,"wear_id")) if(src:wear_id) items += src:wear_id
-	if(hasvar(src,"wear_mask")) if(src:wear_mask) items += src:wear_mask
-	if(hasvar(src,"wear_suit")) if(src:wear_suit) items += src:wear_suit
-//	if(hasvar(src,"w_radio")) if(src:w_radio) items += src:w_radio  commenting this out since headsets go on your ears now PLEASE DON'T BE MAD KEELIN
-	if(hasvar(src,"w_uniform")) if(src:w_uniform) items += src:w_uniform
+// This *might* start getting excessively confusing
+// `unEquip` removes an object from a slot, and calls `dropped` on it - even
+// if it's going immediately back in your hand
 
-	//if(hasvar(src,"l_hand")) if(src:l_hand) items += src:l_hand
-	//if(hasvar(src,"r_hand")) if(src:r_hand) items += src:r_hand
+// Use `unEquip` if you are moving an item from one spot to another
+// use `drop_specific_item/slot` if you just want it to go on the floor
 
-	return items
+// `unEquip` is used to make a mob drop something, but it is also
+// called when moving items within your inventory
+// This proc is for the latter case
+
+// Returns 1 if the slot is now empty, 0 otherwise
+/mob/proc/drop_specific_item(obj/item/I, force = FALSE)
+	if(!loc.allow_drop())
+		return 0
+	return unEquip(I, force)
+
+/mob/proc/drop_slot(slot, force = FALSE)
+	return drop_specific_item(get_item_by_slot(slot), force)
 
 /obj/item/proc/equip_to_best_slot(mob/M)
 	if(src != M.get_active_hand())
@@ -199,6 +197,15 @@
 /mob/proc/get_all_slots()
 	return list(wear_mask, back, l_hand, r_hand)
 
+/mob/proc/get_worn_slots()
+	return get_all_slots() - get_storage_slots()
+
+// A list of slots that are just for storage, and not worn
+// So that you can't, for example, hold a rad suit in your hand, and be fine
+// from partyin' with the supermatter
+/mob/proc/get_storage_slots()
+	return list(l_hand, r_hand)
+
 /mob/proc/get_id_card()
 	for(var/obj/item/I in get_all_slots())
 		. = I.GetID()
@@ -212,3 +219,25 @@
 		if(slot_r_hand)
 			return r_hand
 	return null
+
+// Called when a mob moves from a spot where dropping is forbidden, to a spot
+// where dropping is allowed - so taking off your jumpsuit in a mech doesn't let
+// your ID stay on - or let you carry a large O2 tank in suit storage without
+// the hardsuit itself
+/mob/proc/update_item_drops()
+	for(var/i in 1 to slots_amt)
+		var/obj/item/I = get_item_by_slot(i)
+		if(I && !check_slot_validity(I, i))
+			drop_specific_item(I)
+	return
+
+/mob/proc/check_slot_validity(obj/item/I, slot, disable_warning = TRUE)
+	switch(slot)
+		if(slot_wear_mask)
+			if(!(I.slot_flags & SLOT_MASK))
+				return 0
+
+		if(slot_back)
+			if(!(I.slot_flags & SLOT_BACK))
+				return 0
+	return 1

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -163,6 +163,9 @@
 	if(src != M.get_active_hand())
 		to_chat(M, "<span class='warning'>You are not holding anything to equip!</span>")
 		return 0
+	if(M.loc && !M.loc.allow_inventory())
+		to_chat(M, "<span class='warning'>You cannot use items in your current location.</span>")
+		return 0
 
 	if(M.equip_to_appropriate_slot(src))
 		if(M.hand)

--- a/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/inventory.dm
@@ -13,6 +13,8 @@
 		update_inv_pockets()
 
 /mob/living/carbon/alien/humanoid/attack_ui(slot_id)
+	if(loc && !loc.allow_inventory())
+		return FALSE
 	var/obj/item/W = get_active_hand()
 	if(W)
 		if(!istype(W))	return
@@ -21,17 +23,17 @@
 //			if("head")
 			if(slot_l_store)
 				if(l_store)
-					return
+					return FALSE
 				if(W.w_class > 3)
-					return
+					return FALSE
 				unEquip(W)
 				l_store = W
 				update_inv_pockets()
 			if(slot_r_store)
 				if(r_store)
-					return
+					return FALSE
 				if(W.w_class > 3)
-					return
+					return FALSE
 				unEquip(W)
 				r_store = W
 				update_inv_pockets()

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -137,9 +137,9 @@ var/const/MAX_ACTIVE_TIME = 400
 			if(prob(20))
 				return 0
 			var/obj/item/clothing/W = target.wear_mask
-			if(W.flags & NODROP)
+			// handles drop-ability
+			if(!target.drop_specific_item(W))
 				return 0
-			target.unEquip(W)
 
 			target.visible_message("<span class='danger'>[src] tears [W] off of [target]'s face!</span>", \
 									"<span class='userdanger'>[src] tears [W] off of [target]'s face!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -184,6 +184,8 @@
 
 
 /mob/living/carbon/swap_hand()
+	if(loc && !loc.allow_inventory())
+		return
 	var/obj/item/item_in_hand = src.get_active_hand()
 	if(item_in_hand) //this segment checks if the item in your hand is twohanded.
 		if(istype(item_in_hand,/obj/item/weapon/twohanded))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -359,23 +359,6 @@
 /mob/living/carbon/proc/setDNA(var/datum/dna/newDNA)
 	dna = newDNA
 
-/mob/living/carbon/revive()
-	..()
-	if(handcuffed && !initial(handcuffed))
-		drop_specific_item(handcuffed)
-	handcuffed = initial(handcuffed)
-	update_handcuffed()
-
-	if(legcuffed && !initial(legcuffed))
-		unEquip(legcuffed)
-	legcuffed = initial(legcuffed)
-	update_inv_legcuffed()
-
-	if(reagents)
-		for(var/datum/reagent/R in reagents.reagent_list)
-			reagents.clear_reagents()
-		reagents.addiction_list.Cut()
-
 var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump, /obj/machinery/atmospherics/unary/vent_scrubber)
 
 /mob/living/handle_ventcrawl(var/atom/clicked_on) // -- TLE -- Merged by Carn

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -357,6 +357,22 @@
 /mob/living/carbon/proc/setDNA(var/datum/dna/newDNA)
 	dna = newDNA
 
+/mob/living/carbon/revive()
+	..()
+	if(handcuffed && !initial(handcuffed))
+		drop_specific_item(handcuffed)
+	handcuffed = initial(handcuffed)
+	update_handcuffed()
+
+	if(legcuffed && !initial(legcuffed))
+		unEquip(legcuffed)
+	legcuffed = initial(legcuffed)
+	update_inv_legcuffed()
+
+	if(reagents)
+		for(var/datum/reagent/R in reagents.reagent_list)
+			reagents.clear_reagents()
+		reagents.addiction_list.Cut()
 
 var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump, /obj/machinery/atmospherics/unary/vent_scrubber)
 
@@ -545,6 +561,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 
 	else if(!(I.flags & ABSTRACT)) //can't throw abstract items
 		thrown_thing = I
+		// Not sure if `drop_specific_item` should be used here
 		unEquip(I)
 
 	if(thrown_thing)
@@ -780,7 +797,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		if(do_after(src, time, 0, target = src))
 			visible_message("<span class='warning'>[src] removes [I]!</span>")
 			to_chat(src, "<span class='notice'>You get rid of [I]!</span>")
-			unEquip(I)
+			drop_specific_item(I)
 
 
 /mob/living/carbon/proc/cuff_resist(obj/item/I, breakouttime = 600, cuff_break = 0)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -800,7 +800,7 @@
 			if(do_mob(usr, src, POCKET_STRIP_DELAY/delay_denominator)) //placing an item into the pocket is 4 times faster
 				if(pocket_item)
 					if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
-						unEquip(pocket_item)
+						drop_specific_item(pocket_item)
 						if(thief_mode)
 							usr.put_in_hands(pocket_item)
 						add_logs(usr, src, "stripped", addition="of [pocket_item]", print_attack_log = isLivingSSD(src))
@@ -1399,10 +1399,10 @@
 	if(HULK in mutations)
 		say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 		if(..(I, cuff_break = 1))
-			unEquip(I)
+			drop_specific_item(I)
 	else
 		if(..())
-			unEquip(I)
+			drop_specific_item(I)
 
 /mob/living/carbon/human/get_visible_implants(var/class = 0)
 
@@ -1913,7 +1913,7 @@
 	if(current_size >= STAGE_THREE)
 		var/list/handlist = list(l_hand, r_hand)
 		for(var/obj/item/hand in handlist)
-			if(prob(current_size * 5) && hand.w_class >= ((11-current_size)/2)	&& unEquip(hand))
+			if(prob(current_size * 5) && hand.w_class >= ((11-current_size)/2)	&& drop_specific_item(hand))
 				step_towards(hand, src)
 				to_chat(src, "<span class='warning'>\The [S] pulls \the [hand] from your grip!</span>")
 	apply_effect(current_size * 3, IRRADIATE)
@@ -1935,7 +1935,7 @@
 
 /mob/living/carbon/human/get_permeability_protection()
 	var/list/prot = list("hands"=0, "chest"=0, "groin"=0, "legs"=0, "feet"=0, "arms"=0, "head"=0)
-	for(var/obj/item/I in get_equipped_items())
+	for(var/obj/item/I in get_worn_slots())
 		if(I.body_parts_covered & HANDS)
 			prot["hands"] = max(1 - I.permeability_coefficient, prot["hands"])
 		if(I.body_parts_covered & UPPER_TORSO)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -108,12 +108,12 @@
 			if((E.body_part == HAND_LEFT) || (E.body_part == ARM_LEFT))
 				if(!l_hand)
 					continue
-				if(!unEquip(l_hand))
+				if(!drop_specific_item(l_hand))
 					continue
 			else
 				if(!r_hand)
 					continue
-				if(!unEquip(r_hand))
+				if(!drop_specific_item(r_hand))
 					continue
 
 			var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
@@ -124,12 +124,12 @@
 			if((E.body_part == HAND_LEFT) || (E.body_part == ARM_LEFT))
 				if(!l_hand)
 					continue
-				if(!unEquip(l_hand))
+				if(!drop_specific_item(l_hand))
 					continue
 			else
 				if(!r_hand)
 					continue
-				if(!unEquip(r_hand))
+				if(!drop_specific_item(r_hand))
 					continue
 
 			custom_emote(1, "drops what they were holding, their [E.name] malfunctioning!")

--- a/code/modules/mob/living/carbon/human/interactive/interactive.dm
+++ b/code/modules/mob/living/carbon/human/interactive/interactive.dm
@@ -557,7 +557,7 @@
 		if(BP.can_be_inserted(I))
 			BP.handle_item_insertion(I)
 	else
-		unEquip(I,TRUE)
+		drop_specific_item(I,TRUE)
 	update_hands = 1
 
 /mob/living/carbon/human/interactive/proc/targetRange(towhere)
@@ -716,7 +716,7 @@
 				take_to_slot(C,1)
 				if(!equip_to_appropriate_slot(C))
 					var/obj/item/I = get_item_by_slot(C)
-					unEquip(I)
+					drop_specific_item(I)
 					spawn(5)
 						equip_to_appropriate_slot(C)
 			update_hands = 1
@@ -922,7 +922,7 @@
 /mob/living/carbon/human/interactive/proc/npcDrop(obj/item/A, blacklist = 0)
 	if(blacklist)
 		blacklistItems += A
-	unEquip(A)
+	. = drop_specific_item(A)
 	enforce_hands()
 	update_icons()
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -81,7 +81,7 @@
 	. = ..()
 	var/obj/item/organ/O = I
 	if(istype(O) && O.owner == src)
-		log_debug("Something tried to call `unEquip` on [src]'s giblets. [atom_loc_line(src)]")
+		log_runtime(EXCEPTION("Something tried to call `unEquip` on [src]'s giblets. [atom_loc_line(src)]"))
 		. = 0 // keep a good grip on your heart
 
 /mob/living/carbon/human/unEquip(obj/item/I)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -429,6 +429,12 @@
 		if(1)	return 1
 		if(2)	return 0 //if it returns 2, it wants no normal handling
 
+	// Moving inventory around? VERBOTEN
+	if(loc && !loc.allow_inventory())
+		if(!disable_warning)
+			to_chat(src, "<span class='warning'>You cannot use items in your current location.</span>")
+		return 0
+
 	if(istype(I, /obj/item/clothing/under) || istype(I, /obj/item/clothing/suit))
 		if(FAT in mutations)
 			if(!(I.flags_size & ONESIZEFITSALL))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -639,7 +639,7 @@ var/global/list/damage_icon_parts = list()
 				standing.icon	= 'icons/mob/uniform_fat.dmi'
 			else
 				to_chat(src, "\red You burst out of \the [w_uniform]!")
-				unEquip(w_uniform)
+				drop_specific_item(w_uniform)
 				return
 		else
 			standing.icon	= 'icons/mob/uniform.dmi'
@@ -669,17 +669,8 @@ var/global/list/damage_icon_parts = list()
 	else
 		overlays_standing[UNIFORM_LAYER]	= null
 		// Automatically drop anything in store / id / belt if you're not wearing a uniform.	//CHECK IF NECESARRY
-		for( var/obj/item/thing in list(r_store, l_store, wear_id, wear_pda, belt) )						//
-			if(thing)																			//
-				unEquip(thing)																	//
-				if(client)																		//
-					client.screen -= thing														//
-																								//
-				if(thing)																		//
-					thing.loc = loc																//
-					thing.dropped(src)															//
-					thing.layer = initial(thing.layer)
-					thing.plane = initial(thing.plane)
+		for(var/obj/item/thing in list(r_store, l_store, wear_id, wear_pda, belt))						//
+			drop_specific_item(thing)
 	if(update_icons)   update_icons()
 
 /mob/living/carbon/human/update_inv_wear_id(var/update_icons=1)
@@ -958,14 +949,14 @@ var/global/list/damage_icon_parts = list()
 				standing = image("icon" = 'icons/mob/suit_fat.dmi', "icon_state" = "[wear_suit.icon_state]")
 			else
 				to_chat(src, "\red You burst out of \the [wear_suit]!")
-				unEquip(wear_suit)
+				drop_specific_item(wear_suit)
 				return
 		else
 			standing = image("icon" = 'icons/mob/suit.dmi', "icon_state" = "[wear_suit.icon_state]")
 
 
-		if( istype(wear_suit, /obj/item/clothing/suit/straight_jacket) )
-			unEquip(handcuffed)
+		if(istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
+			drop_specific_item(handcuffed)
 			drop_l_hand()
 			drop_r_hand()
 

--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -18,9 +18,8 @@
 
 /datum/superheroes/proc/equip(var/mob/living/carbon/human/H)
 	H.rename_character(H.real_name, name)
-	for(var/obj/item/W in H)
-		if(istype(W,/obj/item/organ)) continue
-		H.unEquip(W)
+	for(var/obj/item/W in H.get_all_slots())
+		H.drop_specific_item(W)
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset(H), slot_l_ear)
 
 /datum/superheroes/proc/assign_genes(var/mob/living/carbon/human/H)
@@ -217,9 +216,8 @@
 		target.s_tone = 35
 		// No `update_dna=0` here because the character is being over-written
 		target.change_eye_color(1,1,1)
-		for(var/obj/item/W in target)
-			if(istype(W,/obj/item/organ)) continue
-			target.unEquip(W)
+		for(var/obj/item/W in target.get_all_slots())
+			target.drop_specific_item(W)
 		target.rename_character(target.real_name, "Generic Henchman ([rand(1, 1000)])")
 		target.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey/greytide(target), slot_w_uniform)
 		target.equip_to_slot_or_del(new /obj/item/clothing/shoes/black/greytide(target), slot_shoes)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -306,6 +306,23 @@
 
 /mob/living/proc/revive()
 	rejuvenate()
+	if(iscarbon(src))
+		var/mob/living/carbon/C = src
+
+		if(C.handcuffed && !initial(C.handcuffed))
+			C.unEquip(C.handcuffed)
+		C.handcuffed = initial(C.handcuffed)
+		C.update_handcuffed()
+
+		if(C.legcuffed && !initial(C.legcuffed))
+			C.unEquip(C.legcuffed)
+		C.legcuffed = initial(C.legcuffed)
+		C.update_inv_legcuffed()
+
+		if(C.reagents)
+			for(var/datum/reagent/R in C.reagents.reagent_list)
+				C.reagents.clear_reagents()
+			C.reagents.addiction_list.Cut()
 
 /mob/living/proc/rejuvenate()
 	var/mob/living/carbon/human/human_mob = null //Get this declared for use later.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -306,23 +306,6 @@
 
 /mob/living/proc/revive()
 	rejuvenate()
-	if(iscarbon(src))
-		var/mob/living/carbon/C = src
-
-		if(C.handcuffed && !initial(C.handcuffed))
-			C.unEquip(C.handcuffed)
-		C.handcuffed = initial(C.handcuffed)
-		C.update_handcuffed()
-
-		if(C.legcuffed && !initial(C.legcuffed))
-			C.unEquip(C.legcuffed)
-		C.legcuffed = initial(C.legcuffed)
-		C.update_inv_legcuffed()
-
-		if(C.reagents)
-			for(var/datum/reagent/R in C.reagents.reagent_list)
-				C.reagents.clear_reagents()
-			C.reagents.addiction_list.Cut()
 
 /mob/living/proc/rejuvenate()
 	var/mob/living/carbon/human/human_mob = null //Get this declared for use later.
@@ -649,8 +632,7 @@
 	what.add_fingerprint(src)
 	if(do_mob(src, who, what.strip_delay))
 		if(what && what == who.get_item_by_slot(where) && Adjacent(who))
-			who.unEquip(what)
-			if(silent)
+			if(silent && who.drop_specific_item(what))
 				put_in_hands(what)
 			add_logs(src, who, "stripped", addition="of [what]", print_attack_log = isLivingSSD(who))
 

--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -3,7 +3,7 @@
 		return
 
 	if(!cleanWipe)
-		force_fold_out()
+		try_fold_out(force = TRUE)
 
 	var/turf/T = get_turf_or_move(loc)
 	for(var/mob/M in viewers(T))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -356,14 +356,17 @@
 	last_special = world.time + 200
 
 	//I'm not sure how much of this is necessary, but I would rather avoid issues.
-	force_fold_out()
+	if(try_fold_out())
+		visible_message("<span class=notice>[src] folds outwards, expanding into a mobile form.</span>", "<span class=notice>You fold outwards, expanding into a mobile form.</span>")
+	else
+		to_chat(src, "<span class=warning>You are unable to fold out!</span>")
 
-	visible_message("<span class=notice>[src] folds outwards, expanding into a mobile form.</span>", "<span class=notice>You fold outwards, expanding into a mobile form.</span>")
-
-/mob/living/silicon/pai/proc/force_fold_out()
+// 1 on success, 0 on failure
+/mob/living/silicon/pai/proc/try_fold_out(force = FALSE)
 	if(istype(card.loc, /mob))
 		var/mob/holder = card.loc
-		holder.unEquip(card)
+		if(!holder.drop_specific_item(card, force = force))
+			return 0
 	else if(istype(card.loc, /obj/item/device/pda))
 		var/obj/item/device/pda/holder = card.loc
 		holder.pai = null
@@ -372,6 +375,7 @@
 
 	card.forceMove(src)
 	card.screen_loc = null
+	return 1
 
 /mob/living/silicon/pai/verb/fold_up()
 	set category = "pAI Commands"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -166,6 +166,8 @@
 
 //This proc is called whenever someone clicks an inventory ui slot.
 /mob/proc/attack_ui(slot)
+	if(loc && !loc.allow_inventory())
+		return FALSE
 	var/obj/item/W = get_active_hand()
 
 	if(istype(W))
@@ -186,6 +188,9 @@
 	if(ishuman(src) && W == src:head)
 		src:update_hair()
 		src:update_fhair()
+	// yay we succeeded or something why were we checking the value of the return
+	// but not defining it
+	return TRUE
 
 /mob/proc/put_in_any_hand_if_possible(obj/item/W as obj, del_on_fail = 0, disable_warning = 1, redraw_mob = 1)
 	if(equip_to_slot_if_possible(W, slot_l_hand, del_on_fail, disable_warning, redraw_mob))
@@ -618,6 +623,9 @@ var/list/slot_equipment_priority = list( \
 	set name = "Activate Held Object"
 	set category = null
 	set src = usr
+
+	if(loc && !loc.allow_inventory())
+		return
 
 	if(hand)
 		var/obj/item/W = l_hand

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -619,8 +619,6 @@ var/list/slot_equipment_priority = list( \
 	set category = null
 	set src = usr
 
-	if(istype(loc,/obj/mecha)) return
-
 	if(hand)
 		var/obj/item/W = l_hand
 		if(W)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -465,3 +465,9 @@
 
 /mob/proc/update_gravity()
 	return
+
+/mob/forceMove(atom/destination)
+	var/atom/oldloc = loc
+	. = ..()
+	if(!oldloc.allow_drop() && destination.allow_drop())
+		update_item_drops()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -471,3 +471,10 @@
 	. = ..()
 	if(!oldloc.allow_drop() && destination.allow_drop())
 		update_item_drops()
+	// Autoclose the rest of the inventory if you enter a spot where inv access
+	// is verboten
+	if(oldloc.allow_inventory() && !destination.allow_inventory())
+		if(hud_used && hud_used.inventory_shown)
+			hud_used.hide_inventory()
+		// Close any NanoUIs that depend on inventory access
+		nanomanager.update_user_uis(src)

--- a/code/modules/nano/interaction/inventory.dm
+++ b/code/modules/nano/interaction/inventory.dm
@@ -6,5 +6,7 @@
 /datum/topic_state/inventory_state/can_use_topic(var/src_object, var/mob/user)
 	if(!(src_object in user))
 		return STATUS_CLOSE
+	if(user.loc && !user.loc.allow_inventory())
+		return STATUS_CLOSE
 
 	return user.shared_nano_interaction()

--- a/code/modules/nano/interaction/inventory_deep.dm
+++ b/code/modules/nano/interaction/inventory_deep.dm
@@ -7,4 +7,7 @@
 	if(!user.contains(src_object))
 		return STATUS_CLOSE
 
+	if(user.loc && !user.loc.allow_inventory())
+		return STATUS_CLOSE
+
 	return user.shared_nano_interaction()

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -197,6 +197,9 @@
 
 	light_color = icon_light_color[src.icon_state]
 
+/obj/spacepod/allow_drop()
+	return 0
+
 /obj/spacepod/bullet_act(var/obj/item/projectile/P)
 	if(P.damage_type == BRUTE || P.damage_type == BURN)
 		deal_damage(P.damage)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -197,8 +197,8 @@
 
 	light_color = icon_light_color[src.icon_state]
 
-/obj/spacepod/allow_drop()
-	return 0
+/obj/spacepod/allow_inventory()
+	return FALSE
 
 /obj/spacepod/bullet_act(var/obj/item/projectile/P)
 	if(P.damage_type == BRUTE || P.damage_type == BURN)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -198,6 +198,9 @@
 	light_color = icon_light_color[src.icon_state]
 
 /obj/spacepod/allow_inventory()
+	return TRUE
+
+/obj/spacepod/allow_drop()
 	return FALSE
 
 /obj/spacepod/bullet_act(var/obj/item/projectile/P)


### PR DESCRIPTION
This PR makes things a lot more consistent with regards to when you are and are not allowed to interact with your inventory. It also makes it a lot easier to disable inventory when in a given atom, by overriding `allow_inventory` for that atom. By default, `allow_drop` checks the value of `allow_inventory` for that atom.

You are no longer able to drop items when inside:
- Machinery
- Space pods
- Mecha

:cl: Crazylemon
tweak: You can no longer drop items when inside mecha, space pods, and machinery
tweak: You can now interact with items inside your inventory while inside a mecha
tweak: You can no longer use grenades when not on a turf
/:cl:
