### PR TITLE
Robotic Limb Repair now consumes cables

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -241,12 +241,20 @@
 		if(!(S.status & ORGAN_ROBOT) || user.a_intent != I_HELP || S.open == 2)
 			return ..()
 
+		if(!isOn())		//why wasn't this being checked already?
+			to_chat(user, "<span class='warning'>Turn on [src] before attempting repairs!</span>")
+			return 1
+
 		if(S.brute_dam)
 			if(S.brute_dam < ROBOLIMB_SELF_REPAIR_CAP)
-				if(remove_fuel(0,null))
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-					S.heal_damage(15,0,0,1)
-					user.visible_message("<span class='alert'>\The [user] patches some dents on \the [M]'s [S.name] with \the [src].</span>")
+				if(get_fuel() >= 1)
+					if(H == user)
+						if(!do_mob(user, H, 10))
+							return 1
+					if(remove_fuel(1,null))
+						playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+						S.heal_damage(15,0,0,1)
+						user.visible_message("<span class='alert'>\The [user] patches some dents on \the [M]'s [S.name] with \the [src].</span>")
 				else if(S.open != 2)
 					to_chat(user, "<span class='warning'>Need more welding fuel!</span>")
 					return 1

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -517,7 +517,19 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 
 		if(S.burn_dam)
 			if(S.burn_dam < ROBOLIMB_SELF_REPAIR_CAP)
-				S.heal_damage(0,15,0,1)
+				if(S.burn_dam >= 15 && amount >= 5)
+					S.heal_damage(0, 15, 0, 1)
+					use(5)
+				else
+					var/cable_to_use = 0
+					var/dam_left = S.burn_dam
+					while(dam_left > 0)
+						cable_to_use += 1
+						dam_left -= 3
+					if(cable_to_use >= amount)	//make sure we don't use more cable than we have
+						cable_to_use = amount	//in case we have a lot of damage but not a lot of cable
+					use(cable_to_use)
+					S.heal_damage(0, (cable_to_use * 3), 0, 1)
 				user.visible_message("<span class='alert'>\The [user] repairs some burn damage on \the [M]'s [S.name] with \the [src].</span>")
 			else if(S.open != 2)
 				to_chat(user, "<span class='danger'>The damage is far too severe to patch over externally.</span>")

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -517,19 +517,15 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 
 		if(S.burn_dam)
 			if(S.burn_dam < ROBOLIMB_SELF_REPAIR_CAP)
-				if(S.burn_dam >= 15 && amount >= 5)
-					S.heal_damage(0, 15, 0, 1)
-					use(5)
-				else
-					var/cable_to_use = 0
-					var/dam_left = S.burn_dam
-					while(dam_left > 0)
-						cable_to_use += 1
-						dam_left -= 3
-					if(cable_to_use >= amount)	//make sure we don't use more cable than we have
-						cable_to_use = amount	//in case we have a lot of damage but not a lot of cable
-					use(cable_to_use)
-					S.heal_damage(0, (cable_to_use * 3), 0, 1)
+				if(H == user)
+					if(!do_mob(user, H, 10))
+						return 1
+				var/cable_to_use = 0
+				for(cable_to_use in 1 to 5)
+					if(cable_to_use == amount || (cable_to_use * 3) >= S.burn_dam)
+						break
+				use(cable_to_use)
+				S.heal_damage(0, (cable_to_use * 3), 0, 1)
 				user.visible_message("<span class='alert'>\The [user] repairs some burn damage on \the [M]'s [S.name] with \the [src].</span>")
 			else if(S.open != 2)
 				to_chat(user, "<span class='danger'>The damage is far too severe to patch over externally.</span>")


### PR DESCRIPTION
Repairing burn damage on a robotic limb / IPC now consumes cables in the process.

The heal ratio is 3 burn damage per length of cable. Repairing will cap at 15 damage (5 cables) per use, which is the amount that was previously healed with every use.
- If you have less than 15 damage, it will use the number of cables necessary to fully repair the damage.
- If you have fewer than 5 cables, it will attempt to repair as much damage as possible with the amount provided.

![image](https://i.gyazo.com/6261d05db09e0ff1eeda68e182f59575.png)
This image shows the healing from a single (lit) welder attack to the right arm (24.75 damage). The first use healed 15 damage and consumed 5 lengths. The second used 4 lengths to heal 9.75 damage, wasting an additional 2.25 healing as overheal.

A full cable coil (30 lengths) will now heal a total of 90 burn damage, instead of being an infinite healing source as long as you have at least one piece.
- This makes cable coils more comparable to the advanced burn kits in medical for organic patients, which have only 6 uses that always heal 25 damage.

Technically a balance PR, but also could be considered an exploit fix since robotic limbs literally had pocket-sized infinite healing sources readily available across maint while organic limbs didn't have that luxury.

:cl:
tweak: Repairing burn damage to robotic limbs now consumes cable in the process. Each length used repairs 3 burn damage, up to 15 damage per click.
tweak: Repairing brute damage to robotic limbs now uses 1 fuel per repair (click). Heal amount unchanged.
tweak: Self-repairing with cables or welders now incurs a 1 second delay between click and heal completion. Being repaired by a friend is still no delay (but requires a friend).
/:cl: