### PR TITLE
Fixes pAI saving

### DIFF
--- a/code/modules/mob/living/silicon/pai/personality.dm
+++ b/code/modules/mob/living/silicon/pai/personality.dm
@@ -17,10 +17,10 @@
 	var/savefile/F = new /savefile(src.savefile_path(user))
 
 
-	to_chat(F["name"], src.name)
-	to_chat(F["description"], src.description)
-	to_chat(F["role"], src.role)
-	to_chat(F["comments"], src.comments)
+	F["name"] << src.name
+	F["description"] << src.description
+	F["role"] << src.role
+	F["comments"] << src.comments
 
 	F["version"] << 1
 


### PR DESCRIPTION
pAIs should now save their personalities, and not runtime.

:cl: Crazylemon
fix: pAIs should now save
/:cl: