### PR TITLE
Sentient minebots can now see in the dark, allowing them to actually fight

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -821,6 +821,8 @@
 		SetOffenseBehavior()
 	..()
 
+/mob/living/simple_animal/hostile/mining_drone/sentience_act()
+	sight = SEE_MOBS | SEE_TURFS
 
 /**********************Minebot Upgrades**********************/
 


### PR DESCRIPTION
Because it doesn't make sense for something built for operation on a dark asteroid to not have built in answers for being in the dark.

:cl: Ar3nn
add: Minebots now see mobs and turfs at all times
/:cl: