### PR TITLE
Makes Girders Not Be Bulletproof

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -25,7 +25,8 @@
 
 /obj/structure/girder/proc/take_damage(var/amount)
 	health -= amount
-	if(health < 0)
+	if(health <= 0)
+		new /obj/item/stack/sheet/metal(get_turf(src))
 		qdel(src)
 
 /obj/structure/girder/attackby(obj/item/W as obj, mob/user as mob, params)
@@ -188,15 +189,10 @@
 		qdel(src)
 
 /obj/structure/girder/bullet_act(var/obj/item/projectile/Proj)
-	if(istype(Proj, /obj/item/projectile/beam))
-		health -= Proj.damage
-		..()
-		if(health <= 0)
-			new /obj/item/stack/sheet/metal(get_turf(src))
-			qdel(src)
-
 	if(istype(Proj ,/obj/item/projectile/beam/pulse))
 		src.ex_act(2)
+	else
+		take_damage(Proj.damage)
 	..()
 	return 0
 


### PR DESCRIPTION
- Girders now take damage from all damaging projectiles, rather than just beam projectiles.
- Girders now drop a metal sheet when destroyed by any source of numeric damage.
  - The only thing this actually affects is girders smashed by simple animals with tier 1 or 2 `environment_smash`. Beam'd girders already dropped a sheet upon destruction.
- Girders no longer call the parent `bullet_act` proc *twice* when hit by a beam.
  - I have no idea if this even did anything.

:cl:
tweak: Girders are no longer bulletproof.
/:cl: