### PR TITLE
Fixes admin attack log issue with SSDs

### DIFF
--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -45,7 +45,7 @@
 	return .
 
 /proc/key_name_admin(var/whom, var/include_name = 1)
-	var/message = "[key_name(whom, 1, include_name)](<A HREF='?_src_=holder;adminmoreinfo=\ref[whom]'>?</A>)[isAntag(whom) ? "(A)" : ""][isSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom, "holder")])"
+	var/message = "[key_name(whom, 1, include_name)](<A HREF='?_src_=holder;adminmoreinfo=\ref[whom]'>?</A>)[isAntag(whom) ? "(A)" : ""][isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom, "holder")])"
 	return message
 
 /proc/log_and_message_admins(var/message as text)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -34,8 +34,8 @@
 			return 1
 	return 0
 
-proc/isSSD(mob/M)
-	return istype(M) && M.player_logged
+proc/isLivingSSD(mob/M)
+	return istype(M) && M.player_logged && M.stat != DEAD
 
 proc/isAntag(A)
 	if(istype(A, /mob/living/carbon))


### PR DESCRIPTION
Currently:
- Admin attack logs highlight all attacks / object removals done on SSD players. This is good.
- However, players who leave their bodies count as logged out / SSD, so if you're stripping or attacking a dead player who has ghosted, it triggers the warning for online admins with attack logs enabled.

With this PR:
- The highlighting for admins looking at attack logs will only highlight item removals, attacks, etc on SSD players if the SSD players are alive at the time. 
- This should dramatically reduce the amount of incorrect alerts in the logs.

:cl: Kyep
fix: Fixes 'SSD!' warning appearing in attack logs for admins, when the target player was dead and had ghosted out of their body
/:cl: