### PR TITLE
Abductor surgery, Face repair, now all work again

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -1,19 +1,23 @@
 /datum/surgery/organ_extraction
 	name = "experimental dissection"
-	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/open_encased/saw, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/internal/extract_organ, /datum/surgery_step/internal/gland_insert, /datum/surgery_step/generic/cauterize)
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/open_encased/saw, /datum/surgery_step/open_encased/retract, /datum/surgery_step/internal/extract_organ, /datum/surgery_step/internal/gland_insert, /datum/surgery_step/generic/cauterize)
 	possible_locs = list("chest")
 
-/datum/surgery/organ_extraction/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/organ_extraction/can_start(mob/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(!ishuman(user))
 		return 0
-	if(target.get_species() == "Machine") //Maybe add in a machine version, later?
-		return 0
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/affected = H.get_organ(target_zone)
+		if(!affected)
+			return 0
+		if(affected.status & ORGAN_ROBOT) //Maybe add in a machine version, later?
+			return 0
 	var/mob/living/carbon/human/H = user
-	if(H.get_species() == "Abductor")
-		return 1
-	if((locate(/obj/item/weapon/implant/abductor) in H))
-		return 1
-	return 0
+	// You must either: Be of the abductor species, or contain an abductor implant
+	if(!(H.get_species() == "Abductor" || (locate(/obj/item/weapon/implant/abductor) in H)))
+		return 0
+	return 1
 
 
 /datum/surgery_step/internal/extract_organ

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -13,7 +13,11 @@
 		return 0
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && !(affected.status & ORGAN_ROBOT) && affected.encased && affected.open >= 2
+	if(!affected)
+		return 0
+	if(affected.status & ORGAN_ROBOT)
+		return 0
+	return 1
 
 
 /datum/surgery_step/open_encased/saw
@@ -25,12 +29,6 @@
 	)
 
 	time = 54
-
-/datum/surgery_step/open_encased/saw/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	if(!hasorgans(target))
-		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected && affected.open == 2
 
 /datum/surgery_step/open_encased/saw/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
@@ -80,12 +78,6 @@
 	)
 
 	time = 24
-
-/datum/surgery_step/open_encased/retract/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	if(!hasorgans(target))
-		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected && affected.open == 2.5
 
 /datum/surgery_step/open_encased/retract/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
@@ -138,13 +130,6 @@
 
 	time = 24
 
-/datum/surgery_step/open_encased/close/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-
-	if(!hasorgans(target))
-		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected && affected.open == 3
-
 /datum/surgery_step/open_encased/close/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
 	if(!hasorgans(target))
@@ -194,13 +179,6 @@
 	)
 
 	time = 24
-
-/datum/surgery_step/open_encased/mend/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-
-	if(!hasorgans(target))
-		return
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected && affected.open == 2.5
 
 /datum/surgery_step/open_encased/mend/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -7,8 +7,6 @@
 	can_infect = 1
 
 /datum/surgery_step/generic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	if(target_zone == "eyes")	//there are specific steps for eye surgery
-		return 0
 	if(!hasorgans(target))
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -40,10 +38,6 @@
 	)
 
 	time = 16
-
-/datum/surgery_step/generic/cut_open/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected.open == 0 && target_zone != "mouth"
 
 /datum/surgery_step/generic/cut_open/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -174,10 +168,6 @@
 	)
 
 	time = 24
-
-/datum/surgery_step/generic/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return ..() && affected.open && target_zone != "mouth"
 
 /datum/surgery_step/generic/cauterize/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -180,10 +180,6 @@
 			stored_mmi.forceMove(get_turf(src))
 			stored_mmi = null
 	..()
-
-	var/mob/living/holder_mob = loc
-	if(istype(holder_mob))
-		holder_mob.unEquip(src)
 	qdel(src)
 
 /obj/item/organ/internal/brain/mmi_holder/proc/update_from_mmi()

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -68,7 +68,10 @@
 		return 0
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected && affected.open_enough_for_surgery()
+	if(affected)
+		return 1
+
+	return 0
 
 
 

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -108,12 +108,15 @@
 	if(!hasorgans(target))
 		return 0
 
-	if(target_zone == "mouth" || target_zone == "eyes")
-		return 0
-
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	return affected && affected.open == 2 && (affected.status & ORGAN_DEAD)
+	if(!affected)
+		return 0
+
+	if(!(affected.status & ORGAN_DEAD))
+		return 0
+
+	return 1
 
 /datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -164,11 +167,10 @@
 	if(!hasorgans(target))
 		return 0
 
-	if(target_zone == "mouth" || target_zone == "eyes")
-		return 0
-
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	return affected.open == 3 && (affected.status & ORGAN_DEAD)
+	if(!(affected.status & ORGAN_DEAD))
+		return 0
+	return 1
 
 /datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -181,7 +183,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if(!istype(tool, /obj/item/weapon/reagent_containers))
-		return
+		return 0
 
 	var/obj/item/weapon/reagent_containers/container = tool
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -83,7 +83,9 @@
 /datum/surgery_step/robotics/external/unscrew_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return affected && affected.open == 0 && target_zone != "mouth"
+		if(!affected)
+			return 0
+		return 1
 
 /datum/surgery_step/robotics/external/unscrew_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -117,7 +119,9 @@
 /datum/surgery_step/robotics/external/open_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return affected && affected.open == 1
+		if(!affected)
+			return 0
+		return 1
 
 /datum/surgery_step/robotics/external/open_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -151,7 +155,9 @@
 /datum/surgery_step/robotics/external/close_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(..())
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
-		return affected && affected.open
+		if(!affected)
+			return 0
+		return 1
 
 /datum/surgery_step/robotics/external/close_hatch/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -199,9 +205,6 @@
 /datum/surgery_step/robotics/external/repair/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(!affected)
-		return -1
-	if(affected.open != 2)
-		to_chat(user, "<span class='warning'>The [affected] needs to be open to be operated on!</span>")
 		return -1
 
 	if(implement_type in implements_heal_burn)
@@ -335,7 +338,7 @@
 		var/obj/item/device/mmi/M = tool
 
 
-		if(!(affected && affected.open_enough_for_surgery()))
+		if(!affected)
 			return -1
 
 		if(!istype(M))
@@ -368,8 +371,6 @@
 		current_type = "extract"
 		var/list/organs = target.get_organs_zone(target_zone)
 		if(!(affected && (affected.status & ORGAN_ROBOT)))
-			return -1
-		if(!affected.open_enough_for_surgery())
 			return -1
 		if(!organs.len)
 			to_chat(user, "<span class='notice'>There is no removeable organs in [target]'s [parse_zone(target_zone)]!</span>")


### PR DESCRIPTION
Removes all `open` checks from `can_use`, since the new surgery system keeps track of the surgery state anyways.
:cl: Crazylemon
fix: Abductor surgery works again
fix: Face repair surgery works again
/:cl: