### PR TITLE
Fixes Goonchat Delaying Client Creation, Again

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -295,7 +295,8 @@
 	prefs.last_id = computer_id			//these are gonna be used for banning
 
 	. = ..()	//calls mob.Login()
-	chatOutput.start()
+	spawn() // Goonchat does some non-instant checks in start()
+		chatOutput.start()
 
 	if(custom_event_msg && custom_event_msg != "")
 		to_chat(src, "<h1 class='alert'>Custom Event</h1>")

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -37,6 +37,9 @@ var/list/chatResources = list(
 		broken = TRUE
 		return 0
 
+	if(!owner) // In case the client vanishes before winexists returns
+		return 0
+
 	if(winget(owner, "browseroutput", "is-disabled") == "false")
 		doneLoading()
 


### PR DESCRIPTION
`winexists` and `winget` aren't instant, which means their use in Goonchat's start-up proc made client creation non-instant, which is a Bad Thing™. So, I put it in a spawn.

Also, since `winexists` is non-instant, clients were occasionally disconnecting before it returned, causing a runtime. Now there's another check to make sure the client still exists.