### PR TITLE
The message for to_chat runtimes is more descriptive now

### DIFF
--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -217,7 +217,7 @@ var/to_chat_src
 			message = "(null)"
 		else if(istype(target, /datum))
 		 	var/datum/D = target
-			message = "'[D]' ([D.type])"
+			message = "([D.type]): '[D]'"
 		else if(!is_valid_tochat_message(message))
 			message = "(bad message) : '[message]'"
 
@@ -231,8 +231,9 @@ var/to_chat_src
 		log_runtime(new/exception("DEBUG: to_chat called with invalid message/target.", to_chat_filename, to_chat_line), to_chat_src, list("Message: '[message]'", "Target: [targetstring]"))
 		return
 
-	else if(istext(message))
+	else if(is_valid_tochat_message(message))
 		if(istext(target))
+			log_runtime(EXCEPTION("Somehow, to_chat got a text as a target"))
 			return
 
 		message = replacetext(message, "\n", "<br>")

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -199,7 +199,7 @@ var/list/chatResources = list(
 	return "<img [class] src='data:image/png;base64,[bicon_cache[key]]'>"
 
 /proc/is_valid_tochat_message(message)
-	return !(istype(message, /image) || istype(message, /sound))
+	return istext(message)
 
 /proc/is_valid_tochat_target(target)
 	return !istype(target, /savefile) && (ismob(target) || islist(target) || isclient(target) || target == world)
@@ -217,7 +217,7 @@ var/to_chat_src
 		if(istype(target, /datum))
 			var/datum/D = target
 			targetstring += ", [D.type]"
-		world.Error(new/exception("DEBUG: to_chat called with invalid message/target: Message: \'[message]\', Target: [targetstring]", to_chat_filename, to_chat_line), e_src = to_chat_src)
+		log_runtime(new/exception("DEBUG: to_chat called with invalid message/target.", to_chat_filename, to_chat_line), to_chat_src, list("Message: '[message]'", "Target: [targetstring]"))
 		return
 
 	else if(istext(message))

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -211,12 +211,23 @@ var/to_chat_src
 /proc/__to_chat(target, message)
 	if(!is_valid_tochat_message(message) || !is_valid_tochat_target(target))
 		target << message
-		if(!istext(message))
-			message = "(non-text type)"
-		var/targetstring = "\'[target]\'"
+
+		// Info about the "message"
+		if(isnull(message))
+			message = "(null)"
+		else if(istype(target, /datum))
+		 	var/datum/D = target
+			message = "'[D]' ([D.type])"
+		else if(!is_valid_tochat_message(message))
+			message = "(bad message) : '[message]'"
+
+		// Info about the target
+		var/targetstring = "'[target]'"
 		if(istype(target, /datum))
 			var/datum/D = target
 			targetstring += ", [D.type]"
+
+		// The final output
 		log_runtime(new/exception("DEBUG: to_chat called with invalid message/target.", to_chat_filename, to_chat_line), to_chat_src, list("Message: '[message]'", "Target: [targetstring]"))
 		return
 

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -198,16 +198,26 @@ var/list/chatResources = list(
 
 	return "<img [class] src='data:image/png;base64,[bicon_cache[key]]'>"
 
+/proc/is_valid_tochat_message(message)
+	return !(istype(message, /image) || istype(message, /sound))
+
+/proc/is_valid_tochat_target(target)
+	return !istype(target, /savefile) && (ismob(target) || islist(target) || isclient(target) || target == world)
+
 var/to_chat_filename
 var/to_chat_line
 var/to_chat_src
 // Call using macro: to_chat(target, message)
 /proc/__to_chat(target, message)
-	if(istype(message, /image) || istype(message, /sound) || istype(target, /savefile) || !(ismob(target) || islist(target) || isclient(target) || target == world))
+	if(!is_valid_tochat_message(message) || !is_valid_tochat_target(target))
 		target << message
 		if(!istext(message))
 			message = "(non-text type)"
-		world.Error(new/exception("DEBUG: to_chat called with invalid message: [message]", to_chat_filename, to_chat_line), e_src = to_chat_src)
+		var/targetstring = "\'[target]\'"
+		if(istype(target, /datum))
+			var/datum/D = target
+			targetstring += ", [D.type]"
+		world.Error(new/exception("DEBUG: to_chat called with invalid message/target: Message: \'[message]\', Target: [targetstring]", to_chat_filename, to_chat_line), e_src = to_chat_src)
 		return
 
 	else if(istext(message))

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -216,7 +216,7 @@ var/to_chat_src
 		if(isnull(message))
 			message = "(null)"
 		else if(istype(target, /datum))
-		 	var/datum/D = target
+			var/datum/D = target
 			message = "([D.type]): '[D]'"
 		else if(!is_valid_tochat_message(message))
 			message = "(bad message) : '[message]'"


### PR DESCRIPTION
:cl: Crazylemon
fix: The `to_chat` messages are now more descriptive when given a bad target
/:cl: