### PR TITLE
Adds a debug print to help finding clientless `new_player`s

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -24,6 +24,10 @@
 
 
 /mob/new_player/proc/new_player_panel_proc()
+	if(!client)
+		// Ideally, this should never be called on a client-less new_player
+		log_debug("new_player without a client - name: [name], key: [key], gc'd: [qdeleted(src)]")
+		return
 	var/real_name = client.prefs.real_name
 	var/output = "<center><p><a href='byond://?src=\ref[src];show_preferences=1'>Setup Character</A><br /><i>[real_name]</i></p>"
 


### PR DESCRIPTION
This will help track down the source of a runtime, with there being client-less `new_player`s when the `ticker.setup` proc is called.