### PR TITLE
Fixes a gravity generator runtime for null-z areas

### DIFF
--- a/code/modules/space_management/level_traits.dm
+++ b/code/modules/space_management/level_traits.dm
@@ -38,7 +38,7 @@
 
 var/list/default_map_traits = MAP_TRANSITION_CONFIG
 /proc/check_level_trait(z, trait)
-  if(z == 0 || isnull(z))
+  if(!z)
     return 0 // If you're nowhere, you have no traits
   var/list/trait_list
   if(space_manager.initialized)

--- a/code/modules/space_management/level_traits.dm
+++ b/code/modules/space_management/level_traits.dm
@@ -38,7 +38,7 @@
 
 var/list/default_map_traits = MAP_TRANSITION_CONFIG
 /proc/check_level_trait(z, trait)
-  if(z == 0)
+  if(z == 0 || isnull(z))
     return 0 // If you're nowhere, you have no traits
   var/list/trait_list
   if(space_manager.initialized)


### PR DESCRIPTION
As per title - the space manager could not find the level for which the z was `''`