### PR TITLE
AI Nuke Interaction Fix

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -206,7 +206,7 @@ var/bomb_set
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "nuclear_bomb.tmpl", "Nuke Control Panel", 450, 550)
+		ui = new(user, src, ui_key, "nuclear_bomb.tmpl", "Nuke Control Panel", 450, 550, state = physical_state)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -153,6 +153,9 @@ var/bomb_set
 				return
 	..()
 
+/obj/machinery/nuclearbomb/attack_ai(mob/user as mob)
+	return
+
 /obj/machinery/nuclearbomb/attack_ghost(mob/user as mob)
 	attack_hand(user)
 

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -153,9 +153,6 @@ var/bomb_set
 				return
 	..()
 
-/obj/machinery/nuclearbomb/attack_ai(mob/user as mob)
-	return
-
 /obj/machinery/nuclearbomb/attack_ghost(mob/user as mob)
 	attack_hand(user)
 


### PR DESCRIPTION
- Sanity Preservation Circuit prevents AI Units from interacting with nuclear bombs while still being able to see their death by nuclear fire approaching

:cl:
bugfix: AIs can no longer interact with nuclear bombs (Syndicate-brand included). AIs can still see the countdown
/:cl: 