### PR TITLE
Simple Animals Resting Refactor

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -124,9 +124,6 @@
 
 	morph_time = world.time + MORPH_COOLDOWN
 
-/mob/living/simple_animal/hostile/morph/handle_state_icons()
-	return
-
 /mob/living/simple_animal/hostile/morph/death(gibbed)
 	if(morphed)
 		visible_message("<span class='warning'>[src] twists and dissolves into a pile of green flesh!</span>", \

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -132,7 +132,6 @@
 	..()
 	icon_living = icon_state
 	icon_dead = icon_state
-	icon_resting = icon_state
 	access_card = new /obj/item/weapon/card/id(src)
 //This access is so bots can be immediately set to patrol and leave Robotics, instead of having to be let out first.
 	access_card.access += access_robotics
@@ -851,9 +850,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 				to_chat(usr, "<span class='notice'>You eject [paicard] from [bot_name]</span>")
 				ejectpai(usr)
 	update_controls()
-
-/mob/living/simple_animal/bot/handle_state_icons()
-	return
 
 /mob/living/simple_animal/bot/proc/update_icon()
 	icon_state = "[initial(icon_state)][on]"

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -853,6 +853,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	update_controls()
 
 /mob/living/simple_animal/bot/handle_state_icons()
+	return
 
 /mob/living/simple_animal/bot/proc/update_icon()
 	icon_state = "[initial(icon_state)][on]"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -129,13 +129,14 @@
 
 /mob/living/simple_animal/lay_down()
 	..()
-	handle_state_icons()
+	handle_resting_state_icons()
 
-/mob/living/simple_animal/proc/handle_state_icons()
-	if(resting && icon_resting && stat != DEAD)
-		icon_state = icon_resting
-	else if(stat != DEAD)
-		icon_state = icon_living
+/mob/living/simple_animal/proc/handle_resting_state_icons()
+	if(icon_resting)
+		if(resting && stat != DEAD)
+			icon_state = icon_resting
+		else if(stat != DEAD)
+			icon_state = icon_living
 
 /mob/living/simple_animal/handle_regular_status_updates()
 	if(..()) //alive

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -122,14 +122,14 @@
 			if(1 to 5)				healths.icon_state = "health6"
 			if(0)					healths.icon_state = "health7"
 
-/mob/living/simple_animal/Life()
-	. = ..()
-	handle_state_icons()
-
 /mob/living/simple_animal/proc/process_ai()
 	handle_automated_movement()
 	handle_automated_action()
 	handle_automated_speech()
+
+/mob/living/simple_animal/lay_down()
+	..()
+	handle_state_icons()
 
 /mob/living/simple_animal/proc/handle_state_icons()
 	if(resting && icon_resting && stat != DEAD)


### PR DESCRIPTION
Simple Animal Resting was tied to `Life` for some reason...not only does this make it unresponsive (rest instantly, but the icon doesn't update for another 2 seconds), but it means the icon state for living/resting is literally set, every 2 seconds, for every single simple animal in the world.

This is problematic, for a number of reason...one of them being that custom sprite states (like with mining drones) get wiped out every 2 seconds...it also means that warning sines on hostile mobs (particularly evident for mining mobs) aren't as apparent as they should be.