### PR TITLE
Fix href exploit with camera console.

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -138,7 +138,10 @@
 		var/obj/machinery/camera/C = locate(href_list["switchTo"]) in cameranet.cameras
 		if(!C)
 			return 1
-
+		
+		if(!can_access_camera(C))
+			return 1 // No href exploits for you.
+		
 		switch_to_camera(usr, C)
 
 	else if(href_list["reset"])


### PR DESCRIPTION
Fixes an href exploit where, if you know the BYOND address of a camera, you can access it even if you don't have access with a camera monitor.