### PR TITLE
Faster VV, VV by ref

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -7,7 +7,7 @@
 
 
 	if(!usr.client || !usr.client.holder)
-		to_chat(usr, "\red You need to be an administrator to access this.")
+		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
 		return
 
 

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -12,7 +12,7 @@
 
 
 	var/title = ""
-	var/body = ""
+	var/list/body = list()
 
 	if(!D)	return
 	if(istype(D, /atom))
@@ -319,7 +319,7 @@ body
 }
 </style>"}
 	html += "</head><body>"
-	html += body
+	html += body.Join("")
 
 	html += {"
 		<script type='text/javascript'>
@@ -335,7 +335,7 @@ body
 	return
 
 /client/proc/debug_variable(name, value, level, var/datum/DA = null)
-	var/html = ""
+	var/list/html = list()
 
 	if(DA)
 		html += "<li style='backgroundColor:white'>(<a href='?_src_=vars;datumedit=\ref[DA];varnameedit=[name]'>E</a>) (<a href='?_src_=vars;datumchange=\ref[DA];varnamechange=[name]'>C</a>) (<a href='?_src_=vars;datummass=\ref[DA];varnamemass=[name]'>M</a>) "
@@ -414,7 +414,7 @@ body
 		*/
 	html += "</li>"
 
-	return html
+	return html.Join("")
 
 /client/proc/view_var_Topic(href, href_list, hsrc)
 	//This should all be moved over to datum/admins/Topic() or something ~Carn

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -652,6 +652,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		if("strip")
 			//do nothing
 
+		// god is dead
 		if("as job...")
 			if(jobdatum)
 				dresscode = "[jobdatum.title]"

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -1,7 +1,7 @@
 /client/proc/air_status(turf/target as turf)
 	set category = "Debug"
 	set name = "Display Air Status"
-	
+
 	if(!check_rights(R_DEBUG))
 		return
 
@@ -18,22 +18,22 @@
 	to_chat(usr, "\blue @[target.x],[target.y]: O:[GM.oxygen] T:[GM.toxins] N:[GM.nitrogen] C:[GM.carbon_dioxide] w [GM.temperature] Kelvin, [GM.return_pressure()] kPa [(burning)?("\red BURNING"):(null)]")
 	for(var/datum/gas/trace_gas in GM.trace_gases)
 		to_chat(usr, "[trace_gas.type]: [trace_gas.moles]")
-		
+
 	message_admins("[key_name_admin(usr)] has checked the air status of [T]")
-	log_admin("[key_name(usr)] has checked the air status of [T]")	
-		
+	log_admin("[key_name(usr)] has checked the air status of [T]")
+
 	feedback_add_details("admin_verb","DAST") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/fix_next_move()
 	set category = "Debug"
 	set name = "Unfreeze Everyone"
-	
+
 	if(!check_rights(R_DEBUG))
-		return	
-		
+		return
+
 	message_admins("[key_name_admin(usr)] has unfrozen everyone")
 	log_admin("[key_name(usr)] has unfrozen everyone")
-	
+
 	var/largest_move_time = 0
 	var/largest_click_time = 0
 	var/mob/largest_move_mob = null
@@ -56,18 +56,18 @@
 		log_admin("DEBUG: [key_name(M)]  next_move = [M.next_move]  next_click = [M.next_click]  world.time = [world.time]")
 		M.next_move = 1
 		M.next_click = 0
-				
+
 	message_admins("[key_name_admin(largest_move_mob)] had the largest move delay with [largest_move_time] frames / [largest_move_time/10] seconds!", 1)
 	message_admins("[key_name_admin(largest_click_mob)] had the largest click delay with [largest_click_time] frames / [largest_click_time/10] seconds!", 1)
 	message_admins("world.time = [world.time]", 1)
-	
+
 	feedback_add_details("admin_verb","UFE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
 /client/proc/radio_report()
 	set category = "Debug"
 	set name = "Radio report"
-	
+
 	if(!check_rights(R_DEBUG))
 		return
 
@@ -102,9 +102,9 @@
 					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device]<br>"
 
 	usr << browse(output,"window=radioreport")
-	
+
 	message_admins("[key_name_admin(usr)] has generated a radio report")
-	log_admin("[key_name(usr)] has generated a radio report")	
+	log_admin("[key_name(usr)] has generated a radio report")
 
 	feedback_add_details("admin_verb","RR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -112,12 +112,12 @@
 	set name = "Reload Admins"
 	set category = "Debug"
 
-	if(!check_rights(R_SERVER))	
+	if(!check_rights(R_SERVER))
 		return
 
 	message_admins("[key_name_admin(usr)] has manually reloaded admins")
 	log_admin("[key_name(usr)] has manually reloaded admins")
-	
+
 	load_admins()
 	feedback_add_details("admin_verb","RLDA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -126,14 +126,14 @@
 	set name = "Print Jobban Log"
 	set desc = "This spams all the active jobban entries for the current round to standard output."
 	set category = "Debug"
-	
+
 	if(!check_rights(R_DEBUG))
 		return
 
 	to_chat(usr, "<b>Jobbans active in this round.</b>")
 	for(var/t in jobban_keylist)
 		to_chat(usr, "[t]")
-		
+
 	message_admins("[key_name_admin(usr)] has printed the jobban log")
 	log_admin("[key_name(usr)] has printed the jobban log")
 
@@ -141,7 +141,7 @@
 	set name = "Search Jobban Log"
 	set desc = "This searches all the active jobban entries for the current round and outputs the results to standard output."
 	set category = "Debug"
-	
+
 	if(!check_rights(R_DEBUG))
 		return
 
@@ -153,6 +153,26 @@
 	for(var/t in jobban_keylist)
 		if(findtext(t, filter))
 			to_chat(usr, "[t]")
-			
+
 	message_admins("[key_name_admin(usr)] has searched the jobban log for [filter]")
 	log_admin("[key_name(usr)] has searched the jobban log for [filter]")
+
+/client/proc/vv_by_ref()
+	set name = "VV by Ref"
+	set desc = "Give this a ref string, and you will see its corresponding VV panel if it exists"
+	set category = "Debug"
+
+	// It's gated by "Debug Verbs", so might as well gate it to the debug permission
+	if(!check_rights(R_DEBUG))
+		return
+
+	var/refstring = input("Which reference?","Ref") as text|null
+	if(!refstring)
+		return
+
+	var/datum/D = locate(refstring)
+	if(!D)
+		to_chat(usr, "<span class='warning'>That ref string does not correspond to any datum.</span>")
+		return
+
+	debug_variables(D)

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -119,42 +119,6 @@ var/intercom_range_display_status = 0
 					qdel(F)
 	feedback_add_details("admin_verb","mIRD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-var/list/admin_verbs_show_debug_verbs = list(
-	/client/proc/camera_view,
-	/client/proc/sec_camera_report,
-	/client/proc/intercom_view,
-	/client/proc/Cell, //More air things
-	/client/proc/atmosscan, //check plumbing
-	/client/proc/powerdebug, //check power
-	/client/proc/count_objects_on_z_level,
-	/client/proc/count_objects_all,
-	/client/proc/cmd_assume_direct_control,
-	/client/proc/startSinglo,
-	/client/proc/ticklag,
-	/client/proc/cmd_admin_grantfullaccess,
-	/client/proc/cmd_admin_areatest,
-	/client/proc/cmd_admin_rejuvenate,
-	/datum/admins/proc/show_traitor_panel,
-	/client/proc/print_jobban_old,
-	/client/proc/print_jobban_old_filter,
-	/client/proc/forceEvent,
-	/client/proc/nanomapgen_DumpImage,
-	/client/proc/reload_nanoui_resources,
-	/client/proc/admin_redo_space_transitions,
-	/client/proc/make_turf_space_map
-)
-
-/client/proc/enable_debug_verbs()
-	set category = "Debug"
-	set name = "Debug verbs"
-
-	if(!check_rights(R_DEBUG))
-		return
-
-	verbs += admin_verbs_show_debug_verbs
-
-	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 /client/proc/count_objects_on_z_level()
 	set category = "Mapping"
 	set name = "Count Objects On Level"

--- a/code/modules/admin/verbs/toggledebugverbs.dm
+++ b/code/modules/admin/verbs/toggledebugverbs.dm
@@ -1,0 +1,37 @@
+var/list/admin_verbs_show_debug_verbs = list(
+	/client/proc/camera_view,
+	/client/proc/sec_camera_report,
+	/client/proc/intercom_view,
+	/client/proc/Cell, //More air things
+	/client/proc/atmosscan, //check plumbing
+	/client/proc/powerdebug, //check power
+	/client/proc/count_objects_on_z_level,
+	/client/proc/count_objects_all,
+	/client/proc/cmd_assume_direct_control,
+	/client/proc/startSinglo,
+	/client/proc/ticklag,
+	/client/proc/cmd_admin_grantfullaccess,
+	/client/proc/cmd_admin_areatest,
+	/client/proc/cmd_admin_rejuvenate,
+	/datum/admins/proc/show_traitor_panel,
+	/client/proc/print_jobban_old,
+	/client/proc/print_jobban_old_filter,
+	/client/proc/forceEvent,
+	/client/proc/nanomapgen_DumpImage,
+	/client/proc/reload_nanoui_resources,
+	/client/proc/admin_redo_space_transitions,
+	/client/proc/make_turf_space_map,
+	/client/proc/vv_by_ref
+)
+
+// Would be nice to make this a permanent admin pref so we don't need to click it each time
+/client/proc/enable_debug_verbs()
+	set category = "Debug"
+	set name = "Debug verbs"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	verbs += admin_verbs_show_debug_verbs
+
+	feedback_add_details("admin_verb","mDV") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/paradise.dme
+++ b/paradise.dme
@@ -1038,6 +1038,7 @@
 #include "code\modules\admin\verbs\striketeam.dm"
 #include "code\modules\admin\verbs\striketeam_syndicate.dm"
 #include "code\modules\admin\verbs\ticklag.dm"
+#include "code\modules\admin\verbs\toggledebugverbs.dm"
 #include "code\modules\admin\verbs\tripAI.dm"
 #include "code\modules\admin\verbs\vox_raiders.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"


### PR DESCRIPTION
VV now uses `list.Join("")` to form its html, making it much faster to open.
Also, a new admin verb has been added, under the debug verb list, to let admins VV by a ref string conveniently.

:cl: Crazylemon
rscadd: Admins can now VV by a ref string, directly via a verb
tweak: VV now builds its HTML using lists, making it much faster to open
/:cl: