### PR TITLE
Ghost Shuttle Control Fix

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -651,6 +651,8 @@
 				possible_destinations += "[possible_destinations ? ";" : ""][S.id]"
 
 /obj/machinery/computer/shuttle/attack_hand(mob/user)
+	if(!isliving(user))
+		return
 	if(..(user))
 		return
 	if(!shuttleId)


### PR DESCRIPTION
- Bluespace hardening prevents ghosts from controlling shuttle consoles

:cl:
tweak: Ghosts can no longer control shuttle computers
/:cl: