### PR TITLE
Appendicitis Fix

### DIFF
--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -6,6 +6,8 @@
 			continue
 		if(H.species.virus_immune) //don't count things that are virus immune; they'll just get picked and auto-cure
 			continue
+		if(!H.get_int_organ(/obj/item/organ/internal/appendix))
+			continue
 		var/foundAlready = 0	//don't infect someone that already has the virus
 		for(var/datum/disease/D in H.viruses)
 			foundAlready = 1


### PR DESCRIPTION
Fixes #5557.

I have no idea how to be ICly witty about this, so... mobs without appendixes can no longer contract appendicitis.

:cl:
bugfix: Mobs without appendixes can no longer contract appendicitis
/:cl: