### PR TITLE
Fixes Setting Status Display Alerts Through Communications Consoles

### DIFF
--- a/nano/templates/comm_console.tmpl
+++ b/nano/templates/comm_console.tmpl
@@ -87,7 +87,7 @@ Used In File(s): /code/game/machinery/computers/communications.dm
 		<h3>Alerts</h3>
 		{{for data.stat_display.alerts}}
 			<div class="line">
-				<div class="statusLabel">{{:helper.link(value.label,'alert',{'operation':'setstat','statdisp':'alert','exclamation-triangle':value.alert},null,(value.alert==data.stat_display.type?'linkOn':''))}}</div>
+				<div class="statusLabel">{{:helper.link(value.label,'exclamation-triangle',{'operation':'setstat','statdisp':'alert','alert':value.alert},null,(value.alert==data.stat_display.type?'linkOn':''))}}</div>
 			</div>
 		{{/for}}
 		<h3>Messages</h3>


### PR DESCRIPTION
Looks like this was broken by a find-replace gone wrong in #3230. Setting them through PDAs was also broken, but seems to have been quietly fixed by #3578.

:cl:
bugfix: Fixed setting status display alerts through communications consoles.
/:cl: