### PR TITLE
Holosign Movement Fix

### DIFF
--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/holosign.dmi'
 	icon_state = "sign_off"
 	layer = 4
+	anchored = 1
 	var/lit = 0
 	var/id = null
 	var/on_icon = "sign_on"


### PR DESCRIPTION
- Sanity Preservation Circuits prevent holographic signs from being carried around

:cl:
bugfix: Holosigns cannot be pulled around
/:cl: