### PR TITLE
Adds variants of 10mm ammunition.

### DIFF
--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -6,6 +6,8 @@
 			continue
 		if(H.species.virus_immune) //don't count things that are virus immune; they'll just get picked and auto-cure
 			continue
+		if(!H.get_int_organ(/obj/item/organ/internal/appendix))
+			continue
 		var/foundAlready = 0	//don't infect someone that already has the virus
 		for(var/datum/disease/D in H.viruses)
 			foundAlready = 1

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -16,7 +16,6 @@
 	local_transmit = 1
 	ventcrawler = 2
 	magpulse = 1
-	mob_size = MOB_SIZE_TINY
 
 	// We need to keep track of a few module items so we don't need to do list operations
 	// every time we need them. These get set in New() after the module is chosen.

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -27,6 +27,15 @@
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 
+/obj/item/ammo_casing/c10mm/silencer
+	projectile_type = /obj/item/projectile/bullet/midbullet3/silencer
+
+/obj/item/ammo_casing/c10mm/ap
+	projectile_type = /obj/item/projectile/bullet/midbullet3/armourpiercing
+
+/obj/item/ammo_casing/c10mm/fire
+	projectile_type = /obj/item/projectile/bullet/midbullet3/fire
+
 /obj/item/ammo_casing/c9mm
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -180,6 +180,22 @@
 	max_ammo = 8
 	multiple_sprites = 2
 
+/obj/item/ammo_box/magazine/m10mm/fire
+	name = "pistol magazine (10mm incendiary)"
+	desc = "A gun magazine. Loaded with rounds which ignite the target."
+	ammo_type = /obj/item/ammo_casing/c10mm/fire
+
+/obj/item/ammo_box/magazine/m10mm/silencer
+	name = "pistol magazine (10mm silencer)"
+	desc= "A gun magazine. Loaded with rounds which silence the target for a brief duration."
+	ammo_type = /obj/item/ammo_casing/c10mm/silencer
+
+
+/obj/item/ammo_box/magazine/m10mm/AP
+	name = "pistol magazine (10mm AP)"
+	desc= "A gun magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets"
+	ammo_type = /obj/item/ammo_casing/c10mm/ap
+
 /obj/item/ammo_box/magazine/m10mm/empty		//for maint drops
 	desc = "A gun magazine. Seems to be broken and can only hold one bullet. Pretty useless."
 	max_ammo = 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -112,6 +112,21 @@
 /obj/item/projectile/bullet/midbullet3
 	damage = 30
 
+/obj/item/projectile/bullet/midbullet3/silencer/on_hit(atom/target, blocked = 0)
+	if(..(target, blocked))
+		var/mob/living/M = target
+		M.silent += 3
+
+/obj/item/projectile/bullet/midbullet3/armourpiercing
+	damage = 27
+	armour_penetration = 40
+
+/obj/item/projectile/bullet/midbullet3/fire/on_hit(atom/target, blocked = 0)
+	if(..(target, blocked))
+		var/mob/living/M = target
+		M.adjust_fire_stacks(1)
+		M.IgniteMob()
+
 /obj/item/projectile/bullet/heavybullet
 	damage = 35
 

--- a/html/changelogs/AutoChangeLog-pr-5560.yml
+++ b/html/changelogs/AutoChangeLog-pr-5560.yml
@@ -1,0 +1,4 @@
+author: Fox McCloud
+delete-after: True
+changes: 
+  - bugfix: "Fixes drones not being able to bump open doors"

--- a/html/changelogs/AutoChangeLog-pr-5564.yml
+++ b/html/changelogs/AutoChangeLog-pr-5564.yml
@@ -1,0 +1,4 @@
+author: TullyBurnalot
+delete-after: True
+changes: 
+  - bugfix: "Mobs without appendixes can no longer contract appendicitis"

--- a/html/changelogs/AutoChangeLog-pr-5565.yml
+++ b/html/changelogs/AutoChangeLog-pr-5565.yml
@@ -1,0 +1,4 @@
+author: Krausus
+delete-after: True
+changes: 
+  - bugfix: "Fixed setting status display alerts through communications consoles."

--- a/nano/templates/comm_console.tmpl
+++ b/nano/templates/comm_console.tmpl
@@ -87,7 +87,7 @@ Used In File(s): /code/game/machinery/computers/communications.dm
 		<h3>Alerts</h3>
 		{{for data.stat_display.alerts}}
 			<div class="line">
-				<div class="statusLabel">{{:helper.link(value.label,'alert',{'operation':'setstat','statdisp':'alert','exclamation-triangle':value.alert},null,(value.alert==data.stat_display.type?'linkOn':''))}}</div>
+				<div class="statusLabel">{{:helper.link(value.label,'exclamation-triangle',{'operation':'setstat','statdisp':'alert','alert':value.alert},null,(value.alert==data.stat_display.type?'linkOn':''))}}</div>
 			</div>
 		{{/for}}
 		<h3>Messages</h3>


### PR DESCRIPTION
Adds three new types of 10mm ammunition and the relevant magazines. Currently unavailable outside of being spawned by admins.

Incendiary-Ignites the target. The fire can be easily rolled off, so this mostly functions as a diversion tactic in fights rather than significantly increasing the stetchkin's damage output.
AP- Ignores a portion of the target's armor, but does slightly reduced base damage. Gives an edge against security whilst marginally reducing effectiveness against squishy targets. (This one's probably on the weak side right now).
Silencer- Extremely briefly silences the target, allowing for repeated shots to keep them from speaking. Allows for stetchkin users to eliminate a target without fear of them calling out for help provided they can maintain their fire.

:cl: Coldflame
rscadd: Adds three new variants of 10mm ammunition, AP, Silencer, and Incendiary. Currently admin-only.
/:cl: