### PR TITLE
add_logs() Un-fuckery

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -161,7 +161,7 @@ Proc for attack log creation, because really why not
 6 is whether the attack should be logged to the log file and shown to admins
 */
 
-proc/add_logs(mob/target, mob/user, what_done, var/object=null, var/addition=null, var/admin=1) //Victim : Attacker : what they did : what they did it with : extra notes
+proc/add_logs(mob/user, mob/target, what_done, var/object=null, var/addition=null, var/admin=1) //Victim : Attacker : what they did : what they did it with : extra notes
 	var/list/ignore=list("shaked","CPRed","grabbed","punched")
 	if(!user)
 		return
@@ -301,7 +301,7 @@ proc/add_logs(mob/target, mob/user, what_done, var/object=null, var/addition=nul
 		var/mob/living/L = M
 		var/status
 		switch(M.stat)
-			if(CONSCIOUS) 
+			if(CONSCIOUS)
 				status = "Alive"
 			if(UNCONSCIOUS)
 				status = "<font color='orange'><b>Unconscious</b></font>"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -58,14 +58,15 @@
 				return 1
 
 	if(istype(M,/mob/living/carbon/brain))
-		messagesource = M:container
+		var/mob/living/carbon/brain/B = M
+		messagesource = B.container
 	if(hitsound && force > 0)
 		playsound(loc, hitsound, 50, 1, -1)
 	/////////////////////////
 	user.lastattacked = M
 	M.lastattacker = user
 
-	add_logs(M, user, "attacked", src.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+	add_logs(user, M, "attacked", name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])")
 
 	if(!iscarbon(user))
 		M.LAssailant = null

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -71,7 +71,7 @@
 								var/obj/item/brain/B = new /obj/item/brain(user.loc)
 								B.transfer_identity(C)
 								C.death()
-								add_logs(C, user, "magically debrained", addition="INTENT: [uppertext(user.a_intent)]")*/
+								add_logs(user, C, "magically debrained", addition="INTENT: [uppertext(user.a_intent)]")*/
 						if(C.stomach_contents && item_to_retrive in C.stomach_contents)
 							C.stomach_contents -= item_to_retrive
 

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -57,7 +57,7 @@
 	to_chat(user, "<span class='notice'>We stealthily sting [target.name].</span>")
 	if(target.mind && target.mind.changeling)
 		to_chat(target, "<span class='warning'>You feel a tiny prick.</span>")
-		add_logs(target, user, "unsuccessfully stung")
+		add_logs(user, target, "unsuccessfully stung")
 	return 1
 
 
@@ -102,7 +102,7 @@
 	return 1
 
 /obj/effect/proc_holder/changeling/sting/transformation/sting_action(var/mob/user, var/mob/target)
-	add_logs(target, user, "stung", object="transformation sting", addition=" new identity is [selected_dna.real_name]")
+	add_logs(user, target, "stung", object="transformation sting", addition=" new identity is [selected_dna.real_name]")
 	var/datum/dna/NewDNA = selected_dna
 	if(issmall(target))
 		to_chat(user, "<span class='notice'>Our genes cry out as we sting [target.name]!</span>")
@@ -137,7 +137,7 @@ obj/effect/proc_holder/changeling/sting/extract_dna
 		return user.mind.changeling.can_absorb_dna(user, target)
 
 /obj/effect/proc_holder/changeling/sting/extract_dna/sting_action(var/mob/user, var/mob/living/carbon/human/target)
-	add_logs(target, user, "stung", object="extraction sting")
+	add_logs(user, target, "stung", object="extraction sting")
 	if(!(user.mind.changeling.has_dna(target.dna)))
 		user.mind.changeling.absorb_dna(target, user)
 	feedback_add_details("changeling_powers","ED")
@@ -152,7 +152,7 @@ obj/effect/proc_holder/changeling/sting/mute
 	dna_cost = 2
 
 /obj/effect/proc_holder/changeling/sting/mute/sting_action(var/mob/user, var/mob/living/carbon/target)
-	add_logs(target, user, "stung", object="mute sting")
+	add_logs(user, target, "stung", object="mute sting")
 	target.silent += 30
 	feedback_add_details("changeling_powers","MS")
 	return 1
@@ -166,7 +166,7 @@ obj/effect/proc_holder/changeling/sting/blind
 	dna_cost = 1
 
 /obj/effect/proc_holder/changeling/sting/blind/sting_action(var/mob/user, var/mob/target)
-	add_logs(target, user, "stung", object="blind sting")
+	add_logs(user, target, "stung", object="blind sting")
 	to_chat(target, "<span class='danger'>Your eyes burn horrifically!</span>")
 	target.disabilities |= NEARSIGHTED
 	target.eye_blind = 20
@@ -183,7 +183,7 @@ obj/effect/proc_holder/changeling/sting/LSD
 	dna_cost = 1
 
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(var/mob/user, var/mob/living/carbon/target)
-	add_logs(target, user, "stung", object="LSD sting")
+	add_logs(user, target, "stung", object="LSD sting")
 	spawn(rand(300,600))
 		if(target)
 			target.hallucination = max(400, target.hallucination)
@@ -199,10 +199,9 @@ obj/effect/proc_holder/changeling/sting/cryo //Enable when mob cooling is fixed 
 	dna_cost = 2
 
 /obj/effect/proc_holder/changeling/sting/cryo/sting_action(var/mob/user, var/mob/target)
-	add_logs(target, user, "stung", object="cryo sting")
+	add_logs(user, target, "stung", object="cryo sting")
 	if(target.reagents)
 		target.reagents.add_reagent("frostoil", 30)
 		target.reagents.add_reagent("ice", 30)
 	feedback_add_details("changeling_powers","CS")
 	return 1
-

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -351,7 +351,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 				var/holy2unholy = M.reagents.get_reagent_amount("holywater")
 				M.reagents.del_reagent("holywater")
 				M.reagents.add_reagent("unholywater",holy2unholy)
-				add_logs(M, user, "smacked", src, " removing the holy water from them")
+				add_logs(user, M, "smacked", src, " removing the holy water from them")
 			return
 		M.take_organ_damage(0,rand(5,20)) //really lucky - 5 hits for a crit
 		for(var/mob/O in viewers(M, null))

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -455,7 +455,7 @@ Congratulations! You are now trained for xenobiology research!"}
 		var/mob/living/carbon/human/H = L
 		H.forcesay(hit_appends)
 
-	add_logs(L, user, "stunned")
+	add_logs(user, L, "stunned")
 	return
 
 /obj/item/weapon/abductor_baton/proc/SleepAttack(mob/living/L,mob/living/user)
@@ -464,7 +464,7 @@ Congratulations! You are now trained for xenobiology research!"}
 							"<span class='userdanger'>You suddenly feel very drowsy!</span>")
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 		L.Sleeping(60)
-		add_logs(L, user, "put to sleep")
+		add_logs(user, L, "put to sleep")
 	else
 		L.drowsyness += 1
 		to_chat(user, "<span class='warning'>Sleep inducement works fully only on stunned specimens! </span>")
@@ -485,7 +485,7 @@ Congratulations! You are now trained for xenobiology research!"}
 				C.handcuffed = new /obj/item/weapon/restraints/handcuffs/energy/used(C)
 				C.update_handcuffed()
 				to_chat(user, "<span class='notice'>You handcuff [C].</span>")
-				add_logs(C, user, "handcuffed")
+				add_logs(user, C, "handcuffed")
 		else
 			to_chat(user, "<span class='warning'>You fail to handcuff [C].</span>")
 	return

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -105,11 +105,11 @@
 
 		if(drownee.stat) //Mob is in critical.
 			drownee.losebreath -= 3		//You're gonna die here.
-			add_logs(drownee, src, "drowned", null, null, 0)	//log it to their VV, but don't spam the admins' chats with the logs
+			add_logs(src, drownee, "drowned", null, null, 0)	//log it to their VV, but don't spam the admins' chats with the logs
 			drownee.visible_message("<span class='danger'>\The [drownee] appears to be drowning!</span>","<span class='userdanger'>You're quickly drowning!</span>") //inform them that they are fucked.
 		else
 			drownee.losebreath -= 2		//For every time you drown, you miss 2 breath attempts. Hope you catch on quick!
-			add_logs(drownee, src, "drowned", null, null, 0)	//log it to their VV, but don't spam the admins' chats with the logs
+			add_logs(src, drownee, "drowned", null, null, 0)	//log it to their VV, but don't spam the admins' chats with the logs
 			if(prob(35)) //35% chance to tell them what is going on. They should probably figure it out before then.
 				drownee.visible_message("<span class='danger'>\The [drownee] flails, almost like they are drowning!</span>","<span class='userdanger'>You're lacking air!</span>") //*gasp* *gasp* *gasp* *gasp* *gasp*
 

--- a/code/game/machinery/turrets.dm
+++ b/code/game/machinery/turrets.dm
@@ -329,7 +329,7 @@
 	if(M.melee_damage_upper == 0)	return
 	if(!(stat & BROKEN))
 		visible_message("<span class='userdanger'>[M] [M.attacktext] [src]!</span>")
-		add_logs(M, src, "attacked", admin=0)
+		add_logs(src, M, "attacked", admin=0)
 		//src.attack_log += text("\[[time_stamp()]\] <font color='orange'>was attacked by [M.name] ([M.ckey])</font>")
 		src.health -= M.melee_damage_upper
 		if(src.health <= 0)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -460,7 +460,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 			"<span class='userdanger'>You stab yourself in the eyes with [src]!</span>" \
 		)
 
-	add_logs(M, user, "attacked", "[src.name]", "(INTENT: [uppertext(user.a_intent)])")
+	add_logs(user, M, "attacked", "[name]", "(INTENT: [uppertext(user.a_intent)])")
 
 	if(istype(H))
 		var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -17,7 +17,7 @@
 	var/mob/living/silicon/ai/AI = locate(/mob/living/silicon/ai) in src
 	if(AI) //AI is on the card, implies user wants to upload it.
 		target.transfer_ai(AI_TRANS_FROM_CARD, user, AI, src)
-		add_logs(AI,user, "carded", object="[name]")
+		add_logs(user, AI, "carded", object="[name]")
 	else //No AI on the card, therefore the user wants to download one.
 		target.transfer_ai(AI_TRANS_TO_CARD, user, null, src)
 	update_state() //Whatever happened, update the card's state (icon, name) to match.

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -76,7 +76,7 @@
 
 
 /obj/item/device/flash/proc/flash_carbon(var/mob/living/carbon/M, var/mob/user = null, var/power = 5, targeted = 1)
-	add_logs(M, user, "flashed", object="[src.name]")
+	add_logs(user, M, "flashed", object="[src.name]")
 	if(user && targeted)
 		if(M.weakeyes)
 			M.Weaken(3) //quick weaken bypasses eye protection but has no eye flash
@@ -116,10 +116,10 @@
 			if(R.module) // Perhaps they didn't choose a module yet
 				for(var/obj/item/borg/combat/shield/S in R.module.modules)
 					if(R.activated(S))
-						add_logs(M, user, "flashed", object="[src.name]")
+						add_logs(user, M, "flashed", object="[src.name]")
 						user.visible_message("<span class='disarm'>[user] tries to overloads [M]'s sensors with the [src.name], but if blocked by [M]'s shield!</span>", "<span class='danger'>You try to overload [M]'s sensors with the [src.name], but are blocked by his shield!</span>")
 						return 1
-		add_logs(M, user, "flashed", object="[src.name]")
+		add_logs(user, M, "flashed", object="[src.name]")
 		if(M.flash_eyes(affect_silicon = 1))
 			M.Weaken(rand(5,10))
 			user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the [src.name]!</span>", "<span class='danger'>You overload [M]'s sensors with the [src.name]!</span>")

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -276,8 +276,8 @@ obj/item/device/flashlight/lamp/bananalamp
 											"<span class='userdanger'>[user] blinks \the [src] at \the [A].")
 		if(ismob(A))
 			var/mob/M = A
-			add_logs(M, user, "attacked", object="EMP-light")
-		to_chat(user, "\The [src] now has [emp_cur_charges] charge\s.")
+			add_logs(user, M, "attacked", object="EMP-light")
+		to_chat(user, "[src] now has [emp_cur_charges] charge\s.")
 		A.emp_act(1)
 	else
 		to_chat(user, "<span class='warning'>\The [src] needs time to recharge!</span>")

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -102,7 +102,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(user.zone_sel.selecting == "eyes")
-			add_logs(C, user, "shone in the eyes", object="laser pointer")
+			add_logs(user, C, "shone in the eyes", object="laser pointer")
 
 			var/severity = 1
 			if(prob(33))

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -47,7 +47,7 @@ effective or pretty fucking useless.
 	for(var/mob/living/carbon/human/M in oview(7, user))
 		if(prob(50))
 			M.Weaken(rand(4,7))
-			add_logs(M, user, "stunned", src)
+			add_logs(user, M, "stunned", src)
 			to_chat(M, "<span class='danger'>You feel a tremendous, paralyzing wave flood your mind.</span>")
 		else
 			to_chat(M, "<span class='danger'>You feel a sudden, electric jolt travel through your head.</span>")
@@ -90,7 +90,7 @@ effective or pretty fucking useless.
 
 /obj/item/device/rad_laser/attack(mob/living/M, mob/living/user)
 	if(!used)
-		add_logs(M, user, "irradiated", src)
+		add_logs(user, M, "irradiated", src)
 		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>")
 		var/cooldown = round(max(100,(((intensity*8)-(wavelength/2))+(intensity*2))*10))
 		used = 1

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -28,7 +28,7 @@
 
 	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
-	add_logs(M, user, "stunned", src, "(INTENT: [uppertext(user.a_intent)])")
+	add_logs(user, M, "stunned", src, "(INTENT: [uppertext(user.a_intent)])")
 
 /obj/item/borg/overdrive
 	name = "Overdrive"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -334,7 +334,7 @@
 			H.emote("gasp")
 			if(!H.heart_attack && (prob(10) || defib.combat)) // Your heart explodes.
 				H.heart_attack = 1
-			add_logs(M, user, "stunned", object="defibrillator")
+			add_logs(user, M, "stunned", object="defibrillator")
 			defib.deductcharge(revivecost)
 			cooldown = 1
 			busy = 0
@@ -413,7 +413,7 @@
 							if(tplus > tloss)
 								H.setBrainLoss( max(0, min(99, ((tlimit - tplus) / tlimit * 100))))
 							defib.deductcharge(revivecost)
-							add_logs(M, user, "revived", object="defibrillator")
+							add_logs(user, M, "revived", object="defibrillator")
 						else
 							if(tplus > tlimit|| !H.get_int_organ(/obj/item/organ/internal/heart))
 								user.visible_message("<span class='boldnotice'>[defib] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")
@@ -477,7 +477,7 @@
 				H.heart_attack = 1
 			playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
 			H.emote("gasp")
-			add_logs(M, user, "stunned", object="defibrillator")
+			add_logs(user, M, "stunned", object="defibrillator")
 			if(isrobot(user))
 				var/mob/living/silicon/robot/R = user
 				R.cell.use(revivecost)
@@ -534,7 +534,7 @@
 							if(isrobot(user))
 								var/mob/living/silicon/robot/R = user
 								R.cell.use(revivecost)
-							add_logs(M, user, "revived", object="defibrillator")
+							add_logs(user, M, "revived", object="defibrillator")
 						else
 							if(tplus > tlimit)
 								user.visible_message("<span class='warning'>[user] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return for defibrillation.</span>")

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -71,7 +71,7 @@
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)
 			var/turflist = getline(user, target_turf)
-			add_logs(target, user, "flamethrowered", addition="at [target.x],[target.y],[target.z]")
+			add_logs(user, target, "flamethrowered", addition="at [target.x],[target.y],[target.z]")
 			flame_turf(turflist)
 
 /obj/item/weapon/flamethrower/attackby(obj/item/W as obj, mob/user as mob, params)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -46,7 +46,7 @@
 			else
 				feedback_add_details("handcuffs","H")
 
-			add_logs(C, user, "handcuffed", src)
+			add_logs(user, C, "handcuffed", src)
 		else
 			to_chat(user, "<span class='warning'>You fail to handcuff [C].</span>")
 
@@ -154,7 +154,7 @@
 					C.handcuffed = new /obj/item/weapon/restraints/handcuffs/cable/zipties/used(C)
 					C.update_handcuffed()
 					to_chat(user, "<span class='notice'>You handcuff [C].</span>")
-					add_logs(C, user, "ziptie-cuffed")
+					add_logs(user, C, "ziptie-cuffed")
 			else
 				to_chat(user, "<span class='warning'>You fail to handcuff [C].</span>")
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -53,7 +53,7 @@
 		H.sec_hud_set_implants()
 
 	if(user)
-		add_logs(source, user, "implanted", object="[name]")
+		add_logs(user, source, "implanted", object="[name]")
 
 	return 1
 

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -118,7 +118,7 @@
 	if(!discharge)
 		user.visible_message("<span class='danger'>[user] fires \the [src]!</span>", \
 				    		 "<span class='danger'>You fire \the [src]!</span>")
-	add_logs(target, user, "fired at", src)
+	add_logs(user, target, "fired at", src)
 	playsound(src.loc, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
 	for(var/obj/item/ITD in loadedItems) //Item To Discharge
 		spawn(0)

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -95,6 +95,6 @@
 	spawn(0)
 		target.throw_at(throw_target, 5 * fisto_setting, 0.2)
 
-	add_logs(target, user, "power fisted", src)
+	add_logs(user, target, "power fisted", src)
 
 	user.changeNext_move(CLICK_CD_MELEE * click_delay)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -166,7 +166,7 @@
 		var/mob/living/carbon/human/H = L
 		H.forcesay(hit_appends)
 
-	add_logs(L, user, "stunned", object="stunbaton")
+	add_logs(user, L, "stunned", object="stunbaton")
 
 /obj/item/weapon/melee/baton/emp_act(severity)
 	if(bcell)

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -57,7 +57,7 @@
 						return 0
 				playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
 				target.Weaken(3)
-				add_logs(target, user, "stunned", object="[src]")
+				add_logs(user, target, "stunned", object="[src]")
 				src.add_fingerprint(user)
 				target.visible_message("<span class ='danger'>[user] has knocked down [target] with \the [src]!</span>", \
 					"<span class ='userdanger'>[user] has knocked down [target] with \the [src]!</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -211,7 +211,7 @@
 		G.affecting.Weaken(2)
 		G.affecting.visible_message("<span class='danger'>[G.assailant] pushes [G.affecting] onto [src].</span>", \
 									"<span class='userdanger'>[G.assailant] pushes [G.affecting] onto [src].</span>")
-		add_logs(G.affecting, G.assailant, "pushed onto a table")
+		add_logs(G.assailant, G.affecting, "pushed onto a table")
 		qdel(I)
 		return 1
 	qdel(I)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -106,7 +106,7 @@
 				"<span class='userdanger'>[target] hits \himself with a bottle of [src.name][head_attack_message]!</span>")
 
 	//Attack logs
-	add_logs(target, user, "attacked", src)
+	add_logs(user, target, "attacked", src)
 
 	//The reagents in the bottle splash all over the target, thanks for the idea Nodrak
 	SplashReagents(target)

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -47,7 +47,7 @@
 		if(!reagents || !reagents.total_volume)
 			return // The condiment might be empty after the delay.
 		user.visible_message("<span class='warning'>[user] feeds [M] from [src].</span>")
-		add_logs(M, user, "fed", reagentlist(src))
+		add_logs(user, M, "fed", reagentlist(src))
 
 	var/fraction = min(10/reagents.total_volume, 1)
 	reagents.reaction(M, INGEST, fraction)

--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -96,7 +96,7 @@
 /obj/item/weapon/grown/nettle/death/afterattack(mob/living/carbon/M, mob/user)
 	if(istype(M, /mob/living))
 		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of the Deathnettle!</span>")
-		add_logs(M, user, "attacked", src)
+		add_logs(user, M, "attacked", src)
 
 		M.eye_blurry += force/7
 		if(prob(20))

--- a/code/modules/martial_arts/brawling.dm
+++ b/code/modules/martial_arts/brawling.dm
@@ -19,7 +19,7 @@
 	if(!damage)
 		playsound(D.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 		D.visible_message("<span class='warning'>[A] has attempted to hit [D] with a [atk_verb]!</span>")
-		add_logs(D, A, "attempted to hit", atk_verb)
+		add_logs(A, D, "attempted to hit", atk_verb)
 		return 0
 
 
@@ -32,7 +32,7 @@
 								"<span class='userdanger'>[A] has hit [D] with a [atk_verb]!</span>")
 
 	D.apply_damage(damage, STAMINA, affecting, armor_block)
-	add_logs(D, A, "punched")
+	add_logs(A, D, "punched")
 	if(D.getStaminaLoss() > 50)
 		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
 		if((D.stat != DEAD) && prob(knockout_prob))
@@ -61,7 +61,7 @@
 	return 1
 
 /datum/martial_art/drunk_brawling/harm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	add_logs(D, A, "punched")
+	add_logs(A, D, "punched")
 	A.do_attack_animation(D)
 
 	var/atk_verb = pick("jab","uppercut","overhand punch","drunken right hook","drunken left hook")

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -53,7 +53,7 @@
 
 	D.apply_damage(damage, BRUTE, affecting, armor_block)
 
-	add_logs(D, A, "punched")
+	add_logs(A, D, "punched")
 
 	if((D.stat != DEAD) && damage >= A.species.punchstunthreshold)
 		D.visible_message("<span class='danger'>[A] has weakened [D]!!</span>", \

--- a/code/modules/martial_arts/mimejutsu.dm
+++ b/code/modules/martial_arts/mimejutsu.dm
@@ -38,7 +38,7 @@
 		playsound(get_turf(A), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 		D.apply_damage(damage, STAMINA, affecting, armor_block)
-		add_logs(D, A, "mimechucked")
+		add_logs(A, D, "mimechucked")
 
 		return 1
 	return basic_hit(A,D)
@@ -116,4 +116,3 @@
 	to_chat(usr, "<span class='notice'>Mimechucks</span>: Disarm Harm. Hits the opponent with invisible nunchucks.")
 	to_chat(usr, "<span class='notice'>Smokebomb</span>: Disarm Disarm. Drops a mime smokebomb.")
 	to_chat(usr, "<span class='notice'>Silent Palm</span>: Grab Disarm. Using mime energy throw someone back.")
-

--- a/code/modules/martial_arts/wrestleing.dm
+++ b/code/modules/martial_arts/wrestleing.dm
@@ -28,7 +28,7 @@
 	var/armor_block = D.run_armor_check(null, "melee")
 	D.apply_damage(30, BRUTE, null, armor_block)
 	D.apply_effect(6, WEAKEN, armor_block)
-	add_logs(D, A, "suplexed")
+	add_logs(A, D, "suplexed")
 
 	A.SpinAnimation(10,1)
 

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -653,7 +653,7 @@
 			playsound(src,'sound/weapons/resonator_blast.ogg',50,1)
 			if(creator)
 				for(var/mob/living/L in src.loc)
-					add_logs(L, creator, "used a resonator field on", object="resonator")
+					add_logs(creator, L, "used a resonator field on", object="resonator")
 					to_chat(L, "<span class='danger'>The [src.name] ruptured with you in it!</span>")
 					L.adjustBruteLoss(resonance_damage)
 			else

--- a/code/modules/mob/living/carbon/alien/alien_defenses.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defenses.dm
@@ -35,7 +35,7 @@ In all, this is a lot like the monkey code. /N
 				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
 						"<span class='userdanger'>[M.name] bites [src]!</span>")
 				adjustBruteLoss(damage)
-				add_logs(src, M, "attacked", admin=0)
+				add_logs(M, src, "attacked", admin=0)
 				updatehealth()
 			else
 				to_chat(M, "<span class='warning'>[name] is too injured for that.</span>")

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -116,7 +116,7 @@
 				"<span class='userdanger'>[M] [M.attacktext] [src]!</span>")
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
 		adjustBruteLoss(damage)
-		add_logs(src, M, "attacked", admin=0)
+		add_logs(M, src, "attacked", admin=0)
 		updatehealth()
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -541,7 +541,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 				var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
 				var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"
 
-				add_logs(throwable_mob, src, "thrown", addition="from [start_T_descriptor] with the target [end_T_descriptor]")
+				add_logs(src, throwable_mob, "thrown", addition="from [start_T_descriptor] with the target [end_T_descriptor]")
 
 	else if(!(I.flags & ABSTRACT)) //can't throw abstract items
 		thrown_thing = I

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -410,7 +410,7 @@
 		M.do_attack_animation(src)
 		visible_message("<span class='danger'>[M] [M.attacktext] [src]!</span>", \
 						"<span class='userdanger'>[M] [M.attacktext] [src]!</span>")
-		add_logs(src, M, "attacked")
+		add_logs(M, src, "attacked")
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
 		if(check_shields(damage, "the [M.name]", null, MELEE_ATTACK, M.armour_penetration))
 			return 0

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -19,7 +19,7 @@
 	..()
 
 	if((M != src) && M.a_intent != "help" && check_shields(0, M.name, attack_type = UNARMED_ATTACK))
-		add_logs(src, M, "attempted to touch")
+		add_logs(M, src, "attempted to touch")
 		visible_message("<span class='warning'>[M] attempted to touch [src]!</span>")
 		return 0
 
@@ -63,11 +63,11 @@
 							if(S.next_step(M, src))
 								return 1
 						help_shake_act(M)
-						add_logs(src, M, "shaked")
+						add_logs(M, src, "shaked")
 						return 1
 			if(health >= config.health_threshold_crit)
 				help_shake_act(M)
-				add_logs(src, M, "shaked")
+				add_logs(M, src, "shaked")
 				return 1
 			if(!H.check_has_mouth())
 				to_chat(H, "<span class='danger'>You don't have a mouth, you cannot perform CPR!</span>")
@@ -94,7 +94,7 @@
 
 					to_chat(src, "<span class='notice'>You feel a breath of fresh air enter your lungs. It feels good.</span>")
 					to_chat(M, "<span class='alert'>Repeat at least every 7 seconds.")
-					add_logs(src, M, "CPRed")
+					add_logs(M, src, "CPRed")
 					return 1
 			else
 				to_chat(M, "<span class='danger'>You need to stay still while performing CPR!</span>")
@@ -123,7 +123,7 @@
 					return
 				//we're good to suck the blood, blaah
 				M.mind.vampire.handle_bloodsucking(src)
-				add_logs(src, M, "vampirebit")
+				add_logs(M, src, "vampirebit")
 				msg_admin_attack("[key_name_admin(M)] vampirebit [key_name_admin(src)]")
 				return
 				//end vampire codes
@@ -133,7 +133,7 @@
 				var/datum/unarmed_attack/attack = M.species.unarmed
 
 				M.do_attack_animation(src)
-				add_logs(src, M, "[pick(attack.attack_verb)]ed")
+				add_logs(M, src, "[pick(attack.attack_verb)]ed")
 
 				if(!iscarbon(M))
 					LAssailant = null
@@ -172,7 +172,7 @@
 			if(attacker_style && attacker_style.disarm_act(H, src))
 				return 1
 			else
-				add_logs(src, M, "disarmed")
+				add_logs(M, src, "disarmed")
 
 				if(w_uniform)
 					w_uniform.add_fingerprint(M)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -651,7 +651,7 @@
 			who.unEquip(what)
 			if(silent)
 				put_in_hands(what)
-			add_logs(who, src, "stripped", addition="of [what]")
+			add_logs(src, who, "stripped", addition="of [what]")
 
 // The src mob is trying to place an item on someone
 // Override if a certain mob should be behave differently when placing items (can't, for example)
@@ -670,7 +670,7 @@
 			if(what && Adjacent(who))
 				unEquip(what)
 				who.equip_to_slot_if_possible(what, where, 0, 1)
-				add_logs(who, src, "equipped", what)
+				add_logs(src, who, "equipped", what)
 
 
 /mob/living/singularity_act()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -235,7 +235,7 @@
 			to_chat(user, "<span class='notice'>You already grabbed [src].</span>")
 			return
 
-	add_logs(src, user, "grabbed", addition="passively")
+	add_logs(user, src, "grabbed", addition="passively")
 
 	var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(user, src)
 	if(buckled)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -548,7 +548,7 @@ Auto Patrol[]"},
 		C.Weaken(5)
 		C.stuttering = 5
 		C.Stun(5)
-	add_logs(src,C,"stunned")
+	add_logs(src, C, "stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -251,7 +251,7 @@ Auto Patrol: []"},
 		C.Weaken(5)
 		C.stuttering = 5
 		C.Stun(5)
-	add_logs(src,C,"stunned")
+	add_logs(src, C, "stunned")
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -114,7 +114,7 @@
 //			to_chat(M, "<span class='danger'>You feel a tiny prick!</span>")
 			. = 1
 
-		add_logs(M, user, "stabbed", object="[name]")
+		add_logs(user, M, "stabbed", object="[name]")
 
 	else
 		. = ..()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -87,7 +87,7 @@
 		for(var/datum/reagent/R in reagents.reagent_list)
 			reagent_note += R.id + " ("
 			reagent_note += num2text(R.volume) + ") "
-	add_logs(L, firer, "shot", src, reagent_note)
+	add_logs(firer, L, "shot", src, reagent_note)
 	return L.apply_effects(stun, weaken, paralyze, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
 
 /obj/item/projectile/proc/vol_by_damage()

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -639,7 +639,7 @@
 					M.adjustFireLoss(rand(0,15))
 					M.update_revive()
 					M.stat = UNCONSCIOUS
-					add_logs(M, M, "revived", object="strange reagent")
+					add_logs(M, M, "revived", object="strange reagent") //Yes, the logs say you revived yourself.
 	..()
 
 /datum/reagent/strange_reagent/on_mob_life(mob/living/M)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -37,7 +37,7 @@
 
 			var/contained = english_list(injected)
 
-			add_logs(M, user, "injected", src, "([contained])")
+			add_logs(user, M, "injected", src, "([contained])")
 
 /obj/item/weapon/reagent_containers/hypospray/CMO
 	list_reagents = list("omnizine" = 30)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -384,7 +384,7 @@
 	G.change_gender(pick(MALE,FEMALE))
 	G.loc = src.loc
 	G.key = ghost.key
-	add_logs(G, user, "summoned", null, "as a golem")
+	add_logs(user, G, "summoned", null, "as a golem")
 	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost.")
 	qdel(src)
 

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -243,7 +243,7 @@
 	user.visible_message("<span class='notice'> [user] amputates [target]'s [affected.name] at the [affected.amputation_point] with \the [tool].</span>", \
 	"<span class='notice'> You amputate [target]'s [affected.name] with \the [tool].</span>")
 
-	add_logs(target,user ,"surgically removed [affected.name] from", addition="INTENT: [uppertext(user.a_intent)]")//log it
+	add_logs(user, target, "surgically removed [affected.name] from", addition="INTENT: [uppertext(user.a_intent)]")//log it
 
 	var/atom/movable/thing = affected.droplimb(1,DROPLIMB_EDGE)
 	if(istype(thing,/obj/item))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -240,7 +240,7 @@
 			user.visible_message("<span class='notice'> [user] has separated and extracts [target]'s [I] with \the [tool].</span>" , \
 			"<span class='notice'> You have separated and extracted [target]'s [I] with \the [tool].</span>")
 
-			add_logs(target,user, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
+			add_logs(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			spread_germs_to_organ(I, user)
 			I.status |= ORGAN_CUT_AWAY
 			var/obj/item/thing = I.remove(target)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -453,7 +453,7 @@
 			user.visible_message("<span class='notice'> [user] has decoupled [target]'s [I] with \the [tool].</span>" , \
 		"<span class='notice'> You have decoupled [target]'s [I] with \the [tool].</span>")
 
-			add_logs(target,user, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
+			add_logs(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			spread_germs_to_organ(I, user)
 			I.status |= ORGAN_CUT_AWAY
 			var/obj/item/thing = I.remove(target)
@@ -530,7 +530,7 @@
 	"<span class='notice'> You have decoupled [target]'s [affected.name] with \the [tool].</span>")
 
 
-	add_logs(target,user ,"surgically removed [affected.name] from", addition="INTENT: [uppertext(user.a_intent)]")//log it
+	add_logs(user, target, "surgically removed [affected.name] from", addition="INTENT: [uppertext(user.a_intent)]")//log it
 
 	var/atom/movable/thing = affected.droplimb(1,DROPLIMB_EDGE)
 	if(istype(thing,/obj/item))


### PR DESCRIPTION
:cl:
fix: Fixes assorted things logging attacks incorrectly.
/:cl:

THE FIRST TWO ARGUMENTS OF THIS PROC WERE IN THE OPPOSITE ORDER OF LITERALLY EVERY SINGLE OTHER CODEBASE. AS A RESULT THERE WAS A LOT OF ANNOYING SHIT THAT WOULD BE LOGGED BACKWARDS BECAUSE CODERS WERE UNAWARE OF THIS FACT WHEN PORTING THINGS OVER. SERIOUSLY THIS WAS INCREDIBLY ANNOYING.

Fixes #5245