### PR TITLE
Removes Extraneous add_logs() Documentation

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -161,7 +161,7 @@ Proc for attack log creation, because really why not
 6 is whether the attack should be logged to the log file and shown to admins
 */
 
-proc/add_logs(mob/user, mob/target, what_done, var/object=null, var/addition=null, var/admin=1) //Victim : Attacker : what they did : what they did it with : extra notes
+proc/add_logs(mob/user, mob/target, what_done, var/object=null, var/addition=null, var/admin=1)
 	var/list/ignore=list("shaked","CPRed","grabbed","punched")
 	if(!user)
 		return


### PR DESCRIPTION
There were two sets of comments documenting add_logs(), one above the proc, and one on the same line as the proc. The former was incorrect prior to #5571, while the latter was correct; however #5571 swapped those, and there's no point in having the exact same thing be documented twice in the same place.