### PR TITLE
AI Spawning Fixes

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -232,9 +232,8 @@ var/round_start_time = 0
 
 	votetimer()
 
-	for(var/mob/M in mob_list)
-		if(istype(M,/mob/new_player))
-			var/mob/new_player/N = M
+	for(var/mob/new_player/N in mob_list)
+		if(N.client)
 			N.new_player_panel_proc()
 
 	return 1

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -61,6 +61,7 @@ var/global/list/empty_playable_ai_cores = list()
 				loc_landmark = sloc
 
 	forceMove(loc_landmark.loc)
+	view_core()
 
 // Before calling this, make sure an empty core exists, or this will no-op
 /mob/living/silicon/ai/proc/moveToEmptyCore()
@@ -73,6 +74,6 @@ var/global/list/empty_playable_ai_cores = list()
 	empty_playable_ai_cores -= C
 
 	forceMove(C.loc)
-
+	view_core()
 
 	qdel(C)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -37,7 +37,9 @@
 	O.add_ai_verbs()
 
 	O.rename_self("AI",1)
-	qdel(src)
+
+	spawn()
+		qdel(src)
 	return O
 
 /mob/living/carbon/human/make_into_mask(var/should_gib = 0)


### PR DESCRIPTION
- Late-joining AIs will no longer runtime before replacing the unused core they're meant to be in.
  - This was leaving the unused core, allowing further AIs to late-join... and moving none of them to the station. Whoops!
- Both roundstart and late-join AIs will have their cameras properly centered on their core after spawning.
- The new player panel will no longer attempt to be shown to the clientless `new_player` that exists after a round-start AI spawns.