### PR TITLE
Fixes several null `to_chat`s

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -200,7 +200,8 @@
 			f_name += "oil-stained [name][infix]."
 
 	to_chat(user, "[bicon(src)] That's [f_name] [suffix]")
-	to_chat(user, desc)
+	if(desc)
+		to_chat(user, desc)
 
 	if(reagents && is_open_container()) //is_open_container() isn't really the right proc for this, but w/e
 		to_chat(user, "It contains:")

--- a/code/modules/admin/admin_memo.dm
+++ b/code/modules/admin/admin_memo.dm
@@ -99,10 +99,10 @@
 				if(last_editor)
 					output += "<br><span class='memoedit'>Last edit by [last_editor] <A href='?_src_=holder;memoeditlist=[ckey]'>(Click here to see edit log)</A></span>"
 				output += "<br>[memotext]</span><br>"
-			if(!output && !silent)
+			if(output)
+				to_chat(src, output)
+			else if(!silent)
 				to_chat(src, "No memos found in database.")
-				return
-			to_chat(src, output)
 		if("Remove")
 			var/DBQuery/query_memodellist = dbcon.NewQuery("SELECT ckey FROM [format_table_name("memo")]")
 			if(!query_memodellist.Execute())

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -209,7 +209,7 @@
 	power_supply.give(5000)
 	if(!suppressed)
 		playsound(loc, 'sound/weapons/kenetic_reload.ogg', 60, 1)
-	else
+	else if(ismob(loc))
 		to_chat(loc, "<span class='warning'>[src] silently charges up.<span>")
 	update_icon()
 


### PR DESCRIPTION
Fixes #5582 

Fixes a null message when examining something that lacks a description.

Fixes a bad target with the kinetic accelerator

Fixes a null message when an admin joins with no memo set