### PR TITLE
Adds basic Stock Parts to Autolathe

### DIFF
--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -10,7 +10,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor
-	category = list("Stock Parts")
+	category = list("Stock Parts","Electronics","initial")
 	lathe_time_factor = 5
 
 /datum/design/basic_sensor
@@ -21,7 +21,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
-	category = list("Stock Parts")
+	category = list("Stock Parts","Electronics","initial")
 	lathe_time_factor = 5
 
 /datum/design/micro_mani
@@ -32,7 +32,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator
-	category = list("Stock Parts")
+	category = list("Stock Parts","Electronics","initial")
 	lathe_time_factor = 5
 
 /datum/design/basic_micro_laser
@@ -43,7 +43,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser
-	category = list("Stock Parts")
+	category = list("Stock Parts","Electronics","initial")
 	lathe_time_factor = 5
 
 /datum/design/basic_matter_bin
@@ -54,7 +54,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin
-	category = list("Stock Parts")
+	category = list("Stock Parts","Electronics","initial")
 	lathe_time_factor = 5
 
 /datum/design/adv_capacitor


### PR DESCRIPTION
Adds the basic versions of Stock Parts to the Autolathe under the Electronics category.
Now people can build machines without having to go through Science all the time for the components.

:cl:
Added Capacitor, Scanning Module, Micro Manipulator, Matter Bin, Micro-Laser to the Autolathe.
:cl: