### PR TITLE
Adds Syndicate Sleeper board to Uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -791,7 +791,7 @@ var/list/uplink_items = list()
 	reference = "CHHUD"
 	item = /obj/item/clothing/glasses/hud/security/chameleon
 	cost = 2
-	
+
 /datum/uplink_item/stealthy_weapons/chameleonflag
 	name = "Chameleon Flag"
 	desc = "A flag that can be disguised as any other known flag. There is a heat sensitive bomb loaded into the pole that will be detonated if the flag is lit on fire."
@@ -914,6 +914,14 @@ var/list/uplink_items = list()
 	reference = "SSDB"
 	item = /obj/item/weapon/storage/backpack/duffel/syndie/surgery
 	cost = 4
+
+/datum/uplink_item/device_tools/syndiesleeperboard
+	name = "Syndicate Sleeper Board"
+	desc = "The circuit board required to build the Syndicate Sleeper, allowing agents to self-heal in the field."
+	reference = "SYSB"
+	item = /obj/item/weapon/circuitboard/sleeper/syndicate
+	cost = 2
+	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/military_belt
 	name = "Military Belt"


### PR DESCRIPTION
Adds the Syndicate Sleeper board to the Uplink, which can be used in machine frames to build the Syndicate Sleeper, the red and black ones on the nuke ops shuttle. They're different from regular Sleepers in that you can operate the Sleeper yourself while inside, and they are equivalent to fully upgraded Sleepers in the amount of reagent to inject and what reagents are available. Can be bought for 2 TC by all traitors excluding nuke ops.

:cl:
Added Syndicate Sleeper circuit board to traitor uplink for 2 TC
:cl: