### PR TITLE
BEHOLD MY POWERS OVER LIFE AND DEATH

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -142,6 +142,13 @@
 
 	return ..(gibbed)
 
+/mob/living/carbon/human/update_revive()
+	..()
+	// Update healthdoll
+	if(healthdoll)
+		// We're alive again, so re-build the entire healthdoll
+		healthdoll.cached_healthdoll_overlays.Cut()
+
 /mob/living/carbon/human/proc/makeSkeleton()
 	var/obj/item/organ/external/head/H = get_organ("head")
 	if(SKELETON in src.mutations)	return

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -803,10 +803,6 @@
 		if(REGEN in mutations)
 			heal_overall_damage(0.1, 0.1)
 
-		if(!in_stasis)
-			handle_organs()
-			handle_blood()
-
 		if(paralysis)
 			blinded = 1
 			stat = UNCONSCIOUS
@@ -892,6 +888,10 @@
 		// If you're dirty, your gloves will become dirty, too.
 		if(gloves && germ_level > gloves.germ_level && prob(10))
 			gloves.germ_level += 1
+
+		if(!in_stasis)
+			handle_organs()
+			handle_blood()
 
 
 	else //dead


### PR DESCRIPTION
Ports over the following two fixes from #5540:
Fixes the healthdoll failing to update when one is revived
Fixes people who lack blood dying for infinity when paralyzed in some manner
Fixes #5538
Fixes #4889 

Relevant clip
https://youtu.be/LcGg51qtEFY?t=4m47s

:cl: Crazylemon
fix: Dying of low blood is no longer capable of causing eternal death
fix: Having your body brought back to life will no longer break your health doll
/:cl: