### PR TITLE
Adds additional variants of 10mm ammunition.

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -27,6 +27,15 @@
 	caliber = "10mm"
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 
+/obj/item/ammo_casing/c10mm/ap
+	projectile_type = /obj/item/projectile/bullet/midbullet3/ap
+
+/obj/item/ammo_casing/c10mm/fire
+	projectile_type = /obj/item/projectile/bullet/midbullet3/fire
+
+/obj/item/ammo_casing/c10mm/hp
+	projectile_type = /obj/item/projectile/bullet/midbullet3/hp
+
 /obj/item/ammo_casing/c9mm
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -188,7 +188,7 @@
 /obj/item/ammo_box/magazine/m10mm/hp
 	name = "pistol magazine (10mm HP)"
 	desc= "A gun magazine. Loaded with hollow-point rounds, extremely effective against unarmored targets, but nearly useless against protective clothing."
-	ammo_type = /obj/item/ammo_casing/c10mm/silencer
+	ammo_type = /obj/item/ammo_casing/c10mm/hp
 
 /obj/item/ammo_box/magazine/m10mm/ap
 	name = "pistol magazine (10mm AP)"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -180,6 +180,21 @@
 	max_ammo = 8
 	multiple_sprites = 2
 
+/obj/item/ammo_box/magazine/m10mm/fire
+	name = "pistol magazine (10mm incendiary)"
+	desc = "A gun magazine. Loaded with rounds which ignite the target."
+	ammo_type = /obj/item/ammo_casing/c10mm/fire
+
+/obj/item/ammo_box/magazine/m10mm/hp
+	name = "pistol magazine (10mm HP)"
+	desc= "A gun magazine. Loaded with hollow-point rounds, extremely effective against unarmored targets, but nearly useless against protective clothing."
+	ammo_type = /obj/item/ammo_casing/c10mm/silencer
+
+/obj/item/ammo_box/magazine/m10mm/ap
+	name = "pistol magazine (10mm AP)"
+	desc= "A gun magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets"
+	ammo_type = /obj/item/ammo_casing/c10mm/ap
+
 /obj/item/ammo_box/magazine/m10mm/empty		//for maint drops
 	desc = "A gun magazine. Seems to be broken and can only hold one bullet. Pretty useless."
 	max_ammo = 1

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -114,7 +114,7 @@
 
 /obj/item/projectile/bullet/midbullet3/hp
 	damage = 45
-	armor_penetration = -100
+	armour_penetration = -100
 
 /obj/item/projectile/bullet/midbullet3/ap
 	damage = 27

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -114,11 +114,11 @@
 
 /obj/item/projectile/bullet/midbullet3/hp
 	damage = 45
-	armour_penetration = -100
+	armour_penetration = -70
 
 /obj/item/projectile/bullet/midbullet3/ap
 	damage = 27
-	armour_penetration = 80
+	armour_penetration = 40
 
 /obj/item/projectile/bullet/midbullet3/fire/on_hit(atom/target, blocked = 0)
 	if(..(target, blocked))

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -112,9 +112,6 @@
 /obj/item/projectile/bullet/midbullet3
 	damage = 30
 
-/obj/item/projectile/bullet/midbullet3
-	damage = 30
-
 /obj/item/projectile/bullet/midbullet3/hp
 	damage = 45
 	armor_penetration = -100

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -113,8 +113,8 @@
 	damage = 30
 
 /obj/item/projectile/bullet/midbullet3/hp
-	damage = 45
-	armour_penetration = -70
+	damage = 40
+	armour_penetration = -50
 
 /obj/item/projectile/bullet/midbullet3/ap
 	damage = 27

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -112,6 +112,23 @@
 /obj/item/projectile/bullet/midbullet3
 	damage = 30
 
+/obj/item/projectile/bullet/midbullet3
+	damage = 30
+
+/obj/item/projectile/bullet/midbullet3/hp
+	damage = 45
+	armor_penetration = -100
+
+/obj/item/projectile/bullet/midbullet3/ap
+	damage = 27
+	armour_penetration = 80
+
+/obj/item/projectile/bullet/midbullet3/fire/on_hit(atom/target, blocked = 0)
+	if(..(target, blocked))
+		var/mob/living/M = target
+		M.adjust_fire_stacks(1)
+		M.IgniteMob()
+
 /obj/item/projectile/bullet/heavybullet
 	damage = 35
 


### PR DESCRIPTION
Improved version of #5569

Adds three new types of 10mm ammunition, and the relevant magazines. Does not make the ammunition available to players.

AP- Ignores the majority of the target's armor, but does reduced damage. Buffed since its previous iteration.
HP- Does significantly increased base damage, but heavily increases the target's armor effectiveness. This one might not be too well placed in the hands of traitors.
Incendiary- What it says on the tin. Ignites the target, though the fire can easily be extinguished.

Rebalanced silencer rounds may return alongside other variants in a later PR, but this is a more reasonable starting point for 10mm variants.
:cl: Coldflame
rscadd: Adds three new variants of 10mm ammunition, AP, HP, and Incendiary. Currently admin-only.
/:cl: