### PR TITLE
Fixes Mentors Having Access to Roundstart Logout

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -388,7 +388,7 @@ proc/display_roundstart_logout_report()
 
 
 	for(var/mob/M in mob_list)
-		if(M.client && M.client.holder && (M.client.holder.rights & R_ADMIN))
+		if(check_rights(R_ADMIN, 0, M))
 			to_chat(M, msg)
 
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -388,7 +388,7 @@ proc/display_roundstart_logout_report()
 
 
 	for(var/mob/M in mob_list)
-		if(M.client && M.client.holder)
+		if(M.client && M.client.holder && (M.client.holder.rights & R_ADMIN))
 			to_chat(M, msg)
 
 


### PR DESCRIPTION
Fixes mentors seeing the round-start logout report.

They're not supposed to be able to, as they're non-administration.