### PR TITLE
Fixes Species Restrictions Applying To Non-Equipment Slots

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -31,9 +31,13 @@
 //BS12: Species-restricted clothing check.
 /obj/item/clothing/mob_can_equip(M as mob, slot)
 
-	//if we can equip the item anyway, don't bother with species_restricted (aslo cuts down on spam)
+	//if we can't equip the item anyway, don't bother with species_restricted (also cuts down on spam)
 	if(!..())
 		return 0
+
+	// Skip species restriction checks on non-equipment slots
+	if(slot in list(slot_r_hand, slot_l_hand, slot_in_backpack, slot_l_store, slot_r_store))
+		return 1
 
 	if(species_restricted && istype(M,/mob/living/carbon/human))
 


### PR DESCRIPTION
Species restrictions are handled by clothing's `mob_can_equip` proc, but it didn't care whether you were actually trying to equip something or just put it in your hands. This meant that certain procs, such as `put_in_any_hand_if_possible`, would fail to put things in your hands if your species couldn't wear them.

Not many things seem to have actually been affected by this, but trying to retrieve a species-restricted item from inside a spacepod was one of them.

This changes clothing's `mob_can_equip` to skip the restrictions checks if the provided slot is one of the hands, pockets, or the "put in backpack" slot.

:cl:
bugfix: Fixed species-restricted items sometimes failing to "equip" to restricted species' non-equipment slots.
/:cl: