### PR TITLE
Improves Goonchat's Handling of Old Versions of Internet Explorer

### DIFF
--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -6,11 +6,25 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 	<link rel="stylesheet" type="text/css" href="font-awesome.css" />
 	<link rel="stylesheet" type="text/css" href="browserOutput.css" />
-	<script type="text/javascript" src="jquery.min.js"></script>
-	<script type="text/javascript" src="jquery.mark.min.js"></script>
-	<script type="text/javascript" src="json2.min.js"></script>
+
+	<!-- Completely skip loading any normal scripts if below IE8; we won't use them -->
+	<!--[if gte IE 8]><!-->
+		<script type="text/javascript" src="jquery.min.js"></script>
+		<script type="text/javascript" src="json2.min.js"></script>
+	<!--<![endif]-->
+
+	<!-- The following script(s) require IE9 or above -->
+	<!--[if gte IE 9]><!-->
+		<script type="text/javascript" src="jquery.mark.min.js"></script>
+	<!--<![endif]-->
 </head>
 <body>
+	<!--[if lt IE 8]>
+		<script type="text/javascript">
+			alert("You are using an unsupported version of Internet Explorer. Please update to the latest version.");
+		</script>
+	<![endif]-->
+	<!--[if gte IE 8]><!-->
 	<div id="loading">
 		<i class="icon-spinner icon-2x"></i>
 		<div>
@@ -41,5 +55,13 @@
 		</div>
 	</div>
 	<script type="text/javascript" src="browserOutput.js"></script>
+	<!--<![endif]-->
+	<!--[if IE 8]>
+		<script type="text/javascript">
+			setTimeout(function(){
+				output('<span class="internal boldnshit">You are using a very outdated version of Internet Explorer. Some features will not work correctly! Please update to a newer version.</span>', 'internal');
+			}, 2000)
+		</script>
+	<![endif]-->
 </body>
 </html>

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -104,9 +104,13 @@ function setHighlightColor(match) {
 
 //Highlights words based on user settings
 function highlightTerms(el) {
+	var element = $(el)
+	if(!(element.mark)) { // mark.js isn't loaded; give up
+		return
+	}
 	for (var i = 0; i < opts.highlightTerms.length; i++) { //Each highlight term
 		if(opts.highlightTerms[i]) {
-			$(el).mark(opts.highlightTerms[i], {"element" : "span", "each" : setHighlightColor});
+			element.mark(opts.highlightTerms[i], {"element" : "span", "each" : setHighlightColor});
 		}
 	}
 }
@@ -808,6 +812,10 @@ $(function() {
 	});
 
 	$('#highlightTerm').click(function(e) {
+		if(!($().mark)) {
+			output('<span class="internal boldnshit">Highlighting is disabled. You are probably using Internet Explorer 8 and need to update.</span>', 'internal');
+			return;
+		}
 		if ($('.popup .highlightTerm').is(':visible')) {return;}
 		var termInputs = '';
 		for (var i = 0; i < opts.highlightLimit; i++) {


### PR DESCRIPTION
Using the black magic known only as "conditional comments", I've added a few warnings for people who are using particularly old versions of Internet Explorer.

Internet Explorer 7 and below are totally unsupported; players trying to connect with them *should* get the following popup now:

![firefox_2016-09-03_18-56-28](https://cloud.githubusercontent.com/assets/10916307/18228241/ea6c3476-7212-11e6-8f85-2b80bd06a8e2.png)

I say "should" because IE7 is *so old,* Microsoft no longer provides VMs to test with it, so that's from a stripped-down test page fed through a browser-testing rendering service. It *probably* works!™

Internet Explorer 8 isn't really supported anymore (NanoUI, in particular, no longer supports it, and I'm too lazy to touch its code), but the only part of Goonchat that requires it right now is mark.js. Connecting with IE8 will now give you a warning, and "gracefully" disable the highlighting functionality, including a warning if you try to change your highlighting options:

![virtualbox_2016-09-03_19-52-51](https://cloud.githubusercontent.com/assets/10916307/18228250/95fe35dc-7213-11e6-9903-0306b3c22a4b.png)

Anyone who has updated Internet Explorer in the past ~5½ years will be completely unaffected by this.

... unless they're still on Windows XP for some reason.

:cl:
rscadd: Players using very old versions of Internet Explorer will now receive explicit warnings that they're not supported.
/:cl: