### PR TITLE
Creates Syndicate Team Radio Frequency

### DIFF
--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -103,6 +103,7 @@ var/const/PUBLIC_HIGH_FREQ	= 1489
 var/const/RADIO_HIGH_FREQ	= 1600
 
 var/const/SYND_FREQ = 1213
+var/const/SYNDTEAM_FREQ = 1244
 var/const/DTH_FREQ = 1341
 var/const/AI_FREQ	= 1343
 var/const/ERT_FREQ = 1345
@@ -132,6 +133,7 @@ var/list/radiochannels = list(
 	"Response Team" = ERT_FREQ,
 	"Special Ops" 	= DTH_FREQ,
 	"Syndicate" 	= SYND_FREQ,
+	"SyndTeam" 		= SYNDTEAM_FREQ,
 	"Supply" 		= SUP_FREQ,
 	"Service" 		= SRV_FREQ,
 	"AI Private"	= AI_FREQ,
@@ -142,8 +144,11 @@ var/list/radiochannels = list(
 // central command channels, i.e deathsquid & response teams
 var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 
+// Channels that show up as '#unkn'
+var/list/UNKN_FREQS = list(SYND_FREQ)
+
 // Antag channels, i.e. Syndicate
-var/list/ANTAG_FREQS = list(SYND_FREQ)
+var/list/ANTAG_FREQS = list(SYND_FREQ, SYNDTEAM_FREQ)
 
 //Department channels, arranged lexically
 var/list/DEPT_FREQS = list(AI_FREQ, COMM_FREQ, ENG_FREQ, MED_FREQ, SEC_FREQ, SCI_FREQ, SRV_FREQ, SUP_FREQ)

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -144,9 +144,6 @@ var/list/radiochannels = list(
 // central command channels, i.e deathsquid & response teams
 var/list/CENT_FREQS = list(ERT_FREQ, DTH_FREQ)
 
-// Channels that show up as '#unkn'
-var/list/UNKN_FREQS = list(SYND_FREQ)
-
 // Antag channels, i.e. Syndicate
 var/list/ANTAG_FREQS = list(SYND_FREQ, SYNDTEAM_FREQ)
 

--- a/code/defines/procs/radio.dm
+++ b/code/defines/procs/radio.dm
@@ -7,13 +7,16 @@
 	var/freq_text
 
 	// the name of the channel
-	if(display_freq in UNKN_FREQS)
-		freq_text = "#unkn"
-	else
-		for(var/channel in radiochannels)
-			if(radiochannels[channel] == display_freq)
-				freq_text = channel
-				break
+	switch(display_freq)
+		if(SYND_FREQ)
+			freq_text = "#unkn"
+		if(SYNDTEAM_FREQ)
+			freq_text = "#unid"
+		else
+			for(var/channel in radiochannels)
+				if(radiochannels[channel] == display_freq)
+					freq_text = channel
+					break
 
 	// --- If the frequency has not been assigned a name, just use the frequency as the name ---
 	if(!freq_text)

--- a/code/defines/procs/radio.dm
+++ b/code/defines/procs/radio.dm
@@ -7,7 +7,7 @@
 	var/freq_text
 
 	// the name of the channel
-	if(display_freq in ANTAG_FREQS)
+	if(display_freq in UNKN_FREQS)
 		freq_text = "#unkn"
 	else
 		for(var/channel in radiochannels)

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -373,6 +373,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 					blackbox.msg_deathsquad += blackbox_msg
 				if(SYND_FREQ)
 					blackbox.msg_syndicate += blackbox_msg
+				if(SYNDTEAM_FREQ)
+					blackbox.msg_syndteam += blackbox_msg
 				if(SUP_FREQ)
 					blackbox.msg_cargo += blackbox_msg
 				if(SRV_FREQ)
@@ -558,6 +560,8 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 					blackbox.msg_deathsquad += blackbox_msg
 				if(SYND_FREQ)
 					blackbox.msg_syndicate += blackbox_msg
+				if(SYNDTEAM_FREQ)
+					blackbox.msg_syndteam += blackbox_msg
 				if(SUP_FREQ)
 					blackbox.msg_cargo += blackbox_msg
 				if(SRV_FREQ)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -21,6 +21,12 @@
 	origin_tech = "syndicate=3"
 	syndie = 1 //Signifies that it de-crypts Syndicate transmissions
 
+/obj/item/device/encryptionkey/syndteam
+	icon_state = "cypherkey"
+	channels = list("SyndTeam" = 1, "Syndicate" = 1)
+	origin_tech = "syndicate=4"
+	syndie = 1 //Signifies that it de-crypts Syndicate transmissions
+
 /obj/item/device/encryptionkey/binary
 	name = "binary translator key"
 	desc = "An encryption key for a radio headset. To access the binary channel, use :b."

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -96,6 +96,12 @@
 	icon_state = "syndie_headset"
 	item_state = "syndie_headset"
 
+/obj/item/device/radio/headset/syndicate/syndteam
+	ks1type = /obj/item/device/encryptionkey/syndteam
+
+/obj/item/device/radio/headset/syndicate/alt/syndteam
+	ks1type = /obj/item/device/encryptionkey/syndteam
+
 /obj/item/device/radio/headset/binary
 	origin_tech = "syndicate=3"
 	ks1type = /obj/item/device/encryptionkey/binary

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -188,8 +188,8 @@ var/global/sent_syndicate_infiltration_team = 0
 	D.implant(src)
 
 	// Radio & PDA
-	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate(src)
-	R.set_frequency(SYND_FREQ) //Same frequency as the syndicate team in Nuke mode.
+	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate/syndteam(src)
+	R.set_frequency(SYNDTEAM_FREQ)
 	equip_to_slot_or_del(R, slot_l_ear)
 	equip_or_collect(new /obj/item/device/pda(src), slot_in_backpack)
 

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -82,14 +82,6 @@ var/global/sent_syndicate_strike_team = 0
 			new_syndicate_commando.faction += "syndicate"
 			syndicate_commando_number--
 
-//Spawns the rest of the commando gear.
-//	for(var/obj/effect/landmark/L)
-	//	if(L.name == "Commando_Manual")
-			//new /obj/item/weapon/gun/energy/pulse_rifle(L.loc)
-		//	var/obj/item/weapon/paper/P = new(L.loc)
-		//	P.info = "<p><b>Good morning soldier!</b>. This compact guide will familiarize you with standard operating procedure. There are three basic rules to follow:<br>#1 Work as a team.<br>#2 Accomplish your objective at all costs.<br>#3 Leave no witnesses.<br>You are fully equipped and stocked for your mission--before departing on the Spec. Ops. Shuttle due South, make sure that all operatives are ready. Actual mission objective will be relayed to you by Central Command through your headsets.<br>If deemed appropriate, Central Command will also allow members of your team to equip assault power-armor for the mission. You will find the armor storage due West of your position. Once you are ready to leave, utilize the Special Operations shuttle console and toggle the hull doors via the other console.</p><p>In the event that the team does not accomplish their assigned objective in a timely manner, or finds no other way to do so, attached below are instructions on how to operate a Nanotrasen Nuclear Device. Your operations <b>LEADER</b> is provided with a nuclear authentication disk and a pin-pointer for this reason. You may easily recognize them by their rank: Lieutenant, Captain, or Major. The nuclear device itself will be present somewhere on your destination.</p><p>Hello and thank you for choosing Nanotrasen for your nuclear information needs. Today's crash course will deal with the operation of a Fission Class Nanotrasen made Nuclear Device.<br>First and foremost, <b>DO NOT TOUCH ANYTHING UNTIL THE BOMB IS IN PLACE.</b> Pressing any button on the compacted bomb will cause it to extend and bolt itself into place. If this is done to unbolt it one must completely log in which at this time may not be possible.<br>To make the device functional:<br>#1 Place bomb in designated detonation zone<br> #2 Extend and anchor bomb (attack with hand).<br>#3 Insert Nuclear Auth. Disk into slot.<br>#4 Type numeric code into keypad ([nuke_code]).<br>Note: If you make a mistake press R to reset the device.<br>#5 Press the E button to log onto the device.<br>You now have activated the device. To deactivate the buttons at anytime, for example when you have already prepped the bomb for detonation, remove the authentication disk OR press the R on the keypad. Now the bomb CAN ONLY be detonated using the timer. A manual detonation is not an option.<br>Note: Toggle off the <b>SAFETY</b>.<br>Use the - - and + + to set a detonation time between 5 seconds and 10 minutes. Then press the timer toggle button to start the countdown. Now remove the authentication disk so that the buttons deactivate.<br>Note: <b>THE BOMB IS STILL SET AND WILL DETONATE</b><br>Now before you remove the disk if you need to move the bomb you can: Toggle off the anchor, move it, and re-anchor.</p><p>The nuclear authorization code is: <b>[nuke_code ? nuke_code : "None provided"]</b></p><p><b>Good luck, soldier!</b></p>"
-		//	P.name = "Spec. Ops. Manual"
-
 	for(var/obj/effect/landmark/L in landmarks_list)
 		if(L.name == "Syndicate-Commando-Bomb")
 			new /obj/effect/spawner/newbomb/timer/syndicate(L.loc)
@@ -126,8 +118,8 @@ var/global/sent_syndicate_strike_team = 0
 
 /mob/living/carbon/human/proc/equip_syndicate_commando(syndicate_leader_selected = 0)
 
-	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate/alt(src)
-	R.set_frequency(SYND_FREQ) //Same frequency as the syndicate team in Nuke mode.
+	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate/alt/syndteam(src)
+	R.set_frequency(SYNDTEAM_FREQ)
 	equip_to_slot_or_del(R, slot_l_ear)
 	equip_to_slot_or_del(new /obj/item/clothing/under/syndicate(src), slot_w_uniform)
 	equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/syndie/advance(src), slot_shoes)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -29,7 +29,8 @@ var/list/department_radio_keys = list(
 	  ":U" = "Supply",		"#U" = "Supply",		".U" = "Supply",
 	  ":Z" = "Service",		"#Z" = "Service",		".Z" = "Service",
 	  ":P" = "AI Private",	"#P" = "AI Private",	".P" = "AI Private",
-	  ":-" = "Special Ops",	"#-" = "Special Ops",	".-" = "Special Ops"
+	  ":-" = "Special Ops",	"#-" = "Special Ops",	".-" = "Special Ops",
+	  ":_" = "SyndTeam",	"#_" = "SyndTeam",		"._" = "SyndTeam"
 )
 
 

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -209,6 +209,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 	var/list/msg_security = list()
 	var/list/msg_deathsquad = list()
 	var/list/msg_syndicate = list()
+	var/list/msg_syndteam = list()
 	var/list/msg_mining = list()
 	var/list/msg_cargo = list()
 	var/list/msg_service = list()
@@ -235,6 +236,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 		BR.msg_security = msg_security
 		BR.msg_deathsquad = msg_deathsquad
 		BR.msg_syndicate = msg_syndicate
+		BR.msg_syndteam = msg_syndteam
 		BR.msg_mining = msg_mining
 		BR.msg_cargo = msg_cargo
 		BR.msg_service = msg_service
@@ -277,6 +279,7 @@ var/obj/machinery/blackbox_recorder/blackbox
 	feedback_add_details("radio_usage","SEC-[msg_security.len]")
 	feedback_add_details("radio_usage","DTH-[msg_deathsquad.len]")
 	feedback_add_details("radio_usage","SYN-[msg_syndicate.len]")
+	feedback_add_details("radio_usage","SYT-[msg_syndteam.len]")
 	feedback_add_details("radio_usage","MIN-[msg_mining.len]")
 	feedback_add_details("radio_usage","CAR-[msg_cargo.len]")
 	feedback_add_details("radio_usage","SRV-[msg_service.len]")


### PR DESCRIPTION
This PR adds a dedicated radio channel for Syndicate Strike/Infiltration Teams (SSTs/SITs).
- SIT/SST can still use the default traitor channel (.t), but now they also have their own channel (.h) as well. 
- Their channel shows up as "SyndTeam" (unlike normal traitor radio, which reads as "#unkn"). You cannot confuse the two.
- Normal traitors (or people with captured gear from them) cannot access the SyndTeam channel. Only SST/SIT/etc can access it.

Why this is needed:
- SST and SIT are usually called during syndicate-related events.
- During these events, the odds of security having already captured a traitor, and having access to their comms, is high.
- SIT is severely gimped if the station knows they're coming. Trying to plan a stealth op, for example, when security can overhear all your comms chatter, is impossible.
- So, these teams really need their own frequency. That's what this PR gives them.

:cl: Kyep
rscadd: SST and SIT now have their own radio frequency.
/:cl: