### PR TITLE
Data disks now get a nice name and description when written to

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -129,17 +129,26 @@
 	if(stat)
 		return 1
 
-	if(istype(O, /obj/item/weapon/disk/design_disk))
-		user.visible_message("[user] begins to load \the [O] in \the [src]...",
-			"You begin to load a design from \the [O]...",
-			"You hear the chatter of a floppy drive.")
-		busy = 1
-		var/obj/item/weapon/disk/design_disk/D = O
-		if(do_after(user, 14.4, target = src))
-			files.AddDesign2Known(D.blueprint)
-
-		busy = 0
-		return
+	// Disks in general
+	if(istype(O, /obj/item/weapon/disk))
+		if(istype(O, /obj/item/weapon/disk/design_disk))
+			var/obj/item/weapon/disk/design_disk/D = O
+			if(D.blueprint)
+				user.visible_message("[user] begins to load \the [O] in \the [src]...",
+					"You begin to load a design from \the [O]...",
+					"You hear the chatter of a floppy drive.")
+				playsound(get_turf(src), "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+				busy = 1
+				if(do_after(user, 14.4, target = src))
+					files.AddDesign2Known(D.blueprint)
+				busy = 0
+			else
+				to_chat(user, "<span class='warning'>That disk does not have a design on it!</span>")
+			return 1
+		else
+			// So that people who are bad at computers don't shred their disks
+			to_chat(user, "<span class='warning'>This is not the correct type of disk for the autolathe!</span>")
+			return 1
 
 	var/material_amount = materials.get_item_material_amount(O)
 	if(!material_amount)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -234,7 +234,7 @@ proc/CallMaterialName(ID)
 
 	else if(href_list["clear_tech"]) //Erase data on the technology disk.
 		if(t_disk)
-			t_disk.stored = null
+			t_disk.wipe_tech()
 
 	else if(href_list["eject_tech"]) //Eject the technology disk.
 		if(t_disk)
@@ -246,7 +246,7 @@ proc/CallMaterialName(ID)
 	else if(href_list["copy_tech"]) //Copy some technology data from the research holder to the disk.
 		for(var/datum/tech/T in files.known_tech)
 			if(href_list["copy_tech_ID"] == T.id)
-				t_disk.stored = T
+				t_disk.load_tech(T)
 				break
 		menu = 2
 		submenu = 0
@@ -261,7 +261,7 @@ proc/CallMaterialName(ID)
 
 	else if(href_list["clear_design"]) //Erases data on the design disk.
 		if(d_disk)
-			d_disk.blueprint = null
+			d_disk.wipe_blueprint()
 
 	else if(href_list["eject_design"]) //Eject the design disk.
 		if(d_disk)
@@ -284,7 +284,7 @@ proc/CallMaterialName(ID)
 				if(D.build_type & (AUTOLATHE|PROTOLATHE|CRAFTLATHE)) // Specifically excludes circuit imprinter and mechfab
 					D.build_type = autolathe_friendly ? (D.build_type | AUTOLATHE) : D.build_type
 					D.category |= "Imported"
-				d_disk.blueprint = D
+				d_disk.load_blueprint(D)
 				break
 		menu = 2
 		submenu = 0

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -187,7 +187,7 @@ datum/tech/materials
 
 datum/tech/engineering
 	name = "Engineering Research"
-	desc = "Development of new and improved engineering parts and."
+	desc = "Development of new and improved engineering parts and methods."
 	id = "engineering"
 	max_level = 5
 
@@ -206,7 +206,7 @@ datum/tech/powerstorage
 
 datum/tech/bluespace
 	name = "'Blue-space' Research"
-	desc = "Research into the sub-reality known as 'blue-space'"
+	desc = "Research into the sub-reality known as 'blue-space'."
 	id = "bluespace"
 	max_level = 6
 	rare = 2
@@ -293,7 +293,7 @@ datum/tech/robotics
 	return cost
 
 /obj/item/weapon/disk/tech_disk
-	name = "Technology Disk"
+	name = "\improper Technology Disk"
 	desc = "A disk for storing technology data for further research."
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "datadisk2"
@@ -301,13 +301,27 @@ datum/tech/robotics
 	w_class = 1
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 	var/datum/tech/stored
+	var/default_name = "\improper Technology Disk"
+	var/default_desc = "A disk for storing technology data for further research."
 
 /obj/item/weapon/disk/tech_disk/New()
 	src.pixel_x = rand(-5.0, 5)
 	src.pixel_y = rand(-5.0, 5)
 
+/obj/item/weapon/disk/tech_disk/proc/load_tech(datum/tech/T)
+	name = "[default_name] \[[T]\]"
+	desc = T.desc + " Level: '[T.level]'"
+	// NOTE: This is just a reference to the tech on the system it grabbed it from
+	// This seems highly fragile
+	stored = T
+
+/obj/item/weapon/disk/tech_disk/proc/wipe_tech()
+	name = default_name
+	desc = default_desc
+	stored = null
+
 /obj/item/weapon/disk/design_disk
-	name = "Component Design Disk"
+	name = "\improper Component Design Disk"
 	desc = "A disk for storing device design data for construction in lathes."
 	icon = 'icons/obj/cloning.dmi'
 	icon_state = "datadisk2"
@@ -315,7 +329,23 @@ datum/tech/robotics
 	w_class = 1
 	materials = list(MAT_METAL=30, MAT_GLASS=10)
 	var/datum/design/blueprint
+	// I'm doing this so that disk paths with pre-loaded designs don't get weird names
+	// Otherwise, I'd use "initial()"
+	var/default_name = "\improper Component Design Disk"
+	var/default_desc = "A disk for storing device design data for construction in lathes."
 
 /obj/item/weapon/disk/design_disk/New()
 	src.pixel_x = rand(-5.0, 5)
 	src.pixel_y = rand(-5.0, 5)
+
+/obj/item/weapon/disk/design_disk/proc/load_blueprint(datum/design/D)
+	name = "[default_name] \[[D]\]"
+	desc = D.desc
+	// NOTE: This is just a reference to the design on the system it grabbed it from
+	// This seems highly fragile
+	blueprint = D
+
+/obj/item/weapon/disk/design_disk/proc/wipe_blueprint()
+	name = default_name
+	desc = default_desc
+	blueprint = null


### PR DESCRIPTION

![thats_better](https://cloud.githubusercontent.com/assets/5661700/18533518/48723aec-7a98-11e6-956c-205e2a283ef0.png)

Disks now get the name of the design or technology, as well as the description of the data loaded on it. For many designs, this isn't defined, so there might be a few that are just "Desc".

Also, to save people who work with autolathes a bunch of heartache, you will no longer shred non-design disks that you try to give to the autolathe.

:cl:Crazylemon
tweak: Research data disks now have a description and name attached to them automatically, to make working with them less obnoxious.
tweak: Loading design disks now has a sound effect.
tweak: You can no longer feed non-design disks into the autolathe and destroy them on accident.
/:cl: