### PR TITLE
Adds 10mm variants to the syndicate uplink.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -577,10 +577,31 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ammo/pistol
 	name = "Magazine - 10mm"
-	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol. These subsonic rounds are dirt cheap but are half as effective as .357 rounds."
+	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with standard rounds that are weak but inexpensive."
 	reference = "10MM"
 	item = /obj/item/ammo_box/magazine/m10mm
 	cost = 1
+
+/datum/uplink_item/ammo/pistolap
+	name = "Magazine - 10mm Armour Piercing"
+	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds that are less effective at injuring the target but penetrate protective gear."
+	reference = "10MM"
+	item = /obj/item/ammo_box/magazine/m10mm/ap
+	cost = 2
+
+/datum/uplink_item/ammo/pistolfire
+	name = "Magazine - 10mm Incendiary"
+	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with incendiary rounds which ignite the target."
+	reference = "10MM"
+	item = /obj/item/ammo_box/magazine/m10mm/fire
+	cost = 2
+
+/datum/uplink_item/ammo/pistolhp
+	name = "Magazine - 10mm Hollow Point"
+	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds which are more damaging but ineffective against armour."
+	reference = "10MM"
+	item = /obj/item/ammo_box/magazine/m10mm/hp
+	cost = 3
 
 /datum/uplink_item/ammo/revolver
 	name = "Speed Loader - .357"
@@ -791,7 +812,7 @@ var/list/uplink_items = list()
 	reference = "CHHUD"
 	item = /obj/item/clothing/glasses/hud/security/chameleon
 	cost = 2
-	
+
 /datum/uplink_item/stealthy_weapons/chameleonflag
 	name = "Chameleon Flag"
 	desc = "A flag that can be disguised as any other known flag. There is a heat sensitive bomb loaded into the pole that will be detonated if the flag is lit on fire."

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -577,7 +577,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ammo/pistol
 	name = "Magazine - 10mm"
-	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with standard rounds that are weak but inexpensive."
+	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds that are cheap but around half as effective as .357"
 	reference = "10MM"
 	item = /obj/item/ammo_box/magazine/m10mm
 	cost = 1

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -585,21 +585,21 @@ var/list/uplink_items = list()
 /datum/uplink_item/ammo/pistolap
 	name = "Magazine - 10mm Armour Piercing"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds that are less effective at injuring the target but penetrate protective gear."
-	reference = "10MM"
+	reference = "10MMAP"
 	item = /obj/item/ammo_box/magazine/m10mm/ap
 	cost = 2
 
 /datum/uplink_item/ammo/pistolfire
 	name = "Magazine - 10mm Incendiary"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with incendiary rounds which ignite the target."
-	reference = "10MM"
+	reference = "10MMFIRE"
 	item = /obj/item/ammo_box/magazine/m10mm/fire
 	cost = 2
 
 /datum/uplink_item/ammo/pistolhp
 	name = "Magazine - 10mm Hollow Point"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds which are more damaging but ineffective against armour."
-	reference = "10MM"
+	reference = "10MMHP"
 	item = /obj/item/ammo_box/magazine/m10mm/hp
 	cost = 3
 


### PR DESCRIPTION
Adds the magazines from #5596 to the uplink. Available to both traitors and nuke teams. AP and Incendiary rounds cost 2TC a mag, whilst HP mags cost 3TC.

Also slightly adjusts the description of standard ammo in the uplink to be in-line with the descriptions of the new magazines.