### PR TITLE
Port of TGs conveyors

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -616,7 +616,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	access = access_ce
 	announce_beacons = list("Engineering" = list("Chief Engineer's Desk", "Atmospherics"))
 
-/datum/supply_packs/engineering/conveyor  // NEW
+/datum/supply_packs/engineering/conveyor
 	name = "Conveyor Assembly Crate"
 	contains = list(/obj/item/conveyor_construct,
 					/obj/item/conveyor_construct,

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -616,6 +616,19 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	access = access_ce
 	announce_beacons = list("Engineering" = list("Chief Engineer's Desk", "Atmospherics"))
 
+/datum/supply_packs/engineering/conveyor  // NEW
+	name = "Conveyor Assembly Crate"
+	contains = list(/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_construct,
+					/obj/item/conveyor_switch_construct,
+					/obj/item/weapon/paper/conveyor)
+	cost = 15
+	containername = "conveyor assembly crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Medical /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -128,11 +128,14 @@ Class Procs:
 	if(use_power)
 		myArea = get_area_master(src)
 
-	machines += src
+	machines += src //Moved this to New
 	if(!speed_process)
 		machine_processing += src
 	else
 		fast_processing += src
+
+/obj/machinery/New() //new
+	machines += src
 
 /obj/machinery/Destroy()
 	if(myArea)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -120,7 +120,7 @@ Class Procs:
 	var/speed_process = 0 // Process as fast as possible?
 
 /obj/machinery/initialize()
-//	addAtProcessing() //Testing this in new conveyors
+	addAtProcessing()
 	. = ..()
 	power_change()
 
@@ -128,19 +128,11 @@ Class Procs:
 	if(use_power)
 		myArea = get_area_master(src)
 
-/*	machines += src
-	if(!speed_process)
-		machine_processing += src
-	else
-		fast_processing += src */ //Also testing in NEW conveyors
-
-/obj/machinery/new() //new for trying to get the conveyors working with machinery, not world
 	machines += src
 	if(!speed_process)
 		machine_processing += src
 	else
 		fast_processing += src
-	. = ..()
 
 /obj/machinery/Destroy()
 	if(myArea)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -120,7 +120,7 @@ Class Procs:
 	var/speed_process = 0 // Process as fast as possible?
 
 /obj/machinery/initialize()
-	addAtProcessing()
+//	addAtProcessing() //Testing this in new conveyors
 	. = ..()
 	power_change()
 
@@ -128,11 +128,19 @@ Class Procs:
 	if(use_power)
 		myArea = get_area_master(src)
 
+/*	machines += src
+	if(!speed_process)
+		machine_processing += src
+	else
+		fast_processing += src */ //Also testing in NEW conveyors
+
+/obj/machinery/new() //new for trying to get the conveyors working with machinery, not world
 	machines += src
 	if(!speed_process)
 		machine_processing += src
 	else
 		fast_processing += src
+	. = ..()
 
 /obj/machinery/Destroy()
 	if(myArea)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -127,8 +127,6 @@ Class Procs:
 /obj/machinery/proc/addAtProcessing()
 	if(use_power)
 		myArea = get_area_master(src)
-
-	machines += src //Moved this to New
 	if(!speed_process)
 		machine_processing += src
 	else
@@ -136,6 +134,7 @@ Class Procs:
 
 /obj/machinery/New() //new
 	machines += src
+	..()
 
 /obj/machinery/Destroy()
 	if(myArea)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -211,17 +211,24 @@
 	speed_process = 1
 
 
-obj/machinery/conveyor_switch/New(newloc, newid)
+/obj/machinery/conveyor_switch/New(newloc, newid)
 	..(newloc)
 	if(!id)
 		id = newid
 	update()
 
-	spawn(5)		// allow map load
+/*	spawn(5)		// allow map load
 		conveyors = list()
-		for(var/obj/machinery/conveyor/C in machines)
+		for(var/obj/machinery/conveyor/C in machines) //This works if it's: `C in world` , but that's bad practice. Best to try to fix it.
 			if(C.id == id)
-				conveyors += C
+				conveyors += C */ //Moving this to initialise to see if it gets around the bug... do we need the spawn thing? Let's find out.
+
+/obj/machinery/conveyor_switch/initialize() //This whole thing is new
+	conveyors = list()
+	for(var/obj/machinery/conveyor/C in machines)
+		if(C.id == id)
+			conveyors += C
+
 
 // update the icon depending on the position
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -68,15 +68,15 @@
 		if(NORTHEAST)
 			forwards = EAST
 			backwards = SOUTH
-		if(NORTHWEST)
+		if(SOUTHEAST)
 			forwards = NORTH
 			backwards = EAST
-		if(SOUTHEAST)
-			forwards = SOUTH
-			backwards = WEST
 		if(SOUTHWEST)
 			forwards = WEST
 			backwards = NORTH
+		if(NORTHWEST)
+			forwards = SOUTH
+			backwards = WEST
 	if(verted == -1)
 		var/temp = forwards
 		forwards = backwards

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -44,10 +44,20 @@
 	icon_state = "conveyor[operating * verted]"
 
 	// create a conveyor
+/*/obj/machinery/conveyor/New(loc, newdir)
+	..(loc)
+	if(newdir)
+		dir = newdir
+	update_move_direction()*/ // Old
+
 /obj/machinery/conveyor/New(loc, newdir)
 	..(loc)
 	if(newdir)
 		dir = newdir
+	update_move_direction()
+
+
+/obj/machinery/conveyor/proc/update_move_direction() //This proc is new, moved stuff from New
 	switch(dir)
 		if(NORTH)
 			forwards = NORTH
@@ -65,11 +75,11 @@
 			forwards = EAST
 			backwards = SOUTH
 		if(NORTHWEST)
-			forwards = SOUTH
-			backwards = WEST
-		if(SOUTHEAST)
 			forwards = NORTH
 			backwards = EAST
+		if(SOUTHEAST)
+			forwards = SOUTH
+			backwards = WEST
 		if(SOUTHWEST)
 			forwards = WEST
 			backwards = NORTH
@@ -77,6 +87,11 @@
 		var/temp = forwards
 		forwards = backwards
 		backwards = temp
+	if(operating == 1)
+		movedir = forwards
+	else
+		movedir = backwards
+	update()
 
 /obj/machinery/conveyor/proc/setmove()
 	if(operating == 1)
@@ -114,11 +129,33 @@
 		CHECK_TICK
 
 // attack with item, place item on conveyor
-/obj/machinery/conveyor/attackby(var/obj/item/I, mob/user, params)
+/*/obj/machinery/conveyor/attackby(var/obj/item/I, mob/user, params)
 	if(isrobot(user))	return //Carn: fix for borgs dropping their modules on conveyor belts
 	user.drop_item()
 	if(I && I.loc)	I.loc = src.loc
-	return
+	return*/ // NEW CODE HERE ---v
+/obj/machinery/conveyor/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/crowbar))
+		if(!(stat & BROKEN))
+			var/obj/item/conveyor_construct/C = new/obj/item/conveyor_construct(src.loc)
+			C.id = id
+			transfer_fingerprints_to(C)
+		user << "<span class='notice'>You remove the conveyor belt.</span>"
+		qdel(src)
+
+	else if(istype(I, /obj/item/weapon/wrench))
+		if(!(stat & BROKEN))
+			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+			//setDir(turn(dir,-45)) //No such proc
+			dir = turn(dir,-45)
+			update_move_direction()
+			user << "<span class='notice'>You rotate [src].</span>"
+
+	else if(user.a_intent != "harm")
+		if(user.drop_item())
+			I.loc = src.loc
+	else
+		return ..()
 
 // attack with hand, move pulled object onto conveyor
 /obj/machinery/conveyor/attack_hand(mob/user as mob)
@@ -176,6 +213,7 @@
 	var/position = 0			// 0 off, -1 reverse, 1 forward
 	var/last_pos = -1			// last direction setting
 	var/operated = 1			// true if just operated
+	var/convdir = 0				// 0 is two way switch, 1 and -1 means one way
 
 	var/id = "" 				// must match conveyor IDs to control them
 
@@ -184,13 +222,24 @@
 	speed_process = 1
 
 
-/obj/machinery/conveyor_switch/New()
+/*/obj/machinery/conveyor_switch/New()
 	..()
 	update()
 
 	spawn(5)		// allow map load
 		conveyors = list()
 		for(var/obj/machinery/conveyor/C in world)
+			if(C.id == id)
+				conveyors += C*/ //NEW CODE -v
+obj/machinery/conveyor_switch/New(newloc, newid)
+	..(newloc)
+	if(!id)
+		id = newid
+	update()
+
+	spawn(5)		// allow map load
+		conveyors = list()
+		for(var/obj/machinery/conveyor/C in machines)
 			if(C.id == id)
 				conveyors += C
 
@@ -218,8 +267,12 @@
 		C.setmove()
 		CHECK_TICK
 
+/obj/machinery/conveyor_switch/oneway
+	convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)
+	desc = "A conveyor control switch. It appears to only go in one direction."
+
 // attack with hand, switch position
-/obj/machinery/conveyor_switch/attack_hand(mob/user)
+/*/obj/machinery/conveyor_switch/attack_hand(mob/user)
 	if(!allowed(user))
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
@@ -244,11 +297,36 @@
 		if(S.id == src.id)
 			S.position = position
 			S.update()
+		CHECK_TICK*/ //New vode
+/obj/machinery/conveyor_switch/attack_hand(mob/user)
+	if(!allowed(user)) //this is in Para but not TG
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return
+	add_fingerprint(user)
+	if(position == 0)
+		if(convdir)   //is it a oneway switch
+			position = convdir
+		else
+			if(last_pos < 0)
+				position = 1
+				last_pos = 0
+			else
+				position = -1
+				last_pos = 0
+	else
+		last_pos = position
+		position = 0
+
+	operated = 1
+	update()
+
+	// find any switches with same id as this one, and set their positions to match us
+	for(var/obj/machinery/conveyor_switch/S in machines)
+		if(S.id == src.id)
+			S.position = position
+			S.update()
 		CHECK_TICK
 
-/obj/machinery/conveyor_switch/oneway
-	var/convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)
-	desc = "A conveyor control switch. It appears to only go in one direction."
 
 // attack with hand, switch position
 /obj/machinery/conveyor_switch/oneway/attack_hand(mob/user)
@@ -265,3 +343,75 @@
 		if(S.id == src.id)
 			S.position = position
 			S.update()
+
+/obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/crowbar))
+		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
+		C.id = id
+		transfer_fingerprints_to(C)
+		user << "<span class='notice'>You deattach the conveyor switch.</span>"
+		qdel(src)
+
+
+
+//
+// CONVEYOR CONSTRUCTION STARTS HERE
+//   All new here.
+
+/obj/item/conveyor_construct
+	icon = 'icons/obj/recycling.dmi'
+	icon_state = "conveyor0"
+	name = "conveyor belt assembly"
+	desc = "A conveyor belt assembly."
+	w_class = 4
+	var/id = "" //inherited by the belt
+
+/obj/item/conveyor_construct/attackby(obj/item/I, mob/user, params)
+	..()
+	if(istype(I, /obj/item/conveyor_switch_construct))
+		user << "<span class='notice'>You link the switch to the conveyor belt assembly.</span>"
+		var/obj/item/conveyor_switch_construct/C = I
+		id = C.id
+
+/obj/item/conveyor_construct/afterattack(atom/A, mob/user, proximity)
+	if(!proximity || user.stat || !istype(A, /turf/simulated/floor) || istype(A, /area/shuttle))
+		return
+	var/cdir = get_dir(A, user)
+	if(A == user.loc)
+		user << "<span class='notice'>You cannot place a conveyor belt under yourself.</span>"
+		return
+	var/obj/machinery/conveyor/C = new/obj/machinery/conveyor(A,cdir)
+	C.id = id
+	transfer_fingerprints_to(C)
+	qdel(src)
+
+/obj/item/conveyor_switch_construct
+	name = "conveyor switch assembly"
+	desc = "A conveyor control switch assembly."
+	icon = 'icons/obj/recycling.dmi'
+	icon_state = "switch-off"
+	w_class = 4
+	var/id = "" //inherited by the switch
+
+/obj/item/conveyor_switch_construct/New()
+	..()
+	id = rand() //this couldn't possibly go wrong
+
+/obj/item/conveyor_switch_construct/afterattack(atom/A, mob/user, proximity)
+	if(!proximity || user.stat || !istype(A, /turf/simulated/floor) || istype(A, /area/shuttle))
+		return
+	var/found = 0
+	for(var/obj/machinery/conveyor/C in view())
+		if(C.id == src.id)
+			found = 1
+			break
+	if(!found)
+		user << "\icon[src]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>"
+		return
+	var/obj/machinery/conveyor_switch/NC = new/obj/machinery/conveyor_switch(A, id)
+	transfer_fingerprints_to(NC)
+	qdel(src)
+
+/obj/item/weapon/paper/conveyor
+	name = "paper- 'Nano-it-up U-build series, #9: Build your very own conveyor belt, in SPACE'"
+	info = "<h1>Congratulations!</h1><p>You are now the proud owner of the best conveyor set available for space mail order! We at Nano-it-up know you love to prepare your own structures without wasting time, so we have devised a special streamlined assembly procedure that puts all other mail-order products to shame!</p><p>Firstly, you need to link the conveyor switch assembly to each of the conveyor belt assemblies. After doing so, you simply need to install the belt assemblies onto the floor, et voila, belt built. Our special Nano-it-up smart switch will detected any linked assemblies as far as the eye can see! This convenience, you can only have it when you Nano-it-up. Stay nano!</p>"

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -28,7 +28,7 @@
 /obj/machinery/conveyor/auto/New(loc, newdir)
 	..(loc, newdir)
 	operating = 1
-	setmove()
+	update_move_direction()
 
 /obj/machinery/conveyor/auto/update()
 	if(stat & BROKEN)
@@ -68,15 +68,15 @@
 		if(NORTHEAST)
 			forwards = EAST
 			backwards = SOUTH
+		if(NORTHWEST)
+			forwards = SOUTH
+			backwards = WEST
 		if(SOUTHEAST)
 			forwards = NORTH
 			backwards = EAST
 		if(SOUTHWEST)
 			forwards = WEST
 			backwards = NORTH
-		if(NORTHWEST)
-			forwards = SOUTH
-			backwards = WEST
 	if(verted == -1)
 		var/temp = forwards
 		forwards = backwards
@@ -87,12 +87,6 @@
 		movedir = backwards
 	update()
 
-/obj/machinery/conveyor/proc/setmove()
-	if(operating == 1)
-		movedir = forwards
-	else
-		movedir = backwards
-	update()
 
 /obj/machinery/conveyor/proc/update()
 	if(stat & BROKEN)
@@ -225,6 +219,7 @@
 			if(C.id == id)
 				conveyors += C
 
+
 // update the icon depending on the position
 
 /obj/machinery/conveyor_switch/proc/update()
@@ -246,7 +241,7 @@
 
 	for(var/obj/machinery/conveyor/C in conveyors)
 		C.operating = position
-		C.setmove()
+		C.update_move_direction()
 		CHECK_TICK
 
 /obj/machinery/conveyor_switch/oneway
@@ -254,7 +249,7 @@
 
 // attack with hand, switch position
 /obj/machinery/conveyor_switch/attack_hand(mob/user)
-	if(!allowed(user)) //this is in Para but not TG. I don't think there's any which are coded anyway.
+	if(!allowed(user)) //this is in Para but not TG. I don't think there's any which are set anyway.
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	add_fingerprint(user)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -23,7 +23,7 @@
 	id = "round_end_belt"
 
 
-// Auto conveyour is always on unless unpowered
+// Auto conveyor is always on unless unpowered
 
 /obj/machinery/conveyor/auto/New(loc, newdir)
 	..(loc, newdir)
@@ -44,12 +44,6 @@
 	icon_state = "conveyor[operating * verted]"
 
 	// create a conveyor
-/*/obj/machinery/conveyor/New(loc, newdir)
-	..(loc)
-	if(newdir)
-		dir = newdir
-	update_move_direction()*/ // Old
-
 /obj/machinery/conveyor/New(loc, newdir)
 	..(loc)
 	if(newdir)
@@ -57,7 +51,7 @@
 	update_move_direction()
 
 
-/obj/machinery/conveyor/proc/update_move_direction() //This proc is new, moved stuff from New
+/obj/machinery/conveyor/proc/update_move_direction()
 	switch(dir)
 		if(NORTH)
 			forwards = NORTH
@@ -129,11 +123,6 @@
 		CHECK_TICK
 
 // attack with item, place item on conveyor
-/*/obj/machinery/conveyor/attackby(var/obj/item/I, mob/user, params)
-	if(isrobot(user))	return //Carn: fix for borgs dropping their modules on conveyor belts
-	user.drop_item()
-	if(I && I.loc)	I.loc = src.loc
-	return*/ // NEW CODE HERE ---v
 /obj/machinery/conveyor/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/crowbar))
 		if(!(stat & BROKEN))
@@ -222,15 +211,6 @@
 	speed_process = 1
 
 
-/*/obj/machinery/conveyor_switch/New()
-	..()
-	update()
-
-	spawn(5)		// allow map load
-		conveyors = list()
-		for(var/obj/machinery/conveyor/C in world)
-			if(C.id == id)
-				conveyors += C*/ //NEW CODE -v
 obj/machinery/conveyor_switch/New(newloc, newid)
 	..(newloc)
 	if(!id)
@@ -272,34 +252,8 @@ obj/machinery/conveyor_switch/New(newloc, newid)
 	desc = "A conveyor control switch. It appears to only go in one direction."
 
 // attack with hand, switch position
-/*/obj/machinery/conveyor_switch/attack_hand(mob/user)
-	if(!allowed(user))
-		to_chat(user, "<span class='warning'>Access denied.</span>")
-		return
-
-
-	if(position == 0)
-		if(last_pos < 0)
-			position = 1
-			last_pos = 0
-		else
-			position = -1
-			last_pos = 0
-	else
-		last_pos = position
-		position = 0
-
-	operated = 1
-	update()
-
-	// find any switches with same id as this one, and set their positions to match us
-	for(var/obj/machinery/conveyor_switch/S in machines)
-		if(S.id == src.id)
-			S.position = position
-			S.update()
-		CHECK_TICK*/ //New vode
 /obj/machinery/conveyor_switch/attack_hand(mob/user)
-	if(!allowed(user)) //this is in Para but not TG
+	if(!allowed(user)) //this is in Para but not TG. I don't think there's any which are coded anyway.
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return
 	add_fingerprint(user)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -131,20 +131,19 @@
 			var/obj/item/conveyor_construct/C = new/obj/item/conveyor_construct(src.loc)
 			C.id = id
 			transfer_fingerprints_to(C)
-		user << "<span class='notice'>You remove the conveyor belt.</span>"
+		to_chat(usr,"<span class='notice'>You remove the conveyor belt.</span>")
 		qdel(src)
 
 	else if(istype(I, /obj/item/weapon/wrench))
 		if(!(stat & BROKEN))
 			playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-			//setDir(turn(dir,-45)) //No such proc
 			dir = turn(dir,-45)
 			update_move_direction()
-			user << "<span class='notice'>You rotate [src].</span>"
+			to_chat(user, "<span class='notice'>You rotate [src].</span>")
 
 	else if(user.a_intent != "harm")
 		if(user.drop_item())
-			I.loc = src.loc
+			I.forceMove(loc)
 	else
 		return ..()
 
@@ -220,10 +219,11 @@
 		id = newid
 	update()
 
-	conveyors = list()
-	for(var/obj/machinery/conveyor/C in machines)
-		if(C.id == id)
-			conveyors += C
+	spawn(5)
+		conveyors = list()
+		for(var/obj/machinery/conveyor/C in machines)
+			if(C.id == id)
+				conveyors += C
 
 // update the icon depending on the position
 
@@ -250,7 +250,7 @@
 		CHECK_TICK
 
 /obj/machinery/conveyor_switch/oneway
-	convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)
+	convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.) - Cargo uses a reverse belt.
 
 // attack with hand, switch position
 /obj/machinery/conveyor_switch/attack_hand(mob/user)
@@ -288,7 +288,7 @@
 		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
 		C.id = id
 		transfer_fingerprints_to(C)
-		user << "<span class='notice'>You deattach the conveyor switch.</span>"
+		to_chat(user,"<span class='notice'>You deattach the conveyor switch.</span>")
 		qdel(src)
 
 	else if(istype(I, /obj/item/device/multitool))
@@ -325,7 +325,7 @@
 /obj/item/conveyor_construct/attackby(obj/item/I, mob/user, params)
 	..()
 	if(istype(I, /obj/item/conveyor_switch_construct))
-		user << "<span class='notice'>You link the switch to the conveyor belt assembly.</span>"
+		to_chat(user, "<span class='notice'>You link the switch to the conveyor belt assembly.</span>")
 		var/obj/item/conveyor_switch_construct/C = I
 		id = C.id
 
@@ -334,7 +334,7 @@
 		return
 	var/cdir = get_dir(A, user)
 	if(A == user.loc)
-		user << "<span class='notice'>You cannot place a conveyor belt under yourself.</span>"
+		to_chat(user, "<span class='notice'>You cannot place a conveyor belt under yourself.</span>")
 		return
 	var/obj/machinery/conveyor/C = new/obj/machinery/conveyor(A,cdir)
 	C.id = id
@@ -362,7 +362,7 @@
 			found = 1
 			break
 	if(!found)
-		user << "\icon[src]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>"
+		to_chat(usr, "\icon[src]<span class=notice>The conveyor switch did not detect any linked conveyor belts in range.</span>")
 		return
 	var/obj/machinery/conveyor_switch/NC = new/obj/machinery/conveyor_switch(A, id)
 	transfer_fingerprints_to(NC)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -122,6 +122,8 @@
 				step(A,movedir)
 		CHECK_TICK
 
+
+
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/crowbar))
@@ -145,6 +147,7 @@
 			I.loc = src.loc
 	else
 		return ..()
+
 
 // attack with hand, move pulled object onto conveyor
 /obj/machinery/conveyor/attack_hand(mob/user as mob)
@@ -219,15 +222,9 @@
 
 	spawn(5)		// allow map load
 		conveyors = list()
-		for(var/obj/machinery/conveyor/C in machines) //This works if it's: `C in world` , but that's bad practice. Best to try to fix it.
+		for(var/obj/machinery/conveyor/C in machines)
 			if(C.id == id)
-				conveyors += C  //Moving this to initialise to see if it gets around the bug... do we need the spawn thing? Let's find out.
-
-/*/obj/machinery/conveyor_switch/initialize() //This whole thing is new
-	conveyors = list()
-	for(var/obj/machinery/conveyor/C in world) //This works if it's: `C in world` , but that's bad practice. Best to try to fix it so it's in machines
-		if(C.id == id)
-			conveyors += C*/
+				conveyors += C
 
 
 // update the icon depending on the position
@@ -313,6 +310,16 @@
 		user << "<span class='notice'>You deattach the conveyor switch.</span>"
 		qdel(src)
 
+	else if(istype(I, /obj/item/device/multitool))
+		update_multitool_menu(user)
+		return 1
+
+
+/obj/machinery/conveyor_switch/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
+	return {"
+ 	<ul>
+ 	<li><b>One direction only:</b> <a href='?src=\ref[src];toggle_logic=1'>[convdir ? "On" : "Off"]</a></li>
+ 	</ul>"}
 
 
 //

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -220,12 +220,10 @@
 		id = newid
 	update()
 
-	spawn(5)		// allow map load
-		conveyors = list()
-		for(var/obj/machinery/conveyor/C in machines)
-			if(C.id == id)
-				conveyors += C
-
+	conveyors = list()
+	for(var/obj/machinery/conveyor/C in machines)
+		if(C.id == id)
+			conveyors += C
 
 // update the icon depending on the position
 
@@ -253,7 +251,6 @@
 
 /obj/machinery/conveyor_switch/oneway
 	convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)
-	desc = "A conveyor control switch. It appears to only go in one direction."
 
 // attack with hand, switch position
 /obj/machinery/conveyor_switch/attack_hand(mob/user)
@@ -286,22 +283,6 @@
 		CHECK_TICK
 
 
-// attack with hand, switch position
-/obj/machinery/conveyor_switch/oneway/attack_hand(mob/user)
-	if(position == 0)
-		position = convdir
-	else
-		position = 0
-
-	operated = 1
-	update()
-
-	// find any switches with same id as this one, and set their positions to match us
-	for(var/obj/machinery/conveyor_switch/S in world)
-		if(S.id == src.id)
-			S.position = position
-			S.update()
-
 /obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/crowbar))
 		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
@@ -315,6 +296,12 @@
 		return 1
 
 
+/obj/machinery/conveyor_switch/multitool_topic(var/mob/user,var/list/href_list,var/obj/O)
+	..()
+	if("toggle_logic" in href_list)
+		convdir = !convdir //reverses?
+
+
 /obj/machinery/conveyor_switch/multitool_menu(var/mob/user, var/obj/item/device/multitool/P)
 	return {"
  	<ul>
@@ -322,9 +309,10 @@
  	</ul>"}
 
 
+
 //
 // CONVEYOR CONSTRUCTION STARTS HERE
-//   All new here.
+//
 
 /obj/item/conveyor_construct
 	icon = 'icons/obj/recycling.dmi'
@@ -382,4 +370,4 @@
 
 /obj/item/weapon/paper/conveyor
 	name = "paper- 'Nano-it-up U-build series, #9: Build your very own conveyor belt, in SPACE'"
-	info = "<h1>Congratulations!</h1><p>You are now the proud owner of the best conveyor set available for space mail order! We at Nano-it-up know you love to prepare your own structures without wasting time, so we have devised a special streamlined assembly procedure that puts all other mail-order products to shame!</p><p>Firstly, you need to link the conveyor switch assembly to each of the conveyor belt assemblies. After doing so, you simply need to install the belt assemblies onto the floor, et voila, belt built. Our special Nano-it-up smart switch will detected any linked assemblies as far as the eye can see! This convenience, you can only have it when you Nano-it-up. Stay nano!</p>"
+	info = "<h1>Congratulations!</h1><p>You are now the proud owner of the best conveyor set available for space mail order! We at Nano-it-up know you love to prepare your own structures without wasting time, so we have devised a special streamlined assembly procedure that puts all other mail-order products to shame!</p><p>Firstly, you need to link the conveyor switch assembly to each of the conveyor belt assemblies. After doing so, you simply need to install the belt assemblies onto the floor, et voila, belt built. Our special Nano-it-up smart switch will detected any linked assemblies as far as the eye can see! </p><p> Set single directional switches by using your multitool on the switch after you've installed the switch assembly.</p><p> This convenience, you can only have it when you Nano-it-up. Stay nano!</p>"

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -217,17 +217,17 @@
 		id = newid
 	update()
 
-/*	spawn(5)		// allow map load
+	spawn(5)		// allow map load
 		conveyors = list()
 		for(var/obj/machinery/conveyor/C in machines) //This works if it's: `C in world` , but that's bad practice. Best to try to fix it.
 			if(C.id == id)
-				conveyors += C */ //Moving this to initialise to see if it gets around the bug... do we need the spawn thing? Let's find out.
+				conveyors += C  //Moving this to initialise to see if it gets around the bug... do we need the spawn thing? Let's find out.
 
-/obj/machinery/conveyor_switch/initialize() //This whole thing is new
+/*/obj/machinery/conveyor_switch/initialize() //This whole thing is new
 	conveyors = list()
-	for(var/obj/machinery/conveyor/C in machines)
+	for(var/obj/machinery/conveyor/C in world) //This works if it's: `C in world` , but that's bad practice. Best to try to fix it so it's in machines
 		if(C.id == id)
-			conveyors += C
+			conveyors += C*/
 
 
 // update the icon depending on the position

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -713,3 +713,19 @@
 	materials = list(MAT_GLASS = 750, MAT_METAL = 250)
 	build_path = /obj/item/weapon/circuitboard/vendor
 	category = list("initial", "Electronics")
+
+/datum/design/conveyor_belt
+	name = "Conveyor belt"
+	id = "conveyor_belt"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000)
+	build_path = /obj/item/conveyor_construct
+	category = list("initial", "Construction")
+
+/datum/design/conveyor_switch
+	name = "Conveyor belt switch"
+	id = "conveyor_switch"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
+	build_path = /obj/item/conveyor_switch_construct
+	category = list("initial", "Construction")


### PR DESCRIPTION
Ports TG conveyors.

You can now order new conveyor sections through the cargo console, and print them from an autolathe, as well as the levers.

To use new sections, use the lever on every section to link the IDs, then place the sections, and lever. Lever cannot be placed without linked conveyor segments.
Also possible to crowbar up segments and levers, and use wrench to change direction, including corners. Corners are a bit dodgy though (one way), but that's due to the nature of diagonals in the engine.

Issues:
Spawn(5) seems required for initial map placement. 
Construct levers don't like being populated in initialize().

:cl:GeneralChaos
rscadd: Ability to place and remove conveyor belts and levers.
/:cl: