### PR TITLE
Atmos Grenade Balance

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -483,7 +483,8 @@ var/list/uplink_items = list()
 	desc = "A box of two (2) grenades that wreak havoc with the atmosphere of the target area. Capable of engulfing a large area in lit plasma, or N2O. Deploy with extreme caution!"
 	reference = "AGG"
 	item = /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades
-	cost = 6
+	cost = 8
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Grenades and Implanter Kit"
@@ -791,7 +792,7 @@ var/list/uplink_items = list()
 	reference = "CHHUD"
 	item = /obj/item/clothing/glasses/hud/security/chameleon
 	cost = 2
-	
+
 /datum/uplink_item/stealthy_weapons/chameleonflag
 	name = "Chameleon Flag"
 	desc = "A flag that can be disguised as any other known flag. There is a heat sensitive bomb loaded into the pole that will be detonated if the flag is lit on fire."

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -483,8 +483,7 @@ var/list/uplink_items = list()
 	desc = "A box of two (2) grenades that wreak havoc with the atmosphere of the target area. Capable of engulfing a large area in lit plasma, or N2O. Deploy with extreme caution!"
 	reference = "AGG"
 	item = /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades
-	cost = 8
-	gamemodes = list(/datum/game_mode/nuclear)
+	cost = 11
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Grenades and Implanter Kit"


### PR DESCRIPTION
Atmos grenades are a bit strong for regular traitor, especially with how much damage fire does now and the fact it melts walls.

Cost increased to 8 and moved to nuclear only.


:cl: Fox McCloud
tweak: Atmos grenades cost increased from 6 to 11
/:cl: