### PR TITLE
Fix for Riot Foam Darts

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -550,7 +550,7 @@ var/list/uplink_items = list()
 	name = "Box of Riot Darts"
 	desc = "A box of 40 Donksoft foam riot darts, for reloading any compatible foam dart gun. Don't forget to share!"
 	reference = "FOAM"
-	item = /obj/item/ammo_box/foambox/riot
+	item = /obj/item/ammo_box/riot_foambox
 	cost = 2
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
@@ -791,7 +791,7 @@ var/list/uplink_items = list()
 	reference = "CHHUD"
 	item = /obj/item/clothing/glasses/hud/security/chameleon
 	cost = 2
-	
+
 /datum/uplink_item/stealthy_weapons/chameleonflag
 	name = "Chameleon Flag"
 	desc = "A flag that can be disguised as any other known flag. There is a heat sensitive bomb loaded into the pole that will be detonated if the flag is lit on fire."

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -346,11 +346,53 @@
 		to_chat(user, "<span class='notice'>You remove [FD.pen] from [src].</span>")
 		FD.pen = null
 
-/obj/item/ammo_casing/caseless/foam_dart/riot
+/obj/item/ammo_casing/caseless/riot_foam_dart
 	name = "riot foam dart"
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
+	caliber = "foam_force"
+	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foamdart_riot"
+	projectile_type = /obj/item/projectile/bullet/reusable/riot_foam_dart
+	var/modified = 0
+
+/obj/item/ammo_casing/caseless/riot_foam_dart/update_icon()
+	..()
+	if(modified)
+		icon_state = "foamdart_empty"
+		desc = "Whose smart idea was it to use toys as crowd control? ... Although, this one doesn't look too safe."
+		if(BB)
+			BB.icon_state = "foamdart_empty"
+	else
+		icon_state = "foamdart_riot"
+		desc = "Whose smart idea was it to use toys as crowd control?"
+		if(BB)
+			BB.icon_state = "foamdart_empty"
+
+/obj/item/ammo_casing/caseless/riot_foam_dart/attackby(obj/item/A, mob/user, params)
+	..()
+	var/obj/item/projectile/bullet/reusable/riot_foam_dart/FD = BB
+	if(istype(A, /obj/item/weapon/screwdriver) && !modified)
+		modified = 1
+		FD.damage_type = BRUTE
+		update_icon()
+	else if((istype(A, /obj/item/weapon/pen)) && modified && !FD.pen)
+		if(!user.unEquip(A))
+			return
+		A.loc = FD
+		FD.pen = A
+		FD.damage = 5
+		FD.nodamage = 0
+		to_chat(user, "<span class='notice'>You insert [A] into [src].</span>")
+	return
+
+/obj/item/ammo_casing/caseless/riot_foam_dart/attack_self(mob/living/user)
+	var/obj/item/projectile/bullet/reusable/riot_foam_dart/FD = BB
+	if(FD.pen)
+		FD.damage = initial(FD.damage)
+		FD.nodamage = initial(FD.nodamage)
+		user.put_in_hands(FD.pen)
+		to_chat(user, "<span class='notice'>You remove [FD.pen] from [src].</span>")
+		FD.pen = null
 
 /obj/item/ammo_casing/shotgun/dart/assassination
 	desc = "A specialist shotgun dart designed to inncapacitate and kill the target over time, so you can get very far away from your target"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -98,9 +98,12 @@
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 40
 
-/obj/item/ammo_box/foambox/riot
+/obj/item/ammo_box/riot_foambox
+	name = "ammo box (Riot Foam Darts)"
+	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foambox_riot"
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/riot_foam_dart
+	max_ammo = 40
 
 /obj/item/ammo_box/caps
 	name = "speed loader (caps)"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -381,7 +381,7 @@
 	icon_state = "smg9mm-[round(ammo_count(),5)]"
 
 /obj/item/ammo_box/magazine/toy/smg/riot
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/riot_foam_dart
 
 /obj/item/ammo_box/magazine/toy/pistol
 	name = "foam force pistol magazine"
@@ -390,11 +390,11 @@
 	multiple_sprites = 2
 
 /obj/item/ammo_box/magazine/toy/pistol/riot
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/riot_foam_dart
 
 /obj/item/ammo_box/magazine/toy/smgm45
 	name = "donksoft SMG magazine"
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/riot_foam_dart
 	max_ammo = 20
 
 /obj/item/ammo_box/magazine/toy/smgm45/update_icon()
@@ -403,7 +403,7 @@
 
 /obj/item/ammo_box/magazine/toy/m762
 	name = "donksoft box magazine"
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	ammo_type = /obj/item/ammo_casing/caseless/riot_foam_dart
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/toy/m762/update_icon()

--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -59,8 +59,36 @@
 	pen = null
 	return ..()
 
-/obj/item/projectile/bullet/reusable/foam_dart/riot
+/obj/item/projectile/bullet/reusable/riot_foam_dart
 	name = "riot foam dart"
-	icon_state = "foamdart_riot"
-	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	desc = "I hope you're wearing eye protection."
+	damage = 0
 	stamina = 25
+	icon = 'icons/obj/guns/toy.dmi'
+	icon_state = "foamdart_riot"
+	ammo_type = /obj/item/ammo_casing/caseless/riot_foam_dart
+	range = 10
+	var/obj/item/weapon/pen/pen = null
+	edge = 0
+	embed = 0
+
+/obj/item/projectile/bullet/reusable/riot_foam_dart/handle_drop()
+	if(dropped)
+		return
+	dropped = 1
+	var/obj/item/ammo_casing/caseless/riot_foam_dart/newdart = new ammo_type(loc)
+	var/obj/item/ammo_casing/caseless/riot_foam_dart/old_dart = ammo_casing
+	newdart.modified = old_dart.modified
+	if(pen)
+		var/obj/item/projectile/bullet/reusable/riot_foam_dart/newdart_FD = newdart.BB
+		newdart_FD.pen = pen
+		pen.loc = newdart_FD
+		pen = null
+	newdart.BB.damage = damage
+	newdart.BB.nodamage = nodamage
+	newdart.BB.damage_type = damage_type
+	newdart.update_icon()
+
+/obj/item/projectile/bullet/reusable/riot_foam_dart/Destroy()
+	pen = null
+	return ..()


### PR DESCRIPTION
- Separates Riot Foam darts from normal foam darts so they work
- Still lets you load pens into both riot foam darts and normal foam
darts