### PR TITLE
Fixes PMing Stealthmins

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -67,7 +67,7 @@
 	if(istext(whom))
 		if(cmptext(copytext(whom,1,2),"@"))
 			whom = findStealthKey(whom)
-		C = directory[C]
+		C = directory[whom]
 	else if(istype(whom,/client))
 		C = whom
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -76,7 +76,9 @@
 		if(ismob(C)) 		//Old stuff can feed-in mobs instead of clients
 			var/mob/M = C
 			C = M.client
-		cmd_admin_pm(C,null, href_list["type"])
+		if(!C) // Might be a stealthmin ID, so pass it in straight
+			C = href_list["priv_msg"]
+		cmd_admin_pm(C, null, href_list["type"])
 		return
 
 	if(href_list["irc_msg"])


### PR DESCRIPTION
Attempting to reply to a PM from an admin in stealth mode would *always* fail, causing the PM system to fall back to asking if you want to adminhelp. With this fix, players can actually PM stealthmins again.

Another thing broken for nearly a year.  :disappointed:

:cl:
bugfix: Fixed never being able to properly respond to a PM from a stealthed admin.
/:cl: