### PR TITLE
Fixes Golem & Swarmer Ghost Alerts

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -6,8 +6,7 @@
 	icon_state = "swarmer_unactivated"
 
 /obj/item/unactivated_swarmer/New()
-	var/image/alert_overlay = image('icons/mob/swarmer.dmi', "swarmer")
-	notify_ghosts("An unactivated swarmer has been created in [get_area(src)]!", enter_link = "<a href=?src=[UID()];ghostjoin=1>(Click to enter)</a>", source = src, alert_overlay = alert_overlay, attack_not_jump = 1)
+	notify_ghosts("An unactivated swarmer has been created in [get_area(src)]!", enter_link = "<a href=?src=[UID()];ghostjoin=1>(Click to enter)</a>", source = src, attack_not_jump = 1)
 	..()
 
 /obj/item/unactivated_swarmer/Topic(href, href_list)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -6,7 +6,8 @@
 	icon_state = "swarmer_unactivated"
 
 /obj/item/unactivated_swarmer/New()
-	notify_ghosts("An unactivated swarmer has been created in [get_area(src)]!", enter_link = "<a href=?src=[UID()];ghostjoin=1>(Click to enter)</a>", source = src, attack_not_jump = 1)
+	var/image/alert_overlay = image('icons/mob/swarmer.dmi', "swarmer")
+	notify_ghosts("An unactivated swarmer has been created in [get_area(src)]!", enter_link = "<a href=?src=[UID()];ghostjoin=1>(Click to enter)</a>", source = src, alert_overlay = alert_overlay, attack_not_jump = 1)
 	..()
 
 /obj/item/unactivated_swarmer/Topic(href, href_list)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -455,13 +455,15 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HARM)
 					A.attack_not_jump = attack_not_jump
 					A.jump_target = source
 					if(!alert_overlay)
-						var/old_layer = source.layer
-						source.layer = FLOAT_LAYER
-						A.overlays += source
-						source.layer = old_layer
-					else
-						alert_overlay.layer = FLOAT_LAYER
-						A.overlays += alert_overlay
+						if(source)
+							alert_overlay = image(source.icon, source.icon_state)
+						else
+							var/old_layer = source.layer
+							source.layer = FLOAT_LAYER
+							A.overlays += source
+							source.layer = old_layer
+					alert_overlay.layer = FLOAT_LAYER
+					A.overlays += alert_overlay
 
 /mob/proc/switch_to_camera(var/obj/machinery/camera/C)
 	if(!C.can_use() || stat || (get_dist(C, src) > 1 || machine != src || blinded || !canmove))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -457,13 +457,9 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HARM)
 					if(!alert_overlay)
 						if(source)
 							alert_overlay = image(source.icon, source.icon_state)
-						else
-							var/old_layer = source.layer
-							source.layer = FLOAT_LAYER
-							A.overlays += source
-							source.layer = old_layer
-					alert_overlay.layer = FLOAT_LAYER
-					A.overlays += alert_overlay
+					if(alert_overlay)
+						alert_overlay.layer = FLOAT_LAYER
+						A.overlays += alert_overlay
 
 /mob/proc/switch_to_camera(var/obj/machinery/camera/C)
 	if(!C.can_use() || stat || (get_dist(C, src) > 1 || machine != src || blinded || !canmove))

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -510,8 +510,7 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/obj/effect/golemrune/Z = new /obj/effect/golemrune
 	Z.forceMove(get_turf(holder.my_atom))
-	var/image/alert_overlay = image('icons/obj/rune.dmi', "golem")
-	notify_ghosts("Golem rune created in [get_area(Z)].", source = Z, alert_overlay = alert_overlay, attack_not_jump = 1)
+	notify_ghosts("Golem rune created in [get_area(Z)].", source = Z, attack_not_jump = 1)
 
 //Bluespace
 /datum/chemical_reaction/slimefloor2

--- a/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
+++ b/code/modules/reagents/oldchem/chemical_reaction/chemical_reaction_slime.dm
@@ -510,7 +510,8 @@
 	feedback_add_details("slime_cores_used","[type]")
 	var/obj/effect/golemrune/Z = new /obj/effect/golemrune
 	Z.forceMove(get_turf(holder.my_atom))
-	notify_ghosts("Golem rune created in [get_area(Z)].", source = Z)
+	var/image/alert_overlay = image('icons/obj/rune.dmi', "golem")
+	notify_ghosts("Golem rune created in [get_area(Z)].", source = Z, alert_overlay = alert_overlay, attack_not_jump = 1)
 
 //Bluespace
 /datum/chemical_reaction/slimefloor2


### PR DESCRIPTION
Currently, when swarmers or golems are created, ghosts see a dull gray box as an alert.

This PR changes these alerts so they actually show a picture of a swarmer, or golem rune.

Additionally, it makes it so that clicking the alert signs you up to play as the thing.
Rather than jumping you to where the unactivated swarmer is, and you then having to find it.

Image: http://i.imgur.com/LqfPCcE.png

:cl: Kyep
fix: Golem rune and swarmer creation notices now properly use their sprites. No more broken-looking gray boxes.
/:cl: