### PR TITLE
Makes the rnd console less prone to freezing

### DIFF
--- a/code/controllers/Processes/timer.dm
+++ b/code/controllers/Processes/timer.dm
@@ -79,6 +79,11 @@ var/global/datum/controller/process/timer/timer_master
 	return event.id
 
 /proc/deltimer(id)
+	if(id == 0)
+		// No event will correspond to an id of 0 - the timer does not exist
+		// Save us a possibly expensive iteration through the timer list
+		// This would probably be more efficient in general if we used an associative list instead
+		return 0
 	for(var/datum/timedevent/event in timer_master.processing_timers)
 		if(event.id == id)
 			qdel(event)


### PR DESCRIPTION
"wait_message" is now guaranteed to be unset provided that the timer
controller doesn't go down, and it'll be reset anyways by the `spawn` if
nothing runtimes in there

:cl:Crazylemon
fix: The R&D console should now no longer freeze on the "Syncing Database" message or whatever.
/:cl: