### PR TITLE
Map reader now yells when given bad path/empty file

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -43,6 +43,8 @@ var/global/dmm_suite/preloader/_preloader = new
 	if(isfile(tfile))
 		fname = "[tfile]"
 		tfile = file2text(tfile)
+		if(length(tfile) == 0)
+			throw EXCEPTION("Map path '[fname]' does not exist!")
 
 	if(!x_offset)
 		x_offset = 1


### PR DESCRIPTION
This was causing troubles earlier, making isolating the problem difficult - before, it silently failed, saying it didn't have correct bounds. Now, it will tell you exactly what the problem is.

No changelog because this is not a player-facing change.