### PR TITLE
Fixes Goonchat Scrolling When Pruning Old Messages

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -215,13 +215,7 @@ function output(message, flag) {
 		message = linkify(message);
 	}
 
-	opts.messageCount++;
-
-	//Pop the top message off if history limit reached
-	if (opts.messageCount >= opts.messageLimit) {
-		$messages.children('div.entry:first-child').remove();
-		opts.messageCount--; //I guess the count should only ever equal the limit
-	}
+	opts.messageCount++;	
 
 	//Actually append the message
 	var entry = document.createElement('div');
@@ -462,6 +456,20 @@ $(function() {
 		} else if (opts.noResponse) { //Previous ping attempt failed ohno
 			$('.connectionClosed[data-count="'+opts.noResponseCount+'"]:not(.restored)').addClass('restored').text('Your connection has been restored (probably)!');
 			opts.noResponse = false;
+		}
+		if (opts.messageCount > opts.messageLimit) { // Prune old messages beyond the message limit
+			var bodyHeight = $('body').height();
+			var messagesHeight = $messages.outerHeight();
+			var scrollPos = $(window).scrollTop();
+			var atBottom = (bodyHeight + scrollPos >= messagesHeight - opts.scrollSnapTolerance)
+
+			$messages.children().slice(0, opts.messageCount - opts.messageLimit).remove();
+			opts.messageCount = opts.messageLimit;
+			if (!atBottom) {
+				// If we weren't at the bottom, adjust scroll position to compensate for removed elements
+				var newPos = scrollPos - (messagesHeight - $messages.outerHeight())
+				$('body,html').scrollTop(newPos);
+			}
 		}
 	}, 2000); //2 seconds
 


### PR DESCRIPTION
Currently, Goonchat only keeps the most recent 2052 messages in the chat pane; once that limit is hit, every new message causes an old message to get deleted. Unfortunately, it *doesn't* adjust the scroll position to compensate for the now-missing element, which shifts everything up a bit. Once you're at the message limit, scrolling up to look at old messages will look something like this:
![2016-09-22_20-20-15](https://cloud.githubusercontent.com/assets/10916307/18770441/c5124468-8103-11e6-85d1-dc5a60674214.gif)
Now, imagine each of those numbers is a multi-line message that you're trying to read as it aggressively jumps up and out of the visible area.

Fortunately, it's not hard to adjust the scroll position to compensate for the now-missing elements, keeping you almost exactly where you should be. I say *almost* because...
![2016-09-22_18-50-02](https://cloud.githubusercontent.com/assets/10916307/18770483/633b73ee-8104-11e6-84f9-a4f4a0044b34.gif)
... subpixel positioning is a thing. Removing elements from the top of the window tends to result in a not-quite-exact number of pixels disappearing, and the scroll position just isn't accurate enough to handle that, so it sort of "drifts" every time elements are removed. To minimize its impact, old messages are no longer pruned every time a new message arrives, but rather pruned every 2 seconds, which should be infrequent enough to not interfere with reading old messages.

:cl:
bugfix: Fixed full chat panes scrolling unpredictably when trying to view old messages.
/:cl: