### PR TITLE
Fixes #5673 (Can not inject blood of compeltely drained bodies)

### DIFF
--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -231,6 +231,9 @@
 
 	var/datum/reagent/blood/injected = get_blood(container.reagents)
 
+	if (!istype(injected)) //Sanity..
+		return
+
 	if(species && species.flags & NO_BLOOD)
 		reagents.add_reagent("blood", amount, injected.data)
 		reagents.update_total()
@@ -238,8 +241,16 @@
 
 	var/datum/reagent/blood/our = get_blood(vessel)
 
-	if(!istype(injected) || !istype(our))
+	if(!istype(our)) // Do we not have blood?
+		vessel.add_reagent("blood", amount, injected.data) // This is only ran once, so we need to add back thier DNA.
+		vessel.update_total()
+		..()
+		our = get_blood(vessel) // Get the new blood.
+		our.data["blood_DNA"] = src.dna.unique_enzymes // Give it the proper DNA we had before
+		our.data["blood_type"] = src.dna.b_type  // Proper blood type.
+		our.data["donor"] = src // Without this, it'd be random each time it was extracted or Null.
 		return
+
 	if(blood_incompatible(injected.data["blood_type"],our.data["blood_type"]) )
 		reagents.add_reagent("toxin",amount * 0.5)
 		reagents.update_total()

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -242,12 +242,12 @@
 	var/datum/reagent/blood/our = get_blood(vessel)
 
 	if(!istype(our)) // Do we not have blood?
-		vessel.add_reagent("blood", amount, injected.data) // This is only ran once, so we need to add back thier DNA.
+		vessel.add_reagent("blood", amount, injected.data) // This is only ran once, so we need to add back their DNA.
 		vessel.update_total()
 		..()
 		our = get_blood(vessel) // Get the new blood.
-		our.data["blood_DNA"] = src.dna.unique_enzymes // Give it the proper DNA we had before
-		our.data["blood_type"] = src.dna.b_type  // Proper blood type.
+		our.data["blood_DNA"] = dna.unique_enzymes // Give it the proper DNA we had before (src.dna)
+		our.data["blood_type"] = dna.b_type  // Proper blood type.
 		our.data["donor"] = src // Without this, it'd be random each time it was extracted or Null.
 		return
 

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -231,7 +231,7 @@
 
 	var/datum/reagent/blood/injected = get_blood(container.reagents)
 
-	if (!istype(injected)) //Sanity..
+	if(!istype(injected)) //Sanity..
 		return
 
 	if(species && species.flags & NO_BLOOD)


### PR DESCRIPTION
🆑
bugfix: You can now inject blood into bodies that have been completely drained.
/🆑
(I'm fairly sure that's how the automatic changelog thingy works right?)

Should fix #5673, but it's a bit hard to tell as the only way I could test was spawning a test dummy and making it bleed out that way since they don't die, or using VV to remove their blood.

I also added in code to make sure their DNA and other data stays so they don't generate random DNA that would make the detective want to commit suicide or have a random blood type each time someone draws their blood or they get a cut.

(Sidenote: Git did not want to remove my changes from the master branch this time. Took a few tries to finally make it correct, also Baystation's IRC was a great help with this, and turns out they have the same issue.)