### PR TITLE
Fixes Machines Staying Set After Logout

### DIFF
--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,5 +1,6 @@
 /mob/Logout()
 	nanomanager.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
+	unset_machine()
 	player_list -= src
 	log_access("Logout: [key_name(src)]")
 	if(admin_datums[src.ckey])


### PR DESCRIPTION
Some machines (mostly consoles) set themselves as a mob's active machine to handle things like automatically updating their (non-Nano) UI or intercepting certain keypresses. These stay set after you log out, however, which can lead to some machines - most infamously, camera monitors - continuing to steal movement keypresses if you reconnect while using them, despite the UI no longer being present.

This makes mobs automatically unset their machine on logout (that is, a client detaching from the mob). This might sound abusable, but you can unset your machine at literally any time with Cancel Camera View already; this just does it for you automatically. This might even fix problems with other machines that I'm not even aware of!

:cl:
bugfix: Fixed camera monitors immobilizing you if you reconnect while using one.
/:cl: