### PR TITLE
Fixes Selecting Datums Through SDQL2

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -252,6 +252,11 @@
 			if(istype(d, type))
 				out += d
 
+	else if(location == world)
+		for(var/datum/d)
+			if(istype(d, type))
+				out += d
+
 	else
 		for(var/datum/d in location)
 			if(istype(d, type))


### PR DESCRIPTION
Turns out, using a `for` loop to pick all the datums `in world` doesn't work, but leaving out the `in world` (which defaults to searching in the world) *does* work. Thank you, BYOND.

:cl:
bugfix: Fixed selecting datum types through SDQL2 never returning any datums.
/:cl: