### PR TITLE
Fixes Doors Double-Moving

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -281,10 +281,9 @@
 
 /obj/machinery/door/Move(new_loc, new_dir)
 	var/turf/T = loc
-	..()
+	. = ..()
 	move_update_air(T)
 
-	. = ..()
 	if(width > 1)
 		if(dir in list(EAST, WEST))
 			bound_width = width * world.icon_size


### PR DESCRIPTION
Doors don't *usually* move, but when they do, they move twice. Most of the time, this doesn't actually do anything. If they're moving through space, however, each of those two movements will queue up another movement, and ~~each of *those* movements will queue up *another* two, and the door will continue doubling in speed until it hits something... or the server dies from trying to handle a door rapidly accelerating towards the speed of light.~~ only one of them will occur, because space move does more sanity checking than I anticipated. However, when multi-tile doors *try* to move, but *don't* move, the sanity checking fails, and they try exponentially harder (but fail) to move every half second, until the server can't handle all their attempts to move and grinds to a halt. This happens to fix that (though they still don't move for some reason).