### PR TITLE
Fixed Help intent 'Bump' swapping mobs on tables with mobs on the floor

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -194,10 +194,8 @@
 		//it might be 'bubblewrapping' given that this rhymes with 'hugboxing'
 		if((tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || restrained()))
 			if((canmove && tmob.canmove) && (!tmob.buckled && !tmob.buckled_mob))
-			
-				if(locate(/obj/structure/table/, loc) && locate(/obj/structure/table/, tmob.loc) || !locate(/obj/structure/table/, loc) && !locate(/obj/structure/table/, tmob.loc))
+				if(!locate(/obj/structure/table/, loc) == !locate(/obj/structure/table/, tmob.loc))
 				//wont let them switch places if one is on a table and the other is not
-				
 					var/turf/oldloc = loc
 					loc = tmob.loc
 					tmob.loc = oldloc

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -194,14 +194,18 @@
 		//it might be 'bubblewrapping' given that this rhymes with 'hugboxing'
 		if((tmob.a_intent == I_HELP || tmob.restrained()) && (a_intent == I_HELP || restrained()))
 			if((canmove && tmob.canmove) && (!tmob.buckled && !tmob.buckled_mob))
-				var/turf/oldloc = loc
-				loc = tmob.loc
-				tmob.loc = oldloc
-				now_pushing = 0
-				for(var/mob/living/carbon/slime/slime in view(1,tmob))
-					if(slime.Victim == tmob)
-						slime.UpdateFeed()
-				return
+			
+				if(locate(/obj/structure/table/, loc) && locate(/obj/structure/table/, tmob.loc) || !locate(/obj/structure/table/, loc) && !locate(/obj/structure/table/, tmob.loc))
+				//wont let them switch places if one is on a table and the other is not
+				
+					var/turf/oldloc = loc
+					loc = tmob.loc
+					tmob.loc = oldloc
+					now_pushing = 0
+					for(var/mob/living/carbon/slime/slime in view(1,tmob))
+						if(slime.Victim == tmob)
+							slime.UpdateFeed()
+					return
 
 		if(ishuman(tmob) && (FAT in tmob.mutations))
 			if(prob(40) && !(FAT in src.mutations))


### PR DESCRIPTION
Currently a player on a table with help intent can 'bump' into a player on the floor, causing the player on the floor to be 'pushed past' onto the table.

This modification makes it so that even with help intent, a player on a table will 'bump' into a player on the ground as if he was on harm/grab/disarm intent.