### PR TITLE
Fixes Dual Location Objects with Grinder and Biogenerator

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -97,16 +97,17 @@
 	else if(processing)
 		to_chat(user, "<span class='warning'>The biogenerator is currently processing.</span>")
 	else if(istype(O, /obj/item/weapon/storage/bag/plants))
+		var/obj/item/weapon/storage/bag/plants/PB = O
 		var/i = 0
 		for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in contents)
 			i++
 		if(i >= max_items)
 			to_chat(user, "<span class='warning'>The biogenerator is already full! Activate it.</span>")
 		else
-			for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in O.contents)
+			for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in PB.contents)
 				if(i >= max_items)
 					break
-				G.forceMove(src)
+				PB.remove_from_storage(G, src)
 				i++
 			if(i < max_items)
 				to_chat(user, "<span class='info'>You empty the plant bag into the biogenerator.</span>")

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -829,7 +829,6 @@
 
 
 		//All types that you can put into the grinder to transfer the reagents to the beaker. !Put all recipes above this.!
-		/obj/item/weapon/reagent_containers/food/pill = list(),
 		/obj/item/weapon/reagent_containers/food = list(),
 		/obj/item/weapon/reagent_containers/honeycomb = list()
 	)
@@ -895,19 +894,18 @@
 		to_chat(usr, "<span class='warning'>The machine cannot hold anymore items.</span>")
 		return 1
 
-	//Fill machine with the plantbag!
+	//Fill machine with a plantbag!
 	if(istype(O, /obj/item/weapon/storage/bag/plants))
-
-		for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in O.contents)
-			O.contents -= G
-			G.forceMove(src)
+		var/obj/item/weapon/storage/bag/plants/PB = O
+		for(var/obj/item/weapon/reagent_containers/food/snacks/grown/G in PB.contents)
+			PB.remove_from_storage(G, src)
 			holdingitems += G
 			if(holdingitems && holdingitems.len >= limit) //Sanity checking so the blender doesn't overfill
 				to_chat(user, "<span class='notice>You fill the All-In-One grinder to the brim.</span>")
 				break
 
-		if(!O.contents.len)
-			to_chat(user, "<span class='notice'>You empty the plant bag into the All-In-One grinder.</span>")
+		if(!PB.contents.len)
+			to_chat(user, "<span class='notice'>You empty [PB] into the All-In-One grinder.</span>")
 
 		updateUsrDialog()
 		return 0


### PR DESCRIPTION
Sometimes, when you load objects from a storage bag into the bio-generator or a grinder, the object will hang in storage--or worse, hang on your screen--usually these go away when you grind up the object, but sometimes they persist there, stuck.

This is what happens when you don't use the proper proc for something..

:cl: Fox McCloud
fix: Fixes items being in two locations at once when loading things into the bio-generator or reagent grinder.
/:cl: