### PR TITLE
De-snowflakes Dronespeak

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -559,6 +559,17 @@
 	flags = RESTRICTED | HIVEMIND
 	drone_only = 1
 	follow = 1
+	
+/datum/language/drone
+	name = "Drone"
+	desc = "An encrypted stream of data converted to speech patterns."
+	speech_verb = "states"
+	ask_verb = "queries"
+	exclaim_verb = "declares"
+	key = "]"
+	flags = RESTRICTED
+	follow = 1
+	syllables = list ("beep", "boop")
 
 /datum/language/swarmer
 	name = "Swarmer"

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -13,9 +13,10 @@
 	lawupdate = 0
 	density = 0
 	req_access = list(access_engine, access_robotics)
-	local_transmit = 1
 	ventcrawler = 2
 	magpulse = 1
+	
+	default_language = "Drone"
 
 	// We need to keep track of a few module items so we don't need to do list operations
 	// every time we need them. These get set in New() after the module is chosen.
@@ -39,7 +40,9 @@
 	..()
 
 	remove_language("Robot Talk")
+	remove_language("Galactic Common")
 	add_language("Drone Talk", 1)
+	add_language("Drone", 1)
 
 	if(camera && "Robots" in camera.network)
 		camera.network.Add("Engineering")
@@ -284,7 +287,7 @@
 	full_law_reset()
 	to_chat(src, "<br><b>You are a maintenance drone, a tiny-brained robotic repair machine</b>.")
 	to_chat(src, "You have no individual will, no personality, and no drives or urges other than your laws.")
-	to_chat(src, "Use <b>;</b> to talk to other drones, and <b>say</b> to speak silently to your nearby fellows.")
+	to_chat(src, "Use <b>:d</b> to talk to other drones, and <b>say</b> to speak silently in a language only your fellows understand.")
 	to_chat(src, "Remember, you are <b>lawed against interference with the crew</b>. Also remember, <b>you DO NOT take orders from the AI.</b>")
 	to_chat(src, "<b>Don't invade their worksites, don't steal their resources, don't tell them about the changeling in the toilets.</b>")
 	to_chat(src, "<b>Make sure crew members do not notice you.</b>.")

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -43,6 +43,10 @@
 	remove_language("Galactic Common")
 	add_language("Drone Talk", 1)
 	add_language("Drone", 1)
+	
+	// Disable the microphone wire on Drones
+	if(radio)
+		radio.wires.CutWireIndex(WIRE_TRANSMIT)
 
 	if(camera && "Robots" in camera.network)
 		camera.network.Add("Engineering")

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -1,43 +1,11 @@
-/mob/living/silicon/robot/drone/say(var/message)
-	if(local_transmit)
-		if(src.client)
-			if(client.prefs.muted & MUTE_IC)
-				to_chat(src, "You cannot send IC messages (muted).")
-				return 0
-			if(src.client.handle_spam_prevention(message,MUTE_IC))
-				return 0
-
-		message = sanitize(message)
-
-		if(stat == 2)
-			return say_dead(message)
-
-		if(copytext(message,1,2) == "*")
-			return emote(copytext(message,2))
-
-		if(copytext(message,1,2) == ";")
-			var/datum/language/L = all_languages["Drone Talk"]
-			if(istype(L))
-				return L.broadcast(src,trim(copytext(message,2)))
-
-		//Must be concious to speak
-		if(stat)
-			return 0
-
-		var/list/listeners = hearers(5,src)
-		listeners |= src
-
-		for(var/mob/living/silicon/D in listeners)
-			if(D.client && D.local_transmit)
-				to_chat(D, "<b>[src]</b> transmits, \"[message]\"")
-
-		for(var/mob/M in player_list)
-			if(istype(M, /mob/new_player))
-				continue
-			else if(M.stat == 2 && M.client && M.client.prefs.toggles & CHAT_GHOSTEARS)
-				to_chat(M, "<b>[src]</b> transmits, \"[message]\"")
-		return 1
-	return ..(message, 0)
+/mob/living/silicon/robot/drone/say(var/message, var/datum/language/speaking = null)			
+	if(!speaking)
+		speaking = parse_language(message)
+		if(!speaking)
+			speaking = istype(get_default_language(), /datum/language) ? get_default_language() : all_languages[get_default_language()]
+			message = speaking.key + " " + message; // Prepend key to prevent the message from getting trimmed
+	if(speaking)
+		return ..()
 
 /mob/living/silicon/robot/drone/whisper_say(var/message, var/datum/language/speaking = null, var/alt_name="", var/verb="whispers")
 	say(message) //drones do not get to whisper, only speak normally

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -32,7 +32,6 @@
 	var/sec_hud = DATA_HUD_SECURITY_ADVANCED //Determines the sec hud to use
 	var/d_hud = DATA_HUD_DIAGNOSTIC //There is only one kind of diag hud
 
-	var/local_transmit //If set, can only speak to others of the same type within a short range.
 	var/obj/item/device/radio/common_radio
 
 /mob/living/silicon/New()


### PR DESCRIPTION
This removes the snowflaked say() code from Drones, and instead gives them their own language only Drones (and mobs with universal_speak, which includes robots) can understand.

**Pros:**
- Dronespeak is no longer snowflaked.
- Drones now have more control over their language. They can properly set a default language.
- Other mobs will now hear "beep boop beep" (or a variant thereof) when drones speak.

**Cons:**
- Drones can now be understood by certain mobs with universal_speak.

I personally think the pros outweigh the cons here, especially because drones can be warned by an admin if they start communicating actively with robots. Let me know what you think though.

Fixes https://github.com/ParadiseSS13/Paradise/issues/5271.

🆑
tweak: Drones now have their own language only they (and mobs that can understand every language) can understand. 
/🆑