### PR TITLE
Drone emote fix

### DIFF
--- a/code/game/objects/items/mountable_frames/lights.dm
+++ b/code/game/objects/items/mountable_frames/lights.dm
@@ -11,7 +11,7 @@
 	playsound(get_turf(src), 'sound/machines/click.ogg', 75, 1)
 	var/constrdir = user.dir
 	var/constrloc = get_turf(user)
-	if(!do_after(user, 30, target = src))
+	if(!do_after(user, 30, target = on_wall))
 		return
 	var/obj/machinery/light_construct/newlight
 	switch(fixture_type)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -283,8 +283,14 @@ proc/get_radio_key_from_channel(var/channel)
 /mob/living/proc/GetVoice()
 	return name
 
-/mob/living/emote(var/act, var/type, var/message) //emote code is terrible, this is so that anything that isn't
-	if(stat)	return 0                          //already snowflaked to shit can call the parent and handle emoting sanely
+/mob/living/emote(var/act, var/type, var/message) //emote code is terrible, this is so that anything that isn't already snowflaked to shit can call the parent and handle emoting sanely
+	if(client)
+		if(client.prefs.muted & MUTE_IC)
+			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
+			return
+			
+	if(stat)									 
+		return 0
 
 	if(..(act, type, message))
 		return 1

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -1,4 +1,7 @@
-/mob/living/silicon/robot/drone/say(var/message, var/datum/language/speaking = null)			
+/mob/living/silicon/robot/drone/say(var/message, var/datum/language/speaking = null)
+	if(copytext(message, 1, 2) == "*")
+		return emote(copytext(message, 2))
+		
 	if(!speaking)
 		speaking = parse_language(message)
 		if(!speaking)


### PR DESCRIPTION
Turns out drones could no longer emote properly without it explicitly being put in their /say override due to the language being set. This should fix that.

Also fixes light fixture construction not having a progress bar.