### PR TITLE
Fixes #5778 - animal self-attacks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -199,6 +199,9 @@
 			FindTarget()
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
+	if(target == src)
+		to_chat(src,"Why attack yourself?")
+		return
 	target.attack_animal(src)
 
 /mob/living/simple_animal/hostile/proc/Aggro()


### PR DESCRIPTION
Problem:
- Player_controlled simple_animals frequently end up accidentally attacking themselves, since any self-click on anything in their tile is interpreted as a click on them
- They also have no help intent, so all of these clicks translate into attacks
- They also have no ability to heal themselves, so these attacks do permanent damage on mobs which usually have quite low health pools anyway

This PR stops you accidentally attacking yourself when playing a simple_animal.
Where, before, clicking anything in your own tile (such as a window, to attack it) would accidentally attack yourself, now, you just get a "Why attack yourself?" text notice.

🆑 Kyep
bugfix: Clicking yourself, or any other atom on your square, as a simple_animal, no longer attacks yourself. Instead, it produces an alert, so you know what is going on.
/🆑