### PR TITLE
Scrubbers now respect air alarm settings.

### DIFF
--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -213,7 +213,7 @@
 	var/datum/gas_mixture/environment = tile.return_air()
 
 	if(scrubbing)
-		if((environment.toxins>0.001) || (environment.carbon_dioxide>0.001) || (environment.trace_gases.len>0))
+		if((scrub_O2 && environment.oxygen>0.001) || (scrub_N2 && environment.nitrogen>0.001) || (scrub_CO2 && environment.carbon_dioxide>0.001) || (scrub_Toxins && environment.toxins>0.001) || (environment.trace_gases.len>0))
 			var/transfer_moles = min(1, volume_rate/environment.volume)*environment.total_moles()
 
 			//Take a gas sample


### PR DESCRIPTION
Scrubbers only worked when there was CO2, Toxins, or trace gasses in the
atmosphere, ignoring settings on the Air Alarm. 
Whenever a Vox Room was build, scrubbers would not function properly and leave O2 in the atmosphere. NT CC gave us knockoff brands scrubbers, those cheapskates. 
This commit fixes that and makes the scrubber respect the settings.

🆑 Scribblon
bugfix: Fixes scrubbers only scrubbing for toxins, co2 and trace gasses, now respecting Air Alarm settings.
/🆑