### PR TITLE
Pressure limit on disposal units

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -255,20 +255,20 @@
 /obj/machinery/disposal/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/data[0]
 
-	var/pressure = 100 * air_contents.return_pressure() / (SEND_PRESSURE)
+	var/pressure = Clamp(100* air_contents.return_pressure() / (SEND_PRESSURE), 0, 100)
 	var/pressure_round = round(pressure,1)
 
 	data["isAI"] = isAI(user)
 	data["flushing"] = flush
 	data["mode"] = mode
 	if(mode <= 0)
-		data["pumpstatus"] = ""
+		data["pumpstatus"] = "N/A"
 	else if(mode == 1)
-		data["pumpstatus"] = "(pressurizing)"
+		data["pumpstatus"] = "Pressurizing"
 	else if(mode == 2)
-		data["pumpstatus"] = "(ready)"
+		data["pumpstatus"] = "Ready"
 	else
-		data["pumpstatus"] = "(idle)"
+		data["pumpstatus"] = "Idle"
 	data["pressure"] = pressure_round
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/nano/templates/disposal_bin.tmpl
+++ b/nano/templates/disposal_bin.tmpl
@@ -31,6 +31,13 @@ Used In File(s): \code\modules\recycling\disposal.dm
 	<div class="itemContent">
 		{{:helper.link('On', 'gear', {'pump' : 1}, data.mode > 0 ? 'selected' : '')}}
 		{{:helper.link('Off', 'gear', {'pump' : 0}, data.mode <= 0 ? 'selected' : '')}}
+	</div>
+</div>
+<div class="item">
+	<div class="itemLabel">
+		Pump Status:
+	</div>
+	<div class="itemContent">
 		{{:data.pumpstatus}}
 	</div>
 </div>


### PR DESCRIPTION
Disposal units no longer say they're 117% pressurized.

Also makes a super minor change to the disposal UI so the pressure state's on the same line, as that's bothered me since I implemented the UI for it.

🆑 Markolie
bugfix: Disposals will no longer pressurize above 100%.
/🆑