### PR TITLE
Fix for pAI Atmosphere Sensor

### DIFF
--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -547,8 +547,7 @@
 		else
 			var/datum/gas_mixture/env = T.return_air()
 			data["reading"] = 1
-			var/pres = env.return_pressure() * 10
-			data["pressure"] = "[round(pres/10)].[pres%10]"
+			data["pressure"] = env.return_pressure()
 			data["temperature"] = round(env.temperature)
 			data["temperatureC"] = round(env.temperature-T0C)
 


### PR DESCRIPTION
The problem was that in the previous code, data["pressure"] was stored as a String to round it. While NanoUI was programmed to use helper.smoothRound() on that again which didn't like the pushed String Object in data["pressure"].
Fix: As all data are stored as numbers in the module and rounded in the UI, the fix chosen is to stay in that convention. Meaning: making data["pressure"] a number again and let NanoUI:helper.smoothRound() do the rounding.

Partial fix to #5467 , fixes the broken atmosphere sensor.

🆑 Scribblon
bugfix: pAI Atmosphere Sensor fixed.
/🆑