### PR TITLE
Fix Comic Sans HTML parsing

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -142,7 +142,7 @@
 				message = uppertext(message)
 				verb = "yells loudly"
 
-	if(locate(/obj/item/organ/internal/cyberimp/brain/clown_voice) in internal_organs)
+	if((COMIC in mutations) || (locate(/obj/item/organ/internal/cyberimp/brain/clown_voice) in internal_organs))
 		message = "<span class='sans'>[message]</span>"
 
 	returns[1] = message

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -80,9 +80,6 @@ proc/get_radio_key_from_channel(var/channel)
 		verb = "stammers"
 		speech_problem_flag = 1
 
-	if(COMIC in mutations)
-		message = "<span class='sans'>[message]</span>"
-
 	if(!IsVocal())
 		message = ""
 		speech_problem_flag = 1

--- a/nano/templates/chem_dispenser.tmpl
+++ b/nano/templates/chem_dispenser.tmpl
@@ -78,13 +78,7 @@ Used In File(s): \code\modules\reagents\Chemistry-Machinery.dm
 					</div>
 					<div style="height:2px"></div> <!-- This is necessary to prevent the link margins from hitting each other and causing weird things to happen. It's essentialy a smaller <br> tag. -->
 				{{empty}}
-					<span class="bad">
-						{{if data.glass}}
-							Glass
-						{{else}}
-							Beaker
-						{{/if}}
-						is empty
+					<span class="bad">{{if data.glass}}Glass{{else}}Beaker{{/if}} is empty
 					</span>
 				{{/for}}
 			{{else}}

--- a/nano/templates/chem_dispenser.tmpl
+++ b/nano/templates/chem_dispenser.tmpl
@@ -89,13 +89,7 @@ Used In File(s): \code\modules\reagents\Chemistry-Machinery.dm
 				{{/for}}
 			{{else}}
 				<span class="average"><i>
-					No
-					{{if data.glass}}
-						Glass
-					{{else}}
-						Beaker
-					{{/if}}
-					loaded
+					No {{if data.glass}}Glass{{else}}Beaker{{/if}} loaded
 				</i></span>
 			{{/if}}
 		</div>


### PR DESCRIPTION
I moved the mutations check to /human/say() so the sans HTML no longer gets stammered/stuttered. Shouldn't prove to be an issue as humans are really only the one to ever have the sans mutation.

Also fixes the chem dispenser "no beaker loaded" not having any spaces.

🆑 Markolie
bugfix: A person with the Comic Sans mutation stuttering will no longer output HTML.
/🆑