### PR TITLE
Fix up a number of ID checks

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -60,7 +60,7 @@
 	Sound(message_sound)
 	Log(message, message_title)
 
-datum/announcement/proc/Message(message as text, message_title as text)
+/datum/announcement/proc/Message(message as text, message_title as text)
 	for(var/mob/M in player_list)
 		if(!istype(M,/mob/new_player) && !isdeaf(M))
 			to_chat(M, "<h2 class='alert'>[title]</h2>")
@@ -72,14 +72,14 @@ datum/announcement/proc/Message(message as text, message_title as text)
 	to_chat(world, "<b><font size=3><font color=red>[message_title]</font color></font></b>")
 	to_chat(world, "<b><font size=3>[message]</font size></font></b>")
 
-datum/announcement/priority/Message(message as text, message_title as text)
+/datum/announcement/priority/Message(message as text, message_title as text)
 	to_chat(world, "<h1 class='alert'>[message_title]</h1>")
 	to_chat(world, "<span class='alert'>[message]</span>")
 	if(announcer)
 		to_chat(world, "<span class='alert'> -[html_encode(announcer)]</span>")
 	to_chat(world, "<br>")
 
-datum/announcement/priority/command/Message(message as text, message_title as text)
+/datum/announcement/priority/command/Message(message as text, message_title as text)
 	var/command
 	command += "<h1 class='alert'>[command_name()] Update</h1>"
 	if(message_title)
@@ -91,7 +91,7 @@ datum/announcement/priority/command/Message(message as text, message_title as te
 		if(!istype(M,/mob/new_player) && !isdeaf(M))
 			to_chat(M, command)
 
-datum/announcement/priority/enemy/Message(message as text, message_title as text, from as text)
+/datum/announcement/priority/enemy/Message(message as text, message_title as text, from as text)
 	var/command
 	command += "<h1 class='alert'>[from]</h1>"
 	if(message_title)
@@ -103,11 +103,11 @@ datum/announcement/priority/enemy/Message(message as text, message_title as text
 		if(!istype(M,/mob/new_player) && !isdeaf(M))
 			to_chat(M, command)
 
-datum/announcement/priority/security/Message(message as text, message_title as text)
+/datum/announcement/priority/security/Message(message as text, message_title as text)
 	to_chat(world, "<font size=4 color='red'>[message_title]</font>")
 	to_chat(world, "<font color='red'>[message]</font>")
 
-datum/announcement/proc/NewsCast(message as text, message_title as text)
+/datum/announcement/proc/NewsCast(message as text, message_title as text)
 	if(disable_newscasts)
 		return
 	if(!newscast)
@@ -121,28 +121,28 @@ datum/announcement/proc/NewsCast(message as text, message_title as text)
 	news.can_be_redacted = 0
 	announce_newscaster_news(news)
 
-datum/announcement/proc/PlaySound(var/message_sound)
+/datum/announcement/proc/PlaySound(var/message_sound)
 	if(!message_sound)
 		return
 	for(var/mob/M in player_list)
 		if(!istype(M,/mob/new_player) && !isdeaf(M))
 			M << message_sound
 
-datum/announcement/proc/Sound(var/message_sound)
+/datum/announcement/proc/Sound(var/message_sound)
 	PlaySound(message_sound)
 
-datum/announcement/priority/Sound(var/message_sound)
+/datum/announcement/priority/Sound(var/message_sound)
 	if(sound)
 		world << sound
 
-datum/announcement/priority/command/Sound(var/message_sound)
+/datum/announcement/priority/command/Sound(var/message_sound)
 	PlaySound(message_sound)
 
-datum/announcement/proc/Log(message as text, message_title as text)
+/datum/announcement/proc/Log(message as text, message_title as text)
 	if(log)
 		log_say("[key_name(usr)] has made \a [announcement_type]: [message_title] - [message] - [announcer]")
 		message_admins("[key_name_admin(usr)] has made \a [announcement_type].", 1)
-
+		
 /proc/GetNameAndAssignmentFromId(var/obj/item/weapon/card/id/I)
 	// Format currently matches that of newscaster feeds: Registered Name (Assigned Rank)
 	return I.assignment ? "[I.registered_name] ([I.assignment])" : I.registered_name

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -129,7 +129,6 @@ var/const/access_trade_sol = 160
 
 	return 0
 
-
 /obj/item/proc/GetAccess()
 	return list()
 

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -4,7 +4,7 @@
 	name = "airlock electronics"
 	icon = 'icons/obj/doors/door_assembly.dmi'
 	icon_state = "door_electronics"
-	w_class = 2 //It should be tiny! -Agouri
+	w_class = 2 
 	materials = list(MAT_METAL=50, MAT_GLASS=50)
 
 	req_access = list(access_engine)
@@ -12,101 +12,96 @@
 	var/list/conf_access = null
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access
 	var/last_configurator = null
-	var/locked = 1
+	var/locked = TRUE
+	var/const/max_brain_damage = 60 // Maximum brain damage a mob can have until it can't use the electronics
 
-	attack_self(mob/user as mob)
-		if(!ishuman(user) && !istype(user,/mob/living/silicon/robot))
-			return ..(user)
+/obj/item/weapon/airlock_electronics/attack_self(mob/user)
+	if(!ishuman(user) && !isrobot(user))
+		return ..()
 
+	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.getBrainLoss() >= 60)
+		if(H.getBrainLoss() >= max_brain_damage)
+			to_chat(user, "<span class='warning'>You forget how to use \the [src].</span>")
 			return
 
-		var/t1 = text("<B>Access control</B><br>\n")
+	var/t1 = text("<B>Access control</B><br>\n")
 
+	if(last_configurator)
+		t1 += "Operator: [last_configurator]<br>"
 
-		if(last_configurator)
-			t1 += "Operator: [last_configurator]<br>"
+	if(locked)
+		t1 += "<a href='?src=[UID()];login=1'>Swipe ID</a><hr>"
+	else
+		t1 += "<a href='?src=[UID()];logout=1'>Block</a><hr>"
 
-		if(locked)
-			t1 += "<a href='?src=[UID()];login=1'>Swipe ID</a><hr>"
+		t1 += "Access requirement is set to "
+		t1 += one_access ? "<a style='color: green' href='?src=[UID()];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=[UID()];one_access=1'>ALL</a><hr>"
+
+		t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=[UID()];access=all'>All</a><br>"
+
+		t1 += "<br>"
+
+		var/list/accesses = get_all_accesses()
+		for(var/acc in accesses)
+			var/aname = get_access_desc(acc)
+
+			if(!conf_access || !conf_access.len || !(acc in conf_access))
+				t1 += "<a href='?src=[UID()];access=[acc]'>[aname]</a><br>"
+			else if(one_access)
+				t1 += "<a style='color: green' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
+			else
+				t1 += "<a style='color: red' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
+
+	t1 += "<p><a href='?src=[UID()];close=1'>Close</a></p>\n"
+
+	var/datum/browser/popup = new(user, "airlock_electronics", name, 400, 400)
+	popup.set_content(t1)
+	popup.open(0)
+	onclose(user, "airlock")
+
+/obj/item/weapon/airlock_electronics/Topic(href, href_list)
+	..()
+	
+	if(usr.incapacitated() || (!ishuman(usr) && !isrobot(usr)))
+		return 1
+		
+	if(href_list["close"])
+		usr << browse(null, "window=airlock")
+		return
+
+	if(href_list["login"])
+		if(allowed(usr))
+			locked = FALSE
+			last_configurator = usr.name
+
+	if(locked)
+		return
+
+	if(href_list["logout"])
+		locked = TRUE
+
+	if(href_list["one_access"])
+		one_access = !one_access
+
+	if(href_list["access"])
+		toggle_access(href_list["access"])
+
+	attack_self(usr)
+
+/obj/item/weapon/airlock_electronics/proc/toggle_access(var/access)
+	if(access == "all")
+		conf_access = null
+	else
+		var/req = text2num(access)
+
+		if(conf_access == null)
+			conf_access = list()
+
+		if(!(req in conf_access))
+			conf_access += req
 		else
-			t1 += "<a href='?src=[UID()];logout=1'>Block</a><hr>"
-
-			t1 += "Access requirement is set to "
-			t1 += one_access ? "<a style='color: green' href='?src=[UID()];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=[UID()];one_access=1'>ALL</a><hr>"
-
-			t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=[UID()];access=all'>All</a><br>"
-
-			t1 += "<br>"
-
-			var/list/accesses = get_all_accesses()
-			for(var/acc in accesses)
-				var/aname = get_access_desc(acc)
-
-				if(!conf_access || !conf_access.len || !(acc in conf_access))
-					t1 += "<a href='?src=[UID()];access=[acc]'>[aname]</a><br>"
-				else if(one_access)
-					t1 += "<a style='color: green' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
-				else
-					t1 += "<a style='color: red' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
-
-		t1 += "<p><a href='?src=[UID()];close=1'>Close</a></p>\n"
-
-		var/datum/browser/popup = new(user, "airlock_electronics", name, 400, 400)
-		popup.set_content(t1)
-		popup.open(0)
-		onclose(user, "airlock")
-
-	Topic(href, href_list)
-		..()
-		if(usr.stat || usr.restrained() || (!ishuman(usr) && !istype(usr,/mob/living/silicon)))
-			return
-		if(href_list["close"])
-			usr << browse(null, "window=airlock")
-			return
-
-		if(href_list["login"])
-			if(istype(usr,/mob/living/silicon))
-				src.locked = 0
-				src.last_configurator = usr.name
-			else
-				var/obj/item/I = usr.get_active_hand()
-				if(istype(I, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = I
-					I = pda.id
-				if(I && src.check_access(I))
-					src.locked = 0
-					src.last_configurator = I:registered_name
-
-		if(locked)
-			return
-
-		if(href_list["logout"])
-			locked = 1
-
-		if(href_list["one_access"])
-			one_access = !one_access
-
-		if(href_list["access"])
-			toggle_access(href_list["access"])
-
-		attack_self(usr)
-
-	proc
-		toggle_access(var/acc)
-			if(acc == "all")
+			conf_access -= req
+			if(!conf_access.len)
 				conf_access = null
-			else
-				var/req = text2num(acc)
-
-				if(conf_access == null)
-					conf_access = list()
-
-				if(!(req in conf_access))
-					conf_access += req
-				else
-					conf_access -= req
-					if(!conf_access.len)
-						conf_access = null
 

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -16,41 +16,41 @@
 	var/icon_closed = "lockbox"
 	var/icon_broken = "lockbox+b"
 
-
-	attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-		if(istype(W, /obj/item/weapon/card/id))
-			if(src.broken)
-				to_chat(user, "<span class='warning'>It appears to be broken.</span>")
-				return
-			if(src.allowed(user))
-				src.locked = !( src.locked )
-				if(src.locked)
-					src.icon_state = src.icon_locked
-					to_chat(user, "<span class='warning'>You lock the [src.name]!</span>")
-					return
-				else
-					src.icon_state = src.icon_closed
-					to_chat(user, "<span class='warning'>You unlock the [src.name]!</span>")
-					origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
-					return
-			else
-				to_chat(user, "<span class='warning'>Access Denied</span>")
-		else if((istype(W, /obj/item/weapon/card/emag) || istype(W, /obj/item/weapon/melee/energy/blade)) && !broken)
-			emag_act(user)
+/obj/item/weapon/storage/lockbox/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))
+		if(broken)
+			to_chat(user, "<span class='warning'>It appears to be broken.</span>")
 			return
-		if(!locked)
-			..()
+		if(check_access(W))
+			locked = !locked
+			if(locked)
+				icon_state = icon_locked
+				to_chat(user, "<span class='warning'>You lock \the [src]!</span>")
+				return
+			else
+				icon_state = icon_closed
+				to_chat(user, "<span class='warning'>You unlock \the [src]!</span>")
+				origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
+				return
 		else
-			to_chat(user, "<span class='warning'>It's locked!</span>")
+			to_chat(user, "<span class='warning'>Access denied.</span>")
+			return
+	else if((istype(W, /obj/item/weapon/card/emag) || (istype(W, /obj/item/weapon/melee/energy/blade)) && !broken))
+		emag_act(user)
 		return
+	if(!locked)
+		..()
+	else
+		to_chat(user, "<span class='warning'>It's locked!</span>")
+	return
 
 
-	show_to(mob/user as mob)
-		if(locked)
-			to_chat(user, "<span class='warning'>It's locked!</span>")
-		else
-			..()
-		return
+/obj/item/weapon/storage/lockbox/show_to(mob/user as mob)
+	if(locked)
+		to_chat(user, "<span class='warning'>It's locked!</span>")
+	else
+		..()
+	return
 
 /obj/item/weapon/storage/lockbox/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(!locked)
@@ -64,7 +64,7 @@
 		broken = 1
 		locked = 0
 		desc = "It appears to be broken."
-		icon_state = src.icon_broken
+		icon_state = icon_broken
 		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
 		origin_tech = null //wipe out any origin tech if it's unlocked in any way so you can't double-dip tech levels at R&D.
 		return
@@ -84,23 +84,21 @@
 	name = "Lockbox (Mindshield Implants)"
 	req_access = list(access_security)
 
-	New()
-		..()
-		new /obj/item/weapon/implantcase/loyalty(src)
-		new /obj/item/weapon/implantcase/loyalty(src)
-		new /obj/item/weapon/implantcase/loyalty(src)
-		new /obj/item/weapon/implanter/loyalty(src)
-
+/obj/item/weapon/storage/lockbox/loyalty/New()
+	..()
+	new /obj/item/weapon/implantcase/loyalty(src)
+	new /obj/item/weapon/implantcase/loyalty(src)
+	new /obj/item/weapon/implantcase/loyalty(src)
+	new /obj/item/weapon/implanter/loyalty(src)
 
 /obj/item/weapon/storage/lockbox/clusterbang
 	name = "lockbox (clusterbang)"
 	desc = "You have a bad feeling about opening this."
 	req_access = list(access_security)
 
-	New()
-		..()
-		new /obj/item/weapon/grenade/clusterbuster(src)
-
+/obj/item/weapon/storage/lockbox/clusterbang/New()
+	..()
+	new /obj/item/weapon/grenade/clusterbuster(src)
 
 /obj/item/weapon/storage/lockbox/medal
 	name = "medal box"
@@ -116,14 +114,14 @@
 	icon_closed = "medalbox"
 	icon_broken = "medalbox+b"
 
-	New()
-		..()
-		new /obj/item/clothing/accessory/medal/gold/heroism(src)
-		new /obj/item/clothing/accessory/medal/silver/security(src)
-		new /obj/item/clothing/accessory/medal/silver/valor(src)
-		new /obj/item/clothing/accessory/medal/nobel_science(src)
-		new /obj/item/clothing/accessory/medal/bronze_heart(src)
-		new /obj/item/clothing/accessory/medal/conduct(src)
-		new /obj/item/clothing/accessory/medal/conduct(src)
-		new /obj/item/clothing/accessory/medal/conduct(src)
-		new /obj/item/clothing/accessory/medal/gold/captain(src)
+/obj/item/weapon/storage/lockbox/medal/New()
+	..()
+	new /obj/item/clothing/accessory/medal/gold/heroism(src)
+	new /obj/item/clothing/accessory/medal/silver/security(src)
+	new /obj/item/clothing/accessory/medal/silver/valor(src)
+	new /obj/item/clothing/accessory/medal/nobel_science(src)
+	new /obj/item/clothing/accessory/medal/bronze_heart(src)
+	new /obj/item/clothing/accessory/medal/conduct(src)
+	new /obj/item/clothing/accessory/medal/conduct(src)
+	new /obj/item/clothing/accessory/medal/conduct(src)
+	new /obj/item/clothing/accessory/medal/gold/captain(src)

--- a/code/modules/computer3/computers/communications.dm
+++ b/code/modules/computer3/computers/communications.dm
@@ -66,16 +66,21 @@
 		if("main" in href_list)
 			state = STATE_DEFAULT
 		if("login" in href_list)
-			var/mob/M = usr
-			var/obj/item/I = M.get_active_hand()
+			if(!ishuman(usr))
+				to_chat(usr, "<span class='warning'>Access denied.</span>")
+				return
+			var/mob/living/carbon/human/H = usr
+			var/obj/item/I = H.get_active_hand()
 			if(I)
 				I = I.GetID()
 			if(istype(I,/obj/item/weapon/card/id) && check_access(I))
 				authenticated = 1
 				if(access_captain in I.GetAccess())
 					authenticated = 2
-					crew_announcement.announcer = GetNameAndAssignmentFromId(I)
-
+					var/obj/item/weapon/card/id = H.get_idcard(TRUE)
+					if(istype(id))
+						crew_announcement.announcer = GetNameAndAssignmentFromId(id)
+						
 		if("logout" in href_list)
 			authenticated = 0
 			crew_announcement.announcer = ""

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -709,12 +709,19 @@
 	if(!.) 				. = if_no_id	//to prevent null-names making the mob unclickable
 	return
 
-//gets ID card object from special clothes slot or null.
-/mob/living/carbon/human/proc/get_idcard()
+//gets ID card object from special clothes slot or, if applicable, hands as well
+/mob/living/carbon/human/proc/get_idcard(var/check_hands = FALSE)
 	var/obj/item/weapon/card/id/id = wear_id
 	var/obj/item/device/pda/pda = wear_id
 	if(istype(pda) && pda.id)
 		id = pda.id
+		
+	if(check_hands)
+		if(istype(get_active_hand(), /obj/item/weapon/card/id))
+			id = get_active_hand()
+		else if(istype(get_inactive_hand(), /obj/item/weapon/card/id))
+			id = get_inactive_hand()					
+
 	if(istype(id))
 		return id
 
@@ -1977,6 +1984,12 @@
 		var/obj/item/weapon/card/id/id = wear_id
 		if(istype(id) && id.is_untrackable())
 			return 0
+	if(wear_pda)
+		var/obj/item/device/pda/pda = wear_pda
+		if(istype(pda))
+			var/obj/item/weapon/card/id/id = pda.id
+			if(istype(id) && id.is_untrackable())
+				return 0		
 	if(istype(head, /obj/item/clothing/head))
 		var/obj/item/clothing/head/hat = head
 		if(hat.blockTracking)
@@ -1992,6 +2005,8 @@
 
 	if(wear_id)
 		. |= wear_id.GetAccess()
+	if(wear_pda)
+		. |= wear_pda.GetAccess()
 	if(istype(w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = w_uniform
 		if(U.accessories)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -730,18 +730,18 @@ var/list/robot_verbs_default = list(
 		else
 			to_chat(user, "Unable to locate a radio.")
 
-	else if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))			// trying to unlock the interface with an ID card
+	else if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))			// trying to unlock the interface with an ID card
 		if(emagged)//still allow them to open the cover
-			to_chat(user, "The interface seems slightly damaged")
+			to_chat(user, "The interface seems slightly damaged.")
 		if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
 		else
-			if(allowed(usr))
+			if(allowed(W))
 				locked = !locked
 				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
 				update_icons()
 			else
-				to_chat(user, "\red Access denied.")
+				to_chat(user, "<span class='warning'>Access denied.</span>")
 
 	else if(istype(W, /obj/item/borg/upgrade/))
 		var/obj/item/borg/upgrade/U = W
@@ -957,29 +957,15 @@ var/list/robot_verbs_default = list(
 			user.visible_message("<span class='notice'>[user] pets [src]!</span>", \
 								"<span class='notice'>You pet [src]!</span>")
 
-/mob/living/silicon/robot/proc/allowed(mob/M)
-	//check if it doesn't require any access at all
-	if(check_access(null))
+/mob/living/silicon/robot/proc/allowed(obj/item/I)
+	var/obj/dummy = new /obj(null) // Create a dummy object to check access on as to avoid having to snowflake check_access on every mob
+	dummy.req_access = req_access
+	
+	if(dummy.check_access(I))
+		qdel(dummy)
 		return 1
-	if(istype(M, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = M
-		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_hand()) || check_access(H.wear_id))
-			return 1
-	return 0
-
-/mob/living/silicon/robot/proc/check_access(obj/item/weapon/card/id/I)
-	if(!istype(req_access, /list)) //something's very wrong
-		return 1
-
-	var/list/L = req_access
-	if(!L.len) //no requirements
-		return 1
-	if(!I || !istype(I, /obj/item/weapon/card/id) || !I.access) //not ID or no access
-		return 0
-	for(var/req in req_access)
-		if(req in I.access) //have one of the required accesses
-			return 1
+		
+	qdel(dummy)
 	return 0
 
 /mob/living/silicon/robot/update_icons()

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -49,7 +49,7 @@
 
 /obj/item/weapon/gun/energy/gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"
-	desc = "This is a expensive, modern recreation of a antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
+	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
 	icon_state = "hoslaser"
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)

--- a/code/modules/security_levels/keycard authentication.dm
+++ b/code/modules/security_levels/keycard authentication.dm
@@ -3,6 +3,7 @@
 	desc = "This device is used to trigger station functions, which require more than one ID card to authenticate."
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "auth_off"
+	
 	var/active = 0 //This gets set to 1 on all devices except the one where the initial request was made.
 	var/event = ""
 	var/screen = 1
@@ -14,25 +15,25 @@
 	var/mob/event_triggered_by
 	var/mob/event_confirmed_by
 	var/ert_reason = "Reason for ERT"
-	//1 = select event
-	//2 = authenticate
-	anchored = 1.0
+	
+	anchored = 1
 	use_power = 1
 	idle_power_usage = 2
 	active_power_usage = 6
 	power_channel = ENVIRON
+	
+	req_access = list(access_keycard_auth)
 
 /obj/machinery/keycard_auth/attack_ai(mob/user as mob)
-	to_chat(user, "The station AI is not to interact with these devices.")
+	to_chat(user, "<span class='warning'>The station AI is not to interact with these devices.</span>")
 	return
 
 /obj/machinery/keycard_auth/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(stat & (NOPOWER|BROKEN))
 		to_chat(user, "This device is not powered.")
 		return
-	if(istype(W,/obj/item/weapon/card/id))
-		var/obj/item/weapon/card/id/ID = W
-		if(access_keycard_auth in ID.access)
+	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))
+		if(check_access(W))
 			if(active == 1)
 				//This is not the device that made the initial request. It is the device confirming the request.
 				if(event_source)
@@ -44,6 +45,8 @@
 					return
 				event_triggered_by = usr
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
+		else
+			to_chat(user, "<span class='warning'>Access denied.</span>")
 
 /obj/machinery/keycard_auth/power_change()
 	if(powered(ENVIRON))
@@ -51,16 +54,16 @@
 		icon_state = "auth_off"
 	else
 		stat |= NOPOWER
+		
+/obj/machinery/keycard_auth/attack_ghost(mob/user)
+	ui_interact(user)
 
 /obj/machinery/keycard_auth/attack_hand(mob/user as mob)
-	if(!user.IsAdvancedToolUser())
-		return 0
+	if(..())
+		return 1
 	ui_interact(user)
 
 /obj/machinery/keycard_auth/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	if(user.stat || stat & (NOPOWER|BROKEN))
-		to_chat(user, "This device is not powered.")
-		return
 	if(busy)
 		to_chat(user, "This device is busy.")
 		return
@@ -74,19 +77,18 @@
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "keycard_auth.tmpl", "Keycard Authentication Device UI", 520, 320)
+		ui = new(user, src, ui_key, "keycard_auth.tmpl", "Keycard Authentication Device UI", 540, 320)
 		ui.set_initial_data(data)
 		ui.open()
 
 /obj/machinery/keycard_auth/Topic(href, href_list)
 	if(..())
-		return
+		return 1
+		
 	if(busy)
 		to_chat(usr, "This device is busy.")
 		return
-	if(usr.stat || stat & (BROKEN|NOPOWER))
-		to_chat(usr, "This device is without power.")
-		return
+		
 	if(href_list["triggerevent"])
 		event = href_list["triggerevent"]
 		screen = 2

--- a/nano/templates/keycard_auth.tmpl
+++ b/nano/templates/keycard_auth.tmpl
@@ -29,7 +29,7 @@ Used In File(s): \code\modules\security_levels\keycard_authentication.dm
 					</div>
 				</div>
 			{{/if}}
-			<h2 class="blue-header">Please swipe your card to authorize the following event</h2>
+			<h2 class="bad" style="text-align: center;">Please swipe your card to authorize the following event:</h2>
 			<div class="event">{{:data.event}}</div>
 			{{:helper.link('Back', 'close', { 'reset' : 1 })}}
 		{{/if}}


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/5151.
Fixes https://github.com/ParadiseSS13/Paradise/issues/5812.

Also makes a super minor adjustment to the keycard authenticator UI as the "blue-header" class no longer works and ghosts not being able to access the keycard authenticator. Also fixes some grammar in the X-01 energy gun.

🆑 Markolie
tweak: ID checking for communication consoles, airlock electronics, borg frames, lockboxes and keycard authenticators has been improved: it'll now check your PDA for an ID card, and act consistently with other access checks.
bugfix: Fixed up the checks for players being untrackable, so it respects the untrackable status of an ID inside of a PDA.
/🆑