### PR TITLE
Food refactor

### DIFF
--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -42,7 +42,7 @@
 	var/byproduct		// example: = /obj/item/weapon/kitchen/mould		// byproduct to return, such as a mould or trash
 
 
-/datum/recipe/proc/check_reagents(var/datum/reagents/avail_reagents) //1=precisely, 0=insufficiently, -1=superfluous
+/datum/recipe/proc/check_reagents(datum/reagents/avail_reagents) //1=precisely, 0=insufficiently, -1=superfluous
 	. = 1
 	for(var/r_r in reagents)
 		var/aval_r_amnt = avail_reagents.get_reagent_amount(r_r)
@@ -55,7 +55,7 @@
 		return -1
 	return .
 
-/datum/recipe/proc/check_fruit(var/obj/container)
+/datum/recipe/proc/check_fruit(obj/container)
 	. = 1
 	if(fruit && fruit.len)
 		var/list/checklist = list()
@@ -74,7 +74,7 @@
 					break
 	return .
 
-/datum/recipe/proc/check_items(var/obj/container as obj)
+/datum/recipe/proc/check_items(obj/container)
 	. = 1
 	if(items && items.len)
 		var/list/checklist = list()
@@ -96,7 +96,7 @@
 	return .
 
 //general version
-/datum/recipe/proc/make(var/obj/container as obj)
+/datum/recipe/proc/make(obj/container)
 	var/obj/result_obj = new result(container)
 	for(var/obj/O in (container.contents-result_obj))
 		O.reagents.trans_to(result_obj, O.reagents.total_volume)
@@ -106,7 +106,7 @@
 	return result_obj
 
 // food-related
-/datum/recipe/proc/make_food(var/obj/container as obj)
+/datum/recipe/proc/make_food(obj/container)
 	var/obj/result_obj = new result(container)
 	for(var/obj/O in (container.contents-result_obj))
 		if(O.reagents)
@@ -118,7 +118,7 @@
 	score_meals++
 	return result_obj
 
-/proc/select_recipe(var/list/datum/recipe/avaiable_recipes, var/obj/obj as obj, var/exact = 1 as num)
+/proc/select_recipe(list/datum/recipe/avaiable_recipes, obj/obj, exact = 1)
 	if(!exact)
 		exact = -1
 	var/list/datum/recipe/possible_recipes = new

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -81,7 +81,7 @@
 			refill = reagents.get_master_reagent_id()
 			refillName = reagents.get_master_reagent_name()
 
-		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
+		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'> You transfer [trans] units of the solution to [target].</span>")
 
 		if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
@@ -102,22 +102,22 @@
 	if(istype(I, /obj/item/clothing/mask/cigarette)) //ciggies are weird
 		return
 	if(is_hot(I))
-		if(src.reagents)
-			src.reagents.chem_temp += 15
+		if(reagents)
+			reagents.chem_temp += 15
 			to_chat(user, "<span class='notice'>You heat [src] with [I].</span>")
-			src.reagents.handle_reactions()
+			reagents.handle_reactions()
 
 /obj/item/weapon/reagent_containers/food/drinks/examine(mob/user)
 	if(!..(user, 1))
 		return
-	if(!reagents || reagents.total_volume==0)
+	if(!reagents || reagents.total_volume == 0)
 		to_chat(user, "<span class='notice'> \The [src] is empty!</span>")
-	else if(reagents.total_volume<=src.volume/4)
+	else if(reagents.total_volume <= volume/4)
 		to_chat(user, "<span class='notice'> \The [src] is almost empty!</span>")
-	else if(reagents.total_volume<=src.volume*0.66)
+	else if(reagents.total_volume <= volume*0.66)
 		to_chat(user, "<span class='notice'> \The [src] is half full!</span>")// We're all optimistic, right?!
 
-	else if(reagents.total_volume<=src.volume*0.90)
+	else if(reagents.total_volume <= volume*0.90)
 		to_chat(user, "<span class='notice'> \The [src] is almost full!</span>")
 	else
 		to_chat(user, "<span class='notice'> \The [src] is full!</span>")

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -22,9 +22,9 @@
 	else
 		user.drop_item()
 		user.put_in_active_hand(B)
-	B.icon_state = src.icon_state
+	B.icon_state = icon_state
 
-	var/icon/I = new('icons/obj/drinks.dmi', src.icon_state)
+	var/icon/I = new('icons/obj/drinks.dmi', icon_state)
 	I.Blend(B.broken_outline, ICON_OVERLAY, rand(5), 1)
 	I.SwapColor(rgb(255, 0, 220, 255), rgb(0, 0, 0, 0))
 	B.icon = I
@@ -99,11 +99,11 @@
 
 	//Display an attack message.
 	if(target != user)
-		target.visible_message("<span class='danger'>[user] has hit [target][head_attack_message] with a bottle of [src.name]!</span>", \
-				"<span class='userdanger'>[user] has hit [target][head_attack_message] with a bottle of [src.name]!</span>")
+		target.visible_message("<span class='danger'>[user] has hit [target][head_attack_message] with a bottle of [name]!</span>", \
+				"<span class='userdanger'>[user] has hit [target][head_attack_message] with a bottle of [name]!</span>")
 	else
-		user.visible_message("<span class='danger'>[target] hits \himself with a bottle of [src.name][head_attack_message]!</span>", \
-				"<span class='userdanger'>[target] hits \himself with a bottle of [src.name][head_attack_message]!</span>")
+		user.visible_message("<span class='danger'>[target] hits \himself with a bottle of [name][head_attack_message]!</span>", \
+				"<span class='userdanger'>[target] hits \himself with a bottle of [name][head_attack_message]!</span>")
 
 	//Attack logs
 	add_logs(user, target, "attacked", src)

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -9,7 +9,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/cans/attack_self(mob/user)
 	if(canopened == 0)
-		playsound(src.loc,'sound/effects/canopen.ogg', rand(10,50), 1)
+		playsound(loc,'sound/effects/canopen.ogg', rand(10,50), 1)
 		to_chat(user, "<span class='notice'>You open the drink with an audible pop!</span>")
 		canopened = 1
 		flags |= OPENCONTAINER
@@ -32,7 +32,7 @@
 	if(canopened == 0)
 		to_chat(user, "<span class='notice'>You need to open the drink!</span>")
 		return
-	else if(M == user && !src.reagents.total_volume && user.a_intent == "harm" && user.zone_sel.selecting == "head")
+	else if(M == user && !reagents.total_volume && user.a_intent == "harm" && user.zone_sel.selecting == "head")
 		user.visible_message("<span class='warning'>[user] crushes ["\the [src]"] on \his forehead!</span>", "<span class='notice'>You crush \the [src] on your forehead.</span>")
 		crush(user)
 		return

--- a/code/modules/food_and_drinks/food/candy.dm
+++ b/code/modules/food_and_drinks/food/candy.dm
@@ -23,7 +23,7 @@
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
 	bitesize = 2
-	list_reagents = list("nutriment" = 2, "chocolate" = 2)
+	list_reagents = list("nutriment" = 2, "chocolate" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/caramel
 	name = "Caramel"
@@ -142,7 +142,7 @@
 	icon_state = "candycane"
 	filling_color = "#F2F2F2"
 	bitesize = 2
-	list_reagents = list("minttoxin" = 4, "sugar" = 5)
+	list_reagents = list("minttoxin" = 1, "sugar" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear
 	name = "gummy bear"

--- a/code/modules/food_and_drinks/food/candy.dm
+++ b/code/modules/food_and_drinks/food/candy.dm
@@ -23,11 +23,7 @@
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/chocolatebar/New()
-	..()
-	reagents.add_reagent("nutriment", 2)
-	reagents.add_reagent("chocolate",4)
+	list_reagents = list("nutriment" = 2, "chocolate" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/caramel
 	name = "Caramel"
@@ -35,11 +31,8 @@
 	icon_state = "caramel"
 	filling_color = "#DB944D"
 	bitesize = 2
+	list_reagents = list("cream" = 2, "sugar" = 2)
 
-/obj/item/weapon/reagent_containers/food/snacks/candy/caramel/New()
-	..()
-	reagents.add_reagent("cream", 2)
-	reagents.add_reagent("sugar", 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/toffee
 	name = "Toffee"
@@ -47,11 +40,7 @@
 	icon_state = "toffee"
 	filling_color = "#7D5F46"
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/toffee/New()
-	..()
-	reagents.add_reagent("nutriment", 3)
-	reagents.add_reagent("sugar", 3)
+	list_reagents = list("nutriment" = 3, "sugar" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/nougat
 	name = "Nougat"
@@ -59,14 +48,7 @@
 	icon_state = "nougat"
 	filling_color = "#7D5F46"
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/nougat/New()
-	..()
-	reagents.add_reagent("nutriment", 3)
-	reagents.add_reagent("sugar", 3)
-	spawn(1)
-		reagents.del_reagent("egg")
-		reagents.update_total()
+	list_reagents = list("nutriment" = 3, "sugar" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/taffy
 	name = "Saltwater Taffy"
@@ -74,12 +56,11 @@
 	icon_state = "candy1"
 	filling_color = "#7D5F46"
 	bitesize = 2
+	list_reagents = list("nutriment" = 3, "sugar" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/taffy/New()
 	..()
 	icon_state = pick("candy1", "candy2", "candy3", "candy4", "candy5")
-	reagents.add_reagent("nutriment", 3)
-	reagents.add_reagent("sugar", 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/fudge
 	name = "Fudge"
@@ -87,11 +68,7 @@
 	icon_state = "fudge"
 	filling_color = "#7D5F46"
 	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/fudge/New()
-	..()
-	reagents.add_reagent("cream", 3)
-	reagents.add_reagent("chocolate",6)
+	list_reagents = list("cream" = 3, "chocolate" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/fudge/peanut
 	name = "Peanut Fudge"
@@ -110,10 +87,7 @@
 	desc = "An extra creamy fudge with bits of real chocolate cookie mixed in. Crunchy!"
 	icon_state = "fudge_cookies_n_cream"
 	filling_color = "#7D5F46"
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/fudge/cookies_n_cream/New()
-	..()
-	reagents.add_reagent("cream", 3)
+	list_reagents = list("cream" = 6, "chocolate" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/fudge/turtle
 	name = "Turtle Fudge"
@@ -130,11 +104,7 @@
 	desc = "A little treat for blood donors."
 	trash = /obj/item/trash/candy
 	bitesize = 5
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/donor/New()
-	..()
-	reagents.add_reagent("nutriment", 10)
-	reagents.add_reagent("sugar", 3)
+	list_reagents = list("nutriment" = 10, "sugar" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candy_corn
 	name = "candy corn"
@@ -142,11 +112,7 @@
 	icon_state = "candycorn"
 	filling_color = "#FFFCB0"
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/candy_corn/New()
-	..()
-	reagents.add_reagent("nutriment", 4)
-	reagents.add_reagent("sugar", 2)
+	list_reagents = list("nutriment" = 4, "sugar" = 2)
 
 // ***********************************************************
 // Candy Products (plain / unflavored)
@@ -158,11 +124,8 @@
 	icon_state = "cottoncandy_plain"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#FFFFFF"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/New()
-	..()
-	reagents.add_reagent("sugar", 15)
+	bitesize = 4
+	list_reagents = list("sugar" = 15)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candybar
 	name = "candy"
@@ -171,11 +134,7 @@
 	trash = /obj/item/trash/candy
 	filling_color = "#7D5F46"
 	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/candybar/New()
-	..()
-	reagents.add_reagent("nutriment", 2)
-	reagents.add_reagent("chocolate",5)
+	list_reagents = list("nutriment" = 2, "chocolate" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candycane
 	name = "candy cane"
@@ -183,11 +142,7 @@
 	icon_state = "candycane"
 	filling_color = "#F2F2F2"
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/candycane/New()
-	..()
-	reagents.add_reagent("minttoxin", 1)
-	reagents.add_reagent("sugar", 5)
+	list_reagents = list("minttoxin" = 4, "sugar" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear
 	name = "gummy bear"
@@ -195,10 +150,7 @@
 	icon_state = "gbear"
 	filling_color = "#FFFFFF"
 	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/New()
-	..()
-	reagents.add_reagent("sugar", 10)
+	list_reagents = list("sugar" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm
 	name = "gummy worm"
@@ -206,10 +158,7 @@
 	icon_state = "gworm"
 	filling_color = "#FFFFFF"
 	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/New()
-	..()
-	reagents.add_reagent("sugar", 10)
+	list_reagents = list("sugar" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean
 	name = "jelly bean"
@@ -217,10 +166,7 @@
 	icon_state = "jbean"
 	filling_color = "#FFFFFF"
 	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/New()
-	..()
-	reagents.add_reagent("sugar", 10)
+	list_reagents = list("sugar" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jawbreaker
 	name = "jawbreaker"
@@ -228,10 +174,7 @@
 	icon_state = "jawbreaker"
 	filling_color = "#ED0758"
 	bitesize = 0.1	//this is gonna take a while, you'll be working at this all shift.
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jawbreaker/New()
-	..()
-	reagents.add_reagent("sugar", 10)
+	list_reagents = list("sugar" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cash
 	name = "candy cash"
@@ -239,23 +182,15 @@
 	icon_state = "candy_cash"
 	filling_color = "#302000"
 	bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cash/New()
-	..()
-	reagents.add_reagent("nutriment", 2)
-	reagents.add_reagent("chocolate", 4)
+	list_reagents = list("nutriment" = 2, "chocolate" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/coin
 	name = "chocolate coin"
 	desc = "Probably won't work in the vending machines."
 	icon_state = "choc_coin"
 	filling_color = "#302000"
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/coin/New()
-	..()
-	reagents.add_reagent("nutriment", 2)
-	reagents.add_reagent("chocolate",4)
 	bitesize = 3
+	list_reagents = list("nutriment" = 2, "chocolate" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gum
 	name = "bubblegum"
@@ -264,20 +199,14 @@
 	trash = /obj/item/trash/gum
 	filling_color = "#FF7495"
 	bitesize = 0.2
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gum/New()
-	..()
-	reagents.add_reagent("sugar", 5)
+	list_reagents = list("sugar" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/sucker
 	name = "sucker"
 	desc = "For being such a good sport!"
 	icon_state = "sucker"
 	filling_color = "#FFFFFF"
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/sucker/New()
-	..()
-	reagents.add_reagent("sugar", 10)
+	list_reagents = list("sugar" = 10)
 
 // ***********************************************************
 // Gummy Bear Flavors
@@ -288,91 +217,56 @@
 	desc = "A small edible bear. It's red!"
 	icon_state = "gbear_red"
 	filling_color = "#801E28"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/red/New()
-	..()
-	reagents.add_reagent("cherryjelly", 2)
+	list_reagents = list("sugar" = 10, "cherryjelly" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/blue
 	name = "gummy bear"
 	desc = "A small edible bear. It's blue!"
 	icon_state = "gbear_blue"
 	filling_color = "#863333"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/blue/New()
-	..()
-	reagents.add_reagent("berryjuice", 2)
+	list_reagents = list("sugar" = 10, "berryjuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/poison
 	name = "gummy bear"
 	desc = "A small edible bear. It's blue!"
 	icon_state = "gbear_blue"
 	filling_color = "#863353"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/poison/New()
-	..()
-	reagents.add_reagent("poisonberryjuice", 12)
-	spawn(1)
-		reagents.del_reagent("sugar")
-		reagents.update_total()
+	list_reagents = list("poisonberryjuice" = 12)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/green
 	name = "gummy bear"
 	desc = "A small edible bear. It's green!"
 	icon_state = "gbear_green"
 	filling_color = "#365E30"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/green/New()
-	..()
-	reagents.add_reagent("limejuice", 2)
+	list_reagents = list("sugar" = 10, "limejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/yellow
 	name = "gummy bear"
 	desc = "A small edible bear. It's yellow!"
 	icon_state = "gbear_yellow"
 	filling_color = "#863333"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/yellow/New()
-	..()
-	reagents.add_reagent("lemonjuice", 2)
+	list_reagents = list("sugar" = 10, "lemonjuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/orange
 	name = "gummy bear"
 	desc = "A small edible bear. It's orange!"
 	icon_state = "gbear_orange"
 	filling_color = "#E78108"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/orange/New()
-	..()
-	reagents.add_reagent("orangejuice", 2)
+	list_reagents = list("sugar" = 10, "orangejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/purple
 	name = "gummy bear"
 	desc = "A small edible bear. It's purple!"
 	icon_state = "gbear_purple"
 	filling_color = "#993399"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/purple/New()
-	..()
-	reagents.add_reagent("grapejuice", 2)
+	list_reagents = list("sugar" = 10, "grapejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/wtf
 	name = "gummy bear"
 	desc = "A small bear. Wait... what?"
 	icon_state = "gbear_wtf"
 	filling_color = "#60A584"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/wtf/New()
-	..()
-	reagents.add_reagent("space_drugs", 2)
+	list_reagents = list("sugar" = 10, "space_drugs" = 2)
 
 // ***********************************************************
 // Gummy Worm Flavors
@@ -383,91 +277,56 @@
 	desc = "An edible worm, made from gelatin. It's red!"
 	icon_state = "gworm_red"
 	filling_color = "#801E28"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/red/New()
-	..()
-	reagents.add_reagent("cherryjelly", 2)
+	list_reagents = list("sugar" = 10, "cherryjelly" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/blue
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's blue!"
 	icon_state = "gworm_blue"
 	filling_color = "#863333"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/blue/New()
-	..()
-	reagents.add_reagent("berryjuice", 2)
+	list_reagents = list("sugar" = 10, "berryjuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/poison
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's blue!"
 	icon_state = "gworm_blue"
 	filling_color = "#863353"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/poison/New()
-	..()
-	reagents.add_reagent("poisonberryjuice", 12)
-	spawn(1)
-		reagents.del_reagent("sugar")
-		reagents.update_total()
+	list_reagents = list("poisonberryjuice" = 12)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/green
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's green!"
 	icon_state = "gworm_green"
 	filling_color = "#365E30"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/green/New()
-	..()
-	reagents.add_reagent("limejuice", 10)
+	list_reagents = list("sugar" = 10, "limejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/yellow
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's yellow!"
 	icon_state = "gworm_yellow"
 	filling_color = "#863333"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/yellow/New()
-	..()
-	reagents.add_reagent("lemonjuice", 2)
+	list_reagents = list("sugar" = 10, "lemonjuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/orange
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's orange!"
 	icon_state = "gworm_orange"
 	filling_color = "#E78108"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/orange/New()
-	..()
-	reagents.add_reagent("orangejuice", 2)
+	list_reagents = list("sugar" = 10, "orangejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/purple
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's purple!"
 	icon_state = "gworm_purple"
 	filling_color = "#993399"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/purple/New()
-	..()
-	reagents.add_reagent("grapejuice", 2)
+	list_reagents = list("sugar" = 10, "grapejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/wtf
 	name = "gummy worm"
 	desc = "An edible worm. Did it just move?"
 	icon_state = "gworm_wtf"
 	filling_color = "#60A584"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/wtf/New()
-	..()
-	reagents.add_reagent("space_drugs", 2)
+	list_reagents = list("sugar" = 10, "space_drugs" = 2)
 
 // ***********************************************************
 // Jelly Bean Flavors
@@ -478,146 +337,91 @@
 	desc = "A candy bean, guarenteed to not give you gas. It's red!"
 	icon_state = "jbean_red"
 	filling_color = "#801E28"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/red/New()
-	..()
-	reagents.add_reagent("cherryjelly", 2)
+	list_reagents = list("sugar" = 10, "cherryjelly" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/blue
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's blue!"
 	icon_state = "jbean_blue"
 	filling_color = "#863333"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/blue/New()
-	..()
-	reagents.add_reagent("berryjuice", 2)
+	list_reagents = list("sugar" = 10, "berryjuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/poison
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's blue!"
 	icon_state = "jbean_blue"
 	filling_color = "#863353"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/poison/New()
-	..()
-	reagents.add_reagent("poisonberryjuice", 12)
-	spawn(1)
-		reagents.del_reagent("sugar")
-		reagents.update_total()
+	list_reagents = list("poisonberryjuice" = 12)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/green
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's green!"
 	icon_state = "jbean_green"
 	filling_color = "#365E30"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/green/New()
-	..()
-	reagents.add_reagent("limejuice", 2)
+	list_reagents = list("sugar" = 10, "limejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/yellow
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's yellow!"
 	icon_state = "jbean_yellow"
 	filling_color = "#863333"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/yellow/New()
-	..()
-	reagents.add_reagent("lemonjuice", 2)
+	list_reagents = list("sugar" = 10, "lemonjuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/orange
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's orange!"
 	icon_state = "jbean_orange"
 	filling_color = "#E78108"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/orange/New()
-	..()
-	reagents.add_reagent("orangejuice", 2)
+	list_reagents = list("sugar" = 10, "orangejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/purple
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's purple!"
 	icon_state = "jbean_purple"
 	filling_color = "#993399"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/purple/New()
-	..()
-	reagents.add_reagent("grapejuice", 2)
+	list_reagents = list("sugar" = 10, "grapejuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/chocolate
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's chocolate!"
 	icon_state = "jbean_choc"
 	filling_color = "#302000"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/chocolate/New()
-	..()
-	reagents.add_reagent("chocolate",2)
+	list_reagents = list("sugar" = 10, "chocolate" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/popcorn
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's popcorn flavored!"
 	icon_state = "jbean_popcorn"
 	filling_color = "#664330"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/popcorn/New()
-	..()
-	reagents.add_reagent("nutriment", 2)
+	list_reagents = list("sugar" = 10, "nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's Cola flavored!"
 	icon_state = "jbean_cola"
 	filling_color = "#102000"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola/New()
-	..()
-	reagents.add_reagent("cola", 2)
+	list_reagents = list("sugar" = 10, "cola" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/drgibb
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's Dr. Gibb flavored!"
 	icon_state = "jbean_cola"
 	filling_color = "#102000"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/drgibb/New()
-	..()
-	reagents.add_reagent("dr_gibb", 2)
+	list_reagents = list("sugar" = 10, "dr_gibb" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/coffee
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's Coffee flavored!"
 	icon_state = "jbean_choc"
 	filling_color = "#482000"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/coffee/New()
-	..()
-	reagents.add_reagent("coffee", 2)
+	list_reagents = list("sugar" = 10, "coffee" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/wtf
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. You aren't sure what color it is."
 	icon_state = "jbean_wtf"
 	filling_color = "#60A584"
-	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/wtf/New()
-	..()
-	reagents.add_reagent("space_drugs", 2)
+	list_reagents = list("sugar" = 10, "space_drugs" = 2)
 
 // ***********************************************************
 // Cotton Candy Flavors
@@ -629,11 +433,7 @@
 	icon_state = "cottoncandy_red"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#801E28"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/red/New()
-	..()
-	reagents.add_reagent("cherryjelly", 5)
+	list_reagents = list("sugar" = 15, "cherryjelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/blue
 	name = "cotton candy"
@@ -641,11 +441,7 @@
 	icon_state = "cottoncandy_blue"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/blue/New()
-	..()
-	reagents.add_reagent("berryjuice", 5)
+	list_reagents = list("sugar" = 15, "berryjuice" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/poison
 	name = "cotton candy"
@@ -653,14 +449,7 @@
 	icon_state = "cottoncandy_blue"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863353"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/poison/New()
-	..()
-	reagents.add_reagent("poisonberryjuice", 20)
-	spawn(1)
-		reagents.del_reagent("sugar")
-		reagents.update_total()
+	list_reagents = list("poisonberryjuice" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/green
 	name = "cotton candy"
@@ -668,11 +457,7 @@
 	icon_state = "cottoncandy_green"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#365E30"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/green/New()
-	..()
-	reagents.add_reagent("limejuice", 5)
+	list_reagents = list("sugar" = 15, "limejuice" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/yellow
 	name = "cotton candy"
@@ -680,11 +465,7 @@
 	icon_state = "cottoncandy_yellow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/yellow/New()
-	..()
-	reagents.add_reagent("lemonjuice", 5)
+	list_reagents = list("sugar" = 15, "lemonjuice" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/orange
 	name = "cotton candy"
@@ -692,11 +473,7 @@
 	icon_state = "cottoncandy_orange"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#E78108"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/orange/New()
-	..()
-	reagents.add_reagent("orangejuice", 5)
+	list_reagents = list("sugar" = 15, "orangejuice" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/purple
 	name = "cotton candy"
@@ -704,11 +481,7 @@
 	icon_state = "cottoncandy_purple"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#993399"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/purple/New()
-	..()
-	reagents.add_reagent("grapejuice", 5)
+	list_reagents = list("sugar" = 15, "grapejuice" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/pink
 	name = "cotton candy"
@@ -716,11 +489,7 @@
 	icon_state = "cottoncandy_pink"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/pink/New()
-	..()
-	reagents.add_reagent("watermelonjuice", 5)
+	list_reagents = list("sugar" = 15, "watermelonjuice" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/rainbow
 	name = "cotton candy"
@@ -728,14 +497,7 @@
 	icon_state = "cottoncandy_rainbow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#C8A5DC"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/rainbow/New()
-	..()
-	reagents.add_reagent("omnizine", 20)
-	spawn(1)
-		reagents.del_reagent("sugar")
-		reagents.update_total()
+	list_reagents = list("omnizine" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/bad_rainbow
 	name = "cotton candy"
@@ -743,14 +505,7 @@
 	icon_state = "cottoncandy_rainbow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#32127A"
-	bitesize = 4
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/cotton/bad_rainbow/New()
-	..()
-	reagents.add_reagent("sulfonal", 20)
-	spawn(1)
-		reagents.del_reagent("sugar")
-		reagents.update_total()
+	list_reagents = list("sulfonal" = 20)
 
 // ***********************************************************
 // Candybar Flavors

--- a/code/modules/food_and_drinks/food/candy.dm
+++ b/code/modules/food_and_drinks/food/candy.dm
@@ -13,9 +13,6 @@
 	icon = 'icons/obj/food/candy.dmi'
 	icon_state = "candy"
 
-/obj/item/weapon/reagent_containers/food/snacks/candy/New()
-		..()
-
 // ***********************************************************
 // Candy Ingredients / Flavorings / Byproduct
 // ***********************************************************
@@ -25,42 +22,43 @@
 	desc = "Such sweet, fattening food."
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chocolatebar/New()
 	..()
 	reagents.add_reagent("nutriment", 2)
 	reagents.add_reagent("chocolate",4)
-	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/caramel
 	name = "Caramel"
 	desc = "Chewy and dense, yet it practically melts in your mouth!"
 	icon_state = "caramel"
 	filling_color = "#DB944D"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/caramel/New()
 	..()
 	reagents.add_reagent("cream", 2)
 	reagents.add_reagent("sugar", 2)
-	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/toffee
 	name = "Toffee"
 	desc = "A hard, brittle candy with a distinctive taste."
 	icon_state = "toffee"
 	filling_color = "#7D5F46"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/toffee/New()
 	..()
 	reagents.add_reagent("nutriment", 3)
 	reagents.add_reagent("sugar", 3)
-	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/nougat
 	name = "Nougat"
 	desc = "A soft, chewy candy commonly found in candybars."
 	icon_state = "nougat"
 	filling_color = "#7D5F46"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/nougat/New()
 	..()
@@ -69,32 +67,31 @@
 	spawn(1)
 		reagents.del_reagent("egg")
 		reagents.update_total()
-	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/taffy
 	name = "Saltwater Taffy"
 	desc = "Old fashioned saltwater taffy. Chewy!"
 	icon_state = "candy1"
 	filling_color = "#7D5F46"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/taffy/New()
 	..()
 	icon_state = pick("candy1", "candy2", "candy3", "candy4", "candy5")
 	reagents.add_reagent("nutriment", 3)
 	reagents.add_reagent("sugar", 3)
-	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/fudge
 	name = "Fudge"
 	desc = "Chocolate fudge, a timeless classic treat."
 	icon_state = "fudge"
 	filling_color = "#7D5F46"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/fudge/New()
 	..()
 	reagents.add_reagent("cream", 3)
 	reagents.add_reagent("chocolate",6)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/fudge/peanut
 	name = "Peanut Fudge"
@@ -132,24 +129,24 @@
 	name = "Donor Candy"
 	desc = "A little treat for blood donors."
 	trash = /obj/item/trash/candy
+	bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/donor/New()
 	..()
 	reagents.add_reagent("nutriment", 10)
 	reagents.add_reagent("sugar", 3)
-	bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candy_corn
 	name = "candy corn"
 	desc = "It's a handful of candy corn. Cannot be stored in a detective's hat, alas."
 	icon_state = "candycorn"
 	filling_color = "#FFFCB0"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candy_corn/New()
 	..()
 	reagents.add_reagent("nutriment", 4)
 	reagents.add_reagent("sugar", 2)
-	bitesize = 2
 
 // ***********************************************************
 // Candy Products (plain / unflavored)
@@ -161,11 +158,11 @@
 	icon_state = "cottoncandy_plain"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#FFFFFF"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/New()
 	..()
 	reagents.add_reagent("sugar", 15)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candybar
 	name = "candy"
@@ -173,80 +170,80 @@
 	icon_state = "candy"
 	trash = /obj/item/trash/candy
 	filling_color = "#7D5F46"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/New()
 	..()
 	reagents.add_reagent("nutriment", 2)
 	reagents.add_reagent("chocolate",5)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candycane
 	name = "candy cane"
 	desc = "A festive mint candy cane."
 	icon_state = "candycane"
 	filling_color = "#F2F2F2"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/candycane/New()
 	..()
 	reagents.add_reagent("minttoxin", 1)
 	reagents.add_reagent("sugar", 5)
-	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear
 	name = "gummy bear"
 	desc = "A small edible bear. It's squishy and chewy!"
 	icon_state = "gbear"
 	filling_color = "#FFFFFF"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/New()
 	..()
 	reagents.add_reagent("sugar", 10)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin."
 	icon_state = "gworm"
 	filling_color = "#FFFFFF"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/New()
 	..()
 	reagents.add_reagent("sugar", 10)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas."
 	icon_state = "jbean"
 	filling_color = "#FFFFFF"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/New()
 	..()
 	reagents.add_reagent("sugar", 10)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jawbreaker
 	name = "jawbreaker"
 	desc = "An unbelievably hard candy. The name is fitting."
 	icon_state = "jawbreaker"
 	filling_color = "#ED0758"
+	bitesize = 0.1	//this is gonna take a while, you'll be working at this all shift.
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jawbreaker/New()
 	..()
 	reagents.add_reagent("sugar", 10)
-	bitesize = 0.1	//this is gonna take a while, you'll be working at this all shift.
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cash
 	name = "candy cash"
 	desc = "Not legal tender. Tasty though."
 	icon_state = "candy_cash"
 	filling_color = "#302000"
+	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cash/New()
 	..()
 	reagents.add_reagent("nutriment", 2)
 	reagents.add_reagent("chocolate", 4)
-	bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/coin
 	name = "chocolate coin"
@@ -266,11 +263,11 @@
 	icon_state = "bubblegum"
 	trash = /obj/item/trash/gum
 	filling_color = "#FF7495"
+	bitesize = 0.2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gum/New()
 	..()
 	reagents.add_reagent("sugar", 5)
-	bitesize = 0.2
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/sucker
 	name = "sucker"
@@ -281,7 +278,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy/sucker/New()
 	..()
 	reagents.add_reagent("sugar", 10)
-	bitesize = 1
 
 // ***********************************************************
 // Gummy Bear Flavors
@@ -292,28 +288,29 @@
 	desc = "A small edible bear. It's red!"
 	icon_state = "gbear_red"
 	filling_color = "#801E28"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/red/New()
 	..()
 	reagents.add_reagent("cherryjelly", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/blue
 	name = "gummy bear"
 	desc = "A small edible bear. It's blue!"
 	icon_state = "gbear_blue"
 	filling_color = "#863333"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/blue/New()
 	..()
 	reagents.add_reagent("berryjuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/poison
 	name = "gummy bear"
 	desc = "A small edible bear. It's blue!"
 	icon_state = "gbear_blue"
 	filling_color = "#863353"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/poison/New()
 	..()
@@ -321,62 +318,61 @@
 	spawn(1)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/green
 	name = "gummy bear"
 	desc = "A small edible bear. It's green!"
 	icon_state = "gbear_green"
 	filling_color = "#365E30"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/green/New()
 	..()
 	reagents.add_reagent("limejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/yellow
 	name = "gummy bear"
 	desc = "A small edible bear. It's yellow!"
 	icon_state = "gbear_yellow"
 	filling_color = "#863333"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/yellow/New()
 	..()
 	reagents.add_reagent("lemonjuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/orange
 	name = "gummy bear"
 	desc = "A small edible bear. It's orange!"
 	icon_state = "gbear_orange"
 	filling_color = "#E78108"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/orange/New()
 	..()
 	reagents.add_reagent("orangejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/purple
 	name = "gummy bear"
 	desc = "A small edible bear. It's purple!"
 	icon_state = "gbear_purple"
 	filling_color = "#993399"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/purple/New()
 	..()
 	reagents.add_reagent("grapejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/wtf
 	name = "gummy bear"
 	desc = "A small bear. Wait... what?"
 	icon_state = "gbear_wtf"
 	filling_color = "#60A584"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummybear/wtf/New()
 	..()
 	reagents.add_reagent("space_drugs", 2)
-	bitesize = 3
 
 // ***********************************************************
 // Gummy Worm Flavors
@@ -387,28 +383,29 @@
 	desc = "An edible worm, made from gelatin. It's red!"
 	icon_state = "gworm_red"
 	filling_color = "#801E28"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/red/New()
 	..()
 	reagents.add_reagent("cherryjelly", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/blue
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's blue!"
 	icon_state = "gworm_blue"
 	filling_color = "#863333"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/blue/New()
 	..()
 	reagents.add_reagent("berryjuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/poison
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's blue!"
 	icon_state = "gworm_blue"
 	filling_color = "#863353"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/poison/New()
 	..()
@@ -416,62 +413,61 @@
 	spawn(1)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/green
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's green!"
 	icon_state = "gworm_green"
 	filling_color = "#365E30"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/green/New()
 	..()
 	reagents.add_reagent("limejuice", 10)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/yellow
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's yellow!"
 	icon_state = "gworm_yellow"
 	filling_color = "#863333"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/yellow/New()
 	..()
 	reagents.add_reagent("lemonjuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/orange
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's orange!"
 	icon_state = "gworm_orange"
 	filling_color = "#E78108"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/orange/New()
 	..()
 	reagents.add_reagent("orangejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/purple
 	name = "gummy worm"
 	desc = "An edible worm, made from gelatin. It's purple!"
 	icon_state = "gworm_purple"
 	filling_color = "#993399"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/purple/New()
 	..()
 	reagents.add_reagent("grapejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/wtf
 	name = "gummy worm"
 	desc = "An edible worm. Did it just move?"
 	icon_state = "gworm_wtf"
 	filling_color = "#60A584"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/gummyworm/wtf/New()
 	..()
 	reagents.add_reagent("space_drugs", 2)
-	bitesize = 3
 
 // ***********************************************************
 // Jelly Bean Flavors
@@ -482,28 +478,29 @@
 	desc = "A candy bean, guarenteed to not give you gas. It's red!"
 	icon_state = "jbean_red"
 	filling_color = "#801E28"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/red/New()
 	..()
 	reagents.add_reagent("cherryjelly", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/blue
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's blue!"
 	icon_state = "jbean_blue"
 	filling_color = "#863333"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/blue/New()
 	..()
 	reagents.add_reagent("berryjuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/poison
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's blue!"
 	icon_state = "jbean_blue"
 	filling_color = "#863353"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/poison/New()
 	..()
@@ -511,117 +508,116 @@
 	spawn(1)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/green
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's green!"
 	icon_state = "jbean_green"
 	filling_color = "#365E30"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/green/New()
 	..()
 	reagents.add_reagent("limejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/yellow
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's yellow!"
 	icon_state = "jbean_yellow"
 	filling_color = "#863333"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/yellow/New()
 	..()
 	reagents.add_reagent("lemonjuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/orange
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's orange!"
 	icon_state = "jbean_orange"
 	filling_color = "#E78108"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/orange/New()
 	..()
 	reagents.add_reagent("orangejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/purple
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's purple!"
 	icon_state = "jbean_purple"
 	filling_color = "#993399"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/purple/New()
 	..()
 	reagents.add_reagent("grapejuice", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/chocolate
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's chocolate!"
 	icon_state = "jbean_choc"
 	filling_color = "#302000"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/chocolate/New()
 	..()
 	reagents.add_reagent("chocolate",2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/popcorn
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's popcorn flavored!"
 	icon_state = "jbean_popcorn"
 	filling_color = "#664330"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/popcorn/New()
 	..()
 	reagents.add_reagent("nutriment", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's Cola flavored!"
 	icon_state = "jbean_cola"
 	filling_color = "#102000"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/cola/New()
 	..()
 	reagents.add_reagent("cola", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/drgibb
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's Dr. Gibb flavored!"
 	icon_state = "jbean_cola"
 	filling_color = "#102000"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/drgibb/New()
 	..()
 	reagents.add_reagent("dr_gibb", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/coffee
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. It's Coffee flavored!"
 	icon_state = "jbean_choc"
 	filling_color = "#482000"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/coffee/New()
 	..()
 	reagents.add_reagent("coffee", 2)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/wtf
 	name = "jelly bean"
 	desc = "A candy bean, guarenteed to not give you gas. You aren't sure what color it is."
 	icon_state = "jbean_wtf"
 	filling_color = "#60A584"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/jellybean/wtf/New()
 	..()
 	reagents.add_reagent("space_drugs", 2)
-	bitesize = 3
 
 // ***********************************************************
 // Cotton Candy Flavors
@@ -633,11 +629,11 @@
 	icon_state = "cottoncandy_red"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#801E28"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/red/New()
 	..()
 	reagents.add_reagent("cherryjelly", 5)
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/blue
 	name = "cotton candy"
@@ -645,11 +641,11 @@
 	icon_state = "cottoncandy_blue"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/blue/New()
 	..()
 	reagents.add_reagent("berryjuice", 5)
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/poison
 	name = "cotton candy"
@@ -657,6 +653,7 @@
 	icon_state = "cottoncandy_blue"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863353"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/poison/New()
 	..()
@@ -664,7 +661,6 @@
 	spawn(1)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/green
 	name = "cotton candy"
@@ -672,11 +668,11 @@
 	icon_state = "cottoncandy_green"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#365E30"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/green/New()
 	..()
 	reagents.add_reagent("limejuice", 5)
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/yellow
 	name = "cotton candy"
@@ -684,11 +680,11 @@
 	icon_state = "cottoncandy_yellow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/yellow/New()
 	..()
 	reagents.add_reagent("lemonjuice", 5)
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/orange
 	name = "cotton candy"
@@ -696,11 +692,11 @@
 	icon_state = "cottoncandy_orange"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#E78108"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/orange/New()
 	..()
 	reagents.add_reagent("orangejuice", 5)
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/purple
 	name = "cotton candy"
@@ -708,11 +704,11 @@
 	icon_state = "cottoncandy_purple"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#993399"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/purple/New()
 	..()
 	reagents.add_reagent("grapejuice", 5)
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/pink
 	name = "cotton candy"
@@ -720,11 +716,11 @@
 	icon_state = "cottoncandy_pink"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#863333"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/pink/New()
 	..()
 	reagents.add_reagent("watermelonjuice", 5)
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/rainbow
 	name = "cotton candy"
@@ -732,6 +728,7 @@
 	icon_state = "cottoncandy_rainbow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#C8A5DC"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/rainbow/New()
 	..()
@@ -739,7 +736,6 @@
 	spawn(1)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
-	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/bad_rainbow
 	name = "cotton candy"
@@ -747,6 +743,7 @@
 	icon_state = "cottoncandy_rainbow"
 	trash = /obj/item/weapon/c_tube
 	filling_color = "#32127A"
+	bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/cotton/bad_rainbow/New()
 	..()
@@ -754,7 +751,6 @@
 	spawn(1)
 		reagents.del_reagent("sugar")
 		reagents.update_total()
-	bitesize = 4
 
 // ***********************************************************
 // Candybar Flavors

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -82,7 +82,7 @@
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			to_chat(user, "<span class='warning'>you can't add anymore to [target]!</span>")
 			return
-		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
+		var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the condiment to [target].</span>")
 
 /obj/item/weapon/reagent_containers/food/condiment/on_reagent_change()
@@ -223,7 +223,7 @@
 			return
 		else
 			to_chat(user, "<span class='notice'>You tear open [src] above [target] and the condiments drip onto it.</span>")
-			src.reagents.trans_to(target, amount_per_transfer_from_this)
+			reagents.trans_to(target, amount_per_transfer_from_this)
 			qdel(src)
 
 /obj/item/weapon/reagent_containers/food/condiment/pack/on_reagent_change()

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -79,11 +79,7 @@
 	trash = /obj/item/trash/plate
 	bitesize = 2
 	var/list/ingredients = list()
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/pizza
 	name = "personal pizza"

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -82,7 +82,6 @@
 
 	New()
 		..()
-
 		reagents.add_reagent("nutriment", 8)
 
 

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -1,4 +1,4 @@
-/obj/item/weapon/reagent_containers/food/snacks/breadslice/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/weapon/reagent_containers/food/snacks/breadslice/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks) && !(W.flags & NODROP))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/sandwich/S = new(get_turf(user))
 		S.attackby(W,user, params)
@@ -6,13 +6,13 @@
 	else
 		..()
 
-/obj/item/weapon/reagent_containers/food/snacks/bun/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/weapon/reagent_containers/food/snacks/bun/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks) && !(W.flags & NODROP))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/burger/S = new(get_turf(user))
 		S.attackby(W,user, params)
 		qdel(src)
 
-/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks) && !(W.flags & NODROP))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pizza/S = new(get_turf(user))
 		S.attackby(W,user, params)
@@ -21,7 +21,7 @@
 		..()
 
 
-/obj/item/weapon/reagent_containers/food/snacks/boiledspagetti/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/weapon/reagent_containers/food/snacks/boiledspagetti/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks) && !(W.flags & NODROP))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/pasta/S = new(get_turf(user))
 		S.attackby(W,user, params)
@@ -30,7 +30,7 @@
 		..()
 
 
-/obj/item/trash/plate/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/trash/plate/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks) && !(W.flags & NODROP))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/fullycustom/S = new(get_turf(user))
 		S.attackby(W,user, params)
@@ -44,7 +44,7 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "soup"
 
-/obj/item/trash/bowl/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/trash/bowl/attackby(obj/item/W, mob/user, params)
 
 	if(istype(W, /obj/item/weapon/reagent_containers/food/snacks) && !(W.flags & NODROP))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/soup/S = new(get_turf(user))
@@ -54,7 +54,6 @@
 		..()
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/sandwich
-	/obj/item/weapon/reagent_containers/food/snacks/customizable
 	name = "sandwich"
 	desc = "A sandwich! A timeless classic."
 	icon_state = "breadslice"
@@ -318,7 +317,7 @@
 	toptype = new /obj/item/weapon/reagent_containers/food/snacks/bun()
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/attackby(obj/item/I, mob/user, params)
-	if(src.contents.len > sandwich_limit)
+	if(contents.len > sandwich_limit)
 		to_chat(user, "<span class='warning'>If you put anything else in or on [src] it's going to make a mess.</span>")
 		return
 	if(!istype(I, /obj/item/weapon/reagent_containers/food/snacks))
@@ -346,7 +345,7 @@
 	for(var/obj/item/O in ingredients)
 		i++
 		if(!fullycustom)
-			var/image/I = new(src.icon, "[baseicon]_filling")
+			var/image/I = new(icon, "[baseicon]_filling")
 			if(istype(O, /obj/item/weapon/reagent_containers/food/snacks))
 				var/obj/item/weapon/reagent_containers/food/snacks/food = O
 				if(!food.filling_color == "#FFFFFF")
@@ -367,7 +366,7 @@
 			overlays += O.overlays
 
 	if(top)
-		var/image/T = new(src.icon, "[baseicon]_top")
+		var/image/T = new(icon, "[baseicon]_top")
 		T.pixel_x = pick(list(-1,0,1))
 		T.pixel_y = (ingredients.len * 2)+1
 		overlays += T
@@ -383,24 +382,6 @@
 
 	to_chat(user, "<span class='notice'> You think you can see [whatsinside] in there.</span>")
 
-/*
-/obj/item/weapon/reagent_containers/food/snacks/customizable/attack(mob/M as mob, mob/user as mob, def_zone) //SNOOOOOOOWFLAAAAAAAAAAAAAAAAAKES
-
-	var/obj/item/shard
-	for(var/obj/item/O in contents)
-		if(istype(O,/obj/item/weapon/shard))
-			shard = O
-			break
-
-	var/mob/living/H
-	if(istype(M,/mob/living))
-		H = M
-
-	if(H && shard && M == user) //This needs a check for feeding the food to other people, but that could be abusable.
-		to_chat(H, "\red You lacerate your mouth on a [shard.name] in the sandwich!")
-		H.adjustBruteLoss(5) //TODO: Target head if human.
-	..()
-*/
 
 /obj/item/weapon/reagent_containers/food/snacks/customizable/proc/newname()
 	var/unsorteditems[0]
@@ -482,7 +463,7 @@
 		sendback = "[pick(list("absurd","colossal","enormous","ridiculous","massive","oversized","cardiac-arresting","pipe-clogging","edible but sickening","sickening","gargantuan","mega","belly-burster","chest-burster"))] [basename]"
 	return sendback
 
-/obj/item/weapon/reagent_containers/food/snacks/customizable/proc/sortlist(var/list/unsorted, var/highest)
+/obj/item/weapon/reagent_containers/food/snacks/customizable/proc/sortlist(list/unsorted, highest)
 	var/sorted[0]
 	for(var/i = 1, i<= highest, i++)
 		for(var/it in unsorted)

--- a/code/modules/food_and_drinks/food/meat.dm
+++ b/code/modules/food_and_drinks/food/meat.dm
@@ -4,16 +4,14 @@
 	icon_state = "meat"
 	health = 180
 	filling_color = "#FF1C1C"
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
-		src.bitesize = 3
 
-/obj/item/weapon/reagent_containers/food/snacks/meat/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if( \
-			istype(W, /obj/item/weapon/kitchen/knife) || \
-			istype(W, /obj/item/weapon/scalpel) \
-		)
+/obj/item/weapon/reagent_containers/food/snacks/meat/attackby(obj/item/weapon/W, mob/user, params)
+	if(istype(W, /obj/item/weapon/kitchen/knife) || istype(W, /obj/item/weapon/scalpel))
 		new /obj/item/weapon/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/rawcutlet(src)
 		new /obj/item/weapon/reagent_containers/food/snacks/rawcutlet(src)
@@ -49,6 +47,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/ham
 	name = "Ham"
 	desc = "Taste like bacon."
+
 	New()
 		..()
 		reagents.add_reagent("porktonium", 10)

--- a/code/modules/food_and_drinks/food/meat.dm
+++ b/code/modules/food_and_drinks/food/meat.dm
@@ -5,10 +5,7 @@
 	health = 180
 	filling_color = "#FF1C1C"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
+	list_reagents = list("protein" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/meat/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/kitchen/knife) || istype(W, /obj/item/weapon/scalpel))
@@ -47,7 +44,4 @@
 /obj/item/weapon/reagent_containers/food/snacks/meat/ham
 	name = "Ham"
 	desc = "Taste like bacon."
-
-	New()
-		..()
-		reagents.add_reagent("porktonium", 10)
+	list_reagents = list("protein" = 3, "porktonium" = 10)

--- a/code/modules/food_and_drinks/food/seafood.dm
+++ b/code/modules/food_and_drinks/food/seafood.dm
@@ -6,11 +6,7 @@
 	icon_state = "fishfillet"
 	filling_color = "#FFDEFE"
 	bitesize = 6
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
-		reagents.add_reagent("carpotoxin", 3)
+	list_reagents = list("protein" = 3, "carpotoxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/salmonmeat
 	name = "raw salmon"
@@ -19,10 +15,7 @@
 	icon_state = "fishfillet"
 	filling_color = "#FFDEFE"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
+	list_reagents = list("protein" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/salmonsteak
 	name = "Salmon steak"
@@ -32,13 +25,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#7A3D11"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("sodiumchloride", 1)
-		reagents.add_reagent("blackpepper", 1)
-
+	list_reagents = list("nutriment" = 4, "sodiumchloride" = 1, "blackpepper" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/catfishmeat
 	name = "raw catfish"
@@ -47,10 +34,7 @@
 	icon_state = "fishfillet"
 	filling_color = "#FFDEFE"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
+	list_reagents = list("protein" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/fishfingers
 	name = "Fish Fingers"
@@ -59,14 +43,7 @@
 	icon_state = "fishfingers"
 	filling_color = "#FFDEFE"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("carpotoxin", 3)
-		spawn(1)
-			reagents.del_reagent("egg")
-			reagents.update_total()
+	list_reagents = list("nutriment" = 4, "carpotoxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/fishburger
 	name = "Fillet -o- Carp Sandwich"
@@ -75,11 +52,7 @@
 	icon_state = "fishburger"
 	filling_color = "#FFDEFE"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("carpotoxin", 3)
+	list_reagents = list("nutriment" = 6, "carpotoxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/cubancarp
 	name = "Cuban Carp"
@@ -89,12 +62,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#E9ADFF"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("carpotoxin", 3)
-		reagents.add_reagent("capsaicin", 3)
+	list_reagents = list("nutriment" = 6, "carpotoxin" = 3, "capsaicin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/fishandchips
 	name = "Fish and Chips"
@@ -103,11 +71,7 @@
 	icon_state = "fishandchips"
 	filling_color = "#E3D796"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("carpotoxin", 3)
+	list_reagents = list("nutriment" = 6, "carpotoxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/sashimi
 	name = "carp sashimi"
@@ -115,11 +79,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sashimi"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("toxin", 5)
+	list_reagents = list("nutriment" = 6, "toxin" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/fried_shrimp
 	name = "fried shrimp"
@@ -127,10 +87,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "shrimp_fried"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/boiled_shrimp
 	name = "boiled shrimp"
@@ -138,10 +95,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "shrimp_cooked"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Ebi
 	name = "Ebi Sushi"
@@ -149,10 +103,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Ebi"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Ikura
 	name = "Ikura Sushi"
@@ -160,11 +111,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Ikura"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protein", 1)
+	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Sake
 	name = "Sake Sushi"
@@ -172,10 +119,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Sake"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_SmokedSalmon
 	name = "Smoked Salmon Sushi"
@@ -183,10 +127,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_SmokedSalmon"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tamago
 	name = "Tamago Sushi"
@@ -194,10 +135,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Tamago"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Inari
 	name = "Inari Sushi"
@@ -205,10 +143,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Inari"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Masago
 	name = "Masago Sushi"
@@ -216,11 +151,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Masago"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protein", 1)
+	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tobiko
 	name = "Tobiko Sushi"
@@ -228,11 +159,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Masago"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protein", 1)
+	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_TobikoEgg
 	name = "Tobiko and Egg Sushi"
@@ -240,11 +167,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_TobikoEgg"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("protein", 1)
+	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tai
 	name = "Tai Sushi"
@@ -252,10 +175,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Tai"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Unagi
 	name = "Unagi Sushi"
@@ -263,7 +183,4 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Hokki"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)

--- a/code/modules/food_and_drinks/food/seafood.dm
+++ b/code/modules/food_and_drinks/food/seafood.dm
@@ -5,12 +5,12 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishfillet"
 	filling_color = "#FFDEFE"
+	bitesize = 6
 
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
 		reagents.add_reagent("carpotoxin", 3)
-		src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/salmonmeat
 	name = "raw salmon"
@@ -18,11 +18,11 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishfillet"
 	filling_color = "#FFDEFE"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/salmonsteak
 	name = "Salmon steak"
@@ -31,13 +31,13 @@
 	icon_state = "salmonsteak"
 	trash = /obj/item/trash/plate
 	filling_color = "#7A3D11"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("sodiumchloride", 1)
 		reagents.add_reagent("blackpepper", 1)
-		bitesize = 3
 
 
 /obj/item/weapon/reagent_containers/food/snacks/catfishmeat
@@ -46,11 +46,11 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishfillet"
 	filling_color = "#FFDEFE"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/fishfingers
 	name = "Fish Fingers"
@@ -58,6 +58,7 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishfingers"
 	filling_color = "#FFDEFE"
+	bitesize = 3
 
 	New()
 		..()
@@ -66,7 +67,6 @@
 		spawn(1)
 			reagents.del_reagent("egg")
 			reagents.update_total()
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/fishburger
 	name = "Fillet -o- Carp Sandwich"
@@ -74,12 +74,12 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishburger"
 	filling_color = "#FFDEFE"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("carpotoxin", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/cubancarp
 	name = "Cuban Carp"
@@ -88,13 +88,13 @@
 	icon_state = "cubancarp"
 	trash = /obj/item/trash/plate
 	filling_color = "#E9ADFF"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("carpotoxin", 3)
 		reagents.add_reagent("capsaicin", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/fishandchips
 	name = "Fish and Chips"
@@ -102,168 +102,168 @@
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishandchips"
 	filling_color = "#E3D796"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("carpotoxin", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sashimi
 	name = "carp sashimi"
 	desc = "Celebrate surviving attack from hostile alien lifeforms by hospitalising yourself."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sashimi"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("toxin", 5)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/fried_shrimp
 	name = "fried shrimp"
 	desc = "Just one of the many things you can do with shrimp!"
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "shrimp_fried"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/boiled_shrimp
 	name = "boiled shrimp"
 	desc = "Just one of the many things you can do with shrimp!"
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "shrimp_cooked"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Ebi
 	name = "Ebi Sushi"
 	desc = "A simple sushi consisting of cooked shrimp and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Ebi"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Ikura
 	name = "Ikura Sushi"
 	desc = "A simple sushi consisting of salmon roe."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Ikura"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("protein", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Sake
 	name = "Sake Sushi"
 	desc = "A simple sushi consisting of raw salmon and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Sake"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_SmokedSalmon
 	name = "Smoked Salmon Sushi"
 	desc = "A simple sushi consisting of cooked salmon and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_SmokedSalmon"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tamago
 	name = "Tamago Sushi"
 	desc = "A simple sushi consisting of egg and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Tamago"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Inari
 	name = "Inari Sushi"
 	desc = "A piece of fried tofu stuffed with rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Inari"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Masago
 	name = "Masago Sushi"
 	desc = "A simple sushi consisting of goldfish roe."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Masago"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("protein", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tobiko
 	name = "Tobiko Sushi"
 	desc = "A simple sushi consisting of shark roe."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Masago"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("protein", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_TobikoEgg
 	name = "Tobiko and Egg Sushi"
 	desc = "A sushi consisting of shark roe and an egg."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_TobikoEgg"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("protein", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Tai
 	name = "Tai Sushi"
 	desc = "A simple sushi consisting of catfish and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Tai"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sushi_Unagi
 	name = "Unagi Sushi"
 	desc = "A simple sushi consisting of eel and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Hokki"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -63,11 +63,11 @@
 		if(bitecount==0)
 			return
 		else if(bitecount==1)
-			to_chat(user, "\blue \The [src] was bitten by someone!")
+			to_chat(user, "<span class='notice'>[src] was bitten by someone!</span>")
 		else if(bitecount<=3)
-			to_chat(user, "\blue \The [src] was bitten [bitecount] times!")
+			to_chat(user, "<span class='notice'>[src] was bitten [bitecount] times!</span>")
 		else
-			to_chat(user, "\blue \The [src] was bitten multiple times!")
+			to_chat(user, "<span class='notice'>[src] was bitten multiple times!</span>")
 
 
 /obj/item/weapon/reagent_containers/food/snacks/attackby(obj/item/weapon/W, mob/user, params)
@@ -92,10 +92,10 @@
 			"<span class='notice'>You scoop up some [src] with \the [U]!" \
 		)
 
-		src.bitecount++
+		bitecount++
 		U.overlays.Cut()
 		var/image/I = new(U.icon, "loadedfood")
-		I.color = src.filling_color
+		I.color = filling_color
 		U.overlays += I
 
 		var/obj/item/weapon/reagent_containers/food/snacks/collected = new type
@@ -135,7 +135,7 @@
 	else if(W.w_class <= 2 && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
 		if(!iscarbon(user))
 			return 1
-		to_chat(user, "\red You slip [W] inside [src].")
+		to_chat(user, "<span class='warning'>You slip [W] inside [src].</span>")
 		user.unEquip(W)
 		if((user.client && user.s_active != src))
 			user.client.screen -= W
@@ -146,28 +146,28 @@
 	else
 		return 1
 	if( \
-			!isturf(src.loc) || \
-			!(locate(/obj/structure/table) in src.loc) && \
-			!(locate(/obj/machinery/optable) in src.loc) && \
-			!(locate(/obj/item/weapon/storage/bag/tray) in src.loc) \
+			!isturf(loc) || \
+			!(locate(/obj/structure/table) in loc) && \
+			!(locate(/obj/machinery/optable) in loc) && \
+			!(locate(/obj/item/weapon/storage/bag/tray) in loc) \
 		)
-		to_chat(user, "\red You cannot slice [src] here! You need a table or at least a tray to do it.")
+		to_chat(user, "<span class='warning'>You cannot slice [src] here! You need a table or at least a tray to do it.</span>")
 		return 1
 	var/slices_lost = 0
 	if(!inaccurate)
 		user.visible_message( \
-			"\blue [user] slices \the [src]!", \
-			"\blue You slice \the [src]!" \
+			"<span class='notice'>[user] slices [src]!</span>", \
+			"<span class='notice'>You slice [src]!</span>" \
 		)
 	else
 		user.visible_message( \
-			"\blue [user] crudely slices \the [src] with [W]!", \
-			"\blue You crudely slice \the [src] with your [W]!" \
+			"<span class='notice'>[user] crudely slices [src] with [W]!</span>", \
+			"<span class='notice'>You crudely slice [src] with your [W]</span>!" \
 		)
 		slices_lost = rand(1,min(1,round(slices_num/2)))
 	var/reagents_per_slice = reagents.total_volume/slices_num
 	for(var/i=1 to (slices_num-slices_lost))
-		var/obj/slice = new slice_path (src.loc)
+		var/obj/slice = new slice_path (loc)
 		reagents.trans_to(slice,reagents_per_slice)
 	qdel(src)
 
@@ -184,19 +184,19 @@
 		M.changeNext_move(CLICK_CD_MELEE)
 		if(iscorgi(M))
 			if(bitecount >= 4)
-				M.visible_message("[M] [pick("burps from enjoyment", "yaps for more", "woofs twice", "looks at the area where \the [src] was")].","<span class=\"notice\">You swallow up the last part of \the [src].")
-				playsound(src.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+				M.visible_message("[M] [pick("burps from enjoyment", "yaps for more", "woofs twice", "looks at the area where [src] was")].","<span class='notice'>You swallow up the last part of [src].</span>")
+				playsound(loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 				var/mob/living/simple_animal/pet/corgi/C = M
 				C.adjustBruteLoss(-5)
 				C.adjustFireLoss(-5)
 				qdel(src)
 			else
-				M.visible_message("[M] takes a bite of \the [src].","<span class=\"notice\">You take a bite of \the [src].")
-				playsound(src.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+				M.visible_message("[M] takes a bite of [src].","<span class='notice'>You take a bite of [src].</span>")
+				playsound(loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 				bitecount++
 		else if(ismouse(M))
 			var/mob/living/simple_animal/mouse/N = M
-			to_chat(N, text("\blue You nibble away at [src]."))
+			to_chat(N, text("<span class='notice'>You nibble away at [src].</span>"))
 			if(prob(50))
 				N.visible_message("[N] nibbles away at [src].", "")
 			//N.emote("nibbles away at the [src]")
@@ -752,8 +752,8 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/throw_impact(atom/hit_atom)
 	..()
-	new/obj/effect/decal/cleanable/pie_smudge(src.loc)
-	src.visible_message("\red [src.name] splats.","\red You hear a splat.")
+	new/obj/effect/decal/cleanable/pie_smudge(loc)
+	visible_message("<span class='warning'>[src] splats.</span>","<span class='warning'>You hear a splat.</span>")
 	qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/berryclafoutis
@@ -902,7 +902,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/popcorn/On_Consume(mob/M, mob/user)
 	if(prob(unpopped))	//lol ...what's the point?
-		to_chat(user, "\red You bite down on an un-popped kernel!")
+		to_chat(user, "<span class='userdanger'>You bite down on an un-popped kernel!</span>")
 		unpopped = max(0, unpopped-1)
 	..()
 
@@ -1728,9 +1728,9 @@
 	if(istype(W,/obj/item/weapon/kitchen/rollingpin))
 		user.visible_message( \
 			"[user] flattens the dough with the rolling pin!", \
-			"\blue You flatten the dough with your rolling pin!" \
+			"<span class='notice'>You flatten the dough with your rolling pin!</span>" \
 			)
-		new /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough(src.loc)
+		new /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough(loc)
 		qdel(src)
 
 /////////////////////////////////////////////////Sliceable////////////////////////////////////////
@@ -2124,7 +2124,7 @@
 			"[user] cuts the raw cutlet with the knife!", \
 			"<span class ='notice'>You cut the raw cutlet with your knife!</span>" \
 			)
-		new /obj/item/weapon/reagent_containers/food/snacks/raw_bacon(src.loc)
+		new /obj/item/weapon/reagent_containers/food/snacks/raw_bacon(loc)
 		qdel(src)
 
 
@@ -2264,8 +2264,8 @@
 /obj/item/pizzabox/attack_hand(mob/user)
 	if(open && pizza)
 		user.put_in_hands(pizza)
-		to_chat(user, "\red You take the [src.pizza] out of the [src].")
-		src.pizza = null
+		to_chat(user, "<span class='warning'>You take the [pizza] out of the [src].</span>")
+		pizza = null
 		update_icon()
 		return
 
@@ -2278,7 +2278,7 @@
 		boxes -= box
 
 		user.put_in_hands( box )
-		to_chat(user, "\red You remove the topmost [src] from your hand.")
+		to_chat(user, "<span class='warning'>You remove the topmost [src] from your hand.</span>")
 		box.update_icon()
 		update_icon()
 		return
@@ -2311,16 +2311,16 @@
 
 				box.loc = src
 				box.boxes = list() // Clear the box boxes so we don't have boxes inside boxes. - Xzibit
-				src.boxes.Add( boxestoadd )
+				boxes.Add( boxestoadd )
 
 				box.update_icon()
 				update_icon()
 
-				to_chat(user, "\red You put the [box] ontop of the [src]!")
+				to_chat(user, "<span class='warning'>You put the [box] ontop of the [src]!</span>")
 			else
-				to_chat(user, "\red The stack is too high!")
+				to_chat(user, "<span class='warning'>The stack is too high!</span>")
 		else
-			to_chat(user, "\red Close the [box] first!")
+			to_chat(user, "<span class='warning'>Close the [box] first!</span>")
 
 		return
 
@@ -2329,18 +2329,18 @@
 		if(open)
 			user.drop_item()
 			I.loc = src
-			src.pizza = I
+			pizza = I
 
 			update_icon()
 
-			to_chat(user, "\red You put the [I] in the [src]!")
+			to_chat(user, "<span class='warning'>You put the [I] in the [src]!</span>")
 		else
-			to_chat(user, "\red You try to push the [I] through the lid but it doesn't work!")
+			to_chat(user, "<span class='warning'>You try to push the [I] through the lid but it doesn't work!</span>")
 		return
 
 	if(istype(I, /obj/item/weapon/pen/))
 
-		if( src.open )
+		if(open)
 			return
 
 		var/t = input("Enter what you want to add to the tag:", "Write", null, null) as text

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -255,11 +255,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#468C00"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("omnizine", 8)
+	list_reagents = list("nutriment" = 8, "omnizine" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/chips
 	name = "chips"
@@ -267,11 +263,7 @@
 	icon_state = "chips"
 	trash = /obj/item/trash/chips
 	filling_color = "#E8C31E"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("sodiumchloride", 1)
+	list_reagents = list("nutriment" = 3, "sodiumchloride" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/cornchips
 	name = "corn chips"
@@ -279,20 +271,14 @@
 	icon_state = "chips"
 	trash = /obj/item/trash/chips
 	filling_color = "#E8C31E"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/cookie
 	name = "cookie"
 	desc = "COOKIE!!!"
 	icon_state = "COOKIE!!!"
 	filling_color = "#DBC94F"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/chocolatebar
 	name = "Chocolate Bar"
@@ -300,11 +286,7 @@
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("chocolate",4)
+	list_reagents = list("nutriment" = 2, "chocolate" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/choc_pile //for reagent chocolate being spilled on turfs
 	name = "Pile of Chocolate"
@@ -312,10 +294,7 @@
 	icon_state = "cocoa"
 	filling_color = "#7D5F46"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("chocolate",5)		//no longer can be used to generate the reagent infinitely
+	list_reagents = list("chocolate" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/chocolateegg
 	name = "Chocolate Egg"
@@ -323,11 +302,7 @@
 	icon_state = "chocolateegg"
 	filling_color = "#7D5F46"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("chocolate",4)
+	list_reagents = list("nutriment" = 3, "chocolate" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut
 	name = "donut"
@@ -340,23 +315,19 @@
 	name = "donut"
 	desc = "Goes great with Robust Coffee."
 	icon_state = "donut1"
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("sprinkles", 1)
-		if(prob(30))
-			src.icon_state = "donut2"
-			src.name = "frosted donut"
-			reagents.add_reagent("sprinkles", 2)
+	list_reagents = list("nutriment" = 3, "sprinkles" = 1)
+
+/obj/item/weapon/reagent_containers/food/snacks/donut/normal/New()
+	..()
+	if(prob(30))
+		icon_state = "donut2"
+		name = "frosted donut"
+		reagents.add_reagent("sprinkles", 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/sprinkles
 	name = "frosted donut"
 	icon_state = "donut2"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("sprinkles", 3)
+	list_reagents = list("nutriment" = 3, "sprinkles" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/chaos
 	name = "Chaos Donut"
@@ -365,36 +336,14 @@
 	filling_color = "#ED11E6"
 	bitesize = 10
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("sprinkles", 1)
-		var/chaosselect = pick(1,2,3,4,5,6,7,8,9,10)
-		switch(chaosselect)
-			if(1)
-				reagents.add_reagent("nutriment", 3)
-			if(2)
-				reagents.add_reagent("capsaicin", 3)
-			if(3)
-				reagents.add_reagent("frostoil", 3)
-			if(4)
-				reagents.add_reagent("sprinkles", 3)
-			if(5)
-				reagents.add_reagent("plasma", 3)
-			if(6)
-				reagents.add_reagent("chocolate", 3)
-			if(7)
-				reagents.add_reagent("slimejelly", 3)
-			if(8)
-				reagents.add_reagent("banana", 3)
-			if(9)
-				reagents.add_reagent("berryjuice", 3)
-			if(10)
-				reagents.add_reagent("omnizine", 3)
-		if(prob(30))
-			src.icon_state = "donut2"
-			src.name = "Frosted Chaos Donut"
-			reagents.add_reagent("sprinkles", 2)
+/obj/item/weapon/reagent_containers/food/snacks/donut/chaos/New()
+	..()
+	var/extra_reagent = pick("nutriment", "capsaicin", "frostoil", "sprinkles", "plasma", "chocolate", "slimejelly", "banana", "berryjuice", "omnizine")
+	reagents.add_reagent("[extra_reagent]", 3)
+	if(prob(30))
+		icon_state = "donut2"
+		name = "Frosted Chaos Donut"
+		reagents.add_reagent("sprinkles", 2)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/jelly
@@ -403,16 +352,14 @@
 	icon_state = "jdonut1"
 	filling_color = "#ED1169"
 	bitesize = 5
+	list_reagents = list("nutriment" = 3, "sprinkles" = 1, "berryjuice" = 5)
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("sprinkles", 1)
-		reagents.add_reagent("berryjuice", 5)
-		if(prob(30))
-			src.icon_state = "jdonut2"
-			src.name = "Frosted Jelly Donut"
-			reagents.add_reagent("sprinkles", 2)
+/obj/item/weapon/reagent_containers/food/snacks/donut/jelly/New()
+	..()
+	if(prob(30))
+		icon_state = "jdonut2"
+		name = "Frosted Jelly Donut"
+		reagents.add_reagent("sprinkles", 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/slimejelly
 	name = "Jelly Donut"
@@ -420,16 +367,14 @@
 	icon_state = "jdonut1"
 	filling_color = "#ED1169"
 	bitesize = 5
+	list_reagents = list("nutriment" = 3, "sprinkles" = 1, "slimejelly" = 5)
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("sprinkles", 1)
-		reagents.add_reagent("slimejelly", 5)
-		if(prob(30))
-			src.icon_state = "jdonut2"
-			src.name = "Frosted Jelly Donut"
-			reagents.add_reagent("sprinkles", 2)
+/obj/item/weapon/reagent_containers/food/snacks/donut/slimejelly/New()
+	..()
+	if(prob(30))
+		icon_state = "jdonut2"
+		name = "Frosted Jelly Donut"
+		reagents.add_reagent("sprinkles", 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly
 	name = "Jelly Donut"
@@ -437,50 +382,44 @@
 	icon_state = "jdonut1"
 	filling_color = "#ED1169"
 	bitesize = 5
+	list_reagents = list("nutriment" = 3, "sprinkles" = 1, "cherryjelly" = 5)
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("sprinkles", 1)
-		reagents.add_reagent("cherryjelly", 5)
-		if(prob(30))
-			src.icon_state = "jdonut2"
-			src.name = "Frosted Jelly Donut"
-			reagents.add_reagent("sprinkles", 2)
+/obj/item/weapon/reagent_containers/food/snacks/donut/cherryjelly/New()
+	..()
+	if(prob(30))
+		icon_state = "jdonut2"
+		name = "Frosted Jelly Donut"
+		reagents.add_reagent("sprinkles", 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/egg
 	name = "egg"
 	desc = "An egg!"
 	icon_state = "egg"
 	filling_color = "#FDFFD1"
+	list_reagents = list("protein" = 1, "egg" = 5)
 
-	New()
+/obj/item/weapon/reagent_containers/food/snacks/egg/throw_impact(atom/hit_atom)
+	..()
+	var/turf/T = get_turf(hit_atom)
+	new/obj/effect/decal/cleanable/egg_smudge(T)
+	if(reagents)
+		reagents.reaction(hit_atom, TOUCH)
+	qdel(src)
+
+/obj/item/weapon/reagent_containers/food/snacks/egg/attackby(obj/item/weapon/W, mob/user, params)
+	if(istype( W, /obj/item/toy/crayon ))
+		var/obj/item/toy/crayon/C = W
+		var/clr = C.colourName
+
+		if(!(clr in list("blue","green","mime","orange","purple","rainbow","red","yellow")))
+			to_chat(usr, "<span class ='notice'>The egg refuses to take on this color!</span>")
+			return
+
+		to_chat(usr, "<span class ='notice'>You color \the [src] [clr]</span>")
+		icon_state = "egg-[clr]"
+		item_color = clr
+	else
 		..()
-		reagents.add_reagent("protein", 1)
-		reagents.add_reagent("egg", 5)
-
-	throw_impact(atom/hit_atom)
-		..()
-		var/turf/T = get_turf(hit_atom)
-		new/obj/effect/decal/cleanable/egg_smudge(T)
-		if(reagents)
-			reagents.reaction(hit_atom, TOUCH)
-		qdel(src)
-
-	attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-		if(istype( W, /obj/item/toy/crayon ))
-			var/obj/item/toy/crayon/C = W
-			var/clr = C.colourName
-
-			if(!(clr in list("blue","green","mime","orange","purple","rainbow","red","yellow")))
-				to_chat(usr, "\blue The egg refuses to take on this color!")
-				return
-
-			to_chat(usr, "\blue You color \the [src] [clr]")
-			icon_state = "egg-[clr]"
-			item_color = clr
-		else
-			..()
 
 /obj/item/weapon/reagent_containers/food/snacks/egg/blue
 	icon_state = "egg-blue"
@@ -519,24 +458,14 @@
 	desc = "A fried egg, with a touch of salt and pepper."
 	icon_state = "friedegg"
 	filling_color = "#FFDF78"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("egg", 5)
-		reagents.add_reagent("sodiumchloride", 1)
-		reagents.add_reagent("blackpepper", 1)
+	list_reagents = list("nutriment" = 2, "egg" = 5, "sodiumchloride" = 1, "blackpepper" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledegg
 	name = "Boiled egg"
 	desc = "A hard boiled egg."
 	icon_state = "egg"
 	filling_color = "#FFFFFF"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("egg", 5)
+	list_reagents = list("nutriment" = 2, "egg" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/organ
 
@@ -546,10 +475,7 @@
 	icon_state = "appendix"
 	filling_color = "#E00D34"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 4)
+	list_reagents = list("protein" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/appendix
 //yes, this is the same as meat. I might do something different in future
@@ -559,10 +485,7 @@
 	icon_state = "appendix"
 	filling_color = "#E00D34"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
+	list_reagents = list("protein" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/appendix/inflamed
 	name = "inflamed appendix"
@@ -576,10 +499,7 @@
 	desc = "We all love tofu."
 	filling_color = "#FFFEE0"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 3)
+	list_reagents = list("plantmatter" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/fried_tofu
 	name = "Fried Tofu"
@@ -587,10 +507,7 @@
 	desc = "Proof that even vegetarians crave unhealthy foods."
 	filling_color = "#FFFEE0"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/tofurkey
 	name = "Tofurkey"
@@ -598,21 +515,14 @@
 	icon_state = "tofurkey"
 	filling_color = "#FFFEE0"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 12)
-		reagents.add_reagent("ether", 3)
+	list_reagents = list("nutriment" = 12, "ether" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/stuffing
 	name = "Stuffing"
 	desc = "Moist, peppery breadcrumbs for filling the body cavities of dead birds. Dig in!"
 	icon_state = "stuffing"
 	filling_color = "#C9AC83"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice
 	name = "huge mushroom slice"
@@ -620,11 +530,7 @@
 	icon_state = "hugemushroomslice"
 	filling_color = "#E0D7C5"
 	bitesize = 6
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 3)
-		reagents.add_reagent("psilocybin", 3)
+	list_reagents = list("plantmatter" = 3, "psilocybin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/tomatomeat
 	name = "tomato slice"
@@ -632,10 +538,7 @@
 	icon_state = "tomatomeat"
 	filling_color = "#DB0000"
 	bitesize = 6
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
+	list_reagents = list("protein" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/bearmeat
 	name = "bear meat"
@@ -643,11 +546,7 @@
 	icon_state = "bearmeat"
 	filling_color = "#DB0000"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 12)
-		reagents.add_reagent("methamphetamine", 5)
+	list_reagents = list("protein" = 12, "methamphetamine" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/xenomeat
 	name = "meat"
@@ -655,21 +554,14 @@
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
 	bitesize = 6
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
+	list_reagents = list("protein" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/spidermeat
 	name = "spider meat"
 	desc = "A slab of spider meat."
 	icon_state = "spidermeat"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
-		reagents.add_reagent("toxin", 3)
+	list_reagents = list("protein" = 3, "toxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/lizardmeat
 	name = "mutant lizard meat"
@@ -677,22 +569,14 @@
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
-		reagents.add_reagent("toxin", 3)
+	list_reagents = list("protein" = 3, "toxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/spiderleg
 	name = "spider leg"
 	desc = "A still twitching leg of a giant spider... you don't really want to eat this, do you?"
 	icon_state = "spiderleg"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 2)
-		reagents.add_reagent("toxin", 2)
+	list_reagents = list("protein" = 2, "toxin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatball
 	name = "Meatball"
@@ -700,10 +584,7 @@
 	icon_state = "meatball"
 	filling_color = "#DB0000"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 3)
+	list_reagents = list("protein" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/sausage
 	name = "Sausage"
@@ -711,45 +592,31 @@
 	icon_state = "sausage"
 	filling_color = "#DB0000"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 6)
-		reagents.add_reagent("porktonium", 10)
+	list_reagents = list("protein" = 6, "porktonium" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket
 	name = "Donk-pocket"
 	desc = "The food of choice for the seasoned traitor."
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
+	list_reagents = list("nutriment" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/warmdonkpocket
 	name = "Warm Donk-pocket"
 	desc = "The food of choice for the seasoned traitor."
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
+	list_reagents = list("nutriment" = 4)
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-
-	Post_Consume(mob/living/M)
-		M.reagents.add_reagent("omnizine", 15)
+/obj/item/weapon/reagent_containers/food/snacks/warmdonkpocket/Post_Consume(mob/living/M)
+	M.reagents.add_reagent("omnizine", 15)
 
 /obj/item/weapon/reagent_containers/food/snacks/warmdonkpocket_weak
 	name = "Lightly Warm Donk-pocket"
 	desc = "The food of choice for the seasoned traitor. This one is lukewarm."
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
-
-/obj/item/weapon/reagent_containers/food/snacks/warmdonkpocket_weak/New()
-	..()
-	reagents.add_reagent("nutriment", 4)
-	reagents.add_reagent("weak_omnizine", 3)
+	list_reagents = list("nutriment" = 4, "weak_omnizine" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/syndidonkpocket
 	name = "Donk-pocket"
@@ -757,18 +624,15 @@
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
 	bitesize = 100 //nom the whole thing at once.
+	list_reagents = list("nutriment" = 1)
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 1)
-
-	Post_Consume(mob/living/M)
-		M.reagents.add_reagent("omnizine", 15)
-		M.reagents.add_reagent("teporone", 15)
-		M.reagents.add_reagent("synaptizine", 15)
-		M.reagents.add_reagent("salglu_solution", 15)
-		M.reagents.add_reagent("salbutamol", 15)
-		M.reagents.add_reagent("methamphetamine", 15)
+/obj/item/weapon/reagent_containers/food/snacks/syndidonkpocket/Post_Consume(mob/living/M)
+	M.reagents.add_reagent("omnizine", 15)
+	M.reagents.add_reagent("teporone", 15)
+	M.reagents.add_reagent("synaptizine", 15)
+	M.reagents.add_reagent("salglu_solution", 15)
+	M.reagents.add_reagent("salbutamol", 15)
+	M.reagents.add_reagent("methamphetamine", 15)
 
 /obj/item/weapon/reagent_containers/food/snacks/brainburger
 	name = "brainburger"
@@ -776,11 +640,7 @@
 	icon_state = "brainburger"
 	filling_color = "#F2B6EA"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("prions", 10)
+	list_reagents = list("nutriment" = 6, "prions" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/ghostburger
 	name = "Ghost Burger"
@@ -788,11 +648,7 @@
 	icon_state = "ghostburger"
 	filling_color = "#FFF2FF"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/human
 	var/hname = ""
@@ -804,19 +660,13 @@
 	desc = "A bloody burger."
 	icon_state = "hburger"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/cheeseburger
 	name = "cheeseburger"
 	desc = "The cheese adds a good flavor."
 	icon_state = "cheeseburger"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeyburger
 	name = "burger"
@@ -824,10 +674,7 @@
 	icon_state = "hburger"
 	filling_color = "#D63C3C"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/tofuburger
 	name = "Tofu Burger"
@@ -835,10 +682,7 @@
 	icon_state = "tofuburger"
 	filling_color = "#FFFEE0"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/roburger
 	name = "roburger"
@@ -846,11 +690,7 @@
 	icon_state = "roburger"
 	filling_color = "#CCCCCC"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("nanomachines", 10)
+	list_reagents = list("nutriment" = 2, "nanomachines" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/roburgerbig
 	name = "roburger"
@@ -859,10 +699,7 @@
 	filling_color = "#CCCCCC"
 	volume = 100
 	bitesize = 0.1
-
-	New()
-		..()
-		reagents.add_reagent("nanomachines", 100)
+	list_reagents = list("nanomachines" = 100)
 
 /obj/item/weapon/reagent_containers/food/snacks/xenoburger
 	name = "xenoburger"
@@ -870,10 +707,7 @@
 	icon_state = "xburger"
 	filling_color = "#43DE18"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/clownburger
 	name = "Clown Burger"
@@ -881,15 +715,7 @@
 	icon_state = "clownburger"
 	filling_color = "#FF00FF"
 	bitesize = 2
-
-	New()
-		..()
-/*
-		var/datum/disease/F = new /datum/disease/pierrot_throat(0)
-		var/list/data = list("viruses"= list(F))
-		reagents.add_reagent("blood", 4, data)
-*/
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/mimeburger
 	name = "Mime Burger"
@@ -897,10 +723,7 @@
 	icon_state = "mimeburger"
 	filling_color = "#FFFFFF"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/omelette
 	name = "Omelette Du Fromage"
@@ -908,10 +731,7 @@
 	icon_state = "omelette"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFF9A8"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/muffin
 	name = "Muffin"
@@ -919,10 +739,7 @@
 	icon_state = "muffin"
 	filling_color = "#E0CF9B"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie
 	name = "Banana Cream Pie"
@@ -931,11 +748,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FBFFB8"
 	bitesize = 3
-
-/obj/item/weapon/reagent_containers/food/snacks/pie/New()
-	..()
-	reagents.add_reagent("nutriment", 4)
-	reagents.add_reagent("banana",5)
+	list_reagents = list("nutriment" = 4, "banana" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/throw_impact(atom/hit_atom)
 	..()
@@ -949,11 +762,7 @@
 	icon_state = "berryclafoutis"
 	trash = /obj/item/trash/plate
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("berryjuice", 5)
+	list_reagents = list("nutriment" = 4, "berryjuice" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/waffles
 	name = "waffles"
@@ -962,10 +771,7 @@
 	trash = /obj/item/trash/waffles
 	filling_color = "#E6DEB5"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/eggplantparm
 	name = "Eggplant Parmigiana"
@@ -974,10 +780,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#4D2F5E"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/soylentgreen
 	name = "Soylent Green"
@@ -986,10 +789,7 @@
 	trash = /obj/item/trash/waffles
 	filling_color = "#B8E6B5"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
+	list_reagents = list("nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/soylenviridians
 	name = "Soylen Virdians"
@@ -998,11 +798,7 @@
 	trash = /obj/item/trash/waffles
 	filling_color = "#E6FA61"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
-
+	list_reagents = list("nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpie
 	name = "Meat-pie"
@@ -1011,10 +807,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#948051"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
+	list_reagents = list("nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/tofupie
 	name = "Tofu-pie"
@@ -1023,10 +816,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FFFEE0"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
+	list_reagents = list("nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/amanita_pie
 	name = "amanita pie"
@@ -1034,12 +824,7 @@
 	icon_state = "amanita_pie"
 	filling_color = "#FFCCCC"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
-		reagents.add_reagent("amanitin", 3)
-		reagents.add_reagent("psilocybin", 1)
+	list_reagents = list("nutriment" = 5, "amanitin" = 3, "psilocybin" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/plump_pie
 	name = "plump pie"
@@ -1047,16 +832,14 @@
 	icon_state = "plump_pie"
 	filling_color = "#B8279B"
 	bitesize = 2
+	list_reagents = list("nutriment" = 8)
 
-	New()
-		..()
-		if(prob(10))
-			name = "exceptional plump pie"
-			desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump pie!"
-			reagents.add_reagent("nutriment", 8)
-			reagents.add_reagent("omnizine", 5)
-		else
-			reagents.add_reagent("nutriment", 8)
+/obj/item/weapon/reagent_containers/food/snacks/plump_pie/New()
+	..()
+	if(prob(10))
+		name = "exceptional plump pie"
+		desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump pie!" // What
+		reagents.add_reagent("omnizine", 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/xemeatpie
 	name = "Xeno-pie"
@@ -1065,10 +848,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#43DE18"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
+	list_reagents = list("nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/wingfangchu
 	name = "Wing Fang Chu"
@@ -1077,11 +857,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#43DE18"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/human/kabob
 	name = "-kabob"
@@ -1090,10 +866,7 @@
 	trash = /obj/item/stack/rods
 	filling_color = "#A85340"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeykabob
 	name = "Meat-kabob"
@@ -1102,10 +875,7 @@
 	trash = /obj/item/stack/rods
 	filling_color = "#A85340"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/tofukabob
 	name = "Tofu-kabob"
@@ -1114,10 +884,7 @@
 	trash = /obj/item/stack/rods
 	filling_color = "#FFFEE0"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/popcorn
 	name = "Popcorn"
@@ -1127,18 +894,17 @@
 	var/unpopped = 0
 	filling_color = "#FFFAD4"
 	bitesize = 0.1 //this snack is supposed to be eating during looooong time. And this it not dinner food! --rastaf0
+	list_reagents = list("nutriment" = 2)
 
-	New()
-		..()
-		unpopped = rand(1,10)
-		reagents.add_reagent("nutriment", 2)
+/obj/item/weapon/reagent_containers/food/snacks/popcorn/New()
+	..()
+	unpopped = rand(1,10)
 
-	On_Consume(mob/M, mob/user)
-		if(prob(unpopped))	//lol ...what's the point?
-			to_chat(user, "\red You bite down on an un-popped kernel!")
-			unpopped = max(0, unpopped-1)
-		..()
-
+/obj/item/weapon/reagent_containers/food/snacks/popcorn/On_Consume(mob/M, mob/user)
+	if(prob(unpopped))	//lol ...what's the point?
+		to_chat(user, "\red You bite down on an un-popped kernel!")
+		unpopped = max(0, unpopped-1)
+	..()
 
 /obj/item/weapon/reagent_containers/food/snacks/sosjerky
 	name = "Scaredy's Private Reserve Beef Jerky"
@@ -1147,10 +913,7 @@
 	trash = /obj/item/trash/sosjerky
 	filling_color = "#631212"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 4)
+	list_reagents = list("protein" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/pistachios
 	name = "Pistachios"
@@ -1158,11 +921,7 @@
 	desc = "A snack of deliciously salted pistachios. A perfectly valid choice..."
 	trash = /obj/item/trash/pistachios
 	filling_color = "#BAD145"
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 6)
-		reagents.add_reagent("sodiumchloride", 1)
+	list_reagents = list("plantmatter" = 6, "sodiumchloride" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/no_raisin
 	name = "4no Raisins"
@@ -1170,10 +929,7 @@
 	desc = "Best raisins in the universe. Not sure why."
 	trash = /obj/item/trash/raisins
 	filling_color = "#343834"
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 6)
+	list_reagents = list("plantmatter" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/spacetwinkie
 	name = "Space Twinkie"
@@ -1181,10 +937,7 @@
 	desc = "Guaranteed to survive longer then you will."
 	filling_color = "#FFE591"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("sugar", 4)
+	list_reagents = list("sugar" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers
 	name = "Cheesie Honkers"
@@ -1193,58 +946,35 @@
 	trash = /obj/item/trash/cheesie
 	filling_color = "#FFA305"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("fake_cheese", 2)
+	list_reagents = list("nutriment" = 4, "fake_cheese" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/chowmein
 	name = "chow mein"
 	desc = "What is in this anyways?"
 	icon_state = "chinese1"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("beans", 3)
-		reagents.add_reagent("msg",4)
+	list_reagents = list("nutriment" = 6, "beans" = 3, "msg" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/tao
 	name = "Admiral Yamamoto carp"
 	desc = "Tastes like chicken."
 	icon_state = "chinese2"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("protein", 2)
-		reagents.add_reagent("msg",4)
+	list_reagents = list("nutriment" = 4, "protein" = 2, "msg" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles
 	name = "chinese newdles"
 	desc = "Made fresh, weekly!"
 	icon_state = "chinese3"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("msg",4)
+	list_reagents = list("nutriment" = 6, "msg" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/rice
 	name = "fried rice"
 	desc = "A timeless classic."
 	icon_state = "chinese4"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("rice", 3)
-		reagents.add_reagent("msg",4)
+	list_reagents = list("nutriment" = 3, "rice" = 3, "msg" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/syndicake
 	name = "Syndi-Cakes"
@@ -1253,11 +983,7 @@
 	filling_color = "#FF5D05"
 	trash = /obj/item/trash/syndi_cakes
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("salglu_solution", 5)
+	list_reagents = list("nutriment" = 4, "salglu_solution" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato
 	name = "Loaded Baked Potato"
@@ -1265,10 +991,7 @@
 	icon_state = "loadedbakedpotato"
 	filling_color = "#9C7A68"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/fries
 	name = "Space Fries"
@@ -1277,10 +1000,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
+	list_reagents = list("nutriment" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/soydope
 	name = "Soy Dope"
@@ -1289,20 +1009,14 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#C4BF76"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/spagetti
 	name = "Spagetti"
 	desc = "A bundle of raw spaghetti."
 	icon_state = "spagetti"
 	filling_color = "#EDDD00"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 1)
+	list_reagents = list("nutriment" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesyfries
 	name = "Cheesy Fries"
@@ -1311,10 +1025,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/fortunecookie
 	name = "Fortune cookie"
@@ -1322,10 +1033,7 @@
 	icon_state = "fortune_cookie"
 	filling_color = "#E8E79E"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/badrecipe
 	name = "Burned mess"
@@ -1333,14 +1041,13 @@
 	icon_state = "badrecipe"
 	filling_color = "#211F02"
 	bitesize = 2
+	list_reagents = list("????" = 5, "carbon" = 3)
 
-	New()
-		..()
-		reagents.add_reagent("????", 5)
-		reagents.add_reagent("carbon", 3)
-		// it's burned! it should start off being classed as any cooktype that burns
-		cooktype["grilled"] = 1
-		cooktype["deep fried"] = 1
+/obj/item/weapon/reagent_containers/food/snacks/badrecipe/New()
+	..()
+	// it's burned! it should start off being classed as any cooktype that burns
+	cooktype["grilled"] = 1
+	cooktype["deep fried"] = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/meatsteak
 	name = "Meat steak"
@@ -1349,12 +1056,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#7A3D11"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("sodiumchloride", 1)
-		reagents.add_reagent("blackpepper", 1)
+	list_reagents = list("nutriment" = 4, "sodiumchloride" = 1, "blackpepper" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/spacylibertyduff
 	name = "Spacy Liberty Duff"
@@ -1363,11 +1065,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#42B873"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("psilocybin", 6)
+	list_reagents = list("nutriment" = 6, "psilocybin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/amanitajelly
 	name = "Amanita Jelly"
@@ -1376,12 +1074,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#ED0758"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("amanitin", 6)
-		reagents.add_reagent("psilocybin", 3)
+	list_reagents = list("nutriment" = 6, "amanitin" = 6, "psilocybin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/poppypretzel
 	name = "Poppy pretzel"
@@ -1389,11 +1082,7 @@
 	icon_state = "poppypretzel"
 	bitesize = 2
 	filling_color = "#916E36"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
-
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatballsoup
 	name = "Meatball soup"
@@ -1402,11 +1091,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#785210"
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("water", 5)
+	list_reagents = list("nutriment" = 8, "water" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/slimesoup
 	name = "slime soup"
@@ -1414,11 +1099,7 @@
 	icon_state = "slimesoup"
 	filling_color = "#C4DBA0"
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("slimejelly", 5)
-		reagents.add_reagent("water", 10)
+	list_reagents = list("slimejelly" = 5, "water" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/bloodsoup
 	name = "Tomato soup"
@@ -1426,12 +1107,7 @@
 	icon_state = "tomatosoup"
 	filling_color = "#FF0000"
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("blood", 10)
-		reagents.add_reagent("water", 5)
+	list_reagents = list("nutriment" = 2, "blood" = 10, "water" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/clownstears
 	name = "Clown's Tears"
@@ -1439,12 +1115,7 @@
 	icon_state = "clownstears"
 	filling_color = "#C4FBFF"
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("banana", 5)
-		reagents.add_reagent("water", 10)
+	list_reagents = list("nutriment" = 4, "banana" = 5, "water" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablesoup
 	name = "Vegetable soup"
@@ -1453,11 +1124,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#AFC4B5"
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("water", 5)
+	list_reagents = list("nutriment" = 8, "water" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/nettlesoup
 	name = "Nettle soup"
@@ -1466,12 +1133,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#AFC4B5"
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("water", 5)
-		reagents.add_reagent("omnizine", 5)
+	list_reagents = list("nutriment" = 8, "water" = 5, "omnizine" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/mysterysoup
 	name = "Mystery soup"
@@ -1481,44 +1143,44 @@
 	filling_color = "#F082FF"
 	bitesize = 5
 
-	New()
-		..()
-		var/mysteryselect = pick(1,2,3,4,5,6,7,8,9,10)
-		switch(mysteryselect)
-			if(1)
-				reagents.add_reagent("nutriment", 6)
-				reagents.add_reagent("capsaicin", 3)
-				reagents.add_reagent("tomatojuice", 2)
-			if(2)
-				reagents.add_reagent("nutriment", 6)
-				reagents.add_reagent("frostoil", 3)
-				reagents.add_reagent("tomatojuice", 2)
-			if(3)
-				reagents.add_reagent("nutriment", 5)
-				reagents.add_reagent("water", 5)
-				reagents.add_reagent("omnizine", 5)
-			if(4)
-				reagents.add_reagent("nutriment", 5)
-				reagents.add_reagent("water", 10)
-			if(5)
-				reagents.add_reagent("nutriment", 2)
-				reagents.add_reagent("banana", 10)
-			if(6)
-				reagents.add_reagent("nutriment", 6)
-				reagents.add_reagent("blood", 10)
-			if(7)
-				reagents.add_reagent("slimejelly", 10)
-				reagents.add_reagent("water", 10)
-			if(8)
-				reagents.add_reagent("carbon", 10)
-				reagents.add_reagent("toxin", 10)
-			if(9)
-				reagents.add_reagent("nutriment", 5)
-				reagents.add_reagent("tomatojuice", 10)
-			if(10)
-				reagents.add_reagent("nutriment", 6)
-				reagents.add_reagent("tomatojuice", 5)
-				reagents.add_reagent("oculine", 5)
+/obj/item/weapon/reagent_containers/food/snacks/mysterysoup/New()
+	..()
+	var/mysteryselect = pick(1,2,3,4,5,6,7,8,9,10)
+	switch(mysteryselect)
+		if(1)
+			reagents.add_reagent("nutriment", 6)
+			reagents.add_reagent("capsaicin", 3)
+			reagents.add_reagent("tomatojuice", 2)
+		if(2)
+			reagents.add_reagent("nutriment", 6)
+			reagents.add_reagent("frostoil", 3)
+			reagents.add_reagent("tomatojuice", 2)
+		if(3)
+			reagents.add_reagent("nutriment", 5)
+			reagents.add_reagent("water", 5)
+			reagents.add_reagent("omnizine", 5)
+		if(4)
+			reagents.add_reagent("nutriment", 5)
+			reagents.add_reagent("water", 10)
+		if(5)
+			reagents.add_reagent("nutriment", 2)
+			reagents.add_reagent("banana", 10)
+		if(6)
+			reagents.add_reagent("nutriment", 6)
+			reagents.add_reagent("blood", 10)
+		if(7)
+			reagents.add_reagent("slimejelly", 10)
+			reagents.add_reagent("water", 10)
+		if(8)
+			reagents.add_reagent("carbon", 10)
+			reagents.add_reagent("toxin", 10)
+		if(9)
+			reagents.add_reagent("nutriment", 5)
+			reagents.add_reagent("tomatojuice", 10)
+		if(10)
+			reagents.add_reagent("nutriment", 6)
+			reagents.add_reagent("tomatojuice", 5)
+			reagents.add_reagent("oculine", 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/wishsoup
 	name = "Wish Soup"
@@ -1527,13 +1189,13 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#D1F4FF"
 	bitesize = 5
+	list_reagents = list("water" = 10)
 
-	New()
-		..()
-		reagents.add_reagent("water", 10)
-		if(prob(25))
-			src.desc = "A wish come true!"
-			reagents.add_reagent("nutriment", 8)
+/obj/item/weapon/reagent_containers/food/snacks/wishsoup/New()
+	..()
+	if(prob(25))
+		desc = "A wish come true!" // hue
+		reagents.add_reagent("nutriment", 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/hotchili
 	name = "Hot Chili"
@@ -1542,12 +1204,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FF3C00"
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("capsaicin", 3)
-		reagents.add_reagent("tomatojuice", 2)
+	list_reagents = list("nutriment" = 6, "capsaicin" = 3, "tomatojuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/coldchili
 	name = "Cold Chili"
@@ -1556,36 +1213,21 @@
 	filling_color = "#2B00FF"
 	trash = /obj/item/trash/snack_bowl
 	bitesize = 5
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("frostoil", 3)
-		reagents.add_reagent("tomatojuice", 2)
+	list_reagents = list("nutriment" = 6, "frostoil" = 3, "tomatojuice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/raw_bacon
 	name = "raw bacon"
 	desc = "It's fleshy and pink!"
 	icon_state = "raw_bacon"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 1)
-		reagents.add_reagent("porktonium", 10)
+	list_reagents = list("nutriment" = 1, "porktonium" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/bacon
 	name = "bacon"
 	desc = "It looks juicy and tastes amazing!"
 	icon_state = "bacon2"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("porktonium", 10)
-		reagents.add_reagent("msg", 4)
-
+	list_reagents = list("nutriment" = 4, "porktonium" = 10, "msg" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/telebacon
 	name = "Tele Bacon"
@@ -1593,17 +1235,16 @@
 	icon_state = "bacon"
 	var/obj/item/device/radio/beacon/bacon/baconbeacon
 	bitesize = 2
+	list_reagents = list("nutriment" = 4, "porktonium" = 10)
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("porktonium", 10)
-		baconbeacon = new /obj/item/device/radio/beacon/bacon(src)
+/obj/item/weapon/reagent_containers/food/snacks/telebacon/New()
+	..()
+	baconbeacon = new /obj/item/device/radio/beacon/bacon(src)
 
-	On_Consume(mob/M, mob/user)
-		if(!reagents.total_volume)
-			baconbeacon.loc = user
-			baconbeacon.digest_delay()
+/obj/item/weapon/reagent_containers/food/snacks/telebacon/On_Consume(mob/M, mob/user)
+	if(!reagents.total_volume)
+		baconbeacon.loc = user
+		baconbeacon.digest_delay()
 
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube
@@ -1613,13 +1254,11 @@
 	bitesize = 12
 	filling_color = "#ADAC7F"
 	var/monkey_type = "Monkey"
-
-/obj/item/weapon/reagent_containers/food/snacks/monkeycube/New()
-	..()
-	reagents.add_reagent("protein",10)
+	list_reagents = list("protein" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/afterattack(obj/O, mob/user, proximity)
-	if(!proximity) return
+	if(!proximity)
+		return
 	if(istype(O,/obj/structure/sink) && !wrapped)
 		to_chat(user, "<span class='notice'>You place [src] under a stream of water...</span>")
 		user.drop_item()
@@ -1704,10 +1343,7 @@
 	icon_state = "spellburger"
 	filling_color = "#D505FF"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/bigbiteburger
 	name = "Big Bite Burger"
@@ -1715,10 +1351,7 @@
 	icon_state = "bigbiteburger"
 	filling_color = "#E3D681"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 14)
+	list_reagents = list("nutriment" = 14)
 
 /obj/item/weapon/reagent_containers/food/snacks/enchiladas
 	name = "Enchiladas"
@@ -1727,11 +1360,7 @@
 	trash = /obj/item/trash/tray
 	filling_color = "#A36A1F"
 	bitesize = 4
-
-	New()
-		..()
-		reagents.add_reagent("nutriment",8)
-		reagents.add_reagent("capsaicin", 6)
+	list_reagents = list("nutriment" = 8, "capsaicin" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/burrito
 	name = "Burrito"
@@ -1739,10 +1368,7 @@
 	icon_state = "burrito"
 	trash = /obj/item/trash/plate
 	filling_color = "#A36A1F"
-
-/obj/item/weapon/reagent_containers/food/snacks/burrito/New()
-	..()
-	reagents.add_reagent("nutriment", 5)
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/chimichanga
 	name = "Chimichanga"
@@ -1750,11 +1376,7 @@
 	icon_state = "chimichanga"
 	trash = /obj/item/trash/plate
 	filling_color = "#A36A1F"
-
-/obj/item/weapon/reagent_containers/food/snacks/chimichanga/New()
-	..()
-	reagents.add_reagent("omnizine", 4)		//Deadpool reference. Deal with it.
-	reagents.add_reagent("cheese", 2)
+	list_reagents = list("omnizine" = 4, "cheese" = 2) //Deadpool reference. Deal with it.
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeysdelight
 	name = "monkey's Delight"
@@ -1763,13 +1385,7 @@
 	trash = /obj/item/trash/tray
 	filling_color = "#5C3C11"
 	bitesize = 6
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
-		reagents.add_reagent("banana", 5)
-		reagents.add_reagent("blackpepper", 1)
-		reagents.add_reagent("sodiumchloride", 1)
+	list_reagents = list("nutriment" = 10, "banana" = 5, "blackpepper" = 1, "sodiumchloride" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/baguette
 	name = "Baguette"
@@ -1777,12 +1393,7 @@
 	icon_state = "baguette"
 	filling_color = "#E3D796"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("blackpepper", 1)
-		reagents.add_reagent("sodiumchloride", 1)
+	list_reagents = list("nutriment" = 6, "blackpepper" = 1, "sodiumchloride" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/sandwich
 	name = "Sandwich"
@@ -1791,10 +1402,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/toastedsandwich
 	name = "Toasted Sandwich"
@@ -1803,11 +1411,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("carbon", 2)
+	list_reagents = list("nutriment" = 6, "carbon" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grilledcheese
 	name = "Grilled Cheese Sandwich"
@@ -1816,10 +1420,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 7)
+	list_reagents = list("nutriment" = 7) //why make a regualr sandwhich when you can make grilled cheese, with this nutriment value?
 
 /obj/item/weapon/reagent_containers/food/snacks/tomatosoup
 	name = "Tomato Soup"
@@ -1828,11 +1429,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#D92929"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
-		reagents.add_reagent("tomatojuice", 10)
+	list_reagents = list("nutriment" = 5, "tomatojuice" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/rofflewaffles
 	name = "Roffle Waffles"
@@ -1841,11 +1438,7 @@
 	trash = /obj/item/trash/waffles
 	filling_color = "#FF00F7"
 	bitesize = 4
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("psilocybin", 8)
+	list_reagents = list("nutriment" = 8, "psilocybin" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/stew
 	name = "Stew"
@@ -1853,13 +1446,7 @@
 	icon_state = "stew"
 	filling_color = "#9E673A"
 	bitesize = 10
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
-		reagents.add_reagent("tomatojuice", 5)
-		reagents.add_reagent("oculine", 5)
-		reagents.add_reagent("water", 5)
+	list_reagents = list("nutriment" = 10, "tomatojuice" = 5, "oculine" = 5, "water" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast
 	name = "Jellied Toast"
@@ -1868,20 +1455,13 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#B572AB"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 1)
+	list_reagents = list("nutriment" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast/cherry
-	New()
-		..()
-		reagents.add_reagent("cherryjelly", 5)
+	list_reagents = list("nutriment" = 1, "cherryjelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast/slime
-	New()
-		..()
-		reagents.add_reagent("slimejelly", 5)
+	list_reagents = list("nutriment" = 1, "slimejelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellyburger
 	name = "Jelly Burger"
@@ -1889,20 +1469,13 @@
 	icon_state = "jellyburger"
 	filling_color = "#B572AB"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellyburger/slime
-	New()
-		..()
-		reagents.add_reagent("slimejelly", 5)
+	list_reagents = list("nutriment" = 5, "slimejelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellyburger/cherry
-	New()
-		..()
-		reagents.add_reagent("cherryjelly", 5)
+	list_reagents = list("nutriment" = 5, "cherryjelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/milosoup
 	name = "Milosoup"
@@ -1910,11 +1483,7 @@
 	icon_state = "milosoup"
 	trash = /obj/item/trash/snack_bowl
 	bitesize = 4
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("water", 5)
+	list_reagents = list("nutriment" = 8, "water" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/stewedsoymeat
 	name = "Stewed Soy Meat"
@@ -1922,10 +1491,7 @@
 	icon_state = "stewedsoymeat"
 	trash = /obj/item/trash/plate
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspagetti
 	name = "Boiled Spagetti"
@@ -1934,10 +1500,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FCEE81"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledrice
 	name = "Boiled Rice"
@@ -1946,10 +1509,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/ricepudding
 	name = "Rice Pudding"
@@ -1958,10 +1518,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
+	list_reagents = list("nutriment" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/pastatomato
 	name = "Spagetti"
@@ -1970,11 +1527,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#DE4545"
 	bitesize = 4
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("tomatojuice", 10)
+	list_reagents = list("nutriment" = 6, "tomatojuice" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatballspagetti
 	name = "Spagetti & Meatballs"
@@ -1983,11 +1536,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#DE4545"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("synaptizine", 5)
+	list_reagents = list("nutriment" = 8, "synaptizine" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/spesslaw
 	name = "Spesslaw"
@@ -1995,11 +1544,7 @@
 	icon_state = "spesslaw"
 	filling_color = "#DE4545"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("synaptizine", 10)
+	list_reagents = list("nutriment" = 8, "synaptizine" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/poppypretzel
 	name = "Poppy Pretzel"
@@ -2007,10 +1552,7 @@
 	icon_state = "poppypretzel"
 	filling_color = "#AB7D2E"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/carrotfries
 	name = "Carrot Fries"
@@ -2019,11 +1561,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FAA005"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 3)
-		reagents.add_reagent("oculine", 3)
+	list_reagents = list("plantmatter" = 3, "oculine" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/superbiteburger
 	name = "Super Bite Burger"
@@ -2031,10 +1569,7 @@
 	icon_state = "superbiteburger"
 	filling_color = "#CCA26A"
 	bitesize = 10
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 50)
+	list_reagents = list("nutriment" = 50)
 
 /obj/item/weapon/reagent_containers/food/snacks/candiedapple
 	name = "Candied Apple"
@@ -2042,10 +1577,7 @@
 	icon_state = "candiedapple"
 	filling_color = "#F21873"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3) // A candy apple without sugar...
 
 /obj/item/weapon/reagent_containers/food/snacks/applepie
 	name = "Apple Pie"
@@ -2053,10 +1585,7 @@
 	icon_state = "applepie"
 	filling_color = "#E0EDC5"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
+	list_reagents = list("nutriment" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/cherrypie
 	name = "Cherry Pie"
@@ -2064,10 +1593,7 @@
 	icon_state = "cherrypie"
 	filling_color = "#FF525A"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
+	list_reagents = list("nutriment" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/twobread
 	name = "Two Bread"
@@ -2075,10 +1601,7 @@
 	icon_state = "twobread"
 	filling_color = "#DBCC9A"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich
 	name = "Jelly Sandwich"
@@ -2087,40 +1610,27 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#9E3A78"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
+	list_reagents = list("nutriment" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/slime
-	New()
-		..()
-		reagents.add_reagent("slimejelly", 5)
+	list_reagents = list("nutriment" = 2, "slimejelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/cherry
-	New()
-		..()
-		reagents.add_reagent("cherryjelly", 5)
+	list_reagents = list("nutriment" = 2, "cherryjelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledslimecore
 	name = "Boiled Slime Core"
 	desc = "A boiled red thing."
 	icon_state = "boiledrorocore"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("slimejelly", 5)
+	list_reagents = list("slimejelly" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/mint
 	name = "mint"
 	desc = "it is only wafer thin."
 	icon_state = "mint"
 	filling_color = "#F2F2F2"
-
-	New()
-		..()
-		reagents.add_reagent("minttoxin", 1)
+	list_reagents = list("minttoxin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/mushroomsoup
 	name = "chantrelle soup"
@@ -2129,10 +1639,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#E386BF"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit
 	name = "plump helmet biscuit"
@@ -2140,16 +1647,15 @@
 	icon_state = "phelmbiscuit"
 	filling_color = "#CFB4C4"
 	bitesize = 2
+	list_reagents = list("nutriment" = 5)
 
-	New()
-		..()
-		if(prob(10))
-			name = "exceptional plump helmet biscuit"
-			desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump helmet biscuit!"
-			reagents.add_reagent("nutriment", 8)
-			reagents.add_reagent("omnizine", 5)
-		else
-			reagents.add_reagent("nutriment", 5)
+/obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit/New()
+	..()
+	if(prob(10))
+		name = "exceptional plump helmet biscuit"
+		desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump helmet biscuit!" // Is this a reference?
+		reagents.add_reagent("nutriment", 3)
+		reagents.add_reagent("omnizine", 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/chawanmushi
 	name = "chawanmushi"
@@ -2157,10 +1663,7 @@
 	icon_state = "chawanmushi"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#F0F2E4"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/beetsoup
 	name = "beet soup"
@@ -2169,23 +1672,23 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FAC9FF"
 	bitesize = 2
+	list_reagents = list("nutriment" = 8)
 
-	New()
-		..()
-		switch(rand(1,6))
-			if(1)
-				name = "borsch"
-			if(2)
-				name = "bortsch"
-			if(3)
-				name = "borstch"
-			if(4)
-				name = "borsh"
-			if(5)
-				name = "borshch"
-			if(6)
-				name = "borscht"
-		reagents.add_reagent("nutriment", 8)
+/obj/item/weapon/reagent_containers/food/snacks/beetsoup/New()
+	..()
+	switch(rand(1,6))
+		if(1)
+			name = "borsch"
+		if(2)
+			name = "bortsch"
+		if(3)
+			name = "borstch"
+		if(4)
+			name = "borsh"
+		if(5)
+			name = "borshch"
+		if(6)
+			name = "borscht"
 
 /obj/item/weapon/reagent_containers/food/snacks/herbsalad
 	name = "herb salad"
@@ -2194,10 +1697,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#76B87F"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
+	list_reagents = list("nutriment" = 8)
 
 /obj/item/weapon/reagent_containers/food/snacks/validsalad
 	name = "valid salad"
@@ -2206,11 +1706,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#76B87F"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("omnizine", 5)
+	list_reagents = list("nutriment" = 8, "omnizine" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/appletart
 	name = "golden apple streusel tart"
@@ -2219,33 +1715,23 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FFFF00"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("gold", 5)
-		spawn(1)
-			reagents.del_reagent("egg")
-			reagents.update_total()
+	list_reagents = list("nutriment" = 8, "gold" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/dough_ball
 	name = "ball of raw dough"
 	desc = "A ball of raw dough, ready to be molded into new recipes."
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "dough"
+	list_reagents = list("nutriment" = 3)
 
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-
-	attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-		if(istype(W,/obj/item/weapon/kitchen/rollingpin))
-			user.visible_message( \
-				"[user] flattens the dough with the rolling pin!", \
-				"\blue You flatten the dough with your rolling pin!" \
-				)
-			new /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough(src.loc)
-			qdel(src)
+/obj/item/weapon/reagent_containers/food/snacks/dough_ball/attackby(obj/item/weapon/W, mob/user, params)
+	if(istype(W,/obj/item/weapon/kitchen/rollingpin))
+		user.visible_message( \
+			"[user] flattens the dough with the rolling pin!", \
+			"\blue You flatten the dough with your rolling pin!" \
+			)
+		new /obj/item/weapon/reagent_containers/food/snacks/sliceable/flatdough(src.loc)
+		qdel(src)
 
 /////////////////////////////////////////////////Sliceable////////////////////////////////////////
 // All the food items that can be sliced into smaller bits like Meatbread and Cheesewheels
@@ -2259,10 +1745,7 @@
 	icon_state = "flatdough"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/doughslice
 	slices_num = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/doughslice
 	name = "slice of dough"
@@ -2279,11 +1762,7 @@
 	slices_num = 5
 	filling_color = "#FF7575"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 20)
-		reagents.add_reagent("nutriment", 10)
+	list_reagents = list("protein" = 20, "nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatbreadslice
 	name = "meatbread slice"
@@ -2301,11 +1780,7 @@
 	slices_num = 5
 	filling_color = "#8AFF75"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 20)
-		reagents.add_reagent("nutriment", 10)
+	list_reagents = list("protein" = 20, "nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/xenomeatbreadslice
 	name = "xenomeatbread slice"
@@ -2322,12 +1797,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/spidermeatbreadslice
 	slices_num = 5
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 20)
-		reagents.add_reagent("nutriment", 10)
-		reagents.add_reagent("toxin", 15)
+	list_reagents = list("protein" = 20, "nutriment" = 10, "toxin" = 15)
 
 /obj/item/weapon/reagent_containers/food/snacks/spidermeatbreadslice
 	name = "spider meat bread slice"
@@ -2335,10 +1805,7 @@
 	icon_state = "xenobreadslice"
 	trash = /obj/item/trash/plate
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("toxin", 2)
+	list_reagents = list("toxin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/bananabread
 	name = "Banana-nut bread"
@@ -2348,11 +1815,7 @@
 	slices_num = 5
 	filling_color = "#EDE5AD"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("banana", 20)
-		reagents.add_reagent("nutriment", 20)
+	list_reagents = list("banana" = 20, "nutriment" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/bananabreadslice
 	name = "Banana-nut bread slice"
@@ -2370,10 +1833,7 @@
 	slices_num = 5
 	filling_color = "#F7FFE0"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 30)
+	list_reagents = list("nutriment" = 30)
 
 /obj/item/weapon/reagent_containers/food/snacks/tofubreadslice
 	name = "Tofubread slice"
@@ -2383,7 +1843,6 @@
 	filling_color = "#F7FFE0"
 	bitesize = 2
 
-
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/carrotcake
 	name = "Carrot Cake"
 	desc = "A favorite desert of a certain wascally wabbit. Not a lie."
@@ -2392,11 +1851,7 @@
 	slices_num = 5
 	filling_color = "#FFD675"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 25)
-		reagents.add_reagent("oculine", 10)
+	list_reagents = list("nutriment" = 25, "oculine" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/carrotcakeslice
 	name = "Carrot Cake slice"
@@ -2414,12 +1869,7 @@
 	slices_num = 5
 	filling_color = "#E6AEDB"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 15)
-		reagents.add_reagent("nutriment", 10)
-		reagents.add_reagent("mannitol", 10)
+	list_reagents = list("protein" = 15, "nutriment" = 10, "mannitol" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/braincakeslice
 	name = "Brain Cake slice"
@@ -2437,10 +1887,7 @@
 	slices_num = 5
 	filling_color = "#FAF7AF"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 25)
+	list_reagents = list("nutriment" = 25)
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesecakeslice
 	name = "Cheese Cake slice"
@@ -2457,10 +1904,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/plaincakeslice
 	slices_num = 5
 	filling_color = "#F7EDD5"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
+	list_reagents = list("nutriment" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/plaincakeslice
 	name = "Vanilla Cake slice"
@@ -2477,10 +1921,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/orangecakeslice
 	slices_num = 5
 	filling_color = "#FADA8E"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
+	list_reagents = list("nutriment" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/orangecakeslice
 	name = "Orange Cake slice"
@@ -2497,10 +1938,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/limecakeslice
 	slices_num = 5
 	filling_color = "#CBFA8E"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
+	list_reagents = list("nutriment" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/limecakeslice
 	name = "Lime Cake slice"
@@ -2517,10 +1955,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/lemoncakeslice
 	slices_num = 5
 	filling_color = "#FAFA8E"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
+	list_reagents = list("nutriment" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/lemoncakeslice
 	name = "Lemon Cake slice"
@@ -2537,11 +1972,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/chocolatecakeslice
 	slices_num = 5
 	filling_color = "#805930"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
-		reagents.add_reagent("chocolate",20)
+	list_reagents = list("nutriment" = 20, "chocolate" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/chocolatecakeslice
 	name = "Chocolate Cake slice"
@@ -2559,11 +1990,7 @@
 	slices_num = 5
 	filling_color = "#FFF700"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
-		reagents.add_reagent("cheese", 20)
+	list_reagents = list("nutriment" = 20, "cheese" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	name = "Cheese wedge"
@@ -2578,13 +2005,7 @@
 	icon_state = "weirdcheesewedge"
 	filling_color = "#00FF33"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("mercury", 5)
-		reagents.add_reagent("lsd", 5)
-		reagents.add_reagent("ethanol", 5)
-		reagents.add_reagent("weird_cheese", 5)
+	list_reagents = list("mercury" = 5, "lsd" = 5, "ethanol" = 5, "weird_cheese" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/birthdaycake
 	name = "Birthday Cake"
@@ -2594,11 +2015,7 @@
 	slices_num = 5
 	filling_color = "#FFD6D6"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
-		reagents.add_reagent("sprinkles", 10)
+	list_reagents = list("nutriment" = 20, "sprinkles" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/birthdaycakeslice
 	name = "Birthday Cake slice"
@@ -2616,13 +2033,7 @@
 	slices_num = 6
 	filling_color = "#FFE396"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		spawn(1)
-			reagents.del_reagent("egg")
-			reagents.update_total()
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice
 	name = "Bread slice"
@@ -2631,10 +2042,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D27332"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("bread", 5)
+	list_reagents = list("bread" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/creamcheesebread
 	name = "Cream Cheese Bread"
@@ -2644,10 +2052,7 @@
 	slices_num = 5
 	filling_color = "#FFF896"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
+	list_reagents = list("nutriment" = 20)
 
 /obj/item/weapon/reagent_containers/food/snacks/creamcheesebreadslice
 	name = "Cream Cheese Bread slice"
@@ -2657,14 +2062,12 @@
 	filling_color = "#FFF896"
 	bitesize = 2
 
-
 /obj/item/weapon/reagent_containers/food/snacks/watermelonslice
 	name = "Watermelon Slice"
 	desc = "A slice of watery goodness."
 	icon_state = "watermelonslice"
 	filling_color = "#FF3867"
 	bitesize = 2
-
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/applecake
 	name = "Apple Cake"
@@ -2673,10 +2076,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/applecakeslice
 	slices_num = 5
 	filling_color = "#EBF5B8"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 15)
+	list_reagents = list("nutriment" = 15)
 
 /obj/item/weapon/reagent_containers/food/snacks/applecakeslice
 	name = "Apple Cake slice"
@@ -2693,10 +2093,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/pumpkinpieslice
 	slices_num = 5
 	filling_color = "#F5B951"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 15)
+	list_reagents = list("nutriment" = 15)
 
 /obj/item/weapon/reagent_containers/food/snacks/pumpkinpieslice
 	name = "Pumpkin Pie slice"
@@ -2711,10 +2108,7 @@
 	desc = "It's a salted cracker."
 	icon_state = "cracker"
 	filling_color = "#F5DEB8"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 1)
+	list_reagents = list("nutriment" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/rawcutlet
 	name = "raw cutlet"
@@ -2722,19 +2116,16 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawcutlet"
 	bitesize = 1
+	list_reagents = list("protein" = 1)
 
-	New()
-		..()
-		reagents.add_reagent("protein", 1)
-
-	attackby(obj/item/weapon/W, mob/user, params)
-		if(istype(W,/obj/item/weapon/kitchen/knife))
-			user.visible_message( \
-				"[user] cuts the raw cutlet with the knife!", \
-				"<span class ='notice'>You cut the raw cutlet with your knife!</span>" \
-				)
-			new /obj/item/weapon/reagent_containers/food/snacks/raw_bacon(src.loc)
-			qdel(src)
+/obj/item/weapon/reagent_containers/food/snacks/rawcutlet/attackby(obj/item/weapon/W, mob/user, params)
+	if(istype(W,/obj/item/weapon/kitchen/knife))
+		user.visible_message( \
+			"[user] cuts the raw cutlet with the knife!", \
+			"<span class ='notice'>You cut the raw cutlet with your knife!</span>" \
+			)
+		new /obj/item/weapon/reagent_containers/food/snacks/raw_bacon(src.loc)
+		qdel(src)
 
 
 /////////////////////////////////////////////////PIZZA////////////////////////////////////////
@@ -2750,11 +2141,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
 	slices_num = 6
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 40)
-		reagents.add_reagent("tomatojuice", 6)
+	list_reagents = list("nutriment" = 40, "tomatojuice" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
 	name = "Margherita slice"
@@ -2770,12 +2157,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	slices_num = 6
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 30)
-		reagents.add_reagent("nutriment", 20)
-		reagents.add_reagent("tomatojuice", 6)
+	list_reagents = list("protein" = 30, "nutriment" = 20, "tomatojuice" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -2791,11 +2173,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	slices_num = 6
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 25)
-		reagents.add_reagent("nutriment", 10)
+	list_reagents = list("plantmatter" = 25, "nutriment" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
@@ -2811,13 +2189,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	slices_num = 6
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 20)
-		reagents.add_reagent("nutriment", 10)
-		reagents.add_reagent("tomatojuice", 6)
-		reagents.add_reagent("oculine", 12)
+	list_reagents = list("plantmatter" = 20, "nutriment" = 10, "tomatojuice" = 6, "oculine" = 12)
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"
@@ -2889,18 +2261,16 @@
 
 	icon_state = "pizzabox[boxes.len+1]"
 
-/obj/item/pizzabox/attack_hand( mob/user as mob )
-
-	if( open && pizza )
-		user.put_in_hands( pizza )
-
+/obj/item/pizzabox/attack_hand(mob/user)
+	if(open && pizza)
+		user.put_in_hands(pizza)
 		to_chat(user, "\red You take the [src.pizza] out of the [src].")
 		src.pizza = null
 		update_icon()
 		return
 
-	if( boxes.len > 0 )
-		if( user.get_inactive_hand() != src )
+	if(boxes.len > 0)
+		if(user.get_inactive_hand() != src)
 			..()
 			return
 
@@ -2914,9 +2284,8 @@
 		return
 	..()
 
-/obj/item/pizzabox/attack_self( mob/user as mob )
-
-	if( boxes.len > 0 )
+/obj/item/pizzabox/attack_self(mob/user)
+	if(boxes.len > 0)
 		return
 
 	open = !open
@@ -2926,11 +2295,11 @@
 
 	update_icon()
 
-/obj/item/pizzabox/attackby( obj/item/I as obj, mob/user as mob , params)
-	if( istype(I, /obj/item/pizzabox/) )
+/obj/item/pizzabox/attackby( obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/pizzabox/))
 		var/obj/item/pizzabox/box = I
 
-		if( !box.open && !src.open )
+		if(!box.open && !open)
 			// Make a list of all boxes to be added
 			var/list/boxestoadd = list()
 			boxestoadd += box
@@ -2955,9 +2324,9 @@
 
 		return
 
-	if( istype(I, /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/) ) // Long ass fucking object name
+	if(istype(I, /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/)) // Long ass fucking object name
 
-		if( src.open )
+		if(open)
 			user.drop_item()
 			I.loc = src
 			src.pizza = I
@@ -2969,7 +2338,7 @@
 			to_chat(user, "\red You try to push the [I] through the lid but it doesn't work!")
 		return
 
-	if( istype(I, /obj/item/weapon/pen/) )
+	if(istype(I, /obj/item/weapon/pen/))
 
 		if( src.open )
 			return
@@ -3009,119 +2378,62 @@
 	desc = "The precursor to Pigs in a Blanket."
 	icon_state = "wrap"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
+	list_reagents = list("nutriment" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/beans
 	name = "tin of beans"
 	desc = "Musical fruit in a slightly less musical container."
 	icon_state = "beans"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
-		reagents.add_reagent("beans",10)
+	list_reagents = list("nutriment" = 10, "beans" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/benedict
 	name = "eggs benedict"
 	desc = "There is only one egg on this, how rude."
 	icon_state = "benedict"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("egg", 3)
+	list_reagents = list("nutriment" = 3, "egg" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/hotdog
 	name = "hotdog"
 	desc = "Fresh footlong ready to go down on."
 	icon_state = "hotdog"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("ketchup", 3)
+	list_reagents = list("nutriment" = 3, "ketchup" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/meatbun
 	name = "meat bun"
 	desc = "Has the potential to not be Dog."
 	icon_state = "meatbun"
 	bitesize = 6
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich
 	name = "icecream sandwich"
 	desc = "Portable Ice-cream in it's own packaging."
 	icon_state = "icecreamsandwich"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("ice", 2)
+	list_reagents = list("nutriment" = 2, "ice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/notasandwich
 	name = "not-a-sandwich"
 	desc = "Something seems to be wrong with this, you can't quite figure what. Maybe it's his moustache."
 	icon_state = "notasandwich"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/sugarcookie
 	name = "sugar cookie"
 	desc = "Just like your little sister used to make."
 	icon_state = "sugarcookie"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("sugar", 5)
-		spawn(1)
-			reagents.del_reagent("egg")
-			reagents.update_total()
+	list_reagents = list("nutriment" = 2, "sugar" = 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/friedbanana
 	name = "Fried Banana"
 	desc = "Goreng Pisang, also known as fried bananas."
 	icon_state = "friedbanana"
-
-	New()
-		..()
-		reagents.add_reagent("sugar", 5)
-		reagents.add_reagent("nutriment", 8)
-		reagents.add_reagent("cornoil", 4)
-
-/obj/item/weapon/reagent_containers/food/snacks/tofurkey
-	name = "Tofurkey"
-	desc = "A fake turkey made from tofu."
-	icon_state = "tofurkey"
-	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 12)
-		reagents.add_reagent("ether", 3)
-
-/obj/item/weapon/reagent_containers/food/snacks/stuffing
-	name = "Stuffing"
-	desc = "Moist, peppery breadcrumbs for filling the body cavities of dead birds. Dig in!"
-	icon_state = "stuffing"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("sugar" = 5, "nutriment" = 8, "cornoil" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/dionaroast
 	name = "roast diona"
@@ -3130,12 +2442,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#75754B"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 4)
-		reagents.add_reagent("nutriment", 2)
-		reagents.add_reagent("radium", 2)
+	list_reagents = list("plantmatter" = 4, "nutriment" = 2, "radium" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspiderleg
 	name = "boiled spider leg"
@@ -3143,22 +2450,14 @@
 	icon_state = "spiderlegcooked"
 	trash = /obj/item/trash/plate
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
-		reagents.add_reagent("toxin", 2)
+	list_reagents = list("nutriment" = 3, "toxin" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/spidereggs
 	name = "spider eggs"
 	desc = "A cluster of juicy spider eggs. A great side dish for when you care not for your health."
 	icon_state = "spidereggs"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 2)
-		reagents.add_reagent("toxin", 3)
+	list_reagents = list("protein" = 2, "toxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/spidereggsham
 	name = "green eggs and ham"
@@ -3166,12 +2465,7 @@
 	icon_state = "spidereggsham"
 	trash = /obj/item/trash/plate
 	bitesize = 4
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
-		reagents.add_reagent("sodiumchloride", 1)
-		reagents.add_reagent("toxin", 3)
+	list_reagents = list("nutriment" = 6, "sodiumchloride" = 1, "toxin" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/turkey
 	name = "Turkey"
@@ -3180,11 +2474,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/turkeyslice
 	slices_num = 6
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 24)
-		reagents.add_reagent("nutriment", 18)
+	list_reagents = list("protein" = 24, "nutriment" = 18)
 
 /obj/item/weapon/reagent_containers/food/snacks/turkeyslice
 	name = "turkey serving"
@@ -3201,57 +2491,41 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D6D9C1"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 5)
-		reagents.add_reagent("gravy", 5)
-		reagents.add_reagent("mashedpotatoes", 10)
+	list_reagents = list("nutriment" = 5, "gravy" = 5, "mashedpotatoes" = 10)
 
 ////////////////////////////////ICE CREAM///////////////////////////////////
 /obj/item/weapon/reagent_containers/food/snacks/icecream
-        name = "ice cream"
-        desc = "Delicious ice cream."
-        icon = 'icons/obj/kitchen.dmi'
-        icon_state = "icecream_cone"
+	name = "ice cream"
+	desc = "Delicious ice cream."
+	icon = 'icons/obj/kitchen.dmi'
+	icon_state = "icecream_cone"
+	list_reagents = list("nutriment" = 1, "sugar" = 1)
 
-        New()
-                ..()
-                reagents.add_reagent("nutriment", 1)
-                reagents.add_reagent("sugar",1)
-                update_icon()
+/obj/item/weapon/reagent_containers/food/snacks/icecream/New()
+	..()
+	update_icon()
 
-        update_icon()
-                overlays.Cut()
-                var/image/filling = image('icons/obj/kitchen.dmi', src, "icecream_color")
-                filling.icon += mix_color_from_reagents(reagents.reagent_list)
-                overlays += filling
+/obj/item/weapon/reagent_containers/food/snacks/icecream/update_icon()
+	overlays.Cut()
+	var/image/filling = image('icons/obj/kitchen.dmi', src, "icecream_color")
+	filling.icon += mix_color_from_reagents(reagents.reagent_list)
+	overlays += filling
 
 /obj/item/weapon/reagent_containers/food/snacks/icecream/icecreamcone
-        name = "ice cream cone"
-        desc = "Delicious ice cream."
-        icon_state = "icecream_cone"
-        volume = 50
-        bitesize = 3
-
-        New()
-                ..()
-                reagents.add_reagent("nutriment", 2)
-                reagents.add_reagent("sugar",6)
-                reagents.add_reagent("ice",2)
+	name = "ice cream cone"
+	desc = "Delicious ice cream."
+	icon_state = "icecream_cone"
+	volume = 50
+	bitesize = 3
+	list_reagents = list("nutriment" = 3, "sugar" = 7, "ice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/icecream/icecreamcup
-        name = "chocolate ice cream cone"
-        desc = "Delicious ice cream."
-        icon_state = "icecream_cup"
-        volume = 50
-        bitesize = 6
-
-        New()
-                ..()
-                reagents.add_reagent("nutriment", 4)
-                reagents.add_reagent("chocolate",8)
-                reagents.add_reagent("ice",2)
+	name = "chocolate ice cream cone"
+	desc = "Delicious ice cream."
+	icon_state = "icecream_cup"
+	volume = 50
+	bitesize = 6
+	list_reagents = list("nutriment" = 5, "chocolate" = 8, "ice" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/cereal
 	name = "box of cereal"
@@ -3259,10 +2533,7 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "cereal_box"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/deepfryholder
 	name = "Deep Fried Foods Holder Obj"
@@ -3270,10 +2541,7 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "deepfried_holder_icon"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/dough
 	name = "dough"
@@ -3281,10 +2549,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "dough"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 // Dough + rolling pin = flat dough
 /obj/item/weapon/reagent_containers/food/snacks/dough/attackby(obj/item/I, mob/user, params)
@@ -3306,10 +2571,7 @@
 	icon_state = "flat dough"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/doughslice
 	slices_num = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/doughslice
 	name = "dough slice"
@@ -3317,10 +2579,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "doughslice"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 1)
+	list_reagents = list("nutriment" = 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/bun
 	name = "bun"
@@ -3328,20 +2587,14 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "bun"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
+	list_reagents = list("nutriment" = 4)
 
 /obj/item/weapon/reagent_containers/food/snacks/taco
 	name = "taco"
 	desc = "Take a bite!"
 	icon_state = "taco"
 	bitesize = 3
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 7)
+	list_reagents = list("nutriment" = 7)
 
 /obj/item/weapon/reagent_containers/food/snacks/cutlet
 	name = "cutlet"
@@ -3349,10 +2602,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "cutlet"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 2)
+	list_reagents = list("protein" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/rawmeatball
 	name = "raw meatball"
@@ -3360,20 +2610,14 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawmeatball"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 2)
+	list_reagents = list("protein" = 2)
 
 /obj/item/weapon/reagent_containers/food/snacks/hotdog
 	name = "hotdog"
 	desc = "Unrelated to dogs, maybe."
 	icon_state = "hotdog"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("protein", 6)
+	list_reagents = list("protein" = 6)
 
 /obj/item/weapon/reagent_containers/food/snacks/flatbread
 	name = "flatbread"
@@ -3381,10 +2625,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "flatbread"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 3)
+	list_reagents = list("nutriment" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/rawsticks
 	name = "raw potato sticks"
@@ -3392,20 +2633,14 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawsticks"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("plantmatter", 3)
+	list_reagents = list("plantmatter" = 3)
 
 /obj/item/weapon/reagent_containers/food/snacks/ectoplasm
 	name = "ectoplasm"
 	desc = "A luminescent blob of what scientists refer to as 'ghost goo'."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "ectoplasm"
-
-	New()
-		..()
-		reagents.add_reagent("ectoplasm", 10)
+	list_reagents = list("ectoplasm" = 10)
 
 /obj/item/weapon/reagent_containers/food/snacks/liquidfood
 	name = "\improper LiquidFood Ration"
@@ -3414,11 +2649,7 @@
 	trash = /obj/item/trash/liquidfood
 	filling_color = "#A8A8A8"
 	bitesize = 4
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 20)
-		reagents.add_reagent("iron", 3)
+	list_reagents = list("nutriment" = 20, "iron" = 3)
 
 
 /obj/item/weapon/reagent_containers/food/snacks/tastybread
@@ -3428,7 +2659,4 @@
 	trash = /obj/item/trash/tastybread
 	filling_color = "#A66829"
 	bitesize = 2
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 6)
+	list_reagents = list("nutriment" = 6)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -37,10 +37,10 @@
 /obj/item/weapon/reagent_containers/food/snacks/proc/Post_Consume(mob/living/M)
 	return
 
-/obj/item/weapon/reagent_containers/food/snacks/attack_self(mob/user as mob)
+/obj/item/weapon/reagent_containers/food/snacks/attack_self(mob/user)
 	return
 
-/obj/item/weapon/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/weapon/reagent_containers/food/snacks/attack(mob/M, mob/user, def_zone)
 	if(reagents && !reagents.total_volume)						//Shouldn't be needed but it checks to see if it has anything left in it.
 		to_chat(user, "<span class='warning'>None of [src] left, oh no!</span>")
 		M.unEquip(src)	//so icons update :[

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -4,7 +4,6 @@
 	desc = "yummy"
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = null
-	bitesize = 1
 	var/bitecount = 0
 	var/trash = null
 	var/slice_path
@@ -255,49 +254,12 @@
 	icon_state = "aesirsalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#468C00"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("omnizine", 8)
-		bitesize = 3
-
-/*
-/obj/item/weapon/reagent_containers/food/snacks/candy
-	name = "candy"
-	desc = "Nougat, love it or hate it."
-	icon_state = "candy"
-	trash = /obj/item/trash/candy
-	filling_color = "#7D5F46"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 1)
-		reagents.add_reagent("sugar", 3)
-		bitesize = 2
-
-/obj/item/weapon/reagent_containers/food/snacks/candy/donor
-	name = "Donor Candy"
-	desc = "A little treat for blood donors."
-	trash = /obj/item/trash/candy
-	New()
-		..()
-		reagents.add_reagent("nutriment", 10)
-		reagents.add_reagent("sugar", 3)
-		bitesize = 5
-
-/obj/item/weapon/reagent_containers/food/snacks/candy_corn
-	name = "candy corn"
-	desc = "It's a handful of candy corn. Cannot be stored in a detective's hat, alas."
-	icon_state = "candy_corn"
-	filling_color = "#FFFCB0"
-
-	New()
-		..()
-		reagents.add_reagent("nutriment", 4)
-		reagents.add_reagent("sugar", 2)
-		bitesize = 2
-*/
 
 /obj/item/weapon/reagent_containers/food/snacks/chips
 	name = "chips"
@@ -310,7 +272,6 @@
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("sodiumchloride", 1)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/cornchips
 	name = "corn chips"
@@ -322,7 +283,6 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/cookie
 	name = "cookie"
@@ -333,48 +293,48 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/chocolatebar
 	name = "Chocolate Bar"
 	desc = "Such sweet, fattening food."
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("chocolate",4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/choc_pile //for reagent chocolate being spilled on turfs
 	name = "Pile of Chocolate"
 	desc = "A pile of pure chocolate pieces."
 	icon_state = "cocoa"
 	filling_color = "#7D5F46"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("chocolate",5)		//no longer can be used to generate the reagent infinitely
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chocolateegg
 	name = "Chocolate Egg"
 	desc = "Such sweet, fattening food."
 	icon_state = "chocolateegg"
 	filling_color = "#7D5F46"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("chocolate",4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/donut
 	name = "donut"
 	desc = "Goes great with Robust Coffee."
 	icon_state = "donut1"
 	filling_color = "#D9C386"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/donut/normal
 	name = "donut"
@@ -384,7 +344,6 @@
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("sprinkles", 1)
-		src.bitesize = 3
 		if(prob(30))
 			src.icon_state = "donut2"
 			src.name = "frosted donut"
@@ -393,6 +352,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/donut/sprinkles
 	name = "frosted donut"
 	icon_state = "donut2"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
@@ -403,12 +363,12 @@
 	desc = "Like life, it never quite tastes the same."
 	icon_state = "donut1"
 	filling_color = "#ED11E6"
+	bitesize = 10
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("sprinkles", 1)
-		bitesize = 10
 		var/chaosselect = pick(1,2,3,4,5,6,7,8,9,10)
 		switch(chaosselect)
 			if(1)
@@ -442,13 +402,13 @@
 	desc = "You jelly?"
 	icon_state = "jdonut1"
 	filling_color = "#ED1169"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("sprinkles", 1)
 		reagents.add_reagent("berryjuice", 5)
-		bitesize = 5
 		if(prob(30))
 			src.icon_state = "jdonut2"
 			src.name = "Frosted Jelly Donut"
@@ -459,13 +419,13 @@
 	desc = "You jelly?"
 	icon_state = "jdonut1"
 	filling_color = "#ED1169"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("sprinkles", 1)
 		reagents.add_reagent("slimejelly", 5)
-		bitesize = 5
 		if(prob(30))
 			src.icon_state = "jdonut2"
 			src.name = "Frosted Jelly Donut"
@@ -476,13 +436,13 @@
 	desc = "You jelly?"
 	icon_state = "jdonut1"
 	filling_color = "#ED1169"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("sprinkles", 1)
 		reagents.add_reagent("cherryjelly", 5)
-		bitesize = 5
 		if(prob(30))
 			src.icon_state = "jdonut2"
 			src.name = "Frosted Jelly Donut"
@@ -566,7 +526,6 @@
 		reagents.add_reagent("egg", 5)
 		reagents.add_reagent("sodiumchloride", 1)
 		reagents.add_reagent("blackpepper", 1)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledegg
 	name = "Boiled egg"
@@ -586,11 +545,11 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "appendix"
 	filling_color = "#E00D34"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("protein", 4)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/appendix
 //yes, this is the same as meat. I might do something different in future
@@ -599,11 +558,11 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "appendix"
 	filling_color = "#E00D34"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/appendix/inflamed
 	name = "inflamed appendix"
@@ -616,34 +575,34 @@
 	icon_state = "tofu"
 	desc = "We all love tofu."
 	filling_color = "#FFFEE0"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("plantmatter", 3)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/fried_tofu
 	name = "Fried Tofu"
 	icon_state = "tofu"
 	desc = "Proof that even vegetarians crave unhealthy foods."
 	filling_color = "#FFFEE0"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/tofurkey
 	name = "Tofurkey"
 	desc = "A fake turkey made from tofu."
 	icon_state = "tofurkey"
 	filling_color = "#FFFEE0"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 12)
 		reagents.add_reagent("ether", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/stuffing
 	name = "Stuffing"
@@ -654,107 +613,109 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/hugemushroomslice
 	name = "huge mushroom slice"
 	desc = "A slice from a huge mushroom."
 	icon_state = "hugemushroomslice"
 	filling_color = "#E0D7C5"
+	bitesize = 6
 
 	New()
 		..()
 		reagents.add_reagent("plantmatter", 3)
 		reagents.add_reagent("psilocybin", 3)
-		src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/tomatomeat
 	name = "tomato slice"
 	desc = "A slice from a huge tomato"
 	icon_state = "tomatomeat"
 	filling_color = "#DB0000"
+	bitesize = 6
 
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
-		src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/bearmeat
 	name = "bear meat"
 	desc = "A very manly slab of meat."
 	icon_state = "bearmeat"
 	filling_color = "#DB0000"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("protein", 12)
 		reagents.add_reagent("methamphetamine", 5)
-		src.bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/xenomeat
 	name = "meat"
 	desc = "A slab of meat"
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
+	bitesize = 6
 
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
-		src.bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/spidermeat
 	name = "spider meat"
 	desc = "A slab of spider meat."
 	icon_state = "spidermeat"
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
 		reagents.add_reagent("toxin", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/lizardmeat
 	name = "mutant lizard meat"
 	desc = "Seems to be a slab of meat from some mutant lizard thing?"
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
 		reagents.add_reagent("toxin", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/spiderleg
 	name = "spider leg"
 	desc = "A still twitching leg of a giant spider... you don't really want to eat this, do you?"
 	icon_state = "spiderleg"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 2)
 		reagents.add_reagent("toxin", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/meatball
 	name = "Meatball"
 	desc = "A great meal all round."
 	icon_state = "meatball"
 	filling_color = "#DB0000"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 3)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/sausage
 	name = "Sausage"
 	desc = "A piece of mixed, long meat."
 	icon_state = "sausage"
 	filling_color = "#DB0000"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("protein", 6)
 		reagents.add_reagent("porktonium", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/donkpocket
 	name = "Donk-pocket"
@@ -814,23 +775,23 @@
 	desc = "A strange looking burger. It looks almost sentient."
 	icon_state = "brainburger"
 	filling_color = "#F2B6EA"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("prions", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/ghostburger
 	name = "Ghost Burger"
 	desc = "Spooky! It doesn't look very filling."
 	icon_state = "ghostburger"
 	filling_color = "#FFF2FF"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 2
 
 
 /obj/item/weapon/reagent_containers/food/snacks/human
@@ -842,15 +803,17 @@
 	name = "-burger"
 	desc = "A bloody burger."
 	icon_state = "hburger"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/cheeseburger
 	name = "cheeseburger"
 	desc = "The cheese adds a good flavor."
 	icon_state = "cheeseburger"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
@@ -860,34 +823,34 @@
 	desc = "The cornerstone of every nutritious breakfast."
 	icon_state = "hburger"
 	filling_color = "#D63C3C"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/tofuburger
 	name = "Tofu Burger"
 	desc = "What.. is that meat?"
 	icon_state = "tofuburger"
 	filling_color = "#FFFEE0"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/roburger
 	name = "roburger"
 	desc = "The lettuce is the only organic component. Beep."
 	icon_state = "roburger"
 	filling_color = "#CCCCCC"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("nanomachines", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/roburgerbig
 	name = "roburger"
@@ -895,28 +858,29 @@
 	icon_state = "roburger"
 	filling_color = "#CCCCCC"
 	volume = 100
+	bitesize = 0.1
 
 	New()
 		..()
 		reagents.add_reagent("nanomachines", 100)
-		bitesize = 0.1
 
 /obj/item/weapon/reagent_containers/food/snacks/xenoburger
 	name = "xenoburger"
 	desc = "Smells caustic. Tastes like heresy."
 	icon_state = "xburger"
 	filling_color = "#43DE18"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/clownburger
 	name = "Clown Burger"
 	desc = "This tastes funny..."
 	icon_state = "clownburger"
 	filling_color = "#FF00FF"
+	bitesize = 2
 
 	New()
 		..()
@@ -926,18 +890,17 @@
 		reagents.add_reagent("blood", 4, data)
 */
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/mimeburger
 	name = "Mime Burger"
 	desc = "Its taste defies language."
 	icon_state = "mimeburger"
 	filling_color = "#FFFFFF"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/omelette
 	name = "Omelette Du Fromage"
@@ -946,22 +909,20 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FFF9A8"
 
-	//var/herp = 0
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/muffin
 	name = "Muffin"
 	desc = "A delicious and spongy little cake"
 	icon_state = "muffin"
 	filling_color = "#E0CF9B"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/pie
 	name = "Banana Cream Pie"
@@ -969,12 +930,12 @@
 	icon_state = "pie"
 	trash = /obj/item/trash/plate
 	filling_color = "#FBFFB8"
+	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/New()
 	..()
 	reagents.add_reagent("nutriment", 4)
 	reagents.add_reagent("banana",5)
-	bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/pie/throw_impact(atom/hit_atom)
 	..()
@@ -987,11 +948,12 @@
 	desc = "No black birds, this is a good sign."
 	icon_state = "berryclafoutis"
 	trash = /obj/item/trash/plate
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("berryjuice", 5)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/waffles
 	name = "waffles"
@@ -999,11 +961,11 @@
 	icon_state = "waffles"
 	trash = /obj/item/trash/waffles
 	filling_color = "#E6DEB5"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/eggplantparm
 	name = "Eggplant Parmigiana"
@@ -1011,11 +973,11 @@
 	icon_state = "eggplantparm"
 	trash = /obj/item/trash/plate
 	filling_color = "#4D2F5E"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/soylentgreen
 	name = "Soylent Green"
@@ -1023,11 +985,11 @@
 	icon_state = "soylent_green"
 	trash = /obj/item/trash/waffles
 	filling_color = "#B8E6B5"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/soylenviridians
 	name = "Soylen Virdians"
@@ -1035,11 +997,11 @@
 	icon_state = "soylent_yellow"
 	trash = /obj/item/trash/waffles
 	filling_color = "#E6FA61"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpie
@@ -1048,11 +1010,11 @@
 	desc = "An old barber recipe, very delicious!"
 	trash = /obj/item/trash/plate
 	filling_color = "#948051"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/tofupie
 	name = "Tofu-pie"
@@ -1060,30 +1022,31 @@
 	desc = "A delicious tofu pie."
 	trash = /obj/item/trash/plate
 	filling_color = "#FFFEE0"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/amanita_pie
 	name = "amanita pie"
 	desc = "Sweet and tasty poison pie."
 	icon_state = "amanita_pie"
 	filling_color = "#FFCCCC"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
 		reagents.add_reagent("amanitin", 3)
 		reagents.add_reagent("psilocybin", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/plump_pie
 	name = "plump pie"
 	desc = "I bet you love stuff made out of plump helmets!"
 	icon_state = "plump_pie"
 	filling_color = "#B8279B"
+	bitesize = 2
 
 	New()
 		..()
@@ -1092,10 +1055,8 @@
 			desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump pie!"
 			reagents.add_reagent("nutriment", 8)
 			reagents.add_reagent("omnizine", 5)
-			bitesize = 2
 		else
 			reagents.add_reagent("nutriment", 8)
-			bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/xemeatpie
 	name = "Xeno-pie"
@@ -1103,11 +1064,11 @@
 	desc = "A delicious meatpie. Probably heretical."
 	trash = /obj/item/trash/plate
 	filling_color = "#43DE18"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/wingfangchu
 	name = "Wing Fang Chu"
@@ -1115,11 +1076,11 @@
 	icon_state = "wingfangchu"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#43DE18"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 
 /obj/item/weapon/reagent_containers/food/snacks/human/kabob
@@ -1128,11 +1089,11 @@
 	desc = "A human meat, on a stick."
 	trash = /obj/item/stack/rods
 	filling_color = "#A85340"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/monkeykabob
 	name = "Meat-kabob"
@@ -1140,11 +1101,11 @@
 	desc = "Delicious meat, on a stick."
 	trash = /obj/item/stack/rods
 	filling_color = "#A85340"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/tofukabob
 	name = "Tofu-kabob"
@@ -1152,11 +1113,11 @@
 	desc = "Vegan meat, on a stick."
 	trash = /obj/item/stack/rods
 	filling_color = "#FFFEE0"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/popcorn
 	name = "Popcorn"
@@ -1165,12 +1126,13 @@
 	trash = /obj/item/trash/popcorn
 	var/unpopped = 0
 	filling_color = "#FFFAD4"
+	bitesize = 0.1 //this snack is supposed to be eating during looooong time. And this it not dinner food! --rastaf0
 
 	New()
 		..()
 		unpopped = rand(1,10)
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 0.1 //this snack is supposed to be eating during looooong time. And this it not dinner food! --rastaf0
+
 	On_Consume(mob/M, mob/user)
 		if(prob(unpopped))	//lol ...what's the point?
 			to_chat(user, "\red You bite down on an un-popped kernel!")
@@ -1184,11 +1146,11 @@
 	desc = "Beef jerky made from the finest space cows."
 	trash = /obj/item/trash/sosjerky
 	filling_color = "#631212"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("protein", 4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/pistachios
 	name = "Pistachios"
@@ -1218,11 +1180,11 @@
 	icon_state = "space_twinkie"
 	desc = "Guaranteed to survive longer then you will."
 	filling_color = "#FFE591"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("sugar", 4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers
 	name = "Cheesie Honkers"
@@ -1230,79 +1192,83 @@
 	desc = "Bite sized cheesie snacks that will honk all over your mouth"
 	trash = /obj/item/trash/cheesie
 	filling_color = "#FFA305"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("fake_cheese", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/chowmein
 	name = "chow mein"
 	desc = "What is in this anyways?"
 	icon_state = "chinese1"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("beans", 3)
 		reagents.add_reagent("msg",4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/tao
 	name = "Admiral Yamamoto carp"
 	desc = "Tastes like chicken."
 	icon_state = "chinese2"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("protein", 2)
 		reagents.add_reagent("msg",4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles
 	name = "chinese newdles"
 	desc = "Made fresh, weekly!"
 	icon_state = "chinese3"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("msg",4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chinese/rice
 	name = "fried rice"
 	desc = "A timeless classic."
 	icon_state = "chinese4"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("rice", 3)
 		reagents.add_reagent("msg",4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/syndicake
 	name = "Syndi-Cakes"
 	icon_state = "syndi_cakes"
 	desc = "An extremely moist snack cake that tastes just as good after being nuked."
 	filling_color = "#FF5D05"
-
 	trash = /obj/item/trash/syndi_cakes
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("salglu_solution", 5)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/loadedbakedpotato
 	name = "Loaded Baked Potato"
 	desc = "Totally baked."
 	icon_state = "loadedbakedpotato"
 	filling_color = "#9C7A68"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/fries
 	name = "Space Fries"
@@ -1310,11 +1276,11 @@
 	icon_state = "fries"
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/soydope
 	name = "Soy Dope"
@@ -1322,11 +1288,11 @@
 	icon_state = "soydope"
 	trash = /obj/item/trash/plate
 	filling_color = "#C4BF76"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/spagetti
 	name = "Spagetti"
@@ -1337,7 +1303,6 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 1)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesyfries
 	name = "Cheesy Fries"
@@ -1345,35 +1310,34 @@
 	icon_state = "cheesyfries"
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/fortunecookie
 	name = "Fortune cookie"
 	desc = "A true prophecy in each cookie!"
 	icon_state = "fortune_cookie"
 	filling_color = "#E8E79E"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/badrecipe
 	name = "Burned mess"
 	desc = "Someone should be demoted from chef for this."
 	icon_state = "badrecipe"
 	filling_color = "#211F02"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("????", 5)
 		reagents.add_reagent("carbon", 3)
-		bitesize = 2
-
 		// it's burned! it should start off being classed as any cooktype that burns
 		cooktype["grilled"] = 1
 		cooktype["deep fried"] = 1
@@ -1384,13 +1348,13 @@
 	icon_state = "meatstake"
 	trash = /obj/item/trash/plate
 	filling_color = "#7A3D11"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("sodiumchloride", 1)
 		reagents.add_reagent("blackpepper", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/spacylibertyduff
 	name = "Spacy Liberty Duff"
@@ -1398,12 +1362,12 @@
 	icon_state = "spacylibertyduff"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#42B873"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("psilocybin", 6)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/amanitajelly
 	name = "Amanita Jelly"
@@ -1411,13 +1375,13 @@
 	icon_state = "amanitajelly"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#ED0758"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("amanitin", 6)
 		reagents.add_reagent("psilocybin", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/poppypretzel
 	name = "Poppy pretzel"
@@ -1429,7 +1393,6 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
-		bitesize = 2
 
 
 /obj/item/weapon/reagent_containers/food/snacks/meatballsoup
@@ -1438,50 +1401,50 @@
 	icon_state = "meatballsoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#785210"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("water", 5)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/slimesoup
 	name = "slime soup"
 	desc = "If no water is available, you may substitute tears."
 	icon_state = "slimesoup"
 	filling_color = "#C4DBA0"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("slimejelly", 5)
 		reagents.add_reagent("water", 10)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/bloodsoup
 	name = "Tomato soup"
 	desc = "Smells like copper"
 	icon_state = "tomatosoup"
 	filling_color = "#FF0000"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("blood", 10)
 		reagents.add_reagent("water", 5)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/clownstears
 	name = "Clown's Tears"
 	desc = "Not very funny."
 	icon_state = "clownstears"
 	filling_color = "#C4FBFF"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("banana", 5)
 		reagents.add_reagent("water", 10)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablesoup
 	name = "Vegetable soup"
@@ -1489,12 +1452,12 @@
 	icon_state = "vegetablesoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#AFC4B5"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("water", 5)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/nettlesoup
 	name = "Nettle soup"
@@ -1502,13 +1465,13 @@
 	icon_state = "nettlesoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#AFC4B5"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("water", 5)
 		reagents.add_reagent("omnizine", 5)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/mysterysoup
 	name = "Mystery soup"
@@ -1516,6 +1479,7 @@
 	icon_state = "mysterysoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#F082FF"
+	bitesize = 5
 
 	New()
 		..()
@@ -1555,7 +1519,6 @@
 				reagents.add_reagent("nutriment", 6)
 				reagents.add_reagent("tomatojuice", 5)
 				reagents.add_reagent("oculine", 5)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/wishsoup
 	name = "Wish Soup"
@@ -1563,11 +1526,11 @@
 	icon_state = "wishsoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#D1F4FF"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("water", 10)
-		bitesize = 5
 		if(prob(25))
 			src.desc = "A wish come true!"
 			reagents.add_reagent("nutriment", 8)
@@ -1578,34 +1541,34 @@
 	icon_state = "hotchili"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FF3C00"
+	bitesize = 5
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("capsaicin", 3)
 		reagents.add_reagent("tomatojuice", 2)
-		bitesize = 5
-
 
 /obj/item/weapon/reagent_containers/food/snacks/coldchili
 	name = "Cold Chili"
 	desc = "This slush is barely a liquid!"
 	icon_state = "coldchili"
 	filling_color = "#2B00FF"
-
 	trash = /obj/item/trash/snack_bowl
+	bitesize = 5
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("frostoil", 3)
 		reagents.add_reagent("tomatojuice", 2)
-		bitesize = 5
 
 /obj/item/weapon/reagent_containers/food/snacks/raw_bacon
 	name = "raw bacon"
 	desc = "It's fleshy and pink!"
 	icon_state = "raw_bacon"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 1)
@@ -1616,6 +1579,7 @@
 	desc = "It looks juicy and tastes amazing!"
 	icon_state = "bacon2"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
@@ -1629,11 +1593,13 @@
 	icon_state = "bacon"
 	var/obj/item/device/radio/beacon/bacon/baconbeacon
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
 		reagents.add_reagent("porktonium", 10)
 		baconbeacon = new /obj/item/device/radio/beacon/bacon(src)
+
 	On_Consume(mob/M, mob/user)
 		if(!reagents.total_volume)
 			baconbeacon.loc = user
@@ -1737,22 +1703,22 @@
 	desc = "This is absolutely Ei Nath."
 	icon_state = "spellburger"
 	filling_color = "#D505FF"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/bigbiteburger
 	name = "Big Bite Burger"
 	desc = "Forget the Big Mac. THIS is the future!"
 	icon_state = "bigbiteburger"
 	filling_color = "#E3D681"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 14)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/enchiladas
 	name = "Enchiladas"
@@ -1760,12 +1726,12 @@
 	icon_state = "enchiladas"
 	trash = /obj/item/trash/tray
 	filling_color = "#A36A1F"
+	bitesize = 4
 
 	New()
 		..()
 		reagents.add_reagent("nutriment",8)
 		reagents.add_reagent("capsaicin", 6)
-		bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/burrito
 	name = "Burrito"
@@ -1796,6 +1762,7 @@
 	icon_state = "monkeysdelight"
 	trash = /obj/item/trash/tray
 	filling_color = "#5C3C11"
+	bitesize = 6
 
 	New()
 		..()
@@ -1803,20 +1770,19 @@
 		reagents.add_reagent("banana", 5)
 		reagents.add_reagent("blackpepper", 1)
 		reagents.add_reagent("sodiumchloride", 1)
-		bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/baguette
 	name = "Baguette"
 	desc = "Bon appetit!"
 	icon_state = "baguette"
 	filling_color = "#E3D796"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("blackpepper", 1)
 		reagents.add_reagent("sodiumchloride", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/sandwich
 	name = "Sandwich"
@@ -1824,11 +1790,11 @@
 	icon_state = "sandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/toastedsandwich
 	name = "Toasted Sandwich"
@@ -1836,12 +1802,12 @@
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("carbon", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/grilledcheese
 	name = "Grilled Cheese Sandwich"
@@ -1849,11 +1815,11 @@
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 7)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/tomatosoup
 	name = "Tomato Soup"
@@ -1861,12 +1827,12 @@
 	icon_state = "tomatosoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#D92929"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
 		reagents.add_reagent("tomatojuice", 10)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/rofflewaffles
 	name = "Roffle Waffles"
@@ -1874,18 +1840,19 @@
 	icon_state = "rofflewaffles"
 	trash = /obj/item/trash/waffles
 	filling_color = "#FF00F7"
+	bitesize = 4
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("psilocybin", 8)
-		bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/stew
 	name = "Stew"
 	desc = "A nice and warm stew. Healthy and strong."
 	icon_state = "stew"
 	filling_color = "#9E673A"
+	bitesize = 10
 
 	New()
 		..()
@@ -1893,7 +1860,6 @@
 		reagents.add_reagent("tomatojuice", 5)
 		reagents.add_reagent("oculine", 5)
 		reagents.add_reagent("water", 5)
-		bitesize = 10
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast
 	name = "Jellied Toast"
@@ -1901,11 +1867,11 @@
 	icon_state = "jellytoast"
 	trash = /obj/item/trash/plate
 	filling_color = "#B572AB"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 1)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/jelliedtoast/cherry
 	New()
@@ -1922,11 +1888,11 @@
 	desc = "Culinary delight..?"
 	icon_state = "jellyburger"
 	filling_color = "#B572AB"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/jellyburger/slime
 	New()
@@ -1943,21 +1909,23 @@
 	desc = "The universes best soup! Yum!!!"
 	icon_state = "milosoup"
 	trash = /obj/item/trash/snack_bowl
+	bitesize = 4
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("water", 5)
-		bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/stewedsoymeat
 	name = "Stewed Soy Meat"
 	desc = "Even non-vegetarians will LOVE this!"
 	icon_state = "stewedsoymeat"
 	trash = /obj/item/trash/plate
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspagetti
 	name = "Boiled Spagetti"
@@ -1965,11 +1933,11 @@
 	icon_state = "spagettiboiled"
 	trash = /obj/item/trash/plate
 	filling_color = "#FCEE81"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledrice
 	name = "Boiled Rice"
@@ -1977,11 +1945,11 @@
 	icon_state = "boiledrice"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/ricepudding
 	name = "Rice Pudding"
@@ -1989,11 +1957,11 @@
 	icon_state = "rpudding"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/pastatomato
 	name = "Spagetti"
@@ -2001,12 +1969,12 @@
 	icon_state = "pastatomato"
 	trash = /obj/item/trash/plate
 	filling_color = "#DE4545"
+	bitesize = 4
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("tomatojuice", 10)
-		bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/meatballspagetti
 	name = "Spagetti & Meatballs"
@@ -2014,35 +1982,35 @@
 	icon_state = "meatballspagetti"
 	trash = /obj/item/trash/plate
 	filling_color = "#DE4545"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("synaptizine", 5)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/spesslaw
 	name = "Spesslaw"
 	desc = "A lawyers favourite"
 	icon_state = "spesslaw"
 	filling_color = "#DE4545"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("synaptizine", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/poppypretzel
 	name = "Poppy Pretzel"
 	desc = "A large soft pretzel full of POP!"
 	icon_state = "poppypretzel"
 	filling_color = "#AB7D2E"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/carrotfries
 	name = "Carrot Fries"
@@ -2050,68 +2018,67 @@
 	icon_state = "carrotfries"
 	trash = /obj/item/trash/plate
 	filling_color = "#FAA005"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("plantmatter", 3)
 		reagents.add_reagent("oculine", 3)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/superbiteburger
 	name = "Super Bite Burger"
 	desc = "This is a mountain of a burger. FOOD!"
 	icon_state = "superbiteburger"
 	filling_color = "#CCA26A"
+	bitesize = 10
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 50)
-		bitesize = 10
 
 /obj/item/weapon/reagent_containers/food/snacks/candiedapple
 	name = "Candied Apple"
 	desc = "An apple coated in sugary sweetness."
 	icon_state = "candiedapple"
 	filling_color = "#F21873"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/applepie
 	name = "Apple Pie"
 	desc = "A pie containing sweet sweet love... or apple."
 	icon_state = "applepie"
 	filling_color = "#E0EDC5"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
-		bitesize = 3
-
 
 /obj/item/weapon/reagent_containers/food/snacks/cherrypie
 	name = "Cherry Pie"
 	desc = "Taste so good, make a grown man cry."
 	icon_state = "cherrypie"
 	filling_color = "#FF525A"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/twobread
 	name = "Two Bread"
 	desc = "It is very bitter and winy."
 	icon_state = "twobread"
 	filling_color = "#DBCC9A"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich
 	name = "Jelly Sandwich"
@@ -2119,11 +2086,11 @@
 	icon_state = "jellysandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#9E3A78"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/jellysandwich/slime
 	New()
@@ -2139,10 +2106,11 @@
 	name = "Boiled Slime Core"
 	desc = "A boiled red thing."
 	icon_state = "boiledrorocore"
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("slimejelly", 5)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/mint
 	name = "mint"
@@ -2153,7 +2121,6 @@
 	New()
 		..()
 		reagents.add_reagent("minttoxin", 1)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/mushroomsoup
 	name = "chantrelle soup"
@@ -2161,17 +2128,18 @@
 	icon_state = "mushroomsoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#E386BF"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/plumphelmetbiscuit
 	name = "plump helmet biscuit"
 	desc = "This is a finely-prepared plump helmet biscuit. The ingredients are exceptionally minced plump helmet, and well-minced dwarven wheat flour."
 	icon_state = "phelmbiscuit"
 	filling_color = "#CFB4C4"
+	bitesize = 2
 
 	New()
 		..()
@@ -2180,10 +2148,8 @@
 			desc = "Microwave is taken by a fey mood! It has cooked an exceptional plump helmet biscuit!"
 			reagents.add_reagent("nutriment", 8)
 			reagents.add_reagent("omnizine", 5)
-			bitesize = 2
 		else
 			reagents.add_reagent("nutriment", 5)
-			bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/chawanmushi
 	name = "chawanmushi"
@@ -2195,7 +2161,6 @@
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/beetsoup
 	name = "beet soup"
@@ -2203,6 +2168,7 @@
 	icon_state = "beetsoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FAC9FF"
+	bitesize = 2
 
 	New()
 		..()
@@ -2220,7 +2186,6 @@
 			if(6)
 				name = "borscht"
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/herbsalad
 	name = "herb salad"
@@ -2228,11 +2193,11 @@
 	icon_state = "herbsalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#76B87F"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/validsalad
 	name = "valid salad"
@@ -2240,12 +2205,12 @@
 	icon_state = "validsalad"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#76B87F"
+	bitesize = 3
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 8)
 		reagents.add_reagent("omnizine", 5)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/appletart
 	name = "golden apple streusel tart"
@@ -2253,6 +2218,7 @@
 	icon_state = "gappletart"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFFF00"
+	bitesize = 3
 
 	New()
 		..()
@@ -2261,17 +2227,17 @@
 		spawn(1)
 			reagents.del_reagent("egg")
 			reagents.update_total()
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/dough_ball
 	name = "ball of raw dough"
 	desc = "A ball of raw dough, ready to be molded into new recipes."
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "dough"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		bitesize = 1
+
 	attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 		if(istype(W,/obj/item/weapon/kitchen/rollingpin))
 			user.visible_message( \
@@ -2293,10 +2259,10 @@
 	icon_state = "flatdough"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/doughslice
 	slices_num = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/doughslice
 	name = "slice of dough"
@@ -2312,11 +2278,12 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/meatbreadslice
 	slices_num = 5
 	filling_color = "#FF7575"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 20)
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/meatbreadslice
 	name = "meatbread slice"
@@ -2333,11 +2300,12 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/xenomeatbreadslice
 	slices_num = 5
 	filling_color = "#8AFF75"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 20)
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/xenomeatbreadslice
 	name = "xenomeatbread slice"
@@ -2353,12 +2321,13 @@
 	icon_state = "spidermeatbread"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/spidermeatbreadslice
 	slices_num = 5
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 20)
 		reagents.add_reagent("nutriment", 10)
 		reagents.add_reagent("toxin", 15)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/spidermeatbreadslice
 	name = "spider meat bread slice"
@@ -2366,6 +2335,7 @@
 	icon_state = "xenobreadslice"
 	trash = /obj/item/trash/plate
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("toxin", 2)
@@ -2377,11 +2347,12 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/bananabreadslice
 	slices_num = 5
 	filling_color = "#EDE5AD"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("banana", 20)
 		reagents.add_reagent("nutriment", 20)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/bananabreadslice
 	name = "Banana-nut bread slice"
@@ -2398,10 +2369,11 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/tofubreadslice
 	slices_num = 5
 	filling_color = "#F7FFE0"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 30)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/tofubreadslice
 	name = "Tofubread slice"
@@ -2419,11 +2391,12 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/carrotcakeslice
 	slices_num = 5
 	filling_color = "#FFD675"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 25)
 		reagents.add_reagent("oculine", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/carrotcakeslice
 	name = "Carrot Cake slice"
@@ -2440,12 +2413,13 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/braincakeslice
 	slices_num = 5
 	filling_color = "#E6AEDB"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 15)
 		reagents.add_reagent("nutriment", 10)
 		reagents.add_reagent("mannitol", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/braincakeslice
 	name = "Brain Cake slice"
@@ -2462,10 +2436,11 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cheesecakeslice
 	slices_num = 5
 	filling_color = "#FAF7AF"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 25)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesecakeslice
 	name = "Cheese Cake slice"
@@ -2482,6 +2457,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/plaincakeslice
 	slices_num = 5
 	filling_color = "#F7EDD5"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
@@ -2501,6 +2477,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/orangecakeslice
 	slices_num = 5
 	filling_color = "#FADA8E"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
@@ -2520,6 +2497,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/limecakeslice
 	slices_num = 5
 	filling_color = "#CBFA8E"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
@@ -2539,6 +2517,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/lemoncakeslice
 	slices_num = 5
 	filling_color = "#FAFA8E"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
@@ -2558,6 +2537,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/chocolatecakeslice
 	slices_num = 5
 	filling_color = "#805930"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
@@ -2578,11 +2558,12 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	slices_num = 5
 	filling_color = "#FFF700"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
 		reagents.add_reagent("cheese", 20)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/cheesewedge
 	name = "Cheese wedge"
@@ -2597,6 +2578,7 @@
 	icon_state = "weirdcheesewedge"
 	filling_color = "#00FF33"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("mercury", 5)
@@ -2611,11 +2593,12 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/birthdaycakeslice
 	slices_num = 5
 	filling_color = "#FFD6D6"
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
 		reagents.add_reagent("sprinkles", 10)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/birthdaycakeslice
 	name = "Birthday Cake slice"
@@ -2632,6 +2615,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/breadslice
 	slices_num = 6
 	filling_color = "#FFE396"
+	bitesize = 2
 
 	New()
 		..()
@@ -2639,7 +2623,6 @@
 		spawn(1)
 			reagents.del_reagent("egg")
 			reagents.update_total()
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/breadslice
 	name = "Bread slice"
@@ -2660,10 +2643,11 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/creamcheesebreadslice
 	slices_num = 5
 	filling_color = "#FFF896"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/creamcheesebreadslice
 	name = "Cream Cheese Bread slice"
@@ -2689,6 +2673,7 @@
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/applecakeslice
 	slices_num = 5
 	filling_color = "#EBF5B8"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 15)
@@ -2737,9 +2722,11 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawcutlet"
 	bitesize = 1
+
 	New()
 		..()
 		reagents.add_reagent("protein", 1)
+
 	attackby(obj/item/weapon/W, mob/user, params)
 		if(istype(W,/obj/item/weapon/kitchen/knife))
 			user.visible_message( \
@@ -2762,11 +2749,12 @@
 	icon_state = "pizzamargherita"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
 	slices_num = 6
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 40)
 		reagents.add_reagent("tomatojuice", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/margheritaslice
 	name = "Margherita slice"
@@ -2781,12 +2769,13 @@
 	icon_state = "meatpizza"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	slices_num = 6
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 30)
 		reagents.add_reagent("nutriment", 20)
 		reagents.add_reagent("tomatojuice", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -2801,11 +2790,12 @@
 	icon_state = "mushroompizza"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	slices_num = 6
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("plantmatter", 25)
 		reagents.add_reagent("nutriment", 10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
@@ -2820,13 +2810,14 @@
 	icon_state = "vegetablepizza"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	slices_num = 6
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("plantmatter", 20)
 		reagents.add_reagent("nutriment", 10)
 		reagents.add_reagent("tomatojuice", 6)
 		reagents.add_reagent("oculine", 12)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"
@@ -3017,73 +3008,82 @@
 	name = "egg wrap"
 	desc = "The precursor to Pigs in a Blanket."
 	icon_state = "wrap"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 5)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/beans
 	name = "tin of beans"
 	desc = "Musical fruit in a slightly less musical container."
 	icon_state = "beans"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 10)
 		reagents.add_reagent("beans",10)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/benedict
 	name = "eggs benedict"
 	desc = "There is only one egg on this, how rude."
 	icon_state = "benedict"
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("egg", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/hotdog
 	name = "hotdog"
 	desc = "Fresh footlong ready to go down on."
 	icon_state = "hotdog"
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("ketchup", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/meatbun
 	name = "meat bun"
 	desc = "Has the potential to not be Dog."
 	icon_state = "meatbun"
+	bitesize = 6
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/icecreamsandwich
 	name = "icecream sandwich"
 	desc = "Portable Ice-cream in it's own packaging."
 	icon_state = "icecreamsandwich"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("ice", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/notasandwich
 	name = "not-a-sandwich"
 	desc = "Something seems to be wrong with this, you can't quite figure what. Maybe it's his moustache."
 	icon_state = "notasandwich"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/sugarcookie
 	name = "sugar cookie"
 	desc = "Just like your little sister used to make."
 	icon_state = "sugarcookie"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 2)
@@ -3091,12 +3091,12 @@
 		spawn(1)
 			reagents.del_reagent("egg")
 			reagents.update_total()
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/friedbanana
 	name = "Fried Banana"
 	desc = "Goreng Pisang, also known as fried bananas."
 	icon_state = "friedbanana"
+
 	New()
 		..()
 		reagents.add_reagent("sugar", 5)
@@ -3107,20 +3107,21 @@
 	name = "Tofurkey"
 	desc = "A fake turkey made from tofu."
 	icon_state = "tofurkey"
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 12)
 		reagents.add_reagent("ether", 3)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/stuffing
 	name = "Stuffing"
 	desc = "Moist, peppery breadcrumbs for filling the body cavities of dead birds. Dig in!"
 	icon_state = "stuffing"
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
-		bitesize = 1
 
 /obj/item/weapon/reagent_containers/food/snacks/dionaroast
 	name = "roast diona"
@@ -3128,46 +3129,49 @@
 	icon_state = "dionaroast"
 	trash = /obj/item/trash/plate
 	filling_color = "#75754B"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("plantmatter", 4)
 		reagents.add_reagent("nutriment", 2)
 		reagents.add_reagent("radium", 2)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/boiledspiderleg
 	name = "boiled spider leg"
 	desc = "A giant spider's leg that's still twitching after being cooked. Gross!"
 	icon_state = "spiderlegcooked"
 	trash = /obj/item/trash/plate
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
 		reagents.add_reagent("toxin", 2)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/spidereggs
 	name = "spider eggs"
 	desc = "A cluster of juicy spider eggs. A great side dish for when you care not for your health."
 	icon_state = "spidereggs"
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 2)
 		reagents.add_reagent("toxin", 3)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/spidereggsham
 	name = "green eggs and ham"
 	desc = "Would you eat them on a train? Would you eat them on a plane? Would you eat them on a state of the art corporate deathtrap floating through space?"
 	icon_state = "spidereggsham"
 	trash = /obj/item/trash/plate
+	bitesize = 4
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
 		reagents.add_reagent("sodiumchloride", 1)
 		reagents.add_reagent("toxin", 3)
-		bitesize = 4
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/turkey
 	name = "Turkey"
@@ -3175,11 +3179,12 @@
 	icon_state = "turkey"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/turkeyslice
 	slices_num = 6
+	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 24)
 		reagents.add_reagent("nutriment", 18)
-		bitesize = 2
 
 /obj/item/weapon/reagent_containers/food/snacks/turkeyslice
 	name = "turkey serving"
@@ -3202,7 +3207,6 @@
 		reagents.add_reagent("nutriment", 5)
 		reagents.add_reagent("gravy", 5)
 		reagents.add_reagent("mashedpotatoes", 10)
-		bitesize = 2
 
 ////////////////////////////////ICE CREAM///////////////////////////////////
 /obj/item/weapon/reagent_containers/food/snacks/icecream
@@ -3210,11 +3214,11 @@
         desc = "Delicious ice cream."
         icon = 'icons/obj/kitchen.dmi'
         icon_state = "icecream_cone"
+
         New()
                 ..()
                 reagents.add_reagent("nutriment", 1)
                 reagents.add_reagent("sugar",1)
-                bitesize = 1
                 update_icon()
 
         update_icon()
@@ -3228,24 +3232,26 @@
         desc = "Delicious ice cream."
         icon_state = "icecream_cone"
         volume = 50
+        bitesize = 3
+
         New()
                 ..()
                 reagents.add_reagent("nutriment", 2)
                 reagents.add_reagent("sugar",6)
                 reagents.add_reagent("ice",2)
-                bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/icecream/icecreamcup
         name = "chocolate ice cream cone"
         desc = "Delicious ice cream."
         icon_state = "icecream_cup"
         volume = 50
+        bitesize = 6
+
         New()
                 ..()
                 reagents.add_reagent("nutriment", 4)
                 reagents.add_reagent("chocolate",8)
                 reagents.add_reagent("ice",2)
-                bitesize = 6
 
 /obj/item/weapon/reagent_containers/food/snacks/cereal
 	name = "box of cereal"
@@ -3253,15 +3259,18 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "cereal_box"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
+
 /obj/item/weapon/reagent_containers/food/snacks/deepfryholder
 	name = "Deep Fried Foods Holder Obj"
 	desc = "If you can see this description the code for the deep fryer fucked up."
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "deepfried_holder_icon"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
@@ -3272,6 +3281,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "dough"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
@@ -3296,6 +3306,7 @@
 	icon_state = "flat dough"
 	slice_path = /obj/item/weapon/reagent_containers/food/snacks/doughslice
 	slices_num = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
@@ -3306,6 +3317,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "doughslice"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 1)
@@ -3315,17 +3327,18 @@
 	desc = "The base for any self-respecting burger."
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "bun"
-	bitesize = 2
+	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 4)
-		bitesize = 3
 
 /obj/item/weapon/reagent_containers/food/snacks/taco
 	name = "taco"
 	desc = "Take a bite!"
 	icon_state = "taco"
 	bitesize = 3
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 7)
@@ -3336,6 +3349,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "cutlet"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 2)
@@ -3346,6 +3360,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawmeatball"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 2)
@@ -3355,6 +3370,7 @@
 	desc = "Unrelated to dogs, maybe."
 	icon_state = "hotdog"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("protein", 6)
@@ -3365,6 +3381,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "flatbread"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("nutriment", 3)
@@ -3375,6 +3392,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawsticks"
 	bitesize = 2
+
 	New()
 		..()
 		reagents.add_reagent("plantmatter", 3)
@@ -3384,6 +3402,7 @@
 	desc = "A luminescent blob of what scientists refer to as 'ghost goo'."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "ectoplasm"
+
 	New()
 		..()
 		reagents.add_reagent("ectoplasm", 10)
@@ -3394,12 +3413,12 @@
 	icon_state = "liquidfood"
 	trash = /obj/item/trash/liquidfood
 	filling_color = "#A8A8A8"
+	bitesize = 4
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 20)
 		reagents.add_reagent("iron", 3)
-		bitesize = 4
 
 
 /obj/item/weapon/reagent_containers/food/snacks/tastybread
@@ -3408,8 +3427,8 @@
 	icon_state = "tastybread"
 	trash = /obj/item/trash/tastybread
 	filling_color = "#A66829"
+	bitesize = 2
 
 	New()
 		..()
 		reagents.add_reagent("nutriment", 6)
-		bitesize = 2

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -52,13 +52,13 @@
 	else
 		overlays += image('icons/obj/kitchen.dmi', "gridle")
 
-/obj/machinery/gibber/relaymove(mob/user as mob)
+/obj/machinery/gibber/relaymove(mob/user)
 	if(locked)
 		return
 
 	go_out()
 
-/obj/machinery/gibber/attack_hand(mob/user as mob)
+/obj/machinery/gibber/attack_hand(mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		return
 
@@ -73,7 +73,7 @@
 	else
 		startgibbing(user)
 
-/obj/machinery/gibber/attackby(obj/item/P as obj, mob/user as mob, params)
+/obj/machinery/gibber/attackby(obj/item/P, mob/user, params)
 	if(istype(P, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = P
 		if(G.state < 2)
@@ -352,7 +352,7 @@
 	feedinTopanim()
 	return 1
 
-/obj/machinery/gibber/autogibber/proc/ejectclothes(var/mob/living/carbon/human/H)
+/obj/machinery/gibber/autogibber/proc/ejectclothes(mob/living/carbon/human/H)
 	if(!istype(H))	return 0
 	if(H != occupant)	return 0 //only using H as a shortcut to typecast
 	for(var/obj/O in H)

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -126,7 +126,7 @@
 		return
 
 	user.visible_message("<span class='danger'>[user] starts to put [victim] into the gibber!</span>")
-	src.add_fingerprint(user)
+	add_fingerprint(user)
 	if(do_after(user, 30, target = victim) && user.Adjacent(src) && victim.Adjacent(user) && !occupant)
 		user.visible_message("<span class='danger'>[user] stuffs [victim] into the gibber!</span>")
 
@@ -155,7 +155,7 @@
 		return
 
 	for(var/obj/O in src)
-		O.loc = src.loc
+		O.loc = loc
 
 	occupant.forceMove(get_turf(src))
 	occupant = null
@@ -212,11 +212,11 @@
 
 /obj/machinery/gibber/proc/startgibbing(var/mob/user, var/UserOverride=0)
 	if(!istype(user) && !UserOverride)
-		log_debug("Some shit just went down with the gibber at X[x], Y[y], Z[z] with an invalid user. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+		log_debug("Some shit just went down with the gibber at X[x], Y[y], Z[z] with an invalid user. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 		return
 
 	if(UserOverride)
-		msg_admin_attack("[key_name_admin(occupant)] was gibbed by an autogibber (\the [src]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+		msg_admin_attack("[key_name_admin(occupant)] was gibbed by an autogibber (\the [src]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 
 	if(operating)
 		return
@@ -236,7 +236,7 @@
 	var/slab_name = occupant.name
 	var/slab_count = 3
 	var/slab_type = /obj/item/weapon/reagent_containers/food/snacks/meat/human //gibber can only gib humans on paracode, no need to check meat type
-	var/slab_nutrition = src.occupant.nutrition / 15
+	var/slab_nutrition = occupant.nutrition / 15
 
 	slab_nutrition /= slab_count
 
@@ -367,7 +367,7 @@
 		if(O.flags & NODROP)
 			qdel(O) //they are already dead by now
 		H.unEquip(O)
-		O.loc = src.loc
+		O.loc = loc
 		O.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(1,5),15)
 		sleep(1)
 
@@ -375,7 +375,7 @@
 		if(C.flags & NODROP)
 			qdel(C)
 		H.unEquip(C)
-		C.loc = src.loc
+		C.loc = loc
 		C.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(1,5),15)
 		sleep(1)
 
@@ -385,7 +385,7 @@
 	var/spats = 0 //keeps track of how many items get spit out. Don't show a message if none are found.
 	for(var/obj/O in src)
 		if(istype(O))
-			O.loc = src.loc
+			O.loc = loc
 			O.throw_at(get_edge_target_turf(src,gib_throw_dir),rand(1,5),15)
 			spats++
 			sleep(1)

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat_2.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat_2.dm
@@ -63,11 +63,11 @@ var/list/ingredients_source = list(
 	while(ingredients.len < 11)
 		ingredients.Add(5)
 
-/obj/machinery/icecream_vat/attack_hand(mob/user as mob)
+/obj/machinery/icecream_vat/attack_hand(mob/user)
 	user.set_machine(src)
 	interact(user)
 
-/obj/machinery/icecream_vat/interact(mob/user as mob)
+/obj/machinery/icecream_vat/interact(mob/user)
 	var/dat
 	dat += "<a href='?src=[UID()];dispense=[ICECREAM_VANILLA]'><b>Dispense vanilla icecream</b></a> There is [ingredients[ICECREAM_VANILLA]] scoops of vanilla icecream left (made from milk and ice).<br>"
 	dat += "<a href='?src=[UID()];dispense=[FLAVOUR_STRAWBERRY]'><b>Dispense strawberry icecream</b></a> There is [ingredients[FLAVOUR_STRAWBERRY]] dollops of strawberry flavouring left (obtained from berry juice.<br>"
@@ -91,7 +91,7 @@ var/list/ingredients_source = list(
 	popup.set_content(dat)
 	popup.open(0)
 
-/obj/machinery/icecream_vat/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
+/obj/machinery/icecream_vat/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/weapon/reagent_containers))
 		if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/icecream))
 			var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = O

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat_2.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat_2.dm
@@ -99,7 +99,7 @@ var/list/ingredients_source = list(
 				if(ingredients[ICECREAM_VANILLA] > 0)
 					var/flavour_name = get_icecream_flavour_string(dispense_flavour)
 					if(dispense_flavour < 11 && ingredients[dispense_flavour] > 0)
-						src.visible_message("[bicon(src)] <span class='info'>[user] scoops delicious [flavour_name] flavoured icecream into [I].</span>")
+						visible_message("[bicon(src)] <span class='info'>[user] scoops delicious [flavour_name] flavoured icecream into [I].</span>")
 						ingredients[dispense_flavour] -= 1
 						ingredients[ICECREAM_VANILLA] -= 1
 
@@ -127,7 +127,7 @@ var/list/ingredients_source = list(
 		else
 			var/obj/item/weapon/reagent_containers/R = O
 			if(R.reagents)
-				src.visible_message("<span class='info'>[user] has emptied all of [R] into [src].</span>")
+				visible_message("<span class='info'>[user] has emptied all of [R] into [src].</span>")
 				for(var/datum/reagent/current_reagent in R.reagents.reagent_list)
 					if(ingredients_source[current_reagent.id])
 						add(ingredients_source[current_reagent.id], current_reagent.volume / 2)
@@ -151,7 +151,7 @@ var/list/ingredients_source = list(
 				ingredients[INGR_FLOUR] -= amount
 				ingredients[INGR_SUGAR] -= amount
 				ingredients[CONE_WAFFLE] += amount
-				src.visible_message("<span class='info'>[user] cooks up some waffle cones.</span>")
+				visible_message("<span class='info'>[user] cooks up some waffle cones.</span>")
 			else
 				to_chat(user, "<span class='notice'>You require sugar and flour to make waffle cones.</span>")
 		if(CONE_CHOC)
@@ -160,7 +160,7 @@ var/list/ingredients_source = list(
 				ingredients[CONE_WAFFLE] -= amount
 				ingredients[FLAVOUR_CHOCOLATE] -= amount
 				ingredients[CONE_CHOC] += amount
-				src.visible_message("<span class='info'>[user] cooks up some chocolate cones.</span>")
+				visible_message("<span class='info'>[user] cooks up some chocolate cones.</span>")
 			else
 				to_chat(user, "<span class='notice'>You require waffle cones and chocolate flavouring to make chocolate cones.</span>")
 		if(ICECREAM_VANILLA)
@@ -169,7 +169,7 @@ var/list/ingredients_source = list(
 				ingredients[INGR_ICE] -= amount
 				ingredients[INGR_MILK] -= amount
 				ingredients[ICECREAM_VANILLA] += amount
-				src.visible_message("<span class='info'>[user] whips up some vanilla icecream.</span>")
+				visible_message("<span class='info'>[user] whips up some vanilla icecream.</span>")
 			else
 				to_chat(user, "<span class='notice'>You require milk and ice to make vanilla icecream.</span>")
 	updateDialog()
@@ -179,7 +179,7 @@ var/list/ingredients_source = list(
 		return
 	if(href_list["dispense"])
 		dispense_flavour = text2num(href_list["dispense"])
-		src.visible_message("\blue[usr] sets [src] to dispense [get_icecream_flavour_string(dispense_flavour)] flavoured icecream.")
+		visible_message("\blue[usr] sets [src] to dispense [get_icecream_flavour_string(dispense_flavour)] flavoured icecream.")
 
 	if(href_list["cone"])
 		var/dispense_cone = text2num(href_list["cone"])
@@ -187,11 +187,11 @@ var/list/ingredients_source = list(
 			var/cone_name = get_icecream_flavour_string(dispense_cone)
 			if(ingredients[dispense_cone] >= 1)
 				ingredients[dispense_cone] -= 1
-				var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = new(src.loc)
+				var/obj/item/weapon/reagent_containers/food/snacks/icecream/I = new(loc)
 				I.cone_type = cone_name
 				I.icon_state = "icecream_cone_[cone_name]"
 				I.desc = "Delicious [cone_name] cone, but no ice cream."
-				src.visible_message("<span class='info'>[usr] dispenses a crunchy [cone_name] cone from [src].</span>")
+				visible_message("<span class='info'>[usr] dispenses a crunchy [cone_name] cone from [src].</span>")
 			else
 				to_chat(usr, "<span class='warning'>There are no [cone_name] cones left!</span>")
 		updateDialog()
@@ -202,7 +202,7 @@ var/list/ingredients_source = list(
 
 	if(href_list["eject"])
 		if(held_container)
-			held_container.forceMove(src.loc)
+			held_container.forceMove(loc)
 			held_container = null
 		updateDialog()
 
@@ -231,7 +231,7 @@ var/list/ingredients_source = list(
 /obj/item/weapon/reagent_containers/food/snacks/icecream/proc/add_ice_cream(var/flavour)
 	var/flavour_name = get_icecream_flavour_string(flavour)
 	name = "[flavour_name] icecream"
-	src.overlays += "icecream_[flavour_name]"
+	overlays += "icecream_[flavour_name]"
 	desc = "Delicious [cone_type] cone with a dollop of [flavour_name] ice cream."
 	ice_creamed = 1
 

--- a/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
@@ -46,9 +46,9 @@
 				return 0
 			O.forceMove(src)
 			beaker = O
-			src.verbs += /obj/machinery/juicer/verb/detach
+			verbs += /obj/machinery/juicer/verb/detach
 			update_icon()
-			src.updateUsrDialog()
+			updateUsrDialog()
 			return 0
 	if(!is_type_in_list(O, allowed_items))
 		to_chat(user, "It doesn't look like that contains any juice.")
@@ -57,7 +57,7 @@
 		to_chat(user, "<span class='notice'>\the [O] is stuck to your hand, you cannot put it in \the [src]</span>")
 		return 0
 	O.forceMove(src)
-	src.updateUsrDialog()
+	updateUsrDialog()
 	return 0
 
 /obj/machinery/juicer/attack_ai(mob/user as mob)
@@ -74,7 +74,7 @@
 	var/beaker_contents = ""
 
 	for(var/i in allowed_items)
-		for(var/obj/item/O in src.contents)
+		for(var/obj/item/O in contents)
 			if(!istype(O,i))
 				continue
 			processing_chamber+= "some <B>[O]</B><BR>"
@@ -119,7 +119,7 @@
 
 		if("detach")
 			detach()
-	src.updateUsrDialog()
+	updateUsrDialog()
 	return
 
 /obj/machinery/juicer/verb/detach()
@@ -130,8 +130,8 @@
 		return
 	if(!beaker)
 		return
-	src.verbs -= /obj/machinery/juicer/verb/detach
-	beaker.forceMove(src.loc)
+	verbs -= /obj/machinery/juicer/verb/detach
+	beaker.forceMove(loc)
 	beaker = null
 	update_icon()
 
@@ -159,8 +159,8 @@
 		return
 	if(!beaker || beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 		return
-	playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
-	for(var/obj/item/weapon/reagent_containers/food/snacks/O in src.contents)
+	playsound(loc, 'sound/machines/juicer.ogg', 50, 1)
+	for(var/obj/item/weapon/reagent_containers/food/snacks/O in contents)
 		var/r_id = get_juice_id(O)
 		beaker.reagents.add_reagent(r_id,get_juice_amount(O))
 		qdel(O)

--- a/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/juicer.dm
@@ -35,7 +35,7 @@
 	return
 
 
-/obj/machinery/juicer/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
+/obj/machinery/juicer/attackby(obj/item/O, mob/user, params)
 	if(istype(O,/obj/item/weapon/reagent_containers/glass) || \
 		istype(O,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass))
 		if(beaker)
@@ -60,14 +60,14 @@
 	updateUsrDialog()
 	return 0
 
-/obj/machinery/juicer/attack_ai(mob/user as mob)
+/obj/machinery/juicer/attack_ai(mob/user)
 	return 0
 
-/obj/machinery/juicer/attack_hand(mob/user as mob)
+/obj/machinery/juicer/attack_hand(mob/user)
 	user.set_machine(src)
 	interact(user)
 
-/obj/machinery/juicer/interact(mob/user as mob) // The microwave Menu
+/obj/machinery/juicer/interact(mob/user) // The microwave Menu
 	var/is_chamber_empty = 0
 	var/is_beaker_ready = 0
 	var/processing_chamber = ""

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -56,7 +56,7 @@
 *   Item Adding
 ********************/
 
-/obj/machinery/kitchen_machine/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
+/obj/machinery/kitchen_machine/attackby(obj/item/O, mob/user, params)
 	if(operating)
 		return
 	if(!broken && dirty < 100)
@@ -163,10 +163,10 @@
 		return 1
 	updateUsrDialog()
 
-/obj/machinery/kitchen_machine/attack_ai(mob/user as mob)
+/obj/machinery/kitchen_machine/attack_ai(mob/user)
 	return 0
 
-/obj/machinery/kitchen_machine/attack_hand(mob/user as mob)
+/obj/machinery/kitchen_machine/attack_hand(mob/user)
 	user.set_machine(src)
 	interact(user)
 
@@ -174,7 +174,7 @@
 *   Machine Menu	*
 ********************/
 
-/obj/machinery/kitchen_machine/interact(mob/user as mob) // The microwave Menu
+/obj/machinery/kitchen_machine/interact(mob/user) // The microwave Menu
 	if(panel_open || !anchored)
 		return
 	var/dat = ""
@@ -305,7 +305,7 @@
 			new byproduct(loc)
 		return
 
-/obj/machinery/kitchen_machine/proc/wzhzhzh(var/seconds as num)
+/obj/machinery/kitchen_machine/proc/wzhzhzh(seconds)
 	for(var/i=1 to seconds)
 		if(stat & (NOPOWER|BROKEN))
 			return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -77,8 +77,8 @@
 
 	default_deconstruction_crowbar(O)
 
-	if(src.broken > 0)
-		if(src.broken == 2 && istype(O, /obj/item/weapon/screwdriver)) // If it's broken and they're using a screwdriver
+	if(broken > 0)
+		if(broken == 2 && istype(O, /obj/item/weapon/screwdriver)) // If it's broken and they're using a screwdriver
 			user.visible_message( \
 				"<span class='notice'>[user] starts to fix part of \the [src].</span>", \
 				"<span class='notice'>You start to fix part of \the [src].</span>" \
@@ -88,8 +88,8 @@
 					"<span class='notice'>[user] fixes part of \the [src].</span>", \
 					"<span class='notice'>You have fixed part of \the [src].</span>" \
 				)
-				src.broken = 1 // Fix it a bit
-		else if(src.broken == 1 && istype(O, /obj/item/weapon/wrench)) // If it's broken and they're doing the wrench
+				broken = 1 // Fix it a bit
+		else if(broken == 1 && istype(O, /obj/item/weapon/wrench)) // If it's broken and they're doing the wrench
 			user.visible_message( \
 				"<span class='notice'>[user] starts to fix part of \the [src].</span>", \
 				"<span class='notice'>You start to fix part of \the [src].</span>" \
@@ -99,14 +99,14 @@
 					"<span class='notice'>[user] fixes \the [src].</span>", \
 					"<span class='notice'>You have fixed \the [src].</span>" \
 				)
-				src.icon_state = off_icon
-				src.broken = 0 // Fix it!
-				src.dirty = 0 // just to be sure
-				src.flags = OPENCONTAINER
+				icon_state = off_icon
+				broken = 0 // Fix it!
+				dirty = 0 // just to be sure
+				flags = OPENCONTAINER
 		else
 			to_chat(user, "<span class='alert'>It's broken!</span>")
 			return 1
-	else if(src.dirty==100) // The machine is all dirty so can't be used!
+	else if(dirty==100) // The machine is all dirty so can't be used!
 		if(istype(O, /obj/item/weapon/reagent_containers/spray/cleaner) || istype(O, /obj/item/weapon/soap)) // If they're trying to clean it then let them
 			user.visible_message( \
 				"<span class='notice'>[user] starts to clean \the [src].</span>", \
@@ -117,10 +117,10 @@
 					"<span class='notice'>[user]  has cleaned \the [src].</span>", \
 					"<span class='notice'>You have cleaned \the [src].</span>" \
 				)
-				src.dirty = 0 // It's clean!
-				src.broken = 0 // just to be sure
-				src.icon_state = off_icon
-				src.flags = OPENCONTAINER
+				dirty = 0 // It's clean!
+				broken = 0 // just to be sure
+				icon_state = off_icon
+				flags = OPENCONTAINER
 		else //Otherwise bad luck!!
 			to_chat(user, "<span class='alert'>It's dirty!</span>")
 			return 1
@@ -161,7 +161,7 @@
 	else
 		to_chat(user, "<span class='alert'>You have no idea what you can cook with this [O].</span>")
 		return 1
-	src.updateUsrDialog()
+	updateUsrDialog()
 
 /obj/machinery/kitchen_machine/attack_ai(mob/user as mob)
 	return 0
@@ -178,11 +178,11 @@
 	if(panel_open || !anchored)
 		return
 	var/dat = ""
-	if(src.broken > 0)
+	if(broken > 0)
 		dat = {"<TT>Bzzzzttttt</TT>"}
-	else if(src.operating)
-		dat = {"<TT>[pick(src.cook_verbs)] in progress!<BR>Please wait...!</TT>"}
-	else if(src.dirty==100)
+	else if(operating)
+		dat = {"<TT>[pick(cook_verbs)] in progress!<BR>Please wait...!</TT>"}
+	else if(dirty==100)
 		dat = {"<TT>This [src] is dirty!<BR>Please clean it before use!</TT>"}
 	else
 		var/list/items_counts = new
@@ -237,7 +237,7 @@
 	var/datum/browser/popup = new(user, name, name, 400, 400)
 	popup.set_content(dat)
 	popup.open(0)
-	onclose(user, "[src.name]")
+	onclose(user, "[name]")
 	return
 
 
@@ -298,7 +298,7 @@
 		byproduct = recipe.get_byproduct()
 		stop()
 		if(cooked)
-			cooked.forceMove(src.loc)
+			cooked.forceMove(loc)
 		for(var/i=1,i<efficiency,i++)
 			cooked = new cooked.type(loc)
 		if(byproduct)
@@ -323,54 +323,54 @@
 	return 0
 
 /obj/machinery/kitchen_machine/proc/start()
-	src.visible_message("<span class='notice'>\The [src] turns on.</span>", "<span class='notice'>You hear \a [src].</span>")
-	src.operating = 1
-	src.icon_state = on_icon
-	src.updateUsrDialog()
+	visible_message("<span class='notice'>\The [src] turns on.</span>", "<span class='notice'>You hear \a [src].</span>")
+	operating = 1
+	icon_state = on_icon
+	updateUsrDialog()
 
 /obj/machinery/kitchen_machine/proc/abort()
-	src.operating = 0 // Turn it off again aferwards
-	src.icon_state = off_icon
-	src.updateUsrDialog()
+	operating = 0 // Turn it off again aferwards
+	icon_state = off_icon
+	updateUsrDialog()
 
 /obj/machinery/kitchen_machine/proc/stop()
-	playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
-	src.operating = 0 // Turn it off again aferwards
-	src.icon_state = off_icon
-	src.updateUsrDialog()
+	playsound(loc, 'sound/machines/ding.ogg', 50, 1)
+	operating = 0 // Turn it off again aferwards
+	icon_state = off_icon
+	updateUsrDialog()
 
 /obj/machinery/kitchen_machine/proc/dispose()
 	for(var/obj/O in contents)
-		O.forceMove(src.loc)
-	if(src.reagents.total_volume)
-		src.dirty++
-	src.reagents.clear_reagents()
+		O.forceMove(loc)
+	if(reagents.total_volume)
+		dirty++
+	reagents.clear_reagents()
 	to_chat(usr, "<span class='notice'>You dispose of \the [src]'s contents.</span>")
-	src.updateUsrDialog()
+	updateUsrDialog()
 
 /obj/machinery/kitchen_machine/proc/muck_start()
-	playsound(src.loc, 'sound/effects/splat.ogg', 50, 1) // Play a splat sound
-	src.icon_state = dirty_icon // Make it look dirty!!
+	playsound(loc, 'sound/effects/splat.ogg', 50, 1) // Play a splat sound
+	icon_state = dirty_icon // Make it look dirty!!
 
 /obj/machinery/kitchen_machine/proc/muck_finish()
-	playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
-	src.visible_message("<span class='alert'>\The [src] gets covered in muck!</span>")
-	src.dirty = 100 // Make it dirty so it can't be used util cleaned
-	src.flags = null //So you can't add condiments
-	src.icon_state = dirty_icon // Make it look dirty too
-	src.operating = 0 // Turn it off again aferwards
-	src.updateUsrDialog()
+	playsound(loc, 'sound/machines/ding.ogg', 50, 1)
+	visible_message("<span class='alert'>\The [src] gets covered in muck!</span>")
+	dirty = 100 // Make it dirty so it can't be used util cleaned
+	flags = null //So you can't add condiments
+	icon_state = dirty_icon // Make it look dirty too
+	operating = 0 // Turn it off again aferwards
+	updateUsrDialog()
 
 /obj/machinery/kitchen_machine/proc/broke()
 	var/datum/effect/system/spark_spread/s = new
 	s.set_up(2, 1, src)
 	s.start()
-	src.icon_state = broken_icon // Make it look all busted up and shit
-	src.visible_message("<span class='alert'>The [src] breaks!</span>") //Let them know they're stupid
-	src.broken = 2 // Make it broken so it can't be used util fixed
-	src.flags = null //So you can't add condiments
-	src.operating = 0 // Turn it off again aferwards
-	src.updateUsrDialog()
+	icon_state = broken_icon // Make it look all busted up and shit
+	visible_message("<span class='alert'>The [src] breaks!</span>") //Let them know they're stupid
+	broken = 2 // Make it broken so it can't be used util fixed
+	flags = null //So you can't add condiments
+	operating = 0 // Turn it off again aferwards
+	updateUsrDialog()
 
 /obj/machinery/kitchen_machine/proc/fail()
 	var/obj/item/weapon/reagent_containers/food/snacks/badrecipe/ffuu = new(src)
@@ -382,7 +382,7 @@
 			if(id)
 				amount+=O.reagents.get_reagent_amount(id)
 		qdel(O)
-	src.reagents.clear_reagents()
+	reagents.clear_reagents()
 	ffuu.reagents.add_reagent("carbon", amount)
 	ffuu.reagents.add_reagent("????", amount/10)
 	ffuu.forceMove(get_turf(src))
@@ -392,8 +392,8 @@
 		return
 
 	usr.set_machine(src)
-	if(src.operating)
-		src.updateUsrDialog()
+	if(operating)
+		updateUsrDialog()
 		return
 
 	switch(href_list["action"])

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -62,7 +62,7 @@
 				cycle_through = 0
 		to_chat(user, "<span class='notice'>You change the monkeycube type to [initial(cube_type.name)].</span>")
 
-	if(src.stat != 0) //NOPOWER etc
+	if(stat != 0) //NOPOWER etc
 		return
 	if(istype(O, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = O
@@ -76,11 +76,11 @@
 					user.drop_item()
 					qdel(target)
 					to_chat(user, "<span class='notice'>You stuff the monkey in the machine.</span>")
-					playsound(src.loc, 'sound/machines/juicer.ogg', 50, 1)
+					playsound(loc, 'sound/machines/juicer.ogg', 50, 1)
 					var/offset = prob(50) ? -2 : 2
 					animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
 					use_power(500)
-					src.grinded++
+					grinded++
 					sleep(50)
 					pixel_x = initial(pixel_x)
 					to_chat(user, "<span class='notice'>The machine now has [grinded] monkey\s worth of material stored.</span>")
@@ -91,14 +91,14 @@
 	return
 
 /obj/machinery/monkey_recycler/attack_hand(var/mob/user as mob)
-	if(src.stat != 0) //NOPOWER etc
+	if(stat != 0) //NOPOWER etc
 		return
 	if(grinded >= required_grind)
 		to_chat(user, "<span class='notice'>The machine hisses loudly as it condenses the grinded monkey meat. After a moment, it dispenses a brand new monkey cube.</span>")
-		playsound(src.loc, 'sound/machines/hiss.ogg', 50, 1)
+		playsound(loc, 'sound/machines/hiss.ogg', 50, 1)
 		grinded -= required_grind
 		for(var/i = 0, i < cube_production, i++) // Forgot to fix this bit the first time through
-			new cube_type(src.loc)
+			new cube_type(loc)
 		to_chat(user, "<span class='notice'>The machine's display flashes that it has [grinded] monkey\s worth of material left.</span>")
 	else // I'm not sure if the \s macro works with a word in between; I'll play it safe
 		to_chat(user, "<span class='warning'>The machine needs at least [required_grind] monkey\s worth of material to compress [cube_production] monkey\s. It only has [grinded].</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/monkeyrecycler.dm
@@ -33,7 +33,7 @@
 	cube_production = cubes_made
 	required_grind = req_grind
 
-/obj/machinery/monkey_recycler/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
+/obj/machinery/monkey_recycler/attackby(obj/item/O, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "grinder_open", "grinder", O))
 		return
 
@@ -90,7 +90,7 @@
 			to_chat(user, "<span class='warning'>The machine only accepts monkeys!</span>")
 	return
 
-/obj/machinery/monkey_recycler/attack_hand(var/mob/user as mob)
+/obj/machinery/monkey_recycler/attack_hand(mob/user)
 	if(stat != 0) //NOPOWER etc
 		return
 	if(grinded >= required_grind)

--- a/code/modules/food_and_drinks/kitchen_machinery/oven.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven.dm
@@ -60,7 +60,7 @@
 		food_choices.Remove(U)
 	for(var/U in subtypesof(/obj/item/weapon/reagent_containers/food/snacks/customizable/cook))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/cook/V = new U
-		src.food_choices += V
+		food_choices += V
 	return
 
 /obj/machinery/cooking/candy
@@ -75,5 +75,5 @@
 		food_choices.Remove(U)
 	for(var/U in subtypesof(/obj/item/weapon/reagent_containers/food/snacks/customizable/candy))
 		var/obj/item/weapon/reagent_containers/food/snacks/customizable/candy/V = new U
-		src.food_choices += V
+		food_choices += V
 	return

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -154,7 +154,7 @@
 		return P
 	return 0
 
-/obj/machinery/processor/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
+/obj/machinery/processor/attackby(obj/item/O, mob/user, params)
 
 	if(processing)
 		to_chat(user, "<span class='warning'>\the [src] is already processing something!</span>")
@@ -191,7 +191,7 @@
 	what.loc = src
 	return
 
-/obj/machinery/processor/attack_hand(var/mob/user as mob)
+/obj/machinery/processor/attack_hand(mob/user)
 	if(stat & (NOPOWER|BROKEN)) //no power or broken
 		return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -58,9 +58,9 @@
 	var/time = 40
 
 /datum/food_processor_process/proc/process_food(loc, what, obj/machinery/processor/processor)
-	if(src.output && loc && processor)
+	if(output && loc && processor)
 		for(var/i = 0, i < processor.rating_amount, i++)
-			new src.output(loc)
+			new output(loc)
 	if(what)
 		qdel(what)
 
@@ -156,7 +156,7 @@
 
 /obj/machinery/processor/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 
-	if(src.processing)
+	if(processing)
 		to_chat(user, "<span class='warning'>\the [src] is already processing something!</span>")
 		return 1
 
@@ -195,21 +195,21 @@
 	if(stat & (NOPOWER|BROKEN)) //no power or broken
 		return
 
-	if(src.processing)
+	if(processing)
 		to_chat(user, "<span class='warning'>\the [src] is already processing something!</span>")
 		return 1
 
-	if(src.contents.len == 0)
+	if(contents.len == 0)
 		to_chat(user, "<span class='warning'>\the [src] is empty.</span>")
 		return 1
-	src.processing = 1
+	processing = 1
 	user.visible_message("[user] turns on [src].", \
 		"<span class='notice'>You turn on [src].</span>", \
 		"<span class='italics'>You hear a food processor.</span>")
-	playsound(src.loc, 'sound/machines/blender.ogg', 50, 1)
+	playsound(loc, 'sound/machines/blender.ogg', 50, 1)
 	use_power(500)
 	var/total_time = 0
-	for(var/O in src.contents)
+	for(var/O in contents)
 		var/datum/food_processor_process/P = select_recipe(O)
 		if(!P)
 			log_debug("The [O] in processor([src]) does not have a suitable recipe, but it was somehow put inside of the processor anyways.")
@@ -217,14 +217,14 @@
 		total_time += P.time
 	sleep(total_time / rating_speed)
 
-	for(var/O in src.contents)
+	for(var/O in contents)
 		var/datum/food_processor_process/P = select_recipe(O)
 		if(!P)
 			log_debug("The [O] in processor([src]) does not have a suitable recipe, but it was somehow put inside of the processor anyways.")
 			continue
-		P.process_food(src.loc, O, src)
-	src.processing = 0
+		P.process_food(loc, O, src)
+	processing = 0
 
-	src.visible_message("<span class='notice'>\the [src] has finished processing.</span>", \
+	visible_message("<span class='notice'>\the [src] has finished processing.</span>", \
 		"<span class='notice'>\the [src] has finished processing.</span>", \
 		"<span class='notice'>You hear a food processor stopping.</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -170,10 +170,10 @@
 /obj/machinery/smartfridge/process()
 	if(stat & (BROKEN|NOPOWER))
 		return
-	if(src.seconds_electrified > 0)
-		src.seconds_electrified--
-	if(src.shoot_inventory && prob(2))
-		src.throw_item()
+	if(seconds_electrified > 0)
+		seconds_electrified--
+	if(shoot_inventory && prob(2))
+		throw_item()
 
 /obj/machinery/smartfridge/power_change()
 	var/old_stat = stat
@@ -194,7 +194,7 @@
 
 /obj/machinery/smartfridge/attackby(var/obj/item/O as obj, var/mob/user as mob)
 	if(istype(O, /obj/item/weapon/screwdriver) && anchored)
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		panel_open = !panel_open
 		to_chat(user, "You [panel_open ? "open" : "close"] the maintenance panel.")
 		overlays.Cut()
@@ -275,7 +275,7 @@
 	return 0
 
 /obj/machinery/smartfridge/attack_ghost(mob/user as mob)
-	return src.attack_hand(user)
+	return attack_hand(user)
 
 /obj/machinery/smartfridge/attack_hand(mob/user as mob)
 	if(stat & (NOPOWER|BROKEN))
@@ -336,7 +336,7 @@
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "smartfridge.tmpl", src.name, 400, 500)
+		ui = new(user, src, ui_key, "smartfridge.tmpl", name, 400, 500)
 		ui.set_initial_data(data)
 		ui.open()
 
@@ -346,7 +346,7 @@
 	var/mob/user = usr
 	var/datum/nanoui/ui = nanomanager.get_open_ui(user, src, "main")
 
-	src.add_fingerprint(user)
+	add_fingerprint(user)
 
 	if(href_list["close"])
 		user.unset_machine()
@@ -387,7 +387,7 @@
 		item_quants[O]--
 		for(var/obj/T in contents)
 			if(T.name == O)
-				T.forceMove(src.loc)
+				T.forceMove(loc)
 				throw_item = T
 				break
 		break
@@ -395,7 +395,7 @@
 		return 0
 	spawn(0)
 		throw_item.throw_at(target,16,3,src)
-	src.visible_message("<span class='warning'>[src] launches [throw_item.name] at [target.name]!</span>")
+	visible_message("<span class='warning'>[src] launches [throw_item.name] at [target.name]!</span>")
 	return 1
 
 /************************

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -53,7 +53,7 @@
 		A.forceMove(loc)
 	return ..()
 
-/obj/machinery/smartfridge/proc/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/proc/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/reagent_containers/food/snacks/grown/) || istype(O,/obj/item/seeds/))
 		return 1
 	return 0
@@ -66,7 +66,7 @@
 	icon_on = "seeds"
 	icon_off = "seeds-off"
 
-/obj/machinery/smartfridge/seeds/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/seeds/accept_check(obj/item/O)
 	if(istype(O,/obj/item/seeds/))
 		return 1
 	return 0
@@ -77,7 +77,7 @@
 	icon_state = "smartfridge" //To fix the icon in the map editor.
 	icon_on = "smartfridge_chem"
 
-/obj/machinery/smartfridge/medbay/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/medbay/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/reagent_containers/glass/))
 		return 1
 	if(istype(O,/obj/item/weapon/storage/pill_bottle/))
@@ -91,7 +91,7 @@
 	desc = "A refrigerated storage unit for slime extracts"
 	req_access_txt = "47"
 
-/obj/machinery/smartfridge/secure/extract/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/secure/extract/accept_check(obj/item/O)
 	if(istype(O,/obj/item/slime_extract))
 		return 1
 	return 0
@@ -103,7 +103,7 @@
 	icon_on = "smartfridge_chem"
 	req_one_access_txt = "5;33"
 
-/obj/machinery/smartfridge/secure/medbay/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/secure/medbay/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/reagent_containers/glass/))
 		return 1
 	if(istype(O,/obj/item/weapon/storage/pill_bottle/))
@@ -134,7 +134,7 @@
 			nanomanager.update_uis(src)
 			amount--
 
-/obj/machinery/smartfridge/chemistry/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/chemistry/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/storage/pill_bottle) || istype(O,/obj/item/weapon/reagent_containers))
 		return 1
 	return 0
@@ -154,7 +154,7 @@
 					  /obj/item/weapon/reagent_containers/glass/bottle/plasma = 1,
 					  /obj/item/weapon/reagent_containers/glass/bottle/diphenhydramine = 1)
 
-/obj/machinery/smartfridge/secure/chemistry/virology/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/secure/chemistry/virology/accept_check(obj/item/O)
 	if(istype(O, /obj/item/weapon/reagent_containers/syringe) || istype(O, /obj/item/weapon/reagent_containers/glass/bottle) || istype(O, /obj/item/weapon/reagent_containers/glass/beaker))
 		return 1
 	return 0
@@ -163,7 +163,7 @@
 	name = "\improper Drink Showcase"
 	desc = "A refrigerated storage unit for tasty tasty alcohol."
 
-/obj/machinery/smartfridge/drinks/accept_check(var/obj/item/O as obj)
+/obj/machinery/smartfridge/drinks/accept_check(obj/item/O)
 	if(istype(O,/obj/item/weapon/reagent_containers/glass) || istype(O,/obj/item/weapon/reagent_containers/food/drinks) || istype(O,/obj/item/weapon/reagent_containers/food/condiment))
 		return 1
 
@@ -192,7 +192,7 @@
 *   Item Adding
 ********************/
 
-/obj/machinery/smartfridge/attackby(var/obj/item/O as obj, var/mob/user as mob)
+/obj/machinery/smartfridge/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/weapon/screwdriver) && anchored)
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
 		panel_open = !panel_open
@@ -271,20 +271,20 @@
 			return 1
 	return 0
 
-/obj/machinery/smartfridge/attack_ai(mob/user as mob)
+/obj/machinery/smartfridge/attack_ai(mob/user)
 	return 0
 
-/obj/machinery/smartfridge/attack_ghost(mob/user as mob)
+/obj/machinery/smartfridge/attack_ghost(mob/user)
 	return attack_hand(user)
 
-/obj/machinery/smartfridge/attack_hand(mob/user as mob)
+/obj/machinery/smartfridge/attack_hand(mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		return
 	wires.Interact(user)
 	ui_interact(user)
 
 //Drag pill bottle to fridge to empty it into the fridge
-/obj/machinery/smartfridge/MouseDrop_T(obj/over_object as obj, mob/user as mob)
+/obj/machinery/smartfridge/MouseDrop_T(obj/over_object, mob/user)
 	if(!istype(over_object, /obj/item/weapon/storage/pill_bottle)) //Only pill bottles, please
 		return
 
@@ -305,7 +305,7 @@
 		to_chat(user, "<span class='notice'>Some items are refused.</span>")
 	nanomanager.update_uis(src)
 
-/obj/machinery/smartfridge/secure/emag_act(user as mob)
+/obj/machinery/smartfridge/secure/emag_act(user)
 	emagged = 1
 	locked = -1
 	to_chat(user, "You short out the product lock on [src].")
@@ -314,7 +314,7 @@
 *   SmartFridge Menu
 ********************/
 
-/obj/machinery/smartfridge/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+/obj/machinery/smartfridge/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	user.set_machine(src)
 
 	var/data[0]

--- a/code/modules/food_and_drinks/recipes/recipes_candy.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_candy.dm
@@ -79,7 +79,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/nougat
 
 /datum/recipe/candy/nougat/make_food(obj/container)
-	var/obj/item/weapon/reagent_containers/food/snacks/candy/nougat/being_cooked = ..(container)
+	var/obj/item/weapon/reagent_containers/food/snacks/candy/nougat/being_cooked = ..()
 	being_cooked.reagents.del_reagent("egg")
 	return being_cooked
 

--- a/code/modules/food_and_drinks/recipes/recipes_candy.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_candy.dm
@@ -78,6 +78,11 @@
 	items = list(/obj/item/weapon/reagent_containers/food/snacks/egg)
 	result = /obj/item/weapon/reagent_containers/food/snacks/candy/nougat
 
+/datum/recipe/candy/nougat/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/candy/nougat/being_cooked = ..(container)
+	being_cooked.reagents.del_reagent("egg")
+	return being_cooked
+
 // ***********************************************************
 // Base Candy Recipes (unflavored / plain)
 // ***********************************************************

--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -89,6 +89,11 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/fishfingers
 
+/datum/recipe/grill/fishfingers/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/fishfingers/being_cooked = ..(container)
+	being_cooked.reagents.del_reagent("egg")
+	return being_cooked
+
 /datum/recipe/grill/cutlet
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/rawcutlet

--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -90,7 +90,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/fishfingers
 
 /datum/recipe/grill/fishfingers/make_food(obj/container)
-	var/obj/item/weapon/reagent_containers/food/snacks/fishfingers/being_cooked = ..(container)
+	var/obj/item/weapon/reagent_containers/food/snacks/fishfingers/being_cooked = ..()
 	being_cooked.reagents.del_reagent("egg")
 	return being_cooked
 

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -205,10 +205,11 @@
 	reagents = list("water" = 5, "vodka" = 5)
 	fruit = list("amanita" = 3)
 	result = /obj/item/weapon/reagent_containers/food/snacks/amanitajelly
-	make_food(var/obj/container as obj)
-		var/obj/item/weapon/reagent_containers/food/snacks/amanitajelly/being_cooked = ..(container)
-		being_cooked.reagents.del_reagent("amanitin")
-		return being_cooked
+
+/datum/recipe/microwave/amanitajelly/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/amanitajelly/being_cooked = ..()
+	being_cooked.reagents.del_reagent("amanitin")
+	return being_cooked
 
 /datum/recipe/microwave/meatballsoup
 	reagents = list("water" = 10)
@@ -538,10 +539,11 @@ datum/recipe/microwave/slimesandwich
 /datum/recipe/microwave/herbsalad
 	fruit = list("ambrosia" = 3, "apple" = 1)
 	result = /obj/item/weapon/reagent_containers/food/snacks/herbsalad
-	make_food(var/obj/container as obj)
-		var/obj/item/weapon/reagent_containers/food/snacks/herbsalad/being_cooked = ..(container)
-		being_cooked.reagents.del_reagent("toxin")
-		return being_cooked
+
+/datum/recipe/microwave/herbsalad/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/herbsalad/being_cooked = ..()
+	being_cooked.reagents.del_reagent("toxin")
+	return being_cooked
 
 /datum/recipe/microwave/aesirsalad
 	fruit = list("ambrosiadeus" = 3, "goldapple" = 1)
@@ -553,10 +555,11 @@ datum/recipe/microwave/slimesandwich
 		/obj/item/weapon/reagent_containers/food/snacks/meatball,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/validsalad
-	make_food(var/obj/container as obj)
-		var/obj/item/weapon/reagent_containers/food/snacks/validsalad/being_cooked = ..(container)
-		being_cooked.reagents.del_reagent("toxin")
-		return being_cooked
+
+/datum/recipe/microwave/validsalad/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/validsalad/being_cooked = ..()
+	being_cooked.reagents.del_reagent("toxin")
+	return being_cooked
 
 ////////////////////////////FOOD ADDITTIONS///////////////////////////////
 

--- a/code/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -293,6 +293,11 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/bread
 
+/datum/recipe/oven/bread/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/sliceable/bread/being_cooked = ..(container)
+	being_cooked.reagents.del_reagent("egg")
+	return being_cooked
+
 /datum/recipe/oven/applepie
 	fruit = list("apple" = 1)
 	items = list(
@@ -377,6 +382,11 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/appletart
 
+/datum/recipe/oven/appletart/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/appletart/being_cooked = ..(container)
+	being_cooked.reagents.del_reagent("egg")
+	return being_cooked
+
 /datum/recipe/oven/cracker
 	reagents = list("sodiumchloride" = 1)
 	items = list(
@@ -391,6 +401,11 @@
 		/obj/item/weapon/reagent_containers/food/snacks/egg,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/sugarcookie
+
+/datum/recipe/oven/sugarcookie/make_food(obj/container)
+	var/obj/item/weapon/reagent_containers/food/snacks/sugarcookie/being_cooked = ..(container)
+	being_cooked.reagents.del_reagent("egg")
+	return being_cooked
 
 /datum/recipe/oven/flatbread
 	items = list(

--- a/code/modules/food_and_drinks/recipes/recipes_oven.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_oven.dm
@@ -176,20 +176,22 @@
 		/obj/item/weapon/paper,
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/fortunecookie
-	make_food(var/obj/container as obj)
+
+/datum/recipe/oven/fortunecookie/make_food(obj/container)
+	var/obj/item/weapon/paper/paper = locate() in container
+	paper.loc = null //prevent deletion
+	var/obj/item/weapon/reagent_containers/food/snacks/fortunecookie/being_cooked = ..()
+	paper.loc = being_cooked
+	being_cooked.trash = paper //so the paper is left behind as trash without special-snowflake(TM Nodrak) code ~carn
+	return being_cooked
+
+/datum/recipe/oven/fortunecookie/check_items(obj/container)
+	. = ..()
+	if(.)
 		var/obj/item/weapon/paper/paper = locate() in container
-		paper.loc = null //prevent deletion
-		var/obj/item/weapon/reagent_containers/food/snacks/fortunecookie/being_cooked = ..(container)
-		paper.loc = being_cooked
-		being_cooked.trash = paper //so the paper is left behind as trash without special-snowflake(TM Nodrak) code ~carn
-		return being_cooked
-	check_items(var/obj/container as obj)
-		. = ..()
-		if(.)
-			var/obj/item/weapon/paper/paper = locate() in container
-			if(!paper || !paper.info)
-				return -1
-		return .
+		if(!paper || !paper.info)
+			return -1
+	return .
 
 /datum/recipe/oven/pizzamargherita
 	fruit = list("tomato" = 1)
@@ -294,7 +296,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/sliceable/bread
 
 /datum/recipe/oven/bread/make_food(obj/container)
-	var/obj/item/weapon/reagent_containers/food/snacks/sliceable/bread/being_cooked = ..(container)
+	var/obj/item/weapon/reagent_containers/food/snacks/sliceable/bread/being_cooked = ..()
 	being_cooked.reagents.del_reagent("egg")
 	return being_cooked
 
@@ -383,7 +385,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/appletart
 
 /datum/recipe/oven/appletart/make_food(obj/container)
-	var/obj/item/weapon/reagent_containers/food/snacks/appletart/being_cooked = ..(container)
+	var/obj/item/weapon/reagent_containers/food/snacks/appletart/being_cooked = ..()
 	being_cooked.reagents.del_reagent("egg")
 	return being_cooked
 
@@ -403,7 +405,7 @@
 	result = /obj/item/weapon/reagent_containers/food/snacks/sugarcookie
 
 /datum/recipe/oven/sugarcookie/make_food(obj/container)
-	var/obj/item/weapon/reagent_containers/food/snacks/sugarcookie/being_cooked = ..(container)
+	var/obj/item/weapon/reagent_containers/food/snacks/sugarcookie/being_cooked = ..()
 	being_cooked.reagents.del_reagent("egg")
 	return being_cooked
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -80,12 +80,6 @@
 	icon_state = "pill8"
 	list_reagents = list("haloperidol" = 15)
 
-/obj/item/weapon/reagent_containers/food/pill/paroxetine
-	name = "Paroxetine pill"
-	desc = "Heavy anti-depressant."
-	icon_state = "pill8"
-	list_reagents = list("paroxetine" = 15)
-
 /obj/item/weapon/reagent_containers/food/pill/happy
 	name = "Happy pill"
 	desc = "Happy happy joy joy!"


### PR DESCRIPTION
This was a huge pain in the butt, but it has to be done.

Refactors food/snacks and cleans up the code:

- Bitesize var is set on the object as opposed to in `New`
- Reagents now properly use `list_reagents` as opposed to `reagents.add_reagent()` in `New`
- Fixed a few improper reagent values on some candy (ie: some gummies had a total of 25 reagents when it was clear it was meant to be 12, since all the other subtypes were similar)
- Got rid of most relative pathing related to food I could find
- Fixed up some spans
- Reagent removal properly handled on the *recipe* as opposed to the food *object*
- Got rid of an old baychem pill that is unused (and the reagent it has doesn't even exist anymore)
- Removed a lot of implied `src`
- Removed a lot of implied `var`
- Removed a lot of `as X`

Basically this doesn't impact players at all--the single intentional deviation I made was....the *base* type of cotton candy have a bite size of 4 (as opposed to 3) so `bitesize = 4` didn't have to be copy-pasted for ***every*** single child of cotton candy (all the subtypes did, in fact, have a  bitesize value of 4).