### PR TITLE
Phlog now consistently ignites upon application.

### DIFF
--- a/code/modules/reagents/newchem/pyro.dm
+++ b/code/modules/reagents/newchem/pyro.dm
@@ -418,6 +418,7 @@
 		new /obj/effect/hotspot(turf)
 
 /datum/reagent/phlogiston/reaction_mob(mob/living/M, method=TOUCH, volume)
+	M.adjust_fire_stacks(1)
 	M.IgniteMob()
 	..()
 


### PR DESCRIPTION
Before #5251, Phlog used to consistently ignite humans on `life`. Now, it only *actually* sets people on fire if they've got `fire_stacks` on them set first, before putting the phlog in the human's body. This corrects this behavior, and now makes Phlogiston consistently ignite like it did before.

:cl:Crazylemon
fix: Phlogiston now consistently ignites mobs, instead of only sometimes
/:cl: