### PR TITLE
Fixes Fake Blood Sample on Hotel Cleaver

### DIFF
--- a/_maps/map_files/RandomZLevels/spacehotel.dmm
+++ b/_maps/map_files/RandomZLevels/spacehotel.dmm
@@ -523,7 +523,7 @@
 "kc" = (/obj/machinery/door/airlock{name = "Supply Closet"},/turf/unsimulated/floor/carpet,/area/awaymission/spacehotel)
 "kd" = (/obj/machinery/door/airlock/glass{name = "Gateway"},/turf/unsimulated/floor/carpet,/area/awaymission/spacehotel)
 "ke" = (/obj/item/weapon/melee/cultblade,/turf/unsimulated/floor{name = "engraved floor"; icon_state = "cult"},/area/awaymission/spacehotel)
-"kf" = (/obj/item/weapon/kitchen/knife/butcher{blood_DNA = 1e+009},/obj/effect/decal/cleanable/blood/old,/turf/unsimulated/floor{name = "engraved floor"; icon_state = "cult"},/area/awaymission/spacehotel)
+"kf" = (/obj/item/weapon/kitchen/knife/butcher{blood_DNA = list("1e+009" = "O-")},/obj/effect/decal/cleanable/blood/old,/turf/unsimulated/floor{name = "engraved floor"; icon_state = "cult"},/area/awaymission/spacehotel)
 "kg" = (/obj/machinery/light{dir = 8},/obj/structure/stool/bed/chair/sofa/left{icon_state = "sofaend_left"; dir = 4},/turf/unsimulated/floor/carpet,/area/awaymission/spacehotel)
 "kh" = (/obj/effect/hotel_controller,/turf/unsimulated/floor/carpet,/area/awaymission/spacehotel)
 "ki" = (/obj/item/weapon/pen,/obj/structure/table/reinforced,/turf/unsimulated/floor/carpet,/area/awaymission/spacehotel/reception)


### PR DESCRIPTION
The blood sample of the cleaver in the cult room in the space hotel has an unlisted blood sample, causing a runtime when scanned by the detective's scanner, breaking said scanner. This fixes the variable by turning it into a proper list without changing the underlying value. As such, it does give 1e+009 as the readout, but otherwise works appropriately with no runtime.

:cl:Twinmold
Fix: Fixes a runtime issue caused by using the detective's scanner on the space hotel cleaver.
/:cl:
