### PR TITLE
Fixes Arcade Runtime From Lack of People to Remove

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -930,7 +930,8 @@
 	if(specific && specific != dont_remove)
 		safe2remove = list(specific)
 	else
-		removed = pick(safe2remove)
+		if(safe2remove.len >= 1) //need to make sure we even have anyone to remove
+			removed = pick(safe2remove)
 
 	if(removed)
 		if(lings_aboard && prob(40*lings_aboard)) //if there are 2 lings you're twice as likely to get one, obviously


### PR DESCRIPTION
The specific runtime is:
Runtime in arcade.dm,933: pick() from empty list

This adds in a check to make sure the list safe2remove actually has at
least one 'settler' in it before attempting to call pick(), causing the
runtime.

:cl:Twinmold
Fixes: Runtime caused by lack of settlers in the Orion arcade game.
/:cl:
