### PR TITLE
Verb category changes, telecoms verb fix

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -6,13 +6,20 @@ var/runedec = 0
 var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", "self", "see", "other", "hide")
 
 /client/proc/check_words() // -- Urist
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Check Rune Words"
 	set desc = "Check the rune-word meaning"
+	
+	if(!check_rights(R_ADMIN))
+		return	
+	
 	if(!cultwords["travel"])
 		runerandom()
 	for(var/word in engwords)
 		to_chat(usr, "[cultwords[word]] is [word]")
+		
+	log_and_message_admins("checked the rune words.")
+	feedback_add_details("admin_verb","CRW") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!	
 
 /proc/runerandom() //randomizes word meaning
 	var/list/runewords=list("ire","ego","nahlizet","certum","veri","jatkaa","mgar","balaq", "karazet", "geeri") ///"orkan" and "allaq" removed.

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -414,7 +414,7 @@ var/round_start_time = 0
 					var/dat
 					dat += {"<html><head><title>Karma Reminder</title></head><body><h1><B>Karma Reminder</B></h1><br>
 					You have not yet spent your karma for the round, surely there is a player who was worthy of receiving<br>
-					your reward? Look under 'Special Verbs' for the 'Award Karma' button, and use it once a round for best results!</table></body></html>"}
+					your reward? Look under 'OOC' for the 'Award Karma' button, and use it once a round for best results!</table></body></html>"}
 					player << browse(dat, "window=karmareminder;size=400x300")
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -414,7 +414,7 @@ var/round_start_time = 0
 					var/dat
 					dat += {"<html><head><title>Karma Reminder</title></head><body><h1><B>Karma Reminder</B></h1><br>
 					You have not yet spent your karma for the round, surely there is a player who was worthy of receiving<br>
-					your reward? Look under 'OOC' for the 'Award Karma' button, and use it once a round for best results!</table></body></html>"}
+					your reward? Look under 'Karma' for the 'Award Karma' button, and use it once a round for best results!</table></body></html>"}
 					player << browse(dat, "window=karmareminder;size=400x300")
 
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -414,7 +414,7 @@ var/round_start_time = 0
 					var/dat
 					dat += {"<html><head><title>Karma Reminder</title></head><body><h1><B>Karma Reminder</B></h1><br>
 					You have not yet spent your karma for the round, surely there is a player who was worthy of receiving<br>
-					your reward? Look under 'Karma' for the 'Award Karma' button, and use it once a round for best results!</table></body></html>"}
+					your reward? Look under 'OOC' for the 'Award Karma' button, and use it once a round for best results!</table></body></html>"}
 					player << browse(dat, "window=karmareminder;size=400x300")
 
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -540,9 +540,9 @@ var/global/nologevent = 0
 	world.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "end_error", "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", delay)
 
 /datum/admins/proc/announce()
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Announce"
-	set desc="Announce your desires to the world"
+	set desc = "Announce your desires to the world"
 
 	if(!check_rights(R_ADMIN))
 		return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -534,7 +534,7 @@ var/list/admin_verbs_snpc = list(
 #undef AUTOBANTIME
 
 /client/proc/drop_bomb() // Some admin dickery that can probably be done better -- TLE
-	set category = "Special Verbs"
+	set category = "Event"
 	set name = "Drop Bomb"
 	set desc = "Cause an explosion of varying strength at your location."
 

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -405,7 +405,7 @@
 			log_admin("[key_name(usr)] has left build mode.")
 		else
 			new/datum/click_intercept/buildmode(M.client)
-			message_admins("[key_name(usr)] has entered build mode.")
+			message_admins("[key_name_admin(usr)] has entered build mode.")
 			log_admin("[key_name(usr)] has entered build mode.")
 
 /datum/click_intercept/buildmode/InterceptClickOn(user,params,atom/object) //Click Intercept

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -396,7 +396,8 @@
 
 /proc/togglebuildmode(mob/M as mob in player_list)
 	set name = "Toggle Build Mode"
-	set category = "Special Verbs"
+	set category = "Event"
+
 	if(M.client)
 		if(istype(M.client.click_intercept,/datum/click_intercept/buildmode))
 			var/datum/click_intercept/buildmode/B = M.client.click_intercept

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,5 +1,5 @@
 /client/proc/cmd_admin_say(msg as text)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
 	if(!check_rights(R_ADMIN))	return
@@ -17,7 +17,7 @@
 	feedback_add_details("admin_verb","M") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_mentor_say(msg as text)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Msay"
 	set hidden = 1
 

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -1,5 +1,5 @@
 /client/proc/dsay(msg as text)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Dsay" //Gave this shit a shorter name so you only have to time out "dsay" rather than "dead say" to use it --NeoFite
 	set hidden = 1
 	

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -7,13 +7,15 @@
 ////////////////////////////////////////////////////////////////////////////////
 var/global/list/frozen_mob_list = list()
 /client/proc/freeze(var/mob/living/M as mob in mob_list)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Freeze"
-	if(!holder)
-		to_chat(src, "<font color='red'>Error: Freeze: Only administrators may use this command.</font>")
+		
+	if(!check_rights(R_ADMIN))
 		return
-	if(!istype(M))	return
-	if(!check_rights(R_ADMIN))	return
+		
+	if(!istype(M))	
+		return	
+
 	if(M in frozen_mob_list)
 		M.admin_unFreeze(src)
 	else
@@ -83,14 +85,15 @@ var/global/list/frozen_mob_list = list()
 //////////////////////////Freeze Mech
 
 /client/proc/freezemecha(var/obj/mecha/O as obj in mechas_list)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Freeze Mech"
-	if(!holder)
-		to_chat(src, "Only administrators may use this command.")
-		return
+
+	if(!check_rights(R_ADMIN))
+		return	
+	
 	var/obj/mecha/M = O
 	if(!istype(M,/obj/mecha))
-		to_chat(src, "<span class='danger'>This can only be used on Mechs!</span>")
+		to_chat(src, "<span class='danger'>This can only be used on mechs!</span>")
 		return
 	else
 		if(usr)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -139,7 +139,7 @@
 	feedback_add_details("admin_verb","DIRN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_godmode(mob/M as mob in mob_list)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Godmode"
 
 	if(!check_rights(R_ADMIN))
@@ -287,7 +287,7 @@ Works kind of like entering the game with a new character. Character receives a 
 Traitors and the like can also be revived with the previous role mostly intact.
 /N */
 /client/proc/respawn_character()
-	set category = "Special Verbs"
+	set category = "Event"
 	set name = "Respawn Character"
 	set desc = "Respawn a person that has been gibbed/dusted/killed. They must be a ghost for this to work and preferably should not have a body to go back into."
 
@@ -520,7 +520,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	feedback_add_details("admin_verb","IONC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_rejuvenate(mob/living/M as mob in mob_list)
-	set category = "Special Verbs"
+	set category = "Event"
 	set name = "Rejuvenate"
 
 	if(!check_rights(R_REJUVINATE))
@@ -659,7 +659,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 /client/proc/cmd_admin_emp(atom/O as obj|mob|turf in view())
-	set category = "Special Verbs"
+	set category = "Event"
 	set name = "EM Pulse"
 
 	if(!check_rights(R_DEBUG|R_EVENT))
@@ -682,7 +682,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 /client/proc/cmd_admin_gib(mob/M as mob in mob_list)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Gib"
 
 	if(!check_rights(R_ADMIN|R_EVENT))
@@ -722,7 +722,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		feedback_add_details("admin_verb","GIBS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_admin_check_contents(mob/living/M as mob in mob_list)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Check Contents"
 
 	if(!check_rights(R_ADMIN))
@@ -734,7 +734,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	feedback_add_details("admin_verb","CC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/toggle_view_range()
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Change View Range"
 	set desc = "switches between 1x and custom views"
 
@@ -806,7 +806,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("[key_name_admin(usr)] has [shuttle_master.emergencyNoEscape ? "denied" : "allowed"] the shuttle to be called.")
 
 /client/proc/cmd_admin_attack_log(mob/M as mob in mob_list)
-	set category = "Special Verbs"
+	set category = "Admin"
 	set name = "Attack Log"
 
 	if(!check_rights(R_ADMIN))
@@ -875,7 +875,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set name = "Reset Telecomms Scripts"
 	set desc = "Blanks all telecomms scripts from all telecomms servers"
 
-	if(!check_rights(R_ADMIN, 1, src))
+	if(!check_rights(R_ADMIN))
 		return
 
 	var/confirm = alert(src, "You sure you want to blank all NTSL scripts?", "Confirm", "Yes", "No")

--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -84,7 +84,7 @@ var/list/karma_spenders = list()
 /mob/verb/spend_karma_list()
 	set name = "Award Karma"
 	set desc = "Let the gods know whether someone's been nice. Can only be used once per round."
-	set category = "OOC"
+	set category = "Karma"
 
 	if(!can_give_karma())
 		return
@@ -113,7 +113,7 @@ var/list/karma_spenders = list()
 /mob/verb/spend_karma(var/mob/M)
 	set name = "Award Karma to Player"
 	set desc = "Let the gods know whether someone's been nice. Can only be used once per round."
-	set category = "OOC"
+	set category = "Karma"
 
 	if(!M)
 		to_chat(usr, "Please right click a mob to award karma directly, or use the 'Award Karma' verb to select a player from the player listing.")
@@ -144,8 +144,8 @@ var/list/karma_spenders = list()
 
 /client/verb/check_karma()
 	set name = "Check Karma"
-	set category = "OOC"
 	set desc = "Reports how much karma you have accrued."
+	set category = "Karma"
 
 	var/currentkarma=verify_karma()
 	to_chat(usr, {"<br>You have <b>[currentkarma]</b> available."})

--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -84,7 +84,7 @@ var/list/karma_spenders = list()
 /mob/verb/spend_karma_list()
 	set name = "Award Karma"
 	set desc = "Let the gods know whether someone's been nice. Can only be used once per round."
-	set category = "Special Verbs"
+	set category = "OOC"
 
 	if(!can_give_karma())
 		return
@@ -113,7 +113,7 @@ var/list/karma_spenders = list()
 /mob/verb/spend_karma(var/mob/M)
 	set name = "Award Karma to Player"
 	set desc = "Let the gods know whether someone's been nice. Can only be used once per round."
-	set category = "Special Verbs"
+	set category = "OOC"
 
 	if(!M)
 		to_chat(usr, "Please right click a mob to award karma directly, or use the 'Award Karma' verb to select a player from the player listing.")
@@ -144,7 +144,7 @@ var/list/karma_spenders = list()
 
 /client/verb/check_karma()
 	set name = "Check Karma"
-	set category = "Special Verbs"
+	set category = "OOC"
 	set desc = "Reports how much karma you have accrued."
 
 	var/currentkarma=verify_karma()

--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -84,7 +84,7 @@ var/list/karma_spenders = list()
 /mob/verb/spend_karma_list()
 	set name = "Award Karma"
 	set desc = "Let the gods know whether someone's been nice. Can only be used once per round."
-	set category = "Karma"
+	set category = "OOC"
 
 	if(!can_give_karma())
 		return
@@ -113,7 +113,7 @@ var/list/karma_spenders = list()
 /mob/verb/spend_karma(var/mob/M)
 	set name = "Award Karma to Player"
 	set desc = "Let the gods know whether someone's been nice. Can only be used once per round."
-	set category = "Karma"
+	set category = "OOC"
 
 	if(!M)
 		to_chat(usr, "Please right click a mob to award karma directly, or use the 'Award Karma' verb to select a player from the player listing.")
@@ -145,7 +145,7 @@ var/list/karma_spenders = list()
 /client/verb/check_karma()
 	set name = "Check Karma"
 	set desc = "Reports how much karma you have accrued."
-	set category = "Karma"
+	set category = "OOC"
 
 	var/currentkarma=verify_karma()
 	to_chat(usr, {"<br>You have <b>[currentkarma]</b> available."})


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/5855.

Also removes all verbs currently present in the "Special Verbs" tab to their dedicated tabs as a first step to get rid of verb clutter. All karma verbs were moved to "OOC", all event related verbs were moved to "Event" and all general admin verbs were moved to "Admin".

Also adds logging to the "Check Rune Words" verb (which will soon be removed anyway).

🆑 Markolie
tweak: Verbs have been cleaned up: all karma verbs can now be found under "OOC" instead of "Special Verbs". Most admin verbs have been moved out of "Special Verbs" as well.
/🆑