### PR TITLE
Resolves a runtime with alt icons, fixes #5863

### DIFF
--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -159,7 +159,7 @@ var/global/list/limb_icon_cache = list()
 				gender = "f"
 			else
 				gender = "m"
-		if(limb_name == "head")
+		if(limb_name == "head" && !is_stump() && !(status & ORGAN_DESTROYED))
 			var/obj/item/organ/external/head/head_organ = src
 			head_organ.handle_alt_icon()
 


### PR DESCRIPTION
The runtime occurred when get_icon_state() attempted to handle_alt_icon() on a head that was a stump/destroyed.

This resolves the runtime by adding sanity to check if it's a stump or if the organ's destroyed (as how it's handled in update_icons for mobs).

Tested by decapitating an Unathi with the 'sharp' muzzle alt_head with an energy katana leaving a stump, updating the mob icons, then surgically removing the stump and reattaching the head, then updating the mob icons yet again to see if it would produce the runtime after the fix was applied. It didn't.

I then repeated the test but instead of right-clicking the mob and using 'Update Mob Icons', I called 'atom proc call' and used 'update_body' with 2 arguments (update_icons and rebuild_base) both set to 1 in order to ensure the handle_alt_icon sanity would be tested. No runtime here, either.

Furthermore, the Unathi in question still had all their aesthetic features (head accessory, head markings, alt head, facial hair, hair, hair primary/secondary colours, eye colour) after the numerous be/re-headings.