### PR TITLE
Remove spess! Because spess is bad! 

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -456,7 +456,7 @@ turf/simulated/proc/super_conduct()
 					else
 						mimic_temperature_solid(neighbor, neighbor.thermal_conductivity)
 
-	radiate_to_spess()
+	radiate_to_space()
 
 	//Conduct with air on my tile if I have it
 	if(air)
@@ -488,7 +488,7 @@ turf/simulated/proc/consider_superconductivity(starting)
 	air_master.active_super_conductivity |= src
 	return 1
 
-turf/simulated/proc/radiate_to_spess() //Radiate excess tile heat to space
+turf/simulated/proc/radiate_to_space() //Radiate excess tile heat to space
 	if(temperature > T0C) //Considering 0 degC as te break even point for radiation in and out
 		var/delta_temperature = (temperature_archived - 2.7) //hardcoded space temperature
 		if((heat_capacity > 0) && (abs(delta_temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER))

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -98,7 +98,7 @@
 	src.operating = 0
 	return
 
-/obj/machinery/door/poddoor/multi_tile // Whoever wrote the old code for multi-tile spesspod doors needs to burn in hell.
+/obj/machinery/door/poddoor/multi_tile // Whoever wrote the old code for multi-tile spacepod doors needs to burn in hell.
 	name = "Large Pod Door"
 
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver/


### PR DESCRIPTION
It's time to remove the most evil thing in the game: Spess. Spess is the cause of all death. Atmospherics is now a 10x easier job, and the airlock is no longer dangerous. No more SJW's advocating for "Spess lives matter" because spess is black.

Nahhhhhh..... There's a proc that has "spess" in it's name, so I rename it so that it's "space". That's the actual changes. Space still exists.