### PR TITLE
Fixes Paper's In-hand Icon

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -8,6 +8,7 @@
 	gender = PLURAL
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "paper"
+	item_state = "paper"
 	throwforce = 0
 	w_class = 1
 	throw_range = 1


### PR DESCRIPTION
Fixes paper's in-hand icon disappearing when you write on the paper

🆑 Fox McCloud
fix: fixes paper's lack of in-hand icon when you write on it
/:cl: