### PR TITLE
BSA Tweaks

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -55,13 +55,6 @@
 	anchored = 1.0
 	unacidable = 1
 
-/obj/effect/stop
-	var/victim = null
-	icon_state = "empty"
-	name = "Geas"
-	desc = "You can't resist."
-	// name = ""
-
 /obj/effect/projection
 	name = "Projection"
 	desc = "This looks like a projection of something."

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1,6 +1,5 @@
 
 var/global/BSACooldown = 0
-var/global/floorIsLava = 0
 var/global/nologevent = 0
 
 ////////////////////////////////

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1597,11 +1597,11 @@
 			to_chat(usr, "This can only be used on instances of type /mob/living")
 			return
 
-		if(alert(src.owner, "Are you sure you wish to hit [key_name(M)] with Bluespace Artillery?",  "Confirm Firing?" , "Yes" , "No") != "Yes")
+		if(alert(owner, "Are you sure you wish to hit [key_name(M)] with Bluespace Artillery?",  "Confirm Firing?" , "Yes" , "No") != "Yes")
 			return
 
 		if(BSACooldown)
-			to_chat(src.owner, "Standby. Reload cycle in progress. Gunnery crews ready in five seconds!")
+			to_chat(owner, "Standby. Reload cycle in progress. Gunnery crews ready in five seconds!")
 			return
 
 		BSACooldown = 1
@@ -1609,28 +1609,23 @@
 			BSACooldown = 0
 
 		to_chat(M, "You've been hit by bluespace artillery!")
-		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [key_name(src.owner)]")
-		message_admins("[key_name_admin(M)] has been hit by Bluespace Artillery fired by [key_name_admin(src.owner)]")
-
-		var/obj/effect/stop/S
-		S = new /obj/effect/stop
-		S.victim = M
-		S.loc = M.loc
-		spawn(20)
-			qdel(S)
+		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [key_name(owner)]")
+		message_admins("[key_name_admin(M)] has been hit by Bluespace Artillery fired by [key_name_admin(owner)]")
 
 		var/turf/simulated/floor/T = get_turf(M)
 		if(istype(T))
-			if(prob(80))	T.break_tile_to_plating()
-			else			T.break_tile()
+			if(prob(80))
+				T.break_tile_to_plating()
+			else
+				T.break_tile()
 
-		if(M.health == 1)
+		if(M.health <= 1)
 			M.gib()
 		else
-			M.adjustBruteLoss( min( 99 , (M.health - 1) )    )
+			M.adjustBruteLoss(min(99,(M.health - 1)))
 			M.Stun(20)
 			M.Weaken(20)
-			M.stuttering = 20
+			M.Stuttering(20)
 
 	else if(href_list["CentcommReply"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -936,11 +936,6 @@
 	if(wearer.notransform || !wearer.canmove)
 		return
 
-	if(locate(/obj/effect/stop/, wearer.loc))
-		for(var/obj/effect/stop/S in wearer.loc)
-			if(S.victim == wearer)
-				return
-
 	if(!wearer.lastarea)
 		wearer.lastarea = get_area(wearer.loc)
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -95,11 +95,6 @@
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/lesserforcewall)
 	force_threshold = 11
 
-
-/mob/living/simple_animal/construct/armoured/Life()
-	weakened = 0
-	return ..()
-
 /mob/living/simple_animal/construct/armoured/bullet_act(var/obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
 		var/reflectchance = 80 - round(P.damage/3)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -162,11 +162,6 @@
 
 	if(!mob)	return
 
-	if(locate(/obj/effect/stop/, mob.loc))
-		for(var/obj/effect/stop/S in mob.loc)
-			if(S.victim == mob)
-				return
-
 	if(mob.stat==DEAD)	return
 
 // handle possible spirit movement

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -620,7 +620,7 @@
 	heart_rate_decrease = 1
 
 /datum/reagent/ethanol/neurotoxin/on_mob_life(mob/living/M)
-	M.weakened = max(M.weakened, 3)
+	M.Weaken(3)
 	if(current_cycle >=55)
 		M.Druggy(55)
 	if(current_cycle >=200)

--- a/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
+++ b/code/modules/reagents/oldchem/reagents/drink/reagents_alcohol.dm
@@ -620,7 +620,7 @@
 	heart_rate_decrease = 1
 
 /datum/reagent/ethanol/neurotoxin/on_mob_life(mob/living/M)
-	M.Weaken(3)
+	M.weakened = max(M.weakened, 3)
 	if(current_cycle >=55)
 		M.Druggy(55)
 	if(current_cycle >=200)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -133,9 +133,9 @@
 	if(crit_fail)
 		return
 	if(owner.stunned > STUN_SET_AMOUNT)
-		owner.stunned = STUN_SET_AMOUNT
+		owner.SetStunned(STUN_SET_AMOUNT)
 	if(owner.weakened > STUN_SET_AMOUNT)
-		owner.weakened = STUN_SET_AMOUNT
+		owner.SetWeakened(STUN_SET_AMOUNT)
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/emp_act(severity)
 	if(crit_fail)


### PR DESCRIPTION
Removes a super snowflaked effect from the BSA that was literally there to prevent the client from moving (despite the fact this isn't necessary for the BSA to work).

Also changed it so that it would gib if the person's health is less than or equal to one (this seems to be the original intention anyway)--it's a bit silly to require the person to be at exactly 1 health to gib them from a BSA

Probably fixes: https://github.com/ParadiseSS13/Paradise/issues/5836

Other
- Ensured status procs are utilized instead of setting the variable directly.
- Removed a global var


:cl: Fox McCloud
fix: Fixes BSA having peculiar results.
/:cl: