### PR TITLE
Fixes Simple Mobs Attacking Pods/Mechs Across Z-Levels

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -20,7 +20,7 @@
 	jump_action.Grant(user)
 
 /obj/machinery/computer/camera_advanced/check_eye(mob/user)
-	if((stat & (NOPOWER|BROKEN)) || !Adjacent(user) || !user.can_see() || user.incapacitated())
+	if((stat & (NOPOWER|BROKEN)) || !Adjacent(user) || !user.has_vision() || user.incapacitated())
 		user.unset_machine()
 		return 0
 	return 1

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -55,7 +55,7 @@
 	interact(user)
 
 /obj/item/device/camera_bug/check_eye(var/mob/user as mob)
-	if(user.stat || loc != user || !user.canmove || !user.can_see() || !current)
+	if(user.stat || loc != user || !user.canmove || !user.has_vision() || !current)
 		user.reset_view(null)
 		user.unset_machine()
 		return null

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -28,7 +28,7 @@
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if(language && (language.flags & NONVERBAL))
-		if(!can_see()) //blind people can't see dumbass
+		if(!has_vision()) //blind people can't see dumbass
 			message = stars(message)
 
 		if(!speaker || !(speaker in view(src)))
@@ -95,7 +95,7 @@
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if(language && (language.flags & NONVERBAL))
-		if(!can_see()) //blind people can't see dumbass
+		if(!has_vision()) //blind people can't see dumbass
 			message = stars(message)
 
 		if(!speaker || !(speaker in view(src)))

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -118,11 +118,11 @@
 	for(var/atom/check in check_list)
 		for(var/mob/living/M in viewers(world.view + 1, check) - src)
 			if(M.client && CanAttack(M) && !M.has_unlimited_silicon_privilege)
-				if(M.can_see())
+				if(M.has_vision())
 					return M
 		for(var/obj/mecha/M in view(world.view + 1, check)) //assuming if you can see them they can see you
 			if(M.occupant && M.occupant.client)
-				if(M.occupant.can_see())
+				if(M.occupant.has_vision())
 					return M.occupant
 	return null
 

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -1,5 +1,5 @@
 /mob/living/update_blind_effects()
-	if(!can_see())
+	if(!has_vision())
 		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)
 		throw_alert("blind", /obj/screen/alert/blind)
 		return 1
@@ -43,7 +43,7 @@
 	return !(ear_deaf || (disabilities & DEAF))
 
 // Whether the mob is able to see
-/mob/living/can_see()
+/mob/living/has_vision()
 	return !(eye_blind || (disabilities & BLIND) || stat)
 
 // Whether the mob is capable of talking

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -62,7 +62,7 @@
 	if(!client)	return
 
 	if(type)
-		if(type & 1 && !can_see())//Vision related
+		if(type & 1 && !has_vision())//Vision related
 			if(!( alt ))
 				return
 			else
@@ -74,7 +74,7 @@
 			else
 				msg = alt
 				type = alt_type
-				if(type & 1 && !can_see())
+				if(type & 1 && !has_vision())
 					return
 	// Added voice muffling for Issue 41.
 	if(stat == UNCONSCIOUS || (sleeping > 0 && stat != DEAD))

--- a/code/modules/mob/update_status.dm
+++ b/code/modules/mob/update_status.dm
@@ -37,7 +37,7 @@
 /mob/proc/can_hear()
 	return 1
 
-/mob/proc/can_see()
+/mob/proc/has_vision()
 	return 1
 
 /mob/proc/can_speak()


### PR DESCRIPTION
Fixes simple mobs being able to attack mechs and space pods across z-levels

fixes https://github.com/ParadiseSS13/Paradise/issues/5856

🆑 Fox McCloud
fix: Fixes simple mobs being able to attack space pods and mechs across z-levels
/:cl: