### PR TITLE
Fixes Gun Renaming

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -334,7 +334,6 @@ obj/item/weapon/gun/proc/newshot()
 
 /obj/item/weapon/gun/proc/rename_gun(mob/M)
 	var/input = stripped_input(M,"What do you want to name the gun?", ,"", MAX_NAME_LEN)
-
 	if(src && input && !M.stat && in_range(M,src) && !M.restrained() && M.canmove)
 		name = input
 		to_chat(M, "You name the gun [input]. Say hello to your new friend.")

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -34,10 +34,6 @@
 		update_icon()
 		chamber_round(0)
 
-	if(unique_rename)
-		if(istype(A, /obj/item/weapon/pen))
-			rename_gun(user)
-
 /obj/item/weapon/gun/projectile/revolver/attack_self(mob/living/user)
 	var/num_unloaded = 0
 	chambered = null


### PR DESCRIPTION
- Sanity Circuits now provide gun users with a single input box when picking a new name for their gun

:cl:
bugfix: Gun renaming now produces only 1 input box
/:cl:

