### PR TITLE
Vision no longer blinks the blur overlay if your eyes are hurt

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -840,9 +840,9 @@
 			SetEyeBlurry(0)
 
 		else if(!vision || vision.is_broken())   // Vision organs cut out or broken? Permablind.
-			EyeBlind(1)
+			EyeBlind(2)
 			blinded =    1
-			EyeBlurry(1)
+			EyeBlurry(2)
 
 		else
 			//blindness
@@ -859,7 +859,7 @@
 
 			//blurry sight
 			if(vision.is_bruised())   // Vision organs impaired? Permablurry.
-				EyeBlurry(1)
+				EyeBlurry(2)
 
 			if(eye_blurry)	           // Blurry eyes heal slowly
 				AdjustEyeBlurry(-1)


### PR DESCRIPTION
Fixes #5880 
:cl:Crazylemon
fix: Eye damage above 10 no longer causes eternal eye blur flashing
/:cl: