### PR TITLE
Tidies up Machine and Computer crafting backend, fixes #5883

### DIFF
--- a/code/datums/helper_datums/construction_datum.dm
+++ b/code/datums/helper_datums/construction_datum.dm
@@ -61,7 +61,7 @@
 		else if(istype(used_atom, /obj/item/stack/cable_coil))
 			var/obj/item/stack/cable_coil/C = used_atom
 			if(C.amount<4)
-				to_chat(user, ("There's not enough cable to finish the task."))
+				to_chat(user, ("<span class='warning'>There's not enough cable to finish the task.</span>"))
 				return 0
 			else
 				C.use(4)
@@ -69,7 +69,7 @@
 		else if(istype(used_atom, /obj/item/stack))
 			var/obj/item/stack/S = used_atom
 			if(S.amount < 5)
-				to_chat(user, ("There's not enough material in this stack."))
+				to_chat(user, ("<span class='warning'>There's not enough material in this stack.</span>"))
 				return 0
 			else
 				S.use(5)
@@ -106,30 +106,29 @@
 		return
 
 	proc/try_consume(mob/user as mob, atom/used_atom, amount)
-		if(amount>0)
-			// STACKS
-			if(istype(used_atom,/obj/item/stack))
-				var/obj/item/stack/stack=used_atom
-				if(stack.amount < amount)
-					to_chat(user, "\red You don't have enough [stack]! You need at least [amount].")
-					return 0
-				stack.use(amount)
+		if(amount > 0)
 			// CABLES
 			if(istype(used_atom,/obj/item/stack/cable_coil))
 				var/obj/item/stack/cable_coil/coil=used_atom
-				if(coil.amount < amount)
-					to_chat(user, "\red You don't have enough cable! You need at least [amount] coils.")
+				if(!coil.use(amount))
+					to_chat(user, "<span class='warning'>You don't have enough cable! You need at least [amount] coils.</span>")
 					return 0
-				coil.use(amount)
 			// WELDER
 			if(istype(used_atom,/obj/item/weapon/weldingtool))
 				var/obj/item/weapon/weldingtool/welder=used_atom
 				if(!welder.isOn())
-					to_chat(user, "\blue You tap the [src] with your unlit welder.  [pick("Ding","Dong")].")
+					to_chat(user, "<span class='notice'>You tap the [src] with your unlit welder. [pick("Ding","Dong")].</span>")
 					return 0
 				if(!welder.remove_fuel(amount,user))
-					to_chat(user, "\red You don't have enough fuel!")
+					to_chat(user, "<span class='warning'>You don't have enough fuel!</span>")
 					return 0
+			// STACKS
+			if(istype(used_atom,/obj/item/stack))
+				var/obj/item/stack/stack=used_atom
+				if(stack.amount < amount)
+					to_chat(user, "<span class='warning'>You don't have enough [stack]! You need at least [amount].</span>")
+					return 0
+				stack.use(amount)
 		return 1
 
 /datum/construction/reversible

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -287,7 +287,7 @@
 
 /obj/item/weapon/circuitboard/supplycomp/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(istype(I,/obj/item/device/multitool))
-		var/catastasis = src.contraband_enabled
+		var/catastasis = contraband_enabled
 		var/opposite_catastasis
 		if(catastasis)
 			opposite_catastasis = "STANDARD"
@@ -297,9 +297,9 @@
 			catastasis = "STANDARD"
 
 		switch( alert("Current receiver spectrum is set to: [catastasis]","Multitool-Circuitboard interface","Switch to [opposite_catastasis]","Cancel") )
-		//switch( alert("Current receiver spectrum is set to: " {(src.contraband_enabled) ? ("BROAD") : ("STANDARD")} , "Multitool-Circuitboard interface" , "Switch to " {(src.contraband_enabled) ? ("STANDARD") : ("BROAD")}, "Cancel") )
+		//switch( alert("Current receiver spectrum is set to: " {(contraband_enabled) ? ("BROAD") : ("STANDARD")} , "Multitool-Circuitboard interface" , "Switch to " {(contraband_enabled) ? ("STANDARD") : ("BROAD")}, "Cancel") )
 			if("Switch to STANDARD","Switch to BROAD")
-				src.contraband_enabled = !src.contraband_enabled
+				contraband_enabled = !contraband_enabled
 
 			if("Cancel")
 				return
@@ -345,97 +345,110 @@
 	switch(state)
 		if(0)
 			if(istype(P, /obj/item/weapon/wrench))
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 				if(do_after(user, 20, target = src))
-					to_chat(user, "\blue You wrench the frame into place.")
-					src.anchored = 1
-					src.state = 1
+					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
+					anchored = 1
+					state = 1
 			if(istype(P, /obj/item/weapon/weldingtool))
 				var/obj/item/weapon/weldingtool/WT = P
 				if(!WT.remove_fuel(0, user))
-					to_chat(user, "The welding tool must be on to complete this task.")
+					to_chat(user, "<span class='warning'>The welding tool must be on to complete this task.</span>")
 					return
-				playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+				playsound(loc, 'sound/items/Welder.ogg', 50, 1)
 				if(do_after(user, 20, target = src))
 					if(!src || !WT.isOn()) return
-					to_chat(user, "\blue You deconstruct the frame.")
-					new /obj/item/stack/sheet/metal( src.loc, 5 )
+					to_chat(user, "<span class='notice'>You deconstruct the frame.</span>")
+					new /obj/item/stack/sheet/metal(loc, 5)
 					qdel(src)
 		if(1)
 			if(istype(P, /obj/item/weapon/wrench))
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 				if(do_after(user, 20, target = src))
-					to_chat(user, "\blue You unfasten the frame.")
-					src.anchored = 0
-					src.state = 0
+					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
+					anchored = 0
+					state = 0
 			if(istype(P, /obj/item/weapon/circuitboard) && !circuit)
 				var/obj/item/weapon/circuitboard/B = P
 				if(B.board_type == "computer")
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-					to_chat(user, "\blue You place the circuit board inside the frame.")
-					src.icon_state = "1"
-					src.circuit = P
+					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>You place the circuit board inside the frame.</span>")
+					icon_state = "1"
+					circuit = P
 					user.drop_item()
 					P.loc = src
 				else
-					to_chat(user, "\red This frame does not accept circuit boards of this type!")
+					to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 			if(istype(P, /obj/item/weapon/screwdriver) && circuit)
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "\blue You screw the circuit board into place.")
-				src.state = 2
-				src.icon_state = "2"
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
+				state = 2
+				icon_state = "2"
 			if(istype(P, /obj/item/weapon/crowbar) && circuit)
-				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, "\blue You remove the circuit board.")
-				src.state = 1
-				src.icon_state = "0"
-				circuit.loc = src.loc
-				src.circuit = null
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You remove the circuit board.</span>")
+				state = 1
+				icon_state = "0"
+				circuit.loc = loc
+				circuit = null
 		if(2)
 			if(istype(P, /obj/item/weapon/screwdriver) && circuit)
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "\blue You unfasten the circuit board.")
-				src.state = 1
-				src.icon_state = "1"
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
+				state = 1
+				icon_state = "1"
 			if(istype(P, /obj/item/stack/cable_coil))
-				if(P:amount >= 5)
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+				var/obj/item/stack/cable_coil/C = P
+				if(C.amount >= 5)
+					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>You start to add cables to the frame.</span>")
 					if(do_after(user, 20, target = src))
-						if(P)
-							P:amount -= 5
-							if(!P:amount) qdel(P)
-							to_chat(user, "\blue You add cables to the frame.")
-							src.state = 3
-							src.icon_state = "3"
+						if(state == 2 && C.amount >= 5 && C.use(5))
+							to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
+							state = 3
+							icon_state = "3"
+						else
+							to_chat(user, "<span class='warning'>At some point during construction you lost some cable. Make sure you have five lengths before trying again.</span>")
+							return
+				else
+					to_chat(user, "<span class='warning'>You need five lengths of cable to wire the frame.</span>")
+					return
 		if(3)
 			if(istype(P, /obj/item/weapon/wirecutters))
-				playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
-				to_chat(user, "\blue You remove the cables.")
-				src.state = 2
-				src.icon_state = "2"
-				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( src.loc )
+				playsound(loc, 'sound/items/Wirecutter.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You remove the cables.</span>")
+				state = 2
+				icon_state = "2"
+				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
 				A.amount = 5
 
 			if(istype(P, /obj/item/stack/sheet/glass))
-				if(P:amount >= 2)
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+				var/obj/item/stack/sheet/glass/G = P
+				if(G.amount >= 2)
+					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>You start to add the glass panel to the frame.</span>")
 					if(do_after(user, 20, target = src))
-						if(P)
-							P:use(2)
-							to_chat(user, "\blue You put in the glass panel.")
-							src.state = 4
-							src.icon_state = "4"
+						if(state == 3 && G.amount >= 2 && G.use(2))
+							to_chat(user, "<span class='notice'>You put in the glass panel.</span>")
+							state = 4
+							icon_state = "4"
+						else
+							to_chat(user, "<span class='warning'>At some point during construction you lost some glass. Make sure you have two sheets before trying again.</span>")
+							return
+				else
+					to_chat(user, "<span class='warning'>You need two sheets of glass for this.</span>")
+					return
 		if(4)
 			if(istype(P, /obj/item/weapon/crowbar))
-				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, "\blue You remove the glass panel.")
-				src.state = 3
-				src.icon_state = "3"
-				new /obj/item/stack/sheet/glass( src.loc, 2 )
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
+				state = 3
+				icon_state = "3"
+				new /obj/item/stack/sheet/glass(loc, 2)
 			if(istype(P, /obj/item/weapon/screwdriver))
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "\blue You connect the monitor.")
-				var/B = new src.circuit.build_path ( src.loc )
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
+				var/B = new circuit.build_path (loc)
 				if(circuit.powernet) B:powernet = circuit.powernet
 				if(circuit.id) B:id = circuit.id
 				if(circuit.records) B:records = circuit.records
@@ -456,97 +469,110 @@
 	switch(state)
 		if(0)
 			if(istype(P, /obj/item/weapon/wrench))
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 				if(do_after(user, 20, target = src))
-					to_chat(user, "\blue You wrench the frame into place.")
-					src.anchored = 1
-					src.state = 1
+					to_chat(user, "<span class='notice'>You wrench the frame into place.</span>")
+					anchored = 1
+					state = 1
 			if(istype(P, /obj/item/weapon/weldingtool))
 				var/obj/item/weapon/weldingtool/WT = P
 				if(!WT.remove_fuel(0, user))
-					to_chat(user, "The welding tool must be on to complete this task.")
+					to_chat(user, "<span class='warning'>The welding tool must be on to complete this task.</span>")
 					return
-				playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
+				playsound(loc, 'sound/items/Welder.ogg', 50, 1)
 				if(do_after(user, 20, target = src))
 					if(!src || !WT.isOn()) return
-					to_chat(user, "\blue You deconstruct the frame.")
-					new /obj/item/stack/sheet/mineral/bananium( src.loc, 5 )
+					to_chat(user, "<span class='notice'>You deconstruct the frame.</span>")
+					new /obj/item/stack/sheet/mineral/bananium(loc, 5)
 					qdel(src)
 		if(1)
 			if(istype(P, /obj/item/weapon/wrench))
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 				if(do_after(user, 20, target = src))
-					to_chat(user, "\blue You unfasten the frame.")
-					src.anchored = 0
-					src.state = 0
+					to_chat(user, "<span class='notice'>You unfasten the frame.</span>")
+					anchored = 0
+					state = 0
 			if(istype(P, /obj/item/weapon/circuitboard) && !circuit)
 				var/obj/item/weapon/circuitboard/B = P
 				if(B.board_type == "honkcomputer")
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-					to_chat(user, "\blue You place the circuit board inside the frame.")
-					src.icon_state = "1"
-					src.circuit = P
+					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>You place the circuit board inside the frame.</span>")
+					icon_state = "1"
+					circuit = P
 					user.drop_item()
 					P.loc = src
 				else
-					to_chat(user, "\red This frame does not accept circuit boards of this type!")
+					to_chat(user, "<span class='warning'>This frame does not accept circuit boards of this type!</span>")
 			if(istype(P, /obj/item/weapon/screwdriver) && circuit)
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "\blue You screw the circuit board into place.")
-				src.state = 2
-				src.icon_state = "2"
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You screw the circuit board into place.</span>")
+				state = 2
+				icon_state = "2"
 			if(istype(P, /obj/item/weapon/crowbar) && circuit)
-				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, "\blue You remove the circuit board.")
-				src.state = 1
-				src.icon_state = "0"
-				circuit.loc = src.loc
-				src.circuit = null
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You remove the circuit board.</span>")
+				state = 1
+				icon_state = "0"
+				circuit.loc = loc
+				circuit = null
 		if(2)
 			if(istype(P, /obj/item/weapon/screwdriver) && circuit)
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "\blue You unfasten the circuit board.")
-				src.state = 1
-				src.icon_state = "1"
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You unfasten the circuit board.</span>")
+				state = 1
+				icon_state = "1"
 			if(istype(P, /obj/item/stack/cable_coil))
-				if(P:amount >= 5)
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+				var/obj/item/stack/cable_coil/C = P
+				if(C.amount >= 5)
+					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>You start to add cables to the frame.</span>")
 					if(do_after(user, 20, target = src))
-						if(P)
-							P:amount -= 5
-							if(!P:amount) qdel(P)
-							to_chat(user, "\blue You add cables to the frame.")
-							src.state = 3
-							src.icon_state = "3"
+						if(state == 2 && C.amount >= 5 && C.use(5))
+							to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
+							state = 3
+							icon_state = "3"
+						else
+							to_chat(user, "<span class='warning'>At some point during construction you lost some cable. Make sure you have five lengths before trying again.</span>")
+							return
+				else
+					to_chat(user, "<span class='warning'>You need five lengths of cable to wire the frame.</span>")
+					return
 		if(3)
 			if(istype(P, /obj/item/weapon/wirecutters))
-				playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
-				to_chat(user, "\blue You remove the cables.")
-				src.state = 2
-				src.icon_state = "2"
-				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( src.loc )
+				playsound(loc, 'sound/items/Wirecutter.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You remove the cables.</span>")
+				state = 2
+				icon_state = "2"
+				var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
 				A.amount = 5
 
 			if(istype(P, /obj/item/stack/sheet/glass))
-				if(P:amount >= 2)
-					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
+				var/obj/item/stack/sheet/glass/G = P
+				if(G.amount >= 2)
+					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
+					to_chat(user, "<span class='notice'>You start to add the glass panel to the frame.</span>")
 					if(do_after(user, 20, target = src))
-						if(P)
-							P:use(2)
-							to_chat(user, "\blue You put in the glass panel.")
-							src.state = 4
-							src.icon_state = "4"
+						if(state == 3 && G.amount >= 2 && G.use(2))
+							to_chat(user, "<span class='notice'>You put in the glass panel.</span>")
+							state = 4
+							icon_state = "4"
+						else
+							to_chat(user, "<span class='warning'>At some point during construction you lost some glass. Make sure you have two sheets before trying again.</span>")
+							return
+				else
+					to_chat(user, "<span class='warning'>You need two sheets of glass for this.</span>")
+					return
 		if(4)
 			if(istype(P, /obj/item/weapon/crowbar))
-				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, "\blue You remove the glass panel.")
-				src.state = 3
-				src.icon_state = "3"
-				new /obj/item/stack/sheet/glass( src.loc, 2 )
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You remove the glass panel.</span>")
+				state = 3
+				icon_state = "3"
+				new /obj/item/stack/sheet/glass(loc, 2)
 			if(istype(P, /obj/item/weapon/screwdriver))
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, "\blue You connect the monitor.")
-				var/B = new src.circuit.build_path ( src.loc )
+				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
+				to_chat(user, "<span class='notice'>You connect the monitor.</span>")
+				var/B = new circuit.build_path (loc)
 				if(circuit.powernet) B:powernet = circuit.powernet
 				if(circuit.id) B:id = circuit.id
 				if(circuit.records) B:records = circuit.records

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -69,21 +69,23 @@
 					playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 					to_chat(user, "<span class='notice'>You start to add cables to the frame.</span>")
 					if(do_after(user, 20, target = src))
-						if(C.amount >= 5 && state == 1)
-							C.use(5)
+						if(state == 1 && C.amount >= 5 && C.use(5))
 							to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
 							state = 2
 							icon_state = "box_1"
+						else
+							to_chat(user, "<span class='warning'>At some point during construction you lost some cable. Make sure you have five lengths before trying again.</span>")
+							return
 				else
-					to_chat(user, "<span class='warning'>You need five length of cable to wire the frame.</span>")
+					to_chat(user, "<span class='warning'>You need five lengths of cable to wire the frame.</span>")
 					return
 			else if(istype(P, /obj/item/stack/sheet/glass))
 				var/obj/item/stack/sheet/glass/G = P
-				if(G.amount<5)
-					to_chat(user, "\red You do not have enough glass to build a display case.")
+				if(G.amount < 5)
+					to_chat(user, "<span class='warning'>You do not have enough glass to build a display case.</span>")
 					return
 				G.use(5)
-				to_chat(user, "\blue You add the glass to the frame.")
+				to_chat(user, "<span class='notice'>You add the glass to the frame.</span>")
 				playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
 				new /obj/structure/displaycase_frame(src.loc)
 				qdel(src)


### PR DESCRIPTION
Tested by deconstructing the 3 vendors in the bridge meeting room and reconstructing them with the amount of cable (15) - 2 (13). Ended up getting a message when the loading bar for the last vendor finished and upon examination I was left, correctly, with 3 cable pieces remaining (10 spent on the other 2 vendors). Same result with computers, tested with the ones on the right side of the bridge by the door.

While I was at it I removed unnecessary srcs and some old colour macros.

:cl:
fix: Adding cable to multiple computer frames at the same time while not having the correct amount of cables will no longer cause busted coils with a negative number of cables.
/:cl: