### PR TITLE
ERP Warning Fix

### DIFF
--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -145,7 +145,7 @@
 			if(!auth)
 				dat += "<br><hr><dd><span class='notice'>Please authenticate with the server in order to show additional options.</span>"
 			else
-				dat += "<br><hr><dd><span class='warning'>Reg, #514 forbids sending messages to a Head of Staff containing Erotic Rendering Properties.</span>"
+				dat += "<br><hr><dd><span class='warning'>Reg, #514 forbids sending messages containing Erotic Rendering Properties.</span>"
 
 		//Message Logs
 		if(1)

--- a/code/modules/computer3/computers/message.dm
+++ b/code/modules/computer3/computers/message.dm
@@ -104,7 +104,7 @@
 				if(!auth)
 					dat += "<br><hr><dd><span class='notice'>Please authenticate with the server in order to show additional options.</span>"
 				else
-					dat += "<br><hr><dd><span class='warning'>Reg, #514 forbids sending messages to a Head of Staff containing Erotic Rendering Properties.</span>"
+					dat += "<br><hr><dd><span class='warning'>Reg, #514 forbids sending messages containing Erotic Rendering Properties.</span>"
 
 			//Message Logs
 			if(1)


### PR DESCRIPTION
Currently, the warning message on the PDA console forbids "sending messages to a Head of Staff containing Erotic Rendering Properties".

That wording implies that while sending ERP PDA messages to a head of staff is forbidden, sending them to normal crew... isn't.

This PR simply deletes "to a Head of Staff" from the wording, so the warning reads as: "Reg, #514 forbids sending messages containing Erotic Rendering Properties." 

This is a very minor fix. 

🆑 Kyep
tweak: the anti-ERP warning message on PDA message consoles is now accurate.
/🆑