### PR TITLE
Fixes #5894, Spawnable DNA SE Injectors (i.e. ones found in the abandoned mining crates) Now Work

### DIFF
--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -72,6 +72,7 @@
 	spawn(0) //Some mutations have sleeps in them, like monkey
 		if(!(NOCLONE in M.mutations) && !(H && (H.species.flags & NO_DNA))) // prevents drained people from having their DNA changed
 			var/prev_ue = M.dna.unique_enzymes
+			var/mutflags = 0
 			// UI in syringe.
 			if(buf.types & DNA2_BUF_UI)
 				if(!block) //isolated block?
@@ -88,12 +89,13 @@
 					M.dna.SetUIValue(block,src.GetValue())
 					M.UpdateAppearance()
 			if(buf.types & DNA2_BUF_SE)
+				mutflags = MUTCHK_FORCED
 				if(!block) //isolated block?
 					M.dna.SE = buf.dna.SE.Copy()
 					M.dna.UpdateSE()
 				else
 					M.dna.SetSEValue(block,src.GetValue())
-				domutcheck(M, null, 0)
+				domutcheck(M, null, mutflags)
 				M.update_mutations()
 			if(H)
 				H.sync_organ_dna(assimilate = 0, old_ue = prev_ue)


### PR DESCRIPTION
The spawnable DNA Injectors containing powers (XRay, etc.) will now activate/deactivate the powers correctly. I used [this line here](https://github.com/ParadiseSS13/Paradise/blob/18f4aa18b98fcf8503f7173d3e294d581aa2acff/code/datums/spells/wizard.dm#L59) as inspiration.

Tested by spawning in the xraymut injector and injecting myself as a Human. It gave me X-Ray vision.
Tested by spawning in the antixray injector and injecting myself as a Human. It took away my X-Ray vision.

:cl:
fix: The DNA SE injectors one can find in the abandoned mining crates now correctly activate/deactivate the powers they may contain.
/:cl: