### PR TITLE
Fixes Disability/Shock Stuttering, Resolves #5899

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -411,7 +411,7 @@
 /mob/living/SetStuttering(amount, force = 0)
 	//From mob/living/apply_effect: "Stuttering is often associated with Stun"
 	if(status_flags & CANSTUN || force)
-		stuttering = max(stuttering, 0)
+		stuttering = max(amount, stuttering)
 
 /mob/living/AdjustStuttering(amount, bound_lower = 0, bound_upper = INFINITY, force = 0)
 	var/new_value = directional_bounded_sum(stuttering, amount, bound_lower, bound_upper)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -411,7 +411,7 @@
 /mob/living/SetStuttering(amount, force = 0)
 	//From mob/living/apply_effect: "Stuttering is often associated with Stun"
 	if(status_flags & CANSTUN || force)
-		stuttering = max(amount, stuttering)
+		stuttering = max(amount, 0)
 
 /mob/living/AdjustStuttering(amount, bound_lower = 0, bound_upper = INFINITY, force = 0)
 	var/new_value = directional_bounded_sum(stuttering, amount, bound_lower, bound_upper)


### PR DESCRIPTION
The 0 argument was busting this proc because it meant that the current value of stuttering would be the only one stuttering would ever get set to through SetStuttering. It didn't even use the 'amount' value.

This fixes it as per the way it used to be in [this line](https://github.com/ParadiseSS13/Paradise/commit/6a7f7394a807cd8a028d5bb2a1608927c8e4474f#diff-2de2df982739a4fbdb54a4b2715d6f92L114).

:cl:
fix: You now stutter when you're in shock/crit and when you've got the nervous disability as you used to.
/:cl:

Fixes #5899 