### PR TITLE
Tails/body accessories now render properly in ID card photos, 'HD' Char. Preview Icon

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -150,7 +150,10 @@ proc/get_id_photo(var/mob/living/carbon/human/H)
 	preview_icon.Blend(temp, ICON_OVERLAY)
 
 	//Tail
-	if(H.species.tail && H.species.flags & HAS_TAIL)
+	if(H.body_accessory && istype(H.body_accessory, /datum/body_accessory/tail))
+		temp = new/icon("icon" = H.body_accessory.icon, "icon_state" = H.body_accessory.icon_state)
+		preview_icon.Blend(temp, ICON_OVERLAY)
+	else if(H.species.tail && H.species.bodyflags & HAS_TAIL)
 		temp = new/icon("icon" = 'icons/effects/species.dmi', "icon_state" = "[H.species.tail]_s")
 		preview_icon.Blend(temp, ICON_OVERLAY)
 
@@ -173,6 +176,17 @@ proc/get_id_photo(var/mob/living/carbon/human/H)
 	if(H.species.bodyflags & HAS_SKIN_COLOR)
 		preview_icon.Blend(rgb(H.r_skin, H.g_skin, H.b_skin), ICON_ADD)
 
+	//Tail Markings
+	var/icon/t_marking_s
+	if(H.species.bodyflags & HAS_TAIL_MARKINGS)
+		var/tail_marking = H.m_styles["tail"]
+		var/datum/sprite_accessory/tail_marking_style = marking_styles_list[tail_marking]
+		if(tail_marking_style && tail_marking_style.species_allowed)
+			t_marking_s = new/icon("icon" = tail_marking_style.icon, "icon_state" = "[tail_marking_style.icon_state]_s")
+			t_marking_s.Blend(H.m_colours["tail"], ICON_ADD)
+			if(!(H.body_accessory && istype(H.body_accessory, /datum/body_accessory/body)))
+				preview_icon.Blend(t_marking_s, ICON_OVERLAY)
+
 	var/icon/face_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = "bald_s")
 	if(!(H.species.bodyflags & NO_EYES))
 		var/icon/eyes_s = new/icon("icon" = 'icons/mob/human_face.dmi', "icon_state" = H.species ? H.species.eyes : "eyes_s")
@@ -190,7 +204,7 @@ proc/get_id_photo(var/mob/living/carbon/human/H)
 		// I'll want to make a species-specific proc for this sooner or later
 		// But this'll do for now
 		if(head_organ.species.name == "Slime People")
-			hair_s.Blend(rgb(H.r_skin, H.g_skin, H.b_skin, 160), ICON_ADD)
+			hair_s.Blend(rgb(H.r_skin, H.g_skin, H.b_skin, 160), ICON_AND)
 		else
 			hair_s.Blend(rgb(head_organ.r_hair, head_organ.g_hair, head_organ.b_hair), ICON_ADD)
 
@@ -378,9 +392,22 @@ proc/get_id_photo(var/mob/living/carbon/human/H)
 		else
 			clothes_s = new /icon('icons/mob/uniform.dmi', "grey_s")
 			clothes_s.Blend(new /icon('icons/mob/feet.dmi', "black"), ICON_UNDERLAY)
+
 	preview_icon.Blend(face_s, ICON_OVERLAY) // Why do we do this twice
 	if(clothes_s)
 		preview_icon.Blend(clothes_s, ICON_OVERLAY)
+	//Bus body accessories that go over clothes.
+	if(H.body_accessory && istype(H.body_accessory, /datum/body_accessory/body))
+		temp = new/icon("icon" = H.body_accessory.icon, "icon_state" = H.body_accessory.icon_state)
+		if(H.body_accessory.pixel_x_offset)
+			temp.Shift(EAST, H.body_accessory.pixel_x_offset)
+		if(H.body_accessory.pixel_y_offset)
+			temp.Shift(NORTH, H.body_accessory.pixel_y_offset)
+		if(H.species.bodyflags & HAS_SKIN_COLOR)
+			temp.Blend(rgb(H.r_skin, H.g_skin, H.b_skin), H.body_accessory.blend_mode)
+		if(t_marking_s)
+			temp.Blend(t_marking_s, ICON_OVERLAY)
+		preview_icon.Blend(temp, ICON_OVERLAY)
 	qdel(face_s)
 	qdel(clothes_s)
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -249,7 +249,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 	switch(current_tab)
 		if(TAB_CHAR) // Character Settings
-			dat += "<div class='statusDisplay' style='max-width: 128px; position: absolute; left: 150px; top: 150px'><img src=previewicon.png height=64 width=64><img src=previewicon2.png height=64 width=64></div>"
+			dat += "<div class='statusDisplay' style='max-width: 128px; position: absolute; left: 150px; top: 150px'><img src=previewicon.png class='charPreview'><img src=previewicon2.png class='charPreview'></div>"
 			dat += "<table width='100%'><tr><td width='405px' height='25px' valign='top'>"
 			dat += "<b>Name: </b>"
 			dat += "<a href='?_src_=prefs;preference=name;task=input'><b>[real_name]</b></a>"

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -291,11 +291,20 @@
 	if(current_species && (current_species.bodyflags & HAS_TAIL))
 		var/tail_icon
 		var/tail_icon_state
+		var/tail_shift_x
+		var/tail_shift_y
+		var/blend_mode = ICON_ADD
 
 		if(body_accessory)
 			var/datum/body_accessory/accessory = body_accessory_by_name[body_accessory]
 			tail_icon = accessory.icon
 			tail_icon_state = accessory.icon_state
+			if(accessory.blend_mode)
+				blend_mode = accessory.blend_mode
+			if(accessory.pixel_x_offset)
+				tail_shift_x = accessory.pixel_x_offset
+			if(accessory.pixel_y_offset)
+				tail_shift_y = accessory.pixel_y_offset
 		else
 			tail_icon = "icons/effects/species.dmi"
 			if(coloured_tail)
@@ -303,10 +312,14 @@
 			else
 				tail_icon_state = "[current_species.tail]_s"
 
-		var/icon/temp = new /icon("icon" = tail_icon, "icon_state" = tail_icon_state)
+		var/icon/temp = new/icon("icon" = tail_icon, "icon_state" = tail_icon_state)
+		if(tail_shift_x)
+			temp.Shift(EAST, tail_shift_x)
+		if(tail_shift_y)
+			temp.Shift(NORTH, tail_shift_y)
 
 		if(current_species && (current_species.bodyflags & HAS_SKIN_COLOR))
-			temp.Blend(rgb(r_skin, g_skin, b_skin), ICON_ADD)
+			temp.Blend(rgb(r_skin, g_skin, b_skin), blend_mode)
 
 		if(current_species && (current_species.bodyflags & HAS_TAIL_MARKINGS))
 			var/tail_marking = m_styles["tail"]

--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -340,3 +340,9 @@ div.notice
 	width: 100%;
 	clear: both;
 }
+.charPreview
+{
+	-ms-interpolation-mode: nearest-neighbor;
+	width: 64px;
+	height:64px;
+}


### PR DESCRIPTION
:cl:
tweak: The character preview icon in character creation is now more detailed and less blurry.
fix: ID cards now show tails, body accessories and tail markings correctly.
/:cl:

Ports 11149 from VG (which is also a port from TG) which sharpens character preview images, giving them higher definition.

Fixes #5906 by properly rendering tails/tail markings/body accessories in ID cards.

Fixes an issue where the adminbus snake body accessory wasn't properly rendered/coloured in the character creation screen.

_A species with a tail being rendered correctly in ID card photo. Yeah I know the uniform looks odd on Armalis-- there isn't anything resembling species_fit in the ID card or character preview icon generation._
![armalisid](https://cloud.githubusercontent.com/assets/12377767/20636626/53bb8c4e-b33e-11e6-8c16-3e26cfdf494b.PNG)

_A species with a tail and tail markings being rendered correctly in ID card photo._
![tailwithmarkings on id](https://cloud.githubusercontent.com/assets/12377767/20636629/66622286-b33e-11e6-887e-419c6aecda34.PNG)

_A species with a tail-body accessory and tail markings being rendered correctly in ID card photo._
![bodyaccessorywithmarkings on id](https://cloud.githubusercontent.com/assets/12377767/20636633/7640a75e-b33e-11e6-9e91-8f09f46b07b9.PNG)

_A character with the adminbus body accessory being rendered correctly in ID card photo._
![adminbusbodyaccessory id](https://cloud.githubusercontent.com/assets/12377767/20636640/900d2400-b33e-11e6-816d-81453f61e831.PNG)

_Preview of the sharper character preview image._
![sharpidpicture](https://cloud.githubusercontent.com/assets/12377767/20636642/a0e8e8c2-b33e-11e6-8661-ae8893971f40.PNG)

_The adminbus body accessory is now rendered and coloured properly in character preview. I had to crank the colour up a bit because otherwise the snake body would've been pitch black and indiscernable against the black background._
![adminbusbodyaccessory working in charprev](https://cloud.githubusercontent.com/assets/12377767/20636655/d6cbbe2e-b33e-11e6-8850-8a2d5365b8e1.PNG)

