### PR TITLE
Spacepod and Some Runtime Fixes

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -629,7 +629,8 @@
 	spawn(600)
 		if(src)
 			stored_obj.loc = get_turf(src.loc)
-			to_chat(spawner, "<span class='danger'><B>Failure! Your trap on \the [stored_obj] didn't catch anyone this time.</B></span>")
+			if(spawner)
+				to_chat(spawner, "<span class='danger'><B>Failure! Your trap on \the [stored_obj] didn't catch anyone this time.</B></span>")
 			qdel(src)
 
 /obj/item/weapon/guardian_bomb/proc/detonate(var/mob/living/user)

--- a/code/game/objects/structures/crates_lockers/crittercrate.dm
+++ b/code/game/objects/structures/crates_lockers/crittercrate.dm
@@ -25,20 +25,11 @@
 		for(var/i = 1, i <= amount, i++)
 			new content_mob(loc)
 		already_opened = 1
-	..()
+	. = ..()
 
 /obj/structure/closet/critter/close()
 	..()
 	return 1
-
-/obj/structure/closet/critter/attack_hand(mob/user as mob)
-	src.add_fingerprint(user)
-
-	if(src.loc == user.loc)
-		to_chat(user, "<span class='notice'>It won't budge!</span>")
-		toggle()
-	else
-		toggle()
 
 /obj/structure/closet/critter/corgi
 	name = "corgi crate"

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -229,39 +229,15 @@
 	health = max(0, health - damage)
 	var/percentage = (health / initial(health)) * 100
 	occupant_sanity_check()
-	if(passengers | pilot && oldhealth > health && percentage <= 25 && percentage > 0)
-		var/sound/S = sound('sound/effects/engine_alert2.ogg')
-		S.wait = 0 //No queue
-		S.channel = 0 //Any channel
-		S.volume = 50
-		if(pilot)
-			pilot << S
-		if(passengers)
-			for(var/mob/M in passengers)
-				M << S
-	if(passengers | pilot && oldhealth > health && !health)
-		var/sound/S = sound('sound/effects/engine_alert1.ogg')
-		S.wait = 0
-		S.channel = 0
-		S.volume = 50
-		if(pilot)
-			pilot << S
-		if(passengers)
-			for(var/mob/M in passengers)
-				M << S
+	if(oldhealth > health && percentage <= 25 && percentage > 0)
+		play_sound_to_riders('sound/effects/engine_alert2.ogg')
+	else if(oldhealth > health)
+		play_sound_to_riders('sound/effects/engine_alert1.ogg')
 	if(!health)
 		spawn(0)
-			if(pilot)
-				to_chat(pilot, "<span class='userdanger'>Critical damage to the vessel detected, core explosion imminent!</span>")
-			if(passengers)
-				for(var/mob/M in passengers)
-					to_chat(M, "<span class='userdanger'>Critical damage to the vessel detected, core explosion imminent!</span>")
+			message_to_riders("<span class='userdanger'>Critical damage to the vessel detected, core explosion imminent!</span>")
 			for(var/i = 10, i >= 0; --i)
-				if(pilot)
-					to_chat(pilot, "<span class='warning'>[i]</span>")
-				if(passengers)
-					for(var/mob/M in passengers)
-						to_chat(M, "<span class='warning'>[i]</span>")
+				message_to_riders("<span class='warning'>[i]</span>")
 				if(i == 0)
 					explosion(loc, 2, 4, 8)
 					qdel(src)
@@ -307,17 +283,25 @@
 
 	switch(severity)
 		if(1)
-			if(pilot)
-				to_chat(pilot, "<span class='warning'>The pod console flashes 'Heavy EMP WAVE DETECTED'.</span>")
-			if(passengers)
-				for(var/mob/M in passengers)
-					to_chat(M, "<span class='warning'>The pod console flashes 'Heavy EMP WAVE DETECTED'.</span>")
+			message_to_riders("<span class='warning'>The pod console flashes 'Heavy EMP WAVE DETECTED'.</span>")
 		if(2)
-			if(pilot)
-				to_chat(pilot, "<span class='warning'>The pod console flashes 'EMP WAVE DETECTED'.</span>")
-			if(passengers)
-				for(var/mob/M in passengers)
-					to_chat(M, "<span class='warning'>The pod console flashes 'EMP WAVE DETECTED'.</span>")
+			message_to_riders("<span class='warning'>The pod console flashes 'EMP WAVE DETECTED'.</span>")
+
+/obj/spacepod/proc/play_sound_to_riders(mysound)
+	if(length(passengers | pilot) == 0)
+		return
+	var/sound/S = sound(mysound)
+	S.wait = 0 //No queue
+	S.channel = 0 //Any channel
+	S.volume = 50
+	for(var/mob/M in passengers | pilot)
+		M << S
+
+/obj/spacepod/proc/message_to_riders(mymessage)
+	if(length(passengers | pilot) == 0)
+		return
+	for(var/mob/M in passengers | pilot)
+		to_chat(M, mymessage)
 
 /obj/spacepod/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(user.a_intent == I_HARM)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -231,7 +231,7 @@
 	occupant_sanity_check()
 	if(oldhealth > health && percentage <= 25 && percentage > 0)
 		play_sound_to_riders('sound/effects/engine_alert2.ogg')
-	else if(oldhealth > health)
+	if(oldhealth > health && !health)
 		play_sound_to_riders('sound/effects/engine_alert1.ogg')
 	if(!health)
 		spawn(0)


### PR DESCRIPTION
Fixes sending pod pilots to the void when the pod explodes/is destroyed, as well as giving them damage warnings, just like passengers get. Also fixes it so if a guardian traps something, then dies, doesn't runtime. Lastly, fixes it so there isn't a randomly runtime from opening a critter crate, as well as cleaning up a little snowflake code, thanks to Crazylemon.

Changes sound playing and message displaying to procs:

play_sound_to_riders(mysound)
message_to_riders(mymessage)

This clears a little bit of the duplicate code, making it a little more compressed, and also allows playing sounds directly to people in pods and messages. (Perhaps after the feature freeze, we can give pods music radios? Just a crazy idea.)

Fixes the underlying issue of #5909 where the destroyed pod deletes the pilot of the pod.

:cl:Twinmold
Fix: Pilots of spacepods will no longer be sent to the void when the space pod is destroyed in any method.
Fix: Pilots of spacepods will now get the same warnings for damage/core destruction that passengers get.
/:cl: