### PR TITLE
Fixes Faint and Mickey Finn

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -378,7 +378,7 @@
 			message = "<B>[src]</B> faints."
 			if(src.sleeping)
 				return //Can't faint while asleep
-			AdjustSleeping(1)
+			AdjustSleeping(2)
 			m_type = 1
 
 		if("cough", "coughs")

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -326,9 +326,9 @@
 /datum/reagent/beer2/on_mob_life(mob/living/M)
 	switch(current_cycle)
 		if(1 to 50)
-			M.AdjustSleeping(1)
+			M.Sleeping(2)
 		if(51 to INFINITY)
-			M.AdjustSleeping(1)
+			M.Sleeping(2)
 			M.adjustToxLoss((current_cycle - 50)*REAGENTS_EFFECT_MULTIPLIER)
 	..()
 


### PR DESCRIPTION
The instant-update status proc thing broke a few things...particularly related to sleeping.

This fixes the faint emote and Mickey Finn's Special Brew so they actually knock you out properly instead of just making you flop up and down repeatedly.

🆑 Fox McCloud
fix: Fixes faint emote doing nothing
fix: Fixes Mickey Finn's Special Brew not functioning properly/not making you fall asleep
/:cl: