### PR TITLE
The RCD no longer works as a remote permissions control

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -207,9 +207,9 @@ RCD
 						var/obj/machinery/door/airlock/T = new door_type(A)
 						T.autoclose = 1
 						if(one_access)
-							T.req_one_access = door_accesses
+							T.req_one_access = door_accesses.Copy()
 						else
-							T.req_access = door_accesses
+							T.req_access = door_accesses.Copy()
 						return 1
 					return 0
 				return 0


### PR DESCRIPTION
A shallow copy on the RCD led to doors made with the same RCD having the same permissions at all times - meaning, making command airlocks, then later making medical airlocks, would have them all set to medical permissions.

:cl:Crazylemon
fix: The RCD no longer shall work as a remote permissions control
/:cl: