### PR TITLE
Removes vulpkanin

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -141,54 +141,11 @@
 /datum/species/tajaran/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
-/datum/species/vulpkanin
+/datum/species/human/vulpkanin
 	name = "Vulpkanin"
 	name_plural = "Vulpkanin"
-	icobase = 'icons/mob/human_races/r_vulpkanin.dmi'
-	deform = 'icons/mob/human_races/r_vulpkanin.dmi'
-	path = /mob/living/carbon/human/vulpkanin
-	default_language = "Galactic Common"
-	language = "Canilunzt"
-	primitive_form = "Wolpin"
-	tail = "vulptail"
-	unarmed_type = /datum/unarmed_attack/claws
-	darksight = 8
-
-	blurb = "Vulpkanin are a species of sharp-witted canine-pideds residing on the planet Altam just barely within the \
-	dual-star Vazzend system. Their politically de-centralized society and independent natures have led them to become a species and \
-	culture both feared and respected for their scientific breakthroughs. Discovery, loyalty, and utilitarianism dominates their lifestyles \
-	to the degree it can cause conflict with more rigorous and strict authorities. They speak a guttural language known as 'Canilunzt' \
-    which has a heavy emphasis on utilizing tail positioning and ear twitches to communicate intent."
-
-	flags = HAS_LIPS
-	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
-	bodyflags = FEET_PADDED | HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR | HAS_FUR
-	dietflags = DIET_OMNI
-	reagent_tag = PROCESS_ORG
-	flesh_color = "#966464"
-	base_color = "#CF4D2F"
-	butt_sprite = "vulp"
-
-	has_organ = list(
-		"heart" =    /obj/item/organ/internal/heart,
-		"lungs" =    /obj/item/organ/internal/lungs,
-		"liver" =    /obj/item/organ/internal/liver/vulpkanin,
-		"kidneys" =  /obj/item/organ/internal/kidneys,
-		"brain" =    /obj/item/organ/internal/brain,
-		"appendix" = /obj/item/organ/internal/appendix,
-		"eyes" =     /obj/item/organ/internal/eyes,
-		)
-
-	allowed_consumed_mobs = list(/mob/living/simple_animal/mouse, /mob/living/simple_animal/lizard, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
-								 /mob/living/simple_animal/crab, /mob/living/simple_animal/butterfly, /mob/living/simple_animal/parrot, /mob/living/simple_animal/tribble)
-
-	suicide_messages = list(
-		"is attempting to bite their tongue off!",
-		"is jamming their claws into their eye sockets!",
-		"is twisting their own neck!",
-		"is holding their breath!")
-
-/datum/species/vulpkanin/handle_death(var/mob/living/carbon/human/H)
+	
+/datum/species/human/vulpkanin/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
 /datum/species/skrell


### PR DESCRIPTION
:cl: monster860
del: Removes vulpkanin
/:cl:

Okay, whatever, it just makes it a subtype of human and removes everything that makes it vulpkanin. This isn't a new feature, and it will improve the quality of life for many players. Also, Crazylemon is a diety.

So here's my take on Vulp (And tajara!): Let's look at human evolution. Humans lost all their hair somewhere along the line, because when you chase down prey over long distances, you tend to get a bit tired. Now dogbeast are covered in fur. Now I want you to think what would happen if a vulpkanin tried to run down prey. It wouldn't be very successful, wouldn't it.

Now I know you can make the argument that vulp could have come from a cold climate. But in that case, they should look more like this:

![image](https://cloud.githubusercontent.com/assets/3681297/20863573/1a4d834e-b99d-11e6-8c35-f3452d3cf718.png)

Notice anything? He's wearing a coldsuit. A suit, to keep him cold. Because otherwise he would overheat on normal station temperature.
