### PR TITLE
Fixes an Issue with Cloned Vampires Losing Powers

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -242,6 +242,10 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		owner.mind.spell_list.Remove(ability)
 		qdel(ability)
 
+/datum/vampire/proc/update_owner(var/mob/living/carbon/human/current) //Called when a vampire gets cloned. This updates vampire.owner to the new body.
+	if(current.mind && current.mind.vampire && current.mind.vampire.owner && (current.mind.vampire.owner != current))
+		current.mind.vampire.owner = current
+
 /mob/proc/make_vampire()
 	if(!mind)
 		return
@@ -325,8 +329,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			else if(istype(p, /datum/vampire_passive))
 				var/datum/vampire_passive/power = p
 				to_chat(owner, "<span class='notice'>[power.gain_desc]</span>")
-				
-	
+
 /datum/game_mode/proc/remove_vampire(datum/mind/vampire_mind)
 	if(vampire_mind in vampires)
 		ticker.mode.vampires -= vampire_mind
@@ -335,12 +338,12 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		if(vampire_mind.vampire)
 			vampire_mind.vampire.remove_vampire_powers()
 			qdel(vampire_mind.vampire)
-			vampire_mind.vampire = null	
+			vampire_mind.vampire = null
 		if(issilicon(vampire_mind.current))
 			to_chat(vampire_mind.current, "<span class='userdanger'>You have been turned into a robot! You can feel your powers fading away...</span>")
 		else
 			to_chat(vampire_mind.current, "<span class='userdanger'>You have been brainwashed! You are no longer a vampire.</span>")
-		ticker.mode.update_vampire_icons_removed(vampire_mind)	
+		ticker.mode.update_vampire_icons_removed(vampire_mind)
 
 //prepare for copypaste
 /datum/game_mode/proc/update_vampire_icons_added(datum/mind/vampire_mind)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -247,6 +247,7 @@
 	if(grab_ghost_when == CLONER_FRESH_CLONE)
 		clonemind.transfer_to(H)
 		H.ckey = R.ckey
+		update_clone_antag(H) //Since the body's got the mind, update their antag stuff right now. Otherwise, wait until they get kicked out (as per the CLONER_MATURE_CLONE business) to do it.
 		to_chat(H, {"<span class='notice'><b>Consciousness slowly creeps over you
 			as your body regenerates.</b><br><i>So this is what cloning
 			feels like?</i></span>"})
@@ -254,26 +255,6 @@
 		to_chat(clonemind.current, {"<span class='notice'>Your body is
 			beginning to regenerate in a cloning pod. You will
 			become conscious when it is complete.</span>"})
-
-	// -- Mode/mind specific stuff goes here
-	callHook("clone", list(H))
-
-	if((H.mind in ticker.mode:revolutionaries) || (H.mind in ticker.mode:head_revolutionaries))
-		ticker.mode.update_rev_icons_added() //So the icon actually appears
-	if(H.mind in ticker.mode.syndicates)
-		ticker.mode.update_synd_icons_added()
-	if(H.mind in ticker.mode.cult)
-		ticker.mode.add_cult_viewpoint(H)
-		ticker.mode.add_cultist(occupant.mind)
-		ticker.mode.update_cult_icons_added() //So the icon actually appears
-	if(("\ref[H.mind]" in ticker.mode.implanter) || (H.mind in ticker.mode.implanted))
-		ticker.mode.update_traitor_icons_added(H.mind) //So the icon actually appears
-	if(("\ref[H.mind]" in ticker.mode.vampire_thralls) || (H.mind in ticker.mode.vampire_enthralled))
-		ticker.mode.update_vampire_icons_added(H.mind)
- 	if(("\ref[H.mind]" in ticker.mode.shadowling_thralls) || (H.mind in ticker.mode.shadows))
- 		ticker.mode.update_shadow_icons_added(H.mind)
-
-	// -- End mode specific stuff
 
 	if(!R.dna)
 		H.dna = new /datum/dna()
@@ -420,6 +401,28 @@
 	locked = 0
 	go_out()
 
+/obj/machinery/clonepod/proc/update_clone_antag(var/mob/living/carbon/human/H)
+	// Check to see if the clone's mind is an antagonist of any kind and handle them accordingly to make sure they get their spells, HUD/whatever else back.
+	callHook("clone", list(H))
+	if((H.mind in ticker.mode:revolutionaries) || (H.mind in ticker.mode:head_revolutionaries))
+		ticker.mode.update_rev_icons_added() //So the icon actually appears
+	if(H.mind in ticker.mode.syndicates)
+		ticker.mode.update_synd_icons_added()
+	if(H.mind in ticker.mode.cult)
+		ticker.mode.add_cult_viewpoint(H)
+		ticker.mode.add_cultist(occupant.mind)
+		ticker.mode.update_cult_icons_added() //So the icon actually appears
+	if((H.mind in ticker.mode.implanter) || (H.mind in ticker.mode.implanted))
+		ticker.mode.update_traitor_icons_added(H.mind) //So the icon actually appears
+	if(H.mind.vampire)
+		H.mind.vampire.update_owner(H)
+	if((H.mind in ticker.mode.vampire_thralls) || (H.mind in ticker.mode.vampire_enthralled))
+		ticker.mode.update_vampire_icons_added(H.mind)
+	if(H.mind in ticker.mode.changelings)
+		ticker.mode.update_change_icons_added(H.mind)
+ 	if((H.mind in ticker.mode.shadowling_thralls) || (H.mind in ticker.mode.shadows))
+ 		ticker.mode.update_shadow_icons_added(H.mind)
+
 //Put messages in the connected computer's temp var for display.
 /obj/machinery/clonepod/proc/connected_message(message)
 	if((isnull(connected)) || (!istype(connected, /obj/machinery/computer/cloning)))
@@ -461,6 +464,7 @@
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
 		clonemind.transfer_to(occupant)
 		occupant.grab_ghost()
+		update_clone_antag(occupant)
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br>\
 			<i>You feel like a new being.</i></span>")
 		occupant.flash_eyes(visual = 1)


### PR DESCRIPTION
Alright, so the root of the issue was how the vampire gamemode tracks the owner of vampire stuff. This can be seen in [this line](https://github.com/ParadiseSS13/Paradise/blob/ce04590e25547aa54290b5ca1e89e63a6eefdd90/code/game/gamemodes/vampire/vampire.dm#L197) that it tracks a body much like the mind datum does. However, before my fix, this 'owner' fell out of date when a vampire got cloned. While the vampire would get cloned, this owner variable would still refer to their old body, and so stuff would break.

Now, it gets updated with the current body when the vampire gets cloned, thus resolving the issue.

Fixes #5939, tested by upgrading the cloning machinery to the max, turning on auto-cloning, turning myself into a vampire, draining a person entirely of blood, hopping into the cloning pod to get scanned and killing myself. When I popped out of the pod in a new body, I still had my vampire powers and the ability to use them/drain blood from people/burn in the chapel as usual.

:cl:
fix: Resolves an issue where cloned vampires could no longer drain blood, burn in the chapel or use their powers properly.
/:cl: