### PR TITLE
Fix for medbay cryo never auto-ejecting patients with mech limbs

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -122,14 +122,7 @@
 	..()
 	if(autoeject)
 		if(occupant)
-			var/mech_damage = 0
-			if(istype(occupant, /mob/living/carbon/human))
-				var/mob/living/carbon/human/H = occupant
-				for(var/obj/item/organ/external/O in H.organs)
-					if(O.status & ORGAN_ROBOT)
-						mech_damage += O.brute_dam
-						mech_damage += O.burn_dam
-			if(occupant.health >= (100 - mech_damage))
+			if(!occupant.has_organic_damage())
 				on = 0
 				go_out()
 				playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -122,7 +122,14 @@
 	..()
 	if(autoeject)
 		if(occupant)
-			if(occupant.health >= 100)
+			var/mech_damage = 0
+			if(istype(occupant, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = occupant
+				for(var/obj/item/organ/external/O in H.organs)
+					if(O.status & ORGAN_ROBOT)
+						mech_damage += O.brute_dam
+						mech_damage += O.burn_dam
+			if(occupant.health >= (100 - mech_damage))
 				on = 0
 				go_out()
 				playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -201,3 +201,12 @@ I use this to standardize shadowling dethrall code
 		return null
 	var/obj/item/organ/internal/O = get_int_organ(organ_name)
 	return O.parent_organ
+
+/mob/living/carbon/human/has_organic_damage()
+	var/odmg = 0
+	for(var/obj/item/organ/external/O in organs)
+		if(O.status & ORGAN_ROBOT)
+			odmg += O.brute_dam
+			odmg += O.burn_dam
+	return (health < (100 - odmg))
+

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -287,6 +287,10 @@
 	adjustFireLoss(burn)
 	src.updatehealth()
 
+/mob/living/proc/has_organic_damage()
+	return (maxHealth - health)
+
+
 /mob/living/proc/restore_all_organs()
 	return
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -368,6 +368,9 @@
 	if(declare_crit && C.health <= 0) //Critical condition! Call for help!
 		declare(C)
 
+	if(!C.has_organic_damage())
+		return 0
+
 	//If they're injured, we're using a beaker, and don't have one of our WONDERCHEMS.
 	if((reagent_glass) && (use_beaker) && ((C.getBruteLoss() >= heal_threshold) || (C.getToxLoss() >= heal_threshold) || (C.getToxLoss() >= heal_threshold) || (C.getOxyLoss() >= (heal_threshold + 15))))
 		for(var/datum/reagent/R in reagent_glass.reagents.reagent_list)


### PR DESCRIPTION
Fixes an issue where people with damaged mechanical limbs will never be auto-ejected from cryopods.

With this fix, they will be ejected after their organic parts have been healed fully, even if they still have (unrepairable by cryo) damage to their mech limbs.

🆑
fix: Ensures cryo pods will properly auto-eject people whose organic parts (limbs) have been healed, but who still have damaged mechanical limbs.
/🆑