### PR TITLE
Fixes a bug with Changeling Regenerative Stasis

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -5,10 +5,6 @@
 
 //Revive from regenerative stasis
 /obj/effect/proc_holder/changeling/revive/sting_action(var/mob/living/carbon/user)
-	if(user.stat == DEAD)
-		dead_mob_list -= user
-		living_mob_list |= user
-
 	user.setToxLoss(0)
 	user.setOxyLoss(0)
 	user.setCloneLoss(0)
@@ -64,14 +60,12 @@
 			IO.trace_chemicals = list()
 		H.updatehealth()
 
-	user.stat = CONSCIOUS
-
 	to_chat(user, "<span class='notice'>We have regenerated.</span>")
 
 	user.regenerate_icons()
 
 	user.status_flags &= ~(FAKEDEATH)
-	user.update_canmove()
+	user.update_revive() //Handle waking up the changeling after the regenerative stasis has completed.
 	user.mind.changeling.purchasedpowers -= src
 	user.med_hud_set_status()
 	user.med_hud_set_health()

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -8,7 +8,7 @@
 	if(user.stat == DEAD)
 		dead_mob_list -= user
 		living_mob_list |= user
-	user.stat = CONSCIOUS
+
 	user.setToxLoss(0)
 	user.setOxyLoss(0)
 	user.setCloneLoss(0)
@@ -63,6 +63,9 @@
 			IO.damage = 0
 			IO.trace_chemicals = list()
 		H.updatehealth()
+
+	user.stat = CONSCIOUS
+
 	to_chat(user, "<span class='notice'>We have regenerated.</span>")
 
 	user.regenerate_icons()


### PR DESCRIPTION
Changelings who initiated the stasis while they were alive and were 'killed' during the waiting period for regenerative readiness will now regenerate properly.

This fixes #5935. I verified the bug by turning myself into a changeling and initiating the regenerative stasis, then using varedit to kill myself with brute damage in 50-point increments (200 damage meant I was dead). When time came to regenerate, I clicked it and it healed all my damage but I was still dead. That is what told me that it had to be an issue with where my mob's 'STAT' var was being set as, due to it being set to 'CONSCIOUS' BEFORE I was healed of all damage meant that it instantly got set back to 'DEAD', regardless of the healing procs called afterward due to the amount of damage still present at the time of the change..

I just moved the STAT change to the end as it is in the regular rejuvenation/revival procs and it solved this issue. I tested it in the same manner, and I sprung back to life with no issues whatsoever.

:cl:
fix: Resolves an issue with changeling regenerative stasis where changelings who initiated it while alive and died during the waiting period did not come back to life. Now they will, as intended.
/:cl: