### PR TITLE
Fixes #3628 - Disablers no longer blow up mechs

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -565,6 +565,8 @@
 
 	if(prob(deflect_chance * deflection) && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		visible_message("<span class='danger'>[src]'s armour deflects [Proj]!</span>")
+	else if (Proj.damage_type == STAMINA)
+		visible_message("<span class='danger'>[src]'s armour is undamaged by [Proj]!</span>")
 	else
 		visible_message("<span class='danger'>[src] is hit by [Proj].</span>")
 		take_damage(Proj.damage * dam_coeff, Proj.flag)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -563,10 +563,10 @@
 			dam_coeff = B.damage_coeff
 			break
 
-	if(prob(deflect_chance * deflection) && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))
-		visible_message("<span class='danger'>[src]'s armour deflects [Proj]!</span>")
-	else if (Proj.damage_type == STAMINA)
+	if(Proj.damage_type != BRUTE && Proj.damage_type != BURN)
 		visible_message("<span class='danger'>[src]'s armour is undamaged by [Proj]!</span>")
+	else if(prob(deflect_chance * deflection))
+		visible_message("<span class='danger'>[src]'s armour deflects [Proj]!</span>")
 	else
 		visible_message("<span class='danger'>[src] is hit by [Proj].</span>")
 		take_damage(Proj.damage * dam_coeff, Proj.flag)


### PR DESCRIPTION
Issue #3628 states that disabler shots can blow up pods and mechs.
After testing, I found that space pods don't take damage from disablers... but mechs do. Mechs also have a message saying they were 'hit' by tasers, even though it obviously does nothing.

This PR fixes #3628 by:
- Making mechs no longer take any damage from disabler shots
- Making taser/disabler shots against mechs now produce the message that the mech's "armour is undamaged" on impact. 

🆑
fix: Disabler shots no longer damage mechs.
fix: On impact, both taser and disabler shots now produce a message saying that the mech is undamaged by them, instead of a message saying they 'hit'.
/🆑