### PR TITLE
Fix AI crew monitor tracking and door electrification

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -481,7 +481,8 @@ About the new airlock wires panel:
 			shockedby += text("\[[time_stamp()]\] - EMP)")
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
 		electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
-		electrified_timer = addtimer(src, "electrify", SecondsToTicks(duration), 1, 0)
+		if(duration != -1)
+			electrified_timer = addtimer(src, "electrify", SecondsToTicks(duration), 1, 0)
 
 	if(feedback && message)
 		to_chat(usr, message)

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -10,7 +10,7 @@ Used In File(s): \code\game\machinery\computer\crew.dm
 		{{else value.sensor_type == 2}}
 			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss_light">{{:value.oxy}}</span>/<span class="toxin_light">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
 		{{else value.sensor_type == 3}}
-			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss_light">{{:value.oxy}}</span>/<span class="toxin_light">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.reference})}}</td>{{/if}}</tr>
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss_light">{{:value.oxy}}</span>/<span class="toxin_light">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
 		{{/if}}
 	{{/for}}
 </tbody></table>


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/5956.
Fixes https://github.com/ParadiseSS13/Paradise/issues/5957.

🆑 Markolie
fix: The track button on the AI crew monitor now works.
fix: Permanent door electrification by alt-clicking a door as an AI or setting it manually now works again.
/🆑