### PR TITLE
False walls now block atmos

### DIFF
--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -25,6 +25,18 @@
 	/turf/simulated/wall/rust,
 	/turf/simulated/wall/r_wall/rust)
 	smooth = SMOOTH_TRUE
+	
+/obj/structure/falsewall/New(loc)
+	..()
+	air_update_turf(1)
+
+/obj/structure/falsewall/Destroy()
+	density = 0
+	air_update_turf(1)
+	return ..()
+
+/obj/structure/falsewall/CanAtmosPass(turf/T)
+	return !density
 
 /obj/structure/falsewall/attack_hand(mob/user)
 	if(opening)
@@ -47,6 +59,7 @@
 		sleep(4)
 		set_opacity(1)
 		update_icon()
+	air_update_turf(1)
 	opening = 0
 
 /obj/structure/falsewall/proc/do_the_flick()


### PR DESCRIPTION
🆑 Markolie
fix: False walls now block atmospherics, unless it's open.
/🆑

Ported from https://github.com/tgstation/tgstation/pull/18137.