### PR TITLE
ORM/Mining Vendor Unpowered Fixes

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -117,17 +117,18 @@
 		return
 	if(default_unfasten_wrench(user, W))
 		return
-	if(!powered())
-		return
 	if(istype(W,/obj/item/weapon/card/id))
-		var/obj/item/weapon/card/id/I = usr.get_active_hand()
-		if(istype(I) && !istype(inserted_id))
-			if(!user.drop_item())
-				return
-			I.loc = src
-			inserted_id = I
-			interact(user)
-		return
+		if(!powered())
+			return
+		else
+			var/obj/item/weapon/card/id/I = usr.get_active_hand()
+			if(istype(I) && !istype(inserted_id))
+				if(!user.drop_item())
+					return
+				I.loc = src
+				inserted_id = I
+				interact(user)
+			return
 	..()
 
 /obj/machinery/mineral/ore_redemption/proc/SmeltMineral(var/obj/item/weapon/ore/O)
@@ -439,20 +440,24 @@
 		if(istype(I, /obj/item/weapon/crowbar))
 			default_deconstruction_crowbar(I)
 		return 1
-	if(!powered())
-		return
 	if(istype(I, /obj/item/weapon/mining_voucher))
-		RedeemVoucher(I, user)
-		return
+		if(!powered())
+			return
+		else
+			RedeemVoucher(I, user)
+			return
 	if(istype(I,/obj/item/weapon/card/id))
-		var/obj/item/weapon/card/id/C = usr.get_active_hand()
-		if(istype(C) && !istype(inserted_id))
-			if(!usr.drop_item())
-				return
-			C.loc = src
-			inserted_id = C
-			interact(user)
-		return
+		if(!powered())
+			return
+		else
+			var/obj/item/weapon/card/id/C = usr.get_active_hand()
+			if(istype(C) && !istype(inserted_id))
+				if(!usr.drop_item())
+					return
+				C.loc = src
+				inserted_id = C
+				interact(user)
+			return
 	..()
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/weapon/mining_voucher/voucher, mob/redeemer)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -437,6 +437,8 @@
 	return
 
 /obj/machinery/mineral/equipment_vendor/attackby(obj/item/I as obj, mob/user as mob, params)
+	if(!powered())
+		return
 	if(istype(I, /obj/item/weapon/mining_voucher))
 		RedeemVoucher(I, user)
 		return

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -105,6 +105,18 @@
 						i++
 
 /obj/machinery/mineral/ore_redemption/attackby(var/obj/item/weapon/W, var/mob/user, params)
+	if(default_deconstruction_screwdriver(user, "ore_redemption-open", "ore_redemption", W))
+		updateUsrDialog()
+		return
+	if(exchange_parts(user, W))
+		return
+	if(panel_open)
+		if(istype(W, /obj/item/weapon/crowbar))
+			empty_content()
+			default_deconstruction_crowbar(W)
+		return
+	if(default_unfasten_wrench(user, W))
+		return
 	if(!powered())
 		return
 	if(istype(W,/obj/item/weapon/card/id))
@@ -116,23 +128,6 @@
 			inserted_id = I
 			interact(user)
 		return
-
-	if(default_deconstruction_screwdriver(user, "ore_redemption-open", "ore_redemption", W))
-		updateUsrDialog()
-		return
-
-	if(exchange_parts(user, W))
-		return
-
-	if(panel_open)
-		if(istype(W, /obj/item/weapon/crowbar))
-			empty_content()
-			default_deconstruction_crowbar(W)
-		return
-
-	if(default_unfasten_wrench(user, W))
-		return
-
 	..()
 
 /obj/machinery/mineral/ore_redemption/proc/SmeltMineral(var/obj/item/weapon/ore/O)
@@ -437,6 +432,13 @@
 	return
 
 /obj/machinery/mineral/equipment_vendor/attackby(obj/item/I as obj, mob/user as mob, params)
+	if(default_deconstruction_screwdriver(user, "mining-open", "mining", I))
+		updateUsrDialog()
+		return
+	if(panel_open)
+		if(istype(I, /obj/item/weapon/crowbar))
+			default_deconstruction_crowbar(I)
+		return 1
 	if(!powered())
 		return
 	if(istype(I, /obj/item/weapon/mining_voucher))
@@ -451,13 +453,6 @@
 			inserted_id = C
 			interact(user)
 		return
-	if(default_deconstruction_screwdriver(user, "mining-open", "mining", I))
-		updateUsrDialog()
-		return
-	if(panel_open)
-		if(istype(I, /obj/item/weapon/crowbar))
-			default_deconstruction_crowbar(I)
-		return 1
 	..()
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/weapon/mining_voucher/voucher, mob/redeemer)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -125,7 +125,7 @@
 			if(istype(I) && !istype(inserted_id))
 				if(!user.drop_item())
 					return
-				I.loc = src
+				I.forceMove(src)
 				inserted_id = I
 				interact(user)
 			return
@@ -454,7 +454,7 @@
 			if(istype(C) && !istype(inserted_id))
 				if(!usr.drop_item())
 					return
-				C.loc = src
+				C.forceMove(src)
 				inserted_id = C
 				interact(user)
 			return


### PR DESCRIPTION
Fixes #5920

Also fixes a previously untouched bug regarding ORM and Mining Vendor deconstruction.

(Also removes excessive paragraph spacing, for maximum compact reading material)

- Mining Vendors no longer function on wishful thinking and prayer when unpowered, preventing them from eating IDs;

- Sanity Drive installed into the Ore Redemption Machine and Mining Vendor, allowing them to be deconstructed even if unpowered

:cl:
fix: Unpowered Mining Vendors no longer accept IDs
bugfix: Ore Redemption Machine and Mining Vendor can now be deconstructed if unpowered
/:cl: