### PR TITLE
Refines Cloning, Fixes a Couple Genetics-related Bugs.

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -619,7 +619,7 @@
 				numbers += H.mind.initial_account.account_number
 				numbers += H.mind.initial_account.remote_access_pin
 			if(numbers.len>0)
-				to_chat(usr, "<span class='notice'>b>Numbers</b>: You sense the number[numbers.len>1?"s":""] [english_list(numbers)] [numbers.len>1?"are":"is"] important to [M.name].</span>")
+				to_chat(usr, "<span class='notice'><b>Numbers</b>: You sense the number[numbers.len>1?"s":""] [english_list(numbers)] [numbers.len>1?"are":"is"] important to [M.name].</span>")
 		to_chat(usr, "<span class='notice'><b>Thoughts</b>: [M.name] is currently [thoughts].</span>")
 
 		if(EMPATH in M.mutations)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -205,7 +205,7 @@
 	clonemind = locate(R.mind)
 	if(!istype(clonemind))	//not a mind
 		return 0
-	if( clonemind.current && clonemind.current.stat != DEAD )	//mind is associated with a non-dead body
+	if(clonemind.current && clonemind.current.stat != DEAD)	//mind is associated with a non-dead body
 		return 0
 	if(clonemind.active)	//somebody is using that mind
 		if(ckey(clonemind.key) != R.ckey)
@@ -229,12 +229,21 @@
 	spawn(30)
 		eject_wait = 0
 
+	if(!R.dna)
+		R.dna = new /datum/dna()
+
 	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src, R.dna.species)
 	occupant = H
 
 	if(!R.dna.real_name)	//to prevent null names
-		R.dna.real_name = "clone ([rand(0,999)])"
-	H.real_name = R.dna.real_name
+		R.dna.real_name = H.real_name
+	else
+		H.real_name = R.dna.real_name
+
+	H.dna = R.dna.Clone()
+
+	for(var/datum/language/L in R.languages)
+		H.add_language(L.name)
 
 	//Get the clone body ready
 	H.adjustCloneLoss(190) //new damage var so you can't eject a clone early then stab them to abuse the current damage system --NeoFite
@@ -256,30 +265,22 @@
 			beginning to regenerate in a cloning pod. You will
 			become conscious when it is complete.</span>"})
 
-	if(!R.dna)
-		H.dna = new /datum/dna()
-		H.dna.real_name = H.real_name
-		H.dna.ready_dna(H)
-	else
-		H.dna = R.dna.Clone()
+	domutcheck(H, null, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
+
 	if(efficiency > 2 && efficiency < 5 && prob(25))
 		randmutb(H)
 	if(efficiency > 5 && prob(20))
 		randmutg(H)
 	if(efficiency < 3 && prob(50))
 		randmutb(H)
+
 	H.dna.UpdateSE()
 	H.dna.UpdateUI()
 
-	H.set_species(R.dna.species)
 	H.sync_organ_dna(1) // It's literally a fresh body as you can get, so all organs properly belong to it
 	H.UpdateAppearance()
 
-	H.update_body()
 	update_icon()
-
-	for(var/datum/language/L in R.languages)
-		H.add_language(L.name)
 
 	H.suiciding = 0
 	attempting = 0

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2099,37 +2099,6 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 					I.robotize()
 
 	character.dna.b_type = b_type
-	if(disabilities & DISABILITY_FLAG_FAT && character.species.flags & CAN_BE_FAT)
-		character.dna.SetSEState(FATBLOCK,1,1)
-		character.mutations += FAT
-		character.mutations += OBESITY
-		character.overeatduration = 600
-
-	if(disabilities & DISABILITY_FLAG_NEARSIGHTED)
-		character.dna.SetSEState(GLASSESBLOCK,1,1)
-		character.disabilities|=NEARSIGHTED
-
-	if(disabilities & DISABILITY_FLAG_EPILEPTIC)
-		character.dna.SetSEState(EPILEPSYBLOCK,1,1)
-		character.disabilities|=EPILEPSY
-
-	if(disabilities & DISABILITY_FLAG_DEAF)
-		character.dna.SetSEState(DEAFBLOCK,1,1)
-		character.disabilities|=DEAF
-
-	if(disabilities & DISABILITY_FLAG_BLIND)
-		character.dna.SetSEState(BLINDBLOCK,1,1)
-		character.disabilities|=BLIND
-
-	if(disabilities & DISABILITY_FLAG_MUTE)
-		character.dna.SetSEState(MUTEBLOCK,1,1)
-		character.disabilities |= MUTE
-
-	S.handle_dna(character)
-
-	if(character.dna.dirtySE)
-		character.dna.UpdateSE()
-	domutcheck(character)
 
 	// Wheelchair necessary?
 	var/obj/item/organ/external/l_foot = character.get_organ("l_foot")
@@ -2169,6 +2138,38 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			character.change_gender(MALE)
 
 	character.change_eye_color(r_eyes, g_eyes, b_eyes)
+
+	if(disabilities & DISABILITY_FLAG_FAT && character.species.flags & CAN_BE_FAT)
+		character.dna.SetSEState(FATBLOCK,1,1)
+		character.mutations += FAT
+		character.mutations += OBESITY
+		character.overeatduration = 600
+
+	if(disabilities & DISABILITY_FLAG_NEARSIGHTED)
+		character.dna.SetSEState(GLASSESBLOCK,1,1)
+		character.disabilities |= NEARSIGHTED
+
+	if(disabilities & DISABILITY_FLAG_EPILEPTIC)
+		character.dna.SetSEState(EPILEPSYBLOCK,1,1)
+		character.disabilities |= EPILEPSY
+
+	if(disabilities & DISABILITY_FLAG_DEAF)
+		character.dna.SetSEState(DEAFBLOCK,1,1)
+		character.disabilities |= DEAF
+
+	if(disabilities & DISABILITY_FLAG_BLIND)
+		character.dna.SetSEState(BLINDBLOCK,1,1)
+		character.disabilities |= BLIND
+
+	if(disabilities & DISABILITY_FLAG_MUTE)
+		character.dna.SetSEState(MUTEBLOCK,1,1)
+		character.disabilities |= MUTE
+
+	S.handle_dna(character)
+
+	if(character.dna.dirtySE)
+		character.dna.UpdateSE()
+	domutcheck(character, null, MUTCHK_FORCED)
 
 	character.dna.ready_dna(character, flatten_SE = 0)
 	character.sync_organ_dna(assimilate=1)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -49,9 +49,6 @@
 		dna.real_name = real_name
 		sync_organ_dna(1)
 
-	if(species)
-		species.handle_dna(src)
-
 	UpdateAppearance()
 
 /mob/living/carbon/human/OpenCraftingMenu()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1594,6 +1594,7 @@
 		dna.real_name = real_name
 
 	species.handle_post_spawn(src)
+	species.handle_dna(src) //Give them whatever special dna business they got.
 
 	spawn(0)
 		overlays.Cut()


### PR DESCRIPTION
:cl:
fix: Characters will now be correctly assigned their species' genetic quirks at spawn.
fix: Cloning will now correctly assign a characters species' genetic quirks.
fix: Changing a character's species (via C.M.A. or whatever might call the set_species proc) will now correctly assign their species' genetic quirks.
/:cl:

Resolves #5948 and fixes a typo in the mind-reading power's fluff.
Tested by spawning in as a Grey and verifying that I had telepathy by looking at the top-left of my HUD and my player panel, teleporting to cloning and setting the component ratings of the cloning pod and DNA scanner to 9999, turning on auto-cloning, hopping in for a scan and killing myself. I popped out with my telepathy.

I repeated the test by spawning in as a Human, using C.M.A. to turn into a Grey (which gave me telepathy), hopping into the cloner and killing myself. I popped out with my telepathy again.

I then repeated the test yet again by spawning in as a Vulpkanin clown, setting component ratings on the cloner and DNA scanner to 9999, turning on autocloning, hopping in and killing myself and I still had the clown voice when I popped out of the cloner.

Sorry it took a little while, busy week.