### PR TITLE
Self-Propelled Throwing Fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -537,6 +537,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			thrown_thing = throwable_mob
 			var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 			var/turf/end_T = get_turf(target)
+			throwable_mob.forceMove(start_T)
 			if(start_T && end_T)
 				var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
 				var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"


### PR DESCRIPTION
Fixes #5889

(Courtesy of Tigercat for pointing out the solution)

- Throwing a mob behind and over you will no longer shove you in that direction

:cl:
fix: Throwing mobs behind you force moves them to behind you before actually throwing them, preventing throw-shoving
/:cl: