### PR TITLE
Fixes xenomorph walls taking damage from disablers

### DIFF
--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -79,9 +79,12 @@
 
 
 /obj/structure/alien/resin/bullet_act(obj/item/projectile/Proj)
-	health -= Proj.damage
-	..()
-	healthcheck()
+	if(Proj.damage_type != BRUTE && Proj.damage_type != BURN)
+		..()
+	else
+		health -= Proj.damage
+		..()
+		healthcheck()
 
 
 /obj/structure/alien/resin/ex_act(severity)

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -79,12 +79,10 @@
 
 
 /obj/structure/alien/resin/bullet_act(obj/item/projectile/Proj)
-	if(Proj.damage_type != BRUTE && Proj.damage_type != BURN)
-		..()
-	else
+	if(Proj.damage_type == BRUTE || Proj.damage_type == BURN)
 		health -= Proj.damage
-		..()
-		healthcheck()
+	..()
+	healthcheck()
 
 
 /obj/structure/alien/resin/ex_act(severity)


### PR DESCRIPTION
Exactly what it says on the tin.

Prior to this PR, you could destroy xenomorph resin walls with disabler shots. Now, you can't.

🆑
fix: Xenomorph resin walls no longer take damage from disabler beams. Only proper BRUTE or BURN damage hurts them now.
/🆑