### PR TITLE
Stops pods from shooting with insufficient charge, take 2

### DIFF
--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -8,7 +8,9 @@
 		to_chat(usr, "<span class='warning'>Missing equipment or weapons.</span>")
 		my_atom.verbs -= text2path("[type]/proc/fire_weapons")
 		return
-	my_atom.battery.use(shot_cost)
+	if(!my_atom.battery.use(shot_cost))
+		to_chat(usr, "<span class='warning'>Insufficient charge to fire the weapons</span>")
+		return
 	var/olddir
 	for(var/i = 0; i < shots_per; i++)
 		if(olddir != my_atom.dir)


### PR DESCRIPTION
Resubmit of #5971 after breaking my fork trying to remove the update merge commits.
As it says on the tin, pods were able to shoot unlimited shots since cell.use() does use all or nothing, which resulted in nothing, but the weapon didn't check if the charge was used or not.
:cl: MarsMond
bugfix: Pods no longer shoot without using charge
:cl: