### PR TITLE
APC Power Network Update Button

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -997,6 +997,9 @@
 				locked = !locked
 				update_icon()
 
+	else if(href_list["updatepower"])
+		update()
+
 	return 0
 
 /obj/machinery/power/apc/proc/toggle_breaker()

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -177,4 +177,6 @@
 		</div>
 	{{/if}}
 
+	{{:helper.link('Update Area Power Network', 'lightbulb-o', {'updatepower': 1})}}
+
 </div>


### PR DESCRIPTION
Addresses issue reports associated with the PA Computer. Sorta.

The issue with both of these... issues, is not that the PA Computer is broken. Rather, because it spawns in the Cargo Shuttle, which is an unpowered area, it defaults to NOPOWER, which prevents its use. As intended.

Now, this is easily fixable by just having the thing in a powered room and flicking the light switch. The inherent problem is with the way the powergrid functions.

As such, APCs now have a brand new button: Update Area Power Network. Clicking this button manually updates the area the APC is assigned to, which in turn makes sure that every machinery in that area is connected to the grid.

Also fixes any issues with moving vending machines, assuming you have APC access.

:cl:
add: Update Area Power Network button added to APCs, allowing for manual updating of the local powergrid for fringe cases
/:cl: