### PR TITLE
Fixes #5689 - Antags being bounced to lobby at roundstart

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -355,19 +355,19 @@ var/global/datum/controller/occupations/job_master
 
 		Debug("DO, Running AC2")
 
-		// For those who wanted to be civilians if their preferences were filled, here you go.
+		// Antags, who have to get in, come first
+		for(var/mob/new_player/player in unassigned)
+			if(player.mind.special_role)
+				GiveRandomJob(player)
+				if(player in unassigned)
+					AssignRole(player, "Civilian")
+
+		// Then we assign what we can to everyone else.
 		for(var/mob/new_player/player in unassigned)
 			if(player.client.prefs.alternate_option == BE_ASSISTANT)
 				Debug("AC2 Assistant located, Player: [player]")
 				AssignRole(player, "Civilian")
-
-		for(var/mob/new_player/player in unassigned)
-			if(player.mind.special_role)
-				GiveRandomJob(player)
-
-		//For ones returning to lobby
-		for(var/mob/new_player/player in unassigned)
-			if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)
+			else if(player.client.prefs.alternate_option == RETURN_TO_LOBBY)
 				player.ready = 0
 				unassigned -= player
 		return 1


### PR DESCRIPTION
Currently, it is possible for an antag to be bounced out to the lobby at roundstart, keeping their antag status, because no job could be found for them. Either there simply weren't any jobs available except civilian, or their preferences did not allow them any other job. 
This leads to them being an antag in the lobby, and they KEEP their antag status when they join as another job.

This PR fixes this, so:
- Roundstart antags who get unlucky at getting a random job can still roll antag civilian.

I'm not sure of the code on this one, so close scrutiny of the logic would be helpful. I realize this fix might cause some non-antags to be bounced to lobby when they otherwise wouldn't be - but in those cases, its more important that the antags get in at roundstart. Non-antags can latejoin. Antags... it alters the round if they latejoin (because they're choosing their job knowing they're an antag).

🆑Kyep
fix: Antags should no longer get bounced to lobby at round start in certain rare situations.
/🆑