### PR TITLE
Cyborg Ghost Despawning

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -188,7 +188,6 @@
 		/obj/item/weapon/hand_tele,
 		/obj/item/weapon/card/id/captains_spare,
 		/obj/item/device/aicard,
-		/obj/item/device/mmi,
 		/obj/item/device/paicard,
 		/obj/item/weapon/gun,
 		/obj/item/weapon/pinpointer,
@@ -720,5 +719,6 @@
 			O.loc = R
 		qdel(I)
 	qdel(R.module)
+	qdel(occupant)
 
 	return ..()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -184,7 +184,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(P)
 		if(!P.control_computer)
 			P.find_control_computer(urgent=1)
-		if(P.control_computer)
+		if(P.control_computer || istype(P, /obj/machinery/cryopod/robot))
 			P.despawn_occupant()
 	return
 


### PR DESCRIPTION
Fixes #5982

- Cyborgs who ghost while in a robotic cryopod are now properly deleted

:cl:
fix: Ghosting in a cryopod as a cyborg now despawns you
/:cl: