### PR TITLE
Neurotoxin Movement Spitball

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -104,7 +104,7 @@ Doesn't work on other aliens/AI.*/
 			to_chat(src, "<span class='noticealien'>Target is too far away.</span>")
 	return
 
-/mob/living/carbon/alien/humanoid/proc/neurotoxin(mob/user) // ok
+/mob/living/carbon/alien/humanoid/proc/neurotoxin() // ok
 	set name = "Spit Neurotoxin (50)"
 	set desc = "Spits neurotoxin at someone, paralyzing them for a short time."
 	set category = "Alien"
@@ -125,7 +125,7 @@ Doesn't work on other aliens/AI.*/
 		A.xo = U.x - T.x
 		A.fire()
 		A.newtonian_move(get_dir(U, T))
-		user.newtonian_move(get_dir(U, T))
+		newtonian_move(get_dir(U, T))
 	return
 
 /mob/living/carbon/alien/humanoid/proc/resin() // -- TLE

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -104,7 +104,7 @@ Doesn't work on other aliens/AI.*/
 			to_chat(src, "<span class='noticealien'>Target is too far away.</span>")
 	return
 
-/mob/living/carbon/alien/humanoid/proc/neurotoxin() // ok
+/mob/living/carbon/alien/humanoid/proc/neurotoxin(mob/user) // ok
 	set name = "Spit Neurotoxin (50)"
 	set desc = "Spits neurotoxin at someone, paralyzing them for a short time."
 	set category = "Alien"
@@ -125,6 +125,7 @@ Doesn't work on other aliens/AI.*/
 		A.xo = U.x - T.x
 		A.fire()
 		A.newtonian_move(get_dir(U, T))
+		user.newtonian_move(get_dir(U, T))
 	return
 
 /mob/living/carbon/alien/humanoid/proc/resin() // -- TLE


### PR DESCRIPTION
Fixes #5994

- Neurotoxin spit now interacts with the Higgs Field, giving it mass, and therefore allowing the spitter to be pushed in space

:cl:
fix: Neurotoxin Spit now causes the spitter to move in space
/:cl: