### PR TITLE
Proximity "Wet Floor Sign" Mine Fix

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -207,6 +207,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/caution/proximity_sign
 	cost = 4
 	job = list("Janitor")
+	surplus = 0
 
 //Medical
 

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -18,8 +18,6 @@
 		attack_self(mob/user as mob)
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
-				if(H.mind.assigned_role != "Janitor")
-					return
 				if(armed)
 					armed = 0
 					to_chat(user, "\blue You disarm \the [src].")

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -18,6 +18,8 @@
 		attack_self(mob/user as mob)
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
+				if(H.mind.assigned_role != "Janitor")
+					return
 				if(armed)
 					armed = 0
 					to_chat(user, "\blue You disarm \the [src].")


### PR DESCRIPTION
Fixes #5988

- Multiple customer complaints have led to Proximity Mines being discontinued from Syndicate-brand Surplus Crates

:cl:
fix: Proximity Wet Floor Sign Mines can no longer appear in Surplus Crates
/:cl: