### PR TITLE
Cameras Now Handle Disguises

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -207,7 +207,7 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 	..()
 
 
-/obj/item/device/camera/proc/get_icon(list/turfs, turf/center,mob/user)
+/obj/item/device/camera/proc/get_icon(list/turfs, turf/center, mob/user)
 
 	//Bigger icon base to capture those icons that were shifted to the next tile
 	//i.e. pretty much all wall-mounted machinery
@@ -218,11 +218,11 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 
 	var/atoms[] = list()
 	for(var/turf/the_turf in turfs)
-		// Add outselves to the list of stuff to draw
+		// Add ourselves to the list of stuff to draw
 		atoms.Add(the_turf);
 		// As well as anything that isn't invisible.
 		for(var/atom/A in the_turf)
-			if(A.invisibility )
+			if(A.invisibility)
 				if(see_ghosts && istype(A,/mob/dead/observer))
 					var/mob/dead/observer/O = A
 					if(O.following)
@@ -234,7 +234,16 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 				else//its not a ghost
 					continue
 			else//not invisable, not a spookyghost add it.
-				atoms.Add(A)
+				var/disguised = null
+				if(user.viewing_alternate_appearances && user.viewing_alternate_appearances.len && ishuman(A) && A:alternate_appearances && A:alternate_appearances.len) //This whole thing and the stuff below just checks if the atom is a Solid Snake cosplayer.
+					for(var/datum/alternate_appearance/alt_appearance in user.viewing_alternate_appearances)
+						if(alt_appearance.owner == A) //If it turns out they are, don't blow their cover. That'd be rude.
+							atoms.Add(image(alt_appearance.img, A.loc, layer = 4, dir = A.dir)) //Render their disguise.
+							atoms.Remove(A) //Don't blow their cover.
+							disguised = 1
+							continue
+				if(!disguised) //If they aren't, treat them normally.
+					atoms.Add(A)
 
 
 	// Sort the atoms into their layers
@@ -320,14 +329,10 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 		on = 1
 
 /obj/item/device/camera/proc/can_capture_turf(turf/T, mob/user)
-	var/mob/dummy = new(T)	//Go go visibility check dummy
 	var/viewer = user
 	if(user.client)		//To make shooting through security cameras possible
 		viewer = user.client.eye
-	var/can_see = (dummy in viewers(world.view, viewer)) != null
-
-	dummy.loc = null
-	dummy = null	//Alas, nameless creature	//garbage collect it instead
+	var/can_see = (T in view(viewer)) //No x-ray vision cameras.
 	return can_see
 
 /obj/item/device/camera/proc/captureimage(atom/target, mob/user, flag)
@@ -350,7 +355,7 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 	printpicture(user, P)
 
 /obj/item/device/camera/proc/createpicture(atom/target, mob/user, list/turfs, mobs, flag)
-	var/icon/photoimage = get_icon(turfs, target,user)
+	var/icon/photoimage = get_icon(turfs, target, user)
 
 	var/icon/small_img = icon(photoimage)
 	var/icon/tiny_img = icon(photoimage)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -235,7 +235,7 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 					continue
 			else//not invisable, not a spookyghost add it.
 				var/disguised = null
-				if(user.viewing_alternate_appearances && user.viewing_alternate_appearances.len && ishuman(A) && A:alternate_appearances && A:alternate_appearances.len) //This whole thing and the stuff below just checks if the atom is a Solid Snake cosplayer.
+				if(user.viewing_alternate_appearances && user.viewing_alternate_appearances.len && ishuman(A) && A.alternate_appearances && A.alternate_appearances.len) //This whole thing and the stuff below just checks if the atom is a Solid Snake cosplayer.
 					for(var/datum/alternate_appearance/alt_appearance in user.viewing_alternate_appearances)
 						if(alt_appearance.owner == A) //If it turns out they are, don't blow their cover. That'd be rude.
 							atoms.Add(image(alt_appearance.img, A.loc, layer = 4, dir = A.dir)) //Render their disguise.


### PR DESCRIPTION
Fixes a bug where you could take a picture of stuff behind walls (ghetto X-Ray).
Pictures will now render people with disguises as you see them (borgs see people with cardborg suits as borgs, people with cardborg suits see themselves as borgs, everyone sees people carrying plants as plants)
although they will also state the person's name, regardless of disguise (**same as if you hovered over them with your cursor**).

Fixes #6015 

:cl:
fix: Cameras will no longer be able to take photos of stuff outside your line of sight.
tweak: Cameras will now render disguises as you see them.
/:cl:

_Cameras no longer use x-ray tech._
![noxraycamera](https://cloud.githubusercontent.com/assets/12377767/21414442/76298e54-c7cd-11e6-8aae-3f024e72fa66.PNG)

_Taking a picture of someone holding a bush._
![bushdisguise](https://cloud.githubusercontent.com/assets/12377767/21414454/8e810130-c7cd-11e6-99e0-0265d2061020.PNG)

_Taking a picture of someone else wearing a cardborg outfit as a human._
![cardborgphotoother](https://cloud.githubusercontent.com/assets/12377767/21414463/991f0c18-c7cd-11e6-99d7-9b2f5278a3d8.PNG)

_Taking a picture of yourself when you're wearing a cardborg outfit._
![cardborgphotoself](https://cloud.githubusercontent.com/assets/12377767/21414470/a925c7be-c7cd-11e6-9667-c2d5d34197e1.PNG)

_Testing to see if Cyborg onboard cameras inherited the same fix. They did._
![cyborgcameraworking-noxray](https://cloud.githubusercontent.com/assets/12377767/21414473/b31695d2-c7cd-11e6-88e2-8ee2e39f5ed4.PNG)

_Taking a picture of a person wearing a cardborg outfit (left), holding a plant (top) and holding/wearing nothing (right) as a cyborg (bottom)._
![alltogether](https://cloud.githubusercontent.com/assets/12377767/21414480/c2916168-c7cd-11e6-87dc-6f47ebd155e1.PNG)




