### PR TITLE
Fixes Nightvision, Darksight, and X-Ray

### DIFF
--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -161,6 +161,14 @@
 /datum/dna/gene/basic/xray/New()
 	block=XRAYBLOCK
 
+/datum/dna/gene/basic/xray/activate(mob/living/M, connected, flags)
+	..()
+	M.update_sight()
+
+/datum/dna/gene/basic/xray/deactivate(mob/living/M, connected, flags)
+	..()
+	M.update_sight()
+
 /datum/dna/gene/basic/tk
 	name="Telekenesis"
 	activation_messages = list("You feel smarter.")

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -148,13 +148,15 @@
 	flags = GLASSESCOVERSEYES
 	slot_flags = SLOT_EYES
 	materials = list(MAT_GLASS = 250)
-	var/emagged = 0
 	var/vision_flags = 0
-	var/darkness_view = 0//Base human is 2
-	var/invis_override = 0
+	var/darkness_view = 0 //Base human is 2
 	var/invis_view = SEE_INVISIBLE_LIVING
-	var/invisa_view = 0
+	var/invis_override = 0
+
+	var/emagged = 0
 	var/color_view = null//overrides client.color while worn
+	var/prescription = 0
+	var/prescription_upgradable = 0
 	strip_delay = 20			//	   but seperated to allow items to protect but not impair vision, like space helmets
 	put_on_delay = 25
 	burn_state = FIRE_PROOF
@@ -277,8 +279,8 @@ BLIND     // can't see anything
 	var/blockTracking // Do we block AI tracking?
 	var/HUDType = null
 	var/darkness_view = 0
+	var/helmet_goggles_invis_view = 0
 	var/vision_flags = 0
-	var/see_darkness = 1
 	var/can_toggle = null
 
 //Mask

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -1,15 +1,3 @@
-/obj/item/clothing/glasses
-	name = "glasses"
-	icon = 'icons/obj/clothing/glasses.dmi'
-	//w_class = 2
-	//flags = GLASSESCOVERSEYES
-	//slot_flags = SLOT_EYES
-	//var/vision_flags = 0
-	//var/darkness_view = 0//Base human is 2
-	var/prescription = 0
-	var/prescription_upgradable = 0
-	var/see_darkness = 1
-
 /obj/item/clothing/glasses/New()
 	. = ..()
 	if(prescription_upgradable && prescription)
@@ -49,8 +37,8 @@
 	item_state = "glasses"
 	origin_tech = "magnets=2;engineering=2"
 	vision_flags = SEE_TURFS
+	invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 	prescription_upgradable = 1
-	see_darkness = 0 //don't render darkness while wearing mesons
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
@@ -112,7 +100,7 @@
 	icon_state = "nvpurple"
 	item_state = "glasses"
 	darkness_view = 8
-	see_darkness = 0
+	invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 
 /obj/item/clothing/glasses/janitor
 	name = "Janitorial Goggles"
@@ -131,7 +119,7 @@
 	item_state = "glasses"
 	origin_tech = "magnets=2"
 	darkness_view = 8
-	see_darkness = 0
+	invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 	species_fit = list("Vox")
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
@@ -400,7 +388,6 @@
 	item_state = "glasses"
 	origin_tech = "magnets=3"
 	vision_flags = SEE_MOBS
-	invisa_view = 2
 	flash_protect = -1
 	species_fit = list("Vox")
 	sprite_sheets = list(

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -47,7 +47,7 @@
 	icon_state = "healthhudnight"
 	item_state = "glasses"
 	darkness_view = 8
-	see_darkness = 0
+	invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 	prescription_upgradable = 0
 
 /obj/item/clothing/glasses/hud/diagnostic
@@ -66,7 +66,7 @@
 	icon_state = "diagnostichudnight"
 	item_state = "glasses"
 	darkness_view = 8
-	see_darkness = 0
+	invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 	prescription_upgradable = 0
 
 /obj/item/clothing/glasses/hud/security
@@ -95,14 +95,13 @@
 	icon_state = "jensenshades"
 	item_state = "jensenshades"
 	vision_flags = SEE_MOBS
-	invisa_view = 2
 
 /obj/item/clothing/glasses/hud/security/night
 	name = "\improper Night Vision Security HUD"
 	desc = "An advanced heads-up display which provides id data and vision in complete darkness."
 	icon_state = "securityhudnight"
 	darkness_view = 8
-	see_darkness = 0
+	invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 	prescription_upgradable = 0
 
 /obj/item/clothing/glasses/hud/security/sunglasses
@@ -133,5 +132,5 @@
 	icon_state = "hydroponichudnight"
 	item_state = "glasses"
 	darkness_view = 8
-	see_darkness = 0
+	invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 	prescription_upgradable = 0

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -63,7 +63,7 @@
 	name = "night-vision helmet"
 	desc = "A helmet with a built-in pair of night vision goggles."
 	icon_state = "helmetNVG"
-	see_darkness = 0
+	helmet_goggles_invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 
 /obj/item/clothing/head/helmet/alt
 	name = "bulletproof helmet"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -48,7 +48,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	unacidable = 1
 	vision_flags = SEE_MOBS
-	see_darkness = 0
+	helmet_goggles_invis_view = SEE_INVISIBLE_MINIMUM //don't render darkness while wearing these
 	HUDType = MEDHUD
 	strip_delay = 130
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -121,10 +121,13 @@
 		update_inv_glasses()
 	else if(I == head)
 		head = null
-		if(I.flags & BLOCKHAIR || I.flags & BLOCKHEADHAIR)
+		var/obj/item/clothing/head/hat = I
+		if(hat.flags & BLOCKHAIR || hat.flags & BLOCKHEADHAIR)
 			update_hair()	//rebuild hair
 			update_fhair()
 			update_head_accessory()
+		if(hat.vision_flags || hat.darkness_view || hat.helmet_goggles_invis_view)
+			update_sight()
 		head_update(I)
 		update_inv_head()
 	else if(I == r_ear)
@@ -271,10 +274,13 @@
 			update_inv_gloves(redraw_mob)
 		if(slot_head)
 			head = W
+			var/obj/item/clothing/head/hat = W
 			if((head.flags & BLOCKHAIR) || (head.flags & BLOCKHEADHAIR))
 				update_hair(redraw_mob)	//rebuild hair
 				update_fhair(redraw_mob)
 				update_head_accessory(redraw_mob)
+			if(hat.vision_flags || hat.darkness_view || hat.helmet_goggles_invis_view)
+				update_sight()
 			head_update(W)
 			update_inv_head(redraw_mob)
 		if(slot_shoes)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -630,10 +630,10 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 			if(hat.darkness_view) // Pick the lowest of the two darkness_views between the glasses and helmet.
 				lesser_darkview_bonus = min(hat.darkness_view,lesser_darkview_bonus)
 
-			if(!hat.see_darkness)
-				H.see_invisible = SEE_INVISIBLE_MINIMUM
+			if(hat.helmet_goggles_invis_view)
+				H.see_invisible = min(hat.helmet_goggles_invis_view, H.see_invisible)
 
-	if(istype(H.back, /obj/item/weapon/rig)) ///ahhhg so snowflakey
+	if(istype(H.back, /obj/item/weapon/rig)) ///aghhh so snowflakey
 		var/obj/item/weapon/rig/rig = H.back
 		if(rig.visor)
 			if(!rig.helmet || (H.head && rig.helmet == H.head))
@@ -644,8 +644,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 						if(G.vision_flags)		// MESONS
 							H.sight |= G.vision_flags
 
-						if(!G.see_darkness)
-							H.see_invisible = SEE_INVISIBLE_MINIMUM
+						H.see_invisible = min(G.invis_view, H.see_invisible)
 
 	if(lesser_darkview_bonus != INFINITY)
 		H.see_in_dark = max(lesser_darkview_bonus, H.see_in_dark)
@@ -660,6 +659,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	if(XRAY in H.mutations)
 		H.sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
 		H.see_in_dark = max(H.see_in_dark, 8)
+		H.see_invisible = SEE_INVISIBLE_MINIMUM
 
 	if(H.see_override)	//Override all
 		H.see_invisible = H.see_override


### PR DESCRIPTION

Just some vision related fixes and a small refactor.

Fixes X-Ray, nightvision, and species darksight so they actually work, again.

Ensures that vision updates are instant when hats with vision flags/darkness view/night vision are applied

Axed the `see_darkness` flag in favor of just setting the `invis_view` directly on the glasses (same effect, doesn't impact players).

Gets rid of the unused `invsa_view` var (yes, there was both `invisa_view` and `invis_view`).


:cl: Fox McCloud
fix: Fixes X-Ray not doing anything
fix: Fixes nightvision not granting what its name implies
fix: Fixes species/human darksight doing absolutely nothing
/:cl: