### PR TITLE
Fixes Cargo-ordered PAs and Wrenching-down Machines in Powered/Powerless Areas

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -420,6 +420,9 @@ Class Procs:
 		if(do_after(user, time, target = src))
 			to_chat(user, "<span class='notice'>You've [anchored ? "un" : ""]secured [name].</span>")
 			anchored = !anchored
+			if(istype(src, /obj/machinery))
+				var/obj/machinery/M = src
+				M.power_change() //Turn on or off the machine depending on the status of power in the new area.
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		return 1
 	return 0

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -366,6 +366,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				user.visible_message("[user.name] secures the [src.name] to the floor.", \
 					"You secure the external bolts.")
 				temp_state++
+				power_change()
 		if(1)
 			if(iswrench(O))
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
@@ -373,6 +374,7 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				user.visible_message("[user.name] detaches the [src.name] from the floor.", \
 					"You remove the external bolts.")
 				temp_state--
+				power_change()
 			else if(iscoil(O))
 				if(O:use(1))
 					user.visible_message("[user.name] adds wires to the [src.name].", \

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -24,6 +24,7 @@
 /obj/machinery/particle_accelerator/control_box/New()
 	wires = new(src)
 	connected_parts = list()
+	update_icon()
 	..()
 
 /obj/machinery/particle_accelerator/control_box/Destroy()
@@ -62,9 +63,12 @@
 
 /obj/machinery/particle_accelerator/control_box/update_icon()
 	if(active)
-		icon_state = "[reference]p1"
+		icon_state = "[reference]p[strength]"
 	else
-		if(use_power)
+		if(stat & NOPOWER)
+			icon_state = "[reference]w"
+			return
+		else if(use_power)
 			if(assembled)
 				icon_state = "[reference]p"
 			else
@@ -89,7 +93,7 @@
 		to_chat(usr, "<span class='error'>ERROR: Request timed out. Check wire contacts.</span>")
 		return
 
-	if( href_list["close"] )
+	if(href_list["close"])
 		usr << browse(null, "window=pacontrol")
 		usr.unset_machine()
 		return
@@ -152,6 +156,11 @@
 		use_power = 0
 	else if(!stat && construction_state <= 3)
 		use_power = 1
+	src.update_icon()
+	for(var/obj/structure/particle_accelerator/part in connected_parts)
+		part.strength = null
+		part.powered = 0
+		part.update_icon()
 	return
 
 


### PR DESCRIPTION
Particle Accelerators will now update with current power-net information upon being wrenched, just like all other machines. Fixes a bug where Particle Accelerators ordered from cargo would never detect parts.

_Making a PA in cargo and hacking it to fire at strength 3 just because we can._
![cargo ordered pa working](https://cloud.githubusercontent.com/assets/12377767/21465412/5b8d7d40-c970-11e6-8237-77777bd287ce.PNG)

Fixes a bug where machines taken from a powerless area and wrenched into a powered area wouldn't be powered until you flicked the lights on and off (or something to that effect).

Fixes #5968 and fixes #5882.
PR #5983 is no longer necessary

This PR brought to you by PJB3005, thanks a ton!

:cl:
fix: Particle Accelerators ordered from Cargo can now function.
fix: Wrenching powerless machines in a powered area will no longer require you to toggle the lights (or whatever you did before to sort this).
/:cl: