### PR TITLE
Snow Wars Episode II: Attack of the Claus

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
@@ -23,6 +23,8 @@
 /mob/living/simple_animal/hostile/winter/snowman
 	name = "snowman"
 	desc = "A very angry snowman. Doesn't look like it wants to play around..."
+	maxHealth = 75		//slightly beefier to account for it's need to get in your face
+	health = 75
 	icon_state = "snowman"
 	icon_living = "snowman"
 	icon_dead = "snowman-dead"
@@ -34,7 +36,7 @@
 
 
 /mob/living/simple_animal/hostile/winter/snowman/death(gibbed)
-	if(prob(50))		//50% chance to drop weapon on death, if it has one to drop
+	if(prob(50) && !ranged)		//50% chance to drop candy cane sword on death, if it has one to drop
 		loot = list(/obj/item/weapon/melee/candy_sword)
 	if(prob(20))	//chance to become a stationary snowman structure instead of a corpse
 		loot.Add(/obj/structure/snowman)
@@ -45,6 +47,8 @@
 		..()
 
 /mob/living/simple_animal/hostile/winter/snowman/ranged
+	maxHealth = 50
+	health = 50
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
@@ -57,7 +61,8 @@
 	icon_living = "reindeer"
 	icon_dead = "reindeer-dead"
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat = 3)
-
+	maxHealth = 80
+	health = 80
 	melee_damage_lower = 5
 	melee_damage_upper = 10
 	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
@@ -83,17 +88,21 @@
 			qdel(src)	//hide the body
 
 /mob/living/simple_animal/hostile/winter/santa/stage_1		//stage 1: slow melee
+	maxHealth = 150
+	health = 150
 	desc = "GET THE FAT MAN!"
 	next_stage = /mob/living/simple_animal/hostile/winter/santa/stage_2
 	death_message = "<span class='danger'>HO HO HO! YOU THOUGHT IT WOULD BE THIS EASY?!?</span>"
 	speed = 2
-	melee_damage_lower = 5
-	melee_damage_upper = 15
+	melee_damage_lower = 10
+	melee_damage_upper = 20
 
 /mob/living/simple_animal/hostile/winter/santa/stage_2		//stage 2: slow ranged
 	desc = "GET THE FAT MAN AGAIN!"
 	next_stage = /mob/living/simple_animal/hostile/winter/santa/stage_3
 	death_message = "<span class='danger'>YOU'VE BEEN VERY NAUGHTY! PREPARE TO DIE!</span>"
+	maxHealth = 200		//DID YOU REALLY BELIEVE IT WOULD BE THIS EASY!??!!
+	health = 200
 	ranged = 1
 	projectiletype = /obj/item/projectile/ornament
 	retreat_distance = 5
@@ -103,6 +112,8 @@
 	desc = "WHY WON'T HE DIE ALREADY!?"
 	next_stage = /mob/living/simple_animal/hostile/winter/santa/stage_4
 	death_message = "<span class='danger'>FACE MY FINAL FORM AND KNOW DESPAIR!</span>"
+	maxHealth = 250
+	health = 250
 	ranged = 1
 	rapid = 1
 	speed = 0	//he's lost some weight from the fighting
@@ -113,13 +124,13 @@
 /mob/living/simple_animal/hostile/winter/santa/stage_4		//stage 4: fast spinebreaker
 	name = "Final Form Santa"
 	desc = "WHAT THE HELL IS HE!?! WHY WON'T HE STAY DEAD!?!"
-	maxHealth = 200
-	health = 200
+	maxHealth = 300		//YOU FACE JARAX- I MEAN SANTA!
+	health = 300
 	speed = 0	//he's lost some weight from the fighting
 
 	environment_smash = 2		//naughty walls must be punished too
-	melee_damage_lower = 15
-	melee_damage_upper = 25		//that's gonna leave a mark, for sure
+	melee_damage_lower = 20
+	melee_damage_upper = 30		//that's gonna leave a mark, for sure
 
 /mob/living/simple_animal/hostile/winter/santa/stage_4/death(gibbed)
 	to_chat(world, "<span class='notice'><hr></span>")

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -352,7 +352,7 @@ obj/item/projectile/kinetic/New()
 	name = "snowball"
 	icon_state = "snowball"
 	hitsound = 'sound/items/dodgeball.ogg'
-	damage = 3
+	damage = 4
 	damage_type = BURN
 
 /obj/item/projectile/snowball/on_hit(atom/target)	//chilling
@@ -366,7 +366,7 @@ obj/item/projectile/kinetic/New()
 	name = "ornament"
 	icon_state = "ornament-1"
 	hitsound = 'sound/effects/Glasshit.ogg'
-	damage = 5
+	damage = 7
 	damage_type = BRUTE
 
 /obj/item/projectile/ornament/New()


### PR DESCRIPTION
Santa's back, and angrier than ever at the naughty Space Station crew!

Santa's maximum health now increases with each successive stage (previously only increased at Stage 4)
- Stage 1: 150 health (unchanged)
- Stage 2: 200 health (what stage 4 used to be)
- Stage 3: 250 health
- Stage 4: 300 health

Santa's Melee forms have had their damage ranges buffed
- Previously 5-15 in Stage 1 and 15-25 in Stage 4, now 10-20 and 20-30 respectively

Melee Snowmen and Reindeer have had their health increased to provide extra survivability as they attempt to get into attack range. Ranged snowmen unchanged
- Snowmen: was 50, now 75
- Reindeer: was 50, now 80

Ranged snowmen can no longer drop the candy cane sword, as intended. Drop chance unchanged (50% from melee snowmen)

Snowballs (ranged snowman attack) and Ornaments (Santa Stage 2 and Stage 3 attack) have had damage increased slightly. Ornament knockback unchanged.
- Snowballs now deal 4 damage, was 3
- Ornaments now deal 7 damage, was 5

The away_mission_config.txt file in the /config folder will need to be manually editted to reactivate the evil santa away mission.

:cl:
rscadd: Santa's back and with-holding all your presents! Head through the gateway and show the Fat Man the strength of your holiday spirit (and advanced weaponry, you'll be needing that)!
/:cl: