### PR TITLE
Returns Colour Vision when you Unequip Noir Glasses

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -255,10 +255,11 @@
                             0, 0, 1, 0,\
                             0, 0, 0, 1)
 
-#define MATRIX_GREYSCALE list(0.3, 0.3, 0.3, 0,\
-                              0.3, 0.3, 0.3, 0,\
-                              0.3, 0.3, 0.3, 0,\
-                              0,   0,   0,   1)
+#define MATRIX_GREYSCALE list(0.33, 0.33, 0.33, 0,\
+                              0.33, 0.33, 0.33, 0,\
+                              0.33, 0.33, 0.33, 0,\
+                              0.00, 0.00, 0.00, 1,\
+                              0.00, 0.00, 0.00, 0)
 //Gun trigger guards
 #define TRIGGER_GUARD_ALLOW_ALL -1
 #define TRIGGER_GUARD_NONE 0

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -115,7 +115,9 @@
 				result += e
 	else
 		result = first - second
-	return result
+
+	if(result.len)
+		return result
 
 /*
  * Returns list containing entries that are in either list but not both.

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -154,7 +154,7 @@
 	var/invis_override = 0
 
 	var/emagged = 0
-	var/color_view = null//overrides client.color while worn
+	var/list/color_view = null//overrides client.color while worn
 	var/prescription = 0
 	var/prescription_upgradable = 0
 	strip_delay = 20			//	   but seperated to allow items to protect but not impair vision, like space helmets

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -243,29 +243,35 @@
 		return 1
 
 /obj/item/clothing/glasses/sunglasses/noir/proc/toggle_noir()
+	var/list/difference = difflist(usr.client.color, color_view)
+
 	if(!noir_mode)
-		if(color_view && usr.client && !usr.client.color)
+		if(color_view && usr.client && (!usr.client.color || difference))
 			animate(usr.client, color = color_view, time = 10)
 			noir_mode = 1
 	else
-		if(usr.client && usr.client.color)
-			animate(usr.client, color = null, time = 10)
+		if(usr.client && usr.client.color && !difference)
+			animate(usr.client, color = initial(usr.client.color), time = 10)
 			noir_mode = 0
 
 /obj/item/clothing/glasses/sunglasses/noir/equipped(mob/user, slot)
+	var/list/difference = difflist(user.client.color, color_view)
+
 	if(slot == slot_glasses)
 		if(noir_mode)
-			if(color_view && user.client && !user.client.color)
+			if(color_view && user.client && (!user.client.color || difference))
 				animate(user.client, color = color_view, time = 10)
 	else
-		if(user.client && user.client.color)
-			animate(usr.client, color = null, time = 10)
+		if(user.client && user.client.color && !difference)
+			animate(user.client, color = initial(user.client.color), time = 10)
 	..(user, slot)
 
 /obj/item/clothing/glasses/sunglasses/noir/dropped(mob/living/carbon/human/user)
+	var/list/difference = difflist(user.client.color, color_view)
+
 	if(istype(user) && user.glasses == src)
-		if(user.client && user.client.color)
-			animate(user.client, color = null, time = 10)
+		if(user.client && user.client.color && !difference)
+			animate(user.client, color = initial(user.client.color), time = 10)
 	..(user)
 
 /obj/item/clothing/glasses/sunglasses/yeah

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -257,6 +257,9 @@
 		if(noir_mode)
 			if(color_view && user.client && !user.client.color)
 				animate(user.client, color = color_view, time = 10)
+	else
+		if(user.client && user.client.color)
+			animate(usr.client, color = null, time = 10)
 	..(user, slot)
 
 /obj/item/clothing/glasses/sunglasses/noir/dropped(mob/living/carbon/human/user)


### PR DESCRIPTION
:cl:
fix: Taking off noir glasses while noir mode is on will now give you your colour vision back.
/:cl:

Tested by spawning in as Detective, turning my glasses' noir mode on and taking them off.
The reason why this was busted is because dropped() isn't called when you take off your glasses, equipped is in order to put the glasses in a different inventory slot (i.e. hands).

Fixes #6024 