### PR TITLE
Shuttle Manipulator can now only be used by admins

### DIFF
--- a/code/modules/shuttle/shuttle_manipulator.dm
+++ b/code/modules/shuttle/shuttle_manipulator.dm
@@ -59,13 +59,12 @@
 	ui_interact(user)
 
 /obj/machinery/shuttle_manipulator/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-
 	// update the ui if it exists, returns null if no ui is passed/found
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		// the ui does not exist, so we'll create a new() one
         // for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "shuttle_manipulator.tmpl", "Shuttle Manipulator", 660, 700)
+		ui = new(user, src, ui_key, "shuttle_manipulator.tmpl", "Shuttle Manipulator", 660, 700, null, null, admin_state)
 		// when the ui is first opened this is the data it will use
 		// open the new ui window
 		ui.open()


### PR DESCRIPTION
:cl: Crazylemon
fix: The shuttle manipulator can now only be used by admins
/:cl: