### PR TITLE
Bug fixes

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -181,6 +181,7 @@ update_flag
 	if(src.destroyed)
 		src.overlays = 0
 		src.icon_state = text("[]-1", src.canister_color["prim"])//yes, I KNOW the colours don't reflect when the can's borked, whatever.
+		return
 
 	if(icon_state != src.canister_color["prim"])
 		icon_state = src.canister_color["prim"]

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -110,6 +110,9 @@ var/list/alldepartments = list()
 	if(href_list["paper"])
 		if(copyitem)
 			copyitem.forceMove(get_turf(src))
+			if(ishuman(usr))
+				if(!usr.get_active_hand())
+					usr.put_in_hands(copyitem)
 			to_chat(usr, "<span class='notice'>You eject \the [copyitem] from \the [src].</span>")
 			copyitem = null
 		else

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -109,16 +109,15 @@ var/list/alldepartments = list()
 
 	if(href_list["paper"])
 		if(copyitem)
-			copyitem.loc = usr.loc
-			usr.put_in_hands(copyitem)
-			to_chat(usr, "<span class='notice'>You take \the [copyitem] out of \the [src].</span>")
+			copyitem.forceMove(get_turf(src))
+			to_chat(usr, "<span class='notice'>You eject \the [copyitem] from \the [src].</span>")
 			copyitem = null
 		else
 			var/obj/item/I = usr.get_active_hand()
 			if(istype(I, /obj/item/weapon/paper) || istype(I, /obj/item/weapon/photo) || istype(I, /obj/item/weapon/paper_bundle))
 				usr.drop_item()
 				copyitem = I
-				I.loc = src
+				I.forceMove(src)
 				to_chat(usr, "<span class='notice'>You insert \the [I] into \the [src].</span>")
 				flick(insert_anim, src)
 
@@ -163,24 +162,24 @@ var/list/alldepartments = list()
 /obj/machinery/photocopier/faxmachine/proc/scan(var/obj/item/weapon/card/id/card = null)
 	if(scan) // Card is in machine
 		if(ishuman(usr))
-			scan.loc = usr.loc
+			scan.forceMove(get_turf(usr))
 			if(!usr.get_active_hand())
 				usr.put_in_hands(scan)
 			scan = null
 		else
-			scan.loc = src.loc
+			scan.forceMove(get_turf(src))
 			scan = null
 	else
 		if(!card)
 			var/obj/item/I = usr.get_active_hand()
 			if(istype(I, /obj/item/weapon/card/id))
 				usr.drop_item()
-				I.loc = src
+				I.forceMove(src)
 				scan = I
 		else
 			if(istype(card))
 				usr.drop_item()
-				card.loc = src
+				card.forceMove(src)
 				scan = card
 	nanomanager.update_uis(src)
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -79,8 +79,7 @@
 		updateUsrDialog()
 	else if(href_list["remove"])
 		if(copyitem)
-			copyitem.loc = usr.loc
-			usr.put_in_hands(copyitem)
+			copyitem.forceMove(get_turf(src))
 			to_chat(usr, "<span class='notice'>You take \the [copyitem] out of \the [src].</span>")
 			copyitem = null
 			updateUsrDialog()
@@ -125,7 +124,7 @@
 		if(!copyitem)
 			user.drop_item()
 			copyitem = O
-			O.loc = src
+			O.forceMove(src)
 			to_chat(user, "<span class='notice'>You insert \the [O] into \the [src].</span>")
 			flick(insert_anim, src)
 			updateUsrDialog()
@@ -150,10 +149,10 @@
 		if(ismob(G.affecting) && G.affecting != ass)
 			var/mob/GM = G.affecting
 			visible_message("<span class='warning'>[usr] drags [GM.name] onto the photocopier!</span>")
-			GM.loc = get_turf(src)
+			GM.forceMove(get_turf(src))
 			ass = GM
 			if(copyitem)
-				copyitem.loc = src.loc
+				copyitem.forceMove(get_turf(src))
 				copyitem = null
 		updateUsrDialog()
 	return
@@ -290,10 +289,10 @@
 			W = copy(W)
 		else if(istype(W, /obj/item/weapon/photo))
 			W = photocopy(W)
-		W.loc = p
+		W.forceMove(p)
 		p.amount++
 	p.amount--
-	p.loc = src.loc
+	p.forceMove(get_turf(src))
 	p.update_icon()
 	p.icon_state = "paper_words"
 	p.name = bundle.name
@@ -313,10 +312,10 @@
 		if(target.anchored) return
 		if(!ishuman(user)) return
 		visible_message("<span class='warning'>[usr] drags [target.name] onto the photocopier!</span>")
-	target.loc = get_turf(src)
+	target.forceMove(get_turf(src))
 	ass = target
 	if(copyitem)
-		copyitem.loc = src.loc
+		copyitem.forceMove(get_turf(src))
 		visible_message("<span class='notice'>[copyitem] is shoved out of the way by [ass]!</span>")
 		copyitem = null
 	updateUsrDialog()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -80,6 +80,9 @@
 	else if(href_list["remove"])
 		if(copyitem)
 			copyitem.forceMove(get_turf(src))
+			if(ishuman(usr))
+				if(!usr.get_active_hand())
+					usr.put_in_hands(copyitem)
 			to_chat(usr, "<span class='notice'>You take \the [copyitem] out of \the [src].</span>")
 			copyitem = null
 			updateUsrDialog()


### PR DESCRIPTION
Fixes #6041 
Fixes #6029 

Fax machines and photocopiers now simply spit out their papers onto their own tile, rather than trying to make them jump into your hands. Minor change, shouldn't really affect anything.
- Ejecting IDs from the machine will still attempt to place them in your hand only if you are a humanoid, as they did before. Otherwise, they just drop on the machine's tile.

Additionally replaced a bunch of `thing.loc = src.loc` or `thing.loc = src` with proper thing.forceMove() calls