### PR TITLE
Runtime fixes

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -116,8 +116,7 @@
 	else
 		result = first - second
 
-	if(result.len)
-		return result
+	return result
 
 /*
  * Returns list containing entries that are in either list but not both.

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -131,7 +131,7 @@ var/datum/canister_icons/canister_icon_container = new()
 		var/list/LL = L[i]
 		LL = LL.Copy() //make sure we don't edit the datum list
 		LL.Add(list("active" = decals[LL["icon"]])) //"active" used by nanoUI
-		possibledecals[i] = LL
+		possibledecals.Add(LL)
 
 /obj/machinery/portable_atmospherics/canister/proc/check_change()
 	var/old_flag = update_flag

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -120,10 +120,11 @@
 		return 0
 	var/obj/effect/decal/cleanable/blood/B = locate() in contents	//check for existing blood splatter
 	if(!B)
-		blood_splatter(src,M.get_blood(M.vessel),1)
-		B = locate(/obj/effect/decal/cleanable/blood) in contents
-	B.add_blood_list(M)
-	return 1 //we bloodied the floor
+		B = blood_splatter(src,M.get_blood(M.vessel),1)
+	if(B)
+		B.add_blood_list(M)
+		return 1 //we bloodied the floor
+	return 0 // Clean floors club
 
 // Only adds blood on the floor -- Skie
 /turf/simulated/add_blood_floor(mob/living/carbon/M as mob)

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -259,10 +259,10 @@
 
 	if(slot == slot_glasses)
 		if(noir_mode)
-			if(color_view && user.client && (!user.client.color || difference))
+			if(color_view && user.client && (!user.client.color || difference.len))
 				animate(user.client, color = color_view, time = 10)
 	else
-		if(user.client && user.client.color && !difference)
+		if(user.client && user.client.color && !difference.len)
 			animate(user.client, color = initial(user.client.color), time = 10)
 	..(user, slot)
 
@@ -270,7 +270,7 @@
 	var/list/difference = difflist(user.client.color, color_view)
 
 	if(istype(user) && user.glasses == src)
-		if(user.client && user.client.color && !difference)
+		if(user.client && user.client.color && !difference.len)
 			animate(user.client, color = initial(user.client.color), time = 10)
 	..(user)
 

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -634,14 +634,20 @@
 					chems[rid] = gene_chem.Copy()
 					continue
 
+				// Normally a length 2 list - but sometimes, it's length 1 - poisonberries, etc.
+				// This means the reagent does not scale with potency.
+				// Index 1 is the base value, index 2 is the potency per u of reagent
+				var/list/rgnt_list = chems[rid]
+				rgnt_list.len = max(gene_chem.len, rgnt_list.len)
+
 				for(var/i=1;i<=gene_chem.len;i++)
 
 					if(isnull(gene_chem[i])) gene_chem[i] = 0
 
-					if(chems[rid][i])
-						chems[rid][i] = max(1,round((gene_chem[i] + chems[rid][i])/2))
+					if(rgnt_list[i])
+						rgnt_list[i] = max(1,round((gene_chem[i] + rgnt_list[i])/2))
 					else
-						chems[rid][i] = gene_chem[i]
+						rgnt_list[i] = gene_chem[i]
 
 			var/list/new_gasses = gene.values["[TRAIT_EXUDE_GASSES]"]
 			if(islist(new_gasses))

--- a/code/modules/spacepods/parts.dm
+++ b/code/modules/spacepods/parts.dm
@@ -30,7 +30,7 @@
 	var/turf/T
 	var/obj/item/pod_parts/pod_frame/linked
 	var/obj/item/pod_parts/pod_frame/pointer
-	var/connectedparts =  list()
+	var/list/connectedparts =  list()
 	neededparts -= src
 	//log_admin("Starting with [src]")
 	linked = src
@@ -44,7 +44,8 @@
 				connectedparts += pointer
 			linked = pointer
 			pointer = null
-	//log_admin("Parts left: [neededparts.len]") //len not working
+	if(connectedparts.len < 4)
+		return 0
 	for(var/i = 1; i <=4; i++)
 		var/obj/item/pod_parts/pod_frame/F = connectedparts[i]
 		if(F.type in neededparts) //if one of the items can be founded in neededparts


### PR DESCRIPTION
No CL because this doesn't have player-facing effects afaik

Fixes several camera runtimes caused by the tweak to `difflist` made earlier
Fixes a runtime when bleeding without blood
Fixes a runtime when assembling an incomplete pod frame
Fixes a runtime when interfacing with canisters
Fixes a runtime when splicing plants