### PR TITLE
Fixes pAI UIs

### DIFF
--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -109,7 +109,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/atmospherics/unary/cold_sink/freezer/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/atmospherics/unary/cold_sink/freezer/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["on"] = on ? 1 : 0
 	data["gasPressure"] = round(air_contents.return_pressure())
@@ -267,7 +267,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/atmospherics/unary/heat_reservoir/heater/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/atmospherics/unary/heat_reservoir/heater/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["on"] = on ? 1 : 0
 	data["gasPressure"] = round(air_contents.return_pressure())

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -696,7 +696,7 @@
 	data["danger"] = danger
 	return data
 
-/obj/machinery/alarm/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/alarm/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	var/list/href_list = state.href_list()
 

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -117,7 +117,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/portable_atmospherics/pump/ui_data(mob/user, datum/topic_state/state = physical_state)
+/obj/machinery/portable_atmospherics/pump/ui_data(mob/user, ui_key = "main", datum/topic_state/state = physical_state)
 	var/data[0]
 	data["portConnected"] = connected_port ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() > 0 ? air_contents.return_pressure() : 0)

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -128,7 +128,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/portable_atmospherics/scrubber/ui_data(mob/user, datum/topic_state/state = physical_state)
+/obj/machinery/portable_atmospherics/scrubber/ui_data(mob/user, ui_key = "main", datum/topic_state/state = physical_state)
 	var/data[0]
 	data["portConnected"] = connected_port ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() > 0 ? air_contents.return_pressure() : 0)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -92,7 +92,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/operating/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/operating/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	var/mob/living/carbon/human/occupant = src.table.victim
 	data["hasOccupant"] = occupant ? 1 : 0

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -1,14 +1,14 @@
 /obj/machinery/computer/security
 	name = "security camera console"
 	desc = "Used to access the various cameras networks on the station."
-	
+
 	icon_keyboard = "security_key"
 	icon_screen = "cameras"
 	light_color = LIGHT_COLOR_RED
 	circuit = /obj/item/weapon/circuitboard/camera
-	
+
 	var/mapping = 0 // For the overview file (overview.dm), not used on this page
-	
+
 	var/list/network = list()
 	var/list/available_networks = list()
 	var/list/watchers = list() //who's using the console, associated with the camera they're on.
@@ -16,7 +16,7 @@
 /obj/machinery/computer/security/New() // Lists existing networks and their required access. Format: available_networks[<name>] = list(<access>)
 	generate_network_access()
 	..()
-	
+
 /obj/machinery/computer/security/proc/generate_network_access()
 	available_networks["SS13"] =              list(access_hos,access_captain)
 	available_networks["Telecomms"] =         list(access_hos,access_captain)
@@ -39,7 +39,7 @@
 	available_networks["ERT"] =               list(access_cent_specops_commander,access_cent_commander)
 	available_networks["CentComm"] =          list(access_cent_security,access_cent_commander)
 	available_networks["Thunderdome"] =       list(access_cent_thunder,access_cent_commander)
-	
+
 /obj/machinery/computer/security/Destroy()
 	if(watchers.len)
 		for(var/mob/M in watchers)
@@ -58,11 +58,11 @@
 		user.unset_machine()
 		return
 	return 1
-			
+
 /obj/machinery/computer/security/on_unset_machine(mob/user)
 	watchers.Remove(user)
 	user.reset_perspective(null)
-	
+
 /obj/machinery/computer/security/attack_hand(mob/user)
 	if(stat || ..())
 		user.unset_machine()
@@ -83,7 +83,7 @@
 		attack_hand(user)
 	else
 		attack_hand(user)
-		
+
 /obj/machinery.computer/security/proc/get_user_access(mob/user)
 	var/list/access = list()
 	if(ishuman(user))
@@ -105,8 +105,8 @@
 		ui.add_template("mapHeader", "sec_camera_map_header.tmpl")
 
 		ui.open()
-		
-/obj/machinery/computer/security/ui_data(mob/user, datum/topic_state/state = default_state)
+
+/obj/machinery/computer/security/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	var/list/cameras = list()
@@ -126,7 +126,7 @@
 				cameras.Swap(j, j + 1)
 
 	data["cameras"] = cameras
-	
+
 	var/list/access = get_user_access(user)
 	if(emagged)
 		access = get_all_accesses() // Assume captain level access when emagged
@@ -149,8 +149,8 @@
 	data["current"] = null
 	if(watchers[user])
 		var/obj/machinery/camera/watched = watchers[user]
-		data["current"] = watched.nano_structure() 
-		
+		data["current"] = watched.nano_structure()
+
 	return data
 
 /obj/machinery/computer/security/Topic(href, href_list)
@@ -162,7 +162,7 @@
 		var/obj/machinery/camera/C = locate(href_list["switchTo"]) in cameranet.cameras
 		if(!C)
 			return 1
-		
+
 		switch_to_camera(usr, C)
 
 	else if(href_list["reset"])
@@ -180,31 +180,31 @@
 				else
 					network += net
 					break
-	
+
 	nanomanager.update_uis(src)
 
 // Check if camera is accessible when jumping
 /obj/machinery/computer/security/proc/can_access_camera(var/obj/machinery/camera/C, var/mob/M)
 	if(CanUseTopic(M, default_state) != STATUS_INTERACTIVE || M.incapacitated() || M.blinded)
 		return 0
-		
+
 	if(isrobot(M))
 		var/list/viewing = viewers(src)
 		if(!viewing.Find(M))
 			return 0
-			
+
 	if(isAI(M))
 		var/mob/living/silicon/ai/A = M
 		if(!A.is_in_chassis())
 			return 0
-			
+
 	if(!issilicon(M) && !Adjacent(M))
 		return 0
-				
+
 	var/list/shared_networks = network & C.network
 	if(!shared_networks.len || !C.can_use())
 		return 0
-		
+
 	return 1
 
 // Switching to cameras
@@ -212,7 +212,7 @@
 	if(!can_access_camera(C, user))
 		user.unset_machine()
 		return 1
-	
+
 	if(isAI(user))
 		var/mob/living/silicon/ai/A = user
 		A.eyeobj.setLoc(get_turf(C))
@@ -226,12 +226,12 @@
 /obj/machinery/computer/security/proc/jump_on_click(var/mob/user, var/A)
 	if(user.machine != src)
 		return
-		
+
 	var/obj/machinery/camera/jump_to
-	
+
 	if(istype(A, /obj/machinery/camera))
 		jump_to = A
-		
+
 	else if(ismob(A))
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = A
@@ -239,11 +239,11 @@
 		else if(isrobot(A))
 			var/mob/living/silicon/robot/R = A
 			jump_to = R.camera
-			
+
 	else if(isobj(A))
 		var/obj/O = A
 		jump_to = locate() in O
-		
+
 	else if(isturf(A))
 		var/best_dist = INFINITY
 		for(var/obj/machinery/camera/camera in get_area(A))
@@ -255,10 +255,10 @@
 			if(dist < best_dist)
 				best_dist = dist
 				jump_to = camera
-				
+
 	if(isnull(jump_to))
 		return
-		
+
 	if(can_access_camera(jump_to, user))
 		switch_to_camera(user, jump_to)
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -181,7 +181,7 @@ var/time_last_changed_position = 0
 		ui = new(user, src, ui_key, "identification_computer.tmpl", src.name, 775, 700)
 		ui.open()
 
-/obj/machinery/computer/card/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/card/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["src"] = UID()
 	data["station_name"] = station_name()

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -127,7 +127,7 @@
 		ui = new(user, src, ui_key, "cloning_console.tmpl", "Cloning Console UI", 640, 520)
 		ui.open()
 
-/obj/machinery/computer/cloning/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/cloning/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["menu"] = src.menu
 	data["scanner"] = sanitize("[src.scanner]")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -334,7 +334,7 @@
 		// open the new ui window
 		ui.open()
 
-/obj/machinery/computer/communications/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/communications/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["is_ai"]         = isAI(user)||isrobot(user)
 	data["menu_state"]    = data["is_ai"] ? ai_menu_state : menu_state

--- a/code/game/machinery/computer/pod_tracking_console.dm
+++ b/code/game/machinery/computer/pod_tracking_console.dm
@@ -20,7 +20,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/podtracker/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/podtracker/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	var/list/pods[0]
 	for(var/obj/item/device/spacepod_equipment/misc/tracker/TR in world)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -41,7 +41,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/robotics/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/robotics/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	var/list/robots = get_cyborgs(user)
 	if(robots.len)

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -190,7 +190,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/atmospherics/unary/cryo_cell/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/atmospherics/unary/cryo_cell/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["isOperating"] = on
 	data["hasOccupant"] = occupant ? 1 : 0

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -566,7 +566,7 @@ About the new airlock wires panel:
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/door/airlock/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/door/airlock/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["main_power_loss"]		= round(main_power_lost_until 	> 0 ? max(main_power_lost_until - world.time,	0) / 10 : main_power_lost_until,	1)

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -27,7 +27,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data = list(
@@ -83,7 +83,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data = list(
@@ -146,7 +146,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/embedded_controller/radio/airlock/access_controller/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/embedded_controller/radio/airlock/access_controller/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data = list(

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -180,7 +180,7 @@ FIRE ALARM
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/firealarm/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/firealarm/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	var/area/A = get_area(src)

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -135,7 +135,7 @@
 		ui = new(user, src, ui_key, "poolcontroller.tmpl", "Pool Controller Interface", 520, 410)
 		ui.open()
 
-/obj/machinery/poolcontroller/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/poolcontroller/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["currentTemp"] = temperature

--- a/code/game/machinery/portable_tag_turret.dm
+++ b/code/game/machinery/portable_tag_turret.dm
@@ -49,7 +49,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/porta_turret/tag/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/porta_turret/tag/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["access"] = !isLocked(user)
 	data["locked"] = locked

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -200,7 +200,7 @@ var/list/turret_icons
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/porta_turret/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/porta_turret/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["access"] = !isLocked(user)
 	data["screen"] = screen

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -115,7 +115,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/requests_console/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/requests_console/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["department"] = department

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -28,7 +28,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/slot_machine/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/slot_machine/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["working"] = working

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -75,7 +75,7 @@
 		ui = new(user, src, ui_key, "teleporter_console.tmpl", "Teleporter Console UI", 400, 400)
 		ui.open()
 
-/obj/machinery/computer/teleporter/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/teleporter/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["powerstation"] = power_station
 	if(power_station)

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -125,7 +125,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/turretid/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/turretid/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["access"] = !isLocked(user)
 	data["locked"] = locked

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -416,7 +416,7 @@
 		ui = new(user, src, ui_key, "vending_machine.tmpl", src.name, 440, 600)
 		ui.open()
 
-/obj/machinery/vending/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/vending/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/list/data = list()
 	if(currently_vending)
 		data["mode"] = 1

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -155,7 +155,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/mech_bay_power_console/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/mech_bay_power_console/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	if(!recharge_port)
 		reconnect()

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -23,7 +23,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/mecha/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/mecha/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["screen"] = screen
 	if(screen == 0)

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -48,7 +48,7 @@
 		ui.set_auto_update(1)
 
 
-/obj/item/device/aicard/ui_data(mob/user, datum/topic_state/state = inventory_state)
+/obj/item/device/aicard/ui_data(mob/user, ui_key = "main", datum/topic_state/state = inventory_state)
 	var/data[0]
 
 	var/mob/living/silicon/ai/AI = locate() in src

--- a/code/game/objects/items/devices/guitar.dm
+++ b/code/game/objects/items/devices/guitar.dm
@@ -33,8 +33,8 @@
 
 	song.ui_interact(user, ui_key, ui, force_open)
 
-/obj/item/device/guitar/ui_data(mob/user, datum/topic_state/state = default_state)
-	return song.ui_data(user, state)
+/obj/item/device/guitar/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
+	return song.ui_data(user, ui_key, state)
 
 /obj/item/device/guitar/Topic(href, href_list)
 	song.Topic(href, href_list)

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -105,7 +105,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/item/device/radio/electropack/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/item/device/radio/electropack/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["power"] = on

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -114,7 +114,7 @@ var/global/list/default_medbay_channels = list(
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/item/device/radio/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/item/device/radio/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["mic_status"] = broadcasting
@@ -757,7 +757,7 @@ var/global/list/default_medbay_channels = list(
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/item/device/radio/borg/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/item/device/radio/borg/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["mic_status"] = broadcasting

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -101,7 +101,7 @@
 		// auto update every Master Controller tick
 		//ui.set_auto_update(1)
 
-/obj/item/device/transfer_valve/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/item/device/transfer_valve/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["attachmentOne"] = tank_one ? tank_one.name : null

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -198,7 +198,7 @@ var/list/world_uplinks = list()
 		// open the new ui window
 		ui.open()
 
-/obj/item/device/uplink/hidden/ui_data(mob/user, datum/topic_state/state = inventory_state)
+/obj/item/device/uplink/hidden/ui_data(mob/user, ui_key = "main", datum/topic_state/state = inventory_state)
 	var/data[0]
 
 	data["welcome"] = welcome

--- a/code/game/objects/items/devices/violin.dm
+++ b/code/game/objects/items/devices/violin.dm
@@ -38,8 +38,8 @@
 
 	song.ui_interact(user, ui_key, ui, force_open)
 
-/obj/item/device/violin/ui_data(mob/user, datum/topic_state/state = default_state)
-	return song.ui_data(user, state)
+/obj/item/device/violin/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
+	return song.ui_data(user, ui_key, state)
 
 /obj/item/device/violin/Topic(href, href_list)
 	song.Topic(href, href_list)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -89,7 +89,7 @@ RCD
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/item/weapon/rcd/ui_data(mob/user, datum/topic_state/state = inventory_state)
+/obj/item/weapon/rcd/ui_data(mob/user, ui_key = "main", datum/topic_state/state = inventory_state)
 	var/data[0]
 	data["mode"] = mode
 	data["door_type"] = door_type

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -152,7 +152,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/item/weapon/tank/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/item/weapon/tank/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/using_internal
 	if(iscarbon(loc))
 		var/mob/living/carbon/C = loc

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -122,7 +122,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/datum/song/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/song/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["lines"] = lines
@@ -296,8 +296,8 @@
 
 	song.ui_interact(user, ui_key, ui, force_open)
 
-/obj/structure/piano/ui_data(mob/user, datum/topic_state/state = default_state)
-	return song.ui_data(user, state)
+/obj/structure/piano/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
+	return song.ui_data(user, ui_key, state)
 
 /obj/structure/piano/Topic(href, href_list)
 	song.Topic(href, href_list)

--- a/code/modules/awaymissions/bluespaceartillery.dm
+++ b/code/modules/awaymissions/bluespaceartillery.dm
@@ -24,7 +24,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/computer/artillerycontrol/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/artillerycontrol/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	var/time_to_wait = round(reload_cooldown - ((world.time / 10) - last_fire), 1)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -514,7 +514,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/item/weapon/rig/ui_data(mob/user, datum/topic_state/state = inventory_state)
+/obj/item/weapon/rig/ui_data(mob/user, ui_key = "main", datum/topic_state/state = inventory_state)
 	var/data[0]
 
 	data["primarysystem"] = null

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -83,7 +83,7 @@
 		ui = new(user, src, ui_key, "accounts_terminal.tmpl", src.name, 400, 640)
 		ui.open()
 
-/obj/machinery/computer/account_database/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/account_database/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["src"] = UID()

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -322,7 +322,7 @@
 		ui = new(user, src, ui_key, "smartfridge.tmpl", name, 400, 500)
 		ui.open()
 
-/obj/machinery/smartfridge/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/smartfridge/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["contents"] = null

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -166,7 +166,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/botany/extractor/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/botany/extractor/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	var/list/geneMasks[0]
@@ -318,7 +318,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/botany/editor/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/botany/editor/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["activity"] = active

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -114,8 +114,6 @@
 		C.toff = 1
 	..()
 
-/mob/living/silicon/pai/Login()
-	..()
 
 // this function shows the information about being silenced as a pAI in the Status panel
 /mob/living/silicon/pai/proc/show_silenced()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -41,7 +41,12 @@ var/global/list/default_pai_software = list()
 	if(ui_key != "main")
 		var/datum/pai_software/S = software[ui_key]
 		if(S && !S.toggle)
-			S.on_ui_interact(src, ui, force_open)
+			ui = nanomanager.try_update_ui(user, src, S.id, ui, force_open)
+			if(!ui)
+				ui = new(user, src, S.id, S.template_file, S.ui_title, S.ui_width, S.ui_height, state = state)
+				ui.open()
+				if(S.autoupdate)
+					ui.set_auto_update(1)
 		else
 			if(ui)
 				ui.set_status(STATUS_CLOSE, 0)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -58,7 +58,7 @@ var/global/list/default_pai_software = list()
 		ui.open()
 		ui.set_auto_update(1)
 
-/mob/living/silicon/pai/ui_data(mob/user, datum/topic_state/state = self_state)
+/mob/living/silicon/pai/ui_data(mob/user, ui_key = "main", datum/topic_state/state = self_state)
 	var/data[0]
 
 	// Software we have bought

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -61,6 +61,12 @@ var/global/list/default_pai_software = list()
 /mob/living/silicon/pai/ui_data(mob/user, ui_key = "main", datum/topic_state/state = self_state)
 	var/data[0]
 
+	if(ui_key != "main")
+		var/datum/pai_software/S = software[ui_key]
+		if(S && !S.toggle)
+			return S.on_ui_data(user, state)
+		log_runtime(EXCEPTION("Unrecognized/invalid pAI UI state '[ui_key]'"), src)
+		return
 	// Software we have bought
 	var/bought_software[0]
 	// Software we have not bought

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -14,7 +14,7 @@
 
 	// Vars for pAI nanoUI handling
 	var/autoupdate = 0
-	var/template_file = ""
+	var/template_file = "oops"
 	var/ui_title = "somebody forgot to set this"
 	var/ui_width = 450
 	var/ui_height = 600

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -19,9 +19,6 @@
 	var/ui_width = 450
 	var/ui_height = 600
 
-/datum/pai_software/proc/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		return
-
 /datum/pai_software/proc/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	return list()
 
@@ -38,6 +35,10 @@
 	toggle = 0
 	default = 1
 
+	template_file = "pai_directives.tmpl"
+	ui_title = "pAI Directives"
+	autoupdate = 1
+
 /datum/pai_software/directives/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -47,14 +48,6 @@
 	data["supplemental"] = user.pai_laws
 
 	return data
-
-/datum/pai_software/directives/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_directives.tmpl", "pAI Directives", 450, 600)
-		ui.open()
-		ui.set_auto_update(1)
 
 /datum/pai_software/directives/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
@@ -96,6 +89,11 @@
 	toggle = 0
 	default = 1
 
+	template_file = "pai_radio.tmpl"
+	ui_title = "Radio Configuration"
+	ui_width = 300
+	ui_height = 150
+
 /datum/pai_software/radio_config/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -114,12 +112,6 @@
 
 	return data
 
-/datum/pai_software/radio_config/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui = null, force_open = 1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		ui = new(user, user, id, "pai_radio.tmpl", "Radio Configuration", 300, 150)
-		ui.open()
-
 /datum/pai_software/radio_config/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
 	if(!istype(P)) return
@@ -133,6 +125,10 @@
 	id = "manifest"
 	toggle = 0
 
+	autoupdate = 1
+	template_file = "pai_manifest.tmpl"
+	ui_title = "Crew Manifest"
+
 /datum/pai_software/crew_manifest/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -141,19 +137,15 @@
 
 	return data
 
-/datum/pai_software/crew_manifest/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_manifest.tmpl", "Crew Manifest", 450, 600)
-		ui.open()
-		ui.set_auto_update(1)
-
 /datum/pai_software/messenger
 	name = "Digital Messenger"
 	ram_cost = 5
 	id = "messenger"
 	toggle = 0
+
+	autoupdate = 1
+	template_file = "pai_messenger.tmpl"
+	ui_title = "Digital Messenger"
 
 /datum/pai_software/messenger/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
@@ -204,14 +196,6 @@
 
 	return data
 
-/datum/pai_software/messenger/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_messenger.tmpl", "Digital Messenger", 450, 600)
-		ui.open()
-		ui.set_auto_update(1)
-
 /datum/pai_software/messenger/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
 	if(!istype(P)) return
@@ -247,6 +231,10 @@
 	ram_cost = 5
 	id = "chatroom"
 	toggle = 0
+
+	autoupdate = 1
+	template_file = "pai_chatroom.tmpl"
+	ui_title = "Digital Chatroom"
 
 /datum/pai_software/chatroom/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
@@ -285,14 +273,6 @@
 		data["users"] = users
 
 	return data
-
-/datum/pai_software/chatroom/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_chatroom.tmpl", "Digital Chatroom", 450, 600)
-		ui.open()
-		ui.set_auto_update(1)
 
 /datum/pai_software/chatroom/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
@@ -369,6 +349,11 @@
 	id = "med_records"
 	toggle = 0
 
+	autoupdate = 1
+	template_file = "pai_medrecords.tmpl"
+	ui_title = "Medical Records"
+
+
 /datum/pai_software/med_records/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -388,14 +373,6 @@
 	data["could_not_find"] = user.medical_cannotfind
 
 	return data
-
-/datum/pai_software/med_records/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_medrecords.tmpl", "Medical Records", 450, 600)
-		ui.open()
-		ui.set_auto_update(1)
 
 /datum/pai_software/med_records/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
@@ -425,6 +402,11 @@
 	id = "sec_records"
 	toggle = 0
 
+	autoupdate = 1
+	template_file = "pai_secrecords.tmpl"
+	ui_title = "Security Records"
+
+
 /datum/pai_software/sec_records/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -444,14 +426,6 @@
 	data["could_not_find"] = user.security_cannotfind
 
 	return data
-
-/datum/pai_software/sec_records/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_secrecords.tmpl", "Security Records", 450, 600)
-		ui.open()
-		ui.set_auto_update(1)
 
 /datum/pai_software/sec_records/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
@@ -485,6 +459,12 @@
 	id = "door_jack"
 	toggle = 0
 
+	autoupdate = 1
+	template_file = "pai_doorjack.tmpl"
+	ui_title = "Door Jack"
+	ui_width = 300
+	ui_height = 150
+
 /datum/pai_software/door_jack/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -496,14 +476,6 @@
 	data["aborted"] = user.hack_aborted
 
 	return data
-
-/datum/pai_software/door_jack/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_doorjack.tmpl", "Door Jack", 300, 150)
-		ui.open()
-		ui.set_auto_update(1)
 
 /datum/pai_software/door_jack/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
@@ -563,6 +535,12 @@
 	id = "atmos_sense"
 	toggle = 0
 
+	template_file = "pai_atmosphere.tmpl"
+	ui_title = "Atmosphere Sensor"
+	ui_width = 350
+	ui_height = 300
+
+
 /datum/pai_software/atmosphere_sensor/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -606,13 +584,6 @@
 		data["gas"] = gases
 
 		return data
-
-/datum/pai_software/atmosphere_sensor/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_atmosphere.tmpl", "Atmosphere Sensor", 350, 300)
-		ui.open()
 
 /datum/pai_software/sec_hud
 	name = "Security HUD"
@@ -682,6 +653,11 @@
 	id = "signaller"
 	toggle = 0
 
+	template_file = "pai_signaller.tmpl"
+	ui_title = "Signaller"
+	ui_width = 320
+	ui_height = 150
+
 /datum/pai_software/signaller/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 
@@ -689,13 +665,6 @@
 	data["code"] = user.sradio.code
 
 	return data
-
-/datum/pai_software/signaller/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_signaller.tmpl", "Signaller", 320, 150)
-		ui.open()
 
 /datum/pai_software/signaller/Topic(href, href_list)
 	var/mob/living/silicon/pai/P = usr
@@ -727,6 +696,11 @@
 	id = "bioscan"
 	toggle = 0
 
+	template_file = "pai_bioscan.tmpl"
+	ui_title = "Host Bioscan"
+	ui_width = 400
+	ui_height = 350
+
 /datum/pai_software/host_scan/on_ui_data(mob/living/silicon/pai/user, datum/topic_state/state = self_state)
 	var/data[0]
 	var/mob/living/held = user.loc
@@ -752,11 +726,3 @@
 		data["holder"] = 0
 
 	return data
-
-/datum/pai_software/host_scan/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-	ui = nanomanager.try_update_ui(user, user, id, ui, force_open)
-	if(!ui)
-		// Don't copy-paste this unless you're making a pAI software module!
-		ui = new(user, user, id, "pai_bioscan.tmpl", "Host Bioscan", 400, 350)
-		ui.open()
-		//.set_auto_update(1)

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -12,13 +12,13 @@
 	// Whether pAIs should automatically receive this module at no cost
 	var/default = 0
 
-	proc/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+/datum/pai_software/proc/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
 		return
 
-	proc/toggle(mob/living/silicon/pai/user)
+/datum/pai_software/proc/toggle(mob/living/silicon/pai/user)
 		return
 
-	proc/is_active(mob/living/silicon/pai/user)
+/datum/pai_software/proc/is_active(mob/living/silicon/pai/user)
 		return 0
 
 /datum/pai_software/directives
@@ -28,54 +28,54 @@
 	toggle = 0
 	default = 1
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/directives/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		data["master"] = user.master
-		data["dna"] = user.master_dna
-		data["prime"] = user.pai_law0
-		data["supplemental"] = user.pai_laws
+	data["master"] = user.master
+	data["dna"] = user.master_dna
+	data["prime"] = user.pai_law0
+	data["supplemental"] = user.pai_laws
 
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_directives.tmpl", "pAI Directives", 450, 600)
-			ui.set_initial_data(data)
-			ui.open()
-			ui.set_auto_update(1)
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_directives.tmpl", "pAI Directives", 450, 600)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
 
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P)) return
+/datum/pai_software/directives/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P)) return
 
-		if(href_list["getdna"])
-			var/mob/living/M = P.loc
-			var/count = 0
+	if(href_list["getdna"])
+		var/mob/living/M = P.loc
+		var/count = 0
 
-			// Find the carrier
-			while(!istype(M, /mob/living))
-				if(!M || !M.loc || count > 6)
-					//For a runtime where M ends up in nullspace (similar to bluespace but less colourful)
-					to_chat(P, "You are not being carried by anyone!")
-					return 0
-				M = M.loc
-				count++
+		// Find the carrier
+		while(!istype(M, /mob/living))
+			if(!M || !M.loc || count > 6)
+				//For a runtime where M ends up in nullspace (similar to bluespace but less colourful)
+				to_chat(P, "You are not being carried by anyone!")
+				return 0
+			M = M.loc
+			count++
 
-			// Check the carrier
-			var/answer = input(M, "[P] is requesting a DNA sample from you. Will you allow it to confirm your identity?", "[P] Check DNA", "No") in list("Yes", "No")
-			if(answer == "Yes")
-				var/turf/T = get_turf_or_move(P.loc)
-				for(var/mob/v in viewers(T))
-					v.show_message("<span class='notice'>[M] presses \his thumb against [P].</span>", 3, "<span class='notice'>[P] makes a sharp clicking sound as it extracts DNA material from [M].</span>", 2)
-				var/datum/dna/dna = M.dna
-				to_chat(P, "<font color = red><h3>[M]'s UE string : [dna.unique_enzymes]</h3></font>")
-				if(dna.unique_enzymes == P.master_dna)
-					to_chat(P, "<b>DNA is a match to stored Master DNA.</b>")
-				else
-					to_chat(P, "<b>DNA does not match stored Master DNA.</b>")
+		// Check the carrier
+		var/answer = input(M, "[P] is requesting a DNA sample from you. Will you allow it to confirm your identity?", "[P] Check DNA", "No") in list("Yes", "No")
+		if(answer == "Yes")
+			var/turf/T = get_turf_or_move(P.loc)
+			for(var/mob/v in viewers(T))
+				v.show_message("<span class='notice'>[M] presses \his thumb against [P].</span>", 3, "<span class='notice'>[P] makes a sharp clicking sound as it extracts DNA material from [M].</span>", 2)
+			var/datum/dna/dna = M.dna
+			to_chat(P, "<font color = red><h3>[M]'s UE string : [dna.unique_enzymes]</h3></font>")
+			if(dna.unique_enzymes == P.master_dna)
+				to_chat(P, "<b>DNA is a match to stored Master DNA.</b>")
 			else
-				to_chat(P, "[M] does not seem like \he is going to provide a DNA sample willingly.")
-			return 1
+				to_chat(P, "<b>DNA does not match stored Master DNA.</b>")
+		else
+			to_chat(P, "[M] does not seem like \he is going to provide a DNA sample willingly.")
+		return 1
 
 /datum/pai_software/radio_config
 	name = "Radio Configuration"
@@ -84,35 +84,35 @@
 	toggle = 0
 	default = 1
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui = null, force_open = 1)
-		var/data[0]
+/datum/pai_software/radio_config/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui = null, force_open = 1)
+	var/data[0]
 
-		data["listening"] = user.radio.broadcasting
-		data["frequency"] = format_frequency(user.radio.frequency)
+	data["listening"] = user.radio.broadcasting
+	data["frequency"] = format_frequency(user.radio.frequency)
 
-		var/channels[0]
-		for(var/ch_name in user.radio.channels)
-			var/ch_stat = user.radio.channels[ch_name]
-			var/ch_dat[0]
-			ch_dat["name"] = ch_name
-			// FREQ_LISTENING is const in /obj/item/device/radio
-			ch_dat["listening"] = !!(ch_stat & user.radio.FREQ_LISTENING)
-			channels[++channels.len] = ch_dat
+	var/channels[0]
+	for(var/ch_name in user.radio.channels)
+		var/ch_stat = user.radio.channels[ch_name]
+		var/ch_dat[0]
+		ch_dat["name"] = ch_name
+		// FREQ_LISTENING is const in /obj/item/device/radio
+		ch_dat["listening"] = !!(ch_stat & user.radio.FREQ_LISTENING)
+		channels[++channels.len] = ch_dat
 
-		data["channels"] = channels
+	data["channels"] = channels
 
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			ui = new(user, user, id, "pai_radio.tmpl", "Radio Configuration", 300, 150)
-			ui.set_initial_data(data)
-			ui.open()
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		ui = new(user, user, id, "pai_radio.tmpl", "Radio Configuration", 300, 150)
+		ui.set_initial_data(data)
+		ui.open()
 
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P)) return
+/datum/pai_software/radio_config/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P)) return
 
-		P.radio.Topic(href, href_list)
-		return 1
+	P.radio.Topic(href, href_list)
+	return 1
 
 /datum/pai_software/crew_manifest
 	name = "Crew Manifest"
@@ -120,19 +120,18 @@
 	id = "manifest"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+/datum/pai_software/crew_manifest/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
+	data_core.get_manifest_json()
+	data["manifest"] = PDA_Manifest
 
-		var/data[0]
-		data_core.get_manifest_json()
-		data["manifest"] = PDA_Manifest
-
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_manifest.tmpl", "Crew Manifest", 450, 600)
-			ui.set_initial_data(data)
-			ui.open()
-			ui.set_auto_update(1)
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_manifest.tmpl", "Crew Manifest", 450, 600)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
 
 /datum/pai_software/messenger
 	name = "Digital Messenger"
@@ -140,88 +139,88 @@
 	id = "messenger"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/messenger/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		if(!user.pda)
-			return
-		var/datum/data/pda/app/messenger/M = user.pda.find_program(/datum/data/pda/app/messenger)
+	if(!user.pda)
+		return
+	var/datum/data/pda/app/messenger/M = user.pda.find_program(/datum/data/pda/app/messenger)
+	if(!M)
+		return
+
+	data["receiver_off"] = M.toff
+	data["ringer_off"] = M.notify_silent
+	data["current_ref"] = null
+	data["current_name"] = user.current_pda_messaging
+
+	var/pdas[0]
+	if(!M.toff)
+		for(var/obj/item/device/pda/P in PDAs)
+			var/datum/data/pda/app/messenger/PM = P.find_program(/datum/data/pda/app/messenger)
+
+			if(P == user.pda || !PM || !PM.can_receive())
+				continue
+			var/pda[0]
+			pda["name"] = "[P]"
+			pda["owner"] = "[P.owner]"
+			pda["ref"] = "\ref[P]"
+			if(P.owner == user.current_pda_messaging)
+				data["current_ref"] = "\ref[P]"
+			pdas[++pdas.len] = pda
+
+	data["pdas"] = pdas
+
+	var/messages[0]
+	if(user.current_pda_messaging)
+		for(var/index in M.tnote)
+			if(index["owner"] != user.current_pda_messaging)
+				continue
+			var/msg[0]
+			var/sent = index["sent"]
+			msg["sent"] = sent ? 1 : 0
+			msg["target"] = index["owner"]
+			msg["message"] = index["message"]
+			messages[++messages.len] = msg
+
+	data["messages"] = messages
+
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_messenger.tmpl", "Digital Messenger", 450, 600)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
+
+/datum/pai_software/messenger/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P)) return
+
+	if(!isnull(P.pda))
+		var/datum/data/pda/app/messenger/M = P.pda.find_program(/datum/data/pda/app/messenger)
 		if(!M)
 			return
 
-		data["receiver_off"] = M.toff
-		data["ringer_off"] = M.notify_silent
-		data["current_ref"] = null
-		data["current_name"] = user.current_pda_messaging
+		if(href_list["toggler"])
+			M.toff = href_list["toggler"] != "1"
+			return 1
+		else if(href_list["ringer"])
+			M.notify_silent = href_list["ringer"] != "1"
+			return 1
+		else if(href_list["select"])
+			var/s = href_list["select"]
+			if(s == "*NONE*")
+				P.current_pda_messaging = null
+			else
+				P.current_pda_messaging = s
+			return 1
+		else if(href_list["target"])
+			if(P.silence_time)
+				return alert("Communications circuits remain uninitialized.")
 
-		var/pdas[0]
-		if(!M.toff)
-			for(var/obj/item/device/pda/P in PDAs)
-				var/datum/data/pda/app/messenger/PM = P.find_program(/datum/data/pda/app/messenger)
-
-				if(P == user.pda || !PM || !PM.can_receive())
-					continue
-				var/pda[0]
-				pda["name"] = "[P]"
-				pda["owner"] = "[P.owner]"
-				pda["ref"] = "\ref[P]"
-				if(P.owner == user.current_pda_messaging)
-					data["current_ref"] = "\ref[P]"
-				pdas[++pdas.len] = pda
-
-		data["pdas"] = pdas
-
-		var/messages[0]
-		if(user.current_pda_messaging)
-			for(var/index in M.tnote)
-				if(index["owner"] != user.current_pda_messaging)
-					continue
-				var/msg[0]
-				var/sent = index["sent"]
-				msg["sent"] = sent ? 1 : 0
-				msg["target"] = index["owner"]
-				msg["message"] = index["message"]
-				messages[++messages.len] = msg
-
-		data["messages"] = messages
-
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_messenger.tmpl", "Digital Messenger", 450, 600)
-			ui.set_initial_data(data)
-			ui.open()
-			ui.set_auto_update(1)
-
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P)) return
-
-		if(!isnull(P.pda))
-			var/datum/data/pda/app/messenger/M = P.pda.find_program(/datum/data/pda/app/messenger)
-			if(!M)
-				return
-
-			if(href_list["toggler"])
-				M.toff = href_list["toggler"] != "1"
-				return 1
-			else if(href_list["ringer"])
-				M.notify_silent = href_list["ringer"] != "1"
-				return 1
-			else if(href_list["select"])
-				var/s = href_list["select"]
-				if(s == "*NONE*")
-					P.current_pda_messaging = null
-				else
-					P.current_pda_messaging = s
-				return 1
-			else if(href_list["target"])
-				if(P.silence_time)
-					return alert("Communications circuits remain uninitialized.")
-
-				var/target = locate(href_list["target"])
-				M.create_message(P, target, 1)
-				return 1
+			var/target = locate(href_list["target"])
+			M.create_message(P, target, 1)
+			return 1
 
 /datum/pai_software/chatroom
 	name = "Digital Chatroom"
@@ -229,116 +228,116 @@
 	id = "chatroom"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/chatroom/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		if(!user.pda)
-			return
-		var/datum/data/pda/app/chatroom/M = user.pda.find_program(/datum/data/pda/app/chatroom)
+	if(!user.pda)
+		return
+	var/datum/data/pda/app/chatroom/M = user.pda.find_program(/datum/data/pda/app/chatroom)
+	if(!M)
+		return
+
+	data["receiver_off"] = M.toff
+	data["ringer_off"] = M.notify_silent
+
+	var/list/rooms[0]
+	for(var/datum/chatroom/c in chatrooms)
+		if((M in c.users) || (M in c.invites) || c.is_public)
+			rooms += list(list(name = "[c]", ref = "\ref[c]"))
+	data["rooms"] = rooms
+
+	if(M.disconnected || !M.messaging_available(1))
+		data["disconnected"] = 1
+	else if(M.current_room)
+		data["current_room"] = "\ref[M.current_room]"
+		data["current_room_name"] = M.current_room.name
+		data["current_room_topic"] = M.current_room.topic
+		data["messages"] = M.current_room.logs
+		var/list/users[0]
+		for(var/U in M.current_room.users)
+			var/datum/data/pda/app/chatroom/ch = U
+			users += "<span class='good'>[ch.pda.owner]</span>"
+		for(var/U in (M.current_room.invites - M.current_room.users))
+			var/datum/data/pda/app/chatroom/ch = U
+			users += "<span class='average'>[ch.pda.owner]</span>"
+		data["users"] = users
+
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_chatroom.tmpl", "Digital Chatroom", 450, 600)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
+
+/datum/pai_software/chatroom/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P))
+		return
+
+	if(!isnull(P.pda) && P.pda.can_use())
+		var/datum/data/pda/app/chatroom/M = P.pda.find_program(/datum/data/pda/app/chatroom)
 		if(!M)
 			return
 
-		data["receiver_off"] = M.toff
-		data["ringer_off"] = M.notify_silent
-
-		var/list/rooms[0]
-		for(var/datum/chatroom/c in chatrooms)
-			if((M in c.users) || (M in c.invites) || c.is_public)
-				rooms += list(list(name = "[c]", ref = "\ref[c]"))
-		data["rooms"] = rooms
-
-		if(M.disconnected || !M.messaging_available(1))
-			data["disconnected"] = 1
-		else if(M.current_room)
-			data["current_room"] = "\ref[M.current_room]"
-			data["current_room_name"] = M.current_room.name
-			data["current_room_topic"] = M.current_room.topic
-			data["messages"] = M.current_room.logs
-			var/list/users[0]
-			for(var/U in M.current_room.users)
-				var/datum/data/pda/app/chatroom/ch = U
-				users += "<span class='good'>[ch.pda.owner]</span>"
-			for(var/U in (M.current_room.invites - M.current_room.users))
-				var/datum/data/pda/app/chatroom/ch = U
-				users += "<span class='average'>[ch.pda.owner]</span>"
-			data["users"] = users
-
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_chatroom.tmpl", "Digital Chatroom", 450, 600)
-			ui.set_initial_data(data)
-			ui.open()
-			ui.set_auto_update(1)
-
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P))
-			return
-
-		if(!isnull(P.pda) && P.pda.can_use())
-			var/datum/data/pda/app/chatroom/M = P.pda.find_program(/datum/data/pda/app/chatroom)
-			if(!M)
-				return
-
-			if(href_list["toggler"])
-				M.toff = href_list["toggler"] != "1"
+		if(href_list["toggler"])
+			M.toff = href_list["toggler"] != "1"
+			return 1
+		else if(href_list["ringer"])
+			M.notify_silent = href_list["ringer"] != "1"
+			return 1
+		else if(href_list["topic"])
+			if(!M.current_room)
 				return 1
-			else if(href_list["ringer"])
-				M.notify_silent = href_list["ringer"] != "1"
-				return 1
-			else if(href_list["topic"])
-				if(!M.current_room)
-					return 1
 
-				var/t = input("Enter new topic:", M.current_room, M.current_room.topic) as text|null
+			var/t = input("Enter new topic:", M.current_room, M.current_room.topic) as text|null
+			spawn()
+				if(!t || !M.check_messaging_available() || !P.pda.can_use())
+					return
+				t = sanitize(copytext(t, 1, MAX_MESSAGE_LEN))
+				t = readd_quotes(t)
+				if(!t)
+					return
+
+				M.current_room.topic = t
+				M.current_room.announce(M, "Topic has been changed to '[t]' by [P.pda.owner].")
+			return 1
+		else if(href_list["select"])
+			var/s = href_list["select"]
+			if(s == "*NONE*")
+				M.current_room = null
+			else
+				var/datum/chatroom/CR = locate(s)
+				if(istype(CR))
+					if(!(M in CR.users))
+						if(!CR.login(M))
+							return
+					M.current_room = CR
+			return 1
+		else if(href_list["target"])
+			if(P.silence_time)
+				return alert("Communications circuits remain uninitialized.")
+
+			var/datum/chatroom/target = locate(href_list["target"])
+			if(istype(target))
+				if(!(M in target.users))
+					if(!target.login(M))
+						return
+				var/t = input("Please enter message", target) as text|null
 				spawn()
-					if(!t || !M.check_messaging_available() || !P.pda.can_use())
+					if(!t || !M.check_messaging_available())
 						return
 					t = sanitize(copytext(t, 1, MAX_MESSAGE_LEN))
 					t = readd_quotes(t)
-					if(!t)
+					if(!t || !P.pda.can_use())
 						return
 
-					M.current_room.topic = t
-					M.current_room.announce(M, "Topic has been changed to '[t]' by [P.pda.owner].")
-				return 1
-			else if(href_list["select"])
-				var/s = href_list["select"]
-				if(s == "*NONE*")
-					M.current_room = null
-				else
-					var/datum/chatroom/CR = locate(s)
-					if(istype(CR))
-						if(!(M in CR.users))
-							if(!CR.login(M))
-								return
-						M.current_room = CR
-				return 1
-			else if(href_list["target"])
-				if(P.silence_time)
-					return alert("Communications circuits remain uninitialized.")
-
-				var/datum/chatroom/target = locate(href_list["target"])
-				if(istype(target))
-					if(!(M in target.users))
-						if(!target.login(M))
-							return
-					var/t = input("Please enter message", target) as text|null
-					spawn()
-						if(!t || !M.check_messaging_available())
-							return
-						t = sanitize(copytext(t, 1, MAX_MESSAGE_LEN))
-						t = readd_quotes(t)
-						if(!t || !P.pda.can_use())
-							return
-
-						target.post(M, t)
-				return 1
-			else if(href_list["reconnect"])
-				spawn()
-					M.messaging_available()
-				return 1
+					target.post(M, t)
+			return 1
+		else if(href_list["reconnect"])
+			spawn()
+				M.messaging_available()
+			return 1
 
 /datum/pai_software/med_records
 	name = "Medical Records"
@@ -346,53 +345,53 @@
 	id = "med_records"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/med_records/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		var/records[0]
-		for(var/datum/data/record/general in sortRecord(data_core.general))
-			var/record[0]
-			record["name"] = general.fields["name"]
-			record["ref"] = "\ref[general]"
-			records[++records.len] = record
+	var/records[0]
+	for(var/datum/data/record/general in sortRecord(data_core.general))
+		var/record[0]
+		record["name"] = general.fields["name"]
+		record["ref"] = "\ref[general]"
+		records[++records.len] = record
 
-		data["records"] = records
+	data["records"] = records
 
-		var/datum/data/record/G = user.medicalActive1
-		var/datum/data/record/M = user.medicalActive2
-		data["general"] = G ? G.fields : null
-		data["medical"] = M ? M.fields : null
-		data["could_not_find"] = user.medical_cannotfind
+	var/datum/data/record/G = user.medicalActive1
+	var/datum/data/record/M = user.medicalActive2
+	data["general"] = G ? G.fields : null
+	data["medical"] = M ? M.fields : null
+	data["could_not_find"] = user.medical_cannotfind
 
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_medrecords.tmpl", "Medical Records", 450, 600)
-			ui.set_initial_data(data)
-			ui.open()
-			ui.set_auto_update(1)
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_medrecords.tmpl", "Medical Records", 450, 600)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
 
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P)) return
+/datum/pai_software/med_records/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P)) return
 
-		if(href_list["select"])
-			var/datum/data/record/record = locate(href_list["select"])
-			if(record)
-				var/datum/data/record/R = record
-				var/datum/data/record/M = null
-				if(!( data_core.general.Find(R) ))
-					P.medical_cannotfind = 1
-				else
-					P.medical_cannotfind = 0
-					for(var/datum/data/record/E in data_core.medical)
-						if((E.fields["name"] == R.fields["name"] || E.fields["id"] == R.fields["id"]))
-							M = E
-					P.medicalActive1 = R
-					P.medicalActive2 = M
-			else
+	if(href_list["select"])
+		var/datum/data/record/record = locate(href_list["select"])
+		if(record)
+			var/datum/data/record/R = record
+			var/datum/data/record/M = null
+			if(!( data_core.general.Find(R) ))
 				P.medical_cannotfind = 1
-			return 1
+			else
+				P.medical_cannotfind = 0
+				for(var/datum/data/record/E in data_core.medical)
+					if((E.fields["name"] == R.fields["name"] || E.fields["id"] == R.fields["id"]))
+						M = E
+				P.medicalActive1 = R
+				P.medicalActive2 = M
+		else
+			P.medical_cannotfind = 1
+		return 1
 
 /datum/pai_software/sec_records
 	name = "Security Records"
@@ -400,57 +399,57 @@
 	id = "sec_records"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/sec_records/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		var/records[0]
-		for(var/datum/data/record/general in sortRecord(data_core.general))
-			var/record[0]
-			record["name"] = general.fields["name"]
-			record["ref"] = "\ref[general]"
-			records[++records.len] = record
+	var/records[0]
+	for(var/datum/data/record/general in sortRecord(data_core.general))
+		var/record[0]
+		record["name"] = general.fields["name"]
+		record["ref"] = "\ref[general]"
+		records[++records.len] = record
 
-		data["records"] = records
+	data["records"] = records
 
-		var/datum/data/record/G = user.securityActive1
-		var/datum/data/record/S = user.securityActive2
-		data["general"] = G ? G.fields : null
-		data["security"] = S ? S.fields : null
-		data["could_not_find"] = user.security_cannotfind
+	var/datum/data/record/G = user.securityActive1
+	var/datum/data/record/S = user.securityActive2
+	data["general"] = G ? G.fields : null
+	data["security"] = S ? S.fields : null
+	data["could_not_find"] = user.security_cannotfind
 
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_secrecords.tmpl", "Security Records", 450, 600)
-			ui.set_initial_data(data)
-			ui.open()
-			ui.set_auto_update(1)
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_secrecords.tmpl", "Security Records", 450, 600)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
 
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P)) return
+/datum/pai_software/sec_records/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P)) return
 
-		if(href_list["select"])
-			var/datum/data/record/record = locate(href_list["select"])
-			if(record)
-				var/datum/data/record/R = record
-				var/datum/data/record/S = null
-				if(!( data_core.general.Find(R) ))
-					P.securityActive1 = null
-					P.securityActive2 = null
-					P.security_cannotfind = 1
-				else
-					P.security_cannotfind = 0
-					for(var/datum/data/record/E in data_core.security)
-						if((E.fields["name"] == R.fields["name"] || E.fields["id"] == R.fields["id"]))
-							S = E
-					P.securityActive1 = R
-					P.securityActive2 = S
-			else
+	if(href_list["select"])
+		var/datum/data/record/record = locate(href_list["select"])
+		if(record)
+			var/datum/data/record/R = record
+			var/datum/data/record/S = null
+			if(!( data_core.general.Find(R) ))
 				P.securityActive1 = null
 				P.securityActive2 = null
 				P.security_cannotfind = 1
-			return 1
+			else
+				P.security_cannotfind = 0
+				for(var/datum/data/record/E in data_core.security)
+					if((E.fields["name"] == R.fields["name"] || E.fields["id"] == R.fields["id"]))
+						S = E
+				P.securityActive1 = R
+				P.securityActive2 = S
+		else
+			P.securityActive1 = null
+			P.securityActive2 = null
+			P.security_cannotfind = 1
+		return 1
 
 /datum/pai_software/door_jack
 	name = "Door Jack"
@@ -458,44 +457,44 @@
 	id = "door_jack"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/door_jack/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		data["cable"] = user.cable != null
-		data["machine"] = user.cable && (user.cable.machine != null)
-		data["inprogress"] = user.hackdoor != null
-		data["progress_a"] = round(user.hackprogress / 10)
-		data["progress_b"] = user.hackprogress % 10
-		data["aborted"] = user.hack_aborted
+	data["cable"] = user.cable != null
+	data["machine"] = user.cable && (user.cable.machine != null)
+	data["inprogress"] = user.hackdoor != null
+	data["progress_a"] = round(user.hackprogress / 10)
+	data["progress_b"] = user.hackprogress % 10
+	data["aborted"] = user.hack_aborted
 
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_doorjack.tmpl", "Door Jack", 300, 150)
-			ui.set_initial_data(data)
-			ui.open()
-			ui.set_auto_update(1)
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_doorjack.tmpl", "Door Jack", 300, 150)
+		ui.set_initial_data(data)
+		ui.open()
+		ui.set_auto_update(1)
 
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P)) return
+/datum/pai_software/door_jack/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P)) return
 
-		if(href_list["jack"])
-			if(P.cable && P.cable.machine)
-				P.hackdoor = P.cable.machine
-				P.hackloop()
-			return 1
-		else if(href_list["cancel"])
-			P.hackdoor = null
-			return 1
-		else if(href_list["cable"])
-			var/turf/T = get_turf_or_move(P.loc)
-			P.hack_aborted = 0
-			P.cable = new /obj/item/weapon/pai_cable(T)
-			for(var/mob/M in viewers(T))
-				M.show_message("<span class='warning'>A port on [P] opens to reveal [P.cable], which promptly falls to the floor.</span>", 3,
-				               "<span class='warning'>You hear the soft click of something light and hard falling to the ground.</span>", 2)
-			return 1
+	if(href_list["jack"])
+		if(P.cable && P.cable.machine)
+			P.hackdoor = P.cable.machine
+			P.hackloop()
+		return 1
+	else if(href_list["cancel"])
+		P.hackdoor = null
+		return 1
+	else if(href_list["cable"])
+		var/turf/T = get_turf_or_move(P.loc)
+		P.hack_aborted = 0
+		P.cable = new /obj/item/weapon/pai_cable(T)
+		for(var/mob/M in viewers(T))
+			M.show_message("<span class='warning'>A port on [P] opens to reveal [P.cable], which promptly falls to the floor.</span>", 3,
+			               "<span class='warning'>You hear the soft click of something light and hard falling to the ground.</span>", 2)
+		return 1
 
 /mob/living/silicon/pai/proc/hackloop()
 	var/turf/T = get_turf_or_move(src.loc)
@@ -534,66 +533,67 @@
 	id = "atmos_sense"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/atmosphere_sensor/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		var/turf/T = get_turf_or_move(user.loc)
-		if(!T)
-			data["reading"] = 0
-			data["pressure"] = 0
-			data["temperature"] = 0
-			data["temperatureC"] = 0
-			data["gas"] = list()
-		else
-			var/datum/gas_mixture/env = T.return_air()
-			data["reading"] = 1
-			data["pressure"] = env.return_pressure()
-			data["temperature"] = round(env.temperature)
-			data["temperatureC"] = round(env.temperature-T0C)
+	var/turf/T = get_turf_or_move(user.loc)
+	if(!T)
+		data["reading"] = 0
+		data["pressure"] = 0
+		data["temperature"] = 0
+		data["temperatureC"] = 0
+		data["gas"] = list()
+	else
+		var/datum/gas_mixture/env = T.return_air()
+		data["reading"] = 1
+		data["pressure"] = env.return_pressure()
+		data["temperature"] = round(env.temperature)
+		data["temperatureC"] = round(env.temperature-T0C)
 
-			var/t_moles = env.total_moles()
-			var/gases[0]
-			if(t_moles)
-				var/n2[0]
-				n2["name"] = "Nitrogen"
-				n2["percent"] = round((env.nitrogen/t_moles)*100)
-				var/o2[0]
-				o2["name"] = "Oxygen"
-				o2["percent"] = round((env.oxygen/t_moles)*100)
-				var/co2[0]
-				co2["name"] = "Carbon Dioxide"
-				co2["percent"] = round((env.carbon_dioxide/t_moles)*100)
-				var/plasma[0]
-				plasma["name"] = "Plasma"
-				plasma["percent"] = round((env.toxins/t_moles)*100)
-				var/other[0]
-				other["name"] = "Other"
-				other["percent"] = round(1-((env.oxygen/t_moles)+(env.nitrogen/t_moles)+(env.carbon_dioxide/t_moles)+(env.toxins/t_moles)))
-				gases[++gases.len] = n2
-				gases[++gases.len] = o2
-				gases[++gases.len] = co2
-				gases[++gases.len] = plasma
-				gases[++gases.len] = other
-			data["gas"] = gases
+		var/t_moles = env.total_moles()
+		var/gases[0]
+		if(t_moles)
+			var/n2[0]
+			n2["name"] = "Nitrogen"
+			n2["percent"] = round((env.nitrogen/t_moles)*100)
+			var/o2[0]
+			o2["name"] = "Oxygen"
+			o2["percent"] = round((env.oxygen/t_moles)*100)
+			var/co2[0]
+			co2["name"] = "Carbon Dioxide"
+			co2["percent"] = round((env.carbon_dioxide/t_moles)*100)
+			var/plasma[0]
+			plasma["name"] = "Plasma"
+			plasma["percent"] = round((env.toxins/t_moles)*100)
+			var/other[0]
+			other["name"] = "Other"
+			other["percent"] = round(1-((env.oxygen/t_moles)+(env.nitrogen/t_moles)+(env.carbon_dioxide/t_moles)+(env.toxins/t_moles)))
+			gases[++gases.len] = n2
+			gases[++gases.len] = o2
+			gases[++gases.len] = co2
+			gases[++gases.len] = plasma
+			gases[++gases.len] = other
+		data["gas"] = gases
 
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_atmosphere.tmpl", "Atmosphere Sensor", 350, 300)
-			ui.set_initial_data(data)
-			ui.open()
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_atmosphere.tmpl", "Atmosphere Sensor", 350, 300)
+		ui.set_initial_data(data)
+		ui.open()
 
 /datum/pai_software/sec_hud
 	name = "Security HUD"
 	ram_cost = 20
 	id = "sec_hud"
 
-	toggle(mob/living/silicon/pai/user)
-		user.secHUD = !user.secHUD
-		user.remove_med_sec_hud()
-		if(user.secHUD)
-			user.add_sec_hud()
-	is_active(mob/living/silicon/pai/user)
+/datum/pai_software/sec_hud/toggle(mob/living/silicon/pai/user)
+	user.secHUD = !user.secHUD
+	user.remove_med_sec_hud()
+	if(user.secHUD)
+		user.add_sec_hud()
+
+/datum/pai_software/sec_hud/is_active(mob/living/silicon/pai/user)
 		return user.secHUD
 
 /datum/pai_software/med_hud
@@ -601,48 +601,48 @@
 	ram_cost = 20
 	id = "med_hud"
 
-	toggle(mob/living/silicon/pai/user)
-		user.medHUD = !user.medHUD
-		user.remove_med_sec_hud()
-		if(user.medHUD)
-			user.add_med_hud()
+/datum/pai_software/med_hud/toggle(mob/living/silicon/pai/user)
+	user.medHUD = !user.medHUD
+	user.remove_med_sec_hud()
+	if(user.medHUD)
+		user.add_med_hud()
 
-	is_active(mob/living/silicon/pai/user)
-		return user.medHUD
+/datum/pai_software/med_hud/is_active(mob/living/silicon/pai/user)
+	return user.medHUD
 
 /datum/pai_software/translator
 	name = "Universal Translator"
 	ram_cost = 35
 	id = "translator"
 
-	toggle(mob/living/silicon/pai/user)
-		// 	Galactic Common, Sol Common, Tradeband, Gutter and Trinary are added with New() and are therefore the current default, always active languages
-		user.translator_on = !user.translator_on
-		if(user.translator_on)
-			user.add_language("Sinta'unathi")
-			user.add_language("Siik'tajr")
-			user.add_language("Canilunzt")
-			user.add_language("Skrellian")
-			user.add_language("Vox-pidgin")
-			user.add_language("Rootspeak")
-			user.add_language("Chittin")
-			user.add_language("Bubblish")
-			user.add_language("Orluum")
-			user.add_language("Clownish")
-		else
-			user.remove_language("Sinta'unathi")
-			user.remove_language("Siik'tajr")
-			user.remove_language("Canilunzt")
-			user.remove_language("Skrellian")
-			user.remove_language("Vox-pidgin")
-			user.remove_language("Rootspeak")
-			user.remove_language("Chittin")
-			user.remove_language("Bubblish")
-			user.remove_language("Orluum")
-			user.remove_language("Clownish")
+/datum/pai_software/translator/toggle(mob/living/silicon/pai/user)
+	// 	Galactic Common, Sol Common, Tradeband, Gutter and Trinary are added with New() and are therefore the current default, always active languages
+	user.translator_on = !user.translator_on
+	if(user.translator_on)
+		user.add_language("Sinta'unathi")
+		user.add_language("Siik'tajr")
+		user.add_language("Canilunzt")
+		user.add_language("Skrellian")
+		user.add_language("Vox-pidgin")
+		user.add_language("Rootspeak")
+		user.add_language("Chittin")
+		user.add_language("Bubblish")
+		user.add_language("Orluum")
+		user.add_language("Clownish")
+	else
+		user.remove_language("Sinta'unathi")
+		user.remove_language("Siik'tajr")
+		user.remove_language("Canilunzt")
+		user.remove_language("Skrellian")
+		user.remove_language("Vox-pidgin")
+		user.remove_language("Rootspeak")
+		user.remove_language("Chittin")
+		user.remove_language("Bubblish")
+		user.remove_language("Orluum")
+		user.remove_language("Clownish")
 
-	is_active(mob/living/silicon/pai/user)
-		return user.translator_on
+/datum/pai_software/translator/is_active(mob/living/silicon/pai/user)
+	return user.translator_on
 
 /datum/pai_software/signaller
 	name = "Remote Signaller"
@@ -650,42 +650,42 @@
 	id = "signaller"
 	toggle = 0
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
-		var/data[0]
+/datum/pai_software/signaller/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
 
-		data["frequency"] = format_frequency(user.sradio.frequency)
-		data["code"] = user.sradio.code
+	data["frequency"] = format_frequency(user.sradio.frequency)
+	data["code"] = user.sradio.code
 
-		ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_signaller.tmpl", "Signaller", 320, 150)
-			ui.set_initial_data(data)
-			ui.open()
+	ui = nanomanager.try_update_ui(user, user, id, ui, data, force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_signaller.tmpl", "Signaller", 320, 150)
+		ui.set_initial_data(data)
+		ui.open()
 
-	Topic(href, href_list)
-		var/mob/living/silicon/pai/P = usr
-		if(!istype(P)) return
+/datum/pai_software/signaller/Topic(href, href_list)
+	var/mob/living/silicon/pai/P = usr
+	if(!istype(P)) return
 
-		if(href_list["send"])
-			P.sradio.send_signal("ACTIVATE")
-			for(var/mob/O in hearers(1, P.loc))
-				O.show_message("[bicon(P)] *beep* *beep*", 3, "*beep* *beep*", 2)
-			return 1
+	if(href_list["send"])
+		P.sradio.send_signal("ACTIVATE")
+		for(var/mob/O in hearers(1, P.loc))
+			O.show_message("[bicon(P)] *beep* *beep*", 3, "*beep* *beep*", 2)
+		return 1
 
-		else if(href_list["freq"])
-			var/new_frequency = (P.sradio.frequency + text2num(href_list["freq"]))
-			if(new_frequency < PUBLIC_LOW_FREQ || new_frequency > PUBLIC_HIGH_FREQ)
-				new_frequency = sanitize_frequency(new_frequency)
-			P.sradio.set_frequency(new_frequency)
-			return 1
+	else if(href_list["freq"])
+		var/new_frequency = (P.sradio.frequency + text2num(href_list["freq"]))
+		if(new_frequency < PUBLIC_LOW_FREQ || new_frequency > PUBLIC_HIGH_FREQ)
+			new_frequency = sanitize_frequency(new_frequency)
+		P.sradio.set_frequency(new_frequency)
+		return 1
 
-		else if(href_list["code"])
-			P.sradio.code += text2num(href_list["code"])
-			P.sradio.code = round(P.sradio.code)
-			P.sradio.code = min(100, P.sradio.code)
-			P.sradio.code = max(1, P.sradio.code)
-			return 1
+	else if(href_list["code"])
+		P.sradio.code += text2num(href_list["code"])
+		P.sradio.code = round(P.sradio.code)
+		P.sradio.code = min(100, P.sradio.code)
+		P.sradio.code = max(1, P.sradio.code)
+		return 1
 
 /datum/pai_software/host_scan
 	name = "Host Bioscan"
@@ -694,35 +694,34 @@
 	toggle = 0
 
 
-	on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+/datum/pai_software/host_scan/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui=null, force_open=1)
+	var/data[0]
+	var/mob/living/held = user.loc
+	var/count = 0
 
-		var/data[0]
-		var/mob/living/held = user.loc
-		var/count = 0
+		// Find the carrier
+	while(!isliving(held))
+		if(!held || !held.loc || count > 6)
+			//For a runtime where M ends up in nullspace (similar to bluespace but less colourful)
+			to_chat(user, "You are not being carried by anyone!")
+			return 0
+		held = held.loc
+		count++
+	if(isliving(held))
+		data["holder"] = held
+		data["health"] = "[held.stat > 1 ? "dead" : "[held.health]% healthy"]"
+		data["brute"] = "[held.getBruteLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getBruteLoss()]</font>"
+		data["oxy"] = "[held.getOxyLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getOxyLoss()]</font>"
+		data["tox"] = "[held.getToxLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getToxLoss()]</font>"
+		data["burn"] = "[held.getFireLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getFireLoss()]</font>"
+		data["temp"] = "[held.bodytemperature-T0C]&deg;C ([held.bodytemperature*1.8-459.67]&deg;F)"
+	else
+		data["holder"] = 0
 
-			// Find the carrier
-		while(!isliving(held))
-			if(!held || !held.loc || count > 6)
-				//For a runtime where M ends up in nullspace (similar to bluespace but less colourful)
-				to_chat(user, "You are not being carried by anyone!")
-				return 0
-			held = held.loc
-			count++
-		if(isliving(held))
-			data["holder"] = held
-			data["health"] = "[held.stat > 1 ? "dead" : "[held.health]% healthy"]"
-			data["brute"] = "[held.getBruteLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getBruteLoss()]</font>"
-			data["oxy"] = "[held.getOxyLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getOxyLoss()]</font>"
-			data["tox"] = "[held.getToxLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getToxLoss()]</font>"
-			data["burn"] = "[held.getFireLoss() > 50 ? "<font color=#FF5555>" : "<font color=#55FF55>"][held.getFireLoss()]</font>"
-			data["temp"] = "[held.bodytemperature-T0C]&deg;C ([held.bodytemperature*1.8-459.67]&deg;F)"
-		else
-			data["holder"] = 0
-
-		ui = nanomanager.try_update_ui(user, user, id, ui,data , force_open)
-		if(!ui)
-			// Don't copy-paste this unless you're making a pAI software module!
-			ui = new(user, user, id, "pai_bioscan.tmpl", "Host Bioscan", 400, 350)
-			ui.set_initial_data(data)
-			ui.open()
-			//.set_auto_update(1)
+	ui = nanomanager.try_update_ui(user, user, id, ui,data , force_open)
+	if(!ui)
+		// Don't copy-paste this unless you're making a pAI software module!
+		ui = new(user, user, id, "pai_bioscan.tmpl", "Host Bioscan", 400, 350)
+		ui.set_initial_data(data)
+		ui.open()
+		//.set_auto_update(1)

--- a/code/modules/nano/modules/alarm_monitor.dm
+++ b/code/modules/nano/modules/alarm_monitor.dm
@@ -62,7 +62,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/datum/nano_module/alarm_monitor/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/nano_module/alarm_monitor/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	var/categories[0]

--- a/code/modules/nano/modules/atmos_control.dm
+++ b/code/modules/nano/modules/atmos_control.dm
@@ -39,7 +39,7 @@
 		ui.set_auto_update(1)
 	ui_ref = ui
 
-/datum/nano_module/atmos_control/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/nano_module/atmos_control/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["alarms"] = air_alarm_repository.air_alarm_data(monitored_alarms)
 	return data

--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -31,7 +31,7 @@
 		// should make the UI auto-update; doesn't seem to?
 		ui.set_auto_update(1)
 
-/datum/nano_module/crew_monitor/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/nano_module/crew_monitor/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	var/turf/T = get_turf(nano_host())
 

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -217,7 +217,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/datum/nano_module/appearance_changer/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/nano_module/appearance_changer/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	generate_data(check_whitelist, whitelist, blacklist)
 	var/data[0]
 

--- a/code/modules/nano/modules/law_manager.dm
+++ b/code/modules/nano/modules/law_manager.dm
@@ -154,7 +154,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/datum/nano_module/law_manager/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/nano_module/law_manager/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	owner.lawsync()
 

--- a/code/modules/nano/modules/power_monitor.dm
+++ b/code/modules/nano/modules/power_monitor.dm
@@ -18,7 +18,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/datum/nano_module/power_monitor/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/nano_module/power_monitor/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["powermonitor"] = powermonitor

--- a/code/modules/nano/nanoexternal.dm
+++ b/code/modules/nano/nanoexternal.dm
@@ -48,7 +48,7 @@
  *
  * @return list()
  */
-/datum/proc/ui_data(mob/user, datum/topic_state/state = default_state)
+/datum/proc/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	return list()
 
 // Used by the Nano UI Manager (/datum/nanomanager) to track UIs opened by this mob

--- a/code/modules/nano/nanoexternal.dm
+++ b/code/modules/nano/nanoexternal.dm
@@ -44,6 +44,7 @@
  * The ui_data proc is used to get data for the interface
  *
  * @param user /mob The mob who is viewing this ui
+ * @param ui_key string A string key to use for this ui. Allows for multiple unique uis on one obj/mob (defaut value "main")
  * @param state /datum/topic_state Current topic state of the UI
  *
  * @return list()

--- a/code/modules/nano/nanomanager.dm
+++ b/code/modules/nano/nanomanager.dm
@@ -23,7 +23,7 @@
 		ui = get_open_ui(user, src_object, ui_key)
 
 	if(!isnull(ui))
-		var/data = src_object.ui_data(user, ui.state) // Get data from src_object.
+		var/data = src_object.ui_data(user, ui_key, ui.state) // Get data from src_object.
 		if(!force_open)
 			ui.push_data(data)
 		else

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -415,7 +415,7 @@ nanoui is used to open and update nano browser uis
 		return
 
 	if(!initial_data)
-		set_initial_data(src_object.ui_data(user, state)) // Get the UI data.
+		set_initial_data(src_object.ui_data(user, ui_key, state)) // Get the UI data.
 
 	user << browse(get_html(), "window=[window_id];[window_size][window_options]")
 	winset(user, "mapwindow.map", "focus=true") // return keyboard focus to map

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -62,7 +62,7 @@ var/list/alldepartments = list()
 		ui = new(user, src, ui_key, "faxmachine.tmpl", "Fax Machine UI", 540, 450)
 		ui.open()
 
-/obj/machinery/photocopier/faxmachine/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/photocopier/faxmachine/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	if(scan)

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -129,7 +129,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	// auto update every Master Controller tick
 	ui.set_auto_update(auto_update)
 
-/obj/item/device/pda/ui_data(mob/user, datum/topic_state/state = inventory_state)
+/obj/item/device/pda/ui_data(mob/user, ui_key = "main", datum/topic_state/state = inventory_state)
 	var/data[0]
 
 	data["owner"] = owner					// Who is your daddy...

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -787,7 +787,7 @@
 		// Auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/power/apc/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/power/apc/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["locked"] = is_locked(user)
 	data["isOperating"] = operating

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -327,7 +327,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/power/port_gen/pacman/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/power/port_gen/pacman/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["active"] = active

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -375,7 +375,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/power/smes/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/power/smes/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["nameTag"] = name_tag

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -395,7 +395,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/power/solar_control/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/power/solar_control/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["generated"] = round(lastgen)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -265,7 +265,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/power/supermatter_shard/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/power/supermatter_shard/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["integrity_percentage"] = round(get_integrity())

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -121,7 +121,7 @@
 		// open the new ui window
 		ui.open()
 
-/obj/machinery/chem_dispenser/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/chem_dispenser/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["amount"] = amount

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -136,7 +136,7 @@
 		ui = new(user, src, ui_key, "chem_heater.tmpl", "ChemHeater", 350, 270)
 		ui.open()
 
-/obj/machinery/chem_heater/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/chem_heater/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["targetTemp"] = desired_temp

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -328,7 +328,7 @@
 		ui = new(user, src, ui_key, "chem_master.tmpl", name, 575, 400)
 		ui.open()
 
-/obj/machinery/chem_master/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/chem_master/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	data["condi"] = condi

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -247,7 +247,7 @@
 		ui.open()
 		ui.set_auto_update(1)
 
-/obj/machinery/disposal/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/disposal/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	var/pressure = Clamp(100* air_contents.return_pressure() / (SEND_PRESSURE), 0, 100)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -652,7 +652,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		ui = new(user, src, ui_key, "r_n_d.tmpl", src.name, 800, 550)
 		ui.open()
 
-/obj/machinery/computer/rdconsole/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/rdconsole/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 
 	files.RefreshResearch()

--- a/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
+++ b/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
@@ -126,7 +126,7 @@
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/machinery/radiocarbon_spectrometer/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/radiocarbon_spectrometer/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["scanned_item"] = (scanned_item ? scanned_item.name : "")
 	data["scanned_item_desc"] = (scanned_item ? (scanned_item.desc ? scanned_item.desc : "No information on record.") : "")

--- a/code/modules/security_levels/keycard authentication.dm
+++ b/code/modules/security_levels/keycard authentication.dm
@@ -75,7 +75,7 @@
 		ui = new(user, src, ui_key, "keycard_auth.tmpl", "Keycard Authentication Device UI", 540, 320)
 		ui.open()
 
-/obj/machinery/keycard_auth/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/keycard_auth/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["screen"] = screen
 	data["event"] = event

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -430,7 +430,7 @@
 		ui = new(user, src, ui_key, "order_console.tmpl", name, ORDER_SCREEN_WIDTH, ORDER_SCREEN_HEIGHT)
 		ui.open()
 
-/obj/machinery/computer/ordercomp/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/ordercomp/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["last_viewed_group"] = last_viewed_group
 
@@ -579,7 +579,7 @@
 		ui = new(user, src, ui_key, "supply_console.tmpl", name, SUPPLY_SCREEN_WIDTH, SUPPLY_SCREEN_HEIGHT)
 		ui.open()
 
-/obj/machinery/computer/supplycomp/ui_data(mob/user, datum/topic_state/state = default_state)
+/obj/machinery/computer/supplycomp/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	data["last_viewed_group"] = last_viewed_group
 


### PR DESCRIPTION
Fixes #6023 

Also refactors `ui_data` to accept a `ui_key` arg - so that objects with multiple interfaces attached to them can send different data depending on the UI.

:cl:Crazylemon
fix: pAI UIs no longer break
/:cl: