### PR TITLE
Fixes landmarks not being moved by shuttles

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -19,6 +19,10 @@
     . = ..()
     invisibility = 101
 
+/obj/effect/landmark/shuttle_import/onShuttleMove()
+    // Unless you're THIS landmark
+    return 0
+
 /obj/machinery/door/onShuttleMove()
     . = ..()
     if(!.)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -13,6 +13,12 @@
         return 0
     . = ..()
 
+/obj/effect/landmark/onShuttleMove()
+    // Drop invisibility juuust enough to get moved
+    invisibility = 100
+    . = ..()
+    invisibility = 101
+
 /obj/machinery/door/onShuttleMove()
     . = ..()
     if(!.)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -8,19 +8,12 @@
 /atom/movable/lighting_overlay/onShuttleMove()
     return 0
 
-/obj/onShuttleMove()
-    if(invisibility >= 101)
-        return 0
-    . = ..()
-
-/obj/effect/landmark/onShuttleMove()
-    // Drop invisibility juuust enough to get moved
-    invisibility = 100
-    . = ..()
-    invisibility = 101
-
 /obj/effect/landmark/shuttle_import/onShuttleMove()
-    // Unless you're THIS landmark
+    // Used for marking where to preview/load shuttles
+    return 0
+
+/obj/docking_port/onShuttleMove()
+    // Stationary ports shouldn't move, mobile ones move themselves
     return 0
 
 /obj/machinery/door/onShuttleMove()


### PR DESCRIPTION
This was bad for the landmarks used to spawn the nuke and pinpointer locker onto the nuke-ops shuttle, because they'd be left floating in space, right near the station. Whoops!

~~I considered making landmarks' `onShuttleMove` just do the move and return, but I'd rather they not break if something important changes further up the chain, and this seemed like the simplest way to do that without changing anything else. It would *probably* be better if we just didn't use landmarks for this, though...~~

:cl:
bugfix: The syndicate nuke and pinpointer locker will once again spawn into their ship, rather than into space near the station.
/:cl: