### PR TITLE
Fixes web spam bug

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -25,7 +25,11 @@
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/Web()
 	visible_message("<span class='notice'>[src] begins to secrete a sticky substance.</span>")
 	if(do_after(src, 40, target = loc))
-		new /obj/effect/spider/terrorweb(loc)
+		var/obj/effect/spider/terrorweb/T = locate() in get_turf(src)
+		if(T)
+			to_chat(src, "<span class='danger'>There is already a web here.</span>")
+		else
+			new /obj/effect/spider/terrorweb(loc)
 
 /obj/effect/spider/terrorweb
 	name = "terror web"


### PR DESCRIPTION
Currently, there's a bug with Terror Spiders where someone can spam web many times to create almost impassable tiles. 

This PR fixes that, so it is no longer possible to create more than one web on a tile.
🆑Kyep
fix: Terror Spiders can no longer create more than one web on a tile.
/🆑