### PR TITLE
Fixes #5097 - out-of-date vent/scrubber images

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -66,6 +66,10 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/update_icon()
 	return null
 
+/obj/machinery/atmospherics/proc/update_pipe_image()
+	pipe_image = image(src, loc, layer = 20, dir = dir) //the 20 puts it above Byond's darkness (not its opacity view)
+	pipe_image.plane = HUD_PLANE
+
 /obj/machinery/atmospherics/proc/check_icon_cache(var/safety = 0)
 	if(!istype(icon_manager))
 		if(!safety) //to prevent infinite loops

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -100,6 +100,9 @@
 
 	overlays += icon_manager.get_atmos_icon("device", , , vent_icon)
 
+	pipe_image = image(src, loc, layer = 20, dir = dir) //the 20 puts it above Byond's darkness (not its opacity view)
+	pipe_image.plane = HUD_PLANE
+
 /obj/machinery/atmospherics/unary/vent_pump/update_underlays()
 	if(..())
 		underlays.Cut()

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -100,8 +100,7 @@
 
 	overlays += icon_manager.get_atmos_icon("device", , , vent_icon)
 
-	pipe_image = image(src, loc, layer = 20, dir = dir) //the 20 puts it above Byond's darkness (not its opacity view)
-	pipe_image.plane = HUD_PLANE
+	update_pipe_image()
 
 /obj/machinery/atmospherics/unary/vent_pump/update_underlays()
 	if(..())

--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -107,8 +107,7 @@
 		scrubber_icon = "scrubberweld"
 
 	overlays += icon_manager.get_atmos_icon("device", , , scrubber_icon)
-	pipe_image = image(src, loc, layer = 20, dir = dir) //the 20 puts it above Byond's darkness (not its opacity view)
-	pipe_image.plane = HUD_PLANE
+	update_pipe_image()
 
 /obj/machinery/atmospherics/unary/vent_scrubber/update_underlays()
 	if(..())

--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -107,6 +107,8 @@
 		scrubber_icon = "scrubberweld"
 
 	overlays += icon_manager.get_atmos_icon("device", , , scrubber_icon)
+	pipe_image = image(src, loc, layer = 20, dir = dir) //the 20 puts it above Byond's darkness (not its opacity view)
+	pipe_image.plane = HUD_PLANE
 
 /obj/machinery/atmospherics/unary/vent_scrubber/update_underlays()
 	if(..())

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -454,8 +454,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	totalMembers |= pipeline.other_atmosmch
 	for(var/obj/machinery/atmospherics/A in totalMembers)
 		if(!A.pipe_image)
-			A.pipe_image = image(A, A.loc, layer = 20, dir = A.dir) //the 20 puts it above Byond's darkness (not its opacity view)
-			A.pipe_image.plane = HUD_PLANE
+			A.update_pipe_image()
 		pipes_shown += A.pipe_image
 		client.images += A.pipe_image
 


### PR DESCRIPTION
Currently, it is possible to get stuck in vents, because the images of vents/scrubbers you see while in those vents/scrubbers don't always match their actual state. IE: the vent/scrubber can be welded up even though it appears, to you, as if it isn't.

This fixes that, ensuring that these images are always updated when the vent/scrubber's status changes.

🆑Kyep
fix: Mobs in vents no longer see vents/scrubbers as unwelded when they are welded, and vice versa.
/🆑