### PR TITLE
People who are unconscious can no longer disrupt surgery by unresting

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1009,7 +1009,7 @@ proc/get_mob_with_client_list()
 	else if(zone == "l_foot") return "left foot"
 	else if(zone == "r_foot") return "right foot"
 	else return zone
-	
+
 /*
 
  Gets the turf this atom's *ICON* appears to inhabit
@@ -1222,7 +1222,7 @@ var/global/list/common_tools = list(
 
 //check if mob is lying down on something we can operate him on.
 /proc/can_operate(mob/living/carbon/M)
-	return (locate(/obj/machinery/optable, M.loc) && M.resting) || \
+	return (locate(/obj/machinery/optable, M.loc) && (M.lying || M.resting)) || \
 	(locate(/obj/structure/stool/bed/roller, M.loc) && 	\
 	(M.buckled || M.lying || M.weakened || M.stunned || M.paralysis || M.sleeping || M.stat)) && prob(75) || 	\
 	(locate(/obj/structure/table/, M.loc) && 	\


### PR DESCRIPTION
:cl:Crazylemon
tweak: The operating table now checks for both either `lying` or `resting` - so surgery will work no matter what on unconscious people lying on your table.
/:cl: