### PR TITLE
Waking up no longer auto-cancels resting

### DIFF
--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -12,6 +12,4 @@
 				KnockOut()
 		else
 			if(stat == UNCONSCIOUS)
-				// updating=FALSE because `WakeUp` will handle canmove up for us
-				StopResting(updating=FALSE)
 				WakeUp()


### PR DESCRIPTION
A reversion of a change I made in one of my stat refactor PRs that I'm not 100% sure why I did in the first place.
:cl:Crazylemon
tweak: Waking up no longer auto-cancels resting.
/:cl: