### PR TITLE
Safeguards against null-prefs clients from muting everyone

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -209,7 +209,7 @@
 			var/turf/ear = get_turf(M)
 			if(ear)
 				// Ghostship is magic: Ghosts can hear radio chatter from anywhere
-				if(speaker_coverage[ear] || (istype(M, /mob/dead/observer) && (M.client) && (M.client.prefs.toggles & CHAT_GHOSTRADIO)))
+				if(speaker_coverage[ear] || (istype(M, /mob/dead/observer) && M.get_preference(CHAT_GHOSTRADIO)))
 					. |= M		// Since we're already looping through mobs, why bother using |= ? This only slows things down.
 	return .
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -407,7 +407,7 @@ var/round_start_time = 0
 
 		if(player.client)
 			if(player.client.karma_spent == 0)
-				if(player.client.prefs && !(player.client.prefs.toggles & DISABLE_KARMA_REMINDER))
+				if(player.get_preference(DISABLE_KARMA_REMINDER))
 					var/dat
 					dat += {"<html><head><title>Karma Reminder</title></head><body><h1><B>Karma Reminder</B></h1><br>
 					You have not yet spent your karma for the round, surely there is a player who was worthy of receiving<br>

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -150,9 +150,8 @@
 	to_chat(world, "<b>The crew's final score is:</b>")
 	to_chat(world, "<b><font size='4'>[score_crewscore]</font></b>")
 	for(var/mob/E in player_list)
-		if(E.client)
-			if(E.client.prefs && !(E.client.prefs.toggles & DISABLE_SCOREBOARD))
-				E.scorestats()
+		if(E.client && !E.get_preference(DISABLE_SCOREBOARD))
+			E.scorestats()
 
 // A recursive function to properly determine the wealthiest escapee
 /datum/controller/gameticker/proc/get_score_container_worth(atom/C, level=0)

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -285,14 +285,14 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	  /* --- Loop through the receivers and categorize them --- */
 
-		if(R.client && R.client.holder && !(R.client.prefs.toggles & CHAT_RADIO)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
+		if(is_admin(R) && !R.get_preference(CHAT_RADIO)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
 			continue
 
 		if(istype(R, /mob/new_player)) // we don't want new players to hear messages. rare but generates runtimes.
 			continue
 
 		// Ghosts hearing all radio chat don't want to hear syndicate intercepts, they're duplicates
-		if(data == 3 && istype(R, /mob/dead/observer) && R.client && (R.client.prefs.toggles & CHAT_GHOSTRADIO))
+		if(data == 3 && istype(R, /mob/dead/observer) && R.get_preference(CHAT_GHOSTRADIO))
 			continue
 
 		// --- Check for compression ---
@@ -495,7 +495,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 
 	  /* --- Loop through the receivers and categorize them --- */
 
-		if(R.client && !(R.client.prefs.toggles & CHAT_RADIO)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
+		if(R.client && !R.get_preference(CHAT_RADIO)) //Adminning with 80 people on can be fun when you're trying to talk and all you can hear is radios.
 			continue
 
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -48,7 +48,7 @@
 				continue
 			if(findtext(message," snores.")) //Because we have so many sleeping people.
 				break
-			if(M.stat == 2 && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
+			if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
 				M.show_message(message)
 
 
@@ -118,8 +118,8 @@
 			if(istype(M, /mob/new_player))
 				continue
 
-			if(check_rights(R_ADMIN|R_MOD, 0, M) && (M.client.prefs.toggles & CHAT_DEAD)) // Show the emote to admins/mods
+			if(check_rights(R_ADMIN|R_MOD, 0, M) && M.get_preference(CHAT_DEAD)) // Show the emote to admins/mods
 				to_chat(M, message)
 
-			else if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_DEAD)) // Show the emote to regular ghosts with deadchat toggled on
+			else if(M.stat == DEAD && M.get_preference(CHAT_DEAD)) // Show the emote to regular ghosts with deadchat toggled on
 				M.show_message(message, 2)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -868,7 +868,7 @@
 		for(var/mob/M in dead_mob_list)
 			if(!M.client || istype(M, /mob/new_player))
 				continue //skip monkeys, leavers and new players
-			if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
+			if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
 				M.show_message(message)
 
 		switch(m_type)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -241,7 +241,7 @@ proc/get_radio_key_from_channel(var/channel)
 				continue //skip monkeys and leavers
 			if(isnewplayer(M))
 				continue
-			if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS) && client) // client is so that ghosts don't have to listen to mice
+			if(M.stat == DEAD && M.client && M.get_preference(CHAT_GHOSTEARS) && client) // client is so that ghosts don't have to listen to mice
 				listening |= M
 				continue
 			if(get_turf(M) in hearturfs)
@@ -285,8 +285,8 @@ proc/get_radio_key_from_channel(var/channel)
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
 			return
-			
-	if(stat)									 
+
+	if(stat)
 		return 0
 
 	if(..(act, type, message))
@@ -299,7 +299,7 @@ proc/get_radio_key_from_channel(var/channel)
 			if(!M.client || istype(M, /mob/new_player))
 				continue //skip monkeys, leavers and new players //who the hell knows why new players are in the dead mob list
 
-			if(M.stat == DEAD && (M.client.prefs.toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
+			if(M.stat == DEAD && M.get_preference(CHAT_GHOSTSIGHT) && !(M in viewers(src,null)))
 				M.show_message(message)
 
 		switch(type)
@@ -399,7 +399,7 @@ proc/get_radio_key_from_channel(var/channel)
 	for(var/mob/M in dead_mob_list)	//does this include players who joined as observers as well?
 		if(!M.client)
 			continue
-		if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS))
+		if(M.stat == DEAD && M.client && M.get_preference(CHAT_GHOSTEARS))
 			listening |= M
 
 	//Pass whispers on to anything inside the immediate listeners.

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -411,7 +411,7 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HARM)
 				name = realname
 
 	for(var/mob/M in player_list)
-		if(M.client && ((!istype(M, /mob/new_player) && M.stat == DEAD) || check_rights(R_ADMIN|R_MOD,0,M)) && (M.client.prefs.toggles & CHAT_DEAD))
+		if(M.client && ((!istype(M, /mob/new_player) && M.stat == DEAD) || check_rights(R_ADMIN|R_MOD,0,M)) && M.get_preference(CHAT_DEAD))
 			var/follow
 			var/lname
 			if(subject)
@@ -546,3 +546,12 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HARM)
 			return
 
 		rename_character(oldname, newname)
+
+/mob/proc/get_preference(toggleflag)
+	if(!client)
+		return FALSE
+	if(!client.prefs)
+		log_runtime(EXCEPTION("Mob '[src]', ckey '[ckey]' is missing a prefs datum on the client!"))
+		return FALSE
+	// Cast to 1/0
+	return !!(client.prefs.toggles & toggleflag)

--- a/code/modules/research/xenoarchaeology/finds/finds_talkingitem.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_talkingitem.dm
@@ -117,7 +117,7 @@
 			continue //skip monkeys and leavers
 		if(istype(M, /mob/new_player))
 			continue
-		if(M.stat == 2 &&  M.client.prefs.toggles & CHAT_GHOSTEARS)
+		if(M.stat == DEAD && M.get_preference(CHAT_GHOSTEARS))
 			listening|=M
 
 	for(var/mob/M in listening)


### PR DESCRIPTION
A null prefs datum is still logged, so that we are able to isolate the source of the problem, though.

:cl:Crazylemon
fix: You should no longer go mute randomly
/:cl: