### PR TITLE
Wand of Death Reliable Killing

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -67,7 +67,7 @@
 	var/message ="<span class='warning'>You irradiate yourself with pure energy! "
 	message += pick("Do not pass go. Do not collect 200 zorkmids.</span>","You feel more confident in your spell casting skills.</span>","You Die...</span>","Do you want your possessions identified?</span>")
 	to_chat(user, message)
-	user.adjustBruteLoss(3000)
+	user.adjustFireLoss(3000)
 	charges--
 	..()
 

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -67,8 +67,7 @@
 	var/message ="<span class='warning'>You irradiate yourself with pure energy! "
 	message += pick("Do not pass go. Do not collect 200 zorkmids.</span>","You feel more confident in your spell casting skills.</span>","You Die...</span>","Do you want your possessions identified?</span>")
 	to_chat(user, message)
-	user.gib()
-	visible_message("<span class='danger'>[user] has paid the ultimate price for innapropriate wand discipline!")
+	user.adjustBruteLoss(3000)
 	charges--
 	..()
 

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -67,7 +67,8 @@
 	var/message ="<span class='warning'>You irradiate yourself with pure energy! "
 	message += pick("Do not pass go. Do not collect 200 zorkmids.</span>","You feel more confident in your spell casting skills.</span>","You Die...</span>","Do you want your possessions identified?</span>")
 	to_chat(user, message)
-	user.adjustFireLoss(500)
+	user.gib()
+	visible_message("<span class='danger'>[user] has paid the ultimate price for innapropriate wand discipline!")
 	charges--
 	..()
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -10,9 +10,6 @@
 /obj/item/projectile/magic/death
 	name = "bolt of death"
 	icon_state = "pulse1_bl"
-	damage_type = BURN //OXY does not kill IPCs
-	damage = 50000
-	nodamage = 0
 
 /obj/item/projectile/magic/fireball
 	name = "bolt of fireball"
@@ -23,9 +20,13 @@
 
 /obj/item/projectile/magic/death/on_hit(var/mob/living/carbon/G)
 	. = ..()
-	if(ismob(G))
-		G.gib()
-		visible_message("<span class='danger'>[G] explodes violently!")
+	if(isliving(G))
+		if(G.stat != DEAD)
+			G.adjustBruteLoss(300)
+			visible_message("<span class='danger'>[G] falls backward as life is drained from them!")
+		else
+			G.gib()
+			visible_message("<span class='danger'>[G] explodes violently as the magical energies course through their corpse!")
 
 /obj/item/projectile/magic/fireball/Range()
 	var/turf/T1 = get_step(src,turn(dir, -45))

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -21,12 +21,8 @@
 /obj/item/projectile/magic/death/on_hit(var/mob/living/carbon/G)
 	. = ..()
 	if(isliving(G))
-		if(G.stat != DEAD)
-			G.adjustBruteLoss(300)
-			visible_message("<span class='danger'>[G] falls backward as life is drained from them!")
-		else
-			G.gib()
-			visible_message("<span class='danger'>[G] explodes violently as the magical energies course through their corpse!")
+		G.adjustBruteLoss(3000)
+		visible_message("<span class='danger'>[G] topples backwards as the death bolt impacts them!</span>")
 
 /obj/item/projectile/magic/fireball/Range()
 	var/turf/T1 = get_step(src,turn(dir, -45))

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -21,7 +21,7 @@
 /obj/item/projectile/magic/death/on_hit(var/mob/living/carbon/G)
 	. = ..()
 	if(isliving(G))
-		G.adjustBruteLoss(3000)
+		G.adjustFireLoss(3000)
 		visible_message("<span class='danger'>[G] topples backwards as the death bolt impacts them!</span>")
 
 /obj/item/projectile/magic/fireball/Range()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -21,6 +21,12 @@
 	damage_type = BRUTE
 	nodamage = 0
 
+/obj/item/projectile/magic/death/on_hit(var/mob/living/carbon/G)
+	. = ..()
+	if(ismob(G))
+		G.gib()
+		visible_message("<span class='danger'>[G] explodes violently!")
+
 /obj/item/projectile/magic/fireball/Range()
 	var/turf/T1 = get_step(src,turn(dir, -45))
 	var/turf/T2 = get_step(src,turn(dir, 45))


### PR DESCRIPTION
Fixes #6068

- Concentrated magical energies now allow the Wand of Death to reliably kill all living targets

:cl:
fix: Wand of Death now reliably kills people by adding 300 Burn Damage. This includes self-casting
add: Minor flavour text visible on impact of target
/:cl: