### PR TITLE
Fixes AI Camera List by Adding more Sanity

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -25,9 +25,10 @@
 	var/list/T = list()
 
 	for(var/obj/machinery/camera/C in L)
-		var/list/tempnetwork = C.network & src.network
-		if(tempnetwork.len)
-			T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
+		if(C.network)
+			var/list/tempnetwork = C.network & network
+			if(tempnetwork && tempnetwork.len)
+				T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
 
 	track.cameras = T
 	return T


### PR DESCRIPTION
Resolves #6072 
:cl:
fix: AI Camera List should now work for latejoiners.
/:cl:

![ai camera list working](https://cloud.githubusercontent.com/assets/12377767/21703764/6fad3bc8-d382-11e6-979b-5f1c8c15d484.PNG)
