### PR TITLE
Fixes Video Camera's Networkless Camera

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -514,7 +514,7 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 		if(on==0)
 			src.icon_state = icon_off
 			camera.c_tag = null
-			camera.network = null
+			camera.network = list()
 		else
 			src.icon_state = icon_on
 			camera.network = list("news")


### PR DESCRIPTION
A camera's network list is expected to never be null, but turning off a video camera nulled out the network list of its internal camera, breaking anything that assumes it's a list. Fixes #6072.