### PR TITLE
Makes tranquilizer darts actually useful.

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -272,7 +272,8 @@
 /obj/item/projectile/bullet/dart/syringe/tranquilizer
 /obj/item/projectile/bullet/dart/syringe/tranquilizer/New()
 	..()
-	reagents.add_reagent("haloperidol", 15)
+	reagents.add_reagent("mutadone", 5)
+	reagents.add_reagent("haloperidol", 5)
 
 /obj/item/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"


### PR DESCRIPTION
As per title. The tranq darts for the shotty you can find in the armory now have:

- 5u of mutadone, for dealing with those pesky hulks
- 5u of haloperidol for dealing with those geniuses that injected a marijuana (it removes pretty much all combat stims and drugs from the person's system)

:cl: FlattestGuitar
tweak: The tranquilizer darts now have an updated mix of chemicals inside. Contact your assigned Warden for more information.
/:cl: