### PR TITLE
Traitors see codewords highlighted

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -165,7 +165,7 @@ var/syndicate_code_response//Code response for traitors.
 
 /proc/generate_code_phrase()//Proc is used for phrase and response in master_controller.dm
 
-	var/code_phrase = ""//What is returned when the proc finishes.
+	var/list/code_list = list() // returned when proc finishes.
 	var/words = pick(//How many words there will be. Minimum of two. 2, 4 and 5 have a lesser chance of being selected. 3 is the most likely.
 		50; 2,
 		200; 3,
@@ -184,8 +184,9 @@ var/syndicate_code_response//Code response for traitors.
 
 	var/maxwords = words//Extra var to check for duplicates.
 
+	var/new_codeword = ""
 	for(words,words>0,words--)//Randomly picks from one of the choices below.
-
+		new_codeword = ""
 		if(words==1&&(1 in safety)&&(2 in safety))//If there is only one word remaining and choice 1 or 2 have not been selected.
 			safety = list(pick(1,2))//Select choice 1 or 2.
 		else if(words==1&&maxwords==2)//Else if there is only one word remaining (and there were two originally), and 1 or 2 were chosen,
@@ -196,35 +197,32 @@ var/syndicate_code_response//Code response for traitors.
 				switch(rand(1,2))//Mainly to add more options later.
 					if(1)
 						if(names.len&&prob(70))
-							code_phrase += pick(names)
+							new_codeword = pick(names)
 						else
-							code_phrase += pick(pick(first_names_male,first_names_female))
-							code_phrase += " "
-							code_phrase += pick(last_names)
+							new_codeword = pick(pick(first_names_male,first_names_female))
+							new_codeword += " "
+							new_codeword += pick(last_names)
 					if(2)
-						code_phrase += pick(joblist)//Returns a job.
+						new_codeword = pick(joblist)//Returns a job.
 				safety -= 1
 			if(2)
 				switch(rand(1,2))//Places or things.
 					if(1)
-						code_phrase += pick(drinks)
+						new_codeword = pick(drinks)
 					if(2)
-						code_phrase += pick(locations)
+						new_codeword = pick(locations)
 				safety -= 2
 			if(3)
 				switch(rand(1,3))//Nouns, adjectives, verbs. Can be selected more than once.
 					if(1)
-						code_phrase += pick(nouns)
+						new_codeword = pick(nouns)
 					if(2)
-						code_phrase += pick(adjectives)
+						new_codeword = pick(adjectives)
 					if(3)
-						code_phrase += pick(verbs)
-		if(words==1)
-			code_phrase += "."
-		else
-			code_phrase += ", "
+						new_codeword = pick(verbs)
+		code_list += new_codeword
 
-	return code_phrase
+	return code_list
 
 /proc/GenerateKey()
 	var/newKey
@@ -233,88 +231,3 @@ var/syndicate_code_response//Code response for traitors.
 	newKey += pick("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 	return newKey
 
-/*
-//This proc tests the gen above.
-/client/verb/test_code_phrase()
-	set name = "Generate Code Phrase"
-	set category = "Debug"
-
-	to_chat(world, "<span class='warning'>Code Phrase is:</span> [generate_code_phrase()]")
-	return
-
-
-	This was an earlier attempt at code phrase system, aside from an even earlier attempt (and failure).
-	This system more or less works as intended--aside from being unfinished--but it's still very predictable.
-	Particularly, the phrase opening statements are pretty easy to recognize and identify when metagaming.
-	I think the above-used method solves this issue by using words in a sequence, providing for much greater flexibility.
-	/N
-
-	switch(choice)
-		if(1)
-			syndicate_code_phrase += pick("I'm looking for","Have you seen","Maybe you've seen","I'm trying to find","I'm tracking")
-			syndicate_code_phrase += " "
-			syndicate_code_phrase += pick(pick(first_names_male,first_names_female))
-			syndicate_code_phrase += " "
-			syndicate_code_phrase += pick(last_names)
-			syndicate_code_phrase += "."
-		if(2)
-			syndicate_code_phrase += pick("How do I get to","How do I find","Where is","Where do I find")
-			syndicate_code_phrase += " "
-			syndicate_code_phrase += pick("Escape","Engineering","Atmos","the bridge","the brig","Clown Planet","CentComm","the library","the chapel","a bathroom","Med Bay","Tool Storage","the escape shuttle","Robotics","a locker room","the living quarters","the gym","the autolathe","QM","the bar","the theater","the derelict")
-			syndicate_code_phrase += "?"
-		if(3)
-			if(prob(70))
-				syndicate_code_phrase += pick("Get me","I want","I'd like","Make me")
-				syndicate_code_phrase += " a "
-			else
-				syndicate_code_phrase += pick("One")
-				syndicate_code_phrase += " "
-			syndicate_code_phrase += pick("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepksy Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
-			syndicate_code_phrase += "."
-		if(4)
-			syndicate_code_phrase += pick("I wish I was","My dad was","His mom was","Where do I find","The hero this station needs is","I'd fuck","I wouldn't trust","Someone caught","HoS caught","Someone found","I'd wrestle","I wanna kill")
-			syndicate_code_phrase += " [pick("a","the")] "
-			syndicate_code_phrase += pick("wizard","ninja","xeno","lizard","slime","monkey","syndicate","cyborg","clown","space carp","singularity","singulo","mime")
-			syndicate_code_phrase += "."
-		if(5)
-			syndicate_code_phrase += pick("Do we have","Is there","Where is","Where's","Who's")
-			syndicate_code_phrase += " "
-			syndicate_code_phrase += "[pick(joblist)]"
-			syndicate_code_phrase += "?"
-
-	switch(choice)
-		if(1)
-			if(prob(80))
-				syndicate_code_response += pick("Try looking for them near","I they ran off to","Yes. I saw them near","Nope. I'm heading to","Try searching")
-				syndicate_code_response += " "
-				syndicate_code_response += pick("Escape","Engineering","Atmos","the bridge","the brig","Clown Planet","CentComm","the library","the chapel","a bathroom","Med Bay","Tool Storage","the escape shuttle","Robotics","a locker room","the living quarters","the gym","the autolathe","QM","the bar","the theater","the derelict")
-				syndicate_code_response += "."
-			else if(prob(60))
-				syndicate_code_response += pick("No. I'm busy, sorry.","I don't have the time.","Not sure, maybe?","There is no time.")
-			else
-				syndicate_code_response += pick("*shrug*","*smile*","*blink*","*sigh*","*laugh*","*nod*","*giggle*")
-		if(2)
-			if(prob(80))
-				syndicate_code_response += pick("Go to","Navigate to","Try","Sure, run to","Try searching","It's near","It's around")
-				syndicate_code_response += " the "
-				syndicate_code_response += pick("[pick("south","north","east","west")] maitenance door","nearby maitenance","teleporter","[pick("cold","dead")] space","morgue","vacuum","[pick("south","north","east","west")] hall ","[pick("south","north","east","west")] hallway","[pick("white","black","red","green","blue","pink","purple")] [pick("rabbit","frog","lion","tiger","panther","snake","facehugger")]")
-				syndicate_code_response += "."
-			else if(prob(60))
-				syndicate_code_response += pick("Try asking","Ask","Talk to","Go see","Follow","Hunt down")
-				syndicate_code_response += " "
-				if(prob(50))
-					syndicate_code_response += pick(pick(first_names_male,first_names_female))
-					syndicate_code_response += " "
-					syndicate_code_response += pick(last_names)
-				else
-					syndicate_code_response += " the "
-					syndicate_code_response += "[pic(joblist)]"
-				syndicate_code_response += "."
-			else
-				syndicate_code_response += pick("*shrug*","*smile*","*blink*","*sigh*","*laugh*","*nod*","*giggle*")
-		if(3)
-		if(4)
-		if(5)
-
-	return
-*/

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -42,11 +42,11 @@ var/global/list/syndicate_codewords = list()
 
 	if(!syndicate_code_phrase)
 		var/list/new_phrases = generate_code_phrase()
-		syndicate_code_phrase = n_jointext(new_phrases, ", ") + "."
+		syndicate_code_phrase = jointext(new_phrases, ", ") + "."
 		syndicate_codewords += new_phrases
 	if(!syndicate_code_response)
 		var/list/new_responses = generate_code_phrase()
-		syndicate_code_response = n_jointext(new_responses, ", ") + "."
+		syndicate_code_response = jointext(new_responses, ", ") + "."
 		syndicate_codewords += new_responses
 
 

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -10,6 +10,8 @@ var/global/last_tick_duration = 0
 var/global/air_processing_killed = 0
 var/global/pipe_processing_killed = 0
 
+var/global/list/syndicate_codewords = list()
+
 /datum/controller
 	var/processing = 0
 	var/iteration = 0
@@ -38,8 +40,15 @@ var/global/pipe_processing_killed = 0
 		job_master.LoadJobs("config/jobs.txt")
 		log_startup_progress("Job setup complete in [stop_watch(watch)]s.")
 
-	if(!syndicate_code_phrase)		syndicate_code_phrase	= generate_code_phrase()
-	if(!syndicate_code_response)	syndicate_code_response	= generate_code_phrase()
+	if(!syndicate_code_phrase)
+		var/list/new_phrases = generate_code_phrase()
+		syndicate_code_phrase = n_jointext(new_phrases, ", ") + "."
+		syndicate_codewords += new_phrases
+	if(!syndicate_code_response)
+		var/list/new_responses = generate_code_phrase()
+		syndicate_code_response = n_jointext(new_responses, ", ") + "."
+		syndicate_codewords += new_responses
+
 
 /datum/controller/game_controller/Destroy()
 	..()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -52,6 +52,7 @@
 	var/list/datum/objective/special_verbs = list()
 
 	var/has_been_rev = 0//Tracks if this mind has been a rev or not
+	var/knows_codewords = 0 //Tracks if the mob knows what the syndicate codewords are, or not.
 
 	var/miming = 0 // Mime's vow of silence
 	var/datum/faction/faction 			//associated faction
@@ -1165,6 +1166,7 @@
 			if("takeuplink")
 				take_uplink()
 				memory = null//Remove any memory they may have had.
+				knows_codewords = 0
 				log_admin("[key_name(usr)] has taken [key_name(current)]'s uplink")
 				message_admins("[key_name_admin(usr)] has taken [key_name_admin(current)]'s uplink")
 			if("crystals")

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -210,6 +210,7 @@
 
 	traitor_mob.mind.store_memory("<b>Code Phrase</b>: [syndicate_code_phrase]")
 	traitor_mob.mind.store_memory("<b>Code Response</b>: [syndicate_code_response]")
+	traitor_mob.mind.knows_codewords = 1
 
 	to_chat(traitor_mob, "Use the code words in the order provided, during regular conversation, to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
 
@@ -355,8 +356,8 @@
 			to_chat(traitor_mind.current, "<span class='userdanger'>You have been turned into a robot! You are no longer a traitor.</span>")
 		else
 			to_chat(traitor_mind.current, "<span class='userdanger'>You have been brainwashed! You are no longer a traitor.</span>")
-		ticker.mode.update_traitor_icons_removed(traitor_mind)		
-		
+		ticker.mode.update_traitor_icons_removed(traitor_mind)
+
 /datum/game_mode/proc/update_traitor_icons_added(datum/mind/traitor_mind)
 	var/datum/atom_hud/antag/tatorhud = huds[ANTAG_HUD_TRAITOR]
 	tatorhud.join_hud(traitor_mind.current)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -198,6 +198,9 @@
 /mob/proc/knows_codewords()
 	if(mind && (mind.knows_codewords))
 		return 1
+	if(isobserver(src))
+		if(antagHUD || check_rights(R_ADMIN, 0, src))
+			return 1
 	return 0
 
 /mob/proc/format_say_codewords(var/thetext)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -55,6 +55,8 @@
 	if(italics)
 		message = "<i>[message]</i>"
 
+	message = format_say_codewords(message)
+
 	var/track = null
 	if(isobserver(src))
 		if(italics && client.prefs.toggles & CHAT_GHOSTRADIO)
@@ -182,6 +184,9 @@
 		formatted = language.format_message_radio(message, verb)
 	else
 		formatted = "[verb], <span class=\"body\">\"[message]\"</span>"
+
+	formatted = format_say_codewords(formatted)
+
 	if(!can_hear())
 		if(prob(20))
 			to_chat(src, "<span class='warning'>You feel your headset vibrate but can hear nothing from it!</span>")
@@ -189,6 +194,22 @@
 		to_chat(src, "[part_a][track][part_b][formatted]</span></span>")
 	else
 		to_chat(src, "[part_a][speaker_name][part_b][formatted]</span></span>")
+
+/mob/proc/knows_codewords()
+	if(mind && (mind.knows_codewords))
+		return 1
+	return 0
+
+/mob/proc/format_say_codewords(var/thetext)
+	if(!knows_codewords())
+		return thetext
+	var/newtext = ""
+	for(var/word in syndicate_codewords)
+		var/pos = findtext(thetext, word)
+		if(pos)
+			newtext = "<B>[word]</B>"
+			thetext = copytext(thetext, 1, pos) + newtext + copytext(thetext, pos + lentext(word), 0)
+	return thetext
 
 /mob/proc/hear_signlang(var/message, var/verb = "gestures", var/datum/language/language, var/mob/speaker = null)
 	if(!client)


### PR DESCRIPTION
WIP PR that highlights codewords in radio messages and local chat heard by fellow syndicate agents.

Essentially, it makes codewords obvious, so if another traitor tries to use them to tip you off, you'll notice.
Obviously, doesn't make the words appear any differently for normal crew. Only traitors see the special formatting.

Demo: http://i.imgur.com/2M00bQr.png
Thread: https://nanotrasen.se/phpBB3/viewtopic.php?f=12&t=9402
