### PR TITLE
pAI HUD Tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -516,7 +516,6 @@
 				return istype(H.glasses, /obj/item/clothing/glasses/hud/health) || istype(H.glasses, /obj/item/clothing/glasses/hud/health/health_advanced) ||  istype(CIH,/obj/item/organ/internal/cyberimp/eyes/hud/medical)
 			else
 				return 0
-	else if(istype(M, /mob/living/silicon))
 		switch(hudtype)
 			if("security")
 				return 1

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -516,6 +516,7 @@
 				return istype(H.glasses, /obj/item/clothing/glasses/hud/health) || istype(H.glasses, /obj/item/clothing/glasses/hud/health/health_advanced) ||  istype(CIH,/obj/item/organ/internal/cyberimp/eyes/hud/medical)
 			else
 				return 0
+	else if(isrobot(M) || isAI(M)) //Stand-in/Stopgap to prevent pAIs from freely altering records, pending a more advanced Records system
 		switch(hudtype)
 			if("security")
 				return 1


### PR DESCRIPTION
Fixes #6071

Sorta.

pAIs already have access to their own version of Security/Medical records, which are Read-Only. And yet, their SecHUD/MedHUD Software would give them full access to editable records, making their Records software pretty redundant.

Simultaneously, having access to Sec Records would allow pAIs to freely change Arrest Status. The potential abuse of this feature, considering you can mass-produce pAIs, is obvious.

This change turns the pAI HUD options into a purely visual option. You can still see Arrest Status, Job Icon and Implant indicator, for the SecHUD, and the Health Bar and Indicator for the MedHUD.

Record Software is left untouched.

:cl:
tweak: pAI HUDs are now visual-only, restricting their access to editable records
/:cl: