### PR TITLE
Multiple Ascendant Light Fix

### DIFF
--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -143,7 +143,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 
 				sleep(90)
 				H.visible_message("<span class='warning'>[H]'s body begins to violently stretch and contort.</span>", \
-								  "<span class='shadowling'>You begin to rend apart the final barries to godhood.</span>")
+								  "<span class='shadowling'>You begin to rend apart the final barriers to godhood.</span>")
 
 				sleep(40)
 				to_chat(H, "<i><b>Yes!</b></i>")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1368,7 +1368,7 @@
 		spawn(0)
 			for(var/obj/machinery/light/L in area)
 				if(prob(chance))
-					L.broken()
+					L.broken(0, 1)
 					stoplag()
 
 /obj/machinery/power/apc/proc/setsubsystem(val)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1367,8 +1367,6 @@
 		cell.use(20)
 		spawn(0)
 			for(var/obj/machinery/light/L in area)
-				if(!L.isfunctional())
-					continue
 				if(prob(chance))
 					L.broken()
 					stoplag()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1370,7 +1370,6 @@
 				if(!L.isfunctional())
 					continue
 				if(prob(chance))
-					L.on = 1
 					L.broken()
 					stoplag()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1367,6 +1367,8 @@
 		cell.use(20)
 		spawn(0)
 			for(var/obj/machinery/light/L in area)
+				if(!L.isfunctional())
+					continue
 				if(prob(chance))
 					L.on = 1
 					L.broken()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -581,6 +581,9 @@
 		sleep(1)
 		qdel(src)
 
+/obj/machinery/light/proc/isfunctional()
+	return status == LIGHT_OK
+
 // the light item
 // can be tube or bulb subtypes
 // will fit into empty /obj/machinery/light of the corresponding type

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -579,9 +579,6 @@
 		sleep(1)
 		qdel(src)
 
-/obj/machinery/light/proc/isfunctional()
-	return status == LIGHT_OK
-
 // the light item
 // can be tube or bulb subtypes
 // will fit into empty /obj/machinery/light of the corresponding type

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -514,12 +514,14 @@
 	status = LIGHT_EMPTY
 	update()
 
-/obj/machinery/light/proc/broken(skip_sounds_and_sparks = 0)
-	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN || status == LIGHT_BURNED)
+/obj/machinery/light/proc/broken(skip_sound_and_sparks = 0, overloaded = 0)
+	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN)
 		return
-	if(!skip_sounds_and_sparks)
-		if(status == LIGHT_OK)
+
+	if(!skip_sound_and_sparks)
+		if(status == LIGHT_OK || status == LIGHT_BURNED)
 			playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
+		if(on || overloaded)
 			var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 			s.set_up(3, 1, src)
 			s.start()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -514,17 +514,14 @@
 	status = LIGHT_EMPTY
 	update()
 
-/obj/machinery/light/proc/broken(skip_sound_and_sparks = 0)
-	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN)
+/obj/machinery/light/proc/broken()
+	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN || status == LIGHT_BURNED)
 		return
-
-	if(!skip_sound_and_sparks)
-		if(status == LIGHT_OK || status == LIGHT_BURNED)
-			playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		if(on)
-			var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
-			s.set_up(3, 1, src)
-			s.start()
+	if(status == LIGHT_OK)
+		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
+		var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
+		s.set_up(3, 1, src)
+		s.start()
 	status = LIGHT_BROKEN
 	update()
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -514,14 +514,15 @@
 	status = LIGHT_EMPTY
 	update()
 
-/obj/machinery/light/proc/broken()
+/obj/machinery/light/proc/broken(skip_sounds_and_sparks = 0)
 	if(status == LIGHT_EMPTY || status == LIGHT_BROKEN || status == LIGHT_BURNED)
 		return
-	if(status == LIGHT_OK)
-		playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
-		s.set_up(3, 1, src)
-		s.start()
+	if(!skip_sounds_and_sparks)
+		if(status == LIGHT_OK)
+			playsound(src.loc, 'sound/effects/Glasshit.ogg', 75, 1)
+			var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
+			s.set_up(3, 1, src)
+			s.start()
 	status = LIGHT_BROKEN
 	update()
 


### PR DESCRIPTION
Fixes #6116

As it seems, the reason why lights would be "on" and "too hot" even after being destroyed was because the overload_lighting() proc turned every light on before breaking it. This is fixed in the broken() proc, assuming the light is NOT broken or burned.

This means that if a light is overloaded twice, it was set to "on", and the broken() proc did not update it correctly because the light was already broken.

overloading_lighting() no longer forces lights to be on, and broken() skips over any broken/burned lights, making it so that only lights that are on and functional actually break and spark(le).

:cl:
fix: Broken and Burned bulbs are no longer forced on with every overload.
tweak: Only non-broken and non-burned bulbs actually break and spark on an overload.
fix: Fixes a single syntax error in the Shadowling Ascendant descriptive text.
/:cl:

