### PR TITLE
Fixes a few pAI bugs

### DIFF
--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -24,6 +24,5 @@
 	//Read as: I have no idea what I'm doing but asking for help got me nowhere so this is what you get. - Nodrak
 	if(mind)	qdel(mind)
 	living_mob_list -= src
-	ghostize(0)
 	if(icon_state != "[chassis]_dead" || cleanWipe)
 		qdel(src)

--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -24,6 +24,6 @@
 	//Read as: I have no idea what I'm doing but asking for help got me nowhere so this is what you get. - Nodrak
 	if(mind)	qdel(mind)
 	living_mob_list -= src
-	ghostize()
+	ghostize(0)
 	if(icon_state != "[chassis]_dead" || cleanWipe)
 		qdel(src)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -114,6 +114,11 @@
 		C.toff = 1
 	..()
 
+/mob/living/silicon/pai/update_icons()
+	if(stat == DEAD)
+		icon_state = "[chassis]_dead"
+	else
+		icon_state = resting ? "[chassis]_rest" : "[chassis]"
 
 // this function shows the information about being silenced as a pAI in the Status panel
 /mob/living/silicon/pai/proc/show_silenced()
@@ -420,17 +425,17 @@
 	set category = "IC"
 
 	// Pass lying down or getting up to our pet human, if we're in a rig.
-	if(istype(src.loc,/obj/item/device/paicard))
+	if(stat == CONSCIOUS && istype(src.loc,/obj/item/device/paicard))
 		resting = 0
 		var/obj/item/weapon/rig/rig = src.get_rig()
 		if(istype(rig))
 			rig.force_rest(src)
 	else
 		resting = !resting
-		icon_state = resting ? "[chassis]_rest" : "[chassis]"
 		to_chat(src, "<span class='notice'>You are now [resting ? "resting" : "getting up"]</span>")
 
-	canmove = !resting
+	update_icons()
+	update_canmove()
 
 //Overriding this will stop a number of headaches down the track.
 /mob/living/silicon/pai/attackby(obj/item/weapon/W as obj, mob/user as mob, params)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -28,6 +28,9 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 		if("signup" in href_list)
 			var/mob/dead/observer/O = locate(href_list["signup"])
 			if(!O) return
+			if(!(O in respawnable_list))
+				to_chat(O, "You've given up your ability to respawn!")
+				return
 			if(!check_recruit(O)) return
 			recruitWindow(O)
 			return
@@ -360,6 +363,8 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 		if(!player_old_enough_antag(O.client,ROLE_PAI))
 			return 0
 		if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+			return 0
+		if(!(O in respawnable_list))
 			return 0
 		if(O.client)
 			return 1

--- a/code/modules/mob/living/silicon/pai/say.dm
+++ b/code/modules/mob/living/silicon/pai/say.dm
@@ -6,8 +6,11 @@
 
 /mob/living/silicon/pai/get_whisper_loc()
 	if(loc == card)			// currently in its card?
-		if(istype(card.loc, /mob/living))
-			return card.loc	// allow a pai being held or in pocket to whisper
+		var/atom/movable/whisper_loc = card
+		if(istype(card.loc, /obj/item/device/pda)) // Step up 1 level if in a PDA
+			whisper_loc = card.loc
+		if(istype(whisper_loc.loc, /mob/living))
+			return whisper_loc.loc	// allow a pai being held or in pocket to whisper
 		else
-			return card		// allow a pai in its card to whisper
+			return whisper_loc		// allow a pai in its card to whisper
 	return ..()

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -15,7 +15,7 @@
 	return STATUS_UPDATE						// Ghosts can view updates
 
 /mob/living/silicon/pai/default_can_use_topic(var/src_object)
-	if(src_object == src && !stat)
+	if((src_object == src || src_object == radio) && stat == CONSCIOUS)
 		return STATUS_INTERACTIVE
 	else
 		return ..()


### PR DESCRIPTION
A gesture of appreciation for our favorite silicon nuisances!

Fixes #2562
Fixes #2564
Fixes #2810
Fixes #4341
Fixes #4513

:cl:Crazylemon
fix: pAIs can now adjust their radios
fix: pAIs can now more reliably hear nearby whispers
fix: pAIs can now whisper while inside a PDA
fix: pAIs can no longer change their icon from being dead, while dead
fix: Non-respawnable players are no longer prompted to submit a pAI when the opportunity is available
/:cl: