### PR TITLE
Ghosts now have an indicator on whether they can respawn or not

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -226,6 +226,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(client.statpanel == "Status")
 		show_stat_station_time()
 		show_stat_emergency_shuttle_eta()
+		stat(null, "Respawnability: [(src in respawnable_list) ? "Yes" : "No"]")
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"


### PR DESCRIPTION
![can_respawn](https://cloud.githubusercontent.com/assets/5661700/21792817/4572e11a-d6a1-11e6-83fd-570d57e8d97f.png)
![cannot_respawn](https://cloud.githubusercontent.com/assets/5661700/21792818/458cc814-d6a1-11e6-811c-2f2941eb2b6f.png)
Super spartan, but it tells you useful stuff.
Also, will make debugging ghost-related stuff a good deal easier.
:cl:Crazylemon
rscadd: Ghosts can now see if they're allowed to respawn or not at a glance
/:cl: