### PR TITLE
Nerfs Neurotoxin

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -819,8 +819,11 @@
 	drink_desc = "A drink that is guaranteed to knock you silly."
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/M)
+	if(current_cycle >= 12)
+		M.Dizzy(10)
+	if(current_cycle >= 36)
+		M.Weaken(6)
 	if(current_cycle >= 55)
-		M.Weaken(3)
 		M.Druggy(55)
 	if(current_cycle >= 200)
 		M.adjustToxLoss(2)

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -819,10 +819,10 @@
 	drink_desc = "A drink that is guaranteed to knock you silly."
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/M)
-	M.Weaken(3)
-	if(current_cycle >=55)
+	if(current_cycle >= 55)
+		M.Weaken(3)
 		M.Druggy(55)
-	if(current_cycle >=200)
+	if(current_cycle >= 200)
 		M.adjustToxLoss(2)
 	..()
 


### PR DESCRIPTION
Nerfs Neurotoxin.

This really should have been done a long time ago. This is nothing more than a nigh-uncounterable infinitely reproducible instant knock-out chemical; it outclasses and generally outperforms even the ultra-high end traitor-only knockout chems.

Neurotoxin now stuns after 55 cycles instead of being an instantaneous knockout.

:cl: Fox McCloud
tweak: Neurotoxin knockout has a very long delay as opposed to being instant
/:cl: