### PR TITLE
Fixing Food Runtime

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -517,8 +517,6 @@
 	description = "Some cheese. Pour it out to make it solid."
 	reagent_state = SOLID
 	color = "#FFFF00"
-	metabolization_rate = 0 //heheheh
-	nutriment_factor = 0
 
 /datum/reagent/consumable/cheese/on_mob_life(mob/living/M)
 	if(prob(3))
@@ -548,9 +546,7 @@
 	description = "Hell, I don't even know if this IS cheese. Whatever it is, it ain't normal. If you want to, pour it out to make it solid."
 	reagent_state = SOLID
 	color = "#50FF00"
-	metabolization_rate = 0 //heheheh
 	addiction_chance = 5
-	nutriment_factor = 0
 
 /datum/reagent/consumable/weird_cheese/on_mob_life(mob/living/M)
 	if(prob(5))


### PR DESCRIPTION
Fixes not being able to eat under certain circumstances.


Basicccallyyy, if you ate cheese, it would forever break your ability to eat as it would cause a division by 0 runtime.

Cheese forever staying in your system was a great joke, but it can't persist.

"Huh, I guses cheese really does block you up" -@Crazylemon64 1/10/2017