### PR TITLE
TEG's circulators can now be controlled

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -87,14 +87,14 @@
 		return air2
 
 /obj/machinery/atmospherics/binary/circulator/proc/get_inlet_side()
-	if(dir==1||dir==2)
+	if(dir==SOUTH||dir==NORTH)
 		if(sides_inverted==0)
 			return "South"
 		else
 			return "North"
 
 /obj/machinery/atmospherics/binary/circulator/proc/get_outlet_side()
-	if(dir==1||dir==2)
+	if(dir==SOUTH||dir==NORTH)
 		if(sides_inverted==0)
 			return "North"
 		else

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -21,7 +21,7 @@
 	density = 1
 
 	can_unwrench = 1
-	var/sides_inverted = 0
+	var/side_inverted = 0
 
 // Creating a custom circulator pipe subtype to be delivered through cargo
 /obj/item/pipe/circulator
@@ -75,37 +75,37 @@
 	update_icon()
 
 /obj/machinery/atmospherics/binary/circulator/proc/get_inlet_air()
-	if(sides_inverted==0)
+	if(side_inverted==0)
 		return air2
 	else
 		return air1
 
 /obj/machinery/atmospherics/binary/circulator/proc/get_outlet_air()
-	if(sides_inverted==0)
+	if(side_inverted==0)
 		return air1
 	else
 		return air2
 
 /obj/machinery/atmospherics/binary/circulator/proc/get_inlet_side()
 	if(dir==SOUTH||dir==NORTH)
-		if(sides_inverted==0)
+		if(side_inverted==0)
 			return "South"
 		else
 			return "North"
 
 /obj/machinery/atmospherics/binary/circulator/proc/get_outlet_side()
 	if(dir==SOUTH||dir==NORTH)
-		if(sides_inverted==0)
+		if(side_inverted==0)
 			return "North"
 		else
 			return "South"
 
 /obj/machinery/atmospherics/binary/circulator/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/device/multitool))
-		if(sides_inverted == 0)
-			sides_inverted = 1
+	if(ismultitool(W))
+		if(side_inverted == 0)
+			side_inverted = 1
 		else
-			sides_inverted = 0
+			side_inverted = 0
 		to_chat(user, "<span class='notice'>You reverse the circulator's valve settings. The inlet of the circulator is now on the [get_inlet_side(dir)] side.</span>")
 		desc = "A gas circulator pump and heat exchanger. Its input port is on the [get_inlet_side(dir)] side, and its output port is on the [get_outlet_side(dir)] side."
 	else

--- a/code/ATMOSPHERICS/components/binary_devices/circulator.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/circulator.dm
@@ -7,29 +7,30 @@
 	icon_state = "circ1-off"
 
 	var/side = CIRC_LEFT
-	
+
 	var/global/const/CIRC_LEFT = WEST
 	var/global/const/CIRC_RIGHT = EAST
 
 	var/last_pressure_delta = 0
-	
+
 	var/obj/machinery/power/generator/generator
 
 	layer = 2.45 // Just above wires
-	
+
 	anchored = 1
 	density = 1
-	
+
 	can_unwrench = 1
-	
-// Creating a custom circulator pipe subtype to be delivered through cargo	
+	var/sides_inverted = 0
+
+// Creating a custom circulator pipe subtype to be delivered through cargo
 /obj/item/pipe/circulator
 	name = "circulator/heat exchanger fitting"
 
 /obj/item/pipe/circulator/New(loc)
 	var/obj/machinery/atmospherics/binary/circulator/C = new /obj/machinery/atmospherics/binary/circulator(null)
-	..(loc, make_from = C) 
-	
+	..(loc, make_from = C)
+
 /obj/machinery/atmospherics/binary/circulator/Destroy()
 	if(generator && generator.cold_circ == src)
 		generator.cold_circ = null
@@ -38,8 +39,10 @@
 	return ..()
 
 /obj/machinery/atmospherics/binary/circulator/proc/return_transfer_air()
-	var/output_starting_pressure = air1.return_pressure()
-	var/input_starting_pressure = air2.return_pressure()
+	var/datum/gas_mixture/inlet = get_inlet_air()
+	var/datum/gas_mixture/outlet = get_outlet_air()
+	var/output_starting_pressure = outlet.return_pressure()
+	var/input_starting_pressure = inlet.return_pressure()
 
 	if(output_starting_pressure >= input_starting_pressure - 10)
 		//Need at least 10 KPa difference to overcome friction in the mechanism
@@ -47,17 +50,17 @@
 		return null
 
 	//Calculate necessary moles to transfer using PV = nRT
-	if(air2.temperature > 0)
+	if(inlet.temperature > 0)
 		var/pressure_delta = (input_starting_pressure - output_starting_pressure) / 2
 
-		var/transfer_moles = pressure_delta * air1.volume/(air2.temperature * R_IDEAL_GAS_EQUATION)
+		var/transfer_moles = pressure_delta * outlet.volume/(inlet.temperature * R_IDEAL_GAS_EQUATION)
 
 		last_pressure_delta = pressure_delta
 
 		//log_debug("pressure_delta = [pressure_delta]; transfer_moles = [transfer_moles];")
 
 		//Actually transfer the gas
-		var/datum/gas_mixture/removed = air2.remove(transfer_moles)
+		var/datum/gas_mixture/removed = inlet.remove(transfer_moles)
 
 		parent1.update = 1
 		parent2.update = 1
@@ -70,6 +73,43 @@
 /obj/machinery/atmospherics/binary/circulator/process()
 	..()
 	update_icon()
+
+/obj/machinery/atmospherics/binary/circulator/proc/get_inlet_air()
+	if(sides_inverted==0)
+		return air2
+	else
+		return air1
+
+/obj/machinery/atmospherics/binary/circulator/proc/get_outlet_air()
+	if(sides_inverted==0)
+		return air1
+	else
+		return air2
+
+/obj/machinery/atmospherics/binary/circulator/proc/get_inlet_side()
+	if(dir==1||dir==2)
+		if(sides_inverted==0)
+			return "South"
+		else
+			return "North"
+
+/obj/machinery/atmospherics/binary/circulator/proc/get_outlet_side()
+	if(dir==1||dir==2)
+		if(sides_inverted==0)
+			return "North"
+		else
+			return "South"
+
+/obj/machinery/atmospherics/binary/circulator/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/device/multitool))
+		if(sides_inverted == 0)
+			sides_inverted = 1
+		else
+			sides_inverted = 0
+		to_chat(user, "<span class='notice'>You reverse the circulator's valve settings. The inlet of the circulator is now on the [get_inlet_side(dir)] side.</span>")
+		desc = "A gas circulator pump and heat exchanger. Its input port is on the [get_inlet_side(dir)] side, and its output port is on the [get_outlet_side(dir)] side."
+	else
+		..()
 
 /obj/machinery/atmospherics/binary/circulator/update_icon()
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -10,23 +10,23 @@
 	var/obj/machinery/atmospherics/binary/circulator/hot_circ
 
 	var/cold_dir = WEST
-	var/hot_dir = EAST	
-	
+	var/hot_dir = EAST
+
 	var/lastgen = 0
 	var/lastgenlev = -1
 	var/lastcirc = "00"
-	
+
 /obj/machinery/power/generator/New()
 	..()
 	update_desc()
-	
+
 /obj/machinery/power/generator/proc/update_desc()
 	desc = initial(desc) + " Its cold circulator is located on the [dir2text(cold_dir)] side, and its heat circulator is located on the [dir2text(hot_dir)] side."
-	
+
 /obj/machinery/power/generator/Destroy()
 	disconnect()
 	return ..()
-	
+
 /obj/machinery/power/generator/proc/disconnect()
 	if(cold_circ)
 		cold_circ.generator = null
@@ -38,10 +38,10 @@
 /obj/machinery/power/generator/initialize()
 	..()
 	connect()
-	
+
 /obj/machinery/power/generator/proc/connect()
 	connect_to_network()
-	
+
 	var/obj/machinery/atmospherics/binary/circulator/circpath = /obj/machinery/atmospherics/binary/circulator
 	cold_circ = locate(circpath) in get_step(src, cold_dir)
 	hot_circ = locate(circpath) in get_step(src, hot_dir)
@@ -61,13 +61,13 @@
 	power_change()
 	update_icon()
 	updateDialog()
-	
+
 /obj/machinery/power/generator/power_change()
 	if(!anchored)
 		stat |= NOPOWER
 	else
 		..()
-	
+
 /obj/machinery/power/generator/update_icon()
 	if(stat & (NOPOWER|BROKEN))
 		overlays.Cut()
@@ -79,7 +79,7 @@
 
 		overlays += image('icons/obj/power.dmi', "teg-oc[lastcirc]")
 
-/obj/machinery/power/generator/process()	
+/obj/machinery/power/generator/process()
 	if(stat & (NOPOWER|BROKEN))
 		return
 
@@ -128,11 +128,11 @@
 		// update icon overlays only if displayed level has changed
 
 		if(hot_air)
-			var/datum/gas_mixture/hot_circ_air1 = hot_circ.air1
+			var/datum/gas_mixture/hot_circ_air1 = hot_circ.get_outlet_air()
 			hot_circ_air1.merge(hot_air)
 
 		if(cold_air)
-			var/datum/gas_mixture/cold_circ_air1 = cold_circ.air1
+			var/datum/gas_mixture/cold_circ_air1 = cold_circ.get_outlet_air()
 			cold_circ_air1.merge(cold_air)
 
 	var/genlev = max(0, min( round(11 * lastgen / 100000), 11))
@@ -146,12 +146,12 @@
 
 /obj/machinery/power/generator/attack_ai(mob/user)
 	return attack_hand(user)
-	
+
 /obj/machinery/power/generator/attack_ghost(mob/user)
 	if(stat & (NOPOWER|BROKEN))
 		return
-	interact(user)	
-	
+	interact(user)
+
 /obj/machinery/power/generator/attack_hand(mob/user)
 	if(..())
 		user << browse(null, "window=teg")
@@ -172,25 +172,31 @@
 		if(cold_dir == WEST)
 			cold_dir = EAST
 			hot_dir = WEST
-		else
+		else if(cold_dir == NORTH)
+			cold_dir = SOUTH
+			hot_dir = NORTH
+		else if(cold_dir == EAST)
 			cold_dir = WEST
 			hot_dir = EAST
+		else
+			cold_dir = NORTH
+			hot_dir = SOUTH
 		connect()
 		to_chat(user, "<span class='notice'>You reverse the generator's circulator settings. The cold circulator is now on the [dir2text(cold_dir)] side, and the heat circulator is now on the [dir2text(hot_dir)] side.</span>")
 		update_desc()
 	else
-		..()	
-	
+		..()
+
 /obj/machinery/power/generator/proc/get_menu(include_link = 1)
 	var/t = ""
 	if(!powernet)
 		t += "<span class='bad'>Unable to connect to the power network!</span>"
 		t += "<BR><A href='?src=[UID()];check=1'>Retry</A>"
 	else if(cold_circ && hot_circ)
-		var/datum/gas_mixture/cold_circ_air1 = cold_circ.air1
-		var/datum/gas_mixture/cold_circ_air2 = cold_circ.air2
-		var/datum/gas_mixture/hot_circ_air1 = hot_circ.air1
-		var/datum/gas_mixture/hot_circ_air2 = hot_circ.air2
+		var/datum/gas_mixture/cold_circ_air1 = cold_circ.get_outlet_air()
+		var/datum/gas_mixture/cold_circ_air2 = cold_circ.get_inlet_air()
+		var/datum/gas_mixture/hot_circ_air1 = hot_circ.get_outlet_air()
+		var/datum/gas_mixture/hot_circ_air2 = hot_circ.get_inlet_air()
 
 		t += "<div class='statusDisplay'>"
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -168,7 +168,7 @@
 			connect()
 		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>You [anchored ? "secure" : "unsecure"] the bolts holding [src] to the floor.</span>")
-	else if(istype(W, /obj/item/device/multitool))
+	else if(ismultitool(W))
 		if(cold_dir == WEST)
 			cold_dir = EAST
 			hot_dir = WEST


### PR DESCRIPTION
Allows control over TEG's circulator inlet and outlet directions via multitool.
Updates generator to accommodate changes and added code that will allow generator to work if TEG's circulators can be made in N/S configuration (hopefully someone can help me with that).

:cl:
tweak: multitool can now be used to swap directions of TEG's circulator
/:cl:

first commit in this repo