### PR TITLE
Makes Adminbussing Evil Traps Easier

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -15,6 +15,10 @@
 	var/atom_say_verb = "says"
 	var/dont_save = 0 // For atoms that are temporary by necessity - like lighting overlays
 
+	// A list of datums that desire to interact with this atom - used so that automated processes
+	// don't step on one another's toes, if they are doing an action that takes time
+	var/list/interaction_queue = list()
+
 	///Chemistry.
 	var/datum/reagents/reagents = null
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -15,10 +15,6 @@
 	var/atom_say_verb = "says"
 	var/dont_save = 0 // For atoms that are temporary by necessity - like lighting overlays
 
-	// A list of datums that desire to interact with this atom - used so that automated processes
-	// don't step on one another's toes, if they are doing an action that takes time
-	var/list/interaction_queue = list()
-
 	///Chemistry.
 	var/datum/reagents/reagents = null
 

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -132,6 +132,22 @@ Class Procs:
 	else
 		fast_processing += src
 
+// gotta go fast
+/obj/machinery/proc/makeSpeedProcess()
+	if(speed_process)
+		return
+	speed_process = 1
+	machine_processing -= src
+	fast_processing += src
+
+// gotta go slow
+/obj/machinery/proc/makeNormalProcess()
+	if(!speed_process)
+		return
+	speed_process = 0
+	machine_processing += src
+	fast_processing -= src
+
 /obj/machinery/New() //new
 	machines += src
 	..()

--- a/code/modules/admin/buildmode.dm
+++ b/code/modules/admin/buildmode.dm
@@ -446,22 +446,8 @@
 				log_admin("Build Mode: [key_name(user)] built an airlock at ([object.x],[object.y],[object.z])")
 				new/obj/machinery/door/airlock(get_turf(object))
 			else if(istype(object,/turf) && ctrl_click && left_click)
-				switch(build_dir)
-					if(NORTH)
-						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = NORTH
-					if(SOUTH)
-						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = SOUTH
-					if(EAST)
-						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = EAST
-					if(WEST)
-						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = WEST
-					if(NORTHWEST)
-						var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
-						WIN.dir = NORTHWEST
+				var/obj/structure/window/reinforced/WIN = new/obj/structure/window/reinforced(get_turf(object))
+				WIN.set_dir(build_dir)
 				log_admin("Build Mode: [key_name(user)] built a window at ([object.x],[object.y],[object.z])")
 
 		if(ADV_BUILDMODE)
@@ -472,7 +458,7 @@
 					T.ChangeTurf(objholder)
 				else
 					var/obj/A = new objholder (get_turf(object))
-					A.dir = build_dir
+					A.set_dir(build_dir)
 					log_admin("Build Mode: [key_name(user)] modified [A]'s ([A.x],[A.y],[A.z]) dir to [build_dir]")
 			else if(right_click)
 				if(isobj(object))
@@ -561,7 +547,7 @@
 									T.ChangeTurf(objholder)
 								else
 									var/obj/A = new objholder(T)
-									A.dir = build_dir
+									A.set_dir(build_dir)
 						deselect_region()
 					return
 

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -18,7 +18,6 @@
 
 	// For hiding gibs, making an even more devious trap (invisible autogibbers)
 	var/stealthmode = FALSE
-
 	var/list/victims = list()
 
 	use_power = 1
@@ -236,7 +235,7 @@
 	operating = 1
 	update_icon()
 	var/offset = prob(50) ? -2 : 2
-	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = 200) //start shaking
+	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = gibtime * 5) //start shaking
 
 	var/slab_name = occupant.name
 	var/slab_count = 3
@@ -275,7 +274,6 @@
 
 	occupant.emote("scream")
 	playsound(get_turf(src), 'sound/goonstation/effects/gib.ogg', 50, 1)
-
 	victims += "\[[time_stamp()]\] [occupant.name] ([occupant.ckey]) killed by [UserOverride ? "Autogibbing" : "[user] ([user.ckey])"]" //have to do this before ghostizing
 	occupant.death(1)
 	occupant.ghostize()
@@ -332,7 +330,7 @@
 	RefreshParts()
 
 /obj/machinery/gibber/autogibber/process()
-	if(!lturf || occupant || locked || dirty || operating || occupant || victim_targets.len)
+	if(!lturf || occupant || locked || dirty || operating || victim_targets.len)
 		return
 
 	if(acceptdir != lastacceptdir)
@@ -343,8 +341,7 @@
 			lturf = T
 
 	for(var/mob/living/carbon/human/H in lturf)
-		if(istype(H) && H.loc == lturf)
-			victim_targets += H
+		victim_targets += H
 
 	if(victim_targets.len)
 		visible_message({"<span class='danger'>\The [src] states, "Food detected!"</span>"})

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -50,6 +50,10 @@
 		dir = newdir
 	update_move_direction()
 
+/obj/machinery/conveyor/set_dir(newdir)
+	. = ..()
+	update_move_direction()
+
 
 /obj/machinery/conveyor/proc/update_move_direction()
 	switch(dir)


### PR DESCRIPTION
![lemon_is_crazy](https://cloud.githubusercontent.com/assets/5661700/21844276/d12f21f8-d7a2-11e6-96b6-6a648b72dcdd.png)
![hehehe](http://3.bp.blogspot.com/_ibAoXBVpmj8/SRBOauRWY_I/AAAAAAAACWY/qk7iuysKfUY/s320/calvin+evil+grin.bmp)

Conveyor belts can now be aligned directly through buildmode, instead of having to set the vars by hand
Gibbers now have some extra vars to let them be used better for traps and work faster.

Vars/procs added for purpose of admin modification:
The procs `makeSpeedProcess` and `makeNormalProcess` cause a machine to either go fast or slow, respectively.
On gibbers:
`animation_delay` scales how quickly people enter the gibber
`consumption_delay` is how long between the gibber first noticing, and the gibber sucking someone in
`stealthmode`, if set, will hide gibs, blood, and other items, so an invisible gibber can become a trap

On conveyors:
`set_dir` now updates the direction of the belt appropriately - useful for buildmode