### PR TITLE
Graffiti (Hidden) Fingerprints

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -88,7 +88,7 @@
 		to_chat(user, "You start drawing a [temp] on the [target.name].")
 		if(instant || do_after(user, 50, target = target))
 			var/obj/effect/decal/cleanable/crayon/C = new /obj/effect/decal/cleanable/crayon(target,colour,drawtype,temp)
-			C.add_fingerprint(user)
+			C.add_hiddenprint(user)
 			to_chat(user, "You finish drawing [temp].")
 			if(uses)
 				uses--

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -87,7 +87,8 @@
 			temp = "graffiti"
 		to_chat(user, "You start drawing a [temp] on the [target.name].")
 		if(instant || do_after(user, 50, target = target))
-			new /obj/effect/decal/cleanable/crayon(target,colour,drawtype,temp)
+			var/obj/effect/decal/cleanable/crayon/C = new /obj/effect/decal/cleanable/crayon(target,colour,drawtype,temp)
+			C.add_fingerprint(user)
 			to_chat(user, "You finish drawing [temp].")
 			if(uses)
 				uses--


### PR DESCRIPTION
Fixes #6059

No witty commentary. Graffiti now leave hidden fingerprints visible only to Administrators.

:cl:
fix: Graffiti now have hidden (Admin-only) fingerprints added to them
/:cl: