### PR TITLE
Display Case Cyborg Tools

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -266,14 +266,14 @@ var/global/list/captain_display_cases = list()
 			to_chat(user, "<span class='warning'>It's locked, you can't put anything into it.</span>")
 			return
 		if(!occupant)
-			if(user.drop_item())
-				to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
-				W.forceMove(src)
-				occupant=W
-				update_icon()
-			else
-				to_chat(user, "<span class='notice'>That tool is attached to you!</span>")
+			if(!user.drop_item())
+				to_chat(user, "<span class='notice'>The [W] is stuck to you. You cannot put it in the [src]!</span>")
 				return
+			to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
+			user.drop_item()
+			W.forceMove(src)
+			occupant=W
+			update_icon()
 
 /obj/structure/displaycase/attack_hand(mob/user as mob)
 	if(destroyed || (!locked && user.a_intent == I_HARM))

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -266,11 +266,14 @@ var/global/list/captain_display_cases = list()
 			to_chat(user, "<span class='warning'>It's locked, you can't put anything into it.</span>")
 			return
 		if(!occupant)
-			to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
-			user.drop_item()
-			W.forceMove(src)
-			occupant=W
-			update_icon()
+			if(user.drop_item())
+				to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
+				W.forceMove(src)
+				occupant=W
+				update_icon()
+			else
+				to_chat(user, "<span class='notice'>That tool is attached to you!</span>")
+				return
 
 /obj/structure/displaycase/attack_hand(mob/user as mob)
 	if(destroyed || (!locked && user.a_intent == I_HARM))

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -267,7 +267,7 @@ var/global/list/captain_display_cases = list()
 			return
 		if(!occupant)
 			if(!user.drop_item())
-				to_chat(user, "<span class='notice'>The [W] is stuck to you. You cannot put it in the [src]!</span>")
+				to_chat(user, "<span class='notice'>[W] is stuck to you. You cannot put it in [src]!</span>")
 				return
 			to_chat(user, "<span class='notice'>You insert \the [W] into \the [src], and it floats as the hoverfield activates.</span>")
 			user.drop_item()


### PR DESCRIPTION
Fixes #6035

Goddamnit, ForceMove, stop being an asshole.

:cl:
fix: Cyborg tools (and other non-droppable tools) cannot be transferred to an open, empty Display Case
/:cl: