### PR TITLE
Tweaks Cult Datum Initialization

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -31,7 +31,7 @@
 	var/ert_disabled = 0
 	var/uplink_welcome = "Syndicate Uplink Console:"
 	var/uplink_uses = 20
-	var/datum/cult_info/cultdat = new /datum/cult_info() //here instead of cult for adminbus purposes
+	var/datum/cult_info/cultdat //here instead of cult for adminbus purposes
 
 	var/const/waittime_l = 600  //lower bound on time before intercept arrives (in tenths of seconds)
 	var/const/waittime_h = 1800 //upper bound on time before intercept arrives (in tenths of seconds)
@@ -62,7 +62,7 @@
 ///pre_setup()
 ///Attempts to select players for special roles the mode might have.
 /datum/game_mode/proc/pre_setup()
-	cultdat = setupcult()
+
 	return 1
 
 
@@ -334,6 +334,7 @@
 
 /datum/game_mode/New()
 	newscaster_announcements = pick(newscaster_standard_feeds)
+	cultdat = setupcult()
 
 //////////////////////////
 //Reports player logouts//

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -150,12 +150,15 @@
 		ticker.syndicate_coalition.Add(S)
 
 /proc/setupcult()
+	var/static/picked_cult // Only needs to get picked once
+
+	if(picked_cult)
+		return picked_cult
+
 	var/random_cult = pick(all_cults)
-	var/picked_cult = new random_cult() //this seems redundent as fuck
-	log_startup_progress("Summoning eldritch horrors...")
-	if(!picked_cult)//shouldn't happen BUT JUST TO BE SURE LET US KNOW
-		log_startup_progress(" Failed to select a cult datum, Shank a coder!")
-	else
-		log_startup_progress(" [picked_cult] has risen!")
+	picked_cult = new random_cult()
+
+	if(!picked_cult)
+		log_runtime(EXCEPTION("Cult datum creation failed"))
 	//todo:add adminonly datum var, check for said var here...
 	return picked_cult


### PR DESCRIPTION
- Removes the initialization messages.
  - These absolutely should not have been showing up when they were (during round-start game mode initialization) to who they were (everyone).
  - Fixes #6162.
- Moves `mode.cultdat` setting from `pre_setup` to `New`
  - Not all game modes bothered calling the parent `pre_setup`, leaving `cultdat` unrandomized.
- Makes the cult datum only get created once.
  - Previously, every time a game mode tried to start (which could be multiple times, if the first picked mode can't initialize), one would get created alongside the game mode, then *another* would (usually) get created when `pre_setup` ran.
    - Technically, this didn't cause any problems, but it sure was silly.

:cl:
tweak: Players will no longer be informed of what cult may or may not exist on round start.
/:cl: