### PR TITLE
Pet Slime Tweaks

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -254,7 +254,7 @@
 		/mob/living/carbon/slime,
 		/mob/living/carbon/alien/larva,
 		/mob/living/simple_animal/slime,
-		/mob/living/simple_animal/adultslime,
+		/mob/living/simple_animal/slime/adult,
 		/mob/living/simple_animal/chick,
 		/mob/living/simple_animal/chicken,
 		/mob/living/simple_animal/lizard,

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -254,7 +254,6 @@
 		/mob/living/carbon/slime,
 		/mob/living/carbon/alien/larva,
 		/mob/living/simple_animal/slime,
-		/mob/living/simple_animal/slime/adult,
 		/mob/living/simple_animal/chick,
 		/mob/living/simple_animal/chicken,
 		/mob/living/simple_animal/lizard,

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -15,67 +15,13 @@
 	var/colour = "grey"
 	pass_flags = PASSTABLE
 
-/mob/living/simple_animal/slime/Bump(atom/movable/AM as mob|obj, yes)
-
-	spawn( 0 )
-		if((!( yes ) || now_pushing))
-			return
-		now_pushing = 1
-		if(ismob(AM))
-			var/mob/tmob = AM
-			if(istype(tmob, /mob/living/carbon/human) && (FAT in tmob.mutations))
-				if(prob(70))
-					to_chat(src, "<span class='danger'>You fail to push [tmob]'s fat ass out of the way.</span>")
-					now_pushing = 0
-					return
-			if(!(tmob.status_flags & CANPUSH))
-				now_pushing = 0
-				return
-
-			tmob.LAssailant = src
-		now_pushing = 0
-		..()
-		if(!( istype(AM, /atom/movable) ))
-			return
-		if(!( now_pushing ))
-			now_pushing = 1
-			if(!( AM.anchored ))
-				var/t = get_dir(src, AM)
-				if(istype(AM, /obj/structure/window/full))
-					for(var/obj/structure/window/win in get_step(AM,t))
-						now_pushing = 0
-						return
-				step(AM, t)
-			now_pushing = null
-		return
-	return
-
-/mob/living/simple_animal/adultslime
-	name = "pet slime"
-	desc = "A lovable, domesticated slime."
-	icon = 'icons/mob/slimes.dmi'
+/mob/living/simple_animal/slime/adult
 	health = 200
 	maxHealth = 200
 	icon_state = "grey adult slime"
 	icon_living = "grey adult slime"
 	icon_dead = "grey baby slime dead"
-	response_help  = "pets"
-	response_disarm = "shoos"
-	response_harm   = "stomps on"
-	emote_see = list("jiggles", "bounces in place")
-	var/colour = "grey"
-	del_on_death = 1
 
-/mob/living/simple_animal/adultslime/New()
+/mob/living/simple_animal/slime/New()
 	..()
 	overlays += "aslime-:33"
-
-
-/mob/living/simple_animal/slime/adult/death(gibbed)
-	for(var/i in 1 to 2)
-		var/mob/living/simple_animal/slime/S = new /mob/living/simple_animal/slime (src.loc)
-		S.icon_state = "[colour] baby slime"
-		S.icon_living = "[colour] baby slime"
-		S.icon_dead = "[colour] baby slime dead"
-		S.colour = "[colour]"
-	..()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -134,45 +134,42 @@
 	desc = "A potent chemical mix that nullifies a slime's hunger, causing it to become docile and tame."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "bottle19"
+	var/being_used = 0
 
 /obj/item/slimepotion/docility/attack(mob/living/carbon/slime/M, mob/user)
 	if(!isslime(M))
 		to_chat(user, "<span class='warning'> The potion only works on slimes!</span>")
-		return ..()
+		return
 	if(M.stat)
 		to_chat(user, "<span class='warning'> The slime is dead!</span>")
-		return..()
+		return
 	if(M.mind)
 		to_chat(user, "<span class='warning'> The slime resists!</span>")
-		return ..()
+		return
+	if(being_used)
+		to_chat(user, "<span class='warning'> You're already using this on another slime!</span>")
+		return
+
+	var/mob/living/simple_animal/slime/pet
 	if(M.is_adult)
-		var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
+		pet = new /mob/living/simple_animal/slime/adult(M.loc)
 		pet.icon_state = "[M.colour] adult slime"
 		pet.icon_living = "[M.colour] adult slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		qdel(M)
-		var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
-
-		if(!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
-		qdel(src)
 	else
-		var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
+		pet = new /mob/living/simple_animal/slime(M.loc)
 		pet.icon_state = "[M.colour] baby slime"
 		pet.icon_living = "[M.colour] baby slime"
-		pet.icon_dead = "[M.colour] baby slime dead"
-		pet.colour = "[M.colour]"
-		qdel(M)
-		var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
+	pet.icon_dead = "[M.colour] baby slime dead"
+	pet.colour = "[M.colour]"
+	qdel(M)
+	being_used = 1
+	var/newname = sanitize(copytext(input(user, "Would you like to give the slime a name?", "Name your new pet", "pet slime") as null|text,1,MAX_NAME_LEN))
 
-		if(!newname)
-			newname = "pet slime"
-		pet.name = newname
-		pet.real_name = newname
-		qdel(src)
+	if(!newname)
+		newname = "pet slime"
+	pet.name = newname
+	pet.real_name = newname
+	qdel(src)
 	to_chat(user, "You feed the slime the potion, removing it's powers and calming it.")
 
 /obj/item/slimepotion/sentience


### PR DESCRIPTION
- Baby pet slimes now have the :3 face:
  ![petslimes](https://cloud.githubusercontent.com/assets/10916307/21958624/5aa3c5c6-da80-11e6-92b6-43aadb717fbf.gif)
- Adult pet slimes are now a subtype of baby pet slimes.
  - The separate `/adultslime` type has been removed.
- Adult pet slimes can now blorp over tables like regular adult slimes.
- Baby pet slimes no longer have custom bump code that brings the server to its knees.
- Docility potion code has been refactored to reduce redundancy, and no longer allows one potion to be used on multiple slimes.