### PR TITLE
Makes Reagents Holder Process and Refactors NOREACT

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -24,8 +24,8 @@
 #define BLOCK_GAS_SMOKE_EFFECT	8192	// blocks the effect that chemical clouds would have on a mob --glasses, mask and helmets ONLY!
 #define THICKMATERIAL 			8192	//prevents syringes, parapens and hypos if the external suit or helmet (if targeting head) has this flag. Example: space suits, biosuit, bombsuits, thick suits that cover your body. (NOTE: flag shared with BLOCK_GAS_SMOKE_EFFECT)
 
-
-#define	NOREACT					16384 	//Reagents dont' react inside this container.
+//Reagent flags
+#define REAGENT_NOREACT			1
 
 //Species flags.
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -243,7 +243,6 @@
 	desc = "Equipment for medical exosuits. A chem synthesizer with syringe gun. Reagents inside are held in stasis, so no reactions will occur."
 	icon = 'icons/obj/guns/projectile.dmi'
 	icon_state = "syringegun"
-	flags = NOREACT
 	var/list/syringes
 	var/list/known_reagents
 	var/list/processed_reagents
@@ -259,6 +258,7 @@
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/New()
 	..()
 	create_reagents(max_volume)
+	reagents.set_reacting(FALSE)
 	syringes = new
 	known_reagents = list("epinephrine"="Epinephrine","charcoal"="Charcoal")
 	processed_reagents = new
@@ -273,7 +273,8 @@
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/critfail()
 	..()
-	flags &= ~NOREACT
+	if(reagents)
+		reagents.set_reacting(TRUE)
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/can_attach(obj/mecha/medical/M)
 	if(..())

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -42,11 +42,13 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 /obj/item/clothing/mask/cigarette/New()
 	..()
-	flags |= NOREACT // so it doesn't react until you light it
 	create_reagents(chem_volume) // making the cigarrete a chemical holder with a maximum volume of 30
+	reagents.set_reacting(FALSE) // so it doesn't react until you light it
 
 /obj/item/clothing/mask/cigarette/Destroy()
-	qdel(reagents)
+	if(reagents)
+		qdel(reagents)
+	processing_objects -= src
 	return ..()
 
 /obj/item/clothing/mask/cigarette/attack(var/mob/living/M, var/mob/living/user, def_zone)
@@ -135,7 +137,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 				M.unEquip(src, 1)
 			qdel(src)
 			return
-		flags &= ~NOREACT // allowing reagents to react after being lit
+		reagents.set_reacting(TRUE)
 		reagents.handle_reactions()
 		icon_state = icon_on
 		item_state = icon_on

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -176,8 +176,8 @@
 
 /obj/item/weapon/storage/fancy/cigarettes/New()
 	..()
-	flags |= NOREACT
 	create_reagents(30 * storage_slots)//so people can inject cigarettes without opening a packet, now with being able to inject the whole one
+	reagents.set_reacting(FALSE)
 	for(var/i = 1 to storage_slots)
 		var/obj/item/clothing/mask/cigarette/C = new cigarette_type(src)
 		unlaced_cigarettes += C

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -8,7 +8,7 @@
 	use_power = 1
 	idle_power_usage = 5
 	active_power_usage = 100
-	flags = OPENCONTAINER | NOREACT
+	flags = OPENCONTAINER
 	var/operating = 0 // Is it on?
 	var/dirty = 0 // = {0..100} Does it need cleaning?
 	var/broken = 0 // ={0,1,2} How broken is it???
@@ -33,6 +33,7 @@
 
 /obj/machinery/kitchen_machine/New()
 	create_reagents(100)
+	reagents.set_reacting(FALSE)
 	if(!available_recipes)
 		available_recipes = new
 		acceptable_items = new

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -10,7 +10,6 @@
 	use_power = 1
 	idle_power_usage = 5
 	active_power_usage = 100
-	flags = NOREACT
 	var/max_n_of_items = 1500
 	var/icon_on = "smartfridge"
 	var/icon_off = "smartfridge-off"
@@ -25,6 +24,8 @@
 
 /obj/machinery/smartfridge/New()
 	..()
+	create_reagents()
+	reagents.set_reacting(FALSE)
 	component_parts = list()
 	var/obj/item/weapon/circuitboard/smartfridge/board = new(null)
 	board.set_type(type)

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -3,7 +3,6 @@
 	mouse_opacity = 0
 	simulated = 0
 	anchored = 1
-	flags = NOREACT
 	icon = LIGHTING_ICON
 	layer = LIGHTING_LAYER
 	invisibility = INVISIBILITY_LIGHTING

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -233,9 +233,9 @@
 
 /obj/item/ammo_casing/shotgun/dart/New()
 	..()
-	flags |= NOREACT
 	flags |= OPENCONTAINER
 	create_reagents(30)
+	reagents.set_reacting(FALSE)
 
 /obj/item/ammo_casing/shotgun/dart/attackby()
 	return

--- a/code/modules/projectiles/guns/dartgun.dm
+++ b/code/modules/projectiles/guns/dartgun.dm
@@ -154,7 +154,7 @@
 		qdel(S)
 		D.icon_state = "syringeproj"
 		D.name = "syringe"
-		D.flags |= NOREACT
+		D.reagents.set_reacting(FALSE)
 		playsound(user.loc, 'sound/items/syringeproj.ogg', 50, 1)
 
 		for(var/i=0, i<6, i++)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -234,8 +234,8 @@
 
 /obj/item/projectile/bullet/dart/New()
 	..()
-	flags |= NOREACT
 	create_reagents(50)
+	reagents.set_reacting(FALSE)
 
 /obj/item/projectile/bullet/dart/on_hit(var/atom/target, var/blocked = 0, var/hit_zone)
 	if(iscarbon(target))
@@ -251,7 +251,7 @@
 				target.visible_message("<span class='danger'>The [name] was deflected!</span>", \
 									"<span class='userdanger'>You were protected against the [name]!</span>")
 	..(target, blocked, hit_zone)
-	flags &= ~NOREACT
+	reagents.set_reacting(TRUE)
 	reagents.handle_reactions()
 	return 1
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -30,18 +30,12 @@
 	if(!possible_transfer_amounts)
 		verbs -= /obj/item/weapon/reagent_containers/verb/set_APTFT
 	create_reagents(volume)
-	processing_objects.Add(src)
 	if(spawned_disease)
 		var/datum/disease/F = new spawned_disease(0)
 		var/list/data = list("viruses" = list(F), "blood_colour" = "#A10808")
 		reagents.add_reagent("blood", disease_amount, data)
 	if(list_reagents)
 		reagents.add_reagent_list(list_reagents)
-
-/obj/item/weapon/reagent_containers/process()
-	if(reagents)
-		reagents.reagent_on_tick()
-	return
 
 /obj/item/weapon/reagent_containers/ex_act()
 	if(reagents)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -290,7 +290,11 @@
 	materials = list(MAT_GLASS=500)
 	volume = 50
 	amount_per_transfer_from_this = 10
-	flags = OPENCONTAINER | NOREACT
+	flags = OPENCONTAINER
+
+/obj/item/weapon/reagent_containers/glass/beaker/noreact/New()
+	..()
+	reagents.set_reacting(FALSE)
 
 /obj/item/weapon/reagent_containers/glass/beaker/bluespace
 	name = "bluespace beaker"


### PR DESCRIPTION
Refactors individual reagents `on_tick` to be processed on the `reagents` holder datum instead of processing reagent containers specifically.

Also refactors the `NOREACT` flag. The flag itself has been removed as an atom flag and is instead a similarly named flag for the `reagents` holder datum. This means `on_tick` is, naturally, handled on the reagents datum as opposed to the reagents container.

This frees up an additional atom flag (huzzah) and allows for more consistent behavior.

