### PR TITLE
Cyborg Blueprints

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -53,7 +53,7 @@
 						By submitting this form, you accept any fines, fees, or personal injury/death that may occur during construction."
 	w_class = 1
 
-/obj/item/areaeditor/permit/attack_self(mob/user as mob)
+/obj/item/areaeditor/permit/attack_self(mob/user)
 	. = ..()
 	var/area/A = get_area()
 	if(get_area_type() == AREA_STATION)
@@ -85,7 +85,7 @@
 	return ..()
 
 
-/obj/item/areaeditor/blueprints/attack_self(mob/user as mob)
+/obj/item/areaeditor/blueprints/attack_self(mob/user)
 	. = ..()
 	var/area/A = get_area()
 	if(get_area_type() == AREA_STATION)
@@ -305,3 +305,10 @@
 					return ROOM_ERR_SPACE
 		found+=T
 	return found
+
+//Blueprint Subtypes
+
+/obj/item/areaeditor/blueprints/cyborg
+	name = "station schematics"
+	desc = "A digital copy of the station blueprints stored in your memory."
+	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -204,7 +204,7 @@
 	modules += new /obj/item/weapon/gripper(src)
 	modules += new /obj/item/weapon/matter_decompiler(src)
 	modules += new /obj/item/device/floor_painter(src)
-
+	modules += new /obj/item/areaeditor/blueprints/cyborg(src)
 	emag = new /obj/item/borg/stun(src)
 
 	for(var/G in stacktypes) //Attempt to unify Engi-Borg material stacks into fewer lines. See Line 492 for example. Variables changed out of paranoia.


### PR DESCRIPTION
Gives Engiborgs a copy of the station blueprints for construction and renaming areas.

:cl:
add: Engineering Cyborgs now have a digital copy of the station blueprints.
/:cl: