### PR TITLE
Actually nerfs neurotox, take three

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -819,7 +819,10 @@
 	drink_desc = "A drink that is guaranteed to knock you silly."
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/M)
-	M.Weaken(3)
+	if(prob(10))//just like real neurotox
+		M.emote("drool")
+	if(current_cycle == 10)
+		M.Weaken(3)
 	if(current_cycle >=55)
 		M.Druggy(55)
 	if(current_cycle >=200)


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: Neuro-Toxin has a much less severe weakening effect.
/:cl:

On the 10th cycle it will weaken you briefly, no longer is a viable option as a memechem. Also makes you drool from time to time, just like actual nerutoxin.

IT'S A DRINK. LET IT BE WHAT IT WANTS TO BE.

An actual alternative to #6179, with 75% less meme.