### PR TITLE
Dual-port Air Vents can now be unwrenched.

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -10,6 +10,8 @@
 	name = "dual-port air vent"
 	desc = "Has a valve and pump attached to it. There are two ports."
 
+	can_unwrench = 1
+
 	level = 1
 
 	connect_types = list(1,2,3) //connects to regular, supply and scrubbers pipes


### PR DESCRIPTION
This should fix Issue #6168 

For a first PR? I have no idea what else should go here.

:cl: Funce
fix: dual-port air vents can now be unwrenched
/:cl: