### PR TITLE
Revenants Can Breathe in Space

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -36,6 +36,7 @@
 	anchored = 1
 	mob_size = MOB_SIZE_TINY
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 
 	var/essence = 75 //The resource of revenants. Max health is equal to three times this amount
 	var/essence_regen_cap = 75 //The regeneration cap of essence (go figure); regenerates every Life() tick up to this amount.

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -111,7 +111,6 @@
 	action_icon_state = "r_nightvision"
 	action_background_icon_state = "bg_revenant"
 
-
 //Transmit: the revemant's only direct way to communicate. Sends a single message silently to a single mob
 /obj/effect/proc_holder/spell/targeted/revenant_transmit
 	name = "Transmit"


### PR DESCRIPTION
This is partially for #6098

I've tried fixing the night vision issue but after such a clusterduck I can't; statues and anything using the night vision spell under /obj/effect/proc_holder/spell/targeted/night_vision are screwed so somebody else go unduck it k.

:cl: Alexshreds
fix: Revenants can now breathe in space.
/:cl: