### PR TITLE
Neurotoxin Changes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -820,7 +820,7 @@
 
 /datum/reagent/consumable/ethanol/brainbleach/on_mob_life(mob/living/M)
 	if(current_cycle >=30)
-		M.adjustBrainLoss(1)
+		M.AdjustDizzy(1)
 		M.Druggy(55)
 	if(current_cycle >=200)
 		M.adjustToxLoss(2)

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -805,22 +805,22 @@
 	drink_name = "Amasec"
 	drink_desc = "Always handy before COMBAT!!!"
 
-/datum/reagent/consumable/ethanol/neurotoxin
-	name = "Neuro-toxin"
-	id = "neurotoxin"
-	description = "A strong neurotoxin that puts the subject into a death-like state."
+/datum/reagent/consumable/ethanol/brainbleach
+	name = "Brain Bleach"
+	id = "brainbleach"
+	description = "A strong nerve cell killer, that causes brain damage."
 	reagent_state = LIQUID
 	color = "#2E2E61" // rgb: 46, 46, 97
 	dizzy_adj = 6
 	alcohol_perc = 0.7
 	heart_rate_decrease = 1
 	drink_icon = "neurotoxinglass"
-	drink_name = "Neurotoxin"
-	drink_desc = "A drink that is guaranteed to knock you silly."
+	drink_name = "Brain Bleach"
+	drink_desc = "A drink that prunes your excess neurons."
 
-/datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/M)
-	M.Weaken(3)
-	if(current_cycle >=55)
+/datum/reagent/consumable/ethanol/brainbleach/on_mob_life(mob/living/M)
+	if(current_cycle >=30)
+		M.adjustBrainLoss(1)
 		M.Druggy(55)
 	if(current_cycle >=200)
 		M.adjustToxLoss(2)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -502,15 +502,15 @@
 	M.adjustToxLoss(1)
 	..()
 
-/datum/reagent/narcoleptizine
-	name = "Narcoleptizine"
-	id = "narcoleptizine"
+/datum/reagent/somnistimine
+	name = "Somnistimine"
+	id = "somnistimine"
 	description = "A powerful tranquilizer."
 	reagent_state = LIQUID
 	color = "#2E2E61"
 	metabolization_rate = 0.4
 
-/datum/reagent/narcoleptizine/on_mob_life(mob/living/M)
+/datum/reagent/somnistimine/on_mob_life(mob/living/M)
 	if(current_cycle>= 3)
 		M.Weaken(3)
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -511,8 +511,13 @@
 	metabolization_rate = 0.4
 
 /datum/reagent/somnistimine/on_mob_life(mob/living/M)
-	if(current_cycle>= 3)
-		M.Weaken(3)
+	switch(current_cycle)
+		if(1 to 4)
+			M.AdjustEyeBlurry(5)
+			if(prob(25))
+				M.emote("yawn")
+		if(5 to INFINITY)
+			M.Weaken(3)
 	..()
 
 /datum/reagent/cyanide

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -502,15 +502,15 @@
 	M.adjustToxLoss(1)
 	..()
 
-/datum/reagent/acepromazine
-	name = "Acepromazine"
-	id = "acepromazine"
+/datum/reagent/narcoleptizine
+	name = "Narcoleptizine"
+	id = "narcoleptizine"
 	description = "A powerful tranquilizer."
 	reagent_state = LIQUID
 	color = "#2E2E61"
 	metabolization_rate = 0.4
 
-/datum/reagent/acepromazine/on_mob_life(mob/living/M)
+/datum/reagent/narcoleptizine/on_mob_life(mob/living/M)
 	if(current_cycle>= 3)
 		M.Weaken(3)
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -502,6 +502,19 @@
 	M.adjustToxLoss(1)
 	..()
 
+/datum/reagent/acepromazine
+	name = "Acepromazine"
+	id = "acepromazine"
+	description = "A powerful tranquilizer."
+	reagent_state = LIQUID
+	color = "#2E2E61"
+	metabolization_rate = 0.4
+
+/datum/reagent/acepromazine/on_mob_life(mob/living/M)
+	if(current_cycle>= 3)
+		M.Weaken(3)
+	..()
+
 /datum/reagent/cyanide
 	name = "Cyanide"
 	id = "cyanide"

--- a/code/modules/reagents/chemistry/recipes/drinks.dm
+++ b/code/modules/reagents/chemistry/recipes/drinks.dm
@@ -557,10 +557,10 @@
 	result_amount = 3
 	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'
 
-/datum/chemical_reaction/neurotoxin
-	name = "Neurotoxin"
-	id = "neurotoxin"
-	result = "neurotoxin"
+/datum/chemical_reaction/brainbleach
+	name = "Brain Bleach"
+	id = "brainbleach"
+	result = "brainbleach"
 	required_reagents = list("gargleblaster" = 1, "ether" = 1)
 	result_amount = 2
 	mix_sound = 'sound/goonstation/misc/drinkfizz.ogg'

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -17,10 +17,10 @@
 	mix_sound = null
 	no_message = 1
 
-/datum/chemical_reaction/acepromazine
-	name = "Acepromazine"
-	id = "acepromazine"
-	result = "acepromazine"
+/datum/chemical_reaction/narcoleptizine
+	name = "Narcoleptizine"
+	id = "narcoleptizine"
+	result = "narcoleptizine"
 	required_reagents = list("ether" = 1, "capulettium" = 1, "fungus" = 1, "sarin" = 1)
 	result_amount = 4
 	min_temp = 400

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -17,10 +17,10 @@
 	mix_sound = null
 	no_message = 1
 
-/datum/chemical_reaction/narcoleptizine
-	name = "Narcoleptizine"
-	id = "narcoleptizine"
-	result = "narcoleptizine"
+/datum/chemical_reaction/somnistimine
+	name = "Somnistimine"
+	id = "somnistimine"
+	result = "somnistimine"
 	required_reagents = list("ether" = 1, "capulettium" = 1, "fungus" = 1, "sarin" = 1)
 	result_amount = 4
 	min_temp = 400

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -17,6 +17,16 @@
 	mix_sound = null
 	no_message = 1
 
+/datum/chemical_reaction/acepromazine
+	name = "Acepromazine"
+	id = "acepromazine"
+	result = "acepromazine"
+	required_reagents = list("ether" = 1, "capulettium" = 1, "fungus" = 1, "sarin" = 1)
+	result_amount = 4
+	min_temp = 400
+	mix_sound = null
+	no_message = 1
+
 /datum/chemical_reaction/cyanide
 	name = "Cyanide"
 	id = "cyanide"


### PR DESCRIPTION
Changes:
- Bar drink Neurotoxin is renamed to "Brain Bleach", and loses its stunning properties. Instead, it now makes you dizzy on cycle >= 30. This nerfs it from being an instastun chem into being merely a strong alcohol that can poison you if you drink too much. The name "brain bleach" was selected based on the results of a player poll (it won with 56 votes).
- New chemical "Somnistimine" added. It stuns, like current bar drink neurotoxin, but unlike current neurotoxin it takes a few seconds to kick in, doesn't have alcohol effects, and is harder to make (requires ether, capulettium, fungus from maint, and sarin).

These changes:
- Avoid having two chems named 'neurotoxin'.
- Avoid having a strong stun chem be a bar drink.
- Avoid having instastun chems, or easy-to-make stunning chems, whilst still preserving the ability to have a stunning chem for those prepared to put in the work to make it.