### PR TITLE
RCDs No Longer Break Physics (As Much)

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -18,7 +18,7 @@ RCD
 	throw_speed = 3
 	throw_range = 5
 	w_class = 3
-	materials = list(MAT_METAL=100000)
+	materials = list(MAT_METAL = 30000)
 	origin_tech = "engineering=4;materials=2"
 	var/datum/effect/system/spark_spread/spark_system
 	var/max_matter = 100


### PR DESCRIPTION
fixes #6011

Now you get in return the same amount of metal as it takes to create an RCD in an autolathe.

:cl:Alexshreds
fix: Can no longer exploit RCDs for metal
/:cl: