### PR TITLE
Character Slot Randomization and Loading Fixes

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -252,7 +252,8 @@ var/global/datum/controller/occupations/job_master
 		for(var/mob/new_player/player in player_list)
 			if(player.ready && player.mind && !player.mind.assigned_role)
 				unassigned += player
-				if(player.client.prefs.randomslot) player.client.prefs.random_character(player.client)
+				if(player.client.prefs.randomslot)
+					player.client.prefs.load_random_character_slot(player.client)
 		Debug("DO, Len: [unassigned.len]")
 		if(unassigned.len == 0)	return 0
 

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -500,21 +500,24 @@
 		return
 	return 1
 
-/*
-/datum/preferences/proc/random_character(client/C)
+/datum/preferences/proc/load_random_character_slot(client/C)
 	var/DBQuery/query = dbcon.NewQuery("SELECT slot FROM [format_table_name("characters")] WHERE ckey='[C.ckey]' ORDER BY slot")
+	var/list/saves = list()
+
+	if(!query.Execute())
+		var/err = query.ErrorMsg()
+		log_game("SQL ERROR during random character slot picking. Error : \[[err]\]\n")
+		message_admins("SQL ERROR during random character slot picking. Error : \[[err]\]\n")
+		return
 
 	while(query.NextRow())
-	var/list/saves = list()
-	for(var/i=1, i<=MAX_SAVE_SLOTS, i++)
-		if(i==text2num(query.item[1]))
-			saves += i
+		saves += text2num(query.item[1])
 
 	if(!saves.len)
 		load_character(C)
 		return 0
 	load_character(C,pick(saves))
-	return 1*/
+	return 1
 
 /datum/preferences/proc/SetChangelog(client/C,hash)
 	lastchangelog=hash

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -25,6 +25,8 @@
 
 /mob/new_player/proc/new_player_panel_proc()
 	var/real_name = client.prefs.real_name
+	if(client.prefs.randomslot)
+		real_name = "Random Character Slot"
 	var/output = "<center><p><a href='byond://?src=[UID()];show_preferences=1'>Setup Character</A><br /><i>[real_name]</i></p>"
 
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
@@ -168,6 +170,9 @@
 		if(!enter_allowed)
 			to_chat(usr, "\blue There is an administrative lock on entering the game!")
 			return
+
+		if(client.prefs.randomslot)
+			client.prefs.load_random_character_slot(client)
 
 		if(client.prefs.species in whitelisted_species)
 			if(!is_alien_whitelisted(src, client.prefs.species) && config.usealienwhitelist)


### PR DESCRIPTION
- The Randomized Character Slot option now actually works.
  - When enabled, a random character slot will be loaded upon joining the game.
    - This includes late-joining, which would previously not even attempt to randomize.
  - While enabled, the new player panel will reflect its state:
  ![2017-01-16_03-08-01](https://cloud.githubusercontent.com/assets/10916307/21975653/d4097bba-db9b-11e6-96ab-a5ec669a28cd.png)
    - Changing the option will immediately update the panel.
- Selecting a character slot will no longer run 20 database queries.

:cl:
fix: The Randomized Character Slot option now actually works.
/:cl: