### PR TITLE
Goonchat Loading Tweaks

### DIFF
--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -31,8 +31,8 @@
 		<i class="icon-spinner icon-2x"></i>
 		<div>
 			Loading...<br><br>
-			If this takes longer than 30 seconds, it will automatically reload a maximum of 5 times.<br>
-			If it <b>still</b> doesn't work, use the bug report button at the top right of the window.
+			If this takes longer than 10 seconds, it will automatically reload, multiple times if necessary.<br>
+			If it <b>still</b> doesn't work, please adminhelp (F1) and tell us your operating system and Internet Explorer version.
 		</div>
 	</div>
 	<div id="messages">

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -55,11 +55,11 @@ var/list/chatResources = list(
 	if(!owner)
 		return
 
-	for(var/attempts = 1 to 5)
+	for(var/attempts in 1 to 5)
 		for(var/asset in global.chatResources)
 			owner << browse_rsc(file(asset))
 
-		for(var/subattempts = 1 to 3)
+		for(var/subattempts in 1 to 3)
 			owner << browse(file2text("goon/browserassets/html/browserOutput.html"), "window=browseroutput")
 			sleep(10 SECONDS)
 			if(!owner || loaded)

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -59,10 +59,11 @@ var/list/chatResources = list(
 		for(var/asset in global.chatResources)
 			owner << browse_rsc(file(asset))
 
-		owner << browse(file("goon/browserassets/html/browserOutput.html"), "window=browseroutput")
-		sleep(20 SECONDS)
-		if(!owner || loaded)
-			break
+		for(var/subattempts = 1 to 3)
+			owner << browse(file2text("goon/browserassets/html/browserOutput.html"), "window=browseroutput")
+			sleep(10 SECONDS)
+			if(!owner || loaded)
+				return
 
 /datum/chatOutput/Topic(var/href, var/list/href_list)
 	if(usr.client != owner)


### PR DESCRIPTION
- A non-loading chat pane will now be re-loaded every 10 seconds, instead of 20.
  - And assets will only re-send every 3 re-loads (30 seconds).
- The chat pane's main HTML is no longer cached by the client.
  - This may prevent it from loading before other resources get transferred. Maybe.
- The loading messages are now more accurate, telling users to adminhelp instead of using the non-existent bug report button.