### PR TITLE
Fixes People Being Too Full To Stuff A Patch Down Their Throats

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -3,3 +3,4 @@
 #define isclient(A) istype(A, /client)
 
 #define isradio(A) istype(A, /obj/item/device/radio)
+#define ispill(A) istype(A, /obj/item/weapon/reagent_containers/food/pill)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -82,7 +82,7 @@
 		return 1
 	if(istype(O,/obj/item/weapon/storage/pill_bottle/))
 		return 1
-	if(istype(O,/obj/item/weapon/reagent_containers/food/pill/))
+	if(ispill(O))
 		return 1
 	return 0
 
@@ -108,7 +108,7 @@
 		return 1
 	if(istype(O,/obj/item/weapon/storage/pill_bottle/))
 		return 1
-	if(istype(O,/obj/item/weapon/reagent_containers/food/pill/))
+	if(ispill(O))
 		return 1
 	return 0
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -958,7 +958,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return 1
 
 /mob/living/carbon/proc/selfFeed(var/obj/item/weapon/reagent_containers/food/toEat, fullness)
-	if(istype(toEat, /obj/item/weapon/reagent_containers/food/pill))
+	if(ispill(toEat))
 		to_chat(src, "<span class='notify'>You [toEat.apply_method] [toEat].</span>")
 	else
 		if(toEat.junkiness && satiety < -150 && nutrition > NUTRITION_LEVEL_STARVING + 50 )
@@ -981,7 +981,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return 1
 
 /mob/living/carbon/proc/forceFed(var/obj/item/weapon/reagent_containers/food/toEat, mob/user, fullness)
-	if(fullness <= (600 * (1 + overeatduration / 1000)))
+	if(ispill(toEat) || fullness <= (600 * (1 + overeatduration / 1000)))
 		if(!toEat.instant_application)
 			visible_message("<span class='warning'>[user] attempts to force [src] to [toEat.apply_method] [toEat].</span>")
 	else


### PR DESCRIPTION
Using a pill or patch on someone else would fail if they were too full to force-feed, leading to nonsense like "Bob cannot force anymore of the burn patch down Bill's throat". Now, pills and patches will ignore fullness when being forced on someone else, just as they do when you use them on yourself.

Also, I made an `ispill` helper for pill type checks, because *gosh* do they ever have a long type path.

:cl:
fix: You can now use pills and patches on people with full bellies.
/:cl: