### PR TITLE
Adds in Stun Gloves

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -4,16 +4,16 @@
 
 	Otherwise pretty standard.
 */
-/mob/living/carbon/human/UnarmedAttack(var/atom/A, var/proximity)
-	var/obj/item/clothing/gloves/G = gloves // not typecast specifically enough in defines
-
+/mob/living/carbon/human/UnarmedAttack(atom/A, proximity)
 	// Special glove functions:
 	// If the gloves do anything, have them return 1 to stop
 	// normal attack_hand() here.
-	if(proximity && istype(G) && G.Touch(A,1))
+	var/obj/item/clothing/gloves/G = gloves // not typecast specifically enough in defines
+	if(proximity && istype(G) && G.Touch(A, 1))
 		return
 
 	A.attack_hand(src)
+
 /atom/proc/attack_hand(mob/user as mob)
 	return
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -193,8 +193,9 @@ BLIND     // can't see anything
 		"Drask" = 'icons/mob/species/drask/gloves.dmi'
 		)
 
-/obj/item/clothing/gloves/proc/Touch()
-	return
+// Called just before an attack_hand(), in mob/UnarmedAttack()
+/obj/item/clothing/gloves/proc/Touch(atom/A, proximity)
+	return 0 // return 1 to cancel attack_hand()
 
 /obj/item/clothing/gloves/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/wirecutters))

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -62,6 +62,8 @@
 	name = "stun gloves"
 	desc = "Horrendous and awful. It smells like cancer. The fact it has wires attached to it is incidental."
 	var/obj/item/weapon/stock_parts/cell/cell = null
+	var/stun_strength = 5
+	var/stun_cost = 3750
 
 /obj/item/clothing/gloves/color/yellow/stun/New()
 	..()
@@ -84,16 +86,16 @@
 		var/mob/living/carbon/human/H = loc
 		if(H.a_intent == I_HARM)
 			var/mob/living/carbon/C = A
-			if(cell.use(3750))
+			if(cell.use(stun_cost))
 				var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 				s.set_up(5, 0, loc)
 				s.start()
 				playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 				H.do_attack_animation(C)
 				visible_message("<span class='danger'>[C] has been touched with [src] by [H]!</span>")
-				C.Stun(5)
-				C.Weaken(5)
-				C.apply_effect(STUTTER, 5)
+				C.Stun(stun_strength)
+				C.Weaken(stun_strength)
+				C.apply_effect(STUTTER, stun_strength)
 			else
 				to_chat(H, "<span class='notice'>Not enough charge!</span>")
 			return TRUE

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -56,3 +56,72 @@
 	icon_state = "latex"
 	item_state = "lgloves"
 	flags = NODROP
+
+
+/obj/item/clothing/gloves/color/yellow/stun
+	name = "stun gloves"
+	desc = "Horrendous and awful. It smells like cancer. The fact it has wires attached to it is incidental."
+	var/obj/item/weapon/stock_parts/cell/cell = null
+
+/obj/item/clothing/gloves/color/yellow/stun/New()
+	..()
+	update_icon()
+
+/obj/item/clothing/gloves/color/yellow/stun/Destroy()
+	if(cell)
+		qdel(cell)
+		cell = null
+	return ..()
+
+/obj/item/clothing/gloves/color/yellow/stun/Touch(atom/A, proximity)
+	if(!ishuman(loc))
+		return FALSE //Only works while worn
+	if(!iscarbon(A))
+		return FALSE
+	if(!proximity)
+		return FALSE
+	if(cell)
+		var/mob/living/carbon/human/H = loc
+		if(H.a_intent == I_HARM)
+			var/mob/living/carbon/C = A
+			if(cell.use(3750))
+				var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
+				s.set_up(5, 0, loc)
+				s.start()
+				playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
+				H.do_attack_animation(C)
+				visible_message("<span class='danger'>[C] has been touched with [src] by [H]!</span>")
+				C.Stun(5)
+				C.Weaken(5)
+				C.apply_effect(STUTTER, 5)
+			else
+				to_chat(H, "<span class='notice'>Not enough charge!</span>")
+			return TRUE
+	return FALSE
+
+/obj/item/clothing/gloves/color/yellow/stun/update_icon()
+	..()
+	overlays.Cut()
+	overlays += "gloves_wire"
+	if(cell)
+		overlays += "gloves_cell"
+
+/obj/item/clothing/gloves/color/yellow/stun/attackby(obj/item/weapon/W, mob/living/user, params)
+	if(istype(W, /obj/item/weapon/stock_parts/cell))
+		if(!cell)
+			if(!user.drop_item())
+				to_chat(user, "<span class='warning'>[W] is stuck to you!</span>")
+				return
+			W.forceMove(src)
+			cell = W
+			to_chat(user, "<span class='notice'>You attach [W] to [src].</span>")
+			update_icon()
+		else
+			to_chat(user, "<span class='notice'>[src] already has a cell.</span>")
+
+	else if(iswirecutter(W))
+		if(cell)
+			to_chat(user, "<span class='notice'>You cut  [cell] away from [src].</span>")
+			cell.forceMove(get_turf(loc))
+			cell = null
+			update_icon()

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -123,7 +123,7 @@
 
 	else if(iswirecutter(W))
 		if(cell)
-			to_chat(user, "<span class='notice'>You cut  [cell] away from [src].</span>")
+			to_chat(user, "<span class='notice'>You cut [cell] away from [src].</span>")
 			cell.forceMove(get_turf(loc))
 			cell = null
 			update_icon()


### PR DESCRIPTION
Adds in stun gloves, the iconic stun item of yesteryear. Now with 99% less snowflake! This project was born more out of pure boredom than anything else. Stungloves were SUPER snowflakey back in the day and had to be put inside carbon, alien, larva, and human `attack_hand`...turns out things have improved since 3 years ago and we now have procs to do this more OOP! Yay.

Slap on a pair, insert a cell and go to zapping people's butts. Stun/Weakens them for 5 cycles (10 seconds); same as a stunprod.

Also, no, you cannot have them; you can only *look* at them (admin only).

:cl: Fox McCloud
add: Adds in stungloves (inaccessible to players)
/:cl: