### PR TITLE
Fixes a silly loadout error

### DIFF
--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -98,15 +98,15 @@
 	path = /obj/item/clothing/under/rank/head_of_security/skirt
 	allowed_roles = list("Head of Security")
 
-/datum/gear/uniform/job/medical/scrubs
-	subtype_path = /datum/gear/uniform/job/medical/scrubs
+/datum/gear/uniform/medical
+	subtype_path = /datum/gear/uniform/medical
 
-/datum/gear/uniform/job/medical/scrubs/purple
+/datum/gear/uniform/medical/pscrubs
 	display_name = "medical scrubs, purple"
 	path = /obj/item/clothing/under/rank/medical/purple
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor")
 
-/datum/gear/uniform/job/medical/scrubs/green
+/datum/gear/uniform/medical/gscrubs
 	display_name = "medical scrubs, green"
 	path = /obj/item/clothing/under/rank/medical/green
 	allowed_roles = list("Chief Medical Officer", "Medical Doctor")


### PR DESCRIPTION
```
## ERROR: Loadout - Missing display name: /datum/gear/uniform/job/medical
## ERROR: Loadout - Missing display name: /datum/gear/uniform/job
```

👌 