### PR TITLE
Fixes Twemoji Breaking Chat For IE8 Users

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -102,8 +102,8 @@ function linkify(text) {
 
 function emojiparse(el) {
 
-	if (!UNICODE_9_EMOJI || !twemoji) { //something didn't load right, probably IE8
-		return;
+	if ((typeof UNICODE_9_EMOJI === 'undefined') || (typeof twemoji === 'undefined')) {
+		return; //something didn't load right, probably IE8
 	}
 
 	var $el = $(el);


### PR DESCRIPTION
`!variablename` is not how you check whether a variable doesn't exist in Javascript, because if it doesn't, that throws a reference error and ruins everything.

Probably fixes #6208.

:cl:
fix: Fixed the exciting new emoji breaking chat entirely for IE8 users. :clap:
/:cl: