### PR TITLE
Announcement fixes

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -136,6 +136,7 @@
 	formatted_message += "<br><span class='alert'>[message]</span>"
 	if(message_announcer)
 		formatted_message += "<br><span class='alert'> -[message_announcer]</span>"
+	formatted_message += "<br>"
 	
 	return formatted_message
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -39,7 +39,7 @@
 /obj/machinery/computer/communications/New()
 	shuttle_caller_list += src
 	..()
-	crew_announcement.newscast = 1
+	crew_announcement.newscast = 0
 
 /obj/machinery/computer/communications/proc/is_authenticated(var/mob/user, var/message = 1)
 	if(authenticated == COMM_AUTHENTICATION_MAX)

--- a/code/modules/computer3/computers/communications.dm
+++ b/code/modules/computer3/computers/communications.dm
@@ -47,7 +47,7 @@
 
 	New()
 		..()
-		crew_announcement.newscast = 1
+		crew_announcement.newscast = 0
 
 	Reset()
 		..()


### PR DESCRIPTION
Adds a missing line break to priority announcements, and removes the newscaster notification from crew announcements (done through the communications console) that weren't supposed to be enabled.