### PR TITLE
Shadowling Thrall Scaling and Lesser Glare Removal

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -100,10 +100,7 @@ Made by Xhuis
 
 	var/num_players = num_players()
 	required_thralls = round(num_players / 3)
-	if(required_thralls < 15)
-		required_thralls = 15
-	if(required_thralls > 30)
-		required_thralls = 30
+	required_thralls = Clamp(required_thralls, 15, 25)
 
 	..()
 	return 1

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -97,6 +97,14 @@ Made by Xhuis
 		shadow.special_role = SPECIAL_ROLE_SHADOWLING
 		shadow.restricted_roles = restricted_jobs
 		shadowlings--
+
+	var/num_players = num_players()
+	required_thralls = round(num_players / 2.5)
+	if(required_thralls < 15)
+		required_thralls = 15
+	if(required_thralls > 40)
+		required_thralls = 40
+
 	..()
 	return 1
 

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -98,9 +98,8 @@ Made by Xhuis
 		shadow.restricted_roles = restricted_jobs
 		shadowlings--
 
-	var/num_players = num_players()
-	required_thralls = round(num_players / 3)
-	required_thralls = Clamp(required_thralls, 15, 25)
+	var/thrall_scaling = round(num_players() / 3)
+	required_thralls = Clamp(thrall_scaling, 15, 25)
 
 	..()
 	return 1

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -99,11 +99,11 @@ Made by Xhuis
 		shadowlings--
 
 	var/num_players = num_players()
-	required_thralls = round(num_players / 2.5)
+	required_thralls = round(num_players / 3)
 	if(required_thralls < 15)
 		required_thralls = 15
-	if(required_thralls > 40)
-		required_thralls = 40
+	if(required_thralls > 30)
+		required_thralls = 30
 
 	..()
 	return 1
@@ -158,7 +158,6 @@ Made by Xhuis
 		update_shadow_icons_added(new_thrall_mind)
 		new_thrall_mind.current.create_attack_log("<span class='danger'>Became a thrall</span>")
 		new_thrall_mind.current.add_language("Shadowling Hivemind")
-		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_glare(null))
 		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_shadow_walk(null))
 		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_vision/thrall(null))
 		to_chat(new_thrall_mind.current, "<span class='shadowling'><b>You see the truth. Reality has been torn away and you realize what a fool you've been.</b></span>")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -1,4 +1,4 @@
-#define EMPOWERED_THRALL_LIMIT 10
+#define EMPOWERED_THRALL_LIMIT 5
 
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H)) return
@@ -639,12 +639,11 @@
 				sleep(20)
 				thrallToRevive.visible_message("<span class='warning'>[thrallToRevive] slowly rises, no longer recognizable as human.</span>", \
 											   "<span class='shadowling'><b>You feel new power flow into you. You have been gifted by your masters. You now closely resemble them. You are empowered in \
-											    darkness but wither slowly in light. In addition, you now have glare, veil, and true shadow walk.</b></span>")
+											    darkness but wither slowly in light. In addition, you now have glare and true shadow walk.</b></span>")
 				thrallToRevive.set_species("Lesser Shadowling")
 				thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/lesser_shadow_walk)
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/glare(null))
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_walk(null))
-				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/veil(null))
 			if("Revive")
 				if(!is_thrall(thrallToRevive))
 					to_chat(usr, "<span class='warning'>[thrallToRevive] is not a thrall.</span>")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -1,4 +1,4 @@
-#define EMPOWERED_THRALL_LIMIT 5
+#define EMPOWERED_THRALL_LIMIT 10
 
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H)) return
@@ -47,39 +47,6 @@
 			to_chat(target, "<span class='userdanger'>Red lights suddenly dance in your vision, and you are mesmerized by the heavenly lights...</span>")
 		target.Stun(10)
 		M.AdjustSilence(10)
-
-
-/obj/effect/proc_holder/spell/targeted/lesser_glare
-	name = "Lesser Glare"
-	desc = "Stuns and mutes a target for a short duration."
-	panel = "Thrall Abilities"
-	charge_max = 450
-	clothes_req = 0
-	action_icon_state = "glare"
-
-/obj/effect/proc_holder/spell/targeted/lesser_glare/cast(list/targets)
-	for(var/mob/living/carbon/human/target in targets)
-		if(!ishuman(target) || !target)
-			to_chat(usr, "<span class='warning'>You nay only glare at humans!</span>")
-			charge_counter = charge_max
-			return
-		if(target.stat)
-			to_chat(usr, "<span class='warning'>[target] must be conscious!</span>")
-			charge_counter = charge_max
-			return
-		if(is_shadow_or_thrall(target))
-			to_chat(usr, "<span class='warning'>You cannot glare at allies!</span>")
-			charge_counter = charge_max
-			return
-		var/mob/living/carbon/human/M = target
-		usr.visible_message("<span class='warning'><b>[usr]'s eyes flash a blinding red!</b></span>")
-		target.visible_message("<span class='danger'>[target] freezes in place, their eyes glazing over...</span>")
-		if(in_range(target, usr))
-			to_chat(target, "<span class='userdanger'>Your gaze is forcibly drawn into [usr]'s eyes, and you are mesmerized by the heavenly lights...</span>")
-		else
-			to_chat(target, "<span class='userdanger'>Red lights suddenly dance in your vision, and you are mesmerized by their heavenly beauty...</span>")
-		target.Stun(3) //Roughly 30% as long as the normal one
-		M.AdjustSilence(3)
 
 
 /obj/effect/proc_holder/spell/aoe_turf/veil
@@ -672,12 +639,12 @@
 				sleep(20)
 				thrallToRevive.visible_message("<span class='warning'>[thrallToRevive] slowly rises, no longer recognizable as human.</span>", \
 											   "<span class='shadowling'><b>You feel new power flow into you. You have been gifted by your masters. You now closely resemble them. You are empowered in \
-											    darkness but wither slowly in light. In addition, Lesser Glare and Guise have been upgraded into their true forms.</b></span>")
+											    darkness but wither slowly in light. In addition, you now have glare, veil, and true shadow walk.</b></span>")
 				thrallToRevive.set_species("Lesser Shadowling")
-				thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/lesser_glare)
 				thrallToRevive.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/lesser_shadow_walk)
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/glare(null))
 				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_walk(null))
+				thrallToRevive.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/veil(null))
 			if("Revive")
 				if(!is_thrall(thrallToRevive))
 					to_chat(usr, "<span class='warning'>[thrallToRevive] is not a thrall.</span>")


### PR DESCRIPTION
> **Commit One information**
Shadowlings
now have a scaling thrall count for acension dependent on
amount of players.
Min amount of thralls is limited to 15 as normal.
Max amount of thralls is capped to 40.
Formula is Players/2.5
Just happens 100 players is exactly 40 thralls.
Looking at a balancing standpoint, most can agree right now that
shadowlings only needing 15 thralls on 100+ rounds is way too little and
prematurely ends the round before things can get really heated up.
Also the game mode's minimum playercount is 30, to which it still
expects you to convert half the station to thralls, 15. This formula is
much less drastic than that but still raises the count.

> **Commit Two Information:**
Max amount of thralls capped to 30.
Formula is player/3
Thralls lose lesser glare.
Lesser shadowlings gain veil.
Lesser shadowling max count raised to 10.

> **Commit Three Information:**
Max amount of thralls clamped to 25.
Formula is player/3
Thralls lose lesser glare.
Lesser shadowlings gain veil.
Lesser shadowling max count raised to 10.

 **Commit Four/Five Information:**
Max amount of thralls clamped to 25.
Formula is player/3
Thralls lose lesser glare.

Thanks to Kyet for writing this and explaining the in&outs of the code,
and helping me with this.

🆑 scrubmcnoob
tweak: Shadowling Thrall count now scales to a max of 25.
tweak: Shadowling Thralls lose lesser glare
/🆑