### PR TITLE
THE POWER OF SALT COMPELS YOU

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -484,13 +484,6 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "baguette"
 	desc = "a staple of worshipers of the Silentfather, this holy mime artifact has an odd effect on clowns."
-	force = 0
-	throwforce = 0
-
-/obj/item/weapon/nullrod/rosary/bread/New()
-	..()
-	processing_objects.Add(src)
-
 
 /obj/item/weapon/nullrod/rosary/bread/process()
 	if(ishuman(loc))

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -480,7 +480,7 @@
 
 	ghostcall = 1
 	if(do_after(user, 50, target = M))
-		notify_ghosts("The Chaplain is calling ghosts to [get_area(src)] with [src.name]!", source = src)
+		notify_ghosts("The Chaplain is calling ghosts to [get_area(src)] with [name]!", source = src)
 		ghostcall = 0
 		return
 	else
@@ -547,7 +547,7 @@
 		if(src == holder.l_hand || src == holder.r_hand) // Holding this in your hand will
 			for(var/mob/living/carbon/human/H in range(5))
 				if(H.mind.assigned_role == "Clown")
-					H.AdjustSilence(30)
+					H.AdjustSilence(10)
 					animate_fade_grayscale(H,20)
 					if(prob(10))
 						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your honk!</span>")

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -453,6 +453,106 @@
 					if(prob(10))
 						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your powers!</span>")
 
+/obj/item/weapon/nullrod/salt
+	name = "Holy Salt"
+	icon = 'icons/obj/food/containers.dmi'
+	icon_state = "saltshakersmall"
+	item_state = null
+	desc = "While commonly used to repel some ghosts, it appears others are downright attracted to it."
+	force = 0
+	throwforce = 0
+	var/ghostcall = 0
+
+
+/obj/item/weapon/nullrod/salt/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if(iscarbon(M))//no hitting people
+		return ..()
+
+	if(!user.mind || user.mind.assigned_role != "Chaplain")
+		to_chat(user, "<span class='notice'>You are not close enough with [ticker.Bible_deity_name] to use [src].</span>")
+		return
+
+	if(ghostcall)
+		to_chat(user, "<span class='notice'>You are already using [src].</span>")
+
+	user.visible_message("<span class='info'>[user] kneels[M == user ? null : " next to [M]"] and begins to utter a prayer to [ticker.Bible_deity_name] while drawing a circle with salt!.</span>", \
+		"<span class='info'>You kneel[M == user ? null : " next to [M]"] and begin a prayer to [ticker.Bible_deity_name] while drawing a circle!.</span>")
+
+	ghostcall = 1
+	if(do_after(user, 50, target = M))
+		notify_ghosts("The Chaplain is calling ghosts to [get_area(src)] with [src.name]!", source = src)
+		ghostcall = 0
+		return
+	else
+		to_chat(user, "<span class='notice'>Your prayer to [ticker.Bible_deity_name] was interrupted.</span>")
+		ghostcall = 0
+
+
+/obj/item/weapon/nullrod/bread
+	name = "prayer bread"
+	icon = 'icons/obj/trash.dmi'
+	icon_state = "tastybread"
+	desc = "a staple of worshipers of the Silentfather, this holy mime artifact has an odd effect on clowns."
+	force = 0
+	throwforce = 0
+	var/praying = 0
+
+/obj/item/weapon/nullrod/bread/New()
+	..()
+	processing_objects.Add(src)
+
+
+/obj/item/weapon/nullrod/bread/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if(!iscarbon(M))
+		return ..()
+
+	if(!user.mind || user.mind.assigned_role != "Chaplain")
+		to_chat(user, "<span class='notice'>You are not close enough with [ticker.Bible_deity_name] to use [src].</span>")
+		return
+
+	if(praying)
+		to_chat(user, "<span class='notice'>You are already using [src].</span>")
+
+	user.visible_message("<span class='info'>[user] kneels[M == user ? null : " next to [M]"] and begins to utter a prayer to [ticker.Bible_deity_name].</span>", \
+		"<span class='info'>You kneel[M == user ? null : " next to [M]"] and begin a prayer to [ticker.Bible_deity_name].</span>")
+
+	praying = 1
+	if(do_after(user, 150, target = M))
+		if(ishuman(M))
+			var/mob/living/carbon/human/target = M
+
+			if(target.mind)
+				target.mind.miming = 1//will need to remove this after a time
+				to_chat(target, "<span class='notice'>You feel quiet..</span>")
+
+
+			if(prob(25))
+				to_chat(target, "<span class='notice'>[user]'s prayer to [ticker.Bible_deity_name] has eased your pain..and hunger!</span>")
+				target.adjustToxLoss(-5)
+				target.adjustOxyLoss(-5)
+				target.adjustBruteLoss(-5)
+				target.adjustFireLoss(-5)
+				target.nutrition += 1
+
+			praying = 0
+
+	else
+		to_chat(user, "<span class='notice'>Your prayer to [ticker.Bible_deity_name] was interrupted.</span>")
+		praying = 0
+
+/obj/item/weapon/nullrod/bread/process()
+	if(ishuman(loc))
+		var/mob/living/carbon/human/holder = loc
+		//would like to make the holder mime if they have it in on thier person in general
+		if(src == holder.l_hand || src == holder.r_hand) // Holding this in your hand will
+			for(var/mob/living/carbon/human/H in range(5))
+				if(H.current.mind.assigned_role == "Clown")
+					H.mind.miming = 1//will need to remove this after a time
+					H.color = "grey" //and this
+					if(prob(10))
+						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your honk!</span>")
+
+
 /obj/item/weapon/nullrod/missionary_staff
 	name = "holy staff"
 	desc = "It has a mysterious, protective aura."

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -465,7 +465,7 @@
 
 
 /obj/item/weapon/nullrod/salt/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(iscarbon(M))//no hitting people
+	if(!iscarbon(M))
 		return ..()
 
 	if(!user.mind || user.mind.assigned_role != "Chaplain")
@@ -490,8 +490,8 @@
 
 /obj/item/weapon/nullrod/bread
 	name = "prayer bread"
-	icon = 'icons/obj/trash.dmi'
-	icon_state = "tastybread"
+	icon = 'icons/obj/food/food.dmi'
+	icon_state = "baguette"
 	desc = "a staple of worshipers of the Silentfather, this holy mime artifact has an odd effect on clowns."
 	force = 0
 	throwforce = 0

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -492,7 +492,7 @@
 		if(src == holder.l_hand || src == holder.r_hand) // Holding this in your hand will
 			for(var/mob/living/carbon/human/H in range(5))
 				if(H.mind.assigned_role == "Clown")
-					H.AdjustSilence(10)
+					H.Silence(10)
 					animate_fade_grayscale(H,20)
 					if(prob(10))
 						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your honk!</span>")

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -522,7 +522,7 @@
 			var/mob/living/carbon/human/target = M
 
 			if(target.mind)
-				target.mind.miming = 1//will need to remove this after a time
+				H.AdjustSilence(5)
 				to_chat(target, "<span class='notice'>You feel quiet..</span>")
 
 
@@ -546,9 +546,9 @@
 		//would like to make the holder mime if they have it in on thier person in general
 		if(src == holder.l_hand || src == holder.r_hand) // Holding this in your hand will
 			for(var/mob/living/carbon/human/H in range(5))
-				if(H.current.mind.assigned_role == "Clown")
-					H.mind.miming = 1//will need to remove this after a time
-					H.color = "grey" //and this
+				if(H.mind.assigned_role == "Clown")
+					H.AdjustSilence(30)
+					animate_fade_grayscale(H,20)
 					if(prob(10))
 						to_chat(H, "<span class='userdanger'>Being in the presence of [holder]'s [src] is interfering with your honk!</span>")
 

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -522,7 +522,7 @@
 			var/mob/living/carbon/human/target = M
 
 			if(target.mind)
-				H.AdjustSilence(5)
+				target.AdjustSilence(5)
 				to_chat(target, "<span class='notice'>You feel quiet..</span>")
 
 

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -457,7 +457,6 @@
 	name = "Holy Salt"
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "saltshakersmall"
-	item_state = "saltshakersmall"
 	desc = "While commonly used to repel some ghosts, it appears others are downright attracted to it."
 	force = 0
 	throwforce = 0
@@ -472,8 +471,8 @@
 
 	if(!(ghostcall_CD > world.time))
 		ghostcall_CD = world.time + 3000 //deciseconds..5 minutes
-		user.visible_message("<span class='info'>[user] kneels and begins to utter a prayer to [ticker.Bible_deity_name] while drawing a circle with salt!.</span>", \
-		"<span class='info'>You kneel and begin a prayer to [ticker.Bible_deity_name] while drawing a circle!.</span>")
+		user.visible_message("<span class='info'>[user] kneels and begins to utter a prayer to [ticker.Bible_deity_name] while drawing a circle with salt!</span>", \
+		"<span class='info'>You kneel and begin a prayer to [ticker.Bible_deity_name] while drawing a circle!</span>")
 		notify_ghosts("The Chaplain is calling ghosts to [get_area(src)] with [name]!", source = src)
 	else
 		to_chat(user, "<span class='notice'>You need to wait before using [src] again.</span>")

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -457,90 +457,43 @@
 	name = "Holy Salt"
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "saltshakersmall"
-	item_state = null
+	item_state = "saltshakersmall"
 	desc = "While commonly used to repel some ghosts, it appears others are downright attracted to it."
 	force = 0
 	throwforce = 0
-	var/ghostcall = 0
+	var/ghostcall_CD = 0
 
 
-/obj/item/weapon/nullrod/salt/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!iscarbon(M))
-		return ..()
+/obj/item/weapon/nullrod/salt/attack_self(mob/user)
 
 	if(!user.mind || user.mind.assigned_role != "Chaplain")
 		to_chat(user, "<span class='notice'>You are not close enough with [ticker.Bible_deity_name] to use [src].</span>")
 		return
 
-	if(ghostcall)
-		to_chat(user, "<span class='notice'>You are already using [src].</span>")
-
-	user.visible_message("<span class='info'>[user] kneels[M == user ? null : " next to [M]"] and begins to utter a prayer to [ticker.Bible_deity_name] while drawing a circle with salt!.</span>", \
-		"<span class='info'>You kneel[M == user ? null : " next to [M]"] and begin a prayer to [ticker.Bible_deity_name] while drawing a circle!.</span>")
-
-	ghostcall = 1
-	if(do_after(user, 50, target = M))
+	if(!(ghostcall_CD > world.time))
+		ghostcall_CD = world.time + 3000 //deciseconds..5 minutes
+		user.visible_message("<span class='info'>[user] kneels and begins to utter a prayer to [ticker.Bible_deity_name] while drawing a circle with salt!.</span>", \
+		"<span class='info'>You kneel and begin a prayer to [ticker.Bible_deity_name] while drawing a circle!.</span>")
 		notify_ghosts("The Chaplain is calling ghosts to [get_area(src)] with [name]!", source = src)
-		ghostcall = 0
-		return
 	else
-		to_chat(user, "<span class='notice'>Your prayer to [ticker.Bible_deity_name] was interrupted.</span>")
-		ghostcall = 0
+		to_chat(user, "<span class='notice'>You need to wait before using [src] again.</span>")
+		return
 
 
-/obj/item/weapon/nullrod/bread
+/obj/item/weapon/nullrod/rosary/bread
 	name = "prayer bread"
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "baguette"
 	desc = "a staple of worshipers of the Silentfather, this holy mime artifact has an odd effect on clowns."
 	force = 0
 	throwforce = 0
-	var/praying = 0
 
-/obj/item/weapon/nullrod/bread/New()
+/obj/item/weapon/nullrod/rosary/bread/New()
 	..()
 	processing_objects.Add(src)
 
 
-/obj/item/weapon/nullrod/bread/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!iscarbon(M))
-		return ..()
-
-	if(!user.mind || user.mind.assigned_role != "Chaplain")
-		to_chat(user, "<span class='notice'>You are not close enough with [ticker.Bible_deity_name] to use [src].</span>")
-		return
-
-	if(praying)
-		to_chat(user, "<span class='notice'>You are already using [src].</span>")
-
-	user.visible_message("<span class='info'>[user] kneels[M == user ? null : " next to [M]"] and begins to utter a prayer to [ticker.Bible_deity_name].</span>", \
-		"<span class='info'>You kneel[M == user ? null : " next to [M]"] and begin a prayer to [ticker.Bible_deity_name].</span>")
-
-	praying = 1
-	if(do_after(user, 150, target = M))
-		if(ishuman(M))
-			var/mob/living/carbon/human/target = M
-
-			if(target.mind)
-				target.AdjustSilence(5)
-				to_chat(target, "<span class='notice'>You feel quiet..</span>")
-
-
-			if(prob(25))
-				to_chat(target, "<span class='notice'>[user]'s prayer to [ticker.Bible_deity_name] has eased your pain..and hunger!</span>")
-				target.adjustToxLoss(-5)
-				target.adjustOxyLoss(-5)
-				target.adjustBruteLoss(-5)
-				target.adjustFireLoss(-5)
-				target.nutrition += 1
-
-			praying = 0
-
-	else
-		to_chat(user, "<span class='notice'>Your prayer to [ticker.Bible_deity_name] was interrupted.</span>")
-		praying = 0
-
-/obj/item/weapon/nullrod/bread/process()
+/obj/item/weapon/nullrod/rosary/bread/process()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/holder = loc
 		//would like to make the holder mime if they have it in on thier person in general


### PR DESCRIPTION
Adds two new chaplain null rods:
Holy salt - When used on floor will notify ghosts to go to the area used at. Why? to spook the hell out of every one in the area.

Prayer bread - a counter to the honk dagger. This mime bread is kinda like the rosary prayerbeads..only it affects clowns..not vampires.

This PR is subject to code changes or closure depending on if anyone find it too sily. and me figureing out how to make the owner of the prayer bread mute.

Shamlessly based off the prayer beads by Dave 'MFER' Headcrab

:cl: Fethas
rscadd: Adds two new holy weapon skins for people who belive in ghosts and worshipers of the silentfather.
/:cl: