### PR TITLE
Allows shovels/spades to remove soil patches

### DIFF
--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -11,6 +11,20 @@
 		return
 	else if(istype(O,/obj/item/weapon/crowbar))
 		return
+	else if(istype(O, /obj/item/weapon/shovel))
+		if(seed)
+			to_chat(user, "You dig up and dispose of \the [seed.display_name].")
+			seed = null
+			dead = 0
+			sampled = 0
+			age = 0
+			lastproduce = 0
+			yield_mod = 0
+			mutation_mod = 0
+			check_health()
+		else
+			to_chat(user, "You clear up [src]!")
+			qdel(src)
 	else
 		..()
 


### PR DESCRIPTION
Using a spade (or shovel from mining) on a patch of soil will do one of two things:
- If there is a plant currently planted in the soil, it will remove it, freeing up the soil patch.
- If there is no plant present, it will clear away the soil, deleting the soil patch.

Fixes #6232 

:cl:
rscadd: Returns the ability to remove vacant soil with shovels and spades, and adds the ability to dig up plants in soil to remove them instantly.
/:cl: