### PR TITLE
Cluwne Mask now allows internals usage

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -287,7 +287,7 @@
 	icon_override = 'icons/goonstation/mob/clothing/mask.dmi'
 	lefthand_file = 'icons/goonstation/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/goonstation/mob/inhands/clothing_righthand.dmi'
-	flags = NODROP | AIRTIGHT | MASKCOVERSMOUTH
+	flags = NODROP
 
 /obj/item/clothing/mask/cursedclown/equipped(mob/user, slot)
 	..()

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -287,7 +287,7 @@
 	icon_override = 'icons/goonstation/mob/clothing/mask.dmi'
 	lefthand_file = 'icons/goonstation/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/goonstation/mob/inhands/clothing_righthand.dmi'
-	flags = NODROP
+	flags = NODROP | AIRTIGHT | MASKCOVERSMOUTH
 
 /obj/item/clothing/mask/cursedclown/equipped(mob/user, slot)
 	..()


### PR DESCRIPTION
prevents cluwne curse from autokilling Vox because they can't breathe (plasmamen have other problems, but anyway)
🆑 Ar3nn
tweak: cursed cluwne mask now allows internals to be fed through it
/🆑 