### PR TITLE
Rigging Lights and Cells now works with Plasma Dust

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -80,7 +80,7 @@
 
 		to_chat(user, "You inject the solution into the power cell.")
 
-		if(S.reagents.has_reagent("plasma", 5))
+		if(S.reagents.has_reagent("plasma", 5) || S.reagents.has_reagent("plasma_dust", 5))
 
 			rigged = 1
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -84,8 +84,8 @@
 
 			rigged = 1
 
-			log_admin("LOG: [user.name] ([user.ckey]) injected a power cell with plasma, rigging it to explode.")
-			message_admins("LOG: [user.name] ([user.ckey]) injected a power cell with plasma, rigging it to explode.")
+			log_admin("LOG: [key_name(user)] injected a power cell with plasma, rigging it to explode.")
+			message_admins("LOG: [key_name_admin(user)] injected a power cell with plasma, rigging it to explode.")
 
 		S.reagents.clear_reagents()
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -676,8 +676,8 @@
 
 		if(S.reagents.has_reagent("plasma", 5) || S.reagents.has_reagent("plasma_dust", 5))
 
-			log_admin("LOG: [user.name] ([user.ckey]) injected a light with plasma, rigging it to explode.")
-			message_admins("LOG: [user.name] ([user.ckey]) injected a light with plasma, rigging it to explode.")
+			log_admin("LOG: [key_name(user)] injected a light with plasma, rigging it to explode.")
+			message_admins("LOG: [key_name_admin(user)] injected a light with plasma, rigging it to explode.")
 
 			rigged = 1
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -674,7 +674,7 @@
 
 		to_chat(user, "You inject the solution into the [src].")
 
-		if(S.reagents.has_reagent("plasma", 5))
+		if(S.reagents.has_reagent("plasma", 5) || S.reagents.has_reagent("plasma_dust", 5))
 
 			log_admin("LOG: [user.name] ([user.ckey]) injected a light with plasma, rigging it to explode.")
 			message_admins("LOG: [user.name] ([user.ckey]) injected a light with plasma, rigging it to explode.")


### PR DESCRIPTION
Light bulbs, light tubes, and power cells can now be rigged with plasma dust from grinding plasma sheets as well as the standard plasma reagent from a chem dispenser.
- Both reagents require at least 5u of their respective reagent to be injected at once to rig the bulb/tube/cell to explode. This amount was not changed.

If a rigged cell is inserted into a stunprod, it only explodes when you actually attempt to stun something with it, not when you turn the prod on. This was unchanged, but I'm mentioning it so people don't think I
changed that.

Fixes #6238

:cl:
tweak: Plasma dust can now be used to rig lights and power cells, like the plasma reagent, with explosive results.
/:cl: