### PR TITLE
Fixes shadowling scaling.

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -388,7 +388,7 @@
 		return
 	for(var/mob/living/user in targets)
 		var/thralls = 0
-		var/victory_threshold = 15
+		var/victory_threshold = ticker.mode.required_thralls
 		var/mob/M
 
 		to_chat(user, "<span class='shadowling'><b>You focus your telepathic energies abound, harnessing and drawing together the strength of your thralls.</b></span>")


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: Fixes shadowlings thrall scaling
/:cl:

fixes #6247 

The abilities still don't scale, only the victory threshold itself. I think we should reserve that for later, seeing as the lesser glare nerf will likely impact heavily how good shadowlings are.