### PR TITLE
Give brains Galactic Common language

### DIFF
--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -10,6 +10,7 @@
 
 /mob/living/carbon/brain/New()
 	create_reagents(330)
+	add_language("Galactic Common")
 	..()
 
 /mob/living/carbon/brain/Destroy()


### PR DESCRIPTION
Brains now have the Galactic Common language. They don't handle languages the same way humans do (so technically speaking they don't speak Galactic Common and can understand it anyway), but this allows them to understand announcements.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6255.