### PR TITLE
Fixes some mobs being invisible in Check_antagonists

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -393,8 +393,11 @@
 		logout_status = " <i>(snpc)</i>"
 	else
 		logout_status = M.client ? "" : " <i>(logged out)</i>"
+	var/dname = M.real_name
+	if(!dname)
+		dname = M
 
-	return {"<tr><td><a href='?src=[UID()];adminplayeropts=\ref[M]'>[M.real_name]</a><b>[caption]</b>[logout_status][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
+	return {"<tr><td><a href='?src=[UID()];adminplayeropts=\ref[M]'>[dname]</a><b>[caption]</b>[logout_status][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>
 		<td><A href='?src=[usr.UID()];priv_msg=\ref[M]'>PM</A></td>[close ? "</tr>" : ""]"}
 
 /datum/admins/proc/check_antagonists()


### PR DESCRIPTION
Currently, mobs without a real_name set don't have any name displayed (and thus, aren't clickable) in check_antagonists.

This fixes that so, in cases where the mob has no real_name, it uses the normal, visible name of the mob instead. E.g: a headslug would show up as a headslug.

No changelog as its an admin-only change.