### PR TITLE
Bans 2-4-1 Traitor Special

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -58,7 +58,6 @@
 
 //	if(!traitors.len)
 //		return 0
-	..()
 	return 1
 
 
@@ -197,5 +196,3 @@
 				//message_admins("New traitor roll failed.  No new traitor.")
 	//else
 		//message_admins("Late Joiner does not have Be Syndicate")
-
-


### PR DESCRIPTION
The majority, if not all, of the gamemodes call the empty parent `/datum/game_mode/proc/pre_setup()` except for autotraitor, which additionally goes through `traitor.pre_setup()`

"Fixes" #6250

If, for whatever reason, the parent call is required/wanted, then I suppose it's best for `autotraitor.pre_setup` to not be a child of `traitor.pre_setup`

:cl: Alexshreds
bugfix: No more double traitor 241 Special
/:cl: