### PR TITLE
Loosens restrictions on CC ID computer

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -440,20 +440,4 @@ var/time_last_changed_position = 0
 	circuit = /obj/item/weapon/circuitboard/card/centcom
 	req_access = list(access_cent_commander)
 	change_position_cooldown = -1
-	blacklisted = list(
-		/datum/job/ai,
-		/datum/job/captain,
-		/datum/job/hop,
-		/datum/job/hos,
-		/datum/job/chief_engineer,
-		/datum/job/rd,
-		/datum/job/cmo,
-		/datum/job/judge,
-		/datum/job/pilot,
-		/datum/job/brigdoc,
-		/datum/job/mechanic,
-		/datum/job/barber,
-		/datum/job/ntnavyofficer,
-		/datum/job/ntspecops,
-		/datum/job/civilian
-	) // same as default, except without cyborg, blueshield, NT rep, chaplain
+	blacklisted = list()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -439,3 +439,4 @@ var/time_last_changed_position = 0
 	name = "\improper CentComm identification computer"
 	circuit = /obj/item/weapon/circuitboard/card/centcom
 	req_access = list(access_cent_commander)
+	change_position_cooldown = -1

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -440,3 +440,20 @@ var/time_last_changed_position = 0
 	circuit = /obj/item/weapon/circuitboard/card/centcom
 	req_access = list(access_cent_commander)
 	change_position_cooldown = -1
+	blacklisted = list(
+		/datum/job/ai,
+		/datum/job/captain,
+		/datum/job/hop,
+		/datum/job/hos,
+		/datum/job/chief_engineer,
+		/datum/job/rd,
+		/datum/job/cmo,
+		/datum/job/judge,
+		/datum/job/pilot,
+		/datum/job/brigdoc,
+		/datum/job/mechanic,
+		/datum/job/barber,
+		/datum/job/ntnavyofficer,
+		/datum/job/ntspecops,
+		/datum/job/civilian
+	) // same as default, except without cyborg, blueshield, NT rep, chaplain


### PR DESCRIPTION
CC ID computer:
- No longer has a cooldown when modifying open job slots.
- Can now modify open job slots for some jobs that normal ID computer cannot: Cyborg, NT Rep, Chaplain and Blueshield

Reasoning:
- Sometimes, admins want to modify open job slots for event purposes, without having to either wait 60 seconds between each  job slot change, or have to use 'free job slot' on each job, one by one, picking each one from a list.
- There are also situations where we might want more cyborgs, blueshields, or NT reps on the station, such as AI-themed events, revolution rounds, inspections, etc.

No changelog as not visible to players.

The normal ID computer is unaffected. This PR only changes the Centcom version of the ID computer.