### PR TITLE
Fixes initial Xenomorphs not appearing in Check Antagonists

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -29,6 +29,8 @@
 				respawnable_list -= C.client
 				var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
 				new_xeno.key = C.key
+				if(ticker && ticker.mode)
+					ticker.mode.xenos += new_xeno.mind
 
 				spawncount--
 				successSpawn = 1


### PR DESCRIPTION

Currently, the initial xenomorphs spawned by the alien infestation event don't appear in "check antagonists" for admins.

This PR fixes it so they do.

No CL, since its an admin-only change.