### PR TITLE
Dropped Stools can now be Deconstructed

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -76,5 +76,14 @@
 
 /obj/item/weapon/stool/dropped(mob/user) //Make sure we aren't leaving un-deconstructible stools.
 	..()
-	origin.forceMove(user.loc) //Put the structure stool back down, not the weapon.
-	qdel(src)
+	if(!user.in_throw_mode) //If this stool isn't getting thrown, turn it back into a structure.
+		origin.forceMove(user.loc)
+		qdel(src)
+
+/obj/item/weapon/stool/throw_impact(atom/hit_atom) //Thrown but uncaught stools will automatically turn into the structure version as soon as the throw is over.
+	..()
+	if(!iscarbon(loc)) //If it wasn't caught by someone, put the structure version down.
+		var/atom/A = get_turf(src)
+		sleep(6) //Gets the work done at the last frame of the 'impact spin' animation so it doesn't look janky.
+		origin.forceMove(A)
+		qdel(src)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -61,7 +61,6 @@
 	origin.loc = get_turf(src)
 	user.unEquip(src)
 	user.visible_message("<span class='notice'>[user] puts [src] down.</span>", "<span class='notice'>You put [src] down.</span>")
-	qdel(src)
 
 /obj/item/weapon/stool/attack(mob/M as mob, mob/user as mob)
 	if(prob(5) && istype(M,/mob/living))
@@ -74,3 +73,8 @@
 		T.Weaken(5)
 		return
 	..()
+
+/obj/item/weapon/stool/dropped(mob/user) //Make sure we aren't leaving un-deconstructible stools.
+	..()
+	origin.forceMove(user.loc) //Put the structure stool back down, not the weapon.
+	qdel(src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -516,7 +516,6 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return
 
 /mob/living/carbon/throw_item(atom/target)
-	throw_mode_off()
 	if(!target || !isturf(loc))
 		return
 	if(istype(target, /obj/screen))
@@ -526,6 +525,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	var/obj/item/I = src.get_active_hand()
 
 	if(!I || (I.flags & NODROP))
+		throw_mode_off()
 		return
 
 	if(istype(I, /obj/item/weapon/grab))
@@ -551,6 +551,8 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		visible_message("<span class='danger'>[src] has thrown [thrown_thing].</span>")
 		newtonian_move(get_dir(target, src))
 		thrown_thing.throw_at(target, thrown_thing.throw_range, thrown_thing.throw_speed, src)
+
+	throw_mode_off()
 
 /mob/living/carbon/can_use_hands()
 	if(handcuffed)


### PR DESCRIPTION
Resolves #6285 where dropping a stool dropped the un-deconstructible stool `/obj/item/weapon/`, not the `/obj/structure/`.

:cl:
fix: Dropped stools can now be deconstructed.
/:cl: