### PR TITLE
Fix security record time and mecha attackby cooldown

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -369,7 +369,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [worldtime2text()], 2557<BR>[t1]")
+				active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [worldtime2text()]<BR>[t1]")
 
 			if("Delete Record (ALL)")
 				if(active1)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -369,7 +369,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [time2text(world.realtime, "DDD MMM DD hh:mm:ss")], 2557<BR>[t1]")
+				active2.fields[text("com_[counter]")] = text("Made by [authenticated] ([rank]) on [worldtime2text()], 2557<BR>[t1]")
 
 			if("Delete Record (ALL)")
 				if(active1)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -832,6 +832,7 @@
 /obj/mecha/proc/attacked_by(obj/item/I, mob/user)
 	log_message("Attacked by [I]. Attacker - [user]")
 	user.changeNext_move(CLICK_CD_MELEE)
+	user.do_attack_animation(src)
 	var/deflection = deflect_chance
 	var/dam_coeff = 1
 	for(var/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster/B in equipment)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -831,6 +831,7 @@
 
 /obj/mecha/proc/attacked_by(obj/item/I, mob/user)
 	log_message("Attacked by [I]. Attacker - [user]")
+	user.changeNext_move(CLICK_CD_MELEE)
 	var/deflection = deflect_chance
 	var/dam_coeff = 1
 	for(var/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster/B in equipment)


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/6305
The security computer now uses the station's time instead of the real time of the user. Also removes the year from the security computer (because 12:00 2557 doesn't make sense).

Fixes https://github.com/ParadiseSS13/Paradise/issues/6288
Adds a cooldown to attacking a mecha with a weapon and adds a missing attack animation.
