### PR TITLE
Fixes water balloons

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -36,6 +36,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "waterballoon-e"
 	item_state = "balloon-empty"
+	var/burst = 0
 
 /obj/item/toy/balloon/New()
 	create_reagents(10)
@@ -78,16 +79,17 @@
 	return
 
 /obj/item/toy/balloon/throw_impact(atom/hit_atom)
-	if(reagents.total_volume >= 1)
-		visible_message("<span class='warning'>The [src] bursts!</span>","You hear a pop and a splash.")
-		reagents.reaction(get_turf(hit_atom))
-		for(var/atom/A in get_turf(hit_atom))
-			reagents.reaction(A)
-		icon_state = "burst"
-		spawn(5)
-			if(src)
-				qdel(src)
-	return
+	if(!burst)
+		if(reagents.total_volume >= 1)
+			visible_message("<span class='warning'>\The [src] bursts!</span>","You hear a pop and a splash.")
+			burst = 1
+			reagents.reaction(get_turf(hit_atom))
+			for(var/atom/A in get_turf(hit_atom))
+				reagents.reaction(A)
+			icon_state = "burst"
+			spawn(5)
+				if(src)
+					qdel(src)
 
 /obj/item/toy/balloon/update_icon()
 	if(src.reagents.total_volume >= 1)


### PR DESCRIPTION
fixes #6201

`throw_impact()` runs for each atom on the tile where an item hits, so
you were getting the message for each atom on the tile.

This also fixes 2 other problems - reagents in the balloon were reacting
to everything on the tile x number of times where x = number of atoms on
the tile (really good job acid balloons aren't possible lol)

A runtime was also being caused due to the spawned qdel activating
before all the throw_impacts had finished which left it trying to read
`null.reagents.total_volume`