### PR TITLE
Fixes admin ship templates

### DIFF
--- a/_maps/map_files/templates/medium_shuttle1.dmm
+++ b/_maps/map_files/templates/medium_shuttle1.dmm
@@ -6,41 +6,61 @@
 "f" = (/turf/simulated/shuttle/wall,/turf/simulated/shuttle/wall{tag = "icon-wall3 (SOUTHEAST)"; icon_state = "wall3"; dir = 6},/area/ruin/powered{name = "Shuttle"})
 "g" = (/turf/simulated/shuttle/wall,/area/ruin/powered{name = "Shuttle"})
 "h" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating,/area/ruin/powered{name = "Shuttle"})
-"i" = (/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (SOUTHEAST)"; icon_state = "diagonalWall"; dir = 6},/area/ruin/powered{name = "Shuttle"})
+"i" = (/obj/machinery/power/smes/magical{name = "super smes"},/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "j" = (/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "k" = (/obj/machinery/door/airlock/glass,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
-"l" = (/obj/machinery/door/airlock/glass,/turf/space,/area/ruin/powered{name = "Shuttle"})
+"l" = (/obj/structure/computerframe,/obj/item/weapon/circuitboard/teleporter,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "m" = (/obj/structure/table,/obj/item/weapon/storage/firstaid/regular,/turf/simulated/floor/plasteel{tag = "icon-bluefull"; icon_state = "bluefull"},/area/ruin/powered{name = "Shuttle"})
-"n" = (/obj/machinery/sleeper{tag = "icon-sleeper (NORTH)"; icon_state = "sleeper"; dir = 1},/turf/simulated/floor/plasteel{tag = "icon-bluefull"; icon_state = "bluefull"},/area/ruin/powered{name = "Shuttle"})
+"n" = (/obj/structure/table,/obj/item/clothing/head/helmet/space/eva,/obj/item/clothing/suit/space/eva,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "o" = (/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "p" = (/obj/machinery/door/airlock/glass,/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "q" = (/turf/simulated/floor/plasteel{tag = "icon-bluefull"; icon_state = "bluefull"},/area/ruin/powered{name = "Shuttle"})
 "r" = (/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
 "s" = (/obj/structure/table/reinforced,/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
 "t" = (/obj/effect/spawner/window/reinforced,/turf/simulated/floor/plating,/area/ruin/powered{name = "Shuttle"})
-"u" = (/obj/machinery/power/smes/magical,/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
+"u" = (/obj/machinery/teleport/hub,/obj/item/weapon/hand_tele,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "v" = (/turf/simulated/floor/plating,/turf/simulated/shuttle/wall{tag = "icon-window1"; icon_state = "window1"},/area/ruin/powered{name = "Shuttle"})
-"w" = (/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (NORTHWEST)"; icon_state = "diagonalWall"; dir = 9},/area/ruin/powered{name = "Shuttle"})
+"w" = (/obj/machinery/light{dir = 4},/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "x" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (NORTHWEST)"; icon_state = "diagonalWall"; dir = 9},/area/ruin/powered{name = "Shuttle"})
 "y" = (/turf/simulated/shuttle/wall{tag = "icon-wall"; icon_state = "wall"},/area/ruin/powered{name = "Shuttle"})
 "z" = (/obj/structure/shuttle/engine/propulsion/burst/right{tag = "icon-burst_r (EAST)"; icon_state = "burst_r"; dir = 4},/turf/space,/area/ruin/powered{name = "Shuttle"})
 "A" = (/turf/simulated/shuttle/wall,/turf/simulated/shuttle/wall{tag = "icon-wall3 (NORTHEAST)"; icon_state = "wall3"; dir = 5},/area/ruin/powered{name = "Shuttle"})
 "B" = (/turf/space,/turf/simulated/shuttle{tag = "icon-wall3 (SOUTHEAST)"; icon_state = "wall3"; dir = 6},/area/ruin/powered{name = "Shuttle"})
+"C" = (/obj/machinery/light{dir = 1},/obj/machinery/teleport/station,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"D" = (/obj/machinery/light,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"E" = (/obj/machinery/vending/snack,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"F" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"G" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (SOUTHEAST)"; icon_state = "diagonalWall"; dir = 6},/area/ruin/powered{name = "Shuttle"})
+"H" = (/obj/machinery/sleeper,/turf/simulated/floor/plasteel{tag = "icon-bluefull"; icon_state = "bluefull"},/area/ruin/powered{name = "Shuttle"})
+"I" = (/obj/structure/stool/bed,/obj/item/weapon/bedsheet/purple,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"J" = (/obj/machinery/vending/medical,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"K" = (/obj/machinery/light{dir = 4},/obj/machinery/vending/engivend,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"L" = (/obj/structure/stool/bed/chair/comfy/black{dir = 4},/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
+"M" = (/obj/machinery/computer,/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
+"N" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/electrical,/obj/item/clothing/gloves/color/yellow,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"O" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
+"P" = (/obj/machinery/light,/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
+"Q" = (/obj/structure/table,/obj/item/weapon/storage/belt/utility/full/multitool,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"R" = (/obj/machinery/vending/coffee,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"S" = (/obj/item/device/radio/beacon,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"T" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (SOUTHEAST)"; icon_state = "diagonalWall"; dir = 6},/area/space)
+"U" = (/obj/structure/table/reinforced,/obj/machinery/recharger,/obj/item/weapon/gun/energy/laser/retro,/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
 
 (1,1,1) = {"
 aaabcdddeaaaaaaaaaaaaaa
 aaabcddddeaaaaaaaaaaaaa
-aaabcfgggghhgiaaaaaaaaa
-aaggggjjjgjjggiaaaaaaaa
-aagjjkjjjglggggggggiaaa
-ggggkggkggjjgmngjjggggi
-hopoogjjjljjlqqljjlrrst
-gogougjjjgvvgvvggggrrst
-hopoogjjjljjljjljjlrrst
-ggggkggkggjjgjjgjjggggw
-aagjjkjjjglggggggggxaaa
-aaygggjjjgjjggwaaaaaaaa
-aaazcAgggghhgwaaaaaaaaa
+aaabcfgggghhgTaaaaaaaaa
+aagggglCugjjggGaaaaaaaa
+aagNjkjSjgkggggggggGaaa
+ggggkggkggjEgmHgJKggggG
+hopOognjjkjjkqqkjjkrrUt
+gogoignjwgvvgvvggggrLMt
+hopPognjjkjjkjjkjjkrrst
+ggggpggkggjFgIIgjwggggx
+aagQjkjjRgkggggggggxaaa
+aaygggjDjgjjggxaaaaaaaa
+aaazcAgggghhgxaaaaaaaaa
 aaazcdddBaaaaaaaaaaaaaa
 aaazcddBaaaaaaaaaaaaaaa
 "}
+

--- a/_maps/map_files/templates/medium_shuttle2.dmm
+++ b/_maps/map_files/templates/medium_shuttle2.dmm
@@ -6,13 +6,13 @@
 "f" = (/obj/structure/shuttle/engine/propulsion/burst/right{tag = "icon-burst_r (EAST)"; icon_state = "burst_r"; dir = 4},/turf/space,/area/ruin/powered{name = "Shuttle"})
 "g" = (/turf/simulated/shuttle/wall,/turf/simulated/shuttle{tag = "icon-wall3 (SOUTHEAST)"; icon_state = "wall3"; dir = 6},/area/ruin/powered{name = "Shuttle"})
 "h" = (/turf/simulated/shuttle/wall,/area/ruin/powered{name = "Shuttle"})
-"i" = (/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (SOUTHEAST)"; icon_state = "diagonalWall"; dir = 6},/area/space)
+"i" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "j" = (/turf/space,/turf/simulated/shuttle{tag = "icon-wall3 (NORTHWEST)"; icon_state = "wall3"; dir = 9},/area/ruin/powered{name = "Shuttle"})
 "k" = (/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "l" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "m" = (/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "n" = (/obj/machinery/door/airlock/glass,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
-"o" = (/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (SOUTHEAST)"; icon_state = "diagonalWall"; dir = 6},/area/ruin/powered{name = "Shuttle"})
+"o" = (/obj/machinery/light,/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "p" = (/turf/simulated/floor/plasteel{tag = "icon-bluefull"; icon_state = "bluefull"},/area/ruin/powered{name = "Shuttle"})
 "q" = (/obj/machinery/door/airlock/glass,/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "r" = (/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
@@ -23,26 +23,47 @@
 "w" = (/obj/structure/table/reinforced,/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
 "x" = (/obj/effect/spawner/window/reinforced,/turf/simulated/floor/plating,/area/ruin/powered{name = "Shuttle"})
 "y" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating,/area/ruin/powered{name = "Shuttle"})
-"z" = (/obj/machinery/power/smes/magical,/turf/simulated/floor/plating,/area/ruin/powered{name = "Shuttle"})
+"z" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/plasteel,/area/ruin/powered{name = "Shuttle"})
 "A" = (/obj/structure/grille,/obj/structure/shuttle/window,/turf/simulated/floor/plating,/area/ruin/powered{name = "Shuttle"})
 "B" = (/obj/structure/stool/bed/chair/comfy{tag = "icon-comfychair (EAST)"; icon_state = "comfychair"; dir = 4},/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
 "C" = (/turf/simulated/shuttle/wall,/turf/simulated/shuttle{tag = "icon-wall3 (NORTHEAST)"; icon_state = "wall3"; dir = 5},/area/ruin/powered{name = "Shuttle"})
-"D" = (/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (NORTHWEST)"; icon_state = "diagonalWall"; dir = 9},/area/ruin/powered{name = "Shuttle"})
-"E" = (/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (NORTHWEST)"; icon_state = "diagonalWall"; dir = 9},/area/space)
+"D" = (/obj/structure/computerframe,/obj/item/weapon/circuitboard/teleporter,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"E" = (/obj/machinery/teleport/hub,/obj/item/weapon/hand_tele,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
 "F" = (/turf/space,/turf/simulated/shuttle{tag = "icon-wall3 (SOUTHEAST)"; icon_state = "wall3"; dir = 6},/area/ruin/powered{name = "Shuttle"})
+"G" = (/obj/item/device/radio/beacon,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"H" = (/obj/machinery/vending/coffee,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"I" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (SOUTHEAST)"; icon_state = "diagonalWall"; dir = 6},/area/space)
+"J" = (/obj/machinery/light{dir = 1},/obj/machinery/vending/snack,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"K" = (/obj/machinery/light,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"L" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (NORTHWEST)"; icon_state = "diagonalWall"; dir = 9},/area/space)
+"M" = (/obj/structure/stool/bed,/obj/item/weapon/bedsheet/purple,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"N" = (/obj/structure/table,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"O" = (/obj/structure/table,/obj/item/weapon/storage/belt/utility/full/multitool,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"P" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/electrical,/obj/item/clothing/gloves/color/yellow,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"Q" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (SOUTHEAST)"; icon_state = "diagonalWall"; dir = 6},/area/ruin/powered{name = "Shuttle"})
+"R" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-diagonalWall (NORTHWEST)"; icon_state = "diagonalWall"; dir = 9},/area/ruin/powered{name = "Shuttle"})
+"S" = (/obj/structure/table/reinforced,/obj/machinery/recharger,/obj/item/weapon/gun/energy/laser/retro,/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
+"T" = (/obj/structure/table,/obj/item/clothing/head/helmet/space/eva,/obj/item/clothing/suit/space/eva,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"U" = (/obj/machinery/teleport/station,/turf/simulated/floor/plasteel{tag = "icon-dark"; icon_state = "dark"},/area/ruin/powered{name = "Shuttle"})
+"V" = (/obj/machinery/power/smes/magical{name = "super smes"},/turf/simulated/floor/plating,/area/ruin/powered{name = "Shuttle"})
+"W" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/plasteel{tag = "icon-bluefull"; icon_state = "bluefull"},/area/ruin/powered{name = "Shuttle"})
+"X" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
+"Y" = (/obj/machinery/light,/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
+"Z" = (/obj/machinery/computer,/turf/simulated/floor/plasteel{tag = "icon-whiteyellowfull"; icon_state = "whiteyellowfull"},/area/ruin/powered{name = "Shuttle"})
 
 (1,1,1) = {"
 aaabcddddeaaaaaaaaaaaaaaaaaa
-aaafcddghhhiaaaaaaaaaaaaaaaa
-aaajdghhkkhhhhlhiaaaaaaaaaaa
-bcdddhmnkknkkhkhhhhhhhhhhhoa
-fcddghmhhhhkknknknppnkkqrrhh
-aaashtmhhhhnhhhhkhuvhkkhrwxa
-aaaaymmzhhhkhhhhkhAAhAAhBwxa
-aaajhtmhhhhnhhhhkhkkhkkhrwxa
-bcddChmhhhhkknknknkknkkqrrhh
-fcdddhmnkknkkhkhhhhhhhhhhhDa
-aaasdChhkkhhhhlhEaaaaaaaaaaa
-aaabcddChhhEaaaaaaaaaaaaaaaa
+aaafcddghhhIaaaaaaaaaaaaaaaa
+aaajdghhTThhhhlhIaaaaaaaaaaa
+bcdddhinkkhJHhkhhhhhhhhhhhQa
+fcddghmhkknkknknknWpnkkqXrhh
+aaashzmhDkhhhhhhkhuvhNNhrSxa
+aaaaymmhUknkVhhhkhAAhAAhBZxa
+aaajhtmhEGhhhhhhkhMMhPOhrwxa
+bcddChmhkknkknknknKknkkqYrhh
+fcdddhonkkhKkhkhhhhhhhhhhhRa
+aaasdChhNNhhhhlhLaaaaaaaaaaa
+aaabcddChhhLaaaaaaaaaaaaaaaa
 aaafcddddFaaaaaaaaaaaaaaaaaa
 "}
+

--- a/_maps/map_files/templates/small_shuttle_1.dmm
+++ b/_maps/map_files/templates/small_shuttle_1.dmm
@@ -1,33 +1,38 @@
-"a" = (/turf/space,/area/space)
-"b" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f6"; icon_state = "swall_f6"},/area/space)
-"c" = (/obj/structure/grille,/obj/structure/shuttle/window,/turf/simulated/floor/plating/airless,/area/space)
-"d" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f10"; icon_state = "swall_f10"},/area/space)
-"e" = (/turf/simulated/shuttle/wall{tag = "icon-swall3"; icon_state = "swall3"},/area/space)
-"f" = (/turf/simulated/shuttle/floor,/area/space)
-"g" = (/obj/structure/stool/bed/chair{dir = 1},/turf/simulated/shuttle/floor,/area/space)
-"h" = (/turf/simulated/shuttle/wall{tag = "icon-swall13"; icon_state = "swall13"},/area/space)
-"i" = (/turf/simulated/shuttle/wall{tag = "icon-swall8"; icon_state = "swall8"},/area/space)
-"j" = (/obj/machinery/door/unpowered/shuttle,/turf/simulated/shuttle/floor,/area/space)
-"k" = (/turf/simulated/shuttle/wall{tag = "icon-swall4"; icon_state = "swall4"},/area/space)
-"l" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/shuttle/floor,/area/space)
-"m" = (/obj/structure/stool/bed/chair{dir = 8},/turf/simulated/shuttle/floor,/area/space)
-"n" = (/obj/structure/shuttle/engine/heater,/turf/simulated/floor/plating/airless,/area/space)
-"o" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f5"; icon_state = "swall_f5"},/area/space)
-"p" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_l"},/turf/simulated/floor/plating/airless,/area/space)
-"q" = (/obj/structure/shuttle/engine/propulsion,/turf/simulated/floor/plating/airless,/area/space)
-"r" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_r"},/turf/simulated/floor/plating/airless,/area/space)
-"s" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f9"; icon_state = "swall_f9"},/area/space)
+"a" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f6"; icon_state = "swall_f6"},/area/ruin/powered)
+"b" = (/turf/space,/area/ruin/powered)
+"c" = (/turf/simulated/shuttle/wall{tag = "icon-swall3"; icon_state = "swall3"},/area/ruin/powered)
+"d" = (/obj/machinery/door/unpowered/shuttle,/turf/simulated/shuttle/floor,/area/ruin/powered)
+"e" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f5"; icon_state = "swall_f5"},/area/ruin/powered)
+"f" = (/turf/simulated/shuttle/wall{tag = "icon-swall8"; icon_state = "swall8"},/area/ruin/powered)
+"g" = (/obj/structure/grille,/obj/structure/shuttle/window,/turf/simulated/floor/plating/airless,/area/ruin/powered)
+"h" = (/turf/simulated/shuttle/floor,/area/ruin/powered)
+"i" = (/obj/machinery/light,/turf/simulated/shuttle/floor,/area/ruin/powered)
+"j" = (/obj/structure/shuttle/engine/heater,/turf/simulated/floor/plating/airless,/area/ruin/powered)
+"k" = (/obj/structure/shuttle/engine/propulsion,/turf/simulated/floor/plating/airless,/area/ruin/powered)
+"l" = (/turf/simulated/shuttle/wall{tag = "icon-swall13"; icon_state = "swall13"},/area/ruin/powered)
+"m" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/shuttle/floor,/area/ruin/powered)
+"n" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/shuttle/floor,/area/ruin/powered)
+"o" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_l"},/turf/simulated/floor/plating/airless,/area/ruin/powered)
+"p" = (/turf/simulated/shuttle/wall{tag = "icon-swall4"; icon_state = "swall4"},/area/ruin/powered)
+"q" = (/obj/machinery/computer,/turf/simulated/shuttle/floor,/area/ruin/powered)
+"r" = (/obj/structure/stool/bed/chair{dir = 1},/turf/simulated/shuttle/floor,/area/ruin/powered)
+"s" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f10"; icon_state = "swall_f10"},/area/ruin/powered)
+"t" = (/turf/space,/turf/simulated/shuttle/wall{tag = "icon-swall_f9"; icon_state = "swall_f9"},/area/ruin/powered)
+"u" = (/obj/structure/stool/bed/chair{dir = 8},/turf/simulated/shuttle/floor,/area/ruin/powered)
+"v" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/simulated/shuttle/floor,/area/ruin/powered)
+"w" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_r"},/turf/simulated/floor/plating/airless,/area/ruin/powered)
 
 (1,1,1) = {"
-abcccda
-aefgfea
-aefffea
-bhijkhd
-elfffme
-elfffme
-jfffffj
-jfffffj
-efffffe
-ennnnne
-opqqqrs
+bagggsb
+bchrqcb
+bcihicb
+alfdpls
+cmhhhuc
+cmhhhuc
+dhhhhhd
+dhhhhhd
+cnhhhvc
+cjjjjjc
+eokkkwt
 "}
+


### PR DESCRIPTION
Fixes some map templates for shuttles, which were hilariously bad, and thus, unused.

They get:
- Lights (seriously, who flies a starship in the dark?)
- At least one bridge computer - gotta control the ship, after all
- Beds - how does the crew function without these?
- Medical supplies
- A toolbelt, igloves, and electrical toolbox, for maintenance
- At least one EVA suit, and full oxy tank, for spacewalks
- Food, to live on
- Fixes to tiles which were unexpectedly missing floors under airlocks, space tiles in space, missing area definitions, etc
- A retro laser and recharger, for anti-boarding defense
- A constructable teleporter, so they can get to the station

Shuttle 1, before:
![](http://i.imgur.com/XkeQ6cm.png)

and after:
![](http://i.imgur.com/rjBCOoc.png)

Shuttle 2, before:
![](http://i.imgur.com/2QkNxEy.png)

and after:
![](http://i.imgur.com/vObiEee.png)

No changelog, as only admins can load in these templates.
Hopefully these templates will see use now.