### PR TITLE
Fixes Water Balloons

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -78,16 +78,17 @@
 	return
 
 /obj/item/toy/balloon/throw_impact(atom/hit_atom)
+	..()
 	if(reagents.total_volume >= 1)
-		visible_message("<span class='warning'>The [src] bursts!</span>","You hear a pop and a splash.")
+		visible_message("<span class='warning'>\The [src] bursts!</span>","You hear a pop and a splash.")
 		reagents.reaction(get_turf(hit_atom))
 		for(var/atom/A in get_turf(hit_atom))
 			reagents.reaction(A)
 		icon_state = "burst"
+		reagents.remove_any(reagents.total_volume)
 		spawn(5)
 			if(src)
 				qdel(src)
-	return
 
 /obj/item/toy/balloon/update_icon()
 	if(src.reagents.total_volume >= 1)


### PR DESCRIPTION
fixes #6201

replaces #6309

Ok, the real problem was that without a parent call, `throw_impact()`
triggers a `Bump()` which then calls `throw_impact()` - this carried on
until the spawned `qdel()` kicked in and resulted in the runtime.

Also, `throw_impact()` is called on both the object it hits and the turf
of that object, so even without the loop above you'd end up with the
message twice - solved by emptying the reagents once the balloon bursts

Also fixed the grammer issue in "The the water balloon bursts!"