### PR TITLE
Tweak: Mr Chang's vending machine now refillable

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1571,6 +1571,14 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 15
 	containername = "snacks supply crate"
 
+/datum/supply_packs/vending/chinese
+	name = "Chinese Supply Crate"
+	contains = list(/obj/item/weapon/vending_refill/chinese,
+					/obj/item/weapon/vending_refill/chinese,
+					/obj/item/weapon/vending_refill/chinese)
+	cost = 15
+	containername = "chinese supply crate"
+
 /datum/supply_packs/vending/cola
 	name = "Softdrinks Supply Crate"
 	contains = list(/obj/item/weapon/vending_refill/cola,

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -230,6 +230,7 @@ to destroy them and players will be able to make replacements.
 	var/list/names_paths = list("Booze-O-Mat" = /obj/machinery/vending/boozeomat,
 							"Solar's Best Hot Drinks" = /obj/machinery/vending/coffee,
 							"Getmore Chocolate Corp" = /obj/machinery/vending/snack,
+							"Mr. Chang" = /obj/machinery/vending/chinese,
 							"Robust Softdrinks" = /obj/machinery/vending/cola,
 							"ShadyCigs Deluxe" = /obj/machinery/vending/cigarette,
 							"AutoDrobe" = /obj/machinery/vending/autodrobe,

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -800,6 +800,17 @@
 					/obj/item/weapon/reagent_containers/food/snacks/chinese/rice = 6)
 	prices = list(/obj/item/weapon/reagent_containers/food/snacks/chinese/chowmein = 50, /obj/item/weapon/reagent_containers/food/snacks/chinese/tao = 50, /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles = 50,
 					/obj/item/weapon/reagent_containers/food/snacks/chinese/rice = 50)
+	refill_canister = /obj/item/weapon/vending_refill/chinese
+
+/obj/machinery/vending/chinese/New()
+	..()
+	component_parts = list()
+	var/obj/item/weapon/circuitboard/vendor/V = new(null)
+	V.set_type(type)
+	component_parts += V
+	component_parts += new /obj/item/weapon/vending_refill/chinese(0)
+	component_parts += new /obj/item/weapon/vending_refill/chinese(0)
+	component_parts += new /obj/item/weapon/vending_refill/chinese(0)
 
 /obj/machinery/vending/cola
 	name = "\improper Robust Softdrinks"

--- a/code/game/objects/items/weapons/vending_items.dm
+++ b/code/game/objects/items/weapons/vending_items.dm
@@ -82,3 +82,8 @@
 	machine_name = "CritterCare"
 	icon_state = "refill_pet"
 	charges = 31// of 94
+
+/obj/item/weapon/vending_refill/chinese
+	machine_name = "MrChangs"
+	charges = 8// of 24
+


### PR DESCRIPTION
Changed the Mr Chang's vending machine to be able to be refiled with a new Chinese vending refill canister crate that can be ordered by Cargo.

:cl:
tweak: Set the Mr Chang's vending machine to be refillable
rscadd: Added a Supply Crate to the Vending section of the Cargo Request Console for Chinese Refill Canisters
/:cl: