### PR TITLE
IPC Names now Load Correctly from SQL

### DIFF
--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -266,7 +266,7 @@
 
 	//Sanitize
 	metadata		= sanitize_text(metadata, initial(metadata))
-	real_name		= reject_bad_name(real_name)
+	real_name		= reject_bad_name(real_name, 1)
 	if(isnull(species)) species = "Human"
 	if(isnull(language)) language = "None"
 	if(isnull(nanotrasen_relation)) nanotrasen_relation = initial(nanotrasen_relation)


### PR DESCRIPTION
If you want to have a name like ARMA-420 in game you previously had to manually set it every round because it wouldn't load properly from SQL because reject_bad_name doesn't like no numbers.

This changes that.

Tested by creating an IPC character named ARMA-420, saving it to SQL, and reloading the character in the character creation screen to make sure the numbers weren't being lost.
I double checked by killing and restarting the server.

Fixes #6312 
:cl:
fix: IPC names with numbers now load correctly from SQL.
/:cl: