### PR TITLE
Refactors Throw_Impact()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -12,6 +12,7 @@
 	var/throw_speed = 2
 	var/throw_range = 7
 	var/no_spin_thrown = 0 //set this to 1 if you don't want an item that you throw to spin, no matter what. -Fox
+	var/impacted = 0
 	var/moved_recently = 0
 	var/mob/pulledby = null
 	var/inertia_dir = 0
@@ -114,6 +115,7 @@
 /atom/movable/Bump(var/atom/A as mob|obj|turf|area, sendBump)
 	if(src.throwing)
 		src.throw_impact(A)
+		throwing = 0
 
 	if(A && sendBump)
 		A.last_bumped = world.time
@@ -165,23 +167,34 @@
 	if(istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom
 		M.hitby(src,speed)
+		impact(hit_atom, speed)
+		throwing = 0
 
 	else if(isobj(hit_atom))
 		var/obj/O = hit_atom
 		if(!O.anchored)
 			step(O, src.dir)
 		O.hitby(src,speed)
+		impact(hit_atom, speed)
+		throwing = 0
 
-	else if(isturf(hit_atom))
-		src.throwing = 0
-		var/turf/T = hit_atom
-		if(T.density)
-			spawn(2)
-				step(src, turn(src.dir, 180))
-			if(istype(src,/mob/living))
-				var/mob/living/M = src
-				M.turf_collision(T, speed)
+/atom/movable/proc/ground_impact(turf/T, var/speed)
+	throwing = 0
+	if(T.density)
+		spawn(2)
+			step(src, turn(src.dir, 180))
+		if(istype(src,/mob/living))
+			var/mob/living/M = src
+			M.turf_collision(T, speed)
+		impact(T, speed)
 
+// For stuff that happens whether it hits a mob/object or the ground. When overriding start with if(!..()) return to prevent
+// the action happening both when it hits an object/mob and when it hits the ground
+/atom/movable/proc/impact(atom/hit_atom, var/speed)
+	if(impacted)
+		return 0
+	impacted = 1
+	return 1
 
 //Called whenever an object moves and by mobs when they attempt to move themselves through space
 //And when an object or action applies a force on src, see newtonian_move() below
@@ -220,7 +233,8 @@
 		for(var/atom/A in get_turf(src))
 			if(A == src) continue
 			if(istype(A,/mob/living))
-				if(A:lying) continue
+				var/mob/living/M = A
+				if(M.lying) continue
 				src.throw_impact(A,speed)
 			if(isobj(A))
 				if(A.density && !A.throwpass)	// **TODO: Better behaviour for windows which are dense, but shouldn't always stop movement
@@ -315,10 +329,12 @@
 			a = get_area(src.loc)
 
 	//done throwing, either because it hit something or it finished moving
-	if(isobj(src)) src.throw_impact(get_turf(src),speed)
-	src.throwing = 0
-	src.thrower = null
-	src.throw_source = null
+	if(isobj(src) && isturf(loc))
+		ground_impact(get_turf(src),speed)
+	throwing = 0
+	thrower = null
+	throw_source = null
+	impacted = 0
 
 
 //Overlays

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -342,8 +342,9 @@
 	user.drop_item()
 	qdel(src)
 
-/obj/item/weapon/ectoplasm/revenant/throw_impact(atom/hit_atom)
-	..()
+/obj/item/weapon/ectoplasm/revenant/impact(atom/hit_atom)
+	if(!..())
+		return
 	if(inert)
 		return
 	visible_message("<span class='notice'>[src] breaks into particles upon impact, which fade away to nothingness.</span>")

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -307,12 +307,12 @@
 	var/primed = null
 	throwforce = 15
 
-/obj/item/missile/throw_impact(atom/hit_atom)
+/obj/item/missile/impact(atom/hit_atom)
+	if(!..())
+		return
 	if(primed)
 		explosion(hit_atom, 0, 0, 2, 4, 0)
 		qdel(src)
-	else
-		..()
 	return
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -52,7 +52,9 @@
 			die()
 	return
 
-/obj/item/ashtray/throw_impact(atom/hit_atom)
+/obj/item/ashtray/impact(atom/hit_atom)
+	if(!..())
+		return
 	if(health > 0)
 		health = max(0,health - 3)
 		if(health < 1)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -77,7 +77,9 @@
 	update_icon()
 	return
 
-/obj/item/toy/balloon/throw_impact(atom/hit_atom)
+/obj/item/toy/balloon/impact(atom/hit_atom)
+	if(!..())
+		return
 	if(reagents.total_volume >= 1)
 		visible_message("<span class='warning'>The [src] bursts!</span>","You hear a pop and a splash.")
 		reagents.reaction(get_turf(hit_atom))
@@ -236,8 +238,9 @@
 	w_class = 1
 
 
-/obj/item/toy/snappop/virus/throw_impact(atom/hit_atom)
-	..()
+/obj/item/toy/snappop/virus/impact(atom/hit_atom)
+	if(!..())
+		return
 	var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
@@ -270,8 +273,9 @@
 /obj/item/toy/snappop/fire_act()
 	pop_burst()
 
-/obj/item/toy/snappop/throw_impact(atom/hit_atom)
-	..()
+/obj/item/toy/snappop/impact(atom/hit_atom)
+	if(!..())
+		return
 	pop_burst()
 
 /obj/item/toy/snappop/Crossed(H as mob|obj)
@@ -882,8 +886,9 @@ obj/item/toy/cards/deck/syndicate/black
 	icon_state = "minimeteor"
 	w_class = 2
 
-/obj/item/toy/minimeteor/throw_impact(atom/hit_atom)
-	..()
+/obj/item/toy/minimeteor/impact(atom/hit_atom)
+	if(!..())
+		return
 	playsound(src, 'sound/effects/meteorimpact.ogg', 40, 1)
 	for(var/mob/M in range(10, src))
 		if(!M.stat && !istype(M, /mob/living/silicon/ai))\

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -298,7 +298,9 @@
 			desc += " You're not sure if making this out of a carton was the brightest idea."
 			isGlass = 0
 
-/obj/item/weapon/reagent_containers/food/drinks/bottle/molotov/throw_impact(atom/target,mob/thrower)
+/obj/item/weapon/reagent_containers/food/drinks/bottle/molotov/impact(atom/target,mob/thrower)
+	if(!..())
+		return
 	var/firestarter = 0
 	for(var/datum/reagent/R in reagents.reagent_list)
 		for(var/A in accelerants)
@@ -309,7 +311,7 @@
 	if(firestarter && active)
 		target.fire_act()
 		new /obj/effect/hotspot(get_turf(target))
-	..()
+
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/molotov/attackby(obj/item/I, mob/user, params)
 	if(is_hot(I) && !active)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -380,8 +380,9 @@
 	filling_color = "#FDFFD1"
 	list_reagents = list("protein" = 1, "egg" = 5)
 
-/obj/item/weapon/reagent_containers/food/snacks/egg/throw_impact(atom/hit_atom)
-	..()
+/obj/item/weapon/reagent_containers/food/snacks/egg/impact(atom/hit_atom)
+	if(!..())
+		return
 	var/turf/T = get_turf(hit_atom)
 	new/obj/effect/decal/cleanable/egg_smudge(T)
 	if(reagents)
@@ -731,8 +732,9 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "banana" = 5, "vitamin" = 2)
 
-/obj/item/weapon/reagent_containers/food/snacks/pie/throw_impact(atom/hit_atom)
-	..()
+/obj/item/weapon/reagent_containers/food/snacks/pie/impact(atom/hit_atom)
+	if(!..())
+		return
 	new/obj/effect/decal/cleanable/pie_smudge(loc)
 	visible_message("<span class='warning'>[src] splats.</span>","<span class='warning'>You hear a splat.</span>")
 	qdel(src)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -193,8 +193,9 @@
 			if(src) qdel(src)
 			return
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom)
-	..()
+/obj/item/weapon/reagent_containers/food/snacks/grown/impact(atom/hit_atom)
+	if(!..())
+		return
 	if(seed) seed.thrown_at(src,hit_atom)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/attackby(var/obj/item/weapon/W, var/mob/user)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -626,8 +626,9 @@
 	brightness_power = 2
 	brightness_color = "#a0a080"
 
-/obj/item/weapon/light/throw_impact(atom/hit_atom)
-	..()
+/obj/item/weapon/light/impact(atom/hit_atom)
+	if(!..())
+		return
 	shatter()
 
 /obj/item/weapon/light/bulb/fire

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -28,8 +28,9 @@
 		return
 	do_teleport(L, get_turf(L), blink_range, asoundin = 'sound/effects/phasein.ogg')
 
-/obj/item/weapon/ore/bluespace_crystal/throw_impact(atom/hit_atom)
-	..()
+/obj/item/weapon/ore/bluespace_crystal/impact(atom/hit_atom)
+	if(!..())
+		return
 	if(isliving(hit_atom))
 		blink_mob(hit_atom)
 	qdel(src)


### PR DESCRIPTION
Splits `throw_impact()` into 2 procs - 

`throw_impact()` deals with the object hitting a mob or object
`ground_impact()` deals with the object hitting the ground - doesn't run if the item doesn't end up on a turf (eg caught)

Also adds an `impact()` proc which is called by both for behavior that happens whether it hits a mob/object or the ground - this has protection so as long as an override runs an `if(!..()) return` it will only run the first time it impacts something.

`throwing` is now set to 0 when an object hits a mob or object - the lack of this is what was causing caught objects to both be caught and hit a mob

fixes #6201 
fixes #5978 
stops throw_impact() behavior being duplicated 