### PR TITLE
Use advanced mining scanner on ore box to interact with it

### DIFF
--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -10,6 +10,9 @@
 	pressure_resistance = 5*ONE_ATMOSPHERE
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/device/t_scanner/adv_mining_scanner))
+		attack_hand(user)
+		return
 	if(istype(W, /obj/item/weapon/ore))
 		if(!user.drop_item())
 			return


### PR DESCRIPTION
This is to allow mining borgs to see how much ore they have and to drop ore.

:cl:
tweak: You can interact with an ore box by using an advanced mining scanner on it.
/:cl: