### PR TITLE
Botany reagents Tweak

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -219,10 +219,10 @@
 	var/S = 0
 	for(var/obj/item/weapon/reagent_containers/food/snacks/grown/I in contents)
 		S += 5
-		if(I.reagents.get_reagent_amount("nutriment") < 0.1)
+		if(I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter") < 0.1)
 			points += 1*productivity
 		else
-			points += I.reagents.get_reagent_amount("nutriment")*10*productivity
+			points += (I.reagents.get_reagent_amount("nutriment")+I.reagents.get_reagent_amount("plantmatter"))*10*productivity
 		qdel(I)
 	if(S)
 		processing = 1

--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -23,7 +23,7 @@
 	icon_dead = "ambrosia-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/ambrosia/deus)
-	reagents_add = list("space_drugs" = 0.15, "bicaridine" = 0.1, "kelotane" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05, "toxin" = 0.1)
+	reagents_add = list("space_drugs" = 0.15, "bicaridine" = 0.1, "kelotane" = 0.1, "vitamin" = 0.04, "plantmatter" = 0.05, "toxin" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/vulgaris
 	seed = /obj/item/seeds/ambrosia
@@ -40,7 +40,7 @@
 	plantname = "Ambrosia Deus"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/deus
 	mutatelist = list(/obj/item/seeds/ambrosia/gaia)
-	reagents_add = list("weak_omnizine" = 0.15, "synaptizine" = 0.15, "space_drugs" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("weak_omnizine" = 0.15, "synaptizine" = 0.15, "space_drugs" = 0.1, "vitamin" = 0.04, "plantmatter" = 0.05)
 	rarity = 40
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/deus
@@ -80,7 +80,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/cruciatus
 	potency = 10
 	mutatelist = list()
-	reagents_add = list("thc" = 0.15, "kelotane" = 0.15, "bicaridine" = 0.1, "bath_salts" = 0.20, "nutriment" = 0.05)
+	reagents_add = list("thc" = 0.15, "kelotane" = 0.15, "bicaridine" = 0.1, "bath_salts" = 0.20, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/cruciatus
 	seed = /obj/item/seeds/ambrosia/cruciatus

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -14,7 +14,7 @@
 	icon_dead = "apple-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/apple/gold)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple
 	seed = /obj/item/seeds/apple
@@ -28,7 +28,7 @@
 /obj/item/seeds/apple/poisoned
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/apple/poisoned
 	mutatelist = list()
-	reagents_add = list("cyanide" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("cyanide" = 0.5, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 50 // Source of cyanide, and hard (almost impossible) to obtain normally.
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple/poisoned
@@ -45,7 +45,7 @@
 	maturation = 10
 	production = 10
 	mutatelist = list()
-	reagents_add = list("gold" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("gold" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 40 // Alchemy!
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple/gold

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -12,7 +12,7 @@
 	icon_dead = "banana-dead"
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/banana/mime, /obj/item/seeds/banana/bluespace)
-	reagents_add = list("banana" = 0.1, "potassium" = 0.1, "vitamin" = 0.04, "nutriment" = 0.02)
+	reagents_add = list("banana" = 0.1, "potassium" = 0.1, "vitamin" = 0.04, "plantmatter" = 0.02)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/banana
 	seed = /obj/item/seeds/banana
@@ -92,7 +92,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/banana/bluespace
 	mutatelist = list()
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list("singulo" = 0.2, "banana" = 0.1, "vitamin" = 0.04, "nutriment" = 0.02)
+	reagents_add = list("singulo" = 0.2, "banana" = 0.1, "vitamin" = 0.04, "plantmatter" = 0.02)
 	rarity = 30
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/banana/bluespace

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -15,7 +15,7 @@
 	icon_dead = "soybean-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/soya/koi)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/soybeans
 	seed = /obj/item/seeds/soya
@@ -36,7 +36,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/koibeans
 	potency = 10
 	mutatelist = list()
-	reagents_add = list("carpotoxin" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("carpotoxin" = 0.1, "vitamin" = 0.04, "plantmatter" = 0.05)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/koibeans

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -15,7 +15,7 @@
 	icon_dead = "berry-dead" // Same for the dead icon
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/berry/glow, /obj/item/seeds/berry/poison)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries
 	seed = /obj/item/seeds/berry
@@ -35,7 +35,7 @@
 	plantname = "Poison-Berry Bush"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/berries/poison
 	mutatelist = list(/obj/item/seeds/berry/death)
-	reagents_add = list("cyanide" = 0.15, "tirizene" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("cyanide" = 0.15, "tirizene" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 10 // Mildly poisonous berries are common in reality
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries/poison
@@ -56,7 +56,7 @@
 	lifespan = 30
 	potency = 50
 	mutatelist = list()
-	reagents_add = list("coniine" = 0.08, "tirizene" = 0.1, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("coniine" = 0.08, "tirizene" = 0.1, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 30
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries/death
@@ -78,7 +78,7 @@
 	endurance = 25
 	mutatelist = list()
 	genes = list(/datum/plant_gene/trait/glow/berry , /datum/plant_gene/trait/noreact, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list("uranium" = 0.25, "iodine" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("uranium" = 0.25, "iodine" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries/glow
@@ -108,7 +108,7 @@
 	icon_dead = "cherry-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/cherry/blue)
-	reagents_add = list("nutriment" = 0.07, "sugar" = 0.07)
+	reagents_add = list("plantmatter" = 0.07, "sugar" = 0.07)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherries
 	seed = /obj/item/seeds/cherry
@@ -128,7 +128,7 @@
 	plantname = "Blue Cherry Tree"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/bluecherries
 	mutatelist = list()
-	reagents_add = list("nutriment" = 0.07, "sugar" = 0.07)
+	reagents_add = list("plantmatter" = 0.07, "sugar" = 0.07)
 	rarity = 10
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluecherries
@@ -158,7 +158,7 @@
 	icon_dead = "grape-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/grape/green)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1, "sugar" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1, "sugar" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/grapes
 	seed = /obj/item/seeds/grape
@@ -177,7 +177,7 @@
 	species = "greengrape"
 	plantname = "Green-Grape Vine"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/grapes/green
-	reagents_add = list("kelotane" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1, "sugar" = 0.1)
+	reagents_add = list("kelotane" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1, "sugar" = 0.1)
 	// No rarity: technically it's a beneficial mutant, but it's not exactly "new"...
 	mutatelist = list()
 

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -70,6 +70,7 @@
 	plantname = "Meatwheat"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/meatwheat
 	mutatelist = list()
+	reagents_add = list("protein" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/meatwheat
 	name = "meatwheat"

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -11,7 +11,7 @@
 	potency = 15
 	icon_dead = "wheat-dead"
 	mutatelist = list(/obj/item/seeds/wheat/oat, /obj/item/seeds/wheat/meat)
-	reagents_add = list("nutriment" = 0.04)
+	reagents_add = list("plantmatter" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/wheat
 	seed = /obj/item/seeds/wheat

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -16,7 +16,7 @@
 	icon_dead = "chili-dead" // Same for the dead icon
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost)
-	reagents_add = list("capsaicin" = 0.25, "vitamin" = 0.04, "nutriment" = 0.04)
+	reagents_add = list("capsaicin" = 0.25, "vitamin" = 0.04, "plantmatter" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/chili
 	seed = /obj/item/seeds/chili
@@ -39,7 +39,7 @@
 	production = 4
 	rarity = 20
 	mutatelist = list()
-	reagents_add = list("frostoil" = 0.25, "vitamin" = 0.02, "nutriment" = 0.02)
+	reagents_add = list("frostoil" = 0.25, "vitamin" = 0.02, "plantmatter" = 0.02)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/icepepper
 	seed = /obj/item/seeds/chili/ice
@@ -64,7 +64,7 @@
 	yield = 3
 	rarity = 20
 	mutatelist = list()
-	reagents_add = list("condensedcapsaicin" = 0.3, "capsaicin" = 0.55, "nutriment" = 0.04)
+	reagents_add = list("condensedcapsaicin" = 0.3, "capsaicin" = 0.55, "plantmatter" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chili
 	seed = /obj/item/seeds/chili/ghost

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -21,7 +21,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/orange)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/citrus/lime
 	seed = /obj/item/seeds/lime
@@ -47,7 +47,7 @@
 	icon_dead = "lime-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/lime)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/citrus/orange
 	seed = /obj/item/seeds/orange
@@ -72,7 +72,7 @@
 	icon_dead = "lime-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/firelemon)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/citrus/lemon
 	seed = /obj/item/seeds/lemon
@@ -96,7 +96,7 @@
 	lifespan = 55
 	endurance = 45
 	yield = 4
-	reagents_add = list("nutriment" = 0.05)
+	reagents_add = list("plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/firelemon
 	seed = /obj/item/seeds/firelemon

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -16,7 +16,7 @@
 	icon_dead = "cocoapod-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/cocoapod/vanillapod)
-	reagents_add = list("cocoa" = 0.25, "nutriment" = 0.1)
+	reagents_add = list("cocoa" = 0.25, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cocoapod
 	seed = /obj/item/seeds/cocoapod
@@ -36,7 +36,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/vanillapod
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list()
-	reagents_add = list("vanilla" = 0.25, "nutriment" = 0.1)
+	reagents_add = list("vanilla" = 0.25, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/vanillapod
 	seed = /obj/item/seeds/cocoapod/vanillapod

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -13,7 +13,7 @@
 	icon_grow = "corn-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "corn-dead" // Same for the dead icon
 	mutatelist = list(/obj/item/seeds/corn/snapcorn)
-	reagents_add = list("cornoil" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("cornoil" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/corn
 	seed = /obj/item/seeds/corn

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -13,7 +13,7 @@
 	icon_dead = "eggplant-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/eggplant/eggy)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/eggplant
 	seed = /obj/item/seeds/eggplant

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -15,7 +15,7 @@
 	icon_grow = "poppy-grow"
 	icon_dead = "poppy-dead"
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/poppy/lily)
-	reagents_add = list("bicaridine" = 0.2, "nutriment" = 0.05)
+	reagents_add = list("bicaridine" = 0.2, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/poppy
 	seed = /obj/item/seeds/poppy
@@ -78,7 +78,7 @@
 	growthstages = 4
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy)
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
-	reagents_add = list("nutriment" = 0.04)
+	reagents_add = list("plantmatter" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell
 	seed = /obj/item/seeds/harebell
@@ -106,7 +106,7 @@
 	icon_grow = "sunflower-grow"
 	icon_dead = "sunflower-dead"
 	mutatelist = list(/obj/item/seeds/sunflower/moonflower, /obj/item/seeds/sunflower/novaflower)
-	reagents_add = list("cornoil" = 0.08, "nutriment" = 0.04)
+	reagents_add = list("cornoil" = 0.08, "plantmatter" = 0.04)
 
 /obj/item/weapon/grown/sunflower // FLOWER POWER!
 	seed = /obj/item/seeds/sunflower
@@ -134,7 +134,7 @@
 	plantname = "Moonflowers"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/moonflower
 	mutatelist = list()
-	reagents_add = list("moonshine" = 0.2, "vitamin" = 0.02, "nutriment" = 0.02)
+	reagents_add = list("moonshine" = 0.2, "vitamin" = 0.02, "plantmatter" = 0.02)
 	rarity = 15
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/moonflower
@@ -155,7 +155,7 @@
 	plantname = "Novaflowers"
 	product = /obj/item/weapon/grown/novaflower
 	mutatelist = list()
-	reagents_add = list("condensedcapsaicin" = 0.25, "capsaicin" = 0.3, "nutriment" = 0)
+	reagents_add = list("condensedcapsaicin" = 0.25, "capsaicin" = 0.3, "plantmatter" = 0)
 	rarity = 20
 
 /obj/item/weapon/grown/novaflower

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -16,7 +16,7 @@
 	icon_dead = "grass-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/grass/carpet)
-	reagents_add = list("nutriment" = 0.02, "hydrogen" = 0.05)
+	reagents_add = list("plantmatter" = 0.02, "hydrogen" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/grass
 	seed = /obj/item/seeds/grass

--- a/code/modules/hydroponics/grown/herbals.dm
+++ b/code/modules/hydroponics/grown/herbals.dm
@@ -9,7 +9,7 @@
 	maturation = 3
 	growthstages = 1
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
-	reagents_add = list("plantmatter" = 0.1)
+	reagents_add = list("styptic_powder" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/comfrey
 	seed = /obj/item/seeds/comfrey
@@ -35,7 +35,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/aloe
 	yield = 2
 	icon_dead = "ambrosia-dead"
-	reagents_add = list("plantmatter" = 0.1)
+	reagents_add = list("silver_sulfadiazine" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/aloe
 	seed = /obj/item/seeds/aloe

--- a/code/modules/hydroponics/grown/herbals.dm
+++ b/code/modules/hydroponics/grown/herbals.dm
@@ -9,7 +9,7 @@
 	maturation = 3
 	growthstages = 1
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
-	reagents_add = list("nutriment" = 0.1)
+	reagents_add = list("plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/comfrey
 	seed = /obj/item/seeds/comfrey
@@ -35,7 +35,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/aloe
 	yield = 2
 	icon_dead = "ambrosia-dead"
-	reagents_add = list("nutriment" = 0.1)
+	reagents_add = list("plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/aloe
 	seed = /obj/item/seeds/aloe

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -14,7 +14,7 @@
 	growthstages = 4
 	rarity = 30
 	var/list/mutations = list()
-	reagents_add = list("charcoal" = 0.04, "nutriment" = 0.02)
+	reagents_add = list("charcoal" = 0.04, "plantmatter" = 0.02)
 
 /obj/item/seeds/kudzu/Copy()
 	var/obj/item/seeds/kudzu/S = ..()

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -12,7 +12,7 @@
 	icon_dead = "watermelon-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/watermelon/holy)
-	reagents_add = list("water" = 0.2, "vitamin" = 0.04, "nutriment" = 0.2)
+	reagents_add = list("water" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/watermelon
 	seed = /obj/item/seeds/watermelon

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -32,7 +32,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/replicapod)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cabbage
 	seed = /obj/item/seeds/cabbage
@@ -106,7 +106,7 @@
 	plantname = "Cherry Bomb Tree"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/cherry_bomb
 	mutatelist = list()
-	reagents_add = list("nutriment" = 0.1, "sugar" = 0.1, "blackpowder" = 0.7)
+	reagents_add = list("plantmatter" = 0.1, "sugar" = 0.1, "blackpowder" = 0.7)
 	rarity = 60 //See above
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherry_bomb

--- a/code/modules/hydroponics/grown/nymph.dm
+++ b/code/modules/hydroponics/grown/nymph.dm
@@ -10,7 +10,7 @@
 	maturation = 10
 	production = 1
 	yield = 1
-	reagents_add = list("nutriment" = 0.1)
+	reagents_add = list("plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/nymph_pod
 	seed = /obj/item/seeds/nymph

--- a/code/modules/hydroponics/grown/peanut.dm
+++ b/code/modules/hydroponics/grown/peanut.dm
@@ -15,7 +15,7 @@
 	icon_grow = "potato-grow"
 	icon_dead = "potato-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list("nutriment" = 0.1)
+	reagents_add = list("plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/peanuts
 	seed = /obj/item/seeds/peanuts

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -16,7 +16,7 @@
 	icon_dead = "potato-dead"
 	genes = list(/datum/plant_gene/trait/battery)
 	mutatelist = list(/obj/item/seeds/potato/sweet)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato
 	seed = /obj/item/seeds/potato
@@ -56,7 +56,7 @@
 	plantname = "Sweet Potato Plants"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/potato/sweet
 	mutatelist = list()
-	reagents_add = list("vitamin" = 0.1, "sugar" = 0.1, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.1, "sugar" = 0.1, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato/sweet
 	seed = /obj/item/seeds/potato/sweet

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -42,7 +42,7 @@
 	plantname = "Blumpkin Vines"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin
 	mutatelist = list()
-	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.1, "plantmatter" = 0.2)
+	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.1, "plasma" = 0.1, "plantmatter" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -14,7 +14,7 @@
 	icon_dead = "pumpkin-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/pumpkin/blumpkin)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.2)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin
 	seed = /obj/item/seeds/pumpkin
@@ -42,7 +42,7 @@
 	plantname = "Blumpkin Vines"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin
 	mutatelist = list()
-	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.1, "nutriment" = 0.2)
+	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.1, "plantmatter" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -91,6 +91,8 @@
 			podman.ckey = ckey_holder
 		podman.gender = blood_gender
 		podman.faction |= factions
+		podman.faction |= "plants"
+		podman.faction |= "vines"   //Pod grown Diona are allied with plants and vines alike.
 
 	else //else, one packet of seeds. maybe two
 		var/seed_count = 1

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -12,7 +12,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	mutatelist = list(/obj/item/seeds/carrot/parsnip)
-	reagents_add = list("oculine" = 0.25, "vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("oculine" = 0.25, "vitamin" = 0.04, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/carrot
 	seed = /obj/item/seeds/carrot
@@ -43,7 +43,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/parsnip
 	icon_dead = "carrot-dead"
 	mutatelist = list()
-	reagents_add = list("vitamin" = 0.05, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.05, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/parsnip
 	seed = /obj/item/seeds/carrot/parsnip
@@ -67,7 +67,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_dead = "whitebeet-dead"
 	mutatelist = list(/obj/item/seeds/redbeet)
-	reagents_add = list("vitamin" = 0.04, "sugar" = 0.2, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.04, "sugar" = 0.2, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/whitebeet
 	seed = /obj/item/seeds/whitebeet
@@ -91,7 +91,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_dead = "whitebeet-dead"
 	genes = list(/datum/plant_gene/trait/maxchem)
-	reagents_add = list("vitamin" = 0.05, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.05, "plantmatter" = 0.05)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/redbeet
 	seed = /obj/item/seeds/redbeet

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -13,7 +13,7 @@
 	growthstages = 3
 	icon_dead = "tobacco-dead"
 	mutatelist = list(/obj/item/seeds/tobacco/space)
-	reagents_add = list("nicotine" = 0.03, "nutriment" = 0.03)
+	reagents_add = list("nicotine" = 0.03, "plantmatter" = 0.03)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco
 	seed = /obj/item/seeds/tobacco
@@ -31,7 +31,7 @@
 	plantname = "Space Tobacco Plant"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco/space
 	mutatelist = list()
-	reagents_add = list("salbutamol" = 0.05, "nicotine" = 0.08, "nutriment" = 0.03)
+	reagents_add = list("salbutamol" = 0.05, "nicotine" = 0.08, "plantmatter" = 0.03)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco/space

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -11,7 +11,7 @@
 	icon_grow = "tomato-grow"
 	icon_dead = "tomato-dead"
 	genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/tomato/blue, /obj/item/seeds/tomato/blood, /obj/item/seeds/tomato/killer)
+	mutatelist = list(/obj/item/seeds/tomato/blue, /obj/item/seeds/tomato/blood)
 	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato
@@ -31,7 +31,7 @@
 	species = "bloodtomato"
 	plantname = "Blood-Tomato Plants"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blood
-	mutatelist = list()
+	mutatelist = list(/obj/item/seeds/tomato/killer)
 	reagents_add = list("blood" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 20
 
@@ -106,6 +106,7 @@
 	icon_harvest = "killertomato-harvest"
 	icon_dead = "killertomato-dead"
 	mutatelist = list()
+	reagents_add = list("vitamin" = 0.04, "protein" = 0.1)
 	rarity = 30
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/killer

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -12,7 +12,7 @@
 	icon_dead = "tomato-dead"
 	genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/tomato/blue, /obj/item/seeds/tomato/blood, /obj/item/seeds/tomato/killer)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "plantmatter" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato
 	seed = /obj/item/seeds/tomato
@@ -32,7 +32,7 @@
 	plantname = "Blood-Tomato Plants"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blood
 	mutatelist = list()
-	reagents_add = list("blood" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("blood" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blood
@@ -57,7 +57,7 @@
 	icon_grow = "bluetomato-grow"
 	mutatelist = list(/obj/item/seeds/tomato/blue/bluespace)
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list("lube" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("lube" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blue
@@ -80,7 +80,7 @@
 	yield = 2
 	mutatelist = list()
 	genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/repeated_harvest)
-	reagents_add = list("lube" = 0.2, "singulo" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("lube" = 0.2, "singulo" = 0.2, "vitamin" = 0.04, "plantmatter" = 0.1)
 	rarity = 50
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blue/bluespace

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -657,6 +657,10 @@
 		adjustHealth(round(S.get_reagent_amount("nutriment") * 0.5))
 		adjustNutri(round(S.get_reagent_amount("nutriment") * 1))
 
+	if(S.has_reagent("plantmatter", 1))
+		adjustHealth(round(S.get_reagent_amount("plantmatter") * 0.5))
+		adjustNutri(round(S.get_reagent_amount("plantmatter") * 1))
+
 	// Compost for EVERYTHING
 	if(S.has_reagent("virusfood", 1))
 		adjustNutri(round(S.get_reagent_amount("virusfood") * 0.5))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -521,6 +521,12 @@
 		mutmod = 0
 		adjustNutri(round(S.get_reagent_amount("robustharvestnutriment") *1 ))
 
+
+	//Fish Water is both an excellent fertilizer and waters
+	if(S.has_reagent("fishwater", 1))
+		adjustNutri(round(S.get_reagent_amount("fishwater") * 0.75))
+		adjustWater(round(S.get_reagent_amount("fishwater") * 1))
+
 	// Antitoxin binds shit pretty well. So the tox goes significantly down
 	if(S.has_reagent("charcoal", 1))
 		adjustToxic(-round(S.get_reagent_amount("charcoal") * 2))


### PR DESCRIPTION
Said I'd do this once the botany PR was merged and things appeared stable.

Adjusts most of the botany produce to have plantmatter as opposed to "Nutriment". Composting will work with plant matter as well as nutriment, as will the biogenerator.

Gives Blumpkins plasma to retain an existing botany feedback loop (glowshrooms+blumpkins = unstable mutagen).

Also re-adds fish water; oversight for that being axed.

Fixes pod grown diona not being allied with plants and vines.

:cl: Fox McCloud
tweak: adjusts most botany plant reagents to have "plantmatter" as opposed to nutriment
tweak: Blumpkins now have plasma in them
fix: Fixes plant grown diona not being allied with plants and vines
/:cl: