### PR TITLE
Changeling Absorb Memory Fix

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -104,11 +104,13 @@
 /datum/mind/proc/wipe_memory()
 	memory = null
 
-/datum/mind/proc/show_memory(mob/recipient)
-	var/output = "<B>[current.real_name]'s Memory</B><HR>"
+/datum/mind/proc/show_memory(mob/recipient, window=1)
+	if(!recipient)
+		recipient = current
+	var/output = "<B>[current.real_name]'s Memories:</B><HR>"
 	output += memory
 
-	if(objectives.len>0)
+	if(objectives.len)
 		output += "<HR><B>Objectives:</B>"
 
 		var/obj_count = 1
@@ -116,7 +118,7 @@
 			output += "<B>Objective #[obj_count]</B>: [objective.explanation_text]"
 			obj_count++
 
-	if(job_objectives.len>0)
+	if(job_objectives.len)
 		output += "<HR><B>Job Objectives:</B><UL>"
 
 		var/obj_count = 1
@@ -124,8 +126,10 @@
 			output += "<LI><B>Task #[obj_count]</B>: [objective.get_description()]</LI>"
 			obj_count++
 		output += "</UL>"
-
-	recipient << browse(output,"window=memory")
+	if(window)
+		recipient << browse(output,"window=memory")
+	else
+		to_chat(recipient, "<i>[output]</i>")
 
 /datum/mind/proc/edit_memory()
 	if(!ticker || !ticker.mode)
@@ -1324,7 +1328,7 @@
 			var/explanation = "Summon [ticker.mode.cultdat.entity_name] via the use of the appropriate rune. It will only work if nine cultists stand on and around it."
 			to_chat(current, "<B>Objective #1</B>: [explanation]")
 			current.memory += "<B>Objective #1</B>: [explanation]<BR>"
-			
+
 
 	var/mob/living/carbon/human/H = current
 	if(istype(H))

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,3 +1,4 @@
+#define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega")
 
 /datum/game_mode

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,4 +1,3 @@
-#define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega")
 
 /datum/game_mode

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -1,3 +1,5 @@
+#define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
+
 /obj/effect/proc_holder/changeling/absorbDNA
 	name = "Absorb DNA"
 	desc = "Absorb the DNA of our victim."
@@ -25,8 +27,6 @@
 
 	var/mob/living/carbon/target = G.affecting
 	return changeling.can_absorb_dna(user,target)
-
-
 
 /obj/effect/proc_holder/changeling/absorbDNA/sting_action(var/mob/user)
 	var/datum/changeling/changeling = user.mind.changeling
@@ -72,10 +72,7 @@
 		if(target.say_log.len > LING_ABSORB_RECENT_SPEECH)
 			recent_speech = target.say_log.Copy(target.say_log.len-LING_ABSORB_RECENT_SPEECH+1,0) //0 so len-LING_ARS+1 to end of list
 		else
-			for(var/spoken_memory in target.say_log)
-				if(recent_speech.len >= LING_ABSORB_RECENT_SPEECH)
-					break
-				recent_speech += spoken_memory
+			recent_speech = target.say_log.Copy()
 
 		if(recent_speech.len)
 			user.mind.store_memory("<B>Some of [target]'s speech patterns, we should study these to better impersonate them!</B>")
@@ -93,7 +90,6 @@
 			target.mind.changeling.absorbed_dna.len = 1
 			target.mind.changeling.absorbedcount = 0
 
-
 	changeling.chem_charges=min(changeling.chem_charges+10, changeling.chem_storage)
 
 	changeling.isabsorbing = 0
@@ -102,8 +98,6 @@
 	target.death(0)
 	target.Drain()
 	return 1
-
-
 
 //Absorbs the target DNA.
 /datum/changeling/proc/absorb_dna(mob/living/carbon/T, var/mob/user)
@@ -125,3 +119,5 @@
 			return
 	absorbed_dna |= new_dna
 	trim_dna()
+
+#undef LING_ABSORB_RECENT_SPEECH

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -63,7 +63,28 @@
 
 	if(target.mind)//if the victim has got a mind
 
-		target.mind.show_memory(src, 0) //I can read your mind, kekeke. Output all their notes.
+		target.mind.show_memory(user, 0) //I can read your mind, kekeke. Output all their notes.
+
+		//Some of target's recent speech, so the changeling can attempt to imitate them better.
+		//Recent as opposed to all because rounds tend to have a LOT of text.
+		var/list/recent_speech = list()
+
+		if(target.say_log.len > LING_ABSORB_RECENT_SPEECH)
+			recent_speech = target.say_log.Copy(target.say_log.len-LING_ABSORB_RECENT_SPEECH+1,0) //0 so len-LING_ARS+1 to end of list
+		else
+			for(var/spoken_memory in target.say_log)
+				if(recent_speech.len >= LING_ABSORB_RECENT_SPEECH)
+					break
+				recent_speech += spoken_memory
+
+		if(recent_speech.len)
+			user.mind.store_memory("<B>Some of [target]'s speech patterns, we should study these to better impersonate them!</B>")
+			to_chat(user, "<span class='boldnotice'>Some of [target]'s speech patterns, we should study these to better impersonate them!</span>")
+			for(var/spoken_memory in recent_speech)
+				user.mind.store_memory("\"[spoken_memory]\"")
+				to_chat(user, "<span class='notice'>\"[spoken_memory]\"</span>")
+			user.mind.store_memory("<B>We have no more knowledge of [target]'s speech patterns.</B>")
+			to_chat(user, "<span class='boldnotice'>We have no more knowledge of [target]'s speech patterns.</span>")
 
 		if(target.mind.changeling)//If the target was a changeling, suck out their extra juice and objective points!
 			changeling.chem_charges += min(target.mind.changeling.chem_charges, changeling.chem_storage)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -52,5 +52,7 @@
 	var/list/surgeries = list()	//a list of surgery datums. generally empty, they're added when the player wants them.
 
 	var/gene_stability = DEFAULT_GENE_STABILITY
-	
+
 	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
+
+	var/list/say_log = list() //a log of what we've said, plain text, no spans or junk, essentially just each individual "message"

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -149,7 +149,7 @@ proc/get_radio_key_from_channel(var/channel)
 	if(speaking && (speaking.flags & HIVEMIND))
 		speaking.broadcast(src,trim(message))
 		return 1
-		
+
 	if(message_mode == "cords")
 		if(iscarbon(src))
 			var/mob/living/carbon/C = src
@@ -281,6 +281,9 @@ proc/get_radio_key_from_channel(var/channel)
 		spawn(0)
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message, verb, speaking)
+
+	//Log of what we've said, plain message, no spans or junk
+	say_log += message
 
 	log_say("[name]/[key] : [message]")
 	return 1


### PR DESCRIPTION
Fixes changelings not absorbing the memory of absorb victims, and adds a feature where changelings will see the past 8 messages of the absorbed in order to impersonate them successfully (https://github.com/tgstation/tgstation/pull/10599/commits/8a2ad876948190765d5448ac287252ab6c02a48e)

:cl:
fix: Changelings can recall the memories of an absorb victim
add: Changelings will recall some speech of their absorb victims
/:cl: