### PR TITLE
Goonchat Admin Filters

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -161,13 +161,13 @@
 
 		for(var/mob/O in viewers(messagesource, null))
 			if(attack_verb.len)
-				O.show_message("<span class='danger'>[M] has been [pick(attack_verb)] with [src][showname] </span>", 1)
+				O.show_message("<span class='combat danger'>[M] has been [pick(attack_verb)] with [src][showname] </span>", 1)
 			else
-				O.show_message("<span class='danger'>[M] has been attacked with [src][showname] </span>", 1)
+				O.show_message("<span class='combat danger'>[M] has been attacked with [src][showname] </span>", 1)
 
 		if(!showname && user)
 			if(user.client)
-				to_chat(user, "<span class='danger'>You attack [M] with [src]. </span>")
+				to_chat(user, "<span class='combat danger'>You attack [M] with [src]. </span>")
 
 
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -166,7 +166,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/admin_serialize,
 	/client/proc/admin_deserialize,
 	/client/proc/jump_to_ruin,
-	/client/proc/toggle_medal_disable	
+	/client/proc/toggle_medal_disable
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,
@@ -212,6 +212,10 @@ var/list/admin_verbs_snpc = list(
 	/client/proc/customiseSNPC,
 	/client/proc/hide_snpc_verbs
 )
+
+/client/proc/on_holder_add()
+	if(chatOutput && chatOutput.loaded)
+		chatOutput.loadAdmin()
 
 /client/proc/add_admin_verbs()
 	if(holder)

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -32,6 +32,7 @@ var/list/admin_datums = list()
 	if(istype(C))
 		owner = C
 		owner.holder = src
+		owner.on_holder_add()
 		owner.add_admin_verbs()	//TODO
 		owner.verbs -= /client/proc/readmin
 		admins |= C

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -331,6 +331,7 @@
 		world.update_status()
 
 	if(holder)
+		on_holder_add()
 		add_admin_verbs()
 		admin_memo_output("Show", 0, 1)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -57,7 +57,7 @@ emp_act
 	organ.add_autopsy_data(P.name, P.damage) // Add the bullet's name to the autopsy data
 
 	return (..(P , def_zone))
-	
+
 /mob/living/carbon/human/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
 	var/obj/item/organ/external/affecting = get_organ(check_zone(def_zone))
 	if(affecting && !affecting.cannot_amputate && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))
@@ -67,7 +67,7 @@ emp_act
 				damtype = DROPLIMB_BLUNT
 			if(BURN)
 				damtype = DROPLIMB_BURN
-			
+
 		affecting.droplimb(FALSE, damtype)
 
 /mob/living/carbon/human/getarmor(var/def_zone, var/type)
@@ -226,9 +226,9 @@ emp_act
 
 	if(! I.discrete)
 		if(I.attack_verb.len)
-			visible_message("<span class='danger'>[src] has been [pick(I.attack_verb)] in the [hit_area] with [I.name] by [user]!</span>")
+			visible_message("<span class='combat danger'>[src] has been [pick(I.attack_verb)] in the [hit_area] with [I.name] by [user]!</span>")
 		else
-			visible_message("<span class='danger'>[src] has been attacked in the [hit_area] with [I.name] by [user]!</span>")
+			visible_message("<span class='combat danger'>[src] has been attacked in the [hit_area] with [I.name] by [user]!</span>")
 
 	var/armor = run_armor_check(affecting, "melee", "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].", armour_penetration = I.armour_penetration)
 	var/weapon_sharp = is_sharp(I)
@@ -264,8 +264,8 @@ emp_act
 				if("head")//Harder to score a stun but if you do it lasts a bit longer
 					if(stat == CONSCIOUS && armor < 50)
 						if(prob(I.force))
-							visible_message("<span class='danger'>[src] has been knocked down!</span>", \
-											"<span class='userdanger'>[src] has been knocked down!</span>")
+							visible_message("<span class='combat danger'>[src] has been knocked down!</span>", \
+											"<span class='combat userdanger'>[src] has been knocked down!</span>")
 							apply_effect(5, WEAKEN, armor)
 							AdjustConfused(15)
 						if(prob(I.force + ((100 - health)/2)) && src != user && I.damtype == BRUTE)
@@ -284,8 +284,8 @@ emp_act
 
 				if("upper body")//Easier to score a stun but lasts less time
 					if(stat == CONSCIOUS && I.force && prob(I.force + 10))
-						visible_message("<span class='danger'>[src] has been knocked down!</span>", \
-										"<span class='userdanger'>[src] has been knocked down!</span>")
+						visible_message("<span class='combat danger'>[src] has been knocked down!</span>", \
+										"<span class='combat userdanger'>[src] has been knocked down!</span>")
 						apply_effect(5, WEAKEN, armor)
 
 					if(bloody)

--- a/goon/browserassets/html/adminOutput.html
+++ b/goon/browserassets/html/adminOutput.html
@@ -1,0 +1,104 @@
+<script type="text/javascript">
+
+opts.showMessagesFilters = { /* Contains the current filters. "show: false" filters it out. "match" is all the css classes to filter on. */
+	'All': {show: true},
+	'Admin': {show: true, match: ['admin']},
+	'Combat': {show: true, match: ['combat']},
+	'Radios': {show: true, match: ['radio']},
+	'Speech': {show: true, match: ['say']},
+	'OOC': {show: true, match: ['ooc']},
+};
+opts.filterHideAll = false;
+
+$subOptions.append('<a href="#" class="filterMessagesOpt" id="filterMessagesOpt"><span>Filter Messages</span> <i class="icon-filter"></i></a>');
+
+function toggleFilter(type) {
+	if (type == 'All') {
+		if (opts.showMessagesFilters['All'].show === true) {
+			$.each(opts.showMessagesFilters, function (key) {
+				opts.showMessagesFilters[key].show = false;
+				if (key != 'All') {
+					$('#filter_'+key).prop('checked', false);
+				}
+			});
+			$('#messages .entry *:nth-child(1):not(.internal)').parent('.entry').addClass('hidden').attr('data-filter', 'All');
+			opts.filterHideAll = true;
+			internalOutput('<span class="internal boldnshit">Hiding <strong>ALL</strong> messages. Uhhh are you sure about this?</span>');
+		} else {
+			$.each(opts.showMessagesFilters, function (key) {
+				opts.showMessagesFilters[key].show = true;
+				if (key != 'All') {
+					$('#filter_'+key).prop('checked', true);
+				}
+			});
+			$('#messages .entry.hidden[data-filter]').removeClass('hidden');
+			opts.filterHideAll = false;
+			internalOutput('<span class="internal boldnshit">Showing <strong>ALL</strong> messages</span>');
+		}
+	} else {
+		var onoff = !opts.showMessagesFilters[type].show;
+		opts.showMessagesFilters[type].show = onoff;
+		var allTrue = true;
+		var allFalse = true;
+		$.each(opts.showMessagesFilters, function (key, val) {
+			if (key != 'All') {
+				if (allTrue) {
+					allTrue = (val.show ? true : false);
+				} 
+				if (allFalse) {
+					allFalse = (val.show ? false : true);
+				}
+			}
+		});
+		opts.showMessagesFilters['All'].show = (allTrue ? true : false);
+		$('#filter_All').prop('checked', (allTrue ? true : false));
+
+		if (allTrue) {
+			opts.filterHideAll = false;
+			$('#messages .entry.hidden[data-filter]').removeClass('hidden');
+		} else if (allFalse) {
+			opts.filterHideAll = true;
+			$('#messages .entry *:nth-child(1):not(.internal)').each(function (i, el) {
+				$(el).parent('.entry').addClass('hidden').attr('data-filter', 'All');
+			});
+		} else if (typeof opts.showMessagesFilters[type].match != 'undefined') { /* If the filter has classes to match against */
+			/* Hide/Show all prior messages */
+			for (var i = 0; i < opts.showMessagesFilters[type].match.length; i++) {
+				var thisClass = opts.showMessagesFilters[type].match[i];
+				if (onoff) { /* Showing */
+					$('#messages .entry.hidden[data-filter="'+type+'"]').removeClass('hidden');
+				} else { /* Hiding */
+					$('#messages .'+thisClass).each(function (i, el) {
+						$(el).closest('.entry').addClass('hidden').attr('data-filter', type);
+					});
+				}
+			}
+		}
+
+		var msg = (onoff ? 'Showing' : 'Filtering <strong>OUT</strong>') + " messages of type <strong>"+type+"</strong>";
+		internalOutput('<span class="internal boldnshit">'+msg+'</span>');
+	}
+	console.log('filters is: ', opts.showMessagesFilters);
+}
+
+$subOptions.on('click', '#filterMessagesOpt', function (e) {
+	if ($('#filterMessages').is(':visible')) 
+		return;
+
+	var content = '<div class="head">Filter Messsages</div>' +
+		'<div id="filterMessages" class="filterMessages">';
+	$.each(opts.showMessagesFilters, function (key, val) {
+		content += '<div><input type="checkbox" id="filter_'+key+'" name="'+key+'" value="'+key+'" '+(val.show ? 'checked="checked" ' : '')+'/> <label for="filter_'+key+'">'+key+'</label></div>';
+	});
+	content += '</div>';
+	createPopup(content, 150);
+});
+
+$('body').on('click', '#filterMessages input', function () {
+	var type = $(this).val();
+	console.log('hit change event with type: '+type);
+	toggleFilter(type);
+	$('body,html').scrollTop($messages.outerHeight());
+});
+
+</script>

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -396,7 +396,7 @@ function ehjaxCallback(data) {
 			dataJ = $.parseJSON(data);
 		} catch (e) {
 			//But...incorrect :sadtrombone:
-			window.onerror('JSON: '+e+'. '+data, 'browserOutput.html', 327);
+			window.onerror('JSON: '+e+'. '+data+'; data.length = '+data.length, 'browserOutput.html', 327);
 			return;
 		}
 		data = dataJ;

--- a/goon/code/datums/browserOutput.dm
+++ b/goon/code/datums/browserOutput.dm
@@ -99,6 +99,8 @@ var/list/chatResources = list(
 
 	loaded = TRUE
 	winset(owner, "browseroutput", "is-disabled=false")
+	if(owner.holder)
+		loadAdmin()
 	for(var/message in messageQueue)
 		to_chat(owner, message)
 
@@ -119,6 +121,9 @@ var/list/chatResources = list(
 		data = json_encode(data)
 	C << output("[data]", "[window]:ehjaxCallback")
 
+/datum/chatOutput/proc/loadAdmin()
+	var/data = json_encode(list("loadAdminCode" = replacetext(replacetext(file2text("goon/browserassets/html/adminOutput.html"), "\n", ""), "\t", "")))
+	ehjax_send(data = url_encode(data))
 
 /datum/chatOutput/proc/sendClientData()
 	var/list/deets = list("clientData" = list())


### PR DESCRIPTION
This adds Message filters to Goonchat (only for mentors +
administrators).

There is a new option in the settings dropdown of Goonchat to access
these. They are temporary, non-destructive filters which will hide all
messages matching them that are already in your chat, as well as any new
messages matching them.

There are 5 filters currently:
 - Admin; Filters out most admin logs.
 - Combat; Filters out a limited subset of combat messages-
 Specifically, any message with the 'combat' span class. Currently, this
 has only been added to the central /attack and /attacked_by procs, so a
 large considerable amount of hostile actions taken against a
 player are still not going to be filtered out. We can work on adding
 the identifier to more stuff later.
 - Radios: Filters out all radio messages.
 - Speech: Filters out all mob speech.
 - OOC: Filters out OOC chat.

There is also an "All" option, which just turns off all messages that
are not internal to Goonchat.

## Obligatory Screenshot Section

![https://i.imgur.com/D3SdUIz.png](https://i.imgur.com/D3SdUIz.png)
![https://i.imgur.com/HeVeABv.png](https://i.imgur.com/HeVeABv.png)
![https://i.imgur.com/e6FCK4t.png](https://i.imgur.com/e6FCK4t.png)
![https://i.imgur.com/ftHoVMI.png](https://i.imgur.com/ftHoVMI.png)
![https://i.imgur.com/4ojzI7M.png](https://i.imgur.com/4ojzI7M.png)
![https://i.imgur.com/qYlJmOG.png](https://i.imgur.com/qYlJmOG.png)
![https://i.imgur.com/VGshS2Y.png](https://i.imgur.com/VGshS2Y.png)