### PR TITLE
Drying Rack Toggling Uses NanoUI and Other Fixes

### DIFF
--- a/nano/templates/smartfridge.tmpl
+++ b/nano/templates/smartfridge.tmpl
@@ -10,6 +10,16 @@
     </span>
   {{/if}}
 </div>
+<div class="item">
+  {{if data.can_dry}}
+	<div class="itemLabel" style="width: 70%">
+		Drying:
+	</div>
+	<div class="itemContent" style="width: 30%;">
+		{{:helper.link('On', 'power-off', {'dryingOn' : 1}, data.drying ? 'selected' : null)}}{{:helper.link('Off', 'close', {'dryingOff' : 1}, data.drying ? null : 'selected')}}
+	</div>
+  {{/if}}
+</div>
 <div class='item'>
   {{if data.contents}}
     {{for data.contents}}


### PR DESCRIPTION
The Drying rack now uses NanoUI to toggle the drying on/off instead of relying on an icky verb.


![c0113c9c51a13e6db37da3b87f061333 1](https://cloud.githubusercontent.com/assets/5785200/22782486/528de974-ee95-11e6-9251-99fbc6cc75aa.png)

Related Fixes
- Fixes drying rack icon not updating when items are dispensed/thrown from it
- Fixes produce still being listed as being in the drying rack, even when it was
- Fixes drying rack saying it's refusing objects when it should properly accept them

:cl: Fox McCloud
tweak: Drying rack drying now properly uses NanoUI instead of a right-click verb
fix: Fixes produce appearing stuck in a drying rack when it was empty
fix: Fixes a few failed icon updates with the drying rack
/:cl: