### PR TITLE
Fixes Slaughter Demon Bloodcrawl and Demonic Whisper

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -193,10 +193,9 @@
 	return ..()
 
 /datum/action/innate/demon/whisper/proc/choose_targets(mob/user = usr)//yes i am copying from telepathy..hush...
-	var/list/targets = new /list()
-	var/list/validtargets = new /list()
-	for(var/mob/M in view(user.client.view, user))
-		if(M && M.mind)
+	var/list/validtargets = list()
+	for(var/mob/living/M in view(user.client.view, get_turf(user)))
+		if(M && M.mind && M.stat != DEAD)
 			if(M == user)
 				continue
 
@@ -206,15 +205,12 @@
 		to_chat(usr, "<span class='warning'>There are no valid targets!</span>")
 		return
 
-	targets += input("Choose the target to talk to.", "Targeting") as null|mob in validtargets
-
-	if(!targets.len || !targets[1])
-		return
+	var/mob/living/target = input("Choose the target to talk to.", "Targeting") as null|mob in validtargets
+	return target
 
 /datum/action/innate/demon/whisper/Activate()
-	var/list/choice = choose_targets()
-
-	if(!choice.len)
+	var/mob/living/choice = choose_targets()
+	if(!choice)
 		return
 
 	var/msg = stripped_input(usr, "What do you wish to tell [choice]?", null, "")

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -117,9 +117,9 @@ var/global/list/image/splatter_cache=list()
 		user.hand_blood_color = basecolor
 		user.update_inv_gloves(1)
 		user.verbs += /mob/living/carbon/human/proc/bloody_doodle
-		
+
 /obj/effect/decal/cleanable/blood/can_bloodcrawl_in()
-	return amount
+	return TRUE
 
 /obj/effect/decal/cleanable/blood/splatter
 	random_icon_states = list("mgibbl1", "mgibbl2", "mgibbl3", "mgibbl4", "mgibbl5")


### PR DESCRIPTION
The `amount` var is very different from the `bloodiness` var on TG. The bloodiness var is used for stat tracking of how much a blood trail should be faded; `amount` is a bit different than this.

As a result, you can't blood crawl in much of anything at the moment. Oops

Also fixes slaughter demons not being able to whisper, at all.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6379

:cl: Fox McCloud
fix: Fixes not being able to bloodcrawl in most sources of blood
fix: Fixes slaughter demon whisper not working at all
/:cl: