### PR TITLE
Custom War Declaration

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,5 +1,5 @@
 #define CHALLENGE_TIME_LIMIT 6000
-#define MIN_CHALLENGE_PLAYERS 50
+#define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 //25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 /obj/item/device/nuclear_challenge
@@ -9,33 +9,42 @@
 	desc = "Use to send a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \
 	Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 	Must be used within five minutes, or your benefactors will lose interest."
-	var/declaring_war = 0
-
-
+	var/declaring_war = FALSE
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
-	if(declaring_war)
-		return
-	if(player_list.len < MIN_CHALLENGE_PLAYERS)
-		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
-		return
-	if(!is_admin_level(user.z))
-		to_chat(user, "You have to be at your base to use this.")
+	if(!check_allowed(user))
 		return
 
-	if(world.time > CHALLENGE_TIME_LIMIT)
-		to_chat(user, "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand.")
+	declaring_war = TRUE
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [-round((world.time-round_start_time - CHALLENGE_TIME_LIMIT)/10)] seconds to decide.", "Declare war?", "Yes", "No")
+	declaring_war = FALSE
+
+	if(!check_allowed(user))
 		return
 
-	declaring_war = 1
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew?", "Declare war?", "Yes", "No")
 	if(are_you_sure == "No")
 		to_chat(user, "On second thought, the element of surprise isn't so bad after all.")
-		declaring_war = 0
 		return
 
 	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
+
+	declaring_war = TRUE
+	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
+	declaring_war = FALSE
+
+	if(!check_allowed(user))
+		return
+
+	if(custom_threat == "Yes")
+		declaring_war = TRUE
+		war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
+		declaring_war = FALSE
+
+	if(!check_allowed(user) || !war_declaration)
+		return
+
 	event_announcement.Announce(war_declaration, "Declaration of War", 'sound/effects/siren.ogg')
+
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
 	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
@@ -47,7 +56,25 @@
 	config.shuttle_refuel_delay = CHALLENGE_SHUTTLE_DELAY
 	qdel(src)
 
+/obj/item/device/nuclear_challenge/proc/check_allowed(mob/living/user)
+	if(declaring_war)
+		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
+		return FALSE
+	if(player_list.len < CHALLENGE_MIN_PLAYERS)
+		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
+		return FALSE
+	if(!is_admin_level(user.z))
+		to_chat(user, "You have to be at your base to use this.")
+		return FALSE
+	if(world.time > CHALLENGE_TIME_LIMIT)
+		to_chat(user, "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand.")
+		return FALSE
+	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
+		if(S.moved)
+			to_chat(user, "The shuttle has already been moved! You have forfeit the right to declare war.")
+			return FALSE
+	return TRUE
 
 #undef CHALLENGE_TIME_LIMIT
-#undef MIN_CHALLENGE_PLAYERS
+#undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -8,6 +8,7 @@
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_z3;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s"
 	var/challenge = FALSE
+	var/moved = FALSE
 
 /obj/machinery/computer/shuttle/syndicate/recall
 	name = "syndicate shuttle recall terminal"
@@ -18,6 +19,7 @@
 		if(challenge && world.time < SYNDICATE_CHALLENGE_TIMER)
 			to_chat(usr, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least [round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] more minutes to allow them to prepare.</span>")
 			return 0
+		moved = TRUE
 	..()
 
 /obj/machinery/computer/shuttle/syndicate/drop_pod


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/21941

Nuke Ops now get the choice to customize the declaration of war broadcast to the station.
Also made the safety checks for war declaration to be like TG.
Tested and it works

:cl:
add: Nuclear Operatives can customize the Declaration of War.
/:cl: