### PR TITLE
Allows the Rapid Construction Device to set the name of a constructed Airlock

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -28,6 +28,7 @@ RCD
 	var/canRwall = 0
 	var/menu = 1
 	var/door_type = /obj/machinery/door/airlock
+	var/door_name = "Airlock"
 	req_access = list(access_engine)
 	var/list/door_accesses = list()
 	var/list/door_accesses_list = list()
@@ -85,7 +86,7 @@ RCD
 /obj/item/weapon/rcd/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = inventory_state)
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "rcd.tmpl", "[name]", 400, 400, state = state)
+		ui = new(user, src, ui_key, "rcd.tmpl", "[name]", 450, 400, state = state)
 		ui.open()
 		ui.set_auto_update(1)
 
@@ -93,6 +94,7 @@ RCD
 	var/data[0]
 	data["mode"] = mode
 	data["door_type"] = door_type
+	data["door_name"] = door_name
 	data["menu"] = menu
 	data["matter"] = matter
 	data["max_matter"] = max_matter
@@ -164,6 +166,11 @@ RCD
 			door_accesses_list[++door_accesses_list.len] = list("name" = get_access_desc(access), "id" = access, "enabled" = (access in door_accesses))
 		. = 1
 
+	if(href_list["choice"] && !locked)
+		var/temp_t = sanitize(copytext(input("Enter a custom Airlock Name.","Airlock Name"),1,MAX_MESSAGE_LEN))
+		if(temp_t)
+			door_name = temp_t
+
 /obj/item/weapon/rcd/proc/activate()
 	playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
 
@@ -207,6 +214,7 @@ RCD
 						if(!useResource(10, user)) return 0
 						activate()
 						var/obj/machinery/door/airlock/T = new door_type(A)
+						T.name = door_name
 						T.autoclose = 1
 						if(one_access)
 							T.req_one_access = door_accesses.Copy()

--- a/nano/templates/rcd.tmpl
+++ b/nano/templates/rcd.tmpl
@@ -13,6 +13,15 @@
 {{else data.menu == 2}}
 	<div class='item'>{{:helper.link('Back', 'reply', {'menu': 1})}}</div>
 	<div class='item'>
+ 		<div class='statusDisplay'>
+ 			<div class='item'>
+ 				<div style="float:right;">
+ 					{{if !data.locked}}{{:helper.link("Rename", '', {'choice' : 'airlock_name'})}}{{else}}LOCKED{{/if}}
+ 				</div>
+ 				<div class='itemLabel'>
+ 					Airlock Name:
+ 				</div>
+ 				<div class='itemContent'>
  					{{:data.door_name}}
  				</div>
  			</div>

--- a/nano/templates/rcd.tmpl
+++ b/nano/templates/rcd.tmpl
@@ -12,6 +12,12 @@
 	</div>
 {{else data.menu == 2}}
 	<div class='item'>{{:helper.link('Back', 'reply', {'menu': 1})}}</div>
+	<div class='item'>
+ 					{{:data.door_name}}
+ 				</div>
+ 			</div>
+ 		</div>
+ 	</div>
 	<div style='width:49%; float:left'><div class='statusDisplay'>
 		<h3>Type</h3>
 		{{for data.allowed_door_types}}


### PR DESCRIPTION
Adds a new section to the Airlock menu of the Rapid Construction Device, so that you can now set the name of the newly constructed Airlock. Setting a new name is only available if unlocked by an ID.

Also slightly adjusted the width so that the modal dialog's title doesn't wrap around onto a new line when the scrollbar is introduced.

![paradise-rcd-renaming](https://cloud.githubusercontent.com/assets/4669916/22839845/fd2a074a-efc2-11e6-9c31-fc9bc06e7295.png)

:cl:
rscadd: Adds a section to the Airlock menu of the RCD to allow specifying the name of the new Airlock
/:cl: