### PR TITLE
Cult construct description fix

### DIFF
--- a/code/game/gamemodes/cult/cult_datums.dm
+++ b/code/game/gamemodes/cult/cult_datums.dm
@@ -16,11 +16,13 @@
 	var/artificer_name = "Artificer"
 	var/artificer_icon_state = "artificer"
 	var/artificer_dead_state = "shade_dead"
+	var/artificer_desc_state = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies."
 
 	//Behemoth Construct
 	var/behemoth_name = "Behemoth"
 	var/behemoth_icon_state = "behemoth"
 	var/behemoth_dead_state = "shade_dead"
+	var/behemoth_desc_state = "The pinnacle of occult technology, Behemoths are the ultimate weapon in the Cult of Nar-Sie's arsenal."
 
 	//Wraith Construct
 	var/wraith_name = "Wraith"
@@ -36,6 +38,7 @@
 	var/harvester_name = "Harvester"
 	var/harvester_icon_state = "harvester"
 	var/harvester_dead_state = "shade_dead"
+	var/harvester_desc_state = "A harbinger of Nar-Sie's enlightenment. It'll be all over soon."
 
 	//Shade Spirit
 	var/shade_name = "Shade"
@@ -62,9 +65,11 @@
 
 	artificer_name = "Igniting Ember"
 	artificer_icon_state = "fireartificer"
+	artificer_desc_state = "A bulbous construct dedicated to building and maintaining The Cult of Pyr'Kaeus's armies."
 
 	behemoth_name = "Devouring Hatred"
 	behemoth_icon_state = "firejuggernaut"
+	behemoth_desc_state = "The pinnacle of occult technology, Behemoths are the ultimate weapon in the Cult of Pyr'Kaeus's arsenal."
 
 	wraith_name = "Living Flame"
 	wraith_icon_state = "firewraith"
@@ -74,6 +79,7 @@
 
 	harvester_name = "Coal Seeker"//or nipple pincher...
 	harvester_icon_state = "fireharvester"
+	harvester_desc_state = "A harbinger of Pyr'Kaeus's enlightenment. It'll be all over soon."
 
 	shade_name = "Charred Soul"
 	shade_icon_state = "shade"
@@ -91,9 +97,11 @@
 	cult_floor_icon_state = "carpet-broken"
 
 	artificer_name = "Boneshaper"
+	artificer_desc_state = "A bulbous construct dedicated to building and maintaining the armies of the Cult of The Reaper."
 
 	behemoth_name = "Draugr"
 	behemoth_icon_state = "horror"
+	behemoth_desc_state = "The pinnacle of occult technology, Behemoths are the ultimate weapon in the arsenal of the Cult of The Reaper."
 
 	wraith_name = "Wraith"
 	wraith_icon_state = "stand"
@@ -102,6 +110,7 @@
 	juggernaut_icon_state = "horror"
 
 	harvester_name = "Psychopomp"
+	harvester_desc_state = "A harbinger of The Reaper's enlightenment. It'll be all over soon. AYYY LMAO"
 
 	shade_name = "Banshee"
 
@@ -142,3 +151,14 @@
 			return wraith_icon_state
 		if("shade")
 			return shade_icon_state
+
+/datum/cult_info/proc/get_desc(var/type_to_desc)
+	if(!type_to_desc)
+		return
+	switch(type_to_desc)
+		if("behemoth")
+			return behemoth_desc_state
+		if("builder")
+			return artificer_desc_state
+		if("harvester")
+			return harvester_desc_state

--- a/code/game/gamemodes/cult/cult_datums.dm
+++ b/code/game/gamemodes/cult/cult_datums.dm
@@ -110,7 +110,7 @@
 	juggernaut_icon_state = "horror"
 
 	harvester_name = "Psychopomp"
-	harvester_desc_state = "A harbinger of The Reaper's enlightenment. It'll be all over soon. AYYY LMAO"
+	harvester_desc_state = "A harbinger of The Reaper's enlightenment. It'll be all over soon."
 
 	shade_name = "Banshee"
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -34,11 +34,13 @@
 		real_name = const_type
 		icon_living = const_type
 		icon_state = const_type
+		desc = const_type
 	else
 		name = "[ticker.mode.cultdat.get_name(const_type)] ([rand(1, 1000)])"
 		real_name = ticker.mode.cultdat.get_name(const_type)
 		icon_living = ticker.mode.cultdat.get_icon(const_type)
 		icon_state = ticker.mode.cultdat.get_icon(const_type)
+		desc = ticker.mode.cultdat.get_desc(const_type)
 
 	for(var/spell in construct_spells)
 		AddSpell(new spell(null))
@@ -181,7 +183,7 @@
 /mob/living/simple_animal/hostile/construct/builder
 	name = "Artificer"
 	real_name = "Artificer"
-	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies"
+	desc = "you shouldn't be seeing this"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "artificer"
 	icon_living = "artificer"
@@ -259,7 +261,7 @@
 /mob/living/simple_animal/hostile/construct/behemoth
 	name = "Behemoth"
 	real_name = "Behemoth"
-	desc = "The pinnacle of occult technology, Behemoths are the ultimate weapon in the Cult of Nar-Sie's arsenal."
+	desc = "you shouldn't be seeing this"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "behemoth"
 	icon_living = "behemoth"
@@ -293,7 +295,7 @@
 /mob/living/simple_animal/hostile/construct/harvester
 	name = "Harvester"
 	real_name = "Harvester"
-	desc = "A harbinger of Nar-Sie's enlightenment. It'll be all over soon."
+	desc = "you shouldn't be seeing this"
 	icon = 'icons/mob/mob.dmi'
 	icon_state = "harvester"
 	icon_living = "harvester"


### PR DESCRIPTION
A quick note that I am new to the DM language and coding in general and that this is my first PR, so apologies for any glaring errors.


**What this does:**
Changes the description for cult-summoned constructs so that they give mention to the correct God for their cult. No longer does the description for Pyr'Kaeus constructs make reference to Nar'Sie for example.


Thanks to Birdtalon for his suggestion for this fix.