### PR TITLE
Nerfs mech mounted teleporters

### DIFF
--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -51,12 +51,8 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	ME.attach(src)
 
-/obj/mecha/combat/gygax/dark/add_cell(var/obj/item/weapon/stock_parts/cell/C=null)
-	if(C)
-		C.forceMove(src)
-		cell = C
-		return
-	cell = new(src)
+/obj/mecha/combat/gygax/dark/add_cell()
+	cell = new /obj/item/weapon/stock_parts/cell/bluespace(src)
 	cell.charge = 30000
 	cell.maxcharge = 30000
 

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -46,7 +46,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter
+	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter/precise
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	ME.attach(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -50,6 +50,11 @@
 	force = 55
 	max_equip = 5
 
+/obj/mecha/combat/marauder/seraph/add_cell()
+	cell = new /obj/item/weapon/stock_parts/cell/bluespace(src)
+	cell.charge = 40000
+	cell.maxcharge = 40000
+
 /obj/mecha/combat/marauder/seraph/loaded/New()
 	..()//Let it equip whatever is needed.
 	var/obj/item/mecha_parts/mecha_equipment/ME

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -66,7 +66,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter/precise(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay(src)
 	ME.attach(src)

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -11,6 +11,7 @@
 	equip_cooldown = 150
 	energy_drain = 8000
 	range = RANGED
+	var/tele_precision = 4
 
 /obj/item/mecha_parts/mecha_equipment/teleporter/action(atom/target)
 	if(!action_checks(target) || !is_teleport_allowed(loc.z))
@@ -18,9 +19,15 @@
 	var/turf/T = get_turf(target)
 	if(T)
 		chassis.use_power(energy_drain)
-		do_teleport(chassis, T, 4)
+		do_teleport(chassis, T, tele_precision)
 		return 1
 
+/obj/item/mecha_parts/mecha_equipment/teleporter/precise
+	name = "upgraded teleporter"
+	desc = "An exosuit module that allows exosuits to teleport to any position in view. This is the high-precision, energy-efficient version."
+	origin_tech = "bluespace=13"
+	energy_drain = 1000
+	tele_precision = 1
 
 
 ////////////////////////////////////////////// WORMHOLE GENERATOR //////////////////////////////////////////

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -9,7 +9,7 @@
 	icon_state = "mecha_teleport"
 	origin_tech = "bluespace=10"
 	equip_cooldown = 150
-	energy_drain = 1000
+	energy_drain = 8000
 	range = RANGED
 
 /obj/item/mecha_parts/mecha_equipment/teleporter/action(atom/target)
@@ -17,6 +17,7 @@
 		return
 	var/turf/T = get_turf(target)
 	if(T)
+		chassis.use_power(energy_drain)
 		do_teleport(chassis, T, 4)
 		return 1
 


### PR DESCRIPTION
Changes:
- The mech-mounted teleporters produced in R&D/robotics are now only good for 4-5 uses (assuming a bluespace cell) before the mech's battery is drained. This means that mech teleporters can be used for emergency escapes and brilliant charges, but can no longer be spammed to cross the station in the blink of an eye.
- Serpahs (Centcom mechs) and Dark Gygaxes (nuke ops mechs) get a slightly different version of the teleporter, the 'upgraded teleporter'. This version is good for about 40 uses, and is more precise, but cannot be built by crew.

🆑 Kyep
tweak: Mech-mounted teleporters are no longer massively overpowered. They now consume a huge amount of energy to use, to the point that crew mechs with them can only use them a few times. They can no longer be spammed. Dark Gygax mechs used by nuclear operatives get a better version of the teleporter, which has around 40 uses, and is more precise.
/🆑