### PR TITLE
Makes Attack Logs Punchier

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -250,7 +250,7 @@ Proc for attack log creation, because really why not
 */
 
 proc/add_logs(mob/user, mob/target, what_done, var/object=null, var/addition=null, var/admin=1, var/print_attack_log = 1)//print_attack_log notifies admins with attack logs on
-	var/list/ignore=list("shaked", "CPRed", "grabbed", "punched", "disarmed")
+	var/list/ignore=list("shaked", "CPRed", "grabbed", "disarmed")
 	if(!user)
 		return
 	if(ismob(user))


### PR DESCRIPTION
Right now, admins don't see attack logs for punches. They're recorded in VV and logs, but we don't get 'ATTACK:' notices for them, even with attack logs on.
With this PR, that changes. Now, admins with the preference enabled see punches, too. Not disarms, just harmful punches.

We'll now be able to notice fights earlier. But, we may see a lot of punch notices.
