### PR TITLE
SSD Handling

### DIFF
--- a/code/controllers/Processes/ssd.dm
+++ b/code/controllers/Processes/ssd.dm
@@ -10,7 +10,7 @@ var/global/datum/controller/process/ssd/ssd
 
 /datum/controller/process/ssd/setup()
 	name = "SSD"
-	schedule_interval = 3000
+	schedule_interval = 6000
 
 /datum/controller/process/ssd/doWork()
 	current_ssds = list()
@@ -19,7 +19,6 @@ var/global/datum/controller/process/ssd/ssd
 	for(var/obj/machinery/cryopod/P in machines)
 		if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))
 			free_cryopods += P
-	message_admins("A2")
 	for(var/mob/living/carbon/human/H in mob_list)
 		if(H.is_valid_for_cryoing())
 			if(H in ignored_ssds)

--- a/code/controllers/Processes/ssd.dm
+++ b/code/controllers/Processes/ssd.dm
@@ -1,0 +1,65 @@
+
+var/global/datum/controller/process/ssd/ssd
+
+/datum/controller/process/ssd
+	var/list/current_ssds = list()
+	var/list/previous_ssds = list()
+	var/list/ignored_ssds = list()
+	var/list/areas_to_ignore = list(/area/security/prison, /area/security/permabrig)
+
+
+/datum/controller/process/ssd/setup()
+	name = "SSD"
+	schedule_interval = 3000
+
+/datum/controller/process/ssd/doWork()
+	current_ssds = list()
+	var/list/free_cryopods = list()
+	var/obj/machinery/cryopod/target_cryopod = null
+	for(var/obj/machinery/cryopod/P in machines)
+		if(!P.occupant && istype(get_area(P), /area/crew_quarters/sleep))
+			free_cryopods += P
+	message_admins("A2")
+	for(var/mob/living/carbon/human/H in mob_list)
+		if(H.is_valid_for_cryoing())
+			if(H in ignored_ssds)
+				continue
+			if(H.mind)
+				if(H.mind.assigned_role in command_positions)
+					continue
+			var/valid_area = 1
+			for(var/area/A in areas_to_ignore)
+				if(istype(get_area(H), A))
+					valid_area = 0
+					break
+			if(!valid_area)
+				continue
+			current_ssds += H
+	for(var/mob/living/carbon/human/T in current_ssds)
+		if(T in previous_ssds)
+			ignored_ssds += T
+			if(free_cryopods.len)
+				target_cryopod = safepick(free_cryopods)
+				if(target_cryopod.check_occupant_allowed(T))
+					target_cryopod.take_occupant(T, 1)
+					free_cryopods -= target_cryopod
+	previous_ssds = current_ssds
+
+/mob/living/carbon/human/proc/is_valid_for_cryoing()
+	if(!is_station_level(z))
+		return 0
+	if(!isLivingSSD(src))
+		return 0
+	if(anchored)
+		return 0
+	if(stunned)
+		return 0
+	if(handcuffed)
+		return 0
+	if(istype(get_turf(src), /turf/space))
+		return 0
+	if(buckled)
+		return 0
+	if(pulledby)
+		return 0
+	return 1

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -39,6 +39,7 @@
 	var/memory
 
 	var/assigned_role
+	var/role_given_up = 0
 	var/special_role
 	var/list/restricted_roles = list()
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -101,7 +101,7 @@
 
 		visible_message("<span class='notice'>The console beeps happily as it disgorges \the [I].</span>")
 
-		I.loc = get_turf(src)
+		I.forceMove(get_turf(src))
 		frozen_items -= I
 
 	else if(href_list["allitems"])
@@ -117,7 +117,7 @@
 		visible_message("<span class='notice'>The console beeps happily as it disgorges the desired objects.</span>")
 
 		for(var/obj/item/I in frozen_items)
-			I.loc = get_turf(src)
+			I.forceMove(get_turf(src))
 			frozen_items -= I
 
 	src.updateUsrDialog()
@@ -275,7 +275,7 @@
 	//Drop all items into the pod.
 	for(var/obj/item/W in occupant)
 		occupant.unEquip(W)
-		W.loc = src
+		W.forceMove(src)
 
 		if(W.contents.len) //Make sure we catch anything not handled by qdel() on the items.
 			var/preserve = null
@@ -288,7 +288,7 @@
 			for(var/obj/item/O in W.contents)
 				if(istype(O,/obj/item/weapon/tank)) //Stop eating pockets, you fuck!
 					continue
-				O.loc = src
+				O.forceMove(src)
 
 	for(var/obj/machinery/computer/cloning/cloner in machines)
 		for(var/datum/dna2/record/R in cloner.records)
@@ -322,7 +322,7 @@
 				control_computer.frozen_items += W
 				W.loc = null
 			else
-				W.loc = src.loc
+				W.forceMove(src.loc)
 
 	//Update any existing objectives involving this mob.
 	for(var/datum/objective/O in all_objectives)
@@ -447,9 +447,7 @@
 					to_chat(user, "<span class='boldnotice'>\The [src] is in use.</span>")
 					return
 
-				M.forceMove(src)
-
-				time_till_despawn = initial(time_till_despawn) / willing
+				take_occupant(M, willing)
 
 			else //because why the fuck would you keep going if the mob isn't in the pod
 				to_chat(user, "<span class='notice'>You stop putting [M] into the cryopod.</span>")
@@ -481,6 +479,31 @@
 			//Despawning occurs when process() is called with an occupant without a client.
 			src.add_fingerprint(M)
 
+/obj/machinery/cryopod/proc/take_occupant(var/mob/living/carbon/E, var/willing_factor = 1)
+	if(src.occupant)
+		return
+	if(!E)
+		return
+	E.forceMove(src)
+	time_till_despawn = initial(time_till_despawn) / willing_factor
+	if(orient_right)
+		icon_state = "[occupied_icon_state]-r"
+	else
+		icon_state = occupied_icon_state
+	to_chat(E, "<span class='notice'>[on_enter_occupant_message]</span>")
+	to_chat(E, "<span class='boldnotice'>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</span>")
+	occupant = E
+	name = "[name] ([occupant.name])"
+	time_entered = world.time
+	if(findtext("[E.key]","@",1,2))
+		var/FT = replacetext(E.key, "@", "")
+		for(var/mob/dead/observer/Gh in respawnable_list) //this may not be foolproof but it seemed like a better option than 'in world'
+			if(Gh.key == FT)
+				if(Gh.client && Gh.client.holder) //just in case someone has a byond name with @ at the start, which I don't think is even possible but whatever
+					to_chat(Gh, "<span style='color: #800080;font-weight: bold;font-size:4;'>Warning: Your body has entered cryostorage.</span>")
+	log_admin("<span class='notice'>[key_name(E)] entered a stasis pod.</span>")
+	message_admins("[key_name_admin(E)] entered a stasis pod. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
+	src.add_fingerprint(E)
 
 /obj/machinery/cryopod/MouseDrop_T(atom/movable/O as mob|obj, mob/user as mob)
 
@@ -541,38 +564,10 @@
 			if(src.occupant)
 				to_chat(user, "<span class='boldnotice'>\The [src] is in use.</span>")
 				return
-			L.forceMove(src)
-			time_till_despawn = initial(time_till_despawn) / willing
+			take_occupant(L, willing)
 		else
 			to_chat(user, "<span class='notice'>You stop [L == user ? "climbing into the cryo pod." : "putting [L] into the cryo pod."]</span>")
-			return
 
-		if(orient_right)
-			icon_state = "[occupied_icon_state]-r"
-		else
-			icon_state = occupied_icon_state
-
-		to_chat(L, "<span class='notice'>[on_enter_occupant_message]</span>")
-		to_chat(L, "<span class='boldnotice'>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</span>")
-		occupant = L
-		name = "[name] ([occupant.name])"
-		time_entered = world.time
-
-		if(findtext("[L.key]","@",1,2))
-			var/FT = replacetext(L.key, "@", "")
-			for(var/mob/dead/observer/Gh in respawnable_list) //this may not be foolproof but it seemed like a better option than 'in world'
-				if(Gh.key == FT)
-					if(Gh.client && Gh.client.holder) //just in case someone has a byond name with @ at the start, which I don't think is even possible but whatever
-						to_chat(Gh, "<span style='color: #800080;font-weight: bold;font-size:4;'>Warning: Your body has entered cryostorage.</span>")
-
-		// Book keeping!
-		log_admin("[key_name_admin(L)] has entered a stasis pod. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-		message_admins("<span class='notice'>[key_name_admin(L)] has entered a stasis pod.</span>")
-
-		//Despawning occurs when process() is called with an occupant without a client.
-		src.add_fingerprint(L)
-
-	return
 
 /obj/machinery/cryopod/verb/eject()
 	set name = "Eject Pod"
@@ -597,7 +592,7 @@
 	if(announce) items -= announce
 
 	for(var/obj/item/W in items)
-		W.loc = get_turf(src)
+		W.forceMove(get_turf(src))
 
 	src.go_out()
 	add_fingerprint(usr)
@@ -708,7 +703,7 @@
 	qdel(R.mmi)
 	for(var/obj/item/I in R.module) // the tools the borg has; metal, glass, guns etc
 		for(var/obj/item/O in I) // the things inside the tools, if anything; mainly for janiborg trash bags
-			O.loc = R
+			O.forceMove(R)
 		qdel(I)
 	R.module.remove_subsystems_and_actions(R)
 	qdel(R.module)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -346,7 +346,8 @@
 		//Handle job slot/tater cleanup.
 		var/job = occupant.mind.assigned_role
 
-		job_master.FreeRole(job)
+		if(!occupant.mind.role_given_up)
+			job_master.FreeRole(job)
 
 		if(occupant.mind.objectives.len)
 			occupant.mind.objectives.Cut()

--- a/paradise.dme
+++ b/paradise.dme
@@ -186,6 +186,7 @@
 #include "code\controllers\Processes\obj.dm"
 #include "code\controllers\Processes\pipenet.dm"
 #include "code\controllers\Processes\shuttles.dm"
+#include "code\controllers\Processes\ssd.dm"
 #include "code\controllers\Processes\sun.dm"
 #include "code\controllers\Processes\ticker.dm"
 #include "code\controllers\Processes\timer.dm"


### PR DESCRIPTION
After 10-20 minutes of someone being SSD, an extra slot is added for whatever job they have.

This process ignores anyone who is any of the following:
- Not SSD
- Dead
- Off Station
- Anchored, stunned, cuffed, buckled, or pulled
- In space
- A head of staff (including the Captain)
- Not human (ie: a simple mob, borg, etc)
- In a prison area (brig, perma)
- Has gone SSD before in the same round

If you'd like to go SSD for ages without this affecting you, simply buckle yourself to a chair anywhere on the station.

This PR helps avoid situations where SSD people in remote areas of the station are consuming job slots for most of the round, without ever being put in cryo.

As a side bonus, this PR also refactors cryopod.dm to improve it.

🆑 Kyep
rscadd: People who are SSD for awhile will eventually cause more slots to be opened for their job. So someone can do the work they aren't doing. Buckled people, heads, etc are immune.
/🆑