### PR TITLE
Improve View Flagged Books admin verb

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -431,7 +431,7 @@ proc/checkhtml(var/t)
 			text = copytext(text, 1, index) + repl_chars[char] + copytext(text, index+keylength)
 			index = findtext(text, char)
 	return text
-	
+
 //Checks if any of a given list of needles is in the haystack
 /proc/text_in_list(haystack, list/needle_list, start=1, end=0)
 	for(var/needle in needle_list)
@@ -445,3 +445,98 @@ proc/checkhtml(var/t)
 		if(findtextEx(haystack, needle, start, end))
 			return 1
 	return 0
+
+
+// Pencode
+/proc/pencode_to_html(text, mob/user, var/obj/item/weapon/pen/P = null, deffont = "Verdana", signfont = "Times New Roman", crayonfont = "Comic Sans MS")
+	text = replacetext(text, "\n",			"<BR>")
+	text = replacetext(text, "\[center\]",	"<center>")
+	text = replacetext(text, "\[/center\]",	"</center>")
+	text = replacetext(text, "\[br\]",		"<BR>")
+	text = replacetext(text, "\[b\]",		"<B>")
+	text = replacetext(text, "\[/b\]",		"</B>")
+	text = replacetext(text, "\[i\]",		"<I>")
+	text = replacetext(text, "\[/i\]",		"</I>")
+	text = replacetext(text, "\[u\]",		"<U>")
+	text = replacetext(text, "\[/u\]",		"</U>")
+	text = replacetext(text, "\[large\]",	"<font size=\"4\">")
+	text = replacetext(text, "\[/large\]",	"</font>")
+	text = replacetext(text, "\[sign\]",	"<font face=\"[signfont]\"><i>[user ? user.real_name : "Anonymous"]</i></font>")
+	text = replacetext(text, "\[field\]",	"<span class=\"paper_field\"></span>")
+
+	text = replacetext(text, "\[h1\]",	"<H1>")
+	text = replacetext(text, "\[/h1\]",	"</H1>")
+	text = replacetext(text, "\[h2\]",	"<H2>")
+	text = replacetext(text, "\[/h2\]",	"</H2>")
+	text = replacetext(text, "\[h3\]",	"<H3>")
+	text = replacetext(text, "\[/h3\]",	"</H3>")
+
+	if(istype(P, /obj/item/weapon/pen))
+		text = replacetext(text, "\[*\]",		"<li>")
+		text = replacetext(text, "\[hr\]",		"<HR>")
+		text = replacetext(text, "\[small\]",	"<font size = \"1\">")
+		text = replacetext(text, "\[/small\]",	"</font>")
+		text = replacetext(text, "\[list\]",	"<ul>")
+		text = replacetext(text, "\[/list\]",	"</ul>")
+		text = replacetext(text, "\[table\]",	"<table border=1 cellspacing=0 cellpadding=3 style='border: 1px solid black;'>")
+		text = replacetext(text, "\[/table\]",	"</td></tr></table>")
+		text = replacetext(text, "\[grid\]",	"<table>")
+		text = replacetext(text, "\[/grid\]",	"</td></tr></table>")
+		text = replacetext(text, "\[row\]",		"</td><tr>")
+		text = replacetext(text, "\[cell\]",	"<td>")
+		text = replacetext(text, "\[logo\]",	"<img src = ntlogo.png>")
+
+		text = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[text]</font>"
+	else // If it is a crayon, and he still tries to use these, make them empty!
+		text = replacetext(text, "\[*\]", 		"")
+		text = replacetext(text, "\[hr\]",		"")
+		text = replacetext(text, "\[small\]", 	"")
+		text = replacetext(text, "\[/small\]", 	"")
+		text = replacetext(text, "\[list\]", 	"")
+		text = replacetext(text, "\[/list\]", 	"")
+		text = replacetext(text, "\[table\]", 	"")
+		text = replacetext(text, "\[/table\]", 	"")
+		text = replacetext(text, "\[row\]", 	"")
+		text = replacetext(text, "\[cell\]", 	"")
+		text = replacetext(text, "\[logo\]", 	"")
+
+		text = "<font face=\"[crayonfont]\" color=[P ? P.colour : "black"]><b>[text]</b></font>"
+
+	text = copytext(text, 1, MAX_PAPER_MESSAGE_LEN)
+	return text
+
+/proc/html_to_pencode(text)
+	text = replacetext(text, "<BR>",								"\n")
+	text = replacetext(text, "<center>",							"\[center\]")
+	text = replacetext(text, "</center>",							"\[/center\]")
+	text = replacetext(text, "<BR>",								"\[br\]")
+	text = replacetext(text, "<B>",									"\[b\]")
+	text = replacetext(text, "</B>",								"\[/b\]")
+	text = replacetext(text, "<I>",									"\[i\]")
+	text = replacetext(text, "</I>",								"\[/i\]")
+	text = replacetext(text, "<U>",									"\[u\]")
+	text = replacetext(text, "</U>",								"\[/u\]")
+	text = replacetext(text, "<font size=\"4\">",					"\[large\]")
+	text = replacetext(text, "<span class=\"paper_field\"></span>",	"\[field\]")
+
+	text = replacetext(text, "<H1>",	"\[h1\]")
+	text = replacetext(text, "</H1>",	"\[/h1\]")
+	text = replacetext(text, "<H2>",	"\[h2\]")
+	text = replacetext(text, "</H2>",	"\[/h2\]")
+	text = replacetext(text, "<H3>",	"\[h3\]")
+	text = replacetext(text, "</H3>",	"\[/h3\]")
+
+	text = replacetext(text, "<li>",					"\[*\]")
+	text = replacetext(text, "<HR>",					"\[hr\]")
+	text = replacetext(text, "<font size = \"1\">",		"\[small\]")
+	text = replacetext(text, "<ul>",					"\[list\]")
+	text = replacetext(text, "</ul>",					"\[/list\]")
+	text = replacetext(text, "<table border=1 cellspacing=0 cellpadding=3 style='border: 1px solid black;'>",	"\[table\]")
+	text = replacetext(text, "</td></tr></table>",		"\[/table\]")
+	text = replacetext(text, "<table>",					"\[grid\]")
+	text = replacetext(text, "</td></tr></table>",		"\[/grid\]")
+	text = replacetext(text, "</td><tr>",				"\[row\]")
+	text = replacetext(text, "<td>",					"\[cell\]")
+	text = replacetext(text, "<img src = ntlogo.png>",	"\[logo\]")
+	return text
+

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1,4 +1,4 @@
-/datum/admins/Topic(href, href_list)
+7/datum/admins/Topic(href, href_list)
 	..()
 
 	if(usr.client != src.owner || !check_rights(0))
@@ -3021,7 +3021,7 @@
 
 	// Library stuff
 	else if(href_list["library_book_id"])
-		var/isbn = href_list["library_book_id"]
+		var/isbn = sanitizeSQL(href_list["library_book_id"])
 
 		if(href_list["view_library_book"])
 			var/DBQuery/query_view_book = dbcon.NewQuery("SELECT content, title FROM [format_table_name("library")] WHERE id=[isbn]")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1,4 +1,4 @@
-7/datum/admins/Topic(href, href_list)
+/datum/admins/Topic(href, href_list)
 	..()
 
 	if(usr.client != src.owner || !check_rights(0))

--- a/code/modules/library/admin.dm
+++ b/code/modules/library/admin.dm
@@ -29,13 +29,36 @@
 		to_chat(src, "Only administrators may use this command.")
 		return
 
+	holder.view_flagged_books()
+
+/datum/admins/proc/view_flagged_books()
+	if(!usr.client.holder)
+		return
+
+	var/dat = "<table><tr><th>ISBN</th><th>Title</th><th>Total Flags</th><th>Options</th></tr>"
+
 	var/DBQuery/query = dbcon.NewQuery("SELECT id, title, flagged FROM [format_table_name("library")] WHERE flagged > 0 ORDER BY flagged DESC")
 	if(!query.Execute())
 		var/err = query.ErrorMsg()
 		log_game("SQL ERROR getting flagged books. Error : \[[err]\]\n")
 		return
 
-	var/i
-	for(i = 0, query.NextRow(), i++)
-		to_chat(usr, "[add_zero(query.item[1], 4)] ([query.item[2]]) - flagged [query.item[3]] times.")
-	to_chat(usr, "[i] flagged books total.")
+	var/books = 0
+	while(query.NextRow())
+		books++
+		var/isbn = query.item[1]
+		dat += "<tr><td>[add_zero(isbn, 4)]</td><td>[query.item[2]]</td><td>[query.item[3]]</td><td>"
+		dat += "<a href='?_src_=holder;library_book_id=[isbn];view_library_book=1;'>View Content</a>"
+		dat += "<a href='?_src_=holder;library_book_id=[isbn];unflag_library_book=1;'>Unflag</a>"
+		dat += "<a href='?_src_=holder;library_book_id=[isbn];delete_library_book=1;'>Delete</a>"
+		dat += "</td>"
+
+	dat += "</table>"
+
+	if(!books)
+		dat = "<h1>No flagged books! :)</h1>"
+
+	var/datum/browser/popup = new(usr, "admin_view_flagged_books", "Flagged Books", 700, 400)
+	popup.set_content(dat)
+	popup.open(0)
+

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -199,62 +199,8 @@
 	update_icon()
 
 
-/obj/item/weapon/paper/proc/parsepencode(var/t, var/obj/item/weapon/pen/P, mob/user as mob, var/iscrayon = 0)
-//	t = sanitize(copytext(t),1,MAX_MESSAGE_LEN)
-
-	t = replacetext(t, "\[center\]", "<center>")
-	t = replacetext(t, "\[/center\]", "</center>")
-	t = replacetext(t, "\[br\]", "<BR>")
-	t = replacetext(t, "\[b\]", "<B>")
-	t = replacetext(t, "\[/b\]", "</B>")
-	t = replacetext(t, "\[i\]", "<I>")
-	t = replacetext(t, "\[/i\]", "</I>")
-	t = replacetext(t, "\[u\]", "<U>")
-	t = replacetext(t, "\[/u\]", "</U>")
-	t = replacetext(t, "\[large\]", "<font size=\"4\">")
-	t = replacetext(t, "\[/large\]", "</font>")
-	t = replacetext(t, "\[sign\]", "<font face=\"[signfont]\"><i>[user ? user.real_name : "Anonymous"]</i></font>")
-	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
-
-	t = replacetext(t, "\[h1\]", "<H1>")
-	t = replacetext(t, "\[/h1\]", "</H1>")
-	t = replacetext(t, "\[h2\]", "<H2>")
-	t = replacetext(t, "\[/h2\]", "</H2>")
-	t = replacetext(t, "\[h3\]", "<H3>")
-	t = replacetext(t, "\[/h3\]", "</H3>")
-
-	if(!iscrayon)
-		t = replacetext(t, "\[*\]", "<li>")
-		t = replacetext(t, "\[hr\]", "<HR>")
-		t = replacetext(t, "\[small\]", "<font size = \"1\">")
-		t = replacetext(t, "\[/small\]", "</font>")
-		t = replacetext(t, "\[list\]", "<ul>")
-		t = replacetext(t, "\[/list\]", "</ul>")
-		t = replacetext(t, "\[table\]", "<table border=1 cellspacing=0 cellpadding=3 style='border: 1px solid black;'>")
-		t = replacetext(t, "\[/table\]", "</td></tr></table>")
-		t = replacetext(t, "\[grid\]", "<table>")
-		t = replacetext(t, "\[/grid\]", "</td></tr></table>")
-		t = replacetext(t, "\[row\]", "</td><tr>")
-		t = replacetext(t, "\[cell\]", "<td>")
-		t = replacetext(t, "\[logo\]", "<img src = ntlogo.png>")
-
-		t = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[t]</font>"
-	else // If it is a crayon, and he still tries to use these, make them empty!
-		t = replacetext(t, "\[*\]", "")
-		t = replacetext(t, "\[hr\]", "")
-		t = replacetext(t, "\[small\]", "")
-		t = replacetext(t, "\[/small\]", "")
-		t = replacetext(t, "\[list\]", "")
-		t = replacetext(t, "\[/list\]", "")
-		t = replacetext(t, "\[table\]", "")
-		t = replacetext(t, "\[/table\]", "")
-		t = replacetext(t, "\[row\]", "")
-		t = replacetext(t, "\[cell\]", "")
-		t = replacetext(t, "\[logo\]", "")
-
-		t = "<font face=\"[crayonfont]\" color=[P ? P.colour : "black"]><b>[t]</b></font>"
-
-	t = copytext(t, 1, MAX_PAPER_MESSAGE_LEN)
+/obj/item/weapon/paper/proc/parsepencode(var/t, var/obj/item/weapon/pen/P, mob/user as mob)
+	t = pencode_to_html(t, usr, P, deffont, signfont, crayonfont)
 
 //Count the fields
 	var/laststart = 1
@@ -303,12 +249,10 @@
 		//var/t =  strip_html_simple(input("Enter what you want to write:", "Write", null, null)  as message, MAX_MESSAGE_LEN)
 		var/t =  input("Enter what you want to write:", "Write", null, null)  as message
 		var/obj/item/i = usr.get_active_hand() // Check to see if he still got that darn pen, also check if he's using a crayon or pen.
-		var/iscrayon = 0
 		add_hiddenprint(usr) // No more forging nasty documents as someone else, you jerks
 		if(!istype(i, /obj/item/weapon/pen))
 			if(!istype(i, /obj/item/toy/crayon))
 				return
-			iscrayon = 1
 
 
 		// if paper is not in usr, then it must be near them, or in a clipboard or folder, which must be in or near usr
@@ -326,8 +270,7 @@
 				return
 */
 		t = html_encode(t)
-		t = replacetext(t, "\n", "<BR>")
-		t = parsepencode(t, i, usr, iscrayon) // Encode everything from pencode to html
+		t = parsepencode(t, i, usr) // Encode everything from pencode to html
 
 		if(id!="end")
 			addtofield(text2num(id), t) // He wants to edit a field, let him.


### PR DESCRIPTION
This changes the "View Flagged Books" admin verb into a datum/browser
UI. You can see all the books that have been flagged from here, review
them, and remove the flagged status or delete them.

Also refactors pencode into some __HELPER procs, and adds a
"reverse-pencode" proc. It's not perfect, due to the complexity of HTML
and my unwillingness to use BYONDregex, but it's good enough to get the
general idea of the formatting across. It's used for the new "view book"
panel.

![https://i.imgur.com/nesfNNH.png](https://i.imgur.com/nesfNNH.png)
![https://i.imgur.com/BaH9wX7.png](https://i.imgur.com/BaH9wX7.png)
![https://i.imgur.com/1qHc0hu.png](https://i.imgur.com/1qHc0hu.png)