### PR TITLE
Progress bars now stack vertically

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -625,3 +625,15 @@ proc/dd_sortedObjectList(list/incoming)
 
 /datum/alarm/dd_SortValue()
 	return "[sanitize(last_name)]"
+	
+//Picks from the list, with some safeties, and returns the "default" arg if it fails
+#define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+
+#define LAZYINITLIST(L) if (!L) L = list()
+
+#define UNSETEMPTY(L) if (L && !L.len) L = null
+#define LAZYREMOVE(L, I) if(L) { L -= I; if(!L.len) { L = null; } }
+#define LAZYADD(L, I) if(!L) { L = list(); } L += I;
+#define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
+#define LAZYLEN(L) length(L)
+#define LAZYCLEARLIST(L) if(L) L.Cut()

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -33,9 +33,9 @@
 		shown = 0
 		return
 	if(user.client != client)
-		if (client)
+		if(client)
 			client.images -= bar
-		if (user.client)
+		if(user.client)
 			user.client.images += bar
 
 	progress = Clamp(progress, 0, goal)

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -10,9 +10,9 @@
 
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
-	if (!istype(target))
+	if(!istype(target))
 		EXCEPTION("Invalid target given")
-	if (goal_number)
+	if(goal_number)
 		goal = goal_number
 	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0", HUD_LAYER)
 	bar.plane = HUD_PLANE
@@ -29,11 +29,10 @@
 	bar.pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1))
 
 /datum/progressbar/proc/update(progress)
-	//world << "Update [progress] - [goal] - [(progress / goal)] - [((progress / goal) * 100)] - [round(((progress / goal) * 100), 5)]"
-	if (!user || !user.client)
+	if(!user || !user.client)
 		shown = 0
 		return
-	if (user.client != client)
+	if(user.client != client)
 		if (client)
 			client.images -= bar
 		if (user.client)
@@ -41,7 +40,7 @@
 
 	progress = Clamp(progress, 0, goal)
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
-	if (!shown)
+	if(!shown)
 		user.client.images += bar
 		shown = 1
 
@@ -60,7 +59,7 @@
 	if(!bars.len)
 		LAZYREMOVE(user.progressbars, bar.loc)
 
-	if (client)
+	if(client)
 		client.images -= bar
 	qdel(bar)
 	. = ..()

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -1,42 +1,68 @@
+#define PROGRESSBAR_HEIGHT 6
+
 /datum/progressbar
 	var/goal = 1
 	var/image/bar
 	var/shown = 0
 	var/mob/user
 	var/client/client
+	var/listindex
 
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
-	if(!istype(target))
+	if (!istype(target))
 		EXCEPTION("Invalid target given")
-	if(goal_number)
+	if (goal_number)
 		goal = goal_number
-	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0")
+	bar = image('icons/effects/progessbar.dmi', target, "prog_bar_0", HUD_LAYER)
+	bar.plane = HUD_PLANE
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	bar.pixel_y = 32
 	user = User
 	if(user)
 		client = user.client
 
+	LAZYINITLIST(user.progressbars)
+	LAZYINITLIST(user.progressbars[bar.loc])
+	var/list/bars = user.progressbars[bar.loc]
+	bars.Add(src)
+	listindex = bars.len
+	bar.pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1))
+
 /datum/progressbar/proc/update(progress)
-//	to_chat(world, "Update [progress] - [goal] - [(progress / goal)] - [((progress / goal) * 100)] - [round(((progress / goal) * 100), 5)]")
-	if(!user || !user.client)
+	//world << "Update [progress] - [goal] - [(progress / goal)] - [((progress / goal) * 100)] - [round(((progress / goal) * 100), 5)]"
+	if (!user || !user.client)
 		shown = 0
 		return
-	if(user.client != client)
-		if(client)
+	if (user.client != client)
+		if (client)
 			client.images -= bar
-		if(user.client)
+		if (user.client)
 			user.client.images += bar
 
 	progress = Clamp(progress, 0, goal)
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
-	if(!shown)
+	if (!shown)
 		user.client.images += bar
 		shown = 1
 
+/datum/progressbar/proc/shiftDown()
+	--listindex
+	bar.pixel_y -= PROGRESSBAR_HEIGHT
+
 /datum/progressbar/Destroy()
-	if(client)
+	for(var/I in user.progressbars[bar.loc])
+		var/datum/progressbar/P = I
+		if(P != src && P.listindex > listindex)
+			P.shiftDown()
+
+	var/list/bars = user.progressbars[bar.loc]
+	bars.Remove(src)
+	if(!bars.len)
+		LAZYREMOVE(user.progressbars, bar.loc)
+
+	if (client)
 		client.images -= bar
 	qdel(bar)
 	. = ..()
+
+#undef PROGRESSBAR_HEIGHT

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -196,3 +196,5 @@
 	var/list/permanent_huds = list()
 
 	var/list/actions = list()
+	
+	var/list/progressbars = null	//for stacking do_after bars


### PR DESCRIPTION
Ports over https://github.com/tgstation/tgstation/pull/23516 by @Cyberboss. This lets progress bars stack vertically when you are performing multiple actions in one go (they currently stack on top of each other), and lighting no longer affects them.

Also adds a bunch of lazy list helpers that /tg/ implemented a while back that have better performance.

🆑 Developed by Cyberboss, ported by Markolie
tweak: Progress bars will now stack vertically.
fix: Progress bars will no longer be affected by lighting.
/🆑