### PR TITLE
Lets mentors see playtime

### DIFF
--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -48,6 +48,12 @@
 	var/message = "[key_name(whom, 1, include_name)](<A HREF='?_src_=holder;adminmoreinfo=\ref[whom]'>?</A>)[isAntag(whom) ? "<font color='red'>(A)</font>" : ""][isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom)])"
 	return message
 
+/proc/key_name_mentor(var/whom, var/include_name = 1)
+	// Same as key_name_admin, but does not include (?) or (A) for antags.
+	var/message = "[key_name(whom, 1, include_name)] [isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom)])"
+	return message
+
+
 /proc/log_and_message_admins(var/message as text)
 	log_admin("[key_name(usr)] " + message)
 	message_admins("[key_name_admin(usr)] " + message)

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -9,11 +9,20 @@
 	var/list/players_new = list()
 	var/list/players_old = list()
 	var/pline
+	var/datum/job/theirjob
+	var/jtext
 	for(var/client/C in clients)
+		jtext = "No Job"
+		if(C.mob.mind.assigned_role)
+			theirjob = job_master.GetJob(C.mob.mind.assigned_role)
+			if(theirjob)
+				jtext = theirjob.title
+				if(config.use_exp_restrictions && theirjob.exp_requirements && theirjob.exp_type)
+					jtext += "<span class='warning'>*</span>"
 		if(check_rights(R_ADMIN))
-			pline = "<LI> [key_name_admin(C.mob)]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
+			pline = "<LI> [key_name_admin(C.mob)]: [jtext]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
 		else
-			pline = "<LI> [key_name_mentor(C.mob)]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
+			pline = "<LI> [key_name_mentor(C.mob)]: [jtext]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
 		if(C.get_exp_living_num() > 1200)
 			players_old += pline
 		else

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -1,6 +1,6 @@
 // Admin Verbs
 
-/client/proc/cmd_admin_check_player_exp()	//Allows admins to determine who the newer players are.
+/client/proc/cmd_mentor_check_player_exp()	//Allows admins to determine who the newer players are.
 	set category = "Admin"
 	set name = "Check Player Playtime"
 	if(!check_rights(R_ADMIN))

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -3,20 +3,38 @@
 /client/proc/cmd_mentor_check_player_exp()	//Allows admins to determine who the newer players are.
 	set category = "Admin"
 	set name = "Check Player Playtime"
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))
 		return
-	var/msg = "<html><head><title>Playtime Report</title></head><body>Playtime:<BR><UL>"
+	var/msg = "<html><head><title>Playtime Report</title></head><body>"
+	var/list/players_new = list()
+	var/list/players_old = list()
+	var/pline
 	for(var/client/C in clients)
-		msg += "<LI> [key_name_admin(C.mob)]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
-	msg += "</UL></BODY></HTML>"
+		if(check_rights(R_ADMIN))
+			pline = "<LI> [key_name_admin(C.mob)]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
+		else
+			pline = "<LI> [key_name_mentor(C.mob)]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
+		if(C.get_exp_living_num() > 1200)
+			players_old += pline
+		else
+			players_new += pline
+	if(players_new.len)
+		msg += "<BR>Players under 20h:<BR><UL>"
+		msg += players_new.Join()
+		msg += "</UL>"
+	if(players_old.len)
+		msg += "<BR>Players over 20h:<BR><UL>"
+		msg += players_old.Join()
+		msg += "</UL>"
+	msg += "</BODY></HTML>"
 	src << browse(msg, "window=Player_playtime_check")
 
 
-/datum/admins/proc/cmd_show_exp_panel(var/client/C)
+/datum/admins/proc/cmd_mentor_show_exp_panel(var/client/C)
 	if(!C)
 		to_chat(usr, "ERROR: Client not found.")
 		return
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))
 		return
 	var/body = "<html><head><title>Playtime for [C.key]</title></head><BODY><BR>Playtime:"
 	body += C.get_exp_report()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2,7 +2,8 @@
 var/list/admin_verbs_default = list(
 	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
-	/client/proc/cmd_mentor_check_new_players
+	/client/proc/cmd_mentor_check_new_players,
+	/client/proc/cmd_mentor_check_player_exp /* shows players by playtime */
 	)
 var/list/admin_verbs_admin = list(
 	/client/proc/check_antagonists,		/*shows all antags*/
@@ -75,7 +76,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/debug_variables,
 	/client/proc/show_snpc_verbs,
 	/client/proc/reset_all_tcs,			/*resets all telecomms scripts*/
-	/client/proc/cmd_admin_check_player_exp, /* shows players by playtime */
 	/client/proc/toggle_mentor_chat
 )
 var/list/admin_verbs_ban = list(
@@ -166,7 +166,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/admin_serialize,
 	/client/proc/admin_deserialize,
 	/client/proc/jump_to_ruin,
-	/client/proc/toggle_medal_disable	
+	/client/proc/toggle_medal_disable
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2031,7 +2031,7 @@
 		if(!M)
 			to_chat(usr, "ERROR: Mob not found.")
 			return
-		cmd_show_exp_panel(M.client)
+		cmd_mentor_show_exp_panel(M.client)
 
 	else if(href_list["jumpto"])
 		if(!check_rights(R_ADMIN))	return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -88,7 +88,10 @@
 			missing_ages = 1
 			continue
 		if(C.player_age < age)
-			msg += "[key_name_admin(C)]: account is [C.player_age] days old<br>"
+			if(check_rights(R_ADMIN))
+				msg += "[key_name_admin(C.mob)]: [C.player_age] days old<br>"
+			else
+				msg += "[key_name_mentor(C.mob)]: [C.player_age] days old<br>"
 
 	if(missing_ages)
 		to_chat(src, "Some accounts did not have proper ages set in their clients.  This function requires database to be present")


### PR DESCRIPTION
Mentors can already see a list of all players by account age. This includes antags with obvious names, like "Donk Co. Operative #1".

This PR changes the permissions on the playtime report (the one which shows how much playtime everyone has) so mentors can see that, too.

The idea being that this enables mentors to distinguish between "X has an old account" and "X has a lot of experience on paradise". Currently, mentors cannot distinguish the two.

Also, consistency. If mentors can see players' account registration age, they should also be able to see players' playtime experience. They're both intended to let mentors/admins see how experienced someone is. It makes no sense to show mentors one, but not the other.