### PR TITLE
Fixes an IAA bug

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -238,6 +238,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	alt_titles = list("Lawyer","Public Defender")
 	minimal_player_age = 30
 	exp_requirements = 300
+	exp_type = EXP_TYPE_CREW
 	idtype = /obj/item/weapon/card/id/security
 
 	equip(var/mob/living/carbon/human/H)


### PR DESCRIPTION
Fixes a missing definition that was meant to be added in
https://github.com/ParadiseSS13/Paradise/pull/6412

Without this definition, playtime settings for IAA are not recognized as they should be.