### PR TITLE
Fixes Blob Conscious Split Decreasing Scaling

### DIFF
--- a/code/game/gamemodes/blob/powers.dm
+++ b/code/game/gamemodes/blob/powers.dm
@@ -333,7 +333,7 @@
 
 	if(ticker && ticker.mode.name == "blob")
 		var/datum/game_mode/blob/BL = ticker.mode
-		BL.blobwincount = initial(BL.blobwincount) * 2
+		BL.blobwincount += initial(BL.blobwincount)
 
 
 /mob/camera/blob/verb/blob_broadcast()


### PR DESCRIPTION
Makes it so that when a blob uses the Conscious Split verb, it no longer sets it to 700 (350*2), but instead increases the current requirement by 350 (the initial amount) before the blobs can win. This gives blobs the chance to make more cores and in turn theoretically reach that limit quicker (and also gives them a chance to increase their play-time as blob), but if they lose cores, they have much more work ahead of them to make up for that loss.

Fixes #6372

:cl:Twinmold
Fix: Blob Conscious Split now properly scales the requirement of blob tiles to win.
/:cl: