### PR TITLE
Welding Gasmasks/Goggles now work again.

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -327,8 +327,8 @@
 		flash_protect = 0
 		tint = 0
 	var/mob/living/carbon/user = usr
-	user.update_inv_glasses()
 	user.update_tint()
+	user.update_inv_glasses()
 
 	for(var/X in actions)
 		var/datum/action/A = X
@@ -492,4 +492,4 @@
 		else
 			to_chat(user, "<span class='notice'>The eye winks at you and vanishes into the abyss, you feel really unlucky.</span>")
 		qdel(src)
-	..()				
+	..()

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -67,9 +67,9 @@
 		to_chat(usr, "You push the [src] up out of your face.")
 		flash_protect = 0
 		tint = 0
-	var/mob/living/carbon/C = usr
-	C.update_tint()
-	usr.update_inv_head()	//so our mob-overlays update
+	var/mob/living/carbon/user = usr
+	user.update_tint()
+	user.update_inv_head()	//so our mob-overlays update
 
 	for(var/X in actions)
 		var/datum/action/A = X

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -52,7 +52,9 @@
 		to_chat(usr, "You push the [src] up out of your face.")
 		flash_protect = 0
 		tint = 0
-	usr.update_inv_wear_mask()	//so our mob-overlays update
+	var/mob/living/carbon/user = usr
+	user.update_tint()
+	user.update_inv_wear_mask()	//so our mob-overlays update
 
 	for(var/X in actions)
 		var/datum/action/A = X


### PR DESCRIPTION
Just a missing proc call. I believe it got lost somewhere in the (somewhat) recent action button commits. Tested on a local branch by using a welding helmet, gasmask and goggles and fooling with the toggle button. All worked fine.

Resolves #6457 

:cl:
fix: Welding goggles and welding gas masks now properly affect your vision.
/:cl: