### PR TITLE
The ghost cannot honk if you disable his code

### DIFF
--- a/code/game/turfs/simulated/floor/mineral.dm
+++ b/code/game/turfs/simulated/floor/mineral.dm
@@ -73,10 +73,10 @@
 	icons = list("bananium","bananium_dam")
 	var/spam_flag = 0
 
-/turf/simulated/floor/mineral/bananium/Entered(mob/AM)
+/turf/simulated/floor/mineral/bananium/Entered(mob/living/M)
 	.=..()
 	if(!.)
-		if(istype(AM))
+		if(istype(M))
 			squeek()
 
 /turf/simulated/floor/mineral/bananium/attackby(obj/item/weapon/W, mob/user, params)


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/6467
Only living mobs cause bananium tiles to squeak.

:cl:
fix: Ethereal beings no longer cause bananium floor tiles to squeak.
/:cl: