### PR TITLE
Adds config options to shut down Dream Daemon instead of rebooting the world

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -19,6 +19,10 @@ var/shuttle_left = 0
 var/tinted_weldhelh = 1
 var/mouse_respawn_time = 5 //Amount of time that must pass between a player dying as a mouse and repawning as a mouse. In minutes.
 
+// Command to run if shutting down (SHUTDOWN_ON_REBOOT) instead of rebooting
+// It's defined here as a global because this is a hilariously bad thing to have on the easily-edited config datum
+var/global/shutdown_shell_command
+
 // Debug is used exactly once (in living.dm) but is commented out in a lot of places.  It is not set anywhere and only checked.
 // Debug2 is used in conjunction with a lot of admin verbs and therefore is actually legit.
 var/Debug = 0	// global debug switch

--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -21,3 +21,11 @@ var/list/restricted_camera_networks = list( //Those networks can only be accesse
 var/list/mineral_turfs = list()
 
 var/list/ruin_landmarks = list()
+
+var/list/round_end_sounds = list( // Maps available round end sounds to their duration
+		'sound/AI/newroundsexy.ogg' = 2.3 SECONDS,
+		'sound/misc/apcdestroyed.ogg' = 3 SECONDS,
+		'sound/misc/bangindonk.ogg' = 1.6 SECONDS,
+		'sound/goonstation/misc/newround1.ogg' = 6.9 SECONDS,
+		'sound/goonstation/misc/newround2.ogg' = 14.8 SECONDS
+		)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -189,6 +189,8 @@
 
 	var/disable_ooc_emoji = 0 // prevents people from using emoji in OOC
 
+	var/shutdown_on_reboot = 0 // Whether to shut down the world instead of rebooting it
+
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
 	for(var/T in L)
@@ -584,6 +586,12 @@
 
 				if("disable_ooc_emoji")
 					config.disable_ooc_emoji = 1
+
+				if("shutdown_on_reboot")
+					config.shutdown_on_reboot = 1
+
+				if("shutdown_shell_command")
+					shutdown_shell_command = value
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/world.dm
+++ b/code/world.dm
@@ -269,6 +269,7 @@ var/world_topic_spam_protect_time = world.timeofday
 			return
 		else
 			return ..(1)
+
 	var/delay
 	if(!isnull(time))
 		delay = max(0,time)
@@ -278,6 +279,13 @@ var/world_topic_spam_protect_time = world.timeofday
 		to_chat(world, "<span class='boldannounce'>An admin has delayed the round end.</span>")
 		return
 	to_chat(world, "<span class='boldannounce'>Rebooting world in [delay/10] [delay > 10 ? "seconds" : "second"]. [reason]</span>")
+
+	var/round_end_sound = pick(round_end_sounds)
+	var/sound_length = round_end_sounds[round_end_sound]
+	if(delay > sound_length) // If there's time, play the round-end sound before rebooting
+		spawn(delay - sound_length)
+			if(!ticker.delay_end)
+				world << round_end_sound
 	sleep(delay)
 	if(blackbox)
 		blackbox.save_all_data_to_sql()
@@ -287,10 +295,6 @@ var/world_topic_spam_protect_time = world.timeofday
 	feedback_set_details("[feedback_c]","[feedback_r]")
 	log_game("<span class='boldannounce'>Rebooting world. [reason]</span>")
 	//kick_clients_in_lobby("<span class='boldannounce'>The round came to an end with you in the lobby.</span>", 1)
-
-	spawn(0)
-		world << sound(pick('sound/AI/newroundsexy.ogg','sound/misc/apcdestroyed.ogg','sound/misc/bangindonk.ogg', 'sound/goonstation/misc/newround1.ogg', 'sound/goonstation/misc/newround2.ogg'))// random end sounds!! - LastyBatsy
-
 
 	processScheduler.stop()
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -261,7 +261,14 @@ var/world_topic_spam_protect_time = world.timeofday
 			log_admin("[key_name(usr)] has requested an immediate world restart via client side debugging tools")
 		spawn(0)
 			to_chat(world, "<span class='boldannounce'>Rebooting world immediately due to host request</span>")
-		return ..(1)
+		if(config && config.shutdown_on_reboot)
+			sleep(0)
+			if(shutdown_shell_command)
+				shell(shutdown_shell_command)
+			del(world)
+			return
+		else
+			return ..(1)
 	var/delay
 	if(!isnull(time))
 		delay = max(0,time)
@@ -287,10 +294,17 @@ var/world_topic_spam_protect_time = world.timeofday
 
 	processScheduler.stop()
 
-	for(var/client/C in clients)
-		if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
-			C << link("byond://[config.server]")
-	..(0)
+	if(config && config.shutdown_on_reboot)
+		sleep(0)
+		if(shutdown_shell_command)
+			shell(shutdown_shell_command)
+		del(world)
+		return
+	else
+		for(var/client/C in clients)
+			if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
+				C << link("byond://[config.server]")
+		..(0)
 
 #define INACTIVITY_KICK	6000	//10 minutes in ticks (approx.)
 /world/proc/KickInactiveClients()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -335,3 +335,9 @@ DISABLE_SPACE_RUINS
 
 ## Uncomment this if you want to disable usage of emoji in OOC
 #DISABLE_OOC_EMOJI
+
+## Uncomment this to shut down the world any time it would normally reboot
+#SHUTDOWN_ON_REBOOT
+## A command to run prior to the world shutting down, only used if the above option is enabled
+## This default value will kill Dream Daemon on Windows machines
+#SHUTDOWN_SHELL_COMMAND taskkill /f /im dreamdaemon.exe


### PR DESCRIPTION
This adds two config options:
- `SHUTDOWN_ON_REBOOT` causes Dream Daemon to shut down the world when it would normally reboot.
- `SHUTDOWN_SHELL_COMMAND` specifies an arbitrary shell command to run before shutting down the world. The example config file includes a default command, which simply kills the Dream Daemon task entirely on Windows machines.

These probably won't be used by most people, but we're dealing with a situation where we want Dream Daemon to completely kill itself and be restarted, and this is the easiest way to do it.

One downside: ~~the end-of-round sound seems to get cut off when killing the server this way. It's a sacrifice we will simply have to make for improved server reliability.~~ To make end-of-round sounds work consistently, they now have to play before the server reboots, and should finish playing right as it does.

Oh, and if someone untrusted has access to the server config files, they can *really* mess things up. I'm sure we won't regret that at some point in the future.

:cl:
tweak: End-of-round sounds will now play just in time for them to end as the server reboots, rather than starting the moment it reboots.
/:cl: