### PR TITLE
Fixes some sounds not being cached properly

### DIFF
--- a/code/datums/diseases/berserker.dm
+++ b/code/datums/diseases/berserker.dm
@@ -51,5 +51,5 @@
 						affected_mob.visible_message("<span class='danger'>[affected_mob] hits [M] with their thrashing!</span>")
 						M.adjustBruteLoss(damage)
 					else
-						playsound(affected_mob.loc, "sound/weapons/punchmiss.ogg", 25, 1, -1)
+						playsound(affected_mob.loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 						affected_mob.visible_message("<span class='danger'>[affected_mob] fails to hit [M] with their thrashing!</span>")

--- a/code/game/gamemodes/blob/blob_report.dm
+++ b/code/game/gamemodes/blob/blob_report.dm
@@ -46,7 +46,7 @@
 		comm.messagetext.Add(intercepttext)
 		if(!(comm.stat & (BROKEN | NOPOWER)) && comm.prints_intercept)
 			var/obj/item/weapon/paper/intercept = new /obj/item/weapon/paper( comm.loc )
-			playsound(comm.loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+			playsound(comm.loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 			intercept.name = "Classified Central Command Update"
 			intercept.info = intercepttext
 	event_announcement.Announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -245,7 +245,7 @@
 		var/timer = shuttle_master.emergency.timeLeft(1) + cursetime
 		shuttle_master.emergency.setTimer(timer)
 		to_chat(user,"<span class='danger'>You shatter the orb! A dark essence spirals into the air, then disappears.</span>")
-		playsound(user.loc, "sound/effects/Glassbr1.ogg", 50, 1)
+		playsound(user.loc, 'sound/effects/Glassbr1.ogg', 50, 1)
 		qdel(src)
 		sleep(20)
 		var/global/list/curses

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -41,7 +41,7 @@
 	name = "disintegrating touch"
 	desc = "This hand of mine glows with an awesome power!"
 	catchphrase = "EI NATH!!"
-	on_use_sound = "sound/magic/Disintegrate.ogg"
+	on_use_sound = 'sound/magic/Disintegrate.ogg'
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
 
@@ -59,7 +59,7 @@
 	name = "petrifying touch"
 	desc = "That's the bottom line, because flesh to stone said so!"
 	catchphrase = "STAUN EI!!"
-	on_use_sound = "sound/magic/FleshToStone.ogg"
+	on_use_sound = 'sound/magic/FleshToStone.ogg'
 	icon_state = "fleshtostone"
 	item_state = "fleshtostone"
 
@@ -78,7 +78,7 @@
 	name = "toy plastic hand"
 	desc = "This hand of mine glows with an awesome power! Ok, maybe just batteries."
 	catchphrase = "EI NATH!!"
-	on_use_sound = "sound/magic/Disintegrate.ogg"
+	on_use_sound = 'sound/magic/Disintegrate.ogg'
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
 
@@ -95,7 +95,7 @@
 	name = "cluwne touch"
 	desc = "It's time to start clowning around."
 	catchphrase = "NWOLC EGNEVER"
-	on_use_sound = "sound/misc/sadtrombone.ogg"
+	on_use_sound = 'sound/misc/sadtrombone.ogg'
 	icon_state = "cluwnecurse"
 	item_state = "cluwnecurse"
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -473,7 +473,7 @@
 			printing = 1
 			visible_message("<span class='notice'>\The [src] rattles and prints out a sheet of paper.</span>")
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(loc)
-			playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+			playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 			P.info = "<CENTER><B>Body Scan - [href_list["name"]]</B></CENTER><BR>"
 			P.info += "<b>Time of scan:</b> [worldtime2text(world.time)]<br><br>"
 			P.info += "[printing_text]"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -137,7 +137,7 @@
 				user.visible_message("[user] begins to load \the [O] in \the [src]...",
 					"You begin to load a design from \the [O]...",
 					"You hear the chatter of a floppy drive.")
-				playsound(get_turf(src), "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+				playsound(get_turf(src), 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 				busy = 1
 				if(do_after(user, 14.4, target = src))
 					files.AddDesign2Known(D.blueprint)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -362,7 +362,7 @@ var/time_last_changed_position = 0
 		if("print")
 			if(!printing)
 				printing = 1
-				playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+				playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 				spawn(50)
 					printing = null
 					nanomanager.update_uis(src)

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -465,7 +465,7 @@
 			if(href_list["print_p"])
 				if(!( src.printing ))
 					src.printing = 1
-					playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+					playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 					sleep(50)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( src.loc )
 					P.info = "<CENTER><B>Medical Record</B></CENTER><BR>"

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -63,7 +63,7 @@
 			src.spark_system.start()
 			var/obj/item/weapon/paper/monitorkey/MK = new/obj/item/weapon/paper/monitorkey
 			MK.loc = src.loc
-			playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+			playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 			// Will help make emagging the console not so easy to get away with.
 			MK.info += "<br><br><font color='red'>£%@%(*$%&(£&?*(%&£/{}</font>"
 			update_icon()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -318,7 +318,7 @@ What a mess.*/
 			if("Print Record")
 				if(!( printing ))
 					printing = 1
-					playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+					playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 					sleep(50)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( loc )
 					P.info = "<CENTER><B>Security Record</B></CENTER><BR>"
@@ -341,7 +341,7 @@ What a mess.*/
 			if("Print Photo")
 				if(!printing)
 					printing = 1
-					playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+					playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 					sleep(50)
 					if(istype(active1, /datum/data/record) && data_core.general.Find(active1))
 						create_record_photo(active1)

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -253,7 +253,7 @@ What a mess.*/
 			if("Print Record")
 				if(!( printing ))
 					printing = 1
-					playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+					playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 					sleep(50)
 					var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( loc )
 					P.info = "<CENTER><B>Employment Record</B></CENTER><BR>"

--- a/code/game/machinery/guestpass.dm
+++ b/code/game/machinery/guestpass.dm
@@ -159,7 +159,7 @@
 //				to_chat(usr, "Printing the log, standby...")
 				//sleep(50)
 				var/obj/item/weapon/paper/P = new/obj/item/weapon/paper( loc )
-				playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+				playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 				P.name = "activity log"
 				P.info = dat
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -237,7 +237,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine/silenced
 	name = "\improper S.H.H. \"Quietus\" Carbine"
-	fire_sound = "sound/weapons/Gunshot_silenced.ogg"
+	fire_sound = 'sound/weapons/Gunshot_silenced.ogg'
 	icon_state = "mecha_mime"
 	equip_cooldown = 15
 	projectile = /obj/item/projectile/bullet/mime

--- a/code/game/objects/items/devices/autopsy.dm
+++ b/code/game/objects/items/devices/autopsy.dm
@@ -151,7 +151,7 @@
 	for(var/mob/O in viewers(usr))
 		O.show_message("\red \the [src] rattles and prints out a sheet of paper.", 1)
 
-	playsound(loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 	sleep(10)
 
 	var/obj/item/weapon/paper/P = new(usr.loc)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -231,7 +231,7 @@
 		return
 
 	to_chat(usr, "<span class='notice'>Transcript printed.</span>")
-	playsound(loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 	var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(get_turf(src))
 	var/t1 = "<B>Transcript:</B><BR><BR>"
 	for(var/i = 1, mytape.storedinfo.len >= i, i++)

--- a/code/game/objects/items/weapons/scissors.dm
+++ b/code/game/objects/items/weapons/scissors.dm
@@ -78,7 +78,7 @@
 			species_hair = hair_styles_list
 		var/h_new_style = input(user, "Select a hair style", "Grooming")  as null|anything in species_hair
 		user.visible_message("<span class='notice'>[user] starts cutting [M]'s hair!</span>", "<span class='notice'>You start cutting [M]'s hair!</span>") //arguments for this are: 1. what others see 2. what the user sees. --Fixed grammar, (TGameCo)
-		playsound(loc, "sound/goonstation/misc/Scissor.ogg", 100, 1)
+		playsound(loc, 'sound/goonstation/misc/Scissor.ogg', 100, 1)
 		if(do_after(user, 50, target = H)) //this is the part that adds a delay. delay is in deciseconds. --Made it 5 seconds, because hair isn't cut in one second in real life, and I want at least a little bit longer time, (TGameCo)
 			if(!(M in view(1))) //Adjacency test
 				user.visible_message("<span class='notice'>[user] stops cutting [M]'s hair.</span>", "<span class='notice'>You stop cutting [M]'s hair.</span>")
@@ -111,9 +111,9 @@
 		if(!is_cutting)
 			is_cutting = 1
 			user.visible_message("<span class='notice'>[user] starts cutting [M]'s hair!</span>", "<span class='notice'>You start cutting [M]'s hair!</span>")
-			playsound(loc, "sound/goonstation/misc/Scissor.ogg", 100, 1)
+			playsound(loc, 'sound/goonstation/misc/Scissor.ogg', 100, 1)
 			if(do_after(user, 50, target = H))
-				playsound(loc, "sound/weapons/bladeslice.ogg", 50, 1, -1)
+				playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 				user.visible_message("<span class='danger'>[user] abruptly stops cutting [M]'s hair and slices their throat!</span>", "<span class='danger'>You stop cutting [M]'s hair and slice their throat!</span>") //Just a little off the top.
 				H.AdjustLoseBreath(10) //30 Oxy damage over time
 				H.apply_damage(18, BRUTE, "head", sharp =1, edge =1, used_weapon = "scissors")

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -13,7 +13,7 @@
 	materials = list(MAT_METAL = 500)
 	origin_tech = "combat=1"
 	attack_verb = list("robusted")
-	hitsound = "sound/weapons/smash.ogg"
+	hitsound = 'sound/weapons/smash.ogg'
 
 	New()
 		..()

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -101,7 +101,7 @@
 	materials = list(MAT_METAL=80)
 	origin_tech = "materials=1;engineering=1"
 	attack_verb = list("pinched", "nipped")
-	hitsound = "sound/items/Wirecutter.ogg"
+	hitsound = 'sound/items/Wirecutter.ogg'
 	sharp = 1
 	edge = 1
 

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -79,7 +79,7 @@
 	if(victim.buckled)
 		return 0
 	var/mob/living/H = victim
-	playsound(loc, "sound/effects/splat.ogg", 25, 1)
+	playsound(loc, 'sound/effects/splat.ogg', 25, 1)
 	H.forceMove(loc)
 	H.emote("scream")
 	if(istype(H, /mob/living/carbon/human)) //So you don't get human blood when you spike a giant spidere

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -383,7 +383,7 @@
 
 /obj/item/clothing/head/griffin/proc/caw()
 	if(cooldown < world.time - 20) // A cooldown, to stop people being jerks
-		playsound(src.loc, "sound/misc/caw.ogg", 50, 1)
+		playsound(src.loc, 'sound/misc/caw.ogg', 50, 1)
 		cooldown = world.time
 
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -184,7 +184,7 @@
 
 /obj/item/clothing/mask/gas/owl_mask/proc/hoot()
 	if(cooldown < world.time - 35) // A cooldown, to stop people being jerks
-		playsound(src.loc, "sound/misc/hoot.ogg", 50, 1)
+		playsound(src.loc, 'sound/misc/hoot.ogg', 50, 1)
 		cooldown = world.time
 
 // ********************************************************************

--- a/code/modules/detective_work/scanner.dm
+++ b/code/modules/detective_work/scanner.dm
@@ -66,7 +66,7 @@
 	if(log.len && !scanning)
 		scanning = 1
 		to_chat(usr, "<span class='notice'>Printing report, please wait...</span>")
-		playsound(loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+		playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 		spawn(100)
 
 			// Create our paper

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -335,7 +335,7 @@ log transactions
 						to_chat(usr, "<span class='notice'>The [src.name] flashes an error on its display.</span>")
 						return
 					lastprint = world.timeofday
-					playsound(loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+					playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 					var/obj/item/weapon/paper/R = new(src.loc)
 					R.name = "Account balance: [authenticated_account.owner_name]"
 					R.info = {"<b>NT Automated Teller Account Statement</b><br><br>

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -89,7 +89,7 @@ var/global/list/all_money_accounts = list()
 		var/obj/item/smallDelivery/P = new /obj/item/smallDelivery(source_db.loc)
 
 		var/obj/item/weapon/paper/R = new /obj/item/weapon/paper(P)
-		playsound(source_db.loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+		playsound(source_db.loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 		P.wrapped = R
 		R.name = "Account information: [M.owner_name]"
 

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -220,7 +220,7 @@
 
 			if("print")
 				var/text
-				playsound(loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+				playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 				var/obj/item/weapon/paper/P = new(loc)
 				if(detailed_account_view)
 					P.name = "account #[detailed_account_view.account_number] details"

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -26,7 +26,7 @@
 	linked_account = station_account
 
 /obj/item/device/eftpos/proc/print_reference()
-	playsound(loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 	var/obj/item/weapon/paper/R = new(src.loc)
 	R.name = "Reference: [eftpos_name]"
 

--- a/code/modules/economy/POS.dm
+++ b/code/modules/economy/POS.dm
@@ -201,7 +201,7 @@ var/const/POS_HEADER = {"<html>
 		</tr>"}
 	receipt += "</table></body></html>"
 
-	playsound(loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 	var/obj/item/weapon/paper/P = new(loc)
 	P.name="Receipt #[id]-[++sales]"
 	P.info=receipt

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -174,7 +174,7 @@
 			"<span class='userdanger'>The [source] arc flashes and electrocutes you!</span>", \
 			"<span class='italics'>You hear a lightning-like crack!</span>" \
 		)
-		playsound(loc, "sound/effects/eleczap.ogg", 50, 1, -1)
+		playsound(loc, 'sound/effects/eleczap.ogg', 50, 1, -1)
 		explosion(src.loc,-1,0,2,2)
 	if(override)
 		return override

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -221,7 +221,7 @@ var/list/alldepartments = list()
 
 	flick("faxreceive", src)
 
-	playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+	playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 
 	// give the sprite some time to flick
 	sleep(20)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -51,7 +51,7 @@
 		if(stat & (BROKEN|NOPOWER))
 			return
 
-		playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+		playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 		for(var/i = 0, i < copies, i++)
 			if(toner <= 0)
 				break
@@ -111,7 +111,7 @@
 			if(!selection)
 				return
 
-			playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+			playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 			var/obj/item/weapon/photo/p = new /obj/item/weapon/photo (src.loc)
 			p.construct(selection)
 			if(p.desc == "")

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -122,7 +122,7 @@
 	projectile_type = /obj/item/projectile/beam/disabler
 	select_name  = "disable"
 	e_cost = 500
-	fire_sound = "sound/weapons/taser2.ogg"
+	fire_sound = 'sound/weapons/taser2.ogg'
 
 /obj/item/ammo_casing/energy/plasma
 	projectile_type = /obj/item/projectile/plasma
@@ -139,7 +139,7 @@
 /obj/item/ammo_casing/energy/wormhole
 	projectile_type = /obj/item/projectile/beam/wormhole
 	e_cost = 0
-	fire_sound = "sound/weapons/pulse3.ogg"
+	fire_sound = 'sound/weapons/pulse3.ogg'
 	var/obj/item/weapon/gun/energy/wormhole_projector/gun = null
 	select_name = "blue"
 
@@ -193,7 +193,7 @@
 
 /obj/item/ammo_casing/energy/toxplasma
 	projectile_type = /obj/item/projectile/energy/toxplasma
-	fire_sound = "sound/weapons/taser2.ogg"
+	fire_sound = 'sound/weapons/taser2.ogg'
 	select_name = "plasma dart"
 
 /obj/item/ammo_casing/energy/clown

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -8,7 +8,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/change
 	icon_state = "staffofchange"
 	item_state = "staffofchange"
-	fire_sound = "sound/magic/Staff_Change.ogg"
+	fire_sound = 'sound/magic/Staff_Change.ogg'
 
 /obj/item/weapon/gun/magic/staff/animate
 	name = "staff of animation"
@@ -16,7 +16,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/animate
 	icon_state = "staffofanimation"
 	item_state = "staffofanimation"
-	fire_sound = "sound/magic/Staff_animation.ogg"
+	fire_sound = 'sound/magic/Staff_animation.ogg'
 
 /obj/item/weapon/gun/magic/staff/healing
 	name = "staff of healing"
@@ -24,7 +24,7 @@
 	ammo_type = /obj/item/ammo_casing/magic/heal
 	icon_state = "staffofhealing"
 	item_state = "staffofhealing"
-	fire_sound = "sound/magic/Staff_Healing.ogg"
+	fire_sound = 'sound/magic/Staff_Healing.ogg'
 
 /obj/item/weapon/gun/magic/staff/healing/handle_suicide() //Stops people trying to commit suicide to heal themselves
 	return
@@ -38,7 +38,7 @@
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
-	fire_sound = "sound/magic/Staff_Chaos.ogg"
+	fire_sound = 'sound/magic/Staff_Chaos.ogg'
 
 /obj/item/weapon/gun/magic/staff/door
 	name = "staff of door creation"
@@ -49,7 +49,7 @@
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
-	fire_sound = "sound/magic/Staff_Door.ogg"
+	fire_sound = 'sound/magic/Staff_Door.ogg'
 
 /obj/item/weapon/gun/magic/staff/honk
 	name = "staff of the honkmother"
@@ -59,7 +59,7 @@
 	item_state = "honker"
 	max_charges = 4
 	recharge_rate = 8
-	fire_sound = "sound/items/airhorn.ogg"
+	fire_sound = 'sound/items/airhorn.ogg'
 
 /obj/item/weapon/gun/magic/staff/focus
 	name = "mental focus"
@@ -72,7 +72,7 @@
 /obj/item/weapon/gun/magic/staff/spellblade
 	name = "spellblade"
 	desc = "A deadly combination of laziness and boodlust, this blade allows the user to dismember their enemies without all the hard work of actually swinging the sword."
-	fire_sound = "sound/magic/Fireball.ogg"
+	fire_sound = 'sound/magic/Fireball.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/spellblade
 	icon_state = "spellblade"
 	item_state = "spellblade"

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -59,7 +59,7 @@
 /obj/item/weapon/gun/magic/wand/death
 	name = "wand of death"
 	desc = "This deadly wand overwhelms the victim's body with pure energy, slaying them without fail."
-	fire_sound = "sound/magic/WandoDeath.ogg"
+	fire_sound = 'sound/magic/WandoDeath.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/death
 	icon_state = "deathwand"
 	max_charges = 3 //3, 2, 2, 1
@@ -80,7 +80,7 @@
 	name = "wand of resurrection"
 	desc = "This wand uses healing magics to heal and revive. They are rarely utilized within the Wizard Federation for some reason."
 	ammo_type = /obj/item/ammo_casing/magic/heal
-	fire_sound = "sound/magic/Staff_Healing.ogg"
+	fire_sound = 'sound/magic/Staff_Healing.ogg'
 	icon_state = "revivewand"
 	max_charges = 3 //3, 2, 2, 1
 
@@ -98,7 +98,7 @@
 	name = "wand of polymorph"
 	desc = "This wand is attuned to chaos and will radically alter the victim's form."
 	ammo_type = /obj/item/ammo_casing/magic/change
-	fire_sound = "sound/magic/Staff_Change.ogg"
+	fire_sound = 'sound/magic/Staff_Change.ogg'
 	icon_state = "polywand"
 	max_charges = 10 //10, 5, 5, 4
 
@@ -118,7 +118,7 @@
 	icon_state = "telewand"
 	max_charges = 10 //10, 5, 5, 4
 	no_den_usage = 1
-	fire_sound = "sound/magic/Wand_Teleport.ogg"
+	fire_sound = 'sound/magic/Wand_Teleport.ogg'
 
 /obj/item/weapon/gun/magic/wand/teleport/zap_self(mob/living/user)
 	do_teleport(user, user, 10)
@@ -136,7 +136,7 @@
 	name = "wand of door creation"
 	desc = "This particular wand can create doors in any wall for the unscrupulous wizard who shuns teleportation magics."
 	ammo_type = /obj/item/ammo_casing/magic/door
-	fire_sound = "sound/magic/Staff_Door.ogg"
+	fire_sound = 'sound/magic/Staff_Door.ogg'
 	icon_state = "doorwand"
 	max_charges = 20 //20, 10, 10, 7
 
@@ -152,7 +152,7 @@
 /obj/item/weapon/gun/magic/wand/fireball
 	name = "wand of fireball"
 	desc = "This wand shoots scorching balls of fire that explode into destructive flames."
-	fire_sound = "sound/magic/Fireball.ogg"
+	fire_sound = 'sound/magic/Fireball.ogg'
 	ammo_type = /obj/item/ammo_casing/magic/fireball
 	icon_state = "firewand"
 	max_charges = 8 //8, 4, 4, 3

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -96,7 +96,7 @@
 		if(!(printing))
 			printing = 1
 			visible_message("<span class='notice'>[src] rattles and prints out a sheet of paper.</span>")
-			playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+			playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(loc)
 			P.info = "<CENTER><B>Chemical Analysis</B></CENTER><BR>"
 			P.info += "<b>Time of analysis:</b> [worldtime2text(world.time)]<br><br>"

--- a/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
+++ b/code/modules/research/xenoarchaeology/machinery/artifact_analyser.dm
@@ -73,7 +73,7 @@
 			results = get_scan_info(scanned_object)
 
 		src.visible_message("<b>[name]</b> states, \"Scanning complete.\"")
-		playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+		playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 		var/obj/item/weapon/paper/P = new(src.loc)
 		P.name = "[src] report #[++report_num]"
 		P.info = "<b>[src] analysis report #[report_num]</b><br>"

--- a/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
+++ b/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
@@ -257,7 +257,7 @@
 
 	if(scanned_item)
 		//create report
-		playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+		playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 		var/obj/item/weapon/paper/P = new(src)
 		P.name = "[src] report #[++report_num]: [scanned_item.name]"
 		P.stamped = list(/obj/item/weapon/stamp)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -295,7 +295,7 @@
 		return
 
 	var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(_loc)
-	playsound(_loc, "sound/goonstation/machines/printer_thermal.ogg", 50, 1)
+	playsound(_loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 	reqform.name = "Requisition Form - [crates] '[object.name]' for [orderedby]"
 	reqform.info += "<h3>[station_name] Supply Requisition Form</h3><hr>"
 	reqform.info += "INDEX: #[shuttle_master.ordernum]<br>"

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -91,7 +91,7 @@
 	icon_state = "weapon_taser"
 	projectile_type = "/obj/item/projectile/beam/disabler"
 	shot_cost = 400
-	fire_sound = "sound/weapons/Taser.ogg"
+	fire_sound = 'sound/weapons/Taser.ogg'
 
 /obj/item/device/spacepod_equipment/weaponry/burst_taser
 	name = "burst taser system"
@@ -100,7 +100,7 @@
 	projectile_type = "/obj/item/projectile/beam/disabler"
 	shot_cost = 1200
 	shots_per = 3
-	fire_sound = "sound/weapons/Taser.ogg"
+	fire_sound = 'sound/weapons/Taser.ogg'
 	fire_delay = 30
 
 /obj/item/device/spacepod_equipment/weaponry/laser

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -433,7 +433,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 	//HONK
 	else if((findtext(message, honk_words)))
 		spawn(25)
-			playsound(get_turf(owner), "sound/items/bikehorn.ogg", 300, 1)
+			playsound(get_turf(owner), 'sound/items/bikehorn.ogg', 300, 1)
 		if(owner.mind && owner.mind.assigned_role == "Clown")
 			for(var/mob/living/carbon/C in listeners)
 				C.slip(0,7 * power_multiplier)


### PR DESCRIPTION
Some sound files are double-quoted (which loads them as a file at runtime) instead of single-quoted (which loads them into the resource cache during compilation). The latter is preferred, as it cuts down on in-game file caching and sanity-checks sound file names during compilation.

Some sounds (instrument and compli-o-nator sounds) use embedded text expressions to build the filename; since these would require actual code changes to properly pre-cache all of their sounds, I've left them alone.