### PR TITLE
Add [OPEN] option for AI in radio messages

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -37,3 +37,12 @@
 			return
 
 	. = src.emote_dead(message)
+
+/mob/dead/observer/handle_track(var/message, var/verb = "says", var/datum/language/language, var/mob/speaker = null, var/speaker_name, var/atom/follow_target, var/hard_to_hear)
+	return "[speaker_name] ([ghost_follow_link(follow_target, ghost=src)])"
+
+/mob/dead/observer/handle_speaker_name(var/mob/speaker = null, var/vname, var/hard_to_hear)
+	var/speaker_name = ..()
+	if(speaker && (speaker_name != speaker.real_name) && !isAI(speaker)) //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
+		speaker_name = "[speaker.real_name] ([speaker_name])"
+	return speaker_name

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -117,65 +117,8 @@
 	if(hard_to_hear)
 		message = stars(message)
 
-	var/speaker_name = "unknown"
-	if(speaker)
-		speaker_name = speaker.name
-
-	if(vname)
-		speaker_name = vname
-	if(hard_to_hear)
-		speaker_name = "unknown"
-
-	var/changed_voice
-
-	if(isAI(src) && !hard_to_hear)
-		var/jobname // the mob's "job"
-		var/mob/living/carbon/human/impersonating //The crewmember being impersonated, if any.
-
-		if(ishuman(speaker))
-			var/mob/living/carbon/human/H = speaker
-
-			var/obj/item/weapon/card/id/id = H.wear_id
-			if((istype(id) && id.is_untrackable()) && H.HasVoiceChanger())
-				changed_voice = 1
-				var/mob/living/carbon/human/I = locate(speaker_name)
-				if(I)
-					impersonating = I
-					jobname = impersonating.get_assignment()
-				else
-					jobname = "Unknown"
-			else
-				jobname = H.get_assignment()
-
-		else if(iscarbon(speaker)) // Nonhuman carbon mob
-			jobname = "No ID"
-		else if(isAI(speaker))
-			jobname = "AI"
-		else if(isrobot(speaker))
-			jobname = "Cyborg"
-		else if(ispAI(speaker))
-			jobname = "Personal AI"
-		else if(isAutoAnnouncer(speaker))
-			var/mob/living/automatedannouncer/AA = speaker
-			jobname = AA.role
-		else
-			jobname = "Unknown"
-
-		if(changed_voice)
-			if(impersonating)
-				track = "<a href='byond://?src=[UID()];track=\ref[impersonating]'>[speaker_name] ([jobname])</a>"
-			else
-				track = "[speaker_name] ([jobname])"
-		else
-			if(istype(follow_target, /mob/living/simple_animal/bot))
-				track = "<a href='byond://?src=[UID()];trackbot=\ref[follow_target]'>[speaker_name] ([jobname])</a>"
-			else
-				track = "<a href='byond://?src=[UID()];track=\ref[speaker]'>[speaker_name] ([jobname])</a>"
-
-	if(isobserver(src))
-		if(speaker && (speaker_name != speaker.real_name) && !isAI(speaker)) //Announce computer and various stuff that broadcasts doesn't use it's real name but AI's can't pretend to be other mobs.
-			speaker_name = "[speaker.real_name] ([speaker_name])"
-		track = "[speaker_name] ([ghost_follow_link(follow_target, ghost=src)])"
+	var/speaker_name = handle_speaker_name(speaker, vname, hard_to_hear)
+	track = handle_track(message, verb, language, speaker, speaker_name, follow_target, hard_to_hear)
 
 	var/formatted
 	if(language)
@@ -189,6 +132,22 @@
 		to_chat(src, "[part_a][track][part_b][formatted]</span></span>")
 	else
 		to_chat(src, "[part_a][speaker_name][part_b][formatted]</span></span>")
+
+/mob/proc/handle_speaker_name(var/mob/speaker = null, var/vname, var/hard_to_hear)
+	var/speaker_name = "unknown"
+	if(speaker)
+		speaker_name = speaker.name
+
+	if(vname)
+		speaker_name = vname
+
+	if(hard_to_hear)
+		speaker_name = "unknown"
+
+	return speaker_name
+
+/mob/proc/handle_track(var/message, var/verb = "says", var/datum/language/language, var/mob/speaker = null, var/speaker_name, var/atom/follow_target, var/hard_to_hear)
+	return
 
 /mob/proc/hear_signlang(var/message, var/verb = "gestures", var/datum/language/language, var/mob/speaker = null)
 	if(!client)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -1,3 +1,70 @@
+/*
+ * AI Saycode
+ */
+
+
+/mob/living/silicon/ai/handle_track(var/message, var/verb = "says", var/datum/language/language, var/mob/speaker = null, var/speaker_name, var/atom/follow_target, var/hard_to_hear)
+	if(hard_to_hear)
+		return
+
+	var/jobname // the mob's "job"
+	var/mob/living/carbon/human/impersonating //The crewmember being impersonated, if any.
+	var/changed_voice
+
+	if(ishuman(speaker))
+		var/mob/living/carbon/human/H = speaker
+
+		var/obj/item/weapon/card/id/id = H.wear_id
+		if((istype(id) && id.is_untrackable()) && H.HasVoiceChanger())
+			changed_voice = 1
+			var/mob/living/carbon/human/I = locate(speaker_name)
+			if(I)
+				impersonating = I
+				jobname = impersonating.get_assignment()
+			else
+				jobname = "Unknown"
+		else
+			jobname = H.get_assignment()
+
+	else if(iscarbon(speaker)) // Nonhuman carbon mob
+		jobname = "No ID"
+	else if(isAI(speaker))
+		jobname = "AI"
+	else if(isrobot(speaker))
+		jobname = "Cyborg"
+	else if(ispAI(speaker))
+		jobname = "Personal AI"
+	else if(isAutoAnnouncer(speaker))
+		var/mob/living/automatedannouncer/AA = speaker
+		jobname = AA.role
+	else
+		jobname = "Unknown"
+
+	var/track = ""
+	var/mob/mob_to_track = null
+	if(changed_voice)
+		if(impersonating)
+			mob_to_track = impersonating
+		else
+			track = "[speaker_name] ([jobname])"
+	else
+		if(istype(follow_target, /mob/living/simple_animal/bot))
+			track = "<a href='byond://?src=[UID()];trackbot=\ref[follow_target]'>[speaker_name] ([jobname])</a>"
+		else
+			mob_to_track = speaker
+
+	if(mob_to_track)
+		track = "<a href='byond://?src=[UID()];track=\ref[mob_to_track]'>[speaker_name] ([jobname])</a>"
+		track += "<a href='byond://?src=[UID()];open=\ref[mob_to_track]'>\[OPEN\]</a>"
+
+	return track
+
+
+
+/*
+ * AI VOX Announcements
+ */
+
 var/announcing_vox = 0 // Stores the time of the last announcement
 var/const/VOX_CHANNEL = 200
 var/const/VOX_DELAY = 100


### PR DESCRIPTION
Also mildly refactors hear_radio to kill those nasty istype(src)'s.

This makes an [OPEN] link appear on all radio messages the AI hears (to
the right of the follow link). When clicked, it allows the AI to open
the door nearest to the speaker (or, if it is a voice changer, the door
nearest to the poor sap who had his voice stolen)
![https://i.imgur.com/SOGiIMX.png](https://i.imgur.com/SOGiIMX.png)
:cl:
rscadd: The AI has a button next to radio messages to open the door closest to the speaker. ;AI, Open this fucking door!
/:cl: