### PR TITLE
`light_sources` runtime now mentions the culprit source atom

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -66,7 +66,10 @@
 	destroyed = TRUE
 	force_update()
 	if(source_atom)
-		source_atom.light_sources -= src
+		if(!source_atom.light_sources)
+			log_runtime(EXCEPTION("Atom [source_atom] was a light source, but lacked a light source list!\n"), source_atom)
+		else
+			source_atom.light_sources -= src
 
 	if(top_atom)
 		top_atom.light_sources    -= src


### PR DESCRIPTION
No cl, not visible to players