### PR TITLE
Vox Nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -257,12 +257,12 @@
 	smell.<br/><br/>Most humans will never meet a Vox raider, instead learning of this insular species through \
 	dealing with their traders and merchants; those that do rarely enjoy the experience."
 
-	warning_low_pressure = 50
-	hazard_low_pressure = 0
+	warning_low_pressure = (WARNING_LOW_PRESSURE-20)
+	hazard_low_pressure =  (HAZARD_LOW_PRESSURE-10)
 
-	cold_level_1 = 80
-	cold_level_2 = 50
-	cold_level_3 = 0
+	cold_level_1 = 160
+	cold_level_2 = 130
+	cold_level_3 = 90
 
 	atmos_requirements = list(
 		"min_oxy" = 0,


### PR DESCRIPTION
Vox now take low pressure (brute) and low temperature damage (burn) when going into space without a spacesuit. They don't take as much burn damage as humans though.
An alternative nerf I was thinking of was leaving pressure unchanged, but applying ```burn_mod = 1.4``` to them. Vox are too good, their only disadvantage is NO_SCAN: if you're an antag you're not getting cloned anyway, and if non-antag will get SR'd. Everyone else has to fear depressurization (except plasmamen, diona which are shitty to play) while for Vox it's a non-issue.

:cl:
tweak: Vox are no longer immune to low pressure and low temperature damage.
/:cl: