### PR TITLE
Weakens Vox Bones

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -319,6 +319,20 @@
 		"stack" =    /obj/item/organ/internal/stack/vox //Not the same as the cortical stack implant Vox Raiders spawn with. The cortical stack implant is used
 		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.
 
+	has_limbs = list(
+		"chest" =  list("path" = /obj/item/organ/external/chest/vox),
+		"groin" =  list("path" = /obj/item/organ/external/groin/vox),
+		"head" =   list("path" = /obj/item/organ/external/head/vox),
+		"l_arm" =  list("path" = /obj/item/organ/external/arm/vox),
+		"r_arm" =  list("path" = /obj/item/organ/external/arm/right/vox),
+		"l_leg" =  list("path" = /obj/item/organ/external/leg/vox),
+		"r_leg" =  list("path" = /obj/item/organ/external/leg/right/vox),
+		"l_hand" = list("path" = /obj/item/organ/external/hand/vox),
+		"r_hand" = list("path" = /obj/item/organ/external/hand/right/vox),
+		"l_foot" = list("path" = /obj/item/organ/external/foot/vox),
+		"r_foot" = list("path" = /obj/item/organ/external/foot/right/vox)
+		)
+
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
 		"is jamming their claws into their eye sockets!",
@@ -443,6 +457,20 @@
 		"eyes" =     /obj/item/organ/internal/eyes, //Default darksight of 2.
 		"stack" =    /obj/item/organ/internal/stack/vox //Not the same as the cortical stack implant Vox Raiders spawn with. The cortical stack implant is used
 		)												//for determining the success of the heist game-mode's 'leave nobody behind' objective, while this is just an organ.
+
+	has_limbs = list(
+		"chest" =  list("path" = /obj/item/organ/external/chest),
+		"groin" =  list("path" = /obj/item/organ/external/groin),
+		"head" =   list("path" = /obj/item/organ/external/head),
+		"l_arm" =  list("path" = /obj/item/organ/external/arm),
+		"r_arm" =  list("path" = /obj/item/organ/external/arm/right),
+		"l_leg" =  list("path" = /obj/item/organ/external/leg),
+		"r_leg" =  list("path" = /obj/item/organ/external/leg/right),
+		"l_hand" = list("path" = /obj/item/organ/external/hand),
+		"r_hand" = list("path" = /obj/item/organ/external/hand/right),
+		"l_foot" = list("path" = /obj/item/organ/external/foot),
+		"r_foot" = list("path" = /obj/item/organ/external/foot/right)
+		)
 
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",

--- a/code/modules/surgery/organs/subtypes/vox.dm
+++ b/code/modules/surgery/organs/subtypes/vox.dm
@@ -1,3 +1,47 @@
 /obj/item/organ/internal/liver/vox
 	alcohol_intensity = 1.6
 	species = "Vox"
+
+/obj/item/organ/external/chest/vox
+	min_broken_damage = 29.5
+	species = "Vox"
+
+/obj/item/organ/external/groin/vox
+	min_broken_damage = 29.5
+	species = "Vox"
+
+/obj/item/organ/external/head/vox
+	min_broken_damage = 29.5
+	species = "Vox"
+
+/obj/item/organ/external/arm/vox
+	min_broken_damage = 25
+	species = "Vox"
+
+/obj/item/organ/external/arm/right/vox
+	min_broken_damage = 25
+	species = "Vox"
+
+/obj/item/organ/external/leg/vox
+	min_broken_damage = 25
+	species = "Vox"
+
+/obj/item/organ/external/leg/right/vox
+	min_broken_damage = 25
+	species = "Vox"
+
+/obj/item/organ/external/hand/vox
+	min_broken_damage = 12.5
+	species = "Vox"
+
+/obj/item/organ/external/hand/right/vox
+	min_broken_damage = 12.5
+	species = "Vox"
+
+/obj/item/organ/external/foot/vox
+	min_broken_damage = 12.5
+	species = "Vox"
+
+/obj/item/organ/external/foot/right/vox
+	min_broken_damage = 12.5
+	species = "Vox"

--- a/code/modules/surgery/organs/subtypes/vox.dm
+++ b/code/modules/surgery/organs/subtypes/vox.dm
@@ -3,15 +3,15 @@
 	species = "Vox"
 
 /obj/item/organ/external/chest/vox
-	min_broken_damage = 29.5
+	min_broken_damage = 29
 	species = "Vox"
 
 /obj/item/organ/external/groin/vox
-	min_broken_damage = 29.5
+	min_broken_damage = 29
 	species = "Vox"
 
 /obj/item/organ/external/head/vox
-	min_broken_damage = 29.5
+	min_broken_damage = 29
 	species = "Vox"
 
 /obj/item/organ/external/arm/vox
@@ -31,17 +31,17 @@
 	species = "Vox"
 
 /obj/item/organ/external/hand/vox
-	min_broken_damage = 12.5
+	min_broken_damage = 12
 	species = "Vox"
 
 /obj/item/organ/external/hand/right/vox
-	min_broken_damage = 12.5
+	min_broken_damage = 12
 	species = "Vox"
 
 /obj/item/organ/external/foot/vox
-	min_broken_damage = 12.5
+	min_broken_damage = 12
 	species = "Vox"
 
 /obj/item/organ/external/foot/right/vox
-	min_broken_damage = 12.5
+	min_broken_damage = 12
 	species = "Vox"


### PR DESCRIPTION
**As per [the Vox wiki](https://nanotrasen.se/wiki/index.php/Vox).**
"_The Vox skeletal structure is unique with its light, porous, and flexible bones_" which, although granting 'enhanced flexibility, reduced weight and increased agility (tm)', would also mean the bones are also less resilient to damage.

This just makes it such that Vox bones break easier, i.e. 3 toolbox hits vs. 4 to the 'core' (head, chest, groin).
Rather than straight removing a pivotal feature of the race such as space resistance.
This does not mean Vox take more damage, just that it takes less damage to break their bones.

Might encourage players to avoid prolonged fights and choose to flee, as Vox should.

I was going to hold this for further testing and balance tweaks but was prompted to release it earlier than expected by another PR.

I had to redefine the limbs for Vox Armalis because as a child of the Vox species they'd inherit the weaker bones, which is an unintended side-effect. Vox Armalis are no different as a result of this PR due to this.

:cl:
tweak: Vox bones, being light, porous and flexible will break at a slightly lower damage threshold than those of other species.
/:cl: