### PR TITLE
Strange Reagent is now Riskier

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -628,7 +628,7 @@
 	if(iscarbon(M))
 		if(method == INGEST)
 			if(M.stat == DEAD)
-				if(M.getBruteLoss()+M.getFireLoss() >= 150)
+				if(M.getBruteLoss()+M.getFireLoss() >= 150 || prob(10))
 					M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
 					M.gib()
 					return

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -648,6 +648,21 @@
 					M.adjustBruteLoss(rand(0,15))
 					M.adjustToxLoss(rand(0,15))
 					M.adjustFireLoss(rand(0,15))
+					if(ishuman(M) && M.mind && prob(10)) // To prevent people from using this on monkies to cause pandemics
+						var/mob/living/carbon/human/H = M
+						// Their body is being suffused with magical life-inducing stuff - so other things get lively, too
+						// Things are going to get interesting for the reviving party, too
+						var/virus_type = pick(list(
+							/datum/disease/advance/flu,
+							/datum/disease/advance/cold,
+							/datum/disease/brainrot,
+							/datum/disease/magnitis,
+							/datum/disease/fake_gbs, // honk
+							/datum/disease/cold9
+						))
+						var/datum/disease/D = new virus_type()
+						H.AddDisease(D)
+
 					M.update_revive()
 					M.stat = UNCONSCIOUS
 					add_logs(M, M, "revived", object="strange reagent") //Yes, the logs say you revived yourself.

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -617,6 +617,9 @@
 	..()
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, volume)
+	if(volume < 1)
+		// gotta pay to play
+		return ..()
 	if(isanimal(M))
 		if(method == TOUCH)
 			var/mob/living/simple_animal/SM = M
@@ -628,10 +631,11 @@
 	if(iscarbon(M))
 		if(method == INGEST)
 			if(M.stat == DEAD)
-				if(M.getBruteLoss()+M.getFireLoss() >= 150 || prob(10))
+				if(M.getBruteLoss()+M.getFireLoss()+M.getCloneLoss() >= 150)
 					M.visible_message("<span class='warning'>[M]'s body starts convulsing!</span>")
 					M.gib()
 					return
+				M.adjustCloneLoss(50)
 				var/mob/dead/observer/ghost = M.get_ghost()
 				if(ghost)
 					to_chat(ghost, "<span class='ghostalert'>You are attempting to be revived with Strange Reagent. Return to your body if you want to be revived!</span> (Verbs -> Ghost -> Re-enter corpse)")

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -66,7 +66,7 @@ var/list/organ_cache = list()
 			blood_DNA = list()
 		blood_DNA[dna.unique_enzymes] = dna.b_type
 
-/obj/item/organ/proc/die()
+/obj/item/organ/proc/necrotize(update_sprite=TRUE)
 	if(status & ORGAN_ROBOT)
 		return
 	damage = max_damage
@@ -105,10 +105,10 @@ var/list/organ_cache = list()
 		if(germ_level >= INFECTION_LEVEL_TWO)
 			germ_level += rand(2,6)
 		if(germ_level >= INFECTION_LEVEL_THREE)
-			die()
+			necrotize()
 
 		if(damage >= max_damage)
-			die()
+			necrotize()
 
 	else if(owner.bodytemperature >= 170)	//cryo stops germs from moving and doing their bad stuffs
 		//** Handle antibiotics and curing infections
@@ -117,7 +117,7 @@ var/list/organ_cache = list()
 
 	//check if we've hit max_damage
 	if(damage >= max_damage)
-		die()
+		necrotize()
 
 /obj/item/organ/proc/is_preserved()
 	if(istype(loc,/obj/item/device/mmi))

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -68,6 +68,19 @@
 	var/can_stand
 	var/wound_cleanup_timer
 
+/obj/item/organ/external/necrotize(update_sprite=TRUE)
+	if(status & (ORGAN_ROBOT|ORGAN_DEAD))
+		return
+	to_chat(owner, "<span class='notice'>You can't feel your [name] anymore...</span>")
+	status |= ORGAN_DEAD
+	if(dead_icon)
+		icon_state = dead_icon
+	if(owner)
+		owner.update_body(update_sprite)
+		owner.bad_external_organs |= src
+		if(vital)
+			owner.death()
+
 /obj/item/organ/external/Destroy()
 	if(parent && parent.children)
 		parent.children -= src
@@ -541,10 +554,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 					parent.germ_level++
 
 	if(germ_level >= INFECTION_LEVEL_THREE && antibiotics < 30)	//overdosing is necessary to stop severe infections
-		if(!(status & ORGAN_DEAD))
-			status |= ORGAN_DEAD
-			to_chat(owner, "<span class='notice'>You can't feel your [name] anymore...</span>")
-			owner.update_body(1)
+		necrotize()
 
 		germ_level++
 		owner.adjustToxLoss(1)


### PR DESCRIPTION
Strange reagent now has a volume floor of 1 unit per dose, does 50 cloneloss on use on a dead person, and has a 10% chance upon revival of giving the revived patient a disease.

Hopefully, this should push medical to either not let patients die, or stick to more constrained/difficult, yet less punishing means of revival, such as the defib, or botany.

:cl:Crazylemon
experiment: Strange reagent now has a volume floor requirement to activate, induces clone damage, and may cause further trouble...
/:cl: