### PR TITLE
Changes Biogenerator Belt Holster to Accessory Holster

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -184,7 +184,7 @@
 	id = "s_holster"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 400)
-	build_path = /obj/item/weapon/storage/belt/holster
+	build_path = /obj/item/clothing/accessory/holster
 	category = list("initial","Leather and Cloth")
 
 /datum/design/leather_satchel


### PR DESCRIPTION
This simply adjusts the currently available holster from the biogenerator from being the belt item (which can only hold sketckins (pistols) and the detective's revolver) to the accessory holster, which is the same one Blueshields get.

:cl:Twinmold
Adjust: Biogenerator holster from belt object to accessory holster.
/:cl: