### PR TITLE
BloodPack Tagging/Pen Labeling

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -1,11 +1,13 @@
 /obj/item/weapon/reagent_containers/blood
 	name = "BloodPack"
+	var/base_name = "BloodPack"
 	desc = "Contains blood used for transfusion."
 	icon = 'icons/obj/bloodpack.dmi'
 	icon_state = "empty"
 	volume = 200
 
 	var/blood_type = null
+	var/label_text = ""
 
 /obj/item/weapon/reagent_containers/blood/New()
 	..()
@@ -16,6 +18,7 @@
 
 /obj/item/weapon/reagent_containers/blood/on_reagent_change()
 	update_icon()
+	update_name_label()
 
 /obj/item/weapon/reagent_containers/blood/update_icon()
 	var/percent = round((reagents.total_volume / volume) * 100)
@@ -27,27 +30,55 @@
 		if(51 to INFINITY)
 			icon_state = "full"
 
+/obj/item/weapon/reagent_containers/blood/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/flashlight/pen))
+		var/tmp_label = sanitize(input(user, "Enter a label for [name]","Label",label_text))
+		if(length(tmp_label) > MAX_NAME_LEN)
+			to_chat(user, "<span class='warning'>The label can be at most [MAX_NAME_LEN] characters long.</span>")
+		else
+			to_chat(user, "<span class='notice'>You set the label to \"[tmp_label]\".</span>")
+			label_text = tmp_label
+			update_name_label()
+
+/obj/item/weapon/reagent_containers/blood/proc/update_name_label()
+	if(reagents.total_volume == 0)
+		base_name = "Empty BloodPack"
+		desc = "Seems pretty useless... Maybe if there were a way to fill it?"
+	else
+		base_name = "BloodPack"
+		desc = "Contains blood used for transfusion."
+	if(label_text == "")
+		name = base_name
+	else
+		name = "[base_name] ([label_text])"
+
 /obj/item/weapon/reagent_containers/blood/random/New()
 	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-")
 	..()
 
 /obj/item/weapon/reagent_containers/blood/APlus
 	blood_type = "A+"
+	label_text = "A+"
 
 /obj/item/weapon/reagent_containers/blood/AMinus
 	blood_type = "A-"
+	label_text = "A-"
 
 /obj/item/weapon/reagent_containers/blood/BPlus
 	blood_type = "B+"
+	label_text = "B+"
 
 /obj/item/weapon/reagent_containers/blood/BMinus
 	blood_type = "B-"
+	label_text = "B-"
 
 /obj/item/weapon/reagent_containers/blood/OPlus
 	blood_type = "O+"
+	label_text = "O+"
 
 /obj/item/weapon/reagent_containers/blood/OMinus
 	blood_type = "O-"
+	label_text = "O-"
 
 /obj/item/weapon/reagent_containers/blood/empty
 	name = "Empty BloodPack"


### PR DESCRIPTION
With this, you can now use a pen on a bloodpack and add a label to it, giving the ability to tag a bloodpack with the type of blood from donations. Bloodpacks will now switch between "empty" and notso in naming, depending on if there is reagent/blood inside or not.

:cl:Twinmold
Add: Ability to label bloodpacks with a pen, so you can now label a bloodpack from donations without a handlabeler.
Add: Bloodpacks will now change name to say if they are empty or not.
/:cl: