### PR TITLE
Adds checks to prevent runtime in playtime list if mob has no mind

### DIFF
--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -13,12 +13,13 @@
 	var/jtext
 	for(var/client/C in clients)
 		jtext = "No Job"
-		if(C.mob.mind.assigned_role)
-			theirjob = job_master.GetJob(C.mob.mind.assigned_role)
-			if(theirjob)
-				jtext = theirjob.title
-				if(config.use_exp_restrictions && theirjob.exp_requirements && theirjob.exp_type)
-					jtext += "<span class='warning'>*</span>"
+		if(C.mob.mind)
+			if(C.mob.mind.assigned_role)
+				theirjob = job_master.GetJob(C.mob.mind.assigned_role)
+				if(theirjob)
+					jtext = theirjob.title
+					if(config.use_exp_restrictions && theirjob.exp_requirements && theirjob.exp_type)
+						jtext += "<span class='warning'>*</span>"
 		if(check_rights(R_ADMIN))
 			pline = "<LI> [key_name_admin(C.mob)]: [jtext]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
 		else

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -13,13 +13,12 @@
 	var/jtext
 	for(var/client/C in clients)
 		jtext = "No Job"
-		if(C.mob.mind)
-			if(C.mob.mind.assigned_role)
-				theirjob = job_master.GetJob(C.mob.mind.assigned_role)
-				if(theirjob)
-					jtext = theirjob.title
-					if(config.use_exp_restrictions && theirjob.exp_requirements && theirjob.exp_type)
-						jtext += "<span class='warning'>*</span>"
+		if(C.mob.mind && C.mob.mind.assigned_role)
+			theirjob = job_master.GetJob(C.mob.mind.assigned_role)
+			if(theirjob)
+				jtext = theirjob.title
+				if(config.use_exp_restrictions && theirjob.exp_requirements && theirjob.exp_type)
+					jtext += "<span class='warning'>*</span>"
 		if(check_rights(R_ADMIN))
 			pline = "<LI> [key_name_admin(C.mob)]: [jtext]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
 		else


### PR DESCRIPTION
Currently, if you use 'Check Player Playtime' before roundstart, you can get a runtime like this:
[07:00:59] Runtime in job_exp.dm,16: Cannot read null.assigned_role
proc name: Check Player Playtime
(/client/proc/cmd_mentor_check_player_exp)
usr: CHARACTER (CKEY) (/mob/dead/observer)
usr.loc: The floor (41,145,1) (/turf/simulated/shuttle/floor)

This PR fixes it so that runtime should no longer be possible, by checking that C.mob.mind exists before checking whether C.mob.mind.assigned_role exists. 