### PR TITLE
Lighting Performance and Profiling Tweaks

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -31,6 +31,8 @@
 	..()
 	var/datum/space_level/S = space_manager.get_zlev(z)
 	S.remove_from_transit(src)
+	if(light_sources) // Turn off starlight, if present
+		set_light(0)
 
 /turf/space/AfterChange(ignore_air, keep_cabling = FALSE)
 	..()

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -1,4 +1,4 @@
-/var/list/datum/lighting_corner/all_lighting_corners = list()
+/var/total_lighting_corners = 0
 /var/datum/lighting_corner/dummy/dummy_lighting_corner = new
 // Because we can control each corner of every lighting overlay.
 // And corners get shared between multiple turfs (unless you're on the corners of the map, then 1 corner doesn't).
@@ -32,7 +32,7 @@
 /datum/lighting_corner/New(var/turf/new_turf, var/diagonal)
 	. = ..()
 
-	all_lighting_corners += src
+	total_lighting_corners++
 
 	masters[new_turf] = turn(diagonal, 180)
 	z = new_turf.z

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -1,4 +1,4 @@
-var/list/all_lighting_overlays = list() // Global list of lighting overlays.
+/var/total_lighting_overlays = 0
 /atom/movable/lighting_overlay
 	name = ""
 	mouse_opacity = 0
@@ -21,7 +21,7 @@ var/list/all_lighting_overlays = list() // Global list of lighting overlays.
 /atom/movable/lighting_overlay/New(var/atom/loc, var/no_update = FALSE)
 	. = ..()
 	verbs.Cut()
-	global.all_lighting_overlays += src
+	total_lighting_overlays++
 
 	var/turf/T = loc //If this runtimes atleast we'll know what's creating overlays outside of turfs.
 	T.lighting_overlay = src
@@ -77,7 +77,7 @@ var/list/all_lighting_overlays = list() // Global list of lighting overlays.
 	return
 
 /atom/movable/lighting_overlay/Destroy()
-	global.all_lighting_overlays        -= src
+	total_lighting_overlays--
 	global.lighting_update_overlays     -= src
 	global.lighting_update_overlays_old -= src
 

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -1,4 +1,4 @@
-/var/list/datum/light_source/all_lighting_sources = list()
+/var/total_lighting_sources = 0
 // This is where the fun begins.
 // These are the main datums that emit light.
 
@@ -32,7 +32,7 @@
 	var/force_update
 
 /datum/light_source/New(var/atom/owner, var/atom/top)
-	all_lighting_sources += src
+	total_lighting_sources++
 	source_atom = owner // Set our new owner.
 	if(!source_atom.light_sources)
 		source_atom.light_sources = list()
@@ -62,7 +62,7 @@
 
 // Kill ourselves.
 /datum/light_source/proc/destroy()
-	all_lighting_sources -= src
+	total_lighting_sources--
 	destroyed = TRUE
 	force_update()
 	if(source_atom)


### PR DESCRIPTION
**Performance:**
- Lighting now yields every 10% of a tick (twice as often), and defers at 80% of a tick's usage. This will make it compete less for CPU time with other things that happen to run simultaneously.
- Lighting no longer limits the number of light sources, corners, or overlays it processes in a single run.
  - In some cases, some lights will take longer to update than they previously would, but others will update faster, as the process will spend less time *not* updating them.

**Profiling:**
- Instead of trying (and often failing) to list the number of light sources/corners/overlays waiting to be updated at a given moment, a sum of updates that occurred during each of the last 5 seconds(ish) are listed instead. The stats now look like this:
![](https://cloud.githubusercontent.com/assets/10916307/23112624/a38844f6-f6ff-11e6-9787-3094cf26a5d7.png)
- The total number of sources, corners, and overlays are now tracked as numbers, rather than enormous lists.

Also, I made starlit space turfs turn off their light when changing to a different turf, which should get rid of the annoying `light_sources` runtime.