### PR TITLE
Fixes Rigsuit NODROP-Related Bug and Improves Rigsuit Verb Readability

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -195,7 +195,7 @@
 		if(!piece) continue
 		piece.icon_state = "[initial(icon_state)]"
 		if(airtight)
-			piece.flags &= ~(STOPSPRESSUREDMAGE|AIRTIGHT)
+			piece.flags &= ~(STOPSPRESSUREDMAGE | AIRTIGHT)
 	update_icon(1)
 
 /obj/item/weapon/rig/proc/seal(mob/living/user)
@@ -426,11 +426,9 @@
 		helmet.toggle_light(wearer)
 	for(var/obj/item/piece in list(helmet,boots,gloves,chest))
 		if(!(flags & NODROP))
-			piece.flags &= ~STOPSPRESSUREDMAGE
-			piece.flags &= ~AIRTIGHT
+			piece.flags &= ~(STOPSPRESSUREDMAGE | AIRTIGHT)
 		else
-			piece.flags |= STOPSPRESSUREDMAGE
-			piece.flags |= AIRTIGHT
+			piece.flags |= STOPSPRESSUREDMAGE | AIRTIGHT
 
 /obj/item/weapon/rig/process()
 	// If we've lost any parts, grab them back.
@@ -442,7 +440,7 @@
 				M.unEquip(piece)
 			piece.forceMove(src)
 
-	if(!istype(wearer) || loc != wearer || wearer.back != src || (!(flags & NODROP)) || !cell || cell.charge <= 0)
+	if(!istype(wearer) || loc != wearer || wearer.back != src || !(flags & NODROP) || !cell || cell.charge <= 0)
 		if(!cell || cell.charge <= 0)
 			if(electrified > 0)
 				electrified = 0
@@ -777,8 +775,9 @@
 				to_chat(wearer, "<span class='notice'>Your [use_obj] [use_obj.gender == PLURAL ? "retract" : "retracts"] swiftly.")
 
 		else if(deploy_mode != ONLY_RETRACT)
-			if(check_slot && check_slot != use_obj)
-				to_chat(wearer, "<span class='danger'>You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way.</span>")
+			if(check_slot)
+				if(check_slot != use_obj) //If use_obj is already in check_slot, silently bail. Otherwise, tell the user why the part didn't deploy.
+					to_chat(wearer, "<span class='danger'>You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way.</span>")
 				return
 			use_obj.forceMove(wearer)
 			if(!wearer.equip_to_slot_if_possible(use_obj, equip_to, 0, 1))

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -115,7 +115,7 @@
 
 /obj/item/weapon/rig/verb/deploy_suit()
 	set name = "Deploy Hardsuit"
-	set desc = "Deploys helmet, gloves and boots."
+	set desc = "Deploys helmet, gloves and boots all at once."
 	set category = "Hardsuit"
 	set src = usr.contents
 
@@ -136,8 +136,8 @@
 	deploy(wearer, usr)
 
 /obj/item/weapon/rig/verb/toggle_seals_verb()
-	set name = "Toggle Hardsuit"
-	set desc = "Activates or deactivates your rig."
+	set name = "Toggle Hardsuit Seals"
+	set desc = "Seals or unseals your rig."
 	set category = "Hardsuit"
 	set src = usr.contents
 


### PR DESCRIPTION
The bug this PR resolves occurred if you put a Rigsuit control module on, toggled an individual part (lets say the boots) using the **toggle <part name nere>** verb then deployed the suit using the **deploy suit** verb, you could click the individual part you toggled on before you deployed the suit and have that part stuck to your hand rather permanently.

tl;dr: Fixes a bug where you could get part of a rigsuit stuck to your hand by somehow deploying it twice.

:cl:
fix: Fixes a bug where you could get a part of a rigsuit stuck to your hand by deploying it twice.
tweak: Improves the readability of some rigsuit verbs.
/:cl: