### PR TITLE
Moves crown to cargo crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1408,6 +1408,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/clothing/head/collectable/flatcap,
 					/obj/item/clothing/head/collectable/pirate,
 					/obj/item/clothing/head/collectable/kitty,
+					/obj/item/clothing/head/crown/fancy,
 					/obj/item/clothing/head/collectable/rabbitears,
 					/obj/item/clothing/head/collectable/wizard,
 					/obj/item/clothing/head/collectable/hardhat,
@@ -1527,9 +1528,9 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/beach_ball)
 	cost = 20
 	containername = "polo supply crate"
-	
-///////////// Station Goals	
-	
+
+///////////// Station Goals
+
 /datum/supply_packs/misc/bsa
 	name = "Bluespace Artillery Parts"
 	cost = 150

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -15,7 +15,6 @@
 		else
 			new /obj/item/weapon/storage/backpack/satchel_cap(src)
 		new /obj/item/weapon/book/manual/faxes(src)
-		new /obj/item/clothing/head/crown/fancy(src)
 		new /obj/item/weapon/storage/backpack/duffel/captain(src)
 		new /obj/item/clothing/suit/captunic(src)
 		new /obj/item/clothing/suit/captunic/capjacket(src)


### PR DESCRIPTION
Removes crown from Captain locker & adds to collectible hat crate

The Captain is not a monarch, better for a medium RP environment that the Captain does not START with this item. If they get it from Cargo, then great.

:cl: Purpose2
tweak: Captain's crown is now part of the random hats crate, and no longer spawns in their locker.
/:cl: