### PR TITLE
Fix station goals runtime and increase meteor shield satellite goal tenfold

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -910,6 +910,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	holder.modify_goals()
 
 /datum/admins/proc/modify_goals()
+	if(!ticker || !ticker.mode)
+		to_chat(usr, "<span class='warning'>This verb can only be used if the round has started.</span>")
+		return
+	
 	var/dat = ""
 	for(var/datum/station_goal/S in ticker.mode.station_goals)
 		dat += "[S.name] - <a href='?src=[S.UID()];announce=1'>Announce</a> | <a href='?src=[S.UID()];remove=1'>Remove</a><br>"

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -3,7 +3,7 @@
 // Satellites be actived to generate a shield that will block unorganic matter from passing it.
 /datum/station_goal/station_shield
 	name = "Station Shield"
-	var/coverage_goal = 500
+	var/coverage_goal = 5000
 
 /datum/station_goal/station_shield/get_report()
 	return {"<b>Station Shield construction</b><br>


### PR DESCRIPTION
Fixes a runtime when accessing the station goals verb when the round hasn't started and increases the coverage of the meteor shield satellite goal tenfold.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6563

🆑 Markolie
tweak: The meteor shield satellite station goal coverage goal has been increased tenfold.
/🆑