### PR TITLE
Reduces Accidental Ghosts and Ghostly Volunteers

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -463,7 +463,7 @@ proc/pollCandidates(Question, be_special_type, antag_age_check = 0, poll_time = 
 			G << 'sound/misc/notice2.ogg'//Alerting them to their consideration
 			if(flashwindow)
 				window_flash(G.client)
-			switch(alert(G,Question,"Please answer in [poll_time/10] seconds!","Yes","No","Not This Round"))
+			switch(alert(G,Question,"Please answer in [poll_time/10] seconds!","No","Yes","Not This Round"))
 				if("Yes")
 					to_chat(G, "<span class='notice'>Choice registered: Yes.</span>")
 					if((world.time-time_passed)>poll_time)//If more than 30 game seconds passed.

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -169,7 +169,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		var/response
 		var/alertmsg = "Are you -sure- you want to ghost?\n([warningmsg]. If you ghost now, you probably won't be able to rejoin the round! You can't change your mind, so choose wisely!)"
-		response = alert(src, alertmsg,"Are you sure you want to ghost?","Ghost","Stay in body")
+		response = alert(src, alertmsg,"Are you sure you want to ghost?","Stay in body","Ghost")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
 		resting = 1


### PR DESCRIPTION
When ghosting would have consequences, you get an alert box asking whether you're sure you want to ghost... and the "ghost" option is selected by default, so accidentally hitting enter or the space bar will ghost you. This swaps the choices you're given, so "stay in body" is the default, and you have to explicitly select "ghost".

#6541 is probably "fixed" by this, insofar as I can't find anything in the code that could cause the supposed issue, but one could certainly miss the warning if they accidentally select "ghost" quickly enough.

**Added bonus:** The candidate-polling alert boxes ("Do you want to play as a something-or-other?") now have "No" as the default option. The order is a bit weird now ("No" - "Yes" - "Not This Round"), but that's just how it works.

:cl:
tweak: Ghost candidate alert boxes ("Do you want to play as a thing?") will now have "No" as the leftmost, default option, which you will accidentally pick when it pops up while you're trying to type, but at least you won't be stuck as the thing when you didn't actually want to be that thing.
/:cl: