### PR TITLE
Refactors the Chair Rotate verb

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -64,12 +64,12 @@
 		handle_rotation()
 		return
 
-		if(usr.incapacitated())
-			return
-
-		setDir(turn(dir, 90))
-		handle_rotation()
+	if(usr.incapacitated())
 		return
+
+	setDir(turn(dir, 90))
+	handle_rotation()
+	return
 
 /obj/structure/stool/bed/chair/AltClick(mob/user)
 	if(user.incapacitated())

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -63,7 +63,7 @@
 		setDir(turn(dir, 90))
 		handle_rotation()
 		return
-	else
+
 		if(usr.incapacitated())
 			return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -60,14 +60,14 @@
 	set src in oview(1)
 
 	if(config.ghost_interaction)
-		dir = turn(dir, 90)
+		setDir(turn(dir, 90))
 		handle_rotation()
 		return
 	else
 		if(usr.incapacitated())
 			return
 
-		dir = turn(dir, 90)
+		setDir(turn(dir, 90))
 		handle_rotation()
 		return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -59,14 +59,17 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(!usr || !isturf(usr.loc))
+	if(config.ghost_interaction)
+		dir = turn(dir, 90)
+		handle_rotation()
 		return
-	if(usr.stat || usr.restrained())
-		return
+	else
+		if(usr.incapacitated())
+			return
 
-	src.dir = turn(src.dir, 90)
-	handle_rotation()
-	return
+		dir = turn(dir, 90)
+		handle_rotation()
+		return
 
 /obj/structure/stool/bed/chair/AltClick(mob/user)
 	if(user.incapacitated())

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -69,7 +69,6 @@
 
 	setDir(turn(dir, 90))
 	handle_rotation()
-	return
 
 /obj/structure/stool/bed/chair/AltClick(mob/user)
 	if(user.incapacitated())

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -59,19 +59,14 @@
 	set category = "Object"
 	set src in oview(1)
 
-	if(config.ghost_interaction)
-		src.dir = turn(src.dir, 90)
-		handle_rotation()
+	if(!usr || !isturf(usr.loc))
 		return
-	else
-		if(!usr || !isturf(usr.loc))
-			return
-		if(usr.stat || usr.restrained())
-			return
+	if(usr.stat || usr.restrained())
+		return
 
-		src.dir = turn(src.dir, 90)
-		handle_rotation()
-		return
+	src.dir = turn(src.dir, 90)
+	handle_rotation()
+	return
 
 /obj/structure/stool/bed/chair/AltClick(mob/user)
 	if(user.incapacitated())


### PR DESCRIPTION
> Removes the ability for ghosts to spin chairs.
> 
> This doesn't add anything positive to the game... and lately have been abused as a ouiji board to communicate with ghosts.
> 
> (edit) included image of the ouiji board for interest:
> http://i.imgur.com/F4aBYSq.png

This now refactors the verb. 

Ghost interaction will be handled by a config option, and has nothing to do with this PR anymore.

:cl: Purpose2
refactor: Minor refactor of Chair Rotation handling.
/:cl: