### PR TITLE
Fixes

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -399,6 +399,7 @@ var/bomb_set
 /obj/item/weapon/disk/nuclear/New()
 	..()
 	processing_objects.Add(src)
+	poi_list |= src
 
 /obj/item/weapon/disk/nuclear/process()
 	var/turf/disk_loc = get_turf(src)
@@ -414,10 +415,12 @@ var/bomb_set
 	if(force)
 		message_admins("[src] has been !!force deleted!! in ([diskturf ? "[diskturf.x], [diskturf.y] ,[diskturf.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[diskturf.x];Y=[diskturf.y];Z=[diskturf.z]'>JMP</a>":"nonexistent location"]).")
 		log_game("[src] has been !!force deleted!! in ([diskturf ? "[diskturf.x], [diskturf.y] ,[diskturf.z]":"nonexistent location"]).")
+		poi_list.Remove(src)
 		processing_objects.Remove(src)
 		return ..()
 
 	if(blobstart.len > 0)
+		poi_list.Remove(src)
 		var/obj/item/weapon/disk/nuclear/NEWDISK = new(pick(blobstart))
 		transfer_fingerprints_to(NEWDISK)
 		message_admins("[src] has been destroyed at ([diskturf.x], [diskturf.y], [diskturf.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[diskturf.x];Y=[diskturf.y];Z=[diskturf.z]'>JMP</a>). Moving it to ([NEWDISK.x], [NEWDISK.y], [NEWDISK.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[NEWDISK.x];Y=[NEWDISK.y];Z=[NEWDISK.z]'>JMP</a>).")

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -117,7 +117,6 @@ var/time_last_changed_position = 0
 		modify = null
 	else
 		to_chat(usr, "There is nothing to remove from the console.")
-	return
 
 /obj/machinery/computer/card/attackby(obj/item/weapon/card/id/id_card, mob/user, params)
 	if(!istype(id_card))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -100,18 +100,19 @@ var/time_last_changed_position = 0
 	set name = "Eject ID Card"
 	set src in oview(1)
 
-	if(!usr || usr.stat || usr.lying)	return
+	if(usr.restrained())	
+		return
 
 	if(scan)
 		to_chat(usr, "You remove \the [scan] from \the [src].")
-		scan.loc = get_turf(src)
-		if(!usr.get_active_hand())
+		scan.forceMove(get_turf(src))
+		if(!usr.get_active_hand() && Adjacent(usr))
 			usr.put_in_hands(scan)
 		scan = null
 	else if(modify)
 		to_chat(usr, "You remove \the [modify] from \the [src].")
-		modify.loc = get_turf(src)
-		if(!usr.get_active_hand())
+		modify.forceMove(get_turf(src))
+		if(!usr.get_active_hand() && Adjacent(usr))
 			usr.put_in_hands(modify)
 		modify = null
 	else
@@ -260,35 +261,35 @@ var/time_last_changed_position = 0
 				data_core.manifest_modify(modify.registered_name, modify.assignment)
 				modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
 				if(ishuman(usr))
-					modify.loc = usr.loc
-					if(!usr.get_active_hand())
+					modify.forceMove(get_turf(src))
+					if(!usr.get_active_hand() && Adjacent(usr))
 						usr.put_in_hands(modify)
 					modify = null
 				else
-					modify.loc = loc
+					modify.forceMove(get_turf(src))
 					modify = null
-			else
+			else if(Adjacent(usr))	
 				var/obj/item/I = usr.get_active_hand()
 				if(istype(I, /obj/item/weapon/card/id))
 					usr.drop_item()
-					I.loc = src
+					I.forceMove(src)
 					modify = I
 
 		if("scan")
 			if(scan)
 				if(ishuman(usr))
-					scan.loc = usr.loc
-					if(!usr.get_active_hand())
+					scan.forceMove(get_turf(src))
+					if(!usr.get_active_hand() && Adjacent(usr))
 						usr.put_in_hands(scan)
 					scan = null
 				else
-					scan.loc = src.loc
+					scan.forceMove(get_turf(src))
 					scan = null
-			else
+			else if(Adjacent(usr))			
 				var/obj/item/I = usr.get_active_hand()
 				if(istype(I, /obj/item/weapon/card/id))
 					usr.drop_item()
-					I.loc = src
+					I.forceMove(src)
 					scan = I
 
 		if("access")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -242,7 +242,6 @@ var/global/list/default_medbay_channels = list(
 	var/datum/radio_frequency/connection = null
 	if(channel && channels && channels.len > 0)
 		if(channel == "department")
-//			to_chat(world, "DEBUG: channel=\"[channel]\" switching to \"[channels[1]]\"")
 			channel = channels[1]
 		connection = secure_radio_connections[channel]
 	else
@@ -259,9 +258,8 @@ var/global/list/default_medbay_channels = list(
 	Broadcast_Message(connection, A,
 						0, "*garbled automated announcement*", src,
 						message, from, "Automated Announcement", from, "synthesized voice",
-						4, 0, zlevel, connection.frequency, follow_target=follow_target)
+						4, 0, zlevel, connection.frequency, follow_target = follow_target)
 	qdel(A)
-	return
 
 // Just a dummy mob used for making announcements, so we don't create AIs to do this
 // I'm not sure who thought that was a good idea. -- Crazylemon

--- a/code/game/objects/items/weapons/implants/implant_death_alarm.dm
+++ b/code/game/objects/items/weapons/implants/implant_death_alarm.dm
@@ -3,6 +3,7 @@
 	desc = "An alarm which monitors host vital signs and transmits a radio message upon death."
 	var/mobname = "Will Robinson"
 	activated = 0
+	var/static/list/stealth_areas = typecacheof(list(/area/syndicate_station, /area/syndicate_mothership, /area/shuttle/syndicate_elite))
 
 /obj/item/weapon/implant/death_alarm/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
@@ -33,26 +34,26 @@
 /obj/item/weapon/implant/death_alarm/activate(var/cause)
 	var/mob/M = imp_in
 	var/area/t = get_area(M)
+
+	var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset(null)
+	a.follow_target = M
+
 	switch(cause)
 		if("death")
-			var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset(null)
-			if(istype(t, /area/syndicate_station) || istype(t, /area/syndicate_mothership) || istype(t, /area/shuttle/syndicate_elite) )
+			if(is_type_in_typecache(t, stealth_areas))
 				//give the syndies a bit of stealth
 				a.autosay("[mobname] has died in Space!", "[mobname]'s Death Alarm")
 			else
 				a.autosay("[mobname] has died in [t.name]!", "[mobname]'s Death Alarm")
-			qdel(a)
 			qdel(src)
 		if("emp")
-			var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset(null)
 			var/name = prob(50) ? t.name : pick(teleportlocs)
 			a.autosay("[mobname] has died in [name]!", "[mobname]'s Death Alarm")
-			qdel(a)
 		else
-			var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset(null)
 			a.autosay("[mobname] has died-zzzzt in-in-in...", "[mobname]'s Death Alarm")
-			qdel(a)
 			qdel(src)
+			
+	qdel(a)
 
 /obj/item/weapon/implant/death_alarm/emp_act(severity)			//for some reason alarms stop going off in case they are emp'd, even without this
 	activate("emp")	//let's shout that this dude is dead

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -494,7 +494,8 @@
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=[UID()];medrecord=`'>\[View\]</a> <a href='?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
 
-	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
+	if(print_flavor_text() && !skipface) 
+		msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"
 	if(pose)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -470,7 +470,7 @@
 			if(CHEF)
 				clothes_s = new /icon(uniform_dmi, "chef_s")
 				clothes_s.Blend(new /icon('icons/mob/feet.dmi', "black"), ICON_UNDERLAY)
-				clothes_s.Blend(new /icon('icons/mob/head.dmi', "chefhat"), ICON_OVERLAY)
+				clothes_s.Blend(new /icon('icons/mob/head.dmi', "chef"), ICON_OVERLAY)
 				if(prob(1))
 					clothes_s.Blend(new /icon('icons/mob/suit.dmi', "apronchef"), ICON_OVERLAY)
 				switch(backbag)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -198,6 +198,23 @@ var/list/alldepartments = list()
 			card.forceMove(src)
 			scan = card
 	nanomanager.update_uis(src)
+	
+/obj/machinery/photocopier/faxmachine/verb/eject_id()
+	set category = null
+	set name = "Eject ID Card"
+	set src in oview(1)
+
+	if(usr.restrained())	
+		return
+
+	if(scan)
+		to_chat(usr, "You remove \the [scan] from \the [src].")
+		scan.forceMove(get_turf(src))
+		if(!usr.get_active_hand() && Adjacent(usr))
+			usr.put_in_hands(scan)
+		scan = null
+	else
+		to_chat(usr, "There is nothing to remove from \the [src].")
 
 /obj/machinery/photocopier/faxmachine/proc/sendfax(var/destination,var/mob/sender)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -312,7 +312,7 @@ var/list/alldepartments = list()
 /obj/machinery/photocopier/faxmachine/proc/message_admins(var/mob/sender, var/faxname, var/faxtype, var/obj/item/sent, font_colour="#9A04D1")
 	var/msg = "<span class='boldnotice'><font color='[font_colour]'>[faxname]: </font> [key_name_admin(sender)] | REPLY: (<A HREF='?_src_=holder;CentcommReply=\ref[sender]'>RADIO</A>) (<a href='?_src_=holder;AdminFaxCreate=\ref[sender];originfax=\ref[src];faxtype=[faxtype];replyto=\ref[sent]'>FAX</a>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) | REJECT: (<A HREF='?_src_=holder;FaxReplyTemplate=\ref[sender];originfax=\ref[src]'>TEMPLATE</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[sender]'>BSA</A>) (<A HREF='?_src_=holder;EvilFax=\ref[sender];originfax=\ref[src]'>EVILFAX</A>) </span>: Receiving '[sent.name]' via secure connection... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
 	for(var/client/C in admins)
-		if(check_rights(R_EVENT, 0, C))
+		if(check_rights(R_EVENT, 0, C.mob))
 			to_chat(C, msg)
 			if(C.prefs.sound & SOUND_ADMINHELP)
 				C << 'sound/effects/adminhelp.ogg'

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -18,8 +18,10 @@ var/list/alldepartments = list()
 	active_power_usage = 200
 
 	var/obj/item/weapon/card/id/scan = null // identification
+
 	var/authenticated = 0
 	var/sendcooldown = 0 // to avoid spamming fax messages
+	var/cooldown_time = 1800
 
 	var/department = "Unknown" // our department
 
@@ -52,7 +54,7 @@ var/list/alldepartments = list()
 	else
 		return ..()
 
-/obj/machinery/photocopier/faxmachine/emag_act(user as mob)
+/obj/machinery/photocopier/faxmachine/emag_act(mob/user)
 	if(!emagged)
 		emagged = 1
 		to_chat(user, "<span class='notice'>The transmitters realign to an unknown source!</span>")
@@ -123,7 +125,7 @@ var/list/alldepartments = list()
 		if(copyitem)
 			copyitem.forceMove(get_turf(src))
 			if(ishuman(usr))
-				if(!usr.get_active_hand())
+				if(!usr.get_active_hand() && Adjacent(usr))
 					usr.put_in_hands(copyitem)
 			to_chat(usr, "<span class='notice'>You eject \the [copyitem] from \the [src].</span>")
 			copyitem = null
@@ -154,10 +156,10 @@ var/list/alldepartments = list()
 				destination = lastdestination
 
 	if(href_list["auth"])
-		if((!authenticated) && scan)
+		if(!is_authenticated && scan)
 			if(check_access(scan))
 				authenticated = 1
-		else if(!authenticated)
+		else if(is_authenticated)
 			authenticated = 0
 
 	if(href_list["rename"])
@@ -177,25 +179,24 @@ var/list/alldepartments = list()
 /obj/machinery/photocopier/faxmachine/proc/scan(var/obj/item/weapon/card/id/card = null)
 	if(scan) // Card is in machine
 		if(ishuman(usr))
-			scan.forceMove(get_turf(usr))
-			if(!usr.get_active_hand())
+			scan.forceMove(get_turf(src))
+			if(!usr.get_active_hand() && Adjacent(usr))
 				usr.put_in_hands(scan)
 			scan = null
 		else
 			scan.forceMove(get_turf(src))
 			scan = null
-	else
+	else if(Adjacent(usr))
 		if(!card)
 			var/obj/item/I = usr.get_active_hand()
 			if(istype(I, /obj/item/weapon/card/id))
 				usr.drop_item()
 				I.forceMove(src)
 				scan = I
-		else
-			if(istype(card))
-				usr.drop_item()
-				card.forceMove(src)
-				scan = card
+		else if(istype(card))
+			usr.drop_item()
+			card.forceMove(src)
+			scan = card
 	nanomanager.update_uis(src)
 
 /obj/machinery/photocopier/faxmachine/proc/sendfax(var/destination,var/mob/sender)
@@ -220,7 +221,6 @@ var/list/alldepartments = list()
 		F.sent_at = world.time
 
 		visible_message("[src] beeps, \"Message transmitted successfully.\"")
-		//sendcooldown = 600
 	else
 		visible_message("[src] beeps, \"Error transmitting message.\"")
 
@@ -253,6 +253,9 @@ var/list/alldepartments = list()
 /obj/machinery/photocopier/faxmachine/proc/send_admin_fax(var/mob/sender, var/destination)
 	if(stat & (BROKEN|NOPOWER))
 		return
+		
+	if(sendcooldown)
+		return
 
 	use_power(200)
 
@@ -284,15 +287,15 @@ var/list/alldepartments = list()
 			message_admins(sender, "CENTCOM FAX", destination, rcvdcopy, "#006100")
 		if("Syndicate")
 			message_admins(sender, "SYNDICATE FAX", destination, rcvdcopy, "#DC143C")
-	sendcooldown = 1800
-	sleep(50)
-	visible_message("[src] beeps, \"Message transmitted successfully.\"")
+	sendcooldown = cooldown_time
+	spawn(50)
+		visible_message("[src] beeps, \"Message transmitted successfully.\"")
 
 
 /obj/machinery/photocopier/faxmachine/proc/message_admins(var/mob/sender, var/faxname, var/faxtype, var/obj/item/sent, font_colour="#9A04D1")
-	var/msg = "<span class='boldnotice'><font color='[font_colour]'>[faxname]: </font>[key_name(sender, 1)] (<A HREF='?_src_=holder;adminplayeropts=\ref[sender]'>PP</A>) (<A HREF='?_src_=vars;Vars=[sender.UID()]'>VV</A>) (<A HREF='?_src_=holder;secretsadmin=check_antagonist'>CA</A>) ([admin_jump_link(sender)]) | REPLY: (<A HREF='?_src_=holder;CentcommReply=\ref[sender]'>RADIO</A>) (<a href='?_src_=holder;AdminFaxCreate=\ref[sender];originfax=\ref[src];faxtype=[faxtype];replyto=\ref[sent]'>FAX</a>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) | REJECT: (<A HREF='?_src_=holder;FaxReplyTemplate=\ref[sender];originfax=\ref[src]'>TEMPLATE</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[sender]'>BSA</A>) (<A HREF='?_src_=holder;EvilFax=\ref[sender];originfax=\ref[src]'>EVILFAX</A>) </span>: Receiving '[sent.name]' via secure connection... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
+	var/msg = "<span class='boldnotice'><font color='[font_colour]'>[faxname]: </font> [key_name_admin(sender)] | REPLY: (<A HREF='?_src_=holder;CentcommReply=\ref[sender]'>RADIO</A>) (<a href='?_src_=holder;AdminFaxCreate=\ref[sender];originfax=\ref[src];faxtype=[faxtype];replyto=\ref[sent]'>FAX</a>) (<A HREF='?_src_=holder;subtlemessage=\ref[sender]'>SM</A>) | REJECT: (<A HREF='?_src_=holder;FaxReplyTemplate=\ref[sender];originfax=\ref[src]'>TEMPLATE</A>) (<A HREF='?_src_=holder;BlueSpaceArtillery=\ref[sender]'>BSA</A>) (<A HREF='?_src_=holder;EvilFax=\ref[sender];originfax=\ref[src]'>EVILFAX</A>) </span>: Receiving '[sent.name]' via secure connection... <a href='?_src_=holder;AdminFaxView=\ref[sent]'>view message</a>"
 	for(var/client/C in admins)
-		if(R_EVENT & C.holder.rights)
+		if(check_rights(R_EVENT, 0, C))
 			to_chat(C, msg)
 			if(C.prefs.sound & SOUND_ADMINHELP)
 				C << 'sound/effects/adminhelp.ogg'

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -179,6 +179,17 @@
 	var/mob_aoe = FALSE
 	var/list/hit_overlays = list()
 
+/obj/item/projectile/kinetic/pod
+	range = 4
+	
+/obj/item/projectile/kinetic/pod/regular
+	damage = 50
+	pressure_decrease = 0.5
+
+/obj/item/projectile/kinetic/pod/enhanced
+	turf_aoe = TRUE
+	mob_aoe = TRUE
+
 /obj/item/projectile/kinetic/on_range()
 	strike_thing()
 	..()

--- a/code/modules/spacepods/equipment.dm
+++ b/code/modules/spacepods/equipment.dm
@@ -28,9 +28,8 @@
 					firstloc = get_turf(my_atom)
 					secondloc = get_step(firstloc,NORTH)
 		olddir = dir
-		var/proj_type = text2path(projectile_type)
-		var/obj/item/projectile/projone = new proj_type(firstloc)
-		var/obj/item/projectile/projtwo = new proj_type(secondloc)
+		var/obj/item/projectile/projone = new projectile_type(firstloc)
+		var/obj/item/projectile/projtwo = new projectile_type(secondloc)
 		projone.starting = get_turf(my_atom)
 		projone.firer = usr
 		projone.def_zone = "chest"
@@ -79,7 +78,7 @@
 	desc = "You shouldn't be seeing this"
 	icon = 'icons/vehicles/spacepod.dmi'
 	icon_state = "blank"
-	var/projectile_type
+	var/obj/item/projectile/projectile_type
 	var/shot_cost = 0
 	var/shots_per = 1
 	var/fire_sound
@@ -89,7 +88,7 @@
 	name = "disabler system"
 	desc = "A weak taser system for space pods, fires disabler beams."
 	icon_state = "weapon_taser"
-	projectile_type = "/obj/item/projectile/beam/disabler"
+	projectile_type = /obj/item/projectile/beam/disabler
 	shot_cost = 400
 	fire_sound = 'sound/weapons/Taser.ogg'
 
@@ -97,7 +96,7 @@
 	name = "burst taser system"
 	desc = "A weak taser system for space pods, this one fires 3 at a time."
 	icon_state = "weapon_burst_taser"
-	projectile_type = "/obj/item/projectile/beam/disabler"
+	projectile_type = /obj/item/projectile/beam/disabler
 	shot_cost = 1200
 	shots_per = 3
 	fire_sound = 'sound/weapons/Taser.ogg'
@@ -107,7 +106,7 @@
 	name = "laser system"
 	desc = "A weak laser system for space pods, fires concentrated bursts of energy"
 	icon_state = "weapon_laser"
-	projectile_type = "/obj/item/projectile/beam"
+	projectile_type = /obj/item/projectile/beam
 	shot_cost = 600
 	fire_sound = 'sound/weapons/Laser.ogg'
 
@@ -117,7 +116,7 @@
 	desc = "A weak mining laser system for space pods, fires bursts of energy that cut through rock"
 	icon = 'icons/goonstation/pods/ship.dmi'
 	icon_state = "pod_taser"
-	projectile_type = "/obj/item/projectile/kinetic"
+	projectile_type = /obj/item/projectile/kinetic/pod
 	shot_cost = 300
 	fire_delay = 14
 	fire_sound = 'sound/weapons/Kenetic_accel.ogg'
@@ -127,7 +126,7 @@
 	desc = "A mining laser system for space pods, fires bursts of energy that cut through rock"
 	icon = 'icons/goonstation/pods/ship.dmi'
 	icon_state = "pod_m_laser"
-	projectile_type = "/obj/item/projectile/kinetic/super"
+	projectile_type = /obj/item/projectile/kinetic/pod/regular
 	shot_cost = 250
 	fire_delay = 10
 	fire_sound = 'sound/weapons/Kenetic_accel.ogg'
@@ -137,7 +136,7 @@
 	desc = "An enhanced mining laser system for space pods, fires bursts of energy that cut through rock"
 	icon = 'icons/goonstation/pods/ship.dmi'
 	icon_state = "pod_w_laser"
-	projectile_type = "/obj/item/projectile/kinetic/hyper"
+	projectile_type = /obj/item/projectile/kinetic/pod/enhanced
 	shot_cost = 200
 	fire_delay = 8
 	fire_sound = 'sound/weapons/Kenetic_accel.ogg'

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -33,7 +33,6 @@
 	var/oldloc = loc
 	if(bed && !Adjacent(bed))
 		bed = null
-		return
 	. = ..()
 	if(bed && get_dist(oldloc, loc) <= 2)
 		bed.Move(oldloc)

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -31,6 +31,9 @@
 
 /obj/vehicle/ambulance/Move(newloc, Dir)
 	var/oldloc = loc
+	if(bed && !Adjacent(bed))
+		bed = null
+		return
 	. = ..()
 	if(bed && get_dist(oldloc, loc) <= 2)
 		bed.Move(oldloc)


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/6569
Mining pod weapons work again (damn you, text type paths). With the super/hyper accelerator gone, I settled on the following stats for the pod mining weapons (based on the default kinetic accelerator projectile):
 * The weak kinetic projectile has one additional range (4 instead of 3).
 * The regular kinetic projectile does 50 damage and only has 50% of its damage reduced in pressurized environments.
 * The enhanced kinetic projectile can AoE hit turfs and mobs.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6565
Fixes https://github.com/ParadiseSS13/Paradise/issues/6562
You can now only insert/retrieve the ID card from a identification computer/fax machine with(out) telekinesis if you're next to it. Otherwise it'll appear on top of the machine.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6405
Players with their face covered will no longer show their flavor text.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6560
Fixes https://github.com/ParadiseSS13/Paradise/issues/6256
This is a bit of a band aid fix, but will prevent the ambulance for glitching across the map. In the future we need to refactor our Bump() code.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6581
Fixes https://github.com/ParadiseSS13/Paradise/issues/6584

Additional changes:
* Adds an "Eject ID card" verb to fax machines so you can remove the inserted ID card if the machine is unpowered.
* The follow link on death alarms now works.
* Fixed a possible href exploit in admin faxing.

🆑 Markolie
fix: Mining pod weapons are once again functional. Compared to regular kinetic accelerators, the weak projectile has one additional range (3 --> 4). The regular projectile's damage is increased (40 --> 50) and deals more damage in pressurized environments (50% instead of 25%). The enhanced projectile is able to fire its kinetic projectile AoE against turfs and mobs.
fix: Fixed an issue where it was impossible to log out from fax machines.
fix: It is no longer possible to steal ID cards from identification computers/fax machine using telekinesis at range.
fix: The follow link on death alarms now works.
fix: Fixes an exploit where players could use the ambulance trolley to teleport.
fix: The chef now properly shows a chef hat on character preview.
fix: The nuclear ops game mode will no longer always result in a major crew victory.
tweak: Players with their face covered will no longer show their flavor text upon examine.
rscadd: Fax machines now have an "Eject ID card" verb so you can remove the inserted ID when it is depowered.
/🆑