### PR TITLE
Fixes #6572 - double prompt on blob

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -10,16 +10,13 @@
 	var/point_rate = 2
 	var/is_offspring = null
 	var/selecting = 0
-	var/grab_overmind = 1
 
-/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring, is_event)
+/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring)
 	blob_cores += src
 	processing_objects.Add(src)
 	poi_list |= src
 	adjustcolors(color) //so it atleast appears
-	if(is_event)
-		grab_overmind = 0
-	if(!overmind && grab_overmind)
+	if(!overmind)
 		create_overmind(new_overmind)
 	if(overmind)
 		adjustcolors(overmind.blob_reagent_datum.color)
@@ -64,7 +61,7 @@
 	return // Don't regen, we handle it in Life()
 
 /obj/effect/blob/core/Life()
-	if(!overmind && grab_overmind)
+	if(!overmind)
 		create_overmind()
 	else
 		if(resource_delay <= world.time)
@@ -94,7 +91,7 @@
 
 
 /obj/effect/blob/core/proc/create_overmind(var/client/new_overmind, var/override_delay)
-	if(overmind_get_delay > world.time && !override_delay && !new_overmind)
+	if(overmind_get_delay > world.time && !override_delay)
 		return
 
 	overmind_get_delay = world.time + 3000 // 5 minutes

--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -10,13 +10,16 @@
 	var/point_rate = 2
 	var/is_offspring = null
 	var/selecting = 0
+	var/grab_overmind = 1
 
-/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring)
+/obj/effect/blob/core/New(loc, var/h = 200, var/client/new_overmind = null, var/new_rate = 2, offspring, is_event)
 	blob_cores += src
 	processing_objects.Add(src)
 	poi_list |= src
 	adjustcolors(color) //so it atleast appears
-	if(!overmind)
+	if(is_event)
+		grab_overmind = 0
+	if(!overmind && grab_overmind)
 		create_overmind(new_overmind)
 	if(overmind)
 		adjustcolors(overmind.blob_reagent_datum.color)
@@ -61,7 +64,7 @@
 	return // Don't regen, we handle it in Life()
 
 /obj/effect/blob/core/Life()
-	if(!overmind)
+	if(!overmind && grab_overmind)
 		create_overmind()
 	else
 		if(resource_delay <= world.time)
@@ -91,7 +94,7 @@
 
 
 /obj/effect/blob/core/proc/create_overmind(var/client/new_overmind, var/override_delay)
-	if(overmind_get_delay > world.time && !override_delay)
+	if(overmind_get_delay > world.time && !override_delay && !new_overmind)
 		return
 
 	overmind_get_delay = world.time + 3000 // 5 minutes

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -14,8 +14,8 @@
 	var/mob/C
 	if(candidates.len)
 		C = pick(candidates)
-		Blob = new /obj/effect/blob/core(T, 200, C.client, 2, 0)
-		for(var/i = 1; i < rand(3, 6), i++)
+		Blob = new /obj/effect/blob/core(T, new_overmind=C.client)
+		for(var/i in 1 to 5)
 			Blob.process()
 	else
 		return kill()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -14,8 +14,7 @@
 	var/mob/C
 	if(candidates.len)
 		C = pick(candidates)
-		Blob = new /obj/effect/blob/core(T, 200, null, 2, 0, 1)
-		Blob.create_overmind(C.client, 1)
+		Blob = new /obj/effect/blob/core(T, 200, C.client, 2, 0)
 		for(var/i = 1; i < rand(3, 6), i++)
 			Blob.process()
 	else

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -14,11 +14,10 @@
 	var/mob/C
 	if(candidates.len)
 		C = pick(candidates)
-		Blob = new /obj/effect/blob/core(T, 200)
+		Blob = new /obj/effect/blob/core(T, 200, null, 2, 0, 1)
 		Blob.create_overmind(C.client, 1)
-		spawn(30)
-			for(var/i = 1; i < rand(3, 6), i++)
-				Blob.process()
+		for(var/i = 1; i < rand(3, 6), i++)
+			Blob.process()
 	else
 		return kill()
 


### PR DESCRIPTION
Blobs should no longer prompt twice for players.

Would appreciate review of the logic on this one - I cannot completely test it by myself as it requires multiple players. I have tested that blob spawns still work, but I have not verified this eliminates the second prompt. Given the logic, though, it should fix the problem.

🆑
fix: Fixes blob spawns prompting players twice.
/🆑