### PR TITLE
Replaces the IPC APC grabbing thing with a power cord and lets IPCs be genderless

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -135,6 +135,7 @@ var/global/list/bad_blocks[0]
 	// FIXME:  Species-specific defaults pls
 	var/obj/item/organ/external/head/H = character.get_organ("head")
 	var/obj/item/organ/internal/eyes/eyes_organ = character.get_int_organ(/obj/item/organ/internal/eyes)
+	var/datum/species/S = character.species
 
 	/*// Body Accessory
 	if(!character.body_accessory)
@@ -170,7 +171,11 @@ var/global/list/bad_blocks[0]
 
 	SetUIValueRange(DNA_UI_SKIN_TONE,	35-character.s_tone,	220,	1) // Value can be negative.
 
-	SetUIState(DNA_UI_GENDER, character.gender!=MALE, 1)
+	if(S.has_gender)
+		SetUIState(DNA_UI_GENDER, character.gender!=MALE, 1)
+	else
+		SetUIState(DNA_UI_GENDER, pick(0,1), 1)
+
 	/*SetUIValueRange(DNA_UI_BACC_STYLE,	bodyacc,	facial_hair_styles_list.len,	1)*/
 	SetUIValueRange(DNA_UI_HEAD_MARK_STYLE,	head_marks,		marking_styles_list.len,		1)
 	SetUIValueRange(DNA_UI_BODY_MARK_STYLE,	body_marks,		marking_styles_list.len,		1)

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -132,6 +132,7 @@
 		dna.check_integrity()
 		var/mob/living/carbon/human/H = src
 		var/obj/item/organ/external/head/head_organ = H.get_organ("head")
+		var/datum/species/S = H.species
 		dna.write_head_attributes(head_organ)
 
 		H.r_skin		= dna.GetUIValueRange(DNA_UI_SKIN_R,	255)
@@ -144,10 +145,11 @@
 
 		H.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
 
-		if(dna.GetUIState(DNA_UI_GENDER))
-			H.change_gender(FEMALE, 0)
-		else
-			H.change_gender(MALE, 0)
+		if(S.has_gender)
+			if(dna.GetUIState(DNA_UI_GENDER))
+				H.change_gender(FEMALE, 0)
+			else
+				H.change_gender(MALE, 0)
 
 		//Head Markings
 		var/head_marks = dna.GetUIValueRange(DNA_UI_HEAD_MARK_STYLE, marking_styles_list.len)

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -246,7 +246,6 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	if(!user || !user.client)
 		return
 	update_preview_icon()
-	var/datum/species/S = all_species[species]
 	user << browse_rsc(preview_icon_front, "previewicon.png")
 	user << browse_rsc(preview_icon_side, "previewicon2.png")
 
@@ -280,8 +279,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				dat += "<b>You are banned from using custom names and appearances. \
 				You can continue to adjust your characters, but you will be randomised once you join the game.\
 				</b><br>"
-			if(S.has_gender)
-				dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : "Female"]</a>"
+			dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : (gender == FEMALE ? "Female" : "Genderless")]</a>"
 			dat += "<br>"
 			dat += "<b>Age:</b> <a href='?_src_=prefs;preference=age;task=input'>[age]</a><br>"
 			dat += "<b>Body:</b> <a href='?_src_=prefs;preference=all;task=random'>(&reg;)</a><br>"
@@ -1282,8 +1280,8 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 					species = input("Please select a species", "Character Generation", null) in new_species
 					var/datum/species/NS = all_species[species]
 					if(prev_species != species)
-						if(S.has_gender != NS.has_gender)
-							gender = (NS.has_gender ? pick(MALE,FEMALE) : PLURAL)
+						if(NS.has_gender && gender == PLURAL)
+							gender = pick(MALE,FEMALE)
 						var/datum/robolimb/robohead
 						if(species == "Machine")
 							var/head_model = "[!rlimb_data["head"] ? "Morpheus Cyberkinetics" : rlimb_data["head"]]"
@@ -1916,7 +1914,14 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 				if("gender")
 					if(!S.has_gender)
-						gender = PLURAL
+						var/newgender = input(user, "Choose Gender:") as null|anything in list("Male", "Female", "Genderless")
+						switch(newgender)
+							if("Male")
+								gender = MALE
+							if("Female")
+								gender = FEMALE
+							if("Genderless")
+								gender = PLURAL
 					else
 						if(gender == MALE)
 							gender = FEMALE

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -246,6 +246,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	if(!user || !user.client)
 		return
 	update_preview_icon()
+	var/datum/species/S = all_species[species]
 	user << browse_rsc(preview_icon_front, "previewicon.png")
 	user << browse_rsc(preview_icon_side, "previewicon2.png")
 
@@ -279,7 +280,9 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				dat += "<b>You are banned from using custom names and appearances. \
 				You can continue to adjust your characters, but you will be randomised once you join the game.\
 				</b><br>"
-			dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : "Female"]</a><br>"
+			if(S.has_gender)
+				dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : "Female"]</a>"
+			dat += "<br>"
 			dat += "<b>Age:</b> <a href='?_src_=prefs;preference=age;task=input'>[age]</a><br>"
 			dat += "<b>Body:</b> <a href='?_src_=prefs;preference=all;task=random'>(&reg;)</a><br>"
 			dat += "<b>Species:</b> <a href='?_src_=prefs;preference=species;task=input'>[species]</a><br>"
@@ -1031,6 +1034,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
 	if(!user)	return
 
+	var/datum/species/S = all_species[species]
 	if(href_list["preference"] == "job")
 		switch(href_list["task"])
 			if("close")
@@ -1266,9 +1270,9 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 //						var/whitelisted = 0
 
 					if(config.usealienwhitelist) //If we're using the whitelist, make sure to check it!
-						for(var/S in whitelisted_species)
-							if(is_alien_whitelisted(user,S))
-								new_species += S
+						for(var/Spec in whitelisted_species)
+							if(is_alien_whitelisted(user,Spec))
+								new_species += Spec
 //									whitelisted = 1
 //							if(!whitelisted)
 //								alert(user, "You cannot change your species as you need to be whitelisted. If you wish to be whitelisted contact an admin in-game, on the forums, or on IRC.")
@@ -1276,8 +1280,10 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						new_species += whitelisted_species
 
 					species = input("Please select a species", "Character Generation", null) in new_species
-
+					var/datum/species/NS = all_species[species]
 					if(prev_species != species)
+						if(S.has_gender != NS.has_gender)
+							gender = (NS.has_gender ? pick(MALE,FEMALE) : PLURAL)
 						var/datum/robolimb/robohead
 						if(species == "Machine")
 							var/head_model = "[!rlimb_data["head"] ? "Morpheus Cyberkinetics" : rlimb_data["head"]]"
@@ -1315,16 +1321,16 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							m_colours["tail"] = "#000000"
 
 						// Don't wear another species' underwear!
-						var/datum/sprite_accessory/S = underwear_list[underwear]
-						if(!S || !(species in S.species_allowed))
+						var/datum/sprite_accessory/SA = underwear_list[underwear]
+						if(!SA || !(species in SA.species_allowed))
 							underwear = random_underwear(gender, species)
 
-						S = undershirt_list[undershirt]
-						if(!S || !(species in S.species_allowed))
+						SA = undershirt_list[undershirt]
+						if(!SA || !(species in SA.species_allowed))
 							undershirt = random_undershirt(gender, species)
 
-						S = socks_list[socks]
-						if(!S || !(species in S.species_allowed))
+						SA = socks_list[socks]
+						if(!SA || !(species in SA.species_allowed))
 							socks = random_socks(gender, species)
 
 						//reset skin tone and colour
@@ -1402,7 +1408,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				if("h_style")
 					var/list/valid_hairstyles = list()
 					for(var/hairstyle in hair_styles_list)
-						var/datum/sprite_accessory/S = hair_styles_list[hairstyle]
+						var/datum/sprite_accessory/SA = hair_styles_list[hairstyle]
 
 						if(hairstyle == "Bald") //Just in case.
 							valid_hairstyles += hairstyle
@@ -1414,14 +1420,14 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							else
 								head_model = rlimb_data["head"]
 							var/datum/robolimb/robohead = all_robolimbs[head_model]
-							if((species in S.species_allowed) && robohead.is_monitor && ((S.models_allowed && (robohead.company in S.models_allowed)) || !S.models_allowed)) //If this is a hair style native to the user's species, check to see if they have a head with an ipc-style screen and that the head's company is in the screen style's allowed models list.
+							if((species in SA.species_allowed) && robohead.is_monitor && ((SA.models_allowed && (robohead.company in SA.models_allowed)) || !SA.models_allowed)) //If this is a hair style native to the user's species, check to see if they have a head with an ipc-style screen and that the head's company is in the screen style's allowed models list.
 								valid_hairstyles += hairstyle //Give them their hairstyles if they do.
 							else
-								if(!robohead.is_monitor && ("Human" in S.species_allowed)) /*If the hairstyle is not native to the user's species and they're using a head with an ipc-style screen, don't let them access it.
+								if(!robohead.is_monitor && ("Human" in SA.species_allowed)) /*If the hairstyle is not native to the user's species and they're using a head with an ipc-style screen, don't let them access it.
 																							But if the user has a robotic humanoid head and the hairstyle can fit humans, let them use it as a wig. */
 									valid_hairstyles += hairstyle
 						else //If the user is not a species who can have robotic heads, use the default handling.
-							if(species in S.species_allowed) //If the user's head is of a species the hairstyle allows, add it to the list.
+							if(species in SA.species_allowed) //If the user's head is of a species the hairstyle allows, add it to the list.
 								valid_hairstyles += hairstyle
 
 					var/new_h_style = input(user, "Choose your character's hair style:", "Character Preference") as null|anything in valid_hairstyles
@@ -1609,14 +1615,14 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				if("f_style")
 					var/list/valid_facial_hairstyles = list()
 					for(var/facialhairstyle in facial_hair_styles_list)
-						var/datum/sprite_accessory/S = facial_hair_styles_list[facialhairstyle]
+						var/datum/sprite_accessory/SA = facial_hair_styles_list[facialhairstyle]
 
 						if(facialhairstyle == "Shaved") //Just in case.
 							valid_facial_hairstyles += facialhairstyle
 							continue
-						if(gender == MALE && S.gender == FEMALE)
+						if(gender == MALE && SA.gender == FEMALE)
 							continue
-						if(gender == FEMALE && S.gender == MALE)
+						if(gender == FEMALE && SA.gender == MALE)
 							continue
 						if(species == "Machine") //Species that can use prosthetic heads.
 							var/head_model
@@ -1625,14 +1631,14 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							else
 								head_model = rlimb_data["head"]
 							var/datum/robolimb/robohead = all_robolimbs[head_model]
-							if((species in S.species_allowed) && robohead.is_monitor && ((S.models_allowed && (robohead.company in S.models_allowed)) || !S.models_allowed)) //If this is a facial hair style native to the user's species, check to see if they have a head with an ipc-style screen and that the head's company is in the screen style's allowed models list.
+							if((species in SA.species_allowed) && robohead.is_monitor && ((SA.models_allowed && (robohead.company in SA.models_allowed)) || !SA.models_allowed)) //If this is a facial hair style native to the user's species, check to see if they have a head with an ipc-style screen and that the head's company is in the screen style's allowed models list.
 								valid_facial_hairstyles += facialhairstyle //Give them their facial hairstyles if they do.
 							else
-								if(!robohead.is_monitor && ("Human" in S.species_allowed)) /*If the facial hairstyle is not native to the user's species and they're using a head with an ipc-style screen, don't let them access it.
+								if(!robohead.is_monitor && ("Human" in SA.species_allowed)) /*If the facial hairstyle is not native to the user's species and they're using a head with an ipc-style screen, don't let them access it.
 																							But if the user has a robotic humanoid head and the facial hairstyle can fit humans, let them use it as a wig. */
 									valid_facial_hairstyles += facialhairstyle
 						else //If the user is not a species who can have robotic heads, use the default handling.
-							if(species in S.species_allowed) //If the user's head is of a species the facial hair style allows, add it to the list.
+							if(species in SA.species_allowed) //If the user's head is of a species the facial hair style allows, add it to the list.
 								valid_facial_hairstyles += facialhairstyle
 
 					var/new_f_style = input(user, "Choose your character's facial-hair style:", "Character Preference")  as null|anything in valid_facial_hairstyles
@@ -1642,12 +1648,12 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				if("underwear")
 					var/list/valid_underwear = list()
 					for(var/underwear in underwear_list)
-						var/datum/sprite_accessory/S = underwear_list[underwear]
-						if(gender == MALE && S.gender == FEMALE)
+						var/datum/sprite_accessory/SA = underwear_list[underwear]
+						if(gender == MALE && SA.gender == FEMALE)
 							continue
-						if(gender == FEMALE && S.gender == MALE)
+						if(gender == FEMALE && SA.gender == MALE)
 							continue
-						if(!(species in S.species_allowed))
+						if(!(species in SA.species_allowed))
 							continue
 						valid_underwear[underwear] = underwear_list[underwear]
 					var/new_underwear = input(user, "Choose your character's underwear:", "Character Preference") as null|anything in valid_underwear
@@ -1657,12 +1663,12 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				if("undershirt")
 					var/list/valid_undershirts = list()
 					for(var/undershirt in undershirt_list)
-						var/datum/sprite_accessory/S = undershirt_list[undershirt]
-						if(gender == MALE && S.gender == FEMALE)
+						var/datum/sprite_accessory/SA = undershirt_list[undershirt]
+						if(gender == MALE && SA.gender == FEMALE)
 							continue
-						if(gender == FEMALE && S.gender == MALE)
+						if(gender == FEMALE && SA.gender == MALE)
 							continue
-						if(!(species in S.species_allowed))
+						if(!(species in SA.species_allowed))
 							continue
 						valid_undershirts[undershirt] = undershirt_list[undershirt]
 					var/new_undershirt = input(user, "Choose your character's undershirt:", "Character Preference") as null|anything in valid_undershirts
@@ -1673,12 +1679,12 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				if("socks")
 					var/list/valid_sockstyles = list()
 					for(var/sockstyle in socks_list)
-						var/datum/sprite_accessory/S = socks_list[sockstyle]
-						if(gender == MALE && S.gender == FEMALE)
+						var/datum/sprite_accessory/SA = socks_list[sockstyle]
+						if(gender == MALE && SA.gender == FEMALE)
 							continue
-						if(gender == FEMALE && S.gender == MALE)
+						if(gender == FEMALE && SA.gender == MALE)
 							continue
-						if(!(species in S.species_allowed))
+						if(!(species in SA.species_allowed))
 							continue
 						valid_sockstyles[sockstyle] = socks_list[sockstyle]
 					var/new_socks = input(user, "Choose your character's socks:", "Character Preference")  as null|anything in valid_sockstyles
@@ -1909,10 +1915,13 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						toggles ^= DONATOR_PUBLIC
 
 				if("gender")
-					if(gender == MALE)
-						gender = FEMALE
+					if(!S.has_gender)
+						gender = PLURAL
 					else
-						gender = MALE
+						if(gender == MALE)
+							gender = FEMALE
+						else
+							gender = MALE
 					underwear = random_underwear(gender)
 
 				if("hear_adminhelps")
@@ -2155,7 +2164,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	character.backbag = backbag
 
 	//Debugging report to track down a bug, which randomly assigned the plural gender to people.
-	if(character.gender in list(PLURAL, NEUTER))
+	if(S.has_gender && (character.gender in list(PLURAL, NEUTER)))
 		if(isliving(src)) //Ghosts get neuter by default
 			message_admins("[key_name_admin(character)] has spawned with their gender as plural or neuter. Please notify coders.")
 			character.change_gender(MALE)

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -270,6 +270,7 @@
 		gear = params2list(query.item[65])
 
 	//Sanitize
+	var/datum/species/SP = all_species[species]
 	metadata		= sanitize_text(metadata, initial(metadata))
 	real_name		= reject_bad_name(real_name, 1)
 	if(isnull(species)) species = "Human"
@@ -278,7 +279,7 @@
 	if(isnull(speciesprefs)) speciesprefs = initial(speciesprefs)
 	if(!real_name) real_name = random_name(gender,species)
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
-	gender			= sanitize_gender(gender)
+	gender			= sanitize_gender(gender, FALSE, !SP.has_gender)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
 	r_hair			= sanitize_integer(r_hair, 0, 255, initial(r_hair))
 	g_hair			= sanitize_integer(g_hair, 0, 255, initial(g_hair))

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -16,7 +16,7 @@
 
 /mob/living/carbon/human/proc/change_gender(var/new_gender, var/update_dna = 1)
 	var/obj/item/organ/external/head/H = organs_by_name["head"]
-	if(gender == new_gender)
+	if(gender == new_gender || (gender == PLURAL && species.has_gender))
 		return
 
 	gender = new_gender

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -33,7 +33,7 @@
 
 	var/msg = "<span class='info'>*---------*\nThis is "
 
-	if(skipjumpsuit && skipface) //big suits/masks/helmets make it hard to tell their gender
+	if((skipjumpsuit && skipface)) //big suits/masks/helmets make it hard to tell their gender
 		t_He = "They"
 		t_his = "their"
 		t_him = "them"
@@ -51,6 +51,12 @@
 				t_He = "She"
 				t_his = "her"
 				t_him = "her"
+			if(PLURAL)
+				t_He = "They"
+				t_his = "their"
+				t_him = "them"
+				t_has = "have"
+				t_is = "are"
 
 	msg += "<EM>[name]</EM>"
 
@@ -494,7 +500,7 @@
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=[UID()];medrecord=`'>\[View\]</a> <a href='?src=[UID()];medrecordadd=`'>\[Add comment\]</a>\n"
 
 
-	if(print_flavor_text() && !skipface) 
+	if(print_flavor_text() && !skipface)
 		msg += "[print_flavor_text()]\n"
 
 	msg += "*---------*</span>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1483,6 +1483,7 @@
 
 /mob/living/carbon/human/proc/set_species(var/new_species, var/default_colour, var/delay_icon_update = 0)
 	var/datum/species/oldspecies = species
+	var/datum/species/NS = all_species[new_species]
 	if(!dna)
 		if(!new_species)
 			new_species = "Human"
@@ -1502,6 +1503,8 @@
 		if(species.default_language)
 			remove_language(species.default_language)
 
+		if(gender == PLURAL && NS.has_gender)
+			change_gender(pick(MALE,FEMALE))
 		species.handle_pre_change(src)
 
 	species = all_species[new_species]

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -110,6 +110,7 @@
 	var/show_ssd = 1
 	var/virus_immune
 	var/can_revive_by_healing				// Determines whether or not this species can be revived by simply healing them
+	var/has_gender = TRUE
 
 	//Death vars.
 	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -887,6 +887,7 @@
 	default_hair = "Blue IPC Screen"
 	virus_immune = 1
 	can_revive_by_healing = 1
+	has_gender = FALSE
 	reagent_tag = PROCESS_SYN
 	male_scream_sound = 'sound/goonstation/voice/robot_scream.ogg'
 	female_scream_sound = 'sound/goonstation/voice/robot_scream.ogg'

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -899,7 +899,8 @@
 	has_organ = list(
 		"brain" = /obj/item/organ/internal/brain/mmi_holder/posibrain,
 		"cell" = /obj/item/organ/internal/cell,
-		"optics" = /obj/item/organ/internal/eyes/optical_sensor //Default darksight of 2.
+		"optics" = /obj/item/organ/internal/eyes/optical_sensor, //Default darksight of 2.
+		"charger" = /obj/item/organ/internal/cyberimp/chest/arm_mod/power_cord
 		)
 
 	vision_organ = /obj/item/organ/internal/eyes/optical_sensor

--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -223,6 +223,7 @@
 
 	data["specimen"] = owner.species.name
 	data["gender"] = owner.gender
+	data["has_gender"] = owner.species.has_gender
 	data["change_race"] = can_change(APPEARANCE_RACE)
 	if(data["change_race"])
 		var/species[0]

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -640,6 +640,9 @@
 				(istype(W, /obj/item/device/multitool) || \
 				istype(W, /obj/item/weapon/wirecutters) || istype(W, /obj/item/device/assembly/signaler)))
 				return src.attack_hand(user)
+			if(W.flags & NOBLUDGEON)
+				return
+			user.changeNext_move(CLICK_CD_MELEE)
 			user.do_attack_animation(src)
 			user.visible_message("<span class='warning'>The [src.name] has been hit with the [W.name] by [user.name]!</span>", \
 				"<span class='warning'>You hit the [src.name] with your [W.name]!</span>", \
@@ -667,36 +670,6 @@
 	if(!user)
 		return
 	src.add_fingerprint(user)
-	//Synthetic human mob goes here.
-	if(istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		if(H.get_int_organ(/obj/item/organ/internal/cell) && H.a_intent == I_GRAB)
-			if(emagged || stat & BROKEN)
-				var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
-				s.set_up(3, 1, src)
-				s.start()
-				to_chat(H, "<span class='warning'>The APC power currents surge erratically, damaging your chassis!</span>")
-				H.adjustFireLoss(10,0)
-			else if(src.cell && src.cell.charge > 0)
-				if(H.nutrition < NUTRITION_LEVEL_WELL_FED)
-					if(src.cell.charge >= 500)
-						H.nutrition += 50
-						src.cell.charge -= 500
-					else
-						H.nutrition += src.cell.charge/10
-						src.cell.charge = 0
-
-					to_chat(user, "<span class='notice'>You slot your fingers into the APC interface and siphon off some of the stored charge for your own use.</span>")
-					if(src.cell.charge < 0)
-						src.cell.charge = 0
-					if(H.nutrition > NUTRITION_LEVEL_WELL_FED + 50)
-						H.nutrition = NUTRITION_LEVEL_WELL_FED + 50
-					src.charging = 1
-				else
-					to_chat(user, "<span class='notice'>You are already fully charged.</span>")
-			else
-				to_chat(user, "<span class='warning'>There is no charge to draw from that APC.</span>")
-			return
 
 	if(usr == user && opened && (!issilicon(user)))
 		if(cell)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -11,9 +11,9 @@
 	var/non_primary = 0
 
 /obj/item/organ/internal/New(var/mob/living/carbon/holder)
+	..()
 	if(istype(holder))
 		insert(holder)
-	..()
 
 /obj/item/organ/internal/Destroy()
 	if(owner)
@@ -412,7 +412,8 @@
 	colourmatrix = null
 	dark_view = 2
 	..() //Make sure the organ's got the robotic status indicators before updating the client colour.
-	owner.update_client_colour(0) //Since both mechassisted and mechanical eyes give dark_view of 2 and full colour vision atm, just having this here is fine as mechassist() will call it anyway.
+	if(owner)
+		owner.update_client_colour(0) //Since both mechassisted and mechanical eyes give dark_view of 2 and full colour vision atm, just having this here is fine as mechassist() will call it anyway.
 
 /obj/item/organ/internal/mechassist()
 	..() //Go back, call robotize(), adjust the robotic status indicators and the organ damage parameters.

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -398,11 +398,16 @@
 			return
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
+		var/found_damaged_organ = FALSE
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(I && I.damage > 0)
-				if(I.robotic >= 2)
-					user.visible_message("[user] starts mending the damage to [target]'s [I.name]'s mechanisms.", \
-					"You start mending the damage to [target]'s [I.name]'s mechanisms." )
+			if(I && I.damage > 0 && I.robotic >= 2)
+				user.visible_message("[user] starts mending the damage to [target]'s [I.name]'s mechanisms.", \
+				"You start mending the damage to [target]'s [I.name]'s mechanisms.")
+				found_damaged_organ = TRUE
+
+		if(!found_damaged_organ)
+			to_chat(user, "There are no damaged components in [affected].")
+			return -1
 
 		target.custom_pain("The pain in your [affected.name] is living hell!",1)
 
@@ -425,6 +430,7 @@
 					user.visible_message("<span class='notice'> [user] repairs [target]'s [I.name] with [tool].</span>", \
 					"<span class='notice'> You repair [target]'s [I.name] with [tool].</span>" )
 					I.damage = 0
+					I.surgeryize()
 	else if(current_type == "insert")
 		var/obj/item/organ/internal/I = tool
 

--- a/nano/templates/appearance_changer.tmpl
+++ b/nano/templates/appearance_changer.tmpl
@@ -19,6 +19,9 @@
         <div class="itemContentWide">
             {{:helper.link('Male', null, { 'gender' : 'male'}, null, data.gender == 'male' ? 'selected' : null)}}
             {{:helper.link('Female', null, { 'gender' : 'female'}, null, data.gender == 'female' ? 'selected' : null)}}
+						{{if !data.has_gender}}
+							{{:helper.link('Genderless', null, { 'gender' : 'plural'}, null, data.gender == 'plural' ? 'selected' : null)}}
+						{{/if}}
         </div>
     </div>
 {{/if}}


### PR DESCRIPTION
:cl:Crazylemon
rscadd: IPCs now come with a power cord implant to use to recharge from APCs.
tweak: IPCs can now be genderless.
/:cl:

The adjusted preferences screen looks like so:
![ipc_prefs](https://cloud.githubusercontent.com/assets/5661700/23340186/eb4b772c-fbe6-11e6-8e76-3403187bd914.png)


This also allows us to easily make species genderless in the future.