### PR TITLE
Supports +2 Security Officer slots

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -149,8 +149,8 @@
 	title = "Security Officer"
 	flag = OFFICER
 	department_flag = ENGSEC
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 7
+	spawn_positions = 7
 	is_security = 1
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"

--- a/config/example/jobs.txt
+++ b/config/example/jobs.txt
@@ -24,7 +24,7 @@ Shaft Miner=3
 
 Warden=1
 Detective=1
-Security Officer=5
+Security Officer=7
 
 Assistant=-1
 Atmospheric Technician=4


### PR DESCRIPTION
Changes security officer job slots from 5 to 7.
No map changes, as brig already has 8 sec lockers (plus an additional one in arrivals, 9 in total). Plus, I don't want to conflict with Free's PR.

🆑 Kyep
tweak: changed security officer job slots from 5 to 7. 
/🆑