### PR TITLE
Fixes spam when mentors check playtime/playerage

### DIFF
--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -19,7 +19,7 @@
 				jtext = theirjob.title
 				if(config.use_exp_restrictions && theirjob.exp_requirements && theirjob.exp_type)
 					jtext += "<span class='warning'>*</span>"
-		if(check_rights(R_ADMIN))
+		if(check_rights(R_ADMIN, 0))
 			pline = "<LI> [key_name_admin(C.mob)]: [jtext]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"
 		else
 			pline = "<LI> [key_name_mentor(C.mob)]: [jtext]: <A href='?_src_=holder;getplaytimewindow=[C.mob.UID()]'>" + C.get_exp_living() + "</a></LI>"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -88,7 +88,7 @@
 			missing_ages = 1
 			continue
 		if(C.player_age < age)
-			if(check_rights(R_ADMIN))
+			if(check_rights(R_ADMIN, 0))
 				msg += "[key_name_admin(C.mob)]: [C.player_age] days old<br>"
 			else
 				msg += "[key_name_mentor(C.mob)]: [C.player_age] days old<br>"
@@ -899,7 +899,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		to_chat(usr, "\red ERT has been <b>Disabled</b>.")
 		log_admin("Admin [key_name(src)] has disabled ERT calling.")
 		message_admins("Admin [key_name_admin(usr)] has disabled ERT calling.", 1)
-		
+
 /client/proc/modify_goals()
 	set category = "Event"
 	set name = "Modify Station Goals"
@@ -913,7 +913,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!ticker || !ticker.mode)
 		to_chat(usr, "<span class='warning'>This verb can only be used if the round has started.</span>")
 		return
-	
+
 	var/dat = ""
 	for(var/datum/station_goal/S in ticker.mode.station_goals)
 		dat += "[S.name] - <a href='?src=[S.UID()];announce=1'>Announce</a> | <a href='?src=[S.UID()];remove=1'>Remove</a><br>"


### PR DESCRIPTION
Prevents MENTORs getting a stream of "You do not have sufficient rights to do that. You require one of the following flags: +ADMIN" when using "check player age" or "check playtime".

No CL as staff-only.