### PR TITLE
Terror Spiders 4 - Fixes & Tweaks

### DIFF
--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -186,6 +186,7 @@
 	force = 10
 	origin_tech = null
 	selfcharge = 1
+	can_charge = 0
 	var/inawaymission = 1
 
 /obj/item/weapon/gun/energy/laser/awaymission_aeg/process()

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -191,7 +191,7 @@ var/list/event_last_fired = list()
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",	/datum/event/abductor, 		    80, is_one_shot = 1),
 		new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 30), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			0, is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",			/datum/event/spider_terror, 		0,			list(ASSIGNMENT_SECURITY = 20), is_one_shot = 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",			/datum/event/spider_terror, 		0,			list(ASSIGNMENT_SECURITY = 15), is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	15, is_one_shot = 1)
 	)
 

--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -1,6 +1,6 @@
 
 /datum/event/spider_terror
-	announceWhen = 120
+	announceWhen = 240
 	var/spawncount = 1
 
 /datum/event/spider_terror/setup()
@@ -22,7 +22,7 @@
 	switch(infestation_type)
 		if(1)
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/green
-			spawncount = 3
+			spawncount = 4
 		if(2)
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/white
 			spawncount = 2

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -7,7 +7,7 @@
 
 /datum/action/innate/terrorspider/web/Activate()
 	var/mob/living/simple_animal/hostile/poison/terror_spider/user = owner
-	user.Web()
+	user.Web(0)
 
 /datum/action/innate/terrorspider/wrap
 	name = "Wrap"
@@ -32,14 +32,25 @@
 
 // ---------- PRINCE ACTIONS
 
-/datum/action/innate/terrorspider/princesmash
+/datum/action/innate/terrorspider/thickweb
+	name = "Thick Web"
+	icon_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "stickyweb2"
+
+/datum/action/innate/terrorspider/thickweb/Activate()
+	var/mob/living/simple_animal/hostile/poison/terror_spider/user = owner
+	user.Web(1)
+
+// ---------- BOSS ACTIONS
+
+/datum/action/innate/terrorspider/ventsmash
 	name = "Smash Welded Vent"
 	icon_icon = 'icons/atmos/vent_pump.dmi'
 	button_icon_state = "map_vent"
 
-/datum/action/innate/terrorspider/princesmash/Activate()
-	var/mob/living/simple_animal/hostile/poison/terror_spider/prince/user = owner
-	user.DoPrinceSmash()
+/datum/action/innate/terrorspider/ventsmash/Activate()
+	var/mob/living/simple_animal/hostile/poison/terror_spider/user = owner
+	user.DoVentSmash()
 
 // ---------- QUEEN ACTIONS
 
@@ -50,7 +61,7 @@
 
 /datum/action/innate/terrorspider/queen/queennest/Activate()
 	var/mob/living/simple_animal/hostile/poison/terror_spider/queen/user = owner
-	user.NestMode()
+	user.NestPrompt()
 
 /datum/action/innate/terrorspider/queen/queensense
 	name = "Hive Sense"
@@ -81,7 +92,7 @@
 
 // ---------- WEB
 
-/mob/living/simple_animal/hostile/poison/terror_spider/proc/Web()
+/mob/living/simple_animal/hostile/poison/terror_spider/proc/Web(var/thick = 0)
 	var/turf/mylocation = loc
 	visible_message("<span class='notice'>[src] begins to secrete a sticky substance.</span>")
 	if(do_after(src, delay_web, target = loc))
@@ -96,6 +107,8 @@
 			else
 				var/obj/effect/spider/terrorweb/W = new /obj/effect/spider/terrorweb(loc)
 				W.creator_ckey = ckey
+				if(thick)
+					W.opacity = 1
 
 /obj/effect/spider/terrorweb
 	name = "terror web"
@@ -214,7 +227,7 @@
 		busy = 0
 		stop_automated_movement = 0
 
-/mob/living/simple_animal/hostile/poison/terror_spider/prince/proc/DoPrinceSmash()
+/mob/living/simple_animal/hostile/poison/terror_spider/proc/DoVentSmash()
 	for(var/obj/machinery/atmospherics/unary/vent_pump/P in view(1,src))
 		if(P.welded)
 			P.welded = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -25,7 +25,12 @@
 	spider_tier = TS_TIER_3
 	spider_opens_doors = 2
 	var/canspawn = 1
+	var/datum/action/innate/terrorspider/ventsmash/ventsmash_action
 
+/mob/living/simple_animal/hostile/poison/terror_spider/mother/New()
+	..()
+	ventsmash_action = new()
+	ventsmash_action.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/mother/death(gibbed)
 	if(canspawn)
@@ -38,6 +43,7 @@
 			else if(prob(10))
 				S.grow_as = pick(/mob/living/simple_animal/hostile/poison/terror_spider/black, /mob/living/simple_animal/hostile/poison/terror_spider/green)
 			S.amount_grown = 50 // double speed growth
+			S.immediate_ventcrawl = 1
 		visible_message("<span class='userdanger'>[src] breaks apart, the many spiders on its back scurrying everywhere!</span>")
 		degenerate = 1
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -19,8 +19,8 @@
 	maxHealth = 600 // 30 laser shots
 	health = 600
 	regen_points_per_hp = 6 // double the normal - IE halved regen speed
-	melee_damage_lower = 20
-	melee_damage_upper = 30
+	melee_damage_lower = 30
+	melee_damage_upper = 40
 	move_to_delay = 4 // faster than normal
 	ventcrawler = 0
 	ai_ventcrawls = 0
@@ -29,13 +29,12 @@
 	idle_ventcrawl_chance = 0
 	spider_tier = TS_TIER_3
 	spider_opens_doors = 2
-	var/datum/action/innate/terrorspider/princesmash/princesmash_action
-
+	var/datum/action/innate/terrorspider/thickweb/thickweb_action
 
 /mob/living/simple_animal/hostile/poison/terror_spider/prince/New()
 	..()
-	princesmash_action = new()
-	princesmash_action.Grant(src)
+	thickweb_action = new()
+	thickweb_action.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/prince/death(gibbed)
 	if(!hasdied)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -18,6 +18,7 @@
 	icon_dead = "terror_queen_dead"
 	maxHealth = 200
 	health = 200
+	regen_points_per_tick = 3
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	move_to_delay = 15 // yeah, this is very slow, but
@@ -30,7 +31,7 @@
 	var/neststep = 0
 	var/hasnested = 0
 	var/spider_max_per_nest = 20 // above this, queen stops spawning more, and declares war.
-	var/canlay = 0 // main counter for egg-laying ability! # = num uses, incremented at intervals
+	var/canlay = 4 // main counter for egg-laying ability! # = num uses, incremented at intervals
 	var/eggslaid = 0
 	var/spider_can_fakelings = 3 // spawns defective spiderlings that don't grow up, used to freak out crew, atmosphere
 	idle_ventcrawl_chance = 0
@@ -47,12 +48,14 @@
 	var/datum/action/innate/terrorspider/queen/queensense/queensense_action
 	var/datum/action/innate/terrorspider/queen/queeneggs/queeneggs_action
 	var/datum/action/innate/terrorspider/queen/queenfakelings/queenfakelings_action
-
+	var/datum/action/innate/terrorspider/ventsmash/ventsmash_action
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/New()
 	..()
 	queennest_action = new()
 	queennest_action.Grant(src)
+	ventsmash_action = new()
+	ventsmash_action.Grant(src)
 	spider_myqueen = src
 	if(spider_awaymission)
 		spider_growinstantly = 1
@@ -160,8 +163,6 @@
 					if(prob(20))
 						var/obj/effect/spider/eggcluster/terror_eggcluster/N = locate() in get_turf(src)
 						if(!N)
-							if(!spider_awaymission)
-								QueenFakeLings()
 							spider_lastspawn = world.time
 							DoLayTerrorEggs(/mob/living/simple_animal/hostile/poison/terror_spider/red, 2, 1)
 							neststep = 5
@@ -214,6 +215,11 @@
 						else
 							DoLayTerrorEggs(/mob/living/simple_animal/hostile/poison/terror_spider/purple, 2, 0)
 						neststep = 6
+
+/mob/living/simple_animal/hostile/poison/terror_spider/queen/proc/NestPrompt()
+	var/confirm = alert(src, "Are you sure you want to nest? You will be able to lay eggs, and smash walls, but not ventcrawl.","Nest?","Yes","No")
+	if(confirm == "Yes")
+		NestMode()
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/proc/NestMode()
 	queeneggs_action = new()
@@ -316,6 +322,9 @@
 			C.toggle_cam(src, 0)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/queen/proc/QueenFakeLings()
+	if(eggslaid < 10)
+		to_chat(src, "<span class='danger'>You must lay at least 10 eggs before doing this.</span>")
+		return
 	if(spider_can_fakelings)
 		spider_can_fakelings--
 		var/numlings = 15

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -15,6 +15,7 @@
 	var/spider_myqueen = null
 	var/use_vents = 1
 	var/list/enemies = list()
+	var/immediate_ventcrawl = 0
 
 /obj/effect/spider/spiderling/terror_spiderling/New()
 	..()
@@ -73,8 +74,10 @@
 		var/list/nearby = oview(10, src)
 		if(nearby.len)
 			var/target_atom = pick(nearby)
-			walk_to(src, target_atom)
-	else if(prob(10) && use_vents)
+			if(!istype(get_turf(target_atom),/turf/space))
+				walk_to(src, target_atom)
+	else if(immediate_ventcrawl || (prob(10) && use_vents))
+		immediate_ventcrawl = 0
 		for(var/obj/machinery/atmospherics/unary/vent_pump/v in view(7,src))
 			if(!v.welded)
 				entry_vent = v


### PR DESCRIPTION
Changes:
1) Fixes wireless AEGs being able to be recharged in conventional rechargers. This prevents people with recharger access using them as regular laserguns.
2) Fixes spiderlings from dying Mother of Terrors lingering around for a long time. Now, they're forced to ventcrawl immediately if they can.
3) Improves queen health regen. She was regularly getting picked off by one guy with a gun or two.
4) Queen and Mother now gain vent smash ability. Given how often the crew welds literally every vent, this is necessary to avoid them being totally shut out of the vent system in the late game.
5) Prince loses vent smash ability. Instead, he gets the ability to spin thicker (vision-blocking) webs, and +10 melee damage.
6) Fixes 'evil looking spiderling' meta by requiring that queen has laid at least 10 eggs before the ability is usable, so newbie queens don't use it first thing and instantly get discovered/swarmed.
7) Adds confirmation prompt to queen nesting. Queens will no longer be confused about why they cannot ventcrawl after nesting.
8) Reduces the chances of terror spiderlings skittering onto space tiles. Makes them less likely to space themselves.
9) Tweaks TS event by increasing timer, and making green and queen infestations slightly more dangerous. Greens in particular were quite weak, their infestations never succeeding.
10) Reduces the probability of TS infestation events in the major event pool.

🆑 Kyep
fix: Fixed several Terror Spider things that should not be possible, like recharging wireless guns, the 'evil-looking spiderlings' instant meta, and spiderlings spacing themselves.
tweak: Several Terror Spider balance and fun tweaks, such as giving the Prince of Terror a new webbing ability, and ensuring queens/mothers can break open vents, so they cannot be completely shut out late-round. 
/🆑