### PR TITLE
Allows Cargo to order Wood Planks

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1149,6 +1149,13 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 10
 	containername = "glass sheets crate"
 
+/datum/supply_packs/materials/wood30
+	name = "30 Wood Planks Crate"
+	contains = list(/obj/item/stack/sheet/wood)
+	amount = 30
+	cost = 15
+	containername = "wood planks crate"
+
 /datum/supply_packs/materials/cardboard50
 	name = "50 Cardboard Sheets Crate"
 	contains = list(/obj/item/stack/sheet/cardboard)


### PR DESCRIPTION
Only 30 per stack, and 15 points, which is more expensive than metal. Wood in space is rare!

As discussed here: https://nanotrasen.se/phpBB3/viewtopic.php?f=12&t=10050

:cl: Purpose2
rscadd: Enables Cargo to order Wood planks
/:cl: