### PR TITLE
Fixes roundstart airlock runtime

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -990,9 +990,12 @@ About the new airlock wires panel:
 	update_icon()
 	return 1
 
+/obj/machinery/door/airlock/New()
+	..()
+	wires = new(src)
+
 /obj/machinery/door/airlock/initialize()
 	. = ..()
-	wires = new(src)
 	if(closeOtherId != null)
 		for(var/obj/machinery/door/airlock/A in airlocks)
 			if(A.closeOtherId == closeOtherId && A != src)


### PR DESCRIPTION
Related to shuttles and pod doors trying to actuate the doors before the wires exist