### PR TITLE
Plasmaman Suit Auto-Extinguishing Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -249,7 +249,7 @@
 				H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
 			H.IgniteMob()
 	else
-		if(H.fire_stacks)
+		if(H.on_fire && H.fire_stacks > 0)
 			var/obj/item/clothing/suit/space/eva/plasmaman/P = H.wear_suit
 			if(istype(P))
 				P.Extinguish(H)


### PR DESCRIPTION
Had to make it disregard negative firestacks because showers (and probably some other things). This check is extremely similar to one just a few lines above, so it makes sense.

This means that you won't be blowing through extinguisher cartridges because you had firestacks but weren't actually on fire or just had a shower.

Oversight on my part

Fixes #6628 

:cl:
fix: Plasmaman suits will now only auto-extinguish if you're actually on fire (and not just taking a shower).
/:cl: