### PR TITLE
Properly Equips Plasmaman & Vox Multiverse Copies

### DIFF
--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -586,6 +586,11 @@ var/global/list/multiverse = list()
 	W.SetOwnerInfo(M)
 	M.equip_to_slot_or_del(W, slot_wear_id)
 
+	if(M.get_species() == "Vox")
+		M.species.after_equip_job(null, M) //Voxygen(tm)
+	if(M.get_species() == "Plasmaman")
+		M.species.after_equip_job(null, M) //No fireballs from other dimensions.
+
 	M.update_icons()
 
 /obj/item/weapon/multisword/pure_evil

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -35,19 +35,20 @@
 	return message
 
 /datum/species/plasmaman/after_equip_job(datum/job/J, mob/living/carbon/human/H)
+	var/assigned_role = H.mind && H.mind.assigned_role ? H.mind.assigned_role : "Civilian"
 	// Unequip existing suits and hats.
 	H.unEquip(H.wear_suit)
 	H.unEquip(H.head)
-	if(H.mind.assigned_role != "Clown")
+	if(assigned_role != "Clown")
 		H.unEquip(H.wear_mask)
 
 	H.equip_or_collect(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
-	var/suit=/obj/item/clothing/suit/space/eva/plasmaman
-	var/helm=/obj/item/clothing/head/helmet/space/eva/plasmaman
+	var/suit=/obj/item/clothing/suit/space/eva/plasmaman/assistant
+	var/helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/assistant
 	var/tank_slot = slot_s_store
 	var/tank_slot_name = "suit storage"
 
-	switch(H.mind.assigned_role)
+	switch(assigned_role)
 		if("Scientist","Geneticist","Roboticist")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/science
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/science
@@ -55,8 +56,8 @@
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/science/rd
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/science/rd
 		if("Station Engineer", "Mechanic")
-			suit=/obj/item/clothing/suit/space/eva/plasmaman/engineer/
-			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/engineer/
+			suit=/obj/item/clothing/suit/space/eva/plasmaman/engineer
+			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/engineer
 		if("Chief Engineer")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/engineer/ce
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/engineer/ce
@@ -64,11 +65,11 @@
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/atmostech
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/atmostech
 		if("Detective")
-			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/
-			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/
+			suit=/obj/item/clothing/suit/space/eva/plasmaman/security
+			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security
 		if("Warden","Security Officer","Security Pod Pilot")
-			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/
-			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/
+			suit=/obj/item/clothing/suit/space/eva/plasmaman/security
+			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security
 			H.equip_or_collect(new /obj/item/weapon/gun/energy/gun/advtaser(H), slot_in_backpack)
 		if("Internal Affairs Agent")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/lawyer

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -344,12 +344,12 @@
 	return capitalize(newname)
 
 /datum/species/vox/after_equip_job(datum/job/J, mob/living/carbon/human/H)
-	if(H.mind.assigned_role != "Clown" && H.mind.assigned_role != "Mime")
+	if(!H.mind || !H.mind.assigned_role || H.mind.assigned_role != "Clown" && H.mind.assigned_role != "Mime")
 		H.unEquip(H.wear_mask)
 	H.unEquip(H.l_hand)
 
 	H.equip_or_collect(new /obj/item/clothing/mask/breath/vox(H), slot_wear_mask)
-	var/tank_pref = H.client.prefs.speciesprefs
+	var/tank_pref = H.client && H.client.prefs ? H.client.prefs.speciesprefs : null
 	if(tank_pref)//Diseasel, here you go
 		H.equip_or_collect(new /obj/item/weapon/tank/nitrogen(H), slot_l_hand)
 	else


### PR DESCRIPTION
Resolves #6376 by appropriately equipping Vox and Plasmaman multiverse copies. Vox will get their breath mask and nitrogen (and start with it turned on) and Plasmamen will start with their suits, a breathmask, their plasma and internals on. Just like how either species would spawn in at roundstart.

:cl:
fix: Plasmaman multiverse sword copies are now properly equipped (suit, helmet, internals, etc.)
fix: Vox multiverse sword copies are now peoperly equipped (internals).
/:cl: