### PR TITLE
Nerfs Validhunting Chaplains

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -3,7 +3,7 @@
 	desc = "A rod of pure obsidian, its very presence disrupts and dampens the powers of Nar-Sie's followers."
 	icon_state = "nullrod"
 	item_state = "nullrod"
-	force = 18
+	force = 14
 	throw_speed = 3
 	throw_range = 4
 	throwforce = 10
@@ -197,7 +197,7 @@
 	item_state = "hfrequency1"
 	desc = "Bad references are the DNA of the soul."
 	attack_verb = list("chopped", "sliced", "cut", "zandatsu'd")
-	
+
 /obj/item/weapon/nullrod/scythe/spellblade
 	icon_state = "spellblade"
 	item_state = "spellblade"
@@ -328,7 +328,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "carpplushie"
 	item_state = "carp_plushie"
-	force = 15
+	force = 12
 	attack_verb = list("bitten", "eaten", "fin slapped")
 	hitsound = 'sound/weapons/bite.ogg'
 	var/used_blessing = FALSE
@@ -346,7 +346,7 @@
 	name = "monk's staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, now used to harass the clown."
 	w_class = 4
-	force = 15
+	force = 12
 	block_chance = 40
 	slot_flags = SLOT_BACK
 	sharp = 0

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -3,7 +3,7 @@
 	desc = "A rod of pure obsidian, its very presence disrupts and dampens the powers of Nar-Sie's followers."
 	icon_state = "nullrod"
 	item_state = "nullrod"
-	force = 14
+	force = 15
 	throw_speed = 3
 	throw_range = 4
 	throwforce = 10
@@ -328,7 +328,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "carpplushie"
 	item_state = "carp_plushie"
-	force = 12
+	force = 13
 	attack_verb = list("bitten", "eaten", "fin slapped")
 	hitsound = 'sound/weapons/bite.ogg'
 	var/used_blessing = FALSE
@@ -346,7 +346,7 @@
 	name = "monk's staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, now used to harass the clown."
 	w_class = 4
-	force = 12
+	force = 13
 	block_chance = 40
 	slot_flags = SLOT_BACK
 	sharp = 0

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -18,8 +18,6 @@
 	new /obj/item/clothing/suit/holidaypriest(src)
 	new /obj/item/clothing/under/wedding/bride_white(src)
 	new /obj/item/weapon/storage/backpack/cultpack (src)
-	new /obj/item/clothing/head/helmet/riot/knight/templar(src)
-	new /obj/item/clothing/suit/armor/riot/knight/templar(src)
 	new /obj/item/weapon/storage/fancy/candle_box/eternal(src)
 	new /obj/item/weapon/storage/fancy/candle_box/eternal(src)
 	new /obj/item/weapon/storage/fancy/candle_box/eternal(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/chaplain.dm
@@ -18,6 +18,8 @@
 	new /obj/item/clothing/suit/holidaypriest(src)
 	new /obj/item/clothing/under/wedding/bride_white(src)
 	new /obj/item/weapon/storage/backpack/cultpack (src)
+	new /obj/item/clothing/head/helmet/riot/knight/templar(src)
+	new /obj/item/clothing/suit/armor/riot/knight/templar(src)
 	new /obj/item/weapon/storage/fancy/candle_box/eternal(src)
 	new /obj/item/weapon/storage/fancy/candle_box/eternal(src)
 	new /obj/item/weapon/storage/fancy/candle_box/eternal(src)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -222,7 +222,7 @@ obj/item/clothing/head/blob
 	desc = "Deus Vult."
 	icon_state = "knight_templar"
 	item_state = "knight_templar"
-
+	armor = list(melee = 20, bullet = 7, laser = 2, energy = 2, bomb = 2, bio = 2, rad = 0)
 
 //Commander
 /obj/item/clothing/head/helmet/ert/command

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -209,6 +209,7 @@
 	icon_state = "knight_templar"
 	item_state = "knight_templar"
 	allowed = list(/obj/item/weapon/nullrod/claymore)
+	armor = list(melee = 25, bullet = 5, laser = 5, energy = 5, bomb = 0, bio = 0, rad = 0)
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "Bulletproof Vest"


### PR DESCRIPTION
Changes:
- Nerfs nullrod damage from 18 to 15, spellblade/carpblade from 15 to 13. Nullrod keeps its many forms and abilities, but now you have to choose between holy effects of your choice, and great damage. Chaplains no longer get both in the same weapon.
- Nerfs chaplain roundstart "crusader armor" to no longer have stats comparable to the full riot gear in sec's armory. Suit used to have 50 melee, 10 bullet, 10 laser, 10 energy. Helmet used to have 41 melee, 15 bullet, 5 laser, 5 energy, 5 bomb and 2 bio. All of these values have been halved.

The intent of this PR is to encourage Chaplains to play priests. To RP. To have funerals, etc. Rather than simply donning their roundstart riot armor, picking up their powerful holy weapon, and validhunting through maint the whole round.

🆑 Kyep
tweak: Chaplain's armor is no longer riot-grade. In addition, their nullrods do less damage.
/🆑