### PR TITLE
Removes biblefarting

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -225,12 +225,12 @@
 			if(!restrained())
 				message = "<B>[src]</B> is strumming the air and headbanging like a safari chimp."
 				m_type = 1
-				
+
 		if("dance")
 			if(!restrained())
 				message = "<B>[src]</B> dances around happily."
 				m_type = 1
-				
+
 		if("jump")
 			if(!restrained())
 				message = "<B>[src]</B> jumps!"
@@ -834,14 +834,7 @@
 			if(reagents.has_reagent("simethicone"))
 				return
 //			playsound(loc, 'sound/effects/fart.ogg', 50, 1, -3) //Admins still vote no to fun
-			if(locate(/obj/item/weapon/storage/bible) in get_turf(src))
-				to_chat(viewers(src), "<span class='warning'><b>[src] farts on the Bible!</b></span>")
-				to_chat(viewers(src), "<span class='notice'><b>A mysterious force smites [src]!</b></span>")
-				var/datum/effect/system/spark_spread/s = new /datum/effect/system/spark_spread
-				s.set_up(3, 1, src)
-				s.start()
-				gib()
-			else if(TOXIC_FARTS in mutations)
+			if(TOXIC_FARTS in mutations)
 				message = "<b>[src]</b> unleashes a [pick("horrible","terrible","foul","disgusting","awful")] fart."
 			else if(SUPER_FART in mutations)
 				message = "<b>[src]</b> unleashes a [pick("loud","deafening")] fart."


### PR DESCRIPTION
Farting on bibles no longer gibs you.

The gods are _so tired_ of people doing it for their own amusement, safe in the knowledge that they'll be able to inhabit other bodies later. If you want to suicide, you'll have to do it without the gods' help. This also prevents people from biblefarting to get around the 'suicides aren't respawnable' policy.

🆑 Kyep
rscdel: Removed biblefarting.
/🆑