### PR TITLE
Makes french fries a deep fryer recipe instead of a processor recipe

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -94,3 +94,7 @@
 /datum/deepfryer_special/chimichanga
 	input = /obj/item/weapon/reagent_containers/food/snacks/burrito
 	output = /obj/item/weapon/reagent_containers/food/snacks/chimichanga
+
+/datum/deepfryer_special/fries
+	input = /obj/item/weapon/reagent_containers/food/snacks/grown/potato/wedges
+	output = /obj/item/weapon/reagent_containers/food/snacks/fries

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -71,10 +71,6 @@
 	input = /obj/item/weapon/reagent_containers/food/snacks/meat
 	output = /obj/item/weapon/reagent_containers/food/snacks/meatball
 
-/datum/food_processor_process/potatowedges
-	input = /obj/item/weapon/reagent_containers/food/snacks/grown/potato/wedges
-	output = /obj/item/weapon/reagent_containers/food/snacks/fries
-
 /datum/food_processor_process/sweetpotato
 	input = /obj/item/weapon/reagent_containers/food/snacks/grown/potato/sweet
 	output = /obj/item/weapon/reagent_containers/food/snacks/yakiimo


### PR DESCRIPTION
Because it triggers me.

With this, in order to make french fries you will have to put the potato wedges inside the deep fryer instead of the processor, like god intended.