### PR TITLE
Poison Pen, QM/HoP/CargoTech Traitor Item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -347,6 +347,17 @@ var/list/uplink_items = list()
 	cost = 2
 	job = list("Research Director","Chief Medical Officer","Medical Doctor","Psychiatrist","Paramedic","Virologist","Bartender")
 
+// Paper contact poison pen
+
+/datum/uplink_item/stealthy_weapons/poison_pen
+	name = "Poison Pen"
+	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with delayed contact poison."
+	item = /obj/item/weapon/pen/poison
+	cost = 5
+	excludefrom = list(/datum/game_mode/nuclear)
+	job = list("Head of Personnel", "Quartermaster", "Cargo Technician")
+
+
 // DANGEROUS WEAPONS
 
 /datum/uplink_item/dangerous

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -349,11 +349,11 @@ var/list/uplink_items = list()
 
 // Paper contact poison pen
 
-/datum/uplink_item/stealthy_weapons/poison_pen
+/datum/uplink_item/jobspecific/poison_pen
 	name = "Poison Pen"
 	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with delayed contact poison."
 	item = /obj/item/weapon/pen/poison
-	cost = 5
+	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)
 	job = list("Head of Personnel", "Quartermaster", "Cargo Technician")
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -31,6 +31,8 @@
 	var/offset_y[0] //usage by the photocopier
 	var/rigged = 0
 	var/spam_flag = 0
+	var/contact_poison // Reagent ID to transfer on contact
+	var/contact_poison_volume = 0
 
 	var/const/deffont = "Verdana"
 	var/const/signfont = "Times New Roman"
@@ -277,6 +279,8 @@
 		else
 			info += t // Oh, he wants to edit to the end of the file, let him.
 			updateinfolinks()
+
+		i.on_write(src,usr)
 
 		show_content(usr, forceshow = 1, infolinks = 1)
 
@@ -653,3 +657,12 @@
 /obj/item/weapon/paper/evilfax/proc/evilpaper_selfdestruct()
 	visible_message("<span class='danger'>[src] spontaneously catches fire, and burns up!</span>")
 	qdel(src)
+
+/obj/item/weapon/paper/pickup(user)
+	if(contact_poison && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/clothing/gloves/G = H.gloves
+		if(!istype(G) || G.transfer_prints)
+			H.reagents.add_reagent(contact_poison, contact_poison_volume)
+			contact_poison = null
+	..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -33,6 +33,7 @@
 	var/spam_flag = 0
 	var/contact_poison // Reagent ID to transfer on contact
 	var/contact_poison_volume = 0
+	var/contact_poison_poisoner = null
 
 	var/const/deffont = "Verdana"
 	var/const/signfont = "Times New Roman"
@@ -665,4 +666,5 @@
 		if(!istype(G) || G.transfer_prints)
 			H.reagents.add_reagent(contact_poison, contact_poison_volume)
 			contact_poison = null
+			add_logs(user, src, "picked up [src], the paper poisoned by [contact_poison_poisoner]")
 	..()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -196,6 +196,7 @@
 		uses_left--
 		P.contact_poison = "sarin"
 		P.contact_poison_volume = 15
+		P.contact_poison_poisoner = user.name
 		add_logs(user, P, "used poison pen on")
 		to_chat(user, "<span class='warning'>You apply the poison to [P].</span>")
 	else

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -182,3 +182,21 @@
 	else
 		icon_state = initial(icon_state) //looks like a normal pen when off.
 		item_state = initial(item_state)
+
+/obj/item/proc/on_write(obj/item/weapon/paper/P, mob/user)
+	return
+
+/obj/item/weapon/pen/poison
+	var/uses_left = 3
+
+/obj/item/weapon/pen/poison/on_write(obj/item/weapon/paper/P, mob/user)
+	if(P.contact_poison_volume)
+		to_chat(user, "<span class='warning'>[P] is already coated.</span>")
+	else if(uses_left)
+		uses_left--
+		P.contact_poison = "sarin"
+		P.contact_poison_volume = 15
+		add_logs(user, P, "used poison pen on")
+		to_chat(user, "<span class='warning'>You apply the poison to [P].</span>")
+	else
+		to_chat(user, "<span class='warning'>[src] clicks. It seems to be depleted.</span>")

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -194,7 +194,7 @@
 		to_chat(user, "<span class='warning'>[P] is already coated.</span>")
 	else if(uses_left)
 		uses_left--
-		P.contact_poison = "sarin"
+		P.contact_poison = "amanitin"
 		P.contact_poison_volume = 15
 		P.contact_poison_poisoner = user.name
 		add_logs(user, P, "used poison pen on")


### PR DESCRIPTION
- Ports Poison Pen from TG: https://github.com/tgstation/tgstation/pull/23778
- Adds a HoP/Cargotech/QM-only traitor pen that can be used on paper to poison it.
- Picking up poisoned paper without gloves transfers the poison through your skin, into your bloodstream. Subsequent people to pick it up are not affected.
- The poison is 15 units of the nerve agent, sarin. This is enough to kill you in a couple of minutes. It is quite obvious. While the TG version uses a silent chem, I thought that was too hard to counter, so I went with sarin instead. Open to balance feedback on that. 
- The pen looks like a normal pen, costs 5 TC, and has 3 uses. It cannot be used as a direct weapon. It has to be applied to paper to be effective. Unlike the TG version, it costs a bit more, and has limited uses (ie: you can't poison every paper on the station with one pen).

🆑 Kyep
rscadd: Added Poison Pen, a stealthy way of applying a contact-based poison to paper. Available to Syndicate HoPs, QMs, and Cargo Techs.
/🆑