### PR TITLE
Change ORM input/output dirs with multitool

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -114,6 +114,10 @@
 		if(istype(W, /obj/item/weapon/crowbar))
 			empty_content()
 			default_deconstruction_crowbar(W)
+		if(ismultitool(W))
+			input_dir = turn(input_dir, -90)
+			output_dir = turn(output_dir, -90)
+			to_chat(user, "<span class='notice'>You change [src]'s I/O settings, setting the input to [dir2text(input_dir)] and the output to [dir2text(output_dir)].</span>")
 		return
 	if(default_unfasten_wrench(user, W))
 		return


### PR DESCRIPTION
Use a multitool on an open panel ORM to change its input and output directions

:cl:
add: You can now change the input/output directons for Ore Redemption Machines by using a multitool on them with the panel open.
/:cl: