### PR TITLE
Allows monkeys to use all guns

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -847,7 +847,7 @@
 	return tally
 
 /mob/living/proc/can_use_guns(var/obj/item/weapon/gun/G)
-	if(G.trigger_guard != TRIGGER_GUARD_ALLOW_ALL && !IsAdvancedToolUser())
+	if(G.trigger_guard != TRIGGER_GUARD_ALLOW_ALL && !IsAdvancedToolUser() && !issmall(src))
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 0
 	return 1


### PR DESCRIPTION
Monkeys can now use all guns without restriction as long as they're not hulks
Currently the only species that can't use guns are golems (rocks) and shadowlings (muzzle flash), and guns aren't really as complex as computers and machinery

:cl:
Monkeys can now use all guns without restrictions
/:cl: