### PR TITLE
Makes objective changes more obvious

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1204,10 +1204,11 @@
 
 	else if(href_list["obj_announce"])
 		var/obj_count = 1
-		to_chat(current, "\blue Your current objectives:")
+		to_chat(current, "<BR><span class='userdanger'>Your current objectives:</span>")
 		for(var/datum/objective/objective in objectives)
 			to_chat(current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
 			obj_count++
+		current << 'sound/ambience/alarm4.ogg'
 		log_admin("[key_name(usr)] has announced [key_name(current)]'s objectives")
 		message_admins("[key_name_admin(usr)] has announced [key_name_admin(current)]'s objectives")
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -333,7 +333,8 @@
 		else if(O.target && istype(O.target,/datum/mind))
 			if(O.target == occupant.mind)
 				if(O.owner && O.owner.current)
-					to_chat(O.owner.current, "<span class='userdanger'>You get the feeling your target is no longer within reach. Time for Plan [pick("A","B","C","D","X","Y","Z")]. Objectives updated!</span>")
+					to_chat(O.owner.current, "<BR><span class='userdanger'>You get the feeling your target is no longer within reach. Time for Plan [pick("A","B","C","D","X","Y","Z")]. Objectives updated!</span>")
+					O.owner.current << 'sound/ambience/alarm4.ogg'
 				O.target = null
 				spawn(1) //This should ideally fire after the occupant is deleted.
 					if(!O) return


### PR DESCRIPTION
🆑 Kyep
tweak: Antags whose objectives are manually announced by an admin, or altered automatically as a result of their target cryoing, will now hear a warning sound. The sound is the same as the 'crew transfer vote called' sound. Additionally, the text notice for changed objectives is more obvious.
/🆑