### PR TITLE
Ports Monster's finishing of the space allocator

### DIFF
--- a/code/modules/space_management/heap_space_level.dm
+++ b/code/modules/space_management/heap_space_level.dm
@@ -1,15 +1,62 @@
 // This represents a level we can carve up as we please, and hand out
 // chunks of to whatever requests it
 /datum/space_level/heap
-  var/datum/space_chunk/top
-  linkage = UNAFFECTED
+	name = "Heap level #ERROR"
+	var/datum/space_chunk/top
+	linkage = UNAFFECTED
 
-/datum/space_level/heap/New()
-  ..()
-  top = new
+/datum/space_level/heap/New(z, name, transition_type, traits)
+	..(z, "Heap level #[z]", UNAFFECTED, traits)
+	top = new(1, 1, zpos, world.maxx, world.maxy)
+	flags = traits
 
 /datum/space_level/heap/proc/request(width, height)
-  return 1 // All are welcome! At least until I add code for this
+	return top.can_fit_space(width, height)
 
-/datum/zlevel/heap/proc/allocate(width, height)
-  return
+// Returns a space chunk datum for some nerd to work with - tells them what's safe to write into, and such
+/datum/space_level/heap/proc/allocate(width, height)
+	if(!request(width, height))
+		return null
+
+	var/datum/space_chunk/C = top.get_optimal_chunk(width, height)
+	if(!C)
+		return null
+	C.children.Cut()
+
+	if(C.width == width && C.height == height && C.is_empty)
+		C.set_occupied(TRUE)
+		return C
+
+	// Split the chunk into 4 pieces
+	var/datum/space_chunk/return_chunk = new(C.x, C.y, C.zpos, width, height)
+	C.children += return_chunk
+	C.children += new /datum/space_chunk(C.x+width, C.y, C.zpos, C.width-width, height)
+	C.children += new /datum/space_chunk(C.x, C.y+height, C.zpos, width, C.height-height)
+	C.children += new /datum/space_chunk(C.x+width, C.y+height, C.zpos, C.width-width, C.height-height)
+
+	for(var/datum/space_chunk/C2 in C.children)
+		C2.parent = C
+	return_chunk.set_occupied(TRUE)
+	return return_chunk
+
+/datum/space_level/heap/proc/free(datum/space_chunk/C)
+	if(!istype(C))
+		return
+	if(C.zpos != zpos)
+		return
+	C.set_occupied(FALSE)
+	for(var/turf/T in block(locate(C.x, C.y, C.zpos), locate(C.x+C.width-1, C.y+C.height-1, C.zpos)))
+		for(var/atom/movable/M in T)
+			if(istype(M, /mob/dead/observer))
+				continue
+			M.loc = null
+			qdel(M, TRUE)
+		T.ChangeTurf(/turf/space)
+	var/datum/space_chunk/last_empty_parent = C
+	while(last_empty_parent.parent && last_empty_parent.parent.is_empty)
+		last_empty_parent = last_empty_parent.parent
+	// Prevent a self-qdel from killing this proc
+	src = null
+	for(var/datum/space_chunk/child in last_empty_parent.children)
+		qdel(child)
+	last_empty_parent.children.Cut()

--- a/code/modules/space_management/space_chunk.dm
+++ b/code/modules/space_management/space_chunk.dm
@@ -10,13 +10,80 @@
 	var/width
 	var/height
 	var/zpos
+	// Whether dedicated for use or not
+	var/occupied = FALSE
+	// Whether the chunk contains used children or not
+	var/is_empty = TRUE
+	var/list/children = list()
+	var/datum/space_chunk/parent = null
 
-/datum/space_chunk/New(w, h, z, new_x, new_y)
+/datum/space_chunk/New(new_x, new_y, z, w, h)
 	x = new_x
 	y = new_y
 	zpos = z
 	width = w
 	height = h
+
+/datum/space_chunk/Destroy()
+	set_occupied(FALSE)
+	if(parent)
+		parent.children -= src
+	for(var/datum/space_chunk/child in children)
+		qdel(child)
+	children.Cut()
+	parent = null
+	. = ..()
+
+/datum/space_chunk/proc/can_fit_space(w, h)
+	if(w > width || h > height)
+		return FALSE
+	if(occupied)
+		return FALSE
+	if(is_empty)
+		return TRUE
+	for(var/datum/space_chunk/C in children)
+		if(C.can_fit_space(w, h))
+			return TRUE
+	return FALSE
+
+// Recursively drops down the tree and finds the most efficient chunk to use
+/datum/space_chunk/proc/get_optimal_chunk(w, h)
+	if(w > width || h > height)
+		return null
+	if(occupied)
+		return null
+	if(is_empty)
+		return src
+	var/datum/space_chunk/optimal_chunk
+	var/optimal_chunk_optimalness = 99999
+	for(var/datum/space_chunk/C in children)
+		var/datum/space_chunk/C2 = C.get_optimal_chunk(w, h)
+		if(!C2)
+			continue
+		var/optimalness = C2.width + C2.height-w-h
+		if(optimalness < optimal_chunk_optimalness)
+			optimal_chunk_optimalness = optimalness
+			optimal_chunk = C2
+	return optimal_chunk
+
+/datum/space_chunk/proc/set_occupied(new_occupied)
+	var/datum/space_chunk/C = parent
+	if(new_occupied)
+		occupied = TRUE
+		while(C)
+			C.is_empty = FALSE
+			C = C.parent
+	else
+		occupied = FALSE
+		while(C)
+			var/is_children_empty = TRUE
+			for(var/datum/space_chunk/C2 in C.children)
+				if(!C2.is_empty || C2.occupied)
+					is_children_empty = FALSE
+			if(!is_children_empty)
+				break
+			C.is_empty = TRUE
+			C = C.parent
 
 /datum/space_chunk/proc/check_sanity()
 	var/i_am_sane = 1


### PR DESCRIPTION
No CL as this is not a player-facing change

Port of @monster860's finishing of the space allocator

It's implemented as a quad-tree, albeit a totally imbalanced one since this is a quick/naive implementation - which shouldn't matter *too* much since chunks aren't normally winking in and out of existence all that often

Basically, you use this with `zlev_manager.allocate_space(how_wide, how_high)` to get a `space_chunk` datum which contains information about what space you're allowed to work with and not step on any toes of any other mapped-in stuff. If for some reason you don't want to use it anymore, you can do `zlev_manager.free_space(finished_chunk)` to let that space be used by other stuff (everything within that chunk will be annihilated).

Applications of this include making non-euclidean pocket dimensions, spawning arbitrary amounts of antag lairs for separate antagonists, dropping in quick explorable "minimaps" for adventuring purposes, and mapping in arbitrary amounts of space for any number of shuttles, without worrying about there being enough space on z2.

@Draconic-saint @fludd12 since you expressed interest in using this

I am sorry, it is about time that this has been finished.