### PR TITLE
Small backpack sprite fix

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -189,7 +189,7 @@
 /obj/item/weapon/storage/backpack/satchel_norm
 	name = "satchel"
 	desc = "A deluxe NT Satchel, made of the highest quality leather."
-	icon_state = "satchel"
+	icon_state = "satchel-norm"
 
 /obj/item/weapon/storage/backpack/satchel_eng
 	name = "industrial satchel"


### PR DESCRIPTION
Gives the grey satchel the grey satchel sprite instead of the leather one.

:cl:
Fix: The grey satchel uses now the correct sprite instead of the leather one.
/:cl: