### PR TITLE
Cult shoes

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -158,8 +158,8 @@
 	text += "<font color='red'><b>Talisman of Stunning</b></font><br>Attacking a target will knock them down for a long duration in addition to inhibiting their speech. \
 	Robotic lifeforms will suffer the effects of a heavy electromagnetic pulse instead.<br><br>"
 
-	text += "<font color='red'><b>Talisman of Armaments</b></font><br>The Talisman of Arming will equip the user with armored robes, a backpack, an eldritch longsword, an empowered bola. Any items that cannot \
-	be equipped will not be summoned. Attacking a fellow cultist with it will instead equip them.<br><br>"
+	text += "<font color='red'><b>Talisman of Armaments</b></font><br>The Talisman of Arming will equip the user with armored robes, a backpack, shoes, an eldritch longsword, and an empowered bola. Any items that cannot \
+	be equipped will be stored on the user or put on the floor below the user. Attacking a fellow cultist with it will instead equip them.<br><br>"
 
 	text += "<font color='red'><b>Talisman of Horrors</b></font><br>The Talisman of Horror must be applied directly to the victim, it will shatter your victim's mind with visions of the endtimes that may incapitate them.<br><br>"
 

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -158,8 +158,8 @@
 	text += "<font color='red'><b>Talisman of Stunning</b></font><br>Attacking a target will knock them down for a long duration in addition to inhibiting their speech. \
 	Robotic lifeforms will suffer the effects of a heavy electromagnetic pulse instead.<br><br>"
 
-	text += "<font color='red'><b>Talisman of Armaments</b></font><br>The Talisman of Arming will equip the user with armored robes, a backpack, shoes, an eldritch longsword, and an empowered bola. Any items that cannot \
-	be equipped will be stored on the user or put on the floor below the user. Attacking a fellow cultist with it will instead equip them.<br><br>"
+	text += "<font color='red'><b>Talisman of Armaments</b></font><br>The Talisman of Arming will equip the user with armored robes, a backpack, shoes, an eldritch longsword, and an empowered bola. Any equipment that cannot \
+	be equipped will not be summoned, weaponary will be put on the floor below the user. Attacking a fellow cultist with it will instead equip them.<br><br>"
 
 	text += "<font color='red'><b>Talisman of Horrors</b></font><br>The Talisman of Horror must be applied directly to the victim, it will shatter your victim's mind with visions of the endtimes that may incapitate them.<br><br>"
 

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -272,7 +272,7 @@
 						 "<span class='cultitalic'>You speak the words of the talisman, arming yourself!</span>")
 	H.equip_or_collect(new /obj/item/clothing/suit/hooded/cultrobes/alt(user), slot_wear_suit)
 	H.equip_or_collect(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
-	H.equip_or_collect(new /obj/item/clothing/shoes/cult(user), slot_back)
+	H.equip_or_collect(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 	H.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
 	H.put_in_hands(new /obj/item/weapon/restraints/legcuffs/bola/cult(user))
 

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -272,6 +272,7 @@
 						 "<span class='cultitalic'>You speak the words of the talisman, arming yourself!</span>")
 	H.equip_or_collect(new /obj/item/clothing/suit/hooded/cultrobes/alt(user), slot_wear_suit)
 	H.equip_or_collect(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
+	H.equip_or_collect(new /obj/item/clothing/shoes/cult(user), slot_back)
 	H.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
 	H.put_in_hands(new /obj/item/weapon/restraints/legcuffs/bola/cult(user))
 

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -270,9 +270,13 @@
 	var/mob/living/carbon/human/H = user
 	user.visible_message("<span class='warning'>Otherworldly armor suddenly appears on [user]!</span>", \
 						 "<span class='cultitalic'>You speak the words of the talisman, arming yourself!</span>")
-	H.equip_or_collect(new /obj/item/clothing/suit/hooded/cultrobes/alt(user), slot_wear_suit)
-	H.equip_or_collect(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
-	H.equip_or_collect(new /obj/item/clothing/shoes/cult(user), slot_shoes)
+	if(!H.wear_suit) //Only get the equipment if the slot is free.
+		H.equip_or_collect(new /obj/item/clothing/suit/hooded/cultrobes/alt(user), slot_wear_suit)
+	if(!H.back)
+		H.equip_or_collect(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
+	if(!H.shoes)
+		if(H.has_organ_for_slot(slot_shoes)) //Might be empty for a reason.
+			H.equip_or_collect(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 	H.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
 	H.put_in_hands(new /obj/item/weapon/restraints/legcuffs/bola/cult(user))
 

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -270,13 +270,9 @@
 	var/mob/living/carbon/human/H = user
 	user.visible_message("<span class='warning'>Otherworldly armor suddenly appears on [user]!</span>", \
 						 "<span class='cultitalic'>You speak the words of the talisman, arming yourself!</span>")
-	if(!H.wear_suit) //Only get the equipment if the slot is free.
-		H.equip_or_collect(new /obj/item/clothing/suit/hooded/cultrobes/alt(user), slot_wear_suit)
-	if(!H.back)
-		H.equip_or_collect(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
-	if(!H.shoes)
-		if(H.has_organ_for_slot(slot_shoes)) //Might be empty for a reason.
-			H.equip_or_collect(new /obj/item/clothing/shoes/cult(user), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/clothing/suit/hooded/cultrobes/alt(user), slot_wear_suit)
+	H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/cultpack(user), slot_back)
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/cult(user), slot_shoes)
 	H.put_in_hands(new /obj/item/weapon/melee/cultblade(user))
 	H.put_in_hands(new /obj/item/weapon/restraints/legcuffs/bola/cult(user))
 


### PR DESCRIPTION
Gives cultists their shoes on usage of the armor talisman, updates the text in the tome to reflect that. Restored the behaviour that items you can't equiped won't get summoned, as described by the tome. This also fixes a possible exploit of unlimited storage space for cultists since `equip_or_collect()` did put the summoned backpack into your equiped backpack.
:cl:
add: Cultists get shoes on usage of the armor talisman.
add: Cultists only get equipment if they have the slot for it free, weapons are always spawned.
tweak: The tome does a more fitting description of the talisman of armor.
/:cl: