### PR TITLE
Prevents new players from attacking or looting SSDs

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -116,6 +116,11 @@
 	// Allows you to click on a box's contents, if that box is on the ground, but no deeper than that
 	sdepth = A.storage_depth_turf()
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
+		if(ismob(A))
+			var/mob/living/M = A
+			if(isLivingSSD(M) && client && !client.can_harm_ssds() && !isAntag(src))
+				to_chat(src, "<span class='userdanger'>You can't touch SSD crew members. Read the rules.</span>")
+				return
 		if(A.Adjacent(src)) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example, params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -118,8 +118,8 @@
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(ismob(A))
 			var/mob/living/M = A
-			if(isLivingSSD(M) && client && !client.can_harm_ssds() && !isAntag(src))
-				to_chat(src, "<span class='userdanger'>You can't touch SSD crew members. Read the rules.</span>")
+			if(isLivingSSD(M) && client && !client.can_harm_ssds() && !isAntag(src) && (W || (a_intent != I_GRAB && a_intent != I_HELP)))
+				to_chat(src, "<span class='warning'>AdminHelp (F1) to get permission before attacking players who are suffering from Space Sleep Disorder / disconnected from the game. Read the server rules for more details.</span>")
 				return
 		if(A.Adjacent(src)) // see adjacent.dm
 			if(W)

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -132,6 +132,7 @@
 	var/use_exp_tracking = 0
 	var/use_exp_restrictions = 0
 	var/use_exp_restrictions_admin_bypass = 0
+	var/use_exp_ssd_protect = 0
 
 	var/simultaneous_pm_warning_timeout = 100
 
@@ -259,6 +260,9 @@
 
 				if("use_exp_restrictions_admin_bypass")
 					config.use_exp_restrictions_admin_bypass = 1
+
+				if("use_exp_ssd_protect")
+					config.use_exp_ssd_protect = 1
 
 				if("jobs_have_minimal_access")
 					config.jobs_have_minimal_access = 1

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -262,7 +262,7 @@
 					config.use_exp_restrictions_admin_bypass = 1
 
 				if("use_exp_ssd_protect")
-					config.use_exp_ssd_protect = 1
+					config.use_exp_ssd_protect = text2num(value)
 
 				if("jobs_have_minimal_access")
 					config.jobs_have_minimal_access = 1

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -140,6 +140,15 @@
 	var/exp_living = text2num(play_records[EXP_TYPE_LIVING])
 	return exp_living
 
+/client/proc/can_harm_ssds()
+	if(!config.use_exp_tracking)
+		return 1
+	if(!config.use_exp_ssd_protect)
+		return 1
+	if(get_exp_living_num() >= 600)
+		return 1
+	return 0
+
 /proc/get_exp_format(var/expnum)
 	if(expnum > 60)
 		return num2text(round(expnum / 60)) + "h"

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -145,6 +145,12 @@
 		return 1
 	if(!config.use_exp_ssd_protect)
 		return 1
+	if(bypass_ssd_guard)
+		return 1
+	if(mob && mob.job in security_positions)
+		return 1
+	if(config.use_exp_restrictions_admin_bypass && check_rights(R_ADMIN, 0, mob))
+		return 1
 	if(get_exp_living_num() >= 600)
 		return 1
 	return 0

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -151,7 +151,7 @@
 		return 1
 	if(config.use_exp_restrictions_admin_bypass && check_rights(R_ADMIN, 0, mob))
 		return 1
-	if(get_exp_living_num() >= 600)
+	if(get_exp_living_num() >= 300)
 		return 1
 	return 0
 

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -151,7 +151,7 @@
 		return 1
 	if(config.use_exp_restrictions_admin_bypass && check_rights(R_ADMIN, 0, mob))
 		return 1
-	if(get_exp_living_num() >= 300)
+	if(get_exp_living_num() >= (config.use_exp_ssd_protect * 60))
 		return 1
 	return 0
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -79,6 +79,7 @@ var/global/nologevent = 0
 	if(M.client)
 		body += "| <A HREF='?_src_=holder;sendtoprison=\ref[M]'>Prison</A> | "
 		body += "\ <A href='?_src_=holder;sendbacktolobby=\ref[M]'>Send back to Lobby</A> | "
+		body += "\ <A href='?_src_=holder;togglessdguard=[M.UID()]'>Toggle SSD Guard</A> | "
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?_src_=holder;mute=\ref[M];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> |

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1252,6 +1252,27 @@
 		NP.ckey = M.ckey
 		qdel(M)
 
+	else if(href_list["togglessdguard"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/mob/M = locateUID(href_list["togglessdguard"])
+
+		if(!M.client)
+			to_chat(usr, "<span class='warning'>[M] doesn't have an attached client.</span>")
+			return
+
+		var/onoff = "DISABLED"
+		if(M.client.bypass_ssd_guard)
+			M.client.bypass_ssd_guard = FALSE
+			onoff = "ENABLED"
+		else
+			M.client.bypass_ssd_guard = TRUE
+			to_chat(M, "<span class='warning'>You have been given temporary permission to interact with SSD players.</span>")
+
+		log_admin("[key_name(usr)] has [onoff] SSD Guard for [key_name(M)].")
+		message_admins("[key_name_admin(usr)] has [onoff] SSD Guard for [key_name(M)]")
+
 	else if(href_list["tdome1"])
 		if(!check_rights(R_SERVER|R_EVENT))	return
 

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -93,9 +93,12 @@
 
 	// Donator stuff.
 	var/donator_level = DONATOR_LEVEL_NONE
-	
+
 	// If set to true, this client can interact with atoms such as buttons and doors on top of regular machinery interaction
 	var/advanced_admin_interaction = FALSE
 
 	// Has the client been varedited by an admin?
 	var/var_edited = FALSE
+
+	// Has the client been granted permission to mess with SSDs by an admin?
+	var/bypass_ssd_guard = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -643,6 +643,10 @@
 	if(what.flags & NODROP)
 		to_chat(src, "<span class='warning'>You can't remove \the [what.name], it appears to be stuck!</span>")
 		return
+	if(isLivingSSD(who))
+		if(client && !client.can_harm_ssds() && !isAntag(src))
+			to_chat(src, "<span class='userdanger'>You can't remove items from SSD crew members. Read the rules.</span>")
+			return
 	if(!silent)
 		who.visible_message("<span class='danger'>[src] tries to remove [who]'s [what.name].</span>", \
 						"<span class='userdanger'>[src] tries to remove [who]'s [what.name].</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -645,7 +645,7 @@
 		return
 	if(isLivingSSD(who))
 		if(client && !client.can_harm_ssds() && !isAntag(src))
-			to_chat(src, "<span class='userdanger'>You can't remove items from SSD crew members. Read the rules.</span>")
+			to_chat(src, "<span class='warning'>AdminHelp (F1) to get permission before stripping players who are suffering from Space Sleep Disorder / disconnected from the game. Read the server rules for more details.</span>")
 			return
 	if(!silent)
 		who.visible_message("<span class='danger'>[src] tries to remove [who]'s [what.name].</span>", \

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -23,8 +23,8 @@ JOBS_HAVE_MINIMAL_ACCESS
 #USE_EXP_RESTRICTIONS
 ##Allows admins to bypass job playtime requirements.
 USE_EXP_RESTRICTIONS_ADMIN_BYPASS
-##Requires playtime before someone can attack or loot from SSDs. Stops newbies mauling SSD players.
-#USE_EXP_SSD_PROTECT
+##Required number of hours playtime before someone can attack or loot from SSDs. Comment to disable.
+#USE_EXP_SSD_PROTECT 5
 
 ## Unhash this entry to have certain antagonist roles require your account to be at least a certain number of days old to select. You can configure the exact age requirement for different antag roles by editing special_role_times in /code/modules/client/preferences.dm.
 ## See USE_AGE_RESTRICTION_FOR_JOBS for more information

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -23,6 +23,8 @@ JOBS_HAVE_MINIMAL_ACCESS
 #USE_EXP_RESTRICTIONS
 ##Allows admins to bypass job playtime requirements.
 USE_EXP_RESTRICTIONS_ADMIN_BYPASS
+##Requires playtime before someone can attack or loot from SSDs. Stops newbies mauling SSD players.
+#USE_EXP_SSD_PROTECT
 
 ## Unhash this entry to have certain antagonist roles require your account to be at least a certain number of days old to select. You can configure the exact age requirement for different antag roles by editing special_role_times in /code/modules/client/preferences.dm.
 ## See USE_AGE_RESTRICTION_FOR_JOBS for more information


### PR DESCRIPTION
Changes:
- Very new players (those with under 5 hours of playtime) who try to attack, or loot from, an SSD player, are prevented from doing so. Instead, they get a message telling them to read the server rules.
- Anyone who has 5 hours or more of playtime, is an antag that round, or is a member of security, can still attack/loot SSD players. This prevents someone attacking an antag then going SSD to prevent them retaliating, prevents members of command being unable to get a SSD Captain's nuke disk, etc.
- Again: **If you have 5 hours or more of playtime on Paradise, this system won't affect you.**
- This entire system is a config option - and it is disabled by default. 
- Admins also get a new player panel option, "Toggle SSD Guard", which lets them disable the guard for an individual person. So, if a new player does really have a legit reason for stripping a SSD player, they can ahelp it, and get permission.

Why do we need this?

Because people messing with SSDs happens _every round_. And it is almost always new players doing it. And it adds up to a big time-sink for admins, dealing with these cases. Not to mention the hassle of cases where it isn't caught, and someone comes back to the game to find their ID/etc has been stolen. New players will learn not to mess with SSDs far faster if they're prevented from doing so early on, than if they're (maybe/hopefully?) bwoinked for doing so after the fact. 
We shouldn't be forcing admins to handle these cases manually, when this code can handle 90% of the cases for us, freeing up admin time *and* resulting in a better experience for new players.

🆑 Kyep
rscadd: SSDs are now protected against new players messing with them. This protection only works against new players. Anyone who has played on the server for 10 hours or more, or is an antag, is expected to know the rules, and is still able to interact with SSDs.
/🆑