### PR TITLE
Cryopods preserve detective revolvers

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -197,6 +197,7 @@
 		/obj/item/areaeditor/blueprints,
 		/obj/item/clothing/head/helmet/space,
 		/obj/item/weapon/storage/internal,
+		/obj/item/weapon/gun/projectile/revolver/detective,
 		/obj/item/device/spacepod_key
 	)
 	// These items will NOT be preserved


### PR DESCRIPTION
🆑 Kyep
tweak: When a detective goes to cryo, the cryo console will now save their gun, so replacement detectives are not permanently deprived of it.
/🆑