### PR TITLE
Streamlines the ghost-to-player creation process

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -116,6 +116,8 @@
 	name = "Standard Gear"
 	collect_not_del = TRUE // we don't want anyone to lose their job shit
 
+	var/allow_loadout = TRUE
+	var/allow_backbag_choice = TRUE
 	var/jobtype = null
 
 	uniform = /obj/item/clothing/under/color/grey
@@ -135,31 +137,28 @@
 	var/tmp/list/gear_leftovers = list()
 
 /datum/outfit/job/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	switch(H.backbag)
-		if(GBACKPACK)
-			back = /obj/item/weapon/storage/backpack //Grey backpack
-		if(GSATCHEL)
-			back = /obj/item/weapon/storage/backpack/satchel_norm //Grey satchel
-		if(GDUFFLEBAG)
-			back = /obj/item/weapon/storage/backpack/duffel //Grey Dufflebag
-		if(LSATCHEL)
-			back = /obj/item/weapon/storage/backpack/satchel //Leather Satchel
-		if(DSATCHEL)
-			back = satchel //Department satchel
-		if(DDUFFLEBAG)
-			back = dufflebag //Department dufflebag
-		else
-			back = backpack //Department backpack
-
-	var/datum/job/J = job_master.GetJobType(jobtype)
-	if(!J)
-		J = job_master.GetJob(H.job)
+	if(allow_backbag_choice)
+		switch(H.backbag)
+			if(GBACKPACK)
+				back = /obj/item/weapon/storage/backpack //Grey backpack
+			if(GSATCHEL)
+				back = /obj/item/weapon/storage/backpack/satchel_norm //Grey satchel
+			if(GDUFFLEBAG)
+				back = /obj/item/weapon/storage/backpack/duffel //Grey Dufflebag
+			if(LSATCHEL)
+				back = /obj/item/weapon/storage/backpack/satchel //Leather Satchel
+			if(DSATCHEL)
+				back = satchel //Department satchel
+			if(DDUFFLEBAG)
+				back = dufflebag //Department dufflebag
+			else
+				back = backpack //Department backpack
 
 	if(box)
 		backpack_contents.Insert(1, box) // Box always takes a first slot in backpack
 		backpack_contents[box] = 1
 
-	if(H.client && (H.client.prefs.gear && H.client.prefs.gear.len))
+	if(allow_loadout && H.client && (H.client.prefs.gear && H.client.prefs.gear.len))
 		for(var/gear in H.client.prefs.gear)
 			var/datum/gear/G = gear_datums[gear]
 			if(G)
@@ -190,32 +189,11 @@
 	if(visualsOnly)
 		return
 
-	var/datum/job/J = job_master.GetJobType(jobtype)
-	if(!J)
-		J = job_master.GetJob(H.job)
-
-	var/obj/item/weapon/card/id/C = H.wear_id
-	if(istype(C))
-		C.access = J.get_access()
-		C.registered_name = H.real_name
-		C.rank = J.title
-		C.assignment = J.title
-		C.sex = capitalize(H.gender)
-		C.age = H.age
-		C.name = "[C.registered_name]'s ID Card ([C.assignment])"
-		C.photo = get_id_photo(H)
-
-		if(H.mind && H.mind.initial_account)
-			C.associated_account_number = H.mind.initial_account.account_number
+	imprint_idcard(H)
 
 	H.sec_hud_set_ID()
 
-	var/obj/item/device/pda/PDA = H.wear_pda
-	if(istype(PDA))
-		PDA.owner = H.real_name
-		PDA.ownjob = C.assignment
-		PDA.ownrank = C.rank
-		PDA.name = "PDA-[H.real_name] ([PDA.ownjob])"
+	imprint_pda(H)
 
 	if(implants)
 		for(var/implant_type in implants)
@@ -245,3 +223,31 @@
 		qdel(gear_leftovers)
 
 	return 1
+
+/datum/outfit/job/proc/imprint_idcard(mob/living/carbon/human/H)
+	var/datum/job/J = job_master.GetJobType(jobtype)
+	if(!J)
+		J = job_master.GetJob(H.job)
+
+	var/obj/item/weapon/card/id/C = H.wear_id
+	if(istype(C))
+		C.access = J.get_access()
+		C.registered_name = H.real_name
+		C.rank = J.title
+		C.assignment = J.title
+		C.sex = capitalize(H.gender)
+		C.age = H.age
+		C.name = "[C.registered_name]'s ID Card ([C.assignment])"
+		C.photo = get_id_photo(H)
+
+		if(H.mind && H.mind.initial_account)
+			C.associated_account_number = H.mind.initial_account.account_number
+
+/datum/outfit/job/proc/imprint_pda(mob/living/carbon/human/H)
+	var/obj/item/device/pda/PDA = H.wear_pda
+	var/obj/item/weapon/card/id/C = H.wear_id
+	if(istype(PDA) && istype(C))
+		PDA.owner = H.real_name
+		PDA.ownjob = C.assignment
+		PDA.ownrank = C.rank
+		PDA.name = "PDA-[H.real_name] ([PDA.ownjob])"

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -310,3 +310,40 @@
 	H.update_body(0)
 	H.reset_hair()
 	H.dna.ResetUIFrom(H)
+
+
+/obj/machinery/transformer/gene_applier
+	name = "genetic blueprint applier"
+	desc = "Here begin the clone wars. Upload a template by using a genetics disk on this machine."
+	var/datum/dna/template
+	var/locked = FALSE // For admins sealing the deal
+
+/obj/machinery/transformer/gene_applier/do_transform(mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+	if(!istype(template))
+		to_chat(H, "<span class='warning'>No genetic template configured!</span>")
+		return
+	var/prev_ue = H.dna.unique_enzymes
+	H.set_species(template.species)
+	H.dna = template.Clone()
+	H.real_name = template.real_name
+	H.sync_organ_dna(assimilate = 0, old_ue = prev_ue)
+	H.UpdateAppearance()
+	domutcheck(H, null, MUTCHK_FORCED)
+	H.update_mutations()
+
+/obj/machinery/transformer/gene_applier/attackby(obj/item/W, mob/living/user, params)
+	if(istype(W, /obj/item/weapon/disk/data))
+		if(locked)
+			to_chat(user, "<span class='warning'>Access Denied.</span>")
+			return FALSE
+		var/obj/item/weapon/disk/data/D = W
+		if(!D.buf)
+			to_chat(user, "<span class='warning'>Error: No data found.</span>")
+			return FALSE
+		template = D.buf.dna.Clone()
+		to_chat(user, "<span class='notice'>Upload of gene template for '[template.real_name]' complete!</span>")
+		return TRUE
+	else
+		return ..()

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -29,6 +29,12 @@
 	else
 		icon_state = initial(icon_state)
 
+/obj/machinery/transformer/setDir(newdir)
+	. = ..()
+	var/obj/machinery/conveyor/C = locate() in loc
+	C.setDir(newdir)
+	acceptdir = turn(newdir, 180)
+
 /obj/machinery/transformer/Bumped(var/atom/movable/AM)
 
 	if(cooldown == 1)

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -11,6 +11,7 @@
 	var/cooldown_duration = 600 // 1 minute
 	var/cooldown = 0
 	var/robot_cell_charge = 5000
+	var/acceptdir = EAST
 
 /obj/machinery/transformer/New()
 	// On us
@@ -38,7 +39,7 @@
 		// Only humans can enter from the west side, while lying down.
 		var/move_dir = get_dir(loc, AM.loc)
 		var/mob/living/carbon/human/H = AM
-		if((transform_standing || H.lying) && move_dir == EAST)// || move_dir == WEST)
+		if((transform_standing || H.lying) && move_dir == acceptdir)// || move_dir == WEST)
 			AM.loc = src.loc
 			do_transform(AM)
 
@@ -255,3 +256,57 @@
 		playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
 		sleep(30)
 
+/obj/machinery/transformer/equipper
+	name = "Auto-equipper 9000"
+	desc = "Either in employ of people who cannot dress themselves, or Wallace and Gromit."
+	var/selected_outfit = /datum/outfit/job/assistant
+	var/prestrip = TRUE
+
+/obj/machinery/transformer/equipper/do_transform(mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+	if(!ispath(selected_outfit, /datum/outfit))
+		to_chat(H, "<span class='warning'>This equipper is not properly configured! 'selected_outfit': '[selected_outfit]'</span>")
+		return
+
+	if(prestrip)
+		for(var/obj/item/I in H)
+			if(istype(I, /obj/item/weapon/implant))
+				continue
+			if(istype(I, /obj/item/organ))
+				continue
+			qdel(I)
+
+	H.equipOutfit(selected_outfit)
+	H.species.after_equip_job(null, H)
+
+/obj/machinery/transformer/transmogrifier
+	name = "species transmogrifier"
+	desc = "As promoted in Calvin & Hobbes!"
+	var/target_species = "Human"
+
+
+/obj/machinery/transformer/transmogrifier/do_transform(mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+	if(!(target_species in all_species))
+		to_chat(H, "<span class='warning'>'[target_species]' is not a valid species!</span>")
+		return
+	H.set_species(target_species)
+
+
+/obj/machinery/transformer/dnascrambler
+	name = "genetic scrambler"
+	desc = "Step right in and become a new you!"
+
+
+/obj/machinery/transformer/dnascrambler/do_transform(mob/living/carbon/human/H)
+	if(!istype(H))
+		return
+
+	scramble(1, H, 100)
+	H.generate_name()
+	H.sync_organ_dna(assimilate = 1)
+	H.update_body(0)
+	H.reset_hair()
+	H.dna.ResetUIFrom(H)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -23,6 +23,9 @@
 	var/created_window = /obj/structure/window/basic
 	var/full_window = /obj/structure/window/full/basic
 
+/obj/item/stack/sheet/glass/fifty
+	amount = 50
+
 /obj/item/stack/sheet/glass/cyborg
 	materials = list()
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -98,13 +98,16 @@ var/global/list/datum/stack_recipe/metal_recipes = list(
 	flags = CONDUCT
 	origin_tech = "materials=1"
 
+/obj/item/stack/sheet/metal/cyborg
+	materials = list()
+
+/obj/item/stack/sheet/metal/fifty
+	amount = 50
+
 /obj/item/stack/sheet/metal/narsie_act()
 	if(prob(20))
 		new /obj/item/stack/sheet/runed_metal(loc, amount)
 		qdel(src)
-
-/obj/item/stack/sheet/metal/cyborg
-	materials = list()
 
 /obj/item/stack/sheet/metal/New(var/loc, var/amount=null)
 	recipes = metal_recipes

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -376,6 +376,9 @@ RCD
 	explosion(src, 0, 0, 3, 1, flame_range = 1)
 	qdel(src)
 
+/obj/item/weapon/rcd/preloaded
+	matter = 100
+
 /obj/item/weapon/rcd/combat
 	name = "combat RCD"
 	max_matter = 500

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -715,6 +715,18 @@
 	desc = "A modified ID card given only to those people who have devoted their lives to the better interests of Nanotrasen. It sparkles blue."
 	icon_state = "lifetimeid"
 
+/obj/item/weapon/card/id/ert
+	name = "ERT ID"
+	icon_state = "ERT_empty"
+
+/obj/item/weapon/card/id/ert/commander
+	icon_state = "ERT_leader"
+/obj/item/weapon/card/id/ert/security
+	icon_state = "ERT_security"
+/obj/item/weapon/card/id/ert/engineering
+	icon_state = "ERT_engineering"
+/obj/item/weapon/card/id/ert/medic
+	icon_state = "ERT_medical"
 // Decals
 /obj/item/weapon/id_decal
 	name = "identification card decal"

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -95,7 +95,7 @@
 /obj/structure/ghost_beacon/Destroy()
 	if(active)
 		processing_objects.Remove(src)
-	. = ..()
+	return ..()
 
 /obj/structure/ghost_beacon/attack_ghost(mob/dead/observer/user)
 	if(user.can_advanced_admin_interact())

--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -73,3 +73,45 @@
 		log_admin("[key_name(user)] was incarnated by a respawner machine.")
 		message_admins("[key_name_admin(user)] was incarnated by a respawner machine.")
 		user.incarnate_ghost()
+
+/obj/structure/ghost_beacon
+	name = "ethereal beacon"
+	desc = "A structure that draws ethereal attention when active. Use an empty hand to activate."
+	icon = 'icons/obj/lavaland/artefacts.dmi'
+	icon_state = "anomaly_crystal"
+	anchored = 1
+	density = 1
+	var/active = FALSE
+	var/ghost_alert_delay = 30 SECONDS
+	var/last_ghost_alert
+
+
+/obj/structure/ghost_beacon/initialize()
+	. = ..()
+	last_ghost_alert = world.time
+	if(active)
+		processing_objects.Add(src)
+
+/obj/structure/ghost_beacon/Destroy()
+	if(active)
+		processing_objects.Remove(src)
+	. = ..()
+
+/obj/structure/ghost_beacon/attack_ghost(mob/dead/observer/user)
+	if(user.can_advanced_admin_interact())
+		attack_hand(user)
+
+/obj/structure/ghost_beacon/attack_hand(mob/user)
+	if(!is_admin(user))
+		return
+	to_chat(user, "<span class='notice'>You [active ? "disable" : "enable"] \the [src].</span>")
+	if(active)
+		processing_objects.Remove(src)
+	else
+		processing_objects.Add(src)
+	active = !active
+
+/obj/structure/ghost_beacon/process()
+	if(last_ghost_alert + ghost_alert_delay < world.time)
+		notify_ghosts("[src] active in [get_area(src)].", 'sound/effects/ghost2.ogg', source = src)
+		last_ghost_alert = world.time

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -303,8 +303,8 @@ var/ert_request_answered = 0
 
 /datum/outfit/job/centcom/response_team
 	name = "Response team"
-	var/RTassignment = "Emergency Response Team Member"
-	var/RTjob = "This is a bug"
+	var/rt_assignment = "Emergency Response Team Member"
+	var/rt_job = "This is a bug"
 	allow_backbag_choice = FALSE
 	allow_loadout = FALSE
 	pda = /obj/item/device/pda/heads/ert
@@ -322,12 +322,12 @@ var/ert_request_answered = 0
 	var/obj/item/weapon/card/id/W = H.wear_id
 	if(!istype(W))
 		return
-	W.assignment = RTassignment
+	W.assignment = rt_assignment
 	W.rank = W.assignment
 	W.age = H.age
 	W.sex = capitalize(H.gender)
 	W.registered_name = H.real_name
-	W.name = "[H.real_name]'s ID Card ([RTjob])"
+	W.name = "[H.real_name]'s ID Card ([rt_job])"
 	W.access = get_centcom_access(W.assignment)
 	W.photo = get_id_photo(H)
 
@@ -335,14 +335,14 @@ var/ert_request_answered = 0
 	var/obj/item/device/pda/PDA = H.wear_pda
 	if(istype(PDA))
 		PDA.owner = H.real_name
-		PDA.ownjob = RTassignment
-		PDA.ownrank = RTassignment
+		PDA.ownjob = rt_assignment
+		PDA.ownrank = rt_assignment
 		PDA.name = "PDA-[H.real_name] ([PDA.ownjob])"
 
 /datum/outfit/job/centcom/response_team/commander
 	name = "RT Commander"
-	RTassignment = "Emergency Response Team Leader"
-	RTjob = "Emergency Response Team Leader"
+	rt_assignment = "Emergency Response Team Leader"
+	rt_job = "Emergency Response Team Leader"
 
 	uniform = /obj/item/clothing/under/rank/centcom_officer
 	back = /obj/item/weapon/storage/backpack/ert/commander
@@ -403,7 +403,7 @@ var/ert_request_answered = 0
 
 /datum/outfit/job/centcom/response_team/security
 	name = "RT Security"
-	RTjob = "Emergency Response Team Officer"
+	rt_job = "Emergency Response Team Officer"
 	uniform = /obj/item/clothing/under/rank/security
 	back = /obj/item/weapon/storage/backpack/ert/security
 	belt = /obj/item/weapon/storage/belt/security/response_team
@@ -475,7 +475,7 @@ var/ert_request_answered = 0
 
 /datum/outfit/job/centcom/response_team/engineer
 	name = "RT Engineer"
-	RTjob = "Emergency Response Team Engineer"
+	rt_job = "Emergency Response Team Engineer"
 	back = /obj/item/weapon/storage/backpack/ert/engineer
 	uniform = /obj/item/clothing/under/rank/engineer
 
@@ -541,7 +541,7 @@ var/ert_request_answered = 0
 
 /datum/outfit/job/centcom/response_team/medic
 	name = "RT Medic"
-	RTjob = "Emergency Response Team Medic"
+	rt_job = "Emergency Response Team Medic"
 	uniform = /obj/item/clothing/under/rank/medical
 	back = /obj/item/weapon/storage/backpack/ert/medical
 	pda = /obj/item/device/pda/heads/ert/medical

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -204,6 +204,11 @@ var/ert_request_answered = 0
 	var/medical_slots = 3
 	var/security_slots = 3
 
+	var/command_outfit
+	var/engineering_outfit
+	var/medical_outfit
+	var/security_outfit
+
 /datum/response_team/proc/get_slot_list()
 	var/list/slots_available = list()
 	if(command_slots)
@@ -230,83 +235,20 @@ var/ert_request_answered = 0
 	return 0
 
 /datum/response_team/proc/equip_officer(var/officer_type, var/mob/living/carbon/human/M)
-	M.equip_to_slot_or_del(new /obj/item/device/radio/headset/ert/alt(src), slot_l_ear)
-
-	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(M)
-	L.imp_in = M
-	L.implanted = 1
-	M.sec_hud_set_implants()
-
 	switch(officer_type)
 		if("Engineer")
 			engineer_slots -= 1
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/rank/engineer(M), slot_w_uniform)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/ert/engineer(M), slot_back)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/responseteam(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/utility/full/multitool(M), slot_belt)
-
-			var/obj/item/weapon/card/id/W = new(src)
-			W.assignment = "Emergency Response Team Member"
-			W.registered_name = M.real_name
-			W.name = "[M.real_name]'s ID Card (Emergency Response Team Engineer)"
-			W.icon_state = "ERT_engineering"
-			W.access = get_centcom_access(W.assignment)
-			M.equip_to_slot_or_del(W, slot_wear_id)
-
-			var/obj/item/device/pda/heads/pda = new(src)
-			pda.owner = M.real_name
-			pda.ownjob = "Emergency Response Team Member"
-			pda.name = "PDA-[M.real_name] ([pda.ownjob])"
-			pda.icon_state = "pda-engineer"
-			M.equip_to_slot_or_del(pda, slot_wear_pda)
+			M.equipOutfit(engineering_outfit)
 			M.job = "ERT Engineering"
-
 
 		if("Security")
 			security_slots -= 1
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/rank/security(M), slot_w_uniform)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/ert/security(M), slot_back)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/responseteam(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/security/response_team(M), slot_belt)
-
-			var/obj/item/weapon/card/id/W = new(src)
-			W.assignment = "Emergency Response Team Member"
-			W.registered_name = M.real_name
-			W.name = "[M.real_name]'s ID Card (Emergency Response Team Officer)"
-			W.icon_state = "ERT_security"
-			W.access = get_centcom_access(W.assignment)
-			M.equip_to_slot_or_del(W, slot_wear_id)
-
-			var/obj/item/device/pda/heads/pda = new(src)
-			pda.owner = M.real_name
-			pda.ownjob = "Emergency Response Team Member"
-			pda.name = "PDA-[M.real_name] ([pda.ownjob])"
-			pda.icon_state = "pda-security"
-			M.equip_to_slot_or_del(pda, slot_wear_pda)
+			M.equipOutfit(security_outfit)
 			M.job = "ERT Security"
 
 		if("Medic")
 			medical_slots -= 1
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(M), slot_w_uniform)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/ert/medical(M), slot_back)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/responseteam(M), slot_in_backpack)
-
-			var/obj/item/weapon/card/id/W = new(src)
-			W.assignment = "Emergency Response Team Member"
-			W.registered_name = M.real_name
-			W.name = "[M.real_name]'s ID Card (Emergency Response Team Medic)"
-			W.icon_state = "ERT_medical"
-			W.access = get_centcom_access(W.assignment)
-			M.equip_to_slot_or_del(W, slot_wear_id)
-
-			var/obj/item/device/pda/heads/pda = new(src)
-			pda.owner = M.real_name
-			pda.ownjob = "Emergency Response Team Member"
-			pda.name = "PDA-[M.real_name] ([pda.ownjob])"
-			pda.icon_state = "pda-medical"
-			M.equip_to_slot_or_del(pda, slot_wear_pda)
+			M.equipOutfit(medical_outfit)
 			M.job = "ERT Medical"
 
 		if("Commander")
@@ -317,23 +259,7 @@ var/ert_request_answered = 0
 			M.name = M.real_name
 			M.age = rand(35,45)
 
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/rank/centcom_officer(M), slot_w_uniform)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/ert/commander(M), slot_back)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/responseteam(M), slot_in_backpack)
-
-			var/obj/item/weapon/card/id/W = new(src)
-			W.assignment = "Emergency Response Team Leader"
-			W.registered_name = M.real_name
-			W.name = "[M.real_name]'s ID Card (Emergency Response Team Leader)"
-			W.icon_state = "ERT_leader"
-			W.access = get_centcom_access(W.assignment)
-			M.equip_to_slot_or_del(W, slot_wear_id)
-
-			var/obj/item/device/pda/heads/pda = new(src)
-			pda.owner = M.real_name
-			pda.ownjob = "Emergency Response Team Leader"
-			pda.name = "PDA-[M.real_name] ([pda.ownjob])"
-			M.equip_to_slot_or_del(pda, slot_wear_pda)
+			M.equipOutfit(command_outfit)
 			M.job = "ERT Commander"
 
 /datum/response_team/proc/cannot_send_team()
@@ -345,242 +271,344 @@ var/ert_request_answered = 0
 // -- AMBER TEAM --
 
 /datum/response_team/amber
+	engineering_outfit = /datum/outfit/job/centcom/response_team/engineer/amber
+	security_outfit = /datum/outfit/job/centcom/response_team/security/amber
+	medical_outfit = /datum/outfit/job/centcom/response_team/medic/amber
+	command_outfit = /datum/outfit/job/centcom/response_team/commander/amber
 
 /datum/response_team/amber/announce_team()
 	event_announcement.Announce("Attention, [station_name()]. We are sending a code AMBER light Emergency Response Team. Standby.", "ERT En-Route")
 
-/datum/response_team/amber/equip_officer(var/officer_type, var/mob/living/carbon/human/M)
-	..()
-
-	switch(officer_type)
-		if("Engineer")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/yellow(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/engineer(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen/engi(M), slot_s_store)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/meson(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/stack/sheet/glass(M, amount=50), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/stack/sheet/metal(M, amount=50), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/device/t_scanner(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
-
-		if("Security")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/black(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/ert/security(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun/advtaser(M), slot_s_store)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ert/security(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/zipties(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/laser(M), slot_r_hand)
-
-		if("Medic")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/latex(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/ert/medical(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/medical/response_team(M), slot_belt)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ert/medical(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/o2(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/brute(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/hypospray/CMO(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
-
-		if("Commander")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/black(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/vest/ert/command(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun(M), slot_belt)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ert/command(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/restraints/handcuffs(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/lockbox/loyalty(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/pinpointer(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
-
 // -- RED TEAM --
 
 /datum/response_team/red
+	engineering_outfit = /datum/outfit/job/centcom/response_team/engineer/red
+	security_outfit = /datum/outfit/job/centcom/response_team/security/red
+	medical_outfit = /datum/outfit/job/centcom/response_team/medic/red
+	command_outfit = /datum/outfit/job/centcom/response_team/commander/red
 
 /datum/response_team/red/announce_team()
 	event_announcement.Announce("Attention, [station_name()]. We are sending a code RED Emergency Response Team. Standby.", "ERT En-Route")
 
-/datum/response_team/red/equip_officer(var/officer_type, var/mob/living/carbon/human/M)
-	..()
-
-	switch(officer_type)
-		if("Engineer")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/yellow(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/engineer(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen/engi(M), slot_s_store)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/meson(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas(M), slot_in_backpack)
-			var/obj/item/weapon/rcd/R = new /obj/item/weapon/rcd(src)
-			R.matter = 100
-			M.equip_to_slot_or_del(R, slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/device/t_scanner/extended_range(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
-
-		if("Security")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/black(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/security(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun/advtaser(M), slot_s_store)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/security(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/handcuffs(M), slot_in_backpack)
-			if(prob(50))
-				M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/teargas(M), slot_in_backpack)
-			else
-				M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/flashbangs(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/ionrifle/carbine(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/lasercannon(M), slot_r_hand)
-
-		if("Medic")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/latex/nitrile(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/medical(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health/health_advanced(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/defibrillator/compact/loaded(M), slot_belt)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/medical(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/o2(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/toxin(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/surgery(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun(M), slot_in_backpack)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/hypospray/CMO(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
-
-		if("Commander")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/commander(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/sunglasses(M), slot_glasses)
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun/nuclear(M), slot_belt)
-
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/commander(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer/swat(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/restraints/handcuffs(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/lockbox/loyalty(M), slot_in_backpack)
-
-
-			M.equip_to_slot_or_del(new /obj/item/weapon/pinpointer(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
-
 // -- GAMMA TEAM --
 
 /datum/response_team/gamma
+	engineering_outfit = /datum/outfit/job/centcom/response_team/engineer/gamma
+	security_outfit = /datum/outfit/job/centcom/response_team/security/gamma
+	medical_outfit = /datum/outfit/job/centcom/response_team/medic/gamma
+	command_outfit = /datum/outfit/job/centcom/response_team/commander/gamma
 
 /datum/response_team/gamma/announce_team()
 	event_announcement.Announce("Attention, [station_name()]. We are sending a code GAMMA elite Emergency Response Team. Standby.", "ERT En-Route")
 
-/datum/response_team/gamma/equip_officer(var/officer_type, var/mob/living/carbon/human/M)
-	..()
+/datum/outfit/job/centcom/response_team
+	name = "Response team"
+	var/RTassignment = "Emergency Response Team Member"
+	var/RTjob = "This is a bug"
+	allow_backbag_choice = FALSE
+	allow_loadout = FALSE
+	pda = /obj/item/device/pda/heads/ert
+	id = /obj/item/weapon/card/id/ert
+	l_ear = /obj/item/device/radio/headset/ert/alt
 
-	switch(officer_type)
-		if("Engineer")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/advance(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/color/yellow(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/engineer(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_oxygen/double/full(M), slot_s_store)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/meson/night(M), slot_glasses)
+	implants = list(/obj/item/weapon/implant/loyalty)
 
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/engineer(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer/swat(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/rcd/combat, slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo/large(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo/large(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/rcd_ammo/large(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse/pistol(M), slot_in_backpack)
+/datum/outfit/job/centcom/response_team/pre_equip()
+	. = ..()
+	backpack_contents.Insert(1, /obj/item/weapon/storage/box/responseteam)
+	backpack_contents[/obj/item/weapon/storage/box/responseteam] = 1
 
-			M.equip_to_slot_or_del(new /obj/item/device/t_scanner/extended_range(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
+/datum/outfit/job/centcom/response_team/imprint_idcard(mob/living/carbon/human/H)
+	var/obj/item/weapon/card/id/W = H.wear_id
+	if(!istype(W))
+		return
+	W.assignment = RTassignment
+	W.rank = W.assignment
+	W.age = H.age
+	W.sex = capitalize(H.gender)
+	W.registered_name = H.real_name
+	W.name = "[H.real_name]'s ID Card ([RTjob])"
+	W.access = get_centcom_access(W.assignment)
+	W.photo = get_id_photo(H)
 
-		if("Security")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat/swat(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/security(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun/nuclear(M), slot_s_store)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/night(M), slot_glasses)
+/datum/outfit/job/centcom/response_team/imprint_pda(mob/living/carbon/human/H)
+	var/obj/item/device/pda/PDA = H.wear_pda
+	if(istype(PDA))
+		PDA.owner = H.real_name
+		PDA.ownjob = RTassignment
+		PDA.ownrank = RTassignment
+		PDA.name = "PDA-[H.real_name] ([PDA.ownjob])"
 
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/security(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer/swat(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/handcuffs(M), slot_in_backpack)
-			if(prob(50))
-				M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/teargas(M), slot_in_backpack)
-			else
-				M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/flashbangs(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/ionrifle/carbine(M), slot_in_backpack)
+/datum/outfit/job/centcom/response_team/commander
+	name = "RT Commander"
+	RTassignment = "Emergency Response Team Leader"
+	RTjob = "Emergency Response Team Leader"
 
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse/carbine(M), slot_r_hand)
+	uniform = /obj/item/clothing/under/rank/centcom_officer
+	back = /obj/item/weapon/storage/backpack/ert/commander
 
-		if("Medic")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat/swat(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/medical(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/health/night(M), slot_glasses)
+	id = /obj/item/weapon/card/id/ert/commander
 
-			M.equip_to_slot_or_del(new /obj/item/weapon/defibrillator/compact/loaded(M), slot_belt)
+	l_pocket = /obj/item/weapon/pinpointer
+	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
 
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/medical(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer/swat(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/surgery(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse/pistol(M), slot_in_backpack)
+/datum/outfit/job/centcom/response_team/commander/amber
+	name = "RT Commander (Amber)"
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/color/black
+	suit = /obj/item/clothing/suit/armor/vest/ert/command
+	glasses = /obj/item/clothing/glasses/sunglasses
 
-			M.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/hypospray/combat/nanites(src), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
+	belt = /obj/item/weapon/gun/energy/gun
 
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/medbeam(M), slot_r_hand)
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/ert/command = 1,
+		/obj/item/clothing/mask/gas/sechailer = 1,
+		/obj/item/weapon/restraints/handcuffs = 1,
+		/obj/item/weapon/storage/lockbox/loyalty = 1
+	)
 
-		if("Commander")
-			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat/swat(M), slot_shoes)
-			M.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat(M), slot_gloves)
-			M.equip_to_slot_or_del(new /obj/item/clothing/suit/space/hardsuit/ert/commander(M), slot_wear_suit)
-			M.equip_to_slot_or_del(new /obj/item/clothing/glasses/hud/security/night(M), slot_glasses)
+/datum/outfit/job/centcom/response_team/commander/red
+	name = "RT Commander (Red)"
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/combat
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/commander
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/gun/nuclear(M), slot_belt)
+	belt = /obj/item/weapon/gun/energy/gun/nuclear
 
-			M.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/space/hardsuit/ert/commander(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/sechailer/swat(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/restraints/handcuffs(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/lockbox/loyalty(M), slot_in_backpack)
-			M.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse/pistol(M), slot_in_backpack)
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/commander = 1,
+		/obj/item/clothing/mask/gas/sechailer/swat = 1,
+		/obj/item/weapon/restraints/handcuffs = 1,
+		/obj/item/weapon/storage/lockbox/loyalty = 1
+	)
 
-			M.equip_to_slot_or_del(new /obj/item/weapon/pinpointer(M), slot_l_store)
-			M.equip_to_slot_or_del(new /obj/item/weapon/melee/classic_baton/telescopic(M), slot_r_store)
+/datum/outfit/job/centcom/response_team/commander/gamma
+	name = "RT Commander (Gamma)"
+	shoes = /obj/item/clothing/shoes/combat/swat
+	gloves = /obj/item/clothing/gloves/combat
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/commander
+	glasses = /obj/item/clothing/glasses/hud/security/night
 
+	belt = /obj/item/weapon/gun/energy/gun/nuclear
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/commander = 1,
+		/obj/item/clothing/mask/gas/sechailer/swat = 1,
+		/obj/item/weapon/restraints/handcuffs = 1,
+		/obj/item/weapon/storage/lockbox/loyalty = 1,
+		/obj/item/weapon/gun/energy/pulse/pistol = 1
+		)
+
+/datum/outfit/job/centcom/response_team/security
+	name = "RT Security"
+	RTjob = "Emergency Response Team Officer"
+	uniform = /obj/item/clothing/under/rank/security
+	back = /obj/item/weapon/storage/backpack/ert/security
+	belt = /obj/item/weapon/storage/belt/security/response_team
+	pda = /obj/item/device/pda/heads/ert/security
+	id = /obj/item/weapon/card/id/ert/security
+	var/has_grenades = FALSE
+
+/datum/outfit/job/centcom/response_team/security/pre_equip()
+	. = ..()
+	if(has_grenades)
+		var/grenadebox = /obj/item/weapon/storage/box/flashbangs
+		if(prob(50))
+			grenadebox = /obj/item/weapon/storage/box/teargas
+		backpack_contents.Insert(1, grenadebox)
+		backpack_contents[grenadebox] = 1
+
+/datum/outfit/job/centcom/response_team/security/amber
+	name = "RT Security (Amber)"
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/color/black
+	suit = /obj/item/clothing/suit/armor/vest/ert/security
+	suit_store = /obj/item/weapon/gun/energy/gun/advtaser
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+
+	r_hand = /obj/item/weapon/gun/energy/laser
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/ert/security = 1,
+		/obj/item/clothing/mask/gas/sechailer = 1,
+		/obj/item/weapon/storage/box/zipties = 1
+	)
+
+/datum/outfit/job/centcom/response_team/security/red
+	name = "RT Security (Red)"
+	has_grenades = TRUE
+
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/color/black
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/security
+	suit_store = /obj/item/weapon/gun/energy/gun/advtaser
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+
+	r_hand = /obj/item/weapon/gun/energy/lasercannon
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/security = 1,
+		/obj/item/clothing/mask/gas/sechailer = 1,
+		/obj/item/weapon/storage/box/handcuffs = 1,
+		/obj/item/weapon/gun/energy/ionrifle/carbine = 1
+	)
+
+/datum/outfit/job/centcom/response_team/security/gamma
+	name = "RT Security (Gamma)"
+	has_grenades = TRUE
+	shoes = /obj/item/clothing/shoes/combat/swat
+	gloves = /obj/item/clothing/gloves/combat
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/security
+	suit_store = /obj/item/weapon/gun/energy/gun/nuclear
+	glasses = /obj/item/clothing/glasses/hud/security/night
+
+	r_hand = /obj/item/weapon/gun/energy/pulse/carbine
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/security = 1,
+		/obj/item/clothing/mask/gas/sechailer/swat = 1,
+		/obj/item/weapon/storage/box/handcuffs = 1,
+		/obj/item/weapon/gun/energy/ionrifle/carbine = 1
+	)
+
+/datum/outfit/job/centcom/response_team/engineer
+	name = "RT Engineer"
+	RTjob = "Emergency Response Team Engineer"
+	back = /obj/item/weapon/storage/backpack/ert/engineer
+	uniform = /obj/item/clothing/under/rank/engineer
+
+	belt = /obj/item/weapon/storage/belt/utility/full/multitool
+	pda = /obj/item/device/pda/heads/ert/engineering
+	id = /obj/item/weapon/card/id/ert/engineering
+
+/datum/outfit/job/centcom/response_team/engineer/amber
+	name = "RT Engineer (Amber)"
+	shoes = /obj/item/clothing/shoes/magboots
+	gloves = /obj/item/clothing/gloves/color/yellow
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
+	suit_store = /obj/item/weapon/tank/emergency_oxygen/engi
+	glasses = /obj/item/clothing/glasses/meson
+
+	l_pocket = /obj/item/device/t_scanner
+	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/engineer = 1,
+		/obj/item/clothing/mask/gas = 1,
+		/obj/item/stack/sheet/glass/fifty = 1,
+		/obj/item/stack/sheet/metal/fifty = 1
+	)
+
+/datum/outfit/job/centcom/response_team/engineer/red
+	name = "RT Engineer (Red)"
+	shoes = /obj/item/clothing/shoes/magboots
+	gloves = /obj/item/clothing/gloves/color/yellow
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
+	suit_store = /obj/item/weapon/tank/emergency_oxygen/engi
+	glasses = /obj/item/clothing/glasses/meson
+
+	l_pocket = /obj/item/device/t_scanner/extended_range
+	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/engineer = 1,
+		/obj/item/clothing/mask/gas = 1,
+		/obj/item/weapon/rcd/preloaded = 1,
+		/obj/item/weapon/rcd_ammo = 3,
+		/obj/item/weapon/gun/energy/gun = 1
+	)
+
+/datum/outfit/job/centcom/response_team/engineer/gamma
+	name = "RT Engineer (Gamma)"
+	shoes = /obj/item/clothing/shoes/magboots/advance
+	gloves = /obj/item/clothing/gloves/color/yellow
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
+	suit_store = /obj/item/weapon/tank/emergency_oxygen/double/full
+	glasses = /obj/item/clothing/glasses/meson/night
+
+	l_pocket = /obj/item/device/t_scanner/extended_range
+	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/engineer = 1,
+		/obj/item/clothing/mask/gas/sechailer/swat = 1,
+		/obj/item/weapon/rcd/combat = 1,
+		/obj/item/weapon/rcd_ammo/large = 3,
+		/obj/item/weapon/gun/energy/pulse/pistol = 1
+	)
+
+/datum/outfit/job/centcom/response_team/medic
+	name = "RT Medic"
+	RTjob = "Emergency Response Team Medic"
+	uniform = /obj/item/clothing/under/rank/medical
+	back = /obj/item/weapon/storage/backpack/ert/medical
+	pda = /obj/item/device/pda/heads/ert/medical
+	id = /obj/item/weapon/card/id/ert/medic
+
+	l_pocket = /obj/item/weapon/reagent_containers/hypospray/CMO
+	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
+
+/datum/outfit/job/centcom/response_team/medic/amber
+	name = "RT Medic (Amber)"
+
+	shoes = /obj/item/clothing/shoes/white
+	gloves = /obj/item/clothing/gloves/color/latex
+	suit = /obj/item/clothing/suit/armor/vest/ert/medical
+	glasses = /obj/item/clothing/glasses/hud/health
+
+	belt = /obj/item/weapon/storage/belt/medical/response_team
+
+	l_pocket = /obj/item/weapon/reagent_containers/hypospray/CMO
+	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/ert/medical = 1,
+		/obj/item/clothing/mask/surgical = 1,
+		/obj/item/weapon/storage/firstaid/o2 = 1,
+		/obj/item/weapon/storage/firstaid/brute = 1,
+		/obj/item/weapon/storage/firstaid/adv = 1,
+	)
+
+/datum/outfit/job/centcom/response_team/medic/red
+	name = "RT Medic (Red)"
+	shoes = /obj/item/clothing/shoes/white
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/medical
+	glasses = /obj/item/clothing/glasses/hud/health/health_advanced
+
+	belt = /obj/item/weapon/defibrillator/compact/loaded
+
+
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/medical = 1,
+		/obj/item/clothing/mask/surgical = 1,
+		/obj/item/weapon/storage/firstaid/o2 = 1,
+		/obj/item/weapon/storage/firstaid/toxin = 1,
+		/obj/item/weapon/storage/firstaid/adv = 1,
+		/obj/item/weapon/storage/firstaid/surgery = 1,
+		/obj/item/weapon/gun/energy/gun = 1
+	)
+
+/datum/outfit/job/centcom/response_team/medic/gamma
+	name = "RT Medic (Gamma)"
+	shoes = /obj/item/clothing/shoes/combat/swat
+	gloves = /obj/item/clothing/gloves/combat
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/medical
+	glasses = /obj/item/clothing/glasses/hud/health/night
+
+	belt = /obj/item/weapon/defibrillator/compact/loaded
+
+	l_pocket = /obj/item/weapon/reagent_containers/hypospray/combat/nanites
+
+	r_hand = /obj/item/weapon/gun/medbeam
+	backpack_contents = list(
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/medical = 1,
+		/obj/item/clothing/mask/gas/sechailer/swat = 1,
+		/obj/item/weapon/storage/firstaid/surgery = 1,
+		/obj/item/weapon/gun/energy/pulse/pistol = 1
+	)
 
 /obj/item/device/radio/centcom
 	name = "centcomm bounced radio"

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -99,6 +99,18 @@
 	default_cartridge = /obj/item/weapon/cartridge/hos
 	icon_state = "pda-h"
 
+/obj/item/device/pda/heads/ert
+
+/obj/item/device/pda/heads/ert/engineering
+	icon_state = "pda-engineer"
+
+/obj/item/device/pda/heads/ert/security
+	icon_state = "pda-security"
+
+/obj/item/device/pda/heads/ert/medical
+	icon_state = "pda-medical"
+
+
 /obj/item/device/pda/cargo
 	default_cartridge = /obj/item/weapon/cartridge/quartermaster
 	icon_state = "pda-cargo"


### PR DESCRIPTION
:cl:Crazylemon
rscadd: Adds an "ethereal beacon", an admin-only structure usable to attract ghosts to an area.
rscadd: Adds several transformer machines to streamline the ghost-to-PC process.
/:cl:

The "Ethereal beacon" can be activated by hand by an admin, to periodically (normally every 30 seconds) call ghosts to where the beacon is. This can be adjusted by modifying `ghost_alert_delay`, which is in deciseconds.
The "Transmogrifier" has a `target_species` var, and turns any humanoid that passes through it into the corresponding species.
The "Auto-equipper 9000" has a `selected_outfit` var, which is a path to an outfit datum to apply to any human that passes through. You may also want to set `transform_standing` to 1 to let outfits that put items in people's hands do their thing.
The "DNA scrambler" scrambles the appearance of anyone who enters it, to "sanitize" the mob of being any other character.
The "genetic blueprint applier" uses a genetic sample from a gene disk to make all humans that pass through it a carbon-copy of the given DNA. Useful for literal clone wars. Has a `locked` variable if you don't want people tampering with it.

Also refactors ERT equipment code to work off of outfit datums, so we can use ERT outfits with the machines above.