### PR TITLE
Recitence mech makes no sound when turning

### DIFF
--- a/code/game/mecha/combat/recitence.dm
+++ b/code/game/mecha/combat/recitence.dm
@@ -16,6 +16,7 @@
 	max_equip = 3
 	step_energy_drain = 3
 	stepsound = null
+	turnsound = null
 
 /obj/mecha/combat/recitence/loaded/New()
 	..()


### PR DESCRIPTION
Okay round two.

I believe the mime mech could be a bit more silent. It already doesn't make a sound when moving around the station so why stop halfway and not remove the turning sounds as well? This is what this PR does. It now makes no sound when it makes those 90 degree turns.

🆑 Jovaniph
tweak: Recitence no longer makes a sound when turning
/:cl: