### PR TITLE
Minor firelock/airlock force change and firelock explosion change

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -892,11 +892,11 @@ About the new airlock wires panel:
 			if(arePowerSystemsOn())
 				var/obj/item/weapon/crowbar/power/P = C
 				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, 1) //is it aliens or just the CE being a dick?
-				user.visible_message("<span class='notice'>[user] starts forcing \the [src] with \the [P]...</span>", \
-									 "<span class='notice'>You begin forcing \the [src] with \the [P]...</span>")
+				user.visible_message("<span class='notice'>[user] starts forcing [src] with \the [P]...</span>", \
+									 "<span class='notice'>You begin forcing [src] with \the [P]...</span>")
 				if(do_after(user, P.airlock_open_time, target = src))
-					user.visible_message("<span class='notice'>[user] forces \the [src] with \the [P].</span>", \
-						 "<span class='notice'>You force \the [src] with \the [P].</span>")
+					user.visible_message("<span class='notice'>[user] forces [src] with \the [P].</span>", \
+						 "<span class='notice'>You force [src] with \the [P].</span>")
 					open(2)
 					if(density && !open(2))
 						to_chat(user, "<span class='warning'>Despite your attempts, the [src] refuses to open.</span>")

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -891,8 +891,12 @@ About the new airlock wires panel:
 
 			if(arePowerSystemsOn())
 				var/obj/item/weapon/crowbar/power/P = C
-				playsound(src, 'sound/machines/airlock_alien_prying.ogg',100,1) //is it aliens or just the CE being a dick?
+				playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, 1) //is it aliens or just the CE being a dick?
+				user.visible_message("<span class='notice'>[user] starts forcing \the [src] with \the [P]...</span>", \
+									 "<span class='notice'>You begin forcing \the [src] with \the [P]...</span>")
 				if(do_after(user, P.airlock_open_time, target = src))
+					user.visible_message("<span class='notice'>[user] forces \the [src] with \the [P].</span>", \
+						 "<span class='notice'>You force \the [src] with \the [P].</span>")
 					open(2)
 					if(density && !open(2))
 						to_chat(user, "<span class='warning'>Despite your attempts, the [src] refuses to open.</span>")

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -93,7 +93,6 @@
 		user.visible_message("[user] forces \the [src] with [C].",
 		"You force \the [src] with [C].")
 		if(density)
-			autoclose = TRUE
 			open()
 		else
 			close()
@@ -110,7 +109,6 @@
 		if(do_after(user, force_open_time, target = src))
 			user.visible_message("<span class='notice'>[user] forces \the [src].</span>", \
 								 "<span class='notice'>You force \the [src].</span>")
-			autoclose = TRUE
 			open()
 	else if(glass)
 		user.changeNext_move(CLICK_CD_MELEE)
@@ -160,9 +158,12 @@
 	active_alarm = FALSE
 	update_icon()
 
-/obj/machinery/door/firedoor/open()
+/obj/machinery/door/firedoor/open(auto_close = TRUE)
 	. = ..()
-	latetoggle()
+	latetoggle(auto_close)
+	
+	if(auto_close)
+		autoclose = TRUE
 
 /obj/machinery/door/firedoor/close()
 	. = ..()
@@ -174,22 +175,22 @@
 	if(active_alarm)
 		. = ..()
 
-/obj/machinery/door/firedoor/proc/latetoggle()
+/obj/machinery/door/firedoor/proc/latetoggle(auto_close = TRUE)
 	if(operating || stat & NOPOWER || !nextstate)
 		return
 	switch(nextstate)
 		if(OPEN)
 			nextstate = null
-			open()
+			open(auto_close)
 		if(CLOSED)
 			nextstate = null
 			close()
 
-/obj/machinery/door/firedoor/proc/forcetoggle(magic = FALSE)
+/obj/machinery/door/firedoor/proc/forcetoggle(magic = FALSE, auto_close = TRUE)
 	if(!magic && (operating || stat & NOPOWER))
 		return
 	if(density)
-		open()
+		open(auto_close)
 	else
 		close()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -36,6 +36,17 @@
 	if(!density)
 		return ..()
 	return 0
+	
+/obj/machinery/door/firedoor/ex_act(severity)
+	switch(severity)
+		if(1.0)
+			qdel(src)
+		if(2.0)
+			if(prob(50))
+				qdel(src)
+		if(3.0)
+			if(prob(5))
+				qdel(src)
 
 /obj/machinery/door/firedoor/power_change()
 	if(powered(power_channel))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -44,9 +44,6 @@
 		if(2.0)
 			if(prob(50))
 				qdel(src)
-		if(3.0)
-			if(prob(5))
-				qdel(src)
 
 /obj/machinery/door/firedoor/power_change()
 	if(powered(power_channel))

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -7,7 +7,7 @@
 
 /datum/station_goal/bluespace_cannon/get_report()
 	return {"<b>Bluespace Artillery position construction</b><br>
-	Our military presence is inadequate in your sector. We need you to construct BSA-[rand(1,99)] Artillery position aboard your station.
+	Our military presence is inadequate in your sector. We need you to construct a BSA-[rand(1,99)] Artillery position aboard your station.
 	<br><br>
 	Its base parts should be available for shipping by your cargo shuttle.
 	<br>

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -9,7 +9,7 @@
 	return {"<b>Station Shield construction</b><br>
 	The station is located in a zone full of space debris. We have a prototype shielding system you will deploy to reduce collision related accidents.
 	<br><br>
-	You can order the satellites and control systems through cargo shuttle."}
+	You can order the satellites and control systems through the cargo shuttle."}
 
 /datum/station_goal/station_shield/on_report()
 	//Unlock


### PR DESCRIPTION
- Firelocks forced by AI's/cyborgs at range or by admin ghosts will now autoclose as long as there is still an atmospherics alarm present in the area. The reasoning behind is that if the red lights are flashing on the airlocks, it should always autoclose. Previously this wasn't the case with AI/admin ghost closures which caused confusion (and wasn't my initial intention).
- Regular (non-heavy) firelocks will now properly respond to explosions. They are always destroyed in severity 1 explosions and destroyed 50% of the time at severity 2. Heavy firelocks are still only destroyed in severity 1 explosions.
- Added a visible message to forcing airlocks with the Jaws of Life.
- Fixed two minor typos in the station goal orders.

🆑 Markolie
tweak: Firelocks forced by AI's, cyborgs at range or admin ghosts will now autoclose if there's still an atmospherics alarm present.
tweak: Regular (non-heavy) firelocks will now properly respond to explosions (100% chance of being destroyed at severity 1 explosions and 50% at severity 2). Heavy firelocks are still only destroyed in severity 1 explosions.
tweak: Added a visible message to forcing airlocks with the Jaws of Life.
/🆑