### PR TITLE
Fixes Admin Bwoink Preference

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -2,6 +2,7 @@
 var/list/admin_verbs_default = list(
 	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
+	/client/proc/toggleadminhelpsound, /*toggles whether we hear bwoinks*/
 	/client/proc/cmd_mentor_check_new_players,
 	/client/proc/cmd_mentor_check_player_exp /* shows players by playtime */
 	)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -162,8 +162,8 @@
 		C.ckey_last_pm = ckey*/
 
 	//play the recieving admin the adminhelp sound (if they have them enabled)
-	//non-admins shouldn't be able to disable this
-	if(C.prefs.sound & SOUND_ADMINHELP)
+	//non-admins always hear the sound, as they cannot toggle it
+	if((!C.holder) || (C.prefs.sound & SOUND_ADMINHELP))
 		C << 'sound/effects/adminhelp.ogg'
 
 	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -36,8 +36,8 @@
 	to_chat(usr, "You will [(prefs.toggles & CHAT_RADIO) ? "now" : "no longer"] see radio chatter from radios or speakers")
 	feedback_add_details("admin_verb","THR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/verb/toggleadminhelpsound()
-	set name = "Hear/Silence Adminhelps"
+/client/proc/toggleadminhelpsound()
+	set name = "Hear/Silence Admin Bwoinks"
 	set category = "Preferences"
 	set desc = "Toggle hearing a notification when admin PMs are recieved"
 	if(!holder)	return


### PR DESCRIPTION
- Non-admin players will no longer get the "Hear/Silence Adminhelps" preference verb.
  - They could not even use it, as they are not intended to turn off the bwoink.
- PMs to non-admin players will no longer respect the bwoink preference - they will always hear the bwoink, even if it somehow gets turned off in their preferences.
  - This also applies to people who de-admin. You get bwoinked, same as anyone else.
- The preference verb has been renamed from "Hear/Silence Adminhelps" to "Hear/Silence Admin Bwoinks", to make it clear you're toggling the sound and not whether you see adminhelps at all.

Fixes #6723.