### PR TITLE
You can now deep fry the nuke disk... If you dare.

### DIFF
--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -66,3 +66,8 @@
 
 	qdel(src)
 	return
+
+/obj/item/weapon/grenade/spawnergrenade/feral_cats/meme/New()
+	..()
+	prime()
+

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -102,3 +102,7 @@
 /datum/deepfryer_special/carrotfries
 	input = /obj/item/weapon/reagent_containers/food/snacks/grown/carrot/wedges
 	output = /obj/item/weapon/reagent_containers/food/snacks/carrotfries
+	
+/datum/deepfryer_special/disk 	//memes!
+	input = /obj/item/weapon/disk/nuclear
+	output = /obj/item/weapon/grenade/spawnergrenade/feral_cats //CATS!!

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -105,4 +105,4 @@
 	
 /datum/deepfryer_special/disk 	//memes!
 	input = /obj/item/weapon/disk/nuclear
-	output = /obj/item/weapon/grenade/spawnergrenade/feral_cats //CATS!!
+	output = /obj/item/weapon/grenade/spawnergrenade/feral_cats/meme //CATS!!


### PR DESCRIPTION
Basically, if you deep fry the nuke disk, a primed feral cat grenade is given instead of a "deep fried nuclear authentication disk". Better run.  
  
🆑 Reeeeimstupid
rcsadd: You can now deep fry nuclear authentication disks, although it is quite dangerous.
/🆑