### PR TITLE
Quick Tile Replacement

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -138,24 +138,20 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		return 1
 	if(..())
 		return 1
-	if(intact && istype(C, /obj/item/weapon/crowbar))
-		if(broken || burnt)
-			broken = 0
-			burnt = 0
-			to_chat(user, "<span class='danger'>You remove the broken plating.</span>")
-		else
-			if(istype(src, /turf/simulated/floor/wood))
-				to_chat(user, "<span class='danger'>You forcefully pry off the planks, destroying them in the process.</span>")
-			else if(!builtin_tile)
-				to_chat(user, "<span class='notice'>You are unable to pry up \the [src] with a crowbar.</span>")
-				return 1
-			else
-				to_chat(user, "<span class='danger'>You remove \the [builtin_tile.singular_name].</span>")
-				builtin_tile.loc = src
-				builtin_tile = null //deassociate tile, it no longer belongs to this turf
-		make_plating()
-		playsound(src, C.usesound, 80, 1)
+	if(intact && iscrowbar(C))
+		pry_tile(C, user)
 		return 1
+	if(intact && istype(C, /obj/item/stack/tile))
+		var/obj/item/stack/tile/T = C
+		if(T.turf_type == type)
+			return
+		var/obj/item/weapon/crowbar/CB = user.get_inactive_hand(/obj/item/weapon/crowbar)
+		if(!CB)
+			return
+		var/turf/simulated/floor/plating/P = pry_tile(CB, user, TRUE)
+		if(!istype(P))
+			return
+		P.attackby(T, user, params)
 	if(istype(C, /obj/item/pipe))
 		var/obj/item/pipe/P = C
 		if(P.pipe_type != -1) // ANY PIPE
@@ -180,6 +176,24 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 			P.loc = src
 			return 1
 	return 0
+
+/turf/simulated/floor/proc/pry_tile(obj/item/C, mob/user, silent = FALSE)
+	playsound(src, C.usesound, 80, 1)
+	return remove_tile(user, silent)
+
+/turf/simulated/floor/proc/remove_tile(mob/user, silent = FALSE, make_tile = TRUE)
+	if(broken || burnt)
+		broken = 0
+		burnt = 0
+		if(user && !silent)
+			to_chat(user, "<span class='danger'>You remove the broken plating.</span>")
+	else
+		if(user && !silent)
+			to_chat(user, "<span class='danger'>You remove the floor tile.</span>")
+		if(builtin_tile && make_tile)
+			builtin_tile.forceMove(src)
+			builtin_tile = null
+	return make_plating()
 
 /turf/simulated/floor/singularity_pull(S, current_size)
 	if(current_size == STAGE_THREE)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -11,14 +11,32 @@
 /turf/simulated/floor/wood/attackby(obj/item/C, mob/user, params)
 	if(..())
 		return
-	if(istype(C, /obj/item/weapon/screwdriver))
-		if(broken || burnt)
-			return
-		to_chat(user, "<span class='danger'>You unscrew the planks.</span>")
-		new floor_tile(src)
-		make_plating()
-		playsound(src, C.usesound, 80, 1)
+	if(isscrewdriver(C))
+		pry_tile(C, user)
 		return
+
+/turf/simulated/floor/wood/pry_tile(obj/item/C, mob/user, silent = FALSE)
+	var/is_screwdriver = isscrewdriver(C)
+	playsound(src, C.usesound, 80, 1)
+	return remove_tile(user, silent, make_tile = is_screwdriver)
+
+/turf/simulated/floor/wood/remove_tile(mob/user, silent = FALSE, make_tile = TRUE)
+	if(broken || burnt)
+		broken = 0
+		burnt = 0
+		if(user && !silent)
+			to_chat(user, "<span class='danger'>You remove the broken planks.</span>")
+	else
+		if(make_tile)
+			if(user && !silent)
+				to_chat(user, "<span class='danger'>You unscrew the planks.</span>")
+			if(builtin_tile)
+				builtin_tile.forceMove(src)
+				builtin_tile = null
+		else
+			if(user && !silent)
+				to_chat(user, "<span class='danger'>You forcefully pry off the planks, destroying them in the process.</span>")
+	return make_plating()
 
 /turf/simulated/floor/grass
 	name = "grass patch"
@@ -45,7 +63,7 @@
 		to_chat(user, "<span class='notice'>You shovel the grass.</span>")
 		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
 		make_plating()
-		
+
 // NEEDS TO BE UPDATED
 /turf/simulated/floor/basalt //By your powers combined, I am captain planet
 	name = "volcanic floor"
@@ -54,7 +72,7 @@
 	oxygen = 14
 	nitrogen = 23
 	temperature = 300
-	
+
 /turf/simulated/floor/basalt/attackby(obj/item/W, mob/user, params)
 	if(..())
 		return


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/24847

Click a floor with a tile in hand and a crowbar/screwdriver (for wooden) in inactive hand to directly replace the tile. It makes reflooring less time consuming.

:cl:
add: Clicking on a tile with another tile and a crowbar or screwdriver in hand directly replaces the tile.
/:cl: