### PR TITLE
ghetto surgery internal organ disinfection and dead limb revival

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -9,13 +9,21 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1,2,3,4,5)
 	volume = 5
-	var/filled = 0
+
+/obj/item/weapon/reagent_containers/dropper/on_reagent_change()
+	update_icon()
+
+/obj/item/weapon/reagent_containers/dropper/update_icon()
+	if(reagents.total_volume<=0)
+		icon_state = "[initial(icon_state)]"
+	else
+		icon_state = "[initial(icon_state)]1"
 
 /obj/item/weapon/reagent_containers/dropper/afterattack(obj/target, mob/user , flag)
 	if(!target.reagents)
 		return
 
-	if(filled)
+	if(reagents.total_volume)
 
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			to_chat(user, "<span class='warning'>[target] is full.</span>")
@@ -51,12 +59,7 @@
 					spawn(5)
 						reagents.reaction(safe_thing, TOUCH)
 
-
-
 					to_chat(user, "<span class='notice'>You transfer [trans] units of the solution.</span>")
-					if(reagents.total_volume<=0)
-						filled = 0
-						icon_state = "[initial(icon_state)]"
 					return
 
 
@@ -80,9 +83,6 @@
 
 		trans = reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution.</span>")
-		if(reagents.total_volume<=0)
-			filled = 0
-			icon_state = "[initial(icon_state)]"
 
 	else
 
@@ -97,9 +97,6 @@
 		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] units of the solution.</span>")
-
-		filled = 1
-		icon_state = "[initial(icon_state)][filled]"
 
 /obj/item/weapon/reagent_containers/dropper/cyborg
 	name = "Industrial Dropper"

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -212,7 +212,7 @@
 			H.custom_pain("The pain in your [affected.name] is living hell!", 1)
 
 	else if(istype(tool, /obj/item/weapon/reagent_containers/food/snacks/organ))
-		to_chat(user, "<span class='warning'>[tool] was biten by someone! It's too damaged to use!</span>")
+		to_chat(user, "<span class='warning'>[tool] was bitten by someone! It's too damaged to use!</span>")
 		return -1
 
 	..()
@@ -299,20 +299,15 @@
 					user.visible_message("[user] notices there is not enough of \the [tool].", \
 					"You notice there is not enough of \the [tool].")
 					return 0
-				if(I.germ_level < INFECTION_LEVEL_ONE)
+				if(I.germ_level < INFECTION_LEVEL_ONE / 2)
 					to_chat(user, "[I] does not appear to be infected.")
-				if(I.germ_level >= INFECTION_LEVEL_ONE)
+				if(I.germ_level >= INFECTION_LEVEL_ONE / 2)
 					I.surgeryize()//is this even needed?
 					I.germ_level = max(I.germ_level-ethanol, 0)
 					user.visible_message("<span class='notice'> [user] has poured some of \the [tool] over [target]'s [I.name].</span>",
 					"<span class='notice'> You have poured some of \the [tool] over [target]'s [I.name].</span>")
 					R.trans_to(target, GHETTO_DISINFECT_AMOUNT)
 					R.reaction(target, INGEST)
-
-					if(istype(C, /obj/item/weapon/reagent_containers/dropper/) && C.reagents.total_volume<=0) //trans_to() doesnt do this to droppers???
-						var/obj/item/weapon/reagent_containers/dropper/D = C
-						D.filled = 0
-						D.icon_state = "dropper"
 
 	else if(current_type == "finish")
 		if(affected && affected.encased)
@@ -383,11 +378,6 @@
 
 		R.trans_to(target, GHETTO_DISINFECT_AMOUNT * 10)
 		R.reaction(target, INGEST)
-
-		if(istype(C, /obj/item/weapon/reagent_containers/dropper/) && C.reagents.total_volume<=0) //trans_to() doesnt do this to droppers???
-			var/obj/item/weapon/reagent_containers/dropper/D = C
-			D.filled = 0
-			D.icon_state = "dropper"
 
 		user.visible_message("<span class='warning'> [user]'s hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>", \
 		"<span class='warning'> Your hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>")

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -128,8 +128,8 @@
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
 			if(I)
 				if(C.reagents.total_volume < GHETTO_DISINFECT_AMOUNT)
-					user.visible_message("[user] notices \the [tool] is emtpy.", \
-					"You notice \the [tool]. is empty")
+					user.visible_message("[user] notices \the [tool] is empty.", \
+					"You notice \the [tool] is empty")
 					return 0
 
 				var/msg = "[user] starts pouring some of \the [tool] over [target]'s [I.name]."
@@ -312,9 +312,6 @@
 						D.filled = 0
 						D.icon_state = "dropper"
 
-				if(R.has_reagent("mitocholide"))
-					affected.status &= ~ORGAN_DEAD
-
 	else if(current_type == "finish")
 		if(affected && affected.encased)
 			var/msg = "<span class='notice'> [user] bends [target]'s [affected.encased] back into place with \the [tool].</span>"
@@ -389,9 +386,6 @@
 			var/obj/item/weapon/reagent_containers/dropper/D = C
 			D.filled = 0
 			D.icon_state = "dropper"
-
-		if(R.has_reagent("mitocholide"))
-			affected.status &= ~ORGAN_DEAD
 
 		user.visible_message("<span class='warning'> [user]'s hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>", \
 		"<span class='warning'> Your hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>")

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -71,10 +71,12 @@
 	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/kitchen/utensil/fork = 55)
 	var/implements_mend = list(/obj/item/stack/medical/bruise_pack = 20,/obj/item/stack/medical/bruise_pack/advanced = 100,/obj/item/stack/nanopaste = 100)
 	var/implements_clean = list(/obj/item/weapon/reagent_containers/dropper = 100,
-								/obj/item/weapon/reagent_containers/food/drinks/bottle = 75,
-								/obj/item/weapon/reagent_containers/glass/beaker = 65,
-								/obj/item/weapon/reagent_containers/spray = 55,
-								/obj/item/weapon/reagent_containers/glass/bucket = 45)
+								/obj/item/weapon/reagent_containers/glass/bottle = 75,
+								/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
+								/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
+								/obj/item/weapon/reagent_containers/glass/beaker = 60,
+								/obj/item/weapon/reagent_containers/spray = 50,
+								/obj/item/weapon/reagent_containers/glass/bucket = 40)
 	//Finish is just so you can close up after you do other things.
 	var/implements_finsh = list(/obj/item/weapon/scalpel/manager = 120,/obj/item/weapon/retractor = 100 ,/obj/item/weapon/crowbar = 75)
 	var/current_type
@@ -288,7 +290,7 @@
 
 		if(R.reagent_list.len)
 			for(var/datum/reagent/consumable/ethanol/alcohol in R.reagent_list)
-				ethanol += alcohol.alcohol_perc * 500
+				ethanol += alcohol.alcohol_perc * 300
 			ethanol /= R.reagent_list.len
 
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
@@ -372,12 +374,12 @@
 
 		if(R.reagent_list.len)
 			for(var/datum/reagent/consumable/ethanol/alcohol in R.reagent_list)
-				ethanol += alcohol.alcohol_perc * 500
+				ethanol += alcohol.alcohol_perc * 300
 			ethanol /= C.reagents.reagent_list.len
 
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
 			I.germ_level = max(I.germ_level-ethanol, 0)
-			I.take_damage(rand(3,6),0)
+			I.take_damage(rand(4,8),0)
 
 		R.trans_to(target, GHETTO_DISINFECT_AMOUNT * 10)
 		R.reaction(target, INGEST)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -13,6 +13,11 @@
 	steps = list(/datum/surgery_step/generic/cut_open,/datum/surgery_step/generic/clamp_bleeders,/datum/surgery_step/generic/retract_skin,/datum/surgery_step/fix_vein,/datum/surgery_step/generic/cauterize)
 	possible_locs = list("chest","head","groin", "l_arm", "r_arm", "l_leg", "r_leg", "r_hand", "l_hand", "r_foot", "l_foot")
 
+/datum/surgery/debridement
+	name = "Debridement"
+	steps = list(/datum/surgery_step/generic/cut_open,/datum/surgery_step/generic/clamp_bleeders,/datum/surgery_step/generic/retract_skin,/datum/surgery_step/fix_dead_tissue,/datum/surgery_step/treat_necrosis,/datum/surgery_step/generic/cauterize)
+	possible_locs = list("chest","head","groin", "l_arm", "r_arm", "l_leg", "r_leg", "r_hand", "l_hand", "r_foot", "l_foot")
+
 /datum/surgery/infection/can_start(mob/user, mob/living/carbon/target)
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
@@ -94,9 +99,9 @@
 /datum/surgery_step/fix_dead_tissue		//Debridement
 	name = "remove dead tissue"
 	allowed_tools = list(
-		/obj/item/weapon/scalpel = 100,		\
-		/obj/item/weapon/kitchen/knife = 75,	\
-		/obj/item/weapon/shard = 50, 		\
+		/obj/item/weapon/scalpel = 100, \
+		/obj/item/weapon/kitchen/knife = 75, \
+		/obj/item/weapon/shard = 50,
 	)
 
 	can_infect = 1
@@ -115,7 +120,6 @@
 
 	if(!(affected.status & ORGAN_DEAD))
 		return 0
-
 	return 1
 
 /datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -156,7 +160,7 @@
 
 	time = 24
 
-/datum/surgery_step/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(!istype(tool, /obj/item/weapon/reagent_containers))
 		return 0
 
@@ -172,14 +176,14 @@
 		return 0
 	return 1
 
-/datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+datum/surgery_step/treat_necrosis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the affected tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the affected tissue in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",1)
 	..()
 
-/datum/surgery_step/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if(!istype(tool, /obj/item/weapon/reagent_containers))
@@ -199,7 +203,7 @@
 
 	return 1
 
-/datum/surgery_step/fix_dead_tissue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if(!istype(tool, /obj/item/weapon/reagent_containers))

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -44,6 +44,24 @@
 			return 1
 		return 0
 
+/datum/surgery/debridement/can_start(mob/user, mob/living/carbon/target)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
+
+		if(!hasorgans(target))
+			return 0
+
+		if(!affected)
+			return 0
+
+		if(!(affected.status & ORGAN_DEAD))
+			return 0
+
+		return 1
+
+	return 0
+
 /datum/surgery_step/fix_vein
 	name = "mend internal bleeding"
 	allowed_tools = list(
@@ -150,9 +168,11 @@
 	allowed_tools = list(
 		/obj/item/weapon/reagent_containers/dropper = 100,
 		/obj/item/weapon/reagent_containers/glass/bottle = 75,
-		/obj/item/weapon/reagent_containers/glass/beaker = 75,
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
+		/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
+		/obj/item/weapon/reagent_containers/glass/beaker = 60,
 		/obj/item/weapon/reagent_containers/spray = 50,
-		/obj/item/weapon/reagent_containers/glass/bucket = 50,
+		/obj/item/weapon/reagent_containers/glass/bucket = 40
 	)
 
 	can_infect = 0
@@ -160,12 +180,14 @@
 
 	time = 24
 
-datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(!istype(tool, /obj/item/weapon/reagent_containers))
 		return 0
 
 	var/obj/item/weapon/reagent_containers/container = tool
 	if(!container.reagents.has_reagent("mitocholide"))
+		user.visible_message("[user] looks at \the [tool] and ponders." , \
+		"You are not sure if \the [tool] contains mitocholide to treat the necrosis.")
 		return 0
 
 	if(!hasorgans(target))
@@ -176,7 +198,7 @@ datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/hum
 		return 0
 	return 1
 
-datum/surgery_step/treat_necrosis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the affected tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the affected tissue in [target]'s [affected.name] with \the [tool].")

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -212,13 +212,18 @@ datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/hu
 		return 0
 
 	var/obj/item/weapon/reagent_containers/container = tool
+	var/mithocolide = 0
+
+	if(container.reagents.has_reagent("mitocholide"))
+		mithocolide = 1
 
 	var/trans = container.reagents.trans_to(target, container.amount_per_transfer_from_this)
 	if(trans > 0)
 		container.reagents.reaction(target, INGEST)	//technically it's contact, but the reagents are being applied to internal tissue
 
-		if(container.reagents.has_reagent("mitocholide"))
+		if(mithocolide)
 			affected.status &= ~ORGAN_DEAD
+			target.update_body()
 
 		user.visible_message("<span class='notice'> [user] applies [trans] units of the solution to affected tissue in [target]'s [affected.name]</span>", \
 			"<span class='notice'> You apply [trans] units of the solution to affected tissue in [target]'s [affected.name] with \the [tool].</span>")

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -99,18 +99,23 @@
 		return
 	surgery.step_in_progress = 1
 
+	var/speed_mod = 1
+
 	if(begin_step(user, target, target_zone, tool, surgery) == -1)
 		surgery.step_in_progress = 0
 		return
 
-	var/advance = 0
-	var/prob_chance = 100
+	if(tool)
+		speed_mod = tool.toolspeed
 
-	if(implement_type)	//this means it isn't a require nd or any item step.
-		prob_chance = min(allowed_tools[implement_type], 100)
-	prob_chance *= get_location_modifier(target)
+	if(do_after(user, time * speed_mod, target = target))
+		var/advance = 0
+		var/prob_chance = 100
 
-	if(do_after(user, time * tool.toolspeed, target = target))
+		if(implement_type)	//this means it isn't a require nd or any item step.
+			prob_chance = allowed_tools[implement_type]
+		prob_chance *= get_location_modifier(target)
+
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))
 				advance = 1

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -109,7 +109,7 @@
 	if(implement_type)	//this means it isn't a require nd or any item step.
 		prob_chance = min(allowed_tools[implement_type], 100)
 	prob_chance *= get_location_modifier(target)
-	
+
 	if(do_after(user, time * tool.toolspeed, target = target))
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))


### PR DESCRIPTION
i swear i will stop messing with surgery

Allows to use a droppers, bottle, drinking glasses, drinking bottles. beakers, sprays, or if you are brave
enough, an entire bucket, to treat internal organ infections with
alcohol. The more alcoholic the thing is the more it disinfects. This is
an available option during organ manipulation, at the time where you can
apply trauma kits and etc, so you can for instance apply a trauma kit
and then drip a bottle of vodka over someone's liver to treat infection.

Also adds a debridement surgery to revive dead EXTERNAL organs. Same list of utensils as the previous, lets you apply mithocolide on a dead limb or chest to make it unded. Surgery steps are incision, scalpel, applying a reagent container, cauterize.

🆑 pinatacolada
add: ghetto surgery internal organ disinfection with alcohol
add: dead limb revival surgery step
/🆑