### PR TITLE
Fixes

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -152,7 +152,7 @@
 /mob/living/simple_animal/slaughter/cult/New()
 	..()
 	spawn(5)
-		var/list/demon_candidates = pollCandidates("Do you want to play as a slaughter demon?", ROLE_DEMON, 1)
+		var/list/demon_candidates = pollCandidates("Do you want to play as a slaughter demon?", ROLE_DEMON, 1, 100)
 		if(!demon_candidates.len)
 			visible_message("<span class='warning'>[src] disappears in a flash of red light!</span>")
 			qdel(src)

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -104,9 +104,7 @@
 	speed = 0
 	boost = world.time + 60
 
-
-
-
+// Cult slaughter demon
 /mob/living/simple_animal/slaughter/cult //Summoned as part of the cult objective "Bring the Slaughter"
 	name = "harbringer of the slaughter"
 	real_name = "harbringer of the Slaughter"
@@ -154,17 +152,18 @@
 /mob/living/simple_animal/slaughter/cult/New()
 	..()
 	spawn(5)
-		var/list/demon_candidates = get_candidates(ROLE_CULTIST)
+		var/list/demon_candidates = pollCandidates("Do you want to play as a slaughter demon?", ROLE_DEMON, 1)
 		if(!demon_candidates.len)
 			visible_message("<span class='warning'>[src] disappears in a flash of red light!</span>")
 			qdel(src)
 			return 0
-		var/client/C = pick(demon_candidates)
+		var/mob/M = pick(demon_candidates)
 		var/mob/living/simple_animal/slaughter/cult/S = src
-		if(!C)
+		if(!M || !M.client)
 			visible_message("<span class='warning'>[src] disappears in a flash of red light!</span>")
 			qdel(src)
 			return 0
+		var/client/C = M.client
 
 		S.key = C.key
 		S.mind.assigned_role = "Harbringer of the Slaughter"
@@ -181,7 +180,7 @@
 
 ////////////////////The Powers
 
-//Paradise Port:I added this cuase..SPOOPY DEMON IN YOUR BRAIN
+//Paradise Port: I added this because..SPOOPY DEMON IN YOUR BRAIN
 
 
 /datum/action/innate/demon/whisper

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -110,6 +110,7 @@
 		return
 
 	add_fingerprint(user)
+	user.changeNext_move(CLICK_CD_MELEE)
 
 	if(can_force && (!glass || user.a_intent != I_HELP))
 		user.visible_message("<span class='notice'>[user] begins forcing \the [src].</span>", \
@@ -119,7 +120,6 @@
 								 "<span class='notice'>You force \the [src].</span>")
 			open()
 	else if(glass)
-		user.changeNext_move(CLICK_CD_MELEE)
 		user.visible_message("<span class='warning'>[user] bangs on \the [src].</span>",
 							 "<span class='warning'>You bang on \the [src].</span>")
 		playsound(get_turf(src), 'sound/effects/Glassknock.ogg', 10, 1)

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -58,16 +58,18 @@
 		qdel(src)
 
 	else if(iswelder(W) && !anchored)
-		playsound(loc, W.usesound, 40, 1)
-		user.visible_message("[user] is slicing apart the [name].", \
-							 "<span class='notice'>You are slicing apart the [name]...</span>")
-		if(do_after(user, 40 * W.toolspeed, target = src))
-			if(!loc)
-				return
-			playsound(loc, W.usesound, 50, 1)
-			user.visible_message("[user] slices apart the [name].", \
-								 "<span class='notice'>You slice apart the [name]!</span>")
-			Dismantle(TRUE)
+		var/obj/item/weapon/weldingtool/WT = W
+		if(WT.remove_fuel(0, user))
+			playsound(loc, W.usesound, 40, 1)
+			user.visible_message("[user] is slicing apart the [name].", \
+								 "<span class='notice'>You are slicing apart the [name]...</span>")
+			if(do_after(user, 40 * W.toolspeed, target = src))
+				if(!loc)
+					return
+				playsound(loc, W.usesound, 50, 1)
+				user.visible_message("[user] slices apart the [name].", \
+									 "<span class='notice'>You slice apart the [name]!</span>")
+				Dismantle(TRUE)
 	else
 		hardness -= W.force/100
 		..()


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/6745
Cultist slaughter demons now properly uses pollCandidates instead of the deprecated get_candidates. This means it uses the system where ghosts get a question prompt (10 seconds response time) instead of being pulled directly into the role. It also properly uses our ROLE_DEMON role.

Fixes https://github.com/ParadiseSS13/Paradise/issues/6744

It is also no longer possible to spam the firelock force message.

🆑 Markolie
tweak: The system for picking ghosts to inhabit cultist slaughter demons now shows a confirmation prompt like most other role checks.
fix: Fixed an issue where you could join as a cultist slaughter demon despite having antagHUD enabled.
fix: Fixed an issue where it was possible to weld statues without any fuel.
tweak: It is no longer possible to spam the firelock force message.
/🆑