### PR TITLE
Removes the Gatfruit from Botany

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -138,7 +138,7 @@
 		return
 	return ..()
 
-// For item-containing growns such as eggy or gatfruit
+// For item-containing growns such as eggy
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/attack_self(mob/user)
 	user.unEquip(src)
 	if(trash)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -78,7 +78,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/cherry_bomb
 	mutatelist = list()
 	reagents_add = list("plantmatter" = 0.1, "sugar" = 0.1, "blackpowder" = 0.7)
-	rarity = 60 //See above
+	rarity = 60 // Acquirable via Xenobio
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherry_bomb
 	name = "cherry bombs"

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -68,35 +68,6 @@
 	bitesize_mod = 2
 
 
-// Gatfruit
-/obj/item/seeds/gatfruit
-	name = "pack of gatfruit seeds"
-	desc = "These seeds grow into .357 revolvers."
-	icon_state = "seed-gatfruit"
-	species = "gatfruit"
-	plantname = "Gatfruit Tree"
-	product = /obj/item/weapon/reagent_containers/food/snacks/grown/shell/gatfruit
-	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	lifespan = 20
-	endurance = 20
-	maturation = 40
-	production = 10
-	yield = 2
-	potency = 60
-	growthstages = 2
-	rarity = 60 // Obtainable only with xenobio+superluck.
-	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
-	reagents_add = list("sulfur" = 0.1, "carbon" = 0.1, "nitrogen" = 0.07, "potassium" = 0.05)
-
-/obj/item/weapon/reagent_containers/food/snacks/grown/shell/gatfruit
-	seed = /obj/item/seeds/gatfruit
-	name = "gatfruit"
-	desc = "It smells like burning."
-	icon_state = "gatfruit"
-	origin_tech = "combat=6"
-	trash = /obj/item/weapon/gun/projectile/revolver
-	bitesize_mod = 2
-
 //Cherry Bombs
 /obj/item/seeds/cherry/bomb
 	name = "pack of cherry bomb pits"


### PR DESCRIPTION
Removes the Gatfruit tree from Botany, removing their ability to grow .357 Revolvers....

All reactions to this when seen/grown in game has been one of complete and utter disbelief in IC and OOC overwhelmingly.

:cl: Purpose2
tweak: Removes the Gatfruit tree from Botany.
/ :cl: