### PR TITLE
Added 4 new syringes

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -832,6 +832,13 @@ var/list/uplink_items = list()
 	item = /obj/item/flag/chameleon
 	cost = 7
 
+/datum/uplink_item/stealthy_weapons/syringes
+	name = "Syringe Variety Pack"
+	desc = "A variety of syringes, each desgined to serve a specific purpose."
+	reference = "SVP"
+	item = /obj/item/weapon/storage/box/syndie_kit/syringes
+	cost = 5
+
 // STEALTHY TOOLS
 
 /datum/uplink_item/stealthy_tools

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -217,3 +217,15 @@
 		B.deity_name = "Success"
 		B.icon_state = "greentext"
 		B.item_state = "greentext"
+
+/obj/item/weapon/storage/box/syndie_kit/syringes
+	name = "Syringe variety pack"
+
+/obj/item/weapon/storage/box/syndie_kit/syringes/New()
+	..()
+	new /obj/item/weapon/reagent_containers/syringe(src)
+	new /obj/item/weapon/reagent_containers/syringe/cryo(src)
+	new /obj/item/weapon/reagent_containers/syringe/bluespace(src)
+	new /obj/item/weapon/reagent_containers/syringe/microneedle(src)
+	new /obj/item/weapon/reagent_containers/syringe/armorpiercing(src)
+	new /obj/item/weapon/gun/syringe(src)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -250,7 +250,7 @@
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100)
-			if(M.can_inject(null,0,hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
+			if(M.can_inject(null,0,hit_zone,penetrate_thick = piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
 				reagents.reaction(M, INGEST)
 				reagents.trans_to(M, reagents.total_volume)
@@ -277,6 +277,9 @@
 	name = "syringe"
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "syringeproj"
+
+/obj/item/projectile/bullet/dart/syringe/armorpiercing
+	piercing = 1
 
 /obj/item/projectile/bullet/dart/syringe/tranquilizer
 /obj/item/projectile/bullet/dart/syringe/tranquilizer/New()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -18,6 +18,8 @@
 	sharp = 1
 	var/mode = SYRINGE_DRAW
 	var/projectile_type = /obj/item/projectile/bullet/dart/syringe
+	var/stealth = 0
+	var/bypass_protection = 0
 
 /obj/item/weapon/reagent_containers/syringe/New()
 	..()
@@ -64,7 +66,7 @@
 
 	if(isliving(target))
 		var/mob/living/M = target
-		if(!M.can_inject(user, 1))
+		if(!M.can_inject(user, 1, penetrate_thick = bypass_protection))
 			return
 
 	if(mode == SYRINGE_BROKEN)
@@ -105,7 +107,8 @@
 						time = 0
 					else
 						for(var/mob/O in viewers(world.view, user))
-							O.show_message(text("<span class='danger'>[] is trying to take a blood sample from []!</span>", user, target), 1)
+							if (stealth == 0)
+								O.show_message(text("<span class='danger'>[] is trying to take a blood sample from []!</span>", user, target), 1)
 					if(!do_mob(user, target, time))
 						return
 
@@ -132,9 +135,11 @@
 
 						to_chat(user, "\blue You take a blood sample from [target]")
 						for(var/mob/O in viewers(4, user))
-							O.show_message("\red [user] takes a blood sample from [target].", 1)
+							if (stealth == 0)
+								O.show_message("\red [user] takes a blood sample from [target].", 1)
 					else
-						user.visible_message("<span class='warning'>[user] takes a sample from [target].</span>", "<span class='notice'>You take a sample from [target].</span>")
+						if (stealth == 0)
+							user.visible_message("<span class='warning'>[user] takes a sample from [target].</span>", "<span class='notice'>You take a sample from [target].</span>")
 
 			else //if not mob
 				if(!target.reagents.total_volume)
@@ -183,12 +188,14 @@
 
 			if(ismob(target) && target != user)
 				for(var/mob/O in viewers(world.view, user))
-					O.show_message(text("<span class='danger'>[] is trying to inject []!</span>", user, target), 1)
+					if (stealth == 0)
+						O.show_message(text("<span class='danger'>[] is trying to inject []!</span>", user, target), 1)
 
 				if(!do_mob(user, target, 30)) return
 
 				for(var/mob/O in viewers(world.view, user))
-					O.show_message(text("\red [] injects [] with the syringe!", user, target), 1)
+					if (stealth == 0)
+						O.show_message(text("\red [] injects [] with the syringe!", user, target), 1)
 
 				if(istype(target,/mob/living))
 					var/mob/living/M = target
@@ -238,7 +245,7 @@
 		icon_state = "broken"
 		overlays.Cut()
 		return
-	var/rounded_vol = round(reagents.total_volume,5)
+	var/rounded_vol = round(reagents.total_volume,(volume/3))
 	overlays.Cut()
 	if(ismob(loc))
 		var/injoverlay
@@ -366,6 +373,36 @@
 		icon_state = "[rounded_vol]"
 	item_state = "syringe_[rounded_vol]"
 
+/obj/item/weapon/reagent_containers/syringe/cryo
+	..()
+	name = "Cryo Syringe"
+	desc = "A syringe supercooled to prevent chemical reaction. Due to the cooling system it has a lower than normal capacity."
+	volume = 10
+
+/obj/item/weapon/reagent_containers/syringe/cryo/New()
+	..()
+	reagents.set_reacting(FALSE)
+
+/obj/item/weapon/reagent_containers/syringe/bluespace
+	..()
+	name = "Bluespace Syringe"
+	desc = "A syringe that holds more than its size would suggest"
+	volume = 30
+	amount_per_transfer_from_this = 10
+
+/obj/item/weapon/reagent_containers/syringe/microneedle
+	..()
+	name = "Micro-Needle Syringe"
+	desc = "A syringe with a needle so thin you can hardly see it."
+	stealth = 1
+
+/obj/item/weapon/reagent_containers/syringe/armorpiercing
+	..()
+	name = "Armor-Piercing Syringe"
+	desc = "A syringe with a hyper-sharp, reinforced needle. Due to the reinforcing it has a lower than normal capacity."
+	bypass_protection = 1
+	volume = 10
+	projectile_type = /obj/item/projectile/bullet/dart/syringe/armorpiercing
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Syringes. END


### PR DESCRIPTION
Adds four new syringes for traitors to use. They come in a kit with one of each, a plain syringe and a basic syringe gun for 5 TC.

The syringes are as follows:
Micro-Needle, Works like a syringe version of a sleepy pen, no message on usage as a non projectile.
Bluespace, double capacity.
Cryo, reagents don't react inside, 10 unit capacity.
Armor-piercing, allows it to work through hardsuits, 10 unit capacity.

~~As another point if this PR passes I was going to try and add them to science as well, using illegal tech, priced 4,5,6,7 in the order I gave above, as well as other research. I would like to hear input on this as well. On retro spect this seems like a terrible idea. Lets not do this. Except maybe the cryo syringe~~

SCIENCE WILL NOT GET THE SYRINGES! THEY ARE A TRAITOR ITEM ONLY!!!

🆑 Warior4356
Add: Four new syringes.
/ 🆑