### PR TITLE
Ports tesla mech gun, also adds xray/immolator guns

### DIFF
--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -48,7 +48,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/seraph
 	internal_damage_threshold = 20
 	force = 55
-	max_equip = 5
+	max_equip = 6
 
 /obj/mecha/combat/marauder/seraph/add_cell()
 	cell = new /obj/item/weapon/stock_parts/cell/bluespace(src)
@@ -65,6 +65,8 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter/precise(src)
 	ME.attach(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -21,7 +21,7 @@
 	add_req_access = 0
 	internal_damage_threshold = 25
 	force = 45
-	max_equip = 4
+	max_equip = 5
 
 
 /obj/mecha/combat/marauder/loaded/New()
@@ -29,6 +29,8 @@
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay(src)
 	ME.attach(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -47,8 +47,8 @@
 	health = 550
 	wreckage = /obj/effect/decal/mecha_wreckage/seraph
 	internal_damage_threshold = 20
-	force = 55
-	max_equip = 6
+	force = 80
+	max_equip = 8
 
 /obj/mecha/combat/marauder/seraph/add_cell()
 	cell = new /obj/item/weapon/stock_parts/cell/bluespace(src)
@@ -62,11 +62,11 @@
 		for(ME in equipment)
 			equipment -= ME
 			qdel(ME)
-	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/heavy(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray/triple(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/dual(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/teleporter/precise(src)
 	ME.attach(src)
@@ -74,6 +74,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
+
 
 /obj/mecha/combat/marauder/mauler
 	desc = "Heavy-duty, combat exosuit, developed off of the existing Marauder model."

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -68,11 +68,17 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8
-	name = "CH-PS \"Standard\" Laser"
+	name = "CH-PS \"Old Faithful\" Laser"
 	icon_state = "mecha_laser"
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam
 	fire_sound = 'sound/weapons/Laser.ogg'
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/disabler
+	name = "DD7 Rapid Disabler Module"
+	projectile = /obj/item/projectile/beam/disabler
+	projectiles_per_shot = 2
+	projectile_delay = 1
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	equip_cooldown = 10
@@ -102,7 +108,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray
 	equip_cooldown = 35
-	name = "S-1 XRay Projector"
+	name = "S-1 X-Ray Projector"
 	desc = "A weapon for combat exosuits. Fires beams of X-Rays that pass through solid matter."
 	icon_state = "mecha_laser"
 	origin_tech = "materials=3;combat=5;magnets=2;syndicate=2"
@@ -110,9 +116,14 @@
 	projectile = /obj/item/projectile/beam/xray
 	fire_sound = 'sound/weapons/laser3.ogg'
 
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/xray/triple
+	name = "X-XR Triple-barrel X-Ray Stream Projector"
+	projectiles_per_shot = 3
+	projectile_delay = 1
+
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/immolator
 	equip_cooldown = 35
-	name = "ZFI Immolator Cannon"
+	name = "ZFI Immolation Beam Gun"
 	desc = "A weapon for combat exosuits. Fires beams of extreme heat that set targets on fire."
 	icon_state = "mecha_laser"
 	origin_tech = "materials=4;combat=4;magnets=3;plasmatech=2"
@@ -303,8 +314,12 @@
 	variance = 6
 	projectile_delay = 2
 
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/dual
+	name = "XMG-9 Autocannon"
+	projectiles_per_shot = 6
+
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
-	name = "SRM-8 Missile Rack"
+	name = "SRM-8 Light Missile Rack"
 	icon_state = "mecha_missilerack"
 	projectile = /obj/item/missile
 	fire_sound = 'sound/effects/bang.ogg'
@@ -313,6 +328,7 @@
 	equip_cooldown = 60
 	var/missile_speed = 2
 	var/missile_range = 30
+	var/heavy_missile = 0
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/action(target, params)
 	if(!action_checks(target))
@@ -320,6 +336,8 @@
 	set_ready_state(0)
 	var/obj/item/missile/M = new projectile(chassis.loc)
 	M.primed = 1
+	if(heavy_missile)
+		M.heavy_missile = 1
 	playsound(chassis, fire_sound, 50, 1)
 	M.throw_at(target, missile_range, missile_speed, chassis)
 	projectiles--
@@ -330,16 +348,23 @@
 	do_after_cooldown()
 	return
 
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/heavy
+	name = "SRX-13 Heavy Missile Launcher"
+	heavy_missile = 1
 
 /obj/item/missile
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "missile"
 	var/primed = null
+	var/heavy_missile = 0
 	throwforce = 15
 
 /obj/item/missile/throw_impact(atom/hit_atom)
 	if(primed)
-		explosion(hit_atom, 0, 0, 2, 4, 0)
+		if(heavy_missile)
+			explosion(hit_atom, 2, 3, 4, 6, 0)
+		else
+			explosion(hit_atom, 0, 0, 2, 4, 0)
 		qdel(src)
 	else
 		..()

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -68,7 +68,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8
-	name = "CH-PS \"Old Faithful\" Laser"
+	name = "CH-PS \"Firedart\" Laser"
 	icon_state = "mecha_laser"
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -68,7 +68,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	equip_cooldown = 8
-	name = "CH-PS \"Immolator\" Laser"
+	name = "CH-PS \"Standard\" Laser"
 	icon_state = "mecha_laser"
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam
@@ -89,6 +89,36 @@
 	energy_drain = 120
 	projectile = /obj/item/projectile/ion
 	fire_sound = 'sound/weapons/Laser.ogg'
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla
+	equip_cooldown = 35
+	name = "P-X Tesla Cannon"
+	desc = "A weapon for combat exosuits. Fires bolts of electricity similar to the experimental tesla engine"
+	icon_state = "mecha_laser"
+	origin_tech = "materials=4;combat=5;magnets=4"
+	energy_drain = 500
+	projectile = /obj/item/projectile/energy/shock_revolver
+	fire_sound = 'sound/magic/lightningbolt.ogg'
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/xray
+	equip_cooldown = 35
+	name = "S-1 XRay Projector"
+	desc = "A weapon for combat exosuits. Fires beams of X-Rays that pass through solid matter."
+	icon_state = "mecha_laser"
+	origin_tech = "materials=3;combat=5;magnets=2;syndicate=2"
+	energy_drain = 80
+	projectile = /obj/item/projectile/beam/xray
+	fire_sound = 'sound/weapons/laser3.ogg'
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/immolator
+	equip_cooldown = 35
+	name = "ZFI Immolator Cannon"
+	desc = "A weapon for combat exosuits. Fires beams of extreme heat that set targets on fire."
+	icon_state = "mecha_laser"
+	origin_tech = "materials=4;combat=4;magnets=3;plasmatech=2"
+	energy_drain = 80
+	projectile = /obj/item/projectile/beam/immolator
+	fire_sound = 'sound/weapons/laser3.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse
 	equip_cooldown = 30

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -75,7 +75,7 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/disabler
-	name = "DD7 Rapid Disabler Module"
+	name = "CH-PD Disabler"
 	projectile = /obj/item/projectile/beam/disabler
 	projectiles_per_shot = 2
 	projectile_delay = 1

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -883,7 +883,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_laser
-	name = "Exosuit Weapon (CH-PL \"Standard\" Laser)"
+	name = "Exosuit Weapon (CH-PL \"Old Faithful\" Laser)"
 	desc = "Allows for the construction of CH-PS Laser."
 	id = "mech_laser"
 	build_type = MECHFAB
@@ -981,20 +981,9 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
-/datum/design/mech_xray
-	name = "Exosuit Weapon (MKI X-Ray Laser)"
-	desc = "Allows for the construction of MKI X-Ray Laser."
-	id = "mech_tesla"
-	build_type = MECHFAB
-	req_tech = list("combat" = 5, "materials" = 3, "syndicate" = 2, "magnets" = 2)
-	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray
-	materials = list(MAT_GOLD = 5000, MAT_URANIUM = 10000, MAT_METAL = 4000)
-	construction_time = 100
-	category = list("Exosuit Equipment")
-
 /datum/design/mech_immolator
-	name = "Exosuit Weapon (MKI Immolator Laser)"
-	desc = "Allows for the construction of MKI Immolator Laser."
+	name = "Exosuit Weapon (ZFI Immolation Beam Gun)"
+	desc = "Allows for the construction of ZFI Immolation Beam Gun."
 	id = "mech_tesla"
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "materials" = 4, "plasmatech" = 2, "magnets" = 3)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -883,12 +883,23 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_laser
-	name = "Exosuit Weapon (CH-PS \"Immolator\" Laser)"
+	name = "Exosuit Weapon (CH-PL \"Standard\" Laser)"
 	desc = "Allows for the construction of CH-PS Laser."
 	id = "mech_laser"
 	build_type = MECHFAB
 	req_tech = list("combat" = 3, "magnets" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
+	materials = list(MAT_METAL=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
+
+/datum/design/mech_disabler
+	name = "Exosuit Weapon (CH-PD Disabler)"
+	desc = "Allows for the construction of CH-PD Disabler."
+	id = "mech_laser"
+	build_type = MECHFAB
+	req_tech = list("combat" = 3, "magnets" = 3)
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/disabler
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
 	category = list("Exosuit Equipment")

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -971,8 +971,8 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_tesla
-	name = "Exosuit Weapon (MKI Tesla Cannon)"
-	desc = "Allows for the construction of MKI Tesla Cannon."
+	name = "Exosuit Weapon (P-X Tesla Cannon)"
+	desc = "Allows for the construction of P-X Tesla Cannon."
 	id = "mech_tesla"
 	build_type = MECHFAB
 	req_tech = list("combat" = 6, "magnets" = 5, "materials" = 5)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -959,6 +959,39 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
+/datum/design/mech_tesla
+	name = "Exosuit Weapon (MKI Tesla Cannon)"
+	desc = "Allows for the construction of MKI Tesla Cannon."
+	id = "mech_tesla"
+	build_type = MECHFAB
+	req_tech = list("combat" = 6, "magnets" = 5, "materials" = 5)
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 10000, MAT_SILVER = 10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
+
+/datum/design/mech_xray
+	name = "Exosuit Weapon (MKI X-Ray Laser)"
+	desc = "Allows for the construction of MKI X-Ray Laser."
+	id = "mech_tesla"
+	build_type = MECHFAB
+	req_tech = list("combat" = 5, "materials" = 3, "syndicate" = 2, "magnets" = 2)
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/xray
+	materials = list(MAT_GOLD = 5000, MAT_URANIUM = 10000, MAT_METAL = 4000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
+
+/datum/design/mech_immolator
+	name = "Exosuit Weapon (MKI Immolator Laser)"
+	desc = "Allows for the construction of MKI Immolator Laser."
+	id = "mech_tesla"
+	build_type = MECHFAB
+	req_tech = list("combat" = 4, "materials" = 4, "plasmatech" = 2, "magnets" = 3)
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/immolator
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000, MAT_SILVER = 3000, MAT_PLASMA = 2000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
+
 //Cyborg Upgrade Modules
 
 /datum/design/borg_upgrade_reset

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -883,7 +883,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_laser
-	name = "Exosuit Weapon (CH-PL \"Old Faithful\" Laser)"
+	name = "Exosuit Weapon (CH-PL \"Firedart\" Laser)"
 	desc = "Allows for the construction of CH-PS Laser."
 	id = "mech_laser"
 	build_type = MECHFAB


### PR DESCRIPTION
New researchable mech weapons:
- Disabler: "DD7 Rapid Disabler Module": Fires 2 blue disabler beams, which pass through glass/grilles, but not walls.
- Tesla: "P-X Tesla Cannon": Exactly like tesla stun revolver, fires 1 purple tesla bolt that shocks in an area.
- Immolator: "ZFI Immolation Beam Gun": Exactly like Immolator gun, fires 1 red immolator beam that ignites targets.

These guns have the same research and material costs as their R&D versions. The only difference is that they're mech-mounted. 

New sometimes-usable mech weapons:
- X-ray: "S-1 X-Ray Projector": Exactly like x-ray gun, fires 1 green x-ray beam that passes through walls. Fitted to the mechs that DS/gammaERT use. Not buildable.

New ADMIN-ONLY mech weapons (not available to players):
- X-Ray: "X-XR Triple-barrel X-Ray Stream Projector": as x-ray gun, but fires a burst of 3 x-ray lasers. Intended for anti-blob adminbus.
- Bullets: "XMG-9 Autocannon": as Light Machine Gun / Ultra AC 2, but fires 6 rounds, rather than 3.
- Missiles: "SRX-13 Heavy Missile Launcher": as normal missile, but does 2/dev/3heavy/5light/7flash, instead of the normal missile's 2light/4flash. Pretty much guaranteed kill on anything you point it at, short of an Ascendant. Will also wreck you if you're dumb enough to fire it at close range! 

Other changes:
- Admin-only Seraph mech now deals more damage in melee (80 instead of 55) and gets the admin mech weapons as standard.
- Renames "SRM-8 Missile Rack" to "SRM-8 Light Missile Rack".
- Renames "CH-PS Immolator Laser" to "CH-PL Firedart Laser". Otherwise, it would start getting confused with the real immolator laser.

Not sure what the feedback will be on this - but there is only one way to find out. :)

🆑 Kyep
add: Adds mech-mounted variants of the existing tesla, immolator, and x-ray laser guns, with the same material and tech requirements. Admin-only Seraph mech also gets better weapons.
/🆑