### PR TITLE
Admins can now stop global sounds played by other admins 🎶

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -89,7 +89,8 @@ var/list/admin_verbs_sounds = list(
 	/client/proc/play_local_sound,
 	/client/proc/play_sound,
 	/client/proc/play_server_sound,
-	/client/proc/play_intercomm_sound
+	/client/proc/play_intercomm_sound,
+	/client/proc/stop_global_admin_sounds
 	)
 var/list/admin_verbs_event = list(
 	/client/proc/object_talk,
@@ -989,12 +990,12 @@ var/list/admin_verbs_snpc = list(
 	verbs -= admin_verbs_snpc
 	verbs += /client/proc/show_snpc_verbs
 	to_chat(src, "<span class='interface'>SNPC verbs have been toggled off.</span>")
-	
+
 /client/proc/toggle_advanced_interaction()
 	set name = "Toggle Advanced Admin Interaction"
 	set category = "Admin"
 	set desc = "Allows you to interact with atoms such as buttons and doors, on top of regular machinery interaction."
-	
+
 	if(!check_rights(R_ADMIN))
 		return
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -1,5 +1,18 @@
 var/list/sounds_cache = list()
 
+/client/proc/stop_global_admin_sounds()
+	set category = "Event"
+	set name = "Stop Global Admin Sounds"
+	if(!check_rights(R_SOUNDS))
+		return
+
+	var/sound/awful_sound = sound(null, repeat = 0, wait = 0, channel = 777)
+
+	log_admin("[key_name(src)] stopped admin sounds.")
+	message_admins("[key_name_admin(src)] stopped admin sounds.", 1)
+	for(var/mob/M in player_list)
+		M << awful_sound
+
 /client/proc/play_sound(S as sound)
 	set category = "Event"
 	set name = "Play Global Sound"


### PR DESCRIPTION
Pretty useful if you realize that shitty midi you played is actually 30 minutes long.

I also considered adding a similar verb for players to turn the sounds they're hearing off themselves, but the functionality is already there uner the midi preference toggle - just toggle it off and on.

Backstage, so no CL.