### PR TITLE
Fixes Abductor Surgery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -99,18 +99,23 @@
 		return
 	surgery.step_in_progress = 1
 
+	var/speed_mod = 1
+
 	if(begin_step(user, target, target_zone, tool, surgery) == -1)
 		surgery.step_in_progress = 0
 		return
 
-	var/advance = 0
-	var/prob_chance = 100
+	if(tool)
+		speed_mod = tool.toolspeed
 
-	if(implement_type)	//this means it isn't a require nd or any item step.
-		prob_chance = min(allowed_tools[implement_type], 100)
-	prob_chance *= get_location_modifier(target)
-	
-	if(do_after(user, time * tool.toolspeed, target = target))
+	if(do_after(user, time * speed_mod, target = target))
+		var/advance = 0
+		var/prob_chance = 100
+
+		if(implement_type)	//this means it isn't a require nd or any item step.
+			prob_chance = allowed_tools[implement_type]
+		prob_chance *= get_location_modifier(target)
+
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))
 				advance = 1


### PR DESCRIPTION
Any surgery that didn't have a tool would runtime---this impacted both abductor surgeries and cavity implant surgeries.

Also minor refactor of the code order of things so code only runs if it needs to; also allows for greater than 100 success rate tools.

Credit to TG for this, more or less.

:cl: Fox McCloud
fix: Fixes abductor surgeries
/:cl: