### PR TITLE
Adds budget gloves to the glove crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -452,11 +452,11 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	cost = 10
 	containername = "electrical maintenance crate"
 
-/datum/supply_packs/engineering/powergamermitts
+/datum/supply_packs/engineering/randomised/powergamermitts
 	name = "Insulated Gloves Crate"
+	var/num_contained = 4
 	contains = list(/obj/item/clothing/gloves/color/yellow,
-					/obj/item/clothing/gloves/color/yellow,
-					/obj/item/clothing/gloves/color/yellow)
+					/obj/item/clothing/gloves/color/fyellow)
 	cost = 20	//Made of pure-grade bullshittinium
 	containername = "insulated gloves crate"
 	containertype = /obj/structure/closet/crate/engineering/electrical

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -346,8 +346,8 @@
 	slip.info +="CONTENTS:<br><ul>"
 
 	//we now create the actual contents
-	var/list/contains
-	if(istype(object, /datum/supply_packs/misc/randomised))
+	var/list/contains // TODO: de-snowflake-ify randomisation
+	if(istype(object, /datum/supply_packs/misc/randomised) || istype(object, /datum/supply_packs/engineering/randomised/powergamermitts))
 		var/datum/supply_packs/misc/randomised/SO = object
 		contains = list()
 		if(object.contains.len)


### PR DESCRIPTION
NanoTrasen are cost cutting bastards and have started mixing in budget gloves into the insulated gloves crates.

Increased the total slightly to compensate. This'll add a little bit more flavour to the Corporation mid-round.

:cl: Purpose2
rscadd: Ordered gloves now have a 50% chance to be budget gloves.
tweak: Insulated gloves crates now contain 4 items.
/ :cl:

If the idea of wider randomisation of items is liked, we should de-snowflake the code which currently was snowflaked just for the hat crate.