### PR TITLE
Syndicate Pillbox (syndicate uplink item)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -941,6 +941,13 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/toolbox/syndicate
 	cost = 1
 
+/datum/uplink_item/device_tools/pillbox
+	name = "Pillbox Full of Meds"
+	desc = "The pillbox that is filled with all essential meds for special cases. For example when medbay has quite a grudge on you."
+	reference = "PLBX"
+	item = /obj/item/weapon/storage/pill_bottle/syndiepill
+	cost = 2
+
 /datum/uplink_item/device_tools/surgerybag
 	name = "Syndicate Surgery Duffelbag"
 	desc = "The Syndicate surgery duffelbag is a toolkit containing all surgery tools, a straitjacket, and a muzzle."

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -141,6 +141,7 @@
 				/obj/item/weapon/dnascrambler = 1,
 				/obj/item/weapon/storage/backpack/satchel_flat = 2,
 				/obj/item/weapon/storage/toolbox/syndicate = 2,
+				/obj/item/weapon/storage/pill_bottle/syndiepill = 2,
 				/obj/item/weapon/storage/backpack/duffel/syndie/surgery_fake = 2,
 				/obj/item/weapon/storage/belt/military = 2,
 				/obj/item/weapon/storage/box/syndie_kit/space = 2,

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -290,3 +290,23 @@
 	new /obj/item/weapon/reagent_containers/food/pill/salicylic(src)
 	new /obj/item/weapon/reagent_containers/food/pill/salicylic(src)
 	new /obj/item/weapon/reagent_containers/food/pill/salicylic(src)
+
+/obj/item/weapon/storage/pill_bottle/syndiepill
+
+/obj/item/weapon/storage/pill_bottle/syndiepill/New()
+	..()
+	new /obj/item/weapon/reagent_containers/food/pill/mitocholide(src)
+	new /obj/item/weapon/reagent_containers/food/pill/mitocholide(src)
+	new /obj/item/weapon/reagent_containers/food/pill/pen_acid(src)
+	new /obj/item/weapon/reagent_containers/food/pill/pen_acid(src)
+	new /obj/item/weapon/reagent_containers/food/pill/salicylic(src)
+	new /obj/item/weapon/reagent_containers/food/pill/salicylic(src)
+	new /obj/item/weapon/reagent_containers/food/pill/hydrocodone(src)
+	new /obj/item/weapon/reagent_containers/food/pill/oculine(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/perfluorodecalin(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/perfluorodecalin(src)
+

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -38,3 +38,8 @@
 	name = "nicotine patch"
 	desc = "Helps temporarily curb the cravings of nicotine dependency."
 	list_reagents = list("nicotine" = 20)
+
+/obj/item/weapon/reagent_containers/food/pill/patch/perfluorodecalin
+	name = "perfluorodecalin patch"
+	desc = "This experimental perfluoronated solvent has applications in liquid breathing and tissue oxygenation. Use with caution."
+	list_reagents = list("perfluorodecalin" = 20)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -109,3 +109,33 @@
 	desc = "Used to treat respiratory distress."
 	icon_state = "pill8"
 	list_reagents = list("salbutamol" = 20)
+
+/obj/item/weapon/reagent_containers/food/pill/hydrocodone
+	name = "Hydrocodone pill"
+	desc = "An extremely effective painkiller; may have long term abuse consequences."
+	icon_state = "pill2"
+	list_reagents = list("hydrocodone" = 20)
+
+/obj/item/weapon/reagent_containers/food/pill/oculine
+	name = "Oculine pill"
+	desc = "Oculine is a saline eye medication with mydriatic and antibiotic effects."
+	icon_state = "pill3"
+	list_reagents = list("oculine" = 20)
+
+/obj/item/weapon/reagent_containers/food/pill/mitocholide
+	name = "Mitocholide pill"
+	desc = "A specialized drug that stimulates the mitochondria of cells to encourage healing of internal organs."
+	icon_state = "pill4"
+	list_reagents = list("mitocholide" = 20)
+
+/obj/item/weapon/reagent_containers/food/pill/pen_acid
+	name = "Pentetic Acid pill"
+	desc = "Pentetic Acid is an aggressive chelation agent. May cause tissue damage. Use with caution."
+	icon_state = "pill5"
+	list_reagents = list("pen_acid" = 20)
+
+/obj/item/weapon/reagent_containers/food/pill/pen_acid
+	name = "Pentetic Acid pill"
+	desc = "Pentetic Acid is an aggressive chelation agent. May cause tissue damage. Use with caution."
+	icon_state = "pill5"
+	list_reagents = list("pen_acid" = 20)


### PR DESCRIPTION
**It is a first item of many, that has the point in making life a bit more equal for every antag, and all of them will have motto "oops, I've picked wrong department for my objective"**

**Adds new item to syndicate uplink, that can be used in traitor mode and in nuke mode.**
Contains set of potent pills and patches (14 in total). Can be used when you are wanted or having a grudge with medbay, or generally you want to spend leftover points.

Costs 2 TC, comes in standard pillbox without any labels
Contents:
2 mitocholide (20u) pills 
2 pentetic acid (20u) pills
2 salycilic acid (20u) pills
1 hydrocodone (20u) pill
1 oculine (20u) pill
4 synthflesh (20u) patches
2 perfluorodecalin (20u) patches

Can be spawned in maints (same chance as syndie toolbox)
:cl:
rscadd: Added new item for traitors - pillbox full of potent meds
rscadd: Added syndicate pillbox to random maint drop
/:cl:
