### PR TITLE
Borer join message fixed so channel is :bo instead of :x

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -815,7 +815,7 @@
 		to_chat(src, "<span class='notice'>You are a cortical borer!</span>")
 		to_chat(src, "You are a brain slug that worms its way into the head of its victim. Use stealth, persuasion and your powers of mind control to keep you, your host and your eventual spawn safe and warm.")
 		to_chat(src, "Sugar nullifies your abilities, avoid it at all costs!")
-		to_chat(src, "You can speak to your fellow borers by prefixing your messages with ':x'. Check out your Borer tab to see your abilities.")
+		to_chat(src, "You can speak to your fellow borers by prefixing your messages with ':bo'. Check out your Borer tab to see your abilities.")
 
 /proc/create_borer_mind(key)
 	var/datum/mind/M = new /datum/mind(key)


### PR DESCRIPTION
I had to mentorhelp it when I was a borer first, so I figure it deserves a change.