### PR TITLE
Fixes Glovesnipping

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -201,7 +201,7 @@ BLIND     // can't see anything
 /obj/item/clothing/gloves/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/wirecutters))
 		if(!clipped)
-			playsound(src.loc, W>usesound, 100, 1)
+			playsound(src.loc, W.usesound, 100, 1)
 			user.visible_message("<span class='warning'>[user] snips the fingertips off [src].</span>","<span class='warning'>You snip the fingertips off [src].</span>")
 			clipped = 1
 			name = "mangled [name]"


### PR DESCRIPTION
Attempting to snip gloves runtimed out because of that accidental shift-key period business from https://github.com/ParadiseSS13/Paradise/commit/3aa1399995e8a2927699eebb0ba7ec5a8b0b480e. (I love the blame feature github has now, extremely handy!)
Works again.

:cl:
fix: Gloves can be snipped again.
/:cl: