### PR TITLE
Spring Cleaning

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -13,7 +13,7 @@
 		var/mob/living/carbon/M = AM
 		M.slip("soap", 4, 2)
 
-/obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
+/obj/item/weapon/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return
 	//I couldn't feasibly  fix the overlay bugs caused by cleaning items we are wearing.
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn
@@ -37,6 +37,9 @@
 			var/obj/effect/decal/cleanable/C = locate() in target
 			qdel(C)
 			target.clean_blood()
+			if(istype(target, /turf/simulated))
+				var/turf/simulated/T = target
+				T.dirt = 0
 	return
 
 /obj/item/weapon/soap/attack(mob/target as mob, mob/user as mob)

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -28,6 +28,7 @@
 /obj/item/weapon/mop/proc/clean(turf/simulated/A)
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("cleaner", 1) || reagents.has_reagent("holywater", 1))
 		A.clean_blood()
+		A.dirt = 0
 		for(var/obj/effect/O in A)
 			if(is_cleanable(O))
 				qdel(O)


### PR DESCRIPTION
fixes https://github.com/ParadiseSS13/Paradise/issues/6821

Cleaning with a mop or soap would clean the decals on the turf, but wouldn't reset the dirt level...as such, it would be very possible to have dirt return rapdily unless you used space cleaner on a turf or the turf was cleaned by a borg or upgraded janicart.

:cl: Fox McCloud
fix: Floors are now fully properly cleaned with mops and soap
/:cl: