### PR TITLE
Expands Autolathe Items and Enables Stock Parts

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -37,7 +37,7 @@
 
 	var/datum/material_container/materials
 
-	var/list/categories = list("Communication", "Construction", "Electronics", "Imported", "Medical", "Miscellaneous", "Security", "Tools")
+	var/list/categories = list("Tools", "Electronics", "Construction", "Communication", "Security", "Machinery", "Medical", "Miscellaneous", "Dinnerware", "Imported")
 
 /obj/machinery/autolathe/New()
 	..()

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -2,14 +2,6 @@
 //////////Autolathe Designs ///////
 ///////////////////////////////////
 
-/datum/design/analyzer
-	name = "Analyzer"
-	id = "analyzer"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	build_path = /obj/item/device/analyzer
-	category = list("initial","Tools")
-
 /datum/design/bucket
 	name = "Bucket"
 	id = "bucket"
@@ -26,20 +18,20 @@
 	build_path = /obj/item/weapon/crowbar
 	category = list("initial","Tools")
 
-/datum/design/extinguisher
-	name = "Fire Extinguisher"
-	id = "extinguisher"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 90)
-	build_path = /obj/item/weapon/extinguisher
-	category = list("initial","Tools")
-
 /datum/design/flashlight
 	name = "Flashlight"
 	id = "flashlight"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/device/flashlight
+	category = list("initial","Tools")
+
+/datum/design/extinguisher
+	name = "Fire Extinguisher"
+	id = "extinguisher"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 90)
+	build_path = /obj/item/weapon/extinguisher
 	category = list("initial","Tools")
 
 /datum/design/multitool
@@ -50,12 +42,12 @@
 	build_path = /obj/item/device/multitool
 	category = list("initial","Tools")
 
-/datum/design/screwdriver
-	name = "Screwdriver"
-	id = "screwdriver"
+/datum/design/analyzer
+	name = "Analyzer"
+	id = "analyzer"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75)
-	build_path = /obj/item/weapon/screwdriver
+	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
+	build_path = /obj/item/device/analyzer
 	category = list("initial","Tools")
 
 /datum/design/tscanner
@@ -64,6 +56,46 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 150)
 	build_path = /obj/item/device/t_scanner
+	category = list("initial","Tools")
+
+/datum/design/weldingtool
+	name = "Welding Tool"
+	id = "welding_tool"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 70, MAT_GLASS = 20)
+	build_path = /obj/item/weapon/weldingtool
+	category = list("initial","Tools")
+
+/datum/design/mini_weldingtool
+	name = "Emergency welding tool"
+	id = "mini_welding_tool"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30, MAT_GLASS = 10)
+	build_path = /obj/item/weapon/weldingtool/mini
+	category = list("initial","Tools")
+
+/datum/design/screwdriver
+	name = "Screwdriver"
+	id = "screwdriver"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75)
+	build_path = /obj/item/weapon/screwdriver
+	category = list("initial","Tools")
+
+/datum/design/wirecutters
+	name = "Wirecutters"
+	id = "wirecutters"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 80)
+	build_path = /obj/item/weapon/wirecutters
+	category = list("initial","Tools")
+
+/datum/design/wrench
+	name = "Wrench"
+	id = "wrench"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150)
+	build_path = /obj/item/weapon/wrench
 	category = list("initial","Tools")
 
 /datum/design/welding_helmet
@@ -83,44 +115,28 @@
 	category = list("initial","Tools")
 	maxstack = 30
 
-/datum/design/weldingtool
-	name = "Welding Tool"
-	id = "welding_tool"
+/datum/design/toolbox
+	name = "Toolbox"
+	id = "tool_box"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 70, MAT_GLASS = 20)
-	build_path = /obj/item/weapon/weldingtool
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/storage/toolbox
 	category = list("initial","Tools")
 
-/datum/design/wirecutters
-	name = "Wirecutters"
-	id = "wirecutters"
+/datum/design/console_screen
+	name = "Console Screen"
+	id = "console_screen"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 80)
-	build_path = /obj/item/weapon/wirecutters
-	category = list("initial","Tools")
+	materials = list(MAT_GLASS = 200)
+	build_path = /obj/item/weapon/stock_parts/console_screen
+	category = list("initial", "Electronics")
 
-/datum/design/wrench
-	name = "Wrench"
-	id = "wrench"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150)
-	build_path = /obj/item/weapon/wrench
-	category = list("initial","Tools")
-
-/datum/design/spraycan
-	name = "Spraycan"
-	id = "spraycan"
+/datum/design/apc_board
+	name = "APC module"
+	id = "power control"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
-	build_path = /obj/item/toy/crayon/spraycan
-	category = list("initial", "Tools")
-
-/datum/design/airalarm_electronics
-	name = "Air Alarm Electronics"
-	id = "airalarm_electronics"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/airalarm_electronics
+	build_path = /obj/item/weapon/apc_electronics
 	category = list("initial", "Electronics")
 
 /datum/design/airlock_board
@@ -139,28 +155,12 @@
 	build_path = /obj/item/weapon/firelock_electronics
 	category = list("initial", "Electronics")
 
-/datum/design/apc_electronics
-	name="Power Control Module"
-	id = "apc_electronics"
+/datum/design/airalarm_electronics
+	name = "Air Alarm Electronics"
+	id = "airalarm_electronics"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/apc_electronics
-	category = list("initial", "Electronics")
-
-/datum/design/intercom_electronics
-	name = "Intercom Electronics"
-	id = "intercom_electronics"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/intercom_electronics
-	category = list("initial", "Electronics")
-
-/datum/design/console_screen
-	name = "Console Screen"
-	id = "console_screen"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 200)
-	build_path = /obj/item/weapon/stock_parts/console_screen
+	build_path = /obj/item/weapon/airalarm_electronics
 	category = list("initial", "Electronics")
 
 /datum/design/firealarm_electronics
@@ -171,6 +171,14 @@
 	build_path = /obj/item/weapon/firealarm_electronics
 	category = list("initial", "Electronics")
 
+/datum/design/intercom_electronics
+	name = "Intercom Electronics"
+	id = "intercom_electronics"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
+	build_path = /obj/item/weapon/intercom_electronics
+	category = list("initial", "Electronics")
+
 /datum/design/earmuffs
 	name = "Earmuffs"
 	id = "earmuffs"
@@ -179,29 +187,65 @@
 	build_path = /obj/item/clothing/ears/earmuffs
 	category = list("initial", "Miscellaneous")
 
-/datum/design/igniter
-	name = "Igniter"
-	id = "igniter"
+/datum/design/pipe_painter
+	name = "Pipe Painter"
+	id = "pipe_painter"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/assembly/igniter
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 2000)
+	build_path = /obj/item/device/pipe_painter
 	category = list("initial", "Miscellaneous")
 
-/datum/design/infrared_emitter
-	name = "Infrared Emitter"
-	id = "infrared_emitter"
+/datum/design/floorpainter
+	name = "Floor painter"
+	id = "floor_painter"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
-	build_path = /obj/item/device/assembly/infra
+	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
+	build_path = /obj/item/device/floor_painter
 	category = list("initial", "Miscellaneous")
 
-/datum/design/health_sensor
-	name = "Health sensor"
-	id = "health_sensor"
+/datum/design/metal
+	name = "Metal"
+	id = "metal"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/health
-	category = list("initial", "Medical")
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/metal
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/glass
+	name = "Glass"
+	id = "glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/glass
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/rglass
+	name = "Reinforced Glass"
+	id = "rglass"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/rglass
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/rods
+	name = "Metal Rod"
+	id = "rods"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000)
+	build_path = /obj/item/stack/rods
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/rcd_ammo
+	name = "Compressed Matter Cardridge"
+	id = "rcd_ammo"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 16000, MAT_GLASS=8000)
+	build_path = /obj/item/weapon/rcd_ammo
+	category = list("initial","Construction")
 
 /datum/design/kitchen_knife
 	name = "Kitchen Knife"
@@ -209,13 +253,53 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 12000)
 	build_path = /obj/item/weapon/kitchen/knife
-	category = list("initial","Miscellaneous")
+	category = list("initial","Dinnerware")
 
-/datum/design/minihoe
-	name = "Mini Hoe"
-	id = "mini_hoe"
+/datum/design/fork
+	name = "Fork"
+	id = "fork"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50)
+	materials = list(MAT_METAL = 80)
+	build_path = /obj/item/weapon/kitchen/utensil/fork
+	category = list("initial","Dinnerware")
+
+/datum/design/tray
+	name = "Tray"
+	id = "tray"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 3000)
+	build_path = /obj/item/weapon/storage/bag/tray
+	category = list("initial","Dinnerware")
+
+/datum/design/drinking_glass
+	name = "Drinking glass"
+	id = "drinking_glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass
+	category = list("initial","Dinnerware")
+
+/datum/design/shot_glass
+	name = "Shot glass"
+	id = "shot_glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 100)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass
+	category = list("initial","Dinnerware")
+
+/datum/design/shaker
+	name = "Shaker"
+	id = "shaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1500)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/shaker
+	category = list("initial","Dinnerware")
+
+/datum/design/cultivator
+	name = "Cultivator"
+	id = "cultivator"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL=50)
 	build_path = /obj/item/weapon/cultivator
 	category = list("initial","Miscellaneous")
 
@@ -251,37 +335,125 @@
 	build_path = /obj/item/weapon/hatchet
 	category = list("initial","Miscellaneous")
 
-/datum/design/pipe_painter
-	name = "Pipe Painter"
-	id = "pipe_painter"
+/datum/design/scalpel
+	name = "Scalpel"
+	id = "scalpel"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 2000)
-	build_path = /obj/item/device/pipe_painter
-	category = list("initial", "Miscellaneous")
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
+	build_path = /obj/item/weapon/scalpel
+	category = list("initial", "Medical")
 
-/datum/design/prox_sensor
-	name = "Proximity Sensor"
-	id = "prox_sensor"
+/datum/design/circular_saw
+	name = "Circular Saw"
+	id = "circular_saw"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/prox_sensor
-	category = list("initial", "Miscellaneous")
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/circular_saw
+	category = list("initial", "Medical")
 
-/datum/design/mousetrap
-	name = "Mousetrap"
-	id = "mousetrap"
+/datum/design/surgicaldrill
+	name = "Surgical Drill"
+	id = "surgicaldrill"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/mousetrap
-	category = list("initial", "Miscellaneous")
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/surgicaldrill
+	category = list("initial", "Medical")
 
-/datum/design/timer
-	name = "Timer"
-	id = "timer"
+/datum/design/retractor
+	name = "Retractor"
+	id = "retractor"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 6000, MAT_GLASS = 3000)
+	build_path = /obj/item/weapon/retractor
+	category = list("initial", "Medical")
+
+/datum/design/cautery
+	name = "Cautery"
+	id = "cautery"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 2500, MAT_GLASS = 750)
+	build_path = /obj/item/weapon/cautery
+	category = list("initial", "Medical")
+
+/datum/design/hemostat
+	name = "Hemostat"
+	id = "hemostat"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 2500)
+	build_path = /obj/item/weapon/hemostat
+	category = list("initial", "Medical")
+
+/datum/design/bonesetter
+	name = "Bone Setter"
+	id = "bonesetter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/weapon/bonesetter
+	category = list("initial", "Medical")
+
+/datum/design/fixovein
+	name = "FixOVein"
+	id = "fixovein"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000)
+	build_path = /obj/item/weapon/FixOVein
+	category = list("initial", "Medical")
+
+/datum/design/bonegel
+	name = "Bone Gel"
+	id = "bonegel"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/bonegel
+	category = list("initial", "Medical")
+
+/datum/design/beaker
+	name = "Beaker"
+	id = "beaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker
+	category = list("initial", "Medical")
+
+/datum/design/large_beaker
+	name = "Large Beaker"
+	id = "large_beaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 2500)
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker/large
+	category = list("initial", "Medical")
+
+/datum/design/healthanalyzer
+	name = "Health Analyzer"
+	id = "healthanalyzer"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/assembly/timer
-	category = list("initial", "Miscellaneous")
+	build_path = /obj/item/device/healthanalyzer
+	category = list("initial", "Medical")
+
+/datum/design/beanbag_slug
+	name = "Beanbag Slug"
+	id = "beanbag_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 250)
+	build_path = /obj/item/ammo_casing/shotgun/beanbag
+	category = list("initial", "Security")
+
+/datum/design/rubbershot
+	name = "Rubber shot"
+	id = "rubber_shot"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/rubbershot
+	category = list("initial", "Security")
+
+/datum/design/c38
+	name = "Speed Loader (.38)"
+	id = "c38"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c38
+	category = list("initial", "Security")
 
 /datum/design/recorder
 	name = "Universal Recorder"
@@ -299,12 +471,317 @@
 	build_path = /obj/item/device/tape/random
 	category = list("initial", "Miscellaneous")
 
+/datum/design/igniter
+	name = "Igniter"
+	id = "igniter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
+	build_path = /obj/item/device/assembly/igniter
+	category = list("initial", "Miscellaneous")
+
+/datum/design/signaler
+	name = "Remote Signaling Device"
+	id = "signaler"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 400, MAT_GLASS = 120)
+	build_path = /obj/item/device/assembly/signaler
+	category = list("initial", "Communication")
+
+/datum/design/radio_headset
+	name = "Radio Headset"
+	id = "radio_headset"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75)
+	build_path = /obj/item/device/radio/headset
+	category = list("initial", "Communication")
+
+/datum/design/bounced_radio
+	name = "Station Bounced Radio"
+	id = "bounced_radio"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75, MAT_GLASS = 25)
+	build_path = /obj/item/device/radio/off
+	category = list("initial", "Communication")
+
+/datum/design/infrared_emitter
+	name = "Infrared Emitter"
+	id = "infrared_emitter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
+	build_path = /obj/item/device/assembly/infra
+	category = list("initial", "Miscellaneous")
+
+/datum/design/health_sensor
+	name = "Health sensor"
+	id = "health_sensor"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/health
+	category = list("initial", "Medical")
+
+/datum/design/timer
+	name = "Timer"
+	id = "timer"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
+	build_path = /obj/item/device/assembly/timer
+	category = list("initial", "Miscellaneous")
+
 /datum/design/voice_analyser
 	name = "Voice Analyser"
 	id = "voice_analyser"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
 	build_path = /obj/item/device/assembly/voice
+	category = list("initial", "Miscellaneous")
+
+/datum/design/light_tube
+	name = "Light Tube"
+	id = "light_tube"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 100)
+	build_path = /obj/item/weapon/light/tube
+	category = list("initial", "Construction")
+
+/datum/design/light_bulb
+	name = "Light Bulb"
+	id = "light_bulb"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 100)
+	build_path = /obj/item/weapon/light/bulb
+	category = list("initial", "Construction")
+
+/datum/design/camera_assembly
+	name = "Camera Assembly"
+	id = "camera_assembly"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 400, MAT_GLASS = 250)
+	build_path = /obj/item/weapon/camera_assembly
+	category = list("initial", "Construction")
+
+/datum/design/newscaster_frame
+	name = "Newscaster Frame"
+	id = "newscaster_frame"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 14000, MAT_GLASS = 8000)
+	build_path = /obj/item/mounted/frame/newscaster_frame
+	category = list("initial", "Construction")
+
+/datum/design/syringe
+	name = "Syringe"
+	id = "syringe"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
+	build_path = /obj/item/weapon/reagent_containers/syringe
+	category = list("initial", "Medical")
+
+/datum/design/prox_sensor
+	name = "Proximity Sensor"
+	id = "prox_sensor"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/prox_sensor
+	category = list("initial", "Miscellaneous")
+
+/datum/design/foam_dart
+	name = "Box of Foam Darts"
+	id = "foam_dart"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/ammo_box/foambox
+	category = list("initial", "Miscellaneous")
+
+//hacked autolathe recipes
+/datum/design/flamethrower
+	name = "Flamethrower"
+	id = "flamethrower"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/flamethrower/full
+	category = list("hacked", "Security")
+
+/datum/design/rcd
+	name = "Rapid Construction Device (RCD)"
+	id = "rcd"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/weapon/rcd
+	category = list("hacked", "Construction")
+
+/datum/design/electropack
+	name = "Electropack"
+	id = "electropack"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 2500)
+	build_path = /obj/item/device/radio/electropack
+	category = list("hacked", "Tools")
+
+/datum/design/large_welding_tool
+	name = "Industrial Welding Tool"
+	id = "large_welding_tool"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
+	build_path = /obj/item/weapon/weldingtool/largetank
+	category = list("hacked", "Tools")
+
+/datum/design/handcuffs
+	name = "Handcuffs"
+	id = "handcuffs"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/restraints/handcuffs
+	category = list("hacked", "Security")
+
+/datum/design/shotgun_slug
+	name = "Shotgun Slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
+/datum/design/buckshot_shell
+	name = "Buckshot shell"
+	id = "buckshot_shell"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")
+
+/datum/design/shotgun_dart
+	name = "Shotgun Dart"
+	id = "shotgun_dart"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/dart
+	category = list("hacked", "Security")
+
+/datum/design/incendiary_slug
+	name = "Incendiary Slug"
+	id = "incendiary_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/incendiary
+	category = list("hacked", "Security")
+
+/datum/design/riot_dart
+	name = "Foam riot dart"
+	id = "riot_dart"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000) //Discount for making individually - no box = less metal!
+	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
+	category = list("hacked", "Security")
+
+/datum/design/riot_darts
+	name = "Foam riot dart box"
+	id = "riot_darts"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50000) //Comes with 40 darts
+	build_path = /obj/item/ammo_box/foambox/riot
+	category = list("hacked", "Security")
+
+/datum/design/a357
+	name = "Ammo Box (.357)"
+	id = "a357"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/a357
+	category = list("hacked", "Security")
+
+/datum/design/c10mm
+	name = "Ammo Box (10mm)"
+	id = "c10mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c10mm
+	category = list("hacked", "Security")
+
+/datum/design/c45
+	name = "Ammo Box (.45)"
+	id = "c45"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c45
+	category = list("hacked", "Security")
+
+/datum/design/c9mm
+	name = "Ammo Box (9mm)"
+	id = "c9mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c9mm
+	category = list("hacked", "Security")
+
+/datum/design/cleaver
+	name = "Butcher's cleaver"
+	id = "cleaver"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 18000)
+	build_path = /obj/item/weapon/kitchen/knife/butcher
+	category = list("hacked", "Dinnerware")
+
+/datum/design/spraycan
+	name = "Spraycan"
+	id = "spraycan"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
+	build_path = /obj/item/toy/crayon/spraycan
+	category = list("initial", "Tools")
+
+/datum/design/desttagger
+	name = "Destination tagger"
+	id = "desttagger"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 250, MAT_GLASS = 125)
+	build_path = /obj/item/device/destTagger
+	category = list("initial", "Electronics")
+
+/datum/design/handlabeler
+	name = "Hand labeler"
+	id = "handlabel"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
+	build_path = /obj/item/weapon/hand_labeler
+	category = list("initial", "Electronics")
+
+/datum/design/conveyor_belt
+	name = "Conveyor belt"
+	id = "conveyor_belt"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000)
+	build_path = /obj/item/conveyor_construct
+	category = list("initial", "Construction")
+
+/datum/design/conveyor_switch
+	name = "Conveyor belt switch"
+	id = "conveyor_switch"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
+	build_path = /obj/item/conveyor_switch_construct
+	category = list("initial", "Construction")
+
+/datum/design/laptop
+	name = "Laptop Frame"
+	id = "laptop"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 1000)
+	build_path = /obj/item/device/modular_computer/laptop/buildable
+	category = list("initial", "Miscellaneous")
+
+/datum/design/tablet
+	name = "Tablet Frame"
+	id = "tablet"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
+	build_path = /obj/item/device/modular_computer/tablet
+	category = list("initial", "Miscellaneous")
+
+/datum/design/mousetrap
+	name = "Mousetrap"
+	id = "mousetrap"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/mousetrap
 	category = list("initial", "Miscellaneous")
 
 /datum/design/videocam
@@ -339,14 +816,6 @@
 	build_path = /obj/item/weapon/canvas/twentythreeXnineteen
 	category = list("initial", "Miscellaneous")
 
-/datum/design/foambox
-	name = "Box of Foam Force darts"
-	id = "foamforce"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2000)
-	build_path = /obj/item/ammo_box/foambox
-	category = list("initial", "Miscellaneous")
-
 /datum/design/canvas/twentythreeXtwentythree
 	name = "23px by 23px Canvas"
 	id = "canvas23x23"
@@ -354,363 +823,6 @@
 	materials = list(MAT_METAL = 100)
 	build_path = /obj/item/weapon/canvas/twentythreeXtwentythree
 	category = list("initial", "Miscellaneous")
-
-/datum/design/camera_assembly
-	name = "Camera Assembly"
-	id = "camera_assembly"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 400, MAT_GLASS = 250)
-	build_path = /obj/item/weapon/camera_assembly
-	category = list("initial", "Construction")
-
-/datum/design/glass
-	name = "Glass"
-	id = "glass"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/glass
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/light_bulb
-	name = "Light Bulb"
-	id = "light_bulb"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 60, MAT_GLASS = 100)
-	build_path = /obj/item/weapon/light/bulb
-	category = list("initial", "Construction")
-
-/datum/design/light_tube
-	name = "Light Tube"
-	id = "light_tube"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 60, MAT_GLASS = 100)
-	build_path = /obj/item/weapon/light/tube
-	category = list("initial", "Construction")
-
-/datum/design/metal
-	name = "Metal"
-	id = "metal"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/metal
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/newscaster_frame
-	name = "Newscaster Frame"
-	id = "newscaster_frame"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 14000, MAT_GLASS = 8000)
-	build_path = /obj/item/mounted/frame/newscaster_frame
-	category = list("initial", "Construction")
-
-/datum/design/rcd_ammo
-	name = "Compressed Matter Cardridge"
-	id = "rcd_ammo"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 16000, MAT_GLASS=8000)
-	build_path = /obj/item/weapon/rcd_ammo
-	category = list("initial","Construction")
-
-/datum/design/rglass
-	name = "Reinforced Glass"
-	id = "rglass"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/rglass
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/rods
-	name = "Metal Rod"
-	id = "rods"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000)
-	build_path = /obj/item/stack/rods
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/beaker
-	name = "Beaker"
-	id = "beaker"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 500)
-	build_path = /obj/item/weapon/reagent_containers/glass/beaker
-	category = list("initial", "Medical")
-
-/datum/design/cautery
-	name = "Cautery"
-	id = "cautery"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2500, MAT_GLASS = 750)
-	build_path = /obj/item/weapon/cautery
-	category = list("initial", "Medical")
-
-/datum/design/circular_saw
-	name = "Circular Saw"
-	id = "circular_saw"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/circular_saw
-	category = list("initial", "Medical")
-
-/datum/design/hemostat
-	name = "Hemostat"
-	id = "hemostat"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 2500)
-	build_path = /obj/item/weapon/hemostat
-	category = list("initial", "Medical")
-
-/datum/design/large_beaker
-	name = "Large Beaker"
-	id = "large_beaker"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 2500)
-	build_path = /obj/item/weapon/reagent_containers/glass/beaker/large
-	category = list("initial", "Medical")
-
-/datum/design/healthanalyzer
-	name = "Health Analyzer"
-	id = "healthanalyzer"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/healthanalyzer
-	category = list("initial", "Medical")
-
-/datum/design/retractor
-	name = "Retractor"
-	id = "retractor"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 6000, MAT_GLASS = 3000)
-	build_path = /obj/item/weapon/retractor
-	category = list("initial", "Medical")
-
-/datum/design/scalpel
-	name = "Scalpel"
-	id = "scalpel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
-	build_path = /obj/item/weapon/scalpel
-	category = list("initial", "Medical")
-
-/datum/design/surgicaldrill
-	name = "Surgical Drill"
-	id = "surgicaldrill"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/surgicaldrill
-	category = list("initial", "Medical")
-
-/datum/design/bonesetter
-	name = "Bone Setter"
-	id = "bonesetter"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/weapon/bonesetter
-	category = list("initial", "Medical")
-
-/datum/design/fixovein
-	name = "FixOVein"
-	id = "fixovein"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000)
-	build_path = /obj/item/weapon/FixOVein
-	category = list("initial", "Medical")
-
-/datum/design/bonegel
-	name = "Bone Gel"
-	id = "bonegel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/bonegel
-	category = list("initial", "Medical")
-
-/datum/design/syringe
-	name = "Syringe"
-	id = "syringe"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
-	build_path = /obj/item/weapon/reagent_containers/syringe
-	category = list("initial", "Medical")
-
-/datum/design/beanbag_slug
-	name = "Beanbag Slug"
-	id = "beanbag_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250)
-	build_path = /obj/item/ammo_casing/shotgun/beanbag
-	category = list("initial", "Security")
-
-/datum/design/rubbershot
-	name = "Rubber shot"
-	id = "rubber_shot"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/rubbershot
-	category = list("initial", "Security")
-
-/datum/design/c38
-	name = "Speed Loader (.38)"
-	id = "c38"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c38
-	category = list("initial", "Security")
-
-/datum/design/radio_headset
-	name = "Radio Headset"
-	id = "radio_headset"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75)
-	build_path = /obj/item/device/radio/headset
-	category = list("initial", "Communication")
-
-/datum/design/signaler
-	name = "Remote Signaling Device"
-	id = "signaler"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 400, MAT_GLASS = 120)
-	build_path = /obj/item/device/assembly/signaler
-	category = list("initial", "Communication")
-
-/datum/design/bounced_radio
-	name = "Station Bounced Radio"
-	id = "bounced_radio"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75, MAT_GLASS = 25)
-	build_path = /obj/item/device/radio/off
-	category = list("initial", "Communication")
-
-//hacked autolathe recipes
-/datum/design/c45
-	name = "Ammo Box (.45)"
-	id = "c45"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c45
-	category = list("hacked", "Security")
-
-/datum/design/a357
-	name = "Ammo Box (.357)"
-	id = "a357"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/a357
-	category = list("hacked", "Security")
-
-/datum/design/c9mm
-	name = "Ammo Box (9mm)"
-	id = "c9mm"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c9mm
-	category = list("hacked", "Security")
-
-/datum/design/c10mm
-	name = "Ammo Box (10mm)"
-	id = "c10mm"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c10mm
-	category = list("hacked", "Security")
-
-/datum/design/buckshot_shell
-	name = "Buckshot Shell"
-	id = "buckshot_shell"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
-
-/datum/design/electropack
-	name = "Electropack"
-	id = "electropack"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 2500)
-	build_path = /obj/item/device/radio/electropack
-	category = list("hacked", "Tools")
-
-/datum/design/flamethrower
-	name = "Flamethrower"
-	id = "flamethrower"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/flamethrower/full
-	category = list("hacked", "Security")
-
-/datum/design/handcuffs
-	name = "Handcuffs"
-	id = "handcuffs"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/restraints/handcuffs
-	category = list("hacked", "Security")
-
-/datum/design/incendiary_slug
-	name = "Incendiary Slug"
-	id = "incendiary_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/incendiary
-	category = list("hacked", "Security")
-
-/datum/design/large_welding_tool
-	name = "Industrial Welding Tool"
-	id = "large_welding_tool"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
-	build_path = /obj/item/weapon/weldingtool/largetank
-	category = list("hacked", "Tools")
-
-/datum/design/rcd
-	name = "Rapid Construction Device (RCD)"
-	id = "rcd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/weapon/rcd
-	category = list("hacked", "Construction")
-
-/datum/design/shotgun_dart
-	name = "Shotgun Dart"
-	id = "shotgun_dart"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/dart
-	category = list("hacked", "Security")
-
-/datum/design/shotgun_slug
-	name = "Shotgun Slug"
-	id = "shotgun_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
-
-/datum/design/desttagger
-	name = "Destination tagger"
-	id = "desttagger"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250, MAT_GLASS = 125)
-	build_path = /obj/item/device/destTagger
-	category = list("initial", "Electronics")
-
-/datum/design/handlabeler
-	name = "Hand labeler"
-	id = "handlabel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
-	build_path = /obj/item/weapon/hand_labeler
-	category = list("initial", "Electronics")
-
-/datum/design/floorpainter
-	name = "Floor painter"
-	id = "floor_painter"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
-	build_path = /obj/item/device/floor_painter
-	category = list("initial", "Electronics")
 
 /datum/design/logic_board
 	name = "Logic Circuit"
@@ -729,35 +841,3 @@
 	materials = list(MAT_GLASS = 750, MAT_METAL = 250)
 	build_path = /obj/item/weapon/circuitboard/vendor
 	category = list("initial", "Electronics")
-
-/datum/design/conveyor_belt
-	name = "Conveyor belt"
-	id = "conveyor_belt"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000)
-	build_path = /obj/item/conveyor_construct
-	category = list("initial", "Construction")
-
-/datum/design/conveyor_switch
-	name = "Conveyor belt switch"
-	id = "conveyor_switch"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
-	build_path = /obj/item/conveyor_switch_construct
-	category = list("initial", "Construction")
-
-/datum/design/laptop
-	name = "Laptop Frame"
-	id = "laptop"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 1000)
-	build_path = /obj/item/device/modular_computer/laptop/buildable
-	category = list("initial", "Miscellaneous")
-
-/datum/design/tablet
-	name = "Tablet Frame"
-	id = "tablet"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
-	build_path = /obj/item/device/modular_computer/tablet
-	category = list("initial", "Miscellaneous")

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -11,7 +11,7 @@
 	materials = list(MAT_METAL = 700, MAT_GLASS = 50)
 	construction_time=100
 	build_path = /obj/item/weapon/stock_parts/cell
-	category = list("Misc","Power")
+	category = list("Misc","Power","Machinery","initial")
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"

--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -10,7 +10,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
 	build_path = /obj/item/weapon/stock_parts/capacitor
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 5
 
 /datum/design/basic_sensor
@@ -21,7 +21,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/scanning_module
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 5
 
 /datum/design/micro_mani
@@ -32,7 +32,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 30)
 	build_path = /obj/item/weapon/stock_parts/manipulator
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 5
 
 /datum/design/basic_micro_laser
@@ -43,7 +43,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
 	build_path = /obj/item/weapon/stock_parts/micro_laser
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 5
 
 /datum/design/basic_matter_bin
@@ -54,7 +54,7 @@
 	build_type = PROTOLATHE | AUTOLATHE
 	materials = list(MAT_METAL = 80)
 	build_path = /obj/item/weapon/stock_parts/matter_bin
-	category = list("Stock Parts")
+	category = list("Stock Parts","Machinery","initial")
 	lathe_time_factor = 5
 
 /datum/design/adv_capacitor


### PR DESCRIPTION
Expands autolathe available items:

Expands the amount of items available in the autolathe; should allow for easier replacement of common goods to the station.

The biggest change here though is fixing a bug that didn't allow you to print off stock parts from an autolathe. I was originally against this, but after giving it more thought, I think this would be a good thing; it will allow engineering to better fulfill their role as maintainers of the station and even give them a few more options to experiment with, without being dependent on science completely. It also takes away some of science's domineering of the station. Let me stress this is *only* the tier 1 parts; the upgraded ones are not included here.

Also re-organizes the autolathe menu to be more logically layed out and adds two new categories: "Dinnerawre" (for anything kitchen related) and "Machinery" (for stocks parts). The menus are arranged in such a way that the most used categories (that are related) are grouped closer to together.

![img](https://i.gyazo.com/a447d11e3e25b81b0f6b0a26dd6375d9.png)

List of New Items:

- Emergency Welding Tool
- Fork
- Tray
- Drinking Glass
- Shot Glass
- Shaker
- Butcher Cleaver (hacking required)
- Riot Darts (hacking required)
- All stock parts (basic cell, capacitor, scanning module, manipulator, micro-laser, and matter bin).
  -  This is technically a bugfix, but I'm still calling it a feature

Related
- Lights now only cost glass instead of glass+metal

:cl: Fox McCloud
add: Adds in emergency welding tool, fork, trays, drinking glasses, shot glasses, shakers, butcher cleavers, and riot darts to the autolathe
add: Adds all basic stock parts to the autolathe
tweak: re-arranges the autolathe menu to be more logical
tweak: light bulbs no longer require metal to produce
/:cl: