### PR TITLE
Removes "Scarry Sounds" Random Loop

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -958,13 +958,6 @@
 				adjustToxLoss(-3)
 				lastpuke = 0
 
-	//0.1% chance of playing a scary sound to someone who's in complete darkness
-	if(isturf(loc) && rand(1,1000) == 1)
-		var/turf/currentTurf = loc
-		var/atom/movable/lighting_overlay/L = locate(/atom/movable/lighting_overlay) in currentTurf
-		if(L && L.lum_r + L.lum_g + L.lum_b == 0)
-			playsound_local(src,pick(scarySounds),50, 1, -1)
-
 /mob/living/carbon/human/handle_changeling()
 	if(mind)
 		if(mind.changeling)


### PR DESCRIPTION
Removes the "scary sounds" that plays if you're in a dark area.

This is handled on every mob's life loop. Quite frankly, if there's supposed to be scary ambient noises, it should be handled in an area's ambience and not processed by a mob's `Life` loop.

This also "fixes" the bug with scary sounds playing all the time, regardless of your location and regardless of how bright/dark it is.

:cl: Fox McCloud
tweak: removes the random "scary" sounds that play when walking about
/:cl: