### PR TITLE
Fixes personal crafting UI template for older browsers

### DIFF
--- a/nano/templates/personal_crafting.tmpl
+++ b/nano/templates/personal_crafting.tmpl
@@ -1,5 +1,5 @@
 <script>
-	{{var tooltiptext = function(req_text, catalyst_text, tool_text) { let text = ""; if(req_text){text += "REQUIREMENTS: " + req_text + " ";} if(catalyst_text){text += "CATALYSTS: " + catalyst_text + " ";} if(tool_text){text += "TOOLS: " + tool_text;}return text;};}}
+	{{var tooltiptext = function(req_text, catalyst_text, tool_text) { var text = ""; if(req_text){text += "REQUIREMENTS: " + req_text + " ";} if(catalyst_text){text += "CATALYSTS: " + catalyst_text + " ";} if(tool_text){text += "TOOLS: " + tool_text;}return text;};}}
 </script>
 
 


### PR DESCRIPTION
`let` isn't actually supported by anything below IE11, which makes the template completely fail to compile. Gonna go ahead and give @davipatury a little ping to be aware of this...

Fixes #6864.

:cl:
fix: Personal crafting is now usable again for those with an Internet Explorer version below 11.
/:cl: