### PR TITLE
Abductor Gland Rework and Abductor Updates

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -124,6 +124,9 @@
 #define islarva(A)		(istype((A), /mob/living/carbon/alien/larva))
 #define isslime(A)		(istype((A), /mob/living/carbon/slime))
 
+//Human sub-species
+#define isabductor(A) (is_species(A, "Abductor"))
+
 #define isanimal(A)		(istype((A), /mob/living/simple_animal))
 #define iscorgi(A)		(istype((A), /mob/living/simple_animal/pet/corgi))
 #define ismouse(A)		(istype((A), /mob/living/simple_animal/mouse))

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -363,6 +363,13 @@ proc/add_logs(mob/user, mob/target, what_done, var/object=null, var/addition=nul
 	if(progress)
 		qdel(progbar)
 
+/proc/is_species(A, species_name)
+	. = FALSE
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		if(H.get_species() == species_name)
+			. = TRUE
+
 /proc/admin_mob_info(mob/M, mob/user = usr)
 	if(!ismob(M))
 		to_chat(user, "This can only be used on instances of type /mob")

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -247,7 +247,7 @@
 		V.flags |= NODROP
 	agent.equip_to_slot_or_del(V, slot_wear_suit)
 	agent.equip_to_slot_or_del(new /obj/item/weapon/abductor_baton(agent), slot_in_backpack)
-	agent.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/decloner/alien(agent), slot_in_backpack)
+	agent.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/alien(agent), slot_in_backpack)
 	agent.equip_to_slot_or_del(new /obj/item/device/abductor/silencer(agent), slot_in_backpack)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/abductor(agent), slot_head)
 	agent.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/military/abductor/full(agent), slot_belt)
@@ -371,8 +371,22 @@
 	explanation_text = "Steal all"
 
 /datum/objective/abductee/steal/New()
-	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap"))
+	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap", "weapons", "computers", "organs"))
 	explanation_text+=" [target]."
+
+/datum/objective/abductee/paint
+	explanation_text = "The station is hideous. You must color it all"
+
+/datum/objective/abductee/paint/New()
+	var/color = pick(list("red", "blue", "green", "yellow", "orange", "purple", "black", "in rainbows", "in blood"))
+	explanation_text+= " [color]!"
+
+/datum/objective/abductee/speech
+	explanation_text = "Your brain is broken... you can only communicate in"
+
+/datum/objective/abductee/speech/New()
+	var/style = pick(list("pantomime", "rhyme", "haiku", "extended metaphors", "riddles", "extremely literal terms", "sound effects", "military jargon"))
+	explanation_text+= " [style]."
 
 /datum/objective/abductee/capture
 	explanation_text = "Capture"
@@ -413,16 +427,16 @@
 	explanation_text = "Start a collection of corpses. Don't kill people to get these corpses."
 
 /datum/objective/abductee/floors
-	explanation_text = "Replace all the floor tiles with carpeting, wooden boards, or grass."
+	explanation_text = "Replace all the floor tiles with wood, carpeting, grass or bling."
 
 /datum/objective/abductee/POWERUNLIMITED
 	explanation_text = "Flood the station's powernet with as much electricity as you can."
 
 /datum/objective/abductee/pristine
-	explanation_text = "Ensure the station is in absolutely pristine condition."
+	explanation_text = "The CEO of Nanotrasen is coming! Ensure the station is in absolutely pristine condition."
 
-/datum/objective/abductee/window
-	explanation_text = "Replace all normal windows with reinforced windows."
+/datum/objective/abductee/nowalls
+	explanation_text = "The crew must get to know one another better. Break down the walls inside the station!"
 
 /datum/objective/abductee/nations
 	explanation_text = "Ensure your department prospers over all else."
@@ -430,17 +444,11 @@
 /datum/objective/abductee/abductception
 	explanation_text = "You have been changed forever. Find the ones that did this to you and give them a taste of their own medicine."
 
-/datum/objective/abductee/ghosts
-	explanation_text = "Conduct a seance with the spirits of the afterlife."
-
 /datum/objective/abductee/summon
-	explanation_text = "Conduct a ritual to summon an elder god."
+	explanation_text = "The elder gods hunger. Gather a cult and conduct a ritual to summon one."
 
 /datum/objective/abductee/machine
-	explanation_text = "You are secretly an android. Interface with as many machines as you can to boost your own power."
-
-/datum/objective/abductee/prevent
-	explanation_text = "You have been enlightened. This knowledge must not escape. Ensure nobody else can become enlightened."
+	explanation_text = "You are secretly an android. Interface with as many machines as you can to boost your own power so the AI may acknowledge you at last."
 
 /datum/objective/abductee/calling
 	explanation_text = "Call forth a spirit from the other side."
@@ -448,7 +456,7 @@
 /datum/objective/abductee/calling/New()
 	var/mob/dead/D = pick(dead_mob_list)
 	if(D)
-		explanation_text = "You know that [D] has perished. Call them from the spirit realm."
+		explanation_text = "You know that [D] has perished. Hold a seance to call them from the spirit realm."
 
 /datum/objective/abductee/social_experiment
 	explanation_text = "This is a secret social experiment conducted by Nanotrasen. Convince the crew that this is the truth."
@@ -460,7 +468,7 @@
 	explanation_text = "Nanotrasen is abusing the animals! Save as many as you can!"
 
 /datum/objective/abductee/defect
-	explanation_text = "Defect from your employer."
+	explanation_text = "Fuck the system! Defect from the station and start an independent colony in space, Mining Outpost or the derelict. Recruit crewmates if you can."
 
 /datum/objective/abductee/promote
 	explanation_text = "Climb the corporate ladder all the way to the top!"
@@ -473,3 +481,33 @@
 
 /datum/objective/abductee/pragnant
 	explanation_text = "You are pregnant and soon due. Find a safe place to deliver your baby."
+
+/datum/objective/abductee/engine
+	explanation_text = "Go have a good conversation with the singularity/tesla/supermatter crystal. Bonus points if it responds."
+
+/datum/objective/abductee/music
+	explanation_text = "You burn with passion for music. Share your vision. If anyone hates it, beat them on the head with your instrument!"
+
+/datum/objective/abductee/clown
+	explanation_text = "The clown is not funny. You can do better! Steal his audience and make the crew laugh!"
+
+/datum/objective/abductee/party
+	explanation_text = "You're throwing a huge rager. Make it as awesome as possible so the whole crew comes... OR ELSE!"
+
+/datum/objective/abductee/pets
+	explanation_text = "All the pets around here suck. You need to make them cooler. Replace them with exotic beasts!"
+
+/datum/objective/abductee/conspiracy
+	explanation_text = "The leaders of this station are hiding a grand, evil conspiracy. Only you can learn what it is, and expose it to the people!"
+
+/datum/objective/abductee/stalker
+	explanation_text = "The Syndicate has hired you to compile dossiers on all important members of the crew. Be sure they don't know you're doing it."
+
+/datum/objective/abductee/narrator
+	explanation_text = "You're the narrator of this tale. Follow around the protagonists to tell their story."
+
+/datum/objective/abductee/lurve
+	explanation_text = "You are doomed to feel woefully incomplete forever... until you find your true love on this station. They're waiting for you!"
+
+/datum/objective/abductee/sixthsense
+	explanation_text = "You died back there and went to heaven... or is it hell? No one here seems to know they're dead. Convince them, and maybe you can escape this limbo."

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -502,7 +502,7 @@ Congratulations! You are now trained for xenobiology research!"}
 		species = "<span clas=='notice'>[H.species.name]</span>"
 		if(L.mind && L.mind.changeling)
 			species = "<span class='warning'>Changeling lifeform</span>"
-		var/obj/item/organ/internal/gland/temp = locate() in H.internal_organs
+		var/obj/item/organ/internal/heart/gland/temp = locate() in H.internal_organs
 		if(temp)
 			helptext = "<span class='warning'>Experimental gland detected!</span>"
 		else

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -11,7 +11,7 @@
 	icon_state = "vest_stealth"
 	item_state = "armor"
 	blood_overlay_type = "armor"
-	origin_tech = "materials=5;biotech=4;powerstorage=5;abductor=3"
+	origin_tech = "magnets=7;biotech=4;powerstorage=4;abductor=4"
 	armor = list(melee = 15, bullet = 15, laser = 15, energy = 15, bomb = 15, bio = 15, rad = 15)
 	actions_types = list(/datum/action/item_action/hands_free/activate)
 	var/mode = VEST_STEALTH
@@ -34,7 +34,6 @@
 			mode = VEST_STEALTH
 			armor = stealth_armor
 			icon_state = "vest_stealth"
-
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		H.update_inv_wear_suit()
@@ -64,7 +63,6 @@
 		M.overlays = disguise.overlays
 		M.update_inv_r_hand()
 		M.update_inv_l_hand()
-	return
 
 /obj/item/clothing/suit/armor/abductor/vest/proc/DeactivateStealth()
 	if(!stealth_active)
@@ -77,7 +75,6 @@
 		M.name_override = null
 		M.overlays.Cut()
 		M.regenerate_icons()
-	return
 
 /obj/item/clothing/suit/armor/abductor/vest/hit_reaction()
 	DeactivateStealth()
@@ -115,19 +112,11 @@
 	if(combat_cooldown==initial(combat_cooldown))
 		processing_objects.Remove(src)
 
-/obj/item/device/abductor/proc/IsAbductor(user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.get_species() != "Abductor")
-			return 0
-		return 1
-	return 0
-
 /obj/item/device/abductor/proc/AbductorCheck(user)
-	if(IsAbductor(user))
-		return 1
+	if(isabductor(user))
+		return TRUE
 	to_chat(user, "<span class='warning'>You can't figure how this works!</span>")
-	return 0
+	return FALSE
 
 /obj/item/device/abductor/proc/ScientistCheck(user)
 	var/mob/living/carbon/human/H = user
@@ -140,7 +129,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gizmo_scan"
 	item_state = "gizmo"
-	origin_tech = "materials=5;magnets=5;bluespace=6;abductor=4"
+	origin_tech = "engineering=7;magnets=4;bluespace=4;abductor=3"
 	var/mode = GIZMO_SCAN
 	var/mob/living/marked = null
 	var/obj/machinery/abductor/console/console
@@ -187,7 +176,7 @@
 			mark(target, user)
 
 /obj/item/device/abductor/gizmo/proc/scan(atom/target, mob/living/user)
-	if(istype(target,/mob/living/carbon/human))
+	if(ishuman(target))
 		if(console!=null)
 			console.AddSnapshot(target)
 			to_chat(user, "<span class='notice'>You scan [target] and add them to the database.</span>")
@@ -196,8 +185,8 @@
 	if(marked == target)
 		to_chat(user, "<span class='warning'>This specimen is already marked!</span>")
 		return
-	if(istype(target,/mob/living/carbon/human))
-		if(IsAbductor(target))
+	if(ishuman(target))
+		if(isabductor(target))
 			marked = target
 			to_chat(user, "<span class='notice'>You mark [target] for future retrieval.</span>")
 		else
@@ -221,7 +210,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "silencer"
 	item_state = "silencer"
-	origin_tech = "materials=5;magnets=5;abductor=3"
+	origin_tech = "materials=4;programming=7;abductor=3"
 
 /obj/item/device/abductor/silencer/attack(mob/living/M, mob/user)
 	if(!AbductorCheck(user))
@@ -258,61 +247,15 @@
 			if(!istype(I,/obj/item/device/radio/headset))
 				r.broadcasting = 0 //goddamned headset hacks
 
-
-/obj/item/weapon/implant/abductor
-	name = "recall implant"
-	desc = "Returns you to the mothership."
-	icon = 'icons/obj/abductor.dmi'
-	icon_state = "implant"
-	activated = 1
-	origin_tech = "materials=2;biotech=3;magnets=4;bluespace=5;abductor=5"
-	var/obj/machinery/abductor/pad/home
-	var/cooldown = 30
-
-/obj/item/weapon/implant/abductor/activate()
-	if(cooldown == initial(cooldown))
-		home.Retrieve(imp_in,1)
-		cooldown = 0
-		processing_objects.Add(src)
-	else
-		to_chat(imp_in, "<span class='warning'>You must wait [30 - cooldown] seconds to use [src] again!</span>")
-	return
-
-/obj/item/weapon/implant/abductor/process()
-	if(cooldown < initial(cooldown))
-		cooldown++
-		if(cooldown == initial(cooldown))
-			processing_objects.Remove(src)
-
-/obj/item/weapon/implant/abductor/implant(var/mob/source, var/mob/user)
-	if(..())
-		var/obj/machinery/abductor/console/console
-		if(ishuman(source))
-			var/mob/living/carbon/human/H = source
-			if(H.get_species() == "Abductor")
-				console = get_team_console(H.mind.abductor.team)
-				home = console.pad
-
-		if(!home)
-			console = get_team_console(pick(1, 2, 3, 4))
-			home = console.pad
-		return 1
-
-/obj/item/weapon/implant/abductor/proc/get_team_console(var/team)
-	var/obj/machinery/abductor/console/console
-	for(var/obj/machinery/abductor/console/c in abductor_equipment)
-		if(c.team == team)
-			console = c
-			break
-	return console
-
-/obj/item/weapon/gun/energy/decloner/alien
+/obj/item/weapon/gun/energy/alien
 	name = "alien pistol"
 	desc = "A complicated gun that fires bursts of high-intensity radiation."
+	ammo_type = list(/obj/item/ammo_casing/energy/declone)
+	restricted_species = list("Abductor")
 	icon_state = "alienpistol"
 	item_state = "alienpistol"
-	origin_tech = "combat=5;materials=4;powerstorage=3;abductor=3"
-	restricted_species = list("Abductor")
+	origin_tech = "combat=4;magnets=7;powerstorage=3;abductor=3"
+	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 /obj/item/weapon/paper/abductor
 	name = "Dissection Guide"
@@ -321,23 +264,27 @@
 
 <br>
  1.Acquire fresh specimen.<br>
- 2.Put the specimen on operating table<br>
- 3.Apply scalpel to the chest, preparing for dissection<br>
- 4.Apply scalpel to specimen torso<br>
- 5.Clamp bleeders on the specimen's torso<br>
- 6.Retract skin from specimen's torso<br>
- 7.Saw through the specimen's torso<br>
- 8.Retract skin from specimen's torso again<br>
- 9.Search through the specimen's torso with your hands to remove their heart<br>
- 10.Insert replacement gland (Retrieve one from gland storage)<br>
- 11.Cauterize the patient's torso<br>
- 12.Consider dressing the specimen back to not disturb the habitat <br>
- 13.Put the specimen in the experiment machinery<br>
- 14.Choose one of the machine options and follow displayed instructions<br>
+ 2.Put the specimen on operating table.<br>
+ 3.Apply scalpel to the chest, preparing for experimental dissection.<br>
+ 4.Apply scalpel to specimen torso.<br>
+ 5.Clamp bleeders on specimen's torso with a hemostat.<br>
+ 6.Retract skin of specimen's torso with a retractor.<br>
+ 7.Saw through the specimen's torso with a saw.<br>
+ 8.Apply recator again to specimen's torso.<br>
+ 9.Search through the specimen's torso with your hands to remove any superfluous organs.<br>
+ 10.Insert replacement gland (Retrieve one from gland storage).<br>
+ 11.Cauterize the patient's torso with a cautery.<br>
+ 12.Consider dressing the specimen back to not disturb the habitat. <br>
+ 13.Put the specimen in the experiment machinery.<br>
+ 14.Choose one of the machine options. The target will be analyzed and teleported to the selected drop-off point.<br>
+ 15.You will receive one supply credit, and the subject will be counted towards your quota.<br>
 <br>
-Congratulations! You are now trained for xenobiology research!"}
+Congratulations! You are now trained for invasive xenobiology research!"}
 
 /obj/item/weapon/paper/abductor/update_icon()
+	return
+
+/obj/item/weapon/paper/abductor/AltClick()
 	return
 
 #define BATON_STUN 0
@@ -354,9 +301,9 @@ Congratulations! You are now trained for xenobiology research!"}
 	icon_state = "wonderprodStun"
 	item_state = "wonderprod"
 	slot_flags = SLOT_BELT
-	origin_tech = "materials=6;combat=5;biotech=7;abductor=4"
+	origin_tech = "materials=4;combat=4;biotech=7;abductor=4"
 	force = 7
-	w_class = 3
+	w_class = WEIGHT_CLASS_NORMAL
 	actions_types = list(/datum/action/item_action/toggle_mode)
 
 /obj/item/weapon/abductor_baton/proc/toggle(mob/living/user=usr)
@@ -393,16 +340,8 @@ Congratulations! You are now trained for xenobiology research!"}
 			icon_state = "wonderprodProbe"
 			item_state = "wonderprodProbe"
 
-/obj/item/weapon/abductor_baton/proc/IsAbductor(mob/living/user)
-	if(!ishuman(user))
-		return 0
-	var/mob/living/carbon/human/H = user
-	if(H.get_species() != "Abductor")
-		return 0
-	return 1
-
 /obj/item/weapon/abductor_baton/attack(mob/target, mob/living/user)
-	if(!IsAbductor(user))
+	if(!isabductor(user))
 		return
 
 	if(isrobot(target))
@@ -434,7 +373,7 @@ Congratulations! You are now trained for xenobiology research!"}
 
 /obj/item/weapon/abductor_baton/attack_self(mob/living/user)
 	toggle(user)
-	if(istype(user,/mob/living/carbon/human))
+	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.update_inv_l_hand()
 		H.update_inv_r_hand()
@@ -456,10 +395,9 @@ Congratulations! You are now trained for xenobiology research!"}
 		H.forcesay(hit_appends)
 
 	add_logs(user, L, "stunned")
-	return
 
 /obj/item/weapon/abductor_baton/proc/SleepAttack(mob/living/L,mob/living/user)
-	if(L.stunned)
+	if(L.stunned || L.sleeping)
 		L.visible_message("<span class='danger'>[user] has induced sleep in [L] with [src]!</span>", \
 							"<span class='userdanger'>You suddenly feel very drowsy!</span>")
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
@@ -470,7 +408,6 @@ Congratulations! You are now trained for xenobiology research!"}
 		to_chat(user, "<span class='warning'>Sleep inducement works fully only on stunned specimens! </span>")
 		L.visible_message("<span class='danger'>[user] tried to induce sleep in [L] with [src]!</span>", \
 							"<span class='userdanger'>You suddenly feel drowsy!</span>")
-	return
 
 /obj/item/weapon/abductor_baton/proc/CuffAttack(mob/living/L,mob/living/user)
 	if(!iscarbon(L))
@@ -488,7 +425,6 @@ Congratulations! You are now trained for xenobiology research!"}
 				add_logs(user, C, "handcuffed")
 		else
 			to_chat(user, "<span class='warning'>You fail to handcuff [C].</span>")
-	return
 
 /obj/item/weapon/abductor_baton/proc/ProbeAttack(mob/living/L,mob/living/user)
 	L.visible_message("<span class='danger'>[user] probes [L] with [src]!</span>", \
@@ -517,7 +453,7 @@ Congratulations! You are now trained for xenobiology research!"}
 	icon_state = "cuff_white" // Needs sprite
 	breakouttime = 450
 	trashtype = /obj/item/weapon/restraints/handcuffs/energy/used
-	origin_tech = "materials=2;magnets=5;abductor=2"
+	origin_tech = "materials=4;magnets=5;abductor=2"
 
 /obj/item/weapon/restraints/handcuffs/energy/used
 	desc = "energy discharge"
@@ -545,36 +481,42 @@ Congratulations! You are now trained for xenobiology research!"}
 
 /obj/item/weapon/scalpel/alien
 	name = "alien scalpel"
+	desc = "It's a gleaming sharp knife made out of silvery-green metal."
 	icon = 'icons/obj/abductor.dmi'
 	origin_tech = "materials=2;biotech=2;abductor=2"
 	toolspeed = 0.25
 
 /obj/item/weapon/hemostat/alien
 	name = "alien hemostat"
+	desc = "You've never seen this before."
 	icon = 'icons/obj/abductor.dmi'
 	origin_tech = "materials=2;biotech=2;abductor=2"
 	toolspeed = 0.25
 
 /obj/item/weapon/retractor/alien
 	name = "alien retractor"
+	desc = "You're not sure if you want the veil pulled back."
 	icon = 'icons/obj/abductor.dmi'
 	origin_tech = "materials=2;biotech=2;abductor=2"
 	toolspeed = 0.25
 
 /obj/item/weapon/circular_saw/alien
 	name = "alien saw"
+	desc = "Do the aliens also lose this, and need to find an alien hatchet?"
 	icon = 'icons/obj/abductor.dmi'
 	origin_tech = "materials=2;biotech=2;abductor=2"
 	toolspeed = 0.25
 
 /obj/item/weapon/surgicaldrill/alien
 	name = "alien drill"
+	desc = "Maybe alien surgeons have finally found a use for the drill."
 	icon = 'icons/obj/abductor.dmi'
 	origin_tech = "materials=2;biotech=2;abductor=2"
 	toolspeed = 0.25
 
 /obj/item/weapon/cautery/alien
 	name = "alien cautery"
+	desc = "Why would bloodless aliens have a tool to stop bleeding? Unless..."
 	icon = 'icons/obj/abductor.dmi'
 	origin_tech = "materials=2;biotech=2;abductor=2"
 	toolspeed = 0.25
@@ -585,16 +527,11 @@ Congratulations! You are now trained for xenobiology research!"}
 	icon_state = "alienhelmet"
 	item_state = "alienhelmet"
 	blockTracking = 1
-	origin_tech = "materials=6;magnets=5;abductor=3"
+	origin_tech = "materials=7;magnets=4;abductor=3"
 	flags = BLOCKHAIR
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 
 // Operating Table / Beds / Lockers
-
-/obj/machinery/optable/abductor
-	icon = 'icons/obj/abductor.dmi'
-	icon_state = "bed"
-	no_icon_updates = 1 //no icon updates for this; it's static.
 
 /obj/structure/stool/bed/abductor
 	name = "resting contraption"
@@ -628,6 +565,16 @@ Congratulations! You are now trained for xenobiology research!"}
 			new /obj/structure/table/abductor(src.loc)
 			qdel(src)
 		return
+	if(istype(I, /obj/item/stack/sheet/mineral/silver))
+		var/obj/item/stack/sheet/P = I
+		if(P.get_amount() < 1)
+			to_chat(user, "<span class='warning'>You need one sheet of silver to do	this!</span>")
+			return
+		to_chat(user, "<span class='notice'>You start adding [P] to [src]...</span>")
+		if(do_after(user, 50, target = src))
+			P.use(1)
+			new /obj/machinery/optable/abductor(loc)
+			qdel(src)
 
 /obj/structure/table/abductor
 	name = "alien table"
@@ -636,6 +583,11 @@ Congratulations! You are now trained for xenobiology research!"}
 	icon_state = "alien_table"
 	canSmoothWith = null
 	parts = /obj/item/stack/sheet/mineral/abductor
+
+/obj/machinery/optable/abductor
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "bed"
+	no_icon_updates = 1 //no icon updates for this; it's static.
 
 /obj/structure/closet/abductor
 	name = "alien locker"

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -266,11 +266,11 @@
  1.Acquire fresh specimen.<br>
  2.Put the specimen on operating table.<br>
  3.Apply scalpel to the chest, preparing for experimental dissection.<br>
- 4.Apply scalpel to specimen torso.<br>
+ 4.Apply scalpel to specimen's torso.<br>
  5.Clamp bleeders on specimen's torso with a hemostat.<br>
  6.Retract skin of specimen's torso with a retractor.<br>
  7.Saw through the specimen's torso with a saw.<br>
- 8.Apply recator again to specimen's torso.<br>
+ 8.Apply retractor again to specimen's torso.<br>
  9.Search through the specimen's torso with your hands to remove any superfluous organs.<br>
  10.Insert replacement gland (Retrieve one from gland storage).<br>
  11.Cauterize the patient's torso with a cautery.<br>

--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -15,9 +15,9 @@
 			return 0
 	var/mob/living/carbon/human/H = user
 	// You must either: Be of the abductor species, or contain an abductor implant
-	if(!(H.get_species() == "Abductor" || (locate(/obj/item/weapon/implant/abductor) in H)))
-		return 0
-	return 1
+	if((H.get_species() == "Abductor" || (locate(/obj/item/weapon/implant/abductor) in H)))
+		return 1
+	return 0
 
 
 /datum/surgery_step/internal/extract_organ
@@ -47,7 +47,7 @@
 		return 1
 	else
 		to_chat(user, "<span class='warning'>You don't find anything in [target]'s [target_zone]!</span>")
-		return 0
+		return 1
 
 /datum/surgery_step/internal/gland_insert
 	name = "insert gland"

--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -51,7 +51,7 @@
 
 /datum/surgery_step/internal/gland_insert
 	name = "insert gland"
-	allowed_tools = list(/obj/item/organ/internal/gland = 100)
+	allowed_tools = list(/obj/item/organ/internal/heart/gland = 100)
 	time = 32
 
 /datum/surgery_step/internal/gland_insert/begin_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -61,6 +61,6 @@
 /datum/surgery_step/internal/gland_insert/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] inserts [tool] into [target].", "<span class ='notice'>You insert [tool] into [target].</span>")
 	user.drop_item()
-	var/obj/item/organ/internal/gland/gland = tool
+	var/obj/item/organ/internal/heart/gland/gland = tool
 	gland.insert(target, 2)
 	return 1

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -1,12 +1,11 @@
-/obj/item/organ/internal/gland
+/obj/item/organ/internal/heart/gland
 	name = "fleshy mass"
 	desc = "A nausea-inducing hunk of twisting flesh and metal."
 	icon = 'icons/obj/abductor.dmi'
-	parent_organ = "chest"
-	slot = "gland"
 	icon_state = "gland"
 	status = ORGAN_ROBOT
-	origin_tech = "materials=4;biotech=5;abductor=3"
+	origin_tech = "materials=4;biotech=7;abductor=3"
+	beating = TRUE
 	var/cooldown_low = 300
 	var/cooldown_high = 300
 	var/next_activation = 0
@@ -16,30 +15,33 @@
 	tough = 1 //not easily broken by combat damage
 	sterile = 1 //not very germy
 
-/obj/item/organ/internal/gland/proc/ownerCheck()
+/obj/item/organ/internal/heart/gland/proc/ownerCheck()
 	if(ishuman(owner))
 		return 1
 	if(!human_only && iscarbon(owner))
 		return 1
 	return 0
 
-/obj/item/organ/internal/gland/proc/Start()
+/obj/item/organ/internal/heart/gland/proc/Start()
 	active = 1
 	next_activation = world.time + rand(cooldown_low,cooldown_high)
 
 
-/obj/item/organ/internal/gland/remove(var/mob/living/carbon/M, special = 0)
+/obj/item/organ/internal/heart/gland/remove(var/mob/living/carbon/M, special = 0)
 	active = 0
 	if(initial(uses) == 1)
 		uses = initial(uses)
-	..()
+	. = ..()
 
-/obj/item/organ/internal/gland/insert(var/mob/living/carbon/M, special = 0)
+/obj/item/organ/internal/heart/gland/insert(var/mob/living/carbon/M, special = 0)
 	..()
 	if(special != 2 && uses) // Special 2 means abductor surgery
 		Start()
 
-/obj/item/organ/internal/gland/on_life()
+/obj/item/organ/internal/heart/gland/on_life()
+	if(!beating)
+		// alien glands are immune to stopping.
+		beating = TRUE
 	if(!active)
 		return
 	if(!ownerCheck())
@@ -52,30 +54,28 @@
 	if(!uses)
 		active = 0
 
-/obj/item/organ/internal/gland/proc/activate()
+/obj/item/organ/internal/heart/gland/proc/activate()
 	return
 
-/obj/item/organ/internal/gland/heals
-	origin_tech = "materials=4;biotech=6;abductor=3"
+/obj/item/organ/internal/heart/gland/heals
 	cooldown_low = 200
 	cooldown_high = 400
 	uses = -1
 	icon_state = "health"
 
-/obj/item/organ/internal/gland/heals/activate()
+/obj/item/organ/internal/heart/gland/heals/activate()
 	to_chat(owner, "<span class='notice'>You feel curiously revitalized.</span>")
 	owner.adjustBruteLoss(-20)
 	owner.adjustOxyLoss(-20)
 	owner.adjustFireLoss(-20)
 
-/obj/item/organ/internal/gland/slime
-	origin_tech = "materials=4;biotech=6;abductor=3"
+/obj/item/organ/internal/heart/gland/slime
 	cooldown_low = 600
 	cooldown_high = 1200
 	uses = -1
 	icon_state = "slime"
 
-/obj/item/organ/internal/gland/slime/activate()
+/obj/item/organ/internal/heart/gland/slime/activate()
 	to_chat(owner, "<span class='warning'>You feel nauseous!</span>")
 	owner.vomit(20)
 
@@ -83,14 +83,14 @@
 	Slime.Friends = list(owner)
 	Slime.Leader = owner
 
-/obj/item/organ/internal/gland/mindshock
-	origin_tech = "materials=4;biotech=5;magnets=3;abductor=3"
+/obj/item/organ/internal/heart/gland/mindshock
+	origin_tech = "materials=4;biotech=4;magnets=6;abductor=3"
 	cooldown_low = 300
 	cooldown_high = 300
 	uses = -1
 	icon_state = "mindshock"
 
-/obj/item/organ/internal/gland/mindshock/activate()
+/obj/item/organ/internal/heart/gland/mindshock/activate()
 	to_chat(owner, "<span class='notice'>You get a headache.</span>")
 
 	var/turf/T = get_turf(owner)
@@ -100,40 +100,37 @@
 		to_chat(H, "<span class='alien'>You hear a buzz in your head.</span>")
 		H.AdjustConfused(20)
 
-/obj/item/organ/internal/gland/pop
-	origin_tech = "materials=4;biotech=6;abductor=3"
+/obj/item/organ/internal/heart/gland/pop
 	cooldown_low = 900
 	cooldown_high = 1800
-	uses = 6
+	uses = -1
 	human_only = 1
 	icon_state = "species"
 
-/obj/item/organ/internal/gland/pop/activate()
+/obj/item/organ/internal/heart/gland/pop/activate()
 	to_chat(owner, "<span class='notice'>You feel unlike yourself.</span>")
 	var/species = pick("Unathi","Skrell","Diona","Tajaran","Vulpkanin","Kidan","Grey","Diona")
 	owner.set_species(species)
 
-/obj/item/organ/internal/gland/ventcrawling
+/obj/item/organ/internal/heart/gland/ventcrawling
 	origin_tech = "materials=4;biotech=5;bluespace=3;abductor=3"
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1
 	icon_state = "vent"
 
-/obj/item/organ/internal/gland/ventcrawling/activate()
+/obj/item/organ/internal/heart/gland/ventcrawling/activate()
 	to_chat(owner, "<span class='notice'>You feel very stretchy.</span>")
 	owner.ventcrawler = 2
-	return
 
 
-/obj/item/organ/internal/gland/viral
-	origin_tech = "materials=4;biotech=6;abductor=3"
+/obj/item/organ/internal/heart/gland/viral
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1
 	icon_state = "viral"
 
-/obj/item/organ/internal/gland/viral/activate()
+/obj/item/organ/internal/heart/gland/viral/activate()
 	to_chat(owner, "<span class='warning'>You feel sick.</span>")
 	var/virus_type = pick(/datum/disease/beesease, /datum/disease/brainrot, /datum/disease/magnitis)
 	var/datum/disease/D = new virus_type()
@@ -144,51 +141,49 @@
 	owner.med_hud_set_status()
 
 
-/obj/item/organ/internal/gland/emp //TODO : Replace with something more interesting
-	origin_tech = "materials=4;biotech=5;magnets=3;abductor=3"
+/obj/item/organ/internal/heart/gland/emp //TODO : Replace with something more interesting
+	origin_tech = "materials=4;biotech=4;magnets=6;abductor=3"
 	cooldown_low = 900
 	cooldown_high = 1600
 	uses = 10
 	icon_state = "emp"
 
-/obj/item/organ/internal/gland/emp/activate()
+/obj/item/organ/internal/heart/gland/emp/activate()
 	to_chat(owner, "<span class='warning'>You feel a spike of pain in your head.</span>")
 	empulse(get_turf(owner), 2, 5, 1)
 
-/obj/item/organ/internal/gland/spiderman
-	origin_tech = "materials=4;biotech=6;abductor=3"
+/obj/item/organ/internal/heart/gland/spiderman
 	cooldown_low = 450
 	cooldown_high = 900
 	uses = 10
 	icon_state = "spider"
 
-/obj/item/organ/internal/gland/spiderman/activate()
+/obj/item/organ/internal/heart/gland/spiderman/activate()
 	to_chat(owner, "<span class='warning'>You feel something crawling in your skin.</span>")
 	owner.faction |= "spiders"
 	new /obj/effect/spider/spiderling(owner.loc)
 
-/obj/item/organ/internal/gland/egg
-	origin_tech = "materials=4;biotech=6;abductor=3"
+/obj/item/organ/internal/heart/gland/egg
 	cooldown_low = 300
 	cooldown_high = 400
 	uses = -1
 	icon_state = "egg"
 
-/obj/item/organ/internal/gland/egg/activate()
+/obj/item/organ/internal/heart/gland/egg/activate()
 	to_chat(owner, "<span class='boldannounce'>You lay an egg!</span>")
 	var/obj/item/weapon/reagent_containers/food/snacks/egg/egg = new(owner.loc)
 	egg.reagents.add_reagent("sacid",20)
 	egg.desc += " It smells bad."
 
-/obj/item/organ/internal/gland/bloody
-	origin_tech = "materials=4;biotech=6;abductor=3"
+/obj/item/organ/internal/heart/gland/bloody
 	cooldown_low = 200
 	cooldown_high = 400
 	uses = -1
 
-/obj/item/organ/internal/gland/bloody/activate()
-	owner.adjustBruteLoss(15)
-
+/obj/item/organ/internal/heart/gland/bloody/activate()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.drip(200)
 	owner.visible_message("<span class='danger'>[owner]'s skin erupts with blood!</span>",\
 	"<span class='userdanger'>Blood pours from your skin!</span>")
 
@@ -202,22 +197,22 @@
 			H.w_uniform.add_blood(owner)
 			H.update_inv_w_uniform(0)
 
-/obj/item/organ/internal/gland/bodysnatch
-	origin_tech = "materials=4;biotech=7;abductor=3"
+/obj/item/organ/internal/heart/gland/bodysnatch
 	cooldown_low = 600
 	cooldown_high = 600
 	human_only = 1
 	uses = 1
 
-/obj/item/organ/internal/gland/bodysnatch/activate()
+/obj/item/organ/internal/heart/gland/bodysnatch/activate()
 	to_chat(owner, "<span class='warning'>You feel something moving around inside you...</span>")
 	//spawn cocoon with clone greytide snpc inside
 	if(ishuman(owner))
 		var/obj/effect/cocoon/abductor/C = new (get_turf(owner))
 		C.Copy(owner)
 		C.Start()
-	owner.gib()
-	return
+	owner.adjustBruteLoss(40)
+	var/turf/T = get_turf(owner)
+	T.add_blood_floor(src)
 
 /obj/effect/cocoon/abductor
 	name = "slimy cocoon"
@@ -232,10 +227,17 @@
 	var/mob/living/carbon/human/interactive/greytide/clone = new(src)
 	var/datum/dna/owner_dna = H.dna
 	clone.rename_character(clone.name, owner_dna.real_name)
-	clone.body_accessory = H.body_accessory
 	clone.dna = owner_dna.Clone()
 	clone.set_species(H.species.name)
+	clone.body_accessory = H.body_accessory
 	domutcheck(clone)
+
+	for(var/obj/item/I in clone)
+		if(istype(I, /obj/item/weapon/implant))
+			continue
+		if(istype(I, /obj/item/organ))
+			continue
+		qdel(I)
 
 	//There's no define for this / get all items ?
 	var/list/slots = list(slot_back,slot_w_uniform,slot_wear_suit,\
@@ -245,7 +247,7 @@
 	for(var/slot in slots)
 		var/obj/item/I = H.get_item_by_slot(slot)
 		if(I)
-			clone.equip_to_slot_if_possible(I,slot)
+			clone.equip_to_slot_or_del(new I.type(clone), slot)
 
 /obj/effect/cocoon/abductor/proc/Start()
 	hatch_time = world.time + 600
@@ -259,22 +261,25 @@
 			M.forceMove(get_turf(src))
 		qdel(src)
 
-/obj/item/organ/internal/gland/plasma
-	cooldown_low = 2400
-	cooldown_high = 3000
-	origin_tech = "materials=4;biotech=5;plasmatech=3;abductor=3"
-	uses = 1
 
-/obj/item/organ/internal/gland/plasma/activate()
-	to_chat(owner, "<span class='warning'>You feel bloated.</span>")
-	sleep(150)
-	if(!owner) return
-	to_chat(owner, "<span class='userdanger'>A massive stomachache overcomes you.</span>")
-	sleep(50)
-	if(!owner) return
-	owner.visible_message("<span class='danger'>[owner] explodes in a cloud of plasma!</span>")
-	var/turf/simulated/T = get_turf(owner)
-	if(istype(T))
-		T.atmos_spawn_air(SPAWN_TOXINS|SPAWN_20C,300)
-	owner.gib()
-	return
+/obj/item/organ/internal/heart/gland/plasma
+	cooldown_low = 1200
+	cooldown_high = 1800
+	origin_tech = "materials=4;biotech=4;plasmatech=6;abductor=3"
+	uses = -1
+
+/obj/item/organ/internal/heart/gland/plasma/activate()
+	spawn(0)
+		to_chat(owner, "<span class='warning'>You feel bloated.</span>")
+		sleep(150)
+		if(!owner)
+			return
+		to_chat(owner, "<span class='userdanger'>A massive stomachache overcomes you.</span>")
+		sleep(50)
+		if(!owner)
+			return
+		owner.visible_message("<span class='danger'>[owner] vomits a cloud of plasma!</span>")
+		var/turf/simulated/T = get_turf(owner)
+		if(istype(T))
+			T.atmos_spawn_air(SPAWN_TOXINS|SPAWN_20C,50)
+		owner.vomit()

--- a/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
@@ -49,15 +49,12 @@
 	set_droppoint_action.target = console
 	set_droppoint_action.Grant(user)
 
-/obj/machinery/computer/camera_advanced/abductor/proc/IsAbductor(mob/living/carbon/human/H)
-	return H.get_species() == "Abductor"
-
 /obj/machinery/computer/camera_advanced/abductor/proc/IsScientist(mob/living/carbon/human/H)
 	if(H.mind && H.mind.abductor)
 		return H.mind.abductor.scientist
 
 /obj/machinery/computer/camera_advanced/abductor/attack_hand(mob/user)
-	if(!iscarbon(user) || !IsAbductor(user))
+	if(!isabductor(user))
 		return
 	return ..()
 

--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -14,6 +14,7 @@
 	return rgb(rand(0,255),rand(0,255),rand(0,255))
 
 /obj/machinery/abductor/gland_dispenser/New()
+	..()
 	gland_types = subtypesof(/obj/item/organ/internal/heart/gland)
 	gland_types = shuffle(gland_types)
 	gland_colors = new/list(gland_types.len)
@@ -25,7 +26,7 @@
 /obj/machinery/abductor/gland_dispenser/attack_hand(mob/user)
 	if(..())
 		return
-	if(!IsAbductor(user))
+	if(!isabductor(user))
 		return
 	user.set_machine(src)
 	var/box_css = {"
@@ -66,6 +67,8 @@
 		for(var/i=1,i<=gland_colors.len,i++)
 			if(gland_types[i] == W.type)
 				amounts[i]++
+	else
+		..()
 
 /obj/machinery/abductor/gland_dispenser/Topic(href, href_list)
 	if(..())
@@ -74,7 +77,7 @@
 
 	if(href_list["dispense"])
 		Dispense(text2num(href_list["dispense"]))
-	src.updateUsrDialog()
+	updateUsrDialog()
 
 /obj/machinery/abductor/gland_dispenser/proc/Dispense(count)
 	if(amounts[count]>0)

--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -14,7 +14,7 @@
 	return rgb(rand(0,255),rand(0,255),rand(0,255))
 
 /obj/machinery/abductor/gland_dispenser/New()
-	gland_types = subtypesof(/obj/item/organ/internal/gland)
+	gland_types = subtypesof(/obj/item/organ/internal/heart/gland)
 	gland_types = shuffle(gland_types)
 	gland_colors = new/list(gland_types.len)
 	amounts = new/list(gland_types.len)
@@ -59,7 +59,7 @@
 	return
 
 /obj/machinery/abductor/gland_dispenser/attackby(obj/item/weapon/W, mob/user, params)
-	if(istype(W, /obj/item/organ/internal/gland))
+	if(istype(W, /obj/item/organ/internal/heart/gland))
 		if(!user.drop_item())
 			return
 		W.forceMove(src)

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -118,7 +118,7 @@
 	if(H.stat == DEAD)
 		atom_say("Specimen deceased - please provide fresh sample.")
 		return "<span class='bad'>Specimen deceased.</span>"
-	var/obj/item/organ/internal/gland/GlandTest = locate() in H.internal_organs
+	var/obj/item/organ/internal/heart/gland/GlandTest = locate() in H.internal_organs
 	if(!GlandTest)
 		atom_say("Experimental dissection not detected!")
 		return "<span class='bad'>No glands detected!</span>"
@@ -147,7 +147,7 @@
 			obj_count++
 		ticker.mode.update_abductor_icons_added(H.mind)
 
-		for(var/obj/item/organ/internal/gland/G in H.internal_organs)
+		for(var/obj/item/organ/internal/heart/gland/G in H.internal_organs)
 			G.Start()
 			point_reward++
 		if(point_reward > 0)

--- a/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/experiment.dm
@@ -6,6 +6,7 @@
 	anchored = 1
 	density = 1
 	var/points = 0
+	var/credits = 0
 	var/list/history = list()
 	var/list/abductee_minds = list()
 	var/flash = " - || - "
@@ -19,10 +20,10 @@
 /obj/machinery/abductor/experiment/MouseDrop_T(mob/living/carbon/human/target, mob/user)
 	if(user.stat || user.lying || !Adjacent(user) || !target.Adjacent(user) || !ishuman(target))
 		return
-	if(IsAbductor(target))
+	if(isabductor(target))
 		return
 	if(occupant)
-		to_chat(user, "<span class='notice'>\The [src] is already occupied.</span>")
+		to_chat(user, "<span class='notice'>[src] is already occupied.</span>")
 		return //occupied
 	if(target.buckled)
 		return
@@ -155,6 +156,7 @@
 			SendBack(H)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			points += point_reward
+			credits += point_reward
 			return "<span class='good'>Experiment successful! [point_reward] new data-points collected.</span>"
 		else
 			playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, 1)
@@ -183,7 +185,7 @@
 		var/obj/item/weapon/grab/grabbed = G
 		if(!ishuman(grabbed.affecting))
 			return
-		if(IsAbductor(grabbed.affecting))
+		if(isabductor(grabbed.affecting))
 			return
 		if(occupant)
 			to_chat(user, "<span class='notice'>The [src] is already occupied!</span>")

--- a/code/game/gamemodes/miniantags/abduction/machinery/pad.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/pad.dm
@@ -17,6 +17,8 @@
 		target.forceMove(teleport_target)
 		spawn(0)
 			anim(target.loc,target,'icons/mob/mob.dmi',,"uncloak",,target.dir)
+		to_chat(target, "<span class='warning'>The instability of the warp leaves you disoriented!</span>")
+		target.Stun(3)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)

--- a/code/game/objects/items/weapons/implants/implant_abductor.dm
+++ b/code/game/objects/items/weapons/implants/implant_abductor.dm
@@ -1,0 +1,45 @@
+/obj/item/weapon/implant/abductor
+	name = "recall implant"
+	desc = "Returns you to the mothership."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "implant"
+	activated = 1
+	origin_tech = "materials=2;biotech=7;magnets=4;bluespace=4;abductor=5"
+	var/obj/machinery/abductor/pad/home
+	var/cooldown = 30
+
+/obj/item/weapon/implant/abductor/activate()
+	if(cooldown == initial(cooldown))
+		home.Retrieve(imp_in,1)
+		cooldown = 0
+		processing_objects.Add(src)
+	else
+		to_chat(imp_in, "<span class='warning'>You must wait [30 - cooldown] seconds to use [src] again!</span>")
+
+/obj/item/weapon/implant/abductor/process()
+	if(cooldown < initial(cooldown))
+		cooldown++
+		if(cooldown == initial(cooldown))
+			processing_objects.Remove(src)
+
+/obj/item/weapon/implant/abductor/implant(mob/source, mob/user)
+	if(..())
+		var/obj/machinery/abductor/console/console
+		if(ishuman(source))
+			var/mob/living/carbon/human/H = source
+			if(H.get_species() == "Abductor")
+				console = get_team_console(H.mind.abductor.team)
+				home = console.pad
+
+		if(!home)
+			console = get_team_console(pick(1, 2, 3, 4))
+			home = console.pad
+		return 1
+
+/obj/item/weapon/implant/abductor/proc/get_team_console(var/team)
+	var/obj/machinery/abductor/console/console
+	for(var/obj/machinery/abductor/console/c in abductor_equipment)
+		if(c.team == team)
+			console = c
+			break
+	return console

--- a/code/game/objects/items/weapons/implants/implant_abductor.dm
+++ b/code/game/objects/items/weapons/implants/implant_abductor.dm
@@ -15,7 +15,7 @@
 		cooldown = 0
 		processing_objects.Add(src)
 	else
-		to_chat(imp_in, "<span class='warning'>You must wait [(30 - cooldown)*2] seconds to use [src] again!</span>")
+		to_chat(imp_in, "<span class='warning'>You must wait [(total_cooldown - cooldown)*2] seconds to use [src] again!</span>")
 
 /obj/item/weapon/implant/abductor/process()
 	if(cooldown < total_cooldown)

--- a/code/game/objects/items/weapons/implants/implant_abductor.dm
+++ b/code/game/objects/items/weapons/implants/implant_abductor.dm
@@ -7,19 +7,20 @@
 	origin_tech = "materials=2;biotech=7;magnets=4;bluespace=4;abductor=5"
 	var/obj/machinery/abductor/pad/home
 	var/cooldown = 30
+	var/total_cooldown = 30
 
 /obj/item/weapon/implant/abductor/activate()
-	if(cooldown == initial(cooldown))
+	if(cooldown == total_cooldown)
 		home.Retrieve(imp_in,1)
 		cooldown = 0
 		processing_objects.Add(src)
 	else
-		to_chat(imp_in, "<span class='warning'>You must wait [30 - cooldown] seconds to use [src] again!</span>")
+		to_chat(imp_in, "<span class='warning'>You must wait [(30 - cooldown)*2] seconds to use [src] again!</span>")
 
 /obj/item/weapon/implant/abductor/process()
-	if(cooldown < initial(cooldown))
+	if(cooldown < total_cooldown)
 		cooldown++
-		if(cooldown == initial(cooldown))
+		if(cooldown == total_cooldown)
 			processing_objects.Remove(src)
 
 /obj/item/weapon/implant/abductor/implant(mob/source, mob/user)

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -740,7 +740,7 @@
 	..()
 
 /obj/item/clothing/under/contortionist/dropped(mob/living/carbon/human/user)
-	if(!user.get_int_organ(/obj/item/organ/internal/gland/ventcrawling))
+	if(!user.get_int_organ(/obj/item/organ/internal/heart/gland/ventcrawling))
 		user.ventcrawler = 0
 	..()
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1188,7 +1188,8 @@
 	else
 		AdjustLoseBreath(2, bound_lower = 0, bound_upper = 3)
 		adjustOxyLoss(5)
-		adjustBruteLoss(1)
+		Paralyse(4)
+		adjustBruteLoss(2)
 
 
 

--- a/code/modules/mob/living/carbon/human/species/abductor.dm
+++ b/code/modules/mob/living/carbon/human/species/abductor.dm
@@ -18,7 +18,7 @@
 		"eyes" =     /obj/item/organ/internal/eyes/abductor //3 darksight.
 		)
 
-	flags = HAS_LIPS | NO_BLOOD | NO_BREATHE
+	flags = HAS_LIPS | NO_BLOOD | NO_BREATHE | NOGUNS
 
 	oxy_mod = 0
 
@@ -27,11 +27,14 @@
 	dietflags = DIET_OMNI
 	reagent_tag = PROCESS_ORG
 	blood_color = "#FF5AFF"
+	female_scream_sound = 'sound/goonstation/voice/male_scream.ogg'
+	female_cough_sounds = list('sound/effects/mob_effects/m_cougha.ogg','sound/effects/mob_effects/m_coughb.ogg', 'sound/effects/mob_effects/m_coughc.ogg')
+	female_sneeze_sound = 'sound/effects/mob_effects/sneeze.ogg' //Abductors always scream like guys
 
-/datum/species/abductor/can_understand(var/mob/other) //Abductors can understand everyone, but they can only speak over their mindlink to another team-member
+/datum/species/abductor/can_understand(mob/other) //Abductors can understand everyone, but they can only speak over their mindlink to another team-member
 	return 1
 
-/datum/species/abductor/handle_post_spawn(var/mob/living/carbon/human/H)
+/datum/species/abductor/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
 	if(H.mind)
 		H.mind.abductor = new /datum/abductor

--- a/paradise.dme
+++ b/paradise.dme
@@ -846,6 +846,7 @@
 #include "code\game\objects\items\weapons\grenades\spawnergrenade.dm"
 #include "code\game\objects\items\weapons\grenades\syndieminibomb.dm"
 #include "code\game\objects\items\weapons\implants\implant.dm"
+#include "code\game\objects\items\weapons\implants\implant_abductor.dm"
 #include "code\game\objects\items\weapons\implants\implant_chem.dm"
 #include "code\game\objects\items\weapons\implants\implant_death_alarm.dm"
 #include "code\game\objects\items\weapons\implants\implant_explosive.dm"


### PR DESCRIPTION
From TG

Makes various tweak to abductor glands and makes them a type of heart.

Making them a type of heart means that they replace the individuals heart, explicitly. If you remove said heart, then it's going to induce cardiac arrest in the individual instead of being consequence free. If you want to rip the gland out of the patient, you're going to have to get them a replacement heart, first.

Overall goals is to encourage abductors to be more about chaos than out and out killing people or open combat

Tweaks to Abductor Mechanics

- Abductors can no longer use guns--that said, they will still be able to use the alien energy gun the agent starts wtih
- The wonderprod will induce sleep in individuals who are stunned or already sleeping (previously was just stunned)
- Abductors can now purchase a replacement vest from the supplies console
- Abductors can toggle vest locks with the supplies console
- Purchasing supplies from the abductor supply console no longer increments the amount of experiments you must perform
- Can now make abductor surgery tables from abductor table frames with a sheet of silver
- Abductors no longer scream like girls
- After sending someone through the teleport pad ***with the regular console*** (not the camera console) will stun the person getting sent through
- Added a whole slew of new abductor objectives and removed the the objective that generally encouraged murderkilling
- Adjusted the abductor surgery guide to be a bit more precise and clear
- Added descriptions to abductor surgery tools
- Adjusted some origin tech levels on a number of abductor objects

Tweaks to gland:

- Glands are a type of heart; removing them will induce cardiac arrest
- Plasma gland no longer gibs you, but makes you vomit up plasma periodically
- Bodysnatcher gland no longer gibs you, but does massive brute damage to you upon activation
- Blood gland drains blood from you instead of doing brute damage
- Species change gland will change your species an unlimited number of times instead of 6
- Adjusts the origin tech on glands

Other
- Heart attacks paralyse you and do 2 brute instead of 1

Fixes
- Fixes abductor glands not properly returning their values when being removed
- Fixes plasma gland activation locking up all mob processing
- Fixes bodysnatch clone now having the right equipment and looks of its originator mob

:cl: Fox McCloud
tweak: abductor glands now act as actual hearts; removing them induces heart failure
tweak: plasma gland no longer gibs you, but makes you vomit plasma instead
tweak: bodysnatcher gland no longer gibs you, but will deal brute damage instead
tweak: bloody gland will now drain blood instead of dealing brute damage
tweak: species change gland will now change your species until the gland is removed
tweak: adjusted the origin tech on a few gland
tweak: heart attacks will once again paralyse you and do slightly more brute damage
fix: body snatch clones look more like their originator
tweak: Abductors can no longer use guns (minus their own alien energy gun)
tweak: Sending someone with an abductor teleport via the console will stun them for 3 cycles (doesn't apply with the advanced camera console)
add: Abductors can now purchase additional abductor vests
add: Abductors can lock/unlock vests
tweak: Purchasing supplies from the abductor console will no longer increase the amount of experiments you must do
tweak: Wonderprods will not induce sleep in those who are stunned OR sleeping
tweak: altered the origin tech of abductor tools
add: Can make abductor surgery tables from regular tables by adding silver sheets to an abductor table frame
add: Added a bunch more abductee objectives
tweak: abductors no long scream like girls
/:cl: