### PR TITLE
Dirty surgery rooms more prone to infections and ghetto surgery internal organ disinfection and dead limb revival

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -9,13 +9,21 @@
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list(1,2,3,4,5)
 	volume = 5
-	var/filled = 0
+
+/obj/item/weapon/reagent_containers/dropper/on_reagent_change()
+	update_icon()
+
+/obj/item/weapon/reagent_containers/dropper/update_icon()
+	if(reagents.total_volume<=0)
+		icon_state = "[initial(icon_state)]"
+	else
+		icon_state = "[initial(icon_state)]1"
 
 /obj/item/weapon/reagent_containers/dropper/afterattack(obj/target, mob/user , flag)
 	if(!target.reagents)
 		return
 
-	if(filled)
+	if(reagents.total_volume)
 
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			to_chat(user, "<span class='warning'>[target] is full.</span>")
@@ -51,12 +59,7 @@
 					spawn(5)
 						reagents.reaction(safe_thing, TOUCH)
 
-
-
 					to_chat(user, "<span class='notice'>You transfer [trans] units of the solution.</span>")
-					if(reagents.total_volume<=0)
-						filled = 0
-						icon_state = "[initial(icon_state)]"
 					return
 
 
@@ -80,9 +83,6 @@
 
 		trans = reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution.</span>")
-		if(reagents.total_volume<=0)
-			filled = 0
-			icon_state = "[initial(icon_state)]"
 
 	else
 
@@ -97,9 +97,6 @@
 		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this)
 
 		to_chat(user, "<span class='notice'>You fill [src] with [trans] units of the solution.</span>")
-
-		filled = 1
-		icon_state = "[initial(icon_state)][filled]"
 
 /obj/item/weapon/reagent_containers/dropper/cyborg
 	name = "Industrial Dropper"

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -11,9 +11,6 @@
 	volume = 5
 
 /obj/item/weapon/reagent_containers/dropper/on_reagent_change()
-	update_icon()
-
-/obj/item/weapon/reagent_containers/dropper/update_icon()
 	if(reagents.total_volume <= 0)
 		icon_state = "[initial(icon_state)]"
 	else

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -14,7 +14,7 @@
 	update_icon()
 
 /obj/item/weapon/reagent_containers/dropper/update_icon()
-	if(reagents.total_volume<=0)
+	if(reagents.total_volume <= 0)
 		icon_state = "[initial(icon_state)]"
 	else
 		icon_state = "[initial(icon_state)]1"

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -89,7 +89,7 @@
 	user.visible_message("<span class='notice'> [user] clamps bleeders in [target]'s [affected.name] with \the [tool]</span>.",	\
 	"<span class='notice'> You clamp bleeders in [target]'s [affected.name] with \the [tool].</span>")
 	affected.clamp()
-	spread_germs_to_organ(affected, user)
+	spread_germs_to_organ(affected, user, tool)
 	return 1
 
 /datum/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -108,26 +108,26 @@
 	switch(open)
 		if(0)
 			if(istype(W,/obj/item/weapon/scalpel))
-				spread_germs_to_organ(src,user)
+				spread_germs_to_organ(src,user, W)
 				user.visible_message("<span class='danger'><b>[user]</b> cuts [src] open with [W]!</span>")
 				open++
 				return
 		if(1)
 			if(istype(W,/obj/item/weapon/retractor))
-				spread_germs_to_organ(src,user)
+				spread_germs_to_organ(src,user, W)
 				user.visible_message("<span class='danger'><b>[user]</b> cracks [src] open like an egg with [W]!</span>")
 				open++
 				return
 		if(2)
 			if(istype(W,/obj/item/weapon/hemostat))
-				spread_germs_to_organ(src,user)
+				spread_germs_to_organ(src,user, W)
 				if(contents.len)
 					var/obj/item/removing = pick(contents)
 					var/obj/item/organ/internal/O = removing
 					if(istype(O))
 						O.status |= ORGAN_CUT_AWAY
 						if(!O.sterile)
-							spread_germs_to_organ(O,user) // This wouldn't be any cleaner than the actual surgery
+							spread_germs_to_organ(O,user, W) // This wouldn't be any cleaner than the actual surgery
 					user.put_in_hands(removing)
 					user.visible_message("<span class='danger'><b>[user]</b> extracts [removing] from [src] with [W]!</span>")
 				else

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -182,13 +182,13 @@
 
 	else if(implement_type in implements_mend)
 		current_type = "mend"
-		var/tool_name = " [tool]"
+		var/tool_name = "[tool]"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack))
 			tool_name = "the bandaid"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack/advanced))
 			tool_name = "regenerative membrane"
 		else if(istype(tool, /obj/item/stack/nanopaste))
-			tool_name = " [tool]" //what else do you call nanopaste medically?
+			tool_name = "[tool]" //what else do you call nanopaste medically?
 
 		if(!hasorgans(target))
 			to_chat(user, "They do not have organs to mend!")
@@ -219,13 +219,13 @@
 
 /datum/surgery_step/internal/manipulate_organs/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(current_type == "mend")
-		var/tool_name = " [tool]"
+		var/tool_name = "[tool]"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack/advanced))
 			tool_name = "regenerative membrane"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack))
 			tool_name = "the bandaid"
 		if(istype(tool, /obj/item/stack/nanopaste))
-			tool_name = " [tool]" //what else do you call nanopaste medically?
+			tool_name = "[tool]" //what else do you call nanopaste medically?
 
 		if(!hasorgans(target))
 			return
@@ -361,7 +361,7 @@
 	else if(current_type == "clean")
 		if(!hasorgans(target))
 			return
-		if(!istype(tool,/obj/item/weapon/reagent_containers/))
+		if(!istype(tool,/obj/item/weapon/reagent_containers))
 			return
 
 		var/obj/item/weapon/reagent_containers/C = tool

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -104,25 +104,25 @@
 			return -1
 
 		if(I.damage > (I.max_damage * 0.75))
-			to_chat(user, "<span class='notice'> \The [I] is in no state to be transplanted.</span>")
+			to_chat(user, "<span class='notice'>  [I] is in no state to be transplanted.</span>")
 			return -1
 
 		if(target.get_int_organ(I))
-			to_chat(user, "<span class='warning'> \The [target] already has [I].</span>")
+			to_chat(user, "<span class='warning'>  [target] already has [I].</span>")
 			return -1
 
 		if(affected)
-			user.visible_message("[user] starts transplanting \the [tool] into [target]'s [affected.name].", \
-			"You start transplanting \the [tool] into [target]'s [affected.name].")
+			user.visible_message("[user] starts transplanting  [tool] into [target]'s [affected.name].", \
+			"You start transplanting  [tool] into [target]'s [affected.name].")
 			H.custom_pain("Someone's rooting around in your [affected.name]!",1)
 		else
-			user.visible_message("[user] starts transplanting \the [tool] into [target]'s [parse_zone(target_zone)].", \
-			"You start transplanting \the [tool] into [target]'s [parse_zone(target_zone)].")
+			user.visible_message("[user] starts transplanting  [tool] into [target]'s [parse_zone(target_zone)].", \
+			"You start transplanting  [tool] into [target]'s [parse_zone(target_zone)].")
 
 	else if(implement_type in implements_clean)
 		current_type = "clean"
 
-		if(!istype(tool, /obj/item/weapon/reagent_containers/))
+		if(!istype(tool, /obj/item/weapon/reagent_containers))
 			return
 
 		var/obj/item/weapon/reagent_containers/C = tool
@@ -130,12 +130,12 @@
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
 			if(I)
 				if(C.reagents.total_volume < GHETTO_DISINFECT_AMOUNT)
-					user.visible_message("[user] notices \the [tool] is empty.", \
-					"You notice \the [tool] is empty")
+					user.visible_message("[user] notices  [tool] is empty.", \
+					"You notice  [tool] is empty")
 					return 0
 
-				var/msg = "[user] starts pouring some of \the [tool] over [target]'s [I.name]."
-				var/self_msg = "You start pouring some of \the [tool] over [target]'s [I.name]."
+				var/msg = "[user] starts pouring some of  [tool] over [target]'s [I.name]."
+				var/self_msg = "You start pouring some of  [tool] over [target]'s [I.name]."
 				user.visible_message(msg, self_msg)
 				if(H && affected)
 					H.custom_pain("Something burns horribly in your [affected.name]!",1)
@@ -145,12 +145,12 @@
 		current_type = "finish"
 
 		if(affected && affected.encased)
-			var/msg = "[user] starts bending [target]'s [affected.encased] back into place with \the [tool]."
-			var/self_msg = "You start bending [target]'s [affected.encased] back into place with \the [tool]."
+			var/msg = "[user] starts bending [target]'s [affected.encased] back into place with  [tool]."
+			var/self_msg = "You start bending [target]'s [affected.encased] back into place with  [tool]."
 			user.visible_message(msg, self_msg)
 		else
-			var/msg = "[user] starts pulling [target]'s skin back into place with \the [tool]."
-			var/self_msg = "You start pulling [target]'s skin back into place with \the [tool]."
+			var/msg = "[user] starts pulling [target]'s skin back into place with  [tool]."
+			var/self_msg = "You start pulling [target]'s skin back into place with  [tool]."
 			user.visible_message(msg, self_msg)
 
 		if(H && affected)
@@ -173,8 +173,8 @@
 			I = organs[I]
 			if(!I)
 				return -1
-			user.visible_message("[user] starts to separate [target]'s [I] with \the [tool].", \
-			"You start to separate [target]'s [I] with \the [tool] for removal." )
+			user.visible_message("[user] starts to separate [target]'s [I] with  [tool].", \
+			"You start to separate [target]'s [I] with  [tool] for removal." )
 			if(H && affected)
 				H.custom_pain("The pain in your [affected.name] is living hell!",1)
 		else
@@ -182,13 +182,13 @@
 
 	else if(implement_type in implements_mend)
 		current_type = "mend"
-		var/tool_name = "\the [tool]"
+		var/tool_name = " [tool]"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack))
 			tool_name = "the bandaid"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack/advanced))
 			tool_name = "regenerative membrane"
 		else if(istype(tool, /obj/item/stack/nanopaste))
-			tool_name = "\the [tool]" //what else do you call nanopaste medically?
+			tool_name = " [tool]" //what else do you call nanopaste medically?
 
 		if(!hasorgans(target))
 			to_chat(user, "They do not have organs to mend!")
@@ -219,13 +219,13 @@
 
 /datum/surgery_step/internal/manipulate_organs/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(current_type == "mend")
-		var/tool_name = "\the [tool]"
+		var/tool_name = " [tool]"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack/advanced))
 			tool_name = "regenerative membrane"
 		if(istype(tool, /obj/item/stack/medical/bruise_pack))
 			tool_name = "the bandaid"
 		if(istype(tool, /obj/item/stack/nanopaste))
-			tool_name = "\the [tool]" //what else do you call nanopaste medically?
+			tool_name = " [tool]" //what else do you call nanopaste medically?
 
 		if(!hasorgans(target))
 			return
@@ -253,18 +253,18 @@
 			return 0
 
 		if(affected)
-			user.visible_message("<span class='notice'> [user] has transplanted \the [tool] into [target]'s [affected.name].</span>",
-			"<span class='notice'> You have transplanted \the [tool] into [target]'s [affected.name].</span>")
+			user.visible_message("<span class='notice'> [user] has transplanted  [tool] into [target]'s [affected.name].</span>",
+			"<span class='notice'> You have transplanted  [tool] into [target]'s [affected.name].</span>")
 		else
-			user.visible_message("<span class='notice'> [user] has transplanted \the [tool] into [target]'s [parse_zone(target_zone)].</span>",
-			"<span class='notice'> You have transplanted \the [tool] into [target]'s [parse_zone(target_zone)].</span>")
+			user.visible_message("<span class='notice'> [user] has transplanted  [tool] into [target]'s [parse_zone(target_zone)].</span>",
+			"<span class='notice'> You have transplanted  [tool] into [target]'s [parse_zone(target_zone)].</span>")
 
 		I.status &= ~ORGAN_CUT_AWAY
 
 	else if(current_type == "extract")
 		if(I && I.owner == target)
-			user.visible_message("<span class='notice'> [user] has separated and extracts [target]'s [I] with \the [tool].</span>",
-			"<span class='notice'> You have separated and extracted [target]'s [I] with \the [tool].</span>")
+			user.visible_message("<span class='notice'> [user] has separated and extracts [target]'s [I] with  [tool].</span>",
+			"<span class='notice'> You have separated and extracted [target]'s [I] with  [tool].</span>")
 
 			add_logs(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			spread_germs_to_organ(I, user, tool)
@@ -283,7 +283,7 @@
 	else if(current_type == "clean")
 		if(!hasorgans(target))
 			return
-		if(!istype(tool,/obj/item/weapon/reagent_containers/))
+		if(!istype(tool,/obj/item/weapon/reagent_containers))
 			return
 
 		var/obj/item/weapon/reagent_containers/C = tool
@@ -298,28 +298,27 @@
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
 			if(I)
 				if(R.total_volume < GHETTO_DISINFECT_AMOUNT)
-					user.visible_message("[user] notices there is not enough of \the [tool].", \
-					"You notice there is not enough of \the [tool].")
+					user.visible_message("[user] notices there is not enough of  [tool].", \
+					"You notice there is not enough of  [tool].")
 					return 0
 				if(I.germ_level < INFECTION_LEVEL_ONE / 2)
 					to_chat(user, "[I] does not appear to be infected.")
 				if(I.germ_level >= INFECTION_LEVEL_ONE / 2)
-					I.surgeryize()//is this even needed?
 					I.germ_level = max(I.germ_level-ethanol, 0)
-					user.visible_message("<span class='notice'> [user] has poured some of \the [tool] over [target]'s [I.name].</span>",
-					"<span class='notice'> You have poured some of \the [tool] over [target]'s [I.name].</span>")
+					user.visible_message("<span class='notice'> [user] has poured some of  [tool] over [target]'s [I.name].</span>",
+					"<span class='notice'> You have poured some of  [tool] over [target]'s [I.name].</span>")
 					R.trans_to(target, GHETTO_DISINFECT_AMOUNT)
 					R.reaction(target, INGEST)
 
 	else if(current_type == "finish")
 		if(affected && affected.encased)
-			var/msg = "<span class='notice'> [user] bends [target]'s [affected.encased] back into place with \the [tool].</span>"
-			var/self_msg = "<span class='notice'> You bend [target]'s [affected.encased] back into place with \the [tool].</span>"
+			var/msg = "<span class='notice'> [user] bends [target]'s [affected.encased] back into place with  [tool].</span>"
+			var/self_msg = "<span class='notice'> You bend [target]'s [affected.encased] back into place with  [tool].</span>"
 			user.visible_message(msg, self_msg)
 			affected.open = 2.5
 		else
-			var/msg = "<span class='notice'>[user] pulls [target]'s flesh back into place with \the [tool].</span>"
-			var/self_msg = "<span class='notice'>You pull [target]'s flesh back into place with \the [tool].</span>"
+			var/msg = "<span class='notice'>[user] pulls [target]'s flesh back into place with  [tool].</span>"
+			var/self_msg = "<span class='notice'>You pull [target]'s flesh back into place with  [tool].</span>"
 			user.visible_message(msg, self_msg)
 
 		return 1
@@ -331,8 +330,8 @@
 		if(!hasorgans(target))
 			return
 
-		user.visible_message("<span class='warning'> [user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!</span>", \
-		"<span class='warning'> Your hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!</span>")
+		user.visible_message("<span class='warning'> [user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with  [tool]!</span>", \
+		"<span class='warning'> Your hand slips, getting mess and tearing the inside of [target]'s [affected.name] with  [tool]!</span>")
 
 		var/dam_amt = 2
 
@@ -351,8 +350,8 @@
 		return 0
 
 	else if(current_type == "insert")
-		user.visible_message("<span class='warning'> [user]'s hand slips, damaging \the [tool]!</span>", \
-		"<span class='warning'> Your hand slips, damaging \the [tool]!</span>")
+		user.visible_message("<span class='warning'> [user]'s hand slips, damaging  [tool]!</span>", \
+		"<span class='warning'> Your hand slips, damaging  [tool]!</span>")
 		var/obj/item/organ/internal/I = tool
 		if(istype(I) && !I.tough)
 			I.take_damage(rand(3,5),0)
@@ -381,19 +380,19 @@
 		R.trans_to(target, GHETTO_DISINFECT_AMOUNT * 10)
 		R.reaction(target, INGEST)
 
-		user.visible_message("<span class='warning'> [user]'s hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>", \
-		"<span class='warning'> Your hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>")
+		user.visible_message("<span class='warning'> [user]'s hand slips, splashing the contents of  [tool] all over [target]'s [affected.name] incision!</span>", \
+		"<span class='warning'> Your hand slips, splashing the contents of  [tool] all over [target]'s [affected.name] incision!</span>")
 		return 0
 
 	else if(current_type == "extract")
 		if(I && I.owner == target)
 			if(affected)
-				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>", \
-				"<span class='warning'> Your hand slips, damaging [target]'s [affected.name] with \the [tool]!</span>")
+				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [affected.name] with  [tool]!</span>", \
+				"<span class='warning'> Your hand slips, damaging [target]'s [affected.name] with  [tool]!</span>")
 				affected.createwound(BRUISE, 20)
 			else
-				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [parse_zone(target_zone)] with \the [tool]!</span>", \
-				"<span class='warning'> Your hand slips, damaging [target]'s [parse_zone(target_zone)] with \the [tool]!</span>")
+				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [parse_zone(target_zone)] with  [tool]!</span>", \
+				"<span class='warning'> Your hand slips, damaging [target]'s [parse_zone(target_zone)] with  [tool]!</span>")
 		else
 			user.visible_message("[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
 				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
@@ -434,20 +433,20 @@
 
 /datum/surgery_step/saw_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("[user] begins to cut through [target]'s [target_zone] with \the [tool].", \
-	"You begin to cut through [target]'s [target_zone] with \the [tool].")
+	user.visible_message("[user] begins to cut through [target]'s [target_zone] with  [tool].", \
+	"You begin to cut through [target]'s [target_zone] with  [tool].")
 	..()
 
 /datum/surgery_step/saw_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='notice'> [user] has cut [target]'s [target_zone] open with \the [tool].</span>",		\
-	"<span class='notice'> You have cut [target]'s [target_zone] open with \the [tool].</span>")
+	user.visible_message("<span class='notice'> [user] has cut [target]'s [target_zone] open with  [tool].</span>",		\
+	"<span class='notice'> You have cut [target]'s [target_zone] open with  [tool].</span>")
 	return 1
 
 /datum/surgery_step/saw_carapace/fail_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='warning'> [user]'s hand slips, cracking [target]'s [target_zone] with \the [tool]!</span>" , \
-	"<span class='warning'> Your hand slips, cracking [target]'s [target_zone] with \the [tool]!</span>" )
+	user.visible_message("<span class='warning'> [user]'s hand slips, cracking [target]'s [target_zone] with  [tool]!</span>" , \
+	"<span class='warning'> Your hand slips, cracking [target]'s [target_zone] with  [tool]!</span>" )
 	return 0
 
 /datum/surgery_step/cut_carapace
@@ -471,20 +470,20 @@
 
 /datum/surgery_step/cut_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("[user] starts the incision on [target]'s [target_zone] with \the [tool].", \
-	"You start the incision on [target]'s [target_zone] with \the [tool].")
+	user.visible_message("[user] starts the incision on [target]'s [target_zone] with  [tool].", \
+	"You start the incision on [target]'s [target_zone] with  [tool].")
 	..()
 
 /datum/surgery_step/cut_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='notice'> [user] has made an incision on [target]'s [target_zone] with \the [tool].</span>", \
-	"<span class='notice'> You have made an incision on [target]'s [target_zone] with \the [tool].</span>",)
+	user.visible_message("<span class='notice'> [user] has made an incision on [target]'s [target_zone] with  [tool].</span>", \
+	"<span class='notice'> You have made an incision on [target]'s [target_zone] with  [tool].</span>",)
 	return 1
 
 /datum/surgery_step/cut_carapace/fail_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='warning'> [user]'s hand slips, slicing open [target]'s [target_zone] in a wrong spot with \the [tool]!</span>", \
-	"<span class='warning'> Your hand slips, slicing open [target]'s [target_zone] in a wrong spot with \the [tool]!</span>")
+	user.visible_message("<span class='warning'> [user]'s hand slips, slicing open [target]'s [target_zone] in a wrong spot with  [tool]!</span>", \
+	"<span class='warning'> Your hand slips, slicing open [target]'s [target_zone] in a wrong spot with  [tool]!</span>")
 	return 0
 
 /datum/surgery_step/retract_carapace
@@ -500,37 +499,37 @@
 	time = 24
 
 /datum/surgery_step/retract_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/msg = "[user] starts to pry open the incision on [target]'s [target_zone] with \the [tool]."
-	var/self_msg = "You start to pry open the incision on [target]'s [target_zone] with \the [tool]."
+	var/msg = "[user] starts to pry open the incision on [target]'s [target_zone] with  [tool]."
+	var/self_msg = "You start to pry open the incision on [target]'s [target_zone] with  [tool]."
 	if(target_zone == "chest")
-		msg = "[user] starts to separate the ribcage and rearrange the organs in [target]'s torso with \the [tool]."
-		self_msg = "You start to separate the ribcage and rearrange the organs in [target]'s torso with \the [tool]."
+		msg = "[user] starts to separate the ribcage and rearrange the organs in [target]'s torso with  [tool]."
+		self_msg = "You start to separate the ribcage and rearrange the organs in [target]'s torso with  [tool]."
 	if(target_zone == "groin")
-		msg = "[user] starts to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
-		self_msg = "You start to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
+		msg = "[user] starts to pry open the incision and rearrange the organs in [target]'s lower abdomen with  [tool]."
+		self_msg = "You start to pry open the incision and rearrange the organs in [target]'s lower abdomen with  [tool]."
 	user.visible_message(msg, self_msg)
 	..()
 
 /datum/surgery_step/retract_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/msg = "<span class='notice'> [user] keeps the incision open on [target]'s [target_zone] with \the [tool]</span>."
-	var/self_msg = "<span class='notice'> You keep the incision open on [target]'s [target_zone] with \the [tool].</span>"
+	var/msg = "<span class='notice'> [user] keeps the incision open on [target]'s [target_zone] with  [tool]</span>."
+	var/self_msg = "<span class='notice'> You keep the incision open on [target]'s [target_zone] with  [tool].</span>"
 	if(target_zone == "chest")
-		msg = "<span class='notice'> [user] keeps the ribcage open on [target]'s torso with \the [tool].</span>"
-		self_msg = "<span class='notice'> You keep the ribcage open on [target]'s torso with \the [tool].</span>"
+		msg = "<span class='notice'> [user] keeps the ribcage open on [target]'s torso with  [tool].</span>"
+		self_msg = "<span class='notice'> You keep the ribcage open on [target]'s torso with  [tool].</span>"
 	if(target_zone == "groin")
-		msg = "<span class='notice'> [user] keeps the incision open on [target]'s lower abdomen with \the [tool].</span>"
-		self_msg = "<span class='notice'> You keep the incision open on [target]'s lower abdomen with \the [tool].</span>"
+		msg = "<span class='notice'> [user] keeps the incision open on [target]'s lower abdomen with  [tool].</span>"
+		self_msg = "<span class='notice'> You keep the incision open on [target]'s lower abdomen with  [tool].</span>"
 	user.visible_message(msg, self_msg)
 	return 1
 
 /datum/surgery_step/generic/retract_carapace/fail_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/msg = "<span class='warning'> [user]'s hand slips, tearing the edges of incision on [target]'s [target_zone] with \the [tool]!</span>"
-	var/self_msg = "<span class='warning'> Your hand slips, tearing the edges of incision on [target]'s [target_zone] with \the [tool]!</span>"
+	var/msg = "<span class='warning'> [user]'s hand slips, tearing the edges of incision on [target]'s [target_zone] with  [tool]!</span>"
+	var/self_msg = "<span class='warning'> Your hand slips, tearing the edges of incision on [target]'s [target_zone] with  [tool]!</span>"
 	if(target_zone == "chest")
-		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s torso with \the [tool]!</span>"
-		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s torso with \the [tool]!</span>"
+		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s torso with  [tool]!</span>"
+		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s torso with  [tool]!</span>"
 	if(target_zone == "groin")
-		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s lower abdomen with \the [tool]</span>"
-		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s lower abdomen with \the [tool]!</span>"
+		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s lower abdomen with  [tool]</span>"
+		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s lower abdomen with  [tool]!</span>"
 	user.visible_message(msg, self_msg)
 	return 0

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -1,3 +1,5 @@
+#define GHETTO_DISINFECT_AMOUNT 5 //Amount of units to transfer from the container to the organs during ghetto surgery disinfection step
+
 /datum/surgery/organ_manipulation
 	name = "Organ Manipulation"
 	steps = list(/datum/surgery_step/generic/cut_open,/datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/open_encased/saw,
@@ -68,6 +70,13 @@
 	allowed_tools = list(/obj/item/organ/internal = 100, /obj/item/weapon/reagent_containers/food/snacks/organ = 0)
 	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/kitchen/utensil/fork = 55)
 	var/implements_mend = list(/obj/item/stack/medical/bruise_pack = 20,/obj/item/stack/medical/bruise_pack/advanced = 100,/obj/item/stack/nanopaste = 100)
+	var/implements_clean = list(/obj/item/weapon/reagent_containers/dropper = 100,
+								/obj/item/weapon/reagent_containers/glass/bottle = 75,
+								/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
+								/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
+								/obj/item/weapon/reagent_containers/glass/beaker = 60,
+								/obj/item/weapon/reagent_containers/spray = 50,
+								/obj/item/weapon/reagent_containers/glass/bucket = 40)
 	//Finish is just so you can close up after you do other things.
 	var/implements_finsh = list(/obj/item/weapon/scalpel/manager = 120,/obj/item/weapon/retractor = 100 ,/obj/item/weapon/crowbar = 75)
 	var/current_type
@@ -77,7 +86,7 @@
 
 /datum/surgery_step/internal/manipulate_organs/New()
 	..()
-	allowed_tools = allowed_tools + implements_extract + implements_mend + implements_finsh
+	allowed_tools = allowed_tools + implements_extract + implements_mend + implements_clean + implements_finsh
 
 
 /datum/surgery_step/internal/manipulate_organs/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -109,6 +118,27 @@
 		else
 			user.visible_message("[user] starts transplanting \the [tool] into [target]'s [parse_zone(target_zone)].", \
 			"You start transplanting \the [tool] into [target]'s [parse_zone(target_zone)].")
+
+	else if(implement_type in implements_clean)
+		current_type = "clean"
+
+		if(!istype(tool, /obj/item/weapon/reagent_containers/))
+			return
+
+		var/obj/item/weapon/reagent_containers/C = tool
+
+		for(var/obj/item/organ/internal/I in affected.internal_organs)
+			if(I)
+				if(C.reagents.total_volume < GHETTO_DISINFECT_AMOUNT)
+					user.visible_message("[user] notices \the [tool] is empty.", \
+					"You notice \the [tool] is empty")
+					return 0
+
+				var/msg = "[user] starts pouring some of \the [tool] over [target]'s [I.name]."
+				var/self_msg = "You start pouring some of \the [tool] over [target]'s [I.name]."
+				user.visible_message(msg, self_msg)
+				if(H && affected)
+					H.custom_pain("Something burns horribly in your [affected.name]!",1)
 
 	else if(implement_type in implements_finsh)
 	//same as surgery step /datum/surgery_step/open_encased/close/
@@ -168,7 +198,7 @@
 			if(I && I.damage > 0)
 				if(I.robotic < 2 && !istype (tool, /obj/item/stack/nanopaste))
 					if(!(I.sterile))
-						spread_germs_to_organ(I, user)
+						spread_germs_to_organ(I, user, tool)
 					user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 					"You start treating damage to [target]'s [I.name] with [tool_name]." )
 				else if(I.robotic >= 2 && istype(tool, /obj/item/stack/nanopaste))
@@ -217,7 +247,7 @@
 		I = tool
 		user.drop_item()
 		I.insert(target)
-		spread_germs_to_organ(I, user)
+		spread_germs_to_organ(I, user, tool)
 		if(!user.canUnEquip(I, 0))
 			to_chat(user, "<span class='warning'>[I] is stuck to your hand, you can't put it in [target]!</span>")
 			return 0
@@ -237,7 +267,7 @@
 			"<span class='notice'> You have separated and extracted [target]'s [I] with \the [tool].</span>")
 
 			add_logs(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
-			spread_germs_to_organ(I, user)
+			spread_germs_to_organ(I, user, tool)
 			I.status |= ORGAN_CUT_AWAY
 			var/obj/item/thing = I.remove(target)
 			if(!istype(thing))
@@ -249,6 +279,37 @@
 		else
 			user.visible_message("<span class='notice'>[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!</span>",
 				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
+
+	else if(current_type == "clean")
+		if(!hasorgans(target))
+			return
+		if(!istype(tool,/obj/item/weapon/reagent_containers/))
+			return
+
+		var/obj/item/weapon/reagent_containers/C = tool
+		var/datum/reagents/R = C.reagents
+		var/ethanol = 0 //how much alcohol is in the thing
+
+		if(R.reagent_list.len)
+			for(var/datum/reagent/consumable/ethanol/alcohol in R.reagent_list)
+				ethanol += alcohol.alcohol_perc * 300
+			ethanol /= R.reagent_list.len
+
+		for(var/obj/item/organ/internal/I in affected.internal_organs)
+			if(I)
+				if(R.total_volume < GHETTO_DISINFECT_AMOUNT)
+					user.visible_message("[user] notices there is not enough of \the [tool].", \
+					"You notice there is not enough of \the [tool].")
+					return 0
+				if(I.germ_level < INFECTION_LEVEL_ONE / 2)
+					to_chat(user, "[I] does not appear to be infected.")
+				if(I.germ_level >= INFECTION_LEVEL_ONE / 2)
+					I.surgeryize()//is this even needed?
+					I.germ_level = max(I.germ_level-ethanol, 0)
+					user.visible_message("<span class='notice'> [user] has poured some of \the [tool] over [target]'s [I.name].</span>",
+					"<span class='notice'> You have poured some of \the [tool] over [target]'s [I.name].</span>")
+					R.trans_to(target, GHETTO_DISINFECT_AMOUNT)
+					R.reaction(target, INGEST)
 
 	else if(current_type == "finish")
 		if(affected && affected.encased)
@@ -262,7 +323,6 @@
 			user.visible_message(msg, self_msg)
 
 		return 1
-
 
 	return 0
 
@@ -299,6 +359,31 @@
 
 		return 0
 
+	else if(current_type == "clean")
+		if(!hasorgans(target))
+			return
+		if(!istype(tool,/obj/item/weapon/reagent_containers/))
+			return
+
+		var/obj/item/weapon/reagent_containers/C = tool
+		var/datum/reagents/R = C.reagents
+		var/ethanol = 0 //how much alcohol is in the thing
+
+		if(R.reagent_list.len)
+			for(var/datum/reagent/consumable/ethanol/alcohol in R.reagent_list)
+				ethanol += alcohol.alcohol_perc * 300
+			ethanol /= C.reagents.reagent_list.len
+
+		for(var/obj/item/organ/internal/I in affected.internal_organs)
+			I.germ_level = max(I.germ_level-ethanol, 0)
+			I.take_damage(rand(4,8),0)
+
+		R.trans_to(target, GHETTO_DISINFECT_AMOUNT * 10)
+		R.reaction(target, INGEST)
+
+		user.visible_message("<span class='warning'> [user]'s hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>", \
+		"<span class='warning'> Your hand slips, splashing the contents of \the [tool] all over [target]'s [affected.name] incision!</span>")
+		return 0
 
 	else if(current_type == "extract")
 		if(I && I.owner == target)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -104,20 +104,20 @@
 			return -1
 
 		if(I.damage > (I.max_damage * 0.75))
-			to_chat(user, "<span class='notice'>  [I] is in no state to be transplanted.</span>")
+			to_chat(user, "<span class='notice'> [I] is in no state to be transplanted.</span>")
 			return -1
 
 		if(target.get_int_organ(I))
-			to_chat(user, "<span class='warning'>  [target] already has [I].</span>")
+			to_chat(user, "<span class='warning'> [target] already has [I].</span>")
 			return -1
 
 		if(affected)
-			user.visible_message("[user] starts transplanting  [tool] into [target]'s [affected.name].", \
-			"You start transplanting  [tool] into [target]'s [affected.name].")
+			user.visible_message("[user] starts transplanting [tool] into [target]'s [affected.name].", \
+			"You start transplanting [tool] into [target]'s [affected.name].")
 			H.custom_pain("Someone's rooting around in your [affected.name]!",1)
 		else
-			user.visible_message("[user] starts transplanting  [tool] into [target]'s [parse_zone(target_zone)].", \
-			"You start transplanting  [tool] into [target]'s [parse_zone(target_zone)].")
+			user.visible_message("[user] starts transplanting [tool] into [target]'s [parse_zone(target_zone)].", \
+			"You start transplanting [tool] into [target]'s [parse_zone(target_zone)].")
 
 	else if(implement_type in implements_clean)
 		current_type = "clean"
@@ -130,12 +130,12 @@
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
 			if(I)
 				if(C.reagents.total_volume < GHETTO_DISINFECT_AMOUNT)
-					user.visible_message("[user] notices  [tool] is empty.", \
-					"You notice  [tool] is empty")
+					user.visible_message("[user] notices [tool] is empty.", \
+					"You notice [tool] is empty")
 					return 0
 
-				var/msg = "[user] starts pouring some of  [tool] over [target]'s [I.name]."
-				var/self_msg = "You start pouring some of  [tool] over [target]'s [I.name]."
+				var/msg = "[user] starts pouring some of [tool] over [target]'s [I.name]."
+				var/self_msg = "You start pouring some of [tool] over [target]'s [I.name]."
 				user.visible_message(msg, self_msg)
 				if(H && affected)
 					H.custom_pain("Something burns horribly in your [affected.name]!",1)
@@ -145,12 +145,12 @@
 		current_type = "finish"
 
 		if(affected && affected.encased)
-			var/msg = "[user] starts bending [target]'s [affected.encased] back into place with  [tool]."
-			var/self_msg = "You start bending [target]'s [affected.encased] back into place with  [tool]."
+			var/msg = "[user] starts bending [target]'s [affected.encased] back into place with [tool]."
+			var/self_msg = "You start bending [target]'s [affected.encased] back into place with [tool]."
 			user.visible_message(msg, self_msg)
 		else
-			var/msg = "[user] starts pulling [target]'s skin back into place with  [tool]."
-			var/self_msg = "You start pulling [target]'s skin back into place with  [tool]."
+			var/msg = "[user] starts pulling [target]'s skin back into place with [tool]."
+			var/self_msg = "You start pulling [target]'s skin back into place with [tool]."
 			user.visible_message(msg, self_msg)
 
 		if(H && affected)
@@ -173,8 +173,8 @@
 			I = organs[I]
 			if(!I)
 				return -1
-			user.visible_message("[user] starts to separate [target]'s [I] with  [tool].", \
-			"You start to separate [target]'s [I] with  [tool] for removal." )
+			user.visible_message("[user] starts to separate [target]'s [I] with [tool].", \
+			"You start to separate [target]'s [I] with [tool] for removal." )
 			if(H && affected)
 				H.custom_pain("The pain in your [affected.name] is living hell!",1)
 		else
@@ -253,18 +253,18 @@
 			return 0
 
 		if(affected)
-			user.visible_message("<span class='notice'> [user] has transplanted  [tool] into [target]'s [affected.name].</span>",
-			"<span class='notice'> You have transplanted  [tool] into [target]'s [affected.name].</span>")
+			user.visible_message("<span class='notice'> [user] has transplanted [tool] into [target]'s [affected.name].</span>",
+			"<span class='notice'> You have transplanted [tool] into [target]'s [affected.name].</span>")
 		else
-			user.visible_message("<span class='notice'> [user] has transplanted  [tool] into [target]'s [parse_zone(target_zone)].</span>",
-			"<span class='notice'> You have transplanted  [tool] into [target]'s [parse_zone(target_zone)].</span>")
+			user.visible_message("<span class='notice'> [user] has transplanted [tool] into [target]'s [parse_zone(target_zone)].</span>",
+			"<span class='notice'> You have transplanted [tool] into [target]'s [parse_zone(target_zone)].</span>")
 
 		I.status &= ~ORGAN_CUT_AWAY
 
 	else if(current_type == "extract")
 		if(I && I.owner == target)
-			user.visible_message("<span class='notice'> [user] has separated and extracts [target]'s [I] with  [tool].</span>",
-			"<span class='notice'> You have separated and extracted [target]'s [I] with  [tool].</span>")
+			user.visible_message("<span class='notice'> [user] has separated and extracts [target]'s [I] with [tool].</span>",
+			"<span class='notice'> You have separated and extracted [target]'s [I] with [tool].</span>")
 
 			add_logs(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			spread_germs_to_organ(I, user, tool)
@@ -298,27 +298,27 @@
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
 			if(I)
 				if(R.total_volume < GHETTO_DISINFECT_AMOUNT)
-					user.visible_message("[user] notices there is not enough of  [tool].", \
-					"You notice there is not enough of  [tool].")
+					user.visible_message("[user] notices there is not enough of [tool].", \
+					"You notice there is not enough of [tool].")
 					return 0
 				if(I.germ_level < INFECTION_LEVEL_ONE / 2)
 					to_chat(user, "[I] does not appear to be infected.")
 				if(I.germ_level >= INFECTION_LEVEL_ONE / 2)
 					I.germ_level = max(I.germ_level-ethanol, 0)
-					user.visible_message("<span class='notice'> [user] has poured some of  [tool] over [target]'s [I.name].</span>",
-					"<span class='notice'> You have poured some of  [tool] over [target]'s [I.name].</span>")
+					user.visible_message("<span class='notice'> [user] has poured some of [tool] over [target]'s [I.name].</span>",
+					"<span class='notice'> You have poured some of [tool] over [target]'s [I.name].</span>")
 					R.trans_to(target, GHETTO_DISINFECT_AMOUNT)
 					R.reaction(target, INGEST)
 
 	else if(current_type == "finish")
 		if(affected && affected.encased)
-			var/msg = "<span class='notice'> [user] bends [target]'s [affected.encased] back into place with  [tool].</span>"
-			var/self_msg = "<span class='notice'> You bend [target]'s [affected.encased] back into place with  [tool].</span>"
+			var/msg = "<span class='notice'> [user] bends [target]'s [affected.encased] back into place with [tool].</span>"
+			var/self_msg = "<span class='notice'> You bend [target]'s [affected.encased] back into place with [tool].</span>"
 			user.visible_message(msg, self_msg)
 			affected.open = 2.5
 		else
-			var/msg = "<span class='notice'>[user] pulls [target]'s flesh back into place with  [tool].</span>"
-			var/self_msg = "<span class='notice'>You pull [target]'s flesh back into place with  [tool].</span>"
+			var/msg = "<span class='notice'>[user] pulls [target]'s flesh back into place with [tool].</span>"
+			var/self_msg = "<span class='notice'>You pull [target]'s flesh back into place with [tool].</span>"
 			user.visible_message(msg, self_msg)
 
 		return 1
@@ -330,8 +330,8 @@
 		if(!hasorgans(target))
 			return
 
-		user.visible_message("<span class='warning'> [user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with  [tool]!</span>", \
-		"<span class='warning'> Your hand slips, getting mess and tearing the inside of [target]'s [affected.name] with  [tool]!</span>")
+		user.visible_message("<span class='warning'> [user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with [tool]!</span>", \
+		"<span class='warning'> Your hand slips, getting mess and tearing the inside of [target]'s [affected.name] with [tool]!</span>")
 
 		var/dam_amt = 2
 
@@ -350,8 +350,8 @@
 		return 0
 
 	else if(current_type == "insert")
-		user.visible_message("<span class='warning'> [user]'s hand slips, damaging  [tool]!</span>", \
-		"<span class='warning'> Your hand slips, damaging  [tool]!</span>")
+		user.visible_message("<span class='warning'> [user]'s hand slips, damaging [tool]!</span>", \
+		"<span class='warning'> Your hand slips, damaging [tool]!</span>")
 		var/obj/item/organ/internal/I = tool
 		if(istype(I) && !I.tough)
 			I.take_damage(rand(3,5),0)
@@ -380,19 +380,19 @@
 		R.trans_to(target, GHETTO_DISINFECT_AMOUNT * 10)
 		R.reaction(target, INGEST)
 
-		user.visible_message("<span class='warning'> [user]'s hand slips, splashing the contents of  [tool] all over [target]'s [affected.name] incision!</span>", \
-		"<span class='warning'> Your hand slips, splashing the contents of  [tool] all over [target]'s [affected.name] incision!</span>")
+		user.visible_message("<span class='warning'> [user]'s hand slips, splashing the contents of [tool] all over [target]'s [affected.name] incision!</span>", \
+		"<span class='warning'> Your hand slips, splashing the contents of [tool] all over [target]'s [affected.name] incision!</span>")
 		return 0
 
 	else if(current_type == "extract")
 		if(I && I.owner == target)
 			if(affected)
-				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [affected.name] with  [tool]!</span>", \
-				"<span class='warning'> Your hand slips, damaging [target]'s [affected.name] with  [tool]!</span>")
+				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [affected.name] with [tool]!</span>", \
+				"<span class='warning'> Your hand slips, damaging [target]'s [affected.name] with [tool]!</span>")
 				affected.createwound(BRUISE, 20)
 			else
-				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [parse_zone(target_zone)] with  [tool]!</span>", \
-				"<span class='warning'> Your hand slips, damaging [target]'s [parse_zone(target_zone)] with  [tool]!</span>")
+				user.visible_message("<span class='warning'> [user]'s hand slips, damaging [target]'s [parse_zone(target_zone)] with [tool]!</span>", \
+				"<span class='warning'> Your hand slips, damaging [target]'s [parse_zone(target_zone)] with [tool]!</span>")
 		else
 			user.visible_message("[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
 				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
@@ -433,20 +433,20 @@
 
 /datum/surgery_step/saw_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("[user] begins to cut through [target]'s [target_zone] with  [tool].", \
-	"You begin to cut through [target]'s [target_zone] with  [tool].")
+	user.visible_message("[user] begins to cut through [target]'s [target_zone] with [tool].", \
+	"You begin to cut through [target]'s [target_zone] with [tool].")
 	..()
 
 /datum/surgery_step/saw_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='notice'> [user] has cut [target]'s [target_zone] open with  [tool].</span>",		\
-	"<span class='notice'> You have cut [target]'s [target_zone] open with  [tool].</span>")
+	user.visible_message("<span class='notice'> [user] has cut [target]'s [target_zone] open with [tool].</span>",		\
+	"<span class='notice'> You have cut [target]'s [target_zone] open with [tool].</span>")
 	return 1
 
 /datum/surgery_step/saw_carapace/fail_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='warning'> [user]'s hand slips, cracking [target]'s [target_zone] with  [tool]!</span>" , \
-	"<span class='warning'> Your hand slips, cracking [target]'s [target_zone] with  [tool]!</span>" )
+	user.visible_message("<span class='warning'> [user]'s hand slips, cracking [target]'s [target_zone] with [tool]!</span>" , \
+	"<span class='warning'> Your hand slips, cracking [target]'s [target_zone] with [tool]!</span>" )
 	return 0
 
 /datum/surgery_step/cut_carapace
@@ -463,27 +463,27 @@
 	/obj/item/weapon/twohanded/chainsaw = 1, \
 	/obj/item/weapon/claymore = 5, \
 	/obj/item/weapon/melee/energy/ = 5, \
-	/obj/item/weapon/pen/edagger = 5,  \
+	/obj/item/weapon/pen/edagger = 5, \
 	)
 
 	time = 16
 
 /datum/surgery_step/cut_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("[user] starts the incision on [target]'s [target_zone] with  [tool].", \
-	"You start the incision on [target]'s [target_zone] with  [tool].")
+	user.visible_message("[user] starts the incision on [target]'s [target_zone] with [tool].", \
+	"You start the incision on [target]'s [target_zone] with [tool].")
 	..()
 
 /datum/surgery_step/cut_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='notice'> [user] has made an incision on [target]'s [target_zone] with  [tool].</span>", \
-	"<span class='notice'> You have made an incision on [target]'s [target_zone] with  [tool].</span>",)
+	user.visible_message("<span class='notice'> [user] has made an incision on [target]'s [target_zone] with [tool].</span>", \
+	"<span class='notice'> You have made an incision on [target]'s [target_zone] with [tool].</span>",)
 	return 1
 
 /datum/surgery_step/cut_carapace/fail_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 
-	user.visible_message("<span class='warning'> [user]'s hand slips, slicing open [target]'s [target_zone] in a wrong spot with  [tool]!</span>", \
-	"<span class='warning'> Your hand slips, slicing open [target]'s [target_zone] in a wrong spot with  [tool]!</span>")
+	user.visible_message("<span class='warning'> [user]'s hand slips, slicing open [target]'s [target_zone] in a wrong spot with [tool]!</span>", \
+	"<span class='warning'> Your hand slips, slicing open [target]'s [target_zone] in a wrong spot with [tool]!</span>")
 	return 0
 
 /datum/surgery_step/retract_carapace
@@ -499,37 +499,37 @@
 	time = 24
 
 /datum/surgery_step/retract_carapace/begin_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/msg = "[user] starts to pry open the incision on [target]'s [target_zone] with  [tool]."
-	var/self_msg = "You start to pry open the incision on [target]'s [target_zone] with  [tool]."
+	var/msg = "[user] starts to pry open the incision on [target]'s [target_zone] with [tool]."
+	var/self_msg = "You start to pry open the incision on [target]'s [target_zone] with [tool]."
 	if(target_zone == "chest")
-		msg = "[user] starts to separate the ribcage and rearrange the organs in [target]'s torso with  [tool]."
-		self_msg = "You start to separate the ribcage and rearrange the organs in [target]'s torso with  [tool]."
+		msg = "[user] starts to separate the ribcage and rearrange the organs in [target]'s torso with [tool]."
+		self_msg = "You start to separate the ribcage and rearrange the organs in [target]'s torso with [tool]."
 	if(target_zone == "groin")
-		msg = "[user] starts to pry open the incision and rearrange the organs in [target]'s lower abdomen with  [tool]."
-		self_msg = "You start to pry open the incision and rearrange the organs in [target]'s lower abdomen with  [tool]."
+		msg = "[user] starts to pry open the incision and rearrange the organs in [target]'s lower abdomen with [tool]."
+		self_msg = "You start to pry open the incision and rearrange the organs in [target]'s lower abdomen with [tool]."
 	user.visible_message(msg, self_msg)
 	..()
 
 /datum/surgery_step/retract_carapace/end_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/msg = "<span class='notice'> [user] keeps the incision open on [target]'s [target_zone] with  [tool]</span>."
-	var/self_msg = "<span class='notice'> You keep the incision open on [target]'s [target_zone] with  [tool].</span>"
+	var/msg = "<span class='notice'> [user] keeps the incision open on [target]'s [target_zone] with [tool]</span>."
+	var/self_msg = "<span class='notice'> You keep the incision open on [target]'s [target_zone] with [tool].</span>"
 	if(target_zone == "chest")
-		msg = "<span class='notice'> [user] keeps the ribcage open on [target]'s torso with  [tool].</span>"
-		self_msg = "<span class='notice'> You keep the ribcage open on [target]'s torso with  [tool].</span>"
+		msg = "<span class='notice'> [user] keeps the ribcage open on [target]'s torso with [tool].</span>"
+		self_msg = "<span class='notice'> You keep the ribcage open on [target]'s torso with [tool].</span>"
 	if(target_zone == "groin")
-		msg = "<span class='notice'> [user] keeps the incision open on [target]'s lower abdomen with  [tool].</span>"
-		self_msg = "<span class='notice'> You keep the incision open on [target]'s lower abdomen with  [tool].</span>"
+		msg = "<span class='notice'> [user] keeps the incision open on [target]'s lower abdomen with [tool].</span>"
+		self_msg = "<span class='notice'> You keep the incision open on [target]'s lower abdomen with [tool].</span>"
 	user.visible_message(msg, self_msg)
 	return 1
 
 /datum/surgery_step/generic/retract_carapace/fail_step(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
-	var/msg = "<span class='warning'> [user]'s hand slips, tearing the edges of incision on [target]'s [target_zone] with  [tool]!</span>"
-	var/self_msg = "<span class='warning'> Your hand slips, tearing the edges of incision on [target]'s [target_zone] with  [tool]!</span>"
+	var/msg = "<span class='warning'> [user]'s hand slips, tearing the edges of incision on [target]'s [target_zone] with [tool]!</span>"
+	var/self_msg = "<span class='warning'> Your hand slips, tearing the edges of incision on [target]'s [target_zone] with [tool]!</span>"
 	if(target_zone == "chest")
-		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s torso with  [tool]!</span>"
-		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s torso with  [tool]!</span>"
+		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s torso with [tool]!</span>"
+		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s torso with [tool]!</span>"
 	if(target_zone == "groin")
-		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s lower abdomen with  [tool]</span>"
-		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s lower abdomen with  [tool]!</span>"
+		msg = "<span class='warning'> [user]'s hand slips, damaging several organs [target]'s lower abdomen with [tool]</span>"
+		self_msg = "<span class='warning'> Your hand slips, damaging several organs [target]'s lower abdomen with [tool]!</span>"
 	user.visible_message(msg, self_msg)
 	return 0

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -13,6 +13,11 @@
 	steps = list(/datum/surgery_step/generic/cut_open,/datum/surgery_step/generic/clamp_bleeders,/datum/surgery_step/generic/retract_skin,/datum/surgery_step/fix_vein,/datum/surgery_step/generic/cauterize)
 	possible_locs = list("chest","head","groin", "l_arm", "r_arm", "l_leg", "r_leg", "r_hand", "l_hand", "r_foot", "l_foot")
 
+/datum/surgery/debridement
+	name = "Debridement"
+	steps = list(/datum/surgery_step/generic/cut_open,/datum/surgery_step/generic/clamp_bleeders,/datum/surgery_step/generic/retract_skin,/datum/surgery_step/fix_dead_tissue,/datum/surgery_step/treat_necrosis,/datum/surgery_step/generic/cauterize)
+	possible_locs = list("chest","head","groin", "l_arm", "r_arm", "l_leg", "r_leg", "r_hand", "l_hand", "r_foot", "l_foot")
+
 /datum/surgery/infection/can_start(mob/user, mob/living/carbon/target)
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
@@ -38,6 +43,24 @@
 		if(internal_bleeding)
 			return 1
 		return 0
+
+/datum/surgery/debridement/can_start(mob/user, mob/living/carbon/target)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/affected = H.get_organ(user.zone_sel.selecting)
+
+		if(!hasorgans(target))
+			return 0
+
+		if(!affected)
+			return 0
+
+		if(!(affected.status & ORGAN_DEAD))
+			return 0
+
+		return 1
+
+	return 0
 
 /datum/surgery_step/fix_vein
 	name = "mend internal bleeding"
@@ -115,7 +138,6 @@
 
 	if(!(affected.status & ORGAN_DEAD))
 		return 0
-
 	return 1
 
 /datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -146,9 +168,11 @@
 	allowed_tools = list(
 		/obj/item/weapon/reagent_containers/dropper = 100,
 		/obj/item/weapon/reagent_containers/glass/bottle = 75,
-		/obj/item/weapon/reagent_containers/glass/beaker = 75,
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
+		/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
+		/obj/item/weapon/reagent_containers/glass/beaker = 60,
 		/obj/item/weapon/reagent_containers/spray = 50,
-		/obj/item/weapon/reagent_containers/glass/bucket = 50,
+		/obj/item/weapon/reagent_containers/glass/bucket = 40
 	)
 
 	can_infect = 0
@@ -156,12 +180,14 @@
 
 	time = 24
 
-/datum/surgery_step/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(!istype(tool, /obj/item/weapon/reagent_containers))
 		return 0
 
 	var/obj/item/weapon/reagent_containers/container = tool
 	if(!container.reagents.has_reagent("mitocholide"))
+		user.visible_message("[user] looks at \the [tool] and ponders." , \
+		"You are not sure if \the [tool] contains mitocholide to treat the necrosis.")
 		return 0
 
 	if(!hasorgans(target))
@@ -172,34 +198,39 @@
 		return 0
 	return 1
 
-/datum/surgery_step/fix_dead_tissue/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the affected tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the affected tissue in [target]'s [affected.name] with \the [tool].")
 	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",1)
 	..()
 
-/datum/surgery_step/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if(!istype(tool, /obj/item/weapon/reagent_containers))
 		return 0
 
 	var/obj/item/weapon/reagent_containers/container = tool
+	var/mithocolide = 0
+
+	if(container.reagents.has_reagent("mitocholide"))
+		mithocolide = 1
 
 	var/trans = container.reagents.trans_to(target, container.amount_per_transfer_from_this)
 	if(trans > 0)
 		container.reagents.reaction(target, INGEST)	//technically it's contact, but the reagents are being applied to internal tissue
 
-		if(container.reagents.has_reagent("mitocholide"))
+		if(mithocolide)
 			affected.status &= ~ORGAN_DEAD
+			target.update_body()
 
 		user.visible_message("<span class='notice'> [user] applies [trans] units of the solution to affected tissue in [target]'s [affected.name]</span>", \
 			"<span class='notice'> You apply [trans] units of the solution to affected tissue in [target]'s [affected.name] with \the [tool].</span>")
 
 	return 1
 
-/datum/surgery_step/fix_dead_tissue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+/datum/surgery_step/treat_necrosis/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	if(!istype(tool, /obj/item/weapon/reagent_containers))

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -212,16 +212,16 @@
 		return 0
 
 	var/obj/item/weapon/reagent_containers/container = tool
-	var/mithocolide = 0
+	var/mitocholide = 0
 
 	if(container.reagents.has_reagent("mitocholide"))
-		mithocolide = 1
+		mitocholide = 1
 
 	var/trans = container.reagents.trans_to(target, container.amount_per_transfer_from_this)
 	if(trans > 0)
 		container.reagents.reaction(target, INGEST)	//technically it's contact, but the reagents are being applied to internal tissue
 
-		if(mithocolide)
+		if(mitocholide)
 			affected.status &= ~ORGAN_DEAD
 			target.update_body()
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -163,7 +163,7 @@
 	if(ishuman(target))
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		if(can_infect && affected)
-			spread_germs_to_organ(affected, user)
+			spread_germs_to_organ(affected, user, tool)
 	if(ishuman(user) && !(istype(target,/mob/living/carbon/alien)) && prob(60))
 		var/mob/living/carbon/human/H = user
 		if(blood_level)
@@ -180,16 +180,45 @@
 /datum/surgery_step/proc/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	return null
 
+/proc/spread_germs_to_organ(obj/item/organ/E, mob/living/carbon/human/user, obj/item/tool)
+	if(!istype(user) || !istype(E))
+		return
 
-/proc/spread_germs_to_organ(obj/item/organ/E, mob/living/carbon/human/user)
-	if(!istype(user) || !istype(E)) return
-//	to_chat(world, "Germ spread: [E] : [E.owner]")
 	var/germ_level = user.germ_level
+
+	//germ spread from surgeon touching the patient
 	if(user.gloves)
 		germ_level = user.gloves.germ_level
 	if(!(E.status & ORGAN_ROBOT)) //Germs on robotic limbs bad
 		E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
+		spread_germs_by_incision(E,tool)//germ spread from environement to patient
 
+/proc/spread_germs_by_incision(obj/item/organ/external/E,obj/item/tool)
+	if(!istype(E,/obj/item/organ/external))
+		return
+
+	var/germs = 0
+
+	for(var/mob/living/carbon/human/H in view(2, E.loc))//germs from people
+		if(AStar(E.loc, H.loc, /turf/proc/Distance, 2, simulated_only = 0))
+			if((!(NO_BREATH in H.mutations) || !(H.species.flags & NO_BREATH)) && !H.wear_mask) //wearing a mask helps preventing people from breathing cooties into open incisions
+				germs+=H.germ_level/4
+
+	for(var/obj/effect/decal/cleanable/M in view(2, E.loc))//germs from messes
+		if(AStar(E.loc, M.loc, /turf/proc/Distance, 2, simulated_only = 0))
+			if(!istype(M,/obj/effect/decal/cleanable/dirt))//dirt is too common
+				germs++
+
+	if(tool.blood_DNA) //germs from blood-stained tools
+		germs += 30
+
+	if(E.internal_organs.len)
+		germs = germs / E.internal_organs.len
+		for(var/obj/item/organ/internal/O in E.internal_organs)
+			if(!(O.status & ORGAN_ROBOT))
+				O.germ_level += germs
+
+	E.germ_level += germs
 
 /proc/sort_surgeries()
 	var/gap = surgery_steps.len

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -209,7 +209,7 @@
 			if(!istype(M,/obj/effect/decal/cleanable/dirt))//dirt is too common
 				germs++
 
-	if(tool.blood_DNA.len) //germs from blood-stained tools
+	if(tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
 		germs += 30
 
 	if(E.internal_organs.len)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -209,7 +209,7 @@
 			if(!istype(M,/obj/effect/decal/cleanable/dirt))//dirt is too common
 				germs++
 
-	if(tool.blood_DNA) //germs from blood-stained tools
+	if(tool.blood_DNA.len) //germs from blood-stained tools
 		germs += 30
 
 	if(E.internal_organs.len)


### PR DESCRIPTION
Combination of #6743 and #6479, because I am a pro mlg git user, who
would never have issues with the master branch no sir

Doing surgery with another person watching, even if they don't wear a
mask, doesn't warrant an infection either, but beyond that you are
pushing your luck

However, doing surgery in this scenario:

![why would you even do this](http://puu.sh/u7kLj/f3a444e1e9.jpg)
Resulted in acute infections to the heart and lungs.

So, recap:
-Wash your hands, wash your tools if needed, clean your room, wear a
mask and nothing bad happens.
You can even invite a friend to watch over
-Do brain surgery in a blood filled room with 11 clowns honking and
breathing cooties down your patient, and it's just bad
//-Letting your patient go without closing the incisions is also bad why
would you even do that (NOT WORKING ATM)

Allows to use a droppers, bottle, drinking glasses, drinking bottles.
beakers, sprays, or if you are brave
enough, an entire bucket, to treat internal organ infections with
alcohol. The more alcoholic the thing is the more it disinfects. This is
an available option during organ manipulation, at the time where you can
apply trauma kits and etc, so you can for instance apply a trauma kit
and then drip a bottle of vodka over someone's liver to treat infection.

Also adds a debridement surgery to revive dead EXTERNAL organs. Same
list of utensils as the previous, lets you apply mithocolide on a dead
limb or chest to make it unded. Surgery steps are incision, scalpel,
applying a reagent container, cauterize.

Also included is a dropper refactor to keep it in line with the other containers relating to reagent changes, absolutely free, call now and I will double you the offer

🆑 pinatacolada
add: dirty surgery environments get you nasty infections
add: ghetto surgery internal organ disinfection with alcohol
add: dead limb revival surgery step
/🆑