### PR TITLE
Fixes Stack Merge Oddities

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -22,6 +22,7 @@
 	origin_tech = "materials=1"
 	var/created_window = /obj/structure/window/basic
 	var/full_window = /obj/structure/window/full/basic
+	merge_type = /obj/item/stack/sheet/glass
 
 /obj/item/stack/sheet/glass/fifty
 	amount = 50
@@ -155,6 +156,7 @@
 	origin_tech = "materials=2"
 	var/created_window = /obj/structure/window/reinforced
 	var/full_window = /obj/structure/window/full/reinforced
+	merge_type = /obj/item/stack/sheet/rglass
 
 /obj/item/stack/sheet/rglass/cyborg
 	materials = list()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -100,6 +100,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list(
 	throwforce = 10.0
 	flags = CONDUCT
 	origin_tech = "materials=1"
+	merge_type = /obj/item/stack/sheet/metal
 
 /obj/item/stack/sheet/metal/cyborg
 	materials = list()
@@ -136,6 +137,7 @@ var/global/list/datum/stack_recipe/plasteel_recipes = list(
 	throwforce = 10.0
 	flags = CONDUCT
 	origin_tech = "materials=2"
+	merge_type = /obj/item/stack/sheet/plasteel
 
 /obj/item/stack/sheet/plasteel/New(var/loc, var/amount=null)
 	recipes = plasteel_recipes
@@ -171,6 +173,7 @@ var/global/list/datum/stack_recipe/wood_recipes = list(
 	icon_state = "sheet-wood"
 	origin_tech = "materials=1;biotech=1"
 	burn_state = FLAMMABLE
+	merge_type = /obj/item/stack/sheet/wood
 
 /obj/item/stack/sheet/wood/New(var/loc, var/amount=null)
 	recipes = wood_recipes
@@ -208,6 +211,7 @@ var/global/list/datum/stack_recipe/cloth_recipes = list ( \
 	burn_state = FLAMMABLE
 	force = 0
 	throwforce = 0
+	merge_type = /obj/item/stack/sheet/cloth
 
 /obj/item/stack/sheet/cloth/New(loc, amount=null)
 	recipes = cloth_recipes
@@ -240,6 +244,7 @@ var/global/list/datum/stack_recipe/cardboard_recipes = list (
 	icon_state = "sheet-card"
 	origin_tech = "materials=1"
 	burn_state = FLAMMABLE
+	merge_type = /obj/item/stack/sheet/cardboard
 
 /obj/item/stack/sheet/cardboard/New(var/loc, var/amt = null)
 	recipes = cardboard_recipes
@@ -265,6 +270,7 @@ var/global/list/datum/stack_recipe/runed_metal_recipes = list ( \
 	icon_state = "sheet-runed"
 	icon = 'icons/obj/items.dmi'
 	sheettype = "runed"
+	merge_type = /obj/item/stack/sheet/runed_metal
 
 /obj/item/stack/sheet/runed_metal/attack_self(mob/living/user)
 	if(!iscultist(user))
@@ -320,6 +326,7 @@ var/global/list/datum/stack_recipe/plastic_recipes = list ( \
 	icon_state = "sheet-plastic"
 	throwforce = 7
 	origin_tech = "materials=1;biotech=1"
+	merge_type = /obj/item/stack/sheet/plastic
 
 /obj/item/stack/sheet/plastic/New()
 	recipes = plastic_recipes

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -14,11 +14,14 @@
 	var/singular_name
 	var/amount = 1
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
+	var/merge_type = null // This path and its children should merge with this stack, defaults to src.type
 
 /obj/item/stack/New(var/loc, var/amt = null)
 	..()
 	if(amt != null)	//Allow for stacks with the amount=0
 		amount = amt
+	if(!merge_type)
+		merge_type = type
 
 /obj/item/stack/Destroy()
 	if(usr && usr.machine == src)
@@ -232,7 +235,7 @@
 
 /obj/item/stack/attackby(obj/item/W, mob/user, params)
 	..()
-	if(istype(W, type))
+	if(istype(W, merge_type))
 		var/obj/item/stack/S = W
 		if(S.amount >= max_amount)
 			return 1

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -136,6 +136,7 @@
 	icon_state = "tile_space"
 	turf_type = /turf/simulated/floor/fakespace
 	burn_state = FLAMMABLE
+	merge_type = /obj/item/stack/tile/fakespace
 
 /obj/item/stack/tile/fakespace/loaded
 	amount = 30
@@ -148,6 +149,7 @@
 	icon_state = "tile_noslip"
 	turf_type = /turf/simulated/floor/noslip
 	origin_tech = "materials=3"
+	merge_type = /obj/item/stack/tile/noslip
 
 /obj/item/stack/tile/noslip/loaded
 	amount = 20

--- a/code/game/objects/items/weapons/cash.dm
+++ b/code/game/objects/items/weapons/cash.dm
@@ -12,6 +12,7 @@
 	burn_state = FLAMMABLE
 	singular_name = "credit"
 	max_amount = 1000000
+	merge_type = /obj/item/stack/spacecash
 
 /obj/item/stack/spacecash/New(loc, amt = null)
 	..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -475,6 +475,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 	item_state = "coil_red"
 	amount = MAXCOIL
 	max_amount = MAXCOIL
+	merge_type = /obj/item/stack/cable_coil // This is here to let its children merge between themselves
 	color = COLOR_RED
 	desc = "A coil of power cable."
 	throwforce = 10


### PR DESCRIPTION
Under some circumstances, subtypes of a particular stack type would not merge with each other.

This is normally not a problem under most circumstances....unless you have a subtype...meaning the subtype could stack with itself, but not with its parent. 

This is usually only seen with prespawned 50 sheets of metal/glass, but is most apparent/evident with spacecash.

Code from TG.

:cl: Fox McCloud
fix: Fixes some stacks not wanting to stack with similar stacks (such as space cash)
/:cl: