### PR TITLE
Adds tools for mappers

### DIFF
--- a/code/game/objects/effects/spawners/random_barrier.dm
+++ b/code/game/objects/effects/spawners/random_barrier.dm
@@ -28,15 +28,13 @@
 	name = "probably a wall"
 	result = list(
 	/turf/simulated/wall = 9,
-	/obj/structure/falsewall = 1
-	)
+	/obj/structure/falsewall = 1)
 
 /obj/effect/spawner/random_barrier/floor_probably
 	name = "probably a floor"
 	result = list(
 	/turf/simulated/floor/plasteel = 3,
-	/turf/simulated/wall = 1
-	)
+	/turf/simulated/wall = 1)
 
 /obj/effect/spawner/random_barrier/obstruction
 	name = "obstruction"
@@ -44,12 +42,24 @@
 	/turf/simulated/wall = 1,
 	/obj/structure/falsewall = 1,
 	/obj/structure/barricade/wooden = 1,
-	/obj/machinery/door/airlock/welded = 1
-	)
+	/obj/machinery/door/airlock/welded = 1)
 
-/obj/effect/spawner/random_barrier/possibly_welded_airlock
+/obj/effect/spawner/random_barrier/possibly_welded_airlock // these have no access restrictions, so for internal maintenance only
 	name = "possibly welded airlock"
 	result = list(
 	/obj/machinery/door/airlock = 3,
-	/obj/machinery/door/airlock/welded = 1
-	)
+	/obj/machinery/door/airlock/welded = 1)
+
+/obj/effect/spawner/random_spawners/grille_often
+	name = "grille often"
+	result = list(
+	/obj/structure/grille = 8,
+	/obj/structure/grille/broken = 4,
+	/turf/simulated/floor/plating = 2)
+
+/obj/effect/spawner/random_spawners/grille_maybe
+	name = "grille maybe"
+	result = list(
+	/obj/structure/grille = 2,
+	/obj/structure/grille/broken = 2,
+	/turf/simulated/floor/plating = 5)

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -1,0 +1,50 @@
+/obj/effect/spawner/random_spawners
+	name = "random spawners"
+	icon = 'icons/mob/screen_gen.dmi'
+	icon_state = "x2"
+	color = "#00FF00"
+	var/list/result = list(
+	/turf/simulated/floor/plasteel = 1,
+	/turf/simulated/wall = 1,
+	/obj/structure/falsewall = 1,
+	/obj/effect/decal/cleanable/blood/splatter = 1,
+	/obj/structure/barricade/wooden = 1)
+
+// This needs to come before the initialization wave because
+// the thing it creates might need to be initialized too
+/obj/effect/spawner/random_spawners/New()
+	. = ..()
+	var/turf/T = get_turf(src)
+	if(!T)
+		log_runtime(EXCEPTION("Spawner placed in nullspace!"), src)
+		return
+	var/thing_to_place = pickweight(result)
+	if(ispath(thing_to_place, /turf))
+		T.ChangeTurf(thing_to_place)
+	else
+		new thing_to_place(T)
+	qdel(src)
+
+/obj/effect/spawner/random_spawners/blood_maybe
+	name = "blood maybe"
+	result = list(
+	/turf/simulated/floor/plating = 20,
+	/obj/effect/decal/cleanable/blood/splatter = 1)
+
+/obj/effect/spawner/random_spawners/blood_often
+	name = "blood often"
+	result = list(
+	/turf/simulated/floor/plating = 5,
+	/obj/effect/decal/cleanable/blood/splatter = 1)
+
+/obj/effect/spawner/random_spawners/wall_rusted_probably
+	name = "rusted wall probably"
+	result = list(
+	/turf/simulated/wall = 2,
+	/turf/simulated/wall/rust = 7)
+
+/obj/effect/spawner/random_spawners/wall_rusted_maybe
+	name = "rusted wall maybe"
+	result = list(
+	/turf/simulated/wall = 7,
+	/turf/simulated/wall/rust = 1)

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -5,10 +5,10 @@
 	color = "#00FF00"
 	var/list/result = list(
 	/turf/simulated/floor/plasteel = 1,
-	/turf/simulated/wall = 1,
-	/obj/structure/falsewall = 1,
+	/turf/simulated/floor/plating = 1,
 	/obj/effect/decal/cleanable/blood/splatter = 1,
-	/obj/structure/barricade/wooden = 1)
+	/obj/effect/decal/cleanable/blood/oil = 1,
+	/obj/effect/decal/cleanable/fungus = 1)
 
 // This needs to come before the initialization wave because
 // the thing it creates might need to be initialized too
@@ -37,6 +37,18 @@
 	/turf/simulated/floor/plating = 5,
 	/obj/effect/decal/cleanable/blood/splatter = 1)
 
+/obj/effect/spawner/random_spawners/oil_maybe
+	name = "oil maybe"
+	result = list(
+	/turf/simulated/floor/plating = 20,
+	/obj/effect/decal/cleanable/blood/oil = 1)
+
+/obj/effect/spawner/random_spawners/oil_maybe
+	name = "oil often"
+	result = list(
+	/turf/simulated/floor/plating = 5,
+	/obj/effect/decal/cleanable/blood/oil = 1)
+
 /obj/effect/spawner/random_spawners/wall_rusted_probably
 	name = "rusted wall probably"
 	result = list(
@@ -48,3 +60,51 @@
 	result = list(
 	/turf/simulated/wall = 7,
 	/turf/simulated/wall/rust = 1)
+
+/obj/effect/spawner/random_spawners/cobweb_left_frequent
+	name = "cobweb left frequent"
+	result = list(
+	/turf/simulated/floor/plating = 1,
+	/obj/effect/decal/cleanable/cobweb = 1)
+
+/obj/effect/spawner/random_spawners/cobweb_right_frequent
+	name = "cobweb right frequent"
+	result = list(
+	/turf/simulated/floor/plating = 1,
+	/obj/effect/decal/cleanable/cobweb2 = 1)
+
+/obj/effect/spawner/random_spawners/cobweb_left_rare
+	name = "cobweb left rare"
+	result = list(
+	/turf/simulated/floor/plating = 10,
+	/obj/effect/decal/cleanable/cobweb = 1)
+
+/obj/effect/spawner/random_spawners/cobweb_right_rare
+	name = "cobweb right rare"
+	result = list(
+	/turf/simulated/floor/plating = 10,
+	/obj/effect/decal/cleanable/cobweb2 = 1)
+
+/obj/effect/spawner/random_spawners/dirt_frequent
+	name = "dirt frequent"
+	result = list(
+	/turf/simulated/floor/plating = 1,
+	/obj/effect/decal/cleanable/dirt = 1)
+
+/obj/effect/spawner/random_spawners/dirt_rare
+	name = "dirt rare"
+	result = list(
+	/turf/simulated/floor/plating = 10,
+	/obj/effect/decal/cleanable/dirt = 1)
+
+/obj/effect/spawner/random_spawners/fungus_maybe
+	name = "rusted wall maybe"
+	result = list(
+	/turf/simulated/wall = 7,
+	/obj/effect/decal/cleanable/fungus = 1)
+
+/obj/effect/spawner/random_spawners/fungus_probably
+	name = "rusted wall maybe"
+	result = list(
+	/turf/simulated/wall = 1,
+	/obj/effect/decal/cleanable/fungus = 7)

--- a/paradise.dme
+++ b/paradise.dme
@@ -693,6 +693,7 @@
 #include "code\game\objects\effects\spawners\gibspawner.dm"
 #include "code\game\objects\effects\spawners\lootdrop.dm"
 #include "code\game\objects\effects\spawners\random_barrier.dm"
+#include "code\game\objects\effects\spawners\random_spawners.dm"
 #include "code\game\objects\effects\spawners\vaultspawner.dm"
 #include "code\game\objects\effects\spawners\windowspawner.dm"
 #include "code\game\objects\items\ashtray.dm"


### PR DESCRIPTION
Adds some toys for our map builders.

Spawners to add more flavour and a sense of a living world to the maps. And in some way, hurt some meta'ing.

1) Fresh blood patches
2) Rusting of walls
3) Grills that are full, broken or non-existent
4) Oil patches
5) Fungus
6) Cobwebs
7) Dirt

These along with a few more hopefully to come, and CrazyLemon's welded maintenance airlocks spawner, should hopefully liven things up a bit if implemented into the maps.

I haven't included a Cyberiad.dmm file with tweaks implementing these yet, as this PR is simply for the tools, and we can discuss/debate the use of these in a following PR down the road.

Other potentials that I haven't written yet, and will do in a followup PR down the line:
1) Maintenance lights in varying states of setup. Rather than them being broken or not broken, they could have the bulb missing entirely, or just be an unwired assembly on the wall.
2) Grille underwiring, to have a chance that certain wired grill windows aren't / are electrified
3) External windows with the inner pane of glass broken, and a shard in front of the window.

:cl: Purpose2
rcsadd: Adds new toys for our map builders
/ :cl: