### PR TITLE
Refactors Stool/Bed/Chair deconstruction + adds Psych's bed recipe + bug fixes

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -74,11 +74,11 @@
 		agent = preset_agent
 
 
-	scientist.assigned_role = "MODE"
+	scientist.assigned_role = "Abductor Scientist"
 	scientist.special_role = SPECIAL_ROLE_ABDUCTOR_SCIENTIST
 	log_game("[scientist.key] (ckey) has been selected as an abductor team [team_number] scientist.")
 
-	agent.assigned_role = "MODE"
+	agent.assigned_role = "Abductor Agent"
 	agent.special_role = SPECIAL_ROLE_ABDUCTOR_AGENT
 	log_game("[agent.key] (ckey) has been selected as an abductor team [team_number] agent.")
 
@@ -223,6 +223,7 @@
 
 	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate/alt(agent)
 	R.set_frequency(radio_freq)
+	R.name = "strange headset"
 	agent.equip_to_slot_or_del(R, slot_l_ear)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(agent), slot_shoes)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(agent), slot_w_uniform) //they're greys gettit
@@ -287,7 +288,7 @@
 		var/datum/objective/objective = team_objectives[team_number]
 		var/team_name = team_names[team_number]
 		if(console.experiment.points >= objective.target_amount)
-			to_chat(world, "<span class='greenannounce'>[team_name] team fullfilled its mission!</span>")
+			to_chat(world, "<span class='greenannounce'>[team_name] team fulfilled its mission!</span>")
 		else
 			to_chat(world, "<span class='boldannounce'>[team_name] team failed its mission.</span>")
 	..()

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -74,11 +74,11 @@
 		agent = preset_agent
 
 
-	scientist.assigned_role = "Abductor Scientist"
+	scientist.assigned_role = "MODE"
 	scientist.special_role = SPECIAL_ROLE_ABDUCTOR_SCIENTIST
 	log_game("[scientist.key] (ckey) has been selected as an abductor team [team_number] scientist.")
 
-	agent.assigned_role = "Abductor Agent"
+	agent.assigned_role = "MODE"
 	agent.special_role = SPECIAL_ROLE_ABDUCTOR_AGENT
 	log_game("[agent.key] (ckey) has been selected as an abductor team [team_number] agent.")
 
@@ -223,7 +223,7 @@
 
 	var/obj/item/device/radio/R = new /obj/item/device/radio/headset/syndicate/alt(agent)
 	R.set_frequency(radio_freq)
-	R.name = "strange headset"
+	R.name = "alien headset"
 	agent.equip_to_slot_or_del(R, slot_l_ear)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(agent), slot_shoes)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(agent), slot_w_uniform) //they're greys gettit

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -279,7 +279,7 @@ REAGENT SCANNER
 		else
 			to_chat(user, "<span class='notice'>You install the upgrade in the [src].</span>")
 			overlays += "advanced"
-			playsound(src.loc, usesound, 50, 1)
+			playsound(loc, W.usesound, 50, 1)
 			upgraded = 1
 			qdel(W)
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -253,7 +253,7 @@ REAGENT SCANNER
 		if(H.gene_stability < 40)
 			user.show_message("<span class='userdanger'>Subject's genes are quickly breaking down!</span>")
 		else if(H.gene_stability < 70)
-			user.show_message("<span class='danger'>Subject's genes are showing signs of spontenous breakdown.</span>")
+			user.show_message("<span class='danger'>Subject's genes are showing signs of spontaneous breakdown.</span>")
 		else if(H.gene_stability < 85)
 			user.show_message("<span class='warning'>Subject's genes are showing minor signs of instability.</span>")
 		else
@@ -531,5 +531,5 @@ REAGENT SCANNER
 			user.show_message("Possible mutations: [T.slime_mutation[1]], [T.slime_mutation[2]], [T.slime_mutation[3]], [T.slime_mutation[4]]", 1)
 			user.show_message("Genetic destability: [T.mutation_chance]% chance of mutation on splitting", 1)
 	if(T.cores > 1)
-		user.show_message("Anomalious slime core amount detected", 1)
+		user.show_message("Anomalous slime core amount detected", 1)
 	user.show_message("Growth progress: [T.amount_grown]/10", 1)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -22,6 +22,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list(
 	new /datum/stack_recipe("barber chair", /obj/structure/stool/bed/chair/barber, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("wheelchair", /obj/structure/stool/bed/chair/wheelchair, 15, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("bed", /obj/structure/stool/bed, 2, one_per_turf = 1, on_floor = 1),
+	new /datum/stack_recipe("psychiatrist bed", /obj/structure/stool/psychbed, 5, one_per_turf = 1, on_floor = 1),
 	null,
 	new /datum/stack_recipe_list("office chairs",list(
 		new /datum/stack_recipe("dark office chair", /obj/structure/stool/bed/chair/office/dark, 5, one_per_turf = 1, on_floor = 1),

--- a/code/game/objects/items/weapons/dnascrambler.dm
+++ b/code/game/objects/items/weapons/dnascrambler.dm
@@ -22,9 +22,11 @@
 		if(src.used)
 			return
 
-		if(M.get_species() == "Machine")
-			to_chat(user, "<span class='warning'>You failed to inject [M], as they have no DNA to scramble, nor flesh to inject.</span>")
-			return
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.species.flags & NO_DNA)
+				to_chat(user, "<span class='warning'>You failed to inject [M], as they have no DNA to scramble, nor flesh to inject.</span>")
+				return
 
 		if(M == user)
 			user.visible_message("<span class='danger'>[user] injects \himself with [src]!</span>")

--- a/code/game/objects/items/weapons/dnascrambler.dm
+++ b/code/game/objects/items/weapons/dnascrambler.dm
@@ -22,6 +22,10 @@
 		if(src.used)
 			return
 
+		if(M.get_species() == "Machine")
+			to_chat(user, "\red You failed to inject [M.name], as they have no DNA to scramble, nor flesh to inject.")
+			return
+
 		if(M == user)
 			user.visible_message("<span class='danger'>[user.name] injects \himself with [src]!</span>")
 			src.injected(user,user)

--- a/code/game/objects/items/weapons/dnascrambler.dm
+++ b/code/game/objects/items/weapons/dnascrambler.dm
@@ -23,19 +23,19 @@
 			return
 
 		if(M.get_species() == "Machine")
-			to_chat(user, "\red You failed to inject [M.name], as they have no DNA to scramble, nor flesh to inject.")
+			to_chat(user, "<span class='warning'>You failed to inject [M], as they have no DNA to scramble, nor flesh to inject.</span>")
 			return
 
 		if(M == user)
-			user.visible_message("<span class='danger'>[user.name] injects \himself with [src]!</span>")
+			user.visible_message("<span class='danger'>[user] injects \himself with [src]!</span>")
 			src.injected(user,user)
 		else
-			user.visible_message("<span class='danger'>[user.name] is trying to inject [M.name] with [src]!</span>")
+			user.visible_message("<span class='danger'>[user] is trying to inject [M] with [src]!</span>")
 			if(do_mob(user,M,30))
-				user.visible_message("<span class='danger'>[user.name] injects [M.name] with [src].</span>")
+				user.visible_message("<span class='danger'>[user] injects [M] with [src].</span>")
 				src.injected(M, user)
 			else
-				to_chat(user, "\red You failed to inject [M.name].")
+				to_chat(user, "<span class='warning'>You failed to inject [M].</span>")
 
 	proc/injected(var/mob/living/carbon/target, var/mob/living/carbon/user)
 		scramble(1, target, 100)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -1,5 +1,5 @@
 /obj/structure/closet/secure_closet/freezer
-	desc = "It's an immobile card-locked refrigerative storage unit. This one is lead-lined."
+	desc = "It's a card-locked refrigerative storage unit. This one is lead-lined."
 
 /obj/structure/closet/secure_closet/freezer/update_icon()
 	if(broken)

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -50,8 +50,10 @@
 /obj/structure/stool/bed/proc/handle_rotation()
 	return
 
-/obj/structure/stool/bed/attack_animal(var/mob/living/simple_animal/M)//No more buckling hostile mobs to chairs to render them immobile forever
-	if(M.environment_smash)
+/obj/structure/stool/bed/attack_animal(mob/living/simple_animal/user)
+	if(user.environment_smash)
+		user.do_attack_animation(src)
+		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
 		new buildstacktype(loc, buildstackamount)
 		qdel(src)
 

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -15,7 +15,7 @@
 	buckle_lying = 1
 	burn_state = FLAMMABLE
 	burntime = 30
-	parts = 2
+	buildstackamount = 2
 	var/movable = 0 // For mobility checks
 
 /obj/structure/stool/bed/MouseDrop(atom/over_object)
@@ -25,7 +25,7 @@
 	name = "psych bed"
 	desc = "For prime comfort during psychiatric evaluations."
 	icon_state = "psychbed"
-	parts = 5
+	buildstackamount = 5
 	can_buckle = 1
 	buckle_lying = 1
 
@@ -34,8 +34,8 @@
 	icon_state = "dogbed"
 	desc = "A comfy-looking dog bed. You can even strap your pet in, in case the gravity turns off."
 	anchored = 0
-	parts = 10
-	is_wooden = 1
+	buildstackamount = 10
+	buildstacktype = /obj/item/stack/sheet/wood
 
 /obj/structure/stool/bed/dogbed/ian
 	name = "Ian's bed"
@@ -52,7 +52,7 @@
 
 /obj/structure/stool/bed/attack_animal(var/mob/living/simple_animal/M)//No more buckling hostile mobs to chairs to render them immobile forever
 	if(M.environment_smash)
-		new /obj/item/stack/sheet/metal(loc)
+		new buildstacktype(loc, buildstackamount)
 		qdel(src)
 
 /*

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -15,21 +15,17 @@
 	buckle_lying = 1
 	burn_state = FLAMMABLE
 	burntime = 30
+	parts = 2
 	var/movable = 0 // For mobility checks
 
 /obj/structure/stool/bed/MouseDrop(atom/over_object)
 	..(over_object, skip_fucking_stool_shit = 1)
 
-/obj/structure/stool/bed/attackby(obj/item/weapon/W as obj, mob/user, params)
-	if(iswrench(W))
-		playsound(loc, W.usesound, 50, 1)
-		new /obj/item/stack/sheet/metal(loc, 2)
-		qdel(src)
-
 /obj/structure/stool/psychbed
 	name = "psych bed"
 	desc = "For prime comfort during psychiatric evaluations."
 	icon_state = "psychbed"
+	parts = 5
 	can_buckle = 1
 	buckle_lying = 1
 
@@ -38,21 +34,17 @@
 	icon_state = "dogbed"
 	desc = "A comfy-looking dog bed. You can even strap your pet in, in case the gravity turns off."
 	anchored = 0
+	parts = 10
+	is_wooden = 1
 
 /obj/structure/stool/bed/dogbed/ian
 	name = "Ian's bed"
 	desc = "Ian's bed! Looks comfy."
 	anchored = 1
 
-/obj/structure/stool/bed/dogbed/attackby(obj/item/weapon/W, mob/user, params)
-	if(iswrench(W))
-		playsound(loc, W.usesound, 50, 1)
-		new /obj/item/stack/sheet/wood(loc, 10)
-		qdel(src)
-
 /obj/structure/stool/bed/alien
 	name = "resting contraption"
-	desc = "This looks similar to contraptions from earth. Could aliens be stealing our technology?"
+	desc = "This looks similar to contraptions from Earth. Could aliens be stealing our technology?"
 	icon_state = "abed"
 
 /obj/structure/stool/bed/proc/handle_rotation()
@@ -62,7 +54,6 @@
 	if(M.environment_smash)
 		new /obj/item/stack/sheet/metal(loc)
 		qdel(src)
-
 
 /*
  * Roller beds
@@ -95,14 +86,12 @@
 		M.pixel_x = M.get_standard_pixel_x_offset(M.lying)
 		M.pixel_y = M.get_standard_pixel_y_offset(M.lying)
 
-
 /obj/item/roller
 	name = "roller bed"
 	desc = "A collapsed roller bed that can be carried around."
 	icon = 'icons/obj/rollerbed.dmi'
 	icon_state = "folded"
 	w_class = 4 // Can't be put in backpacks.
-
 
 /obj/item/roller/attack_self(mob/user)
 	var/obj/structure/stool/bed/roller/R = new /obj/structure/stool/bed/roller(user.loc)
@@ -128,8 +117,6 @@
 		new/obj/item/roller(get_turf(src))
 		qdel(src)
 		return
-
-
 
 /obj/item/roller_holder
 	name = "roller bed rack"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -84,6 +84,15 @@
 	burntime = 20
 	// TODO:  Special ash subtype that looks like charred chair legs
 
+/obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user)
+	if(user.environment_smash)
+		user.do_attack_animation(src)
+		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		new /obj/item/stack/sheet/wood(get_turf(src))
+		qdel(src)
+
 /obj/structure/stool/bed/chair/wood/narsie_act()
 	return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -4,7 +4,7 @@
 	icon_state = "chair"
 	buckle_lying = 0 //you sit in a chair, not lay
 	burn_state = FIRE_PROOF
-	parts = 1
+	buildstackamount = 1
 
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 
@@ -83,15 +83,15 @@
 /obj/structure/stool/bed/chair/wood
 	burn_state = FLAMMABLE
 	burntime = 20
-	parts = 3
-	is_wooden = 1
+	buildstackamount = 3
+	buildstacktype = /obj/item/stack/sheet/wood
 	// TODO:  Special ash subtype that looks like charred chair legs
 
 /obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user) // Snowflakey, but limited current uses. Future refactor
 	if(user.environment_smash)
 		user.do_attack_animation(src)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
-		new /obj/item/stack/sheet/wood(loc, 3)
+		new buildstacktype(loc, buildstackamount)
 		qdel(src)
 
 /obj/structure/stool/bed/chair/wood/narsie_act()
@@ -114,7 +114,7 @@
 	color = rgb(255,255,255)
 	burn_state = FLAMMABLE
 	burntime = 30
-	parts = 2
+	buildstackamount = 2
 	var/image/armrest = null
 
 /obj/structure/stool/bed/chair/comfy/New()
@@ -159,7 +159,7 @@
 /obj/structure/stool/bed/chair/office
 	anchored = 0
 	movable = 1
-	parts = 5
+	buildstackamount = 5
 
 /obj/structure/stool/bed/chair/office/Bump(atom/A)
 	..()
@@ -189,13 +189,13 @@
 
 /obj/structure/stool/bed/chair/barber
 	icon_state = "barber_chair"
-	parts = 1
+	buildstackamount = 1
 
 /obj/structure/stool/bed/chair/sofa
 	name = "old ratty sofa"
 	icon_state = "sofamiddle"
 	anchored = 1
-	parts = 1
+	buildstackamount = 1
 
 /obj/structure/stool/bed/chair/sofa/left
 	icon_state = "sofaend_left"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -87,7 +87,7 @@
 	buildstacktype = /obj/item/stack/sheet/wood
 	// TODO:  Special ash subtype that looks like charred chair legs
 
-/obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user) // Snowflakey, but limited current uses. Future refactor
+/obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user)
 	if(user.environment_smash)
 		user.do_attack_animation(src)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -4,6 +4,7 @@
 	icon_state = "chair"
 	buckle_lying = 0 //you sit in a chair, not lay
 	burn_state = FIRE_PROOF
+	parts = 1
 
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 
@@ -82,15 +83,15 @@
 /obj/structure/stool/bed/chair/wood
 	burn_state = FLAMMABLE
 	burntime = 20
+	parts = 3
+	is_wooden = 1
 	// TODO:  Special ash subtype that looks like charred chair legs
 
 /obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user) // Snowflakey, but limited current uses. Future refactor
 	if(user.environment_smash)
 		user.do_attack_animation(src)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
-		new /obj/item/stack/sheet/wood(get_turf(src))
-		new /obj/item/stack/sheet/wood(get_turf(src))
-		new /obj/item/stack/sheet/wood(get_turf(src))
+		new /obj/item/stack/sheet/wood(loc, 3)
 		qdel(src)
 
 /obj/structure/stool/bed/chair/wood/narsie_act()
@@ -106,16 +107,6 @@
 	name = "wooden chair"
 	desc = "Old is never too old to not be in fashion."
 
-/obj/structure/stool/bed/chair/wood/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/weapon/wrench))
-		playsound(src.loc, W.usesound, 50, 1)
-		new /obj/item/stack/sheet/wood(get_turf(src))
-		new /obj/item/stack/sheet/wood(get_turf(src))
-		new /obj/item/stack/sheet/wood(get_turf(src))
-		qdel(src)
-	else
-		..()
-
 /obj/structure/stool/bed/chair/comfy
 	name = "comfy chair"
 	desc = "It looks comfy."
@@ -123,6 +114,7 @@
 	color = rgb(255,255,255)
 	burn_state = FLAMMABLE
 	burntime = 30
+	parts = 2
 	var/image/armrest = null
 
 /obj/structure/stool/bed/chair/comfy/New()
@@ -167,15 +159,7 @@
 /obj/structure/stool/bed/chair/office
 	anchored = 0
 	movable = 1
-
-/obj/structure/stool/bed/chair/comfy/attackby(obj/item/weapon/W, mob/user, params)
-	if(iswrench(W))
-		playsound(loc, W.usesound, 50, 1)
-		new /obj/item/stack/sheet/metal(get_turf(src))
-		new /obj/item/stack/sheet/metal(get_turf(src))
-		qdel(src)
-	else
-		..()
+	parts = 5
 
 /obj/structure/stool/bed/chair/office/Bump(atom/A)
 	..()
@@ -205,11 +189,13 @@
 
 /obj/structure/stool/bed/chair/barber
 	icon_state = "barber_chair"
+	parts = 1
 
 /obj/structure/stool/bed/chair/sofa
 	name = "old ratty sofa"
 	icon_state = "sofamiddle"
 	anchored = 1
+	parts = 1
 
 /obj/structure/stool/bed/chair/sofa/left
 	icon_state = "sofaend_left"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -84,7 +84,7 @@
 	burntime = 20
 	// TODO:  Special ash subtype that looks like charred chair legs
 
-/obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user)
+/obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user) // Snowflakey, but limited current uses. Future refactor
 	if(user.environment_smash)
 		user.do_attack_animation(src)
 		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -87,13 +87,6 @@
 	buildstacktype = /obj/item/stack/sheet/wood
 	// TODO:  Special ash subtype that looks like charred chair legs
 
-/obj/structure/stool/bed/chair/wood/attack_animal(mob/living/simple_animal/user)
-	if(user.environment_smash)
-		user.do_attack_animation(src)
-		visible_message("<span class='danger'>[user] smashes [src] apart!</span>")
-		new buildstacktype(loc, buildstackamount)
-		qdel(src)
-
 /obj/structure/stool/bed/chair/wood/narsie_act()
 	return
 

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -4,8 +4,8 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "stool"
 	anchored = 1.0
-	var parts = 1
-	var is_wooden = 0
+	var/buildstackamount = 1
+	var/buildstacktype = /obj/item/stack/sheet/metal
 
 /obj/structure/stool/ex_act(severity)
 	switch(severity)
@@ -14,28 +14,25 @@
 			return
 		if(2.0)
 			if(prob(70))
-				new /obj/item/stack/sheet/metal(loc)
+				new buildstacktype(loc, buildstackamount)
 				qdel(src)
 				return
 		if(3.0)
 			if(prob(50))
-				new /obj/item/stack/sheet/metal(loc)
+				new buildstacktype(loc, buildstackamount)
 				qdel(src)
 				return
 	return
 
 /obj/structure/stool/blob_act()
 	if(prob(75))
-		new /obj/item/stack/sheet/metal(loc)
+		new buildstacktype(loc, buildstackamount)
 		qdel(src)
 
 /obj/structure/stool/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/weapon/wrench))
 		playsound(loc, W.usesound, 50, 1)
-		if(is_wooden)
-			new /obj/item/stack/sheet/wood(loc, parts)
-		else
-			new /obj/item/stack/sheet/metal(loc, parts)
+		new buildstacktype(loc, buildstackamount)
 		qdel(src)
 
 /obj/structure/stool/MouseDrop(atom/over_object, src_location, over_location, src_control, over_control, params, skip_fucking_stool_shit = 0)

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "stool"
 	anchored = 1.0
+	var parts = 1
+	var is_wooden = 0
 
 /obj/structure/stool/ex_act(severity)
 	switch(severity)
@@ -30,7 +32,10 @@
 /obj/structure/stool/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/weapon/wrench))
 		playsound(loc, W.usesound, 50, 1)
-		new /obj/item/stack/sheet/metal(loc)
+		if(is_wooden)
+			new /obj/item/stack/sheet/wood(loc, parts)
+		else
+			new /obj/item/stack/sheet/metal(loc, parts)
 		qdel(src)
 
 /obj/structure/stool/MouseDrop(atom/over_object, src_location, over_location, src_control, over_control, params, skip_fucking_stool_shit = 0)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -122,7 +122,7 @@
 
 /obj/item/clothing/suit/armor/hos/alt
 	name = "armored trenchoat"
-	desc = "A trenchcoat enchanced with a special lightweight kevlar. The epitome of tactical plainclothes."
+	desc = "A trenchcoat enhanced with a special lightweight kevlar. The epitome of tactical plainclothes."
 	icon_state = "hostrench_open"
 	item_state = "hostrench_open"
 	flags_inv = 0
@@ -142,7 +142,7 @@
 
 /obj/item/clothing/suit/armor/vest/warden
 	name = "Warden's armored jacket"
-	desc = "An armoured jacket with silver rank pips and livery."
+	desc = "An armored jacket with silver rank pips and livery."
 	icon_state = "warden_jacket"
 	item_state = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
@@ -166,7 +166,7 @@
 
 /obj/item/clothing/suit/armor/vest/capcarapace/alt
 	name = "captain's parade jacket"
-	desc = "For when an armoured vest isn't fashionable enough."
+	desc = "For when an armored vest isn't fashionable enough."
 	icon_state = "capformal"
 	item_state = "capspacesuit"
 
@@ -412,13 +412,13 @@
 
 /obj/item/clothing/suit/armor/tdome/red
 	name = "Red Thunderdome Armor"
-	desc = "Armor worn by the red Thunderodome team"
+	desc = "Armor worn by the red Thunderdome team."
 	icon_state = "tdred"
 	item_state = "tdred"
 
 /obj/item/clothing/suit/armor/tdome/green
 	name = "Green Thunderdome Armor"
-	desc = "Armor worn by the green Thunderodome team"
+	desc = "Armor worn by the green Thunderdome team."
 	icon_state = "tdgreen"
 	item_state = "tdgreen"
 

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -243,7 +243,7 @@
 		to_chat(user, "Waving around a badge before swiping an ID would be pretty pointless.")
 		return
 	if(isliving(user))
-		user.visible_message("\red [user] displays their NanoTrasen Internal Security Legal Authorization Badge.\nIt reads: [stored_name], NT Security.","\red You display your NanoTrasen Internal Security Legal Authorization Badge.\nIt reads: [stored_name], NT Security.")
+		user.visible_message("\red [user] displays their Nanotrasen Internal Security Legal Authorization Badge.\nIt reads: [stored_name], NT Security.","\red You display your Nanotrasen Internal Security Legal Authorization Badge.\nIt reads: [stored_name], NT Security.")
 
 /obj/item/clothing/accessory/holobadge/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/device/pda))
@@ -361,16 +361,19 @@
 //However, these 3 don't have corgi versions of their sprites
 /obj/item/clothing/accessory/stripedredscarf
 	name = "striped red scarf"
+	desc = "A stylish scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks."
 	icon_state = "stripedredscarf"
 	item_color = "stripedredscarf"
 
 /obj/item/clothing/accessory/stripedgreenscarf
 	name = "striped green scarf"
+	desc = "A stylish scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks."
 	icon_state = "stripedgreenscarf"
 	item_color = "stripedgreenscarf"
 
 /obj/item/clothing/accessory/stripedbluescarf
 	name = "striped blue scarf"
+	desc = "A stylish scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks."
 	icon_state = "stripedbluescarf"
 	item_color = "stripedbluescarf"
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1094,8 +1094,10 @@ var/list/slot_equipment_priority = list( \
 	var/obj/item/weapon/selection = input("What do you want to yank out?", "Embedded objects") in valid_objects
 
 	if(self)
+		visible_message("<span class='warning'>[usr] appears to be trying to extract an object from their body.</span>")
 		to_chat(src, "<span class='warning'>You attempt to get a good grip on [selection] in your body.</span>")
 	else
+		visible_message("<span class='warning'>[usr] attempts to get a good grip on [selection] in [S]'s body.</span>")
 		to_chat(U, "<span class='warning'>You attempt to get a good grip on [selection] in [S]'s body.</span>")
 
 	if(!do_after(U, 80, target = S))


### PR DESCRIPTION
Fixes #2709
Fixes #6934 
Fixes #6931 

Refactors deconstruction of stool types and subtypes. This removes all the multiple instances of attackby() code, which would have had even more as I was fixing 6934 etc... so I went ahead and tidied it up to one instance of it on the parent type of 'stool'. This fixes multiple longstanding bugs with material loss.

This refactor is the largest / more complex thing I've submitted to Paracode, so I'd appreciate a good review to ensure I didn't dick anything, but my testing seems to be successful.

Also adds the psych's bed recipe, as my understanding is the goal is to have everything constructable/deconstructable.

:cl: Purpose2
add: Adds the Psychiatrist's bed/sofa for 5 metal.
fix: Wooden chairs broken by animals no longer drop metal.
fix: Abductors no longer have Syndicate ties.
fix: Fixes material loss on some chair/bed/stool deconstruction types.
fix: IPCs can no longer be DNA Scrambled.
fix: Health analysers clunk again when upgraded
fix: Resolves further grammatical/typo issues.
/ :cl: