### PR TITLE
Pens no longer use comic sans

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -203,7 +203,7 @@
 
 
 /obj/item/weapon/paper/proc/parsepencode(var/t, var/obj/item/weapon/pen/P, mob/user as mob)
-	t = pencode_to_html(t, usr, P, deffont, signfont, crayonfont)
+	t = pencode_to_html(t, usr, P, TRUE, TRUE, deffont, signfont, crayonfont)
 
 //Count the fields
 	var/laststart = 1


### PR DESCRIPTION
Fixes #6805

:cl:Crazylemon
fix: All pens are now certified crayon-wax free!
/:cl: