### PR TITLE
Fixes grammar issue when applying splints

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -175,7 +175,7 @@
 	heal_burn = 12
 
 
-//Splits//
+//Splints//
 
 
 /obj/item/stack/medical/splint
@@ -203,14 +203,14 @@
 				to_chat(user, "<span class='notice'>You remove the splint from [H]'s [limb].</span>")
 			return
 		if(M == user)
-			user.visible_message("<span class='notice'>[user] starts to apply [src] to [H]'s [limb].</span>", \
-								 "<span class='notice'>You start to apply [src] to [H]'s [limb].</span>", \
+			user.visible_message("<span class='notice'>[user] starts to apply [src] to their [limb].</span>", \
+								 "<span class='notice'>You start to apply [src] to your [limb].</span>", \
 								 "<span class='notice'>You hear something being wrapped.</span>")
 			if(!do_mob(user, H, self_delay))
 				return
 		else
-			user.visible_message("<span class='green'>[user] applies [src] to their [limb].</span>", \
-								 "<span class='green'>You apply [src] to your [limb].</span>", \
+			user.visible_message("<span class='green'>[user] applies [src] to [H]'s [limb].</span>", \
+								 "<span class='green'>You apply [src] to [H]'s [limb].</span>", \
 								 "<span class='green'>You hear something being wrapped.</span>")
 
 		affecting.status |= ORGAN_SPLINTED


### PR DESCRIPTION
When someone is splinting you, it says  "are applying the splints to their limb!"  instead of  "are applying the splints to Ty Omaha's limb!" and vice versa when splinting yourself.   This fixes that

:cl: 
fix: Splints will display the proper sentence when applying them
/:cl:
