### PR TITLE
Autopsies No Longer Need Surgery

### DIFF
--- a/code/game/objects/items/devices/autopsy.dm
+++ b/code/game/objects/items/devices/autopsy.dm
@@ -1,14 +1,10 @@
-
-//moved these here from code/defines/obj/weapon.dm
-//please preference put stuff where it's easy to find - C
-
 /obj/item/weapon/autopsy_scanner
 	name = "autopsy scanner"
 	desc = "Extracts information on wounds."
 	icon = 'icons/obj/autopsy_scanner.dmi'
 	icon_state = ""
 	flags = CONDUCT
-	w_class = 1
+	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "materials=1;biotech=1"
 	var/list/datum/autopsy_data_scanner/wdata = list()
 	var/list/datum/autopsy_data_scanner/chemtraces = list()
@@ -28,28 +24,23 @@
 	var/hits = 0
 	var/time_inflicted = 0
 
-	proc/copy()
-		var/datum/autopsy_data/W = new()
-		W.weapon = weapon
-		W.pretend_weapon = pretend_weapon
-		W.damage = damage
-		W.hits = hits
-		W.time_inflicted = time_inflicted
-		return W
+/datum/autopsy_data/proc/copy()
+	var/datum/autopsy_data/W = new()
+	W.weapon = weapon
+	W.pretend_weapon = pretend_weapon
+	W.damage = damage
+	W.hits = hits
+	W.time_inflicted = time_inflicted
+	return W
 
-/obj/item/weapon/autopsy_scanner/proc/add_data(var/obj/item/organ/external/O)
-	if(!O.autopsy_data.len && !O.trace_chemicals.len) return
+/obj/item/weapon/autopsy_scanner/proc/add_data(obj/item/organ/external/O)
+	if(!O.autopsy_data.len && !O.trace_chemicals.len)
+		return
 
 	for(var/V in O.autopsy_data)
 		var/datum/autopsy_data/W = O.autopsy_data[V]
 
 		if(!W.pretend_weapon)
-			/*
-			// the more hits, the more likely it is that we get the right weapon type
-			if(prob(50 + W.hits * 10 + W.damage))
-			*/
-
-			// Buffing this stuff up for now!
 			if(1)
 				W.pretend_weapon = W.weapon
 			else
@@ -76,10 +67,11 @@
 			chemtraces += V
 
 /obj/item/weapon/autopsy_scanner/verb/print_data()
-	set src in view(usr, 1)
 	set name = "Print Data"
-	if(usr.stat || !(istype(usr,/mob/living/carbon/human)))
-		to_chat(usr, "No.")
+	set category = "Object"
+	set src in oview(1)
+
+	if(usr.incapacitated())
 		return
 
 	var/scan_data = ""
@@ -101,8 +93,10 @@
 
 			var/wname = W.pretend_weapon
 
-			if(wname in weapon_chances) weapon_chances[wname] += W.damage
-			else weapon_chances[wname] = max(W.damage, 1)
+			if(wname in weapon_chances)
+				weapon_chances[wname] += W.damage
+			else
+				weapon_chances[wname] = max(W.damage, 1)
 			total_score+=W.damage
 
 
@@ -126,7 +120,8 @@
 			if(30 to 1000)
 				damage_desc = "<font color='red'>severe</font>"
 
-		if(!total_score) total_score = D.organs_scanned.len
+		if(!total_score)
+			total_score = D.organs_scanned.len
 
 		scan_data += "<b>Weapon #[n]</b><br>"
 		if(damaging_weapon)
@@ -148,8 +143,7 @@
 			scan_data += chemID
 			scan_data += "<br>"
 
-	for(var/mob/O in viewers(usr))
-		O.show_message("\red \the [src] rattles and prints out a sheet of paper.", 1)
+	usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
 
 	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 	sleep(10)
@@ -159,24 +153,9 @@
 	P.info = "<tt>[scan_data]</tt>"
 	P.overlays += "paper_words"
 
-	if(istype(usr,/mob/living/carbon))
-		// place the item in the usr's hand if possible
-		if(!usr.r_hand)
-			P.loc = usr
-			usr.r_hand = P
-			P.layer = 20
-			P.plane = HUD_PLANE
-		else if(!usr.l_hand)
-			P.loc = usr
-			usr.l_hand = P
-			P.layer = 20
-			P.plane = HUD_PLANE
+	usr.put_in_hands(P)
 
-	if(istype(usr,/mob/living/carbon/human))
-		usr:update_inv_l_hand()
-		usr:update_inv_r_hand()
-
-/obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M as mob, mob/living/carbon/user as mob)
+/obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M, mob/living/carbon/user)
 	if(!istype(M))
 		return
 
@@ -185,23 +164,18 @@
 
 	if(target_name != M.name)
 		target_name = M.name
-		src.wdata = list()
-		src.chemtraces = list()
-		src.timeofdeath = null
-		to_chat(user, "\red A new patient has been registered.. Purging data for previous patient.")
+		wdata.Cut()
+		chemtraces.Cut()
+		timeofdeath = null
+		to_chat(user, "<span class='warning'>A new patient has been registered. Purging data for previous patient.</span>")
 
-	src.timeofdeath = M.timeofdeath
+	timeofdeath = M.timeofdeath
 
 	var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
 	if(!S)
-		to_chat(usr, "<b>You can't scan this body part.</b>")
+		to_chat(user, "<span class='warning'>You can't scan this body part.</span>")
 		return
-	if(!S.open)
-		to_chat(usr, "<b>You have to cut the limb open first!</b>")
-		return
-	for(var/mob/O in viewers(M))
-		O.show_message("\red [user.name] scans the wounds on [M.name]'s [S.name] with \the [src.name]", 1)
+	M.visible_message("<span class='warning'>[user] scans the wounds on [M]'s [S] with [src]</span>")
 
-	src.add_data(S)
-
+	add_data(S)
 	return 1

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -4,7 +4,7 @@
 //////////////////////////////////////////////////////////////////
 
 /datum/surgery/infection
-	name = "External Infection Treatment/Autopsy"
+	name = "External Infection Treatment"
 	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/cauterize)
 	possible_locs = list("chest","head","groin", "l_arm", "r_arm", "l_leg", "r_leg", "r_hand", "l_hand", "r_foot", "l_foot")
 


### PR DESCRIPTION
Autopsies no longer require surgery to do.

It would be way too snowflakey to give specific exceptions to surgery, but we can go with the next best thing: removal of the surgery aspects of autopsies.

You will still have to put someone on an operating table (or regular table) in order to perform the autopsy, but you will no longer need to cut open every single body part in order to scan it.

If you're looking for some 'mai immershun' explanation, then it's the year 2556, scanners are good or something now.

Also, screw autopsies, autopsy code, autopsy data, trace chems, and the wound system--it's the shitocode to end all shitcode.

:cl: Fox McCloud
tweak: Autopsies can now be performed without needing to cut someone open
/:cl: