### PR TITLE
Adds the RPD (rapid pipe dispenser)

### DIFF
--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -1,0 +1,315 @@
+/*Contains:
+	Rapid Pipe Dispenser
+*/
+
+/obj/item/weapon/rpd
+	name = "rapid pipe dispenser"
+	desc = "This device can rapidly dispense atmospherics and disposals piping, manipulate loose piping, and recycle any detached pipes it is applied to."
+	icon = 'icons/obj/tools.dmi' //Apparently we can't use double quotes here
+	icon_state = "rpd"
+	opacity = 0
+	density = 0
+	anchored = 0.0
+	flags = CONDUCT
+	force = 10.0
+	throwforce = 10.0
+	throw_speed = 3
+	throw_range = 5
+	w_class = 3
+	materials = list(MAT_METAL = 30000, MAT_GLASS = 5000)
+	origin_tech = "engineering=4;materials=2"
+	var/iconrotation = 0 //used to orient icons and pipes
+	var/initialised = 0 //This stops us unnecessarily checking the cache for icons
+	var/mode = 1 //Disposals, atmospherics
+	var/pipemenu = 1 //For nanoUI menus
+	var/pipetype = 1//For nanoUI menus
+	var/whatpipe = 0 //What kind of pipe is it? See code/game/machinery/pipe/construction.dm for a list of defines
+	var/whatdpipe = 0 //What kind of disposals pipe is it? See code/game/machinery/pipe/pipe_dispenser.dm for a list of defines
+	var/cooldown = 0 //Waiting for something to complete?
+	var/spawndelay = 4 //Adding a *slight* delay to the RPD, shouldn't be very noticeable
+	var/walldelay = 40 //How long should drilling into a wall take?
+	var/datum/effect/system/spark_spread/spark_system
+
+/obj/item/weapon/rpd/New()
+	spark_system = new /datum/effect/system/spark_spread()
+	spark_system.set_up(1, 0, src)
+	spark_system.attach(src)
+
+//List of things follow here
+
+//Pipename, pipe type (see construction.dm), pipe category, number of orientations this pipe has, name of pipe in the icon file, is this pipe bendy?
+var/list/pipelist = list(
+	list("key1" = "Straight pipe", "key2" = "0", "key3" = "1", "key4" = "2", "key5" = "simple", "key6" = "0"),
+	list("key1" = "Bent pipe", "key2" = "1", "key3" = "1", "key4" = "4", "key5" = "simple", "key6" = "1"),
+	list("key1" = "T-manifold", "key2" = "5", "key3" = "1", "key4" = "4", "key5" = "manifold", "key6" = "0"),
+	list("key1" = "4-way manifold", "key2" = "19", "key3" = "1", "key4" = "1", "key5" = "manifold4w", "key6" = "0"),
+	list("key1" = "Pipe cap", "key2" = "20", "key3" = "1", "key4" = "4", "key5" = "cap", "key6" = "0"),
+	list("key1" = "Manual valve", "key2" = "8", "key3" = "1", "key4" = "2", "key5" = "mvalve", "key6" = "0"),
+	list("key1" = "Digital valve", "key2" = "35", "key3" = "1", "key4" = "2", "key5" = "dvalve", "key6" = "0"),
+	list("key1" = "Manual T-valve", "key2" = "18", "key3" = "1", "key4" = "4", "key5" = "tvalve", "key6" = "0"),
+	list("key1" = "Digital T-valve", "key2" = "38", "key3" = "1", "key4" = "4", "key5" = "dtvalve", "key6" = "0"),
+	list("key1" = "Straight supply pipe", "key2" = "24", "key3" = "2", "key4" = "2", "key5" = "simple", "key6" = "0"),
+	list("key1" = "Bent supply pipe", "key2" = "25", "key3" = "2", "key4" = "4", "key5" = "simple", "key6" = "1"),
+	list("key1" = "Supply T-manifold", "key2" = "28", "key3" = "2", "key4" = "4", "key5" = "manifold", "key6" = "0"),
+	list("key1" = "4-way supply manifold", "key2" = "30", "key3" = "2", "key4" = "1", "key5" = "manifold4w", "key6" = "0"),
+	list("key1" = "Supply pipe cap", "key2" = "32", "key3" = "2", "key4" = "4", "key5" = "cap", "key6" = "0"),
+	list("key1" = "Straight scrubbers pipe", "key2" = "26", "key3" = "3", "key4" = "2", "key5" = "simple", "key6" = "0"),
+	list("key1" = "Bent scrubbers pipe", "key2" = "27", "key3" = "3", "key4" = "4", "key5" = "simple", "key6" = "1"),
+	list("key1" = "Scrubbers T-manifold", "key2" = "29", "key3" = "3", "key4" = "4", "key5" = "manifold", "key6" = "0"),
+	list("key1" = "4-way scrubbers manifold", "key2" = "31", "key3" = "3", "key4" = "1", "key5" = "manifold4w", "key6" = "0"),
+	list("key1" = "Scrubbers pipe cap", "key2" = "33", "key3" = "3", "key4" = "4", "key5" = "cap", "key6" = "0"),
+	list("key1" = "Universal pipe adapter", "key2" = "23", "key3" = "4", "key4" = "2", "key5" = "universal", "key6" = "0"),
+	list("key1" = "Unary vent", "key2" = "7", "key3" = "4", "key4" = "4", "key5" = "uvent", "key6" = "0"),
+	list("key1" = "Scrubber", "key2" = "10", "key3" = "4", "key4" = "4", "key5" = "scrubber", "key6" = "0"),
+	list("key1" = "Air injector", "key2" = "34", "key3" = "4", "key4" = "4", "key5" = "injector", "key6" = "0"),
+	list("key1" = "Gas pump", "key2" = "9", "key3" = "4", "key4" = "4", "key5" = "pump", "key6" = "0"),
+	list("key1" = "Volume pump", "key2" = "16", "key3" = "4", "key4" = "4", "key5" = "volumepump", "key6" = "0"),
+	list("key1" = "Passive gate", "key2" = "15", "key3" = "4", "key4" = "4", "key5" = "passivegate", "key6" = "0"),
+	list("key1" = "Connector", "key2" = "4", "key3" = "4", "key4" = "4", "key5" = "connector", "key6" = "0"),
+	list("key1" = "Gas sensor", "key2" = "98", "key3" = "4", "key4" = "1", "key5" = "sensor", "key6" = "0"),
+	list("key1" = "Meter", "key2" = "99", "key3" = "4", "key4" = "1", "key5" = "meter", "key6" = "0"),
+	list("key1" = "Gas filter", "key2" = "13", "key3" = "4", "key4" = "4", "key5" = "filter", "key6" = "0"),
+	list("key1" = "Gas mixer", "key2" = "14", "key3" = "4", "key4" = "4", "key5" = "mixer", "key6" = "0"),
+	list("key1" = "Dual-port vent pump", "key2" = "36", "key3" = "4", "key4" = "2", "key5" = "dual-port vent", "key6" = "0"),
+	list("key1" = "Passive vent", "key2" = "37", "key3" = "4", "key4" = "4", "key5" = "passive vent", "key6" = "0"),
+	list("key1" = "Straight HE pipe", "key2" = "2", "key3" = "5", "key4" = "2", "key5" = "he", "key6" = "0"),
+	list("key1" = "Bent HE pipe", "key2" = "3", "key3" = "5", "key4" = "4", "key5" = "he", "key6" = "1"),
+	list("key1" = "Junction", "key2" = "6", "key3" = "5", "key4" = "4", "key5" = "junction", "key6" = "0"),
+	list("key1" = "Heat exchanger", "key2" = "17", "key3" = "5", "key4" = "4", "key5" = "heunary", "key6" = "0"))
+
+//Pipename, pipe type, no. of unique orientations, name of pipe icon
+var/list/dpipelist = list(
+	list("key1" = "Straight pipe", "key2" = "0", "key3" = "2", "key4" = "conpipe-s"),
+	list("key1" = "Bent pipe", "key2" = "1", "key3" = "4", "key4" = "conpipe-c"),
+	list("key1" = "Junction", "key2" = "2", "key3" = "4", "key4" = "conpipe-j1"),
+	list("key1" = "Y-junction", "key2" = "4", "key3" = "4", "key4" = "conpipe-y"),
+	list("key1" = "Trunk", "key2" = "5", "key3" = "4", "key4" = "conpipe-t"),
+	list("key1" = "Bin", "key2" = "6", "key3" = "1", "key4" = "condisposal"),
+	list("key1" = "Outlet", "key2" = "7", "key3" = "4", "key4" = "outlet"),
+	list("key1" = "Chute", "key2" = "8", "key3" = "4", "key4" = "intake"))
+
+//Procs
+
+/obj/item/weapon/rpd/proc/Activaterpd(soundfile, delay)
+	playsound(loc, soundfile, 50, 1)
+	if(prob(15))
+		spark_system.start()
+	if(delay == 1)
+		cooldown = 1
+		spawn(spawndelay)
+		cooldown = 0
+	return
+
+/obj/item/weapon/rpd/proc/Checkifbent(x)
+	if(x in list(1,3,25,27))
+		return 1
+	else
+		return 0
+
+//This proc puts each necessary icon into the initial user's cache for later use. It then sets initialised = 1 to avoid calling itself unnecessarily.
+/obj/item/weapon/rpd/proc/Initialiseicons()
+	if(initialised == 1)
+		return
+	var/F
+	var/I
+	var/disposalsfile = "icons/obj/pipes/disposal.dmi"
+	var/pipefile = "icons/obj/pipe-item.dmi"
+	var/list/filenames
+	for(I in pipelist)
+		if(I["key6"] == "1")//Bendy pipe icons
+			filenames = list(
+			list(I["key5"] + "-southeast.png", SOUTHEAST),
+			list(I["key5"] + "-southwest.png", SOUTHWEST),
+			list(I["key5"] + "-northwest.png", NORTHWEST),
+			list(I["key5"] + "-northeast.png", NORTHEAST))
+		else if(I["key4"] == "2") //Dual state icons
+			filenames = list(
+			list(I["key5"] + "-north.png", NORTH),
+			list(I["key5"] + "-east.png", EAST))
+		else if(I["key4"] == "4")//All other pipes that need icons
+			filenames = list(
+			list(I["key5"] + "-north.png", NORTH),
+			list(I["key5"] + "-east.png", EAST),
+			list(I["key5"] + "-south.png", SOUTH),
+			list(I["key5"] + "-west.png", WEST))
+		else
+			filenames = .
+		for(F in filenames)
+			var/icon/iconfile = icon(pipefile, icon_state = I["key5"], dir = F[2])
+			usr << browse_rsc(iconfile, F[1])
+	for(I in dpipelist) //All disposals pipes have four states so we don't need to bother checking direction
+		filenames = list(
+		list(I["key4"] + "-north.png", NORTH),
+		list(I["key4"] + "-east.png", EAST),
+		list(I["key4"] + "-south.png", SOUTH),
+		list(I["key4"] + "-west.png", WEST))
+		for(F in filenames)
+			var/icon/iconfile = icon(disposalsfile, icon_state = I["key4"], dir = F[2])
+			usr << browse_rsc(iconfile, F[1])
+	initialised = 1
+	return
+
+/obj/item/weapon/rpd/proc/Manipulatepipes(subject, targetturf, atmosverb, disposalsverb)
+	if(istype(subject, /obj/item/pipe))
+		call(subject, atmosverb)()
+	else if(istype(subject, /obj/structure/disposalconstruct/))
+		call(subject, disposalsverb)()
+	else
+		return
+
+//NanoUI stuff
+
+/obj/item/weapon/rpd/attack_self(mob/user as mob)
+	ui_interact(user)
+
+/obj/item/weapon/rpd/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = inventory_state)
+	ui = nanomanager.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "rpd.tmpl", "[name]", 600, 650, state = state)
+		ui.open()
+		Initialiseicons()
+		ui.set_auto_update(1)
+
+/obj/item/weapon/rpd/ui_data(mob/user, ui_key = "main", datum/topic_state/state = inventory_state)
+	var/data[0]
+	data["dpipelist"] = dpipelist
+	data["iconrotation"] = iconrotation
+	data["mode"] = mode
+	data["pipelist"] = pipelist
+	data["pipemenu"] = pipemenu
+	data["pipetype"] = pipetype
+	data["whatdpipe"] = whatdpipe
+	data["whatpipe"] = whatpipe
+	data["mainmenu"] = list(
+	list("key1" = "Atmospherics piping", "key2" = "1", "key3" = "wrench"),
+	list("key1" = "Disposals piping", "key2" = "2", "key3" = "recycle"),
+	list("key1" = "Rotate mode", "key2" = "3", "key3" = "rotate-right"),
+	list("key1" = "Flip mode", "key2" = "4", "key3" = "exchange"),
+	list("key1" = "Recycle mode", "key2" = "5", "key3" = "trash"))
+	data["mainmenu"] = list(
+	list("key1" = "Atmospherics piping", "key2" = "1", "key3" = "wrench"),
+	list("key1" = "Disposals piping", "key2" = "2", "key3" = "recycle"),
+	list("key1" = "Rotate mode", "key2" = "3", "key3" = "rotate-right"),
+	list("key1" = "Flip mode", "key2" = "4", "key3" = "exchange"),
+	list("key1" = "Recycle mode", "key2" = "5", "key3" = "trash"))
+	data["pipemenu"] = list(
+	list("key1" = "Normal pipes", "key2" = "1"),
+	list("key1" = "Supply pipes", "key2" = "2"),
+	list("key1" = "Scrubber pipes", "key2" = "3"),
+	list("key1" = "Devices", "key2" = "4"),
+	list("key1" = "HE pipes", "key2" = "5"))
+	return data
+
+/obj/item/weapon/rpd/Topic(href, href_list, nowindow, state)
+	if(href_list["iconrotation"])
+		iconrotation = text2num(href_list["iconrotation"])
+	else if(href_list["whatpipe"])
+		whatpipe = text2num(href_list["whatpipe"])
+	else if(href_list["whatdpipe"])
+		whatdpipe = text2num(href_list["whatdpipe"])
+	else if(href_list["pipetype"])
+		pipetype = text2num(href_list["pipetype"])
+	else if(href_list["mode"])
+		mode = text2num(href_list["mode"])
+	else if(href_list["refresh"])
+		to_chat(usr, "<span class='notice'>You press the reset button, refreshing all settings on the [src].</span>")
+		iconrotation = 0
+		initialised = 0
+		mode = 1
+		pipemenu = 1
+		pipetype = 1
+		whatpipe = 0
+		whatdpipe = 0
+		cooldown = 0
+		Initialiseicons()
+	else
+		return
+	nanomanager.update_uis(src)
+	return
+
+//What the RPD actually does
+
+/obj/item/weapon/rpd/afterattack(atom/target, mob/user as mob, proximity)
+	var/turf/T = get_turf(target)
+	if(!proximity)
+		return
+	else if(cooldown == 1)
+		return
+	else if(!isturf(target) && !istype(target, /obj/item/pipe) && !istype(target, /obj/item/pipe_meter) && !istype(target, /obj/item/pipe_gsensor) && !istype(target, /obj/structure/disposalconstruct))
+		return
+	else if(istype(target, /turf/simulated/shuttle))
+		return
+	else if(mode == 1) //Atmos mode
+		if(istype(T, /turf/simulated/wall)) //Drilling into walls takes time and we don't want to do anything else while drilling
+			cooldown = 1
+			playsound(get_turf(src), "sound/weapons/circsawhit.ogg", 50, 1)
+			usr.visible_message("<span class='notice'>[usr] starts drilling a hole in [T]...</span>", "<span class='notice'>You start drilling a hole in [T]...</span>", "<span class='warning'>You hear a drill.</span>")
+			if(do_after(usr, walldelay, target = T))
+				usr.visible_message("<span class='notice'>[usr] finishes drilling a hole in [T]!</span>", "<span class = 'notice'>You finish drilling a hole in [T]!</span>", "<span class='warning'>You hear clanking.</span>")
+			else
+				cooldown = 0
+				return
+		if(whatpipe == 98)//need to check if it's a meter or a gas sensor separately ayylmao
+			new /obj/item/pipe_gsensor(T)
+			to_chat(usr, "<span class='notice'>[src] dispenses a sensor!</span>")
+			Activaterpd("sound/machines/click.ogg", 1)
+			return
+		if(whatpipe == 99)
+			new /obj/item/pipe_meter(T)
+			to_chat(usr, "<span class='notice'>[src] dispenses a meter!</span>")
+			Activaterpd("sound/machines/click.ogg", 1)
+			return
+		var/obj/item/pipe/P = new(T, pipe_type=whatpipe, dir = usr.dir) //Now we make the pipes
+		if(iconrotation == 0 && Checkifbent(P.pipe_type) == 1) //Automatic rotation of dispensed pipes
+			P.dir = turn(usr.dir, 135)
+		else if(iconrotation == 0 && P.pipe_type in list(4, 7, 10, 17, 20, 32, 33, 34, 37)) //Some pipes dispense oppositely to what you'd expect, but we don't want to do anything if they selected a direction
+			call(P, /obj/item/pipe/verb/flip)()
+		else if(iconrotation != 0 && Checkifbent(P.pipe_type) == 1) //If they selected a rotation and the pipe is bent
+			P.dir = turn(iconrotation, -45)
+		else if(iconrotation != 0)
+			P.dir = iconrotation
+		P.update()
+		to_chat(usr, "<span class='notice'>[src] rapidly dispenses [P]!</span>")
+		Activaterpd("sound/machines/click.ogg", 1)
+	else if(mode == 2) //Disposals mode
+		if(istype(T, /turf/simulated/wall))
+			to_chat(usr, "<span class='warning'>That type of pipe won't fit on [T]!</span>")
+			return
+		if(is_blocked_turf(T) == 1 && whatdpipe in list(6, 7, 8))//We need to check if the targetted turf is already dense, in case some goofball sticks 100 bins in front of security or something
+			to_chat(usr, "<span class='warning'>You can't dispense that on [T] because something is in the way!</span>")
+			return
+		var/obj/structure/disposalconstruct/P = new(T) //Now we make the pipe
+		P.dir = iconrotation
+		P.ptype = whatdpipe
+		if(whatdpipe in list(6, 7, 8)) //To properly set density of our bins/chutes/outlets
+			P.density = 1
+		if(iconrotation == 0) //Automatic rotation
+			P.dir = usr.dir
+		if(iconrotation == 0 && whatdpipe != 2) //Disposals pipes are in the opposite direction to atmos pipes, so we need to flip them. Junctions don't have this quirk though
+			call(P, /obj/structure/disposalconstruct/verb/flip)()
+		P.update()
+		to_chat(usr, "<span class='notice'>[src] rapidly dispenses [P]!</span>")
+		Activaterpd("sound/machines/click.ogg", 1)
+		return
+	else if(mode == 3) //Rotate mode
+		for(var/obj/W in T)
+			Manipulatepipes(W, T, /obj/item/pipe/verb/rotate, /obj/structure/disposalconstruct/verb/rotate)
+		return
+	else if(mode == 4) //Flip mode
+		for(var/obj/W in T)
+			Manipulatepipes(W, T, /obj/item/pipe/verb/flip, /obj/structure/disposalconstruct/verb/flip)
+		return
+	else if(mode == 5) //Delete mode
+		var/eaten
+		for(var/obj/W in T)
+			if(istype(W, /obj/item/pipe) || istype(W, /obj/item/pipe_meter) || istype(W, /obj/item/pipe_gsensor) || istype(W, /obj/structure/disposalconstruct) && W.anchored == 0)
+				qdel(W)
+				eaten = 1
+		if(eaten == 1)
+			to_chat(usr, "<span class='notice'>[src] sucks up the loose pipes on [T]!</span>")
+			Activaterpd("sound/items/Deconstruct.ogg", 1)
+		else
+			to_chat(usr, "<span class='notice'>There were no loose pipes on [T].</span>")
+		return
+	else //Finished.
+		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -143,3 +143,4 @@
 		new /obj/item/weapon/watertank/atmos(src)
 		new /obj/item/clothing/suit/fire/atmos(src)
 		new /obj/item/clothing/head/hardhat/atmos(src)
+		new /obj/item/weapon/rpd(src)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -2,14 +2,6 @@
 //////////Autolathe Designs ///////
 ///////////////////////////////////
 
-/datum/design/analyzer
-	name = "Analyzer"
-	id = "analyzer"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	build_path = /obj/item/device/analyzer
-	category = list("initial","Tools")
-
 /datum/design/bucket
 	name = "Bucket"
 	id = "bucket"
@@ -26,20 +18,20 @@
 	build_path = /obj/item/weapon/crowbar
 	category = list("initial","Tools")
 
-/datum/design/extinguisher
-	name = "Fire Extinguisher"
-	id = "extinguisher"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 90)
-	build_path = /obj/item/weapon/extinguisher
-	category = list("initial","Tools")
-
 /datum/design/flashlight
 	name = "Flashlight"
 	id = "flashlight"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
 	build_path = /obj/item/device/flashlight
+	category = list("initial","Tools")
+
+/datum/design/extinguisher
+	name = "Fire Extinguisher"
+	id = "extinguisher"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 90)
+	build_path = /obj/item/weapon/extinguisher
 	category = list("initial","Tools")
 
 /datum/design/multitool
@@ -50,12 +42,12 @@
 	build_path = /obj/item/device/multitool
 	category = list("initial","Tools")
 
-/datum/design/screwdriver
-	name = "Screwdriver"
-	id = "screwdriver"
+/datum/design/analyzer
+	name = "Analyzer"
+	id = "analyzer"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75)
-	build_path = /obj/item/weapon/screwdriver
+	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
+	build_path = /obj/item/device/analyzer
 	category = list("initial","Tools")
 
 /datum/design/tscanner
@@ -64,6 +56,46 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 150)
 	build_path = /obj/item/device/t_scanner
+	category = list("initial","Tools")
+
+/datum/design/weldingtool
+	name = "Welding Tool"
+	id = "welding_tool"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 70, MAT_GLASS = 20)
+	build_path = /obj/item/weapon/weldingtool
+	category = list("initial","Tools")
+
+/datum/design/mini_weldingtool
+	name = "Emergency welding tool"
+	id = "mini_welding_tool"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30, MAT_GLASS = 10)
+	build_path = /obj/item/weapon/weldingtool/mini
+	category = list("initial","Tools")
+
+/datum/design/screwdriver
+	name = "Screwdriver"
+	id = "screwdriver"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75)
+	build_path = /obj/item/weapon/screwdriver
+	category = list("initial","Tools")
+
+/datum/design/wirecutters
+	name = "Wirecutters"
+	id = "wirecutters"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 80)
+	build_path = /obj/item/weapon/wirecutters
+	category = list("initial","Tools")
+
+/datum/design/wrench
+	name = "Wrench"
+	id = "wrench"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150)
+	build_path = /obj/item/weapon/wrench
 	category = list("initial","Tools")
 
 /datum/design/welding_helmet
@@ -83,44 +115,28 @@
 	category = list("initial","Tools")
 	maxstack = 30
 
-/datum/design/weldingtool
-	name = "Welding Tool"
-	id = "welding_tool"
+/datum/design/toolbox
+	name = "Toolbox"
+	id = "tool_box"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 70, MAT_GLASS = 20)
-	build_path = /obj/item/weapon/weldingtool
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/storage/toolbox
 	category = list("initial","Tools")
 
-/datum/design/wirecutters
-	name = "Wirecutters"
-	id = "wirecutters"
+/datum/design/console_screen
+	name = "Console Screen"
+	id = "console_screen"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 80)
-	build_path = /obj/item/weapon/wirecutters
-	category = list("initial","Tools")
+	materials = list(MAT_GLASS = 200)
+	build_path = /obj/item/weapon/stock_parts/console_screen
+	category = list("initial", "Electronics")
 
-/datum/design/wrench
-	name = "Wrench"
-	id = "wrench"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150)
-	build_path = /obj/item/weapon/wrench
-	category = list("initial","Tools")
-
-/datum/design/spraycan
-	name = "Spraycan"
-	id = "spraycan"
+/datum/design/apc_board
+	name = "APC module"
+	id = "power control"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
-	build_path = /obj/item/toy/crayon/spraycan
-	category = list("initial", "Tools")
-
-/datum/design/airalarm_electronics
-	name = "Air Alarm Electronics"
-	id = "airalarm_electronics"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/airalarm_electronics
+	build_path = /obj/item/weapon/apc_electronics
 	category = list("initial", "Electronics")
 
 /datum/design/airlock_board
@@ -139,28 +155,12 @@
 	build_path = /obj/item/weapon/firelock_electronics
 	category = list("initial", "Electronics")
 
-/datum/design/apc_electronics
-	name="Power Control Module"
-	id = "apc_electronics"
+/datum/design/airalarm_electronics
+	name = "Air Alarm Electronics"
+	id = "airalarm_electronics"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/apc_electronics
-	category = list("initial", "Electronics")
-
-/datum/design/intercom_electronics
-	name = "Intercom Electronics"
-	id = "intercom_electronics"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/intercom_electronics
-	category = list("initial", "Electronics")
-
-/datum/design/console_screen
-	name = "Console Screen"
-	id = "console_screen"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 200)
-	build_path = /obj/item/weapon/stock_parts/console_screen
+	build_path = /obj/item/weapon/airalarm_electronics
 	category = list("initial", "Electronics")
 
 /datum/design/firealarm_electronics
@@ -171,6 +171,14 @@
 	build_path = /obj/item/weapon/firealarm_electronics
 	category = list("initial", "Electronics")
 
+/datum/design/intercom_electronics
+	name = "Intercom Electronics"
+	id = "intercom_electronics"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
+	build_path = /obj/item/weapon/intercom_electronics
+	category = list("initial", "Electronics")
+
 /datum/design/earmuffs
 	name = "Earmuffs"
 	id = "earmuffs"
@@ -179,29 +187,65 @@
 	build_path = /obj/item/clothing/ears/earmuffs
 	category = list("initial", "Miscellaneous")
 
-/datum/design/igniter
-	name = "Igniter"
-	id = "igniter"
+/datum/design/pipe_painter
+	name = "Pipe Painter"
+	id = "pipe_painter"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/assembly/igniter
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 2000)
+	build_path = /obj/item/device/pipe_painter
 	category = list("initial", "Miscellaneous")
 
-/datum/design/infrared_emitter
-	name = "Infrared Emitter"
-	id = "infrared_emitter"
+/datum/design/floorpainter
+	name = "Floor painter"
+	id = "floor_painter"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
-	build_path = /obj/item/device/assembly/infra
+	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
+	build_path = /obj/item/device/floor_painter
 	category = list("initial", "Miscellaneous")
 
-/datum/design/health_sensor
-	name = "Health sensor"
-	id = "health_sensor"
+/datum/design/metal
+	name = "Metal"
+	id = "metal"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/health
-	category = list("initial", "Medical")
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/metal
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/glass
+	name = "Glass"
+	id = "glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/glass
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/rglass
+	name = "Reinforced Glass"
+	id = "rglass"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/rglass
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/rods
+	name = "Metal Rod"
+	id = "rods"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000)
+	build_path = /obj/item/stack/rods
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/rcd_ammo
+	name = "Compressed Matter Cardridge"
+	id = "rcd_ammo"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 16000, MAT_GLASS=8000)
+	build_path = /obj/item/weapon/rcd_ammo
+	category = list("initial","Construction")
 
 /datum/design/kitchen_knife
 	name = "Kitchen Knife"
@@ -209,13 +253,53 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 12000)
 	build_path = /obj/item/weapon/kitchen/knife
-	category = list("initial","Miscellaneous")
+	category = list("initial","Dinnerware")
 
-/datum/design/minihoe
-	name = "Mini Hoe"
-	id = "mini_hoe"
+/datum/design/fork
+	name = "Fork"
+	id = "fork"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50)
+	materials = list(MAT_METAL = 80)
+	build_path = /obj/item/weapon/kitchen/utensil/fork
+	category = list("initial","Dinnerware")
+
+/datum/design/tray
+	name = "Tray"
+	id = "tray"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 3000)
+	build_path = /obj/item/weapon/storage/bag/tray
+	category = list("initial","Dinnerware")
+
+/datum/design/drinking_glass
+	name = "Drinking glass"
+	id = "drinking_glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass
+	category = list("initial","Dinnerware")
+
+/datum/design/shot_glass
+	name = "Shot glass"
+	id = "shot_glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 100)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass
+	category = list("initial","Dinnerware")
+
+/datum/design/shaker
+	name = "Shaker"
+	id = "shaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1500)
+	build_path = /obj/item/weapon/reagent_containers/food/drinks/shaker
+	category = list("initial","Dinnerware")
+
+/datum/design/cultivator
+	name = "Cultivator"
+	id = "cultivator"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL=50)
 	build_path = /obj/item/weapon/cultivator
 	category = list("initial","Miscellaneous")
 
@@ -251,37 +335,125 @@
 	build_path = /obj/item/weapon/hatchet
 	category = list("initial","Miscellaneous")
 
-/datum/design/pipe_painter
-	name = "Pipe Painter"
-	id = "pipe_painter"
+/datum/design/scalpel
+	name = "Scalpel"
+	id = "scalpel"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 2000)
-	build_path = /obj/item/device/pipe_painter
-	category = list("initial", "Miscellaneous")
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
+	build_path = /obj/item/weapon/scalpel
+	category = list("initial", "Medical")
 
-/datum/design/prox_sensor
-	name = "Proximity Sensor"
-	id = "prox_sensor"
+/datum/design/circular_saw
+	name = "Circular Saw"
+	id = "circular_saw"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/prox_sensor
-	category = list("initial", "Miscellaneous")
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/circular_saw
+	category = list("initial", "Medical")
 
-/datum/design/mousetrap
-	name = "Mousetrap"
-	id = "mousetrap"
+/datum/design/surgicaldrill
+	name = "Surgical Drill"
+	id = "surgicaldrill"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/mousetrap
-	category = list("initial", "Miscellaneous")
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/surgicaldrill
+	category = list("initial", "Medical")
 
-/datum/design/timer
-	name = "Timer"
-	id = "timer"
+/datum/design/retractor
+	name = "Retractor"
+	id = "retractor"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 6000, MAT_GLASS = 3000)
+	build_path = /obj/item/weapon/retractor
+	category = list("initial", "Medical")
+
+/datum/design/cautery
+	name = "Cautery"
+	id = "cautery"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 2500, MAT_GLASS = 750)
+	build_path = /obj/item/weapon/cautery
+	category = list("initial", "Medical")
+
+/datum/design/hemostat
+	name = "Hemostat"
+	id = "hemostat"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 2500)
+	build_path = /obj/item/weapon/hemostat
+	category = list("initial", "Medical")
+
+/datum/design/bonesetter
+	name = "Bone Setter"
+	id = "bonesetter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/weapon/bonesetter
+	category = list("initial", "Medical")
+
+/datum/design/fixovein
+	name = "FixOVein"
+	id = "fixovein"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000)
+	build_path = /obj/item/weapon/FixOVein
+	category = list("initial", "Medical")
+
+/datum/design/bonegel
+	name = "Bone Gel"
+	id = "bonegel"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/bonegel
+	category = list("initial", "Medical")
+
+/datum/design/beaker
+	name = "Beaker"
+	id = "beaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker
+	category = list("initial", "Medical")
+
+/datum/design/large_beaker
+	name = "Large Beaker"
+	id = "large_beaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 2500)
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker/large
+	category = list("initial", "Medical")
+
+/datum/design/healthanalyzer
+	name = "Health Analyzer"
+	id = "healthanalyzer"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/assembly/timer
-	category = list("initial", "Miscellaneous")
+	build_path = /obj/item/device/healthanalyzer
+	category = list("initial", "Medical")
+
+/datum/design/beanbag_slug
+	name = "Beanbag Slug"
+	id = "beanbag_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 250)
+	build_path = /obj/item/ammo_casing/shotgun/beanbag
+	category = list("initial", "Security")
+
+/datum/design/rubbershot
+	name = "Rubber shot"
+	id = "rubber_shot"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/rubbershot
+	category = list("initial", "Security")
+
+/datum/design/c38
+	name = "Speed Loader (.38)"
+	id = "c38"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c38
+	category = list("initial", "Security")
 
 /datum/design/recorder
 	name = "Universal Recorder"
@@ -299,12 +471,325 @@
 	build_path = /obj/item/device/tape/random
 	category = list("initial", "Miscellaneous")
 
+/datum/design/igniter
+	name = "Igniter"
+	id = "igniter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
+	build_path = /obj/item/device/assembly/igniter
+	category = list("initial", "Miscellaneous")
+
+/datum/design/signaler
+	name = "Remote Signaling Device"
+	id = "signaler"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 400, MAT_GLASS = 120)
+	build_path = /obj/item/device/assembly/signaler
+	category = list("initial", "Communication")
+
+/datum/design/radio_headset
+	name = "Radio Headset"
+	id = "radio_headset"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75)
+	build_path = /obj/item/device/radio/headset
+	category = list("initial", "Communication")
+
+/datum/design/bounced_radio
+	name = "Station Bounced Radio"
+	id = "bounced_radio"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75, MAT_GLASS = 25)
+	build_path = /obj/item/device/radio/off
+	category = list("initial", "Communication")
+
+/datum/design/infrared_emitter
+	name = "Infrared Emitter"
+	id = "infrared_emitter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
+	build_path = /obj/item/device/assembly/infra
+	category = list("initial", "Miscellaneous")
+
+/datum/design/health_sensor
+	name = "Health sensor"
+	id = "health_sensor"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/health
+	category = list("initial", "Medical")
+
+/datum/design/timer
+	name = "Timer"
+	id = "timer"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
+	build_path = /obj/item/device/assembly/timer
+	category = list("initial", "Miscellaneous")
+
 /datum/design/voice_analyser
 	name = "Voice Analyser"
 	id = "voice_analyser"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
 	build_path = /obj/item/device/assembly/voice
+	category = list("initial", "Miscellaneous")
+
+/datum/design/light_tube
+	name = "Light Tube"
+	id = "light_tube"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 100)
+	build_path = /obj/item/weapon/light/tube
+	category = list("initial", "Construction")
+
+/datum/design/light_bulb
+	name = "Light Bulb"
+	id = "light_bulb"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 100)
+	build_path = /obj/item/weapon/light/bulb
+	category = list("initial", "Construction")
+
+/datum/design/camera_assembly
+	name = "Camera Assembly"
+	id = "camera_assembly"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 400, MAT_GLASS = 250)
+	build_path = /obj/item/weapon/camera_assembly
+	category = list("initial", "Construction")
+
+/datum/design/newscaster_frame
+	name = "Newscaster Frame"
+	id = "newscaster_frame"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 14000, MAT_GLASS = 8000)
+	build_path = /obj/item/mounted/frame/newscaster_frame
+	category = list("initial", "Construction")
+
+/datum/design/syringe
+	name = "Syringe"
+	id = "syringe"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
+	build_path = /obj/item/weapon/reagent_containers/syringe
+	category = list("initial", "Medical")
+
+/datum/design/prox_sensor
+	name = "Proximity Sensor"
+	id = "prox_sensor"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/prox_sensor
+	category = list("initial", "Miscellaneous")
+
+/datum/design/foam_dart
+	name = "Box of Foam Darts"
+	id = "foam_dart"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/ammo_box/foambox
+	category = list("initial", "Miscellaneous")
+
+//hacked autolathe recipes
+/datum/design/flamethrower
+	name = "Flamethrower"
+	id = "flamethrower"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/flamethrower/full
+	category = list("hacked", "Security")
+
+/datum/design/rcd
+	name = "Rapid Construction Device (RCD)"
+	id = "rcd"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/weapon/rcd
+	category = list("hacked", "Construction")
+
+/datum/design/rpd
+	name = "Rapid Pipe Dispenser"
+	id = "rpd"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000, MAT_GLASS = 5000)
+	build_path = /obj/item/weapon/rpd
+	category = list("hacked", "Construction")
+
+/datum/design/electropack
+	name = "Electropack"
+	id = "electropack"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 2500)
+	build_path = /obj/item/device/radio/electropack
+	category = list("hacked", "Tools")
+
+/datum/design/large_welding_tool
+	name = "Industrial Welding Tool"
+	id = "large_welding_tool"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
+	build_path = /obj/item/weapon/weldingtool/largetank
+	category = list("hacked", "Tools")
+
+/datum/design/handcuffs
+	name = "Handcuffs"
+	id = "handcuffs"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/restraints/handcuffs
+	category = list("hacked", "Security")
+
+/datum/design/shotgun_slug
+	name = "Shotgun Slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
+/datum/design/buckshot_shell
+	name = "Buckshot shell"
+	id = "buckshot_shell"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")
+
+/datum/design/shotgun_dart
+	name = "Shotgun Dart"
+	id = "shotgun_dart"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/dart
+	category = list("hacked", "Security")
+
+/datum/design/incendiary_slug
+	name = "Incendiary Slug"
+	id = "incendiary_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/incendiary
+	category = list("hacked", "Security")
+
+/datum/design/riot_dart
+	name = "Foam riot dart"
+	id = "riot_dart"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000) //Discount for making individually - no box = less metal!
+	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
+	category = list("hacked", "Security")
+
+/datum/design/riot_darts
+	name = "Foam riot dart box"
+	id = "riot_darts"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50000) //Comes with 40 darts
+	build_path = /obj/item/ammo_box/foambox/riot
+	category = list("hacked", "Security")
+
+/datum/design/a357
+	name = "Ammo Box (.357)"
+	id = "a357"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/a357
+	category = list("hacked", "Security")
+
+/datum/design/c10mm
+	name = "Ammo Box (10mm)"
+	id = "c10mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c10mm
+	category = list("hacked", "Security")
+
+/datum/design/c45
+	name = "Ammo Box (.45)"
+	id = "c45"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c45
+	category = list("hacked", "Security")
+
+/datum/design/c9mm
+	name = "Ammo Box (9mm)"
+	id = "c9mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c9mm
+	category = list("hacked", "Security")
+
+/datum/design/cleaver
+	name = "Butcher's cleaver"
+	id = "cleaver"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 18000)
+	build_path = /obj/item/weapon/kitchen/knife/butcher
+	category = list("hacked", "Dinnerware")
+
+/datum/design/spraycan
+	name = "Spraycan"
+	id = "spraycan"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
+	build_path = /obj/item/toy/crayon/spraycan
+	category = list("initial", "Tools")
+
+/datum/design/desttagger
+	name = "Destination tagger"
+	id = "desttagger"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 250, MAT_GLASS = 125)
+	build_path = /obj/item/device/destTagger
+	category = list("initial", "Electronics")
+
+/datum/design/handlabeler
+	name = "Hand labeler"
+	id = "handlabel"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
+	build_path = /obj/item/weapon/hand_labeler
+	category = list("initial", "Electronics")
+
+/datum/design/conveyor_belt
+	name = "Conveyor belt"
+	id = "conveyor_belt"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000)
+	build_path = /obj/item/conveyor_construct
+	category = list("initial", "Construction")
+
+/datum/design/conveyor_switch
+	name = "Conveyor belt switch"
+	id = "conveyor_switch"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
+	build_path = /obj/item/conveyor_switch_construct
+	category = list("initial", "Construction")
+
+/datum/design/laptop
+	name = "Laptop Frame"
+	id = "laptop"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 1000)
+	build_path = /obj/item/device/modular_computer/laptop/buildable
+	category = list("initial", "Miscellaneous")
+
+/datum/design/tablet
+	name = "Tablet Frame"
+	id = "tablet"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
+	build_path = /obj/item/device/modular_computer/tablet
+	category = list("initial", "Miscellaneous")
+
+/datum/design/mousetrap
+	name = "Mousetrap"
+	id = "mousetrap"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/mousetrap
 	category = list("initial", "Miscellaneous")
 
 /datum/design/videocam
@@ -339,14 +824,6 @@
 	build_path = /obj/item/weapon/canvas/twentythreeXnineteen
 	category = list("initial", "Miscellaneous")
 
-/datum/design/foambox
-	name = "Box of Foam Force darts"
-	id = "foamforce"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2000)
-	build_path = /obj/item/ammo_box/foambox
-	category = list("initial", "Miscellaneous")
-
 /datum/design/canvas/twentythreeXtwentythree
 	name = "23px by 23px Canvas"
 	id = "canvas23x23"
@@ -354,371 +831,6 @@
 	materials = list(MAT_METAL = 100)
 	build_path = /obj/item/weapon/canvas/twentythreeXtwentythree
 	category = list("initial", "Miscellaneous")
-
-/datum/design/camera_assembly
-	name = "Camera Assembly"
-	id = "camera_assembly"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 400, MAT_GLASS = 250)
-	build_path = /obj/item/weapon/camera_assembly
-	category = list("initial", "Construction")
-
-/datum/design/glass
-	name = "Glass"
-	id = "glass"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/glass
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/light_bulb
-	name = "Light Bulb"
-	id = "light_bulb"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 60, MAT_GLASS = 100)
-	build_path = /obj/item/weapon/light/bulb
-	category = list("initial", "Construction")
-
-/datum/design/light_tube
-	name = "Light Tube"
-	id = "light_tube"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 60, MAT_GLASS = 100)
-	build_path = /obj/item/weapon/light/tube
-	category = list("initial", "Construction")
-
-/datum/design/metal
-	name = "Metal"
-	id = "metal"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/metal
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/newscaster_frame
-	name = "Newscaster Frame"
-	id = "newscaster_frame"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 14000, MAT_GLASS = 8000)
-	build_path = /obj/item/mounted/frame/newscaster_frame
-	category = list("initial", "Construction")
-
-/datum/design/rcd_ammo
-	name = "Compressed Matter Cardridge"
-	id = "rcd_ammo"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 16000, MAT_GLASS=8000)
-	build_path = /obj/item/weapon/rcd_ammo
-	category = list("initial","Construction")
-
-/datum/design/rglass
-	name = "Reinforced Glass"
-	id = "rglass"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/rglass
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/rods
-	name = "Metal Rod"
-	id = "rods"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000)
-	build_path = /obj/item/stack/rods
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/beaker
-	name = "Beaker"
-	id = "beaker"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 500)
-	build_path = /obj/item/weapon/reagent_containers/glass/beaker
-	category = list("initial", "Medical")
-
-/datum/design/cautery
-	name = "Cautery"
-	id = "cautery"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2500, MAT_GLASS = 750)
-	build_path = /obj/item/weapon/cautery
-	category = list("initial", "Medical")
-
-/datum/design/circular_saw
-	name = "Circular Saw"
-	id = "circular_saw"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/circular_saw
-	category = list("initial", "Medical")
-
-/datum/design/hemostat
-	name = "Hemostat"
-	id = "hemostat"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 2500)
-	build_path = /obj/item/weapon/hemostat
-	category = list("initial", "Medical")
-
-/datum/design/large_beaker
-	name = "Large Beaker"
-	id = "large_beaker"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 2500)
-	build_path = /obj/item/weapon/reagent_containers/glass/beaker/large
-	category = list("initial", "Medical")
-
-/datum/design/healthanalyzer
-	name = "Health Analyzer"
-	id = "healthanalyzer"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/healthanalyzer
-	category = list("initial", "Medical")
-
-/datum/design/retractor
-	name = "Retractor"
-	id = "retractor"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 6000, MAT_GLASS = 3000)
-	build_path = /obj/item/weapon/retractor
-	category = list("initial", "Medical")
-
-/datum/design/scalpel
-	name = "Scalpel"
-	id = "scalpel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
-	build_path = /obj/item/weapon/scalpel
-	category = list("initial", "Medical")
-
-/datum/design/surgicaldrill
-	name = "Surgical Drill"
-	id = "surgicaldrill"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/surgicaldrill
-	category = list("initial", "Medical")
-
-/datum/design/bonesetter
-	name = "Bone Setter"
-	id = "bonesetter"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/weapon/bonesetter
-	category = list("initial", "Medical")
-
-/datum/design/fixovein
-	name = "FixOVein"
-	id = "fixovein"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000)
-	build_path = /obj/item/weapon/FixOVein
-	category = list("initial", "Medical")
-
-/datum/design/bonegel
-	name = "Bone Gel"
-	id = "bonegel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/bonegel
-	category = list("initial", "Medical")
-
-/datum/design/syringe
-	name = "Syringe"
-	id = "syringe"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
-	build_path = /obj/item/weapon/reagent_containers/syringe
-	category = list("initial", "Medical")
-
-/datum/design/beanbag_slug
-	name = "Beanbag Slug"
-	id = "beanbag_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250)
-	build_path = /obj/item/ammo_casing/shotgun/beanbag
-	category = list("initial", "Security")
-
-/datum/design/rubbershot
-	name = "Rubber shot"
-	id = "rubber_shot"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/rubbershot
-	category = list("initial", "Security")
-
-/datum/design/c38
-	name = "Speed Loader (.38)"
-	id = "c38"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c38
-	category = list("initial", "Security")
-
-/datum/design/radio_headset
-	name = "Radio Headset"
-	id = "radio_headset"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75)
-	build_path = /obj/item/device/radio/headset
-	category = list("initial", "Communication")
-
-/datum/design/signaler
-	name = "Remote Signaling Device"
-	id = "signaler"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 400, MAT_GLASS = 120)
-	build_path = /obj/item/device/assembly/signaler
-	category = list("initial", "Communication")
-
-/datum/design/bounced_radio
-	name = "Station Bounced Radio"
-	id = "bounced_radio"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75, MAT_GLASS = 25)
-	build_path = /obj/item/device/radio/off
-	category = list("initial", "Communication")
-
-//hacked autolathe recipes
-/datum/design/c45
-	name = "Ammo Box (.45)"
-	id = "c45"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c45
-	category = list("hacked", "Security")
-
-/datum/design/a357
-	name = "Ammo Box (.357)"
-	id = "a357"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/a357
-	category = list("hacked", "Security")
-
-/datum/design/c9mm
-	name = "Ammo Box (9mm)"
-	id = "c9mm"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c9mm
-	category = list("hacked", "Security")
-
-/datum/design/c10mm
-	name = "Ammo Box (10mm)"
-	id = "c10mm"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c10mm
-	category = list("hacked", "Security")
-
-/datum/design/buckshot_shell
-	name = "Buckshot Shell"
-	id = "buckshot_shell"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
-
-/datum/design/electropack
-	name = "Electropack"
-	id = "electropack"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 2500)
-	build_path = /obj/item/device/radio/electropack
-	category = list("hacked", "Tools")
-
-/datum/design/flamethrower
-	name = "Flamethrower"
-	id = "flamethrower"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/flamethrower/full
-	category = list("hacked", "Security")
-
-/datum/design/handcuffs
-	name = "Handcuffs"
-	id = "handcuffs"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/restraints/handcuffs
-	category = list("hacked", "Security")
-
-/datum/design/incendiary_slug
-	name = "Incendiary Slug"
-	id = "incendiary_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/incendiary
-	category = list("hacked", "Security")
-
-/datum/design/large_welding_tool
-	name = "Industrial Welding Tool"
-	id = "large_welding_tool"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
-	build_path = /obj/item/weapon/weldingtool/largetank
-	category = list("hacked", "Tools")
-
-/datum/design/rcd
-	name = "Rapid Construction Device (RCD)"
-	id = "rcd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/weapon/rcd
-	category = list("hacked", "Construction")
-
-/datum/design/rpd
-	name = "Rapid Pipe Dispenser"
-	id = "rpd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000, MAT_GLASS = 5000)
-	build_path = /obj/item/weapon/rpd
-	category = list("hacked", "Construction")
-
-/datum/design/shotgun_dart
-	name = "Shotgun Dart"
-	id = "shotgun_dart"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/dart
-	category = list("hacked", "Security")
-
-/datum/design/shotgun_slug
-	name = "Shotgun Slug"
-	id = "shotgun_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
-
-/datum/design/desttagger
-	name = "Destination tagger"
-	id = "desttagger"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250, MAT_GLASS = 125)
-	build_path = /obj/item/device/destTagger
-	category = list("initial", "Electronics")
-
-/datum/design/handlabeler
-	name = "Hand labeler"
-	id = "handlabel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
-	build_path = /obj/item/weapon/hand_labeler
-	category = list("initial", "Electronics")
-
-/datum/design/floorpainter
-	name = "Floor painter"
-	id = "floor_painter"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
-	build_path = /obj/item/device/floor_painter
-	category = list("initial", "Electronics")
 
 /datum/design/logic_board
 	name = "Logic Circuit"
@@ -737,35 +849,3 @@
 	materials = list(MAT_GLASS = 750, MAT_METAL = 250)
 	build_path = /obj/item/weapon/circuitboard/vendor
 	category = list("initial", "Electronics")
-
-/datum/design/conveyor_belt
-	name = "Conveyor belt"
-	id = "conveyor_belt"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000)
-	build_path = /obj/item/conveyor_construct
-	category = list("initial", "Construction")
-
-/datum/design/conveyor_switch
-	name = "Conveyor belt switch"
-	id = "conveyor_switch"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
-	build_path = /obj/item/conveyor_switch_construct
-	category = list("initial", "Construction")
-
-/datum/design/laptop
-	name = "Laptop Frame"
-	id = "laptop"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 1000)
-	build_path = /obj/item/device/modular_computer/laptop/buildable
-	category = list("initial", "Miscellaneous")
-
-/datum/design/tablet
-	name = "Tablet Frame"
-	id = "tablet"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
-	build_path = /obj/item/device/modular_computer/tablet
-	category = list("initial", "Miscellaneous")

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -2,6 +2,14 @@
 //////////Autolathe Designs ///////
 ///////////////////////////////////
 
+/datum/design/analyzer
+	name = "Analyzer"
+	id = "analyzer"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
+	build_path = /obj/item/device/analyzer
+	category = list("initial","Tools")
+
 /datum/design/bucket
 	name = "Bucket"
 	id = "bucket"
@@ -18,20 +26,20 @@
 	build_path = /obj/item/weapon/crowbar
 	category = list("initial","Tools")
 
-/datum/design/flashlight
-	name = "Flashlight"
-	id = "flashlight"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
-	build_path = /obj/item/device/flashlight
-	category = list("initial","Tools")
-
 /datum/design/extinguisher
 	name = "Fire Extinguisher"
 	id = "extinguisher"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 90)
 	build_path = /obj/item/weapon/extinguisher
+	category = list("initial","Tools")
+
+/datum/design/flashlight
+	name = "Flashlight"
+	id = "flashlight"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 20)
+	build_path = /obj/item/device/flashlight
 	category = list("initial","Tools")
 
 /datum/design/multitool
@@ -42,38 +50,6 @@
 	build_path = /obj/item/device/multitool
 	category = list("initial","Tools")
 
-/datum/design/analyzer
-	name = "Analyzer"
-	id = "analyzer"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30, MAT_GLASS = 20)
-	build_path = /obj/item/device/analyzer
-	category = list("initial","Tools")
-
-/datum/design/tscanner
-	name = "T-ray Scanner"
-	id = "tscanner"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150)
-	build_path = /obj/item/device/t_scanner
-	category = list("initial","Tools")
-
-/datum/design/weldingtool
-	name = "Welding Tool"
-	id = "welding_tool"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 70, MAT_GLASS = 20)
-	build_path = /obj/item/weapon/weldingtool
-	category = list("initial","Tools")
-
-/datum/design/mini_weldingtool
-	name = "Emergency welding tool"
-	id = "mini_welding_tool"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30, MAT_GLASS = 10)
-	build_path = /obj/item/weapon/weldingtool/mini
-	category = list("initial","Tools")
-
 /datum/design/screwdriver
 	name = "Screwdriver"
 	id = "screwdriver"
@@ -82,20 +58,12 @@
 	build_path = /obj/item/weapon/screwdriver
 	category = list("initial","Tools")
 
-/datum/design/wirecutters
-	name = "Wirecutters"
-	id = "wirecutters"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 80)
-	build_path = /obj/item/weapon/wirecutters
-	category = list("initial","Tools")
-
-/datum/design/wrench
-	name = "Wrench"
-	id = "wrench"
+/datum/design/tscanner
+	name = "T-ray Scanner"
+	id = "tscanner"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 150)
-	build_path = /obj/item/weapon/wrench
+	build_path = /obj/item/device/t_scanner
 	category = list("initial","Tools")
 
 /datum/design/welding_helmet
@@ -115,28 +83,44 @@
 	category = list("initial","Tools")
 	maxstack = 30
 
-/datum/design/toolbox
-	name = "Toolbox"
-	id = "tool_box"
+/datum/design/weldingtool
+	name = "Welding Tool"
+	id = "welding_tool"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/storage/toolbox
+	materials = list(MAT_METAL = 70, MAT_GLASS = 20)
+	build_path = /obj/item/weapon/weldingtool
 	category = list("initial","Tools")
 
-/datum/design/console_screen
-	name = "Console Screen"
-	id = "console_screen"
+/datum/design/wirecutters
+	name = "Wirecutters"
+	id = "wirecutters"
 	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 200)
-	build_path = /obj/item/weapon/stock_parts/console_screen
-	category = list("initial", "Electronics")
+	materials = list(MAT_METAL = 80)
+	build_path = /obj/item/weapon/wirecutters
+	category = list("initial","Tools")
 
-/datum/design/apc_board
-	name = "APC module"
-	id = "power control"
+/datum/design/wrench
+	name = "Wrench"
+	id = "wrench"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150)
+	build_path = /obj/item/weapon/wrench
+	category = list("initial","Tools")
+
+/datum/design/spraycan
+	name = "Spraycan"
+	id = "spraycan"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
-	build_path = /obj/item/weapon/apc_electronics
+	build_path = /obj/item/toy/crayon/spraycan
+	category = list("initial", "Tools")
+
+/datum/design/airalarm_electronics
+	name = "Air Alarm Electronics"
+	id = "airalarm_electronics"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
+	build_path = /obj/item/weapon/airalarm_electronics
 	category = list("initial", "Electronics")
 
 /datum/design/airlock_board
@@ -155,20 +139,12 @@
 	build_path = /obj/item/weapon/firelock_electronics
 	category = list("initial", "Electronics")
 
-/datum/design/airalarm_electronics
-	name = "Air Alarm Electronics"
-	id = "airalarm_electronics"
+/datum/design/apc_electronics
+	name="Power Control Module"
+	id = "apc_electronics"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/airalarm_electronics
-	category = list("initial", "Electronics")
-
-/datum/design/firealarm_electronics
-	name = "Fire Alarm Electronics"
-	id = "firealarm_electronics"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
-	build_path = /obj/item/weapon/firealarm_electronics
+	build_path = /obj/item/weapon/apc_electronics
 	category = list("initial", "Electronics")
 
 /datum/design/intercom_electronics
@@ -179,6 +155,22 @@
 	build_path = /obj/item/weapon/intercom_electronics
 	category = list("initial", "Electronics")
 
+/datum/design/console_screen
+	name = "Console Screen"
+	id = "console_screen"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 200)
+	build_path = /obj/item/weapon/stock_parts/console_screen
+	category = list("initial", "Electronics")
+
+/datum/design/firealarm_electronics
+	name = "Fire Alarm Electronics"
+	id = "firealarm_electronics"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50, MAT_GLASS = 50)
+	build_path = /obj/item/weapon/firealarm_electronics
+	category = list("initial", "Electronics")
+
 /datum/design/earmuffs
 	name = "Earmuffs"
 	id = "earmuffs"
@@ -187,65 +179,29 @@
 	build_path = /obj/item/clothing/ears/earmuffs
 	category = list("initial", "Miscellaneous")
 
-/datum/design/pipe_painter
-	name = "Pipe Painter"
-	id = "pipe_painter"
+/datum/design/igniter
+	name = "Igniter"
+	id = "igniter"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 2000)
-	build_path = /obj/item/device/pipe_painter
+	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
+	build_path = /obj/item/device/assembly/igniter
 	category = list("initial", "Miscellaneous")
 
-/datum/design/floorpainter
-	name = "Floor painter"
-	id = "floor_painter"
+/datum/design/infrared_emitter
+	name = "Infrared Emitter"
+	id = "infrared_emitter"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
-	build_path = /obj/item/device/floor_painter
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
+	build_path = /obj/item/device/assembly/infra
 	category = list("initial", "Miscellaneous")
 
-/datum/design/metal
-	name = "Metal"
-	id = "metal"
+/datum/design/health_sensor
+	name = "Health sensor"
+	id = "health_sensor"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/metal
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/glass
-	name = "Glass"
-	id = "glass"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/glass
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/rglass
-	name = "Reinforced Glass"
-	id = "rglass"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
-	build_path = /obj/item/stack/sheet/rglass
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/rods
-	name = "Metal Rod"
-	id = "rods"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000)
-	build_path = /obj/item/stack/rods
-	category = list("initial","Construction")
-	maxstack = 50
-
-/datum/design/rcd_ammo
-	name = "Compressed Matter Cardridge"
-	id = "rcd_ammo"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 16000, MAT_GLASS=8000)
-	build_path = /obj/item/weapon/rcd_ammo
-	category = list("initial","Construction")
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/health
+	category = list("initial", "Medical")
 
 /datum/design/kitchen_knife
 	name = "Kitchen Knife"
@@ -253,53 +209,13 @@
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 12000)
 	build_path = /obj/item/weapon/kitchen/knife
-	category = list("initial","Dinnerware")
+	category = list("initial","Miscellaneous")
 
-/datum/design/fork
-	name = "Fork"
-	id = "fork"
+/datum/design/minihoe
+	name = "Mini Hoe"
+	id = "mini_hoe"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 80)
-	build_path = /obj/item/weapon/kitchen/utensil/fork
-	category = list("initial","Dinnerware")
-
-/datum/design/tray
-	name = "Tray"
-	id = "tray"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 3000)
-	build_path = /obj/item/weapon/storage/bag/tray
-	category = list("initial","Dinnerware")
-
-/datum/design/drinking_glass
-	name = "Drinking glass"
-	id = "drinking_glass"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 500)
-	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass
-	category = list("initial","Dinnerware")
-
-/datum/design/shot_glass
-	name = "Shot glass"
-	id = "shot_glass"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 100)
-	build_path = /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass
-	category = list("initial","Dinnerware")
-
-/datum/design/shaker
-	name = "Shaker"
-	id = "shaker"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1500)
-	build_path = /obj/item/weapon/reagent_containers/food/drinks/shaker
-	category = list("initial","Dinnerware")
-
-/datum/design/cultivator
-	name = "Cultivator"
-	id = "cultivator"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL=50)
+	materials = list(MAT_METAL = 50)
 	build_path = /obj/item/weapon/cultivator
 	category = list("initial","Miscellaneous")
 
@@ -335,125 +251,37 @@
 	build_path = /obj/item/weapon/hatchet
 	category = list("initial","Miscellaneous")
 
-/datum/design/scalpel
-	name = "Scalpel"
-	id = "scalpel"
+/datum/design/pipe_painter
+	name = "Pipe Painter"
+	id = "pipe_painter"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
-	build_path = /obj/item/weapon/scalpel
-	category = list("initial", "Medical")
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 2000)
+	build_path = /obj/item/device/pipe_painter
+	category = list("initial", "Miscellaneous")
 
-/datum/design/circular_saw
-	name = "Circular Saw"
-	id = "circular_saw"
+/datum/design/prox_sensor
+	name = "Proximity Sensor"
+	id = "prox_sensor"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/circular_saw
-	category = list("initial", "Medical")
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/prox_sensor
+	category = list("initial", "Miscellaneous")
 
-/datum/design/surgicaldrill
-	name = "Surgical Drill"
-	id = "surgicaldrill"
+/datum/design/mousetrap
+	name = "Mousetrap"
+	id = "mousetrap"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/surgicaldrill
-	category = list("initial", "Medical")
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
+	build_path = /obj/item/device/assembly/mousetrap
+	category = list("initial", "Miscellaneous")
 
-/datum/design/retractor
-	name = "Retractor"
-	id = "retractor"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 6000, MAT_GLASS = 3000)
-	build_path = /obj/item/weapon/retractor
-	category = list("initial", "Medical")
-
-/datum/design/cautery
-	name = "Cautery"
-	id = "cautery"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2500, MAT_GLASS = 750)
-	build_path = /obj/item/weapon/cautery
-	category = list("initial", "Medical")
-
-/datum/design/hemostat
-	name = "Hemostat"
-	id = "hemostat"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 2500)
-	build_path = /obj/item/weapon/hemostat
-	category = list("initial", "Medical")
-
-/datum/design/bonesetter
-	name = "Bone Setter"
-	id = "bonesetter"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/weapon/bonesetter
-	category = list("initial", "Medical")
-
-/datum/design/fixovein
-	name = "FixOVein"
-	id = "fixovein"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000)
-	build_path = /obj/item/weapon/FixOVein
-	category = list("initial", "Medical")
-
-/datum/design/bonegel
-	name = "Bone Gel"
-	id = "bonegel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 6000)
-	build_path = /obj/item/weapon/bonegel
-	category = list("initial", "Medical")
-
-/datum/design/beaker
-	name = "Beaker"
-	id = "beaker"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 500)
-	build_path = /obj/item/weapon/reagent_containers/glass/beaker
-	category = list("initial", "Medical")
-
-/datum/design/large_beaker
-	name = "Large Beaker"
-	id = "large_beaker"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 2500)
-	build_path = /obj/item/weapon/reagent_containers/glass/beaker/large
-	category = list("initial", "Medical")
-
-/datum/design/healthanalyzer
-	name = "Health Analyzer"
-	id = "healthanalyzer"
+/datum/design/timer
+	name = "Timer"
+	id = "timer"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/healthanalyzer
-	category = list("initial", "Medical")
-
-/datum/design/beanbag_slug
-	name = "Beanbag Slug"
-	id = "beanbag_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250)
-	build_path = /obj/item/ammo_casing/shotgun/beanbag
-	category = list("initial", "Security")
-
-/datum/design/rubbershot
-	name = "Rubber shot"
-	id = "rubber_shot"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/rubbershot
-	category = list("initial", "Security")
-
-/datum/design/c38
-	name = "Speed Loader (.38)"
-	id = "c38"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c38
-	category = list("initial", "Security")
+	build_path = /obj/item/device/assembly/timer
+	category = list("initial", "Miscellaneous")
 
 /datum/design/recorder
 	name = "Universal Recorder"
@@ -471,317 +299,12 @@
 	build_path = /obj/item/device/tape/random
 	category = list("initial", "Miscellaneous")
 
-/datum/design/igniter
-	name = "Igniter"
-	id = "igniter"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/assembly/igniter
-	category = list("initial", "Miscellaneous")
-
-/datum/design/signaler
-	name = "Remote Signaling Device"
-	id = "signaler"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 400, MAT_GLASS = 120)
-	build_path = /obj/item/device/assembly/signaler
-	category = list("initial", "Communication")
-
-/datum/design/radio_headset
-	name = "Radio Headset"
-	id = "radio_headset"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75)
-	build_path = /obj/item/device/radio/headset
-	category = list("initial", "Communication")
-
-/datum/design/bounced_radio
-	name = "Station Bounced Radio"
-	id = "bounced_radio"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75, MAT_GLASS = 25)
-	build_path = /obj/item/device/radio/off
-	category = list("initial", "Communication")
-
-/datum/design/infrared_emitter
-	name = "Infrared Emitter"
-	id = "infrared_emitter"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 500)
-	build_path = /obj/item/device/assembly/infra
-	category = list("initial", "Miscellaneous")
-
-/datum/design/health_sensor
-	name = "Health sensor"
-	id = "health_sensor"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/health
-	category = list("initial", "Medical")
-
-/datum/design/timer
-	name = "Timer"
-	id = "timer"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
-	build_path = /obj/item/device/assembly/timer
-	category = list("initial", "Miscellaneous")
-
 /datum/design/voice_analyser
 	name = "Voice Analyser"
 	id = "voice_analyser"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
 	build_path = /obj/item/device/assembly/voice
-	category = list("initial", "Miscellaneous")
-
-/datum/design/light_tube
-	name = "Light Tube"
-	id = "light_tube"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 100)
-	build_path = /obj/item/weapon/light/tube
-	category = list("initial", "Construction")
-
-/datum/design/light_bulb
-	name = "Light Bulb"
-	id = "light_bulb"
-	build_type = AUTOLATHE
-	materials = list(MAT_GLASS = 100)
-	build_path = /obj/item/weapon/light/bulb
-	category = list("initial", "Construction")
-
-/datum/design/camera_assembly
-	name = "Camera Assembly"
-	id = "camera_assembly"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 400, MAT_GLASS = 250)
-	build_path = /obj/item/weapon/camera_assembly
-	category = list("initial", "Construction")
-
-/datum/design/newscaster_frame
-	name = "Newscaster Frame"
-	id = "newscaster_frame"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 14000, MAT_GLASS = 8000)
-	build_path = /obj/item/mounted/frame/newscaster_frame
-	category = list("initial", "Construction")
-
-/datum/design/syringe
-	name = "Syringe"
-	id = "syringe"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
-	build_path = /obj/item/weapon/reagent_containers/syringe
-	category = list("initial", "Medical")
-
-/datum/design/prox_sensor
-	name = "Proximity Sensor"
-	id = "prox_sensor"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/prox_sensor
-	category = list("initial", "Miscellaneous")
-
-/datum/design/foam_dart
-	name = "Box of Foam Darts"
-	id = "foam_dart"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/ammo_box/foambox
-	category = list("initial", "Miscellaneous")
-
-//hacked autolathe recipes
-/datum/design/flamethrower
-	name = "Flamethrower"
-	id = "flamethrower"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/flamethrower/full
-	category = list("hacked", "Security")
-
-/datum/design/rcd
-	name = "Rapid Construction Device (RCD)"
-	id = "rcd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/weapon/rcd
-	category = list("hacked", "Construction")
-
-/datum/design/electropack
-	name = "Electropack"
-	id = "electropack"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 2500)
-	build_path = /obj/item/device/radio/electropack
-	category = list("hacked", "Tools")
-
-/datum/design/large_welding_tool
-	name = "Industrial Welding Tool"
-	id = "large_welding_tool"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
-	build_path = /obj/item/weapon/weldingtool/largetank
-	category = list("hacked", "Tools")
-
-/datum/design/handcuffs
-	name = "Handcuffs"
-	id = "handcuffs"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
-	build_path = /obj/item/weapon/restraints/handcuffs
-	category = list("hacked", "Security")
-
-/datum/design/shotgun_slug
-	name = "Shotgun Slug"
-	id = "shotgun_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
-
-/datum/design/buckshot_shell
-	name = "Buckshot shell"
-	id = "buckshot_shell"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
-
-/datum/design/shotgun_dart
-	name = "Shotgun Dart"
-	id = "shotgun_dart"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/dart
-	category = list("hacked", "Security")
-
-/datum/design/incendiary_slug
-	name = "Incendiary Slug"
-	id = "incendiary_slug"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/incendiary
-	category = list("hacked", "Security")
-
-/datum/design/riot_dart
-	name = "Foam riot dart"
-	id = "riot_dart"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000) //Discount for making individually - no box = less metal!
-	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
-	category = list("hacked", "Security")
-
-/datum/design/riot_darts
-	name = "Foam riot dart box"
-	id = "riot_darts"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 50000) //Comes with 40 darts
-	build_path = /obj/item/ammo_box/foambox/riot
-	category = list("hacked", "Security")
-
-/datum/design/a357
-	name = "Ammo Box (.357)"
-	id = "a357"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/a357
-	category = list("hacked", "Security")
-
-/datum/design/c10mm
-	name = "Ammo Box (10mm)"
-	id = "c10mm"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c10mm
-	category = list("hacked", "Security")
-
-/datum/design/c45
-	name = "Ammo Box (.45)"
-	id = "c45"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c45
-	category = list("hacked", "Security")
-
-/datum/design/c9mm
-	name = "Ammo Box (9mm)"
-	id = "c9mm"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/c9mm
-	category = list("hacked", "Security")
-
-/datum/design/cleaver
-	name = "Butcher's cleaver"
-	id = "cleaver"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 18000)
-	build_path = /obj/item/weapon/kitchen/knife/butcher
-	category = list("hacked", "Dinnerware")
-
-/datum/design/spraycan
-	name = "Spraycan"
-	id = "spraycan"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 100, MAT_GLASS = 100)
-	build_path = /obj/item/toy/crayon/spraycan
-	category = list("initial", "Tools")
-
-/datum/design/desttagger
-	name = "Destination tagger"
-	id = "desttagger"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 250, MAT_GLASS = 125)
-	build_path = /obj/item/device/destTagger
-	category = list("initial", "Electronics")
-
-/datum/design/handlabeler
-	name = "Hand labeler"
-	id = "handlabel"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
-	build_path = /obj/item/weapon/hand_labeler
-	category = list("initial", "Electronics")
-
-/datum/design/conveyor_belt
-	name = "Conveyor belt"
-	id = "conveyor_belt"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5000)
-	build_path = /obj/item/conveyor_construct
-	category = list("initial", "Construction")
-
-/datum/design/conveyor_switch
-	name = "Conveyor belt switch"
-	id = "conveyor_switch"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
-	build_path = /obj/item/conveyor_switch_construct
-	category = list("initial", "Construction")
-
-/datum/design/laptop
-	name = "Laptop Frame"
-	id = "laptop"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 10000, MAT_GLASS = 1000)
-	build_path = /obj/item/device/modular_computer/laptop/buildable
-	category = list("initial", "Miscellaneous")
-
-/datum/design/tablet
-	name = "Tablet Frame"
-	id = "tablet"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
-	build_path = /obj/item/device/modular_computer/tablet
-	category = list("initial", "Miscellaneous")
-
-/datum/design/mousetrap
-	name = "Mousetrap"
-	id = "mousetrap"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
-	build_path = /obj/item/device/assembly/mousetrap
 	category = list("initial", "Miscellaneous")
 
 /datum/design/videocam
@@ -816,6 +339,14 @@
 	build_path = /obj/item/weapon/canvas/twentythreeXnineteen
 	category = list("initial", "Miscellaneous")
 
+/datum/design/foambox
+	name = "Box of Foam Force darts"
+	id = "foamforce"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 2000)
+	build_path = /obj/item/ammo_box/foambox
+	category = list("initial", "Miscellaneous")
+
 /datum/design/canvas/twentythreeXtwentythree
 	name = "23px by 23px Canvas"
 	id = "canvas23x23"
@@ -823,6 +354,371 @@
 	materials = list(MAT_METAL = 100)
 	build_path = /obj/item/weapon/canvas/twentythreeXtwentythree
 	category = list("initial", "Miscellaneous")
+
+/datum/design/camera_assembly
+	name = "Camera Assembly"
+	id = "camera_assembly"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 400, MAT_GLASS = 250)
+	build_path = /obj/item/weapon/camera_assembly
+	category = list("initial", "Construction")
+
+/datum/design/glass
+	name = "Glass"
+	id = "glass"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/glass
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/light_bulb
+	name = "Light Bulb"
+	id = "light_bulb"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 60, MAT_GLASS = 100)
+	build_path = /obj/item/weapon/light/bulb
+	category = list("initial", "Construction")
+
+/datum/design/light_tube
+	name = "Light Tube"
+	id = "light_tube"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 60, MAT_GLASS = 100)
+	build_path = /obj/item/weapon/light/tube
+	category = list("initial", "Construction")
+
+/datum/design/metal
+	name = "Metal"
+	id = "metal"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/metal
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/newscaster_frame
+	name = "Newscaster Frame"
+	id = "newscaster_frame"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 14000, MAT_GLASS = 8000)
+	build_path = /obj/item/mounted/frame/newscaster_frame
+	category = list("initial", "Construction")
+
+/datum/design/rcd_ammo
+	name = "Compressed Matter Cardridge"
+	id = "rcd_ammo"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 16000, MAT_GLASS=8000)
+	build_path = /obj/item/weapon/rcd_ammo
+	category = list("initial","Construction")
+
+/datum/design/rglass
+	name = "Reinforced Glass"
+	id = "rglass"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = MINERAL_MATERIAL_AMOUNT)
+	build_path = /obj/item/stack/sheet/rglass
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/rods
+	name = "Metal Rod"
+	id = "rods"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000)
+	build_path = /obj/item/stack/rods
+	category = list("initial","Construction")
+	maxstack = 50
+
+/datum/design/beaker
+	name = "Beaker"
+	id = "beaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 500)
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker
+	category = list("initial", "Medical")
+
+/datum/design/cautery
+	name = "Cautery"
+	id = "cautery"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 2500, MAT_GLASS = 750)
+	build_path = /obj/item/weapon/cautery
+	category = list("initial", "Medical")
+
+/datum/design/circular_saw
+	name = "Circular Saw"
+	id = "circular_saw"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/circular_saw
+	category = list("initial", "Medical")
+
+/datum/design/hemostat
+	name = "Hemostat"
+	id = "hemostat"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 2500)
+	build_path = /obj/item/weapon/hemostat
+	category = list("initial", "Medical")
+
+/datum/design/large_beaker
+	name = "Large Beaker"
+	id = "large_beaker"
+	build_type = AUTOLATHE
+	materials = list(MAT_GLASS = 2500)
+	build_path = /obj/item/weapon/reagent_containers/glass/beaker/large
+	category = list("initial", "Medical")
+
+/datum/design/healthanalyzer
+	name = "Health Analyzer"
+	id = "healthanalyzer"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
+	build_path = /obj/item/device/healthanalyzer
+	category = list("initial", "Medical")
+
+/datum/design/retractor
+	name = "Retractor"
+	id = "retractor"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 6000, MAT_GLASS = 3000)
+	build_path = /obj/item/weapon/retractor
+	category = list("initial", "Medical")
+
+/datum/design/scalpel
+	name = "Scalpel"
+	id = "scalpel"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 1000)
+	build_path = /obj/item/weapon/scalpel
+	category = list("initial", "Medical")
+
+/datum/design/surgicaldrill
+	name = "Surgical Drill"
+	id = "surgicaldrill"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/surgicaldrill
+	category = list("initial", "Medical")
+
+/datum/design/bonesetter
+	name = "Bone Setter"
+	id = "bonesetter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/weapon/bonesetter
+	category = list("initial", "Medical")
+
+/datum/design/fixovein
+	name = "FixOVein"
+	id = "fixovein"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000, MAT_GLASS = 3000)
+	build_path = /obj/item/weapon/FixOVein
+	category = list("initial", "Medical")
+
+/datum/design/bonegel
+	name = "Bone Gel"
+	id = "bonegel"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 1000, MAT_GLASS = 6000)
+	build_path = /obj/item/weapon/bonegel
+	category = list("initial", "Medical")
+
+/datum/design/syringe
+	name = "Syringe"
+	id = "syringe"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10, MAT_GLASS = 20)
+	build_path = /obj/item/weapon/reagent_containers/syringe
+	category = list("initial", "Medical")
+
+/datum/design/beanbag_slug
+	name = "Beanbag Slug"
+	id = "beanbag_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 250)
+	build_path = /obj/item/ammo_casing/shotgun/beanbag
+	category = list("initial", "Security")
+
+/datum/design/rubbershot
+	name = "Rubber shot"
+	id = "rubber_shot"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/rubbershot
+	category = list("initial", "Security")
+
+/datum/design/c38
+	name = "Speed Loader (.38)"
+	id = "c38"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c38
+	category = list("initial", "Security")
+
+/datum/design/radio_headset
+	name = "Radio Headset"
+	id = "radio_headset"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75)
+	build_path = /obj/item/device/radio/headset
+	category = list("initial", "Communication")
+
+/datum/design/signaler
+	name = "Remote Signaling Device"
+	id = "signaler"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 400, MAT_GLASS = 120)
+	build_path = /obj/item/device/assembly/signaler
+	category = list("initial", "Communication")
+
+/datum/design/bounced_radio
+	name = "Station Bounced Radio"
+	id = "bounced_radio"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75, MAT_GLASS = 25)
+	build_path = /obj/item/device/radio/off
+	category = list("initial", "Communication")
+
+//hacked autolathe recipes
+/datum/design/c45
+	name = "Ammo Box (.45)"
+	id = "c45"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c45
+	category = list("hacked", "Security")
+
+/datum/design/a357
+	name = "Ammo Box (.357)"
+	id = "a357"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/a357
+	category = list("hacked", "Security")
+
+/datum/design/c9mm
+	name = "Ammo Box (9mm)"
+	id = "c9mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c9mm
+	category = list("hacked", "Security")
+
+/datum/design/c10mm
+	name = "Ammo Box (10mm)"
+	id = "c10mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/c10mm
+	category = list("hacked", "Security")
+
+/datum/design/buckshot_shell
+	name = "Buckshot Shell"
+	id = "buckshot_shell"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")
+
+/datum/design/electropack
+	name = "Electropack"
+	id = "electropack"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 2500)
+	build_path = /obj/item/device/radio/electropack
+	category = list("hacked", "Tools")
+
+/datum/design/flamethrower
+	name = "Flamethrower"
+	id = "flamethrower"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/flamethrower/full
+	category = list("hacked", "Security")
+
+/datum/design/handcuffs
+	name = "Handcuffs"
+	id = "handcuffs"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 500)
+	build_path = /obj/item/weapon/restraints/handcuffs
+	category = list("hacked", "Security")
+
+/datum/design/incendiary_slug
+	name = "Incendiary Slug"
+	id = "incendiary_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/incendiary
+	category = list("hacked", "Security")
+
+/datum/design/large_welding_tool
+	name = "Industrial Welding Tool"
+	id = "large_welding_tool"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 70, MAT_GLASS = 60)
+	build_path = /obj/item/weapon/weldingtool/largetank
+	category = list("hacked", "Tools")
+
+/datum/design/rcd
+	name = "Rapid Construction Device (RCD)"
+	id = "rcd"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/weapon/rcd
+	category = list("hacked", "Construction")
+
+/datum/design/rpd
+	name = "Rapid Pipe Dispenser"
+	id = "rpd"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000, MAT_GLASS = 5000)
+	build_path = /obj/item/weapon/rpd
+	category = list("hacked", "Construction")
+
+/datum/design/shotgun_dart
+	name = "Shotgun Dart"
+	id = "shotgun_dart"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/dart
+	category = list("hacked", "Security")
+
+/datum/design/shotgun_slug
+	name = "Shotgun Slug"
+	id = "shotgun_slug"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 4000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
+/datum/design/desttagger
+	name = "Destination tagger"
+	id = "desttagger"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 250, MAT_GLASS = 125)
+	build_path = /obj/item/device/destTagger
+	category = list("initial", "Electronics")
+
+/datum/design/handlabeler
+	name = "Hand labeler"
+	id = "handlabel"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
+	build_path = /obj/item/weapon/hand_labeler
+	category = list("initial", "Electronics")
+
+/datum/design/floorpainter
+	name = "Floor painter"
+	id = "floor_painter"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 150, MAT_GLASS = 125)
+	build_path = /obj/item/device/floor_painter
+	category = list("initial", "Electronics")
 
 /datum/design/logic_board
 	name = "Logic Circuit"
@@ -841,3 +737,35 @@
 	materials = list(MAT_GLASS = 750, MAT_METAL = 250)
 	build_path = /obj/item/weapon/circuitboard/vendor
 	category = list("initial", "Electronics")
+
+/datum/design/conveyor_belt
+	name = "Conveyor belt"
+	id = "conveyor_belt"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 5000)
+	build_path = /obj/item/conveyor_construct
+	category = list("initial", "Construction")
+
+/datum/design/conveyor_switch
+	name = "Conveyor belt switch"
+	id = "conveyor_switch"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
+	build_path = /obj/item/conveyor_switch_construct
+	category = list("initial", "Construction")
+
+/datum/design/laptop
+	name = "Laptop Frame"
+	id = "laptop"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 10000, MAT_GLASS = 1000)
+	build_path = /obj/item/device/modular_computer/laptop/buildable
+	category = list("initial", "Miscellaneous")
+
+/datum/design/tablet
+	name = "Tablet Frame"
+	id = "tablet"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
+	build_path = /obj/item/device/modular_computer/tablet
+	category = list("initial", "Miscellaneous")

--- a/nano/templates/rpd.tmpl
+++ b/nano/templates/rpd.tmpl
@@ -1,0 +1,105 @@
+<!-- 
+Used In File(s): /code/game/objects/items/weapons/rpd.dm
+-->
+<h2 style = "float:left;">Mode:</h2>
+<div style = "float:right;">{{:helper.link("Reset RPD", "refresh", {"refresh": 1}, data.refresh == 1 ? "linkOn" : null)}}</div>
+<div class = "item">
+	{{for data.mainmenu}}
+		{{:helper.link(String(value.key1), String(value.key3), {"mode": Number(value.key2)}, data.mode == Number(value.key2) ? "linkOn" : null)}}
+	{{/for}}
+</div>
+{{if data.mode == 1}}
+	<h3>Pipe type:</h3>
+	<div>
+		{{for data.pipemenu}}
+			{{:helper.link(String(value.key1), null, {"pipetype": Number(value.key2)}, data.pipetype == Number(value.key2) ? "linkOn" : null)}}
+		{{/for}}
+	</div>
+	<h3>Available pipes:</h3>
+	<div style = "width:45%; float:left;">
+		{{for data.pipelist}}
+			{{if value.key3 == data.pipetype}}
+				<div class = "item">{{:helper.link(String(value.key1), "arrow-right", {"whatpipe": Number(value.key2)}, data.whatpipe == Number(value.key2) ? "linkOn" : null)}}</div>
+			{{/if}}
+		{{/for}}
+	</div>
+	{{for data.pipelist}}
+		{{if value.key2 == data.whatpipe && value.key4 != 1}}
+			<div style = "float:right; width:50%;">
+				<div style = "margin-bottom:30pt;">
+					{{:helper.link("Orient automatically", null, {"iconrotation": 0}, data.iconrotation == 0 ? "linkOn" : null)}}
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 1}, data.iconrotation == 1 ? "linkOn" : null)}}
+					{{if value.key6 == 1}}
+						<img src = "{{:value.key5}}-northeast.png">
+					{{else}}
+						<img src = "{{:value.key5}}-north.png">
+					{{/if}}
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 4}, data.iconrotation == 4 ? "linkOn" : null)}}
+					{{if value.key6 == 1}}
+						<img src = "{{:value.key5}}-southeast.png">
+					{{else}}
+						<img src = "{{:value.key5}}-east.png">
+					{{/if}}
+				</div>
+			{{if value.key4 == 4}}
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 2}, data.iconrotation == 2 ? "linkOn" : null)}}
+					{{if value.key6 == 1}}
+						<img src = "{{:value.key5}}-southwest.png">
+					{{else}}
+						<img src = "{{:value.key5}}-south.png">
+					{{/if}}
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 8}, data.iconrotation == 8 ? "linkOn" : null)}}
+					{{if value.key6 == 1}}
+						<img src = "{{:value.key5}}-northwest.png">
+					{{else}}
+						<img src = "{{:value.key5}}-west.png">
+					{{/if}}
+				</div>
+			{{/if}}
+			</div>
+		{{/if}}
+	{{/for}}
+{{else data.mode == 2}}
+	<h3>Available pipes:</h3>
+	<div style = "width:45%; float:left;">
+	{{for data.dpipelist}}
+			<div class = "item">{{:helper.link(String(value.key1), "arrow-right", {"whatdpipe": Number(value.key2)}, data.whatdpipe == Number(value.key2) ? "linkOn" : null)}}</div>
+	{{/for}}
+	</div>
+	{{for data.dpipelist}}
+		{{if value.key2 == data.whatdpipe && value.key3 != 1}}
+			<div style = "float:right; width:50%;">
+				<div style = "margin-bottom:30pt;">
+						{{:helper.link("Orient automatically", null, {"iconrotation": 0}, data.iconrotation == 0 ? "linkOn" : null)}}
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 1}, data.iconrotation == 1 ? "linkOn" : null)}} <img src = "{{:value.key4}}-north.png">
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 4}, data.iconrotation == 4 ? "linkOn" : null)}}<img src = "{{:value.key4}}-east.png">
+				</div>
+				{{if value.key3 == 4}}
+					<div>
+						{{:helper.link("", "arrow-right", {"iconrotation": 2}, data.iconrotation == 2 ? "linkOn" : null)}} <img src = "{{:value.key4}}-south.png">
+					</div>
+					<div>
+						{{:helper.link("", "arrow-right", {"iconrotation": 8}, data.iconrotation == 8 ? "linkOn" : null)}}<img src = "{{:value.key4}}-west.png">
+					</div>
+				{{/if}}
+			</div>
+		{{/if}}
+	{{/for}}
+{{else data.mode == 3}}
+	<h3>Device ready to rotate loose pipes...</h3>
+{{else data.mode == 4}}
+	<h3>Device ready to flip loose pipes...</h3>
+{{else data.mode == 5}}
+	<h3>Device ready to eat loose pipes...</h3>
+{{/if}}

--- a/nano/templates/rpd.tmpl
+++ b/nano/templates/rpd.tmpl
@@ -1,70 +1,74 @@
 <!-- 
 Used In File(s): /code/game/objects/items/weapons/rpd.dm
 -->
-<h2 style = "float:left;">Mode:</h2>
+<h2 style = "float:left;">Mode:</h2> <!-- We loop through the mode list and display all entries -->
 <div style = "float:right;">{{:helper.link("Reset RPD", "refresh", {"refresh": 1}, data.refresh == 1 ? "linkOn" : null)}}</div>
 <div class = "item">
-	{{for data.mainmenu}}
+	{{for data.mainmenu}} <!--We loop through the pipe menu list (normal, scrubbers, etc.) and display all entries-->
 		{{:helper.link(String(value.key1), String(value.key3), {"mode": Number(value.key2)}, data.mode == Number(value.key2) ? "linkOn" : null)}}
 	{{/for}}
 </div>
 {{if data.mode == 1}}
 	<h3>Pipe type:</h3>
 	<div>
-		{{for data.pipemenu}}
+		{{for data.pipemenu}} <!--We loop through the pipe menu (normal, scrubbers, etc. and display all entries-->
 			{{:helper.link(String(value.key1), null, {"pipetype": Number(value.key2)}, data.pipetype == Number(value.key2) ? "linkOn" : null)}}
 		{{/for}}
 	</div>
 	<h3>Available pipes:</h3>
 	<div style = "width:45%; float:left;">
-		{{for data.pipelist}}
+		{{for data.pipelist}} <!--Display all pipes that match the selected menu-->
 			{{if value.key3 == data.pipetype}}
 				<div class = "item">{{:helper.link(String(value.key1), "arrow-right", {"whatpipe": Number(value.key2)}, data.whatpipe == Number(value.key2) ? "linkOn" : null)}}</div>
 			{{/if}}
 		{{/for}}
 	</div>
-	{{for data.pipelist}}
-		{{if value.key2 == data.whatpipe && value.key4 != 1}}
-			<div style = "float:right; width:50%;">
+	{{for data.pipelist}} <!-- For the selected pipe, we want to show a preview to allow the user to select a rotation-->
+		<div style = "float:right; width:50%;">
+			{{if value.key2 == data.whatpipe && value.key4 != 1}} <!--For pipes that are bidirectional-->
 				<div style = "margin-bottom:30pt;">
 					{{:helper.link("Orient automatically", null, {"iconrotation": 0}, data.iconrotation == 0 ? "linkOn" : null)}}
 				</div>
+			{{/if}}
+			{{if value.key2 == data.whatpipe && value.key4 != 1 && value.key6 != 1}}
 				<div>
 					{{:helper.link("", "arrow-right", {"iconrotation": 1}, data.iconrotation == 1 ? "linkOn" : null)}}
-					{{if value.key6 == 1}}
-						<img src = "{{:value.key5}}-northeast.png">
-					{{else}}
-						<img src = "{{:value.key5}}-north.png">
-					{{/if}}
+					<img src = "{{:value.key5}}-north.png">
 				</div>
 				<div>
 					{{:helper.link("", "arrow-right", {"iconrotation": 4}, data.iconrotation == 4 ? "linkOn" : null)}}
-					{{if value.key6 == 1}}
-						<img src = "{{:value.key5}}-southeast.png">
-					{{else}}
-						<img src = "{{:value.key5}}-east.png">
-					{{/if}}
+					<img src = "{{:value.key5}}-east.png">
 				</div>
-			{{if value.key4 == 4}}
+			{{/if}}
+			{{if value.key2 == data.whatpipe && value.key4 == 4 && value.key6 != 1}}
 				<div>
 					{{:helper.link("", "arrow-right", {"iconrotation": 2}, data.iconrotation == 2 ? "linkOn" : null)}}
-					{{if value.key6 == 1}}
-						<img src = "{{:value.key5}}-southwest.png">
-					{{else}}
-						<img src = "{{:value.key5}}-south.png">
-					{{/if}}
+					<img src = "{{:value.key5}}-south.png">
 				</div>
 				<div>
 					{{:helper.link("", "arrow-right", {"iconrotation": 8}, data.iconrotation == 8 ? "linkOn" : null)}}
-					{{if value.key6 == 1}}
-						<img src = "{{:value.key5}}-northwest.png">
-					{{else}}
-						<img src = "{{:value.key5}}-west.png">
-					{{/if}}
+					<img src = "{{:value.key5}}-west.png">
 				</div>
 			{{/if}}
-			</div>
-		{{/if}}
+			{{if value.key2 == data.whatpipe && value.key6 == 1}}
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 1}, data.iconrotation == 1 ? "linkOn" : null)}}
+					<img src = "{{:value.key5}}-northeast.png">
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 4}, data.iconrotation == 4 ? "linkOn" : null)}}
+					<img src = "{{:value.key5}}-southeast.png">
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 2}, data.iconrotation == 2 ? "linkOn" : null)}}
+					<img src = "{{:value.key5}}-southwest.png">
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 8}, data.iconrotation == 8 ? "linkOn" : null)}}
+					<img src = "{{:value.key5}}-northwest.png">
+				</div>
+			{{/if}}
+		</div>
 	{{/for}}
 {{else data.mode == 2}}
 	<h3>Available pipes:</h3>
@@ -74,27 +78,31 @@ Used In File(s): /code/game/objects/items/weapons/rpd.dm
 	{{/for}}
 	</div>
 	{{for data.dpipelist}}
-		{{if value.key2 == data.whatdpipe && value.key3 != 1}}
-			<div style = "float:right; width:50%;">
+		<div style = "float:right; width:50%;">
+			{{if value.key2 == data.whatdpipe && value.key3 != 1}}
 				<div style = "margin-bottom:30pt;">
-						{{:helper.link("Orient automatically", null, {"iconrotation": 0}, data.iconrotation == 0 ? "linkOn" : null)}}
+					{{:helper.link("Orient automatically", null, {"iconrotation": 0}, data.iconrotation == 0 ? "linkOn" : null)}}
 				</div>
 				<div>
-					{{:helper.link("", "arrow-right", {"iconrotation": 1}, data.iconrotation == 1 ? "linkOn" : null)}} <img src = "{{:value.key4}}-north.png">
+					{{:helper.link("", "arrow-right", {"iconrotation": 1}, data.iconrotation == 1 ? "linkOn" : null)}}
+					<img src = "{{:value.key4}}-north.png">
 				</div>
 				<div>
-					{{:helper.link("", "arrow-right", {"iconrotation": 4}, data.iconrotation == 4 ? "linkOn" : null)}}<img src = "{{:value.key4}}-east.png">
+					{{:helper.link("", "arrow-right", {"iconrotation": 4}, data.iconrotation == 4 ? "linkOn" : null)}}
+					<img src = "{{:value.key4}}-east.png">
 				</div>
-				{{if value.key3 == 4}}
-					<div>
-						{{:helper.link("", "arrow-right", {"iconrotation": 2}, data.iconrotation == 2 ? "linkOn" : null)}} <img src = "{{:value.key4}}-south.png">
-					</div>
-					<div>
-						{{:helper.link("", "arrow-right", {"iconrotation": 8}, data.iconrotation == 8 ? "linkOn" : null)}}<img src = "{{:value.key4}}-west.png">
-					</div>
-				{{/if}}
-			</div>
-		{{/if}}
+			{{/if}}
+			{{if value.key2 == data.whatdpipe && value.key3 == 4}}
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 2}, data.iconrotation == 2 ? "linkOn" : null)}}
+					<img src = "{{:value.key4}}-south.png">
+				</div>
+				<div>
+					{{:helper.link("", "arrow-right", {"iconrotation": 8}, data.iconrotation == 8 ? "linkOn" : null)}}
+					<img src = "{{:value.key4}}-west.png">
+				</div>
+			{{/if}}
+		</div>
 	{{/for}}
 {{else data.mode == 3}}
 	<h3>Device ready to rotate loose pipes...</h3>


### PR DESCRIPTION
It's finally here!

This PR adds my own implementation of /tg/'s RPD, but made to work with all pipes on paracode. It should also be relatively straightforward to add pipes that are added to the codebase in future.

This RPD can manipulate pipes in a variety of ways, can dispense any type of pipe, and also deletes pipes. It also has its own NanoUI!

http://i.imgur.com/t6OUGwi.gif
http://i.imgur.com/5lmYxgA.gif
http://i.imgur.com/UNjlue8.gif
http://i.imgur.com/nsnOeK7.gif

I've added an RPD to each atmos closet, and I've also updated the autolathe file so that it contains the RPD.

:cl:
rscadd: Adds the Rapid Pipe Dispenser (RPD). One RPD starts in each atmospherics locker, and more can be constructed at a hacked autolathe.
/:cl: