### PR TITLE
Adds enough playtime requirements for jobs, we can turn off "days since reg" system

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -57,6 +57,8 @@
 	minimal_access = list(access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_external_airlocks, access_construction, access_mineral_storeroom)
 	alt_titles = list("Maintenance Technician","Engine Technician","Electrician")
 	minimal_player_age = 7
+	exp_requirements = 300
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/engineer
 
 /datum/outfit/job/engineer
@@ -92,6 +94,8 @@
 	minimal_access = list(access_eva, access_atmospherics, access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_construction, access_mineral_storeroom)
 	alt_titles = list("Atmospheric Technician")
 	minimal_player_age = 7
+	exp_requirements = 300
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/atmos
 
 /datum/outfit/job/atmos

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -52,6 +52,8 @@
 	minimal_access = list(access_medical, access_morgue, access_surgery, access_maint_tunnels)
 	alt_titles = list("Surgeon","Nurse","Coroner")
 	minimal_player_age = 3
+	exp_requirements = 180
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/doctor
 
 /datum/outfit/job/doctor
@@ -115,6 +117,8 @@
 	minimal_access = list(access_medical, access_chemistry, access_maint_tunnels, access_mineral_storeroom)
 	alt_titles = list("Pharmacist","Pharmacologist")
 	minimal_player_age = 7
+	exp_requirements = 300
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/chemist
 
 /datum/outfit/job/chemist
@@ -145,6 +149,8 @@
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_research, access_maint_tunnels)
 	minimal_player_age = 3
+	exp_requirements = 180
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/geneticist
 
 /datum/outfit/job/geneticist
@@ -177,6 +183,8 @@
 	minimal_access = list(access_medical, access_virology, access_maint_tunnels, access_mineral_storeroom)
 	alt_titles = list("Pathologist","Microbiologist")
 	minimal_player_age = 7
+	exp_requirements = 300
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/virologist
 
 /datum/outfit/job/virologist
@@ -245,6 +253,8 @@
 	access = list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_morgue)
 	minimal_access=list(access_paramedic, access_medical, access_sec_doors, access_maint_tunnels, access_external_airlocks, access_morgue)
 	minimal_player_age = 3
+	exp_requirements = 180
+	exp_type = EXP_TYPE_CREW
 	outfit = /datum/outfit/job/paramedic
 
 /datum/outfit/job/paramedic

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -60,7 +60,8 @@
 	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch, access_maint_tunnels, access_mineral_storeroom)
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Plasma Researcher", "Xenobiologist", "Chemical Researcher")
 	minimal_player_age = 3
-
+	exp_requirements = 300
+	exp_type = EXP_TYPE_CREW
 	// All science-y guys get bonuses for maxing out their tech.
 	required_objectives = list(
 		/datum/job_objective/further_research
@@ -97,6 +98,8 @@
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research, access_maint_tunnels, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 	minimal_player_age = 3
+	exp_requirements = 180
+	exp_type = EXP_TYPE_CREW
 
 	required_objectives = list(
 		/datum/job_objective/make_cyborg,


### PR DESCRIPTION
New job playtime requirements:
- Engineer: 5h
- Atmos tech: 5h
- MD: 3h
- Med Chemist: 5h
- Genetics: 3h
- Viro: 5h
- Paramedic: 3h
- Scientist: 5h
- Robotocist: 3h

With these requirements in place, we can turn off the "USE_AGE_RESTRICTION_FOR_JOBS" system in config, and simply use playtime to gate access to jobs instead.
Heads, AI/borgs, and security already have playtime requirements.
Civil jobs don't have playtime requirements because they don't have account age requirements, either.

This is good, because:

- It is no longer possible for griefers, and incompetent people from other servers to immediately sign up as Engineer and release the Tesla, atmos tech and plasma flood the server, Scientist and blow huge holes in the station, etc.
- There is now a logical progression for job unlocks. We reward people who play on the server, and newbies can no longer take critical positions in their first few shifts. New players no longer get confusing screens like this https://gyazo.com/34b267171e15617c38836501f2c2169d which have different requirement types shown for different jobs.

This PR requires a config update (commenting out USE_AGE_RESTRICTION_FOR_JOBS) to take full effect.

🆑 Kyep
rscadd: Access to jobs is now based solely on Playtime, NOT days since BYOND account was registered.
/🆑

