### PR TITLE
Away missions load cables and maploader landmarks smoothly now

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -43,6 +43,8 @@ Pipelines + Other Objects -> Pipe network
 
 	if(!pipe_color_check(pipe_color))
 		pipe_color = null
+	// No need for a tween worldstart roundstart handler - pipenet creation is
+	// handled there
 
 /obj/machinery/atmospherics/initialize()
 	..()

--- a/code/modules/awaymissions/map_rng.dm
+++ b/code/modules/awaymissions/map_rng.dm
@@ -18,6 +18,11 @@
 		template_name = tname
 	if(template_name)
 		template = map_templates[template_name]
+	// Catches the interim-zone of worldstart and roundstart
+	// I want both the ticker to exist (so mapped-in maploaders don't trip this)
+	// but also not have started yet (since the zlevel system would handle this on its own otherwise)
+	if((ticker && ticker.current_state < GAME_STATE_PLAYING))
+		attempt_init()
 
 /obj/effect/landmark/map_loader/initialize()
 	..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -74,6 +74,12 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(level==1) hide(T.intact)
 	cable_list += src //add it to the global cable list
 
+	// Catches the interim-zone of worldstart and roundstart
+	// I want both the ticker to exist (so mapped-in cables don't trip this)
+	// but also not have started yet (since the zlevel system would handle this on its own otherwise)
+	if((ticker && ticker.current_state < GAME_STATE_PLAYING))
+		attempt_init()
+
 
 /obj/structure/cable/Destroy()					// called when a cable is deleted
 	if(powernet)


### PR DESCRIPTION
This kind of feels doofy, but keeps functionality for loaded cables and mapload landmarks triggering as they should.

:cl::Crazylemon
fix: Away mission power works now.
/:cl: