### PR TITLE
Nerfs Neuro-Toxin

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -819,10 +819,11 @@
 	drink_desc = "A drink that is guaranteed to knock you silly."
 
 /datum/reagent/consumable/ethanol/neurotoxin/on_mob_life(mob/living/M)
-	M.Weaken(3)
-	if(current_cycle >=55)
+	if(current_cycle >= 13)
+		M.Weaken(3)
+	if(current_cycle >= 55)
 		M.Druggy(55)
-	if(current_cycle >=200)
+	if(current_cycle >= 200)
 		M.adjustToxLoss(2)
 	..()
 


### PR DESCRIPTION
Here we go again.

Nerfs the bar drink "neuro-toxin".

Instead of weakening you instantly, it'll weaken after 13 cycles.

This is still fairly quick acting, with a low depletion rate, but it's no longer the standard "I win the game" chem that outclasses even antag chems.

Still nerfed, but not as much as my other PR. Obvious alternative to https://github.com/ParadiseSS13/Paradise/pull/6189

:cl: Fox McCloud
tweak: Neuro-toxin bar drink weakens after 13 cycles as opposed to instantly
/:cl: