### PR TITLE
Vox take 20% more brute damage. Fragile bird bones!

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -257,6 +257,8 @@
 	smell.<br/><br/>Most humans will never meet a Vox raider, instead learning of this insular species through \
 	dealing with their traders and merchants; those that do rarely enjoy the experience."
 
+	brute_mod = 1.2 //20% more brute damage. Fragile bird bones.
+
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
 


### PR DESCRIPTION
:cl:
tweak: Vox are now 20% less resilient to brute damage due to their light, porous and flexible skeletons.
/:cl:

**As per [the Vox wiki](https://nanotrasen.se/wiki/index.php/Vox).**
"_The Vox skeletal structure is unique with its light, porous, and flexible bones_" which, although granting 'enhanced flexibility, reduced weight and increased agility (tm)', would also mean the bones are also less resilient to damage.

Based on input it was decided that a brute damage multiplier (2 lines in diff) was preferred over the per-limb bone breaking threshold definitions and per-species limb definitions (40-50 lines diff).

This has a similar effect to https://github.com/ParadiseSS13/Paradise/pull/6492 in the sense that, yes, Vox bones do indeed break easier, but now Vox die quicker too. Definitely not worst-in-class as the Greys have 25% less resilience to brute damage than Humans (5% less resilience than Vox).

Might discourage players from prolonged engagements and encourage them to flee more/fight differently, as Vox should.