### PR TITLE
Gives both red and gamma ERT engineers belts containing CE tools

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -60,6 +60,17 @@
 		/obj/item/device/analyzer,
 		/obj/item/taperoll/engineering,
 		/obj/item/weapon/extinguisher/mini)
+		
+/obj/item/weapon/storage/belt/utility/ert
+	..()
+	new /obj/item/weapon/screwdriver/power(src)
+	new /obj/item/weapon/crowbar/power(src)
+	new /obj/item/weapon/weldingtool/experimental(src)//This can be changed if this is too much
+	new /obj/item/device/multitool(src)
+	new /obj/item/stack/cable_coil(src, 30, pick(COLOR_RED, COLOR_YELLOW, COLOR_ORANGE))
+	new /obj/item/weapon/extinguisher/mini(src)
+	new /obj/item/device/analyzer(src)
+	update_icon()
 
 /obj/item/weapon/storage/belt/utility/full/New()
 	..()

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -65,7 +65,7 @@
 	..()
 	new /obj/item/weapon/screwdriver/power(src)
 	new /obj/item/weapon/crowbar/power(src)
-	new /obj/item/weapon/weldingtool/experimental(src)//This can be changed if this is too much
+	new /obj/item/weapon/weldingtool/experimental(src)
 	new /obj/item/device/multitool(src)
 	new /obj/item/stack/cable_coil(src, 30, pick(COLOR_RED, COLOR_YELLOW, COLOR_ORANGE))
 	new /obj/item/weapon/extinguisher/mini(src)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -61,7 +61,7 @@
 		/obj/item/taperoll/engineering,
 		/obj/item/weapon/extinguisher/mini)
 		
-/obj/item/weapon/storage/belt/utility/ert
+/obj/item/weapon/storage/belt/utility/ert/New()
 	..()
 	new /obj/item/weapon/screwdriver/power(src)
 	new /obj/item/weapon/crowbar/power(src)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -108,7 +108,7 @@
 	..()
 	new /obj/item/weapon/screwdriver/power(src)
 	new /obj/item/weapon/crowbar/power(src)
-	new /obj/item/weapon/weldingtool/experimental(src)//This can be changed if this is too much
+	new /obj/item/weapon/weldingtool/experimental(src)
 	new /obj/item/device/multitool(src)
 	new /obj/item/stack/cable_coil(src, 30, pick(COLOR_RED, COLOR_YELLOW, COLOR_ORANGE))
 	new /obj/item/weapon/extinguisher/mini(src)

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -508,7 +508,7 @@ var/ert_request_answered = 0
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	suit_store = /obj/item/weapon/tank/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson
-	belt = /obj/item/weapon/storage/belt/utility/ert
+	belt = /obj/item/weapon/storage/belt/utility/ert/New()
 
 	l_pocket = /obj/item/device/t_scanner/extended_range
 	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
@@ -528,7 +528,7 @@ var/ert_request_answered = 0
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	suit_store = /obj/item/weapon/tank/emergency_oxygen/double/full
 	glasses = /obj/item/clothing/glasses/meson/night
-	belt = /obj/item/weapon/storage/belt/utility/ert
+	belt = /obj/item/weapon/storage/belt/utility/ert/New()
 
 	l_pocket = /obj/item/device/t_scanner/extended_range
 	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -508,6 +508,7 @@ var/ert_request_answered = 0
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	suit_store = /obj/item/weapon/tank/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson
+	belt = /obj/item/weapon/storage/belt/utility/ert
 
 	l_pocket = /obj/item/device/t_scanner/extended_range
 	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic
@@ -527,6 +528,7 @@ var/ert_request_answered = 0
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	suit_store = /obj/item/weapon/tank/emergency_oxygen/double/full
 	glasses = /obj/item/clothing/glasses/meson/night
+	belt = /obj/item/weapon/storage/belt/utility/ert
 
 	l_pocket = /obj/item/device/t_scanner/extended_range
 	r_pocket = /obj/item/weapon/melee/classic_baton/telescopic


### PR DESCRIPTION
Mostly just did this because I figured that they should be more or less as well equipped as the CE.
It adds a new utility belt, which is simply the CE one but with the traditional sprite. The ERT members are equipped with this belt.