### PR TITLE
Cleans Up Door Emag Code

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -372,7 +372,7 @@ About the new airlock wires panel:
 					return
 			else /*if(src.justzap)*/
 				return
-		else if(user.hallucination > 50 && prob(10) && src.operating == 0)
+		else if(user.hallucination > 50 && prob(10) && !operating)
 			to_chat(user, "<span class='danger'>You feel a powerful shock course through your body!</span>")
 			user.adjustStaminaLoss(50)
 			user.AdjustStunned(5)
@@ -688,7 +688,7 @@ About the new airlock wires panel:
 	if(!issilicon(user) && !isobserver(user))
 		return STATUS_CLOSE
 
-	if(operating < 0) //emagged
+	if(emagged)
 		to_chat(user, "<span class='warning'>Unable to interface: Internal error.</span>")
 		return STATUS_CLOSE
 	if(!canAIControl() && !isobserver(user))
@@ -810,7 +810,7 @@ About the new airlock wires panel:
 		return
 
 	add_fingerprint(user)
-	if((istype(C, /obj/item/weapon/weldingtool) && !( operating ) && density))
+	if((istype(C, /obj/item/weapon/weldingtool) && !operating && density))
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0,user))
 			if(frozen)
@@ -841,7 +841,7 @@ About the new airlock wires panel:
 			beingcrowbarred = 1 //derp, Agouri
 		else
 			beingcrowbarred = 0
-		if( beingcrowbarred && p_open && (operating == -1 || (density && welded && operating != 1 && !arePowerSystemsOn() && !locked)) )
+		if( beingcrowbarred && p_open && (emagged || (density && welded && (!operating || emagged) && !arePowerSystemsOn() && !locked)) )
 			playsound(loc, C.usesound, 100, 1)
 			user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to remove electronics from the airlock assembly.")
 			if(do_after(user, 40 * C.toolspeed, target = src))
@@ -872,7 +872,7 @@ About the new airlock wires panel:
 					ae = electronics
 					electronics = null
 					ae.loc = loc
-				if(operating == -1)
+				if(emagged)
 					ae.icon_state = "door_electronics_smoked"
 					operating = 0
 
@@ -938,7 +938,7 @@ About the new airlock wires panel:
 	..()
 
 /obj/machinery/door/airlock/open(var/forced=0)
-	if( operating || welded || locked )
+	if(operating || welded || locked || emagged)
 		return 0
 	if(!forced)
 		if( !arePowerSystemsOn() || isWireCut(AIRLOCK_WIRE_OPEN_DOOR) )
@@ -953,7 +953,7 @@ About the new airlock wires panel:
 	return ..()
 
 /obj/machinery/door/airlock/close(var/forced=0, var/override = 0)
-	if((operating & !override) || welded || locked)
+	if((operating & !override) || welded || locked || emagged)
 		return
 	if(!forced)
 		//despite the name, this wire is for general door control.
@@ -1056,7 +1056,7 @@ About the new airlock wires panel:
 		return
 
 	add_fingerprint(user)
-	if((istype(C, /obj/item/weapon/weldingtool) && !( operating > 0 ) && density))
+	if((istype(C, /obj/item/weapon/weldingtool) && !operating && density))
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0,user))
 			if(frozen)
@@ -1081,7 +1081,7 @@ About the new airlock wires panel:
 		return
 
 	add_fingerprint(user)
-	if((istype(C, /obj/item/weapon/weldingtool) && !( operating > 0 ) && density))
+	if((istype(C, /obj/item/weapon/weldingtool) && !operating && density))
 		var/obj/item/weapon/weldingtool/W = C
 		if(W.remove_fuel(0,user))
 			if(frozen)
@@ -1115,6 +1115,8 @@ About the new airlock wires panel:
 	update_icon()
 
 /obj/machinery/door/airlock/proc/prison_open()
+	if(emagged)
+		return
 	if(arePowerSystemsOn())
 		unlock()
 		open()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -26,7 +26,7 @@ obj/machinery/door/airlock/receive_signal(datum/signal/signal)
 		execute_current_command()
 
 obj/machinery/door/airlock/proc/execute_current_command()
-	if(operating)
+	if(operating || emagged)
 		return //emagged or busy doing something else
 
 	if(!cur_command)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -42,7 +42,7 @@
 	update_dir()
 	update_freelook_sight()
 	airlocks += src
-	
+
 /obj/machinery/door/setDir(newdir)
 	..()
 	update_dir()
@@ -54,8 +54,8 @@
 			bound_height = world.icon_size
 		else
 			bound_width = world.icon_size
-			bound_height = width * world.icon_size	
-	
+			bound_height = width * world.icon_size
+
 /obj/machinery/door/initialize()
 	air_update_turf(1)
 	..()
@@ -71,7 +71,8 @@
 	return ..()
 
 /obj/machinery/door/Bumped(atom/AM)
-	if(p_open || operating) return
+	if(p_open || operating || emagged)
+		return
 	if(isliving(AM))
 		var/mob/living/M = AM
 		if(world.time - M.last_bumped <= 10) return	//Can bump-open one airlock per second. This is to prevent shock spam.
@@ -99,14 +100,14 @@
 /obj/machinery/door/CanAtmosPass()
 	return !density
 
-/obj/machinery/door/proc/bumpopen(mob/user as mob)
+/obj/machinery/door/proc/bumpopen(mob/user)
 	if(operating)
 		return
 	add_fingerprint(user)
 	if(!requiresID())
 		user = null
 
-	if(density)
+	if(density && !emagged)
 		if(allowed(user) || emergency == 1)
 			open()
 			if(istype(user, /mob/living/simple_animal/bot))
@@ -135,11 +136,12 @@
 	if(istype(I, /obj/item/device/detective_scanner))
 		return
 
-	if(operating || isrobot(user))
+	if(isrobot(user))
 		return //borgs can't attack doors open because it conflicts with their AI-like interaction with them.
 
 	add_fingerprint(user)
-
+	if(operating || emagged)
+		return
 	if(density && (istype(I, /obj/item/weapon/card/emag) || istype(I, /obj/item/weapon/melee/energy/blade)))
 		emag_act(user)
 		return 1
@@ -154,12 +156,12 @@
 	if(density)
 		do_animate("deny")
 
-/obj/machinery/door/emag_act(user as mob)
+/obj/machinery/door/emag_act(mob/user)
 	if(density)
 		flick("door_spark", src)
 		sleep(6)
 		open()
-		operating = -1
+		emagged = 1
 		return 1
 
 /obj/machinery/door/blob_act()
@@ -216,11 +218,11 @@
 /obj/machinery/door/proc/open()
 	if(!density)
 		return 1
-	if(operating > 0)
+	if(operating)
 		return
 	if(!ticker)
 		return 0
-	if(!operating)		operating = 1
+	operating = 1
 
 	do_animate("opening")
 	set_opacity(0)
@@ -243,7 +245,7 @@
 /obj/machinery/door/proc/close()
 	if(density)
 		return 1
-	if(operating > 0)
+	if(operating)
 		return
 	operating = 1
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -46,25 +46,25 @@
 	src.add_fingerprint(user)
 	if(!( istype(C, /obj/item/weapon/crowbar) || (istype(C, /obj/item/weapon/twohanded/fireaxe) && C:wielded == 1) ))
 		return
-	if((src.density && (stat & NOPOWER) && !( src.operating )))
+	if((src.density && (stat & NOPOWER) && !operating))
 		spawn( 0 )
-			src.operating = 1
+			operating = 1
 			flick("pdoorc0", src)
 			src.icon_state = "pdoor0"
 			src.set_opacity(0)
 			sleep(15)
 			src.density = 0
-			src.operating = 0
+			operating = 0
 			return
 	return
 
 /obj/machinery/door/poddoor/open()
-	if(src.operating == 1) //doors can still open when emag-disabled
+	if(operating || emagged) //doors can still open when emag-disabled
 		return
 	if(!ticker)
 		return 0
-	if(!src.operating) //in case of emag
-		src.operating = 1
+	if(!operating) //in case of emag
+		operating = 1
 	flick("pdoorc0", src)
 	src.icon_state = "pdoor0"
 	src.set_opacity(0)
@@ -74,17 +74,17 @@
 	air_update_turf(1)
 	update_freelook_sight()
 
-	if(operating == 1) //emag again
-		src.operating = 0
+	if(operating) //emag again
+		operating = 0
 	if(autoclose)
 		spawn(150)
 			autoclose()
 	return 1
 
 /obj/machinery/door/poddoor/close()
-	if(src.operating)
+	if(operating)
 		return
-	src.operating = 1
+	operating = 1
 	flick("pdoorc1", src)
 	src.icon_state = "pdoor1"
 	src.set_opacity(initial(opacity))
@@ -95,7 +95,7 @@
 	src.density = 1
 	sleep(5)
 
-	src.operating = 0
+	operating = 0
 	return
 
 /obj/machinery/door/poddoor/multi_tile // Whoever wrote the old code for multi-tile spesspod doors needs to burn in hell.

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -30,7 +30,7 @@
 	return
 
 /obj/machinery/door/poddoor/shutters/open()
-	if(operating == 1) //doors can still open when emag-disabled
+	if(operating || emagged) //doors can still open when emag-disabled
 		return
 	if(!ticker)
 		return 0
@@ -44,7 +44,7 @@
 	air_update_turf(1)
 	update_freelook_sight()
 
-	if(operating == 1) //emag again
+	if(operating) //emag again
 		operating = 0
 	if(autoclose)
 		spawn(150)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -97,7 +97,7 @@
 		return 1
 
 /obj/machinery/door/window/open(var/forced=0)
-	if(operating == 1) //doors can still open when emag-disabled
+	if(operating) //doors can still open when emag-disabled
 		return 0
 	if(!ticker)
 		return 0
@@ -119,7 +119,7 @@
 	air_update_turf(1)
 	update_freelook_sight()
 
-	if(operating == 1) //emag again
+	if(operating) //emag again
 		operating = 0
 	return 1
 
@@ -192,7 +192,7 @@
 
 /obj/machinery/door/window/attack_ai(mob/user)
 	return attack_hand(user)
-	
+
 /obj/machinery/door/window/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
 		return attack_hand(user)
@@ -228,10 +228,11 @@
 	return attackby(user, user)
 
 /obj/machinery/door/window/emag_act(mob/user, obj/weapon)
-	if(density)
-		operating = -1
+	if(!operating && density && !emagged)
+		operating = 1
 		flick("[base_state]spark", src)
 		sleep(6)
+		operating = 0
 		desc += "<BR><span class='warning'>Its access panel is smoking slightly.</span>"
 		if(istype(weapon, /obj/item/weapon/melee/energy/blade))
 			var/obj/item/weapon/melee/energy/blade/B


### PR DESCRIPTION
A door's operating var cannot be -1 any more, the emagged var is more prevalent, emagging a closed firelock just opens it now it does not irreversibly break the firelock, you can screwdriver+crowbar an emagged windoor (this was broken when I tested it).

:cl:
fix: Emagging a closed firelock does not permanently break it anymore, only opens it.
fix: Emagged windoors should be able to be screwdriver+crowbar'd again.
/:cl: