### PR TITLE
Fixes Tile Quick-Replacing

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -142,16 +142,7 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		pry_tile(C, user)
 		return 1
 	if(intact && istype(C, /obj/item/stack/tile))
-		var/obj/item/stack/tile/T = C
-		if(T.turf_type == type)
-			return
-		var/obj/item/weapon/crowbar/CB = user.get_inactive_hand(/obj/item/weapon/crowbar)
-		if(!CB)
-			return
-		var/turf/simulated/floor/plating/P = pry_tile(CB, user, TRUE)
-		if(!istype(P))
-			return
-		P.attackby(T, user, params)
+		try_replace_tile(C, user, params)
 	if(istype(C, /obj/item/pipe))
 		var/obj/item/pipe/P = C
 		if(P.pipe_type != -1) // ANY PIPE
@@ -176,6 +167,19 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 			P.loc = src
 			return 1
 	return 0
+
+/turf/simulated/floor/proc/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
+	if(T.turf_type == type)
+		return
+	var/obj/item/weapon/crowbar/CB
+	if(iscrowbar(user.get_inactive_hand()))
+		CB = user.get_inactive_hand()
+	if(!CB)
+		return
+	var/turf/simulated/floor/plating/P = pry_tile(CB, user, TRUE)
+	if(!istype(P))
+		return
+	P.attackby(T, user, params)
 
 /turf/simulated/floor/proc/pry_tile(obj/item/C, mob/user, silent = FALSE)
 	playsound(src, C.usesound, 80, 1)

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -15,6 +15,21 @@
 		pry_tile(C, user)
 		return
 
+/turf/simulated/floor/wood/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
+	if(T.turf_type == type)
+		return
+	var/obj/item/weapon/tool
+	if(isscrewdriver(user.get_inactive_hand()))
+		tool = user.get_inactive_hand()
+	if(!tool && iscrowbar(user.get_inactive_hand()))
+		tool = user.get_inactive_hand()
+	if(!tool)
+		return
+	var/turf/simulated/floor/plating/P = pry_tile(tool, user, TRUE)
+	if(!istype(P))
+		return
+	P.attackby(T, user, params)
+
 /turf/simulated/floor/wood/pry_tile(obj/item/C, mob/user, silent = FALSE)
 	var/is_screwdriver = isscrewdriver(C)
 	playsound(src, C.usesound, 80, 1)


### PR DESCRIPTION
Previously you did not specifically need a crowbar just anything in inactive hand to replace tiles, this fixes that bug

:cl:
fix: Quick-replacing non-wooden tiles will only work with a crowbar in inactive hand instead of any item
/:cl: