### PR TITLE
Fixes the cult shifter

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -300,7 +300,7 @@
 	var/turf/mobloc = get_turf(C)
 	var/list/turfs = new/list()
 	for(var/turf/T in range(user, outer_tele_radius))
-		if(!is_teleport_allowed(T))
+		if(!is_teleport_allowed(T.z))
 			continue
 		if(get_dir(C, T) != C.dir)
 			continue


### PR DESCRIPTION
A check for the turf instead of the turf's level

oops
:cl:Crazylemon
fix: Cult shifter should work now
/:cl: