### PR TITLE
Allows rerouting of ghost beacons

### DIFF
--- a/code/game/objects/structures/misc.dm
+++ b/code/game/objects/structures/misc.dm
@@ -84,22 +84,28 @@
 	var/active = FALSE
 	var/ghost_alert_delay = 30 SECONDS
 	var/last_ghost_alert
+	var/alert_title = "Ethereal Beacon Active!"
+	var/atom/attack_atom
 
 
 /obj/structure/ghost_beacon/initialize()
 	. = ..()
 	last_ghost_alert = world.time
+	attack_atom = src
 	if(active)
 		processing_objects.Add(src)
 
 /obj/structure/ghost_beacon/Destroy()
 	if(active)
 		processing_objects.Remove(src)
+	attack_atom = null
 	return ..()
 
 /obj/structure/ghost_beacon/attack_ghost(mob/dead/observer/user)
 	if(user.can_advanced_admin_interact())
 		attack_hand(user)
+	else if(attack_atom != src)
+		attack_atom.attack_ghost(user)
 
 /obj/structure/ghost_beacon/attack_hand(mob/user)
 	if(!is_admin(user))
@@ -113,5 +119,5 @@
 
 /obj/structure/ghost_beacon/process()
 	if(last_ghost_alert + ghost_alert_delay < world.time)
-		notify_ghosts("[src] active in [get_area(src)].", 'sound/effects/ghost2.ogg', source = src)
+		notify_ghosts("[src] active in [get_area(src)].", 'sound/effects/ghost2.ogg', title = alert_title, source = attack_atom, action = (attack_atom == src ? NOTIFY_JUMP : NOTIFY_ATTACK))
 		last_ghost_alert = world.time

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -460,7 +460,7 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HARM)
 				lname = "<span class='name'>[lname]</span> "
 			to_chat(M, "<span class='deadsay'>[lname][follow][message]</span>")
 
-/proc/notify_ghosts(message, ghost_sound = null, enter_link = null, atom/source = null, image/alert_overlay = null, flashwindow = TRUE, var/action = NOTIFY_JUMP) //Easy notification of ghosts.
+/proc/notify_ghosts(message, ghost_sound = null, enter_link = null, title = null, atom/source = null, image/alert_overlay = null, flashwindow = TRUE, var/action = NOTIFY_JUMP) //Easy notification of ghosts.
 	for(var/mob/dead/observer/O in player_list)
 		if(O.client)
 			to_chat(O, "<span class='ghostalert'>[message][(enter_link) ? " [enter_link]" : ""]<span>")
@@ -473,6 +473,8 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HARM)
 				if(A)
 					if(O.client.prefs && O.client.prefs.UI_style)
 						A.icon = ui_style2icon(O.client.prefs.UI_style)
+					if(title)
+						A.name = title
 					A.desc = message
 					A.action = action
 					A.target = source


### PR DESCRIPTION
Ghost beacons have 2 new vars now:
`alert_title` gives the thing a message other than "New body active"
`attack_atom` redirects the click on the alert from jumping to the beacon to clicking on the marked atom.

Admin-facing change, no CL