### PR TITLE
Gives the CMO Medical HUD Glasses

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -174,7 +174,7 @@
 		new /obj/item/weapon/storage/belt/medical(src)
 		new /obj/item/device/flash(src)
 		new /obj/item/weapon/reagent_containers/hypospray/CMO(src)
-		new /obj/item/organ/internal/cyberimp/eyes/hud/medical(src)
+		new /obj/item/clothing/glasses/hud/health/health_advanced(src)
 		new /obj/item/weapon/door_remote/chief_medical_officer(src)
 
 


### PR DESCRIPTION
The CMO is the only head without flash protection. And they have to make someone do surgery to get the health HUD implant put in. Lets just give the CMO Medical HUD Glasses yes?