### PR TITLE
Fixes blobs destroying themselves

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -50,6 +50,9 @@
 	var/damage = Clamp(0.01 * exposed_temperature, 0, 4)
 	take_damage(damage, BURN)
 
+/obj/structure/blob/blob_act()
+	return
+
 /obj/structure/blob/proc/Life()
 	return
 


### PR DESCRIPTION
#6962 turned blobs into structures.

Blobs *destroy* structures.

Any time a blob is created or tries to expand, there's a 50% chance it will immediately be deleted, so there is, *at best,* a 3.125% chance of a new core *not* dying instantly. Whoops!

This is fixed by simply making blobs ignore `blob_act`.

:cl:
fix: Blobs are no longer nearly guaranteed to immediately tear themselves apart upon spawning.
/:cl: