### PR TITLE
Window Corridor Thrown Objects Fix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -108,21 +108,22 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 
 	return 1
 
-/obj/structure/window/hitby(AM as mob|obj)
-	..()
-	var/tforce = 0
-	if(isobj(AM))
-		var/obj/item/I = AM
-		tforce = I.throwforce
-	if(reinf) tforce *= 0.25
-	playsound(loc, 'sound/effects/Glasshit.ogg', 100, 1)
-	health = max(0, health - tforce)
-	if(health <= 7 && !reinf)
-		anchored = 0
-		update_nearby_icons()
-		step(src, get_dir(AM, src))
-	if(health <= 0)
-		destroy()
+/obj/structure/window/hitby(atom/movable/AM)
+	if(!CanPass(AM, get_step(src, AM.dir))) //So thrown objects that cross a tile with non-full windows will no longer hit the window even if it isn't visually obstructing the path.
+		..()
+		var/tforce = 0
+		if(isobj(AM))
+			var/obj/item/I = AM
+			tforce = I.throwforce
+		if(reinf) tforce *= 0.25
+		playsound(loc, 'sound/effects/Glasshit.ogg', 100, 1)
+		health = max(0, health - tforce)
+		if(health <= 7 && !reinf)
+			anchored = 0
+			update_nearby_icons()
+			step(src, get_dir(AM, src))
+		if(health <= 0)
+			destroy()
 
 
 /obj/structure/window/attack_hand(mob/user as mob)


### PR DESCRIPTION
Thrown objects that cross a tile with non-full windows will no longer hit the window even if it isn't visually obstructing the path.

Fixes #6984 

Tested by throwing my ID card down the same window corridor in the above issue. The ID passed all the way down the corridor and hit the window at the end (because it was obstructing the path) with a 'knock' sound, indicating everything is working properly.

![windowner](https://cloud.githubusercontent.com/assets/12377767/24543355/5d76e14c-15cd-11e7-96e2-a9276b0231d1.png)

:cl:
fix: Thrown objects that cross a tile with non-full windows will no longer hit the window even if it isn't visually obstructing the path.
fix: Shooting guns (i.e. tasers) in the above circumstances means that the taser shots won't be blocked by windows that aren't visually obstructing the path.
/:cl:

:alien: Ayy throwcode ✋ 