### PR TITLE
Heat Proofing Glass Airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -189,7 +189,6 @@
 	opacity = 0
 	assembly_type = /obj/structure/door_assembly/door_assembly_research
 	glass = 1
-	heat_proof = 1
 
 /obj/machinery/door/airlock/glass_mining
 	name = "Maintenance Hatch"
@@ -848,6 +847,7 @@ About the new airlock wires panel:
 				to_chat(user, "\blue You removed the airlock electronics!")
 
 				var/obj/structure/door_assembly/da = new assembly_type(loc)
+				da.heat_proof_finished = heat_proof //tracks whether there's rglass in
 				da.anchored = 1
 				if(mineral)
 					da.glass = mineral

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -23,7 +23,7 @@
 	var/normalspeed = 1
 	var/auto_close_time = 150
 	var/auto_close_time_dangerous = 5
-	var/heat_proof = 0 // For glass airlocks/opacity firedoors
+	var/heat_proof = 0 // For rglass-windowed airlocks and firedoors
 	var/emergency = 0
 	var/air_properties_vary_with_direction = 0
 	var/block_air_zones = 1 //If set, air zones cannot merge across the door even when it is opened.
@@ -310,7 +310,7 @@
 	if(!glass && cameranet)
 		cameranet.updateVisibility(src, 0)
 
-/obj/machinery/door/BlockSuperconductivity()
+/obj/machinery/door/BlockSuperconductivity() // All non-glass airlocks block heat, this is intended.
 	if(opacity || heat_proof)
 		return 1
 	return 0

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -3,8 +3,9 @@
 	desc = "That looks like it doesn't open easily."
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 	icon_state = "pdoor1"
-	var/id_tag = 1.0
 	explosion_block = 3
+	heat_proof = 1
+	var/id_tag = 1.0
 	var/protected = 1
 
 /obj/machinery/door/poddoor/preopen

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -13,6 +13,7 @@
 	var/glass_type = "/glass"
 	var/glass = 0 // 0 = glass can be installed. -1 = glass can't be installed. 1 = glass is already installed. Text = mineral plating is installed instead.
 	var/created_name = null
+	var/heat_proof_finished = 0 //whether to heat-proof the finished airlock
 
 /obj/structure/door_assembly/New()
 	update_state()
@@ -172,7 +173,11 @@
 				if(do_after(user, 40 * WT.toolspeed, target = src))
 					if(!src || !WT.isOn()) return
 					to_chat(user, "\blue You welded the glass panel out!")
-					new /obj/item/stack/sheet/rglass(src.loc)
+					if(heat_proof_finished)
+						new /obj/item/stack/sheet/rglass(get_turf(src))
+						heat_proof_finished = 0
+					else
+						new /obj/item/stack/sheet/glass(get_turf(src))
 					glass = 0
 			else if(!anchored)
 				user.visible_message("[user] disassembles the airlock assembly.", "You start to disassemble the airlock assembly.")
@@ -253,11 +258,15 @@
 		var/obj/item/stack/sheet/S = W
 		if(S)
 			if(S.amount>=1)
-				if(istype(S, /obj/item/stack/sheet/rglass))
+				if(istype(S, /obj/item/stack/sheet/rglass) || istype(S, /obj/item/stack/sheet/glass))
 					playsound(src.loc, S.usesound, 100, 1)
 					user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
 					if(do_after(user, 40 * S.toolspeed, target = src))
-						to_chat(user, "\blue You installed reinforced glass windows into the airlock assembly!")
+						if(S.type == /obj/item/stack/sheet/rglass)
+							to_chat(user, "<span class='notice'>You install reinforced glass windows into the airlock assembly.</span>")
+							heat_proof_finished = 1 //reinforced glass makes the airlock heat-proof
+						else
+							to_chat(user, "<span class='notice'>You install regular glass windows into the airlock assembly.</span>")
 						S.use(1)
 						glass = 1
 				else if(istype(S, /obj/item/stack/sheet/mineral) && S.sheettype)
@@ -288,6 +297,7 @@
 			door.setDir(dir)
 			door.assembly_type = type
 			door.electronics = src.electronics
+			door.heat_proof = heat_proof_finished
 			if(src.electronics.one_access)
 				door.req_access = null
 				door.req_one_access = src.electronics.conf_access
@@ -314,4 +324,4 @@
 			name = "Wired "
 		if(2)
 			name = "Near Finished "
-	name += "[glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"
+	name += "[heat_proof_finished ? "Heat-Proofed " : ""][glass == 1 ? "Window " : ""][istext(glass) ? "[glass] Airlock" : base_name] Assembly"


### PR DESCRIPTION
Currently only glass research airlocks block all heat, now you can make a glass airlock heat-proof by using 1 sheet of reinforced glass on the assembly during construction instead of regular glass

:cl:
add: You can now create heat-proof glass airlocks by using a sheet of reinforced glass on the assembly during construction. Regular glass airlocks just require a sheet of glass.
/:cl: