### PR TITLE
Nerfs the telescopic baton stun time

### DIFF
--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -56,7 +56,7 @@
 					if(H.check_shields(0, "[user]'s [name]", src, MELEE_ATTACK))
 						return 0
 				playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
-				target.Weaken(3)
+				target.Weaken(2)
 				add_logs(user, target, "stunned", object="[src]")
 				src.add_fingerprint(user)
 				target.visible_message("<span class ='danger'>[user] has knocked down [target] with \the [src]!</span>", \


### PR DESCRIPTION
oh boy can you feel it, it's like I'm bathing in the ocean

This also affects the mining baton loot thing and the NT Rep cane, because telebatons are subtypes of them all.

Nerfs the telescopic baton stun time to be the same as it takes to cable
cuff someone, meaning you can't stuncuff them, not without help at
least, meaning it brings the telescopic baton back into the self defense
territory, meaning you can't stuncuff someone to brig, meaning it's no
longer the offensive weapon it currenty is.

It also means you can't stun lock someone, not even close to it, the
stun is like about half the cuff time.

This has been a discussion of ages, this is the most recent topic, let
the salt flow:

https://nanotrasen.se/forum/topic/9861-purge-telebatons-from-the-codebase

:cl:pinatacolada
:tweak: Nerfs the telescopic baton stun time
:cl: