### PR TITLE
Adds debugging jump to link for admins during brand intelligence events

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -29,6 +29,7 @@
 	vendingMachines.Remove(originMachine)
 	originMachine.shut_up = 0
 	originMachine.shoot_inventory = 1
+	log_debug("Original brand intelligence machine: [originMachine] [ADMIN_VV(originMachine)] [ADMIN_JMP(originMachine)]")
 
 /datum/event/brand_intelligence/tick()
 	if(!originMachine || !isnull(originMachine.gcDestroyed) || originMachine.shut_up || originMachine.wires.IsAllCut())	//if the original vending machine is missing or has it's voice switch flipped


### PR DESCRIPTION
Lets admins quickly find out which machine is the source for brand intelligence events.

Feature requested by DLP.
No CL, as admin-only.