### PR TITLE
More GC Fixes and Logging

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -19,12 +19,6 @@
 	overlay_layer = layer
 	..()
 
-/obj/machinery/computer/Destroy()
-	if(circuit)
-		qdel(circuit)
-		circuit = null
-	return ..()
-
 /obj/machinery/computer/initialize()
 	..()
 	power_change()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -157,7 +157,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/enable_debug_verbs,
 	/client/proc/toggledebuglogs,
 	/client/proc/qdel_toggle,
-	/client/proc/gc_dump_hdl,
+	/client/proc/cmd_display_del_log,
 	/client/proc/debugNatureMapGenerator,
 	/client/proc/check_bomb_impacts,
 	/client/proc/test_movable_UI,

--- a/code/modules/garbage_collection/garbage_collector.dm
+++ b/code/modules/garbage_collection/garbage_collector.dm
@@ -7,8 +7,12 @@
 #define GC_FORCE_DEL_PER_TICK 30
 //#define GC_DEBUG
 
-// A list of types that were queued in the GC, and had to be soft deleted; used in testing
-var/list/gc_hard_del_types = list()
+var/list/didntgc = list()   	// list of all types that have failed to GC associated with the number of times that's happened.
+							    // the types are stored as strings
+var/list/sleptDestroy = list()	//Same as above but these are paths that slept during their Destroy call
+
+var/list/noqdelhint = list()    // list of all types that do not return a QDEL_HINT
+
 var/global/datum/controller/process/garbage_collector/garbageCollector
 
 // The time a datum was destroyed by the GC, or null if it hasn't been
@@ -82,7 +86,7 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 #undef GC_COLLECTIONS_PER_TICK
 
 /datum/controller/process/garbage_collector/proc/hardDel(var/datum/D)
-	gc_hard_del_types["[D.type]"]++
+	didntgc["[D.type]"]++
 	D.hard_deleted = 1
 	if(!D.gcDestroyed)
 		spawn(-1)
@@ -126,6 +130,7 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 			return
 		if(!isnull(D.gcDestroyed) && D.gcDestroyed != world.time)
 			gcwarning("Sleep detected in Destroy() call of [D.type]")
+			sleptDestroy["[D.type]"]++
 			D.gcDestroyed = world.time
 
 		switch(hint)
@@ -155,7 +160,9 @@ var/global/datum/controller/process/garbage_collector/garbageCollector
 				#endif
 				garbageCollector.addTrash(D)
 			else
-//				to_chat(world, "WARNING GC DID NOT GET A RETURN VALUE FOR [D], [D.type]!")
+				if(!noqdelhint["[D.type]"])
+					noqdelhint["[D.type]"] = "[D.type]"
+					gcwarning("WARNING: [D.type] is not returning a qdel hint. It is being placed in the queue. Further instances of this type will also be queued.")
 				garbageCollector.addTrash(D)
 
 

--- a/code/modules/garbage_collection/gc_testing.dm
+++ b/code/modules/garbage_collection/gc_testing.dm
@@ -13,21 +13,24 @@
 	log_admin("[key_name(usr)] turned qdel [garbageCollector.del_everything ? "off" : "on"].")
 	message_admins("\blue [key_name_admin(usr)] turned qdel [garbageCollector.del_everything ? "off" : "on"].", 1)
 
-/client/proc/gc_dump_hdl()
-	set name = "(GC) Hard Del List"
-	set desc = "List types that are hard del()'d by the GC."
+/client/proc/cmd_display_del_log()
 	set category = "Debug"
+	set name = "(GC) Display del() Log"
+	set desc = "Displays a list of things that have failed to GC this round"
 
-	if(!check_rights(R_DEBUG))
-		return
+	var/dat = "<B>List of things that failed to GC this round</B><BR><BR>"
+	for(var/path in didntgc)
+		dat += "[path] - [didntgc[path]] times<BR>"
 
-	if(!gc_hard_del_types || !gc_hard_del_types.len)
-		to_chat(usr, "<span class='notice'>No hard del()'d types found.</span>")
-		return
+	dat += "<B>List of paths that did not return a qdel hint in Destroy()</B><BR><BR>"
+	for(var/path in noqdelhint)
+		dat += "[path]<BR>"
 
-	to_chat(usr, "Types hard del()'d by the GC and number of times failed:")
-	for(var/A in gc_hard_del_types)
-		to_chat(usr, "[A] - [gc_hard_del_types[A]] times")
+	dat += "<B>List of paths that slept in Destroy()</B><BR><BR>"
+	for(var/path in sleptDestroy)
+		dat += "[path]<BR>"
+
+	usr << browse(dat, "window=dellog")
 
 #ifdef TESTING
 /client/var/running_find_references

--- a/code/modules/garbage_collection/gc_testing.dm
+++ b/code/modules/garbage_collection/gc_testing.dm
@@ -18,6 +18,9 @@
 	set name = "(GC) Display del() Log"
 	set desc = "Displays a list of things that have failed to GC this round"
 
+	if(!check_rights(R_DEBUG))
+		return
+
 	var/dat = "<B>List of things that failed to GC this round</B><BR><BR>"
 	for(var/path in didntgc)
 		dat += "[path] - [didntgc[path]] times<BR>"

--- a/code/modules/modular_computers/file_system/computer_file.dm
+++ b/code/modules/modular_computers/file_system/computer_file.dm
@@ -23,7 +23,7 @@ var/global/file_uid = 0
 	if(holder.holder && holder.holder.active_program == src)
 		holder.holder.kill_program(forced = TRUE)
 	holder = null
-	..()
+	return ..()
 
 // Returns independent copy of this file.
 /datum/computer_file/proc/clone(rename = 0)

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
@@ -16,11 +16,11 @@
 		AH.register(src, /datum/computer_file/program/alarm_monitor/proc/update_icon)
 
 /datum/computer_file/program/alarm_monitor/Destroy()
-	..()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
 		AH.unregister(src)
 	qdel(alarm_handlers)
 	alarm_handlers = null
+	return ..()
 
 /datum/computer_file/program/alarm_monitor/proc/update_icon()
 	for(var/datum/alarm_handler/AH in alarm_handlers)

--- a/code/modules/pda/chatroom.dm
+++ b/code/modules/pda/chatroom.dm
@@ -78,6 +78,7 @@ var/list/chatrooms = list(new /datum/chatroom("General Discussion"))
 			ch.users -= src
 		if(src in ch.invites)
 			ch.invites -= src
+	return ..()
 
 /datum/data/pda/app/chatroom/start()
 	. = ..()


### PR DESCRIPTION
Just some more fix ups for GC'ing and better logging. Most of this comes from TG.

- Adds in logging for when a path doesn't return a qdel hint
- Adds in logging for when a path has a sleep in its `Destroy`
- Adds in browser window that holds all info on failed to GC paths, no qdel hint paths, and sleep in destroy paths; this replaces the the old verb that prints all the failed to GC paths to the user.

Fixes
- Fixes computer circuits attempting to be deleted (these were paths, not actual objects)
- Fixes PDA chat rooms not returning a qdel hint
- Fixes modular computer programs not returning a qdel hint


Should help in finding mistakes in GC'ing all that much easier---all with better presentation.