### PR TITLE
Per-Species Reagent on_mob_life Rework

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -312,6 +312,7 @@ Made by Xhuis
 
 	silent_steps = 1
 	grant_vision_toggle = 0
+	on_species_life_proc_name = "on_shadowling_life"
 
 /datum/species/shadow/ling/handle_life(var/mob/living/carbon/human/H)
 	if(!H.weakeyes)
@@ -350,6 +351,7 @@ Made by Xhuis
 	burn_mod = 1.1
 	oxy_mod = 0
 	hot_env_multiplier = 1.1
+	on_species_life_proc_name = "on_lesser_shadowling_life"
 
 /datum/species/shadow/ling/lesser/handle_life(var/mob/living/carbon/human/H)
 	if(!H.weakeyes)

--- a/code/modules/mob/living/carbon/human/species/abductor.dm
+++ b/code/modules/mob/living/carbon/human/species/abductor.dm
@@ -25,7 +25,7 @@
 	virus_immune = 1
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	dietflags = DIET_OMNI
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_abductor_life"
 	blood_color = "#FF5AFF"
 
 /datum/species/abductor/can_understand(var/mob/other) //Abductors can understand everyone, but they can only speak over their mindlink to another team-member
@@ -38,6 +38,3 @@
 	H.languages.Cut() //Under no condition should you be able to speak any language
 	H.add_language("Abductor Mindlink") //other than over the abductor's own mindlink
 	return ..()
-
-/datum/species/abductor/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_abductor_life(H)

--- a/code/modules/mob/living/carbon/human/species/abductor.dm
+++ b/code/modules/mob/living/carbon/human/species/abductor.dm
@@ -38,3 +38,6 @@
 	H.languages.Cut() //Under no condition should you be able to speak any language
 	H.add_language("Abductor Mindlink") //other than over the abductor's own mindlink
 	return ..()
+
+/datum/species/abductor/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_abductor_life(H)

--- a/code/modules/mob/living/carbon/human/species/apollo.dm
+++ b/code/modules/mob/living/carbon/human/species/apollo.dm
@@ -83,6 +83,9 @@
 					msg_admin_attack("[key_name(M)] removed [key_name(H)]'s antennae")
 			return 0
 
+/datum/species/wryn/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_wryn_life(H)
+
 /datum/species/nucleation
 	name = "Nucleation"
 	name_plural = "Nucleations"
@@ -126,3 +129,6 @@
 	explosion(T, 0, 0, 2, 2) // Create a small explosion burst upon death
 //	new /obj/item/weapon/shard/supermatter( T )
 	qdel(H)
+
+/datum/species/nucleation/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_nucleation_life(H)

--- a/code/modules/mob/living/carbon/human/species/apollo.dm
+++ b/code/modules/mob/living/carbon/human/species/apollo.dm
@@ -42,7 +42,7 @@
 
 	oxy_mod = 0
 
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_wryn_life"
 	base_color = "#704300"
 	flesh_color = "#704300"
 	blood_color = "#FFFF99"
@@ -83,8 +83,6 @@
 					msg_admin_attack("[key_name(M)] removed [key_name(H)]'s antennae")
 			return 0
 
-/datum/species/wryn/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_wryn_life(H)
 
 /datum/species/nucleation
 	name = "Nucleation"
@@ -108,7 +106,7 @@
 	//Default styles for created mobs.
 	default_hair = "Nucleation Crystals"
 
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_nucleation_life"
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart,
 		"crystallized brain" =    /obj/item/organ/internal/brain/crystal,
@@ -129,6 +127,3 @@
 	explosion(T, 0, 0, 2, 2) // Create a small explosion burst upon death
 //	new /obj/item/weapon/shard/supermatter( T )
 	qdel(H)
-
-/datum/species/nucleation/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_nucleation_life(H)

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -59,6 +59,8 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/golem(H), slot_gloves)
 	..()
 
+/datum/species/golem/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_golem_life(H)
 
 ////////Adamantine Golem stuff I dunno where else to put it
 

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -12,7 +12,7 @@
 
 	virus_immune = 1
 	dietflags = DIET_OMNI		//golems can eat anything because they are magic or something
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_golem_life"
 
 	unarmed_type = /datum/unarmed_attack/punch
 	punchdamagelow = 5
@@ -59,8 +59,6 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/golem(H), slot_gloves)
 	..()
 
-/datum/species/golem/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_golem_life(H)
 
 ////////Adamantine Golem stuff I dunno where else to put it
 

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -93,6 +93,9 @@
 			return 2
 	return 2
 
+/datum/species/monkey/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_monkey_life(H)
+
 /datum/species/monkey/tajaran
 	name = "Farwa"
 	name_plural = "Farwa"
@@ -116,6 +119,8 @@
 		"eyes" =     /obj/item/organ/internal/eyes/tajaran/farwa //Tajara monkey-forms are uniquely colourblind and have excellent darksight, which is why they need a subtype of their greater-form's organ..
 		)
 
+/datum/species/monkey/tajaran/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_farwa_life(H)
 
 /datum/species/monkey/vulpkanin
 	name = "Wolpin"
@@ -140,6 +145,8 @@
 		"eyes" =     /obj/item/organ/internal/eyes/vulpkanin/wolpin //Vulpkanin monkey-forms are uniquely colourblind and have excellent darksight, which is why they need a subtype of their greater-form's organ..
 		)
 
+/datum/species/monkey/vulpkanin/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_wolpin_life(H)
 
 /datum/species/monkey/skrell
 	name = "Neara"
@@ -157,6 +164,9 @@
 
 	bodyflags = FEET_PADDED
 
+/datum/species/monkey/skrell/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_neara_life(H)
+
 
 /datum/species/monkey/unathi
 	name = "Stok"
@@ -173,3 +183,6 @@
 	reagent_tag = PROCESS_ORG
 
 	bodyflags = FEET_CLAWS | HAS_TAIL
+
+/datum/species/monkey/unathi/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_stok_life(H)

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -25,7 +25,7 @@
 
 	tail = "chimptail"
 	bodyflags = FEET_PADDED | HAS_TAIL
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_monkey_life"
 	//Has standard darksight of 2.
 
 	//unarmed_types = list(/datum/unarmed_attack/bite, /datum/unarmed_attack/claws)
@@ -93,8 +93,6 @@
 			return 2
 	return 2
 
-/datum/species/monkey/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_monkey_life(H)
 
 /datum/species/monkey/tajaran
 	name = "Farwa"
@@ -108,7 +106,7 @@
 	flesh_color = "#AFA59E"
 	base_color = "#000000"
 	tail = "farwatail"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_farwa_life"
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart,
 		"lungs" =    /obj/item/organ/internal/lungs,
@@ -119,8 +117,6 @@
 		"eyes" =     /obj/item/organ/internal/eyes/tajaran/farwa //Tajara monkey-forms are uniquely colourblind and have excellent darksight, which is why they need a subtype of their greater-form's organ..
 		)
 
-/datum/species/monkey/tajaran/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_farwa_life(H)
 
 /datum/species/monkey/vulpkanin
 	name = "Wolpin"
@@ -134,7 +130,7 @@
 	flesh_color = "#966464"
 	base_color = "#000000"
 	tail = "wolpintail"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_wolpin_life"
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart,
 		"lungs" =    /obj/item/organ/internal/lungs,
@@ -145,8 +141,6 @@
 		"eyes" =     /obj/item/organ/internal/eyes/vulpkanin/wolpin //Vulpkanin monkey-forms are uniquely colourblind and have excellent darksight, which is why they need a subtype of their greater-form's organ..
 		)
 
-/datum/species/monkey/vulpkanin/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_wolpin_life(H)
 
 /datum/species/monkey/skrell
 	name = "Neara"
@@ -159,13 +153,10 @@
 	default_language = "Neara"
 	flesh_color = "#8CD7A3"
 	blood_color = "#1D2CBF"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_neara_life"
 	tail = null
 
 	bodyflags = FEET_PADDED
-
-/datum/species/monkey/skrell/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_neara_life(H)
 
 
 /datum/species/monkey/unathi
@@ -180,9 +171,6 @@
 	default_language = "Stok"
 	flesh_color = "#34AF10"
 	base_color = "#000000"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_stok_life"
 
 	bodyflags = FEET_CLAWS | HAS_TAIL
-
-/datum/species/monkey/unathi/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_stok_life(H)

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -256,12 +256,5 @@
 				P.Extinguish(H)
 	H.update_fire()
 
-/datum/species/plasmaman/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
-	if(R.id == "plasma")
-		H.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
-		H.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
-		H.adjustPlasma(20)
-		H.reagents.remove_reagent(R.id, REAGENTS_METABOLISM)
-		return 0 //Handling reagent removal on our own. Prevents plasma from dealing toxin damage to Plasmamen.
-
-	return ..()
+/datum/species/plasmaman/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_plasmaman_life(H)

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -8,7 +8,7 @@
 
 	flags = IS_WHITELISTED | NO_BLOOD | NOTRANSSTING
 	dietflags = DIET_OMNI
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_plasmaman_life"
 
 	//default_mutations=list(SKELETON) // This screws things up
 
@@ -255,6 +255,3 @@
 			if(istype(P))
 				P.Extinguish(H)
 	H.update_fire()
-
-/datum/species/plasmaman/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_plasmaman_life(H)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -24,7 +24,7 @@
 	virus_immune = 1
 
 	dietflags = DIET_OMNI		//the mutation process allowed you to now digest all foods regardless of initial race
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_shadow_person_life"
 	suicide_messages = list(
 		"is attempting to bite their tongue off!",
 		"is jamming their claws into their eye sockets!",
@@ -73,6 +73,3 @@
 		else if(light_amount < 2) //heal in the dark
 			H.heal_overall_damage(1,1)
 			H.clear_alert("lightexposure")
-
-/datum/species/shadow/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_shadow_person_life(H)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -73,3 +73,6 @@
 		else if(light_amount < 2) //heal in the dark
 			H.heal_overall_damage(1,1)
 			H.clear_alert("lightexposure")
+
+/datum/species/shadow/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_shadow_person_life(H)

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -43,22 +43,5 @@
 		"brain" = /obj/item/organ/internal/brain/golem,
 	) //Has default darksight of 2.
 
-/datum/species/skeleton/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
-	// Crazylemon is still silly
-	if(R.id == "milk")
-		H.heal_overall_damage(4,4)
-		if(prob(5)) // 5% chance per proc to find a random limb, and mend it
-			var/list/our_organs = H.organs.Copy()
-			shuffle(our_organs)
-			for(var/obj/item/organ/external/L in our_organs)
-				if(istype(L))
-					if(L.brute_dam < L.min_broken_damage)
-						L.status &= ~ORGAN_BROKEN
-						L.status &= ~ORGAN_SPLINTED
-						L.perma_injury = 0
-					break // We're only checking one limb here, bucko
-		if(prob(3))
-			H.say(pick("Thanks Mr Skeltal", "Thank for strong bones", "Doot doot!"))
-		return 1
-
-	return ..()
+/datum/species/skeleton/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_skeleton_life(H)

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -19,7 +19,7 @@
 
 	virus_immune = 1 //why is this a var and not a flag?
 	dietflags = DIET_OMNI
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_skeleton_life"
 
 	warning_low_pressure = -1
 	hazard_low_pressure = -1
@@ -42,6 +42,3 @@
 	has_organ = list(
 		"brain" = /obj/item/organ/internal/brain/golem,
 	) //Has default darksight of 2.
-
-/datum/species/skeleton/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_skeleton_life(H)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -42,7 +42,8 @@
 	var/heat_level_3_breathe = 1000 // Heat damage level 3 above this point; used for breathed air temperature
 
 	var/body_temperature = 310.15	//non-IS_SYNTHETIC species will try to stabilize at this temperature. (also affects temperature processing)
-	var/reagent_tag                 //Used for metabolizing reagents.
+	var/on_species_life_proc_name = "on_mob_life"	//set this to the reagent proc name used for this species. Defaults to "on_mob_life" in case you don't set it
+	var/reagent_process_tag	= PROCESS_ORG			//used to determine if the species can metabolize certain reagents. Defaults to PROCESS_ORG, which most species use.
 	var/hunger_drain = HUNGER_FACTOR
 	var/digestion_ratio = 1 //How quickly the species digests/absorbs reagents.
 
@@ -412,16 +413,17 @@
 	return
 
 /*
-* Do spe-- PROC HIJACKED!
-* This now is used to call the proper reagent proc to handle per-species reagent on life effects for the supplied reagent.
-* Make sure you define this for any new species to call their own reagent proc or else they won't be able to handle their special reagent effects properly!
-* Humans don't need to override this since they are meant to be the base-line for reagent effects. Override it for everyone else you want to have special effects
-* No longer provides a return value, so don't put it in a conditional unless you re-add return values too!
+* This proc is used if you want to adjust HOW a species handles their reagents, not what the reagents do directly.
+* If you want to adjust what a reagent does to a certain species, override the appropriate on_species_life proc on the reagent. (on_tajaran_life, on_vox_life, etc)
+* By default, this simply calls the species' respective on_species_life proc on the provided reagent.
+* However, if you wanted to do things like adjust the rate at which a species metabolizes their reagents, you can easily adjust this proc to support that on that species.
+* You even can make it so that a species will only metabolize the reagents if certain criteria are met, such as being over 50% nutrition or below normal body temp, if you wanted.
+* Just make sure you still use the call proc used below in order to call the proper procs, or else you might find your changes doing nothing.
 */
 /datum/species/proc/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
 	if(!H || !R)
 		return
-	R.on_mob_life(H)
+	call(R, on_species_life_proc_name)(H)
 
 // For special snowflake species effects
 // (Slime People changing color based on the reagents they consume)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -411,12 +411,17 @@
 		H.verbs -= ability
 	return
 
-// Do species-specific reagent handling here
-// Return 1 if it should do normal processing too
-// Return 0 if it shouldn't deplete and do its normal effect
-// Other return values will cause weird badness
+/*
+* Do spe-- PROC HIJACKED!
+* This now is used to call the proper reagent proc to handle per-species reagent on life effects for the supplied reagent.
+* Make sure you define this for any new species to call their own reagent proc or else they won't be able to handle their special reagent effects properly!
+* Humans don't need to override this since they are meant to be the base-line for reagent effects. Override it for everyone else you want to have special effects
+* No longer provides a return value, so don't put it in a conditional unless you re-add return values too!
+*/
 /datum/species/proc/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
-	return 1
+	if(!H || !R)
+		return
+	R.on_mob_life(H)
 
 // For special snowflake species effects
 // (Slime People changing color based on the reagents they consume)

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -82,6 +82,9 @@
 /datum/species/unathi/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
+/datum/species/unathi/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_unathi_life(H)
+
 /datum/species/tajaran
 	name = "Tajaran"
 	name_plural = "Tajaran"
@@ -142,6 +145,10 @@
 /datum/species/tajaran/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
+/datum/species/tajaran/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_tajaran_life(H)
+
+
 /datum/species/vulpkanin
 	name = "Vulpkanin"
 	name_plural = "Vulpkanin"
@@ -192,6 +199,9 @@
 /datum/species/vulpkanin/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
+/datum/species/vulpkanin/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_vulpkanin_life(H)
+
 /datum/species/skrell
 	name = "Skrell"
 	name_plural = "Skrell"
@@ -239,6 +249,9 @@
 		"is twisting their own neck!",
 		"makes like a fish and suffocates!",
 		"is strangling themselves with their own tendrils!")
+
+/datum/species/skrell/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_skrell_life(H)
 
 /datum/species/vox
 	name = "Vox"
@@ -401,13 +414,8 @@
 		H.change_icobase(new_icobase, new_deform, owner_sensitive) //Update the icobase/deform of all our organs, but make sure we don't mess with frankenstein limbs in doing so.
 		H.update_dna()
 
-/datum/species/vox/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
-	if(R.id == "oxygen") //Armalis are above such petty things.
-		H.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER) //Same as plasma.
-		H.reagents.remove_reagent(R.id, REAGENTS_METABOLISM)
-		return 0 //Handling reagent removal on our own.
-
-	return ..()
+/datum/species/vox/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_vox_life(H)
 
 /datum/species/vox/armalis/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.verbs += /mob/living/carbon/human/proc/leap
@@ -470,8 +478,8 @@
 		"is holding their breath!",
 		"is huffing oxygen!")
 
-/datum/species/vox/armalis/handle_reagents() //Skip the Vox oxygen reagent toxicity. Armalis are above such things.
-	return 1
+/datum/species/vox/armalis/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_vox_armalis_life(H)
 
 /datum/species/kidan
 	name = "Kidan"
@@ -513,6 +521,9 @@
 		"is jamming their claws into their eye sockets!",
 		"is twisting their own neck!",
 		"is holding their breath!")
+
+/datum/species/kidan/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_kidan_life(H)
 
 /datum/species/slime
 	name = "Slime People"
@@ -562,6 +573,9 @@
 		/mob/living/carbon/human/verb/toggle_recolor_verb,
 		/mob/living/carbon/human/proc/regrow_limbs
 		)
+
+/datum/species/slime/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_slime_person_life(H)
 
 /datum/species/slime/handle_life(var/mob/living/carbon/human/H)
 //This is allegedly for code "style". Like a plaid sweater?
@@ -753,6 +767,9 @@
 	if(speech_pref)
 		H.mind.speech_span = "wingdings"
 
+/datum/species/grey/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_grey_life(H)
+
 /datum/species/diona
 	name = "Diona"
 	name_plural = "Dionaea"
@@ -838,6 +855,9 @@
 	H.gender = NEUTER
 
 	return ..()
+
+/datum/species/diona/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_diona_life(H)
 
 /datum/species/diona/handle_life(var/mob/living/carbon/human/H)
 	var/rads = H.radiation / 25
@@ -960,6 +980,9 @@
 			H.update_hair()
 			H.update_fhair()
 
+/datum/species/machine/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_machine_person_life(H)
+
 /datum/species/drask
 	name = "Drask"
 	name_plural = "Drask"
@@ -1026,6 +1049,9 @@
 		"eyes" =     				/obj/item/organ/internal/eyes/drask, //5 darksight.
 		"brain" =  					/obj/item/organ/internal/brain/drask
 		)
+
+/datum/species/drask/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
+	R.on_drask_life(H)
 
 /datum/species/drask/handle_temperature(datum/gas_mixture/breath, var/mob/living/carbon/human/H)
 	if( abs(310.15 - breath.temperature) > 50)

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -16,9 +16,9 @@
 	While the central Sol government maintains control of its far-flung people, powerful corporate \
 	interests, rampant cyber and bio-augmentation and secretive factions make life on most human \
 	worlds tumultous at best."
-
-	reagent_tag = PROCESS_ORG
 	//Has standard darksight of 2.
+	//on_species_life_proc_name = "on_mob_life"		//Humans are considered the baseline, so they don't get a special effect proc. Change this if you want to give them one.
+
 
 /datum/species/unathi
 	name = "Unathi"
@@ -53,7 +53,7 @@
 	heat_level_3_breathe = 1100 //Default 1000
 
 	flesh_color = "#34AF10"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_unathi_life"
 	base_color = "#066000"
 	//Default styles for created mobs.
 	default_headacc = "Simple"
@@ -82,8 +82,6 @@
 /datum/species/unathi/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
-/datum/species/unathi/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_unathi_life(H)
 
 /datum/species/tajaran
 	name = "Tajaran"
@@ -117,7 +115,7 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = FEET_PADDED | HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS | HAS_SKIN_COLOR | TAIL_WAGGING | HAS_FUR
 	dietflags = DIET_OMNI
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_tajaran_life"
 	flesh_color = "#AFA59E"
 	base_color = "#424242"
 	butt_sprite = "tajaran"
@@ -145,9 +143,6 @@
 /datum/species/tajaran/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
-/datum/species/tajaran/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_tajaran_life(H)
-
 
 /datum/species/vulpkanin
 	name = "Vulpkanin"
@@ -171,7 +166,7 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = FEET_PADDED | HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR | HAS_FUR
 	dietflags = DIET_OMNI
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_vulpkanin_life"
 	flesh_color = "#966464"
 	base_color = "#CF4D2F"
 	butt_sprite = "vulp"
@@ -199,8 +194,6 @@
 /datum/species/vulpkanin/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
-/datum/species/vulpkanin/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_vulpkanin_life(H)
 
 /datum/species/skrell
 	name = "Skrell"
@@ -230,7 +223,7 @@
 	eyes = "skrell_eyes_s"
 	//Default styles for created mobs.
 	default_hair = "Skrell Male Tentacles"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_skrell_life"
 	butt_sprite = "skrell"
 
 	has_organ = list(
@@ -250,8 +243,6 @@
 		"makes like a fish and suffocates!",
 		"is strangling themselves with their own tendrils!")
 
-/datum/species/skrell/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_skrell_life(H)
 
 /datum/species/vox
 	name = "Vox"
@@ -313,7 +304,7 @@
 	default_hair_colour = "#614f19" //R: 97, G: 79, B: 25
 	butt_sprite = "vox"
 
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_vox_life"
 	scream_verb = "shrieks"
 	male_scream_sound = 'sound/voice/shriek1.ogg'
 	female_scream_sound = 'sound/voice/shriek1.ogg'
@@ -414,8 +405,6 @@
 		H.change_icobase(new_icobase, new_deform, owner_sensitive) //Update the icobase/deform of all our organs, but make sure we don't mess with frankenstein limbs in doing so.
 		H.update_dna()
 
-/datum/species/vox/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_vox_life(H)
 
 /datum/species/vox/armalis/handle_post_spawn(var/mob/living/carbon/human/H)
 	H.verbs += /mob/living/carbon/human/proc/leap
@@ -456,7 +445,7 @@
 	blood_color = "#2299FC"
 	flesh_color = "#808D11"
 
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_vox_armalis_life"
 
 	tail = "armalis_tail"
 	icon_template = 'icons/mob/human_races/r_armalis.dmi'
@@ -478,8 +467,6 @@
 		"is holding their breath!",
 		"is huffing oxygen!")
 
-/datum/species/vox/armalis/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_vox_armalis_life(H)
 
 /datum/species/kidan
 	name = "Kidan"
@@ -499,7 +486,7 @@
 	eyes = "kidan_eyes_s"
 	dietflags = DIET_HERB
 	blood_color = "#FB9800"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_kidan_life"
 	//Default styles for created mobs.
 	default_headacc = "Normal Antennae"
 	butt_sprite = "kidan"
@@ -522,8 +509,6 @@
 		"is twisting their own neck!",
 		"is holding their breath!")
 
-/datum/species/kidan/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_kidan_life(H)
 
 /datum/species/slime
 	name = "Slime People"
@@ -552,7 +537,7 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | NO_EYES
 	dietflags = DIET_CARN
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_slime_person_life"
 	exotic_blood = "water"
 	//ventcrawler = 1 //ventcrawling commented out
 	butt_sprite = "slime"
@@ -573,9 +558,6 @@
 		/mob/living/carbon/human/verb/toggle_recolor_verb,
 		/mob/living/carbon/human/proc/regrow_limbs
 		)
-
-/datum/species/slime/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_slime_person_life(H)
 
 /datum/species/slime/handle_life(var/mob/living/carbon/human/H)
 //This is allegedly for code "style". Like a plaid sweater?
@@ -720,6 +702,7 @@
 	if(H in recolor_list)
 		H.toggle_recolor(silent = 1)
 
+
 /datum/species/grey
 	name = "Grey"
 	name_plural = "Greys"
@@ -750,7 +733,7 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags =  HAS_BODY_MARKINGS
 	dietflags = DIET_HERB
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_grey_life"
 	blood_color = "#A200FF"
 
 /datum/species/grey/handle_dna(var/mob/living/carbon/C, var/remove)
@@ -767,8 +750,6 @@
 	if(speech_pref)
 		H.mind.speech_span = "wingdings"
 
-/datum/species/grey/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_grey_life(H)
 
 /datum/species/diona
 	name = "Diona"
@@ -815,7 +796,7 @@
 	flesh_color = "#907E4A"
 	butt_sprite = "diona"
 
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_diona_life"
 
 	has_organ = list(
 		"nutrient channel" =   /obj/item/organ/internal/liver/diona,
@@ -856,9 +837,6 @@
 
 	return ..()
 
-/datum/species/diona/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_diona_life(H)
-
 /datum/species/diona/handle_life(var/mob/living/carbon/human/H)
 	var/rads = H.radiation / 25
 	H.apply_effect(-rads,IRRADIATE,0)
@@ -890,6 +868,7 @@
 	if(H.nutrition < 200)
 		H.take_overall_damage(10,0)
 		H.traumatic_shock++
+
 
 /datum/species/machine
 	name = "Machine"
@@ -928,7 +907,8 @@
 	virus_immune = 1
 	can_revive_by_healing = 1
 	has_gender = FALSE
-	reagent_tag = PROCESS_SYN
+	reagent_process_tag = PROCESS_SYN
+	on_species_life_proc_name = "on_machine_person_life"
 	male_scream_sound = 'sound/goonstation/voice/robot_scream.ogg'
 	female_scream_sound = 'sound/goonstation/voice/robot_scream.ogg'
 	male_cough_sounds = list('sound/effects/mob_effects/m_machine_cougha.ogg','sound/effects/mob_effects/m_machine_coughb.ogg', 'sound/effects/mob_effects/m_machine_coughc.ogg')
@@ -980,8 +960,6 @@
 			H.update_hair()
 			H.update_fhair()
 
-/datum/species/machine/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_machine_person_life(H)
 
 /datum/species/drask
 	name = "Drask"
@@ -1037,7 +1015,7 @@
 	hot_env_multiplier = 2
 
 	flesh_color = "#a3d4eb"
-	reagent_tag = PROCESS_ORG
+	on_species_life_proc_name = "on_drask_life"
 	base_color = "#a3d4eb"
 	blood_color = "#a3d4eb"
 	butt_sprite = "drask"
@@ -1049,9 +1027,6 @@
 		"eyes" =     				/obj/item/organ/internal/eyes/drask, //5 darksight.
 		"brain" =  					/obj/item/organ/internal/brain/drask
 		)
-
-/datum/species/drask/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
-	R.on_drask_life(H)
 
 /datum/species/drask/handle_temperature(datum/gas_mixture/breath, var/mob/living/carbon/human/H)
 	if( abs(310.15 - breath.temperature) > 50)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -363,7 +363,7 @@
 	// is secretly a silicon
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		if(H.species && H.species.reagent_tag == PROCESS_SYN)
+		if(H.species && H.species.reagent_process_tag == PROCESS_SYN)
 			return 0
 
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -193,7 +193,7 @@ var/global/list/ts_spiderling_list = list()
 			var/can_poison = 1
 			if(ishuman(G))
 				var/mob/living/carbon/human/H = G
-				if(!(H.species.reagent_tag & PROCESS_ORG) || (!H.species.tox_mod))
+				if(!(H.species.reagent_process_tag & PROCESS_ORG) || (!H.species.tox_mod))
 					can_poison = 0
 			spider_specialattack(G,can_poison)
 		else

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -216,14 +216,14 @@ var/const/INGEST = 2
 			var/mob/living/carbon/human/H = M
 			//Check if this mob's species is set and can process this type of reagent
 			var/can_process = 0
-			//If we somehow avoided getting a species or reagent_tag set, we'll assume we aren't meant to process ANY reagents (CODERS: SET YOUR SPECIES AND TAG!)
-			if(H.species && H.species.reagent_tag)
-				if((R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_SYN))		//SYNTHETIC-oriented reagents require PROCESS_SYN
+			//If we somehow avoided getting a species or reagent_process_tag set, we'll assume we aren't meant to process ANY reagents (CODERS: SET YOUR SPECIES AND TAG!)
+			if(H.species && H.species.reagent_process_tag)
+				if((R.process_flags & SYNTHETIC) && (H.species.reagent_process_tag & PROCESS_SYN))		//SYNTHETIC-oriented reagents require PROCESS_SYN
 					can_process = 1
-				if((R.process_flags & ORGANIC) && (H.species.reagent_tag & PROCESS_ORG))		//ORGANIC-oriented reagents require PROCESS_ORG
+				if((R.process_flags & ORGANIC) && (H.species.reagent_process_tag & PROCESS_ORG))		//ORGANIC-oriented reagents require PROCESS_ORG
 					can_process = 1
 				//Species with PROCESS_DUO are only affected by reagents that affect both organics and synthetics, like acid and hellwater
-				if((R.process_flags & ORGANIC) && (R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_DUO))
+				if((R.process_flags & ORGANIC) && (R.process_flags & SYNTHETIC) && (H.species.reagent_process_tag & PROCESS_DUO))
 					can_process = 1
 
 			//If the mob can't process it, remove the reagent at it's normal rate without doing any addictions, overdoses, or on_mob_life() for the reagent
@@ -495,14 +495,14 @@ var/const/INGEST = 2
 	var/can_process = 0
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		//Check if this mob's species is set and can process this type of reagent
-		if(H.species && H.species.reagent_tag)
-			if((R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_SYN))		//SYNTHETIC-oriented reagents require PROCESS_SYN
+		//Check if this mob's species is set and can process this type of reagent (reagent_process_tag)
+		if(H.species && H.species.reagent_process_tag)
+			if((R.process_flags & SYNTHETIC) && (H.species.reagent_process_tag & PROCESS_SYN))		//SYNTHETIC-oriented reagents require PROCESS_SYN
 				can_process = 1
-			if((R.process_flags & ORGANIC) && (H.species.reagent_tag & PROCESS_ORG))		//ORGANIC-oriented reagents require PROCESS_ORG
+			if((R.process_flags & ORGANIC) && (H.species.reagent_process_tag & PROCESS_ORG))		//ORGANIC-oriented reagents require PROCESS_ORG
 				can_process = 1
 			//Species with PROCESS_DUO are only affected by reagents that affect both organics and synthetics, like acid and hellwater
-			if((R.process_flags & ORGANIC) && (R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_DUO))
+			if((R.process_flags & ORGANIC) && (R.process_flags & SYNTHETIC) && (H.species.reagent_process_tag & PROCESS_DUO))
 				can_process = 1
 		if(H.species && H.species.exotic_blood)
 			if(R.id == H.species.exotic_blood)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -211,36 +211,18 @@ var/const/INGEST = 2
 			continue
 		if(!M)
 			M = R.holder.my_atom
+
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			//Check if this mob's species is set and can process this type of reagent
-			var/can_process = 0
-			//If we somehow avoided getting a species or reagent_tag set, we'll assume we aren't meant to process ANY reagents (CODERS: SET YOUR SPECIES AND TAG!)
-			if(H.species && H.species.reagent_tag)
-				if((R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_SYN))		//SYNTHETIC-oriented reagents require PROCESS_SYN
-					can_process = 1
-				if((R.process_flags & ORGANIC) && (H.species.reagent_tag & PROCESS_ORG))		//ORGANIC-oriented reagents require PROCESS_ORG
-					can_process = 1
-				//Species with PROCESS_DUO are only affected by reagents that affect both organics and synthetics, like acid and hellwater
-				if((R.process_flags & ORGANIC) && (R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_DUO))
-					can_process = 1
-
-			//If handle_reagents returns 0, it's doing the reagent removal on its own
-			var/species_handled = !(H.species.handle_reagents(H, R))
-			can_process = can_process && !species_handled
-			//If the mob can't process it, remove the reagent at it's normal rate without doing any addictions, overdoses, or on_mob_life() for the reagent
-			if(can_process == 0)
-				if(!species_handled)
-					R.holder.remove_reagent(R.id, R.metabolization_rate)
-				continue
-		//We'll assume that non-human mobs lack the ability to process synthetic-oriented reagents (adjust this if we need to change that assumption)
-		else
-			if(R.process_flags == SYNTHETIC)
-				R.holder.remove_reagent(R.id, R.metabolization_rate)
-				continue
-		//If you got this far, that means we can process whatever reagent this iteration is for. Handle things normally from here.
-		if(M && R)
+			//Check if this mob's species is set then call the species handle_reagents
+			if(H.species)
+				H.species.handle_reagents(H, R)
+			else	//in case you somehow don't have a species, just use the default on_mob_life
+				R.on_mob_life(H)
+		else	//use the default on_mob_life for non-human mobs
 			R.on_mob_life(M)
+
+		if(M &&R)
 			if(R.volume >= R.overdose_threshold && !R.overdosed && R.overdose_threshold > 0)
 				R.overdosed = 1
 				R.overdose_start(M)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -240,11 +240,7 @@ var/const/INGEST = 2
 		if(M && R)
 			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
-				//Check if this mob's species is set then call the species handle_reagents
-				if(H.species)
-					H.species.handle_reagents(H, R)
-				else	//in case you somehow don't have a species, just use the default on_mob_life
-					R.on_mob_life(H)
+				H.species.handle_reagents(H, R)
 			else	//use the default on_mob_life for non-human mobs
 				R.on_mob_life(M)
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -214,13 +214,39 @@ var/const/INGEST = 2
 
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			//Check if this mob's species is set then call the species handle_reagents
-			if(H.species)
-				H.species.handle_reagents(H, R)
-			else	//in case you somehow don't have a species, just use the default on_mob_life
-				R.on_mob_life(H)
-		else	//use the default on_mob_life for non-human mobs
-			R.on_mob_life(M)
+			//Check if this mob's species is set and can process this type of reagent
+			var/can_process = 0
+			//If we somehow avoided getting a species or reagent_tag set, we'll assume we aren't meant to process ANY reagents (CODERS: SET YOUR SPECIES AND TAG!)
+			if(H.species && H.species.reagent_tag)
+				if((R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_SYN))		//SYNTHETIC-oriented reagents require PROCESS_SYN
+					can_process = 1
+				if((R.process_flags & ORGANIC) && (H.species.reagent_tag & PROCESS_ORG))		//ORGANIC-oriented reagents require PROCESS_ORG
+					can_process = 1
+				//Species with PROCESS_DUO are only affected by reagents that affect both organics and synthetics, like acid and hellwater
+				if((R.process_flags & ORGANIC) && (R.process_flags & SYNTHETIC) && (H.species.reagent_tag & PROCESS_DUO))
+					can_process = 1
+
+			//If the mob can't process it, remove the reagent at it's normal rate without doing any addictions, overdoses, or on_mob_life() for the reagent
+			if(can_process == 0)
+				R.holder.remove_reagent(R.id, R.metabolization_rate)
+				continue
+		//We'll assume that non-human mobs lack the ability to process synthetic-oriented reagents (adjust this if we need to change that assumption)
+		else
+			if(R.process_flags == SYNTHETIC)
+				R.holder.remove_reagent(R.id, R.metabolization_rate)
+				continue
+
+		//If you got this far, that means we can process whatever reagent this iteration is for. Handle things normally from here.
+		if(M && R)
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				//Check if this mob's species is set then call the species handle_reagents
+				if(H.species)
+					H.species.handle_reagents(H, R)
+				else	//in case you somehow don't have a species, just use the default on_mob_life
+					R.on_mob_life(H)
+			else	//use the default on_mob_life for non-human mobs
+				R.on_mob_life(M)
 
 		if(M &&R)
 			if(R.volume >= R.overdose_threshold && !R.overdosed && R.overdose_threshold > 0)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -151,9 +151,9 @@
 		to_chat(M, "<span class='warning'>You would DIE for some [name] right now!</span>")
 
 
-/********************************/
-/*	Species Reagent Overrides	*/
-/********************************/
+/****************************************/
+/*	on_species_life Proc Declarations	*/
+/****************************************/
 /*
 *	Override these procs on a reagent if a certain species should be affected differently by a certain reagent instead of the normal on_mob_life for that reagent
 *	If you don't override the proc, it instead just calls on_mob_life for that reagent to run normally since you didn't want a special interaction
@@ -262,18 +262,18 @@
 	on_shadow_person_life(H)
 
 
-//Monkey species procs
+//Monkey species procs, these default to calling their "evolved" form's proc, but you can override this if you want them to react differently to a reagent in primitive form
 /datum/reagent/proc/on_monkey_life(mob/living/carbon/human/H)				//human monkeys, aka chimps
-	on_mob_life(H)
+	on_mob_life(H)		//humans use on_mob_life, change this if you make humans have their own on_species_life proc
 
 /datum/reagent/proc/on_farwa_life(mob/living/carbon/human/H)				//tajaran monkeys
-	on_mob_life(H)
+	on_tajaran_life(H)
 
 /datum/reagent/proc/on_neara_life(mob/living/carbon/human/H)				//skrell monkeys
-	on_mob_life(H)
+	on_skrell_life(H)
 
 /datum/reagent/proc/on_wolpin_life(mob/living/carbon/human/H)				//vulpkanin monkeys
-	on_mob_life(H)
+	on_vulpkanin_life(H)
 
 /datum/reagent/proc/on_stok_life(mob/living/carbon/human/H)					//unathi monkeys
-	on_mob_life(H)
+	on_unathi_life(H)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -149,3 +149,131 @@
 		to_chat(M, "<span class='warning'>You feel like you can't live without [name]!</span>")
 	if(prob(5))
 		to_chat(M, "<span class='warning'>You would DIE for some [name] right now!</span>")
+
+
+/********************************/
+/*	Species Reagent Overrides	*/
+/********************************/
+/*
+*	Override these procs on a reagent if a certain species should be affected differently by a certain reagent instead of the normal on_mob_life for that reagent
+*	If you don't override the proc, it instead just calls on_mob_life for that reagent to run normally since you didn't want a special interaction
+*	NOTE: These only apply to on_mob_life effects. If you want to have a unique effect to reaction_mob or something, these procs won't help you.
+*
+*	>> IMPORTANT! << Make sure you include this code in the species reagent proc if you override it:
+*
+*			H.reagents.remove_reagent(id, metabolization_rate)
+*
+*	If you don't include that, the reagent won't deplete normally!
+*
+*	You may be asking:
+*		"But why not just include that in the species' handle_reagents proc?"
+*	That's because then you'll remove twice as much (which is bad!) when you don't override this proc, since on_mob_life removes the reagent through a ..() call!
+*	So don't be a dolt and try removing the reagent in handle_reagents okay?
+*
+*	Example:
+*
+*	/datum/reagent/fliptonium/on_vulpkanin_life(mob/living/carbon/human/H)
+*		to_chat(H, "<span class='notice'>Roll over, Fido!</span>")
+*		H.SpinAnimation(speed = 11, loops = -1)
+*		to_chat(H, "<span class='notice'>Good doggo!</span>")
+*		H.reagents.remove_reagent(id, metabolization_rate)
+*
+*	This example override for vulpkanin displays two messages and makes them flip once, then removes the normal amount of fliptonium every cycle.
+*	It probably would also infuriate them since it does it EVERY time they metabolize the chemical. (honk!)
+*
+*	Additionally, including ..() in your override will make it call the normal on_mob_life since the base version of the proc calls it (as seen below).
+*	Be careful when doing this, as you can end up with some weird behavior if you don't pay attention to what both versions' effects do!
+*	However, if your override does all the same things as the base version and a little more, this can save you some copied lines. JUST BE SMART ABOUT IT!
+*
+*	Below are the initial defines for the per-species procs. Included are procs for every species except Human, since Human is meant to be the base-line/generic effect
+*	I realize we might not want to provide effects for all of the species below, but I defined the procs now in case we want to in the future.
+*		You're welcome future coder who wants to make banana juice act like omnizine for ONLY chimps but not farwa (even though both are monkey species types).
+*	Additionally, if you add a new species, you will want to add a new proc for them so they can handle their own reagent effects rather than mooch of some other species.
+*/
+
+//Station species procs (humans aren't included since they are considered the "baseline" and on_mob_life should thus be the effect on humans)
+/datum/reagent/proc/on_tajaran_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_vulpkanin_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_skrell_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_unathi_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_diona_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_grey_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_kidan_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_machine_person_life(mob/living/carbon/human/H)		//aka IPCs
+	on_mob_life(H)
+
+/datum/reagent/proc/on_slime_person_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_vox_life(mob/living/carbon/human/H)					//normal station vox
+	on_mob_life(H)
+
+/datum/reagent/proc/on_plasmaman_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_drask_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+
+//Admin-only species procs
+/datum/reagent/proc/on_skeleton_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_wryn_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_nucleation_life(mob/living/carbon/human/H)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_vox_armalis_life(mob/living/carbon/human/H)			//big admin vox (they might not be affected by a reagent the same way as normal vox)
+	on_mob_life(H)
+
+
+//Other species procs
+/datum/reagent/proc/on_abductor_life(mob/living/carbon/human/H)				//abductors, from the abductor game mode/event
+	on_mob_life(H)
+
+/datum/reagent/proc/on_golem_life(mob/living/carbon/human/H)				//golems, from xenobio
+	on_mob_life(H)
+
+/datum/reagent/proc/on_shadow_person_life(mob/living/carbon/human/H)		//shadow people, from xenobio (NOT SHADOWLINGS)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_shadowling_life(mob/living/carbon/human/H)			//Normal Shadowlings, from the game mode (ascendant shadowlings are a simple_animal mob)
+	on_mob_life(H)
+
+/datum/reagent/proc/on_lesser_shadowling_life(mob/living/carbon/human/H)	//Lesser Shadowlings (empowered thralls), from the shadowling ability "Black Recuperation"
+	//By default, this is going to call the same effect as the basic shadow person version so they will react the same to reagents that affect shadow people.
+	//This is because these are powered up shadow people, but you can override this on reagents you want to handle differently for the empowered version without copying the rest
+	on_shadow_person_life(H)
+
+
+//Monkey species procs
+/datum/reagent/proc/on_monkey_life(mob/living/carbon/human/H)				//human monkeys, aka chimps
+	on_mob_life(H)
+
+/datum/reagent/proc/on_farwa_life(mob/living/carbon/human/H)				//tajaran monkeys
+	on_mob_life(H)
+
+/datum/reagent/proc/on_neara_life(mob/living/carbon/human/H)				//skrell monkeys
+	on_mob_life(H)
+
+/datum/reagent/proc/on_wolpin_life(mob/living/carbon/human/H)				//vulpkanin monkeys
+	on_mob_life(H)
+
+/datum/reagent/proc/on_stok_life(mob/living/carbon/human/H)					//unathi monkeys
+	on_mob_life(H)

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -1061,12 +1061,17 @@
 	drink_desc = "The equivalent of alcohol for synthetic crewmembers. They'd find it awful if they had tastebuds too."
 
 /datum/reagent/consumable/ethanol/synthanol/on_mob_life(mob/living/M)
-	if(!M.isSynthetic())
-		holder.remove_reagent(id, 3.6) //gets removed from organics very fast
-		if(prob(25))
-			holder.remove_reagent(id, 15)
-			M.fakevomit()
-	..()
+	to_chat(M, "synthanol on_mob_life()")
+	holder.remove_reagent(id, 3.6) //gets removed from organics very fast
+	if(prob(25))
+		holder.remove_reagent(id, 15)
+		M.fakevomit()
+
+/datum/reagent/consumable/ethanol/synthanol/on_machine_person_life(mob/living/carbon/human/H)
+	to_chat(H, "synthanol on_machine_life()")
+	H.AdjustDrunk(alcohol_perc)
+	H.AdjustDizzy(dizzy_adj)
+	H.reagents.remove_reagent(id, metabolization_rate)
 
 /datum/reagent/consumable/ethanol/synthanol/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(M.isSynthetic())

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -1061,14 +1061,12 @@
 	drink_desc = "The equivalent of alcohol for synthetic crewmembers. They'd find it awful if they had tastebuds too."
 
 /datum/reagent/consumable/ethanol/synthanol/on_mob_life(mob/living/M)
-	to_chat(M, "synthanol on_mob_life()")
 	holder.remove_reagent(id, 3.6) //gets removed from organics very fast
 	if(prob(25))
 		holder.remove_reagent(id, 15)
 		M.fakevomit()
 
 /datum/reagent/consumable/ethanol/synthanol/on_machine_person_life(mob/living/carbon/human/H)
-	to_chat(H, "synthanol on_machine_life()")
 	H.AdjustDrunk(alcohol_perc)
 	H.AdjustDizzy(dizzy_adj)
 	H.reagents.remove_reagent(id, metabolization_rate)

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -194,6 +194,9 @@
 	..()
 
 /datum/reagent/consumable/drink/milk/on_skeleton_life(mob/living/carbon/human/H)
+	if(type in subtypesof(/datum/reagent/consumable/drink/milk))		//prevents stacking subtypes for healing purposes. only pure milk gives strong bones and calcium.
+		on_mob_life(H)
+		return
 	H.heal_overall_damage(4,4)
 	if(prob(5))	// 5% chance per proc to find a random limb, and mend it
 		var/list/our_organs = H.organs.Copy()

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -193,6 +193,23 @@
 		holder.remove_reagent("capsaicin", 2)
 	..()
 
+/datum/reagent/consumable/drink/milk/on_skeleton_life(mob/living/carbon/human/H)
+	H.heal_overall_damage(4,4)
+	if(prob(5))	// 5% chance per proc to find a random limb, and mend it
+		var/list/our_organs = H.organs.Copy()
+		shuffle(our_organs)
+		for(var/obj/item/organ/external/L in our_organs)
+			if(istype(L))
+				if(L.brute_dam < L.min_broken_damage)
+					L.status &= ~ORGAN_BROKEN
+					L.status &= ~ORGAN_SPLINTED
+					L.perma_injury = 0
+				break	// We're only checking one limb here, bucko
+		if(prob(3))
+			H.say(pick("Thanks Mr Skeltal", "Thank for strong bones", "Doot doot!"))
+	H.reagents.remove_reagent(id, metabolization_rate)
+
+
 /datum/reagent/consumable/drink/milk/soymilk
 	name = "Soy Milk"
 	id = "soymilk"

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -576,23 +576,23 @@
 	addiction_chance = 60
 	metabolization_rate = 0.6
 
-/datum/reagent/lube/ultra/on_mob_life(mob/living/M)
+/datum/reagent/lube/ultra/on_machine_person_life(mob/living/carbon/human/H)
 	var/high_message = pick("You feel your servos whir!", "You feel like you need to go faster.", "You feel like you were just overclocked!")
 	if(prob(1))
 		if(prob(1))
 			high_message = "0100011101001111010101000101010001000001010001110100111101000110010000010101001101010100!"
 	if(prob(5))
-		to_chat(M, "<span class='notice'>[high_message]</span>")
-	M.AdjustParalysis(-2)
-	M.AdjustStunned(-2)
-	M.AdjustWeakened(-2)
-	M.adjustStaminaLoss(-2)
-	M.status_flags |= GOTTAGOREALLYFAST
-	M.Jitter(3)
-	M.adjustBrainLoss(0.5)
+		to_chat(H, "<span class='notice'>[high_message]</span>")
+	H.AdjustParalysis(-2)
+	H.AdjustStunned(-2)
+	H.AdjustWeakened(-2)
+	H.adjustStaminaLoss(-2)
+	H.status_flags |= GOTTAGOREALLYFAST
+	H.Jitter(3)
+	H.adjustBrainLoss(0.5)
 	if(prob(5))
-		M.emote(pick("twitch", "shiver"))
-	..()
+		H.emote(pick("twitch", "shiver"))
+	H.reagents.remove_reagent(id, metabolization_rate)
 
 /datum/reagent/lube/ultra/on_mob_delete(mob/living/M)
 	M.status_flags &= ~GOTTAGOREALLYFAST
@@ -624,15 +624,15 @@
 	addiction_chance = 50
 
 
-/datum/reagent/surge/on_mob_life(mob/living/M)
-	M.Druggy(15)
+/datum/reagent/surge/on_machine_person_life(mob/living/carbon/human/H)
+	H.Druggy(15)
 	var/high_message = pick("You feel calm.", "You feel collected.", "You feel like you need to relax.")
 	if(prob(1))
 		if(prob(1))
 			high_message = "01010100010100100100000101001110010100110100001101000101010011100100010001000101010011100100001101000101."
 	if(prob(5))
-		to_chat(M, "<span class='notice'>[high_message]</span>")
-	..()
+		to_chat(H, "<span class='notice'>[high_message]</span>")
+	H.reagents.remove_reagent(id, metabolization_rate)
 
 /datum/reagent/surge/overdose_process(mob/living/M, severity)
 	//Hit them with the same effects as an electrode!

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -934,20 +934,20 @@
 	color = "#CC7A00"
 	process_flags = SYNTHETIC
 
-/datum/reagent/medicine/degreaser/on_mob_life(mob/living/M)
+/datum/reagent/medicine/degreaser/on_machine_person_life(mob/living/carbon/human/H)
 	if(prob(50))		//Same effects as coffee, to help purge ill effects like paralysis
-		M.AdjustParalysis(-1)
-		M.AdjustStunned(-1)
-		M.AdjustWeakened(-1)
-		M.AdjustConfused(-5)
-	for(var/datum/reagent/R in M.reagents.reagent_list)
+		H.AdjustParalysis(-1)
+		H.AdjustStunned(-1)
+		H.AdjustWeakened(-1)
+		H.AdjustConfused(-5)
+	for(var/datum/reagent/R in H.reagents.reagent_list)
 		if(R != src)
 			if(R.id == "ultralube" || R.id == "lube")
 				//Flushes lube and ultra-lube even faster than other chems
-				M.reagents.remove_reagent(R.id, 5)
+				H.reagents.remove_reagent(R.id, 5)
 			else
-				M.reagents.remove_reagent(R.id,1)
-	..()
+				H.reagents.remove_reagent(R.id,1)
+	H.reagents.remove_reagent(id, metabolization_rate)
 
 /datum/reagent/medicine/degreaser/reaction_turf(turf/simulated/T, volume)
 	if(volume >= 1 && istype(T))
@@ -963,9 +963,9 @@
 	color = "#D7B395"
 	process_flags = SYNTHETIC
 
-/datum/reagent/medicine/liquid_solder/on_mob_life(mob/living/M)
-	M.adjustBrainLoss(-3)
-	..()
+/datum/reagent/medicine/liquid_solder/on_machine_person_life(mob/living/carbon/human/H)
+	H.adjustBrainLoss(-3)
+	H.reagents.remove_reagent(id, metabolization_rate)
 
 
 

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -39,6 +39,11 @@
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 
+/datum/reagent/oxygen/on_vox_life(mob/living/carbon/human/H)		//normal vox are poisoned by oxygen, but vox armalis seem to shrug it off, hence no override for them
+	H.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER)	//same as plasma
+	H.reagents.remove_reagent(id, metabolization_rate)
+
+
 /datum/reagent/nitrogen
 	name = "Nitrogen"
 	id = "nitrogen"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -30,6 +30,12 @@
 		C.adjustPlasma(10)
 	..()
 
+/datum/reagent/plasma/on_plasmaman_life(mob/living/carbon/human/H)
+	H.adjustBruteLoss(-0.5 * REAGENTS_EFFECT_MULTIPLIER)
+	H.adjustFireLoss(-0.5 * REAGENTS_EFFECT_MULTIPLIER)
+	H.adjustPlasma(20)
+	H.reagents.remove_reagent(id, metabolization_rate)
+
 /datum/reagent/plasma/reaction_mob(mob/living/M, method=TOUCH, volume)//Splashing people with plasma is stronger than fuel!
 	if(method == TOUCH)
 		M.adjust_fire_stacks(volume / 5)


### PR DESCRIPTION
Reworks and Refactors how species interact with reagents (and vice versa).

Functionally, this moves the handling of species-specific reagent effects to the reagent rather than the species. The Human species is now considered the "base-line" for reagent effects, with all other species having new versions of the on_mob_life proc added to the base reagent datum defines. These procs can be overridden on specific reagents to have alternate on_mob_life effects for their respective species.
- Note that this is specifically for on_mob_life(), not reaction_mob(), on_mob_death(), or other reagent procs. These typically aren't called as often and are less likely to have drastic differences for multiple species, though we can rework those in the future to be more in line with the on_mob_life overrides if desired/needed.

By default, these procs simply call the normal on_mob_life() proc for the reagent, so if a species does not specifically override a reagent, it will run the standard effects.
- This means if a reagent is overridden for Skrell but not for Kidan, Kidan will experience the normal effects of the reagent while Skrell experience their own effects.

All existing species-dependent reagent effects are maintained.
- Skeletons are still healed by milk
- Plasmamen are still healed by plasma
- Vox are still poisoned by oxygen
- Machine People (IPCs) still process Surge, Ultra Lube, Liquid Solder, Degreaser, and synthanol-based drinks as they did before

While this system currently isn't being fully utilized, this does make it MUCH simpler to add special effects to a reagent for multiple species, such as making ethanol (alcohol) hit Skrell twice as hard and hardly affect Kidan.
- Hopefully this system encourages the adding of more species-dependent effects for reagents, such as some of those lore ones we don't currently have in game.

Additionally, this helps keep the effects of a reagent WITH the defines for that reagent, rather than needing to dig into species code to see just how much brute and fire a plasma heals a Plasmaman each cycle.

No CL since this has no gameplay impact yet. It's purely code-side changes, everything in-game works as it did before without any new stuff.