### PR TITLE
Converts Most Destroys to use QDEL_NULL

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -53,15 +53,11 @@ Pipelines + Other Objects -> Pipe network
 		stored = new(src, make_from = src)
 
 /obj/machinery/atmospherics/Destroy()
-	if(stored)
-		qdel(stored)
-		stored = null
+	QDEL_NULL(stored)
 	for(var/mob/living/L in src) //ventcrawling is serious business
 		L.remove_ventcrawl()
 		L.forceMove(get_turf(src))
-	if(pipe_image)
-		qdel(pipe_image) //we have to del it, or it might keep a ref somewhere else
-		pipe_image = null
+	QDEL_NULL(pipe_image) //we have to del it, or it might keep a ref somewhere else
 	return ..()
 
 // Icons/overlays/underlays

--- a/code/ATMOSPHERICS/pipes/pipe.dm
+++ b/code/ATMOSPHERICS/pipes/pipe.dm
@@ -21,8 +21,7 @@
 
 /obj/machinery/atmospherics/pipe/Destroy()
 	releaseAirToTurf()
-	qdel(air_temporary)
-	air_temporary = null
+	QDEL_NULL(air_temporary)
 
 	var/turf/T = loc
 	for(var/obj/machinery/meter/meter in T)

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -70,8 +70,7 @@
 
 /turf/simulated/Destroy()
 	visibilityChanged()
-	if(active_hotspot)
-		qdel(active_hotspot)
+	QDEL_NULL(active_hotspot)
 	return ..()
 
 /turf/simulated/assume_air(datum/gas_mixture/giver)

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -54,8 +54,7 @@
 	qdel(hide_actions_toggle)
 	hide_actions_toggle = null
 
-	qdel(module_store_icon)
-	module_store_icon = null
+	QDEL_NULL(module_store_icon)
 
 	if(static_inventory.len)
 		for(var/thing in static_inventory)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -29,8 +29,7 @@
 		Remove(owner)
 	if(target)
 		target = null
-	qdel(button)
-	button = null
+	QDEL_NULL(button)
 	return ..()
 
 /datum/action/proc/Grant(mob/M)

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -100,7 +100,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	var/action_icon = 'icons/mob/actions.dmi'
 	var/action_icon_state = "spell_default"
 	var/action_background_icon_state = "bg_spell"
-	
+
 	var/sound = null //The sound the spell makes when it is cast
 
 /obj/effect/proc_holder/spell/proc/cast_check(skipcharge = 0, mob/living/user = usr) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
@@ -184,8 +184,8 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 			user.visible_message(invocation, invocation_emote_self) //same style as in mob/living/emote.dm
 
 /obj/effect/proc_holder/spell/proc/playMagSound()
-	playsound(get_turf(usr), sound,50,1)			
-			
+	playsound(get_turf(usr), sound,50,1)
+
 /obj/effect/proc_holder/spell/New()
 	..()
 	action = new(src)
@@ -194,8 +194,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	charge_counter = charge_max
 
 /obj/effect/proc_holder/spell/Destroy()
-	qdel(action)
-	action = null
+	QDEL_NULL(action)
 	return ..()
 
 /obj/effect/proc_holder/spell/Click()
@@ -223,10 +222,10 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	spawn(0)
 		if(charge_type == "recharge" && recharge)
 			start_recharge()
-			
+
 	if(sound)
-		playMagSound()			
-			
+		playMagSound()
+
 	if(prob(critfailchance))
 		critfail(targets)
 	else

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -76,12 +76,10 @@
 			qdel(AA)
 		alternate_appearances = null
 
-	if(reagents)
-		qdel(reagents)
-		reagents = null
+	QDEL_NULL(reagents)
 	invisibility = 101
 	return ..()
-	
+
 //Hook for running code when a dir change occurs
 /atom/proc/setDir(newdir)
 	dir = newdir

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -35,8 +35,7 @@ var/bomb_set
 	poi_list |= src
 
 /obj/machinery/nuclearbomb/Destroy()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	poi_list.Remove(src)
 	return ..()
 

--- a/code/game/machinery/Beacon.dm
+++ b/code/game/machinery/Beacon.dm
@@ -22,9 +22,7 @@
 	hide(T.intact)
 
 /obj/machinery/bluespace_beacon/Destroy()
-	if(Beacon)
-		qdel(Beacon)
-	Beacon = null
+	QDEL_NULL(Beacon)
 	return ..()
 
 // update the invisibility and icon

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -40,9 +40,7 @@
 		src.colorlist += D
 
 /obj/machinery/pdapainter/Destroy()
-	if(storedpda)
-		qdel(storedpda)
-		storedpda = null
+	QDEL_NULL(storedpda)
 	return ..()
 
 /obj/machinery/pdapainter/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
@@ -85,7 +83,7 @@
 	set name = "Eject PDA"
 	set category = "Object"
 	set src in oview(1)
-	
+
 	if(usr.incapacitated())
 		return
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -212,8 +212,7 @@
 	if(radio_controller)
 		radio_controller.remove_object(src, frequency)
 	air_alarm_repository.update_cache(src)
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/machinery/alarm/proc/first_run()

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -36,10 +36,8 @@
 
 /obj/machinery/portable_atmospherics/Destroy()
 	disconnect()
-	qdel(air_contents)
-	air_contents = null
-	qdel(holding)
-	holding = null
+	QDEL_NULL(air_contents)
+	QDEL_NULL(holding)
 	return ..()
 
 /obj/machinery/portable_atmospherics/update_icon()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -67,10 +67,8 @@
 	RefreshParts()
 
 /obj/machinery/autolathe/Destroy()
-	qdel(wires)
-	wires = null
-	qdel(materials)
-	materials = null
+	QDEL_NULL(wires)
+	QDEL_NULL(materials)
 	return ..()
 
 /obj/machinery/autolathe/interact(mob/user)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -82,12 +82,8 @@
 /obj/machinery/clonepod/Destroy()
 	if(connected)
 		connected.pods -= src
-	if(Radio)
-		qdel(Radio)
-		Radio = null
-	if(countdown)
-		qdel(countdown)
-		countdown = null
+	QDEL_NULL(Radio)
+	QDEL_NULL(countdown)
 	return ..()
 
 /obj/machinery/clonepod/RefreshParts()

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -10,12 +10,9 @@
 	var/obj/item/device/mmi/brain = null
 
 /obj/structure/AIcore/Destroy()
-	qdel(laws)
-	qdel(circuit)
-	qdel(brain)
-	laws = null
-	circuit = null
-	brain = null
+	QDEL_NULL(laws)
+	QDEL_NULL(circuit)
+	QDEL_NULL(brain)
 	return ..()
 
 /obj/structure/AIcore/attackby(obj/item/P as obj, mob/user as mob, params)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -28,8 +28,7 @@
 /obj/machinery/computer/camera_advanced/Destroy()
 	if(current_user)
 		current_user.unset_machine()
-	if(eyeobj)
-		qdel(eyeobj)
+	QDEL_NULL(eyeobj)
 	return ..()
 
 /obj/machinery/computer/camera_advanced/on_unset_machine(mob/M)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -15,8 +15,7 @@
 	..()
 
 /obj/machinery/computer/crew/Destroy()
-	qdel(crew_monitor)
-	crew_monitor = null
+	QDEL_NULL(crew_monitor)
 	return ..()
 
 /obj/machinery/computer/crew/attack_ai(mob/user)

--- a/code/game/machinery/computer/power.dm
+++ b/code/game/machinery/computer/power.dm
@@ -16,7 +16,7 @@
 	power_monitors += src
 	power_monitors = sortAtom(power_monitors)
 	power_monitor = new(src)
-	
+
 /obj/machinery/computer/monitor/initialize()
 	..()
 	powermonitor_repository.update_cache()
@@ -25,8 +25,7 @@
 /obj/machinery/computer/monitor/Destroy()
 	power_monitors -= src
 	powermonitor_repository.update_cache()
-	qdel(power_monitor)
-	power_monitor = null
+	QDEL_NULL(power_monitor)
 	return ..()
 
 /obj/machinery/computer/monitor/power_change()

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -24,8 +24,7 @@
 
 /obj/machinery/computer/station_alert/Destroy()
 	alarm_monitor.unregister(src)
-	qdel(alarm_monitor)
-	alarm_monitor = null
+	QDEL_NULL(alarm_monitor)
 	return ..()
 
 /obj/machinery/computer/station_alert/attack_ai(mob/user)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -348,8 +348,7 @@ About the new airlock wires panel:
 
 
 /obj/machinery/door/airlock/Destroy()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	if(main_power_timer)
 		deltimer(main_power_timer)
 		main_power_timer = null

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -25,9 +25,7 @@
 	density = 0
 	if(health == 0)
 		playsound(src, "shatter", 70, 1)
-	if(electronics)
-		qdel(electronics)
-		electronics = null
+	QDEL_NULL(electronics)
 	return ..()
 
 

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -20,9 +20,7 @@
 	..()
 
 /obj/machinery/floodlight/Destroy()
-	if(cell)
-		qdel(cell)
-		cell = null
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/machinery/floodlight/proc/updateicon()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -15,9 +15,7 @@
 
 /obj/machinery/iv_drip/Destroy()
 	attached = null
-	if(beaker)
-		qdel(beaker)
-		beaker = null
+	QDEL_NULL(beaker)
 	return ..()
 
 /obj/machinery/iv_drip/update_icon()

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -113,9 +113,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 /obj/machinery/newscaster/Destroy()
 	allCasters -= src
 	viewing_channel = null
-	if(photo)
-		qdel(photo)
-		photo = null
+	QDEL_NULL(photo)
 	return ..()
 
 /obj/machinery/newscaster/update_icon()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -20,7 +20,7 @@
 	var/health = 80			//the turret's health
 	var/locked = 1			//if the turret's behaviour control access is locked
 	var/controllock = 0		//if the turret responds to control panels
-	
+
 	var/installation = /obj/item/weapon/gun/energy/gun/turret		//the type of weapon installed
 	var/gun_charge = 0		//the charge of the gun inserted
 	var/projectile = null	//holder for bullettype
@@ -56,7 +56,7 @@
 
 	var/screen = 0 // Screen 0: main control, screen 1: access levels
 	var/one_access = 0 // Determines if access control is set to req_one_access or req_access
-	
+
 	var/syndicate = 0		//is the turret a syndicate turret?
 	var/faction = ""
 	var/emp_vulnerable = 1 // Can be empd
@@ -94,8 +94,7 @@
 	setup()
 
 /obj/machinery/porta_turret/Destroy()
-	qdel(spark_system)
-	spark_system = null
+	QDEL_NULL(spark_system)
 	return ..()
 
 /obj/machinery/porta_turret/centcom/New()
@@ -549,8 +548,8 @@ var/list/turret_icons
 /obj/machinery/porta_turret/proc/in_faction(mob/living/target)
 	if(!(faction in target.faction))
 		return 0
-	return 1			
-				
+	return 1
+
 /obj/machinery/porta_turret/proc/assess_and_assign(var/mob/living/L, var/list/targets, var/list/secondarytargets)
 	switch(assess_living(L))
 		if(TURRET_PRIORITY_TARGET)
@@ -582,7 +581,7 @@ var/list/turret_icons
 
 	if(emagged)		// If emagged not even the dead get a rest
 		return L.stat ? TURRET_SECONDARY_TARGET : TURRET_PRIORITY_TARGET
-		
+
 	if(in_faction(L))
 		return TURRET_NOT_TARGET
 
@@ -967,46 +966,46 @@ var/list/turret_icons
 
 /atom/movable/porta_turret_cover
 	icon = 'icons/obj/turrets.dmi'
-	
+
 // Syndicate turrets
 /obj/machinery/porta_turret/syndicate
 	projectile = /obj/item/projectile/bullet
 	eprojectile = /obj/item/projectile/bullet
 	shot_sound = 'sound/weapons/Gunshot.ogg'
 	eshot_sound = 'sound/weapons/Gunshot.ogg'
-	
+
 	icon_state = "syndieturret0"
 	var/icon_state_initial = "syndieturret0"
 	var/icon_state_active = "syndieturret1"
 	var/icon_state_destroyed = "syndieturret2"
-	
+
 	syndicate = 1
 	installation = null
 	always_up = 1
 	use_power = 0
 	has_cover = 0
 	raised = 1
-	scan_range = 9	
-	
+	scan_range = 9
+
 	faction = "syndicate"
 	emp_vulnerable = 0
-	
+
 	lethal = 1
 	check_arrest = 0
 	check_records = 0
 	check_weapons = 0
 	check_access = 0
-	check_anomalies = 1	
+	check_anomalies = 1
 	check_synth	= 1
 	ailock = 1
-	
+
 /obj/machinery/porta_turret/syndicate/New()
 	..()
 	if(req_one_access && req_one_access.len)
 		req_one_access.Cut()
 	req_access = list(access_syndicate)
 	one_access = 0
-	
+
 /obj/machinery/porta_turret/syndicate/update_icon()
 	if(stat & BROKEN)
 		icon_state = icon_state_destroyed
@@ -1025,7 +1024,7 @@ var/list/turret_icons
 	health = 40
 	projectile = /obj/item/projectile/bullet/weakbullet3
 	eprojectile = /obj/item/projectile/bullet/weakbullet3
-	
+
 /obj/machinery/porta_turret/syndicate/interior
 	name = "machine gun turret (.45)"
 	desc = "Syndicate interior defense turret chambered for .45 rounds. Designed to down intruders without damaging the hull."

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -29,8 +29,7 @@ var/const/SAFETY_COOLDOWN = 100
 	update_icon()
 
 /obj/machinery/recycler/Destroy()
-	qdel(materials)
-	materials = null
+	QDEL_NULL(materials)
 	return ..()
 
 /obj/machinery/recycler/RefreshParts()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -20,9 +20,7 @@
 	return
 
 /obj/machinery/space_heater/Destroy()
-	if(cell)
-		qdel(cell)
-		cell = null
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/machinery/space_heater/update_icon()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -41,8 +41,7 @@
 	..()
 
 /obj/machinery/syndicatebomb/Destroy()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/machinery/syndicatebomb/examine(mob/user)
@@ -102,7 +101,7 @@
 			to_chat(user, "<span class='notice'>[payload] is already loaded into [src], you'll have to remove it first.</span>")
 	else
 		..()
-		
+
 /obj/machinery/syndicatebomb/attack_ghost(mob/user)
 	interact(user)
 
@@ -122,7 +121,7 @@
 				return
 		else if(anchored)
 			to_chat(user, "<span class='notice'>The bomb is bolted to the floor!</span>")
-			
+
 /obj/machinery/syndicatebomb/proc/can_interact(mob/user)
 	if(user.can_advanced_admin_interact())
 		return TRUE

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -146,11 +146,8 @@
 			product_records.Add(product)
 
 /obj/machinery/vending/Destroy()
-	qdel(wires) // qdel
-	wires = null
-	if(coin)
-		qdel(coin) // qdel
-		coin = null
+	QDEL_NULL(wires)
+	QDEL_NULL(coin)
 	return ..()
 
 /obj/machinery/vending/ex_act(severity)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -629,8 +629,7 @@
 	else
 		qdel(cabin_air)
 	cabin_air = null
-	qdel(spark_system)
-	spark_system = null
+	QDEL_NULL(spark_system)
 
 	mechas_list -= src //global mech list
 	return ..()

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -36,9 +36,7 @@
 	to_chat(user, "This is a [generation]\th generation [name]!")
 
 /obj/structure/glowshroom/Destroy()
-	if(myseed)
-		qdel(myseed)
-		myseed = null
+	QDEL_NULL(myseed)
 	return ..()
 
 /obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats)

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -19,9 +19,7 @@
 	ID.access = get_region_accesses(region_access)
 
 /obj/item/weapon/door_remote/Destroy()
-	if(ID)
-		qdel(ID)
-		ID = null
+	QDEL_NULL(ID)
 	return ..()
 
 /obj/item/weapon/door_remote/attack_self(mob/user)

--- a/code/game/objects/items/devices/guitar.dm
+++ b/code/game/objects/items/devices/guitar.dm
@@ -17,8 +17,7 @@
 	song.instrumentExt = "ogg"
 
 /obj/item/device/guitar/Destroy()
-	qdel(song)
-	song = null
+	QDEL_NULL(song)
 	return ..()
 
 /obj/item/device/guitar/attack_self(mob/user as mob)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -35,9 +35,7 @@
 		pointer_icon_state = pick("red_laser","green_laser","blue_laser","purple_laser")
 
 /obj/item/device/laser_pointer/Destroy()
-	if(diode)
-		qdel(diode)
-		diode = null
+	QDEL_NULL(diode)
 	return ..()
 
 /obj/item/device/laser_pointer/upgraded/New()

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -12,7 +12,7 @@
 	var/looking_for_personality = 0
 	var/mob/living/silicon/pai/pai
 	var/list/faction = list("neutral") // The factions the pAI will inherit from the card
-	
+
 /obj/item/device/paicard/syndicate
 	name = "syndicate personal AI device"
 	faction = list("syndicate")
@@ -33,9 +33,7 @@
 		pai.ghostize()
 		qdel(pai)
 		pai = null
-	if(radio)
-		qdel(radio)
-		radio = null
+	QDEL_NULL(radio)
 	return ..()
 
 /obj/item/device/paicard/attack_self(mob/user)

--- a/code/game/objects/items/devices/sensor_device.dm
+++ b/code/game/objects/items/devices/sensor_device.dm
@@ -12,8 +12,7 @@
 	crew_monitor = new(src)
 
 /obj/item/device/sensor_device/Destroy()
-	qdel(crew_monitor)
-	crew_monitor = null
+	QDEL_NULL(crew_monitor)
 	return ..()
 
 /obj/item/device/sensor_device/attack_self(mob/user as mob)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -21,9 +21,7 @@
 	update_icon()
 
 /obj/item/device/taperecorder/Destroy()
-	if(mytape)
-		qdel(mytape)
-		mytape = null
+	QDEL_NULL(mytape)
 	return ..()
 
 /obj/item/device/taperecorder/examine(mob/user)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -13,15 +13,9 @@
 	origin_tech = "materials=1;engineering=1"
 
 /obj/item/device/transfer_valve/Destroy()
-	if(tank_one)
-		qdel(tank_one)
-		tank_one = null
-	if(tank_two)
-		qdel(tank_two)
-		tank_two = null
-	if(attached_device)
-		qdel(attached_device)
-		attached_device = null
+	QDEL_NULL(tank_one)
+	QDEL_NULL(tank_two)
+	QDEL_NULL(attached_device)
 	attacher = null
 	return ..()
 

--- a/code/game/objects/items/devices/violin.dm
+++ b/code/game/objects/items/devices/violin.dm
@@ -18,8 +18,7 @@
 	song.instrumentExt = "ogg"
 
 /obj/item/device/violin/Destroy()
-	qdel(song)
-	song = null
+	QDEL_NULL(song)
 	return ..()
 
 /obj/item/device/violin/initialize()

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -12,9 +12,7 @@
 	var/datum/gas_mixture/air_contents = null
 
 /obj/item/latexballon/Destroy()
-	if(air_contents)
-		qdel(air_contents)
-		air_contents = null
+	QDEL_NULL(air_contents)
 	return ..()
 
 /obj/item/latexballon/proc/blow(obj/item/weapon/tank/tank, mob/user)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -59,8 +59,7 @@ RCD
 	return
 
 /obj/item/weapon/rcd/Destroy()
-	qdel(spark_system)
-	spark_system = null
+	QDEL_NULL(spark_system)
 	rcd_list -= src
 	return ..()
 

--- a/code/game/objects/items/weapons/RCL.dm
+++ b/code/game/objects/items/weapons/RCL.dm
@@ -62,9 +62,7 @@
 		to_chat(user, "<span class='info'>It contains [loaded.amount]/[max_amount] cables.</span>")
 
 /obj/item/weapon/twohanded/rcl/Destroy()
-	if(loaded)
-		qdel(loaded)
-		loaded = null
+	QDEL_NULL(loaded)
 	last = null
 	active = 0
 	return ..()

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -46,9 +46,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	reagents.set_reacting(FALSE) // so it doesn't react until you light it
 
 /obj/item/clothing/mask/cigarette/Destroy()
-	if(reagents)
-		qdel(reagents)
-		reagents = null
+	QDEL_NULL(reagents)
 	processing_objects -= src
 	return ..()
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -172,12 +172,8 @@
 	if(on)
 		var/M = get(paddles, /mob)
 		remove_paddles(M)
-	if(paddles)
-		qdel(paddles)
-		paddles = null
-	if(bcell)
-		qdel(bcell)
-		bcell = null
+	QDEL_NULL(paddles)
+	QDEL_NULL(bcell)
 	return ..()
 
 /obj/item/weapon/defibrillator/proc/deductcharge(var/chrgdeductamt)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -18,9 +18,7 @@
 	..()
 
 /obj/item/weapon/grenade/plastic/Destroy()
-	if(nadeassembly)
-		qdel(nadeassembly)
-		nadeassembly = null
+	QDEL_NULL(nadeassembly)
 	target = null
 	return ..()
 

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -25,15 +25,9 @@
 
 
 /obj/item/weapon/flamethrower/Destroy()
-	if(weldtool)
-		qdel(weldtool)
-		weldtool = null
-	if(igniter)
-		qdel(igniter)
-		igniter = null
-	if(ptank)
-		qdel(ptank)
-		ptank = null
+	QDEL_NULL(weldtool)
+	QDEL_NULL(igniter)
+	QDEL_NULL(ptank)
 	previousturf = null
 	return ..()
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -27,9 +27,7 @@
 	update_icon()
 
 /obj/item/weapon/grenade/chem_grenade/Destroy()
-	if(nadeassembly)
-		qdel(nadeassembly)
-		nadeassembly = null
+	QDEL_NULL(nadeassembly)
 	for(var/thing in beakers)
 		qdel(thing)
 	beakers.Cut()

--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -27,12 +27,8 @@
 	icon_state = "[initial(icon_state)][armed]"
 
 /obj/item/weapon/restraints/legcuffs/beartrap/Destroy()
-	if(IED)
-		qdel(IED)
-		IED = null
-	if(sig)
-		qdel(sig)
-		sig = null
+	QDEL_NULL(IED)
+	QDEL_NULL(sig)
 	return ..()
 
 /obj/item/weapon/restraints/legcuffs/beartrap/suicide_act(mob/user)

--- a/code/game/objects/items/weapons/pneumaticCannon.dm
+++ b/code/game/objects/items/weapons/pneumaticCannon.dm
@@ -17,9 +17,7 @@
 	var/pressureSetting = 1 //How powerful the cannon is - higher pressure = more gas but more powerful throws
 
 /obj/item/weapon/pneumatic_cannon/Destroy()
-	if(tank)
-		qdel(tank)
-		tank = null
+	QDEL_NULL(tank)
 	for(var/obj/item/I in loadedItems)
 		qdel(I)
 	loadedItems.Cut()

--- a/code/game/objects/items/weapons/powerfist.dm
+++ b/code/game/objects/items/weapons/powerfist.dm
@@ -17,9 +17,7 @@
 
 
 /obj/item/weapon/melee/powerfist/Destroy()
-	if(tank)
-		qdel(tank)
-		tank = null
+	QDEL_NULL(tank)
 	return ..()
 
 /obj/item/weapon/melee/powerfist/examine(mob/user)

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -186,7 +186,7 @@
 
 
 /obj/item/weapon/storage/fancy/cigarettes/Destroy()
-	qdel(reagents)
+	QDEL_NULL(reagents)
 	return ..()
 
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -454,8 +454,8 @@
 	for(var/obj/O in contents)
 		O.mouse_opacity = initial(O.mouse_opacity)
 
-	qdel(boxes)
-	qdel(closer)
+	QDEL_NULL(boxes)
+	QDEL_NULL(closer)
 	return ..()
 
 /obj/item/weapon/storage/emp_act(severity)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -24,9 +24,7 @@
 	return
 
 /obj/item/weapon/melee/baton/Destroy()
-	if(bcell)
-		qdel(bcell)
-		bcell = null
+	QDEL_NULL(bcell)
 	return ..()
 
 /obj/item/weapon/melee/baton/loaded/New() //this one starts with a cell pre-installed.
@@ -208,9 +206,7 @@
 	sparkler = new(src)
 
 /obj/item/weapon/melee/baton/cattleprod/Destroy()
-	if(sparkler)
-		qdel(sparkler)
-		sparkler = null
+	QDEL_NULL(sparkler)
 	return ..()
 
 /obj/item/weapon/melee/baton/cattleprod/baton_stun()

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -19,8 +19,7 @@
 	ion_trail.set_up(src)
 
 /obj/item/weapon/tank/jetpack/Destroy()
-	qdel(ion_trail)
-	ion_trail = null
+	QDEL_NULL(ion_trail)
 	return ..()
 
 /obj/item/weapon/tank/jetpack/ui_action_click(mob/user, actiontype)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -33,9 +33,7 @@
 	return
 
 /obj/item/weapon/tank/Destroy()
-	if(air_contents)
-		qdel(air_contents)
-		air_contents = null
+	QDEL_NULL(air_contents)
 
 	processing_objects.Remove(src)
 

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -20,9 +20,7 @@
 	var/obj/item/weapon/canvas/painting = null
 
 /obj/structure/easel/Destroy()
-	if(painting)
-		qdel(painting)
-		painting = null
+	QDEL_NULL(painting)
 	return ..()
 
 //Adding canvases

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -23,12 +23,8 @@ var/global/list/captain_display_cases = list()
 	var/state = DISPLAYCASE_FRAME_CIRCUIT
 
 /obj/structure/displaycase_frame/Destroy()
-	if(circuit)
-		qdel(circuit)
-		circuit = null
-	if(sensor)
-		qdel(sensor)
-		sensor = null
+	QDEL_NULL(circuit)
+	QDEL_NULL(sensor)
 	return ..()
 
 /obj/structure/displaycase_frame/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
@@ -125,8 +121,7 @@ var/global/list/captain_display_cases = list()
 
 /obj/structure/displaycase/Destroy()
 	dump()
-	qdel(circuit)
-	circuit = null
+	QDEL_NULL(circuit)
 	return ..()
 
 /obj/structure/displaycase/captains_laser/Destroy()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -18,9 +18,7 @@
 	update_state()
 
 /obj/structure/door_assembly/Destroy()
-	if(electronics)
-		qdel(electronics)
-		electronics = null
+	QDEL_NULL(electronics)
 	return ..()
 
 /obj/structure/door_assembly/door_assembly_com

--- a/code/game/objects/structures/engicart.dm
+++ b/code/game/objects/structures/engicart.dm
@@ -15,30 +15,14 @@
 	var/obj/item/taperoll/engineering/myengitape = null
 
 /obj/structure/engineeringcart/Destroy()
-	if(myglass)
-		qdel(myglass)
-		myglass = null
-	if(mymetal)
-		qdel(mymetal)
-		mymetal = null
-	if(myplasteel)
-		qdel(myplasteel)
-		myplasteel = null
-	if(myflashlight)
-		qdel(myflashlight)
-		myflashlight = null
-	if(mybluetoolbox)
-		qdel(mybluetoolbox)
-		mybluetoolbox = null
-	if(myyellowtoolbox)
-		qdel(myyellowtoolbox)
-		myyellowtoolbox = null
-	if(myredtoolbox)
-		qdel(myredtoolbox)
-		myredtoolbox = null
-	if(myengitape)
-		qdel(myengitape)
-		myengitape = null
+	QDEL_NULL(myglass)
+	QDEL_NULL(mymetal)
+	QDEL_NULL(myplasteel)
+	QDEL_NULL(myflashlight)
+	QDEL_NULL(mybluetoolbox)
+	QDEL_NULL(myyellowtoolbox)
+	QDEL_NULL(myredtoolbox)
+	QDEL_NULL(myengitape)
 	return ..()
 
 /obj/structure/engineeringcart/proc/put_in_cart(obj/item/I, mob/user)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -9,9 +9,7 @@
 	var/opened = 0
 
 /obj/structure/extinguisher_cabinet/Destroy()
-	if(has_extinguisher)
-		qdel(has_extinguisher)
-		has_extinguisher = null
+	QDEL_NULL(has_extinguisher)
 	return ..()
 
 /obj/structure/extinguisher_cabinet/attackby(obj/item/O, mob/user, params)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -25,18 +25,10 @@
 
 /obj/structure/janitorialcart/Destroy()
 	janitorial_equipment -= src
-	if(mybag)
-		qdel(mybag)
-		mybag = null
-	if(mymop)
-		qdel(mymop)
-		mymop = null
-	if(myspray)
-		qdel(myspray)
-		myspray = null
-	if(myreplacer)
-		qdel(myreplacer)
-		myreplacer = null
+	QDEL_NULL(mybag)
+	QDEL_NULL(mymop)
+	QDEL_NULL(myspray)
+	QDEL_NULL(myreplacer)
 	return ..()
 
 /obj/structure/janitorialcart/proc/wet_mop(obj/item/weapon/mop, mob/user)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -160,9 +160,7 @@
 	return
 
 /obj/structure/morgue/Destroy()
-	if(connected)
-		qdel(connected)
-		connected = null
+	QDEL_NULL(connected)
 	return ..()
 
 /obj/structure/morgue/container_resist(var/mob/living/L)
@@ -405,9 +403,7 @@
 	return
 
 /obj/structure/crematorium/Destroy()
-	if(connected)
-		qdel(connected)
-		connected = null
+	QDEL_NULL(connected)
 	return ..()
 
 /obj/structure/crematorium/container_resist(var/mob/living/L)
@@ -471,7 +467,7 @@
 		connected.connected = null
 	connected = null
 	return ..()
-	
+
 // Crematorium switch
 /obj/machinery/crema_switch
 	desc = "Burn baby burn!"
@@ -484,7 +480,7 @@
 	var/area/area = null
 	var/otherarea = null
 	var/id = 1
-	
+
 /obj/machinery/crema_switch/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
 		return attack_hand(user)

--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -281,8 +281,7 @@
 		icon_state = "piano"
 
 /obj/structure/piano/Destroy()
-	qdel(song)
-	song = null
+	QDEL_NULL(song)
 	return ..()
 
 /obj/structure/piano/initialize()

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -9,9 +9,7 @@
 	var/obj/item/target/pinned_target // the current pinned target
 
 /obj/structure/target_stake/Destroy()
-	if(pinned_target)
-		qdel(pinned_target)
-		pinned_target = null
+	QDEL_NULL(pinned_target)
 	return ..()
 
 /obj/structure/target_stake/Move()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -34,9 +34,7 @@ obj/structure/windoor_assembly/New(dir=NORTH)
 
 obj/structure/windoor_assembly/Destroy()
 	density = 0
-	if(electronics)
-		qdel(electronics)
-		electronics = null
+	QDEL_NULL(electronics)
 	air_update_turf(1)
 	return ..()
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -41,9 +41,7 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		builtin_tile = new floor_tile
 
 /turf/simulated/floor/Destroy()
-	if(builtin_tile)
-		qdel(builtin_tile)
-		builtin_tile = null
+	QDEL_NULL(builtin_tile)
 	return ..()
 
 

--- a/code/game/turfs/unsimulated/beach.dm
+++ b/code/game/turfs/unsimulated/beach.dm
@@ -59,8 +59,7 @@
 	water_overlay = new(src)
 
 /turf/unsimulated/beach/water/drop/Destroy()
-	qdel(water_overlay)
-	water_overlay = null
+	QDEL_NULL(water_overlay)
 	return ..()
 
 /obj/effect/effect/beach_drop_overlay

--- a/code/modules/arcade/mob_hunt/battle_computer.dm
+++ b/code/modules/arcade/mob_hunt/battle_computer.dm
@@ -51,8 +51,7 @@
 			mob_hunt_server.red_terminal = null
 		if(mob_hunt_server.blue_terminal == src)
 			mob_hunt_server.blue_terminal = null
-	if(avatar)
-		qdel(avatar)
+	QDEL_NULL(avatar)
 	return ..()
 
 /obj/machinery/computer/mob_battle_terminal/attackby(obj/item/O, mob/user)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -12,8 +12,7 @@
 	sparks.attach(src)
 
 /obj/item/device/assembly/igniter/Destroy()
-	qdel(sparks)
-	sparks = null
+	QDEL_NULL(sparks)
 	return ..()
 
 

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -255,9 +255,7 @@
 /obj/effect/beam/i_beam/Destroy()
 	if(master.first == src)
 		master.first = null
-	if(next)
-		qdel(next)
-		next = null
+	QDEL_NULL(next)
 	if(previous)
 		previous.next = null
 		master.last = previous

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -10,10 +10,8 @@
 	flags = CONDUCT
 
 /obj/item/assembly/shock_kit/Destroy()
-	qdel(part1)
-	part1 = null
-	qdel(part2)
-	part2 = null
+	QDEL_NULL(part1)
+	QDEL_NULL(part2)
 	return ..()
 
 /obj/item/assembly/shock_kit/attackby(obj/item/weapon/W as obj, mob/user as mob, params)

--- a/code/modules/awaymissions/mission_code/beach.dm
+++ b/code/modules/awaymissions/mission_code/beach.dm
@@ -18,6 +18,7 @@
 	if(water_timer)
 		deltimer(water_timer)
 	water_timer = null
+	return ..()
 
 /obj/effect/waterfall/proc/drip()
 	var/obj/effect/effect/water/W = new(loc)

--- a/code/modules/awaymissions/mission_code/spacehotel.dm
+++ b/code/modules/awaymissions/mission_code/spacehotel.dm
@@ -116,8 +116,7 @@
 	if(roomtimer)
 		deltimer(roomtimer)
 		roomtimer = null
-	qdel(card)
-	card = null
+	QDEL_NULL(card)
 	return ..()
 
 /obj/machinery/door/unpowered/hotel_door/examine(mob/user)
@@ -220,9 +219,7 @@
 	vacant_rooms.Cut()
 	guests.Cut()
 
-	if(radio)
-		qdel(radio)
-		radio = null
+	QDEL_NULL(radio)
 
 	return ..()
 

--- a/code/modules/awaymissions/zvis.dm
+++ b/code/modules/awaymissions/zvis.dm
@@ -111,8 +111,7 @@
 		init(R)
 
 /turf/unsimulated/floor/upperlevel/Destroy()
-	qdel(sensor)
-	sensor = null
+	QDEL_NULL(sensor)
 	return ..()
 
 /turf/unsimulated/floor/upperlevel/proc/init(var/obj/effect/levelref/R)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -70,9 +70,7 @@
 	update_icon()
 
 /obj/item/clothing/gloves/color/yellow/stun/Destroy()
-	if(cell)
-		qdel(cell)
-		cell = null
+	QDEL_NULL(cell)
 	return ..()
 
 /obj/item/clothing/gloves/color/yellow/stun/Touch(atom/A, proximity)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -165,10 +165,8 @@
 			M.unEquip(piece)
 		qdel(piece)
 	processing_objects -= src
-	qdel(wires)
-	wires = null
-	qdel(spark_system)
-	spark_system = null
+	QDEL_NULL(wires)
+	QDEL_NULL(spark_system)
 	return ..()
 
 /obj/item/weapon/rig/proc/suit_is_deployed()

--- a/code/modules/clothing/suits/hood.dm
+++ b/code/modules/clothing/suits/hood.dm
@@ -10,9 +10,7 @@
 	..()
 
 /obj/item/clothing/suit/hooded/Destroy()
-	if(hood)
-		qdel(hood)
-		hood = null
+	QDEL_NULL(hood)
 	return ..()
 
 /obj/item/clothing/suit/hooded/proc/MakeHood()

--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -9,8 +9,7 @@
 	pockets.max_combined_w_class = 4
 
 /obj/item/clothing/suit/storage/Destroy()
-	qdel(pockets)
-	pockets = null
+	QDEL_NULL(pockets)
 	return ..()
 
 /obj/item/clothing/suit/storage/attack_hand(mob/user as mob)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -386,9 +386,7 @@
 	var/obj/item/weapon/card/id/access_id
 
 /obj/item/clothing/accessory/petcollar/Destroy()
-	if(access_id)
-		qdel(access_id)
-		access_id = null
+	QDEL_NULL(access_id)
 	processing_objects -= src
 	return ..()
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -50,8 +50,7 @@
 		wires = new/datum/wires/smartfridge(src)
 
 /obj/machinery/smartfridge/Destroy()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	for(var/atom/movable/A in contents)
 		A.forceMove(loc)
 	return ..()

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -31,12 +31,8 @@
 	RefreshParts()
 
 /obj/machinery/biogenerator/Destroy()
-	if(beaker)
-		qdel(beaker)
-		beaker = null
-	if(files)
-		qdel(files)
-		files = null
+	QDEL_NULL(beaker)
+	QDEL_NULL(files)
 	return ..()
 
 /obj/machinery/biogenerator/ex_act(severity)

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -36,12 +36,8 @@
 	reagent_genes.Cut()
 	trait_genes.Cut()
 	target = null
-	if(seed)
-		qdel(seed)
-		seed = null
-	if(disk)
-		qdel(disk)
-		disk = null
+	QDEL_NULL(seed)
+	QDEL_NULL(disk)
 	return ..()
 
 /obj/machinery/plantgenes/RefreshParts()
@@ -384,9 +380,7 @@
 	pixel_y = rand(-5, 5)
 
 /obj/item/weapon/disk/plantgene/Destroy()
-	if(gene)
-		qdel(gene)
-		gene = null
+	QDEL_NULL(gene)
 	return ..()
 
 /obj/item/weapon/disk/plantgene/attackby(obj/item/weapon/W, mob/user, params)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -40,9 +40,7 @@
 		add_juice()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/Destroy()
-	if(seed)
-		qdel(seed)
-		seed = null
+	QDEL_NULL(seed)
 	return ..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/proc/add_juice()

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -32,9 +32,7 @@
 		add_juice()
 
 /obj/item/weapon/grown/Destroy()
-	if(seed)
-		qdel(seed)
-		seed = null
+	QDEL_NULL(seed)
 	return ..()
 
 /obj/item/weapon/grown/attackby(obj/item/O, mob/user, params)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -75,9 +75,7 @@
 	plant_hud_set_water()
 
 /obj/machinery/hydroponics/Destroy()
-	if(myseed)
-		qdel(myseed)
-		myseed = null
+	QDEL_NULL(myseed)
 	return ..()
 
 /obj/machinery/hydroponics/constructable/attackby(obj/item/I, mob/user, params)

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -33,7 +33,7 @@
 	if(bag)
 		bag.loc = user
 		bag.attackby(W, user, params)
-		
+
 /obj/item/device/shared_storage/attack_self(mob/living/carbon/user)
 	if(!iscarbon(user))
 		return
@@ -116,7 +116,7 @@
 		H.adjustBruteLoss(20)
 		H.emote("scream")
 	..()*/
-	
+
 //Boat
 
 /obj/vehicle/lavaboat
@@ -183,7 +183,7 @@
 	generic_pixel_y = 2
 	generic_pixel_x = 1
 	vehicle_move_delay = 1
-	
+
 // Wisp Lantern
 /obj/item/device/wisp_lantern
 	name = "spooky lantern"
@@ -238,16 +238,16 @@
 	layer = ABOVE_ALL_MOB_LAYER
 	light_power = 1
 	light_range = 7
-	
+
 //Red/Blue Cubes
-	
+
 /obj/item/device/warp_cube
 	name = "blue cube"
 	desc = "A mysterious blue cube."
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "blue_cube"
 	var/obj/item/device/warp_cube/linked
-	
+
 /obj/item/device/warp_cube/Destroy()
 	if(linked)
 		linked.linked = null
@@ -260,14 +260,14 @@
 		return
 
 	var/datum/effect/system/harmless_smoke_spread/smoke = new /datum/effect/system/harmless_smoke_spread()
-	smoke.set_up(1, 0, user.loc) 
+	smoke.set_up(1, 0, user.loc)
 	smoke.start()
 
 	user.forceMove(get_turf(linked))
 	feedback_add_details("warp_cube","[src.type]")
 
 	var/datum/effect/system/harmless_smoke_spread/smoke2 = new /datum/effect/system/harmless_smoke_spread()
-	smoke2.set_up(1, 0, user.loc) 
+	smoke2.set_up(1, 0, user.loc)
 	smoke2.start()
 
 /obj/item/device/warp_cube/red
@@ -281,7 +281,7 @@
 		var/obj/item/device/warp_cube/blue = new(src.loc)
 		linked = blue
 		blue.linked = src
-		
+
 //Meat Hook
 
 /obj/item/weapon/gun/magic/hook
@@ -329,9 +329,9 @@
 			L.forceMove(get_turf(firer))
 
 /obj/item/projectile/hook/Destroy()
-	qdel(chain)
+	QDEL_NULL(chain)
 	return ..()
-	
+
 //Immortality Talisman
 
 /obj/item/device/immortality_talisman

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -226,6 +226,7 @@
 
 /obj/item/device/mobcapsule/Destroy()
 	if(captured)
+		captured.ghostize()
 		qdel(captured)
 		captured = null
 	return ..()

--- a/code/modules/mining/ore.dm
+++ b/code/modules/mining/ore.dm
@@ -62,7 +62,7 @@
 	points = 1
 	refined_type = /obj/item/stack/sheet/glass
 	materials = list(MAT_GLASS=MINERAL_MATERIAL_AMOUNT)
-	
+
 /obj/item/weapon/ore/glass/basalt
 	name = "volcanic ash"
 	icon_state = "volcanic_sand"
@@ -163,8 +163,7 @@
 	var/datum/wires/explosive/gibtonite/wires
 
 /obj/item/weapon/twohanded/required/gibtonite/Destroy()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/item/weapon/twohanded/required/gibtonite/attackby(obj/item/I, mob/user, params)
@@ -192,7 +191,7 @@
 			quality = 1
 			return
 	..()
-	
+
 /obj/item/weapon/twohanded/required/gibtonite/attack_ghost(mob/user)
 	if(wires)
 		wires.Interact(user)

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -167,12 +167,8 @@
 	if(isrobot(loc))
 		var/mob/living/silicon/robot/borg = loc
 		borg.mmi = null
-	if(brainmob)
-		qdel(brainmob)
-		brainmob = null
-	if(held_brain)
-		qdel(held_brain)
-		held_brain = null
+	QDEL_NULL(brainmob)
+	QDEL_NULL(held_brain)
 	return ..()
 
 /obj/item/device/mmi/syndie

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -123,7 +123,5 @@
 	icon_state = "scroll"
 
 /obj/item/organ/internal/brain/Destroy() //copypasted from MMIs.
-	if(brainmob)
-		qdel(brainmob)
-		brainmob = null
+	QDEL_NULL(brainmob)
 	return ..()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -246,7 +246,7 @@ var/list/ai_verbs_default = list(
 	ai_list -= src
 	shuttle_caller_list -= src
 	shuttle_master.autoEvac()
-	qdel(eyeobj) // No AI, no Eye
+	QDEL_NULL(eyeobj) // No AI, no Eye
 	malfhack = null
 	return ..()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -251,12 +251,10 @@ var/list/robot_verbs_default = list(
 		mmi = null
 	if(connected_ai)
 		connected_ai.connected_robots -= src
-	qdel(wires)
-	wires = null
-	qdel(module)
-	module = null
-	camera = null
-	cell = null
+	QDEL_NULL(wires)
+	QDEL_NULL(module)
+	QDEL_NULL(camera)
+	QDEL_NULL(cell)
 	return ..()
 
 /mob/living/silicon/robot/proc/pick_module()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -35,8 +35,7 @@
 	for(var/module in modules)
 		qdel(module)
 	modules.Cut()
-	qdel(emag)
-	emag = null
+	QDEL_NULL(emag)
 	return ..()
 
 /obj/item/weapon/robot_module/proc/fix_modules()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -169,14 +169,11 @@
 /mob/living/simple_animal/bot/Destroy()
 	if(paicard)
 		ejectpai()
-	qdel(Radio)
-	Radio = null
-	qdel(access_card)
-	access_card = null
+	QDEL_NULL(Radio)
+	QDEL_NULL(access_card)
 	if(radio_controller && bot_filter)
 		radio_controller.remove_object(bot_core, control_freq)
-	qdel(bot_core)
-	bot_core = null
+	QDEL_NULL(bot_core)
 	return ..()
 
 /mob/living/simple_animal/bot/death(gibbed)
@@ -263,7 +260,7 @@
 		interact(H)
 	else
 		return ..()
-		
+
 /mob/living/simple_animal/bot/attack_ghost(mob/M)
 	interact(M)
 

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -65,12 +65,8 @@
 
 /mob/living/simple_animal/bot/mulebot/Destroy()
 	unload(0)
-	if(wires)
-		qdel(wires)
-		wires = null
-	if(cell)
-		qdel(cell)
-		cell = null
+	QDEL_NULL(wires)
+	QDEL_NULL(cell)
 	return ..()
 
 /mob/living/simple_animal/bot/mulebot/proc/set_suffix(suffix)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -295,8 +295,7 @@
 	queen = new(src)
 
 /obj/item/queen_bee/Destroy()
-	qdel(queen)
-	queen = null
+	QDEL_NULL(queen)
 	return ..()
 
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -108,7 +108,7 @@ Difficulty: Hard
 		..()
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/Destroy()
-	qdel(spawned_rune)
+	QDEL_NULL(spawned_rune)
 	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/devour(mob/living/L)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -43,7 +43,7 @@
 	mouse_opacity = 2 // Easier to click on in melee, they're giant targets anyway
 
 /mob/living/simple_animal/hostile/megafauna/Destroy()
-	qdel(internal_gps)
+	QDEL_NULL(internal_gps)
 	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/death(gibbed)
@@ -77,7 +77,7 @@
 				OpenFire()
 		else
 			devour(L)
-			
+
 /mob/living/simple_animal/hostile/megafauna/onShuttleMove()
 	var/turf/oldloc = loc
 	. = ..()

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -444,8 +444,7 @@
 		if(assailant.client)
 			assailant.client.screen -= hud
 		assailant = null
-	qdel(hud)
-	hud = null
+	QDEL_NULL(hud)
 	return ..()
 
 

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -41,9 +41,7 @@ var/list/global_modular_computers = list()
 	global_modular_computers.Add(src)
 
 /obj/machinery/modular_computer/Destroy()
-	if(cpu)
-		qdel(cpu)
-		cpu = null
+	QDEL_NULL(cpu)
 	return ..()
 
 /obj/machinery/modular_computer/attack_ghost(mob/dead/observer/user)

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
@@ -18,8 +18,7 @@
 /datum/computer_file/program/alarm_monitor/Destroy()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
 		AH.unregister(src)
-	qdel(alarm_handlers)
-	alarm_handlers = null
+	QDEL_NULL(alarm_handlers)
 	return ..()
 
 /datum/computer_file/program/alarm_monitor/proc/update_icon()

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -11,9 +11,7 @@
 	var/locked = FALSE
 
 /obj/item/weapon/computer_hardware/ai_slot/Destroy()
-	if(stored_card)
-		qdel(stored_card)
-		stored_card = null
+	QDEL_NULL(stored_card)
 	return ..()
 
 

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -14,9 +14,7 @@
 	..()
 
 /obj/item/weapon/computer_hardware/battery/Destroy()
-	if(battery)
-		qdel(battery)
-		battery = null
+	QDEL_NULL(battery)
 	return ..()
 
 /obj/item/weapon/computer_hardware/battery/on_remove(obj/item/device/modular_computer/M, mob/living/user = null)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -11,12 +11,8 @@
 	var/obj/item/weapon/card/id/stored_card2 = null
 
 /obj/item/weapon/computer_hardware/card_slot/Destroy()
-	if(stored_card)
-		qdel(stored_card)
-		stored_card = null
-	if(stored_card2)
-		qdel(stored_card2)
-		stored_card2 = null
+	QDEL_NULL(stored_card)
+	QDEL_NULL(stored_card2)
 	return ..()
 
 /obj/item/weapon/computer_hardware/card_slot/GetAccess()

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -74,6 +74,5 @@
 	spark_system.attach(src)
 
 /obj/item/weapon/katana/energy/Destroy()
-	qdel(spark_system)
-	spark_system = null
+	QDEL_NULL(spark_system)
 	return ..()

--- a/code/modules/paperwork/frames.dm
+++ b/code/modules/paperwork/frames.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 
 	usesound = 'sound/items/Deconstruct.ogg'
-	
+
 	var/icon_base
 	var/obj/displayed
 
@@ -198,9 +198,7 @@
 		verbs |= /obj/structure/sign/picture_frame/proc/tilt
 
 /obj/structure/sign/picture_frame/Destroy()
-	if(frame)
-		qdel(frame)
-		frame = null
+	QDEL_NULL(frame)
 	return ..()
 
 /obj/structure/sign/picture_frame/update_icon()

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -440,7 +440,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		scanmode.scan_atom(A, user)
 
 /obj/item/device/pda/proc/explode() //This needs tuning.
-	if(!detonate) 
+	if(!detonate)
 		return
 	var/turf/T = get_turf(src.loc)
 
@@ -467,9 +467,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	for(var/A in programs)
 		qdel(A)
 	programs.Cut()
-	if(cartridge)
-		qdel(cartridge)
-		cartridge = null
+	QDEL_NULL(cartridge)
 	return ..()
 
 // Pass along the pulse to atoms in contents, largely added so pAIs are vulnerable to EMP

--- a/code/modules/pda/cart.dm
+++ b/code/modules/pda/cart.dm
@@ -24,9 +24,7 @@
 	..()
 
 /obj/item/weapon/cartridge/Destroy()
-	if(radio)
-		qdel(radio)
-		radio = null
+	QDEL_NULL(radio)
 	for(var/A in programs)
 		qdel(A)
 	programs.Cut()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -178,11 +178,8 @@
 	area.power_change()
 	if(occupier)
 		malfvacate(1)
-	qdel(wires)
-	wires = null
-	if(cell)
-		qdel(cell) // qdel
-		cell = null
+	QDEL_NULL(wires)
+	QDEL_NULL(cell)
 	if(terminal)
 		disconnect_terminal()
 	area.apc -= src

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -52,8 +52,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 
 /obj/machinery/gravity_generator/part/Destroy()
 	set_broken()
-	if(main_part)
-		qdel(main_part)
+	QDEL_NULL(main_part)
 	return ..()
 
 //

--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -30,8 +30,7 @@
 /obj/machinery/particle_accelerator/control_box/Destroy()
 	if(active)
 		toggle_power()
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/machinery/particle_accelerator/control_box/attack_ghost(user as mob)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -72,9 +72,7 @@
 
 /obj/machinery/power/supermatter_shard/Destroy()
 	investigate_log("has been destroyed.", "supermatter")
-	if(radio)
-		qdel(radio)
-		radio = null
+	QDEL_NULL(radio)
 	poi_list.Remove(src)
 	return ..()
 

--- a/code/modules/projectiles/guns/throw.dm
+++ b/code/modules/projectiles/guns/throw.dm
@@ -36,8 +36,7 @@
 	notify_ammo_count(user)
 
 /obj/item/weapon/gun/throw/Destroy()
-	qdel(to_launch)
-	to_launch = null
+	QDEL_NULL(to_launch)
 	for(var/atom/A in loaded_projectiles)
 		qdel(A)
 	loaded_projectiles = null

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -93,9 +93,7 @@
 	return
 
 /obj/machinery/reagentgrinder/Destroy()
-	if(beaker)
-		qdel(beaker)
-		beaker = null
+	QDEL_NULL(beaker)
 	return ..()
 
 /obj/machinery/reagentgrinder/ex_act(severity)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -78,9 +78,7 @@
 	var/accepts_rig = 1
 
 /obj/structure/reagent_dispensers/fueltank/Destroy()
-	if(rig)
-		qdel(rig)
-		rig = null
+	QDEL_NULL(rig)
 	return ..()
 
 /obj/structure/reagent_dispensers/fueltank/bullet_act(obj/item/projectile/P)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -429,7 +429,5 @@
 		desc += " The package is not sealed."
 
 /obj/item/shippingPackage/Destroy()
-	if(wrapped)
-		qdel(wrapped)
-		wrapped = null
+	QDEL_NULL(wrapped)
 	return ..()

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -62,8 +62,7 @@ Note: Must be placed west/left of and R&D console to function.
 	reagents.my_atom = src
 
 /obj/machinery/r_n_d/protolathe/Destroy()
-	qdel(materials)
-	materials = null
+	QDEL_NULL(materials)
 	return ..()
 
 /obj/machinery/r_n_d/protolathe/RefreshParts()

--- a/code/modules/spacepods/construction.dm
+++ b/code/modules/spacepods/construction.dm
@@ -20,9 +20,7 @@
 	dir = EAST
 
 /obj/structure/spacepod_frame/Destroy()
-	if(construct)
-		qdel(construct)
-		construct = null
+	QDEL_NULL(construct)
 	return ..()
 
 /obj/structure/spacepod_frame/attackby(obj/item/W as obj, mob/user as mob, params)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -124,22 +124,14 @@
 /obj/spacepod/Destroy()
 	if(equipment_system.cargo_system)
 		equipment_system.cargo_system.removed(null)
-	qdel(equipment_system)
-	equipment_system = null
-	qdel(cargo_hold)
-	cargo_hold = null
-	qdel(battery)
-	battery = null
-	qdel(cabin_air)
-	cabin_air = null
-	qdel(internal_tank)
-	internal_tank = null
-	qdel(pr_int_temp_processor)
-	pr_int_temp_processor = null
-	qdel(pr_give_air)
-	pr_give_air = null
-	qdel(ion_trail)
-	ion_trail = null
+	QDEL_NULL(equipment_system)
+	QDEL_NULL(cargo_hold)
+	QDEL_NULL(battery)
+	QDEL_NULL(cabin_air)
+	QDEL_NULL(internal_tank)
+	QDEL_NULL(pr_int_temp_processor)
+	QDEL_NULL(pr_give_air)
+	QDEL_NULL(ion_trail)
 	occupant_sanity_check()
 	if(pilot)
 		pilot.forceMove(get_turf(src))

--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -150,8 +150,7 @@
 	var/obj/item/device/mmi/stored_mmi
 
 /obj/item/organ/internal/brain/mmi_holder/Destroy()
-	if(stored_mmi)
-		qdel(stored_mmi)
+	QDEL_NULL(stored_mmi)
 	return ..()
 
 /obj/item/organ/internal/brain/mmi_holder/insert(var/mob/living/target,special = 0)

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -140,9 +140,7 @@
 	to_chat(user, "There are [round(rcell.charge/chargecost)] charge\s left.")
 
 /obj/item/weapon/rcs/Destroy()
-	if(rcell)
-		qdel(rcell)
-		rcell = null
+	QDEL_NULL(rcell)
 	return ..()
 
 /obj/item/weapon/rcs/attack_self(mob/user)


### PR DESCRIPTION
Refactors most `Destroy`'s to use `QDEL_NULL` instead of:
```
if(thing)
	qdel(thing)
	thing = null
```

There's still a couple around, particularly if there's more than just qdel and null needed (ie: when something is ghostized or it's being unlinked from interlocking systems).

There's a few minor fixes here and there (things being nulled out instead of deleted, lack of returns for a `Destroy`, and failure to `ghostize` before deleting a mob), but, for hte most part, it's just properly using `QDEL_NULL`