### PR TITLE
Lethal Kitchen

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -115,30 +115,34 @@
 	if(!checkValid(I, user))
 		if(istype(I, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = I
-			if(!iscarbon(G.affecting))
+			if(istype(G.affecting, /mob/living/carbon/human) && !istype(G.affecting, /mob/living/carbon/human/machine))
+//				if(!iscarbon(G.affecting))
+//					to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+//					return
+//				if(G.affecting.stat == DEAD)
+//					to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
+//					return
+				if(G.state < GRAB_AGGRESSIVE)
+					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+					return
+				var/mob/living/carbon/human/C = G.affecting
+				var/obj/item/organ/external/head/head = C.get_organ("head")
+				if(!head)
+					to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
+					return
+				if(istype(src, /obj/machinery/cooker/deepfryer))
+					C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
+									"<span class='userdanger'>[user] dunks your face into [src]!</span>")
+					if(!C.stat)
+						C.emote("scream")
+					user.changeNext_move(CLICK_CD_MELEE)
+					C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
+					head.disfigure("burn")
+					add_logs(G.assailant, G.affecting, "deep-fried face")
+					qdel(I) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
+				return
+			else
 				to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
-				return
-//			if(G.affecting.stat == DEAD)
-//				to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
-//				return
-			if(G.state < GRAB_AGGRESSIVE)
-				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-				return
-			var/mob/living/carbon/human/C = G.affecting
-			var/obj/item/organ/external/head/head = C.get_organ("head")
-			if(!head)
-				to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-				return
-			if(istype(src, /obj/machinery/cooker/deepfryer))
-				C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
-								"<span class='userdanger'>[user] dunks your face into [src]!</span>")
-				if(!C.stat)
-					C.emote("scream")
-				user.changeNext_move(CLICK_CD_MELEE)
-				C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
-				head.disfigure("burn")
-				add_logs(G.assailant, G.affecting, "deep-fried face")
-				qdel(I) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
 		return
 	if(!burns)
 		if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -41,6 +41,8 @@
 		return 0
 	if(istype(check, /obj/item/weapon/reagent_containers/food/snacks))
 		return 1
+	if(istype(check, /obj/item/weapon/grab))
+		return 0
 	to_chat(user, "<span class ='notice'>You can only process food!</span>")
 	return 0
 
@@ -111,6 +113,32 @@
 		to_chat(user, "<span class='warning'>Close the panel first!</span>")
 		return
 	if(!checkValid(I, user))
+		if(istype(I, /obj/item/weapon/grab))
+			var/obj/item/weapon/grab/G = I
+			if(!iscarbon(G.affecting))
+				to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+				return
+//			if(G.affecting.stat == DEAD)
+//				to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
+//				return
+			if(G.state < GRAB_AGGRESSIVE)
+				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+				return
+			var/mob/living/carbon/human/C = G.affecting
+			var/obj/item/organ/external/head/head = C.get_organ("head")
+			if(!head)
+				to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
+				return
+			if(istype(src, /obj/machinery/cooker/deepfryer))
+				C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
+								"<span class='userdanger'>[user] dunks your face into [src]!</span>")
+				if(!C.stat)
+					C.emote("scream")
+				user.changeNext_move(CLICK_CD_MELEE)
+				C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
+				head.disfigure("burn")
+				add_logs(G.assailant, G.affecting, "deep-fried face")
+				qdel(I) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
 		return
 	if(!burns)
 		if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -42,7 +42,7 @@
 	if(istype(check, /obj/item/weapon/reagent_containers/food/snacks))
 		return 1
 	if(istype(check, /obj/item/weapon/grab))
-		return 0
+		return special_attack(check, user)
 	to_chat(user, "<span class ='notice'>You can only process food!</span>")
 	return 0
 
@@ -113,36 +113,6 @@
 		to_chat(user, "<span class='warning'>Close the panel first!</span>")
 		return
 	if(!checkValid(I, user))
-		if(istype(I, /obj/item/weapon/grab))
-			var/obj/item/weapon/grab/G = I
-			if(istype(G.affecting, /mob/living/carbon/human) && (G.affecting.get_species() != "Machine"))
-//				if(!iscarbon(G.affecting))
-//					to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
-//					return
-//				if(G.affecting.stat == DEAD)
-//					to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
-//					return
-				if(G.state < GRAB_AGGRESSIVE)
-					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-					return
-				var/mob/living/carbon/human/C = G.affecting
-				var/obj/item/organ/external/head/head = C.get_organ("head")
-				if(!head)
-					to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-					return
-				if(istype(src, /obj/machinery/cooker/deepfryer))
-					C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
-									"<span class='userdanger'>[user] dunks your face into [src]!</span>")
-					if(!C.stat)
-						C.emote("scream")
-					user.changeNext_move(CLICK_CD_MELEE)
-					C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
-					head.disfigure("burn")
-					add_logs(G.assailant, G.affecting, "deep-fried face")
-					qdel(I) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
-				return
-			else
-				to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
 		return
 	if(!burns)
 		if(istype(I, /obj/item/weapon/reagent_containers/food/snacks))
@@ -175,6 +145,9 @@
 		newfood.cooktype[thiscooktype] = 1
 		turnoff(I)
 		//qdel(I)
+
+/obj/machinery/cooker/proc/special_attack(obj/item/weapon/grab/G, mob/user)
+	return 0
 
 // MAKE SURE TO OVERRIDE THESE ON THE MACHINE IF IT HAS SPECIAL FOOD INTERACTIONS!
 // FAILURE TO OVERRIDE WILL RESULT IN FAILURE TO PROPERLY HANDLE SPECIAL INTERACTIONS!		--FalseIncarnate

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -115,7 +115,7 @@
 	if(!checkValid(I, user))
 		if(istype(I, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = I
-			if(istype(G.affecting, /mob/living/carbon/human) && (G.get_species != "Machine"))
+			if(istype(G.affecting, /mob/living/carbon/human) && (G.affecting.get_species() != "Machine"))
 //				if(!iscarbon(G.affecting))
 //					to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
 //					return

--- a/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/cooker.dm
@@ -115,7 +115,7 @@
 	if(!checkValid(I, user))
 		if(istype(I, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = I
-			if(istype(G.affecting, /mob/living/carbon/human) && !istype(G.affecting, /mob/living/carbon/human/machine))
+			if(istype(G.affecting, /mob/living/carbon/human) && (G.get_species != "Machine"))
 //				if(!iscarbon(G.affecting))
 //					to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
 //					return

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -43,6 +43,37 @@
 	var/obj/item/weapon/reagent_containers/food/snacks/deepfryholder/type = new(get_turf(src))
 	return type
 
+/obj/machinery/cooker/deepfryer/special_attack(obj/item/weapon/grab/G, mob/user)
+	if(istype(G.affecting, /mob/living/carbon/human))
+//				if(!iscarbon(G.affecting))
+//					to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+//					return 0
+//				if(G.affecting.stat == DEAD)
+//					to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
+//					return 0
+		if(G.state < GRAB_AGGRESSIVE)
+			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+			return 0
+		var/mob/living/carbon/human/C = G.affecting
+		var/obj/item/organ/external/head/head = C.get_organ("head")
+		if(!head)
+			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
+			return 0
+		C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
+						"<span class='userdanger'>[user] dunks your face into [src]!</span>")
+		if(!C.stat)
+			C.emote("scream")
+		user.changeNext_move(CLICK_CD_MELEE)
+		if(!(head.status & ORGAN_ROBOT))
+			C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
+			head.disfigure("burn")
+		add_logs(G.assailant, G.affecting, "deep-fried face")
+		qdel(G) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
+	else
+		to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+	return 0
+
+
 /obj/machinery/cooker/deepfryer/checkSpecials(obj/item/I)
 	if(!I)
 		return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -55,7 +55,7 @@
 			return 0
 		C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
 						"<span class='userdanger'>[user] dunks your face into [src]!</span>")
-			C.emote("scream")
+		C.emote("scream")
 		user.changeNext_move(CLICK_CD_MELEE)
 		C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
 		head.disfigure("burn")

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -44,13 +44,7 @@
 	return type
 
 /obj/machinery/cooker/deepfryer/special_attack(obj/item/weapon/grab/G, mob/user)
-	if(istype(G.affecting, /mob/living/carbon/human))
-//				if(!iscarbon(G.affecting))
-//					to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
-//					return 0
-//				if(G.affecting.stat == DEAD)
-//					to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
-//					return 0
+	if(ishuman(G.affecting))
 		if(G.state < GRAB_AGGRESSIVE)
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 			return 0
@@ -61,16 +55,12 @@
 			return 0
 		C.visible_message("<span class='danger'>[user] dunks [C]'s face into [src]!</span>", \
 						"<span class='userdanger'>[user] dunks your face into [src]!</span>")
-		if(!C.stat)
 			C.emote("scream")
 		user.changeNext_move(CLICK_CD_MELEE)
-		if(!(head.status & ORGAN_ROBOT))
-			C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
-			head.disfigure("burn")
-		add_logs(G.assailant, G.affecting, "deep-fried face")
+		C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
+		head.disfigure("burn")
+		add_logs(user, G.affecting, "deep-fried face")
 		qdel(G) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
-	else
-		to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
 	return 0
 
 

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -61,6 +61,7 @@
 		head.disfigure("burn")
 		add_logs(user, G.affecting, "deep-fried face")
 		qdel(G) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
+		return 1
 	return 0
 
 

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -59,7 +59,7 @@
 		user.changeNext_move(CLICK_CD_MELEE)
 		C.apply_damage(25, BURN, "head") //25 fire damage and disfigurement because your face was just deep fried!
 		head.disfigure("burn")
-		add_logs(user, G.affecting, "deep-fried face")
+		add_logs(user, G.affecting, "deep-fried", addition="'s face")
 		qdel(G) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
 		return 1
 	return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -55,7 +55,7 @@
 		C.emote("scream")
 		user.changeNext_move(CLICK_CD_MELEE)
 		C.adjustFireLoss(30)
-		add_logs(user, G.affecting, "burns on a grill")
+		add_logs(user, G.affecting, "burned", src)
 		qdel(G) //Removes the grip to prevent rapid sears and give you a chance to run
 		return 1
 	return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -48,7 +48,7 @@
 	if(ishuman(G.affecting))
 		if(G.state < GRAB_AGGRESSIVE)
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-			return 1
+			return 0
 		var/mob/living/carbon/human/C = G.affecting
 		C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s body!</span>", \
 						"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
@@ -58,5 +58,4 @@
 		add_logs(user, G.affecting, "burns on a grill")
 		qdel(G) //Removes the grip to prevent rapid sears and give you a chance to run
 		return 1
-	else
-		return 0
+	return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -45,7 +45,7 @@
 	efficiency = round((E/2), 1) // There's 2 lasers, so halve the effect on the efficiency to keep it balanced
 
 /obj/machinery/kitchen_machine/grill/special_attack(obj/item/weapon/grab/G, mob/user)
-	if(istype(G.affecting, /mob/living/carbon/human))
+	if(ishuman(G.affecting))
 		if(G.state < GRAB_AGGRESSIVE)
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 			return 1
@@ -54,25 +54,13 @@
 		var/obj/item/organ/external/chest/chest = C.get_organ("chest")
 		var/obj/item/organ/external/arm/l_arm = C.get_organ("l_arm")
 		var/obj/item/organ/external/arm/right/r_arm = C.get_organ("r_arm")
-		if(!head)
-			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-			return 1
-		C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s upper body!</span>", \
+		C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s body!</span>", \
 						"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
-		if(!C.stat)
-			C.emote("scream")
+		C.emote("scream")
 		user.changeNext_move(CLICK_CD_MELEE)
-		if(!(head.status & ORGAN_ROBOT))
-			C.apply_damage(10, BURN, "head") //30 overall upper body damage because your body was just placed over a hot grill!
-		if(!(chest.status & ORGAN_ROBOT))
-			C.apply_damage(10, BURN, "chest")
-		if(!(l_arm.status & ORGAN_ROBOT))
-			C.apply_damage(5, BURN, "l_arm")
-		if(!(r_arm.status & ORGAN_ROBOT))
-			C.apply_damage(5, BURN, "r_arm")
-		add_logs(G.assailant, G.affecting, "burns on a grill")
+		C.adjustFireLoss(30)
+		add_logs(user, G.affecting, "burns on a grill")
 		qdel(G) //Removes the grip to prevent rapid sears and give you a chance to run
 		return 1
 	else
-		to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
 		return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -50,10 +50,6 @@
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 			return 1
 		var/mob/living/carbon/human/C = G.affecting
-		var/obj/item/organ/external/head/head = C.get_organ("head")
-		var/obj/item/organ/external/chest/chest = C.get_organ("chest")
-		var/obj/item/organ/external/arm/l_arm = C.get_organ("l_arm")
-		var/obj/item/organ/external/arm/right/r_arm = C.get_organ("r_arm")
 		C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s body!</span>", \
 						"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
 		C.emote("scream")

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -43,3 +43,36 @@
 	for(var/obj/item/weapon/stock_parts/micro_laser/M in component_parts)
 		E += M.rating
 	efficiency = round((E/2), 1) // There's 2 lasers, so halve the effect on the efficiency to keep it balanced
+
+/obj/machinery/kitchen_machine/grill/special_attack(obj/item/weapon/grab/G, mob/user)
+	if(istype(G.affecting, /mob/living/carbon/human))
+		if(G.state < GRAB_AGGRESSIVE)
+			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+			return 1
+		var/mob/living/carbon/human/C = G.affecting
+		var/obj/item/organ/external/head/head = C.get_organ("head")
+		var/obj/item/organ/external/chest/chest = C.get_organ("chest")
+		var/obj/item/organ/external/arm/l_arm = C.get_organ("l_arm")
+		var/obj/item/organ/external/arm/right/r_arm = C.get_organ("r_arm")
+		if(!head)
+			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
+			return 1
+		C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s upper body!</span>", \
+						"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
+		if(!C.stat)
+			C.emote("scream")
+		user.changeNext_move(CLICK_CD_MELEE)
+		if(!(head.status & ORGAN_ROBOT))
+			C.apply_damage(10, BURN, "head") //30 overall upper body damage because your body was just placed over a hot grill!
+		if(!(chest.status & ORGAN_ROBOT))
+			C.apply_damage(10, BURN, "chest")
+		if(!(l_arm.status & ORGAN_ROBOT))
+			C.apply_damage(5, BURN, "l_arm")
+		if(!(r_arm.status & ORGAN_ROBOT))
+			C.apply_damage(5, BURN, "r_arm")
+		add_logs(G.assailant, G.affecting, "burns on a grill")
+		qdel(G) //Removes the grip to prevent rapid sears and give you a chance to run
+		return 1
+	else
+		to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+		return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -159,7 +159,7 @@
 		if(!istype(src, /obj/machinery/kitchen_machine/oven) && !istype(src, /obj/machinery/kitchen_machine/grill))
 			to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
 			return 1
-		if(istype(G.affecting, /mob/living/carbon/human) && (G.get_species != "Machine"))
+		if(istype(G.affecting, /mob/living/carbon/human) && (G.affecting.get_species() != "Machine"))
 
 //			if(!iscarbon(G.affecting))
 //				to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -159,52 +159,57 @@
 		if(!istype(src, /obj/machinery/kitchen_machine/oven) && !istype(src, /obj/machinery/kitchen_machine/grill))
 			to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
 			return 1
-		if(!iscarbon(G.affecting))
+		if(istype(G.affecting, /mob/living/carbon/human) && !istype(G.affecting, /mob/living/carbon/human/machine))
+
+//			if(!iscarbon(G.affecting))
+//				to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+//				return 1
+//			if(G.affecting.stat == DEAD)
+//				to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
+//				return 1
+			if(G.state < GRAB_AGGRESSIVE)
+				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+				return 1
+			var/mob/living/carbon/human/C = G.affecting
+			var/obj/item/organ/external/head/head = C.get_organ("head")
+			if(!head)
+				to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
+				return 1
+			if(istype(src, /obj/machinery/kitchen_machine/oven))
+				if(G.state < GRAB_AGGRESSIVE)
+					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+					return 1
+				C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
+								"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
+				if(!C.stat)
+					C.emote("scream")
+				user.changeNext_move(CLICK_CD_MELEE)
+				C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
+				C.apply_damage(15, BRUTE, "head")
+				C.Weaken(2)
+				add_logs(G.assailant, G.affecting, "head smashed in oven")
+				qdel(O) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
+				return 1
+			if(istype(src, /obj/machinery/kitchen_machine/grill))
+				if(G.state < GRAB_AGGRESSIVE)
+					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+					return 1
+				C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s upper body!</span>", \
+								"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
+				if(!C.stat)
+					C.emote("scream")
+				user.changeNext_move(CLICK_CD_MELEE)
+				C.apply_damage(10, BURN, "head") //30 overall upper body damage because your body was just placed over a hot grill!
+				C.apply_damage(10, BURN, "chest")
+				C.apply_damage(5, BURN, "l_arm")
+				C.apply_damage(5, BURN, "r_arm")
+				add_logs(G.assailant, G.affecting, "burns on a grill")
+				qdel(O) //Removes the grip to prevent rapid sears and give you a chance to run
+				return 1
+			return 1
+		else
 			to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
 			return 1
-//		if(G.affecting.stat == DEAD)
-//			to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
-//			return 1
-		if(G.state < GRAB_AGGRESSIVE)
-			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-			return 1
-		var/mob/living/carbon/human/C = G.affecting
-		var/obj/item/organ/external/head/head = C.get_organ("head")
-		if(!head)
-			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-			return 1
-		if(istype(src, /obj/machinery/kitchen_machine/oven))
-			if(G.state < GRAB_AGGRESSIVE)
-				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-				return 1
-			C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
-							"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
-			if(!C.stat)
-				C.emote("scream")
-			user.changeNext_move(CLICK_CD_MELEE)
-			C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
-			C.apply_damage(15, BRUTE, "head")
-			C.Weaken(2)
-			add_logs(G.assailant, G.affecting, "head smashed in oven")
-			qdel(O) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
-			return 1
-		if(istype(src, /obj/machinery/kitchen_machine/grill))
-			if(G.state < GRAB_AGGRESSIVE)
-				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-				return 1
-			C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s upper body!</span>", \
-							"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
-			if(!C.stat)
-				C.emote("scream")
-			user.changeNext_move(CLICK_CD_MELEE)
-			C.apply_damage(10, BURN, "head") //30 overall upper body damage because your body was just placed over a hot grill!
-			C.apply_damage(10, BURN, "chest")
-			C.apply_damage(5, BURN, "l_arm")
-			C.apply_damage(5, BURN, "r_arm")
-			add_logs(G.assailant, G.affecting, "burns on a grill")
-			qdel(O) //Removes the grip to prevent rapid sears and give you a chance to run
-			return 1
-		return 1
 	else
 		to_chat(user, "<span class='alert'>You have no idea what you can cook with this [O].</span>")
 		return 1

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -155,61 +155,7 @@
 				return 1
 		//G.reagents.trans_to(src,G.amount_per_transfer_from_this)
 	else if(istype(O,/obj/item/weapon/grab))
-		var/obj/item/weapon/grab/G = O
-		if(!istype(src, /obj/machinery/kitchen_machine/oven) && !istype(src, /obj/machinery/kitchen_machine/grill))
-			to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
-			return 1
-		if(istype(G.affecting, /mob/living/carbon/human) && (G.affecting.get_species() != "Machine"))
-
-//			if(!iscarbon(G.affecting))
-//				to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
-//				return 1
-//			if(G.affecting.stat == DEAD)
-//				to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
-//				return 1
-			if(G.state < GRAB_AGGRESSIVE)
-				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-				return 1
-			var/mob/living/carbon/human/C = G.affecting
-			var/obj/item/organ/external/head/head = C.get_organ("head")
-			if(!head)
-				to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-				return 1
-			if(istype(src, /obj/machinery/kitchen_machine/oven))
-				if(G.state < GRAB_AGGRESSIVE)
-					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-					return 1
-				C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
-								"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
-				if(!C.stat)
-					C.emote("scream")
-				user.changeNext_move(CLICK_CD_MELEE)
-				C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
-				C.apply_damage(15, BRUTE, "head")
-				C.Weaken(2)
-				add_logs(G.assailant, G.affecting, "head smashed in oven")
-				qdel(O) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
-				return 1
-			if(istype(src, /obj/machinery/kitchen_machine/grill))
-				if(G.state < GRAB_AGGRESSIVE)
-					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-					return 1
-				C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s upper body!</span>", \
-								"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
-				if(!C.stat)
-					C.emote("scream")
-				user.changeNext_move(CLICK_CD_MELEE)
-				C.apply_damage(10, BURN, "head") //30 overall upper body damage because your body was just placed over a hot grill!
-				C.apply_damage(10, BURN, "chest")
-				C.apply_damage(5, BURN, "l_arm")
-				C.apply_damage(5, BURN, "r_arm")
-				add_logs(G.assailant, G.affecting, "burns on a grill")
-				qdel(O) //Removes the grip to prevent rapid sears and give you a chance to run
-				return 1
-			return 1
-		else
-			to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
-			return 1
+		return special_attack(O, user)
 	else
 		to_chat(user, "<span class='alert'>You have no idea what you can cook with this [O].</span>")
 		return 1
@@ -221,6 +167,10 @@
 /obj/machinery/kitchen_machine/attack_hand(mob/user)
 	user.set_machine(src)
 	interact(user)
+
+/obj/machinery/kitchen_machine/proc/special_attack(obj/item/weapon/grab/G, mob/user)
+	to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
+	return 0
 
 /********************
 *   Machine Menu	*

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -169,7 +169,7 @@
 	interact(user)
 
 /obj/machinery/kitchen_machine/proc/special_attack(obj/item/weapon/grab/G, mob/user)
-	to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
+	to_chat(user, "<span class='alert'>This is ridiculous. You can not fit [G.affecting] in this [src].</span>")
 	return 0
 
 /********************

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -159,7 +159,7 @@
 		if(!istype(src, /obj/machinery/kitchen_machine/oven) && !istype(src, /obj/machinery/kitchen_machine/grill))
 			to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
 			return 1
-		if(istype(G.affecting, /mob/living/carbon/human) && !istype(G.affecting, /mob/living/carbon/human/machine))
+		if(istype(G.affecting, /mob/living/carbon/human) && (G.get_species != "Machine"))
 
 //			if(!iscarbon(G.affecting))
 //				to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -156,7 +156,54 @@
 		//G.reagents.trans_to(src,G.amount_per_transfer_from_this)
 	else if(istype(O,/obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = O
-		to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
+		if(!istype(src, /obj/machinery/kitchen_machine/oven) && !istype(src, /obj/machinery/kitchen_machine/grill))
+			to_chat(user, "<span class='alert'>This is ridiculous. You can not fit \the [G.affecting] in this [src].</span>")
+			return 1
+		if(!iscarbon(G.affecting))
+			to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+			return 1
+//		if(G.affecting.stat == DEAD)
+//			to_chat(user, "<span class='warning'>[G.affecting] is dead!</span>")
+//			return 1
+		if(G.state < GRAB_AGGRESSIVE)
+			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+			return 1
+		var/mob/living/carbon/human/C = G.affecting
+		var/obj/item/organ/external/head/head = C.get_organ("head")
+		if(!head)
+			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
+			return 1
+		if(istype(src, /obj/machinery/kitchen_machine/oven))
+			if(G.state < GRAB_AGGRESSIVE)
+				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+				return 1
+			C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
+							"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
+			if(!C.stat)
+				C.emote("scream")
+			user.changeNext_move(CLICK_CD_MELEE)
+			C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
+			C.apply_damage(15, BRUTE, "head")
+			C.Weaken(2)
+			add_logs(G.assailant, G.affecting, "head smashed in oven")
+			qdel(O) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
+			return 1
+		if(istype(src, /obj/machinery/kitchen_machine/grill))
+			if(G.state < GRAB_AGGRESSIVE)
+				to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+				return 1
+			C.visible_message("<span class='danger'>[user] forces [C] onto [src], searing [C]'s upper body!</span>", \
+							"<span class='userdanger'>[user] forces you onto [src]! It burns!</span>")
+			if(!C.stat)
+				C.emote("scream")
+			user.changeNext_move(CLICK_CD_MELEE)
+			C.apply_damage(10, BURN, "head") //30 overall upper body damage because your body was just placed over a hot grill!
+			C.apply_damage(10, BURN, "chest")
+			C.apply_damage(5, BURN, "l_arm")
+			C.apply_damage(5, BURN, "r_arm")
+			add_logs(G.assailant, G.affecting, "burns on a grill")
+			qdel(O) //Removes the grip to prevent rapid sears and give you a chance to run
+			return 1
 		return 1
 	else
 		to_chat(user, "<span class='alert'>You have no idea what you can cook with this [O].</span>")

--- a/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
@@ -61,7 +61,7 @@
 		C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
 		C.apply_damage(15, BRUTE, "head")
 		C.Weaken(2)
-		add_logs(user, G.affecting, "head smashed in oven")
+		add_logs(user, G.affecting, "smashed", addition="'s head on [src]")
 		qdel(G) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
 		return 1
 	return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
@@ -43,3 +43,29 @@
 	for(var/obj/item/weapon/stock_parts/micro_laser/M in component_parts)
 		E += M.rating
 	efficiency = round((E/2), 1) // There's 2 lasers, so halve the effect on the efficiency to keep it balanced
+
+/obj/machinery/kitchen_machine/oven/special_attack(obj/item/weapon/grab/G, mob/user)
+	if(istype(G.affecting, /mob/living/carbon/human))
+		if(G.state < GRAB_AGGRESSIVE)
+			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
+			return 1
+		var/mob/living/carbon/human/C = G.affecting
+		var/obj/item/organ/external/head/head = C.get_organ("head")
+		if(!head)
+			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
+			return 1
+		C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
+						"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
+		if(!C.stat)
+			C.emote("scream")
+		user.changeNext_move(CLICK_CD_MELEE)
+		if(!(head.status & ORGAN_ROBOT))
+			C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
+		C.apply_damage(15, BRUTE, "head")
+		C.Weaken(2)
+		add_logs(G.assailant, G.affecting, "head smashed in oven")
+		qdel(G) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
+		return 1
+	else
+		to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
+		return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
@@ -45,7 +45,7 @@
 	efficiency = round((E/2), 1) // There's 2 lasers, so halve the effect on the efficiency to keep it balanced
 
 /obj/machinery/kitchen_machine/oven/special_attack(obj/item/weapon/grab/G, mob/user)
-	if(istype(G.affecting, /mob/living/carbon/human))
+	if(ishuman(G.affecting))
 		if(G.state < GRAB_AGGRESSIVE)
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 			return 1
@@ -56,16 +56,14 @@
 			return 1
 		C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
 						"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
-		if(!C.stat)
-			C.emote("scream")
+		C.emote("scream")
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(!(head.status & ORGAN_ROBOT))
 			C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
 		C.apply_damage(15, BRUTE, "head")
 		C.Weaken(2)
-		add_logs(G.assailant, G.affecting, "head smashed in oven")
+		add_logs(user, G.affecting, "head smashed in oven")
 		qdel(G) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
 		return 1
 	else
-		to_chat(user, "<span class='warning'>You can only harm carbon-based creatures this way!</span>")
 		return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
@@ -48,22 +48,20 @@
 	if(ishuman(G.affecting))
 		if(G.state < GRAB_AGGRESSIVE)
 			to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
-			return 1
+			return 0
 		var/mob/living/carbon/human/C = G.affecting
 		var/obj/item/organ/external/head/head = C.get_organ("head")
 		if(!head)
 			to_chat(user, "<span class='warning'>This person doesn't have a head!</span>")
-			return 1
+			return 0
 		C.visible_message("<span class='danger'>[user] bashes [C]'s head in [src]'s door!</span>", \
 						"<span class='userdanger'>[user] bashes your head in [src]'s door! It feels rather hot in the oven!</span>")
 		C.emote("scream")
 		user.changeNext_move(CLICK_CD_MELEE)
-		if(!(head.status & ORGAN_ROBOT))
-			C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
+		C.apply_damage(5, BURN, "head") //5 fire damage, 15 brute damage, and weakening because your head was just in a hot oven with the door bashing into your neck!
 		C.apply_damage(15, BRUTE, "head")
 		C.Weaken(2)
 		add_logs(user, G.affecting, "head smashed in oven")
 		qdel(G) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
 		return 1
-	else
-		return 0
+	return 0


### PR DESCRIPTION
How metal can the chef get? Adds attacks for aggressive grips on people for the deep fryer, grill, and oven.

Deep Fryer does burn damage to the head and disfigures the face.
Grill does burn damage over the head, chest, and arms.
Oven does light burn and some brute damage while weakening target.

Current iteration doesn't allow you to do this against IPCs. This is pending.

:cl:Twinmold
Add: Adds attack options for deep fryers, grills, and ovens. Those breaking into the kitchen beware.
/:cl: