### PR TITLE
Fixes Poison Pen

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -352,6 +352,7 @@ var/list/uplink_items = list()
 /datum/uplink_item/jobspecific/poison_pen
 	name = "Poison Pen"
 	desc = "Cutting edge of deadly writing implements technology, this gadget will infuse any piece of paper with delayed contact poison."
+	reference = "PP"
 	item = /obj/item/weapon/pen/poison
 	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
Fixes not getting the poison pen when you buy it as Cargo Tech, Quartermaster, or Head of Personnel. Instead, you currently get a Guardian kit instead.

:cl:Twinmold
Fixes: Buying poison pen will actually give you the poison pen now.
/:cl: