### PR TITLE
[s] Shadowling "Extend Shuttle" prevents recall

### DIFF
--- a/code/controllers/Processes/shuttles.dm
+++ b/code/controllers/Processes/shuttles.dm
@@ -160,6 +160,8 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 /datum/controller/process/shuttle/proc/canRecall()
 	if(emergency.mode != SHUTTLE_CALL)
 		return
+	if(!emergency.canRecall)
+		return
 	if(ticker.mode.name == "meteor")
 		return
 	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -718,8 +718,9 @@
 			var/more_minutes = 9000
 			var/timer = shuttle_master.emergency.timeLeft()
 			timer += more_minutes
-			event_announcement.Announce("Major system failure aboard the emergency shuttle. This will extend its arrival time by approximately 15 minutes..", "System Failure", 'sound/misc/notice1.ogg')
+			event_announcement.Announce("Major system failure aboard the emergency shuttle. This will extend its arrival time by approximately 15 minutes and the shuttle is unable to be recalled.", "System Failure", 'sound/misc/notice1.ogg')
 			shuttle_master.emergency.setTimer(timer)
+			shuttle_master.emergency.canRecall = FALSE
 		user.mind.spell_list.Remove(src) //Can only be used once!
 		qdel(src)
 


### PR DESCRIPTION
The Shadowling ability "Extend Shuttle" now prevents the shuttle from being recalled.
- The announcement when the ability is successful now also informs the crew of this inability to recall.

Additionally, attempts to recall a shuttle which cannot be recalled due to the `canRecall` var will no longer be logged since they don't succeed.

Silent PR due to potential for abuse until patched. Admins are advised to watch out and slam anyone who recalls extended shuttles without mercy until patched.

:cl:
tweak: Damage done to the shuttle engines by a shadowling's "Extend Shuttle" ability now prevent the shuttle from being recalled to CentComm.
/:cl: