### PR TITLE
Minor "bug" fixes. (Kidan changes.)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -486,7 +486,7 @@
 	brute_mod = 0.8
 
 	flags = IS_WHITELISTED
-	clothing_flags = HAS_SOCKS
+	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = FEET_CLAWS | HAS_HEAD_ACCESSORY
 	eyes = "kidan_eyes_s"
 	dietflags = DIET_HERB
@@ -512,6 +512,8 @@
 		"is attempting to bite their antenna off!",
 		"is jamming their claws into their eye sockets!",
 		"is twisting their own neck!",
+		"is cracking their exoskeleton!",
+		"is stabbing themselves with their mandibles!",
 		"is holding their breath!")
 
 /datum/species/slime

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -1918,7 +1918,7 @@
 	icon = 'icons/mob/human_face.dmi'
 	species_allowed = list("Kidan")
 	over_hair = 1
-	do_colouration = 0
+	do_colouration = 1
 
 /datum/sprite_accessory/head_accessory/kidan/perked_antennae
 	name = "Perked-up Antennae"


### PR DESCRIPTION
Badum tish.

Allows Kidan's Antenna to be colour-able in game just like they are currently on the menu.

Also allows Kidan to have underwear and undershirts and adds new suicide messages just for kicks.

No reason not to merge to be honest except the danger of them being too cute. 

![](https://puu.sh/vcLQA.png)

![](https://puu.sh/vcMa7.png)

Examples:

![](https://puu.sh/vcIUy.png)

![](https://puu.sh/vcF6M.png)

![](https://puu.sh/vcFeN.png)

EDIT: Just to clarify, kidan antenna are already colour-able, this is just fixing it not showing in game.

