### PR TITLE
Removes pre-confirmation check from karma gifting 👮 

### DIFF
--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -79,7 +79,7 @@ var/list/karma_spenders = list()
 		to_chat(src, "<span class='warning'>You can't spend karma on someone connected from the same IP.</span>")
 		return 0
 	return 1
-	
+
 
 /mob/verb/spend_karma_list()
 	set name = "Award Karma"
@@ -117,8 +117,6 @@ var/list/karma_spenders = list()
 
 	if(!M)
 		to_chat(usr, "Please right click a mob to award karma directly, or use the 'Award Karma' verb to select a player from the player listing.")
-		return
-	if(!can_give_karma_to_mob(M))
 		return
 	if(alert("Give [M.name] good karma?", "Karma", "Yes", "No") != "Yes")
 		return


### PR DESCRIPTION
We've had wayyyy too many people saying they just misclicked the thing, and there's not much point in keeping the check if there's a second one right after.

The change is so minor it doesn't warrant a changelog.