### PR TITLE
Fixes

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -58,9 +58,9 @@
 	if(istype(C, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = C
 		if(WT.remove_fuel(0, user))
-			to_chat(user, "\blue Slicing lattice joints ...")
-		new /obj/item/stack/rods(src.loc)
-		qdel(src)
+			to_chat(user, "<span class='notice'>Slicing lattice joints...</span>")
+			new /obj/item/stack/rods(src.loc)
+			qdel(src)
 
 	return
 


### PR DESCRIPTION
Fixes #7082

:cl: Purpose2
fix: Welders must now been fueled and active to cut lattices.
/ :cl: