### PR TITLE
Rebalances maint drone emagged

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -486,7 +486,7 @@
 	modules += new /obj/item/weapon/soap(src)
 	modules += new /obj/item/device/t_scanner(src)
 
-	emag = new /obj/item/weapon/pickaxe/drill/cyborg/diamond(src)
+	emag = new /obj/item/weapon/extinguisher(src)
 
 	for(var/T in stacktypes)
 		var/obj/item/stack/sheet/W = new T(src)


### PR DESCRIPTION
Oh noes centcom! made a terrible mistake the hidden drone module was a giantic drill! they replaced it with a fire extinguisher

no but really a diamond drill that can break any wall down easily plus do good amount of brute as a ghost role that can be easily emagged is kinda stupid

:cl: Hyena
tweak:Drones are no more manifuctared with diamond drills as their hidden module but instead with a fire extinguisher
/:cl: