### PR TITLE
Removes Xrays from R&D

### DIFF
--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -146,7 +146,7 @@
 	name = "Core AI Module (T.Y.R.A.N.T.)"
 	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Module."
 	id = "tyrant_module"
-	req_tech = list("programming" = 4, "syndicate" = 2, "materials" = 6)
+	req_tech = list("programming" = 4, "syndicate" = 1, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/tyrant

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -146,7 +146,7 @@
 	name = "Core AI Module (T.Y.R.A.N.T.)"
 	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Module."
 	id = "tyrant_module"
-	req_tech = list("programming" = 4, "syndicate" = 1, "materials" = 6)
+	req_tech = list("programming" = 4, "syndicate" = 2, "materials" = 6)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, "sacid" = 20, MAT_DIAMOND = 100)
 	build_path = /obj/item/weapon/aiModule/tyrant

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -209,17 +209,6 @@
 	build_path = /obj/item/ammo_casing/shotgun/techshell
 	category = list("Weapons")
 
-/datum/design/xray
-	name = "Xray Laser Gun"
-	desc = "Not quite as menacing as it sounds"
-	id = "xray"
-	req_tech = list("combat" = 6, "materials" = 5, "biotech" = 5, "powerstorage" = 4)
-	build_type = PROTOLATHE
-	materials = list(MAT_GOLD = 5000,MAT_URANIUM = 10000, MAT_METAL = 4000)
-	build_path = /obj/item/weapon/gun/energy/xray
-	locked = 1
-	category = list("Weapons")
-
 /datum/design/immolator
 	name = "Immolator Laser Gun"
 	desc = "Has fewer shots than a regular laser gun, but ignites the target on hit"


### PR DESCRIPTION
Removes Xray laser guns form being constructed at R&D and replaces with na alternative for your dumb illegal tech upping.

Overall I expect nothing but backlash but let's be real here. They do immense damage, have a high storage capacity, and can penetrate many wallsfor miles while costing not very much to build.

The type of firepower Xray laser guns is just so immense I can see no practical use for it to be player constructed and controlled; and it's been this way for a long while.

This is mainly just a balance factor; especially for late game blobs which just have no chance even to be put up against an Xray laser gun: and that's really about the only time they are ever seriously constructed even though an Advanced Energy Gun can perform just as well against a blob and still be relatively cheap without utterly destroying a blob single handedly.


🆑  Xantholne
tweak: Removes Xray Guns from R&D
/🆑