### PR TITLE
Syndicate Bundle Adjustments

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -50,11 +50,10 @@
 				return
 
 			if("implant")
+				new /obj/item/weapon/implanter/uplink(src)
 				new /obj/item/weapon/implanter/adrenalin(src)
 				new /obj/item/weapon/implanter/storage(src)
 				new /obj/item/weapon/implanter/freedom(src)
-				new /obj/item/weapon/implanter/emp(src)
-				new /obj/item/organ/internal/cyberimp/eyes/thermals(src)
 				return
 
 			if("hacker")

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,84 +1,84 @@
 /obj/item/weapon/storage/box/syndicate/
 	New()
 		..()
-		switch(pickweight(list("bloodyspai" = 1, "stealth" = 1, "bond" = 1, "screwed" = 1, "guns" = 1, "murder" = 1, "implant" = 1, "hacker" = 1, "lordsingulo" = 1, "darklord" = 1)))
+		switch(pickweight(list("bloodyspai" = 1, "thief" = 1, "bond" = 1, "sabotage" = 1, "payday" = 1, "implant" = 1, "hacker" = 1, "darklord" = 1, "gadgets" = 1)))
 			if("bloodyspai")
-				new /obj/item/clothing/under/chameleon(src)
+				new /obj/item/weapon/twohanded/garrote(src)
+				new /obj/item/weapon/pinpointer/advpinpointer(src)
 				new /obj/item/clothing/mask/gas/voice(src)
+				new /obj/item/clothing/under/chameleon(src)
 				new /obj/item/weapon/card/id/syndicate(src)
-				new /obj/item/weapon/card/id/syndicate(src)
-				new /obj/item/clothing/shoes/syndigaloshes(src)
+				new /obj/item/weapon/storage/box/syndie_kit/emp(src)
 				new /obj/item/device/camera_bug(src)
 				return
 
-			if("stealth")
+			if("thief")
 				new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow(src)
-				new /obj/item/weapon/pen/sleepy(src)
 				new /obj/item/device/chameleon(src)
+				new /obj/item/clothing/gloves/color/black/thief(src)
+				new /obj/item/weapon/card/id/syndicate(src)
 				return
 
 			if("bond")
 				new /obj/item/weapon/gun/projectile/automatic/pistol(src)
 				new /obj/item/weapon/suppressor(src)
-				new /obj/item/ammo_box/magazine/m10mm(src)
-				new /obj/item/ammo_box/magazine/m10mm(src)
-				new /obj/item/clothing/under/chameleon(src)
-				new /obj/item/weapon/card/id/syndicate(src)
-
-			if("screwed")
-				new /obj/item/device/radio/beacon/syndicate/bomb(src)
-				new /obj/item/weapon/grenade/syndieminibomb(src)
-				new /obj/item/device/powersink(src)
-				new /obj/item/clothing/suit/space/syndicate/black/red(src)
-				new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
+				new /obj/item/ammo_box/magazine/m10mm/hp(src)
+				new /obj/item/device/encryptionkey/syndicate(src)
+				new /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate(src)
+				new /obj/item/weapon/implanter/krav_maga(src)
+				new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/alliescocktail(src)
 				return
 
-			if("guns")
+			if("sabotage")
+				new /obj/item/device/powersink(src)
+				new /obj/item/weapon/grenade/syndieminibomb(src)
+				new /obj/item/weapon/card/emag(src)
+				new /obj/item/weapon/grenade/clusterbuster/n2o(src)
+				new /obj/item/weapon/storage/box/syndie_kit/space(src)
+				new /obj/item/clothing/gloves/color/yellow(src)
+				new /obj/item/weapon/rcd/preloaded(src)
+				return
+
+			if("payday")
 				new /obj/item/weapon/gun/projectile/revolver(src)
 				new /obj/item/ammo_box/a357(src)
 				new /obj/item/weapon/card/emag(src)
-				new /obj/item/weapon/grenade/plastic/c4(src)
+				new /obj/item/weapon/grenade/plastic/x4(src)
+				new /obj/item/weapon/card/id/syndicate(src)
 				new /obj/item/clothing/gloves/color/latex/nitrile(src)
 				new /obj/item/clothing/mask/gas/clown_hat(src)
-				new /obj/item/clothing/under/suit_jacket/really_black(src)
-				return
-
-			if("murder")
-				new /obj/item/weapon/melee/energy/sword/saber(src)
-				new /obj/item/clothing/glasses/thermal/syndi(src)
-				new /obj/item/weapon/card/emag(src)
-				new /obj/item/clothing/shoes/syndigaloshes(src)
 				return
 
 			if("implant")
-				new /obj/item/weapon/implanter/freedom(src)
-				new /obj/item/weapon/implanter/uplink(src)
-				new /obj/item/weapon/implanter/emp(src)
 				new /obj/item/weapon/implanter/adrenalin(src)
-				new /obj/item/weapon/implanter/explosive(src)
 				new /obj/item/weapon/implanter/storage(src)
+				new /obj/item/weapon/implanter/freedom(src)
+				new /obj/item/weapon/implanter/emp(src)
+				new /obj/item/organ/internal/cyberimp/eyes/thermals(src)
 				return
 
 			if("hacker")
 				new /obj/item/weapon/aiModule/syndicate(src)
-				new /obj/item/weapon/card/emag(src)
 				new /obj/item/device/encryptionkey/binary(src)
 				new /obj/item/weapon/aiModule/toyAI(src)
 				return
 
-			if("lordsingulo")
-				new /obj/item/device/radio/beacon/syndicate(src)
-				new /obj/item/clothing/suit/space/syndicate/black/red(src)
-				new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
-				new /obj/item/weapon/card/emag(src)
-				return
-
 			if("darklord")
-				new /obj/item/weapon/melee/energy/sword/saber(src)
-				new /obj/item/weapon/melee/energy/sword/saber(src)
+				new /obj/item/weapon/melee/energy/sword/saber/red(src)
+				new /obj/item/weapon/melee/energy/sword/saber/red(src)
 				new /obj/item/weapon/dnainjector/telemut/darkbundle(src)
 				new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 				new /obj/item/weapon/card/id/syndicate(src)
+				return
+				
+			if("gadgets")
+				new /obj/item/clothing/gloves/color/yellow/power(src)
+				new /obj/item/weapon/pen/sleepy(src)
+				new /obj/item/clothing/glasses/thermal/syndi(src)
+				new /obj/item/device/flashlight/emp(src)
+				new /obj/item/clothing/shoes/syndigaloshes(src)
+				new /obj/item/weapon/stamp/chameleon(src)
+				new /obj/item/device/multitool/ai_detect(src)
 				return
 
 /obj/item/weapon/storage/box/syndie_kit

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -64,7 +64,8 @@
 				return
 
 			if("darklord")
-				new /obj/item/weapon/twohanded/dualsaber/red(src)
+				new /obj/item/weapon/melee/energy/sword/saber/red(src)
+				new /obj/item/weapon/melee/energy/sword/saber/red(src)
 				new /obj/item/weapon/dnainjector/telemut/darkbundle(src)
 				new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 				new /obj/item/weapon/card/id/syndicate(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -64,8 +64,7 @@
 				return
 
 			if("darklord")
-				new /obj/item/weapon/melee/energy/sword/saber/red(src)
-				new /obj/item/weapon/melee/energy/sword/saber/red(src)
+				new /obj/item/weapon/twohanded/dualsaber/red(src)
 				new /obj/item/weapon/dnainjector/telemut/darkbundle(src)
 				new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 				new /obj/item/weapon/card/id/syndicate(src)

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -63,3 +63,6 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/devilskiss
 	list_reagents = list("devilskiss" = 50)
+	
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/alliescocktail
+	list_reagents = list("alliescocktail" = 50)


### PR DESCRIPTION
"Syndicate Bundles are specialised groups of items that arrive in a plain box. These items are collectively worth more than 20 telecrystals, but you do not know which specialisation you will receive."

Currently this does not hold true, there are several bundles which are well below the mark. By contrast, a few of these bundles are simply godlike. This makes the bundles into an even bigger gamble than the Syndicate Surplus Crate.

The goal of this PR is to make all the bundles feel worthwhile. You get great value and sometimes unique items, but you don't know which role you'll have to play until the points are spent.

```
BLOODYSPAI (Team Fortress 2)
Currently                        This PR
[3TC] Voice Changer              [3TC] Voice Changer    
[2TC] Chamelon Jumpsuit          [2TC] Chameleon Jumpsuit
[1TC] Camera Bug                 [1TC] Camera Bug
[2TC] Agent ID                   [2TC] Agent ID
[2TC] Agent ID                   [2TC] EMP Grenades + Implant
[2TC] No-Slip Shoes              [4TC] Advanced Pinpointer
                                 [12TC] Fiber Wire Garrote
Total: 12 TC                     Total: 26TC
```
The duplicate Agent ID seems to have been put there with the idea of quickly changing identities in mind, per the way the Spy works in TF2, but everyone I brought this up with didn't consider it practical. Given the Spy's tendency to destroy turrets, I decided the EMP kit was a good replacement.

While the Spy never uses a garrote in the video game (to my knowledge), it is the closest thing to his backstabbing mechanic, so I felt it was a worthy addition. I also added the advanced pinpointer since in the game, you have to pursue a highlighted objective such as the intel briefcase. I removed the No-Slip Shoes because bundles can only have 7 items and I do believe it was only added with blood slipping in mind (which our server does not have).

```   
BOND (James Bond)            
Currently                        This PR
[4TC] FK-69 Pistol               [4TC] FK-69 Pistol
[1TC] Suppressor                 [1TC] Suppressor
[1TC] Magazine 10mm              [2TC] Magazine 10mm HP
[1TC] Magazine 10mm              [2TC] Syndi Comm Key
[2TC] Chamelon Jumpsuit          [2TC] Syndicate Smokes
[2TC] Agent ID                   [//] Krav Maga Implanter
                                 [//] Allies Cocktail
Total: 11 TC                     Total: 11 TC + SPECIAL
```
While James Bond dons many disguises, without a voice changer the concept of adding disguise-based items falls flat in my opinion. So I took a more straightforward approach. A frequent smoker, a master of martial arts, and a man particular about his martini cocktails, I feel this fits the Bond vibe far better.

```
DARKLORD (Star Wars)         
Currently                        This PR
[8TC] Energy Sword               [8TC] Energy Sword (Red)
[8TC] Energy Sword               [8TC] Energy Sword (Red)
[2TC] Agent ID                   [2TC] Agent ID
[//] Telekinesis SE              [//] Telekinesis SE
[//] Chaplain Hoodie             [//] Chaplain Hoodie
Total: 18 TC + SPECIAL           Total: 18 TC + SPECIAL
```
The energy swords are red now.

```
HACKER                       
Currently                        This PR
[14TC] Hacked AI Module          [14TC] Hacked AI Module
[5TC] Binary Comm Key            [5TC] Binary Comm Key
[//] Portable AI Upload          [//] Portable AI Upload
[6TC] EMag                      
Total: 25 TC + SPECIAL           Total: 19 TC + SPECIAL
```
The Toy AI this bundle comes with functions as a Portable AI Upload, which is obscenely powerful. The EMag just seems overkill with that in mind.

```
IMPLANT                      
Currently                        This PR
[14TC] Uplink Implant            [14TC] Uplink Implant
[8TC] Storage Implant            [8TC] Storage Implant
[8TC] Adrenal Implant            [8TC] Adrenal Implant
[5TC] Freedom Implant            [5TC] Freedom Implant
[2TC] Microbomb Implant
[~1TC] EMP Implant
Total: 38 TC                     Total: 35 TC
```
The microbomb implant's explosiveness is measured based on how many implants you have, and with as many implants as this bundle comes with, it is quite deadly. The EMP implant is icing on the cake; it is typically part of the EMP kit.

Honestly I don't really like this bundle having 10TC worth of flex-points via the uplink implant as I feel that contradicts the whole point of the bundles, but until I can come up with a better solution this bundle will just have to be better than the rest.

```
LORDSINGULO
Currently                        This PR
[14TC] Power Beacon            
[6TC] EMag                     
[4TC] Syndi Space Suit         
Total: 24 TC                     {Removed}
```
The entire basis of this bundle is to release the singularity/tesla. As a randomized bundle this seems like a bad idea, as if you do not have hijack you can't really utilize it properly. It's easily done with the base 20TC anyway, just get an EVA suit.

```
MURDER
Currently                        This PR
[8TC] Energy Sword             
[6TC] EMag                     
[6TC] Thermal Goggles          
[2TC] No-Slip Shoes            
Total: 22 TC                     {Removed}
```
I tried to make this one work, but at the end of the day, there wasn't any actual 'theme' here... so I just scrapped it for being boring.

```
PAYDAY {GUNS} (Payday 2)
Currently                        This PR
[13TC] .357 Revolver             [13TC] .357 Revolver
[4TC] .357 Speed Loader          [4TC] .357 Speed Loader
[6TC] EMag                       [6TC] EMag
[//] Clown Mask                  [//] Clown Mask
[//] Nitrile Gloves              [//] Nitrile Gloves
[//] Black Jacket                [2TC] Agent ID
[1TC] C4                         [2TC] X4
Total: 24 TC                     Total: 27 TC
```
A slight bump up, the X4 better lets this traitor storm in with clown mask donned and gun in hand as fast as possible. Now comes with an Agent ID for good measure, for Payday-esque names.

```
SABOTAGE {SCREWED}
Currently                        This PR
[10TC] Power Sink                [10TC] Power Sink
[6TC] Syndicate Minibomb         [6TC] Syndicate Minibomb
[4TC] Syndi Space Suit           [4TC] Syndi Space Suit
[11TC] Syndicate Bomb            [6TC] EMag
                                 [~5TC] N2O Atmos Grenade
							     [//] Preloaded RCD
							     [//] Insulated Gloves
Total: 31 TC                     Total: 31 TC + SPECIAL
```
Previously named 'screwed', I wanted to move this away from needing to rely on ahelps for the syndicate bomb (as that is something you should typically do _before_ you buy a syndicate bomb) and focused it more toward sabotaging the station. Being a good saboteur can be difficult if you can't get a hold of insulated gloves, so I made sure it came with a pair. The N2O grenade is good for creating a bit of chaos and/or slowing repairs.

```
THIEF i.e. STEALTH
Currently                        This PR
[12TC] Energy Crossbow           [12TC] Energy Crossbow
[7TC] Chameleon-Projector        [7TC] Chameleon-Projector
[8TC] Sleepy Pen                 [6TC] Pickpocket Gloves
                                 [2TC] Agent ID
                                 
Total: 27 TC                     Total: 27 TC
```
The 'stealth' set seemed rather focused on being a stealthy assassin, but it leaves you very little to do outside of that. By adding the element of thievery into the mix it gives them a bit more to do outside of that.

```
GADGETS
This PR
[10TC] Power Gloves
[8TC] Sleepy Pen
[6TC] Thermal Glasses
[2TC] EMP Flashlight
[2TC] No-Slip Shoes
[1TC] AI Detector
[1TC] Chameleon Stamp
Total: 30 TC
```
This is an entirely new bundle, the idea behind it being entirely inconspicuous objects that are not what they seem. Most of these kind of objects are quite cheap, so I had to include a couple job-exclusive items. I thought about the E20 but as hilarious as it is, I decided against it as a traitor might not realize the function of the die until it is much too late.

🆑 Lady-Luck
tweak: Makes several balance adjustments to existing syndicate bundles, generally making them more worthwhile.
add: Adds an Allies Cocktail object for the Bond bundle.
add: Adds the 'gadgets' syndicate bundle.
del: Removes the 'lordsingulo' and 'murder' syndicate bundles.
/🆑