### PR TITLE
Fixes missing storage limitations on matchboxes

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -579,7 +579,9 @@
 	item_state = "zippo"
 	storage_slots = 10
 	w_class = 1
+	max_w_class = 1
 	slot_flags = SLOT_BELT
+	can_hold = list(/obj/item/weapon/match)
 
 	New()
 		..()


### PR DESCRIPTION
These things were basically tiny cardboard boxes, with extra storage slots, and only *seemingly* limited thanks to their `attackby` override. Whoops!

They're now only allowed to contain matches, which you *still* can't really put back in without resorting to shenanigans.

Oh, almost forgot - fixes #7116.

:cl:
fix: You can no longer squeeze non-match objects into matchboxes.
/:cl: