### PR TITLE
Limits the length of freeform AI laws 🤖

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -92,8 +92,14 @@
 	if(non_whitespace)		return text		//only accepts the text if it has some non-spaces
 
 // Used to get a sanitized input.
-/proc/stripped_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length=MAX_MESSAGE_LEN)
-	var/name = input(user, message, title, default)
+/proc/stripped_input(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length = MAX_MESSAGE_LEN)
+	var/name = input(user, message, title, default)//as input - default
+
+	return strip_html_properly(name, max_length)
+
+// Used to get a sanitized input, just like stripped_input(), but displays a much larger window for the message. Use for larger blocks of text.
+/proc/stripped_input_message(var/mob/user, var/message = "", var/title = "", var/default = "", var/max_length = MAX_MESSAGE_LEN)
+	var/name = input(user, message, title, default) as message
 	return strip_html_properly(name, max_length)
 
 //Filters out undesirable characters from names
@@ -549,4 +555,3 @@ proc/checkhtml(var/t)
 	text = replacetext(text, "<td>",					"\[cell\]")
 	text = replacetext(text, "<img src = ntlogo.png>",	"\[logo\]")
 	return text
-

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -11,6 +11,7 @@
 #define MAX_PAPER_FIELDS 50
 #define MAX_BOOK_MESSAGE_LEN 9216
 #define MAX_NAME_LEN 26
+#define MAX_AI_LAW_LEN 144
 
 // Version check, terminates compilation if someone is using a version of BYOND that's too old
 #if DM_VERSION < 510

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -203,12 +203,10 @@ AI MODULES
 
 /obj/item/weapon/aiModule/freeform/attack_self(var/mob/user as mob)
 	..()
-	var/new_lawpos = input("Please enter the priority for your new law. Can only write to law sectors 15 and above.", "Law Priority (15+)", lawpos) as num
+	var/new_lawpos = input("Please enter the priority for your new law. Can only write to law sectors 15 and above.", "Law Priority (15+)", lawpos) as null|num
 	if(new_lawpos < MIN_SUPPLIED_LAW_NUMBER)	return
 	lawpos = min(new_lawpos, MAX_SUPPLIED_LAW_NUMBER)
-	var/newlaw = ""
-	var/targName = sanitize(copytext(input(usr, "Please enter a new law for the AI.", "Freeform Law Entry", newlaw),1,MAX_MESSAGE_LEN))
-	newFreeFormLaw = targName
+	newFreeFormLaw = stripped_input_message(usr, "Please enter a new law for the AI.", "Freeform Law Entry", newFreeFormLaw, MAX_AI_LAW_LEN)
 	desc = "A 'freeform' AI module: ([lawpos]) '[newFreeFormLaw]'"
 
 /obj/item/weapon/aiModule/freeform/addAdditionalLaws(var/mob/living/silicon/ai/target, var/mob/sender)
@@ -331,8 +329,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/freeformcore/attack_self(var/mob/user as mob)
 	..()
-	var/newlaw = ""
-	var/targName = stripped_input(usr, "Please enter a new core law for the AI.", "Freeform Law Entry", newlaw)
+	var/targName = stripped_input_message(usr, "Please enter a new core law for the AI.", "Freeform Law Entry", newFreeFormLaw, MAX_AI_LAW_LEN)
 	newFreeFormLaw = targName
 	desc = "A 'freeform' Core AI module:  '[newFreeFormLaw]'"
 
@@ -357,8 +354,7 @@ AI MODULES
 
 /obj/item/weapon/aiModule/syndicate/attack_self(var/mob/user as mob)
 	..()
-	var/newlaw = ""
-	var/targName = stripped_input(usr, "Please enter a new law for the AI.", "Freeform Law Entry", newlaw,MAX_MESSAGE_LEN)
+	var/targName = stripped_input_message(usr, "Please enter a new law for the AI.", "Freeform Law Entry", newFreeFormLaw, MAX_AI_LAW_LEN)
 	newFreeFormLaw = targName
 	desc = "A hacked AI law module:  '[newFreeFormLaw]'"
 


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: freeform AI laws can no longer have more than 144 characters
/:cl:

Drops the freeform AI law character limit down to 144 characters, as per public support on the server.

This is for Freefor, Core Freeform and Hacked boards.

Will make it easier for AIs and borgs, as well as help cut down on the powergamey cheese that is using AIs to do all your work for you as a traitor.

Also comes with some usability tweaks, but I'll gladly PR them separately if this doesn't come through.

Note that there do exist lawsets which have longer laws. The longest I counted was 155 characters, the DS lawset.  

If you can't tweet it, you can't law it.