### PR TITLE
Fixes Missing CMO Skirt

### DIFF
--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -50,7 +50,7 @@
 
 /datum/gear/uniform/skirt/job/cmo
 	display_name = "skirt, cmo"
-	path = /obj/item/clothing/under/rank/chief_medical_officer
+	path = /obj/item/clothing/under/rank/chief_medical_officer/skirt
 	allowed_roles = list("Chief Medical Officer")
 
 /datum/gear/uniform/skirt/job/chem


### PR DESCRIPTION
Fixes the pathway for the CMO Skirt that was incorrectly giving you the regular jumpsuit

🆑 Xantholne
fix: You now correctly spawn with the CMO Skirt if selected in loadout menu
/🆑 