### PR TITLE
Allows scythes to mass-clear glowshrooms

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -153,8 +153,16 @@
 
 /obj/structure/glowshroom/attackby(obj/item/I, mob/user)
 	..()
-	if(I.damtype != STAMINA)
-		endurance -= I.force
+	var/force = I.force
+	if(istype(I, /obj/item/weapon/scythe))
+		var/obj/item/weapon/scythe/S = I
+		if(S.extend)	//so folded telescythes won't get damage boosts / insta-clears (they instead will instead be treated like non-scythes)
+			force = force * 4
+			for(var/obj/structure/glowshroom/G in range(1,src))
+				G.endurance -= force
+				G.CheckEndurance()
+	else if(I.damtype != STAMINA)
+		endurance -= force
 		CheckEndurance()
 
 /obj/structure/glowshroom/ex_act(severity)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -161,7 +161,8 @@
 			for(var/obj/structure/glowshroom/G in range(1,src))
 				G.endurance -= force
 				G.CheckEndurance()
-	else if(I.damtype != STAMINA)
+			return
+	if(I.damtype != STAMINA)
 		endurance -= force
 		CheckEndurance()
 

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -153,17 +153,17 @@
 
 /obj/structure/glowshroom/attackby(obj/item/I, mob/user)
 	..()
-	var/force = I.force
+	var/damage_to_do = I.force
 	if(istype(I, /obj/item/weapon/scythe))
 		var/obj/item/weapon/scythe/S = I
 		if(S.extend)	//so folded telescythes won't get damage boosts / insta-clears (they instead will instead be treated like non-scythes)
-			force = force * 4
+			damage_to_do *= 4
 			for(var/obj/structure/glowshroom/G in range(1,src))
-				G.endurance -= force
+				G.endurance -= damage_to_do
 				G.CheckEndurance()
 			return
 	if(I.damtype != STAMINA)
-		endurance -= force
+		endurance -= damage_to_do
 		CheckEndurance()
 
 /obj/structure/glowshroom/ex_act(severity)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -485,29 +485,29 @@
 	if (!W || !user || !W.type)
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
-	var/force = W.force
+	var/damage_to_do = W.force
 
 	if(istype(W, /obj/item/weapon/scythe))
 		var/obj/item/weapon/scythe/S = W
 		if(S.extend)	//so folded telescythes won't get damage boosts / insta-clears (they instead will instead be treated like non-scythes)
-			force = force * 4
+			damage_to_do *= 4
 			for(var/obj/structure/spacevine/B in range(1,src))
-				if(B.health > force)	//this only is going to occur for woodening mutation vines (increased health) or if we nerf scythe damage/multiplier
-					B.health -= force
+				if(B.health > damage_to_do)	//this only is going to occur for woodening mutation vines (increased health) or if we nerf scythe damage/multiplier
+					B.health -= damage_to_do
 				else
 					B.wither()
 			return
 
 	if(is_sharp(W))
-		force = force * 4
+		damage_to_do *= 4
 
 	if(W && W.damtype == "fire")
-		force = force * 4
+		damage_to_do *= 4
 
 	for(var/datum/spacevine_mutation/SM in mutations)
-		force = SM.on_hit(src, user, W, force) //on_hit now takes override damage as arg and returns new value for other mutations to permutate further
+		damage_to_do = SM.on_hit(src, user, W, damage_to_do) //on_hit now takes override damage as arg and returns new value for other mutations to permutate further
 
-	health -= force
+	health -= damage_to_do
 	if(health < 1)
 		wither()
 


### PR DESCRIPTION
Glowshrooms (and subtypes) are no longer immune to the reaper's touch, and will be shredded by scythes just like vines.

:cl:
bugfix: Glowshrooms (and their subtypes) can be mass-cleared by scythes just like vines.
/:cl: