### PR TITLE
Default Alternate Job Preferences Adjustment

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -175,7 +175,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	var/job_karma_low = 0
 
 	//Keeps track of preferrence for not getting any wanted jobs
-	var/alternate_option = 0
+	var/alternate_option = 2
 
 	// maps each organ to either null(intact), "cyborg" or "amputated"
 	// will probably not be able to do this for head and torso ;)


### PR DESCRIPTION
This changes the default alt job setting to return players to the lobby
if their job preferences are unavailable.

Reasoning:
- Random jobs should be an opt in, not an opt out, feature
- Typically,
new players can overlook this option or misunderstand what it means, and
end up in roles they may not have prepared themselves for.
- Being assigned a job that a person absolutely does NOT want means its
far less likely they will even do their job. We can only hope they cryo
in such cases. I'd rather just address one potential source of issues.

Potential cons:

- Might slightly reduce filling the less desireable jobs, but I think
the pros far outweight the cons.

This has NO effect on existing players, unless the admins decide to run
an SQL query. This ONLY affects new players.

:cl:
Tweak: Default Alternate Job Preference changed to "Return to Lobby".
Only affects new players.
/:cl: