### PR TITLE
Introduce gas transfer coefficient

### DIFF
--- a/code/modules/clothing/masks/breath.dm
+++ b/code/modules/clothing/masks/breath.dm
@@ -6,7 +6,7 @@
 	flags = AIRTIGHT
 	flags_cover = MASKCOVERSMOUTH
 	w_class = 2
-	gas_transfer_coefficient = 0.10
+	gas_transfer_coefficient = 0.05
 	permeability_coefficient = 0.50
 	actions_types = list(/datum/action/item_action/adjust)
 	burn_state = FIRE_PROOF
@@ -29,6 +29,7 @@
 	icon_state = "medical"
 	item_state = "medical"
 	permeability_coefficient = 0.01
+	gas_transfer_coefficient = 0
 	put_on_delay = 10
 	species_fit = list("Vox", "Unathi", "Tajaran", "Vulpkanin")
 
@@ -38,5 +39,6 @@
 	icon_state = "voxmask"
 	item_state = "voxmask"
 	permeability_coefficient = 0.01
+	gas_transfer_coefficient = 0
 	species_restricted = list("Vox")
 	actions_types = list()

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -7,7 +7,7 @@
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
 	w_class = 3
 	item_state = "gas_alt"
-	gas_transfer_coefficient = 0.01
+	gas_transfer_coefficient = 0
 	permeability_coefficient = 0.01
 	burn_state = FIRE_PROOF
 	species_fit = list("Vox", "Unathi", "Tajaran", "Vulpkanin")
@@ -71,7 +71,7 @@
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES
 	w_class = 3
 	item_state = "bane_mask"
-	gas_transfer_coefficient = 0.01
+	gas_transfer_coefficient = 0
 	permeability_coefficient = 0.01
 
 
@@ -493,4 +493,3 @@
 
 
 // ********************************************************************
-


### PR DESCRIPTION
:cl: Tayyyyyyy
tweak: Breath masks are no longer effective at filtering toxins, even with internals
fix: You're no longer immune from having your lung punctured when you have internals on
/:cl:

In #7111, I think one thing people agreed on was that there isn't enough to differentiate between a gas mask and a breath mask, so I reimplemented the gas transfer coefficient, which became unused following the transition from ZAS to LINDA.

According to code/game/objects/items.dm, gas_transfer_coefficient is supposed to be "for leaking gas from turf to mask and vice-versa", so I tried to implement this as faithfully as possible. I'm sorry if I got anything wrong, since this is my first real PR and physics stuff (and DreamMaker) is kinda confusing to me. Anyways, the main thing this does is check the gas transfer coefficient after removing air from the internal tank. A gas_transfer_coefficient ratio of moles is then removed from that air and expelled back into the environment. Then, unless you're wearing a helmet that's space proof, the air lost will be replaced by air from the current turf or object (if you're inside a pod or a mech).

As a side effect of this PR, you can now get a punctured lung even if you're on internals. In the past, your lung would only get punctured if your internals ran out of air. Now, if you purposely set the pressure on your internals too low, your lungs will get punctured. Let me know if this was a feature and not a bug.

## Balance Changes
- Breath mask gas_transfer_coefficient adjusted to 0.05, so that it can still give you enough oxygen so that your lungs won't get punctured in the vacuum, but high enough that walking into plasma will poison you.
- All other masks, including gas mask, vox mask, medical mask, bane mask, etc are adjusted to have gas_transfer_coefficient 0, functioning effectively the same as before.

## Stuff I've tested
I've tried thinking of all the scenarios that this would impact, so let me know if I'm missing any:
- Normal breathing in normal air works
- Internals w/ breath mask keeps you breathing in station air
- Internals w/ breath mask keeps you breathing in vacuum
- Internals w/ gas mask keeps you breathing in station air
- Internals w/ gas mask keeps you breathing in vacuum
- Internals w/ breath mask poisons you in toxins
- Internals w/ gas mask doesn't poison you in toxins
- Internals w/ breath mask w/ space suit helmet doesn't poison you in toxins
- You still suffocate in a pod in the vacuum taking air from the environment
- Using internals + mask in a pod works even if the pod is taking air from the vacuum
- You still die from suffocation damage when you're connected to empty internals
- Vox doesn't start dying immediately on arrival
- Plasmamen don't leak plasma everywhere, and it seems like they don't leak enough to self ignite a plasma fire
- Spawned around twenty mobs and equipped them all with internals and breath masks and tried to make sure there wasn't a noticeable performance impact (on a side note, is there an easier way to do this besides spawning, equipping, and assuming direct control of each one manually?)
