### PR TITLE
Add config option to completely disable karma

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -191,6 +191,8 @@
 
 	var/shutdown_on_reboot = 0 // Whether to shut down the world instead of rebooting it
 
+	var/disable_karma = 0 // Disable all karma functions and unlock karma jobs by default
+
 /datum/configuration/New()
 	var/list/L = subtypesof(/datum/game_mode)
 	for(var/T in L)
@@ -592,6 +594,9 @@
 
 				if("shutdown_shell_command")
 					shutdown_shell_command = value
+
+				if("disable_karma")
+					disable_karma = 1
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -21,6 +21,8 @@ var/list/whitelist = list()
 	if(guest_jobbans(rank))
 		if(!config.usewhitelist)
 			return 1
+		if(config.disable_karma)
+			return 1
 		if(check_rights(R_ADMIN, 0, M))
 			return 1
 		if(!dbcon.IsConnected())
@@ -61,6 +63,8 @@ var/list/whitelist = list()
 //todo: admin aliens
 /proc/is_alien_whitelisted(mob/M, var/species)
 	if(!config.usealienwhitelist)
+		return 1
+	if(config.disable_karma)
 		return 1
 	if(species == "human" || species == "Human")
 		return 1

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -97,160 +97,163 @@
 	if(config && config.log_hrefs && href_logfile)
 		to_chat(href_logfile, "<small>[time2text(world.timeofday,"hh:mm")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>")
 
-	switch(href_list["karmashop"])
-		if("tab")
-			karma_tab = text2num(href_list["tab"])
-			karmashopmenu()
+	if(href_list["karmashop"])
+		if(config.disable_karma)
 			return
-		if("shop")
-			if(href_list["KarmaBuy"])
-				var/karma=verify_karma()
-				switch(href_list["KarmaBuy"])
-					if("1")
-						if(karma <5)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Barber?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_job_unlock("Barber",5)
-							return
-					if("2")
-						if(karma <5)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Brig Physician?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_job_unlock("Brig Physician",5)
-							return
-					if("3")
-						if(karma <30)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Nanotrasen Representative?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_job_unlock("Nanotrasen Representative",30)
-							return
-					if("5")
-						if(karma <30)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Blueshield?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_job_unlock("Blueshield",30)
-							return
-					if("6")
-						if(karma <30)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Mechanic?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_job_unlock("Mechanic",30)
-							return
-					if("7")
-						if(karma <45)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Magistrate?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_job_unlock("Magistrate",45)
-							return
-					if("9")
-						if(karma <30)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Security Pod Pilot?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_job_unlock("Security Pod Pilot",30)
-							return
-			if(href_list["KarmaBuy2"])
-				var/karma=verify_karma()
-				switch(href_list["KarmaBuy2"])
-					if("1")
-						if(karma <15)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Machine People?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_species_unlock("Machine",15)
-							return
-					if("2")
-						if(karma <30)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Kidan?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_species_unlock("Kidan",30)
-							return
-					if("3")
-						if(karma <30)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Grey?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_species_unlock("Grey",30)
-							return
-					if("4")
-						if(karma <45)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Vox?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_species_unlock("Vox",45)
-							return
-					if("5")
-						if(karma <45)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Slime People?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_species_unlock("Slime People",45)
-							return
-					if("6")
-						if(karma <100)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Plasmaman?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_species_unlock("Plasmaman",100)
-							return
-					if("7")
-						if(karma <30)
-							to_chat(usr, "You do not have enough karma!")
-							return
-						else
-							if(alert("Are you sure you want to unlock Drask?", "Confirmation", "No", "Yes") != "Yes")
-								return
-							DB_species_unlock("Drask",30)
-							return
-			if(href_list["KarmaRefund"])
-				var/type = href_list["KarmaRefundType"]
-				var/job = href_list["KarmaRefund"]
-				var/cost = href_list["KarmaRefundCost"]
-				karmarefund(type,job,cost)
+
+		switch(href_list["karmashop"])
+			if("tab")
+				karma_tab = text2num(href_list["tab"])
+				karmashopmenu()
 				return
+			if("shop")
+				if(href_list["KarmaBuy"])
+					var/karma=verify_karma()
+					switch(href_list["KarmaBuy"])
+						if("1")
+							if(karma <5)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Barber?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_job_unlock("Barber",5)
+								return
+						if("2")
+							if(karma <5)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Brig Physician?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_job_unlock("Brig Physician",5)
+								return
+						if("3")
+							if(karma <30)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Nanotrasen Representative?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_job_unlock("Nanotrasen Representative",30)
+								return
+						if("5")
+							if(karma <30)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Blueshield?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_job_unlock("Blueshield",30)
+								return
+						if("6")
+							if(karma <30)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Mechanic?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_job_unlock("Mechanic",30)
+								return
+						if("7")
+							if(karma <45)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Magistrate?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_job_unlock("Magistrate",45)
+								return
+						if("9")
+							if(karma <30)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Security Pod Pilot?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_job_unlock("Security Pod Pilot",30)
+								return
+				if(href_list["KarmaBuy2"])
+					var/karma=verify_karma()
+					switch(href_list["KarmaBuy2"])
+						if("1")
+							if(karma <15)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Machine People?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_species_unlock("Machine",15)
+								return
+						if("2")
+							if(karma <30)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Kidan?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_species_unlock("Kidan",30)
+								return
+						if("3")
+							if(karma <30)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Grey?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_species_unlock("Grey",30)
+								return
+						if("4")
+							if(karma <45)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Vox?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_species_unlock("Vox",45)
+								return
+						if("5")
+							if(karma <45)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Slime People?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_species_unlock("Slime People",45)
+								return
+						if("6")
+							if(karma <100)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Plasmaman?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_species_unlock("Plasmaman",100)
+								return
+						if("7")
+							if(karma <30)
+								to_chat(usr, "You do not have enough karma!")
+								return
+							else
+								if(alert("Are you sure you want to unlock Drask?", "Confirmation", "No", "Yes") != "Yes")
+									return
+								DB_species_unlock("Drask",30)
+								return
+				if(href_list["KarmaRefund"])
+					var/type = href_list["KarmaRefundType"]
+					var/job = href_list["KarmaRefund"]
+					var/cost = href_list["KarmaRefundCost"]
+					karmarefund(type,job,cost)
+					return
 
 	switch(href_list["_src_"])
 		if("holder")	hsrc = holder
 		if("usr")		hsrc = mob
 		if("prefs")		return prefs.process_link(usr,href_list)
 		if("vars")		return view_var_Topic(href,href_list,hsrc)
-	
+
 	//Polls and shit
 	if(href_list["showpoll"])
-
 		handle_player_polling()
 		return
 	if(href_list["createpollwindow"])
@@ -260,7 +263,6 @@
 		create_poll_function(href_list)
 		return
 	if(href_list["pollid"])
-
 		var/pollid = href_list["pollid"]
 		if(istext(pollid))
 			pollid = text2num(pollid)
@@ -443,7 +445,7 @@
 			winset(src, null, "command=\".configure graphics-hwmode on\"")
 
 	log_client_to_db(tdata)
-	
+
 	. = ..()	//calls mob.Login()
 
 	if(ckey in clientmessages)

--- a/code/modules/karma/karma.dm
+++ b/code/modules/karma/karma.dm
@@ -52,6 +52,9 @@ var/list/karma_spenders = list()
 /mob/proc/can_give_karma()
 	if(!client)
 		return 0
+	if(config.disable_karma)
+		to_chat(src, "<span class='warning'>Karma is disabled.</span>")
+		return 0
 	if(!ticker || !player_list.len || (ticker.current_state == GAME_STATE_PREGAME))
 		to_chat(src, "<span class='warning'>You can't award karma until the game has started.</span>")
 		return 0
@@ -118,6 +121,9 @@ var/list/karma_spenders = list()
 	if(!M)
 		to_chat(usr, "Please right click a mob to award karma directly, or use the 'Award Karma' verb to select a player from the player listing.")
 		return
+	if(config.disable_karma) // this is here because someone thought it was a good idea to add an alert box before checking if they can even give a mob karma
+		to_chat(usr, "<span class='warning'>Karma is disabled.</span>")
+		return
 	if(alert("Give [M.name] good karma?", "Karma", "Yes", "No") != "Yes")
 		return
 	if(!can_give_karma_to_mob(M))
@@ -144,6 +150,10 @@ var/list/karma_spenders = list()
 	set name = "Check Karma"
 	set desc = "Reports how much karma you have accrued."
 	set category = "OOC"
+
+	if(config.disable_karma)
+		to_chat(src, "<span class='warning'>Karma is disabled.</span>")
+		return 0
 
 	var/currentkarma=verify_karma()
 	to_chat(usr, {"<br>You have <b>[currentkarma]</b> available."})
@@ -175,6 +185,10 @@ You've gained <b>[totalkarma]</b> total karma in your time here.<br>"}
 	set name = "karmashop"
 	set desc = "Spend your hard-earned karma here"
 	set hidden = 1
+
+	if(config.disable_karma)
+		to_chat(src, "<span class='warning'>Karma is disabled.</span>")
+		return 0
 
 	karmashopmenu()
 	return

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -328,7 +328,7 @@ DISABLE_SPACE_RUINS
 
 ## Hub address for tracking stats
 ## example: Hubmakerckey.Hubname
-#MEDAL_HUB_ADDRESS 
+#MEDAL_HUB_ADDRESS
 
 ## Password for the hub page
 #MEDAL_HUB_PASSWORD
@@ -341,3 +341,6 @@ DISABLE_SPACE_RUINS
 ## A command to run prior to the world shutting down, only used if the above option is enabled
 ## This default value will kill Dream Daemon on Windows machines
 #SHUTDOWN_SHELL_COMMAND taskkill /f /im dreamdaemon.exe
+
+## Uncomment this to disable karma and unlock all karma purchases for players by default
+#DISABLE_KARMA


### PR DESCRIPTION
This is purely for the benefit of downstream servers, it's a fairly common complaint I've heard from small closed communities. "We don't want to use karma at all".

Technically partially redundant due to the `USEWHITELIST` and `USEALIENWHITELIST` config options, but if those are overlooked and you disable karma, the behavior expected would be to unlock everything, rather than lock it off for everyone.