### PR TITLE
Prevent incapacitated people from using space pod verbs

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -589,19 +589,13 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 			desc = "A rough looking space pod meant for industrial work"
 	update_icons()
 
-/obj/spacepod/proc/can_use_verb()
-	if(usr.incapacitated())
-		to_chat(usr, "<span class='notice'>You cannot do this while unconscious or restrained.</span>")
-		return FALSE
-	return TRUE
-
 /obj/spacepod/verb/toggle_internal_tank()
 	set name = "Toggle internal airtank usage"
 	set category = "Spacepod"
 	set src = usr.loc
 	set popup_menu = 0
 
-	if(!can_use_verb())
+	if(usr.incapacitated())
 		return
 
 	if(usr != src.pilot)
@@ -801,7 +795,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	if(!istype(user))
 		return
 
-	if(!can_use_verb()) // unconscious and restrained people can't let themselves out
+	if(usr.incapacitated()) // unconscious and restrained people can't let themselves out
 		return
 
 	occupant_sanity_check()
@@ -820,7 +814,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set category = "Spacepod"
 	set src = usr.loc
 
-	if(!can_use_verb())
+	if(usr.incapacitated())
 		return
 
 	if(usr in passengers && usr != src.pilot)
@@ -836,7 +830,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set category = "Spacepod"
 	set src = usr.loc
 
-	if(!can_use_verb())
+	if(usr.incapacitated())
 		return
 
 	if(usr != src.pilot)
@@ -871,7 +865,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set category = "Spacepod"
 	set src = usr.loc
 
-	if(!can_use_verb())
+	if(usr.incapacitated())
 		return
 
 	if(usr != src.pilot)
@@ -888,7 +882,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set category = "Spacepod"
 	set src = usr.loc
 
-	if(!can_use_verb())
+	if(usr.incapacitated())
 		return
 
 	if(usr != src.pilot)
@@ -904,7 +898,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set category = "Spacepod"
 	set src = usr.loc
 
-	if(!can_use_verb())
+	if(usr.incapacitated())
 		return
 
 	if(usr != src.pilot)
@@ -928,7 +922,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set src = usr.loc
 	var/mob/user = usr
 
-	if(!can_use_verb())
+	if(usr.incapacitated())
 		return
 
 	to_chat(user, "<span class='notice'>You start rooting around under the seat for lost items</span>")

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -589,11 +589,21 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 			desc = "A rough looking space pod meant for industrial work"
 	update_icons()
 
+/obj/spacepod/proc/can_use_verb()
+	if(usr.incapacitated())
+		to_chat(usr, "<span class='notice'>You cannot do this while unconscious or restrained.</span>")
+		return FALSE
+	return TRUE
+
 /obj/spacepod/verb/toggle_internal_tank()
 	set name = "Toggle internal airtank usage"
 	set category = "Spacepod"
 	set src = usr.loc
 	set popup_menu = 0
+
+	if(!can_use_verb())
+		return
+
 	if(usr != src.pilot)
 		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
 		return
@@ -791,7 +801,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	if(!istype(user))
 		return
 
-	if(user.stat != CONSCIOUS || user.incapacitated()) // unconscious and restrained people can't let themselves out
+	if(!can_use_verb()) // unconscious and restrained people can't let themselves out
 		return
 
 	occupant_sanity_check()
@@ -810,6 +820,9 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set category = "Spacepod"
 	set src = usr.loc
 
+	if(!can_use_verb())
+		return
+
 	if(usr in passengers && usr != src.pilot)
 		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
 		return
@@ -822,6 +835,9 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set name = "Toggle Nearby Pod Doors"
 	set category = "Spacepod"
 	set src = usr.loc
+
+	if(!can_use_verb())
+		return
 
 	if(usr != src.pilot)
 		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
@@ -854,6 +870,10 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set desc = "Fire the weapons."
 	set category = "Spacepod"
 	set src = usr.loc
+
+	if(!can_use_verb())
+		return
+
 	if(usr != src.pilot)
 		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
 		return
@@ -867,6 +887,10 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set desc = "Unloads the cargo"
 	set category = "Spacepod"
 	set src = usr.loc
+
+	if(!can_use_verb())
+		return
+
 	if(usr != src.pilot)
 		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
 		return
@@ -879,6 +903,10 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set name = "Toggle Lights"
 	set category = "Spacepod"
 	set src = usr.loc
+
+	if(!can_use_verb())
+		return
+
 	if(usr != src.pilot)
 		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
 		return
@@ -899,6 +927,10 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 	set category = "Spacepod"
 	set src = usr.loc
 	var/mob/user = usr
+
+	if(!can_use_verb())
+		return
+
 	to_chat(user, "<span class='notice'>You start rooting around under the seat for lost items</span>")
 	if(do_after(user, 40, target = src))
 		var/obj/badlist = list(internal_tank, cargo_hold, pilot, battery) + passengers + equipment_system.installed_modules


### PR DESCRIPTION
:cl: Tayyyyyyy
fix: You can no longer use space pod verbs when restrained, dead, or otherwise incapacitated.
/:cl:

This mostly just solves niche cases where the pod pilot is going in and out of crit or passing out in the pod, but perhaps the more exploitable scenario would be where, if the pod pilot lost their key somehow and then arrested and threw someone into the pod, the person inside would be able to lock the doors. The existing code seems to intend for the passenger not to be able to lock the doors anyways, but fails in achieving this. I haven't changed this behavior. Now, no matter who you are you can't lock the doors or do anything else with the pod if you're restrained or otherwise incapacitated.

Also, it's just weird that a dead person is able to root around in the space pod.

Note: #2659 was already fixed, so someone should close that issue.