### PR TITLE
Fixes nukes

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -237,7 +237,7 @@ var/round_start_time = 0
 
 	//Plus it provides an easy way to make cinematics for other events. Just use this as a template :)
 //Plus it provides an easy way to make cinematics for other events. Just use this as a template
-/datum/controller/gameticker/proc/station_explosion_cinematic(station_missed = 0, override = null, zlev = 0)
+/datum/controller/gameticker/proc/station_explosion_cinematic(station_missed = 0, override = null, zlev = 2)
 	if(cinematic)
 		return	//already a cinematic in progress!
 

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -237,7 +237,7 @@ var/round_start_time = 0
 
 	//Plus it provides an easy way to make cinematics for other events. Just use this as a template :)
 //Plus it provides an easy way to make cinematics for other events. Just use this as a template
-/datum/controller/gameticker/proc/station_explosion_cinematic(station_missed = 0, override = null)
+/datum/controller/gameticker/proc/station_explosion_cinematic(station_missed = 0, override = null, zlev = 0)
 	if(cinematic)
 		return	//already a cinematic in progress!
 
@@ -251,24 +251,18 @@ var/round_start_time = 0
 	cinematic.screen_loc = "1,0"
 
 	var/obj/structure/stool/bed/temp_buckle = new(src)
-	if(station_missed)
-		for(var/mob/M in mob_list)
-			M.buckled = temp_buckle				//buckles the mob so it can't do anything
-			if(M.client)
-				M.client.screen += cinematic	//show every client the cinematic
-	else	//nuke kills everyone on z-level 1 to prevent "hurr-durr I survived"
-		for(var/mob/M in mob_list)
-			M.buckled = temp_buckle
-			if(M.stat != DEAD)
-				var/turf/T = get_turf(M)
-				if(T && is_station_level(T.z) && !istype(M.loc, /obj/structure/closet/secure_closet/freezer))
-					var/mob/ghost = M.ghostize()
-					M.dust() //no mercy
-					if(ghost && ghost.client) //Play the victims an uninterrupted cinematic.
-						ghost.client.screen += cinematic
-					CHECK_TICK
-			if(M && M.client) //Play the survivors a cinematic.
-				M.client.screen += cinematic
+	for(var/mob/M in mob_list)
+		M.buckled = temp_buckle
+		if(M.stat != DEAD)
+			var/turf/T = get_turf(M)
+			if(T && T.z == zlev && !istype(M.loc, /obj/structure/closet/secure_closet/freezer))
+				var/mob/ghost = M.ghostize()
+				M.dust() //no mercy
+				if(ghost && ghost.client) //Play the victims an uninterrupted cinematic.
+					ghost.client.screen += cinematic
+				CHECK_TICK
+		if(M && M.client) //Play the survivors a cinematic.
+			M.client.screen += cinematic
 
 	//Now animate the cinematic
 	switch(station_missed)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -368,7 +368,7 @@ var/bomb_set
 			if(syndie_shuttle)
 				ticker.mode:syndies_didnt_escape = is_station_level(syndie_shuttle.z)
 			ticker.mode:nuke_off_station = off_station
-		ticker.station_explosion_cinematic(off_station,null)
+		ticker.station_explosion_cinematic(off_station, null, bomb_location.z)
 		if(ticker.mode)
 			ticker.mode.explosion_in_progress = 0
 			if(ticker.mode.name == "nuclear emergency")

--- a/code/modules/admin/verbs/cinematic.dm
+++ b/code/modules/admin/verbs/cinematic.dm
@@ -14,4 +14,7 @@
 					override = input(src, "mode = ?","Enter Parameter", null) as anything in list("nuclear emergency", "fake", "no override")
 				if(0)
 					override = input(src, "mode = ?","Enter Parameter", null) as anything in list("blob", "nuclear emergency", "AI malfunction", "no override")
-			ticker.station_explosion_cinematic(parameter, override)
+			if(mob)
+				ticker.station_explosion_cinematic(parameter, override, mob.z)
+			else
+				ticker.station_explosion_cinematic(parameter, override, 0)

--- a/code/modules/admin/verbs/cinematic.dm
+++ b/code/modules/admin/verbs/cinematic.dm
@@ -14,4 +14,4 @@
 					override = input(src, "mode = ?","Enter Parameter", null) as anything in list("nuclear emergency", "fake", "no override")
 				if(0)
 					override = input(src, "mode = ?","Enter Parameter", null) as anything in list("blob", "nuclear emergency", "AI malfunction", "no override")
-			ticker.station_explosion_cinematic(parameter, override)
+			ticker.station_explosion_cinematic(parameter, override, 0)

--- a/code/modules/admin/verbs/cinematic.dm
+++ b/code/modules/admin/verbs/cinematic.dm
@@ -14,4 +14,4 @@
 					override = input(src, "mode = ?","Enter Parameter", null) as anything in list("nuclear emergency", "fake", "no override")
 				if(0)
 					override = input(src, "mode = ?","Enter Parameter", null) as anything in list("blob", "nuclear emergency", "AI malfunction", "no override")
-			ticker.station_explosion_cinematic(parameter, override, 0)
+			ticker.station_explosion_cinematic(parameter, override)


### PR DESCRIPTION
Currently, if a nuke detonates at centcom, in an awaymission, etc, it won't harm anyone. Even if you're standing right next to it. Obviously, this is silly. This PR fixes that.

🆑 Kyep
fix: Nuclear fission explosives now kill all mobs on whatever zlevel they detonate, even if they detonate at centcom, in awaymissions, etc.
/🆑