### PR TITLE
Removes a disgusting hack

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -29,13 +29,6 @@
 		if(I.stat == DEAD && is_station_level(I.z))
 			score_deadcrew++
 
-		if(I && I.mind)
-			if(I.mind.assigned_role == "Clown")
-				for(var/thing in I.attack_log)
-					if(findtext(thing, "<font color='orange'>")) //This has to be the hackiest fucking way _ever_ to see attacks.
-						score_clownabuse++
-
-
 	if(shuttle_master.emergency.mode >= SHUTTLE_ENDGAME)
 		for(var/mob/living/player in mob_list)
 			if(player.client)

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -72,6 +72,7 @@
 
 /obj/item/clothing/under/rank/clown/hit_reaction()
 	playsound(loc, 'sound/items/bikehorn.ogg', 50, 1, -1)
+	score_clownabuse++
 	return 0
 
 /obj/item/clothing/under/rank/head_of_personnel

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -72,7 +72,10 @@
 
 /obj/item/clothing/under/rank/clown/hit_reaction()
 	playsound(loc, 'sound/items/bikehorn.ogg', 50, 1, -1)
-	score_clownabuse++
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		if(H.mind && H.mind.assigned_role == "Clown")
+ 	 		score_clownabuse++
 	return 0
 
 /obj/item/clothing/under/rank/head_of_personnel

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -75,7 +75,7 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(H.mind && H.mind.assigned_role == "Clown")
- 	 		score_clownabuse++
+			score_clownabuse++
 	return 0
 
 /obj/item/clothing/under/rank/head_of_personnel


### PR DESCRIPTION
No longer at round end, will the server have to scrape through all clowns attack logs and increment... now it'll increment when the clown's get hit.

This theoretically will speed up the round-end screen / reduce the hitch that happens.

No CL as this'll effect nothing really player-side.