### PR TITLE
Ports Catsplosion from TG

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -37,6 +37,59 @@
 	icon_resting = "cat_rest"
 	gender = FEMALE
 	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
+	var/list/family = list()
+	var/lives = 9
+	var/memory_saved = 0
+
+/mob/living/simple_animal/pet/cat/Runtime/New()
+	Read_Memory()
+	..()
+
+/mob/living/simple_animal/pet/cat/Runtime/Life()
+	if(!stat && ticker.current_state == GAME_STATE_FINISHED && !memory_saved)
+		Write_Memory()
+	..()
+
+/mob/living/simple_animal/pet/cat/Runtime/death()
+	if(!memory_saved)
+		Write_Memory(1)
+	..()
+
+/mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
+	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
+	S["family"] 			>> family
+	S["lives"]				>> lives
+
+	if(isnull(family))
+		family = list()
+
+	if(isnull(lives))
+		lives = 9
+
+	if(lives <= 0)
+		lives = 10 //Lowers to 9 in Write_Memory
+		Write_Memory(1)
+		qdel(src)
+
+	for(var/cat_type in family)
+		if(family[cat_type] > 0)
+			for(var/i in 1 to family[cat_type])
+				new cat_type(loc)
+
+/mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
+	var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
+	if(dead)
+		S["lives"] 				<< lives - 1
+	family = list()
+	for(var/mob/living/simple_animal/pet/cat/C in mob_list)
+		if(istype(C,type) || C.stat || !C.butcher_results || C.name == "SyndiCat")
+			continue
+		if(C.type in family)
+			family[C.type] += 1
+		else
+			family[C.type] = 1
+	S["family"]				<< family
+	memory_saved = 1
 
 /mob/living/simple_animal/pet/cat/handle_automated_action()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -93,29 +93,29 @@
 				new cat_type(loc)
 
 
-/mob/living/simple_animal/pet/cat/Life()
-	if(!stat && !buckled && !client)
-		if(prob(1))
-			custom_emote(1, pick("stretches out for a belly rub.", "wags its tail.", "lies down."))
-			icon_state = "[icon_living]_rest"
-			resting = 1
+/mob/living/simple_animal/pet/cat/handle_automated_action()
+	..()
+	if(prob(1))
+		custom_emote(1, pick("stretches out for a belly rub.", "wags its tail.", "lies down."))
+		icon_state = "[icon_living]_rest"
+		resting = 1
+		update_canmove()
+	else if (prob(1))
+		custom_emote(1, pick("sits down.", "crouches on its hind legs.", "looks alert."))
+		icon_state = "[icon_living]_sit"
+		resting = 1
+		update_canmove()
+	else if (prob(1))
+		if (resting)
+			custom_emote(1, pick("gets up and meows.", "walks around.", "stops resting."))
+			icon_state = "[icon_living]"
+			resting = 0
 			update_canmove()
-		else if (prob(1))
-			custom_emote(1, pick("sits down.", "crouches on its hind legs.", "looks alert."))
-			icon_state = "[icon_living]_sit"
-			resting = 1
-			update_canmove()
-		else if (prob(1))
-			if (resting)
-				custom_emote(1, pick("gets up and meows.", "walks around.", "stops resting."))
-				icon_state = "[icon_living]"
-				resting = 0
-				update_canmove()
-			else
-				custom_emote(1, pick("grooms its fur.", "twitches its whiskers.", "shakes out its coat."))
+		else
+			custom_emote(1, pick("grooms its fur.", "twitches its whiskers.", "shakes out its coat."))
 
 	//MICE!
-	if((src.loc) && isturf(src.loc))
+	if(eats_mice && loc && isturf(loc) && !incapacitated())
 		if(!stat && !resting && !buckled)
 			for(var/mob/living/simple_animal/mouse/M in view(1,src))
 				if(!M.stat && Adjacent(M))
@@ -124,11 +124,10 @@
 					movement_target = null
 					stop_automated_movement = 0
 					break
-
-	..()
-
 	make_babies()
 
+/mob/living/simple_animal/pet/cat/handle_automated_movement()
+	..()
 	if(!stat && !resting && !buckled)
 		turns_since_scan++
 		if(turns_since_scan > 5)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -115,15 +115,14 @@
 			custom_emote(1, pick("grooms its fur.", "twitches its whiskers.", "shakes out its coat."))
 
 	//MICE!
-	if(eats_mice && loc && isturf(loc) && !incapacitated())
-		if(!stat && !resting && !buckled)
-			for(var/mob/living/simple_animal/mouse/M in view(1,src))
-				if(!M.stat && Adjacent(M))
-					custom_emote(1, "splats \the [M]!")
-					M.splat()
-					movement_target = null
-					stop_automated_movement = 0
-					break
+	if(eats_mice && isturf(loc) && !incapacitated())
+		for(var/mob/living/simple_animal/mouse/M in view(1,src))
+			if(!M.stat && Adjacent(M))
+				custom_emote(1, "splats \the [M]!")
+				M.splat()
+				movement_target = null
+				stop_automated_movement = 0
+				break
 	make_babies()
 
 /mob/living/simple_animal/pet/cat/handle_automated_movement()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -147,12 +147,6 @@
 				walk_to(src,movement_target,0,3)
 
 
-/mob/living/simple_animal/pet/cat/Runtime/make_babies()
-	var/mob/baby = ..()
-	if(baby)
-		children += baby
-		return baby
-
 /mob/living/simple_animal/pet/cat/Proc
 	name = "Proc"
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -592,7 +592,7 @@
 			alone = 0
 			continue
 	if(alone && partner && children < 3)
-		new childtype(loc)
+		return new childtype(loc)
 
 /mob/living/simple_animal/say_quote(var/message)
 	var/verb = "says"


### PR DESCRIPTION
[#15714](https://github.com/tgstation/tgstation/pull/15714)
- Runtime now keeps track of all cats in the world, at the start of the next round any cats that survived the previous one will spawn with Runtime in the CMO's office.  If Runtime dies, only Runtime will appear the next round.
- Cats now have additional emotes they will preform.
---------------

🆑 Alffd
Add: Ports Incoming5643's persistence features for Runtime from TG
Add: Ports additional cat NPC emotes from TG 
/🆑

