### PR TITLE
Enhances Unathi Language and Naming Conventions

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -148,7 +148,10 @@
 	colour = "soghun"
 	key = "o"
 	flags = RESTRICTED
-	syllables = list("ss","ss","ss","ss","skak","seeki","resh","las","esi","kor","sh")
+	syllables = list("za","az","ze","ez","zi","iz","zo","oz","zu","uz","zs","sz","ha","ah","he","eh","hi","ih", \
+	"ho","oh","hu","uh","hs","sh","la","al","le","el","li","il","lo","ol","lu","ul","ls","sl","ka","ak","ke","ek", \
+	"ki","ik","ko","ok","ku","uk","ks","sk","sa","as","se","es","si","is","so","os","su","us","ss","ss","ra","ar", \
+	"re","er","ri","ir","ro","or","ru","ur","rs","sr","a","a","e","e","i","i","o","o","u","u","s","s" )
 
 /datum/language/unathi/get_random_name()
 


### PR DESCRIPTION
**Port of https://github.com/PolarisSS13/Polaris/pull/1648 which was a port by ParadoxSpace of a PR originally by GinjaNinja32**

_Speech (Sinta'Unathi above GalCom)_
![unathitestspeech](https://cloud.githubusercontent.com/assets/12377767/25352070/b22d1dda-28f8-11e7-9ead-8a59e4da485b.png)

_Naming (100 names per file, 10 files in the archive)_
[1000unathinames.zip](https://github.com/ParadiseSS13/Paradise/files/952711/1000unathinames.zip)

**Syllables can be adjusted/changed as needed,** though I don't feel it necessary at all.
My personal thoughts on this are that it's just fine as-is. I really dig the majority of the names I'm seeing generated (not to mention that current Unathi names still fit in reasonably well) and hearing someone speak Sinta'Unathi feels like it's much more feasible as an actual language.
Not to mention that now Uueoa'esa and Sinta'Unathi seem like they'd be feasible words (as they very well should).