### PR TITLE
Lets you resist out of straightjackets, straightjacketed people can be handcuffed

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -527,6 +527,7 @@
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	flags_size = ONESIZEFITSALL
 	strip_delay = 60
+	breakouttime = 3000
 
 /obj/item/clothing/suit/ianshirt
 	name = "worn shirt"

--- a/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/update_icons.dm
@@ -103,8 +103,7 @@
 				t_suit = "armor"
 			standing.overlays	+= image("icon" = 'icons/effects/blood.dmi', "icon_state" = "[t_suit]blood")
 
-		if(istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
-			unEquip(handcuffed)
+		if(wear_suit.breakouttime)
 			drop_r_hand()
 			drop_l_hand()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -808,6 +808,10 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 				legcuffed = null
 				update_inv_legcuffed()
 				return
+			else
+				unEquip(I)
+				I.dropped()
+				return
 			return 1
 		else
 			to_chat(src, "<span class='warning'>You fail to remove [I]!</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1408,6 +1408,14 @@
 		if(..())
 			unEquip(I)
 
+/mob/living/carbon/human/resist_restraints()
+	if(wear_suit && wear_suit.breakouttime)
+		changeNext_move(CLICK_CD_BREAKOUT)
+		last_special = world.time + CLICK_CD_BREAKOUT
+		cuff_resist(wear_suit)
+	else
+		..()
+
 /mob/living/carbon/human/get_visible_implants(var/class = 0)
 
 	var/list/visible_implants = list()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -964,8 +964,7 @@ var/global/list/damage_icon_parts = list()
 			standing = image("icon" = 'icons/mob/suit.dmi', "icon_state" = "[wear_suit.icon_state]")
 
 
-		if( istype(wear_suit, /obj/item/clothing/suit/straight_jacket) )
-			unEquip(handcuffed)
+		if(wear_suit.breakouttime)
 			drop_l_hand()
 			drop_r_hand()
 


### PR DESCRIPTION
No more unfun. Takes 5 minutes.
If you really need to torture a player that much just use chems, or remove their eyes, or just watch your prisoners.

:cl:
tweak: You can now resist out of straightjackets
tweak: Straightjacketed people can be handcuffed
/:cl: