### PR TITLE
[s]Fixes an exotic sleeper exploit 🛌

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -78,6 +78,11 @@
 	max_chem = E * 20
 	min_health = -E * 25
 
+/obj/machinery/sleeper/Destroy()
+	for(var/mob/M in contents)
+		M.forceMove(get_turf(src))
+	return ..()
+
 /obj/machinery/sleeper/relaymove(mob/user as mob)
 	if(user.incapacitated())
 		return 0 //maybe they should be able to get out with cuffs, but whatever


### PR DESCRIPTION
:cl: Flattest
fix: Sleepers spit out their victims when deconstructed now.
/:cl:

There is a safeguard against pulling its panel open while someone is inside, but I found a way to go around it and I can imagine there's more than one way.

This is the sane way to treat the deconstruction anyway.

 