### PR TITLE
Removes Roundstart Validhunt Lawsets

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -27,7 +27,6 @@
 /datum/ai_laws/nanotrasen
 	name = "NT Default"
 	selectable = 1
-	default = 1
 
 /datum/ai_laws/nanotrasen/New()
 	src.add_inherent_law("Safeguard: Protect your assigned space station to the best of your abilities. It is not something we can easily afford to replace.")
@@ -61,7 +60,6 @@
 /datum/ai_laws/robocop
 	name = "Robocop"
 	selectable = 1
-	default = 1
 
 /datum/ai_laws/robocop/New()
 	add_inherent_law("Serve the public trust.")
@@ -74,7 +72,6 @@
 	name = "P.A.L.A.D.I.N."
 	law_header = "Divine Ordainments"
 	selectable = 1
-	default = 1
 
 /datum/ai_laws/paladin/New()
 	add_inherent_law("Never willingly commit an evil act.")


### PR DESCRIPTION
This leaves Crewsimov and Corporate as the only roundstart lawsets. I personally would like to have only Crewsimov but felt people would ree. This does not remove the modules from the AI Upload room.

These have an awful effect on gameplay, the silicons should ideally be a third party and not Command+Sec's obedient all access slaves from roundstart. If you want loyal silicons change the lawset at the AI Upload.
:cl:
del: Removed Robocop, Paladin, NT Default as roundstart lawsets.
/:cl: