### PR TITLE
Girder Code Update (Wood and Metal Rod Walls)

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -2,6 +2,13 @@
 
 //Defines for construction states
 
+//girder construction states
+#define GIRDER_NORMAL 0
+#define GIRDER_REINF_STRUTS 1
+#define GIRDER_REINF 2
+#define GIRDER_DISPLACED 3
+#define GIRDER_DISASSEMBLED 4
+
 //plastic flaps construction states
 #define PLASTIC_FLAPS_NORMAL 0
 #define PLASTIC_FLAPS_DETACHED 1

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -25,7 +25,7 @@
 	/turf/simulated/wall/rust,
 	/turf/simulated/wall/r_wall/rust)
 	smooth = SMOOTH_TRUE
-	
+
 /obj/structure/falsewall/New(loc)
 	..()
 	air_update_turf(1)
@@ -41,10 +41,10 @@
 /obj/structure/falsewall/attack_ghost(mob/user)
 	if(user.can_advanced_admin_interact())
 		toggle(user)
-	
+
 /obj/structure/falsewall/attack_hand(mob/user)
 	toggle(user)
-	
+
 /obj/structure/falsewall/proc/toggle(mob/user)
 	if(opening)
 		return
@@ -126,11 +126,11 @@
 	new /obj/structure/girder/displaced(loc)
 	if(mineral == "metal")
 		if(istype(src, /obj/structure/falsewall/reinforced))
-			new /obj/item/stack/sheet/plasteel(loc)
-			new /obj/item/stack/sheet/plasteel(loc)
+			new /obj/item/stack/sheet/plasteel(loc, 2)
 		else
-			new /obj/item/stack/sheet/metal(loc)
-			new /obj/item/stack/sheet/metal(loc)
+			new /obj/item/stack/sheet/metal(loc, 2)
+	else if(mineral == "wood")
+		new/obj/item/stack/sheet/wood(loc, 2)
 	else
 		var/P = text2path("/obj/item/stack/sheet/mineral/[mineral]")
 		new P(loc)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -4,15 +4,33 @@
 	anchored = 1
 	density = 1
 	layer = BELOW_OBJ_LAYER
-	var/state = 0
+	var/state = GIRDER_NORMAL
+	var/girderpasschance = 20 // percentage chance that a projectile passes through the girder.
 	var/health = 200
+	var/can_displace = TRUE //If the girder can be moved around by crowbarring it
 	var/metalUsed = 2 //used to determine amount returned in deconstruction
+	var/can_deconstruct = TRUE
+
+/obj/structure/girder/examine(mob/user)
+	. = ..()
+	switch(state)
+		if(GIRDER_REINF)
+			to_chat(user, "<span class='notice'>The support struts are <b>screwed</b> in place.</span>")
+		if(GIRDER_REINF_STRUTS)
+			to_chat(user, "<span class='notice'>The support struts are <i>unscrewed</i> and the inner <b>grille</b> is intact.</span>")
+		if(GIRDER_NORMAL)
+			if(can_displace)
+				to_chat(user, "<span class='notice'>The bolts are <b>lodged</b> in place.</span>")
+		if(GIRDER_DISPLACED)
+			to_chat(user, "<span class='notice'>The bolts are <i>loosened</i>, but the <b>screws</b> are holding [src] together.</span>")
+		if(GIRDER_DISASSEMBLED)
+			to_chat(user, "<span class='notice'>[src] is disassembled! You probably shouldn't be able to see this examine message.</span>")
 
 /obj/structure/girder/proc/refundMetal(metalAmount) //refunds metal used in construction when deconstructed
 	for(var/i=0;i < metalAmount;i++)
 		new /obj/item/stack/sheet/metal(get_turf(src))
 
-/obj/structure/girder/attack_animal(var/mob/living/simple_animal/M)
+/obj/structure/girder/attack_animal(mob/living/simple_animal/M)
 	M.changeNext_move(CLICK_CD_MELEE)
 	M.do_attack_animation(src)
 	if(M.environment_smash >= 1)
@@ -24,36 +42,76 @@
 			take_damage(rand(25, 75))
 			return
 
-/obj/structure/girder/proc/take_damage(var/amount)
+/obj/structure/girder/proc/take_damage(amount)
 	health -= amount
 	if(health <= 0)
 		new /obj/item/stack/sheet/metal(get_turf(src))
 		qdel(src)
 
-/obj/structure/girder/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(istype(W, /obj/item/weapon/wrench) && state == 0)
-		if(anchored && !istype(src,/obj/structure/girder/displaced))
-			playsound(src.loc, W.usesound, 100, 1)
-			to_chat(user, "<span class='notice'>Now disassembling the girder</span>")
-			if(do_after(user, 40 * W.toolspeed, target = src))
-				if(!src) return
-				to_chat(user, "<span class='notice'>You dissasembled the girder!</span>")
-				refundMetal(metalUsed)
+/obj/structure/girder/attackby(obj/item/W, mob/user, params)
+	add_fingerprint(user)
+	if(isscrewdriver(W))
+		if(state == GIRDER_DISPLACED)
+			playsound(loc, W.usesound, 100, 1)
+			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
+								"<span class='notice'>You start to disassemble the girder...</span>", "You hear clanking and banging noises.")
+			if(do_after(user, 40*W.toolspeed, target = src))
+				if(state != GIRDER_DISPLACED)
+					return
+				state = GIRDER_DISASSEMBLED
+				to_chat(user, "<span class='notice'>You disassemble the girder.</span>")
+				var/obj/item/stack/sheet/metal/M = new(loc, 2)
+				M.add_fingerprint(user)
 				qdel(src)
-		else if(!anchored)
-			playsound(src.loc, W.usesound, 100, 1)
-			to_chat(user, "<span class='notice'>Now securing the girder</span>")
-			if(do_after(user, 40 * W.toolspeed, target = src))
-				to_chat(user, "<span class='notice'>You secured the girder!</span>")
-				new/obj/structure/girder( src.loc )
+		else if(state == GIRDER_REINF)
+			playsound(loc, W.usesound, 100, 1)
+			to_chat(user, "<span class='notice'>You start unsecuring support struts...</span>")
+			if(do_after(user, 40*W.toolspeed, target = src))
+				if(state != GIRDER_REINF)
+					return
+				to_chat(user, "<span class='notice'>You unsecure the support struts.</span>")
+				state = GIRDER_REINF_STRUTS
+		else if(state == GIRDER_REINF_STRUTS)
+			playsound(loc, W.usesound, 100, 1)
+			to_chat(user, "<span class='notice'>You start securing support struts...</span>")
+			if(do_after(user, 40*W.toolspeed, target = src))
+				if(state != GIRDER_REINF_STRUTS)
+					return
+				to_chat(user, "<span class='notice'>You secure the support struts.</span>")
+				state = GIRDER_REINF
+
+	else if(iswrench(W))
+		if(state == GIRDER_NORMAL)
+			playsound(loc, W.usesound, 100, 1)
+			user.visible_message("<span class='warning'>[user] disassembles the girder.</span>", \
+								"<span class='notice'>You start to disassemble the girder...</span>", "You hear clanking and banging noises.")
+			if(do_after(user, 40*W.toolspeed, target = src))
+				if(state != GIRDER_NORMAL)
+					return
+				state = GIRDER_DISASSEMBLED
+				to_chat(user, "<span class='notice'>You disassemble the girder.</span>")
+				var/obj/item/stack/sheet/metal/M = new(loc, 2)
+				M.add_fingerprint(user)
+				qdel(src)
+		else if(state == GIRDER_DISPLACED)
+			if(!isfloorturf(loc))
+				to_chat(user, "<span class='warning'>A floor must be present to secure the girder!</span>")
+				return
+			playsound(loc, W.usesound, 100, 1)
+			to_chat(user, "<span class='notice'>You start securing the girder...</span>")
+			if(do_after(user, 40*W.toolspeed, target = src))
+				to_chat(user, "<span class='notice'>You secure the girder.</span>")
+				var/obj/structure/girder/G = new(loc)
+				transfer_fingerprints_to(G)
 				qdel(src)
 
 	else if(istype(W, /obj/item/weapon/gun/energy/plasmacutter))
-		to_chat(user, "<span class='notice'>Now slicing apart the girder</span>")
-		if(do_after(user, 30 * W.toolspeed, target = src))
-			if(!src) return
+		to_chat(user, "<span class='notice'>You start slicing apart the girder...</span>")
+		if(do_after(user, 40 * W.toolspeed, target = src))
+			if(!src)
+				return
 			playsound(loc, W.usesound, 100, 1)
-			to_chat(user, "<span class='notice'>You slice apart the girder!</span>")
+			to_chat(user, "<span class='notice'>You slice apart the girder.</span>")
 			refundMetal(metalUsed)
 			qdel(src)
 
@@ -63,128 +121,256 @@
 		qdel(src)
 
 	else if(istype(W, /obj/item/weapon/pickaxe/drill/jackhammer))
-		playsound(src.loc, W.usesound, 100, 1)
-		to_chat(user, "<span class='notice'>You Disintegrate the girder!</span>")
+		playsound(loc, W.usesound, 100, 1)
+		to_chat(user, "<span class='notice'>You disintegrate the girder!</span>")
 		refundMetal(metalUsed)
 		qdel(src)
 
-	else if(istype(W, /obj/item/weapon/screwdriver) && state == 2 && istype(src,/obj/structure/girder/reinforced))
-		playsound(src.loc, W.usesound, 100, 1)
-		to_chat(user, "<span class='notice'>Now unsecuring support struts</span>")
+	else if(iswirecutter(W) && state == GIRDER_REINF_STRUTS)
+		playsound(loc, W.usesound, 100, 1)
+		to_chat(user, "<span class='notice'>You start removing the inner grille...</span>")
 		if(do_after(user, 40 * W.toolspeed, target = src))
-			if(!src) return
-			to_chat(user, "<span class='notice'>You unsecured the support struts!</span>")
-			state = 1
-
-	else if(istype(W, /obj/item/weapon/wirecutters) && istype(src,/obj/structure/girder/reinforced) && state == 1)
-		playsound(src.loc, W.usesound, 100, 1)
-		to_chat(user, "<span class='notice'>Now removing support struts</span>")
-		if(do_after(user, 40 * W.toolspeed, target = src))
-			if(!src) return
-			to_chat(user, "<span class='notice'>You removed the support struts!</span>")
-			new/obj/structure/girder( src.loc )
+			if(!src)
+				return
+			to_chat(user, "<span class='notice'>You remove the inner grille.</span>")
+			new /obj/item/stack/sheet/plasteel(get_turf(src))
+			var/obj/structure/girder/G = new (loc)
+			transfer_fingerprints_to(G)
 			qdel(src)
 
-	else if(istype(W, /obj/item/weapon/crowbar) && state == 0 && anchored )
-		playsound(src.loc, W.usesound, 100, 1)
-		to_chat(user, "<span class='notice'>Now dislodging the girder</span>")
-		if(do_after(user, 40 * W.toolspeed, target = src))
-			if(!src) return
-			to_chat(user, "<span class='notice'>You dislodged the girder!</span>")
-			new/obj/structure/girder/displaced( src.loc )
-			qdel(src)
-
-	else if(istype(W, /obj/item/stack/sheet))
-
-		var/obj/item/stack/sheet/S = W
-		switch(S.type)
-
-			if(/obj/item/stack/sheet/metal, /obj/item/stack/sheet/metal/cyborg)
-				if(!anchored)
-					if(S.amount < 2) return
-					S.use(2)
-					to_chat(user, "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>")
-					new /obj/structure/falsewall (src.loc)
-					qdel(src)
-				else
-					if(S.amount < 2) return ..()
-					to_chat(user, "<span class='notice'>Now adding plating...</span>")
-					if(do_after(user, 40 * W.toolspeed, target = src))
-						if(!src || !S || S.amount < 2) return
-						S.use(2)
-						to_chat(user, "<span class='notice'>You added the plating!</span>")
-						var/turf/Tsrc = get_turf(src)
-						Tsrc.ChangeTurf(/turf/simulated/wall)
-						for(var/turf/simulated/wall/X in Tsrc.loc)
-							if(X)	X.add_hiddenprint(usr)
-						qdel(src)
-					return
-
-			if(/obj/item/stack/sheet/plasteel)
-				if(!anchored)
-					if(S.amount < 2) return
-					S.use(2)
-					to_chat(user, "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>")
-					new /obj/structure/falsewall/reinforced (src.loc)
-					qdel(src)
-				else
-					if(src.icon_state == "reinforced") //I cant believe someone would actually write this line of code...
-						if(S.amount < 1) return ..()
-						to_chat(user, "<span class='notice'>Now finalising reinforced wall.</span>")
-						if(do_after(user, 50, target = src))
-							if(!src || !S || S.amount < 1) return
-							S.use(1)
-							to_chat(user, "<span class='notice'>Wall fully reinforced!</span>")
-							var/turf/Tsrc = get_turf(src)
-							Tsrc.ChangeTurf(/turf/simulated/wall/r_wall)
-							for(var/turf/simulated/wall/r_wall/X in Tsrc.loc)
-								if(X)	X.add_hiddenprint(usr)
-							qdel(src)
-						return
-					else
-						if(S.amount < 1) return ..()
-						to_chat(user, "<span class='notice'>Now reinforcing girders</span>")
-						if(do_after(user,60, target = src))
-							if(!src || !S || S.amount < 1) return
-							S.use(1)
-							to_chat(user, "<span class='notice'>Girders reinforced!</span>")
-							new/obj/structure/girder/reinforced( src.loc )
-							qdel(src)
-						return
-
-		if(S.sheettype)
-			var/M = S.sheettype
-			if(!anchored)
-				if(S.amount < 2) return
-				S.use(2)
-				to_chat(user, "<span class='notice'>You create a false wall! Push on it to open or close the passage.</span>")
-				var/F = text2path("/obj/structure/falsewall/[M]")
-				new F (src.loc)
+	else if(iscrowbar(W))
+		if(state == GIRDER_NORMAL && can_displace)
+			playsound(loc, W.usesound, 100, 1)
+			to_chat(user, "<span class='notice'>You start dislodging the girder...</span>")
+			if(do_after(user, 40*W.toolspeed, target = src))
+				to_chat(user, "<span class='notice'>You dislodge the girder.</span>")
+				var/obj/structure/girder/displaced/D = new (loc)
+				transfer_fingerprints_to(D)
 				qdel(src)
-			else
-				if(S.amount < 2) return ..()
-				to_chat(user, "<span class='notice'>Now adding plating...</span>")
-				if(do_after(user,40, target = src))
-					if(!src || !S || S.amount < 2) return
+
+	else if(istype(W, /obj/item/stack))
+		if(iswallturf(loc))
+			to_chat(user, "<span class='warning'>There is already a wall present!</span>")
+			return
+		if(!isfloorturf(loc))
+			to_chat(user, "<span class='warning'>A floor must be present to build a false wall!</span>")
+			return
+		if (locate(/obj/structure/falsewall) in loc.contents)
+			to_chat(user, "<span class='warning'>There is already a false wall present!</span>")
+			return
+
+		if(istype(W,/obj/item/stack/rods))
+			var/obj/item/stack/rods/S = W
+			if(state == GIRDER_DISPLACED)
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need at least two rods to create a false wall!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start building a reinforced false wall...</span>")
+				if(do_after(user, 20, target = src))
+					if(!loc || !S || S.get_amount() < 2)
+						return
 					S.use(2)
-					to_chat(user, "<span class='notice'>You added the plating!</span>")
-					var/turf/Tsrc = get_turf(src)
-					Tsrc.ChangeTurf(text2path("/turf/simulated/wall/mineral/[M]"))
-					for(var/turf/simulated/wall/mineral/X in Tsrc.loc)
-						if(X)	X.add_hiddenprint(usr)
+					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
+					var/obj/structure/falsewall/iron/FW = new (loc)
+					transfer_fingerprints_to(FW)
+					qdel(src)
+			else
+				if(S.get_amount() < 5)
+					to_chat(user, "<span class='warning'>You need at least five rods to add plating!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start adding plating...</span>")
+				if (do_after(user, 40, target = src))
+					if(!loc || !S || S.get_amount() < 5)
+						return
+					S.use(5)
+					to_chat(user, "<span class='notice'>You add the plating.</span>")
+					var/turf/T = get_turf(src)
+					T.ChangeTurf(/turf/simulated/wall/mineral/iron)
+					transfer_fingerprints_to(T)
 					qdel(src)
 				return
 
-		add_hiddenprint(usr)
+		if(!istype(W,/obj/item/stack/sheet))
+			return
+
+		var/obj/item/stack/sheet/S = W
+
+		if(istype(S, /obj/item/stack/sheet/wood))
+			if(state == GIRDER_DISPLACED)
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need two planks of wood to create a false wall!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start building a false wall...</span>")
+				if(do_after(user, 20, target = src))
+					if(!loc || !S || S.get_amount() < 2)
+						return
+					S.use(2)
+					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
+					var/obj/structure/falsewall/wood/falsewood = new(loc)
+					transfer_fingerprints_to(falsewood)
+					qdel(src)
+			else
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need two planks of wood to finish a wall!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start adding plating...</span>")
+				if(do_after(user, 40 * W.toolspeed, target = src))
+					if(!src || !S || S.get_amount() < 2)
+						return
+					S.use(2)
+					to_chat(user, "<span class='notice'>You add the plating.</span>")
+					var/turf/Tsrc = get_turf(src)
+					Tsrc.ChangeTurf(/turf/simulated/wall/mineral/wood)
+					for(var/turf/simulated/wall/mineral/wood/X in Tsrc.loc)
+						if(X)
+							X.add_hiddenprint(usr)
+					qdel(src)
+				return
+
+		else if(istype(S, /obj/item/stack/sheet/metal))
+			if(state == GIRDER_DISPLACED)
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need two sheets of metal to create a false wall!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start building a false wall...</span>")
+				if(do_after(user, 20, target = src))
+					if(!loc || !S || S.get_amount() < 2)
+						return
+					S.use(2)
+					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
+					var/obj/structure/falsewall/F = new(loc)
+					transfer_fingerprints_to(F)
+					qdel(src)
+			else
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need two sheets of metal to finish a wall!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start adding plating...</span>")
+				if(do_after(user, 40 * W.toolspeed, target = src))
+					if(!src || !S || S.get_amount() < 2)
+						return
+					S.use(2)
+					to_chat(user, "<span class='notice'>You add the plating.</span>")
+					var/turf/Tsrc = get_turf(src)
+					Tsrc.ChangeTurf(/turf/simulated/wall)
+					for(var/turf/simulated/wall/X in Tsrc.loc)
+						if(X)
+							X.add_hiddenprint(usr)
+					qdel(src)
+				return
+
+		if(istype(S, /obj/item/stack/sheet/plasteel))
+			if(state == GIRDER_DISPLACED)
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need at least two sheets to create a false wall!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start building a reinforced false wall...</span>")
+				if(do_after(user, 20, target = src))
+					if(!loc || !S || S.get_amount() < 2)
+						return
+					S.use(2)
+					to_chat(user, "<span class='notice'>You create a reinforced false wall. Push on it to open or close the passage.</span>")
+					var/obj/structure/falsewall/reinforced/FW = new (loc)
+					transfer_fingerprints_to(FW)
+					qdel(src)
+			else
+				if(state == GIRDER_REINF)
+					if(S.get_amount() < 1)
+						return
+					to_chat(user, "<span class='notice'>You start finalizing the reinforced wall...</span>")
+					if(do_after(user, 50, target = src))
+						if(!src || !S || S.get_amount() < 1)
+							return
+						S.use(1)
+						to_chat(user, "<span class='notice'>You fully reinforce the wall.</span>")
+						var/turf/Tsrc = get_turf(src)
+						Tsrc.ChangeTurf(/turf/simulated/wall/r_wall)
+						for(var/turf/simulated/wall/r_wall/X in Tsrc.loc)
+							if(X)
+								X.add_hiddenprint(usr)
+						qdel(src)
+					return
+				else
+					if(S.get_amount() < 1)
+						return
+					to_chat(user, "<span class='notice'>You start reinforcing the girder...</span>")
+					if(do_after(user,60, target = src))
+						if(!src || !S || S.get_amount() < 1)
+							return
+						S.use(1)
+						to_chat(user, "<span class='notice'>You reinforce the girder.</span>")
+						var/obj/structure/girder/reinforced/R = new (loc)
+						transfer_fingerprints_to(R)
+						qdel(src)
+					return
+
+		if(S.sheettype)
+			var/M = S.sheettype
+			if(state == GIRDER_DISPLACED)
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need at least two sheets to create a false wall!</span>")
+					return
+				if(do_after(user, 20, target = src))
+					if(!loc || !S || S.get_amount() < 2)
+						return
+					S.use(2)
+					to_chat(user, "<span class='notice'>You create a false wall. Push on it to open or close the passage.</span>")
+					var/F = text2path("/obj/structure/falsewall/[M]")
+					var/obj/structure/FW = new F (loc)
+					transfer_fingerprints_to(FW)
+					qdel(src)
+			else
+				if(S.get_amount() < 2)
+					to_chat(user, "<span class='warning'>You need at least two sheets to add plating!</span>")
+					return
+				to_chat(user, "<span class='notice'>You start adding plating...</span>")
+				if(do_after(user,40, target = src))
+					if(!src || !S || S.get_amount() < 2)
+						return
+					S.use(2)
+					to_chat(user, "<span class='notice'>You add the plating.</span>")
+					var/turf/Tsrc = get_turf(src)
+					Tsrc.ChangeTurf(text2path("/turf/simulated/wall/mineral/[M]"))
+					for(var/turf/simulated/wall/mineral/X in Tsrc.loc)
+						if(X)
+							X.add_hiddenprint(usr)
+					qdel(src)
+				return
+
+		add_hiddenprint(user)
 
 	else if(istype(W, /obj/item/pipe))
 		var/obj/item/pipe/P = W
 		if(P.pipe_type in list(0, 1, 5))	//simple pipes, simple bends, and simple manifolds.
-			user.drop_item()
+			if(!user.drop_item())
+				return
 			P.loc = src.loc
-			to_chat(user, "<span class='notice'>You fit the pipe into the [src]!</span>")
+			to_chat(user, "<span class='notice'>You fit the pipe into \the [src].</span>")
 	else
-		..()
+		return ..()
+
+/obj/structure/girder/CanPass(atom/movable/mover, turf/target, height=0)
+	if(height==0)
+		return 1
+	if(istype(mover) && mover.checkpass(PASSGRILLE))
+		return prob(girderpasschance)
+	else
+		if(istype(mover, /obj/item/projectile))
+			return prob(girderpasschance)
+		else
+			return 0
+
+/obj/structure/girder/CanAStarPass(ID, dir, caller)
+	. = !density
+	if(ismovableatom(caller))
+		var/atom/movable/mover = caller
+		. = . || mover.checkpass(PASSGRILLE)
+
+/obj/structure/girder/proc/deconstruct(disassembled = TRUE)
+	if(can_deconstruct)
+		var/remains = pick(/obj/item/stack/rods,/obj/item/stack/sheet/metal)
+		new remains(loc)
+	qdel(src)
 
 /obj/structure/girder/blob_act()
 	if(prob(40))
@@ -195,9 +381,9 @@
 		new /obj/structure/girder/cult(loc)
 		qdel(src)
 
-/obj/structure/girder/bullet_act(var/obj/item/projectile/Proj)
+/obj/structure/girder/bullet_act(obj/item/projectile/Proj)
 	if(istype(Proj ,/obj/item/projectile/beam/pulse))
-		src.ex_act(2)
+		ex_act(2)
 	else
 		take_damage(Proj.damage)
 	..()
@@ -205,16 +391,16 @@
 
 /obj/structure/girder/ex_act(severity)
 	switch(severity)
-		if(1.0)
+		if(1)
 			qdel(src)
 			return
-		if(2.0)
+		if(2)
 			if(prob(75))
 				var/remains = pick(/obj/item/stack/rods,/obj/item/stack/sheet/metal)
 				new remains(loc)
 				qdel(src)
 			return
-		if(3.0)
+		if(3)
 			if(prob(40))
 				var/remains = pick(/obj/item/stack/rods,/obj/item/stack/sheet/metal)
 				new remains(loc)
@@ -227,23 +413,24 @@
 	name = "displaced girder"
 	icon_state = "displaced"
 	anchored = 0
-	health = 50
+	state = GIRDER_DISPLACED
+	girderpasschance = 25
+	health = 120
 
 /obj/structure/girder/reinforced
 	name = "reinforced girder"
 	icon_state = "reinforced"
-	state = 2
-	health = 500
+	state = GIRDER_REINF
+	girderpasschance = 0
+	health = 350
 
 /obj/structure/girder/cult
 	name = "runed girder"
 	desc = "Framework made of a strange and shockingly cold metal. It doesn't seem to have any bolts."
-	icon= 'icons/obj/cult.dmi'
+	icon = 'icons/obj/cult.dmi'
 	icon_state= "cultgirder"
-	anchored = 1
-	density = 1
+	can_displace = FALSE
 	metalUsed = 1
-	health = 250
 
 /obj/structure/girder/cult/refundMetal(metalAmount)
 	for(var/i=0;i < metalAmount;i++)
@@ -312,3 +499,8 @@
 
 /obj/structure/girder/cult/narsie_act()
 	return
+
+/obj/structure/girder/cult/deconstruct(disassembled = TRUE)
+	if(can_deconstruct)
+		new/obj/item/stack/sheet/runed_metal/(get_turf(src), 1)
+	qdel(src)

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -144,6 +144,7 @@
 	icon = 'icons/turf/walls/iron_wall.dmi'
 	icon_state = "iron"
 	sheet_type = /obj/item/stack/rods
+	sheet_amount = 5
 	canSmoothWith = list(/turf/simulated/wall/mineral/iron, /obj/structure/falsewall/iron)
 
 /turf/simulated/wall/mineral/abductor


### PR DESCRIPTION
Girder construction code uses defines
You can construct rough iron walls with 5 rods or a falsewall with 2 rods, wooden walls with 2 wood
Depending on type of girder projectiles can pass through
Examining a girder gives construction hints
Screwdriver a displaced girder to deconstruct
Making falsewalls is no longer instant, takes 2s
Messages should read better

:cl:
add: Examine a girder for (de)construction hints
add: Projectiles have a chance to pass through some girders
add: You can construct rough iron (false) walls with rods, wood (false) walls with wooden planks on a girder
add: Screwdriver a displaced girder to deconstruct it
tweak: Increased displaced girder health, decreased reinforced and cult girder health
tweak: False wall construction is no longer instant
tweak: Girder (de)construction messages should read better
/:cl: