### PR TITLE
[DNM] Janitor can now access medical

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -304,8 +304,8 @@
 	is_service = 1
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
-	access = list(access_janitor, access_maint_tunnels)
-	minimal_access = list(access_janitor, access_maint_tunnels)
+	access = list(access_janitor, access_medical, access_maint_tunnels)
+	minimal_access = list(access_janitor, access_medical, access_maint_tunnels)
 	alt_titles = list("Custodial Technician")
 	outfit = /datum/outfit/job/janitor
 


### PR DESCRIPTION
Medbay's a mess. Time to clean it up. Gave janitor access to main medical only.

Reasoning:
- I hate playing janitor.
- I love playing janiborg.
- I can clean the bloodiest place on the station without beating my face against the door trying to get in. Thus, making me like janitor quite a bit more.
- Closes the gap a little bit on janitor and janiborg.
- Surgery changes and infection changes means its more important to keep the place clean, and I think the janitor having an easier time getting into medbay means the surgeons can see the janitor more easily, but still be able to decide if he should be let into the ORs.
- Mildly buffs janitor antags.

We'll see how much this helps. I'm sticking in line with my philosophy of small changes at a time, we'll see how much this benefits.

This goes not grant access to anywhere except main medbay only. Surgery, cloning, chemistry, virology, these are all still off limits, as they should be. Nor does it give access to any of the other departments, mainly because its either rare for bloody messes, or it needs to remain controlled access (security).

EDIT: realized there's a lot of issues giving janitor medical level access. Too many. Will varedit and mapmerge the doors instead in the next couple days.