### PR TITLE
Hide sling announcements from lobby

### DIFF
--- a/code/game/gamemodes/shadowling/ascendant_shadowling.dm
+++ b/code/game/gamemodes/shadowling/ascendant_shadowling.dm
@@ -40,3 +40,11 @@
 
 /mob/living/simple_animal/ascendant_shadowling/singularity_act()
 	return 0 //Well hi, fellow god! How are you today?
+
+/mob/living/simple_animal/ascendant_shadowling/proc/announce(var/text, var/size = 4, var/new_sound = null)
+	var/message = "<font size=[size]><span class='shadowling'><b>\"[text]\"</font></span>"
+	for(var/mob/M in player_list)
+		if(!isnewplayer(M) && M.client)
+			to_chat(M, message)
+			if(new_sound)
+				M << new_sound

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -867,8 +867,8 @@
 	action_icon_state = "transmit"
 
 /obj/effect/proc_holder/spell/targeted/shadowlingAscendantTransmit/cast(list/targets, mob/user = usr)
-	for(var/mob/living/target in targets)
+	for(var/mob/living/simple_animal/ascendant_shadowling/target in targets)
 		var/text = stripped_input(target, "What do you want to say to everything on and near [station_name()]?.", "Transmit to World", "")
 		if(!text)
 			return
-		to_chat(world, "<font size=4><span class='shadowling'><b>\"[text]\"</font></span>")
+		target.announce(text)

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -155,11 +155,10 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				for(var/mob/living/M in orange(7, H))
 					M.Weaken(10)
 					to_chat(M, "<span class='userdanger'>An immense pressure slams you onto the ground!</span>")
-				to_chat(world, "<font size=5><span class='shadowling'><b>\"VYSHA NERADA YEKHEZET U'RUU!!\"</font></span>")
-				world << 'sound/hallucinations/veryfar_noise.ogg'
 				for(var/obj/machinery/power/apc/A in apcs)
 					A.overload_lighting()
-				var/mob/A = new /mob/living/simple_animal/ascendant_shadowling(H.loc)
+				var/mob/living/simple_animal/ascendant_shadowling/A = new /mob/living/simple_animal/ascendant_shadowling(H.loc)
+				A.announce("VYSHA NERADA YEKHEZET U'RUU!!", 5, 'sound/hallucinations/veryfar_noise.ogg')
 				for(var/obj/effect/proc_holder/spell/S in H.mind.spell_list)
 					if(S == src) continue
 					H.mind.RemoveSpell(S)


### PR DESCRIPTION
Removes the chatting to world stuff for both ascendancy and ascendant transmit, and replaces it with a shadowling ascendant proc.