### PR TITLE
Refactors "organs" to be "bodyparts" to end confusion once and for all

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -639,5 +639,4 @@ proc/dd_sortedObjectList(list/incoming)
 #define LAZYCLEARLIST(L) if(L) L.Cut()
 
 // LAZYING PT 2: THE LAZENING
-#define LAZYREINITLIST(L) LAZYCLEARLIST(L); LAZYINITLIST(L)
-#define LAZYQDELLIST(L) if(L) for(var/o in L) { qdel(o); L.Cut() }
+#define LAZYREINITLIST(L) LAZYCLEARLIST(L); LAZYINITLIST(L);

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -78,8 +78,8 @@
 	for (var/thing in atoms)
 		var/atom/A = thing
 		if(typecache[A.type])
-			. += A	
-	
+			. += A
+
 //Like typesof() or subtypesof(), but returns a typecache instead of a list
 /proc/typecacheof(path, ignore_root_path)
 	if(ispath(path))
@@ -625,7 +625,7 @@ proc/dd_sortedObjectList(list/incoming)
 
 /datum/alarm/dd_SortValue()
 	return "[sanitize(last_name)]"
-	
+
 //Picks from the list, with some safeties, and returns the "default" arg if it fails
 #define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
 
@@ -637,3 +637,7 @@ proc/dd_sortedObjectList(list/incoming)
 #define LAZYACCESS(L, I) (L ? (isnum(I) ? (I > 0 && I <= L.len ? L[I] : null) : L[I]) : null)
 #define LAZYLEN(L) length(L)
 #define LAZYCLEARLIST(L) if(L) L.Cut()
+
+// LAZYING PT 2: THE LAZENING
+#define LAZYREINITLIST(L) LAZYCLEARLIST(L); LAZYINITLIST(L)
+#define LAZYQDELLIST(L) if(L) for(var/o in L) { qdel(o); L.Cut() }

--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -1,2 +1,5 @@
 #define QDEL_IN(item, time) addtimer(GLOBAL_PROC, "qdel", time, FALSE, item)
 #define QDEL_NULL(item) if(item) { qdel(item); item = null }
+#define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L.Cut(); }
+#define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } L.Cut(); }
+#define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qel(L[I]); L.Cut(); }

--- a/code/datums/cargoprofile.dm
+++ b/code/datums/cargoprofile.dm
@@ -654,7 +654,7 @@
 		var/bruteloss = M.bruteloss
 		if(istype(M,/mob/living/carbon/human))
 			var/mob/living/carbon/human/C = M
-			for(var/obj/item/organ/external/L in C.organs)
+			for(var/obj/item/organ/external/L in C.bodyparts)
 				bruteloss += L.brute_dam
 		if(bruteloss < 100) // requires tenderization
 			M.apply_damage(rand(5,15),BRUTE)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -372,7 +372,7 @@ var/record_id_num = 1001
 		temp = new/icon("icon" = 'icons/effects/species.dmi', "icon_state" = "[H.tail]_s")
 		preview_icon.Blend(temp, ICON_OVERLAY)
 
-	for(var/obj/item/organ/external/E in H.organs)
+	for(var/obj/item/organ/external/E in H.bodyparts)
 		preview_icon.Blend(E.get_icon(), ICON_OVERLAY)
 
 	// Skin tone

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -164,7 +164,7 @@ var/list/diseases = subtypesof(/datum/disease)
 		if(ishuman(affected_mob))
 			var/mob/living/carbon/human/H = affected_mob
 			for(var/obj/item/organ/O in required_organs)
-				if(!locate(O) in H.organs)
+				if(!locate(O) in H.bodyparts)
 					if(!locate(O) in H.internal_organs)
 						cure()
 						return

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1171,7 +1171,7 @@
 				if(ishuman(current))
 					var/mob/living/carbon/human/H = current
 					// Don't "undress" organs right out of the body
-					for(var/obj/item/W in H.contents - (H.organs | H.internal_organs))
+					for(var/obj/item/W in H.contents - (H.bodyparts | H.internal_organs))
 						current.unEquip(W, 1)
 				else
 					for(var/obj/item/W in current)

--- a/code/datums/spells/rathens.dm
+++ b/code/datums/spells/rathens.dm
@@ -33,7 +33,7 @@
 			H.apply_damage(10, BRUTE, "chest")
 			to_chat(H, "<span class='userdanger'>You have no appendix, but something had to give! Holy shit, what was that?</span>")
 			H.Weaken(3)
-			for(var/obj/item/organ/external/E in H.organs)
+			for(var/obj/item/organ/external/E in H.bodyparts)
 				if(istype(E, /obj/item/organ/external/head))
 					continue
 				if(istype(E, /obj/item/organ/external/chest))
@@ -43,5 +43,3 @@
 				if(prob(7))
 					to_chat(H, "<span class='userdanger'>Your [E] was severed by the explosion!</span>")
 					E.droplimb(1, DROPLIMB_EDGE, 0, 1)
-
-

--- a/code/datums/spells/summonitem.dm
+++ b/code/datums/spells/summonitem.dm
@@ -70,8 +70,8 @@
 
 					if(ishuman(M)) //Edge case housekeeping
 						var/mob/living/carbon/human/C = M
-						/*if(C.internal_organs_by_name  && item_to_retrive in C.internal_organs_by_name ) //This won't work, as we use organ datums instead of objects. --DZD
-							C.internal_organs_by_name  -= item_to_retrive
+						/*if(C.internal_bodyparts_by_name  && item_to_retrive in C.internal_bodyparts_by_name ) //This won't work, as we use organ datums instead of objects. --DZD
+							C.internal_bodyparts_by_name  -= item_to_retrive
 							if(istype(marked_item, /obj/item/brain)) //If this code ever runs I will be happy
 								var/obj/item/brain/B = new /obj/item/brain(target.loc)
 								B.transfer_identity(C)

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -263,11 +263,11 @@
 /obj/effect/proc_holder/spell/targeted/eat/proc/doHeal(var/mob/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		for(var/name in H.organs_by_name)
+		for(var/name in H.bodyparts_by_name)
 			var/obj/item/organ/external/affecting = null
-			if(!H.organs[name])
+			if(!H.bodyparts_by_name[name])
 				continue
-			affecting = H.organs[name]
+			affecting = H.bodyparts_by_name[name]
 			if(!istype(affecting, /obj/item/organ/external))
 				continue
 			affecting.heal_damage(4, 0)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -35,8 +35,8 @@
 		H.species.create_organs(H)
 		// Now that recreating all organs is necessary, the rest of this organ stuff probably
 		//  isn't, but I don't want to remove it, just in case.
-		for(var/organ_name in H.organs_by_name)
-			var/obj/item/organ/external/O = H.organs_by_name[organ_name]
+		for(var/organ_name in H.bodyparts_by_name)
+			var/obj/item/organ/external/O = H.bodyparts_by_name[organ_name]
 			if(!O) continue
 			for(var/obj/item/weapon/shard/shrapnel/s in O.implants)
 				if(istype(s))

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -121,7 +121,7 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	vox.update_dna()
 	vox.update_eyes()
 
-	for(var/obj/item/organ/external/limb in vox.organs)
+	for(var/obj/item/organ/external/limb in vox.bodyparts)
 		limb.status &= ~(ORGAN_DESTROYED | ORGAN_ROBOT)
 
 	//Now apply cortical stack.

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -28,7 +28,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H.visible_message("<span class='warning'>[H]'s things suddenly slip off. They hunch over and vomit up a copious amount of purple goo which begins to shape around them!</span>", \
 									"<span class='shadowling'>You remove any equipment which would hinder your hatching and begin regurgitating the resin which will protect you.</span>")
 
-				for(var/obj/item/I in H.contents - (H.organs | H.internal_organs)) //drops all items except organs
+				for(var/obj/item/I in H.contents - (H.bodyparts | H.internal_organs)) //drops all items except organs
 					H.unEquip(I)
 
 				sleep(50)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -464,7 +464,7 @@ var/global/list/multiverse = list()
 
 			if("cyborg")
 				if(M.get_species() != "Machine")
-					for(var/obj/item/organ/O in M.organs)
+					for(var/obj/item/organ/O in M.bodyparts)
 						O.robotize()
 				M.equip_to_slot_or_del(new /obj/item/clothing/glasses/thermal/eyepatch(M), slot_glasses)
 				M.equip_to_slot_or_del(sword, slot_r_hand)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -385,7 +385,7 @@
 		occupantData["implant_len"] = implantData.len
 
 		var/extOrganData[0]
-		for(var/obj/item/organ/external/E in H.organs)
+		for(var/obj/item/organ/external/E in H.bodyparts)
 			var/organData[0]
 			organData["name"] = E.name
 			organData["open"] = E.open
@@ -562,7 +562,7 @@
 			dat += "<th>Other Wounds</th>"
 			dat += "</tr>"
 
-			for(var/obj/item/organ/external/e in occupant.organs)
+			for(var/obj/item/organ/external/e in occupant.bodyparts)
 				dat += "<tr>"
 				var/AN = ""
 				var/open = ""

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -186,9 +186,9 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	if(!user) return 0
 	if(hasorgans(user))
 		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
+		var/obj/item/organ/external/temp = H.bodyparts_by_name["r_hand"]
 		if(user.hand)
-			temp = H.organs_by_name["l_hand"]
+			temp = H.bodyparts_by_name["l_hand"]
 		if(!temp)
 			to_chat(user, "<span class='warning'>You try to use your hand, but it's missing!</span>")
 			return 0
@@ -469,7 +469,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	if(istype(H))
 		var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)
 		if(!eyes) // should still get stabbed in the head
-			var/obj/item/organ/external/head/head = H.organs_by_name["head"]
+			var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
 			head.take_damage(rand(10,14), 1)
 			return
 		eyes.take_damage(rand(3,4), 1)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -204,8 +204,8 @@ REAGENT SCANNER
 		user.show_message("<span class='warning'>Significant brain damage detected. Subject may have had a concussion.</span>")
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		for(var/name in H.organs_by_name)
-			var/obj/item/organ/external/e = H.organs_by_name[name]
+		for(var/name in H.bodyparts_by_name)
+			var/obj/item/organ/external/e = H.bodyparts_by_name[name]
 			if(!e)
 				continue
 			var/limb = e.name
@@ -215,14 +215,14 @@ REAGENT SCANNER
 			if(e.has_infected_wound())
 				user.show_message("<span class='warning'>Infected wound detected in subject [limb]. Disinfection recommended.</span>")
 
-		for(var/name in H.organs_by_name)
-			var/obj/item/organ/external/e = H.organs_by_name[name]
+		for(var/name in H.bodyparts_by_name)
+			var/obj/item/organ/external/e = H.bodyparts_by_name[name]
 			if(!e)
 				continue
 			if(e.status & ORGAN_BROKEN)
 				user.show_message(text("<span class='warning'>Bone fractures detected. Advanced scanner required for location.</span>"), 1)
 				break
-		for(var/obj/item/organ/external/e in H.organs)
+		for(var/obj/item/organ/external/e in H.bodyparts)
 			for(var/datum/wound/W in e.wounds) if(W.internal)
 				user.show_message(text("<span class='warning'>Internal bleeding detected. Advanced scanner required for location.</span>"), 1)
 				break

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -393,7 +393,7 @@
 						M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 						playsound(get_turf(src), "bodyfall", 50, 1)
 						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-						for(var/obj/item/organ/external/O in H.organs)
+						for(var/obj/item/organ/external/O in H.bodyparts)
 							total_brute	+= O.brute_dam
 							total_burn	+= O.burn_dam
 						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations) && (H.get_int_organ(/obj/item/organ/internal/heart) || H.get_int_organ(/obj/item/organ/internal/brain/slime)))
@@ -515,7 +515,7 @@
 						M.visible_message("<span class='warning'>[M]'s body convulses a bit.")
 						playsound(get_turf(src), "bodyfall", 50, 1)
 						playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-						for(var/obj/item/organ/external/O in H.organs)
+						for(var/obj/item/organ/external/O in H.bodyparts)
 							total_brute	+= O.brute_dam
 							total_burn	+= O.burn_dam
 						if(total_burn <= 180 && total_brute <= 180 && !H.suiciding && !ghost && tplus < tlimit && !(NOCLONE in H.mutations))

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -32,7 +32,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/heal_amt = 10
-		for(var/obj/item/organ/external/affecting in H.organs)
+		for(var/obj/item/organ/external/affecting in H.bodyparts)
 			if(affecting.heal_damage(heal_amt, heal_amt))
 				H.UpdateDamageIcon()
 	return

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -289,7 +289,7 @@
 	playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/head/head = H.organs_by_name["head"]
+		var/obj/item/organ/external/head/head = H.bodyparts_by_name["head"]
 		if(head)
 			head.droplimb(0, DROPLIMB_BLUNT, FALSE, TRUE)
 			playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
@@ -400,7 +400,7 @@
 /obj/item/weapon/weldingtool/attack(mob/M, mob/user)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
+		var/obj/item/organ/external/S = H.bodyparts_by_name[user.zone_sel.selecting]
 		if(!S)
 			return
 

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -33,9 +33,9 @@
 		return
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
+		var/obj/item/organ/external/temp = H.bodyparts_by_name["r_hand"]
 		if(user.hand)
-			temp = H.organs_by_name["l_hand"]
+			temp = H.bodyparts_by_name["l_hand"]
 		if(temp && !temp.is_usable())
 			to_chat(user, "<span class='notice'>You try to move your [temp.name], but cannot!")
 			return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -392,9 +392,9 @@
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
+		var/obj/item/organ/external/temp = H.bodyparts_by_name["r_hand"]
 		if(user.hand)
-			temp = H.organs_by_name["l_hand"]
+			temp = H.bodyparts_by_name["l_hand"]
 		if(temp && !temp.is_usable())
 			to_chat(user, "<span class='notice'>You try to move your [temp.name], but cannot!")
 			return

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -480,7 +480,7 @@ client/proc/one_click_antag()
 	new_vox.update_dna()
 	new_vox.update_eyes()
 
-	for(var/obj/item/organ/external/limb in new_vox.organs)
+	for(var/obj/item/organ/external/limb in new_vox.bodyparts)
 		limb.status &= ~(ORGAN_DESTROYED | ORGAN_ROBOT)
 
 	//Now apply cortical stack.

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2104,15 +2104,10 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	for(var/name in organ_data)
 
 		var/status = organ_data[name]
-		var/obj/item/organ/external/O = character.organs_by_name[name]
+		var/obj/item/organ/external/O = character.bodyparts_by_name[name]
 		if(O)
 			if(status == "amputated")
-				character.organs_by_name[O.limb_name] = null
-				character.organs -= O
-				if(O.children) // This might need to become recursive.
-					for(var/obj/item/organ/external/child in O.children)
-						character.organs_by_name[child.limb_name] = null
-						character.organs -= child
+				O.remove(character)
 
 			else if(status == "cyborg")
 				if(rlimb_data[name])

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2107,7 +2107,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 		var/obj/item/organ/external/O = character.bodyparts_by_name[name]
 		if(O)
 			if(status == "amputated")
-				O.remove(character)
+				qdel(O.remove(character))
 
 			else if(status == "cyborg")
 				if(rlimb_data[name])

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -219,7 +219,7 @@
 				"<span class='notice'>You check yourself for injuries.</span>" \
 				)
 
-			for(var/obj/item/organ/external/org in H.organs)
+			for(var/obj/item/organ/external/org in H.bodyparts)
 				var/status = ""
 				var/brutedamage = org.brute_dam
 				var/burndamage = org.burn_dam

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -15,7 +15,7 @@
 	return 1
 
 /mob/living/carbon/human/proc/change_gender(var/new_gender, var/update_dna = 1)
-	var/obj/item/organ/external/head/H = organs_by_name["head"]
+	var/obj/item/organ/external/head/H = bodyparts_by_name["head"]
 	if(gender == new_gender || (gender == PLURAL && species.has_gender))
 		return
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -22,7 +22,7 @@
 			spawn()
 				thing.throw_at(get_edge_target_turf(src,pick(alldirs)),rand(1,3),5)
 
-	for(var/obj/item/organ/external/E in src.organs)
+	for(var/obj/item/organ/external/E in bodyparts)
 		if(istype(E, /obj/item/organ/external/chest))
 			continue
 		// Only make the limb drop if it's not too damaged
@@ -177,7 +177,7 @@
 	return
 
 /mob/living/carbon/human/proc/ChangeToHusk()
-	var/obj/item/organ/external/head/H = organs_by_name["head"]
+	var/obj/item/organ/external/head/H = bodyparts_by_name["head"]
 	if(HUSK in mutations)	return
 
 	if(istype(H))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -45,7 +45,7 @@
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm'
 				found_slime_bodypart = 1
 			else
-				for(var/obj/item/organ/external/L in organs) // if your limbs are squishy you can squish too!
+				for(var/obj/item/organ/external/L in bodyparts) // if your limbs are squishy you can squish too!
 					if(L.dna.species in list("Slime People"))
 						on_CD = handle_emote_CD()
 						found_slime_bodypart = 1

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -295,7 +295,7 @@
 		var/organ_descriptor = organ_data["descriptor"]
 		is_destroyed["[organ_data["descriptor"]]"] = 1
 
-		var/obj/item/organ/external/E = organs_by_name[organ_tag]
+		var/obj/item/organ/external/E = bodyparts_by_name[organ_tag]
 		if(!E)
 			wound_flavor_text["[organ_tag]"] = "<span class='warning'><b>[t_He] [t_is] missing [t_his] [organ_descriptor].</b></span>\n"
 		else if(E.is_stump())
@@ -303,7 +303,7 @@
 		else
 			continue
 
-	for(var/obj/item/organ/external/temp in organs)
+	for(var/obj/item/organ/external/temp in bodyparts)
 		if(temp && !temp.is_stump())
 			if(temp.status & ORGAN_ROBOT)
 				if(!(temp.brute_dam + temp.burn_dam))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -65,9 +65,7 @@
 	add_to_all_human_data_huds()
 
 /mob/living/carbon/human/Destroy()
-	for(var/atom/movable/organelle in bodyparts)
-		qdel(organelle)
-	bodyparts.Cut()
+	QDEL_LIST(bodyparts)
 	return ..()
 
 /mob/living/carbon/human/dummy

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -65,9 +65,9 @@
 	add_to_all_human_data_huds()
 
 /mob/living/carbon/human/Destroy()
-	for(var/atom/movable/organelle in organs)
+	for(var/atom/movable/organelle in bodyparts)
 		qdel(organelle)
-	organs = list()
+	bodyparts.Cut()
 	return ..()
 
 /mob/living/carbon/human/dummy
@@ -310,7 +310,7 @@
 
 				var/limbs_affected = pick(2,3,4)
 				var/obj/item/organ/external/processing_dismember
-				var/list/valid_limbs = organs.Copy()
+				var/list/valid_limbs = bodyparts.Copy()
 
 				while(limbs_affected != 0 && valid_limbs.len > 0)
 					processing_dismember = pick(valid_limbs)
@@ -328,7 +328,7 @@
 
 			var/limbs_affected = 0
 			var/obj/item/organ/external/processing_dismember
-			var/list/valid_limbs = organs.Copy()
+			var/list/valid_limbs = bodyparts.Copy()
 
 			if(prob(getarmor(null, "bomb")))
 				b_loss = b_loss/1.5
@@ -361,7 +361,7 @@
 
 				var/limbs_affected = pick(0, 1)
 				var/obj/item/organ/external/processing_dismember
-				var/list/valid_limbs = organs.Copy()
+				var/list/valid_limbs = bodyparts.Copy()
 
 				while(limbs_affected != 0 && valid_limbs.len > 0)
 					processing_dismember = pick(valid_limbs)
@@ -1263,20 +1263,20 @@
 		if(istype(organ, /obj/item/organ/external/stump)) //Get rid of all stumps.
 			qdel(organ)
 			H.contents -= organ //Making sure the list entry is removed.
-	for(var/obj/item/organ/organ in H.organs)
+	for(var/obj/item/organ/organ in H.bodyparts)
 		if(istype(organ, /obj/item/organ/external/stump))
 			qdel(organ)
-			H.organs -= organ //Making sure the list entry is removed.
-	for(var/organ_name in H.organs_by_name)
-		var/obj/item/organ/organ = H.organs_by_name[organ_name]
+			H.bodyparts -= organ //Making sure the list entry is removed.
+	for(var/organ_name in H.bodyparts_by_name)
+		var/obj/item/organ/organ = H.bodyparts_by_name[organ_name]
 		if(istype(organ, /obj/item/organ/external/stump) || !organ) //The !organ check is to account for mechanical limb (prostheses) losses, since those are handled in a way that leaves indexed but null list entries instead of stumps.
 			qdel(organ)
-			H.organs_by_name -= organ_name //Making sure the list entry is removed.
+			H.bodyparts_by_name -= organ_name //Making sure the list entry is removed.
 
 	//Replacing lost limbs with the species default.
 	var/mob/living/carbon/human/temp_holder
 	for(var/limb_type in H.species.has_limbs)
-		if(!(limb_type in H.organs_by_name))
+		if(!(limb_type in H.bodyparts_by_name))
 			var/list/organ_data = H.species.has_limbs[limb_type]
 			var/limb_path = organ_data["path"]
 			var/obj/item/organ/external/O = new limb_path(temp_holder)
@@ -1286,7 +1286,7 @@
 			else
 				O = new limb_path(H) //Create the limb on the player.
 				O.owner = H
-				H.organs |= H.organs_by_name[O.limb_name]
+				H.bodyparts |= H.bodyparts_by_name[O.limb_name]
 
 	//Replacing lost organs with the species default.
 	temp_holder = new /mob/living/carbon/human()
@@ -1411,7 +1411,7 @@
 /mob/living/carbon/human/get_visible_implants(var/class = 0)
 
 	var/list/visible_implants = list()
-	for(var/obj/item/organ/external/organ in src.organs)
+	for(var/obj/item/organ/external/organ in bodyparts)
 		for(var/obj/item/weapon/O in organ.implants)
 			if(!istype(O,/obj/item/weapon/implant) && (O.w_class > class) && !istype(O,/obj/item/weapon/shard/shrapnel))
 				visible_implants += O
@@ -1427,7 +1427,7 @@
 
 /mob/living/carbon/human/proc/handle_embedded_objects()
 
-	for(var/obj/item/organ/external/organ in src.organs)
+	for(var/obj/item/organ/external/organ in bodyparts)
 		if(organ.status & ORGAN_SPLINTED) //Splints prevent movement.
 			continue
 		for(var/obj/item/weapon/O in organ.implants)
@@ -2052,7 +2052,7 @@
 	return .
 
 /mob/living/carbon/human/proc/change_icobase(var/new_icobase, var/new_deform, var/owner_sensitive)
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		O.change_organ_icobase(new_icobase, new_deform, owner_sensitive) //Change the icobase/deform of all our organs. If owner_sensitive is set, that means the proc won't mess with frankenstein limbs.
 
 /mob/living/carbon/human/serialize()
@@ -2074,8 +2074,8 @@
 	data["uwear"] = underwear
 
 	// Limbs
-	for(var/limb in organs_by_name)
-		var/obj/item/organ/O = organs_by_name[limb]
+	for(var/limb in bodyparts_by_name)
+		var/obj/item/organ/O = bodyparts_by_name[limb]
 		if(!O)
 			limbs_list[limb] = "missing"
 			continue
@@ -2116,7 +2116,7 @@
 	for(var/obj/item/organ/internal/iorgan in internal_organs)
 		qdel(iorgan)
 
-	for(var/obj/item/organ/external/organ in organs)
+	for(var/obj/item/organ/external/organ in bodyparts)
 		qdel(organ)
 
 	for(var/limb in limbs_list)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -9,9 +9,9 @@
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))
-		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
+		var/obj/item/organ/external/temp = H.bodyparts_by_name["r_hand"]
 		if(H.hand)
-			temp = H.organs_by_name["l_hand"]
+			temp = H.bodyparts_by_name["l_hand"]
 		if(!temp || !temp.is_usable())
 			to_chat(H, "<span class='warning'>You can't use your hand.</span>")
 			return

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -8,7 +8,7 @@
 	var/total_burn  = 0
 	var/total_brute = 0
 
-	for(var/obj/item/organ/external/O in organs)	//hardcoded to streamline things a bit
+	for(var/obj/item/organ/external/O in bodyparts)	//hardcoded to streamline things a bit
 		total_brute += O.brute_dam //calculates health based on organ brute and burn
 		total_burn += O.burn_dam
 
@@ -77,13 +77,13 @@
 //These procs fetch a cumulative total damage from all organs
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		amount += O.brute_dam
 	return amount
 
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		amount += O.burn_dam
 	return amount
 
@@ -108,7 +108,7 @@
 	if(species)
 		amount = amount * species.brute_mod
 
-	if(organ_name in organs_by_name)
+	if(organ_name in bodyparts_by_name)
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
@@ -122,7 +122,7 @@
 	if(species)
 		amount = amount * species.burn_mod
 
-	if(organ_name in organs_by_name)
+	if(organ_name in bodyparts_by_name)
 		var/obj/item/organ/external/O = get_organ(organ_name)
 
 		if(amount > 0)
@@ -148,7 +148,7 @@
 	if(amount > 0) //cloneloss is being added
 		if(prob(mut_prob))
 			var/list/obj/item/organ/external/candidates = list() //TYPECASTED LISTS ARE NOT A FUCKING THING WHAT THE FUCK
-			for(var/obj/item/organ/external/O in organs)
+			for(var/obj/item/organ/external/O in bodyparts)
 				if(O.status & ORGAN_ROBOT)
 					continue
 				if(!(O.status & ORGAN_MUTATED))
@@ -163,7 +163,7 @@
 
 	else //cloneloss is being subtracted
 		if(prob(heal_prob))
-			for(var/obj/item/organ/external/O in organs)
+			for(var/obj/item/organ/external/O in bodyparts)
 				if(O.status & ORGAN_MUTATED)
 					O.unmutate()
 					to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
@@ -171,7 +171,7 @@
 
 
 	if(getCloneLoss() < 1) //no cloneloss, fixes organs
-		for(var/obj/item/organ/external/O in organs)
+		for(var/obj/item/organ/external/O in bodyparts)
 			if(O.status & ORGAN_MUTATED)
 				O.unmutate()
 				to_chat(src, "<span class='notice'>Your [O.name] is shaped normally again.</span>")
@@ -203,7 +203,7 @@
 //Returns a list of damaged organs
 /mob/living/carbon/human/proc/get_damaged_organs(brute, burn, flags = AFFECT_ALL_ORGANS)
 	var/list/obj/item/organ/external/parts = list()
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		if((brute && O.brute_dam) || (burn && O.burn_dam))
 			if(!(flags & AFFECT_ROBOTIC_ORGAN) && O.status & ORGAN_ROBOT)
 				continue
@@ -215,7 +215,7 @@
 //Returns a list of damageable organs
 /mob/living/carbon/human/proc/get_damageable_organs()
 	var/list/obj/item/organ/external/parts = list()
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		if(O.brute_dam + O.burn_dam < O.max_damage)
 			parts += O
 	return parts
@@ -313,7 +313,7 @@ This function restores the subjects blood to max.
 This function restores all organs.
 */
 /mob/living/carbon/human/restore_all_organs()
-	for(var/obj/item/organ/external/current_organ in organs)
+	for(var/obj/item/organ/external/current_organ in bodyparts)
 		current_organ.rejuvenate()
 
 /mob/living/carbon/human/proc/HealDamage(zone, brute, burn)
@@ -331,7 +331,7 @@ This function restores all organs.
 	if(zone in list("eyes", "mouth"))
 		zone = "head"
 
-	return organs_by_name[zone]
+	return bodyparts_by_name[zone]
 
 /mob/living/carbon/human/apply_damage(damage = 0, damagetype = BRUTE, def_zone = null, blocked = 0, sharp = 0, edge = 0, obj/used_weapon = null)
 	//Handle other types of damage

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -83,7 +83,7 @@ emp_act
 		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.
 
 	//If you don't specify a bodypart, it checks ALL your bodyparts for protection, and averages out the values
-	for(var/obj/item/organ/external/organ in organs)
+	for(var/obj/item/organ/external/organ in bodyparts)
 		armorval += getarmor_organ(organ, type)
 		organnum++
 
@@ -100,8 +100,8 @@ emp_act
 		if(bp && istype(bp ,/obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(C.body_parts_covered & def_zone.body_part)
-				protection += C.armor[type]	
-				
+				protection += C.armor[type]
+
 	return protection
 
 //this proc returns the Siemens coefficient of electrical resistivity for a particular external organ.

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -4,8 +4,8 @@
 		eyes.update_colour()
 		update_body()
 
-/mob/living/carbon/human/var/list/organs = list()
-/mob/living/carbon/human/var/list/organs_by_name = list() // map organ names to organs
+/mob/living/carbon/human/var/list/bodyparts = list()
+/mob/living/carbon/human/var/list/bodyparts_by_name = list() // map organ names to organs
 
 // Takes care of organ related updates, such as broken and missing limbs
 /mob/living/carbon/human/proc/handle_organs()
@@ -18,7 +18,7 @@
 	last_dam = damage_this_tick
 	if(force_process)
 		bad_external_organs.Cut()
-		for(var/obj/item/organ/external/Ex in organs)
+		for(var/obj/item/organ/external/Ex in bodyparts)
 			bad_external_organs |= Ex
 
 	//processing internal organs is pretty cheap, do that first.
@@ -69,7 +69,7 @@
 		return
 
 	for(var/limb_tag in list("l_leg","r_leg","l_foot","r_foot"))
-		var/obj/item/organ/external/E = organs_by_name[limb_tag]
+		var/obj/item/organ/external/E = bodyparts_by_name[limb_tag]
 		if(!E || (E.status & (ORGAN_DESTROYED|ORGAN_DEAD)) || E.is_malfunctioning())
 			stance_damage += 2 // let it fail even if just foot&leg. Also malfunctioning happens sporadically so it should impact more when it procs
 		else if(E.is_broken() || !E.is_usable())
@@ -100,7 +100,7 @@
 	if(!l_hand && !r_hand)
 		return
 
-	for(var/obj/item/organ/external/E in organs)
+	for(var/obj/item/organ/external/E in bodyparts)
 		if(!E || !E.can_grasp || (E.status & ORGAN_SPLINTED))
 			continue
 
@@ -175,7 +175,7 @@
 /mob/living/carbon/human/proc/handle_trace_chems()
 	//New are added for reagents to random organs.
 	for(var/datum/reagent/A in reagents.reagent_list)
-		var/obj/item/organ/internal/O = pick(organs)
+		var/obj/item/organ/internal/O = pick(bodyparts)
 		O.trace_chemicals[A.name] = 100
 
 /*
@@ -186,7 +186,7 @@ old_ue: Set this to a UE string, and this proc will overwrite the dna of organs 
 */
 /mob/living/carbon/human/proc/sync_organ_dna(var/assimilate = 1, var/old_ue = null)
 	var/ue_to_compare = (old_ue) ? old_ue : dna.unique_enzymes
-	var/list/all_bits = internal_organs|organs
+	var/list/all_bits = internal_organs|bodyparts
 	for(var/obj/item/organ/O in all_bits)
 		if(assimilate || O.dna.unique_enzymes == ue_to_compare)
 			O.set_dna(dna)
@@ -204,9 +204,8 @@ I use this to standardize shadowling dethrall code
 
 /mob/living/carbon/human/has_organic_damage()
 	var/odmg = 0
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		if(O.status & ORGAN_ROBOT)
 			odmg += O.brute_dam
 			odmg += O.burn_dam
 	return (health < (100 - odmg))
-

--- a/code/modules/mob/living/carbon/human/interactive/interactive.dm
+++ b/code/modules/mob/living/carbon/human/interactive/interactive.dm
@@ -268,20 +268,20 @@
 	zone_sel.selecting = "chest"
 	//arms
 	if(prob((SNPC_FUZZY_CHANCE_LOW+SNPC_FUZZY_CHANCE_HIGH)/4))
-		var/obj/item/organ/external/R = organs_by_name["r_arm"]
+		var/obj/item/organ/external/R = bodyparts_by_name["r_arm"]
 		if(R)
 			R.robotize()
 	else
-		var/obj/item/organ/external/L = organs_by_name["l_arm"]
+		var/obj/item/organ/external/L = bodyparts_by_name["l_arm"]
 		if(L)
 			L.robotize()
 	//legs
 	if(prob((SNPC_FUZZY_CHANCE_LOW+SNPC_FUZZY_CHANCE_HIGH)/4))
-		var/obj/item/organ/external/R = organs_by_name["r_leg"]
+		var/obj/item/organ/external/R = bodyparts_by_name["r_leg"]
 		if(R)
 			R.robotize()
 	else
-		var/obj/item/organ/external/L = organs_by_name["l_leg"]
+		var/obj/item/organ/external/L = bodyparts_by_name["l_leg"]
 		if(L)
 			L.robotize()
 	UpdateDamageIcon()

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -23,7 +23,7 @@
 
 
 /mob/living/carbon/human/proc/has_organ(name)
-	var/obj/item/organ/external/O = organs_by_name[name]
+	var/obj/item/organ/external/O = bodyparts_by_name[name]
 
 	return (O && !(O.status & ORGAN_DESTROYED)  && !O.is_stump())
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -255,8 +255,8 @@
 							emote("gasp")
 						updatehealth()
 
-				if(damage && organs.len)
-					var/obj/item/organ/external/O = pick(organs)
+				if(damage && bodyparts.len)
+					var/obj/item/organ/external/O = pick(bodyparts)
 					if(istype(O)) O.add_autopsy_data("Radiation Poisoning", damage)
 
 /mob/living/carbon/human/breathe()

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -48,7 +48,7 @@
 	if(R.id == "milk")
 		H.heal_overall_damage(4,4)
 		if(prob(5)) // 5% chance per proc to find a random limb, and mend it
-			var/list/our_organs = H.organs.Copy()
+			var/list/our_organs = H.bodyparts.Copy()
 			shuffle(our_organs)
 			for(var/obj/item/organ/external/L in our_organs)
 				if(istype(L))

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -184,8 +184,8 @@
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
-	LAZYQDELLIST(H.internal_organs)
-	LAZYQDELLIST(H.bodyparts)
+	QDEL_LIST(H.internal_organs)
+	QDEL_LIST(H.bodyparts)
 
 	LAZYREINITLIST(H.bodyparts)
 	LAZYREINITLIST(H.bodyparts_by_name)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -184,20 +184,12 @@
 
 /datum/species/proc/create_organs(var/mob/living/carbon/human/H) //Handles creation of mob organs.
 
-	for(var/obj/item/organ/internal/iorgan in H.internal_organs)
-		if(iorgan in H.internal_organs)
-			qdel(iorgan)
+	LAZYQDELLIST(H.internal_organs)
+	LAZYQDELLIST(H.bodyparts)
 
-	for(var/obj/item/organ/organ in H.contents)
-		if(organ in H.organs)
-			qdel(organ)
-
-	if(H.organs)                  H.organs.Cut()
-	if(H.organs_by_name)          H.organs_by_name.Cut()
-
-	H.organs = list()
-	H.internal_organs = list()
-	H.organs_by_name = list()
+	LAZYREINITLIST(H.bodyparts)
+	LAZYREINITLIST(H.bodyparts_by_name)
+	LAZYREINITLIST(H.internal_organs)
 
 	for(var/limb_type in has_limbs)
 		var/list/organ_data = has_limbs[limb_type]
@@ -210,10 +202,10 @@
 		// organ new code calls `insert` on its own
 		new organ(H)
 
-	for(var/name in H.organs_by_name)
-		H.organs |= H.organs_by_name[name]
+	for(var/name in H.bodyparts_by_name)
+		H.bodyparts |= H.bodyparts_by_name[name]
 
-	for(var/obj/item/organ/external/O in H.organs)
+	for(var/obj/item/organ/external/O in H.bodyparts)
 		O.owner = H
 
 /datum/species/proc/handle_breath(var/datum/gas_mixture/breath, var/mob/living/carbon/human/H)
@@ -551,7 +543,7 @@
 			var/list/cached_overlays = H.healthdoll.cached_healthdoll_overlays
 			// Use the dead health doll as the base, since we have proper "healthy" overlays now
 			H.healthdoll.icon_state = "healthdoll_DEAD"
-			for(var/obj/item/organ/external/O in H.organs)
+			for(var/obj/item/organ/external/O in H.bodyparts)
 				var/damage = O.burn_dam + O.brute_dam
 				var/comparison = (O.max_damage/5)
 				var/icon_num = 0

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -580,8 +580,8 @@
 		H.g_skin = new_color_list[2]
 		H.b_skin = new_color_list[3]
 		if(world.time % SLIMEPERSON_ICON_UPDATE_PERIOD > SLIMEPERSON_ICON_UPDATE_PERIOD - 20) // The 20 is because this gets called every 2 seconds, from the mob controller
-			for(var/organname in H.organs_by_name)
-				var/obj/item/organ/external/E = H.organs_by_name[organname]
+			for(var/organname in H.bodyparts_by_name)
+				var/obj/item/organ/external/E = H.bodyparts_by_name[organname]
 				if(istype(E) && E.dna.species == "Slime People")
 					E.sync_colour_to_human(H)
 			H.update_hair(0)
@@ -634,13 +634,13 @@
 		return
 
 	var/list/missing_limbs = list()
-	for(var/l in organs_by_name)
-		var/obj/item/organ/external/E = organs_by_name[l]
+	for(var/l in bodyparts_by_name)
+		var/obj/item/organ/external/E = bodyparts_by_name[l]
 		if(!istype(E) || istype(E, /obj/item/organ/external/stump))
 			var/list/limblist = species.has_limbs[l]
 			var/obj/item/organ/external/limb = limblist["path"]
 			var/parent_organ = initial(limb.parent_organ)
-			var/obj/item/organ/external/parentLimb = organs_by_name[parent_organ]
+			var/obj/item/organ/external/parentLimb = bodyparts_by_name[parent_organ]
 			if(!istype(parentLimb) || parentLimb.is_stump())
 				continue
 			missing_limbs[initial(limb.name)] = l
@@ -662,7 +662,7 @@
 			to_chat(src, "<span class='warning'>You're too hungry to regenerate a limb!</span>")
 			return
 
-		var/obj/item/organ/external/O = organs_by_name[chosen_limb]
+		var/obj/item/organ/external/O = bodyparts_by_name[chosen_limb]
 
 		var/stored_brute = 0
 		var/stored_burn = 0
@@ -680,7 +680,7 @@
 		var/limb_list = species.has_limbs[chosen_limb]
 		var/obj/item/organ/external/limb_path = limb_list["path"]
 		// Parent check
-		var/obj/item/organ/external/potential_parent = organs_by_name[initial(limb_path.parent_organ)]
+		var/obj/item/organ/external/potential_parent = bodyparts_by_name[initial(limb_path.parent_organ)]
 		if(!istype(potential_parent) || potential_parent.is_stump())
 			to_chat(src, "<span class='danger'>You've lost the organ that you've been growing your new part on!</span>")
 			return // No rayman for you

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -171,7 +171,7 @@ var/global/list/damage_icon_parts = list()
 	// first check whether something actually changed about damage appearance
 	var/damage_appearance = ""
 
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		if(O.is_stump())
 			continue
 		if(O.status & ORGAN_DESTROYED) damage_appearance += "d"
@@ -189,7 +189,7 @@ var/global/list/damage_icon_parts = list()
 	var/image/standing_image = new /image("icon" = standing)
 
 	// blend the individual damage states with our icons
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		if(O.is_stump())
 			continue
 		if(!(O.status & ORGAN_DESTROYED))
@@ -240,7 +240,7 @@ var/global/list/damage_icon_parts = list()
 		icon_key += "#000000"
 
 	for(var/organ_tag in species.has_limbs)
-		var/obj/item/organ/external/part = organs_by_name[organ_tag]
+		var/obj/item/organ/external/part = bodyparts_by_name[organ_tag]
 		if(isnull(part) || part.is_stump() || (part.status & ORGAN_DESTROYED))
 			icon_key += "0"
 		else if(part.status & ORGAN_ROBOT)
@@ -269,7 +269,7 @@ var/global/list/damage_icon_parts = list()
 		var/obj/item/organ/external/chest = get_organ("chest")
 		base_icon = chest.get_icon(skeleton)
 
-		for(var/obj/item/organ/external/part in organs)
+		for(var/obj/item/organ/external/part in bodyparts)
 			var/icon/temp = part.get_icon(skeleton)
 			//That part makes left and right legs drawn topmost and lowermost when human looks WEST or EAST
 			//And no change in rendering for other parts (they icon_position is 0, so goes to 'else' part)
@@ -1333,7 +1333,7 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)   update_icons()
 
 /mob/living/carbon/human/proc/force_update_limbs()
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		O.sync_colour_to_human(src)
 	update_body(0)
 

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -20,7 +20,7 @@
 	// broken or ripped off organs will add quite a bit of pain
 	if(istype(src,/mob/living/carbon/human))
 		var/mob/living/carbon/human/M = src
-		for(var/obj/item/organ/external/organ in M.organs)
+		for(var/obj/item/organ/external/organ in M.bodyparts)
 			if(!organ)
 				continue
 			else if(organ.status & ORGAN_BROKEN || organ.open)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -230,7 +230,7 @@
 			to_chat(user, "<span class='notice'>External prosthetics:</span>")
 			var/organ_found
 			if(H.internal_organs.len)
-				for(var/obj/item/organ/external/E in H.organs)
+				for(var/obj/item/organ/external/E in H.bodyparts)
 					if(!(E.status & ORGAN_ROBOT))
 						continue
 					organ_found = 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -870,8 +870,8 @@ var/list/slot_equipment_priority = list( \
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 		if(H.health <= config.health_threshold_softcrit)
-			for(var/name in H.organs_by_name)
-				var/obj/item/organ/external/e = H.organs_by_name[name]
+			for(var/name in H.bodyparts_by_name)
+				var/obj/item/organ/external/e = H.bodyparts_by_name[name]
 				if(e && H.lying)
 					if(((e.status & ORGAN_BROKEN && !(e.status & ORGAN_SPLINTED)) || e.status & ORGAN_BLEEDING) && (H.getBruteLoss() + H.getFireLoss() >= 100))
 						return 1
@@ -1117,7 +1117,7 @@ var/list/slot_equipment_priority = list( \
 		var/mob/living/carbon/human/H = src
 		var/obj/item/organ/external/affected
 
-		for(var/obj/item/organ/external/organ in H.organs) //Grab the organ holding the implant.
+		for(var/obj/item/organ/external/organ in H.bodyparts) //Grab the organ holding the implant.
 			for(var/obj/item/weapon/O in organ.implants)
 				if(O == selection)
 					affected = organ

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -352,7 +352,7 @@
 							(affected.glasses && affected.glasses.flags_cover & GLASSESCOVERSEYES))
 							to_chat(assailant, "<span class='danger'>You're going to need to remove the eye covering first.</span>")
 							return
-						if(!affected.internal_organs_by_name["eyes"])
+						if(!affected.internal_bodyparts_by_name["eyes"])
 							to_chat(assailant, "<span class='danger'>You cannot locate any eyes on [affecting]!</span>")
 							return
 						assailant.visible_message("<span class='danger'>[assailant] presses \his fingers into [affecting]'s eyes!</span>")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -17,7 +17,7 @@
 
 /mob/living/carbon/human/isSynthetic()
 	// If they are 100% robotic, they count as synthetic.
-	for(var/obj/item/organ/external/E in organs)
+	for(var/obj/item/organ/external/E in bodyparts)
 		if(!(E.status & ORGAN_ROBOT))
 			return 0
 	return 1

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -55,7 +55,7 @@
 	canmove = 0
 	icon = null
 	invisibility = 101
-	for(var/t in organs)
+	for(var/t in bodyparts)
 		qdel(t)
 	for(var/i in internal_organs)
 		qdel(i)
@@ -115,7 +115,7 @@
 	canmove = 0
 	icon = null
 	invisibility = 101
-	for(var/t in organs)
+	for(var/t in bodyparts)
 		qdel(t)
 
 	var/alien_caste = pick("Hunter","Sentinel","Drone")
@@ -147,7 +147,7 @@
 	canmove = 0
 	icon = null
 	invisibility = 101
-	for(var/t in organs)
+	for(var/t in bodyparts)
 		qdel(t)
 
 	var/mob/living/carbon/slime/new_slime
@@ -183,7 +183,7 @@
 	canmove = 0
 	icon = null
 	invisibility = 101
-	for(var/t in organs)	//this really should not be necessary
+	for(var/t in bodyparts)	//this really should not be necessary
 		qdel(t)
 
 	var/mob/living/simple_animal/pet/corgi/new_corgi = new /mob/living/simple_animal/pet/corgi (loc)
@@ -212,7 +212,7 @@
 	icon = null
 	invisibility = 101
 
-	for(var/t in organs)
+	for(var/t in bodyparts)
 		qdel(t)
 
 	var/mob/new_mob = new mobpath(src.loc)
@@ -252,7 +252,7 @@
 	canmove = 0
 	icon = null
 	invisibility = 101
-	for(var/t in organs)	//this really should not be necessary
+	for(var/t in bodyparts)	//this really should not be necessary
 		qdel(t)
 
 	var/obj/item/device/paicard/card = new(loc)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -54,9 +54,9 @@
 /obj/item/weapon/paper_bin/attack_hand(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/temp = H.organs_by_name["r_hand"]
+		var/obj/item/organ/external/temp = H.bodyparts_by_name["r_hand"]
 		if(H.hand)
-			temp = H.organs_by_name["l_hand"]
+			temp = H.bodyparts_by_name["l_hand"]
 		if(temp && !temp.is_usable())
 			to_chat(H, "<span class='notice'>You try to move your [temp.name], but cannot!")
 			return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -521,7 +521,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 /obj/item/stack/cable_coil/attack(mob/M, mob/user)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
+		var/obj/item/organ/external/S = H.bodyparts_by_name[user.zone_sel.selecting]
 
 		if(!S)
 			return

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -103,7 +103,7 @@
 	target.adjustFireLoss(-4)
 	if(ishuman(target))
 		var/var/mob/living/carbon/human/H = target
-		for(var/obj/item/organ/external/E in H.organs)
+		for(var/obj/item/organ/external/E in H.bodyparts)
 			if(prob(10))
 				if(E.mend_fracture())
 					E.perma_injury = 0

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -162,7 +162,7 @@ proc/wabbajack(mob/living/M)
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
 					// Make sure there are no organs or limbs to drop
-					for(var/t in H.organs)
+					for(var/t in H.bodyparts)
 						qdel(t)
 					for(var/i in H.internal_organs)
 						qdel(i)

--- a/code/modules/reagents/chemistry/reagents/admin.dm
+++ b/code/modules/reagents/chemistry/reagents/admin.dm
@@ -21,7 +21,7 @@
 		for(var/name in H.internal_organs)
 			var/obj/item/organ/internal/I = H.get_int_organ(name)
 			I.damage = max(0, I.damage-5)
-		for(var/obj/item/organ/external/E in H.organs)
+		for(var/obj/item/organ/external/E in H.bodyparts)
 			if(E.mend_fracture())
 				E.perma_injury = 0
 	M.SetEyeBlind(0)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -652,7 +652,7 @@
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
 						var/necrosis_prob = 40 * min((20 MINUTES), max((time_dead - (1 MINUTES)), 0)) / ((20 MINUTES) - (1 MINUTES))
-						for(var/obj/item/organ/O in (H.organs | H.internal_organs))
+						for(var/obj/item/organ/O in (H.bodyparts | H.internal_organs))
 							// Per non-vital body part:
 							// 0% chance of necrosis within 1 minute of death
 							// 40% chance of necrosis after 20 minutes of death

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_heal.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_heal.dm
@@ -13,7 +13,7 @@
 
 			if(ishuman(toucher))
 				var/mob/living/carbon/human/H = toucher
-				for(var/obj/item/organ/external/affecting in H.organs)
+				for(var/obj/item/organ/external/affecting in H.bodyparts)
 					if(affecting && istype(affecting))
 						affecting.heal_damage(25 * weakness, 25 * weakness)
 				//H:heal_organ_damage(25, 25)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -198,7 +198,7 @@
 	user.visible_message("<span class='notice'>[user] has connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>",	\
 	"<span class='notice'>You have connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>")
 	E.status &= ~ORGAN_DESTROYED
-	var/obj/item/organ/external/stump = target.organs_by_name["limb stump"]
+	var/obj/item/organ/external/stump = target.bodyparts_by_name["limb stump"]
 	if(stump)
 		stump.remove(target)
 	if(E.children)
@@ -248,7 +248,7 @@
 			if(!organ_data)
 				continue
 			// This will break if there's more than one stump ever
-			var/obj/item/organ/external/stump = target.organs_by_name["limb stump"]
+			var/obj/item/organ/external/stump = target.bodyparts_by_name["limb stump"]
 			if(stump)
 				stump.remove(target)
 			var/new_limb_type = organ_data["path"]

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -118,7 +118,7 @@
 
 		//Bleeding out
 		var/blood_max = 0
-		for(var/obj/item/organ/external/temp in organs)
+		for(var/obj/item/organ/external/temp in bodyparts)
 			if(!(temp.status & ORGAN_BLEEDING) || temp.status & ORGAN_ROBOT)
 				continue
 			for(var/datum/wound/W in temp.wounds)

--- a/code/modules/surgery/organs/helpers.dm
+++ b/code/modules/surgery/organs/helpers.dm
@@ -43,6 +43,6 @@
 	return istype(A, /obj/item/organ/internal)
 
 /mob/living/carbon/human/proc/get_limb_by_name(limb_name) //Look for a limb with the given limb name in the source mob, and return it if found.
-	for(var/obj/item/organ/external/O in organs)
+	for(var/obj/item/organ/external/O in bodyparts)
 		if(limb_name == O.limb_name)
 			return O

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -92,7 +92,7 @@
 			qdel(O)
 
 	if(owner)
-		owner.organs_by_name[limb_name] = null
+		owner.bodyparts_by_name[limb_name] = null
 
 	if(children)
 		for(var/obj/item/organ/external/C in children)
@@ -157,15 +157,15 @@
 	status = status & ~ORGAN_DESTROYED
 	forceMove(owner)
 	if(istype(owner))
-		if(!isnull(owner.organs_by_name[limb_name]))
+		if(!isnull(owner.bodyparts_by_name[limb_name]))
 			log_debug("Duplicate organ in slot \"[limb_name]\", mob '[target]'")
-		owner.organs_by_name[limb_name] = src
-		owner.organs |= src
+		owner.bodyparts_by_name[limb_name] = src
+		owner.bodyparts |= src
 		for(var/atom/movable/stuff in src)
 			stuff.attempt_become_organ(src, owner)
 
 	if(parent_organ)
-		parent = owner.organs_by_name[src.parent_organ]
+		parent = owner.bodyparts_by_name[src.parent_organ]
 		if(parent)
 			if(!parent.children)
 				parent.children = list()
@@ -726,7 +726,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(status & ORGAN_ROBOT)
 				stump.robotize()
 			stump.wounds |= W
-			victim.organs |= stump
+			victim.bodyparts |= stump
 			stump.update_damages()
 		parent = null
 
@@ -946,9 +946,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 		thing.forceMove(src)
 
 	release_restraints(victim)
-	victim.organs -= src
+	victim.bodyparts -= src
 	if(is_primary_organ(victim))
-		victim.organs_by_name[limb_name] = null	// Remove from owner's vars.
+		victim.bodyparts_by_name[limb_name] = null	// Remove from owner's vars.
 
 	//Robotic limbs explode if sabotaged.
 	if(is_robotic && sabotaged)
@@ -984,7 +984,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		O = owner
 	if(!istype(O)) // You're not the primary organ of ANYTHING, bucko
 		return 0
-	return src == O.organs_by_name[limb_name]
+	return src == O.bodyparts_by_name[limb_name]
 
 // The callback we use to remove wounds from an un-processed limb
 /obj/item/organ/external/proc/cleanup_wounds(var/list/slated_wounds)

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -55,7 +55,7 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/head/sync_colour_to_human(var/mob/living/carbon/human/H)
 	..()
-	var/obj/item/organ/internal/eyes/eyes = owner.get_int_organ(/obj/item/organ/internal/eyes)//owner.internal_organs_by_name["eyes"]
+	var/obj/item/organ/internal/eyes/eyes = owner.get_int_organ(/obj/item/organ/internal/eyes)//owner.internal_bodyparts_by_name["eyes"]
 	if(eyes) eyes.update_colour()
 
 /obj/item/organ/external/head/remove()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -42,7 +42,7 @@
 			log_runtime(EXCEPTION("[src] attempted to insert into a [parent_organ], but [parent_organ] wasn't an organ! [atom_loc_line(M)]"), src)
 		else
 			parent.internal_organs |= src
-	//M.internal_organs_by_name[src] |= src(H,1)
+	//M.internal_bodyparts_by_name[src] |= src(H,1)
 	loc = null
 	for(var/X in actions)
 		var/datum/action/A = X

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -92,7 +92,7 @@ mob/living/carbon/human/proc/handle_pain()
 		return
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
-	for(var/obj/item/organ/external/E in organs)
+	for(var/obj/item/organ/external/E in bodyparts)
 		if(E.status & ORGAN_DEAD|ORGAN_ROBOT) continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,

--- a/code/modules/surgery/organs/subtypes/diona.dm
+++ b/code/modules/surgery/organs/subtypes/diona.dm
@@ -89,7 +89,7 @@
 /* /obj/item/organ/external/diona/removed()
 	var/mob/living/carbon/human/H = owner
 	..()
-	if(!istype(H) || !H.organs || !H.organs.len)
+	if(!istype(H) || !H.bodyparts || !H.bodyparts.len)
 		H.death()
 	if(prob(50) && spawn_diona_nymph_from_organ(src))
 		qdel(src) */
@@ -141,7 +141,7 @@
 /*/obj/item/organ/diona/removed(var/mob/living/user)
 	var/mob/living/carbon/human/H = owner
 	..()
-	if(!istype(H) || !H.organs || !H.organs.len)
+	if(!istype(H) || !H.bodyparts || !H.bodyparts.len)
 		H.death()
 	if(prob(50) && spawn_diona_nymph_from_organ(src))
 		qdel(src) */


### PR DESCRIPTION
Because I think everyone and their cat was sick of conflating `internal_organs` (which contained internal organs) and `organs` (which contains limbs), the latter has been renamed to `bodyparts`, as has `organs_by_name`, which is now `bodyparts_by_name`.