### PR TITLE
Allow Vox clones

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -232,8 +232,11 @@
 
 	if(!R.dna)
 		R.dna = new /datum/dna()
-
-	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src, R.dna.species)
+	var/mob/living/carbon/human/H = null
+	if(!R.dna.species == "Vox")
+		H = new /mob/living/carbon/human(src, R.dna.species)
+	else
+		H = new /mob/living/carbon/human/interactive/greytide(src, R.dna.species)
 	occupant = H
 
 	if(!R.dna.real_name)	//to prevent null names

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -288,7 +288,7 @@
 	breath_type = "nitrogen"
 	poison_type = "oxygen"
 
-	flags = NO_SCAN | IS_WHITELISTED | NOTRANSSTING
+	flags = IS_WHITELISTED | NOTRANSSTING
 	clothing_flags = HAS_SOCKS
 	dietflags = DIET_OMNI
 	bodyflags = HAS_ICON_SKIN_TONE | HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_BODY_MARKINGS | HAS_TAIL_MARKINGS


### PR DESCRIPTION
Recent upgrades to NanoTrasen standard issue clone pods along with a greater understand of Vox physiology has allowed for Vox tissue to be vat grown.

This enables the cloning of station Vox, complete with a NanoTrasen cortical implant based on the designs of real Vox cortical stacks.

🆑
tweak: Allows Vox to be cloned.
/🆑