### PR TITLE
Tk refactor+Remote tool use

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -11,7 +11,8 @@ var/const/tk_maxrange = 15
 	By default, emulate the user's unarmed attack
 */
 /atom/proc/attack_tk(mob/user)
-	if(user.stat) return
+	if(user.stat)
+		return
 	user.UnarmedAttack(src,0) // attack_hand, attack_paw, etc
 	return
 
@@ -26,7 +27,8 @@ var/const/tk_maxrange = 15
 	return
 
 /obj/attack_tk(mob/user)
-	if(user.stat) return
+	if(user.stat)
+		return
 	if(anchored)
 		..()
 		return
@@ -35,7 +37,8 @@ var/const/tk_maxrange = 15
 	O.form_grab(user, src)
 
 /obj/item/attack_tk(mob/user)
-	if(user.stat || !isturf(loc)) return
+	if(user.stat || !isturf(loc))
+		return
 	if((TK in user.mutations) && !user.get_active_hand()) // both should already be true to get here
 		var/obj/item/tk_grab/O = new(src)
 		O.form_grab(user, src)
@@ -76,7 +79,7 @@ var/const/tk_maxrange = 15
 	host = null
 	return ..()
 
-/obj/item/tk_grab/dropped(mob/user as mob)
+/obj/item/tk_grab/dropped(mob/user)
 	if(focus && user && loc != user && loc != user.loc) // drop_item() gets called when you tk-attack a table/closet with an item
 		if(focus.Adjacent(loc))
 			focus.loc = loc
@@ -85,12 +88,13 @@ var/const/tk_maxrange = 15
 
 
 	//stops TK grabs being equipped anywhere but into hands
-/obj/item/tk_grab/equipped(var/mob/user, var/slot)
-	if( (slot == slot_l_hand) || (slot== slot_r_hand) )	return
+/obj/item/tk_grab/equipped(mob/user, var/slot)
+	if( (slot == slot_l_hand) || (slot== slot_r_hand) )
+		return
 	qdel(src)
 
 
-/obj/item/tk_grab/attack_self(mob/user as mob)
+/obj/item/tk_grab/attack_self(mob/user)
 	if(focus)
 		focus.attack_self_tk(user)
 
@@ -98,9 +102,11 @@ var/const/tk_maxrange = 15
 	afterattack(target, user)
 	return TRUE
 
-/obj/item/tk_grab/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)//TODO: go over this
-	if(!target || !user)	return
-	if(last_throw+3 > world.time)	return
+/obj/item/tk_grab/afterattack(atom/target , mob/living/user, proximity, params)//TODO: go over this
+	if(!target || !user)
+		return
+	if(last_throw+3 > world.time)
+		return
 	if(!host || host != user)
 		qdel(src)
 		return
@@ -138,7 +144,7 @@ var/const/tk_maxrange = 15
 		focus.throw_at(target, 10, 1, user)
 		last_throw = world.time
 
-/obj/item/tk_grab/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
+/obj/item/tk_grab/attack(mob/living/M, mob/living/user, def_zone)
 	return
 
 /obj/item/tk_grab/is_equivalent(obj/item/I)
@@ -147,7 +153,8 @@ var/const/tk_maxrange = 15
 		return I == focus
 
 /obj/item/tk_grab/proc/focus_object(var/obj/target, var/mob/user)
-	if(!istype(target,/obj))	return//Cant throw non objects atm might let it do mobs later
+	if(!istype(target,/obj))
+		return//Cant throw non objects atm might let it do mobs later
 	if(target.anchored || !isturf(target.loc))
 		qdel(src)
 		return
@@ -171,7 +178,8 @@ var/const/tk_maxrange = 15
 	update_icon()
 
 /obj/item/tk_grab/proc/apply_focus_overlay()
-	if(!focus)	return
+	if(!focus)
+		return
 	// Oh jeez ow
 	var/obj/effect/overlay/O = new /obj/effect/overlay(locate(focus.x,focus.y,focus.z))
 	O.name = "sparkles"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -558,3 +558,10 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 /obj/item/proc/is_crutch() //Does an item prop up a human mob and allow them to stand if they are missing a leg/foot?
 	return 0
+
+// Return true if you don't want regular throw handling
+/obj/item/proc/override_throw(mob/user, atom/target)
+	return FALSE
+
+/obj/item/proc/is_equivalent(obj/item/I)
+	return I == src

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -73,7 +73,7 @@
 			temp = pick(graffiti)
 		else
 			temp = href_list["type"]
-	if((usr.restrained() || usr.stat || usr.get_active_hand() != src))
+	if((usr.restrained() || usr.stat || !usr.is_in_active_hand(src)))
 		return
 	drawtype = temp
 	update_window(usr)
@@ -167,7 +167,7 @@
 	..()
 
 /obj/item/toy/crayon/mime/Topic(href,href_list)
-	if((usr.restrained() || usr.stat || usr.get_active_hand() != src))
+	if((usr.restrained() || usr.stat || usr.is_in_active_hand(src)))
 		return
 	if(href_list["color"])
 		if(colour != "#FFFFFF")
@@ -195,7 +195,7 @@
 
 	if(href_list["color"])
 		var/temp = input(usr, "Please select colour.", "Crayon colour") as color
-		if((usr.restrained() || usr.stat || usr.get_active_hand() != src))
+		if((usr.restrained() || usr.stat || usr.is_in_active_hand(src)))
 			return
 		colour = temp
 		update_window(usr)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -55,7 +55,7 @@ var/global/list/datum/stack_recipe/rod_recipes = list ( \
 						 "<span class='notice'>You shape [src] into metal with the welding tool.</span>", \
 						 "<span class='italics'>You hear welding.</span>")
 
-			var/replace = user.get_inactive_hand() == src
+			var/replace = user.is_in_inactive_hand(src)
 			use(2)
 			if(get_amount() <= 0 && replace)
 				user.unEquip(src, 1)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -36,6 +36,23 @@
 /obj/item/stack/attack_self(mob/user)
 	list_recipes(user)
 
+/obj/item/stack/attack_self_tk(mob/user)
+	list_recipes(user)
+
+/obj/item/stack/attack_tk(mob/user)
+	if(user.stat || !isturf(loc)) return
+	// Allow remote stack splitting, because telekinetic inventory managing
+	// is really cool
+	if(src in user.tkgrabbed_objects)
+		var/obj/item/stack/F = split(user, 1)
+		F.attack_tk(user)
+		if(src && user.machine == src)
+			spawn(0)
+				interact(user)
+	else
+		..()
+
+
 /obj/item/stack/proc/list_recipes(mob/user, recipes_sublist)
 	if(!recipes)
 		return
@@ -107,7 +124,7 @@
 
 /obj/item/stack/Topic(href, href_list)
 	..()
-	if(usr.incapacitated() || usr.get_active_hand() != src)
+	if(usr.incapacitated() || !usr.is_in_active_hand(src))
 		return 0
 
 	if(href_list["sublist"] && !href_list["make"])
@@ -124,6 +141,7 @@
 
 		var/datum/stack_recipe/R = recipes_list[text2num(href_list["make"])]
 		var/multiplier = text2num(href_list["multiplier"])
+		var/atom/creation_loc = (loc == usr) ? usr.loc : loc
 		if(!multiplier)
 			multiplier = 1
 
@@ -134,11 +152,11 @@
 				to_chat(usr, "<span class='warning'>You haven't got enough [src] to build \the [R.title]!</span>")
 			return 0
 
-		if(R.one_per_turf && (locate(R.result_type) in usr.loc))
+		if(R.one_per_turf && (locate(R.result_type) in creation_loc))
 			to_chat(usr, "<span class='warning'>There is another [R.title] here!</span>")
 			return 0
 
-		if(R.on_floor && !istype(usr.loc, /turf/simulated))
+		if(R.on_floor && !istype(creation_loc, /turf/simulated))
 			to_chat(usr, "<span class='warning'>\The [R.title] must be constructed on the floor!</span>")
 			return 0
 
@@ -150,7 +168,7 @@
 		if(amount < R.req_amount * multiplier)
 			return
 
-		var/atom/O = new R.result_type(usr.loc)
+		var/atom/O = new R.result_type(creation_loc)
 		O.dir = usr.dir
 		if(R.max_res_amount > 1)
 			var/obj/item/stack/new_item = O
@@ -215,7 +233,7 @@
 	return max_amount
 
 /obj/item/stack/proc/split(mob/user, amt)
-	var/obj/item/stack/F = new type(user, amt)
+	var/obj/item/stack/F = new type(loc, amt)
 	F.copy_evidences(src)
 	if(isliving(user))
 		add_fingerprint(user)
@@ -224,7 +242,7 @@
 	return F
 
 /obj/item/stack/attack_hand(mob/user)
-	if(user.get_inactive_hand() == src)
+	if(user.is_in_inactive_hand(src))
 		var/obj/item/stack/F = split(user, 1)
 		user.put_in_hands(F)
 		if(src && usr.machine == src)
@@ -241,7 +259,7 @@
 			return 1
 
 		var/to_transfer
-		if(user.get_inactive_hand() == src)
+		if(user.is_in_inactive_hand(src))
 			var/desired = input("How much would you like to transfer from this stack?", "How much?", 1) as null|num
 			if(!desired)
 				return

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -84,6 +84,9 @@ RCD
 	//Change the mode
 	ui_interact(user)
 
+/obj/item/weapon/rcd/attack_self_tk(mob/user)
+	ui_interact(user)
+
 /obj/item/weapon/rcd/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = inventory_state)
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -61,7 +61,7 @@
 		nadeassembly.attack_self(user)
 		return
 	var/newtime = input(usr, "Please set the timer.", "Timer", 10) as num
-	if(user.get_active_hand() == src)
+	if(user.is_in_active_hand(src))
 		newtime = Clamp(newtime, 10, 60000)
 		det_time = newtime
 		to_chat(user, "Timer set for [det_time] seconds.")

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -62,7 +62,7 @@
 /obj/item/weapon/flamethrower/afterattack(atom/target, mob/user, flag)
 	if(flag) return // too close
 	// Make sure our user is still holding us
-	if(user && user.get_active_hand() == src)
+	if(user && user.is_in_active_hand(src))
 		var/turf/target_turf = get_turf(target)
 		if(target_turf)
 			var/turflist = getline(user, target_turf)

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -32,7 +32,7 @@
 /*/obj/item/weapon/grenade/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 	if(istype(target, /obj/item/weapon/storage)) return ..() // Trying to put it in a full container
 	if(istype(target, /obj/item/weapon/gun/grenadelauncher)) return ..()
-	if((user.get_active_hand() == src) && (!active) && (clown_check(user)) && target.loc != src.loc)
+	if((user.is_in_active_hand(src)) && (!active) && (clown_check(user)) && target.loc != src.loc)
 		to_chat(user, "<span class='warning'>You prime the [name]! [det_time/10] seconds!</span>")
 		active = 1
 		icon_state = initial(icon_state) + "_active"

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -478,7 +478,7 @@
 /obj/item/weapon/storage/attack_self(mob/user as mob)
 
 	//Clicking on itself will empty it, if it has the verb to do that.
-	if(user.get_active_hand() == src)
+	if(user.is_in_active_hand(src))
 		if(src.verbs.Find(/obj/item/weapon/storage/verb/quick_empty))
 			src.quick_empty()
 			return

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -128,7 +128,7 @@ Frequency:
 	if(turfs.len)
 		L["None (Dangerous)"] = pick(turfs)
 	var/t1 = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") as null|anything in L
-	if(!t1 || (user.get_active_hand() != src || user.stat || user.restrained()))
+	if(!t1 || (user.is_in_active_hand(src) || user.stat || user.restrained()))
 		return
 	if(active_portals >= 3)
 		user.show_message("<span class='notice'>\The [src] is recharging!</span>")

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -2097,7 +2097,7 @@
 		return
 
 	if(boxes.len > 0)
-		if(user.get_inactive_hand() != src)
+		if(user.is_in_inactive_hand(src))
 			..()
 			return
 

--- a/code/modules/mining/lavaland/loot/hierophant_loot.dm
+++ b/code/modules/mining/lavaland/loot/hierophant_loot.dm
@@ -52,7 +52,7 @@
 		friendly_fire_check = !friendly_fire_check
 		to_chat(user, "<span class='warning'>You toggle friendly fire [friendly_fire_check ? "off":"on"]!</span>")
 		return
-	if(user.get_active_hand() != src && user.get_inactive_hand() != src) //you need to hold the staff to teleport
+	if(user.is_in_active_hand(src) && user.is_in_inactive_hand(src)) //you need to hold the staff to teleport
 		to_chat(user, "<span class='warning'>You need to hold the staff in your hands to [rune ? "teleport with it" : "create a rune"]!</span>")
 		return
 	if(!rune)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -6,10 +6,21 @@
 	if(hand)	return l_hand
 	else		return r_hand
 
+/mob/proc/is_in_active_hand(obj/item/I)
+	var/obj/item/item_to_test = get_active_hand()
+
+	return item_to_test && item_to_test.is_equivalent(I)
+
+
 //Returns the thing in our inactive hand
 /mob/proc/get_inactive_hand()
 	if(hand)	return r_hand
 	else		return l_hand
+
+/mob/proc/is_in_inactive_hand(obj/item/I)
+	var/obj/item/item_to_test = get_inactive_hand()
+
+	return item_to_test && item_to_test.is_equivalent(I)
 
 //Returns if a certain item can be equipped to a certain slot.
 // Currently invalid for two-handed items - call obj/item/mob_can_equip() instead.
@@ -119,6 +130,9 @@
 	else if(I == l_hand)
 		l_hand = null
 		update_inv_l_hand()
+	else if(I in tkgrabbed_objects)
+		var/obj/item/tk_grab/tkgrab = tkgrabbed_objects[I]
+		unEquip(tkgrab, force)
 
 	if(I)
 		if(client)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -535,17 +535,18 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	return
 
 /mob/living/carbon/throw_item(atom/target)
-	throw_mode_off()
-	if(!target || !isturf(loc))
-		return
-	if(istype(target, /obj/screen))
+	if(!target || !isturf(loc) || istype(target, /obj/screen))
+		throw_mode_off()
 		return
 
-	var/atom/movable/thrown_thing
 	var/obj/item/I = src.get_active_hand()
 
-	if(!I || (I.flags & NODROP))
+	if(!I || I.override_throw(src, target) || (I.flags & NODROP))
+		throw_mode_off()
 		return
+
+	throw_mode_off()
+	var/atom/movable/thrown_thing
 
 	if(istype(I, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = I

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -11,6 +11,7 @@
 	for(var/mob/dead/observer/M in following_mobs)
 		M.following = null
 	following_mobs = null
+	QDEL_LIST_ASSOC_VAL(tkgrabbed_objects)
 	for(var/I in tkgrabbed_objects)
 		qdel(tkgrabbed_objects[I])
 	tkgrabbed_objects = null

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -11,6 +11,9 @@
 	for(var/mob/dead/observer/M in following_mobs)
 		M.following = null
 	following_mobs = null
+	for(var/I in tkgrabbed_objects)
+		qdel(tkgrabbed_objects[I])
+	tkgrabbed_objects = null
 	if(buckled)
 		buckled.unbuckle_mob()
 	if(viewing_alternate_appearances)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -198,3 +198,5 @@
 	var/list/actions = list()
 
 	var/list/progressbars = null	//for stacking do_after bars
+
+	var/list/tkgrabbed_objects = list() // Assoc list of items to TK grabs

--- a/code/modules/nano/interaction/inventory.dm
+++ b/code/modules/nano/interaction/inventory.dm
@@ -4,7 +4,7 @@
 /var/global/datum/topic_state/inventory_state/inventory_state = new()
 
 /datum/topic_state/inventory_state/can_use_topic(var/src_object, var/mob/user)
-	if(!(src_object in user))
+	if(!((src_object in user) || user.is_in_active_hand(src_object) || user.is_in_inactive_hand(src_object)))
 		return STATUS_CLOSE
 
 	return user.shared_nano_interaction()

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -87,7 +87,7 @@
 				user.visible_message("[class][user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.", \
 				"[class]You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.")
 
-				if(user.get_inactive_hand() == src)
+				if(user.is_in_inactive_hand(src))
 					user.unEquip(src)
 
 				new /obj/effect/decal/cleanable/ash(get_turf(src))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -64,7 +64,7 @@
 				user.visible_message("[class][user] burns right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.", \
 				"[class]You burn right through \the [src], turning it to ash. It flutters through the air before settling on the floor in a heap.")
 
-				if(user.get_inactive_hand() == src)
+				if(user.is_in_inactive_hand(src))
 					user.unEquip(src)
 
 				new /obj/effect/decal/cleanable/ash(get_turf(src))


### PR DESCRIPTION
TK can now use tools on tiles adjacent to the object, and also is more able to use RCDs, manipulate stacks, and now works more consistently (less cloned/duped references) when interacting with certain objects.

With stronger atmos now a factor, TK has greater applications in construction - in that when you're not adjacent to a vacuum gradient, you can more easily build without being flung around.

Also adds an `/obj/item/proc/override_throw(mob/user)` proc that lets you override the throwing behavior on an individual object - return `TRUE` from that proc if you want to do so.

There is also now `/obj/item/proc/is_equivalent(obj/item/I)` - this is used to determine whether two items can be considered "the same" - important for wrapper items like the robot grasper, or TK as in this PR.

:cl:Crazylemon
rscadd: TK can now manipulate adjacent tiles. Use throw mode to override this if you want to move an object a single tile.
rscadd: TK can now remotely manipulate item stacks.
rscadd: TK can now remotely operate an RCD
fix: TK now behaves more consistently regarding interacting with various objects remotely
/:cl: