### PR TITLE
Fixes carded AIs generating checkTurfVis warnings

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -35,11 +35,18 @@
 		return
 
 	var/turf/pixel_turf = get_turf_pixel(A)
-	if(pixel_turf && !cameranet.checkTurfVis(pixel_turf) && !(istype(loc, /obj/item/device/aicard) && pixel_turf in view(client.view, loc)))
-		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)])")
-		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(A)]))")
-		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)]))")
-		return
+	var/turf_visible
+	if(pixel_turf)
+		turf_visible = cameranet.checkTurfVis(pixel_turf)
+		if(!turf_visible)
+			if(istype(loc, /obj/item/device/aicard) && (pixel_turf in view(client.view, loc)))
+				turf_visible = TRUE
+			else
+				if(pixel_turf.obscured)
+					log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)])")
+					message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(pixel_turf)]))")
+					send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(pixel_turf)]))")
+				return
 
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -35,7 +35,7 @@
 		return
 
 	var/turf/pixel_turf = get_turf_pixel(A)
-	if(pixel_turf && !cameranet.checkTurfVis(pixel_turf) && !istype(loc, /obj/item/device/aicard))
+	if(pixel_turf && !cameranet.checkTurfVis(pixel_turf) && !(istype(loc, /obj/item/device/aicard) && pixel_turf in view(client.view, loc)))
 		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)])")
 		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(A)]))")
 		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)]))")

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -33,9 +33,9 @@
 
 	if(control_disabled || stat)
 		return
-		
+
 	var/turf/pixel_turf = get_turf_pixel(A)
-	if(pixel_turf && !cameranet.checkTurfVis(pixel_turf))
+	if(pixel_turf && !cameranet.checkTurfVis(pixel_turf) && !istype(loc, /obj/item/device/aicard))
 		log_admin("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)])")
 		message_admins("[key_name_admin(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([ADMIN_COORDJMP(A)]))")
 		send2irc_adminless_only("NOCHEAT", "[key_name(src)] might be running a modified client! (failed checkTurfVis on AI click of [A]([COORD(A)]))")


### PR DESCRIPTION
Fixes bug where carded AIs that click on turfs not visible to any camera generate warnings to admins.

No CL as admin-only.