### PR TITLE
Fixes vampire enthrall not creating VV or ATTACK: logs

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -340,7 +340,7 @@
 	H.mind.special_role = SPECIAL_ROLE_VAMPIRE_THRALL
 	to_chat(H, "<span class='danger'>You have been Enthralled by [user]. Follow their every command.</span>")
 	to_chat(user, "<span class='warning'>You have successfully Enthralled [H]. <i>If they refuse to do as you say just adminhelp.</i></span>")
-	log_admin("[ckey(user.key)] has mind-slaved [ckey(H.key)].")
+	add_logs(user, H, "vampire-thralled", admin = 1, print_attack_log = 1)
 
 /obj/effect/proc_holder/spell/vampire/self/cloak
 	name = "Cloak of Darkness"

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -340,7 +340,7 @@
 	H.mind.special_role = SPECIAL_ROLE_VAMPIRE_THRALL
 	to_chat(H, "<span class='danger'>You have been Enthralled by [user]. Follow their every command.</span>")
 	to_chat(user, "<span class='warning'>You have successfully Enthralled [H]. <i>If they refuse to do as you say just adminhelp.</i></span>")
-	add_logs(user, H, "vampire-thralled", admin = 1, print_attack_log = 1)
+	add_logs(user, H, "vampire-thralled")
 
 /obj/effect/proc_holder/spell/vampire/self/cloak
 	name = "Cloak of Darkness"


### PR DESCRIPTION
Currently, enthralling someone as a vamp:
- does not create an ATTACK: log visible to admins
- does not create attack_logs on the VV of the mobs
- is mistakenly logged to the ADMIN log as a mind-slave event

No CL as this is admin-only.