### PR TITLE
Hand tele's "None (Dangerous)" mode may now target carbon mobs

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -95,36 +95,40 @@
 //do the monkey dance
 /datum/teleport/proc/doTeleport()
 
-	var/turf/destturf
+	var/atom/dest
 	var/turf/curturf = get_turf(teleatom)
 	var/area/destarea = get_area(destination)
-	if(precision)
+	if(precision && isturf(destination))
 		var/list/posturfs = list()
 		var/center = get_turf(destination)
 		if(!center)
 			center = destination
 		for(var/turf/T in range(precision,center))
 			posturfs.Add(T)
-		destturf = safepick(posturfs)
+		dest = safepick(posturfs)
 	else
-		destturf = get_turf(destination)
+		dest = destination
 
-	if(!destturf || !curturf)
+	if(!dest || !curturf)
 		return 0
 
 	playSpecials(curturf,effectin,soundin)
 
 	if(force_teleport)
-		teleatom.forceMove(destturf)
-		playSpecials(destturf,effectout,soundout)
+		teleatom.forceMove(dest)
+		playSpecials(dest,effectout,soundout)
 	else
-		if(teleatom.Move(destturf))
-			playSpecials(destturf,effectout,soundout)
+		if(teleatom.Move(dest))
+			playSpecials(dest,effectout,soundout)
 
 	if(isliving(teleatom))
 		var/mob/living/L = teleatom
 		if(L.buckled)
 			L.buckled.unbuckle_mob()
+
+	if(iscarbon(dest))
+		var/mob/living/carbon/C = dest
+		C.stomach_contents += teleatom
 
 	destarea.Entered(teleatom)
 

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -117,16 +117,23 @@ Frequency:
 				L["[com.id] (Active)"] = com.target
 			else
 				L["[com.id] (Inactive)"] = com.target
-	var/list/turfs = list(	)
-	var/area/A
-	for(var/turf/T in orange(10))
-		if(T.x>world.maxx-8 || T.x<8)	continue	//putting them at the edge is dumb
-		if(T.y>world.maxy-8 || T.y<8)	continue
-		A = get_area(T)
-		if(A.tele_proof == 1) continue // Telescience-proofed areas require a beacon.
-		turfs += T
-	if(turfs.len)
-		L["None (Dangerous)"] = pick(turfs)
+
+	var/list/possible_random_locations = list()
+	for(var/O in orange(10))
+		if(!isturf(O) && !iscarbon(O))
+			continue
+		var/atom/A = O
+		if(A.x > world.maxx - 8 || A.x < 8)
+			continue // putting them at the edge is dumb
+		if(A.y > world.maxy - 8 || A.y < 8)
+			continue
+		var/area/AA = get_area(A)
+		if(AA.tele_proof == 1)
+			continue // Telescience-proofed areas require a beacon.
+		possible_random_locations += A
+
+	if(possible_random_locations.len)
+		L["None (Dangerous)"] = pick(possible_random_locations)
 	var/t1 = input(user, "Please select a teleporter to lock in on.", "Hand Teleporter") as null|anything in L
 	if(!t1 || (user.get_active_hand() != src || user.stat || user.restrained()))
 		return


### PR DESCRIPTION
This basically means you have a super low chance to end up being
teleported _inside_ a mob. The teleport datum changes are to accommodate
this, it previously used get_turf regardless of target, now it will
actually set location to the proper target if applicable.

:cl:
rscadd: The hand tele's random mode may now end up putting you inside someone. Don't forget your telebatons at home!
/:cl: