### PR TITLE
Don't step on the glass

### DIFF
--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -71,7 +71,7 @@
 /obj/item/weapon/shard/Crossed(AM as mob|obj)
 	if(isliving(AM))
 		var/mob/living/M = AM
-		if(M.incorporeal_move || M.flying)//you are incorporal or flying..no shard stepping!
+		if(M.incorporeal_move || M.flying || M.throwing)//you are incorporal or flying or being thrown ..no shard stepping!
 			return
 		to_chat(M, "<span class='danger'>You step on \the [src]!</span>")
 		playsound(src.loc, 'sound/effects/glass_step.ogg', 50, 1) // not sure how to handle metal shards with sounds


### PR DESCRIPTION
Thrown mobs will not step on broken glass while being thrown.

This change prevents the following image from occurring, this is more of a possibility with the LINDA PR, but can still occur on the production server as it stands now.

![Walking on broken glass](https://i.imgur.com/9BoEMQa.png)

🆑Alffd
tweak: Thrown mobs will not step on broken glass while being thrown.
/🆑

Thanks @tigercat2000!