### PR TITLE
add log files for cells

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -63,6 +63,24 @@
 			stat |= BROKEN
 		update_icon()
 
+/obj/machinery/door_timer/proc/print_report()
+	var/logname = input(usr, "Name of the guilty?","[id] log name")
+	var/logcharges = input(usr, "What are they being charged with?","[id] log charges")
+
+	for(var/obj/machinery/computer/prisoner/C in prisoncomputer_list)
+
+		var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(C.loc)
+		P.name = "[id] log - [logname]"
+		P.info =  "<center><b>[id] - Brig record</b></center><br><hr><br>"
+		P.info += "<center>NSS Cyberaid - Security Department</center><br>"
+		P.info += "<center><small><b>Admission data:</b></small></center><br>"
+		P.info += "<small><b>Log generated at:   </b>		[worldtime2text(world.time)]<br>"
+		P.info += "<b>Suspect:</b>		[logname]<br>"
+		P.info += "<b>Duration:</b>		[timetoset/60/10]<br>"
+		P.info += "<b>Charge(s):</b>		[logcharges] minute(s)<br>"
+		P.info += "<b>Arresting Officer:</b>		[usr.name]<br><hr><br>"
+		P.info += "<small>Disclaimer: This is an automatic generated log file upon activation of a cell timer. Please store this file and save it for record purposes.</small>"
+
 /obj/machinery/door_timer/Destroy()
 	QDEL_NULL(Radio)
 	targets.Cut()
@@ -100,6 +118,8 @@
 /obj/machinery/door_timer/proc/timer_start()
 	if(stat & (NOPOWER|BROKEN))
 		return 0
+
+	print_report()
 
 	// Set releasetime
 	releasetime = world.timeofday + timetoset


### PR DESCRIPTION
Upon activation of a cell timer, user will be asked to input name and charges. A cell log file(paper) will be generated at all prison mangement computers.

<img>https://i.gyazo.com/d9fb6799ba374a4523636c3b2c8b78c2.png<img>


also, this is my first PR and code so hit it hard.