### PR TITLE
Fixes Deep-Fried Grabs and Display Case Grabs

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -256,7 +256,7 @@ var/global/list/captain_display_cases = list()
 			new /obj/machinery/constructable_frame/machine_frame(T)
 		qdel(src)
 		return
-	if(istype(W,/obj/item/weapon/grab))
+	if(W.flags & ABSTRACT)
 		to_chat(user, "<span class='danger'>You can't put this into the case.</span>")
 		return
 	if(user.a_intent == I_HARM)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -256,6 +256,9 @@ var/global/list/captain_display_cases = list()
 			new /obj/machinery/constructable_frame/machine_frame(T)
 		qdel(src)
 		return
+	if(istype(W,/obj/item/weapon/grab))
+		to_chat(user, "<span class='danger'>You can't put this into the case.</span>")
+		return
 	if(user.a_intent == I_HARM)
 		if(locked && !destroyed)
 			src.health -= W.force

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -61,7 +61,7 @@
 		head.disfigure("burn")
 		add_logs(user, G.affecting, "deep-fried", addition="'s face")
 		qdel(G) //Removes the grip so the person MIGHT have a small chance to run the fuck away and to prevent rapid dunks.
-		return 1
+		return 0
 	return 0
 
 

--- a/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill_new.dm
@@ -57,5 +57,5 @@
 		C.adjustFireLoss(30)
 		add_logs(user, G.affecting, "burned", src)
 		qdel(G) //Removes the grip to prevent rapid sears and give you a chance to run
-		return 1
+		return 0
 	return 0

--- a/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/oven_new.dm
@@ -63,5 +63,5 @@
 		C.Weaken(2)
 		add_logs(user, G.affecting, "smashed", addition="'s head on [src]")
 		qdel(G) //Removes the grip to prevent rapid bashes. With the weaken, you PROBABLY can't run unless they are slow to grab you again...
-		return 1
+		return 0
 	return 0


### PR DESCRIPTION
Fixes two issues: the ability to cook/deep-fry grabs and the ability to put grabs into display cases.

Fixes #7212
Fixes #7239

:cl: Twinmold
Fix: No longer able to put grabs into kitchen equipment (deep-fried grab).
Fix: No longer able to put grabs inside of display cases.
/:cl: