### PR TITLE
Radios no longer double-dip initialize 4noraisin

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -26,7 +26,7 @@
 
 	// If you're wondering what goofery this is, this is for things that need the environment
 	// around them set up - like `air_update_turf` and the like
-	if((ticker && ticker.current_state == GAME_STATE_PLAYING))
+	if((ticker && ticker.current_state >= GAME_STATE_SETTING_UP))
 		attempt_init()
 
 /atom/movable/Destroy()
@@ -231,7 +231,7 @@
 			if(isobj(A))
 				if(A.density && !A.throwpass)	// **TODO: Better behaviour for windows which are dense, but shouldn't always stop movement
 					src.throw_impact(A,speed)
-					
+
 /atom/movable/proc/throw_at_fast(atom/target, range, speed, thrower, no_spin)
 	set waitfor = 0
 	throw_at(target, range, speed, thrower, no_spin)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -66,8 +66,6 @@ var/global/list/default_medbay_channels = list(
 /obj/item/device/radio/New()
 	..()
 	wires = new(src)
-	if(radio_controller)
-		initialize()
 
 	internal_channels = default_internal_channels.Copy()
 	global_radios |= src


### PR DESCRIPTION
Was causing GC issues and I saw no point to doing it this way. If you call `initialize` outside of where it is done automatically, make sure you have a VERY good reason, and add a comment explaining why!