### PR TITLE
Fixes repaired r-walls not smoothing

### DIFF
--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -109,6 +109,7 @@
 					d_state = 0
 					update_icon()
 					src.icon_state = "r_wall"
+					update_icon()
 					to_chat(user, "<span class='notice'>You replace the outer grille.</span>")
 				else
 					to_chat(user, "<span class='warning'>You don't have enough rods for that!</span>")


### PR DESCRIPTION
When wirecut, and rod re-applied to the cut area, the wall wouldn't re-smooth.

Moving the update_icon() to afterwards only broke the icon entirely. Placing it in both locations fixed it.

:cl: Purpose2
fix: Repaired reinforced walls will now auto-smooth
:cl: