### PR TITLE
Adds cell timer logs

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -13,6 +13,7 @@ var/global/list/singularities = list()				//list of all singularities
 var/global/list/janitorial_equipment = list()		//list of janitorial equipment
 var/global/list/crafting_recipes = list() //list of all crafting recipes
 var/global/list/prisoncomputer_list = list()
+var/global/list/cell_logs = list()
 
 var/global/list/all_areas = list()
 var/global/list/machines = list()

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -12,6 +12,7 @@ var/global/list/airlocks = list()					//list of all airlocks
 var/global/list/singularities = list()				//list of all singularities
 var/global/list/janitorial_equipment = list()		//list of janitorial equipment
 var/global/list/crafting_recipes = list() //list of all crafting recipes
+var/global/list/prisoncomputer_list = list()
 
 var/global/list/all_areas = list()
 var/global/list/machines = list()

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -20,6 +20,14 @@
 /obj/machinery/computer/prisoner/attack_ai(var/mob/user as mob)
 	return src.attack_hand(user)
 
+/obj/machinery/computer/prisoner/New()
+ 	prisoncomputer_list += src
+ 	return ..()
+
+/obj/machinery/computer/prisoner/Destroy()
+ 	prisoncomputer_list -= src
+ 	return ..()
+
 /obj/machinery/computer/prisoner/attack_hand(var/mob/user as mob)
 	if(..())
 		return 1

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -141,6 +141,12 @@
 					qdel(R)
 				update_all_mob_security_hud()
 				setTemp("<h3>All records deleted.</h3>")
+			if("del_alllogs2")
+				if(cell_logs.len)
+					setTemp("<h3>All cell logs deleted.</h3>")
+					cell_logs.Cut()
+				else
+					to_chat(usr, "<span class='notice'>Error; No cell logs to delete.</span>")
 			if("del_r2")
 				if(active2)
 					qdel(active2)
@@ -254,6 +260,12 @@
 			buttons[++buttons.len] = list("name" = "No", "icon" = "times", "href" = null, "status" = null)
 			setTemp("<h3>Are you sure you wish to delete all records?</h3>", buttons)
 
+		else if(href_list["del_alllogs"])
+			var/list/buttons = list()
+			buttons[++buttons.len] = list("name" = "Yes", "icon" = "check", "href" = "del_alllogs2=1", "status" = null)
+			buttons[++buttons.len] = list("name" = "No", "icon" = "times", "href" = null, "status" = null)
+			setTemp("<h3>Are you sure you wish to delete all cell logs?</h3>", buttons)
+
 		else if(href_list["del_rg"])
 			if(active1)
 				var/list/buttons = list()
@@ -343,16 +355,22 @@
 				printing = 0
 
 		else if(href_list["printlogs"])
-			var/obj/item/weapon/paper/P = (input(usr, "Select log to print", "Available Cell Logs") as null|anything in cell_logs)
-			if(!P)
-				return 0
-			playsound(src.loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
-			to_chat(usr, "<span class='danger'>Printing [P.name].</span>")
-			sleep(50)
-			var/obj/item/weapon/paper/LOG = new /obj/item/weapon/paper(src.loc)
-			LOG.name = P.name
-			LOG.info = P.info
-			return 1
+			if(cell_logs.len && !printing)
+				var/obj/item/weapon/paper/P = input(usr, "Select log to print", "Available Cell Logs") as null|anything in cell_logs
+				if(!P)
+					return 0
+				printing = 1
+				playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+				to_chat(usr, "<span class='notice'>Printing file [P.name].</span>")
+				sleep(50)
+				var/obj/item/weapon/paper/log = new /obj/item/weapon/paper(loc)
+				log.name = P.name
+				log.info = P.info
+				printing = 0
+				return 1
+			else
+				to_chat(usr, "<span class='notice'>[src] has no logs stored or is already printing.</span>")
+
 
 		else if(href_list["add_c"])
 			if(istype(active2, /datum/data/record))
@@ -366,7 +384,6 @@
 			var/index = min(max(text2num(href_list["del_c"]) + 1, 1), length(active2.fields["comments"]))
 			if(istype(active2, /datum/data/record) && active2.fields["comments"][index])
 				active2.fields["comments"] -= active2.fields["comments"][index]
-				return 0
 
 		if(href_list["field"])
 			if(..())

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -120,7 +120,7 @@
 				else
 					security["empty"] = 1
 	return data
-	
+
 /obj/machinery/computer/secure_data/Topic(href, href_list)
 	if(..())
 		return 1
@@ -342,6 +342,18 @@
 					create_record_photo(active1)
 				printing = 0
 
+		else if(href_list["printlogs"])
+			var/obj/item/weapon/paper/P = (input(usr, "Select log to print", "Available Cell Logs") as null|anything in cell_logs)
+			if(!P)
+				return 0
+			playsound(src.loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+			to_chat(usr, "<span class='danger'>Printing [P.name].</span>")
+			sleep(50)
+			var/obj/item/weapon/paper/LOG = new /obj/item/weapon/paper(src.loc)
+			LOG.name = P.name
+			LOG.info = P.info
+			return 1
+
 		else if(href_list["add_c"])
 			if(istype(active2, /datum/data/record))
 				var/a2 = active2
@@ -354,6 +366,7 @@
 			var/index = min(max(text2num(href_list["del_c"]) + 1, 1), length(active2.fields["comments"]))
 			if(istype(active2, /datum/data/record) && active2.fields["comments"][index])
 				active2.fields["comments"] -= active2.fields["comments"][index]
+				return 0
 
 		if(href_list["field"])
 			if(..())
@@ -454,10 +467,10 @@
 
 /obj/machinery/computer/secure_data/proc/setTemp(text, list/buttons = list())
 	temp = list("text" = text, "buttons" = buttons, "has_buttons" = buttons.len > 0)
-	
-/obj/machinery/computer/secure_data/proc/update_all_mob_security_hud()	
+
+/obj/machinery/computer/secure_data/proc/update_all_mob_security_hud()
 	for(var/mob/living/carbon/human/H in mob_list)
-		H.sec_hud_set_security_status()	
+		H.sec_hud_set_security_status()
 
 /obj/machinery/computer/secure_data/proc/create_record_photo(datum/data/record/R)
 	// basically copy-pasted from the camera code but different enough that it has to be redone

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -28,8 +28,33 @@
 	var/list/obj/machinery/targets = list()
 	var/timetoset = 0		// Used to set releasetime upon starting the timer
 	var/obj/item/device/radio/Radio
+	var/printed = 0
 	maptext_height = 26
 	maptext_width = 32
+
+/obj/machinery/door_timer/proc/print_report()
+ 	var/logname = input(usr, "Name of the guilty?","[id] log name")
+ 	var/logcharges = input(usr, "What have they been charged with?","[id] log charges")
+
+ 	if(!logname || !logcharges)
+  		return 0
+
+ 	for(var/obj/machinery/computer/prisoner/C in prisoncomputer_list)
+ 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(C.loc)
+ 			P.name = "[id] log - [logname]"
+ 			P.info =  "<center><b>[id] - Brig record</b></center><br><hr><br>"
+ 			P.info += {"<center>[station_name()] - Security Department</center><br>
+ 						<center><small><b>Admission data:</b></small></center><br>
+ 						<small><b>Log generated at:</b>		[worldtime2text(world.time)]<br>
+ 						<b>Detainee:</b>		[logname]<br>
+ 						<b>Duration:</b>		[timetoset/60/10] minute(s)<br>
+ 						<b>Charge(s):</b>	[logcharges]<br>
+ 						<b>Arresting Officer:</b>		[usr.name]<br><hr><br>
+ 						<small>This log file was generated automatically upon activation of a cell timer.</small>"}
+
+ 			playsound(C.loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+
+ 	return 1
 
 /obj/machinery/door_timer/initialize()
 	..()
@@ -98,8 +123,14 @@
 
 // Closes and locks doors, power check
 /obj/machinery/door_timer/proc/timer_start()
+
 	if(stat & (NOPOWER|BROKEN))
 		return 0
+
+	if(!printed)
+		if(!print_report())
+			timing = 0
+			return 0
 
 	// Set releasetime
 	releasetime = world.timeofday + timetoset
@@ -134,6 +165,7 @@
 
 	// Reset releasetime
 	releasetime = 0
+	printed = 0
 
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
 		if(!door.density)
@@ -277,6 +309,7 @@
 				F.flash()
 
 		if(href_list["change"])
+			printed = 1
 			timer_start()
 
 	add_fingerprint(usr)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -41,7 +41,7 @@
 
  	for(var/obj/machinery/computer/prisoner/C in prisoncomputer_list)
  			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper(C.loc)
- 			P.name = "[id] log - [logname]"
+ 			P.name = "[id] log - [logname] [worldtime2text()]"
  			P.info =  "<center><b>[id] - Brig record</b></center><br><hr><br>"
  			P.info += {"<center>[station_name()] - Security Department</center><br>
  						<center><small><b>Admission data:</b></small></center><br>
@@ -53,7 +53,7 @@
  						<small>This log file was generated automatically upon activation of a cell timer.</small>"}
 
  			playsound(C.loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
-
+ 			cell_logs += P
  	return 1
 
 /obj/machinery/door_timer/initialize()

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -47,7 +47,7 @@
  						<center><small><b>Admission data:</b></small></center><br>
  						<small><b>Log generated at:</b>		[worldtime2text()]<br>
  						<b>Detainee:</b>		[logname]<br>
- 						<b>Duration:</b>		[timetoset/60/10] minute(s)<br>
+ 						<b>Duration:</b>		[timetoset/10] seconds<br>
  						<b>Charge(s):</b>	[logcharges]<br>
  						<b>Arresting Officer:</b>		[usr.name]<br><hr><br>
  						<small>This log file was generated automatically upon activation of a cell timer.</small>"}

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -45,7 +45,7 @@
  			P.info =  "<center><b>[id] - Brig record</b></center><br><hr><br>"
  			P.info += {"<center>[station_name()] - Security Department</center><br>
  						<center><small><b>Admission data:</b></small></center><br>
- 						<small><b>Log generated at:</b>		[worldtime2text(world.time)]<br>
+ 						<small><b>Log generated at:</b>		[worldtime2text()]<br>
  						<b>Detainee:</b>		[logname]<br>
  						<b>Duration:</b>		[timetoset/60/10] minute(s)<br>
  						<b>Charge(s):</b>	[logcharges]<br>

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -34,7 +34,7 @@
 
 /obj/machinery/door_timer/proc/print_report()
  	var/logname = input(usr, "Name of the guilty?","[id] log name")
- 	var/logcharges = input(usr, "What have they been charged with?","[id] log charges")
+ 	var/logcharges = stripped_multiline_input(usr, "What have they been charged with?","[id] log charges")
 
  	if(!logname || !logcharges)
   		return 0

--- a/nano/templates/secure_data.tmpl
+++ b/nano/templates/secure_data.tmpl
@@ -112,6 +112,7 @@ Used In File(s): \code\game\machinery\computer\security.dm
 		</div>
 		<h3><center>Menu</center></h3>
 		<div class="line">{{:helper.link('Record Maintenance', 'wrench', {'screen' : 2})}}</div>
+		<div class="line">{{:helper.link('Cell Logs', 'print', {'printlogs' : 1})}}</div>
 		<div class="line">{{:helper.link('Logout', 'lock', {'logout' : 1})}}</div>
 	{{else data.screen == 2}} <!-- SEC_DATA_MAINT -->
 		<h3>Records Maintenance</h3>

--- a/nano/templates/secure_data.tmpl
+++ b/nano/templates/secure_data.tmpl
@@ -112,13 +112,14 @@ Used In File(s): \code\game\machinery\computer\security.dm
 		</div>
 		<h3><center>Menu</center></h3>
 		<div class="line">{{:helper.link('Record Maintenance', 'wrench', {'screen' : 2})}}</div>
-		<div class="line">{{:helper.link('Cell Logs', 'print', {'printlogs' : 1})}}</div>
+		<div class="line">{{:helper.link('Print Cell Log', 'print', {'printlogs' : 1})}}</div>
 		<div class="line">{{:helper.link('Logout', 'lock', {'logout' : 1})}}</div>
 	{{else data.screen == 2}} <!-- SEC_DATA_MAINT -->
 		<h3>Records Maintenance</h3>
 		<div class="line">{{:helper.link('Backup To Disk', 'download', {'back' : 1}, 'disabled')}}</div>
-		<div class="line">{{:helper.link('Upload From disk', 'upload', {'u_load' : 1}, 'disabled')}}</div>
+		<div class="line">{{:helper.link('Upload From Disk', 'upload', {'u_load' : 1}, 'disabled')}}</div>
 		<div class="line">{{:helper.link('Delete All Records', 'trash', {'del_all' : 1})}}</div>
+		<div class="line">{{:helper.link('Delete All Cell Logs', 'trash', {'del_alllogs' : 1})}}</div>
 		<div class="line">{{:helper.link('Back', 'arrow-left', {'screen' : 1})}}</div>
 	{{else data.screen == 3}} <!-- SEC_DATA_RECORD -->
 		<h3><center>Security Record</center></h3>


### PR DESCRIPTION
Sorry for all the github spam
OLD PR: https://github.com/ParadiseSS13/Paradise/pull/7228

Upon starting a cell timer user will now be prompted for names and charges. If both are given it will print a cell log(paper) at prison management consoles which can be stored by the Warden. 

Afterwards the timer will start and door close. If you don't fill out both inputs the cell timer will not run. If you choose to adjust time during sentence it will not ask for inputs again or print a new paper.

UPDATE. These cell logs will also be saved to the record computer and can be printed again by choosing it from the "Print Cell Log" Button. Other way around, these cell logs can also be deleted from "Record Maintenance"

![example](https://i.gyazo.com/338211cf7b591ba30a0dbef0c3fee9a8.png)
![example](https://i.gyazo.com/85049c8a57cf3a5dea6aceea67caf32d.png)
![example](https://i.gyazo.com/2955c1830b955ce6663aa13d34a8e317.png)
![example](https://i.gyazo.com/57dd389edc36075b0a0cd1a9d4f39eb2.png)

Thanks to all the help and handholding from everyone! 

:cl: Fruerlund
add: adds a new game mechanic. When activating a cell timer it will demand input and charges then print a paper at prison management consoles
add: adds saving cell logs and the option to delete them
edit: Edits a lowercase to uppercase in the template.
:cl: