### PR TITLE
Adds italics and strikethrough to OOC

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -82,7 +82,20 @@ var/global/admin_ooc_colour = "#b82e00"
 			if(!config.disable_ooc_emoji)
 				msg = "<span class='emoji_enabled'>[msg]</span>"
 
+			msg = apply_formatting(msg)
+
 			to_chat(C, "<font color='[display_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
+
+/proc/apply_formatting(message)
+	var/static/regex/italics = new("(?<!\\\\)\\*(.*?)(?<!\\\\)\\*", "g")
+	var/static/regex/strikethrough = new("(?<!\\\\)~(?<!\\\\)~(.*?)(?<!\\\\)~(?<!\\\\)~", "g")
+	var/static/regex/escape = new("(?<!\\\\)\\\\(\[~\\*\\\\\])", "g")
+
+	message = italics.Replace(message, "<i>$1</i>")
+	message = strikethrough.Replace(message, "<s>$1</s>")
+	message = escape.Replace(message, "$1")//jesus christ, regex
+
+	return message
 
 /proc/toggle_ooc()
 	config.ooc_allowed = ( !config.ooc_allowed )


### PR DESCRIPTION
Works like in Markdown.

`~~memes~~` produces ~~memes~~

`*memes*` produces *memes*

All OOC text is already bold, so it makes no sense to let people make it more bold.

Use `\` to escape characters to not apply them.

![](http://i.imgur.com/AHv1wHg.png)

I'm 90% sure there's a better, cleaner way to do this, but I wasn't able to find it.