### PR TITLE
Give nukeops magboots

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -999,6 +999,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/elite_hardsuit
 	cost = 8
 	reference = "ESHS"
+	excludefrom = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/suits/hardsuit/shielded
@@ -1007,6 +1008,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/box/syndie_kit/shielded_hardsuit
 	cost = 30
 	reference = "SHS"
+	excludefrom = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 
 
@@ -1055,6 +1057,7 @@ var/list/uplink_items = list()
 	reference = "ABRMB"
 	item = /obj/item/clothing/shoes/magboots/syndie/advance
 	cost = 3
+	excludefrom = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/plastic_explosives

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -991,6 +991,7 @@ var/list/uplink_items = list()
 	reference = "BRHS"
 	item = /obj/item/weapon/storage/box/syndie_kit/hardsuit
 	cost = 8
+	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/suits/hardsuit/elite
 	name = "Elite Syndicate Hardsuit"
@@ -1045,6 +1046,14 @@ var/list/uplink_items = list()
 	These reverse-engineered knockoffs of Nanotrasen's 'Advanced Magboots' slow you down in simulated-gravity environments much like the standard issue variety."
 	reference = "BRMB"
 	item = /obj/item/clothing/shoes/magboots/syndie
+	cost = 3
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/device_tools/magboots/advance
+	name = "Advanced Blood-Red Magboots"
+	desc = "Reverse-engineered magboots that appear to be based on an advanced model, as they have a lighter magnetic pull. Property of Gorlex Marauders."
+	reference = "ABRMB"
+	item = /obj/item/clothing/shoes/magboots/syndie/advance
 	cost = 3
 	gamemodes = list(/datum/game_mode/nuclear)
 

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -27,6 +27,7 @@
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
 	new /obj/item/weapon/tank/jetpack/oxygen/harness(src)
+	new /obj/item/clothing/shoes/magboots/syndie(src)
 
 /obj/structure/closet/syndicate/nuclear
 	desc = "It's a storage unit for a Syndicate boarding party.."


### PR DESCRIPTION
Puts a pair of blood red magboots in syndi suit storage.

This allows them to better perform EVA operations in support of the syndicate.

🆑 Alffd
add: A pair of blood red magboots have been added to all nukeops suit storage lockers.
add: Adds the ability to purchase advanced magboots from the nukeops uplink.
del: Removes magboots from the nukeops uplink.
del: Removes nukeops basic hardsuits from the nukeops uplink.
🆑