### PR TITLE
Fixes Some Diseases Not GCing

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -155,7 +155,7 @@ var/list/diseases = subtypesof(/datum/disease)
 		if(disease_flags & CAN_RESIST)
 			if(!(type in affected_mob.resistances))
 				affected_mob.resistances += type
-				remove_virus()
+		remove_virus()
 	qdel(src)
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -2,13 +2,11 @@
 	mob_list -= src
 	dead_mob_list -= src
 	living_mob_list -= src
-	qdel(hud_used)
-	hud_used = null
+	QDEL_NULL(hud_used)
 	if(mind && mind.current == src)
 		spellremove(src)
 	mobspellremove(src)
-	for(var/infection in viruses)
-		qdel(infection)
+	QDEL_LIST(viruses)
 	ghostize()
 	for(var/mob/dead/observer/M in following_mobs)
 		M.following = null

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -7,8 +7,8 @@
 	if(mind && mind.current == src)
 		spellremove(src)
 	mobspellremove(src)
-	for(var/datum/disease/D in viruses)
-		D.cure(0)
+	for(var/infection in viruses)
+		qdel(infection)
 	ghostize()
 	for(var/mob/dead/observer/M in following_mobs)
 		M.following = null

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -7,8 +7,8 @@
 	if(mind && mind.current == src)
 		spellremove(src)
 	mobspellremove(src)
-	for(var/infection in viruses)
-		qdel(infection)
+	for(var/datum/disease/D in viruses)
+		D.cure(0)
 	ghostize()
 	for(var/mob/dead/observer/M in following_mobs)
 		M.following = null


### PR DESCRIPTION
I noticed a few diseases that don't GC; really the only external refs to diseases, from what I can see are a mob's virus list (and blood, which is unused); then I noticed this.

The only time a virus is ever fully removed from a mob is when you can resist the disease (ie: develop immunity); otherwise, it deletes the disease but leaves it to be stuck in your virus list until its hard deleted (and then remains as a null entry).

Either case, fixed now! I was going to push this to TG too, but it seems they already fixed it. RIP.