### PR TITLE
Easier shoe silencing

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -175,27 +175,15 @@
 	item_color = "noble_boot"
 	item_state = "noble_boot"
 
-
 /obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/shoe_silencer))
-		silence_steps = 1
-		shoe_sound = null
-		user.unEquip(I)
-		qdel(I)
-	else . = ..()
-
-/obj/item/shoe_silencer
-	name = "shoe rags"
-	desc = "Looks sneaky."
-	icon_state = "sheet-cloth"
-
-/datum/crafting_recipe/shoe_rags
-	name = "Shoe Rags"
-	result = /obj/item/shoe_silencer
-	reqs = list(/obj/item/stack/tape_roll = 10)
-	tools = list(/obj/item/weapon/wirecutters)
-	time = 40
-	category = CAT_MISC
+	if(istype(I, /obj/item/stack/tape_roll))
+		var/obj/item/stack/tape_roll/TR = I
+		if((!silence_steps || shoe_sound) && TR.use(4))
+			silence_steps = 1
+			shoe_sound = null
+			to_chat(user, "You tape the soles of [src] to silence their footsteps.")
+	else
+		return ..()
 
 /obj/item/clothing/shoes/sandal/white
 	name = "White Sandals"


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: You can now silence shoes just by using some duct tape on them! Shoe rags no longer exist.
/:cl:

Seriously, who needs wirecutters to cut duct tape?

No more shoe rags. Just click  with duct tape on a pair of shoes. You can silence 2.5 pairs of shoes with a single roll.