### PR TITLE
Adds radios and prisoner IDs to prisoner lockers

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -606,6 +606,12 @@
 	name = "Prisoner #13-007"
 	registered_name = "Prisoner #13-007"
 
+/obj/item/weapon/card/id/prisoner/random
+/obj/item/weapon/card/id/prisoner/random/New()
+	var/random_number = "#[rand(0, 99)]-[rand(0, 999)]"
+	name = "Prisoner [random_number]"
+	registered_name = name
+
 /obj/item/weapon/card/id/salvage_captain
 	name = "Captain's ID"
 	registered_name = "Captain"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -376,8 +376,10 @@
 
 	New()
 		..()
-		new /obj/item/clothing/under/color/orange/prison( src )
-		new /obj/item/clothing/shoes/orange( src )
+		new /obj/item/clothing/under/color/orange/prison(src)
+		new /obj/item/clothing/shoes/orange(src)
+		new /obj/item/weapon/card/id/prisoner/random(src)
+		new /obj/item/device/radio/headset(src)
 
 
 


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: Brig lockers now have radios and prisoner IDs. As per SOP!
/:cl:

So Officers don't have to run to the locker room and hope there's a spare radio for the Syndicate Agent they're about to perma.

The IDs have their numbers randomly generated. My conservative estimates say one pair of IDs will have the same number once every 200 shifts, but you most likely won't notice anyway. It seems there's some sort of a convention with the current IDs, but I don't care about the lore of prisoner ID numbers. I'm sorry.