### PR TITLE
Fixes Disposal Bin Light

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -467,6 +467,7 @@
 			I.loc = src
 			for(var/mob/M in viewers(src))
 				M.show_message("\the [I] lands in \the [src].", 3)
+			update()
 		else
 			for(var/mob/M in viewers(src))
 				M.show_message("\the [I] bounces off of \the [src]'s rim!.", 3)


### PR DESCRIPTION
Fixes #7304

- Items thrown successfully into a Disposal Bin will now turn the "contents" light on correctly

:cl:
fix: Disposal Bin Light now works with thrown items
/:cl: