### PR TITLE
Psychiatrist Traitor Item - The "Harmless Book"

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -327,6 +327,15 @@ var/list/uplink_items = list()
 	cost = 10
 	job = list("Life Support Specialist")
 
+//Psychiatrist
+/datum/uplink_item/jobspecific/mindbook
+	name = "A Harmless Book"
+	desc = "A harmless-looking book that will let you beam messages straight into the minds of people around you."
+	reference = "MB"
+	item = /obj/item/weapon/book/mindbook
+	cost = 3
+	job = list("Psychiatrist")
+
 //Stimulants
 
 /datum/uplink_item/jobspecific/stims

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -330,7 +330,7 @@ var/list/uplink_items = list()
 //Psychiatrist
 /datum/uplink_item/jobspecific/mindbook
 	name = "A Harmless Book"
-	desc = "A harmless-looking book that will let you beam messages straight into the minds of people around you."
+	desc = "A harmless-looking book that will let you beam messages straight into the minds of people around you, or torture them with hallucinations."
 	reference = "MB"
 	item = /obj/item/weapon/book/mindbook
 	cost = 3

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -293,13 +293,34 @@
 /obj/item/weapon/book/mindbook/attack_self(mob/living/H)
 	if(ishuman(H))
 		var/mob/living/carbon/human/P = H
-		if(!(P.mind && P.mind.assigned_role in list("Psychiatrist")))
+		if(!(P.mind && P.mind.assigned_role == "Psychiatrist"))
 			to_chat(P, "The book appears to be completely empty.")
 			P.adjustBrainLoss(5)
 			return
 		else
-			to_chat(P, "Seems to work!")
-			return
+			var/message = input("Torture your victim with voices in their head!")
+			if(!message)
+				return
+
+			var/list/victim_list = list()
+			for(var/mob/living/carbon/human/V in view(P.client.view, P))
+				if(!isliving(V))
+					continue
+				if(!(V.client && V.mind))
+					continue
+				if(PSY_RESIST in V.mutations)
+					continue
+				victim_list += V
+			if(!victim_list.len)
+				to_chat(P, "There are no available victims around!")
+				return
+			else
+				var/victim = input("Select your hapless victim!", "Cancel") as null|mob in victim_list
+				if(isnull(victim))
+					return
+				else
+					to_chat(victim, "<span class='notice'>[message]</span>")
+					return
 	else
 		return
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -10,7 +10,8 @@
 /*
  * Bookcase
  */
-#define HALCOOL 300
+#define HALCOOL 3000
+#define MESSAGE_DELAY 100
 
 /obj/structure/bookcase
 	name = "bookcase"
@@ -302,7 +303,7 @@
 			else
 				var/list/victim_list = list()
 				for(var/mob/living/carbon/human/V in view(P.client.view, P))
-					if(!(V.stat == DEAD))
+					if(V.stat == DEAD)
 						continue
 					if(!(V.client && V.mind))
 						continue
@@ -324,16 +325,9 @@
 								var/message = input("Torture your victim with voices in their head!")
 								if(!message)
 									return
-								else
-									var/list/intensity = list("Peaceful", "Forceful")
-									var/message_intensity = input("Select the intensity of your message!") as null|anything in intensity
-									switch(message_intensity)
-										if("Peaceful")
-											to_chat(victim, "<span class='notice'>[message]</span>")
-											return
-										if("Forceful")
-											to_chat(victim, "<span class='danger'>[message]</span>")
-											return
+								var/list/intensity = list("Peaceful", "Forceful")
+								var/message_intensity = input("Select the intensity of your message!") as null|anything in intensity
+								addtimer(src, "send_message", MESSAGE_DELAY, unique = FALSE, message_intensity, victim, message)
 							if("Hallucinations")
 								victim.AdjustHallucinate(60)
 								hallucinatory_cooldown = world.time + HALCOOL
@@ -345,6 +339,14 @@
 	else
 		return
 
+/obj/item/weapon/book/mindbook/proc/send_message(message_intensity, victim, message)
+	switch(message_intensity)
+		if("Peaceful")
+			to_chat(victim, "<span class='notice'>[message]</span>")
+			return
+		if("Forceful")
+			to_chat(victim, "<span class='danger'>[message]</span>")
+			return
 
 /*
  * Barcode Scanner

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -283,6 +283,24 @@
 	else
 		return ..()
 
+/obj/item/weapon/book/mindbook
+	name = "A Harmless Book"
+	icon = 'icons/obj/library.dmi'
+	icon_state ="book"
+	unique = 1
+	forbidden = 1
+
+/obj/item/weapon/book/mindbook/attack_self(var/mob/living/carbon/P as mob)
+	if(!ishuman(P))
+		return
+	if(!(P.mind && P.mind.assigned_role in list("Psychiatrist")))
+		to_chat(P, "The book appears to be completely empty.")
+		P.adjustBrainLoss(5)
+		return
+	else
+		to_chat(P, "Seems to work!")
+		return
+
 
 /*
  * Barcode Scanner

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -302,7 +302,7 @@
 			else
 				var/list/victim_list = list()
 				for(var/mob/living/carbon/human/V in view(P.client.view, P))
-					if(!isliving(V))
+					if(!(V.stat == DEAD))
 						continue
 					if(!(V.client && V.mind))
 						continue
@@ -335,12 +335,11 @@
 											to_chat(victim, "<span class='danger'>[message]</span>")
 											return
 							if("Hallucinations")
-								to_chat(victim, "<span class='danger'>You feel a presence bearing down on you...</span>")
 								victim.AdjustHallucinate(60)
 								hallucinatory_cooldown = world.time + HALCOOL
 								return
 		else
-			to_chat(P, "You cannot make sense of the book's contents. Your head hurts.")
+			to_chat(P, "The book seems to be empty.")
 			P.adjustBrainLoss(10)
 			return
 	else

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -290,15 +290,17 @@
 	unique = 1
 	forbidden = 1
 
-/obj/item/weapon/book/mindbook/attack_self(var/mob/living/carbon/P as mob)
-	if(!ishuman(P))
-		return
-	if(!(P.mind && P.mind.assigned_role in list("Psychiatrist")))
-		to_chat(P, "The book appears to be completely empty.")
-		P.adjustBrainLoss(5)
-		return
+/obj/item/weapon/book/mindbook/attack_self(mob/living/H)
+	if(ishuman(H))
+		var/mob/living/carbon/human/P = H
+		if(!(P.mind && P.mind.assigned_role in list("Psychiatrist")))
+			to_chat(P, "The book appears to be completely empty.")
+			P.adjustBrainLoss(5)
+			return
+		else
+			to_chat(P, "Seems to work!")
+			return
 	else
-		to_chat(P, "Seems to work!")
 		return
 
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -10,6 +10,7 @@
 /*
  * Bookcase
  */
+#define HALCOOL 300
 
 /obj/structure/bookcase
 	name = "bookcase"
@@ -289,6 +290,7 @@
 	icon_state ="book"
 	unique = 1
 	forbidden = 1
+	var/hallucinatory_cooldown
 
 /obj/item/weapon/book/mindbook/attack_self(mob/living/H)
 	if(ishuman(H))
@@ -298,36 +300,49 @@
 			P.adjustBrainLoss(5)
 			return
 		else
-			var/message = input("Torture your victim with voices in their head!")
-			if(!message)
-				return
-
-			var/list/victim_list = list()
-			for(var/mob/living/carbon/human/V in view(P.client.view, P))
-				if(!isliving(V))
-					continue
-				if(!(V.client && V.mind))
-					continue
-				if(PSY_RESIST in V.mutations)
-					continue
-				victim_list += V
-			if(!victim_list.len)
-				to_chat(P, "There are no available victims around!")
+			if(hallucinatory_cooldown > world.time)
+				to_chat(P, "The book needs to recharge.")
 				return
 			else
-				var/victim = input("Select your hapless victim!", "Cancel") as null|mob in victim_list
-				if(isnull(victim))
+				var/list/victim_list = list()
+				for(var/mob/living/carbon/human/V in view(P.client.view, P))
+					if(!isliving(V))
+						continue
+					if(!(V.client && V.mind))
+						continue
+					if(PSY_RESIST in V.mutations)
+						continue
+					victim_list += V
+				if(!victim_list.len)
+					to_chat(P, "There are no available victims around!")
 					return
 				else
-					var/list/intensity = list("Peaceful", "Forceful")
-					var/message_intensity = input("Select the intensity of your message!") as null|anything in intensity
-					switch(message_intensity)
-						if("Peaceful")
-							to_chat(victim, "<span class='notice'>[message]</span>")
-							return
-						if("Forceful")
-							to_chat(victim, "<span class='danger'>[message]</span>")
-							return
+					var/mob/living/victim = input("Select your hapless victim!", "Cancel") as null|mob in victim_list
+					if(isnull(victim))
+						return
+					else
+						var/torture = list("Hallucinations", "Voices")
+						var/torture_type = input("Select how best to torture your victim.", "Cancel") as null|anything in torture
+						switch(torture_type)
+							if("Voices")
+								var/message = input("Torture your victim with voices in their head!")
+								if(!message)
+									return
+								else
+									var/list/intensity = list("Peaceful", "Forceful")
+									var/message_intensity = input("Select the intensity of your message!") as null|anything in intensity
+									switch(message_intensity)
+										if("Peaceful")
+											to_chat(victim, "<span class='notice'>[message]</span>")
+											return
+										if("Forceful")
+											to_chat(victim, "<span class='danger'>[message]</span>")
+											return
+							if("Hallucinations")
+								to_chat(victim, "<span class='danger'>You feel a presence bearing down on you...</span>")
+								victim.AdjustHallucinate(60)
+								hallucinatory_cooldown = world.time + HALCOOL
+								return
 	else
 		return
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -295,11 +295,7 @@
 /obj/item/weapon/book/mindbook/attack_self(mob/living/H)
 	if(ishuman(H))
 		var/mob/living/carbon/human/P = H
-		if(!(P.mind && P.mind.assigned_role == "Psychiatrist"))
-			to_chat(P, "The book appears to be completely empty.")
-			P.adjustBrainLoss(5)
-			return
-		else
+		if((P.mind && P.mind.assigned_role == "Psychiatrist") || prob(50))
 			if(hallucinatory_cooldown > world.time)
 				to_chat(P, "The book needs to recharge.")
 				return
@@ -343,6 +339,10 @@
 								victim.AdjustHallucinate(60)
 								hallucinatory_cooldown = world.time + HALCOOL
 								return
+		else
+			to_chat(P, "You cannot make sense of the book's contents. Your head hurts.")
+			P.adjustBrainLoss(10)
+			return
 	else
 		return
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -11,7 +11,6 @@
  * Bookcase
  */
 #define HALCOOL 3000
-#define MESSAGE_DELAY 100
 
 /obj/structure/bookcase
 	name = "bookcase"
@@ -327,9 +326,17 @@
 									return
 								var/list/intensity = list("Peaceful", "Forceful")
 								var/message_intensity = input("Select the intensity of your message!") as null|anything in intensity
-								addtimer(src, "send_message", MESSAGE_DELAY, unique = FALSE, message_intensity, victim, message)
+								spawn(100)
+								switch(message_intensity)
+									if("Peaceful")
+										to_chat(victim, "<span class='notice'>[message]</span>")
+										return
+									if("Forceful")
+										to_chat(victim, "<span class='danger'>[message]</span>")
+										return
 							if("Hallucinations")
-								victim.AdjustHallucinate(60)
+								to_chat(P, "<span class='notice'>You torment your foe with mental visions.</span>")
+								victim.AdjustHallucinate(100)
 								hallucinatory_cooldown = world.time + HALCOOL
 								return
 		else
@@ -338,15 +345,6 @@
 			return
 	else
 		return
-
-/obj/item/weapon/book/mindbook/proc/send_message(message_intensity, victim, message)
-	switch(message_intensity)
-		if("Peaceful")
-			to_chat(victim, "<span class='notice'>[message]</span>")
-			return
-		if("Forceful")
-			to_chat(victim, "<span class='danger'>[message]</span>")
-			return
 
 /*
  * Barcode Scanner

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -319,8 +319,15 @@
 				if(isnull(victim))
 					return
 				else
-					to_chat(victim, "<span class='notice'>[message]</span>")
-					return
+					var/list/intensity = list("Peaceful", "Forceful")
+					var/message_intensity = input("Select the intensity of your message!") as null|anything in intensity
+					switch(message_intensity)
+						if("Peaceful")
+							to_chat(victim, "<span class='notice'>[message]</span>")
+							return
+						if("Forceful")
+							to_chat(victim, "<span class='danger'>[message]</span>")
+							return
 	else
 		return
 


### PR DESCRIPTION
Introducing a 3 Telecrystal Psychiatrist-only Traitor Item: the "Harmless Book", AKA, the "Mind Book".

How it works:

- It affects every living player within visual range that does not have Psychic Resistance;

- It can trigger either Hallucinations, or Voices;

- Hallucinations makes your target hallucinate for one minute, with the book then having to go through a five minute cooldown;

- Voices lets you narrate directly to your target, as a voice in their head, if you will. It also lets you pick between a "Forceful" and "Peaceful" voice, affecting font;

- Psychiatrists can use this item without any danger. Non-Psychiatrists have a 50% chance of failure every time they try to use the book, leading to 10 Brain Damage if they fail

The intended purpose is to provide for the Psychiatrist a unique method to torture/take down someone via continuous mental torture.

:cl:
add: Adds the "Harmless Book", a psychiatrist-only traitor item that can speak directly to the mind of other players, or trigger hallucinations in them
/:cl: