### PR TITLE
Mouth coverings block Food and Drinks

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -939,6 +939,45 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 /mob/living/carbon/proc/eat(var/obj/item/weapon/reagent_containers/food/toEat, mob/user, var/bitesize_override)
 	if(!istype(toEat))
 		return 0
+
+	var/skip_check = 0
+	//skip the check if:
+	if(istype(toEat, /obj/item/weapon/reagent_containers/food/pill/patch))
+		//the item being fed is a patch (they typically aren't applied to the mouth anyways)
+		skip_check = 1
+
+	if(!skip_check)
+		var/covered = 0
+		var/snowflek = 0
+		if(head && (head.flags_cover & HEADCOVERSMOUTH))
+			if(istype(head, /obj/item/clothing/head/helmet/space/eva/plasmaman))
+				snowflek = 1
+			else
+				covered = 1
+		if(wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH) && !wear_mask.mask_adjusted)
+			if(snowflek)
+				if(!istype(wear_mask, /obj/item/clothing/mask/breath))
+					covered = 1
+			else
+				covered = 1
+		if(covered)
+			if(user == src)
+				to_chat(user, "<span class='warning'>Your mouth is covered, preventing you from ingesting [toEat]!</span>")
+			else
+				if(prob(5) && !istype(toEat, /obj/item/weapon/reagent_containers/food/drinks))	//don't annoy them with a drink, but do annoy them with food and pills (5% chance)
+					var/list/possible_quips = list("CHOO CHOO! Here comes the train! Open the tunnel!",
+													"NNNEEEARRROW! Here comes the airplane! Open the hanger!",
+													"This is NTV DELICIOUS, requesting permission to dock. Clear the docking zone.",
+													"LET ME FEED YOU!",
+													"There are starving children in the Epsilon Indi system, so eat up!")
+					if(istype(toEat, /obj/item/weapon/reagent_containers/food/pill))
+						possible_quips -= "LET ME FEED YOU!"
+						possible_quips += "TAKE YOUR MEDICINE!"
+					user.say(pick(possible_quips))
+				visible_message("<span class='warning'>[user] pushes [toEat] into the face of [src], but their mouth is covered!</span>")
+			return 0
+
+
 	var/fullness = nutrition + 10
 	if(istype(toEat, /obj/item/weapon/reagent_containers/food/snacks))
 		for(var/datum/reagent/consumable/C in reagents.reagent_list) //we add the nutrition value of what we're currently digesting


### PR DESCRIPTION
Eating and drinking now requires open access to the consumer's mouth.

Helmets and masks which cover the mouth (HEADCOVERSMOUTH and MASKCOVERSMOUTH flags respectively) now prevent the consumption of food, drinks, and pills.
- Masks which are pushed down won't block consumption since they don't cover the mouth while adjusted.

Plasmamen helmets won't block consumption on their own.
- If worn with a mask, the plasmaman will only be able to eat if
  - They have a breath mask on underneath
  - OR have a mask that doesn't cover the mouth and/or is pushed down underneath.
- This is since they literally explode into flames if they take the helmet off, which would lead to them killing themselves because they want a bite of steak.

Vox gotta deal.
- Vox is pox.
  - In seriousness though, the minor toxins damage they take from the half second of O2 exposure is the risk they gotta take. You picked a race with an obvious downside, I'm not inclined to babyproof the station for you so you can ignore that weakness. Plasmamen only get the special treatment because they literally burst into flames if they take their helmet off, so they'd take way more damage.

Attempting to forcefeed another person whose mouth is covered will rarely cause you to spout a quip at them.
- Food and pills can trigger a quip, drinks will not.
![image](https://cloud.githubusercontent.com/assets/8988254/26281060/ea9d29ba-3db8-11e7-9509-96df6e0321b0.png)
- The chance is 5%, so it is going to take some serious luck or major spamming to see these frequently.

:cl:
tweak: Eating and drinking now requires unobstructed access to the mouth. No eating through those gasmasks!
/:cl: