### PR TITLE
Adds a print report functions to Handheld Chemistry Equipment

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -145,7 +145,7 @@
 	name = "Pull The Starting Cord"
 
 /datum/action/item_action/print_report
-	name = "Print Forensic Report"
+	name = "Print Report"
 
 /datum/action/item_action/toggle_gunlight
 	name = "Toggle Gunlight"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -379,7 +379,6 @@ REAGENT SCANNER
 	origin_tech = "magnets=2;biotech=2"
 	var/details = 0
 	var/recent_fail = 0
-	var/datatoprint = ""
 
 /obj/item/device/mass_spectrometer/New()
 	..()
@@ -425,9 +424,22 @@ REAGENT SCANNER
 					return
 				else
 					recent_fail = 1
-		to_chat(user, "[dat]")
-		datatoprint = dat
-		reagents.clear_reagents()
+		if(dat)
+			to_chat(user, "Trace chemicals detected in blood sample: [dat]")
+			if(alert("Do you want to print a log file?","Scan Results","Yes", "No") == "Yes")
+				usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
+				playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+				sleep(30)
+				var/obj/item/weapon/paper/P = new(usr.loc)
+				P.name = "Mass Spectrometer Scanner Report: [worldtime2text()]"
+				P.info = "<center><b>Mass Spectrometer</b></center><br><center>Data Analysis:</center><br><hr><br><b>Trace chemicals detected:</b><br>[dat]<br><hr>"
+				usr.put_in_hands(P)
+				reagents.clear_reagents()
+			else
+				reagents.clear_reagents()
+		else
+			reagents.clear_reagents()
+			to_chat(user, "<span class='notice'>No trace chemicals detected in blood sample.</span>")
 	return
 
 /obj/item/device/mass_spectrometer/adv
@@ -435,19 +447,6 @@ REAGENT SCANNER
 	icon_state = "adv_spectrometer"
 	details = 1
 	origin_tech = "magnets=4;biotech=2"
-
-/obj/item/device/mass_spectrometer/verb/print_report()
-	set name = "Print Scanner report"
-	set category = "Object"
-
-	usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
-	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
-	sleep(30)
-	var/obj/item/weapon/paper/P = new(usr.loc)
-	P.name = "Mass Spectrometer Scanner Report: [worldtime2text()]"
-	P.info = "<center><b>Mass Spectrometer</b></center><br><center>Data Analysis:</center><br><hr><br><b>Trace chemicals detected:</b><br>[datatoprint]<br><hr>"
-	datatoprint = ""
-	usr.put_in_hands(P)
 
 /obj/item/device/reagent_scanner
 	name = "reagent scanner"
@@ -464,7 +463,6 @@ REAGENT SCANNER
 	origin_tech = "magnets=2;biotech=2"
 	var/details = 0
 	var/recent_fail = 0
-	var/datatoprint = ""
 
 /obj/item/device/reagent_scanner/afterattack(obj/O, mob/user as mob)
 	if(user.stat)
@@ -477,7 +475,6 @@ REAGENT SCANNER
 	if(crit_fail)
 		to_chat(user, "<span class='warning'>This device has critically failed and is no longer functional!</span>")
 		return
-
 	if(!isnull(O.reagents))
 		var/dat = ""
 		if(O.reagents.reagent_list.len > 0)
@@ -494,12 +491,18 @@ REAGENT SCANNER
 					recent_fail = 1
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found: [dat]</span>")
-			datatoprint = dat
+			if(alert("Do you want to print a log file?","Scan Results","Yes", "No") == "Yes")
+				usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
+				playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+				sleep(30)
+				var/obj/item/weapon/paper/P = new(usr.loc)
+				P.name = "Reagent Scanner Report: [worldtime2text()]"
+				P.info = "<center><b>Reagent Scanner</b></center><br><center>Data Analysis:</center><br><hr><br><b>Chemical agents detected:</b><br> [dat]<br><hr>"
+				usr.put_in_hands(P)
 		else
 			to_chat(user, "<span class='notice'>No active chemical agents found in [O].</span>")
 	else
 		to_chat(user, "<span class='notice'>No significant chemical agents found in [O].</span>")
-
 	return
 
 /obj/item/device/reagent_scanner/adv
@@ -507,19 +510,6 @@ REAGENT SCANNER
 	icon_state = "adv_spectrometer"
 	details = 1
 	origin_tech = "magnets=4;biotech=2"
-
-/obj/item/device/reagent_scanner/verb/print_report()
-	set name = "Print Scanner report"
-	set category = "Object"
-
-	usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
-	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
-	sleep(30)
-	var/obj/item/weapon/paper/P = new(usr.loc)
-	P.name = "Reagent Scanner Report: [worldtime2text()]"
-	P.info = "<center><b>Reagent Scanner</b></center><br><center>Data Analysis:</center><br><hr><br><b>Chemical agents detected:</b><br> [datatoprint]<br><hr>"
-	datatoprint = ""
-	usr.put_in_hands(P)
 
 /obj/item/device/slime_scanner
 	name = "slime scanner"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -379,6 +379,7 @@ REAGENT SCANNER
 	origin_tech = "magnets=2;biotech=2"
 	var/details = 0
 	var/recent_fail = 0
+	var/datatoprint = ""
 
 /obj/item/device/mass_spectrometer/New()
 	..()
@@ -409,7 +410,7 @@ REAGENT SCANNER
 			else
 				blood_traces = params2list(R.data["trace_chem"])
 				break
-		var/dat = "Trace Chemicals Found: "
+		var/dat = ""
 		for(var/R in blood_traces)
 			if(prob(reliability))
 				if(details)
@@ -425,6 +426,7 @@ REAGENT SCANNER
 				else
 					recent_fail = 1
 		to_chat(user, "[dat]")
+		datatoprint = dat
 		reagents.clear_reagents()
 	return
 
@@ -433,6 +435,19 @@ REAGENT SCANNER
 	icon_state = "adv_spectrometer"
 	details = 1
 	origin_tech = "magnets=4;biotech=2"
+
+/obj/item/device/mass_spectrometer/verb/print_report()
+	set name = "Print Scanner report"
+	set category = "Object"
+
+	usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+	sleep(30)
+	var/obj/item/weapon/paper/P = new(usr.loc)
+	P.name = "Mass Spectrometer Scanner Report: [worldtime2text()]"
+	P.info = "<center><b>Mass Spectrometer</b></center><br><center>Data Analysis:</center><br><hr><br><b>Trace chemicals detected:</b><br>[datatoprint]<br><hr>"
+	datatoprint = ""
+	usr.put_in_hands(P)
 
 /obj/item/device/reagent_scanner
 	name = "reagent scanner"
@@ -449,6 +464,7 @@ REAGENT SCANNER
 	origin_tech = "magnets=2;biotech=2"
 	var/details = 0
 	var/recent_fail = 0
+	var/datatoprint = ""
 
 /obj/item/device/reagent_scanner/afterattack(obj/O, mob/user as mob)
 	if(user.stat)
@@ -478,6 +494,7 @@ REAGENT SCANNER
 					recent_fail = 1
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found: [dat]</span>")
+			datatoprint = dat
 		else
 			to_chat(user, "<span class='notice'>No active chemical agents found in [O].</span>")
 	else
@@ -490,6 +507,19 @@ REAGENT SCANNER
 	icon_state = "adv_spectrometer"
 	details = 1
 	origin_tech = "magnets=4;biotech=2"
+
+/obj/item/device/reagent_scanner/verb/print_report()
+	set name = "Print Scanner report"
+	set category = "Object"
+
+	usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+	sleep(30)
+	var/obj/item/weapon/paper/P = new(usr.loc)
+	P.name = "Reagent Scanner Report: [worldtime2text()]"
+	P.info = "<center><b>Reagent Scanner</b></center><br><center>Data Analysis:</center><br><hr><br><b>Chemical agents detected:</b><br> [datatoprint]<br><hr>"
+	datatoprint = ""
+	usr.put_in_hands(P)
 
 /obj/item/device/slime_scanner
 	name = "slime scanner"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -379,6 +379,9 @@ REAGENT SCANNER
 	origin_tech = "magnets=2;biotech=2"
 	var/details = 0
 	var/recent_fail = 0
+	var/datatoprint = ""
+	var/scanning = 1
+	actions_types = list(/datum/action/item_action/print_report)
 
 /obj/item/device/mass_spectrometer/New()
 	..()
@@ -415,7 +418,7 @@ REAGENT SCANNER
 				if(details)
 					dat += "[R] ([blood_traces[R]] units) "
 				else
-					dat += "[R] "
+					dat += "[R] <br>"
 				recent_fail = 0
 			else
 				if(recent_fail)
@@ -426,17 +429,9 @@ REAGENT SCANNER
 					recent_fail = 1
 		if(dat)
 			to_chat(user, "Trace chemicals detected in blood sample: [dat]")
-			if(alert("Do you want to print a log file?","Scan Results","Yes", "No") == "Yes")
-				usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
-				playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
-				sleep(30)
-				var/obj/item/weapon/paper/P = new(usr.loc)
-				P.name = "Mass Spectrometer Scanner Report: [worldtime2text()]"
-				P.info = "<center><b>Mass Spectrometer</b></center><br><center>Data Analysis:</center><br><hr><br><b>Trace chemicals detected:</b><br>[dat]<br><hr>"
-				usr.put_in_hands(P)
-				reagents.clear_reagents()
-			else
-				reagents.clear_reagents()
+			datatoprint = dat
+			scanning = 0
+			reagents.clear_reagents()
 		else
 			reagents.clear_reagents()
 			to_chat(user, "<span class='notice'>No trace chemicals detected in blood sample.</span>")
@@ -447,6 +442,28 @@ REAGENT SCANNER
 	icon_state = "adv_spectrometer"
 	details = 1
 	origin_tech = "magnets=4;biotech=2"
+
+/obj/item/device/mass_spectrometer/proc/print_report()
+	if(!scanning)
+		usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
+		playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+		sleep(50)
+
+		var/obj/item/weapon/paper/P = new(get_turf(src))
+		P.name = "Mass Spectrometer Scanner Report: [worldtime2text()]"
+		P.info = "<center><b>Mass Spectrometer</b></center><br><center>Data Analysis:</center><br><hr><br><b>Trace chemicals detected:</b><br>[datatoprint]<br><hr>"
+
+		if(ismob(loc))
+			var/mob/M = loc
+			M.put_in_hands(P)
+			to_chat(M, "<span class='notice'>Report printed. Log cleared.<span>")
+			datatoprint = ""
+			scanning = 1
+	else
+		to_chat(usr, "<span class='notice'>[src] has no logs or is already in use.</span>")
+
+/obj/item/device/mass_spectrometer/ui_action_click()
+	print_report()
 
 /obj/item/device/reagent_scanner
 	name = "reagent scanner"
@@ -463,6 +480,9 @@ REAGENT SCANNER
 	origin_tech = "magnets=2;biotech=2"
 	var/details = 0
 	var/recent_fail = 0
+	var/datatoprint = ""
+	var/scanning = 1
+	actions_types = list(/datum/action/item_action/print_report)
 
 /obj/item/device/reagent_scanner/afterattack(obj/O, mob/user as mob)
 	if(user.stat)
@@ -491,14 +511,8 @@ REAGENT SCANNER
 					recent_fail = 1
 		if(dat)
 			to_chat(user, "<span class='notice'>Chemicals found: [dat]</span>")
-			if(alert("Do you want to print a log file?","Scan Results","Yes", "No") == "Yes")
-				usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
-				playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
-				sleep(30)
-				var/obj/item/weapon/paper/P = new(usr.loc)
-				P.name = "Reagent Scanner Report: [worldtime2text()]"
-				P.info = "<center><b>Reagent Scanner</b></center><br><center>Data Analysis:</center><br><hr><br><b>Chemical agents detected:</b><br> [dat]<br><hr>"
-				usr.put_in_hands(P)
+			datatoprint = dat
+			scanning = 0
 		else
 			to_chat(user, "<span class='notice'>No active chemical agents found in [O].</span>")
 	else
@@ -510,6 +524,28 @@ REAGENT SCANNER
 	icon_state = "adv_spectrometer"
 	details = 1
 	origin_tech = "magnets=4;biotech=2"
+
+/obj/item/device/reagent_scanner/proc/print_report()
+	if(!scanning)
+		usr.visible_message("<span class='warning'>[src] rattles and prints out a sheet of paper.</span>")
+		playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+		sleep(50)
+
+		var/obj/item/weapon/paper/P = new(get_turf(src))
+		P.name = "Reagent Scanner Report: [worldtime2text()]"
+		P.info = "<center><b>Reagent Scanner</b></center><br><center>Data Analysis:</center><br><hr><br><b>Chemical agents detected:</b><br> [datatoprint]<br><hr>"
+
+		if(ismob(loc))
+			var/mob/M = loc
+			M.put_in_hands(P)
+			to_chat(M, "<span class='notice'>Report printed. Log cleared.<span>")
+			datatoprint = ""
+			scanning = 1
+	else
+		to_chat(usr, "<span class='notice'>[src]  has no logs or is already in use.</span>")
+
+/obj/item/device/reagent_scanner/ui_action_click()
+	print_report()
 
 /obj/item/device/slime_scanner
 	name = "slime scanner"


### PR DESCRIPTION
Mass Spectrometers and Reagent Scanners will now print reports if users
choose to via an action button

As inspired by @TullyBurnalot autopsy PR

![example](https://i.gyazo.com/82495536dc146b445b620e619990f4ff.png)
![example](https://i.gyazo.com/3cbffaaeaf4e1cefacb4470e3b77f9c5.png)

:cl: Fruerlund
add: adds an option to mass spectrometers and reagent scanners to print a report with the scan data
edit: renames the item_action from "Print Forensic Report" to "Print Report" so it can be used for the handheld chemistry equipment too
:cl: