### PR TITLE
Corrects Oversight & Fixes a Bug w/ Roundstart Disabilities

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -826,7 +826,8 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	return 1
 
 /datum/preferences/proc/ShowDisabilityState(mob/user,flag,label)
-	if(flag==DISABILITY_FLAG_FAT && species!=("Human" || "Tajaran" || "Grey"))
+	var/datum/species/S = all_species[species]
+	if(flag==DISABILITY_FLAG_FAT && !(S.flags & CAN_BE_FAT))
 		return "<li><i>[species] cannot be fat.</i></li>"
 	return "<li><b>[label]:</b> <a href=\"?_src_=prefs;task=input;preference=disabilities;disability=[flag]\">[disabilities & flag ? "Yes" : "No"]</a></li>"
 
@@ -1088,7 +1089,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			if("input")
 				var/dflag=text2num(href_list["disability"])
 				if(dflag >= 0)
-					if(dflag==DISABILITY_FLAG_FAT && (S.flags & CAN_BE_FAT))
+					if(!(dflag==DISABILITY_FLAG_FAT && !(S.flags & CAN_BE_FAT))) //If the disability isn't fatness, toggle it. If it IS fatness, check to see if the species can be fat before going ahead.
 						disabilities ^= text2num(href_list["disability"]) //MAGIC
 				SetDisabilities(user)
 			else


### PR DESCRIPTION
The roundstart disability bug is my own doing from PR #7019 and reported in issue #7369.
The other line changed was an oversight-- a place I should've used the CAN_BE_FAT flag but didn't, and thus an inconsistency that I felt right to correct in this pass.

:cl:
fix: Fixes a bug where only the fat roundstart disability could be selected.
/:cl: