### PR TITLE
Adds a jobs board to the newscaster

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -68,6 +68,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 #define NEWSCASTER_D_NOTICE_FC	9	// D-Notice feed channel
 #define NEWSCASTER_W_ISSUE_H	10	// Wanted Issue handler
 #define NEWSCASTER_W_ISSUE		11	// STATIONWIDE WANTED ISSUE
+#define NEWSCASTER_JOBS			12	// Available jobs
 
 /obj/machinery/newscaster
 	name = "newscaster"
@@ -94,6 +95,21 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 	var/silence = 0
 	var/temp = null
 	var/temp_back_screen = NEWSCASTER_MAIN
+	var/list/jobblacklist = list(
+		/datum/job/ai,
+		/datum/job/cyborg,
+		/datum/job/captain,
+		/datum/job/judge,
+		/datum/job/blueshield,
+		/datum/job/nanotrasenrep,
+		/datum/job/pilot,
+		/datum/job/brigdoc,
+		/datum/job/mechanic,
+		/datum/job/barber,
+		/datum/job/chaplain,
+		/datum/job/ntnavyofficer,
+		/datum/job/ntspecops,
+		/datum/job/civilian)
 
 	var/static/REDACTED = "<b class='bad'>\[REDACTED\]</b>"
 	light_range = 0
@@ -252,6 +268,14 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			data["criminal"] = news_network.wanted_issue.author
 			data["description"] = news_network.wanted_issue.body
 			data["photo"] = news_network.wanted_issue.img ? icon2base64(news_network.wanted_issue.img) : 0
+		if(12)
+			var/list/jobs = list()
+			data["jobs"] = jobs
+			for(var/datum/job/job in job_master.occupations)
+				if(job_blacklisted(job))
+					continue
+				if(job.is_position_available())
+					jobs[++jobs.len] = list("title" = job.title)
 	return data
 
 /obj/machinery/newscaster/Topic(href, href_list)
@@ -535,6 +559,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		if(can_scan(usr))
 			scan_user(usr) //Newscaster scans you
 
+	else if(href_list["jobs"])
+		screen = NEWSCASTER_JOBS
+
 	nanomanager.update_uis(src)
 	return 1
 
@@ -747,6 +774,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 
 
 ////////////////////////////////////helper procs
+
+/obj/machinery/newscaster/proc/job_blacklisted(datum/job/job)
+	return (job.type in jobblacklist)
 
 /obj/machinery/newscaster/proc/scan_user(mob/user)
 	if(ishuman(user))                      							 //User is a human

--- a/nano/styles/_formatting.less
+++ b/nano/styles/_formatting.less
@@ -156,6 +156,11 @@
     float: left;
 }
 
+.jobValues {
+	float: left;
+	width: 30%;
+}
+
 // CHROMELESS STUFF
 
 .fancy {

--- a/nano/templates/newscaster.tmpl
+++ b/nano/templates/newscaster.tmpl
@@ -31,6 +31,7 @@ Property of Nanotrasen</font><br>
 			{{if data.wanted_issue}}
 				<div class='line'>{{:helper.link('Read Wanted issue', 'exclamation-triangle', {'view_wanted' : 1})}}</div>
 			{{/if}}
+			<div class='line'>{{:helper.link('View available NT jobs', 'share', {'jobs' : 1})}}</div>
 			<div class='line'>{{:helper.link('Create feed channel', 'plus', {'create_channel' : 1})}}</div>
 			<div class='line'>{{:helper.link('View feed channels', 'arrow-right', {'view' : 1})}}</div>
 			<div class='line'>{{:helper.link('Submit new feed story', 'share', {'create_feed_story' : 1})}}</div>
@@ -296,6 +297,23 @@ Property of Nanotrasen</font><br>
 		</div>
 		<div class='item'>
 			<div class='line'>{{:helper.link('Back', 'arrow-left', {'setScreen' : 0})}}</div>
+		</div>
+	{{else data.screen == 12}} <!-- NEWSCASTER_JOBS -->
+		<center><h3 class='good'>CAREERS AT NANOTRASEN</h3>
+		<i><font size=1>Work for a better future.</font></i></center>
+		<hr>
+		{{for data.jobs}}
+			<div class='jobValues'>
+				{{:value.title}}<br>
+			</div>
+			{{empty}}
+				<i>No available jobs...</i>
+		{{/for}}
+		
+		<hr>
+		<div class='item'>
+			<div class='line'>{{:helper.link('Refresh', 'refresh', {'refresh' : 0})}}</div>
+			<div class='line'>{{:helper.link('Back', 'arrow-left', {'setScreen' : 1})}}</div>
 		</div>
 	{{/if}}
 {{/if}}


### PR DESCRIPTION
This adds a jobs board, that lists what jobs are available through the Newscaster. No longer (hopefully) should people enter the HOP line saying "I'm a doctor, engineer and world renowned scientist!" they can enter the queue and proudly say "gimme dat Janitor job you got going".

I'm still wrestling with the CSS, because 50% of the time it ignores my styles entirely.

:cl: Purpose2
add: Adds a jobs board to the Newscaster. See what roles are available before seeing the HoP!
/ :cl: