### PR TITLE
Visibly message when someone points a gun at something

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -66,6 +66,7 @@
 			return 1
 		A.visible_message("<span class='danger'>[src] points [hand_item] at [A]!</span>",
 											"<span class='userdanger'>[src] points [hand_item] at you!</span>")
+		A << 'sound/weapons/TargetOn.ogg'
 		return 1
 	visible_message("<b>[src]</b> points to [A]")
 	return 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -59,6 +59,15 @@
 		return 0
 	if(!..())
 		return 0
+	if(ishuman(src))
+		var/obj/item/hand_item = src.get_active_hand()
+		if(hand_item && istype(hand_item, /obj/item/weapon/gun) && A != hand_item)
+			if(src.a_intent == I_HELP || !ismob(A))
+				visible_message("<b>[src]</b> points to [A] with [hand_item]")
+				return 1
+			A.visible_message("<span class='warning'><b>[src] points [hand_item] at [A]!</span>",
+												"<span class='danger'><font size=4><b>[src] points [hand_item] at you!</span>")
+			return 1
 	visible_message("<b>[src]</b> points to [A]")
 	return 1
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -59,15 +59,14 @@
 		return 0
 	if(!..())
 		return 0
-	if(ishuman(src))
-		var/obj/item/hand_item = src.get_active_hand()
-		if(hand_item && istype(hand_item, /obj/item/weapon/gun) && A != hand_item)
-			if(src.a_intent == I_HELP || !ismob(A))
-				visible_message("<b>[src]</b> points to [A] with [hand_item]")
-				return 1
-			A.visible_message("<span class='warning'><b>[src] points [hand_item] at [A]!</span>",
-												"<span class='danger'><font size=4><b>[src] points [hand_item] at you!</span>")
+	var/obj/item/hand_item = get_active_hand()
+	if(istype(hand_item, /obj/item/weapon/gun) && A != hand_item)
+		if(a_intent == I_HELP || !ismob(A))
+			visible_message("<b>[src]</b> points to [A] with [hand_item]")
 			return 1
+		A.visible_message("<span class='danger'>[src] points [hand_item] at [A]!</span>",
+											"<span class='userdanger'>[src] points [hand_item] at you!</span>")
+		return 1
 	visible_message("<b>[src]</b> points to [A]")
 	return 1
 


### PR DESCRIPTION
People missed the RP factor of targeting mode when it was removed, so this is intended to bring that part of targeting mode back. Basically a less fancy version of StratusSS13/Stratus-legacy#18. Thanks @FlattestGuitar for the help!

You can't point a gun at itself, and help intent or pointing it at a non-mob will result in a less aggressive message, just in case you missed your point or forgot you were on help intent. I didn't add the targeting reticule back in, so pointing is visually the exact same as before.

Works with borgs now, too, thanks @tigercat2000!

Now has a sound notification so you don't miss the message if you're the target.

View from pointer:
![pointer](https://cloud.githubusercontent.com/assets/26497062/26473044/fbe5e312-415d-11e7-9294-03549ac873cc.png)

View from pointee:
![pointee](https://cloud.githubusercontent.com/assets/26497062/26473051/03a52054-415e-11e7-9746-6976559ba050.png)

:cl: Tayyyyyyy, FlattestGuitar
add: A targeting mode-esque message and sound when you point at something with a gun in your active hand
/:cl:
