### PR TITLE
Cyborg Rodeo

### DIFF
--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -150,7 +150,7 @@
 
 
 /datum/riding/janicart/get_offsets(pass_index) // list(dir = x, y, layer)
-	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(-12, 7), "[EAST]" = list(0, 7), "[WEST]" = list( 12, 7))
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(0, 7), "[EAST]" = list(-12, 7), "[WEST]" = list( 12, 7))
 
 
 
@@ -226,7 +226,7 @@
 	keytype = /obj/item/key/ambulance
 
 /datum/riding/ambulance/get_offsets(pass_index) // list(dir = x, y, layer)
-	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(-12, 7), "[EAST]" = list(0, 7), "[WEST]" = list( 12, 7))
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(0, 7), "[EAST]" = list(-12, 7), "[WEST]" = list( 12, 7))
 
 ///////////////BOATS////////////
 /datum/riding/boat

--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -81,7 +81,7 @@
 		return
 	next_vehicle_move = world.time + vehicle_move_delay
 	if(keycheck(user))
-		if(!Process_Spacemove(direction) || !isturf(ridden.loc))
+		if(!ridden.Process_Spacemove(direction) || !isturf(ridden.loc))
 			return
 		step(ridden, direction)
 
@@ -404,6 +404,7 @@
 
 /obj/item/riding_offhand/dropped()
 	selfdeleting = TRUE
+	qdel(src)
 	. = ..()
 
 /obj/item/riding_offhand/equipped()
@@ -416,4 +417,5 @@
 	if(selfdeleting)
 		if(rider in ridden.buckled_mob)
 			ridden.unbuckle_mob(rider)
+			qdel(src)
 	. = ..()

--- a/code/datums/riding.dm
+++ b/code/datums/riding.dm
@@ -1,0 +1,419 @@
+/datum/riding
+	var/next_vehicle_move = 0 //used for move delays
+	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
+	var/keytype = null
+	var/atom/movable/ridden = null
+
+	var/slowed = FALSE
+	var/slowvalue = 1
+
+/datum/riding/New(atom/movable/_ridden)
+	ridden = _ridden
+
+/datum/riding/Destroy()
+	ridden = null
+	return ..()
+
+/datum/riding/proc/handle_vehicle_layer()
+	if(ridden.dir != NORTH)
+		ridden.layer = ABOVE_MOB_LAYER
+	else
+		ridden.layer = OBJ_LAYER
+
+/datum/riding/proc/on_vehicle_move()
+	for(var/mob/living/M in ridden.buckled_mob)
+		ride_check(M)
+	handle_vehicle_offsets()
+	handle_vehicle_layer()
+
+/datum/riding/proc/ride_check(mob/living/M)
+	return TRUE
+
+/datum/riding/proc/force_dismount(mob/living/M)
+	ridden.unbuckle_mob(M)
+
+/datum/riding/proc/handle_vehicle_offsets()
+	var/ridden_dir = "[ridden.dir]"
+	var/passindex = 0
+	if(ridden.has_buckled_mobs())
+		for(var/m in ridden.buckled_mob)
+			passindex++
+			var/mob/living/buckled_mob = m
+			var/list/offsets = get_offsets(passindex)
+			dir_loop:
+				for(var/offsetdir in offsets)
+					if(offsetdir == ridden_dir)
+						var/list/diroffsets = offsets[offsetdir]
+						buckled_mob.pixel_x = diroffsets[1]
+						if(diroffsets.len == 2)
+							buckled_mob.pixel_y = diroffsets[2]
+						if(diroffsets.len == 3)
+							buckled_mob.layer = diroffsets[3]
+						break dir_loop
+
+
+//Override this to set your vehicle's various pixel offsets
+/datum/riding/proc/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 0), "[SOUTH]" = list(0, 0), "[EAST]" = list(0, 0), "[WEST]" = list(0, 0))
+
+//KEYS
+/datum/riding/proc/keycheck(mob/user)
+	if(keytype)
+		if(istype(user.l_hand, keytype) || istype(user.r_hand, keytype))
+			return TRUE
+	else
+		return TRUE
+	return FALSE
+
+//BUCKLE HOOKS
+/datum/riding/proc/restore_position(mob/living/buckled_mob)
+	if(istype(buckled_mob))
+		buckled_mob.pixel_x = 0
+		buckled_mob.pixel_y = 0
+
+//MOVEMENT
+/datum/riding/proc/handle_ride(mob/user, direction)
+	if(user.incapacitated())
+		Unbuckle(user)
+		return
+
+	if(world.time < next_vehicle_move)
+		return
+	next_vehicle_move = world.time + vehicle_move_delay
+	if(keycheck(user))
+		if(!Process_Spacemove(direction) || !isturf(ridden.loc))
+			return
+		step(ridden, direction)
+
+		handle_vehicle_layer()
+		handle_vehicle_offsets()
+	else
+		to_chat(user, "<span class='notice'>You'll need the keys in one of your hands to drive \the [ridden.name].</span>")
+
+/datum/riding/proc/Unbuckle(atom/movable/M)
+	addtimer(CALLBACK(ridden, /atom/movable/.proc/unbuckle_mob, M), 0, 0x1)
+
+
+//atv
+/datum/riding/atv
+	keytype = /obj/item/key
+	vehicle_move_delay = 1
+
+/datum/riding/atv/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(0, 4), "[EAST]" = list(0, 4), "[WEST]" = list( 0, 4))
+
+
+/datum/riding/atv/handle_vehicle_layer()
+	if(ridden.dir == SOUTH)
+		ridden.layer = ABOVE_MOB_LAYER
+	else
+		ridden.layer = OBJ_LAYER
+
+/datum/riding/atv/turret
+	var/obj/machinery/porta_turret/syndicate/vehicle_turret/turret = null
+
+/datum/riding/atv/turret/handle_vehicle_layer()
+	if(ridden.dir == SOUTH)
+		ridden.layer = ABOVE_MOB_LAYER
+	else
+		ridden.layer = OBJ_LAYER
+
+	if(turret)
+		if(ridden.dir == NORTH)
+			turret.layer = ABOVE_MOB_LAYER
+		else
+			turret.layer = OBJ_LAYER
+
+
+/datum/riding/atv/turret/handle_vehicle_offsets()
+	..()
+	if(turret)
+		turret.forceMove(get_turf(ridden))
+		switch(ridden.dir)
+			if(NORTH)
+				turret.pixel_x = 0
+				turret.pixel_y = 4
+			if(EAST)
+				turret.pixel_x = -12
+				turret.pixel_y = 4
+			if(SOUTH)
+				turret.pixel_x = 0
+				turret.pixel_y = 4
+			if(WEST)
+				turret.pixel_x = 12
+				turret.pixel_y = 4
+
+
+//pimpin ride
+/datum/riding/janicart
+	keytype = /obj/item/key/janitor
+
+
+/datum/riding/janicart/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(-12, 7), "[EAST]" = list(0, 7), "[WEST]" = list( 12, 7))
+
+
+
+/datum/riding/proc/account_limbs(mob/living/M)
+	var/mob/living/carbon/human/driver = M
+	var/obj/item/organ/external/l_leg = driver.get_organ("l_leg")
+	var/obj/item/organ/external/r_leg = driver.get_organ("r_leg")
+
+	if(!(l_leg || r_leg) && !slowed)
+		vehicle_move_delay = vehicle_move_delay + slowvalue
+		slowed = TRUE
+	else if(slowed)
+		vehicle_move_delay = vehicle_move_delay - slowvalue
+		slowed = FALSE
+
+
+///secway
+/datum/riding/secway
+	keytype = /obj/item/key/security
+
+/datum/riding/secway/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(0, 4), "[EAST]" = list(0, 4), "[WEST]" = list( 0, 4))
+
+/datum/riding/snowmobile
+	keytype = /obj/item/key/snowmobile
+
+/datum/riding/snowmobile/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(0, 4), "[EAST]" = list(0, 4), "[WEST]" = list( 0, 4))
+
+/datum/riding/motorcycle
+	keytype = null
+
+/datum/riding/motorcycle/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(0, 4), "[EAST]" = list(0, 4), "[WEST]" = list( 0, 4))
+
+//speedbike
+/datum/riding/space/speedbike
+	keytype = null
+	vehicle_move_delay = 0
+
+/datum/riding/space/speedbike/handle_vehicle_layer()
+	switch(ridden.dir)
+		if(NORTH,SOUTH)
+			ridden.pixel_x = -16
+			ridden.pixel_y = -16
+		if(EAST,WEST)
+			ridden.pixel_x = -18
+			ridden.pixel_y = 0
+
+/datum/riding/space/speedbike/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, -8), "[SOUTH]" = list(0, 4), "[EAST]" = list(-10, 5), "[WEST]" = list( 10, 5))
+
+//SPEEDUWAGON
+
+/datum/riding/speedwagon
+	vehicle_move_delay = 0
+
+/datum/riding/speedwagon/handle_vehicle_layer()
+	ridden.layer = BELOW_MOB_LAYER
+
+/datum/riding/space/speedwagon/get_offsets(pass_index) // list(dir = x, y, layer)
+	switch(pass_index)
+		if(1)
+			return list("[NORTH]" = list(-10, -4), "[SOUTH]" = list(16, 3), "[EAST]" = list(-4, 30), "[WEST]" = list(4, -3))
+		if(2)
+			return list("[NORTH]" = list(19, -5, 4), "[SOUTH]" = list(-13, 3, 4), "[EAST]" = list(-4, -3, 4.1), "[WEST]" = list(4, 28, 3.9))
+		if(3)
+			return list("[NORTH]" = list(-10, -18, 4.2), "[SOUTH]" = list(16, 25, 3.9), "[EAST]" = list(-22, 30), "[WEST]" = list(22, -3, 4.1))
+		if(4)
+			return list("[NORTH]" = list(19, -18, 4.2), "[SOUTH]" = list(-13, 25, 3.9), "[EAST]" = list(-22, 3, 3.9), "[WEST]" = list(22, 28))
+
+/datum/riding/ambulance
+	keytype = /obj/item/key/ambulance
+
+/datum/riding/ambulance/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(-12, 7), "[EAST]" = list(0, 7), "[WEST]" = list( 12, 7))
+
+///////////////BOATS////////////
+/datum/riding/boat
+	keytype = /obj/item/weapon/oar
+
+/datum/riding/boat/handle_ride(mob/user, direction)
+	var/turf/next = get_step(ridden, direction)
+	var/turf/current = get_turf(ridden)
+
+	if(istype(next, /turf/unsimulated/floor/lava) || istype(current, /turf/unsimulated/floor/lava)) //We can move from land to lava, or lava to land, but not from land to land
+		..()
+	else
+		to_chat(user, "Boats don't go on land!")
+		return 0
+
+/datum/riding/boat/dragon
+	keytype = null
+	vehicle_move_delay = 1
+
+/datum/riding/boat/dragon/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(1, 2), "[SOUTH]" = list(1, 2), "[EAST]" = list(1, 2), "[WEST]" = list( 1, 2))
+
+//general animals
+/datum/riding/animal
+	keytype = null
+
+/datum/riding/animal/handle_ride(mob/user, direction)
+	if(user.incapacitated())
+		Unbuckle(user)
+		return
+
+	if(world.time < next_vehicle_move)
+		return
+
+	next_vehicle_move = world.time + vehicle_move_delay
+	if(keycheck(user))
+		if(!isturf(ridden.loc))
+			return
+		step(ridden, direction)
+
+		handle_vehicle_layer()
+		handle_vehicle_offsets()
+	else
+		to_chat(user, "<span class='notice'>You'll need something  to guide the [ridden.name].</span>")
+
+///////Humans. Yes, I said humans. No, this won't end well...//////////
+/datum/riding/human
+	keytype = null
+
+/datum/riding/human/ride_check(mob/living/M)
+	var/mob/living/carbon/human/H = ridden	//IF this runtimes I'm blaming the admins.
+	if(M.incapacitated(FALSE, TRUE) || H.incapacitated(FALSE, TRUE))
+		M.visible_message("<span class='warning'>[M] falls off [ridden]!</span>")
+		Unbuckle(M)
+		return FALSE
+	if(M.restrained(TRUE))
+		M.visible_message("<span class='warning'>[M] can't hang onto [ridden] with their hands cuffed!</span>")	//Honestly this should put the ridden mob in a chokehold.
+		Unbuckle(M)
+		return FALSE
+	if(H.pulling == M)
+		H.stop_pulling()
+
+/datum/riding/human/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 6), "[SOUTH]" = list(0, 6), "[EAST]" = list(-6, 4), "[WEST]" = list( 6, 4))
+
+
+/datum/riding/human/handle_vehicle_layer()
+	if(ridden.buckled_mob)
+		if(ridden.dir == SOUTH)
+			ridden.layer = ABOVE_MOB_LAYER
+		else
+			ridden.layer = OBJ_LAYER
+	else
+		ridden.layer = MOB_LAYER
+
+/datum/riding/human/force_dismount(mob/living/user)
+	ridden.unbuckle_mob(user)
+	user.Weaken(3)
+	user.Stun(3)
+	user.visible_message("<span class='warning'>[ridden] pushes [user] off of them!</span>")
+
+/datum/riding/cyborg
+	keytype = null
+
+/datum/riding/cyborg/ride_check(mob/user)
+	if(user.incapacitated())
+		var/kick = TRUE
+		if(istype(ridden, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/R = ridden
+			if(R.module && R.module.ride_allow_incapacitated)
+				kick = FALSE
+		if(kick)
+			to_chat(user, "<span class='userdanger'>You fall off of [ridden]!</span>")
+			Unbuckle(user)
+			return
+	if(ishuman(user))
+		var/mob/living/carbon/human/carbonuser = user
+		var/obj/item/organ/external/l_hand = carbonuser.get_organ("l_hand")
+		var/obj/item/organ/external/r_hand = carbonuser.get_organ("r_hand")
+		if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
+			Unbuckle(user)
+			to_chat(user, "<span class='userdanger'>You can't grab onto [ridden] with no hands!</span>")
+			return
+
+/datum/riding/cyborg/handle_vehicle_layer()
+	if(ridden.buckled_mob)
+		if(ridden.dir == SOUTH)
+			ridden.layer = ABOVE_MOB_LAYER
+		else
+			ridden.layer = OBJ_LAYER
+	else
+		ridden.layer = MOB_LAYER
+
+/datum/riding/cyborg/get_offsets(pass_index) // list(dir = x, y, layer)
+	return list("[NORTH]" = list(0, 4), "[SOUTH]" = list(0, 4), "[EAST]" = list(-6, 3), "[WEST]" = list( 6, 3))
+
+/datum/riding/cyborg/handle_vehicle_offsets()
+	if(ridden.has_buckled_mobs())
+		for(var/mob/living/M in ridden.buckled_mob)
+			M.setDir(ridden.dir)
+			if(issilicon(ridden))
+				var/mob/living/silicon/robot/R = ridden
+				if(istype(R.module))
+					M.pixel_x = R.module.ride_offset_x[dir2text(ridden.dir)]
+					M.pixel_y = R.module.ride_offset_y[dir2text(ridden.dir)]
+			else
+				..()
+
+/datum/riding/cyborg/force_dismount(mob/living/M)
+	ridden.unbuckle_mob(M)
+	var/turf/target = get_edge_target_turf(ridden, ridden.dir)
+	var/turf/targetm = get_step(get_turf(ridden), ridden.dir)
+	M.Move(targetm)
+	M.visible_message("<span class='warning'>[M] is thrown clear of [ridden]!</span>")
+	M.throw_at(target, 14, 5, ridden)
+	M.Weaken(3)
+
+/datum/riding/proc/equip_buckle_inhands(mob/living/carbon/human/user, amount_required = 1)
+	var/amount_equipped = 0
+	for(var/amount_needed = amount_required, amount_needed > 0, amount_needed--)
+		var/obj/item/riding_offhand/inhand = new /obj/item/riding_offhand(user)
+		inhand.rider = user
+		inhand.ridden = ridden
+		if(user.put_in_hands(inhand, TRUE))
+			amount_equipped++
+		else
+			break
+	if(amount_equipped >= amount_required)
+		return TRUE
+	else
+		unequip_buckle_inhands(user)
+		return FALSE
+
+/datum/riding/proc/unequip_buckle_inhands(mob/living/carbon/user)
+	for(var/obj/item/riding_offhand/O in user.contents)
+		if(O.ridden != ridden)
+			CRASH("RIDING OFFHAND ON WRONG MOB")
+			continue
+		if(O.selfdeleting)
+			continue
+		else
+			qdel(O)
+	return TRUE
+
+/obj/item/riding_offhand
+	name = "offhand"
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "offhand"
+	w_class = WEIGHT_CLASS_HUGE
+	flags = ABSTRACT | NOBLUDGEON
+	burn_state = LAVA_PROOF | FIRE_PROOF
+	var/mob/living/carbon/rider
+	var/mob/living/ridden
+	var/selfdeleting = FALSE
+
+/obj/item/riding_offhand/dropped()
+	selfdeleting = TRUE
+	. = ..()
+
+/obj/item/riding_offhand/equipped()
+	if(loc != rider)
+		selfdeleting = TRUE
+		qdel(src)
+	. = ..()
+
+/obj/item/riding_offhand/Destroy()
+	if(selfdeleting)
+		if(rider in ridden.buckled_mob)
+			ridden.unbuckle_mob(rider)
+	. = ..()

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -72,6 +72,12 @@
 
 		post_buckle_mob(.)
 
+/atom/movable/proc/unbuckle_all_mobs(force=FALSE)
+	if(!has_buckled_mobs())
+		return
+	for(var/m in buckled_mob)
+		unbuckle_mob(m, force)
+
 //Handle any extras after buckling/unbuckling
 //Called on buckle_mob() and unbuckle_mob()
 /atom/movable/proc/post_buckle_mob(mob/living/M)

--- a/code/modules/mining/lavaland/loot/tendril_loot.dm
+++ b/code/modules/mining/lavaland/loot/tendril_loot.dm
@@ -124,18 +124,11 @@
 	desc = "A boat used for traversing lava."
 	icon_state = "goliath_boat"
 	icon = 'icons/obj/lavaland/dragonboat.dmi'
-	keytype = /obj/item/weapon/oar
 	burn_state = LAVA_PROOF | FIRE_PROOF
 
-/obj/vehicle/lavaboat/relaymove(mob/user, direction)
-	var/turf/next = get_step(src, direction)
-	var/turf/current = get_turf(src)
-
-	if(istype(next, /turf/unsimulated/floor/lava) || istype(current, /turf/unsimulated/floor/lava)) //We can move from land to lava, or lava to land, but not from land to land
-		..()
-	else
-		to_chat(user, "<span class='warning'>Boats don't go on land!</span>")
-		return 0
+/obj/vehicle/lavaboat/buckle_mob(mob/living/M, force = 0, check_loc = 1)
+	. = ..()
+	riding_datum = new/datum/riding/boat
 
 /obj/item/weapon/oar
 	name = "oar"
@@ -178,11 +171,11 @@
 /obj/vehicle/lavaboat/dragon
 	name = "mysterious boat"
 	desc = "This boat moves where you will it, without the need for an oar."
-	keytype = null
 	icon_state = "dragon_boat"
-	generic_pixel_y = 2
-	generic_pixel_x = 1
-	vehicle_move_delay = 1
+
+/obj/vehicle/lavaboat/dragon/buckle_mob(mob/living/M, force = 0, check_loc = 1)
+	..()
+	riding_datum = new/datum/riding/boat/dragon
 
 // Wisp Lantern
 /obj/item/device/wisp_lantern

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -724,23 +724,6 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 /mob/living/carbon/is_muzzled()
 	return(istype(src.wear_mask, /obj/item/clothing/mask/muzzle))
 
-/mob/living/carbon/proc/spin(spintime, speed)
-	spawn()
-		var/D = dir
-		while(spintime >= speed)
-			sleep(speed)
-			switch(D)
-				if(NORTH)
-					D = EAST
-				if(SOUTH)
-					D = WEST
-				if(EAST)
-					D = SOUTH
-				if(WEST)
-					D = NORTH
-			dir = D
-			spintime -= speed
-
 /mob/living/carbon/resist_buckle()
 	spawn(0)
 		resist_muzzle()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -778,6 +778,12 @@
 					if(M == src)
 						continue
 					M.reagents.add_reagent("jenkem", 1)
+		if("spin")
+			var/M = handle_emote_param(param, null, 1)
+
+			if(M)
+				message = "<B>[src]</B> spins around dizzily!"
+			spin(20, 1)
 
 		if("help")
 			var/emotelist = "aflap(s), airguitar, blink(s), blink(s)_r, blush(es), bow(s)-(none)/mob, burp(s), choke(s), chuckle(s), clap(s), collapse(s), cough(s),cry, cries, custom, dance, dap(s)(none)/mob," \

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2076,7 +2076,7 @@
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
 
-	var/obj/item/weapon/grab/G = user.get_active_hand()
+	var/obj/item/weapon/grab/G = locate() in src
 	if((target != pulling) || (G.state < GRAB_AGGRESSIVE) || (user != target))	//Get consent first :^)
 		. = ..()
 		return

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -73,3 +73,7 @@ var/global/default_martial_art = new/datum/martial_art
 
 	var/datum/body_accessory/body_accessory = null
 	var/tail // Name of tail image in species effects icon file.
+
+	can_buckle = TRUE
+	buckle_lying = FALSE
+	can_ride_typecache = list(/mob/living/carbon/human, /mob/living/simple_animal/parrot)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -74,6 +74,6 @@ var/global/default_martial_art = new/datum/martial_art
 	var/datum/body_accessory/body_accessory = null
 	var/tail // Name of tail image in species effects icon file.
 
-	can_buckle = TRUE
-	buckle_lying = FALSE
+	can_buckle = 1
+	buckle_lying = 0
 	can_ride_typecache = list(/mob/living/carbon/human, /mob/living/simple_animal/parrot)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -108,6 +108,10 @@
 				return
 			var/obj/item/clothing/shoes/S = shoes
 			S.step_action(src)
+/mob/living/carbon/human/Moved()
+	. = ..()
+	if(buckled_mob && riding_datum)
+		riding_datum.on_vehicle_move()
 
 /mob/living/carbon/human/handle_footstep(turf/T)
 	if(..())

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2,6 +2,9 @@
 /mob/living/Destroy()
 	if(ranged_ability)
 		ranged_ability.remove_ranged_ability(src)
+	if(buckled)
+		buckled.unbuckle_mob(src,force=1)
+	QDEL_NULL(riding_datum)
 	return ..()
 
 /mob/living/ghostize(can_reenter_corpse = 1)
@@ -942,3 +945,8 @@
 		to_chat(src, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return 0
 	return 1
+
+/mob/living/post_buckle_mob(mob/living/M)
+	if(riding_datum)
+		riding_datum.handle_vehicle_offsets()
+		riding_datum.handle_vehicle_layer()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -59,3 +59,5 @@
 	var/tesla_ignore = FALSE
 
 	var/list/say_log = list() //a log of what we've said, plain text, no spans or junk, essentially just each individual "message"
+
+	var/datum/riding/riding_datum

--- a/code/modules/mob/living/silicon/emote.dm
+++ b/code/modules/mob/living/silicon/emote.dm
@@ -74,7 +74,18 @@
 			playsound(src.loc, 'sound/machines/buzz-two.ogg', 50, 0)
 			m_type = 2
 
+		if("spin")
+			var/M = handle_emote_param(param, null, 1)
 
+			if(M)
+				message = "<B>[src]</B> spins around dizzily!"
+			spin(20, 1)
+			if(istype(src, /mob/living/silicon/robot))
+				var/mob/living/silicon/robot/R = src
+				if(R.buckled_mob)
+	 			for(var/mob/H in R.buckled_mob)
+	 				if(R.riding_datum)
+	 					R.riding_datum.force_dismount(H)
 		if("help")
 			to_chat(src, "yes, no, beep, ping, buzz, scream, buzz2")
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -16,6 +16,10 @@
 	var/list/stacktypes
 	var/channels = list()
 
+	var/list/ride_offset_x = list("north" = 0, "south" = 0, "east" = -6, "west" = 6)
+	var/list/ride_offset_y = list("north" = 4, "south" = 4, "east" = 3, "west" = 3)
+	var/ride_allow_incapacitated = FALSE
+	var/allow_riding = TRUE
 
 /obj/item/weapon/robot_module/emp_act(severity)
 	if(modules)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -16,8 +16,10 @@
 
 	return tally+config.robot_delay
 
-/mob/living/silicon/robot/Move()
-	..()
+/mob/living/silicon/robot/Moved()
+	. = ..()
+	if(riding_datum)
+		riding_datum.on_vehicle_move()
 
 /mob/living/silicon/robot/mob_negates_gravity()
 	return magpulse

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -381,6 +381,8 @@ var/global/chicken_count = 0
 	maxHealth = 50
 	can_collar = 1
 	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
+	tame = 1
+	saddled = 1
 
 /mob/living/simple_animal/walrus
 	name = "walrus"

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -106,7 +106,8 @@
 	verbs.Add(/mob/living/simple_animal/parrot/proc/steal_from_ground, \
 			  /mob/living/simple_animal/parrot/proc/steal_from_mob, \
 			  /mob/living/simple_animal/parrot/verb/drop_held_item_player, \
-			  /mob/living/simple_animal/parrot/proc/perch_player)
+			  /mob/living/simple_animal/parrot/proc/perch_player, \
+			  /mob/living/simple_animal/parrot/proc/perch_mob_player)
 
 /mob/living/simple_animal/parrot/Destroy()
 	hear_radio_list -= src
@@ -117,6 +118,11 @@
 		held_item.loc = src.loc
 		held_item = null
 	walk(src,0)
+	if(buckled)
+		buckled.buckled_mob = null
+	buckled = null
+	pixel_x = initial(pixel_x)
+	pixel_y = initial(pixel_y)
 	..()
 
 /mob/living/simple_animal/parrot/Stat()
@@ -654,6 +660,43 @@
 	held_item.loc = src.loc
 	held_item = null
 	return 1
+
+/mob/living/simple_animal/parrot/proc/perch_mob_player()
+	set name = "Sit on Human's Shoulder"
+	set category = "Parrot"
+	set desc = "Sit on a nice comfy human being!"
+
+	if(stat || !client)
+		return
+
+	if(icon_state == "parrot_fly")
+		for(var/mob/living/carbon/human/H in view(src,1))
+			if(H.buckled_mob) //Already has a parrot, or is being eaten by a slime
+				continue
+			perch_on_human(H)
+			return
+		to_chat(src, "<span class='warning'>There is nobody nearby that you can sit on!</span>")
+	else
+		icon_state = "parrot_fly"
+		parrot_state = PARROT_WANDER
+		if(buckled)
+			to_chat(src, "<span class='notice'>You are no longer sitting on [buckled]'s shoulder.</span>")
+			buckled.buckled_mob = null
+		buckled = null
+		pixel_x = initial(pixel_x)
+		pixel_y = initial(pixel_y)
+
+/mob/living/simple_animal/parrot/proc/perch_on_human(mob/living/carbon/human/H)
+	if(!H)
+		return
+	loc = get_turf(H)
+	H.buckle_mob(src, force=1)
+	pixel_y = 9
+	pixel_x = pick(-8,8) //pick left or right shoulder
+	icon_state = "parrot_sit"
+	parrot_state = PARROT_PERCH
+	to_chat(src, "<span class='notice'>You sit on [H]'s shoulder.</span>")
+
 
 /mob/living/simple_animal/parrot/proc/perch_player()
 	set name = "Sit"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -80,6 +80,10 @@
 	var/deathmessage = ""
 	var/death_sound = null //The sound played on death
 
+	//domestication
+	var/tame = 0
+	var/saddled = 0
+
 
 /mob/living/simple_animal/New()
 	..()
@@ -721,3 +725,36 @@
 
 /mob/living/simple_animal/SetEarDeaf()
 	return
+
+//ANIMAL RIDING
+//ANIMAL RIDING
+/mob/living/simple_animal/unbuckle_mob(mob/living/buckled_mob, force = 0, check_loc = 1)
+	if(riding_datum)
+		riding_datum.restore_position(buckled_mob)
+	. = ..()
+
+
+/mob/living/simple_animal/user_buckle_mob(mob/living/M, mob/user)
+	if(riding_datum)
+		if(user.incapacitated())
+			return
+		for(var/atom/movable/A in get_turf(src))
+			if(A != src && A != M && A.density)
+				return
+		M.loc = get_turf(src)
+		riding_datum.handle_vehicle_offsets()
+		riding_datum.ridden = src
+
+/mob/living/simple_animal/relaymove(mob/user, direction)
+	if(tame && riding_datum)
+		riding_datum.handle_ride(user, direction)
+
+/mob/living/simple_animal/Moved()
+	. = ..()
+	if(riding_datum)
+		riding_datum.on_vehicle_move()
+
+
+/mob/living/simple_animal/buckle_mob(mob/living/buckled_mob, force = 0, check_loc = 1)
+	. = ..()
+	riding_datum = new/datum/riding/animal

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -27,6 +27,7 @@
 	else
 		living_mob_list += src
 	prepare_huds()
+	can_ride_typecache = typecacheof(can_ride_typecache)
 	..()
 
 /atom/proc/prepare_huds()
@@ -1343,3 +1344,20 @@ var/list/slot_equipment_priority = list( \
 
 	attack_log += new_log
 	last_log = world.timeofday
+
+/mob/proc/spin(spintime, speed)
+	set waitfor = 0
+	var/D = dir
+	while(spintime >= speed)
+		sleep(speed)
+		switch(D)
+			if(NORTH)
+				D = EAST
+			if(SOUTH)
+				D = WEST
+			if(EAST)
+				D = SOUTH
+			if(WEST)
+				D = NORTH
+		setDir(D)
+		spintime -= speed

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -196,5 +196,7 @@
 	var/list/permanent_huds = list()
 
 	var/list/actions = list()
-	
+
 	var/list/progressbars = null	//for stacking do_after bars
+
+	var/list/can_ride_typecache = list()

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -2,7 +2,6 @@
 	name = "ambulance"
 	desc = "what the paramedic uses to run over people to take to medbay."
 	icon_state = "docwagon2"
-	keytype = /obj/item/key/ambulance
 	var/obj/structure/stool/bed/amb_trolley/bed = null
 
 
@@ -11,23 +10,9 @@
 	desc = "A keyring with a small steel key, and tag with a red cross on it."
 	icon_state = "keydoc"
 
-
-/obj/vehicle/ambulance/handle_vehicle_offsets()
-	..()
-	if(buckled_mob)
-		switch(buckled_mob.dir)
-			if(SOUTH)
-				buckled_mob.pixel_x = 0
-				buckled_mob.pixel_y = 7
-			if(WEST)
-				buckled_mob.pixel_x = 13
-				buckled_mob.pixel_y = 7
-			if(NORTH)
-				buckled_mob.pixel_x = 0
-				buckled_mob.pixel_y = 4
-			if(EAST)
-				buckled_mob.pixel_x = -13
-				buckled_mob.pixel_y = 7
+/obj/vehicle/janicart/buckle_mob()
+	. = ..()
+	riding_datum = new/datum/riding/janicart
 
 /obj/vehicle/ambulance/Move(newloc, Dir)
 	var/oldloc = loc

--- a/code/modules/vehicle/atv.dm
+++ b/code/modules/vehicle/atv.dm
@@ -3,11 +3,11 @@
 	desc = "An all-terrain vehicle built for traversing rough terrain with ease. One of the few old-earth technologies that are still relevant on most planet-bound outposts."
 	icon = 'icons/vehicles/4wheeler.dmi'
 	icon_state = "fourwheel"
-	keytype = /obj/item/key
-	generic_pixel_x = 0
-	generic_pixel_y = 4
-	vehicle_move_delay = 1
 	var/static/image/atvcover = null
+
+/obj/vehicle/atv/buckle_mob()
+	. = ..()
+	riding_datum = new/datum/riding/atv
 
 /obj/vehicle/atv/New()
 	..()
@@ -21,12 +21,6 @@
 	else
 		overlays -= atvcover
 
-/obj/vehicle/atv/handle_vehicle_layer()
-	if(dir == SOUTH)
-		layer = MOB_LAYER+0.1
-	else
-		layer = OBJ_LAYER
-
 //TURRETS!
 /obj/vehicle/atv/turret
 	var/obj/machinery/porta_turret/syndicate/vehicle_turret/turret = null
@@ -38,36 +32,10 @@
 	density = 0
 
 /obj/vehicle/atv/turret/New()
-	..()
+	. = ..()
 	turret = new(loc)
 	//turret.base = src
 
-/obj/vehicle/atv/turret/handle_vehicle_layer()
-	if(dir == SOUTH)
-		layer = MOB_LAYER+0.1
-	else
-		layer = OBJ_LAYER
-
-	if(turret)
-		if(dir == NORTH)
-			turret.layer = MOB_LAYER+0.1
-		else
-			turret.layer = OBJ_LAYER
-
-/obj/vehicle/atv/turret/handle_vehicle_offsets()
+/obj/vehicle/atv/turret/buckle_mob()
 	..()
-	if(turret)
-		turret.loc = loc
-		switch(dir)
-			if(NORTH)
-				turret.pixel_x = 0
-				turret.pixel_y = 4
-			if(EAST)
-				turret.pixel_x = -12
-				turret.pixel_y = 4
-			if(SOUTH)
-				turret.pixel_x = 0
-				turret.pixel_y = 4
-			if(WEST)
-				turret.pixel_x = 12
-				turret.pixel_y = 4
+	riding_datum = new/datum/riding/atv/turret

--- a/code/modules/vehicle/janicart.dm
+++ b/code/modules/vehicle/janicart.dm
@@ -3,27 +3,14 @@
 	name = "janicart (pimpin' ride)"
 	desc = "A brave janitor cyborg gave its life to produce such an amazing combination of speed and utility."
 	icon_state = "pussywagon"
-	keytype = /obj/item/key/janitor
 	var/obj/item/weapon/storage/bag/trash/mybag = null
 	var/floorbuffer = 0
 
 
-/obj/vehicle/janicart/handle_vehicle_offsets()
-	..()
-	if(buckled_mob)
-		switch(buckled_mob.dir)
-			if(NORTH)
-				buckled_mob.pixel_x = 0
-				buckled_mob.pixel_y = 4
-			if(EAST)
-				buckled_mob.pixel_x = -12
-				buckled_mob.pixel_y = 7
-			if(SOUTH)
-				buckled_mob.pixel_x = 0
-				buckled_mob.pixel_y = 7
-			if(WEST)
-				buckled_mob.pixel_x = 12
-				buckled_mob.pixel_y = 7
+/obj/vehicle/janicart/buckle_mob()
+	. = ..()
+	riding_datum = new/datum/riding/janicart
+
 
 
 /obj/item/key/janitor
@@ -61,17 +48,22 @@
 
 /obj/vehicle/janicart/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/storage/bag/trash))
-		if(keytype == /obj/item/key/janitor)
-			if(!user.drop_item())
-				return
-			to_chat(user, "<span class='notice'>You hook the trashbag onto \the [name].</span>")
-			I.loc = src
-			mybag = I
+		if(mybag)
+			to_chat(user, "<span class='warning'>[src] already has a trashbag hooked!</span>")
+			return
+		if(!user.drop_item())
+			return
+		to_chat(user, "<span class='notice'>You hook the trashbag onto [src].</span>")
+		I.loc = src
+		mybag = I
+		update_icon()
 	else if(istype(I, /obj/item/janiupgrade))
-		if(keytype == /obj/item/key/janitor)
-			floorbuffer = 1
-			qdel(I)
-			to_chat(user,"<span class='notice'>You upgrade \the [name] with the floor buffer.</span>")
+		if(floorbuffer)
+			to_chat(user, "<span class='warning'>[src] already has a floor buffer!</span>")
+			return
+		floorbuffer = TRUE
+		qdel(I)
+		to_chat(user, "<span class='notice'>You upgrade [src] with the floor buffer.</span>")
 	update_icon()
 
 	..()

--- a/code/modules/vehicle/motorcycle.dm
+++ b/code/modules/vehicle/motorcycle.dm
@@ -3,28 +3,23 @@
 	desc = "A fast and highly maneuverable vehicle."
 	icon = 'icons/vehicles/motorcycle.dmi'
 	icon_state = "motorcycle_4dir"
-	generic_pixel_x = 0
-	generic_pixel_y = 4
-	vehicle_move_delay = 1
 	var/static/image/bikecover = null
 
+/obj/vehicle/motorcycle/buckle_mob()
+	. = ..()
+	riding_datum = new/datum/riding/motorcycle
 
 /obj/vehicle/motorcycle/New()
 	..()
 	if(!bikecover)
 		bikecover = image("icons/vehicles/motorcycle.dmi", "motorcycle_overlay_4d")
 		bikecover.layer = MOB_LAYER + 0.1
+		riding_datum = new/datum/riding/motorcycle
 
 
-obj/vehicle/motorcycle/post_buckle_mob(mob/living/M)
+/obj/vehicle/motorcycle/post_buckle_mob(mob/living/M)
 	if(buckled_mob)
 		overlays += bikecover
 	else
 		overlays -= bikecover
 
-
-/obj/vehicle/motorcycle/handle_vehicle_layer()
-	if(dir == SOUTH)
-		layer = MOB_LAYER+0.1
-	else
-		layer = OBJ_LAYER

--- a/code/modules/vehicle/secway.dm
+++ b/code/modules/vehicle/secway.dm
@@ -2,11 +2,12 @@
 	name = "secway"
 	desc = "A brave security cyborg gave its life to help you look like a complete tool."
 	icon_state = "secway"
-	keytype = /obj/item/key/security
-	generic_pixel_x = 0
-	generic_pixel_y = 4
 
 
 /obj/item/key/security
 	desc = "A keyring with a small steel key, and a rubber stun baton accessory."
 	icon_state = "keysec"
+
+/obj/vehicle/secway/buckle_mob()
+	. = ..()
+	riding_datum = new/datum/riding/secway

--- a/code/modules/vehicle/snowmobile.dm
+++ b/code/modules/vehicle/snowmobile.dm
@@ -3,9 +3,10 @@
 	desc = "Wheeeeeeeeeeee."
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "snowmobile"
-	keytype = /obj/item/key/snowmobile
-	generic_pixel_x = 0
-	generic_pixel_y = 4
+
+/obj/vehicle/snowmobile/buckle_mob()
+	. = ..()
+	riding_datum = new/datum/riding/snowmobile
 
 /obj/vehicle/snowmobile/blue
 	name = "blue snowmobile"

--- a/code/modules/vehicle/speedbike.dm
+++ b/code/modules/vehicle/speedbike.dm
@@ -3,16 +3,20 @@
 	icon = 'icons/obj/bike.dmi'
 	icon_state = "speedbike_blue"
 	layer = MOB_LAYER - 0.1
-	keytype = null
-	vehicle_move_delay = 0
 	var/overlay_state = "cover_blue"
 	var/image/overlay = null
 
+/obj/vehicle/space/speedbike/buckle_mob()
+	. = ..()
+	riding_datum = new/datum/riding/space/speedbike
+
+
 /obj/vehicle/space/speedbike/New()
-	..()
+	. = ..()
 	overlay = image("icons/obj/bike.dmi", overlay_state)
 	overlay.layer = MOB_LAYER + 0.1
 	overlays += overlay
+	riding_datum = new/datum/riding/space/speedbike
 
 /obj/effect/overlay/temp/speedbike_trail
 	name = "speedbike trails"
@@ -31,31 +35,6 @@
 		new /obj/effect/overlay/temp/speedbike_trail(loc)
 	. = ..()
 
-/obj/vehicle/space/speedbike/handle_vehicle_layer()
-	switch(dir)
-		if(NORTH,SOUTH)
-			pixel_x = -16
-			pixel_y = -16
-		if(EAST,WEST)
-			pixel_x = -18
-			pixel_y = 0
-
-/obj/vehicle/space/speedbike/handle_vehicle_offsets()
-	if(buckled_mob)
-		buckled_mob.dir = dir
-		switch(dir)
-			if(NORTH)
-				buckled_mob.pixel_x = 0
-				buckled_mob.pixel_y = -8
-			if(SOUTH)
-				buckled_mob.pixel_x = 0
-				buckled_mob.pixel_y = 4
-			if(EAST)
-				buckled_mob.pixel_x = -10
-				buckled_mob.pixel_y = 5
-			if(WEST)
-				buckled_mob.pixel_x = 10
-				buckled_mob.pixel_y = 5
 
 /obj/vehicle/space/speedbike/red
 	icon_state = "speedbike_red"

--- a/code/modules/vehicle/sportscar.dm
+++ b/code/modules/vehicle/sportscar.dm
@@ -3,11 +3,11 @@
 	desc = "A very luxurious vehicle."
 	icon = 'icons/vehicles/sportscar.dmi'
 	icon_state = "sportscar"
-	generic_pixel_x = 0
-	generic_pixel_y = 4
-	vehicle_move_delay = 1
 	var/static/image/carcover = null
 
+/obj/vehicle/car/buckle_mob(mob/living/M, force = 0, check_loc = 1)
+	. = ..()
+	riding_datum = new/datum/riding/speedwagon
 
 /obj/vehicle/car/New()
 	..()
@@ -22,26 +22,3 @@
 	else
 		overlays -= carcover
 
-/obj/vehicle/car/handle_vehicle_offsets()
-	..()
-	if(buckled_mob)
-		switch(buckled_mob.dir)
-			if(NORTH)
-				buckled_mob.pixel_x = 2
-				buckled_mob.pixel_y = 20
-			if(EAST)
-				buckled_mob.pixel_x = 20
-				buckled_mob.pixel_y = 23
-			if(SOUTH)
-				buckled_mob.pixel_x = 20
-				buckled_mob.pixel_y = 27
-			if(WEST)
-				buckled_mob.pixel_x = 34
-				buckled_mob.pixel_y = 10
-
-
-/obj/vehicle/car/handle_vehicle_layer()
-	if(dir == SOUTH)
-		layer = MOB_LAYER+0.1
-	else
-		layer = OBJ_LAYER

--- a/code/modules/vehicle/vehicle.dm
+++ b/code/modules/vehicle/vehicle.dm
@@ -8,53 +8,14 @@
 	anchored = 0
 	can_buckle = 1
 	buckle_lying = 0
-	var/keytype = null //item typepath, if non-null an item of this type is needed in your hands to drive this vehicle
-	var/next_vehicle_move = 0 //used for move delays
-	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
 	var/auto_door_open = TRUE
 	var/needs_gravity = 0//To allow non-space vehicles to move in no gravity or not, mostly for adminbus
-	//Pixels
-	var/generic_pixel_x = 0 //All dirs show this pixel_x for the driver
-	var/generic_pixel_y = 0 //All dirs shwo this pixel_y for the driver
 	var/spaceworthy = FALSE
 
-
-/obj/vehicle/New()
-	..()
-	handle_vehicle_layer()
-
-
-//APPEARANCE
-/obj/vehicle/proc/handle_vehicle_layer()
-	if(dir != NORTH)
-		layer = MOB_LAYER+0.1
-	else
-		layer = OBJ_LAYER
-
-
-//Override this to set your vehicle's various pixel offsets
-//if they differ between directions, otherwise use the
-//generic variables
-/obj/vehicle/proc/handle_vehicle_offsets()
-	if(buckled_mob)
-		buckled_mob.dir = dir
-		buckled_mob.pixel_x = generic_pixel_x
-		buckled_mob.pixel_y = generic_pixel_y
-
+	var/datum/riding/riding_datum = null
 
 /obj/vehicle/update_icon()
 	return
-
-
-
-//KEYS
-/obj/vehicle/proc/keycheck(mob/user)
-	if(keytype)
-		if(istype(user.l_hand, keytype) || istype(user.r_hand, keytype))
-			return 1
-	else
-		return 1
-	return 0
 
 /obj/item/key
 	name = "key"
@@ -63,12 +24,13 @@
 	icon_state = "key"
 	w_class = 1
 
+/obj/vehicle/Destroy()
+	QDEL_NULL(riding_datum)
+	return ..()
 
 //BUCKLE HOOKS
 /obj/vehicle/unbuckle_mob(force = 0)
-	if(buckled_mob)
-		buckled_mob.pixel_x = 0
-		buckled_mob.pixel_y = 0
+	riding_datum.restore_position(buckled_mob)
 	. = ..()
 
 
@@ -81,8 +43,8 @@
 				return
 	M.loc = get_turf(src)
 	..()
-	handle_vehicle_offsets()
-
+	riding_datum.handle_vehicle_offsets()
+	riding_datum.ridden = src
 
 /obj/vehicle/bullet_act(obj/item/projectile/Proj)
 	if(buckled_mob)
@@ -90,44 +52,14 @@
 
 //MOVEMENT
 /obj/vehicle/relaymove(mob/user, direction)
-	if(user.incapacitated())
-		unbuckle_mob()
-
-	if(keycheck(user))
-		if(!Process_Spacemove(direction) || world.time < next_vehicle_move || !isturf(loc))			return
-		next_vehicle_move = world.time + vehicle_move_delay
-
-		step(src, direction)
-
-		if(buckled_mob)
-			if(buckled_mob.loc != loc)
-				buckled_mob.buckled = null //Temporary, so Move() succeeds.
-				buckled_mob.buckled = src //Restoring
-
-			if(istype(src.loc, /turf/simulated))
-				var/turf/simulated/T = src.loc
-				if(T.wet == TURF_WET_LUBE)	//Lube! Fall off!
-					playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-					buckled_mob.Stun(7)
-					buckled_mob.Weaken(7)
-					unbuckle_mob()
-					step(src, dir)
-
-		handle_vehicle_layer()
-		handle_vehicle_offsets()
-	else
-		to_chat(user, "<span class='notice'>You'll need the keys in one of your hands to drive \the [name].</span>")
+	riding_datum.handle_ride(user, direction)
 
 
-/obj/vehicle/Move(NewLoc,Dir=0,step_x=0,step_y=0)
+/obj/vehicle/Moved()
 	..()
-	handle_vehicle_layer()
-	handle_vehicle_offsets()
+	riding_datum.handle_vehicle_layer()
+	riding_datum.handle_vehicle_offsets()
 
-
-/obj/vehicle/attackby(obj/item/I, mob/user, params)
-	if(keytype && istype(I, keytype))
-		to_chat(user, "Hold [I] in one of your hands while you drive \the [name].")
 
 
 /obj/vehicle/Bump(atom/movable/M)

--- a/paradise.dme
+++ b/paradise.dme
@@ -216,6 +216,7 @@
 #include "code\datums\periodic_news.dm"
 #include "code\datums\progressbar.dm"
 #include "code\datums\recipe.dm"
+#include "code\datums\riding.dm"
 #include "code\datums\ruins.dm"
 #include "code\datums\shuttles.dm"
 #include "code\datums\spell.dm"


### PR DESCRIPTION

Refactors the Vehicles i ported from TG to TG riding datums.

This includes:
Riding Cyborgs(you cannot rid one with your hands full)
Piggy backing on players
Parrots riding human
Support for ridable simple animals.

Damageing has an chance to knock your off a cyborg or human.

Runtimes:
I was on this for a few hours so i am brain fried as of writing this. so any extra eyes on what i am doing or missed is nice.
[01:47:11] Runtime in riding.dm,30: Cannot execute null.has buckled mobs().

[01:47:11] Runtime in riding.dm,155: Cannot execute null.has buckled mobs().
Retesting drag and dropping was not working earlier
the spin emote is not working (it lets cyborgs buck people off!)

oh god it has a merge conflict from when i made this branch hours ago!

:cl: Fethas
rscadd: Ride cyborgs, people, the cow!
rscadd: refactors vehicle and riding datums
/ :cl: