### PR TITLE
Loadout Requirement Fixes

### DIFF
--- a/code/modules/client/preference/loadout/loadout_hat.dm
+++ b/code/modules/client/preference/loadout/loadout_hat.dm
@@ -137,7 +137,7 @@
 /datum/gear/hat/med_beret
 	display_name = "medical beret"
 	path = /obj/item/clothing/head/beret/med
-	allowed_roles = list("Chief Medical Officer", "Medical Doctor" , "Virologist", "Brig Physician")
+	allowed_roles = list("Chief Medical Officer", "Medical Doctor" , "Virologist", "Brig Physician" , "Coroner")
 
 /datum/gear/hat/surgicalcap_purple
 	display_name = "surgical cap, purple"

--- a/code/modules/client/preference/loadout/loadout_racial.dm
+++ b/code/modules/client/preference/loadout/loadout_racial.dm
@@ -19,7 +19,7 @@
 	display_name = "lightweight veil"
 	description = "A common traditional nano-fiber veil worn by many Tajaran, It is rare and offensive to see it on other races. This one has an in-built medical HUD."
 	path = /obj/item/clothing/glasses/hud/health/tajblind
-	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Brig Physician")
+	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Brig Physician" , "Coroner")
 
 /datum/gear/racial/tajsci
 	display_name = "hi-tech veil"

--- a/code/modules/client/preference/loadout/loadout_suit.dm
+++ b/code/modules/client/preference/loadout/loadout_suit.dm
@@ -29,7 +29,7 @@
 /datum/gear/suit/coat/job/med
 	display_name = "winter coat, medical"
 	path = /obj/item/clothing/suit/hooded/wintercoat/medical
-	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Brig Physician")
+	allowed_roles = list("Chief Medical Officer", "Medical Doctor", "Chemist", "Psychiatrist", "Paramedic", "Virologist", "Brig Physician" , "Coroner")
 
 /datum/gear/suit/coat/job/sci
 	display_name = "winter coat, science"

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -61,12 +61,12 @@
 /datum/gear/uniform/skirt/job/viro
 	display_name = "skirt, virologist"
 	path = /obj/item/clothing/under/rank/virologist/skirt
-	allowed_roles = list("Chief Medical Officer","Medical Doctor" , "Virologist")
+	allowed_roles = list("Virologist")
 
 /datum/gear/uniform/skirt/job/med
 	display_name = "skirt, medical"
 	path = /obj/item/clothing/under/rank/medical/skirt
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic","Brig Physician", "Virologist" , "Coroner")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Psychiatrist","Paramedic","Coroner")
 
 /datum/gear/uniform/skirt/job/phys
 	display_name = "skirt, physician"

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -61,17 +61,17 @@
 /datum/gear/uniform/skirt/job/viro
 	display_name = "skirt, virologist"
 	path = /obj/item/clothing/under/rank/virologist/skirt
-	allowed_roles = list("Chief Medical Officer","Medical Doctor")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor" , "Virologist")
 
 /datum/gear/uniform/skirt/job/med
 	display_name = "skirt, medical"
 	path = /obj/item/clothing/under/rank/medical/skirt
-	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic","Brig Physician")
+	allowed_roles = list("Chief Medical Officer","Medical Doctor","Chemist","Psychiatrist","Paramedic","Brig Physician", "Virologist" , "Coroner")
 
 /datum/gear/uniform/skirt/job/phys
 	display_name = "skirt, physician"
 	path = /obj/item/clothing/under/rank/security/brigphys/skirt
-	allowed_roles = list("Brig Physician")
+	allowed_roles = list("Brig Physician" , "Chief Medical Officer")
 
 /datum/gear/uniform/skirt/job/sci
 	display_name = "skirt, scientist"

--- a/code/modules/client/preference/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference/loadout/loadout_uniform.dm
@@ -71,7 +71,7 @@
 /datum/gear/uniform/skirt/job/phys
 	display_name = "skirt, physician"
 	path = /obj/item/clothing/under/rank/security/brigphys/skirt
-	allowed_roles = list("Brig Physician" , "Chief Medical Officer")
+	allowed_roles = list("Brig Physician")
 
 /datum/gear/uniform/skirt/job/sci
 	display_name = "skirt, scientist"


### PR DESCRIPTION
Fixes some missing Loadout menu requirements.

🆑Xantholne
fix: Virologists actually spawn with their skirt
fix: Coroner now can finally spawn with some Medical loadout clothes.
fix: Medical Doctors will stop spawning with Chemist/Virologist Skirts
fix: CMOs won't spawn with a virologist skirt anymore.
fix: Virologists and Chemists wont spawn with a Medical Doctor skirt anymore.
/🆑 