### PR TITLE
[s] Removes hotel gateway alien embryo

### DIFF
--- a/_maps/map_files/templates/spacehotel/n_04.dmm
+++ b/_maps/map_files/templates/spacehotel/n_04.dmm
@@ -14,7 +14,7 @@
 "n" = (/obj/machinery/door/window/southright,/obj/structure/alien/weeds{icon_state = "weeds1"},/turf/unsimulated/floor/carpet,/area/template_noop)
 "o" = (/obj/structure/table/woodentable,/obj/item/weapon/lipstick/black,/turf/unsimulated/floor/carpet,/area/template_noop)
 "p" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/obj/structure/alien/weeds,/obj/structure/mirror{dir = 8; pixel_x = -28},/turf/unsimulated/floor{icon_state = "freezerfloor"},/area/template_noop)
-"q" = (/obj/structure/toilet{dir = 1},/obj/structure/alien/weeds{icon_state = "weeds2"},/obj/item/organ/internal/body_egg/alien_embryo,/turf/unsimulated/floor{icon_state = "freezerfloor"},/area/template_noop)
+"q" = (/obj/structure/toilet{dir = 1},/obj/structure/alien/weeds{icon_state = "weeds2"},/turf/unsimulated/floor{icon_state = "freezerfloor"},/area/template_noop)
 "r" = (/obj/machinery/door/window/eastleft,/obj/structure/alien/weeds,/turf/unsimulated/floor{icon_state = "freezerfloor"},/area/template_noop)
 "s" = (/obj/machinery/shower{dir = 8},/obj/structure/alien/weeds{icon_state = "weeds1"},/turf/unsimulated/floor{icon_state = "freezerfloor"},/area/template_noop)
 "t" = (/turf/unsimulated/wall/metal,/area/template_noop)


### PR DESCRIPTION
:cl: FlattyPatty
rscdel: Removes gateway hotel xeno embryo for the crew's safety.
/:cl:

Yes, you can use it.
No, I'm not telling you how until this is merged.