### PR TITLE
Classes encryption keys as 'small' items

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "cypherkey"
 	item_state = ""
+	w_class = 1
 	var/translate_binary = 0
 	var/translate_hive = 0
 	var/syndie = 0

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "cypherkey"
 	item_state = ""
-	w_class = 1
+	w_class = WEIGHT_CLASS_TINY
 	var/translate_binary = 0
 	var/translate_hive = 0
 	var/syndie = 0


### PR DESCRIPTION
Because why the hell are they bigger than the headsets they go into....

You couldn't put it in a box, but you could put it in a headset, and put that headset in a box....

:cl: Purpose2
tweak: Headset encryption keys are now 'small' items.
/ :cl: