### PR TITLE
Movement fixes

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -15,6 +15,9 @@
 	alien_organs += new /obj/item/organ/internal/xenos/resinspinner
 	..()
 
+/mob/living/carbon/alien/humanoid/drone/movement_delay()
+	. = ..()
+
 //Drones use the same base as generic humanoids.
 //Drone verbs
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -15,9 +15,6 @@
 	alien_organs += new /obj/item/organ/internal/xenos/resinspinner
 	..()
 
-/mob/living/carbon/alien/humanoid/drone/movement_delay()
-	. = ..()
-
 //Drones use the same base as generic humanoids.
 //Drone verbs
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -13,6 +13,10 @@
 	alien_organs += new /obj/item/organ/internal/xenos/plasmavessel/hunter
 	..()
 
+/mob/living/carbon/alien/humanoid/hunter/movement_delay()
+	. = -1		//hunters are sanic
+	. += ..()	//but they still need to slow down on stun
+
 /mob/living/carbon/alien/humanoid/hunter/handle_regular_hud_updates()
 	..() //-Yvarov
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -12,14 +12,12 @@
 	pixel_x = -16
 	maxHealth = 200
 	health = 200
-	move_delay_add = 1
 	large = 1
 
 /mob/living/carbon/alien/humanoid/sentinel/praetorian
 	name = "alien praetorian"
 	maxHealth = 200
 	health = 200
-	move_delay_add = 1
 	large = 1
 
 /mob/living/carbon/alien/humanoid/sentinel/large/update_icons()
@@ -43,6 +41,9 @@
 	alien_organs += new /obj/item/organ/internal/xenos/acidgland
 	alien_organs += new /obj/item/organ/internal/xenos/neurotoxin
 	..()
+
+/mob/living/carbon/alien/humanoid/sentinel/movement_delay()
+	. = ..()
 
 /mob/living/carbon/alien/humanoid/sentinel/handle_regular_hud_updates()
 	..() //-Yvarov

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -42,9 +42,6 @@
 	alien_organs += new /obj/item/organ/internal/xenos/neurotoxin
 	..()
 
-/mob/living/carbon/alien/humanoid/sentinel/movement_delay()
-	. = ..()
-
 /mob/living/carbon/alien/humanoid/sentinel/handle_regular_hud_updates()
 	..() //-Yvarov
 

--- a/code/modules/mob/living/carbon/alien/humanoid/empress.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/empress.dm
@@ -6,7 +6,6 @@
 	icon_state = "alienq_s"
 	status_flags = CANPARALYSE
 	mob_size = MOB_SIZE_LARGE
-	move_delay_add = 3
 	large = 1
 	ventcrawler = 0
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -26,16 +26,8 @@
 
 
 /mob/living/carbon/alien/humanoid/movement_delay()
-	var/tally = 0
-	if(istype(src, /mob/living/carbon/alien/humanoid/queen))
-		tally += 4
-	if(istype(src, /mob/living/carbon/alien/humanoid/drone))
-		tally += 0
-	if(istype(src, /mob/living/carbon/alien/humanoid/sentinel))
-		tally += 0
-	if(istype(src, /mob/living/carbon/alien/humanoid/hunter))
-		tally = -2 // hunters go supersuperfast
-	return (tally + move_delay_add + config.alien_delay)
+	. = ..()
+	. += move_delay_add + config.alien_delay //move_delay_add is used to slow aliens with stuns
 
 /mob/living/carbon/alien/humanoid/Process_Spacemove(var/check_drift = 0)
 	if(..())

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -28,6 +28,9 @@
 	alien_organs += new /obj/item/organ/internal/xenos/neurotoxin
 	..()
 
+/mob/living/carbon/alien/humanoid/queen/movement_delay()
+	. += 4
+	. = ..()
 
 /mob/living/carbon/alien/humanoid/queen/handle_regular_hud_updates()
 	..() //-Yvarov

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -29,8 +29,8 @@
 	..()
 
 /mob/living/carbon/alien/humanoid/queen/movement_delay()
-	. += 4
 	. = ..()
+	. += 3
 
 /mob/living/carbon/alien/humanoid/queen/handle_regular_hud_updates()
 	..() //-Yvarov

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -1,75 +1,8 @@
 /mob/living/carbon/human/movement_delay()
 	. = 0
 	. += ..()
-
-	var/gravity = 1
-
-	if(!has_gravity(src))
-		gravity = 0
-
-	if(flying)
-		gravity = 0
-
-	if(embedded_flag)
-		handle_embedded_objects() //Moving with objects stuck in you can cause bad times.
-
-	if(slowed)
-		. += 10
-
-	if(gravity)
-		if(species.slowdown)
-			. = species.slowdown
-
-		var/health_deficiency = (maxHealth - health + staminaloss)
-		if(reagents)
-			for(var/datum/reagent/R in reagents.reagent_list)
-				if(R.shock_reduction)
-					health_deficiency -= R.shock_reduction
-		if(health_deficiency >= 40)
-			. += (health_deficiency / 25)
-
-		var/hungry = (500 - nutrition)/5 // So overeat would be 100 and default level would be 80
-		if(hungry >= 70)
-			. += hungry/50
-
-		if(wear_suit)
-			. += wear_suit.slowdown
-
-		if(!buckled)
-			if(shoes)
-				. += shoes.slowdown
-
-		if(shock_stage >= 10)
-			. += 3
-
-		if(back)
-			. += back.slowdown
-
-		if(l_hand && (l_hand.flags & HANDSLOW))
-			. += l_hand.slowdown
-		if(r_hand && (r_hand.flags & HANDSLOW))
-			. += r_hand.slowdown
-
-		if(FAT in src.mutations)
-			. += 1.5
-
-		if(bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
-			. += (BODYTEMP_COLD_DAMAGE_LIMIT - bodytemperature) / COLD_SLOWDOWN_FACTOR
-
-		. += 2 * stance_damage //damaged/missing feet or legs is slow
-
-		if(RUN in mutations)
-			. = -1
-
-		if(status_flags & IGNORESLOWDOWN) // make sure this is always at the end so we don't have ignore slowdown getting ignored itself
-			. = -1
-
-		if(status_flags & GOTTAGOFAST)
-			. -= 1
-		if(status_flags & GOTTAGOREALLYFAST)
-			. -= 2
-
 	. += config.human_delay
+	. += species.movement_delay(src)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0)
 

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -83,10 +83,11 @@
 	if(bodytemperature >= 330.23) // 135 F
 		return -1	// slimes become supercharged at high temperatures
 
-	. = ..(1)
+	. = ..()
 
 	var/health_deficiency = (100 - health)
-	if(health_deficiency >= 45) . += (health_deficiency / 25)
+	if(health_deficiency >= 45)
+		. += (health_deficiency / 25)
 
 	if(bodytemperature < 183.222)
 		. += (283.222 - bodytemperature) / 10 * 1.75
@@ -101,7 +102,7 @@
 	if(health <= 0) // if damaged, the slime moves twice as slow
 		. *= 2
 
-	return . + config.slime_delay
+	. += config.slime_delay
 
 /mob/living/carbon/slime/ObjBump(obj/O)
 	if(!client && powerlevel > 0)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -919,7 +919,6 @@
 
 /mob/living/movement_delay(ignorewalk = 0)
 	. = ..()
-
 	if(isturf(loc))
 		var/turf/T = loc
 		. += T.slowdown

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -122,14 +122,7 @@
 	. = ..()
 	. += slowdown
 	. += 1 //A bit slower than humans, so they're easier to smash
-
-/mob/living/silicon/pai/Process_Spacemove(movement_dir = 0)
-	. = ..()
-	if(!.)
-		slowdown = 2
-		return TRUE
-	slowdown = initial(slowdown)
-	return TRUE
+	. += config.robot_delay
 
 /mob/living/silicon/pai/update_icons()
 	if(stat == DEAD)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -82,6 +82,7 @@
 
 	var/current_pda_messaging = null
 	var/custom_sprite = 0
+	var/slowdown = 0
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard)
 	loc = paicard
@@ -116,6 +117,19 @@
 		var/datum/data/pda/app/chatroom/C = pda.find_program(/datum/data/pda/app/chatroom)
 		C.toff = 1
 	..()
+
+/mob/living/silicon/pai/movement_delay()
+	. = ..()
+	. += slowdown
+	. += 1 //A bit slower than humans, so they're easier to smash
+
+/mob/living/silicon/pai/Process_Spacemove(movement_dir = 0)
+	. = ..()
+	if(!.)
+		slowdown = 2
+		return TRUE
+	slowdown = initial(slowdown)
+	return TRUE
 
 /mob/living/silicon/pai/update_icons()
 	if(stat == DEAD)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -7,14 +7,11 @@
 
  //No longer needed, but I'll leave it here incase we plan to re-use it.
 /mob/living/silicon/robot/movement_delay()
-	. = ..(1) //Incase I need to add stuff other than "speed" later
-
+	. = ..()
 	. += speed
-
 	if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 		. -= 3
-
-	return . + config.robot_delay
+	. += config.robot_delay
 
 /mob/living/silicon/robot/mob_negates_gravity()
 	return magpulse

--- a/code/modules/mob/living/simple_animal/friendly/sloth.dm
+++ b/code/modules/mob/living/simple_animal/friendly/sloth.dm
@@ -21,7 +21,7 @@
 	melee_damage_upper = 18
 	health = 50
 	maxHealth = 50
-	speed = 1
+	speed = 2
 
 
 //Cargo Sloth

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -22,7 +22,6 @@
 
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
-	speed = 4
 
 	faction = list("faithless")
 	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/undead.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/undead.dm
@@ -31,7 +31,7 @@
 	response_disarm = "shoves"
 	response_harm = "hits"
 	turns_per_move = 10
-	speed = -1
+	speed = 0
 	maxHealth = 20
 	health = 20
 
@@ -74,7 +74,7 @@
 	response_help = "shakes hands with"
 	response_disarm = "shoves"
 	response_harm = "hits"
-	speed = -1
+	speed = 0
 	maxHealth = 20
 	health = 20
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -505,7 +505,8 @@
 /mob/living/simple_animal/parrot/movement_delay()
 	if(client && stat == CONSCIOUS && parrot_state != "parrot_fly")
 		icon_state = "parrot_fly"
-	..()
+		//Because the most appropriate place to set icon_state is movement_delay(), clearly
+	return ..()
 
 /mob/living/simple_animal/parrot/proc/search_for_item()
 	for(var/atom/movable/AM in view(src))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -434,11 +434,11 @@
 
 
 /mob/living/simple_animal/movement_delay()
-	var/tally = 0 //Incase I need to add stuff other than "speed" later
+	. = ..()
 
-	tally = speed
+	. = speed
 
-	return tally+config.animal_delay
+	. += config.animal_delay
 
 /mob/living/simple_animal/Stat()
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1008,9 +1008,10 @@ var/list/slot_equipment_priority = list( \
 	drop_l_hand()
 	drop_r_hand()
 
-/mob/proc/facedir(var/ndir)
-	if(!canface())	return 0
-	dir = ndir
+/mob/proc/facedir(ndir)
+	if(!canface())
+		return 0
+	setDir(ndir)
 	client.move_delay += movement_delay()
 	return 1
 


### PR DESCRIPTION
Movement related fixes.

- `RUN`/`IGNORESLOW` now properly ignores slows instead of increasing speed
 -  Refactored human movement to be on the species level
- Fixed `slowed` applying twice to humans
- Animals now obey `movement_delay`
 -  Some values may look different, but the effect it the same, due to movement calculation differences.
- Xenos now obey `movement_delay`
 -  Some values may look different, but the effect it the same, due to movement calculation differences.
- PAIs now obey `movement_delay`

:cl: Fox McCloud
fix: Fixes various mobs moving around faster than intended
/:cl: