### PR TITLE
Fixes the issue with borgs being super-fast

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -66,7 +66,7 @@ var/list/robot_verbs_default = list(
 	var/weaponlock_time = 120
 	var/lawupdate = 1 //Cyborgs will sync their laws with their AI by default
 	var/lockcharge //Used when locking down a borg to preserve cell charge
-	var/speed = 0 //Cause sec borgs gotta go fast //No they dont!
+	var/speed = 1 //Cause sec borgs gotta go fast //No they dont!
 	var/scrambledcodes = 0 // Used to determine if a borg shows up on the robotics console.  Setting to one hides them.
 	var/tracking_entities = 0 //The number of known entities currently accessing the internal camera
 	var/braintype = "Cyborg"


### PR DESCRIPTION
Apparently #7066 sped up borgs to be as fast as shoe-wearing humans. Since this wasn't documented anywhere and it hadn't been evaluated on its merit by *anyone* before the merge, I'm calling this a fix.

With this PR borgs move as fast as they moved before, while a VTEC makes them move exactly as fast as humans.

:cl: FlattestGuitar
fix: Borgs now move at their regular speed again
/:cl: