### PR TITLE
Plant Bags of Holding

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -169,6 +169,14 @@
 	can_hold = list(/obj/item/weapon/reagent_containers/food/snacks/grown,/obj/item/seeds,/obj/item/weapon/grown,/obj/item/weapon/reagent_containers/food/snacks/ash_flora)
 	burn_state = FLAMMABLE
 
+/obj/item/weapon/storage/bag/plants/holding
+	name = "plant bag of holding"
+	desc = "A revolution in convenience, this satchel allows for infinite plant storage. It's been outfitted with anti-malfunction safety measures."
+	storage_slots = INFINITY
+	max_combined_w_class = INFINITY
+	origin_tech = "bluespace=3"
+	icon_state = "satchel_bspace"
+
 /obj/item/weapon/storage/bag/plants/portaseeder
 	name = "portable seed extractor"
 	desc = "For the enterprising botanist on the go. Less efficient than the stationary model, it creates one seed per plant."

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -66,7 +66,7 @@
 	build_path = /obj/item/weapon/storage/bag/ore/holding
 	category = list("Bluespace")
 
-/datum/design/miningsatchel_holding
+/datum/design/plantbag_holding
 	name = "Plant Bag of Holding"
 	desc = "A plant bag that can hold an infinite amount of plants."
 	id = "plantbag_holding"

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -66,6 +66,17 @@
 	build_path = /obj/item/weapon/storage/bag/ore/holding
 	category = list("Bluespace")
 
+/datum/design/miningsatchel_holding
+	name = "Plant Bag of Holding"
+	desc = "A plant bag that can hold an infinite amount of plants."
+	id = "plantbag_holding"
+	req_tech = list("bluespace" = 3, "materials" = 4)
+	build_type = PROTOLATHE
+	materials = list(MAT_GOLD = 250, MAT_URANIUM = 500) //quite cheap, for more convenience
+	reliability = 100
+	build_path = /obj/item/weapon/storage/bag/plants/holding
+	category = list("Bluespace")
+
 /datum/design/telepad_beacon
 	name = "Telepad Beacon"
 	desc = "Use to warp in a cargo telepad."


### PR DESCRIPTION
This is mostly a convenience thing for botany. I didn't realize how restricting only being able to hold 100 plants was until a recent botany traitor shift where I ran out of space in my plant bag, and wasn't able to hold my desired amount of combat plants.

Lots of room for suggestions, and this is my first pull request ever so if I goofed anywhere be sure to tell me. Infinity might be a bit much so I can turn that down a bit too.

Just tossing this idea out there because it can be a bit cumbersome late-game botany when messing around with countless plants.

🆑Imsxz
add: adds the plant bag of holding item
add: adds the plant bag of holding design to protolathe
/ 🆑 