### PR TITLE
ERTs are no longer bankrupt

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -580,7 +580,7 @@ var/global/datum/controller/occupations/job_master
 	H.mind.store_memory(remembered_info)
 
 	// If they're head, give them the account info for their department
-	if(job.head_position)
+	if(job && job.head_position)
 		remembered_info = ""
 		var/datum/money_account/department_account = department_accounts[job.department]
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -195,6 +195,8 @@ var/ert_request_answered = 0
 	ticker.mode.ert += M.mind
 	M.forceMove(spawn_location)
 
+	job_master.CreateMoneyAccount(M, class, null)
+
 	active_team.equip_officer(class, M)
 
 	return M
@@ -332,6 +334,8 @@ var/ert_request_answered = 0
 	W.name = "[H.real_name]'s ID Card ([rt_job])"
 	W.access = get_centcom_access(W.assignment)
 	W.photo = get_id_photo(H)
+	if(H.mind && H.mind.initial_account && H.mind.initial_account.account_number)
+		W.associated_account_number = H.mind.initial_account.account_number
 
 /datum/outfit/job/centcom/response_team/imprint_pda(mob/living/carbon/human/H)
 	var/obj/item/device/pda/PDA = H.wear_pda


### PR DESCRIPTION
ERT members now get bank accounts during their creation.
This prevents situations where the ERT is equipped with the latest high-tech emergency gear, but is also so penniless that they can't afford a coffee from a vending machine. More importantly, it means they won't starve if the chef isn't making food (which, in a lot of ERT-worthy situations, they aren't).

🆑 Kyep
fix: ERTs no longer start penniless, unable to afford even basic food, or coffee.
/🆑