### PR TITLE
Adds a build-time table construction

### DIFF
--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -88,9 +88,10 @@
 	for(var/obj/structure/table/T in user.loc)
 		to_chat(user, "<span class=warning>You can't build tables on top of tables!</span>")
 		return
-	new result(user.loc)
-	user.drop_item()
-	qdel(src)
+	if(do_after(user, 20, target = loc))
+		new result(user.loc)
+		user.drop_item()
+		qdel(src)
 
 /*
  * Rack Parts

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -103,7 +103,8 @@
 		qdel(src)
 
 /obj/item/weapon/rack_parts/attack_self(mob/user as mob)
-	var/obj/structure/rack/R = new /obj/structure/rack(user.loc)
-	R.add_fingerprint(user)
-	user.drop_item()
-	qdel(src)
+	if(do_after(user, 20, target = loc))
+		var/obj/structure/rack/R = new /obj/structure/rack(user.loc)
+		R.add_fingerprint(user)
+		user.drop_item()
+		qdel(src)


### PR DESCRIPTION
This is a balance change; therefore I'd appreciate reasoned arguments for and against in the comments.

------

Currently you can instantly build tables. With no wait, whatsoever.

The issue with this is, it is a 'get-out-of-chases-free' card through maintenance, just by carrying table parts in your backpack. This gets you a spare 5+ seconds MINIMUM against a sec officer chaser... and if its a Sec-borg? They cannot do anything about the table.

By applying this delay, this weakens power-gamers, but keeps it as a tactic.

TL;DR you aren't pro-IKEA, you can't insta-build tables.

:cl: Purpose2
tweak: Adds a build-time on Tables & Racks.
/ :cl: