### PR TITLE
Wirecutters destroy glowshrooms

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -162,6 +162,9 @@
 				G.endurance -= damage_to_do
 				G.CheckEndurance()
 			return
+	if(istype(I, /obj/item/weapon/wirecutters))
+		endurance -= 15 // two hits
+		CheckEndurance()
 	if(I.damtype != STAMINA)
 		endurance -= damage_to_do
 		CheckEndurance()


### PR DESCRIPTION
Two hits with a wirecutter now destroy glowshrooms. This makes it possible to remove glowshroom infestations more easily without scythes.

🆑 Kyep
rscadd: glowshrooms are now destroyable with two hits from a wirecutter.
/🆑