### PR TITLE
Breathing Oxygen Deep-crits Vox from Full-HP ~1min 30sec Faster

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -273,7 +273,7 @@
 
 	atmos_requirements = list(
 		"min_oxy" = 0,
-		"max_oxy" = 0.005,
+		"max_oxy" = 0.75,
 		"min_nitro" = 16,
 		"max_nitro" = 0,
 		"min_tox" = 0,

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -273,7 +273,7 @@
 
 	atmos_requirements = list(
 		"min_oxy" = 0,
-		"max_oxy" = 1,
+		"max_oxy" = 0.005,
 		"min_nitro" = 16,
 		"max_nitro" = 0,
 		"min_tox" = 0,
@@ -453,6 +453,19 @@
 
 	tail = "armalis_tail"
 	icon_template = 'icons/mob/human_races/r_armalis.dmi'
+
+	atmos_requirements = list(
+		"min_oxy" = 0,
+		"max_oxy" = 1,
+		"min_nitro" = 16,
+		"max_nitro" = 0,
+		"min_tox" = 0,
+		"max_tox" = 0.005,
+		"min_co2" = 0,
+	 	"max_co2" = 10,
+	 	"sa_para" = 1,
+		"sa_sleep" = 5
+		)
 
 	has_organ = list(
 		"heart" =    /obj/item/organ/internal/heart,


### PR DESCRIPTION
### This is a PR with two options.
**ONE:** PR stays as is: 25% increase to deadliness of breathing Oxygen (comparing pre-nerf state and Plasma-level deadliness).
**TWO:** PR changed so Oxygen will kill Vox just as quick as Plasma.

_Notice how I got that second commit in there? If it's determined this is to be taken all the way, I'll just peel a layer off the proverbial onion._

------------------------------------------------


Does what it says on the tin.

Oxygen is now right between being just as deadly as plasma to Vox and its current state in the live environment.

The alternative is to have max_oxy set to 0.005, which makes Vox drop into deep crit from full HP at the same time plasma would make them.

The figures:
------------------------------------------------
_Preface: I chose 'time to deep crit' because you stop taking breath-tox damage at that stage as you're technically no longer breathing._

max_oxy = time to deep crit
1	= ~05min 25sec -> Current value
0.75	= ~03min 55sec -> Middle of the road
0.5	= ~02min 25sec -> From here on, all max_oxy values kill you just about as quick.
			Might as well make it the same as plasma: 0.005.
0.05	= ~02min 15sec
0.005	= ~02min 10sec -> Just as deadly as plasma

------------------------------------------------

:cl:
tweak: The Vox now have a more severe aversion to Oxygen. Not breathing pure Oxygen now puts them in a deep-critical state ~1min 30sec/25% faster (takes ~3min 55sec vs. ~5min 25sec).
/:cl: