### PR TITLE
Adds Drask emotes to species specific emote help

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -745,7 +745,7 @@
 				playsound(loc, 'sound/effects/snap.ogg', 50, 1)
 
 		// Needed for M_TOXIC_FART
-\		if("fart", "farts")
+		if("fart", "farts")
 			if(reagents.has_reagent("simethicone"))
 				return
 //			playsound(loc, 'sound/effects/fart.ogg', 50, 1, -3) //Admins still vote no to fun

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -789,6 +789,8 @@
 				emotelist += "\nMachine specific emotes :- beep(s)-(none)/mob, buzz(es)-none/mob, no-(none)/mob, ping(s)-(none)/mob, yes-(none)/mob"
 			else if(species.name == "Slime People")
 				emotelist += "\nSlime people specific emotes :- squish(es)-(none)/mob"
+ 			else if(species.name == "Drask")	 
+				emotelist += "/nDrask specific emotes :- drone(s)-(none)/mob, hum(s)-(none)/mob, rumble(s)-(none)/mob"
 			to_chat(src, emotelist)
 
 		else

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -745,7 +745,7 @@
 				playsound(loc, 'sound/effects/snap.ogg', 50, 1)
 
 		// Needed for M_TOXIC_FART
-		if("fart", "farts")
+\		if("fart", "farts")
 			if(reagents.has_reagent("simethicone"))
 				return
 //			playsound(loc, 'sound/effects/fart.ogg', 50, 1, -3) //Admins still vote no to fun
@@ -790,7 +790,7 @@
 			else if(species.name == "Slime People")
 				emotelist += "\nSlime people specific emotes :- squish(es)-(none)/mob"
  			else if(species.name == "Drask")	 
-				emotelist += "/nDrask specific emotes :- drone(s)-(none)/mob, hum(s)-(none)/mob, rumble(s)-(none)/mob"
+				emotelist += "\nDrask specific emotes :- drone(s)-(none)/mob, hum(s)-(none)/mob, rumble(s)-(none)/mob"
 			to_chat(src, emotelist)
 
 		else


### PR DESCRIPTION
🆑 MarcellusPye
 tweak: Using *help in chat while a Drask will now display Drask emotes along with the regular emotes
 /🆑
Apoligies for any formatting or style errors, I have never contributed before and could not find a guide