### PR TITLE
Fixes non-crossbreeding fish only laying duds

### DIFF
--- a/code/modules/fish/fishtank.dm
+++ b/code/modules/fish/fishtank.dm
@@ -383,7 +383,7 @@
 		var/datum/fish/parent2 = pick(breed_candidates)
 		if(!parent2.crossbreeder)						//second fish refuses to crossbreed, spawn a dud
 			egg_list.Add(/obj/item/fish_eggs)
-		else if(parent1 == parent2)						//both fish are the same type
+		else if(parent1.type == parent2.type)						//both fish are the same type
 			if(prob(90))									//90% chance to get that type of egg
 				egg_list.Add(parent1.egg_item)
 			else											//10% chance to get a dud

--- a/code/modules/fish/fishtank.dm
+++ b/code/modules/fish/fishtank.dm
@@ -369,14 +369,18 @@
 /obj/machinery/fishtank/proc/breed_fish()
 	var/list/breed_candidates = fish_list.Copy()
 	var/datum/fish/parent1 = pick_n_take(breed_candidates)
-	var/datum/fish/parent2 = null
 	if(!parent1.crossbreeder)							//fish with crossbreed = 0 will only breed with their own species, and only leave duds if they can't breed
-		if(parent1 in breed_candidates)
+		var/match_found = 0
+		for(var/datum/fish/possible in breed_candidates)
+			if(parent1.type == possible.type)
+				match_found = 1
+				break
+		if(match_found)
 			egg_list.Add(parent1.egg_item)
 		else
 			egg_list.Add(/obj/item/fish_eggs)
 	else
-		parent2 = pick(breed_candidates)
+		var/datum/fish/parent2 = pick(breed_candidates)
 		if(!parent2.crossbreeder)						//second fish refuses to crossbreed, spawn a dud
 			egg_list.Add(/obj/item/fish_eggs)
 		else if(parent1 == parent2)						//both fish are the same type


### PR DESCRIPTION
Shrimp and electric eels will now properly lay eggs of their type if another of their species is in the tank with them. They will lay duds if they are the only one of their species present as normal, or if another  type of fish attempts to crossbreed with them.

:cl:
bugfix: Shrimp and electric eels properly lay their own eggs again if they have a suitable partner.
/:cl: