### PR TITLE
Allows for plasma-pires

### DIFF
--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -10,7 +10,7 @@
 	config_tag = "vampire"
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Blueshield", "Nanotrasen Representative", "Security Pod Pilot", "Magistrate", "Chaplain", "Brig Physician", "Internal Affairs Agent", "Nanotrasen Navy Officer", "Special Operations Officer")
-	protected_species = list("Machine", "Plasmaman")
+	protected_species = list("Machine")
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4


### PR DESCRIPTION
When looking through this all, found out that plasmamen can be vampires on a traitor+vamp round, but not a normal vampire round, this PR should fix that little inconsistency.

🆑 DarkPyrolord
fix: Plasmamen should be able to become vampires on normal vampire rounds.
/ 🆑 