### PR TITLE
Fixes a couple cloning issues

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -332,7 +332,7 @@
 
 				while((progress / milestone) > INSTALLED && LAZYLEN(missing_organs))
 					var/obj/item/organ/I = pick_n_take(missing_organs)
-					I.replaced(occupant)
+					I.safe_replace(occupant)
 
 #undef INSTALLED
 
@@ -377,7 +377,7 @@
 			return
 		else
 			connected_message("Authorized Ejection")
-			announce_radio_message("An authorized ejection of [occupant.real_name] has occured")
+			announce_radio_message("An authorized ejection of [(occupant) ? occupant.real_name : "the malfunctioning pod"] has occured")
 			to_chat(user, "<span class='notice'>You force an emergency ejection.</span>")
 			go_out()
 

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -327,6 +327,10 @@ var/list/organ_cache = list()
 /obj/item/organ/proc/replaced(var/mob/living/carbon/human/target)
 	return // Nothing uses this, it is always overridden
 
+// A version of `replaced` that "flattens" the process of insertion, making organs "Plug'n'play"
+// (Particularly the heart, which stops beating when removed)
+/obj/item/organ/proc/safe_replace(var/mob/living/carbon/human/target)
+	replaced(target)
 
 /obj/item/organ/proc/surgeryize()
 	return

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -170,6 +170,10 @@
 			if(!owner)
 				Stop()
 
+/obj/item/organ/internal/heart/safe_replace(mob/living/carbon/human/target)
+	Restart()
+	..()
+
 /obj/item/organ/internal/heart/proc/Stop()
 	beating = 0
 	update_icon()


### PR DESCRIPTION
* Cloning no longer stops heart
* You can now empty an EMP'd clone pod

:cl:Crazylemon
fix: Clone's hearts now start operational
fix: EMP'd clone pods can now be emptied again
/:cl: