### PR TITLE
Cloning a defibbed individual no longer shunts the client

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -462,12 +462,14 @@
 		return
 
 	if(grab_ghost_when == CLONER_MATURE_CLONE)
-		clonemind.transfer_to(occupant)
-		occupant.grab_ghost()
-		update_clone_antag(occupant)
-		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br>\
-			<i>You feel like a new being.</i></span>")
-		occupant.flash_eyes(visual = 1)
+		if(!(clonemind.current && clonemind.current.stat != DEAD))
+			// Make sure they aren't just mostly dead (e.g. defibbed or something)
+			clonemind.transfer_to(occupant)
+			occupant.grab_ghost()
+			update_clone_antag(occupant)
+			to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br>\
+				<i>You feel like a new being.</i></span>")
+			occupant.flash_eyes(visual = 1)
 
 	for(var/i in missing_organs)
 		qdel(i)


### PR DESCRIPTION
Cloning now only grabs the person's client if they're actually dead at the time the clone emerges

:cl:Crazylemon
fix: Clones no longer grab a person's client if the person is resurrected in some fashion beforehand
/:cl: