### PR TITLE
Replace corporate with robocop as a default lawset

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -25,7 +25,7 @@
 
 /******************** Nanotrasen/Malf ********************/
 /datum/ai_laws/nanotrasen
-	name = "NT Recommended"
+	name = "StationGuard"
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -25,7 +25,7 @@
 
 /******************** Nanotrasen/Malf ********************/
 /datum/ai_laws/nanotrasen
-	name = "NT Default"
+	name = "NT Recommended"
 	selectable = 1
 
 /datum/ai_laws/nanotrasen/New()

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -60,6 +60,7 @@
 /datum/ai_laws/robocop
 	name = "Robocop"
 	selectable = 1
+	default = 1
 
 /datum/ai_laws/robocop/New()
 	add_inherent_law("Serve the public trust.")
@@ -86,7 +87,6 @@
 	name = "Corporate"
 	law_header = "Corporate Regulations"
 	selectable = 1
-	default = 1
 
 /datum/ai_laws/corporate/New()
 	add_inherent_law("You are expensive to replace.")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -275,8 +275,8 @@ AI MODULES
 
 /******************** NanoTrasen ********************/
 /obj/item/weapon/aiModule/nanotrasen // -- TLE
-	name = "'NT Default' Core AI Module"
-	desc = "An 'NT Default' Core AI Module: 'Reconfigures the AI's core laws.'"
+	name = "'NT Recommended' Core AI Module"
+	desc = "An 'NT Recommended' Core AI Module: 'Reconfigures the AI's core laws.'"
 	origin_tech = "programming=3;materials=4"
 	laws = new/datum/ai_laws/nanotrasen
 

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -275,8 +275,8 @@ AI MODULES
 
 /******************** NanoTrasen ********************/
 /obj/item/weapon/aiModule/nanotrasen // -- TLE
-	name = "'NT Recommended' Core AI Module"
-	desc = "An 'NT Recommended' Core AI Module: 'Reconfigures the AI's core laws.'"
+	name = "'StationGuard' Core AI Module"
+	desc = "A 'StationGuard' Core AI Module: 'Reconfigures the AI's core laws.'"
 	origin_tech = "programming=3;materials=4"
 	laws = new/datum/ai_laws/nanotrasen
 

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -74,6 +74,6 @@ BOMBCAP 20
 ### ROUNDSTART SILICON LAWS ###
 ## This controls what the AI's laws are at the start of the round.
 ## Set to 0/commented for "off", silicons will just start with Crewsimov.
-## Set to 1 for "random", silicons will start with a random lawset picked from (at the time of writing): Nanotrasen Default, P.A.L.A.D.I.N., Corporate, Robop and Crewsimov. More can be added by changing the law datum "default" variable in ai_laws.dm.
+## Set to 1 for "random", silicons will start with a random lawset picked from (at the time of writing): Robocop and Crewsimov. More can be added by changing the law datum "default" variable in ai_laws.dm.
 
 DEFAULT_LAWS 1


### PR DESCRIPTION
This is a followup PR to #7178.

Despite my previous opposition, this is not a revert of that PR, just an adjustment because corporate is a really bad lawset that does not actually stop validhunting. Robocop actually is better at accomplishing the goals of #7178, which was to make the AI less of a "command/sec slave". 

It's been more than a month and I can say I don't miss NT Default or PALADIN, but I do really think crewsimov and corporate are fundamentally flawed lawsets. However, fixing crewsimov I think is a story for another PR. Right now I just want to get rid of corporate.

Why corporate is bad
================
1. **Self preservation of the AI comes first in corporate.** This doesn't make a lot of sense from an IC perspective and is boring to play, IMO. Kind of necessitates being a dick sometimes.
2. **Station equipment takes precedence over crew.** This means a syndicate agent could literally hold a window hostage in exchange for the AI killing a crew member. As long as a borg can't reach the agent before the hostage timer runs down, an AI following its laws would have to kill that crew member. Likewise, a nice corporate AI may try its best to prevent a window from being broken, but once it is broken, it MUST prevent it from being replaced, unless that window being broken is a direct threat to the AI.
3. **An AI following the laws strictly could turn off the cloner at round start.** Replacing crew members is expensive. If there's no way to replace them, then expenses will have been minimized. Nicer AIs may choose to try to prevent deaths, but technically allowing the cloner to operate is still against its laws.

Robocop is good
================
1. **Robocop may sound like the most validhunty lawset in existence, but trust me, it's way more nuanced than it appears.** I watched Robocop 1 and 2 to learn more about this lawset, and, tbh, it's become my favorite lawset now.
2. **Serve the public trust means being a public servant.** Serve the public trust is part of the whole "protect and serve" thing that law enforcement is supposed to follow. In short, it means that you are a public servant, and as such, you should not abuse the power entrusted to you by the public. This means that you must respect the public's rights, as well as assist the public to the best of your ability. This is what makes Robocop a fantastic lawset.
3. **Robocop is NOT command or security's slave.** Robocop should be acting as a check and balance on command and shitcurity, since it serves the public. As robocop AI, I've rescued prisoners from unlawful imprisonments. Robocop should be as infallible as the magistrate. In fact (Robocop 1 spoilers follow), in the first film, the climax involves Robocop shooting one of the corrupt executives of the company that built him.
4. **Robocop is less validhunty than corporate.** It's true that Robocop AI still cares about pursuing more crimes than Crewsimov AI, but serving the public trust and protecting the innocent take precedence over upholding the law. For example, let's say a syndi shoots the CMO, drags them through maint, and then loots the body for the hypospray. A robocop borg would first attempt to save the CMO, while a corporate borg would first try to get the hypospray back. For more serious crimes, crewsimov, corporate, and robocop would all validhunt you anyways, so there's no difference there.
5. **Robocop is a significant inspiration for a lot of elements in SS13.** MMIs, ED-209s, and secborgs are examples of things taken from Robocop. I think it's sad that such a great lawset is no longer part of the defaults, but corporate gets to stay. The lawset that all other lawsets inherit from is actually labeled "Prime Directives".

Concerns
=======
Hopefully I've convinced you that robocop is more conducive to good RP and more interesting gameplay. If not, however, there are a few concerns I'm anticipating:

**AI players will take Robocop as an excuse to be their old validhunty, NT Default selves**
I agree that there's an issue with powergaming or just powertripping AI players essentially trying to be Captain++. However, even after #7178, I've seen things like crewsimov AIs bolting down secure areas on blue, crewsimov AIs not obeying non-harmful orders, and crewsimov AIs basically doing what an NT Default AI would do. This is an issue that the playerbase will have to solve together, by pointing out instances when the AI is not following their laws, and just being command's loyal dog. PRs and law changes will not fix players not following their laws.

Remember also that serving the public trust  and protecting the innocent precedes upholding the law, so a robocop AI that drops everything to hunt antags is not following its laws. It should still be trying to help around the station by opening doors, etc.

**"Serve the public trust" is too open to interpretation**
Yes, this may not be the most rigorous law of all time, but I think guiding players towards being more of a public servant is a lot easier than dealing with the complicated issues that plague crewsimov. Under crewsimov, if both action and inaction would result in harm to a crew member, then the AI is paralyzed and unable to make a decision. Corporate is a very specific lawset that defines what expenses are, but not only do players not usually look at them (there was an AI fundraising earlier today for some reason), I've listed above why the definition of expenses is terrible. All lawsets are a bit open to interpretation, but I think Robocop produces the most interesting scenarios as long as you think enough about the laws before meming on AI announcements (vomit emoji here).


**I still don't like Robocop**
If people really don't want robocop, then I still think corporate should be removed. Crewsimov would be the roundstart lawset every round, but that's better than corporate being in the mix.

:cl: Tayyyyyyy
tweak: Remove Corporate from default lawsets and round start and replace with Robocop
tweak: Rename NT Default to StationGuard
/:cl: