### PR TITLE
Tweaks instagib lasers

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -134,5 +134,3 @@
 		var/mob/living/L = target
 		L.visible_message("<span class='danger'>[L] explodes!</span>")
 		L.gib()
-	else if(isturf(target) || istype(target,/obj/structure/))
-		target.ex_act(2)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -130,7 +130,9 @@
 
 /obj/item/projectile/beam/instakill/on_hit(atom/target)
 	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/M = target
-		M.visible_message("<span class='danger'>[M] explodes into a shower of gibs!</span>")
-		M.gib()
+	if(isliving(target))
+		var/mob/living/L = target
+		L.visible_message("<span class='danger'>[L] explodes!</span>")
+		L.gib()
+	else if(isturf(target) || istype(target,/obj/structure/))
+		target.ex_act(2)


### PR DESCRIPTION
Instagib lasers now work on non-carbon mobs (such as simple_animals).

🆑 Kyep
fix: Instagib lasers now work against non-carbon mobs, such as animals and borgs.
/🆑