### PR TITLE
Makes Araneus spawn at his full 250 HP

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/pet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/pet.dm
@@ -12,7 +12,7 @@
 	response_help = "pets"
 	emote_hear = list("chitters")
 	maxHealth = 250
-	health = 200
+	health = 250
 	harm_intent_damage = 3
 	melee_damage_lower = 15
 	melee_damage_upper = 20


### PR DESCRIPTION
Araneus doesn't spawn at his full 250 HP for reasons, instead spawning at 200. This fixes that.

🆑 
fix: Sergeant Araneus now spawns at full HP.
/🆑 