### PR TITLE
Allows vampire screech to stun borgs

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -250,8 +250,17 @@
 
 /obj/effect/proc_holder/spell/vampire/self/screech/cast(list/targets, mob/user = usr)
 	user.visible_message("<span class='warning'>[user] lets out an ear piercing shriek!</span>", "<span class='warning'>You let out a loud shriek.</span>", "<span class='warning'>You hear a loud painful shriek!</span>")
-	for(var/mob/living/carbon/C in hearers(4))
-		if(C == user)
+	for(var/mob/living/M in get_mobs_in_view(4, user))
+		if(issilicon(M))
+			to_chat(S, "<span class='warning'><b>ERROR $!(@ ERROR )#^! SENSORY OVERLOAD \[$(!@#</b></span>")
+			S << 'sound/misc/interference.ogg'
+			playsound(S, 'sound/machines/warning-buzzer.ogg', 50, 1)
+			var/datum/effect/system/spark_spread/sp = new /datum/effect/system/spark_spread
+			sp.set_up(5, 1, S)
+			sp.start()
+			S.Weaken(6)
+		if(iscarbon(M))
+			if(C == user)
 			continue
 		if(ishuman(C) && (C:l_ear || C:r_ear) && istype((C:l_ear || C:r_ear), /obj/item/clothing/ears/earmuffs))
 			continue


### PR DESCRIPTION
Vampires currently have no real counter to borgs, compared to nearly every other antagonist. This gives them a way to defend themselves against the crazy fast sec borgs. Changelings/traitors get easy access to EMPs, shadowlings get a similar screech that stuns borgs, it only seems fair to give something to vampires.

Lemme know if I fucked something up, I couldn't test it because of where I am currently and I'm still super new to GitHub/programming with byond stuff in general. I will fix any borked things ASAP.

:cl: add: vampires can now stun cyborgs via screech.
/ :cl: 