### PR TITLE
Misc. Fixes

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -266,7 +266,7 @@ CREATE TABLE `player` (
   `UI_style` varchar(10) DEFAULT 'Midnight',
   `UI_style_color` varchar(7) DEFAULT '#ffffff',
   `UI_style_alpha` smallint(4) DEFAULT '255',
-  `be_role` mediumtext NOT NULL,
+  `be_role` mediumtext,
   `default_slot` smallint(4) DEFAULT '1',
   `toggles` mediumint(8) DEFAULT '383',
   `sound` mediumint(8) DEFAULT '31',

--- a/SQL/paradise_schema_prefixed.sql
+++ b/SQL/paradise_schema_prefixed.sql
@@ -265,7 +265,7 @@ CREATE TABLE `SS13_player` (
   `UI_style` varchar(10) DEFAULT 'Midnight',
   `UI_style_color` varchar(7) DEFAULT '#ffffff',
   `UI_style_alpha` smallint(4) DEFAULT '255',
-  `be_role` mediumtext NOT NULL,
+  `be_role` mediumtext,
   `default_slot` smallint(4) DEFAULT '1',
   `toggles` mediumint(8) DEFAULT '383',
   `sound` mediumint(8) DEFAULT '31',

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -229,7 +229,8 @@ var/list/admin_verbs_snpc = list(
 			verbs += /client/proc/togglebuildmodeself
 		if(holder.rights & R_ADMIN)
 			verbs += admin_verbs_admin
-			control_freak = 0
+			spawn(1)
+				control_freak = 0
 		if(holder.rights & R_BAN)
 			verbs += admin_verbs_ban
 		if(holder.rights & R_EVENT)


### PR DESCRIPTION
This fixes the following:
 - Admins not having `control_freak` set to zero (I have no idea why this broke, something about BYOND just flat refuses to let this function without a spawn in the proc)
 - The default SQL schema containing broken columns for the player table. This only affects vanilla MySQL on Windows running under `strict` mode, see ![this.](https://stackoverflow.com/questions/3466872/why-cant-a-text-column-have-a-default-value-in-mysql)

