### PR TITLE
Adds Highlander Style: The Martial Art of Highlanders

### DIFF
--- a/code/game/objects/items/weapons/highlander_swords.dm
+++ b/code/game/objects/items/weapons/highlander_swords.dm
@@ -1,0 +1,46 @@
+
+//Highlander Style Martial Art
+//	Prevents use of guns, but makes the highlander impervious to ranged attacks. Their bravery in battle shields them from the weapons of COWARDS!
+
+/datum/martial_art/highlander
+	name = "Highlander Style"
+	deflection_chance = 100
+	can_use_guns = 0
+	no_guns_message = "You'd never stoop so low as to use the weapon of a COWARD!"
+
+
+//Highlander Claymore
+//	Grants the wielder the Highlander Style Martial Art
+
+/obj/item/weapon/claymore/highlander
+	name = "Highlander Claymore"
+	desc = "Imbues the wielder with legendary martial prowress and a nigh-unquenchable thirst for glorious battle!"
+	var/datum/martial_art/highlander/style = new
+
+/obj/item/weapon/claymore/highlander/equipped(mob/user, slot)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(slot == slot_r_hand || slot == slot_l_hand)
+		if(H.martial_art && H.martial_art != style)
+			style.teach(H, 1)
+			to_chat(H, "<span class='notice'>THERE CAN ONLY BE ONE!</span>")
+	else if(H.martial_art && H.martial_art == style)
+		style.remove(H)
+		var/obj/item/weapon/claymore/highlander/sword = H.is_in_hands(/obj/item/weapon/claymore/highlander)
+		if(sword)
+			//if we have a highlander sword in the other hand, relearn the style from that sword.
+			sword.style.teach(H, 1)
+
+	return
+
+/obj/item/weapon/claymore/highlander/dropped(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	style.remove(H)
+	var/obj/item/weapon/claymore/highlander/sword = H.is_in_hands(/obj/item/weapon/claymore/highlander)
+	if(sword)
+		//if we have a highlander sword in the other hand, relearn the style from that sword.
+		sword.style.teach(H, 1)
+	return

--- a/code/game/objects/items/weapons/highlander_swords.dm
+++ b/code/game/objects/items/weapons/highlander_swords.dm
@@ -17,6 +17,13 @@
 	desc = "Imbues the wielder with legendary martial prowress and a nigh-unquenchable thirst for glorious battle!"
 	var/datum/martial_art/highlander/style = new
 
+/obj/item/weapon/claymore/highlander/Destroy()
+	if(ishuman(loc))	//just in case it gets destroyed while in someone's possession, such as due to acid or something?
+		var/mob/living/carbon/human/H = loc
+		style.remove(H)
+	QDEL_NULL(style)
+	return ..()
+
 /obj/item/weapon/claymore/highlander/equipped(mob/user, slot)
 	if(!ishuman(user))
 		return
@@ -32,8 +39,6 @@
 			//if we have a highlander sword in the other hand, relearn the style from that sword.
 			sword.style.teach(H, 1)
 
-	return
-
 /obj/item/weapon/claymore/highlander/dropped(mob/user)
 	if(!ishuman(user))
 		return
@@ -43,4 +48,3 @@
 	if(sword)
 		//if we have a highlander sword in the other hand, relearn the style from that sword.
 		sword.style.teach(H, 1)
-	return

--- a/code/game/objects/items/weapons/highlander_swords.dm
+++ b/code/game/objects/items/weapons/highlander_swords.dm
@@ -5,7 +5,7 @@
 /datum/martial_art/highlander
 	name = "Highlander Style"
 	deflection_chance = 100
-	can_use_guns = 0
+	no_guns = TRUE
 	no_guns_message = "You'd never stoop so low as to use the weapon of a COWARD!"
 
 

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -37,7 +37,7 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/kilt(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/captain(H), slot_l_ear)
 		H.equip_to_slot_or_del(new /obj/item/clothing/head/beret(H), slot_head)
-		H.equip_to_slot_or_del(new /obj/item/weapon/claymore(H), slot_r_hand)
+		H.equip_to_slot_or_del(new /obj/item/weapon/claymore/highlander(H), slot_r_hand)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/weapon/pinpointer(H.loc), slot_l_store)
 

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -7,8 +7,8 @@
 	var/datum/martial_art/base = null // The permanent style
 	var/deflection_chance = 0 //Chance to deflect projectiles
 	var/help_verb = null
-	var/can_use_guns = 1	//set to zero to prevent users of this style from using guns (sleeping carp, highlander). They can still pick them up, but not fire them.
-	var/no_guns_message = ""	//message to tell the style user if they try and use a gun while can_use_guns = 0 (DISHONORABRU!)
+	var/no_guns = FALSE	//set to TRUE to prevent users of this style from using guns (sleeping carp, highlander). They can still pick them up, but not fire them.
+	var/no_guns_message = ""	//message to tell the style user if they try and use a gun while no_guns = TRUE (DISHONORABRU!)
 
 /datum/martial_art/proc/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	return 0

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -7,6 +7,8 @@
 	var/datum/martial_art/base = null // The permanent style
 	var/deflection_chance = 0 //Chance to deflect projectiles
 	var/help_verb = null
+	var/can_use_guns = 1	//set to zero to prevent users of this style from using guns (sleeping carp, highlander). They can still pick them up, but not fire them.
+	var/no_guns_message = ""	//message to tell the style user if they try and use a gun while can_use_guns = 0 (DISHONORABRU!)
 
 /datum/martial_art/proc/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	return 0

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -8,7 +8,7 @@
 	name = "The Sleeping Carp"
 	deflection_chance = 100
 	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help
-	can_use_guns = 0
+	no_guns = TRUE
 	no_guns_message = "Use of ranged weaponry would bring dishonor to the clan."
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -8,6 +8,8 @@
 	name = "The Sleeping Carp"
 	deflection_chance = 100
 	help_verb = /mob/living/carbon/human/proc/sleeping_carp_help
+	can_use_guns = 0
+	no_guns_message = "Use of ranged weaponry would bring dishonor to the clan."
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(findtext(streak,WRIST_WRENCH_COMBO))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1985,7 +1985,7 @@
 			to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return 0
 
-	if(martial_art && !martial_art.can_use_guns) //great dishonor to famiry
+	if(martial_art && martial_art.no_guns) //great dishonor to famiry
 		to_chat(src, "<span class='warning'>[martial_art.no_guns_message]</span>")
 		return 0
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1985,8 +1985,8 @@
 			to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return 0
 
-	if(martial_art && martial_art.name == "The Sleeping Carp") //great dishonor to famiry
-		to_chat(src, "<span class='warning'>Use of ranged weaponry would bring dishonor to the clan.</span>")
+	if(martial_art && !martial_art.can_use_guns) //great dishonor to famiry
+		to_chat(src, "<span class='warning'>[martial_art.no_guns_message]</span>")
 		return 0
 
 	return .

--- a/paradise.dme
+++ b/paradise.dme
@@ -804,6 +804,7 @@
 #include "code\game\objects\items\weapons\garrote.dm"
 #include "code\game\objects\items\weapons\gift_wrappaper.dm"
 #include "code\game\objects\items\weapons\handcuffs.dm"
+#include "code\game\objects\items\weapons\highlander_swords.dm"
 #include "code\game\objects\items\weapons\holosign.dm"
 #include "code\game\objects\items\weapons\holy_weapons.dm"
 #include "code\game\objects\items\weapons\kitchen.dm"


### PR DESCRIPTION
Adds a new martial art: Highlander Style!
- Wielders of the powerful Highlander claymores are imbued with this mythical prowress. Should your both your hands ever lack a grip on a Highlander claymore, you will relinquish your newfound skill.
- Highlander Style grants immunity to ranged attacks and an unwavering distain of cowardly guns. Just like with Sleeping Carp, you will deflect projectiles and cannot fire guns (but can pick them up to throw in the trash where they belong).

Adds new weapon: Highlander Claymore
- Grants the wielder the Highlander Style while held in either hand.
- Normal claymores were left in, but do not provide the martial art (so they are "safe" to use outside highlander)

Minor refactor to martial arts which prevent use of guns.
- No longer relies on the name of the style, but rather the new aptly-named var: `can_use_guns`

:cl:
rscadd: Adds Highlander Style, granted to the wielder of Highlander Claymores. This martial art allows you to deflect ranged attacks from the weapons of COWARDS. FOR THE HONOR OF THE HIGHLANDERS!
tweak: Highlander now equips combatants with a Highlander claymore instead of a normal claymore. FIGHT ON BROTHERS!
/:cl: