### PR TITLE
Adds flashes maintnence loot

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -150,7 +150,7 @@
 				/obj/item/weapon/implanter/storage = 1,
 				/obj/item/toy/cards/deck/syndicate = 2,
 				/obj/item/weapon/storage/secure/briefcase/syndie = 2,
-				"" = 70
+				"" = 68
 				)
 
 /obj/effect/spawner/lootdrop/crate_spawner // for ruins

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -75,6 +75,7 @@
 				/obj/item/clothing/under/rank/vice = 10,
 				/obj/item/device/assembly/prox_sensor = 40,
 				/obj/item/device/assembly/timer = 30,
+				/obj/item/device/flash = 2,
 				/obj/item/device/flashlight = 40,
 				/obj/item/device/flashlight/pen = 10,
 				/obj/item/device/multitool = 20,


### PR DESCRIPTION
Flashes are generally a robust self defense item, and can also be turned into robotics to assist with Borg creation. I propose that flashes spawn as maintnence loot as both a buff to antagonists to help deal with the new fast borgs, and to add a self defense option that ISNT a stechkin, alongside interactions between the maintnence dwellers and robotics.

The spawn rate of them is the same as no-slip shoes, so still pretty rare. 

🆑 Imsxz
add: Adds a small chance for flashes to spawn in maintnence
/🆑 