### PR TITLE
Replaces Illegal R&D Gear with Other Implants

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_track.dm
+++ b/code/game/objects/items/weapons/implants/implant_track.dm
@@ -30,3 +30,11 @@
 				circuitry. As a result neurotoxins can cause massive damage.<HR>
 				Implant Specifics:<BR>"}
 	return dat
+
+/obj/item/weapon/implantcase/track
+	name = "implant case - 'Tracking'"
+	desc = "A glass case containing a tracking implant."
+
+/obj/item/weapon/implantcase/track/New()
+	imp = new /obj/item/weapon/implant/tracking(src)
+	..()

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -394,22 +394,22 @@
 	build_path = /obj/item/weapon/implantcase
 	category = list("Medical")
 
-/datum/design/implant_freedom
-	name = "Freedom Implant Case"
+/datum/design/implant_chem
+	name = "Chemical Implant Case"
 	desc = "A glass case containing an implant."
-	id = "implant_freedom"
-	req_tech = list("combat" = 6, "biotech" = 5, "magnets" = 3, "syndicate" = 3)
+	id = "implant_chem"
+	req_tech = list("materials" = 3, "biotech" = 5,)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 800, MAT_GLASS = 500, MAT_GOLD = 500)
-	build_path = /obj/item/weapon/implantcase/freedom
+	materials = list(MAT_GLASS = 700)
+	build_path = /obj/item/weapon/implantcase/chem
 	category = list("Medical")
 
-/datum/design/implant_adrenalin
-	name = "Adrenalin Implant Case"
+/datum/design/implant_tracking
+	name = "Tracking Implant Case"
 	desc = "A glass case containing an implant."
-	id = "implant_adrenalin"
-	req_tech = list("biotech" = 6, "combat" = 6, "syndicate" = 6)
+	id = "implant_tracking"
+	req_tech = list("materials" = 2, "biotech" = 3, "magnets" = 3, "programming" = 2)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1000, MAT_GLASS = 500, MAT_GOLD = 500, MAT_URANIUM = 600, MAT_DIAMOND = 600)
-	build_path = /obj/item/weapon/implantcase/adrenaline
+	materials = list(MAT_METAL = 500, MAT_GLASS = 500)
+	build_path = /obj/item/weapon/implantcase/track
 	category = list("Medical")


### PR DESCRIPTION
Port of: https://github.com/tgstation/tgstation/pull/28124

Replaces the uplink/syndicate freedom and adrenaline implants with the far more legal chem and tracking implants.

:cl: Fox McCloud
rscdel: Remove adrenaline and freedom implants from R&D
add: Added chem and tracking implants to R&D
/:cl: