### PR TITLE
Fixes ED209 bots getting stuck on eachother​ in hallways.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -3,7 +3,7 @@
 	desc = "A security robot.  He looks less than thrilled."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "ed2090"
-	density = 1
+	density = 0
 	anchored = 0
 	health = 100
 	maxHealth = 100


### PR DESCRIPTION
A big issue with constructing EDs is that they constantly get stuck on eachother in hallways, unable to move. This allows them to pass through each other like most other bots.

🆑 Imsxz
fix: Fixes ED209s getting stuck on eachother in hallways
\ 🆑 