### PR TITLE
Fixes the karma message popping up when you disconnected but had already spent karma

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -263,7 +263,7 @@
 				timer = world.time
 				priority_announcement.Announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.")
 				for(var/mob/M in player_list)
-					if(!isnewplayer(M) && !M.client.karma_spent && !M.get_preference(DISABLE_KARMA_REMINDER))
+					if(!isnewplayer(M) && !M.client.karma_spent && !M.client.ckey in karma_spenders && !M.get_preference(DISABLE_KARMA_REMINDER))
 						to_chat(M, "<i>You have not yet spent your karma for the round; was there a player worthy of receiving your reward? Look under OOC tab, Award Karma.</i>")
 
 		if(SHUTTLE_ESCAPE)


### PR DESCRIPTION
Fixes #7509 by also checking if the client's ckey is in `karma_spenders`.

I'd appreciate it if someone looked over the line I added to see if I did anything wrong, as I can't really test karma interactions without a database or another player

:cl:
fix: Disconnecting before the shuttle leaves after having spent karma will no longer prompt you to spend karma.
/:cl: