### PR TITLE
Prevents deep space cult bases

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -240,6 +240,9 @@
 	if(locate(/obj/effect/rune) in runeturf)
 		to_chat(user, "<span class='cult'>There is already a rune here.</span>")
 		return
+	if(!is_station_level(user.z) && !is_mining_level(user.z) && !is_admin_level(user.z))
+		to_chat(user, "<span class='warning'>The veil is not weak enough to create a working rune here.</span>")
+		return
 	for(var/T in subtypesof(/obj/effect/rune) - /obj/effect/rune/malformed)
 		var/obj/effect/rune/R = T
 		if(initial(R.cultist_name))


### PR DESCRIPTION
We've all seen cult rounds where they create bases on the white ship, abandoned / russian station, little platforms in space, or other such areas that will never be found, let alone successfully attacked, by crew.

This PR stops that.
You can now only draw runes (and thus, create cult bases) on the station, the mining zlevel, and z2 (so admins can still test runes in the testing area). Attempting to create runes with a tome on other zlevels, like the various places in deep space, will fail.

🆑 Kyep
add: Cult runes now only work on the station, mining, and centcom zlevels. They no longer work on telecommms, the abandoned stations, the white ship, or other locations in deep space. Cultists can no longer create totally unassailable bases in deep space.
/🆑
