### PR TITLE
Ports Job Priority System

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -10,10 +10,12 @@ var/global/datum/controller/occupations/job_master
 	var/list/occupations = list()
 	var/list/name_occupations = list()	//Dict of all jobs, keys are titles
 	var/list/type_occupations = list()	//Dict of all jobs, keys are types
+	var/list/prioritized_jobs = list() // List of jobs set to priority by HoP/Captain
 	//Players who need jobs
 	var/list/unassigned = list()
 	//Debug info
 	var/list/job_debug = list()
+
 
 /datum/controller/occupations/proc/SetupOccupations(var/list/faction = list("Station"))
 	occupations = list()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -363,7 +363,7 @@
 		dat += "<font color='red'>The station is currently undergoing evacuation procedures.</font><br>"
 
 	if(length(job_master.prioritized_jobs))
-		dat += "<font color='green'>The station has flagged these jobs as high priority: "
+		dat += "<font color='lime'>The station has flagged these jobs as high priority: "
 		var/amt = length(job_master.prioritized_jobs)
 		var/amt_count
 		for(var/datum/job/a in job_master.prioritized_jobs)
@@ -422,7 +422,10 @@
 		dat += "<fieldset style='border: 2px solid [color]; display: inline'>"
 		dat += "<legend align='center' style='color: [color]'>[jobcat]</legend>"
 		for(var/datum/job/job in categorizedJobs[jobcat]["jobs"])
-			dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</a><br>"
+			if(job in job_master.prioritized_jobs)
+				dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'><font color='lime'><B>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</B></font></a><br>"
+			else
+				dat += "<a href='byond://?src=[UID()];SelectedJob=[job.title]'>[job.title] ([job.current_positions]) (Active: [activePlayers[job]])</a><br>"
 		dat += "</fieldset><br>"
 
 	dat += "</td></tr></table></center>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -362,6 +362,18 @@
 	else if(shuttle_master.emergency.mode >= SHUTTLE_CALL)
 		dat += "<font color='red'>The station is currently undergoing evacuation procedures.</font><br>"
 
+	if(length(job_master.prioritized_jobs))
+		dat += "<font color='green'>The station has flagged these jobs as high priority: "
+		var/amt = length(job_master.prioritized_jobs)
+		var/amt_count
+		for(var/datum/job/a in job_master.prioritized_jobs)
+			amt_count++
+			if(amt_count != amt)
+				dat += " [a.title], "
+			else
+				dat += " [a.title]. </font><br>"
+
+
 	dat += "Choose from the following open positions:<br><br>"
 
 	var/list/activePlayers = list()

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -41,6 +41,7 @@
 				<span class="average" style="font-weight: bold;">{{:value.title}}: {{:value.current_positions}}/{{:value.total_positions}}</span>
 				{{:helper.link('-', null, {'choice' : 'make_job_unavailable', 'job' : value.title}, value.can_close == 1 && data.authenticated ? null : 'disabled')}}
 				{{:helper.link('+', null, {'choice' : 'make_job_available', 'job' : value.title}, value.can_open == 1 && data.authenticated ? null : 'disabled')}}
+				{{:helper.link('*', null, {'choice' : 'prioritize_job', 'job' : value.title}, value.can_prioritize > 0 && data.authenticated ? null : 'disabled')}} {{if value.can_prioritize == 2}}<span class='warning'>Priority Job</span> {{/if}}
 			</div>
 		{{/for}}
 	</div>


### PR DESCRIPTION
This system allows the HoP to set up to 3 jobs as 'priority' jobs via the ID console.
Priority jobs are highlighted in green to everyone who is late-joining.

This allows the HoP to actively encourage late-arriving crew to take jobs the station needs, avoiding departments/roles being critically short-handed.

Based on a similar feature from TG.

![](https://preview.ibb.co/dnr3OF/job_priority_example.png)

🆑 Kyep
add: HoPs can now set jobs as 'priority'. Priority jobs are highlighted on the latejoin screen. This allows HoPs to proactively broadcast that they need more people to fill those jobs - and reduces the chance of critical crew shortages.
/🆑