### PR TITLE
Changes illegal borg module level

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -206,7 +206,7 @@
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg"
 	icon_state = "cyborg_upgrade3"
-	origin_tech = "combat=4;syndicate=1"
+	origin_tech = "combat=4;syndicate=3"
 	require_module = 1
 
 /obj/item/borg/upgrade/syndicate/action(mob/living/silicon/robot/R)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1075,7 +1075,7 @@
 	name = "Cyborg Upgrade (Illegal Modules)"
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4, "syndicate" = 2)
+	req_tech = list("combat" = 4, "syndicate" = 4)
 	build_path = /obj/item/borg/upgrade/syndicate
 	materials = list(MAT_METAL=10000,MAT_GLASS=15000,MAT_DIAMOND = 10000)
 	construction_time = 120


### PR DESCRIPTION
This PR is another short and simple one, rebalances the illegal tech module so it can no longer be obtained by a single bit of small level syndicate gear on top of normal research (as in a full team of borgs kit out with illegals 30-40 minutes into a round).

🆑DarkPyrolord
tweak: Illegal equipment module now requires syndicate level 4 research, not syndicate level 2
/🆑