### PR TITLE
Fixes speeds

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -35,6 +35,7 @@
 	anchored = 1
 	mob_size = MOB_SIZE_TINY
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
+	speed = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 
 	var/essence = 75 //The resource of revenants. Max health is equal to three times this amount

--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -83,7 +83,7 @@
 /mob/living/simple_animal/slaughter/Life()
 	..()
 	if(boost<world.time)
-		speed = 2
+		speed = 1
 	else
 		speed = 0
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -302,7 +302,6 @@
 	melee_damage_lower = 1
 	melee_damage_upper = 5
 	attacktext = "prods"
-	speed = 0
 	environment_smash = 3
 	see_in_dark = 8
 	attack_sound = 'sound/weapons/tap.ogg'

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -48,7 +48,7 @@ ROBOT_DELAY 1.5
 MONKEY_DELAY 1.5
 ALIEN_DELAY 1.5
 SLIME_DELAY 1.5
-ANIMAL_DELAY 1.5
+ANIMAL_DELAY 2.5
 
 ## Comment for "normal" explosions, which ignore obstacles
 ## Uncomment for explosions that react to doors and walls


### PR DESCRIPTION
So, come to find out, one of the reasons our movement speed values were off for animals wassss, TG was hiding their speed debuff for animals behind the game_options, where it's exactly `1` slower than humans. Ooops.

This makes some further adjustments to speeds of various simple mobs that I missed the first time. Slaughter demons should a movement speed slower than humans by default, but the same when they get their initial boost, right out of the blood crawl.

:cl: Fox McCloud
tweak: tweaked Revenant and slaughter demon movement speed
/:cl: