### PR TITLE
Spiderbot Rework

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -34,6 +34,7 @@
 
 	var/emagged = 0               //is it getting ready to explode?
 	var/obj/item/device/mmi/mmi = null
+	var/emagged_master = null //for administrative purposes, to see who emagged the spiderbot; also for a holder for if someone emags an empty frame first then inserts an MMI.
 
 /mob/living/simple_animal/spiderbot/Destroy()
 	if(emagged)
@@ -134,6 +135,7 @@
 		emagged = 1
 		to_chat(user, "<span class='notice'>You short out the security protocols and rewrite [src]'s internal memory.</span>")
 		to_chat(src, "<span class='userdanger'>You have been emagged; you are now completely loyal to [user] and their every order!</span>")
+		emagged_master = user.name
 		add_logs(user, src, "emagged")
 		maxHealth = 60
 		health = 60
@@ -146,6 +148,8 @@
 	mind.key = M.brainmob.key
 	ckey = M.brainmob.ckey
 	name = "Spider-bot ([M.brainmob.name])"
+	if(emagged)
+		to_chat(src, "<span class='userdanger'>You have been emagged; you are now completely loyal to [emagged_master] and their every order!</span>")
 
 /mob/living/simple_animal/spiderbot/proc/update_icon()
 	if(mmi)

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -1,53 +1,52 @@
 /mob/living/simple_animal/spiderbot
-
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	minbodytemp = 0
-	maxbodytemp = 500
-
-	var/obj/item/device/radio/borg/radio = null
-	var/mob/living/silicon/ai/connected_ai = null
-	var/obj/item/weapon/stock_parts/cell/cell = null
-	var/obj/machinery/camera/camera = null
-	var/obj/item/device/mmi/mmi = null
-	var/list/req_access = list(access_robotics) //Access needed to pop out the brain.
-
 	name = "Spider-bot"
-	desc = "A skittering robotic friend!"
+	desc = "A skittering robotic friend!" //More like ultimate shitter
 	icon = 'icons/mob/robots.dmi'
 	icon_state = "spiderbot-chassis"
 	icon_living = "spiderbot-chassis"
 	icon_dead = "spiderbot-smashed"
 	wander = 0
 	universal_speak = 1
-	health = 10
-	maxHealth = 10
+	health = 40
+	maxHealth = 40
 
+	melee_damage_lower = 2
+	melee_damage_upper = 2
+	melee_damage_type = BURN
 	attacktext = "shocks"
-	attacktext = "shocks"
-	melee_damage_lower = 1
-	melee_damage_upper = 3
+	attack_sound = "sparks"
 
 	response_help  = "pets"
 	response_disarm = "shoos"
 	response_harm   = "stomps on"
-
-	var/obj/item/held_item = null //Storage for single item they can hold.
-	var/emagged = 0               //IS WE EXPLODEN?
-	var/syndie = 0                //IS WE SYNDICAT? (currently unused)
-	speed = -1                    //Spiderbots gotta go fast.
-	//pass_flags = PASSTABLE      //Maybe griefy?
+	speed = 0
 	mob_size = MOB_SIZE_SMALL
 	speak_emote = list("beeps","clicks","chirps")
+
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	minbodytemp = 0
+	maxbodytemp = 500
+
 	can_hide = 1
 	ventcrawler = 2
 	loot = list(/obj/effect/decal/cleanable/blood/gibs/robot)
 	del_on_death = 1
 
-/mob/living/simple_animal/spiderbot/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
+	var/emagged = 0               //is it getting ready to explode?
+	var/obj/item/device/mmi/mmi = null
 
-	if(istype(O, /obj/item/device/mmi) || istype(O, /obj/item/device/mmi/posibrain))
+/mob/living/simple_animal/spiderbot/Destroy()
+	if(emagged)
+		QDEL_NULL(mmi)
+		explosion(get_turf(src), -1, -1, 3, 5)
+	else
+		eject_brain()
+	return ..()
+
+/mob/living/simple_animal/spiderbot/attackby(obj/item/O, mob/living/user, params)
+	if(istype(O, /obj/item/device/mmi))
 		var/obj/item/device/mmi/B = O
-		if(src.mmi) //There's already a brain in it.
+		if(mmi) //There's already a brain in it.
 			to_chat(user, "<span class='warning'>There's already a brain in [src]!</span>")
 			return
 		if(!B.brainmob)
@@ -65,45 +64,47 @@
 						ghost_can_reenter = 1
 						break
 			if(!ghost_can_reenter)
-				to_chat(user, "<span class='notice'>[O] is completely unresponsive; there's no point.</span>")
+				to_chat(user, "<span class='notice'>[B] is completely unresponsive; there's no point.</span>")
 				return
 
 		if(B.brainmob.stat == DEAD)
-			to_chat(user, "<span class='warning'>[O] is dead. Sticking it into the frame would sort of defeat the purpose.</span>")
+			to_chat(user, "<span class='warning'>[B] is dead. Sticking it into the frame would sort of defeat the purpose.</span>")
 			return
 
-		if(jobban_isbanned(B.brainmob, "Cyborg") || jobban_isbanned(B.brainmob,"nonhumandept"))
-			to_chat(user, "<span class='warning'>[O] does not seem to fit.</span>")
+		if(jobban_isbanned(B.brainmob, "Cyborg") || jobban_isbanned(B.brainmob, "nonhumandept"))
+			to_chat(user, "<span class='warning'>[B] does not seem to fit.</span>")
 			return
 
-		to_chat(user, "<span class='notice'>You install [O] in [src]!</span>")
+		to_chat(user, "<span class='notice'>You install [B] in [src]!</span>")
 
 		user.drop_item()
-		src.mmi = O
-		src.transfer_personality(O)
+		B.forceMove(src)
+		mmi = B
+		transfer_personality(B)
 
-		O.loc = src
-		src.update_icon()
+		update_icon()
 		return 1
 
-	if(istype(O, /obj/item/weapon/weldingtool))
+	else if(iswelder(O) && user.a_intent == INTENT_HELP)
 		var/obj/item/weapon/weldingtool/WT = O
+		user.changeNext_move(CLICK_CD_MELEE)
 		if(WT.remove_fuel(0))
 			if(health < maxHealth)
-				health += pick(1,1,1,2,2,3)
-				if(health > maxHealth)
-					health = maxHealth
+				adjustHealth(-5)
+				playsound(loc, WT.usesound, 50, 1)
 				add_fingerprint(user)
-				for(var/mob/W in viewers(user, null))
-					W.show_message(text("<span class='warning'>[user] has spot-welded some of the damage to [src]!</span>"), 1)
+				visible_message("<span class='warning'>[user] has spot-welded some of the damage to [src]!</span>")
 			else
 				to_chat(user, "<span class='notice'>[src] is undamaged!</span>")
 		else
 			to_chat(user, "Need more welding fuel!")
-			return
-	else if(istype(O, /obj/item/weapon/card/id)||istype(O, /obj/item/device/pda))
+	else if(istype(O, /obj/item/weapon/card/id) || istype(O, /obj/item/device/pda))
 		if(!mmi)
 			to_chat(user, "<span class='warning'>There's no reason to swipe your ID - the spiderbot has no brain to remove.</span>")
+			return 0
+
+		if(emagged)
+			to_chat(user, "<span class='warning'>[src] doesn't seem to respond.</span>")
 			return 0
 
 		var/obj/item/weapon/card/id/id_card
@@ -117,63 +118,38 @@
 		if(access_robotics in id_card.access)
 			to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of [src].</span>")
 			eject_brain()
-
-			if(held_item)
-				held_item.loc = src.loc
-				held_item = null
-
 			return 1
 		else
 			to_chat(user, "<span class='warning'>You swipe your card, with no effect.</span>")
 			return 0
 
 	else
-		if(O.force)
-			var/damage = O.force
-			if(O.damtype == STAMINA)
-				damage = 0
-			adjustBruteLoss(damage)
-			for(var/mob/M in viewers(src, null))
-				if((M.client && !( M.blinded )))
-					M.show_message("<span class='boldwarning'>[src] has been attacked with the [O] by [user]. </span>")
-		else
-			to_chat(usr, "<span class='warning'>This weapon is ineffective, it does no damage.</span>")
-			for(var/mob/M in viewers(src, null))
-				if((M.client && !( M.blinded )))
-					M.show_message("<span class='warning'>[user] gently taps [src] with the [O]. </span>")
+		..()
 
-/mob/living/simple_animal/spiderbot/emag_act(user as mob)
+/mob/living/simple_animal/spiderbot/emag_act(mob/living/user)
 	if(emagged)
-		to_chat(user, "<span class='warning'>[src] is already overloaded - better run.</span>")
+		to_chat(user, "<span class='warning'>[src] doesn't seem to respond.</span>")
 		return 0
 	else
 		emagged = 1
-		to_chat(user, "<span class='notice'>You short out the security protocols and overload [src]'s cell, priming it to explode in a short time.</span>")
-		spawn(100)
-			to_chat(src, "<span class='warning'>Your cell seems to be outputting a lot of power...</span>")
-		spawn(200)
-			to_chat(src, "<span class='warning'>Internal heat sensors are spiking! Something is badly wrong with your cell!</span>")
-		spawn(300)
-			src.explode()
+		to_chat(user, "<span class='notice'>You short out the security protocols and rewrite [src]'s internal memory.</span>")
+		to_chat(src, "<span class='userdanger'>You have been emagged; you are now completely loyal to [user] and their every order!</span>")
+		add_logs(user, src, "emagged")
+		maxHealth = 60
+		health = 60
+		melee_damage_lower = 15
+		melee_damage_upper = 15
+		attack_sound = 'sound/machines/defib_zap.ogg'
 
-/mob/living/simple_animal/spiderbot/proc/transfer_personality(var/obj/item/device/mmi/M as obj)
-
-		src.mind = M.brainmob.mind
-		src.mind.key = M.brainmob.key
-		src.ckey = M.brainmob.ckey
-		src.name = "Spider-bot ([M.brainmob.name])"
-
-/mob/living/simple_animal/spiderbot/proc/explode() //When emagged.
-	for(var/mob/M in viewers(src, null))
-		if((M.client && !( M.blinded )))
-			M.show_message("<span class='warning'>[src] makes an odd warbling noise, fizzles, and explodes.</span>")
-	explosion(get_turf(loc), -1, -1, 3, 5)
-	eject_brain()
-	death()
+/mob/living/simple_animal/spiderbot/proc/transfer_personality(obj/item/device/mmi/M)
+	mind = M.brainmob.mind
+	mind.key = M.brainmob.key
+	ckey = M.brainmob.ckey
+	name = "Spider-bot ([M.brainmob.name])"
 
 /mob/living/simple_animal/spiderbot/proc/update_icon()
 	if(mmi)
-		if(istype(mmi,/obj/item/device/mmi))
+		if(istype(mmi, /obj/item/device/mmi))
 			icon_state = "spiderbot-chassis-mmi"
 			icon_living = "spiderbot-chassis-mmi"
 		if(istype(mmi, /obj/item/device/mmi/posibrain))
@@ -186,99 +162,10 @@
 
 /mob/living/simple_animal/spiderbot/proc/eject_brain()
 	if(mmi)
-		var/turf/T = get_turf(loc)
-		if(T)
-			mmi.loc = T
-		if(mind)	mind.transfer_to(mmi.brainmob)
+		var/turf/T = get_turf(src)
+		mmi.forceMove(T)
+		if(mind)
+			mind.transfer_to(mmi.brainmob)
 		mmi = null
-		src.name = "Spider-bot"
+		name = "Spider-bot"
 		update_icon()
-
-/mob/living/simple_animal/spiderbot/Destroy()
-	eject_brain()
-	return ..()
-
-/mob/living/simple_animal/spiderbot/New()
-
-	radio = new /obj/item/device/radio/borg(src)
-	camera = new /obj/machinery/camera(src)
-	camera.c_tag = "Spiderbot-[real_name]"
-	camera.network = list("SS13")
-
-	..()
-
-/mob/living/simple_animal/spiderbot/death(gibbed)
-	if(camera)
-		camera.status = 0
-
-	if(held_item)
-		held_item.forceMove(src.loc)
-		held_item = null
-	..()
-
-//Cannibalized from the parrot mob. ~Zuhayr
-
-/mob/living/simple_animal/spiderbot/verb/drop_held_item()
-	set name = "Drop held item"
-	set category = "Spiderbot"
-	set desc = "Drop the item you're holding."
-
-	if(stat)
-		return
-
-	if(!held_item)
-		to_chat(usr, "<span class='warning'>You have nothing to drop!</span>")
-		return 0
-
-	if(istype(held_item, /obj/item/weapon/grenade))
-		visible_message("<span class='warning'>[src] launches \the [held_item]!</span>", "<span class='warning'>You launch \the [held_item]!</span>", "You hear a skittering noise and a thump!")
-		var/obj/item/weapon/grenade/G = held_item
-		G.loc = src.loc
-		G.prime()
-		held_item = null
-		return 1
-
-	visible_message("<span class='notice'>[src] drops \the [held_item]!</span>", "<span class='notice'>You drop \the [held_item]!</span>", "You hear a skittering noise and a soft thump.")
-
-	held_item.loc = src.loc
-	held_item = null
-	return 1
-
-	return
-
-/mob/living/simple_animal/spiderbot/verb/get_item()
-	set name = "Pick up item"
-	set category = "Spiderbot"
-	set desc = "Allows you to take a nearby small item."
-
-	if(stat)
-		return -1
-
-	if(held_item)
-		to_chat(src, "<span class='warning'>You are already holding \the [held_item]</span>")
-		return 1
-
-	var/list/items = list()
-	for(var/obj/item/I in view(1,src))
-		if(I.loc != src && I.w_class <= WEIGHT_CLASS_SMALL)
-			items.Add(I)
-
-	var/obj/selection = input("Select an item.", "Pickup") in items
-
-	if(selection)
-		for(var/obj/item/I in view(1, src))
-			if(selection == I)
-				held_item = selection
-				selection.loc = src
-				visible_message("<span class='notice'>[src] scoops up \the [held_item]!</span>", "<span class='notice'>You grab \the [held_item]!</span>", "You hear a skittering noise and a clink.")
-				return held_item
-		to_chat(src, "<span class='warning'>\The [selection] is too far away.</span>")
-		return 0
-
-	to_chat(src, "<span class='warning'>There is nothing of interest to take.</span>")
-	return 0
-
-/mob/living/simple_animal/spiderbot/examine(mob/user)
-	..(user)
-	if(src.held_item)
-		to_chat(user, "It is carrying \a [src.held_item] [bicon(src.held_item)].")


### PR DESCRIPTION
Changes Spiderbots quite a bit.

Spiderbots, near as I can tell are awful Cael code...not only this, but they have a large number of problems with them that haven't ever really been addressed...not to mention they have a ton of copy-pasted code from borgs.

This changes them quite a bit so they fit their niche: a near-useless little holding platform for an MMI.

Changes
 - Spiderbots have been slowed down to human levels
 - Spiderbots melee attack consistently deals 2 damage, deals burn, and plays a sparks sound
 - Spiderbots no longer have a built in camera
 - Spiderbots now have 40 health (previously 10)
 - Attacking a spiderbot more consistent with other simple mobs
 - Healing a spiderbot with a welder now plays a sound and incurs a cooldown
 - Spiderbots can no longer carry items
 - Emagging a spiderbot makes it loyal to the person who emagged it. Additionally, it gains 20 extra health, its shocks will do 15 damage, and will explode on death 

The ability to hold items is, quite frankly, overpowered for a little mob like this--additionally, having a blacklist or lots of checks for what it can/cannot hold and where is just not worth it, especially for a platform that was meant to just be for temporarily holding an MMI until a borg can be made or if someone wants to fiddle around.

Emagging a spiderbot, however, was underwhelming, as such, it's been changed to essentially make them "drones light". The spiderbot is loyal to the emagger, gets a damage boost, and its MMI cannot be removed. If someone takes the time to actually yank out someone's brain to put it in a spiderbot to emag it, they should at least get a little something, beyond a mob that just explodes and leaves the person to yack their head off about how awful Traitor McEmagger is and how he should valided ASAP.

fixes https://github.com/ParadiseSS13/Paradise/issues/7526

:cl: Fox McCloud
 tweak: Spiderbots have been slowed down to human levels
 tweak: Spiderbots melee attack consistently deals 2 damage, deals burn, and plays a sparks sound
 tweak: Spiderbots no longer have a built in camera
 tweak: Spiderbots now have 40 health (previously 10)
 tweak: Attacking a spiderbot more consistent with other simple mobs
 tweak: Healing a spiderbot with a welder now plays a sound and incurs a cooldown
 tweak: Spiderbots can no longer carry items
 tweak: Emagging a spiderbot makes it loyal to the person who emagged it. Additionally, it gains 20 extra health, its shocks will do 15 damage, and will explode on death 
/:cl: