### PR TITLE
Walking over your friends with murderous intent or while fat will now trample them [WIP]

### DIFF
--- a/code/game/objects/items/misc.dm
+++ b/code/game/objects/items/misc.dm
@@ -9,6 +9,13 @@
 
 /obj/item/mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
+/obj/item/weapon/hobnails
+	icon = 'icons/obj/shards.dmi'
+	icon_state = "shrapnellarge"
+	name = "hobnails"
+	desc = "These look like they could be driven into some boots..."
+	w_class = WEIGHT_CLASS_SMALL
+
 /obj/item/weapon/beach_ball
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "ball"
@@ -22,3 +29,4 @@
 	throw_speed = 1
 	throw_range = 20
 	flags = CONDUCT
+

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -372,6 +372,8 @@ BLIND     // can't see anything
 	var/silence_steps = 0
 	var/shoe_sound_footstep = 1
 	var/shoe_sound = null
+	var/spiked
+	var/can_be_spiked
 	var/trampling_coefficient = 1 //The bigger this is, the more damage trampling will do
 
 	permeability_coefficient = 0.50

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -372,6 +372,7 @@ BLIND     // can't see anything
 	var/silence_steps = 0
 	var/shoe_sound_footstep = 1
 	var/shoe_sound = null
+	var/trampling_coefficient = 1 //The bigger this is, the more damage trampling will do
 
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -6,7 +6,7 @@
 	var/magboot_state = "magboots"
 	var/magpulse = 0
 	var/slowdown_active = 2
-	trampling_coefficient = 1.5 //They're essentially lumps of metal
+	trampling_coefficient = 1.25 //They're essentially lumps of metal
 	actions_types = list(/datum/action/item_action/toggle)
 	strip_delay = 70
 	put_on_delay = 70

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -6,6 +6,7 @@
 	var/magboot_state = "magboots"
 	var/magpulse = 0
 	var/slowdown_active = 2
+	trampling_coefficient = 1.5 //They're essentially lumps of metal
 	actions_types = list(/datum/action/item_action/toggle)
 	strip_delay = 70
 	put_on_delay = 70

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -1,3 +1,25 @@
+/obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/stack/tape_roll) && !spiked)
+		var/obj/item/stack/tape_roll/TR = I
+		if((!silence_steps || shoe_sound) && TR.use(4))
+			silence_steps = 1
+			shoe_sound = null
+			to_chat(user, "You tape the soles of [src] to silence their footsteps.")
+	if(istype(I, /obj/item/weapon/hobnails) && can_be_spiked == TRUE)
+		user.unEquip(I)
+		I.forceMove(src)
+		to_chat(user, "<span class = 'notice'>You drive [I] through the soles of [src].</span>")
+		name = "hobnailed [name]"
+		desc = "[desc]\nSeveral crudely-fashioned spikes are protruding from the soles."
+		trampling_coefficient += 0.25
+		can_be_spiked = FALSE
+		spiked = TRUE
+		slowdown = SHOES_SLOWDOWN + 1
+		shoe_sound = "jackboot"
+		silence_steps = TRUE //Looks dumb but prevents you hearing footsteps on top of shoe_sound
+	else
+		return ..()
+
 /obj/item/clothing/shoes/syndigaloshes
 	desc = "A pair of brown shoes. They seem to have extra grip."
 	name = "brown shoes"
@@ -24,6 +46,7 @@
 	armor = list(melee = 25, bullet = 25, laser = 25, energy = 25, bomb = 50, bio = 10, rad = 0)
 	strip_delay = 70
 	burn_state = FIRE_PROOF
+	can_be_spiked = TRUE
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "\improper SWAT shoes"
@@ -33,8 +56,10 @@
 	trampling_coefficient = 2
 	flags = NOSLIP
 
+/obj/item/clothing/shoes/combat/mantreads //because why not
+	name = "mantreads"
 	desc = "It's time to stamp out your foes."
-	trampling_coefficient = 25
+	trampling_coefficient = 40
 
 /obj/item/clothing/shoes/sandal
 	desc = "A pair of rather plain, wooden sandals."
@@ -94,6 +119,7 @@
 	var/footstep = 1
 	silence_steps = 1
 	shoe_sound = "jackboot"
+	can_be_spiked = TRUE
 
 /obj/item/clothing/shoes/jackboots/jacksandals
 	name = "jacksandals"
@@ -117,6 +143,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
+	can_be_spiked = TRUE
 
 /obj/item/clothing/shoes/cult
 	name = "boots"
@@ -129,6 +156,7 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
+	can_be_spiked = TRUE
 
 /obj/item/clothing/shoes/cyborg
 	name = "cyborg boots"
@@ -162,6 +190,7 @@
 	item_state = "roman"
 	strip_delay = 100
 	put_on_delay = 100
+	can_be_spiked = TRUE
 
 /obj/item/clothing/shoes/centcom
 	name = "dress shoes"
@@ -181,16 +210,6 @@
 	icon_state = "noble_boot"
 	item_color = "noble_boot"
 	item_state = "noble_boot"
-
-/obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/stack/tape_roll))
-		var/obj/item/stack/tape_roll/TR = I
-		if((!silence_steps || shoe_sound) && TR.use(4))
-			silence_steps = 1
-			shoe_sound = null
-			to_chat(user, "You tape the soles of [src] to silence their footsteps.")
-	else
-		return ..()
 
 /obj/item/clothing/shoes/sandal/white
 	name = "White Sandals"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -14,7 +14,7 @@
 		trampling_coefficient += 0.25
 		can_be_spiked = FALSE
 		spiked = TRUE
-		slowdown = SHOES_SLOWDOWN + 1
+		slowdown += 1
 		shoe_sound = "jackboot"
 		silence_steps = TRUE //Looks dumb but prevents you hearing footsteps on top of shoe_sound
 	else

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -30,7 +30,11 @@
 	desc = "High speed, no drag combat boots."
 	permeability_coefficient = 0.01
 	armor = list(melee = 40, bullet = 30, laser = 25, energy = 25, bomb = 50, bio = 30, rad = 30)
+	trampling_coefficient = 2
 	flags = NOSLIP
+
+	desc = "It's time to stamp out your foes."
+	trampling_coefficient = 25
 
 /obj/item/clothing/shoes/sandal
 	desc = "A pair of rather plain, wooden sandals."
@@ -38,6 +42,7 @@
 	icon_state = "wizard"
 	strip_delay = 50
 	put_on_delay = 50
+	trampling_coefficient = 0.5 //Soft shoes
 
 /obj/item/clothing/shoes/sandal/marisa
 	desc = "A pair of magic, black shoes."
@@ -135,12 +140,14 @@
 	desc = "Fluffy!"
 	icon_state = "slippers"
 	item_state = "slippers"
+	trampling_coefficient = 0
 
 /obj/item/clothing/shoes/slippers_worn
 	name = "worn bunny slippers"
 	desc = "Fluffy..."
 	icon_state = "slippers_worn"
 	item_state = "slippers_worn"
+	trampling_coefficient = 0
 
 /obj/item/clothing/shoes/laceup
 	name = "laceup shoes"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -7,7 +7,7 @@
 			to_chat(user, "You tape the soles of [src] to silence their footsteps.")
 	if(istype(I, /obj/item/weapon/hobnails) && can_be_spiked == TRUE)
 		user.unEquip(I)
-		I.forceMove(src)
+		I.forceMove()
 		to_chat(user, "<span class = 'notice'>You drive [I] through the soles of [src].</span>")
 		name = "hobnailed [name]"
 		desc = "[desc]\nSeveral crudely-fashioned spikes are protruding from the soles."

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -330,3 +330,14 @@
 	reqs = list(/obj/item/weapon/grown/log = 5)
 	result = /obj/structure/bonfire
 	category = CAT_PRIMAL
+
+/datum/crafting_recipe/hobnails
+	name = "Hobnails"
+	result = /obj/item/weapon/hobnails
+	time = 20
+	reqs = list(/obj/item/stack/rods = 2,
+				/obj/item/stack/sheet/metal = 1)
+	tools = list(/obj/item/weapon/weldingtool,
+				/obj/item/weapon/wrench,
+				/obj/item/weapon/wirecutters)
+	category = CAT_MISC

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1,4 +1,4 @@
-#define TRAMPLING_DAMAGE	rand(4, 8) / 2 //Average of 3
+#define TRAMPLING_DAMAGE	2
 #define STOMP_COOLDOWN		15
 
 /mob/living/carbon/human

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -560,16 +560,16 @@
 			return
 		if(M.buckled || M.throwing) //If they're buckled into something or being thrown, they will not stomp
 			return
-		if(src.incapacitated() && !(M.incapacitated())) //If the victim is incapacitated and the assailant is not incapacitated. This also catches weird fringe cases where you might end up stomping yourself
+		if(incapacitated() && !(M.incapacitated())) //If the victim is incapacitated and the assailant is not incapacitated. This also catches weird fringe cases where you might end up stomping yourself
 			M.trample(src)
 
 /mob/living/carbon/human/proc/trample(var/mob/living/carbon/human/H)
 	var/D = TRAMPLING_DAMAGE
 	var/armour = H.run_armor_check()
-	if(src.is_fat()) //Being fat makes you tread with more force
+	if(is_fat()) //Being fat makes you tread with more force
 		D += 1
-	if(src.shoes)
-		var/obj/item/clothing/shoes/S = src.shoes
+	if(shoes)
+		var/obj/item/clothing/shoes/S = shoes
 		if(S.trampling_coefficient == 0) //No point treading on them if we're going to do 0 damage
 			return
 		D *= S.trampling_coefficient
@@ -578,7 +578,7 @@
 	if(H.stat == DEAD)
 		H.visible_message("<span class = 'warning'>[src] treads upon [H]'s lifeless form.</span>", "<span class = 'warning'>[src] further violates your corpse.</span>", "<span class = 'warning'>You hear a fleshy thud.</span>")
 	else
-		H.visible_message("<span class = 'warning'>[src] stomps on [H]!</span>", "<span class = 'danger'>[src] squashes you under their feet!</span>", "<span class = 'warning'>You hear a fleshy thud.</span>")
+		H.visible_message("<span class = 'danger'>[src] stomps on [H]!</span>", "<span class = 'userdanger'>[src] squashes you under their feet!</span>", "<span class = 'warning'>You hear a fleshy thud.</span>")
 	playsound(H, 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	H.apply_damage(D, blocked = armour, used_weapon = "stomping")
 	laststomped = world.time

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -564,6 +564,10 @@
 			M.trample(src)
 
 /mob/living/carbon/human/proc/trample(var/mob/living/carbon/human/H)
+	if(!(H.client)) //If they're SSD, we merely trip over them
+		H.visible_message("<span class = 'warning'>[src] trips on [H]!</span>", "<span class = 'warning'>[src] trips over you!</span>", "<span class = 'warning'>You hear someone stumbling!</span>")
+		Weaken(3)
+		return
 	var/D = TRAMPLING_DAMAGE
 	var/armour = H.run_armor_check()
 	if(is_fat()) //Being fat makes you tread with more force

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1,3 +1,6 @@
+#define TRAMPLING_DAMAGE	rand(4, 6)
+#define STOMP_COOLDOWN		8
+
 /mob/living/carbon/human
 	name = "unknown"
 	real_name = "unknown"
@@ -539,13 +542,45 @@
 	popup.set_content(dat)
 	popup.open()
 
+/mob/living/carbon/human/proc/is_fat() //So we can check if someone is obese from genetics or from overeating
+	if((FAT in mutations) || (OBESITY in mutations))
+		return TRUE
 
 // called when something steps onto a human
-// this handles mulebots and vehicles
+// this handles mulebots, vehicles, and stomping
 /mob/living/carbon/human/Crossed(var/atom/movable/AM)
 	if(istype(AM, /obj/vehicle))
 		var/obj/vehicle/V = AM
 		V.RunOver(src)
+	if(ishuman(AM)) //Trample trample trample
+		var/mob/living/carbon/human/M = AM
+		if(world.time < M.laststomped + STOMP_COOLDOWN)
+			return
+		if(!(M.is_fat()) && M.a_intent == INTENT_HELP) //If they're fat or are on a non-help intent, then we can continue. Otherwise we don't trample them
+			return
+		if(src.incapacitated() && !(M.incapacitated())) //If the victim is incapacitated and the assailant is not incapacitated. This also catches weird fringe cases where you might end up stomping yourself
+			M.trample(src)
+
+/mob/living/carbon/human/proc/trample(var/mob/living/carbon/human/H)//H is the target
+	var/D = TRAMPLING_DAMAGE
+	var/armour = H.run_armor_check()
+	if(src.shoes)
+		var/obj/item/clothing/shoes/S = src.shoes
+		if(S.trampling_coefficient == 0) //No point treading on them if we're going to do 0 damage
+			return
+		D *= S.trampling_coefficient
+	else
+		D *= 0.25 //Standing on someone without shoes isn't that damaging
+	if(src.is_fat()) //Being fat makes you tread with more force
+		D *= 1.5
+	if(H.stat == DEAD)
+		H.visible_message("<span class = 'warning'>[src] treads upon [H]'s lifeless form.</span>", "<span class = 'warning'>[src] further violates your corpse.</span>", "<span class = 'warning'>You hear a fleshy thud.</span>")
+	else
+		H.visible_message("<span class = 'warning'>[src] stomps on [H]!</span>", "<span class = 'danger'>[src] squashes you under their feet!</span>", "<span class = 'warning'>You hear a fleshy thud.</span>")
+	playsound(H, 'sound/effects/hit_kick.ogg', 50, 1, -1)
+	H.apply_damage(D, blocked = armour, used_weapon = "stomping")
+	laststomped = world.time
+	add_logs(src, H, "stomped")
 
 // Get rank from ID, ID inside PDA, PDA, ID in wallet, etc.
 /mob/living/carbon/human/proc/get_authentification_rank(var/if_no_id = "No id", var/if_no_job = "No job")
@@ -2094,3 +2129,6 @@
 	update_icons()
 
 	..()
+
+#undef TRAMPLING_DAMAGE
+#undef STOMP_COOLDOWN

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -558,7 +558,7 @@
 			return
 		if(!(M.is_fat()) && M.a_intent == INTENT_HELP) //If they're fat or are on a non-help intent, then we can continue. Otherwise we don't trample them
 			return
-		if(M.buckled || M.throwing) //If they're buckled into something or being thrown, they will not stomp
+		if(M.buckled || M.throwing || M.m_intent == MOVE_INTENT_WALK) //If they're buckled into something, being thrown, or walking, they will not stomp
 			return
 		if(incapacitated() && !(M.incapacitated())) //If the victim is incapacitated and the assailant is not incapacitated. This also catches weird fringe cases where you might end up stomping yourself
 			M.trample(src)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1,5 +1,5 @@
-#define TRAMPLING_DAMAGE	rand(4, 6)
-#define STOMP_COOLDOWN		8
+#define TRAMPLING_DAMAGE	rand(4, 8) / 2 //Average of 3
+#define STOMP_COOLDOWN		15
 
 /mob/living/carbon/human
 	name = "unknown"
@@ -558,12 +558,16 @@
 			return
 		if(!(M.is_fat()) && M.a_intent == INTENT_HELP) //If they're fat or are on a non-help intent, then we can continue. Otherwise we don't trample them
 			return
+		if(M.buckled || M.throwing) //If they're buckled into something or being thrown, they will not stomp
+			return
 		if(src.incapacitated() && !(M.incapacitated())) //If the victim is incapacitated and the assailant is not incapacitated. This also catches weird fringe cases where you might end up stomping yourself
 			M.trample(src)
 
-/mob/living/carbon/human/proc/trample(var/mob/living/carbon/human/H)//H is the target
+/mob/living/carbon/human/proc/trample(var/mob/living/carbon/human/H)
 	var/D = TRAMPLING_DAMAGE
 	var/armour = H.run_armor_check()
+	if(src.is_fat()) //Being fat makes you tread with more force
+		D += 1
 	if(src.shoes)
 		var/obj/item/clothing/shoes/S = src.shoes
 		if(S.trampling_coefficient == 0) //No point treading on them if we're going to do 0 damage
@@ -571,8 +575,6 @@
 		D *= S.trampling_coefficient
 	else
 		D *= 0.25 //Standing on someone without shoes isn't that damaging
-	if(src.is_fat()) //Being fat makes you tread with more force
-		D *= 1.5
 	if(H.stat == DEAD)
 		H.visible_message("<span class = 'warning'>[src] treads upon [H]'s lifeless form.</span>", "<span class = 'warning'>[src] further violates your corpse.</span>", "<span class = 'warning'>You hear a fleshy thud.</span>")
 	else

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -59,6 +59,8 @@ var/global/default_martial_art = new/datum/martial_art
 
 	var/name_override //For temporary visible name changes
 
+	var/laststomped = 0 //For stomping unfortunate souls
+
 	var/xylophone = 0 //For the spoooooooky xylophone cooldown
 
 	var/mob/remoteview_target = null


### PR DESCRIPTION
This PR implements trampling!

Only mobs that are human may trample or be trampled (meaning drones, pets etc. are safe). Mobs may only be trampled if they are lying on the ground, and the damage dealt to them is dependent on multiple factors, such as the trampling mob's footwear.

I've also added an `is_fat()` proc to `mob/living/carbon/human/human.dm` to check if a human is either obese from genetics or merely from overeating. (Relevant to other PRs!) 

:cl:
add: Human mobs can now get trampled by other mobs if they are on the floor. The attacker must have a non-help intent, or be fat. Certain shoes are also better at trampling mobs than other shoes.
add: Added mantreads and hobnails, Mantreads deal ridiculous trampling damage to prone mobs. Hobnails are craftable items which increase shoes' attacking capabilities at the cost of slowdown and being loud.
/:cl:

EDIT: quick numbers, for anyone who wants to know roughly how much damage this will do.
Under normal circumstances you will do 3 damage per stomp.
Being fat will bump this up to 4 damage.
Wearing magboots will deal 3.75 damage.
Being fat and wearing magboots will deal roughly 5 damage.
You can trample at most every 1.5 seconds - you can't trample someone a hundred times with one stun.