### PR TITLE
Being FAT no longer lets you swallow humans whole

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -408,9 +408,6 @@
 	if(ishuman(attacker) && (/datum/dna/gene/basic/grant_spell/mattereater in attacker.active_genes)) // MATTER EATER CARES NOT OF YOUR FORM
 		return 1
 
-	if(ishuman(attacker) && (FAT in attacker.mutations) && iscarbon(prey) && !isalien(prey)) //Fat people eating carbon mobs but not xenos
-		return 1
-
 	if(isalien(attacker) && iscarbon(prey)) //Xenomorphs eating carbon mobs
 		return 1
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -408,6 +408,9 @@
 	if(ishuman(attacker) && (/datum/dna/gene/basic/grant_spell/mattereater in attacker.active_genes)) // MATTER EATER CARES NOT OF YOUR FORM
 		return 1
 
+	if(ishuman(attacker) && (FAT in attacker.mutations) && iscarbon(prey) && issmall(prey) && !issmall(attacker)) //Fat people eating monkeys
+		return 1
+
 	if(isalien(attacker) && iscarbon(prey)) //Xenomorphs eating carbon mobs
 		return 1
 


### PR DESCRIPTION
Currently, human mobs with the FAT gene can eat other humans using an aggressive grab.

This is bad because:
- It is silly. Being fat is not a superpower. Being fat shouldn't grant you superhuman cannibalism powers that enable you to consume the bodies of your fellow humans in seconds. That's not how being fat works. Fat status should be a disability. Not a superpower. Minor perks, like people being unable to push you aside, are fine. Superhuman cannibalism powers are not.
- It has balance implications. Specifically, if you have the FAT gene, you may be able to perfectly dispose of corpses. IE: make them vanish into effectively thin air. Together with everything they are wearing. And all their organs. Including their brain. This effectively makes them unrevivable. In terms of covering up murder, that's pretty powerful. No amount of searching, short of gibbing you, will reveal the body of the person you killed, or allow you to revive them.

This PR tweaks the FAT gene so that you can only do this with monkeys (which are much smaller), not full-size humans.

🆑 Kyep
tweak: Humans with the FAT disability can no longer swallow their fellow full-size humans whole with one bite. They're still able to do this with small monkeys.
/🆑