### PR TITLE
Adds Cash Registers to cargo order list

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1251,6 +1251,12 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containertype = /obj/structure/largecrate
 	containername = "water tank crate"
 
+/datum/supply_packs/misc
+	name = "Point of Sale System"
+	contains = list(/obj/machinery/pos)
+	cost = 25
+	containername = "Point of Sale crate"
+
 /datum/supply_packs/misc/hightank
 	name = "High-Capacity Water Tank Crate"
 	contains = list(/obj/structure/reagent_dispensers/watertank/high)


### PR DESCRIPTION
You can now order a CASH register also known as Point of Sale(POS) from CARGO. It's basicly a functioning cash register. You can add items to your list, and people can pay with cash or card. The register also keeps till so make sure noone steals your credits.

This will allow people to set up small shops and to encourage roleplay and the use of economy.

🆑Fruerlund
tweak: Updates the POS system. Adds a few new procs and changes the unit to credits Cr
add: You can now order it via CARGO.
/🆑
