### PR TITLE
Adds random colours on cable cuffs & crayons, and the ability for flashes to start burnt out

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -147,6 +147,29 @@
 	colour = "#DA00FF"
 	colourName = "purple"
 
+/obj/item/toy/crayon/random/New()
+	icon_state = pick(list("crayonred", "crayonorange", "crayonyellow", "crayongreen", "crayonblue", "crayonpurple"))
+	switch(icon_state)
+		if("crayonred")
+			colour = "#DA0000"
+			colourName = "red"
+		if("crayonorange")
+			colour = "#FF9300"
+			colourName = "orange"
+		if("crayonyellow")
+			colour = "#FFF200"
+			colourName = "yellow"
+		if("crayongreen")
+			colour = "#A8E61D"
+			colourName = "green"
+		if("crayonblue")
+			colour = "#00B7EF"
+			colourName = "blue"
+		if("crayonpurple")
+			colour = "#DA00FF"
+			colourName = "purple"
+	..()
+
 /obj/item/toy/crayon/white
 	icon_state = "crayonwhite"
 	colour = "#FFFFFF"

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -39,6 +39,11 @@
 			overcharged = 1
 			overlays += "overcharge"
 
+/obj/item/device/flash/random/New()
+	..()
+	if(prob(25))
+		broken = 1
+		icon_state = "[initial(icon_state)]burnt"
 
 /obj/item/device/flash/proc/burn_out() //Made so you can override it if you want to have an invincible flash from R&D or something.
 	broken = 1

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -104,6 +104,10 @@
 /obj/item/weapon/restraints/handcuffs/cable/white
 	color = COLOR_WHITE
 
+/obj/item/weapon/restraints/handcuffs/cable/random/New()
+	color = pick(COLOR_RED, COLOR_BLUE, COLOR_GREEN, COLOR_WHITE, COLOR_PINK, COLOR_YELLOW, COLOR_CYAN)
+	..()
+
 /obj/item/weapon/restraints/handcuffs/alien
 	icon_state = "handcuffAlien"
 


### PR DESCRIPTION
More useful as a tool for mappers, so the colour of the cuffs/crayon is random.

Also adds an option for flashes to spawn burnt out. Currently set to 25% of the time. This may be handy for #7497. This is nice because you can't always say that a flash has been used (or emp'd) if found in maint.

No changelog this'll never impact anyone but the mappers, and isn't mapped in anywhere.