### PR TITLE
Increases distant sounds of honking and screaming

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -128,6 +128,14 @@ var/list/uplink_items = list()
 	cost = 5
 	job = list("Clown")
 
+/datum/uplink_item/jobspecific/syndie_horn
+	name = "Sharpened Bike Horn"
+	desc = "A bike horn that has been specially sharpened to ensure that laughter isn't the best medicine, it is the leading cause of requiring it."
+	reference = "SH"
+	item = /obj/item/weapon/bikehorn/syndie
+	cost = 5
+	job = list("Clown")
+
 //mime
 /datum/uplink_item/job_specific/caneshotgun
 	name = "Cane Shotgun + Assassination Darts"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -129,8 +129,8 @@ var/list/uplink_items = list()
 	job = list("Clown")
 
 /datum/uplink_item/jobspecific/syndie_horn
-	name = "Sharpened Bike Horn"
-	desc = "A bike horn that has been specially sharpened to ensure that laughter isn't the best medicine, it is the leading cause of requiring it."
+	name = "Supersonic Bike Horn"
+	desc = "You must always honk the crew, and not through inaction allow the crew to escape honks. A useful but noisy melee weapon for when your jokes need an edge."
 	reference = "SH"
 	item = /obj/item/weapon/bikehorn/syndie
 	cost = 5

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -69,9 +69,11 @@
 	var/cooldowntime = 20
 
 /obj/item/weapon/bikehorn/syndie
-	desc = "For those with a rapier wit, and cutting satire."
+	desc = "Guaranteed to make you the subject of a Doctor Doctor joke."
+	attack_verb = list("VIOLENTLY HONKED", "VICIOUSLY MOCKED")
+	origin_tech = "combat=3;syndicate=1"
 	force = 25
-	no_embed = 1
+	no_embed = TRUE
 
 /obj/item/weapon/bikehorn/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!spam_flag)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -73,7 +73,6 @@
 	attack_verb = list("VIOLENTLY HONKED", "VICIOUSLY MOCKED")
 	origin_tech = "combat=3;syndicate=1"
 	force = 25
-	no_embed = TRUE
 
 /obj/item/weapon/bikehorn/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!spam_flag)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -68,6 +68,11 @@
 	var/honk_sound = 'sound/items/bikehorn.ogg'
 	var/cooldowntime = 20
 
+/obj/item/weapon/bikehorn/syndie
+	desc = "For those with a rapier wit, and cutting satire."
+	force = 25
+	no_embed = 1
+
 /obj/item/weapon/bikehorn/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(!spam_flag)
 		playsound(loc, honk_sound, 50, 1, -1) //plays instead of tap.ogg!


### PR DESCRIPTION
Adds a bike horn orderable from the uplink. Looks identical, other than the examine text. Does 5 less damage than e-swords, and (obviously) doesn't reflect projectiles.

Gives the clown a thematic way to kill someone, which is still 'loud', but could be overlooked in the same way that toy e-swords help make real e-swords get overlooked sometimes.

I've stuck this in at 5tc, but I'm sure there will be debate.

:cl: Purpose2
add: This time laughter is actually the leading cause of requiring medicine. The Syndicate have developed a Supersonic Bike Horn.
/ :cl: