### PR TITLE
Removes singularity beacon from surplus crate

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1079,6 +1079,7 @@ var/list/uplink_items = list()
 	reference = "SNGB"
 	item = /obj/item/device/radio/beacon/syndicate
 	cost = 14
+	surplus = 0
 
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb"


### PR DESCRIPTION
Singularity beacon is 99% a hijack only item. You will NEVER find a use for it outside of having hijack, as that's the only time you can release the engine. Additionally, it takes up a huge 14 TC of the surplus crate, which is 28% of the telecrystal value, entirely useless. I understand that the point of the surplus crate is that you may get items that don't fit your current play style or objectives, but there is nearly never a time where you will be able to use this item. Other typically hijack oriented items such as the syndie bomb can be justified without hijack, unlike this item. It is a very unhealthy item to keep in the surplus crate rotation, and encourages engine releases without hijack.

🆑 Imsxz
tweak: removes singularity beacon from surplus crate.
\ 🆑 