### PR TITLE
You can once again screwdriver camera consoles to deconstruct them

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -71,7 +71,7 @@
 	ui_interact(user)
 
 /obj/machinery/computer/security/attackby(obj/item/I, user as mob, params)
-	if(istype(I, /obj/item/weapon/screwdriver/))
+	if(isscrewdriver(I))
 		..()
 	else if(I.GetAccess()) // If hit by something with access.
 		attack_hand(user)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -71,7 +71,9 @@
 	ui_interact(user)
 
 /obj/machinery/computer/security/attackby(obj/item/I, user as mob, params)
-	if(I.GetAccess()) // If hit by something with access.
+	if(istype(I, /obj/item/weapon/screwdriver/))
+		..()
+	else if(I.GetAccess()) // If hit by something with access.
 		attack_hand(user)
 	else
 		..()


### PR DESCRIPTION
Not sure why this broke in the first place but here you go.

:cl:
fix: Using a screwdriver on a camera console will now deconstruct it instead of opening the camera window.
/:cl: