### PR TITLE
Security Sunglasses / Sec Hud Distribution

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -179,6 +179,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/helmet
 	l_ear = /obj/item/device/radio/headset/headset_sec/alt
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	id = /obj/item/weapon/card/id/security
 	l_pocket = /obj/item/device/flash
 	suit_store = /obj/item/weapon/gun/energy/gun/advtaser

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -273,7 +273,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	suit = /obj/item/clothing/suit/storage/internalaffairs
 	shoes = /obj/item/clothing/shoes/brown
 	l_ear = /obj/item/device/radio/headset/headset_sec/alt
-	glasses = /obj/item/clothing/glasses/sunglasses
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	id = /obj/item/weapon/card/id/security
 	l_pocket = /obj/item/device/laser_pointer
 	r_pocket = /obj/item/device/flash

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -273,7 +273,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	suit = /obj/item/clothing/suit/storage/internalaffairs
 	shoes = /obj/item/clothing/shoes/brown
 	l_ear = /obj/item/device/radio/headset/headset_sec/alt
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	glasses = /obj/item/clothing/glasses/sunglasses
 	id = /obj/item/weapon/card/id/security
 	l_pocket = /obj/item/device/laser_pointer
 	r_pocket = /obj/item/device/flash

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -951,7 +951,7 @@
 	icon_deny = "sec-deny"
 	req_access_txt = "1"
 	products = list(/obj/item/weapon/restraints/handcuffs = 8,/obj/item/weapon/restraints/handcuffs/cable/zipties = 8,/obj/item/weapon/grenade/flashbang = 4,/obj/item/device/flash = 5,
-					/obj/item/weapon/reagent_containers/food/snacks/donut = 12,/obj/item/weapon/storage/box/evidence = 6,/obj/item/device/flashlight/seclite = 4,/obj/item/weapon/restraints/legcuffs/bola/energy = 7)
+					/obj/item/weapon/reagent_containers/food/snacks/donut = 12,/obj/item/weapon/storage/box/evidence = 6,/obj/item/device/flashlight/seclite = 4,/obj/item/weapon/restraints/legcuffs/bola/energy = 7,/obj/item/clothing/glasses/hud/security = 3)
 	contraband = list(/obj/item/clothing/glasses/sunglasses = 2,/obj/item/weapon/storage/fancy/donut_box = 2,/obj/item/device/hailer = 5)
 
 /obj/machinery/vending/hydronutrients

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -188,7 +188,6 @@
 		new /obj/item/weapon/grenade/flashbang(src)
 		new /obj/item/weapon/storage/belt/security/sec(src)
 		new /obj/item/clothing/mask/gas/sechailer(src)
-		new /obj/item/clothing/glasses/hud/security(src)
 		new /obj/item/clothing/head/helmet(src)
 		new /obj/item/weapon/melee/baton/loaded(src)
 		new /obj/item/taperoll/police(src)
@@ -343,6 +342,7 @@
 		new /obj/item/clothing/glasses/sunglasses/yeah(src)
 		new /obj/item/device/flashlight/seclite(src)
 		new /obj/item/clothing/accessory/black(src)
+		new /obj/item/clothing/glasses/hud/security(src)
 
 /obj/structure/closet/secure_closet/detective/update_icon()
 	if(broken)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -188,7 +188,7 @@
 		new /obj/item/weapon/grenade/flashbang(src)
 		new /obj/item/weapon/storage/belt/security/sec(src)
 		new /obj/item/clothing/mask/gas/sechailer(src)
-		new /obj/item/clothing/glasses/hud/security/sunglasses(src)
+		new /obj/item/clothing/glasses/hud/security(src)
 		new /obj/item/clothing/head/helmet(src)
 		new /obj/item/weapon/melee/baton/loaded(src)
 		new /obj/item/taperoll/police(src)


### PR DESCRIPTION
The suggestion came from: https://nanotrasen.se/forum/topic/10590-security-lockers/

So basically this PR allows security officers (especially ones who join late game) to be equipped with security sunglasses upon joining. The reason being is that normally during round start Blueshield/HoP/Captain/Detective, would try to obtain security sunglasses from the security lockers leaving a security officer not fully equipped to do their jobs if they join late game.

~~In addition, I replace the security sunglasses inside the lockers with security HUDs. If any of them wants to obtain a SecHUD, they can, but they will lack any flash protection as a downside. In addition, this will still allow antags to emag lockers to screw with security using sechuds instead.~~

🆑  Jovaniph
tweak: Security Officer starts with security sunglasses upon joining the round
tweak: remove security sunglasses from security locker
tweak: added security HUD in security vendor (3 per vendor)
tweak: added security HUD in detective locker
/:cl: