### PR TITLE
Radiation Fixes and Refactor

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -948,7 +948,7 @@
 			occupant.take_organ_damage(0,radiation_level*2 + rand(1,3))
 		if(radiation_level > 1)
 			occupant.take_organ_damage(0,radiation_level + rand(1,3))
-		occupant.radiation += radiation_level*10
+		occupant.apply_effect(radiation_level*10, IRRADIATE)
 
 /obj/machinery/suit_cycler/proc/finished_job()
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -191,73 +191,47 @@
 
 	if(!(species.flags & RADIMMUNE))
 		if(radiation)
-
-			if(get_int_organ(/obj/item/organ/internal/nucleation/resonant_crystal))
-				var/rads = radiation/25
-				radiation -= rads
-				radiation -= 0.1
-				reagents.add_reagent("radium", rads/10)
-				if( prob(10) )
-					to_chat(src, "<span class='notice'>You feel relaxed.</span>")
-				return
-
 			if(radiation > 100)
-				radiation = 100
-				Weaken(10)
-				if(!lying)
-					to_chat(src, "<span class='alert'>You feel weak.</span>")
+				if(!weakened)
 					emote("collapse")
+				Weaken(10)
+				to_chat(src, "<span class='danger'>You feel weak.</span>")
 
-			if(radiation < 0)
-				radiation = 0
+			radiation = Clamp(radiation, 0, 100)
 
-			else
-				var/damage = 0
-				switch(radiation)
-					if(0 to 49)
-						radiation--
-						if(prob(25))
-							adjustToxLoss(1)
-							damage = 1
-							updatehealth()
-
-					if(50 to 74)
-						radiation -= 2
-						damage = 1
+			var/autopsy_damage = 0
+			switch(radiation)
+				if(0 to 50)
+					radiation = max(radiation-1, 0)
+					if(prob(25))
 						adjustToxLoss(1)
-						if(prob(5))
-							radiation -= 5
-							Weaken(3)
-							if(!lying)
-								to_chat(src, "<span class='alert'>You feel weak.</span>")
-								emote("collapse")
-						updatehealth()
+						autopsy_damage = 1
 
-					if(75 to 100)
-						radiation -= 3
-						adjustToxLoss(3)
-						damage = 3
-						if(prob(1))
-							to_chat(src, "<span class='alert'>You mutate!</span>")
-							randmutb(src)
-							domutcheck(src,null)
-							emote("gasp")
-						updatehealth()
+				if(50 to 75)
+					radiation = max(radiation-2, 0)
+					adjustToxLoss(1)
+					autopsy_damage = 1
+					if(prob(5))
+						radiation = max(radiation-5, 0)
+						if(!weakened)
+							emote("collapse")
+						Weaken(3)
+						to_chat(src, "<span class='danger'>You feel weak.</span>")
 
-					else
-						radiation -= 5
-						adjustToxLoss(5)
-						damage = 5
-						if(prob(1))
-							to_chat(src, "<span class='alert'>You mutate!</span>")
-							randmutb(src)
-							domutcheck(src,null)
-							emote("gasp")
-						updatehealth()
+				if(75 to 100)
+					radiation = max(radiation-3, 0)
+					adjustToxLoss(3)
+					autopsy_damage = 3
+					if(prob(1))
+						to_chat(src, "<span class='danger'>You mutate!</span>")
+						randmutb(src)
+						domutcheck(src, null)
+						emote("gasp")
 
-				if(damage && bodyparts.len)
-					var/obj/item/organ/external/O = pick(bodyparts)
-					if(istype(O)) O.add_autopsy_data("Radiation Poisoning", damage)
+			if(autopsy_damage && bodyparts.len)
+				var/obj/item/organ/external/O = pick(bodyparts)
+				if(istype(O))
+					O.add_autopsy_data("Radiation Poisoning", autopsy_damage)
 
 /mob/living/carbon/human/breathe()
 

--- a/code/modules/mob/living/carbon/human/species/apollo.dm
+++ b/code/modules/mob/living/carbon/human/species/apollo.dm
@@ -99,7 +99,7 @@
 	burn_mod = 4 // holy shite, poor guys wont survive half a second cooking smores
 	brute_mod = 2 // damn, double wham, double dam
 	oxy_mod = 0
-	flags = IS_WHITELISTED | NO_BREATHE | NO_BLOOD | NO_PAIN | HAS_LIPS | NO_SCAN
+	flags = IS_WHITELISTED | NO_BREATHE | NO_BLOOD | NO_PAIN | HAS_LIPS | NO_SCAN | RADIMMUNE
 	dietflags = DIET_OMNI		//still human at their core, so they maintain their eating habits and diet
 
 	//Default styles for created mobs.
@@ -110,8 +110,7 @@
 		"heart" =    /obj/item/organ/internal/heart,
 		"crystallized brain" =    /obj/item/organ/internal/brain/crystal,
 		"eyes" =     /obj/item/organ/internal/eyes/luminescent_crystal, //Standard darksight of 2.
-		"strange crystal" = /obj/item/organ/internal/nucleation/strange_crystal,
-		"resonant crystal" = /obj/item/organ/internal/nucleation/resonant_crystal
+		"strange crystal" = /obj/item/organ/internal/nucleation/strange_crystal
 		)
 	vision_organ = /obj/item/organ/internal/eyes/luminescent_crystal
 

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -843,22 +843,19 @@
 	return ..()
 
 /datum/species/diona/handle_life(var/mob/living/carbon/human/H)
+	H.radiation = Clamp(H.radiation, 0, 100) //We have to clamp this first, then decrease it, or there's a few edge cases of massive heals if we clamp and decrease at the same time.
 	var/rads = H.radiation / 25
-	H.apply_effect(-rads,IRRADIATE,0)
-	H.nutrition += rads
+	H.radiation = max(H.radiation-rads, 0)
+	H.nutrition = min(H.nutrition+rads, NUTRITION_LEVEL_WELL_FED+10)
 	H.adjustBruteLoss(-(rads))
-	H.adjustOxyLoss(-(rads))
 	H.adjustToxLoss(-(rads))
 
 	var/light_amount = 0 //how much light there is in the place, affects receiving nutrition and healing
 	if(isturf(H.loc)) //else, there's considered to be no light
 		var/turf/T = H.loc
 		light_amount = min(T.get_lumcount() * 10, 5)  //hardcapped so it's not abused by having a ton of flashlights
-	H.nutrition += light_amount
+	H.nutrition = min(H.nutrition+light_amount, NUTRITION_LEVEL_WELL_FED+10)
 	H.traumatic_shock -= light_amount
-
-	if(H.nutrition > NUTRITION_LEVEL_WELL_FED)
-		H.nutrition = NUTRITION_LEVEL_WELL_FED
 
 	if(light_amount > 0)
 		H.clear_alert("nolight")
@@ -869,8 +866,7 @@
 
 		H.adjustBruteLoss(-(light_amount/2))
 		H.adjustFireLoss(-(light_amount/4))
-		H.adjustOxyLoss(-(light_amount))
-	if(H.nutrition < 200)
+	if(H.nutrition < NUTRITION_LEVEL_STARVING+50)
 		H.take_overall_damage(10,0)
 		H.traumatic_shock++
 


### PR DESCRIPTION
closes https://github.com/ParadiseSS13/Paradise/pull/7568

- All irradiation of mobs is now handled via `apply_damage(amount, IRRADIATE)`
- Cleans up radiation damage taking on human mobs to make use of `min` and `max` rather than checking for `<` or `>`.
- Removed nucleation radiation snowflake handling; they're just RADIMMUNE now
  - This wasn't something spectacular; it was a special organ that made it so if you were irradiated, it would make your body generate radium, which would irradiate you, which would...you get the picture. It also spammed you with a message of feeling calmed if you were irradiated. 
- Clamped Diona's radiation to 0 and 100 (this means no more mega heals)
- slightly increased Diona's maximum nutrition by 10 points
  - This was done purely so that the nutrition meter stopped flickering constantly if you were in full light

:cl: Fox McCloud
tweak: Diona nutrition bar should no longer flicker constantly
/:cl: