### PR TITLE
Alters the AI's chat message OPEN link

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -55,7 +55,7 @@
 
 	if(mob_to_track)
 		track = "<a href='byond://?src=[UID()];track=\ref[mob_to_track]'>[speaker_name] ([jobname])</a>"
-		track += "<a href='byond://?src=[UID()];open=\ref[mob_to_track]'>\[OPEN\]</a>"
+		track += "<a href='byond://?src=[UID()];open=\ref[mob_to_track]'>\[O\]</a>"
 
 	return track
 


### PR DESCRIPTION
Spoke to 4 regular AI players for their opinion, and there were in unanimous agreement.

Every single message being prefixed with [OPEN] obscures when people genuinely make requests for open doors... you become numb to the word and it doesn't catch your attention like it used to.

This simply changes the [OPEN] link to [O].

:cl: Purpose2
tweak: AIs door open link is now [O] rather than [OPEN].
/ :cl: