### PR TITLE
Expands Smite / Dark Priest to cover many characters

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -17,12 +17,8 @@
 	if(special_icon)
 		I.icon_state = special_icon
 
-/datum/outfit/admin
-	var/is_hunter_outfit = 0 // Whether this can be used by the Smite command to send a hunter after someone
-
 /datum/outfit/admin/syndicate
 	name = "Syndicate Agent"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/syndicate
 	back = /obj/item/weapon/storage/backpack
@@ -63,7 +59,6 @@
 
 /datum/outfit/admin/syndicate/infiltrator
 	name = "Syndicate Infiltrator"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/chameleon
 	glasses = /obj/item/clothing/glasses/hud/security/chameleon
@@ -93,7 +88,6 @@
 
 /datum/outfit/admin/syndicate/operative
 	name = "Syndicate Nuclear Operative"
-	is_hunter_outfit = 1
 
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	belt = /obj/item/weapon/storage/belt/military
@@ -125,7 +119,6 @@
 
 /datum/outfit/admin/syndicate_strike_team
 	name = "Syndicate Strike Team"
-	is_hunter_outfit = 1
 
 /datum/outfit/admin/syndicate_strike_team/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return H.equip_syndicate_commando()
@@ -364,14 +357,12 @@
 
 /datum/outfit/admin/death_commando
 	name = "NT Death Commando"
-	is_hunter_outfit = 1
 
 /datum/outfit/admin/death_commando/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return H.equip_death_commando()
 
 /datum/outfit/admin/pirate
 	name = "Space Pirate"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/pirate
 	back = /obj/item/weapon/storage/backpack/satchel
@@ -393,14 +384,12 @@
 
 /datum/outfit/admin/pirate/first_mate
 	name = "Space Pirate First Mate"
-	is_hunter_outfit = 1
 
 	glasses = /obj/item/clothing/glasses/eyepatch
 	head = /obj/item/clothing/head/bandana
 
 /datum/outfit/admin/pirate/captain
 	name = "Space Pirate Captain"
-	is_hunter_outfit = 1
 
 	suit = /obj/item/clothing/suit/pirate_black
 	head = /obj/item/clothing/head/pirate
@@ -444,7 +433,6 @@
 
 /datum/outfit/admin/tunnel_clown
 	name = "Tunnel Clown"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/rank/clown
 	suit = /obj/item/clothing/suit/hooded/chaplain_hoodie
@@ -475,7 +463,6 @@
 
 /datum/outfit/admin/mime_assassin
 	name = "Mime Assassin"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/mime
 	suit = /obj/item/clothing/suit/suspenders
@@ -525,7 +512,6 @@
 
 /datum/outfit/admin/greytide
 	name = "Greytide"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/color/grey
 	back = /obj/item/weapon/storage/backpack
@@ -551,7 +537,6 @@
 
 /datum/outfit/admin/greytide/leader
 	name = "Greytide Leader"
-	is_hunter_outfit = 1
 
 	belt = /obj/item/weapon/storage/belt/utility/full/multitool
 	gloves = /obj/item/clothing/gloves/color/yellow
@@ -626,7 +611,6 @@
 
 /datum/outfit/admin/soviet/soldier
 	name = "Soviet Soldier"
-	is_hunter_outfit = 1
 
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
@@ -698,7 +682,6 @@
 
 /datum/outfit/admin/solgov
 	name = "Solar Federation Marine"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/solgov
 	back = /obj/item/weapon/storage/backpack/security
@@ -724,7 +707,6 @@
 
 /datum/outfit/admin/solgov/lieutenant
 	name = "Solar Federation Lieutenant"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/solgov/command
 	head = /obj/item/clothing/head/soft/solgov/command
@@ -772,7 +754,6 @@
 
 /datum/outfit/admin/chrono
 	name = "Chrono Legionnaire"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/chronos
@@ -964,7 +945,6 @@
 
 /datum/outfit/admin/masked_killer
 	name = "Masked Killer"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/overalls
 	suit = /obj/item/clothing/suit/apron
@@ -1000,7 +980,6 @@
 
 /datum/outfit/admin/singuloth_knight
 	name = "Singuloth Knight"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/syndicate/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/singuloth
@@ -1026,7 +1005,6 @@
 
 /datum/outfit/admin/assassin
 	name = "Syndicate Assassin"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/suit_jacket
 	suit = /obj/item/clothing/suit/wcoat
@@ -1064,7 +1042,6 @@
 
 /datum/outfit/admin/spy
 	name = "Spy"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/suit_jacket/really_black
 	back = /obj/item/weapon/storage/backpack
@@ -1109,7 +1086,6 @@
 
 /datum/outfit/admin/dark_lord
 	name = "Dark Lord"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/color/black
 	suit = /obj/item/clothing/suit/hooded/chaplain_hoodie
@@ -1182,7 +1158,6 @@
 
 /datum/outfit/admin/dark_priest
 	name = "Dark Priest"
-	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/color/black
 	suit = /obj/item/clothing/suit/hooded/chaplain_hoodie

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1034,34 +1034,17 @@
 	glasses = /obj/item/clothing/glasses/sunglasses
 	id = /obj/item/weapon/card/id/syndicate
 	l_pocket = /obj/item/weapon/melee/energy/sword/saber
-	l_hand = /obj/item/weapon/storage/secure/briefcase
+	l_hand = /obj/item/weapon/storage/secure/briefcase/reaper
 	pda = /obj/item/device/pda/heads
 	backpack_contents = list(
 		/obj/item/weapon/storage/box/survival = 1,
 		/obj/item/device/flashlight = 1
 	)
 
-	var/briefcase_contents = list(
-		/obj/item/stack/spacecash/c1000 = 3,
-		/obj/item/weapon/gun/energy/kinetic_accelerator/crossbow = 1,
-		/obj/item/weapon/gun/projectile/revolver/mateba = 1,
-		/obj/item/ammo_box/a357 = 1,
-		/obj/item/weapon/grenade/plastic/c4 = 1
-	)
-
 /datum/outfit/admin/assassin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(visualsOnly)
 		return
-
-	var/obj/item/weapon/storage/secure/briefcase/B = H.l_hand
-	if(istype(B))
-		for(var/obj/item/I in B)
-			qdel(I)
-		for(var/path in briefcase_contents)
-			var/number = backpack_contents[path]
-			for(var/i = 0, i < number, i++)
-				B.handle_item_insertion(new path(B), 1)
 
 	var/obj/item/weapon/implant/dust/D = new /obj/item/weapon/implant/dust(H)
 	D.implant(H)

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -18,9 +18,11 @@
 		I.icon_state = special_icon
 
 /datum/outfit/admin
+	var/is_hunter_outfit = 0 // Whether this can be used by the Smite command to send a hunter after someone
 
 /datum/outfit/admin/syndicate
 	name = "Syndicate Agent"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/syndicate
 	back = /obj/item/weapon/storage/backpack
@@ -61,6 +63,7 @@
 
 /datum/outfit/admin/syndicate/infiltrator
 	name = "Syndicate Infiltrator"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/chameleon
 	glasses = /obj/item/clothing/glasses/hud/security/chameleon
@@ -90,6 +93,7 @@
 
 /datum/outfit/admin/syndicate/operative
 	name = "Syndicate Nuclear Operative"
+	is_hunter_outfit = 1
 
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi
 	belt = /obj/item/weapon/storage/belt/military
@@ -121,6 +125,7 @@
 
 /datum/outfit/admin/syndicate_strike_team
 	name = "Syndicate Strike Team"
+	is_hunter_outfit = 1
 
 /datum/outfit/admin/syndicate_strike_team/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return H.equip_syndicate_commando()
@@ -359,6 +364,7 @@
 
 /datum/outfit/admin/death_commando
 	name = "NT Death Commando"
+	is_hunter_outfit = 1
 
 /datum/outfit/admin/death_commando/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return H.equip_death_commando()
@@ -435,6 +441,7 @@
 
 /datum/outfit/admin/tunnel_clown
 	name = "Tunnel Clown"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/rank/clown
 	suit = /obj/item/clothing/suit/hooded/chaplain_hoodie
@@ -465,6 +472,7 @@
 
 /datum/outfit/admin/mime_assassin
 	name = "Mime Assassin"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/mime
 	suit = /obj/item/clothing/suit/suspenders
@@ -514,6 +522,7 @@
 
 /datum/outfit/admin/greytide
 	name = "Greytide"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/color/grey
 	back = /obj/item/weapon/storage/backpack
@@ -539,6 +548,7 @@
 
 /datum/outfit/admin/greytide/leader
 	name = "Greytide Leader"
+	is_hunter_outfit = 1
 
 	belt = /obj/item/weapon/storage/belt/utility/full/multitool
 	gloves = /obj/item/clothing/gloves/color/yellow
@@ -613,6 +623,7 @@
 
 /datum/outfit/admin/soviet/soldier
 	name = "Soviet Soldier"
+	is_hunter_outfit = 1
 
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
@@ -684,6 +695,7 @@
 
 /datum/outfit/admin/solgov
 	name = "Solar Federation Marine"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/solgov
 	back = /obj/item/weapon/storage/backpack/security
@@ -709,6 +721,7 @@
 
 /datum/outfit/admin/solgov/lieutenant
 	name = "Solar Federation Lieutenant"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/solgov/command
 	head = /obj/item/clothing/head/soft/solgov/command
@@ -756,6 +769,7 @@
 
 /datum/outfit/admin/chrono
 	name = "Chrono Legionnaire"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/chronos
@@ -947,6 +961,7 @@
 
 /datum/outfit/admin/masked_killer
 	name = "Masked Killer"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/overalls
 	suit = /obj/item/clothing/suit/apron
@@ -982,6 +997,7 @@
 
 /datum/outfit/admin/singuloth_knight
 	name = "Singuloth Knight"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/syndicate/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/singuloth
@@ -1006,7 +1022,8 @@
 		apply_to_card(I, H, get_all_accesses(), "Singuloth Knight")
 
 /datum/outfit/admin/assassin
-	name = "Assassin"
+	name = "Syndicate Assassin"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/suit_jacket
 	suit = /obj/item/clothing/suit/wcoat
@@ -1061,6 +1078,7 @@
 
 /datum/outfit/admin/spy
 	name = "Spy"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/suit_jacket/really_black
 	back = /obj/item/weapon/storage/backpack
@@ -1105,6 +1123,7 @@
 
 /datum/outfit/admin/dark_lord
 	name = "Dark Lord"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/color/black
 	suit = /obj/item/clothing/suit/hooded/chaplain_hoodie
@@ -1177,6 +1196,7 @@
 
 /datum/outfit/admin/dark_priest
 	name = "Dark Priest"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/color/black
 	suit = /obj/item/clothing/suit/hooded/chaplain_hoodie

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -371,6 +371,7 @@
 
 /datum/outfit/admin/pirate
 	name = "Space Pirate"
+	is_hunter_outfit = 1
 
 	uniform = /obj/item/clothing/under/pirate
 	back = /obj/item/weapon/storage/backpack/satchel
@@ -392,12 +393,14 @@
 
 /datum/outfit/admin/pirate/first_mate
 	name = "Space Pirate First Mate"
+	is_hunter_outfit = 1
 
 	glasses = /obj/item/clothing/glasses/eyepatch
 	head = /obj/item/clothing/head/bandana
 
 /datum/outfit/admin/pirate/captain
 	name = "Space Pirate Captain"
+	is_hunter_outfit = 1
 
 	suit = /obj/item/clothing/suit/pirate_black
 	head = /obj/item/clothing/head/pirate

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -216,6 +216,14 @@
 	for(var/i = 0, i < storage_slots - 2, i++)
 		handle_item_insertion(new /obj/item/stack/spacecash/c1000, 1)
 
+/obj/item/weapon/storage/secure/briefcase/reaper/New()
+	..()
+	handle_item_insertion(new /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow, 1)
+	handle_item_insertion(new /obj/item/weapon/gun/projectile/revolver/mateba, 1)
+	handle_item_insertion(new /obj/item/ammo_box/a357, 1)
+	handle_item_insertion(new /obj/item/weapon/grenade/plastic/c4, 1)
+
+
 // -----------------------------
 //        Secure Safe
 // -----------------------------

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3339,9 +3339,7 @@
 	var/hunter_outfits = list()
 	for(var/type in admin_outfits)
 		var/datum/outfit/admin/O = type
-		var/is_hunter_outfit = initial(O.is_hunter_outfit)
-		if(is_hunter_outfit)
-			hunter_outfits[initial(O.name)] = type
+		hunter_outfits[initial(O.name)] = type
 	var/dresscode = input("Select type", "Contracted Agents") as null|anything in hunter_outfits
 	if(isnull(dresscode))
 		return


### PR DESCRIPTION
This PR adds 3 options for the admin 'Smite' and 'Bless' commands:
1. Bless can now be used to grant a character a harmless pet mob, like a cat or pug. This is offered to ghosts, complete with custom name, on spawn. It serves as a way for the light gods to give a character a minor reward, one that won't make them more powerful, and might create some RP.
2. Bless can now be used to grant a character a biological guardian. They're rather like holoparasites, but look different, and are not illegal. These are the same bio-guardians you can get from scarab eggs in mining. This is a much bigger blessing, used to protect characters from dangerous evil.
3. Both Bless and Smite can now be used to send 'event mobs' at targets.

Event mobs include various kinds of syndie agents, tunnel clowns, mime assassins, solgov marines, dark lords, soviet forces, dark priests, and _many_ other rare, costumed minor characters, drawn from ghosts. All of them are issued a pinpointer, to find the person they were sent to find.
If an admin sends you one as a blessing, their mission will be to protect you.
If an admin sends you one as a smiting, their mission will be to kill you.
None of this requires the person to pray first, but, only GAs+ can use this command.

Why have this event mob system? How does this make Smite/Bless better?
- It lets the 'send someone to kill this guy' feature be used in many contexts, from the Syndicate putting out a hit on someone, to NT wishing to get rid of an embarrassing problem, to a deranged individual taking it upon themselves to kill the target. Dark gods are no longer the only people who can hire hitmen.
- It lets you select the strength of the hunter based on the target. IE: to be able to send weaker hunters after assistants, and stronger ones after Sec/Command.
- It makes it FAR harder to predict who is on a mission of murder. Players probably won't memorize all the special characters in this list. This also makes it harder to metagame.
- It also prevents metagame in another way. Previously, everyone knew Dark Priests were only sent on missions of murder. Now, it is possible for them to be sent on missions of protection (e.g: protecting a chaplain during a cult round). The crew can't know for sure. All of the costumed characters this PR uses can be sent on protection, or murder, missions. 
- It enables a wide variety of costumed characters, yes, including tunnel clowns, masked killers, etc, to have a purpose and be easily deployable with a specific goal in a round. This makes it easier to run events, and use these characters. 

🆑 Kyep
add: Admins' Smite command has been upgraded. No longer limited to Dark Priests, it can now send over a dozen different entities in search of its target, from the comic, like Greytiders, Tunnel Clowns, Masked Killers and Mime Assasins, to the serious, such as Syndicates, Soviets, Dark Lords and more. All come with a dust implant. These same characters can also be sent to protect specific crew members, so they aren't predictable.
fix: The 'reaper' admin outfit now has a working briefcase.
fix: Use of the 'Bless' command to bestow powers no longer causes genetic damage.
/🆑

