### PR TITLE
Applies a 2s cooldown to slapping

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -76,7 +76,7 @@
 			on_CD = handle_emote_CD(50) //longer cooldown
 		if("fart", "farts", "flip", "flips", "snap", "snaps")
 			on_CD = handle_emote_CD()				//proc located in code\modules\mob\emote.dm
-		if("cough", "coughs")
+		if("cough", "coughs", "slap", "slaps")
 			on_CD = handle_emote_CD()
 		if("sneeze", "sneezes")
 			on_CD = handle_emote_CD()


### PR DESCRIPTION
This was requested to be opened again by Necaladun with a **two** second cooldown.

If we could not repeat the toxicity of #7075 - that'd be swell.

:cl: Purpose2
tweak: The *slap emote now has a cooldown like all other noise making emotes.
/ :cl: