### PR TITLE
Stops Coroners from barfing while doing autopsies...

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1100,7 +1100,7 @@
 			if(H.species && H.species.flags & NO_BREATHE)
 				return //no puking if you can't smell!
 			// Humans can lack a mind datum, y'know
-			if(H.mind && H.mind.assigned_role == "Detective")
+			if(H.mind && (H.mind.assigned_role == "Detective" || H.mind.assigned_role == "Coroner") )
 				return //too cool for puke
 			to_chat(H, "<spawn class='warning'>You smell something foul...")
 			H.fakevomit()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1100,7 +1100,7 @@
 			if(H.species && H.species.flags & NO_BREATHE)
 				return //no puking if you can't smell!
 			// Humans can lack a mind datum, y'know
-			if(H.mind && (H.mind.assigned_role == "Detective" || H.mind.assigned_role == "Coroner") )
+			if(H.mind && (H.mind.assigned_role == "Detective" || H.mind.assigned_role == "Coroner"))
 				return //too cool for puke
 			to_chat(H, "<spawn class='warning'>You smell something foul...")
 			H.fakevomit()


### PR DESCRIPTION
Just like the detective, maybe the coroner shouldn't have the stomach of a 12 year old girl.

:cl: Purpose2
Add: Coroners are more battlehardened, and thus don't throw up around dead bodies anymore.
/ :cl: