### PR TITLE
Fixes weird offset with beds when buckled.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -5,6 +5,7 @@
 	var/buckle_lying = -1 //bed-like behaviour, forces mob.lying = buckle_lying if != -1 //except -1 actually means "rotate 90 degrees to the left" as it is used by 1*buckle_lying.
 	var/buckle_requires_restraints = 0 //require people to be handcuffed before being able to buckle. eg: pipes
 	var/mob/living/buckled_mob = null
+	var/buckle_offset = 0
 
 
 //Interaction

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -17,19 +17,10 @@
 	burntime = 30
 	buildstackamount = 2
 	var/movable = 0 // For mobility checks
-	var/x_offset = 0
-	var/y_offset = -6
+	buckle_offset = -6
 
 /obj/structure/stool/bed/MouseDrop(atom/over_object)
 	..(over_object, skip_fucking_stool_shit = 1)
-
-/obj/structure/stool/bed/post_buckle_mob(mob/living/M)
-	if(M == buckled_mob)
-		M.pixel_y = y_offset
-		M.pixel_x = x_offset
-	else
-		M.pixel_y = M.get_standard_pixel_y_offset()
-		M.pixel_x = M.get_standard_pixel_x_offset()
 
 /obj/structure/stool/psychbed
 	name = "psych bed"
@@ -46,7 +37,7 @@
 	anchored = 0
 	buildstackamount = 10
 	buildstacktype = /obj/item/stack/sheet/wood
-	y_offset = 0
+	buckle_offset = 0
 
 /obj/structure/stool/bed/dogbed/ian
 	name = "Ian's bed"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -17,9 +17,19 @@
 	burntime = 30
 	buildstackamount = 2
 	var/movable = 0 // For mobility checks
+	var/x_offset = 0
+	var/y_offset = -6
 
 /obj/structure/stool/bed/MouseDrop(atom/over_object)
 	..(over_object, skip_fucking_stool_shit = 1)
+
+/obj/structure/stool/bed/post_buckle_mob(mob/living/M)
+	if(M == buckled_mob)
+		M.pixel_y = y_offset
+		M.pixel_x = x_offset
+	else
+		M.pixel_y = M.get_standard_pixel_y_offset()
+		M.pixel_x = M.get_standard_pixel_x_offset()
 
 /obj/structure/stool/psychbed
 	name = "psych bed"
@@ -36,6 +46,7 @@
 	anchored = 0
 	buildstackamount = 10
 	buildstacktype = /obj/item/stack/sheet/wood
+	y_offset = 0
 
 /obj/structure/stool/bed/dogbed/ian
 	name = "Ian's bed"

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -5,7 +5,7 @@
 	buckle_lying = 0 //you sit in a chair, not lay
 	burn_state = FIRE_PROOF
 	buildstackamount = 1
-
+	y_offset = 0
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 
 /obj/structure/stool/bed/chair/New()

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -5,7 +5,7 @@
 	buckle_lying = 0 //you sit in a chair, not lay
 	burn_state = FIRE_PROOF
 	buildstackamount = 1
-	y_offset = 0
+	buckle_offset = 0
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 
 /obj/structure/stool/bed/chair/New()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -881,8 +881,10 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 
 /mob/living/carbon/get_standard_pixel_y_offset(lying = 0)
 	if(lying)
-		if(buckled)	return initial(pixel_y)
-		return -6
+		if(buckled)
+			return buckled.buckle_offset //tg just has this whole block removed, always returning -6. Paradise is special.
+		else
+			return -6
 	else
 		return initial(pixel_y)
 


### PR DESCRIPTION
Makes it so beds and child objects have two offset vars, for x and y. Beds now use -6, so that the buckled mob doesn't look like it is lying on the side of the bed.

Before:
![image](https://user-images.githubusercontent.com/6334647/27312843-74cf4152-5530-11e7-88e2-0d660be06ee3.png)

After:
![image](https://user-images.githubusercontent.com/6334647/27312852-7a918d98-5530-11e7-8f1b-57b64b64a3e3.png)

:cl: Vivalas
fix: Buckling mobs to beds now displays them correctly.
/:cl: