### PR TITLE
Fixes RCDs placing multiple airlocks on a single tile

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -6,7 +6,7 @@ RCD
 */
 /obj/item/weapon/rcd
 	name = "rapid-construction-device (RCD)"
-	desc = "A device used to rapidly build and deconstruct walls and floors."
+	desc = "A device used to rapidly build and deconstruct walls, floors and airlocks."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcd"
 	opacity = 0
@@ -68,7 +68,7 @@ RCD
 	if(istype(W, /obj/item/weapon/rcd_ammo))
 		var/obj/item/weapon/rcd_ammo/R = W
 		if((matter + R.ammoamt) > max_matter)
-			to_chat(user, "<span class='notice'>The RCD cant hold any more matter-units.</span>")
+			to_chat(user, "<span class='notice'>The RCD can't hold any more matter-units.</span>")
 			return
 		matter += R.ammoamt
 		user.drop_item()
@@ -199,7 +199,8 @@ RCD
 					to_chat(user, "Building Wall ...")
 					playsound(loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 20 * toolspeed, target = A))
-						if(!useResource(3, user)) return 0
+						if(!useResource(3, user))
+							return 0
 						activate()
 						var/turf/AT = A
 						AT.ChangeTurf(/turf/simulated/wall)
@@ -212,7 +213,10 @@ RCD
 					to_chat(user, "Building Airlock...")
 					playsound(loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50 * toolspeed, target = A))
-						if(!useResource(10, user)) return 0
+						for(var/obj/machinery/door/airlock/D in A.contents)
+							return 0
+						if(!useResource(10, user))
+							return 0
 						activate()
 						var/obj/machinery/door/airlock/T = new door_type(A)
 						T.name = door_name
@@ -233,7 +237,8 @@ RCD
 					to_chat(user, "Deconstructing Wall...")
 					playsound(loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 40 * toolspeed, target = A))
-						if(!useResource(5, user)) return 0
+						if(!useResource(5, user))
+							return 0
 						activate()
 						var/turf/AT = A
 						AT.ChangeTurf(/turf/simulated/floor/plating)
@@ -245,7 +250,8 @@ RCD
 					to_chat(user, "Deconstructing Floor...")
 					playsound(loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50 * toolspeed, target = A))
-						if(!useResource(5, user)) return 0
+						if(!useResource(5, user))
+							return 0
 						activate()
 						var/turf/AT = A
 						AT.ChangeTurf(/turf/space)
@@ -257,7 +263,8 @@ RCD
 					to_chat(user, "Deconstructing Airlock...")
 					playsound(loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, 50 * toolspeed, target = A))
-						if(!useResource(20, user)) return 0
+						if(!useResource(20, user))
+							return 0
 						activate()
 						qdel(A)
 						return 1
@@ -361,7 +368,7 @@ RCD
 
 /obj/item/weapon/rcd/borg/New()
 	..()
-	desc = "A device used to rapidly build and deconstruct walls and floors."
+	desc = "A device used to rapidly build and deconstruct walls, floors and airlocks."
 	canRwall = 1
 
 


### PR DESCRIPTION
Stops the RCD from placing hundreds of Airlocks on a single tile. Also a light tidying up of the formatting.

:cl: Purpose2
fix: RCDs can no longer construct multiple airlocks on a single tile
/ :cl: