### PR TITLE
Removes the last references to no_embed

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -4,7 +4,6 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	name = "item"
 	icon = 'icons/obj/items.dmi'
 	var/discrete = 0 // used in item_attack.dm to make an item not show an attack message to viewers
-	var/no_embed = 0 // For use in item_attack.dm
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/blood_overlay_color = null
 	var/item_state = null

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -98,7 +98,6 @@
 	throw_range = 6
 	materials = list(MAT_METAL=12000)
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	no_embed = 1
 	sharp = 1
 	edge = 1
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -6,7 +6,6 @@
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/icon_state_on = "axe1"
 	var/list/attack_verb_on = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	no_embed = 1 // Physically impossible for energy weapons to embed themselves into people, this should fix that. -- Dave
 	hitsound = 'sound/weapons/blade1.ogg' // Probably more appropriate than the previous hitsound. -- Dave
 	usesound = 'sound/weapons/blade1.ogg'
 	toolspeed = 1

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -210,7 +210,6 @@
 	block_chance = 75
 	sharp = 1
 	edge = 1
-	no_embed = 1 // Like with the single-handed esword, this shouldn't be embedding in people.
 
 /obj/item/weapon/twohanded/dualsaber/New()
 	blade_color = pick("red", "blue", "green", "purple")
@@ -500,7 +499,6 @@
 	attack_verb = list("sawed", "cut", "hacked", "carved", "cleaved", "butchered", "felled", "timbered")
 	sharp = 1
 	edge = 1
-	no_embed = 1
 
 /obj/item/weapon/twohanded/chainsaw/update_icon()
 	if(wielded)
@@ -539,7 +537,6 @@
 	icon_state = "mjollnir0"
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
-	no_embed = 1
 	force = 5
 	force_unwielded = 5
 	force_wielded = 20
@@ -604,7 +601,6 @@
 	icon_state = "mjollnir0"
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
-	no_embed = 1
 	force = 5
 	force_unwielded = 5
 	force_wielded = 25
@@ -652,7 +648,6 @@
 	icon_state = "knighthammer0"
 	flags = CONDUCT
 	slot_flags = SLOT_BACK
-	no_embed = 1
 	force = 5
 	force_unwielded = 5
 	force_wielded = 30

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -297,21 +297,6 @@ emp_act
 	if(Iforce > 10 || Iforce >= 5 && prob(33))
 		forcesay(hit_appends)	//forcesay checks stat already
 
-/*	//Melee weapon embedded object code. Commented out, as most people on the forums seem to find this annoying and think it does not contribute to general gameplay. - Dave
-	if(I.damtype == BRUTE && !I.is_robot_module())
-		var/damage = I.force
-		if(armor)
-			damage /= armor+1
-
-		//blunt objects should really not be embedding in things unless a huge amount of force is involved
-		var/embed_chance = weapon_sharp? damage/I.w_class : damage/(I.w_class*3)
-		var/embed_threshold = weapon_sharp? 5*I.w_class : 15*I.w_class
-
-		//Sharp objects will always embed if they do enough damage.
-		if(((weapon_sharp && damage > (10*I.w_class)) || (damage > embed_threshold && prob(embed_chance))) && (I.no_embed == 0) )
-			affecting.embed(I)
-	return 1*/
-
 //this proc handles being hit by a thrown atom
 /mob/living/carbon/human/hitby(atom/movable/AM, skipcatch = 0, hitpush = 1, blocked = 0)
 	var/obj/item/I
@@ -325,24 +310,6 @@ emp_act
 		hitpush = 0
 		skipcatch = 1
 		blocked = 1
-	/*else if(I)
-		if(I.throw_speed >= EMBED_THROWSPEED_THRESHOLD)
-			if(!I.is_robot_module())
-				var/armor = run_armor_check(affecting, "melee", "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].", I.armour_penetration) //I guess "melee" is the best fit here
-				var/sharp = is_sharp(I)
-				var/damage = throwpower * (I.throw_speed / 5)
-				if(armor)
-					damage /= armor + 1
-
-				//blunt objects should really not be embedding in things unless a huge amount of force is involved
-				var/embed_chance = sharp? damage / I.w_class : damage/(I.w_class * 3)
-				var/embed_threshold = sharp? 5 * I.w_class : 15 * I.w_class
-
-				//Sharp objects will always embed if they do enough damage.
-				//Thrown sharp objects have some momentum already and have a small chance to embed even if the damage is below the threshold
-
-				if(((sharp && prob(damage / (10 * I.w_class) * 100)) || (damage > embed_threshold && prob(embed_chance))) && (I.no_embed == 0))
-					affecting.embed(I)*/
 	return ..()
 
 /mob/living/carbon/human/proc/bloody_hands(var/mob/living/source, var/amount = 2)


### PR DESCRIPTION
We don't use this anymore, we have an entirely different system. So lets remove all references to this, its not needed.

No changelog, this is backroom stuff.