### PR TITLE
Adds rolling pins to the kitchen equipment crate

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -932,6 +932,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 					/obj/item/weapon/reagent_containers/food/condiment/soymilk,
 					/obj/item/weapon/reagent_containers/food/condiment/saltshaker,
 					/obj/item/weapon/reagent_containers/food/condiment/peppermill,
+					/obj/item/weapon/kitchen/rollingpin,
 					/obj/item/weapon/storage/fancy/egg_box,
 					/obj/item/weapon/reagent_containers/food/condiment/enzyme,
 					/obj/item/weapon/reagent_containers/food/condiment/sugar,


### PR DESCRIPTION
~~SUPER HIGH PRIORITY PR~~

Someone pointed out there isn't a proper way to get more of these. Figured I'd include this with the other supplies.

:cl: Purpose2
add: The chef's supply crate now comes with another rolling pin. Stop misplacing these.
/ :cl: