### PR TITLE
Allows coroner to use Medical antag items & Chef to get antag poison bottles

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -209,16 +209,7 @@ var/list/uplink_items = list()
 	reference = "RL"
 	item = /obj/item/device/rad_laser
 	cost = 5
-	job = list(
-		"Chief Medical Officer",
-		"Medical Doctor",
-		"Geneticist",
-		"Psychiatrist",
-		"Chemist",
-		"Paramedic",
-		"Coroner",
-		"Virologist",
-		"Brig Physician") // in the very rare instance that this is possible
+	job = list("Chief Medical Officer", "Medical Doctor", "Geneticist", "Psychiatrist",	"Chemist", "Paramedic", "Coroner", "Virologist")
 
 /datum/uplink_item/dangerous/cat_grenade
 	name = "Feral Cat Delivery Grenade"
@@ -276,9 +267,7 @@ var/list/uplink_items = list()
 	reference = "PG"
 	item = /obj/item/clothing/gloves/color/yellow/power
 	cost = 10
-	job = list(
-		"Station Engineer",
-		"Chief Engineer")
+	job = list("Station Engineer", "Chief Engineer")
 
 //RD
 
@@ -333,18 +322,7 @@ var/list/uplink_items = list()
 	reference = "ST"
 	item = /obj/item/weapon/reagent_containers/hypospray/autoinjector/stimulants
 	cost = 7
-	job = list(
-		"Scientist",
-		"Research Director",
-		"Geneticist",
-		"Chief Medical Officer",
-		"Medical Doctor",
-		"Psychiatrist",
-		"Chemist",
-		"Paramedic",
-		"Coroner",
-		"Virologist",
-		"Brig Physician")
+	job = list("Scientist", "Research Director", "Geneticist", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Chemist", "Paramedic", "Coroner", "Virologist")
 
 //Tator Poison Bottles
 
@@ -354,15 +332,7 @@ var/list/uplink_items = list()
 	reference = "TPB"
 	item = /obj/item/weapon/reagent_containers/glass/bottle/traitor
 	cost = 2
-	job = list(
-		"Research Director",
-		"Chief Medical Officer",
-		"Medical Doctor",
-		"Psychiatrist",
-		"Paramedic",
-		"Virologist",
-		"Bartender",
-		"Chef")
+	job = list("Research Director", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Paramedic", "Virologist", "Bartender", "Chef")
 
 // Paper contact poison pen
 
@@ -373,10 +343,7 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/pen/poison
 	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)
-	job = list(
-		"Head of Personnel",
-		"Quartermaster",
-		"Cargo Technician")
+	job = list("Head of Personnel", "Quartermaster", "Cargo Technician")
 
 
 // DANGEROUS WEAPONS

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -54,7 +54,7 @@ var/list/uplink_items = list()
 	var/list/excludefrom = list() //Empty list does nothing. Place the name of gamemode you don't want this item to be available in here. This is so you dont have to list EVERY mode to exclude something.
 	var/list/job = null
 	var/surplus = 100 //Chance of being included in the surplus crate (when pick() selects it)
-	var/hijack_only = 0 //can this item be purchased only during hijackings?
+	var/hijack_only = FALSE //can this item be purchased only during hijackings?
 
 /datum/uplink_item/proc/spawn_item(var/turf/loc, var/obj/item/device/uplink/U)
 	if(hijack_only)
@@ -129,21 +129,13 @@ var/list/uplink_items = list()
 	job = list("Clown")
 
 //mime
-/datum/uplink_item/job_specific/caneshotgun
+/datum/uplink_item/jobspecific/caneshotgun
 	name = "Cane Shotgun + Assassination Darts"
 	desc = "A specialized, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes with 6 special darts and a preloaded shrapnel round."
 	reference = "MCS"
 	item = /obj/item/weapon/storage/box/syndie_kit/caneshotgun
 	cost = 15
 	job = list("Mime")
-
-/datum/uplink_item/dangerous/cat_grenade
-	name = "Feral Cat Delivery Grenade"
-	desc = "The feral cat delivery grenade contains 8 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
-	item = /obj/item/weapon/grenade/spawnergrenade/feral_cats
-	reference = "CCLG"
-	cost = 5
-	job = list("Psychiatrist")//why? Becuase its funny that a person in charge of your mental wellbeing has a cat granade..
 
 //Chef
 /datum/uplink_item/jobspecific/specialsauce
@@ -195,8 +187,8 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/storage/toolbox/green/memetic
 	cost = 20
 	job = list("Chaplain")
-	surplus = 0     //No lucky chances from the crate; if you get this, this is ALL you're getting
-	hijack_only = 1 //This is a murderbone weapon, as such, it should only be available in those scenarios.
+	surplus = 0 //No lucky chances from the crate; if you get this, this is ALL you're getting
+	hijack_only = TRUE //This is a murderbone weapon, as such, it should only be available in those scenarios.
 
 //Janitor
 
@@ -211,10 +203,9 @@ var/list/uplink_items = list()
 
 //Medical
 
-
 /datum/uplink_item/jobspecific/rad_laser
 	name = "Radiation Laser"
-	desc = "A radiation laser concealed inside of a Health Analyser. After a moderate delay, causes temporary collapse and radiation.  Has adjustable controls, but will not function as a regular health analyser, only appears like one. May not function correctly on radiation resistant humanoids!"
+	desc = "A radiation laser concealed inside of a Health Analyser. After a moderate delay, causes temporary collapse and radiation. Has adjustable controls, but will not function as a regular health analyser, only appears like one. May not function correctly on radiation resistant humanoids!"
 	reference = "RL"
 	item = /obj/item/device/rad_laser
 	cost = 5
@@ -225,9 +216,17 @@ var/list/uplink_items = list()
 		"Psychiatrist",
 		"Chemist",
 		"Paramedic",
+		"Coroner",
 		"Virologist",
-		"Brig Physician"
-	)
+		"Brig Physician") // in the very rare instance that this is possible
+
+/datum/uplink_item/dangerous/cat_grenade
+	name = "Feral Cat Delivery Grenade"
+	desc = "The feral cat delivery grenade contains 8 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
+	item = /obj/item/weapon/grenade/spawnergrenade/feral_cats
+	reference = "CCLG"
+	cost = 5
+	job = list("Psychiatrist")//why? Becuase its funny that a person in charge of your mental wellbeing has a cat granade..
 
 //Assistant
 
@@ -249,10 +248,9 @@ var/list/uplink_items = list()
 	cost = 6
 	job = list("Bartender")
 
-
 //Barber
 
-/datum/uplink_item/jobspecific/safety_scissors  //Hue
+/datum/uplink_item/jobspecific/safety_scissors //Hue
 	name = "Safety Scissors"
 	desc = "A pair of scissors that are anything but what their name implies; can easily cut right into someone's throat."
 	reference = "CTS"
@@ -278,7 +276,9 @@ var/list/uplink_items = list()
 	reference = "PG"
 	item = /obj/item/clothing/gloves/color/yellow/power
 	cost = 10
-	job = list("Station Engineer","Chief Engineer")
+	job = list(
+		"Station Engineer",
+		"Chief Engineer")
 
 //RD
 
@@ -299,7 +299,6 @@ var/list/uplink_items = list()
 	cost = 3
 	job = list("Librarian")
 
-
 //Botanist
 /datum/uplink_item/jobspecific/ambrosiacruciatus
 	name = "Ambrosia Cruciatus Seeds"
@@ -308,7 +307,6 @@ var/list/uplink_items = list()
 	item = /obj/item/seeds/ambrosia/cruciatus
 	cost = 2
 	job = list("Botanist")
-
 
 //Atmos Tech
 /datum/uplink_item/jobspecific/contortionist
@@ -335,7 +333,18 @@ var/list/uplink_items = list()
 	reference = "ST"
 	item = /obj/item/weapon/reagent_containers/hypospray/autoinjector/stimulants
 	cost = 7
-	job = list("Scientist","Research Director","Geneticist","Chief Medical Officer","Medical Doctor","Psychiatrist","Chemist","Paramedic","Virologist","Brig Physician")
+	job = list(
+		"Scientist",
+		"Research Director",
+		"Geneticist",
+		"Chief Medical Officer",
+		"Medical Doctor",
+		"Psychiatrist",
+		"Chemist",
+		"Paramedic",
+		"Coroner",
+		"Virologist",
+		"Brig Physician")
 
 //Tator Poison Bottles
 
@@ -345,7 +354,15 @@ var/list/uplink_items = list()
 	reference = "TPB"
 	item = /obj/item/weapon/reagent_containers/glass/bottle/traitor
 	cost = 2
-	job = list("Research Director","Chief Medical Officer","Medical Doctor","Psychiatrist","Paramedic","Virologist","Bartender")
+	job = list(
+		"Research Director",
+		"Chief Medical Officer",
+		"Medical Doctor",
+		"Psychiatrist",
+		"Paramedic",
+		"Virologist",
+		"Bartender",
+		"Chef")
 
 // Paper contact poison pen
 
@@ -356,7 +373,10 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/pen/poison
 	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)
-	job = list("Head of Personnel", "Quartermaster", "Cargo Technician")
+	job = list(
+		"Head of Personnel",
+		"Quartermaster",
+		"Cargo Technician")
 
 
 // DANGEROUS WEAPONS
@@ -400,7 +420,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/dangerous/machinegun
 	name = "L6 Squad Automatic Weapon"
-	desc = "A fully-loaded Aussec Armoury belt-fed machine gun. This deadly weapon has a massive 50-round magazine of devastating 7.62x51mm ammunition."
+	desc = "A fully-loaded Aussec Armory belt-fed machine gun. This deadly weapon has a massive 50-round magazine of devastating 7.62x51mm ammunition."
 	reference = "LMG"
 	item = /obj/item/weapon/gun/projectile/automatic/l6_saw
 	cost = 40


### PR DESCRIPTION
Oversight on my part not to include Coroner to antag options of other medical jobs.

Also balance-wise... the bartender was able to get poison bottles, but not the chef. That seemed like an oversight as well, so I've added that. Happy to remove if you can make a good case, but I think its legit that the chef can poison food!

I also tided up the file a bit, fixed a few typos.... but it seems to me that we should be using defines for all these "Job Roles"... if you agree Maintainers, I'll at some point start a project to do this... this'll stop any potential issues with typos etc that wouldn't be caught by the compiler.

:cl: Purpose2
fix: The Syndicate once more recognises the Coroner as a member of the medical team for purposes for uplink items.
add: The chef may now tap into the Syndicate's poison networks for use in his dishes.
/ :cl: