### PR TITLE
Allows admins to edit telecomms without having to spawn a mob

### DIFF
--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -192,7 +192,7 @@
 	add_fingerprint(user)
 	user.set_machine(src)
 
-	if(!allowed(user) && !emagged)
+	if(!allowed(user) && !emagged && !user.can_admin_interact())
 		to_chat(user, "<span class='danger'>Access Denied.</span>")
 		return 0
 


### PR DESCRIPTION
Currently, admins have to spawn a mob with telecomms access on the minisat to edit telecomms scripts. We can reset them all with a command, but we can't easily edit them - or even see what was uploaded in its natural format.

This fixes that. Now, admin-ghosts can click the telecomms console and interact with it as if they were a mob with access, including viewing and editing scripts. 

The idea is to make it easier for admins to read scripts - and also to enable admins to remove the problematic parts of a script without having to wipe the whole thing.

No CL, as this is a tiny, admin-only change.