### PR TITLE
QOL improvement for antag barbers

### DIFF
--- a/code/game/objects/items/weapons/scissors.dm
+++ b/code/game/objects/items/weapons/scissors.dm
@@ -95,7 +95,6 @@
 		user.visible_message("<span class='notice'>[user] finishes cutting [M]'s hair!</span>")
 
 /obj/item/weapon/scissors/safety //Totally safe, I assure you.
-	name = "safety scissors"
 	desc = "The blades of the scissors appear to be made of some sort of ultra-strong metal alloy."
 	force = 18 //same as e-daggers
 	var/is_cutting = 0 //to prevent spam clicking this for huge accumulation of losebreath.


### PR DESCRIPTION
Simply makes the scissors less obvious by changing its name. Still identifable by its description, but now you can't just see 'safety scissors' in your barber's hands and know that he is gonna wreck your shit.

:cl: Purpose2
tweak: Antag barbers scissors now have the same name as regular scissors.
/ :cl: