### PR TITLE
Tweaks Department shuttle

### DIFF
--- a/_maps/map_files/shuttles/emergency_dept.dmm
+++ b/_maps/map_files/shuttles/emergency_dept.dmm
@@ -45,30 +45,30 @@
 "aS" = (/turf/simulated/shuttle/wall{tag = "icon-swall7"; icon_state = "swall7"; dir = 2},/area/shuttle/escape)
 "aT" = (/obj/docking_port/mobile/emergency{dir = 4; dwidth = 11; height = 13; timid = 1; width = 24},/obj/machinery/door/airlock/shuttle{aiControlDisabled = 1; hackProof = 1; id_tag = "s_docking_airlock"; name = "Shuttle Hatch"},/turf/simulated/shuttle/floor,/area/shuttle/escape)
 "aU" = (/turf/simulated/floor/plasteel,/area/shuttle/escape)
-"aV" = (/obj/structure/stool/bed/chair{dir = 4},/obj/item/device/radio/intercom{dir = 8; name = "station intercom (General)"; pixel_x = -28},/obj/machinery/light/spot{tag = "icon-tube1 (WEST)"; icon_state = "tube1"; dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
-"aW" = (/obj/machinery/door/window/northleft{req_access_txt = "32"},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
+"aV" = (/obj/machinery/door/window/southright{autoclose = 1; name = "engineering door"; req_access_txt = "32"},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
+"aW" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/shuttle/floor4,/area/shuttle/escape)
 "aX" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
 "aY" = (/obj/structure/stool/bed/chair{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/plasteel,/area/shuttle/escape)
 "aZ" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/plasteel,/area/shuttle/escape)
 "ba" = (/obj/structure/stool/bed/chair{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
-"bb" = (/obj/machinery/door/window/northleft{req_access_txt = "47"},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
-"bc" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/closet/walllocker/emerglocker{pixel_x = 28},/obj/machinery/light/spot{tag = "icon-tube1 (EAST)"; icon_state = "tube1"; dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
-"bd" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
-"be" = (/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
-"bf" = (/obj/structure/stool/bed/chair{dir = 8},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
+"bb" = (/obj/structure/stool/bed/chair{dir = 8},/turf/simulated/shuttle/floor4,/area/shuttle/escape)
+"bc" = (/obj/machinery/door/window/southright{autoclose = 1; name = "science door"; req_access_txt = "47"},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
+"bd" = (/obj/machinery/door/window/northleft{autoclose = 1; name = "security door"; req_access_txt = "2"},/turf/simulated/shuttle/floor4,/area/shuttle/escape)
+"be" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
+"bf" = (/obj/structure/stool/bed/chair{dir = 4},/obj/item/device/radio/intercom{dir = 8; name = "station intercom (General)"; pixel_x = -28},/obj/machinery/light/spot{tag = "icon-tube1 (WEST)"; icon_state = "tube1"; dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor4,/area/shuttle/escape)
 "bg" = (/obj/structure/grille,/obj/structure/window/full/shuttle{icon_state = "8"},/turf/simulated/floor/plating,/area/shuttle/escape)
 "bh" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/floor/plasteel,/area/shuttle/escape)
 "bi" = (/obj/structure/stool/bed/chair{dir = 8},/turf/simulated/floor/plasteel,/area/shuttle/escape)
-"bj" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
-"bk" = (/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
-"bl" = (/obj/structure/stool/bed/chair{dir = 8},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
+"bj" = (/obj/structure/stool/bed/chair{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
+"bk" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor4,/area/shuttle/escape)
+"bl" = (/obj/machinery/door/window/northleft{autoclose = 1; name = "medical door"; req_access_txt = "5"},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/shuttle/escape)
 "bm" = (/obj/structure/stool/bed/chair{dir = 4},/obj/structure/window/reinforced,/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
-"bn" = (/obj/machinery/door/window/southright{req_access_txt = "32"},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
+"bn" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
 "bo" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/window/reinforced,/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
 "bp" = (/obj/structure/window/reinforced,/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/floor/plasteel,/area/shuttle/escape)
 "bq" = (/obj/structure/window/reinforced,/obj/structure/stool/bed/chair{dir = 8},/turf/simulated/floor/plasteel,/area/shuttle/escape)
 "br" = (/obj/structure/stool/bed/chair{dir = 4},/obj/structure/window/reinforced,/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
-"bs" = (/obj/machinery/door/window/southright{req_access_txt = "47"},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
+"bs" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/closet/walllocker/emerglocker{pixel_x = 28},/obj/machinery/light/spot{tag = "icon-tube1 (EAST)"; icon_state = "tube1"; dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/shuttle/escape)
 "bt" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/window/reinforced,/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
 "bu" = (/obj/machinery/light/spot{tag = "icon-tube1 (WEST)"; icon_state = "tube1"; dir = 8},/turf/simulated/floor/plasteel,/area/shuttle/escape)
 "bv" = (/obj/machinery/light/spot{tag = "icon-tube1 (EAST)"; icon_state = "tube1"; dir = 4},/turf/simulated/floor/plasteel,/area/shuttle/escape)
@@ -76,8 +76,7 @@
 "bx" = (/obj/structure/noticeboard,/turf/simulated/shuttle/wall{icon_state = "swall12"; dir = 2},/area/shuttle/escape)
 "by" = (/obj/machinery/door/airlock/shuttle{aiControlDisabled = 1; hackProof = 1; id_tag = null; name = "Shuttle Cargo Hatch"},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/shuttle/escape)
 "bz" = (/obj/structure/stool/bed/chair{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/shuttle/escape)
-"bA" = (/obj/machinery/door/window/northleft{req_access_txt = "5"},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/shuttle/escape)
-"bB" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/shuttle/escape)
+"bA" = (/obj/structure/stool/bed/chair{dir = 8},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor5"},/area/shuttle/escape)
 "bC" = (/obj/machinery/door/airlock/glass_medical{id_tag = null; name = "Escape Shuttle Infirmary"; req_access_txt = "0"},/turf/simulated/floor/plasteel,/area/shuttle/escape)
 "bD" = (/turf/simulated/shuttle/wall{icon_state = "swall11"; dir = 2},/area/shuttle/escape)
 "bE" = (/obj/machinery/door/airlock/shuttle{aiControlDisabled = 1; hackProof = 1; id_tag = "s_docking_airlock"; name = "Shuttle Hatch"},/turf/simulated/shuttle/floor{icon_state = "floor2"},/area/shuttle/escape)
@@ -111,16 +110,16 @@ apaIaIaIaIaMaCaDaEaCaNaOap
 aPaIaIaQaQaBaCaDaEaCaRaRac
 aSaeaeaeaeaJaCaDaEaCaCaCap
 aTaUaUaUaUaUaUaUaUaUaUaUap
-apaVaWaXaBaYaUaZaBbabbbcap
-aBbdbebfbgbhaUbibgbjbkblaB
-bgbdbebfbgbhaUbibgbjbkblbg
-aJbmbnboaJbpaUbqaJbrbsbtaJ
+apbfbdbkaBaYaUaZaBbzblbsap
+aBaWaIbbbgbhaUbibgbFbGbHaB
+bgbjbeaXbgbhaUbibgbabnbAbg
+aJbmaVboaJbpaUbqaJbrbcbtaJ
 apbuaUaUaUaUaUaUaUaUaUbvap
 bwaUaUaUaUaUaUaUaUaUaUaUac
-aSaebxbyaBbzbAbBaBbCacaebD
-bEaUaUaUbgbFbGbHbgaUaUbIap
-acaUaUaUbgbFbGbHbgaUaUbJap
-apbKbLbLaJbFbGbHaJbNbMbOap
+aSaebxbyaBaYaUaZaBbCacaebD
+bEaUaUaUbgbhaUbibgaUaUbIap
+acaUaUaUbgbhaUbibgaUaUbJap
+apbKbLbLaJbhaUbiaJbNbMbOap
 bPaxbQbQawaeaeaeawbRbRaxbS
 aabPbTbTbSbUbUbUbPbTbTbSaa
 "}


### PR DESCRIPTION
Since https://github.com/ParadiseSS13/Paradise/pull/7504 was merged, I've spawned the shuttle a few times to see how the crew react to it. During these spawns, I've noticed an issue: there is not enough public seating. This PR fixes that by reducing the amount of department-reserved seating, and increasing the amount of public seating. It also gives names to the interior doors, so its more obvious what the colored areas are.

![new_dept_shuttle](https://user-images.githubusercontent.com/16434066/27475241-42b4f3fc-57b9-11e7-8fcb-366132ae631e.PNG)


🆑 Kyep
tweak: New 'department' shuttle now has more public-access seating.
/🆑