### PR TITLE
Makes surgery great again, part 2. (nerfs spaceacillin)

### DIFF
--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -216,6 +216,7 @@ var/list/organ_cache = list()
 
 	if(germ_level < INFECTION_LEVEL_ONE)
 		germ_level = 0	//cure instantly
+		return
 	else if(germ_level < INFECTION_LEVEL_TWO)
 		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds, for one external infection
 	else

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -218,11 +218,10 @@ var/list/organ_cache = list()
 		germ_level = 0	//cure instantly
 		return
 	else if(germ_level < INFECTION_LEVEL_TWO)
-		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds, for one external infection
+		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds for external infection
 	else
-		germ_level -= 4 * germ_mod	// at germ_level == 1000, this will cure the infection in 2 minute, 30 seconds, for one external infection
+		germ_level -= 4 * germ_mod	// at germ_level == 1000, this will cure the infection in 2 minute for external infection
 						// Let's not drag this on, but curing every infection in the body with 25u of spaceacillin is a bit silly.
-	owner.reagents.remove_reagent("spaceacillin",0.1) //curing one infection is okay but not all of them at once
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -32,6 +32,8 @@ var/list/organ_cache = list()
 	var/sterile = 0 //can the organ be infected by germs?
 	var/tough = 0 //can organ be easily damaged?
 
+	var/germ_mod = 1 //modifier for antibiotic's effects on this organ
+
 /obj/item/organ/Destroy()
 	processing_objects.Remove(src)
 	if(owner)
@@ -215,10 +217,11 @@ var/list/organ_cache = list()
 	if(germ_level < INFECTION_LEVEL_ONE)
 		germ_level = 0	//cure instantly
 	else if(germ_level < INFECTION_LEVEL_TWO)
-		germ_level -= 24	//at germ_level == 500, this should cure the infection in 15 seconds
+		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds, for one external infection
 	else
-		germ_level -= 8	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
-						// Let's not drag this on, medbay has only so much antibiotics
+		germ_level -= 4 * germ_mod	// at germ_level == 1000, this will cure the infection in 2 minute, 30 seconds, for one external infection
+						// Let's not drag this on, but curing every infection in the body with 25u of spaceacillin is a bit silly.
+	owner.reagents.remove_reagent("spaceacillin",0.1) //curing one infection is okay but not all of them at once
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -10,6 +10,8 @@
 	vital = 0
 	var/non_primary = 0
 
+	germ_mod = 0.5 //curing infected internal organs should be hard, outside surgery
+
 /obj/item/organ/internal/New(var/mob/living/carbon/holder)
 	..()
 	if(istype(holder))


### PR DESCRIPTION
Alright, so a long time ago in that nice big vaunted organ PR (#2885), spaceacillin was given a hardcore buff for infections. Now, I dunno if this was a stealth thing or not since from my limited skim of the 300 comments, none of them pointed this out, but as it stands now as a result of this PR, believe it or not, you can fix *every single infection in the body, internal, external, septic, WHATEVER, **with only 25u of spaceacillin***. 25u of spaceacillin is roughly 2 syringes worth. Every infection. No washing the organ under the sink, transplanting septic hearts etc., cloning patients, or using ethanol, just 25u of spaceacillin will do the trick.

Now, since this wasn't mentioned in the PR (I think), is not mentioned in surgery guides (which still alludes to having to use "every syringe of spaceacillin in medbay" to treat an internal organ), and is probably not well known by most medics, I'm "nerfing" spaceacillin.

Basically I've cut its effectiveness in half (the PR quadrupled it's effectiveness), and caused healing infections to consume more spaceacillin per tick per organ being healed (0.1u).

Just some numbers for infection healing - post nerf (pre nerf):

Healing one acute external infection will require about 12.5u of spaceacillin (4u).

Healing one septic external infection will require about 70u (25u).

Note surgery for external infection cleansing is pretty simple, just scalpel and cautery, otherwise you'll need a lot of spaceacillin.

Healing one acute organ infection will require 25u of spaceacillin (4u). 

Healing one septic organ infection will require 135u of spaceacillin (25u). Internal disinfection or transplantation might be easier than collecting 135u from the vendors.

These are the numbers for two infections:

Acute external: 16u (4u)
Septic external: 90u (25u)

Acute internal: 33u (4u)
Septic internal: 180u (25u).

Healing all acute external infections (each part of the body) will consume about 55u of spaceacillin.
Healing all septic external infections will consume about 300u of spaceacillin.

Healing all acute internal infections will consume about 66u of spaceacillin.
Healing all septic internal infections will consume about 360u of spaceacillin.

Comments, balance concerns, rage, and suggestions are welcome for these numbers but the current values (25u for cure-all) is a bit unacceptable IMO.