### PR TITLE
Spaceacillin changes

### DIFF
--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -216,6 +216,7 @@ var/list/organ_cache = list()
 
 	if(germ_level < INFECTION_LEVEL_ONE)
 		germ_level = 0	//cure instantly
+		return
 	else if(germ_level < INFECTION_LEVEL_TWO)
 		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds, for one external infection
 	else

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -218,7 +218,7 @@ var/list/organ_cache = list()
 		germ_level = 0	//cure instantly
 		return
 	else if(germ_level < INFECTION_LEVEL_TWO)
-		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds for external infection
+		germ_level -= 7 * germ_mod	//at germ_level == 500, this should cure the infection in 50 seconds for external infection
 	else
 		germ_level -= 4 * germ_mod	// at germ_level == 1000, this will cure the infection in 2 minute for external infection
 						// Let's not drag this on, but curing every infection in the body with 25u of spaceacillin is a bit silly.

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -218,11 +218,10 @@ var/list/organ_cache = list()
 		germ_level = 0	//cure instantly
 		return
 	else if(germ_level < INFECTION_LEVEL_TWO)
-		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds, for one external infection
+		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds for external infection
 	else
-		germ_level -= 4 * germ_mod	// at germ_level == 1000, this will cure the infection in 2 minute, 30 seconds, for one external infection
+		germ_level -= 4 * germ_mod	// at germ_level == 1000, this will cure the infection in 2 minute for external infection
 						// Let's not drag this on, but curing every infection in the body with 25u of spaceacillin is a bit silly.
-	owner.reagents.remove_reagent("spaceacillin",0.1) //curing one infection is okay but not all of them at once
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -32,6 +32,8 @@ var/list/organ_cache = list()
 	var/sterile = 0 //can the organ be infected by germs?
 	var/tough = 0 //can organ be easily damaged?
 
+	var/germ_mod = 1 //modifier for antibiotic's effects on this organ
+
 /obj/item/organ/Destroy()
 	processing_objects.Remove(src)
 	if(owner)
@@ -215,10 +217,11 @@ var/list/organ_cache = list()
 	if(germ_level < INFECTION_LEVEL_ONE)
 		germ_level = 0	//cure instantly
 	else if(germ_level < INFECTION_LEVEL_TWO)
-		germ_level -= 24	//at germ_level == 500, this should cure the infection in 15 seconds
+		germ_level -= 12 * germ_mod	//at germ_level == 500, this should cure the infection in 30 seconds, for one external infection
 	else
-		germ_level -= 8	// at germ_level == 1000, this will cure the infection in 1 minute, 15 seconds
-						// Let's not drag this on, medbay has only so much antibiotics
+		germ_level -= 4 * germ_mod	// at germ_level == 1000, this will cure the infection in 2 minute, 30 seconds, for one external infection
+						// Let's not drag this on, but curing every infection in the body with 25u of spaceacillin is a bit silly.
+	owner.reagents.remove_reagent("spaceacillin",0.1) //curing one infection is okay but not all of them at once
 
 //Adds autopsy data for used_weapon.
 /obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -10,6 +10,8 @@
 	vital = 0
 	var/non_primary = 0
 
+	germ_mod = 0.5 //curing infected internal organs should be hard, outside surgery
+
 /obj/item/organ/internal/New(var/mob/living/carbon/holder)
 	..()
 	if(istype(holder))


### PR DESCRIPTION
Since I think "nerf " is the wrong word here.

This change makes spaceacillin 2/3 as effective for treating infections and 1/3 as effective for treating organ infections.

Acute infections now require about 15u of spaceacillin to be treated, and acute internal infections require about 30u of spaceacillin to be treated.

Septic infections require 45u and 90u, for internal and external, respectively, but these tend to take a long time to form and are somewhat rare. 

These amounts will still completely cure any infections at the same rate, and does not increase with the number of infections in the patient.

As a tradeoff, injecting 5u of spaceacillin into a target area during organ manipulation surgery instantly and completely cleanses all organs in that area of infection, which is much more economical in the long run. Dumping alcohol in still works too, and using syringes now in alcoholic disinfection carries a 100% chance of success.

#7623 was perhaps a bit too much of a nerf to spaceacillin, and I think this is a much better tradeoff between surgery being more effective at treating infections, but spaceacillin injections still being practical to treat infections (even internal ones). I mean, if you really fuck up and someone has a septic infection to their heart, you can jam 6 syringes of spaceacillin in them, but it will probably be easier just to cut em open and inject 5u.

:cl: Vivalas
tweak: In an effort to cut costs, Nanotrasen has diluted their proprietary Spaceacillin :tm: brand super antibiotic to be somewhat less stronger, and require more than just two syringes worth to completely cure the patient of any bacterial infection. This new blend, however, is stable enough to be injected directly into internal organs, for maximum treatment potential.
/:cl:
