### PR TITLE
Heart fixes / tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1011,6 +1011,11 @@
 
 	var/temp = PULSE_NORM
 
+	if(can_heartattack())
+		var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
+		if(heart && heart.damage >= heart.max_damage / 2)
+			temp = PULSE_2FAST //thump-thump-thump-thump, ruh roh
+
 	var/blood_type = get_blood_name()
 	if(round(vessel.get_reagent_amount(blood_type)) <= BLOOD_VOLUME_BAD)	//how much blood do we have
 		temp = PULSE_THREADY	//not enough :(

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -86,11 +86,6 @@
 
 		//Effects of bloodloss
 		var/oxy_immune = species.flags & NO_BREATHE //Some species have blood, but don't breathe; they should still suffer the effects of bloodloss.
-		if(can_heartattack()) //if we have no need for a heart it doesn't affect blood volume
-			var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
-			if(heart && heart.beating) //Let's not make heart attacks worse...
-				blood_volume *= (1 - (heart.damage / (heart.max_damage * 2))) //up tp -50% blood_volume for a totalled heart
-
 		switch(blood_volume)
 			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
 				if(prob(5))

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -89,7 +89,7 @@
 		if(can_heartattack()) //if we have no need for a heart it doesn't affect blood volume
 			var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
 			if(heart && heart.beating) //Let's not make heart attacks worse...
-				blood_volume = max(0,round(blood_volume - blood_volume * (heart.damage / (heart.max_damage * 2)))) //up tp -50% blood_volume for a totalled heart
+				blood_volume *= (1 - (heart.damage / (heart.max_damage * 2))) //up tp -50% blood_volume for a totalled heart
 
 		switch(blood_volume)
 			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -86,6 +86,10 @@
 
 		//Effects of bloodloss
 		var/oxy_immune = species.flags & NO_BREATHE //Some species have blood, but don't breathe; they should still suffer the effects of bloodloss.
+		if(can_heartattack()) //if we have no need for a heart it doesn't affect blood volume
+			var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
+			if(heart) //I'm a tinman
+				blood_volume = max(0,round(blood_volume - blood_volume * (heart.damage / (heart.max_damage * 2)))) //up tp -50% blood_volume for a totalled heart
 
 		switch(blood_volume)
 			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -88,7 +88,7 @@
 		var/oxy_immune = species.flags & NO_BREATHE //Some species have blood, but don't breathe; they should still suffer the effects of bloodloss.
 		if(can_heartattack()) //if we have no need for a heart it doesn't affect blood volume
 			var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
-			if(heart) //I'm a tinman
+			if(heart && heart.beating) //Let's not make heart attacks worse...
 				blood_volume = max(0,round(blood_volume - blood_volume * (heart.damage / (heart.max_damage * 2)))) //up tp -50% blood_volume for a totalled heart
 
 		switch(blood_volume)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -185,7 +185,7 @@
 
 /obj/item/organ/internal/heart/necrotize()
 	..()
-	beating = FALSE
+	owner.set_heartattack(TRUE)
 
 /obj/item/organ/internal/heart/proc/Stop()
 	beating = FALSE

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -140,9 +140,18 @@
 	parent_organ = "chest"
 	slot = "heart"
 	origin_tech = "biotech=5"
-	var/beating = 1
+	var/beating = TRUE
 	dead_icon = "heart-off"
 	var/icon_base = "heart"
+
+/obj/item/organ/internal/heart/on_life()
+	if(damage >= max_damage / 2) //heart problems suck
+		if(prob(2))
+			to_chat(owner, "<span class='danger'>Your heart is racing in your chest!</span>")
+		if(prob(1))
+			to_chat(owner, "<span class='danger'>Your heart feels like it is trying to bust out of your chest!</span>")
+			owner.custom_emote(1, "pants loudly.")
+			owner.Stun(1)
 
 /obj/item/organ/internal/heart/update_icon()
 	if(beating)
@@ -174,13 +183,17 @@
 	Restart()
 	..()
 
+/obj/item/organ/internal/heart/necrotize()
+	..()
+	beating = FALSE
+
 /obj/item/organ/internal/heart/proc/Stop()
-	beating = 0
+	beating = FALSE
 	update_icon()
 	return 1
 
 /obj/item/organ/internal/heart/proc/Restart()
-	beating = 1
+	beating = TRUE
 	update_icon()
 	return 1
 
@@ -288,6 +301,7 @@
 			owner.custom_emote(1, "coughs up blood!")
 			owner.drip(10)
 		if(prob(4))
+
 			owner.custom_emote(1, "gasps for air!")
 			owner.AdjustLoseBreath(5)
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -301,7 +301,6 @@
 			owner.custom_emote(1, "coughs up blood!")
 			owner.drip(10)
 		if(prob(4))
-
 			owner.custom_emote(1, "gasps for air!")
 			owner.AdjustLoseBreath(5)
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -185,7 +185,8 @@
 
 /obj/item/organ/internal/heart/necrotize()
 	..()
-	owner.set_heartattack(TRUE)
+	if(owner)
+		owner.set_heartattack(TRUE)
 
 /obj/item/organ/internal/heart/proc/Stop()
 	beating = FALSE


### PR DESCRIPTION
Heart death will now actually trigger heart attacks.

Additionally, hearts now adjust blood_volume calculations by up to -50% blood at max damage. Past 30 heart damage you now get fluff messages about your heart beating real fast, your heart beats real fast, and you get external indicators of heart damage such as panting and brief stuns.

:cl: Vivalas
tweak: Heart damage is now actually somewhat relevant. Effective blood volume for oxyloss calculations now scales linearly with heart damage, at max -50%.
fix: Heart death now properly triggers heart attacks
/:cl:

