### PR TITLE
Fixes CMOs being unable to demote coroners

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -83,6 +83,7 @@
 	spawn_positions = 1
 	is_medical = 1
 	supervisors = "the chief medical officer"
+	department_head = list("Chief Medical Officer")
 	selection_color = "#ffeef0"
 	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_mineral_storeroom)
 	minimal_access = list(access_medical, access_morgue, access_maint_tunnels)


### PR DESCRIPTION
Looks like an issue with conflict resolution in the past that this got missed.

:cl:
fix: The Coroner will respect the CMO's Authoritah.
/ :cl: