### PR TITLE
Adds 10h playtime requirement to drones

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -39,7 +39,7 @@
 #define ROLE_ERT				"emergency response team"
 #define ROLE_NYMPH				"Dionaea"
 #define ROLE_GSPIDER			"giant spider"
-
+#define ROLE_DRONE				"drone"
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -7,6 +7,7 @@ var/global/list/role_playtime_requirements = list(
 	ROLE_SENTIENT = 5,
 	ROLE_ERT = 10, // High, because they're team-based, and we want ERT to be robust
 	ROLE_TRADER = 5,
+	ROLE_DRONE = 10, // High, because they're like mini engineering cyborgs that can ignore the AI, ventcrawl, and respawn themselves
 
 	// SOLO ANTAGS
 	ROLE_TRAITOR = 3,

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -53,7 +53,7 @@
 	if(..())
 		return
 
-	if(!allowed(usr))
+	if(!allowed(usr) && !usr.can_admin_interact())
 		to_chat(usr, "<span class='warning'>Access denied.</span>")
 		return
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -108,6 +108,12 @@
 		to_chat(usr, "<span class='warning'>This role is not yet available to you. You need to wait another [player_age_check] days.</span>")
 		return
 
+	var/pt_req = role_available_in_playtime(client, ROLE_DRONE)
+	if(pt_req)
+		var/pt_req_string = get_exp_format(pt_req)
+		to_chat(usr, "<span class='warning'>This role is not yet available to you. Play another [pt_req_string] to unlock it.</span>")
+		return
+
 	var/deathtime = world.time - src.timeofdeath
 	var/joinedasobserver = 0
 	if(istype(src,/mob/dead/observer))


### PR DESCRIPTION
Drones are essentially mini engineering borgs, with the ability to run under objects, ventcrawl, ignore the AI and respawn themselves. Given that we have playtime requirements for borgs, we really should have playtime requirements for these too.
Also, this change was requested by Neca.

🆑 Kyep
add: Playing as a drone now requires 10h of playtime.
fix: Admin-ghosts can now interact with (ie: activate) the drone fab without having to spawn in as engineer to do so.
/ 🆑