### PR TITLE
Detective's Noir Sunglasses with built in SecHud

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -122,7 +122,7 @@
 	shoes = /obj/item/clothing/shoes/brown
 	head = /obj/item/clothing/head/det_hat
 	l_ear = /obj/item/device/radio/headset/headset_sec/alt
-	glasses = /obj/item/clothing/glasses/sunglasses/noir
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/noir
 	id = /obj/item/weapon/card/id/security
 	l_pocket = /obj/item/toy/crayon/white
 	r_pocket = /obj/item/weapon/lighter/zippo

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -235,22 +235,6 @@
 	flash_protect = 0
 	tint = 0
 
-/obj/item/clothing/glasses/sunglasses/noir
-	name = "noir sunglasses"
-	desc = "Somehow these seem even more out-of-date than normal sunglasses."
-	actions_types = list(/datum/action/item_action/noir)
-
-/obj/item/clothing/glasses/sunglasses/noir/attack_self()
-	toggle_noir()
-
-/obj/item/clothing/glasses/sunglasses/noir/item_action_slot_check(slot)
-	if(slot == slot_glasses)
-		return 1
-
-/obj/item/clothing/glasses/sunglasses/noir/proc/toggle_noir()
-	color_view = color_view ? null : MATRIX_GREYSCALE //Toggles between null and grayscale, with null being the default option.
-	usr.update_client_colour()
-
 /obj/item/clothing/glasses/sunglasses/yeah
 	name = "agreeable glasses"
 	desc = "H.C Limited edition."

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -141,6 +141,24 @@
 		"Vox" = 'icons/mob/species/vox/eyes.dmi'
 		)
 
+/obj/item/clothing/glasses/hud/security/sunglasses/noir
+	name = "noir sunglasses"
+	desc = "Somehow these seem even more out-of-date than normal sunglasses. It comes with a built in security heads-up display"
+	icon_state = "sun"
+	item_state = "sunglasses"
+	actions_types = list(/datum/action/item_action/noir)
+
+/obj/item/clothing/glasses/hud/security/sunglasses/noir/attack_self()
+	toggle_noir()
+
+/obj/item/clothing/glasses/hud/security/sunglasses/noir/item_action_slot_check(slot)
+	if(slot == slot_glasses)
+		return 1
+
+/obj/item/clothing/glasses/hud/security/sunglasses/noir/proc/toggle_noir()
+	color_view = color_view ? null : MATRIX_GREYSCALE //Toggles between null and grayscale, with null being the default option.
+	usr.update_client_colour()
+
 /obj/item/clothing/glasses/hud/hydroponic/night
 	name = "Night Vision Hydroponic HUD"
 	desc = "A hydroponic HUD fitted with a light amplifier."


### PR DESCRIPTION
Okay so here is another proposal which I have a good feeling about. The Detective sunglasses now has a built in SecHud. The Detective no longer has to ask the Warden or Head of Security for one and the Detective will be able to get information about someone and add comments to players on the server (or set them to arrest, whatever).

🆑 Jovaniph
tweak: Detective Noir Sunglasses now has a built in security heads-up display
/🆑