### PR TITLE
Fixes #7630 - job priority outlasting slots being filled

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -302,7 +302,9 @@
 		AnnounceArrival(character, rank, join_message)
 		callHook("latespawn", list(character))
 
-
+	var/datum/job/thisjob = job_master.GetJob(rank)
+	if(!thisjob.is_position_available() && thisjob in job_master.prioritized_jobs)
+		job_master.prioritized_jobs -= thisjob
 	qdel(src)
 
 


### PR DESCRIPTION
🆑 Kyep
fix: Prioritized jobs now lose their priority status once all their slots are filled. In the event someone with a formerly prioritized job cryos, the HoP may want to re-prioritize the job.
/ 🆑

Fixes #7630
Prevents prioritized jobs, even after being filled, from being listed in green on the new_player screen for the rest of the round.