### PR TITLE
Gave plasmaman virologists a medical plasma suit

### DIFF
--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -90,7 +90,7 @@
 		if("Nanotrasen Representative")
 			suit = /obj/item/clothing/suit/space/eva/plasmaman/nt_rep
 			helm = /obj/item/clothing/head/helmet/space/eva/plasmaman/nt_rep
-		if("Medical Doctor","Brig Physician")
+		if("Medical Doctor","Brig Physician","Virologist")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/medical
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/medical
 			H.equip_or_collect(new /obj/item/device/flashlight/pen(H), slot_in_backpack)


### PR DESCRIPTION
This is my first PR in a long time (and third ever), but I'm pretty sure I did it right. 🤞

If you play plasmaman and decide to be the virologist, you spawn with the assistant plasmasuit. This makes them spawn with the medical plasmasuit, since the virologist is part of the medical department.

🆑 ProperPants
add: Plasmaman virologists now spawn with a medical plasmasuit instead of an assistant one.
/ 🆑 