### PR TITLE
It's a morgue, not a rec room.

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -9,7 +9,7 @@
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
-	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue, access_weapons, access_mineral_storeroom)
+	access = list(access_hydroponics, access_bar, access_kitchen, access_weapons, access_mineral_storeroom)
 	minimal_access = list(access_bar, access_maint_tunnels, access_weapons, access_mineral_storeroom)
 	outfit = /datum/outfit/job/bartender
 

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -77,8 +77,8 @@
 	supervisors = "the head of personnel"
 	department_head = list("Head of Personnel")
 	selection_color = "#dddddd"
-	access = list(access_hydroponics, access_bar, access_kitchen, access_morgue)
-	minimal_access = list(access_hydroponics, access_morgue, access_maint_tunnels)
+	access = list(access_hydroponics, access_bar, access_kitchen)
+	minimal_access = list(access_hydroponics, access_maint_tunnels)
 	alt_titles = list("Hydroponicist", "Botanical Researcher")
 	outfit = /datum/outfit/job/hydro
 


### PR DESCRIPTION
The bartender, chef, and botanist all have morgue access. I don't know why or when, but this access is functionally useless to the core of their jobs.

**Bartender**
I have removed morgue access from the bartender because I truly see no reason they should have it. Maybe it has a tiny impact to bartender changelings or something? Even then, it would put them in the same boat as the other 90+% of the station that can't just stroll into the morgue.

**Chef**
I have left the chef with morgue access because the morgue is a prime source of... exotic ingredients. It seems appropriate/funny, especially if you are trying to RP someone like Hannibal Lecter.

**Botanist**
I have removed morgue access from the botanist. The only conceivable reason that the botanist should be in the morgue is to get blood for replica pods; however, the chance of someone being cloned via replica pod is so low, that if the people who are actually in charge of cloning (doctors, geneticists, coroner) want it to happen, then can just give a syringe of blood to botany.

🆑 ProperPants
tweak: Removes morgue access from bartender.
tweak: Removes morgue access from botanist.
/ 🆑 