### PR TITLE
Enables printing of Demotion console circuitboards

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -142,6 +142,26 @@
 	build_path = /obj/item/weapon/circuitboard/card
 	category = list("Computer Boards")
 
+/datum/design/idcardconsole/ce
+	name = "Console Board (ID Computer - CE Access)"
+	id = "idcardconsolece"
+	build_path = /obj/item/weapon/circuitboard/card/minor/ce
+
+/datum/design/idcardconsole/rd
+	name = "Console Board (ID Computer - RD Access)"
+	id = "idcardconsolerd"
+	build_path = /obj/item/weapon/circuitboard/card/minor/rd
+
+/datum/design/idcardconsole/hos
+	name = "Console Board (ID Computer - HoS Access)"
+	id = "idcardconsolehos"
+	build_path = /obj/item/weapon/circuitboard/card/minor/hos
+
+/datum/design/idcardconsole/cmo
+	name = "Console Board (ID Computer - CMO Access)"
+	id = "idcardconsolecmo"
+	build_path = /obj/item/weapon/circuitboard/card/minor/cmo
+
 /datum/design/mechapower
 	name = "Console Board (Mech Bay Power Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a mech bay power control console."


### PR DESCRIPTION
Continuing the trend of making everything (within reason) constructible, and that this was missed off of #6766, admitted by the author [here ](https://nanotrasen.se/forum/topic/10665-list-of-irreplaceble-itemsmachinery-on-station/#comment-88368)- I figured I'd rectify it.

:cl: Purpose2
add: Demotion console circuitboard designs now available from your local Research and Development laboratory!
/ :cl: