### PR TITLE
Ghetto Hemostat - changes cable coil to wirecutters in most surgery steps

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -63,7 +63,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 75, 	\
+	/obj/item/weapon/wirecutters = 75, 	\
 	/obj/item/device/assembly/mousetrap = 20
 	)
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -352,7 +352,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 75, 	\
+	/obj/item/weapon/wirecutters = 75, 	\
 	/obj/item/device/assembly/mousetrap = 20
 	)
 	var/obj/item/organ/external/L = null

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -175,7 +175,7 @@
 	name = "connect limb"
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 75, 	\
+	/obj/item/weapon/wirecutters = 75, 	\
 	/obj/item/device/assembly/mousetrap = 20
 	)
 	can_infect = 1

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -68,7 +68,7 @@
 /datum/surgery_step/internal/manipulate_organs
 	name = "manipulate organs"
 	allowed_tools = list(/obj/item/organ/internal = 100, /obj/item/weapon/reagent_containers/food/snacks/organ = 0)
-	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/kitchen/utensil/fork = 55)
+	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/wirecutters = 75, /obj/item/weapon/kitchen/utensil/fork = 55)
 	var/implements_mend = list(/obj/item/stack/medical/bruise_pack = 20,/obj/item/stack/medical/bruise_pack/advanced = 100,/obj/item/stack/nanopaste = 100)
 	var/implements_clean = list(/obj/item/weapon/reagent_containers/dropper = 100,
 								/obj/item/weapon/reagent_containers/glass/bottle = 75,


### PR DESCRIPTION
This PR tries to make some ghetto surgery tools a bit more consistent. Cable coil is supposed to act as a ghetto fixovein, and wirecutters are to act as a ghetto hemostat. Wirecutters already functioned as hemostat in some surgeries such as ghetto implant removal, where it wouldn't function in surgeries like removing organs. Anyways, it makes a bit more sense to be able to rip out organs with wirecutters, doesnt it?

🆑  imsxz
tweak: changes cable coil to wirecutters in lots of ghetto surgeries
add: adds wirecutters to list of tools that can extract organs
\🆑 