### PR TITLE
Makes emagged turrets fire more quickly

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -453,6 +453,7 @@ var/list/turret_icons
 		enabled = 0 //turns off the turret temporarily
 		sleep(60) //6 seconds for the traitor to gtfo of the area before the turret decides to ruin his shit
 		enabled = 1 //turns it back on. The cover popUp() popDown() are automatically called in process(), no need to define it here
+		makeSpeedProcess() //GOTTA GO FAST
 
 /obj/machinery/porta_turret/proc/take_damage(var/force)
 	if(!raised && !raising)


### PR DESCRIPTION
Fixes #7666. This was apparently the intended mode of emagged turrets, but never got implemented correctly.

Emagged turrets will now fire every game tick, as opposed to once every 2 seconds.

Also: balance considerations. 

🆑 
tweak: Emagged turrets now fire much more quickly.
/🆑 