### PR TITLE
Tweaks SecHUDs

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -190,7 +190,7 @@
 
 /mob/living/carbon/human/proc/sec_hud_set_security_status()
 	var/image/holder = hud_list[WANTED_HUD]
-	var/perpname = get_face_name(get_id_name(""))
+	var/perpname = get_visible_name(TRUE) //gets the name of the perp, works if they have an id or if their face is uncovered
 	if(!ticker) return //wait till the game starts or the monkeys runtime....
 	if(perpname)
 		var/datum/data/record/R = find_record("name", perpname, data_core.security)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -597,7 +597,7 @@
 	return
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere
-/mob/living/carbon/human/get_visible_name()
+/mob/living/carbon/human/get_visible_name(var/id_override = FALSE)
 	if(name_override)
 		return name_override
 	if(wear_mask && (wear_mask.flags_inv & HIDEFACE))	//Wearing a mask which hides our face, use id-name if possible
@@ -606,7 +606,7 @@
 		return get_id_name("Unknown")		//Likewise for hats
 	var/face_name = get_face_name()
 	var/id_name = get_id_name("")
-	if(id_name && (id_name != face_name))
+	if(id_name && (id_name != face_name) && !id_override)
 		return "[face_name] (as [id_name])"
 	return face_name
 


### PR DESCRIPTION
...Not even sure what this bit of code did before since get_face_name() doesn't have any arguments, but now they behave more consistently with how they check records for setting criminal status.

SecHUDs now only display wanted status / notes / etc. if the subject's face is uncovered or if they have an ID. Being able to see the wanted status of someone with no ID and a gas mask defeats the purpose of hiding your identity in the first place.

:cl: Vivalas
fix: "Tweaks" SecHUDs to only display criminal status of people if their face is uncovered or they have no ID.
/:cl: