### PR TITLE
Replaces IRC link with Discord link in changelog

### DIFF
--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -26,7 +26,7 @@
 			<div align='center'><font size='3'><b>Paradise Station</b></font></div>
 			
 			<p><div align='center'><font size='3'><a href="http://nanotrasen.se/phpBB3/index.php">Forum</a> | <a href="http://nanotrasen.se/wiki/index.php/Main_Page">Wiki</a> | <a href="https://github.com/ParadiseSS13/Paradise">Source</a></font></div></p>
-			<font size='2'><b>Visit our IRC channel:</b> #crew on neko.sneeza.me</font>
+			<font size='2'><b>Visit our Discord channel:</b> https://discordapp.com/invite/nuqD478</font>
 			</td>
 	</tr>
 </table>

--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -26,7 +26,7 @@
 			<div align='center'><font size='3'><b>Paradise Station</b></font></div>
 			
 			<p><div align='center'><font size='3'><a href="http://nanotrasen.se/phpBB3/index.php">Forum</a> | <a href="http://nanotrasen.se/wiki/index.php/Main_Page">Wiki</a> | <a href="https://github.com/ParadiseSS13/Paradise">Source</a></font></div></p>
-			<font size='2'><b>Visit our Discord channel:</b> https://discordapp.com/invite/nuqD478</font>
+			<font size='2'><b>Visit our Discord channel:</b><a href='https://discordapp.com/invite/nuqD478<'>-Click Here-</a></font>
 			</td>
 	</tr>
 </table>


### PR DESCRIPTION
Dunno if this IRC channel is still used, but replaced the link with a reference to the Discord channel. If preferred I could just remove this line completely.