### PR TITLE
Hotkeys for liquid dispensers!

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -199,6 +199,11 @@
 		Topic(src, list("src" = UID(), "command"="lights", "activate" = "0"), 1)
 	return
 
+/obj/machinery/ai_slipper/AICtrlClick() //Turns liquid dispenser on or off
+	ToggleOn()
+
+/obj/machinery/ai_slipper/AIAltClick() //Dispenses liquid if on
+	Activate()
 
 //
 // Override AdjacentQuick for AltClicking

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -169,6 +169,12 @@
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
 	AIAltClick()
 
+/obj/machinery/ai_slipper/BorgCtrlClick() //Turns liquid dispenser on or off
+	ToggleOn()
+
+/obj/machinery/ai_slipper/BorgAltClick() //Dispenses liquid if on
+	Activate()
+
 /*
 	As with AI, these are not used in click code,
 	because the code for robots is specific, not generic.

--- a/code/game/machinery/ai_slipper.dm
+++ b/code/game/machinery/ai_slipper.dm
@@ -5,12 +5,12 @@
 	layer = 3
 	anchored = 1.0
 	var/uses = 20
-	var/disabled = 1
+	var/disabled = TRUE
 	var/lethal = 0
-	var/locked = 1
+	var/locked = TRUE
 	var/cooldown_time = 0
 	var/cooldown_timeleft = 0
-	var/cooldown_on = 0
+	var/cooldown_on = FALSE
 	req_access = list(access_ai_upload)
 
 /obj/machinery/ai_slipper/power_change()
@@ -22,6 +22,7 @@
 		else
 			icon_state = "motion0"
 			stat |= NOPOWER
+			disabled = TRUE
 
 /obj/machinery/ai_slipper/proc/setState(var/enabled, var/uses)
 	disabled = disabled
@@ -48,6 +49,24 @@
 			to_chat(user, "<span class='warning'>Access denied.</span>")
 			return
 	return
+
+/obj/machinery/ai_slipper/proc/ToggleOn()
+	if(stat & (NOPOWER|BROKEN))
+		return
+	disabled = !disabled
+	icon_state = disabled? "motion0":"motion3"
+
+/obj/machinery/ai_slipper/proc/Activate()
+	if(stat & (NOPOWER|BROKEN))
+		return
+	if(cooldown_on || disabled)
+		return
+	else
+		new /obj/structure/foam(loc)
+		uses--
+		cooldown_on = TRUE
+		cooldown_time = world.timeofday + 100
+		slip_process()
 
 /obj/machinery/ai_slipper/attack_ai(mob/user)
 	return attack_hand(user)
@@ -87,18 +106,10 @@
 		return 1
 
 	if(href_list["toggleOn"])
-		disabled = !disabled
-		icon_state = disabled? "motion0":"motion3"
+		ToggleOn()
+
 	if(href_list["toggleUse"])
-		if(cooldown_on || disabled)
-			return
-		else
-			new /obj/structure/foam(loc)
-			uses--
-			cooldown_on = 1
-			cooldown_time = world.timeofday + 100
-			slip_process()
-			return
+		Activate()
 
 	attack_hand(usr)
 
@@ -115,5 +126,5 @@
 	if(uses <= 0)
 		return
 	if(uses >= 0)
-		cooldown_on = 0
+		cooldown_on = FALSE
 	power_change()


### PR DESCRIPTION
Small QoL feature for AIs and cyborgs. The liquid dispensers can be turned on / off using control-click, and if they are on, alt-clicking them makes them dispense foam.

🆑 
tweak: AIs and cyborgs can now toggle liquid dispensers by ctrl-clicking them, and can make them dispense foam by alt-clicking.
/:cl: