### PR TITLE
Gives traitor medical chemists access to the poison bottle uplink item.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -332,7 +332,7 @@ var/list/uplink_items = list()
 	reference = "TPB"
 	item = /obj/item/weapon/reagent_containers/glass/bottle/traitor
 	cost = 2
-	job = list("Research Director", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Paramedic", "Virologist", "Bartender", "Chef")
+	job = list("Research Director", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Paramedic", "Virologist", "Bartender", "Chef", "Chemist")
 
 // Paper contact poison pen
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -332,7 +332,7 @@ var/list/uplink_items = list()
 	reference = "TPB"
 	item = /obj/item/weapon/reagent_containers/glass/bottle/traitor
 	cost = 2
-	job = list("Research Director", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Paramedic", "Virologist", "Bartender", "Chef", "Chemist")
+	job = list("Research Director", "Chief Medical Officer", "Medical Doctor", "Psychiatrist", "Chemist", "Paramedic", "Virologist", "Bartender", "Chef")
 
 // Paper contact poison pen
 


### PR DESCRIPTION
This PR allows medical chemists to access syndicate poison bottles. I thought that it was odd that they did not have access to this in line with the other medical jobs, especially as dealing with chemicals is literally their job. A very small change to what looks like an oversight to me.

:cl: Birdtalon
tweak: Traitor medical chemists can now access syndicate poison bottles.
/ :cl: