### PR TITLE
Gives Red/Gamma ERTs magboots

### DIFF
--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -387,6 +387,7 @@ var/ert_request_answered = 0
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/commander = 1,
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/weapon/restraints/handcuffs = 1,
+		/obj/item/clothing/shoes/magboots = 1,
 		/obj/item/weapon/storage/lockbox/mindshield = 1
 	)
 
@@ -403,6 +404,7 @@ var/ert_request_answered = 0
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/commander = 1,
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/weapon/restraints/handcuffs = 1,
+		/obj/item/clothing/shoes/magboots/advance = 1,
 		/obj/item/weapon/storage/lockbox/mindshield = 1,
 		/obj/item/weapon/gun/energy/pulse/pistol = 1
 		)
@@ -457,6 +459,7 @@ var/ert_request_answered = 0
 	backpack_contents = list(
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/security = 1,
 		/obj/item/clothing/mask/gas/sechailer = 1,
+		/obj/item/clothing/shoes/magboots = 1,
 		/obj/item/weapon/storage/box/handcuffs = 1,
 		/obj/item/weapon/gun/energy/ionrifle/carbine = 1
 	)
@@ -475,6 +478,7 @@ var/ert_request_answered = 0
 	backpack_contents = list(
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/security = 1,
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
+		/obj/item/clothing/shoes/magboots/advance = 1,
 		/obj/item/weapon/storage/box/handcuffs = 1,
 		/obj/item/weapon/gun/energy/ionrifle/carbine = 1
 	)
@@ -594,7 +598,8 @@ var/ert_request_answered = 0
 		/obj/item/weapon/storage/firstaid/toxin = 1,
 		/obj/item/weapon/storage/firstaid/adv = 1,
 		/obj/item/weapon/storage/firstaid/surgery = 1,
-		/obj/item/weapon/gun/energy/gun = 1
+		/obj/item/weapon/gun/energy/gun = 1,
+		/obj/item/clothing/shoes/magboots = 1
 	)
 
 /datum/outfit/job/centcom/response_team/medic/gamma
@@ -613,6 +618,7 @@ var/ert_request_answered = 0
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/medical = 1,
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/weapon/storage/firstaid/surgery = 1,
+		/obj/item/clothing/shoes/magboots/advance = 1,
 		/obj/item/weapon/gun/energy/pulse/pistol = 1
 	)
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -393,7 +393,7 @@ var/ert_request_answered = 0
 
 /datum/outfit/job/centcom/response_team/commander/gamma
 	name = "RT Commander (Gamma)"
-	shoes = /obj/item/clothing/shoes/combat/swat
+	shoes = /obj/item/clothing/shoes/magboots/advance
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/commander
 	glasses = /obj/item/clothing/glasses/hud/security/night
@@ -404,7 +404,6 @@ var/ert_request_answered = 0
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/commander = 1,
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/weapon/restraints/handcuffs = 1,
-		/obj/item/clothing/shoes/magboots/advance = 1,
 		/obj/item/weapon/storage/lockbox/mindshield = 1,
 		/obj/item/weapon/gun/energy/pulse/pistol = 1
 		)
@@ -467,7 +466,7 @@ var/ert_request_answered = 0
 /datum/outfit/job/centcom/response_team/security/gamma
 	name = "RT Security (Gamma)"
 	has_grenades = TRUE
-	shoes = /obj/item/clothing/shoes/combat/swat
+	shoes = /obj/item/clothing/shoes/magboots/advance
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/security
 	suit_store = /obj/item/weapon/gun/energy/gun/nuclear
@@ -478,7 +477,6 @@ var/ert_request_answered = 0
 	backpack_contents = list(
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/security = 1,
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
-		/obj/item/clothing/shoes/magboots/advance = 1,
 		/obj/item/weapon/storage/box/handcuffs = 1,
 		/obj/item/weapon/gun/energy/ionrifle/carbine = 1
 	)
@@ -513,7 +511,7 @@ var/ert_request_answered = 0
 
 /datum/outfit/job/centcom/response_team/engineer/red
 	name = "RT Engineer (Red)"
-	shoes = /obj/item/clothing/shoes/magboots
+	shoes = /obj/item/clothing/shoes/magboots/advance
 	gloves = /obj/item/clothing/gloves/color/yellow
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
 	suit_store = /obj/item/weapon/tank/emergency_oxygen/engi
@@ -604,7 +602,7 @@ var/ert_request_answered = 0
 
 /datum/outfit/job/centcom/response_team/medic/gamma
 	name = "RT Medic (Gamma)"
-	shoes = /obj/item/clothing/shoes/combat/swat
+	shoes = /obj/item/clothing/shoes/magboots/advance
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/medical
 	glasses = /obj/item/clothing/glasses/hud/health/night
@@ -618,7 +616,6 @@ var/ert_request_answered = 0
 		/obj/item/clothing/head/helmet/space/hardsuit/ert/medical = 1,
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/weapon/storage/firstaid/surgery = 1,
-		/obj/item/clothing/shoes/magboots/advance = 1,
 		/obj/item/weapon/gun/energy/pulse/pistol = 1
 	)
 


### PR DESCRIPTION
All red ERTs now get magboots.
Red engineer/commander, and all gamma ERT, get advanced magboots.

Without them, fastmos frequently causes them to go flying (and drop gear).

🆑 Kyep
tweak: Red and Gamma ERTs now come equipped with magboots.
🆑