### PR TITLE
🎵 That's the Power of Love🎵 

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -122,6 +122,7 @@
 
 	var/has_enabled_antagHUD = 0
 	var/antagHUD = 0
+	var/can_change_intents = 1 //all mobs can change intents by default.
 
 //Generic list for proc holders. Only way I can see to enable certain verbs/procs. Should be modified if needed.
 	var/proc_holder_list[] = list()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -337,30 +337,31 @@ var/list/intents = list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
 	set name = "a-intent"
 	set hidden = 1
 
-	if(ishuman(src) || isalienadult(src) || isbrain(src))
-		switch(input)
-			if(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
-				a_intent = input
-			if("right")
-				a_intent = intent_numeric((intent_numeric(a_intent)+1) % 4)
-			if("left")
-				a_intent = intent_numeric((intent_numeric(a_intent)+3) % 4)
-		if(hud_used && hud_used.action_intent)
-			hud_used.action_intent.icon_state = "[a_intent]"
+	if(can_change_intents)
+		if(ishuman(src) || isalienadult(src) || isbrain(src))
+			switch(input)
+				if(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
+					a_intent = input
+				if("right")
+					a_intent = intent_numeric((intent_numeric(a_intent)+1) % 4)
+				if("left")
+					a_intent = intent_numeric((intent_numeric(a_intent)+3) % 4)
+			if(hud_used && hud_used.action_intent)
+				hud_used.action_intent.icon_state = "[a_intent]"
 
-	else if(isrobot(src) || islarva(src))
-		switch(input)
-			if(INTENT_HELP)
-				a_intent = INTENT_HELP
-			if(INTENT_HARM)
-				a_intent = INTENT_HARM
-			if("right","left")
-				a_intent = intent_numeric(intent_numeric(a_intent) - 3)
-		if(hud_used && hud_used.action_intent)
-			if(a_intent == INTENT_HARM)
-				hud_used.action_intent.icon_state = "harm"
-			else
-				hud_used.action_intent.icon_state = "help"
+		else if(isrobot(src) || islarva(src))
+			switch(input)
+				if(INTENT_HELP)
+					a_intent = INTENT_HELP
+				if(INTENT_HARM)
+					a_intent = INTENT_HARM
+				if("right","left")
+					a_intent = intent_numeric(intent_numeric(a_intent) - 3)
+			if(hud_used && hud_used.action_intent)
+				if(a_intent == INTENT_HARM)
+					hud_used.action_intent.icon_state = "harm"
+				else
+					hud_used.action_intent.icon_state = "help"
 
 
 /mob/living/verb/mob_sleep()

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -371,10 +371,12 @@
 	description = "What is this emotion you humans call \"love?\"  Oh, it's this?  This is it? Huh, well okay then, thanks."
 	reagent_state = LIQUID
 	color = "#FF83A5"
+	process_flags = ORGANIC | SYNTHETIC // That's the power of love~
 
 /datum/reagent/love/on_mob_life(mob/living/M)
-	if(M.a_intent == INTENT_HARM)
-		M.a_intent = INTENT_HELP
+	if(M.a_intent != INTENT_HELP)
+		M.a_intent_change(INTENT_HELP)
+	M.can_change_intents = 0 //Now you have no choice but to be helpful.
 
 	if(prob(8))
 		var/lovely_phrase = pick("appreciated", "loved", "pretty good", "really nice", "pretty happy with yourself, even though things haven't always gone as well as they could")
@@ -391,8 +393,13 @@
 					break
 	..()
 
+/datum/reagent/love/on_mob_delete(mob/living/M)
+	M.can_change_intents = 1
+	..()
+
 /datum/reagent/love/reaction_mob(mob/living/M, method=TOUCH, volume)
 	to_chat(M, "<span class='notice'>You feel loved!</span>")
+
 
 /datum/reagent/royal_bee_jelly
 	name = "royal bee jelly"


### PR DESCRIPTION
Having the love reagent in you now sets your intent to "help", regardless of the intent you're on, instead of just preventing harm intent.

Additionally, having "love" in you prevents you from changing intents *at all*.

Also fixes the reagent's intent changing so it actually updates your HUD.

Oh, also synthetic mobs can now experience love.

:cl: Fox McCloud
tweak: love just got more powerful; it now prevents a mob from being on anything other than help intent
tweak: IPCs can now process the love reagent
/:cl: