### PR TITLE
Fixes being able to sentience potion pirates & other sentient simple_animals

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -26,6 +26,7 @@
 			/obj/item/weapon/melee/energy/sword/pirate)
 	del_on_death = 1
 	faction = list("pirate")
+	sentience_type = SENTIENCE_OTHER
 
 /mob/living/simple_animal/hostile/pirate/ranged
 	name = "Pirate Gunner"

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -25,7 +25,7 @@
 	loot = list(/obj/effect/landmark/mobcorpse/russian,
 			/obj/item/weapon/kitchen/knife)
 	del_on_death = 1
-
+	sentience_type = SENTIENCE_OTHER
 
 /mob/living/simple_animal/hostile/russian/ranged
 	icon_state = "russianranged"

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -47,8 +47,6 @@
 	var/cannot_be_seen = 1
 	var/mob/living/creator = null
 
-	sentience_type = SENTIENCE_OTHER
-
 
 // No movement while seen code.
 

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -47,6 +47,8 @@
 	var/cannot_be_seen = 1
 	var/mob/living/creator = null
 
+	sentience_type = SENTIENCE_OTHER
+
 
 // No movement while seen code.
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -25,6 +25,7 @@
 	status_flags = CANPUSH
 	loot = list(/obj/effect/landmark/mobcorpse/syndicatesoldier)
 	del_on_death = 1
+	sentience_type = SENTIENCE_OTHER
 
 ///////////////Sword and shield////////////
 


### PR DESCRIPTION
🆑Kyep
bugfix: it is no longer possible to use a sentience potion to convert space pirates in the beach away mission to your side. Nor is this possible with other sentient NPCs, such as syndies or russians.
/🆑