### PR TITLE
Makes 5.56 consistent between all guns

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -271,11 +271,6 @@
 	projectile_type = /obj/item/projectile/bullet/dart/syringe/tranquilizer
 	materials = list(MAT_METAL=250)
 
-/obj/item/ammo_casing/a556
-	desc = "A 5.56mm bullet casing."
-	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/heavybullet
-
 /obj/item/ammo_casing/shotgun/fakebeanbag
 	name = "beanbag shell"
 	desc = "A weak beanbag shell."

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -350,7 +350,7 @@
 	name = "toploader magazine (5.56mm)"
 	icon_state = "5.56m"
 	origin_tech = "combat=5;syndicate=1"
-	ammo_type = /obj/item/ammo_casing/a556
+	ammo_type = /obj/item/ammo_casing/mm556x45
 	caliber = "a556"
 	max_ammo = 30
 	multiple_sprites = 2

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -104,7 +104,7 @@ obj/item/projectile/bullet/saw/incen/Move()
 	icon_state = "a762-50"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/mm556x45
-	caliber = "mm55645"
+	caliber = "a556"
 	max_ammo = 50
 
 /obj/item/ammo_box/magazine/mm556x45/bleeding
@@ -136,7 +136,7 @@ obj/item/projectile/bullet/saw/incen/Move()
 /obj/item/ammo_casing/mm556x45
 	desc = "A 556x45mm bullet casing."
 	icon_state = "762-casing"
-	caliber = "mm55645"
+	caliber = "a556"
 	projectile_type = /obj/item/projectile/bullet/saw
 
 /obj/item/ammo_casing/mm556x45/bleeding


### PR DESCRIPTION
This makes it so there is only one kind of 5.56x45mm ammo. Currently, there are two different kinds of 5.56x45mm ammo, one made for the L6, and one made for the M-90gl. The L6 version does slightly more damage then the M-90gl, with the L6 doing 45 damage to the M-90gl's 35 damage. Because of this, if you happen to have a magazine of M-90gl ammo and a magazine of L6 ammo, you cannot load one with the other, even if you are meant to (see syndicate outpost). This PR does slightly buff the M-90GL, however, I don't think it will be that game changing since one burst will put you in crit either way. Especially since it does fix a major inconsistency where 5.56x45mm won't be able to be loaded in a 5.56x45mm gun. It also paves the way for specialty ammo for the M-90gl.

:cl: Shazbot
change: Now all 5.56x45mm is loaded the same, and will be accepted in all 5.56x45mm guns.
/:cl: