### PR TITLE
[WIP] Adds in a stasis pod for the paradmedic

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -137,3 +137,40 @@
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 			return
+
+
+/obj/structure/closet/body_bag/cryobag/cryopod
+	name = "stasis bag"
+	desc = "A bigger brother to the stasis bag. This one is both studier and reusable. It still does cause genetic damage however."
+	icon = 'icons/obj/cryobag.dmi'
+	sound = 'sound/machines/click.ogg'
+	density = 1
+
+	open()
+		if(opened)
+			return 0
+		if(!can_open())
+			return 0
+		dump_contents()
+		icon_state = icon_opened
+		opened = 1
+		if(sound)
+			playsound(loc, sound, 15, 1, -3)
+		else
+			playsound(loc, 'sound/machines/click.ogg', 15, 1, -3)
+		density = 0
+		return 1
+	MouseDrop(obj/over_object as obj)
+		if(istype(over_object, /obj/vehicle/ambulance))
+			var/obj/vehicle/ambulance/amb = over_object
+			if(amb.bed)
+				amb.bed = null
+				to_chat(usr, "You unhook the bed to the ambulance.")
+			else
+				amb.bed = src
+				to_chat(usr, "You hook the bed to the ambulance.")
+	close()
+		if(..())
+			density = 1
+			return 1
+		return 0


### PR DESCRIPTION
Adds in a stasis pod for the paramedic. It works much like the stasis bag, but is reusable and can hook to the ambulance. It still causes genetic damage like the bag version. This is a [WIP] because I do not have sprites for it nor do I have it mapped in yet, as it might replace the trolly for the ambulance, or both might be given as to give a choice. Do note however, that people can still die in stasis, I'm not 100% sure how to fix that, but that is not within the scope of this PR.

<Pictures here for when I have the sprites.>

:cl: Shazbot
Adds: We finaly put to use the disposable stasis bag technology into a bigger resuable stasis pod.
/:cl: 