### PR TITLE
Give atmos techs engineering bags

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -112,6 +112,9 @@
 	id = /obj/item/weapon/card/id/engineering
 	pda = /obj/item/device/pda/atmos
 
+	backpack = /obj/item/weapon/storage/backpack/industrial 
+	satchel = /obj/item/weapon/storage/backpack/satchel_eng 
+	dufflebag = /obj/item/weapon/storage/backpack/duffel/engineering 
 	box = /obj/item/weapon/storage/box/engineer
 
 /datum/job/mechanic


### PR DESCRIPTION
Makes atmos techs full citizens of engineering by giving them engineering bags. No more being mistaken for graytide with a suit!