### PR TITLE
Darts no longer proc reaction

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -250,7 +250,6 @@
 		if(blocked != 100)
 			if(M.can_inject(null,0,hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
-				reagents.reaction(M, INGEST)
 				reagents.trans_to(M, reagents.total_volume)
 				return 1
 			else


### PR DESCRIPTION
Shotgun darts and syringe gun darts no longer proc `reaction` on hit.


:cl: Fox McCloud
tweak: shotgun darts and syringe darts no longer react their reagents on hit (they will still transfer reagents)
/:cl: