### PR TITLE
Projectile Reflection Refactor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -10,7 +10,7 @@ emp_act
 
 /mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone)
 
-	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
+	if(P.is_reflectable)
 		if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
 			visible_message("<span class='danger'>The [P.name] gets reflected by [src]!</span>", \
 							"<span class='userdanger'>The [P.name] gets reflected by [src]!</span>")

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -37,6 +37,7 @@
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb	//Cael - bio and rad are also valid
 	var/projectile_type = "/obj/item/projectile"
 	var/range = 50 //This will de-increment every step. When 0, it will delete the projectile.
+	var/is_reflectable = FALSE // Can it be reflected or not?
 	//Effects
 	var/stun = 0
 	var/weaken = 0

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -8,6 +8,7 @@
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
 	flag = "laser"
 	eyeblur = 2
+	is_reflectable = TRUE
 
 /obj/item/projectile/beam/laser
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -4,6 +4,7 @@
 	damage = 0
 	damage_type = BURN
 	flag = "energy"
+	is_reflectable = TRUE
 
 /obj/item/projectile/energy/electrode
 	name = "electrode"


### PR DESCRIPTION
A port of my own code from TG: https://github.com/tgstation/tgstation/pull/29081

Refactors projectile reflection from a snowflake `istype` check to checking for a var on the projectile itself.


Zero impacts on gameplay.

Technically faster and allows for more customization (maybe a bullet will be reflectable some day, or maybe there's some energy/beam types that shouldn't be reflectable).