### PR TITLE
Removes A* call and Fixes Blood Virus Infections

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -119,11 +119,19 @@ var/list/diseases = subtypesof(/datum/disease)
 		else
 			return
 
-	if(isturf(source.loc))
+	var/turf/T = source.loc
+	if(istype(T))
 		for(var/mob/living/carbon/C in oview(spread_range, source))
-			if(isturf(C.loc))
-				if(AStar(source, C.loc, /turf/proc/Distance, spread_range, adjacent = (spread_flags & AIRBORNE) ? /turf/proc/reachableAdjacentAtmosTurfs : /turf/proc/reachableAdjacentTurfs))
-					C.ContractDisease(src)
+			var/turf/V = get_turf(C)
+			if(V)
+				while(TRUE)
+					if(V == T)
+						C.ContractDisease(src)
+						break
+					var/turf/Temp = get_step_towards(V, T)
+					if(!V.CanAtmosPass(Temp))
+						break
+					V = Temp
 
 
 /datum/disease/proc/process()


### PR DESCRIPTION
Port of: https://github.com/tgstation/tgstation/pull/28197

The less we rely on A* the better....


Also means that blood that has viruses in it will actually be infectious now (previously blood that had viruses in it just sat there and did nothing while processing forever).

:cl: Fox McCloud
fix: Blood (on the floor) that has viruses in it will now properly infect you, if you get near
/:cl: