### PR TITLE
Human Radiation Rework

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -195,47 +195,62 @@
 
 	if(!(species.flags & RADIMMUNE))
 		if(radiation)
-			if(radiation > 100)
-				if(!weakened)
-					emote("collapse")
-				Weaken(10)
-				to_chat(src, "<span class='danger'>You feel weak.</span>")
-
-			radiation = Clamp(radiation, 0, 100)
+			radiation = Clamp(radiation, 0, 200)
 
 			var/autopsy_damage = 0
 			switch(radiation)
-				if(0 to 50)
+				if(1 to 49)
 					radiation = max(radiation-1, 0)
 					if(prob(25))
 						adjustToxLoss(1)
-						autopsy_damage = 1
+						adjustFireLoss(1)
+						autopsy_damage = 2
 
-				if(50 to 75)
+				if(50 to 74)
 					radiation = max(radiation-2, 0)
 					adjustToxLoss(1)
-					autopsy_damage = 1
+					adjustFireLoss(1)
+					autopsy_damage = 2
 					if(prob(5))
 						radiation = max(radiation-5, 0)
-						if(!weakened)
-							emote("collapse")
 						Weaken(3)
 						to_chat(src, "<span class='danger'>You feel weak.</span>")
+						emote("collapse")
 
 				if(75 to 100)
-					radiation = max(radiation-3, 0)
-					adjustToxLoss(3)
-					autopsy_damage = 3
-					if(prob(1))
+					radiation = max(radiation-2, 0)
+					adjustToxLoss(2)
+					adjustFireLoss(2)
+					autopsy_damage = 4
+					if(prob(2))
 						to_chat(src, "<span class='danger'>You mutate!</span>")
 						randmutb(src)
 						domutcheck(src, null)
-						emote("gasp")
 
-			if(autopsy_damage && bodyparts.len)
-				var/obj/item/organ/external/O = pick(bodyparts)
-				if(istype(O))
-					O.add_autopsy_data("Radiation Poisoning", autopsy_damage)
+				if(101 to 150)
+					radiation = max(radiation-3, 0)
+					adjustToxLoss(2)
+					adjustFireLoss(3)
+					autopsy_damage = 5
+					if(prob(4))
+						to_chat(src, "<span class='danger'>You mutate!</span>")
+						randmutb(src)
+						domutcheck(src, null)
+
+				if(151 to INFINITY)
+					radiation = max(radiation-3, 0)
+					adjustToxLoss(2)
+					adjustFireLoss(3)
+					autopsy_damage = 5
+					if(prob(6))
+						to_chat(src, "<span class='danger'>You mutate!</span>")
+						randmutb(src)
+						domutcheck(src, null)
+
+			if(autopsy_damage)
+				var/obj/item/organ/external/chest/chest = get_organ("chest")
+				if(chest)
+					chest.add_autopsy_data("Radiation Poisoning", autopsy_damage)
 
 /mob/living/carbon/human/breathe()
 


### PR DESCRIPTION
Reworks human radiation damage (xenos and such are left unaffected). Inspired by Goon.

Radiation damage is a bit of an oddity; if you have a lot of it, it just keeps you permastunned, and your only real option is pretty much to sit there and die as you accumulate tox damage.

This changes radiation in a number of ways:

- Max radiation is now 200, instead of 100 (for the intents of Diona, it's still 100)
- Radiation causes burn as well as tox damage
- Radiation has an increased chance of mutating you; at 75 to 100  rads it has a 2% chance; 101-150 it has a 4% chance, and past 150 it has a 6% chance.
- Radiation damage, for autopsy purposes, is now handled on the chest


Overall, this should keep radiation strong (particularly for traitor chems like polonium), while preventing "permastun" status very early on; this also encourages a bit more broad spectrum treatment by medbay when dealing with radiation poisoning victims.


:cl: Fox McCloud
tweak: Radiation poisoning no longer permastuns, but deals burn damage now and has increased mutation chances
/:cl: