### PR TITLE
Fix: Adds the clownish language to honksquad members

### DIFF
--- a/code/modules/admin/verbs/honksquad.dm
+++ b/code/modules/admin/verbs/honksquad.dm
@@ -93,6 +93,7 @@ var/global/sent_honksquad = 0
 	new_honksquad.mind_initialize()
 	new_honksquad.mind.assigned_role = "MODE"
 	new_honksquad.mind.special_role = SPECIAL_ROLE_HONKSQUAD
+	new_honksquad.add_language("Clownish")
 	ticker.mode.traitors |= new_honksquad.mind//Adds them to current traitor list. Which is really the extra antagonist list.
 	new_honksquad.equip_honksquad(honk_leader_selected)
 	return new_honksquad


### PR DESCRIPTION
This is just a small fix in response to r3valkyrie's issue here: https://github.com/ParadiseSS13/Paradise/issues/7737

🆑
add: Adds the clownish language to honk squad members.
/ 🆑

