### PR TITLE
Halts another macro suicide method

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -428,7 +428,7 @@
 // if hands aren't protected and the light is on, burn the player
 
 /obj/machinery/light/attack_hand(mob/user)
-
+	user.changeNext_move(CLICK_CD_MELEE)
 	add_fingerprint(user)
 
 	if(status == LIGHT_EMPTY)
@@ -454,7 +454,6 @@
 			to_chat(user, "You telekinetically remove the light [fitting].")
 		else
 			if(user.a_intent == INTENT_DISARM || user.a_intent == INTENT_GRAB)
-				user.changeNext_move(CLICK_CD_MELEE)
 				to_chat(user, "You try to remove the light [fitting], but you burn your hand on it!")
 
 				var/obj/item/organ/external/affecting = H.get_organ("[user.hand ? "l" : "r" ]_hand")

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -454,6 +454,7 @@
 			to_chat(user, "You telekinetically remove the light [fitting].")
 		else
 			if(user.a_intent == INTENT_DISARM || user.a_intent == INTENT_GRAB)
+				user.changeNext_move(CLICK_CD_MELEE)
 				to_chat(user, "You try to remove the light [fitting], but you burn your hand on it!")
 
 				var/obj/item/organ/external/affecting = H.get_organ("[user.hand ? "l" : "r" ]_hand")


### PR DESCRIPTION
Adding a cooldown to burning yourself with a lightbulb. All interactable things should already have cooldowns apply, this is an outlier.

Also this has balance implications due to your ability to kill yourself as fast as if you typed `suicide`, but by using this method you are eligible for mid-round antags.