### PR TITLE
Hijack-only GBS kit for virology traitors

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -314,6 +314,16 @@ var/list/uplink_items = list()
 	cost = 10
 	job = list("Life Support Specialist")
 
+//Virologist
+/datum/uplink_item/jobspecific/gbskit
+	name = "GBS Virus Kit"
+	desc = "A kit containing the highly dangerous Gravitokinetic Bipotential SADS+ virus. If not cured in time, it will cause the infected person(s) to explode! Treatments are included in the case of accidental self-infection."
+	reference = "GBS"
+	item = /obj/item/weapon/storage/box/syndie_kit/gbskit
+	cost = 20
+	job = list("Virologist")
+	hijack_only = TRUE
+
 //Stimulants
 
 /datum/uplink_item/jobspecific/stims

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -320,7 +320,7 @@ var/list/uplink_items = list()
 	desc = "A kit containing the highly dangerous Gravitokinetic Bipotential SADS+ virus. If not cured in time, it will cause the infected person(s) to explode! Treatments are included in the case of accidental self-infection."
 	reference = "GBS"
 	item = /obj/item/weapon/storage/box/syndie_kit/gbskit
-	cost = 20
+	cost = 18
 	job = list("Virologist")
 	hijack_only = TRUE
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -242,3 +242,13 @@
 	for(var/i in 1 to 3)
 		new/obj/item/cardboard_cutout/adaptive(src)
 	new/obj/item/toy/crayon/spraycan(src)
+
+/obj/item/weapon/storage/box/syndie_kit/gbskit
+	name = "GBS Virus Kit"
+
+/obj/item/weapon/storage/box/syndie_kit/gbskit/New()
+	..()
+	new/obj/item/weapon/reagent_containers/glass/bottle/gbs(src)
+	new/obj/item/weapon/reagent_containers/syringe(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/reagent/sulfur(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/diphenhydramine(src)

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -206,6 +206,12 @@
 	desc = "A bottle of the ever-changing quantum hair dye."
 	list_reagents = list("hair_dye" = 50)
 
+/obj/item/weapon/reagent_containers/glass/bottle/reagent/sulfur
+	name = "sulfur bottle"
+	desc = "A small bottle of sulfur."
+	icon_state = "bottle"
+	list_reagents = list("sulfur" = 30)
+
 ////////////////////Traitor Poison Bottle//////////////////////////////
 
 /obj/item/weapon/reagent_containers/glass/bottle/traitor


### PR DESCRIPTION
Adds a hijack-only and virologist-specific syndicate uplink item called the 'GBS Virus Kit'.

The kit costs 18TC and includes a bottle of the 'real' and very dangerous GBS virus, a syringe and two bottles, one of sulfur and one of diphenhydramine (for curing/self-vaccinating).

The description in the uplink is: 

> A kit containing the highly dangerous Gravitokinetic Bipotential SADS+ virus. If not cured in time, it will cause the infected person(s) to explode! Treatments are included in the case of accidental self-infection.

This PR was inspired by a suggestion from @Fox-McCloud.
![foxspeaks](https://user-images.githubusercontent.com/25696538/28017489-62b46a0a-6571-11e7-975b-296c164a3948.png)

:cl:
add: Adds a hijack-only, virologist-only traitor item known as 'GBS Virus Kit', costing 18TC. The kit contains 1 bottle of the GBS virus, a syringe and bottles of sulfur and diphenhydramine for self-vaccinating.

add: Adds a sulfur reagent bottle to the game, for use in this kit.
/ :cl:
