### PR TITLE
New 'Syndicate Water Flower' item for clown traitors 🤡

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -130,7 +130,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/syndiwaterflower
 	name = "Syndicate Water Flower"
-	desc = "A subtly-altered and seemingly innocuous waterflower. Engineered to hold more and dispense a greater quantity of reagents than it's non-altered equivalent. Contains pepper spray as standard."
+	desc = "A subtly-altered and seemingly innocuous waterflower. Engineered to hold more and dispense a greater quantity of reagents than its non-altered equivalent. Contains pepper spray as standard."
 	reference = "SWF"
 	item = /obj/item/weapon/reagent_containers/spray/syndiwaterflower
 	cost = 5

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -133,7 +133,7 @@ var/list/uplink_items = list()
 	desc = "A subtly-altered and seemingly innocuous waterflower. Engineered to hold more and dispense a greater quantity of reagents than its non-altered equivalent. Contains pepper spray as standard."
 	reference = "SWF"
 	item = /obj/item/weapon/reagent_containers/spray/syndiwaterflower
-	cost = 5
+	cost = 2
 	job = list("Clown")
 
 //mime

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -132,7 +132,7 @@ var/list/uplink_items = list()
 	name = "Syndicate Water Flower"
 	desc = "A subtly-altered and seemingly innocuous waterflower. Engineered to hold more and dispense a greater quantity of reagents than its non-altered equivalent. Contains pepper spray as standard."
 	reference = "SWF"
-	item = /obj/item/weapon/reagent_containers/spray/syndiwaterflower
+	item = /obj/item/weapon/reagent_containers/spray/waterflower/syndiwaterflower
 	cost = 2
 	job = list("Clown")
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -128,6 +128,14 @@ var/list/uplink_items = list()
 	cost = 5
 	job = list("Clown")
 
+/datum/uplink_item/jobspecific/syndiwaterflower
+	name = "Syndicate Water Flower"
+	desc = "A subtly-altered and seemingly innocuous waterflower. Engineered to hold more and dispense a greater quantity of reagents than it's non-altered equivalent. Contains pepper spray as standard."
+	reference = "SWF"
+	item = /obj/item/weapon/reagent_containers/spray/syndiwaterflower
+	cost = 5
+	job = list("Clown")
+
 //mime
 /datum/uplink_item/jobspecific/caneshotgun
 	name = "Cane Shotgun + Assassination Darts"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -140,7 +140,7 @@
 //syndicate water flower
 /obj/item/weapon/reagent_containers/spray/syndiwaterflower
 	name = "water flower"
-	desc = "A seemingly innocent sunflower...with a serious twist."
+	desc = "A seemingly innocent sunflower... with a serious twist."
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "sunflower"
 	item_state = "sunflower"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -138,15 +138,14 @@
 	return
 
 //syndicate water flower
-/obj/item/weapon/reagent_containers/spray/syndiwaterflower
-	name = "water flower"
+/obj/item/weapon/reagent_containers/spray/waterflower/syndiwaterflower
 	desc = "A seemingly innocent sunflower... with a serious twist."
-	icon = 'icons/obj/hydroponics/harvest.dmi'
-	icon_state = "sunflower"
-	item_state = "sunflower"
 	amount_per_transfer_from_this = 10
 	volume = 100
 	list_reagents = list("condensedcapsaicin" = 100)
+
+/obj/item/weapon/reagent_containers/spray/waterflower/syndiwaterflower/attack_self(mob/user)
+    ..()
 
 //chemsprayer
 /obj/item/weapon/reagent_containers/spray/chemsprayer

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -137,6 +137,17 @@
 /obj/item/weapon/reagent_containers/spray/waterflower/attack_self(mob/user) //Don't allow changing how much the flower sprays
 	return
 
+//syndicate water flower
+/obj/item/weapon/reagent_containers/spray/syndiwaterflower
+	name = "water flower"
+	desc = "A seemingly innocent sunflower...with a serious twist."
+	icon = 'icons/obj/hydroponics/harvest.dmi'
+	icon_state = "sunflower"
+	item_state = "sunflower"
+	amount_per_transfer_from_this = 10
+	volume = 100
+	list_reagents = list("condensedcapsaicin" = 100)
+
 //chemsprayer
 /obj/item/weapon/reagent_containers/spray/chemsprayer
 	name = "chem sprayer"


### PR DESCRIPTION
Adds a stealthy, clown-only, traitor item called the 'Syndicate Water Flower' to the uplink. 

This item: 
- Costs 2TC.
- Can hold up to 100u of reagents and dispense 5u/10u at a time. Compared with the 10u and 1u, respectively, of the regular water flower.
- Starts off containing 100u of condensed capsaicin (pepper spray).
- Has the same name as and is visually indistinguishable from its non-syndicate equivalent and contains only a subtle difference in description.

The description in the uplink:
> "A subtly-altered and seemingly innocuous waterflower. Engineered to hold more and dispense a greater quantity of reagents than it's non-altered equivalent. Contains pepper spray as standard."

The description of the item:
> "A seemingly innocent sunflower...with a serious twist."

The addition of the word 'serious' is the only difference in the syndicate/non-syndicate water flower description.

The contained regeant is still up for discussion but I thought pepper spray might be the most useful for traitors. Likewise I'm happy to discuss a change in the TC cost.

Time for some serious pranks. HONK! 🤡

🆑
- Adds a clown-only traitor item called the 'Syndicate Water Flower' to the uplink (details above).

/🆑