### PR TITLE
Fixes two minor spelling/grammar issues.

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -202,7 +202,7 @@
 
 /obj/structure/blob/examine(mob/user)
 	..(user)
-	to_chat(user, "It looks like it's of a [get_chem_name()] kind.")
+	to_chat(user, "It looks like it's made of [get_chem_name()].")
 
 
 /obj/structure/blob/proc/get_chem_name()

--- a/nano/templates/poolcontroller.tmpl
+++ b/nano/templates/poolcontroller.tmpl
@@ -13,7 +13,7 @@ Used In File(s): \code\game\machinery\poolcontroller.dm
 
 <div class="item">
 	<div class="itemLabel">
-		Saftey Status:
+		Safety Status:
 	</div>
 	<div class="itemContent">
 		{{if data.emagged}}


### PR DESCRIPTION
Fixes #7599 
Pool controller now reads "Safety" instead of "Saftey"

Fixes #7530 
Tweaked the description of the blob to no longer rely on "a" or "an".

🆑 Birdtalon
fix: Pool contractors have been back to school and can now spell "safety" on the controller correctly.
tweak: Minor change to blob description to address grammar issue.
/🆑