### PR TITLE
SQL version control

### DIFF
--- a/SQL/updates/Readme.md
+++ b/SQL/updates/Readme.md
@@ -1,0 +1,7 @@
+### UPDATING SQL
+The contents of this directory contain update sql scripts for the paracode SQL database.
+
+Files following the naming convention <old number>-<new number>.sql
+Files are designed to be run sequentialy, moving from version 2, to version 4 would require running the following SQL scripts.
+2-3.sql
+3-4.sql

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -347,3 +347,6 @@
 #define BLOOD_STATE_HUMAN			"blood"
 #define BLOOD_STATE_XENO			"xeno"
 #define BLOOD_STATE_NOT_BLOODY		"no blood whatsoever"
+
+// The SQL version required by this version of the code
+#define SQL_VERSION 0

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -667,6 +667,7 @@
 
 /datum/configuration/proc/loadsql(filename)  // -- TLE
 	var/list/Lines = file2list(filename)
+	var/db_version = 0
 	for(var/t in Lines)
 		if(!t)	continue
 
@@ -704,8 +705,18 @@
 				sqlfdbkpass = value
 			if("feedback_tableprefix")
 				sqlfdbktableprefix = value
+			if("db_version")
+				db_version = text2num(value)
 			else
 				diary << "Unknown setting in configuration: '[name]'"
+	if(config.sql_enabled && db_version != SQL_VERSION)
+		config.sql_enabled = 0
+		diary << "WARNING: DB_CONFIG DEFINITION MISMATCH!"
+		spawn(60)
+			if(ticker.current_state == GAME_STATE_PREGAME)
+				going = 0
+				spawn(600)
+					to_chat(world, "<span class='alert'>DB_CONFIG MISMATCH, ROUND START DELAYED. <BR>Please check database version for recent upstream changes!</span>")
 
 /datum/configuration/proc/loadoverflowwhitelist(filename)
 	var/list/Lines = file2list(filename)

--- a/config/example/dbconfig.txt
+++ b/config/example/dbconfig.txt
@@ -5,6 +5,12 @@
 ## Should SQL be enabled? Uncomment to enable.
 #SQL_ENABLED
 
+## Database version.  This value is used if SQL_ENABLED is uncommented
+## This value must be set to the version of the paradise schema in use.
+## If this value does not match, the SQL database will not be loaded and an error will be generated.
+## Roundstart will be delayed.
+DB_VERSION 0
+
 ## Server the MySQL database can be found at.
 # Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.
 ADDRESS localhost


### PR DESCRIPTION
This PR adds a simple version control mechanism for SQL updates.

Each PR that updates the SQL database increments the defined sql version by +1, replaces the base sql files in /sql, and places an update script in /sql/updates.

If a server operator fails to notice the update and is using the SQL backend, the round start will be delayed and after a delay, a message informing all online of the issue will be broadcast.  Acknowledgement of the update is performed by incrementing the variable added to dbconfig

This message is not limited to admins, as without an admin config file, no admins may have their admin rights properly assigned when the server starts.