### PR TITLE
Emote limiting

### DIFF
--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -9,6 +9,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	materials = list(MAT_METAL=10000, MAT_GLASS=2500)
 	var/code = 2
+	var/sonic = 0
 
 	is_special = 1
 
@@ -70,12 +71,12 @@
 	else if(href_list["power"])
 		on = !on
 
+	else if(href_list["sonic"])
+		sonic = !sonic
+
 	add_fingerprint(usr)
 
-/obj/item/device/radio/electropack/receive_signal(datum/signal/signal)
-	if(!signal || signal.encryption != code)
-		return
-
+/obj/item/device/radio/electropack/proc/do_shock()
 	if(ismob(loc) && on)
 		var/mob/M = loc
 		var/turf/T = M.loc
@@ -92,7 +93,14 @@
 		s.start()
 
 		M.Weaken(5)
+		M.Stuttering(1)
+		M.Jitter(20)
 
+
+/obj/item/device/radio/electropack/receive_signal(datum/signal/signal)
+	if(!signal || signal.encryption != code)
+		return
+	do_shock()
 	if(master)
 		master.receive_signal()
 	return
@@ -111,5 +119,6 @@
 	data["power"] = on
 	data["freq"] = format_frequency(frequency)
 	data["code"] = code
+	data["sonic"] = sonic
 
 	return data

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -9,7 +9,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	materials = list(MAT_METAL=10000, MAT_GLASS=2500)
 	var/code = 2
-	var/sonic = 0
+	var/noise_suppression = FALSE
 
 	is_special = 1
 
@@ -71,8 +71,8 @@
 	else if(href_list["power"])
 		on = !on
 
-	else if(href_list["sonic"])
-		sonic = !sonic
+	else if(href_list["noise_suppression"])
+		noise_suppression = !noise_suppression
 
 	add_fingerprint(usr)
 
@@ -119,6 +119,6 @@
 	data["power"] = on
 	data["freq"] = format_frequency(frequency)
 	data["code"] = code
-	data["sonic"] = sonic
+	data["noise_suppression"] = noise_suppression
 
 	return data

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -37,7 +37,7 @@
 			if(species.name == "Drask")		//Only Drask can make whale noises
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
 			else
-				return				
+				return
 		if("howl", "howls")
 			if (species.name == "Vulpkanin")		//Only Vulpkanin can howl
 				on_CD = handle_emote_CD(100)
@@ -47,7 +47,7 @@
 			if (species.name == "Vulpkanin")		//Only Vulpkanin can growl
 				on_CD = handle_emote_CD()
 			else
-				return				
+				return
 		if("squish", "squishes")
 			var/found_slime_bodypart = 0
 
@@ -101,11 +101,18 @@
 		if("me")									//OKAY SO RANT TIME, THIS FUCKING HAS TO BE HERE OR A SHITLOAD OF THINGS BREAK
 			return custom_emote(m_type, message)	//DO YOU KNOW WHY SHIT BREAKS? BECAUSE SO MUCH OLDCODE CALLS mob.emote("me",1,"whatever_the_fuck_it_wants_to_emote")
 													//WHO THE FUCK THOUGHT THAT WAS A GOOD FUCKING IDEA!?!?
-													
+
 		if("howl", "howls")
 			var/M = handle_emote_param(param) //Check to see if the param is valid (mob with the param name is in view).
-			message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
-			playsound(loc, 'sound/goonstation/voice/howl.ogg', 100, 0, 10)
+			if(!muzzled)
+				message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
+				playsound(loc, 'sound/goonstation/voice/howl.ogg', 100, 0, 10)
+				if(src.back && istype(src.back, /obj/item/device/radio/electropack))
+					var/obj/item/device/radio/electropack/E = src.back
+					if(E.sonic)
+						E.do_shock()
+			else
+				message = "<B>[src]</B> makes an odd animal like noise."
 			m_type = 2
 
 		if("growl", "growls")
@@ -113,7 +120,7 @@
 			message = "<B>[src]</B> growls[M ? " at [M]" : ""]."
 			playsound(loc, "growls", 80, 0)
 			m_type = 2
-			
+
 		if("ping", "pings")
 			var/M = handle_emote_param(param)
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1,3 +1,9 @@
+/mob/living/carbon/human/proc/emote_zap()
+	if(src.back && istype(src.back, /obj/item/device/radio/electropack))
+		var/obj/item/device/radio/electropack/E = src.back
+		if(E.sonic)
+			E.do_shock()
+
 /mob/living/carbon/human/emote(var/act,var/m_type=1,var/message = null,var/force)
 
 	if(stat == DEAD)
@@ -107,14 +113,10 @@
 			if(!muzzled)
 				message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
 				playsound(loc, 'sound/goonstation/voice/howl.ogg', 100, 0, 10)
-				if(src.back && istype(src.back, /obj/item/device/radio/electropack))
-					var/obj/item/device/radio/electropack/E = src.back
-					if(E.sonic)
-						E.do_shock()
 			else
 				message = "<B>[src]</B> makes an odd animal like noise."
 			m_type = 2
-
+			emote_zap()
 		if("growl", "growls")
 			var/M = handle_emote_param(param)
 			message = "<B>[src]</B> growls[M ? " at [M]" : ""]."
@@ -162,6 +164,7 @@
 			message = "<B>[src]</B> squishes[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/effects/slime_squish.ogg', 50, 0) //Credit to DrMinky (freesound.org) for the sound.
 			m_type = 2
+			emote_zap()
 
 		if("clack", "clacks")
 			var/M = handle_emote_param(param)
@@ -744,6 +747,7 @@
 						playsound(loc, "[species.female_scream_sound]", 80, 1, 0, pitch = get_age_pitch())
 					else
 						playsound(loc, "[species.male_scream_sound]", 80, 1, 0, pitch = get_age_pitch()) //default to male screams if no gender is present.
+					emote_zap()
 
 				else
 					message = "<B>[src]</B> makes a very loud noise[M ? " at [M]" : ""]."

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human/proc/emote_zap()
-	if(src.back && istype(src.back, /obj/item/device/radio/electropack))
-		var/obj/item/device/radio/electropack/E = src.back
-		if(E.sonic)
+	if(back && istype(back, /obj/item/device/radio/electropack))
+		var/obj/item/device/radio/electropack/E = back
+		if(E.noise_suppression)
 			E.do_shock()
 
 /mob/living/carbon/human/emote(var/act,var/m_type=1,var/message = null,var/force)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -129,6 +129,7 @@
 			message = "<B>[src]</B> pings[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/machines/ping.ogg', 50, 0)
 			m_type = 2
+			emote_zap()
 
 		if("buzz2")
 			var/M = handle_emote_param(param)
@@ -136,6 +137,7 @@
 			message = "<B>[src]</B> emits an irritated buzzing sound[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/machines/buzz-two.ogg', 50, 0)
 			m_type = 2
+			emote_zap()
 
 		if("buzz", "buzzes")
 			var/M = handle_emote_param(param)
@@ -143,6 +145,7 @@
 			message = "<B>[src]</B> buzzes[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/machines/buzz-sigh.ogg', 50, 0)
 			m_type = 2
+			emote_zap()
 
 		if("beep", "beeps")
 			var/M = handle_emote_param(param)
@@ -150,6 +153,7 @@
 			message = "<B>[src]</B> beeps[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/machines/twobeep.ogg', 50, 0)
 			m_type = 2
+			emote_zap()
 
 		if("drone", "drones", "hum", "hums", "rumble", "rumbles")
 			var/M = handle_emote_param(param)
@@ -157,6 +161,7 @@
 			message = "<B>[src]</B> [M ? "drones at [M]" : "rumbles"]."
 			playsound(loc, 'sound/voice/DraskTalk.ogg', 50, 0)
 			m_type = 2
+			emote_zap()
 
 		if("squish", "squishes")
 			var/M = handle_emote_param(param)
@@ -172,6 +177,7 @@
 			message = "<B>[src]</B> clacks their mandibles[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/effects/Kidanclack.ogg', 50, 0) //Credit to DrMinky (freesound.org) for the sound.
 			m_type = 2
+			emote_zap()
 
 		if("click", "clicks")
 			var/M = handle_emote_param(param)
@@ -179,6 +185,7 @@
 			message = "<B>[src]</B> clicks their mandibles[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/effects/Kidanclack2.ogg', 50, 0) //Credit to DrMinky (freesound.org) for the sound.
 			m_type = 2
+			emote_zap()
 
 		if("hiss", "hisses")
 			var/M = handle_emote_param(param)
@@ -186,6 +193,7 @@
 			message = "<B>[src]</B> hisses[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/effects/unathihiss.ogg', 50, 0) //Credit to Jamius (freesound.org) for the sound.
 			m_type = 2
+			emote_zap()
 
 		if("yes")
 			var/M = handle_emote_param(param)
@@ -193,6 +201,7 @@
 			message = "<B>[src]</B> emits an affirmative blip[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/machines/synth_yes.ogg', 50, 0)
 			m_type = 2
+			emote_zap()
 
 		if("no")
 			var/M = handle_emote_param(param)
@@ -200,6 +209,7 @@
 			message = "<B>[src]</B> emits a negative blip[M ? " at [M]" : ""]."
 			playsound(loc, 'sound/machines/synth_no.ogg', 50, 0)
 			m_type = 2
+			emote_zap()
 
 		if("wag", "wags")
 			if(body_accessory)
@@ -393,6 +403,7 @@
 					else
 						if(species.male_cough_sounds)
 							playsound(src, pick(species.male_cough_sounds), 120)
+					emote_zap()
 				else
 					message = "<B>[src]</B> makes a strong noise."
 					m_type = 2
@@ -637,6 +648,7 @@
 					else
 						playsound(src, species.male_sneeze_sound, 70)
 					m_type = 2
+					emote_zap()
 				else
 					message = "<B>[src]</B> makes a strange noise."
 					m_type = 2
@@ -748,7 +760,6 @@
 					else
 						playsound(loc, "[species.male_scream_sound]", 80, 1, 0, pitch = get_age_pitch()) //default to male screams if no gender is present.
 					emote_zap()
-
 				else
 					message = "<B>[src]</B> makes a very loud noise[M ? " at [M]" : ""]."
 					m_type = 2

--- a/nano/templates/radio_electro.tmpl
+++ b/nano/templates/radio_electro.tmpl
@@ -41,7 +41,7 @@ Used In File(s): /code/game/objects/item/devices/radio/electropack.dm
 		Sonic Supression
 	</div>
 	<div class="itemContent">
-		{{:helper.link('On', null, {'sonic' : 1}, data.sonic ? 'selected' : null)}}
-		{{:helper.link('Off', null, {'sonic' : 1}, data.sonic ? null : 'selected')}}
+		{{:helper.link('On', null, {'noise_suppression' : 1}, data.noise_suppression ? 'selected' : null)}}
+		{{:helper.link('Off', null, {'noise_suppression' : 1}, data.noise_suppression ? null : 'selected')}}
 	</div>
 </div>

--- a/nano/templates/radio_electro.tmpl
+++ b/nano/templates/radio_electro.tmpl
@@ -35,3 +35,13 @@ Used In File(s): /code/game/objects/item/devices/radio/electropack.dm
 		{{:helper.link('++', null, {'code' : 5})}}
 	</div>
 </div>
+
+<div class="item">
+	<div class="itemLabel">
+		Sonic Supression
+	</div>
+	<div class="itemContent">
+		{{:helper.link('On', null, {'sonic' : 1}, data.sonic ? 'selected' : null)}}
+		{{:helper.link('Off', null, {'sonic' : 1}, data.sonic ? null : 'selected')}}
+	</div>
+</div>


### PR DESCRIPTION
This PR provides two ways to limit the use of the *howl emote by Vulpkanin.

Vulpkanin are not able to howl when muzzled.

Electropacks now come with a "Sound Suppression" option, any howling, screaming, or squishing done while fitted with a sound suppression enabled electropack will result in an electric shock.

🆑 Alffd
tweak: Vulpkanin cannot howl while muzzled
add: Electropacks now come with an anti-vocalization features.
/🆑