### PR TITLE
Shotgun darts are no longer noreact like cryobeakers

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -248,7 +248,6 @@
 	..()
 	flags |= OPENCONTAINER
 	create_reagents(30)
-	reagents.set_reacting(FALSE)
 
 /obj/item/ammo_casing/shotgun/dart/attackby()
 	return


### PR DESCRIPTION
Currently, it is possible to load shotgun darts with the components of azide, and then shoot people. This results in them exploding, typically losing their hands. Hardsuits don't protect against this. It is one-shot weapon that blows limbs off, and no armor protects against it, not even armored hardsuits. I've even heard reports that it works as explosive ammo against borgs.

This PR changes shotgun darts so that they are no longer function like cryobeakers. IE: you can still use them to force reagents into people through hardsuits... but you can't rely on them to safely hold reagents which *should* explode when mixed.

🆑 Kyep
tweak: Reagents placed in shotgun shells will now react. It is no longer possible to make explosive shotgun darts by using regular darts like cryobeakers.
/🆑