### PR TITLE
Door access fix for pet's wearing collars

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -77,8 +77,14 @@
 		var/mob/living/M = AM
 		if(world.time - M.last_bumped <= 10) return	//Can bump-open one airlock per second. This is to prevent shock spam.
 		M.last_bumped = world.time
-		if(!M.restrained() && M.mob_size > MOB_SIZE_SMALL)
-			bumpopen(M)
+		if(!M.restrained())
+			if(istype(AM, /mob/living/simple_animal))
+				var/mob/living/simple_animal/A = AM
+				if(ispet(AM) && A.collar)
+					bumpopen(M)
+			else
+				if(M.mob_size > MOB_SIZE_SMALL)
+					bumpopen(M)
 		return
 
 	if(istype(AM, /obj/mecha))


### PR DESCRIPTION
Changes in door.dm
* if check to determine if a pet animal that is collarable and has a collar is attempting to bumpopen a door, and if so, lets them. All other small animals are still unable to do so.

:cl: matt81093
fix: Pets with collars are now able to bump open doors with appropriate access; keeps previous behavior
tweak: /Bumbed() now checked if the mob is restrained, as usual, then if they are a simple_animal that is a pet and has a collar let them try to bump open doors, otherwise follows previous behavior of only letting mobs larger than small bump doors.
/ :cl: