### PR TITLE
Fixes mech missile launchers

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -237,7 +237,7 @@
 		pulledby.stop_pulling()
 
 	// They are moving! Wouldn't it be cool if we calculated their momentum and added it to the throw?
-	if(thrower && thrower.last_move && isliving(thrower) && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
+	if(thrower && thrower.last_move && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
 		var/user_momentum = thrower.movement_delay()
 		if(!user_momentum) // no movement_delay, this means they move once per byond tick, let's calculate from that instead
 			user_momentum = world.tick_lag

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -237,7 +237,7 @@
 		pulledby.stop_pulling()
 
 	// They are moving! Wouldn't it be cool if we calculated their momentum and added it to the throw?
-	if(thrower && thrower.last_move && !istype(thrower, /obj/mecha) && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
+	if(thrower && thrower.last_move && isliving(thrower) && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
 		var/user_momentum = thrower.movement_delay()
 		if(!user_momentum) // no movement_delay, this means they move once per byond tick, let's calculate from that instead
 			user_momentum = world.tick_lag

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -237,7 +237,7 @@
 		pulledby.stop_pulling()
 
 	// They are moving! Wouldn't it be cool if we calculated their momentum and added it to the throw?
-	if(thrower && thrower.last_move && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
+	if(thrower && thrower.last_move && !istype(thrower, /obj/mecha) && thrower.client && thrower.client.move_delay >= world.time + world.tick_lag * 2)
 		var/user_momentum = thrower.movement_delay()
 		if(!user_momentum) // no movement_delay, this means they move once per byond tick, let's calculate from that instead
 			user_momentum = world.tick_lag

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -348,7 +348,7 @@
 	if(heavy_missile)
 		M.heavy_missile = 1
 	playsound(chassis, fire_sound, 50, 1)
-	M.throw_at(target, missile_range, missile_speed, chassis)
+	M.throw_at(target, missile_range, missile_speed)
 	projectiles--
 	log_message("Fired from [name], targeting [target].")
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
🆑 Kyep
fix: Mechs firing missiles no longer cause the missiles to drop at their feet, as if frozen in midair.
/🆑

Fixes #7575 

The problem was a runtime:
[02:52:45] Runtime in atoms_movable.dm,240: undefined variable /obj/mecha/combat/marauder/seraph/loaded/var/client
   proc name: throw at (/atom/movable/proc/throw_at)

It was caused by the fact the throw_at proc assumes that the thrower is something that can have a client. Rather than giving clients to mechs, I simply made it not calculate momentum for mech-launched weapons. Mech launchers are probably powered anyway, and can only face forward, so it doesn't really make sense for them to have momentum anyway.
