### PR TITLE
Makes HONK Rifle selfcharge

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -273,6 +273,7 @@
 	icon_state = "disabler"
 	ammo_type = list(/obj/item/ammo_casing/energy/clown)
 	clumsy_check = 0
+	selfcharge = 1
 	ammo_x_offset = 3
 
 /obj/item/weapon/gun/energy/toxgun


### PR DESCRIPTION
HONK Rifle is currently kinda underwhelming, you can only use it so much before you run out of ammo, and the clown/HONK squad has no easy access to rechargers. All the HONK Rifle does is shoot snap pops, completely safe so there's not much of a balance issue here.

🆑 imsxz
tweak: makes HONK rifle selfcharge
/🆑 