### PR TITLE
Refactors Species Flags into Species Traits List

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -22,46 +22,26 @@
 //Reagent flags
 #define REAGENT_NOREACT			1
 
-//Species flags.
-
-#define NO_BLOOD		1
-#define NO_BREATHE 		2
-#define NO_DNA			4
-#define NO_SCAN 		8
-#define NO_PAIN 		16
-#define IS_WHITELISTED 	32
-#define HAS_LIPS 		64
-#define IS_PLANT 		128
-#define CAN_BE_FAT 		256
-#define NO_INTORGANS	512
-#define RADIMMUNE		1024
-#define ALL_RPARTS		2048
-#define NOGUNS			4096
-#define NOTRANSSTING	8192
-
 //Species clothing flags
 #define HAS_UNDERWEAR 	1
 #define HAS_UNDERSHIRT 	2
 #define HAS_SOCKS		4
 
 //Species Body Flags
-#define FEET_CLAWS			1
-#define FEET_PADDED			2
-#define FEET_NOSLIP			4
-#define HAS_HEAD_ACCESSORY	8
-#define HAS_TAIL 			16
-#define TAIL_OVERLAPPED		32
-#define HAS_SKIN_TONE 		64
-#define HAS_ICON_SKIN_TONE	128
-#define HAS_SKIN_COLOR		256
-#define HAS_HEAD_MARKINGS	512
-#define HAS_BODY_MARKINGS	1024
-#define HAS_TAIL_MARKINGS	2048
+#define HAS_HEAD_ACCESSORY	1
+#define HAS_TAIL 			2
+#define TAIL_OVERLAPPED		4
+#define HAS_SKIN_TONE 		8
+#define HAS_ICON_SKIN_TONE	16
+#define HAS_SKIN_COLOR		32
+#define HAS_HEAD_MARKINGS	64
+#define HAS_BODY_MARKINGS	128
+#define HAS_TAIL_MARKINGS	256
 #define HAS_MARKINGS		HAS_HEAD_MARKINGS|HAS_BODY_MARKINGS|HAS_TAIL_MARKINGS
-#define TAIL_WAGGING    	4096
-#define NO_EYES				8192
-#define HAS_FUR				16384
-#define HAS_ALT_HEADS		32768
+#define TAIL_WAGGING    	512
+#define NO_EYES				1024
+#define HAS_ALT_HEADS		2048
+#define ALL_RPARTS			4096
 
 //Species Diet Flags
 #define DIET_CARN		1

--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -133,3 +133,4 @@
 #define RADIMMUNE		10
 #define NOGUNS			11
 #define NOTRANSSTING	12
+#define VIRUSIMMUNE		13

--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -122,15 +122,16 @@
 //Species traits.
 
 #define IS_WHITELISTED 	1
-#define NO_BLOOD		2
-#define NO_BREATHE 		3
-#define NO_DNA			4
-#define NO_SCAN 		5
-#define NO_PAIN 		6
-#define IS_PLANT 		7
-#define CAN_BE_FAT 		8
-#define NO_INTORGANS	9
-#define RADIMMUNE		10
-#define NOGUNS			11
-#define NOTRANSSTING	12
-#define VIRUSIMMUNE		13
+#define LIPS			2
+#define NO_BLOOD		3
+#define NO_BREATHE 		4
+#define NO_DNA			5
+#define NO_SCAN 		6
+#define NO_PAIN 		7
+#define IS_PLANT 		8
+#define CAN_BE_FAT 		9
+#define NO_INTORGANS	10
+#define RADIMMUNE		11
+#define NOGUNS			12
+#define NOTRANSSTING	13
+#define VIRUSIMMUNE		14

--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -118,3 +118,18 @@
 
 #define CLONER_FRESH_CLONE "fresh"
 #define CLONER_MATURE_CLONE "mature"
+
+//Species traits.
+
+#define IS_WHITELISTED 	1
+#define NO_BLOOD		2
+#define NO_BREATHE 		3
+#define NO_DNA			4
+#define NO_SCAN 		5
+#define NO_PAIN 		6
+#define IS_PLANT 		7
+#define CAN_BE_FAT 		8
+#define NO_INTORGANS	9
+#define RADIMMUNE		10
+#define NOGUNS			11
+#define NOTRANSSTING	12

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -45,7 +45,7 @@
 		S.race_key = ++rkey //Used in mob icon caching.
 		all_species[S.name] = S
 
-		if(S.flags & IS_WHITELISTED)
+		if(IS_WHITELISTED in S.species_traits)
 			whitelisted_species += S.name
 
 	init_subtypes(/datum/crafting_recipe, crafting_recipes)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -381,12 +381,7 @@ var/record_id_num = 1001
 			preview_icon.Blend(rgb(H.s_tone, H.s_tone, H.s_tone), ICON_ADD)
 		else
 			preview_icon.Blend(rgb(-H.s_tone,  -H.s_tone,  -H.s_tone), ICON_SUBTRACT)
-/* Commented out due to broken-ness, see below comment
-	// Skin color
-	if(H.species.flags & HAS_SKIN_TONE)
-		if(!H.species || H.species.flags & HAS_SKIN_COLOR)
-			preview_icon.Blend(rgb(H.r_skin, H.g_skin, H.b_skin), ICON_ADD)
-*/
+
 	// Proper Skin color - Fix, you can't have HAS_SKIN_TONE *and* HAS_SKIN_COLOR
 	if(H.species.bodyflags & HAS_SKIN_COLOR)
 		preview_icon.Blend(rgb(H.r_skin, H.g_skin, H.b_skin), ICON_ADD)

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -134,7 +134,7 @@
 
 
 /mob/living/carbon/human/CanContractDisease(datum/disease/D)
-	if(species.virus_immune && !D.bypasses_immunity)
+	if((VIRUSIMMUNE in species.species_traits) && !D.bypasses_immunity)
 		return 0
 	for(var/thing in D.required_organs)
 		if(!((locate(thing) in bodyparts) || (locate(thing) in internal_organs)))

--- a/code/game/dna/dna2_domutcheck.dm
+++ b/code/game/dna/dna2_domutcheck.dm
@@ -16,7 +16,7 @@
 /proc/genemutcheck(var/mob/living/M, var/block, var/connected=null, var/flags=0)
 	if(ishuman(M)) // Would've done this via species instead of type, but the basic mob doesn't have a species, go figure.
 		var/mob/living/carbon/human/H = M
-		if(H.species.flags & NO_DNA)
+		if(NO_DNA in H.species.species_traits)
 			return
 	if(!M)
 		return

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -224,11 +224,8 @@
 	var/red = GetUIValueRange(DNA_UI_EYES_R,	255)
 	var/green = GetUIValueRange(DNA_UI_EYES_G,	255)
 	var/blue = GetUIValueRange(DNA_UI_EYES_B,	255)
-	eyes_organ.eye_colour = list(
-	red,
-	green,
-	blue
-	)
+	if(eyes_organ)
+		eyes_organ.eye_colour = list(red, green, blue)
 
 /*
 	TRAIT CHANGING PROCS

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -327,7 +327,7 @@
 
 	if(ishuman(occupant))
 		var/mob/living/carbon/human/H = occupant
-		if((H.species.flags & NO_DNA))
+		if(NO_DNA in H.species.species_traits)
 			return 1
 
 	var/radiation_protection = occupant.run_armor_check(null, "rad", "Your clothes feel warm.", "Your clothes feel warm.")

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -44,7 +44,7 @@
 		return 0
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.species && H.species.flags & RADIMMUNE && !(flags & MUTCHK_FORCED))
+		if((RADIMMUNE in H.species.species_traits) && !(flags & MUTCHK_FORCED))
 			return 0
 	return 1
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -307,7 +307,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		to_chat(user, "<span class='warning'>DNA of [target] is ruined beyond usability!</span>")
 		return
 
-	if(T.species.flags & NO_DNA)
+	if(NO_DNA in T.species.species_traits)
 		to_chat(user, "<span class='warning'>This creature does not have DNA!</span>")
 		return
 
@@ -317,4 +317,4 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	return 1
 
 /proc/can_absorb_species(datum/species/S)
-  return !(S.flags & NO_DNA)
+	return !(NO_DNA in S.species_traits)

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -17,7 +17,7 @@
 	if((NOCLONE || SKELETON || HUSK) in target.mutations)
 		to_chat(user, "<span class='warning'>DNA of [target] is ruined beyond usability!</span>")
 		return
-	if(!istype(target) || issmall(target) || target.species.flags & NO_DNA)
+	if(!istype(target) || issmall(target) || NO_DNA in target.species.species_traits)
 		to_chat(user, "<span class='warning'>[target] is not compatible with this ability.</span>")
 		return
 	return 1

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -81,7 +81,7 @@
 	if(!selected_dna)
 		return
 	var/datum/species/newspecies = all_species[selected_dna.species]
-	if((newspecies.flags & NOTRANSSTING) || newspecies.is_small)
+	if((NOTRANSSTING in newspecies.species_traits) || newspecies.is_small)
 		to_chat(user, "<span class='warning'>The selected DNA is incompatible with our sting.</span>")
 		return
 	..()
@@ -94,7 +94,7 @@
 		return FALSE
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		if(H.species.flags & NO_DNA)
+		if(NO_DNA in H.species.species_traits)
 			to_chat(user, "<span class='warning'>This won't work on a creature without DNA.</span>")
 			return FALSE
 	return TRUE

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -43,13 +43,14 @@
 	embed_chance = 75
 	var/cooldown = 0
 
-/obj/item/weapon/melee/cultblade/dagger/afterattack(mob/living/target as mob, mob/living/carbon/human/user as mob)
+/obj/item/weapon/melee/cultblade/dagger/afterattack(atom/target, mob/living/carbon/human/user)
 	..()
-	var/mob/living/carbon/human/bleeder = target
-	if(!(cooldown > world.time) && ((bleeder.stat != DEAD) && !(NO_BLOOD in bleeder.species.species_traits)))
-		user.visible_message("<span class='danger'>The runes on the blade absorb the blood of [target]!</span>")
-		bleeder.bleed(5000)
-		cooldown = world.time + 2400
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(!(cooldown > world.time) && ((H.stat != DEAD) && !(NO_BLOOD in H.species.species_traits)))
+			user.visible_message("<span class='danger'>The runes on the blade absorb the blood of [H]!</span>")
+			H.bleed(5000)
+			cooldown = world.time + 2400
 
 /obj/item/weapon/restraints/legcuffs/bola/cult
 	name = "runed bola"

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -46,7 +46,7 @@
 /obj/item/weapon/melee/cultblade/dagger/afterattack(mob/living/target as mob, mob/living/carbon/human/user as mob)
 	..()
 	var/mob/living/carbon/human/bleeder = target
-	if(!(cooldown > world.time) && ((bleeder.stat != DEAD) && !(bleeder.species.flags & NO_BLOOD)))
+	if(!(cooldown > world.time) && ((bleeder.stat != DEAD) && !(NO_BLOOD in bleeder.species.species_traits)))
 		user.visible_message("<span class='danger'>The runes on the blade absorb the blood of [target]!</span>")
 		bleeder.bleed(5000)
 		cooldown = world.time + 2400

--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -37,7 +37,7 @@
 
 /datum/surgery_step/internal/extract_organ/end_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/carbon/human/AB = target
-	if(AB.species.flags & NO_INTORGANS)
+	if(NO_INTORGANS in AB.species.species_traits)
 		user.visible_message("[user] prepares [target]'s [target_zone] for further dissection!", "<span class='notice'>You prepare [target]'s [target_zone] for further dissection.</span>")
 		return 1
 	if(IC)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -287,7 +287,7 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) \
 	for(var/datum/mind/possible_target in ticker.minds)
 		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && possible_target.current.client)
 			var/mob/living/carbon/human/H = possible_target.current
-			if(!(H.species.flags & NO_DNA))
+			if(!(NO_DNA in H.species.species_traits))
 				possible_targets += possible_target
 	if(possible_targets.len > 0)
 		target = pick(possible_targets)
@@ -457,7 +457,7 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) \
 					n_p++
 		else if(ticker.current_state == GAME_STATE_PLAYING)
 			for(var/mob/living/carbon/human/P in player_list)
-				if(P.species.flags & NO_DNA)
+				if(NO_DNA in P.species.species_traits)
 					continue
 				if(P.client && !(P.mind in ticker.mode.changelings) && P.mind!=owner)
 					n_p++

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -305,7 +305,7 @@ Made by Xhuis
 	blood_color = "#555555"
 	flesh_color = "#222222"
 
-	flags = NO_BLOOD | NO_BREATHE | RADIMMUNE | NOGUNS //Can't use guns due to muzzle flash
+	species_traits = list(NO_BLOOD, NO_BREATHE, RADIMMUNE, NOGUNS) //Can't use guns due to muzzle flash
 	burn_mod = 1.5 //1.5x burn damage, 2x is excessive
 	oxy_mod = 0
 	hot_env_multiplier = 1.5
@@ -346,7 +346,7 @@ Made by Xhuis
 	blood_color = "#CCCCCC"
 	flesh_color = "#AAAAAA"
 
-	flags = NO_BLOOD | NO_BREATHE | RADIMMUNE
+	species_traits = list(NO_BLOOD, NO_BREATHE, RADIMMUNE)
 	burn_mod = 1.1
 	oxy_mod = 0
 	hot_env_multiplier = 1.1

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -92,7 +92,7 @@
 	if(filtering > 0)
 		if(beaker)
 			// To prevent runtimes from drawing blood from runtime, and to prevent getting IPC blood.
-			if(!istype(occupant) || !occupant.dna || (occupant.species && occupant.species.flags & NO_BLOOD))
+			if(!istype(occupant) || !occupant.dna || (NO_BLOOD in occupant.species.species_traits))
 				filtering = 0
 				return
 
@@ -197,7 +197,7 @@
 		crisis = (occupant.health < min_health)
 		// I'm not sure WHY you'd want to put a simple_animal in a sleeper, but precedent is precedent
 		// Runtime is aptly named, isn't she?
-		if(ishuman(occupant) && !(occupant.species && occupant.species.flags & NO_BLOOD))
+		if(ishuman(occupant) && !(NO_BLOOD in occupant.species.species_traits))
 			occupantData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
 			occupantData["hasBlood"] = 1
 			occupantData["bloodLevel"] = round(occupant.blood_volume)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -371,7 +371,7 @@
 
 		var/bloodData[0]
 		bloodData["hasBlood"] = 0
-		if(ishuman(H) && !(H.species && H.species.flags & NO_BLOOD))
+		if(ishuman(H) && !(NO_BLOOD in H.species.species_traits))
 			bloodData["hasBlood"] = 1
 			bloodData["volume"] = H.blood_volume
 			bloodData["percent"] = round(((H.blood_volume / BLOOD_VOLUME_NORMAL)*100))

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -148,7 +148,7 @@
 		occupantData["btCelsius"] = occupant.bodytemperature - T0C
 		occupantData["btFaren"] = ((occupant.bodytemperature - T0C) * (9.0/5.0))+ 32
 
-		if(ishuman(occupant) && !(occupant.species && occupant.species.flags & NO_BLOOD))
+		if(ishuman(occupant) && !(NO_BLOOD in occupant.species.species_traits))
 			occupantData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
 			occupantData["hasBlood"] = 1
 			occupantData["bloodLevel"] = round(occupant.blood_volume)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -356,7 +356,7 @@
 		return
 	if(scan_brain && !can_brainscan())
 		return
-	if((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna) || (subject.species.flags & NO_SCAN))
+	if((isnull(subject)) || (!(ishuman(subject))) || (!subject.dna) || (NO_SCAN in subject.species.species_traits))
 		scantemp = "<span class=\"bad\">Error: Unable to locate valid genetic data.</span>"
 		nanomanager.update_uis(src)
 		return
@@ -364,7 +364,7 @@
 		var/obj/item/organ/internal/brain/Brn = subject.get_int_organ(/obj/item/organ/internal/brain)
 		if(istype(Brn))
 			var/datum/species/S = all_species[Brn.dna.species] // stepladder code wooooo
-			if(S.flags & NO_SCAN)
+			if(NO_SCAN in S.species_traits)
 				scantemp = "<span class=\"bad\">Error: Subject's brain is incompatible.</span>"
 				nanomanager.update_uis(src)
 				return
@@ -403,7 +403,7 @@
 		B.dna.check_integrity()
 		R.dna=B.dna.Clone()
 		var/datum/species/S = all_species[R.dna.species]
-		if(S.flags & NO_SCAN)
+		if(NO_SCAN in S.species_traits)
 			extra_info = "Proper genetic interface not found, defaulting to genetic data of the body."
 			R.dna.species = subject.species.name
 		R.id= copytext(md5(B.dna.real_name), 2, 6)

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -93,7 +93,7 @@
 	if(drownee && (drownee.lying || deep_water)) //Mob lying down or water is deep (determined by controller)
 		if(drownee.internal)
 			return //Has internals, no drowning
-		if((drownee.species.flags & NO_BREATHE) || (NO_BREATHE in drownee.mutations))
+		if((NO_BREATHE in drownee.species.species_traits) || (NO_BREATHE in drownee.mutations))
 			return //doesn't breathe, no drowning
 		if(drownee.get_species() == "Skrell" || drownee.get_species() == "Neara")
 			return //fish things don't drown

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -81,7 +81,7 @@
 		return
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if((HULK in H.mutations) || (H.species.flags & NOGUNS))
+		if((HULK in H.mutations) || (NOGUNS in H.species.species_traits))
 			user << "<span class='warning'>Your fingers can't press the button!</span>"
 			return
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -99,7 +99,7 @@
 			if(!get_location_accessible(H, "mouth"))
 				to_chat(user, "<span class='warning'>The mask is in the way.</span>")
 				return
-			if((C.species && C.species.flags & ALL_RPARTS) && robohead.is_monitor) //If the target is of a species that can have prosthetic heads, but the head doesn't support human hair 'wigs'...
+			if((C.species.bodyflags & ALL_RPARTS) && robohead.is_monitor) //If the target is of a species that can have prosthetic heads, but the head doesn't support human hair 'wigs'...
 				to_chat(user, "<span class='warning'>You find yourself disappointed at the appalling lack of facial hair.</span>")
 				return
 			if(C.f_style == "Shaved")
@@ -130,7 +130,7 @@
 			if(!get_location_accessible(H, "head"))
 				to_chat(user, "<span class='warning'>The headgear is in the way.</span>")
 				return
-			if((C.species && C.species.flags & ALL_RPARTS) && robohead.is_monitor) //If the target is of a species that can have prosthetic heads, but the head doesn't support human hair 'wigs'...
+			if((C.species.bodyflags & ALL_RPARTS) && robohead.is_monitor) //If the target is of a species that can have prosthetic heads, but the head doesn't support human hair 'wigs'...
 				to_chat(user, "<span class='warning'>You find yourself disappointed at the appalling lack of hair.</span>")
 				return
 			if(C.h_style == "Bald" || C.h_style == "Balding Hair" || C.h_style == "Skinhead")

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -74,7 +74,7 @@
 		H = M
 
 	spawn(0) //Some mutations have sleeps in them, like monkey
-		if(!(NOCLONE in M.mutations) && !(H && (H.species.flags & NO_DNA))) // prevents drained people from having their DNA changed
+		if(!(NOCLONE in M.mutations) && !(H && (NO_DNA in H.species.species_traits))) // prevents drained people from having their DNA changed
 			var/prev_ue = M.dna.unique_enzymes
 			var/mutflags = 0
 			// UI in syringe.
@@ -113,7 +113,7 @@
 
 	if(ishuman(M)) // Would've done this via species instead of type, but the basic mob doesn't have a species, go figure.
 		var/mob/living/carbon/human/H = M
-		if(H.species.flags & NO_DNA)
+		if(NO_DNA in H.species.species_traits)
 			return 0
 
 	if(!user.IsAdvancedToolUser())

--- a/code/game/objects/items/weapons/dnascrambler.dm
+++ b/code/game/objects/items/weapons/dnascrambler.dm
@@ -24,7 +24,7 @@
 
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if(H.species.flags & NO_DNA)
+			if(NO_DNA in H.species.species_traits)
 				to_chat(user, "<span class='warning'>You failed to inject [M], as they have no DNA to scramble, nor flesh to inject.</span>")
 				return
 

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -58,7 +58,7 @@
 		var/mob/living/carbon/M = AM
 		if(ishuman(M))
 			if(isobj(M:shoes))
-				if((M:shoes.flags&NOSLIP) || (M:species.bodyflags & FEET_NOSLIP))
+				if(M:shoes.flags & NOSLIP)
 					return
 			else
 				to_chat(M, "<span class='warning'>Your feet feel like they're on fire!</span>")

--- a/code/game/objects/items/weapons/scissors.dm
+++ b/code/game/objects/items/weapons/scissors.dm
@@ -38,14 +38,14 @@
 				for(var/i in facial_hair_styles_list)
 					var/datum/sprite_accessory/facial_hair/tmp_facial = facial_hair_styles_list[i]
 					if(C.species.name in tmp_facial.species_allowed)  //If the species is allowed to have the style, add the style to the list. Or, if the character has a prosthetic head, give them the human hair styles.
-						if(C.species.flags & ALL_RPARTS) //If the character is of a species that can have full body prosthetics and their head doesn't suport human hair 'wigs', don't add the style to the list.
+						if(C.species.bodyflags & ALL_RPARTS) //If the character is of a species that can have full body prosthetics and their head doesn't suport human hair 'wigs', don't add the style to the list.
 							if(robohead.is_monitor)
 								to_chat(user, "<span class='warning'>You are unable to find anything on [H]'s face worth cutting. How disappointing.</span>")
 								return
 							continue //If the head DOES support human hair wigs, make sure they don't get monitor-oriented styles.
 						species_facial_hair += i
 					else
-						if(C.species.flags & ALL_RPARTS) //If the target is of a species that can have prosthetic heads, and the head supports human hair 'wigs' AND the hair-style is human-suitable, add it to the list.
+						if(C.species.bodyflags & ALL_RPARTS) //If the target is of a species that can have prosthetic heads, and the head supports human hair 'wigs' AND the hair-style is human-suitable, add it to the list.
 							if(!robohead.is_monitor)
 								if("Human" in tmp_facial.species_allowed)
 									species_facial_hair += i
@@ -61,14 +61,14 @@
 			for(var/i in hair_styles_list)
 				var/datum/sprite_accessory/hair/tmp_hair = hair_styles_list[i]
 				if(C.species.name in tmp_hair.species_allowed) //If the species is allowed to have the style, add the style to the list. Or, if the character has a prosthetic head, give them the human facial hair styles.
-					if(C.species.flags & ALL_RPARTS) //If the character is of a species that can have full body prosthetics and their head doesn't suport human hair 'wigs', don't add the style to the list.
+					if(C.species.bodyflags & ALL_RPARTS) //If the character is of a species that can have full body prosthetics and their head doesn't suport human hair 'wigs', don't add the style to the list.
 						if(robohead.is_monitor)
 							to_chat(user, "<span class='warning'>You are unable to find anything on [H]'s head worth cutting. How disappointing.</span>")
 							return
 						continue //If the head DOES support human hair wigs, make sure they don't get monitor-oriented styles.
 					species_hair += i
 				else
-					if(C.species.flags & ALL_RPARTS) //If the target is of a species that can have prosthetic heads, and the head supports human hair 'wigs' AND the hair-style is human-suitable, add it to the list.
+					if(C.species.bodyflags & ALL_RPARTS) //If the target is of a species that can have prosthetic heads, and the head supports human hair 'wigs' AND the hair-style is human-suitable, add it to the list.
 						if(!robohead.is_monitor)
 							if("Human" in tmp_hair.species_allowed)
 								species_hair += i

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -37,7 +37,7 @@
 
 	// Failing that...
 	if(!(damagetype & BRUTELOSS) && !(damagetype & FIRELOSS) && !(damagetype & TOXLOSS) && !(damagetype & OXYLOSS))
-		if(species.flags & NO_BREATHE)
+		if(NO_BREATHE in species.species_traits)
 			// the ultimate fallback
 			take_overall_damage(max(dmgamt - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0), 0)
 		else

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -351,7 +351,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			dat += "<br>"
 
 
-			if(!(S.flags & ALL_RPARTS))
+			if(!(S.bodyflags & ALL_RPARTS))
 				dat += "<b>Eyes:</b> "
 				dat += "<a href='?_src_=prefs;preference=eyes;task=input'>Color</a> [color_square(r_eyes, g_eyes, b_eyes)]<br>"
 
@@ -827,7 +827,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 /datum/preferences/proc/ShowDisabilityState(mob/user,flag,label)
 	var/datum/species/S = all_species[species]
-	if(flag==DISABILITY_FLAG_FAT && !(S.flags & CAN_BE_FAT))
+	if(flag==DISABILITY_FLAG_FAT && !(CAN_BE_FAT in S.species_traits))
 		return "<li><i>[species] cannot be fat.</i></li>"
 	return "<li><b>[label]:</b> <a href=\"?_src_=prefs;task=input;preference=disabilities;disability=[flag]\">[disabilities & flag ? "Yes" : "No"]</a></li>"
 
@@ -1089,7 +1089,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			if("input")
 				var/dflag=text2num(href_list["disability"])
 				if(dflag >= 0)
-					if(!(dflag==DISABILITY_FLAG_FAT && !(S.flags & CAN_BE_FAT))) //If the disability isn't fatness, toggle it. If it IS fatness, check to see if the species can be fat before going ahead.
+					if(!(dflag==DISABILITY_FLAG_FAT && !(CAN_BE_FAT in S.species_traits))) //If the disability isn't fatness, toggle it. If it IS fatness, check to see if the species can be fat before going ahead.
 						disabilities ^= text2num(href_list["disability"]) //MAGIC
 				SetDisabilities(user)
 			else
@@ -1175,7 +1175,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	switch(href_list["task"])
 		if("random")
 			var/datum/robolimb/robohead
-			if(S.flags & ALL_RPARTS)
+			if(S.bodyflags & ALL_RPARTS)
 				var/head_model = "[!rlimb_data["head"] ? "Morpheus Cyberkinetics" : rlimb_data["head"]]"
 				robohead = all_robolimbs[head_model]
 			switch(href_list["preference"])
@@ -1300,7 +1300,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						if(NS.has_gender && gender == PLURAL)
 							gender = pick(MALE,FEMALE)
 						var/datum/robolimb/robohead
-						if(NS.flags & ALL_RPARTS)
+						if(NS.bodyflags & ALL_RPARTS)
 							var/head_model = "[!rlimb_data["head"] ? "Morpheus Cyberkinetics" : rlimb_data["head"]]"
 							robohead = all_robolimbs[head_model]
 						//grab one of the valid hair styles for the newly chosen species
@@ -1437,7 +1437,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						if(hairstyle == "Bald") //Just in case.
 							valid_hairstyles += hairstyle
 							continue
-						if(S.flags & ALL_RPARTS) //Species that can use prosthetic heads.
+						if(S.bodyflags & ALL_RPARTS) //Species that can use prosthetic heads.
 							var/head_model
 							if(!rlimb_data["head"]) //Handle situations where the head is default.
 								head_model = "Morpheus Cyberkinetics"
@@ -1520,7 +1520,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 								if(M.heads_allowed && !("All" in M.heads_allowed))
 									continue
 
-							if(S.flags & ALL_RPARTS) //Species that can use prosthetic heads.
+							if(S.bodyflags & ALL_RPARTS) //Species that can use prosthetic heads.
 								var/head_model
 								if(!rlimb_data["head"]) //Handle situations where the head is default.
 									head_model = "Morpheus Cyberkinetics"
@@ -1648,7 +1648,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							continue
 						if(gender == FEMALE && SA.gender == MALE)
 							continue
-						if(S.flags & ALL_RPARTS) //Species that can use prosthetic heads.
+						if(S.bodyflags & ALL_RPARTS) //Species that can use prosthetic heads.
 							var/head_model
 							if(!rlimb_data["head"]) //Handle situations where the head is default.
 								head_model = "Morpheus Cyberkinetics"
@@ -1777,7 +1777,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 				if("limbs")
 					var/valid_limbs = list("Left Leg", "Right Leg", "Left Arm", "Right Arm", "Left Foot", "Right Foot", "Left Hand", "Right Hand")
-					if(S.flags & ALL_RPARTS)
+					if(S.bodyflags & ALL_RPARTS)
 						valid_limbs = list("Torso", "Lower Body", "Head", "Left Leg", "Right Leg", "Left Arm", "Right Arm", "Left Foot", "Right Foot", "Left Hand", "Right Hand")
 					var/limb_name = input(user, "Which limb do you want to change?") as null|anything in valid_limbs
 					if(!limb_name) return
@@ -1813,19 +1813,19 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 							second_limb = "r_hand"
 						if("Left Foot")
 							limb = "l_foot"
-							if(!(S.flags & ALL_RPARTS))
+							if(!(S.bodyflags & ALL_RPARTS))
 								third_limb = "l_leg"
 						if("Right Foot")
 							limb = "r_foot"
-							if(!(S.flags & ALL_RPARTS))
+							if(!(S.bodyflags & ALL_RPARTS))
 								third_limb = "r_leg"
 						if("Left Hand")
 							limb = "l_hand"
-							if(!(S.flags & ALL_RPARTS))
+							if(!(S.bodyflags & ALL_RPARTS))
 								third_limb = "l_arm"
 						if("Right Hand")
 							limb = "r_hand"
-							if(!(S.flags & ALL_RPARTS))
+							if(!(S.bodyflags & ALL_RPARTS))
 								third_limb = "r_arm"
 
 					var/new_state = input(user, "What state do you wish the limb to be in?") as null|anything in valid_limb_states
@@ -1881,7 +1881,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 								if(subchoice)
 									choice = subchoice
 							if(limb in list("head", "chest", "groin"))
-								if(!(S.flags & ALL_RPARTS))
+								if(!(S.bodyflags & ALL_RPARTS))
 									return
 								if(limb == "head")
 									ha_style = "None"
@@ -2204,7 +2204,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 
 	character.change_eye_color(r_eyes, g_eyes, b_eyes)
 
-	if(disabilities & DISABILITY_FLAG_FAT && character.species.flags & CAN_BE_FAT)
+	if(disabilities & DISABILITY_FLAG_FAT && (CAN_BE_FAT in character.species.species_traits))
 		character.dna.SetSEState(FATBLOCK,1,1)
 		character.overeatduration = 600
 

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -45,8 +45,6 @@
 
 /obj/item/clothing/mask/muzzle/tapegag/dropped(mob/living/carbon/human/user)
 	var/atom/movable/R = new /obj/item/trash/tapetrash
-	if(user.species.bodyflags & HAS_FUR)
-		R.desc += " Is that...fur?"
 	var/turf/T = get_turf(src)
 	R.loc = T
 	transfer_fingerprints_to(R)

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -136,7 +136,7 @@
 			user.visible_message("[user] places \the [src] against [M]'s chest and listens attentively.", "You place \the [src] against [M]'s chest...")
 		var/obj/item/organ/internal/H = M.get_int_organ(/obj/item/organ/internal/heart)
 		var/obj/item/organ/internal/L = M.get_int_organ(/obj/item/organ/internal/lungs)
-		if((H && M.pulse) || (L && !(NO_BREATH in M.mutations) && !(M.species.flags & NO_BREATH)))
+		if((H && M.pulse) || (L && !(NO_BREATH in M.mutations) && !(NO_BREATH in M.species.species_traits)))
 			var/color = "notice"
 			if(H)
 				var/heart_sound

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -18,7 +18,7 @@
 			continue
 		if(!H.client)
 			continue
-		if(H.species.virus_immune) //don't let virus immune things get diseases they're not supposed to get.
+		if(VIRUSIMMUNE in H.species.species_traits) //don't let virus immune things get diseases they're not supposed to get.
 			continue
 		var/turf/T = get_turf(H)
 		if(!T)

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -4,7 +4,7 @@
 /datum/event/mass_hallucination/start()
 	for(var/mob/living/carbon/human/H in living_mob_list)
 		var/armor = H.getarmor(type = "rad")
-		if((H.species.flags & RADIMMUNE) || armor >= 75) // Leave radiation-immune species/rad armored players completely unaffected
+		if((RADIMMUNE in H.species.species_traits) || armor >= 75) // Leave radiation-immune species/rad armored players completely unaffected
 			continue
 		H.AdjustHallucinate(rand(50, 100))
 

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -37,7 +37,7 @@
 		for(var/i = 0, i < 10, i++)
 			for(var/mob/living/carbon/human/H in living_mob_list)
 				var/armor = H.getarmor(type = "rad")
-				if((H.species.flags & RADIMMUNE) || armor >= 100) // Leave radiation-immune species/fully rad armored players completely unaffected
+				if((RADIMMUNE in H.species.species_traits) || armor >= 100) // Leave radiation-immune species/fully rad armored players completely unaffected
 					continue
 				var/turf/T = get_turf(H)
 				if(!T)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -938,7 +938,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	if(!(slipAny))
 		if(istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src
-			if((isobj(H.shoes) && H.shoes.flags & NOSLIP) || H.species.bodyflags & FEET_NOSLIP)
+			if(isobj(H.shoes) && H.shoes.flags & NOSLIP)
 				return 0
 	if(tilesSlipped)
 		for(var/t = 0, t<=tilesSlipped, t++)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -343,7 +343,7 @@
 				continue
 			if(blacklist.len && (current_species_name in blacklist))
 				continue
-			if((current_species.flags & IS_WHITELISTED) && !is_alien_whitelisted(src, current_species_name))
+			if((IS_WHITELISTED in current_species.species_traits) && !is_alien_whitelisted(src, current_species_name))
 				continue
 
 		valid_species += current_species_name
@@ -364,7 +364,7 @@
 			continue
 		if((H.gender == MALE && S.gender == FEMALE) || (H.gender == FEMALE && S.gender == MALE))
 			continue
-		if(H.species.flags & ALL_RPARTS) //If the user is a species who can have a robotic head...
+		if(H.species.bodyflags & ALL_RPARTS) //If the user is a species who can have a robotic head...
 			var/datum/robolimb/robohead = all_robolimbs[H.model]
 			if((H.species.name in S.species_allowed) && robohead.is_monitor && ((S.models_allowed && (robohead.company in S.models_allowed)) || !S.models_allowed)) //If this is a hair style native to the user's species, check to see if they have a head with an ipc-style screen and that the head's company is in the screen style's allowed models list.
 				valid_hairstyles += hairstyle //Give them their hairstyles if they do.
@@ -392,7 +392,7 @@
 			continue
 		if((H.gender == MALE && S.gender == FEMALE) || (H.gender == FEMALE && S.gender == MALE))
 			continue
-		if(H.species.flags & ALL_RPARTS) //If the user is a species who can have a robotic head...
+		if(H.species.bodyflags & ALL_RPARTS) //If the user is a species who can have a robotic head...
 			var/datum/robolimb/robohead = all_robolimbs[H.model]
 			if(H.species.name in S.species_allowed) //If this is a facial hair style native to the user's species...
 				if((H.species.name in S.species_allowed) && robohead.is_monitor && ((S.models_allowed && (robohead.company in S.models_allowed)) || !S.models_allowed)) //If this is a facial hair style native to the user's species, check to see if they have a head with an ipc-style screen and that the head's company is in the screen style's allowed models list.
@@ -446,7 +446,7 @@
 					continue
 		if(location == "head")
 			var/datum/sprite_accessory/body_markings/head/M = marking_styles_list[S.name]
-			if(H.species.flags & ALL_RPARTS)//If the user is a species that can have a robotic head...
+			if(H.species.bodyflags & ALL_RPARTS)//If the user is a species that can have a robotic head...
 				var/datum/robolimb/robohead = all_robolimbs[H.model]
 				if(!(S.models_allowed && (robohead.company in S.models_allowed))) //Make sure they don't get markings incompatible with their head.
 					continue

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1602,7 +1602,7 @@
 		to_chat(src, "<span class='warning'>Where's your head at? Can't change your monitor/display without one.</span>")
 		return
 
-	if(species.flags & ALL_RPARTS) //If they can have a fully cybernetic body...
+	if(species.bodyflags & ALL_RPARTS) //If they can have a fully cybernetic body...
 		var/datum/robolimb/robohead = all_robolimbs[head_organ.model]
 		if(!head_organ)
 			return
@@ -1936,7 +1936,7 @@
 				. |= A.GetAccess()
 
 /mob/living/carbon/human/is_mechanical()
-	return ..() || (species.flags & ALL_RPARTS) != 0
+	return ..() || (species.bodyflags & ALL_RPARTS) != 0
 
 /mob/living/carbon/human/can_use_guns(var/obj/item/weapon/gun/G)
 	. = ..()
@@ -1945,7 +1945,7 @@
 		if(HULK in mutations)
 			to_chat(src, "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>")
 			return 0
-		if(species.flags & NOGUNS)
+		if(NOGUNS in species.species_traits)
 			to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return 0
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -109,7 +109,7 @@
 		if(INTENT_HARM)
 			//Vampire code
 			if(M.mind && M.mind.vampire && (M.mind in ticker.mode.vampires) && !M.mind.vampire.draining && M.zone_sel && M.zone_sel.selecting == "head" && src != M)
-				if(species && species.flags & NO_BLOOD)//why this hell were we never checkinf for this?
+				if(NO_BLOOD in species.species_traits)//why this hell were we never checkinf for this?
 					to_chat(M, "<span class='warning'>They have no blood!</span>")
 					return
 				if(mind && mind.vampire && (mind in ticker.mode.vampires))

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -90,7 +90,7 @@
 	// standing is poor
 	if(stance_damage >= 8)
 		if(!(lying || resting))
-			if(species && !(species.flags & NO_PAIN))
+			if(!(NO_PAIN in species.species_traits))
 				emote("scream")
 			custom_emote(1, "collapses!")
 		Weaken(5) //can't emote while weakened, apparently.
@@ -118,7 +118,7 @@
 					continue
 
 			var/emote_scream = pick("screams in pain and ", "lets out a sharp cry and ", "cries out and ")
-			custom_emote(1, "[(species.flags & NO_PAIN) ? "" : emote_scream ]drops what they were holding in their [E.name]!")
+			custom_emote(1, "[(NO_PAIN in species.species_traits) ? "" : emote_scream ]drops what they were holding in their [E.name]!")
 
 		else if(E.is_malfunctioning())
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -193,7 +193,7 @@
 					if(gene_stability < GENETIC_DAMAGE_STAGE_3)
 						gib()
 
-	if(!(species.flags & RADIMMUNE))
+	if(!(RADIMMUNE in species.species_traits))
 		if(radiation)
 			radiation = Clamp(radiation, 0, 200)
 
@@ -254,7 +254,7 @@
 
 /mob/living/carbon/human/breathe()
 
-	if((NO_BREATH in mutations) || (species && (species.flags & NO_BREATHE)) || reagents.has_reagent("lexorin"))
+	if((NO_BREATH in mutations) || (NO_BREATHE in species.species_traits) || reagents.has_reagent("lexorin"))
 		adjustOxyLoss(-5)
 		oxygen_alert = 0
 		toxins_alert = 0
@@ -658,7 +658,7 @@
 		return 0	//godmode
 
 	//The fucking FAT mutation is the greatest shit ever. It makes everyone so hot and bothered.
-	if(species.flags & CAN_BE_FAT)
+	if(CAN_BE_FAT in species.species_traits)
 		if(FAT in mutations)
 			if(overeatduration < 100)
 				becomeSlim()
@@ -722,7 +722,8 @@
 		AdjustDizzy(-3)
 		AdjustJitter(-3)
 
-	if(species && species.flags & NO_INTORGANS) return
+	if(NO_INTORGANS in species.species_traits)
+		return
 
 	handle_trace_chems()
 
@@ -975,7 +976,7 @@
 	..()
 	if(status_flags & GODMODE)
 		return 0	//godmode
-	if(species && species.flags & NO_PAIN)
+	if(NO_PAIN in species.species_traits)
 		return
 
 	if(health <= config.health_threshold_softcrit)// health 0 makes you immediately collapse
@@ -1028,7 +1029,7 @@
 	if(mob_master.current_cycle % 5)
 		return pulse	//update pulse every 5 life ticks (~1 tick/sec, depending on server load)
 
-	if(species && species.flags & NO_BLOOD)
+	if(NO_BLOOD in species.species_traits)
 		return PULSE_NONE //No blood, no pulse.
 
 	if(stat == DEAD)
@@ -1098,7 +1099,7 @@
 			var/obj/item/clothing/mask/M = H.wear_mask
 			if(M && (M.flags_cover & MASKCOVERSMOUTH))
 				return
-			if(H.species && H.species.flags & NO_BREATHE)
+			if(NO_BREATHE in species.species_traits)
 				return //no puking if you can't smell!
 			// Humans can lack a mind datum, y'know
 			if(H.mind && (H.mind.assigned_role == "Detective" || H.mind.assigned_role == "Coroner"))
@@ -1178,7 +1179,9 @@
 
 
 /mob/living/carbon/human/proc/can_heartattack()
-	if(species.flags & (NO_BLOOD|NO_INTORGANS))
+	if(NO_BLOOD in species.species_traits)
+		return FALSE
+	if(NO_INTORGANS in species.species_traits)
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/species/abductor.dm
+++ b/code/modules/mob/living/carbon/human/species/abductor.dm
@@ -18,11 +18,10 @@
 		"eyes" =     /obj/item/organ/internal/eyes/abductor //3 darksight.
 		)
 
-	species_traits = list(NO_BLOOD, NO_BREATHE, NOGUNS)
+	species_traits = list(NO_BLOOD, NO_BREATHE, VIRUSIMMUNE, NOGUNS)
 
 	oxy_mod = 0
 
-	virus_immune = 1
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	dietflags = DIET_OMNI
 	reagent_tag = PROCESS_ORG

--- a/code/modules/mob/living/carbon/human/species/abductor.dm
+++ b/code/modules/mob/living/carbon/human/species/abductor.dm
@@ -18,7 +18,7 @@
 		"eyes" =     /obj/item/organ/internal/eyes/abductor //3 darksight.
 		)
 
-	flags = HAS_LIPS | NO_BLOOD | NO_BREATHE | NOGUNS
+	species_traits = list(NO_BLOOD, NO_BREATHE, NOGUNS)
 
 	oxy_mod = 0
 

--- a/code/modules/mob/living/carbon/human/species/apollo.dm
+++ b/code/modules/mob/living/carbon/human/species/apollo.dm
@@ -99,7 +99,7 @@
 	burn_mod = 4 // holy shite, poor guys wont survive half a second cooking smores
 	brute_mod = 2 // damn, double wham, double dam
 	oxy_mod = 0
-	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_BLOOD, NO_PAIN, NO_SCAN, RADIMMUNE)
+	species_traits = list(LIPS, IS_WHITELISTED, NO_BREATHE, NO_BLOOD, NO_PAIN, NO_SCAN, RADIMMUNE)
 	dietflags = DIET_OMNI		//still human at their core, so they maintain their eating habits and diet
 
 	//Default styles for created mobs.

--- a/code/modules/mob/living/carbon/human/species/apollo.dm
+++ b/code/modules/mob/living/carbon/human/species/apollo.dm
@@ -36,7 +36,7 @@
 		"antennae" =    /obj/item/organ/internal/wryn/hivenode
 		)
 
-	flags = IS_WHITELISTED | HAS_LIPS | NO_BREATHE | HAS_SKIN_COLOR | NO_SCAN | HIVEMIND
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, HAS_SKIN_COLOR, NO_SCAN, HIVEMIND)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	dietflags = DIET_HERB		//bees feed off nectar, so bee people feed off plants too
 
@@ -99,7 +99,7 @@
 	burn_mod = 4 // holy shite, poor guys wont survive half a second cooking smores
 	brute_mod = 2 // damn, double wham, double dam
 	oxy_mod = 0
-	flags = IS_WHITELISTED | NO_BREATHE | NO_BLOOD | NO_PAIN | HAS_LIPS | NO_SCAN | RADIMMUNE
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_BLOOD, NO_PAIN, NO_SCAN, RADIMMUNE)
 	dietflags = DIET_OMNI		//still human at their core, so they maintain their eating habits and diet
 
 	//Default styles for created mobs.

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -6,11 +6,10 @@
 	deform = 'icons/mob/human_races/r_golem.dmi'
 
 	default_language = "Galactic Common"
-	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, NOGUNS)
+	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, VIRUSIMMUNE, NOGUNS)
 
 	oxy_mod = 0
 
-	virus_immune = 1
 	dietflags = DIET_OMNI		//golems can eat anything because they are magic or something
 	reagent_tag = PROCESS_ORG
 

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -6,7 +6,7 @@
 	deform = 'icons/mob/human_races/r_golem.dmi'
 
 	default_language = "Galactic Common"
-	flags = NO_BREATHE | NO_BLOOD | RADIMMUNE | NOGUNS
+	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, NOGUNS)
 
 	oxy_mod = 0
 

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -24,7 +24,7 @@
 	female_scream_sound = 'sound/goonstation/voice/monkey_scream.ogg'
 
 	tail = "chimptail"
-	bodyflags = FEET_PADDED | HAS_TAIL
+	bodyflags = HAS_TAIL
 	reagent_tag = PROCESS_ORG
 	//Has standard darksight of 2.
 
@@ -155,9 +155,6 @@
 	reagent_tag = PROCESS_ORG
 	tail = null
 
-	bodyflags = FEET_PADDED
-
-
 /datum/species/monkey/unathi
 	name = "Stok"
 	name_plural = "Stok"
@@ -172,4 +169,4 @@
 	base_color = "#000000"
 	reagent_tag = PROCESS_ORG
 
-	bodyflags = FEET_CLAWS | HAS_TAIL
+	bodyflags = HAS_TAIL

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -6,7 +6,7 @@
 	//language = "Clatter"
 	unarmed_type = /datum/unarmed_attack/punch
 
-	flags = IS_WHITELISTED | NO_BLOOD | NOTRANSSTING
+	species_traits = list(IS_WHITELISTED, NO_BLOOD, NOTRANSSTING)
 	dietflags = DIET_OMNI
 	reagent_tag = PROCESS_ORG
 

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -17,11 +17,9 @@
 		"eyes" = /obj/item/organ/internal/eyes/shadow //8 darksight.
 		)
 
-	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE)
+	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, VIRUSIMMUNE)
 
 	oxy_mod = 0
-
-	virus_immune = 1
 
 	dietflags = DIET_OMNI		//the mutation process allowed you to now digest all foods regardless of initial race
 	reagent_tag = PROCESS_ORG

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -17,7 +17,7 @@
 		"eyes" = /obj/item/organ/internal/eyes/shadow //8 darksight.
 		)
 
-	flags = NO_BLOOD | NO_BREATHE | RADIMMUNE
+	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE)
 
 	oxy_mod = 0
 

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -13,11 +13,10 @@
 	blood_color = "#FFFFFF"
 	flesh_color = "#E6E6C6"
 
-	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE)
+	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE, VIRUSIMMUNE)
 
 	oxy_mod = 0
 
-	virus_immune = 1 //why is this a var and not a flag?
 	dietflags = DIET_OMNI
 	reagent_tag = PROCESS_ORG
 

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -13,7 +13,7 @@
 	blood_color = "#FFFFFF"
 	flesh_color = "#E6E6C6"
 
-	flags = NO_BREATHE | NO_BLOOD | RADIMMUNE
+	species_traits = list(NO_BREATHE, NO_BLOOD, RADIMMUNE)
 
 	oxy_mod = 0
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -111,7 +111,6 @@
 	var/icon/icon_template
 	var/is_small
 	var/show_ssd = 1
-	var/virus_immune
 	var/can_revive_by_healing				// Determines whether or not this species can be revived by simply healing them
 	var/has_gender = TRUE
 

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -91,7 +91,8 @@
 
 	var/list/allowed_consumed_mobs = list() //If a species can consume mobs, put the type of mobs it can consume here.
 
-	var/flags = 0       // Various specific features.
+	var/list/species_traits = list()
+
 	var/clothing_flags = 0 // Underwear and socks.
 	var/exotic_blood
 	var/bodyflags = 0
@@ -585,7 +586,7 @@
 				if(SCREWYHUD_DEAD)	H.healths.icon_state = "health7"
 				if(SCREWYHUD_HEALTHY)	H.healths.icon_state = "health0"
 				else
-					switch(100 - ((flags & NO_PAIN) ? 0 : H.traumatic_shock) - H.staminaloss)
+					switch(100 - ((NO_PAIN in species_traits) ? 0 : H.traumatic_shock) - H.staminaloss)
 						if(100 to INFINITY)		H.healths.icon_state = "health0"
 						if(80 to 100)			H.healths.icon_state = "health1"
 						if(60 to 80)			H.healths.icon_state = "health2"

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -904,7 +904,7 @@
 	oxy_mod = 0
 	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."
 
-	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_BLOOD, NO_PAIN, NO_DNA, RADIMMUNE, NOTRANSSTING)
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_BLOOD, NO_PAIN, NO_DNA, RADIMMUNE, VIRUSIMMUNE, NOTRANSSTING)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS
 	dietflags = 0		//IPCs can't eat, so no diet
@@ -912,7 +912,6 @@
 	flesh_color = "#AAAAAA"
 	//Default styles for created mobs.
 	default_hair = "Blue IPC Screen"
-	virus_immune = 1
 	can_revive_by_healing = 1
 	has_gender = FALSE
 	reagent_tag = PROCESS_SYN

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -6,7 +6,7 @@
 	primitive_form = "Monkey"
 	path = /mob/living/carbon/human/human
 	language = "Sol Common"
-	flags = HAS_LIPS | CAN_BE_FAT
+	species_traits = list(CAN_BE_FAT)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_TONE | HAS_BODY_MARKINGS
 	dietflags = DIET_OMNI
@@ -38,9 +38,8 @@
 	else, frequently even their own lives. They prefer warmer temperatures than most species and \
 	their native tongue is a heavy hissing laungage called Sinta'Unathi."
 
-	flags = HAS_LIPS
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
-	bodyflags = FEET_CLAWS | HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_BODY_MARKINGS | HAS_HEAD_MARKINGS | HAS_SKIN_COLOR | HAS_ALT_HEADS | TAIL_WAGGING
+	bodyflags = HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_BODY_MARKINGS | HAS_HEAD_MARKINGS | HAS_SKIN_COLOR | HAS_ALT_HEADS | TAIL_WAGGING
 	dietflags = DIET_CARN
 
 	cold_level_1 = 280 //Default 260 - Lower is better
@@ -110,9 +109,9 @@
 
 	primitive_form = "Farwa"
 
-	flags = HAS_LIPS | CAN_BE_FAT
+	species_traits = list(CAN_BE_FAT)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
-	bodyflags = FEET_PADDED | HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS | HAS_SKIN_COLOR | TAIL_WAGGING | HAS_FUR
+	bodyflags = HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS | HAS_SKIN_COLOR | TAIL_WAGGING
 	dietflags = DIET_OMNI
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#AFA59E"
@@ -160,9 +159,8 @@
 	to the degree it can cause conflict with more rigorous and strict authorities. They speak a guttural language known as 'Canilunzt' \
     which has a heavy emphasis on utilizing tail positioning and ear twitches to communicate intent."
 
-	flags = HAS_LIPS
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
-	bodyflags = FEET_PADDED | HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR | HAS_FUR
+	bodyflags = HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR
 	dietflags = DIET_OMNI
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#966464"
@@ -211,7 +209,6 @@
 	herbivores on the whole and tend to be co-operative with the other species of the galaxy, although they rarely reveal \
 	the secrets of their empire to their allies."
 
-	flags = HAS_LIPS
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_BODY_MARKINGS
 	dietflags = DIET_HERB
@@ -291,7 +288,7 @@
 	breath_type = "nitrogen"
 	poison_type = "oxygen"
 
-	flags = NO_SCAN | IS_WHITELISTED | NOTRANSSTING
+	species_traits = list(NO_SCAN, IS_WHITELISTED, NOTRANSSTING)
 	clothing_flags = HAS_SOCKS
 	dietflags = DIET_OMNI
 	bodyflags = HAS_ICON_SKIN_TONE | HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_BODY_MARKINGS | HAS_TAIL_MARKINGS
@@ -444,7 +441,7 @@
 	breath_type = "nitrogen"
 	poison_type = "oxygen"
 
-	flags = NO_SCAN | NO_BLOOD | NO_PAIN | IS_WHITELISTED
+	species_traits = list(NO_SCAN, NO_BLOOD, NO_PAIN, IS_WHITELISTED)
 	bodyflags = HAS_TAIL
 	dietflags = DIET_OMNI	//should inherit this from vox, this is here just in case
 
@@ -488,9 +485,9 @@
 
 	brute_mod = 0.8
 
-	flags = IS_WHITELISTED
+	species_traits = list(IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
-	bodyflags = FEET_CLAWS | HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS
+	bodyflags = HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS
 	eyes = "kidan_eyes_s"
 	dietflags = DIET_HERB
 	blood_color = "#FB9800"
@@ -543,7 +540,7 @@
 	male_cough_sounds = list('sound/effects/slime_squish.ogg')
 	female_cough_sounds = list('sound/effects/slime_squish.ogg')
 
-	flags = IS_WHITELISTED | NO_BREATHE | HAS_LIPS | NO_INTORGANS | NO_SCAN
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_INTORGANS, NO_SCAN)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | NO_EYES
 	dietflags = DIET_CARN
@@ -741,7 +738,7 @@
 	default_genes = list(REMOTE_TALK)
 
 
-	flags = IS_WHITELISTED | HAS_LIPS | CAN_BE_FAT
+	species_traits = list(IS_WHITELISTED, CAN_BE_FAT)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags =  HAS_BODY_MARKINGS
 	dietflags = DIET_HERB
@@ -801,7 +798,7 @@
 	even the simplest concepts of other minds. Their alien physiology allows them survive happily off a diet of nothing but light, \
 	water and other radiation."
 
-	flags = NO_BREATHE | RADIMMUNE | IS_PLANT | NO_BLOOD | NO_PAIN
+	species_traits = list(NO_BREATHE, RADIMMUNE, IS_PLANT, NO_BLOOD, NO_PAIN)
 	clothing_flags = HAS_SOCKS
 	dietflags = 0		//Diona regenerate nutrition in light, no diet necessary
 
@@ -907,9 +904,9 @@
 	oxy_mod = 0
 	death_message = "gives one shrill beep before falling limp, their monitor flashing blue before completely shutting off..."
 
-	flags = IS_WHITELISTED | NO_BREATHE | NO_SCAN | NO_BLOOD | NO_PAIN | NO_DNA | RADIMMUNE | ALL_RPARTS | NOTRANSSTING
+	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_SCAN, NO_BLOOD, NO_PAIN, NO_DNA, RADIMMUNE, NOTRANSSTING)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
-	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY
+	bodyflags = HAS_SKIN_COLOR | HAS_HEAD_MARKINGS | HAS_HEAD_ACCESSORY | ALL_RPARTS
 	dietflags = 0		//IPCs can't eat, so no diet
 	blood_color = "#1F181F"
 	flesh_color = "#AAAAAA"
@@ -1007,9 +1004,9 @@
 		"is sucking in warm air!",
 		"is holding their breath!")
 
-	flags = IS_WHITELISTED | HAS_LIPS
+	species_traits = list(IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT
-	bodyflags = FEET_CLAWS | HAS_SKIN_TONE | HAS_BODY_MARKINGS
+	bodyflags = HAS_SKIN_TONE | HAS_BODY_MARKINGS
 	dietflags = DIET_OMNI
 
 	cold_level_1 = -1 //Default 260 - Lower is better

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -6,7 +6,7 @@
 	primitive_form = "Monkey"
 	path = /mob/living/carbon/human/human
 	language = "Sol Common"
-	species_traits = list(CAN_BE_FAT)
+	species_traits = list(LIPS, CAN_BE_FAT)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_TONE | HAS_BODY_MARKINGS
 	dietflags = DIET_OMNI
@@ -38,6 +38,7 @@
 	else, frequently even their own lives. They prefer warmer temperatures than most species and \
 	their native tongue is a heavy hissing laungage called Sinta'Unathi."
 
+	species_traits = list(LIPS)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_BODY_MARKINGS | HAS_HEAD_MARKINGS | HAS_SKIN_COLOR | HAS_ALT_HEADS | TAIL_WAGGING
 	dietflags = DIET_CARN
@@ -109,7 +110,7 @@
 
 	primitive_form = "Farwa"
 
-	species_traits = list(CAN_BE_FAT)
+	species_traits = list(LIPS, CAN_BE_FAT)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_TAIL | HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS | HAS_SKIN_COLOR | TAIL_WAGGING
 	dietflags = DIET_OMNI
@@ -159,6 +160,7 @@
 	to the degree it can cause conflict with more rigorous and strict authorities. They speak a guttural language known as 'Canilunzt' \
     which has a heavy emphasis on utilizing tail positioning and ear twitches to communicate intent."
 
+	species_traits = list(LIPS)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR
 	dietflags = DIET_OMNI
@@ -209,6 +211,7 @@
 	herbivores on the whole and tend to be co-operative with the other species of the galaxy, although they rarely reveal \
 	the secrets of their empire to their allies."
 
+	species_traits = list(LIPS)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | HAS_BODY_MARKINGS
 	dietflags = DIET_HERB
@@ -540,7 +543,7 @@
 	male_cough_sounds = list('sound/effects/slime_squish.ogg')
 	female_cough_sounds = list('sound/effects/slime_squish.ogg')
 
-	species_traits = list(IS_WHITELISTED, NO_BREATHE, NO_INTORGANS, NO_SCAN)
+	species_traits = list(LIPS, IS_WHITELISTED, NO_BREATHE, NO_INTORGANS, NO_SCAN)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_SKIN_COLOR | NO_EYES
 	dietflags = DIET_CARN
@@ -738,7 +741,7 @@
 	default_genes = list(REMOTE_TALK)
 
 
-	species_traits = list(IS_WHITELISTED, CAN_BE_FAT)
+	species_traits = list(LIPS, IS_WHITELISTED, CAN_BE_FAT)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags =  HAS_BODY_MARKINGS
 	dietflags = DIET_HERB
@@ -1003,7 +1006,7 @@
 		"is sucking in warm air!",
 		"is holding their breath!")
 
-	species_traits = list(IS_WHITELISTED)
+	species_traits = list(LIPS, IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT
 	bodyflags = HAS_SKIN_TONE | HAS_BODY_MARKINGS
 	dietflags = DIET_OMNI

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -341,7 +341,7 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)
 		update_icons()
 
-	if(lip_style  && species && species.flags & HAS_LIPS)
+	if(lip_style)
 		var/icon/lips = icon("icon"='icons/mob/human_face.dmi', "icon_state"="lips_[lip_style]_s")
 		lips.Blend(lip_color, ICON_ADD)
 
@@ -453,7 +453,7 @@ var/global/list/damage_icon_parts = list()
 		//if(!src.get_int_organ(/obj/item/organ/internal/brain) && src.get_species() != "Machine" )//make it obvious we have NO BRAIN
 		//	hair_standing.Blend(debrained_s, ICON_OVERLAY)
 		if(hair_style && hair_style.species_allowed)
-			if((head_organ.species.name in hair_style.species_allowed) || (head_organ.species.flags & ALL_RPARTS)) //If the head's species is in the list of allowed species for the hairstyle, or the head's species is one flagged to have bodies comprised wholly of cybernetics...
+			if((head_organ.species.name in hair_style.species_allowed) || (head_organ.species.bodyflags & ALL_RPARTS)) //If the head's species is in the list of allowed species for the hairstyle, or the head's species is one flagged to have bodies comprised wholly of cybernetics...
 				var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 				if(head_organ.species.name == "Slime People") // I am el worstos
 					hair_s.Blend(rgb(r_skin, g_skin, b_skin, 160), ICON_AND)
@@ -499,7 +499,7 @@ var/global/list/damage_icon_parts = list()
 	if(head_organ.f_style)
 		var/datum/sprite_accessory/facial_hair/facial_hair_style = facial_hair_styles_list[head_organ.f_style]
 		if(facial_hair_style && facial_hair_style.species_allowed)
-			if((head_organ.species.name in facial_hair_style.species_allowed) || (head_organ.species.flags & ALL_RPARTS)) //If the head's species is in the list of allowed species for the hairstyle, or the head's species is one flagged to have bodies comprised wholly of cybernetics...
+			if((head_organ.species.name in facial_hair_style.species_allowed) || (head_organ.species.bodyflags & ALL_RPARTS)) //If the head's species is in the list of allowed species for the hairstyle, or the head's species is one flagged to have bodies comprised wholly of cybernetics...
 				var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 				if(head_organ.species.name == "Slime People") // I am el worstos
 					facial_s.Blend(rgb(r_skin, g_skin, b_skin, 160), ICON_AND)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -341,7 +341,7 @@ var/global/list/damage_icon_parts = list()
 	if(update_icons)
 		update_icons()
 
-	if(lip_style)
+	if(lip_style  && (LIPS in species.species_traits))
 		var/icon/lips = icon("icon"='icons/mob/human_face.dmi', "icon_state"="lips_[lip_style]_s")
 		lips.Blend(lip_color, ICON_ADD)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -641,7 +641,7 @@
 
 /mob/living/carbon/human/makeTrail(turf/T)
 
-	if((species.flags & NO_BLOOD) || species.exotic_blood || !bleed_rate || bleedsuppress)
+	if((NO_BLOOD in species.species_traits) || species.exotic_blood || !bleed_rate || bleedsuppress)
 		return
 	..()
 

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -176,7 +176,7 @@
 	if(!M || !src)
 		return
 
-	if(M.species.flags & NO_BLOOD)
+	if(NO_BLOOD in M.species.species_traits)
 		to_chat(src, "<span class='warning'>That donor has no blood to take.</span>")
 		return
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -516,7 +516,7 @@
 
 /mob/new_player/proc/is_species_whitelisted(datum/species/S)
 	if(!S) return 1
-	return is_alien_whitelisted(src, S.name) || !config.usealienwhitelist || !(S.flags & IS_WHITELISTED)
+	return is_alien_whitelisted(src, S.name) || !config.usealienwhitelist || !(IS_WHITELISTED in S.species_traits)
 
 /mob/new_player/get_species()
 	var/datum/species/chosen_species

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -254,7 +254,7 @@
 		icobase = 'icons/mob/human_races/r_human.dmi'
 
 	var/fat=""
-	if(disabilities & DISABILITY_FLAG_FAT && current_species.flags & CAN_BE_FAT)
+	if(disabilities & DISABILITY_FLAG_FAT && (CAN_BE_FAT in current_species.species_traits))
 		fat="_fat"
 	preview_icon = new /icon(icobase, "torso_[g][fat]")
 	preview_icon.Blend(new /icon(icobase, "groin_[g]"), ICON_OVERLAY)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -134,7 +134,7 @@
 	var/mob/living/M = target
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = M
-		if(H.species.flags & IS_PLANT)
+		if(IS_PLANT in H.species.species_traits)
 			if(prob(15))
 				M.apply_effect((rand(30,80)),IRRADIATE)
 				M.Weaken(5)
@@ -167,7 +167,7 @@
 	var/mob/M = target
 	if(ishuman(target)) //These rays make plantmen fat.
 		var/mob/living/carbon/human/H = M
-		if(H.species.flags & IS_PLANT)
+		if(IS_PLANT in H.species.species_traits)
 			H.nutrition = min(H.nutrition+30, NUTRITION_LEVEL_FULL)
 	else if(iscarbon(target))
 		M.show_message("<span class='notice'>The radiation beam dissipates harmlessly through your body.</span>")

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -31,7 +31,7 @@
 			if(H.can_eat(diet_flags))	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
 				if(prob(50))
 					M.adjustBruteLoss(-1)
-					if(!(H.species.flags & NO_BLOOD))//do not restore blood on things with no blood by nature.
+					if(!(NO_BLOOD in H.species.species_traits))//do not restore blood on things with no blood by nature.
 						if(H.blood_volume < BLOOD_VOLUME_NORMAL)
 							H.blood_volume += 0.4
 	..()
@@ -63,7 +63,7 @@
 		M.satiety += 30
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(!(H.species.flags & NO_BLOOD))//do not restore blood on things with no blood by nature.
+		if(!(NO_BLOOD in H.species.species_traits))//do not restore blood on things with no blood by nature.
 			if(H.blood_volume < BLOOD_VOLUME_NORMAL)
 				H.blood_volume += 0.5
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -212,7 +212,7 @@
 		M.adjustFireLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
 	if(ishuman(M) && prob(33))
 		var/mob/living/carbon/human/H = M
-		if(!(H.species.flags & NO_BLOOD))//do not restore blood on things with no blood by nature.
+		if(!(NO_BLOOD in H.species.species_traits))//do not restore blood on things with no blood by nature.
 			if(H.blood_volume < BLOOD_VOLUME_NORMAL)
 				H.blood_volume += 1
 	..()

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -147,7 +147,7 @@
 /datum/reagent/iron/on_mob_life(mob/living/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(!H.species.exotic_blood && !(H.species.flags & NO_BLOOD))
+		if(!H.species.exotic_blood && !(NO_BLOOD in H.species.species_traits))
 			H.blood_volume += 0.8
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -956,7 +956,7 @@
 			C.adjustToxLoss(lethality)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if(H.species.flags & IS_PLANT) //plantmen take a LOT of damage
+			if(IS_PLANT in H.species.species_traits) //plantmen take a LOT of damage
 				H.adjustToxLoss(50)
 				..()
 	else if(istype(M, /mob/living/simple_animal/diona)) //plantmen monkeys (diona) take EVEN MORE damage

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -21,7 +21,7 @@
 	if(in_stasis)
 		return
 
-	if(species && species.flags & NO_BLOOD)
+	if(NO_BLOOD in species.species_traits)
 		bleed_rate = 0
 		return
 
@@ -95,7 +95,7 @@
 				add_splatter_floor(loc, 1)
 
 /mob/living/carbon/human/bleed(amt)
-	if(!(species && species.flags & NO_BLOOD))
+	if(!(NO_BLOOD in species.species_traits))
 		..()
 		if(species.exotic_blood)
 			var/datum/reagent/R = chemical_reagents_list[get_blood_id()]
@@ -197,7 +197,7 @@
 /mob/living/carbon/human/get_blood_id()
 	if(species.exotic_blood)//some races may bleed water..or kethcup..
 		return species.exotic_blood
-	else if((species && species.flags & NO_BLOOD) || (NOCLONE in mutations))
+	else if((NO_BLOOD in species.species_traits) || (NOCLONE in mutations))
 		return
 	return "blood"
 
@@ -265,7 +265,7 @@
 	B.update_icon()
 
 /mob/living/carbon/human/add_splatter_floor(turf/T, small_drip)
-	if(!(species && species.flags & NO_BLOOD))
+	if(!(NO_BLOOD in species.species_traits))
 		..()
 
 /mob/living/carbon/alien/add_splatter_floor(turf/T, small_drip)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -96,7 +96,7 @@ var/list/organ_cache = list()
 		return
 
 	//Process infections
-	if((status & ORGAN_ROBOT) || sterile ||(owner && owner.species && (owner.species.flags & IS_PLANT)))
+	if((status & ORGAN_ROBOT) || sterile ||(owner && (IS_PLANT in owner.species.species_traits)))
 		germ_level = 0
 		return
 
@@ -318,7 +318,7 @@ var/list/organ_cache = list()
 	processing_objects |= src
 	var/datum/reagent/blood/organ_blood
 	if(reagents) organ_blood = reagents.get_reagent_from_id(owner.get_blood_id())
-	if((!organ_blood || !organ_blood.data["blood_DNA"]) && (owner && !(owner.species.flags & NO_BLOOD)))
+	if((!organ_blood || !organ_blood.data["blood_DNA"]) && (owner && !(NO_BLOOD in owner.species.species_traits)))
 		owner.transfer_blood_to(src)
 
 	if(owner && vital && is_primary_organ()) // I'd do another check for species or whatever so that you couldn't "kill" an IPC by removing a human head from them, but it doesn't matter since they'll come right back from the dead

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -322,13 +322,6 @@
 		status &= ~ORGAN_BROKEN
 		perma_injury = 0
 
-/*
-	if((brute || burn) && children && children.len && (owner.species.flags & REGENERATES_LIMBS))
-		var/obj/item/organ/external/stump/S = locate() in children
-		if(S)
-//			to_chat(world, "Extra healing to go around ([brute+burn]) and [owner] needs a replacement limb.")
-*/
-
 	//Sync the organ's damage with its wounds
 	src.update_damages()
 	owner.updatehealth()
@@ -491,7 +484,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 */
 /obj/item/organ/external/proc/update_germs()
 
-	if(status & (ORGAN_ROBOT|ORGAN_DESTROYED) || (owner.species && owner.species.flags & IS_PLANT)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
+	if(status & (ORGAN_ROBOT|ORGAN_DESTROYED) || (IS_PLANT in owner.species.species_traits)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
 		germ_level = 0
 		return
 
@@ -634,7 +627,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		if(!(status & ORGAN_ROBOT) && W.bleeding())
 			W.bleed_timer--
-			if(H && (H.species.flags & NO_BLOOD)) // Bloodless organic races are finicky
+			if(H && (NO_BLOOD in H.species.species_traits)) // Bloodless organic races are finicky
 				W.clamped = 1
 				W.bleed_timer = 0
 			else
@@ -644,7 +637,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		number_wounds += W.amount
 
-	if(open && !clamped && (H && !(H.species.flags & NO_BLOOD)))
+	if(open && !clamped && (H && !(NO_BLOOD in H.species.species_traits)))
 		status |= ORGAN_BLEEDING
 
 	//Bone fractures
@@ -826,7 +819,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			"<span class='warning'>You hear a loud cracking sound coming from \the [owner].</span>",\
 			"<span class='danger'>Something feels like it shattered in your [name]!</span>",\
 			"You hear a sickening crack.")
-		if(owner.species && !(owner.species.flags & NO_PAIN))
+		if(owner.species && !(NO_PAIN in owner.species.species_traits))
 			owner.emote("scream")
 
 	status |= ORGAN_BROKEN

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -49,7 +49,7 @@ var/global/list/limb_icon_cache = list()
 	if(!isnull(dna.GetUIValue(DNA_UI_SKIN_TONE)) && ((species.bodyflags & HAS_SKIN_TONE) || (species.bodyflags & HAS_ICON_SKIN_TONE)))
 		s_col = null
 		s_tone = dna.GetUIValue(DNA_UI_SKIN_TONE)
-	if(species.flags & HAS_SKIN_COLOR)
+	if(species.bodyflags & HAS_SKIN_COLOR)
 		s_tone = null
 		s_col = list(dna.GetUIValue(DNA_UI_SKIN_R), dna.GetUIValue(DNA_UI_SKIN_G), dna.GetUIValue(DNA_UI_SKIN_B))
 
@@ -115,7 +115,7 @@ var/global/list/limb_icon_cache = list()
 			mob_icon.Blend(eyes_icon, ICON_OVERLAY)
 			overlays |= eyes_icon
 
-	if(owner.lip_style && (species && (species.flags & HAS_LIPS)))
+	if(owner.lip_style)
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
 		overlays |= lip_icon
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)
@@ -139,7 +139,7 @@ var/global/list/limb_icon_cache = list()
 
 	if(f_style)
 		var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[f_style]
-		if(facial_hair_style && ((facial_hair_style.species_allowed && (species.name in facial_hair_style.species_allowed)) || (src.species.flags & ALL_RPARTS)))
+		if(facial_hair_style && ((facial_hair_style.species_allowed && (species.name in facial_hair_style.species_allowed)) || (src.species.bodyflags & ALL_RPARTS)))
 			var/icon/facial_s = new/icon("icon" = facial_hair_style.icon, "icon_state" = "[facial_hair_style.icon_state]_s")
 			if(species.name == "Slime People") // I am el worstos
 				facial_s.Blend(rgb(owner.r_skin, owner.g_skin, owner.b_skin, 160), ICON_AND)
@@ -149,7 +149,7 @@ var/global/list/limb_icon_cache = list()
 
 	if(h_style && !(owner.head && (owner.head.flags & BLOCKHEADHAIR)))
 		var/datum/sprite_accessory/hair_style = hair_styles_list[h_style]
-		if(hair_style && ((species.name in hair_style.species_allowed) || (src.species.flags & ALL_RPARTS)))
+		if(hair_style && ((species.name in hair_style.species_allowed) || (src.species.bodyflags & ALL_RPARTS)))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")
 			if(species.name == "Slime People") // I am el worstos
 				hair_s.Blend(rgb(owner.r_skin, owner.g_skin, owner.b_skin, 160), ICON_AND)
@@ -192,7 +192,7 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/chest/get_icon_state(skeletal)
 	var/result = ..()
-	if(fat && !skeletal && !(status & ORGAN_ROBOT) && (species.flags & CAN_BE_FAT))
+	if(fat && !skeletal && !(status & ORGAN_ROBOT) && (CAN_BE_FAT in species.species_traits))
 		result[2] += "_fat"
 	return result
 

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -115,7 +115,7 @@ var/global/list/limb_icon_cache = list()
 			mob_icon.Blend(eyes_icon, ICON_OVERLAY)
 			overlays |= eyes_icon
 
-	if(owner.lip_style)
+	if(owner.lip_style && (LIPS in species.species_traits))
 		var/icon/lip_icon = new/icon('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
 		overlays |= lip_icon
 		mob_icon.Blend(lip_icon, ICON_OVERLAY)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -211,7 +211,7 @@
 
 /obj/item/organ/internal/heart/cursed/attack(mob/living/carbon/human/H, mob/living/carbon/human/user, obj/target)
 	if(H == user && istype(H))
-		if(H.species.flags & NO_BLOOD || H.species.exotic_blood)
+		if(NO_BLOOD in H.species.species_traits)
 			to_chat(H, "<span class = 'userdanger'>\The [src] is not compatible with your form!</span>")
 			return
 		playsound(user,'sound/effects/singlebeat.ogg', 40, 1)
@@ -224,7 +224,7 @@
 	if(world.time > (last_pump + pump_delay))
 		if(ishuman(owner) && owner.client) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/H = owner
-			if(!(H.species.flags & NO_BLOOD))
+			if(!(NO_BLOOD in H.species.species_traits))
 				H.blood_volume = max(H.blood_volume - blood_loss, 0)
 				to_chat(H, "<span class='userdanger'>You have to keep pumping your blood!</span>")
 				if(H.client)
@@ -257,7 +257,7 @@
 
 		var/mob/living/carbon/human/H = owner
 		if(istype(H))
-			if(!(H.species.flags & NO_BLOOD))
+			if(!(NO_BLOOD in H.species.species_traits))
 				H.blood_volume = min(H.blood_volume + cursed_heart.blood_loss*0.5, BLOOD_VOLUME_MAXIMUM)
 				if(owner.client)
 					owner.client.color = ""

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -47,7 +47,8 @@ mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0
 mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
 	if(stat >= 1) return
 
-	if(species && species.flags & NO_PAIN) return
+	if(NO_PAIN in species.species_traits)
+		return
 
 	if(reagents.has_reagent("morphine"))
 		return
@@ -66,7 +67,7 @@ mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
 mob/living/carbon/human/proc/handle_pain()
 	// not when sleeping
 
-	if(species && species.flags & NO_PAIN)
+	if(NO_PAIN in species.species_traits)
 		//While synthetics don't feel pain, they will notice their gears gunking up with residue (toxins)
 		if(isSynthetic())
 			var/toxDamageMessage = null

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -201,7 +201,7 @@
 
 	for(var/mob/living/carbon/human/H in view(2, E.loc))//germs from people
 		if(AStar(E.loc, H.loc, /turf/proc/Distance, 2, simulated_only = 0))
-			if((!(NO_BREATH in H.mutations) || !(H.species.flags & NO_BREATH)) && !H.wear_mask) //wearing a mask helps preventing people from breathing cooties into open incisions
+			if((!(NO_BREATH in H.mutations) || !(NO_BREATH in H.species.species_traits)) && !H.wear_mask) //wearing a mask helps preventing people from breathing cooties into open incisions
 				germs+=H.germ_level/4
 
 	for(var/obj/effect/decal/cleanable/M in view(2, E.loc))//germs from messes


### PR DESCRIPTION
Re-upload of: https://github.com/ParadiseSS13/Paradise/pull/7357 because the merge conflicts killed it dead.

Refactors species bitflags to instead be list based. Idea and species list name taken from TG.

Why? Simple, we can run out of bitflags very quickly, but when it comes to a list, then the amount of traits we can have skyrockets.

This also removes a few unused species bodyflags, and a flag that was literally only used for single item description (there's just too few bodyflags to go around to warrant its existence).

Also fixed an instance where the code was checking for `HAS_SKIN_COLOR` in the species `flags` as opposed to its `bodyflags`.

Lastly fixes a runtime with assigning eye color if the person doesn't have eyes.

Marked as high priority, because this will conflict with a lot of stuff very easily.

No CL as this is all back end.