### PR TITLE
Makes Circuit Imprinter Metal Compatible

### DIFF
--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -11,6 +11,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	flags = OPENCONTAINER
 
 	var/g_amount = 0
+	var/metal_amount = 0
 	var/gold_amount = 0
 	var/diamond_amount = 0
 	var/max_material_amount = 75000.0
@@ -75,6 +76,8 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	switch(M)
 		if(MAT_GLASS)
 			return (g_amount - (being_built.materials[M]/efficiency_coeff) >= 0)
+		if(MAT_METAL)
+			return (metal_amount - (being_built.materials[M]/efficiency_coeff) >= 0)
 		if(MAT_GOLD)
 			return (gold_amount - (being_built.materials[M]/efficiency_coeff) >= 0)
 		if(MAT_DIAMOND)
@@ -84,7 +87,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 
 
 /obj/machinery/r_n_d/circuit_imprinter/proc/TotalMaterials()
-	return g_amount + gold_amount + diamond_amount
+	return g_amount + metal_amount + gold_amount + diamond_amount
 
 /obj/machinery/r_n_d/circuit_imprinter/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if(shocked)
@@ -109,6 +112,9 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 			if(g_amount >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/glass/G = new /obj/item/stack/sheet/glass(src.loc)
 				G.amount = round(g_amount / MINERAL_MATERIAL_AMOUNT)
+			if(metal_amount >= MINERAL_MATERIAL_AMOUNT)
+				var/obj/item/stack/sheet/metal/G = new /obj/item/stack/sheet/metal(src.loc)
+				G.amount = round(metal_amount / MINERAL_MATERIAL_AMOUNT)
 			if(gold_amount >= MINERAL_MATERIAL_AMOUNT)
 				var/obj/item/stack/sheet/mineral/gold/G = new /obj/item/stack/sheet/mineral/gold(src.loc)
 				G.amount = round(gold_amount / MINERAL_MATERIAL_AMOUNT)
@@ -127,7 +133,7 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 		return 1
 	if(O.is_open_container())
 		return
-	if(!istype(O, /obj/item/stack/sheet/glass) && !istype(O, /obj/item/stack/sheet/mineral/gold) && !istype(O, /obj/item/stack/sheet/mineral/diamond))
+	if(!istype(O, /obj/item/stack/sheet/glass) && !istype(O, /obj/item/stack/sheet/metal) && !istype(O, /obj/item/stack/sheet/mineral/gold) && !istype(O, /obj/item/stack/sheet/mineral/diamond))
 		to_chat(user, "<span class='warning'>You cannot insert this item into the [name]!</span>")
 		return
 	if(stat)
@@ -151,6 +157,8 @@ using metal and glass, it uses glass and reagents (usually sulfuric acis).
 	to_chat(user, "<span class='notice'>You add [amount] sheets to the [src.name].</span>")
 	if(istype(stack, /obj/item/stack/sheet/glass))
 		g_amount += amount * MINERAL_MATERIAL_AMOUNT
+	else if(istype(stack, /obj/item/stack/sheet/metal))
+		metal_amount += amount * MINERAL_MATERIAL_AMOUNT
 	else if(istype(stack, /obj/item/stack/sheet/mineral/gold))
 		gold_amount += amount * MINERAL_MATERIAL_AMOUNT
 	else if(istype(stack, /obj/item/stack/sheet/mineral/diamond))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -513,6 +513,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						switch(M)
 							if(MAT_GLASS)
 								linked_imprinter.g_amount = max(0, (linked_imprinter.g_amount-being_built.materials[M]/coeff))
+							if(MAT_METAL)
+								linked_imprinter.metal_amount = max(0, (linked_imprinter.metal_amount-being_built.materials[M]/coeff))
 							if(MAT_GOLD)
 								linked_imprinter.gold_amount = max(0, (linked_imprinter.gold_amount-being_built.materials[M]/coeff))
 							if(MAT_DIAMOND)
@@ -568,6 +570,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(MAT_GLASS)
 				type = /obj/item/stack/sheet/glass
 				res_amount = "g_amount"
+			if(MAT_METAL)
+				type = /obj/item/stack/sheet/metal
+				res_amount = "metal_amount"
 			if(MAT_GOLD)
 				type = /obj/item/stack/sheet/mineral/gold
 				res_amount = "gold_amount"
@@ -851,6 +856,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			var/list/materials_list = list()
 			data["loaded_materials"] = materials_list
 			materials_list[++materials_list.len] = list("name" = "Glass", "id" = MAT_GLASS, "amount" = linked_imprinter.g_amount)
+			materials_list[++materials_list.len] = list("name" = "Metal", "id" = MAT_METAL, "amount" = linked_imprinter.metal_amount)
 			materials_list[++materials_list.len] = list("name" = "Gold", "id" = MAT_GOLD, "amount" = linked_imprinter.gold_amount)
 			materials_list[++materials_list.len] = list("name" = "Diamond", "id" = MAT_DIAMOND, "amount" = linked_imprinter.diamond_amount)
 		if(submenu == 3)


### PR DESCRIPTION
What it says on the tin. Allows the circuit imprinter to now be fed/spit back out metal for designs that require metal.

:cl:granodd
add: circuit imprinter is now compatible with metal
/:cl:

