### PR TITLE
Removes Metal Requirements from Network Cards

### DIFF
--- a/code/modules/research/designs/computer_part_designs.dm
+++ b/code/modules/research/designs/computer_part_designs.dm
@@ -63,7 +63,7 @@
 	id = "netcard_basic"
 	req_tech = list("programming" = 2, "engineering" = 1)
 	build_type = IMPRINTER
-	materials = list(MAT_METAL = 250, MAT_GLASS = 100, "sacid" = 20)
+	materials = list(MAT_GLASS = 350, "sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/network_card
 	category = list("Computer Parts")
 
@@ -72,7 +72,7 @@
 	id = "netcard_advanced"
 	req_tech = list("programming" = 4, "engineering" = 2)
 	build_type = IMPRINTER
-	materials = list(MAT_METAL = 500, MAT_GLASS = 200, "sacid" = 20)
+	materials = list(MAT_GLASS = 700, "sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/network_card/advanced
 	category = list("Computer Parts")
 
@@ -81,7 +81,7 @@
 	id = "netcard_wired"
 	req_tech = list("programming" = 5, "engineering" = 3)
 	build_type = IMPRINTER
-	materials = list(MAT_METAL = 2500, MAT_GLASS = 400, "sacid" = 20)
+	materials = list(MAT_GLASS = 2900, "sacid" = 20)
 	build_path = /obj/item/weapon/computer_hardware/network_card/wired
 	category = list("Computer Parts")
 


### PR DESCRIPTION
Removes the metal requirements from the network cards in the circuit imprinter and shifts the weight of the material over to the glass. They were the only three designs in the imprinter that used metal, so removing the requirements in lieu of changing the entire imprinter's code seemed like the more logical decision.

:cl:granodd
add: network cards no longer require metal to create
/:cl: