### PR TITLE
Makes clipboard code less horrible

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -9,6 +9,8 @@
 
 #define is_cleanable(A) (istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/rune)) //if something is cleanable
 
+#define is_pen(W) (istype(W, /obj/item/weapon/pen))
+
 var/list/static/global/pointed_types = typecacheof(list(
 	/obj/item/weapon/pen,
 	/obj/item/weapon/screwdriver,

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -1,154 +1,157 @@
+#define PAPERWORK	1
+#define PHOTO		2
+
 /obj/item/weapon/clipboard
 	name = "clipboard"
+	desc = "It looks like you're writing a letter. Want some help?"
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "clipboard"
 	item_state = "clipboard"
-	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL
-	throw_speed = 3
-	throw_range = 10
-	var/obj/item/weapon/pen/haspen		//The stored pen.
-	var/obj/item/weapon/toppaper	//The topmost piece of paper.
+	var/obj/item/weapon/pen
+	var/obj/item/weapon/toppaper
 	slot_flags = SLOT_BELT
 	burn_state = FLAMMABLE
 
 /obj/item/weapon/clipboard/New()
+	..()
 	update_icon()
 
-/obj/item/weapon/clipboard/MouseDrop(obj/over_object as obj) //Quick clipboard fix. -Agouri
-	if(ishuman(usr))
-		var/mob/M = usr
-		if(!(istype(over_object, /obj/screen) ))
-			return ..()
+/obj/item/weapon/clipboard/verb/removePen()
+	set category = "Object"
+	set name = "Remove clipboard pen"
+	if(!ishuman(usr) || usr.incapacitated())
+		return
+	penPlacement(FALSE, pen)
 
-		if(!M.restrained() && !M.stat)
-			switch(over_object.name)
-				if("r_hand")
-					M.unEquip(src)
-					M.put_in_r_hand(src)
-				if("l_hand")
-					M.unEquip(src)
-					M.put_in_l_hand(src)
+/obj/item/weapon/clipboard/proc/isPaperwork(var/obj/item/weapon/W) //This could probably do with being somewhere else but for now it's fine here.
+	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/paper_bundle))
+		return PAPERWORK
+	if(istype(W, /obj/item/weapon/photo))
+		return PHOTO
 
-			add_fingerprint(usr)
+/obj/item/weapon/clipboard/proc/isPen(var/obj/item/weapon/W) //Should also probably be somewhere else
+	if(istype(W, /obj/item/weapon/pen))
+		return TRUE
+
+/obj/item/weapon/clipboard/proc/checkTopPaper()
+	if(toppaper.loc != src) //Oh no! We're missing a top sheet! Better get another one to be at the top.
+		var/obj/item/weapon/paper/newtoppaper = locate(/obj/item/weapon/paper) in src
+		if(!newtoppaper) //In case there's no paper, try find a paper bundle instead (why is paper_bundle not a subtype of paper?)
+			newtoppaper = locate(/obj/item/weapon/paper_bundle) in src
+		if(newtoppaper)
+			toppaper = newtoppaper
+		else
+			toppaper = null
+
+obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen/P)
+	if(placing == TRUE)
+		if(pen)
+			to_chat(usr, "<span class = 'warning'>There's already a pen in [src]!</span>")
 			return
+		if(!isPen(P))
+			return
+		to_chat(usr, "<span class='notice'>You slide [P] into [src].</span>")
+		usr.unEquip(P)
+		P.forceMove(src)
+		pen = P
+	else
+		if(!pen)
+			to_chat(usr, "<span class = 'warning'>There isn't a pen in [src] for you to remove!</span>")
+			return
+		to_chat(usr, "<span class = 'notice'>You remove [pen] from [src].</span>")
+		usr.put_in_hands(pen)
+		pen = null
+	update_icon()
+
+/obj/item/weapon/clipboard/proc/show_clipboard() //Show them what's on the clipboard
+	var/dat = "<title>[src]</title>"
+	dat += "<a href='?src=[UID()];doPenThings=[pen ? "Remove" : "Add"]'>[pen ? "Remove pen" : "Add pen"]</a><br><hr>"
+	for(var/obj/item/weapon/P in src)
+		if(isPaperwork(P) == PAPERWORK)
+			dat += "<a href='?src=[UID()];remove=\ref[P]'>Remove</a> <a href='?src=[UID()];topPaper=\ref[P]'>[toppaper == P ? "On top" : "Put on top"]</a> <a href='?src=[UID()];viewOrWrite=\ref[P]'>[toppaper == P ? "<strong>" : null][P.name][toppaper == P ? "</strong>" : null]</a><br><br>"
+		if(isPaperwork(P) == PHOTO)
+			dat += "<a href='?src=[UID()];remove=\ref[P]'>Remove</a> <a href='?src=[UID()];viewOrWrite=\ref[P]'>[P.name]</a><br><br>"
+	var/datum/browser/popup = new(usr, "clipboard", "[src]", 400, 400)
+	popup.set_content(dat)
+	popup.open()
 
 /obj/item/weapon/clipboard/update_icon()
 	overlays.Cut()
 	if(toppaper)
 		overlays += toppaper.icon_state
 		overlays += toppaper.overlays
-	if(haspen)
+	if(pen)
 		overlays += "clipboard_pen"
 	overlays += "clipboard_over"
 	return
 
-/obj/item/weapon/clipboard/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-
-	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/photo))
-		user.drop_item()
-		W.loc = src
-		if(istype(W, /obj/item/weapon/paper))
-			toppaper = W
-		to_chat(user, "<span class='notice'>You clip the [W] onto \the [src].</span>")
+/obj/item/weapon/clipboard/attackby(obj/item/weapon/W, mob/user)
+	var/obj/item/weapon/P = W
+	if(isPaperwork(P)) //If it's a photo, paper bundle, or piece of paper, place it on the clipboard.
+		user.unEquip(P)
+		P.forceMove(src)
+		to_chat(user, "<span class='notice'>You clip [P] onto [src].</span>")
+		if(isPaperwork(P) == PAPERWORK)
+			toppaper = P
 		update_icon()
+	else if(isPen(W)) //If it's not a pen, we're done here
+		if(!toppaper) //If there's no paper we can write on, just stick the pen into the clipboard
+			penPlacement(TRUE, P)
+			return
+		if(pen) //If there's a pen in the clipboard, let's just let them write and not bother asking about the pen
+			var/obj/item/weapon/paper/T = toppaper
+			T.attackby(P, user)
+			return
+		var/writeonwhat = input(user, "Write on [toppaper.name], or place your pen in [src]?", "Pick one!") as null|anything in list("Write", "Place pen")
+		if(!writeonwhat)
+			return
+		if(writeonwhat == "Write")
+			var/obj/item/weapon/paper/T = toppaper
+			T.attackby(P, user)
+		else if(writeonwhat == "Place pen")
+			penPlacement(TRUE, P)
 
-	else if(istype(toppaper) && istype(W, /obj/item/weapon/pen))
-		toppaper.attackby(W, usr, params)
-		update_icon()
-
-	return
-
-/obj/item/weapon/clipboard/attack_self(mob/user as mob)
-	var/dat = "<title>Clipboard</title>"
-	if(haspen)
-		dat += "<A href='?src=[UID()];pen=1'>Remove Pen</A><BR><HR>"
-	else
-		dat += "<A href='?src=[UID()];addpen=1'>Add Pen</A><BR><HR>"
-
-	//The topmost paper. I don't think there's any way to organise contents in byond, so this is what we're stuck with.	-Pete
-	if(toppaper)
-		var/obj/item/weapon/paper/P = toppaper
-		dat += "<A href='?src=[UID()];write=\ref[P]'>Write</A> <A href='?src=[UID()];remove=\ref[P]'>Remove</A> - <A href='?src=[UID()];read=\ref[P]'>[P.name]</A><BR><HR>"
-
-	for(var/obj/item/weapon/paper/P in src)
-		if(P==toppaper)
-			continue
-		dat += "<A href='?src=[UID()];remove=\ref[P]'>Remove</A> - <A href='?src=[UID()];read=\ref[P]'>[P.name]</A><BR>"
-	for(var/obj/item/weapon/photo/Ph in src)
-		dat += "<A href='?src=[UID()];remove=\ref[Ph]'>Remove</A> - <A href='?src=[UID()];look=\ref[Ph]'>[Ph.name]</A><BR>"
-
-	user << browse(dat, "window=clipboard")
-	onclose(user, "clipboard")
-	add_fingerprint(usr)
-	return
+/obj/item/weapon/clipboard/attack_self(mob/user)
+	show_clipboard()
 
 /obj/item/weapon/clipboard/Topic(href, href_list)
 	..()
-	if((usr.stat || usr.restrained()))
+	if(!Adjacent(usr) || usr.incapacitated())
 		return
+	var/obj/item/I = usr.get_active_hand()
+	if(href_list["doPenThings"])
+		if(href_list["doPenThings"] == "Add")
+			var/obj/item/weapon/pen/W = usr.get_active_hand()
+			penPlacement(TRUE, W)
+		else
+			penPlacement(FALSE, pen)
+	else if(href_list["remove"])
+		var/obj/item/P = locate(href_list["remove"])
+		if(isPaperwork(P))
+			usr.put_in_hands(P)
+			to_chat(usr, "<span class = 'notice'>You remove [P] from [src].</span>")
+			checkTopPaper() //So we don't accidentally make the top sheet not be on the clipboard
+	else if(href_list["viewOrWrite"])
+		var/obj/item/weapon/P = locate(href_list["viewOrWrite"])
+		if(!isPaperwork(P))
+			return
+		if(isPen(I) && isPaperwork(P) != PHOTO) //Because you can't write on photos that aren't in your hand
+			P.attackby(I, usr)
+		else if(isPaperwork(P) == PAPERWORK) //Why can't these be subtypes of paper
+			P.examine(usr)
+		else if(isPaperwork(P) == PHOTO)
+			var/obj/item/weapon/photo/Ph = P
+			Ph.show(usr)
+	else if(href_list["topPaper"])
+		var/obj/item/weapon/paper/P = locate(href_list["topPaper"])
+		if(P == toppaper)
+			return
+		to_chat(usr, "<span class = 'notice'>You flick the pages so that [P] is on top.</span>")
+		playsound(loc, "pageturn", 50, 1)
+		toppaper = P
+	update_icon()
+	show_clipboard()
 
-	if(src.loc == usr)
-
-		if(href_list["pen"])
-			if(istype(haspen) && (haspen.loc == src))
-				haspen.loc = usr.loc
-				usr.put_in_hands(haspen)
-				haspen = null
-
-		else if(href_list["addpen"])
-			if(!haspen)
-				var/obj/item/weapon/pen/W = usr.get_active_hand()
-				if(istype(W, /obj/item/weapon/pen))
-					usr.drop_item()
-					W.loc = src
-					haspen = W
-					to_chat(usr, "<span class='notice'>You slot the pen into \the [src].</span>")
-
-		else if(href_list["write"])
-			var/obj/item/weapon/P = locate(href_list["write"])
-
-			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper) && (P == toppaper) )
-
-				var/obj/item/I = usr.get_active_hand()
-
-				if(istype(I, /obj/item/weapon/pen))
-
-					P.attackby(I, usr)
-
-		else if(href_list["remove"])
-			var/obj/item/P = locate(href_list["remove"])
-
-			if(P && (P.loc == src) && (istype(P, /obj/item/weapon/paper) || istype(P, /obj/item/weapon/photo)) )
-
-				P.loc = usr.loc
-				usr.put_in_hands(P)
-				if(P == toppaper)
-					toppaper = null
-					var/obj/item/weapon/paper/newtop = locate(/obj/item/weapon/paper) in src
-					if(newtop && (newtop != P))
-						toppaper = newtop
-					else
-						toppaper = null
-
-		else if(href_list["read"])
-			var/obj/item/weapon/paper/P = locate(href_list["read"])
-
-			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper) )
-				P.show_content(usr)
-
-		else if(href_list["look"])
-			var/obj/item/weapon/photo/P = locate(href_list["look"])
-			if(P && (P.loc == src) && istype(P, /obj/item/weapon/photo) )
-				P.show(usr)
-
-		else if(href_list["top"]) // currently unused
-			var/obj/item/P = locate(href_list["top"])
-			if(P && (P.loc == src) && istype(P, /obj/item/weapon/paper) )
-				toppaper = P
-				to_chat(usr, "<span class='notice'>You move [P.name] to the top.</span>")
-
-		//Update everything
-		attack_self(usr)
-		update_icon()
-	return
+#undef PAPERWORK
+#undef PHOTO

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -8,7 +8,7 @@
 	icon_state = "clipboard"
 	item_state = "clipboard"
 	w_class = WEIGHT_CLASS_SMALL
-	var/obj/item/weapon/pen
+	var/obj/item/weapon/pen/containedpen
 	var/obj/item/weapon/toppaper
 	slot_flags = SLOT_BELT
 	burn_state = FLAMMABLE
@@ -22,7 +22,7 @@
 	set name = "Remove clipboard pen"
 	if(!ishuman(usr) || usr.incapacitated())
 		return
-	penPlacement(FALSE, pen)
+	penPlacement(FALSE, containedpen)
 
 /obj/item/weapon/clipboard/proc/isPaperwork(var/obj/item/weapon/W) //This could probably do with being somewhere else but for now it's fine here.
 	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/paper_bundle))
@@ -46,7 +46,7 @@
 
 obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen/P)
 	if(placing == TRUE)
-		if(pen)
+		if(containedpen)
 			to_chat(usr, "<span class = 'warning'>There's already a pen in [src]!</span>")
 			return
 		if(!isPen(P))
@@ -54,19 +54,19 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 		to_chat(usr, "<span class='notice'>You slide [P] into [src].</span>")
 		usr.unEquip(P)
 		P.forceMove(src)
-		pen = P
+		containedpen = P
 	else
-		if(!pen)
+		if(!containedpen)
 			to_chat(usr, "<span class = 'warning'>There isn't a pen in [src] for you to remove!</span>")
 			return
-		to_chat(usr, "<span class = 'notice'>You remove [pen] from [src].</span>")
-		usr.put_in_hands(pen)
-		pen = null
+		to_chat(usr, "<span class = 'notice'>You remove [containedpen] from [src].</span>")
+		usr.put_in_hands(containedpen)
+		containedpen = null
 	update_icon()
 
 /obj/item/weapon/clipboard/proc/show_clipboard() //Show them what's on the clipboard
 	var/dat = "<title>[src]</title>"
-	dat += "<a href='?src=[UID()];doPenThings=[pen ? "Remove" : "Add"]'>[pen ? "Remove pen" : "Add pen"]</a><br><hr>"
+	dat += "<a href='?src=[UID()];doPenThings=[containedpen ? "Remove" : "Add"]'>[containedpen ? "Remove pen" : "Add pen"]</a><br><hr>"
 	for(var/obj/item/weapon/P in src)
 		if(isPaperwork(P) == PAPERWORK)
 			dat += "<a href='?src=[UID()];remove=\ref[P]'>Remove</a> <a href='?src=[UID()];topPaper=\ref[P]'>[toppaper == P ? "On top" : "Put on top"]</a> <a href='?src=[UID()];viewOrWrite=\ref[P]'>[toppaper == P ? "<strong>" : null][P.name][toppaper == P ? "</strong>" : null]</a><br><br>"
@@ -81,7 +81,7 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 	if(toppaper)
 		overlays += toppaper.icon_state
 		overlays += toppaper.overlays
-	if(pen)
+	if(containedpen)
 		overlays += "clipboard_pen"
 	overlays += "clipboard_over"
 	return
@@ -99,7 +99,7 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 		if(!toppaper) //If there's no paper we can write on, just stick the pen into the clipboard
 			penPlacement(TRUE, P)
 			return
-		if(pen) //If there's a pen in the clipboard, let's just let them write and not bother asking about the pen
+		if(containedpen) //If there's a pen in the clipboard, let's just let them write and not bother asking about the pen
 			var/obj/item/weapon/paper/T = toppaper
 			T.attackby(P, user)
 			return
@@ -125,7 +125,7 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 			var/obj/item/weapon/pen/W = usr.get_active_hand()
 			penPlacement(TRUE, W)
 		else
-			penPlacement(FALSE, pen)
+			penPlacement(FALSE, containedpen)
 	else if(href_list["remove"])
 		var/obj/item/P = locate(href_list["remove"])
 		if(isPaperwork(P))

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -150,4 +150,4 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 
 #undef PAPERWORK
 #undef PHOTO
-#undef IS_PEN(x)
+#undef IS_PEN

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -1,5 +1,6 @@
 #define PAPERWORK	1
 #define PHOTO		2
+#define IS_PEN(x)	(istype(x, /obj/item/weapon/pen))
 
 /obj/item/weapon/clipboard
 	name = "clipboard"
@@ -30,10 +31,6 @@
 	if(istype(W, /obj/item/weapon/photo))
 		return PHOTO
 
-/obj/item/weapon/clipboard/proc/isPen(var/obj/item/weapon/W) //Should also probably be somewhere else
-	if(istype(W, /obj/item/weapon/pen))
-		return TRUE
-
 /obj/item/weapon/clipboard/proc/checkTopPaper()
 	if(toppaper.loc != src) //Oh no! We're missing a top sheet! Better get another one to be at the top.
 		var/obj/item/weapon/paper/newtoppaper = locate(/obj/item/weapon/paper) in src
@@ -49,7 +46,7 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 		if(containedpen)
 			to_chat(usr, "<span class = 'warning'>There's already a pen in [src]!</span>")
 			return
-		if(!isPen(P))
+		if(!IS_PEN(P))
 			return
 		to_chat(usr, "<span class='notice'>You slide [P] into [src].</span>")
 		usr.unEquip(P)
@@ -95,7 +92,7 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 		if(isPaperwork(W) == PAPERWORK)
 			toppaper = W
 		update_icon()
-	else if(isPen(W)) //If it's not a pen, we're done here
+	else if(IS_PEN(W)) //If it's not a pen, we're done here
 		if(!toppaper) //If there's no paper we can write on, just stick the pen into the clipboard
 			penPlacement(TRUE, W)
 			return
@@ -134,7 +131,7 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 		var/obj/item/weapon/P = locate(href_list["viewOrWrite"])
 		if(!isPaperwork(P))
 			return
-		if(isPen(I) && isPaperwork(P) != PHOTO) //Because you can't write on photos that aren't in your hand
+		if(IS_PEN(I) && isPaperwork(P) != PHOTO) //Because you can't write on photos that aren't in your hand
 			P.attackby(I, usr)
 		else if(isPaperwork(P) == PAPERWORK) //Why can't these be subtypes of paper
 			P.examine(usr)
@@ -153,3 +150,4 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 
 #undef PAPERWORK
 #undef PHOTO
+#undef IS_PEN(x)

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -87,30 +87,28 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 	return
 
 /obj/item/weapon/clipboard/attackby(obj/item/weapon/W, mob/user)
-	var/obj/item/weapon/P = W
-	if(isPaperwork(P)) //If it's a photo, paper bundle, or piece of paper, place it on the clipboard.
-		user.unEquip(P)
-		P.forceMove(src)
-		to_chat(user, "<span class='notice'>You clip [P] onto [src].</span>")
-		if(isPaperwork(P) == PAPERWORK)
-			toppaper = P
+	if(isPaperwork(W)) //If it's a photo, paper bundle, or piece of paper, place it on the clipboard.
+		user.unEquip(W)
+		W.forceMove(src)
+		to_chat(user, "<span class='notice'>You clip [W] onto [src].</span>")
+		playsound(loc, "pageturn", 50, 1)
+		if(isPaperwork(W) == PAPERWORK)
+			toppaper = W
 		update_icon()
 	else if(isPen(W)) //If it's not a pen, we're done here
 		if(!toppaper) //If there's no paper we can write on, just stick the pen into the clipboard
-			penPlacement(TRUE, P)
+			penPlacement(TRUE, W)
 			return
 		if(containedpen) //If there's a pen in the clipboard, let's just let them write and not bother asking about the pen
-			var/obj/item/weapon/paper/T = toppaper
-			T.attackby(P, user)
+			toppaper.attackby(W, user)
 			return
 		var/writeonwhat = input(user, "Write on [toppaper.name], or place your pen in [src]?", "Pick one!") as null|anything in list("Write", "Place pen")
 		if(!writeonwhat)
 			return
 		if(writeonwhat == "Write")
-			var/obj/item/weapon/paper/T = toppaper
-			T.attackby(P, user)
+			toppaper.attackby(W, user)
 		else if(writeonwhat == "Place pen")
-			penPlacement(TRUE, P)
+			penPlacement(TRUE, W)
 
 /obj/item/weapon/clipboard/attack_self(mob/user)
 	show_clipboard()
@@ -144,7 +142,7 @@ obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen
 			var/obj/item/weapon/photo/Ph = P
 			Ph.show(usr)
 	else if(href_list["topPaper"])
-		var/obj/item/weapon/paper/P = locate(href_list["topPaper"])
+		var/obj/item/weapon/P = locate(href_list["topPaper"])
 		if(P == toppaper)
 			return
 		to_chat(usr, "<span class = 'notice'>You flick the pages so that [P] is on top.</span>")

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -25,7 +25,7 @@
 		return
 	penPlacement(FALSE, containedpen)
 
-/obj/item/weapon/clipboard/proc/isPaperwork(var/obj/item/weapon/W) //This could probably do with being somewhere else but for now it's fine here.
+/obj/item/weapon/clipboard/proc/isPaperwork(obj/item/weapon/W) //This could probably do with being somewhere else but for now it's fine here.
 	if(istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/weapon/paper_bundle))
 		return PAPERWORK
 	if(istype(W, /obj/item/weapon/photo))
@@ -41,7 +41,7 @@
 	if(..(user, 1) && toppaper)
 		toppaper.examine(user)
 
-obj/item/weapon/clipboard/proc/penPlacement(var/placing, var/obj/item/weapon/pen/P)
+obj/item/weapon/clipboard/proc/penPlacement(placing, obj/item/weapon/pen/P)
 	if(placing)
 		if(containedpen)
 			to_chat(usr, "<span class = 'warning'>There's already a pen in [src]!</span>")


### PR DESCRIPTION
Clipboard code needed improvement, so I improved it.

List of changes:

- You can now move a piece of paper to the top of the clipboard, allowing you to change which piece of paper you scrawl upon when you click it with a pen.
- You can now click on a clipboard with pen in hand to put it directly into the clipboard
- You can now add paper bundles to the clipboard..
- Added "Remove clipboard pen" verb
- Clipboard now uses the default interface instead of the all-white one with Times New Roman font.
- You can now write on any piece of paper in a clipboard instead of only the topmost piece -- to do this, open the interface and click the piece of paper with a pen in active hand.
- Examining a clipboard now shows you the topmost piece of paper, if you are close enough.
- You can now stamp the topmost piece of paper!

Observations:
- The entire paperwork system really needs a refactor so things like photos and paper bundles are children of the paper item.
- Clipboard needs an in-righthand sprite.

Screenshot of clipboard interface: http://i.imgur.com/ZU8VtRC.png
:cl:
tweak: Clipboards now have more functionality. You can now stamp them, attach paper bundles to them, write on any contained paper by clicking on the paper's name using a pen, add pens directly to them, and rearrange what piece of paper is on top!
/:cl: