### PR TITLE
Makes syndie soft suit and helmet have the same description

### DIFF
--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -4,7 +4,8 @@
 	desc = "Top secret Spess Helmet."
 	icon_state = "syndicate"
 	item_state = "syndicate"
-	desc = "Has a tag: Totally not property of an enemy corporation, honest."
+	desc = "Has a tag on it: Totally not property of of a hostile corporation, honest!"
+	w_class = WEIGHT_CLASS_NORMAL
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
 
 /obj/item/clothing/suit/space/syndicate

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -5,7 +5,6 @@
 	icon_state = "syndicate"
 	item_state = "syndicate"
 	desc = "Has a tag on it: Totally not property of of a hostile corporation, honest!"
-	w_class = WEIGHT_CLASS_NORMAL
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
 
 /obj/item/clothing/suit/space/syndicate

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -4,14 +4,14 @@
 	desc = "Top secret Spess Helmet."
 	icon_state = "syndicate"
 	item_state = "syndicate"
-	desc = "Has a tag on it: Totally not property of of a hostile corporation, honest!"
+	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
 
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"
 	icon_state = "syndicate"
 	item_state = "space_suit_syndicate"
-	desc = "Has a tag on it: Totally not property of of a hostile corporation, honest!"
+	desc = "Has a tag on it: Totally not property of a hostile corporation, honest!"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/melee/energy/sword/saber,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank)
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)


### PR DESCRIPTION
Does as the title says. Currently, the descriptions are both different in a minor way. This really bugged me, so I am making a PR to change it.

🆑 imsxz
tweak: Edits the syndicate soft suit helmet's description to match the suit's.
/🆑 