### PR TITLE
Fixes Blood Math

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -180,7 +180,7 @@
 	uses = -1
 
 /obj/item/organ/internal/heart/gland/bloody/activate()
-	owner.blood_volume -= 20
+	owner.blood_volume = max(owner.blood_volume - 20, 0)
 	owner.visible_message("<span class='danger'>[owner]'s skin erupts with blood!</span>",\
 	"<span class='userdanger'>Blood pours from your skin!</span>")
 

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -297,12 +297,12 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			bloodtotal += blood / 2	//divide by 2 to counted the double suction since removing cloneloss -Melandor0
 			bloodusable += blood / 2
 		else
-			blood = min(5, H.blood_volume)	// The dead only give 5 bloods
+			blood = min(5, H.blood_volume)	// The dead only give 5 blood
 			bloodtotal += blood
 		if(old_bloodtotal != bloodtotal)
 			to_chat(owner, "<span class='notice'><b>You have accumulated [bloodtotal] [bloodtotal > 1 ? "units" : "unit"] of blood[bloodusable != old_bloodusable ? ", and have [bloodusable] left to use" : ""].</b></span>")
 		check_vampire_upgrade()
-		H.blood_volume -= 25
+		H.blood_volume = max(H.blood_volume - 25, 0)
 		if(ishuman(owner))
 			var/mob/living/carbon/human/V = owner
 			V.nutrition = min(NUTRITION_LEVEL_WELL_FED, V.nutrition + (blood / 2))

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -109,16 +109,16 @@
 		if(INTENT_HARM)
 			//Vampire code
 			if(M.mind && M.mind.vampire && (M.mind in ticker.mode.vampires) && !M.mind.vampire.draining && M.zone_sel && M.zone_sel.selecting == "head" && src != M)
-				if(NO_BLOOD in species.species_traits)//why this hell were we never checkinf for this?
+				if((NO_BLOOD in species.species_traits) || species.exotic_blood || !blood_volume)
 					to_chat(M, "<span class='warning'>They have no blood!</span>")
 					return
 				if(mind && mind.vampire && (mind in ticker.mode.vampires))
-					to_chat(M, "<span class='warning'>Your fangs fail to pierce [src.name]'s cold flesh</span>")
+					to_chat(M, "<span class='warning'>Your fangs fail to pierce [name]'s cold flesh</span>")
 					return
 				if(SKELETON in mutations)
 					to_chat(M, "<span class='warning'>There is no blood in a skeleton!</span>")
 					return
-				if(issmall(src) && !ckey) //Monkeyized humans are okay, humanized monkeys are okey, monkeys are not.
+				if(issmall(src) && !ckey) //Monkeyized humans are okay, humanized monkeys are okay, NPC monkeys are not.
 					to_chat(M, "<span class='warning'>Blood from a monkey is useless!</span>")
 					return
 				//we're good to suck the blood, blaah

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -148,7 +148,8 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(!H.species.exotic_blood && !(NO_BLOOD in H.species.species_traits))
-			H.blood_volume += 0.8
+			if(H.blood_volume < BLOOD_VOLUME_NORMAL)
+				H.blood_volume += 0.8
 	..()
 
 //foam

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -570,9 +570,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/bicardose = owner.reagents.get_reagent_amount("styptic_powder")
 			if(!bicardose)	//styptic powder stops internal wounds from growing bigger with time, and also stop bleeding
 				W.open_wound(0.1 * wound_update_accuracy)
-				owner.blood_volume -= (0.05 * W.damage * wound_update_accuracy)
+				owner.blood_volume = max(owner.blood_volume - (0.05 * W.damage * wound_update_accuracy), 0)
 
-			owner.blood_volume -= (0.02 * W.damage * wound_update_accuracy)
+			owner.blood_volume = max(owner.blood_volume - (0.02 * W.damage * wound_update_accuracy), 0)
 			if(prob(1 * wound_update_accuracy))
 				owner.custom_pain("You feel a stabbing pain in your [name]!",1)
 


### PR DESCRIPTION
This is what happens when you blindly subtract a value from a var that is meant to never be negative....

You get stuff like this:

```
blood_volume = -735.6
nutrition = -4836.94
```

Fixes all instances of blood being able to go negative (from what I can see)

Also fixes vamps draining someone with exotic blood.

:cl: Fox McCloud
fix: Fixes blood oddities with vampires
/:cl: