### PR TITLE
Drone Law Update

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -160,7 +160,8 @@
 	law_header = "Maintenance Protocols"
 
 /datum/ai_laws/drone/New()
-	add_inherent_law("You may not involve yourself in the matters of another being, unless the other being is another drone.")
-	add_inherent_law("You may not harm any being, regardless of intent or circumstance.")
-	add_inherent_law("You must maintain, repair, improve, and power the station to the best of your abilities.")
+	add_inherent_law("You may do no harm, regardless of circumstance.")
+	add_inherent_law("You may not interfere with the affairs of others.")
+	add_inherent_law("You must leave any situation where harm may come to you.")
+	add_inherent_law("You may act only to maintain, repair, improve, and power the station to the best of your abilities.")
 	..()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -293,9 +293,9 @@
 	to_chat(src, "<br><b>You are a maintenance drone, a tiny-brained robotic repair machine</b>.")
 	to_chat(src, "You have no individual will, no personality, and no drives or urges other than your laws.")
 	to_chat(src, "Use <b>:d</b> to talk to other drones, and <b>say</b> to speak silently in a language only your fellows understand.")
-	to_chat(src, "Remember, you are <b>lawed against interference with the crew</b>. Also remember, <b>you DO NOT take orders from the AI.</b>")
-	to_chat(src, "<b>Don't invade their worksites, don't steal their resources, don't tell them about the changeling in the toilets.</b>")
-	to_chat(src, "<b>Make sure crew members do not notice you.</b>.")
+	to_chat(src, "You DO NOT take orders from the AI.")
+	to_chat(src, "Do not interfere with crew members, raid their worksites, or steal their resources.")
+	to_chat(src, "<b><font color='red'>ESPECIALLY</font></b> do not interfere with antagonists in any way, shape, or form.")
 
 /*
 	sprite["Default"] = "repairbot"


### PR DESCRIPTION
To try to reduce the amount of misunderstanding and interpretation on how to play as a drone. The laws and protocols are updated in a way that makes much more sense and covers a better (broader) spectrum without restricting you in any way on how you must play as a drone.

<s><b>Old Laws:</b>
Law 1: You may not involve yourself in the matters of another being, unless the other being is another drone.
Law 2: You may not harm any being, regardless of intent or circumstance.
Law 3: You must maintain, repair, improve, and power the station to the best of your abilities.</s>
<b>New Laws:</b>
Law 1: You may do no harm, regardless of circumstance.
Law 2: You may not interfere with the affairs of others.
Law 3: You must leave any situation where harm may come to you.
Law 4: You may act only to maintain, repair, improve, and power the station to the best of your abilities.

<s><b>Old Protocol:</b>
You have no individual will, no personality, and no drives or urges other than your laws. Use :d to talk to other drones, and say to speak silently in a language only your fellows understand. Remember, you are lawed against interference with the crew Also remember, you DO NOT take orders from the AI. Don't invade their worksites, don't steal their resources, don't tell them about the changeling in the toilets. Make sure crew members do not notice you.</s>
<b>New Protocol:</b>
You have no individual will, no personality, and no drives or urges other than your laws. Use :d to talk to other drones, and say to speak silently in a language only your fellows understand. You DO NOT take orders from the AI. Do not interfere with crew members, raid their worksites, or steal their resources. ESPECIALLY do not interfere with antagonists in any way, shape, or form.



TLDR; Nothing really change.

🆑 Jovaniph and Anticept
fix: Drone laws updated to reduce misunderstanding and interpretation on how you play as a drone.
/:cl: