### PR TITLE
Item stumbling

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -5,3 +5,6 @@
 #define WEIGHT_CLASS_BULKY    4 //Items that can be weilded or equipped but not stored in an inventory, ex: Defibrillator, Backpack, Space Suits
 #define WEIGHT_CLASS_HUGE     5 //Usually represents objects that require two hands to operate, ex: Shotgun, Two Handed Melee Weapons
 #define WEIGHT_CLASS_GIGANTIC 6 //Essentially means it cannot be picked up or placed in an inventory, ex: Mech Parts, Safe
+
+#define TV_TRIP "trip"
+#define TV_SLIP "slip"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -87,6 +87,15 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	var/sprite_sheets_obj = null //Used to override hardcoded clothing inventory object dmis in human clothing proc.
 	var/list/species_fit = null //This object has a different appearance when worn by these species
 
+	var/trip_verb = TV_TRIP
+	var/trip_bonus = 0
+
+	var/trip_stun = 0
+	var/trip_weaken = 2
+	var/trip_any = FALSE
+	var/trip_walksafe = TRUE
+	var/trip_tiles = 0
+
 /obj/item/New()
 	..()
 	for(var/path in actions_types)
@@ -530,3 +539,14 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 /obj/item/proc/is_equivalent(obj/item/I)
 	return I == src
+
+/obj/item/Crossed(atom/movable/AM)
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		if(prob(trip_bonus))
+			on_trip(H)
+
+/obj/item/proc/on_trip(mob/living/carbon/human/H)
+	if(H.slip(src, trip_stun, trip_weaken, trip_tiles, trip_walksafe, trip_any, trip_verb))
+		H.visible_message("<span class='warning'>[H] [trip_verb]s on [src]!</span>")
+		return TRUE

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -8,10 +8,6 @@
 /*
  * Soap
  */
-/obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
-	if(istype(AM, /mob/living/carbon))
-		var/mob/living/carbon/M = AM
-		M.slip("soap", 4, 2)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -50,24 +50,21 @@
 */
 
 /obj/item/weapon/grown/bananapeel/traitorpeel
+	trip_stun = 0
+	trip_weaken = 7
+	trip_tiles = 4
+	trip_walksafe = FALSE
+
+	trip_bonus = 100
 
 
-/obj/item/weapon/grown/bananapeel/traitorpeel/Crossed(AM as mob|obj)
-	var/burned = rand(2,5)
-	if(istype(AM, /mob/living/carbon))
-		var/mob/living/carbon/M = AM
-		if(ishuman(M))
-			if(isobj(M:shoes))
-				if(M:shoes.flags & NOSLIP)
-					return
-			else
-				to_chat(M, "<span class='warning'>Your feet feel like they're on fire!</span>")
-				M.take_overall_damage(0, max(0, (burned - 2)))
-
-		if(!istype(M, /mob/living/carbon/slime) && !isrobot(M))
-			M.slip("banana peel!", 0, 7, 4)
-			M.take_organ_damage(2) // Was 5 -- TLE
-			M.take_overall_damage(0, burned)
+/obj/item/weapon/grown/bananapeel/traitorpeel/on_trip(mob/living/carbon/human/H)
+	. = ..()
+	if(.)
+		var/burned = rand(2,5)
+		to_chat(H, "<span class='warning'>Your feet feel like they're on fire!</span>")
+		H.take_overall_damage(0, max(0, 2*burned - 2))
+		H.take_organ_damage(2) // Was 5 -- TLE
 
 /obj/item/weapon/grown/bananapeel/traitorpeel/throw_impact(atom/hit_atom)
 	var/burned = rand(1,3)

--- a/code/game/objects/items/weapons/grenades/clowngrenade.dm
+++ b/code/game/objects/items/weapons/grenades/clowngrenade.dm
@@ -68,7 +68,7 @@
 
 /obj/item/weapon/grown/bananapeel/traitorpeel/throw_impact(atom/hit_atom)
 	var/burned = rand(1,3)
-	if(istype(hit_atom ,/mob/living))
+	if(istype(hit_atom, /mob/living))
 		var/mob/living/M = hit_atom
 		M.take_organ_damage(0, burned)
 	return ..()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -9,6 +9,13 @@
 	throw_speed = 4
 	throw_range = 20
 	discrete = 1
+
+	trip_stun = 4
+	trip_weaken = 2
+	trip_bonus = 100
+	trip_walksafe = FALSE
+	trip_verb = TV_SLIP
+
 	var/cleanspeed = 50 //slower than mop
 
 /obj/item/weapon/soap/nanotrasen

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -69,16 +69,16 @@
 
 			switch(src.wet)
 				if(TURF_WET_WATER)
-					if(!(M.slip("wet floor", 4, 2, 0, 1)))
+					if(!(M.slip("wet floor", 4, 2, tilesSlipped = 0, walkSafely = 1)))
 						M.inertia_dir = 0
 						return
 
 				if(TURF_WET_LUBE) //lube
-					M.slip("floor", 0, 5, 3, 0, 1)
+					M.slip("floor", 0, 5, tilesSlipped = 3, walkSafely = 0, slipAny = 1)
 
 
 				if(TURF_WET_ICE) // Ice
-					if(!(prob(30) && M.slip("icy floor", 4, 2, 1, 1)))
+					if(!(prob(30) && M.slip("icy floor", 4, 2, tilesSlipped = 1, walkSafely = 1)))
 						M.inertia_dir = 0
 
 /turf/simulated/ChangeTurf(var/path)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -131,6 +131,11 @@
 			T.on_cross(src, AM)
 	..()
 
+/obj/item/weapon/reagent_containers/food/snacks/grown/on_trip(mob/living/carbon/human/H)
+	. = ..()
+	if(. && seed)
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			T.on_slip(src, H)
 
 // Glow gene procs
 /obj/item/weapon/reagent_containers/food/snacks/grown/generate_trash(atom/location)

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -113,9 +113,12 @@
 /obj/item/weapon/grown/bananapeel/specialpeel     //used by /obj/item/clothing/shoes/clown_shoes/banana_shoes
 	name = "synthesized banana peel"
 	desc = "A synthetic banana peel."
+	trip_stun = 2
+	trip_weaken = 2
+	trip_bonus = 100
+	trip_walksafe = FALSE
+	trip_verb = TV_SLIP
 
-/obj/item/weapon/grown/bananapeel/specialpeel/Crossed(AM)
-	if(iscarbon(AM))
-		var/mob/living/carbon/carbon = AM
-		if(carbon.slip("[src]", 2, 2))
-			qdel(src)
+/obj/item/weapon/grown/bananapeel/specialpeel/on_trip(mob/living/carbon/human/H)
+	if(..())
+		qdel(src)

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -57,6 +57,12 @@
 			T.on_cross(src, AM)
 	..()
 
+/obj/item/weapon/grown/on_trip(mob/living/carbon/human/H)
+	. = ..()
+	if(. && seed)
+		for(var/datum/plant_gene/trait/T in seed.genes)
+			T.on_slip(src, H)
+
 /obj/item/weapon/grown/throw_impact(atom/hit_atom)
 	if(!..()) //was it caught by a mob?
 		if(seed)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -204,24 +204,23 @@
 	rate = 0.1
 	examine_line = "<span class='info'>It has a very slippery skin.</span>"
 
-/datum/plant_gene/trait/slip/on_cross(obj/item/weapon/reagent_containers/food/snacks/grown/G, atom/target)
-	if(iscarbon(target))
-		var/obj/item/seeds/seed = G.seed
-		var/mob/living/carbon/M = target
+/datum/plant_gene/trait/slip/on_new(obj/item/weapon/reagent_containers/food/snacks/grown/G, newloc)
+	. = ..()
+	if(istype(G) && ispath(G.trash, /obj/item/weapon/grown))
+		return
 
-		var/stun_len = seed.potency * rate * 0.8
-		if(istype(G) && ispath(G.trash, /obj/item/weapon/grown))
-			return
+	var/stun_len = G.seed.potency * rate * 0.8
 
-		if(!istype(G, /obj/item/weapon/grown/bananapeel) && (!G.reagents || !G.reagents.has_reagent("lube")))
-			stun_len /= 3
+	if(!istype(G, /obj/item/weapon/grown/bananapeel) && (!G.reagents || !G.reagents.has_reagent("lube")))
+		stun_len /= 3
 
-		var/stun = min(stun_len, 7)
-		var/weaken = min(stun_len, 7)
+	stun_len = min(stun_len, 7) // No fun allowed
 
-		if(M.slip("[G]", stun, weaken))
-			for(var/datum/plant_gene/trait/T in seed.genes)
-				T.on_slip(G, M)
+	G.trip_stun = stun_len
+	G.trip_weaken = stun_len
+	G.trip_bonus = 100
+	G.trip_verb = TV_SLIP
+	G.trip_walksafe = FALSE
 
 /datum/plant_gene/trait/cell_charge
 	// Cell recharging trait. Charges all mob's power cells to (potency*rate)% mark when eaten.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -947,6 +947,8 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	visible_message("<span class='warning'>[src] [slipVerb]s on [description]!</span>", "<span class='danger'>You [slipVerb] on [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 	// Something something don't run with scissors
+	if(CLUMSY in mutations)
+		CLickOn(src)
 	Stun(stun)
 	Weaken(weaken)
 	return 1

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -944,7 +944,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		for(var/t = 0, t<=tilesSlipped, t++)
 			spawn (t) step(src, src.dir)
 	stop_pulling()
-	to_chat(src, "<span class='notice'>You [slipVerb]ped on [description]!</span>")
+	visible_message("<span class='warning'>[src] [slipVerb]s on [description]!</span>", "<span class='danger'>You [slipVerb] on [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 	// Something something don't run with scissors
 	Stun(stun)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -930,7 +930,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 				W.plane = initial(W.plane)
 
 
-/mob/living/carbon/proc/slip(var/description, var/stun, var/weaken, var/tilesSlipped, var/walkSafely, var/slipAny)
+/mob/living/carbon/proc/slip(description, stun, weaken, tilesSlipped, walkSafely, slipAny, slipVerb = "slip")
 	if(flying || buckled || (walkSafely && m_intent == MOVE_INTENT_WALK))
 		return 0
 	if((lying) && (!(tilesSlipped)))
@@ -944,10 +944,10 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 		for(var/t = 0, t<=tilesSlipped, t++)
 			spawn (t) step(src, src.dir)
 	stop_pulling()
-	to_chat(src, "<span class='notice'>You slipped on [description]!</span>")
+	to_chat(src, "<span class='notice'>You [slipVerb]ped on [description]!</span>")
 	playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-	if(stun)
-		Stun(stun)
+	// Something something don't run with scissors
+	Stun(stun)
 	Weaken(weaken)
 	return 1
 

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -21,6 +21,9 @@
 	burntime = 5
 	attack_verb = list("bapped")
 
+	trip_bonus = 5 // Putting down lots of paper can make things slippery
+	trip_verb = TV_SLIP
+
 	var/info		//What's actually written on the paper.
 	var/info_links	//A different version of the paper which includes html links at fields and EOF
 	var/stamps		//The (text for the) stamps on the paper.

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -24,6 +24,10 @@
 	var/colour = "black"	//what colour the ink is!
 	pressure_resistance = 2
 
+	// Small chance to trip on the pen if you're not careful
+	trip_bonus = 3
+	trip_verb = TV_SLIP
+
 /obj/item/weapon/pen/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='suicide'>[user] starts scribbling numbers over \himself with the [src.name]! It looks like \he's trying to commit sudoku.</span>")
 	return (BRUTELOSS)

--- a/code/modules/pda/pdas.dm
+++ b/code/modules/pda/pdas.dm
@@ -38,10 +38,11 @@
 	desc = "A portable microcomputer by Thinktronic Systems, LTD. The surface is coated with polytetrafluoroethylene and banana drippings."
 	ttone = "honk"
 
-/obj/item/device/pda/clown/Crossed(AM as mob|obj) //Clown PDA is slippery.
-	if(istype(AM, /mob/living/carbon))
-		var/mob/living/carbon/M =	AM
-		M.slip("pda", 8, 5, 0, 1)
+	trip_stun = 8
+	trip_weaken = 5
+	trip_bonus = 100
+	trip_walksafe = TRUE
+	trip_verb = TV_SLIP
 
 /obj/item/device/pda/mime
 	default_cartridge = /obj/item/weapon/cartridge/mime

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -435,7 +435,7 @@ var/static/regex/multispin_words = regex("like a record baby")
 			playsound(get_turf(owner), 'sound/items/bikehorn.ogg', 300, 1)
 		if(owner.mind && owner.mind.assigned_role == "Clown")
 			for(var/mob/living/carbon/C in listeners)
-				C.slip(0,7 * power_multiplier)
+				C.slip("your feet", 0, 7 * power_multiplier)
 			next_command = world.time + cooldown_stun
 		else
 			next_command = world.time + cooldown_meme


### PR DESCRIPTION
Any item that is not tiny is now capable of tripping you when you step on it, with a probability that starts out low for small items, that increases with the size of the item. This can either be negated by walking, or keeping your environment clear of detritus. 

Other items that trip or slip you have been refactored to work with this new system.

For normal objects, the rates are as follows:
* Tiny: 0%
* Small: 3%
* Normal: 5%
* Bulky: 10%
* Huge: 20%
* Gigantic: 40%

Other objects capable of possibly inducing a slip are pens, and paper, at 3% and 5% respectively.

:cl:Crazylemon
feature: Clutter that is Small or larger is now capable of causing you to stumble if you run on it. Keep your workplace tidy!
/:cl: