### PR TITLE
Fixes #7826 & #7809 - blood decals being unanchored

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -1,8 +1,8 @@
 /obj/effect/decal/cleanable
+	anchored = 1
 	var/list/random_icon_states = list()
 	var/noscoop = 0   //if it has this, don't let it be scooped up
 	var/noclear = 0    //if it has this, don't delete it when its' scooped up
-	anchored = 1
 
 /obj/effect/decal/cleanable/proc/can_bloodcrawl_in()
 	return FALSE

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -2,6 +2,7 @@
 	var/list/random_icon_states = list()
 	var/noscoop = 0   //if it has this, don't let it be scooped up
 	var/noclear = 0    //if it has this, don't delete it when its' scooped up
+	anchored = 1
 
 /obj/effect/decal/cleanable/proc/can_bloodcrawl_in()
 	return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -196,7 +196,7 @@
 					choices += L
 		for(var/obj/O in oview(1,src))
 			if(Adjacent(O) && !O.anchored)
-				if(!istype(O, /obj/structure/spider/terrorweb) && !istype(O, /obj/structure/spider/cocoon) && !istype(O, /obj/structure/spider/spiderling/terror_spiderling) && !istype(O, /obj/effect))
+				if(!istype(O, /obj/structure/spider/terrorweb) && !istype(O, /obj/structure/spider/cocoon) && !istype(O, /obj/structure/spider/spiderling/terror_spiderling))
 					choices += O
 		if(choices.len)
 			cocoon_target = input(src,"What do you wish to cocoon?") in null|choices

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/actions.dm
@@ -196,7 +196,7 @@
 					choices += L
 		for(var/obj/O in oview(1,src))
 			if(Adjacent(O) && !O.anchored)
-				if(!istype(O, /obj/structure/spider/terrorweb) && !istype(O, /obj/structure/spider/cocoon) && !istype(O, /obj/structure/spider/spiderling/terror_spiderling))
+				if(!istype(O, /obj/structure/spider/terrorweb) && !istype(O, /obj/structure/spider/cocoon) && !istype(O, /obj/structure/spider/spiderling/terror_spiderling) && !istype(O, /obj/effect))
 					choices += O
 		if(choices.len)
 			cocoon_target = input(src,"What do you wish to cocoon?") in null|choices


### PR DESCRIPTION
🆑 Kyep
fix: Blood decals are no longer movable. This means LINDA cannot move them, spiders cannot wrap them, etc.
/🆑
