### PR TITLE
Admins can now set a var to allow a mob to spam-attack

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -27,9 +27,9 @@
 		client.click_intercept.InterceptClickOn(src, params, A)
 		return
 
-	if(world.time <= next_click)
+	if(next_click > world.time)
 		return
-	next_click = world.time + 1
+	changeNext_click(1)
 
 	if(control_disabled || stat)
 		return

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -3,8 +3,35 @@
 	~Sayu
 */
 
+
+// THESE DO NOT AFFECT THE BASE 1 DECISECOND DELAY OF NEXT_CLICK
+/mob/var/next_move_adjust = 0 //Amount to adjust action delays by, + or -
+/mob/var/next_move_modifier = 1 //Value to multiply action delays by
+
+//Delays the mob's next action by num deciseconds
+// eg: 10-3 = 7 deciseconds of delay
+// eg: 10*0.5 = 5 deciseconds of delay
+// DOES NOT EFFECT THE BASE 1 DECISECOND DELAY OF NEXT_CLICK
+
+/mob/proc/changeNext_move(num)
+	next_move = world.time + ((num+next_move_adjust)*next_move_modifier)
+
 // 1 decisecond click delay (above and beyond mob/next_move)
+//This is mainly modified by click code, to modify click delays elsewhere, use next_move and changeNext_move()
 /mob/var/next_click	= 0
+
+// THESE DO AFFECT THE BASE 1 DECISECOND DELAY OF NEXT_CLICK
+/mob/var/next_click_adjust = 0
+/mob/var/next_click_modifier = 1 //Value to multiply click delays by
+
+//Delays the mob's next click by num deciseconds
+// eg: 10-3 = 7 deciseconds of delay
+// eg: 10*0.5 = 5 deciseconds of delay
+// DOES NOT EFFECT THE BASE 1 DECISECOND DELAY OF NEXT_CLICK
+
+/mob/proc/changeNext_click(num)
+	next_click = world.time + ((num+next_click_adjust)*next_click_modifier)
+
 
 /*
 	Before anything else, defer these calls to a per-mobtype handler.  This allows us to
@@ -38,9 +65,9 @@
 		client.click_intercept.InterceptClickOn(src, params, A)
 		return
 
-	if(world.time <= next_click)
+	if(next_click > world.time)
 		return
-	next_click = world.time + 1
+	changeNext_click(1)
 
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] && modifiers["ctrl"])
@@ -136,9 +163,6 @@
 
 	return
 
-/mob/proc/changeNext_move(num)
-	next_move = world.time + num
-
 // Default behavior: ignore double clicks, consider them normal clicks instead
 /mob/proc/DblClickOn(var/atom/A, var/params)
 	return
@@ -201,7 +225,7 @@
 
 /mob/living/carbon/MiddleClickOn(var/atom/A)
 	if(!src.stat && src.mind && src.mind.changeling && src.mind.changeling.chosen_sting && (istype(A, /mob/living/carbon)) && (A != src))
-		next_click = world.time + 5
+		changeNext_click(5)
 		mind.changeling.chosen_sting.try_to_sting(src, A)
 	else
 		..()
@@ -256,7 +280,7 @@
 
 /mob/living/carbon/AltClickOn(var/atom/A)
 	if(!src.stat && src.mind && src.mind.changeling && src.mind.changeling.chosen_sting && (istype(A, /mob/living/carbon)) && (A != src))
-		next_click = world.time + 5
+		changeNext_click(5)
 		mind.changeling.chosen_sting.try_to_sting(src, A)
 	else
 		..()

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -11,9 +11,9 @@
 		client.click_intercept.InterceptClickOn(src, params, A)
 		return
 
-	if(world.time <= next_click)
+	if(next_click > world.time)
 		return
-	next_click = world.time + 1
+	changeNext_click(1)
 
 
 	var/list/modifiers = params2list(params)

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -13,7 +13,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 		to_chat(user, "<span class='warning'><b>[user.ranged_ability.name]</b> has been disabled.")
 		user.ranged_ability.remove_ranged_ability(user)
 		return TRUE //TRUE for failed, FALSE for passed.
-	user.next_click = world.time + CLICK_CD_CLICK_ABILITY
+	user.changeNext_click(CLICK_CD_CLICK_ABILITY)
 	user.face_atom(A)
 	return FALSE
 


### PR DESCRIPTION
By setting the `nextClick_modifier` and `nextMove_modifier` vars on a mob to 0, admins are able to let mobs act very stupid fast. If they want to curse a player instead, they can set the appropriate `_adjust` var instead to something very high. For purposes of fun only.