### PR TITLE
Fixes tab issues on enforcer handgun magazine

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -235,8 +235,8 @@
 		return 1
 	return 0
 
-	/obj/item/ammo_box/magazine/m45/enforcer45/lethal
-		ammo_type = /obj/item/ammo_casing/c45
+/obj/item/ammo_box/magazine/m45/enforcer45/lethal
+	ammo_type = /obj/item/ammo_casing/c45
 
 /obj/item/ammo_box/magazine/wt550m9
 	name = "wt550 magazine (4.6x30mm)"


### PR DESCRIPTION
Fixes a poorly offset object definition on the enforcer lethal magazine.

No CL as its a fix to an admin only weapon.