### PR TITLE
Fixes IPC and Diona Knockdown Immunity

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -1,14 +1,12 @@
 ///////////////////ORGAN DEFINES///////////////////
 
 // Organ defines.
-#define ORGAN_CUT_AWAY   1
-#define ORGAN_BROKEN     2
-#define ORGAN_DESTROYED  4
-#define ORGAN_ROBOT      8
-#define ORGAN_SPLINTED   16
-#define ORGAN_DEAD       32
-#define ORGAN_MUTATED    64
-#define ORGAN_ASSISTED   128
+#define ORGAN_BROKEN     1
+#define ORGAN_ROBOT      2
+#define ORGAN_SPLINTED   4
+#define ORGAN_DEAD       8
+#define ORGAN_MUTATED    16
+#define ORGAN_ASSISTED   32
 
 #define DROPLIMB_SHARP 0
 #define DROPLIMB_BLUNT 1

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -20,7 +20,7 @@
 		H.EyeBlurry(20)
 		var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
 		if(istype(E))
-			E.damage = max(E.damage+5, 0)
+			E.take_damage(5, 1)
 		H.AdjustConfused(3)
 	for(var/mob/living/silicon/S in range(2,user))
 		to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -48,7 +48,7 @@
 			O.status = 0
 			O.trace_chemicals.Cut()
 		for(var/obj/item/organ/internal/IO in H.internal_organs)
-			IO.damage = 0
+			IO.rejuvenate()
 			IO.trace_chemicals.Cut()
 		H.remove_all_embedded_objects()
 		H.updatehealth()

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -122,7 +122,7 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	vox.update_eyes()
 
 	for(var/obj/item/organ/external/limb in vox.bodyparts)
-		limb.status &= ~(ORGAN_DESTROYED | ORGAN_ROBOT)
+		limb.status &= ~ORGAN_ROBOT
 
 	//Now apply cortical stack.
 	var/obj/item/weapon/implant/cortical/I = new(vox)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -413,8 +413,6 @@
 			organData["shrapnel_len"] = shrapnelData.len
 
 			var/organStatus[0]
-			if(E.status & ORGAN_DESTROYED)
-				organStatus["destroyed"] = 1
 			if(E.status & ORGAN_BROKEN)
 				organStatus["broken"] = E.broken_description
 			if(E.status & ORGAN_ROBOT)
@@ -614,10 +612,7 @@
 					imp += "Unknown body present:"
 				if(!AN && !open && !infected & !imp)
 					AN = "None:"
-				if(!(e.status & ORGAN_DESTROYED))
-					dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[e.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][internal_bleeding][lung_ruptured]</td>"
-				else
-					dat += "<td>[e.name]</td><td>-</td><td>-</td><td>Not Found</td>"
+				dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[e.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][internal_bleeding][lung_ruptured]</td>"
 				dat += "</tr>"
 			for(var/obj/item/organ/internal/i in occupant.internal_organs)
 				var/mech = i.desc

--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -94,7 +94,7 @@ var/global/list/image/splatter_cache=list()
 		var/obj/item/organ/external/l_foot = H.get_organ("l_foot")
 		var/obj/item/organ/external/r_foot = H.get_organ("r_foot")
 		var/hasfeet = 1
-		if((!l_foot || l_foot.status & ORGAN_DESTROYED) && (!r_foot || r_foot.status & ORGAN_DESTROYED))
+		if(!l_foot && !r_foot)
 			hasfeet = 0
 		if(H.shoes && blood_state && bloodiness)
 			var/obj/item/clothing/shoes/S = H.shoes

--- a/code/game/objects/effects/decals/Cleanable/tracks.dm
+++ b/code/game/objects/effects/decals/Cleanable/tracks.dm
@@ -36,7 +36,7 @@ var/global/list/image/fluidtrack_cache=list()
 		var/obj/item/organ/external/l_foot = H.get_organ("l_foot")
 		var/obj/item/organ/external/r_foot = H.get_organ("r_foot")
 		var/hasfeet = 1
-		if((!l_foot || l_foot.status & ORGAN_DESTROYED) && (!r_foot || r_foot.status & ORGAN_DESTROYED))
+		if(!l_foot && !r_foot)
 			hasfeet = 0
 		if(S && S.bloody_shoes[blood_state] && S.blood_color == basecolor)
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)
@@ -59,7 +59,7 @@ var/global/list/image/fluidtrack_cache=list()
 		var/obj/item/organ/external/l_foot = H.get_organ("l_foot")
 		var/obj/item/organ/external/r_foot = H.get_organ("r_foot")
 		var/hasfeet = 1
-		if((!l_foot || l_foot.status & ORGAN_DESTROYED) && (!r_foot || r_foot.status & ORGAN_DESTROYED))
+		if(!l_foot && !r_foot)
 			hasfeet = 0
 		if(S && S.bloody_shoes[blood_state] && S.blood_color == basecolor)
 			S.bloody_shoes[blood_state] = max(S.bloody_shoes[blood_state] - BLOOD_LOSS_PER_STEP, 0)

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -55,7 +55,8 @@
 		proc/dead_legs(mob/living/carbon/human/H as mob)
 			var/obj/item/organ/external/l = H.get_organ("l_leg")
 			var/obj/item/organ/external/r = H.get_organ("r_leg")
-			if(l && !(l.status & ORGAN_DESTROYED))
-				l.status |= ORGAN_DESTROYED
-			if(r && !(r.status & ORGAN_DESTROYED))
-				r.status |= ORGAN_DESTROYED
+			if(l)
+				l.droplimb(0, DROPLIMB_SHARP)
+			if(r)
+				r.droplimb(0, DROPLIMB_SHARP)
+

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -37,7 +37,7 @@
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
 			if(E)
-				E.damage += 8
+				E.take_damage(8, 1)
 
 	if(M.flash_eyes(affect_silicon = 1))
 		M.Stun(max(10/distance, 3))

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -41,12 +41,12 @@
 			var/mob/living/carbon/human/driver = user
 			var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
 			var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
-			if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
+			if(!l_hand && !r_hand)
 				return 0 // No hands to drive your chair? Tough luck!
 
 			for(var/organ_name in list("l_hand","r_hand","l_arm","r_arm"))
 				var/obj/item/organ/external/E = driver.get_organ(organ_name)
-				if(!E || (E.status & ORGAN_DESTROYED))
+				if(!E)
 					calculated_move_delay += 4
 				else if(E.status & ORGAN_SPLINTED)
 					calculated_move_delay += 0.5
@@ -129,12 +129,12 @@
 			var/mob/living/carbon/human/driver = user
 			var/obj/item/organ/external/l_hand = driver.get_organ("l_hand")
 			var/obj/item/organ/external/r_hand = driver.get_organ("r_hand")
-			if((!l_hand || (l_hand.status & ORGAN_DESTROYED)) && (!r_hand || (r_hand.status & ORGAN_DESTROYED)))
+			if(!l_hand && !r_hand)
 				calculated_move_delay += 0.5	//I can ride my bike with no handlebars... (but it's slower)
 
 			for(var/organ_name in list("l_leg","r_leg","l_foot","r_foot"))
 				var/obj/item/organ/external/E = driver.get_organ(organ_name)
-				if(!E || (E.status & ORGAN_DESTROYED))
+				if(!E)
 					return 0	//Bikes need both feet/legs to work. missing even one makes it so you can't ride the bike
 				else if(E.status & ORGAN_SPLINTED)
 					calculated_move_delay += 0.5

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -513,7 +513,7 @@ client/proc/one_click_antag()
 	new_vox.update_eyes()
 
 	for(var/obj/item/organ/external/limb in new_vox.bodyparts)
-		limb.status &= ~(ORGAN_DESTROYED | ORGAN_ROBOT)
+		limb.status &= ~ORGAN_ROBOT
 
 	//Now apply cortical stack.
 	var/obj/item/weapon/implant/cortical/I = new(new_vox)

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -2170,7 +2170,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	// Wheelchair necessary?
 	var/obj/item/organ/external/l_foot = character.get_organ("l_foot")
 	var/obj/item/organ/external/r_foot = character.get_organ("r_foot")
-	if((!l_foot || l_foot.status & ORGAN_DESTROYED) && (!r_foot || r_foot.status & ORGAN_DESTROYED))
+	if(!l_foot && !r_foot)
 		var/obj/structure/stool/bed/chair/wheelchair/W = new /obj/structure/stool/bed/chair/wheelchair (character.loc)
 		character.buckled = W
 		character.update_canmove()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -216,10 +216,13 @@
 				"<span class='notice'>You check yourself for injuries.</span>" \
 				)
 
-			for(var/obj/item/organ/external/org in H.bodyparts)
+			var/list/missing = list("head", "chest", "groin", "l_arm", "r_arm", "l_hand", "r_hand", "l_leg", "r_leg", "l_foot", "r_foot")
+			for(var/X in H.bodyparts)
+				var/obj/item/organ/external/LB = X
+				missing -= LB.limb_name
 				var/status = ""
-				var/brutedamage = org.brute_dam
-				var/burndamage = org.burn_dam
+				var/brutedamage = LB.brute_dam
+				var/burndamage = LB.burn_dam
 
 				if(brutedamage > 0)
 					status = "bruised"
@@ -236,16 +239,17 @@
 					status += "blistered"
 				else if(burndamage > 0)
 					status += "numb"
-				if(org.status & ORGAN_DESTROYED)
-					status = "MISSING!"
-				if(org.status & ORGAN_MUTATED)
+				if(LB.status & ORGAN_MUTATED)
 					status = "weirdly shapen."
 				if(status == "")
 					status = "OK"
-				src.show_message(text("\t []My [] is [].",status=="OK"?"<span class='notice'></span>":"<span class='warning'></span>",org.name,status),1)
+				to_chat(src, "\t <span class='[status == "OK" ? "notice" : "warning"]'>Your [LB.name] is [status].</span>")
 
-				for(var/obj/item/I in org.embedded_objects)
-					to_chat(src, "\t <a href='byond://?src=[UID()];embedded_object=[I.UID()];embedded_limb=[org.UID()]' class='warning'>There is \a [I] embedded in your [org.name]!</a>")
+				for(var/obj/item/I in LB.embedded_objects)
+					to_chat(src, "\t <a href='byond://?src=[UID()];embedded_object=[I.UID()];embedded_limb=[LB.UID()]' class='warning'>There is \a [I] embedded in your [LB.name]!</a>")
+
+			for(var/t in missing)
+				to_chat(src, "<span class='boldannounce'>Your [parse_zone(t)] is missing!</span>")
 
 			if(H.bleed_rate)
 				to_chat(src, "<span class='danger'>You are bleeding!</span>")
@@ -297,7 +301,9 @@
 					)
 					if(istype(src,/mob/living/carbon/human))
 						var/mob/living/carbon/human/H = src
-						if(H.w_uniform)
+						if(H.wear_suit)
+							H.wear_suit.add_fingerprint(M)
+						else if(H.w_uniform)
 							H.w_uniform.add_fingerprint(M)
 
 /mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -323,15 +323,15 @@
 			if(1)
 				to_chat(src, "<span class='warning'>Your eyes sting a little.</span>")
 				if(prob(40)) //waiting on carbon organs
-					E.damage += 1
+					E.take_damage(1, 1)
 
 			if(2)
 				to_chat(src, "<span class='warning'>Your eyes burn.</span>")
-				E.damage += rand(2, 4)
+				E.take_damage(rand(2, 4), 1)
 
 			else
 				to_chat(src, "Your eyes itch and burn severely!</span>")
-				E.damage += rand(12, 16)
+				E.take_damage(rand(12, 16), 1)
 
 		if(E.damage > E.min_bruised_damage)
 			AdjustEyeBlind(damage)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -37,7 +37,7 @@
 			if(species.name == "Drask")		//Only Drask can make whale noises
 				on_CD = handle_emote_CD()			//proc located in code\modules\mob\emote.dm
 			else
-				return				
+				return
 		if("howl", "howls")
 			if (species.name == "Vulpkanin")		//Only Vulpkanin can howl
 				on_CD = handle_emote_CD(100)
@@ -47,7 +47,7 @@
 			if (species.name == "Vulpkanin")		//Only Vulpkanin can growl
 				on_CD = handle_emote_CD()
 			else
-				return				
+				return
 		if("squish", "squishes")
 			var/found_slime_bodypart = 0
 
@@ -101,7 +101,7 @@
 		if("me")									//OKAY SO RANT TIME, THIS FUCKING HAS TO BE HERE OR A SHITLOAD OF THINGS BREAK
 			return custom_emote(m_type, message)	//DO YOU KNOW WHY SHIT BREAKS? BECAUSE SO MUCH OLDCODE CALLS mob.emote("me",1,"whatever_the_fuck_it_wants_to_emote")
 													//WHO THE FUCK THOUGHT THAT WAS A GOOD FUCKING IDEA!?!?
-													
+
 		if("howl", "howls")
 			var/M = handle_emote_param(param) //Check to see if the param is valid (mob with the param name is in view).
 			message = "<B>[src]</B> howls[M ? " at [M]" : ""]!"
@@ -113,7 +113,7 @@
 			message = "<B>[src]</B> growls[M ? " at [M]" : ""]."
 			playsound(loc, "growls", 80, 0)
 			m_type = 2
-			
+
 		if("ping", "pings")
 			var/M = handle_emote_param(param)
 
@@ -750,9 +750,9 @@
 				var/obj/item/organ/external/R = H.get_organ("r_hand")
 				var/left_hand_good = 0
 				var/right_hand_good = 0
-				if(L && (!(L.status & ORGAN_DESTROYED)) && (!(L.status & ORGAN_SPLINTED)) && (!(L.status & ORGAN_BROKEN)))
+				if(L && (!(L.status & ORGAN_SPLINTED)) && (!(L.status & ORGAN_BROKEN)))
 					left_hand_good = 1
-				if(R && (!(R.status & ORGAN_DESTROYED)) && (!(R.status & ORGAN_SPLINTED)) && (!(R.status & ORGAN_BROKEN)))
+				if(R && (!(R.status & ORGAN_SPLINTED)) && (!(R.status & ORGAN_BROKEN)))
 					right_hand_good = 1
 
 				if(!left_hand_good && !right_hand_good)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -609,7 +609,7 @@
 //Returns "Unknown" if facially disfigured and real_name if not. Useful for setting name when polyacided or when updating a human's name variable
 /mob/living/carbon/human/proc/get_face_name()
 	var/obj/item/organ/external/head = get_organ("head")
-	if( !head || head.disfigured || (head.status & ORGAN_DESTROYED) || !real_name || (HUSK in mutations) )	//disfigured. use id-name if possible
+	if( !head || head.disfigured || !real_name || (HUSK in mutations) )	//disfigured. use id-name if possible
 		return "Unknown"
 	return real_name
 
@@ -1590,7 +1590,7 @@
 		return
 
 	var/obj/item/organ/external/head/head_organ = get_organ("head")
-	if(!head_organ || (head_organ.status & ORGAN_DESTROYED)) //If the rock'em-sock'em robot's head came off during a fight, they shouldn't be able to change their screen/optics.
+	if(!head_organ) //If the rock'em-sock'em robot's head came off during a fight, they shouldn't be able to change their screen/optics.
 		to_chat(src, "<span class='warning'>Where's your head at? Can't change your monitor/display without one.</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -201,10 +201,10 @@ emp_act
 			qdel(src)
 
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(user.zone_sel.selecting))
-	if(!affecting || (affecting.status & ORGAN_DESTROYED))
+	if(!affecting)
 		to_chat(user, "<span class='danger'>They are missing that limb!</span>")
 		return 1
-	var/hit_area = affecting.name
+	var/hit_area = parse_zone(affecting.limb_name)
 
 	if(user != src)
 		user.do_attack_animation(src)
@@ -270,7 +270,7 @@ emp_act
 							update_inv_glasses(0)
 
 
-				if("upper body")//Easier to score a stun but lasts less time
+				if("chest")//Easier to score a stun but lasts less time
 					if(stat == CONSCIOUS && I.force && prob(I.force + 10))
 						visible_message("<span class='combat danger'>[src] has been knocked down!</span>", \
 										"<span class='combat userdanger'>[src] has been knocked down!</span>")

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -45,7 +45,7 @@
 			var/obj/item/organ/external/l_foot = get_organ("l_foot")
 			var/obj/item/organ/external/r_foot = get_organ("r_foot")
 			var/hasfeet = 1
-			if((!l_foot || l_foot.status & ORGAN_DESTROYED) && (!r_foot || r_foot.status & ORGAN_DESTROYED))
+			if(!l_foot && !r_foot)
 				hasfeet = 0
 
 			if(shoes)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -43,7 +43,7 @@
 
 	for(var/limb_tag in list("l_leg","r_leg","l_foot","r_foot"))
 		var/obj/item/organ/external/E = bodyparts_by_name[limb_tag]
-		if(!E || (E.status & (ORGAN_DESTROYED|ORGAN_DEAD)) || E.is_malfunctioning())
+		if(!E || (E.status & ORGAN_DEAD) || E.is_malfunctioning())
 			stance_damage += 2 // let it fail even if just foot&leg. Also malfunctioning happens sporadically so it should impact more when it procs
 		else if(E.is_broken() || !E.is_usable())
 			stance_damage += 1

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -24,8 +24,7 @@
 
 /mob/living/carbon/human/proc/has_organ(name)
 	var/obj/item/organ/external/O = bodyparts_by_name[name]
-
-	return (O && !(O.status & ORGAN_DESTROYED))
+	return O
 
 /mob/living/carbon/human/proc/has_organ_for_slot(slot)
 	switch(slot)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -172,10 +172,7 @@ var/global/list/damage_icon_parts = list()
 	var/damage_appearance = ""
 
 	for(var/obj/item/organ/external/O in bodyparts)
-		if(O.status & ORGAN_DESTROYED)
-			damage_appearance += "d"
-		else
-			damage_appearance += O.damage_state
+		damage_appearance += O.damage_state
 
 	if(damage_appearance == previous_damage_appearance)
 		// nothing to do here
@@ -189,20 +186,19 @@ var/global/list/damage_icon_parts = list()
 
 	// blend the individual damage states with our icons
 	for(var/obj/item/organ/external/O in bodyparts)
-		if(!(O.status & ORGAN_DESTROYED))
-			O.update_icon()
-			if(O.damage_state == "00") continue
-			var/icon/DI
-			var/cache_index = "[O.damage_state]/[O.icon_name]/[species.blood_color]/[species.name]"
+		O.update_icon()
+		if(O.damage_state == "00") continue
+		var/icon/DI
+		var/cache_index = "[O.damage_state]/[O.icon_name]/[species.blood_color]/[species.name]"
 
-			if(damage_icon_parts[cache_index] == null)
-				DI = new /icon(species.damage_overlays, O.damage_state)			// the damage icon for whole human
-				DI.Blend(new /icon(species.damage_mask, O.icon_name), ICON_MULTIPLY)	// mask with this organ's pixels
-				DI.Blend(species.blood_color, ICON_MULTIPLY)
-				damage_icon_parts[cache_index] = DI
-			else
-				DI = damage_icon_parts[cache_index]
-			standing_image.overlays += DI
+		if(damage_icon_parts[cache_index] == null)
+			DI = new /icon(species.damage_overlays, O.damage_state)			// the damage icon for whole human
+			DI.Blend(new /icon(species.damage_mask, O.icon_name), ICON_MULTIPLY)	// mask with this organ's pixels
+			DI.Blend(species.blood_color, ICON_MULTIPLY)
+			damage_icon_parts[cache_index] = DI
+		else
+			DI = damage_icon_parts[cache_index]
+		standing_image.overlays += DI
 
 	overlays_standing[DAMAGE_LAYER]	= standing_image
 
@@ -238,7 +234,7 @@ var/global/list/damage_icon_parts = list()
 
 	for(var/organ_tag in species.has_limbs)
 		var/obj/item/organ/external/part = bodyparts_by_name[organ_tag]
-		if(isnull(part)  || (part.status & ORGAN_DESTROYED))
+		if(isnull(part))
 			icon_key += "0"
 		else if(part.status & ORGAN_ROBOT)
 			icon_key += "2[part.model ? "-[part.model]": ""]"
@@ -365,7 +361,7 @@ var/global/list/damage_icon_parts = list()
 
 	//Body markings.
 	var/obj/item/organ/external/chest/chest_organ = get_organ("chest")
-	if(chest_organ && !(chest_organ.status & ORGAN_DESTROYED) && m_styles["body"])
+	if(chest_organ && m_styles["body"])
 		var/body_marking = m_styles["body"]
 		var/datum/sprite_accessory/body_marking_style = marking_styles_list[body_marking]
 		if(body_marking_style && body_marking_style.species_allowed && (species.name in body_marking_style.species_allowed))
@@ -375,7 +371,7 @@ var/global/list/damage_icon_parts = list()
 			markings_standing.Blend(b_marking_s, ICON_OVERLAY)
 	//Head markings.
 	var/obj/item/organ/external/head/head_organ = get_organ("head")
-	if(head_organ && !(head_organ.status & ORGAN_DESTROYED) && m_styles["head"]) //If the head is destroyed, forget the head markings. This prevents floating optical markings on decapitated IPCs, for example.
+	if(head_organ && m_styles["head"]) //If the head is destroyed, forget the head markings. This prevents floating optical markings on decapitated IPCs, for example.
 		var/head_marking = m_styles["head"]
 		var/datum/sprite_accessory/head_marking_style = marking_styles_list[head_marking]
 		if(head_marking_style && head_marking_style.species_allowed && (head_organ.species.name in head_marking_style.species_allowed))
@@ -395,7 +391,7 @@ var/global/list/damage_icon_parts = list()
 	overlays_standing[HEAD_ACC_OVER_LAYER]	= null
 
 	var/obj/item/organ/external/head/head_organ = get_organ("head")
-	if(!head_organ || (head_organ.status & ORGAN_DESTROYED) )
+	if(!head_organ)
 		if(update_icons)   update_icons()
 		return
 
@@ -432,7 +428,7 @@ var/global/list/damage_icon_parts = list()
 	overlays_standing[HAIR_LAYER] = null
 
 	var/obj/item/organ/external/head/head_organ = get_organ("head")
-	if(!head_organ || (head_organ.status & ORGAN_DESTROYED))
+	if(!head_organ)
 		if(update_icons)   update_icons()
 		return
 
@@ -481,7 +477,7 @@ var/global/list/damage_icon_parts = list()
 	overlays_standing[FHAIR_OVER_LAYER]	= null
 
 	var/obj/item/organ/external/head/head_organ = get_organ("head")
-	if(!head_organ || (head_organ.status & ORGAN_DESTROYED))
+	if(!head_organ)
 		if(update_icons)   update_icons()
 		return
 

--- a/code/modules/reagents/chemistry/reagents/admin.dm
+++ b/code/modules/reagents/chemistry/reagents/admin.dm
@@ -18,9 +18,9 @@
 	M.setBrainLoss(0)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		for(var/name in H.internal_organs)
-			var/obj/item/organ/internal/I = H.get_int_organ(name)
-			I.damage = max(0, I.damage-5)
+		for(var/thing in H.internal_organs)
+			var/obj/item/organ/internal/I = thing
+			I.take_damage(-5)
 		for(var/obj/item/organ/external/E in H.bodyparts)
 			if(E.mend_fracture())
 				E.perma_injury = 0

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -92,8 +92,7 @@
 
 		//Mitocholide is hard enough to get, it's probably fair to make this all internal organs
 		for(var/obj/item/organ/internal/I in H.internal_organs)
-			if(I.damage > 0)
-				I.damage = max(I.damage-0.4, 0)
+			I.take_damage(-0.4)
 	..()
 
 /datum/reagent/medicine/mitocholide/reaction_obj(obj/O, volume)
@@ -512,7 +511,7 @@
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
 			if(istype(E))
-				E.damage = max(E.damage-1, 0)
+				E.take_damage(-1)
 		M.AdjustEyeBlurry(-1)
 		M.AdjustEarDamage(-1)
 	if(prob(50))

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -12,8 +12,6 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected == null)
 		return 0
-	if(affected.status & ORGAN_DESTROYED)
-		return 0
 	if(affected.status & ORGAN_ROBOT)
 		return 0
 	return 1
@@ -214,8 +212,6 @@
 		return 0
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected == null)
-		return 0
-	if(affected.status & ORGAN_DESTROYED)
 		return 0
 	return !affected.cannot_amputate
 

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -165,10 +165,6 @@
 			H.h_style = "Bald"
 			H.f_style = "Shaved"
 			target.m_styles["head"] = "None"
-	E.status &= ~ORGAN_DESTROYED
-	if(E.children)
-		for(var/obj/item/organ/external/C in E.children)
-			C.status &= ~ORGAN_DESTROYED
 
 
 /datum/surgery_step/limb/connect
@@ -197,10 +193,6 @@
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
 	user.visible_message("<span class='notice'>[user] has connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>",	\
 	"<span class='notice'>You have connected tendons and muscles in [target]'s [E.amputation_point] with [tool].</span>")
-	E.status &= ~ORGAN_DESTROYED
-	if(E.children)
-		for(var/obj/item/organ/external/C in E.children)
-			C.status &= ~ORGAN_DESTROYED
 	target.update_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()
@@ -251,10 +243,6 @@
 			var/new_limb_type = organ_data["path"]
 			var/obj/item/organ/external/new_limb = new new_limb_type(target)
 			new_limb.robotize(L.model_info)
-			new_limb.status &= ~ORGAN_DESTROYED
-			if(new_limb.children)
-				for(var/obj/item/organ/external/C in new_limb.children)
-					C.status &= ~ORGAN_DESTROYED
 			if(L.sabotaged)
 				new_limb.sabotaged = 1
 	target.update_body()

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -195,7 +195,7 @@ var/list/organ_cache = list()
 	return damage >= min_bruised_damage
 
 /obj/item/organ/proc/is_broken()
-	return (damage >= min_broken_damage || (status & ORGAN_CUT_AWAY) || ((status & ORGAN_BROKEN) && !(status & ORGAN_SPLINTED)))
+	return (damage >= min_broken_damage || ((status & ORGAN_BROKEN) && !(status & ORGAN_SPLINTED)))
 
 //Germs
 /obj/item/organ/proc/handle_antibiotics()
@@ -243,14 +243,12 @@ var/list/organ_cache = list()
 	robotic = 2
 	status &= ~ORGAN_BROKEN
 	status &= ~ORGAN_SPLINTED
-	status &= ~ORGAN_CUT_AWAY
-	status &= ~ORGAN_DESTROYED
 	status |= ORGAN_ROBOT
-	status |= ORGAN_ASSISTED
 
 /obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc
 	robotize(1) //Skip the icon/name setting that occurs in robotize to avoid having to reset the icon file.
 	status &= ~ORGAN_ROBOT
+	status |= ORGAN_ASSISTED
 	robotic = 1
 	min_bruised_damage = 15
 	min_broken_damage = 35

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -115,10 +115,6 @@ var/list/organ_cache = list()
 		handle_antibiotics()
 		handle_germ_effects()
 
-	//check if we've hit max_damage
-	if(damage >= max_damage)
-		necrotize()
-
 /obj/item/organ/proc/is_preserved()
 	if(istype(loc,/obj/item/device/mmi))
 		germ_level = max(0, germ_level - 1) // So a brain can slowly recover from being left out of an MMI
@@ -172,9 +168,6 @@ var/list/organ_cache = list()
 
 		if(prob(3))	//about once every 30 seconds
 			take_damage(1,silent=prob(30))
-
-/obj/item/organ/proc/receive_chem(chemical as obj)
-	return 0
 
 /obj/item/organ/proc/rejuvenate()
 	damage = 0
@@ -239,6 +232,10 @@ var/list/organ_cache = list()
 			if(parent && !silent)
 				owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
 
+		//check if we've hit max_damage
+	if(damage >= max_damage)
+		necrotize()
+
 /obj/item/organ/proc/robotize() //Being used to make robutt hearts, etc
 	robotic = 2
 	status &= ~ORGAN_BROKEN
@@ -253,7 +250,7 @@ var/list/organ_cache = list()
 	min_bruised_damage = 15
 	min_broken_damage = 35
 
-/obj/item/organ/emp_act(severity)
+/obj/item/organ/external/emp_act(severity)
 	if(!(status & ORGAN_ROBOT))
 		return
 	if(tough)

--- a/code/modules/surgery/organs/organ_icon.dm
+++ b/code/modules/surgery/organs/organ_icon.dm
@@ -172,7 +172,7 @@ var/global/list/limb_icon_cache = list()
 				gender = "f"
 			else
 				gender = "m"
-		if(limb_name == "head" && !(status & ORGAN_DESTROYED))
+		if(limb_name == "head")
 			var/obj/item/organ/external/head/head_organ = src
 			head_organ.handle_alt_icon()
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -431,20 +431,17 @@
 		//High toxins levels are dangerous
 		if(owner.getToxLoss() >= 60 && !owner.reagents.has_reagent("charcoal"))
 			//Healthy liver suffers on its own
-			if(src.damage < min_broken_damage)
-				src.damage += 0.2 * PROCESS_ACCURACY
+			if(damage < min_broken_damage)
+				take_damage(0.2 * PROCESS_ACCURACY)
 			//Damaged one shares the fun
 			else
 				var/obj/item/organ/internal/O = pick(owner.internal_organs)
 				if(O)
-					O.damage += 0.2  * PROCESS_ACCURACY
+					O.take_damage(0.2  * PROCESS_ACCURACY)
 
 		//Detox can heal small amounts of damage
-		if(src.damage && src.damage < src.min_bruised_damage && owner.reagents.has_reagent("charcoal"))
-			src.damage -= 0.2 * PROCESS_ACCURACY
-
-		if(src.damage < 0)
-			src.damage = 0
+		if(damage && damage < min_bruised_damage && owner.reagents.has_reagent("charcoal"))
+			take_damage(-0.2 * PROCESS_ACCURACY)
 
 		// Get the effectiveness of the liver.
 		var/filter_effect = 3
@@ -454,7 +451,7 @@
 			filter_effect -= 2
 
 		// Damaged liver means some chemicals are very dangerous
-		if(src.damage >= src.min_bruised_damage)
+		if(damage >= min_bruised_damage)
 			for(var/datum/reagent/R in owner.reagents.reagent_list)
 				// Ethanol and all drinks are bad
 				if(istype(R, /datum/reagent/consumable/ethanol))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -200,7 +200,7 @@
 			return
 
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(I && I.damage > 0)
+			if(I && I.damage)
 				if(I.robotic < 2 && !istype (tool, /obj/item/stack/nanopaste))
 					if(!(I.sterile))
 						spread_germs_to_organ(I, user, tool)
@@ -238,7 +238,7 @@
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
 			if(I)
 				I.surgeryize()
-			if(I && I.damage > 0)
+			if(I && I.damage)
 				if(I.robotic < 2 && !istype (tool, /obj/item/stack/nanopaste))
 					user.visible_message("<span class='notice'> [user] treats damage to [target]'s [I.name] with [tool_name].</span>", \
 					"<span class='notice'> You treat damage to [target]'s [I.name] with [tool_name].</span>" )
@@ -353,7 +353,7 @@
 			affected.take_damage(5)
 
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(I && I.damage > 0 && !(I.tough))
+			if(I && I.damage && !(I.tough))
 				I.take_damage(dam_amt,0)
 
 		return 0

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -264,8 +264,6 @@
 			user.visible_message("<span class='notice'> [user] has transplanted [tool] into [target]'s [parse_zone(target_zone)].</span>",
 			"<span class='notice'> You have transplanted [tool] into [target]'s [parse_zone(target_zone)].</span>")
 
-		I.status &= ~ORGAN_CUT_AWAY
-
 	else if(current_type == "extract")
 		var/mob/living/simple_animal/borer/B = target.has_brain_worms()
 		if(target_zone == "head" && B && B.host == target)
@@ -280,7 +278,6 @@
 
 			add_logs(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			spread_germs_to_organ(I, user, tool)
-			I.status |= ORGAN_CUT_AWAY
 			var/obj/item/thing = I.remove(target)
 			if(!istype(thing))
 				thing.forceMove(get_turf(target))

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -398,7 +398,7 @@
 
 		var/found_damaged_organ = FALSE
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(I && I.damage > 0 && I.robotic >= 2)
+			if(I && I.damage && I.robotic >= 2)
 				user.visible_message("[user] starts mending the damage to [target]'s [I.name]'s mechanisms.", \
 				"You start mending the damage to [target]'s [I.name]'s mechanisms.")
 				found_damaged_organ = TRUE
@@ -423,7 +423,7 @@
 		if(!hasorgans(target))
 			return
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(I && I.damage > 0)
+			if(I && I.damage)
 				if(I.robotic >= 2)
 					user.visible_message("<span class='notice'> [user] repairs [target]'s [I.name] with [tool].</span>", \
 					"<span class='notice'> You repair [target]'s [I.name] with [tool].</span>" )

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -56,8 +56,6 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(affected == null)
 		return 0
-	if(affected.status & ORGAN_DESTROYED)
-		return 0
 	return 1
 
 /datum/surgery_step/robotics/external
@@ -443,8 +441,6 @@
 		user.visible_message("<span class='notice'> [user] has reattached [target]'s [I].</span>" , \
 		"<span class='notice'> You have reattached [target]'s [I].</span>")
 
-		if(I && istype(I))
-			I.status &= ~ORGAN_CUT_AWAY
 	else if(current_type == "install")
 		user.visible_message("<span class='notice'> [user] has installed \the [tool] into [target]'s [affected.name].</span>", \
 		"<span class='notice'> You have installed \the [tool] into [target]'s [affected.name].</span>")
@@ -461,7 +457,6 @@
 
 			add_logs(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			spread_germs_to_organ(I, user)
-			I.status |= ORGAN_CUT_AWAY
 			var/obj/item/thing = I.remove(target)
 			if(!istype(thing))
 				thing.forceMove(get_turf(target))

--- a/nano/templates/adv_med.tmpl
+++ b/nano/templates/adv_med.tmpl
@@ -151,7 +151,6 @@ Used In File(s): \code\game\machinery\adv_med.dm
 					<td> {{if value.fireLoss> 0}} <span class='average'> {{else}} <span> {{/if}} {{:helper.smoothRound(value.fireLoss)}} </span> 	</td>
 					<td>
 						<span class='average'>
-						{{if value.status.destroyed}} DESTROYED <br> {{/if}}
 						{{if value.internalBleeding}} internal bleeding <br> {{/if}}
 						{{if value.lungRuptured}} lung ruptured <br> {{/if}}
 						{{if value.status.broken}} {{:value.status.broken}} <br> {{/if}}


### PR DESCRIPTION
Fixes Diona and IPCs being immune to knockdown from brute.

Because their limb names had speshul names, they ended up being immune to knockdown from brute damage. Bad.

Code wise
- Cleans up the `ORGAN_DEAD` and `ORGAN_CUT_AWAY` defines. These were virtually unused except for a "what were you thinking" case of adding these status flags directly to the limbs for the proximity mine. `ORGAN_CUT_AWAY` is entirely unused...no idea why this even existed.
- Shaking someone properly leaves a fingerprint on someones suit, if they're wearing one (or their uniform, if they're not)
- made it so that all organ damage instances (except a few exceptions) use `take_damage`. The check for making an organ die, once it hits max damage, is now done in `take_damage` instead of relying on `process` to check for it (yay, instant damage updates for internal organs instead of up to 2 seconds delay)

:cl: Fox McCloud
fix: Fixes IPCs and Diona being immune to weapon knockdown
/:cl: