### PR TITLE
Reduces Stat Calls

### DIFF
--- a/code/modules/examine/examine.dm
+++ b/code/modules/examine/examine.dm
@@ -49,8 +49,17 @@
 	description_holders["icon"] = "[bicon(A)]"
 	description_holders["desc"] = A.desc
 
+// Byond seemingly calls stat, each tick.
+// Calling things each tick can get expensive real quick.
+// So we slow this down a little.
+// See: http://www.byond.com/docs/ref/info.html#/client/proc/Stat
 /client/Stat()
 	. = ..()
+	if(holder)
+		sleep(1)
+	else
+		sleep(5)
+		stoplag()
 	if(usr && statpanel("Examine"))
 		stat(null,"[description_holders["icon"]]    <font size='5'>[description_holders["name"]]</font>") //The name, written in big letters.
 		stat(null,"[description_holders["desc"]]") //the default examine text.

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -153,14 +153,10 @@
 	return has_fine_manipulation
 
 /mob/living/carbon/alien/Stat()
-
+	..()
 	statpanel("Status")
 	stat(null, "Intent: [a_intent]")
 	stat(null, "Move Mode: [m_intent]")
-
-	..()
-
-
 	show_stat_emergency_shuttle_eta()
 
 /mob/living/carbon/alien/SetStunned(amount, updating = 1, force = 0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -893,11 +893,11 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	..()
 
 /mob/living/carbon/Stat()
+	..()
 	if(statpanel("Status"))
 		var/obj/item/organ/internal/xenos/plasmavessel/vessel = get_int_organ(/obj/item/organ/internal/xenos/plasmavessel)
 		if(vessel)
 			stat(null, "Plasma Stored: [vessel.stored_plasma]/[vessel.max_plasma]")
-	..()
 
 /mob/living/carbon/get_all_slots()
 	return list(l_hand,

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -144,11 +144,11 @@
 
 // This adds the basic clock, shuttle recall timer, and malf_ai info to all silicon lifeforms
 /mob/living/silicon/Stat()
+	..()
 	if(statpanel("Status"))
 		show_stat_station_time()
 		show_stat_emergency_shuttle_eta()
 		show_system_integrity()
-	..()
 
 //Silicon mob language procs
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -67,9 +67,9 @@
 	return
 
 /mob/new_player/Stat()
+	..()
 	if((!ticker) || ticker.current_state == GAME_STATE_PREGAME)
 		statpanel("Lobby") // First tab during pre-game.
-	..()
 
 	statpanel("Status")
 	if(client.statpanel == "Status" && ticker)


### PR DESCRIPTION
Credit to TG for this.

`Stat` is a proc to display various information in various tabs, periodically.

For whatever reason, this gets updated every single BYOND tick, and the recommendation for cuttings its cost is to limit world `tick_lag` (ahahah....what), or to make it sleep.

https://www.hastebin.com/usitubehij.hs

As can bee seen above, `Stat` is quite expensive for what it does.

If we add a little bit of a sleep to it, then we can dramatically cut down on the amount of times it gets called, thus improving performance.

Admins (and technically mentor, though they don't really need this) still update at a much higher rate, for debugging purposes (mostly involving the DI panel).

I also found this improved local client performance when playing with the DI tab active.