### PR TITLE
Ian is no longer Kirby

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -194,17 +194,22 @@
 	if(isanimal(M))
 		M.changeNext_move(CLICK_CD_MELEE)
 		if(iscorgi(M))
-			if(bitecount >= 4)
+			var/mob/living/simple_animal/pet/corgi/G = M
+			if(world.time < (G.last_eaten + 300))
+				to_chat(G, text("<span class='notice'>You are too full to try eating [src] right now.</span>"))
+			else if(bitecount >= 4)
 				M.visible_message("[M] [pick("burps from enjoyment", "yaps for more", "woofs twice", "looks at the area where [src] was")].","<span class='notice'>You swallow up the last part of [src].</span>")
 				playsound(loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 				var/mob/living/simple_animal/pet/corgi/C = M
 				C.adjustBruteLoss(-5)
 				C.adjustFireLoss(-5)
 				qdel(src)
+				G.last_eaten = world.time
 			else
 				M.visible_message("[M] takes a bite of [src].","<span class='notice'>You take a bite of [src].</span>")
 				playsound(loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 				bitecount++
+				G.last_eaten = world.time
 		else if(ismouse(M))
 			var/mob/living/simple_animal/mouse/N = M
 			to_chat(N, text("<span class='notice'>You nibble away at [src].</span>"))

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -196,7 +196,7 @@
 		if(iscorgi(M))
 			var/mob/living/simple_animal/pet/corgi/G = M
 			if(world.time < (G.last_eaten + 300))
-				to_chat(G, text("<span class='notice'>You are too full to try eating [src] right now.</span>"))
+				to_chat(G, "<span class='notice'>You are too full to try eating [src] right now.</span>")
 			else if(bitecount >= 4)
 				M.visible_message("[M] [pick("burps from enjoyment", "yaps for more", "woofs twice", "looks at the area where [src] was")].","<span class='notice'>You swallow up the last part of [src].</span>")
 				playsound(loc,'sound/items/eatfood.ogg', rand(10,50), 1)

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -22,12 +22,13 @@
 	see_in_dark = 5
 	childtype = /mob/living/simple_animal/pet/corgi/puppy
 	simplespecies = /mob/living/simple_animal/pet/corgi
+	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
 	var/shaved = 0
 	var/obj/item/inventory_head
 	var/obj/item/inventory_back
 	var/facehugger
 	var/default_atmos_requirements = 0
-	gold_core_spawnable = CHEM_MOB_SPAWN_FRIENDLY
+	var/last_eaten = 0
 
 /mob/living/simple_animal/pet/corgi/New()
 	..()


### PR DESCRIPTION
🆑 Kyep
tweak: Eating as Ian (and other player-controlled corgis) is now rate-limited. 
/🆑

Previously: Ian could consume food endlessly, as fast as their player could click. This resulted in Ian being able to devor more food in a minute than their entire corgi body actually weighs. Effectively, Ian was Kirby.

Now: Ian can only take a bite of food every 30 seconds. He can still eat. He can still swipe food. But he cannot single-handedly clear out a banquet that took the chef an hour to prepare, gone in less than a minute, with little opportunity to stop him.

Effectively, this PR prevents people playing Ian from being jerks that ruin the Chef's round, whilst still allowing them to eat, self-heal, and swipe food.