### PR TITLE
No more cheesing the gateway with video cameras

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -46,6 +46,12 @@
 			M.unset_machine() //to properly reset the view of the users if the console is deleted.
 	return ..()
 
+/obj/machinery/computer/security/proc/isFarAway(var/atom/C)
+	var/turf/CONSOLETURF = get_turf(C)
+	var/turf/T = get_turf(src)
+	if((is_away_level(T.z) || is_away_level(CONSOLETURF.z)) && !atoms_share_level(T, CONSOLETURF)) //can only recieve away mission cameras on away missions
+		return TRUE
+
 /obj/machinery/computer/security/check_eye(mob/user)
 	if(!(user in watchers))
 		user.unset_machine()
@@ -54,6 +60,9 @@
 		user.unset_machine()
 		return
 	var/obj/machinery/camera/C = watchers[user]
+	if(isFarAway(C))
+		user.unset_machine()
+		return
 	if(!can_access_camera(C, user))
 		user.unset_machine()
 		return
@@ -113,7 +122,7 @@
 
 	var/list/cameras = list()
 	for(var/obj/machinery/camera/C in cameranet.cameras)
-		if((is_away_level(z) || is_away_level(C.z)) && !atoms_share_level(C, src)) //can only recieve away mission cameras on away missions
+		if(isFarAway(C))
 			continue
 		if(!can_access_camera(C, user))
 			continue

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -46,10 +46,10 @@
 			M.unset_machine() //to properly reset the view of the users if the console is deleted.
 	return ..()
 
-/obj/machinery/computer/security/proc/isFarAway(var/atom/C)
-	var/turf/CONSOLETURF = get_turf(C)
-	var/turf/T = get_turf(src)
-	if((is_away_level(T.z) || is_away_level(CONSOLETURF.z)) && !atoms_share_level(T, CONSOLETURF)) //can only recieve away mission cameras on away missions
+/obj/machinery/computer/security/proc/isCameraFarAway(obj/machinery/camera/C)
+	var/turf/consoleturf = get_turf(src)
+	var/turf/cameraturf = get_turf(C)
+	if((is_away_level(cameraturf.z) || is_away_level(consoleturf.z)) && !atoms_share_level(cameraturf, consoleturf)) //can only recieve away mission cameras on away missions
 		return TRUE
 
 /obj/machinery/computer/security/check_eye(mob/user)
@@ -60,7 +60,7 @@
 		user.unset_machine()
 		return
 	var/obj/machinery/camera/C = watchers[user]
-	if(isFarAway(C))
+	if(isCameraFarAway(C))
 		user.unset_machine()
 		return
 	if(!can_access_camera(C, user))
@@ -122,7 +122,7 @@
 
 	var/list/cameras = list()
 	for(var/obj/machinery/camera/C in cameranet.cameras)
-		if(isFarAway(C))
+		if(isCameraFarAway(C))
 			continue
 		if(!can_access_camera(C, user))
 			continue


### PR DESCRIPTION
The majority of video camera usage comes from tossing it through the gateway to see which mission it is with no danger to the crew; this PR removes the video camera's ability to broadcast beyond the gateway.

They should probably also not broadcast to consoles that aren't on the same z-level as them, but that's for another PR.

:cl:
tweak: Nanotrasen's legal department clamped down on video cameras being misappropriated by crew, and as such cameras are now unable to broadcast from beyond the gateway.
/:cl: