### PR TITLE
Revert "Darts no longer proc reaction" but makes facid unusable in syringe guns

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -238,6 +238,7 @@
 		if(blocked != 100)
 			if(M.can_inject(null,0,hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
+				reagents.reaction(M, INGEST)
 				reagents.trans_to(M, reagents.total_volume)
 				return 1
 			else

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -595,13 +595,13 @@
 			if(volume < 5)
 				to_chat(M, "<span class='danger'>The blueish acidic substance stings you, but isn't concentrated enough to harm you!</span>")
 
-			if(volume >=5 && volume <=10)
+			if(volume >=5 && volume <=15)
 				if(!H.unacidable)
 					M.take_organ_damage(0,max(volume-5,2)*4)
 					M.emote("scream")
 
 
-			if(volume > 10)
+			if(volume > 15)
 
 				if(method == TOUCH)
 					if(H.wear_mask)


### PR DESCRIPTION
What this pr dose:

- Restores the reaction proc in syringes shooted from syringe gun
- Changes the way fluorosulphuric acid dose damage

4u or less will deal no damage(unchanged)
5u to 15u will deal 20(changed 10u to 15u)
16u or more will deal 80(changed 11u to 16u)

🆑 alexkar598
del: Revert "Darts no longer proc reaction"
tweak: You now need 16u or more of fluorosulphuric acid to deal 80 damage
/🆑