### PR TITLE
Protolathe Speed Fix

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -423,10 +423,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					message_admins("Protolathe exploit attempted by [key_name(usr, usr.client)]!")
 
 				if(g2g) //If input is incorrect, nothing happens
-					var/time_to_construct = PROTOLATHE_CONSTRUCT_DELAY * amount * coeff
+					var/new_coeff = coeff * being_built.lathe_time_factor
+					var/time_to_construct = PROTOLATHE_CONSTRUCT_DELAY * new_coeff * amount ** 0.8
 					var/enough_materials = 1
 
-					time_to_construct /= being_built.lathe_time_factor
 					add_wait_message("Constructing Prototype. Please Wait...", time_to_construct)
 					linked_lathe.busy = 1
 					flick("protolathe_n",linked_lathe)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -423,7 +423,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 					message_admins("Protolathe exploit attempted by [key_name(usr, usr.client)]!")
 
 				if(g2g) //If input is incorrect, nothing happens
-					var/time_to_construct = PROTOLATHE_CONSTRUCT_DELAY * amount / coeff
+					var/time_to_construct = PROTOLATHE_CONSTRUCT_DELAY * amount * coeff
 					var/enough_materials = 1
 
 					time_to_construct /= being_built.lathe_time_factor


### PR DESCRIPTION
#7883 Brought this to my attention.

A coefficient for the time to construct is calculated in protolathe.dm as follows;

```
T = 1.2
for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
		T -= M.rating/10
	efficiency_coeff = min(max(0, T), 1)
```

Meaning that the higher the rating of the parts, the lower T will be, therefore the `efficiency_coeff` will be lower as it takes the minimum value between T and 1 (assuming T is greater than 0).

Therefore if the rating of the parts is 4, for example:

T = 1.2
T -= 4/10
T = 0.8
therefore

efficiency_coeff = min(max(0,0.8),1) = 0.8

In rdconsole.dm however, the var `time_to_construct` is calculated by **dividing** by this coefficient. Therefore if you divide by a decimal number, the `time_to_construct` is greater.
```
var/coeff = linked_lathe.efficiency_coeff
var/time_to_construct = PROTOLATHE_CONSTRUCT_DELAY * amount / coeff
```

This PR changes rdconsole.dm so that the `time_to_construct` is calculated by multiplying by this coefficient, therefore reducing the time to construct these parts.

Fixes #7883 

I may have this completely wrong which is why I wrote my thinking out as I did, can someone please check this for me as I haven't had a second opinion yet.

🆑 Birdtalon
fix: Protolathe speed now increases when upgraded with manipulators.
/🆑