### PR TITLE
Fixes Dead Hearts Allowing you to live.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1157,8 +1157,11 @@
 	if(!can_heartattack())
 		return FALSE
 	var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
-	if(istype(heart) && heart.beating)
-		return FALSE
+	if(istype(heart))
+		if(heart.status & ORGAN_DEAD)
+			return TRUE
+		if(heart.beating)
+			return FALSE
 	return TRUE
 
 /mob/living/carbon/human/proc/set_heartattack(status)

--- a/code/modules/reagents/chemistry/reagents/disease.dm
+++ b/code/modules/reagents/chemistry/reagents/disease.dm
@@ -146,6 +146,7 @@
 			var/mob/living/carbon/human/H = M
 			if(!H.undergoing_cardiac_arrest())
 				H.set_heartattack(TRUE) // rip in pepperoni
+	..()
 
 //virus foods
 


### PR DESCRIPTION
Fixes dead hearts allowing someone to live and walk around.

Technically you can defib someone with a dead heart, but they're just going to acquire a heart attack immediately, again, so, I don't really view that as a problem.

Also fixes concentrated initro never metabolizing.

:cl: Fox McCloud
fix: Dead hearts now induce a heart attack
fix: Fixed concentrated initro never metabolizing
/:cl: