### PR TITLE
Fixes TS Mother gateway crossover

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -82,7 +82,7 @@
 		/mob/living/simple_animal/hostile/poison/terror_spider/black)
 		S.spider_myqueen = spider_myqueen
 		if(prob(sbpc))
-			S.stillborn = 1
+			S.stillborn = TRUE
 		if(spider_growinstantly)
 			S.amount_grown = 250
 
@@ -94,7 +94,7 @@
 	for(var/obj/structure/spider/eggcluster/terror_eggcluster/T in ts_egg_list)
 		qdel(T)
 	for(var/obj/structure/spider/spiderling/terror_spiderling/T in ts_spiderling_list)
-		T.stillborn = 1
+		T.stillborn = TRUE
 	to_chat(src, "<span class='userdanger'>All Terror Spiders, except yourself, will die off shortly.</span>")
 
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -33,9 +33,9 @@
 	ventsmash_action.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/mother/death(gibbed)
-	var/always_stillborn = 0
+	var/always_stillborn = FALSE
 	if(spider_awaymission && !is_away_level(z))
-		always_stillborn = 1
+		always_stillborn = TRUE
 	if(canspawn)
 		canspawn = 0
 		for(var/i in 0 to 30)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -33,12 +33,15 @@
 	ventsmash_action.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/mother/death(gibbed)
+	var/always_stillborn = 0
+	if(spider_awaymission && !is_away_level(z))
+		always_stillborn = 1
 	if(canspawn)
 		canspawn = 0
 		for(var/i in 0 to 30)
 			var/obj/structure/spider/spiderling/terror_spiderling/S = new /obj/structure/spider/spiderling/terror_spiderling(get_turf(src))
 			S.grow_as = pick(/mob/living/simple_animal/hostile/poison/terror_spider/red, /mob/living/simple_animal/hostile/poison/terror_spider/gray)
-			if(prob(66))
+			if(always_stillborn || prob(66))
 				S.stillborn = 1
 			else if(prob(10))
 				S.grow_as = pick(/mob/living/simple_animal/hostile/poison/terror_spider/black, /mob/living/simple_animal/hostile/poison/terror_spider/green)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -333,7 +333,7 @@
 		for(var/i in 1 to numlings)
 			var/obj/structure/spider/spiderling/terror_spiderling/S = new /obj/structure/spider/spiderling/terror_spiderling(get_turf(src))
 			S.grow_as = /mob/living/simple_animal/hostile/poison/terror_spider/red
-			S.stillborn = 1
+			S.stillborn = TRUE
 			S.name = "Evil-Looking Spiderling"
 			S.desc = "It moves very quickly, hisses loudly for its size... and has disproportionately large fangs. Hopefully it does not grow up..."
 		if(!spider_can_fakelings)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -10,19 +10,19 @@
 	anchored = 0
 	layer = 2.75
 	health = 3
-	var/stillborn = 0
+	var/stillborn = FALSE
 	faction = list("terrorspiders")
 	var/spider_myqueen = null
 	var/use_vents = 1
 	var/list/enemies = list()
 	var/immediate_ventcrawl = 0
-	var/spider_awaymission = 0
+	var/spider_awaymission = FALSE
 
 /obj/structure/spider/spiderling/terror_spiderling/New()
 	..()
 	ts_spiderling_list += src
 	if(is_away_level(z))
-		spider_awaymission = 1
+		spider_awaymission = TRUE
 
 /obj/structure/spider/spiderling/terror_spiderling/Destroy()
 	ts_spiderling_list -= src
@@ -89,7 +89,7 @@
 		amount_grown += rand(0,2)
 		if(amount_grown >= 100)
 			if(spider_awaymission && !is_away_level(z))
-				stillborn = 1
+				stillborn = TRUE
 			if(stillborn)
 				die()
 			else
@@ -179,6 +179,6 @@
 		var/rnum = 5 - spiderling_number
 		for(var/i=0, i<rnum, i++)
 			var/obj/structure/spider/spiderling/terror_spiderling/S = new /obj/structure/spider/spiderling/terror_spiderling(get_turf(src))
-			S.stillborn = 1
+			S.stillborn = TRUE
 			// every set of eggs always spawn 5 spiderlings, but most are decoys
 		qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/reproduction.dm
@@ -16,10 +16,13 @@
 	var/use_vents = 1
 	var/list/enemies = list()
 	var/immediate_ventcrawl = 0
+	var/spider_awaymission = 0
 
 /obj/structure/spider/spiderling/terror_spiderling/New()
 	..()
 	ts_spiderling_list += src
+	if(is_away_level(z))
+		spider_awaymission = 1
 
 /obj/structure/spider/spiderling/terror_spiderling/Destroy()
 	ts_spiderling_list -= src
@@ -85,6 +88,8 @@
 	if(isturf(loc))
 		amount_grown += rand(0,2)
 		if(amount_grown >= 100)
+			if(spider_awaymission && !is_away_level(z))
+				stillborn = 1
 			if(stillborn)
 				die()
 			else


### PR DESCRIPTION
🆑 Kyep
fix: Evil-minded players can no longer use the Gateway's Mother of Terror spider to create an infestation on-station.
/ 🆑

Also refactors some 1 into TRUE and 0 into FALSE.