### PR TITLE
Reduces confusion for antagonist collaborators

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -573,5 +573,5 @@ proc/display_roundstart_logout_report()
 
 	to_chat(M, "You suddenly remember \an [adjective] note you received earlier informing you that a chance to [action_words] may present itself today. An agent of the [organization] may contact you for help.")
 	to_chat(M, "The note had the words \"[my_word]\" and \"[my_reply]\" written at the bottom, which you memorized just in case.")
-	to_chat(M, "<span class='warning'>You are NOT an antagonist, so self-antagging rules still apply to you. Use your good judgement and ahelp if you are unsure of what you are allowed to do.</span>")
+	to_chat(M, "<span class='warning'>Unless stated otherwise; you are NOT an antagonist, so self-antagging rules may still apply to you. Use your good judgement and ahelp if you are unsure of what you are allowed to do.</span>")
 	M.mind.store_memory("<b>Important Words</b>: \"[my_word]\", \"[my_reply]\"")


### PR DESCRIPTION
Fixes #7604 

This PR introduces a very minor wording change for antagonist collaborators being told that they are **NOT** an antagonist.

This issue has not been addressed with regards to whether we want vampires + changelings being collaborators but at least with this PR it is slightly clearer to people who may get mixed messages being told they both are and are not antagonists in their round greetings.

🆑 Birdtalon
tweak: Small wording change to syndicate collaborator greetings.
/🆑