### PR TITLE
Porta Turret Performance Fixup

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -7,7 +7,6 @@
 #define SEE_INVISIBLE_LIVING 25
 
 #define SEE_INVISIBLE_LEVEL_ONE 35	//Used by some stuff in code. It's really poorly organized.
-#define INVISIBILITY_LEVEL_ONE 35	//Used by some stuff in code. It's really poorly organized.
 
 #define SEE_INVISIBLE_LEVEL_TWO 45	//Used by some other stuff in code. It's really poorly organized.
 #define INVISIBILITY_LEVEL_TWO 45	//Used by some other stuff in code. It's really poorly organized.

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -537,12 +537,12 @@ var/list/turret_icons
 
 	var/list/targets = list()			//list of primary targets
 	var/list/secondarytargets = list()	//targets that are least important
-	var/turretview = view(scan_range, src)
+	var/static/things_to_scan = typecacheof(list(/obj/mecha, /obj/spacepod, /obj/vehicle, /mob/living))
 
-	for(var/A in turretview)
+	for(var/A in typecache_filter_list(view(scan_range, src), things_to_scan))
 		var/atom/AA = A
 
-		if((AA.invisibility >= INVISIBILITY_LEVEL_ONE) || !simulated) //Let's not do typechecks and stuff on invisible things or the lighting layer
+		if(AA.invisibility >= INVISIBILITY_LEVEL_ONE) //Let's not do typechecks and stuff on invisible things
 			continue
 
 		if(istype(AA, /obj/mecha))

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -542,23 +542,23 @@ var/list/turret_icons
 	for(var/A in typecache_filter_list(view(scan_range, src), things_to_scan))
 		var/atom/AA = A
 
-		if(AA.invisibility >= INVISIBILITY_LEVEL_ONE) //Let's not do typechecks and stuff on invisible things
+		if(AA.invisibility > SEE_INVISIBLE_LIVING) //Let's not do typechecks and stuff on invisible things
 			continue
 
-		if(istype(AA, /obj/mecha))
-			var/obj/mecha/ME = AA
+		if(istype(A, /obj/mecha))
+			var/obj/mecha/ME = A
 			assess_and_assign(ME.occupant, targets, secondarytargets)
 
-		if(istype(AA, /obj/spacepod))
-			var/obj/spacepod/SP = AA
+		if(istype(A, /obj/spacepod))
+			var/obj/spacepod/SP = A
 			assess_and_assign(SP.pilot, targets, secondarytargets)
 
-		if(istype(AA, /obj/vehicle))
-			var/obj/vehicle/T = AA
+		if(istype(A, /obj/vehicle))
+			var/obj/vehicle/T = A
 			assess_and_assign(T.buckled_mob, targets, secondarytargets)
 
-		if(isliving(AA))
-			var/mob/living/C = AA
+		if(isliving(A))
+			var/mob/living/C = A
 			assess_and_assign(C, targets, secondarytargets)
 
 	if(!tryToShootAt(targets))


### PR DESCRIPTION
Freaking portaturrets man, they use up so much CPU.

This is just a minor refactor to them.

- Cleans up spawns/sleeps, where possible/needed
  - Keep in mind, `process` has `set waitfor = FALSE`, so sleeps in the `process` loop are ok now
- Make turret `process` cheaper with typeless for loops, using a typecache, skipping invisible objects, and removing a `isliving` typecheck from turret assessment (not needed; you shouldn't be passing a non-mob to that proc anyway).

Overall, the typeless and other checking stuff didn't help much (only about 0.2 CPU saved in total over 20,000 calls), but making it a typecache cut the cost dramatically.

Before:
```
Proc Name                                Self CPU    Total CPU    Real Time    Calls
--------------------------------------------------------------------------------------
/obj/machinery/porta_turret/process       7.577        7.624        7.698        20109
```

After:

```
Proc Name                                Self CPU    Total CPU    Real Time    Calls
--------------------------------------------------------------------------------------
/obj/machinery/porta_turret/process         2.957        4.688        4.914        20137
```