### PR TITLE
Reduces Tesla Cost

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -87,6 +87,13 @@
 		if(!typecache[A.type])
 			. += A
 
+/proc/typecache_filter_multi_list_exclusion(list/atoms, list/typecache_include, list/typecache_exclude)
+	. = list()
+	for(var/thing in atoms)
+		var/atom/A = thing
+		if(typecache_include[A.type] && !typecache_exclude[A.type])
+			. += A
+
 //Like typesof() or subtypesof(), but returns a typecache instead of a list
 /proc/typecacheof(path, ignore_root_path)
 	if(ispath(path))

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -75,9 +75,16 @@
 //returns a new list with only atoms that are in typecache L
 /proc/typecache_filter_list(list/atoms, list/typecache)
 	. = list()
-	for (var/thing in atoms)
+	for(var/thing in atoms)
 		var/atom/A = thing
 		if(typecache[A.type])
+			. += A
+
+/proc/typecache_filter_list_reverse(list/atoms, list/typecache)
+	. = list()
+	for(var/thing in atoms)
+		var/atom/A = thing
+		if(!typecache[A.type])
 			. += A
 
 //Like typesof() or subtypesof(), but returns a typecache instead of a list

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -171,7 +171,7 @@
 										/obj/machinery/the_singularitygen/tesla))
 
 
-	for(var/A in typecache_filter_list_reverse(typecache_filter_list(oview(source, zap_range+2), things_to_shock), blacklisted_tesla_types))
+	for(var/A in typecache_filter_multi_list_exclusion(oview(source, zap_range+2), things_to_shock, blacklisted_tesla_types))
 		if(istype(A, /obj/machinery/power/tesla_coil))
 			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -1,24 +1,6 @@
 #define TESLA_DEFAULT_POWER 1738260
 #define TESLA_MINI_POWER 869130
 
-var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
-										/obj/machinery/power/emitter,
-										/obj/machinery/field/generator,
-										/mob/living/simple_animal,
-										/obj/machinery/particle_accelerator/control_box,
-										/obj/structure/particle_accelerator/fuel_chamber,
-										/obj/structure/particle_accelerator/particle_emitter/center,
-										/obj/structure/particle_accelerator/particle_emitter/left,
-										/obj/structure/particle_accelerator/particle_emitter/right,
-										/obj/structure/particle_accelerator/power_box,
-										/obj/structure/particle_accelerator/end_cap,
-										/obj/machinery/field/containment,
-										/obj/structure/disposalpipe,
-										/obj/structure/sign,
-										/obj/machinery/gateway,
-										/obj/structure/grille,
-										/obj/machinery/the_singularitygen/tesla))
-
 /obj/singularity/energy_ball
 	name = "energy ball"
 	desc = "An energy ball."
@@ -169,8 +151,27 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 	var/obj/machinery/closest_machine
 	var/obj/structure/closest_structure
 	var/obj/structure/blob/closest_blob
+	var/static/things_to_shock = typecacheof(list(/obj/machinery, /mob/living, /obj/structure))
+	var/static/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
+										/obj/machinery/power/emitter,
+										/obj/machinery/field/generator,
+										/mob/living/simple_animal,
+										/obj/machinery/particle_accelerator/control_box,
+										/obj/structure/particle_accelerator/fuel_chamber,
+										/obj/structure/particle_accelerator/particle_emitter/center,
+										/obj/structure/particle_accelerator/particle_emitter/left,
+										/obj/structure/particle_accelerator/particle_emitter/right,
+										/obj/structure/particle_accelerator/power_box,
+										/obj/structure/particle_accelerator/end_cap,
+										/obj/machinery/field/containment,
+										/obj/structure/disposalpipe,
+										/obj/structure/sign,
+										/obj/machinery/gateway,
+										/obj/structure/grille,
+										/obj/machinery/the_singularitygen/tesla))
 
-	for(var/A in oview(source, zap_range+2))
+
+	for(var/A in typecache_filter_list_reverse(typecache_filter_list(oview(source, zap_range+2), things_to_shock), blacklisted_tesla_types))
 		if(istype(A, /obj/machinery/power/tesla_coil))
 			var/dist = get_dist(source, A)
 			var/obj/machinery/power/tesla_coil/C = A
@@ -193,7 +194,7 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 				closest_atom = A
 				closest_dist = dist
 
-		else if(closest_grounding_rod || is_type_in_typecache(A, blacklisted_tesla_types))
+		else if(closest_grounding_rod)
 			continue
 
 		else if(isliving(A))


### PR DESCRIPTION
A port of my own PR over at TG: https://github.com/tgstation/tgstation/pull/29699

Basically, it makes the Tesla about 32% cheaper (15.6 seconds over 10,000 calls as opposed to 23 seconds over 10,000 calls), which is an obvious boost to performance.

No behavior changes.

We heard you liked filters so we put a filter in your filter and saved you 32% CPU time for the Tesla engine.