### PR TITLE
Makes has_brain_worms cheaper

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -148,7 +148,7 @@
 		holder.icon_state = "hudxeno"
 	else if(check_virus())
 		holder.icon_state = "hudill"
-	else if(has_brain_worms() && B != null && B.controlling)
+	else if(B && B.controlling)
 		holder.icon_state = "hudbrainworm"
 	else
 		holder.icon_state = "hudhealthy"

--- a/code/game/gamemodes/changeling/powers/panacea.dm
+++ b/code/game/gamemodes/changeling/powers/panacea.dm
@@ -13,8 +13,6 @@
 
 	var/mob/living/simple_animal/borer/B = user.has_brain_worms()
 	if(B)
-		if(B.controlling)
-			B.detach()
 		B.leave_host()
 		if(iscarbon(user))
 			var/mob/living/carbon/C = user

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -351,7 +351,7 @@
 		to_chat(src, "They are no longer in range!")
 		return
 
-/mob/living/simple_animal/borer/proc/perform_infestation(var/mob/living/carbon/M)
+/mob/living/simple_animal/borer/proc/perform_infestation(mob/living/carbon/M)
 	if(!M)
 		return
 
@@ -359,6 +359,7 @@
 		to_chat(src, "<span class='warning'>[M] is already infested!</span>")
 		return
 	host = M
+	M.borer = src
 	forceMove(M)
 
 	host.status_flags |= PASSEMOTES
@@ -564,7 +565,8 @@
 	host.reset_perspective(null)
 	host.machine = null
 
-	var/mob/living/H = host
+	var/mob/living/carbon/H = host
+	H.borer = null
 	H.verbs -= /mob/living/proc/borer_comm
 	talk_to_borer_action.Remove(host)
 	H.status_flags &= ~PASSEMOTES
@@ -704,10 +706,12 @@
 
 //Check for brain worms in head.
 /mob/proc/has_brain_worms()
+	return FALSE
 
-	for(var/I in contents)
-		if(istype(I,/mob/living/simple_animal/borer))
-			return I
+/mob/living/carbon/has_brain_worms()
+
+	if(borer)
+		return borer
 
 	return FALSE
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -19,6 +19,10 @@
 /mob/living/carbon/Destroy()
 	QDEL_LIST(internal_organs)
 	QDEL_LIST(stomach_contents)
+	var/mob/living/simple_animal/borer/B = has_brain_worms()
+	if(B)
+		B.leave_host()
+		qdel(B)
 	remove_from_all_data_huds()
 	return ..()
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -14,6 +14,8 @@
 	var/obj/item/head = null
 	var/obj/item/clothing/suit/wear_suit = null		//TODO: necessary? Are they even used? ~Carn
 
+	var/mob/living/simple_animal/borer/borer = null
+
 	//Active emote/pose
 	var/pose = null
 


### PR DESCRIPTION
`has_brain_worms` gets called a whopping 1,000,000 times in a 2 hour shift...that's ridiculous.


Unfortunately, due to the nature of borers, this proc **has** to be utilized for a lot of common things...any time there's a medical hud update or whenever someone hears someone talking.

Either case, this makes the proc a lot cheaper by making it so that it doesn't loop through all of a mob's contents then do an istype check on each one until it finds the borer and returns the borer.

Now carbons just have a `borer` holder var that is checked for. No looping and no istype checking.

Additionally, for whatever reason, the medical hud checks for `has_brain_worms` twice. I haven't a clue as to why this is.

This also should help resolve hypothetical GC issues (haha, mobs....GC...ha) when a carbon with a borer is deleted.

