### PR TITLE
Change order of HOS gun modes

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -53,7 +53,7 @@
 	icon_state = "hoslaser"
 	origin_tech = null
 	force = 10
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/hos)
 	ammo_x_offset = 4
 
 /obj/item/weapon/gun/energy/gun/blueshield


### PR DESCRIPTION
As requested: https://nanotrasen.se/forum/topic/11158-hos-shot-type-order/

Previous order was: Stun, Kill, Disable
Now: Stun, Disable, Kill

🆑 Jovaniph
tweak: Change order of HOS's gun to Stun > Disable > Kill.
/ 🆑