### PR TITLE
Fixes for Modular Computers

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -152,6 +152,7 @@
 			if(F)
 				var/datum/computer_file/data/backup = F.clone()
 				HDD.remove_file(F)
+				F = backup.clone() //When the file gets removed from the HDD, it gets queued for garbage collection. Hacky fix is to make a copy.
 				F.stored_data = newtext
 				F.calculate_size()
 				// We can't store the updated file, it's probably too large. Print an error and restore backed up version.

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -122,8 +122,12 @@
 			var/datum/computer_file/F = HDD.find_file_by_name(href_list["name"])
 			if(!F || !istype(F))
 				return 1
-			var/datum/computer_file/C = F.clone(1)
-			HDD.store_file(C)
+			var/newname = stripped_input(usr, "Enter clone file name:", "File clone", "Copy of " + F.filename, max_length=50)
+			if(F && newname)
+				var/datum/computer_file/C = F.clone(1)
+				C.filename = newname
+				if(!HDD.store_file(C))
+					error = "I/O error: Unable to clone file. Hard drive is probably full."
 		if("PRG_rename")
 			. = 1
 			if(!HDD)

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -34,6 +34,8 @@
 	if(paper_title)
 		P.name = paper_title
 	P.update_icon()
+	P.populatefields()
+	P.updateinfolinks()
 	stored_paper--
 	P = null
 	return TRUE

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -38,6 +38,9 @@
 	P.updateinfolinks()
 	stored_paper--
 	P = null
+
+	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+
 	return TRUE
 
 /obj/item/weapon/computer_hardware/printer/try_insert(obj/item/I, mob/living/user = null)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -204,17 +204,17 @@
 
 /obj/item/weapon/paper/proc/parsepencode(var/t, var/obj/item/weapon/pen/P, mob/user as mob)
 	t = pencode_to_html(t, usr, P, TRUE, TRUE, TRUE, deffont, signfont, crayonfont)
+	return t
 
-//Count the fields
+/obj/item/weapon/paper/proc/populatefields()
+		//Count the fields
 	var/laststart = 1
 	while(fields < MAX_PAPER_FIELDS)
-		var/i = findtext(t, "<span class=\"paper_field\">", laststart)
+		var/i = findtext(info, "<span class=\"paper_field\">", laststart)
 		if(i==0)
 			break
 		laststart = i+1
 		fields++
-
-	return t
 
 
 /obj/item/weapon/paper/proc/openhelp(mob/user as mob)
@@ -280,6 +280,8 @@
 		else
 			info += t // Oh, he wants to edit to the end of the file, let him.
 			updateinfolinks()
+
+		populatefields()
 
 		i.on_write(src,usr)
 

--- a/nano/templates/computer_fabricator.tmpl
+++ b/nano/templates/computer_fabricator.tmpl
@@ -14,7 +14,7 @@
 				<td><b>Current Price:</b>
 				<td>{{:data.totalprice}}C
 			</tr>
-			<tr>	
+			<tr>
 				<td><b>Battery:</b>
 				<td>{{:helper.link('Standard', 'bolt', {'action' : 'hw_battery', 'battery' : 1}, data.hw_battery == 1 ? "selected" : null)}}
 				<td>{{:helper.link('Upgraded', 'bolt', {'action' : 'hw_battery', 'battery' : 2}, data.hw_battery == 2 ? "selected" : null)}}
@@ -32,11 +32,13 @@
 				<td>{{:helper.link('Standard', 'signal', {'action' : 'hw_netcard', 'netcard' : 1}, data.hw_netcard == 1 ? "selected" : null)}}
 				<td>{{:helper.link('Advanced', 'signal', {'action' : 'hw_netcard', 'netcard' : 2}, data.hw_netcard == 2 ? "selected" : null)}}
 			</tr>
+			{{if data.devtype != 2}}
 			<tr>
 				<td><b>Nano Printer:</b>
 				<td>{{:helper.link('None', 'times', {'action' : 'hw_nanoprint', 'print' : 0}, data.hw_nanoprint == 0 ? "selected" : null)}}
 				<td>{{:helper.link('Standard', 'print', {'action' : 'hw_nanoprint', 'print' : 1}, data.hw_nanoprint == 1 ? "selected" : null)}}
 			</tr>
+			{{/if}}
 			<tr>
 				<td><b>Card Reader:</b>
 				<td>{{:helper.link('None', 'times', {'action' : 'hw_card', 'card' : 0}, data.hw_card == 0 ? "selected" : null)}}
@@ -61,7 +63,7 @@
 				<td>{{:helper.link('CONFIRM', 'check', {'action' : 'confirm_order'})}}
 			</tr>
 		</table>
-		
+
 		<hr>
 		<b>Battery</b> allows your device to operate without external utility power source. Advanced batteries increase battery life.<br>
 		<b>Hard Drive</b> stores file on your device. Advanced drives can store more files, but use more power, shortening battery life.<br>


### PR DESCRIPTION
Whole bunch of fixes to make modular computers less broken.

Fixes #7347, #7910 and #7049. Also, #7349 should be re-tested after this PR is merged. 

I also discovered a bunch of bugs myself and fixed them without raising issues.

:cl:AndrewMontagne
fix: Modular computers now print fields correctly.
fix: Files on modular computers no longer vanish shortly after editing.
add: Modular computers printers now make printing noises.
fix: You can no longer try and buy a tablet with a printer.
fix: Cloning a file now works.
/:cl: