### PR TITLE
Blood Trail Colouration is the Same as Pools, Fixes #7958

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -15,7 +15,6 @@ var/global/list/image/splatter_cache=list()
 	icon_state = "mfloor1"
 	random_icon_states = list("mfloor1", "mfloor2", "mfloor3", "mfloor4", "mfloor5", "mfloor6", "mfloor7")
 	var/base_icon = 'icons/effects/blood.dmi'
-	appearance_flags = NO_CLIENT_COLOR
 	blood_DNA = list()
 	var/blood_state = BLOOD_STATE_HUMAN
 	var/bloodiness = MAX_SHOE_BLOODINESS
@@ -155,6 +154,7 @@ var/global/list/image/splatter_cache=list()
 	random_icon_states = null
 	var/list/existing_dirs = list()
 	blood_DNA = list()
+	appearance_flags = NO_CLIENT_COLOR
 
 /obj/effect/decal/cleanable/trail_holder/can_bloodcrawl_in()
 	return TRUE


### PR DESCRIPTION
Blood pools had a duplicate definition of `NO_CLIENT_COLOUR` while it wasn't defined at all for blood trails.

This resulted in a bug whereby wearing a pair of noir shades or being colourblind meant that you saw blood trails as a different colour than than that of the blood pools they came from.

Now resolved by moving the duplicate definition to a place where it can do some good.

Tiny bit of oversight when porting /tg/blood.

:cl:
fix: Blood trails are now the same colour as the blood pools they came from when viewed by colour blind or noir shades wearing humanoids.
/:cl:

Fixes #7958

_Obligatory screenshot._
![bloodtrailfix](https://user-images.githubusercontent.com/12377767/29153073-3ea1ce00-7d59-11e7-8be7-f0f1132178e0.PNG)
