### PR TITLE
Adds overdose threshold and symptoms for Saline Glucose

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -226,7 +226,6 @@
 		M.emote(pick("cough", "gasp"))
 		to_chat(M, "Your chest feels heavy and you struggle to catch your breath.")
 
-
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"
 	id = "synthflesh"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -205,6 +205,7 @@
 	penetrates_skin = TRUE
 	metabolization_rate = 0.15
 	taste_message = "salt"
+	overdose_threshold = 100
 
 /datum/reagent/medicine/salglu_solution/on_mob_life(mob/living/M)
 	if(prob(33))
@@ -216,6 +217,15 @@
 			if(H.blood_volume < BLOOD_VOLUME_NORMAL)
 				H.blood_volume += 1
 	..()
+
+/datum/reagent/medicine/salglu_solution/overdose_process(mob/living/M, severity)
+	M.adjustOxyLoss(1.5)
+	M.adjustToxLoss(0.1)
+	if(prob(5))
+		M.visible_message("<span class ='warning'>[M] wheezes, struggling for breath.")
+		M.emote(pick("cough", "gasp"))
+		to_chat(M, "Your chest feels heavy and you struggle to catch your breath.")
+
 
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -219,12 +219,12 @@
 	..()
 
 /datum/reagent/medicine/salglu_solution/overdose_process(mob/living/M, severity)
-	M.adjustOxyLoss(1.5)
 	M.adjustToxLoss(0.1)
-	if(prob(5))
-		M.visible_message("<span class ='warning'>[M] wheezes, struggling for breath.")
-		M.emote(pick("cough", "gasp"))
-		to_chat(M, "Your chest feels heavy and you struggle to catch your breath.")
+	if(prob(20) && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/internal/kidneys/K = H.get_int_organ(/obj/item/organ/internal/kidneys)
+		if(istype(K))
+			K.take_damage(0.5)
 
 /datum/reagent/medicine/synthflesh
 	name = "Synthflesh"


### PR DESCRIPTION
The objective of this PR is to prevent people from being able to dose up with enough Saline-Glucose solution to last for the entire shift. With access to a chemistry area you can easily create 1000 units of Saline Glucose which will give you a small regeneration buff with no downsides which will last for 2 hours.

I have added an overdose threshold of 100 units. Which means you can still get approximately 20 minutes of healing, however you can no longer dose up on a massive amount with no downsides. 20 minutes of healing is more than enough to ensure that Saline Glucose is still a useful chemical and can still be used by antagonists but requires some maintenance.

The damage dealt is small and will take quite a while to debilitate you.

Forum Thread: https://nanotrasen.se/forum/topic/11199-add-an-overdose-limit-to-saline/

🆑 Birdtalon
tweak: Saline Glucose now has overdose downsides past 100 units.
/🆑 