### PR TITLE
Fixes Spiderbots being unable to pass tables.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -9,6 +9,7 @@
 	universal_speak = 1
 	health = 40
 	maxHealth = 40
+	pass_flags = PASSTABLE
 
 	melee_damage_lower = 2
 	melee_damage_upper = 2


### PR DESCRIPTION
Fixes #7968 

Spider-bots can use Hide but cannot pass tables, therefore making it moot. They can now pass tables.

🆑 Birdtalon
fix: Spiderbots can now pass tables, making their Hide worthwhile.
/🆑 