### PR TITLE
Makes cryogenic oversight console emaggable.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -54,6 +54,13 @@
 	user << browse(dat, "window=cryopod_console")
 	onclose(user, "cryopod_console")
 
+/obj/machinery/computer/cryopod/emag_act(user as mob)
+	if(!emagged)
+		playsound(loc, 'sound/effects/sparks4.ogg', 60, 1)
+		req_one_access = list()
+		emagged = 1
+		to_chat(user, "<span class='notice'>You short out the identification circuitry</span>")
+
 /obj/machinery/computer/cryopod/Topic(href, href_list)
 	if(..())
 		return 1

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -9,6 +9,7 @@
 	universal_speak = 1
 	health = 40
 	maxHealth = 40
+	pass_flags = PASSTABLE
 
 	melee_damage_lower = 2
 	melee_damage_upper = 2


### PR DESCRIPTION
Cryogenic Oversight Console can be emagged to remove the access requirements.

Fixes #7961 

🆑 Birdtalon
add: Cryogenic oversight console can now be emagged.
/🆑 