### PR TITLE
Nanotrasen Mining Bots take EMP damage.

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -62,7 +62,7 @@
 	SetCollectBehavior()
 
 /mob/living/simple_animal/hostile/mining_drone/emp_act(severity)
-	adjustFireLoss(100 / severity)
+	adjustHealth(100 / severity)
 	to_chat(src, "<span class='userdanger'>NOTICE: EMP detected, systems damaged!</span>")
 	visible_message("<span class='warning'>[src] crackles and buzzes violently!</span>")
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -61,6 +61,11 @@
 
 	SetCollectBehavior()
 
+/mob/living/simple_animal/hostile/mining_drone/emp_act(severity)
+	adjustFireLoss(100 / severity)
+	to_chat(src, "<span class='userdanger'>NOTICE: EMP detected, systems damaged!</span>")
+	visible_message("<span class='warning'>[src] crackles and buzzes violently!</span>")
+
 /mob/living/simple_animal/hostile/mining_drone/sentience_act()
 	AIStatus = AI_OFF
 	check_friendly_fire = 0


### PR DESCRIPTION
This makes Nanotrasen Mining Bots take damage equal to 100 over the severity of the EMP affecting it.

Damage up for consultation, should a severity 1 EMP kill them in one hit?

Fixes #7946 

🆑 Birdtalon
tweak: Nanotrasen Mining Bots are no longer safe from EMPs.
/🆑 