### PR TITLE
Control click to open wall lockers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/walllocker.dm
@@ -17,6 +17,9 @@
 
 //spawns endless (3 sets) amounts of breathmask, emergency oxy tank and crowbar
 
+/obj/structure/closet/walllocker/CtrlClick()
+	verb_toggleopen()
+
 /obj/structure/closet/walllocker/emerglocker
 	name = "emergency locker"
 	desc = "A wall mounted locker with emergency supplies"


### PR DESCRIPTION
A small quality of life which allows you to open wall lockers by using control click as well as right clicking to access the verb.

🆑 Birdtalon
add: You can open wall lockers with control click.
/🆑 