### PR TITLE
Fixes interactions with cargo crates

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -440,7 +440,7 @@
 	icon_closed = "largebin"
 	anchored = TRUE
 
-/obj/structure/closet/crate/attackby(obj/item/weapon/W, mob/living/user, params)
+/obj/structure/closet/crate/can/attackby(obj/item/weapon/W, mob/living/user, params)
 	add_fingerprint(user)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if(iswrench(W))


### PR DESCRIPTION
So #7837 broke all the cargo crates. Simple fix of making this new proc apply only to the new waste bin and not its parent.

Fixes #7960 

🆑 
fix: Fixes interactions with cargo crates.
/🆑 