### PR TITLE
Hacky "Fix" for medbot internal beakers

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -429,6 +429,7 @@
 		chemscan(src, A)
 
 /mob/living/simple_animal/bot/medbot/proc/medicate_patient(mob/living/carbon/C)
+	var/inject_beaker = FALSE
 	if(!on)
 		return
 
@@ -484,7 +485,8 @@
 		if(reagent_id && use_beaker && reagent_glass && reagent_glass.reagents.total_volume)
 			for(var/datum/reagent/R in reagent_glass.reagents.reagent_list)
 				if(!C.reagents.has_reagent(R.id))
-					reagent_id = "internal_beaker"
+					reagent_id = R.id
+					inject_beaker = TRUE
 					break
 
 	if(!reagent_id) //If they don't need any of that they're probably cured!
@@ -501,7 +503,7 @@
 
 		spawn(30)//replace with do mob
 			if((get_dist(src, patient) <= 1) && on && assess_patient(patient))
-				if(reagent_id == "internal_beaker")
+				if(inject_beaker)
 					if(use_beaker && reagent_glass && reagent_glass.reagents.total_volume)
 						var/fraction = min(injection_amount/reagent_glass.reagents.total_volume, 1)
 						reagent_glass.reagents.reaction(patient, INGEST, fraction)


### PR DESCRIPTION
This is a horrible hacky "fix" for the runtime which is generated when trying to use a medbot internal beaker.
The code for medbots is quite frankly horrible, however unless someone wants to take on a full refactor... this at least lets you use the feature for now, and this has been a problem for _so long_.
Take it or leave it.

The medbot will inject from its internal beaker once and then fall back on its internal synthesizer after that. But this whole proc is just horrible and could be much better in general.

Fixes #7918 
Fixes #7037

🆑 Birdtalon
fix: Medbots can now inject from their internal beakers.
/🆑 