### PR TITLE
Removes the special off Cult Daggers

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -45,12 +45,21 @@
 
 /obj/item/weapon/melee/cultblade/dagger/afterattack(atom/target, mob/living/carbon/human/user)
 	..()
+	if(!iscultist(user))
+		user.Weaken(5)
+		user.unEquip(src, 1)
+		user.visible_message("<span class='warning'>A powerful force shoves [user] away from [target]!</span>", \
+							 "<span class='cultlarge'>\"You shouldn't play with sharp things. You'll poke someone's eye out.\"</span>")
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.apply_damage(rand(force/2, force), BRUTE, pick("l_arm", "r_arm"))
+		else
+			user.adjustBruteLoss(rand(force/2,force))
+
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		if(!(cooldown > world.time) && ((H.stat != DEAD) && !(NO_BLOOD in H.species.species_traits)))
-			user.visible_message("<span class='danger'>The runes on the blade absorb the blood of [H]!</span>")
-			H.bleed(5000)
-			cooldown = world.time + 2400
+		if((H.stat != DEAD) && !(NO_BLOOD in H.species.species_traits))
+			H.bleed(5)
 
 /obj/item/weapon/restraints/legcuffs/bola/cult
 	name = "runed bola"

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -43,23 +43,12 @@
 	embed_chance = 75
 	var/cooldown = 0
 
-/obj/item/weapon/melee/cultblade/dagger/afterattack(atom/target, mob/living/carbon/human/user)
+/obj/item/weapon/melee/cultblade/dagger/attack(atom/target, mob/living/carbon/human/user)
 	..()
-	if(!iscultist(user))
-		user.Weaken(5)
-		user.unEquip(src, 1)
-		user.visible_message("<span class='warning'>A powerful force shoves [user] away from [target]!</span>", \
-							 "<span class='cultlarge'>\"You shouldn't play with sharp things. You'll poke someone's eye out.\"</span>")
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			H.apply_damage(rand(force/2, force), BRUTE, pick("l_arm", "r_arm"))
-		else
-			user.adjustBruteLoss(rand(force/2,force))
-
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if((H.stat != DEAD) && !(NO_BLOOD in H.species.species_traits))
-			H.bleed(5)
+			H.bleed(50)
 
 /obj/item/weapon/restraints/legcuffs/bola/cult
 	name = "runed bola"

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -41,7 +41,6 @@
 	force = 15
 	throwforce = 25
 	embed_chance = 75
-	var/cooldown = 0
 
 /obj/item/weapon/melee/cultblade/dagger/attack(atom/target, mob/living/carbon/human/user)
 	..()


### PR DESCRIPTION
CAUSE GOD YOU PEOPLE CANNOT BE TRUSTED WITH SOME THINGS.

Now deals 5 bleed on attack.
Adds a cultist wield check.
Propgating over to my cultpass PR.

:cl: Fethas
tweak: The cultist dagger has had its special removed, it still cuases small bleed and retains its embed chance.
/:cl: