### PR TITLE
Cult structures take damage from melee and projectiles.

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -70,7 +70,7 @@
 		destroy_structure()
 
 /obj/structure/cult/functional/proc/take_damage(damage, damage_type = BRUTE)
-	if(damage_type == BRUTE || damage_type = BURN)
+	if(damage_type == BRUTE || damage_type == BURN)
 		health -= damage
 		updatehealth()
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -65,6 +65,23 @@
 	else
 		return ..()
 
+/obj/structure/cult/functional/proc/updatehealth()
+	if(health <= 0)
+		destroy_structure()
+
+/obj/structure/cult/functional/proc/take_damage(damage, damage_type = BRUTE)
+	if(damage_type != STAMINA)
+		health -= damage
+		updatehealth()
+
+/obj/structure/cult/functional/attackby(obj/item/I, mob/living/user)
+	..()
+	take_damage(I.force * 0.5, I.damtype)
+	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
+
+/obj/structure/cult/functional/bullet_act(var/obj/item/projectile/P)
+	take_damage(P.damage, P.damage_type)
+
 /obj/structure/cult/functional/attack_hand(mob/living/user)
 	if(!iscultist(user))
 		to_chat(user, "[heathen_message]")
@@ -142,6 +159,8 @@
 			C.apply_damage(30, BURN, "head") //30 fire damage because it's FUCKING LAVA
 			head.disfigure("burn") //Your face is unrecognizable because it's FUCKING LAVA
 		return 1
+	else
+		..()
 
 var/list/blacklisted_pylon_turfs = typecacheof(list(
 	/turf/simulated/floor/engine/cult,

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -70,14 +70,14 @@
 		destroy_structure()
 
 /obj/structure/cult/functional/proc/take_damage(damage, damage_type = BRUTE)
-	if(damage_type != STAMINA)
+	if(damage_type == BRUTE || damage_type = BURN)
 		health -= damage
 		updatehealth()
 
 /obj/structure/cult/functional/attackby(obj/item/I, mob/living/user)
 	..()
-	take_damage(I.force * 0.5, I.damtype)
-	playsound(loc, 'sound/effects/grillehit.ogg', 80, 1)
+	take_damage(I.force, I.damtype)
+	playsound(loc, I.hitsound, 80, 1)
 
 /obj/structure/cult/functional/bullet_act(var/obj/item/projectile/P)
 	take_damage(P.damage, P.damage_type)


### PR DESCRIPTION
This PR makes cult structures susceptible to damage from melee and from projectiles.

Now you can destroy them with something other than bombs.

Fixes #7699 

🆑 Birdtalon
add: Cultist structures can now be destroyed using melee and or projectiles
/🆑 
