### PR TITLE
Flips have a chance to fail! How embarrassing...

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -324,8 +324,14 @@
 								G.affecting.forceMove(oldloc)
 								message = "<B>[src]</B> flips over [G.affecting]!"
 						else
-							message = "<B>[src]</B> does a flip!"
-							SpinAnimation(5,1)
+							if(prob(5))
+								message = "<B>[src]</B> attempts a flip and crashes to the floor!"
+								SpinAnimation(5,1)
+								sleep(3)
+								src.Weaken(2)
+							else
+								message = "<B>[src]</B> does a flip!"
+								SpinAnimation(5,1)
 
 		if("aflap", "aflaps")
 			if(!restrained())

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -328,7 +328,7 @@
 								message = "<B>[src]</B> attempts a flip and crashes to the floor!"
 								SpinAnimation(5,1)
 								sleep(3)
-								src.Weaken(2)
+								Weaken(2)
 							else
 								message = "<B>[src]</B> does a flip!"
 								SpinAnimation(5,1)


### PR DESCRIPTION
Flips have a 5% chance of fail and send you crashing to the floor. How embarrassing in front of your fellow crewmembers!

This was too good of a chance to pass up.
![flipemote](https://user-images.githubusercontent.com/25027759/29585505-3fa25452-877f-11e7-8ab0-11110cf6fb35.png)


🆑 Birdtalon
tweak: Flip emote has a small chance of a failure and 100% chance of embarrassing yourself.
/🆑 