### PR TITLE
Adds IPC Dissection Surgery

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -11,7 +11,7 @@
 		var/obj/item/organ/external/affected = H.get_organ(target_zone)
 		if(!affected)
 			return 0
-		if(affected.status & ORGAN_ROBOT) //Maybe add in a machine version, later?
+		if(affected.status & ORGAN_ROBOT)
 			return 0
 	var/mob/living/carbon/human/H = user
 	// You must either: Be of the abductor species, or contain an abductor implant
@@ -64,3 +64,31 @@
 	var/obj/item/organ/internal/heart/gland/gland = tool
 	gland.insert(target, 2)
 	return 1
+
+//IPC Gland Surgery//
+
+/datum/surgery/organ_extraction/synth
+	name = "experimental robotic dissection"
+	steps = list(/datum/surgery_step/robotics/external/unscrew_hatch,/datum/surgery_step/robotics/external/open_hatch,/datum/surgery_step/internal/extract_organ/synth,/datum/surgery_step/internal/gland_insert,/datum/surgery_step/robotics/external/close_hatch)
+	possible_locs = list("chest")
+	requires_organic_bodypart = 0
+
+/datum/surgery/organ_extraction/synth/can_start(mob/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
+	if(!ishuman(user))
+		return FALSE
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/external/affected = H.get_organ(target_zone)
+		if(!affected)
+			return FALSE
+		if(!(affected.status & ORGAN_ROBOT))
+			return FALSE
+	var/mob/living/carbon/human/H = user
+	// You must either: Be of the abductor species, or contain an abductor implant
+	if((H.get_species() == "Abductor" || (locate(/obj/item/weapon/implant/abductor) in H)))
+		return TRUE
+	return FALSE
+
+/datum/surgery_step/internal/extract_organ/synth
+	name = "remove cell"
+	organ_types = list(/obj/item/organ/internal/cell)


### PR DESCRIPTION
Adds in IPC dissection surgery for abductors; now IPCs are no longer immune to your probing ways.

Surgery is a simple: unscrew hatch, open hatch, remove cell, place in gland, close hatch.

fixes: https://github.com/ParadiseSS13/Paradise/issues/7978

:cl: Fox McCloud
add: IPCs can now be dissected by adbudctors
/:cl: