### PR TITLE
Allows medical cyborgs to diagnose IPC's with robutt analyzer

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -133,6 +133,7 @@
 /obj/item/weapon/robot_module/medical/New()
 	..()
 	modules += new /obj/item/device/healthanalyzer/advanced(src)
+	modules += new /obj/item/device/robotanalyzer(src)
 	modules += new /obj/item/device/reagent_scanner/adv(src)
 	modules += new /obj/item/weapon/borg_defib(src)
 	modules += new /obj/item/roller_holder(src)


### PR DESCRIPTION
Just a simple addition to the medical cyborg to allow them to diagnose machine species IPC's.

Wondering if examine could analyze em for medical cyborgs though.

🆑 
add: robot analyzer to medical module cyborgs for IPC diagnosing
/🆑 