### PR TITLE
Holodeck Sword Sound

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -436,8 +436,10 @@
 	item_state = "claymorered"
 
 /obj/item/weapon/holo/esword
-	desc = "May the force be within you. Sorta"
+	name = "Holographic Energy Sword"
+	desc = "This looks like a real energy sword!"
 	icon_state = "sword0"
+	hitsound = "sound/weapons/blade1.ogg"
 	force = 3.0
 	throw_speed = 1
 	throw_range = 5


### PR DESCRIPTION
The Holodeck Energy Swords now has the same sound as a real energy sword. The name was changed from 'weapon' to 'Holodeck Energy Sword'. The description has been changed, but can be subject to change.

:cl: Jovaniph
tweak: Holodeck Energy Swords sound was change to simulate being attacked by a real energy sword.
/ 🆑 