### PR TITLE
Supply Pack: EVA Suit

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -627,10 +627,10 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 
 /datum/supply_packs/engineering/engine/spacesuit
 	name = "Space Suit Crate"
-	contains = list(/obj/item/clothing/suit/space,
-					/obj/item/clothing/suit/space,
-					/obj/item/clothing/head/helmet/space,
-					/obj/item/clothing/head/helmet/space,
+	contains = list(/obj/item/clothing/suit/space/eva,
+					/obj/item/clothing/suit/space/eva,
+					/obj/item/clothing/head/helmet/space/eva,
+					/obj/item/clothing/head/helmet/space/eva,
 					/obj/item/clothing/mask/breath,
 					/obj/item/clothing/mask/breath)
 	cost = 30

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -131,34 +131,6 @@
 	strip_delay = 40
 	put_on_delay = 20
 
-//Paramedic EVA suit
-/obj/item/clothing/head/helmet/space/eva/paramedic
-	name = "Paramedic EVA helmet"
-	desc = "A paramedic EVA helmet. Used in the recovery of bodies from space."
-	icon_state = "paramedic-eva-helmet"
-	item_state = "paramedic-eva-helmet"
-	species_fit = list("Vox", "Grey")
-	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/helmet.dmi',
-		"Grey" = 'icons/mob/species/grey/helmet.dmi'
-		)
-	sprite_sheets_obj = list(
-		"Vox" = 'icons/obj/clothing/species/vox/hats.dmi'
-		)
-
-/obj/item/clothing/suit/space/eva/paramedic
-	name = "Paramedic EVA suit"
-	icon_state = "paramedic-eva"
-	item_state = "paramedic-eva"
-	desc = "A paramedic EVA suit. Used in the recovery of bodies from space."
-	species_fit = list("Vox")
-	sprite_sheets = list(
-		"Vox" = 'icons/mob/species/vox/suit.dmi'
-		)
-	sprite_sheets_obj = list(
-		"Vox" = 'icons/obj/clothing/species/vox/suits.dmi'
-		)
-
 /obj/item/clothing/suit/space/eva
 	name = "EVA suit"
 	icon_state = "spacenew"
@@ -200,6 +172,34 @@
 	sprite_sheets_obj = list(
 		"Vox" = 'icons/obj/clothing/species/vox/hats.dmi',
 		"Vulpkanin" = 'icons/obj/clothing/species/vulpkanin/hats.dmi'
+		)
+
+//Paramedic EVA suit
+/obj/item/clothing/head/helmet/space/eva/paramedic
+	name = "Paramedic EVA helmet"
+	desc = "A paramedic EVA helmet. Used in the recovery of bodies from space."
+	icon_state = "paramedic-eva-helmet"
+	item_state = "paramedic-eva-helmet"
+	species_fit = list("Vox", "Grey")
+	sprite_sheets = list(
+		"Vox" = 'icons/mob/species/vox/helmet.dmi',
+		"Grey" = 'icons/mob/species/grey/helmet.dmi'
+		)
+	sprite_sheets_obj = list(
+		"Vox" = 'icons/obj/clothing/species/vox/hats.dmi'
+		)
+
+/obj/item/clothing/suit/space/eva/paramedic
+	name = "Paramedic EVA suit"
+	icon_state = "paramedic-eva"
+	item_state = "paramedic-eva"
+	desc = "A paramedic EVA suit. Used in the recovery of bodies from space."
+	species_fit = list("Vox")
+	sprite_sheets = list(
+		"Vox" = 'icons/mob/species/vox/suit.dmi'
+		)
+	sprite_sheets_obj = list(
+		"Vox" = 'icons/obj/clothing/species/vox/suits.dmi'
 		)
 
 //Mime's Hardsuit


### PR DESCRIPTION
This changes the space suit that you get from cargo to be the same space suit you get from the EVA storage room. Also moved the /space/eva thingy to be on top of the rest of the other thingies because OCD reasons and formatting and other big words.

🆑 Jovaniph
tweak: Replace space suit in supply pack to be the EVA suit for consistency.
/ 🆑 