### PR TITLE
Buffs HoP door remote V2 + Tiny refactor

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -243,16 +243,17 @@
 #define FIRE_LAYER				33	//If you're on fire
 #define TOTAL_LAYERS			33
 
-///Access Region Codes///
-#define REGION_ALL			0
-#define REGION_GENERAL		1
-#define REGION_SECURITY		2
-#define REGION_MEDBAY		3
-#define REGION_RESEARCH		4
-#define REGION_ENGINEERING	5
-#define REGION_SUPPLY		6
-#define REGION_COMMAND		7
-#define REGION_CENTCOMM		8
+//Access Region Codes
+
+#define REGION_GENERAL       1
+#define REGION_SECURITY      2
+#define REGION_MEDBAY        4
+#define REGION_RESEARCH      8
+#define REGION_ENGINEERING   16
+#define REGION_SUPPLY        32
+#define REGION_COMMAND       64
+#define REGION_CENTCOMM      128
+#define REGION_ALL           255
 
 //used for maploader
 #define MAP_MINX 1

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -258,25 +258,24 @@ var/const/access_trade_sol = 160
 	return (get_all_accesses() | get_all_centcom_access() | get_all_syndicate_access() | get_all_misc_access())
 
 /proc/get_region_accesses(code)
-	switch(code)
-		if(REGION_ALL)
-			return get_all_accesses()
-		if(REGION_GENERAL) //station general
-			return list(access_kitchen, access_bar, access_hydroponics, access_janitor, access_chapel_office, access_crematorium, access_library, access_theatre, access_lawyer, access_magistrate, access_clown, access_mime)
-		if(REGION_SECURITY) //security
-			return list(access_sec_doors, access_weapons, access_security, access_brig, access_armory, access_forensics_lockers, access_court, access_pilot, access_hos)
-		if(REGION_MEDBAY) //medbay
-			return list(access_medical, access_genetics, access_morgue, access_chemistry, access_psychiatrist, access_virology, access_surgery, access_cmo, access_paramedic)
-		if(REGION_RESEARCH) //research
-			return list(access_research, access_tox, access_tox_storage, access_genetics, access_robotics, access_xenobiology, access_xenoarch, access_minisat, access_rd, access_network)
-		if(REGION_ENGINEERING) //engineering and maintenance
-			return list(access_construction, access_maint_tunnels, access_engine, access_engine_equip, access_external_airlocks, access_tech_storage, access_atmospherics, access_minisat, access_ce, access_mechanic)
-		if(REGION_SUPPLY) //supply
-			return list(access_mailsorting, access_mining, access_mining_station, access_mineral_storeroom, access_cargo, access_qm)
-		if(REGION_COMMAND) //command
-			return list(access_heads, access_RC_announce, access_keycard_auth, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_tcomsat, access_gateway, access_all_personal_lockers, access_heads_vault, access_blueshield, access_ntrep, access_hop, access_captain)
-		if(REGION_CENTCOMM) //because why the heck not
-			return get_all_centcom_access() + get_all_accesses()
+	var/return_accesses = null
+	if(code & REGION_GENERAL)
+		return_accesses += list(access_kitchen, access_bar, access_hydroponics, access_janitor, access_chapel_office, access_crematorium, access_library, access_theatre, access_lawyer, access_magistrate, access_clown, access_mime)
+	if(code & REGION_SECURITY)
+		return_accesses += list(access_sec_doors, access_weapons, access_security, access_brig, access_armory, access_forensics_lockers, access_court, access_pilot, access_hos)
+	if(code & REGION_MEDBAY)
+		return_accesses += list(access_medical, access_genetics, access_morgue, access_chemistry, access_psychiatrist, access_virology, access_surgery, access_cmo, access_paramedic)
+	if(code & REGION_RESEARCH)
+		return_accesses += list(access_research, access_tox, access_tox_storage, access_genetics, access_robotics, access_xenobiology, access_xenoarch, access_minisat, access_rd, access_network)
+	if(code & REGION_ENGINEERING)
+		return_accesses += list(access_construction, access_maint_tunnels, access_engine, access_engine_equip, access_external_airlocks, access_tech_storage, access_atmospherics, access_minisat, access_ce, access_mechanic)
+	if(code & REGION_SUPPLY)
+		return_accesses += list(access_mailsorting, access_mining, access_mining_station, access_mineral_storeroom, access_cargo, access_qm)
+	if(code & REGION_COMMAND)
+		return_accesses += list(access_heads, access_RC_announce, access_keycard_auth, access_change_ids, access_ai_upload, access_teleporter, access_eva, access_tcomsat, access_gateway, access_all_personal_lockers, access_heads_vault, access_blueshield, access_ntrep, access_hop, access_captain)
+	if(code & REGION_CENTCOMM)
+		return_accesses = get_all_centcom_access() + get_all_accesses()
+	return return_accesses
 
 /proc/get_region_accesses_name(code)
 	switch(code)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -281,7 +281,7 @@ var/time_last_changed_position = 0
 
 	else if(modify)
 		var/list/regions = list()
-		for(var/i = 1; i <= 7; i++)
+		for(var/i = 1; i <= 64; i += i)
 			var/list/accesses = list()
 			for(var/access in get_region_accesses(i))
 				if(get_access_desc(access))

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -11,12 +11,15 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/mode = WAND_OPEN
 	var/region_access = 1 //See access.dm
+	var/singular_access // define access flags in a list to add additonal access without using regions
 	var/obj/item/weapon/card/id/ID
 
 /obj/item/weapon/door_remote/New()
 	..()
 	ID = new /obj/item/weapon/card/id
-	ID.access = get_region_accesses(region_access)
+	ID.access = get_region_accesses(region_access) // Get region access from the remote
+	if(singular_access) // If we have any singular access flags, then add them too.
+		ID.access += singular_access
 
 /obj/item/weapon/door_remote/Destroy()
 	QDEL_NULL(ID)
@@ -101,10 +104,11 @@
 	icon_state = "gangtool-blue"
 	region_access = REGION_MEDBAY
 
-/obj/item/weapon/door_remote/civillian
-	name = "civillian door remote"
+/obj/item/weapon/door_remote/civilian
+	name = "civilian door remote"
 	icon_state = "gangtool-white"
-	region_access = REGION_GENERAL
+	region_access = REGION_GENERAL + REGION_SUPPLY
+	singular_access = list(access_hop)
 
 /obj/item/weapon/door_remote/centcomm
 	name = "centcomm door remote"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -56,7 +56,7 @@
 		new /obj/item/weapon/gun/energy/gun(src)
 		new /obj/item/device/flash(src)
 		new /obj/item/clothing/accessory/petcollar(src)
-		new /obj/item/weapon/door_remote/civillian(src)
+		new /obj/item/weapon/door_remote/civilian(src)
 
 /obj/structure/closet/secure_closet/hop2
 	name = "head of personnel's attire"

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -395,7 +395,7 @@
 
 	else if(modify)
 		var/list/regions = list()
-		for(var/i = 1; i <= 7; i++)
+		for(var/i = 1; i <= 64; i += i)
 			var/list/accesses = list()
 			for(var/access in get_region_accesses(i))
 				if(get_access_desc(access))


### PR DESCRIPTION
So with the first PR #7999 I didn't think deeply about the implications of the change and it resulted in #8020 - Unfortunately I was asleep during this time so couldn't make a fix at the point it was identified.

I have gone back and looked at this again and come up with some changes which will not break the console:

- Small refactor to the `get_region_accesses` proc to allow it to return multiple regional access flags.
- Redefined the region defines as powers of 2.
- Small change to the ID console to respect the new defines.
- Added a `singular_access` var to control wands to allow for creation of control wands with specific access or additional access outside of the regional defines. These can be used to spawn new remotes and set access via VV if admins wanted to.
- Finally... buffs the HoP door remote to allow for supply access and HoP door access.
- Fixes spelling of "civilian" on that remote.

**I have tested this, but please if you can think of something else which may be impacted here then throw it at me so I can ensure it won't break anything else.**

🆑 Birdtalon
tweak: Head of Personnel had a bit of trouble and has traded his new remote in for the old version but with a little more access.
fix: Fixes spelling of said door remote.
/🆑 