### PR TITLE
Control Click shortcut for defibrillator toggle paddles verb

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -78,7 +78,8 @@
 	toggle_paddles()
 
 /obj/item/weapon/defibrillator/CtrlClick()
-	toggle_paddles()
+	if(ishuman(usr) && Adjacent(usr))
+		toggle_paddles()
 
 /obj/item/weapon/defibrillator/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/stock_parts/cell))

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -77,6 +77,9 @@
 /obj/item/weapon/defibrillator/ui_action_click()
 	toggle_paddles()
 
+/obj/item/weapon/defibrillator/CtrlClick()
+	toggle_paddles()
+
 /obj/item/weapon/defibrillator/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/stock_parts/cell))
 		var/obj/item/weapon/stock_parts/cell/C = W


### PR DESCRIPTION
![discord_2017-08-29_14-05-29](https://user-images.githubusercontent.com/25027759/29822396-328fa2ee-8cc3-11e7-9f29-4727116bad9b.png)

Control click shortcut to access the toggle paddles verb. If the defibrillator is on the floor this functionality overrides pulling it as it currently stands. @Maints if you would rather the shortcut be changed for consistency then I can do so.

🆑 Birdtalon
add: You can now Control Click a defibrillator to toggle paddles.
/🆑 