### PR TITLE
Fix changeturf not properly destroying own lights.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -157,6 +157,7 @@
 		return
 	if(!use_preloader && path == type) // Don't no-op if the map loader requires it to be reconstructed
 		return src
+	set_light(0)
 	var/old_opacity = opacity
 	var/old_dynamic_lighting = dynamic_lighting
 	var/old_affecting_lights = affecting_lights


### PR DESCRIPTION
Changeturf doesn't call Destroy() so lights on the source turf weren't getting removed, resulting in runtimes later as the light attempted to remove from a turf that didn't know about it.

No changelog due to being an internal code fix.