### PR TITLE
Cryopods eject objective items upon emag

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1,6 +1,6 @@
 var/global/list/all_objectives = list()
 
-var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datum/theft_objective/steal - /datum/theft_objective/number
+var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datum/theft_objective/steal - /datum/theft_objective/number - /datum/theft_objective/unique
 
 /datum/objective
 	var/datum/mind/owner = null			//Who owns the objective.

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -6,8 +6,8 @@
 #define THEFT_FLAG_UNIQUE 2
 
 /datum/theft_objective
-	var/name = ""
-	var/typepath=/atom
+	var/name = "this objective is impossible, yell at a coder"
+	var/typepath=/obj/effect/debugging
 	var/list/protected_jobs = list()
 	var/list/altitems = list()
 	var/flags = 0


### PR DESCRIPTION
Inspired by #7976 

Emagging a cryopod console will eject all items that are needed for an objective, while leaving everything else in place.

:cl: Crazylemon
rscadd: Emagging cryopod oversight consoles ejects all objective items within
/:cl: