### PR TITLE
Medbots v1.2 - Refactor + Improvement

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -61,3 +61,10 @@ var/global/list/safe_chem_list = list("antihol", "charcoal", "epinephrine", "ins
 									  "omnizine", "stimulants", "synaptizine", "potass_iodide", "oculine", "mannitol", "styptic_powder",
 									  "spaceacillin", "salglu_solution", "sal_acid", "cryoxadone", "blood", "synthflesh", "hydrocodone",
 									  "mitocholide", "rezadone")
+
+//Lists of chems by what they heal for INJEST only
+
+var/global/list/brute_healing_chems_injest = list("salglu_solution","atropine","sal_acid","omnizine","epinephrine")
+var/global/list/burn_healing_chems_injest = list("salglu_solution","atropine","omnizine","epinephrine")
+var/global/list/oxy_healing_chems_injest = list("salbutamol","atropine","perfluorodecalin","epinephrine")
+var/global/list/tox_healing_chems_injest = list("charcoal","omnizine","pen_acid","epinephrine")

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -292,6 +292,7 @@
 	var/treatment_fire = "salglu_solution"
 	var/treatment_tox = "charcoal"
 	var/treatment_virus = "spaceacillin"
+	var/treatment_evil = "pancuronium"
 	req_one_access = list(access_medical, access_robotics)
 
 	/obj/item/weapon/firstaid_arm_assembly/New()
@@ -374,11 +375,14 @@
 					S.skin = skin
 					S.name = created_name
 					S.bot_core.req_one_access = req_one_access
-					S.treatment_oxy = treatment_oxy
-					S.treatment_brute = treatment_brute
-					S.treatment_fire = treatment_fire
-					S.treatment_tox = treatment_tox
-					S.treatment_virus = treatment_virus
+					S.treatments = list(
+						"brute" = treatment_brute,
+						"fire" = treatment_fire,
+						"tox" = treatment_tox,
+						"oxy" = treatment_oxy,
+						"virus" = treatment_virus,
+						"evil" = treatment_evil
+						)
 					user.unEquip(src, 1)
 					qdel(src)
 

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -376,10 +376,10 @@
 					S.name = created_name
 					S.bot_core.req_one_access = req_one_access
 					S.treatments = list(
-						"brute" = treatment_brute,
-						"fire" = treatment_fire,
-						"tox" = treatment_tox,
-						"oxy" = treatment_oxy,
+						BRUTE = treatment_brute,
+						BURN = treatment_fire,
+						TOX = treatment_tox,
+						OXY = treatment_oxy,
 						"virus" = treatment_virus,
 						"evil" = treatment_evil
 						)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -52,6 +52,7 @@
 		)
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
 	var/shut_up = 0 //self explanatory :)
+	var/internalsafety = TRUE // If true attempt to check internal reagent before injecting
 
 /mob/living/simple_animal/bot/medbot/tox
 	skin = "tox"
@@ -185,6 +186,10 @@
 		dat += "Reagent Source: "
 		dat += "<a href='?src=[UID()];use_beaker=1'>[use_beaker ? "Loaded Beaker (When available)" : "Internal Synthesizer"]</a><br>"
 
+		if(reagent_glass)
+			dat += "Internal Reagent Safety:"
+			dat += "<a href='?src=[UID()];internalsafety=1'>[internalsafety ? "Yes" : "No"]</a><br>"
+
 		dat += "Treat Viral Infections: <a href='?src=[UID()];virus=1'>[treat_virus ? "Yes" : "No"]</a><br>"
 		dat += "The speaker switch is [shut_up ? "off" : "on"]. <a href='?src=[UID()];togglevoice=[1]'>Toggle</a><br>"
 		dat += "Critical Patient Alerts: <a href='?src=[UID()];critalerts=1'>[declare_crit ? "Yes" : "No"]</a><br>"
@@ -233,6 +238,9 @@
 
 	else if(href_list["virus"])
 		treat_virus = !treat_virus
+
+	else if(href_list["internalsafety"])
+		internalsafety = !internalsafety
 
 	update_controls()
 	return
@@ -472,6 +480,8 @@
 		return
 
 /mob/living/simple_animal/bot/medbot/proc/special_reagent_check(reagent_id, damagetype)
+	if(!internalsafety)
+		return TRUE
 //Check to see if the reagent actually treats the corresponding damage type.
 	switch(damagetype)
 		if(BRUTE)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -43,10 +43,10 @@
 	var/stationary_mode = 0 //If enabled, the Medibot will not move automatically.
 	//Setting which reagents to use to treat what by default. By id.
 	var/treatments = list(
-		"brute" = "salglu_solution",
-		"fire" = "salglu_solution",
-		"oxy" = "salbutamol",
-		"tox" = "charcoal",
+		BRUTE = "salglu_solution",
+		BURN = "salglu_solution",
+		OXY = "salbutamol",
+		TOX = "charcoal",
 		"virus" = "spaceacillin",
 		"evil" = "pancuronium"
 		)
@@ -76,10 +76,10 @@
 	desc = "International Medibot of mystery."
 	skin = "bezerk"
 	treatments = list(
-		"oxy" = "perfluorodecalin",
-		"brute" = "styptic_powder",
-		"fire" = "silver_sulfadiazine",
-		"tox" = "charcoal",
+		BRUTE = "styptic_powder",
+		BURN = "silver_sulfadiazine",
+		OXY = "perfluorodecalin",
+		TOX = "charcoal",
 		"virus" = "spaceacillin",
 		"evil" = "pancuronium"
 		)
@@ -89,10 +89,10 @@
 	desc = "You'd better have insurance!"
 	skin = "bezerk"
 	treatments = list(
-		"oxy" = "perfluorodecalin",
-		"brute" = "styptic_powder",
-		"fire" = "silver_sulfadiazine",
-		"tox" = "charcoal",
+		BRUTE = "styptic_powder",
+		BURN = "silver_sulfadiazine",
+		OXY = "perfluorodecalin",
+		TOX = "charcoal",
 		"virus" = "spaceacillin",
 		"evil" = "pancuronium"
 		)
@@ -386,13 +386,13 @@
 	if(treat_virus && scan_for_virus(C)) // If we're looking for viruses and they have one which is detectable by us.
 		patient_status |= REQ_VIRUS
 	if(C.has_organic_damage()) // Now damage checks. No point doing this if they have no damage.
-		if((C.getBruteLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatments["brute"])))
+		if((C.getBruteLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatments[BRUTE])))
 			patient_status |= REQ_BRUTE
-		if((C.getFireLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatments["fire"])))
+		if((C.getFireLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatments[BURN])))
 			patient_status |= REQ_BURN
-		if((C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatments["tox"])))
+		if((C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatments[TOX])))
 			patient_status |= REQ_TOX
-		if((C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatments["oxy"])))
+		if((C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatments[OXY])))
 			patient_status |= REQ_OXY
 		return patient_status
 	else
@@ -474,16 +474,16 @@
 /mob/living/simple_animal/bot/medbot/proc/special_reagent_check(reagent_id, damagetype)
 //Check to see if the reagent actually treats the corresponding damage type.
 	switch(damagetype)
-		if("brute")
+		if(BRUTE)
 			if(brute_healing_chems_injest.Find(reagent_id))
 				return TRUE
-		if("fire")
+		if(BURN)
 			if(burn_healing_chems_injest.Find(reagent_id))
 				return TRUE
-		if("oxy")
+		if(OXY)
 			if(oxy_healing_chems_injest.Find(reagent_id))
 				return TRUE
-		if("tox")
+		if(TOX)
 			if(tox_healing_chems_injest.Find(reagent_id))
 				return TRUE
 	return FALSE
@@ -495,14 +495,14 @@
 		if(C.health >= 50) // If their health is above 60 then we can should treat the virus.
 			var/virus_weight = C.health / 2 // We calculate the weight based on their current health over 2 to prioratise actual damage.
 			dam += list("virus" = virus_weight)
-	if((patient_status & REQ_BURN) && !C.reagents.has_reagent(treatments["fire"]))
-		dam += list("fire" = C.getFireLoss())
-	if((patient_status & REQ_BRUTE) && !C.reagents.has_reagent(treatments["brute"]))
-		dam += list("brute" = C.getBruteLoss())
-	if((patient_status & REQ_OXY) && !C.reagents.has_reagent(treatments["oxy"]))
-		dam += list("oxy" = C.getOxyLoss())
-	if((patient_status & REQ_TOX) && !C.reagents.has_reagent(treatments["tox"]))
-		dam += list("tox" = C.getToxLoss())
+	if((patient_status & REQ_BURN) && !C.reagents.has_reagent(treatments[BURN]))
+		dam += list(BURN = C.getFireLoss())
+	if((patient_status & REQ_BRUTE) && !C.reagents.has_reagent(treatments[BRUTE]))
+		dam += list(BRUTE = C.getBruteLoss())
+	if((patient_status & REQ_OXY) && !C.reagents.has_reagent(treatments[OXY]))
+		dam += list(OXY = C.getOxyLoss())
+	if((patient_status & REQ_TOX) && !C.reagents.has_reagent(treatments[TOX]))
+		dam += list(TOX = C.getToxLoss())
 
 	var/highest = 0
 	var/highest_key
@@ -534,11 +534,11 @@
 	switch(skin)
 		if("ointment")
 			new /obj/item/weapon/storage/firstaid/fire/empty(Tsec)
-		if("tox")
+		if(TOX)
 			new /obj/item/weapon/storage/firstaid/toxin/empty(Tsec)
 		if("o2")
 			new /obj/item/weapon/storage/firstaid/o2/empty(Tsec)
-		if("brute")
+		if(BRUTE)
 			new /obj/item/weapon/storage/firstaid/brute/empty(Tsec)
 		if("adv")
 			new /obj/item/weapon/storage/firstaid/adv/empty(Tsec)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1667,7 +1667,6 @@
 #include "code\modules\mob\living\simple_animal\simple_animal.dm"
 #include "code\modules\mob\living\simple_animal\spawner.dm"
 #include "code\modules\mob\living\simple_animal\tribbles.dm"
-#include "code\modules\mob\living\simple_animal\bot\birdbot.dm"
 #include "code\modules\mob\living\simple_animal\bot\bot.dm"
 #include "code\modules\mob\living\simple_animal\bot\cleanbot.dm"
 #include "code\modules\mob\living\simple_animal\bot\construction.dm"

--- a/paradise.dme
+++ b/paradise.dme
@@ -1667,6 +1667,7 @@
 #include "code\modules\mob\living\simple_animal\simple_animal.dm"
 #include "code\modules\mob\living\simple_animal\spawner.dm"
 #include "code\modules\mob\living\simple_animal\tribbles.dm"
+#include "code\modules\mob\living\simple_animal\bot\birdbot.dm"
 #include "code\modules\mob\living\simple_animal\bot\bot.dm"
 #include "code\modules\mob\living\simple_animal\bot\cleanbot.dm"
 #include "code\modules\mob\living\simple_animal\bot\construction.dm"


### PR DESCRIPTION
Refactors parts of the medbot code, breaks a couple of huge procs into smaller ones, as well as adding some intelligence to the medbots themselves.

- Medbots now check which type of damage is greatest for the patient and will treat that first.
- When using an internal beaker, medbots will check to see if the reagent is actually useful for treating the damage before using it. If not it will fall back on the internal synthesizer .
- Medbots will no longer inject their internal beaker with impunity regardless of if it's helpful or harmful. They must be toggled to over-ride this manually.
- Medbots will now only seek to treat viruses if the patient is reasonably healthy first (over 50 health) and even then will prioritise any serious damage first before attempting to treat the virus.

🆑 Birdtalon
add: Medbots now prioritise the highest sustained damage type to treat first.
add: Medbots will check to see if internal beaker chems are useful before using them.
tweak: Medbots will have to be emagged before injecting harmful internal beaker chems.
/🆑 