### PR TITLE
Cyborgs can now correctly synthesize flaming moe

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -44,7 +44,7 @@ var/list/drinks = list("beer2","hot_coco","orangejuice","tomatojuice","limejuice
 					"vodkatonic","ginfizz","bahama_mama","singulo","sbiten","devilskiss","red_mead",
 					"mead","iced_beer","grog","aloe","andalusia","alliescocktail","soy_latte",
 					"cafe_latte","acidspit","amasec","neurotoxin","hippiesdelight","bananahonk",
-					"silencer","changelingsting","irishcarbomb","syndicatebomb","erikasurprise","driestmartini")
+					"silencer","changelingsting","irishcarbomb","syndicatebomb","erikasurprise","driestmartini", "flamingmoe")
 
 //Random chem blacklist
 var/global/list/blocked_chems = list("polonium", "initropidril", "concentrated_initro",


### PR DESCRIPTION
Fixes #8045 - turns out I'd forgotten to add flaming moe to the global list of drinks. 🔥 

:cl:
fix: Cyborgs can now synthesize flaming moe correctly
/:cl: