### PR TITLE
Adds PDF files to Modular Computers

### DIFF
--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -76,6 +76,7 @@ var/list/global_modular_computers = list()
 /obj/machinery/modular_computer/proc/eject_id()
 	set name = "Eject ID"
 	set category = "Object"
+	set src in view(1)
 
 	if(cpu)
 		cpu.eject_id()
@@ -84,6 +85,7 @@ var/list/global_modular_computers = list()
 /obj/machinery/modular_computer/proc/eject_disk()
 	set name = "Eject Data Disk"
 	set category = "Object"
+	set src in view(1)
 
 	if(cpu)
 		cpu.eject_disk()

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -178,7 +178,7 @@
 				error = "Missing Hardware: Your computer does not have required hardware to complete this operation."
 				return 1
 			if(!printer.print_text(prepare_printjob(F.stored_data, computer.emagged ? CRAYON_FONT : PRINTER_FONT), open_file))
-				error = "Hardware error: Printer was unable to print the file. It may be out of paper."
+				error = "Hardware error: Printer was unable to print the file. It may be out of paper or already printing."
 				return 1
 		if("PRG_copytousb")
 			. = 1

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -6,6 +6,7 @@
 	icon_state = "printer"
 	w_class = WEIGHT_CLASS_NORMAL
 	device_type = MC_PRINT
+	var/printing = FALSE										// Prevent printing spam
 	var/stored_paper = 20
 	var/max_paper = 30
 
@@ -24,27 +25,35 @@
 	if(!check_functionality())
 		return FALSE
 
-	var/obj/item/weapon/paper/P = new/obj/item/weapon/paper(get_turf(holder))
+	if(!printing)
+		printing = TRUE
+		playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
+		sleep(50)
+		var/obj/item/weapon/paper/P = new/obj/item/weapon/paper(get_turf(holder))
 
 	// Damaged printer causes the resulting paper to be somewhat harder to read.
-	if(damage > damage_malfunction)
-		P.info = stars(text_to_print, 100-malfunction_probability)
+
+		if(damage > damage_malfunction)
+			P.info = stars(text_to_print, 100-malfunction_probability)
+		else
+			P.info = text_to_print
+		if(paper_title)
+			P.name = paper_title
+
+		P.update_icon()
+		P.populatefields()
+		P.updateinfolinks()
+		stored_paper--
+		P = null
+		printing = FALSE
+		return TRUE
 	else
-		P.info = text_to_print
-	if(paper_title)
-		P.name = paper_title
-	P.update_icon()
-	P.populatefields()
-	P.updateinfolinks()
-	stored_paper--
-	P = null
-
-	playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
-
-	return TRUE
+		to_chat(usr, "<span class='notice'>[src] is already printing. Please wait</span>")
 
 /obj/item/weapon/computer_hardware/printer/try_insert(obj/item/I, mob/living/user = null)
+	var/obj/item/weapon/computer_hardware/hard_drive/HDD = holder.all_components[MC_HDD]
 	if(istype(I, /obj/item/weapon/paper))
+		var/obj/item/weapon/paper/P = I
 		if(stored_paper >= max_paper)
 			if(user)
 				to_chat(user, "<span class='warning'>You try to add \the [I] into [src], but its paper bin is full!</span>")
@@ -54,7 +63,24 @@
 			return FALSE
 
 		if(user)
-			to_chat(user, "<span class='notice'>You insert \the [I] into [src]'s paper recycler.</span>")
+			user.put_in_hands(P)
+			if(P.info == null)
+				to_chat(user, "<span class='notice'>You insert \the [I] into [src]'s paper recycler.</span>")
+			else
+				switch(alert("How would you like to proceed?", "Options.", "Scan Paper","Recycle Paper", "Abort"))
+					if("Abort")
+						return 0
+					if("Scan Paper")
+						to_chat(user, "<span class='notice'>You scan \the [I] with [src]'s paper scanner.</span>")
+						var/datum/computer_file/data/F = new/datum/computer_file/data()
+						F.filename = "[P.name] [worldtime2text()]"
+						F.filetype = "PDF"
+						F.stored_data = P.info
+						F.do_not_edit = 1
+						HDD.store_file(F)
+						return 0
+					if("Recycle Paper")
+						to_chat(user, "<span class='notice'>You insert \the [I] into [src]'s paper recycler.</span>")
 		qdel(I)
 		stored_paper++
 		return TRUE

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -58,10 +58,8 @@
 			if(user)
 				to_chat(user, "<span class='warning'>You try to add \the [I] into [src], but its paper bin is full!</span>")
 			return FALSE
-
 		if(user && !user.unEquip(I))
 			return FALSE
-
 		if(user)
 			user.put_in_hands(P)
 			if(P.info == null)
@@ -84,6 +82,17 @@
 		qdel(I)
 		stored_paper++
 		return TRUE
+	if(istype(I, /obj/item/weapon/paper_bundle))
+		var/obj/item/weapon/paper_bundle/B = I
+		var/datum/computer_file/data/F = new/datum/computer_file/data()
+		F.filename = "paper bundle - [B.name] [worldtime2text()]"
+		F.stored_data = ""
+		F.do_not_edit = 1
+		F.filetype = "PDF"
+		to_chat(user, "<span class='notice'>You scan the bundle [I] with [src]'s paper scanner.</span>")
+		for(var/obj/item/weapon/paper/P in B)
+			F.stored_data += "<br><hr><b><center>[P.name]</center></b><br>[P.info]"
+		HDD.store_file(F)
 	return FALSE
 
 /obj/item/weapon/computer_hardware/printer/mini

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -22,6 +22,7 @@
 	var/dev_cpu = 1							// 1: Default, 2: Upgraded
 	var/dev_battery = 1						// 1: Default, 2: Upgraded, 3: Advanced
 	var/dev_disk = 1						// 1: Default, 2: Upgraded, 3: Advanced
+	var/dev_portable = 1					// 1: Default, 2: Upgraded, 3: Advanced
 	var/dev_netcard = 0						// 0: None, 1: Basic, 2: Long-Range
 	var/dev_apc_recharger = 0				// 0: None, 1: Standard (LAPTOP ONLY)
 	var/dev_printer = 0						// 0: None, 1: Standard
@@ -92,6 +93,19 @@
 				if(fabricate)
 					fabricated_laptop.install_component(new /obj/item/weapon/computer_hardware/network_card/advanced)
 				total_price += 299
+		switch(dev_portable)
+			if(1) // Basic(16QC)
+				if(fabricate)
+					fabricated_laptop.install_component(new /obj/item/weapon/computer_hardware/hard_drive/portable)
+				total_price += 50
+			if(2) // Upgraded(64GQ)
+				if(fabricate)
+					fabricated_laptop.install_component(new /obj/item/weapon/computer_hardware/hard_drive/portable/advanced)
+				total_price += 99
+			if(3) // Advanced(256GQ)
+				if(fabricate)
+					fabricated_laptop.install_component(new /obj/item/weapon/computer_hardware/hard_drive/portable/super)
+				total_price += 299
 		if(dev_apc_recharger)
 			total_price += 399
 			if(fabricate)
@@ -147,6 +161,19 @@
 				if(fabricate)
 					fabricated_tablet.install_component(new/obj/item/weapon/computer_hardware/network_card/advanced)
 				total_price += 299
+		switch(dev_portable)
+			if(1) // Basic(16QC)
+				if(fabricate)
+					fabricated_tablet.install_component(new /obj/item/weapon/computer_hardware/hard_drive/portable)
+				total_price += 50
+			if(2) // Upgraded(64GQ)
+				if(fabricate)
+					fabricated_tablet.install_component(new /obj/item/weapon/computer_hardware/hard_drive/portable/advanced)
+				total_price += 99
+			if(3) // Advanced(256GQ)
+				if(fabricate)
+					fabricated_tablet.install_component(new /obj/item/weapon/computer_hardware/hard_drive/portable/super)
+				total_price += 299
 		if(dev_printer)
 			total_price += 99
 			if(fabricate)
@@ -197,6 +224,10 @@
 			dev_netcard = text2num(href_list["netcard"])
 			fabricate_and_recalc_price(0)
 			return 1
+		if("hw_portable")
+			dev_portable = text2num(href_list["portable"])
+			fabricate_and_recalc_price(0)
+			return 1
 		if("hw_tesla")
 			dev_apc_recharger = text2num(href_list["tesla"])
 			fabricate_and_recalc_price(0)
@@ -229,6 +260,7 @@
 		data["hw_battery"] = dev_battery
 		data["hw_disk"] = dev_disk
 		data["hw_netcard"] = dev_netcard
+		data["hw_portable"] = dev_portable
 		data["hw_tesla"] = dev_apc_recharger
 		data["hw_nanoprint"] = dev_printer
 		data["hw_card"] = dev_card

--- a/nano/templates/computer_fabricator.tmpl
+++ b/nano/templates/computer_fabricator.tmpl
@@ -32,6 +32,12 @@
 				<td>{{:helper.link('Standard', 'signal', {'action' : 'hw_netcard', 'netcard' : 1}, data.hw_netcard == 1 ? "selected" : null)}}
 				<td>{{:helper.link('Advanced', 'signal', {'action' : 'hw_netcard', 'netcard' : 2}, data.hw_netcard == 2 ? "selected" : null)}}
 			</tr>
+			<tr>
+				<td><b>Portable Device:</b>
+				<td>{{:helper.link('Standard', 'hdd-o', {'action' : 'hw_portable', 'portable' : 1}, data.hw_portable == 1 ? "selected" : null)}}
+				<td>{{:helper.link('Upgraded', 'hdd-o', {'action' : 'hw_portable', 'portable' : 2}, data.hw_portable == 2 ? "selected" : null)}}
+				<td>{{:helper.link('Advanced', 'hdd-o', {'action' : 'hw_portable', 'portable' : 3}, data.hw_portable == 3 ? "selected" : null)}}
+			</tr>
 			{{if data.devtype != 2}}
 			<tr>
 				<td><b>Nano Printer:</b>
@@ -69,6 +75,7 @@
 		<b>Hard Drive</b> stores file on your device. Advanced drives can store more files, but use more power, shortening battery life.<br>
 		<b>Network Card</b> allows your device to wirelessly connect to stationwide NTNet network. Basic cards are limited to on-station use, while advanced cards can operate anywhere near the station, which includes the asteroid outposts.<br>
 		<b>Processor Unit</b> is critical for your device's functionality. It allows you to run programs from your hard drive. Advanced CPUs use more power, but allow you to run more programs on background at once.<br>
+		<b>Portable</b>A portable USB used for transfering files manually. The super portable device contains most memory.
 		<b>Tesla Relay</b> is an advanced wireless power relay that allows your device to connect to nearby area power controller to provide alternative power source. This component is currently unavailable on tablet computers due to size restrictions.<br>
 		<b>Nano Printer</b> is device that allows for various paperwork manipulations, such as, scanning of documents or printing new ones. This device was certified EcoFriendlyPlus and is capable of recycling existing paper for printing purposes.<br>
 		<b>Card Reader</b> adds a slot that allows you to manipulate RFID cards. Please note that this is not necessary to allow the device to read your identification, it is just necessary to manipulate other cards.


### PR DESCRIPTION
You can now scan files into modular computers.
That means papers that looks very nice such as detective reports, body scanners can be scanned into the modular computer and sent, printed or whatever. What you cannot do is edit them, if you try to you will be warned.

Computers/tablets bought at the computer vendor will now include a portable USB device.

🆑Fruerlund
feature: You can now scan papers into modular computers.
feature: Laptops and tablets now come with a portable device included.
/🆑