### PR TITLE
Nerfs missionary/wololo staff

### DIFF
--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -621,7 +621,7 @@
 	target.mind.make_zealot(missionary, convert_duration, team_color)
 	zealots_made++
 
-	missionary.adjustBruteLoss(8 * zealots_made)
+	missionary.adjustBruteLoss(8 * zealots_made * pick(0.5,1,2))
 
 	target << sound('sound/misc/wololo.ogg', 0, 1, 25)
 	missionary.say("WOLOLO!")

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -519,6 +519,8 @@
 	var/obj/item/clothing/suit/hooded/chaplain_hoodie/missionary_robe/robes = null		//the robes linked with this staff
 	var/faith = 99	//a conversion requires 100 faith to attempt. faith recharges over time while you are wearing missionary robes that have been linked to the staff.
 
+	var/zealots_made = 0
+
 /obj/item/weapon/nullrod/missionary_staff/New()
 	team_color = pick("red", "blue")
 	icon_state = "godstaff-[team_color]"
@@ -617,6 +619,9 @@
 		faith -= 100
 	//if you made it this far: congratulations! you are now a religious zealot!
 	target.mind.make_zealot(missionary, convert_duration, team_color)
+	zealots_made++
+
+	missionary.adjustBruteLoss(8 * zealots_made)
 
 	target << sound('sound/misc/wololo.ogg', 0, 1, 25)
 	missionary.say("WOLOLO!")

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -570,7 +570,7 @@
 	if(!target.mind)	//no mind means no conversion, but also means no faith lost.
 		to_chat(missionary, "<span class='warning'>You halt the conversion as you realize [target] is mindless! Best to save your faith for someone more worthwhile.</span>")
 		return
-	if(do_after(missionary, 40))	//4 seconds to temporarily convert, roughly 1 second faster than a vampire's enthrall ability
+	if(do_after(missionary, 80))	//8 seconds to temporarily convert, roughly 3 seconds slower than a vamp's enthrall, but its a ranged thing
 		if(faith < 100)		//to stop people from trying to exploit the do_after system to multi-convert, we check again if you have enough faith when it completes
 			to_chat(missionary, "<span class='warning'>You don't have enough faith to complete the conversion on [target]!</span>")
 			return
@@ -591,14 +591,9 @@
 		faith -= 25		//same faith cost as losing sight of them mid-conversion, but did you just find someone who can lead you to a fellow traitor?
 		return
 	if(ismindshielded(target))
-		if(prob(20))	//loyalty implants typically overpower this, but you CAN get lucky and convert still (20% chance of success)
-			faith -= 125	//yes, this puts it negative. it's gonna take longer to recharge if you manage to convert a one of these people to balance the new power you gained through them
-			to_chat(missionary, "<span class='notice'>Through sheer willpower, you overcome their closed mind and rally [target] to your cause! You may need a bit longer than usual before your faith is fully recharged, and they won't remain loyal to you for long ...</span>")
-			convert_duration = 3000		//5 min, because the loyalty implant will attempt to counteract the subversion
-		else	//80% chance to fail
-			faith -= 75
-			to_chat(missionary, "<span class='warning'>Your faith is strong, but their mind remains closed to your ideals. Your resolve helps you retain a bit of faith though.</span>")
-			return
+		faith -= 75
+		to_chat(missionary, "<span class='warning'>Your faith is strong, but their mind remains closed to your ideals. Your resolve helps you retain a bit of faith though.</span>")
+		return
 	else if(target.mind.assigned_role == "Psychiatrist" || target.mind.assigned_role == "Librarian")		//fancy book lernin helps counter religion (day 0 job love, what madness!)
 		if(prob(35))	//35% chance to fail
 			to_chat(missionary, "<span class='warning'>This one is well trained in matters of the mind... They will not be swayed as easily as you thought...</span>")
@@ -620,8 +615,6 @@
 	//if you made it this far: congratulations! you are now a religious zealot!
 	target.mind.make_zealot(missionary, convert_duration, team_color)
 	zealots_made++
-
-	missionary.adjustBruteLoss(8 * zealots_made * pick(0.5,1,2))
 
 	target << sound('sound/misc/wololo.ogg', 0, 1, 25)
 	missionary.say("WOLOLO!")

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -519,8 +519,6 @@
 	var/obj/item/clothing/suit/hooded/chaplain_hoodie/missionary_robe/robes = null		//the robes linked with this staff
 	var/faith = 99	//a conversion requires 100 faith to attempt. faith recharges over time while you are wearing missionary robes that have been linked to the staff.
 
-	var/zealots_made = 0
-
 /obj/item/weapon/nullrod/missionary_staff/New()
 	team_color = pick("red", "blue")
 	icon_state = "godstaff-[team_color]"
@@ -615,7 +613,6 @@
 		faith -= 100
 	//if you made it this far: congratulations! you are now a religious zealot!
 	target.mind.make_zealot(missionary, convert_duration, team_color)
-	zealots_made++
 
 	target << sound('sound/misc/wololo.ogg', 0, 1, 25)
 	missionary.say("WOLOLO!")

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -570,6 +570,7 @@
 	if(!target.mind)	//no mind means no conversion, but also means no faith lost.
 		to_chat(missionary, "<span class='warning'>You halt the conversion as you realize [target] is mindless! Best to save your faith for someone more worthwhile.</span>")
 		return
+	to_chat(target, "<span class='userdanger'>Your mind seems foggy. For a moment, all you can think about is serving the greater good... the greater good...</span>")
 	if(do_after(missionary, 80))	//8 seconds to temporarily convert, roughly 3 seconds slower than a vamp's enthrall, but its a ranged thing
 		if(faith < 100)		//to stop people from trying to exploit the do_after system to multi-convert, we check again if you have enough faith when it completes
 			to_chat(missionary, "<span class='warning'>You don't have enough faith to complete the conversion on [target]!</span>")


### PR DESCRIPTION
This PR nerfs the missionary/wololo staff, by:
- Giving targets a warning when conversion starts ("Your mind seems foggy. For a moment, all you can think about is serving the greater good... the greater good...") rather than simply informing victims they were converted successfully after its too late for them to do anything about it.
- Changing the time it takes to convert, from 4 seconds (faster than vamp enthrall, despite this being a ranged and renewable ability) to 8 seconds (slower than vamp enthrall).
- Making the enthrall ability of the staff never work against mindshielded crew, rather than still work 20% of the time, without even removing the mindshield, as it does currently.

Currently, the staff is horribly overpowered, as it is a hard-to-counter, quick acting, ranged enthrall that can be repeated as many times as you like throughout a round, limited only by its recharge. Worse, it doesn't even notify you that you're being targeted by it until you're already enthralled by it. And you can be targeted with it anywhere the wielder can see, even potentially through doors or walls. These nerfs are aimed at making it more fair (you have a chance to escape it if you're paying attention) and less overpowered.

🆑 Kyep
tweak: Victims of the missionary/wololo staff are now warned when the staff starts being used on them, it takes 8 seconds to convert (rather than 4) and the staff no longer works on mindshielded crew.
/🆑