### PR TITLE
Adds Enforcer .45 crate to cargo.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -336,6 +336,17 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 
 /////// Weapons: Specialist
 
+/datum/supply_packs/security/armory/enforcer
+	name = "Enforcer .45 Crate"
+	contains = list(/obj/item/weapon/gun/projectile/automatic/pistol/enforcer,
+					/obj/item/weapon/gun/projectile/automatic/pistol/enforcer,
+					/obj/item/weapon/gun/projectile/automatic/pistol/enforcer,
+					/obj/item/ammo_box/magazine/m45/enforcer45,
+					/obj/item/ammo_box/magazine/m45/enforcer45,
+					/obj/item/ammo_box/magazine/m45/enforcer45)
+	cost = 45
+	containername = "enforcer .45 crate"
+
 /datum/supply_packs/security/armory/ballistic
 	name = "Riot Shotguns Crate"
 	contains = list(/obj/item/weapon/gun/projectile/shotgun/riot,

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -209,6 +209,7 @@
 	caliber = ".45"
 	max_ammo = 8
 	multiple_sprites = 1
+
 /obj/item/ammo_box/magazine/m45/enforcer45
 	name = "handgun magazine (.45)"
 	icon_state = "enforcer"


### PR DESCRIPTION
![discord_2017-09-10_23-39-25](https://user-images.githubusercontent.com/25027759/30253652-4a3190ac-9681-11e7-9e51-fb33f8af9b1d.png)

Adds enforcer .45 crate orderable through cargo for 45 points.

Contains three Enforcer .45 pistols and three spare magazines. Rubber bullets.

🆑 Birdtalon
add: Adds Enforcer .45 cargo crate for security at 45 points.
/🆑 