### PR TITLE
Flaming shot glass code cleanup

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/shotglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/shotglass.dm
@@ -1,5 +1,3 @@
-#define SHOT_FLAME_TEMPERATURE	700
-
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass
 	name = "shot glass"
 	desc = "No glasses were shot in the making of this glass."
@@ -79,7 +77,7 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass/attackby(obj/item/W)
 	..()
-	if(is_hot(W) >= 600)
+	if(is_hot(W))
 		fire_act()
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass/attack_hand(mob/user, pickupfireoverride = TRUE)


### PR DESCRIPTION
- Removes unused `SHOT_FLAME_TEMPERATURE` define (this was a remnant from when flaming shots were hot, I just forgot to remove this define)
- Removes temperature check on is_hot (this changes nothing in-game as everything that is hot exceeds 600K, the current level at which shots burst into flame)

No CL as this is entirely code tweaks.