### PR TITLE
Fixes Greys being harmed by inactive showers.

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -242,7 +242,8 @@
 	wash(O)
 	if(ismob(O))
 		mobpresent += 1
-		check_heat(O)
+		if(on)
+			check_heat(O)
 
 /obj/machinery/shower/Uncrossed(atom/movable/O)
 	if(ismob(O))


### PR DESCRIPTION
`check_heat()` will no longer be called when the shower is off.

Fixes #8082 

🆑 Birdtalon
fix: Greys are no longer harmed by ghostly water at inactive showers.
/🆑 