### PR TITLE
Fix for [field]s not populating on paper.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -279,9 +279,9 @@
 			addtofield(text2num(id), t) // He wants to edit a field, let him.
 		else
 			info += t // Oh, he wants to edit to the end of the file, let him.
-			updateinfolinks()
 
 		populatefields()
+		updateinfolinks()
 
 		i.on_write(src,usr)
 


### PR DESCRIPTION
Calls `updateinfolinks()` after `populatefields()`, instead of before.

:cl:
fix: Fixed fields not working on paper.
/:cl: