### PR TITLE
holodeck esword sound fix

### DIFF
--- a/code/game/machinery/computer/HolodeckControl.dm
+++ b/code/game/machinery/computer/HolodeckControl.dm
@@ -439,7 +439,7 @@
 	name = "Holographic Energy Sword"
 	desc = "This looks like a real energy sword!"
 	icon_state = "sword0"
-	hitsound = "sound/weapons/blade1.ogg"
+	hitsound = "swing_hit"
 	force = 3.0
 	throw_speed = 1
 	throw_range = 5
@@ -468,12 +468,14 @@
 	if(active)
 		force = 30
 		icon_state = "sword[item_color]"
+		hitsound = "sound/weapons/blade1.ogg"
 		w_class = WEIGHT_CLASS_BULKY
 		playsound(user, 'sound/weapons/saberon.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>[src] is now active.</span>")
 	else
 		force = 3
 		icon_state = "sword0"
+		hitsound = "swing_hit"
 		w_class = WEIGHT_CLASS_SMALL
 		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)
 		to_chat(user, "<span class='notice'>[src] can now be concealed.</span>")


### PR DESCRIPTION
Small oversight when turning on and off the holographic energy sword.

🆑 Jovaniph
fix: Proper hit sound when holographic energy sword is turned on or off.
/ 🆑 