### PR TITLE
Prevents bees form synthesising forbidden reagents

### DIFF
--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -71,8 +71,12 @@
 
 	var/datum/reagent/R = null
 	if(random_reagent)
-		R = pick(subtypesof(/datum/reagent))
-		R = chemical_reagents_list[initial(R.id)]
+		var/synthable = FALSE
+		while(!synthable)
+			R = pick(subtypesof(/datum/reagent))
+			if(R.can_synth)
+				R = chemical_reagents_list[initial(R.id)]
+				synthable = TRUE
 
 	queen_bee = new(src)
 	queen_bee.beehome = src
@@ -89,13 +93,12 @@
 		B.beehome = src
 		B.assign_reagent(R)
 
-
 /obj/structure/beebox/premade/random
 	random_reagent = TRUE
 
 
 /obj/structure/beebox/process()
-	if(queen_bee)
+	if(queen_bee && !queen_bee.beegent.can_synth)
 		if(bee_resources >= BEE_RESOURCE_HONEYCOMB_COST)
 			if(honeycombs.len < get_max_honeycomb())
 				bee_resources = max(bee_resources-BEE_RESOURCE_HONEYCOMB_COST, 0)
@@ -172,11 +175,13 @@
 
 		var/obj/item/queen_bee/qb = I
 		user.unEquip(qb)
-
-		qb.queen.forceMove(src)
-		bees += qb.queen
-		queen_bee = qb.queen
-		qb.queen = null
+		if(qb.queen.beegent.can_synth)
+			qb.queen.forceMove(src)
+			bees += qb.queen
+			queen_bee = qb.queen
+			qb.queen = null
+		else
+			visible_message("<span class='notice'>The [qb] refuses to settle down. Maybe it's something to do with its reagent?</span>")
 
 		if(queen_bee)
 			visible_message("<span class='notice'>[user] sets [qb] down inside the apiary, making it their new home.</span>")

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -71,12 +71,7 @@
 
 	var/datum/reagent/R = null
 	if(random_reagent)
-		var/synthable = FALSE
-		while(!synthable)
-			R = pick(subtypesof(/datum/reagent))
-			if(R.can_synth)
-				R = chemical_reagents_list[initial(R.id)]
-				synthable = TRUE
+		R = get_random_reagent_id()
 
 	queen_bee = new(src)
 	queen_bee.beehome = src

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -251,7 +251,7 @@
 			if(S.reagents.has_reagent("royal_bee_jelly",5))
 				S.reagents.remove_reagent("royal_bee_jelly", 5)
 				if(!queen.beegent.can_synth)
-					to_chat(user, "<span class='warning'>You inject [src] with the royal bee jelly. It's ineffecive! Maybe it's something to do with the [src] reagent.</span>")
+					to_chat(user, "<span class='warning'>You inject [src] with the royal bee jelly. It's ineffective! Maybe it's something to do with the [src] reagent.</span>")
 					return
 				var/obj/item/queen_bee/qb = new(get_turf(user))
 				qb.queen = new(qb)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -127,9 +127,6 @@
 		return 1
 	return 0
 
-
-
-
 //Botany Worker Bees
 /mob/living/simple_animal/hostile/poison/bees/worker
 	//Blank type define in case we need to give them special stuff later, plus organization (currently they are same as base type bee)
@@ -253,6 +250,9 @@
 		if(S.reagents.has_reagent("royal_bee_jelly")) //checked twice, because I really don't want royal bee jelly to be duped
 			if(S.reagents.has_reagent("royal_bee_jelly",5))
 				S.reagents.remove_reagent("royal_bee_jelly", 5)
+				if(!queen.beegent.can_synth)
+					to_chat(user, "<span class='warning'>You inject [src] with the royal bee jelly. It's ineffecive! Maybe it's something to do with the [src] reagent.</span>")
+					return
 				var/obj/item/queen_bee/qb = new(get_turf(user))
 				qb.queen = new(qb)
 				if(queen && queen.beegent)


### PR DESCRIPTION
A request.

Some reagents such as Adminordrazine are unable to be synthesised using an Odysseus for example with `can_synth = FALSE` it was brought to my attention that bees can be used to infinitely reproduce every reagent as they ignore this check.

- Prevents random spawn beeboxes from spawning with a forbidden reagent
- Prevents replicating bees with forbidden reagents using royal bee jelly.
- Queen bees wtih forbidden reagents placed into a hive will not take to it.
- If all else fails, if the hive has managed to get a queen with forbidden reagent (somehow) it won't produce honeycomb.

I think I've covered all eventualities here.

🆑 Birdtalon
fix: Bees can no longer reproduce un-synthable reagents.
/🆑