### PR TITLE
Chemist start with Chemistry bag

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -166,6 +166,9 @@
 	glasses = /obj/item/clothing/glasses/science
 	id = /obj/item/weapon/card/id/medical
 	pda = /obj/item/device/pda/chemist
+	backpack_contents = list(
+		/obj/item/weapon/storage/bag/chemistry = 1
+	)
 
 	backpack = /obj/item/weapon/storage/backpack/chemistry
 	satchel = /obj/item/weapon/storage/backpack/satchel_chem
@@ -315,4 +318,3 @@
 	satchel = /obj/item/weapon/storage/backpack/satchel_med
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/medical
 	box = /obj/item/weapon/storage/box/engineer
-


### PR DESCRIPTION
Because there is only two chemistry bags in the closet where every single doctor has access to grab one (including trespassers). This allow chemist who join in late to have a chemistry bag available to use to transport medicine with ease and without worry that they miss the opportunity to snatch a bag from the closet.

🆑 Jovaniph
add: Chemist now spawn with a chemistry bags.
/ 🆑 