### PR TITLE
Make Lobby first tab for new_player mobs

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -65,14 +65,6 @@
 	return
 
 /mob/new_player/Stat()
-	..()
-	if((!ticker) || ticker.current_state == GAME_STATE_PREGAME)
-		statpanel("Lobby") // First tab during pre-game.
-
-	statpanel("Status")
-	if(client.statpanel == "Status" && ticker)
-		if(ticker.current_state != GAME_STATE_PREGAME)
-			stat(null, "Station Time: [worldtime2text()]")
 	statpanel("Lobby")
 	if(client.statpanel=="Lobby" && ticker)
 		if(ticker.hide_mode)
@@ -100,6 +92,14 @@
 				totalPlayers++
 				if(player.ready)
 					totalPlayersReady++
+
+	..()
+
+	statpanel("Status")
+	if(client.statpanel == "Status" && ticker)
+		if(ticker.current_state != GAME_STATE_PREGAME)
+			stat(null, "Station Time: [worldtime2text()]")
+
 
 /mob/new_player/Topic(href, href_list[])
 	if(!client)	return 0


### PR DESCRIPTION
Simple little fix, ensures new_player mobs (people in the lobby) always get the `Lobby` tab first. 

![https://i.imgur.com/05dS7Cs.png](https://i.imgur.com/05dS7Cs.png)
![https://i.imgur.com/8CpbUlR.png](https://i.imgur.com/8CpbUlR.png)

:cl:
fix: People in the lobby see the lobby tab first again.
/:cl: