### PR TITLE
Admin Event Info

### DIFF
--- a/code/_globalvars/game_modes.dm
+++ b/code/_globalvars/game_modes.dm
@@ -5,3 +5,4 @@ var/wavesecret = 0 // meteor mode, delays wave progression, terrible name
 var/datum/station_state/start_state = null // Used in round-end report
 
 var/custom_event_msg = null
+var/custom_event_admin_msg = null

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -109,6 +109,7 @@ var/list/admin_verbs_event = list(
 	/client/proc/toggle_ert_calling,
 	/client/proc/cmd_admin_change_custom_event,
 	/client/proc/cmd_admin_custom_event_info,
+	/client/proc/cmd_view_custom_event_info,
 	/datum/admins/proc/access_news_network,	/*allows access of newscasters*/
 	/client/proc/cmd_admin_direct_narrate,	/*send text directly to a player with no padding. Useful for narratives and fluff-text*/
 	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -108,6 +108,7 @@ var/list/admin_verbs_event = list(
 	/client/proc/toggle_random_events,
 	/client/proc/toggle_ert_calling,
 	/client/proc/cmd_admin_change_custom_event,
+	/client/proc/cmd_admin_custom_event_info,
 	/datum/admins/proc/access_news_network,	/*allows access of newscasters*/
 	/client/proc/cmd_admin_direct_narrate,	/*send text directly to a player with no padding. Useful for narratives and fluff-text*/
 	/client/proc/cmd_admin_world_narrate,	/*sends text to all players with no padding*/

--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -45,7 +45,7 @@
 	set category = "Event"
 	set name = "Change Custom Admin Event Info"
 
-	if(check_rights(R_EVENT))
+	if(!check_rights(R_EVENT))
 		to_chat(src, "Only administrators may use this command.")
 		return
 
@@ -72,7 +72,7 @@
 	set category = "Event"
 	set name = "Custom Event Admin Info"
 
-	if(check_rights(R_EVENT))
+	if(!check_rights(R_EVENT))
 		to_chat(src, "Only administrators may use this command.")
 		return
 

--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -45,7 +45,7 @@
 	set category = "Event"
 	set name = "Change Custom Admin Event Info"
 
-	if(!holder && check_rights(R_EVENT))
+	if(check_rights(R_EVENT))
 		to_chat(src, "Only administrators may use this command.")
 		return
 
@@ -72,7 +72,7 @@
 	set category = "Event"
 	set name = "Custom Event Admin Info"
 
-	if(!holder && check_rights(R_EVENT))
+	if(check_rights(R_EVENT))
 		to_chat(src, "Only administrators may use this command.")
 		return
 

--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -38,3 +38,46 @@
 	to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
 	to_chat(src, "<span class='alert'>[html_encode(custom_event_msg)]</span>")
 	to_chat(src, "<br>")
+
+//admin event info to be view by admins
+
+/client/proc/cmd_admin_custom_event_info()
+	set category = "Event"
+	set name = "Change Custom Admin Event Info"
+
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.")
+		return
+
+	var/input = input(usr, "Enter the description of the custom event. This is informations for admins only. Use it to notify other admins of event info but not players.", "Custom Event Info", custom_event_msg) as message|null
+	if(!input || input == "")
+		custom_event_msg = null
+		log_admin("[key_name(usr)] has cleared the custom admin event info text.")
+		message_admins("[key_name_admin(usr)] has cleared the custom admin event text.")
+		return
+
+	log_admin("[key_name(usr)] has changed the custom admin event info text.")
+	message_admins("[key_name_admin(usr)] has changed the custom admin event info text.")
+
+	custom_event_msg = input
+
+	for(var/client/X in admins)
+		if(check_rights(R_EVENT,0,X.mob))
+			to_chat(X, "<h1 class='alert'>Custom Admin Event Info</h1>")
+			to_chat(X, "<h2 class='alert'>A custom event is starting. OOC Admin Info:</h2>")
+			to_chat(X, "<span class='alert'>[html_encode(custom_event_msg)]</span>")
+			to_chat(X,"<br>")
+
+/client/verb/cmd_view_custom_event_info()
+	set category = "Event"
+	set name = "Custom Event Admin Info"
+
+	if(!custom_event_msg || custom_event_msg == "")
+		to_chat(src, "There currently is no known custom admin event taking place.")
+		to_chat(src, "Keep in mind: it is possible that an admin has not properly set this.")
+		return
+
+	to_chat(src, "<h1 class='alert'>Custom Event Info</h1>")
+	to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
+	to_chat(src, "<span class='alert'>[html_encode(custom_event_msg)]</span>")
+	to_chat(src, "<br>")

--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -45,7 +45,7 @@
 	set category = "Event"
 	set name = "Change Custom Admin Event Info"
 
-	if(!holder)
+	if(!holder && check_rights(R_EVENT))
 		to_chat(src, "Only administrators may use this command.")
 		return
 
@@ -72,7 +72,7 @@
 	set category = "Event"
 	set name = "Custom Event Admin Info"
 
-	if(!holder)
+	if(!holder && check_rights(R_EVENT))
 		to_chat(src, "Only administrators may use this command.")
 		return
 

--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -51,7 +51,7 @@
 
 	var/input = input(usr, "Enter the description of the custom event. This is informations for admins only. Use it to notify other admins of event info but not players.", "Custom Event Info", custom_event_msg) as message|null
 	if(!input || input == "")
-		custom_event_msg = null
+		custom_event_admin_msg = null
 		log_admin("[key_name(usr)] has cleared the custom admin event info text.")
 		message_admins("[key_name_admin(usr)] has cleared the custom admin event text.")
 		return
@@ -59,25 +59,28 @@
 	log_admin("[key_name(usr)] has changed the custom admin event info text.")
 	message_admins("[key_name_admin(usr)] has changed the custom admin event info text.")
 
-	custom_event_msg = input
+	custom_event_admin_msg = input
 
 	for(var/client/X in admins)
 		if(check_rights(R_EVENT,0,X.mob))
 			to_chat(X, "<h1 class='alert'>Custom Admin Event Info</h1>")
 			to_chat(X, "<h2 class='alert'>A custom event is starting. OOC Admin Info:</h2>")
-			to_chat(X, "<span class='alert'>[html_encode(custom_event_msg)]</span>")
+			to_chat(X, "<span class='alert'>[html_encode(custom_event_admin_msg)]</span>")
 			to_chat(X,"<br>")
 
-/client/verb/cmd_view_custom_event_info()
+/client/proc/cmd_view_custom_event_info()
 	set category = "Event"
 	set name = "Custom Event Admin Info"
 
-	if(!custom_event_msg || custom_event_msg == "")
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.")
+		return
+
+	if(!custom_event_admin_msg || custom_event_admin_msg == "")
 		to_chat(src, "There currently is no known custom admin event taking place.")
-		to_chat(src, "Keep in mind: it is possible that an admin has not properly set this.")
 		return
 
 	to_chat(src, "<h1 class='alert'>Custom Event Info</h1>")
 	to_chat(src, "<h2 class='alert'>A custom event is taking place. OOC Info:</h2>")
-	to_chat(src, "<span class='alert'>[html_encode(custom_event_msg)]</span>")
+	to_chat(src, "<span class='alert'>[html_encode(custom_event_admin_msg)]</span>")
 	to_chat(src, "<br>")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -436,6 +436,8 @@
 		on_holder_add()
 		add_admin_verbs()
 		admin_memo_output("Show", 0, 1)
+		if(custom_event_admin_msg && custom_event_admin_msg != "")
+			cmd_view_custom_event_info()
 
 	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
 	// (but turn them off first, since sometimes BYOND doesn't turn them on properly otherwise)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -436,7 +436,7 @@
 		on_holder_add()
 		add_admin_verbs()
 		admin_memo_output("Show", 0, 1)
-		if(custom_event_admin_msg && custom_event_admin_msg != "")
+		if(custom_event_admin_msg && custom_event_admin_msg != "" && check_rights(R_EVENT))
 			cmd_view_custom_event_info()
 
 	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.


### PR DESCRIPTION
I may need to reword alot of stuff, but i suck at words. This was a request.

The gist of it, we all know admins can set OOC custom event info telling the players an event is starting, Such as 'A virus is about to hit the crew"

What this does is add two new verbs  Change Custom Admin Event Info and Custom Event Admin Info
 
This event info is admin view only, so while the players know a virus is about to hit the crew..you can let your admin buddys know 'I am about to turn the crew slowly into cluwnes'

While yes we have Asay this does save on retyping long bits of info if another admin were to log on. you don't even need to set a custom event for player first, you can use the admin verion to let the team know what evil plans you have for the crew.

and the players will be none the wiser.

This is an admin tool and won't need a changelog...I THINK.
