### PR TITLE
Silver Slime Core and Random Reagent changes

### DIFF
--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -17,7 +17,7 @@ var/list/standard_chemicals = list("slimejelly","blood","water","lube","charcoal
 								"lipolicide","condensedcapsaicin","frostoil","amanitin","psilocybin",
 								"enzyme","nothing","salglu_solution","antifreeze","neurotoxin")
 // Rare chemicals
-var/list/rare_chemicals = list("minttoxin","nanites","xenomicrobes","adminordrazine")
+var/list/rare_chemicals = list("minttoxin","syndicate_nanites")
 // Standard medicines
 var/list/standard_medicines = list("charcoal","toxin","cyanide","morphine","epinephrine","space_drugs",
 								"serotrotium","mutadone","mutagen","teporone","lexorin","silver_sulfadiazine",
@@ -27,7 +27,7 @@ var/list/standard_medicines = list("charcoal","toxin","cyanide","morphine","epin
 								"diethylamine","antihol","pancuronium","lipolicide","condensedcapsaicin",
 								"frostoil","amanitin","psilocybin","nothing","salglu_solution","neurotoxin")
 // Rare medicines
-var/list/rare_medicines = list("nanites","xenomicrobes","minttoxin","adminordrazine","blood")
+var/list/rare_medicines = list("syndicate_nanites","minttoxin","blood")
 // Drinks
 var/list/drinks = list("beer2","hot_coco","orangejuice","tomatojuice","limejuice","carrotjuice",
 					"berryjuice","poisonberryjuice","watermelonjuice","lemonjuice","banana",
@@ -55,7 +55,7 @@ var/global/list/blocked_chems = list("polonium", "initropidril", "concentrated_i
 							"syndicate_nanites", "ripping_tendrils", "boiling_oil",
 							"envenomed_filaments", "lexorin_jelly", "kinetic",
 							"cryogenic_liquid", "dark_matter", "b_sorium",
-							"reagent", "life","dragonsbreath")
+							"reagent", "life","dragonsbreath", "xenomicrobes")
 
 var/global/list/safe_chem_list = list("antihol", "charcoal", "epinephrine", "insulin", "teporone","silver_sulfadiazine", "salbutamol",
 									  "omnizine", "stimulants", "synaptizine", "potass_iodide", "oculine", "mannitol", "styptic_powder",

--- a/code/_globalvars/lists/reagents.dm
+++ b/code/_globalvars/lists/reagents.dm
@@ -17,7 +17,7 @@ var/list/standard_chemicals = list("slimejelly","blood","water","lube","charcoal
 								"lipolicide","condensedcapsaicin","frostoil","amanitin","psilocybin",
 								"enzyme","nothing","salglu_solution","antifreeze","neurotoxin")
 // Rare chemicals
-var/list/rare_chemicals = list("minttoxin","syndicate_nanites")
+var/list/rare_chemicals = list("minttoxin","syndicate_nanites", "xenomicrobes")
 // Standard medicines
 var/list/standard_medicines = list("charcoal","toxin","cyanide","morphine","epinephrine","space_drugs",
 								"serotrotium","mutadone","mutagen","teporone","lexorin","silver_sulfadiazine",
@@ -27,7 +27,7 @@ var/list/standard_medicines = list("charcoal","toxin","cyanide","morphine","epin
 								"diethylamine","antihol","pancuronium","lipolicide","condensedcapsaicin",
 								"frostoil","amanitin","psilocybin","nothing","salglu_solution","neurotoxin")
 // Rare medicines
-var/list/rare_medicines = list("syndicate_nanites","minttoxin","blood")
+var/list/rare_medicines = list("syndicate_nanites","minttoxin","blood", "xenomicrobes")
 // Drinks
 var/list/drinks = list("beer2","hot_coco","orangejuice","tomatojuice","limejuice","carrotjuice",
 					"berryjuice","poisonberryjuice","watermelonjuice","lemonjuice","banana",
@@ -55,7 +55,7 @@ var/global/list/blocked_chems = list("polonium", "initropidril", "concentrated_i
 							"syndicate_nanites", "ripping_tendrils", "boiling_oil",
 							"envenomed_filaments", "lexorin_jelly", "kinetic",
 							"cryogenic_liquid", "dark_matter", "b_sorium",
-							"reagent", "life","dragonsbreath", "xenomicrobes")
+							"reagent", "life","dragonsbreath")
 
 var/global/list/safe_chem_list = list("antihol", "charcoal", "epinephrine", "insulin", "teporone","silver_sulfadiazine", "salbutamol",
 									  "omnizine", "stimulants", "synaptizine", "potass_iodide", "oculine", "mannitol", "styptic_powder",

--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -3,13 +3,14 @@
 // -------------------------------------
 /obj/item/toy/random
 	name = "Random Toy"
-	New()
-		..()
-		var/list/types = list(/obj/item/weapon/gun/projectile/shotgun/toy/crossbow, /obj/item/toy/balloon,/obj/item/toy/spinningtoy,/obj/item/weapon/reagent_containers/spray/waterflower) + subtypesof(/obj/item/toy/prize)
-		var/T = pick(types)
-		new T(loc)
-		spawn(1)
-			qdel(src)
+
+/obj/item/toy/random/New()
+	..()
+	var/list/types = list(/obj/item/weapon/gun/projectile/shotgun/toy/crossbow, /obj/item/toy/balloon,/obj/item/toy/spinningtoy,/obj/item/weapon/reagent_containers/spray/waterflower) + subtypesof(/obj/item/toy/prize)
+	var/T = pick(types)
+	new T(loc)
+	spawn(1)
+		qdel(src)
 
 // -------------------------------------
 //	Random cleanables, clearly this makes sense
@@ -17,24 +18,26 @@
 
 /obj/effect/decal/cleanable/random
 	name = "Random Mess"
-	New()
-		..()
-		var/list/list = subtypesof(/obj/effect/decal/cleanable) - list(/obj/effect/decal/cleanable/random,/obj/effect/decal/cleanable/cobweb,/obj/effect/decal/cleanable/cobweb2)
-		var/T = pick(list)
-		new T(loc)
-		spawn(0)
-			qdel(src)
+
+/obj/effect/decal/cleanable/random/New()
+	..()
+	var/list/list = subtypesof(/obj/effect/decal/cleanable) - list(/obj/effect/decal/cleanable/random,/obj/effect/decal/cleanable/cobweb,/obj/effect/decal/cleanable/cobweb2)
+	var/T = pick(list)
+	new T(loc)
+	spawn(0)
+		qdel(src)
 
 
 /obj/item/stack/sheet/animalhide/random
 	name = "random animal hide"
-	New()
-		..()
-		spawn(1)
-			var/htype = pick(/obj/item/stack/sheet/animalhide/cat,/obj/item/stack/sheet/animalhide/corgi,/obj/item/stack/sheet/animalhide/human,/obj/item/stack/sheet/animalhide/lizard,/obj/item/stack/sheet/animalhide/monkey)
-			var/obj/item/stack/S = new htype(loc)
-			S.amount = amount
-			qdel(src)
+
+/obj/item/stack/sheet/animalhide/random/New()
+	..()
+	spawn(1)
+		var/htype = pick(/obj/item/stack/sheet/animalhide/cat,/obj/item/stack/sheet/animalhide/corgi,/obj/item/stack/sheet/animalhide/human,/obj/item/stack/sheet/animalhide/lizard,/obj/item/stack/sheet/animalhide/monkey)
+		var/obj/item/stack/S = new htype(loc)
+		S.amount = amount
+		qdel(src)
 
 // -------------------------------------
 //    Not yet identified chemical.
@@ -43,103 +46,108 @@
 
 /obj/item/weapon/reagent_containers/glass/bottle/random_reagent
 	name = "unlabelled bottle"
-//	identify_probability = 0
-	New()
-		..()
-		var/datum/reagent/R = pick(chemical_reagents_list)
-		if(rare_chemicals.Find(R))
-			reagents.add_reagent(R,10)
-		else
-			reagents.add_reagent(R,rand(2,3)*10)
-		pixel_x = rand(-10,10)
-		pixel_y = rand(-10,10)
+	//	identify_probability = 0
+
+/obj/item/weapon/reagent_containers/glass/bottle/random_reagent/New()
+	..()
+	var/list/possible_chems = chemical_reagents_list.Copy()
+	possible_chems -= blocked_chems.Copy()
+	var/datum/reagent/R = pick(possible_chems)
+	if(rare_chemicals.Find(R))
+		reagents.add_reagent(R, 10)
+	else
+		reagents.add_reagent(R, rand(2, 3)*10)
+	pixel_x = rand(-10, 10)
+	pixel_y = rand(-10, 10)
 
 //Cuts out the food and drink reagents
 /obj/item/weapon/reagent_containers/glass/bottle/random_chem
 	name = "unlabelled chemical bottle"
-//	identify_probability = 0
-	New()
-		..()
+	//	identify_probability = 0
 
-		var/datum/reagent/R = pick(standard_chemicals + rare_chemicals)
-		if(rare_chemicals.Find(R))
-			reagents.add_reagent(R,10)
-		else
-			reagents.add_reagent(R,rand(2,3)*10)
-		name = "unlabelled bottle"
-		pixel_x = rand(-10,10)
-		pixel_y = rand(-10,10)
+/obj/item/weapon/reagent_containers/glass/bottle/random_chem/New()
+	..()
+	var/R = get_random_reagent_id()
+	if(rare_chemicals.Find(R))
+		reagents.add_reagent(R, 10)
+	else
+		reagents.add_reagent(R, rand(2, 3)*10)
+	name = "unlabelled bottle"
+	pixel_x = rand(-10, 10)
+	pixel_y = rand(-10, 10)
 
 /obj/item/weapon/reagent_containers/glass/bottle/random_base_chem
 	name = "unlabelled chemical bottle"
-//	identify_probability = 0
-	New()
-		..()
-		var/datum/reagent/R = pick(base_chemicals)
-		reagents.add_reagent(R,rand(2,6)*5)
-		name = "unlabelled bottle"
-		pixel_x = rand(-10,10)
-		pixel_y = rand(-10,10)
+	//	identify_probability = 0
+
+/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem/New()
+	..()
+	var/datum/reagent/R = pick(base_chemicals)
+	reagents.add_reagent(R, rand(2, 6)*5)
+	name = "unlabelled bottle"
+	pixel_x = rand(-10, 10)
+	pixel_y = rand(-10, 10)
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink
 	name = "unlabelled drink"
 	icon = 'icons/obj/drinks.dmi'
-	New()
-		..()
-		var/list/additional_drinks = list()
-		if(prob(50))
-			additional_drinks += list("pancuronium","lsd","omnizine","blood")
 
-		var/datum/reagent/R = pick(drinks + additional_drinks)
-		reagents.add_reagent(R,volume)
-		name = "unlabelled bottle"
-		icon_state = pick("alco-white","alco-green","alco-blue","alco-clear","alco-red")
-		pixel_x = rand(-5,5)
-		pixel_y = rand(-5,5)
+/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink/New()
+	..()
+	var/list/possible_drinks = drinks.Copy()
+	if(prob(50))
+		possible_drinks += list("pancuronium","lsd","omnizine","blood")
+
+	var/datum/reagent/R = pick(possible_drinks)
+	reagents.add_reagent(R, volume)
+	name = "unlabelled bottle"
+	icon_state = pick("alco-white","alco-green","alco-blue","alco-clear","alco-red")
+	pixel_x = rand(-5, 5)
+	pixel_y = rand(-5, 5)
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/random_reagent // Same as the chembottle code except the container
 	name = "unlabelled drink?"
 	icon = 'icons/obj/drinks.dmi'
-	New()
-		..()
-		var/datum/reagent/R = pick(chemical_reagents_list)
-		if(rare_chemicals.Find(R))
-			reagents.add_reagent(R,10)
-		else
-			reagents.add_reagent(R,rand(3,10)*10)
-		name = "unlabelled bottle"
-		icon_state = pick("alco-white","alco-green","alco-blue","alco-clear","alco-red")
-		pixel_x = rand(-5,5)
-		pixel_y = rand(-5,5)
-		spawn(0)
-			qdel(src)
+
+/obj/item/weapon/reagent_containers/food/drinks/bottle/random_reagent/New()
+	..()
+
+	var/R = get_random_reagent_id()
+	if(rare_chemicals.Find(R))
+		reagents.add_reagent(R, 10)
+	else
+		reagents.add_reagent(R, rand(3, 10)*10)
+	name = "unlabelled bottle"
+	icon_state = pick("alco-white","alco-green","alco-blue","alco-clear","alco-red")
+	pixel_x = rand(-5, 5)
+	pixel_y = rand(-5, 5)
+	spawn(0)
+		qdel(src)
 
 /obj/item/weapon/storage/pill_bottle/random_meds
 	name = "unlabelled pillbottle"
 	desc = "The sheer recklessness of this bottle's existence astounds you."
 
-	New()
-		..()
-		var/i = 1
-		while(i < storage_slots)
+/obj/item/weapon/storage/pill_bottle/random_meds/New()
+	..()
+	var/i = 1
+	while(i < storage_slots)
+		var/list/possible_medicines = standard_medicines.Copy()
+		if(prob(50))
+			possible_medicines += rare_medicines.Copy()
+		var/datum/reagent/R = pick(possible_medicines)
+		var/obj/item/weapon/reagent_containers/food/pill/P = new(src)
 
-			var/datum/reagent/R
-			if(prob(50))
-				R = pick(standard_medicines + rare_medicines)
-			else
-				R = pick(standard_medicines)
-			var/obj/item/weapon/reagent_containers/food/pill/P = new(src)
+		if(rare_medicines.Find(R))
+			P.reagents.add_reagent(R, 10)
+		else
+			P.reagents.add_reagent(R, rand(2, 5)*10)
+		P.name = "Unlabelled Pill"
+		P.desc = "Something about this pill entices you to try it, against your better judgement."
+		i++
+	pixel_x = rand(-10, 10)
+	pixel_y = rand(-10, 10)
 
-			if(rare_medicines.Find(R))
-				P.reagents.add_reagent(R,10)
-			else
-				P.reagents.add_reagent(R,rand(2,5)*10)
-			P.name = "Unlabelled Pill"
-			P.desc = "Something about this pill entices you to try it, against your better judgement."
-			i++
-		pixel_x = rand(-10,10)
-		pixel_y = rand(-10,10)
-		return
 
 // -------------------------------------
 //    Containers full of unknown crap
@@ -150,43 +158,43 @@
 	desc = "Crate full of chemicals of unknown type and value from a 'trusted' source."
 	req_one_access = list(access_chemistry,access_research,access_qm) // the qm knows a guy, you see.
 
-	New()
-		..()
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_chem(src)
-		new/obj/item/weapon/reagent_containers/glass/bottle/random_chem(src)
-		while(prob(50))
-			new/obj/item/weapon/reagent_containers/glass/bottle/random_reagent(src)
+/obj/structure/closet/crate/secure/unknownchemicals/New()
+	..()
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_base_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_chem(src)
+	new/obj/item/weapon/reagent_containers/glass/bottle/random_chem(src)
+	while(prob(50))
+		new/obj/item/weapon/reagent_containers/glass/bottle/random_reagent(src)
 
+	new/obj/item/weapon/storage/pill_bottle/random_meds(src)
+	while(prob(25))
 		new/obj/item/weapon/storage/pill_bottle/random_meds(src)
-		while(prob(25))
-			new/obj/item/weapon/storage/pill_bottle/random_meds(src)
 
 /obj/structure/closet/crate/secure/chemicals
-	name		= "chemical supply kit"
-	desc		= "Full of basic chemistry supplies."
-	req_one_access	= list(access_chemistry,access_research)
+	name = "chemical supply kit"
+	desc = "Full of basic chemistry supplies."
+	req_one_access = list(access_chemistry,access_research)
 
-	New()
-		..()
-		for(var/chem in standard_chemicals)
-			var/obj/item/weapon/reagent_containers/glass/bottle/B = new(src)
-			B.reagents.add_reagent(chem,B.volume)
-			if(prob(85))
-				var/datum/reagent/r = chemical_reagents_list[chem]
-				B.name	= "[r.name] bottle"
-//				B.identify_probability = 100
-			else
-				B.name	= "unlabelled bottle"
-				B.desc	= "Looks like the label fell off."
-//				B.identify_probability = 0
+/obj/structure/closet/crate/secure/chemicals/New()
+	..()
+	for(var/chem in standard_chemicals)
+		var/obj/item/weapon/reagent_containers/glass/bottle/B = new(src)
+		B.reagents.add_reagent(chem, B.volume)
+		if(prob(85))
+			var/datum/reagent/r = chemical_reagents_list[chem]
+			B.name	= "[r.name] bottle"
+//			B.identify_probability = 100
+		else
+			B.name	= "unlabelled bottle"
+			B.desc	= "Looks like the label fell off."
+//			B.identify_probability = 0
 
 /*
 /obj/structure/closet/crate/bin/flowers
@@ -235,15 +243,15 @@
 	icon_broken = "cabinetdetective_broken"
 	icon_off = "cabinetdetective_broken"
 
-	New()
-		..()
-		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
-		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
-		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
-		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
-		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
-		while(prob(25))
-			new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_reagent(src)
+/obj/structure/closet/secure_closet/random_drinks/New()
+	..()
+	new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
+	new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
+	new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
+	new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
+	new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_drink(src)
+	while(prob(25))
+		new/obj/item/weapon/reagent_containers/food/drinks/bottle/random_reagent(src)
 
 
 // -------------------------------------
@@ -257,23 +265,23 @@
 	name = "\improper Mysterious Crate"
 	desc = "What could it be?"
 
-	attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-		if(istype(W, /obj/item/weapon/crowbar))
-			var/list/menace = pick(	/mob/living/simple_animal/hostile/carp,/mob/living/simple_animal/hostile/faithless,/mob/living/simple_animal/hostile/pirate,
-									/mob/living/simple_animal/hostile/creature,/mob/living/simple_animal/hostile/pirate/ranged,
-									/mob/living/simple_animal/hostile/hivebot,/mob/living/simple_animal/hostile/viscerator,/mob/living/simple_animal/hostile/pirate)
+/obj/structure/largecrate/evil/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/weapon/crowbar))
+		var/list/menace = pick(	/mob/living/simple_animal/hostile/carp,/mob/living/simple_animal/hostile/faithless,/mob/living/simple_animal/hostile/pirate,
+								/mob/living/simple_animal/hostile/creature,/mob/living/simple_animal/hostile/pirate/ranged,
+								/mob/living/simple_animal/hostile/hivebot,/mob/living/simple_animal/hostile/viscerator,/mob/living/simple_animal/hostile/pirate)
 
-			visible_message("<span class='warning'>Something falls out of the [src]!</span>")
-			var/obj/item/weapon/grenade/clusterbuster/C = new(src.loc)
-			C.prime()
-			spawn(10)
-				new menace(src.loc)
-				while(prob(15))
-					new menace(get_step_rand(src.loc))
-				..()
-			return 1
-		else
-			return ..()
+		visible_message("<span class='warning'>Something falls out of the [src]!</span>")
+		var/obj/item/weapon/grenade/clusterbuster/C = new(src.loc)
+		C.prime()
+		spawn(10)
+			new menace(src.loc)
+			while(prob(15))
+				new menace(get_step_rand(src.loc))
+			..()
+		return 1
+	else
+		return ..()
 
 
 //
@@ -288,22 +296,22 @@
 	name = "Schrodinger's Crate"
 	desc = "What happens if you open it?"
 
-	attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-		if(istype(W, /obj/item/weapon/crowbar))
-			var/mob/living/simple_animal/pet/cat/Cat1 = new(loc)
-			Cat1.apply_damage(250)//,TOX)
-			Cat1.name = "Schrodinger's Cat"
-			Cat1.desc = "It seems it's been dead for a while."
+/obj/structure/largecrate/schrodinger/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/weapon/crowbar))
+		var/mob/living/simple_animal/pet/cat/Cat1 = new(loc)
+		Cat1.apply_damage(250)//,TOX)
+		Cat1.name = "Schrodinger's Cat"
+		Cat1.desc = "It seems it's been dead for a while."
 
-			var/mob/living/simple_animal/pet/cat/Cat2 = new(loc)
-			Cat2.name = "Schrodinger's Cat"
-			Cat2.desc = "It's was alive the whole time!"
-			sleep(2)
-			if(prob(50))
-				qdel(Cat1)
-			else
-				qdel(Cat2)
-		return ..()
+		var/mob/living/simple_animal/pet/cat/Cat2 = new(loc)
+		Cat2.name = "Schrodinger's Cat"
+		Cat2.desc = "It's was alive the whole time!"
+		sleep(2)
+		if(prob(50))
+			qdel(Cat1)
+		else
+			qdel(Cat2)
+	return ..()
 
 // --------------------------------------
 //   Collen's box of wonder and mystery
@@ -318,18 +326,18 @@
 	/obj/item/weapon/grenade/chem_grenade/dirt, /obj/item/weapon/grenade/chem_grenade/lube, /obj/item/weapon/grenade/smokebomb,
 	/obj/item/weapon/grenade/chem_grenade/drugs, /obj/item/weapon/grenade/chem_grenade/ethanol) // holy list batman
 
-	New()
-		..()
-		var/nade1 = pick(grenadelist)
-		var/nade2 = pick(grenadelist)
-		var/nade3 = pick(grenadelist)
-		var/nade4 = pick(grenadelist)
-		var/nade5 = pick(grenadelist)
-		var/nade6 = pick(grenadelist)
+/obj/item/weapon/storage/box/grenades/New()
+	..()
+	var/nade1 = pick(grenadelist)
+	var/nade2 = pick(grenadelist)
+	var/nade3 = pick(grenadelist)
+	var/nade4 = pick(grenadelist)
+	var/nade5 = pick(grenadelist)
+	var/nade6 = pick(grenadelist)
 
-		new nade1(src)
-		new nade2(src)
-		new nade3(src)
-		new nade4(src)
-		new nade5(src)
-		new nade6(src)
+	new nade1(src)
+	new nade2(src)
+	new nade3(src)
+	new nade4(src)
+	new nade5(src)
+	new nade6(src)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -22,8 +22,8 @@
 		var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
 							"atrazine","banana","charcoal","space_drugs","methamphetamine","holywater","ethanol","hot_coco","facid",
 							"blood","morphine","ether","fluorine","mutadone","mutagen","hydrocodone","fuel",
-							"haloperidol","lsd","nanites","lipolicide","frostoil","salglu_solution","beepskysmash",
-							"omnizine", "amanitin", "adminordrazine", "neurotoxin", "synaptizine")
+							"haloperidol","lsd","syndicate_nanites","lipolicide","frostoil","salglu_solution","beepskysmash",
+							"omnizine", "amanitin", "neurotoxin", "synaptizine")
 		var/datum/reagents/R = new/datum/reagents(50)
 		R.my_atom = vent
 		R.add_reagent(pick(gunk), 50)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -19,19 +19,14 @@
 	if(activeFor % interval == 0)
 		var/obj/vent = pick_n_take(vents)
 
-		var/list/common_gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
+		var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
 							"atrazine","banana","charcoal","space_drugs","methamphetamine","holywater","ethanol","hot_coco","facid",
 							"blood","morphine","ether","fluorine","mutadone","mutagen","hydrocodone","fuel",
-							"haloperidol","lsd","lipolicide","frostoil","salglu_solution","beepskysmash",
-							"amanitin", "neurotoxin", "synaptizine")
-		var/list/uncommon_gunk = list("omnizine", "syndicate_nanites", "xenomicrobes", "nanomachines", "minttoxin", "unholywater", "blackpowder",
-									"mugwort", "ectoplasm", "love", "carpet", "hair_dye", "super_hairgrownium", "colorful_reagent")
+							"haloperidol","lsd","nanites","lipolicide","frostoil","salglu_solution","beepskysmash",
+							"omnizine", "amanitin", "adminordrazine", "neurotoxin", "synaptizine")
 		var/datum/reagents/R = new/datum/reagents(50)
 		R.my_atom = vent
-		if(prob(20))
-			R.add_reagent(pick(uncommon_gunk), rand(5, 25))
-		else
-			R.add_reagent(pick(common_gunk), 50)
+		R.add_reagent(pick(gunk), 50)
 
 		var/datum/effect/system/chem_smoke_spread/smoke = new
 		smoke.set_up(R, rand(1, 2), 0, vent, 0, silent = 1)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -19,14 +19,19 @@
 	if(activeFor % interval == 0)
 		var/obj/vent = pick_n_take(vents)
 
-		var/list/gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
+		var/list/common_gunk = list("water","carbon","flour","radium","toxin","cleaner","nutriment","condensedcapsaicin","psilocybin","lube",
 							"atrazine","banana","charcoal","space_drugs","methamphetamine","holywater","ethanol","hot_coco","facid",
 							"blood","morphine","ether","fluorine","mutadone","mutagen","hydrocodone","fuel",
-							"haloperidol","lsd","nanites","lipolicide","frostoil","salglu_solution","beepskysmash",
-							"omnizine", "amanitin", "adminordrazine", "neurotoxin", "synaptizine")
+							"haloperidol","lsd","lipolicide","frostoil","salglu_solution","beepskysmash",
+							"amanitin", "neurotoxin", "synaptizine")
+		var/list/uncommon_gunk = list("omnizine", "syndicate_nanites", "xenomicrobes", "nanomachines", "minttoxin", "unholywater", "blackpowder",
+									"mugwort", "ectoplasm", "love", "carpet", "hair_dye", "super_hairgrownium", "colorful_reagent")
 		var/datum/reagents/R = new/datum/reagents(50)
 		R.my_atom = vent
-		R.add_reagent(pick(gunk), 50)
+		if(prob(20))
+			R.add_reagent(pick(uncommon_gunk), rand(5, 25))
+		else
+			R.add_reagent(pick(common_gunk), 50)
 
 		var/datum/effect/system/chem_smoke_spread/smoke = new
 		smoke.set_up(R, rand(1, 2), 0, vent, 0, silent = 1)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -555,6 +555,11 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 1)
 
+/obj/item/weapon/reagent_containers/food/snacks/xenomeat/New()
+	..()
+	if(prob(10))	//not every piece will have microbes, so you'll need to put in some actual effort to get large amounts of xenomicrobes
+		reagents.add_reagent("xenomicrobes", 0.5)
+
 /obj/item/weapon/reagent_containers/food/snacks/spidermeat
 	name = "spider meat"
 	desc = "A slab of spider meat."
@@ -706,6 +711,12 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
+/obj/item/weapon/reagent_containers/food/snacks/xenoburger/New()
+	..()
+	spawn(1)
+		if(reagents.has_reagent("xenomicrobes"))
+			reagents.add_reagent("xenomicrobes", reagents.get_reagent_amount("xenomicrobes"))	//doubles the xenomicrobes from ingredients if present
+
 /obj/item/weapon/reagent_containers/food/snacks/clownburger
 	name = "Clown Burger"
 	desc = "This tastes funny..."
@@ -849,6 +860,12 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#43DE18"
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+
+/obj/item/weapon/reagent_containers/food/snacks/xemeatpie/New()
+	..()
+	spawn(1)
+		if(reagents.has_reagent("xenomicrobes"))
+			reagents.add_reagent("xenomicrobes", reagents.get_reagent_amount("xenomicrobes"))	//doubles the microbes from ingredients if present
 
 /obj/item/weapon/reagent_containers/food/snacks/wingfangchu
 	name = "Wing Fang Chu"
@@ -1644,6 +1661,12 @@
 	slices_num = 5
 	filling_color = "#8AFF75"
 	list_reagents = list("protein" = 20, "nutriment" = 10, "vitamin" = 5)
+
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/xenomeatbread/New()
+	..()
+	spawn(1)
+		if(reagents.has_reagent("xenomicrobes"))
+			reagents.add_reagent("xenomicrobes", reagents.get_reagent_amount("xenomicrobes"))	//doubles the microbes from ingredients if present
 
 /obj/item/weapon/reagent_containers/food/snacks/xenomeatbreadslice
 	name = "xenomeatbread slice"

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -555,11 +555,6 @@
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 1)
 
-/obj/item/weapon/reagent_containers/food/snacks/xenomeat/New()
-	..()
-	if(prob(10))	//not every piece will have microbes, so you'll need to put in some actual effort to get large amounts of xenomicrobes
-		reagents.add_reagent("xenomicrobes", 0.5)
-
 /obj/item/weapon/reagent_containers/food/snacks/spidermeat
 	name = "spider meat"
 	desc = "A slab of spider meat."
@@ -711,12 +706,6 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
-/obj/item/weapon/reagent_containers/food/snacks/xenoburger/New()
-	..()
-	spawn(1)
-		if(reagents.has_reagent("xenomicrobes"))
-			reagents.add_reagent("xenomicrobes", reagents.get_reagent_amount("xenomicrobes"))	//doubles the xenomicrobes from ingredients if present
-
 /obj/item/weapon/reagent_containers/food/snacks/clownburger
 	name = "Clown Burger"
 	desc = "This tastes funny..."
@@ -860,12 +849,6 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#43DE18"
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
-
-/obj/item/weapon/reagent_containers/food/snacks/xemeatpie/New()
-	..()
-	spawn(1)
-		if(reagents.has_reagent("xenomicrobes"))
-			reagents.add_reagent("xenomicrobes", reagents.get_reagent_amount("xenomicrobes"))	//doubles the microbes from ingredients if present
 
 /obj/item/weapon/reagent_containers/food/snacks/wingfangchu
 	name = "Wing Fang Chu"
@@ -1661,12 +1644,6 @@
 	slices_num = 5
 	filling_color = "#8AFF75"
 	list_reagents = list("protein" = 20, "nutriment" = 10, "vitamin" = 5)
-
-/obj/item/weapon/reagent_containers/food/snacks/sliceable/xenomeatbread/New()
-	..()
-	spawn(1)
-		if(reagents.has_reagent("xenomicrobes"))
-			reagents.add_reagent("xenomicrobes", reagents.get_reagent_amount("xenomicrobes"))	//doubles the microbes from ingredients if present
 
 /obj/item/weapon/reagent_containers/food/snacks/xenomeatbreadslice
 	name = "xenomeatbread slice"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -193,6 +193,22 @@
 
 	feedback_add_details("slime_cores_used","[type]")
 	var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
+	var/list/blocked = list(/obj/item/weapon/reagent_containers/food/drinks/cans/adminbooze,
+							/obj/item/weapon/reagent_containers/food/drinks/cans/madminmalt,
+							/obj/item/weapon/reagent_containers/food/drinks/bottle/random_reagent,
+							/obj/item/weapon/reagent_containers/food/drinks/shaker,
+							/obj/item/weapon/reagent_containers/food/drinks/britcup,
+							/obj/item/weapon/reagent_containers/food/drinks/sillycup,
+							/obj/item/weapon/reagent_containers/food/drinks/cans,
+							/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/shotglass,
+							/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+							/obj/item/weapon/reagent_containers/food/drinks/bottle,
+							/obj/item/weapon/reagent_containers/food/drinks/mushroom_bowl
+							)
+	blocked += typesof(/obj/item/weapon/reagent_containers/food/drinks/flask)
+	blocked += typesof(/obj/item/weapon/reagent_containers/food/drinks/trophy)
+	blocked += typesof(/obj/item/weapon/reagent_containers/food/drinks/cans/bottler)
+	borks -= blocked
 	// BORK BORK BORK
 
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -159,6 +159,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/meat/slab,
 		/obj/item/weapon/reagent_containers/food/snacks/grown,
 		/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom,
+		/obj/item/weapon/reagent_containers/food/snacks/deepfryholder
 		)
 	blocked |= typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
 
@@ -195,7 +196,6 @@
 	var/list/borks = subtypesof(/obj/item/weapon/reagent_containers/food/drinks)
 	var/list/blocked = list(/obj/item/weapon/reagent_containers/food/drinks/cans/adminbooze,
 							/obj/item/weapon/reagent_containers/food/drinks/cans/madminmalt,
-							/obj/item/weapon/reagent_containers/food/drinks/bottle/random_reagent,
 							/obj/item/weapon/reagent_containers/food/drinks/shaker,
 							/obj/item/weapon/reagent_containers/food/drinks/britcup,
 							/obj/item/weapon/reagent_containers/food/drinks/sillycup,


### PR DESCRIPTION
Silver Slime Cores now should only spawn drink containers that come pre-filled with a drink.
- This means no more empty cups/trophies/bottler containers/flasks

![image](https://user-images.githubusercontent.com/8988254/30463360-4220842a-9999-11e7-8317-b0ae64f8bc47.png)

The random reagent bottle now properly respects blacklisted chems, instead of blindly picking from all reagents.
- If the reagent can't be synthesized (can_synth = FALSE), it won't spawn in the bottle. This is now consistent with other sources of random chemicals, such as botany strange seeds.

Removed a file's worth of relative pathing (random_items.dm)
- Additionally adjusted the code for picking random reagents to use copied lists or `get_random_reagent_id()` as appropriate to keep things sanitized and respect blacklisted chems

:cl:
tweak: Silver Slime Core reactions can only summon forth drinks that actually contain a drink. Begone thirst!
tweak: Removes some "unsafe" chemicals from lists of potential chemicals for inclusion in things like random pills or bottles, added one to replace them.
tweak: Removes adminordrazine and nanites from vent clog, replaces nanites with syndicate_nanites.
/:cl: