### PR TITLE
Gives immolator mech weapon unique ID, allows it to be constructed

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -984,7 +984,7 @@
 /datum/design/mech_immolator
 	name = "Exosuit Weapon (ZFI Immolation Beam Gun)"
 	desc = "Allows for the construction of ZFI Immolation Beam Gun."
-	id = "mech_tesla"
+	id = "mech_immolator"
 	build_type = MECHFAB
 	req_tech = list("combat" = 6, "magnets" = 5, "materials" = 5)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/immolator


### PR DESCRIPTION
The 'Immolator' Mech weapon had the same ID as the mech tesla cannon, namely 'mech_tesla', which made it not show up in the list of exosuit equipment in the fabricator.

This changes the Immolator's ID to something unique, allowing it to be constructed.

:cl:
bugfix: Immolator ID changed from 'mech_tesla' to 'mech_immolator', allowing it to be constructed.
/ :cl: