### PR TITLE
Introduce surgery failure chance for patients that feel pain and are awake.

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -34,7 +34,7 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/weapon/screwdriver = 90
 	)
 	can_infect = 1
 	blood_level = 1
@@ -70,7 +70,7 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/bonesetter = 100,	\
-	/obj/item/weapon/wrench = 75		\
+	/obj/item/weapon/wrench = 90	\
 	)
 
 	time = 32
@@ -109,7 +109,7 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/bonesetter = 100,	\
-	/obj/item/weapon/wrench = 75		\
+	/obj/item/weapon/wrench = 90		\
 	)
 
 	time = 32
@@ -144,7 +144,7 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/weapon/screwdriver = 90
 	)
 	can_infect = 1
 	blood_level = 1

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -68,8 +68,8 @@
 	name = "make cavity space"
 	allowed_tools = list(
 	/obj/item/weapon/surgicaldrill = 100,	\
-	/obj/item/weapon/pen = 75,	\
-	/obj/item/stack/rods = 50
+	/obj/item/weapon/pen = 90,	\
+	/obj/item/stack/rods = 60
 	)
 
 	time = 54
@@ -93,9 +93,9 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 75,	\
-	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/clothing/mask/cigarette = 90,	\
+	/obj/item/weapon/lighter = 60,			\
+	/obj/item/weapon/weldingtool = 30
 	)
 
 	time = 24

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -25,7 +25,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
 	/obj/item/weapon/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 90
 	)
 
 	time = 54
@@ -72,7 +72,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75
+	/obj/item/weapon/crowbar = 90
 	)
 
 	time = 24
@@ -123,7 +123,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75
+	/obj/item/weapon/crowbar = 90
 	)
 
 	time = 24
@@ -173,7 +173,7 @@
 	name = "mend bone"
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/weapon/screwdriver = 90
 	)
 
 	time = 24

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -29,8 +29,8 @@
 	name = "make incision"
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
 	)
 
 	time = 16
@@ -60,8 +60,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/hemostat = 100, 	\
-	/obj/item/stack/cable_coil = 75, 	\
-	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
+	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/device/assembly/mousetrap = 12	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
 	time = 24
@@ -87,8 +87,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 55,	\
-	/obj/item/weapon/kitchen/utensil/fork = 75)
+	/obj/item/weapon/crowbar = 65,	\
+	/obj/item/weapon/kitchen/utensil/fork = 90)
 
 	time = 64
 
@@ -114,9 +114,9 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 75,	\
-	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/clothing/mask/cigarette = 90,	\
+	/obj/item/weapon/lighter = 60,			\
+	/obj/item/weapon/weldingtool = 30
 	)
 
 	time = 24

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -22,13 +22,13 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
-	/obj/item/weapon/scissors = 10,		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
+	/obj/item/weapon/scissors = 12,		\
 	/obj/item/weapon/twohanded/chainsaw = 1, \
-	/obj/item/weapon/claymore = 5, \
-	/obj/item/weapon/melee/energy/ = 5, \
-	/obj/item/weapon/pen/edagger = 5,  \
+	/obj/item/weapon/claymore = 6, \
+	/obj/item/weapon/melee/energy/ = 6, \
+	/obj/item/weapon/pen/edagger = 6,  \
 	)
 
 	time = 16
@@ -60,8 +60,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 75, 	\
-	/obj/item/device/assembly/mousetrap = 20
+	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/device/assembly/mousetrap = 25
 	)
 
 	time = 24
@@ -94,8 +94,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/crowbar = 90,	\
+	/obj/item/weapon/kitchen/utensil/fork = 60
 	)
 
 	time = 24
@@ -149,9 +149,9 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 75,	\
-	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/clothing/mask/cigarette = 90,	\
+	/obj/item/weapon/lighter = 60,			\
+	/obj/item/weapon/weldingtool = 30
 	)
 
 	time = 24
@@ -199,8 +199,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
 	/obj/item/weapon/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/weapon/hatchet = 75, \
-	/obj/item/weapon/melee/arm_blade = 60
+	/obj/item/weapon/hatchet = 90, \
+	/obj/item/weapon/melee/arm_blade = 75
 	)
 
 	time = 100

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -81,7 +81,8 @@
 			return 1
 	return 0
 
-
+/proc/get_pain_modifier(mob/M)
+	return 1
 
 /proc/get_location_modifier(mob/M)
 	var/turf/T = get_turf(M)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -88,6 +88,13 @@
 		var/mob/living/carbon/human/H = M
 		if(NO_PAIN in H.species.species_traits)//if you don't feel pain, you can hold still
 			return 1
+		if(M.drunk)
+			if(M.drunk>=80)//really damn drunk
+				return 0.95
+			if(M.drunk>=40)//pretty drunk
+				return 0.9
+			if(M.drunk>=15)//a little buzz
+				return 0.85
 	return 0.8 //20% failure chance
 
 /proc/get_location_modifier(mob/M)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -92,13 +92,13 @@
 			return 0.97
 		if(M.reagents.has_reagent("morphine"))//Morphine can knock you out completely to guarantee success, but even a little bit helps
 			return 0.95
-		if(M.drunk>=80)//really damn drunk
+		if(M.drunk >= 80)//really damn drunk
 			return 0.95
-		if(M.drunk>=40)//pretty drunk
+		if(M.drunk >= 40)//pretty drunk
 			return 0.9
 		if(M.reagents.has_reagent("sal_acid")) //it's better than nothing, as far as painkillers go.
 			return 0.85
-		if(M.drunk>=15)//a little drunk
+		if(M.drunk >= 15)//a little drunk
 			return 0.85
 	return 0.8 //20% failure chance
 

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -86,10 +86,10 @@
 		return 1
 	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
 		return 1
-	if(M.reagents.has_reagent("hydrocodone"))//The most effective pain killer
-		return 0.97
-	if(M.reagents.has_reagent("morphine"))//Morphine can knock you out completely to guarantee success, but even a little bit helps
-		return 0.95
+	if(M.reagents.has_reagent("hydrocodone"))//really good pain killer
+		return 0.99
+	if(M.reagents.has_reagent("morphine"))//Just as effective as Hydrocodone, but has an addiction chance
+		return 0.99
 	if(M.drunk >= 80)//really damn drunk
 		return 0.95
 	if(M.drunk >= 40)//pretty drunk

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -88,13 +88,18 @@
 		var/mob/living/carbon/human/H = M
 		if(NO_PAIN in H.species.species_traits)//if you don't feel pain, you can hold still
 			return 1
-		if(M.drunk)
-			if(M.drunk>=80)//really damn drunk
-				return 0.95
-			if(M.drunk>=40)//pretty drunk
-				return 0.9
-			if(M.drunk>=15)//a little buzz
-				return 0.85
+		if(M.reagents.has_reagent("hydrocodone"))//The most effective pain killer
+			return 0.97
+		if(M.reagents.has_reagent("morphine"))//Morphine can knock you out completely to guarantee success, but even a little bit helps
+			return 0.95
+		if(M.drunk>=80)//really damn drunk
+			return 0.95
+		if(M.drunk>=40)//pretty drunk
+			return 0.9
+		if(M.reagents.has_reagent("sal_acid")) //it's better than nothing, as far as painkillers go.
+			return 0.85
+		if(M.drunk>=15)//a little drunk
+			return 0.85
 	return 0.8 //20% failure chance
 
 /proc/get_location_modifier(mob/M)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -81,8 +81,12 @@
 			return 1
 	return 0
 
-/proc/get_pain_modifier(mob/M)
-	return 1
+/proc/get_pain_modifier(mob/M) //returns modfier to make surgery harder if patient is conscious and feels pain
+	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too.
+		return 1
+	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
+		return 1
+	return 0.8 //20% failure chance
 
 /proc/get_location_modifier(mob/M)
 	var/turf/T = get_turf(M)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -81,25 +81,23 @@
 			return 1
 	return 0
 
-/proc/get_pain_modifier(mob/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too.
+/proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
+	if(M.stat && !M.sleeping) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
 		return 1
-	if(ishuman(M)) //default mob doesn't have species
-		var/mob/living/carbon/human/H = M
-		if(NO_PAIN in H.species.species_traits)//if you don't feel pain, you can hold still
-			return 1
-		if(M.reagents.has_reagent("hydrocodone"))//The most effective pain killer
-			return 0.97
-		if(M.reagents.has_reagent("morphine"))//Morphine can knock you out completely to guarantee success, but even a little bit helps
-			return 0.95
-		if(M.drunk >= 80)//really damn drunk
-			return 0.95
-		if(M.drunk >= 40)//pretty drunk
-			return 0.9
-		if(M.reagents.has_reagent("sal_acid")) //it's better than nothing, as far as painkillers go.
-			return 0.85
-		if(M.drunk >= 15)//a little drunk
-			return 0.85
+	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
+		return 1
+	if(M.reagents.has_reagent("hydrocodone"))//The most effective pain killer
+		return 0.97
+	if(M.reagents.has_reagent("morphine"))//Morphine can knock you out completely to guarantee success, but even a little bit helps
+		return 0.95
+	if(M.drunk >= 80)//really damn drunk
+		return 0.95
+	if(M.drunk >= 40)//pretty drunk
+		return 0.9
+	if(M.reagents.has_reagent("sal_acid")) //it's better than nothing, as far as painkillers go.
+		return 0.85
+	if(M.drunk >= 15)//a little drunk
+		return 0.85
 	return 0.8 //20% failure chance
 
 /proc/get_location_modifier(mob/M)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -84,8 +84,10 @@
 /proc/get_pain_modifier(mob/M) //returns modfier to make surgery harder if patient is conscious and feels pain
 	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too.
 		return 1
-	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
-		return 1
+	if(ishuman(M)) //default mob doesn't have species
+		var/mob/living/carbon/human/H = M
+		if(NO_PAIN in H.species.species_traits)//if you don't feel pain, you can hold still
+			return 1
 	return 0.8 //20% failure chance
 
 /proc/get_location_modifier(mob/M)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -171,8 +171,8 @@
 	name = "connect limb"
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 75, 	\
-	/obj/item/device/assembly/mousetrap = 20
+	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/device/assembly/mousetrap = 25
 	)
 	can_infect = 1
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -68,17 +68,17 @@
 /datum/surgery_step/internal/manipulate_organs
 	name = "manipulate organs"
 	allowed_tools = list(/obj/item/organ/internal = 100, /obj/item/weapon/reagent_containers/food/snacks/organ = 0)
-	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/kitchen/utensil/fork = 55)
+	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/kitchen/utensil/fork = 70)
 	var/implements_mend = list(/obj/item/stack/medical/bruise_pack = 20,/obj/item/stack/medical/bruise_pack/advanced = 100,/obj/item/stack/nanopaste = 100)
 	var/implements_clean = list(/obj/item/weapon/reagent_containers/dropper = 100,
-								/obj/item/weapon/reagent_containers/glass/bottle = 75,
-								/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
-								/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
-								/obj/item/weapon/reagent_containers/glass/beaker = 60,
-								/obj/item/weapon/reagent_containers/spray = 50,
-								/obj/item/weapon/reagent_containers/glass/bucket = 40)
+								/obj/item/weapon/reagent_containers/glass/bottle = 90,
+								/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 85,
+								/obj/item/weapon/reagent_containers/food/drinks/bottle = 80,
+								/obj/item/weapon/reagent_containers/glass/beaker = 75,
+								/obj/item/weapon/reagent_containers/spray = 60,
+								/obj/item/weapon/reagent_containers/glass/bucket = 50)
 	//Finish is just so you can close up after you do other things.
-	var/implements_finsh = list(/obj/item/weapon/scalpel/laser/manager = 100,/obj/item/weapon/retractor = 100 ,/obj/item/weapon/crowbar = 75)
+	var/implements_finsh = list(/obj/item/weapon/scalpel/laser/manager = 100,/obj/item/weapon/retractor = 100 ,/obj/item/weapon/crowbar = 90)
 	var/current_type
 	var/obj/item/organ/internal/I = null
 	var/obj/item/organ/external/affected = null
@@ -436,7 +436,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
 	/obj/item/weapon/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 90
 	)
 
 	time = 54
@@ -464,13 +464,13 @@
 	name = "cut carapace"
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
-	/obj/item/weapon/scissors = 10,		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
+	/obj/item/weapon/scissors = 12,		\
 	/obj/item/weapon/twohanded/chainsaw = 1, \
-	/obj/item/weapon/claymore = 5, \
-	/obj/item/weapon/melee/energy/ = 5, \
-	/obj/item/weapon/pen/edagger = 5, \
+	/obj/item/weapon/claymore = 6, \
+	/obj/item/weapon/melee/energy/ = 6, \
+	/obj/item/weapon/pen/edagger = 6, \
 	)
 
 	time = 16
@@ -499,8 +499,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/crowbar = 90,	\
+	/obj/item/weapon/kitchen/utensil/fork = 60
 	)
 
 	time = 24

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -62,7 +62,7 @@
 	name = "mend internal bleeding"
 	allowed_tools = list(
 	/obj/item/weapon/FixOVein = 100, \
-	/obj/item/stack/cable_coil = 75
+	/obj/item/stack/cable_coil = 90
 	)
 	can_infect = 1
 	blood_level = 1
@@ -107,8 +107,8 @@
 	name = "remove dead tissue"
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,		\
-		/obj/item/weapon/kitchen/knife = 75,	\
-		/obj/item/weapon/shard = 50, 		\
+		/obj/item/weapon/kitchen/knife = 90,	\
+		/obj/item/weapon/shard = 60, 		\
 	)
 
 	can_infect = 1
@@ -156,12 +156,12 @@
 	name = "treat necrosis"
 	allowed_tools = list(
 		/obj/item/weapon/reagent_containers/dropper = 100,
-		/obj/item/weapon/reagent_containers/glass/bottle = 75,
-		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
-		/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
-		/obj/item/weapon/reagent_containers/glass/beaker = 60,
-		/obj/item/weapon/reagent_containers/spray = 50,
-		/obj/item/weapon/reagent_containers/glass/bucket = 40
+		/obj/item/weapon/reagent_containers/glass/bottle = 90,
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 85,
+		/obj/item/weapon/reagent_containers/food/drinks/bottle = 80,
+		/obj/item/weapon/reagent_containers/glass/beaker = 75,
+		/obj/item/weapon/reagent_containers/spray = 60,
+		/obj/item/weapon/reagent_containers/glass/bucket = 50
 	)
 
 	can_infect = 0

--- a/code/modules/surgery/slime.dm
+++ b/code/modules/surgery/slime.dm
@@ -18,8 +18,8 @@
 /datum/surgery_step/slime/cut_flesh
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
 	)
 
 	time = 16
@@ -46,8 +46,8 @@
 /datum/surgery_step/slime/cut_innards
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
 	)
 
 	time = 16
@@ -73,7 +73,7 @@
 /datum/surgery_step/slime/saw_core
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 90
 	)
 
 	time = 16

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -117,7 +117,7 @@
 		prob_chance *= get_location_modifier(target)
 
 
-		if(!istype(surgery.steps[surgery.status], /datum/surgery_step/robotics))//Repairing robotic limbs doesn't hurt
+		if(!ispath(surgery.steps[surgery.status], /datum/surgery_step/robotics))//Repairing robotic limbs doesn't hurt
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target //typecast to human
 				prob_chance *= get_pain_modifier(H)//operating on conscious people is hard.

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -115,7 +115,9 @@
 		if(implement_type)	//this means it isn't a require nd or any item step.
 			prob_chance = allowed_tools[implement_type]
 		prob_chance *= get_location_modifier(target)
-		prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
+
+		if(!istype(steps[status], /datum/surgery_step/robotics)//Repairing robotic limbs doesn't hurt
+			prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
 
 
 		if(prob(prob_chance) || isrobot(user))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -115,6 +115,8 @@
 		if(implement_type)	//this means it isn't a require nd or any item step.
 			prob_chance = allowed_tools[implement_type]
 		prob_chance *= get_location_modifier(target)
+		prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
+
 
 
 		if(prob(prob_chance) || isrobot(user))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -115,7 +115,9 @@
 		if(implement_type)	//this means it isn't a require nd or any item step.
 			prob_chance = allowed_tools[implement_type]
 		prob_chance *= get_location_modifier(target)
-		prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
+
+		if(!istype(surgery.steps[surgery.status], /datum/surgery_step/robotics))//Repairing robotic limbs doesn't hurt
+			prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
 
 
 		if(prob(prob_chance) || isrobot(user))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -116,6 +116,7 @@
 			prob_chance = allowed_tools[implement_type]
 		prob_chance *= get_location_modifier(target)
 
+
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))
 				advance = 1

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -117,7 +117,7 @@
 		prob_chance *= get_location_modifier(target)
 
 
-		if(!ispath(surgery.steps[surgery.status], /datum/surgery_step/robotics))//Repairing robotic limbs doesn't hurt
+		if(!ispath(surgery.steps[surgery.status], /datum/surgery_step/robotics) && !ispath(surgery.steps[surgery.status], /datum/surgery_step/rigsuit))//Repairing robotic limbs doesn't hurt, and neither does cutting someone out of a rig
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target //typecast to human
 				prob_chance *= get_pain_modifier(H)//operating on conscious people is hard.

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -115,9 +115,7 @@
 		if(implement_type)	//this means it isn't a require nd or any item step.
 			prob_chance = allowed_tools[implement_type]
 		prob_chance *= get_location_modifier(target)
-
-		if(!istype(steps[status], /datum/surgery_step/robotics)//Repairing robotic limbs doesn't hurt
-			prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
+		prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
 
 
 		if(prob(prob_chance) || isrobot(user))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -116,9 +116,11 @@
 			prob_chance = allowed_tools[implement_type]
 		prob_chance *= get_location_modifier(target)
 
-		if(!istype(surgery.steps[surgery.status], /datum/surgery_step/robotics))//Repairing robotic limbs doesn't hurt
-			prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
 
+		if(!istype(surgery.steps[surgery.status], /datum/surgery_step/robotics))//Repairing robotic limbs doesn't hurt
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target //typecast to human
+				prob_chance *= get_pain_modifier(H)//operating on conscious people is hard.
 
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -118,7 +118,6 @@
 		prob_chance *= get_pain_modifier(target)//operating on conscious people is hard.
 
 
-
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))
 				advance = 1


### PR DESCRIPTION
At the moment, there is no in-game reason to ever use anesthesia or allow it to be used on you for surgery, aside from RP concerns. People gleefully jump onto the table and hold relaxed conversations while bold, red messages tell them in what horrible agony they constantly are.

This PR introduces a failure chance for surgery, based on the fact that it is pretty damn hard for a patient to lie perfectly still while his skull is being sawed open.

On top of that, it should make things more interesting for antagonists that perform surgery. With the code as it is now, it is almost suspicious to insist your patient be placed under anesthesia, denying a doctor chances to for example put mindslave implants in their patients.


The exact numbers are as follows:

- Dead or unconscious patients as well as those that don't feel pain do not cause any failure chance.
- Conscious patients with hydrocodone or morphine in their bodies have a 1% failure chance and those with salicylic acid 15%.
- Ghetto anesthesia is possible with alcohol. Depending on how drunk a patient is, the failure chance can be 5%, 10% or 15%.
- Finally, without any anesthesia and no mitigating factors, the failure chance is 20%.

By now you are probably asking: But what about Vox/plasmamen/slimes, we can't anesthetize them with the tank in surgery.
There are ways beyond the anesthesia tanks to sedate a patient. You can dose them with ether or morphine in sufficient doses. You can give them hydrocodone and accept the minor failure chance. You can get them super-drunk, etc. Overall, I think the need for painkillers should have the side effect of giving the chemist some more reasons to produce more varied chemicals.


:cl:
add: Surgery failure chance for conscious patients that feel pain, can be reduced with painkillers or by getting them drunk.
tweak: Adjusts ghetto surgery tool chances up so ghetto surgery has roughly the same odds as before.
/:cl: