### PR TITLE
Lowers Mech Bola Launcher Combat Tech

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -482,6 +482,7 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/bola
 	name = "PCMK-6 Bola Launcher"
 	icon_state = "mecha_bola"
+	origin_tech = "combat=4;engineering=4"
 	projectile = /obj/item/weapon/restraints/legcuffs/bola
 	fire_sound = 'sound/weapons/whip.ogg'
 	projectiles = 10


### PR DESCRIPTION
From 5 to 4. Also removed the materials tech from it. To raise combat past 5 you're supposed to order an expensive crate or grow a dangerous plant not print an easy to obtain non-lethal mech weapon from Robotics

:cl:
balance: Lowered Mech Bola Launcher Combat Tech from 5 to 4, removed Materials Tech from it as well.
/:cl: