### PR TITLE
Fixes bug with supervillain recruitment

### DIFF
--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -175,6 +175,7 @@
 			return
 		if(target.mind.assigned_role != "Civilian")
 			to_chat(user, "<span class='warning'>You can only recruit Civilians.</span>")
+			return
 		if(recruiting)
 			to_chat(user, "<span class='danger'>You are already recruiting!</span>")
 			charge_counter = charge_max


### PR DESCRIPTION
Someone forgot to write "return" when checking the recruitment targets job, allowing villians to recruit any job. It now properly doesn't allow recruoting non civilians.

🆑 Imsxz
fix: fixes supervillains recruiting non-civilians
/🆑 