### PR TITLE
Fixed efficiency math in Turbine.dm

### DIFF
--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -156,7 +156,7 @@
 
 // RPM function to include compression friction - be advised that too low/high of a compfriction value can make things screwy
 
-	rpm = max(0, rpm - (rpm*rpm)/(COMPFRICTION/efficiency))
+	rpm = max(0, rpm - (rpm*rpm)/(COMPFRICTION*efficiency))
 
 
 	if(starter && !(stat & NOPOWER))


### PR DESCRIPTION
Fixed the RPM equation in the Compressor part of Turbine.

Formerly, the Efficiency increase would make the friction of the Compressor bigger, throttling RPM.
This had the effect of decreasing power output across the entire curve if the compressor is upgraded with better components.
A simple equation fix makes any increase on the Efficiency variable have a positive impact on power generated as is intended.
This fixes the issue where the player was punished for upgrading the Compressor part of the Turbine from the basic Mico-Manipulator components to anything higher. Upgrading to Nano, Pico and Femto gives an output increase, making the Turbine more viable.

🆑
Fix:Stops the Turbine Compressor from getting worse across the board with each upgrade it gets.
/🆑