### PR TITLE
Fixes a typo with the russian revolver

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1397,7 +1397,7 @@ obj/item/toy/cards/deck/syndicate/black
 			is_empty = 1
 			playsound(src, 'sound/weapons/Gunshot.ogg', 50, 1)
 			user.visible_message("<span class='danger'>The [src] goes off!</span>")
-			M.apply_damage(200, BRUTE, "head", sharp =1, used_weapon = "Self-inflicted gunshot would to the head.")
+			M.apply_damage(200, BRUTE, "head", sharp =1, used_weapon = "Self-inflicted gunshot wound to the head.")
 			M.death()
 	else
 		user.visible_message("<span class='danger'>[user] lowers the [src] from their head.</span>")


### PR DESCRIPTION
Big change of a whoole letter, you now get a self inflicted gunshot wound instead of a gunshot would if you loose russian roulette.
:cl:
Fix: Typo in the autopsy message for russian roulette wounds.
/:cl: