### PR TITLE
Fixes the electrified arm for implants

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "elecarm"
 	var/charge_cost = 30
+	var/needs_cell_charge = TRUE
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/silicon/robot/user)
 	if(ishuman(M))
@@ -15,7 +16,7 @@
 			playsound(M, 'sound/weapons/Genhit.ogg', 50, 1)
 			return 0
 
-	if(!user.cell.use(charge_cost))
+	if(needs_cell_charge && !user.cell.use(charge_cost))
 		return
 
 	user.do_attack_animation(M)
@@ -29,6 +30,9 @@
 	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
 	add_logs(user, M, "stunned", src, "(INTENT: [uppertext(user.a_intent)])")
+
+/obj/item/borg/stun/implant
+	needs_cell_charge = FALSE
 
 /obj/item/borg/overdrive
 	name = "Overdrive"

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -7,7 +7,6 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "elecarm"
 	var/charge_cost = 30
-	var/needs_cell_charge = TRUE
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/silicon/robot/user)
 	if(ishuman(M))
@@ -16,7 +15,9 @@
 			playsound(M, 'sound/weapons/Genhit.ogg', 50, 1)
 			return 0
 
-	if(needs_cell_charge && !user.cell.use(charge_cost))
+	if(!handlecharge())
+		M.visible_message("<span class='warning'>[user] has poked [M] with [src], which does let out a quiet sizzling. Sounds like the power for it has run out.</span>", \
+						"<span class='warning'>[user] has poked you with [src], which does let out a quiet sizzling. Sounds like the power for it has run out.</span>")
 		return
 
 	user.do_attack_animation(M)
@@ -31,8 +32,34 @@
 
 	add_logs(user, M, "stunned", src, "(INTENT: [uppertext(user.a_intent)])")
 
+/obj/item/borg/stun/proc/handlecharge(var/mob/living/silicon/robot/user)
+	return user.cell.use(charge_cost)
+
 /obj/item/borg/stun/implant
-	needs_cell_charge = FALSE
+	var/obj/item/weapon/stock_parts/cell/bcell = null
+	var/charge_tick = 0
+	var/charge_delay = 6
+	charge_cost = 100
+
+/obj/item/borg/stun/implant/New()
+	..()
+	bcell = new(src)
+	processing_objects.Add(src)
+
+/obj/item/borg/stun/implant/Destroy()
+	processing_objects.Remove(src)
+	QDEL_NULL(bcell)
+	return ..()
+
+/obj/item/borg/stun/implant/handlecharge()
+	return bcell.use(charge_cost)
+
+/obj/item/borg/stun/implant/process()
+	charge_tick++
+	if(charge_tick < charge_delay)
+		return
+	charge_tick = 0
+	bcell.give(100)
 
 /obj/item/borg/overdrive
 	name = "Overdrive"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -220,13 +220,13 @@
 /obj/item/organ/internal/cyberimp/arm/baton
 	name = "arm electrification implant"
 	desc = "An illegal combat implant that allows the user to administer disabling shocks from their arm."
-	contents = newlist(/obj/item/borg/stun)
+	contents = newlist(/obj/item/borg/stun/implant)
 	origin_tech = "materials=3;combat=5;biotech=4;powerstorage=4;syndicate=3"
 
 /obj/item/organ/internal/cyberimp/arm/combat
 	name = "combat cybernetics implant"
 	desc = "A powerful cybernetic implant that contains combat modules built into the user's arm"
-	contents = newlist(/obj/item/weapon/melee/energy/blade/hardlight, /obj/item/weapon/gun/medbeam, /obj/item/borg/stun, /obj/item/device/flash/armimplant)
+	contents = newlist(/obj/item/weapon/melee/energy/blade/hardlight, /obj/item/weapon/gun/medbeam, /obj/item/borg/stun/implant, /obj/item/device/flash/armimplant)
 	origin_tech = "materials=5;combat=7;biotech=5;powerstorage=5;syndicate=6;programming=5"
 
 /obj/item/organ/internal/cyberimp/arm/combat/New()


### PR DESCRIPTION
The electrified arm, if used by humans, currently runtime, as they search for a borg cell on a human. Adds a subtype that does have it's own power supply, that recharges over time. The recharge should be slow enough to stop it from being used to permastun someone. The speed the recharge does happen can be easily edited for adminbuse, or changed if it needs to be re-balanced.
:cl:
Fix: Stops the electrified arm from combat and stunbaton implant from runtiming.
Add: Adds a self-recharging battery to the electrified arm implant, limiting the uses you have in a given timeframe.
/:cl: