### PR TITLE
Some Ling Changes

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -1,3 +1,7 @@
+#define LING_FAKEDEATH_TIME					400 //40 seconds
+#define LING_DEAD_GENETICDAMAGE_HEAL_CAP	50	//The lowest value of geneticdamage handle_changeling() can take it to while dead.
+#define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
+
 var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon","Zeta","Eta","Theta","Iota","Kappa","Lambda","Mu","Nu","Xi","Omicron","Pi","Rho","Sigma","Tau","Upsilon","Phi","Chi","Psi","Omega")
 
 /datum/game_mode
@@ -253,9 +257,14 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	else
 		changelingID = "[honorific] [rand(1,999)]"
 
-/datum/changeling/proc/regenerate()
-	chem_charges = min(max(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown), chem_storage)
-	geneticdamage = max(0, geneticdamage-1)
+/datum/changeling/proc/regenerate(mob/living/carbon/the_ling)
+	if(istype(the_ling))
+		if(the_ling.stat == DEAD)
+			chem_charges = min(max(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown), (chem_storage*0.5))
+			geneticdamage = max(LING_DEAD_GENETICDAMAGE_HEAL_CAP,geneticdamage-1)
+		else //not dead? no chem/geneticdamage caps.
+			chem_charges = min(max(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown), chem_storage)
+			geneticdamage = max(0, geneticdamage-1)
 
 /datum/changeling/proc/GetDNA(dna_owner)
 	for(var/datum/dna/DNA in (absorbed_dna + protected_dna))

--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -15,6 +15,7 @@
 	var/req_stat = CONSCIOUS // CONSCIOUS, UNCONSCIOUS or DEAD
 	var/genetic_damage = 0 // genetic damage caused by using the sting. Nothing to do with cloneloss.
 	var/max_genetic_damage = 100 // hard counter for spamming abilities. Not used/balanced much yet.
+	var/always_keep = 0 // important for abilities like regenerate that screw you if you lose them.
 
 /obj/effect/proc_holder/changeling/proc/on_purchase(var/mob/user)
 	return

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -407,7 +407,7 @@ var/list/sting_paths
 			mind.changeling.changeling_speak = 0
 			mind.changeling.reset()
 			for(var/obj/effect/proc_holder/changeling/p in mind.changeling.purchasedpowers)
-				if(p.dna_cost == 0 && keep_free_powers)
+				if((p.dna_cost == 0 && keep_free_powers) || p.always_keep)
 					continue
 				mind.changeling.purchasedpowers -= p
 				p.on_refund(src)

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -1,5 +1,3 @@
-#define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
-
 /obj/effect/proc_holder/changeling/absorbDNA
 	name = "Absorb DNA"
 	desc = "Absorb the DNA of our victim."

--- a/code/game/gamemodes/changeling/powers/chameleon_skin.dm
+++ b/code/game/gamemodes/changeling/powers/chameleon_skin.dm
@@ -1,0 +1,27 @@
+/obj/effect/proc_holder/changeling/chameleon_skin
+	name = "Chameleon Skin"
+	desc = "Our skin pigmentation rapidly changes to suit our current environment."
+	helptext = "Allows us to become invisible after a few seconds of standing still. Can be toggled on and off."
+	dna_cost = 2
+	chemical_cost = 25
+	req_human = 1
+
+/obj/effect/proc_holder/changeling/chameleon_skin/sting_action(mob/user)
+	var/mob/living/carbon/human/H = user //SHOULD always be human, because req_human = 1
+	if(!istype(H)) // req_human could be done in can_sting stuff.
+		return
+	if(H.dna.GetSEState(CHAMELEONBLOCK))
+		H.dna.SetSEState(CHAMELEONBLOCK, 0)
+		genemutcheck(H, CHAMELEONBLOCK, null, MUTCHK_FORCED)
+	else
+		H.dna.SetSEState(CHAMELEONBLOCK, 1)
+		genemutcheck(H, CHAMELEONBLOCK, null, MUTCHK_FORCED)
+
+	feedback_add_details("changeling_powers","CS")
+	return TRUE
+
+/obj/effect/proc_holder/changeling/chameleon_skin/on_refund(mob/user)
+	var/mob/living/carbon/C = user
+	if(C.dna.GetSEState(CHAMELEONBLOCK))
+		C.dna.SetSEState(CHAMELEONBLOCK, 0)
+		genemutcheck(C, CHAMELEONBLOCK, null, MUTCHK_FORCED)

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -7,30 +7,31 @@
 	req_stat = DEAD
 	max_genetic_damage = 100
 
-
 //Fake our own death and fully heal. You will appear to be dead but regenerate fully after a short delay.
 /obj/effect/proc_holder/changeling/fakedeath/sting_action(var/mob/living/user)
 
 	to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
-
 	if(user.stat != DEAD)
 		user.emote("deathgasp")
 		user.timeofdeath = world.time
-
 	user.status_flags |= FAKEDEATH		//play dead
 	user.update_canmove()
 
-	spawn(800)
-		if(user && user.mind && user.mind.changeling && user.mind.changeling.purchasedpowers)
-			to_chat(user, "<span class='notice'>We are ready to regenerate.</span>")
-			user.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/revive(null)
-
+	addtimer(src, "ready_to_regenerate", LING_FAKEDEATH_TIME, FALSE, user)
 	feedback_add_details("changeling_powers","FD")
 	return 1
 
+/obj/effect/proc_holder/changeling/fakedeath/proc/ready_to_regenerate(mob/user)
+	if(user && user.mind && user.mind.changeling && user.mind.changeling.purchasedpowers)
+		to_chat(user, "<span class='notice'>We are ready to regenerate.</span>")
+		user.mind.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/revive(null)
+
 /obj/effect/proc_holder/changeling/fakedeath/can_sting(var/mob/user)
 	if(user.status_flags & FAKEDEATH)
+		to_chat(user, "<span class='warning'>We are already regenerating.</span>")
 		return
-	if(!user.stat && alert("Are we sure we wish to fake our death?",,"Yes","No") == "No")//Confirmation for living changelings if they want to fake their death
-		return
+	if(!user.stat)//Confirmation for living changelings if they want to fake their death
+		switch(alert("Are we sure we wish to fake our death?",,"Yes","No"))
+			if("No")
+				return
 	return ..()

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -2,22 +2,53 @@
 	name = "Fleshmend"
 	desc = "Our flesh rapidly regenerates, healing our wounds."
 	helptext = "Heals a moderate amount of damage over a short period of time. Can be used while unconscious."
-	chemical_cost = 25
+	chemical_cost = 20
 	dna_cost = 2
 	req_stat = UNCONSCIOUS
+	var/recent_uses = 1 //The factor of which the healing should be divided by
+	var/healing_ticks = 10
+	// The ideal total healing amount,
+	// divided by healing_ticks to get heal/tick
+	var/total_healing = 100
+
+/obj/effect/proc_holder/changeling/fleshmend/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/effect/proc_holder/changeling/fleshmend/Destroy()
+	processing_objects.Remove(src)
+	return ..()
+
+/obj/effect/proc_holder/changeling/fleshmend/process()
+	if(recent_uses > 1)
+		recent_uses = max(1, recent_uses - (1 / healing_ticks))
 
 //Starts healing you every second for 10 seconds. Can be used whilst unconscious.
 /obj/effect/proc_holder/changeling/fleshmend/sting_action(var/mob/living/user)
 	to_chat(user, "<span class='notice'>We begin to heal rapidly.</span>")
+	if(recent_uses > 1)
+		to_chat(user, "<span class='warning'>Our healing's effectiveness is reduced \
+			by quick repeated use!</span>")
+
+	recent_uses++
+	addtimer(src, "fleshmend", 0, FALSE, user)
+	feedback_add_details("changeling_powers","RR")
+	return TRUE
+
+/obj/effect/proc_holder/changeling/fleshmend/proc/fleshmend(mob/living/user)
+
+	// The healing itself - doesn't heal toxin damage
+	// (that's anatomic panacea) and the effectiveness decreases with
+	// each use in a short timespan
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		H.restore_blood()
 		H.shock_stage = 0
-	spawn(0)
-		for(var/i = 0, i<10,i++)
-			user.heal_overall_damage(10, 10)
-			user.adjustOxyLoss(-10)
-			sleep(10)
-
-	feedback_add_details("changeling_powers","RR")
-	return 1
+	for(var/i in 1 to healing_ticks)
+		if(user)
+			var/healpertick = -(total_healing / healing_ticks)
+			user.heal_overall_damage((-healpertick/recent_uses), (-healpertick/recent_uses))
+			user.adjustOxyLoss(healpertick/recent_uses)
+			user.updatehealth()
+		else
+			break
+		sleep(10)

--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -48,6 +48,7 @@
 			var/healpertick = -(total_healing / healing_ticks)
 			user.heal_overall_damage((-healpertick/recent_uses), (-healpertick/recent_uses))
 			user.adjustOxyLoss(healpertick/recent_uses)
+			user.blood_volume += 30
 			user.updatehealth()
 		else
 			break

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -167,7 +167,7 @@
 			user.visible_message("<span class='warning'>[user] jams [src] into the airlock and starts prying it open!</span>", "<span class='warning'>We start forcing the airlock open.</span>", \
 			"<span class='italics'>You hear a metal screeching sound.</span>")
 			playsound(A, 'sound/machines/airlock_alien_prying.ogg', 150, 1)
-			if(!do_after(user, 150, target = A))
+			if(!do_after(user, 100, target = A))
 				return
 
 		//user.say("Heeeeeeeeeerrre's Johnny!")

--- a/code/game/gamemodes/changeling/powers/panacea.dm
+++ b/code/game/gamemodes/changeling/powers/panacea.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/changeling/panacea
 	name = "Anatomic Panacea"
-	desc = "Expels impurifications from our form; curing diseases, removing toxins and radiation, and resetting our genetic code completely."
+	desc = "Expels impurifications from our form; curing diseases, removing parasites, sobering us, purging toxins and radiation, and resetting our genetic code completely."
 	helptext = "Can be used while unconscious."
 	chemical_cost = 20
 	dna_cost = 1
@@ -30,6 +30,8 @@
 	user.reagents.add_reagent("mutadone", 10)
 	user.reagents.add_reagent("potass_iodide", 10)
 	user.reagents.add_reagent("charcoal", 20)
+	user.reagents.add_reagent("antihol", 10)
+	user.reagents.add_reagent("mannitol", 25)
 
 	for(var/thing in user.viruses)
 		var/datum/disease/D = thing

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -2,6 +2,7 @@
 	name = "Regenerate"
 	desc = "We regenerate, healing all damage from our form."
 	req_stat = DEAD
+	always_keep = 1
 
 //Revive from regenerative stasis
 /obj/effect/proc_holder/changeling/revive/sting_action(var/mob/living/carbon/user)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -932,7 +932,7 @@
 /mob/living/carbon/human/handle_changeling()
 	if(mind)
 		if(mind.changeling)
-			mind.changeling.regenerate()
+			mind.changeling.regenerate(src)
 			if(hud_used)
 				hud_used.lingchemdisplay.invisibility = 0
 				hud_used.lingchemdisplay.maptext = "<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(mind.changeling.chem_charges)]</font></div>"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -12,8 +12,8 @@
 		handle_blood()
 		for(var/obj/item/organ/internal/O in internal_organs)
 			O.on_life()
-		handle_changeling()
 
+	handle_changeling()
 	handle_wetness()
 
 	// Increase germ_level regularly

--- a/paradise.dme
+++ b/paradise.dme
@@ -408,6 +408,7 @@
 #include "code\game\gamemodes\changeling\traitor_chan.dm"
 #include "code\game\gamemodes\changeling\powers\absorb.dm"
 #include "code\game\gamemodes\changeling\powers\augmented_eyesight.dm"
+#include "code\game\gamemodes\changeling\powers\chameleon_skin.dm"
 #include "code\game\gamemodes\changeling\powers\digitalcamo.dm"
 #include "code\game\gamemodes\changeling\powers\epinephrine.dm"
 #include "code\game\gamemodes\changeling\powers\fakedeath.dm"


### PR DESCRIPTION
Regenerative Stasis takes 40s down from 80s
New power for lings: Chameleon Skin. Costs 2 evolution points, uses 25 chems on toggling, and basically gives you the chameleon skin genetics power that lets you fade in gradually
Fleshmend chem cost changed from 25 to 20, restores only a bit of blood (use regen stasis for that) and repeated use of it quickly results in less effective healing
Armblade opening doors takes 10s now down from 15s just like the Jaws of Life. Still plenty of time to get caught with an armblade out.
Anatomic Panacea also gives you Antihol and Mannitol now, curing drunkenness and brain damage
When lings die, they will still generate chems up to half the maximum (so 37.5). I noticed that when lings got into fights, they'd use up all their chemicals fast, and when they finally died they couldn't go into Regen Stasis even if they had 14 chems. So now that they generate when dead you can go into Regen Stasis when you're dead.
I made it impossible to accidentally lose the ability to Revive if you Readapt while in stasis.
As with the Biodegrade PR this is from /tg/

:cl:
add: Chameleon Skin power for changelings. Costs 2 evolution points and lets you toggle the Chameleon gene on and off
balance: Changelings will now regenerate chemicals when dead, up to half the maximum (37.5)
balance: Fleshmend costs 20 chems down from 25. However it no longer restores all blood only a bit of blood volume, and using it multiple times quickly results in less effective healing
balance: Regenerative Stasis takes half the time, 40s instead of 80s
fix: Changelings cannot accidentally lose the ability to revive by readapting in stasis
tweak: Armblade opening doors takes 10s instead of 15s
tweak: Anatomic Panacea cures drunkenness and brain damage too
/:cl: