### PR TITLE
Fix: Nukies can now purchase tactical no-slips

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -868,6 +868,7 @@ var/list/uplink_items = list()
 	reference = "NNSSS"
 	cost = 4 //but they aren't
 	gamemodes = list(/datum/game_mode/nuclear)
+	excludefrom = list()
 
 /datum/uplink_item/stealthy_tools/agent_card
 	name = "Agent ID Card"


### PR DESCRIPTION
Tactical no slips are a subtype uplink selection of no slips meant for nukies, but never had their excludefrom list updated, meaning nukies couldn't purchase it. Now they can.

🆑 Imsxz
fix: Allows Nukies to purchase tactical no-slip shoes.
/🆑 