### PR TITLE
Crates will now forcemove mobs inside when opened

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -44,8 +44,10 @@
 				return 2
 
 	playsound(src.loc, 'sound/machines/click.ogg', 15, 1, -3)
-	for(var/obj/O in src)
+	for(var/obj/O in src) //Objects
 		O.forceMove(loc)
+	for(var/mob/M in src) //Mobs
+		M.forceMove(loc)
 	icon_state = icon_opened
 	src.opened = 1
 


### PR DESCRIPTION
Crates will now `forceMove()` mobs inside when opened as well as objects.

Fixes #8149 

🆑 Birdtalon
fix: Emergency equipment crate will now release its medbot and cleanbot contents.
/🆑 