### PR TITLE
Brig Cell timers QoL changes.

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -29,7 +29,7 @@
 
 /proc/time_stamp()
 	return time2text(world.timeofday, "hh:mm:ss")
-	
+
 /proc/gameTimestamp(format = "hh:mm:ss") // Get the game time in text
 	return time2text(world.time - timezoneOffset + 432000, format)
 
@@ -61,6 +61,12 @@ proc/isDay(var/month, var/day)
  */
 /proc/stop_watch(wh)
 	return round(0.1 * (TimeOfGame - wh), 0.1)
-	
+
 /proc/month2number(month)
 	return month_names.Find(month)
+
+//Take a value in seconds and returns a string of minutes and seconds in the format X minute(s) and X seconds.
+/proc/seconds_to_time(var/seconds as num)
+	var/numSeconds = seconds % 60
+	var/numMinutes = (seconds - numSeconds) / 60
+	return "[numMinutes] [numMinutes > 1 ? "minutes" : "minute"] and [numSeconds] seconds."

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -277,7 +277,7 @@
 		dat += "Set Timer: [(setminute ? text("[setminute]:") : null)][setsecond]<br/>"
 
 	// Controls
-	dat += "<a href='?src=[UID()];settime=1'>Set Timer</a>"
+	dat += "<a href='?src=[UID()];settime=1'>Input Time</a>"
 
 	// Mounted flash controls
 	for(var/obj/machinery/flasher/F in targets)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -46,7 +46,7 @@
 						<center><small><b>Admission data:</b></small></center><br>
 						<small><b>Log generated at:</b>		[worldtime2text()]<br>
 						<b>Detainee:</b>		[logname]<br>
-						<b>Duration:</b>		[timetoset/10] seconds<br>
+						<b>Duration:</b>		[seconds_to_time(timetoset / 10)]<br>
 						<b>Charge(s):</b>	[logcharges]<br>
 						<b>Arresting Officer:</b>		[usr.name]<br><hr><br>
 						<small>This log file was generated automatically upon activation of a cell timer.</small>"}
@@ -55,7 +55,7 @@
 		cell_logs += P
 
 	var/datum/data/record/R = find_security_record("name", logname)
-	Radio.autosay("Detainee [logname] has been incarcerated for [timetoset/10] seconds for the charges of, '[logcharges]'. \
+	Radio.autosay("Detainee [logname] has been incarcerated for [seconds_to_time(timetoset / 10)] seconds for the charges of, '[logcharges]'. \
 	Arresting Officer: [usr.name].[R ? "" : " Detainee record not found, manual record update required."]", name, "Security", list(z))
 
 	if(R)
@@ -277,7 +277,7 @@
 		dat += "Set Timer: [(setminute ? text("[setminute]:") : null)][setsecond]<br/>"
 
 	// Controls
-	dat += "<a href='?src=[UID()];tp=-60'>-</a> <a href='?src=[UID()];tp=-1'>-</a> <a href='?src=[UID()];tp=1'>+</a> <A href='?src=[UID()];tp=60'>+</a><br/>"
+	dat += "<a href='?src=[UID()];settime=1'>Set Timer</a>"
 
 	// Mounted flash controls
 	for(var/obj/machinery/flasher/F in targets)
@@ -319,13 +319,9 @@
 			Radio.autosay("Timer stopped manually by [usr.name].", name, "Security", list(z))
 
 	else
-		if(href_list["tp"])  //adjust timer, close door if not already closed
-			var/tp = text2num(href_list["tp"])
-			var/addtime = (timetoset / 10)
-			addtime += tp
-			addtime = min(max(round(addtime), 0), 3600)
-
-			timeset(addtime)
+		if(href_list["settime"])
+			var/time = min(max(round(return_time_input(usr)), 0), 3600)
+			timeset(time)
 
 		if(href_list["fc"])
 			for(var/obj/machinery/flasher/F in targets)
@@ -368,6 +364,11 @@
 	overlays.Cut()
 	overlays += image('icons/obj/status_display.dmi', icon_state=picture_state)
 
+/obj/machinery/door_timer/proc/return_time_input()
+	var/mins = input(usr, "Minutes", "Enter number of minutes", 0) as num
+	var/seconds = input(usr, "Seconds", "Enter number of seconds", 0) as num
+	var/totaltime = (seconds + (mins * 60))
+	return totaltime
 
 //Checks to see if there's 1 line or 2, adds text-icons-numbers/letters over display
 // Stolen from status_display

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -55,7 +55,7 @@
 		cell_logs += P
 
 	var/datum/data/record/R = find_security_record("name", logname)
-	Radio.autosay("Detainee [logname] has been incarcerated for [seconds_to_time(timetoset / 10)] seconds for the charges of, '[logcharges]'. \
+	Radio.autosay("Detainee [logname] has been incarcerated for [seconds_to_time(timetoset / 10)] for the charges of, '[logcharges]'. \
 	Arresting Officer: [usr.name].[R ? "" : " Detainee record not found, manual record update required."]", name, "Security", list(z))
 
 	if(R)


### PR DESCRIPTION
I was asked to work on something along these lines by Spartan a while back but never really got around to it.

- Adds `seconds_to_time()` proc, which accepts a value of seconds as an argument and returns a string of `X minute(s) and X seconds`
- Replaces `-- ++` incremental controls with a single button which prompts two input boxes, one for minutes and seconds.
- Replaces values in seconds with minutes and seconds on the radio output and the printouts from security record computers.

Please note in the screenshot below I have replaced **"Set Timer"** with **"Input Time"** for a bit more clarity.
![2017-09-27_23-46-01](https://user-images.githubusercontent.com/25027759/30942020-40da69fe-a3e0-11e7-9b8c-19bc7fef3bf8.png)
![2017-09-27_23-45-38](https://user-images.githubusercontent.com/25027759/30942022-46364ee0-a3e0-11e7-9fdc-7af2bfdc227b.png)
![2017-09-27_23-45-50](https://user-images.githubusercontent.com/25027759/30942023-47cd4704-a3e0-11e7-97fa-540d18b2a03c.png)
![dreamseeker_2017-09-27_23-57-24](https://user-images.githubusercontent.com/25027759/30942030-4a6d3b90-a3e0-11e7-8d71-c084967fe8f2.png)
![dreamseeker_2017-09-27_23-57-35](https://user-images.githubusercontent.com/25027759/30942032-4c18d65c-a3e0-11e7-92a0-f67ed86affc8.png)

🆑 Birdtalon
tweak: User interface tweaks to Brig timers.
tweak: Seconds converted to minutes and seconds in Brig radio and security console printouts.
/🆑 