### PR TITLE
Alternative fix for the electrified arm

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -16,8 +16,9 @@
 			playsound(M, 'sound/weapons/Genhit.ogg', 50, 1)
 			return 0
 
-	if(!user.cell.use(charge_cost))
-		return
+	if(isrobot(user))
+		if(!user.cell.use(charge_cost))
+			return
 
 	user.do_attack_animation(M)
 	M.Weaken(5)


### PR DESCRIPTION
Alternative to #8135, does not attempt to balance the implant, just adds a sanity check to stop it from runtiming.
:cl:
Fix: Stops the electrified arm from combat and stunbaton implant from runtiming.
/:cl: