### PR TITLE
Fixes significant bag of holding exploit

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -38,6 +38,8 @@
 	max_w_class = WEIGHT_CLASS_HUGE
 	max_combined_w_class = 35
 	burn_state = FIRE_PROOF
+	cant_hold = list(/obj/item/weapon/storage/backpack/holding)
+	
 
 /obj/item/weapon/storage/backpack/holding/New()
 	..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -39,7 +39,6 @@
 	max_combined_w_class = 35
 	burn_state = FIRE_PROOF
 	cant_hold = list(/obj/item/weapon/storage/backpack/holding)
-	
 
 /obj/item/weapon/storage/backpack/holding/New()
 	..()


### PR DESCRIPTION
Fixes #8129 
There might be a better way to go about fixing this, if anyone has suggestions let me know. For the uninformed, view #8129 for details on the exploit. In short, it allowed for potentially infinite storage.

🆑 Imsxz
fix: Bag of holding can no longer hold bags of holding
/🆑 