### PR TITLE
Fixes vampires enthralling the chaplain

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -313,6 +313,7 @@
 		return 0
 	if(!affects(C))
 		C.visible_message("<span class='warning'>[C] seems to resist the takeover!</span>", "<span class='notice'>Your faith of [ticker.Bible_deity_name] has kept your mind clear of all evil.</span>")
+		return 0
 	if(!ishuman(C))
 		to_chat(user, "<span class='warning'>You can only enthrall humans!</span>")
 		return 0


### PR DESCRIPTION
Someone forgot to "return", allowing vampires to enthrall chaplains.

🆑 Imsxz
fix: Vampires can no longer enthrall chaplains
/🆑 