### PR TITLE
Shadowling Passive Healing now heals eye damage

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -329,6 +329,9 @@ Made by Xhuis
 				H << 'sound/weapons/sear.ogg'
 		else if(light_amount < LIGHT_HEAL_THRESHOLD)
 			H.clear_alert("lightexposure")
+			var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
+			if(istype(E))
+				E.take_damage(-1)
 			H.heal_overall_damage(5, 5)
 			H.adjustToxLoss(-5)
 			H.adjustBrainLoss(-25) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -332,6 +332,8 @@ Made by Xhuis
 			H.heal_overall_damage(5, 5)
 			H.adjustToxLoss(-5)
 			H.adjustBrainLoss(-25) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"
+			H.AdjustEyeBlurry(-1)
+			H.AdjustEarDamage(-1)
 			H.adjustCloneLoss(-1)
 			H.SetWeakened(0)
 			H.SetStunned(0)

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -333,7 +333,8 @@ Made by Xhuis
 			H.adjustToxLoss(-5)
 			H.adjustBrainLoss(-25) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"
 			H.AdjustEyeBlurry(-1)
-			H.AdjustEarDamage(-1)
+			H.CureNearsighted()
+			H.CureBlind()
 			H.adjustCloneLoss(-1)
 			H.SetWeakened(0)
 			H.SetStunned(0)


### PR DESCRIPTION
Exactly what it says on the title.

EDIT: This is a response to the fact that spamming flashes near Shadowlings more or less turns into a battle of attrition that inevitably ends with the Shadowling going blind unless they also manage to get a thrall to perform eye surgery on them.

EDIT 2: Even with this change, blinding Shadowlings is fully possible, albeit only temporarily, so the flash spam is still a viable way of quickly getting rid of a Shadowling. They will not, however, be permanently fucked because of it.

:cl:
add: Shadowlings now passively heal eye damage, eye blurriness
/:cl: