### PR TITLE
Plasmamen Shadowlings no longer burn to death

### DIFF
--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -96,6 +96,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 
 				sleep(10)
 				to_chat(H, "<span class='shadowling'><b><i>Your powers are awoken. You may now live to your fullest extent. Remember your goal. Cooperate with your thralls and allies.</b></i></span>")
+				H.rejuvenate()
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_vision(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/enthrall(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/glare(null))

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -96,7 +96,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 
 				sleep(10)
 				to_chat(H, "<span class='shadowling'><b><i>Your powers are awoken. You may now live to your fullest extent. Remember your goal. Cooperate with your thralls and allies.</b></i></span>")
-				H.rejuvenate()
+				H.ExtinguishMob()
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_vision(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/enthrall(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/glare(null))


### PR DESCRIPTION
Exactly what it says on the title, again. Shadowlings are rejuvenated immediately after hatching, clearing prior status effects (such as the Plasmamen fire stacks).

:cl:
add: Shadowlings are extinguished after hatching, allowing Plasmamen Shadowlings to not burn to death.
/:cl: