### PR TITLE
Increase energy cost of cyborg's laser & disabler

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -11,6 +11,9 @@
 	projectile_type = /obj/item/projectile/beam/laser
 	select_name = "kill"
 
+/obj/item/ammo_casing/energy/laser/cyborg //to balance cyborg energy cost seperately
+    e_cost = 300
+
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/item/projectile/beam/laser
 	e_cost = 83
@@ -125,6 +128,9 @@
 	select_name  = "disable"
 	e_cost = 50
 	fire_sound = 'sound/weapons/taser2.ogg'
+
+/obj/item/ammo_casing/energy/disabler/cyborg //seperate balancing for cyborg, again
+	e_cost = 300
 
 /obj/item/ammo_casing/energy/plasma
 	projectile_type = /obj/item/projectile/plasma

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -12,7 +12,7 @@
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/cyborg //to balance cyborg energy cost seperately
-    e_cost = 300
+    e_cost = 250
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/item/projectile/beam/laser
@@ -130,7 +130,7 @@
 	fire_sound = 'sound/weapons/taser2.ogg'
 
 /obj/item/ammo_casing/energy/disabler/cyborg //seperate balancing for cyborg, again
-	e_cost = 300
+	e_cost = 250
 
 /obj/item/ammo_casing/energy/plasma
 	projectile_type = /obj/item/projectile/plasma

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -46,6 +46,7 @@
 /obj/item/weapon/gun/energy/laser/cyborg
 	can_charge = 0
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/cyborg)
 	origin_tech = null
 
 /obj/item/weapon/gun/energy/laser/cyborg/newshot()

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -52,6 +52,7 @@
 /obj/item/weapon/gun/energy/disabler/cyborg
 	name = "cyborg disabler"
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/cyborg)
 	can_charge = 0
 
 /obj/item/weapon/gun/energy/disabler/cyborg/newshot()


### PR DESCRIPTION
First PR.

Make two new type of ammo_casing, specifically for cyborg only.

They both costs 250 charge to fire. The original value is 50 (For disabler) and 83 (For laser)

Disabler is no longer cheaper than laser as it is often more useful than a laser, taking only 3 shot to down a person instead of 5. 

While unable to deter potato cyborg from mowing down the entire station, this should make most borg have to care more about energy usage while firing their lazers / disabler.

EDIT 1: Value changed to 250 on 10/3/2017. Here's two chart portraying what the change may mean for you.

BEFORE: 
![](https://i.imgur.com/YEQKJOS.png)
AFTER: 
![](https://i.imgur.com/L9SLx8R.png)

:cl:Ansari
Increase energy cost for cyborg disabler and laser to 250.
/:cl: