### PR TITLE
Gambling never pay

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -47,14 +47,14 @@
 		if(operation == 1) // Play
 			if(working == 1)
 				return
-			if(!account || account.money < 10)
+			if(!account || account.money < 100)
 				return
-			if(!account.charge(10, transaction_purpose = "Bet", dest_name = name))
+			if(!account.charge(100, transaction_purpose = "Bet", dest_name = name))
 				return
 			plays += 1
 			working = 1
 			icon_state = "slots-on"
-			var/roll = rand(1,1350)
+			var/roll = rand(1,20000)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			spawn(25)
 				if(roll == 1)


### PR DESCRIPTION
Make it impossible, on average, to earn money from playing slot machine. Just like real gambling, the house always win.

The odd divisor (Whatever the term is) changed to 20,000 from 1,350.

The bet amount changed to 100 from 10. 

(Assuming I got the math correctly)
Before: 
![](https://i.imgur.com/e05IV3V.png)
After: 
![](https://i.imgur.com/lfjzAv3.png)

:cl:Ansari
Slot machine no longer earn you money on average. Like real gambling.
:cl: