### PR TITLE
Nerf yellow slime cell & Buff ion thruster 

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -171,6 +171,7 @@
 	icon_state = "yellow slime extract"
 	materials = list()
 	self_recharge = 1 // Infused slime cores self-recharge, over time
+	chargerate = 500
 
 /obj/item/weapon/stock_parts/cell/pulse //200 pulse shots
 	name = "pulse rifle power cell"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -490,7 +490,7 @@ var/list/robot_verbs_default = list(
 		toggle_ionpulse()
 		return
 
-	cell.charge -= 50 // 500 steps on a default cell.
+	cell.charge -= 25 // 500 steps on a default cell.
 	return 1
 
 /mob/living/silicon/robot/proc/toggle_ionpulse()


### PR DESCRIPTION
Yellow slime cell's **charge rate** has been changed to **500** from **1500**. 

**Ion thrusters'** cost has been **reduced** to **50** from **100**. I feel like for a thruster that only moved you one tile, without imparting any momentum (unlike a disabler shot etc.), it was a bit too weak. Now at 50 cost it should make for a more efficient thruster to use during tactical manouever, but efficiency is still horrid for long-range travel (And you should be using disabler for that)

EDIT1: I am posting some test results here: 
Test condition: Emagged borg, var-edited cell, headlamp = 5, all modules activated:
Capacity: 10,000
Self_recharge = 1
Energy cost per shot = **250**
At charge rate **1500**:
**139** shots were fired non-stop
At charge rate **500**:
**53** shots were fired non-stop

Durand & Space Pod test:
Durand moving while firing with solaris cannon, with a **500** charge rate self-charging cell: **Infinite** endurance, or close to infinite.

Space pod: 
**23** shots before stopping.

I believe yellow slime core is in fact, overpowered as a result, as they practically completely negate energy management save for the most ridiculous of scenario (e.g. harmbatoning someone non-stop as a secborg). The nerf will hopefully make them have to care about energy management in **some** scenario.