### PR TITLE
More consistent alien spawning

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -1,12 +1,10 @@
 /datum/event/alien_infestation
 	announceWhen	= 400
-	var/spawncount = 1
+	var/spawncount = 2
 	var/successSpawn = 0	//So we don't make a command report if nothing gets spawned.
 
 /datum/event/alien_infestation/setup()
 	announceWhen = rand(announceWhen, announceWhen + 50)
-	if(prob(50))
-		spawncount++
 
 /datum/event/alien_infestation/announce()
 	if(successSpawn)


### PR DESCRIPTION
More often than not, in my experience, xenos get stomped early into their spawning usually due to inexperience or station competence. This is a small balance change that should hopefully buff aliens a bit by removing some RNG in their spawning when the event is first initiated. Rather than only 1 alien spawning with a 50% chance of a second alien, there is now ALWAYS 2 aliens spawning. 

:cl: imsxz
tweak: Aliens now always spawn as a pair when their infestation event begins.
/:cl: 