### PR TITLE
Buffs farting.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -74,7 +74,7 @@
 
 		if("scream", "screams")
 			on_CD = handle_emote_CD(50) //longer cooldown
-		if("fart", "farts", "flip", "flips", "snap", "snaps")
+		if("flip", "flips", "snap", "snaps")
 			on_CD = handle_emote_CD()				//proc located in code\modules\mob\emote.dm
 		if("cough", "coughs")
 			on_CD = handle_emote_CD()


### PR DESCRIPTION
Since fart doesn't have a noise, animation, or otherwise stuff that needs a cooldown, I decided that it would be better off without a cooldown. *fart

Revert this ~~when~~ if we add a fart noise.

🆑 Imsxz
tweak: Removes farting cooldown.
/🆑 