### PR TITLE
Black gloves mangling

### DIFF
--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -77,13 +77,18 @@
 /obj/item/clothing/gloves/color/black/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/weapon/wirecutters))
 		if(can_be_cut && icon_state == initial(icon_state))//only if not dyed
-			to_chat(user, "<span class='notice'>You snip the fingertips off of [src].</span>")
-			playsound(user.loc, W.usesound, rand(10,50), 1)
-			var/obj/item/clothing/gloves/fingerless/F = new/obj/item/clothing/gloves/fingerless(user.loc)
-			if(pickpocket)
-				F.pickpocket = 1
-			qdel(src)
-			return
+			var/confirm = alert("Do you want to cut off the gloves fingertips? Warning: It might destroy their functionality.","Cut tips?","Yes","No")
+			if(get_dist(user, src) > 1)
+				to_chat(user, "You have moved too far away.")
+				return
+			if(confirm == "Yes")
+				to_chat(user, "<span class='notice'>You snip the fingertips off of [src].</span>")
+				playsound(user.loc, W.usesound, rand(10,50), 1)
+				var/obj/item/clothing/gloves/fingerless/F = new/obj/item/clothing/gloves/fingerless(user.loc)
+				if(pickpocket)
+					F.pickpocket = FALSE
+				qdel(src)
+				return
 	..()
 
 /obj/item/clothing/gloves/color/orange

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -151,6 +151,7 @@ datum/martial_art/krav_maga/grab_act(var/mob/living/carbon/human/A, var/mob/livi
 
 /obj/item/clothing/gloves/color/black/krav_maga
 	var/datum/martial_art/krav_maga/style = new
+	can_be_cut = FALSE
 
 /obj/item/clothing/gloves/color/black/krav_maga/equipped(mob/user, slot)
 	if(!ishuman(user))


### PR DESCRIPTION
Gives the choice whether to completely cut of finger, or to just mangle them, when you apply wirecutters to types of black gloves. While the supposed effect between the options is quite similar, complete cutting does generate new gloves, and such, special effects of the gloves can be lost.
Krav Maga gloves were made to only be mangleable, to stop destruction of them, and turning red gloves into black ones by cutting a piece off.
:cl:
Add: Gives a choice whether to mangle black gloves, or to completely cut of the fingertips
/:cl: