### PR TITLE
pAI cannot be inserted into MULE anymore

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -47,6 +47,7 @@
 	var/bloodiness = 0
 	var/currentBloodColor = "#A10808"
 	var/currentDNA = null
+	allow_pai = 0
 
 /mob/living/simple_animal/bot/mulebot/New()
 	..()


### PR DESCRIPTION
As per title.

Mulebot, when used by a pAI, often become a nearly unstoppable death machine that deal 8 ticks of weaken and can kill people within nearly two hits. 

I believe those stats are fine if it is a niche usage done by PDA-savvy people / AI, but not by someone who can easily control it to roll over people precisely with WASD. 

The fact that during the past two days, PAI mulebot were used to great effect against war op (Who are equipped with effective gun, unlike 90% of antags, crew and sometime security member), killing at least 1 - 2 members each try, should be proof that pAI mulebot is just too strong.

🆑 Ansari
tweak: pAI can no longer be inserted into Mulebot.
/🆑 