### PR TITLE
War OP TC now scale to amount of players

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,7 +1,7 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define CHALLENGE_TIME_LIMIT 6000
 #define CHALLENGE_SCALE_PLAYER 1 // How many player per scaling bonus
-#define CHALLENGE_SCALE_BONUS 4 // How many TC per scaling bonus
+#define CHALLENGE_SCALE_BONUS 2 // How many TC per scaling bonus
 #define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 //25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,3 +1,5 @@
+#define CHALLENGE_TELECRYSTALS 280
+#define CHALLENGE_SCALE_FACTOR 1 // For ease of balancing the TC scaling from war ops
 #define CHALLENGE_TIME_LIMIT 6000
 #define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 //25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
@@ -52,7 +54,7 @@
 
 	var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(get_turf(user))
 	U.hidden_uplink.uplink_owner= "[user.key]"
-	U.hidden_uplink.uses = 280
+	U.hidden_uplink.uses = CHALLENGE_TELECRYSTALS + (((player_list.len * 4) - CHALLENGE_MIN_PLAYERS * 4) * CHALLENGE_SCALE_FACTOR) // Add 4 telecrystals per player above CHLALENGE_MIN_PLAYERS (50). Scale factor multiply it.
 	config.shuttle_refuel_delay = CHALLENGE_SHUTTLE_DELAY
 	qdel(src)
 
@@ -78,3 +80,5 @@
 #undef CHALLENGE_TIME_LIMIT
 #undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY
+#undef CHALLENGE_TELECRYSTALS
+#undef CHALLENGE_SCALE_FACTOR

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,6 +1,7 @@
 #define CHALLENGE_TELECRYSTALS 280
-#define CHALLENGE_SCALE_FACTOR 1 // For ease of balancing the TC scaling from war ops
 #define CHALLENGE_TIME_LIMIT 6000
+#define CHALLENGE_SCALE_PLAYER 1 // How many player per scaling bonus
+#define CHALLENGE_SCALE_BONUS 4 // How many TC per scaling bonus
 #define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 //25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
@@ -48,13 +49,14 @@
 	event_announcement.Announce(war_declaration, "Declaration of War", 'sound/effects/siren.ogg')
 
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
+	to_chat(user, "<b>Look below you on the floor for the extra uplink</b>")
 
 	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
 		S.challenge = TRUE
 
 	var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(get_turf(user))
 	U.hidden_uplink.uplink_owner= "[user.key]"
-	U.hidden_uplink.uses = CHALLENGE_TELECRYSTALS + (((player_list.len + CHALLENGE_MIN_PLAYERS) * 4) * CHALLENGE_SCALE_FACTOR) // Add 4 telecrystals per player above CHLALENGE_MIN_PLAYERS (50). Scale factor multiply it.
+	U.hidden_uplink.uses = CHALLENGE_TELECRYSTALS + round((((player_list.len - CHALLENGE_MIN_PLAYERS)/CHALLENGE_SCALE_PLAYER) * CHALLENGE_SCALE_BONUS)) // No. of player - Min. Player to dec, divided by player per bonus, then multipled by TC per bonus. Rounded.
 	config.shuttle_refuel_delay = CHALLENGE_SHUTTLE_DELAY
 	qdel(src)
 
@@ -81,4 +83,5 @@
 #undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY
 #undef CHALLENGE_TELECRYSTALS
-#undef CHALLENGE_SCALE_FACTOR
+#undef CHALLENGE_SCALE_PLAYER
+#undef CHALLENGE_SCALE_BONUS

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -54,7 +54,7 @@
 
 	var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(get_turf(user))
 	U.hidden_uplink.uplink_owner= "[user.key]"
-	U.hidden_uplink.uses = CHALLENGE_TELECRYSTALS + (((player_list.len * 4) - CHALLENGE_MIN_PLAYERS * 4) * CHALLENGE_SCALE_FACTOR) // Add 4 telecrystals per player above CHLALENGE_MIN_PLAYERS (50). Scale factor multiply it.
+	U.hidden_uplink.uses = CHALLENGE_TELECRYSTALS + (((player_list.len + CHALLENGE_MIN_PLAYERS) * 4) * CHALLENGE_SCALE_FACTOR) // Add 4 telecrystals per player above CHLALENGE_MIN_PLAYERS (50). Scale factor multiply it.
 	config.shuttle_refuel_delay = CHALLENGE_SHUTTLE_DELAY
 	qdel(src)
 


### PR DESCRIPTION
Amount of telecrystals from war declaration now scale partially to the amount of player.

The original number is a flat 280.

The new number is a 280 + 2 per player above 50. 

Might replace with a better algorithm in the future, but this should give more incentive to go war op on high pop and make it easier to win against a massive amount of heavily armed, angry greytide.

Also add in a bolded message to tell the WarOP leader the uplink spawned below them.

🆑Ansari
tweak: TC from war op increased by 2 per player above 50.
/🆑  