### PR TITLE
Portal beam don't detonate tank anymore

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -206,7 +206,7 @@
 	damage = 0
 	var/obj/item/weapon/gun/energy/wormhole_projector/gun
 	color = "#33CCFF"
-	nodamage = 1
+	nodamage = TRUE
 
 /obj/item/projectile/beam/wormhole/orange
 	name = "orange bluespace beam"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -203,9 +203,10 @@
 	name = "bluespace beam"
 	icon_state = "spark"
 	hitsound = "sparks"
-	damage = 3
+	damage = 0
 	var/obj/item/weapon/gun/energy/wormhole_projector/gun
 	color = "#33CCFF"
+	nodamage = 1
 
 /obj/item/projectile/beam/wormhole/orange
 	name = "orange bluespace beam"


### PR DESCRIPTION
Fixes #8209 

Add in a no_damage tag for portal beam, change damage from 3 to 0. Not like that 3 damage matter at all.

🆑Ansari
Portal beam no longer detonate fuel tank.
/🆑 