### PR TITLE
Fix UI inconsistency on slot machine.

### DIFF
--- a/nano/templates/slotmachine.tmpl
+++ b/nano/templates/slotmachine.tmpl
@@ -12,10 +12,10 @@ Used In File(s): /code/game/machinery/slotmachine.dm
 	</div>
 	<div class="item">
 		<div class="statusLabel">
-			Ten credits to play!
+			Hundred credits to play!
 		</div>
 		<div class="statusValue">
-			{{:helper.link('SPIN!', 'refresh', {'ops' : 1}, data.money >= 10 && !data.working ? null : 'disabled')}}
+			{{:helper.link('SPIN!', 'refresh', {'ops' : 1}, data.money >= 100 && !data.working ? null : 'disabled')}}
 		</div>
 	</div>
 	{{if data.result}}
@@ -29,6 +29,6 @@ Used In File(s): /code/game/machinery/slotmachine.dm
 {{else}}
 	<div class="notice">
 		Could not scan your card or could not find account!<br>
-		Please wear or hold your ID and try again.
+		Please wear or hold your ID and try again.	
 	</div>
 {{/if}}


### PR DESCRIPTION
Fix an issue with #8182 

The slot machine UI now display 100 credits to play instead of ten.

CL is the slot machine one because I cannot write CL properly and it was never logged.

🆑
tweak: Slot machine no longer earn money on average. Bet changed to 100.
/🆑 