### PR TITLE
Nerf revenant defile window damage

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -263,7 +263,7 @@
 					new/obj/effect/overlay/temp/revenant(T)
 					T.ChangeTurf(/turf/simulated/wall/r_wall/rust)
 				for(var/obj/structure/window/window in T.contents)
-					window.hit(rand(30,80))
+					window.hit(rand(20,30))
 					if(window && window.is_fulltile())
 						new/obj/effect/overlay/temp/revenant/cracks(window.loc)
 				for(var/obj/structure/closet/closet in T.contents)


### PR DESCRIPTION
As per title. Revenant's defile does 30 - 80 damage to all windows in an AOE. This allow them to become a force of mass destruction spacing security and cargo constantly, and possibly other parts of the station.

This just tone it down so that it average out at four hits instead of two, making revenant less able to atmos-troll the crew.

🆑
tweak: Reduce revenant damage on window to an average of 25 instead of 55.
/🆑 