### PR TITLE
Nuke Op items discount & rebalance

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -236,7 +236,7 @@ var/list/uplink_items = list()
 	desc = "A box containing 6 shotgun shells that simulate the effects of extreme drunkenness on the target, more effective for each type of alcohol in the target's system."
 	reference = "BSS"
 	item = /obj/item/weapon/storage/box/syndie_kit/boolets
-	cost = 4
+	cost = 3
 	job = list("Bartender")
 
 //Barber

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -466,7 +466,7 @@ var/list/uplink_items = list()
 	desc = "A box full of preloaded syringes, containing various chemicals that seize up the victim's motor and broca system , making it impossible for them to move or speak while in their system."
 	reference = "BTS"
 	item = /obj/item/weapon/storage/box/syndie_kit/bioterror
-	cost = 6
+	cost = 5
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/saringrenades
@@ -474,7 +474,7 @@ var/list/uplink_items = list()
 	desc = "A box of four (4) grenades filled with Sarin, a deadly neurotoxin. Use extreme caution when handling and be sure to vacate the premise after using; ensure communication is maintained with team to avoid accidental gassings."
 	reference = "TGG"
 	item = /obj/item/weapon/storage/box/syndie_kit/sarin
-	cost = 15
+	cost = 12
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
@@ -698,7 +698,7 @@ var/list/uplink_items = list()
 	desc = "A 3-round magazine of soporific ammo designed for use with .50 sniper rifles. Put your enemies to sleep today!"
 	reference = "50S"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/soporific
-	cost = 6
+	cost = 3
 
 /datum/uplink_item/ammo/sniper/haemorrhage
 	name = ".50 Haemorrhage Magazine"
@@ -783,6 +783,15 @@ var/list/uplink_items = list()
 	item = /obj/item/weapon/gun/syringe/syndicate
 	cost = 4
 	surplus = 50
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/stealthy_weapons/RSG
+	name = "Rapid Syringe Gun"
+	desc = "A rapid syringe gun able to hold six shot and fire them rapidly. Great together with the bioterror syringe"
+	reference = "RSG"
+	item = /obj/item/weapon/gun/syringe/rapidsyringe
+	cost = 4
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/detomatix
 	name = "Detomatix PDA Cartridge"
@@ -968,7 +977,7 @@ var/list/uplink_items = list()
 	and other medical supplies helpful for a medical field operative."
 	reference = "SCMK"
 	item = /obj/item/weapon/storage/firstaid/tactical
-	cost = 9
+	cost = 7
 	gamemodes = list(/datum/game_mode/nuclear)
 
 //Space Suits and Hardsuits
@@ -1138,7 +1147,7 @@ var/list/uplink_items = list()
 	desc = "A printed circuit board that completes the teleporter onboard the mothership. Advise you test fire the teleporter before entering it, as malfunctions can occur."
 	item = /obj/item/weapon/circuitboard/teleporter
 	reference = "TP"
-	cost = 40
+	cost = 20
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
@@ -1147,7 +1156,7 @@ var/list/uplink_items = list()
 	desc = "Use to select the landing zone of your assault pod."
 	item = /obj/item/device/assault_pod
 	reference = "APT"
-	cost = 30
+	cost = 25
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1036,7 +1036,7 @@ var/list/uplink_items = list()
 	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary."
 	reference = "BITK"
 	item = /obj/item/device/encryptionkey/binary
-	cost = 3
+	cost = 5
 	surplus = 75
 
 /datum/uplink_item/device_tools/cipherkey

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -357,7 +357,7 @@ var/list/uplink_items = list()
 	reference = "SPI"
 	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible with suppressors."
 	item = /obj/item/weapon/gun/projectile/automatic/pistol
-	cost = 3
+	cost = 4
 
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate .357 Revolver"
@@ -996,6 +996,7 @@ var/list/uplink_items = list()
 	reference = "BRHS"
 	item = /obj/item/weapon/storage/box/syndie_kit/hardsuit
 	cost = 8
+	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/suits/hardsuit/elite
 	name = "Elite Syndicate Hardsuit"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -236,7 +236,7 @@ var/list/uplink_items = list()
 	desc = "A box containing 6 shotgun shells that simulate the effects of extreme drunkenness on the target, more effective for each type of alcohol in the target's system."
 	reference = "BSS"
 	item = /obj/item/weapon/storage/box/syndie_kit/boolets
-	cost = 2
+	cost = 4
 	job = list("Bartender")
 
 //Barber
@@ -357,7 +357,7 @@ var/list/uplink_items = list()
 	reference = "SPI"
 	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible with suppressors."
 	item = /obj/item/weapon/gun/projectile/automatic/pistol
-	cost = 4
+	cost = 3
 
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate .357 Revolver"
@@ -457,7 +457,7 @@ var/list/uplink_items = list()
 	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred any non-operatives in the area."
 	reference = "VDG"
 	item = /obj/item/weapon/grenade/spawnergrenade/manhacks
-	cost = 7
+	cost = 6
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 35
 
@@ -608,7 +608,7 @@ var/list/uplink_items = list()
 	desc = "A speed loader that contains seven additional .357 Magnum rounds for the syndicate revolver. For when you really need a lot of things dead."
 	reference = "357"
 	item = /obj/item/ammo_box/a357
-	cost = 4
+	cost = 3
 
 /datum/uplink_item/ammo/smg
 	name = "Magazine - .45"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -134,7 +134,7 @@ var/list/uplink_items = list()
 	desc = "A specialized, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes with 6 special darts and a preloaded shrapnel round."
 	reference = "MCS"
 	item = /obj/item/weapon/storage/box/syndie_kit/caneshotgun
-	cost = 15
+	cost = 10
 	job = list("Mime")
 
 //Chef
@@ -216,7 +216,7 @@ var/list/uplink_items = list()
 	desc = "The feral cat delivery grenade contains 8 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
 	item = /obj/item/weapon/grenade/spawnergrenade/feral_cats
 	reference = "CCLG"
-	cost = 5
+	cost = 4
 	job = list("Psychiatrist")//why? Becuase its funny that a person in charge of your mental wellbeing has a cat granade..
 
 //Assistant
@@ -236,7 +236,7 @@ var/list/uplink_items = list()
 	desc = "A box containing 6 shotgun shells that simulate the effects of extreme drunkenness on the target, more effective for each type of alcohol in the target's system."
 	reference = "BSS"
 	item = /obj/item/weapon/storage/box/syndie_kit/boolets
-	cost = 6
+	cost = 2
 	job = list("Bartender")
 
 //Barber
@@ -417,7 +417,7 @@ var/list/uplink_items = list()
 	desc = "A flamethrower, fuelled by a portion of highly flammable bio-toxins stolen previously from Nanotrasen stations. Make a statement by roasting the filth in their own greed. Use with caution."
 	reference = "FT"
 	item = /obj/item/weapon/flamethrower/full/tank
-	cost = 11
+	cost = 8
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 40
 
@@ -457,7 +457,7 @@ var/list/uplink_items = list()
 	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred any non-operatives in the area."
 	reference = "VDG"
 	item = /obj/item/weapon/grenade/spawnergrenade/manhacks
-	cost = 8
+	cost = 7
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 35
 
@@ -726,7 +726,7 @@ var/list/uplink_items = list()
 			will instantly put them in your grasp and silence them, as well as causing rapid suffocation. Does not work on those who do not need to breathe."
 	reference = "GAR"
 	item = /obj/item/weapon/twohanded/garrote
-	cost = 12
+	cost = 10
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
@@ -1026,7 +1026,7 @@ var/list/uplink_items = list()
 	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary."
 	reference = "BITK"
 	item = /obj/item/device/encryptionkey/binary
-	cost = 5
+	cost = 3
 	surplus = 75
 
 /datum/uplink_item/device_tools/cipherkey
@@ -1042,7 +1042,7 @@ var/list/uplink_items = list()
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
 	reference = "HAI"
 	item = /obj/item/weapon/aiModule/syndicate
-	cost = 14
+	cost = 12
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"
@@ -1083,7 +1083,7 @@ var/list/uplink_items = list()
 			sends you a small beacon that will teleport the larger beacon to your location upon activation."
 	reference = "SNGB"
 	item = /obj/item/device/radio/beacon/syndicate
-	cost = 14
+	cost = 12
 	surplus = 0
 
 /datum/uplink_item/device_tools/syndicate_bomb

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -134,7 +134,7 @@ var/list/uplink_items = list()
 	desc = "A specialized, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes with 6 special darts and a preloaded shrapnel round."
 	reference = "MCS"
 	item = /obj/item/weapon/storage/box/syndie_kit/caneshotgun
-	cost = 10
+	cost = 15
 	job = list("Mime")
 
 //Chef
@@ -216,7 +216,7 @@ var/list/uplink_items = list()
 	desc = "The feral cat delivery grenade contains 8 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
 	item = /obj/item/weapon/grenade/spawnergrenade/feral_cats
 	reference = "CCLG"
-	cost = 4
+	cost = 5
 	job = list("Psychiatrist")//why? Becuase its funny that a person in charge of your mental wellbeing has a cat granade..
 
 //Assistant
@@ -236,7 +236,7 @@ var/list/uplink_items = list()
 	desc = "A box containing 6 shotgun shells that simulate the effects of extreme drunkenness on the target, more effective for each type of alcohol in the target's system."
 	reference = "BSS"
 	item = /obj/item/weapon/storage/box/syndie_kit/boolets
-	cost = 3
+	cost = 6
 	job = list("Bartender")
 
 //Barber
@@ -608,7 +608,7 @@ var/list/uplink_items = list()
 	desc = "A speed loader that contains seven additional .357 Magnum rounds for the syndicate revolver. For when you really need a lot of things dead."
 	reference = "357"
 	item = /obj/item/ammo_box/a357
-	cost = 3
+	cost = 4
 
 /datum/uplink_item/ammo/smg
 	name = "Magazine - .45"
@@ -726,7 +726,7 @@ var/list/uplink_items = list()
 			will instantly put them in your grasp and silence them, as well as causing rapid suffocation. Does not work on those who do not need to breathe."
 	reference = "GAR"
 	item = /obj/item/weapon/twohanded/garrote
-	cost = 10
+	cost = 12
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
@@ -1093,7 +1093,7 @@ var/list/uplink_items = list()
 			sends you a small beacon that will teleport the larger beacon to your location upon activation."
 	reference = "SNGB"
 	item = /obj/item/device/radio/beacon/syndicate
-	cost = 12
+	cost = 14
 	surplus = 0
 
 /datum/uplink_item/device_tools/syndicate_bomb

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -165,12 +165,11 @@
 /obj/item/weapon/storage/firstaid/tactical/New()
 	..()
 	if(empty) return
-	new /obj/item/clothing/accessory/stethoscope( src )
-	new /obj/item/weapon/defibrillator/compact/combat/loaded(src)
 	new /obj/item/weapon/reagent_containers/hypospray/combat(src)
-	new /obj/item/weapon/reagent_containers/food/pill/patch/styptic(src)
-	new /obj/item/weapon/reagent_containers/food/pill/patch/silver_sulf(src)
-	new /obj/item/weapon/reagent_containers/ld50_syringe/lethal(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src) // Because you ain't got no time to look at what damage dey taking yo
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 	return
 

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -170,6 +170,7 @@
 	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
 	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
 	new /obj/item/weapon/reagent_containers/food/pill/patch/synthflesh(src)
+	new /obj/item/weapon/defibrillator/compact/combat/loaded(src)
 	new /obj/item/clothing/glasses/hud/health/night(src)
 	return
 


### PR DESCRIPTION
Reduce cost for some underappreciated items in the nukie arsenal. Also remove syndicate hardsuit from the nuke op purchase list, as it is just a redundant noob trap. Traitor items split off into #8315

Feedback highly welcome, since I am not an expert on this. No cost increase are intended, I'd rather see underappreciated items used more. 

List of price changes:

**Nuke op:**
Flamethrower (For nukie): 11 -> 8 (The fact that they cost as much as a SMG seems to make em a bit too costly, given their much lower destructive potential. They do have CC potential so I am not sure though)
Viscerator: 8 -> 6 (Too costly for its effect and vulnerability)
Assault pod: 30 -> 25 
Teleporter: 40 -> 20 (Way too expensive for something you can do for free)
Soporific .50: 6 -> 3 (For some non-lethal round that doesn't even fit with a loud as fuck sniper, they are 50% more expensive than normal ammo.)
Sarin gas: 15 -> 12 (Compared to atmos nade, they are more expensive and less mass destructive, even though you get four of them. Besides, they are also timed and not cluster) 
Combat Medkit: 9 -> 7. Stetho & lethal syringe removed. Burn & brute patch replaced with four synthflesh patch. 
Syndicate Hardsuit: **Removed from nuclear op due to being a noob trap**
Dart gun: Removed from nukie
Rapid Syringe Gun: Added to nukie for 4 TC

🆑
tweak: A lot of underused nuke op items made cheaper.
tweak: Syndicate hardsuit removed from nuke op because you already got one free.
tweak: Tactical medkit give you four synthflesh patch, no more stetho or lethal syringe.
add: RSG added to nuke op uplink. Dart gun no longer available.
/🆑 