### PR TITLE
Diona are no longer valid for transformation sting

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -799,7 +799,7 @@
 	even the simplest concepts of other minds. Their alien physiology allows them survive happily off a diet of nothing but light, \
 	water and other radiation."
 
-	species_traits = list(NO_BREATHE, RADIMMUNE, IS_PLANT, NO_BLOOD, NO_PAIN)
+	species_traits = list(NO_BREATHE, RADIMMUNE, IS_PLANT, NO_BLOOD, NO_PAIN, NOTRANSSTING)
 	clothing_flags = HAS_SOCKS
 	dietflags = 0		//Diona regenerate nutrition in light, no diet necessary
 	taste_sensitivity = TASTE_SENSITIVITY_NO_TASTE


### PR DESCRIPTION
Because transformation sting is there to cause chaos, not to act as a free CC technique, slowdown & vulernability machine.

Diona's gameplay mechanic are too drastically different from baseline species for it to be usable in transformation sting.

🆑
tweak: Diona no longer valid species for transformation sting anymore.
/🆑 