### PR TITLE
Mini ballistic rebalance

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -118,7 +118,7 @@
 	desc = "A 12 gauge lead slug."
 	icon_state = "blshell"
 	caliber = "shotgun"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/slug
 	materials = list(MAT_METAL=4000)
 
 
@@ -128,7 +128,7 @@
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet
 	pellets = 6
-	variance = 25
+	variance = 40 // Lower accuracy tradeoff for buckshot versus slug
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
@@ -155,7 +155,7 @@
 	projectile_type = /obj/item/projectile/bullet/pellet/weak
 	materials = list(MAT_METAL=250)
 	pellets = 10
-	variance = 25
+	variance = 40 // Would not make sense if somehow improvised shell is more accurate than buckshot.
 
 
 /obj/item/ammo_casing/shotgun/improvised/overload

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -109,7 +109,6 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = 0
-	burst_size = 2
 	actions_types = list()
 
 /obj/item/weapon/gun/projectile/automatic/wt550/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -109,7 +109,7 @@
 	mag_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = 0
-	burst_size = 1
+	burst_size = 2
 	actions_types = list()
 
 /obj/item/weapon/gun/projectile/automatic/wt550/update_icon()

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -37,7 +37,7 @@
 	stamina = 60
 	icon_state = "bullet-r"
 
-/obj/item/projectile/bullet/weakbullet3
+/obj/item/projectile/bullet/weakbullet3 // WT-550 standard round & Turret
 	damage = 20
 
 /obj/item/projectile/bullet/weakbullet4
@@ -47,7 +47,7 @@
 	icon_state = "bullet-r"
 
 /obj/item/projectile/bullet/toxinbullet
-	damage = 15
+	damage = 20
 	damage_type = TOX
 
 /obj/item/projectile/bullet/incendiary
@@ -66,12 +66,18 @@
 	damage = 17
 	armour_penetration = 10
 
+/obj/item/projectile/bullet/slug // For seperate balancing of shotgun slug from syndicate revolver
+	damage = 60
+	armour_penetration = 10
+
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
 	damage = 12.5
+	armour_penetration = -10 // Net effect of -25% damage against syndie elite hardsuit
 
 /obj/item/projectile/bullet/pellet/weak
 	damage = 6
+	armour_penetration = -10 // Because it make sense from improvised round
 
 /obj/item/projectile/bullet/pellet/weak/New()
 	range = rand(1, 8)


### PR DESCRIPTION
Currently, the optimal ammo ballistic ammo to use for almost all situation is always buckshot. This lead to buckshot being almost always optimal as WT-550 and slug are by comparison, relatively weak.

This PR sought to remedy some of that problem by adjusting their relative power to eachother.

Feedbacks are highly welcome.

List of changes:
Toxin bullet: 15 -> 20 damage
Buckshot & Weak pellet: Armor penetration of -10 (Results in -25% damage against syndicate elite hardsuit)
Buckshot: Spread changed to 40 degree instead of 25. Result in a 1 - 2 bullet hitting a single tile at maximum screen length.
Slug: New type of projectile created. +10 penetration. Against syndie hardsuit, this result in 24 -> 30 damage from before. 

🆑
tweak: Buckshot & Improvised shell AP ability reduced. Slug AP increased. Toxin bullet damage increased to 20. 
/🆑 

