### PR TITLE
Fix explosive lance embedding

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -341,8 +341,8 @@
 	if(G)
 		explosive = G
 		name = "explosive lance"
+		embed_chance = 0
 		desc = "A makeshift spear with [G] attached to it. Alt+click on the spear to set your war cry!"
-		sharp = 0 
 		update_icon()
 
 //GREY TIDE

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -342,6 +342,7 @@
 		explosive = G
 		name = "explosive lance"
 		desc = "A makeshift spear with [G] attached to it. Alt+click on the spear to set your war cry!"
+		sharp = 0 
 		update_icon()
 
 //GREY TIDE


### PR DESCRIPTION
Fix #8235

Reduce embed chance to zero when there's a grenade in a spear

🆑
fix: Explosive lance doesn't embed anymore.
/🆑  