### PR TITLE
Headmins get Loopy Permissions

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -242,16 +242,19 @@
 
 		else if(task == "permissions")
 			if(!D)	return
-			var/list/permissionlist = list()
-			for(var/i=1, i<=R_MAXPERMISSION, i<<=1)		//that <<= is shorthand for i = i << 1. Which is a left bitshift
-				permissionlist[rights2text(i)] = i
-			var/new_permission = input("Select a permission to turn on/off", "Permission toggle", null, null) as null|anything in permissionlist
-			if(!new_permission)	return
-			D.rights ^= permissionlist[new_permission]
+			while (TRUE)
+				var/list/permissionlist = list()
+				for(var/i=1, i<=R_MAXPERMISSION, i<<=1)		//that <<= is shorthand for i = i << 1. Which is a left bitshift
+					permissionlist[rights2text(i)] = i
+				var/new_permission = input("Select a permission to turn on/off", adm_ckey + "'s Permissions", null, null) as null|anything in permissionlist
+				if(!new_permission)
+					return
+				D.rights ^= permissionlist[new_permission]
 
-			message_admins("[key_name_admin(usr)] toggled the [new_permission] permission of [adm_ckey]")
-			log_admin("[key_name(usr)] toggled the [new_permission] permission of [adm_ckey]")
-			log_admin_permission_modification(adm_ckey, permissionlist[new_permission])
+				message_admins("[key_name_admin(usr)] toggled the [new_permission] permission of [adm_ckey]")
+				log_admin("[key_name(usr)] toggled the [new_permission] permission of [adm_ckey]")
+				log_admin_permission_modification(adm_ckey, permissionlist[new_permission])
+
 
 		edit_admin_permissions()
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -249,10 +249,14 @@
 				var/new_permission = input("Select a permission to turn on/off", adm_ckey + "'s Permissions", null, null) as null|anything in permissionlist
 				if(!new_permission)
 					return
+				var oldrights = D.rights
+				var toggleresult = "ON"
 				D.rights ^= permissionlist[new_permission]
+				if(oldrights > D.rights)
+					toggleresult = "OFF"
 
-				message_admins("[key_name_admin(usr)] toggled the [new_permission] permission of [adm_ckey]")
-				log_admin("[key_name(usr)] toggled the [new_permission] permission of [adm_ckey]")
+				message_admins("[key_name_admin(usr)] toggled the [new_permission] permission of [adm_ckey] to [toggleresult]")
+				log_admin("[key_name(usr)] toggled the [new_permission] permission of [adm_ckey] to [toggleresult]")
 				log_admin_permission_modification(adm_ckey, permissionlist[new_permission])
 
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -242,7 +242,7 @@
 
 		else if(task == "permissions")
 			if(!D)	return
-			while (TRUE)
+			while(TRUE)
 				var/list/permissionlist = list()
 				for(var/i=1, i<=R_MAXPERMISSION, i<<=1)		//that <<= is shorthand for i = i << 1. Which is a left bitshift
 					permissionlist[rights2text(i)] = i

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -249,8 +249,8 @@
 				var/new_permission = input("Select a permission to turn on/off", adm_ckey + "'s Permissions", null, null) as null|anything in permissionlist
 				if(!new_permission)
 					return
-				var oldrights = D.rights
-				var toggleresult = "ON"
+				var/oldrights = D.rights
+				var/toggleresult = "ON"
 				D.rights ^= permissionlist[new_permission]
 				if(oldrights > D.rights)
 					toggleresult = "OFF"


### PR DESCRIPTION
🆑 Kyep
tweak: Heads of staff who are editing another admin's permissions in the admin panel can now toggle several permissions for a person without re-finding them in the list. Hitting 'cancel' at any point drops out of the loop. It also notifies admins whether they're toggling a permission on, or off.
/🆑

Previous workflow for headmins editing another admin's permissions:
1) Find admin in list
2) Click permissions edit button
3) Select which permission to change
4) Hit OK
5) Go to step 1. Repeat for every permission you want to change.

New workflow for headmins editing another admin's permissions:
1) Find admin in list
2) Click permissions edit button
3) Select which permission to change
4) Hit OK
5) Go to step 3. Repeat for every permission you want to change.
6) Hit 'cancel' to back out of the edit window and save changes.

The difference is that the new flow doesn't require you to re-find them in the list every time.

Bonus: it also now tells you whether you're toggling the permission ON or OFF.