### PR TITLE
Fix preference description

### DIFF
--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -1730,7 +1730,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 						nanotrasen_relation = new_relation
 
 				if("flavor_text")
-					var/msg = input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(flavor_text)) as message
+					var/msg = input(usr,"Set the flavor text in your 'examine' verb. The flavor text should be a physical descriptor of your character at a glance. SFW Drawn Art of your character is acceptable.","Flavor Text",html_decode(flavor_text)) as message
 
 					if(msg != null)
 						msg = copytext(msg, 1, MAX_MESSAGE_LEN)


### PR DESCRIPTION
This change the preference instructions in the character setup so it is consistent with the rules.

From: This can also be used for OOC notes and preferences!
to: The flavor text should be a physical descriptor of your character at a glance. SFW Drawn Art of your character is acceptable.

🆑
tweak: Flavour text description in character setup now consistent with rules.
/🆑 