### PR TITLE
Fixes weirdness when a mob being force-fed finishes a snack

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -24,7 +24,7 @@
 		if(!reagents.total_volume)
 			if(M == user)
 				to_chat(user, "<span class='notice'>You finish eating \the [src].</span>")
-			user.visible_message("<span class='notice'>[user] finishes eating \the [src].</span>")
+			user.visible_message("<span class='notice'>[M] finishes eating \the [src].</span>")
 			user.unEquip(src)	//so icons update :[
 			Post_Consume(M)
 			var/obj/item/trash_item = generate_trash(usr)


### PR DESCRIPTION
It looks weird when you finish force-feeding another mob and it says that you finished eating. This changes it so the message comes from whatever mob you are force-feeding.

🆑 VexingRaven
fix: Fixes the message that appears when a mob being force-fed a snack finishes eating that snack.
/ 🆑