### PR TITLE
Moves Paramedic's key from his clothes-locker to his EVA locker, removes an extraneous helmet from Paramedic's EVA locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -141,4 +141,3 @@
 	new /obj/item/clothing/suit/storage/paramedic(src)
 	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
-	new /obj/item/key/ambulance(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -245,7 +245,6 @@
 	..()
 	new /obj/item/clothing/suit/space/eva/paramedic(src)
 	new /obj/item/clothing/head/helmet/space/eva/paramedic(src)
-	new /obj/item/clothing/head/helmet/space/eva/paramedic(src)
 	new /obj/item/device/sensor_device(src)
 	new /obj/item/key/ambulance(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -247,6 +247,7 @@
 	new /obj/item/clothing/head/helmet/space/eva/paramedic(src)
 	new /obj/item/clothing/head/helmet/space/eva/paramedic(src)
 	new /obj/item/device/sensor_device(src)
+	new /obj/item/key/ambulance(src)
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"


### PR DESCRIPTION
In order to make it less easily stolen, considering it's a one-of-a-kind vehicle. This should help any latejoining Paramedics retain their sweet ride, but still allow people with access to ~~steal~~ appropriate it rather easily still.

🆑 FreeStylaLT
tweak: Moves Ambulance's key to Paramedic's EVA locker from his clothing locker
del: Removed an unnecessary EVA helmet from Paramedic's EVA locker
/🆑