### PR TITLE
Adds Freedom Operatives

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -117,6 +117,11 @@
 	var/obj/item/weapon/implant/explosive/E = new(H)
 	E.implant(H)
 
+/datum/outfit/admin/syndicate/operative/freedom
+	name = "Syndicate Freedom Operative"
+	suit = /obj/item/clothing/suit/space/hardsuit/syndi/freedom
+	head = /obj/item/clothing/head/helmet/space/hardsuit/syndi/freedom
+
 /datum/outfit/admin/syndicate_strike_team
 	name = "Syndicate Strike Team"
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -347,6 +347,12 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
+/obj/item/clothing/head/helmet/space/hardsuit/syndi/freedom
+	name = "eagle helmet"
+	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle."
+	icon_state = "griffinhat"
+	item_state = "griffinhat"
+
 /obj/item/clothing/suit/space/hardsuit/syndi
 	name = "blood-red hardsuit"
 	desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in travel mode. Property of Gorlex Marauders."
@@ -428,6 +434,14 @@
 	else
 		name = "elite syndicate hardsuit (combat)"
 		desc = "An elite version of the syndicate hardsuit, with improved armour and fire shielding. It is in combat mode. Property of Gorlex Marauders."
+
+
+/obj/item/clothing/suit/space/hardsuit/syndi/freedom
+	name = "eagle suit"
+	desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit."
+	icon_state = "freedom"
+	item_state = "freedom"
+
 
 //Wizard hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/wizard

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -246,24 +246,3 @@
 	species_fit = null
 	sprite_sheets = null
 	sprite_sheets_obj = null
-
-/obj/item/clothing/head/helmet/space/freedom
-	name = "eagle helmet"
-	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle."
-	icon_state = "griffinhat"
-	item_state = "griffinhat"
-	armor = list(melee = 20, bullet = 40, laser = 30, energy = 25, bomb = 100, bio = 100, rad = 100)
-	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
-	unacidable = 1
-	strip_delay = 130
-
-/obj/item/clothing/suit/space/freedom
-	name = "eagle suit"
-	desc = "An advanced, light suit, fabricated from a mixture of synthetic feathers and space-resistant material. A gun holster appears to be integrated into the suit and the wings appear to be stuck in 'freedom' mode."
-	icon_state = "freedom"
-	item_state = "freedom"
-	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank)
-	armor = list(melee = 20, bullet = 40, laser = 30, energy = 25, bomb = 100, bio = 100, rad = 100)
-	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
-	unacidable = 1
-	strip_delay = 130


### PR DESCRIPTION
🆑 Kyep
add: Freedom Operatives are now a support outfit that admins can equip players as.
/ 🆑

This PR:
- Changes freedom suits to be a subtype of nukeop hardsuits, meaning that they now have identical stats (and features!) to the nukeop red suits.
- Adds a 'syndicate freedom operative' to the admin outfit list, meaning it is now much easier for admins to equip someone as a freedom operative, or spawn a bunch of freedom operatives using the Gimmick Team secret.

These changes make it easier for admins to introduce freedom operatives into rounds, without having to manually spawn the suits, varedit them so their stats match, etc.