### PR TITLE
Fixes all-access Soviets

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -600,7 +600,7 @@
 
 	var/obj/item/weapon/card/id/I = H.wear_id
 	if(istype(I))
-		apply_to_card(I, H, get_all_accesses(), name)
+		apply_to_card(I, H, list(access_maint_tunnels), name)
 
 /datum/outfit/admin/soviet/tourist
 	name = "Soviet Tourist"


### PR DESCRIPTION
🆑 Kyep
fix: Soviets (including Soviet Tourists, a non-antag filler role) no longer get all-access to the Cyberiad when they visit. 
/ 🆑

Soviet Tourists are a light fun role, an excuse to RP, get drunk, etc. They're not meant to have all-access, but they do.

Soviet Soldiers and Admirals should be able to break into things. They shouldn't need all-access.