### PR TITLE
Salty Solution to Slime Cliques

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -275,6 +275,44 @@
 		M.adjustBrainLoss(1)
 	..()
 
+/datum/reagent/consumable/sodiumchloride/reaction_mob(mob/living/M, method=TOUCH, volume)
+	if(method == TOUCH || method == INGEST)
+		if(ishuman(M) && is_species(M, "Slime People"))
+			var/mob/living/carbon/human/H = M
+
+			if(method == TOUCH)
+				H.adjustFireLoss(volume * 0.8)
+				H.Weaken(volume * 0.1)
+				H.EyeBlurry(25)
+
+				if(volume < 15)
+					to_chat(H, "<span class='warning'>The salt burns as it sucks the moisture from your skin!</span>")
+				else if(volume > 15 && volume < 45)
+					to_chat(H, "<span class='warning'>You are in agony as the salt leeches away your bodily moisture!</span>")
+				else
+					if(H.has_limbs)
+						for(var/organ in H.bodyparts_by_name)
+							var/obj/item/organ/external/O = H.bodyparts_by_name[organ]
+							if(istype(O, /obj/item/organ/external/leg) || istype(O, /obj/item/organ/external/hand) || istype(O, /obj/item/organ/external/arm) || istype(O, /obj/item/organ/external/foot))
+								qdel(O)
+					H.update_body()
+					H.regenerate_icons()
+					to_chat(H, "<span class='warning'>The pain is excruciating as your limbs shrivel up inside your body!")
+
+				H.emote("scream")
+				to_chat(H, "<span class='notice'>Your body feels dry and you struggle to move...</span>")
+
+			else
+				H.adjustFireLoss(volume)
+
+				if(volume < 10)
+					to_chat(H, "<span class='warning'>Your insides are burning!</span>")
+				else
+					to_chat(H, "<span class='warning'>Your insides are on fire!</span>")
+					H.visible_message("[H] clutches their gut in agony!" / "You clutch your gut in agony!")
+					H.Weaken(volume * 0.1)
+					H.emote("scream")
+
 /datum/reagent/consumable/blackpepper
 	name = "Black Pepper"
 	id = "blackpepper"


### PR DESCRIPTION
Have you ever seen the effect of sprinkling salt onto a slug? The salt draws the water from the slug's moist skin and it's rather nasty.

Slime people should be vulnerable to the same kind of treatment. Salt grenades anyone!?

![2017-10-23_12-50-04](https://user-images.githubusercontent.com/25027759/31887892-f6c3d3ca-b7f1-11e7-853d-4709bc09ad50.gif)

Or you could try a more precise and concentrated strike!

![2017-10-23_12-51-23](https://user-images.githubusercontent.com/25027759/31887908-02ca6d82-b7f2-11e7-9b22-e575ad4a8f6d.gif)

Slimes now take damage upon contact with Salt. In greater volumes it has the ability to shrivel their limbs up rendering them a helpless little nugget! Stand up to slime cliques today and get yourself some salt!

![230608680645558272](https://user-images.githubusercontent.com/25027759/31888030-6327e538-b7f2-11e7-9df8-1765c2c8da1e.png)


🆑 Birdtalon
add: Slime people are now vulnerable to attack by Sodium Chloride
/🆑 