### PR TITLE
Sign language as a secondary language option for all.

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -154,16 +154,16 @@
 		return
 
 	if(say_understands(speaker, language))
-		message = "<B>[src]</B> [verb], \"[message]\""
+		message = "<span class='game say'><span class='name'>[src]</span> [verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>"
 	else
-		message = "<B>[src]</B> [verb]."
+		message = "<span class='game say'><span class='name'>[src]</span> [verb] with their hands, but you don't understand.</span>"
 
 	if(src.status_flags & PASSEMOTES)
 		for(var/obj/item/weapon/holder/H in src.contents)
-			H.show_message(message)
+			H.show_message(message, 1)
 		for(var/mob/living/M in src.contents)
-			M.show_message(message)
-	src.show_message(message)
+			M.show_message(message, 1)
+	src.show_message(message, 1)
 
 /mob/proc/hear_sleep(var/message)
 	var/heard = ""

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -154,9 +154,9 @@
 		return
 
 	if(say_understands(speaker, language))
-		message = "<span class='game say'><span class='name'>[src]</span> [verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>"
+		message = "<span class='game say'><span class='name'>[speaker.name]</span> [verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>"
 	else
-		message = "<span class='game say'><span class='name'>[src]</span> [verb] with their hands, but you don't understand.</span>"
+		message = "<span class='game say'><span class='name'>[speaker.name]</span> [verb] with their hands, but you don't understand.</span>"
 
 	if(src.status_flags & PASSEMOTES)
 		for(var/obj/item/weapon/holder/H in src.contents)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -406,6 +406,15 @@
 	key = "3"
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
 
+/datum/language/sign
+	name = "Sign Language"
+	desc = "A non-verbal form of communication that utilizes hand gestures to form words and meanings."
+	speech_verb = "signs"
+	signlang_verb = list("signs", "gestures")
+	colour = "say_quote"
+	key = "~"
+	flags = SIGNLANG | NO_STUTTER
+
 /datum/language/clown
 	name = "Clownish"
 	desc = "The language of clown planet. Mother tongue of clowns throughout the Galaxy."

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -415,6 +415,26 @@
 	key = "~"
 	flags = SIGNLANG | NO_STUTTER
 
+/datum/language/sign/check_can_speak(mob/living/speaker)
+
+	if(ishuman(speaker))
+		var/mob/living/carbon/human/S = speaker
+		var/obj/item/organ/external/rhand = S.get_organ("r_hand")
+		var/obj/item/organ/external/lhand = S.get_organ("l_hand")
+		if((!rhand || !rhand.is_usable()) && (!lhand || !lhand.is_usable()))
+			to_chat(speaker, "<span class='warning'>You try to use your hand to sign, but you can't!</span>")
+			return FALSE
+
+	if(speaker.l_hand || speaker.r_hand)
+		to_chat(speaker, "<span class='warning'>Both your hands must be empty to be able to sign!</span>")
+		return FALSE
+
+	if(!speaker.can_use_hands() || speaker.incapacitated(ignore_lying = 1))
+		to_chat(speaker,"<span class='warning'>You can't sign while unable to move your hands!</span>")
+		return FALSE
+
+	return TRUE
+
 /datum/language/clown
 	name = "Clownish"
 	desc = "The language of clown planet. Mother tongue of clowns throughout the Galaxy."

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -289,41 +289,18 @@ proc/get_radio_key_from_channel(var/channel)
 	return 1
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/datum/language/language)
-	if(restrained())
-		to_chat(src, "<span class='danger'>You are restrained and cannot sign!</span>")
-		return
+	if(language.check_can_speak(src))
+		to_chat(src, "<span class='notice'>You attempt to sign a message.</span>")
+		
+		if(do_after(src, 30, target = src))
+			for(var/mob/M in get_mobs_in_view(7, src))
+				if(M.see_invisible < invisibility)
+					continue
+				M.hear_signlang(message, verb, language, src)
 
-	if(stat || paralysis || stunned || weakened)
-		to_chat(src, "<span class='danger'>You are not currently able to sign!</span>")
-		return
-
-	if(istype(src.loc,/obj/mecha))
-		to_chat(src, "<span class='warning'>You are unable to sign effectively in a mech!</span>")
-		return
-
-	if(!ishuman(src))
-		to_chat(src, "<span class='warning'>You do not have the ability to sign this.</span>")
-		return
-
-	var/mob/living/carbon/human/C = src
-
-	var/obj/item/organ/external/rhand = C.bodyparts_by_name["r_hand"]
-	var/obj/item/organ/external/lhand = C.bodyparts_by_name["l_hand"]
-	if((!rhand || !rhand.is_usable() || rhand.is_broken()) || (!lhand || !lhand.is_usable() || lhand.is_broken()))
-		to_chat(C, "<span class='warning'>You try to use your hand to sign, but you can't!</span>")
-		return
-
-	if(C.l_hand || C.r_hand)
-		to_chat(C, "<span class='warning'>Both your hands must be empty to be able to sign!</span>")
-		return 0
-
-	for(var/mob/M in get_mobs_in_view(3, C))
-		if(M.see_invisible < invisibility)
-			continue
-		M.hear_signlang(message, verb, language, C)
-
-	log_say("[name]/[key] : [message]")
-	return 1
+			log_say("[name]/[key] : [message]")
+			return 1
+	return 0
 
 /obj/effect/speech_bubble
 	var/mob/parent

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -289,8 +289,24 @@ proc/get_radio_key_from_channel(var/channel)
 	return 1
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/datum/language/language)
-	for(var/mob/O in viewers(src, null))
-		O.hear_signlang(message, verb, language, src)
+	if(restrained())
+		to_chat(src, "<span class='danger'>You're restrained and cannot sign!</span>")
+		return
+
+	if(ishuman(src))
+		var/mob/living/carbon/human/C = src
+		var/obj/item/organ/external/rhand = C.bodyparts_by_name["r_hand"]
+		var/obj/item/organ/external/lhand = C.bodyparts_by_name["l_hand"]
+		if((!rhand || !rhand.is_usable() || rhand.is_broken()) || (!lhand || !lhand.is_usable() || lhand.is_broken()))
+			to_chat(src, "<span class='warning'>You try to use your hand to sign, but you can't!</span>")
+			return
+
+	for(var/mob/M in get_mobs_in_view(7, src))
+		if(M.see_invisible < invisibility)
+			continue
+		M.hear_signlang(message, verb, language, src)
+
+	log_say("[name]/[key] : [message]")
 	return 1
 
 /obj/effect/speech_bubble

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -165,6 +165,7 @@ var/list/ai_verbs_default = list(
 	add_language("Sol Common", 1)
 	add_language("Tradeband", 1)
 	add_language("Gutter", 0)
+	add_language("Sign Language", 0)
 	add_language("Sinta'unathi", 0)
 	add_language("Siik'tajr", 0)
 	add_language("Canilunzt", 0)

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -632,6 +632,7 @@
 		user.add_language("Bubblish")
 		user.add_language("Orluum")
 		user.add_language("Clownish")
+		user.add_language("Sign Language")
 	else
 		user.remove_language("Sinta'unathi")
 		user.remove_language("Siik'tajr")
@@ -643,6 +644,7 @@
 		user.remove_language("Bubblish")
 		user.remove_language("Orluum")
 		user.remove_language("Clownish")
+		user.remove_language("Sign Language")
 
 /datum/pai_software/translator/is_active(mob/living/silicon/pai/user)
 	return user.translator_on

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -78,6 +78,7 @@
 	R.add_language("Sol Common", 1)
 	R.add_language("Tradeband", 1)
 	R.add_language("Gutter", 0)
+	R.add_language("Sign Language", 0)
 	R.add_language("Sinta'unathi", 0)
 	R.add_language("Siik'tajr", 0)
 	R.add_language("Canilunzt", 0)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -142,6 +142,7 @@
 	add_language("Sol Common", 1)
 	add_language("Tradeband", 1)
 	add_language("Gutter", 1)
+	add_language("Sign Language", 1)
 	add_language("Trinary", 1)
 	default_language = all_languages["Galactic Common"]
 


### PR DESCRIPTION
Adds a new secondary language, Sign Language, available to all, to provide an additional communication option for Deaf/Mute characters to converse with others who know Sign Language.

This also provides the AI and Borgs the ability to understand these languages by default, and adds the language to the pAI's Universal Translator software package.

I've put in some checks so that characters cannot sign if they are restrained/cuffed, or if their hands are missing or broken.

There was already some elements of the Sign Language already supported in the code, it just needed an extra push.

:cl:
rscadd: Adds Sign Language as an secondary language option.
/:cl: