### PR TITLE
Improves Ghost HUDs

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -289,9 +289,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	switch(data_hud_seen) //give new huds
 		if(0)
-			show_me_the_hud(DATA_HUD_SECURITY_BASIC)
+			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			to_chat(src, "<span class='notice'>Security HUD set.</span>")
-		if(DATA_HUD_SECURITY_BASIC)
+		if(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>Medical HUD set.</span>")
 		if(DATA_HUD_MEDICAL_ADVANCED)


### PR DESCRIPTION
🆑 Kyep
add: Ghosts with sec hud enabled can now see mindshield, tracker and chem implants, as well as wanted status.
/🆑

With this PR, ghosts who have security HUDs will see crew members exactly the same as a normal mob wearing a sec HUD would. IE: they can see all the things a normal crew member wearing that HUD could see. 

Obviously, this does **NOT** grant ghosts the ability to actually change wanted status like an officer can.