### PR TITLE
Buffs Service Borgs

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -55,6 +55,22 @@ RSF
 		to_chat(user, "Changed dispensing mode to 'Cigarette'")
 		return
 	if(mode == 6)
+		mode = 7
+		to_chat(user, "Changed dispensing mode to 'Snack - Tofu Turkey'")
+		return
+	if(mode == 7)
+		mode = 8
+		to_chat(user, "Changed dispensing mode to 'Snack - Chicken Soup'")
+		return
+	if(mode == 8)
+		mode = 9
+		to_chat(user, "Changed dispensing mode to 'Snack - Tofu Burger'")
+		return
+	if(mode == 9)
+		mode = 10
+		to_chat(user, "Changed dispensing mode to 'Snack - Noodles'")
+		return
+	if(mode == 10)
 		mode = 1
 		to_chat(user, "Changed dispensing mode to 'Dosh'")
 		return
@@ -232,6 +248,115 @@ RSF
 				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
 				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
 		return
+	else if(istype(A, /obj/structure/table) && mode == 7)
+		if(istype(A, /obj/structure/table) && matter >= 1)
+			to_chat(user, "Dispensing Snack - Tofu Turkey...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/snacks/tofurkey( A.loc )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+
+	else if(istype(A, /turf/simulated/floor) && mode == 7)
+		if(istype(A, /turf/simulated/floor) && matter >= 1)
+			to_chat(user, "Dispensing Snack - Tofu Turkey...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/snacks/tofurkey( A )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+	else if(istype(A, /obj/structure/table) && mode == 8)
+		if(istype(A, /obj/structure/table) && matter >= 1)
+			to_chat(user, "Dispensing Snack - Chicken Soup...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/drinks/chicken_soup( A.loc )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+
+	else if(istype(A, /turf/simulated/floor) && mode == 8)
+		if(istype(A, /turf/simulated/floor) && matter >= 1)
+			to_chat(user, "Dispensing Snack - Chicken Soup...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/drinks/chicken_soup( A )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+	else if(istype(A, /obj/structure/table) && mode == 9)
+		if(istype(A, /obj/structure/table) && matter >= 1)
+			to_chat(user, "Dispensing Tofu Burger...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/snacks/tofuburger( A.loc )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+
+	else if(istype(A, /turf/simulated/floor) && mode == 9)
+		if(istype(A, /turf/simulated/floor) && matter >= 1)
+			to_chat(user, "Dispensing Tofu Burger...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/snacks/tofuburger( A )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+	else if(istype(A, /obj/structure/table) && mode == 10)
+		if(istype(A, /obj/structure/table) && matter >= 1)
+			to_chat(user, "Dispensing Newdles...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles( A.loc )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+
+	else if(istype(A, /turf/simulated/floor) && mode == 10)
+		if(istype(A, /turf/simulated/floor) && matter >= 1)
+			to_chat(user, "Dispensing Newdles...")
+			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+			new /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles( A )
+			if(isrobot(user))
+				var/mob/living/silicon/robot/engy = user
+				engy.cell.charge -= 500
+			else
+				matter--
+				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+		return
+
 
 /obj/item/weapon/cookiesynth
 	name = "\improper Cookie Synthesizer"

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -1,8 +1,8 @@
 /*
 CONTAINS:
 RSF
-
 */
+
 /obj/item/weapon/rsf
 	name = "\improper Rapid-Service-Fabricator"
 	desc = "A device used to rapidly deploy service items."
@@ -14,9 +14,21 @@ RSF
 	var/matter = 0
 	var/mode = 1
 	w_class = WEIGHT_CLASS_NORMAL
+	var/list/configured_items = list()
 
 /obj/item/weapon/rsf/New()
 	desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+	// configured_items[ID_NUMBER] = list("Human-readable name", price in energy, /type/path)
+	configured_items[++configured_items.len] = list("Dosh", 50, /obj/item/stack/spacecash/c10)
+	configured_items[++configured_items.len] = list("Drinking Glass", 50, /obj/item/weapon/reagent_containers/food/drinks/drinkingglass)
+	configured_items[++configured_items.len] = list("Paper", 50, /obj/item/weapon/paper)
+	configured_items[++configured_items.len] = list("Pen", 50, /obj/item/weapon/pen)
+	configured_items[++configured_items.len] = list("Dice Pack", 50, /obj/item/weapon/storage/pill_bottle/dice)
+	configured_items[++configured_items.len] = list("Cigarette", 50, /obj/item/clothing/mask/cigarette)
+	configured_items[++configured_items.len] = list("Snack - Newdles", 250, /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles)
+	configured_items[++configured_items.len] = list("Snack - Donut", 250, /obj/item/weapon/reagent_containers/food/snacks/donut)
+	configured_items[++configured_items.len] = list("Snack - Chicken Soup", 500, /obj/item/weapon/reagent_containers/food/drinks/chicken_soup)
+	configured_items[++configured_items.len] = list("Snack - Turkey Burger", 500, /obj/item/weapon/reagent_containers/food/snacks/tofuburger)
 	return
 
 /obj/item/weapon/rsf/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
@@ -34,328 +46,38 @@ RSF
 
 /obj/item/weapon/rsf/attack_self(mob/user as mob)
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
-	if(mode == 1)
-		mode = 2
-		to_chat(user, "Changed dispensing mode to 'Drinking Glass'")
-		return
-	if(mode == 2)
-		mode = 3
-		to_chat(user, "Changed dispensing mode to 'Paper'")
-		return
-	if(mode == 3)
-		mode = 4
-		to_chat(user, "Changed dispensing mode to 'Pen'")
-		return
-	if(mode == 4)
-		mode = 5
-		to_chat(user, "Changed dispensing mode to 'Dice Pack'")
-		return
-	if(mode == 5)
-		mode = 6
-		to_chat(user, "Changed dispensing mode to 'Cigarette'")
-		return
-	if(mode == 6)
-		mode = 7
-		to_chat(user, "Changed dispensing mode to 'Snack - Tofu Turkey'")
-		return
-	if(mode == 7)
-		mode = 8
-		to_chat(user, "Changed dispensing mode to 'Snack - Chicken Soup'")
-		return
-	if(mode == 8)
-		mode = 9
-		to_chat(user, "Changed dispensing mode to 'Snack - Tofu Burger'")
-		return
-	if(mode == 9)
-		mode = 10
-		to_chat(user, "Changed dispensing mode to 'Snack - Noodles'")
-		return
-	if(mode == 10)
+	if(mode == configured_items.len)
 		mode = 1
-		to_chat(user, "Changed dispensing mode to 'Dosh'")
-		return
-	// Change mode
+	else
+		mode++
+	to_chat(user, "Changed dispensing mode to '" + configured_items[mode][1] + "'")
+
 
 /obj/item/weapon/rsf/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity) return
 	if(!(istype(A, /obj/structure/table) || istype(A, /turf/simulated/floor)))
 		return
 
-	if(istype(A, /obj/structure/table) && mode == 1)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Dosh...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/stack/spacecash/c10( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 200 //once money becomes useful, I guess changing this to a high ammount, like 500 units a kick, till then, enjoy dosh!
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
+	var spawn_location
+	if(istype(A, /obj/structure/table))
+		spawn_location = A.loc
+	else if (istype(A, /obj/structure/table))
+		spawn_location = A
+	else
+		to_chat(user, "The RSF can only create service items on tables, or floors.")
 		return
 
-	else if(istype(A, /turf/simulated/floor) && mode == 1)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Dosh...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/stack/spacecash/c10( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 200 //once money becomes useful, I guess changing this to a high ammount, like 500 units a kick, till then, enjoy dosh!
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /obj/structure/table) && mode == 2)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Drinking Glass...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 50
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 2)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Drinking Glass...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/drinks/drinkingglass( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 50
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /obj/structure/table) && mode == 3)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Paper Sheet...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/paper( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 10
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 3)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Paper Sheet...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/paper( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 10
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /obj/structure/table) && mode == 4)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Pen...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/pen( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 50
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 4)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Pen...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/pen( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 50
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /obj/structure/table) && mode == 5)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Dice Pack...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/storage/pill_bottle/dice( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 200
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 5)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Dice Pack...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/storage/pill_bottle/dice( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 200
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /obj/structure/table) && mode == 6)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Cigarette...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/clothing/mask/cigarette( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 10
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 6)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Cigarette...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/clothing/mask/cigarette( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 10
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-	else if(istype(A, /obj/structure/table) && mode == 7)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Snack - Tofu Turkey...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/snacks/tofurkey( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 7)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Snack - Tofu Turkey...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/snacks/tofurkey( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-	else if(istype(A, /obj/structure/table) && mode == 8)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Snack - Chicken Soup...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/drinks/chicken_soup( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 8)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Snack - Chicken Soup...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/drinks/chicken_soup( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-	else if(istype(A, /obj/structure/table) && mode == 9)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Tofu Burger...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/snacks/tofuburger( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 9)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Tofu Burger...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/snacks/tofuburger( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-	else if(istype(A, /obj/structure/table) && mode == 10)
-		if(istype(A, /obj/structure/table) && matter >= 1)
-			to_chat(user, "Dispensing Newdles...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles( A.loc )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
-
-	else if(istype(A, /turf/simulated/floor) && mode == 10)
-		if(istype(A, /turf/simulated/floor) && matter >= 1)
-			to_chat(user, "Dispensing Newdles...")
-			playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
-			new /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles( A )
-			if(isrobot(user))
-				var/mob/living/silicon/robot/engy = user
-				engy.cell.charge -= 500
-			else
-				matter--
-				to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
-				desc = "A RSF. It currently holds [matter]/30 fabrication-units."
-		return
+	to_chat(user, "Dispensing " + configured_items[mode][1] + "...")
+	playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+	var type_path = configured_items[mode][3]
+	new type_path(spawn_location)
+	if(isrobot(user))
+		var/mob/living/silicon/robot/engy = user
+		engy.cell.charge -= configured_items[mode][2]
+	else
+		matter--
+		to_chat(user, "The RSF now holds [matter]/30 fabrication-units.")
+		desc = "A RSF. It currently holds [matter]/30 fabrication-units."
 
 
 /obj/item/weapon/cookiesynth

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -25,10 +25,10 @@ RSF
 	configured_items[++configured_items.len] = list("Pen", 50, /obj/item/weapon/pen)
 	configured_items[++configured_items.len] = list("Dice Pack", 50, /obj/item/weapon/storage/pill_bottle/dice)
 	configured_items[++configured_items.len] = list("Cigarette", 50, /obj/item/clothing/mask/cigarette)
-	configured_items[++configured_items.len] = list("Snack - Newdles", 250, /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles)
-	configured_items[++configured_items.len] = list("Snack - Donut", 250, /obj/item/weapon/reagent_containers/food/snacks/donut)
-	configured_items[++configured_items.len] = list("Snack - Chicken Soup", 500, /obj/item/weapon/reagent_containers/food/drinks/chicken_soup)
-	configured_items[++configured_items.len] = list("Snack - Turkey Burger", 500, /obj/item/weapon/reagent_containers/food/snacks/tofuburger)
+	configured_items[++configured_items.len] = list("Snack - Newdles", 4000, /obj/item/weapon/reagent_containers/food/snacks/chinese/newdles)
+	configured_items[++configured_items.len] = list("Snack - Donut", 4000, /obj/item/weapon/reagent_containers/food/snacks/donut)
+	configured_items[++configured_items.len] = list("Snack - Chicken Soup", 4000, /obj/item/weapon/reagent_containers/food/drinks/chicken_soup)
+	configured_items[++configured_items.len] = list("Snack - Turkey Burger", 4000, /obj/item/weapon/reagent_containers/food/snacks/tofuburger)
 	return
 
 /obj/item/weapon/rsf/attackby(obj/item/weapon/W as obj, mob/user as mob, params)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -283,6 +283,14 @@
 	isGlass = 0
 	list_reagents = list("limejuice" = 100)
 
+/obj/item/weapon/reagent_containers/food/drinks/bottle/milk
+	name = "Milk"
+	desc = "Soothing milk."
+	icon_state = "milk"
+	item_state = "carton"
+	isGlass = 0
+	list_reagents = list("milk" = 100)
+
 ////////////////////////// MOLOTOV ///////////////////////
 /obj/item/weapon/reagent_containers/food/drinks/bottle/molotov
 	name = "molotov cocktail"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -271,9 +271,18 @@
 	..()
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice(src) // -0.3 oxy/sec
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/tomatojuice(src) // -0.2 fire/sec
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/limejuice(src) // -0.2 tox/sec
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/milk(src) // -0.2 brute/sec
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/coffee(src) // -1 paralysis stunned & weakened/sec
+	modules += new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/tea(src)
+
 	modules += new /obj/item/weapon/pen(src)
 	modules += new /obj/item/weapon/razor(src)
 	modules += new /obj/item/device/instrument/piano_synth(src)
+	modules += new /obj/item/device/healthanalyzer/advanced(src)
 
 	var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf(src)
 	M.matter = 30

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -270,6 +270,7 @@
 /obj/item/weapon/robot_module/butler/New()
 	..()
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/cola(src)
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice(src) // -0.3 oxy/sec
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/tomatojuice(src) // -0.2 fire/sec
@@ -278,6 +279,13 @@
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/coffee(src) // -1 paralysis stunned & weakened/sec
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/tea(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/ice(src)
+	modules += new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/cream(src)
+
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/tequila(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey(src)
 
 	modules += new /obj/item/weapon/pen(src)
 	modules += new /obj/item/weapon/razor(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -271,16 +271,16 @@
 	..()
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/cola(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/sodawater(src)
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/orangejuice(src) // -0.3 oxy/sec
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/tomatojuice(src) // -0.2 fire/sec
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/limejuice(src) // -0.2 tox/sec
-	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/milk(src) // -0.2 brute/sec
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/coffee(src) // -1 paralysis stunned & weakened/sec
-	modules += new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/tea(src)
-	modules += new /obj/item/weapon/reagent_containers/food/drinks/ice(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/milk(src) // -0.2 brute/sec
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/sugar(src)
+	modules += new /obj/item/weapon/reagent_containers/food/drinks/ice(src)
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/cream(src)
 
 	modules += new /obj/item/weapon/reagent_containers/food/drinks/bottle/tequila(src)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -323,12 +323,12 @@
 	M.EyeBlurry(3)
 	..()
 
-/datum/reagent/beer2	//disguised as normal beer for use by emagged brobots
+/datum/reagent/beer2	//disguised as normal beer for use by emagged service borgs
 	name = "Beer"
 	id = "beer2"
 	description = "An alcoholic beverage made from malted grains, hops, yeast, and water."
 	color = "#664300" // rgb: 102, 67, 0
-	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	drink_icon ="beerglass"
 	drink_name = "Beer glass"
 	drink_desc = "A freezing pint of beer"


### PR DESCRIPTION
Service borgs now have the following additional reagent dispensers:
- Orange Juice (cures some viruses, reduces oxy damage slightly)
- Tomato Juice (reduces fire damage ~0.2/second)
- Lime Juice & Tea (each reduces tox damage ~0.2/second)
- Milk (reduces brute damage ~0.2/second)
- Coffee (reduces paralysis/stunned/weakened status 1/second)
- Sugar (intended for addition to coffee/tea)

They also get a health analyser, so they can scan crew members, notice they're injured, and serve them a refreshing drink for RP and minor healing. They use the Rapid Service Fabricator to create a glass, then a reagent dispenser on the glass to fill it. These dispensers recharge from the cyborg's battery.

When emagged, they still have their dispenser for poisoned beer, but the poison has also been changed to have the same metabolism rate as cyanide. What this means is that it takes 15 times as long to deplete as it used to. Essentially, if someone drinks a significant amount of poisoned beer, and doesn't get dialysis or similar soon, they die.

Finally, their RSF can create some snack food items: tofu burgers, tofu snacks, noodles, and chicken soup.

Based on a suggestions forum post: https://nanotrasen.se/forum/topic/11776-give-service-borgs-more-functionality-a-buff-they-need

🆑 Kyep
add: Service borgs are now able to dispense a variety of fruit juices, as well as coffee and tea. Additionally, they can use a health scanner on crew, and the poisoned beer they get from being emagged is much more deadly. They can also create snackfood using their Rapid Service Fabricator.
/🆑