### PR TITLE
Tweaks/Improves ERT borgs

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -211,7 +211,7 @@
 		//Unfortunately adding the emag module to the list of modules has to be here. This is because a borg can
 		//be emagged before they actually select a module. - or some situation can cause them to get a new module
 		// - or some situation might cause them to get de-emagged or something.
-		if(R.emagged || R.ert_upgrade)
+		if(R.emagged || R.weapons_unlock)
 			if(!(R.module.emag in R.module.modules))
 				R.module.modules.Add(R.module.emag)
 		else

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -211,7 +211,7 @@
 		//Unfortunately adding the emag module to the list of modules has to be here. This is because a borg can
 		//be emagged before they actually select a module. - or some situation can cause them to get a new module
 		// - or some situation might cause them to get de-emagged or something.
-		if(R.emagged)
+		if(R.emagged || R.ert_upgrade)
 			if(!(R.module.emag in R.module.modules))
 				R.module.modules.Add(R.module.emag)
 		else

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -68,7 +68,7 @@
 /obj/item/borg/upgrade/rename/action(var/mob/living/silicon/robot/R)
 	if(..())
 		return
-	if(R.ert_upgrade)
+	if(!R.allow_rename)
 		to_chat(R, "<span class='warning'>Internal diagnostic error: incompatible upgrade module detected.</span>");
 		return 0
 	R.notify_ai(3, R.name, heldname)
@@ -218,7 +218,7 @@
 	if(R.emagged)
 		return
 
-	if(R.ert_upgrade)
+	if(R.weapons_unlock)
 		to_chat(R, "<span class='warning'>Internal diagnostic error: incompatible upgrade module detected.</span>");
 		return
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -68,6 +68,9 @@
 /obj/item/borg/upgrade/rename/action(var/mob/living/silicon/robot/R)
 	if(..())
 		return
+	if(R.ert_upgrade)
+		to_chat(R, "<span class='warning'>Internal diagnostic error: incompatible upgrade module detected.</span>");
+		return 0
 	R.notify_ai(3, R.name, heldname)
 	R.name = heldname
 	R.custom_name = heldname
@@ -213,6 +216,10 @@
 		return
 
 	if(R.emagged)
+		return
+
+	if(R.ert_upgrade)
+		to_chat(R, "<span class='warning'>Internal diagnostic error: incompatible upgrade module detected.</span>");
 		return
 
 	R.emagged = 1

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -118,7 +118,9 @@ var/ert_request_answered = 0
 		var/mob/living/silicon/robot/ert/R = new()
 		R.forceMove(spawn_location)
 		var/rnum = rand(1,1000)
-		R.name = "ERT [rnum]"
+		var/borgname = "ERT [rnum]"
+		R.name = borgname
+		R.custom_name = borgname
 		R.real_name = R.name
 		R.mind = new
 		R.mind.current = R

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -758,15 +758,8 @@ var/list/robot_verbs_default = list(
 	var/mob/living/M = user
 	if(!opened)//Cover is closed
 		if(locked)
-			if(ert_upgrade)
-				if(prob(20))
-					to_chat(user, "You successfully emag the cover lock.")
-					locked = 0
-				else
-					to_chat(user, "You try to emag the cover lock - but it simply blinks red.")
-			else
-				to_chat(user, "You emag the cover lock.")
-				locked = 0
+			to_chat(user, "You emag the cover lock.")
+			locked = 0
 		else
 			to_chat(user, "The cover is already unlocked.")
 		return


### PR DESCRIPTION
Fixes a few issues with ERT borgs:
1) ERT borgs can now talk on ERT radio.
2) ERT borgs' radio now lists all their channels properly.
3) ERT borgs are now always named 'ERT' plus a number.

Changes:
1) ERT borgs may no longer choose their own names. This prevents antags getting surprised by going to mess with a borg only to find out it is a renamed ERT borg. They now always have 'ERT' plus a number as their name.
2) ERT borgs may no longer select the mining, service, or janitor modules. This prevents people wasting ERT borg slots by selecting modules that aren't helpful when dealing with an emergency.
3) ERT borgs can no longer have rename or illegal equipment upgrades applied to them.
4) ERT borgs now start with emagged modules unlocked. For Eng borg, this is the stun arm, effectively a stunbaton. For Medical borg, polyacid spray. For Sec borg, laser gun. Without this change, Sec borgs have no lethal ranged weapon, and the others don't have a dedicated weapon. That limited them quite a lot, especially against monsters, such as xenomorphs.
5) ERT borgs now have an 80% chance to resist their cover being emagged. You can still emag one if you flash it first, but you can't drive-by-emag them so easily.

🆑 Kyep
fix: ERT borgs can now speak on ERT radio, even after choosing a module.
add: ERT borgs are now always named as such, may only take modules that would be useful in an emergency, and always have their emagged modules unlocked. They also have an 80% chance to resist emagging their cover lock, so you will need to stun them with a flash before trying to emag them.
/🆑