### PR TITLE
Syndicate Item Rebalance PR. Tator Items Only.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1045,7 +1045,7 @@ var/list/uplink_items = list()
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
 	reference = "HAI"
 	item = /obj/item/weapon/aiModule/syndicate
-	cost = 12
+	cost = 14
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -134,7 +134,7 @@ var/list/uplink_items = list()
 	desc = "A specialized, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes with 6 special darts and a preloaded shrapnel round."
 	reference = "MCS"
 	item = /obj/item/weapon/storage/box/syndie_kit/caneshotgun
-	cost = 15
+	cost = 10
 	job = list("Mime")
 
 //Chef
@@ -216,7 +216,7 @@ var/list/uplink_items = list()
 	desc = "The feral cat delivery grenade contains 8 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
 	item = /obj/item/weapon/grenade/spawnergrenade/feral_cats
 	reference = "CCLG"
-	cost = 5
+	cost = 4
 	job = list("Psychiatrist")//why? Becuase its funny that a person in charge of your mental wellbeing has a cat granade..
 
 //Assistant
@@ -236,7 +236,7 @@ var/list/uplink_items = list()
 	desc = "A box containing 6 shotgun shells that simulate the effects of extreme drunkenness on the target, more effective for each type of alcohol in the target's system."
 	reference = "BSS"
 	item = /obj/item/weapon/storage/box/syndie_kit/boolets
-	cost = 6
+	cost = 3
 	job = list("Bartender")
 
 //Barber
@@ -608,7 +608,7 @@ var/list/uplink_items = list()
 	desc = "A speed loader that contains seven additional .357 Magnum rounds for the syndicate revolver. For when you really need a lot of things dead."
 	reference = "357"
 	item = /obj/item/ammo_box/a357
-	cost = 4
+	cost = 3
 
 /datum/uplink_item/ammo/smg
 	name = "Magazine - .45"
@@ -726,7 +726,7 @@ var/list/uplink_items = list()
 			will instantly put them in your grasp and silence them, as well as causing rapid suffocation. Does not work on those who do not need to breathe."
 	reference = "GAR"
 	item = /obj/item/weapon/twohanded/garrote
-	cost = 12
+	cost = 10
 
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
@@ -1045,7 +1045,7 @@ var/list/uplink_items = list()
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
 	reference = "HAI"
 	item = /obj/item/weapon/aiModule/syndicate
-	cost = 14
+	cost = 12
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"
@@ -1095,7 +1095,7 @@ var/list/uplink_items = list()
 			sends you a small beacon that will teleport the larger beacon to your location upon activation."
 	reference = "SNGB"
 	item = /obj/item/device/radio/beacon/syndicate
-	cost = 14
+	cost = 12
 	surplus = 0
 
 /datum/uplink_item/device_tools/syndicate_bomb


### PR DESCRIPTION
As per title. Basically #8226 but the tator item has been split off for review purpose. 

**Normal Tators:**
Cane shotgun: 15 -> 10 
Feral Cat: 5 -> 4  
Booze shells: 6 -> 3 (Loud, not instantly effective and absolutely underappreciated)
Garrote: 12 -> 10 (Highly situational items, powerful, but underused)
Power beacon: 14 -> 12 
Revolver ammo: 4 -> 3(You can print it anyhow)

🆑
tweak: Some underappreciated traitor items had been made cheaper.
/🆑 