### PR TITLE
Custom Title for Command Warnings

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -367,6 +367,10 @@ var/time_last_changed_position = 0
 				if(!job_in_department(job_master.GetJob(t1)))
 					return 0
 				if(t1 == "Custom")
+					if(modify.assignment in command_positions)
+						if(alert("Command personnel with custom titles do not show up correctly on the Crew Manifest, and may not be recognized as easily by crew. Proceed? \
+						", "Caution: Custom Command Title", "No", "Yes")!="Yes")
+							return
 					var/temp_t = sanitize(copytext(input("Enter a custom job assignment.","Assignment"),1,MAX_MESSAGE_LEN))
 					//let custom jobs function as an impromptu alt title, mainly for sechuds
 					if(temp_t && modify)


### PR DESCRIPTION
Adds a warning when attempting to set a custom job title on a command-level ID card.

Screenshot: 
![command_custom_title_warning](https://user-images.githubusercontent.com/16434066/32098823-cdadfb5e-bac2-11e7-97a5-d45b1acc4dee.PNG)


Note:
- The warning is just a warning, it can be dismissed with a single click. It doesn't actually stop you doing anything, it just encourages people to think twice.
- It only appears when trying to assign a custom title to a command staff member using an ID console. Custom titles for regular crew are unaffected. Standard titles, including command titles, can still be assigned without triggering this. It only occurs if you go to assign a custom title to someone who is already a member of Command.

Why is this a good idea?
- Because custom titles don't show up correctly on the crew manifest. They show up at the very bottom, which can give the impression that there is no head of staff for the relevant department. Or, in cases of an acting Captain, no Captain at all. This creates confusion, both for players and admins, and the regular cry of 'Captain, what Captain?'.
- I believe I remember reading on the wiki that "The Captain of the station should always use the title 'Captain', so it is clear to everyone who is in charge of the station". So, this has already been considered best practice for awhile.
- Custom titles are also prone to not working with Sec HUDs. For example, if you assign 'Acting HoS' to a Security Officer, their SecHUD icon won't update, but if you assign 'Head of Security' (the real title) then it will. This makes peoples' real jobs easier to recognize, at least for key roles, both on manifest, and on SecHUDs.

Effectively, this PR softly discourages people from using custom titles in Command positions, as it tends to bork the manifest, sec HUDs, etc. Of course, antagonists are always going to dismiss it, but regular Command will hopefully think twice.

A similar effect could be achieved by adding "Do not give custom titles to members of Command" to station SOP - discouraging it but not preventing it. I went the easy-to-dismiss warning route as I am hoping it will stir some discussion on the topic. 

🆑 Kyep
add: Attempting to set a Command-level ID to a custom title (which won't show up correctly on the manifest, or, in some cases, on SecHUDs) now triggers a confirmation prompt. You can say yes, but at least you'll be aware of the issues it can cause.
/🆑