### PR TITLE
Fixes Freedom Op suits going red when toggled

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -353,6 +353,9 @@
 	icon_state = "griffinhat"
 	item_state = "griffinhat"
 
+/obj/item/clothing/head/helmet/space/hardsuit/syndi/freedom/update_icon()
+	return
+
 /obj/item/clothing/suit/space/hardsuit/syndi
 	name = "blood-red hardsuit"
 	desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in travel mode. Property of Gorlex Marauders."
@@ -442,6 +445,8 @@
 	icon_state = "freedom"
 	item_state = "freedom"
 
+/obj/item/clothing/suit/space/hardsuit/syndi/freedom/update_icon()
+	return
 
 //Wizard hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/wizard


### PR DESCRIPTION
🆑 Kyep
fix: Freedom Operative suits no longer revert to a normal red syndi suit icon when you use their 'toggle hardsuit mode' option.
/ 🆑

They do, however, keep their multiple suit modes, a feature the original freedom suits did not have.