### PR TITLE
Adds the GitHub button

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -84,6 +84,7 @@
 	var/wikiurl = "http://example.org"
 	var/forumurl = "http://example.org"
 	var/rulesurl = "http://example.org"
+	var/githuburl = "http://example.org"
 	var/donationsurl = "http://example.org"
 	var/repositoryurl = "http://example.org"
 
@@ -374,6 +375,9 @@
 
 				if("rulesurl")
 					config.rulesurl = value
+
+				if("githuburl")
+					config.githuburl = value
 
 				if("donationsurl")
 					config.donationsurl = value

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -185,6 +185,9 @@ CHECK_RANDOMIZER
 ## Rules address
 # RULESURL http://example.org
 
+## GitHub address
+# GITHUBURL http://example.org
+
 ## Donations address
 # DONATIONSURL http://example.org
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -71,7 +71,7 @@
 	set desc = "Visit the GitHub page."
 	set hidden = 1
 	if(config.githuburl)
-		if(alert("This will open our Source Code page on GitHub. Are you sure?",,"Yes","No")=="No")
+		if(alert("This will open our source code page on GitHub. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.githuburl)
 	else

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -71,7 +71,7 @@
 	set desc = "Visit the GitHub page."
 	set hidden = 1
 	if(config.githuburl)
-		if(alert("This will open our source code page on GitHub. Are you sure?",,"Yes","No")=="No")
+		if(alert("This will open our GitHub repository in your browser. Are you sure?",,"Yes","No")=="No")
 			return
 		src << link(config.githuburl)
 	else

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -66,6 +66,18 @@
 		to_chat(src, "<span class='danger'>The rules URL is not set in the server configuration.</span>")
 	return
 
+/client/verb/github()
+	set name = "GitHub"
+	set desc = "Visit the GitHub page."
+	set hidden = 1
+	if(config.githuburl)
+		if(alert("This will open our Source Code page on GitHub. Are you sure?",,"Yes","No")=="No")
+			return
+		src << link(config.githuburl)
+	else
+		to_chat(src, "<span class='danger'>The GitHub URL is not set in the server configuration.</span>")
+	return
+
 /client/verb/donate()
 	set name = "Donate"
 	set desc = "Donate to help with hosting costs."

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -1,7 +1,7 @@
 //Please use mob or src (not usr) in these procs. This way they can be called in the same fashion as procs.
 /client/verb/wiki(query as text)
 	set name = "wiki"
-	set desc = "Type what you want to know about.  This will open the wiki on your web browser."
+	set desc = "Type what you want to know about.  This will open the wiki in your web browser."
 	set hidden = 1
 	if(config.wikiurl)
 		if(query)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1611,20 +1611,6 @@ window "rpane"
 		type = MAIN
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
-	elem "donate"
-		type = BUTTON
-		pos = 544,0
-		size = 60x16
-		background-color = #8080ff
-		text = "Donate"
-		command = "Donate"
-	elem "karma"
-		type = BUTTON
-		pos = 474,0
-		size = 67x16
-		background-color = #ff8040
-		text = "Karma Shop"
-		command = "karmashop"
 	elem "rpanewindow"
 		type = CHILD
 		pos = -9,15
@@ -1637,36 +1623,6 @@ window "rpane"
 		is-vert = false
 		splitter = 50
 		show-splitter = true
-	elem "rulesb"
-		type = BUTTON
-		pos = 278,0
-		size = 60x16
-		text = "Rules"
-		command = "rules"
-	elem "changelog"
-		type = BUTTON
-		pos = 404,0
-		size = 67x16
-		text = "Changelog"
-		command = "Changelog"
-	elem "githubb"
-		type = BUTTON
-		pos = 341,0
-		size = 60x16
-		text = "GitHub"
-		command = "github"
-	elem "forumb"
-		type = BUTTON
-		pos = 215,0
-		size = 60x16
-		text = "Forum"
-		command = "forum"
-	elem "wikib"
-		type = BUTTON
-		pos = 152,0
-		size = 60x16
-		text = "Wiki"
-		command = "wiki"
 	elem "textb"
 		type = BUTTON
 		pos = 0,0
@@ -1678,16 +1634,6 @@ window "rpane"
 		is-checked = true
 		group = "rpanemode"
 		button-type = pushbox
-	elem "browseb"
-		type = BUTTON
-		pos = 561,0
-		size = 60x16
-		is-visible = false
-		saved-params = "is-checked"
-		text = "Browser"
-		command = ".winset \"rpanewindow.left=browserwindow\""
-		group = "rpanemode"
-		button-type = pushbox
 	elem "infob"
 		type = BUTTON
 		pos = 64,0
@@ -1696,6 +1642,60 @@ window "rpane"
 		saved-params = "is-checked"
 		text = "Info"
 		command = ".winset \"rpanewindow.left=infowindow\""
+		group = "rpanemode"
+		button-type = pushbox
+	elem "wikib"
+		type = BUTTON
+		pos = 155,0
+		size = 60x16
+		text = "Wiki"
+		command = "wiki"
+	elem "forumb"
+		type = BUTTON
+		pos = 220,0
+		size = 60x16
+		text = "Forum"
+		command = "forum"
+	elem "rulesb"
+		type = BUTTON
+		pos = 285,0
+		size = 60x16
+		text = "Rules"
+		command = "rules"
+	elem "githubb"
+		type = BUTTON
+		pos = 350,0
+		size = 60x16
+		text = "GitHub"
+		command = "github"
+	elem "changelog"
+		type = BUTTON
+		pos = 415,0
+		size = 67x16
+		text = "Changelog"
+		command = "Changelog"
+	elem "karma"
+		type = BUTTON
+		pos = 487,0
+		size = 67x16
+		background-color = #ff8040
+		text = "Karma Shop"
+		command = "karmashop"
+	elem "donate"
+		type = BUTTON
+		pos = 559,0
+		size = 60x16
+		background-color = #8080ff
+		text = "Donate"
+		command = "Donate"
+	elem "browseb"
+		type = BUTTON
+		pos = 561,0
+		size = 60x16
+		is-visible = false
+		saved-params = "is-checked"
+		text = "Browser"
+		command = ".winset \"rpanewindow.left=browserwindow\""
 		group = "rpanemode"
 		button-type = pushbox
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1613,14 +1613,14 @@ window "rpane"
 		is-pane = true
 	elem "donate"
 		type = BUTTON
-		pos = 480,-2
-		size = 60x20
+		pos = 544,0
+		size = 60x16
 		background-color = #8080ff
 		text = "Donate"
 		command = "Donate"
 	elem "karma"
 		type = BUTTON
-		pos = 410,0
+		pos = 474,0
 		size = 67x16
 		background-color = #ff8040
 		text = "Karma Shop"
@@ -1645,10 +1645,16 @@ window "rpane"
 		command = "rules"
 	elem "changelog"
 		type = BUTTON
-		pos = 341,0
+		pos = 404,0
 		size = 67x16
 		text = "Changelog"
 		command = "Changelog"
+	elem "githubb"
+		type = BUTTON
+		pos = 341,0
+		size = 60x16
+		text = "GitHub"
+		command = "github"
 	elem "forumb"
 		type = BUTTON
 		pos = 215,0


### PR DESCRIPTION
Reason: Opens up more interaction for possible coders to add to the server

preview: ![](https://i.imgur.com/bPgxtxe.png)

🆑 NewSta
add: There is now a "GitHub" button.
tweak: Modified the height of the "Donate" button to make it equal to that of other buttons.
tweak: The distance between the info and wiki buttons is now 30 px. All other buttons now have a 5px distance between them.
fix: Fixed a typo in the wiki window.
/ 🆑