### PR TITLE
Helps prevent blatently illegal executions

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -170,13 +170,14 @@
 					var/t1
 					if(temp_href[2] == "execute")
 						t1 = copytext(trim(sanitize(input("Explain why they are being executed. Include a list of their crimes, and victims.", "EXECUTION ORDER", null, null) as text)), 1, MAX_MESSAGE_LEN)
-						if(!t1)
-							setTemp("<h3 class='bad'>Error: setting someone to execute REQUIRES a valid reason.</h3>")
-							return 1
 					else
 						t1 = copytext(trim(sanitize(input("Enter Reason:", "Secure. records", null, null) as text)), 1, MAX_MESSAGE_LEN)
-						if(!t1)
-							t1 = "(none)"
+					var visible_reason
+					if(t1)
+						visible_reason = t1
+					else
+						t1 = "(none)"
+						visible_reason = "<span class='warning'>NO REASON PROVIDED</span>"
 					switch(temp_href[2])
 						if("none")
 							active2.fields["criminal"] = "None"
@@ -185,7 +186,7 @@
 						if("execute")
 							if((access_magistrate in authcard_access) || (access_armory in authcard_access))
 								active2.fields["criminal"] = "*Execute*"
-								message_admins("[key_name_admin(usr)] authorized <span class='warning'>EXECUTION</span> for [their_rank] [their_name], with comment: [t1] \
+								message_admins("[key_name_admin(usr)] authorized <span class='warning'>EXECUTION</span> for [their_rank] [their_name], with comment: [visible_reason] \
 									| (<A HREF='?_src_=holder;adminplayeropts=\ref[usr]'>PP</A>) \
 									| (<A HREF='?_src_=holder;CentcommReply=\ref[usr]'>RADIO</A>) \
 									| (<A HREF='?_src_=holder;subtlemessage=\ref[usr]'>SM</A>) \

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -172,7 +172,7 @@
 						t1 = copytext(trim(sanitize(input("Explain why they are being executed. Include a list of their crimes, and victims.", "EXECUTION ORDER", null, null) as text)), 1, MAX_MESSAGE_LEN)
 					else
 						t1 = copytext(trim(sanitize(input("Enter Reason:", "Secure. records", null, null) as text)), 1, MAX_MESSAGE_LEN)
-					var visible_reason
+					var/visible_reason
 					if(t1)
 						visible_reason = t1
 					else
@@ -186,12 +186,7 @@
 						if("execute")
 							if((access_magistrate in authcard_access) || (access_armory in authcard_access))
 								active2.fields["criminal"] = "*Execute*"
-								message_admins("[key_name_admin(usr)] authorized <span class='warning'>EXECUTION</span> for [their_rank] [their_name], with comment: [visible_reason] \
-									| (<A HREF='?_src_=holder;adminplayeropts=\ref[usr]'>PP</A>) \
-									| (<A HREF='?_src_=holder;CentcommReply=\ref[usr]'>RADIO</A>) \
-									| (<A HREF='?_src_=holder;subtlemessage=\ref[usr]'>SM</A>) \
-									| ([admin_jump_link(usr)]) \
-								")
+								message_admins("[ADMIN_FULLMONTY(usr)] authorized <span class='warning'>EXECUTION</span> for [their_rank] [their_name], with comment: [visible_reason]")
 							else
 								setTemp("<h3 class='bad'>Error: permission denied.</h3>")
 								return 1

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -167,9 +167,16 @@
 				if(active2)
 					var/their_name = active2.fields["name"]
 					var/their_rank = active2.fields["rank"]
-					var/t1 = copytext(trim(sanitize(input("Enter Reason:", "Secure. records", null, null) as text)), 1, MAX_MESSAGE_LEN)
-					if(!t1)
-						t1 = "(none)"
+					var/t1
+					if(temp_href[2] == "execute")
+						t1 = copytext(trim(sanitize(input("Explain why they are being executed. Include a list of their crimes, and victims.", "EXECUTION ORDER", null, null) as text)), 1, MAX_MESSAGE_LEN)
+						if(!t1)
+							setTemp("<h3 class='bad'>Error: setting someone to execute REQUIRES a valid reason.</h3>")
+							return 1
+					else
+						t1 = copytext(trim(sanitize(input("Enter Reason:", "Secure. records", null, null) as text)), 1, MAX_MESSAGE_LEN)
+						if(!t1)
+							t1 = "(none)"
 					switch(temp_href[2])
 						if("none")
 							active2.fields["criminal"] = "None"
@@ -178,10 +185,14 @@
 						if("execute")
 							if((access_magistrate in authcard_access) || (access_armory in authcard_access))
 								active2.fields["criminal"] = "*Execute*"
-								message_admins("[key_name_admin(usr)] authorized execution for [their_rank] [their_name], with comment: [t1]")
+								message_admins("[key_name_admin(usr)] authorized <span class='warning'>EXECUTION</span> for [their_rank] [their_name], with comment: [t1] \
+									| (<A HREF='?_src_=holder;adminplayeropts=\ref[usr]'>PP</A>) \
+									| (<A HREF='?_src_=holder;CentcommReply=\ref[usr]'>RADIO</A>) \
+									| (<A HREF='?_src_=holder;subtlemessage=\ref[usr]'>SM</A>) \
+									| ([admin_jump_link(usr)]) \
+								")
 							else
 								setTemp("<h3 class='bad'>Error: permission denied.</h3>")
-								//to_chat(usr, "<span class='notice'>Error: permission denied.</span>")
 								return 1
 						if("incarcerated")
 							active2.fields["criminal"] = "Incarcerated"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1688,9 +1688,9 @@
 		if(!input)	return
 
 		to_chat(src.owner, "You sent [input] to [H] via a secure channel.")
-		log_admin("[key_name(src.owner)] replied to [key_name(H)]'s Centcomm message with the message: [input]")
+		log_admin("[key_name(src.owner)] replied to [key_name(H)]'s Centcomm message with the message [input].")
 		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)]'s Centcom message with: \"[input]\"")
-		to_chat(H, "<span class='warning'>You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: [input]\" </span>")
+		to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. [input].  Message ends.\"")
 
 	else if(href_list["EvilFax"])
 		if(!check_rights(R_ADMIN))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1688,9 +1688,9 @@
 		if(!input)	return
 
 		to_chat(src.owner, "You sent [input] to [H] via a secure channel.")
-		log_admin("[key_name(src.owner)] replied to [key_name(H)]'s Centcomm message with the message [input].")
+		log_admin("[key_name(src.owner)] replied to [key_name(H)]'s Centcomm message with the message: [input]")
 		message_admins("[key_name_admin(src.owner)] replied to [key_name_admin(H)]'s Centcom message with: \"[input]\"")
-		to_chat(H, "You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows. [input].  Message ends.\"")
+		to_chat(H, "<span class='warning'>You hear something crackle in your headset for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: [input]\" </span>")
 
 	else if(href_list["EvilFax"])
 		if(!check_rights(R_ADMIN))


### PR DESCRIPTION
🆑 Kyep
tweak: It is now much harder for Command/HoS to get away with illegal executions. Admins are far more likely to notice people being set to execute, more detailed explanations of executions must be sent to CC, and admins are more able to intervene when an execution is obviously illegal.
/ 🆑

Changes:
1) ~~When setting someone to execute, failing to enter a reason will now result in an error message stating "setting someone to execute REQUIRES a valid reason". Previously, you could skip entering a reason when setting someone to execute, which made it almost impossible for the admin who sees it to know if it was valid without a lengthy investigation.~~ Removed due to Tully request.
2) When setting someone to execute, the prompt has been changed from "Enter Reason" to "Explain why they are being executed. Include a list of their crimes, and victims". This implies that something like 'EoC' or 'vampire' isn't valid, but 'Murder of the HoP John Jones" is. This ensures that when an admin sees someone being set to execute, they can easily verify whether or not that person really does deserve execution. It is intended to make it easier to investigate claims of illegal executions by Security.
3) Whenever someone is successfully set to execute, the message broadcast to admins now includes a big red "EXECUTE". This is intended to stop it getting lost in the endless amount of attack logs admins get.
4) Admins also see PP, JMP, FLW, SM, RADIO etc options on the alerts they get about people being set to execute. This enables them to quickly look at the situation - and send a reply directly to the person's headset. E.g: "Clowns are not automatically execution-worthy. Also, you are fired."
~~All centcom messages sent to a person's headset now appear in RED TEXT. I changed this because, right now, they have no text formatting whatsoever, and are thus really easy to miss.~~ Removed due to Tiger request.

![execution_improvements](https://user-images.githubusercontent.com/16434066/32258426-ac4a92a2-be77-11e7-8c99-045088d3ccb8.PNG)
