### PR TITLE
Remove redundant you

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1036,7 +1036,7 @@
 		return //no message spam
 
 	if(final_taste_list.len == 0)//too many reagents - none meet their thresholds
-		to_chat(src, "<span class='notice'>You you can't really make out what you're tasting...</span>")
+		to_chat(src, "<span class='notice'>You can't really make out what you're tasting...</span>")
 		return
 
 	to_chat(src, "<span class='notice'>You can taste [english_list(final_taste_list)].</span>")


### PR DESCRIPTION
There was an extra you when you can't make out what you're tasting when eating something.

This PR fix it.

No CL.