### PR TITLE
Atmos Fix

### DIFF
--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -45,7 +45,7 @@
 	icon = 'icons/vehicles/CargoTrain.dmi'
 	icon_state = "ambulance"
 	anchored = 0
-	throw_pressure_limit = 9001 //Throwing an ambulance trolley can kill the process scheduler.
+	throw_pressure_limit = INFINITY //Throwing an ambulance trolley can kill the process scheduler.
 
 /obj/structure/stool/bed/amb_trolley/MouseDrop(obj/over_object as obj)
 	..()


### PR DESCRIPTION
Fixes ambulance once and for all.

🆑  Alffd
fix: Makes throwing the ambulance with atmospherics almost impossible.
/🆑 