### PR TITLE
Revert Fastmos

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -305,27 +305,14 @@
 
 
 /atom/movable/var/pressure_resistance = 5
-/atom/movable/var/throw_pressure_limit = 15
 /atom/movable/var/last_forced_movement = 0
 
 /atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
-	if(last_forced_movement >= air_master.current_cycle)
+	if(last_forced_movement + 4 >= air_master.current_cycle)
 		return 0
-	else if(!anchored && !pulledby)
-		if(pressure_difference >= throw_pressure_limit)
-			var/general_direction = get_edge_target_turf(src, direction)
-			if(last_forced_movement + 10 < air_master.current_cycle && is_valid_tochat_target(src)) //the first check prevents spamming throw to_chat
-				to_chat(src, "<span class='userdanger'>The pressure sends you flying!</span>")
-			if(ishuman(src))
-				var/mob/living/carbon/human/H = src
-				H.Weaken(min(pressure_difference / 10, 10))
-			spawn()
-				throw_at(general_direction, pressure_difference / 10, pressure_difference / 200, null, 0, 0, null)
-			last_forced_movement = air_master.current_cycle
-			return 1
-		else if(pressure_difference > pressure_resistance)
-			spawn()
-				step(src, direction)
+	if(!anchored && !pulledby && pressure_difference > pressure_resistance)
+		spawn()
+			step(src, direction)
 			last_forced_movement = air_master.current_cycle
 			return 1
 	return 0

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -42,7 +42,6 @@
 	var/is_zombie = 0
 	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 	pressure_resistance = 100    //100 kPa difference required to push
-	throw_pressure_limit = 120  //120 kPa difference required to throw
 
 /mob/living/simple_animal/hostile/blob/blobspore/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	..()
@@ -91,7 +90,6 @@
 	update_icons()
 	H.loc = src
 	pressure_resistance = 20  //5 kPa difference required to push lowered
-	throw_pressure_limit = 30  //15 kPa difference required to throw lowered
 	loc.visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
@@ -168,7 +166,6 @@
 	environment_smash = 3
 	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 	pressure_resistance = 100    //100 kPa difference required to push
-	throw_pressure_limit = 120  //120 kPa difference required to throw
 
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/blob_act()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -14,7 +14,6 @@
 	var/custom_pixel_x_offset = 0 //for admin fuckery.
 	var/custom_pixel_y_offset = 0
 	pressure_resistance = 100    //100 kPa difference required to push
-	throw_pressure_limit = 120  //120 kPa difference required to throw
 
 //This is fine right now, if we're adding organ specific damage this needs to be updated
 /mob/living/carbon/alien/humanoid/New()

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -24,7 +24,6 @@
 	unsuitable_atmos_damage = 15
 	heat_damage_per_tick = 20
 	pressure_resistance = 100    //100 kPa difference required to push
-	throw_pressure_limit = 120   //120 kPa difference required to throw
 	faction = list("alien")
 	status_flags = CANPUSH
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -39,7 +39,6 @@ var/global/list/ts_spiderling_list = list()
 	move_to_delay = 6
 	turns_per_move = 5
 	pressure_resistance = 50    //50 kPa difference required to push
-	throw_pressure_limit = 100  //100 kPa difference required to throw
 	pass_flags = PASSTABLE
 
 	// Ventcrawling

--- a/code/modules/vehicle/ambulance.dm
+++ b/code/modules/vehicle/ambulance.dm
@@ -45,7 +45,6 @@
 	icon = 'icons/vehicles/CargoTrain.dmi'
 	icon_state = "ambulance"
 	anchored = 0
-	throw_pressure_limit = INFINITY //Throwing an ambulance trolley can kill the process scheduler.
 
 /obj/structure/stool/bed/amb_trolley/MouseDrop(obj/over_object as obj)
 	..()


### PR DESCRIPTION
It was decided based on the results of the recent poll to remove the throwing and space wind effect.

This keeps atmos at its increased speed, however pressure based throwing is removed, additionally spacewind is reduced to previous levels, no more then 1 tile moved per 2 seconds with no blocking of movement, regardless of pressure.

Related thread can be found at [Revert Fastmos](https://nanotrasen.se/forum/topic/11976-revert-fastmos/)

:cl: TullyBBurnalot
del: Revert Fastmos
tweak: Reduce spacewind by a factor of 4
/:cl: 

