### PR TITLE
Contortionist Jumpsuit fix

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -751,11 +751,12 @@
 	item_state = "noble_clothes"
 
 /obj/item/clothing/under/contortionist
-	name = "Contortionist's Jumpsuit"
+	name = "atmospheric technician's jumpsuit"
 	desc = "A light jumpsuit useful for squeezing through narrow vents."
 	icon_state = "atmos"
 	item_state = "atmos_suit"
 	item_color = "atmos"
+	burn_state = FIRE_PROOF
 
 /obj/item/clothing/under/contortionist/equipped(mob/living/carbon/human/user, slot)
 	if(!user.ventcrawler)


### PR DESCRIPTION
Fixes the name of the Contortionist's jumpsuit actually being "Contortionist's Jumpsuit". It is now named "atmospheric technician's jumpsuit", as it is meant to look exactly like an atmos tech jumpsuit.
- The uplink still lists it as the Contortionist's Jumpsuit, so you know what you are buying and don't mistake it for the normal atmos tech jumpsuit being offered.

Also gave the suit the FIRE_PROOF burn_state, meaning it won't burn to ash, again mimicking the atmos tech jumpsuit.

It does NOT, however, have the ONESIZEFITSALL flag, so fatties can't wear it (you're squeezing into a tight space anyways, it makes more sense it won't fit the huskier of spessfolk).

:cl:
tweak: The Syndicate has determined that subtle and stealthy items don't benefit from obvious names, and thus have rebranded their contortionist jumpsuit to something less eye-catching.
tweak: The Syndicate decided to be less stingy than Nanotrasen and made the contortionist jumpsuit out of flame resistant materials. You may burn, but the jumpsuit won't!
/:cl: