### PR TITLE
Nerfs Shotgun Pellets

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -134,7 +134,7 @@
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "cshell"
-	projectile_type = /obj/item/projectile/bullet/rpellet
+	projectile_type = /obj/item/projectile/bullet/pellet/rubber
 	pellets = 6
 	variance = 25
 	materials = list(MAT_METAL=4000)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -69,8 +69,26 @@
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
 	damage = 12.5
+	var/tile_dropoff = 0.75
+	var/tile_dropoff_s = 1.25
+
+/obj/item/projectile/bullet/pellet/Range()
+	..()
+	if(damage > 0)
+		damage -= tile_dropoff
+	if(stamina > 0)
+		stamina -= tile_dropoff_s
+	if(damage < 0 && stamina < 0)
+		qdel(src)
+
+/obj/item/projectile/bullet/pellet/rubber
+	name = "rubber pellet"
+	damage = 3
+	stamina = 25
+	icon_state = "bullet-r"
 
 /obj/item/projectile/bullet/pellet/weak
+	tile_dropoff = 0.55		//Come on it does 6 damage don't be like that.
 	damage = 6
 
 /obj/item/projectile/bullet/pellet/weak/New()
@@ -127,12 +145,6 @@
 
 /obj/item/projectile/bullet/heavybullet
 	damage = 35
-
-/obj/item/projectile/bullet/rpellet
-	name = "rubber pellet"
-	damage = 3
-	stamina = 25
-	icon_state = "bullet-r"
 
 /obj/item/projectile/bullet/stunshot//taser slugs for shotguns, nothing special
 	name = "stunshot"


### PR DESCRIPTION
From TG

Shotguns are still the go-to thing for dealing with anything you need killed; the most egregious use of them though, is still buckshot.

This doesn't really change how effective they are at point blank range; they're still going to destroy whatever you shoot up close.

That said, for the "spray and pray while half a screen away" strat? This won't be as effective. Shotgun pellets lose 0.75 damage (per pellet) for each turf they travel. When their damage hits 0, they delete.

Shotguns will still remain ridiculously strong when used point blank, but they should no longer be the absolute best weapon for any mob in any situation you come across.

:cl: Fox McCloud
tweak: shotgun pellets deal less damage the further they travel
/:cl: