### PR TITLE
Gambling machines now payout again

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -47,14 +47,14 @@
 		if(operation == 1) // Play
 			if(working == 1)
 				return
-			if(!account || account.money < 100)
+			if(!account || account.money < 10)
 				return
-			if(!account.charge(100, transaction_purpose = "Bet", dest_name = name))
+			if(!account.charge(10, transaction_purpose = "Bet", dest_name = name))
 				return
 			plays += 1
 			working = 1
 			icon_state = "slots-on"
-			var/roll = rand(1,20000)
+			var/roll = rand(1,1350)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			spawn(25)
 				if(roll == 1)

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -54,7 +54,7 @@
 			plays += 1
 			working = 1
 			icon_state = "slots-on"
-			var/roll = rand(1,1350)
+			var/roll = rand(1,4050)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
 			spawn(25)
 				if(roll == 1)
@@ -69,27 +69,27 @@
 					result = "Big Winner! You win a hundred thousand credits!"
 					resultlvl = "good"
 					win_money(100000, 'sound/goonstation/misc/klaxon.ogg')
-				else if(roll > 5 && roll <= 25)
+				else if(roll > 5 && roll <= 50)
 					visible_message("<b>[src]</b> says, 'Big Winner! [usr.name] has won ten thousand credits!'")
 					result = "You win ten thousand credits!"
 					resultlvl = "good"
 					win_money(10000, 'sound/goonstation/misc/klaxon.ogg')
-				else if(roll > 25 && roll <= 50)
+				else if(roll > 50 && roll <= 100)
 					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won a thousand credits!'")
 					result = "You win a thousand credits!"
 					resultlvl = "good"
 					win_money(1000, 'sound/goonstation/misc/bell.ogg')
-				else if(roll > 50 && roll <= 100)
+				else if(roll > 100 && roll <= 200)
 					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won a hundred credits!'")
 					result = "You win a hundred credits!"
 					resultlvl = "good"
 					win_money(100, 'sound/goonstation/misc/bell.ogg')
-				else if(roll > 100 && roll <= 200)
+				else if(roll > 200 && roll <= 300)
 					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won fifty credits!'")
 					result = "You win fifty credits!"
 					resultlvl = "good"
 					win_money(50)
-				else if(roll > 200 && roll <= 500)
+				else if(roll > 300 && roll <= 600)
 					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won ten credits!'")
 					result = "You win ten credits!"
 					resultlvl = "good"

--- a/nano/templates/slotmachine.tmpl
+++ b/nano/templates/slotmachine.tmpl
@@ -12,10 +12,10 @@ Used In File(s): /code/game/machinery/slotmachine.dm
 	</div>
 	<div class="item">
 		<div class="statusLabel">
-			Hundred credits to play!
+			Ten credits to play!
 		</div>
 		<div class="statusValue">
-			{{:helper.link('SPIN!', 'refresh', {'ops' : 1}, data.money >= 100 && !data.working ? null : 'disabled')}}
+			{{:helper.link('SPIN!', 'refresh', {'ops' : 1}, data.money >= 10 && !data.working ? null : 'disabled')}}
 		</div>
 	</div>
 	{{if data.result}}


### PR DESCRIPTION
~~Reverts https://github.com/ParadiseSS13/Paradise/pull/8182 - and the subsequent https://github.com/ParadiseSS13/Paradise/pull/8222~~

~~As it is right now - there is absolutely no reliable way to earn money.~~ Gambling machines sit idle, ignored in the bar because of the realism slap.

~~Things that can be bought with money are novel, and there is really no downside in not restricting those items.~~

~~If an attempt at an economy or making money "useful" wants to be done, it should be done all together instead of removing the only reliable way to make money while keeping all the other aspects and doing the rest later.~~

### **Edit: Compared to how it used to be, it is now to 2x harder to win something and 3x harder for the 1 mil & 100k jackpot**
_(*unless my math is wrong which wouldn't be surprising and it's really like 1.5x harder. correct me if that's the case)_

While it won't be a "money printer" again now, it certainly won't be a scam like the current iteration.


:cl:
tweak: Gambling machines now payout again.
/:cl:
