### PR TITLE
Small fixes and improvments for rigsuits 

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -43,7 +43,7 @@
 	//Component/device holders.
 	var/obj/item/weapon/tank/air_supply                       // Air tank, if any.
 	var/obj/item/clothing/shoes/magboots/boots = null             // Deployable boots, if any.
-	var/obj/item/clothing/shoes/under_boots = null								//Boots that are between the feet and the rib boots, if any.
+	var/obj/item/clothing/shoes/under_boots = null								//Boots that are between the feet and the rig boots, if any.
 	var/obj/item/clothing/suit/space/new_rig/chest                // Deployable chestpiece, if any.
 	var/obj/item/clothing/head/helmet/space/new_rig/helmet = null // Deployable helmet, if any.
 	var/obj/item/clothing/gloves/rig/gloves = null            // Deployable gauntlets, if any.

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -50,6 +50,19 @@
 				rig.electrified = 30
 			rig.shock(usr,100)
 
+/datum/wires/rig/GetWireName(index)
+	switch(index)
+		if(RIG_SECURITY)
+			return "ID check"
+		if(RIG_AI_OVERRIDE)
+			return "AI control"
+		if(RIG_SYSTEM_CONTROL)
+			return "System control"
+		if(RIG_INTERFACE_LOCK)
+			return "Interface lock"
+		if(RIG_INTERFACE_SHOCK)
+			return "Electrification"
+
 /datum/wires/rig/CanUse(var/mob/living/L)
 	var/obj/item/weapon/rig/rig = holder
 	if(rig.open)

--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -5,7 +5,7 @@
 	icon_state = "breacher_rig_cheap"
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 30, bomb = 45, bio = 100, rad = 50)
 	emp_protection = -20
-	slowdown = 6
+	active_slowdown = 6
 	offline_slowdown = 10
 	vision_restriction = 1
 	offline_vision_restriction = 2

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -6,7 +6,7 @@
 	icon_state = "security_rig"
 	suit_type = "combat hardsuit"
 	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100)
-	slowdown = 1
+	active_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = 1
 

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -6,7 +6,7 @@
 	suit_type = "light suit"
 	allowed = list(/obj/item/weapon/gun,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/tank,/obj/item/weapon/stock_parts/cell)
 	emp_protection = 10
-	slowdown = 0
+	active_slowdown = 0
 	flags = STOPSPRESSUREDMAGE | THICKMATERIAL
 	offline_slowdown = 0
 	offline_vision_restriction = 0
@@ -77,7 +77,7 @@
 	icon_state = "ninja_rig"
 	armor = list(melee = 50, bullet = 15, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 30)
 	emp_protection = 40 //change this to 30 if too high.
-	slowdown = 0
+	active_slowdown = 0
 
 	chest_type = /obj/item/clothing/suit/space/new_rig/light/ninja
 	glove_type = /obj/item/clothing/gloves/rig/light/ninja

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -6,7 +6,7 @@
 	icon_state = "merc_rig"
 	suit_type = "crimson hardsuit"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
-	slowdown = 1
+	active_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = 1
 

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -17,7 +17,7 @@
 	icon_state = "internalaffairs_rig"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
-	slowdown = 0
+	active_slowdown = 0
 	offline_slowdown = 0
 	offline_vision_restriction = 0
 
@@ -52,7 +52,7 @@
 	desc = "A heavy, powerful rig used by construction crews and mining corporations."
 	icon_state = "engineering_rig"
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
-	slowdown = 3
+	active_slowdown = 3
 	offline_slowdown = 10
 	offline_vision_restriction = 2
 	emp_protection = -20
@@ -80,7 +80,7 @@
 	suit_type = "EVA hardsuit"
 	desc = "A light rig for repairs and maintenance to the outside of habitats and vessels."
 	icon_state = "eva_rig"
-	slowdown = 0
+	active_slowdown = 0
 	offline_slowdown = 1
 	offline_vision_restriction = 1
 
@@ -108,7 +108,7 @@
 	desc = "An advanced voidsuit that protects against hazardous, low pressure environments. Shines with a high polish."
 	icon_state = "ce_rig"
 	armor = list(melee = 40, bullet = 5, laser = 10, energy = 5, bomb = 50, bio = 100, rad = 90)
-	slowdown = 0
+	active_slowdown = 0
 	offline_slowdown = 0
 	offline_vision_restriction = 0
 
@@ -149,7 +149,7 @@
 	suit_type = "hazmat hardsuit"
 	desc = "An Anomalous Material Interaction hardsuit that protects against the strangest energies the universe can throw at it."
 	icon_state = "science_rig"
-	slowdown = 1
+	active_slowdown = 1
 	offline_vision_restriction = 1
 
 	helm_type = /obj/item/clothing/head/helmet/space/new_rig/hazmat
@@ -176,7 +176,7 @@
 	desc = "A durable suit designed for medical rescue in high risk areas."
 	icon_state = "medical_rig"
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 50)
-	slowdown = 1
+	active_slowdown = 1
 	offline_vision_restriction = 1
 
 	helm_type = /obj/item/clothing/head/helmet/space/new_rig/medical
@@ -201,7 +201,7 @@
 	desc = "A Security hardsuit designed for prolonged EVA in dangerous environments."
 	icon_state = "hazard_rig"
 	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50)
-	slowdown = 1
+	active_slowdown = 1
 	offline_slowdown = 3
 	offline_vision_restriction = 1
 


### PR DESCRIPTION
Fixes the rigsuit shocking someone who did use a signaller to pulse a wire from afar. Also fixes the shocked and malfunction counter from not counting down if the suit is not worn.
Adds the wire naming for advanced multitool users like the abductor multitool.
Allows wearing of shoes "under" the rigsuits boots, to allow a person to not run around barefoot if they would want to run around with the rig on the back, but only to suit up when needed.
Removes the slowdown from the back item, as it seems to have been intended to dictate the slowdown of the deployed and powered suit, which it does now.
:cl:
Fix: Stops rigsuits from shocking over distance.
Fix: Let's malfunction count down while not being actively worn, to avoid permanetly breaking it.
Add: Allows boots to be worn under rigsuit boots.
Add: Wirenames for the rigsuit wires if you can see them.
Tweak: Rigsuits only slow you down when deployed, potentially less if active.
/:cl: