### PR TITLE
Allows the code to show tails when hardsuits are shown

### DIFF
--- a/code/modules/mob/living/carbon/human/body_accessories.dm
+++ b/code/modules/mob/living/carbon/human/body_accessories.dm
@@ -97,7 +97,7 @@ var/global/list/body_accessory_by_species = list("None" = null)
 	animated_icon_state = "null"
 
 /datum/body_accessory/tail/try_restrictions(var/mob/living/carbon/human/H)
-	if(!H.wear_suit || !(H.wear_suit.flags_inv & HIDETAIL) && !istype(H.wear_suit, /obj/item/clothing/suit/space))
+	if(!H.wear_suit || !(H.wear_suit.flags_inv & HIDETAIL))
 		return 1
 	return 0
 
@@ -140,4 +140,3 @@ var/global/list/body_accessory_by_species = list("None" = null)
 	icon_state = "vulptail6"
 	animated_icon_state = "vulptail6_a"
 	allowed_species = list("Vulpkanin")
-


### PR DESCRIPTION
The hidetail flag will hide the tail when needed, as such, checking for the spacesuit afterwards is unneeded. All hardsuits except the freedom ops suit and the CC officer jacket do have the hidetail flag. No change for player-accessable spacesuits as far as i am aware. So unsure if this will require a cl entry.