### PR TITLE
Removes a wrong usage of two flags

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -77,8 +77,7 @@
 	desc = "An armored beret commonly used by special operations officers."
 	icon_state = "beret_officer"
 	armor = list(melee = 65, bullet = 55, laser = 35, energy = 20, bomb = 30, bio = 30, rad = 30)
-	flags =  STOPSPRESSUREDMAGE | THICKMATERIAL 
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	flags =  STOPSPRESSUREDMAGE | THICKMATERIAL
 
 /obj/item/clothing/suit/space/deathsquad/officer
 	name = "officer jacket"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -77,7 +77,8 @@
 	desc = "An armored beret commonly used by special operations officers."
 	icon_state = "beret_officer"
 	armor = list(melee = 65, bullet = 55, laser = 35, energy = 20, bomb = 30, bio = 30, rad = 30)
-	flags = HEADCOVERSEYES | HEADCOVERSMOUTH | STOPSPRESSUREDMAGE | THICKMATERIAL //idfk
+	flags =  STOPSPRESSUREDMAGE | THICKMATERIAL 
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 /obj/item/clothing/suit/space/deathsquad/officer
 	name = "officer jacket"


### PR DESCRIPTION
The beret did have two flags designed for flags_cover used as normal flags. As the parent does already supply flags_cover with exactly theese two flags, they were removed.
:cl:
Fix: A (possibly non-existant) officer's beret does no longer incorrectly hide hair.
/:cl: