### PR TITLE
No invisible ERT suits

### DIFF
--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -41,6 +41,10 @@
 	/obj/item/device/radio, /obj/item/device/analyzer, /obj/item/weapon/gun/energy/laser, /obj/item/weapon/gun/energy/pulse, \
 	/obj/item/weapon/gun/energy/gun/advtaser, /obj/item/weapon/melee/baton, /obj/item/weapon/gun/energy/gun)
 	strip_delay = 130
+	species_fit = list("Drask")
+	sprite_sheets = list(
+		"Drask" = 'icons/mob/species/drask/suit.dmi'
+		)
 
 //Commander
 /obj/item/clothing/head/helmet/space/hardsuit/ert/commander


### PR DESCRIPTION
Currently, only drask do have special ERT hardsuit sprites, so the will only use a different sprite sheet for them. That also stops some species to get an invisible hardsuit when wearing an ERT hardsuit.
:cL:
Fix: ERT hardsuits show on everyone.
Fix: Drask use their ERT hardsuit sprites.
/:cl: