### PR TITLE
No Bone Rune Glow

### DIFF
--- a/code/game/magic/Uristrunes.dm
+++ b/code/game/magic/Uristrunes.dm
@@ -1,7 +1,7 @@
 /proc/get_rune_cult(word)
 	var/animated
 
-	if(word && !(ticker.mode.cultdat.theme == "fire"))
+	if(word && !(ticker.mode.cultdat.theme == "fire" || ticker.mode.cultdat.theme == "death"))
 		animated = 1
 	else
 		animated = 0


### PR DESCRIPTION
🆑 Fethas
tweak:Cult Bone Runes should not pulse red.
/🆑