### PR TITLE
Nerf the fastmos object death blender

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -320,7 +320,33 @@
 				var/mob/living/carbon/human/H = src
 				H.Weaken(min(pressure_difference / 50, 2))
 			spawn()
-				throw_at(general_direction, pressure_difference / 10, pressure_difference / 200, null, 0, 0, null)
+				var/max_distance = 14 // reduce by one each calculation to prevent infinate loops.
+				var/min_observed_pressure = INFINITY
+				var/turf/target = get_turf(src)
+				if(isunsimulatedturf(target))
+					return 0
+				var/turf/possible_target = get_turf(src)
+				while(!isunsimulatedturf(target) && max_distance > 0)
+					max_distance--
+					var/datum/gas_mixture/target_air = target.return_air()
+					min_observed_pressure = target_air.return_pressure()
+					possible_target = get_step_towards(target,general_direction)
+					if(istype(possible_target, /turf/space))
+						target = possible_target
+						break
+					if(!CanAtmosPass(possible_target))
+						target = possible_target
+						max_distance = 0
+						break
+					var/datum/gas_mixture/possible_target_air = possible_target.return_air()
+					if(possible_target_air.return_pressure() > min_observed_pressure)
+						target = possible_target
+						break
+					target = possible_target
+				if(max_distance)
+					throw_at(target, get_dist(src, target), pressure_difference / 200, null, 0, 0, null)
+				else
+					throw_at(target, pressure_difference / 10, pressure_difference / 200, null, 0, 0, null)
 			last_forced_movement = SSair.times_fired
 			return 1
 		else if(pressure_difference > pressure_resistance)

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -320,9 +320,6 @@
 			var/general_direction = get_edge_target_turf(src, direction)
 			if(last_forced_movement + 10 < SSair.times_fired && is_valid_tochat_target(src)) //the first check prevents spamming throw to_chat
 				to_chat(src, "<span class='userdanger'>The pressure sends you flying!</span>")
-			if(ishuman(src))
-				var/mob/living/carbon/human/H = src
-				H.Weaken(min(pressure_difference / 50, 2))
 			spawn()
 				var/max_distance = 14 // reduce by one each calculation to prevent infinate loops.
 				var/min_observed_pressure = INFINITY

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -312,6 +312,10 @@
 	if(last_forced_movement >= SSair.times_fired)
 		return 0
 	else if(!anchored && !pulledby)
+		var/turf/target = get_turf(src)
+		var/datum/gas_mixture/target_air = target.return_air()
+		if(isunsimulatedturf(target) || pressure_resistance > target_air.return_pressure())
+			return 0
 		if(pressure_difference >= throw_pressure_limit)
 			var/general_direction = get_edge_target_turf(src, direction)
 			if(last_forced_movement + 10 < SSair.times_fired && is_valid_tochat_target(src)) //the first check prevents spamming throw to_chat
@@ -322,13 +326,10 @@
 			spawn()
 				var/max_distance = 14 // reduce by one each calculation to prevent infinate loops.
 				var/min_observed_pressure = INFINITY
-				var/turf/target = get_turf(src)
-				if(isunsimulatedturf(target))
-					return 0
 				var/turf/possible_target = get_turf(src)
 				while(!isunsimulatedturf(target) && max_distance > 0)
 					max_distance--
-					var/datum/gas_mixture/target_air = target.return_air()
+					target_air = target.return_air()
 					min_observed_pressure = target_air.return_pressure()
 					possible_target = get_step_towards(target,general_direction)
 					if(istype(possible_target, /turf/space))


### PR DESCRIPTION
This PR adds a series of logic checks to the atmospherics code that are designed to limit the circumstances in which an object "death blender" can occur.  In the event that one does occur, these checks will greatly reduce its strength and duration. 

Throw stuns also removed.


![giphy](https://user-images.githubusercontent.com/8165455/32985518-eecdb638-cc8a-11e7-891a-0096d4ee4a5e.gif)


🆑 Alffd
add: Logic checks to lessen death from flying objects due to atmospheric breaches.
del: Removes atmospheric stunning while thrown.
/🆑 