### PR TITLE
Fixes Slime Transformation

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -186,7 +186,7 @@
 	stage3	= list("<span class='danger'>Your appendages are melting away.</span>", "<span class='danger'>Your limbs begin to lose their shape.</span>")
 	stage4	= list("<span class='danger'>You are turning into a slime.</span>")
 	stage5	= list("<span class='danger'>You have become a slime.</span>")
-	new_form = /mob/living/simple_animal/slime
+	new_form = /mob/living/carbon/slime/random
 
 /datum/disease/transformation/slime/stage_act()
 	..()

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -66,6 +66,10 @@
 		coretype = text2path("/obj/item/slime_extract/[sanitizedcolour]")
 	..()
 
+/mob/living/carbon/slime/random/New()
+	colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
+	..()
+
 /mob/living/carbon/slime/Destroy()
 	for(var/obj/machinery/computer/camera_advanced/xenobio/X in machines)
 		if(src in X.stored_slimes)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -17,7 +17,7 @@
 	damage = 10
 	damage_type = BRUTE
 	nodamage = 0
-	
+
 	//explosion values
 	var/exp_heavy = 0
 	var/exp_light = 2
@@ -55,7 +55,7 @@
 	if(ismob(target)) //multiple flavors of pain
 		var/mob/living/M = target
 		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately
-		
+
 
 /obj/item/projectile/magic/fireball/infernal
 	name = "infernal fireball"
@@ -187,7 +187,7 @@ proc/wabbajack(mob/living/M)
 					if(ishuman(M))
 						Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
 				if("slime")
-					new_mob = new /mob/living/carbon/slime(M.loc)
+					new_mob = new /mob/living/carbon/slime/random(M.loc)
 					new_mob.universal_speak = 1
 				if("xeno")
 					if(prob(50))
@@ -293,4 +293,4 @@ proc/wabbajack(mob/living/M)
 	damage_type = BURN
 	flag = "magic"
 	dismemberment = 50
-	nodamage = 0		
+	nodamage = 0

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -681,8 +681,7 @@
 
 /datum/chemical_reaction/slimeRNG/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	var/mob/living/carbon/slime/S = new /mob/living/carbon/slime
-	S.colour = pick("grey","orange", "metal", "blue", "purple", "dark purple", "dark blue", "green", "silver", "yellow", "gold", "yellow", "red", "silver", "pink", "cerulean", "sepia", "bluespace", "pyrite", "light pink", "oil", "adamantine", "black")
+	var/mob/living/carbon/slime/random/S = new /mob/living/carbon/slime/random
 	S.forceMove(get_turf(holder.my_atom))
 	S.visible_message("<span class='danger'>Infused with plasma, the core begins to quiver and grow, and soon a new baby slime emerges from it!</span>")
 


### PR DESCRIPTION
Just a fix and tweak

Slime transformation potions will now turn you into an actual slime instead of a pet slime.

This is a fix and not a feature--it's due to an oversight when the disease system implemented. On TG their slimes are *all* simple mobs, where as ours are carbons...and friendly slimes are specifically simple mobs.

That's why the code compiled but it wasn't really caught. The original intention and purpose of slime transformation potions has always been for them to make you an actual slime.

Tweak wise, slime transformation and wizard slime polymorph will turn you into a random colored slime instead of always grey.

:cl: Fox McCloud
fix: Fixes slime transformation potion not making you a real slime
tweak: Polymorph slimes are now random color
/:cl: