### PR TITLE
Griffin Typo fix

### DIFF
--- a/code/modules/mob/living/carbon/superheroes.dm
+++ b/code/modules/mob/living/carbon/superheroes.dm
@@ -188,7 +188,7 @@
 			switch(progress)
 				if(1)
 					to_chat(user, "<span class='notice'>You begin by introducing yourself and explaining what you're about.</span>")
-					user.visible_message("<span class='danger'>[user]'s introduces \himself and explains \his plans.</span>")
+					user.visible_message("<span class='danger'>[user] introduces \himself and explains \his plans.</span>")
 				if(2)
 					to_chat(user, "<span class='notice'>You begin the recruitment of [target].</span>")
 					user.visible_message("<span class='danger'>[user] leans over towards [target], whispering excitedly as he gives a speech.</span>")


### PR DESCRIPTION
Fixes a typo when a civilian is being signed up by the griffin.

Not sure if this minor a change is worth a changelog entry.