### PR TITLE
Fixes Being Able to Recall Abductor Shuttle call

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -282,6 +282,7 @@
 			var/datum/objective/objective = team_objectives[team_number]
 			if(con.experiment.points >= objective.target_amount)
 				shuttle_master.emergency.request(null, 0.5)
+				shuttle_master.emergency.canRecall = FALSE
 				finished = 1
 				return ..()
 	return ..()


### PR DESCRIPTION
What it says on the tin

:cl: Fox McCloud
fix: Fixes being able to recall Abductor-called shuttles
/:cl: