### PR TITLE
Removed req_amount from stack_recipe_list

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -27,7 +27,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list(
 	new /datum/stack_recipe_list("office chairs",list(
 		new /datum/stack_recipe("dark office chair", /obj/structure/stool/bed/chair/office/dark, 5, one_per_turf = 1, on_floor = 1),
 		new /datum/stack_recipe("light office chair", /obj/structure/stool/bed/chair/office/light, 5, one_per_turf = 1, on_floor = 1),
-	), 5),
+	)),
 
 	new /datum/stack_recipe_list("comfy chairs", list(
 		new /datum/stack_recipe("beige comfy chair", /obj/structure/stool/bed/chair/comfy/beige, 2, one_per_turf = 1, on_floor = 1),
@@ -39,7 +39,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list(
 		new /datum/stack_recipe("blue comfy chair", /obj/structure/stool/bed/chair/comfy/blue, 2, one_per_turf = 1, on_floor = 1),
 		new /datum/stack_recipe("purple comfy chair", /obj/structure/stool/bed/chair/comfy/purp, 2, one_per_turf = 1, on_floor = 1),
 		new /datum/stack_recipe("green comfy chair", /obj/structure/stool/bed/chair/comfy/green, 2, one_per_turf = 1, on_floor = 1),
-	), 2),
+	)),
 
 	null,
 	new /datum/stack_recipe("table parts", /obj/item/weapon/table_parts, 2),
@@ -76,7 +76,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list(
 		new /datum/stack_recipe("maintenance hatch assembly", /obj/structure/door_assembly/door_assembly_mhatch, 4, time = 50, one_per_turf = 1, on_floor = 1),
 		new /datum/stack_recipe("high security airlock assembly", /obj/structure/door_assembly/door_assembly_highsecurity, 4, time = 50, one_per_turf = 1, on_floor = 1),
 		new /datum/stack_recipe("multi-tile airlock assembly", /obj/structure/door_assembly/multi_tile, 4, time = 50, one_per_turf = 1, on_floor = 1),
-	), 4),
+	)),
 	null,
 	new /datum/stack_recipe("mass driver button frame", /obj/item/mounted/frame/driver_button, 1, time = 50, one_per_turf = 0, on_floor = 1),
 	new /datum/stack_recipe("light switch frame", /obj/item/mounted/frame/light_switch, 1, time = 50, one_per_turf = 0, on_floor = 1),

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -80,10 +80,7 @@
 
 		if(istype(E, /datum/stack_recipe_list))
 			var/datum/stack_recipe_list/srl = E
-			if(amount >= srl.req_amount)
-				t1 += "<a href='?src=[UID()];sublist=[i]'>[srl.title] ([srl.req_amount] [singular_name]\s)</a>"
-			else
-				t1 += "[srl.title] ([srl.req_amount] [singular_name]\s)<br>"
+			t1 += "<a href='?src=[UID()];sublist=[i]'>[srl.title]</a>"
 
 		if(istype(E, /datum/stack_recipe))
 			var/datum/stack_recipe/R = E

--- a/code/game/objects/items/stacks/stack_recipe.dm
+++ b/code/game/objects/items/stacks/stack_recipe.dm
@@ -46,10 +46,8 @@
 /datum/stack_recipe_list
 	var/title = "ERROR"
 	var/list/recipes = null
-	var/req_amount = 1
 
-/datum/stack_recipe_list/New(title, recipes, req_amount = 1)
+/datum/stack_recipe_list/New(title, recipes)
 	src.title = title
 	src.recipes = recipes
-	src.req_amount = req_amount
 


### PR DESCRIPTION
Opening a recipe list does not use up anything, /tg/ and Bay already got rid of this