### PR TITLE
Slime Blueprint Change

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -61,6 +61,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/no_teleportlocs = 0
 
 	var/outdoors = 0 //For space, the asteroid, lavaland, etc. Used with blueprints to determine if we are adding a new area (vs editing a station room)
+	var/xenobiology_compatible = FALSE //Can the Xenobio management console transverse this area by default?
 
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
@@ -1868,6 +1869,7 @@ area/security/podbay
 /area/toxins/xenobiology
 	name = "\improper Xenobiology Lab"
 	icon_state = "toxmix"
+	xenobiology_compatible = TRUE
 
 /area/toxins/xenobiology/xenoflora_storage
 	name = "\improper Xenoflora Storage"

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -12,7 +12,7 @@
 
 /mob/camera/aiEye/remote/xenobio/setLoc(t)
 	var/area/new_area = get_area(t)
-	if(new_area && new_area.name == allowed_area || istype(new_area, /area/toxins/xenobiology ))
+	if(new_area && new_area.name == allowed_area ||  new_area && new_area.xenobiology_compatible)
 		return ..()
 	else
 		return

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -589,16 +589,16 @@
 
 /obj/item/areaeditor/blueprints/slime
 	name = "cerulean prints"
-	desc = "A one use set of blueprints made of jelly like organic material. Renaming an area to 'Xenobiology Lab' will extend the reach of the management console."
+	desc = "A one use set of blueprints made of jelly like organic material. Extends the reach of the management console."
 	color = "#2956B2"
 
 /obj/item/areaeditor/blueprints/slime/edit_area()
-	. = ..()
+	..()
 	var/area/A = get_area(src)
-	if(.)
-		for(var/turf/T in A)
-			T.color = "#2956B2"
-		qdel(src)
+	for(var/turf/T in A)
+		T.color = "#2956B2"
+	A.xenobiology_compatible = TRUE
+	qdel(src)
 
 /turf/simulated/floor/sepia
 	slowdown = 2


### PR DESCRIPTION
Xenobio blueprints now color an area blue and make it able to be transversed by the Xenobio camera, regardless of what you name the area (you can leave the area name alone if you wish, or change it to "nerd kingdom 500"...whatever suits your fancy).

The primary advantage of this is that you're not polluting the station with duplicate instances of "Xenobiology Lab", making it confusing to the rest of the station where things are at.

:cl: Fox McCloud
tweak: Slime blueprints can now make an area compatible with Xenobio consoles, regardless of the name of the new area
/:cl:
