### PR TITLE
Fix R_SPAWN exploit w/ JSON serialization

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -171,7 +171,6 @@ var/list/admin_verbs_debug = list(
 	/client/proc/map_template_upload,
 	/client/proc/view_runtimes,
 	/client/proc/admin_serialize,
-	/client/proc/admin_deserialize,
 	/client/proc/jump_to_ruin,
 	/client/proc/toggle_medal_disable,
 	/client/proc/startadmintickets,

--- a/code/modules/admin/verbs/serialization.dm
+++ b/code/modules/admin/verbs/serialization.dm
@@ -3,7 +3,7 @@
 	set desc = "Turns your marked object into a JSON string you can later use to re-create the object"
 	set category = "Debug"
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_DEBUG))
 		return
 
 	if(!istype(holder.marked_datum, /atom/movable))
@@ -18,7 +18,7 @@
 	set desc = "Creates an object from a JSON string"
 	set category = "Debug"
 
-	if(!check_rights(R_ADMIN|R_DEBUG))
+	if(!check_rights(R_SPAWN)) // this involves spawning things
 		return
 
 	var/json_text = input("Enter the JSON code:","Text") as message|null


### PR DESCRIPTION
As it is, anyone with R_DEBUG can spawn objects- by using the JSON object deserialization. This fixes that, and makes it so that deserialization can only be done with the R_SPAWN permission (JSON Serialization is left intact for actual debugging purposes)