### PR TITLE
Refactors new lung breath code to fix Drask

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -34,7 +34,6 @@
 	var/tox_damage_type = TOX
 
 	var/cold_message = "your face freezing and an icicle forming"
-	var/cold_modifier = null	//To be overridden at individual organ level, in which case it will modify the species modifier.
 	var/cold_level_1_threshold = 260
 	var/cold_level_2_threshold = 200
 	var/cold_level_3_threshold = 120
@@ -44,7 +43,6 @@
 	var/cold_damage_type = list(BURN)
 
 	var/hot_message = "your face burning and a searing heat"
-	var/heat_modifier = null
 	var/heat_level_1_threshold = 360
 	var/heat_level_2_threshold = 400
 	var/heat_level_3_threshold = 1000
@@ -271,10 +269,7 @@
 		species_traits = H.species.species_traits
 
 	if(!(COLDRES in H.mutations) && !(RESISTCOLD in species_traits)) // COLD DAMAGE
-		var/CM = 1
-		if(!cold_modifier)
-			CM = H.species.coldmod
-		else CM = (cold_modifier*abs(H.species.coldmod))
+		var/CM = abs(H.species.coldmod)
 		var/TC = 0
 		if(breath_temperature < cold_level_3_threshold)
 			TC = cold_level_3_damage
@@ -290,10 +285,7 @@
 				to_chat(H, "<span class='warning'>You feel [cold_message] in your [name]!</span>")
 
 	if(!(HEATRES in H.mutations) && !(RESISTHOT in species_traits)) // HEAT DAMAGE
-		var/HM = 1
-		if(!heat_modifier)
-			HM = H.species.heatmod
-		else HM = (heat_modifier*abs(H.species.heatmod))
+		var/HM = abs(H.species.heatmod)
 		var/TH = 0
 		if(breath_temperature > heat_level_1_threshold && breath_temperature < heat_level_2_threshold)
 			TH = heat_level_1_damage
@@ -339,5 +331,7 @@
 
 	cold_message = "an invigorating coldness"
 	cold_level_3_threshold = 60
-	cold_modifier = -1	//They heal when the air is cold
+	cold_level_1_damage = -COLD_GAS_DAMAGE_LEVEL_1 //They heal when the air is cold
+	cold_level_2_damage = -COLD_GAS_DAMAGE_LEVEL_2
+	cold_level_3_damage = -COLD_GAS_DAMAGE_LEVEL_3
 	cold_damage_type = list(BRUTE, BURN)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -40,7 +40,10 @@
 	var/cold_level_1_damage = COLD_GAS_DAMAGE_LEVEL_1 //Keep in mind with gas damage levels, you can set these to be negative, if you want someone to heal, instead.
 	var/cold_level_2_damage = COLD_GAS_DAMAGE_LEVEL_2
 	var/cold_level_3_damage = COLD_GAS_DAMAGE_LEVEL_3
-	var/cold_damage_type = list(BURN)
+	var/cold_BRUTE_mod = 0		//If you want to add a damage type, simply set its mod to something besides 0
+	var/cold_BURN_mod = 1
+	var/cold_OXY_mod = 0
+	var/cold_TOX_mod = 0
 
 	var/hot_message = "your face burning and a searing heat"
 	var/heat_level_1_threshold = 360
@@ -49,7 +52,10 @@
 	var/heat_level_1_damage = HEAT_GAS_DAMAGE_LEVEL_1
 	var/heat_level_2_damage = HEAT_GAS_DAMAGE_LEVEL_2
 	var/heat_level_3_damage = HEAT_GAS_DAMAGE_LEVEL_3
-	var/heat_damage_type = list(BURN)
+	var/heat_BRUTE_mod = 0
+	var/heat_BURN_mod = 1
+	var/heat_OXY_mod = 0
+	var/heat_TOX_mod = 0
 
 /obj/item/organ/internal/lungs/insert(mob/living/carbon/M, special = 0, dont_remove_slot = 0)
 	..()
@@ -278,8 +284,10 @@
 		if(breath_temperature > cold_level_2_threshold && breath_temperature < cold_level_1_threshold)
 			TC = cold_level_1_damage
 		if(TC)
-			for(var/D in cold_damage_type)
-				H.apply_damage_type(TC*CM, D)
+			H.apply_damage_type(TC*CM*cold_BRUTE_mod, BRUTE)
+			H.apply_damage_type(TC*CM*cold_BURN_mod, BURN)
+			H.apply_damage_type(TC*CM*cold_OXY_mod, OXY)
+			H.apply_damage_type(TC*CM*cold_TOX_mod, TOX)
 		if(breath_temperature < cold_level_1_threshold)
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [cold_message] in your [name]!</span>")
@@ -294,8 +302,10 @@
 		if(breath_temperature > heat_level_3_threshold)
 			TH = heat_level_3_damage
 		if(TH)
-			for(var/D in heat_damage_type)
-				H.apply_damage_type(TH*HM, D)
+			H.apply_damage_type(TH*HM*heat_BRUTE_mod, BRUTE)
+			H.apply_damage_type(TH*HM*heat_BURN_mod, BURN)
+			H.apply_damage_type(TH*HM*heat_OXY_mod, OXY)
+			H.apply_damage_type(TH*HM*heat_TOX_mod, TOX)
 		if(breath_temperature > heat_level_1_threshold)
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [hot_message] in your [name]!</span>")
@@ -334,4 +344,7 @@
 	cold_level_1_damage = -COLD_GAS_DAMAGE_LEVEL_1 //They heal when the air is cold
 	cold_level_2_damage = -COLD_GAS_DAMAGE_LEVEL_2
 	cold_level_3_damage = -COLD_GAS_DAMAGE_LEVEL_3
-	cold_damage_type = list(BRUTE, BURN)
+	cold_BRUTE_mod = 1
+	cold_BURN_mod = 0.5
+	cold_OXY_mod = 0
+	cold_TOX_mod = 0

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -40,10 +40,7 @@
 	var/cold_level_1_damage = COLD_GAS_DAMAGE_LEVEL_1 //Keep in mind with gas damage levels, you can set these to be negative, if you want someone to heal, instead.
 	var/cold_level_2_damage = COLD_GAS_DAMAGE_LEVEL_2
 	var/cold_level_3_damage = COLD_GAS_DAMAGE_LEVEL_3
-	var/cold_BRUTE_mod = 0		//If you want to add a damage type, simply set its mod to something besides 0
-	var/cold_BURN_mod = 1
-	var/cold_OXY_mod = 0
-	var/cold_TOX_mod = 0
+	var/cold_damage_types = list(BURN = 1)
 
 	var/hot_message = "your face burning and a searing heat"
 	var/heat_level_1_threshold = 360
@@ -52,10 +49,7 @@
 	var/heat_level_1_damage = HEAT_GAS_DAMAGE_LEVEL_1
 	var/heat_level_2_damage = HEAT_GAS_DAMAGE_LEVEL_2
 	var/heat_level_3_damage = HEAT_GAS_DAMAGE_LEVEL_3
-	var/heat_BRUTE_mod = 0
-	var/heat_BURN_mod = 1
-	var/heat_OXY_mod = 0
-	var/heat_TOX_mod = 0
+	var/heat_damage_types = list(BURN = 1)
 
 /obj/item/organ/internal/lungs/insert(mob/living/carbon/M, special = 0, dont_remove_slot = 0)
 	..()
@@ -284,10 +278,8 @@
 		if(breath_temperature > cold_level_2_threshold && breath_temperature < cold_level_1_threshold)
 			TC = cold_level_1_damage
 		if(TC)
-			H.apply_damage_type(TC*CM*cold_BRUTE_mod, BRUTE)
-			H.apply_damage_type(TC*CM*cold_BURN_mod, BURN)
-			H.apply_damage_type(TC*CM*cold_OXY_mod, OXY)
-			H.apply_damage_type(TC*CM*cold_TOX_mod, TOX)
+			for(var/D in cold_damage_types)
+				H.apply_damage_type(TC * CM * cold_damage_types[D], D)
 		if(breath_temperature < cold_level_1_threshold)
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [cold_message] in your [name]!</span>")
@@ -302,10 +294,8 @@
 		if(breath_temperature > heat_level_3_threshold)
 			TH = heat_level_3_damage
 		if(TH)
-			H.apply_damage_type(TH*HM*heat_BRUTE_mod, BRUTE)
-			H.apply_damage_type(TH*HM*heat_BURN_mod, BURN)
-			H.apply_damage_type(TH*HM*heat_OXY_mod, OXY)
-			H.apply_damage_type(TH*HM*heat_TOX_mod, TOX)
+			for(var/D in heat_damage_types)
+				H.apply_damage_type(TH * HM * heat_damage_types[D], D)
 		if(breath_temperature > heat_level_1_threshold)
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [hot_message] in your [name]!</span>")
@@ -344,7 +334,4 @@
 	cold_level_1_damage = -COLD_GAS_DAMAGE_LEVEL_1 //They heal when the air is cold
 	cold_level_2_damage = -COLD_GAS_DAMAGE_LEVEL_2
 	cold_level_3_damage = -COLD_GAS_DAMAGE_LEVEL_3
-	cold_BRUTE_mod = 1
-	cold_BURN_mod = 0.5
-	cold_OXY_mod = 0
-	cold_TOX_mod = 0
+	cold_damage_types = list(BRUTE = 1, BURN = 0.5)

--- a/code/modules/surgery/organs/subtypes/drask.dm
+++ b/code/modules/surgery/organs/subtypes/drask.dm
@@ -15,6 +15,7 @@
 /obj/item/organ/internal/liver/drask
 	name = "metabolic strainer"
 	icon = 'icons/obj/surgery_drask.dmi'
+	icon_state = "kidneys"
 	alcohol_intensity = 0.8
 	species = "Drask"
 


### PR DESCRIPTION
Fixes #8432
Also refactors the new lung code to make it possible for lung temperature damage to have multiple types, once again allowing Drask to regenerate both Brute and Burn. At the same time, maintains the new behavior of allowing other species to use this regen if they get a lung transplant from Drask.

I realize I could extend this damage type behavior to other parts of the breath code, but I'll save that for later as this is kinda a hotfix.

Also, while I'm here I fixed a broken icon path on one of their other organs.

:cl:HugoLuman
:fix: Drask no longer damaged by their own regeneration
:fix: Drask once more regen both brute and burn
:fix: Drask metabolic strainers no longer lack icon
/:cl: