### PR TITLE
Fixes Various Issues with Giant Spiders

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -237,7 +237,7 @@
 				E = locate() in get_turf(src)
 				if(!E)
 					var/obj/structure/spider/eggcluster/C = new /obj/structure/spider/eggcluster(src.loc)
-					C.faction = faction
+					C.faction = faction.Copy()
 					C.master_commander = master_commander
 					if(ckey)
 						C.player_spiders = 1

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -67,7 +67,7 @@
 
 	var/gold_core_spawnable = CHEM_MOB_SPAWN_INVALID //if CHEM_MOB_SPAWN_HOSTILE can be spawned by plasma with gold core, CHEM_MOB_SPAWN_FRIENDLY are 'friendlies' spawned with blood
 
-	var/master_commander = null //holding var for determining who own/controls a sentient simple animal (for sentience potions).
+	var/mob/living/carbon/human/master_commander = null //holding var for determining who own/controls a sentient simple animal (for sentience potions).
 
 	var/mob/living/simple_animal/hostile/spawner/nest
 


### PR DESCRIPTION
Fixes a number of issues with giant spiders.

I suspect factions are getting nulled out by reference somewhere, so...safer to just make a copy of the faction list whenever spiders transfer their factions.

Also the spider's display text wasn't getting shown because the eggcluster was getting `qdel`'d (how this wasn't runtimming since it was referencing `null.master_commander` is beyond me).

This should hopefully resolve issues of spiders attacking each other for seemingly no reason. It also means that text is displayed for when you take control of a spider; this was always supposed to be there, but wasn't being properly displayed. It now looks like this, in huge text:

![img](https://i.gyazo.com/14d97e0e9254ac791795fbf57f1c3c8c.png)

Fixes https://github.com/ParadiseSS13/Paradise/issues/8407
Fixes https://github.com/ParadiseSS13/Paradise/issues/8305

:cl: Fox McCloud
fix: Having a master, as a spider means you actually get a message who is your master now
/:cl: