### PR TITLE
Fix getting sucked into scrubber machine

### DIFF
--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -12,7 +12,7 @@
 	volume = 750
 
 	var/minrate = 0//probably useless, but whatever
-	var/maxrate = 10 * ONE_ATMOSPHERE
+	var/maxrate = 10 * ONE_ATMOSPHERE / 4
 
 /obj/machinery/portable_atmospherics/scrubber/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))


### PR DESCRIPTION
Not all scrubbers were nerfed, the portable ones can still murder you.

🆑 Alffd
tweak: portable (stationary) scrubbers now remove 1/4th as much air per tick at maximum.
/ 🆑 