### PR TITLE
Being thrown through space no longer allows you to move

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -197,9 +197,6 @@
 	if(pulledby && !pulledby.pulling)
 		return 1
 
-	if(throwing)
-		return 1
-
 	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
 		return 1
 


### PR DESCRIPTION
As per title.
@tigercat2000 
I've tested this to ensure you're still able to move in space while thrown if you have a jetpack, and that you're still able to be thrown through space.

:cl:Crazylemon
fix: Being thrown through space no longer allows you to move when you otherwise could not.
/:cl: