### PR TITLE
Remove atmospheric stun effect

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -316,9 +316,6 @@
 			var/general_direction = get_edge_target_turf(src, direction)
 			if(last_forced_movement + 10 < air_master.current_cycle && is_valid_tochat_target(src)) //the first check prevents spamming throw to_chat
 				to_chat(src, "<span class='userdanger'>The pressure sends you flying!</span>")
-			if(ishuman(src))
-				var/mob/living/carbon/human/H = src
-				H.Weaken(min(pressure_difference / 10, 10))
 			spawn()
 				throw_at(general_direction, pressure_difference / 10, pressure_difference / 200, null, 0, 0, null)
 			last_forced_movement = air_master.current_cycle


### PR DESCRIPTION
Removes the atmospheric stun effect as it is now unnecessary due to #8453

🆑 Alffd
del: Removes atmospheric stunning while thrown.
/🆑 