### PR TITLE
Borer antag hud check and helper proc

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -457,7 +457,7 @@ proc/pollCandidates(Question, be_special_type, antag_age_check = 0, poll_time = 
 		if(config.use_exp_restrictions && min_hours)
 			if(G.client.get_exp_living_num() < min_hours * 60)
 				continue
-		if(G.has_enabled_antagHUD)
+		if(canPosses(G))
 			continue
 		spawn(0)
 			G << 'sound/misc/notice2.ogg'//Alerting them to their consideration

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -457,7 +457,7 @@ proc/pollCandidates(Question, be_special_type, antag_age_check = 0, poll_time = 
 		if(config.use_exp_restrictions && min_hours)
 			if(G.client.get_exp_living_num() < min_hours * 60)
 				continue
-		if(canPosses(G))
+		if(cannotPossess(G))
 			continue
 		spawn(0)
 			G << 'sound/misc/notice2.ogg'//Alerting them to their consideration

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -123,6 +123,9 @@
 	GrantBorerActions()
 
 /mob/living/simple_animal/borer/attack_ghost(mob/user)
+	if(canPosses(user))
+		to_chat(user, "<span class='boldnotice'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
+		return
 	if(jobban_isbanned(user, "Syndicate"))
 		return
 	if(key)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -123,7 +123,7 @@
 	GrantBorerActions()
 
 /mob/living/simple_animal/borer/attack_ghost(mob/user)
-	if(canPosses(user))
+	if(cannotPossess(user))
 		to_chat(user, "<span class='boldnotice'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 		return
 	if(jobban_isbanned(user, "Syndicate"))

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -51,7 +51,7 @@ var/ert_request_answered = 0
 		to_chat(src, "<span class='warning'>This role is not yet available to you. You need to wait another [player_age_check] days.</span>")
 		return 0
 
-	if(canPosses(src))
+	if(cannotPossess(src))
 		to_chat(src, "<span class='boldnotice'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 		return 0
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -51,7 +51,7 @@ var/ert_request_answered = 0
 		to_chat(src, "<span class='warning'>This role is not yet available to you. You need to wait another [player_age_check] days.</span>")
 		return 0
 
-	if(has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+	if(canPosses(src))
 		to_chat(src, "<span class='boldnotice'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 		return 0
 

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -47,7 +47,7 @@
 			to_chat(O, "<span class='boldnotice'>\A [src] has been activated. (<a href='?src=[O.UID()];jump=\ref[src]'>Teleport</a> | <a href='?src=[UID()];signup=\ref[O]'>Sign Up</a>)</span>")
 
 /obj/item/device/mmi/posibrain/proc/check_observer(var/mob/dead/observer/O)
-	if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+	if(canPosses(O))
 		return 0
 	if(jobban_isbanned(O, "Cyborg") || jobban_isbanned(O,"nonhumandept"))
 		return 0
@@ -133,7 +133,7 @@
 	if(!check_observer(O))
 		to_chat(O, "<span class='warning'>You cannot be \a [src].</span>")
 		return
-	if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+	if(canPosses(O))
 		to_chat(O, "<span class='warning'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 		return
 	if(jobban_isbanned(O, "Cyborg") || jobban_isbanned(O,"nonhumandept"))

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -47,7 +47,7 @@
 			to_chat(O, "<span class='boldnotice'>\A [src] has been activated. (<a href='?src=[O.UID()];jump=\ref[src]'>Teleport</a> | <a href='?src=[UID()];signup=\ref[O]'>Sign Up</a>)</span>")
 
 /obj/item/device/mmi/posibrain/proc/check_observer(var/mob/dead/observer/O)
-	if(canPosses(O))
+	if(cannotPossess(O))
 		return 0
 	if(jobban_isbanned(O, "Cyborg") || jobban_isbanned(O,"nonhumandept"))
 		return 0
@@ -133,7 +133,7 @@
 	if(!check_observer(O))
 		to_chat(O, "<span class='warning'>You cannot be \a [src].</span>")
 		return
-	if(canPosses(O))
+	if(cannotPossess(O))
 		to_chat(O, "<span class='warning'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 		return
 	if(jobban_isbanned(O, "Cyborg") || jobban_isbanned(O,"nonhumandept"))

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -360,7 +360,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			return 0
 		if(!player_old_enough_antag(O.client,ROLE_PAI))
 			return 0
-		if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+		if(canPosses(O))
 			return 0
 		if(!(O in respawnable_list))
 			return 0

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -360,7 +360,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			return 0
 		if(!player_old_enough_antag(O.client,ROLE_PAI))
 			return 0
-		if(canPosses(O))
+		if(cannotPossess(O))
 			return 0
 		if(!(O in respawnable_list))
 			return 0

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -263,7 +263,7 @@
 
 /mob/living/silicon/robot/drone/proc/request_player()
 	for(var/mob/dead/observer/O in player_list)
-		if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+		if(canPosses(O))
 			continue
 		if(jobban_isbanned(O,"nonhumandept") || jobban_isbanned(O,"Drone"))
 			continue

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -263,7 +263,7 @@
 
 /mob/living/silicon/robot/drone/proc/request_player()
 	for(var/mob/dead/observer/O in player_list)
-		if(canPosses(O))
+		if(cannotPossess(O))
 			continue
 		if(jobban_isbanned(O,"nonhumandept") || jobban_isbanned(O,"Drone"))
 			continue

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -118,7 +118,7 @@
 	var/joinedasobserver = 0
 	if(istype(src,/mob/dead/observer))
 		var/mob/dead/observer/G = src
-		if(canPosses(G))
+		if(cannotPossess(G))
 			to_chat(usr, "<span class='warning'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 			return
 		if(G.started_as_observer == 1)

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -118,7 +118,7 @@
 	var/joinedasobserver = 0
 	if(istype(src,/mob/dead/observer))
 		var/mob/dead/observer/G = src
-		if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+		if(canPosses(G))
 			to_chat(usr, "<span class='warning'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 			return
 		if(G.started_as_observer == 1)

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
@@ -16,7 +16,7 @@
 	humanize_prompt += " Role: [spider_role_summary]"
 	if(user.ckey in ts_ckey_blacklist)
 		error_on_humanize = "You are not able to control any terror spider this round."
-	else if(user.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+	else if(canPosses(user))
 		error_on_humanize = "You have enabled antag HUD and are unable to re-enter the round."
 	else if(spider_awaymission)
 		error_on_humanize = "Terror spiders that are part of an away mission cannot be controlled by ghosts."

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/ghost.dm
@@ -16,7 +16,7 @@
 	humanize_prompt += " Role: [spider_role_summary]"
 	if(user.ckey in ts_ckey_blacklist)
 		error_on_humanize = "You are not able to control any terror spider this round."
-	else if(canPosses(user))
+	else if(cannotPossess(user))
 		error_on_humanize = "You have enabled antag HUD and are unable to re-enter the round."
 	else if(spider_awaymission)
 		error_on_humanize = "Terror spiders that are part of an away mission cannot be controlled by ghosts."

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -85,11 +85,11 @@
 
 	return 1
 
-/proc/canPosses(A)
+/proc/cannotPossess(A)
 	var/mob/dead/observer/G = A
 	if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
-		return 0
-	return 1
+		return 1
+	return 0
 
 
 /proc/iscuffed(A)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -51,17 +51,17 @@
 			return 1
 	return 0
 
-proc/isLivingSSD(mob/M)
+/proc/isLivingSSD(mob/M)
 	return istype(M) && M.player_logged && M.stat != DEAD
 
-proc/isAntag(A)
+/proc/isAntag(A)
 	if(istype(A, /mob/living/carbon))
 		var/mob/living/carbon/C = A
 		if(C.mind && C.mind.special_role)
 			return 1
 	return 0
 
-proc/isNonCrewAntag(A)
+/proc/isNonCrewAntag(A)
 	if(!isAntag(A))
 		return 0
 
@@ -85,21 +85,28 @@ proc/isNonCrewAntag(A)
 
 	return 1
 
-proc/iscuffed(A)
+/proc/canPosses(A)
+	var/mob/dead/observer/G = A
+	if(G.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+		return 0
+	return 1
+
+
+/proc/iscuffed(A)
 	if(istype(A, /mob/living/carbon))
 		var/mob/living/carbon/C = A
 		if(C.handcuffed)
 			return 1
 	return 0
 
-proc/hassensorlevel(A, var/level)
+/proc/hassensorlevel(A, var/level)
 	var/mob/living/carbon/human/H = A
 	if(istype(H) && istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
 		return U.sensor_mode >= level
 	return 0
 
-proc/getsensorlevel(A)
+/proc/getsensorlevel(A)
 	var/mob/living/carbon/human/H = A
 	if(istype(H) && istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
@@ -170,7 +177,7 @@ proc/getsensorlevel(A)
 		p++
 	return t
 
-proc/slur(phrase, var/list/slurletters = ("'"))//use a different list as an input if you want to make robots slur with $#@%! characters
+/proc/slur(phrase, var/list/slurletters = ("'"))//use a different list as an input if you want to make robots slur with $#@%! characters
 	phrase = html_decode(phrase)
 	var/leng=lentext(phrase)
 	var/counter=lentext(phrase)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -458,7 +458,7 @@
 		return FALSE
 	if(!O.can_reenter_corpse)
 		return FALSE
-	if(canPosses(O))
+	if(cannotPossess(O))
 		return FALSE
 	return TRUE
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -458,7 +458,7 @@
 		return FALSE
 	if(!O.can_reenter_corpse)
 		return FALSE
-	if(O.has_enabled_antagHUD == 1 && config.antag_hud_restricted)
+	if(canPosses(O))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
Moves the antaghud check to a helper proc and adds said proc to borers.


:cl: Fethas
bugfix: Borers can no longer be possesed by ghosts using an antag hud.
/:cl: