### PR TITLE
EMP-Proof Organ Framework

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -53,7 +53,9 @@
 /obj/item/organ/internal/cyberimp/arm/emag_act()
 	return 0
 
-/obj/item/organ/internal/cyberimp/arm/gun/emp_act(severity)
+/obj/item/organ/internal/cyberimp/arm/emp_act(severity)
+	if(emp_proof)
+		return
 	if(prob(15/severity) && owner)
 		to_chat(owner, "<span class='warning'>[src] is hit by EMP!</span>")
 		// give the owner an idea about why his implant is glitching
@@ -141,6 +143,8 @@
 
 
 /obj/item/organ/internal/cyberimp/arm/gun/emp_act(severity)
+	if(emp_proof)
+		return
 	if(prob(30/severity) && owner && !crit_fail)
 		Retract()
 		owner.visible_message("<span class='danger'>A loud bang comes from [owner]\'s [parent_organ == "r_arm" ? "right" : "left"] arm!</span>")
@@ -251,6 +255,8 @@
 /obj/item/organ/internal/cyberimp/arm/power_cord/emp_act(severity)
 	// To allow repair via nanopaste/screwdriver
 	// also so IPCs don't also catch on fire and fall even more apart upon EMP
+	if(emp_proof)
+		return
 	damage = 1
 	crit_fail = TRUE
 

--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -27,7 +27,7 @@
 	M.update_sight()
 
 /obj/item/organ/internal/cyberimp/eyes/emp_act(severity)
-	if(!owner)
+	if(!owner || emp_proof)
 		return
 	if(severity > 1)
 		if(prob(10 * severity))

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -30,7 +30,7 @@
 	parent_organ = "head"
 
 /obj/item/organ/internal/cyberimp/brain/emp_act(severity)
-	if(!owner)
+	if(!owner || emp_proof)
 		return
 	var/stun_amount = 5 + (severity-1 ? 0 : 5)
 	owner.Stun(stun_amount)
@@ -91,7 +91,7 @@
 		r_hand_obj = null
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop/emp_act(severity)
-	if(!owner)
+	if(!owner || emp_proof)
 		return
 	var/range = severity ? 10 : 5
 	var/atom/A
@@ -138,7 +138,7 @@
 		owner.SetWeakened(STUN_SET_AMOUNT)
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/emp_act(severity)
-	if(crit_fail)
+	if(crit_fail || emp_proof)
 		return
 	crit_fail = 1
 	spawn(90 / severity)
@@ -158,6 +158,8 @@
 	origin_tech = "materials=2;biotech=3"
 
 /obj/item/organ/internal/cyberimp/mouth/breathing_tube/emp_act(severity)
+	if(emp_proof)
+		return
 	if(prob(60/severity) && owner)
 		to_chat(owner, "<span class='warning'>Your breathing tube suddenly closes!</span>")
 		owner.AdjustLoseBreath(2)
@@ -203,7 +205,7 @@
 			synthesizing = 0
 
 /obj/item/organ/internal/cyberimp/chest/nutriment/emp_act(severity)
-	if(!owner)
+	if(!owner || emp_proof)
 		return
 	owner.reagents.add_reagent("????",poison_amount / severity) //food poisoning
 	to_chat(owner, "<span class='warning'>You feel like your insides are burning.</span>")
@@ -258,13 +260,13 @@
 	reviving = 1
 
 /obj/item/organ/internal/cyberimp/chest/reviver/emp_act(severity)
-	if(!owner)
+	if(!owner || emp_proof)
 		return
 	if(reviving)
 		revive_cost += 200
 	else
 		cooldown += 200
-	if(istype(owner, /mob/living/carbon/human))
+	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		if(H.stat != DEAD && prob(50 / severity))
 			H.set_heartattack(TRUE)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -29,6 +29,7 @@
 
 	var/sterile = FALSE //can the organ be infected by germs?
 	var/tough = FALSE //can organ be easily damaged?
+	var/emp_proof = FALSE //is the organ immune to EMPs?
 
 
 /obj/item/organ/Destroy()
@@ -252,7 +253,7 @@
 	min_broken_damage = 35
 
 /obj/item/organ/external/emp_act(severity)
-	if(!(status & ORGAN_ROBOT))
+	if(!(status & ORGAN_ROBOT) || emp_proof)
 		return
 	if(tough)
 		switch(severity)
@@ -272,7 +273,7 @@
 				take_damage(0, 7)
 
 /obj/item/organ/internal/emp_act(severity)
-	if(!robotic)
+	if(!robotic || emp_proof)
 		return
 	if(robotic == 2)
 		switch(severity)
@@ -284,6 +285,8 @@
 		take_damage(11, 1)
 
 /obj/item/organ/internal/heart/emp_act(intensity)
+	if(emp_proof)
+		return
 	if(owner && robotic == 2)
 		Stop() // In the name of looooove~!
 		owner.visible_message("<span class='danger'>[owner] clutches their chest and gasps!</span>","<span class='userdanger'>You clutch your chest in pain!</span>")


### PR DESCRIPTION
Adds a framework for individual organs to be EMP-proof with a simple var `emp_proof`.

Not used at the moment.

Also fixes duplicate definitions of `/obj/item/organ/internal/cyberimp/arm/gun/emp_act`; it seems quite clear the first definition is meant to be `/obj/item/organ/internal/cyberimp/arm/emp_act`

:cl: Fox McCloud
fix: Fixes arm implants being immune to EMPs.
/:cl: