### PR TITLE
Removes FlattestGuitar

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -82,20 +82,7 @@ var/global/admin_ooc_colour = "#b82e00"
 			if(!config.disable_ooc_emoji)
 				msg = "<span class='emoji_enabled'>[msg]</span>"
 
-			msg = apply_formatting(msg)
-
 			to_chat(C, "<font color='[display_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
-
-/proc/apply_formatting(message)
-	var/static/regex/italics = new("(?<!\\\\)\\*(.*?)(?<!\\\\)\\*", "g")
-	var/static/regex/strikethrough = new("(?<!\\\\)~(?<!\\\\)~(.*?)(?<!\\\\)~(?<!\\\\)~", "g")
-	var/static/regex/escape = new("(?<!\\\\)\\\\(\[~\\*\\\\\])", "g")
-
-	message = italics.Replace(message, "<i>$1</i>")
-	message = strikethrough.Replace(message, "<s>$1</s>")
-	message = escape.Replace(message, "$1")//jesus christ, regex
-
-	return message
 
 /proc/toggle_ooc()
 	config.ooc_allowed = ( !config.ooc_allowed )


### PR DESCRIPTION
So, we tracked the shitcode that causes the server to crash on load 9 times out of 10.

Hug your local FlattestGuitar today. (And kick him in the bollocks)

Reverts the OOC strikethrough/italics PR.

love,
Purpose

:cl: Purpose2
del: You may no longer use strikethroughs/italics in OOC. This was causing backend server problems due to how shoddily BYOND is coded, and cannot be safely added right now.
/:cl: