### PR TITLE
No candy

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -244,7 +244,6 @@ proc/issyndicate(mob/living/M as mob)
 	synd_mob.equip_or_collect(new /obj/item/clothing/gloves/combat(synd_mob), slot_gloves)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate(synd_mob), slot_wear_id)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(synd_mob), slot_back)
-	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/pill/initropidril(synd_mob), slot_in_backpack)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/pistol(synd_mob), slot_belt)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(synd_mob.back), slot_in_backpack)
 


### PR DESCRIPTION
Somethinge else I got asked to PR.

Another newbie nukie just ate the candy he found in his backpack before they made it to the station.

Removes the initropodril pill from the nukies backpacks. This only exists because of "lol cyanide capsules" so they don't get caught and interrogated. But they have a microbomb implant they can trigger instead, much easier. This this is superfluous.

:cl: Purpose2
del: Removes nukie candy
/:cl: