### PR TITLE
Colorblindness now effects wire panels

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -278,14 +278,19 @@
                                0.4,0.6,0.0,\
                                0.2,0.2,0.6)
 
-#define LIST_GREYSCALE_REPLACE list("red" = "lightgrey", "blue" = "darkgrey", "green" = "darkgrey", "orange" = "lightgrey", "brown" = "darkgrey",\
-									"gold" = "lightgrey", "cyan" = "lightgrey", "navy" = "darkgrey", "purple" = "darkgrey", "pink"= "lightgrey")
+#define LIST_REPLACE_RENAME list("rebeccapurple" = "dark purple", "darkslategrey" = "dark grey", "darkolivegreen" = "dark green", "darkslateblue" = "dark blue",\
+								 "darkkhaki" = "khaki", "darkseagreen" = "light green", "midnightblue" = "blue", "lightgrey" = "light grey", "darkgrey" = "dark grey",\
+								 "steelblue" = "blue", "goldenrod" = "gold")
 
-#define LIST_VULP_REPLACE list("red" = "goldenrod", "green" = "goldenrod", "orange" = "peru", "purple" = "skyblue", "pink" = "skyblue",\
-							   "cyan" = "skyblue")
+#define LIST_GREYSCALE_REPLACE list("red" = "lightgrey", "blue" = "grey", "green" = "grey", "orange" = "lightgrey", "brown" = "grey",\
+									"gold" = "lightgrey", "cyan" = "lightgrey", "navy" = "grey", "purple" = "grey", "pink"= "lightgrey")
 
-#define LIST_TAJ_REPLACE list("red" = "goldenrod", "green" = "goldenrod", "orange" = "peru", "purple" = "skyblue", "pink" = "skyblue",\
-							   "cyan" = "skyblue")
+#define LIST_VULP_REPLACE list("pink" = "beige", "orange" = "goldenrod", "gold" = "goldenrod", "red" = "darkolivegreen", "brown" = "darkolivegreen",\
+									 "green" = "darkslategrey", "cyan" = "steelblue", "purple" = "darkslategrey", "navy" = "midnightblue")
+
+#define LIST_TAJ_REPLACE list("red" = "rebeccapurple", "brown" = "rebeccapurple", "purple" = "darkslateblue", "blue" = "darkslateblue",\
+									 "green" = "darkolivegreen", "orange" = "darkkhaki", "gold" = "darkkhaki", "cyan" = "darkseagreen", \
+									 "navy" = "midnightblue", "pink" = "lightgrey")
 
 
 //Gun trigger guards

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -281,9 +281,11 @@
 #define LIST_GREYSCALE_REPLACE list("red" = "lightgrey", "blue" = "darkgrey", "green" = "darkgrey", "orange" = "lightgrey", "brown" = "darkgrey",\
 									"gold" = "lightgrey", "cyan" = "lightgrey", "navy" = "darkgrey", "purple" = "darkgrey", "pink"= "lightgrey")
 
-#define LIST_VULP_REPLACE list("red" = "goldenrod", "green" = "palegoldenrod", "orange" = "khaki", "purple" = "mediumblue", "pink" = "deepskyblue")
+#define LIST_VULP_REPLACE list("red" = "goldenrod", "green" = "goldenrod", "orange" = "peru", "purple" = "skyblue", "pink" = "skyblue",\
+							   "cyan" = "skyblue")
 
-#define LIST_TAJ_REPLACE list("red" = "goldenrod", "green" = "palegoldenrod", "orange" = "khaki", "purple" = "mediumblue", "pink" = "deepskyblue")
+#define LIST_TAJ_REPLACE list("red" = "goldenrod", "green" = "goldenrod", "orange" = "peru", "purple" = "skyblue", "pink" = "skyblue",\
+							   "cyan" = "skyblue")
 
 
 //Gun trigger guards

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -278,6 +278,13 @@
                                0.4,0.6,0.0,\
                                0.2,0.2,0.6)
 
+#define LIST_GREYSCALE_REPLACE list("red" = "lightgrey", "blue" = "darkgrey", "green" = "darkgrey", "orange" = "lightgrey", "brown" = "darkgrey",\
+									"gold" = "lightgrey", "cyan" = "lightgrey", "navy" = "darkgrey", "purple" = "darkgrey", "pink"= "lightgrey")
+
+#define LIST_VULP_REPLACE list("red" = "goldenrod", "green" = "palegoldenrod", "orange" = "khaki", "purple" = "mediumblue", "pink" = "deepskyblue")
+
+#define LIST_TAJ_REPLACE list("red" = "goldenrod", "green" = "palegoldenrod", "orange" = "khaki", "purple" = "mediumblue", "pink" = "deepskyblue")
+
 
 //Gun trigger guards
 #define TRIGGER_GUARD_ALLOW_ALL -1

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -83,10 +83,22 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 
 /datum/wires/ui_data(mob/user, ui_key = "main", datum/topic_state/state = physical_state)
 	var/data[0]
+	var/list/replace_colours = null
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)
+		if(eyes && H.disabilities & COLOURBLIND)
+			replace_colours = eyes.replace_colours
+
 
 	var/list/W[0]
 	for(var/colour in wires)
-		W[++W.len] = list("colour" = capitalize(colour), "cut" = IsColourCut(colour), "index" = can_see_wire_index(user) ? GetWireName(GetIndex(colour)) : null, "attached" = IsAttached(colour))
+		var/new_colour = colour
+		if(colour in replace_colours)
+			new_colour = replace_colours[colour]
+		else
+			new_colour = colour
+		W[++W.len] = list("seen_colour" = capitalize(new_colour),"colour" = capitalize(colour), "cut" = IsColourCut(colour), "index" = can_see_wire_index(user) ? GetWireName(GetIndex(colour)) : null, "attached" = IsAttached(colour))
 
 	if(W.len > 0)
 		data["wires"] = W
@@ -99,7 +111,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 
 /datum/wires/nano_host()
 	return holder
-	
+
 /datum/wires/proc/can_see_wire_index(mob/user)
 	if(user.can_admin_interact())
 		return TRUE
@@ -107,13 +119,12 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 		var/obj/item/device/multitool/M = user.get_active_hand()
 		if(M.shows_wire_information)
 			return TRUE
-		
+
 	return FALSE
 
 /datum/wires/Topic(href, href_list)
 	if(..())
 		return 1
-
 	var/mob/L = usr
 	if(CanUse(L) && href_list["action"])
 		var/obj/item/I = L.get_active_hand()
@@ -212,7 +223,7 @@ var/const/POWER = 8
 		return index
 	else
 		CRASH("[colour] is not a key in wires.")
-		
+
 /datum/wires/proc/GetWireName(index)
 	return
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -104,6 +104,12 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 		data["wires"] = W
 
 	var/list/status = get_status()
+	if(replace_colours)
+		for(var/colour in replace_colours)
+			var/i
+			for(i=1, i<=status.len, i++)
+				if(findtext(status[i],colour))
+					status[i] = replacetext(status[i],colour,replace_colours[colour])
 	data["status_len"] = status.len
 	data["status"] = status
 

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -94,22 +94,32 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 	var/list/W[0]
 	for(var/colour in wires)
 		var/new_colour = colour
+		var/colour_name = colour
 		if(colour in replace_colours)
 			new_colour = replace_colours[colour]
+			if(new_colour in LIST_REPLACE_RENAME)
+				colour_name = LIST_REPLACE_RENAME[new_colour]
+			else
+				colour_name = new_colour
 		else
 			new_colour = colour
-		W[++W.len] = list("seen_colour" = capitalize(new_colour),"colour" = capitalize(colour), "cut" = IsColourCut(colour), "index" = can_see_wire_index(user) ? GetWireName(GetIndex(colour)) : null, "attached" = IsAttached(colour))
+			colour_name = new_colour
+		W[++W.len] = list("colour_name" = capitalize(colour_name), "seen_colour" = capitalize(new_colour),"colour" = capitalize(colour), "cut" = IsColourCut(colour), "index" = can_see_wire_index(user) ? GetWireName(GetIndex(colour)) : null, "attached" = IsAttached(colour))
 
 	if(W.len > 0)
 		data["wires"] = W
 
 	var/list/status = get_status()
 	if(replace_colours)
-		for(var/colour in replace_colours)
-			var/i
-			for(i=1, i<=status.len, i++)
+		var/i
+		for(i=1, i<=status.len, i++)
+			for(var/colour in replace_colours)
+				var/new_colour = replace_colours[colour]
+				if(new_colour in LIST_REPLACE_RENAME)
+					new_colour = LIST_REPLACE_RENAME[new_colour]
 				if(findtext(status[i],colour))
-					status[i] = replacetext(status[i],colour,replace_colours[colour])
+					status[i] = replacetext(status[i],colour,new_colour)
+					break
 	data["status_len"] = status.len
 	data["status"] = status
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -297,6 +297,7 @@
 	var/eye_colour = "#000000"
 	var/list/colourmatrix = null
 	var/list/colourblind_matrix = MATRIX_GREYSCALE //Special colourblindness parameters. By default, it's black-and-white.
+	var/list/replace_colours = LIST_GREYSCALE_REPLACE
 	var/dependent_disabilities = null //Gets set by eye-dependent disabilities such as colourblindness so the eyes can transfer the disability during transplantation.
 	var/dark_view = 2 //Default dark_view for Humans.
 	var/weld_proof = null //If set, the eyes will not take damage during welding. eg. IPC optical sensors do not take damage when they weld things while all other eyes will.

--- a/code/modules/surgery/organs/subtypes/tajaran.dm
+++ b/code/modules/surgery/organs/subtypes/tajaran.dm
@@ -6,6 +6,7 @@
 	name = "tajaran eyeballs"
 	species = "Tajaran"
 	colourblind_matrix = MATRIX_TAJ_CBLIND //The colour matrix and darksight parameters that the mob will recieve when they get the disability.
+	replace_colours = LIST_TAJ_REPLACE
 	dark_view = 8
 
 /obj/item/organ/internal/eyes/tajaran/farwa //Being the lesser form of Tajara, Farwas have an utterly incurable version of their colourblindness.
@@ -13,3 +14,4 @@
 	species = "Farwa"
 	colourmatrix = MATRIX_TAJ_CBLIND
 	dark_view = 8
+	replace_colours = LIST_TAJ_REPLACE

--- a/code/modules/surgery/organs/subtypes/vulpkanin.dm
+++ b/code/modules/surgery/organs/subtypes/vulpkanin.dm
@@ -6,7 +6,8 @@
 /obj/item/organ/internal/eyes/vulpkanin
 	name = "vulpkanin eyeballs"
 	species = "Vulpkanin"
-	colourblind_matrix = MATRIX_VULP_CBLIND
+	colourblind_matrix = MATRIX_VULP_CBLIND //The colour matrix and darksight parameters that the mob will recieve when they get the disability.
+	replace_colours = LIST_VULP_REPLACE
 	dark_view = 8
 
 /obj/item/organ/internal/eyes/vulpkanin/wolpin //Being the lesser form of Vulpkanin, Wolpins have an utterly incurable version of their colourblindness.
@@ -14,3 +15,4 @@
 	species = "Wolpin"
 	colourmatrix = MATRIX_VULP_CBLIND
 	dark_view = 8
+	replace_colours = LIST_VULP_REPLACE

--- a/nano/templates/wires.tmpl
+++ b/nano/templates/wires.tmpl
@@ -2,7 +2,7 @@
 	<table style='width:100%;'>
 		{{for data.wires}}
 			<tr>
-			<td style='color: {{:value.seen_colour}};'>{{:value.seen_colour}} {{if value.index}}({{:value.index}}){{/if}}</td>
+			<td style='color: {{:value.seen_colour}};'>{{:value.colour_name}} {{if value.index}}({{:value.index}}){{/if}}</td>
 			<td class='floatRight'>
 			{{:helper.link(value.cut ? 'Mend' : 'Cut', null, {'action' : 'cut', 'wire' : value.colour})}}
 			{{:helper.link('Pulse', null, {'action' : 'pulse', 'wire' : value.colour})}}

--- a/nano/templates/wires.tmpl
+++ b/nano/templates/wires.tmpl
@@ -2,7 +2,7 @@
 	<table style='width:100%;'>
 		{{for data.wires}}
 			<tr>
-			<td style='color: {{:value.colour}};'>{{:value.colour}} {{if value.index}}({{:value.index}}){{/if}}</td>
+			<td style='color: {{:value.seen_colour}};'>{{:value.seen_colour}} {{if value.index}}({{:value.index}}){{/if}}</td>
 			<td class='floatRight'>
 			{{:helper.link(value.cut ? 'Mend' : 'Cut', null, {'action' : 'cut', 'wire' : value.colour})}}
 			{{:helper.link('Pulse', null, {'action' : 'pulse', 'wire' : value.colour})}}


### PR DESCRIPTION
Wire panel colors can be overridden by eyes and the colorblindness trait

Full color
![ms_orig](https://user-images.githubusercontent.com/8165455/34458744-c2d9e956-edab-11e7-81d9-ea713777e939.png)

Vulp
![ms_vulp](https://user-images.githubusercontent.com/8165455/34458746-c4ed0da4-edab-11e7-909b-57cff491f6ff.PNG)

Taj
![ms_taj](https://user-images.githubusercontent.com/8165455/34458748-c80c8366-edab-11e7-9183-0eefef4e34e1.PNG)

Vending Machine
![ms_vend](https://user-images.githubusercontent.com/8165455/34458749-c9cfad9a-edab-11e7-8de8-21a0f9f11a34.PNG)

Monochromatic
![ms_cb](https://user-images.githubusercontent.com/8165455/34458750-cc6ed9f4-edab-11e7-8f8e-aa686af710ff.PNG)


@MarsM0nd redid the color transformations on Taj and Vulp to better reflect the in game color matrix.
@Shadeykins came up with the idea to / made me add the ability to rename colors separate from their value.

🆑 Alffd
add: Wire panels are now effected by the colorblindness disability
add: Wire panel color changes now support RGB hex values
/🆑 