### PR TITLE
Reduce chat spam

### DIFF
--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -217,6 +217,21 @@ a.popt {text-decoration: none;}
 /* ADD HERE FOR ITALIC */
 .italic, .ghostdronesay.broadcast {font-style: italic;}
 
+/* BADGE */
+.repeatBadge {
+    display: inline-block;
+    min-width: 0.5em;
+    font-size: 0.7em;
+    padding: 0.2em 0.3em;
+    line-height: 1;
+    color: white;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    background-color: crimson;
+    border-radius: 10px;
+}
+
 /* OUTPUT COLORS */
 .highlight {background: yellow;}
 h1, h2, h3, h4, h5, h6	{color: #0000ff;font-family: Georgia, Verdana, sans-serif;}

--- a/goon/browserassets/html/browserOutput.html
+++ b/goon/browserassets/html/browserOutput.html
@@ -49,6 +49,7 @@
 				<a href="#" class="decreaseFont" id="decreaseFont"><span>Decrease font size</span> <i class="icon-font">-</i></a>
 				<a href="#" class="increaseFont" id="increaseFont"><span>Increase font size</span> <i class="icon-font">+</i></a>
 				<a href="#" class="chooseFont" id="chooseFont">Change font <i class="icon-font"></i></a>
+				<a href="#" class="toggleHideSpam" id="toggleHideSpam"><span>Condense chat</span> <i class="icon-font">Ø</i></a>
 				<a href="#" class="togglePing" id="togglePing"><span>Toggle ping display</span> <i class="icon-circle"></i></a>
 				<a href="#" class="highlightTerm" id="highlightTerm"><span>Highlight string</span> <i class="icon-tag"></i></a>
 				<a href="#" class="saveLog" id="saveLog"><span>Save chat log</span> <i class="icon-save"></i></a>

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -32,6 +32,8 @@ var opts = {
 	'chatMode': 'default', //The mode the chat is in
 	'priorChatHeight': 0, //Thing for height-resizing detection
 	'restarting': false, //Is the round restarting?
+	'previousMessage': '',
+	'previousMessageCount': 1,
 
 	//Options menu
 	'subOptionsLoop': null, //Contains the interval loop for closing the options menu
@@ -268,7 +270,17 @@ function output(message, flag) {
 		emojiparse(entry);
 	}
 
+	if (entry.innerHTML === opts.previousMessage) {
+		opts.previousMessageCount++;
+		var lastIndex = $messages[0].children.length - 1;
+		var countBadge = '<span class="repeatBadge">x' + opts.previousMessageCount + '</span>';
+		$messages[0].children[lastIndex].innerHTML = opts.previousMessage + countBadge;
+		return;
+	}
 
+
+	opts.previousMessage = entry.innerHTML;
+	opts.previousMessageCount = 1;
 	$messages[0].appendChild(entry);
 
 	//Actually do the snap
@@ -932,6 +944,8 @@ $(function() {
 	$('#clearMessages').click(function() {
 		$messages.empty();
 		opts.messageCount = 0;
+		opts.previousMessage = '';
+		opts.previousMessageCount = 1;
 	});
 
 	// Tell BYOND to give us a macro list.

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -34,6 +34,7 @@ var opts = {
 	'restarting': false, //Is the round restarting?
 	'previousMessage': '',
 	'previousMessageCount': 1,
+	'hideSpam': false,
 
 	//Options menu
 	'subOptionsLoop': null, //Contains the interval loop for closing the options menu
@@ -270,7 +271,7 @@ function output(message, flag) {
 		emojiparse(entry);
 	}
 
-	if (entry.innerHTML === opts.previousMessage) {
+	if (opts.hideSpam && entry.innerHTML === opts.previousMessage) {
 		opts.previousMessageCount++;
 		var lastIndex = $messages[0].children.length - 1;
 		var countBadge = '<span class="repeatBadge">x' + opts.previousMessageCount + '</span>';
@@ -545,6 +546,7 @@ $(function() {
 		'spingDisabled': getCookie('pingdisabled'),
 		'shighlightTerms': getCookie('highlightterms'),
 		'shighlightColor': getCookie('highlightcolor'),
+		'shideSpam': getCookie('hidespam'),
 	};
 
 	if (savedConfig.sfontSize) {
@@ -579,6 +581,10 @@ $(function() {
 	if (savedConfig.shighlightColor) {
 		opts.highlightColor = savedConfig.shighlightColor;
 		internalOutput('<span class="internal boldnshit">Loaded highlight color of: '+savedConfig.shighlightColor+'</span>', 'internal');
+	}
+	if (savedConfig.shideSpam) {
+		opts.hideSpam = $.parseJSON(savedConfig.shideSpam);
+		internalOutput('<span class="internal boldnshit">Loaded hide spam preference of: ' + savedConfig.shideSpam + '</span>', 'internal');
 	}
 
 	(function() {
@@ -837,6 +843,12 @@ $(function() {
 		var font = $(this).attr('data-font');
 		$messages.css('font-family', font);
 		setCookie('fonttype', font, 365);
+	});
+
+	$('#toggleHideSpam').click(function(e) {
+		opts.hideSpam = !opts.hideSpam;
+		setCookie('hidespam', opts.hideSpam, 365);
+		internalOutput('<span class="internal boldnshit">Duplicate chat line condensing set to ' + opts.hideSpam + '</span>', 'internal');
 	});
 
 	$('#togglePing').click(function(e) {

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -34,7 +34,7 @@ var opts = {
 	'restarting': false, //Is the round restarting?
 	'previousMessage': '',
 	'previousMessageCount': 1,
-	'hideSpam': false,
+	'hideSpam': true,
 
 	//Options menu
 	'subOptionsLoop': null, //Contains the interval loop for closing the options menu

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -275,10 +275,18 @@ function output(message, flag) {
 		opts.previousMessageCount++;
 		var lastIndex = $messages[0].children.length - 1;
 		var countBadge = '<span class="repeatBadge">x' + opts.previousMessageCount + '</span>';
-		$messages[0].children[lastIndex].innerHTML = opts.previousMessage + countBadge;
+		var lastEntry = $messages[0].children[lastIndex];
+		lastEntry.innerHTML = opts.previousMessage + countBadge;
+		var insertedBadge = $(lastEntry).find('.repeatBadge');
+		insertedBadge.animate({
+			"font-size": "0.9em"
+		}, 100, function() {
+			insertedBadge.animate({
+				"font-size": "0.7em"
+			}, 100);
+		});
 		return;
 	}
-
 
 	opts.previousMessage = entry.innerHTML;
 	opts.previousMessageCount = 1;


### PR DESCRIPTION
A bit of javascript to condense chat lines if the same one happens a bunch of times, by default set to on. Not sure if I like the appearance of the badge. Would like input on what people would want this to look like:

### Gif:
![gif](https://i.imgur.com/1SLx4Do.gif)

### Before:
![before_badge](https://user-images.githubusercontent.com/26497062/34343526-e108cd90-e98f-11e7-9c9f-b4998f3bca2f.png)

### After:
![after_badge](https://user-images.githubusercontent.com/26497062/34343527-e61f441c-e98f-11e7-941a-ee27f203d923.PNG)

### Preferences:
![badge_preferences](https://user-images.githubusercontent.com/26497062/34343648-a1793606-e994-11e7-8519-ef6e574019b3.png)

:cl: Tayyyyyyy
add: Repeated lines are now combined in the chat window. This can be disabled in chat window preferences.
/:cl:
