### PR TITLE
Fixes air alarms

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -53,15 +53,15 @@
 	return cameras
 
 
-/area/proc/atmosalert(danger_level, var/alarm_source)
+/area/proc/atmosalert(danger_level, var/alarm_source, var/force = 0)
 	if(danger_level == ATMOS_ALARM_NONE)
 		atmosphere_alarm.clearAlarm(src, alarm_source)
 	else
 		atmosphere_alarm.triggerAlarm(src, alarm_source, severity = danger_level)
 
-	//Check all the alarms before lowering atmosalm. Raising is perfectly fine.
+	//Check all the alarms before lowering atmosalm. Raising is perfectly fine. If force = 1 we don't care.
 	for(var/obj/machinery/alarm/AA in src)
-		if(!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted && AA.report_danger_level)
+		if(!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted && AA.report_danger_level && !force)
 			danger_level = max(danger_level, AA.danger_level)
 
 	if(danger_level != atmosalm)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -53,7 +53,7 @@
 	return cameras
 
 
-/area/proc/atmosalert(danger_level, var/alarm_source, var/force = 0)
+/area/proc/atmosalert(danger_level, var/alarm_source, var/force = FALSE)
 	if(danger_level == ATMOS_ALARM_NONE)
 		atmosphere_alarm.clearAlarm(src, alarm_source)
 	else

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -921,7 +921,7 @@
 		return 1
 
 	if(href_list["atmos_reset"])
-		if(alarm_area.atmosalert(ATMOS_ALARM_NONE, src,1))
+		if(alarm_area.atmosalert(ATMOS_ALARM_NONE, src, TRUE))
 			apply_danger_level(ATMOS_ALARM_NONE)
 		alarmActivated = 0
 		update_icon()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -921,7 +921,7 @@
 		return 1
 
 	if(href_list["atmos_reset"])
-		if(alarm_area.atmosalert(ATMOS_ALARM_NONE, src))
+		if(alarm_area.atmosalert(ATMOS_ALARM_NONE, src,1))
 			apply_danger_level(ATMOS_ALARM_NONE)
 		alarmActivated = 0
 		update_icon()


### PR DESCRIPTION
This makes it so you can cancel alerts when the air alarm is in warning mode. Previously nothing happened, but now you can turn off the alarm prematurely before it reaches green mode.

If you try to cancel during danger mode, the doors will briefly open as if crowbarred then close again, which is still somewhat useful.

Fixes #8477