### PR TITLE
Normalize vending machine status messages with other wire equipment.

### DIFF
--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -20,9 +20,9 @@ var/const/AUTOLATHE_DISABLE_WIRE = 4
 /datum/wires/autolathe/get_status()
 	. = ..()
 	var/obj/machinery/autolathe/A = holder
-	. += "The red light is [A.disabled ? "off" : "on"]."
-	. += "The green light is [A.shocked ? "off" : "on"]."
-	. += "The blue light is [A.hacked ? "off" : "on"]."
+	. += "The disable light is [A.disabled ? "off" : "on"]."
+	. += "The grounding light is [A.shocked ? "off" : "on"]."
+	. += "The prohibition light is [A.hacked ? "off" : "on"]."
 
 /datum/wires/autolathe/CanUse()
 	var/obj/machinery/autolathe/A = holder

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -34,9 +34,9 @@ var/const/SMARTFRIDGE_WIRE_IDSCAN		= 4
 /datum/wires/smartfridge/get_status()
 	. = ..()
 	var/obj/machinery/smartfridge/S = holder
-	. += "The orange light is [S.seconds_electrified ? "off" : "on"]."
-	. += "The red light is [S.shoot_inventory ? "off" : "blinking"]."
-	. += "A [S.scan_id ? "purple" : "yellow"] light is on."
+	. += "The grounding light is [S.seconds_electrified ? "off" : "on"]."
+	. += "The dispenser warning light is [S.shoot_inventory ? "off" : "blinking"]."
+	. += "The access control light is [S.scan_id ? "off" : "on"]."
 
 /datum/wires/smartfridge/UpdatePulsed(index)
 	var/obj/machinery/smartfridge/S = holder

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -36,10 +36,10 @@ var/const/VENDING_WIRE_IDSCAN = 8
 /datum/wires/vending/get_status()
 	. = ..()
 	var/obj/machinery/vending/V = holder
-	. += "The orange light is [V.seconds_electrified ? "on" : "off"]."
-	. += "The red light is [V.shoot_inventory ? "off" : "blinking"]."
-	. += "The green light is [(V.categories & CAT_HIDDEN) ? "on" : "off"]."
-	. += "A [V.scan_id ? "purple" : "yellow"] light is on."
+	. += "The grounding light is [V.seconds_electrified ? "on" : "off"]."
+	. += "The dispenser light is [V.shoot_inventory ? "off" : "blinking"]."
+	. += "The prohibition light is [(V.categories & CAT_HIDDEN) ? "on" : "off"]."
+	. += "The access control light is [V.scan_id ? "off" : "on"]."
 
 /datum/wires/vending/UpdatePulsed(index)
 	var/obj/machinery/vending/V = holder


### PR DESCRIPTION
This PR normalizes the vending machine lights to match other wire equipment like airlocks.

My thought is that everyone just need to have the colors in their OOC notes, and thats an extra step in modifying things not present on airlocks or other equipment.

Feel free to down vote into oblivion this is tired to the colorblind wire PR and is the easiest way to deal with the issue of blinky lights that don't involve a ton of ❄️

🆑 Alffd
tweak: Changes the Autolathe, fridge, and vending machine wires to the same standard as all other hackable devices.
/🆑 

