### PR TITLE
Fix two minor issues with chat condensing

### DIFF
--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -285,12 +285,13 @@ function output(message, flag) {
 				"font-size": "0.7em"
 			}, 100);
 		});
-		return;
+		entry = lastEntry;
 	}
-
-	opts.previousMessage = entry.innerHTML;
-	opts.previousMessageCount = 1;
-	$messages[0].appendChild(entry);
+	else {
+		opts.previousMessage = entry.innerHTML;
+		opts.previousMessageCount = 1;
+		$messages[0].appendChild(entry);
+	}
 
 	//Actually do the snap
 	if (!filteredOut && atBottom) {


### PR DESCRIPTION
Oops, didn't catch these while testing:

- Condensed messages would remove highlighting, if you set some words to highlight using the goonchat highlight string feature
- In rare instances, the chat wouldn't snap to the bottom if the repeated badge overflowed onto the next line