### PR TITLE
Fix crew pinpointer losing signal when target enters something

### DIFF
--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -325,15 +325,15 @@
 
 /obj/item/weapon/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
-	if((H.z == 0 || H.z == here.z) && istype(H.w_uniform, /obj/item/clothing/under))
+	if(istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
 
 		// Suit sensors must be on maximum.
 		if(!U.has_sensor || U.sensor_mode < 3)
 			return FALSE
 
-		var/turf/there = get_turf(H)
-		return (H.z != 0 || (there && there.z == H.z))
+		var/turf/there = get_turf(U)
+		return there && there.z == here.z
 
 	return FALSE
 


### PR DESCRIPTION
Oh no, another bug fix PR. Going inside a mech/sleeper/etc will no longer break tracking for the crew pinpointer. You must still be on the same z level for the pinpointer to work.

:cl: Tayyyyyyy
fix: Crew pinpointers no longer lose signal when the target enters something like a sleeper or a mech
/:cl: