### PR TITLE
Dark view increases flash damage to eyes

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -313,6 +313,7 @@
 /mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	. = ..()
 	var/damage = intensity - check_eye_prot()
+	var/extra_damage = 0
 	if(.)
 		if(visual)
 			return
@@ -323,19 +324,22 @@
 		if(!E || (E && E.weld_proof))
 			return
 
+		if(E.dark_view)
+			extra_damage = max(E.dark_view - 2, 0)
+
 		switch(damage)
 			if(1)
 				to_chat(src, "<span class='warning'>Your eyes sting a little.</span>")
 				if(prob(40)) //waiting on carbon organs
-					E.receive_damage(1, 1)
+					E.receive_damage(1 + extra_damage, 1)
 
 			if(2)
 				to_chat(src, "<span class='warning'>Your eyes burn.</span>")
-				E.receive_damage(rand(2, 4), 1)
+				E.receive_damage(rand(2, 4) + extra_damage, 1)
 
 			else
 				to_chat(src, "Your eyes itch and burn severely!</span>")
-				E.receive_damage(rand(12, 16), 1)
+				E.receive_damage(rand(12, 16) + extra_damage, 1)
 
 		if(E.damage > E.min_bruised_damage)
 			AdjustEyeBlind(damage)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -324,15 +324,25 @@
 		if(!E || (E && E.weld_proof))
 			return
 
+		var/extra_darkview = 0
 		if(E.dark_view)
-			extra_damage = max(E.dark_view - 2, 0)
+			extra_darkview = max(E.dark_view - 2, 0)
+			extra_damage = extra_darkview
+
+		var/light_amount = 10 // assume full brightness
+		if(isturf(src.loc))
+			var/turf/T = src.loc
+			light_amount = round(T.get_lumcount() * 10)
+
+		// a dark view of 8, in full darkness, will result in maximum 1st tier damage
+		var/extra_prob = (10 - light_amount) * extra_darkview
 
 		switch(damage)
 			if(1)
 				to_chat(src, "<span class='warning'>Your eyes sting a little.</span>")
-				if(prob(40)) //waiting on carbon organs
-					E.receive_damage(1 + extra_damage, 1)
-
+				var/minor_damage_multiplier = min(40 + extra_prob, 100) / 100
+				var/minor_damage = minor_damage_multiplier * (1 + extra_damage)
+				E.receive_damage(minor_damage, 1)
 			if(2)
 				to_chat(src, "<span class='warning'>Your eyes burn.</span>")
 				E.receive_damage(rand(2, 4) + extra_damage, 1)


### PR DESCRIPTION
Just throwing this out there to go along with #8468 and #8489. I am not sure at all if this is the most balanced way to do this. Unlike nightvision glasses, this just increases the damage done to you by flashing, rather than lowering flash protection, so you'll be fine with sunglasses/welding helmet/etc.

People with dark_view 2 or less won't get any additional damage.

I removed the RNG aspect of flash damage and converted it to using a multiplier instead. If fractional eye damage is bad, I can find a way around this.

1st tier flash eye damage (default vanilla eyes without any protection/antiprotection vs a normal flash (flashbang, handheld flash, cell flash) is dependent on darkness level as well as dark view. Here's a graph, with 0 being completely dark and 10 being fully lit:

![capture](https://user-images.githubusercontent.com/26497062/34464574-66ffd93c-ee42-11e7-8cbe-aae1c77162ed.PNG)


Other ideas:
- Lowering eye protection like night vision glasses
- Increasing stun/confusion length (this will probably require refactoring/snowflake)
- Differing multipliers on extra dark_view eye damage based on eye protection

:cl: Tayyyyyyy, FPK
tweak: The more dark view you have, the more eye damage you take from flashing. Darkness amplifies this effect.
/:cl: