### PR TITLE
Adds an emergency action check for air alarms

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -117,6 +117,8 @@
 
 	var/report_danger_level = 1
 
+	var/automatic_emergency = 1 //Does the alarm automaticly respond to an emergency condition
+
 /obj/machinery/alarm/monitor
 	report_danger_level = 0
 
@@ -302,7 +304,7 @@
 
 	if(old_danger_level!=danger_level)
 		apply_danger_level()
-		if(mode == AALARM_MODE_SCRUBBING && danger_level == ATMOS_ALARM_DANGER)
+		if(automatic_emergency && mode == AALARM_MODE_SCRUBBING && danger_level == ATMOS_ALARM_DANGER)
 			if(pressure_dangerlevel == ATMOS_ALARM_DANGER)
 				mode = AALARM_MODE_OFF
 				if(temperature_dangerlevel == ATMOS_ALARM_DANGER && cur_tlv.max2 <= environment.temperature)


### PR DESCRIPTION
Adds a var for automatic_emergency which is on by default.

When on, this will trigger emergency states when in scrubbing to respond to atmospheric breaches and fires.

When disabled, no automatic actions occur.

🆑 Alffd
add: Adds an automated emergency var on air alarms for mappers
/🆑 

@Kyep 