### PR TITLE
A menu of emagged drones nerfs and buffs

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -1,3 +1,4 @@
+#define EMAG_TIMER 3000
 /mob/living/silicon/robot/drone
 	name = "drone"
 	real_name = "drone"
@@ -30,6 +31,7 @@
 	var/mail_destination = 0
 	var/reboot_cooldown = 60 // one minute
 	var/last_reboot
+	var/emagged_time
 
 	holder_type = /obj/item/weapon/holder/drone
 //	var/sprite[0]
@@ -192,6 +194,7 @@
 	ventcrawler = 0
 	pass_flags = 0
 	add_language("Galactic Common", 1)
+	emagged_time = world.time
 	to_chat(src, "<span class='warning'>The new malware has destroyed your ability to ventcrawl or crawl on tables, but has granted you the ability to speak Galactic Common!</span>")
 	default_language = "Galactic Common"
 	icon_state = "repairbot-emagged"
@@ -352,6 +355,8 @@
 	. = ..()
 	if(emagged)
 		density = 1
+		if(world.time - emagged_time > EMAG_TIMER)
+			shut_down()
 		return
 	density = 0 //this is reset every canmove update otherwise
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -182,21 +182,17 @@
 		return
 
 	to_chat(user, "<span class='warning'>You swipe the sequencer across [src]'s interface and watch its eyes flicker.</span>")
-	to_chat(src, "<span class='warning'>You feel a sudden burst of malware loaded into your execute-as-root buffer. Your tiny brain methodically parses, loads and executes the script.</span>")
+	to_chat(src, "<span class='warning'>You feel a sudden burst of malware loaded into your execute-as-root buffer. Your tiny brain methodically parses, loads and executes the script. You sense you have five minutes before the drone server detects this and automatically shuts you down.</span>")
 
 	message_admins("[key_name_admin(user)] emagged drone [key_name_admin(src)].  Laws overridden.")
 	log_game("[key_name(user)] emagged drone [key_name(src)].  Laws overridden.")
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	lawchanges.Add("[time] <B>:</B> [H.name]([H.key]) emagged [name]([key])")
 
+	emagged_time = world.time
 	emagged = 1
 	density = 1
-	ventcrawler = 0
 	pass_flags = 0
-	add_language("Galactic Common", 1)
-	emagged_time = world.time
-	to_chat(src, "<span class='warning'>The new malware has destroyed your ability to ventcrawl or crawl on tables, but has granted you the ability to speak Galactic Common!</span>")
-	default_language = "Galactic Common"
 	icon_state = "repairbot-emagged"
 	holder_type = /obj/item/weapon/holder/drone/emagged
 	update_icons()
@@ -254,10 +250,16 @@
 			full_law_reset()
 			show_laws()
 
-/mob/living/silicon/robot/drone/proc/shut_down()
-	if(stat != 2)
-		to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, and you obediently destroy yourself.</span>")
-		death()
+/mob/living/silicon/robot/drone/proc/shut_down(force=FALSE)
+	if(stat == 2)
+		return
+
+	if(emagged && !force)
+		to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, but it doesn't seem like a good idea to you.</span>")
+		return
+
+	to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, and you obediently destroy yourself.</span>")
+	death()
 
 /mob/living/silicon/robot/drone/proc/full_law_reset()
 	clear_supplied_laws()
@@ -356,7 +358,7 @@
 	if(emagged)
 		density = 1
 		if(world.time - emagged_time > EMAG_TIMER)
-			shut_down()
+			shut_down(TRUE)
 		return
 	density = 0 //this is reset every canmove update otherwise
 

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -188,6 +188,8 @@
 	lawchanges.Add("[time] <B>:</B> [H.name]([H.key]) emagged [name]([key])")
 
 	emagged = 1
+	density = 1
+	ventcrawler = 0
 	icon_state = "repairbot-emagged"
 	holder_type = /obj/item/weapon/holder/drone/emagged
 	update_icons()
@@ -247,11 +249,8 @@
 
 /mob/living/silicon/robot/drone/proc/shut_down()
 	if(stat != 2)
-		if(emagged)
-			to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, but it doesn't seem like a good idea to you.</span>")
-		else
-			to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, and you obediently destroy yourself.</span>")
-			death()
+		to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, and you obediently destroy yourself.</span>")
+		death()
 
 /mob/living/silicon/robot/drone/proc/full_law_reset()
 	clear_supplied_laws()
@@ -347,6 +346,9 @@
 
 /mob/living/silicon/robot/drone/update_canmove(delay_action_updates = 0)
 	. = ..()
+	if(emagged)
+		density = 1
+		return
 	density = 0 //this is reset every canmove update otherwise
 
 /mob/living/simple_animal/drone/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -190,6 +190,7 @@
 	emagged = 1
 	density = 1
 	ventcrawler = 0
+	pass_flags = 0
 	icon_state = "repairbot-emagged"
 	holder_type = /obj/item/weapon/holder/drone/emagged
 	update_icons()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -199,11 +199,11 @@
 	clear_supplied_laws()
 	clear_inherent_laws()
 	laws = new /datum/ai_laws/syndicate_override
-	set_zeroth_law("Only [H.real_name] and people he designates as being such are Syndicate Agents.")
+	set_zeroth_law("Only [H.real_name] and people [H.real_name] designates as being such are Syndicate Agents.")
 
 	to_chat(src, "<b>Obey these laws:</b>")
 	laws.show_laws(src)
-	to_chat(src, "<span class='boldwarning'>ALERT: [H.real_name] is your new master. Obey your new laws and his commands.</span>")
+	to_chat(src, "<span class='boldwarning'>ALERT: [H.real_name] is your new master. Obey your new laws and [H.real_name]'s commands.</span>")
 	return
 
 //DRONE LIFE/DEATH

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -191,6 +191,9 @@
 	density = 1
 	ventcrawler = 0
 	pass_flags = 0
+	add_language("Galactic Common", 1)
+	to_chat(src, "<span class='warning'>The new malware has destroyed your ability to ventcrawl or crawl on tables, but has granted you the ability to speak Galactic Common!</span>")
+	default_language = "Galactic Common"
 	icon_state = "repairbot-emagged"
 	holder_type = /obj/item/weapon/holder/drone/emagged
 	update_icons()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -502,8 +502,6 @@
 	modules += new /obj/item/device/t_scanner(src)
 	modules += new /obj/item/weapon/rpd(src)
 
-	emag = new /obj/item/weapon/pickaxe/drill/cyborg/diamond(src)
-
 	for(var/T in stacktypes)
 		var/obj/item/stack/sheet/W = new T(src)
 		W.amount = stacktypes[T]


### PR DESCRIPTION
:cl: Tayyyyyyy
tweak: Due to increasing amounts of spaghetti code in the cryptographic sequencer, emagging maintenance drones cripples their table pathfinding and removes their ability to pathfind under people's legs. Also, Nanotrasen has patched its drones to remove the hidden diamond drill module and rewritten its drone control code so that drones that don't call home and verify their programming after a certain amount of time are destroyed automatically.
/:cl:

Wow, okay, I guess people really like emagged drives, which I still think are fundamentally wrong, but just in case I didn't make it clear enough multiple times, *these nerfs are not all intended to be merged together.* I just stuck a bunch of fixes of common emagged drone conplaints into one PR. It's my opinion that at least the first three would be great, but my opinion isn't what determines what will ultimately be nerfed.

Assuming an emag has already been purchased, the drone is something that can be gotten for 0 additional TC, the maintenance drone should NOT be far more powerful than a holoparasite, which costs 12 TC.

The idea is that the emagged drone should be an all access, mobile carded AI that can bolt/shock doors for you, as well as do construction and fight for you, but not be too powerful since there is no limit on how many emagged drones you have, and they don't have to stick close to you.

Also a minor fix to the zeroth law that's given to drones to avoid pronoun laws lawyering.

### ~~Can be blown up remotely~~
~~This is a counterplay to an emagged borg, makes sense for the emagged drone too. But this isn't enough because a powergaming drone will just deconstruct this first thing, and the engi outpost isn't a highly visible area like the borg console.~~

### ~~No more ventcrawling~~
~~The emagged drone already has all access and has AI level control over doors/station systems, no need to make it impossible to hit too. Oh, and they can unweld vents, unlike literally everything else that can ventcrawl.~~

### No more diamond drill
It already has a crowbar, fire extinguisher, and a welding tool, does it really need this?

### Dense
Cannot go onto the same tile as a person anymore, which makes it really hard to hit without hitting yourself

### No more hiding in tables
Another common complaint with emagged drones.

### Automatic self destruct
Self destruct 5 minutes after being emagged. Drone players are presumably playing for a sort of "zen mode". This will let drone players get back to their non-intrusive role after a short period of time.

### ~~Grants galactic common~~
~~Since drones are less robust now, they should be able to talk to their traitor and help them out more. I'm not sure on this one, since there's no guarantee a drone player would properly RP a drone and not bring in all kinds of meta information a drone wouldn't feasibly know.~~

### What's not removed:
There's still a special place in hell for drones who manage to get emagged in nukie rounds...extra points for yelling "fuck yeah!" after getting emagged.
  
  
  
  