### PR TITLE
Fixes #6229 - tripwire mines not working / brings back frikin' laser beams

### DIFF
--- a/code/game/objects/items/weapons/grenades/custom_grenades.dm
+++ b/code/game/objects/items/weapons/grenades/custom_grenades.dm
@@ -111,23 +111,23 @@
 	payload_name = "lubricant"
 	stage = 2
 
-	New()
-		..()
-		var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
-		B1.reagents.add_reagent("lube",50)
-		beakers += B1
-/obj/item/weapon/grenade/chem_grenade/lube/remote
-	New()
-		..()
-		CreateDefaultTrigger(/obj/item/device/assembly/signaler)
-/obj/item/weapon/grenade/chem_grenade/lube/prox
-	New()
-		..()
-		CreateDefaultTrigger(/obj/item/device/assembly/prox_sensor)
-/obj/item/weapon/grenade/chem_grenade/lube/tripwire
-	New()
-		..()
-		CreateDefaultTrigger(/obj/item/device/assembly/infra)
+/obj/item/weapon/grenade/chem_grenade/lube/New()
+	..()
+	var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
+	B1.reagents.add_reagent("lube",50)
+	beakers += B1
+
+/obj/item/weapon/grenade/chem_grenade/lube/remote/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/signaler)
+
+/obj/item/weapon/grenade/chem_grenade/lube/prox/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/prox_sensor)
+
+/obj/item/weapon/grenade/chem_grenade/lube/tripwire/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/infra)
 
 
 // Basic explosion grenade
@@ -135,32 +135,68 @@
 	payload_name = "conventional"
 	stage = 2
 
-	New()
-		..()
-		var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
-		var/obj/item/weapon/reagent_containers/glass/beaker/B2 = new(src)
-		B1.reagents.add_reagent("glycerol",30) // todo: someone says NG is overpowered, test.
-		B1.reagents.add_reagent("sacid",15)
-		B2.reagents.add_reagent("sacid",15)
-		B2.reagents.add_reagent("facid",30)
-		beakers += B1
-		beakers += B2
+/obj/item/weapon/grenade/chem_grenade/explosion/New()
+	..()
+	var/obj/item/weapon/reagent_containers/glass/beaker/B1 = new(src)
+	var/obj/item/weapon/reagent_containers/glass/beaker/B2 = new(src)
+	B1.reagents.add_reagent("glycerol",30) // todo: someone says NG is overpowered, test.
+	B1.reagents.add_reagent("sacid",15)
+	B2.reagents.add_reagent("sacid",15)
+	B2.reagents.add_reagent("facid",30)
+	beakers += B1
+	beakers += B2
 
 // Assembly Variants
-/obj/item/weapon/grenade/chem_grenade/explosion/remote
-	New()
-		..()
-		CreateDefaultTrigger(/obj/item/device/assembly/signaler)
+/obj/item/weapon/grenade/chem_grenade/explosion/remote/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/signaler)
 
-/obj/item/weapon/grenade/chem_grenade/explosion/prox
-	New()
-		..()
-		CreateDefaultTrigger(/obj/item/device/assembly/prox_sensor)
+/obj/item/weapon/grenade/chem_grenade/explosion/prox/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/prox_sensor)
 
-/obj/item/weapon/grenade/chem_grenade/explosion/mine
-	New()
-		..()
-		CreateDefaultTrigger(/obj/item/device/assembly/mousetrap)
+/obj/item/weapon/grenade/chem_grenade/explosion/mine/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/mousetrap)
+
+
+// Water + Potassium = Boom
+
+/obj/item/weapon/grenade/chem_grenade/waterpotassium
+	payload_name = "chem explosive"
+	stage = 2
+
+/obj/item/weapon/grenade/chem_grenade/waterpotassium/New()
+	..()
+	var/obj/item/weapon/reagent_containers/glass/beaker/large/B1 = new(src)
+	var/obj/item/weapon/reagent_containers/glass/beaker/large/B2 = new(src)
+	B1.reagents.add_reagent("water",100)
+	B2.reagents.add_reagent("potassium",100)
+	beakers += B1
+	beakers += B2
+
+/obj/item/weapon/grenade/chem_grenade/waterpotassium/remote/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/signaler)
+
+/obj/item/weapon/grenade/chem_grenade/waterpotassium/prox/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/prox_sensor)
+
+
+/obj/item/weapon/grenade/chem_grenade/waterpotassium/tripwire/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/infra)
+
+/obj/item/weapon/grenade/chem_grenade/waterpotassium/tripwire_armed/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/infra/armed)
+
+/obj/item/weapon/grenade/chem_grenade/waterpotassium/tripwire_armed_stealth/New()
+	..()
+	CreateDefaultTrigger(/obj/item/device/assembly/infra/armed/stealth)
+
+
 
 // Basic EMP grenade
 /obj/item/weapon/grenade/chem_grenade/emp

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -7,12 +7,16 @@
 
 	bomb_name = "tripwire mine"
 
+	secured = 0 // toggle_secure()'ed in New() for correct adding to processing_objects, won't work otherwise
+	dir = EAST
 	var/on = 0
-	var/visible = 0
+	var/visible = 1
 	var/obj/effect/beam/i_beam/first = null
 	var/obj/effect/beam/i_beam/last = null
 	var/max_nesting_level = 10
 	var/turf/fire_location
+	var/emission_cycles = 0
+	var/emission_cap = 20
 
 /obj/item/device/assembly/infra/Destroy()
 	if(first)
@@ -22,7 +26,11 @@
 	return ..()
 
 /obj/item/device/assembly/infra/describe()
-	return "The infrared trigger is [on?"on":"off"]."
+	return "The assembly is [secured?"secure":"not secure"]. The infrared trigger is [on?"on":"off"]."
+
+/obj/item/device/assembly/infra/examine(mob/user)
+	..()
+	to_chat(user, describe())
 
 /obj/item/device/assembly/infra/activate()
 	if(!..())	return 0//Cooldown check
@@ -36,10 +44,21 @@
 		processing_objects.Add(src)
 	else
 		on = 0
-		if(first)	qdel(first)
+		if(first)
+			qdel(first)
 		processing_objects.Remove(src)
 	update_icon()
 	return secured
+
+/obj/item/device/assembly/infra/New()
+	..()
+	if (!secured)
+		toggle_secure()
+
+/obj/item/device/assembly/infra/proc/arm() // Forces the device to arm no matter its current state.
+	if (!secured) // Checked because arm() might be called sometime after the object is spawned.
+		toggle_secure()
+	on = 1
 
 /obj/item/device/assembly/infra/update_icon()
 	overlays.Cut()
@@ -71,18 +90,21 @@
 	return null
 
 /obj/item/device/assembly/infra/process()
-	if(!on || fire_location != get_turf(loc))
-		if(first)
-			qdel(first)
-			return
+	var/turf/T = get_turf(src)
+	if(first && (!on || !fire_location || fire_location != T || emission_cycles >= emission_cap))
+		qdel(first)
+		return
+	if(!on)
+		return
 	if(!secured)
 		return
 	if(first && last)
 		last.process()
+		emission_cycles++
 		return
-	var/turf/T = get_valid_loc()
 	if(T)
 		fire_location = T
+		emission_cycles = 0
 		var/obj/effect/beam/i_beam/I = new /obj/effect/beam/i_beam(T)
 		I.master = src
 		I.density = 1
@@ -124,6 +146,8 @@
 		return 0
 	pulse(0)
 	audible_message("[bicon(src)] *beep* *beep*", null, 3)
+	if(first)
+		qdel(first)
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
@@ -177,6 +201,21 @@
 	if(usr.machine == src)
 		interact(usr)
 
+	if(first)
+		qdel(first)
+
+
+
+/obj/item/device/assembly/infra/armed/New()
+	..()
+	spawn(3)
+		if(holder)
+			if(holder.master)
+				dir = holder.master.dir
+		arm()
+
+/obj/item/device/assembly/infra/armed/stealth
+	visible = 0
 
 
 /***************************IBeam*********************************/
@@ -191,6 +230,8 @@
 	var/limit = null
 	var/visible = 0.0
 	var/left = null
+	var/life_cycles = 0
+	var/life_cap = 20
 	anchored = 1.0
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
@@ -209,7 +250,8 @@
 	transform = turn(matrix(), dir2angle(dir))
 
 /obj/effect/beam/i_beam/process()
-	if((loc.density || !(master)))
+	life_cycles++
+	if(loc.density || !master || life_cycles >= life_cap)
 		qdel(src)
 		return
 	if(left > 0)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -26,7 +26,7 @@
 	return ..()
 
 /obj/item/device/assembly/infra/describe()
-	return "The assembly is [secured?"secure":"not secure"]. The infrared trigger is [on?"on":"off"]."
+	return "The assembly is [secured ? "secure" : "not secure"]. The infrared trigger is [on ? "on" : "off"]."
 
 /obj/item/device/assembly/infra/examine(mob/user)
 	..()
@@ -52,11 +52,11 @@
 
 /obj/item/device/assembly/infra/New()
 	..()
-	if (!secured)
+	if(!secured)
 		toggle_secure()
 
 /obj/item/device/assembly/infra/proc/arm() // Forces the device to arm no matter its current state.
-	if (!secured) // Checked because arm() might be called sometime after the object is spawned.
+	if(!secured) // Checked because arm() might be called sometime after the object is spawned.
 		toggle_secure()
 	on = 1
 

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -70,25 +70,6 @@
 	if(holder)
 		holder.update_icon()
 
-/obj/item/device/assembly/infra/proc/get_valid_loc(atom/A, atom/prev, level = 0)
-	if(!A)
-		A = loc
-	if(!prev)
-		prev = src
-	if(level > max_nesting_level)
-		return null
-	else if(isturf(A))
-		return A
-	else if(isobj(A))
-		var/obj/O = A
-		if(isassembly(A) || O.IsAssemblyHolder() || istype(A, /obj/item/device/onetankbomb))
-			return .(A.loc, A, level + 1)
-	else if(ismob(A))
-		var/mob/user = A
-		if(user.get_active_hand() == prev || user.get_inactive_hand() == prev)
-			return .(A.loc, A, level + 1)
-	return null
-
 /obj/item/device/assembly/infra/process()
 	var/turf/T = get_turf(src)
 	if(first && (!on || !fire_location || fire_location != T || emission_cycles >= emission_cap))


### PR DESCRIPTION
Fixes & Tweaks Infrared Lasers:
- Infrared laser assemblies now actually work as device (ie: bomb) triggers. Fixes #6229
- This means you can once again set up laser mines that detonate when their beam is crossed.
- Infrared laser assemblies now default to emitting visible red lasers. You can still toggle them to emitting invisible lasers.
- Some pre-made explosive tripwire mines have been added. /obj/item/weapon/grenade/chem_grenade/waterpotassium/tripwire, tripwire_armed, and tripwire_armed_stealth. The first is safe to handle. The second arms itself on spawn. The third arms itself on spawn, and uses an invisible laser. All three contain 100 water/potassium, and will probably blow your limbs off if they go off close to you.
- The pre-armed versions are intended for use in mapping. If you place them in a map and set their 'dir' variable, they will project lasers in that direction a few seconds after the map loads.
- All tripwire mines will occasionally (every 20 cycles) refresh (recreate) their lasers. This addresses cases where a tripwire mine is moved in an unexpected fashion, e.g: teleported, destroyed, etc. It prevents the lasers from hanging around in incorrect locations.
- As a positive side effect of this, mines will also blink off for one cycle every 20 cycles. This means that if you're well positioned and act fast, it is possible to get past a laser minefield using manual dexterity.

Semi-unrelated fixes/tweaks:
- Some types of chem grenades in custom_grenades have been changed from relative to absolute pathing. IE: "New()" to "/obj/item/weapon/grenade/chem_grenade/lube/remote/New()". I was editing that area anyway, so it made sense to put in absolute paths for their procs.

Example of pre-made, visible laser traps:
![infrared_laser_looks](https://user-images.githubusercontent.com/16434066/34472730-22ee80dc-ef1d-11e7-8e5a-0948b7e08a25.PNG)
