### PR TITLE
Fixes demotion consoles not working for Captain+

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -194,6 +194,8 @@ var/time_last_changed_position = 0
 		return 1
 	if(!scan.assignment)
 		return 0
+	if(access_captain in scan.access)
+		return 1
 	if(!targetjob || !targetjob.title)
 		return 0
 	if(targetjob.title in get_subordinates(scan.assignment, includecivs))


### PR DESCRIPTION
🆑 Kyep
fix: Department management (aka: demotion) consoles only worked for their respective head of staff. Captains, CC characters, etc could not use them.
/🆑