### PR TITLE
Decouples the ability to recieve damage to the brain organ in mobs with the Grey species

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -714,6 +714,7 @@
 		)
 
 	brute_mod = 1.25 //greys are fragile
+	brain_mod = 0 // wrinklebrained
 
 	default_genes = list(REMOTE_TALK)
 


### PR DESCRIPTION
🆑 imsxz
tweak: sets grey brain_mod to 0
/🆑 

requested by somebody. i like greys and they need a buff, because currently they're actual trash. i could list why they're actual trash but i've typed that out dozens of times already in the past and i'm sure the audience of this pull request knows why.