### PR TITLE
Fixes Atmos Machines Not Dropping Parts

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -187,7 +187,7 @@ Pipelines + Other Objects -> Pipe network
 			//You unwrenched a pipe full of pressure? let's splat you into the wall silly.
 			if(unsafe_wrenching)
 				unsafe_pressure_release(user,internal_pressure)
-			deconstruct()
+			deconstruct(TRUE)
 	else
 		return ..()
 
@@ -208,13 +208,16 @@ Pipelines + Other Objects -> Pipe network
 	//Values based on 2*ONE_ATMOS (the unsafe pressure), resulting in 20 range and 4 speed
 	user.throw_at(general_direction,pressures/10,pressures/50)
 
-/obj/machinery/atmospherics/deconstruct()
-	if(can_unwrench)
-		stored.loc = get_turf(src)
-		transfer_fingerprints_to(stored)
-		stored = null
-
-	qdel(src)
+/obj/machinery/atmospherics/deconstruct(disassembled = TRUE)
+	if(can_deconstruct)
+		if(can_unwrench)
+			if(stored)
+				stored.forceMove(get_turf(src))
+				if(!disassembled)
+					stored.obj_integrity = stored.max_integrity * 0.5
+				transfer_fingerprints_to(stored)
+				stored = null
+	..()
 
 /obj/machinery/atmospherics/on_construction(D, P, C)
 	if(C)
@@ -321,7 +324,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/singularity_pull(S, current_size)
 	if(current_size >= STAGE_FIVE)
-		deconstruct()
+		deconstruct(FALSE)
 
 /obj/machinery/atmospherics/update_remote_sight(mob/user)
 	user.sight |= (SEE_TURFS|BLIND)

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -404,14 +404,19 @@ Class Procs:
 	return 0
 
 /obj/machinery/deconstruct(disassembled = TRUE)
-	on_deconstruction()
-	spawn_frame()
-	for(var/obj/item/I in component_parts)
-		I.forceMove(loc)
+	if(can_deconstruct)
+		on_deconstruction()
+		if(component_parts && component_parts.len)
+			spawn_frame()
+			for(var/obj/item/I in component_parts)
+				I.forceMove(loc)
 	qdel(src)
 
-/obj/machinery/proc/spawn_frame()
+/obj/machinery/proc/spawn_frame(disassembled)
 	var/obj/machinery/constructable_frame/machine_frame/M = new /obj/machinery/constructable_frame/machine_frame(loc)
+	if(!disassembled)
+		M.obj_integrity = M.max_integrity * 0.5 //the frame is already half broken
+	transfer_fingerprints_to(M)
 	M.state = 2
 	M.icon_state = "box_1"
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -429,9 +429,9 @@
 		component_parts.Cut()
 	component_parts = null
 
-/obj/machinery/smartfridge/drying_rack/Destroy()
+/obj/machinery/smartfridge/drying_rack/on_deconstruction()
 	new /obj/item/stack/sheet/wood(loc, 10)
-	return ..()
+	..()
 
 /obj/machinery/smartfridge/drying_rack/RefreshParts()
 	return


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/8523
Machine frames that drop from deconstruction will have fingerprints transferred over too
improved code in a few places

:cl:
fix: Freezers and other atmos machines will drop frame and parts correctly again
/:cl:
  