### PR TITLE
Some Fixes and Usability Stuff

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -608,6 +608,7 @@ var/list/teleport_runes = list()
 	new /mob/living/simple_animal/slaughter/cult(T, pick(NORTHEAST, SOUTHEAST, NORTHWEST, SOUTHWEST))
 	cult_mode.demons_summoned = 1
 	shuttle_master.emergency.request(null, 0.5,null)
+	shuttle_master.emergency.canRecall = FALSE
 	cult_mode.third_phase()
 	qdel(src)
 

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -178,6 +178,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				sleep(50)
 				if(!ticker.mode.shadowling_ascended)
 					shuttle_master.emergency.request(null, 0.3)
+					shuttle_master.emergency.canRecall = FALSE
 				ticker.mode.shadowling_ascended = 1
 				A.mind.RemoveSpell(src)
 				qdel(H)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -504,7 +504,7 @@
 		log_game("[key_name(user)] has recalled the shuttle.")
 		message_admins("[key_name_admin(user)] has recalled the shuttle - [ADMIN_FLW(user)].", 1)
 	else
-		to_chat(user, "<span class='warning'>The shuttle can not be recalled! Central Orders!</span>")
+		to_chat(user, "<span class='warning'>Central Command has refused the recall request!</span>")
 		log_game("[key_name(user)] has tried and failed to recall the shuttle.")
 		message_admins("[key_name_admin(user)] has tried and failed to recall the shuttle - [ADMIN_FLW(user)].", 1)
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -500,10 +500,13 @@
 	if(ticker.mode.name == "meteor")
 		return
 
-	shuttle_master.cancelEvac(user)
-	log_game("[key_name(user)] has recalled the shuttle.")
-	message_admins("[key_name_admin(user)] has recalled the shuttle - [formatJumpTo(user)].", 1)
-	return
+	if(shuttle_master.cancelEvac(user))
+		log_game("[key_name(user)] has recalled the shuttle.")
+		message_admins("[key_name_admin(user)] has recalled the shuttle - [formatJumpTo(user)].", 1)
+	else
+		to_chat(user, "The shuttle can not be recalled! Central Orders!")
+		log_game("[key_name(user)] has tried and failed to recall the shuttle.")
+		message_admins("[key_name_admin(user)] has tried and failed to recall the shuttle - [formatJumpTo(user)].", 1)
 
 /proc/post_status(command, data1, data2, mob/user = null)
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -502,11 +502,11 @@
 
 	if(shuttle_master.cancelEvac(user))
 		log_game("[key_name(user)] has recalled the shuttle.")
-		message_admins("[key_name_admin(user)] has recalled the shuttle - [formatJumpTo(user)].", 1)
+		message_admins("[key_name_admin(user)] has recalled the shuttle - [ADMIN_FLW(user)].", 1)
 	else
-		to_chat(user, "The shuttle can not be recalled! Central Orders!")
+		to_chat(user, "<span class='warning'>The shuttle can not be recalled! Central Orders!</span>")
 		log_game("[key_name(user)] has tried and failed to recall the shuttle.")
-		message_admins("[key_name_admin(user)] has tried and failed to recall the shuttle - [formatJumpTo(user)].", 1)
+		message_admins("[key_name_admin(user)] has tried and failed to recall the shuttle - [ADMIN_FLW(user)].", 1)
 
 /proc/post_status(command, data1, data2, mob/user = null)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -787,11 +787,14 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		return
 
 	if(shuttle_master.emergency.canRecall == FALSE)
-		if(alert("Shuttle is currently set to be nonrecallable. Normally this happens due to round ending events. Respect Recall Status?", "Override Recall Status?", "Yes", "No") == "Yes")
-			shuttle_master.emergency.canRecall = TRUE // Resets incase the admin recalls a round ender for some reason.
-			shuttle_master.emergency.cancel()
-		else
+		if(alert("Shuttle is currently set to be nonrecallable. Recalling may break things. Respect Recall Status?", "Override Recall Status?", "Yes", "No") == "Yes")
 			return
+		else
+			var/keepStatus = alert("Maintain recall status on future shuttle calls?", "Maintain Status?", "Yes", "No") == "Yes" //Keeps or drops recallability
+			shuttle_master.emergency.canRecall = TRUE // must be true for cancel proc to work
+			shuttle_master.emergency.cancel()
+			if(keepStatus)
+				shuttle_master.emergency.canRecall = FALSE // restores original status
 	else
 		shuttle_master.emergency.cancel()
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -762,6 +762,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
 	if(confirm != "Yes") return
+	switch(alert(src, "Can the crew recall?", "Recallable?", "Yes", "No"))
+		if("Yes")
+			shuttle_master.emergency.canRecall = TRUE
+		else
+			shuttle_master.emergency.canRecall = FALSE
 
 	shuttle_master.emergency.request()
 
@@ -781,7 +786,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(shuttle_master.emergency.mode >= SHUTTLE_DOCKED)
 		return
 
+	shuttle_master.emergency.canRecall = TRUE // Resets incase the admin recalls a round ender for some reason.
 	shuttle_master.emergency.cancel()
+
 	feedback_add_details("admin_verb","CCSHUT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_admin("[key_name(usr)] admin-recalled the emergency shuttle.")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] admin-recalled the emergency shuttle.</span>")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -762,11 +762,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/confirm = alert(src, "You sure?", "Confirm", "Yes", "No")
 	if(confirm != "Yes") return
-	switch(alert(src, "Can the crew recall?", "Recallable?", "Yes", "No"))
-		if("Yes")
-			shuttle_master.emergency.canRecall = TRUE
-		else
-			shuttle_master.emergency.canRecall = FALSE
+
+	if(alert("Set Shuttle Recallable (Select Yes unless you know what this does)", "Recallable?", "Yes", "No") == "Yes")
+		shuttle_master.emergency.canRecall = TRUE
+	else
+		shuttle_master.emergency.canRecall = FALSE
 
 	shuttle_master.emergency.request()
 
@@ -786,8 +786,14 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(shuttle_master.emergency.mode >= SHUTTLE_DOCKED)
 		return
 
-	shuttle_master.emergency.canRecall = TRUE // Resets incase the admin recalls a round ender for some reason.
-	shuttle_master.emergency.cancel()
+	if(shuttle_master.emergency.canRecall == FALSE)
+		if(alert("Shuttle is currently set to be nonrecallable. Normally this happens due to round ending events. Respect Recall Status?", "Override Recall Status?", "Yes", "No") == "Yes")
+			shuttle_master.emergency.canRecall = TRUE // Resets incase the admin recalls a round ender for some reason.
+			shuttle_master.emergency.cancel()
+		else
+			return
+	else
+		shuttle_master.emergency.cancel()
 
 	feedback_add_details("admin_verb","CCSHUT") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_admin("[key_name(usr)] admin-recalled the emergency shuttle.")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -576,7 +576,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 			command_announcement.Announce(input, customname, MsgSound[beepsound], , , type)
 			print_command_report(input, "[command_name()] Update")
-		else if("No")
+		if("No")
 			//same thing as the blob stuff - it's not public, so it's classified, dammit
 			command_announcer.autosay("A classified message has been printed out at all communication consoles.");
 			print_command_report(input, "Classified [command_name()] Update")

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -38,6 +38,7 @@
 
 	sleep(70)
 	shuttle_master.emergency.request(null, 0.3) // Cannot recall
+	shuttle_master.emergency.canRecall = FALSE
 
 /obj/singularity/narsie/large/attack_ghost(mob/dead/observer/user as mob)
 	makeNewConstruct(/mob/living/simple_animal/hostile/construct/harvester, user, null, 1)


### PR DESCRIPTION
Fixes #8507
Fixes #8484

:cl:
fix: Cancel means Cancel on admeme console reports!
fix: When eldritch gods, demons, handsy aliens, and incarnations of darkness tell you it's time to go, you go
tweak: Comms Console will tell you when the shuttle can't be recalled
tweak: Admemes can now designate whether a shuttle they call is recallable
tweak: Admemes can exercise their power to recall any shuttle, even in defiance of spooky ghosts!
/:cl: