### PR TITLE
IAA Headsets

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -256,7 +256,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	uniform = /obj/item/clothing/under/rank/internalaffairs
 	suit = /obj/item/clothing/suit/storage/internalaffairs
 	shoes = /obj/item/clothing/shoes/brown
-	l_ear = /obj/item/device/radio/headset/headset_sec/alt
+	l_ear = /obj/item/device/radio/headset/headset_iaa
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	id = /obj/item/weapon/card/id/security
 	l_pocket = /obj/item/device/laser_pointer

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -66,6 +66,11 @@
 	icon_state = "medsci_cypherkey"
 	channels = list("Medical" = 1, "Science" = 1)
 
+/obj/item/device/encryptionkey/headset_iaa
+	name = "IAA's Encryption Key"
+	icon_state = "sec_cypherkey"
+	channels = list("Security" = 1, "Engineering" = 0, "Science" = 0, "Medical" = 0, "Supply" = 0, "Service" = 0)
+
 /obj/item/device/encryptionkey/headset_com
 	name = "Command Radio Encryption Key"
 	icon_state = "com_cypherkey"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -114,6 +114,14 @@
 	icon_state = "sec_headset_alt"
 	item_state = "sec_headset_alt"
 
+/obj/item/device/radio/headset/headset_iaa
+	name = "IAA radio headset"
+	desc = "This is used by internal affairs agents. Protects ears from flashbangs."
+	flags = EARBANGPROTECT
+	icon_state = "sec_headset_alt"
+	item_state = "sec_headset_alt"
+	ks2type = /obj/item/device/encryptionkey/headset_iaa
+
 /obj/item/device/radio/headset/headset_eng
 	name = "engineering radio headset"
 	desc = "When the engineers wish to chat like girls."


### PR DESCRIPTION
🆑 Kyep
tweak: IAA radio headsets can now access med/eng/sci/supply/service channels in a similar manner to NTR headsets. They do not get command radio access.
/🆑

Details:
- IAAs now start with IAA headsets.
- IAA headsets are like NT Rep headsets, except that they don't get access to Command radio. 
- Like NTR headsets, they start out with only one channel enabled (Security), but can manually enable the rest of the channels they have access to.
- Like Sec headsets, including the headsets they already have, these headsets have flashbang protection.
- This PR was based on a suggestion by Streaky. The logic was that since IAAs are in theory meant to care about more than just Security, they should have access to more than just Security radio. **I'm not really pushing the idea, I'm mostly putting it up here so Streaky's suggestion can get seriously discussed.**
