### PR TITLE
Prevents mentors from seeing stealthed admins

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -60,7 +60,7 @@ var/global/admin_ooc_colour = "#b82e00"
 
 	for(var/client/C in clients)
 		if(C.prefs.toggles & CHAT_OOC)
-			var/display_name = src.key
+			var/display_name = key
 
 			if(prefs.unlock_content)
 				if(prefs.toggles & MEMBER_PUBLIC)
@@ -75,7 +75,7 @@ var/global/admin_ooc_colour = "#b82e00"
 			if(holder)
 				if(holder.fakekey)
 					if(C.holder.rights & R_ADMIN)
-						display_name = "[holder.fakekey]/([src.key])"
+						display_name = "[holder.fakekey]/([key])"
 					else
 						display_name = holder.fakekey
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -74,7 +74,7 @@ var/global/admin_ooc_colour = "#b82e00"
 
 			if(holder)
 				if(holder.fakekey)
-					if(C.holder.rights & R_ADMIN)
+					if(C.holder && C.holder.rights & R_ADMIN)
 						display_name = "[holder.fakekey]/([key])"
 					else
 						display_name = holder.fakekey

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -74,7 +74,7 @@ var/global/admin_ooc_colour = "#b82e00"
 
 			if(holder)
 				if(holder.fakekey)
-					if(C.holder)
+					if(C.holder.rights & R_ADMIN)
 						display_name = "[holder.fakekey]/([src.key])"
 					else
 						display_name = holder.fakekey

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -34,7 +34,7 @@
 		if(check_rights(R_ADMIN|R_MOD|R_MENTOR, 0, C.mob))
 			var/display_name = key
 			if(holder.fakekey)
-				if(C.holder.rights & R_ADMIN)
+				if(C.holder && C.holder.rights & R_ADMIN)
 					display_name = "[holder.fakekey]/([key])"
 				else
 					display_name = holder.fakekey

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -32,7 +32,13 @@
 
 	for(var/client/C in admins)
 		if(check_rights(R_ADMIN|R_MOD|R_MENTOR, 0, C.mob))
-			to_chat(C, "<span class='[check_rights(R_ADMIN, 0) ? "mentor_channel_admin" : "mentor_channel"]'>MENTOR: <span class='name'>[key_name(usr, 1)]</span> ([admin_jump_link(mob)]): <span class='message'>[msg]</span></span>")
+			var/display_name = src.key
+			if(holder.fakekey)
+				if(C.holder.rights & R_ADMIN)
+					display_name = "[holder.fakekey]/([src.key])"
+				else
+					display_name = holder.fakekey
+			to_chat(C, "<span class='[check_rights(R_ADMIN, 0) ? "mentor_channel_admin" : "mentor_channel"]'>MENTOR: <span class='name'>[display_name]</span> ([admin_jump_link(mob)]): <span class='message'>[msg]</span></span>")
 
 	feedback_add_details("admin_verb","MS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -32,10 +32,10 @@
 
 	for(var/client/C in admins)
 		if(check_rights(R_ADMIN|R_MOD|R_MENTOR, 0, C.mob))
-			var/display_name = src.key
+			var/display_name = key
 			if(holder.fakekey)
 				if(C.holder.rights & R_ADMIN)
-					display_name = "[holder.fakekey]/([src.key])"
+					display_name = "[holder.fakekey]/([key])"
 				else
 					display_name = holder.fakekey
 			to_chat(C, "<span class='[check_rights(R_ADMIN, 0) ? "mentor_channel_admin" : "mentor_channel"]'>MENTOR: <span class='name'>[display_name]</span> ([admin_jump_link(mob)]): <span class='message'>[msg]</span></span>")


### PR DESCRIPTION
fixes #8448 
Also uses the stealthed key in msay.
How it appears to mentors:
![image](https://user-images.githubusercontent.com/29051928/35156162-dc42d602-fd94-11e7-8f95-844afcea1cb4.png)
How it appears to admins:
![image](https://user-images.githubusercontent.com/29051928/35156206-04362ccc-fd95-11e7-9354-d4035619049c.png)
