### PR TITLE
The good clown brings +0.1 layer to poddoors

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -101,7 +101,7 @@
 
 /obj/machinery/door/poddoor/multi_tile // Whoever wrote the old code for multi-tile spesspod doors needs to burn in hell.
 	name = "large pod door"
-	layer = 3.1
+	layer = CLOSED_DOOR_LAYER
 
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver/
 	icon = 'icons/obj/doors/1x4blast_vert.dmi'

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -101,6 +101,7 @@
 
 /obj/machinery/door/poddoor/multi_tile // Whoever wrote the old code for multi-tile spesspod doors needs to burn in hell.
 	name = "large pod door"
+	layer = 3.1
 
 /obj/machinery/door/poddoor/multi_tile/four_tile_ver/
 	icon = 'icons/obj/doors/1x4blast_vert.dmi'


### PR DESCRIPTION
Poddoors now finally start above podlocks, so mappers now don't have to adjust this manually every damn time.