### PR TITLE
Kidan Rebalance

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -161,7 +161,6 @@
 	strip_delay = 20			//	   but seperated to allow items to protect but not impair vision, like space helmets
 	put_on_delay = 25
 	burn_state = FIRE_PROOF
-	species_restricted = list("exclude","Kidan")
 /*
 SEE_SELF  // can see self, no matter what
 SEE_MOBS  // can see all mobs, no matter what

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -472,7 +472,7 @@
 
 	brute_mod = 0.8
 
-	species_traits = list(IS_WHITELISTED)
+	species_traits = list(NO_SCAN, IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS
 	eyes = "kidan_eyes_s"

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -471,8 +471,9 @@
 	unarmed_type = /datum/unarmed_attack/claws
 
 	brute_mod = 0.8
+	tox_mod = 1.3
 
-	species_traits = list(NO_SCAN, IS_WHITELISTED)
+	species_traits = list(IS_WHITELISTED)
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_HEAD_ACCESSORY | HAS_HEAD_MARKINGS | HAS_BODY_MARKINGS
 	eyes = "kidan_eyes_s"


### PR DESCRIPTION
Currently, almost nobody plays Kidan, because their "unable to wear glasses" restriction is way too onerous.
- It prevents them wearing mesons, hurting their ability to do mining, engineering, and atmos.
- It prevents them wearing sec HUDs, which hurts them in all security jobs.
- It prevents them wearing medical HUDs, which hurts them in most medical jobs.
- It prevents them wearing science and diagnostic HUDs, which hurt them in science and robotics jobs.

In short, Kidan are at a big disadvantage in trying to play most jobs.
Yes, they get a 20% reduction in incoming brute damage, and better unarmed attacks.
Still, this isn't sufficient compensation for their loss of ability to wear eyewear/HUDs.
Both unarmed attacks and brute damage mitigation are situational benefits, but the inability to wear eyewear is a far more regular problem in most departments.
It is way easier to get extra brute damage mitigation (even civilians can get shields), than it is to work around the eyewear issue.

So, in this PR, I make two changes to Kidans, with the goal of making them a more viable race.
- First, they can now wear eyewear, like the other races.
- Second, to compensate for this, ~~they are no longer clonable~~ they now take 30% extra damage from toxins.

Yes, this leaves Kidan arguably stronger than they were before. That is intentional.
Right now they're seen as a crippled race that nobody plays.
My hope is these changes get them out of the doghouse, and get people to take them seriously as a race they might want to play.
They still cost 30 KP, so there is still a high barrier to playing them, but at least now people might actually see them as worth it.

![kidan_officer](https://user-images.githubusercontent.com/16434066/35438334-f49a21dc-024a-11e8-8ec3-a1bfaf00c996.PNG)
![kidan_doctor](https://user-images.githubusercontent.com/16434066/35438338-f7cf532c-024a-11e8-99da-9fa4f0f8f939.PNG)



🆑 Kyep
tweak: Kidan can now wear glasses, but also take +30% more tox damage from all tox damage sources.
/🆑