### PR TITLE
PLZ dont misinform coders on z-level checks, KTHXBYE

### DIFF
--- a/_maps/cyberiad.dm
+++ b/_maps/cyberiad.dm
@@ -1,8 +1,8 @@
 /*
-You need to have 7 z-levels of the same size dimensions.
-z-level order is important, the order you put them in inside this file will determine what z level number they are assigned ingame.
-Names of z-level do not matter, but order does greatly, for instances such as checking alive status of revheads on z1
-current as of 2015/05/11
+All z-levels should be identical in size. Their numbers should not matter.
+The order of z-levels should not matter as long as their attributes are properly defined at MAP_TRANSITION_CONFIG.
+Old code checked for the number of the z-level (for example whether there are any revheads on Z1),
+currently it should check for the define (for example whether there are any revheads on any z-levels defined as STATION_LEVEL).
 z1 = station
 z2 = centcomm
 z3 = telecommunications center

--- a/_maps/metastation.dm
+++ b/_maps/metastation.dm
@@ -1,9 +1,8 @@
 /*
-The /tg/ codebase currently requires you to have 7 z-levels of the same size dimensions.
-z-level order is important, the order you put them in inside this file will determine what z level number they are assigned ingame.
-Names of z-level do not matter, but order does greatly, for instances such as checking alive status of revheads on z1
-
-current as of 2014/11/24
+All z-levels should be identical in size. Their numbers should not matter.
+The order of z-levels should not matter as long as their attributes are properly defined at MAP_TRANSITION_CONFIG.
+Old code checked for the number of the z-level (for example whether there are any revheads on Z1),
+currently it should check for the define (for example whether there are any revheads on any z-levels defined as STATION_LEVEL).
 z1 = station
 z2 = centcomm
 z3 = derelict telecomms satellite


### PR DESCRIPTION
As of #5254 nothing should check the number of the z-level when looking for game conditions. If such things still exist they should be purged and replaced with the newer, more efficient model.

The comments mislead the coder, and may (have) cause(d) them to use the wrong way. The comments should be up to date now.

No CL, since this PR does nothing other than giving instructions.