### PR TITLE
Add light to lasers and flashbangs

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -3,12 +3,18 @@
 	icon_state = "flashbang"
 	item_state = "flashbang"
 	origin_tech = "materials=2;combat=3"
+	light_power = 10
+	light_color = LIGHT_COLOR_WHITE
+	var/light_time = 2
 
 /obj/item/weapon/grenade/flashbang/prime()
 	update_mob()
 	var/flashbang_turf = get_turf(src)
 	if(!flashbang_turf)
 		return
+
+	set_light(7)
+
 	for(var/mob/living/M in hearers(7, flashbang_turf))
 		bang(get_turf(M), M)
 
@@ -16,7 +22,9 @@
 		var/damage = round(30/(get_dist(B,get_turf(src))+1))
 		B.health -= damage
 		B.update_icon()
-	qdel(src)
+
+	spawn(light_time)
+		qdel(src)
 
 /obj/item/weapon/grenade/flashbang/proc/bang(var/turf/T , var/mob/living/M)
 	M.show_message("<span class='warning'>BANG</span>", 2)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -20,6 +20,11 @@
 
 	update_light()
 
+/atom/proc/flash_light(l_range, l_power, l_color = NONSENSICAL_VALUE, time = 2)
+	set_light(l_range, l_power, l_color)
+	spawn(time)
+		set_light(0)
+
 #undef NONSENSICAL_VALUE
 
 /atom/proc/update_light()

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -20,11 +20,6 @@
 
 	update_light()
 
-/atom/proc/flash_light(l_range, l_power, l_color = NONSENSICAL_VALUE, time = 2)
-	set_light(l_range, l_power, l_color)
-	spawn(time)
-		set_light(0)
-
 #undef NONSENSICAL_VALUE
 
 /atom/proc/update_light()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -9,6 +9,8 @@
 	flag = "laser"
 	eyeblur = 2
 	is_reflectable = TRUE
+	light_range = 2
+	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/beam/laser
 
@@ -35,6 +37,7 @@
 	irradiate = 30
 	forcedodge = 1
 	range = 15
+	light_color = LIGHT_COLOR_GREEN
 
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
@@ -44,11 +47,13 @@
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
+	light_color = LIGHT_COLOR_CYAN
 
 /obj/item/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
+	light_color = LIGHT_COLOR_DARKBLUE
 
 /obj/item/projectile/beam/pulse/on_hit(var/atom/target, var/blocked = 0)
 	if(istype(target,/turf/)||istype(target,/obj/structure/))
@@ -77,6 +82,7 @@
 	flag = "laser"
 	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)
 	log_override = TRUE
+	light_color = LIGHT_COLOR_DARKBLUE
 
 /obj/item/projectile/beam/lasertag/on_hit(atom/target, blocked = 0)
 	. = ..()
@@ -94,6 +100,7 @@
 /obj/item/projectile/beam/lasertag/redtag
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
+	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/beam/lasertag/bluetag
 	icon_state = "bluelaser"
@@ -106,6 +113,7 @@
 	stun = 5
 	weaken = 5
 	stutter = 5
+	light_color = LIGHT_COLOR_PINK
 
 /obj/item/projectile/beam/immolator
 	name = "immolation beam"
@@ -122,12 +130,15 @@
 	icon_state = "purple_laser"
 	damage = 200
 	damage_type = BURN
+	light_color = LIGHT_COLOR_PURPLE
 
 /obj/item/projectile/beam/instakill/blue
 	icon_state = "blue_laser"
+	light_color = LIGHT_COLOR_DARKBLUE
 
 /obj/item/projectile/beam/instakill/red
 	icon_state = "red_laser"
+	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/beam/instakill/on_hit(atom/target)
 	. = ..()


### PR DESCRIPTION
:cl: Tayyyyyyy
tweak: Energy beams of all types emit light.
tweak: Flashbangs emit a burst of light when detonated
/:cl:

This should cover every type of laser in the game.

[video](https://imgur.com/a/XHrIV)

Sorry for bad video quality, I can make better ones later if people want but this is pretty much exactly the same settings tg has on their lasers.

Here's the flashbang. The radius of the light effect is the same as the radius of the flashbang!:
![flashbang_range](https://user-images.githubusercontent.com/26497062/35305639-b10454c0-005f-11e8-88bf-3e691bec62fe.gif)

<!-- ![output](https://user-images.githubusercontent.com/26497062/35302020-ca4792b0-0052-11e8-9265-f2597ceff7ab.gif)-->

[clusterbang video!](https://streamable.com/jqkpc)

~~Also added, but currently not used, is a helper proc on the light atom called `flash_light` that will quickly turn on and then turn off a light after a specified number of deciseconds. May prove useful for muzzle flashes in the future, though those are a bit more complicated so I'm not gonna try to do that in this PR.~~ After a bit of testing it didn't look that great so I'm removing it.

