### PR TITLE
Fixes pod lock buster

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -387,8 +387,8 @@
 				return
 			if(L.on && unlocked == FALSE) //The buster is on, we don't have a lock system, and the pod is still somehow locked, unlocking.
 				unlocked = TRUE
-				user.visible_message(user, "<span class='warning'>[user] has destroyed the [src]'s malfunction that locks the doors!</span>",
-					"<span class='notice'>You destroy the [src]'s malfunction that locks the doors!</span>")
+				user.visible_message(user, "<span class='notice'>[user] repairs [src]'s doors with [L].</span>",
+					"<span class='notice'>You repair [src]'s doors with [L].</span>")
 			to_chat(user, "<span class='notice'>Turn the [L] on first.</span>")
 			return
 
@@ -611,7 +611,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 		return
 
 	if(usr != src.pilot)
-		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
+		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair.</span>")
 		return
 	use_internal_tank = !use_internal_tank
 	to_chat(usr, "<span class='notice'>Now taking air from [use_internal_tank?"internal airtank":"environment"].</span>")
@@ -830,12 +830,12 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 		return
 
 	if(usr in passengers && usr != src.pilot)
-		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair.")
+		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair.</span>")
 		return
 
 	if(!equipment_system.lock_system)
-		to_chat(usr, "<span class='notice'>There is no locking system you could lock.")
-		unlocked = TRUE //Should never be true without a lock, but if it somehow happens, that will force an unlock.
+		to_chat(usr, "<span class='warning'>[src] has no locking mechanism.</span>")
+		unlocked = TRUE //Should never be false without a lock, but if it somehow happens, that will force an unlock.
 	else
 		unlocked = !unlocked
 		to_chat(usr, "<span class='warning'>You [unlocked ? "unlock" : "lock"] the doors.</span>")
@@ -850,7 +850,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 		return
 
 	if(usr != src.pilot)
-		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
+		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair</span>")
 		return
 
 	for(var/obj/machinery/door/poddoor/multi_tile/P in orange(3,src))
@@ -885,7 +885,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 		return
 
 	if(usr != src.pilot)
-		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
+		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair.</span>")
 		return
 	if(!equipment_system.weapon_system)
 		to_chat(usr, "<span class='warning'>[src] has no weapons!</span>")
@@ -902,7 +902,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 		return
 
 	if(usr != src.pilot)
-		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
+		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair.</span>")
 		return
 	if(!equipment_system.cargo_system)
 		to_chat(usr, "<span class='warning'>[src] has no cargo system!</span>")
@@ -918,7 +918,7 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 		return
 
 	if(usr != src.pilot)
-		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
+		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair.</span>")
 		return
 	lightsToggle()
 

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -63,7 +63,7 @@
 									 "pod_black" = "#3B8FE5", \
 									 "pod_industrial" = "#CCCC00")
 
-	var/unlocked = 1
+	var/unlocked = TRUE
 
 	var/move_delay = 2
 	var/next_move = 0
@@ -378,12 +378,17 @@
 					"<span class='notice'>You start drilling through the [src]'s lock!</span>")
 				if(do_after(user, 100 * W.toolspeed, target = src))
 					QDEL_NULL(equipment_system.lock_system)
+					unlocked = TRUE
 					user.visible_message(user, "<span class='warning'>[user] has destroyed the [src]'s lock!</span>",
 						"<span class='notice'>You destroy the [src]'s lock!</span>")
 				else
 					user.visible_message(user, "<span class='warning'>[user] fails to break through the [src]'s lock!</span>",
 					"<span class='notice'>You were unable to break through the [src]'s lock!</span>")
 				return
+			if(L.on && unlocked == FALSE) //The buster is on, we don't have a lock system, and the pod is still somehow locked, unlocking.
+				unlocked = TRUE
+				user.visible_message(user, "<span class='warning'>[user] has destroyed the [src]'s malfunction that locks the doors!</span>",
+					"<span class='notice'>You destroy the [src]'s malfunction that locks the doors!</span>")
 			to_chat(user, "<span class='notice'>Turn the [L] on first.</span>")
 			return
 
@@ -825,11 +830,15 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 		return
 
 	if(usr in passengers && usr != src.pilot)
-		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair")
+		to_chat(usr, "<span class='notice'>You can't reach the controls from your chair.")
 		return
 
-	unlocked = !unlocked
-	to_chat(usr, "<span class='warning'>You [unlocked ? "unlock" : "lock"] the doors.</span>")
+	if(!equipment_system.lock_system)
+		to_chat(usr, "<span class='notice'>There is no locking system you could lock.")
+		unlocked = TRUE //Should never be true without a lock, but if it somehow happens, that will force an unlock.
+	else
+		unlocked = !unlocked
+		to_chat(usr, "<span class='warning'>You [unlocked ? "unlock" : "lock"] the doors.</span>")
 
 
 /obj/spacepod/verb/toggleDoors()


### PR DESCRIPTION
Fixes: #8588
Ensures pods are only locked when there is a pod lock, and let's pod
lock busters unlock the pod, and not jusre destroy a lock. Also minor
typo correction and replacing a 1 used as boolean with TRUE
:cl:
Fix: Pod lock busters can now unlock pods
Tweak: Pods can only be locked with a locking system installed.
/:cl: