### PR TITLE
Movement delay is no longer rounded to the tick

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -147,11 +147,12 @@
 			mob.control_object.forceMove(get_step(mob.control_object, direct))
 	return
 
-
+#define MOVEMENT_DELAY_BUFFER 0.75
+#define MOVEMENT_DELAY_BUFFER_DELTA 1.25
 /client/Move(n, direct)
 	if(world.time < move_delay)
 		return
-
+	var/old_move_delay = move_delay
 	move_delay = world.time + world.tick_lag //this is here because Move() can now be called multiple times per tick
 	if(!mob || !mob.loc)
 		return 0
@@ -220,7 +221,11 @@
 
 	//We are now going to move
 	moving = 1
-	move_delay = mob.movement_delay() + world.time
+	var/delay = mob.movement_delay()
+	if(old_move_delay + (delay * MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
+		move_delay = old_move_delay + delay
+	else
+		move_delay = delay + world.time
 	mob.last_movement = world.time
 
 	if(locate(/obj/item/weapon/grab, mob))


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/28616

Fixes an issue we inherited with instant movement, see https://github.com/tgstation/tgstation/issues/13376

:cl:
fix: Insta-movement works marginally better
/:cl: