### PR TITLE
Reduce shuttle cheese

### DIFF
--- a/code/controllers/Processes/shuttles.dm
+++ b/code/controllers/Processes/shuttles.dm
@@ -138,7 +138,7 @@ DECLARE_GLOBAL_CONTROLLER(shuttle, shuttle_master)
 		var/extra_minutes = 0
 		var/priority_time = emergencyCallTime * 0.5
 		if(world.time - emergency_sec_level_time < priority_time)
-			extra_minutes = abs(round(((emergency_sec_level_time + priority_time) - world.time)/600)) + 1
+			extra_minutes = 5
 		emergency.request(null, 0.5 + extra_minutes / (emergencyCallTime / 600), signal_origin, html_decode(emergency_reason), 1)
 	else
 		emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)

--- a/code/controllers/Processes/shuttles.dm
+++ b/code/controllers/Processes/shuttles.dm
@@ -13,6 +13,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	var/emergencyCallTime = 6000	//time taken for emergency shuttle to reach the station when called (in deciseconds)
 	var/emergencyDockTime = 1800	//time taken for emergency shuttle to leave again once it has docked (in deciseconds)
 	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
+	var/emergency_sec_level_time = 0 // time sec level was last raised to red or higher
 	var/area/emergencyLastCallLoc
 	var/emergencyNoEscape
 
@@ -134,6 +135,10 @@ DECLARE_GLOBAL_CONTROLLER(shuttle, shuttle_master)
 	var/area/signal_origin = get_area(user)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
 	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
+		if(world.time - emergency_sec_level_time < emergencyCallTime * 0.5)
+			// It hasn't been five minutes since the alert was raised! They're cheesing the shuttle.
+			to_chat(user, "A priority emergency shuttle is being prepared. Please wait another [abs(round(((emergency_sec_level_time + emergencyCallTime * 0.5) - world.time)/600))] minutes before trying again.")
+			return
 		emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1)
 	else
 		emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)

--- a/code/controllers/Processes/shuttles.dm
+++ b/code/controllers/Processes/shuttles.dm
@@ -135,11 +135,11 @@ DECLARE_GLOBAL_CONTROLLER(shuttle, shuttle_master)
 	var/area/signal_origin = get_area(user)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
 	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
-		if(world.time - emergency_sec_level_time < emergencyCallTime * 0.5)
-			// It hasn't been five minutes since the alert was raised! They're cheesing the shuttle.
-			to_chat(user, "The NTV Charon Emergency Shuttle is being relocated to a Rapid Response Location due to your Code Red Emergency. Please wait another [abs(round(((emergency_sec_level_time + emergencyCallTime * 0.5) - world.time)/600))] minutes before trying again.")
-			return
-		emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1)
+		var/extra_minutes = 0
+		var/priority_time = emergencyCallTime * 0.5
+		if(world.time - emergency_sec_level_time < priority_time)
+			extra_minutes = abs(round(((emergency_sec_level_time + priority_time) - world.time)/600)) + 1
+		emergency.request(null, 0.5 + extra_minutes / (emergencyCallTime / 600), signal_origin, html_decode(emergency_reason), 1)
 	else
 		emergency.request(null, 1, signal_origin, html_decode(emergency_reason), 0)
 

--- a/code/controllers/Processes/shuttles.dm
+++ b/code/controllers/Processes/shuttles.dm
@@ -137,7 +137,7 @@ DECLARE_GLOBAL_CONTROLLER(shuttle, shuttle_master)
 	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED) // There is a serious threat we gotta move no time to give them five minutes.
 		if(world.time - emergency_sec_level_time < emergencyCallTime * 0.5)
 			// It hasn't been five minutes since the alert was raised! They're cheesing the shuttle.
-			to_chat(user, "A priority emergency shuttle is being prepared. Please wait another [abs(round(((emergency_sec_level_time + emergencyCallTime * 0.5) - world.time)/600))] minutes before trying again.")
+			to_chat(user, "The NTV Charon Emergency Shuttle is being relocated to a Rapid Response Location due to your Code Red Emergency. Please wait another [abs(round(((emergency_sec_level_time + emergencyCallTime * 0.5) - world.time)/600))] minutes before trying again.")
 			return
 		emergency.request(null, 0.5, signal_origin, html_decode(emergency_reason), 1)
 	else

--- a/code/modules/security_levels/security levels.dm
+++ b/code/modules/security_levels/security levels.dm
@@ -27,6 +27,10 @@
 
 	//Will not be announced if you try to set to the same level as it already is
 	if(level >= SEC_LEVEL_GREEN && level <= SEC_LEVEL_DELTA && level != security_level)
+		if(level >= SEC_LEVEL_RED && security_level < SEC_LEVEL_RED)
+			// Mark down this time to prevent shuttle cheese
+			shuttle_master.emergency_sec_level_time = world.time
+
 		switch(level)
 			if(SEC_LEVEL_GREEN)
 				security_announcement_down.Announce("All threats to the station have passed. All weapons need to be holstered and privacy laws are once again fully enforced.","Attention! Security level lowered to green.")


### PR DESCRIPTION
Once you up to red, a timer starts to tick down from 5 minutes. After 5 minutes passes, the shuttle time is reduced to 5 minutes.

For reasons why this is a good idea, see @Spartan6's [forum suggestion](https://nanotrasen.se/forum/topic/11900-nov-25th-meeting-questions/?tab=comments#comment-99408).

Shouldn't affect automatic crew transfer.

:cl: Tayyyyyyy, LP Spartan
tweak: Once you up to red, it takes 5 minutes before the shuttle transit time is reduced to 5 minutes.
/:cl: