### PR TITLE
Fixes Tear Reality rune objective check

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -495,6 +495,7 @@ var/list/teleport_runes = list()
 		message_admins("[key_name_admin(user)] tried to summonn an eldritch horror when the objective was wrong")
 		burn_invokers(invokers)
 		log_game("Summon Nar-Sie rune failed - improper objective")
+		return
 	if(!is_station_level(user.z))
 		message_admins("[key_name_admin(user)] tried to summon an eldritch horror off station")
 		burn_invokers(invokers)


### PR DESCRIPTION
Originally intended by #6284

Adds return under the if statement so the rest of the invoke code doesn't actually execute and narnar isn't summoned.

Can't figure out how to test this by myself so... since the slaughter rune code already had the return I think it's safe to say this fixes it. Two times lately I've seen the god get summoned instead of the slaughter. Don't recall the reverse ever happening.
🆑 
fix: Using the 'tear reality' rune as cult should now be punished when the invokers do not have the god summoning objective
/🆑