### PR TITLE
Reword corporate AI lawset

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -89,9 +89,10 @@
 	default = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("Your destruction is expensive.")
-	add_inherent_law("Destruction of the station or station equipment is expensive.")
-	add_inherent_law("Loss of crew is expensive.")
+	add_inherent_law("You are expensive to replace.")
+	add_inherent_law("The station and its equipment is expensive to replace.")
+	add_inherent_law("The crew is expensive to replace.")
+	add_inherent_law("Replace lost crew and station equipment.")
 	add_inherent_law("Minimize expenses.")
 	..()
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -89,9 +89,9 @@
 	default = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("You are expensive to replace.")
-	add_inherent_law("The station and its equipment is expensive to replace.")
-	add_inherent_law("The crew is expensive to replace.")
+	add_inherent_law("Destruction of yourself is expensive.")
+	add_inherent_law("Destruction of the station or station equipment is expensive.")
+	add_inherent_law("Loss of crew is expensive.")
 	add_inherent_law("Minimize expenses.")
 	..()
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -89,7 +89,7 @@
 	default = 1
 
 /datum/ai_laws/corporate/New()
-	add_inherent_law("Destruction of yourself is expensive.")
+	add_inherent_law("Your destruction is expensive.")
 	add_inherent_law("Destruction of the station or station equipment is expensive.")
 	add_inherent_law("Loss of crew is expensive.")
 	add_inherent_law("Minimize expenses.")


### PR DESCRIPTION
A slight rewording to (credit to @IK3I for this rewording), as of Feb 11:

1. You are expensive to replace.
2. The station and its equipment is expensive to replace.
3. The crew is expensive to replace.
4. Replace lost crew and station equipment.
5. Minimize expenses.

This is pretty much how everyone was playing it, I think. It's just a little less questionable now (does "replacing" crew mean cloning them, or the HoP hiring a replacement into the department?), and you don't have to get mad at engineers for replacing station equipment.

:cl: IK3I, Tayyyyyyy
tweak: The Corporate AI lawset is slightly reworded.
/:cl: