### PR TITLE
Remove sleep verb

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -31,7 +31,6 @@
 	var/list/alien_organs = list()
 
 /mob/living/carbon/alien/New()
-	verbs += /mob/living/verb/mob_sleep
 	verbs += /mob/living/verb/lay_down
 	alien_organs += new /obj/item/organ/internal/brain/xeno
 	alien_organs += new /obj/item/organ/internal/xenos/hivenode

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -370,18 +370,6 @@ var/list/intents = list(INTENT_HELP,INTENT_DISARM,INTENT_GRAB,INTENT_HARM)
 				else
 					hud_used.action_intent.icon_state = "help"
 
-
-/mob/living/verb/mob_sleep()
-	set name = "Sleep"
-	set category = "IC"
-
-	if(sleeping)
-		to_chat(src, "<span class='notice'>You are already sleeping.</span>")
-		return
-	else
-		if(alert(src, "You sure you want to sleep for a while?", "Sleep", "Yes", "No") == "Yes")
-			SetSleeping(20) //Short nap
-
 /mob/living/verb/lay_down()
 	set name = "Rest"
 	set category = "IC"


### PR DESCRIPTION
:cl: Tayyyyyyy
del: Sleep verb has been removed
/:cl:

I don't think there were any legit uses for this. It was only used for cheesing surgery and cheesing gateway mobs.