### PR TITLE
Reduce atmospheric stun times

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -318,7 +318,7 @@
 				to_chat(src, "<span class='userdanger'>The pressure sends you flying!</span>")
 			if(ishuman(src))
 				var/mob/living/carbon/human/H = src
-				H.Weaken(min(pressure_difference / 10, 10))
+				H.Weaken(min(pressure_difference / 50, 2))
 			spawn()
 				throw_at(general_direction, pressure_difference / 10, pressure_difference / 200, null, 0, 0, null)
 			last_forced_movement = air_master.current_cycle


### PR DESCRIPTION
Makes maximum atmospherics stun 4 seconds and reduces all other atmospheric stuns less then 4 seconds by 80%

🆑 Alffd
tweak: Reduce all atmospheric stuns by 80%
tweak: Cap the maximum atmospheric stun time to 4 seconds
/🆑 