### PR TITLE
Port tg AI status panel

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -229,10 +229,10 @@ var/list/ai_verbs_default = list(
 /mob/living/silicon/ai/Stat()
 	..()
 	if(statpanel("Status"))
-		if(!stat)
-			show_borg_info()
+		if(stat)
+			stat(null, text("Systems nonfunctional"))
 			return
-		stat(null, text("Systems nonfunctional"))
+		show_borg_info()
 
 /mob/living/silicon/ai/proc/show_borg_info()
 	stat(null, text("Connected cyborgs: [connected_robots.len]"))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -226,6 +226,27 @@ var/list/ai_verbs_default = list(
 
 	job = "AI"
 
+/mob/living/silicon/ai/Stat()
+	..()
+	if(statpanel("Status"))
+		if(!stat)
+			show_borg_info()
+			return
+		stat(null, text("Systems nonfunctional"))
+
+/mob/living/silicon/ai/proc/show_borg_info()
+	stat(null, text("Connected cyborgs: [connected_robots.len]"))
+	for(var/mob/living/silicon/robot/R in connected_robots)
+		var/robot_status = "Nominal"
+		if(R.stat || !R.client)
+			robot_status = "OFFLINE"
+		else if(!R.cell || R.cell.charge <= 0)
+			robot_status = "DEPOWERED"
+		// Name, Health, Battery, Module, Area, and Status! Everything an AI wants to know about its borgies!
+		var/area/A = get_area(R)
+		stat(null, text("[R.name] | S.Integrity: [R.health]% | Cell: [R.cell ? "[R.cell.charge] / [R.cell.maxcharge]" : "Empty"] | \
+		Module: [R.designation] | Loc: [sanitize(A.name)] | Status: [robot_status]"))
+
 /mob/living/silicon/ai/rename_character(oldname, newname)
 	if(!..(oldname, newname))
 		return FALSE


### PR DESCRIPTION
Kay hopefully this is the last of the random small PRs I've wanted to do for a while...
This ports tg's AI status panel, which shows the name, health, module, area, and status of synced borgs.

![ai_status_panel](https://user-images.githubusercontent.com/26497062/35957531-a6d1ff9e-0c61-11e8-9bc7-c167ceb983cb.png)

:cl: Tayyyyyyy
add: AIs can view info of their synced borgs in the status panel
/:cl: