### PR TITLE
Cuffing briefcases to your wrist

### DIFF
--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -14,6 +14,50 @@
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	burn_state = FLAMMABLE
 	burntime = 20
+	var/cuff
+	var/cuff_active = FALSE
 
 /obj/item/weapon/storage/briefcase/New()
 	..()
+
+/obj/item/weapon/storage/briefcase/MouseDrop_T(obj/item/weapon/restraints/handcuffs/I, mob/user)
+	if(user.incapacitated() || !ishuman(user))
+		return
+
+	if(cuffs)
+		to_chat(user, "<span class='notice'>[src] already has [cuff.name] attached!</span>")
+
+	else
+		to_chat(user, "<span class='notice'>You start attaching [I] to [src]'s handle.</span>")
+		if(do_after(user, 20))
+			cuff = I
+			to_chat(user, "<span class='notice'>You successfully clip the shackle of [I] around [src]'s handle.'</span>")
+			qdel(I)
+			desc += " It has [cuff.name] hanging from its handle."
+
+/obj/item/weapon/storage/briefcase/attack_self(mob/living/human/user)
+	if(!cuff)
+		return
+
+	var/hand
+	if(user.incapacitated())
+		return
+
+	if(user.l_hand == src)
+		user.l_hand.flags ^= NODROP
+		cuff_active = !cuff_active
+		hand = "left"
+
+	else if(user.r_hand == src)
+		user.r_hand.flags ^= NODROP
+		cuff_active = !cuff_active
+		hand = "right"
+
+	else
+		to_chat(user, "<span class='notice'>[src] isn't in your hand!</span>")
+		return
+
+	if(cuff_active)
+		to_chat(user, "<span class='notice'>You attach [src] to your [hand] wrist using its [I.name]</span>")
+	else
+		to_chat(user, "<span class='notice'>You unclip [src]'s shackle from your [hand] wrist.</span>")

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -14,8 +14,6 @@
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	burn_state = FLAMMABLE
 	burntime = 20
-	var/cuff
-	var/cuff_active = FALSE
 
 /obj/item/weapon/storage/briefcase/New()
 	..()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -31,6 +31,9 @@
 	if(ishuman(usr)) //so monkeys can take off their backpacks -- Urist
 		var/mob/M = usr
 
+		if(checkCuffActive(M))
+			return
+
 		if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
 			return
 
@@ -103,6 +106,10 @@
 	return L
 
 /obj/item/weapon/storage/proc/show_to(mob/user as mob)
+
+	if(checkCuffActive(user))
+		return
+
 	if(user.s_active != src)
 		for(var/obj/item/I in src)
 			if(I.on_found(user))
@@ -130,6 +137,7 @@
 	return
 
 /obj/item/weapon/storage/proc/open(mob/user as mob)
+
 	if(src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 1, -5)
 
@@ -143,6 +151,12 @@
 	src.hide_from(user)
 	user.s_active = null
 	return
+
+/obj/item/weapon/storage/proc/checkCuffActive(mob/user)
+	if(cuff_active)
+		if(user)
+			to_chat(user, "<span class='notice'>The case is held closed by its cuff!</span>")
+		return TRUE
 
 //This proc draws out the inventory and places the items on it. tx and ty are the upper left tile and mx, my are the bottm right.
 //The numbers are calculated from the bottom-left The bottom-left slot being 1,1.
@@ -235,6 +249,9 @@
 //Set the stop_messages to stop it from printing messages
 /obj/item/weapon/storage/proc/can_be_inserted(obj/item/W as obj, stop_messages = 0)
 	if(!istype(W) || (W.flags & ABSTRACT)) return //Not an item
+
+	if(checkCuffActive())
+		return 0 //Case is handcuffed shut
 
 	if(src.loc == W)
 		return 0 //Means the item is already in the storage item


### PR DESCRIPTION
This PR adds the ability to cuff briefcases and secure briefcases to your own wrists.

To attach a handcuff to a briefcase drag a pair of handcuffs onto any briefcase or secure briefcase.
To lock the cuff around your wrist, hold the briefcase in your hand and drag it onto your sprite. The same to unlock it again.

This overwrites opening the briefcase with this method on briefcases which have cuffs attached. The briefcase can no longer be accessed while it is cuffed to you. Nor can items be deposited inside.

While cuffed to you the briefcase cannot be taken by anybody else short of amputation of the hand.

https://nanotrasen.se/forum/topic/12621-letting-us-cuff-briefcases-to-are-wrist/

🆑 Birdtalon
add: Briefcases can now be cuffed to your hand.
/🆑 