### PR TITLE
We don't need 5 separate variables to know which station we are on, take two

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -17,7 +17,7 @@ var/church_name = null
 
 var/command_name = null
 /proc/command_name()
-+	return using_map.dock_name
+	return using_map.dock_name
 
 var/religion_name = null
 /proc/religion_name()
@@ -32,7 +32,7 @@ var/religion_name = null
 	return capitalize(name)
 
 /proc/system_name()
-+	return using_map.starsys_name
+	return using_map.starsys_name
 
 /proc/station_name()
 	return using_map.station_name

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -17,19 +17,7 @@ var/church_name = null
 
 var/command_name = null
 /proc/command_name()
-	if(command_name)
-		return command_name
-
-	var/name = "Central Command"
-
-	command_name = name
-	return name
-
-/proc/change_command_name(var/name)
-
-	command_name = name
-
-	return name
++	return using_map.dock_name
 
 var/religion_name = null
 /proc/religion_name()
@@ -44,20 +32,10 @@ var/religion_name = null
 	return capitalize(name)
 
 /proc/system_name()
-	return "Nyx"
++	return using_map.starsys_name
 
 /proc/station_name()
-	if(station_name)
-		return station_name
-
-	var/name = ""
-
-	if(config && config.server_name)
-		world.name = "[config.server_name]: [name]"
-	else
-		world.name = station_name
-
-	return station_name
+	return using_map.station_name
 
 /proc/new_station_name()
 	var/random = rand(1,5)
@@ -101,18 +79,6 @@ var/religion_name = null
 		if(13)
 			new_station_name += pick("13","XIII","Thirteen")
 	return new_station_name
-
-
-/proc/world_name(var/name)
-
-	station_name = name
-
-	if(config && config.server_name)
-		world.name = "[config.server_name]: [name]"
-	else
-		world.name = name
-
-	return name
 
 var/syndicate_name = null
 /proc/syndicate_name()

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -2,7 +2,6 @@ var/datum/configuration/config = null
 
 var/host = null
 var/join_motd = null
-var/station_name = "NSS Cyberiad"
 var/game_version = "Custom ParaCode"
 var/changelog_hash = md5('html/changelog.html') //used to check if the CL changed
 var/game_year = (text2num(time2text(world.realtime, "YYYY")) + 544)

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -231,7 +231,7 @@ var/specops_shuttle_timeleft = 0
 
 	for(var/turf/T in get_area_turfs(end_location) )
 		var/mob/M = locate(/mob) in T
-		to_chat(M, "<span class='warning'>You have arrived to [station_name]. Commence operation!</span>")
+		to_chat(M, "<span class='warning'>You have arrived to [station_name()]. Commence operation!</span>")
 
 	for(var/obj/machinery/computer/specops_shuttle/S in world)
 		S.specops_shuttle_timereset = world.time + SPECOPS_RETURN_DELAY
@@ -275,8 +275,8 @@ var/specops_shuttle_timeleft = 0
 		dat = temp
 	else
 		dat += {"<BR><B>Special Operations Shuttle</B><HR>
-		\nLocation: [specops_shuttle_moving_to_station || specops_shuttle_moving_to_centcom ? "Departing for [station_name] in ([specops_shuttle_timeleft] seconds.)":specops_shuttle_at_station ? "Station":"Dock"]<BR>
-		[specops_shuttle_moving_to_station || specops_shuttle_moving_to_centcom ? "\n*The Special Ops. shuttle is already leaving.*<BR>\n<BR>":specops_shuttle_at_station ? "\n<A href='?src=[UID()];sendtodock=1'>Shuttle standing by...</A><BR>\n<BR>":"\n<A href='?src=[UID()];sendtostation=1'>Depart to [station_name]</A><BR>\n<BR>"]
+		\nLocation: [specops_shuttle_moving_to_station || specops_shuttle_moving_to_centcom ? "Departing for [station_name()] in ([specops_shuttle_timeleft] seconds.)":specops_shuttle_at_station ? "Station":"Dock"]<BR>
+		[specops_shuttle_moving_to_station || specops_shuttle_moving_to_centcom ? "\n*The Special Ops. shuttle is already leaving.*<BR>\n<BR>":specops_shuttle_at_station ? "\n<A href='?src=[UID()];sendtodock=1'>Shuttle standing by...</A><BR>\n<BR>":"\n<A href='?src=[UID()];sendtostation=1'>Depart to [station_name()]</A><BR>\n<BR>"]
 		\n<A href='?src=[user.UID()];mach_close=computer'>Close</A>"}
 
 	user << browse(dat, "window=computer;size=575x450")
@@ -318,7 +318,7 @@ var/specops_shuttle_timeleft = 0
 			to_chat(usr, "<span class='warning'>The Special Operations shuttle is unable to leave.</span>")
 			return
 
-		to_chat(usr, "<span class='notice'>The Special Operations shuttle will arrive on [station_name] in [(SPECOPS_MOVETIME/10)] seconds.</span>")
+		to_chat(usr, "<span class='notice'>The Special Operations shuttle will arrive on [station_name()] in [(SPECOPS_MOVETIME/10)] seconds.</span>")
 
 		temp += "Shuttle departing.<BR><BR><A href='?src=[UID()];mainmenu=1'>OK</A>"
 		updateUsrDialog()

--- a/code/game/machinery/computer/syndicate_specops_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_specops_shuttle.dm
@@ -172,7 +172,7 @@ var/syndicate_elite_shuttle_timeleft = 0
 
 	for(var/turf/T in get_area_turfs(end_location) )
 		var/mob/M = locate(/mob) in T
-		to_chat(M, "<span class='warning'>You have arrived to [station_name]. Commence operation!</span>")
+		to_chat(M, "<span class='warning'>You have arrived to [station_name()]. Commence operation!</span>")
 
 /proc/syndicate_elite_can_move()
 	if(syndicate_elite_shuttle_moving_to_station || syndicate_elite_shuttle_moving_to_mothership) return 0
@@ -209,8 +209,8 @@ var/syndicate_elite_shuttle_timeleft = 0
 		dat = temp
 	else
 		dat  = {"<BR><B>Special Operations Shuttle</B><HR>
-		\nLocation: [syndicate_elite_shuttle_moving_to_station || syndicate_elite_shuttle_moving_to_mothership ? "Departing for [station_name] in ([syndicate_elite_shuttle_timeleft] seconds.)":syndicate_elite_shuttle_at_station ? "Station":"Dock"]<BR>
-		[syndicate_elite_shuttle_moving_to_station || syndicate_elite_shuttle_moving_to_mothership ? "\n*The Syndicate Elite shuttle is already leaving.*<BR>\n<BR>":syndicate_elite_shuttle_at_station ? "\n<A href='?src=[UID()];sendtodock=1'>Shuttle Offline</A><BR>\n<BR>":"\n<A href='?src=[UID()];sendtostation=1'>Depart to [station_name]</A><BR>\n<BR>"]
+		\nLocation: [syndicate_elite_shuttle_moving_to_station || syndicate_elite_shuttle_moving_to_mothership ? "Departing for [station_name()] in ([syndicate_elite_shuttle_timeleft] seconds.)":syndicate_elite_shuttle_at_station ? "Station":"Dock"]<BR>
+		[syndicate_elite_shuttle_moving_to_station || syndicate_elite_shuttle_moving_to_mothership ? "\n*The Syndicate Elite shuttle is already leaving.*<BR>\n<BR>":syndicate_elite_shuttle_at_station ? "\n<A href='?src=[UID()];sendtodock=1'>Shuttle Offline</A><BR>\n<BR>":"\n<A href='?src=[UID()];sendtostation=1'>Depart to [station_name()]</A><BR>\n<BR>"]
 		\n<A href='?src=[user.UID()];mach_close=computer'>Close</A>"}
 
 	user << browse(dat, "window=computer;size=575x450")
@@ -237,7 +237,7 @@ var/syndicate_elite_shuttle_timeleft = 0
 			to_chat(usr, "<span class='warning'>The Syndicate Elite shuttle is unable to leave.</span>")
 			return
 
-		to_chat(usr, "<span class='notice'>The Syndicate Elite shuttle will arrive on [station_name] in [(SYNDICATE_ELITE_MOVETIME/10)] seconds.</span>")
+		to_chat(usr, "<span class='notice'>The Syndicate Elite shuttle will arrive on [station_name()] in [(SYNDICATE_ELITE_MOVETIME/10)] seconds.</span>")
 
 		temp  = "Shuttle departing.<BR><BR><A href='?src=[UID()];mainmenu=1'>OK</A>"
 		updateUsrDialog()

--- a/code/modules/holiday/holiday.dm
+++ b/code/modules/holiday/holiday.dm
@@ -349,8 +349,6 @@
 		holiday_master.holidays = list()
 	holiday_master.holidays[H.name] = H
 
-	station_name = null
-	station_name()
 	//update our hub status
 	world.update_status()
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -297,7 +297,7 @@
 	var/obj/item/weapon/paper/reqform = new /obj/item/weapon/paper(_loc)
 	playsound(_loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 	reqform.name = "Requisition Form - [crates] '[object.name]' for [orderedby]"
-	reqform.info += "<h3>[station_name] Supply Requisition Form</h3><hr>"
+	reqform.info += "<h3>[station_name()] Supply Requisition Form</h3><hr>"
 	reqform.info += "INDEX: #[shuttle_master.ordernum]<br>"
 	reqform.info += "REQUESTED BY: [orderedby]<br>"
 	reqform.info += "RANK: [orderedbyRank]<br>"

--- a/code/world.dm
+++ b/code/world.dm
@@ -67,8 +67,12 @@ var/global/list/map_transition_config = MAP_TRANSITION_CONFIG
 		map_name = "[using_map.name]"
 	else
 		map_name = "Unknown"
-
-
+	
+	
+	if(config && config.server_name)
+		name = "[config.server_name]: [station_name()]"
+	else
+		name = station_name()
 
 
 #undef RECOMMENDED_VERSION


### PR DESCRIPTION
#8594

> Everything normally should use station_name() now to get the station's name. Everything I did not delete does not affect gamepley directly.
> 
> Bonus:
> Central Command Reports now respect CC's name. In the case of the Cyberiad we now get NAS Trurl Reports (actual announcements are unnaffected, printed papers however will now carry the name).

In this edition we have less stupidity, a lot less commits, and a lot less syntax errors.