### PR TITLE
Add clickbait

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -288,7 +288,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		return 1
 
 	if(href_list["set_channel_name"])
-		channel_name = trim(sanitizeSQL(strip_html_simple(input(usr, "Provide a Feed Channel Name", "Network Channel Handler", ""))))
+		channel_name = trim(sanitize(strip_html_simple(input(usr, "Provide a Feed Channel Name", "Network Channel Handler", ""))))
 
 	else if(href_list["set_channel_lock"])
 		c_locked = !c_locked

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -252,7 +252,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			var/list/messages = list()
 			data["messages"] = messages
 			for(var/datum/feed_message/M in viewing_channel.messages)
-				messages[++messages.len] = list("body" = M.body, "body_redacted" = (M.body == REDACTED ? 1 : 0) , "message_type" = M.message_type, "author" = M.author, "author_redacted" = (M.author == REDACTED ? 1 : 0), "ref" = "\ref[M]", "view_count" = M.view_count)
+				messages[++messages.len] = list("title" = M.title, "body" = M.body, "body_redacted" = (M.body == REDACTED ? 1 : 0) , "message_type" = M.message_type, "author" = M.author, "author_redacted" = (M.author == REDACTED ? 1 : 0), "ref" = "\ref[M]", "view_count" = M.view_count)
 		if(10)
 			var/wanted_already = 0
 			var/end_param = 1

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -4,6 +4,7 @@
 
 /datum/feed_message
 	var/author = ""
+	var/title = ""
 	var/body = ""
 	var/message_type = "Story"
 	var/backup_body = ""
@@ -42,8 +43,10 @@
 	is_admin_channel = 0
 	total_view_count = 0
 
-/datum/feed_channel/proc/announce_news()
-	return "Breaking news from [channel_name]!"
+/datum/feed_channel/proc/announce_news(title="")
+	if(title)
+		return "Breaking news from [channel_name]: [title]"
+	return "Breaking news from [channel_name]"
 
 /datum/feed_channel/station/announce_news()
 	return "New Station Announcement Available"
@@ -87,6 +90,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		// 1 = there has
 	var/scanned_user = "Unknown" //Will contain the name of the person who currently uses the newscaster
 	var/msg = "" //Feed message
+	var/msg_title = "" // Feed message title
 	var/obj/item/weapon/photo/photo = null
 	var/channel_name = "" //the feed channel which will be receiving the feed, or being created
 	var/c_locked = 0 //Will our new channel be locked to public submissions?
@@ -213,6 +217,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		if(3)
 			data["scanned_user"] = scanned_user
 			data["channel_name"] = channel_name
+			data["title"] = msg_title
 			data["msg"] = msg
 			data["photo"] = photo ? 1 : 0
 		if(4)
@@ -236,7 +241,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			var/list/messages = list()
 			data["messages"] = messages
 			for(var/datum/feed_message/M in viewing_channel.messages)
-				messages[++messages.len] = list("body" = M.body, "img" = M.img ? icon2base64(M.img) : null, "message_type" = M.message_type, "author" = M.author, "view_count" = M.view_count)
+				messages[++messages.len] = list("title" = M.title, "body" = M.body, "img" = M.img ? icon2base64(M.img) : null, "message_type" = M.message_type, "author" = M.author, "view_count" = M.view_count)
 		if(8, 9)
 			data["channel_name"] = viewing_channel.channel_name
 			data["ref"] = "\ref[viewing_channel]"
@@ -283,9 +288,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		return 1
 
 	if(href_list["set_channel_name"])
-		channel_name = sanitizeSQL(strip_html_simple(input(usr, "Provide a Feed Channel Name", "Network Channel Handler", "")))
-		while(findtext(channel_name," ") == 1)
-			channel_name = copytext(channel_name, 2, lentext(channel_name) + 1)
+		channel_name = trim(sanitizeSQL(strip_html_simple(input(usr, "Provide a Feed Channel Name", "Network Channel Handler", ""))))
 
 	else if(href_list["set_channel_lock"])
 		c_locked = !c_locked
@@ -333,10 +336,12 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				available_channels += F.channel_name
 		channel_name = strip_html_simple(input(usr, "Choose receiving Feed Channel", "Network Channel Handler") in available_channels)
 
+	else if(href_list["set_message_title"])
+		msg_title = trim(strip_html(input(usr, "Write a title for your feed story", "Network Channel Handler", "")))
+		msg_title = dd_limittext(msg_title, 256)
+
 	else if(href_list["set_new_message"])
-		msg = strip_html(input(usr, "Write your feed story", "Network Channel Handler", ""))
-		while(findtext(msg, " ") == 1)
-			msg = copytext(msg, 2, lentext(msg) + 1)
+		msg = trim(strip_html(input(usr, "Write your feed story", "Network Channel Handler", "")))
 
 	else if(href_list["set_attachment"])
 		AttachPhoto(usr)
@@ -355,6 +360,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		else
 			var/datum/feed_message/newMsg = new /datum/feed_message
 			newMsg.author = scanned_user
+			newMsg.title = msg_title
 			newMsg.body = msg
 			if(photo)
 				newMsg.img = photo.img
@@ -363,7 +369,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			for(var/datum/feed_channel/FC in news_network.network_channels)
 				if(FC.channel_name == channel_name)
 					FC.messages += newMsg                  //Adding message to the network's appropriate feed_channel
-					announcement = FC.announce_news()
+					announcement = FC.announce_news(msg_title)
 					break
 			temp = "<span class='good'>Feed story successfully submitted to [channel_name].</span>"
 			temp_back_screen = NEWSCASTER_MAIN
@@ -408,14 +414,10 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		screen = NEWSCASTER_W_ISSUE_H
 
 	else if(href_list["set_wanted_name"])
-		channel_name = strip_html(input(usr, "Provide the name of the wanted person", "Network Security Handler", ""))
-		while(findtext(channel_name, " ") == 1)
-			channel_name = copytext(channel_name, 2, lentext(channel_name) + 1)
+		channel_name = trim(strip_html(input(usr, "Provide the name of the wanted person", "Network Security Handler", "")))
 
 	else if(href_list["set_wanted_desc"])
-		msg = strip_html(input(usr, "Provide the a description of the wanted person and any other details you deem important", "Network Security Handler", ""))
-		while(findtext(msg, " ") == 1)
-			msg = copytext(msg, 2, lentext(msg) + 1)
+		msg = trim(strip_html(input(usr, "Provide the a description of the wanted person and any other details you deem important", "Network Security Handler", "")))
 
 	else if(href_list["submit_wanted"])
 		var/input_param = text2num(href_list["submit_wanted"])
@@ -534,6 +536,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		if(screen == NEWSCASTER_MAIN)
 			scanned_user = "Unknown"
 			msg = ""
+			msg_title = ""
 			c_locked = 0
 			channel_name = ""
 			viewing_channel = null
@@ -687,7 +690,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 						var/i = 0
 						for(var/datum/feed_message/MESSAGE in C.messages)
 							i++
-							dat+="-[MESSAGE.body] <BR>"
+							dat+="<b>[MESSAGE.title]</b> <br>"
+							dat+="[MESSAGE.body] <BR>"
 							if(MESSAGE.img)
 								user << browse_rsc(MESSAGE.img, "tmp_photo[i].png")
 								dat+="<img src='tmp_photo[i].png' width = '180'><BR>"

--- a/nano/templates/newscaster.tmpl
+++ b/nano/templates/newscaster.tmpl
@@ -226,7 +226,7 @@ Property of Nanotrasen</font><br>
 		</div>
 	{{else data.screen == 9}} <!-- NEWSCASTER_D_NOTICE_FC -->
 		<b>{{:data.channel_name}}</b> <i><font size=1>[created by: <span class='good'>{{:data.author}}</span>]</font></i><br>
-		<i>Channel messages listed below. If you deem them dangerous to the station, you can <div style='clear: both;'>{{:helper.link('Bestow a D-Notice upon the channel', null, {'toggle_d_notice' : data.ref})}}</div></i><br><hr>
+		<i>Channel messages listed below. If you deem them dangerous to the station, you can <div style='clear: both;'>{{:helper.link(data.censored ? 'Remove the D-Notice on the channel' : 'Bestow a D-Notice upon the channel', null, {'toggle_d_notice' : data.ref})}}</div></i><br><hr>
 		{{if data.censored}}
 			<div class='statusDisplay'>
 				<b class='bad'>ATTENTION: </b>This channel has been deemed as threatening to the welfare of the station, and marked with a Nanotrasen D-Notice. 

--- a/nano/templates/newscaster.tmpl
+++ b/nano/templates/newscaster.tmpl
@@ -206,7 +206,8 @@ Property of Nanotrasen</font><br>
 		<i>{{:helper.link(data.author_redacted ? 'Undo author censorship' : 'Censor channel author', null, {'censor_channel_author' : data.ref})}}</i><br><hr>
 		{{for data.messages}}
 			<div class='statusDisplay'>
-				- {{:value.body}}<br>
+				<b>{{:value.title}}</b><br>
+				{{:value.body}}<br>
 				{{if value.img}}
 					<img src='{{:value.img}}' width=180><br>
 				{{/if}}
@@ -234,7 +235,8 @@ Property of Nanotrasen</font><br>
 		{{else}}
 			{{for data.messages}}
 				<div class='statusDisplay'>
-					- {{:value.body}}<br>
+					<b>{{:value.title}}</b><br>
+					{{:value.body}}<br>
 					{{if value.img}}
 						<img src='{{:value.img}}' width=180><br>
 					{{/if}}

--- a/nano/templates/newscaster.tmpl
+++ b/nano/templates/newscaster.tmpl
@@ -97,6 +97,13 @@ Property of Nanotrasen</font><br>
 			</div>
 		</div>
 		<div class='item'>
+			<div class='itemLabel'>Title:</div>
+			<div class='itemContent'>
+				<a style='float: left; padding-right: 6px;'>{{:data.title}}</a>
+				{{:helper.link('Edit', 'pencil', {'set_message_title' : 1})}}
+			</div>
+		</div>
+		<div class='item'>
 			<div class='itemLabel'>Message body:</div>
 			<div class='itemContent'>
 				<a style='float: left; padding-right: 6px;'>{{:data.msg}}</a>
@@ -132,7 +139,8 @@ Property of Nanotrasen</font><br>
 		{{else}}
 			{{for data.messages}}
 				<div class='statusDisplay'>
-					- {{:value.body}}<br>
+					<b>{{:value.title}}</b><br>
+					{{:value.body}}<br>
 					{{if value.img}}
 						<img src='data:image/png;base64,{{:value.img}}' width=180><br>
 					{{/if}}


### PR DESCRIPTION
:cl: Tayyyyyyy, bryanayalalugo
add: News reporters can now add titles to their stories!
/:cl:

Now that I've baited you into clicking on this PR...

This PR implements [this forum idea](https://nanotrasen.se/forum/topic/12193-news-header/).

You can add a title to your story:
![newscaster1](https://user-images.githubusercontent.com/26497062/36020492-8aefc51c-0d48-11e8-9b57-8b8a1ed09c2e.png)

The alert will display the title:
![newscaster2](https://user-images.githubusercontent.com/26497062/36020498-93a24e5a-0d48-11e8-99ad-4246fa7c0bce.png)

When viewed, it looks like this:
![newscaster4](https://user-images.githubusercontent.com/26497062/36020640-02d4ee0e-0d49-11e8-9522-b065a982f7a8.png)

And it'll show up in the newspaper too:
![newscaster3](https://user-images.githubusercontent.com/26497062/36044646-f509afee-0d98-11e8-81ed-b8a712605057.png)

I've also refactored a tiny bit and replaced trimming code with calls to `trim`.