### PR TITLE
Fixes bluespace bread (and other slice foods as well)

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -132,8 +132,8 @@
 			istype(W, /obj/item/weapon/hatchet) \
 		)
 		inaccurate = 1
-	if(total_w_class > MAX_WEIGHT_CLASS && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
-		if(contents.len)
+	else if(W.w_class <= WEIGHT_CLASS_SMALL && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
+		if(total_w_class > MAX_WEIGHT_CLASS)
 			// Nope, no bluespace slice food
 			to_chat(user, "<span class='warning'>Something is already in [src]!</span>")
 			return 1

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -132,7 +132,7 @@
 			istype(W, /obj/item/weapon/hatchet) \
 		)
 		inaccurate = 1
-	if(total_w_class > MAX_WEIGHT_CLASS)
+	if(total_w_class > MAX_WEIGHT_CLASS && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
 		if(contents.len)
 			// Nope, no bluespace slice food
 			to_chat(user, "<span class='warning'>Something is already in [src]!</span>")

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -1,3 +1,4 @@
+#define MAX_WEIGHT_CLASS WEIGHT_CLASS_SMALL * 2
 //Food items that are eaten normally and don't leave anything behind.
 /obj/item/weapon/reagent_containers/food/snacks
 	name = "snack"
@@ -14,6 +15,7 @@
 	var/dry = 0
 	var/cooktype[0]
 	var/cooked_type = null  //for microwave cooking. path of the resulting item after microwaving
+	var/total_w_class = 0 //for the total weight an item of food can carry
 
 
 	//Placeholder for effect that trigger on eating that aren't tied to reagents.
@@ -130,10 +132,10 @@
 			istype(W, /obj/item/weapon/hatchet) \
 		)
 		inaccurate = 1
-	else if(W.w_class <= WEIGHT_CLASS_SMALL && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
+	if(total_w_class > MAX_WEIGHT_CLASS)
 		if(contents.len)
 			// Nope, no bluespace slice food
-			to_chat(user, "<span class='warning'>Something is already in the [src]!</span>")
+			to_chat(user, "<span class='warning'>Something is already in [src]!</span>")
 			return 1
 		if(!iscarbon(user))
 			return 1
@@ -142,6 +144,7 @@
 		if((user.client && user.s_active != src))
 			user.client.screen -= W
 		W.dropped(user)
+		total_w_class += W.w_class
 		add_fingerprint(user)
 		contents += W
 		return
@@ -2526,3 +2529,4 @@
 	list_reagents = list("nutriment" = 3)
 	filling_color = "#C0C9A0"
 	gender = PLURAL
+#undef MAX_WEIGHT_CLASS

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -131,6 +131,10 @@
 		)
 		inaccurate = 1
 	else if(W.w_class <= WEIGHT_CLASS_SMALL && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
+		if(contents.len)
+			// Nope, no bluespace slice food
+			to_chat(user, "<span class='warning'>Something is already in the [src]!</span>")
+			return 1
 		if(!iscarbon(user))
 			return 1
 		to_chat(user, "<span class='warning'>You slip [W] inside [src].</span>")


### PR DESCRIPTION
From: #4330
As it says in the title, a quick little fix for slice foods, infinite storage inside of a loaf of bread should no longer be possible, things such as this below.

![thebread1](https://user-images.githubusercontent.com/9261635/36152343-97be1326-112f-11e8-89b0-a4a7813442ce.png)
![thebread2](https://user-images.githubusercontent.com/9261635/36152348-9d29d00c-112f-11e8-8cf4-8cb0bc99ef16.png)

🆑 DarkPyrolord
fix: Sliceable food items are no longer hammerspace capable 
/🆑