### PR TITLE
Let paint buckets be used on sec spess pods

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -254,6 +254,7 @@
 	pda = /obj/item/device/pda/security
 	backpack_contents = list(
 		/obj/item/weapon/restraints/handcuffs = 1
+		/obj/item/weapon/pod_paint_bucket = 1
 	)
 	implants = list(/obj/item/weapon/implant/mindshield)
 	backpack = /obj/item/weapon/storage/backpack/security

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -253,7 +253,7 @@
 	suit_store = /obj/item/weapon/gun/energy/gun/advtaser
 	pda = /obj/item/device/pda/security
 	backpack_contents = list(
-		/obj/item/weapon/restraints/handcuffs = 1
+		/obj/item/weapon/restraints/handcuffs = 1,
 		/obj/item/weapon/pod_paint_bucket = 1
 	)
 	implants = list(/obj/item/weapon/implant/mindshield)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -253,8 +253,7 @@
 	suit_store = /obj/item/weapon/gun/energy/gun/advtaser
 	pda = /obj/item/device/pda/security
 	backpack_contents = list(
-		/obj/item/weapon/restraints/handcuffs = 1,
-		/obj/item/weapon/pod_paint_bucket = 1
+		/obj/item/weapon/restraints/handcuffs = 1
 	)
 	implants = list(/obj/item/weapon/implant/mindshield)
 	backpack = /obj/item/weapon/storage/backpack/security

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -7,7 +7,7 @@
 
 /obj/item/weapon/pod_paint_bucket
 	name = "space pod paintkit"
-	desc = "Pimp your ride"
+	desc = "Pimp your ride.It is highly recommended the user does not drink his paint and the paint is only used for painting."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "paint_red"
 

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -480,6 +480,9 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 			return
 		if("Lock System")
 			remove_equipment(user, equipment_system.lock_system, "lock_system")
+	if(istype(W, /obj/item/weapon/pod_paint_bucket))
+		apply_paint(user)
+		return
 
 /obj/spacepod/proc/remove_equipment(mob/user, var/obj/item/device/spacepod_equipment/SPE, var/slot)
 
@@ -533,12 +536,6 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 /obj/spacepod/civilian
 	icon_state = "pod_civ"
 	desc = "A sleek civilian space pod."
-
-/obj/spacepod/civilian/attackby(obj/item/W as obj, mob/user as mob, params)
-	..()
-	if(istype(W, /obj/item/weapon/pod_paint_bucket))
-		apply_paint(user)
-		return
 
 /obj/spacepod/random
 	icon_state = "pod_civ"

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -394,6 +394,9 @@
 
 		if(cargo_hold.storage_slots > 0 && !hatch_open && unlocked) // must be the last option as all items not listed prior will be stored
 			cargo_hold.attackby(W, user, params)
+		if(istype(W, /obj/item/weapon/pod_paint_bucket))
+			apply_paint(user)
+		return
 
 obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment/SPE, var/slot)
 	if(equipment_system.vars[slot])
@@ -480,9 +483,6 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/device/spacepod_equipment
 			return
 		if("Lock System")
 			remove_equipment(user, equipment_system.lock_system, "lock_system")
-	if(istype(W, /obj/item/weapon/pod_paint_bucket))
-		apply_paint(user)
-		return
 
 /obj/spacepod/proc/remove_equipment(mob/user, var/obj/item/device/spacepod_equipment/SPE, var/slot)
 


### PR DESCRIPTION
Allows sec spess pod to be painted using a pod paint bucket by moving the check from /obj/spacepod/civilian/attackby() to /obj/spacepod/attackby()

~~Also gives the pod pilot a paint bucket to go with this~~

Attackby() is a mess but i dont want to touch that.

🆑 alexkar598
tweak: You can now paint sec space pods as well as civilian space pod.
/🆑