### PR TITLE
fixes #8680

### DIFF
--- a/code/modules/spacepods/construction.dm
+++ b/code/modules/spacepods/construction.dm
@@ -140,7 +140,7 @@
 					state_next = list(
 						"key"      = /obj/item/stack/sheet/metal,
 						"amount"   = 5,
-						"vis_msg"  = "{USER} frabricates a pressure bulkhead for the {HOLDER}.",
+						"vis_msg"  = "{USER} fabricates a pressure bulkhead for the {HOLDER}.",
 						"self_msg" = "You frabricate a pressure bulkhead for the {HOLDER}."
 					)
 				),


### PR DESCRIPTION
fixes #8680 

fixed simple typo: "Frabricated" to fabricated.