### PR TITLE
Remove genetics from medbay

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -171,40 +171,6 @@
 	satchel = /obj/item/weapon/storage/backpack/satchel_chem
 	dufflebag = /obj/item/weapon/storage/backpack/duffel/chemistry
 
-/datum/job/geneticist
-	title = "Geneticist"
-	flag = GENETICIST
-	department_flag = MEDSCI
-	total_positions = 2
-	spawn_positions = 2
-	is_medical = 1
-	supervisors = "the chief medical officer and the research director"
-	department_head = list("Chief Medical Officer", "Research Director")
-	selection_color = "#ffeef0"
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research, access_mineral_storeroom)
-	minimal_access = list(access_medical, access_morgue, access_genetics, access_research, access_maint_tunnels)
-	minimal_player_age = 3
-	exp_requirements = 180
-	exp_type = EXP_TYPE_CREW
-	outfit = /datum/outfit/job/geneticist
-
-/datum/outfit/job/geneticist
-	name = "Geneticist"
-	jobtype = /datum/job/geneticist
-
-	uniform = /obj/item/clothing/under/rank/geneticist
-	suit = /obj/item/clothing/suit/storage/labcoat/genetics
-	shoes = /obj/item/clothing/shoes/white
-	l_ear = /obj/item/device/radio/headset/headset_medsci
-	id = /obj/item/weapon/card/id/medical
-	suit_store = /obj/item/device/flashlight/pen
-	pda = /obj/item/device/pda/geneticist
-
-	backpack = /obj/item/weapon/storage/backpack/genetics
-	satchel = /obj/item/weapon/storage/backpack/satchel_gen
-	dufflebag = /obj/item/weapon/storage/backpack/duffel/genetics
-
-
 /datum/job/virologist
 	title = "Virologist"
 	flag = VIROLOGIST

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -9,9 +9,9 @@
 	department_head = list("Captain")
 	selection_color = "#ffddf0"
 	req_admin_notify = 1
-	access = list(access_medical, access_morgue, access_genetics, access_heads,
+	access = list(access_medical, access_morgue, access_genetics access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_sec_doors, access_psychiatrist, access_paramedic, access_mineral_storeroom)
+			access_keycard_auth, access_sec_doors, access_psychiatrist, access_mineral_storeroom)
 	minimal_access = list(access_eva, access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_maint_tunnels, access_paramedic, access_mineral_storeroom)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_mineral_storeroom)
-	minimal_access = list(access_eva, access_medical, access_morgue, access_genetics, access_heads,
+	minimal_access = list(access_eva, access_medical, access_morgue, access_paramedic, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_maint_tunnels, access_paramedic, access_mineral_storeroom)
 	minimal_player_age = 21

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -9,7 +9,7 @@
 	department_head = list("Captain")
 	selection_color = "#ffddf0"
 	req_admin_notify = 1
-	access = list(access_medical, access_morgue, access_genetics access_heads,
+	access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_mineral_storeroom)
 	minimal_access = list(access_eva, access_medical, access_morgue, access_genetics, access_heads,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -132,8 +132,8 @@
 	supervisors = "the research director"
 	department_head = list("Research Director")
 	selection_color = "#ffeef0"
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research, access_mineral_storeroom)
-	minimal_access = list(access_medical, access_morgue, access_genetics, access_research, access_maint_tunnels)
+	access = list(access_genetics, access_research, access_mineral_storeroom)
+	minimal_access = list(access_genetics, access_research, access_maint_tunnels)
 	minimal_player_age = 3
 	exp_requirements = 180
 	exp_type = EXP_TYPE_CREW

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -121,3 +121,36 @@
 	l_ear = /obj/item/device/radio/headset/headset_sci
 	id = /obj/item/weapon/card/id/research
 	pda = /obj/item/device/pda/roboticist
+
+/datum/job/geneticist
+	title = "Geneticist"
+	flag = GENETICIST
+	department_flag = MEDSCI
+	total_positions = 2
+	spawn_positions = 2
+	is_medical = 1
+	supervisors = "the research director"
+	department_head = list("Research Director")
+	selection_color = "#ffeef0"
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_research, access_mineral_storeroom)
+	minimal_access = list(access_medical, access_morgue, access_genetics, access_research, access_maint_tunnels)
+	minimal_player_age = 3
+	exp_requirements = 180
+	exp_type = EXP_TYPE_CREW
+	outfit = /datum/outfit/job/geneticist
+
+/datum/outfit/job/geneticist
+	name = "Geneticist"
+	jobtype = /datum/job/geneticist
+
+	uniform = /obj/item/clothing/under/rank/geneticist
+	suit = /obj/item/clothing/suit/storage/labcoat/genetics
+	shoes = /obj/item/clothing/shoes/white
+	l_ear = /obj/item/device/radio/headset/headset_medsci
+	id = /obj/item/weapon/card/id/medical
+	suit_store = /obj/item/device/flashlight/pen
+	pda = /obj/item/device/pda/geneticist
+
+	backpack = /obj/item/weapon/storage/backpack/genetics
+	satchel = /obj/item/weapon/storage/backpack/satchel_gen
+	dufflebag = /obj/item/weapon/storage/backpack/duffel/genetics

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -82,7 +82,6 @@ var/list/engineering_positions = list(
 var/list/medical_positions = list(
 	"Chief Medical Officer",
 	"Medical Doctor",
-	"Geneticist",
 	"Psychiatrist",
 	"Chemist",
 	"Virologist",


### PR DESCRIPTION
After some disscussion with a few people on discord, we have concluded that genetics is useless to medbay therefore I would like to remove genetics from medbay. The three things that genetics provide for medbay are, to clone, monkey cubes, and cure genetic defects. Genetic defects can be cured via mutadone and monkey cubes can be obtained via virology. And what about cloning? Cloning is neglected by the geneticists and is often taked up by the coroner. A map change walling off the genetic research lab and cloning should be made. SOP should also be edited to make cloning an official duty of the coroner and cut ties with medbay.