### PR TITLE
Re balances ether into a better anaesthetic

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -853,16 +853,17 @@
 	description = "A strong anesthetic and sedative."
 	reagent_state = LIQUID
 	color = "#96DEDE"
+	metabolization_rate = 0.1
 
 /datum/reagent/medicine/ether/on_mob_life(mob/living/M)
 	M.AdjustJitter(-25)
 	switch(current_cycle)
-		if(1 to 15)
+		if(1 to 30)
 			if(prob(7))
 				M.emote("yawn")
-		if(16 to 35)
+		if(31 to 40)
 			M.Drowsy(20)
-		if(36 to INFINITY)
+		if(41 to INFINITY)
 			M.Paralyse(15)
 			M.Drowsy(20)
 	..()


### PR DESCRIPTION
The aim of this PR is to make Ether more reliable as a general anaesthetic chem for use on species without the option gas anaesthetics.

- Metabolism rate has been significantly reduced. Ether will stay in your system for 4x longer.
- The "yawn" messages will play for twice as long before any effects begin.
- The time taken for paralysis and therefore unconsciousness to set in has been increased.

The idea here is to give surgeons a longer window of time to operate on species who require ether as an anaesthetic without having to give them 30+ units. Therefore less chance for the surgery to fail due to the patient waking up early because the surgeon wasn't fast enough. However the time before unconsciousness begins has been increased to ensure that this chem cannot easily be used offensively except in very extended combat. (Who uses ether in combat anyway)

🆑 Birdtalon
tweak: Ether re-balanced into a more effective anaesthetic for surgery.
/🆑 