### PR TITLE
Removes printing photos from security consoles

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -369,15 +369,6 @@
 				P.name = "paper - 'Security Record'"
 				printing = 0
 
-		else if(href_list["print_p"])
-			if(!printing)
-				printing = 1
-				playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
-				sleep(50)
-				if(istype(active1, /datum/data/record) && data_core.general.Find(active1))
-					create_record_photo(active1)
-				printing = 0
-
 		else if(href_list["printlogs"])
 			if(cell_logs.len && !printing)
 				var/obj/item/weapon/paper/P = input(usr, "Select log to print", "Available Cell Logs") as null|anything in cell_logs

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -369,6 +369,17 @@
 				P.name = "paper - 'Security Record'"
 				printing = 0
 
+/* Removed due to BYOND issue
+		else if(href_list["print_p"])
+			if(!printing)
+				printing = 1
+				playsound(loc, "sound/goonstation/machines/printer_dotmatrix.ogg", 50, 1)
+				sleep(50)
+				if(istype(active1, /datum/data/record) && data_core.general.Find(active1))
+					create_record_photo(active1)
+				printing = 0
+*/
+
 		else if(href_list["printlogs"])
 			if(cell_logs.len && !printing)
 				var/obj/item/weapon/paper/P = input(usr, "Select log to print", "Available Cell Logs") as null|anything in cell_logs
@@ -501,6 +512,8 @@
 /obj/machinery/computer/secure_data/proc/setTemp(text, list/buttons = list())
 	temp = list("text" = text, "buttons" = buttons, "has_buttons" = buttons.len > 0)
 
+/* Proc disabled due to BYOND Issue
+
 /obj/machinery/computer/secure_data/proc/create_record_photo(datum/data/record/R)
 	// basically copy-pasted from the camera code but different enough that it has to be redone
 	var/icon/photoimage = get_record_photo(R)
@@ -526,6 +539,8 @@
 
 	var/obj/item/weapon/photo/PH = new/obj/item/weapon/photo(loc)
 	PH.construct(P)
+
+*/
 
 /obj/machinery/computer/secure_data/proc/get_record_photo(datum/data/record/R)
 	// similar to the code to make a photo, but of course the actual rendering is completely different

--- a/nano/templates/secure_data.tmpl
+++ b/nano/templates/secure_data.tmpl
@@ -143,9 +143,6 @@ Used In File(s): \code\game\machinery\computer\security.dm
 					</td>
 					<td valign='middle' align='center' style='width: 300px;'>
 						{{if data.general.has_photos}}
-							<div style="text-align: center;">
-								<div style="display: inline-block;">{{:helper.link('Print photo', 'camera', {'print_p' : 1})}}</div>
-							</div>
 							{{for data.general.photos}}
 								{{if value.photo}}
 									<img src={{:value.photo}} height=96 width=96 border=5>

--- a/nano/templates/secure_data.tmpl
+++ b/nano/templates/secure_data.tmpl
@@ -29,24 +29,24 @@ Used In File(s): \code\game\machinery\computer\security.dm
 				hidden.parent("td").parent("tr").hide()
 			}
 		}
-		
+
 		function selectTextField(){
 			var filter_text = document.getElementById('filter');
 			filter_text.focus();
 			filter_text.select();
 		}
-		
+
 		$(window).load(function() {
 			selectTextField();
 			updateSearch();
 		});
-		
+
 		$("#filter").keyup(function() {
 			updateSearch();
 		});
 	</script>
 {{/if}}
-<style type="text/css">			
+<style type="text/css">
 	.infoButton {
 		background: none;
 		border: none;
@@ -143,6 +143,11 @@ Used In File(s): \code\game\machinery\computer\security.dm
 					</td>
 					<td valign='middle' align='center' style='width: 300px;'>
 						{{if data.general.has_photos}}
+<!--	Removed due to BYOND issue.
+						<div style="text-align: center;">
+								<div style="display: inline-block;">{{:helper.link('Print photo', 'camera', {'print_p' : 1})}}</div>
+							</div>
+						-->
 							{{for data.general.photos}}
 								{{if value.photo}}
 									<img src={{:value.photo}} height=96 width=96 border=5>
@@ -153,7 +158,7 @@ Used In File(s): \code\game\machinery\computer\security.dm
 				</tr></table>
 			</div>
 		{{/if}}
-		
+
 		<h4><center>Security Data</center></h4>
 		{{if data.security.empty}}
 			<span class="bad"><center>Security Record Lost!</center></span>
@@ -175,22 +180,22 @@ Used In File(s): \code\game\machinery\computer\security.dm
 					<br>
 				{{/if}}
 			{{/for}}
-			
+
 			<h4><center>Comments/Log</center></h4>
 			{{for data.security.comments}}
 				<div class="line">{{:value}}</div>
 				<div class="line">{{:helper.link('Remove entry', 'trash', {'del_c' : index})}}</div>
 				<br><hr>
 			{{/for}}
-			
+
 			<div style="text-align: center;">
 				<div style="display: inline-block; height: 100%; vertical-align: middle;">{{:helper.link('Add Entry', 'plus', {'add_c' : 1})}}</div>
 			</div>
-			
+
 			<h3><center>Menu</center></h3>
 			<div class="line">{{:helper.link('Delete Record (Security Only)', 'trash', {'del_r' : 1})}}</div>
 		{{/if}}
-		
+
 		<div class="line">{{:helper.link('Delete Record (All)', 'trash', {'del_rg' : 1})}}</div>
 		<div class="line">{{:helper.link('Print Record', 'print', {'print_r' : 1})}}</div>
 		<div class="line">{{:helper.link('Back', 'arrow-left', {'screen' : 1})}}</div>
@@ -208,7 +213,7 @@ Used In File(s): \code\game\machinery\computer\security.dm
 			{{else}}
 				<center>{{:data.temp.text}}</center>
 			{{/if}}
-			
+
 			{{if data.temp.has_buttons}}
 				<div class="line">
 					<div style="display: inline-block;">
@@ -220,7 +225,7 @@ Used In File(s): \code\game\machinery\computer\security.dm
 					</div>
 				</div>
 			{{/if}}
-			
+
 			<div style="display: inline-block;">
 				<div class="item">{{:helper.link('Clear screen', 'home', {'temp' : 1})}}</div>
 			</div>


### PR DESCRIPTION
I was asked to remove this by @Spartan6 apparently it causes people to crash en-masse when used.

🆑 
rscdel: Removes printing photos on security consoles.
/🆑 