### PR TITLE
IPCs no longer super-lose russian roulette

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -947,6 +947,8 @@
 
 /datum/species/machine/handle_death(var/mob/living/carbon/human/H)
 	var/obj/item/organ/external/head/head_organ = H.get_organ("head")
+	if(!head_organ)
+		return
 	head_organ.h_style = "Bald"
 	head_organ.f_style = "Shaved"
 	spawn(100)

--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -164,7 +164,7 @@
 			. = stored_mmi
 			if(owner.mind)
 				owner.mind.transfer_to(stored_mmi.brainmob)
-			stored_mmi.forceMove(get_turf(src))
+			stored_mmi.forceMove(get_turf(owner))
 			stored_mmi = null
 	..()
 	qdel(src)


### PR DESCRIPTION
This took way too long. Fixes #8699, and also fixes an issue where a headless IPC causes runtimes upon death.

🆑 
fix: IPCs can now lose russian roulette without going to nullspace
/🆑 