### PR TITLE
APC Interface Lock works for Silicons again

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -769,6 +769,7 @@
 	data["totalLoad"] = round(lastused_equip + lastused_light + lastused_environ)
 	data["coverLocked"] = coverlocked
 	data["siliconUser"] = istype(user, /mob/living/silicon)
+	data["siliconLock"] = locked
 	data["malfStatus"] = get_malf_status(user)
 
 	var/powerChannels[0]

--- a/nano/templates/apc.tmpl
+++ b/nano/templates/apc.tmpl
@@ -4,7 +4,7 @@
 			Interface Lock:
 		</div>
 		<div class="itemContentFull">
-			{{:helper.link('Engaged', 'lock', {'toggleaccess' : 1}, data.locked ? 'selected' : null)}}{{:helper.link('Disengaged', 'unlock', {'toggleaccess' : 1}, data.malfStatus >= 2 ? 'linkOff' : (data.locked ? null : 'selected'))}}
+			{{:helper.link('Engaged', 'lock', {'toggleaccess' : 1}, data.siliconLock ? 'selected' : null)}}{{:helper.link('Disengaged', 'unlock', {'toggleaccess' : 1}, data.malfStatus >= 2 ? 'linkOff' : (data.siliconLock ? null : 'selected'))}}
 		</div>
 		<div class="clearBoth"></div>
 	{{else}}


### PR DESCRIPTION
Just a small bug I found.

fixes #3000

:cl: Funce
fix: APC Interface lock UI works for silicons.
/:cl: