### PR TITLE
Updates an example config comment

### DIFF
--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -95,7 +95,7 @@ PROBABILITY EXTENDED 2
 PROBABILITY NUCLEAR 3
 PROBABILITY ABDUCTION 0
 
-# MAXIMUM SECONDS SHADOWLINGS CAN REMAIN UNHATCHED BEFORE THEY TAKE DAMAGE
+## Maximum cycles shadowlings can remain unhatched before they take damage. 1800 = 60 minutes, 900 = 30 minutes, 0 = feature disabled.
 SHADOWLING_MAX_AGE 0
 
 ## Hash out to disable random events during the round.


### PR DESCRIPTION
Previously, the example config for the shadowling timer feature implied that the # in the config meant seconds.

Now, it correctly states that it means cycles, where each cycle is two seconds.

