### PR TITLE
Restricts RPD use to certain turf types

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -66,6 +66,7 @@
 
 //turf-only flags
 #define NOJAUNT		1
+#define RPD_ALLOWED_HERE 2//By default, RPD is disabled on turfs.
 
 //ITEM INVENTORY SLOT BITMASKS
 #define SLOT_OCLOTHING 1

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -180,7 +180,10 @@ var/list/pipemenu = list(
 /obj/item/weapon/rpd/afterattack(atom/target, mob/user, proximity)
 	..()
 	var/turf/T = get_turf(target)
-	if(src.loc != user || ismob(target) || istype(target, /obj/structure/window) || !proximity || world.time < lastused + spawndelay)
+	if(loc != user || ismob(target) || istype(target, /obj/structure/window) || !proximity || world.time < lastused + spawndelay)
+		return
+	if(!(T.flags & RPD_ALLOWED_HERE))
+		to_chat(user, "<span class='notice'>[src] beeps, \"Unable to interface with [T]. Please try again later.\"</span>")
 		return
 	if(mode == ATMOS_MODE && !istype(T, /turf/simulated/shuttle)) //No pipes on shuttles nerds
 		if(istype(T, /turf/simulated/wall)) //Drilling into walls takes time

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -185,7 +185,7 @@ var/list/pipemenu = list(
 	if(!(T.flags & RPD_ALLOWED_HERE))
 		to_chat(user, "<span class='notice'>[src] beeps, \"Unable to interface with [T]. Please try again later.\"</span>")
 		return
-	if(mode == ATMOS_MODE && !istype(T, /turf/simulated/shuttle)) //No pipes on shuttles nerds
+	if(mode == ATMOS_MODE)
 		if(istype(T, /turf/simulated/wall)) //Drilling into walls takes time
 			playsound(loc, "sound/weapons/circsawhit.ogg", 50, 1)
 			user.visible_message("<span class = 'notice'>[user] starts drilling a hole in [T]...</span>", "<span class = 'notice'>You start drilling a hole in [T]...</span>", "<span class = 'warning'>You hear a drill.</span>")

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -4,6 +4,7 @@
 	var/image/wet_overlay = null
 
 	var/thermite = 0
+	flags = RPD_ALLOWED_HERE
 	oxygen = MOLES_O2STANDARD
 	nitrogen = MOLES_N2STANDARD
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed

--- a/code/game/turfs/simulated/shuttle.dm
+++ b/code/game/turfs/simulated/shuttle.dm
@@ -1,6 +1,7 @@
 /turf/simulated/shuttle
 	name = "shuttle"
 	icon = 'icons/turf/shuttle.dmi'
+	flags = null
 	thermal_conductivity = 0.05
 	heat_capacity = 0
 	layer = 2

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -3,6 +3,7 @@
 	name = "\proper space"
 	icon_state = "0"
 	dynamic_lighting = 0
+	flags = RPD_ALLOWED_HERE
 	luminosity = 1
 
 	temperature = TCMB

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -1,4 +1,5 @@
 /turf/space/transit
+	flags = null
 	var/pushdirection // push things that get caught in the transit tile this direction
 
 //Overwrite because we dont want people building rods in space.


### PR DESCRIPTION
This PR does the following: 
- Adds a new turf flag that allows usage of the RPD on certain tiles. Default behaviour of turfs is to deny RPD usage; all station-side turf types that aren't `/turf/simulated/shuttle` allow RPD usage.

The reason for this PR is that you shouldn't be able to use the RPD on unsimulated turfs for a bunch of reasons.

The only difference that players should notice is that you can't suck up pipes on shuttles now. This is fine.

:cl:
tweak: Restricts RPD usage to certain station-side turfs.
/:cl: