### PR TITLE
Bags of bags of holding no longer possible.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -38,6 +38,7 @@
 	max_w_class = WEIGHT_CLASS_HUGE
 	max_combined_w_class = 35
 	burn_state = FIRE_PROOF
+	cant_hold = list(/obj/item/weapon/storage/backpack/holding)
 
 /obj/item/weapon/storage/backpack/holding/New()
 	..()


### PR DESCRIPTION
fixes #8759 
fixes #8129

:cl:
fix: Lord Singuloth's wrath can no longer be bypassed by baking your input device.
/:cl: