### PR TITLE
Renames level 6 singularity to Hawking-level Singularity

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -1,6 +1,6 @@
 /obj/singularity
 	name = "gravitational singularity"
-	desc = "A gravitational singularity."
+	desc = "Consideration of black holes suggests, not only that God does play dice, but that he sometimes confuses us by throwing them where they can't be seen."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "singularity_s1"
 	anchored = 1

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -272,7 +272,7 @@
 	src.energy += gain
 	if(istype(A, /obj/machinery/power/supermatter_shard) && !consumedSupermatter)
 		desc = "[initial(desc)] It glows fiercely with inner fire."
-		name = "supermatter-charged [initial(name)]"
+		name = "Hawking-level [initial(name)]"
 		consumedSupermatter = 1
 		light_range = 10
 	return


### PR DESCRIPTION
Stephen Hawking developed Hawking radiation, which is given off by black holes, and is an important part of their life cycle, it is theorized to ultimately cause their death.

https://en.wikipedia.org/wiki/Hawking_radiation

It seems fitting that we tribute him with our own gravitational singularity, so this PR renames the level 6 singularity to "Hawking-level gravitational singularity", from "supermatter-charged gravitational singularity"

Name open for feedback.

🆑 
Change: renames the level 6 gravitational singularity from "supermatter-charged" to "Hawking-level"
Change: changes the default description of the singularity to "Consideration of black holes suggests, not only that God does play dice, but that he sometimes confuses us by throwing them where they can't be seen."
/🆑 
