### PR TITLE
Fixes ED-209 and floorbot + changes to ED-209 behavior.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -17,7 +17,7 @@
 	bot_filter = RADIO_SECBOT
 	model = "ED-209"
 	bot_purpose = "seek out criminals, handcuff them, and report their location to security"
-	bot_core = /obj/machinery/bot_core/secbot
+	bot_core_type = /obj/machinery/bot_core/secbot
 	window_id = "autoed209"
 	window_name = "Automatic Security Unit v2.6"
 	path_image_color = "#FF0000"

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -111,9 +111,7 @@
 	"<A href='?src=[UID()];power=1'>[on ? "On" : "Off"]</A>" )
 
 	if(!locked || issilicon(user) || user.can_admin_interact())
-		dat += text({"Auto Patrol[]<BR>"},
-
-		"<A href='?src=[UID()];operation=patrol'>[auto_patrol ? "On" : "Off"]</A>")
+		dat += "Auto Patrol <A href='?src=[UID()];operation=patrol'>[auto_patrol ? "On" : "Off"]</A><BR>"
 
 		if(!lasercolor)
 			dat += text({"<BR>

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -64,7 +64,7 @@
 			declare_arrests = 0 // Don't spam sec
 			bot_core.req_access = list(access_maint_tunnels, access_theatre, access_robotics)
 
-			if(created_name == "ED-209 Security Robot" || !created_name)
+			if(created_name == initial(name) || !created_name)
 				if(lasercolor == "b")
 					name = pick("BLUE BALLER","SANIC","BLUE KILLDEATH MURDERBOT")
 				else if (lasercolor == "r")
@@ -254,14 +254,13 @@
 						target_lastloc = null
 						return
 
-				else								// not next to perp
-					if(!disabled)
-						var/turf/olddist = get_dist(src, target)
-						walk_to(src, target,1,4)
-						if((get_dist(src, target)) >= (olddist))
-							frustration++
-						else
-							frustration = 0
+				else if(!disabled) // not next to perp
+					var/turf/olddist = get_dist(src, target)
+					walk_to(src, target,1,4)
+					if((get_dist(src, target)) >= (olddist))
+						frustration++
+					else
+						frustration = 0
 			else
 				back_to_idle()
 

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -240,7 +240,7 @@
 				back_to_idle()
 
 			if(target)		// make sure target exists
-				if(Adjacent(target) && isturf(target.loc)) // if right next to perp
+				if(Adjacent(target) && isturf(target.loc) && !lasercolor) // if right next to perp and we're not playing laser tag
 					stun_attack(target)
 
 					mode = BOT_PREP_ARREST
@@ -409,7 +409,7 @@
 	shoot_sound = 'sound/weapons/laser.ogg'
 	if(emagged == 2)
 		if(lasercolor)
-			projectile = /obj/item/projectile/beam/lasertag
+			projectile = /obj/item/projectile/beam/disabler
 		else
 			projectile = /obj/item/projectile/beam
 	else

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -61,9 +61,10 @@
 			shot_delay = 6//Longer shot delay because JESUS CHRIST
 			check_records = 0//Don't actively target people set to arrest
 			arrest_type = 1//Don't even try to cuff
+			declare_arrests = 0 // Don't spam sec
 			bot_core.req_access = list(access_maint_tunnels, access_theatre, access_robotics)
 
-			if(created_name == "ED-209 Security Robot")
+			if(created_name == "ED-209 Security Robot" || !created_name)
 				if(lasercolor == "b")
 					name = pick("BLUE BALLER","SANIC","BLUE KILLDEATH MURDERBOT")
 				else if (lasercolor == "r")
@@ -240,21 +241,27 @@
 				back_to_idle()
 
 			if(target)		// make sure target exists
-				if(Adjacent(target) && isturf(target.loc) && !lasercolor) // if right next to perp and we're not playing laser tag
+				if(Adjacent(target) && isturf(target.loc)) // if right next to perp
 					stun_attack(target)
-
-					mode = BOT_PREP_ARREST
-					anchored = 1
-					target_lastloc = target.loc
-					return
+					if(!lasercolor)
+						mode = BOT_PREP_ARREST
+						anchored = 1
+						target_lastloc = target.loc
+						return
+					else
+						mode = BOT_HUNT
+						target = null
+						target_lastloc = null
+						return
 
 				else								// not next to perp
-					var/turf/olddist = get_dist(src, target)
-					walk_to(src, target,1,4)
-					if((get_dist(src, target)) >= (olddist))
-						frustration++
-					else
-						frustration = 0
+					if(!disabled)
+						var/turf/olddist = get_dist(src, target)
+						walk_to(src, target,1,4)
+						if((get_dist(src, target)) >= (olddist))
+							frustration++
+						else
+							frustration = 0
 			else
 				back_to_idle()
 
@@ -504,6 +511,7 @@
 		if(lasertag_check)
 			icon_state = "[lasercolor]ed2090"
 			disabled = 1
+			walk_to(src, 0)
 			target = null
 			spawn(100)
 				disabled = 0

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -14,7 +14,7 @@
 	bot_filter = RADIO_FLOORBOT
 	model = "Floorbot"
 	bot_purpose = "seek out damaged or missing floor tiles, and repair or replace them as necessary"
-	bot_core = /obj/machinery/bot_core/floorbot
+	bot_core_type = /obj/machinery/bot_core/floorbot
 	window_id = "autofloor"
 	window_name = "Automatic Station Floor Repairer v1.1"
 	path_image_color = "#FFA500"


### PR DESCRIPTION
This fixes an unintended mistype in the code declaring what kind of robot ED-209 is for access purposes.

Robotics will no longer have access, as it will now be treated similarly to the mighty Beepsky!, a securitron.

Robotics will have access now to the lasertag ED-209, however.

They weren't meant to have access in the first place. 

Noticed the same in floorbot.dm and fixed it as well. Now only engineering and robotics can access the controls for floorbot.

Additional fixes added for the laser mode for ED-209. Patrol mode now appears as it should and ED209 will be automatically renamed unless a custom name is already defined.

Emagged lasertag ED-209 now shoots disablers, Lasertag ED-209 won't spam security comms when it stuns someone.



:cl: Desolate
fix: ED-209 code corrected to work properly. Floorbot code corrected to work properly.
/:cl: