### PR TITLE
Makes message monitors fixable

### DIFF
--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -39,8 +39,6 @@
 
 
 /obj/machinery/computer/message_monitor/attackby(obj/item/weapon/O as obj, mob/living/user as mob, params)
-	if(stat & (NOPOWER|BROKEN))
-		return
 	if(!istype(user))
 		return
 	if(isscrewdriver(O) && emag)


### PR DESCRIPTION
The stat does get checked later on by the machinery parent type, which
already does stop using the console, screwdriver are handled at that
point, and the removed part stopped screwdriver from fixing the broken stat.
:cl:
fix: You can now fix broken message monitors
/:cl: