### PR TITLE
Vulp Hunger Hotfix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -196,7 +196,7 @@
 	clothing_flags = HAS_UNDERWEAR | HAS_UNDERSHIRT | HAS_SOCKS
 	bodyflags = HAS_TAIL | TAIL_WAGGING | TAIL_OVERLAPPED | HAS_HEAD_ACCESSORY | HAS_MARKINGS | HAS_SKIN_COLOR
 	dietflags = DIET_OMNI
-	hunger_drain = 1
+	hunger_drain = 0.11
 	taste_sensitivity = TASTE_SENSITIVITY_SHARP
 	reagent_tag = PROCESS_ORG
 	flesh_color = "#966464"


### PR DESCRIPTION
Increasing hunger drain rate from 0.1 to 1.0 is not a "slight increase". 

It's a 1000% increase.

This adjusts the Vulp hunger drain rate from 0.1 to 0.11, which is a 10% increase, which is "slightl".

:cl: Fox McCloud
fix: Fixes Vulpkanin hunger drain rate being absurd
/:cl: