### PR TITLE
Tiny mug fix

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/mugs.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/mugs.dm
@@ -79,7 +79,7 @@
 /datum/novelty_mug/pills
 	name = "prescription mug"
 	description = "Prescription: caffeine. Dosage: As much as it takes."
-	state = "mug_pills"
+	state = "mug_pill"
 
 /datum/novelty_mug/rainbow
 	name = "rainbow mug"


### PR DESCRIPTION
The .dmi has the icon named mug_pill, the .dm mug_pills, causing an invisible mug. Removes that s from the .dm
:cl:
fix: Stops a mug from being invisible
/:cl: