### PR TITLE
Stun batons now checks for their hit cost to turn on insteed of the hitcost + 1

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -89,7 +89,7 @@
 	return
 
 /obj/item/weapon/melee/baton/attack_self(mob/user)
-	if(bcell && bcell.charge > hitcost)
+	if(bcell && bcell.charge >= hitcost)
 		status = !status
 		to_chat(user, "<span class='notice'>[src] is now [status ? "on" : "off"].</span>")
 		playsound(loc, "sparks", 75, 1, -1)


### PR DESCRIPTION
fixes #8755 

the check used an > now its an >=

it used to check for 1001 energy(stunbaton) and 2001(stunprod) but only used 1000(stunbaton) or 2000(stunprod)

now it checks for 1000 and 2000 and uses 1000 and 2000