### PR TITLE
Add "One access" to non secure windoor #5973

### DIFF
--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -291,7 +291,10 @@ obj/structure/windoor_assembly/Destroy()
 							windoor.setDir(dir)
 							windoor.density = FALSE
 
-							windoor.req_access = electronics.conf_access
+							if(electronics.one_access)
+								windoor.req_one_access = electronics.conf_access
+							else
+								windoor.req_access = electronics.conf_access
 							windoor.electronics = src.electronics
 							electronics.forceMove(windoor)
 							if(created_name)


### PR DESCRIPTION
Secure windoor has conditions for "One" and "All" access but default windoor only has "All" access. This adds "One" and "All" access to default windoor. Fixes #5973