### PR TITLE
Russian Revolvers no longer calls death()

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1406,8 +1406,7 @@ obj/item/toy/cards/deck/syndicate/black
 			is_empty = 1
 			playsound(src, 'sound/weapons/Gunshot.ogg', 50, 1)
 			user.visible_message("<span class='danger'>The [src] goes off!</span>")
-			M.apply_damage(200, BRUTE, "head", sharp =1, used_weapon = "Self-inflicted gunshot wound to the head.")
-			M.death()
+			M.apply_damage(500, BRUTE, "head", sharp =1, used_weapon = "Self-inflicted gunshot wound to the head.")
 	else
 		user.visible_message("<span class='danger'>[user] lowers the [src] from their head.</span>")
 


### PR DESCRIPTION
fixes #8634 

russian revolver now causes 500 dmg just to be sure

a downside of this is you cant die(of the revolver anyways) as ipc if you have no head
🆑 alexkar598
fix:you can no longer move into the ghost world by shooting yourself with a russian revolver as ipc
/🆑