### PR TITLE
Atmos grenades now Nuclear Emergency only

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -483,7 +483,9 @@ var/list/uplink_items = list()
 	desc = "A box of two (2) grenades that wreak havoc with the atmosphere of the target area. Capable of engulfing a large area in lit plasma, or N2O. Deploy with extreme caution!"
 	reference = "AGG"
 	item = /obj/item/weapon/storage/box/syndie_kit/atmosgasgrenades
+	gamemodes = list(/datum/game_mode/nuclear)
 	cost = 11
+	surplus = 0
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Grenades and Implanter Kit"


### PR DESCRIPTION
@Spartan6 request

Moves atmos grenades out of surplus. Make's them available on nuclear emergency only.

🆑 Birdtalon
tweak: Atmos grenades are now Nuclear Operative only.
/🆑 