### PR TITLE
RCD floors work on lattice & space

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -187,16 +187,16 @@ RCD
 	if(!proximity) return
 	if(istype(A,/area/shuttle)||istype(A,/turf/space/transit))
 		return 0
-	if(!(istype(A, /turf) || istype(A, /obj/machinery/door/airlock) || istype(A, /obj/structure/grille) || istype(A, /obj/structure/window)))
+	if(!(istype(A, /turf) || istype(A, /obj/machinery/door/airlock) || istype(A, /obj/structure/grille) || istype(A, /obj/structure/window) || istype(A, /obj/structure/lattice)))
 		return 0
 
 	switch(mode)
 		if(1)
-			if(istype(A, /turf/space))
+			if(istype(A, /turf/space) || istype(A, /obj/structure/lattice))
 				if(useResource(1, user))
 					to_chat(user, "Building Floor...")
 					activate()
-					var/turf/AT = A
+					var/turf/AT = get_turf(A)
 					AT.ChangeTurf(/turf/simulated/floor/plating)
 					return 1
 				return 0


### PR DESCRIPTION
Player can place RCD floors on space & lattice
Instead of having to click on the space in between the lattice just allow the player to click on the lattice.