### PR TITLE
Added emergency tracking option to suit sensors

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -224,7 +224,7 @@ BLIND     // can't see anything
 		to_chat(user, "This suit does not have any sensors.")
 		return 0
 
-	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon")
+	var/list/modes = list("Off", "Binary sensors", "Vitals tracker", "Tracking beacon","Emergency")
 	var/switchMode = input("Select a sensor mode:", "Suit Sensor Mode", modes[sensor_mode + 1]) in modes
 	if(get_dist(user, src) > 1)
 		to_chat(user, "You have moved too far away.")
@@ -241,6 +241,8 @@ BLIND     // can't see anything
 				to_chat(user, "Your suit will now report your vital lifesigns.")
 			if(3)
 				to_chat(user, "Your suit will now report your vital lifesigns as well as your coordinate position.")
+			if(4)
+				to_chat(user, "Your suit will now report distress along with your vital life signs as well as your coordinate position.")
 		if(istype(user,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = user
 			if(H.w_uniform == src)
@@ -260,6 +262,9 @@ BLIND     // can't see anything
 			if(3)
 				for(var/mob/V in viewers(user, 1))
 					V.show_message("[user] sets [src.loc]'s sensors to maximum.", 1)
+			if(4)
+				for(var/mob/V in viewers(user, 1))
+					V.show_message("[user] sets [src.loc]'s sensors to emergency.", 1)
 		if(istype(src,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src
 			if(H.w_uniform == src)

--- a/nano/templates/crew_monitor.tmpl
+++ b/nano/templates/crew_monitor.tmpl
@@ -11,6 +11,8 @@ Used In File(s): \code\game\machinery\computer\crew.dm
 			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss_light">{{:value.oxy}}</span>/<span class="toxin_light">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td><span class="neutral">Not Available</td></td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {}, 'disabled')}}</td>{{/if}}</tr>
 		{{else value.sensor_type == 3}}
 			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='good'>Living</span>"}} (<span class="oxyloss_light">{{:value.oxy}}</span>/<span class="toxin_light">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
+		{{else value.sensor_type == 4}}
+			<tr><td>{{:value.name}} ({{:value.assignment}})</td><td>{{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='average'>Living</span>"}} (<span class="oxyloss_light">{{:value.oxy}}</span>/<span class="toxin_light">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>)</td><td>{{:value.area}}({{:value.x}}, {{:value.y}})</td>{{if data.isAI}}<td class='tracking'>{{:helper.link('Track', null, {'track' : value.ref})}}</td>{{/if}}</tr>
 		{{/if}}
 	{{/for}}
 </tbody></table>

--- a/nano/templates/crew_monitor_map_content.tmpl
+++ b/nano/templates/crew_monitor_map_content.tmpl
@@ -10,6 +10,13 @@ Used In File(s): \code\game\machinery\computer\crew.dm
             </div>
         </div>
     {{/if}}
+    {{if value.sensor_type == 4}}
+        <div class="mapIcon mapIcon16 rank-{{:value.rank.ckey()}} {{:value.dead ? 'dead' : 'average'}}" style="left: {{:(value.x)}}px; bottom: {{:(value.y - 1)}}px;" unselectable="on">
+            <div class="tooltip hidden">
+                {{:value.name}} ({{:value.assignment}}) ({{:value.dead ? "<span class='bad'>Deceased</span>" : "<span class='average'>Living</span>"}}) (<span class="oxyloss_light">{{:value.oxy}}</span>/<span class="toxin_light">{{:value.tox}}</span>/<span class="burn">{{:value.fire}}</span>/<span class="brute">{{:value.brute}}</span>) ({{:value.area}}: {{:value.x}}, {{:value.y}})
+            </div>
+        </div>
+    {{/if}}
 {{/for}}
 
 <div class="mapIcon mapIcon16 rank-captain alive"  style="left: 10px; bottom: 10px;" unselectable="on"></div>


### PR DESCRIPTION
Added emergency tracking option to suit sensors to alert users that you need attention before you die. People crew monitors prioritize those in distress and the only way to signify that with the current system is the die. This gives the player the option to flag up distress so that users of the crew monitor know to attempt a rescue.

In other words Emergency is tracking beacon mode but with orange "Alive" text and icon which signifies an emergency

[Video Example](https://puu.sh/zOnsB/1c0fe981b0.mp4)

clothing.dm adds the emergency option and associated text
crew_monitor.tmpl associates orange text with emergency option to crew monitor detail list
crew_monitor_map_content.tmpl associates orange text/icon to tracker map

:cl:
add: Added emergency tracking to suit sensors
/:cl:
