### PR TITLE
Fixes #8797 : Borg vision resets

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -34,6 +34,7 @@
 	R.notify_ai(2)
 
 	R.uneq_all()
+	R.sight_mode = null
 	R.hands.icon_state = "nomod"
 	R.icon_state = "robot"
 	R.module.remove_subsystems_and_actions(R)


### PR DESCRIPTION
Fixes #8797
No vision for you borg!

:cl: 
Fix: Borgs no longer keep their special vision when reset with the reset module
/:cl: