### PR TITLE
QoL addition to record printouts

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -515,7 +515,7 @@
 				else
 					P.info += "<B>Medical Record Lost!</B><BR>"
 				P.info += "</TT>"
-				P.name = "paper- 'Medical Record'"
+				P.name = "paper- 'Medical Record: [active1.fields["name"]'"
 				printing = 0
 	return 1
 

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -515,7 +515,7 @@
 				else
 					P.info += "<B>Medical Record Lost!</B><BR>"
 				P.info += "</TT>"
-				P.name = "paper- 'Medical Record: [active1.fields["name"]'"
+				P.name = "paper- 'Medical Record: [active1.fields["name"]]'"
 				printing = 0
 	return 1
 

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -366,7 +366,7 @@
 				else
 					P.info += "<B>Security Record Lost!</B><BR>"
 				P.info += "</TT>"
-				P.name = "paper - 'Security Record'"
+				P.name = "paper - 'Security Record: [active1.fields["name"]]'"
 				printing = 0
 
 /* Removed due to BYOND issue

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -232,7 +232,7 @@
 				else
 					P.info += "<B>General Record Lost!</B><BR>"
 				P.info += "</TT>"
-				P.name = "paper - 'Employment Record'"
+				P.name = "paper - 'Employment Record: [active1.fields["name"]'"
 				printing = 0
 
 		if(href_list["field"])

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -232,7 +232,7 @@
 				else
 					P.info += "<B>General Record Lost!</B><BR>"
 				P.info += "</TT>"
-				P.name = "paper - 'Employment Record: [active1.fields["name"]'"
+				P.name = "paper - 'Employment Record: [active1.fields["name"]]'"
 				printing = 0
 
 		if(href_list["field"])


### PR DESCRIPTION
Security, Medical, and Employment record printouts automatically get the name of the person added to the lable of the paper.
Originally requested by @Fruerlund for security records, seen no reason not to also add it to the other records.
:cl:
add: Record printouts now automatically get labled with the name of the person.
/:cl: