### PR TITLE
Silicons no longer automatically pass surgery check

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -122,7 +122,7 @@
 				var/mob/living/carbon/human/H = target //typecast to human
 				prob_chance *= get_pain_modifier(H)//operating on conscious people is hard.
 
-		if(prob(prob_chance) || isrobot(user))
+		if(prob(prob_chance))
 			if(end_step(user, target, target_zone, tool, surgery))
 				advance = 1
 		else


### PR DESCRIPTION
Although not a bug per se - Fixes #8716 

Silicons no longer automatically pass surgery probability checks.

🆑 Birdtalon
tweak: Borgs now have a chance to fail surgery on anaesthetised patients.
/🆑 