### PR TITLE
Stops bluespace Cheese cheese

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -526,6 +526,14 @@ proc/GaussRandRound(var/sigma,var/roundto)
 
 	return toReturn
 
+//Searches contents of the atom and returns the sum of all w_class of obj/item within
+/atom/proc/GetTotalContentsWeight(searchDepth = 5)
+	var/weight = 0
+	var/list/content = GetAllContents(searchDepth)
+	for(var/obj/item/I in content)
+		weight += I.w_class
+	return weight
+
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(var/atom/source, var/atom/target, var/length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.
 	var/turf/current = get_turf(source)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -1,4 +1,4 @@
-#define MAX_WEIGHT_CLASS WEIGHT_CLASS_SMALL * 2
+#define MAX_WEIGHT_CLASS WEIGHT_CLASS_SMALL
 //Food items that are eaten normally and don't leave anything behind.
 /obj/item/weapon/reagent_containers/food/snacks
 	name = "snack"
@@ -133,9 +133,10 @@
 		)
 		inaccurate = 1
 	else if(W.w_class <= WEIGHT_CLASS_SMALL && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
-		if(total_w_class > MAX_WEIGHT_CLASS)
+		var/newweight = GetTotalContentsWeight() + W.GetTotalContentsWeight() + W.w_class
+		if(newweight > MAX_WEIGHT_CLASS)
 			// Nope, no bluespace slice food
-			to_chat(user, "<span class='warning'>Something is already in [src]!</span>")
+			to_chat(user, "<span class='warning'>You cannot fit [W] in [src]!</span>")
 			return 1
 		if(!iscarbon(user))
 			return 1


### PR DESCRIPTION
Adds recursive checking for weight classes of slicable foods. #8681 almost got there but didn't check recursively (containers within containers etc) allowing for infinite chains of food within food.

I have also reduced the weight capacity of the sliceable foods from 4 to 2. You can put either 2 tiny items inside or one small item.

🆑 Birdtalon
fix: Enforces size limits for placing items inside slicable food
/🆑  