### PR TITLE
stops poolcontroller drowning sending messages to admins

### DIFF
--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -100,7 +100,10 @@
 		if(drownee.losebreath > 20)	//You've probably got bigger problems than drowning at this point, so we won't add to it until you get that under control.
 			return
 
-		add_logs(src, drownee, "drowned", null, null, 0, 0)	//log it to their VV, but don't spam the admins' chats with the logs
+		if (isLivingSSD(drownee))
+			add_logs(src, drownee, "drowned", null, null, 0, 1)	// Notify admins, since the person is SSD
+		else
+			add_logs(src, drownee, "drowned", null, null, 0, 0)	// Do not notify admins.
 		if(drownee.stat) //Mob is in critical.
 			drownee.AdjustLoseBreath(3, bound_lower = 0, bound_upper = 20)
 			drownee.visible_message("<span class='danger'>\The [drownee] appears to be drowning!</span>","<span class='userdanger'>You're quickly drowning!</span>") //inform them that they are fucked.

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -100,7 +100,7 @@
 		if(drownee.losebreath > 20)	//You've probably got bigger problems than drowning at this point, so we won't add to it until you get that under control.
 			return
 
-		add_logs(src, drownee, "drowned", null, null, 0)	//log it to their VV, but don't spam the admins' chats with the logs
+		add_logs(src, drownee, "drowned", null, null, 0, 0)	//log it to their VV, but don't spam the admins' chats with the logs
 		if(drownee.stat) //Mob is in critical.
 			drownee.AdjustLoseBreath(3, bound_lower = 0, bound_upper = 20)
 			drownee.visible_message("<span class='danger'>\The [drownee] appears to be drowning!</span>","<span class='userdanger'>You're quickly drowning!</span>") //inform them that they are fucked.

--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -100,7 +100,7 @@
 		if(drownee.losebreath > 20)	//You've probably got bigger problems than drowning at this point, so we won't add to it until you get that under control.
 			return
 
-		if (isLivingSSD(drownee))
+		if(isLivingSSD(drownee))
 			add_logs(src, drownee, "drowned", null, null, 0, 1)	// Notify admins, since the person is SSD
 		else
 			add_logs(src, drownee, "drowned", null, null, 0, 0)	// Do not notify admins.


### PR DESCRIPTION
Currently, when anyone takes damage due to being underwater without proper breathing gear, online admins get a notification like this:

ATTACK: *invalid:/obj/machinery/poolcontroller*(?) (FLW) drowned CKEY/(CHARNAME)(?) (FLW) 

Such events can trigger every few seconds, which is very spammy.

This PR changes it so that:
- Players who are drowning no longer generate attack notifications to admins.
- The exception is SSD players. Those still generate attack notifications.

No changelog, as this change is invisible to players.