### PR TITLE
Fixes Mech Disablers being not printable half the time

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -896,7 +896,7 @@
 /datum/design/mech_disabler
 	name = "Exosuit Weapon (CH-PD Disabler)"
 	desc = "Allows for the construction of CH-PD Disabler."
-	id = "mech_laser"
+	id = "mech_disabler"
 	build_type = MECHFAB
 	req_tech = list("combat" = 3)
 	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/disabler


### PR DESCRIPTION
Apparently the Firedart and Mech-Disabler have the same ID for some bizarre reason. This PR fixes it. Its a minor fix and my first PR (on para). Its basicly just changing one line to fix this pretty decent mech weapon to make it printable like it is every now and then.

Cause its weird that you can print it from round to round, but most of the time you can only print the stupid firedart.

:cl: EldritchSigma
fix: Mech mounted Disablers are now printable with consistency.
/:cl:
