### PR TITLE
Nerfs loot-pinata-ing of hotel guards

### DIFF
--- a/code/modules/awaymissions/mission_code/spacehotel_npcs.dm
+++ b/code/modules/awaymissions/mission_code/spacehotel_npcs.dm
@@ -17,6 +17,26 @@
 /mob/living/carbon/human/interactive/away/hotel/guard/doSetup()
 	..("Guard")
 
+	// anti-pinata cheese
+	var/obj/item/weapon/implant/dust/D = new /obj/item/weapon/implant/dust(src)
+	D.implant(src)
+
+	for(var/obj/item/I in get_all_slots())
+		I.flags |= NODROP
+
+	// FIXME(crazylemon) a hack to prevent guards from running around with an
+	// extra security jumpsuit like a goof
+	for(var/obj/item/clothing/under/U in get_all_slots())
+		if(w_uniform != U)
+			qdel(U)
+
+/mob/living/carbon/human/interactive/away/hotel/guard/KnockOut()
+	// you'll never take me alive (this triggers the implant)
+	emote("deathgasp")
+	if(stat != DEAD)
+		// mission failed. we'll get em next time
+		..()
+
 /mob/living/carbon/human/interactive/away/hotel/chef
 	default_job = /datum/job/chef
 	away_area = /area/awaymission/spacehotel/kitchen

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -3,6 +3,10 @@
 	var/datum/middleClickOverride/middleClickOverride = null
 
 /mob/living/carbon/Destroy()
+	// This clause is here due to items falling off from limb deletion
+	for(var/obj/item in get_all_slots())
+		unEquip(item)
+		qdel(item)
 	QDEL_LIST(internal_organs)
 	QDEL_LIST(stomach_contents)
 	var/mob/living/simple_animal/borer/B = has_brain_worms()

--- a/code/modules/mob/living/carbon/human/interactive/functions.dm
+++ b/code/modules/mob/living/carbon/human/interactive/functions.dm
@@ -237,10 +237,15 @@
 /mob/living/carbon/human/interactive/proc/shitcurity(obj)
 	var/list/allContents = getAllContents()
 
-	if(retal && TARGET && Adjacent(TARGET))
-		var/obj/item/weapon/restraints/R = locate() in allContents
-		if(R)
-			R.attack(TARGET, src) // go go bluespace restraint launcher!
+	if(retal && TARGET)
+		if(Adjacent(TARGET))
+			var/obj/item/weapon/restraints/R = locate() in allContents
+			if(R)
+				R.attack(TARGET, src) // go go bluespace restraint launcher!
+		else if(TARGET in oview(7, src))
+			var/obj/item/weapon/gun/G = locate() in allContents
+			if(G)
+				G.afterattack(TARGET, src)
 
 /mob/living/carbon/human/interactive/proc/clowning(obj)
 	if(shouldModulePass())

--- a/code/modules/mob/living/carbon/human/interactive/interactive.dm
+++ b/code/modules/mob/living/carbon/human/interactive/interactive.dm
@@ -556,8 +556,12 @@
 	var/obj/item/I = get_item_by_slot(pick(slots))
 	var/obj/item/weapon/storage/BP = get_item_by_slot(slot_back)
 	if(back && BP && I)
+		// hack to allow SNPCs to "sticky grab" items without losing their inventorying
+		var/oldnodrop = I.flags | NODROP
+		I.flags &= ~NODROP
 		if(BP.can_be_inserted(I))
 			BP.handle_item_insertion(I)
+		I.flags |= oldnodrop
 	else
 		unEquip(I,TRUE)
 	update_hands = 1


### PR DESCRIPTION
:cl:Crazylemon
fix: Deletion of human mobs now properly deletes equipment
balance: Hotel guards now dust on death
balance: Hotel guards no longer drop equipment when stunned
balance: Hotel guards now are able to use the tasers they hold
/:cl:

An alternative to #8404 