### PR TITLE
Better ID computer logging

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -480,8 +480,8 @@ var/time_last_changed_position = 0
 				access = jobdatum.get_access()
 
 				var/jobnamedata = modify.getRankAndAssignment()
-				log_game("[key_name(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian.")
-				message_admins("[key_name_admin(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian.")
+				log_game("[key_name(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian (Unassigned).")
+				message_admins("[key_name_admin(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian (Unassigned).")
 
 				modify.access = access
 				modify.rank = "Civilian"

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -373,6 +373,7 @@ var/time_last_changed_position = 0
 					//let custom jobs function as an impromptu alt title, mainly for sechuds
 					if(temp_t && modify)
 						modify.assignment = temp_t
+						log_game("[key_name(usr)] has given \"[modify.registered_name]\" the custom job title \"[temp_t]\".")
 				else
 					var/list/access = list()
 					if(is_centcom())

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -392,9 +392,9 @@ var/time_last_changed_position = 0
 						access = jobdatum.get_access()
 
 					var/jobnamedata = modify.getRankAndAssignment()
-					log_game("[key_name(usr)] has reassigned \"[modify.registered_name]\" from [jobnamedata] to [t1].")
+					log_game("[key_name(usr)] has reassigned \"[modify.registered_name]\" from \"[jobnamedata]\" to \"[t1]\".")
 					if(t1 == "Civilian")
-						message_admins("[key_name_admin(usr)] has reassigned \"[modify.registered_name]\" from [jobnamedata] to [t1].")
+						message_admins("[key_name_admin(usr)] has reassigned \"[modify.registered_name]\" from \"[jobnamedata]\" to \"[t1]\".")
 
 					modify.access = access
 					modify.rank = t1
@@ -461,8 +461,8 @@ var/time_last_changed_position = 0
 		if("terminate")
 			if(is_authenticated(usr) && !target_dept)
 				var/jobnamedata = modify.getRankAndAssignment()
-				log_game("[key_name(usr)] has terminated the employment of \"[modify.registered_name]\" the [jobnamedata].")
-				message_admins("[key_name_admin(usr)] has terminated the employment of \"[modify.registered_name]\" the [jobnamedata].")
+				log_game("[key_name(usr)] has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\".")
+				message_admins("[key_name_admin(usr)] has terminated the employment of \"[modify.registered_name]\" the \"[jobnamedata]\".")
 				modify.assignment = "Terminated"
 				modify.access = list()
 				callHook("terminate_employee", list(modify))
@@ -481,8 +481,8 @@ var/time_last_changed_position = 0
 				access = jobdatum.get_access()
 
 				var/jobnamedata = modify.getRankAndAssignment()
-				log_game("[key_name(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian (Unassigned).")
-				message_admins("[key_name_admin(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian (Unassigned).")
+				log_game("[key_name(usr)] has demoted \"[modify.registered_name]\" the \"[jobnamedata]\" to \"Civilian (Unassigned)\".")
+				message_admins("[key_name_admin(usr)] has demoted \"[modify.registered_name]\" the \"[jobnamedata]\" to \"Civilian (Unassigned)\".")
 
 				modify.access = access
 				modify.rank = "Civilian"

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -390,6 +390,11 @@ var/time_last_changed_position = 0
 
 						access = jobdatum.get_access()
 
+					var/jobnamedata = modify.getRankAndAssignment()
+					log_game("[key_name(usr)] has reassigned \"[modify.registered_name]\" from [jobnamedata] to [t1].")
+					if(t1 == "Civilian")
+						message_admins("[key_name_admin(usr)] has reassigned \"[modify.registered_name]\" from [jobnamedata] to [t1].")
+
 					modify.access = access
 					modify.rank = t1
 					modify.assignment = t1
@@ -454,6 +459,9 @@ var/time_last_changed_position = 0
 
 		if("terminate")
 			if(is_authenticated(usr) && !target_dept)
+				var/jobnamedata = modify.getRankAndAssignment()
+				log_game("[key_name(usr)] has terminated the employment of \"[modify.registered_name]\" the [jobnamedata].")
+				message_admins("[key_name_admin(usr)] has terminated the employment of \"[modify.registered_name]\" the [jobnamedata].")
 				modify.assignment = "Terminated"
 				modify.access = list()
 				callHook("terminate_employee", list(modify))
@@ -470,6 +478,10 @@ var/time_last_changed_position = 0
 				var/list/access = list()
 				var/datum/job/jobdatum = new /datum/job/civilian
 				access = jobdatum.get_access()
+
+				var/jobnamedata = modify.getRankAndAssignment()
+				log_game("[key_name(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian.")
+				message_admins("[key_name_admin(usr)] has demoted \"[modify.registered_name]\" the [jobnamedata] to Civilian.")
 
 				modify.access = access
 				modify.rank = "Civilian"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -187,6 +187,14 @@
 /obj/item/weapon/card/id/GetID()
 	return src
 
+/obj/item/weapon/card/id/proc/getRankAndAssignment()
+	var/jobnamedata = ""
+	if(rank)
+		jobnamedata += rank
+	if(rank != assignment)
+		jobnamedata += " (" + assignment + ")"
+	return jobnamedata
+
 /obj/item/weapon/card/id/proc/is_untrackable()
 	return untrackable
 

--- a/nano/templates/card_prog.tmpl
+++ b/nano/templates/card_prog.tmpl
@@ -41,6 +41,7 @@
 				<span class="average" style="font-weight: bold;">{{:value.title}}: {{:value.current_positions}}/{{:value.total_positions}}</span>
 				{{:helper.link('-', null, {'action' : 'PRG_make_job_unavailable', 'job' : value.title}, value.can_close == 1 && data.authenticated ? null : 'disabled')}}
 				{{:helper.link('+', null, {'action' : 'PRG_make_job_available', 'job' : value.title}, value.can_open == 1 && data.authenticated ? null : 'disabled')}}
+				{{:helper.link('Pri', null, {'action' : 'PRG_prioritize_job', 'job' : value.title}, value.can_prioritize > 0 && data.authenticated ? null : 'disabled')}} {{if value.can_prioritize == 2}}<span class='warning'>Priority Job</span> {{/if}}
 			</div>
 		{{/for}}
 	</div>

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -41,7 +41,7 @@
 				<span class="average" style="font-weight: bold;">{{:value.title}}: {{:value.current_positions}}/{{:value.total_positions}}</span>
 				{{:helper.link('-', null, {'choice' : 'make_job_unavailable', 'job' : value.title}, value.can_close == 1 && data.authenticated ? null : 'disabled')}}
 				{{:helper.link('+', null, {'choice' : 'make_job_available', 'job' : value.title}, value.can_open == 1 && data.authenticated ? null : 'disabled')}}
-				{{:helper.link('*', null, {'choice' : 'prioritize_job', 'job' : value.title}, value.can_prioritize > 0 && data.authenticated ? null : 'disabled')}} {{if value.can_prioritize == 2}}<span class='warning'>Priority Job</span> {{/if}}
+				{{:helper.link('Pri', null, {'choice' : 'prioritize_job', 'job' : value.title}, value.can_prioritize > 0 && data.authenticated ? null : 'disabled')}} {{if value.can_prioritize == 2}}<span class='warning'>Priority Job</span> {{/if}}
 			</div>
 		{{/for}}
 	</div>


### PR DESCRIPTION
In ID Computers, Modular Computers, and Demotion Consoles:
- Job transfers, demotions, terminations, and custom job title assignments are now logged to the game log. 
- Demotions and terminations, in addition to being logged, now also generate a message to all online admins. 
- Modular computers now support toggling priority on/off for jobs. This was already a feature of proper ID computers, it was just that modular computers did not have it.
- The 'toggle priority' button is now marked 'Pri', rather than '*', so it is now obvious what it does.

Examples of messages to admins:
![id_computer_messages](https://user-images.githubusercontent.com/16434066/38225446-cc3b05a6-36a9-11e8-829c-7cfde46fb6c6.PNG)

The first message above is for someone being manually assigned the 'Civilian' job. All job changes are logged, but only job changes to civilian (since they're effectively demotions) are broadcast to admins. 
The second is for someone being terminated by an ID computer.
The third is for someone being demoted by the demote button on an ID computer, or demotion console.

The intention of this PR is to make demotions more visible to admins, so that we can consider applying a job ban if the situation warrants it.  As a bonus, this PR also reduces the feature disparity between modular ID computer programs, and proper ID computers.

🆑 Kyep
tweak: Crew demotions and terminations now generate an automatic message to admins. All job changes are also logged.
tweak: Modular computers now support toggling priority on/off for jobs. The button for doing this in both normal and modular computers is now marked 'Pri', instead of the old '*'.
/🆑