### PR TITLE
Agent ID occupation options

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -440,7 +440,37 @@
 						RebuildHTML()
 
 					if("Occupation")
-						var/new_job = sanitize(stripped_input(user,"What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation", "Civilian", MAX_MESSAGE_LEN))
+						var/list/departments =list(
+							"Civilian",
+							"Engineering",
+							"Medical",
+							"Science",
+							"Security",
+							"Support",
+							"Command",
+							"Custom",
+						)
+
+						var/department = input(user, "What job would you like to put on this card?\nChoose a department or a custom job title.\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in departments
+						var/new_job = "Civilian"
+
+						if(department == "Custom")
+							new_job = sanitize(stripped_input(user,"Choose a custom jon title:","Agent Card Occupation", "Civilian", MAX_MESSAGE_LEN))
+						else if(department != "Civilian")
+							switch(department)
+								if("Engineering")
+									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in engineering_positions
+								if("Medical")
+									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in medical_positions
+								if("Science")
+									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in science_positions
+								if("Security")
+									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in security_positions
+								if("Support")
+									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in support_positions
+								if("Command")
+									new_job = input(user, "What job would you like to put on this card?\nChanging occupation will not grant or remove any access levels.","Agent Card Occupation") in command_positions
+
 						if(!Adjacent(user))
 							return
 						src.assignment = new_job


### PR DESCRIPTION
After making the mistake of mistyping my occupation on my agent ID, I thought it would be appropriate to spend a few minutes adding some preset options for both efficiency and clarity.
The ID now presents a list of departments or the option for a custom job title. After choosing a department, you can select a job title in that department.

🆑 Dyhr
tweak: Agent ID's now provide some presets for valid occupations.
/🆑