### PR TITLE
Classic worldtime2text & Ticker State for world/Topic

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -34,7 +34,7 @@
  * If you want to display the time for which dream daemon has been running ("round time") use worldtime2text.
  * If you want to display the canonical station "time" (aka the in-character time of the station) use station_time_timestamp
  */
-/proc/classic_worldtime2text()
+/proc/classic_worldtime2text(time = world.time)
 	time = (round_start_time ? (time - round_start_time) : (time - world.time))
 	return "[round(time / 36000)+12]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
 

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -30,6 +30,14 @@
 
 	return wtime + (time_offset + wusage) * world.tick_lag
 
+/* This proc should only be used for world/Topic.
+ * If you want to display the time for which dream daemon has been running ("round time") use worldtime2text.
+ * If you want to display the canonical station "time" (aka the in-character time of the station) use station_time_timestamp
+ */
+/proc/classic_worldtime2text()
+	time = (round_start_time ? (time - round_start_time) : (time - world.time))
+	return "[round(time / 36000)+12]:[(time / 600 % 60) < 10 ? add_zero(time / 600 % 60, 1) : time / 600 % 60]"
+
 //Returns the world time in english
 /proc/worldtime2text()
 	return gameTimestamp("hh:mm:ss", world.time)

--- a/code/world.dm
+++ b/code/world.dm
@@ -118,6 +118,7 @@ var/world_topic_spam_protect_time = world.timeofday
 		s["players"] = list()
 		s["roundtime"] = worldtime2text()
 		s["stationtime"] = station_time_timestamp()
+		s["oldstationtime"] = classic_worldtime2text() // more "consistent" indication of the round's running time
 		s["listed"] = "Public"
 		if(!hub_password)
 			s["listed"] = "Invisible"

--- a/code/world.dm
+++ b/code/world.dm
@@ -141,6 +141,7 @@ var/world_topic_spam_protect_time = world.timeofday
 				s["real_mode"] = ticker.mode.name
 
 			s["security_level"] = get_security_level()
+			s["ticker_state"] = ticker.current_state
 
 			if(shuttle_master && shuttle_master.emergency)
 				// Shuttle status, see /__DEFINES/stat.dm


### PR DESCRIPTION
This is a workaround for issues we're having with the server back-end. Dropping legacy support broke shit, so re-adding it until we can migrate to new methods.