### PR TITLE
Makes Stacks Garbage Collect

### DIFF
--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -5,7 +5,8 @@
 	icon = 'icons/obj/nanopaste.dmi'
 	icon_state = "tube"
 	origin_tech = "materials=2;engineering=3"
-	amount = 10
+	amount = 6
+	max_amount = 6
 	toolspeed = 1
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -26,8 +26,7 @@
 /obj/item/stack/Destroy()
 	if(usr && usr.machine == src)
 		usr << browse(null, "window=stack")
-	..()
-	return QDEL_HINT_HARDDEL_NOW // because qdel'd stacks act strange for cyborgs
+	return ..()
 
 /obj/item/stack/examine(mob/user)
 	if(..(user, 1))
@@ -195,15 +194,18 @@
 			interact(usr)
 			return
 
-/obj/item/stack/proc/use(var/used)
+/obj/item/stack/proc/use(used)
 	if(amount < used)
 		return 0
 	amount -= used
 	if(amount < 1) // Just in case a stack's amount ends up fractional somehow
+		if(isrobot(loc))
+			var/mob/living/silicon/robot/R = loc  //Horrifying cyborg snowflake code that allows stacks to GC and cyborgs not to horrendously break
+			if(locate(src) in R.module.modules)
+				R.module.modules -= src
 		if(usr)
-			usr.unEquip(src, 1)
-		spawn()
-			qdel(src)
+			usr.unEquip(src, TRUE) // this has to be unEquip() over drop_item() or something similar because of cyborgs
+		qdel(src)
 	update_icon()
 	return 1
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -233,7 +233,7 @@
 
 /mob/living/silicon/robot/unEquip(obj/item/I)
 	if(I == module_active)
-		deselect_module(get_selected_module())
+		uneq_active(I)
 	return ..()
 
 /mob/living/silicon/robot/proc/update_module_icon()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -54,7 +54,6 @@
 		var/obj/item/stack/S = O
 
 		if(!S)
-			modules -= null
 			S = new T(src)
 			modules += S
 			S.amount = 1
@@ -124,10 +123,10 @@
 	module_type = "Medical"
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor)
 	stacktypes = list(
-		/obj/item/stack/medical/bruise_pack/advanced = 5,
-		/obj/item/stack/medical/ointment/advanced = 5,
-		/obj/item/stack/medical/splint = 5,
-		/obj/item/stack/nanopaste = 5
+		/obj/item/stack/medical/bruise_pack/advanced = 6,
+		/obj/item/stack/medical/ointment/advanced = 6,
+		/obj/item/stack/medical/splint = 6,
+		/obj/item/stack/nanopaste = 6
 		)
 
 /obj/item/weapon/robot_module/medical/New()


### PR DESCRIPTION
Makes stacks garbage collect. To my knowledge, they actually did GC fairly well, but they wrecked absolute havoc on cyborgs (the stacks wouldn't respawn and the borg's module would get gunked up until the item was hard deleted). This makes it so they do, in fact, GC with borgs.

Due to how crazy cyborgs are coded, this really couldn't _not_ be snowflaked, sadly.

Also fixes some inconsistency with cyborgs stacks and nanopaste stacks in terms of total number (they're all 6 now).

:cl: Fox McCloud
fix: Fixes medical cyborgs having one less stack than they should have they recharge
fix: Fixes inconsistency in the medical stacks amounts (they should all be 6)
/:cl:

