### PR TITLE
Makes Records GC (most of the time)

### DIFF
--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -22,8 +22,15 @@
 	var/list/fields = list(  )
 
 /datum/data/record/Destroy()
-	..()
-	return QDEL_HINT_HARDDEL_NOW
+	if(src in data_core.medical)
+		data_core.medical -= src
+	if(src in data_core.security)
+		data_core.security -= src
+	if(src in data_core.general)
+		data_core.general -= src
+	if(src in data_core.locked)
+		data_core.locked -= src
+	. = ..()
 
 /datum/data/text
 	name = "text"

--- a/code/datums/mixed.dm
+++ b/code/datums/mixed.dm
@@ -30,7 +30,7 @@
 		data_core.general -= src
 	if(src in data_core.locked)
 		data_core.locked -= src
-	. = ..()
+	return ..()
 
 /datum/data/text
 	name = "text"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -5,7 +5,7 @@
 #define MED_DATA_V_DATA	5	// Virus database
 #define MED_DATA_MEDBOT	6	// Medbot monitor
 
-/obj/machinery/computer/med_data//TODO:SANITY
+/obj/machinery/computer/med_data //TODO:SANITY
 	name = "medical records console"
 	desc = "This can be used to check medical records."
 	icon_keyboard = "med_key"
@@ -22,6 +22,11 @@
 	var/printing = null
 
 	light_color = LIGHT_COLOR_DARKBLUE
+
+/obj/machinery/computer/med_data/Destroy()
+	active1 = null
+	active2 = null
+	return ..()
 
 /obj/machinery/computer/med_data/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/weapon/card/id) && !scan)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -24,6 +24,10 @@
 
 	light_color = LIGHT_COLOR_RED
 
+/obj/machinery/computer/secure_data/Destroy()
+	active1 = null
+	active2 = null
+	return ..()
 
 /obj/machinery/computer/secure_data/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/weapon/card/id) && !scan)

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -23,6 +23,9 @@
 	var/sortBy = "name"
 	var/order = 1 // -1 = Descending - 1 = Ascending
 
+/obj/machinery/computer/skills/Destroy()
+	active1 = null
+	return ..()
 
 /obj/machinery/computer/skills/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/weapon/card/id) && !scan)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -99,7 +99,6 @@
 	var/rank = null			//actual job
 	var/dorm = 0			// determines if this ID has claimed a dorm already
 
-	var/datum/data/record/active1 = null
 	var/sex
 	var/age
 	var/photo

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -118,6 +118,14 @@
 		C.toff = 1
 	..()
 
+/mob/living/silicon/pai/Destroy()
+	medicalActive1 = null
+	medicalActive2 = null
+	securityActive1 = null
+	securityActive2 = null
+	return ..()
+
+
 /mob/living/silicon/pai/movement_delay()
 	. = ..()
 	. += slowdown


### PR DESCRIPTION
Makes data records GC, most of the time.

There's still cases where they won't GC (such as if someone is viewing a record on a console), but this should handle records failing to GC most of the time.

I'm prepared to convert this back over to `QDEL_HINT_HARDDEL_NOW` if this starts causing issues with infinite loop "so and so has entered cryo" or officers not being able to clear out/set arrest warrant status.

I'm *decently* sure that these shouldn't happen as `qdel` a record will mean that their hanging reference won't be in the `data_core` anymore.