### PR TITLE
Fixes issues with chem smoke bombs

### DIFF
--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -72,6 +72,7 @@
 			var/fraction = 0.5/(2 ** distance) //50/25/12/6... for a 200u splash, 25/12/6/3... for a 100u, 12/6/3/1 for a 50u
 			splash_holder.reaction(A, TOUCH, fraction)
 
+	spawn(0)
 	qdel(splash_holder)
 	return 1
 


### PR DESCRIPTION
So it turns out that smoke bombs (and their contents) are deleted before they transfer their contents to the smoke because the smoke isn't set up immediately.

This caused all chemical smoke bombs not to function at all.

The solution was just to make the bomb wait before deleting its chemical holder.
Fixes #8636

🆑 Dyhr
fix: Chemical smoke bombs are no longer deleted before they emit smoke
/🆑