### PR TITLE
Changed defib timer from 3 minutes to 5 minutes

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -356,7 +356,7 @@
 
 				QDEL_NULL(ghost)
 			var/tplus = world.time - H.timeofdeath
-			var/tlimit = 1800 //past this much time the patient is unrecoverable (in deciseconds)
+			var/tlimit = 3000 //past this much time the patient is unrecoverable (in deciseconds)
 			var/tloss = 600 //brain damage starts setting in on the patient after some time left rotting
 			var/total_burn	= 0
 			var/total_brute	= 0
@@ -501,7 +501,7 @@
 
 				QDEL_NULL(ghost)
 			var/tplus = world.time - H.timeofdeath
-			var/tlimit = 1800 //past this much time the patient is unrecoverable (in deciseconds)
+			var/tlimit = 3000 //past this much time the patient is unrecoverable (in deciseconds)
 			var/tloss = 600 //brain damage starts setting in on the patient after some time left rotting
 			var/total_burn	= 0
 			var/total_brute	= 0


### PR DESCRIPTION
This changes the defib time limit from three minutes to five minutes.

A long time ago, it used to be 10 minutes, which I agree that it was far too much time. 3 minutes is the current defib time and it is a tad too short... With 5 minutes, there's still a rush to get people there, but now it's actually possible to do a little bit of triage and still get the defib in.

This does NOT change the fact that brain damage sets in after one minute.

🆑 Anticept
tweak: Changed defib timer from 3 minutes to 5 minutes
/🆑