### PR TITLE
Syndies and Security can wipe their headsets

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -180,6 +180,9 @@
 /datum/action/item_action/toggle_headphones
 	name = "Toggle Headphones"
 
+/datum/action/item_action/wipe_headset
+	name = "Wipe Headset Keys"
+
 /datum/action/item_action/toggle_helmet_light
 	name = "Toggle Helmet Light"
 


### PR DESCRIPTION
Follow up to #8595

Adds an action button for headset wiping. Using it will reduce all encryption keys from the headset into their component atoms.

Bowman headsets with access to sec/command have this ability.

The syndicate encryption key is a little different. Adding it to a headset will add the action button, but wiping it will only wipe the syndicate encryption key and remove the action, if the headset didn't start off with the wiping ability. If you add a syndi encryption key to a bowman headest with wiping already, wiping it the first time will wipe the syndi encryption key without removing the wipe ability. Wiping it again will wipe its sec access. tldr wiping your syndi encryption key will leave no trace no matter what headset you're using.

![capture](https://user-images.githubusercontent.com/26497062/38760056-c794d912-3f3e-11e8-8705-5215219fd63d.PNG)


:cl: Tayyyyyyy
add: Syndicate encryption key can be wiped with an action button.
add: Security/command bowman headsets can be wiped with an action button.
/:cl: