### PR TITLE
Cable coils can transfer part of a stack

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -13,6 +13,7 @@
 	var/list/recipes = list() // /datum/stack_recipe
 	var/singular_name
 	var/amount = 1
+	var/to_transfer = 0
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/merge_type = null // This path and its children should merge with this stack, defaults to src.type
 
@@ -231,6 +232,9 @@
 /obj/item/stack/proc/get_max_amount()
 	return max_amount
 
+/obj/item/stack/proc/get_amount_transferred()
+	return to_transfer
+
 /obj/item/stack/proc/split(mob/user, amt)
 	var/obj/item/stack/F = new type(loc, amt)
 	F.copy_evidences(src)
@@ -257,7 +261,6 @@
 		if(S.amount >= max_amount)
 			return 1
 
-		var/to_transfer
 		if(user.is_in_inactive_hand(src))
 			var/desired = input("How much would you like to transfer from this stack?", "How much?", 1) as null|num
 			if(!desired)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -13,6 +13,7 @@
 	var/list/recipes = list() // /datum/stack_recipe
 	var/singular_name
 	var/amount = 1
+	var/to_transfer = 0
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/merge_type = null // This path and its children should merge with this stack, defaults to src.type
 
@@ -231,7 +232,6 @@
 /obj/item/stack/proc/get_max_amount()
 	return max_amount
 
-var/to_transfer = 0
 /obj/item/stack/proc/get_amount_transferred()
 	return to_transfer
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -13,7 +13,6 @@
 	var/list/recipes = list() // /datum/stack_recipe
 	var/singular_name
 	var/amount = 1
-	var/to_transfer = 0
 	var/max_amount //also see stack recipes initialisation, param "max_res_amount" must be equal to this max_amount
 	var/merge_type = null // This path and its children should merge with this stack, defaults to src.type
 
@@ -232,6 +231,7 @@
 /obj/item/stack/proc/get_max_amount()
 	return max_amount
 
+var/to_transfer = 0
 /obj/item/stack/proc/get_amount_transferred()
 	return to_transfer
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -588,6 +588,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 	..()
 	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
+		// Cable merging is handled by parent proc
 		if(C.amount >= MAXCOIL)
 			to_chat(user, "The coil is as long as it will get.")
 			return

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -589,29 +589,14 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = W
 		if(C.amount >= MAXCOIL)
-			to_chat(user, "The coil is too long, you cannot add any more cable to it.")
+			to_chat(user, "The coil is as long as it will get.")
 			return
-
 		if( (C.amount + src.amount <= MAXCOIL) )
 			to_chat(user, "You join the cable coils together.")
-			C.give(src.amount) // give it cable
-			src.use(src.amount) // make sure this one cleans up right
 			return
-
 		else
-			var/amt = MAXCOIL - C.amount
-			to_chat(user, "You transfer [amt] length\s of cable from one coil to the other.")
-			C.give(amt)
-			src.use(amt)
+			to_chat(user, "You transfer [get_amount_transferred()] length\s of cable from one coil to the other.")
 			return
-
-//add cables to the stack
-/obj/item/stack/cable_coil/proc/give(var/extra)
-	if(amount + extra > MAXCOIL)
-		amount = MAXCOIL
-	else
-		amount += extra
-	update_icon()
 
 ///////////////////////////////////////////////
 // Cable laying procedures


### PR DESCRIPTION
Previously you had to transfer the whole stack

Cable coils now allow you to transfer a part of the stack

Stack handling from cable.dm is removed ( .use() .give() )  as stack.dm already handles it

Previously the message would state the cable coil was to long, however if you merge a 5 and 25 stack it would reach the max length and wouldn't be to long, changed the message to "The coil is as long as it will get." to fit both cases of being exact maximum length and trying to fit excessive amounts of coil

:cl:
tweak: Cable coils now allow you to transfer a part of the stack
del: Stack handling from cable.dm is removed as stack.dm already handles it
tweak: Changed cable coil message
/:cl: