### PR TITLE
Kitchen machinery now calls ..() in New()

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/kitchen_machine.dm
@@ -32,6 +32,7 @@
 ********************/
 
 /obj/machinery/kitchen_machine/New()
+	..()
 	create_reagents(100)
 	reagents.set_reacting(FALSE)
 	if(!available_recipes)


### PR DESCRIPTION
Fixes an oversight in the code. Currently, when you examine kitchen machinery, it tells you it's falling apart. This fixes that. (Also everything should call `..()` in `New()` anyways)

![image](https://user-images.githubusercontent.com/18459142/38768403-1bf390c8-3feb-11e8-8c0d-19dace8737f8.png)

:cl:
fix: Kitchen machinery no longer looks as if it is falling apart.
/:cl: