### PR TITLE
Makes Pipenets Actually Rebuild and Pipes GC

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -57,6 +57,7 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/Destroy()
 	QDEL_NULL(stored)
 	SSair.atmos_machinery -= src
+	SSair.deferred_pipenet_rebuilds -= src
 	for(var/mob/living/L in src) //ventcrawling is serious business
 		L.remove_ventcrawl()
 		L.forceMove(get_turf(src))
@@ -143,12 +144,13 @@ Pipelines + Other Objects -> Pipe network
 /obj/machinery/atmospherics/proc/replacePipenet()
 	return
 
-/obj/machinery/atmospherics/proc/build_network()
+/obj/machinery/atmospherics/proc/build_network(remove_deferral = FALSE)
 	// Called to build a network from this node
-	return
+	if(remove_deferral)
+		SSair.deferred_pipenet_rebuilds -= src
 
 /obj/machinery/atmospherics/proc/defer_build_network()
-	deferred_pipenet_rebuilds += src
+	SSair.deferred_pipenet_rebuilds += src
 
 /obj/machinery/atmospherics/proc/disconnect(obj/machinery/atmospherics/reference)
 	return

--- a/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/binary_atmos_base.dm
@@ -67,7 +67,7 @@
 	update_icon()
 	update_underlays()
 
-/obj/machinery/atmospherics/binary/build_network()
+/obj/machinery/atmospherics/binary/build_network(remove_deferral = FALSE)
 	if(!parent1)
 		parent1 = new /datum/pipeline()
 		parent1.build_pipeline(src)
@@ -75,6 +75,7 @@
 	if(!parent2)
 		parent2 = new /datum/pipeline()
 		parent2.build_pipeline(src)
+	..()
 
 /obj/machinery/atmospherics/binary/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)

--- a/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
+++ b/code/ATMOSPHERICS/components/omni_devices/omni_base.dm
@@ -237,11 +237,12 @@
 	return
 
 // Pipenet procs
-/obj/machinery/atmospherics/omni/build_network()
+/obj/machinery/atmospherics/omni/build_network(remove_deferral = FALSE)
 	for(var/datum/omni_port/P in ports)
 		if(!P.parent)
 			P.parent = new /datum/pipeline()
 			P.parent.build_pipeline(src)
+	..()
 
 /obj/machinery/atmospherics/omni/disconnect(obj/machinery/atmospherics/reference)
 	for(var/datum/omni_port/P in ports)

--- a/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
+++ b/code/ATMOSPHERICS/components/trinary_devices/trinary_base.dm
@@ -104,7 +104,7 @@
 	update_icon()
 	update_underlays()
 
-/obj/machinery/atmospherics/trinary/build_network()
+/obj/machinery/atmospherics/trinary/build_network(remove_deferral = FALSE)
 	if(!parent1)
 		parent1 = new /datum/pipeline()
 		parent1.build_pipeline(src)
@@ -116,6 +116,7 @@
 	if(!parent3)
 		parent3 = new /datum/pipeline()
 		parent3.build_pipeline(src)
+	..()
 
 /obj/machinery/atmospherics/trinary/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)

--- a/code/ATMOSPHERICS/components/unary_devices/unary_base.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/unary_base.dm
@@ -50,10 +50,11 @@
 		build_network()
 		. = 1
 
-/obj/machinery/atmospherics/unary/build_network()
+/obj/machinery/atmospherics/unary/build_network(remove_deferral = FALSE)
 	if(!parent)
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
+	..()
 
 /obj/machinery/atmospherics/unary/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node)

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -1,5 +1,3 @@
-var/global/list/deferred_pipenet_rebuilds = list()
-
 /datum/pipeline
 	var/datum/gas_mixture/air
 	var/list/datum/gas_mixture/other_airs = list()

--- a/code/ATMOSPHERICS/pipes/pipe.dm
+++ b/code/ATMOSPHERICS/pipes/pipe.dm
@@ -66,10 +66,11 @@
 		return 0
 	return parent.air
 
-/obj/machinery/atmospherics/pipe/build_network()
+/obj/machinery/atmospherics/pipe/build_network(remove_deferral = FALSE)
 	if(!parent)
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
+	..()
 
 /obj/machinery/atmospherics/pipe/setPipenet(datum/pipeline/P)
 	parent = P

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -27,6 +27,7 @@ SUBSYSTEM_DEF(air)
 	var/list/excited_groups = list()
 	var/list/active_turfs = list()
 	var/list/hotspots = list()
+	var/list/deferred_pipenet_rebuilds = list()
 	var/list/networks = list()
 	var/list/atmos_machinery = list()
 	var/list/pipe_init_dirs_cache = list()
@@ -39,7 +40,7 @@ SUBSYSTEM_DEF(air)
 
 
 	var/list/currentrun = list()
-	var/currentpart = SSAIR_PIPENETS
+	var/currentpart = SSAIR_DEFERREDPIPENETS
 
 /datum/controller/subsystem/air/stat_entry(msg)
 	msg += "C:{"
@@ -141,7 +142,7 @@ SUBSYSTEM_DEF(air)
 		if(state != SS_RUNNING)
 			return
 		resumed = 0
-	currentpart = SSAIR_PIPENETS
+	currentpart = SSAIR_DEFERREDPIPENETS
 
 /datum/controller/subsystem/air/proc/process_deferred_pipenets(resumed = 0)
 	if(!resumed)
@@ -152,7 +153,7 @@ SUBSYSTEM_DEF(air)
 		var/obj/machinery/atmospherics/A = currentrun[currentrun.len]
 		currentrun.len--
 		if(A)
-			A.build_network()
+			A.build_network(remove_deferral = TRUE)
 		else
 			deferred_pipenet_rebuilds.Remove(A)
 		if(MC_TICK_CHECK)


### PR DESCRIPTION
Fixes pipenets almost never properly rebuilding (how this wasn't causing runtime errors and a plethora of other issues in atmos is beyond me).

This also ensures that when a deferred network is rebuilt, it's removed from the `deferred_pipenet_rebuilds` list; this is so the list doesn't bloat up and become huge, over time, anddd so that pipes will actually GC (right now, pipes almost never GC).

Lastly, moved the `deferred_pipenet_rebuilds` from being a global list to actually being on the air controller.