### PR TITLE
Removes Pipenet Deferring

### DIFF
--- a/code/ATMOSPHERICS/atmospherics.dm
+++ b/code/ATMOSPHERICS/atmospherics.dm
@@ -147,9 +147,6 @@ Pipelines + Other Objects -> Pipe network
 	// Called to build a network from this node
 	return
 
-/obj/machinery/atmospherics/proc/defer_build_network()
-	deferred_pipenet_rebuilds += src
-
 /obj/machinery/atmospherics/proc/disconnect(obj/machinery/atmospherics/reference)
 	return
 

--- a/code/ATMOSPHERICS/datum_pipeline.dm
+++ b/code/ATMOSPHERICS/datum_pipeline.dm
@@ -1,5 +1,3 @@
-var/global/list/deferred_pipenet_rebuilds = list()
-
 /datum/pipeline
 	var/datum/gas_mixture/air
 	var/list/datum/gas_mixture/other_airs = list()

--- a/code/ATMOSPHERICS/pipes/cap.dm
+++ b/code/ATMOSPHERICS/pipes/cap.dm
@@ -32,11 +32,9 @@
 		. = PROCESS_KILL
 
 /obj/machinery/atmospherics/pipe/cap/Destroy()
-	. = ..()
 	if(node)
 		node.disconnect(src)
-		node.defer_build_network()
-		node = null
+	return ..()
 
 /obj/machinery/atmospherics/pipe/cap/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node)

--- a/code/ATMOSPHERICS/pipes/manifold.dm
+++ b/code/ATMOSPHERICS/pipes/manifold.dm
@@ -73,20 +73,22 @@
 		. = PROCESS_KILL
 
 /obj/machinery/atmospherics/pipe/manifold/Destroy()
-	. = ..()
-
 	if(node1)
+		var/obj/machinery/atmospherics/A = node1
 		node1.disconnect(src)
-		node1.defer_build_network()
 		node1 = null
+		A.build_network()
 	if(node2)
+		var/obj/machinery/atmospherics/A = node2
 		node2.disconnect(src)
-		node2.defer_build_network()
 		node2 = null
+		A.build_network()
 	if(node3)
+		var/obj/machinery/atmospherics/A = node3
 		node3.disconnect(src)
-		node3.defer_build_network()
 		node3 = null
+		A.build_network()
+	return ..()
 
 /obj/machinery/atmospherics/pipe/manifold/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)

--- a/code/ATMOSPHERICS/pipes/manifold4w.dm
+++ b/code/ATMOSPHERICS/pipes/manifold4w.dm
@@ -32,24 +32,27 @@
 		. = PROCESS_KILL
 
 /obj/machinery/atmospherics/pipe/manifold4w/Destroy()
-	. = ..()
-
 	if(node1)
+		var/obj/machinery/atmospherics/A = node1
 		node1.disconnect(src)
-		node1.defer_build_network()
 		node1 = null
+		A.build_network()
 	if(node2)
+		var/obj/machinery/atmospherics/A = node2
 		node2.disconnect(src)
-		node2.defer_build_network()
 		node2 = null
+		A.build_network()
 	if(node3)
+		var/obj/machinery/atmospherics/A = node3
 		node3.disconnect(src)
-		node3.defer_build_network()
 		node3 = null
+		A.build_network()
 	if(node4)
+		var/obj/machinery/atmospherics/A = node4
 		node4.disconnect(src)
-		node4.defer_build_network()
 		node4 = null
+		A.build_network()
+	return ..()
 
 /obj/machinery/atmospherics/pipe/manifold4w/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)

--- a/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
+++ b/code/ATMOSPHERICS/pipes/simple/pipe_simple.dm
@@ -101,16 +101,17 @@
 		dir = 4
 
 /obj/machinery/atmospherics/pipe/simple/Destroy()
-	. = ..()
-
 	if(node1)
+		var/obj/machinery/atmospherics/A = node1
 		node1.disconnect(src)
-		node1.defer_build_network()
 		node1 = null
+		A.build_network()
 	if(node2)
+		var/obj/machinery/atmospherics/A = node2
 		node2.disconnect(src)
-		node2.defer_build_network()
 		node2 = null
+		A.build_network()
+	return ..()
 
 /obj/machinery/atmospherics/pipe/simple/disconnect(obj/machinery/atmospherics/reference)
 	if(reference == node1)


### PR DESCRIPTION
An alternative to: https://github.com/ParadiseSS13/Paradise/pull/8882

Straight up removes pipenet deferring; makes pipes just rebuild their networks instantly on deletion.

This does technically make explosions and the singularity a bit more expensive by about 50-100%  (but you're talking 0.18 to 0.3-0.36, so that's not as bad as it sounds).

I'm not sure how much pipenet deferring is necessary these days; it's a double edged sword. It does mean that rebuilding the network takes place on a different tick other than the explosion, but when this was added in, the air controller only fired once every 2 seconds; now it fires once every 0.5, so...having it spread out isn't as impactful.

Why remove it? It's really not that useful from a performance perspective and it's the reason why pipes almost never GC.
