### PR TITLE
Adds nobludgeon to door remotes so they always work on doors

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -9,6 +9,7 @@
 	name = "control wand"
 	desc = "Remotely controls airlocks."
 	w_class = WEIGHT_CLASS_TINY
+	flags = NOBLUDGEON
 	var/mode = WAND_OPEN
 	var/region_access = 1 //See access.dm
 	var/obj/item/weapon/card/id/ID


### PR DESCRIPTION
Previously if you were within 1 tile of a door remote you would open the door. If you were on harm intent you would smack the door and use the remote.

No bludgeon makes it so the remote just works as expected. You use it on the door and it does the door remote effect.

:cl:
fix: Adds NOBLUDGEON to door_remote so the remote always triggers
/:cl:

Thanks to #8890 for pointing out the problem and how to fix it.
