### PR TITLE
Adds more viruses to the Viral Outbreak event

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -11,7 +11,7 @@
 
 /datum/event/disease_outbreak/start()
 	if(!virus_type)
-		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/gbs, /datum/disease/pierrot_throat, /datum/disease/rhumba_beat)
+		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/gbs, /datum/disease/pierrot_throat, /datum/disease/lycan)
 
 	for(var/mob/living/carbon/human/H in shuffle(living_mob_list))
 		if(issmall(H)) //don't infect monkies; that's a waste

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -11,7 +11,7 @@
 
 /datum/event/disease_outbreak/start()
 	if(!virus_type)
-		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/gbs, /datum/disease/pierrot_throat, /datum/disease/lycan)
+		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/fluspanish, /datum/disease/pierrot_throat, /datum/disease/lycan)
 
 	for(var/mob/living/carbon/human/H in shuffle(living_mob_list))
 		if(issmall(H)) //don't infect monkies; that's a waste

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -11,7 +11,7 @@
 
 /datum/event/disease_outbreak/start()
 	if(!virus_type)
-		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis)
+		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/gbs, /datum/disease/pierrot_throat, /datum/disease/rhumba_beat)
 
 	for(var/mob/living/carbon/human/H in shuffle(living_mob_list))
 		if(issmall(H)) //don't infect monkies; that's a waste


### PR DESCRIPTION
As it is right now, nobody cares about this event since all the viruses are mundane.


This adds:

1. Beesease
2. Anxiety
3. Fake GBS
4. Spanish Flu
5. Pierrot Throat
6. Lycan

to the possible viruses in the Viral Outbreak random event.

🆑 More viruses added to the "Viral Outbreak" event / 🆑 