### PR TITLE
Death Squid hitbox adjustment

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/deathsquid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/deathsquid.dm
@@ -11,6 +11,8 @@
 	icon_state = "deathsquid"
 	icon_living = "deathsquid"
 	icon_dead = "deathsquiddead"
+	pixel_x = -24
+	pixel_y = -24
 
 	attacktext = "slices"
 	attack_sound = 'sound/weapons/bladeslice.ogg'


### PR DESCRIPTION
Corrects pull #8835 since @SkullyRoberts appears to be inactive for the time being. (Would have prefer to use existing PR, but..)

This PR attempts to offset the hitbox of the death squid so it is in the middle of the sprite.

:cl: 
Fixes: death squid hitbox position
/:cl: 