### PR TITLE
Adds F.R.A.M.E. Cartridge

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -874,6 +874,16 @@ var/list/uplink_items = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 	excludefrom = list()
 
+/datum/uplink_item/stealthy_tools/frame
+	name = "F.R.A.M.E. PDA Cartridge"
+	desc = "When inserted into a personal digital assistant, this cartridge gives you five PDA viruses which \
+			when used cause the targeted PDA to become a new uplink with zero TCs, and immediately become unlocked.  \
+			You will receive the unlock code upon activating the virus, and the new uplink may be charged with \
+			telecrystals normally."
+	reference = "FRAME"
+	item = /obj/item/cartridge/frame
+	cost = 4
+
 /datum/uplink_item/stealthy_tools/agent_card
 	name = "Agent ID Card"
 	desc = "Agent cards prevent artificial intelligences from tracking the wearer, and can copy access from other identification cards. The access is cumulative, so scanning one card does not erase the access gained from another."
@@ -1152,6 +1162,20 @@ var/list/uplink_items = list()
 	item = /obj/item/stack/telecrystal
 	cost = 1
 	surplus = 0
+
+/datum/uplink_item/device_tools/telecrystal/five
+	name = "5 Raw Telecrystals"
+	desc = "Five telecrystals in their rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
+	reference = "RTCF"
+	item = /obj/item/stack/telecrystal/five
+	cost = 5
+
+/datum/uplink_item/device_tools/telecrystal/twenty
+	name = "20 Raw Telecrystals"
+	desc = "Twenty telecrystals in their rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
+	reference = "RTCT"
+	item = /obj/item/stack/telecrystal/twenty
+	cost = 20
 
 /datum/uplink_item/device_tools/jammer
 	name = "Radio Jammer"

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -11,6 +11,7 @@ var/list/world_uplinks = list()
 /obj/item/device/uplink
 	var/welcome 			// Welcoming menu message
 	var/uses 				// Numbers of crystals
+	var/hidden_crystals = 0
 	var/list/ItemsCategory	// List of categories with lists of items
 	var/list/ItemsReference	// List of references with an associated item
 	var/list/nanoui_items	// List of items for NanoUI use
@@ -231,6 +232,8 @@ var/list/world_uplinks = list()
 			return 1
 		else if(href_list["lock"])
 			toggle()
+			uses += hidden_crystals
+			hidden_crystals = 0
 			ui.close()
 			return 1
 		if(href_list["return"])

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -32,7 +32,7 @@
 			return
 		cart.telecrystals += amount
 		use(amount)
-		to_chat(user, "<span class='notice'>You slot [src] into the [cart].  The next time it's used, it will also give telecrystals</span>")
+		to_chat(user, "<span class='notice'>You slot [src] into [cart].  The next time it's used, it will also give telecrystals</span>")
 
 /obj/item/stack/telecrystal/five
 	amount = 5

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -21,7 +21,7 @@
 /obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
 	if(!proximity)
 		return
-	if(istype(I, /obj/item) && I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
+	if(istype(I) && I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
 		I.hidden_uplink.uses += amount
 		use(amount)
 		to_chat(user, "<span class='notice'>You slot [src] into [I] and charge its internal uplink.</span>")

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -10,19 +10,32 @@
 	flags = NOBLUDGEON
 	origin_tech = "materials=6;syndicate=1"
 
-/obj/item/stack/telecrystal/attack(mob/target as mob, mob/user as mob)
+/obj/item/stack/telecrystal/attack(mob/target, mob/user)
 	if(target == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.
 		for(var/obj/item/implant/uplink/I in target)
-			if(I && I.implanted)
-				I.hidden_uplink.uses +=1
-				use(1)
-				to_chat(user, "<span class='notice'>You press the [src] onto yourself and charge your hidden uplink.</span>")
+			if(I && I.imp_in)
+				I.hidden_uplink.uses += amount
+				use(amount)
+				to_chat(user, "<span class='notice'>You press [src] onto yourself and charge your hidden uplink.</span>")
 
-/obj/item/stack/telecrystal/afterattack(var/obj/item/I as obj, mob/user as mob, proximity)
+/obj/item/stack/telecrystal/afterattack(obj/item/I, mob/user, proximity)
 	if(!proximity)
 		return
-	if(istype(I, /obj/item))
-		if(I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
-			I.hidden_uplink.uses +=1
-			use(1)
-			to_chat(user, "<span class='notice'>You slot the [src] into the [I] and charge its internal uplink.</span>")
+	if(istype(I, /obj/item) && I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
+		I.hidden_uplink.uses += amount
+		use(amount)
+		to_chat(user, "<span class='notice'>You slot [src] into [I] and charge its internal uplink.</span>")
+	else if(istype(I, /obj/item/cartridge/frame))
+		var/obj/item/cartridge/frame/cart = I
+		if(!cart.charges)
+			to_chat(user, "<span class='notice'>[cart] is out of charges, it's refusing to accept [src]</span>")
+			return
+		cart.telecrystals += amount
+		use(amount)
+		to_chat(user, "<span class='notice'>You slot [src] into the [cart].  The next time it's used, it will also give telecrystals</span>")
+
+/obj/item/stack/telecrystal/five
+	amount = 5
+
+/obj/item/stack/telecrystal/twenty
+	amount = 20

--- a/code/modules/pda/cart.dm
+++ b/code/modules/pda/cart.dm
@@ -296,6 +296,13 @@
 	if(istype(D))
 		D.remote_door_id = initial_remote_door_id
 
+/obj/item/cartridge/frame
+	name = "F.R.A.M.E. cartridge"
+	icon_state = "cart"
+	charges = 5
+	var/telecrystals = 0
+	messenger_plugins = list(new/datum/data/pda/messenger_plugin/virus/frame)
+
 /obj/item/cartridge/mob_hunt_game
 	name = "Nano-Mob Hunter GO! Cartridge"
 	desc = "The hit new PDA game that lets you track down and capture your favorite Nano-Mobs living in your world!"

--- a/code/modules/pda/messenger_plugins.dm
+++ b/code/modules/pda/messenger_plugins.dm
@@ -73,3 +73,22 @@
 			log_admin("[key_name(user)] just attempted to blow up [P] with the Detomatix cartridge and succeded")
 			message_admins("[key_name_admin(user)] just attempted to blow up [P] with the Detomatix cartridge and succeded", 1)
 			P.explode()
+
+/datum/data/pda/messenger_plugin/virus/frame
+	icon = "exclamation-circle"
+
+/datum/data/pda/messenger_plugin/virus/frame/user_act(mob/user, obj/item/device/pda/P)
+	. = ..(user, P)
+	if(.)
+		var/lock_code = "[rand(100,999)] [pick("Alpha","Bravo","Charlie","Delta","Echo","Foxtrot","Golf","Hotel","India","Juliet","Kilo","Lima","Mike","November","Oscar","Papa","Quebec","Romeo","Sierra","Tango","Uniform","Victor","Whiskey","X-ray","Yankee","Zulu")]"
+		user.show_message("<span class='notice'>Virus Sent!  The unlock code to the target is: [lock_code]</span>")
+		if(!P.hidden_uplink)
+			var/obj/item/device/uplink/hidden/uplink = new(P)
+			P.hidden_uplink = uplink
+			P.lock_code = lock_code
+		else
+			P.hidden_uplink.hidden_crystals += P.hidden_uplink.uses //Temporarially hide the PDA's crystals, so you can't steal telecrystals.
+		var/obj/item/cartridge/frame/parent_cart = pda.cartridge
+		P.hidden_uplink.uses = parent_cart.telecrystals
+		parent_cart.telecrystals = 0
+		P.hidden_uplink.active = TRUE


### PR DESCRIPTION
Ports @lordpidey's F.R.A.M.E. cartridge: https://github.com/tgstation/tgstation/pull/28113

How this cartridge works: you insert it into your PDA and can send a virus to anyone who has their messenger on. Upon receiving a virus, that person will be given a hidden uplink and it will be forced open. The person who *sent* the virus will get the unlock code for the PDA. Additionally, the cartridge can be charged with raw telecrystal; if you then send someone this virus, it will not only force open the uplink, but give them that telecrystal as well.

There's a few caveats here: If you send the virus to someone who already has a hidden uplink, it does *not* change their lock code. The reason for this is so traitors can't just send this to another traitor, then steal all their TC. Additionally, no matter how many TC the person actually has, sending a person the virus will always display their TC as how much you sent to them---again, to prevent out and out TC theft.

The purpose of this item? Well, as the name implies, you can "frame" someone. That said, its larger functionality pretty much destroys security's ability to uplink peak and nail the person as a traitor instantly. Just because someone has an uplink doesn't automatically mean they're a traitor anymore; they could have been framed.

The clever among you have probably already noted that you could use this as a "traitor check", but you'd be incorrect. While, as an officer, you could send this to a suspected traitor, and if the lock code that you get doesn't work, it *does* confirm their PDA has an uplink; that said, it tells you nothing about the origin of their uplink. They could have been sent a virus before, they could be a traitor. You have no way of knowing.

End result: meta'ing someone as a tator-tot is going to be impossible based upon uplink alone; you'll need other evidence to slam them in permabrig. Maybe they're a traitor, maybe they're a victim; you won't be able to know.

Also makes a minor tweak to raw telecrystal so that using it on yourself or an active uplink just transfers it all at once, instead of one at a time.

Lastly, adds 5 and 20 telecrystal bundles to the uplink, so you don't have to sit there and spam click raw telecrystal 20 times if you want to buy a bunch.

:cl: Fox McCloud
add: Destroys uplink metagaming: Adds in F.R.A.M.E. cartridge
tweak: using raw telecrystal on an active uplink or yourself will use the entire stack at once
add: can purchase 5 and 20 unit TC bundles from the uplink
/:cl: