### PR TITLE
Create tgstation.dme symlink for mapdiffbot

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1,0 +1,1 @@
+paradise.dme


### PR DESCRIPTION
This should work correctly when cloned on a linux machine...