### PR TITLE
Fixed Unathi tail lash logic

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -93,7 +93,7 @@
 
 /datum/action/innate/tail_lash/Activate()
 	var/mob/living/carbon/human/user = owner
-	if(!user.restrained() || !user.buckled)
+	if(user.restrained() || user.buckled)
 		to_chat(user, "<span class='warning'>You need freedom of movement to tail lash!</span>")
 		return
 	if(user.getStaminaLoss() >= 50)


### PR DESCRIPTION
This change allows tail lash to actually work.

I'm a bit discontent about the fact that part of the tail lash merge included a brute damage increase for unathi, this is sort of backwards from lore. I figure perhaps it is supposed to offset tail lash.

Upon limited testing though, tail lash is limited in damage, very random what part it hits, and takes a lot of stamina from the user. However, I believe it better to see how tail lash works out first before creating a PR to redo balance...

That said, tail lash has hilarious meme potential... seeing a bunch of unathi spinning down the hall lashing everything long the way would be intimidating!

🆑 Anticept
fix: Unathi tail lash logic fixed.
/🆑