### PR TITLE
Adds the Aurora Caelus event, the deep-space equivalent of the northern lights.

### DIFF
--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -30,3 +30,5 @@ var/list/round_end_sounds = list( // Maps available round end sounds to their du
 		'sound/goonstation/misc/newround1.ogg' = 6.9 SECONDS,
 		'sound/goonstation/misc/newround2.ogg' = 14.8 SECONDS
 		)
+
+GLOBAL_LIST(station_level_space_turfs)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -19,7 +19,10 @@
 
 	if(!istype(src, /turf/space/transit))
 		icon_state = SPACE_ICON_STATE
-	update_starlight()
+	if(update_starlight() && is_station_level(z))
+	// before you ask: Yes, this is fucking stupid, but looping through turf/space in world is how you make the server freeze 
+	// so I don't see a better way of doing this
+		LAZYADD(GLOB.station_level_space_turfs, src)
 
 /turf/space/Destroy(force)
 	if(force)
@@ -43,11 +46,13 @@
 
 /turf/space/proc/update_starlight()
 	if(!config.starlight)
-		return
+		return FALSE
 	if(locate(/turf/simulated) in orange(src,1))
 		set_light(config.starlight)
+		return TRUE
 	else
 		set_light(0)
+		return FALSE
 
 /turf/space/attackby(obj/item/C as obj, mob/user as mob, params)
 	..()

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -1,0 +1,51 @@
+/datum/event/aurora_caelus
+	announceWhen = 5
+	startWhen = 1
+	endWhen = 50
+	var/list/aurora_colors = list("#A2FF80", "#A2FF8B", "#A2FF96", "#A2FFA5", "#A2FFB6", "#A2FFC7", "#A2FFDE")
+	var/aurora_progress = 0 //this cycles from 1 to 7, slowly changing colors from gentle green to gentle blue
+
+/datum/event/aurora_caelus/announce()
+	event_announcement.Announce("[station_name()]: A harmless cloud of ions is approaching your station, and will exhaust their energy battering the hull.\
+Nanotrasen has approved a short break for all employees to relax and observe this very rare event.\
+During this time, starlight will be bright but gentle, shifting between quiet green and blue colors.\
+Any staff who would like to view these lights for themselves may proceed to the area nearest to them with viewing ports to open space.\
+We hope you enjoy the lights.", "Harmless ions approaching", new_sound = 'sound/misc/notice2.ogg', from = "Nanotrasen Meterology Divison")
+	for(var/V in player_list)
+		var/mob/M = V
+		if((M.client.prefs.toggles & SOUND_MIDI) && is_station_level(M.z))
+			M.playsound_local(null, 'sound/ambience/aurora_caelus.ogg', 20, FALSE, pressure_affected = FALSE)
+
+/datum/event/aurora_caelus/start()
+	for(var/s in GLOB.station_level_space_turfs)
+		var/turf/space/S = s
+		S.set_light(S.light_range * 3, S.light_power * 0.5, aurora_colors[1])
+		CHECK_TICK
+
+/datum/event/aurora_caelus/tick()
+	if(aurora_progress >= aurora_colors.len)
+		return
+	if(activeFor % 5 == 0)
+		aurora_progress++
+		var/aurora_color = aurora_colors[aurora_progress]
+		for(var/s in GLOB.station_level_space_turfs)
+			var/turf/space/S = s
+			S.set_light(l_color = aurora_color)
+			CHECK_TICK
+
+/datum/event/aurora_caelus/end()
+	for(var/s in GLOB.station_level_space_turfs)
+		var/turf/space/S = s
+		fade_to_black(S)
+	event_announcement.Announce("The aurora caelus event is now ending. Starlight conditions will slowly return to normal.\
+When this has concluded, please return to your workplace and continue work as normal.\
+Have a pleasant shift, [station_name()], and thank you for watching with us.",
+"Harmless ions approaching", new_sound = 'sound/misc/notice2.ogg', from = "Nanotrasen Meterology Divison")
+
+/datum/event/aurora_caelus/proc/fade_to_black(turf/space/S)
+	set waitfor = FALSE
+	var/new_light = config.starlight
+	while(S.light_range > new_light)
+		S.set_light(S.light_range - 0.2)
+		sleep(30)
+	S.set_light(new_light, 1, l_color = "") // we should be able to use `, null` as the last arg but BYOND is a piece of FUCKING SHIT AND SET_LIGHT DOESN'T WORK THAT WAY DESPITE EVERY FUCKING THING ABOUT IT INDICATING THAT IT GODDAMN WELL SHOULD AAAAAAAAAAAAAAAAA

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -138,7 +138,8 @@ var/list/event_last_fired = list()
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 		/datum/event/mundane_news, 		300),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation, 		100,	list(ASSIGNMENT_JANITOR = 100)),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Sentience",			/datum/event/sentience,			50),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50))
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",			/datum/event/wallrot, 			0,		list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_GARDENER = 50)),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Aurora Caelus",		/datum/event/aurora_caelus,		15,		is_one_shot = TRUE)
 	)
 
 /datum/event_container/moderate

--- a/paradise.dme
+++ b/paradise.dme
@@ -1323,6 +1323,7 @@
 #include "code\modules\events\anomaly_grav.dm"
 #include "code\modules\events\anomaly_pyro.dm"
 #include "code\modules\events\anomaly_vortex.dm"
+#include "code\modules\events\aurora_caelus.dm"
 #include "code\modules\events\blob.dm"
 #include "code\modules\events\brand_intelligence.dm"
 #include "code\modules\events\carp_migration.dm"

--- a/sound/ambience/license.txt
+++ b/sound/ambience/license.txt
@@ -1,0 +1,2 @@
+aurora_caelus.ogg is Music for Manatees, by Kevin Macleod. It has been licensed under CC-BY 3.0 license.
+	It has been cropped for use ingame, and also fades out.


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/35987


![https://s3.us-west-1.amazonaws.com/katherine.sharex/2018/04/2018-04-22_20-06-12.webm](https://s3.us-west-1.amazonaws.com/katherine.sharex/2018/04/waterfox_2018-04-22_20-10-18.png)

https://s3.us-west-1.amazonaws.com/katherine.sharex/2018/04/2018-04-22_20-06-12.webm

This includes music that plays to anyone with midi prefs enabled. The music itself is Music for Manatees by Kevin Macleod, and is licensed under the CC-BY 3.0 license. It has been shortened to just under two minutes for in-game use. Proper attributions have been included.

🆑 Xhuis
add: The Nanotrasen Meteorology Division has identified the aurora caelus in your sector. If you are lucky, you may get a chance to witness it with your own eyes.
/🆑