### PR TITLE
Hide PM mob name from non-admins

### DIFF
--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -1,5 +1,11 @@
 // Always return "Something/(Something)", even if it's an error message.
 /proc/key_name(whom, include_link = FALSE, type = null)
+	return key_name_helper(whom, TRUE, include_link, type)
+
+/proc/key_name_hidden(whom, include_link = FALSE, type = null)
+	return key_name_helper(whom, FALSE, include_link, type)
+
+/proc/key_name_helper(whom, include_name, include_link = FALSE, type = null)
 	if(include_link != FALSE && include_link != TRUE)
 		log_runtime(EXCEPTION("Key_name was called with an incorrect include_link [include_link]"))
 
@@ -34,7 +40,7 @@
 	. = ""
 
 	if(key)
-		if(C && C.holder && C.holder.fakekey)
+		if(C && C.holder && C.holder.fakekey && !include_name)
 			if(include_link)
 				. += "<a href='?priv_msg=[C.findStealthKey()];type=[type]'>"
 			. += "Administrator"
@@ -49,14 +55,15 @@
 	else
 		. += "INVALID"
 
-	var/name = "INVALID"
-	if(M)
-		if(M.real_name)
-			name = M.real_name
-		else if(M.name)
-			name = M.name
+	if(include_name)
+		var/name = "INVALID"
+		if(M)
+			if(M.real_name)
+				name = M.real_name
+			else if(M.name)
+				name = M.name
 
-	. += "/([name])"
+		. += "/([name])"
 
 	return .
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -152,9 +152,9 @@
 
 
 	var/emoji_msg = "<span class='emoji_enabled'>[msg]</span>"
-	recieve_message = "<span class='[recieve_span]'>[type] from-<b>[recieve_pm_type][key_name(src, TRUE, type)]</b>: [emoji_msg]</span>"
+	recieve_message = "<span class='[recieve_span]'>[type] from-<b>[recieve_pm_type][C.holder ? key_name(src, TRUE, type) : key_name_hidden(src, TRUE, type)]</b>: [emoji_msg]</span>"
 	to_chat(C, recieve_message)
-	to_chat(src, "<font color='blue'>[send_pm_type][type] to-<b>[key_name(C, TRUE, type)]</b>: [emoji_msg]</font>")
+	to_chat(src, "<font color='blue'>[send_pm_type][type] to-<b>[holder ? key_name(C, TRUE, type) : key_name_hidden(src, TRUE, type)]</b>: [emoji_msg]</font>")
 
 	/*if(holder && !C.holder)
 		C.last_pm_recieved = world.time


### PR DESCRIPTION
:cl: Tayyyyyyy
fix: You can't see admin character names in PMs
/:cl: