### PR TITLE
Cleanbot oversight

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -161,13 +161,14 @@
 		target_types += /obj/effect/decal/cleanable/blood/gibs/
 		target_types += /obj/effect/decal/cleanable/blood/tracks
 		target_types += /obj/effect/decal/cleanable/dirt
+		target_types += /obj/effect/decal/cleanable/trail_holder
 
 /mob/living/simple_animal/bot/cleanbot/proc/clean(obj/effect/decal/cleanable/target)
 	anchored = 1
 	icon_state = "cleanbot-c"
 	visible_message("<span class='notice'>[src] begins to clean up [target]</span>")
 	mode = BOT_CLEANING
-	spawn(50)
+	spawn(25)
 		if(mode == BOT_CLEANING)
 			QDEL_NULL(target)
 			anchored = 0

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -168,7 +168,7 @@
 	icon_state = "cleanbot-c"
 	visible_message("<span class='notice'>[src] begins to clean up [target]</span>")
 	mode = BOT_CLEANING
-	spawn(25)
+	spawn(50)
 		if(mode == BOT_CLEANING)
 			QDEL_NULL(target)
 			anchored = 0


### PR DESCRIPTION
This fixes them not cleaning blood trails

🆑 Kluys
Fix: Cleanblots not cleaning /obj/effect/decal/cleanable/trail_holder (blood trails)
/🆑