### PR TITLE
Fixes Cryo Ghosting

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -229,18 +229,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"
 	set name = "Re-enter Corpse"
-	if(!client)	return
-	if(!can_reenter_corpse)
-		to_chat(src, "<span class='warning'>You've given up your right to respawn!</span>")
+	if(!client)
 		return
-	if(!(mind && mind.current && can_reenter_corpse))
+	if(!mind || QDELETED(mind.current))
 		to_chat(src, "<span class='warning'>You have no body.</span>")
+		return
+	if(!can_reenter_corpse)
+		to_chat(src, "<span class='warning'>You cannot re-enter your body.</span>")
 		return
 	if(mind.current.key && copytext(mind.current.key,1,2)!="@")	//makes sure we don't accidentally kick any clients
 		to_chat(usr, "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>")
 		return
 
-	mind.current.ajourn=0
 	mind.current.key = key
 
 	var/obj/structure/morgue/Morgue = locate() in mind.current.loc

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -46,7 +46,6 @@
 	var/gen_record = ""
 	var/blinded = null
 	var/bhunger = 0			//Carbon
-	var/ajourn = 0
 	var/lying = 0
 	var/lying_prev = 0
 	var/canmove = 1


### PR DESCRIPTION
This *should* fix the respawning exploit/ghosting in cryo/re-entering corpse exploit.

I cannot 100% confirm this, as I've not been able to reproduce the bug, myself.

That said, I suspect the only reason this was possible was because of a dangling reference of the mind datum's `current` mob to something that hasn't *technically* been fully removed from the game yet.

The `QDELETED` check should resolve this.

Fixes https://github.com/ParadiseSS13/Paradise/issues/8844