### PR TITLE
Adds shock muzzle

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -129,6 +129,9 @@
 #define TINT_BLIND 3			//Threshold of tint level to obscure vision fully
 #define EYE_SHINE_THRESHOLD 6	//dark_view threshold past which a humanoid's eyes will 'shine' in the dark.
 
+#define EMOTE_VISUAL 1  //A mob emote is visual
+#define EMOTE_SOUND 2  //A mob emote is sound
+
 //Human sub-species
 #define isshadowling(A) (is_species(A, /datum/species/shadow/ling))
 #define isshadowlinglesser(A) (is_species(A, /datum/species/shadow/ling/lesser))

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -10,46 +10,67 @@
 
 	bomb_name = "voice-activated bomb"
 
-	describe()
-		if(recorded || listening)
-			return "A meter on [src] flickers with every nearby sound."
-		else
-			return "[src] is deactivated."
+/obj/item/assembly/voice/describe()
+	if(recorded || listening)
+		return "A meter on [src] flickers with every nearby sound."
+	else
+		return "[src] is deactivated."
 
-	hear_talk(mob/living/M as mob, msg)
-		hear_input(M, msg, 0)
+/obj/item/assembly/voice/hear_talk(mob/living/M as mob, msg)
+	hear_input(M, msg, 0)
 
-	hear_message(mob/living/M as mob, msg)
+/obj/item/assembly/voice/hear_message(mob/living/M as mob, msg)
 		hear_input(M, msg, 1)
 
-	proc/hear_input(mob/living/M as mob, msg, type)
-		if(!istype(M,/mob/living))
-			return
-		if(listening)
-			recorded = msg
-			recorded_type = type
-			listening = 0
-			var/turf/T = get_turf(src)	//otherwise it won't work in hand
-			T.visible_message("[bicon(src)] beeps, \"Activation message is [type ? "the sound when one [recorded]" : "'[recorded]'."]\"")
-		else
-			if(findtext(msg, recorded) && type == recorded_type)
-				pulse(0)
-				var/turf/T = get_turf(src)  //otherwise it won't work in hand
-				T.visible_message("<span class='warning'>[bicon(src)] beeps!</span>")
-
-	activate()
-		return // previously this toggled listning when not in a holder, that's a little silly.  It was only called in attack_self that way.
-
-
-	attack_self(mob/user)
-		if(!user || !secured)	return 0
-
-		listening = !listening
-		var/turf/T = get_turf(src)
-		T.visible_message("[bicon(src)] beeps, \"[listening ? "Now" : "No longer"] recording input.\"")
-		return 1
-
-
-	toggle_secure()
-		. = ..()
+/obj/item/assembly/voice/proc/hear_input(mob/living/M as mob, msg, type)
+	if(!istype(M,/mob/living))
+		return
+	if(listening)
+		recorded = msg
+		recorded_type = type
 		listening = 0
+		var/turf/T = get_turf(src)	//otherwise it won't work in hand
+		T.visible_message("[bicon(src)] beeps, \"Activation message is [type ? "the sound when one [recorded]" : "'[recorded]'."]\"")
+	else if(findtext(msg, recorded) && type == recorded_type)
+		pulse(0)
+		var/turf/T = get_turf(src)  //otherwise it won't work in hand
+		T.visible_message("<span class='warning'>[bicon(src)] beeps!</span>")
+
+/obj/item/assembly/voice/activate()
+	return // previously this toggled listning when not in a holder, that's a little silly.  It was only called in attack_self that way.
+
+
+/obj/item/assembly/voice/attack_self(mob/user)
+	if(!user || !secured)	return 0
+
+	listening = !listening
+	var/turf/T = get_turf(src)
+	T.visible_message("[bicon(src)] beeps, \"[listening ? "Now" : "No longer"] recording input.\"")
+	return 1
+
+
+/obj/item/assembly/voice/toggle_secure()
+	. = ..()
+	listening = 0
+
+/obj/item/assembly/voice/noise
+	name = "noise sensor"
+	desc = "A simple noise sensor that triggers on vocalizations other then speech."
+	icon_state = "voice"
+	materials = list(MAT_METAL=100, MAT_GLASS=10)
+	origin_tech = "magnets=1;engineering=1"
+	bomb_name = "noise-activated bomb"
+
+/obj/item/assembly/voice/noise/attack_self(mob/user)
+	return
+
+/obj/item/assembly/voice/noise/describe()
+	return "[src] does not appear to have any controls."
+
+/obj/item/assembly/voice/noise/hear_talk(mob/living/M as mob, msg)
+	return
+
+/obj/item/assembly/voice/hear_message(mob/living/M as mob, msg)
+	pulse(0)
+	var/turf/T = get_turf(src)  //otherwise it won't work in hand
+	T.visible_message("<span class='warning'>[bicon(src)] beeps!</span>")

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -130,7 +130,7 @@
 	materials = list(MAT_METAL=500, MAT_GLASS=50)
 
 /obj/item/clothing/mask/muzzle/safety/shock/attackby(obj/item/W, mob/user, params)
-	if(isscrewdriver(W))
+	if(isscrewdriver(W) && trigger)
 		to_chat(user, "<span class='notice'>You disassemble [src].</span>")
 		trigger.forceMove(get_turf(user))
 		trigger.master = null
@@ -140,7 +140,7 @@
 	else if(istype(W, /obj/item/assembly/signaler) || istype(W, /obj/item/assembly/voice))
 		if(istype(trigger, /obj/item/assembly/signaler) || istype(trigger, /obj/item/assembly/voice))
 			to_chat(user, "<span class='notice'>Something is already attached to [src].</span>")
-			return TRUE
+			return FALSE
 		if(!user.drop_item())
 			to_chat(user, "<span class='warning'>You are unable to insert [W] into [src].</span>")
 			return FALSE
@@ -152,7 +152,7 @@
 		return TRUE
 	else if(istype(W, /obj/item/assembly))
 		to_chat(user, "<span class='notice'>That won't fit in [src]. Perhaps a signaler or voice analyzer would?</span>")
-		return TRUE
+		return FALSE
 
 	return ..()
 
@@ -167,8 +167,8 @@
 
 /obj/item/clothing/mask/muzzle/safety/shock/proc/process_activation(var/obj/D, var/normal = 1, var/special = 1)
 	visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
-	if(can_shock(loc))
-		var/mob/M = can_shock(loc)
+	var/mob/M = can_shock(loc)
+	if(M)
 		to_chat(M, "<span class='danger'>You feel a sharp shock!</span>")
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(3, 1, M)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -121,6 +121,69 @@
 	security_lock = TRUE
 	locked = FALSE
 
+/obj/item/clothing/mask/muzzle/safety/shock
+	name = "shock muzzle"
+	desc = "A muzzle designed to prevent biting.  This one is fitted with a behavior correction system."
+	var/obj/item/assembly/trigger = null
+	origin_tech = "materials=1;engineering=1"
+
+/obj/item/clothing/mask/muzzle/safety/shock/attackby(obj/item/W, mob/user, params)
+	if(isscrewdriver(W))
+		to_chat(user, "<span class='notice'>You disassemble [src].</span>")
+		trigger.forceMove(get_turf(user))
+		trigger.master = null
+		trigger.holder = null
+		trigger = null
+	else if(trigger)
+		to_chat(user, "<span class='notice'>Something is already attached to [src].</span>")
+	else if(istype(W, /obj/item/assembly/signaler) || istype(W, /obj/item/assembly/voice))
+		user.drop_item()
+		trigger = W
+		trigger.forceMove(src)
+		trigger.master = src
+		trigger.holder = src
+		to_chat(user, "<span class='notice'>You attach the [W] to [src].</span>")
+	else
+		return ..()
+
+
+/obj/item/clothing/mask/muzzle/safety/shock/equipped(obj/item/clothing/C)
+	if(istype(C))
+		if(isliving(C.loc))
+			return C.loc
+	else if(isliving(loc))
+		return loc
+	return FALSE
+
+/obj/item/clothing/mask/muzzle/safety/shock/proc/process_activation(var/obj/D, var/normal = 1, var/special = 1)
+	visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
+	if(equipped(loc))
+		var/mob/M = equipped(loc)
+		to_chat(M, "<span class='danger'>You feel a sharp shock!</span>")
+		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
+		s.set_up(3, 1, M)
+		s.start()
+
+		M.Weaken(5)
+		if(ishuman(M))
+			M.Stuttering(1)
+			M.Jitter(20)
+	return
+
+/obj/item/clothing/mask/muzzle/safety/shock/HasProximity(atom/movable/AM as mob|obj)
+	if(trigger)
+		trigger.HasProximity(AM)
+
+
+/obj/item/clothing/mask/muzzle/safety/shock/hear_talk(mob/living/M as mob, msg)
+	if(trigger)
+		trigger.hear_talk(M, msg)
+
+/obj/item/clothing/mask/muzzle/safety/shock/hear_message(mob/living/M as mob, msg)
+	if(trigger)
+		trigger.hear_message(M, msg)
+
+
 
 /obj/item/clothing/mask/surgical
 	name = "sterile mask"

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -120,12 +120,14 @@
 	mute = MUZZLE_MUTE_NONE
 	security_lock = TRUE
 	locked = FALSE
+	materials = list(MAT_METAL=500, MAT_GLASS=50)
 
 /obj/item/clothing/mask/muzzle/safety/shock
 	name = "shock muzzle"
 	desc = "A muzzle designed to prevent biting.  This one is fitted with a behavior correction system."
 	var/obj/item/assembly/trigger = null
 	origin_tech = "materials=1;engineering=1"
+	materials = list(MAT_METAL=500, MAT_GLASS=50)
 
 /obj/item/clothing/mask/muzzle/safety/shock/attackby(obj/item/W, mob/user, params)
 	if(isscrewdriver(W))

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -136,20 +136,28 @@
 		trigger.master = null
 		trigger.holder = null
 		trigger = null
-	else if(trigger)
-		to_chat(user, "<span class='notice'>Something is already attached to [src].</span>")
+		return TRUE
 	else if(istype(W, /obj/item/assembly/signaler) || istype(W, /obj/item/assembly/voice))
-		user.drop_item()
+		if(istype(trigger, /obj/item/assembly/signaler) || istype(trigger, /obj/item/assembly/voice))
+			to_chat(user, "<span class='notice'>Something is already attached to [src].</span>")
+			return TRUE
+		if(!user.drop_item())
+			to_chat(user, "<span class='warning'>You are unable to insert [W] into [src].</span>")
+			return FALSE
 		trigger = W
 		trigger.forceMove(src)
 		trigger.master = src
 		trigger.holder = src
 		to_chat(user, "<span class='notice'>You attach the [W] to [src].</span>")
-	else
-		return ..()
+		return TRUE
+	else if(istype(W, /obj/item/assembly))
+		to_chat(user, "<span class='notice'>That won't fit in [src]. Perhaps a signaler or voice analyzer would?</span>")
+		return TRUE
+
+	return ..()
 
 
-/obj/item/clothing/mask/muzzle/safety/shock/equipped(obj/item/clothing/C)
+/obj/item/clothing/mask/muzzle/safety/shock/proc/can_shock(obj/item/clothing/C)
 	if(istype(C))
 		if(isliving(C.loc))
 			return C.loc
@@ -159,17 +167,16 @@
 
 /obj/item/clothing/mask/muzzle/safety/shock/proc/process_activation(var/obj/D, var/normal = 1, var/special = 1)
 	visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
-	if(equipped(loc))
-		var/mob/M = equipped(loc)
+	if(can_shock(loc))
+		var/mob/M = can_shock(loc)
 		to_chat(M, "<span class='danger'>You feel a sharp shock!</span>")
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(3, 1, M)
 		s.start()
 
 		M.Weaken(5)
-		if(ishuman(M))
-			M.Stuttering(1)
-			M.Jitter(20)
+		M.Stuttering(1)
+		M.Jitter(20)
 	return
 
 /obj/item/clothing/mask/muzzle/safety/shock/HasProximity(atom/movable/AM as mob|obj)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -31,8 +31,13 @@
 			to_chat(usr, "You are unable to emote.")
 		return
 
-	var/muzzled = istype(src.wear_mask, /obj/item/clothing/mask/muzzle)
-	if(m_type == 2 && muzzled) return
+	var/muzzled = is_muzzled()
+	if(muzzled)
+		var/obj/item/clothing/mask/muzzle/M = wear_mask
+		if(M.mute)
+			return //Not all muzzles block sound
+	if(m_type == 2 && !can_speak())
+		return
 
 	var/input
 	if(!message)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -34,7 +34,7 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(M.mute)
+		if(m_type == 2 && M.mute)
 			return //Not all muzzles block sound
 	if(m_type == 2 && !can_speak())
 		return

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -34,7 +34,7 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(m_type == EMOTE_SOUND && M.mute)
+		if(m_type == EMOTE_SOUND && M.mute & EMOTE_SOUND)
 			return //Not all muzzles block sound
 	if(!can_speak())
 		return

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -24,7 +24,7 @@
 					return target
 
 // All mobs should have custom emote, really..
-/mob/proc/custom_emote(var/m_type=1,var/message = null)
+/mob/proc/custom_emote(var/m_type=EMOTE_VISUAL,var/message = null)
 
 	if(stat || !use_me && usr == src)
 		if(usr)
@@ -34,9 +34,9 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(m_type == 2 && M.mute)
+		if(m_type == EMOTE_SOUND && M.mute)
 			return //Not all muzzles block sound
-	if(m_type == 2 && !can_speak())
+	if(!can_speak())
 		return
 
 	var/input
@@ -68,7 +68,7 @@
 
 
 		// Type 1 (Visual) emotes are sent to anyone in view of the item
-		if(m_type & 1)
+		if(m_type & EMOTE_VISUAL)
 			var/list/can_see = get_mobs_in_view(1,src)  //Allows silicon & mmi mobs carried around to see the emotes of the person carrying them around.
 			can_see |= viewers(src,null)
 			for(var/mob/O in can_see)
@@ -85,7 +85,7 @@
 
 		// Type 2 (Audible) emotes are sent to anyone in hear range
 		// of the *LOCATION* -- this is important for pAIs to be heard
-		else if(m_type & 2)
+		else if(m_type & EMOTE_SOUND)
 			for(var/mob/O in get_mobs_in_view(7,src))
 
 				if(O.status_flags & PASSEMOTES)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -34,7 +34,7 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(m_type == EMOTE_SOUND && M.mute & EMOTE_SOUND)
+		if(m_type == EMOTE_SOUND && M.mute >= MUZZLE_MUTE_MUFFLE)
 			return //Not all muzzles block sound
 	if(!can_speak())
 		return

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -12,7 +12,7 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(M.mute == MUTE_NONE)
+		if(M.mute == MUZZLE_MUTE_NONE)
 			muzzled = 0 //Not all muzzles block sound
 	if(!can_speak())
 		muzzled = 1

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -10,6 +10,10 @@
 		act = copytext(act, 1, t1)
 
 	var/muzzled = is_muzzled()
+	if(muzzled)
+		var/obj/item/clothing/mask/muzzle/M = wear_mask
+		if(!M.mute)
+			muzzled = 0 //Not all muzzles block sound
 	if(!can_speak())
 		muzzled = 1
 	//var/m_type = 1

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -12,7 +12,7 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(!(M.mute & EMOTE_SOUND))
+		if(M.mute == MUTE_NONE)
 			muzzled = 0 //Not all muzzles block sound
 	if(!can_speak())
 		muzzled = 1

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -12,7 +12,7 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(!M.mute)
+		if(M.mute & EMOTE_SOUND)
 			muzzled = 0 //Not all muzzles block sound
 	if(!can_speak())
 		muzzled = 1

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -12,7 +12,7 @@
 	var/muzzled = is_muzzled()
 	if(muzzled)
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
-		if(M.mute & EMOTE_SOUND)
+		if(!(M.mute & EMOTE_SOUND))
 			muzzled = 0 //Not all muzzles block sound
 	if(!can_speak())
 		muzzled = 1

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -49,7 +49,14 @@
 
 // Whether the mob is capable of talking
 /mob/living/can_speak()
-	return !(silent || (disabilities & MUTE))
+	if(!(silent || (disabilities & MUTE)))
+		if(is_muzzled())
+			var/obj/item/clothing/mask/muzzle/M = wear_mask
+			if(M.mute == 2)
+				return FALSE
+		return TRUE
+	else
+		return FALSE
 
 // Whether the mob is capable of standing or not
 /mob/living/proc/can_stand()

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -49,7 +49,7 @@
 
 // Whether the mob is capable of talking
 /mob/living/can_speak()
-	return !(silent || (disabilities & MUTE) || is_muzzled())
+	return !(silent || (disabilities & MUTE))
 
 // Whether the mob is capable of standing or not
 /mob/living/proc/can_stand()

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -52,7 +52,7 @@
 	if(!(silent || (disabilities & MUTE)))
 		if(is_muzzled())
 			var/obj/item/clothing/mask/muzzle/M = wear_mask
-			if(M.mute >= MUTE_MUFFLE)
+			if(M.mute >= MUZZLE_MUTE_MUFFLE)
 				return FALSE
 		return TRUE
 	else

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -52,7 +52,7 @@
 	if(!(silent || (disabilities & MUTE)))
 		if(is_muzzled())
 			var/obj/item/clothing/mask/muzzle/M = wear_mask
-			if(M.mute & EMOTE_SOUND)
+			if(M.mute >= MUTE_MUFFLE)
 				return FALSE
 		return TRUE
 	else

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -52,7 +52,7 @@
 	if(!(silent || (disabilities & MUTE)))
 		if(is_muzzled())
 			var/obj/item/clothing/mask/muzzle/M = wear_mask
-			if(M.mute == 2)
+			if(M.mute & EMOTE_SOUND)
 				return FALSE
 		return TRUE
 	else

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -551,6 +551,14 @@
 	build_path = /obj/item/assembly/voice
 	category = list("initial", "Miscellaneous")
 
+/datum/design/noise_analyser
+	name = "Noise Analyser"
+	id = "Noise_analyser"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 100, MAT_GLASS = 10)
+	build_path = /obj/item/assembly/voice/noise
+	category = list("initial", "Miscellaneous")
+
 /datum/design/light_tube
 	name = "Light Tube"
 	id = "light_tube"

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -60,3 +60,23 @@
 	materials = list(MAT_METAL = 500, MAT_GLASS = 300)
 	build_path = /obj/item/camera/digital
 	category = list("Miscellaneous")
+
+/datum/design/safety_muzzle
+	name = "Safety Muzzle"
+	desc = "Produce a lockable muzzle keyed to security ID cards"
+	id = "safetymuzzle"
+	req_tech = list("materials" = 1)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL=500, MAT_GLASS=50)
+	build_path = /obj/item/clothing/mask/muzzle/safety
+	category = list("Miscellaneous")
+
+/datum/design/shock_muzzle
+	name = "Shock Muzzle"
+	desc = "Produce a modified saftey muzzle that includes an electric shock pack and a slot for a trigger assembly."
+	id = "shockmuzzle"
+	req_tech = list("materials" = 1, "engineering" = 1)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL=500, MAT_GLASS=50)
+	build_path = /obj/item/clothing/mask/muzzle/safety/shock
+	category = list("Miscellaneous")

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -73,7 +73,7 @@
 
 /datum/design/shock_muzzle
 	name = "Shock Muzzle"
-	desc = "Produce a modified saftey muzzle that includes an electric shock pack and a slot for a trigger assembly."
+	desc = "Produce a modified safety muzzle that includes an electric shock pack and a slot for a trigger assembly."
 	id = "shockmuzzle"
 	req_tech = list("materials" = 1, "engineering" = 1)
 	build_type = PROTOLATHE


### PR DESCRIPTION
This PR adds a new version of the safety muzzle which can be constructed by research.  It is capable of fitting either a remote signaler or voice analyzer and will give the user a harmless electric shock when pulsed.

Additionally a new type of voice analyzer has been added and may be printed at autolathes, it will trigger whenever an audible emote is detected within range.

In order to support the above, I also fixed a bug with how emote code checked for if a mob was muzzled.  The code now checks to see if the muzzle is muting or not and now functions identically to say.

:cl: Alffd
fix: Fixes emote code to preform mute checking in the same manner as say code.
add: Adds a new type of muzzle that will shock its wearer when pulsed by an assembly.
add: Adds a new type of voice trigger assembly that is activated by audible emotes.
/ :cl: 