### PR TITLE
Small syndi officer fix

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -145,6 +145,7 @@
 	belt = /obj/item/gun/projectile/automatic/pistol/deagle/camo
 	l_ear = /obj/item/radio/headset/syndicate/alt
 	l_pocket = /obj/item/pinpointer/advpinpointer
+	r_pocket = null // stop them getting a radio uplink, they get an implant instead
 
 	backpack_contents = list(
 		/obj/item/storage/box/engineer = 1,
@@ -158,7 +159,6 @@
 
 	id_icon = "commander"
 	id_access = "Syndicate Operative Leader"
-	uplink_uses = 500
 
 /datum/outfit/admin/syndicate/officer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()


### PR DESCRIPTION
Syndi officers (the admin select equipment outfit) currently get two uplinks. 

The first one is fine. It is an uplink implant.

The second one was an oversight. It is a radio in their pocket that wasn't meant to be there, isn't necessary, and would present issues if it was lost or stolen (since syndi officers have effectively unlimited TC - you don't want that ever falling into the hands of the crew).

This fix removes the second, unintentional uplink, and leaves only the intended one.

No CL, as this is admin-only.