### PR TITLE
Solar Federation Outfit Fixes/Tweaks

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -613,15 +613,16 @@
 
 	uniform = /obj/item/clothing/under/solgov/rep
 	back = /obj/item/storage/backpack/satchel
+	glasses = /obj/item/clothing/glasses/hud/security/night
 	gloves = /obj/item/clothing/gloves/color/white
 	shoes = /obj/item/clothing/shoes/centcom
-	l_ear = /obj/item/radio/headset
+	l_ear = /obj/item/radio/headset/ert
 	id = /obj/item/card/id/silver
 	r_pocket = /obj/item/lighter/zippo/blue
 	l_pocket = /obj/item/storage/fancy/cigarettes/cigpack_robustgold
 	pda = /obj/item/pda
 	backpack_contents = list(
-		/obj/item/storage/box/survival = 1,
+		/obj/item/storage/box/responseteam = 1,
 		/obj/item/implanter/dust = 1,
 		/obj/item/implanter/death_alarm = 1,
 	)
@@ -633,25 +634,33 @@
 
 	var/obj/item/card/id/I = H.wear_id
 	if(istype(I))
-		apply_to_card(I, H, get_centcom_access("VIP Guest"), "Solar Federation Representative")
+		apply_to_card(I, H, get_all_accesses(), name, "lifetimeid")
 
 
 /datum/outfit/admin/solgov
 	name = "Solar Federation Marine"
 
 	uniform = /obj/item/clothing/under/solgov
+	suit = /obj/item/clothing/suit/armor/bulletproof
 	back = /obj/item/storage/backpack/security
+	belt = /obj/item/storage/belt/military/assault
 	head = /obj/item/clothing/head/soft/solgov
+	glasses = /obj/item/clothing/glasses/hud/security/night
 	gloves = /obj/item/clothing/gloves/combat
 	shoes = /obj/item/clothing/shoes/combat
+	l_ear = /obj/item/radio/headset/ert
 	id = /obj/item/card/id
 	l_hand = /obj/item/gun/projectile/automatic/ar
+	r_pocket = /obj/item/flashlight/seclite
+	pda = /obj/item/pda
 	backpack_contents = list(
-		/obj/item/storage/box/survival = 1,
-		/obj/item/kitchen/knife/combat = 1,
+		/obj/item/storage/box/responseteam = 1,
 		/obj/item/ammo_box/magazine/m556 = 3,
-		/obj/item/clothing/shoes/magboots = 1
+		/obj/item/clothing/shoes/magboots = 1,
+		/obj/item/gun/projectile/automatic/pistol/deagle = 1,
+		/obj/item/ammo_box/magazine/m50 = 2
 	)
+	var/is_tsf_lieutenant = FALSE
 
 
 /datum/outfit/admin/solgov/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -659,9 +668,14 @@
 	if(visualsOnly)
 		return
 
+	if(is_tsf_lieutenant)
+		H.real_name = "Lieutenant [pick(last_names)]"
+	else
+		H.real_name = "[pick("Corporal", "Sergeant", "Staff Sergeant", "Sergeant First Class", "Master Sergeant", "Sergeant Major")] [pick(last_names)]"
+	H.name = H.real_name
 	var/obj/item/card/id/I = H.wear_id
 	if(istype(I))
-		apply_to_card(I, H, get_centcom_access("VIP Guest"), name)
+		apply_to_card(I, H, get_all_accesses(), name, "lifetimeid")
 
 /datum/outfit/admin/solgov/lieutenant
 	name = "Solar Federation Lieutenant"
@@ -670,14 +684,14 @@
 	head = /obj/item/clothing/head/soft/solgov/command
 	back = /obj/item/storage/backpack/satchel
 	l_hand = null
-	belt = /obj/item/gun/projectile/automatic/pistol/deagle
+	l_pocket = /obj/item/pinpointer/advpinpointer
 	backpack_contents = list(
-		/obj/item/storage/box/survival = 1,
-		/obj/item/kitchen/knife/combat = 1,
+		/obj/item/storage/box/responseteam = 1,
 		/obj/item/melee/classic_baton/telescopic = 1,
-		/obj/item/ammo_box/magazine/m50 = 2,
 		/obj/item/clothing/shoes/magboots/advance = 1
 	)
+	is_tsf_lieutenant = TRUE
+
 
 /datum/outfit/admin/chrono
 	name = "Chrono Legionnaire"

--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -657,8 +657,8 @@
 		/obj/item/storage/box/responseteam = 1,
 		/obj/item/ammo_box/magazine/m556 = 3,
 		/obj/item/clothing/shoes/magboots = 1,
-		/obj/item/gun/projectile/automatic/pistol/deagle = 1,
-		/obj/item/ammo_box/magazine/m50 = 2
+		/obj/item/gun/projectile/automatic/pistol/m1911 = 1,
+		/obj/item/ammo_box/magazine/m45 = 2
 	)
 	var/is_tsf_lieutenant = FALSE
 
@@ -688,7 +688,9 @@
 	backpack_contents = list(
 		/obj/item/storage/box/responseteam = 1,
 		/obj/item/melee/classic_baton/telescopic = 1,
-		/obj/item/clothing/shoes/magboots/advance = 1
+		/obj/item/clothing/shoes/magboots/advance = 1,
+		/obj/item/gun/projectile/automatic/pistol/deagle = 1,
+		/obj/item/ammo_box/magazine/m50 = 2
 	)
 	is_tsf_lieutenant = TRUE
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -29,7 +29,7 @@
 /obj/item/ammo_casing/update_icon()
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"
-	desc = "[initial(desc)][BB ? "" : " This one is spent"]"
+	desc = "[initial(desc)][BB ? "" : " This one is spent."]"
 
 /obj/item/ammo_casing/proc/newshot(params) //For energy weapons, shotgun shells and wands (!).
 	if(!BB)


### PR DESCRIPTION
Currently, the Solar Federation outfits are rather useless.
- They lack absolutely critical gear, such as headsets. They don't even have radio communications by default.
- They lack equipment you'd expect to find on front-line combatants, like, for example, body armor, belts, etc.
- They have zero access to the station. They can't even open airlocks to maint, that civilians can open. The only place they do have access is centcom, which is silly, as they're not needed on centcom.
- Some of their stuff is not very well fleshed out. They use the standard ID skin, standard names, etc.

This PR is intended to re-work the Solar Federation outfits, to make them actually viable for events, instead of being totally useless / requiring lots of manual fiddling by admins to do an event with.
It is *loosely* based on the forum thread: https://nanotrasen.se/forum/topic/13246-changes-to-pre-existing-job-trans-solar-federation-marine-tune-up-suggestion

Changes to Solar Federation Rep, Marine and Lieutenant:
- ID cards are now blue, and have all-access to station, but no longer have access to centcom.
- Radio is now ERT headset, giving them the ability to use response team comms.
- Their survival box is replaced with a response team box. This gives them a bigger oxy tank, a flare, a backup centcom radio, and single-use salicylic/synthflesh meds.
- Standard issue gear now includes NV sec hud.

Changes to just marine/lieutenant:
- Standard issue gear now includes bulletproof armor, an (empty) assault belt, a pistol (desert eagle for LT, M1911 for normal marine, either way the pistol comes with two ammo clips), a PDA, and a seclite.
- Marines will now use the standard ERT naming scheme. Lieutenants will now always use 'Lieutenant (lastname)' as their name.

Global changes:
- When viewing a spent ammo casing, the phrase "This one is spent" now has a period at the end. This is simply a grammar fix.


Overall, this should make it more viable to use the marines as a group of event characters, without them being hopelessly disorganized and under-equipped.

There are, however, a few changes from the forum thread that I decided NOT to do, they are:
- I did not add a dedicated solfed radio channel, because I think access to the ERT channel works just as well, and is already supported.
- I did not add a sec hud icon for solfed marines, because admin outfits do not generally get sechud icons, and its obvious what they are anyway from all their gear, ID, and general color scheme.
- I did not change the description of the ARG rifle to reference 'various forces', because AFAIK its still intended to be an NT weapon.
- I did not rename 'Sol Federation' to 'Trans-Solar Federation' as I prefer shorter names, and don't see any benefit to making the name longer.

No CL, as this is related to an admin-only event outfit.