### PR TITLE
Adds a Self Destruct alarm to Borgs.

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -90,6 +90,11 @@
 			if(target.connected_ai)
 				to_chat(target.connected_ai, "<br><br><span class='alert'>ALERT - Cyborg detonation detected: [target.name]</span><br>")
 			spawn(10)
+				var/area/t = get_area(target)
+				var/obj/item/radio/headset/a = new /obj/item/radio/headset(target)
+				a.follow_target = target
+				a.autosay("[target.name] has been detonated in [t.name]!", "[target.name]'s Self-destruct Alarm")
+				qdel(a)
 				target.self_destruct()
 
 	// Locks or unlocks the cyborg
@@ -182,6 +187,11 @@
 			if(R.connected_ai)
 				to_chat(R.connected_ai, "<br><br><span class='alert'>ALERT - Cyborg detonation detected: [R.name]</span><br>")
 			spawn(10)
+				var/area/t = get_area(R)
+				var/obj/item/radio/headset/a = new /obj/item/radio/headset(R)
+				a.follow_target = R
+				a.autosay("[R.name] has been detonated in [t.name]!", "[R.name]'s Self-destruct Alarm")
+				qdel(a)
 				R.self_destruct()
 
 // Proc: get_cyborgs()


### PR DESCRIPTION
Whenever a cyborg is detonated, their Self Destruct alarm will go off over Common. 

This will provide a location for the detonation of the Cyborg, allowing a better chance for the MMI to be found, rather than the player either sitting staring at their brain or forcibly ghosting thus removing any chance of joining the round again.

This works for individual and mass detonation.

![image](https://user-images.githubusercontent.com/23273289/39411532-8d1209c8-4bd1-11e8-8a33-f83c70e4a4a6.png)

:cl: Desolate
add: Cyborg detonation now sets off a Self Destruct alarm.
/ :cl: 

