### PR TITLE
Does Surgery on Surgery to Fix Surgery

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -42,7 +42,7 @@
 	if(lying && surgeries.len)
 		if(user.a_intent == INTENT_HELP)
 			for(var/datum/surgery/S in surgeries)
-				if(S.next_step(user, user.a_intent))
+				if(S.next_step(user, src))
 					return 1
 	return 0
 


### PR DESCRIPTION
We can't pass user intent as an argument on our surgery code, so uh, this caused really bad runtimes.

`Runtime in abduction_surgery.dm,31: Cannot read "help".internal_organs`

👌 

