### PR TITLE
Abduction surgery fix

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -50,7 +50,8 @@
 		return 1
 
 /datum/surgery_step/internal/extract_organ/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	return end_step(user, target, target_zone, tool, surgery)
+	user.visible_message("<span class='warning'>[user]'s hand slips, failing to extract anything!</span>", "<span class='warning'>Your hand slips, failing to extract anything!</span>")
+	return 0
 
 /datum/surgery_step/internal/gland_insert
 	name = "insert gland"
@@ -69,7 +70,8 @@
 	return 1
 
 /datum/surgery_step/internal/gland_insert/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	return end_step(user, target, target_zone, tool, surgery)
+	user.visible_message("<span class='warning'>[user]'s hand slips, failing to insert the gland!</span>", "<span class='warning'>Your hand slips, failing to insert the gland!</span>")
+	return 0
 
 //IPC Gland Surgery//
 

--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -49,6 +49,9 @@
 		to_chat(user, "<span class='warning'>You don't find anything in [target]'s [target_zone]!</span>")
 		return 1
 
+/datum/surgery_step/internal/extract_organ/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	return end_step(user, target, target_zone, tool, surgery)
+
 /datum/surgery_step/internal/gland_insert
 	name = "insert gland"
 	allowed_tools = list(/obj/item/organ/internal/heart/gland = 100)
@@ -64,6 +67,9 @@
 	var/obj/item/organ/internal/heart/gland/gland = tool
 	gland.insert(target, 2)
 	return 1
+
+/datum/surgery_step/internal/gland_insert/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	return end_step(user, target, target_zone, tool, surgery)
 
 //IPC Gland Surgery//
 

--- a/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_surgery.dm
@@ -5,19 +5,19 @@
 
 /datum/surgery/organ_extraction/can_start(mob/user, mob/living/carbon/target, target_zone, obj/item/tool,datum/surgery/surgery)
 	if(!ishuman(user))
-		return 0
+		return FALSE
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/external/affected = H.get_organ(target_zone)
 		if(!affected)
-			return 0
+			return FALSE
 		if(affected.status & ORGAN_ROBOT)
-			return 0
+			return FALSE
 	var/mob/living/carbon/human/H = user
 	// You must either: Be of the abductor species, or contain an abductor implant
 	if((H.get_species() == "Abductor" || (locate(/obj/item/implant/abductor) in H)))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 
 /datum/surgery_step/internal/extract_organ
@@ -39,19 +39,19 @@
 	var/mob/living/carbon/human/AB = target
 	if(NO_INTORGANS in AB.species.species_traits)
 		user.visible_message("[user] prepares [target]'s [target_zone] for further dissection!", "<span class='notice'>You prepare [target]'s [target_zone] for further dissection.</span>")
-		return 1
+		return TRUE
 	if(IC)
 		user.visible_message("[user] pulls [IC] out of [target]'s [target_zone]!", "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>")
 		user.put_in_hands(IC)
 		IC.remove(target, special = 1)
-		return 1
+		return TRUE
 	else
 		to_chat(user, "<span class='warning'>You don't find anything in [target]'s [target_zone]!</span>")
-		return 1
+		return TRUE
 
 /datum/surgery_step/internal/extract_organ/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='warning'>[user]'s hand slips, failing to extract anything!</span>", "<span class='warning'>Your hand slips, failing to extract anything!</span>")
-	return 0
+	return FALSE
 
 /datum/surgery_step/internal/gland_insert
 	name = "insert gland"
@@ -67,11 +67,11 @@
 	user.drop_item()
 	var/obj/item/organ/internal/heart/gland/gland = tool
 	gland.insert(target, 2)
-	return 1
+	return TRUE
 
 /datum/surgery_step/internal/gland_insert/fail_step(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='warning'>[user]'s hand slips, failing to insert the gland!</span>", "<span class='warning'>Your hand slips, failing to insert the gland!</span>")
-	return 0
+	return FALSE
 
 //IPC Gland Surgery//
 


### PR DESCRIPTION
~Fixes a new abduction surgery runtime on using hands to remove organs from #8817.~
Makes the extract organ and insert gland of abduction surgery always succeed, rather than fail silently.