### PR TITLE
Makes Bomb Range Multi-Use

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -6505,7 +6505,7 @@
 "cve" = (/obj/item/assembly/timer,/obj/item/assembly/timer{pixel_x = 6},/obj/item/assembly/timer{pixel_x = -5; pixel_y = 6},/obj/structure/table,/obj/item/assembly/timer{pixel_x = -3; pixel_y = -4},/obj/item/assembly/timer{pixel_x = 8; pixel_y = 8},/obj/item/assembly/timer,/obj/machinery/light_switch{pixel_y = -23},/obj/machinery/light,/obj/machinery/requests_console{department = "Science"; departmentType = 2; name = "Science Requests Console"; pixel_x = 0; pixel_y = -30},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/mixing)
 "cvf" = (/obj/machinery/atmospherics/trinary/mixer{density = 0; dir = 8; req_access = null},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/mixing)
 "cvg" = (/obj/machinery/atmospherics/unary/portables_connector{dir = 4},/obj/item/radio/intercom{name = "station intercom (General)"; pixel_y = -28},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/mixing)
-"cvh" = (/obj/item/radio/beacon,/obj/effect/decal/warning_stripes/red/hollow,/turf/simulated/floor/plasteel/airless,/area/toxins/test_area)
+"cvh" = (/obj/item/radio/beacon,/obj/effect/decal/warning_stripes/red/hollow,/turf/simulated/floor/plasteel/airless/indestructible,/area/toxins/test_area)
 "cvi" = (/obj/machinery/atmospherics/binary/valve{dir = 4},/obj/machinery/firealarm{dir = 1; pixel_y = -24},/turf/simulated/floor/plasteel{icon_state = "white"},/area/toxins/mixing)
 "cvj" = (/obj/machinery/mass_driver{dir = 4; id_tag = "toxinsdriver"},/turf/simulated/floor/plating,/area/toxins/launch{name = "Toxins Launch Room"})
 "cvk" = (/obj/structure/closet/crate,/obj/effect/spawner/lootdrop/maintenance,/turf/simulated/floor/plating,/area/maintenance/apmaint)

--- a/code/game/turfs/simulated/floor/plasteel_floor.dm
+++ b/code/game/turfs/simulated/floor/plasteel_floor.dm
@@ -18,8 +18,13 @@
 
 /turf/simulated/floor/plasteel/airless/New()
 	..()
-	name = "floor"		
-		
+	name = "floor"
+
+/turf/simulated/floor/plasteel/airless/indestructible // For bomb testing range
+
+/turf/simulated/floor/plasteel/airless/indestructible/ex_act(severity)
+	return
+
 /turf/simulated/floor/plasteel/goonplaque
 	icon_state = "plaque"
 	name = "Commemorative Plaque"


### PR DESCRIPTION
The bomb testing range is supposed to have more than one use; that's why there's an indestructible shuttle wall that stops the bomb. There's just one problem; since the turf underneath it can be destroyed (and the space refactor made things bounce off walls) so the bomb will bounce off and come back to you, thus you're likely to blow yourself up.

This fixes that and allows the bomb testing range to be used multiple times.

:cl: Fox McCloud
fix: Bomb testing range can now be utilized multiple times without worry of the bomb bouncing off and returning back to you
/:cl: