### PR TITLE
Updates Surgery Augment: Adds it to R&D

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -271,6 +271,17 @@
 	build_path = /obj/item/organ/internal/cyberimp/mouth/breathing_tube
 	category = list("Misc", "Medical")
 
+/datum/design/cyberimp_surgical
+	name = "Surgical Arm Implant"
+	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
+	id = "ci-surgey"
+	req_tech = list("materials" = 3, "engineering" = 3, "biotech" = 3, "programming" = 2, "magnets" = 3)
+	build_type = PROTOLATHE | MECHFAB
+	materials = list (MAT_METAL = 2500, MAT_GLASS = 1500, MAT_SILVER = 1500)
+	construction_time = 200
+	build_path = /obj/item/organ/internal/cyberimp/arm/surgery
+	category = list("Misc", "Medical")
+
 /datum/design/cyberimp_toolset
 	name = "Toolset Arm Implant"
 	desc = "A stripped-down version of engineering cyborg toolset, designed to be installed on subject's arm."

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -242,7 +242,7 @@
 /obj/item/organ/internal/cyberimp/arm/surgery
 	name = "surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm"
-	contents = newlist(/obj/item/retractor, /obj/item/hemostat, /obj/item/cautery, /obj/item/surgicaldrill, /obj/item/scalpel, /obj/item/circular_saw, /obj/item/bonegel, /obj/item/FixOVein, /obj/item/bonesetter)
+	contents = newlist(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment, /obj/item/bonegel/augment, /obj/item/FixOVein/augment, /obj/item/bonesetter/augment)
 	origin_tech = "materials=3;engineering=3;biotech=3;programming=2;magnets=3"
 
 // lets make IPCs even *more* vulnerable to EMPs!

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -8,6 +8,10 @@
 	w_class = WEIGHT_CLASS_SMALL
 	origin_tech = "materials=1;biotech=1"
 
+/obj/item/retractor/augment
+	desc = "Micro-mechanical manipulator for retracting stuff."
+	w_class = WEIGHT_CLASS_TINY
+	toolspeed = 0.5
 
 /obj/item/hemostat
 	name = "hemostat"
@@ -20,6 +24,9 @@
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("attacked", "pinched")
 
+/obj/item/hemostat/augment
+	desc = "Tiny servos power a pair of pincers to stop bleeding."
+	toolspeed = 0.5
 
 /obj/item/cautery
 	name = "cautery"
@@ -32,6 +39,9 @@
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("burnt")
 
+/obj/item/cautery/augment
+	desc = "A heated element that cauterizes wounds."
+	toolspeed = 0.5
 
 /obj/item/surgicaldrill
 	name = "surgical drill"
@@ -52,6 +62,12 @@
 							"<span class='suicide'>[user] is pressing [src] to \his chest and activating it! It looks like \he's trying to commit suicide.</span>"))
 		return (BRUTELOSS)
 
+/obj/item/surgicaldrill/augment
+	desc = "Effectively a small power drill contained within your arm, edges dulled to prevent tissue damage. May or may not pierce the heavens."
+	hitsound = 'sound/weapons/circsawhit.ogg'
+	force = 10
+	w_class = WEIGHT_CLASS_SMALL
+	toolspeed = 0.5
 
 /obj/item/scalpel
 	name = "scalpel"
@@ -77,6 +93,10 @@
 							"<span class='suicide'>[user] is slitting \his stomach open with [src]! It looks like \he's trying to commit seppuku.</span>"))
 		return (BRUTELOSS)
 
+
+/obj/item/scalpel/augment
+	desc = "Ultra-sharp blade attached directly to your bone for extra-accuracy."
+	toolspeed = 0.5
 
 /*
  * Researchable Scalpels
@@ -129,6 +149,12 @@
 	origin_tech = "biotech=1;combat=1"
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 
+/obj/item/circular_saw/augment
+	desc = "A small but very fast spinning saw. Edges dulled to prevent accidental cutting inside of the surgeon."
+	force = 10
+	w_class = WEIGHT_CLASS_SMALL
+	toolspeed = 0.5
+
 //misc, formerly from code/defines/weapons.dm
 /obj/item/bonegel
 	name = "bone gel"
@@ -139,6 +165,9 @@
 	throwforce = 1.0
 	origin_tech = "materials=1;biotech=1"
 
+/obj/item/bonegel/augment
+	toolspeed = 0.5
+
 /obj/item/FixOVein
 	name = "FixOVein"
 	icon = 'icons/obj/surgery.dmi'
@@ -147,6 +176,9 @@
 	throwforce = 1.0
 	origin_tech = "materials=1;biotech=1"
 	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/FixOVein/augment
+	toolspeed = 0.5
 
 /obj/item/bonesetter
 	name = "bone setter"
@@ -159,6 +191,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("attacked", "hit", "bludgeoned")
 	origin_tech = "materials=1;biotech=1"
+
+/obj/item/bonesetter/augment
+	toolspeed = 0.5
 
 /obj/item/surgical_drapes
 	name = "surgical drapes"


### PR DESCRIPTION
From TG.

Updates the surgical augment; it now has special version of each of the tools that are faster than normal tools. They're not quite as combat worthy as their full sized counterparts, but they're superior for surgery.

Additionally, you can produce and make this surgical tool implant at R&D.

:cl: Fox McCloud
add: Adds surgical augment to R&D
tweak: Tools on surgical augment are slightly faster at surgery
/:cl: