### PR TITLE
Monkey business logging

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -1250,7 +1250,13 @@
 /obj/item/reagent_containers/food/snacks/monkeycube/proc/Expand()
 	if(!QDELETED(src))
 		visible_message("<span class='notice'>[src] expands!</span>")
-		new/mob/living/carbon/human(get_turf(src), monkey_type)
+		if(fingerprintslast)
+			log_game("Cube ([monkey_type]) inflated, last touched by: " + fingerprintslast)
+		else
+			log_game("Cube ([monkey_type]) inflated, last touched by: NO_DATA")
+		var/mob/living/carbon/human/creature = new /mob/living/carbon/human(get_turf(src), monkey_type)
+		if(fingerprintshidden.len)
+			creature.fingerprintshidden = fingerprintshidden.Copy()
 		qdel(src)
 
 /obj/item/reagent_containers/food/snacks/monkeycube/farwacube


### PR DESCRIPTION
Today, we had two different rounds where someone spawned a bunch of monkeys when they shouldn't have.
Actually tracking this down was a lot harder than it should have been, because monkey creation isn't properly logged.
This PR attempts to fix that.

Two changes:
1) Upon inflating a monkey cube, the newly-created monkey will have the same hidden (admin-only) fingerprint log as the cube that created it. This means that VVing on a monkey created from a cube should generally tell you who created that monkey.
2) Upon inflating a monkey cube, a game_log will be created showing the last person to touch that cube (assuming anyone touched it). This should ensure that even if the server totally crashes from excessive monkeys, we will at least be able to find out who did it.

Example game log entry:
[2018-05-02T23:59:29] GAME: Cube (Monkey) inflated, last touched by: CKEY

No CL as this is admin stuff.