### PR TITLE
Hopefully fixes all dumb disposals nullspace shit

### DIFF
--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -250,8 +250,6 @@
 						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
 						src.transfer_fingerprints_to(P)
 						P.dir = dir
-						var/obj/structure/disposalpipe/trunk/Trunk = CP
-						Trunk.linked = P
 
 					else if(ptype==8) // Disposal outlet
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -36,19 +36,19 @@
 	update()
 
 /obj/machinery/disposal/proc/trunk_check()
-	trunk = locate() in src.loc
-	if(!trunk)
+	var/obj/structure/disposalpipe/trunk/T = locate() in loc
+	if(!T)
 		mode = 0
 		flush = 0
 	else
 		mode = initial(mode)
 		flush = initial(flush)
-		trunk.linked = src	// link the pipe trunk to self
+		T.nicely_link_to_other_stuff(src)
 
 /obj/machinery/disposal/Destroy()
 	eject()
 	if(trunk)
-		trunk.linked = null
+		trunk.remove_trunk_links()
 	return ..()
 
 /obj/machinery/disposal/initialize()
@@ -1155,24 +1155,39 @@
 		if(D.trunk == src)
 			D.go_out()
 			D.trunk = null
-
-	linked = null
+	remove_trunk_links()
 	return ..()
 
 /obj/structure/disposalpipe/trunk/proc/getlinked()
-	linked = null
 	var/obj/machinery/disposal/D = locate() in src.loc
 	if(D)
-		linked = D
-		if(!D.trunk)
-			D.trunk = src
-
+		nicely_link_to_other_stuff(D)
+		return
 	var/obj/structure/disposaloutlet/O = locate() in src.loc
 	if(O)
-		linked = O
+		nicely_link_to_other_stuff(O)
 
-	update()
-	return
+/obj/structure/disposalpipe/trunk/proc/remove_trunk_links() //disposals is well-coded
+	if(!linked)
+		return
+	else if(istype(linked, /obj/machinery/disposal)) //jk lol
+		var/obj/machinery/disposal/D = linked
+		D.trunk = null
+	else if(istype(linked, /obj/structure/disposaloutlet)) //God fucking damn it
+		var/obj/structure/disposaloutlet/D = linked
+		D.linkedtrunk = null
+	linked = null
+
+/obj/structure/disposalpipe/trunk/proc/nicely_link_to_other_stuff(obj/O)
+	remove_trunk_links() //Breaks the connections between this trunk and the linked machinery so we don't get sent to nullspace or some shit like that
+	if(istype(O, /obj/machinery/disposal))
+		var/obj/machinery/disposal/D = O
+		linked = D
+		D.trunk = src
+	else if(istype(O, /obj/structure/disposaloutlet))
+		var/obj/structure/disposaloutlet/D = O
+		linked = D
+		D.linkedtrunk = src
 
 	// Override attackby so we disallow trunkremoval when somethings ontop
 /obj/structure/disposalpipe/trunk/attackby(var/obj/item/I, var/mob/user, params)
@@ -1277,77 +1292,72 @@
 	var/obj/structure/disposalpipe/trunk/linkedtrunk
 	var/mode = 0
 
-	New()
-		..()
-
-		spawn(1)
-			target = get_ranged_target_turf(src, dir, 10)
-
-
-			linkedtrunk = locate() in src.loc
-			if(linkedtrunk)
-				linkedtrunk.linked = src
+/obj/structure/disposaloutlet/New()
+	..()
+	spawn(1)
+		target = get_ranged_target_turf(src, dir, 10)
+		var/obj/structure/disposalpipe/trunk/T = locate() in loc
+		if(T)
+			T.nicely_link_to_other_stuff(src)
 
 	// expel the contents of the holder object, then delete it
 	// called when the holder exits the outlet
-	proc/expel(var/obj/structure/disposalholder/H, animation = 1)
-
-		if(animation)
-			flick("outlet-open", src)
-			playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
-			sleep(20)	//wait until correct animation frame
-			playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
-
-		if(H)
-			for(var/atom/movable/AM in H)
-				AM.forceMove(loc)
-				AM.pipe_eject(dir)
-				if(!istype(AM,/mob/living/silicon/robot/drone)) //Drones keep smashing windows from being fired out of chutes. Bad for the station. ~Z
-					spawn(5)
-						if(AM)
-							AM.throw_at(target, 3, 1)
-			H.vent_gas(src.loc)
-			qdel(H)
+/obj/structure/disposaloutlet/proc/expel(var/obj/structure/disposalholder/H, animation = 1)
+	if(animation)
+		flick("outlet-open", src)
+		playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
+		sleep(20)	//wait until correct animation frame
+		playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+	if(H)
+		for(var/atom/movable/AM in H)
+			AM.forceMove(loc)
+			AM.pipe_eject(dir)
+			if(!istype(AM,/mob/living/silicon/robot/drone)) //Drones keep smashing windows from being fired out of chutes. Bad for the station. ~Z
+				spawn(5)
+					if(AM)
+						AM.throw_at(target, 3, 1)
+		H.vent_gas(src.loc)
+		qdel(H)
 
 
-	attackby(var/obj/item/I, var/mob/user, params)
-		if(!I || !user)
+/obj/structure/disposaloutlet/attackby(var/obj/item/I, var/mob/user, params)
+	if(!I || !user)
+		return
+	src.add_fingerprint(user)
+	if(istype(I, /obj/item/screwdriver))
+		if(mode==0)
+			mode=1
+			playsound(src.loc, I.usesound, 50, 1)
+			to_chat(user, "You remove the screws around the power connection.")
 			return
-		src.add_fingerprint(user)
-		if(istype(I, /obj/item/screwdriver))
-			if(mode==0)
-				mode=1
-				playsound(src.loc, I.usesound, 50, 1)
-				to_chat(user, "You remove the screws around the power connection.")
-				return
-			else if(mode==1)
-				mode=0
-				playsound(src.loc, I.usesound, 50, 1)
-				to_chat(user, "You attach the screws around the power connection.")
-				return
-		else if(istype(I,/obj/item/weldingtool) && mode==1)
-			var/obj/item/weldingtool/W = I
-			if(W.remove_fuel(0,user))
-				playsound(src.loc, W.usesound, 100, 1)
-				to_chat(user, "You start slicing the floorweld off the disposal outlet.")
-				if(do_after(user, 20 * W.toolspeed, target = src))
-					if(!src || !W.isOn()) return
-					to_chat(user, "You sliced the floorweld off the disposal outlet.")
-					var/obj/structure/disposalconstruct/C = new (src.loc)
-					src.transfer_fingerprints_to(C)
-					C.ptype = 7 // 7 =  outlet
-					C.update()
-					C.anchored = 1
-					C.density = 1
-					qdel(src)
-				return
-			else
-				to_chat(user, "You need more welding fuel to complete this task.")
-				return
+		else if(mode==1)
+			mode=0
+			playsound(src.loc, I.usesound, 50, 1)
+			to_chat(user, "You attach the screws around the power connection.")
+			return
+	else if(istype(I,/obj/item/weldingtool) && mode==1)
+		var/obj/item/weldingtool/W = I
+		if(W.remove_fuel(0,user))
+			playsound(src.loc, W.usesound, 100, 1)
+			to_chat(user, "You start slicing the floorweld off the disposal outlet.")
+			if(do_after(user, 20 * W.toolspeed, target = src))
+				if(!src || !W.isOn()) return
+				to_chat(user, "You sliced the floorweld off the disposal outlet.")
+				var/obj/structure/disposalconstruct/C = new (src.loc)
+				src.transfer_fingerprints_to(C)
+				C.ptype = 7 // 7 =  outlet
+				C.update()
+				C.anchored = 1
+				C.density = 1
+				qdel(src)
+			return
+		else
+			to_chat(user, "You need more welding fuel to complete this task.")
+			return
 
 /obj/structure/disposaloutlet/Destroy()
 	if(linkedtrunk)
-		linkedtrunk.linked = null
+		linkedtrunk.remove_trunk_links()
 	return ..()
 
 // called when movable is expelled from a disposal pipe or outlet


### PR DESCRIPTION
Because despite numerous fixes, you can STILL SEND PEOPLE TO NULLSPACE IF YOU KNOW HOW

Also refactors `/obj/structure/disposaloutlet` so that it's pathed absolutely, not relatively

:cl:
fix: Hopefully fixes all issues with disposals sending you to disposals.
/:cl: