### PR TITLE
Fixes #8271 - rare borg runtimes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -883,9 +883,10 @@ var/list/robot_verbs_default = list(
 			icon_state = "[base_icon]-roll"
 		else
 			icon_state = base_icon
-		for(var/obj/item/borg/combat/shield/S in module.modules)
-			if(activated(S))
-				overlays += "[base_icon]-shield"
+		if(module)
+			for(var/obj/item/borg/combat/shield/S in module.modules)
+				if(activated(S))
+					overlays += "[base_icon]-shield"
 	update_fire()
 
 /mob/living/silicon/robot/proc/installed_modules()


### PR DESCRIPTION
Nations/Combat borgs no longer generate a runtime when inhabited by a player.

Example of the error they used to generate: https://github.com/ParadiseSS13/Paradise/issues/8271

No CL, as this is purely a back-end fix invisible to players.