### PR TITLE
High-Pop Job Slots

### DIFF
--- a/code/game/jobs/job_scaling.dm
+++ b/code/game/jobs/job_scaling.dm
@@ -1,0 +1,10 @@
+/hook/roundstart/proc/jobscaling()
+	sleep(10 SECONDS) // give everyone time to finish spawning, and the lag to die down
+	var/playercount = length(clients)
+	var/highpop_trigger = 80
+
+	if(playercount >= highpop_trigger)
+		log_debug("Playercount: [playercount] versus trigger: [highpop_trigger] - loading highpop job config");
+		job_master.LoadJobs("config/jobs_highpop.txt")
+	else
+		log_debug("Playercount: [playercount] versus trigger: [highpop_trigger] - keeping standard job config");

--- a/code/game/jobs/job_scaling.dm
+++ b/code/game/jobs/job_scaling.dm
@@ -8,3 +8,4 @@
 		job_master.LoadJobs("config/jobs_highpop.txt")
 	else
 		log_debug("Playercount: [playercount] versus trigger: [highpop_trigger] - keeping standard job config");
+	return 1

--- a/config/example/jobs_highpop.txt
+++ b/config/example/jobs_highpop.txt
@@ -1,0 +1,37 @@
+Captain=1
+Head of Personnel=1
+Head of Security=1
+Chief Engineer=1
+Research Director=1
+Chief Medical Officer=1
+
+Station Engineer=7
+Roboticist=1
+
+Medical Doctor=7
+Geneticist=2
+Virologist=1
+
+Scientist=5
+Chemist=2
+
+Bartender=1
+Botanist=2
+Chef=1
+Janitor=2
+Quartermaster=1
+Shaft Miner=5
+
+Warden=1
+Detective=1
+Security Officer=9
+
+Assistant=-1
+Atmospheric Technician=4
+Cargo Technician=5
+Chaplain=1
+Lawyer=2
+Librarian=1
+
+AI=1
+Cyborg=1

--- a/config/example/jobs_highpop.txt
+++ b/config/example/jobs_highpop.txt
@@ -5,30 +5,30 @@ Chief Engineer=1
 Research Director=1
 Chief Medical Officer=1
 
-Station Engineer=7
+Station Engineer=5
 Roboticist=1
 
-Medical Doctor=7
+Medical Doctor=5
 Geneticist=2
 Virologist=1
 
-Scientist=5
+Scientist=3
 Chemist=2
 
 Bartender=1
 Botanist=2
 Chef=1
-Janitor=2
+Janitor=1
 Quartermaster=1
-Shaft Miner=5
+Shaft Miner=3
 
 Warden=1
 Detective=1
-Security Officer=9
+Security Officer=7
 
 Assistant=-1
 Atmospheric Technician=4
-Cargo Technician=5
+Cargo Technician=3
 Chaplain=1
 Lawyer=2
 Librarian=1

--- a/paradise.dme
+++ b/paradise.dme
@@ -527,6 +527,7 @@
 #include "code\game\jobs\job_controller.dm"
 #include "code\game\jobs\job_exp.dm"
 #include "code\game\jobs\job_objective.dm"
+#include "code\game\jobs\job_scaling.dm"
 #include "code\game\jobs\jobs.dm"
 #include "code\game\jobs\whitelist.dm"
 #include "code\game\jobs\job\central.dm"


### PR DESCRIPTION
This PR adjusts job slots based on the number of players on the server.
Specifically, at roundstart, it checks if there are >= 80 players on the server. 
If this is true, it updates the available job slots based on the (new) jobs_highpop.txt config file.
In the **example** config provided, that adds the following slots:
- +2 doctors (5->7)
- +2 engineers (5->7)
- +1 atmos tech (3->4)
- +2 sec officers (7->9)
- +2 scientist (3->5)
- +1 cargo tech (4->5)
- +2 shaft miners (3->5)
- +1 janitor (1->2)

All-in-all, this adds +13 job slots to the server when there are lots of players connected.
It only adds these at roundstart, though. So, they will primarily be used by latejoin players.
This is intentional - it ensures that every department should have at least a basic level of staffing before additional slots are opened.

🆑 Kyep
add: Additional job slots are now available at 80+ server population.
/🆑