### PR TITLE
Fixes snacks.dm runtime and monkey bug

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -1255,9 +1255,7 @@
 		else
 			log_game("Cube ([monkey_type]) inflated, last touched by: NO_DATA")
 		var/mob/living/carbon/human/creature = new /mob/living/carbon/human(get_turf(src))
-		if(!fingerprintshidden)
-			fingerprintshidden = list()
-		if(fingerprintshidden.len)
+		if(LAZYLEN(fingerprintshidden))
 			creature.fingerprintshidden = fingerprintshidden.Copy()
 		creature.set_species(monkey_type)
 		qdel(src)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -1255,6 +1255,8 @@
 		else
 			log_game("Cube ([monkey_type]) inflated, last touched by: NO_DATA")
 		var/mob/living/carbon/human/creature = new /mob/living/carbon/human(get_turf(src))
+		if(!fingerprintshidden)
+			fingerprintshidden = list()
 		if(fingerprintshidden.len)
 			creature.fingerprintshidden = fingerprintshidden.Copy()
 		creature.set_species(monkey_type)


### PR DESCRIPTION
Currently, dumping all monkey cubes from a monkey cube box leaves their fingerprintshidden var as null. This causes a runtime after they're actually inflated, but before the cube is deleted. Result: you get one runtime per cube, and can create an infinite amount of monkeys from the same cube (exploit).

This PR adds a check for that condition happening, and prevents it. This eliminates the runtime and stops people getting more than one monkey out of the same cube.

🆑 Kyep
fix: It is no longer possible to create an infinite number of monkeys from the same monkey cube.
/🆑