### PR TITLE
Naming bots is now logged

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -33,7 +33,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
-		log_game("[key_name(usr)] has renamed a robot to [t]")
+		log_game("[key_name(user)] has renamed a robot to [t]")
 
 //Edbot Assembly
 
@@ -57,7 +57,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
-		log_game("[key_name(usr)] has renamed a robot to [t]")
+		log_game("[key_name(user)] has renamed a robot to [t]")
 		return
 
 	switch(build_step)
@@ -259,7 +259,7 @@
 			return
 
 		created_name = t
-		log_game("[key_name(usr)] has renamed a robot to [t]")
+		log_game("[key_name(user)] has renamed a robot to [t]")
 
 /obj/item/toolbox_tiles_sensor/attackby(obj/item/W, mob/user, params)
 	..()
@@ -279,7 +279,7 @@
 			return
 
 		created_name = t
-		log_game("[key_name(usr)] has renamed a robot to [t]")
+		("[key_name(usr)] has renamed a robot to [t]")
 
 //Medbot Assembly
 /obj/item/firstaid_arm_assembly
@@ -354,7 +354,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
-		log_game("[key_name(usr)] has renamed a robot to [t]")
+		log_game("[key_name(user)] has renamed a robot to [t]")
 	else
 		switch(build_step)
 			if(0)
@@ -465,7 +465,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
-		log_game("[key_name(usr)] has renamed a robot to [t]")
+		log_game("[key_name(user)] has renamed a robot to [t]")
 
 	else if(istype(I, /obj/item/screwdriver))
 		if(!build_step)

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -33,6 +33,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
+		log_game("[key_name(usr)] has renamed a robot to [t]")
 
 //Edbot Assembly
 
@@ -56,6 +57,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
+		log_game("[key_name(usr)] has renamed a robot to [t]")
 		return
 
 	switch(build_step)
@@ -257,6 +259,7 @@
 			return
 
 		created_name = t
+		log_game("[key_name(usr)] has renamed a robot to [t]")
 
 /obj/item/toolbox_tiles_sensor/attackby(obj/item/W, mob/user, params)
 	..()
@@ -276,6 +279,7 @@
 			return
 
 		created_name = t
+		log_game("[key_name(usr)] has renamed a robot to [t]")
 
 //Medbot Assembly
 /obj/item/firstaid_arm_assembly
@@ -350,6 +354,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
+		log_game("[key_name(usr)] has renamed a robot to [t]")
 	else
 		switch(build_step)
 			if(0)
@@ -460,6 +465,7 @@
 		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
+		log_game("[key_name(usr)] has renamed a robot to [t]")
 
 	else if(istype(I, /obj/item/screwdriver))
 		if(!build_step)

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -30,7 +30,7 @@
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)
 			return
-		if(!in_range(src, usr) && loc != usr)
+		if(!in_range(src, user) && loc != user)
 			return
 		created_name = t
 		log_game("[key_name(user)] has renamed a robot to [t]")
@@ -54,7 +54,7 @@
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)
 			return
-		if(!in_range(src, usr) && loc != usr)
+		if(!in_range(src, user) && loc != user)
 			return
 		created_name = t
 		log_game("[key_name(user)] has renamed a robot to [t]")
@@ -255,7 +255,7 @@
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)
 			return
-		if(!in_range(src, usr) && loc != usr)
+		if(!in_range(src, user) && loc != user)
 			return
 
 		created_name = t
@@ -275,11 +275,11 @@
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)
 			return
-		if(!in_range(src, usr) && loc != usr)
+		if(!in_range(src, user) && loc != user)
 			return
 
 		created_name = t
-		("[key_name(usr)] has renamed a robot to [t]")
+		log_game("[key_name(user)] has renamed a robot to [t]")
 
 //Medbot Assembly
 /obj/item/firstaid_arm_assembly
@@ -351,7 +351,7 @@
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)
 			return
-		if(!in_range(src, usr) && loc != usr)
+		if(!in_range(src, user) && loc != user)
 			return
 		created_name = t
 		log_game("[key_name(user)] has renamed a robot to [t]")
@@ -462,7 +462,7 @@
 		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
 		if(!t)
 			return
-		if(!in_range(src, usr) && loc != usr)
+		if(!in_range(src, user) && loc != user)
 			return
 		created_name = t
 		log_game("[key_name(user)] has renamed a robot to [t]")


### PR DESCRIPTION
So that admins can catch people who name their bots inappropriately. No CL as this is a backend administration change.