### PR TITLE
Adds login/logout to attack logs

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -4,6 +4,7 @@
 	lastKnownIP	= client.address
 	computer_id	= client.computer_id
 	log_access_in(client)
+	create_attack_log("<font color='red'>Logged in at [atom_loc_line(get_turf(src))]</font>")
 	if(config.log_access)
 		for(var/mob/M in player_list)
 			if(M == src)	continue

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -3,6 +3,7 @@
 	unset_machine()
 	player_list -= src
 	log_access_out(src)
+	create_attack_log("<font color='red'>Logged out at [atom_loc_line(get_turf(src))]</font>")
 	// `holder` is nil'd out by now, so we check the `admin_datums` array directly
 	//Only report this stuff if we are currently playing.
 	if(admin_datums[ckey] && ticker && ticker.current_state == GAME_STATE_PLAYING)


### PR DESCRIPTION
This is a small tweak that ensures login/logout is added to the attack_logs var of player mobs.

What does this mean?
It means that when an admin is looking at a player's attack_logs, they can tell exactly when they logged out, and back in again, and thus, exactly which attacks in their log were performed against them when they were SSD.

This is a tool that allows admins to more effectively enforce our rules against attacking SSDs, by showing them logins/logouts and attacks on that player in the same place.

No CL, as it is back-end only.
Credit to Tigercat for the code.