### PR TITLE
Potential Powernet Fix

### DIFF
--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -44,8 +44,8 @@ SUBSYSTEM_DEF(machines)
 		if(O)
 			var/datum/powernet/newPN = new() // create a new powernet...
 			propagate_network(O, newPN)//... and propagate it to the other side of the cable
-		else
-			deferred_powernet_rebuilds.Remove(O)
+
+		deferred_powernet_rebuilds.Remove(O)
 		if(MC_TICK_CHECK)
 			return
 


### PR DESCRIPTION
When a powernet is destroyed, it rebuilds incessantly and never gets removed. 

This leads to powernets rebuilding and recreating thousands of times a second.

This may fix the issue, it may not; we can only try this out.