### PR TITLE
Fixes Basilisk Projectiles

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -342,9 +342,9 @@
 	user << browse("<TITLE>Temperature Gun Configuration</TITLE><HR>[dat]", "window=tempgun;size=510x120")
 	onclose(user, "tempgun")
 
-/obj/item/gun/energy/temperature/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/card/emag) && !emagged)
-		emagged = 1
+/obj/item/gun/energy/temperature/emag_act(mob/user)
+	if(!emagged)
+		emagged = TRUE
 		to_chat(user, "<span class='caution'>You double the gun's temperature cap! Targets hit by searing beams will burst into flames!</span>")
 		desc = "A gun that changes the body temperature of its targets. Its temperature cap has been hacked."
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -52,7 +52,7 @@
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
 /obj/item/projectile/temp/New(loc, shot_temp)
-	..(loc)
+	..()
 	if(!isnull(shot_temp))
 		temperature = shot_temp
 	switch(temperature)
@@ -86,7 +86,6 @@
 		else
 			name = "temperature beam"//failsafe
 			icon_state = "temp_4"
-	..()
 
 
 /obj/item/projectile/temp/on_hit(var/atom/target, var/blocked = 0)//These two could likely check temp protection on the mob


### PR DESCRIPTION
Fixes: https://github.com/ParadiseSS13/Paradise/issues/9013

Turns out `..()` was being called twice, in `/obj/item/projectile/temp/New` which was causing issues....