### PR TITLE
Removes Advance release grenades

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -100,16 +100,6 @@
 	build_path = /obj/item/grenade/chem_grenade/cryo
 	category = list("Weapons")
 
-/datum/design/adv_grenade
-	name = "Advanced Release Grenade"
-	desc = "An advanced grenade that can be detonated several times, best used with a repeating igniter."
-	id = "adv_Grenade"
-	req_tech = list("combat" = 3, "engineering" = 4)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 3000, MAT_GLASS = 500)
-	build_path = /obj/item/grenade/chem_grenade/adv_release
-	category = list("Weapons")
-
 /datum/design/tele_shield
 	name = "Telescopic Riot Shield"
 	desc = "An advanced riot shield made of lightweight materials that collapses for easy storage."


### PR DESCRIPTION
So this PR was given to me from Spartan who was given it by Crazylemon. This is the description he gave.

"Since many reactions do not scale based on reagent volume, the advanced release grenade's behavior is currently poorly balanced. As such, the design is now removed from what R&D can research until reactions are better-balanced for repeat controlled use"

This PR just removes it from the protolathe, but keeps the item in game. 

:cl:
rscdel: R&D can no longer create advanced-release grenades due to certain reactions not scaling with reagent amount
/:cl: