### PR TITLE
Newbies can always join as Civilian

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -197,17 +197,27 @@
 
 /mob/new_player/proc/IsJobAvailable(rank)
 	var/datum/job/job = job_master.GetJob(rank)
-	if(!job)	return 0
-	if(!job.is_position_available()) return 0
-	if(jobban_isbanned(src,rank))	return 0
-	if(!is_job_whitelisted(src, rank))	 return 0
-	if(!job.player_old_enough(client))	return 0
-	if(job.admin_only && !(check_rights(R_EVENT, 0))) return 0
+	if(!job)
+		return 0
+	if(!job.is_position_available())
+		return 0
+	if(jobban_isbanned(src,rank))
+		return 0
+	if(!is_job_whitelisted(src, rank))
+		return 0
+	if(!job.player_old_enough(client))
+		return 0
+	if(job.admin_only && !(check_rights(R_EVENT, 0)))
+		return 0
 	if(job.available_in_playtime(client))
 		return 0
 
 	if(config.assistantlimit)
 		if(job.title == "Civilian")
+			if(config.use_exp_restrictions && client)
+				var/living_exp = client.get_exp_living_num()
+				if(living_exp < 600) // <10 hours
+					return 1
 			var/count = 0
 			var/datum/job/officer = job_master.GetJob("Security Officer")
 			var/datum/job/warden = job_master.GetJob("Warden")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -214,7 +214,7 @@
 
 	if(config.assistantlimit)
 		if(job.title == "Civilian")
-			if(config.use_exp_restrictions && client)
+			if(config.use_exp_tracking && config.use_exp_restrictions && client)
 				var/living_exp = client.get_exp_living_num()
 				if(living_exp < 600) // <10 hours
 					return 1


### PR DESCRIPTION
This PR does two very simple things:

- It ensures that new players (under 10 hours of playtime) can ALWAYS join as Civilian, no matter what. This is needed because all the other jobs they might be able to join as are regularly full, resulting in them getting a blank 'choose your job' screen, and having a not-so-great first impression of the server.
- It tidies up the IsJobAvailable proc a little.

🆑 Kyep
tweak: New players (under 10 hours playtime) are now always allowed to join as Civilian.
/🆑
