### PR TITLE
Add 3000 more delay to shuttle (5 minutes) on war declaration

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -3,7 +3,7 @@
 #define CHALLENGE_SCALE_PLAYER 1 // How many player per scaling bonus
 #define CHALLENGE_SCALE_BONUS 2 // How many TC per scaling bonus
 #define CHALLENGE_MIN_PLAYERS 50
-#define CHALLENGE_SHUTTLE_DELAY 15000 //25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+#define CHALLENGE_SHUTTLE_DELAY 18000 //30 minutes, so the ops have at least 5 minutes before the shuttle is callable. Gives the nuke op at least 15 minutes before shuttle arrive.
 
 /obj/item/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -3,7 +3,7 @@
 #define CHALLENGE_SCALE_PLAYER 1 // How many player per scaling bonus
 #define CHALLENGE_SCALE_BONUS 2 // How many TC per scaling bonus
 #define CHALLENGE_MIN_PLAYERS 50
-#define CHALLENGE_SHUTTLE_DELAY 18000 //30 minutes, so the ops have at least 5 minutes before the shuttle is callable. Gives the nuke op at least 15 minutes before shuttle arrive.
+#define CHALLENGE_SHUTTLE_DELAY 18000 //30 minutes, so the ops have at least 10 minutes before the shuttle is callable. Gives the nuke ops at least 15 minutes before shuttle arrive.
 
 /obj/item/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"


### PR DESCRIPTION
In response to a round today where the shuttle was called nearly instantly after it can be called on war op, I am making this PR.

Assuming perfect time between war operative arriving on station and the crew instantly call the shuttle when it is available, they should have more than ten minutes to secure the disk.

Letting them call the shuttle in 5 minutes tilt the game unfairly in favour of crew, and ten minutes is usually way less than what is needed to tilt war in one side or the other's favour decisively. 

It also waste everyone's time by depriving them of the opportunity to fight.

So this PR add 3000 tick of delay to the shuttle, meaning it can be called at 30:00 instead of 25:00 on warop. Assuming red alert, that means the shuttle will arrive at 35:00 at the earliest, giving war operative 12 - 15 minutes to fight instead of the previous 7 - 10 minutes.

🆑 
tweak: Shuttle can be called at 30:00 instead of 25:00 during War Ops.
/🆑 