### PR TITLE
Fix fallback amber team never working

### DIFF
--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -203,13 +203,13 @@ var/ert_request_answered = 0
 	var/cyborg_unlock = 0
 
 /datum/response_team/proc/setSlots(com, sec, med, eng, jan, par, cyb)
-	command_slots = com
-	security_slots = sec
-	medical_slots = med
-	engineer_slots = eng
-	janitor_slots = jan
-	paranormal_slots = par
-	cyborg_slots = cyb
+	command_slots = com || command_slots
+	security_slots = sec || security_slots
+	medical_slots = med || medical_slots
+	engineer_slots = eng || engineer_slots
+	janitor_slots = jan || janitor_slots
+	paranormal_slots = par || paranormal_slots
+	cyborg_slots = cyb || cyborg_slots
 
 /datum/response_team/proc/reduceCyborgSlots()
 	cyborg_slots--


### PR DESCRIPTION
The issue was that this line:
`trigger_armed_response_team(new /datum/response_team/amber) // No admins? No problem. Automatically send a code amber ERT.` called `trigger_armed_response_team` with all `null` slots, so on this line `class = input(src, "Which loadout would you like to choose?") in active_team.get_slot_list()`, `active_team.get_slot_list()` always returned an empty list.

This makes it use the default slot numbers instead.

:cl:Tayyyyyyy
fix: ERT should deploy properly without admins now.
/:cl: