### PR TITLE
Revert "Create tgstation.dme symlink for mapdiffbot"

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1,1 +1,0 @@
-paradise.dme


### PR DESCRIPTION
This reverts commit b609a032bfbc15fe96428caadce66b29994af24b.

Mapdiffbot got updated.