### PR TITLE
Adds Free Vending Machines

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -840,6 +840,9 @@
 				  /obj/item/reagent_containers/food/drinks/chicken_soup = 30,/obj/item/reagent_containers/food/drinks/weightloss = 50, /obj/item/reagent_containers/food/drinks/mug = 50)
 	refill_canister = /obj/item/vending_refill/coffee
 
+/obj/machinery/vending/coffee/free
+	prices = list()
+
 /obj/machinery/vending/coffee/New()
 	..()
 	component_parts = list()
@@ -892,6 +895,9 @@
 					/obj/item/reagent_containers/food/snacks/pistachios = 35, /obj/item/reagent_containers/food/snacks/spacetwinkie = 30,/obj/item/reagent_containers/food/snacks/cheesiehonkers = 25,/obj/item/reagent_containers/food/snacks/tastybread = 30)
 	refill_canister = /obj/item/vending_refill/snack
 
+/obj/machinery/vending/snack/free
+	prices = list()
+
 /obj/machinery/vending/snack/New()
 	..()
 	component_parts = list()
@@ -912,6 +918,9 @@
 	prices = list(/obj/item/reagent_containers/food/snacks/chinese/chowmein = 50, /obj/item/reagent_containers/food/snacks/chinese/tao = 50, /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball = 50, /obj/item/reagent_containers/food/snacks/chinese/newdles = 50,
 					/obj/item/reagent_containers/food/snacks/chinese/rice = 50)
 	refill_canister = /obj/item/vending_refill/chinese
+
+/obj/machinery/vending/chinese/free
+	prices = list()
 
 /obj/machinery/vending/chinese/New()
 	..()
@@ -937,6 +946,9 @@
 					/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 20,/obj/item/reagent_containers/food/drinks/cans/starkist = 20,
 					/obj/item/reagent_containers/food/drinks/cans/space_up = 20,/obj/item/reagent_containers/food/drinks/cans/grape_juice = 20)
 	refill_canister = /obj/item/vending_refill/cola
+
+/obj/machinery/vending/cola/free
+	prices = list()
 
 /obj/machinery/vending/cola/New()
 	..()
@@ -964,6 +976,9 @@
 					/obj/item/cartridge/atmos = 75,/obj/item/cartridge/janitor = 100,/obj/item/cartridge/signal/toxins = 150,
 					/obj/item/cartridge/signal = 75)
 	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 0, bio = 0, rad = 0)
+
+/obj/machinery/vending/cart/free
+	prices = list()
 
 /obj/machinery/vending/liberationstation
 	name = "\improper Liberation Station"
@@ -993,6 +1008,9 @@
 	premium = list(/obj/item/clothing/mask/cigarette/cigar/havana = 2,/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 1)
 	prices = list(/obj/item/storage/fancy/cigarettes = 60,/obj/item/storage/fancy/cigarettes/cigpack_uplift = 60,/obj/item/storage/fancy/cigarettes/cigpack_robust = 60,/obj/item/storage/fancy/cigarettes/cigpack_carp = 60,/obj/item/storage/fancy/cigarettes/cigpack_midori = 60,/obj/item/storage/fancy/cigarettes/cigpack_random = 150, /obj/item/reagent_containers/food/pill/patch/nicotine = 15, /obj/item/storage/box/matches = 10,/obj/item/lighter/random = 60, /obj/item/storage/fancy/rollingpapers = 20)
 	refill_canister = /obj/item/vending_refill/cigarette
+
+/obj/machinery/vending/cigarette/free
+	prices = list()
 
 /obj/machinery/vending/cigarette/New()
 	..()
@@ -1432,6 +1450,9 @@
 	contraband = list(/obj/item/fish_eggs/babycarp = 5)
 	premium = list(/obj/item/toy/pet_rock/fred = 1, /obj/item/toy/pet_rock/roxie = 1)
 	refill_canister = /obj/item/vending_refill/crittercare
+
+/obj/machinery/vending/crittercare/free
+	prices = list()
 
 /obj/machinery/vending/crittercare/New()
 	..()


### PR DESCRIPTION
This is more of a mappers tool than anything else.

There's times where you want to have a vending machine in a specific area that can dispense things, but, since it's off station or the people using it are not crew (and therefore don't have money in a station account), it becomes largely decorative.

In any event, this adds free versions of all the vending machines there are; I'm sure these could come in handy in existing maps, but I haven't mapped them in, in this PR.

no CL as this doesn't impact anyone playing the game.