### PR TITLE
Added magboots in the Paramedic's EVA Gear closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -262,6 +262,7 @@
 	new /obj/item/sensor_device(src)
 	new /obj/item/key/ambulance(src)
 	new /obj/item/pinpointer/crew(src)
+	new /obj/item/clothing/shoes/magboots(src)
 
 /obj/structure/closet/secure_closet/reagents
 	name = "chemical storage closet"


### PR DESCRIPTION
The EVA gear needs magboots, otherwise if you'll try to rescue someone in a low pressure enviroment you'll just get flinged everywhere
🆑 Piccione
rscadd: Added Magboots to the Paramedic's EVA gear closet
/ 🆑