### PR TITLE
Medical kit now uses overheal on eligible attached limbs

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -89,21 +89,29 @@
 	var/nrembrute = rembrute
 	var/nremburn	= remburn
 	affecting.heal_damage(heal_brute, heal_burn)
-	if(affecting.body_part in list(ARM_LEFT, ARM_RIGHT, LEG_LEFT, LEG_RIGHT, UPPER_TORSO, LOWER_TORSO))
-		for(var/obj/item/organ/external/E in affecting.children)
-			if(rembrute <= 0 && remburn <= 0) // Make sure there's actually overheal left and the organ is damaged before bothering
-				break
-			else if(E.status && ORGAN_ROBOT || E.open) // Ignore robotic or open limb
-				continue
-			else if(!E.brute_dam && !E.burn_dam) // Ignore undamaged limb
-				continue
-			nrembrute = rembrute - E.brute_dam // Deduct the healed damage from the remain
-			nremburn = remburn - E.burn_dam
-			E.heal_damage(rembrute, remburn)
-			rembrute = nrembrute
-			remburn = nremburn
-			user.visible_message("<span class='green'>[user] [healverb]s the wounds on [H]'s [E.name] with the remaining medication.</span>", \
-								 "<span class='green'>You [healverb] the wounds on [H]'s [E.name] with the remaining medication.</span>" )
+	var/list/achildlist = affecting.children.Copy()
+	var/parenthealed = 0
+	while(rembrute + remburn > 0): // Don't bother if there's not enough leftover heal
+		var/obj/item/organ/external/E
+		if(achildlist.len):
+			E = pick(achildlist) // Pick a random children
+			achildlist -= E
+		else if(affecting.parent && !parenthealed): // If there's a parent and no healing attempt was made on it
+			E = affecting.parent
+			parenthealed = 1
+		else:
+			break // If the organ have no child left and no parent / parent healed, break
+		if(E.status & ORGAN_ROBOT || E.open) // Ignore robotic or open limb
+			continue
+		else if(!E.brute_dam && !E.burn_dam) // Ignore undamaged limb
+			continue
+		nrembrute = rembrute - E.brute_dam // Deduct the healed damage from the remain
+		nremburn = remburn - E.burn_dam
+		E.heal_damage(rembrute, remburn)
+		rembrute = nrembrute
+		remburn = nremburn
+		user.visible_message("<span class='green'>[user] [healverb]s the wounds on [H]'s [E.name] with the remaining medication.</span>", \
+							 "<span class='green'>You [healverb] the wounds on [H]'s [E.name] with the remaining medication.</span>" )
 
 //Bruise Packs//
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -95,7 +95,7 @@
 				break
 			else if(E.status && ORGAN_ROBOT || E.open) // Ignore robotic or open limb
 				continue
-			else if(E.brute_dam == 0 && E.burn_dam == 0) // Ignore undamaged limb
+			else if(!E.brute_dam && !E.burn_dam) // Ignore undamaged limb
 				continue
 			nrembrute = rembrute - E.brute_dam // Deduct the healed damage from the remain
 			nremburn = remburn - E.burn_dam

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -104,7 +104,27 @@
 			if(stop_bleeding)
 				if(!H.bleedsuppress) //so you can't stack bleed suppression
 					H.suppress_bloodloss(stop_bleeding)
+
+			var/rembrute = max(0, heal_brute - affecting.brute_dam)
+			var/remburn = max(0, heal_burn - affecting.burn_dam)
+			var/nrembrute = rembrute
+			var/nremburn	= remburn
 			affecting.heal_damage(heal_brute, heal_burn)
+			if(affecting.body_part in list(ARM_LEFT, ARM_RIGHT, LEG_LEFT, LEG_RIGHT, UPPER_TORSO))
+				for(var/obj/item/organ/external/E in affecting.children)
+					if(rembrute <= 0 && remburn <= 0) // Make sure there's actually overheal left and the organ is damaged before bothering
+						break
+					else if(E.status && ORGAN_ROBOT || E.open == 1) // Ignore robotic or open limb
+						continue
+					else if(E.brute_dam == 0 && E.burn_dam == 0) // Ignore undamaged limb
+						continue
+					nrembrute = rembrute - E.brute_dam // Deduct the healed damage from the remain
+					nremburn = remburn - E.burn_dam
+					E.heal_damage(rembrute, remburn)
+					rembrute = nrembrute
+					remburn = nremburn
+					user.visible_message("<span class='green'>[user] bandages the wounds on [H]'s [E.name] with the remaining bandages.</span>", \
+										 "<span class='green'>You bandages the wounds on [H]'s [E.name] with the remaining bandages.</span>" )
 			H.UpdateDamageIcon()
 			use(1)
 		else
@@ -143,9 +163,26 @@
 		if(affecting.open == 0)
 			affecting.germ_level = 0
 
-			user.visible_message("<span class='green'>[user] salves the wounds on [H]'s [affecting.name].</span>", \
-							 	 "<span class='green'>You salve the wounds on [H]'s [affecting.name].</span>" )
+			var/rembrute = max(0, heal_brute - affecting.brute_dam)
+			var/remburn = max(0, heal_burn - affecting.burn_dam)
+			var/nrembrute = rembrute
+			var/nremburn	= remburn
 			affecting.heal_damage(heal_brute, heal_burn)
+			if(affecting.body_part in list(ARM_LEFT, ARM_RIGHT, LEG_LEFT, LEG_RIGHT, UPPER_TORSO))
+				for(var/obj/item/organ/external/E in affecting.children)
+					if(rembrute <= 0 && remburn <= 0) // Make sure there's actually overheal left and the organ is damaged before bothering
+						break
+					else if(E.status && ORGAN_ROBOT || E.open == 1) // Ignore robotic or open limb
+						continue
+					else if(E.brute_dam == 0 && E.burn_dam == 0) // Ignore undamaged limb
+						continue
+					nrembrute = rembrute - E.brute_dam // Deduct the healed damage from the remain
+					nremburn = remburn - E.burn_dam
+					E.heal_damage(rembrute, remburn)
+					rembrute = nrembrute
+					remburn = nremburn
+					user.visible_message("<span class='green'>[user] salves the wounds on [H]'s [E.name] with the remaining ointment.</span>", \
+										 "<span class='green'>You salve the wounds on [H]'s [E.name] with the remaining ointment.</span>" )
 			H.UpdateDamageIcon()
 			use(1)
 		else

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -104,8 +104,8 @@
 			continue
 		else if(!E.brute_dam && !E.burn_dam) // Ignore undamaged limb
 			continue
-		nrembrute = rembrute - E.brute_dam // Deduct the healed damage from the remain
-		nremburn = remburn - E.burn_dam
+		nrembrute = max(0, rembrute - E.brute_dam) // Deduct the healed damage from the remain
+		nremburn = max(0, remburn - E.burn_dam)
 		E.heal_damage(rembrute, remburn)
 		rembrute = nrembrute
 		remburn = nremburn

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -163,6 +163,9 @@
 		if(affecting.open == 0)
 			affecting.germ_level = 0
 
+			user.visible_message("<span class='green'>[user] salves the wounds on [H]'s [affecting.name].</span>", \
+								 "<span class='green'>You salves the wounds on [H]'s [affecting.name].</span>" )
+
 			var/rembrute = max(0, heal_brute - affecting.brute_dam)
 			var/remburn = max(0, heal_burn - affecting.burn_dam)
 			var/nrembrute = rembrute

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -110,7 +110,7 @@
 			var/nrembrute = rembrute
 			var/nremburn	= remburn
 			affecting.heal_damage(heal_brute, heal_burn)
-			if(affecting.body_part in list(ARM_LEFT, ARM_RIGHT, LEG_LEFT, LEG_RIGHT, UPPER_TORSO))
+			if(affecting.body_part in list(ARM_LEFT, ARM_RIGHT, LEG_LEFT, LEG_RIGHT, UPPER_TORSO, LOWER_TORSO))
 				for(var/obj/item/organ/external/E in affecting.children)
 					if(rembrute <= 0 && remburn <= 0) // Make sure there's actually overheal left and the organ is damaged before bothering
 						break
@@ -171,7 +171,7 @@
 			var/nrembrute = rembrute
 			var/nremburn	= remburn
 			affecting.heal_damage(heal_brute, heal_burn)
-			if(affecting.body_part in list(ARM_LEFT, ARM_RIGHT, LEG_LEFT, LEG_RIGHT, UPPER_TORSO))
+			if(affecting.body_part in list(ARM_LEFT, ARM_RIGHT, LEG_LEFT, LEG_RIGHT, UPPER_TORSO, LOWER_TORSO))
 				for(var/obj/item/organ/external/E in affecting.children)
 					if(rembrute <= 0 && remburn <= 0) // Make sure there's actually overheal left and the organ is damaged before bothering
 						break

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -84,22 +84,21 @@
 	user.visible_message("<span class='green'>[user] [healverb]s the wounds on [H]'s [affecting.name].</span>", \
 						 "<span class='green'>You [healverb] the wounds on [H]'s [affecting.name].</span>" )
 
-	var/rembrute = max(0, heal_brute - affecting.brute_dam)
-	var/remburn = max(0, heal_burn - affecting.burn_dam)
+	var/rembrute = max(0, heal_brute - affecting.brute_dam) // Maxed with 0 since heal_damage let you pass in a negative value
+	var/remburn = max(0, heal_burn - affecting.burn_dam) // And deduct it from their health (aka deal damage)
 	var/nrembrute = rembrute
-	var/nremburn	= remburn
+	var/nremburn = remburn
 	affecting.heal_damage(heal_brute, heal_burn)
 	var/list/achildlist = affecting.children.Copy()
-	var/parenthealed = 0
-	while(rembrute + remburn > 0): // Don't bother if there's not enough leftover heal
+	var/parenthealed = FALSE
+	while(rembrute + remburn > 0) // Don't bother if there's not enough leftover heal
 		var/obj/item/organ/external/E
-		if(achildlist.len):
-			E = pick(achildlist) // Pick a random children
-			achildlist -= E
-		else if(affecting.parent && !parenthealed): // If there's a parent and no healing attempt was made on it
+		if(achildlist.len)
+			E = pick_n_take(achildlist) // Pick a random children and then remove it from the list
+		else if(affecting.parent && !parenthealed) // If there's a parent and no healing attempt was made on it
 			E = affecting.parent
-			parenthealed = 1
-		else:
+			parenthealed = TRUE
+		else
 			break // If the organ have no child left and no parent / parent healed, break
 		if(E.status & ORGAN_ROBOT || E.open) // Ignore robotic or open limb
 			continue


### PR DESCRIPTION
If there's any remaining heal left after healing a targeted limb using a medkit, the remaining overheal would be applied to eligible limbs. This makes the advanced trauma & burn kit a bit stronger and more worth using. 

The eligible limbs are the limb's children (If any) and their parent. Starting from their children first.

EDIT:
For clarification, the advanced kit heals 25 (burn and trauma), and how this PR work is that if you have LEFTOVER HEAL (not use) from a single use, it'll be applied to eligible limbs. 

As an example. A kit with 5 uses and 25 brute, is applied on a right arm with 20 damage. There's a right hand with 20 damage.

Upon using it, ONE USE is deducted from the kit and the right arm would have 0 damage. The remaining bandage get applied to the right hand, and it now has 15 damage.

It doesn't force you to use up any additional uses - It just saves the "Spillover heal" so to speak.

tl;dr - Uses overheal on attached limbs if any

EDIT2:
Better worded CL thanks to Citinited

🆑 
tweak: Assuming there is heal left, bandages and ointments used on limbs now heal both the limb and the hand / foot. Bandages and ointments used on the torso now heal head, arms, and lower body. The one on lower body heals the legs too.
/🆑 