### PR TITLE
Syndicate purchase (and surplus crate content) are now logged to game_log

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1426,6 +1426,7 @@ var/list/uplink_items = list()
 	for(var/category in temp_uplink_list)
 		buyable_items += temp_uplink_list[category]
 	var/list/bought_items = list()
+	var/list/itemlog = list()
 	U.uses -= cost
 	U.used_TC = 20
 	var/remaining_TC = 50
@@ -1441,8 +1442,11 @@ var/list/uplink_items = list()
 			continue
 		bought_items += I.item
 		remaining_TC -= I.cost
+		itemlog += I.name // To make the name more readable for the log compared to just i.item
 
 	U.purchase_log += "<BIG>[bicon(C)]</BIG>"
 	for(var/item in bought_items)
 		new item(C)
 		U.purchase_log += "<BIG>[bicon(item)]</BIG>"
+	var/mob/user = usr
+	log_game("[key_name(user)] purchased a surplus crate with [jointext(itemlog, ", ")]")

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -97,6 +97,7 @@ var/list/uplink_items = list()
 		if(I)
 			if(ishuman(user))
 				var/mob/living/carbon/human/A = user
+				log_game("[key_name(user)] purchased [I.name]")
 				A.put_in_any_hand_if_possible(I)
 
 				if(istype(I,/obj/item/storage/box/) && I.contents.len>0)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1448,5 +1448,4 @@ var/list/uplink_items = list()
 	for(var/item in bought_items)
 		new item(C)
 		U.purchase_log += "<BIG>[bicon(item)]</BIG>"
-	var/mob/user = usr
-	log_game("[key_name(user)] purchased a surplus crate with [jointext(itemlog, ", ")]")
+	log_game("[key_name(usr)] purchased a surplus crate with [jointext(itemlog, ", ")]")


### PR DESCRIPTION
Syndicate purchases and syndicate surplus crate purchase are now logged to game log.

This'll help admins investigate who got what items and better reconstruct events.

Backend no CL blah blah