### PR TITLE
EMP logging improvement

### DIFF
--- a/code/datums/spells/emplosion.dm
+++ b/code/datums/spells/emplosion.dm
@@ -10,6 +10,6 @@
 /obj/effect/proc_holder/spell/targeted/emplosion/cast(list/targets, mob/user = usr)
 
 	for(var/mob/living/target in targets)
-		empulse(target.loc, emp_heavy, emp_light)
+		empulse(target.loc, emp_heavy, emp_light, 1)
 
 	return

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -740,7 +740,7 @@ var/list/teleport_runes = list()
 				to_chat(L, "<span class=userdanger'>You chant in unison and a colossal burst of energy knocks you backward!</span>")
 				L.Weaken(2)
 	qdel(src) //delete before pulsing because it's a delay reee
-	empulse(E, 9*invokers.len, 12*invokers.len) // Scales now, from a single room to most of the station depending on # of chanters
+	empulse(E, 9*invokers.len, 12*invokers.len, 1) // Scales now, from a single room to most of the station depending on # of chanters
 
 //Rite of Astral Communion: Separates one's spirit from their body. They will take damage while it is active.
 /obj/effect/rune/astral

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -220,7 +220,7 @@
 	. = ..()
 	user.visible_message("<span class='warning'>[user]'s hand flashes a bright blue!</span>", \
 						 "<span class='cultitalic'>You speak the words of the talisman, emitting an EMP blast.</span>")
-	empulse(src, 4, 8)
+	empulse(src, 4, 8, 1)
 
 
 //Rite of Disorientation: Stuns and inhibit speech on a single target for quite some time

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -5,8 +5,8 @@
 		epicenter = get_turf(epicenter.loc)
 
 	if(log)
-		message_admins("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
-		log_game("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] ")
+		message_admins("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] [ADMIN_COORDJMP(epicenter)]</a>")
+		log_game("EMP with size ([heavy_range], [light_range]) in area [epicenter.loc.name] [COORD(epicenter)]")
 
 	if(heavy_range > 1)
 		new/obj/effect/temp_visual/emp/pulse(epicenter)

--- a/code/game/objects/items/weapons/grenades/emgrenade.dm
+++ b/code/game/objects/items/weapons/grenades/emgrenade.dm
@@ -7,5 +7,5 @@
 
 /obj/item/grenade/empgrenade/prime()
 	update_mob()
-	empulse(src, 4, 10)
+	empulse(src, 4, 10, 1)
 	qdel(src)

--- a/code/game/objects/items/weapons/implants/implant_misc.dm
+++ b/code/game/objects/items/weapons/implants/implant_misc.dm
@@ -58,7 +58,7 @@
 
 /obj/item/implant/emp/activate()
 	uses--
-	empulse(imp_in, 3, 5)
+	empulse(imp_in, 3, 5, 1)
 	if(!uses)
 		qdel(src)
 

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -8,14 +8,14 @@
 
 /obj/item/projectile/ion/on_hit(var/atom/target, var/blocked = 0)
 	..()
-	empulse(target, 1, 1)
+	empulse(target, 1, 1, 1)
 	return 1
 
 /obj/item/projectile/ion/weak
 
 /obj/item/projectile/ion/weak/on_hit(atom/target, blocked = 0)
 	..()
-	empulse(target, 0, 0)
+	empulse(target, 0, 0, 1)
 	return 1
 
 /obj/item/projectile/bullet/gyro

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -334,7 +334,7 @@
 
 /datum/chemical_reaction/slimeoverload/on_reaction(datum/reagents/holder, created_volume)
 	feedback_add_details("slime_cores_used","[type]")
-	empulse(get_turf(holder.my_atom), 3, 7)
+	empulse(get_turf(holder.my_atom), 3, 7, 1)
 
 
 /datum/chemical_reaction/slimecell


### PR DESCRIPTION
When EMPulse is logged, it now provide you with the coordinate of the epicenter and allow you to jump to it.

Most instance of EMP grenade and explosion's code has been toggled to be logged - Like EMPgrenade, emp talismen, etc. They're just as necessary as attack log to investigate things. 

No CL, backend