### PR TITLE
Pain Refactor and Tweaks

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -24,13 +24,13 @@
 	user.CureNearsighted()
 	user.reagents.clear_reagents()
 	user.germ_level = 0
-	user.next_pain_time = 0
 	user.timeofdeath = 0
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.restore_blood()
 		H.traumatic_shock = 0
 		H.shock_stage = 0
+		H.next_pain_time = 0
 		H.species.create_organs(H)
 		// Now that recreating all organs is necessary, the rest of this organ stuff probably
 		//  isn't, but I don't want to remove it, just in case.

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -15,6 +15,7 @@
 	parent_organ = "head"
 	slot = "brain"
 	vital = 1
+	hidden_pain = TRUE //the brain has no pain receptors, and brain damage is meant to be a stealthy damage type.
 	var/mmi_icon = 'icons/obj/assemblies.dmi'
 	var/mmi_icon_state = "mmi_full"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1201,7 +1201,7 @@
 		return 0
 
 	if(!L.is_bruised())
-		src.custom_pain("You feel a stabbing pain in your chest!", 1)
+		custom_pain("You feel a stabbing pain in your chest!")
 		L.damage = L.min_bruised_damage
 
 //returns 1 if made bloody, returns 0 otherwise

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -20,7 +20,7 @@
 		//Moving around with fractured ribs won't do you any good
 			if(E.is_broken() && E.internal_organs && E.internal_organs.len && prob(15))
 				var/obj/item/organ/internal/I = pick(E.internal_organs)
-				custom_pain("You feel broken bones moving in your [E.name]!", 1)
+				custom_pain("You feel broken bones moving in your [E.name]!")
 				I.receive_damage(rand(3,5))
 
 	//handle_stance()

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -49,7 +49,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the damaged bones in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the damaged bones in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",1)
+	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 	..()
 
 /datum/surgery_step/glue_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -83,7 +83,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to set the bone in [target]'s [affected.name] in place with \the [tool]." , \
 		"You are beginning to set the bone in [target]'s [affected.name] in place with \the [tool].")
-	target.custom_pain("The pain in your [affected.name] is going to make you pass out!",1)
+	target.custom_pain("The pain in your [affected.name] is going to make you pass out!")
 	..()
 
 /datum/surgery_step/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -78,7 +78,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool].", \
 	"You start making some space inside [target]'s [get_cavity(affected)] cavity with \the [tool]." )
-	target.custom_pain("The pain in your chest is living hell!",1)
+	target.custom_pain("The pain in your chest is living hell!")
 	..()
 
 /datum/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -104,7 +104,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts mending [target]'s [get_cavity(affected)] cavity wall with \the [tool].", \
 	"You start mending [target]'s [get_cavity(affected)] cavity wall with \the [tool]." )
-	target.custom_pain("The pain in your chest is living hell!",1)
+	target.custom_pain("The pain in your chest is living hell!")
 	..()
 
 /datum/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -155,7 +155,7 @@
 	else //no internal items..but we still need a message!
 		user.visible_message("[user] checks for items in [target]'s [target_zone].", "<span class='notice'>You check for items in [target]'s [target_zone]...</span>")
 
-	target.custom_pain("The pain in your [target_zone] is living hell!",1)
+	target.custom_pain("The pain in your [target_zone] is living hell!")
 	..()
 
 /datum/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -190,7 +190,7 @@
 			if((tool.w_class > get_max_wclass(affected)/2 && prob(50) && !(affected.status & ORGAN_ROBOT)))
 				to_chat(user, "<span class='warning'> You tear some vessels trying to fit the object in the cavity.</span>")
 				affected.internal_bleeding = TRUE
-				affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1)
+				affected.owner.custom_pain("You feel something rip in your [affected.name]!")
 			user.drop_item()
 			affected.hidden = tool
 			tool.forceMove(affected)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -38,7 +38,7 @@
 
 	user.visible_message("[user] begins to cut through [target]'s [affected.encased] with \the [tool].", \
 	"You begin to cut through [target]'s [affected.encased] with \the [tool].")
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
 /datum/surgery_step/open_encased/saw/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -86,7 +86,7 @@
 	var/msg = "[user] starts to force open the [affected.encased] in [target]'s [affected.name] with \the [tool]."
 	var/self_msg = "You start to force open the [affected.encased] in [target]'s [affected.name] with \the [tool]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
 /datum/surgery_step/open_encased/retract/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -137,7 +137,7 @@
 	var/msg = "[user] starts bending [target]'s [affected.encased] back into place with \the [tool]."
 	var/self_msg = "You start bending [target]'s [affected.encased] back into place with \the [tool]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
 /datum/surgery_step/open_encased/close/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -187,7 +187,7 @@
 	var/msg = "[user] starts applying \the [tool] to [target]'s [affected.encased]."
 	var/self_msg = "You start applying \the [tool] to [target]'s [affected.encased]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("Something hurts horribly in your [affected.name]!",1)
+	target.custom_pain("Something hurts horribly in your [affected.name]!")
 	..()
 
 /datum/surgery_step/open_encased/mend/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -37,7 +37,7 @@
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("[user] starts the incision on [target]'s [affected.name] with \the [tool].", \
 		"You start the incision on [target]'s [affected.name] with \the [tool].")
-		target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!",1)
+		target.custom_pain("You feel a horrible pain as if from a sharp knife in your [affected.name]!")
 		..()
 
 /datum/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -71,7 +71,7 @@
 		var/obj/item/organ/external/affected = target.get_organ(target_zone)
 		user.visible_message("[user] starts clamping bleeders in [target]'s [affected.name] with \the [tool].", \
 		"You start clamping bleeders in [target]'s [affected.name] with \the [tool].")
-		target.custom_pain("The pain in your [affected.name] is maddening!",1)
+		target.custom_pain("The pain in your [affected.name] is maddening!")
 		..()
 
 /datum/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -111,7 +111,7 @@
 		msg = "[user] starts to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
 		self_msg = "You start to pry open the incision and rearrange the organs in [target]'s lower abdomen with \the [tool]."
 	user.visible_message(msg, self_msg)
-	target.custom_pain("It feels like the skin on your [affected.name] is on fire!",1)
+	target.custom_pain("It feels like the skin on your [affected.name] is on fire!")
 	..()
 
 /datum/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -160,7 +160,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to cauterize the incision on [target]'s [affected.name] with \the [tool]." , \
 	"You are beginning to cauterize the incision on [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("Your [affected.name] is being burned!",1)
+	target.custom_pain("Your [affected.name] is being burned!")
 	..()
 
 /datum/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -219,7 +219,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] is beginning to amputate [target]'s [affected.name] with \the [tool]." , \
 	"You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool].")
-	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",1)
+	target.custom_pain("Your [affected.amputation_point] is being ripped apart!")
 	..()
 
 /datum/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -45,7 +45,7 @@
 	I = locate(/obj/item/implant) in target
 	user.visible_message("[user] starts poking around inside [target]'s [affected.name] with \the [tool].", \
 	"You start poking around inside [target]'s [affected.name] with \the [tool]." )
-	target.custom_pain("The pain in your [affected.name] is living hell!",1)
+	target.custom_pain("The pain in your [affected.name] is living hell!")
 	..()
 
 /datum/surgery_step/extract_implant/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -30,6 +30,7 @@
 	var/sterile = FALSE //can the organ be infected by germs?
 	var/tough = FALSE //can organ be easily damaged?
 	var/emp_proof = FALSE //is the organ immune to EMPs?
+	var/hidden_pain = FALSE //will it skip pain messages?
 
 
 /obj/item/organ/Destroy()
@@ -232,7 +233,7 @@
 		if(owner && parent_organ && amount > 0)
 			var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 			if(parent && !silent)
-				owner.custom_pain("Something inside your [parent.name] hurts a lot.", 1)
+				owner.custom_pain("Something inside your [parent.name] hurts a lot.")
 
 		//check if we've hit max_damage
 	if(damage >= max_damage)

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -409,7 +409,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/local_damage = brute_dam + damage
 	if(damage > 15 && local_damage > 30 && prob(damage) && !(status & ORGAN_ROBOT))
 		internal_bleeding = TRUE
-		owner.custom_pain("You feel something rip in your [name]!", 1)
+		owner.custom_pain("You feel something rip in your [name]!")
 
 // new damage icon system
 // returns just the brute/burn damage code

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -1,41 +1,28 @@
-mob/var/list/pain_stored = list()
-mob/var/last_pain_message = ""
-mob/var/next_pain_time = 0
+/mob/living/carbon/human
+	var/last_pain_message = ""
+	var/next_pain_time = 0
 
 // partname is the name of a body part
 // amount is a num from 1 to 100
-mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0)
-	if(stat >= 2) return
+/mob/living/carbon/human/proc/pain(partname, amount)
+	if(stat >= UNCONSCIOUS)
+		return
 	if(reagents.has_reagent("sal_acid"))
 		return
 	if(reagents.has_reagent("morphine"))
 		return
 	if(reagents.has_reagent("hydrocodone"))
 		return
-	if(world.time < next_pain_time && !force)
+	if(world.time < next_pain_time)
 		return
-	if(amount > 10 && istype(src,/mob/living/carbon/human))
-		if(paralysis)
-			AdjustParalysis(-round(amount/10))
-	if(amount > 50 && prob(amount / 5))
-		src:drop_item()
 	var/msg
-	if(burning)
-		switch(amount)
-			if(1 to 10)
-				msg = "<span class='danger'>Your [partname] burns.</span>"
-			if(11 to 90)
-				msg = "<span class='danger'><font size=2>Your [partname] burns badly!</font></span>"
-			if(91 to 10000)
-				msg = "<span class='danger'><font size=3>OH GOD! Your [partname] is on fire!</font></span>"
-	else
-		switch(amount)
-			if(1 to 10)
-				msg = "<b>Your [partname] hurts.</b>"
-			if(11 to 90)
-				msg = "<b><font size=2>Your [partname] hurts badly.</font></b>"
-			if(91 to 10000)
-				msg = "<b><font size=3>OH GOD! Your [partname] is hurting terribly!</font></b>"
+	switch(amount)
+		if(1 to 10)
+			msg = "<b>Your [partname] hurts.</b>"
+		if(11 to 90)
+			msg = "<b><font size=2>Your [partname] hurts badly.</font></b>"
+		if(91 to INFINITY)
+			msg = "<b><font size=3>OH GOD! Your [partname] is hurting terribly!</font></b>"
 	if(msg && (msg != last_pain_message || prob(10)))
 		last_pain_message = msg
 		to_chat(src, msg)
@@ -43,20 +30,18 @@ mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0
 
 
 // message is the custom message to be displayed
-// flash_strength is 0 for weak pain flash, 1 for strong pain flash
-mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
-	if(stat >= 1) return
+mob/living/carbon/human/proc/custom_pain(message)
+	if(stat >= UNCONSCIOUS)
+		return
 
 	if(NO_PAIN in species.species_traits)
 		return
-
 	if(reagents.has_reagent("morphine"))
 		return
 	if(reagents.has_reagent("hydrocodone"))
 		return
+
 	var/msg = "<span class='danger'>[message]</span>"
-	if(flash_strength >= 1)
-		msg = "<span class='warning'><font size=3><b>[message]</b></font></span>"
 
 	// Anti message spam checks
 	if(msg && ((msg != last_pain_message) || (world.time >= next_pain_time)))
@@ -67,70 +52,33 @@ mob/living/carbon/human/proc/custom_pain(var/message, var/flash_strength)
 mob/living/carbon/human/proc/handle_pain()
 	// not when sleeping
 
-	if(NO_PAIN in species.species_traits)
-		//While synthetics don't feel pain, they will notice their gears gunking up with residue (toxins)
-		if(isSynthetic())
-			var/toxDamageMessage = null
-			var/toxMessageProb = 1
-			switch(getToxLoss())
-				if(25 to 50)
-					toxMessageProb = 1
-					toxDamageMessage = "Your servos seem to be working harder."
-				if(50 to 75)
-					toxMessageProb = 2
-					toxDamageMessage = "Your joints seem to stick randomly."
-				if(75 to INFINITY)
-					toxMessageProb = 5
-					toxDamageMessage = "Your motors seem to slip; it really grinds your gears!"
-			if(toxDamageMessage && prob(toxMessageProb))
-				src.custom_pain(toxDamageMessage, getToxLoss() >= 15)
+	if(stat >= UNCONSCIOUS)
 		return
-
-	if(stat >= 2) return
+	if(NO_PAIN in species.species_traits)
+		return
 	if(reagents.has_reagent("morphine"))
 		return
 	if(reagents.has_reagent("hydrocodone"))
 		return
+
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/E in bodyparts)
-		if(E.status & ORGAN_DEAD|ORGAN_ROBOT) continue
+		if((E.status & ORGAN_DEAD|ORGAN_ROBOT) || E.hidden_pain)
+			continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,
 		// but also sometimes use one of the less damaged ones
-		if(dam > maxdam && (maxdam == 0 || prob(70)) )
+		if(dam > maxdam && (maxdam == 0 || prob(70)))
 			damaged_organ = E
 			maxdam = dam
 		if(damaged_organ)
-			pain(damaged_organ.name, maxdam, 0)
-
+			pain(damaged_organ.name, maxdam)
 
 	// Damage to internal organs hurts a lot.
 	for(var/obj/item/organ/internal/I in internal_organs)
-		if(istype(I, /obj/item/organ/internal/brain)) //the brain has no pain receptors, and brain damage is meant to be a stealthy damage type.
+		if(I.hidden_pain)
 			continue
-		if(I.damage > 2) if(prob(2))
+		if(I.damage > 2 && prob(2))
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
-			src.custom_pain("You feel a sharp pain in your [parent.limb_name]", 1)
-
-	var/toxDamageMessage = null
-	var/toxMessageProb = 1
-	switch(getToxLoss())
-		if(1 to 5)
-			toxMessageProb = 1
-			toxDamageMessage = "Your body stings slightly."
-		if(6 to 10)
-			toxMessageProb = 2
-			toxDamageMessage = "Your whole body hurts a little."
-		if(11 to 15)
-			toxMessageProb = 2
-			toxDamageMessage = "Your whole body hurts."
-		if(15 to 25)
-			toxMessageProb = 3
-			toxDamageMessage = "Your whole body hurts badly."
-		if(26 to INFINITY)
-			toxMessageProb = 5
-			toxDamageMessage = "Your body aches all over, it's driving you mad."
-
-	if(toxDamageMessage && prob(toxMessageProb))
-		src.custom_pain(toxDamageMessage, getToxLoss() >= 15)
+			custom_pain("You feel a sharp pain in your [parent.limb_name]")

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -116,7 +116,7 @@
 		if(affected)
 			user.visible_message("[user] starts transplanting [tool] into [target]'s [affected.name].", \
 			"You start transplanting [tool] into [target]'s [affected.name].")
-			H.custom_pain("Someone's rooting around in your [affected.name]!",1)
+			H.custom_pain("Someone's rooting around in your [affected.name]!")
 		else
 			user.visible_message("[user] starts transplanting [tool] into [target]'s [parse_zone(target_zone)].", \
 			"You start transplanting [tool] into [target]'s [parse_zone(target_zone)].")
@@ -143,7 +143,7 @@
 					self_msg = "You begin injecting [tool] into [target]'s [I.name]."
 				user.visible_message(msg, self_msg)
 				if(H && affected)
-					H.custom_pain("Something burns horribly in your [affected.name]!",1)
+					H.custom_pain("Something burns horribly in your [affected.name]!")
 
 	else if(implement_type in implements_finsh)
 	//same as surgery step /datum/surgery_step/open_encased/close/
@@ -159,7 +159,7 @@
 			user.visible_message(msg, self_msg)
 
 		if(H && affected)
-			H.custom_pain("Something hurts horribly in your [affected.name]!",1)
+			H.custom_pain("Something hurts horribly in your [affected.name]!")
 
 	else if(implement_type in implements_extract)
 		current_type = "extract"
@@ -188,7 +188,7 @@
 			user.visible_message("[user] starts to separate [target]'s [I] with [tool].", \
 			"You start to separate [target]'s [I] with [tool] for removal." )
 			if(H && affected)
-				H.custom_pain("The pain in your [affected.name] is living hell!",1)
+				H.custom_pain("The pain in your [affected.name] is living hell!")
 		else
 			return -1
 
@@ -221,7 +221,7 @@
 				to_chat(user, "[I] does not appear to be damaged.")
 
 		if(affected)
-			H.custom_pain("The pain in your [affected.name] is living hell!", 1)
+			H.custom_pain("The pain in your [affected.name] is living hell!")
 
 	else if(istype(tool, /obj/item/reagent_containers/food/snacks/organ))
 		to_chat(user, "<span class='warning'>[tool] was bitten by someone! It's too damaged to use!</span>")

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -80,7 +80,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts patching the damaged vein in [target]'s [affected.name] with \the [tool]." , \
 	"You start patching the damaged vein in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("The pain in [affected.name] is unbearable!",1)
+	target.custom_pain("The pain in [affected.name] is unbearable!")
 	..()
 
 /datum/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -133,7 +133,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts cutting away necrotic tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start cutting away necrotic tissue in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("The pain in [affected.name] is unbearable!",1)
+	target.custom_pain("The pain in [affected.name] is unbearable!")
 	..()
 
 /datum/surgery_step/fix_dead_tissue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
@@ -191,7 +191,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts applying medication to the affected tissue in [target]'s [affected.name] with \the [tool]." , \
 	"You start applying medication to the affected tissue in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",1)
+	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!")
 	..()
 
 /datum/surgery_step/treat_necrosis/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -325,7 +325,7 @@
 
 		user.visible_message("[user] begins reattaching [target]'s [tool].", \
 		"You start reattaching [target]'s [tool].")
-		target.custom_pain("Someone's rooting around in your [affected.name]!",1)
+		target.custom_pain("Someone's rooting around in your [affected.name]!")
 	else if(istype(tool,/obj/item/mmi))
 		current_type = "install"
 
@@ -386,7 +386,7 @@
 				user.visible_message("[user] starts to decouple [target]'s [I] with \the [tool].", \
 				"You start to decouple [target]'s [I] with \the [tool]." )
 
-				target.custom_pain("The pain in your [affected.name] is living hell!",1)
+				target.custom_pain("The pain in your [affected.name] is living hell!")
 			else
 				return -1
 
@@ -407,7 +407,7 @@
 			to_chat(user, "There are no damaged components in [affected].")
 			return -1
 
-		target.custom_pain("The pain in your [affected.name] is living hell!",1)
+		target.custom_pain("The pain in your [affected.name] is living hell!")
 
 	else if(implement_type in implements_finish)
 		current_type = "finish"
@@ -522,7 +522,7 @@
 	user.visible_message("[user] starts to decouple [target]'s [affected.name] with \the [tool].", \
 	"You start to decouple [target]'s [affected.name] with \the [tool]." )
 
-	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",1)
+	target.custom_pain("Your [affected.amputation_point] is being ripped apart!")
 	..()
 
 /datum/surgery_step/robotics/external/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)


### PR DESCRIPTION
Just a cleanup of the pain file along with some tweaks

Fixes
- Fixes any pain message occurring when unconscious

Balance changes
- Helps make toxin damage more stealthy; it will no longer cause messages of stinging
  - High toxin levels are still going to make you throw up and give you the nausea messages though
- Removes some code logic that related to reducing paralysis if you took damage

Other
- Removed code for dropping items if you had damage levels over 50 on external limbs (this code literally never runs, under any condition, ever)
- Made pain checking based on individual organs more OOP
- Removed flash pain, as it's no longer used
- Removes unused burning pain code

:cl: Fox McCloud
tweak: Toxin damage is stealthier and will no longer cause stinging spam message
/:cl: