### PR TITLE
Laser tag projectiles make tap sound when striking

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -77,7 +77,7 @@
 /obj/item/projectile/beam/lasertag
 	name = "laser tag beam"
 	icon_state = "omnilaser"
-	hitsound = null
+	hitsound = 'sound/weapons/tap.ogg'
 	damage = 0
 	damage_type = STAMINA
 	flag = "laser"


### PR DESCRIPTION
As per Fox's suggestion. Laser tag gun projectiles now just play tap.ogg instead of the melee hit sound.

Fixes #9034 

🆑 Birdtalon
fix: laser tag gun projectiles now play appropriate sound when striking.
/🆑 