### PR TITLE
Small holoparasite update

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -448,6 +448,14 @@
  <b>Support</b>:Has two modes. Combat: Medium power attacks and damage resist. Healer: Attacks heal damage, but low damage resist and slow movemen. Can deploy a bluespace beacon and warp targets to it (including you) in either mode.<br>
  <br>
  <b>Explosive</b>: High damage resist and medium power attack. Can turn any object into a bomb, dealing explosive damage to the next person to touch it. The object will return to normal after the trap is triggered.<br>
+ <br>
+ <b>Assassin</b>: Medium damage with no damage resistance, can enter stealth which massively increases the damage of the next attack causing it to ignore armour.
+ <br>
+ <b>Charger</b>: Medium damage and defense, very fast and has a special charge attack which damages a target and knocks items out of their hands.
+ <br>
+ <b>Lightning</b>: Applies lightning chains to any targets on attack with a link to your summoner, lightning chains will shock anyone nearby.
+ <br>
+ <b>Protector</b>: You will become leashed to your holoparasite instead of them to you. Has two modes, a medium attack/defense mode and a protection mode which greatly reduces incoming damage to the holoparasite.
 "}
 
 /obj/item/paper/guardian/update_icon()

--- a/code/game/gamemodes/miniantags/guardian/types/charger.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/charger.dm
@@ -6,7 +6,7 @@
 	ranged_cooldown_time = 40
 	speed = -1
 	damage_transfer = 0.6
-	playstyle_string = "As a <b>Charger</b> type you do medium damage, have medium damage resistance, move very fast, and can charge at a location, damaging any target hit and forcing them to drop any items they are holding."
+	playstyle_string = "As a <b>Charger</b> type you do medium damage, have medium damage resistance, move very fast, and can charge at a location, damaging any target hit and forcing them to drop any items they are holding. (Click a tile to use your charge ability)"
 	magic_fluff_string = "..And draw the Hunter, an alien master of rapid assault."
 	tech_fluff_string = "Boot sequence complete. Charge modules loaded. Holoparasite swarm online."
 	bio_fluff_string = "Your scarab swarm finishes mutating and stirs to life, ready to deal damage."


### PR DESCRIPTION
Updates holoparasite guide to include the new types, this never got updated when those were added.

Adds a small tooltip for charger holoparasite on how to use their ability. (I had no idea when I spawned as one for the first time)

🆑 Birdtalon
tweak: Holoparasite guide updated to include newer models. Small tooltip added for charger models.
/🆑 