### PR TITLE
Reduce sling dethrall surgery steps

### DIFF
--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -241,7 +241,7 @@
 //////////////////////////////////////////////////////////////////
 /datum/surgery/remove_thrall
 	name = "Remove Shadow Tumor"
-	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/internal/dethrall, /datum/surgery_step/generic/cauterize)
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin,  /datum/surgery_step/internal/dethrall, /datum/surgery_step/generic/cauterize)
 	possible_locs = list("head", "chest", "groin")
 
 /datum/surgery/remove_thrall/synth

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -241,7 +241,7 @@
 //////////////////////////////////////////////////////////////////
 /datum/surgery/remove_thrall
 	name = "Remove Shadow Tumor"
-	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/generic/clamp_bleeders, /datum/surgery_step/generic/retract_skin, /datum/surgery_step/open_encased/saw,/datum/surgery_step/open_encased/retract, /datum/surgery_step/internal/dethrall, /datum/surgery_step/glue_bone, /datum/surgery_step/set_bone,/datum/surgery_step/finish_bone,/datum/surgery_step/generic/cauterize)
+	steps = list(/datum/surgery_step/generic/cut_open, /datum/surgery_step/internal/dethrall, /datum/surgery_step/generic/cauterize)
 	possible_locs = list("head", "chest", "groin")
 
 /datum/surgery/remove_thrall/synth


### PR DESCRIPTION
First, sorry for another balance PR on top of so many open PRs already. Here's an idea for making shadowlings less snowbally. Surgery for dethralling has been reduced to five steps:

1. Scalpel to the head
2. Hemostat
3. Retractor
4. Shine light
5. Cautery

This will make it easier to handle thralls ~,as well as allow for simple dethralling with a glass shard, a flashlight, and a lighter~. Steps were restored cause it's a little weird and unintuitive to have a 3 step surgery. A 5 step surgery is more in line with other surgeries.

:cl: Tayyyyyyy
tweak: Shadowling dethrall has been shortened to scalpel, hemostat, retractor, shine light, cautery
/:cl: