### PR TITLE
Fix ToS consent logic

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -26,6 +26,7 @@
 
 /mob/new_player/proc/handle_tos_consent()
 	if(!GLOB.join_tos)
+		tos_consent = TRUE
 		return TRUE
 
 	establish_db_connection()


### PR DESCRIPTION
Not having a Terms of Service file no longer makes it impossible to consent to the Terms of Service.