### PR TITLE
Improved (ish) attack log logging

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -255,8 +255,8 @@ This is always put in the attack log.
 			add_attack_logs(user, M, what_done, admin_notify)
 		return
 
-	var/user_str = key_name(user)
-	var/target_str = key_name(target)
+	var/user_str = key_name_log(user)
+	var/target_str = key_name_log(target)
 
 	if(istype(user))
 		user.create_attack_log("<font color='red'>Attacked [target_str]: [what_done]</font>")

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -78,7 +78,7 @@
 
 /proc/key_name_log(whom)
 	// Key_name_admin, but does not include (?) or jump link - For logging purpose to reduce clutter while figuring out who is SSD and/or antag when being attacked. Also remove formatting since it is not displayed
-	var/message = "[key_name(whom, 1)][isAntag(whom) ? "(ANTAG)" : ""][isLivingSSD(whom) ? "(SSD!)": ""]"
+	var/message = "[key_name(whom, 0)][isAntag(whom) ? "(ANTAG)" : ""][isLivingSSD(whom) ? "(SSD!)": ""]"
 	return message
 
 /proc/log_and_message_admins(var/message as text)

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -77,8 +77,8 @@
 	return message
 
 /proc/key_name_log(whom)
-	// Key_name_admin, but does not include (?) or jump link - For logging purpose to reduce clutter while figuring out who is SSD and/or antag when being attacked
-	var/message = "[key_name(whom, 1)][isAntag(whom) ? "<font color='red'>(A)</font>" : ""][isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""]"
+	// Key_name_admin, but does not include (?) or jump link - For logging purpose to reduce clutter while figuring out who is SSD and/or antag when being attacked. Also remove formatting since it is not displayed
+	var/message = "[key_name(whom, 1)][isAntag(whom) ? "(ANTAG)" : ""][isLivingSSD(whom) ? "(SSD!)": ""]"
 	return message
 
 /proc/log_and_message_admins(var/message as text)

--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -76,6 +76,10 @@
 	var/message = "[key_name(whom, 1)] [isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""] ([admin_jump_link(whom)])"
 	return message
 
+/proc/key_name_log(whom)
+	// Key_name_admin, but does not include (?) or jump link - For logging purpose to reduce clutter while figuring out who is SSD and/or antag when being attacked
+	var/message = "[key_name(whom, 1)][isAntag(whom) ? "<font color='red'>(A)</font>" : ""][isLivingSSD(whom) ? "<span class='danger'>(SSD!)</span>" : ""]"
+	return message
 
 /proc/log_and_message_admins(var/message as text)
 	log_admin("[key_name(usr)] " + message)

--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -179,8 +179,7 @@
 		C.ExtinguishMob()
 
 		C.visible_message("<span class='warning'>[user] sprays a cloud of fine ice crystals, engulfing [C]!</span>")
-		log_attack(user, C, "Used cryokinesis on a victim without internals or a suit")
-		msg_admin_attack("[key_name_admin(user)] has cast cryokinesis on [key_name_admin(C)] (NO SUIT)")
+		add_attack_logs(user, C, "Cryokinesis- NO SUIT/INTERNALS")
 
 	//playsound(user.loc, 'bamf.ogg', 50, 0)
 

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -84,7 +84,7 @@
 		var/confirm = alert("Are you sure you want to wipe this card's memory? This cannot be undone once started.", "Confirm Wipe", "Yes", "No")
 		if(confirm == "Yes" && (CanUseTopic(user, state) == STATUS_INTERACTIVE))
 			msg_admin_attack("[key_name_admin(user)] wiped [key_name_admin(AI)] with \the [src].")
-			log_attack(user, AI, "Wiped with [src].")
+			add_attack_logs(user, AI, "Wiped with [src].")
 			flush = 1
 			AI.suiciding = 1
 			to_chat(AI, "Your core files are being wiped!")


### PR DESCRIPTION
This PR addresses some of the concern about attack log logging:

1. A new proc called key_name_log is added - It is like key_name_admin, except with the jump and ? function and formatting removed so it doesn't clutter up the backend log as much
2. Create_attack_log now use key_name_log instead of key_name, providing admin with vital info on whether the target is SSD and the victim / initiator is an antag
3. Replaced two instances where log_attack is directly used with Create_attack_logs, which is more consistent and notify the admins online.

No CL, backend