### PR TITLE
Add shuttle cooldown

### DIFF
--- a/code/controllers/Processes/shuttles.dm
+++ b/code/controllers/Processes/shuttles.dm
@@ -227,12 +227,15 @@ DECLARE_GLOBAL_CONTROLLER(shuttle, shuttle_master)
 	var/obj/docking_port/stationary/D = getDock(dockId)
 	if(!M)
 		return 1
+	if(M.cd + M.cdint > world.time)
+		return 2
 	if(timed)
 		if(M.request(D))
-			return 2
+			return 3
 	else
 		if(M.dock(D))
-			return 2
+			return 3
+	M.cd = world.time
 	return 0	//dock successful
 
 /datum/controller/process/shuttle/proc/initial_move()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -75,7 +75,6 @@
 		_y + (-dwidth+width-1)*sin + (-dheight+height-1)*cos
 		)
 
-
 //returns turfs within our projected rectangle in a specific order.
 //this ensures that turfs are copied over in the same order, regardless of any rotation
 /obj/docking_port/proc/return_ordered_turfs(_x, _y, _z, _dir, area/A)
@@ -206,6 +205,8 @@
 	var/roundstart_move				//id of port to send shuttle to at roundstart
 	var/travelDir = 0				//direction the shuttle would travel in
 	var/rebuildable = 0				//can build new shuttle consoles for this one
+	var/cd = 0 // cooldown, tied to the shuttle
+	var/cdint = 300 // cooldowninterval, tied to the shuttle, in deciseconds
 
 	var/obj/docking_port/stationary/destination
 	var/obj/docking_port/stationary/previous
@@ -779,6 +780,8 @@
 				to_chat(usr, "<span class='notice'>Shuttle received message and will be sent shortly.</span>")
 			if(1)
 				to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")
+			if(2)
+				to_chat(usr, "<span class='warning'>Shuttle's on cooldown!</span>")
 			else
 				to_chat(usr, "<span class='notice'>Unable to comply.</span>")
 		return 1

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -778,6 +778,7 @@
 		switch(shuttle_master.moveShuttle(shuttleId, href_list["move"], 1))
 			if(0)
 				to_chat(usr, "<span class='notice'>Shuttle received message and will be sent shortly.</span>")
+				log_game("[key_name(usr)] called a shuttle on [src.name]")
 			if(1)
 				to_chat(usr, "<span class='warning'>Invalid shuttle requested.</span>")
 			if(2)


### PR DESCRIPTION
This PR adds a cooldown to shuttles (of all kind). It is attached to the shuttle instead of a console, so that you don't have a non-sensical situation where you can build multiple consoles to bypass the cooldown or.

It has a default value of 30 seconds (I opted for that instead of 0 to avoid giving mapmaker headaches).

It also adds logging when a shuttle is successfully called by a console

This should be useful for preventing shuttle from being called non-stop without a cooldown. Report any unintended side-effect/oversight. It is very likely I've missed a process here or there.

🆑 
feature: Shuttles (of all kind) now have a cooldown - Defaults to 30 seconds.
/🆑 