### PR TITLE
Cleans Up Medibot Code, Re-Allows Syndicate Medibot

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -403,6 +403,7 @@
 	icon_state = "AquaticKit"
 	throw_speed = 2
 	throw_range = 8
+	med_bot_skin = "fish"
 
 /obj/item/storage/firstaid/aquatic_kit/full
 	desc = "It's a starter kit for an acquarium; includes 1 tank brush, 1 egg scoop, 1 fish net, and 1 container of fish food."

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -21,6 +21,8 @@
 	var/treatment_fire = "salglu_solution"
 	var/treatment_tox = "charcoal"
 	var/treatment_virus = "spaceacillin"
+	var/med_bot_skin = null
+	var/syndicate_aligned = FALSE
 
 
 /obj/item/storage/firstaid/fire
@@ -28,6 +30,7 @@
 	desc = "A medical kit that contains several medical patches and pills for treating burns. Contains one epinephrine syringe for emergency use and a health analyzer."
 	icon_state = "ointment"
 	item_state = "firstaid-ointment"
+	med_bot_skin = "ointment"
 
 	New()
 		..()
@@ -68,6 +71,7 @@
 	desc = "A medical kit designed to counter poisoning by common toxins. Contains three pills and syringes, and a health analyzer to determine the health of the patient."
 	icon_state = "antitoxin"
 	item_state = "firstaid-toxin"
+	med_bot_skin = "tox"
 
 	New()
 		..()
@@ -92,6 +96,7 @@
 	desc = "A first aid kit that contains four pills of salbutamol, which is able to counter injuries caused by suffocation. Also contains a health analyzer to determine the health of the patient."
 	icon_state = "o2"
 	item_state = "firstaid-o2"
+	med_bot_skin = "o2"
 
 	New()
 		..()
@@ -111,6 +116,7 @@
 	desc = "A medical kit that contains several medical patches and pills for treating brute injuries. Contains one epinephrine syringe for emergency use and a health analyzer."
 	icon_state = "brute"
 	item_state = "firstaid-brute"
+	med_bot_skin = "brute"
 
 	New()
 		..()
@@ -135,6 +141,7 @@
 	desc = "Contains advanced medical treatments."
 	icon_state = "advfirstaid"
 	item_state = "firstaid-advanced"
+	med_bot_skin = "adv"
 
 /obj/item/storage/firstaid/adv/New()
 	..()
@@ -157,10 +164,12 @@
 	desc = "I hope you've got insurance."
 	max_w_class = WEIGHT_CLASS_NORMAL
 	treatment_oxy = "perfluorodecalin"
-	treatment_brute = "styptic_powder"
-	treatment_fire = "silver_sulfadiazine"
+	treatment_brute = "bicaridine"
+	treatment_fire = "kelotane"
 	treatment_tox = "charcoal"
 	req_one_access =list(access_syndicate)
+	med_bot_skin = "bezerk"
+	syndicate_aligned = TRUE
 
 /obj/item/storage/firstaid/tactical/New()
 	..()

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -282,73 +282,66 @@
 		log_game("[key_name(user)] has renamed a robot to [t]")
 
 //Medbot Assembly
-/obj/item/firstaid_arm_assembly
-	name = "incomplete medibot assembly."
-	desc = "A first aid kit with a robot arm permanently grafted to it."
-	icon = 'icons/obj/aibots.dmi'
-	icon_state = "firstaid_arm"
-	var/build_step = 0
-	var/created_name = "Medibot" //To preserve the name if it's a unique medbot I guess
-	var/skin = null //Same as medbot, set to tox or ointment for the respective kits.
-	w_class = WEIGHT_CLASS_NORMAL
-	var/treatment_brute = "salglu_solution"
-	var/treatment_oxy = "salbutamol"
-	var/treatment_fire = "salglu_solution"
-	var/treatment_tox = "charcoal"
-	var/treatment_virus = "spaceacillin"
-	req_one_access = list(access_medical, access_robotics)
-
-	/obj/item/firstaid_arm_assembly/New()
-		..()
-		spawn(5)
-			if(skin)
-				overlays += image('icons/obj/aibots.dmi', "kit_skin_[skin]")
-
-/obj/item/storage/firstaid/attackby(obj/item/robot_parts/S, mob/user, params)
-
-	if((!istype(S, /obj/item/robot_parts/l_arm)) && (!istype(S, /obj/item/robot_parts/r_arm)))
-		..()
-		return
+/obj/item/storage/firstaid/attackby(obj/item/I, mob/user, params)
+	if(!istype(I, /obj/item/robot_parts/l_arm) && !istype(I, /obj/item/robot_parts/r_arm))
+		return ..()
 
 	//Making a medibot!
-	if(contents.len >= 1)
+	if(contents.len)
 		to_chat(user, "<span class='warning'>You need to empty [src] out first!</span>")
 		return
 
-	var/obj/item/firstaid_arm_assembly/A = new /obj/item/firstaid_arm_assembly
-	if(istype(src,/obj/item/storage/firstaid/fire))
-		A.skin = "ointment"
-	else if(istype(src,/obj/item/storage/firstaid/toxin))
-		A.skin = "tox"
-	else if(istype(src,/obj/item/storage/firstaid/o2))
-		A.skin = "o2"
-	else if(istype(src,/obj/item/storage/firstaid/brute))
-		A.skin = "brute"
-	else if(istype(src,/obj/item/storage/firstaid/adv))
-		A.skin = "adv"
-	else if(istype(src,/obj/item/storage/firstaid/tactical))
-		A.skin = "bezerk"
-	else if(istype(src,/obj/item/storage/firstaid/aquatic_kit))
-		A.skin = "fish"
+	var/obj/item/firstaid_arm_assembly/A = new /obj/item/firstaid_arm_assembly(loc, med_bot_skin)
 
 	A.req_one_access = req_one_access
+	A.syndicate_aligned = syndicate_aligned
 	A.treatment_oxy = treatment_oxy
 	A.treatment_brute = treatment_brute
 	A.treatment_fire = treatment_fire
 	A.treatment_tox = treatment_tox
 	A.treatment_virus = treatment_virus
 
-	qdel(S)
+	qdel(I)
 	user.put_in_hands(A)
 	to_chat(user, "<span class='notice'>You add the robot arm to the first aid kit.</span>")
 	user.unEquip(src, 1)
 	qdel(src)
 
+/obj/item/firstaid_arm_assembly
+	name = "incomplete medibot assembly."
+	desc = "A first aid kit with a robot arm permanently grafted to it."
+	icon = 'icons/obj/aibots.dmi'
+	icon_state = "firstaid_arm"
+	w_class = WEIGHT_CLASS_NORMAL
+	req_one_access = list(access_medical, access_robotics)
+	var/build_step = 0
+	var/created_name = "Medibot" //To preserve the name if it's a unique medbot I guess
+	var/skin = null //Same as medbot, set to tox or ointment for the respective kits.
+	var/syndicate_aligned = FALSE
+	var/treatment_brute = "salglu_solution"
+	var/treatment_oxy = "salbutamol"
+	var/treatment_fire = "salglu_solution"
+	var/treatment_tox = "charcoal"
+	var/treatment_virus = "spaceacillin"
 
-/obj/item/firstaid_arm_assembly/attackby(obj/item/W, mob/user, params)
+/obj/item/firstaid_arm_assembly/New(loc, new_skin)
 	..()
-	if(istype(W, /obj/item/pen))
-		var/t = stripped_input(user, "Enter new robot name", name, created_name,MAX_NAME_LEN)
+	if(new_skin)
+		skin = new_skin
+	update_icon()
+
+/obj/item/firstaid_arm_assembly/update_icon()
+	overlays.Cut()
+	if(skin)
+		overlays += image('icons/obj/aibots.dmi', "kit_skin_[skin]")
+	if(build_step > 0)
+		overlays += image('icons/obj/aibots.dmi', "na_scanner")
+
+
+/obj/item/firstaid_arm_assembly/attackby(obj/item/I, mob/user, params)
+	..()
+	if(istype(I, /obj/item/pen))
+		var/t = stripped_input(user, "Enter new robot name", name, created_name, MAX_NAME_LEN)
 		if(!t)
 			return
 		if(!in_range(src, user) && loc != user)
@@ -358,32 +351,34 @@
 	else
 		switch(build_step)
 			if(0)
-				if(istype(W, /obj/item/healthanalyzer))
-					if(!user.unEquip(W))
+				if(istype(I, /obj/item/healthanalyzer))
+					if(!user.drop_item())
 						return
-					qdel(W)
+					qdel(I)
 					build_step++
 					to_chat(user, "<span class='notice'>You add the health sensor to [src].</span>")
 					name = "First aid/robot arm/health analyzer assembly"
-					overlays += image('icons/obj/aibots.dmi', "na_scanner")
+					update_icon()
 
 			if(1)
-				if(isprox(W))
-					if(!user.unEquip(W))
+				if(isprox(I))
+					if(!user.drop_item())
 						return
-					qdel(W)
+					qdel(I)
 					build_step++
 					to_chat(user, "<span class='notice'>You complete the Medibot. Beep boop!</span>")
 					var/turf/T = get_turf(src)
-					var/mob/living/simple_animal/bot/medbot/S = new /mob/living/simple_animal/bot/medbot(T)
-					S.skin = skin
-					S.name = created_name
-					S.bot_core.req_one_access = req_one_access
-					S.treatment_oxy = treatment_oxy
-					S.treatment_brute = treatment_brute
-					S.treatment_fire = treatment_fire
-					S.treatment_tox = treatment_tox
-					S.treatment_virus = treatment_virus
+					if(!syndicate_aligned)
+						var/mob/living/simple_animal/bot/medbot/S = new /mob/living/simple_animal/bot/medbot(T, skin)
+						S.name = created_name
+						S.bot_core.req_one_access = req_one_access
+						S.treatment_oxy = treatment_oxy
+						S.treatment_brute = treatment_brute
+						S.treatment_fire = treatment_fire
+						S.treatment_tox = treatment_tox
+						S.treatment_virus = treatment_virus
+					else
+						new /mob/living/simple_animal/bot/medbot/syndicate(T) //Syndicate medibots are a special case that have so many unique vars on them, it's not worth passing them through construction phases
 					user.unEquip(src, 1)
 					qdel(src)
 

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -44,6 +44,7 @@
 	var/treatment_virus = "spaceacillin"
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
 	var/shut_up = 0 //self explanatory :)
+	var/syndicate_aligned = FALSE // Will it only treat operatives?
 
 /mob/living/simple_animal/bot/medbot/tox
 	skin = "tox"
@@ -68,8 +69,8 @@
 	desc = "International Medibot of mystery."
 	skin = "bezerk"
 	treatment_oxy = "perfluorodecalin"
-	treatment_brute = "styptic_powder"
-	treatment_fire = "silver_sulfadiazine"
+	treatment_brute = "bicaridine"
+	treatment_fire = "kelotane"
 	treatment_tox = "charcoal"
 
 /mob/living/simple_animal/bot/medbot/syndicate
@@ -77,9 +78,10 @@
 	desc = "You'd better have insurance!"
 	skin = "bezerk"
 	treatment_oxy = "perfluorodecalin"
-	treatment_brute = "styptic_powder"
-	treatment_fire = "silver_sulfadiazine"
+	treatment_brute = "bicaridine"
+	treatment_fire = "kelotane"
 	treatment_tox = "charcoal"
+	syndicate_aligned = TRUE
 	bot_core_type = /obj/machinery/bot_core/medbot/syndicate
 	control_freq = BOT_FREQ + 1000 // make it not show up on lists
 	radio_channel = "Syndicate"
@@ -90,6 +92,9 @@
 	Radio.syndie = 1
 
 /mob/living/simple_animal/bot/medbot/update_icon()
+	overlays.Cut()
+	if(skin)
+		overlays += "medskin_[skin]"
 	if(!on)
 		icon_state = "medibot0"
 		return
@@ -101,21 +106,20 @@
 	else
 		icon_state = "medibot1"
 
-/mob/living/simple_animal/bot/medbot/New()
+/mob/living/simple_animal/bot/medbot/New(loc, new_skin)
 	..()
-	update_icon()
-
-	spawn(4)
-		if(skin)
-			overlays += image('icons/obj/aibots.dmi', "medskin_[skin]")
-
-		var/datum/job/doctor/J = new/datum/job/doctor
-		access_card.access += J.get_access()
-		prev_access = access_card.access
+	var/datum/job/doctor/J = new /datum/job/doctor
+	access_card.access += J.get_access()
+	prev_access = access_card.access
+	qdel(J)
 
 	var/datum/atom_hud/medsensor = huds[DATA_HUD_MEDICAL_ADVANCED]
 	medsensor.add_hud_to(src)
 	permanent_huds |= medsensor
+
+	if(new_skin)
+		skin = new_skin
+	update_icon()
 
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()
@@ -371,7 +375,7 @@
 	if(emagged == 2) //Everyone needs our medicine. (Our medicine is toxins)
 		return 1
 
-	if((skin == "bezerk") && (!("syndicate" in C.faction)))
+	if(syndicate_aligned && (!("syndicate" in C.faction)))
 		return 0
 
 	if(declare_crit && C.health <= 0) //Critical condition! Call for help!
@@ -554,7 +558,8 @@
 		if("adv")
 			new /obj/item/storage/firstaid/adv/empty(Tsec)
 		if("bezerk")
-			new /obj/item/storage/firstaid/tactical/empty(Tsec)
+			var/obj/item/storage/firstaid/tactical/empty/T = new(Tsec)
+			T.syndicate_aligned = syndicate_aligned //This is a special case since Syndicate medibots and the mysterious medibot look the same; we also dont' want crew building Syndicate medibots if the mysterious medibot blows up.
 		if("fish")
 			new /obj/item/storage/firstaid/aquatic_kit(Tsec)
 		else
@@ -579,7 +584,7 @@
 /mob/living/simple_animal/bot/medbot/proc/declare(crit_patient)
 	if(declare_cooldown)
 		return
-	if((skin == "bezerk"))
+	if(syndicate_aligned)
 		return
 	var/area/location = get_area(src)
 	speak("Medical emergency! [crit_patient ? "<b>[crit_patient]</b>" : "A patient"] is in critical condition at [location]!", radio_channel)


### PR DESCRIPTION
Clean up of medibot construction code so it's not so horrendous.

- Icons overlay of a medibot is pulled from the firstaid kit instead of horrifying `istype(src)` checks.
- Whether a medibot will heal you is determined by a var instead of a `skin` check
  - This fixes an issue with the mysterious medibot never wanting to heal anyone
- Medibot construction icon updating is more responsive. No more nonsense of making the bot, then half a second later, the icon finally changes
- Syndicate medibot is constructable, once again, with the tactical medkit
- Buffed the Mysterious medibot and the syndicate medibot to inject you with kelotane and bicaridine instead of silver sulfadiazine and stypic powder. The latter two just aren't well inclined to medibot use because of their very high depletion rates.

This is another reason the medical kit is a high cost, because syndicate medibots are effectively infinite healing sources for operatives. I forgot that constructing them was broken, though.

Potentially alternative to: https://github.com/ParadiseSS13/Paradise/pull/9069

:cl: Fox McCloud
fix: Fixes syndicate medibot not being constructable from tactical medkits
tweak: Syndicate medibot and the mysterious medibot are better at treating brute and burn damage
/:cl: