### PR TITLE
Bug fixes

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -877,7 +877,7 @@ var/list/teleport_runes = list()
 		fail_invoke()
 		log_game("Summon Cultist rune failed - target in away mission")
 		return
-	if((cultist_to_summon.reagents.has_reagent("holywater") || cultist_to_summon.restrained()) && invokers < 3)
+	if((cultist_to_summon.reagents.has_reagent("holywater") || cultist_to_summon.restrained()) && invokers.len < 3)
 		to_chat(user, "<span class='cultitalic'>The summoning of [cultist_to_summon] is being blocked somehow! You need 3 chanters to counter it!</span>")
 		fail_invoke()
 		new /obj/effect/temp_visual/cult/sparks(get_turf(cultist_to_summon)) //observer warning

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -99,6 +99,7 @@
 		U.overlays += I
 
 		var/obj/item/reagent_containers/food/snacks/collected = new type
+		collected.name = name
 		collected.loc = U
 		collected.reagents.remove_any(collected.reagents.total_volume)
 		collected.trash = null


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/7203
- Food on utensils now properly inherits the name of the source dish.

Fixes #9007 
- Joined Souls rune can now properly can summon restrained targets with 3+ invokers.

:cl:
bugfix: Food on utensils now properly inherits the name of the source dish.
bugfix: Joined Souls rune can now properly can summon restrained targets with 3+ invokers.
/:cl: