### PR TITLE
Remove lock on airlock electronics, fix href_list close

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -10,8 +10,6 @@
 	usesound = 'sound/items/Deconstruct.ogg'
 	var/list/conf_access = null
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access
-	var/last_configurator = null
-	var/locked = TRUE
 	var/const/max_brain_damage = 60 // Maximum brain damage a mob can have until it can't use the electronics
 
 /obj/item/airlock_electronics/attack_self(mob/user)
@@ -26,31 +24,23 @@
 
 	var/t1 = text("<B>Access control</B><br>\n")
 
-	if(last_configurator)
-		t1 += "Operator: [last_configurator]<br>"
+	t1 += "Access requirement is set to "
+	t1 += one_access ? "<a style='color: green' href='?src=[UID()];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=[UID()];one_access=1'>ALL</a><hr>"
 
-	if(locked)
-		t1 += "<a href='?src=[UID()];login=1'>Swipe ID</a><hr>"
-	else
-		t1 += "<a href='?src=[UID()];logout=1'>Block</a><hr>"
+	t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=[UID()];access=all'>All</a><br>"
 
-		t1 += "Access requirement is set to "
-		t1 += one_access ? "<a style='color: green' href='?src=[UID()];one_access=1'>ONE</a><hr>" : "<a style='color: red' href='?src=[UID()];one_access=1'>ALL</a><hr>"
+	t1 += "<br>"
 
-		t1 += conf_access == null ? "<font color=red>All</font><br>" : "<a href='?src=[UID()];access=all'>All</a><br>"
+	var/list/accesses = get_all_accesses()
+	for(var/acc in accesses)
+		var/aname = get_access_desc(acc)
 
-		t1 += "<br>"
-
-		var/list/accesses = get_all_accesses()
-		for(var/acc in accesses)
-			var/aname = get_access_desc(acc)
-
-			if(!conf_access || !conf_access.len || !(acc in conf_access))
-				t1 += "<a href='?src=[UID()];access=[acc]'>[aname]</a><br>"
-			else if(one_access)
-				t1 += "<a style='color: green' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
-			else
-				t1 += "<a style='color: red' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
+		if(!conf_access || !conf_access.len || !(acc in conf_access))
+			t1 += "<a href='?src=[UID()];access=[acc]'>[aname]</a><br>"
+		else if(one_access)
+			t1 += "<a style='color: green' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
+		else
+			t1 += "<a style='color: red' href='?src=[UID()];access=[acc]'>[aname]</a><br>"
 
 	t1 += "<p><a href='?src=[UID()];close=1'>Close</a></p>\n"
 
@@ -66,19 +56,8 @@
 		return 1
 
 	if(href_list["close"])
-		usr << browse(null, "window=airlock")
+		usr << browse(null, "window=airlock_electronics")
 		return
-
-	if(href_list["login"])
-		if(allowed(usr))
-			locked = FALSE
-			last_configurator = usr.name
-
-	if(locked)
-		return
-
-	if(href_list["logout"])
-		locked = TRUE
 
 	if(href_list["one_access"])
 		one_access = !one_access


### PR DESCRIPTION
Removes lock on airlock electronics, last_configurator was only being used to see who unlocked the electronic so that goes along with it.

The close button for the airlock electronics now works, it wasn't calling the correct window name.

:cl:
del: Airlock electronics lock
fix: Airlock electronics close button
/:cl: