### PR TITLE
Nuclear challenge time limit take into account round start time

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -20,7 +20,7 @@
 		return
 
 	declaring_war = TRUE
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [-round((world.time-round_start_time - CHALLENGE_TIME_LIMIT)/10)] seconds to decide.", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [-round((world.time-round_start_time - CHALLENGE_TIME_LIMIT)/10)] seconds to decide.", "Declare war?", "Yes", "No")
 	declaring_war = FALSE
 
 	if(!check_allowed(user))
@@ -71,7 +71,7 @@
 	if(!is_admin_level(user.z))
 		to_chat(user, "You have to be at your base to use this.")
 		return FALSE
-	if(world.time > CHALLENGE_TIME_LIMIT)
+	if((world.time - round_start_time) > CHALLENGE_TIME_LIMIT) // Only count after the round started
 		to_chat(user, "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand.")
 		return FALSE
 	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)


### PR DESCRIPTION
Make it so that the nuclear challenge time limit takes into account the round start time.

Fixes an issue with delayed round start reducing the amounts of time nukies have to make a decision, and also an issue with them getting 3 minutes less than they deserve by default.

🆑 
tweak: Nuclear challenge time limit now depends on round start time.
/🆑 