### PR TITLE
Fix emitters

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -21,7 +21,7 @@
 
 #define START_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = TRUE;Processor.processing += Datum}
 #define STOP_PROCESSING(Processor, Datum) Datum.isprocessing = FALSE;Processor.processing -= Datum
-#define START_DEFFERED_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = TRUE;Processor.processing.Insert(1,Datum)}
+#define START_DEFERRED_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = TRUE;Processor.processing.Insert(1,Datum)}
 
 //SubSystem flags (Please design any new flags so that the default is off, to make adding flags to subsystems easier)
 

--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -21,6 +21,7 @@
 
 #define START_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = TRUE;Processor.processing += Datum}
 #define STOP_PROCESSING(Processor, Datum) Datum.isprocessing = FALSE;Processor.processing -= Datum
+#define START_DEFFERED_PROCESSING(Processor, Datum) if (!Datum.isprocessing) {Datum.isprocessing = TRUE;Processor.processing.Insert(1,Datum)}
 
 //SubSystem flags (Please design any new flags so that the default is off, to make adding flags to subsystems easier)
 

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -11,6 +11,7 @@ SUBSYSTEM_DEF(machines)
 	var/list/currentrun = list()
 	var/list/powernets = list()
 	var/list/deferred_powernet_rebuilds = list()
+	var/list/deferred_process = list()
 
 	var/currentpart = SSMACHINES_DEFERREDPOWERNETS
 
@@ -90,6 +91,22 @@ SUBSYSTEM_DEF(machines)
 	while(currentrun.len)
 		var/obj/machinery/thing = currentrun[currentrun.len]
 		currentrun.len--
+		if( thing.deferred_processing )
+			deferred_process += thing
+		else{
+			if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
+				if(thing.use_power)
+					thing.auto_use_power() //add back the power state
+			else
+				processing -= thing
+				if(!QDELETED(thing))
+					thing.isprocessing = FALSE
+		}
+		if(MC_TICK_CHECK)
+			return
+	while(deferred_process.len)
+		var/obj/machinery/thing = deferred_process[deferred_process.len]
+		deferred_process.len--
 		if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
 			if(thing.use_power)
 				thing.auto_use_power() //add back the power state

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -91,9 +91,9 @@ SUBSYSTEM_DEF(machines)
 	while(currentrun.len)
 		var/obj/machinery/thing = currentrun[currentrun.len]
 		currentrun.len--
-		if( thing.deferred_processing )
+		if(thing.deferred_processing)
 			deferred_process += thing
-		else{
+		else
 			if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
 				if(thing.use_power)
 					thing.auto_use_power() //add back the power state
@@ -101,7 +101,6 @@ SUBSYSTEM_DEF(machines)
 				processing -= thing
 				if(!QDELETED(thing))
 					thing.isprocessing = FALSE
-		}
 		if(MC_TICK_CHECK)
 			return
 	while(deferred_process.len)

--- a/code/controllers/subsystem/machinery.dm
+++ b/code/controllers/subsystem/machinery.dm
@@ -11,7 +11,6 @@ SUBSYSTEM_DEF(machines)
 	var/list/currentrun = list()
 	var/list/powernets = list()
 	var/list/deferred_powernet_rebuilds = list()
-	var/list/deferred_process = list()
 
 	var/currentpart = SSMACHINES_DEFERREDPOWERNETS
 
@@ -91,21 +90,6 @@ SUBSYSTEM_DEF(machines)
 	while(currentrun.len)
 		var/obj/machinery/thing = currentrun[currentrun.len]
 		currentrun.len--
-		if(thing.deferred_processing)
-			deferred_process += thing
-		else
-			if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
-				if(thing.use_power)
-					thing.auto_use_power() //add back the power state
-			else
-				processing -= thing
-				if(!QDELETED(thing))
-					thing.isprocessing = FALSE
-		if(MC_TICK_CHECK)
-			return
-	while(deferred_process.len)
-		var/obj/machinery/thing = deferred_process[deferred_process.len]
-		deferred_process.len--
 		if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
 			if(thing.use_power)
 				thing.auto_use_power() //add back the power state

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -132,7 +132,7 @@ Class Procs:
 		if(!src.defer_process)
 			START_PROCESSING(SSmachines, src)
 		else
-			START_DEFFERED_PROCESSING(SSmachines, src)
+			START_DEFERRED_PROCESSING(SSmachines, src)
 	else
 		fast_processing += src
 		isprocessing = TRUE // all of these  isprocessing = TRUE  can be removed when the PS is dead

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -118,7 +118,7 @@ Class Procs:
 	var/list/settagwhitelist = list()//WHITELIST OF VARIABLES THAT THE set_tag HREF CAN MODIFY, DON'T PUT SHIT YOU DON'T NEED ON HERE, AND IF YOU'RE GONNA USE set_tag (format_tag() proc), ADD TO THIS LIST.
 	atom_say_verb = "beeps"
 	var/speed_process = 0 // Process as fast as possible?
-	var/deferred_processing = 0
+	var/defer_process = 0
 
 /obj/machinery/Initialize()
 	addAtProcessing()
@@ -129,7 +129,10 @@ Class Procs:
 	if(use_power)
 		myArea = get_area_master(src)
 	if(!speed_process)
-		START_PROCESSING(SSmachines, src)
+		if(!src.defer_process)
+			START_PROCESSING(SSmachines, src)
+		else
+			START_DEFFERED_PROCESSING(SSmachines, src)
 	else
 		fast_processing += src
 		isprocessing = TRUE // all of these  isprocessing = TRUE  can be removed when the PS is dead

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -118,6 +118,7 @@ Class Procs:
 	var/list/settagwhitelist = list()//WHITELIST OF VARIABLES THAT THE set_tag HREF CAN MODIFY, DON'T PUT SHIT YOU DON'T NEED ON HERE, AND IF YOU'RE GONNA USE set_tag (format_tag() proc), ADD TO THIS LIST.
 	atom_say_verb = "beeps"
 	var/speed_process = 0 // Process as fast as possible?
+	var/deferred_processing = 0
 
 /obj/machinery/Initialize()
 	addAtProcessing()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -129,7 +129,7 @@ Class Procs:
 	if(use_power)
 		myArea = get_area_master(src)
 	if(!speed_process)
-		if(!src.defer_process)
+		if(!defer_process)
 			START_PROCESSING(SSmachines, src)
 		else
 			START_DEFERRED_PROCESSING(SSmachines, src)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -13,7 +13,7 @@
 	icon_state = "smes"
 	density = 1
 	anchored = 1
-	deferred_processing = 1
+	defer_process = 1
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 0 // actual charge

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -13,6 +13,7 @@
 	icon_state = "smes"
 	density = 1
 	anchored = 1
+	deferred_processing = 1
 
 	var/capacity = 5e6 // maximum charge
 	var/charge = 0 // actual charge
@@ -38,7 +39,6 @@
 	var/name_tag = null
 	var/building_terminal = 0 //Suggestions about how to avoid clickspam building several terminals accepted!
 	var/obj/machinery/power/terminal/terminal = null
-
 
 /obj/machinery/power/smes/New()
 	..()


### PR DESCRIPTION
The order in which power is consumed is dependent on the order in which they were modified on the map. Defer the SMES processing until after all normal processing has been done so they don't suck up all the power before it reaches the containment emitters. Fixes #9095
:cl:
fixes: Containment emitters
add: deferred processing of SMES
/:cl: