### PR TITLE
Fixes SQL version (3->4), plus a runtime

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -346,7 +346,7 @@
 #define INVESTIGATE_BOMB "bombs"
 
 // The SQL version required by this version of the code
-#define SQL_VERSION 3
+#define SQL_VERSION 4
 
 // Vending machine stuff
 #define CAT_NORMAL 1

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -271,7 +271,7 @@ This is always put in the attack log.
 	else if(istype(target))
 		if(isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE
 			loglevel = ATKLOG_FEW
-		else if(!user.ckey && !target.ckey) // Attacks between NPCs are only shown to admins with ATKLOG_ALL
+		else if(istype(user) && !user.ckey && !target.ckey) // Attacks between NPCs are only shown to admins with ATKLOG_ALL
 			loglevel = ATKLOG_ALL
 		else if(!target.ckey) // Attacks by players on NPCs are only shown to admins with ATKLOG_ALL or ATKLOG_ALMOSTALL
 			loglevel = ATKLOG_ALMOSTALL

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -266,7 +266,7 @@ This is always put in the attack log.
 
 	var/loglevel = ATKLOG_MOST
 
-	if(custom_level)
+	if(!isnull(custom_level))
 		loglevel = custom_level
 	else if(istype(target))
 		if(isLivingSSD(target))  // Attacks on SSDs are shown to admins with any log level except ATKLOG_NONE


### PR DESCRIPTION
Fix 1:

Updates the define for SQL version.  **At the same time as this PR is merged, the config for the live server (config/dbconfig.txt) must have "DB_VERSION 3" changed to "DB_VERSION 4". The server is already at SQL v4, this just makes it official.**


Fix 2:

Fixes a runtime in add_attack_log/mobs.dm which happened when a human was gibbed, or otherwise add_attack_logs was called without specifying a source mob.


Fix 3:

Fixes a bug in add_attack_log which caused attack logs with a custom_level of 0 (ATKLOG_ALL) to have their custom level ignored, which caused them to show up to admins whose settings were meant to filter them out.