### PR TITLE
Fixes can_vote runtime

### DIFF
--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -30,11 +30,11 @@
 	callHook("mob_login", list("client" = client, "mob" = src))
 
 	new_player_panel()
-	
+
 	spawn(30)
 		// Annoy the player with polls.
 		establish_db_connection()
-		if(dbcon.IsConnected() && client.can_vote())
+		if(dbcon.IsConnected() && client && client.can_vote())
 			var/isadmin = 0
 			if(client && client.holder)
 				isadmin = 1
@@ -46,7 +46,7 @@
 				break
 			if(newpoll)
 				client.handle_player_polling()
-	
+
 	if(ckey in deadmins)
 		verbs += /client/proc/readmin
 	spawn(40)


### PR DESCRIPTION
When someone logs in as a new_player, but immediately joins the game or observes, it can create runtimes like this:
[2018-06-14T08:50:10] Runtime in login.dm,37: Cannot execute null.can vote().
[2018-06-14T08:50:10]   proc name: Login (/mob/new_player/Login)

This PR prevents these from happening, by forcing the login code to check whether the new_player entity still has a client before trying to call can_vote().