### PR TITLE
Make it so that vox can wear SWAT suit

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -71,6 +71,11 @@
 	allowed = list(/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/restraints/handcuffs,/obj/item/tank,/obj/item/kitchen/knife/combat)
 	armor = list(melee = 40, bullet = 30, laser = 30, energy = 30, bomb = 50, bio = 90, rad = 20)
 	strip_delay = 120
+	species_restricted = list("exclude", "Diona", "Wryn")
+	species_fit = list("Vox")
+	sprite_sheets = list(
+		"Vox" = 'icons/mob/species/vox/suit.dmi'
+		)
 
 /obj/item/clothing/head/helmet/space/deathsquad/beret
 	name = "officer's beret"


### PR DESCRIPTION
Fixes an oversight with the vox suit sprite PR where a new sprite is added in but you cannot wear it:

![](https://i.imgur.com/7Ty1439.png)

🆑 
feature: Vox can now wear SWAT suit.
/🆑 