### PR TITLE
Adds new item to Clowns syndicate Uplink!

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -121,6 +121,15 @@ var/list/uplink_items = list()
 	category = "Job Specific Tools"
 
 //Clown
+/datum/uplink_item/jobspecific/honker
+	name = "H.O.N.K"
+	desc = "Produced by \"Tyranny of Honk, INC\", this exosuit is designed as heavy clown-support. Used to spread the fun and joy of life. HONK!"
+	reference = "HM"
+	item = /obj/mecha/combat/honker/loaded
+	cost = 1
+	job = list("Clown")
+	surplus = 1
+	
 /datum/uplink_item/jobspecific/clowngrenade
 	name = "Banana Grenade"
 	desc = "A grenade that explodes into HONK! brand banana peels that are genetically modified to be extra slippery and extrude caustic acid when stepped on"


### PR DESCRIPTION
The Honkmother has started a corporate relationship with Cybersun Industries, Gorlex Marauders, Donk Corporationand Waffle Corporation to supply all their Clown Employees, if they wish, with H.O.N.K. Mechs a plenty. The Syndicate remains silent about this shadowy deal. With the abundance of H.O.N.K. mechs the clown planet will once again prosper!
🆑 PPI
add: H.O.N.K mech to Clown Syndicate Uplink
add: H.O.N.K mech to supply crate
/🆑