### PR TITLE
Can Cast Spells on Z-Level 2 on Ragin'

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -115,7 +115,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 			caster.reset_perspective(0)
 			return 0
 
-	if(is_admin_level(user.z) && (!centcom_cancast || ticker.mode.name == "ragin' mages")) //Certain spells are not allowed on the centcom zlevel
+	if(is_admin_level(user.z) && !centcom_cancast) //Certain spells are not allowed on the centcom zlevel
 		return 0
 
 	if(!skipcharge)


### PR DESCRIPTION
I think we can trust our players enough to not go ham against each other, as wizards, on the wizard station.

This also solves the odd/jarring problem of wizard/slaughter demons/other spell users from being able to use their abilities because the shuttle is in transit.

Spells that are CentComm blocked, by default, are still, of course, blocked.

:cl: Fox McCloud
tweak: Can cast spells on CentComm z-level during ragin' mages
/:cl: