### PR TITLE
Customize Honk Sound for Clown Uniform

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -69,9 +69,10 @@
 	item_state = "clown"
 	item_color = "clown"
 	flags_size = ONESIZEFITSALL
+	var/honk_sound = 'sound/items/bikehorn.ogg'
 
 /obj/item/clothing/under/rank/clown/hit_reaction()
-	playsound(loc, 'sound/items/bikehorn.ogg', 50, 1, -1)
+	playsound(loc, honk_sound, 50, 1, -1)
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(H.mind && H.mind.assigned_role == "Clown")


### PR DESCRIPTION
You can now var-edit the clown's uniform to give it a a custom sound to play when you abuse the clown.

