### PR TITLE
Change the High-five emote time frame from 2.5 seconds to 4 seconds

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -2,7 +2,7 @@
 
 /datum/status_effect/high_five
 	id = "high_five"
-	duration = 25
+	duration = 40
 	alert_type = null
 
 /datum/status_effect/high_five/on_timeout()


### PR DESCRIPTION
🆑 
Extends the time that you can high-five someone from 2.5 seconds to 4 seconds.
/:cl: R1f73r
