### PR TITLE
Stechkin Maintenance Pistol Change

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -130,7 +130,7 @@
 				////////////////CONTRABAND STUFF//////////////////
 				/obj/item/grenade/clown_grenade = 3,
 				/obj/item/seeds/ambrosia/cruciatus = 3,
-				/obj/item/gun/projectile/automatic/pistol/empty = 1,
+				/obj/item/gun/projectile/automatic/pistol = 1,
 				/obj/item/ammo_box/magazine/m10mm = 4,
 				/obj/item/soap/syndie = 7,
 				/obj/item/gun/syringe/syndicate = 2,

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -198,13 +198,6 @@
 	desc= "A gun magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets"
 	ammo_type = /obj/item/ammo_casing/c10mm/ap
 
-/obj/item/ammo_box/magazine/m10mm/empty		//for maint drops
-	desc = "A gun magazine. Seems to be broken and can only hold one bullet. Pretty useless."
-	max_ammo = 1
-
-/obj/item/ammo_box/magazine/m10mm/empty/update_icon()
-	icon_state = "[initial(icon_state)]-[stored_ammo.len ? "8" : "0"]"
-
 /obj/item/ammo_box/magazine/m45
 	name = "handgun magazine (.45)"
 	icon_state = "45"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -26,12 +26,6 @@
 	mag_type = /obj/item/ammo_box/magazine/m45
 	can_suppress = 0
 
-/obj/item/gun/projectile/automatic/pistol/empty	//empty stetchshit for maint spawns
-
-/obj/item/gun/projectile/automatic/pistol/empty/New()
-	magazine = new /obj/item/ammo_box/magazine/m10mm/empty(src)
-	..()
-
 /obj/item/gun/projectile/automatic/pistol/enforcer
 	name = "Enforcer .45"
 	desc = "A pistol of modern design."


### PR DESCRIPTION
Stechkins found in maintenance are fairly easy to identify as being directly from there; they have a magazine in them that is "broken" and can only hold one bullet.

The whole reason the maintenance contraband loot was added was to "break the meta". When you can tell something is specifically from a specific location, it's not really fulfilling that role.

This is especially more pertinent now that the Stechkin is solidly considered contraband, instead of dangerous Contraband

:cl: Fox McCloud
tweak: Stechkin pistols in maintenance no longer spawn with a broken magazine
/:cl: