### PR TITLE
Heads off a Problem Beforehand: Posibrain Radio Speak

### DIFF
--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -165,7 +165,6 @@
 			if(owner.mind)
 				owner.mind.transfer_to(stored_mmi.brainmob)
 			stored_mmi.forceMove(get_turf(owner))
-			stored_mmi.silenced = TRUE //Posibrains are always silenced when removed, no exceptions
 			stored_mmi = null
 	..()
 	qdel(src)
@@ -193,3 +192,9 @@
 		else
 			stored_mmi.loc = get_turf(src)
 			qdel(src)
+
+/obj/item/organ/internal/brain/mmi_holder/posibrain/remove()
+	if(stored_mmi)
+		var/obj/item/mmi/posibrain/P = stored_mmi
+		P.silenced = TRUE //Posibrains are always silenced when removed, no exceptions
+	..()

--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -165,6 +165,7 @@
 			if(owner.mind)
 				owner.mind.transfer_to(stored_mmi.brainmob)
 			stored_mmi.forceMove(get_turf(owner))
+			stored_mmi.silenced = TRUE //Posibrains are always silenced when removed, no exceptions
 			stored_mmi = null
 	..()
 	qdel(src)


### PR DESCRIPTION
I can see this becoming a problem, especially with the radio upgrade.

For those interested in the problem:

- Yank out IPC's posibrian
- Flip their switch on so their speaker is on
- Put the Posibrain back in

IPC can now speak (and over radio) when its posibrain is removed.

:cl: Fox McCloud
tweak: IPCs are no longer able to speak when their posibrains are initially removed
/:cl: