### PR TITLE
Restrained spacepod passenger can now exit pod after 2 minutes

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -812,10 +812,16 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/spacepod_equipment/SPE, v
 	if(!istype(user))
 		return
 
-	if(usr.incapacitated()) // unconscious and restrained people can't let themselves out
+	if(usr.stat) // unconscious people can't let themselves out
 		return
 
 	occupant_sanity_check()
+
+	if(usr.restrained())
+		to_chat(usr, "<span class='notice'>You attempt to stumble out of the [src]. This will take two minutes.</span>")
+		if(do_after(usr, 1200, target = src))
+		else
+			return
 
 	if(user == pilot)
 		user.forceMove(get_turf(src))

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -812,15 +812,16 @@ obj/spacepod/proc/add_equipment(mob/user, var/obj/item/spacepod_equipment/SPE, v
 	if(!istype(user))
 		return
 
-	if(usr.stat) // unconscious people can't let themselves out
+	if(usr.stat != CONSCIOUS) // unconscious people can't let themselves out
 		return
 
 	occupant_sanity_check()
 
 	if(usr.restrained())
 		to_chat(usr, "<span class='notice'>You attempt to stumble out of the [src]. This will take two minutes.</span>")
-		if(do_after(usr, 1200, target = src))
-		else
+		if(pilot)
+			to_chat(pilot, "<span class='warning'>[usr] is trying to escape the [src].</span>")
+		if(!do_after(usr, 1200, target = src))
 			return
 
 	if(user == pilot)


### PR DESCRIPTION
Had someone on discord complaining about spending an entire round stuck in a spacepod as a traitor because the space pod pilot have shoved them in the pod and ran off and died. This left her stuck in the spacepod for the rest of the round and admins refused to do anything about it.

Being stuck inside of a spacepod the whole round because a spacepod pilot dying is just something that shouldn't be able to happen.

Thus this change makes it so a restrained ( handcuffed ) person can stumble their way out of the securitypod after 2 minutes if it doesn't move for 2 minutes.

For reference it actually currently takes 1 minute to get out of a cryotube ( even though it says 2 minutes it's 600 deciseconds which is 60 seconds )

:cl:
Tweak: Restrained spacepod passanger can now exit pending a 2 minute wait time without moving.
/:cl: