### PR TITLE
Makes CONTRIBUTING.md respect the contributing standarts set by the CONTRIBUTING.md file.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -113,21 +113,21 @@ actual development.
   `<span class='notice'>blue text</span>`.
     - Bad:
     ```
-    usr << "\red Red Text \black black text"
+    to_chat(src, "\red Red Text \black black text")
     ```
     - Good:
     ```
-    usr << "<span class='warning'>Red Text</span>black text"
+    to_chat(src, "<span class='warning'>Red Text</span>black text")
     ```
   - To use variables in strings, you should **never** use the `text()` operator, use
    embedded expressions directly in the string.
      - Bad:
      ```
-     usr << text("\The [] is leaking []!", src.name, src.liquid_type)
+     to_chat(src, text("\The [] is leaking []!", src.name, src.liquid_type))
      ```
      - Good:
      ```
-     usr << "\The [src] is leaking [liquid_type]"
+     to_chat(src, "\The [src] is leaking [liquid_type]")
      ```
   - To reference a variable/proc on the src object, you should **not** use
    `src.var`/`src.proc()`. The `src.` in these cases is implied, so you should just use


### PR DESCRIPTION
In the file it is stated:

> If you want to output a message to a player's chat (this includes text sent to world), use to_chat(mob/client/world, "message"). Do not use mob/client/world << "message".

But it uses some `usr <<`.This changes all `usr << "message"` to` to_chat(src, "message")`