### PR TITLE
Prevent swarmers from destroying active clone pods

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -308,7 +308,7 @@
 
 /obj/machinery/clonepod/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	if(attempting)
-		to_chat(s, "<span class='warning'>Destroying this machine while an it is occupied would result in biological and sentient resources to be harmed. Aborting.</span>")
+		to_chat(S, "<span class='warning'>Destroying this machine while an it is occupied would result in biological and sentient resources to be harmed. Aborting.</span>")
 		return
 		
 /mob/living/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -308,7 +308,7 @@
 
 /obj/machinery/clonepod/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	if(attempting)
-		to_chat(S, "<span class='warning'>Destroying this machine while an it is occupied would result in biological and sentient resources to be harmed. Aborting.</span>")
+		to_chat(S, "<span class='warning'>Destroying this machine while it is occupied would result in biological and sentient resources to be harmed. Aborting.</span>")
 		return
 		
 /mob/living/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -123,7 +123,7 @@
 	to_chat(src, "<b>Prime Directives:</b>")
 	to_chat(src, "1. Consume resources and replicate until there are no more resources left.")
 	to_chat(src, "2. Ensure that the station is fit for invasion at a later date, do not perform actions that would render it dangerous or inhospitable.")
-	to_chat(src, "3. Biological and Sentient resources will be harvested at a later date, do not harm them.")
+	to_chat(src, "3. Biological and sentient resources will be harvested at a later date, do not harm them.")
 
 /mob/living/simple_animal/hostile/swarmer/New()
 	..()
@@ -306,6 +306,11 @@
 /obj/spacepod/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	to_chat(S, "<span class='warning'>Destroying this vehicle would destroy us. Aborting.</span>")
 
+/obj/machinery/clonepod/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
+	if(attempting)
+		to_chat(s, "<span class='warning'>Destroying this machine while an it is occupied would result in biological and sentient resources to be harmed. Aborting.</span>")
+		return
+		
 /mob/living/swarmer_act(mob/living/simple_animal/hostile/swarmer/S)
 	S.DisperseTarget(src)
 


### PR DESCRIPTION
also decapitalize the S in sentient in swarmies laws.

Fixes #9160 

:cl:alexkar598
tweak:Swarmers can no longer destroy active clone pods.
/:cl: