### PR TITLE
Tachyon-doppler array now logs explosions in-game

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -22,7 +22,6 @@ var/list/doppler_arrays = list()
 	epicenter = log_epicenter
 	actual_size_message = log_actual_size_message
 	theoretical_size_message = log_theoretical_size_message
-	UID()
 
 /obj/machinery/doppler_array/New()
 	..()
@@ -168,6 +167,7 @@ var/list/doppler_arrays = list()
 	var/data[0]
 	var/list/explosion_data = list()
 	for(var/datum/explosion_log/E in logged_explosions)
+		E.UID()
 		explosion_data += list(list(
 			"logged_time" = E.logged_time,
 			"epicenter" = E.epicenter,

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -55,6 +55,7 @@ var/list/doppler_arrays = list()
 /obj/machinery/doppler_array/attack_hand(mob/user)
 	if(..())
 		return
+	add_fingerprint(user)
 	ui_interact(user)
 
 /obj/machinery/doppler_array/attack_ghost(mob/user)
@@ -78,29 +79,7 @@ var/list/doppler_arrays = list()
 	dir = turn(dir, 90)
 	to_chat(user, "<span class='notice'>You rotate [src].</span>")
 
-/obj/item/paper/explosive_log
-	name = "explosive log"
-	info = "<h3>Explosive Log Report</h3>\
-	<table style='width:400px;text-align:left;'>\
-	<tr>\
-	<th>Time logged</th>\
-	<th>Epicenter</th>\
-	<th>Actual</th>\
-	<th>Theoretical</th>\
-	</tr>" //NB: the <table> tag is left open, it is closed later on, when the doppler array adds its data
-
-/obj/machinery/doppler_array/verb/print_logs(mob/user)
-	set name = "Print Explosive Logs"
-	set category = "Object"
-	set src in oview(1)
-
-	if(user.incapacitated())
-		return
-	if(!Adjacent(user))
-		return
-	if(!user.IsAdvancedToolUser())
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do that!</span>")
-		return
+/obj/machinery/doppler_array/proc/print_explosive_logs(mob/user)
 	if(!logged_explosions.len)
 		atom_say("<span class='notice'>No logs currently stored in internal database.</span>")
 		return
@@ -198,6 +177,7 @@ var/list/doppler_arrays = list()
 			"theoretical_size_message" = E.theoretical_size_message,
 			"unique_datum_id" = E.unique_datum_id))
 	data["explosion_data"] = explosion_data
+	data["printer_timer"] = printer_timer
 	return data
 
 /obj/machinery/doppler_array/Topic(href, href_list)
@@ -211,4 +191,19 @@ var/list/doppler_arrays = list()
 				qdel(D)
 				to_chat(usr, "<span class='notice'>Log deletion successful.</span>")
 				break
-		SSnanoui.update_uis(src)
+	else if(href_list["print_logs"])
+		print_explosive_logs(usr)
+	else
+		return
+	SSnanoui.update_uis(src)
+
+/obj/item/paper/explosive_log
+	name = "explosive log"
+	info = "<h3>Explosive Log Report</h3>\
+	<table style='width:380px;text-align:left;'>\
+	<tr>\
+	<th>Time logged</th>\
+	<th>Epicenter</th>\
+	<th>Actual</th>\
+	<th>Theoretical</th>\
+	</tr>" //NB: the <table> tag is left open, it is closed later on, when the doppler array adds its data

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -8,6 +8,21 @@ var/list/doppler_arrays = list()
 	density = 1
 	anchored = 1
 	atom_say_verb = "states coldly"
+	var/list/logged_explosions = list()
+
+/datum/explosion_log
+	var/logged_time
+	var/epicenter
+	var/actual_size_message
+	var/theoretical_size_message
+
+/datum/explosion_log/New(var/log_time, var/log_epicenter, var/log_actual_size_message, var/log_theoretical_size_message)
+	..()
+	logged_time = log_time
+	epicenter = log_epicenter
+	actual_size_message = log_actual_size_message
+	theoretical_size_message = log_theoretical_size_message
+	UID()
 
 /obj/machinery/doppler_array/New()
 	..()
@@ -34,52 +49,75 @@ var/list/doppler_arrays = list()
 	else
 		return ..()
 
-/obj/machinery/doppler_array/verb/rotate()
+/obj/machinery/doppler_array/attack_hand(mob/user)
+	if(..())
+		return
+	ui_interact(user)
+
+/obj/machinery/doppler_array/attack_ghost(mob/user)
+	ui_interact(user)
+
+/obj/machinery/doppler_array/AltClick(mob/user)
+	rotate(user)
+
+/obj/machinery/doppler_array/verb/rotate(mob/user)
 	set name = "Rotate Tachyon-doppler Dish"
 	set category = "Object"
 	set src in oview(1)
 
-	if(!usr || !isturf(usr.loc))
+	if(user.incapacitated())
 		return
-	if(usr.stat || usr.restrained() || !usr.canmove)
+	if(!Adjacent(user))
 		return
-	src.dir = turn(src.dir, 90)
-	return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do that!</span>")
+		return
+	dir = turn(dir, 90)
+	to_chat(user, "<span class='notice'>You rotate [src].</span>")
 
 /obj/machinery/doppler_array/proc/sense_explosion(var/x0,var/y0,var/z0,var/devastation_range,var/heavy_impact_range,var/light_impact_range,
 												  var/took,var/orig_dev_range,var/orig_heavy_range,var/orig_light_range)
-	if(stat & NOPOWER)	return
-	if(z != z0)			return
+	if(stat & NOPOWER)
+		return
+	if(z != z0)
+		return
 
 	var/dx = abs(x0-x)
 	var/dy = abs(y0-y)
 	var/distance
 	var/direct
+	var/capped = FALSE
 
 	if(dx > dy)
 		distance = dx
-		if(x0 > x)	direct = EAST
-		else		direct = WEST
+		if(x0 > x)
+			direct = EAST
+		else
+			direct = WEST
 	else
 		distance = dy
-		if(y0 > y)	direct = NORTH
-		else		direct = SOUTH
+		if(y0 > y)
+			direct = NORTH
+		else
+			direct = SOUTH
 
-	if(distance > 100)		return
-	if(!(direct & dir))	return
-
+	if(distance > 100)
+		return
+	if(!(direct & dir))
+		return
 
 	var/list/messages = list("Explosive disturbance detected.", \
 							 "Epicenter at: grid ([x0],[y0]). Temporal displacement of tachyons: [took] seconds.", \
 							 "Factual: Epicenter radius: [devastation_range]. Outer radius: [heavy_impact_range]. Shockwave radius: [light_impact_range].")
 
-	// If the bomb was capped, say it's theoretical size.
+	// If the bomb was capped, say its theoretical size.
 	if(devastation_range < orig_dev_range || heavy_impact_range < orig_heavy_range || light_impact_range < orig_light_range)
+		capped = TRUE
 		messages += "Theoretical: Epicenter radius: [orig_dev_range]. Outer radius: [orig_heavy_range]. Shockwave radius: [orig_light_range]."
-
+	logged_explosions.Insert(1, new /datum/explosion_log(station_time_timestamp(), "[x0],[y0]", "[devastation_range], [heavy_impact_range], [light_impact_range]", capped ? "[orig_dev_range], [orig_heavy_range], [orig_light_range]" : "n/a")) //Newer logs appear first
+	messages += "Event successfully logged in internal database."
 	for(var/message in messages)
 		atom_say(message)
-
 
 /obj/machinery/doppler_array/power_change()
 	if(stat & BROKEN)
@@ -91,3 +129,36 @@ var/list/doppler_arrays = list()
 		else
 			icon_state = "[initial(icon_state)]-off"
 			stat |= NOPOWER
+
+/obj/machinery/doppler_array/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "doppler_array.tmpl", "Tachyon-doppler array", 500, 650)
+		ui.open()
+		ui.set_auto_update(1)
+
+/obj/machinery/doppler_array/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
+	var/data[0]
+	var/list/explosion_data = list()
+	for(var/datum/explosion_log/E in logged_explosions)
+		explosion_data += list(list(
+			"logged_time" = E.logged_time,
+			"epicenter" = E.epicenter,
+			"actual_size_message" = E.actual_size_message,
+			"theoretical_size_message" = E.theoretical_size_message,
+			"unique_datum_id" = E.unique_datum_id))
+	data["explosion_data"] = explosion_data
+	return data
+
+/obj/machinery/doppler_array/Topic(href, href_list)
+	if(..())
+		return
+	if(href_list["log_to_delete"])
+		var/log_to_delete = sanitize(href_list["log_to_delete"])
+		for(var/datum/D in logged_explosions)
+			if(D.unique_datum_id == log_to_delete)
+				logged_explosions -= D
+				qdel(D)
+				to_chat(usr, "<span class='notice'>Log deletion successful.</span>")
+				break
+		SSnanoui.update_uis(src)

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -167,13 +167,12 @@ var/list/doppler_arrays = list()
 	var/data[0]
 	var/list/explosion_data = list()
 	for(var/datum/explosion_log/E in logged_explosions)
-		E.UID()
 		explosion_data += list(list(
 			"logged_time" = E.logged_time,
 			"epicenter" = E.epicenter,
 			"actual_size_message" = E.actual_size_message,
 			"theoretical_size_message" = E.theoretical_size_message,
-			"unique_datum_id" = E.unique_datum_id))
+			"unique_datum_id" = E.UID()))
 	data["explosion_data"] = explosion_data
 	data["printing"] = active_timers
 	return data

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -166,7 +166,8 @@ var/list/doppler_arrays = list()
 /obj/machinery/doppler_array/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
 	var/list/explosion_data = list()
-	for(var/datum/explosion_log/E in logged_explosions)
+	for(var/D in logged_explosions)
+		var/datum/explosion_log/E = D
 		explosion_data += list(list(
 			"logged_time" = E.logged_time,
 			"epicenter" = E.epicenter,
@@ -182,10 +183,11 @@ var/list/doppler_arrays = list()
 		return
 	if(href_list["log_to_delete"])
 		var/log_to_delete = sanitize(href_list["log_to_delete"])
-		for(var/datum/D in logged_explosions)
-			if(D.unique_datum_id == log_to_delete)
-				logged_explosions -= D
-				qdel(D)
+		for(var/D in logged_explosions)
+			var/datum/explosion_log/E = D
+			if(E.UID() == log_to_delete)
+				logged_explosions -= E
+				qdel(E)
 				to_chat(usr, "<span class='notice'>Log deletion successful.</span>")
 				break
 	else if(href_list["print_logs"])

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -9,7 +9,6 @@ var/list/doppler_arrays = list()
 	anchored = 1
 	atom_say_verb = "states coldly"
 	var/list/logged_explosions = list()
-	var/printer_timer
 
 /datum/explosion_log
 	var/logged_time
@@ -83,15 +82,14 @@ var/list/doppler_arrays = list()
 	if(!logged_explosions.len)
 		atom_say("<span class='notice'>No logs currently stored in internal database.</span>")
 		return
-	if(printer_timer)
+	if(active_timers)
 		to_chat(user, "<span class='notice'>[src] is already printing something, please wait.</span>")
 		return
 	atom_say("<span class='notice'>Printing explosive log. Standby...</span>")
-	printer_timer = addtimer(CALLBACK(src, .proc/print), 50)
+	addtimer(CALLBACK(src, .print), 50)
 
 /obj/machinery/doppler_array/proc/print()
-	printer_timer = FALSE
-	visible_message("<span class='notice'>[src] rattles off a sheet of paper!</span>")
+	visible_message("<span class='notice'>[src] prints a piece of paper!</span>")
 	playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 	var/obj/item/paper/explosive_log/P = new(get_turf(src))
 	for(var/datum/explosion_log/E in logged_explosions)
@@ -177,7 +175,7 @@ var/list/doppler_arrays = list()
 			"theoretical_size_message" = E.theoretical_size_message,
 			"unique_datum_id" = E.unique_datum_id))
 	data["explosion_data"] = explosion_data
-	data["printer_timer"] = printer_timer
+	data["printing"] = active_timers
 	return data
 
 /obj/machinery/doppler_array/Topic(href, href_list)

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -29,8 +29,7 @@ var/list/doppler_arrays = list()
 
 /obj/machinery/doppler_array/Destroy()
 	doppler_arrays -= src
-	for(var/datum/D in logged_explosions)
-		qdel(D)
+	logged_explosions.Cut()
 	return ..()
 
 /obj/machinery/doppler_array/process()
@@ -91,7 +90,8 @@ var/list/doppler_arrays = list()
 	visible_message("<span class='notice'>[src] prints a piece of paper!</span>")
 	playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 	var/obj/item/paper/explosive_log/P = new(get_turf(src))
-	for(var/datum/explosion_log/E in logged_explosions)
+	for(var/D in logged_explosions)
+		var/datum/explosion_log/E = D
 		P.info += "<tr>\
 		<td>[E.logged_time]</td>\
 		<td>[E.epicenter]</td>\

--- a/nano/templates/doppler_array.tmpl
+++ b/nano/templates/doppler_array.tmpl
@@ -1,4 +1,4 @@
-<h2>Logged explosions:</h3>
+<h2>Logged explosions:</h2>
 {{if data.explosion_data == 0}}
 	<p>No explosions logged this shift.</p>
 {{else}}
@@ -20,4 +20,6 @@
 			</span>
 		</div>
 	{{/for}}
+	<br/>
+	{{:helper.link("Print all logs", "print", {"print_logs": 'yes'}, data.printer_timer ? 'disabled' : null)}}
 {{/if}}

--- a/nano/templates/doppler_array.tmpl
+++ b/nano/templates/doppler_array.tmpl
@@ -1,0 +1,23 @@
+<h2>Logged explosions:</h3>
+{{if data.explosion_data == 0}}
+	<p>No explosions logged this shift.</p>
+{{else}}
+	<div>
+		<span style="display:inline-block;width:20%;">Time logged</span>
+		<span style="display:inline-block;width:20%;">Epicenter</span>
+		<span style="display:inline-block;width:20%;">Actual size</span>
+		<span style="display:inline-block;width:25%;">Theoretical size<span>
+	</div>
+	<hr/>
+	{{for data.explosion_data}}
+		<div style = "min-height:30px;">
+			<span>
+				<span style="display:inline-block;width:20%;">{{:value.logged_time}}</span>
+				<span style="display:inline-block;width:20%;">{{:value.epicenter}}</span>
+				<span style="display:inline-block;width:20%;">{{:value.actual_size_message}}</span>
+				<span style="display:inline-block;width:25%;">{{:value.theoretical_size_message}}</span>
+				<span style="display:inline-block;width:15%;vertical-align:middle;">{{:helper.link("Delete", "trash", {"log_to_delete": value.unique_datum_id})}}</span>
+			</span>
+		</div>
+	{{/for}}
+{{/if}}

--- a/nano/templates/doppler_array.tmpl
+++ b/nano/templates/doppler_array.tmpl
@@ -21,5 +21,5 @@
 		</div>
 	{{/for}}
 	<br/>
-	{{:helper.link("Print all logs", "print", {"print_logs": 'yes'}, data.printer_timer ? 'disabled' : null)}}
+	{{:helper.link("Print all logs", "print", {"print_logs": 'yes'}, data.printing ? 'disabled' : null)}}
 {{/if}}


### PR DESCRIPTION
Adds a nanoUI interface to the tachyon-doppler array, that lets you view all explosions the array has witnessed. It's mostly for people who want to show off the size of their booms. This doesn't track crew names or any identifying information, it only tracks the data it already announces. You can also delete explosion logs if you don't want a particular log accessible.

You can get a print-out of all explosive logs from the nanoUI menu.

You can now alt-click the tachyon-doppler array to rotate it

Also cleans up the code a bit, and makes it so things like mice can't rotate the dish.
**Images:**

Tachyon-doppler array interface
![image](https://user-images.githubusercontent.com/18459142/42191260-d224471e-7e59-11e8-8578-52a92d9cbaea.png)

Printable log
![image](https://user-images.githubusercontent.com/18459142/42191269-e327dfb2-7e59-11e8-9971-147a5161bb2f.png)

:cl:
tweak: The tachyon-doppler array now has a logging interface, and can print off stored explosive logs. Brag to your friends about your bomb-making skills!
/:cl: