### PR TITLE
Removes Explosive Lances

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -313,7 +313,6 @@
 	sharp = TRUE
 	no_spin_thrown = TRUE
 	var/obj/item/grenade/explosive = null
-	var/war_cry = "AAAAARGH!!!"
 
 /obj/item/twohanded/spear/update_icon()
 	if(explosive)
@@ -327,7 +326,6 @@
 	if(isturf(AM)) //So you can actually melee with it
 		return
 	if(explosive && wielded)
-		user.say("[war_cry]")
 		explosive.forceMove(AM)
 		explosive.prime()
 		qdel(src)
@@ -337,30 +335,6 @@
 	if(explosive)
 		explosive.prime()
 		qdel(src)
-
-/obj/item/twohanded/spear/AltClick(mob/user)
-	..()
-	if(!explosive)
-		return
-	if(ishuman(loc))
-		var/mob/living/carbon/human/M = loc
-		var/input = stripped_input(M, "What do you want your war cry to be? You will shout it when you hit someone in melee.", ,"", 50)
-		if(input)
-			war_cry = input
-
-/obj/item/twohanded/spear/CheckParts(list/parts_list)
-	..()
-	if(explosive)
-		explosive.forceMove(get_turf(loc))
-		explosive = null
-		update_icon()
-	var/obj/item/grenade/G = locate() in contents
-	if(G)
-		explosive = G
-		name = "explosive lance"
-		embed_chance = 0
-		desc = "A makeshift spear with [G] attached to it. Alt+click on the spear to set your war cry!"
-		update_icon()
 
 //GREY TIDE
 /obj/item/twohanded/spear/grey_tide

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -25,15 +25,6 @@
 	time = 15
 	category = CAT_WEAPON
 
-/datum/crafting_recipe/lance
-	name = "explosive lance (grenade)"
-	result = /obj/item/twohanded/spear
-	reqs = list(/obj/item/twohanded/spear = 1,
-				/obj/item/grenade = 1)
-	parts = list(/obj/item/grenade = 1)
-	time = 15
-	category = CAT_WEAPON
-
 /datum/crafting_recipe/molotov
 	name = "Molotov"
 	result = /obj/item/reagent_containers/food/drinks/bottle/molotov


### PR DESCRIPTION
Explosive lances can't really be balanced; adding in tons of snowflake to check for their power really isn't possible, and they hinder future potential additions of unreliable (but moderately powerful) explosives.

They've become universal in handling any big-name antag, and, worse yet, they're stupidly effective at dispatching them, often taking them out in one hit.

Some code has been left in so if admins want to fiddle with the grenades and make them, themselves, for special situations, they still can.

:cl: Fox McCloud
del: removes explosive lances
/:cl: