### PR TITLE
Fixes Service Borg's RSF being unable to dispense items on floors

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -57,16 +57,13 @@ RSF
 	if(!proximity) return
 	if(!(istype(A, /obj/structure/table) || istype(A, /turf/simulated/floor)))
 		return
-
 	var spawn_location
-	if(istype(A, /obj/structure/table))
-		spawn_location = A.loc
-	else if (istype(A, /turf/simulated/floor))
-		spawn_location = A
+	var/turf/T = get_turf(A)
+	if(istype(T) && !T.density)
+		spawn_location = T
 	else
 		to_chat(user, "The RSF can only create service items on tables, or floors.")
 		return
-
 	if(isrobot(user))
 		var/mob/living/silicon/robot/engy = user
 		if(!engy.cell.use(configured_items[mode][2]))

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -64,7 +64,7 @@ RSF
 	else if (istype(A, /obj/structure/table))
 		spawn_location = A
 	else
-		to_chat(user, "The RSF can only create service items on tables, or floors.")
+		to_chat(user, "The RSF can only create service items on tables.")
 		return
 
 	if(isrobot(user))

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -61,7 +61,7 @@ RSF
 	var spawn_location
 	if(istype(A, /obj/structure/table))
 		spawn_location = A.loc
-	else if (istype(A, /obj/structure/floor))
+	else if (istype(A, /turf/simulated/floor))
 		spawn_location = A
 	else
 		to_chat(user, "The RSF can only create service items on tables, or floors.")

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -61,10 +61,10 @@ RSF
 	var spawn_location
 	if(istype(A, /obj/structure/table))
 		spawn_location = A.loc
-	else if (istype(A, /obj/structure/table))
+	else if (istype(A, /obj/structure/floor))
 		spawn_location = A
 	else
-		to_chat(user, "The RSF can only create service items on tables.")
+		to_chat(user, "The RSF can only create service items on tables, or floors.")
 		return
 
 	if(isrobot(user))


### PR DESCRIPTION
The ability to dispense items on floors was removed by #8302 as an undocumented change. This fixes that.

🆑
fix: Fixed the ability of Service Borgs to spawn items on floors. Dosh!
/🆑