### PR TITLE
Fixes 'Naked' Wizards

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -1063,6 +1063,7 @@
 
 
 /datum/outfit/admin/wizard
+	name = "Blue Wizard"
 	uniform = /obj/item/clothing/under/color/lightpurple
 	suit = /obj/item/clothing/suit/wizrobe
 	back = /obj/item/storage/backpack
@@ -1085,10 +1086,6 @@
 	var/obj/item/card/id/I = H.wear_id
 	if(istype(I))
 		apply_to_card(I, H, get_all_accesses(), "Wizard")
-
-/datum/outfit/admin/wizard/blue
-	name = "Blue Wizard"
-	// the default wizard clothes are blue
 
 /datum/outfit/admin/wizard/red
 	name = "Red Wizard"


### PR DESCRIPTION
Bug: For admins, in the 'select equipment' list, there is an option listed as 'Naked' which in fact dresses someone as a blue wizard. This was caused by a datum lacking a proper 'name' definition.

Now fixed: the option no longer appears. Admins can still dress someone as a wizard by selecting 'blue wizard', 'red wizard', etc.

No CL, as backend only.