### PR TITLE
Adds Buildable Automated Machine Frames & Robotic Limb Surgery

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -166,7 +166,8 @@
 		L.origin_tech = I.origin_tech
 	else
 		I.loc = get_step(src,SOUTH)
-	I.materials = res_coef
+	if(istype(I))
+		I.materials = res_coef
 	atom_say("[I] is complete.")
 	being_built = null
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -118,6 +118,19 @@
 /mob/living/carbon/human/machine/Initialize(mapload)
 	..(mapload, "Machine")
 
+/mob/living/carbon/human/machine/created
+	name = "automated machine-frame"
+
+/mob/living/carbon/human/machine/created/Initialize(mapload)
+	..()
+	real_name = "automated machine-frame ([rand(1, 1000)])"
+	for(var/obj/item/organ/external/E in bodyparts)
+		if(istype(E, /obj/item/organ/external/chest) || istype(E, /obj/item/organ/external/groin))
+			continue
+		qdel(E)
+	for(var/obj/item/organ/O in internal_organs)
+		qdel(O)
+
 /mob/living/carbon/human/shadow/Initialize(mapload)
 	..(mapload, "Shadow")
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1120,6 +1120,15 @@
 	construction_time = 350
 	category = list("Misc")
 
+/datum/design/automated_machine_frame
+	name = "Automated Machine Frame"
+	id = "automated_machine_frame"
+	build_type = MECHFAB
+	build_path = /mob/living/carbon/human/machine/created
+	materials = list(MAT_METAL = 40000)
+	construction_time = 400
+	category = list("Misc")
+
 /datum/design/ipc_cell
 	name = "IPC Microbattery"
 	id = "ipc_cell"

--- a/code/modules/surgery/organs/subtypes/machine.dm
+++ b/code/modules/surgery/organs/subtypes/machine.dm
@@ -167,7 +167,8 @@
 			stored_mmi.forceMove(get_turf(owner))
 			stored_mmi = null
 	..()
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 /obj/item/organ/internal/brain/mmi_holder/proc/update_from_mmi()
 	if(!stored_mmi)
@@ -183,12 +184,13 @@
 	stored_mmi = new /obj/item/mmi/posibrain/ipc(src)
 	..()
 	spawn(1)
-		if(owner)
-			stored_mmi.name = "positronic brain ([owner.real_name])"
-			stored_mmi.brainmob.real_name = owner.real_name
-			stored_mmi.brainmob.name = stored_mmi.brainmob.real_name
-			stored_mmi.icon_state = "posibrain-occupied"
-			update_from_mmi()
-		else
-			stored_mmi.loc = get_turf(src)
-			qdel(src)
+		if(!QDELETED(src))
+			if(owner)
+				stored_mmi.name = "positronic brain ([owner.real_name])"
+				stored_mmi.brainmob.real_name = owner.real_name
+				stored_mmi.brainmob.name = stored_mmi.brainmob.real_name
+				stored_mmi.icon_state = "posibrain-occupied"
+				update_from_mmi()
+			else
+				stored_mmi.loc = get_turf(src)
+				qdel(src)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -541,3 +541,59 @@
 	user.visible_message("<span class='warning'> [user]'s hand slips!</span>", \
 	"<span class='warning'> Your hand slips!</span>")
 	return 0
+
+/datum/surgery/cybernetic_customization
+	name = "Cybernetic Appearance Customization"
+	steps = list(/datum/surgery_step/robotics/external/unscrew_hatch, /datum/surgery_step/robotics/external/customize_appearance)
+	possible_locs = list("head", "chest", "l_arm", "r_arm", "r_leg", "l_leg")
+	requires_organic_bodypart = FALSE
+
+/datum/surgery/cybernetic_customization/can_start(mob/user, mob/living/carbon/human/target)
+	if(ishuman(target))
+		var/obj/item/organ/external/affected = target.get_organ(user.zone_sel.selecting)
+		if(!affected)
+			return FALSE
+		if(!(affected.status & ORGAN_ROBOT))
+			return FALSE
+		return TRUE
+
+/datum/surgery_step/robotics/external/customize_appearance
+	name = "reprogram limb"
+	allowed_tools = list(/obj/item/multitool = 100)
+	time = 48
+
+/datum/surgery_step/robotics/external/customize_appearance/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+	if(..())
+		var/obj/item/organ/external/affected = target.get_organ(target_zone)
+		if(!affected)
+			return FALSE
+		return TRUE
+
+/datum/surgery_step/robotics/external/customize_appearance/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("[user] begins to reprogram the appearance of [target]'s [affected.name] with [tool]." , \
+	"You begin to reprogram the appearance of [target]'s [affected.name] with [tool].")
+	..()
+
+/datum/surgery_step/robotics/external/customize_appearance/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+	var/chosen_appearance = input(user, "Select the company appearance for this limb.", "Limb Company Selection") as null|anything in selectable_robolimbs
+	if(!chosen_appearance)
+		return FALSE
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	affected.robotize(chosen_appearance, convert_all = FALSE)
+	if(istype(affected, /obj/item/organ/external/head))
+		var/obj/item/organ/external/head/head = affected
+		head.h_style = "Bald" // nearly all the appearance changes for heads are non-monitors; we want to get rid of a floating screen
+		target.update_hair()
+	target.update_body()
+	target.updatehealth()
+	target.UpdateDamageIcon()
+	user.visible_message("<span class='notice'> [user] reprograms the appearance of [target]'s [affected.name] with [tool].</span>", \
+	"<span class='notice'> You reprogram the appearance of [target]'s [affected.name] with [tool].</span>")
+	return TRUE
+
+/datum/surgery_step/robotics/external/customize_appearance/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool,datum/surgery/surgery)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message("<span class='warning'> [user]'s [tool.name] slips, failing to reprogram [target]'s [affected.name].</span>",
+	"<span class='warning'> Your [tool.name] slips, failing to reprogram [target]'s [affected.name].</span>")
+	return FALSE


### PR DESCRIPTION
PR adds two major features:

- The ability for robotics to build automated machine frames
- The ability to perform surgery on robotic limbs and reprogram them to a different appearance

The robotic limb surgery is fairly simple; just use a screwdriver then a multitool on a robotic arm, leg, chest, or head, and you can reprogram its appearance; if the roboticist makes a mistake when attaching a new robotic limb (or you have already had your limb attached from round start, ala IPC), he can just initiate a surgery to change the appearance of the limb, without having to saw off your limb and print an entirely new one and set it to the correct appearance.

The second feature is adding automated machine frames. Automated machine frames are non-sentient machines that can hold a posibrain; they exist to take orders from a master and fulfill orders (much like golems). They are very similar to IPCs in terms of appearance, strengths and weaknesses.

How you build one is from a mech fabricator; you'll have to attach all limbs to it, in addition to installing all its internal components (battery, optics, etc), then finally a posibrain before it will boot up and be ready to receive whatever orders you give it.

On that note, regarding posibrains. Posibrains are bound to whoever booted them up; this bounding ends, however, if the posibrain encounters hardcoded borg and/or AI laws. That said, if the posibrain is put inside an automated machine frame, the bounding stays and it must follow orders of whoever it is bound to (again, like golems).

IPCs, of course, are immune to binding; you cannot yank out an IPC's posibrain and bind it to yourself or anyone else.

:cl: Fox McCloud
add: Adds constructable automated machine frames
add: Adds surgery to customize existing robotic limb appearances
/:cl: