### PR TITLE
Egg runtime fix

### DIFF
--- a/code/modules/surgery/organs/parasites.dm
+++ b/code/modules/surgery/organs/parasites.dm
@@ -35,7 +35,8 @@
 /obj/item/organ/internal/body_egg/spider_eggs/remove(var/mob/living/carbon/M, var/special = 0)
 	..()
 	M.reagents.del_reagent("spidereggs") //purge all remaining spider eggs reagent if caught, in time.
-	qdel(src) //We don't want people re-implanting these for near instant gibbings.
+	if(!QDELETED(src))
+		qdel(src) // prevent people re-implanting them into others
 	return null
 
 
@@ -114,5 +115,6 @@
 
 /obj/item/organ/internal/body_egg/terror_eggs/remove(var/mob/living/carbon/M, var/special = 0)
 	..()
-	qdel(src) // prevent people re-implanting them into others
+	if(!QDELETED(src))
+		qdel(src) // prevent people re-implanting them into others
 	return null


### PR DESCRIPTION
Currently, it is possible for eggs which have Destroy() called on them before remove() to generate runtimes like this:

[2018-07-11T08:54:20] Runtime in garbage.dm,354: /obj/item/organ/internal/body_egg/terror_eggs destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic
   proc name: qdel (/proc/qdel)
   src: null
   call stack:
   qdel(the terror eggs (/obj/item/organ/internal/body_egg/terror_eggs), 0)
   the terror eggs (/obj/item/organ/internal/body_egg/terror_eggs): remove(Deep Astral Diving (/mob/living/carbon/human), 1)
   the terror eggs (/obj/item/organ/internal/body_egg/terror_eggs): Destroy(0)
   qdel(the terror eggs (/obj/item/organ/internal/body_egg/terror_eggs), 0)

This PR adds a check to prevent calling qdel() during Destroy() if the object is already qdel'ed.
This fix applies to both white terror spider eggs, and also standard spider eggs.