### PR TITLE
Prevents surgery infections for Abductors

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -269,6 +269,7 @@
 		console.gizmo = G
 		G.console = console
 	scientist.equip_to_slot_or_del(G, slot_in_backpack)
+
 	var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(scientist)
 	beamplant.implant(scientist)
 	scientist.update_icons()

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -232,7 +232,6 @@
 	agent.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(agent), slot_shoes)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(agent), slot_w_uniform) //they're greys gettit
 	agent.equip_to_slot_or_del(new /obj/item/storage/backpack(agent), slot_back)
-	agent.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat, slot_gloves)
 
 /datum/game_mode/abduction/proc/get_team_console(team)
 	var/obj/machinery/abductor/console/console

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -233,7 +233,6 @@
 	agent.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(agent), slot_w_uniform) //they're greys gettit
 	agent.equip_to_slot_or_del(new /obj/item/storage/backpack(agent), slot_back)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat, slot_gloves)
-	agent.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical, slot_in_backpack)
 
 /datum/game_mode/abduction/proc/get_team_console(team)
 	var/obj/machinery/abductor/console/console
@@ -271,7 +270,6 @@
 		console.gizmo = G
 		G.console = console
 	scientist.equip_to_slot_or_del(G, slot_in_backpack)
-	scientist.equip_to_slot_or_del(new /obj/item/reagent_containers/spray/cleaner, slot_in_backpack)
 	var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(scientist)
 	beamplant.implant(scientist)
 	scientist.update_icons()

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -232,6 +232,8 @@
 	agent.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat(agent), slot_shoes)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(agent), slot_w_uniform) //they're greys gettit
 	agent.equip_to_slot_or_del(new /obj/item/storage/backpack(agent), slot_back)
+	agent.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat, slot_gloves)
+	agent.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical, slot_in_backpack)
 
 /datum/game_mode/abduction/proc/get_team_console(team)
 	var/obj/machinery/abductor/console/console
@@ -269,7 +271,7 @@
 		console.gizmo = G
 		G.console = console
 	scientist.equip_to_slot_or_del(G, slot_in_backpack)
-
+	scientist.equip_to_slot_or_del(new /obj/item/reagent_containers/spray/cleaner, slot_in_backpack)
 	var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(scientist)
 	beamplant.implant(scientist)
 	scientist.update_icons()

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -258,7 +258,7 @@
 	name = "Dissection Guide"
 	icon_state = "alienpaper_words"
 	info = {"<b>Dissection for Dummies</b><br>
-
+ Always keep your dissection area sterile, and wear gloves and mask while dissection is in-progress.<br>
 <br>
  1.Acquire fresh specimen.<br>
  2.Put the specimen on operating table.<br>

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -258,7 +258,6 @@
 	name = "Dissection Guide"
 	icon_state = "alienpaper_words"
 	info = {"<b>Dissection for Dummies</b><br>
- Always keep your dissection area sterile, and wear gloves and mask while dissection is in-progress.<br>
 <br>
  1.Acquire fresh specimen.<br>
  2.Put the specimen on operating table.<br>
@@ -593,7 +592,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "bed"
 	no_icon_updates = 1 //no icon updates for this; it's static.
-	injected_reagents = list("corazone")
+	injected_reagents = list("corazone","spaceacillin")
 
 /obj/structure/closet/abductor
 	name = "alien locker"


### PR DESCRIPTION
Fixes #9199

Adds spaceacillin to the reagents injected by the abductor surgery table, preventing infections. 

🆑
rscadd: Provided abductors with an infection free surgery table.
/🆑