### PR TITLE
Fixes Ridiculous Surgical Infections

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -195,7 +195,7 @@
 	//germ spread from surgeon touching the patient
 	if(user.gloves)
 		germ_level = user.gloves.germ_level
-	E.germ_level += germ_level
+	E.germ_level = max(germ_level, E.germ_level)
 	spread_germs_by_incision(E, tool) //germ spread from environement to patient
 
 /proc/spread_germs_by_incision(obj/item/organ/external/E,obj/item/tool)


### PR DESCRIPTION
Fixes the logic of germ handling during surgery.

I mistakenly changed this during the larger wound datum removal, mostly because the logic didn't make much sense for it to be `max`. Either case, this is resulting in people dying from just a few surgical steps if there's any mistakes or mishaps; not good.

Infections *exciting* and *engaging* gameplay =V