### PR TITLE
Adds a location hint for the Theft objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -352,7 +352,9 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 		if(O.flags & 2)
 			continue
 		steal_target=O
-		explanation_text = "Steal [steal_target]. One can be found in [get_location()]."
+		explanation_text = "Steal [steal_target]. One was last seen in [get_location()]. "
+		if(islist(O.protected_jobs) && O.protected_jobs.len)
+			explanation_text += "It may also be in the possession of the [jointext(O.protected_jobs, ", ")]."
 		return
 	explanation_text = "Free Objective."
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -329,11 +329,17 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 	explanation_text = "Destroy the station with a nuclear device."
 	martyr_compatible = 1
 
-
-
 /datum/objective/steal
 	var/datum/theft_objective/steal_target
 	martyr_compatible = 0
+	var/theft_area
+
+/datum/objective/steal/proc/get_location()
+    if(steal_target.location_override)
+        return steal_target.location_override
+    var/obj/item/T = locate(steal_target.typepath)
+    theft_area = get_area(T.loc)
+    return "[theft_area]"
 
 /datum/objective/steal/find_target()
 	var/loop=50
@@ -346,7 +352,7 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 		if(O.flags & 2)
 			continue
 		steal_target=O
-		explanation_text = "Steal [O]."
+		explanation_text = "Steal [steal_target]. One can be found in [get_location()]."
 		return
 	explanation_text = "Free Objective."
 

--- a/code/game/gamemodes/steal_items.dm
+++ b/code/game/gamemodes/steal_items.dm
@@ -11,6 +11,7 @@
 	var/list/protected_jobs = list()
 	var/list/altitems = list()
 	var/flags = 0
+	var/location_override
 
 /datum/theft_objective/proc/check_completion(var/datum/mind/owner)
 	if(!owner.current)
@@ -49,6 +50,7 @@
 /datum/theft_objective/ai
 	name = "a functional AI"
 	typepath = /obj/item/aicard
+	location_override = "AI Satellite. An intellicard for transportation can be found in Tech Storage, Science Department or manufactured"
 
 datum/theft_objective/ai/check_special_completion(var/obj/item/aicard/C)
 	if(..())
@@ -91,6 +93,7 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/aicard/C)
 	name = "a sample of unused slime extract"
 	typepath = /obj/item/slime_extract
 	protected_jobs = list("Research Director","Scientist")
+	location_override = "Xenobiology"
 
 /datum/theft_objective/slime_extract/check_special_completion(var/obj/item/slime_extract/E)
 	if(..())
@@ -169,6 +172,7 @@ datum/theft_objective/ai/check_special_completion(var/obj/item/aicard/C)
 	min=28
 	max=28
 	protected_jobs = list("Chief Engineer", "Station Engineer", "Scientist", "Research Director", "Life Support Specialist")
+	location_override = "Engineering or Toxin Mixing"
 
 /datum/theft_objective/number/plasma_gas/getAmountStolen(var/obj/item/I)
 	return I:air_contents:toxins


### PR DESCRIPTION
What it says on the tin. When you are first made an antag with a theft objective, you are given a location hint. 
No more mhelps of "where krav naga???", mentors rejoice.

Example:
![img](https://i.imgur.com/JjLLQFd.png)
Special exceptions were added for AI, Plasma tank and the slime core.

🆑freestylalt
tweak:Theft objectives now give a hint as to where you can find the object.
/🆑