### PR TITLE
Removes the x-ray genetic mutation, makes the implant admin-only

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -26,7 +26,6 @@
 // Generic mutations:
 #define	TK				1
 #define COLDRES			2
-#define XRAY			3
 #define HULK			4
 #define CLUMSY			5
 #define FAT				6

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1309,13 +1309,6 @@ var/list/uplink_items = list()
 	item = /obj/item/organ/internal/cyberimp/eyes/thermals
 	cost = 8
 
-/datum/uplink_item/cyber_implants/xray
-	name = "X-Ray Vision Implant"
-	desc = "These cybernetic eyes will give you X-ray vision. Comes with an automated implanting tool."
-	reference = "CIX"
-	item = /obj/item/organ/internal/cyberimp/eyes/xray
-	cost = 10
-
 /datum/uplink_item/cyber_implants/antistun
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. \

--- a/code/game/dna/genes/powers.dm
+++ b/code/game/dna/genes/powers.dm
@@ -150,27 +150,6 @@
 		M.status_flags |= CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH //temporary fix until the problem can be solved.
 		to_chat(M, "<span class='danger'>You suddenly feel very weak.</span>")
 
-/datum/dna/gene/basic/xray
-	name="X-Ray Vision"
-	activation_messages=list("The walls suddenly disappear.")
-	deactivation_messages=list("the walls around you re-appear.")
-	instability = GENE_INSTABILITY_MAJOR
-	mutation=XRAY
-	activation_prob=15
-
-/datum/dna/gene/basic/xray/New()
-	block=XRAYBLOCK
-
-/datum/dna/gene/basic/xray/activate(mob/living/M, connected, flags)
-	..()
-	M.update_sight()
-	M.update_icons() //Apply eyeshine as needed.
-
-/datum/dna/gene/basic/xray/deactivate(mob/living/M, connected, flags)
-	..()
-	M.update_sight()
-	M.update_icons() //Remove eyeshine as needed.
-
 /datum/dna/gene/basic/tk
 	name="Telekenesis"
 	activation_messages = list("You feel smarter.")

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -40,7 +40,6 @@
 	HULKBLOCK          = getAssignedBlock("HULK",          numsToAssign, DNA_HARD_BOUNDS, good=1)
 	TELEBLOCK          = getAssignedBlock("TELE",          numsToAssign, DNA_HARD_BOUNDS, good=1)
 	FIREBLOCK          = getAssignedBlock("FIRE",          numsToAssign, DNA_HARDER_BOUNDS, good=1)
-	XRAYBLOCK          = getAssignedBlock("XRAY",          numsToAssign, DNA_HARDER_BOUNDS, good=1)
 	CLUMSYBLOCK        = getAssignedBlock("CLUMSY",        numsToAssign)
 	FAKEBLOCK          = getAssignedBlock("FAKE",          numsToAssign)
 	COUGHBLOCK         = getAssignedBlock("COUGH",         numsToAssign)

--- a/code/game/objects/items/weapons/dna_injector.dm
+++ b/code/game/objects/items/weapons/dna_injector.dm
@@ -173,27 +173,6 @@
 		block = HULKBLOCK
 		..()
 
-/obj/item/dnainjector/xraymut
-	name = "DNA-Injector (Xray)"
-	desc = "Finally you can see what the Captain does."
-	datatype = DNA2_BUF_SE
-	value = 0xFFF
-	//block = 8
-	New()
-		block = XRAYBLOCK
-		..()
-
-/obj/item/dnainjector/antixray
-	name = "DNA-Injector (Anti-Xray)"
-	desc = "It will make you see harder."
-	datatype = DNA2_BUF_SE
-	value = 0x001
-	//block = 8
-	New()
-		block = XRAYBLOCK
-		..()
-
-
 /obj/item/dnainjector/firemut
 	name = "DNA-Injector (Fire)"
 	desc = "Gives you fire."

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -719,11 +719,6 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 			H.weakeyes = 1
 		H.sight |= H.vision_type.sight_flags
 
-	if(XRAY in H.mutations)
-		H.sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		H.see_in_dark = max(H.see_in_dark, 8)
-		H.see_invisible = SEE_INVISIBLE_MINIMUM
-
 	if(H.see_override)	//Override all
 		H.see_invisible = H.see_override
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -441,9 +441,6 @@
 	see_in_dark = initial(see_in_dark)
 	sight = initial(sight)
 
-	if(XRAY in mutations)
-		grant_xray_vision()
-
 	if(client.eye != src)
 		var/atom/A = client.eye
 		if(A.update_remote_sight(src)) //returns 1 if we override all other sight updates.

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -257,16 +257,6 @@
 	see_in_dark = 8
 	see_invisible = SEE_INVISIBLE_OBSERVER
 
-// See through walls, dark, etc.
-// basically the same as death vision except you can't
-// see ghosts
-/mob/living/proc/grant_xray_vision()
-	sight |= SEE_TURFS
-	sight |= SEE_MOBS
-	sight |= SEE_OBJS
-	see_in_dark = 8
-	see_invisible = SEE_INVISIBLE_LEVEL_TWO
-
 /mob/living/proc/handle_hud_icons()
 	handle_hud_icons_health()
 	return

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -315,6 +315,18 @@
 	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/security
 	category = list("Misc", "Medical")
 
+/datum/design/cyberimp_xray
+	name = "X-Ray implant"
+	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
+	id = "ci-xray"
+	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 7, "magnets" = 5,"plasmatech" = 6)
+	build_type = PROTOLATHE | MECHFAB
+	construction_time = 60
+	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_URANIUM = 1000, MAT_DIAMOND = 1000, MAT_BLUESPACE = 1000)
+	build_path = /obj/item/organ/internal/cyberimp/eyes/xray
+	category = list("Misc", "Medical")
+
+
 /datum/design/cyberimp_thermals
 	name = "Thermals implant"
 	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -315,17 +315,6 @@
 	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/security
 	category = list("Misc", "Medical")
 
-/datum/design/cyberimp_xray
-	name = "X-Ray implant"
-	desc = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
-	id = "ci-xray"
-	req_tech = list("materials" = 7, "programming" = 5, "biotech" = 7, "magnets" = 5,"plasmatech" = 6)
-	build_type = PROTOLATHE | MECHFAB
-	construction_time = 60
-	materials = list(MAT_METAL = 600, MAT_GLASS = 600, MAT_SILVER = 600, MAT_GOLD = 600, MAT_PLASMA = 1000, MAT_URANIUM = 1000, MAT_DIAMOND = 1000, MAT_BLUESPACE = 1000)
-	build_path = /obj/item/organ/internal/cyberimp/eyes/xray
-	category = list("Misc", "Medical")
-
 /datum/design/cyberimp_thermals
 	name = "Thermals implant"
 	desc = "These cybernetic eyes will give you Thermal vision. Vertical slit pupil included."

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -4,7 +4,6 @@
 // DNA vaults require high tier stock parts and cold
 // After completion each crewmember can receive single upgrade chosen out of 2 for the mob.
 #define VAULT_SPACEIMMUNE "Space Immunity"
-#define VAULT_XRAY "X-Ray Vision"
 #define VAULT_TELEKINESIS "Telekinesis"
 #define VAULT_PSYCHIC "Psychic Powers"
 #define VAULT_SPEED "Speediness"
@@ -280,9 +279,6 @@ var/list/non_simple_animals = typecacheof(list(/mob/living/carbon/human/monkey,/
 			to_chat(H, "<span class='notice'>You suddenly don't feel the need to breathe anymore. You also don't feel any cold anymore.</span>")
 			grant_power(H, BREATHLESSBLOCK, BREATHLESS)
 			grant_power(H, FIREBLOCK, COLDRES)
-		if(VAULT_XRAY)
-			to_chat(H, "<span class='notice'>You can suddenly see through walls.</span>")
-			grant_power(H, XRAYBLOCK, XRAY)
 		if(VAULT_TELEKINESIS)
 			to_chat(H, "<span class='notice'>You gain the ability to control objects from a distance.</span>")
 			grant_power(H, TELEBLOCK, TK)


### PR DESCRIPTION
Theoretically, completely removes the x-ray mutation. Removes x-ray implants from nuke ops uplinks and protolathe design.
I've seen many people complain about x-ray, and how it made things unfair for the antagonists. X-ray is now only available for cameras, or through admins.

:cl: Superhats
del: Removes x-ray from the list of genetic mutations
tweak: X-ray implants are no-longer available through protolathes, or uplinks.
/:cl: