### PR TITLE
Changes to kidan bioluminescent lantern

### DIFF
--- a/code/modules/surgery/organs/subtypes/kidan.dm
+++ b/code/modules/surgery/organs/subtypes/kidan.dm
@@ -2,9 +2,9 @@
 	alcohol_intensity = 0.5
 	species = "Kidan"
 
-#define KIDAN_LANTERN_HUNGERCOST 0.5
+#define KIDAN_LANTERN_HUNGERCOST 0.4
 #define KIDAN_LANTERN_MINHUNGER 150
-#define KIDAN_LANTERN_LIGHT 4
+#define KIDAN_LANTERN_LIGHT 3
 
 /obj/item/organ/internal/lantern
 	name = "Bioluminescent Lantern"
@@ -19,6 +19,9 @@
 	var/glowing = 0
 
 /obj/item/organ/internal/lantern/ui_action_click()
+	if(!colour) // That's here just to make sure colour is no broken
+		var/obj/item/organ/internal/eyes/eyes = owner.get_int_organ(/obj/item/organ/internal/eyes) //Kida eye color info is stored in eye organ
+		colour = eyes.eye_colour // changes glowing color to eye color
 	if(toggle_biolum())
 		if(glowing)
 			owner.visible_message("<span class='notice'>[owner] starts to glow!</span>", "<span class='notice'>You enable your bioluminescence.</span>")
@@ -42,8 +45,9 @@
 
 		var/new_light = calculate_glow(KIDAN_LANTERN_LIGHT)
 
-		if(!colour)																		//this should never happen in theory
-			colour = BlendRGB(owner.m_colours["body"], owner.m_colours["head"], 0.65)	//then again im pretty bad at theoretics
+		if(!colour) //this should never happen in theory
+			var/obj/item/organ/internal/eyes/eyes = owner.get_int_organ(/obj/item/organ/internal/eyes)
+			colour = eyes.eye_colour //then again im pretty bad at theoretics
 
 		if(new_light != glowing)
 			var/obj/item/organ/external/groin/lbody = owner.get_organ(check_zone(parent_organ))
@@ -66,7 +70,8 @@
 		return 0
 
 	if(!colour)
-		colour = BlendRGB(owner.m_colours["head"], owner.m_colours["body"], 0.65)
+		var/obj/item/organ/internal/eyes/eyes = owner.get_int_organ(/obj/item/organ/internal/eyes)
+		colour = eyes.eye_colour
 
 	if(!glowing)
 		var/light = calculate_glow(KIDAN_LANTERN_LIGHT)
@@ -94,14 +99,18 @@
 	if(owner.wear_suit)
 		occlusion++
 
-	return light - occlusion
+	if(light-occlusion<2) //That locks glowing range to min 2
+		return 2
+	else
+		return light - occlusion
 
 /obj/item/organ/internal/lantern/remove(mob/living/carbon/M, special = 0)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 
 		if(!colour)								//if its removed before used save the color
-			colour = BlendRGB(H.m_colours["body"], H.m_colours["head"], 0.65)
+			var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)
+			colour = eyes.eye_colour
 
 		if(glowing)
 			toggle_biolum(1)


### PR DESCRIPTION
### Have you ever seen kidan using his/her lantern?
Propably not.
I changed it a little bit so they actually start using it.

### So, how does it work right now?
Current KIDAN_LANTERN_LIGHT is 4. What creates light with range of 6. Seems preety bright right?
But the range is decreasing. 
If you have anything on your jumpsuit slot: -1
anything on exosuit slot? -1
anything on your head? -1

If you are fully equipped, you generate no light.

I decreased KIDAN_LANTERN_LIGHT to 3 (range: 4), but I set minimum range to 2, no matter what. What means kidan can ALWAYS use it.

Besides that. I changed KIDAN_LANTERN_HUGERCOST from 0.5 to 0.4, what should allow them to glow just a little bit longer.

### Also, I changed the way it determins the glowing color. Why? 
Kida cannot have different skin color. If you look at the two different kida. The only things that differ them are eyes, antennae and body markings. Body markings almost always are covered by clothes, or are just black or not even present. No one really can see the difference between antennae, so really only thing that differ kida are eyes normally.
That why I changed the way it determins color. Now glowing color should match eye color.
It just kinda makes more sense to me, especially that glowing color is based on body markings color that doesn't need to be present for kidan to glow.


Kida can use it instead of flash light. It's weaker, but still.
Shadowlings may have a small problems with kida, but we anyway have like 5? active kida players? 
That also might convince more people to actually play kidan.
I'd love to see that!

