### PR TITLE
Reveal identity while using megaphone 

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -65,7 +65,7 @@
 			spamcheck = 0
 
 /obj/item/megaphone/proc/saymsg(mob/living/user as mob, message)
-	audible_message("<span class='game say'><span class='name'>[user]</span> broadcasts, <span class='reallybig'>\"[message]\"</span></span>", hearing_distance = 14)
+	audible_message("<span class='game say'><span class='name'>[user.GetVoice()]</span> [user.GetAltName()] broadcasts, <span class='reallybig'>\"[message]\"</span></span>", hearing_distance = 14)
 	log_say(message, user)
 	for(var/obj/O in oview(14, get_turf(src)))
 		O.hear_talk(user, "<span class='reallybig'>[message]</span>")

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -1,6 +1,6 @@
 // At minimum every mob has a hear_say proc.
 
-/mob/proc/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/proc/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
 	if(!client)
 		return 0
 
@@ -70,12 +70,12 @@
 			if(speaker == src)
 				to_chat(src, "<span class='warning'>You cannot hear yourself speak!</span>")
 			else
-				to_chat(src, "<span class='name'>[speaker_name]</span>[alt_name] talks but you cannot hear [speaker.p_them()].")
+				to_chat(src, "<span class='name'>[speaker_name]</span>[speaker.GetAltName()] talks but you cannot hear [speaker.p_them()].")
 	else
 		if(language)
-			to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][language.format_message(message, verb)]</span>")
+			to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span>[speaker.GetAltName()] [track][language.format_message(message, verb)]</span>")
 		else
-			to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span>[alt_name] [track][verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
+			to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span>[speaker.GetAltName()] [track][verb], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
 		if(speech_sound && (get_dist(speaker, src) <= world.view && src.z == speaker.z))
 			var/turf/source = speaker? get_turf(speaker) : get_turf(src)
 			src.playsound_local(source, speech_sound, sound_vol, 1)

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -29,7 +29,7 @@
 				to_chat(usr, "<span class='warning'>You cannot speak, as your internal speaker is turned off.</span>")
 			. = FALSE
 
-/mob/living/carbon/brain/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios, var/alt_name)
+/mob/living/carbon/brain/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios)
 	switch(message_mode)
 		if("headset")
 			var/radio_worked = 0 // If any of the radios our brainmob could use functioned, this is set true so that we don't use any others
@@ -45,6 +45,6 @@
 					radio_worked = c.radio.talk_into(src, message, message_mode, verb, speaking)
 			return radio_worked
 		if("whisper")
-			whisper_say(message, speaking, alt_name)
+			whisper_say(message, speaking)
 			return 1
 		else return 0

--- a/code/modules/mob/living/carbon/human/interactive/interactive.dm
+++ b/code/modules/mob/living/carbon/human/interactive/interactive.dm
@@ -581,7 +581,7 @@
 	saveVoice()
 	..()
 
-/mob/living/carbon/human/interactive/hear_say(message, verb = "says", datum/language/language = null, alt_name = "", italics = 0, mob/speaker = null, sound/speech_sound, sound_vol)
+/mob/living/carbon/human/interactive/hear_say(message, verb = "says", datum/language/language = null, italics = 0, mob/speaker = null, sound/speech_sound, sound_vol)
 	if(!istype(speaker, /mob/living/carbon/human/interactive))
 		knownStrings |= html_decode(message)
 	..()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,10 +1,10 @@
 /mob/living/carbon/human/say(var/message, var/sanitize = TRUE, var/ignore_speech_problems = FALSE, var/ignore_atmospherics = FALSE)
-	var/alt_name = ""
+	..(message, sanitize = sanitize, ignore_speech_problems = ignore_speech_problems, ignore_atmospherics = ignore_atmospherics)	//ohgod we should really be passing a datum here.
 
+/mob/living/carbon/human/GetAltName()
 	if(name != GetVoice())
-		alt_name = " (as [get_id_name("Unknown")])"
-
-	..(message, alt_name = alt_name, sanitize = sanitize, ignore_speech_problems = ignore_speech_problems, ignore_atmospherics = ignore_atmospherics)	//ohgod we should really be passing a datum here.
+		return " (as [get_id_name("Unknown")])"
+	return ..()
 
 /mob/living/carbon/human/proc/forcesay(list/append)
 	if(stat == CONSCIOUS)
@@ -160,7 +160,7 @@
 	returns[3] = speech_problem_flag
 	return returns
 
-/mob/living/carbon/human/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios, var/alt_name)
+/mob/living/carbon/human/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios)
 	switch(message_mode)
 		if("intercom")
 			for(var/obj/item/radio/intercom/I in view(1, src))
@@ -203,7 +203,7 @@
 				R.talk_into(src, message, null, verb, speaking)
 
 		if("whisper")
-			whisper_say(message, speaking, alt_name)
+			whisper_say(message, speaking)
 			return 1
 		else
 			if(message_mode)

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -1,10 +1,5 @@
 //Lallander was here
 /mob/living/carbon/human/whisper(message as text)
-	var/alt_name = ""
-
-	if(name != GetVoice())
-		alt_name = "(as [get_id_name("Unknown")])"
-
 	message = trim_strip_html_properly(message) //bit of duplicate code, acceptable because the workaround would be annoying
 
 	//parse the language code and consume it
@@ -23,4 +18,4 @@
 	message = trim_left(message)
 	message = handle_autohiss(message, speaking)
 
-	whisper_say(message, speaking, alt_name)
+	whisper_say(message, speaking)

--- a/code/modules/mob/living/carbon/slime/say.dm
+++ b/code/modules/mob/living/carbon/slime/say.dm
@@ -14,7 +14,7 @@
 		return 1
 	return ..()
 
-/mob/living/carbon/slime/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/living/carbon/slime/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
 	if(speaker in Friends)
 		speech_buffer = list()
 		speech_buffer.Add(speaker)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -95,10 +95,10 @@ proc/get_radio_key_from_channel(var/channel)
 	returns[3] = speech_problem_flag
 	return returns
 
-/mob/living/proc/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+/mob/living/proc/handle_message_mode(message_mode, message, verb, speaking, used_radios)
 	switch(message_mode)
 		if("whisper") //all mobs can whisper by default
-			whisper_say(message, speaking, alt_name)
+			whisper_say(message, speaking)
 			return 1
 	return 0
 
@@ -109,7 +109,7 @@ proc/get_radio_key_from_channel(var/channel)
 	return returns
 
 
-/mob/living/say(var/message, var/datum/language/speaking = null, var/verb = "says", var/alt_name = "", var/sanitize = TRUE, var/ignore_speech_problems = FALSE, var/ignore_atmospherics = FALSE)
+/mob/living/say(var/message, var/datum/language/speaking = null, var/verb = "says", var/sanitize = TRUE, var/ignore_speech_problems = FALSE, var/ignore_atmospherics = FALSE)
 	if(client)
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
@@ -184,7 +184,7 @@ proc/get_radio_key_from_channel(var/channel)
 		return 0
 
 	var/list/used_radios = list()
-	if(handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name))
+	if(handle_message_mode(message_mode, message, verb, speaking, used_radios))
 		return 1
 
 	var/list/handle_v = handle_speech_sound()
@@ -268,7 +268,7 @@ proc/get_radio_key_from_channel(var/channel)
 	var/speech_bubble_test = say_test(message)
 
 	for(var/mob/M in listening)
-		M.hear_say(message, verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+		M.hear_say(message, verb, speaking, italics, src, speech_sound, sound_vol)
 		if(M.client)
 			speech_bubble_recipients.Add(M.client)
 	spawn(0)
@@ -359,7 +359,7 @@ proc/get_radio_key_from_channel(var/channel)
 /mob/living/proc/get_whisper_loc()
 	return src
 
-/mob/living/proc/whisper_say(var/message, var/datum/language/speaking = null, var/alt_name="", var/verb="whispers")
+/mob/living/proc/whisper_say(var/message, var/datum/language/speaking = null, var/verb="whispers")
 	if(client)
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, "<span class='danger'>You cannot speak in IC (Muted).</span>")
@@ -466,14 +466,14 @@ proc/get_radio_key_from_channel(var/channel)
 	var/speech_bubble_test = say_test(message)
 
 	for(var/mob/M in listening)
-		M.hear_say(message, verb, speaking, alt_name, italics, src)
+		M.hear_say(message, verb, speaking, italics, src)
 		if(M.client)
 			speech_bubble_recipients.Add(M.client)
 
 	if(eavesdropping.len)
 		var/new_message = stars(message)	//hopefully passing the message twice through stars() won't hurt... I guess if you already don't understand the language, when they speak it too quietly to hear normally you would be able to catch even less.
 		for(var/mob/M in eavesdropping)
-			M.hear_say(new_message, verb, speaking, alt_name, italics, src)
+			M.hear_say(new_message, verb, speaking, italics, src)
 			if(M.client)
 				speech_bubble_recipients.Add(M.client)
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -137,6 +137,6 @@
 	acceleration = !acceleration
 	to_chat(usr, "Camera acceleration has been toggled [acceleration ? "on" : "off"].")
 
-/mob/camera/aiEye/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "", var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
+/mob/camera/aiEye/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/italics = 0, var/mob/speaker = null, var/sound/speech_sound, var/sound_vol)
 	if(relay_speech)
 		ai.relay_speech(speaker, message, verb, language)

--- a/code/modules/mob/living/silicon/robot/drone/drone_say.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_say.dm
@@ -1,7 +1,7 @@
 /mob/living/silicon/robot/drone/say(var/message, var/datum/language/speaking = null)
 	if(copytext(message, 1, 2) == "*")
 		return emote(copytext(message, 2))
-		
+
 	if(!speaking)
 		speaking = parse_language(message)
 		if(!speaking)
@@ -10,6 +10,6 @@
 	if(speaking)
 		return ..()
 
-/mob/living/silicon/robot/drone/whisper_say(var/message, var/datum/language/speaking = null, var/alt_name="", var/verb="whispers")
+/mob/living/silicon/robot/drone/whisper_say(var/message, var/datum/language/speaking = null, var/verb="whispers")
 	say(message) //drones do not get to whisper, only speak normally
 	return 1

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -1,9 +1,9 @@
-/mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+/mob/living/silicon/handle_message_mode(message_mode, message, verb, speaking, used_radios)
 	log_say(message, src)
 	if(..())
 		return 1
 
-/mob/living/silicon/robot/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+/mob/living/silicon/robot/handle_message_mode(message_mode, message, verb, speaking, used_radios)
 	if(..())
 		return 1
 	if(message_mode)
@@ -15,7 +15,7 @@
 			message_mode = null
 		return radio.talk_into(src,message,message_mode,verb,speaking)
 
-/mob/living/silicon/ai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+/mob/living/silicon/ai/handle_message_mode(message_mode, message, verb, speaking, used_radios)
 	if(..())
 		return 1
 	if(message_mode == "department")
@@ -30,11 +30,11 @@
 			message_mode = null
 		return aiRadio.talk_into(src,message,message_mode,verb,speaking)
 
-/mob/living/silicon/pai/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name)
+/mob/living/silicon/pai/handle_message_mode(message_mode, message, verb, speaking, used_radios)
 	if(..())
 		return 1
 	else if(message_mode == "whisper")
-		whisper_say(message, speaking, alt_name)
+		whisper_say(message, speaking)
 		return 1
 	else if(message_mode)
 		if(message_mode == "general")

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -703,12 +703,12 @@
 	available_channels = list(":e")
 	..()
 
-/mob/living/simple_animal/parrot/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios, var/alt_name)
+/mob/living/simple_animal/parrot/handle_message_mode(var/message_mode, var/message, var/verb, var/speaking, var/used_radios)
 	if(message_mode && istype(ears))
 		ears.talk_into(src, message, message_mode, verb, speaking)
 		used_radios += ears
 
-/mob/living/simple_animal/parrot/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/alt_name = "",var/italics = 0, var/mob/speaker = null)
+/mob/living/simple_animal/parrot/hear_say(var/message, var/verb = "says", var/datum/language/language = null, var/italics = 0, var/mob/speaker = null)
 	if(speaker != src && prob(50))
 		parrot_hear(html_decode(message))
 	..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -47,6 +47,9 @@
 /mob/proc/generate_name()
 	return name
 
+/mob/proc/GetAltName()
+	return ""
+
 
 /mob/proc/Cell()
 	set category = "Admin"


### PR DESCRIPTION
See #3031

* Displays who is really speaking when they use the microphone
* Refactor to remove alt_name arguments from hear, speak, and whisper. Moved it to a proc on mob called GetAltName

I tested it for a while and it seems to be working. But this is my first change and I'm not very familiar with the code base.

Tried these things:

* whispering
* Using megaphone
* speaking
* speaking on radio

I'm not sure how it appears from the other player's perspective. Please let me know if I should test more or what to change, thanks

[cl]
:fix: Megaphones now reveal the identity of the speaker, like speaking normally.
[/cl]