### PR TITLE
Pai light and veil refactor

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -60,58 +60,6 @@
 	var/blacklisted_lights = list(/obj/item/flashlight/flare, /obj/item/flashlight/slime)
 	action_icon_state = "veil"
 
-/obj/effect/proc_holder/spell/aoe_turf/veil/proc/extinguishItem(var/obj/item/I) //WARNING NOT SUFFICIENT TO EXTINGUISH AN ITEM HELD BY A MOB
-	if(istype(I, /obj/item/flashlight))
-		var/obj/item/flashlight/F = I
-		if(F.on)
-			if(is_type_in_list(I, blacklisted_lights))
-				I.visible_message("<span class='danger'>[I] dims slightly before scattering the shadows around it.</span>")
-				return
-			F.on = 0
-			F.update_brightness()
-	else if(istype(I, /obj/item/pda))
-		var/obj/item/pda/P = I
-		var/datum/data/pda/utility/flashlight/FL = P.find_program(/datum/data/pda/utility/flashlight)
-		if(FL && FL.fon)
-			FL.start()
-	else if(istype(I, /obj/item/clothing/head/helmet/space/hardsuit))
-		var/obj/item/clothing/head/helmet/space/hardsuit/R = I
-		if(R.on)
-			R.toggle_light()
-			R.visible_message("<span class='danger'>[R]'s light fades and turns off.</span>")
-	else if(istype(I, /obj/item/clothing/head/helmet/space/eva/plasmaman))
-		var/obj/item/clothing/head/helmet/space/eva/plasmaman/P = I
-		if(P.on)
-			P.toggle_light()
-			P.visible_message("<span class='danger'>[P]'s light fades and turns off.</span>")
-	else if(istype(I, /obj/item/gun))
-		var/obj/item/gun/G = I
-		if(G.gun_light)
-			var/obj/item/flashlight/F = G.gun_light
-			if(F.on)
-				G.toggle_gunlight()
-				G.visible_message("<span class='danger'>[G]'s light fades and turns off.</span>")
-	else if(istype(I, /obj/item/clothing/head/hardhat)) //There really needs to be a better way to handle this.
-		var/obj/item/clothing/head/hardhat/hhat = I
-		if(hhat.on)
-			hhat.on = 0
-			hhat.set_light(0)
-			hhat.icon_state = "hardhat0_[hhat.item_color]"
-			hhat.item_state = "hardhat0_[hhat.item_color]"
-			hhat.visible_message("<span class='danger'>[hhat]'s light fades and turns off.</span>")
-	return I.light_range
-
-/obj/effect/proc_holder/spell/aoe_turf/veil/proc/extinguishMob(mob/living/L)
-	for(var/obj/item/F in L)
-		if(F.light_range > 0)
-			extinguishItem(F)
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		var/obj/item/organ/internal/lantern/O = H.get_int_organ(/obj/item/organ/internal/lantern)
-		if(O && O.glowing)
-			O.toggle_biolum(1)
-			H.visible_message("<span class='danger'>[H] is engulfed in shadows and fades into the darkness.</span>", "<span class='danger'>A sense of dread washes over you as you suddenly dim dark.</span>")
-
 /obj/effect/proc_holder/spell/aoe_turf/veil/cast(list/targets, mob/user = usr)
 	if(!shadowling_check(user))
 		charge_counter = charge_max
@@ -121,23 +69,8 @@
 		G.visible_message("<span class='warning'>\The [G] withers away!</span>")
 		qdel(G)
 	for(var/turf/T in targets)
-		for(var/obj/item/F in T.contents)
-			extinguishItem(F)
-		for(var/obj/machinery/floodlight/F in T.contents)
-			F.on = 0
-			F.set_light(0)
-		for(var/obj/machinery/light/L in T.contents)
-			L.on = 0
-			L.visible_message("<span class='danger'>[L] flickers and falls dark.</span>")
-			L.update(0)
-		for(var/obj/machinery/computer/C in T.contents)
-			C.set_light(0)
-			C.visible_message("<span class='danger'>[C] grows dim, its screen barely readable.</span>")
-		for(var/mob/living/H in T.contents)
-			extinguishMob(H)
-		for(var/mob/living/silicon/robot/borg in T.contents)
-			borg.update_headlamp(1, charge_max)
-
+		for(var/atom/A in T.contents)
+			A.extinguish_light()
 
 /obj/effect/proc_holder/spell/targeted/shadow_walk
 	name = "Shadow Walk"

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -68,6 +68,10 @@
 		set_broken()
 		density = 0
 
+/obj/machinery/computer/extinguish_light()
+	set_light(0)
+	visible_message("<span class='danger'>[src] grows dim, its screen barely readable.</span>")
+
 /obj/machinery/computer/update_icon()
 	overlays.Cut()
 	if(stat & NOPOWER)

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -117,3 +117,7 @@
 				cell = W
 				to_chat(user, "You insert the power cell.")
 	updateicon()
+
+/obj/machinery/floodlight/extinguish_light()
+	on = 0
+	set_light(0)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -9,7 +9,7 @@
 	slot_flags = SLOT_BELT
 	materials = list(MAT_METAL=50, MAT_GLASS=20)
 	actions_types = list(/datum/action/item_action/toggle_light)
-	var/on = 0
+	var/on = FALSE
 	var/brightness_on = 4 //luminosity when on
 
 /obj/item/flashlight/Initialize()
@@ -85,7 +85,7 @@
 
 /obj/item/flashlight/extinguish_light()
 	if(on)
-		on = 0
+		on = FALSE
 		update_brightness()
 
 /obj/item/flashlight/pen
@@ -126,7 +126,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	flags = CONDUCT
 	materials = list()
-	on = 1
+	on = TRUE
 
 
 // green-shaded desk lamp
@@ -239,7 +239,7 @@ obj/item/flashlight/lamp/bananalamp
 	brightness_on = 6
 	light_color = "#FFBF00"
 	materials = list()
-	on = 1 //Bio-luminesence has one setting, on.
+	on = TRUE //Bio-luminesence has one setting, on.
 
 /obj/item/flashlight/slime/New()
 	set_light(brightness_on)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -83,6 +83,11 @@
 	else
 		return ..()
 
+/obj/item/flashlight/extinguish_light()
+	if(on)
+		on = 0
+		update_brightness()
+
 /obj/item/flashlight/pen
 	name = "penlight"
 	desc = "A pen-sized light, used by medical staff."
@@ -211,6 +216,9 @@ obj/item/flashlight/lamp/bananalamp
 		src.damtype = "fire"
 		processing_objects += src
 
+/obj/item/flashlight/flare/extinguish_light()
+	visible_message("<span class='danger'>[src] dims slightly before scattering the shadows around it.</span>")
+	
 /obj/item/flashlight/flare/torch
 	name = "torch"
 	desc = "A torch fashioned from some leaves and a log."
@@ -241,6 +249,9 @@ obj/item/flashlight/lamp/bananalamp
 
 /obj/item/flashlight/slime/attack_self(mob/user)
 	return //Bio-luminescence does not toggle.
+
+/obj/item/flashlight/slime/extinguish_light()
+	visible_message("<span class='danger'>[src] dims slightly before scattering the shadows around it.</span>")
 
 /obj/item/flashlight/emp
 	origin_tech = "magnets=3;syndicate=1"

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -339,3 +339,7 @@
 		pai.ex_act(severity)
 	else
 		qdel(src)
+
+/obj/item/paicard/extinguish_light()
+	for(var/atom/A in src)
+		A.extinguish_light()

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -342,3 +342,4 @@
 
 /obj/item/paicard/extinguish_light()
 	pai.extinguish_light()
+	set_light(0)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -341,5 +341,4 @@
 		qdel(src)
 
 /obj/item/paicard/extinguish_light()
-	for(var/atom/A in src)
-		A.extinguish_light()
+	pai.extinguish_light()

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -5,7 +5,7 @@
 	icon_state = "hardhat0_yellow"
 	item_state = "hardhat0_yellow"
 	var/brightness_on = 4 //luminosity when on
-	var/on = 0
+	var/on = FALSE
 	item_color = "yellow" //Determines used sprites: hardhat[on]_[color] and hardhat[on]_[color]2 (lying down sprite)
 	armor = list(melee = 15, bullet = 5, laser = 20, energy = 10, bomb = 20, bio = 10, rad = 20)
 	flags_inv = 0
@@ -28,7 +28,7 @@
 
 /obj/item/clothing/head/hardhat/extinguish_light()
 	if(on)
-		on = 0
+		on = FALSE
 		set_light(0)
 		icon_state = "hardhat0_[item_color]"
 		item_state = "hardhat0_[item_color]"

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -26,6 +26,13 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
+/obj/item/clothing/head/hardhat/extinguish_light()
+	if(on)
+		on = 0
+		set_light(0)
+		icon_state = "hardhat0_[item_color]"
+		item_state = "hardhat0_[item_color]"
+		visible_message("<span class='danger'>[src]'s light fades and turns off.</span>")
 
 /obj/item/clothing/head/hardhat/orange
 	icon_state = "hardhat0_orange"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -57,6 +57,11 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
+/obj/item/clothing/head/helmet/space/hardsuit/extinguish_light()
+	if(on)
+		toggle_light()
+		visible_message("<span class='danger'>[src]'s light fades and turns off.</span>")
+
 /obj/item/clothing/head/helmet/space/hardsuit/item_action_slot_check(slot)
 	if(slot == slot_head)
 		return 1

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -102,6 +102,11 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
+/obj/item/clothing/head/helmet/space/eva/plasmaman/extinguish_light()
+	if(on)
+		toggle_light()
+		visible_message("<span class='danger'>[src]'s light fades and turns off.</span>")
+
 // ENGINEERING
 /obj/item/clothing/suit/space/eva/plasmaman/atmostech
 	name = "plasmaman atmospheric suit"

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -40,6 +40,9 @@
 		else
 			light = new /datum/light_source(src, .)
 
+/atom/proc/extinguish_light()
+	return
+
 /atom/Destroy()
 	if(light)
 		light.destroy()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2022,5 +2022,5 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 	var/obj/item/organ/internal/lantern/O = get_int_organ(/obj/item/organ/internal/lantern)
 	if(O && O.glowing)
-		O.toggle_biolum(1)
+		O.toggle_biolum(TRUE)
 		visible_message("<span class='danger'>[src] is engulfed in shadows and fades into the darkness.</span>", "<span class='danger'>A sense of dread washes over you as you suddenly dim dark.</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2015,3 +2015,12 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 /mob/living/carbon/human/proc/special_post_clone_handling()
 	if(mind && mind.assigned_role == "Cluwne") //HUNKE your suffering never stops
 		makeCluwne()
+
+/mob/living/carbon/human/extinguish_light()
+	// Parent function handles stuff the human may be holding
+	..()
+
+	var/obj/item/organ/internal/lantern/O = get_int_organ(/obj/item/organ/internal/lantern)
+	if(O && O.glowing)
+		O.toggle_biolum(1)
+		visible_message("<span class='danger'>[src] is engulfed in shadows and fades into the darkness.</span>", "<span class='danger'>A sense of dread washes over you as you suddenly dim dark.</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -996,3 +996,8 @@
 		return
 
 	to_chat(src, "<span class='notice'>You can taste [english_list(final_taste_list)].</span>")
+
+/mob/living/extinguish_light()
+	for(var/atom/A in src)
+		if(A.light_range > 0)
+			A.extinguish_light()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -618,3 +618,7 @@
 	else //something went very wrong.
 		CRASH("pAI without card")
 	loc = card
+
+/mob/living/silicon/pai/extinguish_light()
+	flashlight_on = 0
+	set_light(0)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -79,7 +79,7 @@
 	var/obj/item/integrated_radio/signal/sradio // AI's signaller
 
 	var/translator_on = 0 // keeps track of the translator module
-	var/flashlight_on = 0 //keeps track of the flashlight module
+	var/flashlight_on = FALSE //keeps track of the flashlight module
 
 	var/current_pda_messaging = null
 	var/custom_sprite = 0
@@ -620,5 +620,5 @@
 	loc = card
 
 /mob/living/silicon/pai/extinguish_light()
-	flashlight_on = 0
+	flashlight_on = FALSE
 	set_light(0)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -622,3 +622,4 @@
 /mob/living/silicon/pai/extinguish_light()
 	flashlight_on = FALSE
 	set_light(0)
+	card.set_light(0)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -79,6 +79,7 @@
 	var/obj/item/integrated_radio/signal/sradio // AI's signaller
 
 	var/translator_on = 0 // keeps track of the translator module
+	var/flashlight_on = 0 //keeps track of the flashlight module
 
 	var/current_pda_messaging = null
 	var/custom_sprite = 0

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -619,8 +619,10 @@
 	user.flashlight_on = !user.flashlight_on
 	if(user.flashlight_on)
 		user.set_light(2)
+		user.card.set_light(2)
 		return
 	user.set_light(0)
+	user.card.set_light(0)
 
 /datum/pai_software/flashlight/is_active(mob/living/silicon/pai/user)
 	return user.flashlight_on

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -609,3 +609,18 @@
 		data["holder"] = 0
 
 	return data
+
+/datum/pai_software/flashlight
+	name = "Flashlight"
+	ram_cost = 5
+	id = "flashlight"
+
+/datum/pai_software/flashlight/toggle(mob/living/silicon/pai/user)
+	user.flashlight_on = !user.flashlight_on
+	if(user.flashlight_on)
+		user.set_light(2)
+		return
+	user.set_light(0)
+
+/datum/pai_software/flashlight/is_active(mob/living/silicon/pai/user)
+	return user.flashlight_on

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1433,6 +1433,10 @@ var/list/robot_verbs_default = list(
 			disable_component("comms", 160)
 		if(2)
 			disable_component("comms", 60)
+
+/mob/living/silicon/robot/extinguish_light()
+	update_headlamp(1, 150)
+
 /mob/living/silicon/robot/rejuvenate()
 	..()
 	var/brute = 1000

--- a/code/modules/pda/PDA.dm
+++ b/code/modules/pda/PDA.dm
@@ -511,3 +511,8 @@ var/global/list/obj/item/pda/PDAs = list()
 /obj/item/pda/process()
 	if(current_app)
 		current_app.program_process()
+
+/obj/item/pda/extinguish_light()
+	var/datum/data/pda/utility/flashlight/FL = find_program(/datum/data/pda/utility/flashlight)
+	if(FL && FL.fon)
+		FL.start()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -137,7 +137,7 @@
 	idle_power_usage = 2
 	active_power_usage = 20
 	power_channel = LIGHT //Lights are calc'd via area so they dont need to be in the machine list
-	var/on = 0					// 1 if on, 0 if off
+	var/on = FALSE					// 1 if on, 0 if off
 	var/on_gs = 0
 	var/static_power_used = 0
 	var/brightness_range = 8	// luminosity when on, also used in power calculation
@@ -212,7 +212,7 @@
 /obj/machinery/light/Destroy()
 	var/area/A = get_area(src)
 	if(A)
-		on = 0
+		on = FALSE
 //		A.update_lights()
 	return ..()
 
@@ -223,13 +223,13 @@
 			icon_state = "[base_state][on]"
 		if(LIGHT_EMPTY)
 			icon_state = "[base_state]-empty"
-			on = 0
+			on = FALSE
 		if(LIGHT_BURNED)
 			icon_state = "[base_state]-burned"
-			on = 0
+			on = FALSE
 		if(LIGHT_BROKEN)
 			icon_state = "[base_state]-broken"
-			on = 0
+			on = FALSE
 	return
 
 // update the icon_state and luminosity of the light depending on its state
@@ -254,7 +254,7 @@
 				if(status == LIGHT_OK && trigger)
 					status = LIGHT_BURNED
 					icon_state = "[base_state]-burned"
-					on = 0
+					on = FALSE
 					set_light(0)
 			else
 				use_power = 2
@@ -734,6 +734,6 @@
 	return FIRELOSS
 
 /obj/machinery/light/extinguish_light()
-	on = 0
+	on = FALSE
 	visible_message("<span class='danger'>[src] flickers and falls dark.</span>")
 	update(0)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -159,7 +159,6 @@
 	var/nightshift_light_power = 0.45
 	var/nightshift_light_color = "#FFDDCC"
 
-
 // the smaller bulb light fixture
 
 /obj/machinery/light/small
@@ -733,3 +732,8 @@
 		if(limb)
 			limb.droplimb(0, DROPLIMB_BURN)
 	return FIRELOSS
+
+/obj/machinery/light/extinguish_light()
+	on = 0
+	visible_message("<span class='danger'>[src] flickers and falls dark.</span>")
+	update(0)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -303,6 +303,11 @@ obj/item/gun/proc/newshot()
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
+/obj/item/gun/extinguish_light()
+	if(gun_light.on)
+		toggle_gunlight()
+		visible_message("<span class='danger'>[src]'s light fades and turns off.</span>")
+
 /obj/item/gun/pickup(mob/user)
 	..()
 	if(azoom)


### PR DESCRIPTION
Continuation of #8827 

Refactored veil so it isn't a bunch of branching typechecks

Known issue: pAI in card form card doesn't shine when it's in your hand. This is cause the pAI is inside the card. Will look into fixing this soon.

Needs more testing, but pAIs should get extinguished in either form and when held by mobs.

:cl: Spacemanspark, Tayyyyyyy
add: pAI units now have access to a flashlight module, which can be obtained with 5 RAM points.
/:cl: