### PR TITLE
Fixes runtime error from medical kit change

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -89,11 +89,13 @@
 	var/nrembrute = rembrute
 	var/nremburn = remburn
 	affecting.heal_damage(heal_brute, heal_burn)
-	var/list/achildlist = affecting.children.Copy()
+	var/list/achildlist
+	if(!isnull(affecting.children))
+		achildlist = affecting.children.Copy()
 	var/parenthealed = FALSE
 	while(rembrute + remburn > 0) // Don't bother if there's not enough leftover heal
 		var/obj/item/organ/external/E
-		if(achildlist.len)
+		if(!isnull(achildlist) && achildlist.len)
 			E = pick_n_take(achildlist) // Pick a random children and then remove it from the list
 		else if(affecting.parent && !parenthealed) // If there's a parent and no healing attempt was made on it
 			E = affecting.parent

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -95,7 +95,7 @@
 	var/parenthealed = FALSE
 	while(rembrute + remburn > 0) // Don't bother if there's not enough leftover heal
 		var/obj/item/organ/external/E
-		if(!isnull(achildlist) && achildlist.len)
+		if(LAZYLEN(achildlist))
 			E = pick_n_take(achildlist) // Pick a random children and then remove it from the list
 		else if(affecting.parent && !parenthealed) // If there's a parent and no healing attempt was made on it
 			E = affecting.parent


### PR DESCRIPTION
This fixes a runtime error that I introducd by accident in an earlier Medical Kit PR.

I forgot to check if the list is null before calling a function on them (oops!). This fixes it.

🆑Ansari
fix: Fixes runtime error from medical kit change
/🆑 