### PR TITLE
Adds overheal to welder & cable coil

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -1,3 +1,5 @@
+#define HEALPERWELD 15
+
 /* Tools!
  * Note: Multitools are in devices
  *
@@ -407,24 +409,47 @@
 			to_chat(user, "<span class='warning'>Turn on [src] before attempting repairs!</span>")
 			return 1
 
-		if(S.brute_dam)
-			if(S.brute_dam < ROBOLIMB_SELF_REPAIR_CAP)
-				if(get_fuel() >= 1)
-					if(H == user)
-						if(!do_mob(user, H, 10))
-							return 1
-					if(remove_fuel(1,null))
-						playsound(src.loc, usesound, 50, 1)
-						S.heal_damage(15,0,0,1)
-						user.visible_message("<span class='alert'>\The [user] patches some dents on \the [M]'s [S.name] with \the [src].</span>")
-				else if(S.open != 2)
-					to_chat(user, "<span class='warning'>Need more welding fuel!</span>")
-					return 1
-			else
-				to_chat(user, "<span class='danger'>The damage is far too severe to patch over externally.</span>")
-			return 1
-		else if(S.open != 2)
+		if(S.brute_dam > ROBOLIMB_SELF_REPAIR_CAP)
+			to_chat(user, "<span class='danger'>The damage is far too severe to patch over externally.</span>")
+			return
+
+		if(!S.brute_dam)
 			to_chat(user, "<span class='notice'>Nothing to fix!</span>")
+			return
+
+		if(get_fuel() >= 1)
+			if(H == user)
+				if(!do_mob(user, H, 10))
+					return 1
+			if(!remove_fuel(1,null))
+				to_chat(user, "<span class='warning'>Need more welding fuel!</span>")
+			var/rembrute = HEALPERWELD
+			var/nrembrute = 0
+			var/childlist
+			if(!isnull(S.children))
+				childlist = S.children.Copy()
+			var/parenthealed = FALSE
+			while(rembrute > 0)
+				var/obj/item/organ/external/E
+				if(S.brute_dam)
+					E = S
+				else if(LAZYLEN(childlist))
+					E = pick_n_take(childlist)
+					if(!E.brute_dam || !E.is_robotic())
+						continue
+				else if(S.parent && !parenthealed)
+					E = S.parent
+					parenthealed = TRUE
+					if(!E.brute_dam || !E.is_robotic())
+						break
+				else
+					break
+				playsound(src.loc, usesound, 50, 1)
+				nrembrute = max(rembrute - E.brute_dam, 0)
+				E.heal_damage(rembrute,0,0,1)
+				rembrute = nrembrute
+				user.visible_message("<span class='alert'>\The [user] patches some dents on \the [M]'s [E.name] with \the [src].</span>")
+			return 1
 	else
 		return ..()
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -1,3 +1,5 @@
+#define HEALPERCABLE 3
+#define MAXCABLEPERHEAL 8
 ///////////////////////////////
 //CABLE STRUCTURE
 ///////////////////////////////
@@ -531,23 +533,44 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 		if(!S.is_robotic() || user.a_intent != INTENT_HELP || S.open == 2)
 			return ..()
 
-		if(S.burn_dam)
-			if(S.burn_dam < ROBOLIMB_SELF_REPAIR_CAP)
-				if(H == user)
-					if(!do_mob(user, H, 10))
-						return 1
-				var/cable_to_use = 0
-				for(cable_to_use in 1 to 5)
-					if(cable_to_use == amount || (cable_to_use * 3) >= S.burn_dam)
-						break
-				use(cable_to_use)
-				S.heal_damage(0, (cable_to_use * 3), 0, 1)
-				user.visible_message("<span class='alert'>\The [user] repairs some burn damage on \the [M]'s [S.name] with \the [src].</span>")
-			else if(S.open != 2)
-				to_chat(user, "<span class='danger'>The damage is far too severe to patch over externally.</span>")
-			return 1
-		else if(S.open != 2)
+		if(S.burn_dam > ROBOLIMB_SELF_REPAIR_CAP)
+			to_chat(user, "<span class='danger'>The damage is far too severe to patch over externally.</span>")
+			return
+
+		if(!S.burn_dam)
 			to_chat(user, "<span class='notice'>Nothing to fix!</span>")
+			return
+
+		if(H == user)
+			if(!do_mob(user, H, 10))
+				return 0
+		var/cable_used = 0
+		var/childlist
+		if(!isnull(S.children))
+			childlist = S.children.Copy()
+		var/parenthealed = FALSE
+		while(cable_used <= MAXCABLEPERHEAL && amount >= 1)
+			var/obj/item/organ/external/E
+			if(S.burn_dam)
+				E = S
+			else if(LAZYLEN(childlist))
+				E = pick_n_take(childlist)
+				if(!E.burn_dam || !E.is_robotic())
+					continue
+			else if(S.parent && !parenthealed)
+				E = S.parent
+				parenthealed = TRUE
+				if(!E.burn_dam || !E.is_robotic())
+					break
+			else
+				break
+			while(cable_used <= MAXCABLEPERHEAL && E.burn_dam && amount >= 1)
+				use(1)
+				cable_used += 1
+				E.heal_damage(0, HEALPERCABLE, 0, 1)
+			user.visible_message("<span class='alert'>\The [user] repairs some burn damage on \the [M]'s [E.name] with \the [src].</span>")
+		return 1
+
 	else
 		return ..()
 
@@ -820,3 +843,6 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 	var/cablecolor = input(user,"Pick a cable color.","Cable Color") in list("red","yellow","green","blue","pink","orange","cyan","white")
 	color = cablecolor
 	update_icon()
+
+#undef MAXCABLEPERHEAL
+#undef HEALPERCABLE


### PR DESCRIPTION
This adds overheal mechanism to cable coil and welder like my previous PR #9045 

For cable coil:
You can use a maximum of 8 pieces of cable coils per click. Each cable coil heals 3 damage. If you healed the original limb and the amount of cable coil used is less than 8, then it continues to go through the robotic children of the limb and its parent, healing them.

Note: I changed it from 5 pieces of coil to 8 pieces of coil, so each click can heal 24 damage to advanced trauma kit's 25.

For welder tool:
15 damage will be healed maximum per click. If there's leftover damage, then it is used on attached robotic parent / children.

🆑:
feature: Welder tool now applies leftover heal on the target organ's children and parent (In that order).
feature: You may use 8 cable coils per repair click, up from 5. Cable coil uses may be spread between the limb you targeted and its children and parent
/🆑 