### PR TITLE
Cyborg analyzer no longer rounds off damage number

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -237,7 +237,7 @@
 					if(!E.is_robotic())
 						continue
 					organ_found = 1
-					to_chat(user, "[E.name]: <font color='red'>[round(E.brute_dam)]</font> <font color='#FFA500'>[round(E.burn_dam)]</font>")
+					to_chat(user, "[E.name]: <font color='red'>[E.brute_dam]</font> <font color='#FFA500'>[E.burn_dam]</font>")
 			if(!organ_found)
 				to_chat(user, "<span class='warning'>No prosthetics located.</span>")
 			to_chat(user, "<hr>")


### PR DESCRIPTION
That's just dishonest, man.

Rounding off the number is inconsistent with health analyzer so it is no longer rounded. Also, it was giving me inaccurate diagnosis of damage when I was testing my other PR (I thought there were a off-by-one error).

🆑:
tweak: Cyborg Analyzer no longer rounds off the damage number it displays.
/🆑 

