### PR TITLE
MouseBlobs

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -11,14 +11,20 @@
 	if(!T)
 		return kill()
 	var/list/candidates = pollCandidates("Do you want to play as a blob?", ROLE_BLOB, 1)
-	var/mob/C
-	if(candidates.len)
-		C = pick(candidates)
-		Blob = new /obj/structure/blob/core(T, new_overmind=C.client)
-		for(var/i in 1 to 5)
-			Blob.process()
-	else
+	if(!candidates.len)
 		return kill()
+	var/list/vents = list()
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in all_vent_pumps)
+		if(is_station_level(temp_vent.loc.z) && !temp_vent.welded)
+			if(temp_vent.parent.other_atmosmch.len > 50)
+				vents += temp_vent
+	var/obj/vent = pick(vents)
+	var/mob/living/simple_animal/mouse/blobinfected/B = new(vent.loc)
+	var/mob/M = pick(candidates)
+	B.key = M.key
+	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
+	var/image/alert_overlay = image('icons/mob/blob.dmi', "blank_blob")
+	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B, alert_overlay = alert_overlay)
 
 /datum/event/blob/tick()
 	if(!Blob)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -161,7 +161,7 @@
 /mob/living/simple_animal/mouse/blobinfected/Life()
 	cycles_alive++
 	var/timeleft = (cycles_limit - cycles_alive) * 2
-	if(ismob(loc)) // if some taj/etc ate the mouse, burst instantly.
+	if(ismob(loc)) // if someone ate it, burst immediately
 		burst(FALSE)
 	else if(timeleft < 1) // if timer expired, burst.
 		burst(FALSE)
@@ -197,4 +197,6 @@
 	if(!gibbed)
 		gib()
 
-
+/mob/living/simple_animal/mouse/blobinfected/get_scooped(mob/living/carbon/grabber)
+	to_chat(grabber, "<span class='warning'>You try to pick up [src], but they slip out of your grasp!</span>")
+	to_chat(src, "<span class='warning'>[src] tries to pick you up, but you wriggle free of their grasp!</span>")

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -175,7 +175,7 @@
 	if(has_burst)
 		return FALSE
 	var/turf/T = get_turf(src)
-	if(!is_station_level(T.z) || istype(T, /turf/space))
+	if(!is_station_level(T.z) || isspaceturf(T))
 		to_chat(src, "<span class='userdanger'>You feel ready to burst, but this isn't an appropriate place!  You must return to the station!</span>")
 		return FALSE
 	has_burst = TRUE

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -153,18 +153,20 @@
 	health = 100
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 	var/cycles_alive = 0
 	var/cycles_limit = 30
 	var/has_burst = FALSE
 
 /mob/living/simple_animal/mouse/blobinfected/Life()
 	cycles_alive++
-	if(prob(20))
-		var/timeleft = (cycles_limit - cycles_alive) * 2
-		if(timeleft < 1)
-			burst(FALSE)
-		else
-			to_chat(src, "<span class='warning'>[timeleft] seconds until you burst, and become a blob...</span>")
+	var/timeleft = (cycles_limit - cycles_alive) * 2
+	if(ismob(loc)) // if some taj/etc ate the mouse, burst instantly.
+		burst(FALSE)
+	else if(timeleft < 1) // if timer expired, burst.
+		burst(FALSE)
+	else if(cycles_alive % 2 == 0) // give the mouse/player a countdown reminder every 2 cycles
+		to_chat(src, "<span class='warning'>[timeleft] seconds until you burst, and become a blob...</span>")
 	return ..()
 
 /mob/living/simple_animal/mouse/blobinfected/death(gibbed)


### PR DESCRIPTION
Currently, lateround blobs spawn in as a blob core, typically in a highly visible position that guarantees they're quickly spotted and killed.

With this PR, lateround blobs spawn in initially as a blob-infected mouse. They spawn somewhere on the station, on top of an unwelded vent, like spiderlings in a spider outbreak do. The blob player then has 60 seconds to move the mouse to their preferred nesting area, before they burst and turn into a blob core. They can ventcrawl, and they can burst while inside a vent, too. So, 60 seconds of ventcrawl movement gives them quite a lot of flexibility in where their initial core will be created.

This PR prevents blobs always being in one of a number of pre-set, easily metagamable locations.
It also means that lateround blobs won't be forced to spawn in BAD locations that get them instantly seen/killed. Now, if the blob spawns their core in a bad area, that's their fault.

Infected mice have 100 HP, unlike normal mice, and even if killed, they instantly turn into a blob core. So, it isn't possible to prevent an infected mouse from turning into a blob.

🆑 Kyep
tweak: Lateround blobs now start off as an infected mouse. By moving around/ventcrawling as a mouse, they can find themselves a good nesting area before they turn into a blob core.
/🆑