### PR TITLE
Fixes prefab SNPC instances

### DIFF
--- a/code/modules/mob/living/carbon/human/interactive/prefabs.dm
+++ b/code/modules/mob/living/carbon/human/interactive/prefabs.dm
@@ -2,7 +2,7 @@
 	TRAITS |= TRAIT_ROBUST
 	TRAITS |= TRAIT_MEAN
 	faction += "bot_angry"
-	..()
+	return ..()
 
 /mob/living/carbon/human/interactive/friendly/Initialize(mapload)
 	TRAITS |= TRAIT_FRIENDLY
@@ -10,7 +10,7 @@
 	faction += "bot_friendly"
 	faction += "neutral"
 	functions -= "combat"
-	..()
+	return ..()
 
 /mob/living/carbon/human/interactive/greytide/Initialize(mapload)
 	TRAITS |= TRAIT_ROBUST
@@ -21,4 +21,4 @@
 	targetInterestShift = 2 // likewise
 	faction += "bot_grey"
 	graytide = 1
-	..()
+	return ..()


### PR DESCRIPTION
In the maploader fixup PR #9206 I added `LATE_INITIALIZE` to SNPCs so that they would have all their attributes defined before loading them up with equipment. However, I neglected to make the return calls here not omit this, causing the prefab SNPCs to break.

:cl:Crazylemon
fix: Non-hotel SNPCs work again
/:cl: