### PR TITLE
Fixes terror spider dragging

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -3,6 +3,7 @@
 	appearance_flags = TILE_BOUND
 	var/last_move = null
 	var/anchored = 0
+	var/pullable = TRUE
 	// var/elevation = 2    - not used anywhere
 	var/move_speed = 10
 	var/l_move_time = 1

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
@@ -4,7 +4,7 @@
 // --------------------------------------------------------------------------------
 // -------------: ROLE: guarding queen nests
 // -------------: AI: dies if too far from queen
-// -------------: SPECIAL: chance to stun on hit
+// -------------: SPECIAL: thick (vision-blocking) webs
 // -------------: TO FIGHT IT: shoot it from range, bring friends!
 // -------------: SPRITES FROM: FoS, http://nanotrasen.se/phpBB3/memberlist.php?mode=viewprofile&u=386
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -41,7 +41,7 @@ var/global/list/ts_spiderling_list = list()
 	pressure_resistance = 50    //50 kPa difference required to push
 	throw_pressure_limit = 100  //100 kPa difference required to throw
 	pass_flags = PASSTABLE
-	anchored = 1 // cannot be dragged
+	pullable = FALSE // cannot be pulled
 	a_intent = INTENT_HARM
 
 	// Ventcrawling

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -41,6 +41,7 @@ var/global/list/ts_spiderling_list = list()
 	pressure_resistance = 50    //50 kPa difference required to push
 	throw_pressure_limit = 100  //100 kPa difference required to throw
 	pass_flags = PASSTABLE
+	anchored = 1 // cannot be dragged
 
 	// Ventcrawling
 	ventcrawler = 1 // allows player ventcrawling

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -42,6 +42,7 @@ var/global/list/ts_spiderling_list = list()
 	throw_pressure_limit = 100  //100 kPa difference required to throw
 	pass_flags = PASSTABLE
 	anchored = 1 // cannot be dragged
+	a_intent = INTENT_HARM
 
 	// Ventcrawling
 	ventcrawler = 1 // allows player ventcrawling

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -42,7 +42,6 @@ var/global/list/ts_spiderling_list = list()
 	throw_pressure_limit = 100  //100 kPa difference required to throw
 	pass_flags = PASSTABLE
 	pullable = FALSE // cannot be pulled
-	a_intent = INTENT_HARM
 
 	// Ventcrawling
 	ventcrawler = 1 // allows player ventcrawling

--- a/code/modules/mob/pulling.dm
+++ b/code/modules/mob/pulling.dm
@@ -5,6 +5,8 @@
 		return
 	if(!AM || !isturf(AM.loc))	//if there's no object or the object being pulled is inside something: abort!
 		return
+	if(!AM.pullable)
+		return
 	if(!(AM.anchored))
 		AM.add_fingerprint(src)
 


### PR DESCRIPTION
🆑 Kyep
fix: Terror Spiders can no longer be dragged.
/🆑

Reasons:

- The ability to drag terror spiders allows them to be dragged away from vents, which makes them too easy to kill. It also doesn't make much sense, given that they're bigger than the average humanoid, have many legs, and have a low center of gravity.
- The ability to run through terror spiders as if they were on help intent doesn't make sense either. Hostile creatures don't generally allow you to do this. You can push them... but that at least gives them a chance to react, as opposed to running straight through them, and off into the sunset.


