### PR TITLE
Prevents pulling live terror spiders

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -3,6 +3,7 @@
 	appearance_flags = TILE_BOUND
 	var/last_move = null
 	var/anchored = 0
+	var/pullable = TRUE
 	// var/elevation = 2    - not used anywhere
 	var/move_speed = 10
 	var/l_move_time = 1

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
@@ -4,7 +4,7 @@
 // --------------------------------------------------------------------------------
 // -------------: ROLE: guarding queen nests
 // -------------: AI: dies if too far from queen
-// -------------: SPECIAL: chance to stun on hit
+// -------------: SPECIAL: thick (vision-blocking) webs
 // -------------: TO FIGHT IT: shoot it from range, bring friends!
 // -------------: SPRITES FROM: FoS, http://nanotrasen.se/phpBB3/memberlist.php?mode=viewprofile&u=386
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -41,6 +41,7 @@ var/global/list/ts_spiderling_list = list()
 	pressure_resistance = 50    //50 kPa difference required to push
 	throw_pressure_limit = 100  //100 kPa difference required to throw
 	pass_flags = PASSTABLE
+	pullable = FALSE
 
 	// Ventcrawling
 	ventcrawler = 1 // allows player ventcrawling

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -314,6 +314,7 @@ var/global/list/ts_spiderling_list = list()
 /mob/living/simple_animal/hostile/poison/terror_spider/proc/handle_dying()
 	if(!hasdied)
 		hasdied = 1
+		pullable = TRUE
 		ts_count_dead++
 		ts_death_last = world.time
 		if(spider_awaymission)

--- a/code/modules/mob/pulling.dm
+++ b/code/modules/mob/pulling.dm
@@ -5,6 +5,8 @@
 		return
 	if(!AM || !isturf(AM.loc))	//if there's no object or the object being pulled is inside something: abort!
 		return
+	if(!AM.pullable)
+		return
 	if(!(AM.anchored))
 		AM.add_fingerprint(src)
 


### PR DESCRIPTION
🆑 Kyep
tweak: Live terror spiders can no longer be pulled around.
/🆑

The ability to drag live terror spiders allows them to be dragged away from vents they're trying to crawl into, which makes them too easy to kill. It also doesn't make much sense, given that they're bigger than the average humanoid, have many legs, and have a low center of gravity.