### PR TITLE
Species Refactor Followup

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -32,11 +32,10 @@
 #define CANWEAKEN	2
 #define CANPARALYSE	4
 #define CANPUSH		8
-#define LEAPING		16
-#define PASSEMOTES	32      //Mob has a cortical borer or holders inside of it that need to see emotes.
-#define GOTTAGOFAST	64
-#define GOTTAGOREALLYFAST	128
-#define IGNORESLOWDOWN	256
+#define PASSEMOTES	16      //Mob has a cortical borer or holders inside of it that need to see emotes.
+#define GOTTAGOFAST	32
+#define GOTTAGOREALLYFAST	64
+#define IGNORESLOWDOWN	128
 #define GODMODE		4096
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define XENO_HOST	16384	//Tracks whether we're gonna be a baby alien's mummy.

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -365,6 +365,7 @@
 		var/mob/living/carbon/human/H = target
 		H.visible_message("<span class='warning'>[H]'s skin suddenly bubbles and shifts around [H.p_their()] body!</span>", \
 							 "<span class='shadowling'>You regenerate your protective armor and cleanse your form of defects.</span>")
+		H.set_species(/datum/species/shadow/ling)
 		H.adjustCloneLoss(-target.getCloneLoss())
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/shadowling(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/shadowling(H), slot_shoes)
@@ -373,7 +374,6 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/shadowling(H), slot_gloves)
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/shadowling(H), slot_wear_mask)
 		H.equip_to_slot_or_del(new /obj/item/clothing/glasses/shadowling(H), slot_glasses)
-		H.set_species(/datum/species/shadow/ling)
 
 /obj/effect/proc_holder/spell/targeted/collective_mind //Lets a shadowling bring together their thralls' strength, granting new abilities and a headcount
 	name = "Collective Hivemind"

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -84,6 +84,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H.socks = "None"
 				H.faction |= "faithless"
 
+				H.set_species(/datum/species/shadow/ling)	//can't be a shadowling without being a shadowling
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/shadowling(user), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/shadowling(user), slot_shoes)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/space/shadowling(user), slot_wear_suit)
@@ -91,7 +92,6 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H.equip_to_slot_or_del(new /obj/item/clothing/gloves/shadowling(user), slot_gloves)
 				H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/shadowling(user), slot_wear_mask)
 				H.equip_to_slot_or_del(new /obj/item/clothing/glasses/shadowling(user), slot_glasses)
-				H.set_species(/datum/species/shadow/ling)	//can't be a shadowling without being a shadowling
 
 				H.mind.RemoveSpell(src)
 

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -79,8 +79,6 @@
 	var/bodyflags = 0
 	var/dietflags  = 0	// Make sure you set this, otherwise it won't be able to digest a lot of foods
 
-	var/list/abilities = list()	// For species-derived or admin-given powers
-
 	var/blood_color = "#A10808" //Red.
 	var/flesh_color = "#FFC896" //Pink.
 	var/single_gib_type = /obj/effect/decal/cleanable/blood/gibs
@@ -151,9 +149,7 @@
 		"l_hand" = list("path" = /obj/item/organ/external/hand),
 		"r_hand" = list("path" = /obj/item/organ/external/hand/right),
 		"l_foot" = list("path" = /obj/item/organ/external/foot),
-		"r_foot" = list("path" = /obj/item/organ/external/foot/right)
-		)
-	var/list/proc/species_abilities = list()
+		"r_foot" = list("path" = /obj/item/organ/external/foot/right))
 
 /datum/species/New()
 	//If the species has eyes, they are the default vision organ
@@ -259,24 +255,15 @@
 			. -= 2
 	return .
 
-/datum/species/proc/handle_post_spawn(mob/living/carbon/C) //Handles anything not already covered by basic species assignment.
-	grant_abilities(C)
+/datum/species/proc/on_species_gain(mob/living/carbon/human/H) //Handles anything not already covered by basic species assignment.
+	return
+
+/datum/species/proc/on_species_loss(mob/living/carbon/human/H)
+	if(H.butcher_results) //clear it out so we don't butcher a actual human.
+		H.butcher_results = null
 
 /datum/species/proc/updatespeciescolor(mob/living/carbon/human/H) //Handles changing icobase for species that have multiple skin colors.
 	return
-
-/datum/species/proc/grant_abilities(mob/living/carbon/human/H)
-	for(var/proc/ability in species_abilities)
-		H.verbs += ability
-
-/datum/species/proc/handle_pre_change(mob/living/carbon/human/H)
-	if(H.butcher_results) //clear it out so we don't butcher a actual human.
-		H.butcher_results = null
-	remove_abilities(H)
-
-/datum/species/proc/remove_abilities(mob/living/carbon/human/H)
-	for(var/proc/ability in species_abilities)
-		H.verbs -= ability
 
 // Do species-specific reagent handling here
 // Return 1 if it should do normal processing too
@@ -297,7 +284,7 @@
 		H.setOxyLoss(0)
 		H.SetLoseBreath(0)
 
-/datum/species/proc/handle_dna(mob/living/carbon/C, remove) //Handles DNA mutations, as that doesn't work at init. Make sure you call genemutcheck on any blocks changed here
+/datum/species/proc/handle_dna(mob/living/carbon/human/H, remove) //Handles DNA mutations, as that doesn't work at init. Make sure you call genemutcheck on any blocks changed here
 	return
 
 /datum/species/proc/handle_death(mob/living/carbon/human/H) //Handles any species-specific death events (such as dionaea nymph spawns).

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -93,6 +93,8 @@
 	var/show_ssd = 1
 	var/can_revive_by_healing				// Determines whether or not this species can be revived by simply healing them
 	var/has_gender = TRUE
+	var/blacklisted = FALSE
+	var/dangerous_existence = FALSE
 
 	//Death vars.
 	var/death_message = "seizes up and falls limp, their eyes dead and lifeless..."
@@ -705,3 +707,14 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 /datum/species/proc/water_act(mob/living/carbon/human/M, volume, temperature, source)
 	if(abs(temperature - M.bodytemperature) > 10) //If our water and mob temperature varies by more than 10K, cool or/ heat them appropriately
 		M.bodytemperature = (temperature + M.bodytemperature) * 0.5 //Approximation for gradual heating or cooling
+
+/proc/get_random_species(species_name = FALSE)	// Returns a random non black-listed or hazardous species, either as a string or datum
+	var/static/list/random_species = list()
+	if(!random_species.len)
+		for(var/thing  in subtypesof(/datum/species))
+			var/datum/species/S = thing
+			if(!initial(S.dangerous_existence) && !initial(S.blacklisted))
+				random_species += initial(S.name)
+	var/picked_species = pick(random_species)
+	var/datum/species/selected_species = GLOB.all_species[picked_species]
+	return species_name ? picked_species : selected_species.type

--- a/code/modules/mob/living/carbon/human/species/abductor.dm
+++ b/code/modules/mob/living/carbon/human/species/abductor.dm
@@ -32,15 +32,15 @@
 /datum/species/abductor/can_understand(mob/other) //Abductors can understand everyone, but they can only speak over their mindlink to another team-member
 	return TRUE
 
-/datum/species/abductor/handle_post_spawn(mob/living/carbon/human/H)
+/datum/species/abductor/on_species_gain(mob/living/carbon/human/H)
+	..()
 	H.gender = NEUTER
 	H.languages.Cut() //Under no condition should you be able to speak any language
 	H.add_language("Abductor Mindlink") //other than over the abductor's own mindlink
 	var/datum/atom_hud/abductor_hud = huds[DATA_HUD_ABDUCTOR]
 	abductor_hud.add_hud_to(H)
-	return ..()
 
-/datum/species/abductor/remove_abilities(mob/living/carbon/human/H)
+/datum/species/abductor/on_species_loss(mob/living/carbon/human/H)
 	..()
 	var/datum/atom_hud/abductor_hud = huds[DATA_HUD_ABDUCTOR]
 	abductor_hud.remove_hud_from(H)

--- a/code/modules/mob/living/carbon/human/species/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/diona.dm
@@ -76,17 +76,16 @@
 		"pulls out a secret stash of herbicide and takes a hearty swig!",
 		"is pulling themselves apart!")
 
-/datum/species/diona/can_understand(var/mob/other)
+/datum/species/diona/can_understand(mob/other)
 	if(istype(other, /mob/living/simple_animal/diona))
 		return 1
 	return 0
 
-/datum/species/diona/handle_post_spawn(var/mob/living/carbon/human/H)
+/datum/species/diona/on_species_gain(mob/living/carbon/human/H)
+	..()
 	H.gender = NEUTER
 
-	return ..()
-
-/datum/species/diona/handle_life(var/mob/living/carbon/human/H)
+/datum/species/diona/handle_life(mob/living/carbon/human/H)
 	H.radiation = Clamp(H.radiation, 0, 100) //We have to clamp this first, then decrease it, or there's a few edge cases of massive heals if we clamp and decrease at the same time.
 	var/rads = H.radiation / 25
 	H.radiation = max(H.radiation-rads, 0)

--- a/code/modules/mob/living/carbon/human/species/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/golem.dm
@@ -42,7 +42,8 @@
 		"is crumbling into dust!",
 		"is smashing their body apart!")
 
-/datum/species/golem/handle_post_spawn(var/mob/living/carbon/human/H)
+/datum/species/golem/on_species_gain(mob/living/carbon/human/H)
+	..()
 	if(H.mind)
 		H.mind.assigned_role = "Golem"
 		H.mind.special_role = SPECIAL_ROLE_GOLEM
@@ -53,7 +54,6 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/golem(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/golem(H), slot_wear_mask)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/golem(H), slot_gloves)
-	..()
 
 
 ////////Adamantine Golem stuff I dunno where else to put it

--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -29,19 +29,15 @@
 	reagent_tag = PROCESS_ORG
 	blood_color = "#A200FF"
 
-/datum/species/grey/handle_dna(var/mob/living/carbon/C, var/remove)
-	if(!remove)
-		C.dna.SetSEState(REMOTETALKBLOCK,1,1)
-		genemutcheck(C,REMOTETALKBLOCK,null,MUTCHK_FORCED)
-	else
-		C.dna.SetSEState(REMOTETALKBLOCK,0,1)
-		genemutcheck(C,REMOTETALKBLOCK,null,MUTCHK_FORCED)
+/datum/species/grey/handle_dna(mob/living/carbon/human/H, remove)
 	..()
+	H.dna.SetSEState(REMOTETALKBLOCK, !remove, 1)
+	genemutcheck(H, REMOTETALKBLOCK, null, MUTCHK_FORCED)
 
-/datum/species/grey/water_act(var/mob/living/carbon/C, volume, temperature, source)
+/datum/species/grey/water_act(mob/living/carbon/human/H, volume, temperature, source)
 	..()
-	C.take_organ_damage(5,min(volume,20))
-	C.emote("scream")
+	H.take_organ_damage(5, min(volume, 20))
+	H.emote("scream")
 
 /datum/species/grey/after_equip_job(datum/job/J, mob/living/carbon/human/H)
 	var/speech_pref = H.client.prefs.speciesprefs

--- a/code/modules/mob/living/carbon/human/species/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/monkey.dm
@@ -35,7 +35,7 @@
 	brute_mod = 1.5
 	burn_mod = 1.5
 
-/datum/species/monkey/handle_npc(var/mob/living/carbon/human/H)
+/datum/species/monkey/handle_npc(mob/living/carbon/human/H)
 	if(H.stat != CONSCIOUS)
 		return
 	if(prob(33) && H.canmove && isturf(H.loc) && !H.pulledby) //won't move if being pulled
@@ -46,16 +46,17 @@
 /datum/species/monkey/get_random_name()
 	return "[lowertext(name)] ([rand(100,999)])"
 
-/datum/species/monkey/handle_post_spawn(var/mob/living/carbon/human/H)
+/datum/species/monkey/on_species_gain(mob/living/carbon/human/H)
+	..()
 	H.real_name = "[lowertext(name)] ([rand(100,999)])"
 	H.name = H.real_name
 	H.butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/monkey = 5)
 
+/datum/species/monkey/handle_dna(mob/living/carbon/human/H, remove)
 	..()
-
-/datum/species/monkey/handle_dna(var/mob/living/carbon/human/H)
-	H.dna.SetSEState(MONKEYBLOCK,1)
-	genemutcheck(H,MONKEYBLOCK,null,MUTCHK_FORCED)
+	if(!remove)
+		H.dna.SetSEState(MONKEYBLOCK, TRUE)
+		genemutcheck(H, MONKEYBLOCK, null, MUTCHK_FORCED)
 
 /datum/species/monkey/handle_can_equip(obj/item/I, slot, disable_warning = 0, mob/living/carbon/human/user)
 	switch(slot)

--- a/code/modules/mob/living/carbon/human/species/nucleation.dm
+++ b/code/modules/mob/living/carbon/human/species/nucleation.dm
@@ -2,6 +2,7 @@
 	name = "Nucleation"
 	name_plural = "Nucleations"
 	icobase = 'icons/mob/human_races/r_nucleation.dmi'
+	blacklisted = TRUE
 	blurb = "A sub-race of unfortunates who have been exposed to too much supermatter radiation. As a result, \
 	supermatter crystal clusters have begun to grow across their bodies. Research to find a cure for this ailment \
 	has been slow, and so this is a common fate for veteran engineers. The supermatter crystals produce oxygen, \

--- a/code/modules/mob/living/carbon/human/species/nucleation.dm
+++ b/code/modules/mob/living/carbon/human/species/nucleation.dm
@@ -28,14 +28,13 @@
 		)
 	vision_organ = /obj/item/organ/internal/eyes/luminescent_crystal
 
-/datum/species/nucleation/handle_post_spawn(var/mob/living/carbon/human/H)
+/datum/species/nucleation/on_species_gain(mob/living/carbon/human/H)
+	..()
 	H.light_color = "#1C1C00"
 	H.set_light(2)
-	return ..()
 
-/datum/species/nucleation/handle_death(var/mob/living/carbon/human/H)
+/datum/species/nucleation/handle_death(mob/living/carbon/human/H)
 	var/turf/T = get_turf(H)
 	H.visible_message("<span class='warning'>[H]'s body explodes, leaving behind a pile of microscopic crystals!</span>")
 	explosion(T, 0, 0, 2, 2) // Create a small explosion burst upon death
-//	new /obj/item/shard/supermatter( T )
 	qdel(H)

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -162,7 +162,7 @@
 	H.internal = H.get_item_by_slot(tank_slot)
 	H.update_action_buttons_icon()
 
-/datum/species/plasmaman/handle_life(var/mob/living/carbon/human/H)
+/datum/species/plasmaman/handle_life(mob/living/carbon/human/H)
 	if(!istype(H.wear_suit, /obj/item/clothing/suit/space/eva/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/eva/plasmaman))
 		var/datum/gas_mixture/environment = H.loc.return_air()
 		if(environment && environment.oxygen && environment.oxygen >= OXYCONCEN_PLASMEN_IGNITION) //Plasmamen so long as there's enough oxygen (0.5 moles, same as it takes to burn gaseous plasma).
@@ -178,7 +178,7 @@
 	H.update_fire()
 	..()
 
-/datum/species/plasmaman/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
+/datum/species/plasmaman/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	if(R.id == "plasma")
 		H.adjustBruteLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)
 		H.adjustFireLoss(-0.5*REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -3,6 +3,7 @@
 	name_plural = "Plasmamen"
 	icobase = 'icons/mob/human_races/r_plasmaman_sb.dmi'
 	deform = 'icons/mob/human_races/r_plasmaman_pb.dmi'  // TODO: Need deform.
+	dangerous_existence = TRUE //So so much
 	//language = "Clatter"
 
 	species_traits = list(IS_WHITELISTED, NO_BLOOD, NOTRANSSTING)

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -28,7 +28,7 @@
 		"is twisting their own neck!",
 		"is staring into the closest light source!")
 
-	var/grant_vision_toggle = 1
+	var/grant_vision_toggle = TRUE
 	var/datum/action/innate/shadow/darkvision/vision_toggle
 
 /datum/action/innate/shadow/darkvision //Darkvision toggle so shadowpeople can actually see where darkness is
@@ -46,19 +46,19 @@
 		H.vision_type = null
 		to_chat(H, "<span class='notice'>You adjust your vision to recognize the shadows.</span>")
 
-/datum/species/shadow/grant_abilities(var/mob/living/carbon/human/H)
-	. = ..()
+/datum/species/shadow/on_species_gain(mob/living/carbon/human/H)
+	..()
 	if(grant_vision_toggle)
 		vision_toggle = new
 		vision_toggle.Grant(H)
 
-/datum/species/shadow/remove_abilities(var/mob/living/carbon/human/H)
-	. = ..()
+/datum/species/shadow/on_species_loss(mob/living/carbon/human/H)
+	..()
 	if(grant_vision_toggle && vision_toggle)
 		H.vision_type = null
 		vision_toggle.Remove(H)
 
-/datum/species/shadow/handle_life(var/mob/living/carbon/human/H)
+/datum/species/shadow/handle_life(mob/living/carbon/human/H)
 	var/light_amount = 0
 	if(isturf(H.loc))
 		var/turf/T = H.loc

--- a/code/modules/mob/living/carbon/human/species/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/shadow.dm
@@ -4,6 +4,7 @@
 
 	icobase = 'icons/mob/human_races/r_shadow.dmi'
 	deform = 'icons/mob/human_races/r_shadow.dmi'
+	dangerous_existence = TRUE
 
 	unarmed_type = /datum/unarmed_attack/claws
 

--- a/code/modules/mob/living/carbon/human/species/shadowling.dm
+++ b/code/modules/mob/living/carbon/human/species/shadowling.dm
@@ -20,7 +20,7 @@
 		"brain" =    /obj/item/organ/internal/brain,
 		"eyes" =     /obj/item/organ/internal/eyes)
 
-/datum/species/shadow/ling/handle_life(var/mob/living/carbon/human/H)
+/datum/species/shadow/ling/handle_life(mob/living/carbon/human/H)
 	if(!H.weakeyes)
 		H.weakeyes = 1 //Makes them more vulnerable to flashes and flashbangs
 	var/light_amount = 0
@@ -65,7 +65,7 @@
 	oxy_mod = 0
 	heatmod = 1.1
 
-/datum/species/shadow/ling/lesser/handle_life(var/mob/living/carbon/human/H)
+/datum/species/shadow/ling/lesser/handle_life(mob/living/carbon/human/H)
 	if(!H.weakeyes)
 		H.weakeyes = 1 //Makes them more vulnerable to flashes and flashbangs
 	var/light_amount = 0

--- a/code/modules/mob/living/carbon/human/species/shadowling.dm
+++ b/code/modules/mob/living/carbon/human/species/shadowling.dm
@@ -4,6 +4,7 @@
 
 	icobase = 'icons/mob/human_races/r_shadowling.dmi'
 	deform = 'icons/mob/human_races/r_shadowling.dmi'
+	blacklisted = TRUE
 
 	blood_color = "#555555"
 	flesh_color = "#222222"
@@ -60,7 +61,7 @@
 	blood_color = "#CCCCCC"
 	flesh_color = "#AAAAAA"
 
-	species_traits = list(NO_BLOOD, NO_BREATHE, RADIMMUNE)
+	species_traits = list(NO_BLOOD, NO_BREATHE, RADIMMUNE, NO_EXAMINE)
 	burn_mod = 1.1
 	oxy_mod = 0
 	heatmod = 1.1

--- a/code/modules/mob/living/carbon/human/species/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/species/skeleton.dm
@@ -39,7 +39,7 @@
 		"brain" = /obj/item/organ/internal/brain/golem,
 	) //Has default darksight of 2.
 
-/datum/species/skeleton/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
+/datum/species/skeleton/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	// Crazylemon is still silly
 	if(R.id == "milk")
 		H.heal_overall_damage(4,4)

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -1,3 +1,11 @@
+#define SLIMEPERSON_COLOR_SHIFT_TRIGGER 0.1
+#define SLIMEPERSON_ICON_UPDATE_PERIOD 200 // 20 seconds
+#define SLIMEPERSON_BLOOD_SCALING_FACTOR 5 // Used to adjust how much of an effect the blood has on the rate of color change. Higher is slower.
+
+#define SLIMEPERSON_HUNGERCOST 50
+#define SLIMEPERSON_MINHUNGER 250
+#define SLIMEPERSON_REGROWTHDELAY 450 // 45 seconds
+
 /datum/species/slime
 	name = "Slime People"
 	name_plural = "Slime People"
@@ -41,33 +49,24 @@
 		"is turning a dull, brown color and melting into a puddle!")
 
 	var/reagent_skin_coloring = FALSE
+	var/datum/action/innate/regrow/grow
+	var/datum/action/innate/slimecolor/recolor
 
-	var/datum/action/innate/regrow/grow = new()
-
-	species_abilities = list(
-		/mob/living/carbon/human/verb/toggle_recolor_verb,
-		/mob/living/carbon/human/proc/regrow_limbs
-		)
-
-/datum/species/slime/handle_post_spawn(var/mob/living/carbon/human/H)
-	grow.Grant(H)
+/datum/species/slime/on_species_gain(mob/living/carbon/human/H)
 	..()
+	grow = new()
+	grow.Grant(H)
+	recolor = new()
+	recolor.Grant(H)
 
-/datum/action/innate/regrow
-	name = "Regrow limbs"
-	icon_icon = 'icons/effects/effects.dmi'
-	button_icon_state = "greenglow"
+/datum/species/slime/on_species_loss(mob/living/carbon/human/H)
+	..()
+	if(grow)
+		grow.Remove(H)
+	if(recolor)
+		recolor.Remove(H)
 
-/datum/action/innate/regrow/Activate()
-	var/mob/living/carbon/human/user = owner
-	user.regrow_limbs()
-
-
-/datum/species/slime/handle_life(var/mob/living/carbon/human/H)
-//This is allegedly for code "style". Like a plaid sweater?
-#define SLIMEPERSON_COLOR_SHIFT_TRIGGER 0.1
-#define SLIMEPERSON_ICON_UPDATE_PERIOD 200 // 20 seconds
-#define SLIMEPERSON_BLOOD_SCALING_FACTOR 5 // Used to adjust how much of an effect the blood has on the rate of color change. Higher is slower.
+/datum/species/slime/handle_life(mob/living/carbon/human/H)
 	// Slowly shifting to the color of the reagents
 	if(reagent_skin_coloring && H.reagents.total_volume > SLIMEPERSON_COLOR_SHIFT_TRIGGER)
 		var/blood_amount = H.blood_volume
@@ -83,118 +82,99 @@
 			H.update_body()
 	..()
 
-#undef SLIMEPERSON_COLOR_SHIFT_TRIGGER
-#undef SLIMEPERSON_ICON_UPDATE_PERIOD
-#undef SLIMEPERSON_BLOOD_SCALING_FACTOR
+/datum/action/innate/slimecolor
+	name = "Toggle Recolor"
+	check_flags = AB_CHECK_CONSCIOUS
+	icon_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "greenglow"
 
-/mob/living/carbon/human/proc/toggle_recolor(silent = FALSE)
-	if(!isslimeperson(src))
-		if(!silent)
-			to_chat(src, "You're not a slime person!")
-		return
-
-	var/datum/species/slime/S = dna.species
+/datum/action/innate/slimecolor/Activate()
+	var/mob/living/carbon/human/H = owner
+	var/datum/species/slime/S = H.dna.species
 	if(S.reagent_skin_coloring)
-		S.reagent_skin_coloring = TRUE
-		if(!silent)
-			to_chat(src, "You adjust your internal chemistry to filter out pigments from things you consume.")
+		S.reagent_skin_coloring = FALSE
+		to_chat(H, "You adjust your internal chemistry to filter out pigments from things you consume.")
 	else
 		S.reagent_skin_coloring = TRUE
-		if(!silent)
-			to_chat(src, "You adjust your internal chemistry to permit pigments in chemicals you consume to tint you.")
+		to_chat(H, "You adjust your internal chemistry to permit pigments in chemicals you consume to tint you.")
 
-/mob/living/carbon/human/verb/toggle_recolor_verb()
-	set category = "IC"
-	set name = "Toggle Reagent Recoloring"
-	set desc = "While active, you'll slowly adjust your body's color to that of the reagents inside of you, moderated by how much blood you have."
+/datum/action/innate/regrow
+	name = "Regrow limbs"
+	check_flags = AB_CHECK_CONSCIOUS
+	icon_icon = 'icons/effects/effects.dmi'
+	button_icon_state = "greenglow"
 
-	toggle_recolor()
-
-
-/mob/living/carbon/human/proc/regrow_limbs()
-	set category = "IC"
-	set name = "Regrow Limbs"
-	set desc = "Regrow one of your missing limbs at the cost of a large amount of hunger"
-
-#define SLIMEPERSON_HUNGERCOST 50
-#define SLIMEPERSON_MINHUNGER 250
-#define SLIMEPERSON_REGROWTHDELAY 450 // 45 seconds
-
-	if(stat || paralysis || stunned)
-		to_chat(src, "<span class='warning'>You cannot regenerate missing limbs in your current state.</span>")
-		return
-
-	if(nutrition < SLIMEPERSON_MINHUNGER)
-		to_chat(src, "<span class='warning'>You're too hungry to regenerate a limb!</span>")
+/datum/action/innate/regrow/Activate()
+	var/mob/living/carbon/human/H = owner
+	if(H.nutrition < SLIMEPERSON_MINHUNGER)
+		to_chat(H, "<span class='warning'>You're too hungry to regenerate a limb!</span>")
 		return
 
 	var/list/missing_limbs = list()
-	for(var/l in bodyparts_by_name)
-		var/obj/item/organ/external/E = bodyparts_by_name[l]
+	for(var/l in H.bodyparts_by_name)
+		var/obj/item/organ/external/E = H.bodyparts_by_name[l]
 		if(!istype(E))
-			var/list/limblist = dna.species.has_limbs[l]
+			var/list/limblist = H.dna.species.has_limbs[l]
 			var/obj/item/organ/external/limb = limblist["path"]
 			var/parent_organ = initial(limb.parent_organ)
-			var/obj/item/organ/external/parentLimb = bodyparts_by_name[parent_organ]
+			var/obj/item/organ/external/parentLimb = H.bodyparts_by_name[parent_organ]
 			if(!istype(parentLimb))
 				continue
 			missing_limbs[initial(limb.name)] = l
 
 	if(!missing_limbs.len)
-		to_chat(src, "<span class='warning'>You're not missing any limbs!</span>")
+		to_chat(H, "<span class='warning'>You're not missing any limbs!</span>")
 		return
 
-	var/limb_select = input(src, "Choose a limb to regrow", "Limb Regrowth") as null|anything in missing_limbs
+	var/limb_select = input(H, "Choose a limb to regrow", "Limb Regrowth") as null|anything in missing_limbs
 	var/chosen_limb = missing_limbs[limb_select]
 
-	visible_message("<span class='notice'>[src] begins to hold still and concentrate on [p_their()] missing [limb_select]...</span>", "<span class='notice'>You begin to focus on regrowing your missing [limb_select]... (This will take [round(SLIMEPERSON_REGROWTHDELAY/10)] seconds, and you must hold still.)</span>")
-	if(do_after(src, SLIMEPERSON_REGROWTHDELAY, needhand=0, target = src))
-		if(stat || paralysis || stunned)
-			to_chat(src, "<span class='warning'>You cannot regenerate missing limbs in your current state.</span>")
+	H.visible_message("<span class='notice'>[H] begins to hold still and concentrate on [H.p_their()] missing [limb_select]...</span>", "<span class='notice'>You begin to focus on regrowing your missing [limb_select]... (This will take [round(SLIMEPERSON_REGROWTHDELAY/10)] seconds, and you must hold still.)</span>")
+	if(do_after(H, SLIMEPERSON_REGROWTHDELAY, needhand = 0, target = H))
+		if(H.incapacitated())
+			to_chat(H, "<span class='warning'>You cannot regenerate missing limbs in your current state.</span>")
 			return
 
-		if(nutrition < SLIMEPERSON_MINHUNGER)
-			to_chat(src, "<span class='warning'>You're too hungry to regenerate a limb!</span>")
+		if(H.nutrition < SLIMEPERSON_MINHUNGER)
+			to_chat(H, "<span class='warning'>You're too hungry to regenerate a limb!</span>")
 			return
 
-		var/obj/item/organ/external/O = bodyparts_by_name[chosen_limb]
+		var/obj/item/organ/external/O = H.bodyparts_by_name[chosen_limb]
 
 		var/stored_brute = 0
 		var/stored_burn = 0
 		if(istype(O))
-			to_chat(src, "<span class='warning'>You distribute the damaged tissue around your body, out of the way of your new pseudopod!</span>")
+			to_chat(H, "<span class='warning'>You distribute the damaged tissue around your body, out of the way of your new pseudopod!</span>")
 			var/obj/item/organ/external/doomedStump = O
 			stored_brute = doomedStump.brute_dam
 			stored_burn = doomedStump.burn_dam
 			qdel(O)
 
-		var/limb_list = dna.species.has_limbs[chosen_limb]
+		var/limb_list = H.dna.species.has_limbs[chosen_limb]
 		var/obj/item/organ/external/limb_path = limb_list["path"]
 		// Parent check
-		var/obj/item/organ/external/potential_parent = bodyparts_by_name[initial(limb_path.parent_organ)]
+		var/obj/item/organ/external/potential_parent = H.bodyparts_by_name[initial(limb_path.parent_organ)]
 		if(!istype(potential_parent))
-			to_chat(src, "<span class='danger'>You've lost the organ that you've been growing your new part on!</span>")
+			to_chat(H, "<span class='danger'>You've lost the organ that you've been growing your new part on!</span>")
 			return // No rayman for you
 		// Grah this line will leave a "not used" warning, in spite of the fact that the new() proc WILL do the thing.
 		// Bothersome.
-		var/obj/item/organ/external/new_limb = new limb_path(src)
+		var/obj/item/organ/external/new_limb = new limb_path(H)
 		new_limb.open = 0 // This is just so that the compiler won't think that new_limb is unused, because the compiler is horribly stupid.
-		adjustBruteLoss(stored_brute)
-		adjustFireLoss(stored_burn)
-		update_body()
-		updatehealth()
-		UpdateDamageIcon()
-		nutrition -= SLIMEPERSON_HUNGERCOST
-		visible_message("<span class='notice'>[src] finishes regrowing [p_their()] missing [new_limb]!</span>", "<span class='notice'>You finish regrowing your [limb_select]</span>")
+		H.adjustBruteLoss(stored_brute)
+		H.adjustFireLoss(stored_burn)
+		H.update_body()
+		H.updatehealth()
+		H.UpdateDamageIcon()
+		H.nutrition -= SLIMEPERSON_HUNGERCOST
+		H.visible_message("<span class='notice'>[H] finishes regrowing [H.p_their()] missing [new_limb]!</span>", "<span class='notice'>You finish regrowing your [limb_select]</span>")
 	else
-		to_chat(src, "<span class='warning'>You need to hold still in order to regrow a limb!</span>")
-	return
+		to_chat(H, "<span class='warning'>You need to hold still in order to regrow a limb!</span>")
+
+#undef SLIMEPERSON_COLOR_SHIFT_TRIGGER
+#undef SLIMEPERSON_ICON_UPDATE_PERIOD
+#undef SLIMEPERSON_BLOOD_SCALING_FACTOR
 
 #undef SLIMEPERSON_HUNGERCOST
 #undef SLIMEPERSON_MINHUNGER
 #undef SLIMEPERSON_REGROWTHDELAY
-
-/datum/species/slime/handle_pre_change(mob/living/carbon/human/H)
-	..()
-	if(reagent_skin_coloring)
-		H.toggle_recolor(silent = 1)

--- a/code/modules/mob/living/carbon/human/species/tajaran.dm
+++ b/code/modules/mob/living/carbon/human/species/tajaran.dm
@@ -54,5 +54,5 @@
 		"is twisting their own neck!",
 		"is holding their breath!")
 
-/datum/species/tajaran/handle_death(var/mob/living/carbon/human/H)
+/datum/species/tajaran/handle_death(mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)

--- a/code/modules/mob/living/carbon/human/species/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/unathi.dm
@@ -56,12 +56,18 @@
 		"is twisting their own neck!",
 		"is holding their breath!")
 
-	var/datum/action/innate/tail_lash/lash = new()
+	var/datum/action/innate/tail_lash/lash
 
 
-/datum/species/unathi/handle_post_spawn(var/mob/living/carbon/human/H)
-	lash.Grant(H)
+/datum/species/unathi/on_species_gain(mob/living/carbon/human/H)
 	..()
+	lash = new
+	lash.Grant(H)
+
+/datum/species/unathi/on_species_loss(mob/living/carbon/human/H)
+	..()
+	if(lash)
+		lash.Remove(H)
 
 /datum/action/innate/tail_lash
 	name = "Tail lash"
@@ -88,5 +94,5 @@
 
 
 
-/datum/species/unathi/handle_death(var/mob/living/carbon/human/H)
+/datum/species/unathi/handle_death(mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -77,7 +77,7 @@
 		"is holding their breath!",
 		"is deeply inhaling oxygen!")
 
-/datum/species/vox/handle_death(var/mob/living/carbon/human/H)
+/datum/species/vox/handle_death(mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 
 /datum/species/vox/after_equip_job(datum/job/J, mob/living/carbon/human/H)
@@ -95,13 +95,12 @@
 	H.internal = H.l_hand
 	H.update_action_buttons_icon()
 
-/datum/species/vox/handle_post_spawn(var/mob/living/carbon/human/H)
+/datum/species/vox/on_species_gain(mob/living/carbon/human/H)
+	..()
 	updatespeciescolor(H)
 	H.update_icons()
-	//H.verbs += /mob/living/carbon/human/proc/leap
-	..()
 
-/datum/species/vox/updatespeciescolor(var/mob/living/carbon/human/H, var/owner_sensitive = 1) //Handling species-specific skin-tones for the Vox race.
+/datum/species/vox/updatespeciescolor(mob/living/carbon/human/H, owner_sensitive = 1) //Handling species-specific skin-tones for the Vox race.
 	if(H.dna.species.bodyflags & HAS_ICON_SKIN_TONE) //Making sure we don't break Armalis.
 		var/new_icobase = 'icons/mob/human_races/vox/r_vox.dmi' //Default Green Vox.
 		var/new_deform = 'icons/mob/human_races/vox/r_def_vox.dmi' //Default Green Vox.
@@ -132,18 +131,13 @@
 		H.change_icobase(new_icobase, new_deform, owner_sensitive) //Update the icobase/deform of all our organs, but make sure we don't mess with frankenstein limbs in doing so.
 		H.update_dna()
 
-/datum/species/vox/handle_reagents(var/mob/living/carbon/human/H, var/datum/reagent/R)
+/datum/species/vox/handle_reagents(mob/living/carbon/human/H, datum/reagent/R)
 	if(R.id == "oxygen") //Armalis are above such petty things.
 		H.adjustToxLoss(1*REAGENTS_EFFECT_MULTIPLIER) //Same as plasma.
 		H.reagents.remove_reagent(R.id, REAGENTS_METABOLISM)
-		return 0 //Handling reagent removal on our own.
+		return FALSE //Handling reagent removal on our own.
 
 	return ..()
-
-/datum/species/vox/armalis/handle_post_spawn(var/mob/living/carbon/human/H)
-	H.verbs += /mob/living/carbon/human/proc/leap
-	H.verbs += /mob/living/carbon/human/proc/gut
-	..()
 
 /datum/species/vox/armalis
 	name = "Vox Armalis"
@@ -198,4 +192,4 @@
 		"is huffing oxygen!")
 
 /datum/species/vox/armalis/handle_reagents() //Skip the Vox oxygen reagent toxicity. Armalis are above such things.
-	return 1
+	return TRUE

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -3,6 +3,7 @@
 	name_plural = "Vox"
 	icobase = 'icons/mob/human_races/vox/r_vox.dmi'
 	deform = 'icons/mob/human_races/vox/r_def_vox.dmi'
+	dangerous_existence = TRUE
 	language = "Vox-pidgin"
 	tail = "voxtail"
 	speech_sounds = list('sound/voice/shriek1.ogg')
@@ -145,6 +146,7 @@
 	icobase = 'icons/mob/human_races/r_armalis.dmi'
 	deform = 'icons/mob/human_races/r_armalis.dmi'
 	unarmed_type = /datum/unarmed_attack/claws/armalis
+	blacklisted = TRUE
 
 	warning_low_pressure = 50
 	hazard_low_pressure = 0

--- a/code/modules/mob/living/carbon/human/species/vulpkanin.dm
+++ b/code/modules/mob/living/carbon/human/species/vulpkanin.dm
@@ -48,5 +48,5 @@
 		"is twisting their own neck!",
 		"is holding their breath!")
 
-/datum/species/vulpkanin/handle_death(var/mob/living/carbon/human/H)
+/datum/species/vulpkanin/handle_death(mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)

--- a/code/modules/mob/living/carbon/human/species/wryn.dm
+++ b/code/modules/mob/living/carbon/human/species/wryn.dm
@@ -3,6 +3,7 @@
 	name_plural = "Wryn"
 	icobase = 'icons/mob/human_races/r_wryn.dmi'
 	deform = 'icons/mob/human_races/r_wryn.dmi'
+	blacklisted = TRUE
 	language = "Wryn Hivemind"
 	tail = "wryntail"
 	punchdamagelow = 0

--- a/code/modules/mob/living/carbon/human/species/wryn.dm
+++ b/code/modules/mob/living/carbon/human/species/wryn.dm
@@ -7,7 +7,6 @@
 	tail = "wryntail"
 	punchdamagelow = 0
 	punchdamagehigh = 1
-	//primitive = /mob/living/carbon/monkey/wryn
 	slowdown = 1
 	warning_low_pressure = -300
 	hazard_low_pressure = 1
@@ -49,11 +48,11 @@
 	default_hair = "Antennae"
 
 
-/datum/species/wryn/handle_death(var/mob/living/carbon/human/H)
+/datum/species/wryn/handle_death(mob/living/carbon/human/H)
 	for(var/mob/living/carbon/C in living_mob_list)
 		if(C.get_int_organ(/obj/item/organ/internal/wryn/hivenode))
 			to_chat(C, "<span class='danger'><B>Your antennae tingle as you are overcome with pain...</B></span>")
-			to_chat(C, "<span class='danger'>It feels like part of you has died.</span>")
+			to_chat(C, "<span class='danger'>It feels like part of you has died.</span>") // This is bullshit
 
 /datum/species/wryn/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(target.handcuffed && target.get_int_organ(/obj/item/organ/internal/wryn/hivenode))

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -56,11 +56,7 @@
 	if(abilities)
 		client.verbs |= abilities
 
-	if(istype(src,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = src
-		if(H.dna.species && H.dna.species.abilities)
-			client.verbs |= H.dna.species.abilities
-
+	if(ishuman(src))
 		client.screen += client.void
 
 	//HUD updates (antag hud, etc)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -146,114 +146,120 @@
 	. = ..()
 	wabbajack(change)
 
-proc/wabbajack(mob/living/M)
-	if(istype(M))
-		if(istype(M, /mob/living) && M.stat != DEAD)
-			if(M.notransform)
-				return
-			M.notransform = 1
-			M.canmove = 0
-			M.icon = null
-			M.overlays.Cut()
-			M.invisibility = 101
+/proc/wabbajack(mob/living/M)
+	if(istype(M) && M.stat != DEAD && !M.notransform)
+		M.notransform = TRUE
+		M.canmove = FALSE
+		M.icon = null
+		M.overlays.Cut()
+		M.invisibility = 101
 
-			if(istype(M, /mob/living/silicon/robot))
-				var/mob/living/silicon/robot/Robot = M
-				if(Robot.mmi)
-					qdel(Robot.mmi)
-				Robot.notify_ai(1)
-			else
-				if(ishuman(M))
-					var/mob/living/carbon/human/H = M
-					// Make sure there are no organs or limbs to drop
-					for(var/t in H.bodyparts)
-						qdel(t)
-					for(var/i in H.internal_organs)
-						qdel(i)
-				for(var/obj/item/W in M)
-					M.unEquip(W, 1)
-					qdel(W)
+		if(isrobot(M))
+			var/mob/living/silicon/robot/Robot = M
+			QDEL_NULL(Robot.mmi)
+			Robot.notify_ai(1)
+		else
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				// Make sure there are no organs or limbs to drop
+				for(var/t in H.bodyparts)
+					qdel(t)
+				for(var/i in H.internal_organs)
+					qdel(i)
+			for(var/obj/item/W in M)
+				M.unEquip(W, 1)
+				qdel(W)
 
-			var/mob/living/new_mob
+		var/mob/living/new_mob
 
-			var/randomize = pick("robot","slime","xeno","human","animal")
-			switch(randomize)
-				if("robot")
-					if(prob(30))
-						new_mob = new /mob/living/silicon/robot/syndicate(M.loc)
-					else
-						new_mob = new /mob/living/silicon/robot(M.loc)
-					new_mob.gender = M.gender
-					new_mob.invisibility = 0
-					new_mob.job = "Cyborg"
-					var/mob/living/silicon/robot/Robot = new_mob
-					Robot.mmi = new /obj/item/mmi(new_mob)
-					if(ishuman(M))
-						Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
-				if("slime")
-					new_mob = new /mob/living/carbon/slime/random(M.loc)
-					new_mob.universal_speak = 1
-				if("xeno")
-					if(prob(50))
-						new_mob = new /mob/living/carbon/alien/humanoid/hunter(M.loc)
-					else
-						new_mob = new /mob/living/carbon/alien/humanoid/sentinel(M.loc)
-					new_mob.universal_speak = 1
-				if("animal")
-					if(prob(50))
-						var/beast = pick("carp","bear","mushroom","statue", "bat", "goat", "tomato")
-						switch(beast)
-							if("carp")		new_mob = new /mob/living/simple_animal/hostile/carp(M.loc)
-							if("bear")		new_mob = new /mob/living/simple_animal/hostile/bear(M.loc)
-							if("mushroom")	new_mob = new /mob/living/simple_animal/hostile/mushroom(M.loc)
-							if("statue")	new_mob = new /mob/living/simple_animal/hostile/statue(M.loc)
-							if("bat") 		new_mob = new /mob/living/simple_animal/hostile/scarybat(M.loc)
-							if("goat")		new_mob = new /mob/living/simple_animal/hostile/retaliate/goat(M.loc)
-							if("tomato")	new_mob = new /mob/living/simple_animal/hostile/killertomato(M.loc)
-					else
-						var/animal = pick("parrot","corgi","crab","pug","cat","mouse","chicken","cow","lizard","chick","fox")
-						switch(animal)
-							if("parrot")	new_mob = new /mob/living/simple_animal/parrot(M.loc)
-							if("corgi")		new_mob = new /mob/living/simple_animal/pet/corgi(M.loc)
-							if("crab")		new_mob = new /mob/living/simple_animal/crab(M.loc)
-							if("cat")		new_mob = new /mob/living/simple_animal/pet/cat(M.loc)
-							if("mouse")		new_mob = new /mob/living/simple_animal/mouse(M.loc)
-							if("chicken")	new_mob = new /mob/living/simple_animal/chicken(M.loc)
-							if("cow")		new_mob = new /mob/living/simple_animal/cow(M.loc)
-							if("lizard")	new_mob = new /mob/living/simple_animal/lizard(M.loc)
-							if("fox") 		new_mob = new /mob/living/simple_animal/pet/fox(M.loc)
-							else			new_mob = new /mob/living/simple_animal/chick(M.loc)
-					new_mob.universal_speak = 1
-				if("human")
-					new_mob = new /mob/living/carbon/human(M.loc)
-					// Include standard, whitelisted, and monkey species...
-					var/list/new_species = list()
-					for(var/datum/species/S in subtypesof(/datum/species))
-						if(istype(S, /datum/species/vox/armalis))
-							continue
-						new_species.Add(S)
-					var/mob/living/carbon/human/H = new_mob
-					var/datum/species/S = pick(new_species)
-					H.set_species(S)
-					randomize = initial(S.name)
-					var/datum/preferences/A = new()	//Randomize appearance for the human
-					A.copy_to(new_mob)
+		var/randomize = pick("robot", "slime", "xeno", "human", "animal")
+		switch(randomize)
+			if("robot")
+				if(prob(30))
+					new_mob = new /mob/living/silicon/robot/syndicate(M.loc)
 				else
-					return
-
-			M.create_attack_log("<font color='orange'>[key_name(M)] became [new_mob.real_name].</font>")
-			new_mob.attack_log = M.attack_log
-
-			new_mob.a_intent = INTENT_HARM
-			if(M.mind)
-				M.mind.transfer_to(new_mob)
+					new_mob = new /mob/living/silicon/robot(M.loc)
+				new_mob.gender = M.gender
+				new_mob.invisibility = 0
+				new_mob.job = "Cyborg"
+				var/mob/living/silicon/robot/Robot = new_mob
+				Robot.mmi = new /obj/item/mmi(new_mob)
+				if(ishuman(M))
+					Robot.mmi.transfer_identity(M)	//Does not transfer key/client.
+			if("slime")
+				new_mob = new /mob/living/carbon/slime/random(M.loc)
+				new_mob.universal_speak = TRUE
+			if("xeno")
+				if(prob(50))
+					new_mob = new /mob/living/carbon/alien/humanoid/hunter(M.loc)
+				else
+					new_mob = new /mob/living/carbon/alien/humanoid/sentinel(M.loc)
+				new_mob.universal_speak = TRUE
+			if("animal")
+				if(prob(50))
+					var/beast = pick("carp","bear","mushroom","statue", "bat", "goat", "tomato")
+					switch(beast)
+						if("carp")
+							new_mob = new /mob/living/simple_animal/hostile/carp(M.loc)
+						if("bear")
+							new_mob = new /mob/living/simple_animal/hostile/bear(M.loc)
+						if("mushroom")
+							new_mob = new /mob/living/simple_animal/hostile/mushroom(M.loc)
+						if("statue")
+							new_mob = new /mob/living/simple_animal/hostile/statue(M.loc)
+						if("bat")
+							new_mob = new /mob/living/simple_animal/hostile/scarybat(M.loc)
+						if("goat")
+							new_mob = new /mob/living/simple_animal/hostile/retaliate/goat(M.loc)
+						if("tomato")
+							new_mob = new /mob/living/simple_animal/hostile/killertomato(M.loc)
+				else
+					var/animal = pick("parrot", "corgi", "crab", "pug", "cat", "mouse", "chicken", "cow", "lizard", "chick", "fox")
+					switch(animal)
+						if("parrot")
+							new_mob = new /mob/living/simple_animal/parrot(M.loc)
+						if("corgi")
+							new_mob = new /mob/living/simple_animal/pet/corgi(M.loc)
+						if("crab")
+							new_mob = new /mob/living/simple_animal/crab(M.loc)
+						if("cat")
+							new_mob = new /mob/living/simple_animal/pet/cat(M.loc)
+						if("mouse")
+							new_mob = new /mob/living/simple_animal/mouse(M.loc)
+						if("chicken")
+							new_mob = new /mob/living/simple_animal/chicken(M.loc)
+						if("cow")
+							new_mob = new /mob/living/simple_animal/cow(M.loc)
+						if("lizard")
+							new_mob = new /mob/living/simple_animal/lizard(M.loc)
+						if("fox")
+							new_mob = new /mob/living/simple_animal/pet/fox(M.loc)
+						else
+							new_mob = new /mob/living/simple_animal/chick(M.loc)
+				new_mob.universal_speak = TRUE
+			if("human")
+				new_mob = new /mob/living/carbon/human(M.loc)
+				var/mob/living/carbon/human/H = new_mob
+				var/datum/preferences/A = new()	//Randomize appearance for the human
+				A.species = get_random_species(TRUE)
+				A.copy_to(new_mob)
+				randomize = H.dna.species.name
 			else
-				new_mob.key = M.key
+				return
 
-			to_chat(new_mob, "<B>Your form morphs into that of a [randomize].</B>")
+		M.create_attack_log("<font color='orange'>[key_name(M)] became [new_mob.real_name].</font>")
+		new_mob.attack_log = M.attack_log
 
-			qdel(M)
-			return new_mob
+		new_mob.a_intent = INTENT_HARM
+		if(M.mind)
+			M.mind.transfer_to(new_mob)
+		else
+			new_mob.key = M.key
+
+		to_chat(new_mob, "<B>Your form morphs into that of a [randomize].</B>")
+
+		qdel(M)
+		return new_mob
 
 /obj/item/projectile/magic/animate
 	name = "bolt of animation"


### PR DESCRIPTION
Just a follow up to the original species refactor. This changes a number of proc names to be more consistent with TG (and also inspired by @Aurorablade's PR). 

This also guts all species verbs in favor of using action buttons. I removed Vox leap and gut because it's not going to come back, and Armalis isn't used enough for me to spend the time fixing it up to work as an action button.


There's always more work to be done on species, but this is relatively minor and won't break anything, so.


:cl: Fox McCloud
tweak: IPC Change monitor is now an action button
tweak: Slime Color change is now an action button
fix: Fixes staff of change leaving behind unknowns
fix: Fixes Shadowlings not having shock resistant and thermal vision
fix: Fixes staff of change gibbing people
/:cl: