### PR TITLE
Fixes Head Robotization by Resetting alt_head and icon_name

### DIFF
--- a/code/modules/surgery/organs/subtypes/standard.dm
+++ b/code/modules/surgery/organs/subtypes/standard.dm
@@ -202,7 +202,6 @@
 
 /obj/item/organ/external/head/replaced()
 	name = limb_name
-
 	..()
 
 /obj/item/organ/external/head/receive_damage(brute, burn, sharp, used_weapon = null, list/forbidden_limbs = list(), ignore_resists = FALSE)
@@ -221,6 +220,11 @@
 	else //If alt_head is null, set it to "None" and default icon_name for sanity.
 		alt_head = initial(alt_head)
 		icon_name = initial(icon_name)
+
+/obj/item/organ/external/head/robotize(company, make_tough = 0, convert_all = 1) //Undoes alt_head business to avoid getting in the way of robotization. Make sure we pass all args down the line...
+	alt_head = initial(alt_head)
+	icon_name = initial(icon_name)
+	..()
 
 /obj/item/organ/external/head/set_dna(datum/dna/new_dna)
 	..()


### PR DESCRIPTION
:cl:
fix: You can now safely augment the heads of pointy-snooted Unathi, although your mileage may vary.
/:cl:

Fixes #9253, thanks for letting me know @Fox-McCloud :grin: 

_Obligatory demonstration._
![head robotization fix](https://user-images.githubusercontent.com/12377767/43352902-1be06ec6-921b-11e8-9d24-cd9a5742ee85.PNG)