### PR TITLE
Limits Walking Mushrooms

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -34,6 +34,7 @@
 	var/faint_ticker = 0 //If we hit three, another mushroom's gonna eat us
 	var/image/cap_living = null //Where we store our cap icons so we dont generate them constantly to update our icon
 	var/image/cap_dead = null
+	var/spawn_time = 0
 
 /mob/living/simple_animal/hostile/mushroom/examine(mob/user)
 	..(user)
@@ -44,7 +45,7 @@
 
 /mob/living/simple_animal/hostile/mushroom/Life(seconds, times_fired)
 	..()
-	if(!stat)//Mushrooms slowly regenerate if conscious, for people who want to save them from being eaten
+	if(!stat && world.time < (spawn_time + 3000))//Mushrooms slowly during their first 5 minutes of life.
 		adjustBruteLoss(-2)
 
 /mob/living/simple_animal/hostile/mushroom/New()//Makes every shroom a little unique
@@ -59,6 +60,7 @@
 	cap_dead.color = cap_color
 	UpdateMushroomCap()
 	health = maxHealth
+	spawn_time = world.time
 	..()
 
 /mob/living/simple_animal/hostile/mushroom/adjustHealth(damage)//Possibility to flee from a fight just to make it more visually interesting


### PR DESCRIPTION
Currently, walking mushrooms heal 2 points on every Life() cycle. So, if a large number of them are created in the same place, they can stand there, attacking each other but not dying, for a very long time. 

This PR seeks to make them less annoying. It limits their regeneration to their first five minutes of life. That's enough time for botany to create a bunch of them, have them fight each other, then harvest the high-level ones. If they're released into the wider station, though, after a few minutes their regeneration will stop, and they are sure to kill each other off until only one remains.

This idea is meant to keep them viable for botany, but prevent them becoming a long-lasting, loud annoyance to the rest of the station.

🆑 Kyep
tweak: Walking mushrooms now only regenerate health for the first 5 minutes of their lifetimes. After this, they are more likely to kill each other off as they fight among themselves.
/🆑
