### PR TITLE
Removes Tigercat from the list of current maintainers

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -523,7 +523,6 @@ responsible for properly tagging new pull requests and issues, moderating commen
 pull requests/issues, and merging/closing pull requests.
 
 ### Maintainer List
-* [tigercat2000](https://github.com/tigercat2000)
 * [Fox P McCloud](https://github.com/Fox-McCloud)
 * [Crazy Lemon](https://github.com/Crazylemon64)
 


### PR DESCRIPTION
This file wasn't updated when tigercat stepped down, so I'm fixing that now.