### PR TITLE
No more item spam attacks

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -342,9 +342,9 @@
 						break
 					target = possible_target
 				if(max_distance)
-					throw_at(target, get_dist(src, target), pressure_difference / 200, null, 0, 0, null)
+					throw_at(target, get_dist(src, target), pressure_difference / 200, null, 0, 0, null, 1)
 				else
-					throw_at(target, pressure_difference / 10, pressure_difference / 200, null, 0, 0, null)
+					throw_at(target, pressure_difference / 10, pressure_difference / 200, null, 0, 0, null, 1)
 			last_forced_movement = SSair.times_fired
 			return 1
 		else if(pressure_difference > pressure_resistance)

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -53,6 +53,8 @@
 
 // LAVA_PROTECT used on the flags_2 variable for both SUIT and HEAD items, and stops lava damage. Must be present in both to stop lava damage.
 #define LAVA_PROTECT_2			2048
+//Thing was last thrown by atmos
+#define ATMOS_THROW				4096
 
 //Reagent flags
 #define REAGENT_NOREACT			1

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -221,7 +221,7 @@
 		step(src, AM.dir)
 	..()
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, var/datum/callback/callback, var/atmos = FALSE)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, var/datum/callback/callback, atmos = FALSE)
 	if(!target || (flags & NODROP) || speed <= 0)
 		return 0
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -221,9 +221,14 @@
 		step(src, AM.dir)
 	..()
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, var/datum/callback/callback)
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, var/datum/callback/callback, var/atmos = FALSE)
 	if(!target || (flags & NODROP) || speed <= 0)
 		return 0
+
+	if(atmos)
+		flags_2 |= ATMOS_THROW
+	else
+		flags_2 &= ~ATMOS_THROW
 
 	if(pulledby)
 		pulledby.stop_pulling()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -500,7 +500,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 			itempush = 0 // too light to push anything
 		return A.hitby(src, 0, itempush)
 
-/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, var/atmos = FALSE)
+/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, atmos = FALSE)
 	thrownby = thrower
 	callback = CALLBACK(src, .proc/after_throw, callback) //replace their callback with our own
 	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, atmos)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -500,10 +500,10 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 			itempush = 0 // too light to push anything
 		return A.hitby(src, 0, itempush)
 
-/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
+/obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, var/atmos = FALSE)
 	thrownby = thrower
 	callback = CALLBACK(src, .proc/after_throw, callback) //replace their callback with our own
-	. = ..(target, range, speed, thrower, spin, diagonals_first, callback)
+	. = ..(target, range, speed, thrower, spin, diagonals_first, callback, atmos)
 
 /obj/item/proc/after_throw(datum/callback/callback)
 	if(callback) //call the original callback

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -111,7 +111,7 @@
 /obj/item/dice/attack_self(mob/user as mob)
 	diceroll(user)
 
-/obj/item/dice/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, var/atmos = FALSE)
+/obj/item/dice/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, atmos = FALSE)
 	if(!..())
 		return
 	diceroll(thrower)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -111,7 +111,7 @@
 /obj/item/dice/attack_self(mob/user as mob)
 	diceroll(user)
 
-/obj/item/dice/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
+/obj/item/dice/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, var/atmos = FALSE)
 	if(!..())
 		return
 	diceroll(thrower)

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -1,5 +1,6 @@
-/mob/living/carbon/alien/hitby(atom/movable/AM, skipcatch, hitpush)
-	..(AM, hitpush = 0)
+/mob/living/carbon/alien/hitby(atom/movable/AM, skipcatch = 0, hitpush = 0, blocked = 0)
+	hitpush = 0
+	return ..()
 
 /*Code for aliens attacking aliens. Because aliens act on a hivemind, I don't see them as very aggressive with each other.
 As such, they can either help or harm other aliens. Help works like the human help command while harm is a simple nibble.

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -1,3 +1,18 @@
+/mob/living/carbon/alien/humanoid/hitby(atom/movable/AM, skipcatch = 0, hitpush = 0, blocked = 0)
+	hitpush = 0
+	var/obj/item/I
+	if(istype(AM, /obj/item))
+		I = AM
+	if(I)
+		if(I.throwforce)
+			if(!I.thrownby)
+				if(prob(90))
+					visible_message("<span class='danger'>[src] dodges the [I] with lightning speed!</span>","<span class='userdanger'>You dodge the [I]!</span>")
+					blocked = 1
+				else
+					Paralyse(1)
+	return ..()
+
 /mob/living/carbon/alien/humanoid/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)
 	if(user.a_intent == INTENT_HARM)
 		..(user, TRUE)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -1,16 +1,12 @@
 /mob/living/carbon/alien/humanoid/hitby(atom/movable/AM, skipcatch = 0, hitpush = 0, blocked = 0)
-	hitpush = 0
 	var/obj/item/I
 	if(istype(AM, /obj/item))
 		I = AM
-	if(I)
-		if(I.throwforce)
-			if(!I.thrownby)
-				if(prob(90))
-					visible_message("<span class='danger'>[src] dodges the [I] with lightning speed!</span>","<span class='userdanger'>You dodge the [I]!</span>")
-					blocked = 1
-				else
-					Paralyse(1)
+		if(I.throwforce && (I.flags_2 & ATMOS_THROW))
+			if(prob(90))
+				blocked = 1
+			else
+				Paralyse(1)
 	return ..()
 
 /mob/living/carbon/alien/humanoid/attack_hulk(mob/living/carbon/human/user, does_attack_animation = FALSE)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -316,6 +316,10 @@ emp_act
 					visible_message("<span class='danger'>[I] embeds itself in [src]'s [L.name]!</span>","<span class='userdanger'>[I] embeds itself in your [L.name]!</span>")
 					hitpush = 0
 					skipcatch = 1 //can't catch the now embedded item
+		if(I.throwforce)
+			if(!I.thrownby)
+				visible_message("<span class='danger'>[I] knocks [src] over!</span>","<span class='userdanger'>[I] knocks you over!</span>")
+				Weaken(2)
 	return ..()
 
 /mob/living/carbon/human/proc/bloody_hands(var/mob/living/source, var/amount = 2)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -316,10 +316,9 @@ emp_act
 					visible_message("<span class='danger'>[I] embeds itself in [src]'s [L.name]!</span>","<span class='userdanger'>[I] embeds itself in your [L.name]!</span>")
 					hitpush = 0
 					skipcatch = 1 //can't catch the now embedded item
-		if(I.throwforce)
-			if(!I.thrownby)
-				visible_message("<span class='danger'>[I] knocks [src] over!</span>","<span class='userdanger'>[I] knocks you over!</span>")
-				Weaken(2)
+		if(I.throwforce && (I.flags_2 & ATMOS_THROW))
+			visible_message("<span class='danger'>[I] knocks [src] over!</span>","<span class='userdanger'>[I] knocks you over!</span>")
+			Weaken(2)
 	return ..()
 
 /mob/living/carbon/human/proc/bloody_hands(var/mob/living/source, var/amount = 2)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -64,10 +64,6 @@
 	var/obj/item/I
 	if(istype(AM, /obj/item))
 		I = AM
-	if(I)
-		if(I.throwforce)
-			if(!I.thrownby)
-				if(prob(80))
-					visible_message("<span class='danger'>[I] Hits [src] but does not leave a mark!</span>","<span class='userdanger'>[I] hits you just right, failing to cause any damage!</span>")
-					blocked = 1
+		if(I.throwforce && (I.flags_2 & ATMOS_THROW) && prob(80))
+			blocked = 1
 	return ..()

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -37,6 +37,8 @@
 	updatehealth()
 	return
 
+
+
 /mob/living/silicon/robot/attack_hand(mob/living/carbon/human/user)
 	add_fingerprint(user)
 
@@ -57,3 +59,15 @@
 				step_away(src, user, 15)
 				sleep(3)
 				step_away(src, user, 15)
+
+/mob/living/silicon/robot/hitby(atom/movable/AM, skipcatch = 0, hitpush = 1, blocked = 0)
+	var/obj/item/I
+	if(istype(AM, /obj/item))
+		I = AM
+	if(I)
+		if(I.throwforce)
+			if(!I.thrownby)
+				if(prob(80))
+					visible_message("<span class='danger'>[I] Hits [src] but does not leave a mark!</span>","<span class='userdanger'>[I] hits you just right, failing to cause any damage!</span>")
+					blocked = 1
+	return ..()


### PR DESCRIPTION
This is to address the last remaining death blenders.

🆑 Alffd
add: Humans are knocked down for two seconds when hit by an item blender object that is strong enough to hurt them.  This will have them down long enough for the blender to subside.
add: Borgs when hit by item blender objects, will have a 80% chance of taking no damage, and a 20% chance of taking damage from the hit.
add: Xenos when hit by item blender objects, will have a 90% chance of dodging and a 10% chance of taking a hit and getting knocked down for 1 second.
/ 🆑 

In my last test, it was possible to survive a swarm of 45 glass shards while only taking 20 brute in the case of humans and xenos.

Borgs took 90 brute.

As it stands now, the mob would take 450 brute.

Bask in the reflected glory of the Nanotrasen materials safety test chamber!

![image](https://user-images.githubusercontent.com/8165455/43362153-b770a366-92b0-11e8-9569-556709a6bc7a.png)
