### PR TITLE
Adds a min and max button to freezers and heaters

### DIFF
--- a/code/game/machinery/Freezer.dm
+++ b/code/game/machinery/Freezer.dm
@@ -140,7 +140,11 @@
 	if(href_list["toggleStatus"])
 		src.on = !src.on
 		update_icon()
-	if(href_list["temp"])
+	else if(href_list["minimum"])
+		current_temperature = min_temperature
+	else if(href_list["maximum"])
+		current_temperature = T20C
+	else if(href_list["temp"])
 		var/amount = text2num(href_list["temp"])
 		if(amount > 0)
 			src.current_temperature = min(T20C, src.current_temperature+amount)
@@ -299,7 +303,11 @@
 	if(href_list["toggleStatus"])
 		src.on = !src.on
 		update_icon()
-	if(href_list["temp"])
+	else if(href_list["minimum"])
+		current_temperature = T20C
+	else if(href_list["maximum"])
+		current_temperature = max_temperature + T20C
+	else if(href_list["temp"])
 		var/amount = text2num(href_list["temp"])
 		if(amount > 0)
 			src.current_temperature = min((T20C+max_temperature), src.current_temperature+amount)

--- a/nano/templates/freezer.tmpl
+++ b/nano/templates/freezer.tmpl
@@ -36,6 +36,7 @@
 	<div class="itemContent">
 		{{:helper.displayBar(data.targetGasTemperature, data.minGasTemperature, data.maxGasTemperature)}}
 		<div style="clear: both; padding-top: 4px;">
+			{{:helper.link('Min', null, {'minimum' : 'yes'}, (data.targetGasTemperature > data.minGasTemperature) ? null : 'disabled')}}
 			{{:helper.link('-', null, {'temp' : -100}, (data.targetGasTemperature > data.minGasTemperature) ? null : 'disabled')}}
 			{{:helper.link('-', null, {'temp' : -10}, (data.targetGasTemperature > data.minGasTemperature) ? null : 'disabled')}}
 			{{:helper.link('-', null, {'temp' : -1}, (data.targetGasTemperature > data.minGasTemperature) ? null : 'disabled')}}
@@ -43,6 +44,7 @@
 			{{:helper.link('+', null, {'temp' : 1}, (data.targetGasTemperature < data.maxGasTemperature) ? null : 'disabled')}}
 			{{:helper.link('+', null, {'temp' : 10}, (data.targetGasTemperature < data.maxGasTemperature) ? null : 'disabled')}}
 			{{:helper.link('+', null, {'temp' : 100}, (data.targetGasTemperature < data.maxGasTemperature) ? null : 'disabled')}}
+			{{:helper.link('Max', null, {'maximum' : 'yes'}, (data.targetGasTemperature < data.maxGasTemperature) ? null : 'disabled')}}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
As requested on the discord, this adds a `min` and `max` button to heaters / freezers so you don't need to spend time clicking lots to get to the extremes.

:cl:
tweak: Heaters and freezers now have min and max buttons
/:cl: