### PR TITLE
Updates syndi hardsuit description

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1029,9 +1029,8 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/suits/hardsuit
 	name = "Syndicate Hardsuit"
-	desc = "The feared suit of a syndicate nuclear agent. Features slightly better armoring and a built in jetpack \
-			that runs off standard atmospheric tanks. When the built in helmet is deployed your identity will be \
-			protected, even in death, as the suit cannot be removed by outside forces. Toggling the suit in and out of \
+	desc = "The feared suit of a syndicate nuclear agent. Features armor and a combat mode \
+			for faster movement on station. Toggling the suit in and out of \
 			combat mode will allow you all the mobility of a loose fitting uniform without sacrificing armoring. \
 			Additionally the suit is collapsible, making it small enough to fit within a backpack. \
 			Nanotrasen crew who spot these suits are known to panic."


### PR DESCRIPTION
Current syndicate hardsuit description doesn't fit what the current suit offers. This changes the description to fit the suit's current features.

🆑
rscadd: Updated syndicate hardsuit description.
/🆑