### PR TITLE
Fix runtime with bluespace projector

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -196,7 +196,7 @@
 
 /obj/item/gun/energy/wormhole_projector/process_chamber()
 	..()
-	select_fire()
+	select_fire(usr)
 
 /obj/item/gun/energy/wormhole_projector/proc/portal_destroyed(obj/effect/portal/P)
 	if(P.icon_state == "portal")


### PR DESCRIPTION
This fixes a runtime with bluespace projector that happened because usr wasn't passed into select_fire(). There's no actual gameplay effect (That I know of)

🆑:
fix: fix a runtime error with bluespace projector
/🆑 