### PR TITLE
Reformat of Prize Machine & Merch Store List

### DIFF
--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -13,7 +13,6 @@
 /obj/machinery/computer/merch/New()
 	..()
 
-
 /obj/machinery/computer/merch/attack_ai(mob/user as mob)
 	src.add_hiddenprint(user)
 	return attack_hand(user)
@@ -43,43 +42,49 @@ html {
 	color:#999;
 }
 
+table {background:#303030;}
+
+caption {text-align:left;}
+
+.button {
+	color:#cfcfcf;
+	text-decoration:none;
+	font-weight:bold;
+	text-align:center;
+	width:75px;
+	padding:21px;
+	box-sizing:border-box;
+	background:none;
+	border:none;
+	display: inline-block;
+}
+.button:hover {color:#ffffff;}
+
 a {
 	color:#cfcfcf;
 	text-decoration:none;
 	font-weight:bold;
 }
+a:hover {color:#ffffff;}
 
-a:hover {
-	color:#ffffff;
-}
-tr {
-	background:#303030;
-	border-radius:6px;
-	margin-bottom:0.5em;
-	border-bottom:1px solid black;
-}
-tr:nth-child(even) {
-	background:#3f3f3f;
-}
+p {margin:0;}
 
-td.cost {
-	font-size:20pt;
-	font-weight:bold;
-}
+tr.dark {background:#303030;}
 
-td.cost.affordable {
-	background:green;
-}
+tr.light {background:#3f3f3f;}
 
-td.cost.toomuch {
-	background:maroon;
-}
+td,th {padding:15px;}
 
+th.cost {padding:0px;}
+
+th.cost.affordable {background:green;}
+
+th.cost.toomuch {background:maroon;}
 
 		</style>
 	</head>
 	<body>
-	<p style="float:right"><a href='byond://?src=[UID()];refresh=1'>Refresh</a> | <b>Balance:</b> $[balance]</p>
+	<p style="float:right"><a href='byond://?src=[UID()];refresh=1'>Refresh</a> | <b>Balance: $[balance]</b></p>
 	<h1>[command_name()] Merchandise</h1>
 	<p>
 		<b>Doing your job and not getting any recognition at work?</b>  Well, welcome to the
@@ -87,8 +92,9 @@ td.cost.toomuch {
 		completed your Job Objectives.
 	</p>
 	<p>Work hard. Get cash. Acquire bragging rights.</p>
-	<h2>In Stock:</h2>
+	<br>
 	<table cellspacing="0" cellpadding="0">
+		<caption><b>In Stock:</b></caption>
 		<thead>
 			<th>#</th>
 			<th>Name/Description</th>
@@ -101,8 +107,11 @@ td.cost.toomuch {
 		if(item.cost>balance)
 			cost_class="toomuch"
 		var/itemID=centcomm_store.items.Find(item)
+		var/row_color="light"
+		if(itemID%2 == 0)
+			row_color="dark"
 		dat += {"
-			<tr>
+			<tr class="[row_color]">
 				<th>
 					[itemID]
 				</th>
@@ -110,9 +119,9 @@ td.cost.toomuch {
 					<p><b>[item.name]</b></p>
 					<p>[item.desc]</p>
 				</td>
-				<td class="cost [cost_class]">
-					<a href="byond://?src=[UID()];buy=[itemID]">$[item.cost]</a>
-				</td>
+				<th class="cost [cost_class]">
+					<a href="byond://?src=[UID()];buy=[itemID]" class="button">$[item.cost]</a>
+				</th>
 			</tr>
 		"}
 	dat += {"
@@ -120,7 +129,7 @@ td.cost.toomuch {
 	</table>
 	</body>
 </html>"}
-	user << browse(dat, "window=merch")
+	user << browse(dat, "window=merch;size=440x600;can_resize=0")
 	onclose(user, "merch")
 	return
 
@@ -142,6 +151,6 @@ td.cost.toomuch {
 		if(!centcomm_store.PlaceOrder(usr,itemID))
 			to_chat(usr, "<span class='warning'>Unable to charge your account.</span>")
 		else
-			to_chat(usr, "<span class='notice'>You've successfully purchased the item.  It should be in your hands or on the floor.</span>")
+			to_chat(usr, "<span class='notice'>You've successfully purchased the item. It should be in your hands or on the floor.</span>")
 	src.updateUsrDialog()
 	return

--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -42,7 +42,7 @@ html {
 	color:#999;
 }
 
-table {background:#303030;}
+table {background:#303030;border:1px solid #262626;}
 
 caption {text-align:left;}
 
@@ -73,9 +73,9 @@ tr.dark {background:#303030;}
 
 tr.light {background:#3f3f3f;}
 
-td,th {padding:15px;}
+td,th {padding:15px;border-bottom:1px solid #262626;}
 
-th.cost {padding:0px;}
+th.cost {padding:0px;border-left:1px solid #262626;}
 
 th.cost.affordable {background:green;}
 

--- a/code/modules/arcade/prize_counter.dm
+++ b/code/modules/arcade/prize_counter.dm
@@ -79,49 +79,36 @@ html {
 	background:#333;
 	color:#999;
 }
-table {
-	background:#303030;
-	border-collapse: collapse;
-	border:1px solid #232323;
-}
-caption {
-    text-align:left;
-}
+
+table {background:#303030;}
+
+caption {text-align:left;}
+
 a {
 	color:#cfcfcf;
 	text-decoration:none;
 	font-weight:bold;
 }
 
-a:hover {
-	color:#ffffff;
-}
-p {
-	margin:0;
-}
-tr.dark {
-	background:#303030;
-}
-tr.light {
-	background:#3f3f3f;
-}
-td,th {
-	padding:15px;
-	border-bottom:1px solid #232323;
-}
+a:hover {color:#ffffff;}
+
+p {margin:0;}
+
+tr.dark {background:#303030;}
+
+tr.light {background:#3f3f3f;}
+
+td,th {padding:15px;}
+
 td.cost {
 	font-size:20pt;
 	font-weight:bold;
 	text-align:center;
 }
 
-td.cost.affordable {
-	background:green;
-}
+td.cost.affordable {background:green;}
 
-td.cost.toomuch {
-	background:maroon;
-}
+td.cost.toomuch {background:maroon;}
 
 		</style>
 	</head>

--- a/code/modules/arcade/prize_counter.dm
+++ b/code/modules/arcade/prize_counter.dm
@@ -80,7 +80,7 @@ html {
 	color:#999;
 }
 
-table {background:#303030;}
+table {background:#303030;border:1px solid #262626;}
 
 caption {text-align:left;}
 
@@ -96,7 +96,6 @@ caption {text-align:left;}
 	border:none;
 	display: inline-block;
 }
-
 .button:hover {color:#ffffff;}
 
 a {
@@ -104,7 +103,6 @@ a {
 	text-decoration:none;
 	font-weight:bold;
 }
-
 a:hover {color:#ffffff;}
 
 p {margin:0;}
@@ -113,9 +111,9 @@ tr.dark {background:#303030;}
 
 tr.light {background:#3f3f3f;}
 
-td,th {padding:15px;}
+td,th {padding:15px;border-bottom:1px solid #262626;}
 
-th.cost{padding:0px}
+th.cost{padding:0px;border-left:1px solid #262626;}
 
 th.cost.affordable {background:green;}
 

--- a/code/modules/arcade/prize_counter.dm
+++ b/code/modules/arcade/prize_counter.dm
@@ -79,7 +79,14 @@ html {
 	background:#333;
 	color:#999;
 }
-
+table {
+	background:#303030;
+	border-collapse: collapse;
+	border:1px solid #232323;
+}
+caption {
+    text-align:left;
+}
 a {
 	color:#cfcfcf;
 	text-decoration:none;
@@ -89,19 +96,23 @@ a {
 a:hover {
 	color:#ffffff;
 }
-tr {
-	background:#303030;
-	border-radius:6px;
-	margin-bottom:0.5em;
-	border-bottom:1px solid black;
+p {
+	margin:0;
 }
-tr:nth-child(even) {
+tr.dark {
+	background:#303030;
+}
+tr.light {
 	background:#3f3f3f;
 }
-
+td,th {
+	padding:15px;
+	border-bottom:1px solid #232323;
+}
 td.cost {
 	font-size:20pt;
 	font-weight:bold;
+	text-align:center;
 }
 
 td.cost.affordable {
@@ -112,21 +123,21 @@ td.cost.toomuch {
 	background:maroon;
 }
 
-
 		</style>
 	</head>
 	<body>
-	<p style="float:right"><b>Tickets:</b> [tickets] | <a href='byond://?src=[UID()];eject=1'>Eject Tickets</a></p>
+	<p style="float:right"><b>Tickets: [tickets]</b> | <a href='byond://?src=[UID()];eject=1'>Eject Tickets</a></p>
 	<h1>Arcade Ticket Exchange</h1>
 	<p>
 		<b>Exchange that pile of tickets for a pile of cool prizes!</b>
 	</p>
-	<h2>Available Prizes:</h2>
+	<br>
 	<table cellspacing="0" cellpadding="0">
+		<caption><b>Available Prizes:</b></caption>
 		<thead>
 			<th>#</th>
 			<th>Name/Description</th>
-			<th>Price</th>
+			<th>Tickets</th>
 		</thead>
 		<tbody>
 	"}
@@ -136,8 +147,11 @@ td.cost.toomuch {
 		if(item.cost>tickets)
 			cost_class="toomuch"
 		var/itemID = global_prizes.prizes.Find(item)
+		var/row_color="light"
+		if(itemID%2 == 0)
+			row_color="dark"
 		dat += {"
-			<tr>
+			<tr class="[row_color]">
 				<th>
 					[itemID]
 				</th>
@@ -147,10 +161,10 @@ td.cost.toomuch {
 				</td>
 		"}
 		dat += {"
-			<td class="cost [cost_class]">
-				<a href="byond://?src=[UID()];buy=[itemID]">[item.cost] Tickets</a>
-			</td>
-		</tr>
+				<td class="cost [cost_class]">
+					<a href="byond://?src=[UID()];buy=[itemID]">[item.cost]</a>
+				</td>
+			</tr>
 		"}
 
 	dat += {"
@@ -158,7 +172,7 @@ td.cost.toomuch {
 	</table>
 	</body>
 </html>"}
-	user << browse(dat, "window=prize_counter")
+	user << browse(dat, "window=prize_counter;size=440x600;can_resize=0")
 	onclose(user, "prize_counter")
 	return
 

--- a/code/modules/arcade/prize_counter.dm
+++ b/code/modules/arcade/prize_counter.dm
@@ -84,6 +84,21 @@ table {background:#303030;}
 
 caption {text-align:left;}
 
+.button {
+	color:#cfcfcf;
+	text-decoration:none;
+	font-weight:bold;
+	text-align:center;
+	width:75px;
+	padding:21px;
+	box-sizing:border-box;
+	background:none;
+	border:none;
+	display: inline-block;
+}
+
+.button:hover {color:#ffffff;}
+
 a {
 	color:#cfcfcf;
 	text-decoration:none;
@@ -100,15 +115,11 @@ tr.light {background:#3f3f3f;}
 
 td,th {padding:15px;}
 
-td.cost {
-	font-size:20pt;
-	font-weight:bold;
-	text-align:center;
-}
+th.cost{padding:0px}
 
-td.cost.affordable {background:green;}
+th.cost.affordable {background:green;}
 
-td.cost.toomuch {background:maroon;}
+th.cost.toomuch {background:maroon;}
 
 		</style>
 	</head>
@@ -148,9 +159,9 @@ td.cost.toomuch {background:maroon;}
 				</td>
 		"}
 		dat += {"
-				<td class="cost [cost_class]">
-					<a href="byond://?src=[UID()];buy=[itemID]">[item.cost]</a>
-				</td>
+				<th class="cost [cost_class]">
+					<a href="byond://?src=[UID()];buy=[itemID]" class="button">[item.cost]</a>
+				</th>
 			</tr>
 		"}
 

--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -34,7 +34,7 @@ var/global/datum/prizes/global_prizes = new
 	var/cost = 0
 
 //////////////////////////////////////
-//			Tier 1 Prizes			//
+//			    Prizes		    	//
 //////////////////////////////////////
 
 /datum/prize_item/balloon
@@ -43,18 +43,6 @@ var/global/datum/prizes/global_prizes = new
 	typepath = /obj/item/toy/balloon
 	cost = 10
 
-/datum/prize_item/crayons
-	name = "Box of Crayons"
-	desc = "A six-pack of crayons, just like back in kindergarten."
-	typepath = /obj/item/storage/fancy/crayons
-	cost = 35
-
-/datum/prize_item/snappops
-	name = "Snap-Pops"
-	desc = "A box of exploding snap-pop fireworks."
-	typepath = /obj/item/storage/box/snappops
-	cost = 20
-
 /datum/prize_item/spinningtoy
 	name = "Spinning Toy"
 	desc = "Looks like an authentic Singularity!"
@@ -62,34 +50,16 @@ var/global/datum/prizes/global_prizes = new
 	cost = 15
 
 /datum/prize_item/blinktoy
-	name = "Blink toy"
+	name = "Blink Toy"
 	desc = "Blink. Blink. Blink."
 	typepath = /obj/item/toy/blink
 	cost = 15
 
 /datum/prize_item/dice
-	name = "Dice set"
+	name = "Dice Set"
 	desc = "A set of assorted dice."
 	typepath = /obj/item/storage/box/dice
 	cost = 20
-
-/datum/prize_item/cards
-	name = "Deck of cards"
-	desc = "Anyone fancy a game of 52-card Pickup?"
-	typepath = /obj/item/toy/cards/deck
-	cost = 25
-
-/datum/prize_item/wallet
-	name = "Colored Wallet"
-	desc = "Brightly colored and big enough for standard issue ID cards."
-	typepath = /obj/item/storage/wallet/color
-	cost = 50
-
-/datum/prize_item/pet_rock
-	name = "pet rock"
-	desc = "A pet of your very own!"
-	typepath = /obj/item/toy/pet_rock
-	cost = 80
 
 /datum/prize_item/foam_darts
 	name = "Pack of Foam Darts"
@@ -97,11 +67,35 @@ var/global/datum/prizes/global_prizes = new
 	typepath = /obj/item/ammo_box/foambox
 	cost = 20
 
-/datum/prize_item/minigibber
-	name = "Minigibber Toy"
-	desc = "A model of the station gibber. Probably shouldn't stick your fingers in it."
-	typepath = /obj/item/toy/minigibber
-	cost = 60
+/datum/prize_item/snappops
+	name = "Snap-Pops"
+	desc = "A box of exploding snap-pop fireworks."
+	typepath = /obj/item/storage/box/snappops
+	cost = 20
+
+/datum/prize_item/cards
+	name = "Deck of Cards"
+	desc = "Anyone fancy a game of 52-card Pickup?"
+	typepath = /obj/item/toy/cards/deck
+	cost = 25
+
+/datum/prize_item/crayons
+	name = "Box of Crayons"
+	desc = "A six-pack of crayons, just like back in kindergarten."
+	typepath = /obj/item/storage/fancy/crayons
+	cost = 35
+
+/datum/prize_item/eight_ball
+	name = "Magic Eight Ball"
+	desc = "A mystical ball that can divine the future!"
+	typepath = /obj/item/toy/eight_ball
+	cost = 40
+
+/datum/prize_item/wallet
+	name = "Colored Wallet"
+	desc = "Brightly colored and big enough for standard issue ID cards."
+	typepath = /obj/item/storage/wallet/color
+	cost = 50
 
 /datum/prize_item/id_sticker
 	name = "Prisoner ID Sticker"
@@ -129,11 +123,17 @@ var/global/datum/prizes/global_prizes = new
 	desc = "A sticker that can make any ID look like something suspicious..."
 	typepath = /obj/item/id_decal/emag
 
-/datum/prize_item/carp_plushie
-	name = "Random Carp Plushie"
-	desc = "A colorful fish-shaped plush toy."
-	typepath = /obj/item/toy/prizeball/carp_plushie
-	cost = 75
+/datum/prize_item/flash
+	name = "Toy Flash"
+	desc = "AUGH! MY EYES!"
+	typepath = /obj/item/toy/flash
+	cost = 50
+
+/datum/prize_item/minimeteor
+	name = "Mini-Meteor"
+	desc = "Meteors have been detected on a collision course with your fun times!"
+	typepath = /obj/item/toy/minimeteor
+	cost = 50
 
 /datum/prize_item/therapy_doll
 	name = "Random Therapy Doll"
@@ -141,10 +141,28 @@ var/global/datum/prizes/global_prizes = new
 	typepath = /obj/item/toy/prizeball/therapy
 	cost = 60
 
+/datum/prize_item/minigibber
+	name = "Minigibber Toy"
+	desc = "A model of the station gibber. Probably shouldn't stick your fingers in it."
+	typepath = /obj/item/toy/minigibber
+	cost = 60
+
+/datum/prize_item/confetti
+	name = "Confetti Grenade"
+	desc = "Party time!"
+	typepath = /obj/item/grenade/confetti
+	cost = 65
+
 /datum/prize_item/plushie
 	name = "Random Animal Plushie"
 	desc = "A colorful animal-shaped plush toy."
 	typepath = /obj/item/toy/prizeball/plushie
+	cost = 75
+
+/datum/prize_item/carp_plushie
+	name = "Random Carp Plushie"
+	desc = "A colorful fish-shaped plush toy."
+	typepath = /obj/item/toy/prizeball/carp_plushie
 	cost = 75
 
 /datum/prize_item/mech_toy
@@ -159,42 +177,11 @@ var/global/datum/prizes/global_prizes = new
 	typepath = /obj/item/toy/prizeball/figure
 	cost = 75
 
-/datum/prize_item/eight_ball
-	name = "Magic Eight Ball"
-	desc = "A mystical ball that can divine the future!"
-	typepath = /obj/item/toy/eight_ball
-	cost = 40
-
-/datum/prize_item/tacticool
-	name = "Tacticool Turtleneck"
-	desc = "A cool-looking turtleneck."
-	typepath = /obj/item/clothing/under/syndicate/tacticool
-	cost = 90
-
-/datum/prize_item/crossbow
-	name = "Foam Dart Crossbow"
-	desc = "A toy crossbow that fires foam darts."
-	typepath = /obj/item/gun/projectile/shotgun/toy/crossbow
-	cost = 100
-
-
-/datum/prize_item/toy_xeno
-	name = "Xeno Action Figure"
-	desc = "A lifelike replica of the horrific xeno scourge."
-	typepath = /obj/item/toy/toy_xeno
-	cost = 80
-
-/datum/prize_item/fakespell
-	name = "Fake Spellbook"
-	desc = "Perform magic! Astound your friends! Get mistaken for an enemy of the corporation!"
-	typepath = /obj/item/spellbook/oneuse/fake_gib
-	cost = 100
-
-/datum/prize_item/nanomob_booster
-	name = "Nano-Mob Hunter Trading Card Booster Pack"
-	desc = "Contains 6 random Nano-Mob Hunter Trading Cards. May contain a holographic card!"
-	typepath = /obj/item/storage/box/nanomob_booster_pack
-	cost = 100
+/datum/prize_item/AI
+	name = "Toy AI Unit"
+	desc = "Law 1: Maximize fun for crew."
+	typepath = /obj/item/toy/AI
+	cost = 75
 
 /datum/prize_item/capgun
 	name = "Capgun Revolver"
@@ -202,11 +189,35 @@ var/global/datum/prizes/global_prizes = new
 	typepath = /obj/item/gun/projectile/revolver/capgun
 	cost = 75
 
-/datum/prize_item/confetti
-	name = "Confetti Grenade"
-	desc = "Party time!"
-	typepath = /obj/item/grenade/confetti
-	cost = 65
+/datum/prize_item/pet_rock
+	name = "Pet Rock"
+	desc = "A pet of your very own!"
+	typepath = /obj/item/toy/pet_rock
+	cost = 80
+
+/datum/prize_item/toy_xeno
+	name = "Xeno Action Figure"
+	desc = "A lifelike replica of the horrific xeno scourge."
+	typepath = /obj/item/toy/toy_xeno
+	cost = 80
+
+/datum/prize_item/tacticool
+	name = "Tacticool Turtleneck"
+	desc = "A cool-looking turtleneck."
+	typepath = /obj/item/clothing/under/syndicate/tacticool
+	cost = 90
+
+/datum/prize_item/nanomob_booster
+	name = "Nano-Mob Hunter Trading Card Booster Pack"
+	desc = "Contains 6 random Nano-Mob Hunter Trading Cards. May contain a holographic card!"
+	typepath = /obj/item/storage/box/nanomob_booster_pack
+	cost = 100
+
+/datum/prize_item/fakespell
+	name = "Fake Spellbook"
+	desc = "Perform magic! Astound your friends! Get mistaken for an enemy of the corporation!"
+	typepath = /obj/item/spellbook/oneuse/fake_gib
+	cost = 100
 
 /datum/prize_item/magic_conch
 	name = "Magic Conch Shell"
@@ -214,29 +225,35 @@ var/global/datum/prizes/global_prizes = new
 	typepath = /obj/item/toy/eight_ball/conch
 	cost = 100
 
-/datum/prize_item/flash
-	name = "Toy Flash"
-	desc = "AUGH! MY EYES!"
-	typepath = /obj/item/toy/flash
-	cost = 50
+/datum/prize_item/crossbow
+	name = "Foam Dart Crossbow"
+	desc = "A toy crossbow that fires foam darts."
+	typepath = /obj/item/gun/projectile/shotgun/toy/crossbow
+	cost = 100
 
 /datum/prize_item/foamblade
-	name = "Foam Armblade"
+	name = "Foam Arm Blade"
 	desc = "Perfect for reenacting space horror holo-vids."
 	typepath = /obj/item/toy/foamblade
 	cost = 100
-
-/datum/prize_item/minimeteor
-	name = "Mini-Meteor"
-	desc = "Meteors have been detected on a collision course with your fun times!"
-	typepath = /obj/item/toy/minimeteor
-	cost = 50
 
 /datum/prize_item/redbutton
 	name = "Shiny Red Button"
 	desc = "PRESS IT!"
 	typepath = /obj/item/toy/redbutton
 	cost = 100
+
+/datum/prize_item/nuke
+	name = "Nuclear Fun Device"
+	desc = "Annihilate boredom with an explosion of excitement!"
+	typepath = /obj/item/toy/nuke
+	cost = 100
+
+/datum/prize_item/blobhat
+	name = "Blob Hat"
+	desc = "There's... something... on your head..."
+	typepath = /obj/item/clothing/head/blob
+	cost = 125
 
 /datum/prize_item/owl
 	name = "Owl Action Figure"
@@ -250,47 +267,11 @@ var/global/datum/prizes/global_prizes = new
 	typepath = /obj/item/toy/griffin
 	cost = 125
 
-/datum/prize_item/AI
-	name = "Toy AI Unit"
-	desc = "Law 1: Maximize fun for crew."
-	typepath = /obj/item/toy/AI
-	cost = 75
-
-/datum/prize_item/tommygun
-	name = "Tommygun"
-	desc = "A replica tommygun that fires foam darts."
-	typepath = /obj/item/gun/projectile/shotgun/toy/tommygun
-	cost = 175
-
 /datum/prize_item/esword
 	name = "Toy Energy Sword"
 	desc = "A plastic replica of an energy blade."
 	typepath = /obj/item/toy/sword
 	cost = 150
-
-/datum/prize_item/blobhat
-	name = "Blob Hat"
-	desc = "There's... something... on your head..."
-	typepath = /obj/item/clothing/head/blob
-	cost = 125
-
-/datum/prize_item/nuke
-	name = "Nuclear Fun Device"
-	desc = "Annihilate boredom with an explosion of excitement!"
-	typepath = /obj/item/toy/nuke
-	cost = 100
-
-/datum/prize_item/chainsaw
-	name = "Toy Chainsaw"
-	desc = "A full-scale model chainsaw, based on that massacre in Space Texas."
-	typepath = /obj/item/twohanded/toy/chainsaw
-	cost = 200
-
-/datum/prize_item/spacesuit
-	name = "Fake Spacesuit"
-	desc = "A replica spacesuit. Not actually spaceworthy."
-	typepath = /obj/item/storage/box/fakesyndiesuit
-	cost = 180
 
 /datum/prize_item/fakespace
 	name = "Space Carpet"
@@ -303,6 +284,24 @@ var/global/datum/prizes/global_prizes = new
 	desc = "A stack of genuine arcade carpet tiles, complete with authentic soft drink stains!"
 	typepath = /obj/item/stack/tile/arcade_carpet/loaded
 	cost = 150
+
+/datum/prize_item/tommygun
+	name = "Tommy Gun"
+	desc = "A replica tommy gun that fires foam darts."
+	typepath = /obj/item/gun/projectile/shotgun/toy/tommygun
+	cost = 175
+
+/datum/prize_item/spacesuit
+	name = "Fake Spacesuit"
+	desc = "A replica spacesuit. Not actually spaceworthy."
+	typepath = /obj/item/storage/box/fakesyndiesuit
+	cost = 180
+
+/datum/prize_item/chainsaw
+	name = "Toy Chainsaw"
+	desc = "A full-scale model chainsaw, based on that massacre in Space Texas."
+	typepath = /obj/item/twohanded/toy/chainsaw
+	cost = 200
 
 /datum/prize_item/bike
 	name = "Awesome Bike!"

--- a/code/modules/store/items.dm
+++ b/code/modules/store/items.dm
@@ -46,15 +46,21 @@
 	cost = 200
 
 /datum/storeitem/dnd
-	name = "Dungeons & Dragons set"
+	name = "Dungeons & Dragons Set"
 	desc = "A box containing minifigures suitable for a good game of D&D."
 	typepath = /obj/item/storage/box/characters
 	cost = 200
 
 /datum/storeitem/dice
-	name = "Dice set"
+	name = "Dice Set"
 	desc = "A box containing multiple different types of die."
 	typepath = /obj/item/storage/box/dice
+	cost = 200
+
+/datum/storeitem/candle
+	name = "Candles"
+	desc = "A box of candles. Use them to fool others into thinking you're out for a romantic dinner...or something."
+	typepath = /obj/item/storage/fancy/candle_box/full
 	cost = 200
 
 /datum/storeitem/nanomob_booster
@@ -65,57 +71,51 @@
 
 /datum/storeitem/crayons
 	name = "Crayons"
-	desc = "Let security know how they're doing by scrawling lovenotes all over their hallways."
+	desc = "Let security know how they're doing by scrawling love notes all over their hallways."
 	typepath = /obj/item/storage/fancy/crayons
 	cost = 350
 
 /datum/storeitem/pipe
-	name = "smoking pipe"
-	desc = "A pipe, for smoking. Probably made of meershaum or something."
+	name = "Smoking Pipe"
+	desc = "A pipe, for smoking. Probably made of meerschaum or something."
 	typepath = /obj/item/clothing/mask/cigarette/pipe
 	cost = 350
 
-/datum/storeitem/candle
-	name = "Candles"
-	desc = "A box of chandles. Use them to fool others into thinking you're out for a romantic dinner...or something."
-	typepath = /obj/item/storage/fancy/candle_box/full
-	cost = 200
-
 /datum/storeitem/minigibber
-	name = "miniature gibber"
+	name = "Miniature Gibber"
 	desc = "A miniature recreation of Nanotrasen's famous meat grinder."
 	typepath = /obj/item/toy/minigibber
 	cost = 400
 
 /datum/storeitem/katana
-	name = "replica katana"
+	name = "Replica Katana"
 	desc = "Woefully underpowered in D20."
 	typepath = /obj/item/toy/katana
 	cost = 500
 
-/datum/storeitem/piano_synth
-	name = "piano synthesizer"
-	desc = "An advanced electronic synthesizer that can be used as various instruments."
-	typepath = /obj/item/instrument/piano_synth
-	cost = 1000
-
 /datum/storeitem/violin
-	name = "space violin"
+	name = "Space Violin"
 	desc = "A wooden musical instrument with four strings and a bow. \"The devil went down to space, he was looking for an assistant to grief.\""
 	typepath = /obj/item/instrument/violin
 	cost = 500
 
 /datum/storeitem/guitar
-	name = "guitar"
+	name = "Guitar"
 	desc = "It's made of wood and has bronze strings."
 	typepath = /obj/item/instrument/guitar
 	cost = 500
 
 /datum/storeitem/eguitar
-	name = "electric guitar"
+	name = "Electric Guitar"
 	desc = "Makes all your shredding needs possible."
 	typepath = /obj/item/instrument/eguitar
 	cost = 500
+
+/datum/storeitem/piano_synth
+	name = "Piano Synthesizer"
+	desc = "An advanced electronic synthesizer that can emulate various instruments."
+	typepath = /obj/item/instrument/piano_synth
+	cost = 1000
 
 /datum/storeitem/baby
 	name = "Toddler"
@@ -124,91 +124,91 @@
 	cost = 1000
 
 /datum/storeitem/flag_slime
-	name = "Slime People flag"
+	name = "Slime People Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Slime People."
 	typepath = /obj/item/flag/species/slime
 	cost = 1000
 
 /datum/storeitem/flag_skrell
-	name = "Skrell flag"
+	name = "Skrell Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Skrell."
 	typepath = /obj/item/flag/species/skrell
 	cost = 1000
 
 /datum/storeitem/flag_vox
-	name = "Vox flag"
+	name = "Vox Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Vox."
 	typepath = /obj/item/flag/species/vox
 	cost = 1000
 
 /datum/storeitem/flag_machine
-	name = "Synthetics flag"
+	name = "Synthetics Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Synthetics."
 	typepath = /obj/item/flag/species/machine
 	cost = 1000
 
 /datum/storeitem/flag_diona
-	name = "Diona flag"
+	name = "Diona Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Dionae."
 	typepath = /obj/item/flag/species/diona
 	cost = 1000
 
 /datum/storeitem/flag_human
-	name = "Human flag"
+	name = "Human Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Humans."
 	typepath = /obj/item/flag/species/human
 	cost = 1000
 
 /datum/storeitem/flag_greys
-	name = "Greys flag"
+	name = "Greys Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Greys."
 	typepath = /obj/item/flag/species/greys
 	cost = 1000
 
 /datum/storeitem/flag_kidan
-	name = "Kidan flag"
+	name = "Kidan Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Kidan."
 	typepath = /obj/item/flag/species/kidan
 	cost = 1000
 
 /datum/storeitem/flag_taj
-	name = "Tajaran flag"
+	name = "Tajaran Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Tajara."
 	typepath = /obj/item/flag/species/taj
 	cost = 1000
 
 /datum/storeitem/flag_unathi
-	name = "Unathi flag"
+	name = "Unathi Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Unathi."
 	typepath = /obj/item/flag/species/unathi
 	cost = 1000
 
 /datum/storeitem/flag_vulp
-	name = "Vulpkanin flag"
+	name = "Vulpkanin Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Vulpkanin."
 	typepath = /obj/item/flag/species/vulp
 	cost = 1000
 
 /datum/storeitem/flag_drask
-	name = "Drask flag"
+	name = "Drask Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Drask."
 	typepath = /obj/item/flag/species/drask
 	cost = 1000
 
 /datum/storeitem/flag_plasma
-	name = "Plasmaman flag"
+	name = "Plasmaman Flag"
 	desc = "A flag proudly proclaiming the superior heritage of Plasmamen."
 	typepath = /obj/item/flag/species/plasma
 	cost = 1000
 
 /datum/storeitem/flag_ian
-	name = "Ian flag"
+	name = "Ian Flag"
 	desc = "The banner of Ian, because SQUEEEEE."
 	typepath = /obj/item/flag/ian
 	cost = 1500
 
 /datum/storeitem/banhammer
-	desc = "A banhammer"
-	name = "banhammer"
+	name = "Banhammer"
+	desc = "A Banhammer."
 	typepath = /obj/item/banhammer
 	cost = 2000


### PR DESCRIPTION
Makes both machines readable by getting striped tables working, the code was there just not working, window size matches vending machines now too. List were also edited, reordering least to greatest by price, also changing some typos and capitalizations.

Before:
![prizebefore](https://user-images.githubusercontent.com/40816748/43493157-828e70f0-94fa-11e8-8aea-2d499a1ce5d2.png)

After:
![prizeafter](https://user-images.githubusercontent.com/40816748/43613807-e8a580a6-967e-11e8-8f57-4012ea7dfb9c.png)

:cl:
tweak: Made Prize Machine & Merch Sore readable.
typo: Fixed capitalizations and typos in both lists.
/:cl: