### PR TITLE
Fix hood runtime

### DIFF
--- a/code/modules/clothing/suits/hood.dm
+++ b/code/modules/clothing/suits/hood.dm
@@ -31,6 +31,8 @@
 	..()
 
 /obj/item/clothing/suit/hooded/proc/RemoveHood()
+	if(isnull(hood))
+		return
 	icon_state = "[initial(icon_state)]"
 	suit_adjusted = 0
 	if(ishuman(hood.loc))


### PR DESCRIPTION
This fix a runtime with hood that's caused by removehood() not  checking there's a hood before attempting to access its loc. 

![2018-08-01_12-56-22](https://user-images.githubusercontent.com/40092670/43502135-ca3ad812-958b-11e8-972a-3f3777830da0.png)

No CL
