### PR TITLE
Fixes some more runtime

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -878,10 +878,10 @@ var/global/nologevent = 0
 				to_chat(usr, "[P.pai_laws]")
 			continue // Skip showing normal silicon laws for pAIs - they don't have any
 		else
-			to_chat(usr, "<b>SILICON [key_name(S, usr)]'s laws:</b>")
+			to_chat(usr, "<b>SILICON [key_name(S, TRUE)]'s laws:</b>")
 
 		if(S.laws == null)
-			to_chat(usr, "[key_name(S, usr)]'s laws are null. Contact a coder.")
+			to_chat(usr, "[key_name(S, TRUE)]'s laws are null. Contact a coder.")
 		else
 			S.laws.show_laws(usr)
 	if(!ai_number)

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -33,7 +33,7 @@
 		dream_images += pick_n_take(nightmares)
 		nightmare++
 	for(var/i in 1 to dream_images.len)
-		addtimer(CALLBACK(src, .proc/experience_dream, nightmares[i], TRUE), ((i - 1) * rand(30,60)))
+		addtimer(CALLBACK(src, .proc/experience_dream, dream_images[i], TRUE), ((i - 1) * rand(30,60)))
 	return TRUE
 
 /mob/living/carbon/proc/handle_dreams()
@@ -54,4 +54,3 @@
 	if(isNightmare)
 		dream_image = "<span class='cultitalic'>[dream_image]</span>"
 	to_chat(src, "<span class='notice'><i>... [dream_image] ...</i></span>")
-


### PR DESCRIPTION
This fixes two runtimes caused by:
1. Passing in usr where a boolean is expected in check_ai_laws
2. Accessing the wrong list in dreaming.dm (This also fixes nightmare which was not functional because of this)

🆑:
fix: Nightmares now works. Sleep well.
/🆑 