### PR TITLE
Observer's "Boo!" spell to rotate nearby chairs once

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -56,20 +56,24 @@
 	if(buckled_mob)
 		buckled_mob.dir = dir
 
-/obj/structure/stool/bed/chair/verb/rotate()
+/obj/structure/stool/bed/chair/verb/rotate(var/clockwise=0)
 	set name = "Rotate Chair"
 	set category = "Object"
 	set src in oview(1)
 
+	var/degrees = 90
+	if(clockwise)
+		degrees = -90
+
 	if(config.ghost_interaction)
-		setDir(turn(dir, 90))
+		setDir(turn(dir, degrees))
 		handle_rotation()
 		return
 
 	if(usr.incapacitated())
 		return
 
-	setDir(turn(dir, 90))
+	setDir(turn(dir, degrees))
 	handle_rotation()
 
 /obj/structure/stool/bed/chair/AltClick(mob/user)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -56,14 +56,12 @@
 	if(buckled_mob)
 		buckled_mob.dir = dir
 
-/obj/structure/stool/bed/chair/verb/rotate(var/clockwise=0)
+/obj/structure/stool/bed/chair/verb/rotate(var/clockwise as null|num)
 	set name = "Rotate Chair"
 	set category = "Object"
 	set src in oview(1)
 
-	var/degrees = 90
-	if(clockwise)
-		degrees = -90
+	var/degrees = clockwise ? -90 : 90
 
 	if(config.ghost_interaction)
 		setDir(turn(dir, degrees))

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -42,7 +42,7 @@ var/global/list/boo_phrases=list(
 					L.flicker()
 
 			// Ro-ro-rotate your chair
-			if(istype(A,/obj/structure/stool/bed/chair))
+			if(istype(A, /obj/structure/stool/bed/chair))
 				var/obj/structure/stool/bed/chair/C = A
 				C.rotate(prob(50))
 

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -44,8 +44,7 @@ var/global/list/boo_phrases=list(
 			// Ro-ro-rotate your chair
 			if(istype(A,/obj/structure/stool/bed/chair))
 				var/obj/structure/stool/bed/chair/C = A
-				if(C)
-					C.rotate()
+				C.rotate()
 
 			// OH GOD BLUE APC (single animation cycle)
 			if(istype(A, /obj/machinery/power/apc))

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -44,7 +44,7 @@ var/global/list/boo_phrases=list(
 			// Ro-ro-rotate your chair
 			if(istype(A,/obj/structure/stool/bed/chair))
 				var/obj/structure/stool/bed/chair/C = A
-				C.rotate()
+				C.rotate(prob(50))
 
 			// OH GOD BLUE APC (single animation cycle)
 			if(istype(A, /obj/machinery/power/apc))

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -43,7 +43,7 @@ var/global/list/boo_phrases=list(
 
 			// Ro-ro-rotate your chair
 			if(istype(A,/obj/structure/stool/bed/chair))
-				var/structure/stool/bed/chair/C = A
+				var/obj/structure/stool/bed/chair/C = A
 				if(C)
 					C.rotate()
 

--- a/code/modules/mob/dead/observer/spells.dm
+++ b/code/modules/mob/dead/observer/spells.dm
@@ -41,6 +41,12 @@ var/global/list/boo_phrases=list(
 				if(L)
 					L.flicker()
 
+			// Ro-ro-rotate your chair
+			if(istype(A,/obj/structure/stool/bed/chair))
+				var/structure/stool/bed/chair/C = A
+				if(C)
+					C.rotate()
+
 			// OH GOD BLUE APC (single animation cycle)
 			if(istype(A, /obj/machinery/power/apc))
 				A:spookify()


### PR DESCRIPTION
:cl: gingeralesy
add: The ability to rotate nearby chairs once using "Boo!" spell
/:cl:

In distant past it used to be that ghosts could use "Rotate Chair" command. This was great and spooky but unfortunately led to people using chairs to do ghost divination to gain information available to the observers.

This change adds the chair rotation capability to the "Boo!" spell making it a neat little way to spook people once again but without allowing it to be spammed to annoyance.

Edit: Fixed the historical account.