### PR TITLE
Fixes the barber spawning with 2 pairs of shoes

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -381,7 +381,6 @@
 	shoes = /obj/item/clothing/shoes/black
 	l_ear = /obj/item/radio/headset/headset_service
 	backpack_contents = list(
-		/obj/item/clothing/shoes/black = 1,
 		/obj/item/storage/box/lip_stick = 1,
 		/obj/item/storage/box/barber = 1
 	)


### PR DESCRIPTION
The barber will no longer spawn with a pair of shoes in his bag, as well as a pair he already has on his feet.

:cl: AffectedArc07
tweak: Barber no longer spawns with an extra pair of shoes in his bag
/ :cl:
