### PR TITLE
Fixes the barber spawning with 2 pairs of shoes

### DIFF
--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -381,7 +381,7 @@
 	shoes = /obj/item/clothing/shoes/black
 	l_ear = /obj/item/radio/headset/headset_service
 	backpack_contents = list(
-		/obj/item/clothing/shoes/black = 1,
+		/obj/item/clothing/shoes/black = 2,
 		/obj/item/storage/box/lip_stick = 1,
 		/obj/item/storage/box/barber = 1
 	)


### PR DESCRIPTION
Alternative to #9295.

🆑 FlattestGuitar9
tweak: Barber no longer spawns with one extra pair of shoes in his bag
/ 🆑

It's two now.