### PR TITLE
Fixes customizable food runtime

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -378,9 +378,9 @@
 
 /obj/item/reagent_containers/food/snacks/customizable/examine(mob/user)
 	..(user)
-	var/whatsinside = pick(ingredients)
-
-	to_chat(user, "<span class='notice'> You think you can see [whatsinside] in there.</span>")
+	if(LAZYLEN(ingredients))
+		var/whatsinside = pick(ingredients)
+		to_chat(user, "<span class='notice'> You think you can see [whatsinside] in there.</span>")
 
 
 /obj/item/reagent_containers/food/snacks/customizable/proc/newname()
@@ -470,4 +470,3 @@
 			if(unsorted[it] == i)
 				sorted[it] = i
 	return sorted
-


### PR DESCRIPTION
This fixes the following runtime caused by attempting to pick from an empty list:

> [2018-08-02T06:38:06] Runtime in customizables.dm,381: pick() from empty list
>    proc name: examine (/obj/item/reagent_containers/food/snacks/customizable/examine)
>    usr: Kita Flans (ansari) (/mob/dead/observer)
>    usr.loc: The floor (158,31,2) (/turf/simulated/floor/plasteel)
>    src: the spaghetti 