### PR TITLE
Fixed random_med for loop again.

### DIFF
--- a/code/game/objects/items/random_items.dm
+++ b/code/game/objects/items/random_items.dm
@@ -130,7 +130,7 @@
 
 /obj/item/storage/pill_bottle/random_meds/New()
 	..()
-	for(var/i in 1 to storage_slots)
+	for(var/i in 1 to storage_slots-1)
 		var/list/possible_medicines = standard_medicines.Copy()
 		if(prob(50))
 			possible_medicines += rare_medicines.Copy()


### PR DESCRIPTION
My bad, didn't read contributing doc right last time, loop was a < not <=.
#9274 

"if you want < then you should write it as 1 to some_value-1"

:cl:
typo: Fixed random_med for loop.
/:cl: