### PR TITLE
fixes assigning virus name for Kingstons

### DIFF
--- a/code/datums/diseases/kingstons.dm
+++ b/code/datums/diseases/kingstons.dm
@@ -66,7 +66,7 @@
 	chosentype = pick(virspecies)
 	chosensuff = pick(virsuffix)
 
-	name = "[chosentype] [chosensuff]"
+	name = "[chosentype.name] [chosensuff]"
 
 /datum/disease/kingstons/advanced/stage_act()
 	..()

--- a/code/datums/diseases/kingstons.dm
+++ b/code/datums/diseases/kingstons.dm
@@ -66,7 +66,7 @@
 	chosentype = pick(virspecies)
 	chosensuff = pick(virsuffix)
 
-	name = "[chosentype.name] [chosensuff]"
+	name = "[initial(chosentype.name)] [chosensuff]"
 
 /datum/disease/kingstons/advanced/stage_act()
 	..()


### PR DESCRIPTION
Fixes #9304 

Kingston's disease was not assigning the name correctly upon New()