### PR TITLE
Mice do not squik

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -6,8 +6,8 @@
 	icon_living = "mouse_gray"
 	icon_dead = "mouse_gray_dead"
 	speak = list("Squeek!","SQUEEK!","Squeek?")
-	speak_emote = list("squeeks","squeeks","squiks")
-	emote_hear = list("squeeks","squeaks","squiks")
+	speak_emote = list("squeeks","squeeks")
+	emote_hear = list("squeeks","squeaks")
 	emote_see = list("runs in a circle", "shakes", "scritches at something")
 	speak_chance = 1
 	turns_per_move = 5


### PR DESCRIPTION
TL:DR. Mice cannot squik as a spoken verb

According to urban dictionary, to `squik` is to gross someone out entirely. As far as I know, a mouse isnt capable of this, and plus it just looks like a typo. Plus its a spoken thing, mice cannot squik by speaking, unless squeaking counts, which brings up my point before.

🆑 AffectedArc07
tweak: Mice can no longer SQUIK (Not squeak)
/ 🆑 