### PR TITLE
Space ruins no longer can fill the border of the level

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -172,6 +172,9 @@
 	var/disable_away_missions = 0 // disable away missions
 	var/disable_space_ruins = 0 //disable space ruins
 
+	var/extra_space_ruin_levels_min = 2
+	var/extra_space_ruin_levels_max = 4
+
 	var/ooc_allowed = 1
 	var/looc_allowed = 1
 	var/dooc_allowed = 1
@@ -580,6 +583,14 @@
 
 				if("disable_cid_warn_popup")
 					config.disable_cid_warn_popup = 1
+
+				if("extra_space_ruin_levels_min")
+					var/vvalue = text2num(value)
+					config.extra_space_ruin_levels_min = max(vvalue, 0)
+
+				if("extra_space_ruin_levels_max")
+					var/vvalue = text2num(value)
+					config.extra_space_ruin_levels_max = max(vvalue, 0)
 
 				if("max_loadout_points")
 					config.max_loadout_points = text2num(value)

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -46,13 +46,12 @@ var/global/pipe_processing_killed = 0
 		seedRuins(level_name_to_num(EMPTY_AREA), rand(0, 3), /area/space, space_ruins_templates)
 		log_startup_progress("Loaded random space levels in [stop_watch(timer)]s.")
 
-		// We'll keep this around for the time when we finally expunge all
-		// code that checks on hard-defined z positions
+		// load in extra levels of space ruins
 
-		// var/num_extra_space = 6
-		// for(var/i = 1, i <= num_extra_space, i++)
-		// 	var/zlev = space_manager.add_new_zlevel("[EMPTY_AREA] #[i]", linkage = CROSSLINKED)
-		// 	seedRuins(zlev, rand(0, 3), /area/space, space_ruins_templates)
+		var/num_extra_space = 6
+		for(var/i = 1, i <= num_extra_space, i++)
+			var/zlev = space_manager.add_new_zlevel("[EMPTY_AREA] #[i]", linkage = CROSSLINKED)
+			seedRuins(zlev, rand(0, 3), /area/space, space_ruins_templates)
 
 	space_manager.do_transition_setup()
 

--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -48,7 +48,7 @@ var/global/pipe_processing_killed = 0
 
 		// load in extra levels of space ruins
 
-		var/num_extra_space = 6
+		var/num_extra_space = rand(config.extra_space_ruin_levels_min, config.extra_space_ruin_levels_max)
 		for(var/i = 1, i <= num_extra_space, i++)
 			var/zlev = space_manager.add_new_zlevel("[EMPTY_AREA] #[i]", linkage = CROSSLINKED)
 			seedRuins(zlev, rand(0, 3), /area/space, space_ruins_templates)

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -156,7 +156,8 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 
 		while(sanity > 0)
 			sanity--
-			var/turf/T = locate(rand(25, world.maxx - 25), rand(25, world.maxy - 25), z_level)
+			// 8: 7 is the normal view distance of a client, +1 so that ruins don't suddenly appear
+			var/turf/T = locate(rand(TRANSITION_BORDER_WEST + (8 + ruin.width/2), TRANSITION_BORDER_EAST - (8 + ruin.width/2)), rand(TRANSITION_BORDER_SOUTH + (8 + ruin.height/2), TRANSITION_BORDER_NORTH - (8 + ruin.height/2)), z_level)
 			var/valid = 1
 
 			for(var/turf/check in ruin.get_affected_turfs(T,1))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -304,7 +304,13 @@ PLAYER_REROUTE_CAP 0
 #DISABLE_AWAY_MISSIONS
 
 ## Disable the loading of space ruins
-DISABLE_SPACE_RUINS
+#DISABLE_SPACE_RUINS
+
+## Minimum number of space ruins levels to generate
+EXTRA_SPACE_RUINS_LEVELS_MIN 2
+
+## Maximum number of space ruins levels to generate
+EXTRA_SPACE_RUINS_LEVELS_MAX 4
 
 ## Uncomment to disable the OOC/LOOC channel by default.
 #DISABLE_OOC


### PR DESCRIPTION
Fixes #5558

Also adds 2-4 extra levels of space ruins

:cl:Crazylemon
fix: Space ruins can no longer trap you upon border transition
add: There are now several levels of space ruins
/:cl: