### PR TITLE
Makes girders melt

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -371,3 +371,6 @@
 #define GET_RANDOM_JOB 0
 #define BE_ASSISTANT 1
 #define RETURN_TO_LOBBY 2
+
+//Melting Temperatures for various specific objects
+#define GIRDER_MELTING_TEMP 5000

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -47,6 +47,11 @@
 		new /obj/item/stack/sheet/metal(get_turf(src))
 		qdel(src)
 
+/obj/structure/girder/temperature_expose(gas_mixture/air, exposed_temperature)
+	var/temp_check = exposed_temperature
+	if(temp_check >= GIRDER_MELTING_TEMP)
+		take_damage(10)
+
 /obj/structure/girder/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
 	if(isscrewdriver(W))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -47,7 +47,7 @@
 		new /obj/item/stack/sheet/metal(get_turf(src))
 		qdel(src)
 
-/obj/structure/girder/temperature_expose(gas_mixture/air, exposed_temperature)
+/obj/structure/girder/temperature_expose(datum/gas_mixture/air, exposed_temperature)
 	var/temp_check = exposed_temperature
 	if(temp_check >= GIRDER_MELTING_TEMP)
 		take_damage(10)


### PR DESCRIPTION
Having large plasma fires form neat outlines for each has-been room has never looked like it made sense, and it made rebuilding fired-up rooms surprisingly simple (in terms of rebuilding individual rooms), which seems to contradict the intention behind being able to melt _walls_ in the first place (thus, melting away the outline of a room and allowing the fire to spread).
🆑 FreeStylaLT
add:girders now melt in hot fires.
/🆑