### PR TITLE
Removes the traitor kill objective

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -99,10 +99,10 @@
 					objective_count++
 
 		for(var/i = objective_count, i < config.traitor_objectives_amount, i++)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = traitor
-			kill_objective.find_target()
-			traitor.objectives += kill_objective
+				var/datum/objective/maroon/maroon_objective = new
+				maroon_objective.owner = traitor
+				maroon_objective.find_target()
+				traitor.objectives += maroon_objective
 
 		var/datum/objective/survive/survive_objective = new
 		survive_objective.owner = traitor
@@ -138,11 +138,6 @@
 					maroon_objective.owner = traitor
 					maroon_objective.find_target()
 					traitor.objectives += maroon_objective
-				else
-					var/datum/objective/assassinate/kill_objective = new
-					kill_objective.owner = traitor
-					kill_objective.find_target()
-					traitor.objectives += kill_objective
 			else
 				var/datum/objective/steal/steal_objective = new
 				steal_objective.owner = traitor

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -99,10 +99,10 @@
 					objective_count++
 
 		for(var/i = objective_count, i < config.traitor_objectives_amount, i++)
-				var/datum/objective/maroon/maroon_objective = new
-				maroon_objective.owner = traitor
-				maroon_objective.find_target()
-				traitor.objectives += maroon_objective
+			var/datum/objective/maroon/maroon_objective = new
+			maroon_objective.owner = traitor
+			maroon_objective.find_target()
+			traitor.objectives += maroon_objective
 
 		var/datum/objective/survive/survive_objective = new
 		survive_objective.owner = traitor


### PR DESCRIPTION
Theoretically removes the _assassinate_ traitor objective, replaces it with marroon
From a gameplay standpoint, both are mostly similar, with marroon giving the traitor more freedom in their strategy, as they aren't forced to kill the person, while still leaving murder as an option.
