### PR TITLE
Polaris card bugfix (Plus paperbin)

### DIFF
--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -221,6 +221,8 @@
 		return
 
 	if(over_object == M)
+		if(!remove_item_from_storage(M))
+			M.unEquip(src)
 		M.put_in_hands(src)
 
 	else if(istype(over_object, /obj/screen))
@@ -374,10 +376,11 @@
 	H.parentdeck = parentdeck
 	H.concealed = concealed
 	H.update_icon()
-	update_icon()
 
 	if(!cards.len)
 		qdel(src)
+		return
+	update_icon()
 
 /obj/item/cardhand/verb/discard(var/mob/user as mob)
 
@@ -410,7 +413,7 @@
 		if(cards.len)
 			update_icon()
 		if(H.cards.len)
-			usr.visible_message("<span class='notice'>The [user] plays the [discarding].</span>", "<span class='notice'>You play the [discarding].</span>")
+			usr.visible_message("<span class='notice'>The [usr] plays the [discarding].</span>", "<span class='notice'>You play the [discarding].</span>")
 		H.loc = get_step(usr,usr.dir)
 
 	if(!cards.len)
@@ -419,7 +422,6 @@
 /obj/item/cardhand/update_icon(var/direction = 0)
 
 	if(!cards.len)
-		qdel(src)
 		return
 	else if(cards.len > 1)
 		name = "hand of cards"

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -32,6 +32,8 @@
 		return
 
 	if(over_object == M)
+		if(!remove_item_from_storage(M))
+			M.unEquip(src)
 		M.put_in_hands(src)
 
 	else if(istype(over_object, /obj/screen))


### PR DESCRIPTION
This fixes the following bugs:
1. When you drag the deck's sprite over yourself and it is in your pocket, it doesn't unequip properly and the slot is blocked
2. When you discard, the name doesn't show up properly
3. A potential paperbin bug related to 1 (due to using the same code) that never happens because paper bin cannot be put in pocket. This is pre-emptively "fixed" too.

🆑:
fix: Fixes the discard action not displaying who discarded a card from a hand of card
fix: Fixes deck of card not being removed properly from your pocket when you drag it over your sprite.
/🆑 