### PR TITLE
Depot Fixes

### DIFF
--- a/code/game/area/depot-areas.dm
+++ b/code/game/area/depot-areas.dm
@@ -335,12 +335,6 @@
 		if(!L.locked)
 			L.locked = !L.locked
 		L.update_icon()
-	for(var/obj/machinery/door/airlock/hatch/syndicate/vault/V in src)
-		if(!V.density)
-			V.close()
-		if(!V.locked)
-			V.locked = !V.locked
-		V.update_icon()
 
 /area/syndicate_depot/core/proc/shields_key_check()
 	if(!shield_list.len)
@@ -359,10 +353,6 @@
 		if(L.locked)
 			L.locked = !L.locked
 			L.update_icon()
-	for(var/obj/machinery/door/airlock/hatch/syndicate/vault/V in src)
-		if(V.locked)
-			V.locked = !V.locked
-			V.update_icon()
 
 /area/syndicate_depot/core/proc/despawn_guards()
 	for(var/mob/thismob in list_getmobs(guard_list))

--- a/code/game/area/depot-areas.dm
+++ b/code/game/area/depot-areas.dm
@@ -57,22 +57,32 @@
 /area/syndicate_depot/core/proc/reset_alert()
 
 	if(used_self_destruct)
-		return
+		for(var/obj/effect/overload/O in src)
+			new /obj/structure/fusionreactor(O.loc)
+			qdel(O)
+
+	if(on_peaceful)
+		peaceful_mode(FALSE, TRUE)
 
 	local_alarm = FALSE
 	called_backup = FALSE
+	unlock_computers()
 	used_self_destruct = FALSE
+
+	run_started = FALSE
+	run_finished = FALSE
+
+	guard_list = list()
+	hostile_list = list()
+	dead_list = list()
+	peaceful_list = list()
+
 	something_looted = FALSE
 	detected_mech = FALSE
 	detected_pod = FALSE
 	detected_double_agent = FALSE
 	updateicon()
 	despawn_guards()
-
-	guard_list = list()
-	hostile_list = list()
-	dead_list = list()
-	peaceful_list = list()
 
 	alert_log += "Alert level reset."
 
@@ -96,6 +106,13 @@
 	something_looted = TRUE
 	if(on_peaceful)
 		increase_alert("Thieves!")
+
+/area/syndicate_depot/core/proc/armory_locker_looted()
+	if(!run_finished && !used_self_destruct)
+		if(shield_list.len)
+			activate_self_destruct("Armory compromised despite armory shield being online.", FALSE)
+			return
+		declare_finished()
 
 /area/syndicate_depot/core/proc/turret_died()
 	something_looted = TRUE
@@ -133,19 +150,12 @@
 			if(L.opened)
 				L.close()
 			if(!L.locked)
-				L.locked = 1
+				L.locked = !L.locked
 			L.req_access = list(access_syndicate_leader)
 			L.update_icon()
 		for(var/obj/machinery/computer/syndicate_depot/teleporter/P in src)
 			if(!P.portal_enabled)
 				P.toggle_portal()
-		for(var/obj/machinery/door/airlock/hatch/syndicate/vault/V in src)
-			if(!V.density)
-				V.close()
-			V.emergency = 0
-			if(!V.locked)
-				V.locked = !V.locked
-			V.update_icon()
 	else
 		log_game("Depot visit: ended")
 		alert_log += "Visitor mode ended."
@@ -250,7 +260,7 @@
 	if(user)
 		var/turf/T = get_turf(user)
 		var/area/A = get_area(T)
-		var/log_msg = "[key_name(user)] has armed the depot self destruct device at [A.name] ([T.x],[T.y],[T.z])"
+		var/log_msg = "[key_name(user)] has triggered the depot self destruct at [A.name] ([T.x],[T.y],[T.z])"
 		message_admins(log_msg)
 		log_game(log_msg)
 		playsound(user, 'sound/machines/Alarm.ogg', 100, 0, 0)
@@ -271,12 +281,16 @@
 	for(var/obj/machinery/door/airlock/A in src)
 		spawn(0)
 			A.close()
-			if(A.density)
+			if(A.density && !A.locked)
 				A.lock()
 
 /area/syndicate_depot/core/proc/lockout_computers()
 	for(var/obj/machinery/computer/syndicate_depot/C in src)
 		C.activate_security_lockout()
+
+/area/syndicate_depot/core/proc/unlock_computers()
+	for(var/obj/machinery/computer/syndicate_depot/C in src)
+		C.security_lockout = FALSE
 
 /area/syndicate_depot/core/proc/toggle_door_locks()
 	for(var/obj/machinery/door/airlock/A in src)
@@ -315,6 +329,18 @@
 		if(L.name == "syndi_depot_shield")
 			var/obj/machinery/shieldwall/syndicate/S = new /obj/machinery/shieldwall/syndicate(L.loc)
 			shield_list += S.UID()
+	for(var/obj/structure/closet/secure_closet/syndicate/depot/armory/L in src)
+		if(L.opened)
+			L.close()
+		if(!L.locked)
+			L.locked = !L.locked
+		L.update_icon()
+	for(var/obj/machinery/door/airlock/hatch/syndicate/vault/V in src)
+		if(!V.density)
+			V.close()
+		if(!V.locked)
+			V.locked = !V.locked
+		V.update_icon()
 
 /area/syndicate_depot/core/proc/shields_key_check()
 	if(!shield_list.len)
@@ -329,6 +355,14 @@
 		if(S)
 			qdel(S)
 	shield_list = list()
+	for(var/obj/structure/closet/secure_closet/syndicate/depot/armory/L in src)
+		if(L.locked)
+			L.locked = !L.locked
+			L.update_icon()
+	for(var/obj/machinery/door/airlock/hatch/syndicate/vault/V in src)
+		if(V.locked)
+			V.locked = !V.locked
+			V.update_icon()
 
 /area/syndicate_depot/core/proc/despawn_guards()
 	for(var/mob/thismob in list_getmobs(guard_list))

--- a/code/game/area/depot-areas.dm
+++ b/code/game/area/depot-areas.dm
@@ -257,8 +257,10 @@
 	else
 		log_game("Depot self destruct activated.")
 	if(reactor)
-		reactor.overload(containment_failure)
+		if(!reactor.has_overloaded)
+			reactor.overload(containment_failure)
 	else
+		log_debug("Depot: [src] called activate_self_destruct with no reactor.");
 		message_admins("<span class='adminnotice'>Syndicate Depot lacks reactor to initiate self-destruct. Must be destroyed manually.</span>")
 	updateicon()
 

--- a/code/game/area/depot-areas.dm
+++ b/code/game/area/depot-areas.dm
@@ -72,7 +72,7 @@
 	run_started = FALSE
 	run_finished = FALSE
 
-	guard_list = list()
+	despawn_guards()
 	hostile_list = list()
 	dead_list = list()
 	peaceful_list = list()
@@ -82,7 +82,7 @@
 	detected_pod = FALSE
 	detected_double_agent = FALSE
 	updateicon()
-	despawn_guards()
+
 
 	alert_log += "Alert level reset."
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -305,6 +305,10 @@
 /atom/proc/rpd_act()
 	return
 
+/atom/proc/rpd_blocksusage()
+	// Atoms that return TRUE prevent RPDs placing any kind of pipes on their turf.
+	return FALSE
+
 /atom/proc/hitby(atom/movable/AM, skipcatch, hitpush, blocked)
 	if(density && !has_gravity(AM)) //thrown stuff bounces off dense stuff in no grav, unless the thrown stuff ends up inside what it hit(embedding, bola, etc...).
 		addtimer(CALLBACK(src, .proc/hitby_react, AM), 2)

--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -138,6 +138,7 @@
 	if(depotarea)
 		depotarea.toggle_door_locks(src)
 		to_chat(user, "<span class='notice'>Door locks toggled.</span>")
+		playsound(user, sound_yes, 50, 0)
 
 /obj/machinery/computer/syndicate_depot/doors/secondary(mob/user, subcommand)
 	if(..())
@@ -145,6 +146,7 @@
 	if(depotarea)
 		depotarea.toggle_falsewalls(src)
 		to_chat(user, "<span class='notice'>False walls toggled.</span>")
+		playsound(user, sound_yes, 50, 0)
 
 
 // Engineering AKA self destruct computer, no useful functions, just a trap for the people who can't resist pushing dangerous-sounding buttons.
@@ -285,6 +287,7 @@
 		to_chat(user, "<span class='warning'>[src] requires authentication with syndicate codewords, which you do not know.</span>")
 		raise_alert("Detected unauthorized access by [user] to [src]!")
 	updateUsrDialog()
+	playsound(user, sound_yes, 50, 0)
 
 /obj/machinery/computer/syndicate_depot/syndiecomms/secondary(mob/user, subcommand)
 	if(..())
@@ -319,6 +322,7 @@
 	else
 		to_chat(user, "<span class='warning'>ERROR: [src] is unable to uplink to depot network.</span>")
 	updateUsrDialog()
+	playsound(user, sound_yes, 50, 0)
 
 /obj/machinery/computer/syndicate_depot/syndiecomms/proc/grant_syndie_faction(mob/user)
 	user.faction += "syndicate"
@@ -432,6 +436,7 @@
 	var/bresult = mybeacon.toggle()
 	to_chat(user, "<span class='notice'>Syndicate Teleporter Beacon: [bresult ? "<span class='green'>ON</span>" : "<span class='red'>OFF</span>"]</span>")
 	updateUsrDialog()
+	playsound(user, sound_yes, 50, 0)
 
 /obj/machinery/computer/syndicate_depot/teleporter/secondary(mob/user)
 	if(..())
@@ -444,6 +449,7 @@
 	toggle_portal()
 	to_chat(user, "<span class='notice'>Outgoing Teleport Portal: [portal_enabled ? "<span class='green'>ON</span>" : "<span class='red'>OFF</span>"]</span>")
 	updateUsrDialog()
+	playsound(user, sound_yes, 50, 0)
 
 /obj/machinery/computer/syndicate_depot/teleporter/proc/toggle_portal()
 	portal_enabled = !portal_enabled
@@ -507,6 +513,7 @@
 	if(depotarea)
 		depotarea.reset_alert()
 		to_chat(user, "Alert level reset.")
+		playsound(user, sound_yes, 50, 0)
 
 /obj/machinery/computer/syndicate_depot/aiterminal/secondary(mob/user)
 	if(..())
@@ -517,3 +524,4 @@
 		to_chat(user, "[B] has been recalled.")
 		qdel(B)
 		raise_alert("Sentry bot removed via emergency recall.")
+	playsound(user, sound_yes, 50, 0)

--- a/code/game/machinery/computer/depot.dm
+++ b/code/game/machinery/computer/depot.dm
@@ -169,9 +169,9 @@
 	if(depotarea.used_self_destruct)
 		playsound(user, sound_no, 50, 0)
 		return
-	playsound(user, sound_click, 20, 1)
 	if(depotarea)
 		depotarea.activate_self_destruct("Fusion reactor containment field disengaged. All hands, evacuate. All hands, evacuate!", TRUE, user)
+		playsound(user, sound_click, 20, 1)
 
 
 // Shield computer, used to manipulate base shield, and armory shield

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -140,6 +140,7 @@
 //update the name and icon of the pipe item depending on the type
 
 /obj/item/pipe/rpd_act(mob/user, obj/item/rpd/our_rpd)
+	. = TRUE
 	if(our_rpd.mode == RPD_ROTATE_MODE)
 		rotate()
 	else if(our_rpd.mode == RPD_FLIP_MODE)
@@ -147,7 +148,7 @@
 	else if(our_rpd.mode == RPD_DELETE_MODE)
 		our_rpd.delete_single_pipe(user, src)
 	else
-		..()
+		return ..()
 
 /obj/item/pipe/proc/update(var/obj/machinery/atmospherics/make_from)
 	name = "[get_pipe_name(pipe_type, PIPETYPE_ATMOS)] fitting"

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1013,15 +1013,14 @@ var/list/turret_icons
 	check_anomalies = 1
 	check_synth	= 1
 	ailock = 1
+	var/area/syndicate_depot/core/depotarea
 
 /obj/machinery/porta_turret/syndicate/die()
 	. = ..()
-	var/area/syndicate_depot/core/depotarea = areaMaster
 	if(istype(depotarea))
 		depotarea.turret_died()
 
 /obj/machinery/porta_turret/syndicate/shootAt(mob/living/target)
-	var/area/syndicate_depot/core/depotarea = areaMaster
 	if(istype(depotarea))
 		depotarea.list_add(target, depotarea.hostile_list)
 		depotarea.declare_started()

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -541,6 +541,8 @@
 /obj/machinery/shieldwall/attack_hand(mob/user as mob)
 	return
 
+/obj/machinery/shieldwall/rpd_blocksusage()
+	return TRUE
 
 /obj/machinery/shieldwall/process()
 	if(needs_power)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -14,14 +14,12 @@
 /obj/effect/mine/Crossed(AM as mob|obj)
 	if(!isliving(AM))
 		return
-	if(isanimal(AM))
-		var/mob/living/simple_animal/SA = AM
-		if(faction && (faction in SA.faction))
-			return
-		if(!SA.flying)
-			triggermine(SA)
-	else
-		triggermine(AM)
+	var/mob/living/M = AM
+	if(faction && (faction in M.faction))
+		return
+	if(M.flying)
+		return
+	triggermine(M)
 
 /obj/effect/mine/proc/triggermine(mob/living/victim)
 	if(triggered)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -34,6 +34,11 @@
 	triggered = 1
 	qdel(src)
 
+/obj/effect/mine/ex_act(severity)
+	// Necessary because, as effects, they have infinite health, and wouldn't be destroyed otherwise.
+	// Also, they're pressure-sensitive mines, it makes sense that an explosion (wave of pressure) triggers/destroys them.
+	qdel(src)
+
 /obj/effect/mine/explosive
 	name = "explosive mine"
 	var/range_devastation = 0

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -300,10 +300,9 @@
 		/obj/structure/falsewall/reinforced = 1)
 
 /obj/effect/spawner/random_spawners/syndicate/layout/door/vault
-	name = "60pc vaultdoor 20pc falsewall 20pc wall"
-	result = list(/obj/machinery/door/airlock/hatch/syndicate/vault = 6,
-		/turf/simulated/wall/r_wall = 2,
-		/obj/structure/falsewall/reinforced = 2)
+	name = "80pc vaultdoor 20pc wall"
+	result = list(/obj/machinery/door/airlock/hatch/syndicate/vault = 4,
+		/turf/simulated/wall/r_wall = 1)
 
 
 /obj/effect/spawner/random_spawners/syndicate/layout/spacepod

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -264,6 +264,7 @@
 
 /obj/effect/spawner/random_spawners/syndicate/loot/level4
 	name = "armory loot"
+	spawn_inside = /obj/structure/closet/secure_closet/syndicate/depot/armory
 	// Loot schema: high-power weapons (m90, esword, ebow, revolver), devices that negate depot challenges (thermal glasses, chameleon device), explosives
 	result = list(/obj/item/gun/projectile/automatic/c20r = 1,
 		/obj/item/gun/projectile/automatic/m90 = 1,

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -192,6 +192,10 @@ var/list/pipemenu = list(
 		return
 	if(world.time < lastused + spawndelay)
 		return
+	var/turf/T = get_turf(target)
+	for(var/obj/machinery/shieldwall/S in T)
+		to_chat(user, "<span class='warning'>[S] blocks access!</span>")
+		return
 	target.rpd_act(user, src) //Handle RPD effects in separate procs
 
 #undef RPD_COOLDOWN_TIME

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -71,10 +71,6 @@
 	SSnanoui.close_uis(src)
 	return ..()
 
-/obj/rpd_act(mob/user, obj/item/rpd/our_rpd)
-	var/turf/T = get_turf(src) //This preserves RPD behaviour on specific turfs
-	T.rpd_act(user, our_rpd)
-
 /obj/proc/process()
 	set waitfor = 0
 	processing_objects.Remove(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
@@ -41,6 +41,12 @@
 		return
 	return ..(M)
 
+/obj/structure/closet/secure_closet/syndicate/depot/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/rcs))
+		to_chat(user, "<span class='warning'>Bluespace interference prevents the [W] from locking onto [src]!</span>")
+		return
+	return ..()
+
 /obj/structure/closet/secure_closet/syndicate/depot/emp_act(severity)
 	return
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
@@ -6,6 +6,7 @@
 	anchored = 1
 	health = 200
 	req_access = list()
+	var/ignore_use = FALSE
 
 
 /obj/structure/closet/secure_closet/syndicate/depot/New()
@@ -26,9 +27,10 @@
 	. = ..()
 
 /obj/structure/closet/secure_closet/syndicate/depot/proc/loot_pickup()
-	var/area/syndicate_depot/core/depotarea = areaMaster
-	if(depotarea)
-		depotarea.locker_looted()
+	if(!ignore_use)
+		var/area/syndicate_depot/core/depotarea = areaMaster
+		if(depotarea)
+			depotarea.locker_looted()
 
 /obj/structure/closet/secure_closet/syndicate/depot/attack_animal(mob/M)
 	if(isanimal(M) && "syndicate" in M.faction)
@@ -43,3 +45,9 @@
 	. = ..()
 	if(!locked)
 		loot_pickup()
+
+/obj/structure/closet/secure_closet/syndicate/depot/attack_ghost(mob/user)
+	if(user.can_advanced_admin_interact())
+		ignore_use = TRUE
+		toggle(user)
+		ignore_use = FALSE

--- a/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/depot.dm
@@ -6,6 +6,7 @@
 	anchored = 1
 	health = 200
 	req_access = list()
+	var/is_armory = FALSE
 	var/ignore_use = FALSE
 
 
@@ -29,8 +30,10 @@
 /obj/structure/closet/secure_closet/syndicate/depot/proc/loot_pickup()
 	if(!ignore_use)
 		var/area/syndicate_depot/core/depotarea = areaMaster
-		if(depotarea)
+		if(istype(depotarea))
 			depotarea.locker_looted()
+			if(is_armory)
+				depotarea.armory_locker_looted()
 
 /obj/structure/closet/secure_closet/syndicate/depot/attack_animal(mob/M)
 	if(isanimal(M) && "syndicate" in M.faction)
@@ -51,3 +54,7 @@
 		ignore_use = TRUE
 		toggle(user)
 		ignore_use = FALSE
+
+/obj/structure/closet/secure_closet/syndicate/depot/armory
+	req_access = list(access_syndicate)
+	is_armory = TRUE

--- a/code/game/objects/structures/depot.dm
+++ b/code/game/objects/structures/depot.dm
@@ -12,8 +12,12 @@
 /obj/structure/fusionreactor/Initialize()
 	. = ..()
 	depotarea = areaMaster
-	if(depotarea)
+	if(istype(depotarea))
 		depotarea.reactor = src
+		spawn(50) // Necessary since random spawners may take a second to spawn turrets in depot.
+			for(var/obj/machinery/porta_turret/syndicate/T in range(50, loc))
+				if(!istype(T.depotarea))
+					T.depotarea = depotarea
 
 /obj/structure/fusionreactor/Destroy()
 	if(istype(depotarea))

--- a/code/game/objects/structures/depot.dm
+++ b/code/game/objects/structures/depot.dm
@@ -10,14 +10,16 @@
 	var/has_overloaded = FALSE
 
 /obj/structure/fusionreactor/Initialize()
-	. = ..()
+	..()
 	depotarea = areaMaster
 	if(istype(depotarea))
 		depotarea.reactor = src
-		spawn(50) // Necessary since random spawners may take a second to spawn turrets in depot.
-			for(var/obj/machinery/porta_turret/syndicate/T in range(50, loc))
-				if(!istype(T.depotarea))
-					T.depotarea = depotarea
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/fusionreactor/LateInitialize()
+	for(var/obj/machinery/porta_turret/syndicate/T in range(50, loc))
+		if(!istype(T.depotarea))
+			T.depotarea = depotarea
 
 /obj/structure/fusionreactor/Destroy()
 	if(istype(depotarea))

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -17,8 +17,8 @@
 	if(announce)
 		event_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", new_sound = 'sound/AI/poweroff.ogg')
 
-	var/list/skipped_areas = list(/area/turret_protected/ai, /area/syndicate_depot)
-	var/list/skipped_areas_apc = list(/area/engine/engineering, /area/syndicate_depot)
+	var/list/skipped_areas = list(/area/turret_protected/ai, /area/syndicate_depot/core, /area/syndicate_depot/outer)
+	var/list/skipped_areas_apc = list(/area/engine/engineering, /area/syndicate_depot/core, /area/syndicate_depot/outer)
 
 	for(var/obj/machinery/power/smes/S in machines)
 		var/area/current_area = get_area(S)
@@ -41,8 +41,8 @@
 			C.cell.charge = 0
 
 /proc/power_restore(var/announce = 1)
-	var/list/skipped_areas = list(/area/turret_protected/ai, /area/syndicate_depot)
-	var/list/skipped_areas_apc = list(/area/engine/engineering, /area/syndicate_depot)
+	var/list/skipped_areas = list(/area/turret_protected/ai, /area/syndicate_depot/core, /area/syndicate_depot/outer)
+	var/list/skipped_areas_apc = list(/area/engine/engineering, /area/syndicate_depot/core, /area/syndicate_depot/outer)
 
 	if(announce)
 		event_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -17,12 +17,12 @@
 	if(announce)
 		event_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", new_sound = 'sound/AI/poweroff.ogg')
 
-	var/list/skipped_areas = list(/area/turret_protected/ai, /area/syndicate_depot/core, /area/syndicate_depot/outer)
-	var/list/skipped_areas_apc = list(/area/engine/engineering, /area/syndicate_depot/core, /area/syndicate_depot/outer)
+	var/list/skipped_areas = list(/area/turret_protected/ai)
+	var/list/skipped_areas_apc = list(/area/engine/engineering)
 
 	for(var/obj/machinery/power/smes/S in machines)
 		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas || !is_station_level(S.z))
+		if((current_area.type in skipped_areas) || !is_station_level(S.z))
 			continue
 		S.last_charge			= S.charge
 		S.last_output_attempt	= S.output_attempt
@@ -35,26 +35,26 @@
 
 	for(var/obj/machinery/power/apc/C in apcs)
 		var/area/current_area = get_area(C)
-		if(current_area.type in skipped_areas_apc || !is_station_level(C.z))
+		if((current_area.type in skipped_areas_apc) || !is_station_level(C.z))
 			continue
 		if(C.cell)
 			C.cell.charge = 0
 
 /proc/power_restore(var/announce = 1)
-	var/list/skipped_areas = list(/area/turret_protected/ai, /area/syndicate_depot/core, /area/syndicate_depot/outer)
-	var/list/skipped_areas_apc = list(/area/engine/engineering, /area/syndicate_depot/core, /area/syndicate_depot/outer)
+	var/list/skipped_areas = list(/area/turret_protected/ai)
+	var/list/skipped_areas_apc = list(/area/engine/engineering)
 
 	if(announce)
 		event_announcement.Announce("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal", new_sound = 'sound/AI/poweron.ogg')
 	for(var/obj/machinery/power/apc/C in apcs)
 		var/area/current_area = get_area(C)
-		if(current_area.type in skipped_areas_apc || !is_station_level(C.z))
+		if((current_area.type in skipped_areas_apc) || !is_station_level(C.z))
 			continue
 		if(C.cell)
 			C.cell.charge = C.cell.maxcharge
 	for(var/obj/machinery/power/smes/S in machines)
 		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas || !is_station_level(S.z))
+		if((current_area.type in skipped_areas) || !is_station_level(S.z))
 			continue
 		S.charge = S.last_charge
 		S.output_attempt = S.last_output_attempt

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -205,8 +205,11 @@
 	alert_on_shield_breach = TRUE
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/death()
-	if(depotarea)
-		depotarea.declare_finished()
+	if(istype(depotarea))
+		if(depotarea.shield_list.len)
+			depotarea.activate_self_destruct("[src] has died while the armory shield is up.", FALSE)
+		else
+			depotarea.declare_finished()
 	return ..()
 
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -128,6 +128,9 @@
 			seen_revived_enemy = TRUE
 			raise_alert("[name] reports intruder [target] has returned from death!")
 			depotarea.list_remove(target, depotarea.dead_list)
+		if(!atoms_share_level(src, target) && prob(20))
+			// This prevents someone from aggroing a depot mob, then hiding in a locker, perfectly safe, while the mob stands there getting killed by their friends.
+			LoseTarget()
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/handle_automated_action()
 	if(seen_enemy)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -134,6 +134,14 @@
 	if(scan_cycles >= 15 && istype(depotarea))
 		scan_cycles = 0
 		if(!atoms_share_level(src, spawn_turf))
+			if(istype(loc, /obj/structure/closet))
+				var/obj/structure/closet/O = loc
+				forceMove(get_turf(src))
+				visible_message("<span class='boldwarning'>[src] smashes their way out of [O]!</span>")
+				qdel(O)
+				raise_alert("[src] reported being trapped in a locker.")
+				raised_alert = FALSE
+				return
 			if(alert_on_spacing)
 				raise_alert("[src] lost in space.")
 			death()

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -204,15 +204,6 @@
 	alert_on_timeout = TRUE
 	alert_on_shield_breach = TRUE
 
-/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/death()
-	if(istype(depotarea))
-		if(depotarea.shield_list.len)
-			depotarea.activate_self_destruct("[src] has died while the armory shield is up.", FALSE)
-		else
-			depotarea.declare_finished()
-	return ..()
-
-
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/Initialize()
 	. = ..()
 	if(istype(depotarea))

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -51,7 +51,10 @@
 			var/damage = O.force
 			if(O.damtype == STAMINA)
 				damage = 0
-			health -= damage
+			if(force_threshold && damage < force_threshold)
+				visible_message("<span class='boldwarning'>[src] is unharmed by [O]!</span>")
+				return
+			adjustHealth(damage)
 			visible_message("<span class='boldwarning'>[src] has been attacked with the [O] by [user]. </span>")
 		playsound(loc, O.hitsound, 25, 1, -1)
 	else

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -258,6 +258,7 @@
 			return
 
 /obj/structure/disposalconstruct/rpd_act(mob/user, obj/item/rpd/our_rpd)
+	. = TRUE
 	if(our_rpd.mode == RPD_ROTATE_MODE)
 		rotate()
 	else if(our_rpd.mode == RPD_FLIP_MODE)
@@ -265,4 +266,4 @@
 	else if(our_rpd.mode == RPD_DELETE_MODE)
 		our_rpd.delete_single_pipe(user, src)
 	else
-		..()
+		return ..()


### PR DESCRIPTION
🆑 Kyep
fix: Fixed a few bugs (notably, grid check event raising alert level) in the depot.
/🆑

Fixes for bugs I noticed:
- Fix: 'grid check' event no longer affects areas outside of the main station, including depot areas. Previously, it did, causing depot alert level to rise during grid check events.
- Fix: some depot computers no longer fail to beep when used.
- Fix: aghosts opening/closing lockers no longer flags the depot as having been 'looted', which would have prevented traitors who visit later from signing in as visitors.
- Fix: mines are now properly destroyed by explosions. Previously, they were invincible to them, which led to strange mines floating in space after the depot went delta.
- Fix: falsewalls into depot armory will no longer be super obvious, due to having shields underneath them, rather than on top of them like proper walls.
- Fix: depot syndie NPC mobs being immune to melee damage, and not properly generating a message when attacks did no damge.
- Fix: depot syndie NPC mobs getting confused forever by targets hiding in lockers.
- Fix: external depot turrets not being linked to depot AI.
- Fix: peaceful syndi visitors to depot still setting off mines that are meant to ignore syndies.

Also, fixes for bugs & exploits found by Denthamos:
- Fix: depot NPCs trapped in lockers no longer count as 'lost in space' due to lockerspace being nullspace.
- Fix: no longer possible to destroy the fusion reactor without triggering delta under certain conditions.
- Fix: no longer possible to use certain cheesy methods to get the armory loot without properly unlocking the armory first. Attempting to do so now triggers instant delta. 
- Fix: no longer possible to bypass shields.
- Fix: no longer possible to steal loot as peaceful visitor without triggering a reaction from the depot.