### PR TITLE
Abducts #9233

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -197,17 +197,17 @@
 /datum/game_mode/proc/auto_declare_completion_abduction()
 	var/text = ""
 	if(abductors.len)
-		text += "<br><span class='big'><b>The abductors were:</b></span>"
+		text += "<br><span class='big'><b>The abductors were:</b></span><br>"
 		for(var/datum/mind/abductor_mind in abductors)
 			text += printplayer(abductor_mind)
 			text += printobjectives(abductor_mind)
-		text += "<br>"
+			text += "<br>"
 		if(abductees.len)
-			text += "<br><span class='big'><b>The abductees were:</b></span>"
+			text += "<br><span class='big'><b>The abductees were:</b></span><br>"
 			for(var/datum/mind/abductee_mind in abductees)
 				text += printplayer(abductee_mind)
 				text += printobjectives(abductee_mind)
-	text += "<br>"
+				text += "<br>"
 	to_chat(world, text)
 
 //Landmarks


### PR DESCRIPTION
Fixes #9232

I was able to verify that the edits in #9233 did in fact work. Granted
there were only five of us on the server and two of us were abductors
while only kidnapping one person, but it did work.

![capture](https://user-images.githubusercontent.com/1978025/43926453-f17c7d4e-9bef-11e8-9e01-97fbd08065ce.PNG)

Uh, I SHOULD also mention this was run on an older codebase my friends use. I was not able to run my own server at the time. I did confirm that their abductor round end code was the same as ours before applying the edits to them. That's why the `MODE` issue is there. I should fix that for them too

:cl:
fix: Corrects formatting for the abductor objective messages
/:cl: