### PR TITLE
Broken SMES fixed

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -64,9 +64,10 @@
 					if(term && term.dir == turn(d, 180))
 						terminal = term
 						break dir_loop
-		if(!terminal)
+		/*if(!terminal)
 			stat |= BROKEN
 			return
+			*/ //
 		terminal.master = src
 		if(!terminal.powernet)
 			terminal.connect_to_network()


### PR DESCRIPTION
PR to my own issue #9345 

Tested in game by spawning a new SMES. Existing SMES work normal.

Also deconstructed the SMES and built it all over again, even though after deconstructing it shows that it is "slightly damaged" (machine frame) after putting all the components together and screwdrive it, it is no longer on the BROKEN state. Wiring it up and it is fixed.

I am not sure if this is breaking something, as i found it odd setting the state to BROKEN on new() only because it cannot detect a terminal. Terminal's are only available AFTER it is manually added (This seems to answer why the map SMES work perfectly, as they can detect a terminal upon creation -- new() )

Another fix would be to check the loop above this code (which i did not remove in fear) after we manually add a terminal (by opening the case and adding wires to the SMES, with the character below where we want that terminal.)

-- EDIT: I'd like to add that this is my first contribuition and PR in my entire life. I assume i f'ed up in someway or another. Please tell me what is wrong with either the code or my PR as i am entirely new on here.