### PR TITLE
Fixes comfrey

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -205,6 +205,7 @@
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "tea_aspera_leaves"
 	color = "#378C61"
+	stop_bleeding = 0
 	heal_brute = 12
 
 


### PR DESCRIPTION
This fixes comfrey by setting its stop_bleeding to zero. Previously it inherited its parent's stop_bleeding stat and led to it being treated as a bandage instead of a bruise kit that applies brute heal.

🆑:
fix: Comfrey now actually works for healing brute damage.
/🆑 