### PR TITLE
Allows medical belts to hold hyposprays

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -128,6 +128,8 @@
 		/obj/item/clothing/mask/surgical,
 		/obj/item/clothing/gloves/color/latex,
         /obj/item/reagent_containers/hypospray/autoinjector,
+        /obj/item/reagent_containers/hypospray/CMO,
+        /obj/item/reagent_containers/hypospray/safety,
         /obj/item/rad_laser,
 		/obj/item/sensor_device,
 		/obj/item/wrench/medical,


### PR DESCRIPTION
Adds CMO's hypospray and medical hypospray to list of items that a medical belt can hold.

Was playing paramedic and wondered why they didn't fit on the belt. They are rather small items, clearly medical. Especially now that we have more hyposprays for medbay, storing them on your convenient belt is nice. Unless there's some huge balance implication I'm missing and they were left off deliberately?

:cl:
add: Medbelts can now hold hyposprays.
/:cl: