### PR TITLE
Analyser > Analyzer

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -214,7 +214,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/jobspecific/rad_laser
 	name = "Radiation Laser"
-	desc = "A radiation laser concealed inside of a Health Analyser. After a moderate delay, causes temporary collapse and radiation. Has adjustable controls, but will not function as a regular health analyser, only appears like one. May not function correctly on radiation resistant humanoids!"
+	desc = "A radiation laser concealed inside of a Health Analyzer. After a moderate delay, causes temporary collapse and radiation. Has adjustable controls, but will not function as a regular health analyzer, only appears like one. May not function correctly on radiation resistant humanoids!"
 	reference = "RL"
 	item = /obj/item/rad_laser
 	cost = 5

--- a/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
+++ b/code/modules/awaymissions/mission_code/UO71-terrorspiders.dm
@@ -181,7 +181,7 @@
 
 /obj/item/paper/terrorspiders9
 	name = "paper - 'Research Notes'"
-	info = "<b>The notes appear gibberish to you. Perhaps a destructive analyser in R&D could make sense of them.</b>"
+	info = "<b>The notes appear gibberish to you. Perhaps a destructive analyzer in R&D could make sense of them.</b>"
 	origin_tech = "combat=4;materials=4;engineering=4;biotech=4"
 
 /obj/item/gun/energy/laser/awaymission_aeg
@@ -257,5 +257,3 @@
 		else
 			to_chat(user, "<span class='notice'>Your ID card already has all the access this machine can give.</span>")
 		. = 1
-
-

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -163,7 +163,7 @@
 	icon_state = "radio"
 
 //
-//Robotic Component Analyser, basically a health analyser for robots
+//Robotic Component Analyzer, basically a health analyzer for robots
 //
 /obj/item/robotanalyzer
 	name = "cyborg analyzer"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -543,9 +543,9 @@
 	build_path = /obj/item/assembly/timer
 	category = list("initial", "Miscellaneous")
 
-/datum/design/voice_analyser
-	name = "Voice Analyser"
-	id = "voice_analyser"
+/datum/design/voice_analyzer
+	name = "Voice Analyzer"
+	id = "voice_analyzer"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 500, MAT_GLASS = 50)
 	build_path = /obj/item/assembly/voice


### PR DESCRIPTION
Fixes some spelling inconsistency. All instance of analyser (Except for one in commented out economy code) are analyzer now.

Fixes #9279 

🆑:
tweak: Analyzer are now consistently spelled Analyzer instead of Analyser.
/🆑 