### PR TITLE
Removes Atmos Grenades from Surplus

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -500,6 +500,7 @@ var/list/uplink_items = list()
 	reference = "AGG"
 	item = /obj/item/storage/box/syndie_kit/atmosgasgrenades
 	cost = 11
+	surplus = 0
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Grenades and Implanter Kit"


### PR DESCRIPTION
Getting a grenade set you can RARELY use due to server rules is just terrible. The same reason why the singularity beacon was removed from surplus. It prevents mass destruction because of people thinking "I got it from surplus so its fine to use I guess". It is mainly to prevent extreme frustration by surplus crate using traitors of items they cannot use OOCly because server rules. Thus they shouldnt appear in the surplus crates at all if you cant use them at all.

:cl:
Fix: Atmos Grenades wont appear in Surplus anymore due to them virtually being unuseable due to OOC reasons in almost any case.
/:cl: