### PR TITLE
Fixes pod fab bug

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -655,11 +655,11 @@ obj/item/circuitboard/rdserver
 	build_path = /obj/machinery/mecha_part_fabricator/spacepod
 	board_type = "machine"
 	origin_tech = "programming=2;engineering=2"
-	frame_desc = "Requires 3 Matter Bins, 2 Manipulators, 2 Micro-Lasers, and 1 Console Screen."
+	frame_desc = "Requires 2 Matter Bins, 1 Manipulators, 1 Micro-Lasers, and 1 Console Screen."
 	req_components = list(
-							/obj/item/stock_parts/matter_bin = 3,
-							/obj/item/stock_parts/manipulator = 2,
-							/obj/item/stock_parts/micro_laser = 2,
+							/obj/item/stock_parts/matter_bin = 2,
+							/obj/item/stock_parts/manipulator = 1,
+							/obj/item/stock_parts/micro_laser = 1,
 							/obj/item/stock_parts/console_screen = 1)
 
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -462,6 +462,19 @@
 								"Pod_Frame",
 								"Misc")
 
+/obj/machinery/mecha_part_fabricator/spacepod/New()
+	. = ..()
+	for(var/obj/O in component_parts)
+		qdel(O)
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/podfab(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stock_parts/micro_laser(null)
+	component_parts += new /obj/item/stock_parts/console_screen(null)
+	RefreshParts()
+
 /obj/machinery/mecha_part_fabricator/robot
 	name = "Robotic Fabricator"
 	part_sets = list("Cyborg")

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -461,6 +461,7 @@
 								"Pod_Parts",
 								"Pod_Frame",
 								"Misc")
+	req_access = list(access_mechanic)
 
 /obj/machinery/mecha_part_fabricator/spacepod/New()
 	. = ..()

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -464,7 +464,7 @@
 	req_access = list(access_mechanic)
 
 /obj/machinery/mecha_part_fabricator/spacepod/New()
-	. = ..()
+	..()
 	QDEL_LIST(component_parts)
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/podfab(null)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -465,8 +465,7 @@
 
 /obj/machinery/mecha_part_fabricator/spacepod/New()
 	. = ..()
-	for(var/obj/O in component_parts)
-		qdel(O)
+	QDEL_LIST(component_parts)
 	component_parts = list()
 	component_parts += new /obj/item/circuitboard/podfab(null)
 	component_parts += new /obj/item/stock_parts/matter_bin(null)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -272,6 +272,16 @@
 	build_path = /obj/item/circuitboard/mechfab
 	category = list("Research Machinery")
 
+/datum/design/podfab
+	name = "Machine Board (Spacepod Fabricator)"
+	desc = "The circuit board for an Spacepod Fabricator"
+	id = "podfab"
+	req_tech = list("programming" = 3, "engineering" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000)
+	build_path = /obj/item/circuitboard/podfab
+	category = list("Research Machinery")
+
 /datum/design/mech_recharger
 	name = "Machine Board (Mech Bay Recharger)"
 	desc = "The circuit board for a Mech Bay Recharger."


### PR DESCRIPTION
🆑 Kyep
fix: Deconstructing/reconstructing the space pod fab no longer turns it into a mech fab. No more mechanics building surprise mechs.
tweak: The spacepod fab circuit is now buildable in R&D. 
tweak: Spacepod fabs now require mechanic access to use, like the mechanic R&D console does.
/🆑
  