### PR TITLE
Wallet icon defaults to green if it is filled with an id of any type

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -49,9 +49,6 @@
 
 	if(front_id)
 		switch(front_id.icon_state)
-			if("id")
-				icon_state = "walletid"
-				return
 			if("silver")
 				icon_state = "walletid_silver"
 				return
@@ -60,6 +57,9 @@
 				return
 			if("centcom")
 				icon_state = "walletid_centcom"
+				return
+			else
+				icon_state = "walletid"
 				return
 	icon_state = "wallet"
 
@@ -124,9 +124,6 @@
 /obj/item/storage/wallet/color/update_icon()
 	if(front_id)
 		switch(front_id.icon_state)
-			if("id")
-				icon_state = "[item_color]_walletid"
-				return
 			if("silver")
 				icon_state = "[item_color]_walletid_silver"
 				return
@@ -135,6 +132,9 @@
 				return
 			if("centcom")
 				icon_state = "[item_color]_walletid_centcom"
+				return
+			else
+				icon_state = "[item_color]_walletid"
 				return
 	icon_state = "[item_color]_wallet"
 


### PR DESCRIPTION
If you put in an ID that isn't green, silver, centcomm or gold, the wallet's decal doesn't update to show there's a card inside. This fixes it so that the default icon is the green decal.

Fixes #3028

Before:
![](https://i.imgur.com/XqwGBb4.png)
After:
![](https://i.imgur.com/GpzkdBS.png)

🆑:
tweak: A wallet now shows a green card decal by default if there's a card inside.
/🆑 