### PR TITLE
Fixes Changeling Fleshmend blood bug

### DIFF
--- a/code/game/gamemodes/changeling/powers/fleshmend.dm
+++ b/code/game/gamemodes/changeling/powers/fleshmend.dm
@@ -48,7 +48,7 @@
 			var/healpertick = -(total_healing / healing_ticks)
 			user.heal_overall_damage((-healpertick/recent_uses), (-healpertick/recent_uses))
 			user.adjustOxyLoss(healpertick/recent_uses)
-			user.blood_volume += 30
+			user.blood_volume = min(user.blood_volume + 30, BLOOD_VOLUME_NORMAL)
 			user.updatehealth()
 		else
 			break


### PR DESCRIPTION
The fleshmend ability added blood beyond maximum, thus allowing for easy changeling detection. This PR fixes this.

🆑
fix: Changeling fleshmend no longer overfills their blood.
/🆑