### PR TITLE
Made cryokinesis only lower body temperature, Drask no longer take damage from it.

### DIFF
--- a/code/game/dna/genes/goon_powers.dm
+++ b/code/game/dna/genes/goon_powers.dm
@@ -171,11 +171,9 @@
 					H.visible_message("<span class='warning'>[user] sprays a cloud of fine ice crystals engulfing, [H]!</span>",
 										"<span class='warning'>[user] sprays a cloud of fine ice crystals cover your [H.head]'s visor and make it into your air vents!.</span>")
 					add_attack_logs(user, C, "Cryokinesis")
-					H.bodytemperature = max(0, H.bodytemperature - 50)
-					H.adjustFireLoss(5)
+					H.bodytemperature = max(0, H.bodytemperature - 100)
 	if(!handle_suit)
-		C.bodytemperature = max(0, C.bodytemperature - 100)
-		C.adjustFireLoss(10)
+		C.bodytemperature = max(0, C.bodytemperature - 200)
 		C.ExtinguishMob()
 
 		C.visible_message("<span class='warning'>[user] sprays a cloud of fine ice crystals, engulfing [C]!</span>")


### PR DESCRIPTION
Fixes #9239

Made cryokinesis (genetics cold touch) just lower body temperature instead of lowering temperature and dealing burn damage. 
This still results in burn damage for most species. The total damage will be lower but the slow down is longer. 

🆑:
fix: Drask no longer take damage from cryokinesis
tweak: Cryokinesis deals less damage, but lowers the body temperature a lot more.
/🆑