### PR TITLE
Slightly alters set_species equipping (changeling hardsuit bug).

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1328,7 +1328,7 @@
 	dna.species.create_organs(src)
 
 	for(var/thing in kept_items)
-		equip_to_slot_or_del(thing, kept_items[thing])
+		equip_to_slot_if_possible(thing, kept_items[thing], redraw_mob = 0)
 
 	//Handle default hair/head accessories for created mobs.
 	var/obj/item/organ/external/head/H = get_organ("head")


### PR DESCRIPTION
Alters the handling of re-equipping items in `set_species()`.

In some instances, i.e. Hard suits where the helmet is required to be attached to the hard suit itself would result in the helmet being deleted. The strange thing here is that `equip_to_slot_if_possible()` still reports being unable to equip the items, despite equipping them... any input into this would be most welcome.

As of this PR, items equip properly and generate no runtimes. Upon using `set_speices()` be it through changeling transform, CMA etc.

Fixes #9381 

🆑 Birdtalon
fix: Fixes unexpected item deletion upon changing species.
/🆑 