### PR TITLE
Small poster bugfix

### DIFF
--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -108,6 +108,9 @@
 	qdel(src)
 
 /obj/structure/sign/poster/proc/roll_and_drop(loc)
+	if(ruined)
+		qdel(src)
+		return
 	pixel_x = 0
 	pixel_y = 0
 	var/obj/item/poster/P = new(loc, src)


### PR DESCRIPTION
This fixes #9376 which was caused by the posters `roll_and_drop()` being called after the poster was torn down - creating the hypothetical poster. It's now just deleted if the poster is ruined when `roll_and_drop()` is called.

🆑 Birdtalon
fix: Fixes torn down posters dropping hypothetical poster when their wall is deconstructed.
/🆑 