### PR TITLE
Allow cryo to fix all clone damage on limbs

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -123,7 +123,7 @@
 	..()
 	if(autoeject)
 		if(occupant)
-			if(!occupant.has_organic_damage())
+			if(!occupant.has_organic_damage() && !occupant.has_mutated_organs())
 				on = 0
 				go_out()
 				playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
@@ -367,7 +367,7 @@
 	if(air_contents.total_moles() < 10)
 		return
 	if(occupant)
-		if(occupant.stat == 2 || occupant.health >= 100)  //Why waste energy on dead or healthy people
+		if(occupant.stat == 2 || (occupant.health >= 100 && !occupant.has_mutated_organs()))  //Why waste energy on dead or healthy people
 			occupant.bodytemperature = T0C
 			return
 		occupant.bodytemperature += 2*(air_contents.temperature - occupant.bodytemperature)*current_heat_capacity/(current_heat_capacity + air_contents.heat_capacity())

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -78,6 +78,10 @@
 
 #undef STOMACH_ATTACK_DELAY
 
+/mob/living/carbon/proc/has_mutated_organs()
+	return FALSE
+
+
 /mob/living/carbon/proc/vomit(var/lost_nutrition = 10, var/blood = 0, var/stun = 1, var/distance = 0, var/message = 1)
 	if(src.is_muzzled())
 		if(message)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1768,6 +1768,12 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	else
 		return FALSE
 
+/mob/living/carbon/human/has_mutated_organs()
+	for(var/obj/item/organ/external/E in bodyparts)
+		if(E.status & ORGAN_MUTATED)
+			return TRUE
+	return FALSE
+
 /mob/living/carbon/human/InCritical()
 	return (health <= config.health_threshold_crit && stat == UNCONSCIOUS)
 


### PR DESCRIPTION
# Problem

When being healed by the cryo tubes, cryo tubes eject you even when you have mutated limbs just because you reached 100 health.

# Change
This PR adds an additional check to make sure none of your limbs are mutated before ejecting. 

# Reproduction

1. Use view variables to deal 5 clone damage to yourself until a bunch of your limbs are mutated
2. Set your health to 100
3. Use a cryo tube with cryoxadone and the correct temperature
4. You are ejected but your limbs still don't work


This happened to me after I spent a while as geneticist. I ended up with severe genetic damage but once healed I still couldn't use my hands.


:cl:
fix: Cryo now heals all your mutated limbs
/:cl: