### PR TITLE
Remove tech storage access from roboticists

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -96,8 +96,8 @@
 	supervisors = "the research director"
 	department_head = list("Research Director")
 	selection_color = "#ffeeff"
-	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
-	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research, access_maint_tunnels, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	access = list(access_robotics, access_tox, access_tox_storage, access_morgue, access_research, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	minimal_access = list(access_robotics, access_morgue, access_research, access_maint_tunnels, access_mineral_storeroom) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	alt_titles = list("Biomechanical Engineer","Mechatronic Engineer")
 	minimal_player_age = 3
 	exp_requirements = 180


### PR DESCRIPTION
Remove roboticist's tech storage access to prevent them stealing boards and insulated gloves. They really have no business doing that. Ask someone with more access.

🆑:
tweak: Roboticists no longer have tech storage access.
/🆑 