### PR TITLE
Add logging to borer infestation

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -363,7 +363,9 @@
 	if(M.has_brain_worms())
 		to_chat(src, "<span class='warning'>[M] is already infested!</span>")
 		return
+
 	host = M
+	add_attack_logs(src, host, "Infested as borer")
 	M.borer = src
 	forceMove(M)
 


### PR DESCRIPTION
Fixes #9355 

Add attack log when someone is infested by borer.

![image](https://user-images.githubusercontent.com/40092670/44467809-68c5ec80-a656-11e8-8ea2-bcaee2519e8b.png)


🆑:
add: Logging to borer infestation.
/🆑 