### PR TITLE
Stop implantcase from disappearing

### DIFF
--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -16,7 +16,7 @@
 	if(imp)
 		icon_state = "implantcase-[imp.item_color]"
 		origin_tech = imp.origin_tech
-		flags = imp.flags
+		flags = imp.flags & ~DROPDEL
 		reagents = imp.reagents
 	else
 		icon_state = "implantcase-0"


### PR DESCRIPTION
Fixes #8863 

When an implant case updates its icon, it inherit the implant's flags. This allows for it to inherit flag like OPENCONTAINER that is necessary for it to function properly when you need to inject chemical into a chemical implant.

Unfortunately all implant has the DROPDEL flag. That deletes it when dropped.

Negating the flag solves this issue.

🆑:
fix: Implantcase no longer disappears when dropped or placed in bag.
/🆑 