### PR TITLE
Adds support for Perfect Scaling on 4K Monitors

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1419,6 +1419,15 @@ menu "menu"
 		group = "size"
 		is-disabled = false
 		saved-params = "is-checked"
+	elem "icon128"
+		name = "&128x128 (4x)"
+		command = ".winset \"mapwindow.map.icon-size=128\""
+		category = "&Icons"
+		is-checked = false
+		can-check = true
+		group = "size"
+		is-disabled = false
+		saved-params = "is-checked"		
 	elem "icon96"
 		name = "&96x96 (3x)"
 		command = ".winset \"mapwindow.map.icon-size=96\""


### PR DESCRIPTION
Adds 128x128 icon size for the interface, which allows for perfect pixel scaling for monitors that are 4K.

Using stretch to fit will almost always generate distortions for the viewing area, at worst, and at best, make the image overly soft.

If you want crisp perfectly scaled pixels, you have to use an integer variations of 32x32. 64x64 *almost* fits perfectly on 1920x1080 (as the viewing area will be 960 x 960...reason it's not perfect is due to start menu and file menu window padding). 96x6 (1,440x1,440) fits easily on a 4K monitor, but the picture will be small.

Introducing 128x128 (1,920x1,920) will let you play with a sharp image that possesses zero distortion on a 4K monitor while taking up as much real-estate as possible.


Added because I know there's gotta be some 4K players out there.

:cl: Fox McCloud
add: adds support for 128x128 skin interface pixel size for 4K monitors
/:cl: