### PR TITLE
Adds the poison pen to the Librarian syndicate items

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -352,7 +352,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/pen/poison
 	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)
-	job = list("Head of Personnel", "Quartermaster", "Cargo Technician")
+	job = list("Head of Personnel", "Quartermaster", "Cargo Technician", "Librarian")
 
 
 // DANGEROUS WEAPONS


### PR DESCRIPTION
Adds the Librarian to the list of jobs that can buy the poison pen.

It fits the role, and I figure the librarian, as a role with no special access could use the love.

🆑:
tweak: Made the poison pen available to traitor librarians
/🆑