### PR TITLE
Makes punching / harm intent attack animations red

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -428,8 +428,11 @@
 	flick_overlay(I, viewing, 5) // 5 ticks/half a second
 
 	// And animate the attack!
-	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3)
-
-
+	var/t_color = "#ffffff"
+	if(ismob(src) &&  ismob(A) && (!used_item))
+		var/mob/M = src
+		t_color = M.a_intent == INTENT_HARM ? "#ff0000" : "#ffffff"
+	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3, color = t_color)
+	
 /atom/movable/proc/portal_destroyed(obj/effect/portal/P)
 	return


### PR DESCRIPTION
Big thanks to Tiger and Ansari for the help 

It makes punches / slashes / anything else on harm intent with one of these icons red. Disarms are still white

It doesn't make attacking with objects red

![jwfqtuj](https://i.gyazo.com/2ae1d6c7b04aed82516ebaa06bc91303.gif)

![jwfqtsuj](https://i.gyazo.com/c3c10e4400a41e14b23c1ba2d9ef322c.gif)

🆑 
tweak: Harm intent attack animations are red instead of white
/🆑 