### PR TITLE
Fixes criminal status sorting

### DIFF
--- a/nano/templates/secure_data.tmpl
+++ b/nano/templates/secure_data.tmpl
@@ -93,7 +93,7 @@ Used In File(s): \code\game\machinery\computer\security.dm
 							<th>{{:helper.link('ID', null, {'sort' : 'id'}, null, 'infoButton')}}</th>
 							<th>{{:helper.link('Rank', null, {'sort' : 'rank'}, null, 'infoButton')}}</th>
 							<th>{{:helper.link('Fingerprints', null, {'sort' : 'fingerprint'}, null, 'infoButton')}}</th>
-							<th>{{:helper.link('Criminal Status', null, {'sort' : 'name'}, null, 'infoButton')}}</th>
+							<th>{{:helper.link('Criminal Status', null, {'sort' : 'crimstat'}, null, 'infoButton')}}</th>
 						</tr>
 					</thead>
 					<tbody>


### PR DESCRIPTION
This fixes #9197 
was a simple copypasta issue.

![2018-08-28_17-38-34](https://user-images.githubusercontent.com/40092670/44715166-ab217a80-aae9-11e8-91df-4df60007296f.png)
🆑:
fix: Criminal status sorting now work properly instead of sorting by name.
/
🆑 