### PR TITLE
more consistent checks for dressing and undressing your boss

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -857,7 +857,7 @@ var/list/slot_equipment_priority = list( \
 		if(machine && in_range(src, usr))
 			show_inv(machine)
 
-	if(!usr.stat && usr.canmove && !usr.restrained() && in_range(src, usr))
+	if(!usr.incapacitated() && in_range(src, usr))
 		if(href_list["item"])
 			var/slot = text2num(href_list["item"])
 			var/obj/item/what = get_item_by_slot(slot)


### PR DESCRIPTION
Both putting items on people and taking them off gets this treatment.

all of these weird checks should probably be migrated to `incapacitated()`

fixes #9230 

:cl: Flatty
fix: You can now put items on people and take them off while you're riding that sweet, sweet wheelchair.
/:cl: