### PR TITLE
Ensure bola cannot snare anyone without enough legs

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -160,7 +160,7 @@
 	if(..() || !iscarbon(hit_atom))//if it gets caught or the target can't be cuffed,
 		return//abort
 	var/mob/living/carbon/C = hit_atom
-	if(!C.legcuffed)
+	if(!C.legcuffed && C.get_num_legs() >= 2)
 		visible_message("<span class='danger'>[src] ensnares [C]!</span>")
 		C.legcuffed = src
 		forceMove(C)


### PR DESCRIPTION
As per title. 

Fixes #8243

This add a check to bola that ensure they have enough legs before they get ensnared.

Notice that due to energy bola's special code, it still shows a message of "Triggers an energy snare". However they won't be bola'ed.

🆑:
fix: You cannot bola people without at least two legs (on them) anymore.
/🆑 