### PR TITLE
Vox nitrogen tanks now auto equip at spawn and almost never overwrite job items.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -92,12 +92,12 @@
 		internal_tank = new /obj/item/tank/nitrogen(H)
 	else
 		internal_tank = new /obj/item/tank/emergency_oxygen/vox(H)
-	if (!H.equip_to_appropriate_slot(internal_tank))
-		if (!H.put_in_any_hand_if_possible(internal_tank))
+	if(!H.equip_to_appropriate_slot(internal_tank))
+		if(!H.put_in_any_hand_if_possible(internal_tank))
 			H.unEquip(H.l_hand)
 			H.equip_or_collect(internal_tank, slot_l_hand)
 			to_chat(H, "<span class='boldannounce'>Could not find an empty slot for internals! Please report this as a bug</span>")
-	internal_tank.toggle_internals(H)
+	H.internal = internal_tank
 	to_chat(H, "<span class='notice'>You are now running on nitrogen internals from the [internal_tank]. Your species finds oxygen toxic, so you must breathe nitrogen only.</span>")
 	H.update_action_buttons_icon()
 

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -84,16 +84,21 @@
 /datum/species/vox/after_equip_job(datum/job/J, mob/living/carbon/human/H)
 	if(!H.mind || !H.mind.assigned_role || H.mind.assigned_role != "Clown" && H.mind.assigned_role != "Mime")
 		H.unEquip(H.wear_mask)
-	H.unEquip(H.l_hand)
 
 	H.equip_or_collect(new /obj/item/clothing/mask/breath/vox(H), slot_wear_mask)
 	var/tank_pref = H.client && H.client.prefs ? H.client.prefs.speciesprefs : null
+	var/obj/item/tank/internal_tank
 	if(tank_pref)//Diseasel, here you go
-		H.equip_or_collect(new /obj/item/tank/nitrogen(H), slot_l_hand)
+		internal_tank = new /obj/item/tank/nitrogen(H)
 	else
-		H.equip_or_collect(new /obj/item/tank/emergency_oxygen/vox(H), slot_l_hand)
-	to_chat(H, "<span class='notice'>You are now running on nitrogen internals from the [H.l_hand] in your hand. Your species finds oxygen toxic, so you must breathe nitrogen only.</span>")
-	H.internal = H.l_hand
+		internal_tank = new /obj/item/tank/emergency_oxygen/vox(H)
+	if (!H.equip_to_appropriate_slot(internal_tank))
+		if (!H.put_in_any_hand_if_possible(internal_tank))
+			H.unEquip(H.l_hand)
+			H.equip_or_collect(internal_tank, slot_l_hand)
+			to_chat(H, "<span class='boldannounce'>Could not find an empty slot for internals! Please report this as a bug</span>")
+	internal_tank.toggle_internals(H)
+	to_chat(H, "<span class='notice'>You are now running on nitrogen internals from the [internal_tank]. Your species finds oxygen toxic, so you must breathe nitrogen only.</span>")
 	H.update_action_buttons_icon()
 
 /datum/species/vox/on_species_gain(mob/living/carbon/human/H)


### PR DESCRIPTION
Fixes #9120
Edit: Likely also fixes #8615 (untested)
When spawning tries to put the nitrogen tank into a free slot, if that fails tries to put it into an empty hand, if that fails reverts to the old behavior and overwrites the item in the left hand.

:cl: uc_guy
tweak: Vox auto equip the nitrogen tank when spawning if possible.
fix: Nitrogen tanks no longer overwrite job items.
/:cl:
