### PR TITLE
Fixes #7089 - plus other bugs with spider obj attacks

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -29,16 +29,33 @@
 		visible_message("<span class='danger'>[user] has [pick(W.attack_verb)] [src] with [W]!</span>")
 	else
 		visible_message("<span class='danger'>[user] has attacked [src] with [W]!</span>")
-
 	var/damage = W.force / 4
-
 	if(iswelder(W))
 		var/obj/item/weldingtool/WT = W
-
 		if(WT.remove_fuel(0, user))
 			damage = 15
 			playsound(loc, WT.usesound, 100, 1)
+	user.changeNext_move(CLICK_CD_MELEE)
+	user.do_attack_animation(src)
+	health -= damage
+	healthcheck()
 
+/obj/structure/spider/attack_animal(mob/living/simple_animal/M)
+	if(M.melee_damage_upper == 0)
+		return
+	var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
+	M.changeNext_move(CLICK_CD_MELEE)
+	M.do_attack_animation(src)
+	visible_message("<span class='danger'>\The [M] [M.attacktext] [src]!</span>")
+	health -= damage
+	healthcheck()
+
+/obj/structure/spider/attack_alien(mob/living/carbon/alien/humanoid/M)
+	playsound(loc, 'sound/weapons/slash.ogg', 25, 1, -1)
+	visible_message("<span class='danger'>[M] has slashed at [src]!</span>", "<span class='userdanger'>[M] has slashed at [src]!</span>")
+	M.changeNext_move(CLICK_CD_MELEE)
+	M.do_attack_animation(src)
+	var/damage = rand(10, 20)
 	health -= damage
 	healthcheck()
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -171,8 +171,8 @@ var/global/list/ts_spiderling_list = list()
 			visible_message("<span class='notice'>[src] harmlessly nuzzles [target].</span>")
 		T.CheckFaction()
 		CheckFaction()
-	else if(istype(target, /obj/structure/spider/cocoon))
-		to_chat(src, "Destroying our own cocoons would not help us.")
+	else if(istype(target, /obj/structure/spider)) // Prevents destroying coccoons (exploit), eggs (horrible misclick), etc
+		to_chat(src, "Destroying things created by fellow spiders would not help us.")
 	else if(istype(target, /obj/machinery/door/firedoor))
 		var/obj/machinery/door/firedoor/F = target
 		if(F.density)


### PR DESCRIPTION
🆑 Kyep
fix: Fixed various bugs with spider structures (webs, cocoons, etc), such as them not triggering attack animations, not respecting melee cooldowns, being invulnerable to simple_animals and aliens, etc.
/🆑

Attacking spider structures (webs, eggs, cocoons, etc) has had several bugs fixed:
- Attack animations are now shown
- Melee cooldown is now respected on attacks (no more macro'ed spam attacks)
- Simple_animals and carbon xenos can now attack them

Caveats:
- Terror spiders retain their old behavior of not being able to attack any spider structures, partly for exploit prevention reasons (destroy cocoons+ reweb target = exploit gaining you infinite regen points), partly to prevent fatal misclicks (green terror destroys eggs with a misclick) and partly to retain old balance (spiders with special webs cannot destroy normal webs to put up their special webs, which are stronger).
- Humans retain the old behavior of not being able to use unarmed attacks against spider structures, partly because it would often be stupid (punch web = get stuck in web, punch egg = spiderlings all over your hands, etc), partly because it would be too gross for humans to want to do, and partly for balance reasons (some sort of object should be required to destroy them).