### PR TITLE
Gateway now also checks for exile implants in buckled mobs.

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -96,9 +96,12 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 
 /obj/machinery/gateway/centerstation/proc/toggleon(mob/user as mob)
-	if(!ready)			return
-	if(linked.len != 8)	return
-	if(!powered())		return
+	if(!ready)
+		return
+	if(linked.len != 8)
+		return
+	if(!powered())
+		return
 	if(!awaygate)
 		awaygate = locate(/obj/machinery/gateway/centeraway) in world
 		if(!awaygate)
@@ -135,9 +138,12 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 //okay, here's the good teleporting stuff
 /obj/machinery/gateway/centerstation/Bumped(atom/movable/M as mob|obj)
-	if(!ready)		return
-	if(!active)		return
-	if(!awaygate)	return
+	if(!ready)
+		return
+	if(!active)
+		return
+	if(!awaygate)
+		return
 
 	if(awaygate.calibrated)
 		M.forceMove(get_step(awaygate.loc, SOUTH))
@@ -207,8 +213,10 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 
 /obj/machinery/gateway/centeraway/proc/toggleon(mob/user as mob)
-	if(!ready)			return
-	if(linked.len != 8)	return
+	if(!ready)
+		return
+	if(linked.len != 8)
+		return
 	if(!stationgate)
 		stationgate = locate(/obj/machinery/gateway/centerstation) in world
 		if(!stationgate)
@@ -241,15 +249,20 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 
 
 /obj/machinery/gateway/centeraway/Bumped(atom/movable/M as mob|obj)
-	if(!ready)	return
-	if(!active)	return
+	if(!ready)
+		return
+	if(!active)
+		return
 	if(istype(M, /mob/living/carbon))
-		if(exilecheck(M)) return
+		if(exilecheck(M))
+			return
 	if(istype(M, /obj))
 		if(M.can_buckle && M.has_buckled_mobs())
-			if(exilecheck(M.buckled_mob)) return
+			if(exilecheck(M.buckled_mob))
+				return
 		for(var/mob/living/carbon/F in M)
-			if(exilecheck(F)) return
+			if(exilecheck(F))
+				return
 	M.forceMove(get_step(stationgate.loc, SOUTH))
 	M.dir = SOUTH
 

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -246,6 +246,8 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 	if(istype(M, /mob/living/carbon))
 		if(exilecheck(M)) return
 	if(istype(M, /obj))
+		if(M.can_buckle && M.has_buckled_mobs())
+			if(exilecheck(M.buckled_mob)) return
 		for(var/mob/living/carbon/F in M)
 			if(exilecheck(F)) return
 	M.forceMove(get_step(stationgate.loc, SOUTH))


### PR DESCRIPTION
Fixes #9402

:cl: uc_guy
fix: Fixed exploit that allowed exiled mobs to return to the station
/:cl: