### PR TITLE
Fixes wire cutting runtime and two potential key_name runtime

### DIFF
--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -7,7 +7,7 @@
 
 /proc/key_name_helper(whom, include_name, include_link = FALSE, type = null)
 	if(include_link != FALSE && include_link != TRUE)
-		log_runtime(EXCEPTION("Key_name was called with an incorrect include_link [include_link]"))
+		log_runtime(EXCEPTION("Key_name was called with an incorrect include_link [include_link]"), src)
 
 	var/mob/M
 	var/client/C

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -151,7 +151,7 @@ By design, d1 is the smallest direction and d2 is the highest
 						if(c.d1 == 12 || c.d2 == 12)
 							c.qdel()*/
 ///// Z-Level Stuff
-		investigate_log("was cut by [key_name(usr, usr.client)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
+		investigate_log("was cut by [key_name(usr, 1)] in [get_area(user)]([T.x], [T.y], [T.z] - [ADMIN_JMP(T)])","wires")
 
 		qdel(src) // qdel
 		return

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -426,7 +426,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				var/key = usr.key	//so we don't lose the info during the spawn delay
 				if(!(being_built.build_type & PROTOLATHE))
 					g2g = 0
-					message_admins("Protolathe exploit attempted by [key_name(usr, usr.client)]!")
+					message_admins("Protolathe exploit attempted by [key_name(usr, TRUE)]!")
 
 				if(g2g) //If input is incorrect, nothing happens
 					var/new_coeff = coeff * being_built.lathe_time_factor
@@ -502,7 +502,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				power = max(2000, power)
 				if(!(being_built.build_type & IMPRINTER))
 					g2g = 0
-					message_admins("Circuit imprinter exploit attempted by [key_name(usr, usr.client)]!")
+					message_admins("Circuit imprinter exploit attempted by [key_name(usr, TRUE)]!")
 
 				if(g2g) //Again, if input is wrong, do nothing
 					add_wait_message("Imprinting Circuit. Please Wait...", IMPRINTER_DELAY)


### PR DESCRIPTION
This fixes a runtime caused by cutting wires. The usr's client were being passed into what is supposed to be a boolean parameter.

This also fixes two instances of the same error I spotted in rd console's code while looking for the cause of the error.

🆑:
fix: Cutting wires shouldn't cause a runtime error anymore.
/🆑 