### PR TITLE
Fixes paper bundle runtimes

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -316,7 +316,7 @@
 				to_chat(user, "<span class='notice'>Take off the carbon copy first.</span>")
 				add_fingerprint(user)
 				return
-		var/obj/item/paper_bundle/B = new(src.loc)
+		var/obj/item/paper_bundle/B = new(src.loc, default_papers = FALSE)
 		if(name != "paper")
 			B.name = name
 		else if(P.name != "paper" && P.name != "photo")

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -11,11 +11,15 @@
 	layer = 4
 	pressure_resistance = 1
 	attack_verb = list("bapped")
-	var/amount = 0 //Amount of items clipped to the paper
+	var/amount = 0 //Amount of items clipped to the paper. Note: If you have 2 paper, this should be 1
 	var/page = 1
 	var/screen = 0
 
-
+/obj/item/paper_bundle/New(default_papers = TRUE)
+	if(default_papers) // This is to avoid runtime occuring from a paper bundle being created without a paper in it.
+		new /obj/item/paper(src)
+		new /obj/item/paper(src)
+		amount += 1
 /obj/item/paper_bundle/attackby(obj/item/W as obj, mob/user as mob, params)
 	..()
 	var/obj/item/paper/P

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -74,7 +74,7 @@
 			else if(istype(copyitem, /obj/item/paper_bundle))
 				var/obj/item/paper_bundle/C = copyitem
 				if(toner < (C.amount + 1))
-					visible_message("<span class='notice'>A yellow light on \the [src] flashes, indicating there's not enough toner for the operation.</span>") // It is better to prevent partial bundle than to produce broken paper bundle
+					visible_message("<span class='notice'>A yellow light on [src] flashes, indicating there's not enough toner for the operation.</span>") // It is better to prevent partial bundle than to produce broken paper bundle
 					return
 				var/obj/item/paper_bundle/B = bundlecopy(copyitem)
 				if(!B)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -73,8 +73,10 @@
 				sleep(15)
 			else if(istype(copyitem, /obj/item/paper_bundle))
 				var/obj/item/paper_bundle/B = bundlecopy(copyitem)
+				if(!B)
+					return
 				sleep(15*B.amount)
-			else if(ass && ass.loc == src.loc)
+			else if(ass && ass.loc == loc)
 				copyass()
 				sleep(15)
 			else
@@ -287,7 +289,7 @@
 
 //If need_toner is 0, the copies will still be lightened when low on toner, however it will not be prevented from printing. TODO: Implement print queues for fax machines and get rid of need_toner
 /obj/machinery/photocopier/proc/bundlecopy(var/obj/item/paper_bundle/bundle, var/need_toner=1)
-	var/obj/item/paper_bundle/p = new /obj/item/paper_bundle (src)
+	var/obj/item/paper_bundle/P = new /obj/item/paper_bundle (src, default_papers = FALSE)
 	for(var/obj/item/W in bundle)
 		if(toner <= 0 && need_toner)
 			toner = 0
@@ -298,16 +300,19 @@
 			W = copy(W)
 		else if(istype(W, /obj/item/photo))
 			W = photocopy(W)
-		W.forceMove(p)
-		p.amount++
-	p.amount--
-	p.forceMove(get_turf(src))
-	p.update_icon()
-	p.icon_state = "paper_words"
-	p.name = bundle.name
-	p.pixel_y = rand(-8, 8)
-	p.pixel_x = rand(-9, 9)
-	return p
+		W.forceMove(P)
+		P.amount++
+	if(!P.amount)
+		qdel(P)
+		return null
+	P.amount--
+	P.forceMove(get_turf(src))
+	P.update_icon()
+	P.icon_state = "paper_words"
+	P.name = bundle.name
+	P.pixel_y = rand(-8, 8)
+	P.pixel_x = rand(-9, 9)
+	return P
 
 
 /obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -72,6 +72,10 @@
 				photocopy(copyitem)
 				sleep(15)
 			else if(istype(copyitem, /obj/item/paper_bundle))
+				var/obj/item/paper_bundle/C = copyitem
+				if(toner < (C.amount + 1))
+					visible_message("<span class='notice'>A yellow light on \the [src] flashes, indicating there's not enough toner for the operation.</span>") // It is better to prevent partial bundle than to produce broken paper bundle
+					return
 				var/obj/item/paper_bundle/B = bundlecopy(copyitem)
 				if(!B)
 					return


### PR DESCRIPTION
This fixes a paper bundle runtime. This is caused by attempting to show the paper's content when there's no paper in it.

There's also some minor refactoring.

There's now a default parameter in paper bundle's construct (that defaults to TRUE but is overridden to FALSE in two cases). A new paper bundle will come with two piece of paper by default. This avoid paper bundle created by create_object causing runtime.

Also, the photocopier will delete any paper bundle that somehow manage to end up with zero amount. It also has a safety check - It will no longer print out partial paper bundle, preferring to not print them out at all if there's more paper in the bundle than toners. This should prevent a case where a paper bundle is created with only one paper.  (The other alternative solution would be printing out a single paper in that case, but it is a bit too complicated at the moment and veer into the territory of feature)

Fixes #8408

🆑:
fix: A runtime that occurs with paper bundle being created with one or less paper.
/🆑 
