### PR TITLE
icon scaling settings

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1401,69 +1401,85 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Icons"
 		command = ""
-		category = ""
-		is-checked = false
-		can-check = false
-		group = ""
-		is-disabled = false
+		saved-params = "is-checked"
+	elem 
+		name = "&Size"
+		command = ""
+		category = "&Icons"
 		saved-params = "is-checked"
 	elem "stretch"
 		name = "&Stretch to fit"
 		command = ".winset \"mapwindow.map.icon-size=0\""
-		category = "&Icons"
+		category = "&Size"
 		is-checked = true
 		can-check = true
 		group = "size"
-		is-disabled = false
 		saved-params = "is-checked"
 	elem "icon96"
 		name = "&96x96 (3x)"
 		command = ".winset \"mapwindow.map.icon-size=96\""
-		category = "&Icons"
-		is-checked = false
+		category = "&Size"
 		can-check = true
 		group = "size"
-		is-disabled = false
 		saved-params = "is-checked"
 	elem "icon64"
 		name = "&64x64 (2x)"
 		command = ".winset \"mapwindow.map.icon-size=64\""
-		category = "&Icons"
-		is-checked = false
+		category = "&Size"
 		can-check = true
 		group = "size"
-		is-disabled = false
 		saved-params = "is-checked"
 	elem "icon48"
 		name = "&48x48 (1.5x)"
 		command = ".winset \"mapwindow.map.icon-size=48\""
-		category = "&Icons"
-		is-checked = false
+		category = "&Size"
 		can-check = true
 		group = "size"
-		is-disabled = false
 		saved-params = "is-checked"
 	elem "icon32"
 		name = "&32x32"
 		command = ".winset \"mapwindow.map.icon-size=32\""
-		category = "&Icons"
-		is-checked = false
+		category = "&Size"
 		can-check = true
 		group = "size"
-		is-disabled = false
+		saved-params = "is-checked"
+	elem 
+		name = "&Scaling"
+		command = ""
+		category = "&Icons"
+		saved-params = "is-checked"
+	elem "NN"
+		name = "&Nearest Neighbor"
+		command = ".winset \"mapwindow.map.zoom-mode=distort\""
+		category = "&Scaling"
+		can-check = true
+		group = "scale"
+		saved-params = "is-checked"
+	elem "PS"
+		name = "&Point Sampling"
+		command = ".winset \"mapwindow.map.zoom-mode=normal\""
+		category = "&Scaling"
+		can-check = true
+		group = "scale"
+		saved-params = "is-checked"
+	elem "BL"
+		name = "&Bilinear"
+		command = ".winset \"mapwindow.map.zoom-mode=blur\""
+		category = "&Scaling"
+		can-check = true
+		group = "scale"
 		saved-params = "is-checked"
 	elem "textmode"
 		name = "&Text"
 		command = ".winset \"menu.textmode.is-checked=true?mapwindow.map.text-mode=true:mapwindow.map.text-mode=false\""
 		category = "&Icons"
-		is-checked = false
 		can-check = true
 		group = ""
-		is-disabled = false
 		saved-params = "is-checked"
+
 	elem
 		name = "&Help"
 		command = ""


### PR DESCRIPTION
I have three merged fixes. I won't ask Crazylemon whether they're okay, I'll instead make a PR and guilt-trip him into not closing it. (pls)

![2018-08-29_17-43-56](https://user-images.githubusercontent.com/15747030/44799088-68c47000-abb3-11e8-9b9f-780bf2f5fccb.gif)

Adds icon scaling settings! Completely undocumented in the reference, but they work, I swear. Look at the gif.

:cl: Flatty
add: Icons scaling settings! No longer are we slaves to Nearest-Neighbor scaling! We have nothing to lose but our poorly-aging scaling algorithms! Click the "icons" button on top left.
/:cl:

These help a ton if you have a screen that doesn't fit the exact size of a 64x64 window and you don't want to roll with the ugly Nearest-Neighbor thing.

Also, the "text" icon mode isn't my doing. I'd rip it out, but that's not what the PR is for.