### PR TITLE
Fixes depot armory Initialize() bug

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -211,12 +211,13 @@
 	alert_on_shield_breach = TRUE
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/Initialize()
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory/LateInitialize()
 	if(istype(depotarea))
 		var/list/key_candidates = list()
 		for(var/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/officer/O in living_mob_list)
-			if(O == src)
-				continue
 			key_candidates += O
 		if(key_candidates.len)
 			var/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/officer/O = pick(key_candidates)


### PR DESCRIPTION
🆑 Kyep
fix: Fixed depot armory shield key not being properly randomized.
/🆑

Details:
- The armory boss (/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory) is meant to randomly choose a depot officer to hold the key each round.
- Unfortunately, he makes this choice in Initialize(), and at that point, not all of the officers have been added to living_mob_list yet. So, his selection is limited to the officers who have been initialized before he was. Since most typically aren't, this bug turns an assignment that was meant to be entirely random, into a fairly predictable pattern. In each specific round, it looks fine, but if you look at which officer gets the key and which don't over a bunch of rounds, you will start to see the pattern, and be able to make accurate predictions based on it.
- That pattern is bad, because anyone who recognizes it can use it to metagame the depot. It also rewards people who learn a 'correct' path through the depot and stick to it, rather than varying their approach each time, which is what the design was meant to reward.

This PR fixes the problem by having the boss assign the key in LateInitialize(), which ensures he will fairly distribute the key randomly among his officers.

This PR also removes an obsolete "if(O == src)" check. That check is now redundant, because /mob/.../depot/armory is no longer a subtype of /mob/.../depot/officer, and so will not show up in the list of mobs in "for(var/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/officer/O in living_mob_list)". Since it can't possibly be there, the check is now redundant, and has been removed.
