### PR TITLE
Allow mute characters to wave again

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -36,7 +36,7 @@
 		var/obj/item/clothing/mask/muzzle/M = wear_mask
 		if(m_type == EMOTE_SOUND && M.mute >= MUZZLE_MUTE_MUFFLE)
 			return //Not all muzzles block sound
-	if(!can_speak())
+	if(m_type == EMOTE_SOUND && !can_speak())
 		return
 
 	var/input


### PR DESCRIPTION
🆑 Alffd
fix: Fix emote check of can_speak() to only return if the emote produces sound.
/ 🆑 