### PR TITLE
Fixes math error with mime forcewall

### DIFF
--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -17,16 +17,9 @@
 	icon_state = "empty"
 	name = "invisible wall"
 	desc = "You have a bad feeling about this."
-	var/timeleft = 300
-	var/last_process = 0
+	var/lifetime = 30 SECONDS
 
 /obj/effect/forcefield/mime/New()
 	..()
-	last_process = world.time
-	processing_objects.Add(src)
-
-/obj/effect/forcefield/mime/process()
-	timeleft -= (world.time - last_process)
-	if(timeleft <= 0)
-		processing_objects.Remove(src)
-		qdel(src)
+	if(lifetime)
+		QDEL_IN(src, lifetime)


### PR DESCRIPTION
Fixes #3981

This refactors 300 to 30 SECONDS for consistency sake, and also fixes an error that led to forcewall's time becoming 1/3 of what it should be. Because last_process wasn't updated, instead of timeleft being decreased by 20 constantly every process tick, instead it decreased by 20 + 20n where n is the number of process tick since elapsed.

Which means a sequence of timeleft:
> 300 - 280 - 260 - 240 - 220 - 200 - 180 - 160 - 140 - 120 - 100 - 80 - 60 - 40 - 20 - 0
got turned into
> 300 - 280 - 240 - 180 - 100 - 0 
Resulting in the amount of time decreasing to roughly 10 seconds.

🆑:
fix: Mime forcewall now properly last for 30 seconds instead of 10.
/🆑 