### PR TITLE
Fix hyposprays not spreading viruses

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -34,6 +34,8 @@
 				injected += R.name
 
 			var/primary_reagent_name = reagents.get_master_reagent_name()
+			var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
+			reagents.reaction(M, INGEST, fraction)
 			var/trans = reagents.trans_to(M, amount_per_transfer_from_this)
 
 			if(safety_hypo)


### PR DESCRIPTION
This PR adds reaction to blood injection from hypospray, letting you spread viruses (and I believe vaccines) with them.

Things that transmit blood but not viruses and should : 

Hypospray : Fixed by this PR
Sleepy pen : Not functional
Syringe gun : Not functional
Blood smoke : Not functional

I'd like to fix all of these, but it seems fixing those is more difficult as they are not reagent containers subtypes like syringe/hypospray. If you know how to fix, let me know, please!

🆑:
fix: Fixed hypospray not spreading viruses.
/🆑