### PR TITLE
Reduces metal return for ammo boxes

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -85,7 +85,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	item_state = "syringe_kit"
-	materials = list(MAT_METAL = 2000)
+	materials = list(MAT_METAL = 30000)
 	throwforce = 2
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 4
@@ -96,11 +96,14 @@
 	var/multiple_sprites = 0
 	var/caliber
 	var/multiload = 1
+	var/list/initial_mats //For calculating refund values.
 
 /obj/item/ammo_box/New()
 	for(var/i in 1 to max_ammo)
 		stored_ammo += new ammo_type(src)
 	update_icon()
+	initial_mats = materials.Copy()
+	update_mat_value()
 
 /obj/item/ammo_box/Destroy()
 	QDEL_LIST(stored_ammo)
@@ -115,6 +118,7 @@
 		stored_ammo -= b
 		if(keep)
 			stored_ammo.Insert(1,b)
+		update_mat_value()
 		return b
 
 /obj/item/ammo_box/proc/give_round(obj/item/ammo_casing/R, replace_spent = 0)
@@ -125,6 +129,7 @@
 	if(stored_ammo.len < max_ammo)
 		stored_ammo += R
 		R.loc = src
+		update_mat_value()
 		return 1
 	//for accessibles magazines (e.g internal ones) when full, start replacing spent ammo
 	else if(replace_spent)
@@ -135,6 +140,7 @@
 
 				stored_ammo += R
 				R.loc = src
+				update_mat_value()
 				return 1
 
 	return 0
@@ -183,6 +189,19 @@
 		if(2)
 			icon_state = "[initial(icon_state)]-[stored_ammo.len ? "[max_ammo]" : "0"]"
 	desc = "[initial(desc)] There are [stored_ammo.len] shell\s left!"
+
+/obj/item/ammo_box/proc/update_mat_value()
+	var/num_ammo = 0
+	for(var/B in stored_ammo)
+		var/obj/item/ammo_casing/AC = B
+		if(!AC.BB) //Skip any casing which are empty
+			continue
+		num_ammo++
+	for(var/M in initial_mats) //In case we have multiple types of materials
+		var/materials_per = initial_mats[M] / max_ammo
+		
+		var/value = max(materials_per * num_ammo, 2000) //Enforce a minimum of 2000 units even if empty.
+		materials[M] = value
 
 //Behavior for magazines
 /obj/item/ammo_box/magazine/proc/ammo_count()

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -85,7 +85,7 @@
 	flags = CONDUCT
 	slot_flags = SLOT_BELT
 	item_state = "syringe_kit"
-	materials = list(MAT_METAL=30000)
+	materials = list(MAT_METAL = 2000)
 	throwforce = 2
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 4


### PR DESCRIPTION
The simplest solution tends to be the best. Reduces metal return for ammo boxes. Ammo boxes now return metal scaled to the number of bullets in the box instead of a flat 30,000 when recycling. Preventing creation of infinite ammo.

Fixes #8232

🆑 Birdtalon
fix: Ammo boxes now return materials proportional to their contents when recycling, nullifying infinite ammo exploit.
/🆑 