### PR TITLE
All injection methods + smoke nades now transfer virusses and vaccines.

### DIFF
--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -280,6 +280,7 @@
 		if(iscarbon(A))
 			var/mob/living/carbon/C = A
 			if(C.can_breathe_gas())
+				chemholder.reagents.reaction(C, INGEST)//React with the living, transfers virusses and vaccines alike
 				chemholder.reagents.copy_to(C, chemholder.reagents.total_volume)
 	qdel(smokeholder)
 	for(var/i=0, i<number, i++)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -133,6 +133,7 @@
 	if(..())
 		if(reagents.total_volume)
 			if(M.reagents)
+				reagents.reaction(M, INGEST)//React with the living, transfers virusses and vaccines alike
 				reagents.trans_to(M, 50)
 
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -250,6 +250,7 @@
 		if(blocked != 100)
 			if(M.can_inject(null,0,hit_zone)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
+				reagents.reaction(M, INGEST)// React with the living, transfers virusses and vaccines alike
 				reagents.trans_to(M, reagents.total_volume)
 				return 1
 			else

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -34,6 +34,7 @@
 				injected += R.name
 
 			var/primary_reagent_name = reagents.get_master_reagent_name()
+			reagents.reaction(M, INGEST)
 			var/trans = reagents.trans_to(M, amount_per_transfer_from_this)
 
 			if(safety_hypo)


### PR DESCRIPTION
This PR makes it so that virusses and vaccines will be transmittable using Hypo's, syringe guns, sleepy pens and smoke grenades. 
All ways are tested and will transmit the virus as if using a syringe. Normal chemicals should all react normally with this change.

Credit to @datlo for helping and creating part of this fix.

🆑:
fix: Fixed hypospray, syringe guns, sleepy pens and smoking grenades not spreading virusses/vaccines.
/🆑