### PR TITLE
Lets you remove KA mods from borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -653,14 +653,12 @@ var/list/robot_verbs_default = list(
 					var/datum/robot_component/C = components[V]
 					if(C.installed == 1 || C.installed == -1)
 						removable_components += V
-				if(src.module && istype(src.module, /obj/item/robot_module/miner))
-					removable_components += "KA modkits"
+				if(module && istype(src.module, /obj/item/robot_module/miner))
+					removable_components += module.custom_removals
 				var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
 				if(!remove)
 					return
-				if(remove == "KA modkits")
-					for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/D in src.module.modules)
-						D.attackby(W, user, params)
+				if(module.handle_custom_removal(remove, user, W, params))
 					return
 				var/datum/robot_component/C = components[remove]
 				var/obj/item/robot_parts/robot_component/I = C.wrapped

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -653,9 +653,14 @@ var/list/robot_verbs_default = list(
 					var/datum/robot_component/C = components[V]
 					if(C.installed == 1 || C.installed == -1)
 						removable_components += V
-
+				if(src.module && istype(src.module, /obj/item/robot_module/miner))
+					removable_components += "KA modkits"
 				var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
 				if(!remove)
+					return
+				if(remove == "KA modkits")
+					for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/D in src.module.modules)
+						D.attackby(W, user, params)
 					return
 				var/datum/robot_component/C = components[remove]
 				var/obj/item/robot_parts/robot_component/I = C.wrapped

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -15,6 +15,7 @@
 
 	var/list/stacktypes
 	var/channels = list()
+	var/list/custom_removals = list()
 
 
 /obj/item/robot_module/emp_act(severity)
@@ -102,6 +103,10 @@
 		A.Remove(R)
 		qdel(A)
 	R.module_actions.Cut()
+
+// Return true in an overridden subtype to prevent normal removal handling
+/obj/item/robot_module/proc/handle_custom_removal(component_id, mob/living/user, obj/item/W, params)
+    return FALSE
 
 /obj/item/robot_module/standard
 	name = "standard robot module"
@@ -325,6 +330,7 @@
 	module_actions = list(
 		/datum/action/innate/robot_sight/meson,
 	)
+	custom_removals = list("KA modkits")
 
 /obj/item/robot_module/miner/New()
 	..()
@@ -340,6 +346,13 @@
 	emag = new /obj/item/borg/stun(src)
 
 	fix_modules()
+
+/obj/item/robot_module/miner/handle_custom_removal(component_id, mob/living/user, obj/item/W, params)
+    if(component_id == "KA modkits")
+        for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/D in src)
+            D.attackby(W, user, params)
+        return TRUE
+    return ..()
 
 /obj/item/robot_module/deathsquad
 	name = "NT advanced combat module"


### PR DESCRIPTION
You can now remove KA mods from borgs. This fixes #8227 in a way. To remove the KA mods, you need to open the borg, remove the battery, then apply crowbar to the borg, just like you are removing a component, then select KA mods. 

🆑 Shazbot
fix: You can now remove KA mods from borgs.
/🆑 