### PR TITLE
Syndicate Suit Tail Fix

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -313,7 +313,7 @@
 	on = 1
 	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
 	flags = BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL
-	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE
+	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDETAIL
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
@@ -379,7 +379,7 @@
 		desc = "A dual-mode advanced hardsuit designed for work in special operations. It is in travel mode. Property of Gorlex Marauders."
 		slowdown = 1
 		flags = STOPSPRESSUREDMAGE | THICKMATERIAL
-		flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
+		flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 		cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	else
 		to_chat(user, "<span class='notice'>You switch your hardsuit to combat mode. You will take damage in zero pressure environments, but you are more suited for a fight.</span>")


### PR DESCRIPTION
This adds the HIDETAIL var to syndicate hardsuits so things like this don't happen.
![image](https://user-images.githubusercontent.com/15992551/44942612-9a336c00-ad6a-11e8-8445-2f00befb034b.png)
This visual error _probably_ exists on other hardsuits, and I'll be rolling through adding the var to suits with species fits wherein an alternate tail type would cause similar errors (in a different PR).