### PR TITLE
Fix plasmamen wizard space suit to let them cast spells

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -146,7 +146,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 		if(!istype(H.shoes, /obj/item/clothing/shoes/sandal))
 			to_chat(user, "<span class='notice'>I don't feel strong enough without my sandals.</span>")
 			return 0
-		if(!istype(H.head, /obj/item/clothing/head/wizard) && !istype(H.head, /obj/item/clothing/head/helmet/space/hardsuit/wizard) && !istype(H.wear_suit, /obj/item/clothing/head/helmet/space/eva/plasmaman/wizard))
+		if(!istype(H.head, /obj/item/clothing/head/wizard) && !istype(H.head, /obj/item/clothing/head/helmet/space/hardsuit/wizard) && !istype(H.head, /obj/item/clothing/head/helmet/space/eva/plasmaman/wizard))
 			to_chat(user, "<span class='notice'>I don't feel strong enough without my hat.</span>")
 			return 0
 	else if(!ishuman(user))


### PR DESCRIPTION
See #8679 

Problem: Plasmamen need space suits to survive, so when they are wizard they get wizard space suit, but it's not letting them cast spells

There was just a typo in a condition check. Tested and works

:cl:
fix: Fixes Plasmamen wizards not counting as fully garbed
/:cl: