### PR TITLE
Prevent rev victory from happening instantly

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -306,7 +306,7 @@
 			if(!(objective.check_completion()))
 				return 0
 
-		return 1
+	return 1
 
 /////////////////////////////
 //Checks for a head victory//


### PR DESCRIPTION
See #9466

Typo in a loop, so if there are any revs at all they always win.

I don't know how to test this. How do I start a custom gamemode? I looked at all the menu options as server operator 😕 

:cl:
fix: Prevent instant rev victory in rev gamemode
/:cl: