### PR TITLE
Fixes hivelord stabilizer

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/hivelord.dm
@@ -65,10 +65,12 @@
 	addtimer(CALLBACK(src, .proc/inert_check), 2400)
 
 /obj/item/organ/internal/hivelord_core/proc/inert_check()
-	if(!owner && !preserved)
-		go_inert()
-	else
+	if(owner)
 		preserved(implanted = 1)
+	else if(preserved)
+		preserved()
+	else
+		go_inert()
 
 /obj/item/organ/internal/hivelord_core/proc/preserved(implanted = 0)
 	inert = FALSE


### PR DESCRIPTION
Fixes #8354 

The check required a hivelord remain to be implanted **and** preserved. Which doesn't really make sense. Judging by how the preserved proc is implemented, it is meant to be preserved by being implanted **or** stabilized.

This fixes it.

🆑:
fix: Hivelord remains can be stabilized by being implanted **or** preserved (Both is also ok). Instead of and. 
/🆑 