### PR TITLE
Disables lichdom on Ragin' mages

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -220,6 +220,14 @@
 	log_name = "LD"
 	category = "Defensive"
 
+/datum/spellbook_entry/lichdom/IsAvailible()
+	if(!ticker.mode) // In case spellbook is placed on map
+		return 0
+	if(ticker.mode.name == "ragin' mages")
+		return 0
+	else
+		return 1
+
 /datum/spellbook_entry/lightningbolt
 	name = "Lightning Bolt"
 	spell_type = /obj/effect/proc_holder/spell/targeted/lightning


### PR DESCRIPTION
Fixes #8278

Lichdom doesn't work on raging mages because wizards are gibbed on
death. While lichdom has perks other than reviving, it is its main
feature.

Disabling the spell is IMO the cleanest way to prevent major salt
without altering balance... as far as balance goes during raging mages
anyway. 

This'd be the third spell disabled during raging, after summon magic and guns.

🆑:
fix: Disabled lichdom during raging mages due to reviving being impossible in that gamemode.
/🆑