### PR TITLE
Fixes #8071, prevents move swapping into anchored AI

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -89,7 +89,7 @@
 		else if((M.restrained() || M.a_intent == INTENT_HELP) && (restrained() || a_intent == INTENT_HELP))
 			mob_swap = 1
 		//the AI is not supposed to move without being pulled, unanchor and drag it
-		if (M.type == /mob/living/silicon/ai)
+		if(istype(M, /mob/living/silicon/ai))
 			mob_swap = 0
 		if(mob_swap)
 			//switch our position with M

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -88,6 +88,9 @@
 		//restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
 		else if((M.restrained() || M.a_intent == INTENT_HELP) && (restrained() || a_intent == INTENT_HELP))
 			mob_swap = 1
+		//the AI is not supposed to move without being pulled, unanchor and drag it
+		if (M.type == /mob/living/silicon/ai)
+			mob_swap = 0
 		if(mob_swap)
 			//switch our position with M
 			if(loc && !loc.Adjacent(M.loc))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -88,8 +88,8 @@
 		//restrained people act if they were on 'help' intent to prevent a person being pulled from being seperated from their puller
 		else if((M.restrained() || M.a_intent == INTENT_HELP) && (restrained() || a_intent == INTENT_HELP))
 			mob_swap = 1
-		//the AI is not supposed to move without being pulled, unanchor and drag it
-		if(istype(M, /mob/living/silicon/ai))
+		//anchored mobs are not supposed to move
+		if(M.anchored == 1)
 			mob_swap = 0
 		if(mob_swap)
 			//switch our position with M


### PR DESCRIPTION
Fixes #8071

The AI can be move swapped into on help intent like any other mobs even when it's unanchored and supposed not to be able to be moved, this adds a check for anchored when bumping

🆑:
fix: Made the AI impossible to move swap into on help intent.
/🆑