### PR TITLE
Blob fixes, including biohazard warning fix and storage blob fix #9365

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -121,3 +121,16 @@
 			spawn(0)
 				if(is_offspring)
 					B.verbs -= /mob/camera/blob/verb/split_consciousness
+
+/obj/structure/blob/core/proc/lateblobtimer()
+	addtimer(CALLBACK(src, .proc/lateblobcheck), 50)
+
+/obj/structure/blob/core/proc/lateblobcheck()
+	if(overmind)
+		overmind.add_points(60)
+		if(overmind.mind)
+			overmind.mind.special_role = SPECIAL_ROLE_BLOB_OVERMIND
+		else
+			log_debug("/obj/structure/blob/core/proc/lateblobcheck: Blob core lacks a overmind.mind.")
+	else
+		log_debug("/obj/structure/blob/core/proc/lateblobcheck: Blob core lacks an overmind.")

--- a/code/game/gamemodes/blob/blobs/storage.dm
+++ b/code/game/gamemodes/blob/blobs/storage.dm
@@ -7,7 +7,7 @@
 	var/mob/camera/blob/overmind = null
 
 /obj/structure/blob/storage/update_icon()
-	if(health <= 0)
+	if(health <= 0 && !QDELETED(src))
 		overmind.max_blob_points -= 50
 		qdel(src)
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -1,7 +1,6 @@
 /datum/event/blob
-	announceWhen	= 60
-	endWhen			= 120
-	var/obj/structure/blob/core/Blob
+	announceWhen	= 120
+	endWhen			= 180
 
 /datum/event/blob/announce()
 	event_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", 'sound/AI/outbreak5.ogg')
@@ -25,10 +24,3 @@
 	to_chat(B, "<span class='userdanger'>You are now a mouse, infected with blob spores. Find somewhere isolated... before you burst and become the blob! Use ventcrawl (alt-click on vents) to move around.</span>")
 	var/image/alert_overlay = image('icons/mob/blob.dmi', "blank_blob")
 	notify_ghosts("Infected Mouse has appeared in [get_area(B)].", source = B, alert_overlay = alert_overlay)
-
-/datum/event/blob/tick()
-	if(!Blob)
-		kill()
-		return
-	if(IsMultiple(activeFor, 3))
-		Blob.process()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -186,9 +186,16 @@
 	if(istype(blobmind) && istype(C))
 		blobmind.special_role = SPECIAL_ROLE_BLOB
 		var/obj/structure/blob/core/core = new(T, 200, C, 3)
-		if(core.overmind && core.overmind.mind)
-			//core.overmind.mind.name = blob.name
-			core.overmind.mind.special_role = SPECIAL_ROLE_BLOB_OVERMIND
+		spawn(20)
+			// This delay is necessary because /obj/structure/blob/core/proc/create_overmind has a spawn() in it which causes core.overmind not to be defined immediately.
+			if(core.overmind)
+				core.overmind.add_points(60)
+				if(core.overmind.mind)
+					core.overmind.mind.special_role = SPECIAL_ROLE_BLOB_OVERMIND
+				else
+					log_debug("blobinfected/proc/burst: Blob lacks a core.overmind.mind.")
+			else
+				log_debug("blobinfected/proc/burst: Blob lacks an core.overmind.")
 	else
 		new /obj/structure/blob/core(T) // Ghosts will be prompted to control it.
 	if(ismob(loc)) // in case some taj/etc ate the mouse.

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -186,16 +186,7 @@
 	if(istype(blobmind) && istype(C))
 		blobmind.special_role = SPECIAL_ROLE_BLOB
 		var/obj/structure/blob/core/core = new(T, 200, C, 3)
-		spawn(20)
-			// This delay is necessary because /obj/structure/blob/core/proc/create_overmind has a spawn() in it which causes core.overmind not to be defined immediately.
-			if(core.overmind)
-				core.overmind.add_points(60)
-				if(core.overmind.mind)
-					core.overmind.mind.special_role = SPECIAL_ROLE_BLOB_OVERMIND
-				else
-					log_debug("blobinfected/proc/burst: Blob lacks a core.overmind.mind.")
-			else
-				log_debug("blobinfected/proc/burst: Blob lacks an core.overmind.")
+		core.lateblobtimer()
 	else
 		new /obj/structure/blob/core(T) // Ghosts will be prompted to control it.
 	if(ismob(loc)) // in case some taj/etc ate the mouse.


### PR DESCRIPTION
🆑 Kyep
fix: Fixed several bugs with blob, including lateround blobs not generating biohazard alerts, blobs missing out on early resources they should have, and a bug with blob storage being broken that prevented blobs getting any resources.
/🆑

This PR:
1) Fixes the bug causing blobs not to generate a level 5 biohazard as they should, due to the blob event being ended early.
2) Fixes the bug causing blobs to miss out on extra resource points they used to get.
3) Fixes the bug causing blobs to sometimes end up with zero blob point storage (unable to do anything) when a storage blob is destroyed. Fixes #9365


The first two bugs were introduced in my PR https://github.com/ParadiseSS13/Paradise/pull/9260
In https://github.com/ParadiseSS13/Paradise/blob/60376965382054f04bbaf07e4535000a99e18e63/code/modules/events/blob.dm the /datum/event/blob's var/obj/structure/blob/core/Blob is meant to be set during /datum/event/blob/start(), but it isn't. As a result /datum/event/blob/tick() detects (!Blob) and runs kill(), so the event never lasts long enough for /datum/event/blob/announce() to run. It also never calls the Blob.process() during tick() that it should, so over the course of the event's runtime the blob misses out on a bunch of resources they should have got.

To fix this, the PR removes var/obj/structure/blob/core/Blob from /datum/event/blob, and also deletes its tick() override.
This means that the (!Blob) no longer calls kill(), the event is not aborted early, and the announce() proc now runs correctly. This also increases the timer of the blob alert message by one minute, to allow time for the mouse to move.

To compensate for the fact that lateround blobs no longer get the benefit of 40 extra calls of process() during their first 3 minutes, this PR adds a flat 60 blob points to the starting blob points of lateround blobs. Effectively, their bonus resources are added at spawn time by the proc of the blobinfected mouse, rather than by the event during its tick().


As to bug #3, this is an old one. It was caused by /obj/structure/blob/storage/update_icon() running multiple times while the blob storage was at <=0 health. That proc has been changed so that after running once in this state, it being qdeleted stops it from running again.