### PR TITLE
Refactor of #9471

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -561,6 +561,7 @@ BLIND     // can't see anything
 	strip_delay = 80
 	put_on_delay = 80
 	burn_state = FIRE_PROOF
+	hide_tail_by_species = null
 	species_restricted = list("exclude","Diona","Vox","Wryn")
 
 //Under clothing

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -13,6 +13,8 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 
 	//Species-specific stuff.
+	var/list/hide_tail_by_species = null
+	hide_tail_by_species = list("Vox" , "Vulpkanin" , "Unathi" , "Tajaran")
 	species_restricted = list("exclude","Diona","Wryn")
 	sprite_sheets = list(
 		"Unathi" = 'icons/mob/species/unathi/helmet.dmi',

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -13,8 +13,6 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 
 	//Species-specific stuff.
-	var/list/hide_tail_by_species = null
-	hide_tail_by_species = list("Vox" , "Vulpkanin" , "Unathi" , "Tajaran")
 	species_restricted = list("exclude","Diona","Wryn")
 	sprite_sheets = list(
 		"Unathi" = 'icons/mob/species/unathi/helmet.dmi',
@@ -72,6 +70,7 @@
 	allowed = list(/obj/item/flashlight,/obj/item/tank,/obj/item/t_scanner, /obj/item/rcd)
 	siemens_coefficient = 0
 
+	hide_tail_by_species = list("Vox" , "Vulpkanin" , "Unathi" , "Tajaran")
 	species_restricted = list("exclude","Diona","Wryn")
 	sprite_sheets = list(
 		"Unathi" = 'icons/mob/species/unathi/suit.dmi',


### PR DESCRIPTION
Refactors https://github.com/ParadiseSS13/Paradise/pull/9471 and implements the original fix in a much smarter way, also future proofs hardsuits with mode switches. As far as I'm aware the only suits with the tail problems were the syndicate suits.

Replaces a single `HIDETAIL` call by defining `var/list/hide_tail_by_species = null` in the 'stock' spacesuit in clothing.dm and hardsuit.dm

Again prevents: 
![image](https://user-images.githubusercontent.com/15992551/45145908-9e022c80-b176-11e8-86b7-64c5cd5d8cbe.png)

Proof:

![image](https://user-images.githubusercontent.com/15992551/45145911-a195b380-b176-11e8-9e9f-9a0d6804c71b.png)
![image](https://user-images.githubusercontent.com/15992551/45145916-a3f80d80-b176-11e8-94dc-e745bfc0846a.png)

:cl:
tweak: changes implementation of https://github.com/ParadiseSS13/Paradise/pull/9471 to be smarter and more long term.
/:cl:

