### PR TITLE
Fixes #7056

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -243,7 +243,6 @@
 /obj/item/clothing/accessory/holobadge/cord
 	icon_state = "holobadge-cord"
 	item_color = "holobadge-cord"
-	slot_flags = SLOT_MASK | SLOT_TIE
 
 /obj/item/clothing/accessory/holobadge/attack_self(mob/user as mob)
 	if(!stored_name)


### PR DESCRIPTION
https://github.com/ParadiseSS13/Paradise/issues/7056

Holobadge-cords shouldn't be able to equip to the mask slot anyway. Seriously, why?

Even the commented explanation said neck (accessory) and belt only.

🆑 
fix: removes the equip region for the mask slot on holobadge-cords
/:cl: