### PR TITLE
Fixes a woops with vampire

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1349,7 +1349,7 @@
 		special_role = SPECIAL_ROLE_VAMPIRE
 		ticker.mode.forge_vampire_objectives(src)
 		ticker.mode.greet_vampire(src)
-		ticker.mode.update_change_icons_added(src)
+		ticker.mode.update_vampire_icons_added(src)
 
 /datum/mind/proc/make_Changeling()
 	if(!(src in ticker.mode.changelings))


### PR DESCRIPTION
As per title. This fixes vampire icons becoming changeling icon. This is a mistake I made ages ago while refactoring one-click antag.

🆑:
fix: One-click antag vampire showing up as a changeling on antag HUD.
/🆑 