### PR TITLE
Ghosts can no longer eject IDs from fax machines and ID computers.

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -107,7 +107,7 @@ var/time_last_changed_position = 0
 	set name = "Eject ID Card"
 	set src in oview(1)
 
-	if(usr.restrained())
+	if(usr.incapacitated())
 		return
 
 	if(scan)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -207,7 +207,7 @@ var/list/alldepartments = list()
 	set name = "Eject ID Card"
 	set src in oview(1)
 
-	if(usr.restrained())
+	if(usr.incapacitated())
 		return
 
 	if(scan)


### PR DESCRIPTION
Fixes #9487

:cl: uc_guy
fix: Ghosts can no longer eject IDs from fax machines and ID computers.
/:cl: