### PR TITLE
Fixes edit memory cancel not working

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -482,7 +482,7 @@
 		var/new_memo = copytext(input("Write new memory", "Memory", memory) as null|message,1,MAX_MESSAGE_LEN)
 		if(isnull(new_memo))
 			return
-		var/confirmed = alert(usr, "Are you sure?", "Edit Memory", "Yes", "No")
+		var/confirmed = alert(usr, "Are you sure? (Click NO to cancel! YES will replace current memory!)", "Edit Memory", "Yes", "No")
 		if(confirmed == "Yes") // Because it is too easy to accidentally wipe someone's memory
 			memory = new_memo
 			log_admin("[key_name(usr)] has edited [key_name(current)]'s memory")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -479,10 +479,11 @@
 		message_admins("[key_name_admin(usr)] has changed [key_name_admin(current)]'s assigned role to [assigned_role]")
 
 	else if(href_list["memory_edit"])
-		var/new_memo = copytext(input("Write new memory", "Memory", memory) as null|message,1,MAX_MESSAGE_LEN)
-		if(isnull(new_memo))
+		var/messageinput = input("Write new memory", "Memory", memory) as null|message
+		if(isnull(messageinput))
 			return
-		var/confirmed = alert(usr, "Are you sure? (Click NO to cancel! YES will replace current memory!)", "Edit Memory", "Yes", "No")
+		var/new_memo = copytext(messageinput, 1,MAX_MESSAGE_LEN)
+		var/confirmed = alert(usr, "Are you sure you want to edit their memory? It will wipe out their original memory!", "Edit Memory", "Yes", "No")
 		if(confirmed == "Yes") // Because it is too easy to accidentally wipe someone's memory
 			memory = new_memo
 			log_admin("[key_name(usr)] has edited [key_name(current)]'s memory")


### PR DESCRIPTION
Fixes #7778

Also make the confirmation message a bit more detailed.

🆑:
fix: The cancel button actually work properly when editing memory now.
/🆑  