### PR TITLE
Bugfix for card & lightning

### DIFF
--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -252,7 +252,7 @@
 
 /obj/item/pack/attack_self(mob/user as mob)
 	user.visible_message("<span class='notice'>[name] rips open the [src]!</span>", "<span class='notice'>You rips open the [src]!</span>")
-	var/obj/item/cardhand/H = new()
+	var/obj/item/cardhand/H = new(get_turf(user))
 
 	H.cards += cards
 	cards.Cut()
@@ -260,7 +260,7 @@
 	qdel(src)
 
 	H.update_icon()
-	user.put_in_active_hand(H)
+	user.put_in_hands(H)
 
 /obj/item/cardhand
 	name = "hand of cards"
@@ -370,7 +370,7 @@
 	var/datum/playingcard/card = pickablecards[pickedcard]
 
 	var/obj/item/cardhand/H = new(get_turf(src))
-	user.put_in_active_hand(H)
+	user.put_in_hands(H)
 	H.cards += card
 	cards -= card
 	H.parentdeck = parentdeck

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -484,7 +484,7 @@
 
 
 	// create a light tube/bulb item and put it in the user's hand
-	var/obj/item/light/L = new light_type()
+	var/obj/item/light/L = new light_type(get_turf(user))
 	L.status = status
 	L.rigged = rigged
 	L.brightness_range = brightness_range
@@ -499,7 +499,7 @@
 	L.update()
 	L.add_fingerprint(user)
 
-	user.put_in_active_hand(L)	//puts it in our active hand
+	user.put_in_hands(L)	//puts it in our active hand
 
 	status = LIGHT_EMPTY
 	update()


### PR DESCRIPTION
Fixes #9513 

This ensures that the constructor for the cards & light fixture defaults to the location of the user so the card / light tube don't disappear because it was created in null.

Thanks to Tigercat2000 for helping me with this.

🆑:
fix: When you remove a light tube while lying down, the light tube disappear. This no longer happens.
/🆑 