### PR TITLE
Slotmachine "Cleanup"

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -18,7 +18,6 @@
 			account = get_card_account(user.get_active_hand())
 		else
 			account = null
-
 	ui_interact(user)
 
 /obj/machinery/slot_machine/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
@@ -30,81 +29,78 @@
 
 /obj/machinery/slot_machine/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)
 	var/data[0]
-
 	data["working"] = working
 	data["money"] = account ? account.money : null
 	data["plays"] = plays
 	data["result"] = result
 	data["resultlvl"] = resultlvl
-
 	return data
 
 /obj/machinery/slot_machine/Topic(href, href_list)
 	add_fingerprint(usr)
 
 	if(href_list["ops"])
-		var/operation = text2num(href_list["ops"])
-		if(operation == 1) // Play
-			if(working == 1)
+		if(text2num(href_list["ops"]))	// Play
+			if(working)
 				return
 			if(!account || account.money < 10)
 				return
 			if(!account.charge(10, null, "Bet", "Slot Machine", "Slot Machine"))
 				return
-			plays += 1
+			plays++
 			working = 1
 			icon_state = "slots-on"
-			var/roll = rand(1,4050)
 			playsound(src.loc, 'sound/machines/ding.ogg', 50, 1)
-			spawn(25)
-				if(roll == 1)
-					visible_message("<b>[src]</b> says, 'JACKPOT! [usr.name] has won a MILLION CREDITS!'")
-					event_announcement.Announce("Congratulations to [usr.name] on winning the Jackpot of ONE MILLION CREDITS!", "Jackpot Winner")
-					result = "JACKPOT! You win one million credits!"
-					resultlvl = "highlight"
-					win_money(1000000, 'sound/goonstation/misc/airraid_loop.ogg')
-				else if(roll > 1 && roll <= 5)
-					visible_message("<b>[src]</b> says, 'Big Winner! [usr.name] has won a hundred thousand credits!'")
-					event_announcement.Announce("Congratulations to [usr.name] on winning a hundred thousand credits!", "Big Winner")
-					result = "Big Winner! You win a hundred thousand credits!"
-					resultlvl = "good"
-					win_money(100000, 'sound/goonstation/misc/klaxon.ogg')
-				else if(roll > 5 && roll <= 50)
-					visible_message("<b>[src]</b> says, 'Big Winner! [usr.name] has won ten thousand credits!'")
-					result = "You win ten thousand credits!"
-					resultlvl = "good"
-					win_money(10000, 'sound/goonstation/misc/klaxon.ogg')
-				else if(roll > 50 && roll <= 100)
-					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won a thousand credits!'")
-					result = "You win a thousand credits!"
-					resultlvl = "good"
-					win_money(1000, 'sound/goonstation/misc/bell.ogg')
-				else if(roll > 100 && roll <= 200)
-					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won a hundred credits!'")
-					result = "You win a hundred credits!"
-					resultlvl = "good"
-					win_money(100, 'sound/goonstation/misc/bell.ogg')
-				else if(roll > 200 && roll <= 300)
-					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won fifty credits!'")
-					result = "You win fifty credits!"
-					resultlvl = "good"
-					win_money(50)
-				else if(roll > 300 && roll <= 1000)
-					visible_message("<b>[src]</b> says, 'Winner! [usr.name] has won ten credits!'")
-					result = "You win ten credits!"
-					resultlvl = "good"
-					win_money(10)
-				else
-					result = "<span class='warning'>No luck!</span>"
-					resultlvl = "average"
-				working = 0
-				icon_state = "slots-off"
+			addtimer(CALLBACK(src, .proc/spin_slots, usr.name), 25)
+			
+/obj/machinery/slot_machine/proc/spin_slots(var/userName)
+	switch(rand(1,4050))
+		if(1)
+			atom_say("JACKPOT! [userName] has won a MILLION CREDITS!")
+			event_announcement.Announce("Congratulations to [userName] on winning the Jackpot of ONE MILLION CREDITS!", "Jackpot Winner")
+			result = "JACKPOT! You win one million credits!"
+			resultlvl = "highlight"
+			win_money(1000000, 'sound/goonstation/misc/airraid_loop.ogg')
+		if(2 to 5)
+			atom_say("Big Winner! [userName] has won a hundred thousand credits!")
+			event_announcement.Announce("Congratulations to [userName] on winning a hundred thousand credits!", "Big Winner")
+			result = "Big Winner! You win a hundred thousand credits!"
+			resultlvl = "good"
+			win_money(100000, 'sound/goonstation/misc/klaxon.ogg')
+		if(6 to 50)
+			atom_say("Big Winner! [userName] has won ten thousand credits!")
+			result = "You win ten thousand credits!"
+			resultlvl = "good"
+			win_money(10000, 'sound/goonstation/misc/klaxon.ogg')
+		if(51 to 100)
+			atom_say("Winner! [userName] has won a thousand credits!")
+			result = "You win a thousand credits!"
+			resultlvl = "good"
+			win_money(1000, 'sound/goonstation/misc/bell.ogg')
+		if(101 to 200)
+			atom_say("Winner! [userName] has won a hundred credits!")
+			result = "You win a hundred credits!"
+			resultlvl = "good"
+			win_money(100, 'sound/goonstation/misc/bell.ogg')
+		if(201 to 300)
+			atom_say("Winner! [userName] has won fifty credits!")
+			result = "You win fifty credits!"
+			resultlvl = "good"
+			win_money(50)
+		if(301 to 1000)
+			atom_say("Winner! [userName] has won ten credits!")
+			result = "You win ten credits!"
+			resultlvl = "good"
+			win_money(10)
+		else
+			result = "<span class='warning'>No luck!</span>"
+			resultlvl = "average"
+	working = 0
+	icon_state = "slots-off"
 
 /obj/machinery/slot_machine/proc/win_money(amt, sound='sound/machines/ping.ogg')
 	if(sound)
 		playsound(loc, sound, 55, 1)
-
 	if(!account)
 		return
-
 	account.credit(amt, "Slot Winnings", "Slot Machine", account.owner_name)


### PR DESCRIPTION
Removed two unnecessary variables, changed to switch statement, replaced a spawn() with addtimer(), and replaced visible_message() with atom_say().

:cl:
refactor: Changed slot machine to use switches, addtimer() and atom_say().
/:cl: