### PR TITLE
Fixes special char being allowed in some name

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -546,7 +546,7 @@
 			to_chat(usr, "This can only be used on instances of type /mob")
 			return
 
-		var/new_name = sanitize(copytext(input(usr,"What would you like to name this mob?","Input a name",M.real_name) as text|null,1,MAX_NAME_LEN))
+		var/new_name = reject_bad_name(sanitize(copytext(input(usr,"What would you like to name this mob?","Input a name",M.real_name) as text|null,1,MAX_NAME_LEN)))
 		if( !new_name || !M )	return
 
 		message_admins("Admin [key_name_admin(usr)] renamed [key_name_admin(M)] to [new_name].")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -271,7 +271,13 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			return 0
 	var/obj/item/paicard/card = new(T)
 	var/mob/living/silicon/pai/pai = new(card)
-	pai.name = input(choice, "Enter your pAI name:", "pAI Name", "Personal AI") as text
+	var/raw_name = input(choice, "Enter your pAI name:", "pAI Name", "Personal AI") as text
+	var/new_name = reject_bad_name(raw_name, 1)
+	if(new_name)
+		pai.name = new_name
+		pai.real_name = new_name
+	else
+		to_chat(usr, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 	pai.real_name = pai.name
 	pai.key = choice.key
 	card.setPersonality(pai)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -65,7 +65,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 				if("name")
 					t = input("Enter a name for your pAI", "pAI Name", candidate.name) as text
 					if(t)
-						candidate.name = sanitize(copytext(t,1,MAX_NAME_LEN))
+						candidate.name = reject_bad_name(sanitize(copytext(t,1,MAX_NAME_LEN)))
 				if("desc")
 					t = input("Enter a description for your pAI", "pAI Description", candidate.description) as message
 					if(t)
@@ -84,7 +84,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 					candidate.savefile_load(usr)
 					//In case people have saved unsanitized stuff.
 					if(candidate.name)
-						candidate.name = sanitize(copytext(candidate.name,1,MAX_NAME_LEN))
+						candidate.name = reject_bad_name(sanitize(copytext(candidate.name,1,MAX_NAME_LEN)))
 					if(candidate.description)
 						candidate.description = sanitize(copytext(candidate.description,1,MAX_MESSAGE_LEN))
 					if(candidate.role)


### PR DESCRIPTION
pAI name allowed special characters in spite of sanitization, which lead to all of their messages not appearing in chat. 

This stops pAI from being made with problematic names. It also prevent mob being renamed with such name. It will not stop direct VV of the name variable, however.

🆑:
fix: pAI can no longer use name with special characters that cause their chat messages to disappear.
/🆑 