### PR TITLE
Fixes vending machine bank account security purchases

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -386,9 +386,8 @@
 	// empty at high security levels
 	if(customer_account.security_level != 0) //If card requires pin authentication (ie seclevel 1 or 2)
 		var/attempt_pin = input("Enter pin code", "Vendor transaction") as num
-		customer_account = attempt_account_access(customer_account, attempt_pin, 2)
-
-		if(!customer_account)
+	
+		if(!attempt_account_access(customer_account.account_number, attempt_pin, 2))
 			src.status_message = "Unable to access account: incorrect credentials."
 			src.status_error = 1
 			return 0


### PR DESCRIPTION
Fixes: #9526 
Fixes: #8748 

Makes it so you can use vending machines with a bank account security level higher than 0.

So the issue was, it was sending an account, where the `attempt_account_access` function was needing an account _number_, not an account.

With the old line 391, it just didn't work where it said "incorrect credentials". This does however.

🆑 
fix: Fixes vending machine bank account security. You can now use them with a bank account security level above zero.
/ 🆑 