### PR TITLE
Fixes logic with obscure proc

### DIFF
--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -210,5 +210,5 @@
 	return
 
 /mob/proc/adjust_bodytemperature(amount, min_temp = 0, max_temp = INFINITY)
-	if(bodytemperature > min_temp && bodytemperature < max_temp)
+	if(bodytemperature >= min_temp && bodytemperature <= max_temp)
 		bodytemperature = Clamp(bodytemperature + amount, min_temp, max_temp)


### PR DESCRIPTION
from https://github.com/tgstation/tgstation/pull/40061

https://github.com/ParadiseSS13/Paradise/blob/6fe83a698757f023d26171355fff906d95ee764b/code/datums/weather/weather_types/snow_storm.dm

thats the only place where its actually used, everything else just edits the body temp without the function

🆑 
fix: Fixes logic with obscure proc adjust_bodytemperature
/ 🆑 