### PR TITLE
Tidies up floodlights.dm & enables mappers to have round-start lights enabled

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -4,18 +4,19 @@
 	icon_state = "flood00"
 	anchored = FALSE
 	density = TRUE
+	light_power = 20
 	var/on = FALSE
 	var/obj/item/stock_parts/cell/high/cell = null
 	var/use = 5
 	var/unlocked = FALSE
 	var/open = FALSE
 	var/brightness_on = 14
-	light_power = 20
 
-/obj/machinery/floodlight/New()
+
+/obj/machinery/floodlight/Initialize()
+	. = ..()
 	src.cell = new(src)
-	turnOn()
-	..()
+	mapVarInit()
 
 /obj/machinery/floodlight/Destroy()
 	QDEL_NULL(cell)
@@ -67,7 +68,7 @@
 
 	updateicon()
 
-/obj/machinery/floodlight/proc/turnOn()
+/obj/machinery/floodlight/proc/mapVarInit()
 	if(on)
 		if(!cell)
 			return

--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -1,22 +1,20 @@
-//these are probably broken
-
 /obj/machinery/floodlight
-	name = "Emergency Floodlight"
+	name = "emergency floodlight"
 	icon = 'icons/obj/machines/floodlight.dmi'
 	icon_state = "flood00"
-	anchored = 0
-	density = 1
-	var/on = 0
+	anchored = FALSE
+	density = TRUE
+	var/on = FALSE
 	var/obj/item/stock_parts/cell/high/cell = null
 	var/use = 5
-	var/unlocked = 0
-	var/open = 0
+	var/unlocked = FALSE
+	var/open = FALSE
 	var/brightness_on = 14
 	light_power = 20
-	//var/brightness_on = 999		//can't remember what the maxed out value is //Lighting overhaul: No max, stop TRYING TO ILLUMINATE MORE TILES THAN THE MAP CONSISTS OF.
 
 /obj/machinery/floodlight/New()
 	src.cell = new(src)
+	turnOn()
 	..()
 
 /obj/machinery/floodlight/Destroy()
@@ -30,13 +28,12 @@
 	if(on)
 		cell.charge -= use
 		if(cell.charge <= 0)
-			on = 0
+			on = FALSE
 			updateicon()
 			set_light(0)
 			src.visible_message("<span class='warning'>[src] shuts down due to lack of power!</span>")
-			return
 
-/obj/machinery/floodlight/attack_ai(mob/user as mob)
+/obj/machinery/floodlight/attack_ai()
 	return
 
 /obj/machinery/floodlight/attack_hand(mob/user as mob)
@@ -51,25 +48,33 @@
 		cell.update_icon()
 
 		src.cell = null
-		to_chat(user, "You remove the power cell")
+		to_chat(user, "You remove the power cell.")
 		updateicon()
 		return
 
 	if(on)
-		on = 0
-		to_chat(user, "<span class='notice'>You turn off the light</span>")
+		on = FALSE
+		to_chat(user, "<span class='notice'>You turn off the light.</span>")
 		set_light(0)
 	else
 		if(!cell)
 			return
 		if(cell.charge <= 0)
 			return
-		on = 1
-		to_chat(user, "<span class='notice'>You turn on the light</span>")
+		on = TRUE
+		to_chat(user, "<span class='notice'>You turn on the light.</span>")
 		set_light(brightness_on)
 
 	updateicon()
 
+/obj/machinery/floodlight/proc/turnOn()
+	if(on)
+		if(!cell)
+			return
+		if(cell.charge <= 0)
+			return
+		set_light(brightness_on)
+		updateicon()
 
 /obj/machinery/floodlight/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/wrench))
@@ -79,32 +84,32 @@
 				"[user] tightens \the [src]'s casters.", \
 				"<span class='notice'> You have tightened \the [src]'s casters.</span>", \
 				"You hear ratchet.")
-			anchored = 1
+			anchored = TRUE
 		else if(anchored)
 			playsound(src.loc, W.usesound, 50, 1)
 			user.visible_message( \
 				"[user] loosens \the [src]'s casters.", \
 				"<span class='notice'> You have loosened \the [src]'s casters.</span>", \
 				"You hear ratchet.")
-			anchored = 0
+			anchored = FALSE
 	if(istype(W, /obj/item/screwdriver))
 		if(!open)
 			if(unlocked)
-				unlocked = 0
+				unlocked = FALSE
 				to_chat(user, "You screw the battery panel in place.")
 			else
-				unlocked = 1
+				unlocked = TRUE
 				to_chat(user, "You unscrew the battery panel.")
 
 	if(istype(W, /obj/item/crowbar))
 		if(unlocked)
 			if(open)
-				open = 0
+				open = FALSE
 				overlays = null
 				to_chat(user, "You crowbar the battery panel in place.")
 			else
 				if(unlocked)
-					open = 1
+					open = TRUE
 					to_chat(user, "You remove the battery panel.")
 
 	if(istype(W, /obj/item/stock_parts/cell))


### PR DESCRIPTION
Tidies it up a bit, also adds the ability for mappers to have floodlights turned on at round start.

:cl: Purpose
add: Mappers can now have Floodlights round-start enabled.
/:cl: