### PR TITLE
Fixes blobs not deleting light fixtures

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -576,7 +576,7 @@
 
 /obj/machinery/light/blob_act()
 	if(prob(75))
-		broken()
+		qdel(src)
 
 
 // timed process


### PR DESCRIPTION
Goofy that blobs delete everything including walls... but light fixtures just hang around in the air. Fixed that.

![image](https://user-images.githubusercontent.com/7415122/45575082-2add7200-b86a-11e8-88ee-9b5b4add47e9.png)


:cl: Purpose
fix: Blobs now delete light fixtures correctly.
/:cl: