### PR TITLE
MMI Radio Upgrade now has a tech origin

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI_radio.dm
+++ b/code/modules/mob/living/carbon/brain/MMI_radio.dm
@@ -3,3 +3,4 @@
 	desc = "Enables radio capability on MMIs when either installed directly on the MMI, or through a cyborg's chassis."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade1"
+	origin_tech = "programming=3;biotech=2;engineering=2"


### PR DESCRIPTION
Adds in the origin tech for the mmi radio upgrade


:cl: Desolate
Fix: MMI Radio Upgrade now has origin tech levels.
\ :cl: 
