### PR TITLE
Fixes holopad's power use

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -386,7 +386,8 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/proc/SetLightsAndPower()
 	var/total_users = masters.len + LAZYLEN(holo_calls)
-	use_power = HOLOPAD_PASSIVE_POWER_USAGE + HOLOGRAM_POWER_USAGE * total_users
+	use_power = total_users > 0 ? ACTIVE_POWER_USE : IDLE_POWER_USE
+	active_power_usage = HOLOPAD_PASSIVE_POWER_USAGE + (HOLOGRAM_POWER_USAGE * total_users)
 	if(total_users)
 		set_light(2)
 		icon_state = "holopad1"


### PR DESCRIPTION
holopads now correctly set use_power and the active_power_usage

:cl: Purpose
fix: Holopads now use the correct amount of power.
/:cl: