### PR TITLE
Window alt clicking utility

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -65,7 +65,7 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 		else
 			to_chat(user, "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>")
 	if(!anchored && !fulltile)
-		to_chat(user, "<span class='notice'>Alt-click to rotate it.</span>")
+		to_chat(user, "<span class='notice'>alt-click to rotate it.</span>")
 
 /obj/structure/window/New(Loc, direct)
 	..()
@@ -355,7 +355,7 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	set category = "Object"
 	set src in oview(1)
 
-	if(usr.stat || !usr.canmove || usr.restrained())
+	if(usr.incapacitated())
 		return
 
 	if(anchored)
@@ -378,7 +378,7 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	set category = "Object"
 	set src in oview(1)
 
-	if(usr.stat || !usr.canmove || usr.restrained())
+	if(usr.incapacitated())
 		return
 
 	if(anchored)
@@ -397,11 +397,17 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	return TRUE
 
 /obj/structure/window/AltClick(mob/user)
-	if(usr.stat || !usr.canmove || usr.restrained())
+
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+
+	if(!Adjacent(user))
+		to_chat(user, "<span class='warning'>Move closer to the window!</span>")
 		return
 
 	if(anchored)
-		to_chat(usr, "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>")
+		to_chat(user, "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>")
 		return FALSE
 
 	var/target_dir = turn(dir, 270)
@@ -409,12 +415,12 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	if(!valid_window_location(loc, target_dir))
 		target_dir = turn(dir, 90)
 	if(!valid_window_location(loc, target_dir))
-		to_chat(usr, "<span class='warning'>There is no room to rotate the [src]</span>")
+		to_chat(user, "<span class='warning'>There is no room to rotate the [src]</span>")
 		return FALSE
 
 	setDir(target_dir)
 	ini_dir = dir
-	add_fingerprint(usr)
+	add_fingerprint(user)
 	return TRUE
 
 /obj/structure/window/Destroy()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -65,7 +65,7 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 		else
 			to_chat(user, "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>")
 	if(!anchored && !fulltile)
-		to_chat(user, "<span class='notice'>alt-click to rotate it.</span>")
+		to_chat(user, "<span class='notice'>Alt-click to rotate it.</span>")
 
 /obj/structure/window/New(Loc, direct)
 	..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -65,7 +65,7 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 		else
 			to_chat(user, "<span class='notice'>The window is <i>unscrewed</i> from the floor, and could be deconstructed by <b>wrenching</b>.</span>")
 	if(!anchored && !fulltile)
-		to_chat(user, "<span class='notice'>Alt-click to rotate it clockwise.</span>")
+		to_chat(user, "<span class='notice'>Alt-click to rotate it.</span>")
 
 /obj/structure/window/New(Loc, direct)
 	..()
@@ -397,12 +397,25 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	return TRUE
 
 /obj/structure/window/AltClick(mob/user)
-	if(user.incapacitated())
-		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+	if(usr.stat || !usr.canmove || usr.restrained())
 		return
-	if(!Adjacent(user))
-		return
-	revrotate()
+
+	if(anchored)
+		to_chat(usr, "<span class='warning'>[src] cannot be rotated while it is fastened to the floor!</span>")
+		return FALSE
+
+	var/target_dir = turn(dir, 270)
+
+	if(!valid_window_location(loc, target_dir))
+		target_dir = turn(dir, 90)
+	if(!valid_window_location(loc, target_dir))
+		to_chat(usr, "<span class='warning'>There is no room to rotate the [src]</span>")
+		return FALSE
+
+	setDir(target_dir)
+	ini_dir = dir
+	add_fingerprint(usr)
+	return TRUE
 
 /obj/structure/window/Destroy()
 	density = FALSE


### PR DESCRIPTION
Alt clicking a window now checks both directions for availability instead of stating that rotating is impossible when the clockwise direction isn't available. 

https://puu.sh/Bwx9X/69079c06f2.gif A gif to show the new situation

I intentionally left out flipping the window when there is room for it because that would make for a very easy way to get into the station without being affected by fastmos.

🆑 Kluys
Added: Alt clicking windows will attempt to rotate them counterclockwise if the clockwise direction is unavailable
Also replaces a few instances where incapacitated() wasn't used (instead using 3 different checks that do the same thing)
/🆑