### PR TITLE
Fixes fire alarm deconstruction steps

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -70,7 +70,7 @@ FIRE ALARM
 /obj/machinery/firealarm/attackby(obj/item/I, mob/user, params)
 	add_fingerprint(user)
 
-	if(iswirecutter(I) && buildstage == 2)
+	if(isscrewdriver(I) && buildstage == 2)
 		wiresexposed = !wiresexposed
 		update_icon()
 		return


### PR DESCRIPTION
This is supposed to be a screwdriver check.

🆑 Birdtalon
fix: Screwdrivers now open fire alarms instead of wirecutters.
/🆑 