### PR TITLE
Lasertag ED-209 bots now get assigned correct names on construction

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -44,7 +44,7 @@
 	icon_state = "ed209_frame"
 	item_state = "ed209_frame"
 	var/build_step = 0
-	var/created_name = "ED-209 Security Robot" //To preserve the name if it's a unique securitron I guess
+	var/created_name = "\improper ED-209 Security Robot" //To preserve the name if it's a unique securitron I guess
 	var/lasercolor = ""
 
 /obj/item/ed209_assembly/attackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
🆑 Birdtalon
fix: Laser tag ED-209 bots get the correct names upon construction.
/🆑 