### PR TITLE
Restore / add back in Qdellog / HardDelete log

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -91,6 +91,9 @@
 /proc/log_adminsay(text, mob/speaker)
 	if(config.log_adminchat)
 		WRITE_LOG(GLOB.world_game_log, "ADMINSAY: [speaker.simple_info_line()]: [html_decode(text)][log_end]")
+	
+/proc/log_qdel(text)
+	WRITE_LOG(GLOB.world_qdel_log, "QDEL: [text]")
 
 /proc/log_mentorsay(text, mob/speaker)
 	if(config.log_adminchat)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -6,6 +6,8 @@ GLOBAL_VAR(config_error_log)
 GLOBAL_PROTECT(config_error_log)
 GLOBAL_VAR(world_runtime_log)
 GLOBAL_PROTECT(world_runtime_log)
+GLOBAL_VAR(world_qdel_log)
+GLOBAL_PROTECT(world_qdel_log)
 GLOBAL_VAR(world_href_log)
 GLOBAL_PROTECT(world_href_log)
 

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(garbage)
 	msg += " | Fail:[fail_counts.Join(",")]"
 	..(msg)
 
-/* TO-DO
+
 /datum/controller/subsystem/garbage/Shutdown()
 	//Adds the del() log to the qdel log file
 	var/list/dellog = list()
@@ -83,7 +83,6 @@ SUBSYSTEM_DEF(garbage)
 		if(I.no_hint)
 			dellog += "\tNo hint: [I.no_hint] times"
 	log_qdel(dellog.Join("\n"))
-*/
 
 /datum/controller/subsystem/garbage/fire()
 	//the fact that this resets its processing each fire (rather then resume where it left off) is intentional.

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -442,9 +442,11 @@ var/failed_old_db_connections = 0
 	GLOB.world_game_log = "[GLOB.log_directory]/game.log"
 	GLOB.world_href_log = "[GLOB.log_directory]/hrefs.log"
 	GLOB.world_runtime_log = "[GLOB.log_directory]/runtime.log"
+	GLOB.world_qdel_log = "[GLOB.log_directory]/qdel.log"
 	start_log(GLOB.world_game_log)
 	start_log(GLOB.world_href_log)
 	start_log(GLOB.world_runtime_log)
+	start_log(GLOB.world_qdel_log)
 
 	if(fexists(GLOB.config_error_log))
 		fcopy(GLOB.config_error_log, "[GLOB.log_directory]/config_error.log")


### PR DESCRIPTION
The server sometime get a random amount of harddelete. One of the cause I found out was the wild west gateway. However I am not certain this is the only source so I am re-adding this back in for us to use as a resource.

Proof from last night's server profile on why we might need this log:

![dreamseeker_2018-09-18_21-53-20](https://user-images.githubusercontent.com/40092670/45737660-00e8ce80-bc21-11e8-9dee-59681f881808.png)

Unfortunately I couldn't figure out a way to get this to log automatically on server restart instead of a manual subsystem shutdown (Through the shutdown proc). I would appreciate any pointer related to that.

🆑:
tweak: Qdel log is now re-added to the garbage subsystem to enable coders to investigate sources of hard delete.
/🆑 