### PR TITLE
Cuts Xray weapons range in half

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -36,7 +36,7 @@
 	damage = 15
 	irradiate = 30
 	forcedodge = 1
-	range = 15
+	range = 7
 	light_color = LIGHT_COLOR_GREEN
 
 /obj/item/projectile/beam/disabler


### PR DESCRIPTION
Alright so I have been asked to do some kind of balance change to Xray Weapons. I had tried some things like using the accelerator damage increase and turning it into a damage fall off. That made xray weapons pretty useless against anything. I also tried to give thick blob tiles laser reflective properties. That makes it worse actually.

Then I found out that the Xray Gun has a set maximum range of 15 tiles. By cutting that roughly in half (7 tiles) the crew is forced to get close with their Xray guns, range decrease can be altered pretty easily since the code for that is already in there. They are still potent against blobs yes. But now the blob got a chance to fight back and not get sniped across the screen with anti fun lasers. How it works out in practice will be seen in due time. I know its a feature freeze but I basicly did this because I was asked for it. 

I might be able to remove the entire pierce effect of xray guns but that would completly destroy the weapons purpose of well... being able to shoot through obstacles.

So what I basicly did was the simplest yet (in my eyes) most efficient solution: Nerf Xray Guns range without touching any of its other properties. Its still a super good weapon. Its just not as cheesy anymore against blobs or rogue AIs. 

Side effects include: Mech mounted xray stream projector and xray cannons are nerfed too. But who uses them anyways when you have a pulse cannon on your ERT mech...


:cl: Irkalla
tweak: Cuts Xray Lasers range from 15 tiles down to 7
/:cl:/