### PR TITLE
Beepsky responds to disarming

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -175,7 +175,7 @@ Auto Patrol: []"},
 		mode = BOT_HUNT
 
 /mob/living/simple_animal/bot/secbot/attack_hand(mob/living/carbon/human/H)
-	if(H.a_intent == INTENT_HARM)
+	if(H.a_intent == INTENT_HARM || H.a_intent == INTENT_DISARM)
 		retaliate(H)
 	return ..()
 


### PR DESCRIPTION
This just looks like an oversight to me more so than a balance question. Fixes #9589 
- Beepsky responds appropriately to attacking him with disarm intent instead of turning the other cheek.

🆑 Birdtalon
tweak: Beepsky responds to attacking him with disarm intent.
/🆑 