### PR TITLE
Larger default window size for secure console.

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -50,7 +50,7 @@
 /obj/machinery/computer/secure_data/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "secure_data.tmpl", name, 800, 380)
+		ui = new(user, src, ui_key, "secure_data.tmpl", name, 800, 800)
 		ui.open()
 
 /obj/machinery/computer/secure_data/ui_data(mob/user, ui_key = "main", datum/topic_state/state = default_state)


### PR DESCRIPTION
Just a usability thing. The console UI spawns far too narrow to be realistically usable and has to be resized every time. Just making it a bit bigger.

🆑 Birdtalon
tweak: Secure console UI (security records) appears bigger by default.
/🆑 