### PR TITLE
Additional check for one-click-antag 

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -32,7 +32,7 @@ client/proc/one_click_antag()
 	if(M.stat || !M.mind || M.mind.special_role)
 		return FALSE
 	if(temp)
-		if(M.mind.assigned_role in temp.restricted_jobs || M.client.prefs.species in temp.protected_species)
+		if(M.mind.assigned_role in temp.restricted_jobs || M.mind.assigned_role in temp.protected_jobs || M.client.prefs.species in temp.protected_species)
 			return FALSE
 	if(role) // Don't even bother evaluating if there's no role
 		if(player_old_enough_antag(M.client,role) && (role in M.client.prefs.be_special) && (!jobban_isbanned(M, role)))


### PR DESCRIPTION
Adds a check for the gamemode's `protected_jobs`.

🆑 Birdtalon
tweak: One-click-antag now respects game-mode's protected jobs.
/🆑 