### PR TITLE
Fixes #9561

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -381,6 +381,7 @@ proc/get_radio_key_from_channel(var/channel)
 	var/eavesdropping_range = 2
 	var/watching_range = 5
 	var/italics = 1
+	var/adverb_added = FALSE
 
 	var/not_heard //the message displayed to people who could not hear the whispering
 	if(speaking)
@@ -389,6 +390,7 @@ proc/get_radio_key_from_channel(var/channel)
 			not_heard = "[verb] something"
 		else
 			var/adverb = pick("quietly", "softly")
+			adverb_added = TRUE
 			verb = "[speaking.speech_verb] [adverb]"
 			not_heard = "[speaking.speech_verb] something [adverb]"
 	else
@@ -404,7 +406,7 @@ proc/get_radio_key_from_channel(var/channel)
 	if(verb == "yells loudly")
 		verb = "slurs emphatically"
 
-	else if(speech_problem_flag)
+	else if(speech_problem_flag && !adverb_added)
 		var/adverb = pick("quietly", "softly")
 		verb = "[verb] [adverb]"
 


### PR DESCRIPTION
Whispering with a speech verb such as mrowls or rawrs with a speech problem would cause two conditions to be met to add quietly or softly adverbs, causing the issue in #9561 . 

This PR makes the speech problem statement check if an adverb was already added or not before adding one.

:cl: DesolateG
fix: Added a check to whispering adverbs to prevent double adverbs while whispering.
/:cl: 