### PR TITLE
Jade lipstick color fix (and minor refactor)

### DIFF
--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -12,8 +12,11 @@
 	colour = "purple"
 
 /obj/item/lipstick/jade
-	//It's still called Jade, but theres no HTML color for jade, so we use lime.
 	name = "jade lipstick"
+	colour = "#216F43"
+
+/obj/item/lipstick/lime
+	name = "lime lipstick"
 	colour = "lime"
 
 /obj/item/lipstick/black

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -6,49 +6,51 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/colour = "red"
 	var/open = 0
-	var/stickprefix = "red"
+	var/list/lipstick_colors = list(
+		"purple" = "purple",
+		"jade" = "#216F43",
+		"lime" = "lime",
+		"black" = "black",
+		"green" = "green",
+		"blue" = "blue",
+		"white" = "white")
+
 
 /obj/item/lipstick/purple
 	name = "purple lipstick"
 	colour = "purple"
-	stickprefix = "purple"
 
 /obj/item/lipstick/jade
 	name = "jade lipstick"
 	colour = "#216F43"
-	stickprefix = "jade"
 
 /obj/item/lipstick/lime
 	name = "lime lipstick"
 	colour = "lime"
-	stickprefix = "lime"
 
 /obj/item/lipstick/black
 	name = "black lipstick"
 	colour = "black"
-	stickprefix = "black"
 
 /obj/item/lipstick/green
 	name = "green lipstick"
 	colour = "green"
-	stickprefix = "green"
 
 /obj/item/lipstick/blue
 	name = "blue lipstick"
 	colour = "blue"
-	stickprefix = "blue"
 
 /obj/item/lipstick/white
 	name = "white lipstick"
 	colour = "white"
-	stickprefix = "white"
 
 /obj/item/lipstick/random
 	name = "lipstick"
 
 /obj/item/lipstick/random/New()
-	colour = pick("red","purple","lime","black","green","blue","white","#216F43")
-	name = "[stickprefix] lipstick"
+	var/lscolor = pick(lipstick_colors)
+	colour = lipstick_colors[lscolor]
+	name = "[lscolor] lipstick"
 
 
 /obj/item/lipstick/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -48,9 +48,9 @@
 	name = "lipstick"
 
 /obj/item/lipstick/random/New()
-	var/lscolor = pick(lipstick_colors)
-	colour = lipstick_colors[lscolor]
-	name = "[lscolor] lipstick"
+	var/lscolor = pick(lipstick_colors)//A random color is picked from the var defined initially in a new var.
+	colour = lipstick_colors[lscolor]//The color of the lipstick is pulled from the new variable (right hand side, HTML & Hex RGB)
+	name = "[lscolor] lipstick"//The new variable is also used to match the name to the color of the lipstick. Kudos to Desolate & Lemon
 
 
 /obj/item/lipstick/attack_self(mob/user as mob)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -6,41 +6,49 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/colour = "red"
 	var/open = 0
+	var/stickprefix = "red"
 
 /obj/item/lipstick/purple
 	name = "purple lipstick"
 	colour = "purple"
+	stickprefix = "purple"
 
 /obj/item/lipstick/jade
 	name = "jade lipstick"
 	colour = "#216F43"
+	stickprefix = "jade"
 
 /obj/item/lipstick/lime
 	name = "lime lipstick"
 	colour = "lime"
+	stickprefix = "lime"
 
 /obj/item/lipstick/black
 	name = "black lipstick"
 	colour = "black"
+	stickprefix = "black"
 
 /obj/item/lipstick/green
 	name = "green lipstick"
 	colour = "green"
+	stickprefix = "green"
 
 /obj/item/lipstick/blue
 	name = "blue lipstick"
 	colour = "blue"
+	stickprefix = "blue"
 
 /obj/item/lipstick/white
 	name = "white lipstick"
 	colour = "white"
+	stickprefix = "white"
 
 /obj/item/lipstick/random
 	name = "lipstick"
 
 /obj/item/lipstick/random/New()
-	colour = pick("red","purple","lime","black","green","blue","white")
-	name = "[colour] lipstick"
+	colour = pick("red","purple","lime","black","green","blue","white","#216F43")
+	name = "[stickprefix] lipstick"
 
 
 /obj/item/lipstick/attack_self(mob/user as mob)

--- a/code/modules/client/preference/loadout/loadout_cosmetics.dm
+++ b/code/modules/client/preference/loadout/loadout_cosmetics.dm
@@ -1,7 +1,11 @@
 /datum/gear/lipstick
+	display_name = "lipstick, red"
+	path = /obj/item/lipstick
+	sort_category = "Cosmetics"
+
+/datum/gear/lipstick/black
 	display_name = "lipstick, black"
 	path = /obj/item/lipstick/black
-	sort_category = "Cosmetics"
 
 /datum/gear/lipstick/jade
 	display_name = "lipstick, jade"
@@ -11,9 +15,13 @@
 	display_name = "lipstick, purple"
 	path = /obj/item/lipstick/purple
 
-/datum/gear/lipstick/red
-	display_name = "lipstick, red"
-	path = /obj/item/lipstick
+/datum/gear/lipstick/blue
+	display_name = "lipstick, blue"
+	path = /obj/item/lipstick/blue
+
+/datum/gear/lipstick/lime
+	display_name = "lipstick, lime"
+	path = /obj/item/lipstick/lime
 
 /datum/gear/monocle
 	display_name = "monocle"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15992551/45924254-54248080-beb0-11e8-90e8-cd309cc07055.png)
![image](https://user-images.githubusercontent.com/15992551/45925799-47fceb00-bed1-11e8-92b1-1c3c75f0e2d7.png)
![image](https://user-images.githubusercontent.com/15992551/45925801-492e1800-bed1-11e8-98c5-7844b36999a5.png)




Changes an HTML color call to an RGB value, jade should not be lime.
Adds [stickprefix] and makes the naming scheme for random lipstick use that variable. Now any RGB 
 Hex code can be called instead of HTML color codes. Taste the lipstick rainbow.

:cl: Triiodine
Fix: Fixes jade lipstick being lime.
Add: Adds lime lipstick.
/:cl: