### PR TITLE
Fixes gear disappearing on lobby screen

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -316,8 +316,7 @@
 	job_master.AssignRole(src, rank, 1)
 
 	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
-	character = job_master.EquipRank(character, rank, 1)					//equips the human
-	EquipCustomItems(character)
+
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
@@ -364,6 +363,9 @@
 		character.buckled.dir = character.dir
 
 	ticker.mode.latespawn(character)
+
+	character = job_master.EquipRank(character, rank, 1)					//equips the human
+	EquipCustomItems(character)
 
 	if(character.mind.assigned_role == "Cyborg")
 		AnnounceCyborg(character, rank, join_message)


### PR DESCRIPTION
This change the order in which items is equipped onto a late joining character.

This way excessive gears will be dropped onto the floor instead of in the lobby screen. Do note there might be a slight balance issue because of how this make plasmaman get an extra copy of their gears. That is something that'll be fixed in another PR (Or this one if the maints want to)

Vox's advanced medkit no longer disappears.

Fixes #9120 
Fixes #2519

DOES NOT fix bible not spawning on vox. That's a separate overriding issue.

🆑:
tweak: When you late join, extra items you can't equip / hold spawn on the ground instead of in the lobby screen. Including vox medkit etc.
/🆑 

