### PR TITLE
Adds in drop_location & AllowDrop()

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -395,3 +395,9 @@
 		temp_airlock.prison_open()
 	for(var/obj/machinery/door/window/temp_windoor in src)
 		temp_windoor.open()
+
+/area/AllowDrop()
+	CRASH("Bad op: area/AllowDrop() called")
+
+/area/drop_location()
+	CRASH("Bad op: area/drop_location() called")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -204,9 +204,6 @@
 
 
 
-/atom/proc/allow_drop()
-	return 1
-
 /atom/proc/CheckExit()
 	return 1
 
@@ -713,3 +710,12 @@ var/list/blood_splatter_icons = list()
 	.["Add reagent"] = "?_src_=vars;addreagent=[UID()]"
 	.["Trigger explosion"] = "?_src_=vars;explode=[UID()]"
 	.["Trigger EM pulse"] = "?_src_=vars;emp=[UID()]"
+
+/atom/proc/AllowDrop()
+	return FALSE
+
+/atom/proc/drop_location()
+	var/atom/L = loc
+	if(!L)
+		return null
+	return L.AllowDrop() ? L : get_turf(L)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -103,8 +103,8 @@
 	for(var/obj/item/stock_parts/micro_laser/P in component_parts)
 		damage_coeff = P.rating
 
-/obj/machinery/dna_scannernew/allow_drop()
-	return 0
+/obj/machinery/dna_scannernew/AllowDrop()
+	return FALSE
 
 /obj/machinery/dna_scannernew/relaymove(mob/user as mob)
 	if(user.stat)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -519,8 +519,8 @@
 		return
 	return
 
-/obj/machinery/sleeper/allow_drop()
-	return 0
+/obj/machinery/sleeper/AllowDrop()
+	return FALSE
 
 /obj/machinery/sleeper/verb/move_inside()
 	set name = "Enter Sleeper"

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -149,8 +149,8 @@
 		parent.update = 1
 
 
-/obj/machinery/atmospherics/unary/cryo_cell/allow_drop()
-	return 0
+/obj/machinery/atmospherics/unary/cryo_cell/AllowDrop()
+	return FALSE
 
 
 /obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user as mob)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -109,8 +109,8 @@
 /obj/machinery/recharge_station/Bumped(var/mob/AM)
 	move_inside(AM)
 
-/obj/machinery/recharge_station/allow_drop()
-	return 0
+/obj/machinery/recharge_station/AllowDrop()
+	return FALSE
 
 /obj/machinery/recharge_station/relaymove(mob/user as mob)
 	if(user.stat)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -41,8 +41,8 @@
 	var/inject_amount = 10
 	salvageable = 0
 
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/allow_drop()
-	return 0
+/obj/item/mecha_parts/mecha_equipment/medical/sleeper/AllowDrop()
+	return FALSE
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/Destroy()
 	for(var/atom/movable/AM in src)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -165,8 +165,6 @@
 			to_chat(user, "[bicon(ME)] [ME]")
 
 
-/obj/mecha/proc/drop_item()//Derpfix, but may be useful in future for engineering exosuits.
-	return
 
 /obj/mecha/hear_talk(mob/M, text)
 	if(M == occupant && radio.broadcasting)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -557,3 +557,6 @@
 		else
 			log_runtime(EXCEPTION("Non-list thing found in storage/deserialize."), src, list("Thing: [thing]"))
 	..()
+
+/obj/item/storage/AllowDrop()
+	return TRUE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -424,3 +424,6 @@
 /obj/structure/closet/get_remote_view_fullscreens(mob/user)
 	if(user.stat == DEAD || !(user.sight & (SEEOBJS|SEEMOBS)))
 		user.overlay_fullscreen("remote_view", /obj/screen/fullscreen/impaired, 1)
+
+/obj/structure/closet/AllowDrop()
+	return TRUE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -475,3 +475,6 @@
 	SSair.remove_from_active(T0)
 	T0.CalculateAdjacentTurfs()
 	SSair.add_to_active(T0,1)
+
+/turf/AllowDrop()
+	return TRUE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -83,7 +83,7 @@
 //This is probably the main one you need to know :)
 //Just puts stuff on the floor for most mobs, since all mobs have hands but putting stuff in the AI/corgi/ghost hand is VERY BAD.
 /mob/proc/put_in_hands(obj/item/W)
-	W.forceMove(get_turf(src))
+	W.forceMove(drop_location())
 	W.layer = initial(W.layer)
 	W.plane = initial(W.plane)
 	W.dropped()
@@ -137,7 +137,7 @@
 	if(I)
 		if(client)
 			client.screen -= I
-		I.forceMove(loc)
+		I.forceMove(drop_location())
 		I.dropped(src)
 		if(I)
 			I.layer = initial(I.layer)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -68,8 +68,6 @@
 /mob/living/silicon/proc/show_laws()
 	return
 
-/mob/living/silicon/drop_item()
-	return
 
 /mob/living/silicon/emp_act(severity)
 	switch(severity)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -68,6 +68,8 @@
 /mob/living/silicon/proc/show_laws()
 	return
 
+/mob/living/silicon/drop_item()
+	return
 
 /mob/living/silicon/emp_act(severity)
 	switch(severity)

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -24,7 +24,7 @@
 	if(!check_functionality())
 		return FALSE
 
-	var/obj/item/paper/P = new/obj/item/paper(get_turf(holder))
+	var/obj/item/paper/P = new/obj/item/paper(holder.drop_location())
 
 	// Damaged printer causes the resulting paper to be somewhat harder to read.
 	if(damage > damage_malfunction)


### PR DESCRIPTION
Basically a mirror of #tgstation/tgstation/pull/29814 . This add in drop_location() and AllowDrop(). This DOES NOT refactor what we have extensively or replace get_turf with drop_location() extensively to avoid creating a lot of reviewing works.

I'll need to look into how we handle items being moved into nullspace & review this PR before considering it ready, however.

🆑:
tweak: drop_location & AllowDrop() has been ported over from tg. Report unexpected issues with dropping items.
/🆑 