### PR TITLE
Fix of #3313

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -708,13 +708,13 @@
 
 
 
-	if(NO_BLOOD in H.dna.species.species_traits)
-		return
+	if(NO_BLOOD in H.dna.species.species_traits)//Does the run over mob have blood?
+		return//If it doesn't it shouldn't bleed (Though a check should be made eventually for things with liquid in them, like slime people, vox armalis, etc.)
 	else
-		var/turf/T = get_turf(src)
-	H.add_mob_blood(H)
-	H.add_splatter_floor(T)
-	bloodiness += 4
+		var/turf/T = get_turf(src)//Where are we?
+		H.add_mob_blood(H)//Cover the victim in their own blood.
+		H.add_splatter_floor(T)//Put the blood where we are.
+		bloodiness += 4
 
 	var/list/blood_dna = H.get_blood_dna_list()
 	if(blood_dna)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -710,11 +710,11 @@
 
 	if(NO_BLOOD in H.dna.species.species_traits)//Does the run over mob have blood?
 		return//If it doesn't it shouldn't bleed (Though a check should be made eventually for things with liquid in them, like slime people, vox armalis, etc.)
-	else
-		var/turf/T = get_turf(src)//Where are we?
-		H.add_mob_blood(H)//Cover the victim in their own blood.
-		H.add_splatter_floor(T)//Put the blood where we are.
-		bloodiness += 4
+
+	var/turf/T = get_turf(src)//Where are we?
+	H.add_mob_blood(H)//Cover the victim in their own blood.
+	H.add_splatter_floor(T)//Put the blood where we are.
+	bloodiness += 4
 
 	var/list/blood_dna = H.get_blood_dna_list()
 	if(blood_dna)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -706,10 +706,14 @@
 	H.apply_damage(0.5*damage, BRUTE, "r_arm", run_armor_check("r_arm", "melee"))
 
 
-	var/turf/T = get_turf(src)
+
+
+	if(NO_BLOOD in H.dna.species.species_traits)
+		return
+	else
+		var/turf/T = get_turf(src)
 	H.add_mob_blood(H)
 	H.add_splatter_floor(T)
-
 	bloodiness += 4
 
 	var/list/blood_dna = H.get_blood_dna_list()


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/3313 while still working with Aurorablade's blood refactor. Things without blood will no longer leak, however this doesn't (yet) account for species with 'exotic blood' (Slimes, Vox Armalis, etc...). Thanks to @DesolateG and @SamHPurp for helping with this one. 

A better fix a for more experienced coder to implement would to have a check for if the rolled over mob has exotic blood (despite a NO_BLOOD flag) and to display the color of said 'blood'.

![image](https://user-images.githubusercontent.com/15992551/45931784-a9e83f80-bf27-11e8-8b10-865f961cd205.png)
The above will no longer happen.
![image](https://user-images.githubusercontent.com/15992551/45931786-b2407a80-bf27-11e8-98ca-dfe6c232fd5e.png)
Honk.

:cl: Triiodine, Desolate,
fix: Things without blood bleeding red when rolled over by a mulebot.
/:cl: