### PR TITLE
Fixes missing space turfs in Intactemptyship.dmm

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -1,7 +1,7 @@
 "a" = (/turf/space,/area/space)
-"b" = (/turf/simulated/shuttle/wall{dir = 8; icon_state = "diagonalWall3"},/area/ruin/powered)
+"b" = (/turf/space,/turf/simulated/shuttle/wall{dir = 8; icon_state = "diagonalWall3"},/area/ruin/powered)
 "c" = (/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/ruin/powered)
-"d" = (/turf/simulated/shuttle/wall{dir = 1; icon_state = "diagonalWall3"},/area/ruin/powered)
+"d" = (/turf/space,/turf/simulated/shuttle/wall{dir = 2; icon_state = "diagonalWall3"},/area/ruin/powered)
 "e" = (/obj/structure/shuttle/engine/propulsion{dir = 8; icon_state = "propulsion"; tag = "icon-propulsion (EAST)"},/turf/space,/area/ruin/powered)
 "f" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/shuttle/engine/heater{tag = "icon-heater (WEST)"; icon_state = "heater"; dir = 8},/turf/simulated/floor/plating,/area/ruin/powered)
 "g" = (/obj/structure/table/wood,/obj/item/clothing/under/shorts/black,/turf/simulated/shuttle/floor{tag = "icon-floor5"; icon_state = "floor5"},/area/ruin/powered)
@@ -24,22 +24,22 @@
 "x" = (/obj/machinery/door_control{name = "Strange Ship Door Control"; pixel_x = 6; pixel_y = 0; id = "strange ship"},/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/ruin/powered)
 "y" = (/obj/machinery/light,/turf/simulated/shuttle/floor{tag = "icon-floor5"; icon_state = "floor5"},/area/ruin/powered)
 "z" = (/mob/living/simple_animal/bot/medbot,/turf/simulated/shuttle/floor{tag = "icon-floor5"; icon_state = "floor5"},/area/ruin/powered)
-"A" = (/turf/simulated/shuttle/wall{dir = 2; icon_state = "diagonalWall3"},/area/ruin/powered)
+"A" = (/turf/space,/turf/simulated/shuttle/wall{dir = 1; icon_state = "diagonalWall3"},/area/ruin/powered)
 "B" = (/obj/structure/stool/bed/chair,/turf/simulated/shuttle/floor{tag = "icon-floor5"; icon_state = "floor5"},/area/ruin/powered)
-"C" = (/turf/simulated/shuttle/wall{dir = 4; icon_state = "diagonalWall3"},/area/ruin/powered)
+"C" = (/turf/space,/turf/simulated/shuttle/wall{dir = 4; icon_state = "diagonalWall3"},/area/ruin/powered)
 "D" = (/obj/machinery/light,/obj/structure/stool/bed,/turf/simulated/shuttle/floor{tag = "icon-floor5"; icon_state = "floor5"},/area/ruin/powered)
 
 (1,1,1) = {"
-aabcccccdaaaa
+aabcccccAaaaa
 aefghijkcaaaa
-aeflhhhhccccd
+aeflhhhhccccA
 bccccmhhcmhjc
 cnophhhhqhhrc
 shhthhhhuhvwc
 xhypzhhhqhhnc
-Accccmhhcmhjc
+dccccmhhcmhjc
 aefBhhhhccccC
 aefnnDhjcaaaa
-aaAcccccCaaaa
+aadcccccCaaaa
 "}
 


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/7415122/45971717-a7720c80-c031-11e8-82d4-eb63a61e12ed.png)


:cl: Purpose
fix: Space is now visible under corner pieces of the Intact Empty Ship ruin.
/:cl: