### PR TITLE
Fixes 128x128 Scaling

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1421,11 +1421,9 @@ menu "menu"
 	elem "icon128"
 		name = "&128x128 (4x)"
 		command = ".winset \"mapwindow.map.icon-size=128\""
-		category = "&Icons"
-		is-checked = false
+		category = "&Size"
 		can-check = true
 		group = "size"
-		is-disabled = false
 		saved-params = "is-checked"		
 	elem "icon96"
 		name = "&96x96 (3x)"


### PR DESCRIPTION
Ensures 128x128 scaling is in the correct location.

Fixes https://github.com/ParadiseSS13/Paradise/issues/9614

:cl: Fox McCloud
fix: Fixes 128x128 menu location
/:cl: