### PR TITLE
Avert plasmaman taking over Paradise with double firepower

### DIFF
--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -83,7 +83,6 @@
 		if("Warden","Security Officer","Security Pod Pilot")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/security
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security
-			H.equip_or_collect(new /obj/item/gun/energy/gun/advtaser(H), slot_in_backpack)
 		if("Internal Affairs Agent")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/lawyer
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/lawyer
@@ -93,7 +92,6 @@
 		if("Head of Security")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/hos
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/hos
-			H.equip_or_collect(new /obj/item/gun/energy/gun(H), slot_in_backpack)
 		if("Captain", "Blueshield")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/security/captain
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/security/captain


### PR DESCRIPTION
With the latetst gear spawn in arrival fix, latespawned plasmaman's job gun now spawn in properly. However their species also equip them with an extra gun when spawning.

So they got their job gun on the floor and their species gun in the backpack, doubling their firepower.

This removes their species gun. Yes, this will leave their job-gun on the floor. This should be a separate PR's matter to fix. It might require a refactor of equip logic (With prioritized slot).

🆑:
fix: Plasmaman no longer get double the firepower when spawning in as Captain, BS, or sec roles.
/🆑 