### PR TITLE
Fixes point blank shots not hitting the correct target if multiple people are on the same tile.

### DIFF
--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -40,6 +40,12 @@
 	if(!istype(targloc) || !istype(curloc) || !BB)
 		return 0
 	BB.ammo_casing = src
+	
+	if(target && get_dist(user, target) <= 1) //Point blank shot must always hit
+		target.bullet_act(BB, BB.def_zone)
+		QDEL_NULL(BB)
+		return 1
+
 	if(targloc == curloc)
 		if(target) //if the target is right on our location we go straight to bullet_act()
 			target.bullet_act(BB, BB.def_zone)


### PR DESCRIPTION
Fixes #9092 

Before:
![image](https://user-images.githubusercontent.com/15887760/46165455-f4075300-c290-11e8-905d-fb46f0774d91.png)
After:
![image](https://user-images.githubusercontent.com/15887760/46165792-c8389d00-c291-11e8-94b5-aeeb37d67efd.png)

🆑 Farie82
fix: Point blank shots not hitting the correct person. When multiple people are on the same tile.
/🆑