### PR TITLE
It is no longer possible to duplicate uvents.

### DIFF
--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -381,6 +381,8 @@
 	if(!welded)
 		if(open)
 			for(var/obj/item/W in src)
+				if(istype(W, /obj/item/pipe))
+					continue
 				W.forceMove(get_turf(src))
 
 


### PR DESCRIPTION
I don't know if it is an elegant fix, but it is a fix.

Fixes #9193

:cl: uc_guy
fix: It is no longer possible to duplicate uvents.
/:cl: