### PR TITLE
Fixes the cling transform sting problem and adds a proc for it

### DIFF
--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -81,3 +81,18 @@
 	if(req_human && !ishuman(user))
 		return 0
 	return 1
+
+// Transform the target to the chosen dna. Used in transform.dm and tiny_prick.dm (handy for changes since it's the same thing done twice)
+/obj/effect/proc_holder/changeling/proc/transform_dna(var/mob/living/carbon/human/H, var/datum/dna/D)
+	if(!D)
+		return
+	
+	H.set_species(D.species.type)
+	H.dna = D.Clone()
+	H.real_name = D.real_name
+	domutcheck(H, null, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
+	H.flavor_text = ""
+	H.dna.UpdateSE()
+	H.dna.UpdateUI()
+	H.sync_organ_dna(1)
+	H.UpdateAppearance()

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -100,7 +100,6 @@
 
 /obj/effect/proc_holder/changeling/sting/transformation/sting_action(var/mob/user, var/mob/target)
 	add_attack_logs(user, target, "Transformation sting (changeling) (new identity is [selected_dna.real_name])")
-	var/datum/dna/NewDNA = selected_dna
 	if(issmall(target))
 		to_chat(user, "<span class='notice'>Our genes cry out as we sting [target.name]!</span>")
 
@@ -111,13 +110,7 @@
 	target.visible_message("<span class='danger'>[target] begins to violenty convulse!</span>","<span class='userdanger'>You feel a tiny prick and a begin to uncontrollably convulse!</span>")
 
 	spawn(10)
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			H.set_species(NewDNA.species.type)
-		target.dna = NewDNA.Clone()
-		target.real_name = NewDNA.real_name
-		target.UpdateAppearance()
-		domutcheck(target, null)
+		transform_dna(target,selected_dna)//target is always human so no problem here
 	feedback_add_details("changeling_powers","TS")
 	return TRUE
 

--- a/code/game/gamemodes/changeling/powers/transform.dm
+++ b/code/game/gamemodes/changeling/powers/transform.dm
@@ -14,16 +14,8 @@
 
 	if(!chosen_dna)
 		return
-	if(ishuman(user))
-		user.set_species(chosen_dna.species.type)
-	user.dna = chosen_dna.Clone()
-	user.real_name = chosen_dna.real_name
-	domutcheck(user, null, MUTCHK_FORCED) //Ensures species that get powers by the species proc handle_dna keep them
-	user.flavor_text = ""
-	user.dna.UpdateSE()
-	user.dna.UpdateUI()
-	user.sync_organ_dna(1)
-	user.UpdateAppearance()
+	
+	transform_dna(user,chosen_dna)
 
 	user.changeling_update_languages(changeling.absorbed_languages)
 


### PR DESCRIPTION
fixes #9536 

Fixes the transformed humanoids looking kinda pale.
I cried when I saw that the problem was that the transform code was not fully copied to the transform sting code. So I made a proc for it.

before:
![pre](https://user-images.githubusercontent.com/15887760/46228235-b292a880-c361-11e8-89f9-89ccbea4b598.PNG)

after:
![after](https://user-images.githubusercontent.com/15887760/46228237-b4f50280-c361-11e8-8bcc-1db1fc7bce21.PNG)

:cl: farie82
fix: fixed cling transformed humanoids looking rather pale.
/:cl:

