### PR TITLE
Fixed emagged camera consoles not opening the tabs

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -116,7 +116,10 @@
 
 /obj/machinery/computer/security/proc/get_user_access(mob/user)
 	var/list/access = list()
-	if(ishuman(user))
+	
+	if(emagged)
+		access = get_all_accesses() // Assume captain level access when emagged
+	else if(ishuman(user))
 		access = user.get_access()
 	else if((isAI(user) || isrobot(user)) && CanUseTopic(user, default_state) == STATUS_INTERACTIVE)
 		access = get_all_accesses() // Assume captain level access when AI
@@ -159,7 +162,6 @@
 
 	var/list/access = get_user_access(user)
 	if(emagged)
-		access = get_all_accesses() // Assume captain level access when emagged
 		data["emagged"] = 1
 
 	var/list/networks_list = list()


### PR DESCRIPTION
Fixes #8707 
Previously the tabs would not allow you to open them even though it was emagged.
Moved the emag check to the actual proc that checks for access.

:cl: farie82
fix: Fixed emagged camera consoles not opening the tabs
/:cl:

