### PR TITLE
Nerfs Medical Plasmemes, No extra penlights for you!

### DIFF
--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -104,7 +104,6 @@
 		if("Medical Doctor","Brig Physician","Virologist")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/medical
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/medical
-			H.equip_or_collect(new /obj/item/flashlight/pen(H), slot_in_backpack)
 		if("Paramedic")
 			suit=/obj/item/clothing/suit/space/eva/plasmaman/medical/paramedic
 			helm=/obj/item/clothing/head/helmet/space/eva/plasmaman/medical/paramedic


### PR DESCRIPTION
**What does this PR do:**
Fixes #9622. Also, does this count towards my thingy.

**Changelog:**
:cl: Dapocalypse
fix: Removes extra penlight given to plasmemes.
/:cl:

