### PR TITLE
Fix of #8056

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -146,6 +146,7 @@ proc/issyndicate(mob/living/M as mob)
 
 	M.set_species(/datum/species/human, TRUE)
 	M.dna.ready_dna(M) // Quadriplegic Nuke Ops won't be participating in the paralympics
+	M.dna.species.create_organs(M)
 	M.reagents.add_reagent("mutadone", 1) //No fat/blind/colourblind/epileptic/whatever ops.
 	M.overeatduration = 0
 


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/8056 by calling a proc that replaces all nukeops organs with their default species (human) organs, instead of taking them with from the player's organ preferences (Which is apparently what used to happen). No longer will paraplegic nukies EMP themselves to death.

![AltText](https://media.giphy.com/media/etQ7nOXvZ9Hkehw1t4/giphy.gif)
_In testing I set nuclear emergency to only require 1 player, spawned in as nukeop with the shown prefs, etc._

This should probably be done for wizards, changelings, and shadowlings (Maybe SIT as well.) given that those antagonists are **not** the character a player has setup on their selection screen. I might get around to them later.


:cl: Triiodine
fix: Nukies spawning with cybernetic organs/limbs
/:cl:

