### PR TITLE
Refactor the airlock.DM and changed a smoll inconsistency

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -306,6 +306,10 @@ About the new airlock wires panel:
 	else
 		return 0
 
+//Checks if the user can get shocked and shocks him if it can. Returns TRUE if it happened
+/obj/machinery/door/airlock/proc/shock_user(mob/user, prob)
+	return (!issilicon(user) && isElectrified() && shock(user, prob))
+
 /obj/machinery/door/airlock/update_icon(state=0, override=0)
 	if(operating && !override)
 		return
@@ -630,11 +634,25 @@ About the new airlock wires panel:
 	return ..()
 
 /obj/machinery/door/airlock/attack_hand(mob/user)
-	if(!issilicon(user))
-		if(isElectrified())
-			if(shock(user, 100))
-				return
+	if(shock_user(user, 100))
+		return
 
+	if(headbutt_airlock(user))
+		return//Smack that head against that airlock
+	if(remove_airlock_note(user, FALSE))
+		return
+
+	if(panel_open)
+		if(security_level)
+			to_chat(user, "<span class='warning'>Wires are protected!</span>")
+			return
+		wires.Interact(user)
+	else
+		..()
+
+
+//Checks if the user can headbutt the airlock and does it if it can. Returns TRUE if it happened
+/obj/machinery/door/airlock/proc/headbutt_airlock(mob/user)
 	if(ishuman(user) && prob(40) && density)
 		var/mob/living/carbon/human/H = user
 		if(H.getBrainLoss() >= 60 && Adjacent(user))
@@ -648,23 +666,23 @@ About the new airlock wires panel:
 					H.UpdateDamageIcon()
 			else
 				visible_message("<span class='warning'>[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet.</span>")
-			return
+			return TRUE
+	return FALSE
 
-	if(note && ishuman(user) && user.a_intent == INTENT_GRAB)
-		user.visible_message("<span class='notice'>[user] removes [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
-		playsound(src, 'sound/items/poster_ripped.ogg', 50, 1)
-		note.forceMove(get_turf(user))
-		note = null
-		update_icon()
+//For the tools being used on the door. Since you don't want to call the attack_hand method if you're using hands. That would be silly
+//Also it's a bit inconsistent that when you access the panel you headbutt it. But not while crowbarring 
+//Try to interact with the panel. If the user can't it'll try activating the door
+/obj/machinery/door/airlock/proc/interact_with_panel(mob/user)
+	if(shock_user(user, 100))
 		return
-
+	
 	if(panel_open)
 		if(security_level)
 			to_chat(user, "<span class='warning'>Wires are protected!</span>")
 			return
 		wires.Interact(user)
 	else
-		..()
+		try_to_activate_door(user)
 
 /obj/machinery/door/airlock/CanUseTopic(mob/user)
 	if(!issilicon(user) && !isobserver(user))
@@ -785,12 +803,13 @@ About the new airlock wires panel:
 	return 1
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
-	if(!issilicon(user))
-		if(isElectrified())
-			if(shock(user, 75))
-				return
+	if(shock_user(user, 75))
+		return
 
 	add_fingerprint(user)
+
+	if(headbutt_airlock(user))//See if the user headbutts the airlock
+		return
 
 	if(panel_open)
 		switch(security_level)
@@ -930,17 +949,13 @@ About the new airlock wires panel:
 		update_icon()
 	else if(iswirecutter(C))
 		if(note)
-			user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
-			playsound(src, 'sound/items/Wirecutter.ogg', 50, 1)
-			note.forceMove(get_turf(user))
-			note = null
-			update_icon()
+			remove_airlock_note(user, TRUE)
 		else
-			return attack_hand(user)
+			return interact_with_panel(user)
 	else if(ismultitool(C))
-		return attack_hand(user)
+		return interact_with_panel(user)
 	else if(istype(C, /obj/item/assembly/signaler))
-		return attack_hand(user)
+		return interact_with_panel(user)
 	else if(istype(C, /obj/item/pai_cable))	// -- TLE
 		var/obj/item/pai_cable/cable = C
 		cable.plugin(src, user)
@@ -1301,6 +1316,23 @@ About the new airlock wires panel:
 		return "note"
 	else if(istype(note, /obj/item/photo))
 		return "photo"
+
+//Removes the current note on the door if any. Returns if a note is removed
+/obj/machinery/door/airlock/proc/remove_airlock_note(mob/user, wirecutters_used=TRUE)
+	if(note)
+		if(!wirecutters_used)
+			if (ishuman(user) && user.a_intent == INTENT_GRAB)//grab that note
+				user.visible_message("<span class='notice'>[user] removes [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
+				playsound(src, 'sound/items/poster_ripped.ogg', 50, 1)
+			else return FALSE
+		else 
+			user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
+			playsound(src, 'sound/items/Wirecutter.ogg', 50, 1)
+		note.forceMove(get_turf(user))
+		note = null
+		update_icon()
+		return TRUE
+	return FALSE
 
 /obj/machinery/door/airlock/narsie_act()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
Refactors the airlock.DM.

- removes the calls to attack_hand from the tool part
- Makes procs from functionallity that is used more than once or is just to big for the current proc.
- Adds the headbutting to the tool usage as well. So there is a chance to headbutt the airlock if you want to add grilling or such.

:cl: farie82
tweak: Headbutting the airlock is more consistent.
fix: refactored the airlock code.
fix: Using multitools and such on a door with a note now doesn't remove the note. Only grabbing with an empty hand now.
/:cl:

