### PR TITLE
Finally fixes one click antagonist giving antag to the wrong people

### DIFF
--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -32,7 +32,7 @@ client/proc/one_click_antag()
 	if(M.stat || !M.mind || M.mind.special_role)
 		return FALSE
 	if(temp)
-		if(M.mind.assigned_role in temp.restricted_jobs || M.mind.assigned_role in temp.protected_jobs || M.client.prefs.species in temp.protected_species)
+		if((M.mind.assigned_role in temp.restricted_jobs) || (M.client.prefs.species in temp.protected_species))
 			return FALSE
 	if(role) // Don't even bother evaluating if there's no role
 		if(player_old_enough_antag(M.client,role) && (role in M.client.prefs.be_special) && (!jobban_isbanned(M, role)))


### PR DESCRIPTION
**What does this PR do:**
Unfortunately Bird's PR didn't catch the actual problem.

It was brackets.

Brackets, brackets, my kingdom for two brackets.

Kids, don't forget to put parenthesis or BYOND will mess you up with order of operation.

🆑 
fix: One click antagonist giving antag to people in restricted job.
/🆑 

