### PR TITLE
Added the ability to print a virus release form using the PANDEMIC

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -184,7 +184,8 @@
 		var/reason = input(user,"Enter a reason for the release", "Write", null) as message
 		reason += "<span class=\"paper_field\"></span>"
 		var/english_symptoms = list()
-		for(var/datum/symptom/S in D.symptoms)
+		for(var/I in D.symptoms)
+			var/datum/symptom/S = I
 			english_symptoms += S.name
 		var/symtoms = english_list(english_symptoms)
 

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -9,6 +9,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 20
 	var/temp_html = ""
+	var/printing = null
 	var/wait = null
 	var/obj/item/reagent_containers/beaker = null
 
@@ -162,6 +163,10 @@
 			for(var/datum/disease/advance/AD in active_diseases)
 				AD.Refresh()
 		updateUsrDialog()
+	else if(href_list["print_form"])
+		var/datum/disease/D = GetVirusByIndex(text2num(href_list["print_form"]))
+		D = archive_diseases[D.GetDiseaseID()]//We know it's advanced no need to check
+		print_form(D, usr)
 
 
 	else
@@ -171,6 +176,46 @@
 
 	add_fingerprint(usr)
 	return
+
+//Prints a nice virus release form. Props to Urbanliner for the layout
+/obj/machinery/computer/pandemic/proc/print_form(var/datum/disease/advance/D, mob/living/user)
+	D = archive_diseases[D.GetDiseaseID()]
+	if(!(printing) && D)
+		var/reason = input(user,"Enter a reason for the release", "Write", null) as message
+		reason += "<span class=\"paper_field\"></span>"
+		var/english_symptoms = list()
+		for(var/datum/symptom/S in D.symptoms)
+			english_symptoms += S.name
+		var/symtoms = english_list(english_symptoms)
+
+		
+		var/signature
+		if(alert(user,"Would you like to add your signature?",,"Yes","No") == "Yes")
+			signature = "<font face=\"[SIGNFONT]\"><i>[user ? user.real_name : "Anonymous"]</i></font>"
+		else 
+			signature = "<span class=\"paper_field\"></span>"
+		
+		printing = 1
+		var/obj/item/paper/P = new /obj/item/paper(loc)
+		visible_message("<span class='notice'>[src] rattles and prints out a sheet of paper.</span>")
+		playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
+		
+		P.info = "<U><font size=\"4\"><B><center> Releasing Virus </B></center></font></U>"
+		P.info += "<HR>"
+		P.info += "<U>Name of the Virus:</U> [D.name] <BR>"
+		P.info += "<U>Symptoms:</U> [symtoms]<BR>"
+		P.info += "<U>Spreads by:</U> [D.spread_text]<BR>"
+		P.info += "<U>Cured by:</U> [D.cure_text]<BR>"
+		P.info += "<BR>"
+		P.info += "<U>Reason for releasing:</U> [reason]"
+		P.info += "<HR>"
+		P.info += "The Virologist is responsible for any biohazards caused by the virus released.<BR>"
+		P.info += "<U>Virologist's sign:</U> [signature]<BR>"
+		P.info += "If approved, stamp below with the Chief Medical Officer's stamp, and/or the Captain's stamp if required:"
+		P.populatefields()
+		P.updateinfolinks()
+		P.name = "Releasing Virus - [D.name]"
+		printing = null
 
 /obj/machinery/computer/pandemic/attack_hand(mob/user)
 	if(..())
@@ -214,8 +259,11 @@
 
 								var/datum/disease/advance/A = D
 								D = archive_diseases[A.GetDiseaseID()]
-								if(D && D.name == "Unknown")
-									dat += "<b><a href='?src=[UID()];name_disease=[i]'>Name Disease</a></b><BR>"
+								if(D)
+									if(D.name == "Unknown")
+										dat += "<b><a href='?src=[UID()];name_disease=[i]'>Name Disease</a></b><BR>"
+									else
+										dat += "<b><a href='?src=[UID()];print_form=[i]'>Print release form</a></b><BR>"
 
 							if(!D)
 								CRASH("We weren't able to get the advance disease from the archive.")


### PR DESCRIPTION
Adds the ability to print a virus release form using the PANDEMIC

1. Will check if the virus is advanced and named. If so add the option
2. When the button is pressed it'll ask for a reason to release. (Paper will have a field to add more to the reason if a mistake was made)
3. Then it'll ask if the user wants to sign the document himself.

Example (does not print prestamped, if only)
![image](https://user-images.githubusercontent.com/15887760/46250526-b8a98780-c43c-11e8-990f-72aec8098b05.png)



Props to Urbanliner for his virus form format.

Since it's a feature freeze, but a smol feature HUE. now I'll use this fix:
#9633

:cl: Farie82
add: PANDEMIC can print a virus release form now. Viromancers REJOICE!
/:cl:

