### PR TITLE
Corrects the comment for IPC damage

### DIFF
--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -15,8 +15,8 @@
 	skinned_type = /obj/item/stack/sheet/metal // Let's grind up IPCs for station resources!
 
 	eyes = "blank_eyes"
-	brute_mod = 2.5 // 100% * 2.5 * 0.6 (robolimbs) ~= 150%
-	burn_mod = 2.5  // So they take 50% extra damage from brute/burn overall.
+	brute_mod = 2.5 // 100% * 2.5 * 0.66 (robolimbs) = 165%
+	burn_mod = 2.5  // So they take 65% extra damage from brute/burn overall.
 	tox_mod = 0
 	clone_mod = 0
 	oxy_mod = 0


### PR DESCRIPTION
**What does this PR do:**
This PR corrects a comment that summarizes the math for IPC damage, to reflect reality.
Fixes #9566 

**Changelog:**
:cl: Crazylemon
tweak: Corrects a comment in the code regarding IPC damage.
/:cl: