### PR TITLE
Fixes RnD server control console data management

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -45,7 +45,8 @@
 	heat_gen /= max(1, tot_rating)
 
 /obj/machinery/r_n_d/server/proc/initialize_serv()
-	if(!files) files = new /datum/research(src)
+	if(!files)
+		files = new /datum/research(src)
 	var/list/temp_list
 	if(!id_with_upload.len)
 		temp_list = list()
@@ -252,7 +253,8 @@
 	else if(href_list["reset_tech"])
 		var/choice = alert("Technology Data Reset", "Are you sure you want to reset this technology to its default data? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
-			for(var/datum/tech/T in temp_server.files.known_tech)
+			for(var/I in temp_server.files.known_tech)
+				var/datum/tech/T = temp_server.files.known_tech[I]
 				if(T.id == href_list["reset_tech"])
 					T.level = 1
 					break
@@ -261,9 +263,10 @@
 	else if(href_list["reset_design"])
 		var/choice = alert("Design Data Deletion", "Are you sure you want to delete this design? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
-			for(var/datum/design/D in temp_server.files.known_designs)
+			for(var/I in temp_server.files.known_designs)
+				var/datum/design/D = temp_server.files.known_designs[I]
 				if(D.id == href_list["reset_design"])
-					temp_server.files.known_designs -= D
+					temp_server.files.known_designs -= D.id
 					break
 		temp_server.files.RefreshResearch()
 
@@ -312,13 +315,15 @@
 		if(2) //Data Management menu
 			dat += "[temp_server.name] Data Management<BR><BR>"
 			dat += "Known Technologies<BR>"
-			for(var/datum/tech/T in temp_server.files.known_tech)
+			for(var/I in temp_server.files.known_tech)
+				var/datum/tech/T = temp_server.files.known_tech[I]
 				if(T.level <= 0)
 					continue
 				dat += "* [T.name] "
 				dat += "<A href='?src=[UID()];reset_tech=[T.id]'>(Reset)</A><BR>" //FYI, these are all strings.
 			dat += "Known Designs<BR>"
-			for(var/datum/design/D in temp_server.files.known_designs)
+			for(var/I in temp_server.files.known_designs)
+				var/datum/design/D = temp_server.files.known_designs[I]
 				dat += "* [D.name] "
 				dat += "<A href='?src=[UID()];reset_design=[D.id]'>(Delete)</A><BR>"
 			dat += "<HR><A href='?src=[UID()];main=1'>Main Menu</A>"

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -310,7 +310,7 @@
 			dat += "<HR><A href='?src=[UID()];main=1'>Main Menu</A>"
 
 		if(2) //Data Management menu
-			dat += "[temp_server.name] Data ManagementP<BR><BR>"
+			dat += "[temp_server.name] Data Management<BR><BR>"
 			dat += "Known Technologies<BR>"
 			for(var/datum/tech/T in temp_server.files.known_tech)
 				if(T.level <= 0)


### PR DESCRIPTION
**What does this PR do:**
This fixes #9503 making the data management window of the server control console actually useful. Thanks to Birdtalon for spotting the error.
Also fixed a minor inconsistency where an if statement was on the same line as code, as well as a typo in the data management screen.

**Changelog:**
:cl:
fix: RnD server control console's data management now works, allowing for deletion of research levels and known techs.
/:cl:

