### PR TITLE
Laser tag guns can no longer set off plasma statues, fixes #7234

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -174,6 +174,8 @@
 
 /obj/structure/statue/plasma/bullet_act(obj/item/projectile/Proj)
 	var/burn = FALSE
+	if(Proj.damage == 0)//lasertag guns and so on don't set off plasma anymore. can't use nodamage here because lasertag guns actually don't have it.
+		return
 	if(istype(Proj,/obj/item/projectile/beam))
 		PlasmaBurn(2500)
 		burn = TRUE

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -115,6 +115,8 @@
 		PlasmaBurn(exposed_temperature)
 
 /turf/simulated/wall/mineral/plasma/bullet_act(var/obj/item/projectile/Proj)
+	if(Proj.damage == 0)//lasertag guns and so on don't set off plasma anymore. can't use nodamage here because lasertag guns actually don't have it.
+		return
 	if(istype(Proj,/obj/item/projectile/beam))
 		PlasmaBurn(2500)
 	else if(istype(Proj,/obj/item/projectile/ion))


### PR DESCRIPTION
**What does this PR do:**
This fixes #7234 by making it so weapons that do 0 damage do not ignite plasma statues (or plasma walls, to make it consistent)


**Changelog:**
:cl: 
fix: Plasma statues and walls are no longer ignited by laser tag guns or practice lasers.
/:cl:

