### PR TITLE
Makes water tiles unremovable with a crowbar

### DIFF
--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -53,6 +53,10 @@
 	icon_state = "water"
 	mouse_opacity = 0
 
+/turf/simulated/floor/beach/water/pry_tile(obj/item/C, mob/user, silent = FALSE)
+	return	//cannot pry off tiles of water
+
+
 /turf/simulated/floor/beach/water/New()
 	..()
 	overlays += image("icon"='icons/misc/beach.dmi',"icon_state"="water5","layer"=MOB_LAYER+0.1)


### PR DESCRIPTION
**What does this PR do:**
Fixes #9489 by making you unable to remove the 'water' floortile with a crowbar. I wasn't sure if I should override the pry function or in the attackby function, went with the pry function for now.

**Changelog:**
:cl:
fix: Crowbars can no longer make pool water invisible.
/:cl:

