### PR TITLE
Removes get_area_master - left over junk

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -7,12 +7,6 @@
 	src:Topic(href, href_list)
 	return null
 
-/proc/get_area_master(const/O)
-	var/area/A = get_area(O)
-
-	if(isarea(A))
-		return A
-
 /proc/get_area(atom/A)
 	if(!istype(A))
 		return
@@ -392,23 +386,23 @@
 
 /proc/mobs_in_area(var/area/the_area, var/client_needed=0, var/moblist=mob_list)
 	var/list/mobs_found[0]
-	var/area/our_area = get_area_master(the_area)
+	var/area/our_area = get_area(the_area)
 	for(var/mob/M in moblist)
 		if(client_needed && !M.client)
 			continue
-		if(our_area != get_area_master(M))
+		if(our_area != get_area(M))
 			continue
 		mobs_found += M
 	return mobs_found
 
 /proc/alone_in_area(var/area/the_area, var/mob/must_be_alone, var/check_type = /mob/living/carbon)
-	var/area/our_area = get_area_master(the_area)
+	var/area/our_area = get_area(the_area)
 	for(var/C in living_mob_list)
 		if(!istype(C, check_type))
 			continue
 		if(C == must_be_alone)
 			continue
-		if(our_area == get_area_master(C))
+		if(our_area == get_area(C))
 			return 0
 	return 1
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -309,8 +309,8 @@
 		var/mob/M=A
 
 		if(!M.lastarea)
-			M.lastarea = get_area_master(M)
-		newarea = get_area_master(M)
+			M.lastarea = get_area(M)
+		newarea = get_area(M)
 		oldarea = M.lastarea
 
 		if(newarea==oldarea) return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -26,7 +26,7 @@
 
 /atom/movable/New()
 	. = ..()
-	areaMaster = get_area_master(src)
+	areaMaster = get_area(src)
 
 /atom/movable/attempt_init()
 	var/turf/T = get_turf(src)
@@ -433,6 +433,6 @@
 		var/mob/M = src
 		t_color = M.a_intent == INTENT_HARM ? "#ff0000" : "#ffffff"
 	animate(I, alpha = 175, pixel_x = 0, pixel_y = 0, pixel_z = 0, time = 3, color = t_color)
-	
+
 /atom/movable/proc/portal_destroyed(obj/effect/portal/P)
 	return

--- a/code/game/machinery/atmoalter/area_atmos_computer.dm
+++ b/code/game/machinery/atmoalter/area_atmos_computer.dm
@@ -163,7 +163,7 @@
 
 		var/turf/T = get_turf(src)
 		if(!T.loc) return
-		var/area/A = get_area_master(T)
+		var/area/A = get_area(T)
 		for(var/obj/machinery/portable_atmospherics/scrubber/huge/scrubber in world )
 			var/turf/T2 = get_turf(scrubber)
 			if(T2 && T2.loc)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -33,7 +33,7 @@
 	if(radio_controller)
 		set_frequency(frequency)
 	spawn(5)
-		src.area = src.loc.loc
+		src.area = get_area(src)
 
 		if(otherarea)
 			src.area = locate(text2path("/area/[otherarea]"))

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -127,7 +127,7 @@ Class Procs:
 
 /obj/machinery/proc/addAtProcessing()
 	if(use_power)
-		myArea = get_area_master(src)
+		myArea = get_area(src)
 	if(!speed_process)
 		if(!defer_process)
 			START_PROCESSING(SSmachines, src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -207,7 +207,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	for(var/obj/effect/step_trigger/S in locate(x, y, z))	//<-- this is dumb
 		S.Crossed(src)
 
-	var/area/A = get_area_master(src)
+	var/area/A = get_area(src)
 	if(A)
 		A.Entered(src)
 

--- a/code/modules/modular_computers/hardware/recharger.dm
+++ b/code/modules/modular_computers/hardware/recharger.dm
@@ -39,7 +39,7 @@
 
 	else
 		var/area/A = get_area(src)
-		if(!A || !isarea(A))
+		if(!istype(A))
 			return 0
 
 		if(A.powered(EQUIP))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -161,7 +161,7 @@
 	if(building==0)
 		init()
 	else
-		area = src.loc.loc
+		area = get_area(src)
 		area.apc |= src
 		opened = 1
 		operating = 0
@@ -1068,7 +1068,6 @@
 		if(prob(3))
 			src.locked = 1
 			if(src.cell.charge > 0)
-//				to_chat(world, "<span class='warning'>blew APC in [src.loc.loc]</span>")
 				src.cell.charge = 0
 				cell.corrupt()
 				src.malfhack = 1

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -396,7 +396,7 @@
 // returns whether this light has power
 // true if area has power and lightswitch is on
 /obj/machinery/light/proc/has_power()
-	var/area/A = src.loc.loc
+	var/area/A = get_area(src)
 	return A.lightswitch && A.power_light
 
 /obj/machinery/light/proc/flicker(var/amount = rand(10, 20))
@@ -584,8 +584,9 @@
 
 // called when area power state changes
 /obj/machinery/light/power_change()
-	var/area/A = get_area_master(src)
-	if(A) seton(A.lightswitch && A.power_light)
+	var/area/A = get_area(src)
+	if(A)
+		seton(A.lightswitch && A.power_light)
 
 // called when on fire
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -59,11 +59,13 @@
 // defaults to power_channel
 /obj/machinery/proc/powered(var/chan = -1) // defaults to power_channel
 
-	if(!src.loc)
+	if(!loc)
 		return 0
+	if(!use_power)
+		return 1
 
-	var/area/A = src.loc.loc		// make sure it's in an area
-	if(!A || !isarea(A))
+	var/area/A = get_area(src)		// make sure it's in an area
+	if(!A)
 		return 0					// if not, then not powered
 	if(chan == -1)
 		chan = power_channel
@@ -72,7 +74,7 @@
 // increment the power usage stats for an area
 /obj/machinery/proc/use_power(var/amount, var/chan = -1) // defaults to power_channel
 	var/area/A = get_area(src)		// make sure it's in an area
-	if(!A || !isarea(A))
+	if(!A)
 		return
 	if(chan == -1)
 		chan = power_channel


### PR DESCRIPTION
Think this was used in the past by lighting, but it isn't used anymore.

Made a few of the `src.loc.loc`'s not super dumb anymore...

:cl: Purpose
:tweak: Excavates a few relics from area code.
/:cl: