### PR TITLE
Change grille cooldown to 1 second instead

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -18,7 +18,7 @@
 	var/grille_type
 	var/broken_type = /obj/structure/grille/broken
 	var/shockcooldown = 0
-	var/my_shockcooldown = 50
+	var/my_shockcooldown = 1 SECONDS
 
 /obj/structure/grille/fence/
 	var/width = 3


### PR DESCRIPTION
**What does this PR do:**
Merging in #9656 without discussing its cooldown was a big mistake on my part. This changes the cooldown to 1 second. This PR will be left up for community / head discussion for 24 hours at minimum to decide whether 1 second or 5 second (Or whatever in between) is the better cooldown.



🆑 
tweak: Grill shock cooldown is 1 second instead.
/🆑 

