### PR TITLE
Makes you able to break down bluespace polycrystals in space

### DIFF
--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -55,7 +55,7 @@
 
 // Polycrystals, aka stacks
 
-var/global/list/datum/stack_recipe/bluespace_crystal_recipes = list(new/datum/stack_recipe("Breakdown into bluespace crystal", /obj/item/ore/bluespace_crystal/refined, 1, one_per_turf = 0, on_floor = 1))
+var/global/list/datum/stack_recipe/bluespace_crystal_recipes = list(new/datum/stack_recipe("Breakdown into bluespace crystal", /obj/item/ore/bluespace_crystal/refined, 1))
 
 /obj/item/stack/sheet/bluespace_crystal
 	name = "bluespace polycrystal"


### PR DESCRIPTION
**What does this PR do:**
Fixes #8046 by making you able to break off a piece of the polycrystal while floating in space. I see no real reason you shouldn't be able to do that either flavourwise nor gameplay wise, seems like just a copy-paste error. Also removed the unnecessary one_per_turf=0 since 0 is the default value already.

**Changelog:**
:cl:
fix: bluespace polycrystals can now correctly be broken down while floating in space.
/:cl:

