### PR TITLE
Fix grey changelings keeping their wingdings

### DIFF
--- a/code/game/gamemodes/changeling/powers/transform.dm
+++ b/code/game/gamemodes/changeling/powers/transform.dm
@@ -14,10 +14,14 @@
 
 	if(!chosen_dna)
 		return
-	
+
 	transform_dna(user,chosen_dna)
 
 	user.changeling_update_languages(changeling.absorbed_languages)
+
+	if(user.mind.speech_span == "wingdings") //greys' wingdings isn't stored in DNA
+		user.mind.speech_span = ""
+		to_chat(user, "<span class='warning'>Our vocal cords have permanently shifted. We will now speak regularly.</span>")
 
 	feedback_add_details("changeling_powers","TR")
 	return 1


### PR DESCRIPTION
Fixes #8421

Changelings with wingdings now permanently switch to regular speech after transforming

🆑
fix: Changelings with wingdings now permanently switch to regular speech after transforming
/🆑