### PR TITLE
Borgs can now heal patients while there is an active surgery going on

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -29,7 +29,7 @@
 
 /datum/surgery/proc/next_step(mob/user, mob/living/carbon/target)
 	if(step_in_progress)	return
-
+	
 	var/datum/surgery_step/S = get_surgery_step()
 	if(S)
 		if(S.try_op(user, target, user.zone_sel.selecting, user.get_active_hand(), src))
@@ -86,8 +86,8 @@
 		if(target_zone == surgery.location)
 			initiate(user, target, target_zone, tool, surgery)
 			return 1//returns 1 so we don't stab the guy in the dick or wherever.
-	if(isrobot(user) && user.a_intent != INTENT_HARM) //to save asimov borgs a LOT of heartache
-		return 1
+	/*if(isrobot(user) && user.a_intent != INTENT_HARM) //to save asimov borgs a LOT of heartache
+		return 1*/
 	return 0
 
 /datum/surgery_step/proc/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -29,7 +29,7 @@
 
 /datum/surgery/proc/next_step(mob/user, mob/living/carbon/target)
 	if(step_in_progress)	return
-	
+
 	var/datum/surgery_step/S = get_surgery_step()
 	if(S)
 		if(S.try_op(user, target, user.zone_sel.selecting, user.get_active_hand(), src))
@@ -86,8 +86,6 @@
 		if(target_zone == surgery.location)
 			initiate(user, target, target_zone, tool, surgery)
 			return 1//returns 1 so we don't stab the guy in the dick or wherever.
-	/*if(isrobot(user) && user.a_intent != INTENT_HARM) //to save asimov borgs a LOT of heartache
-		return 1*/
 	return 0
 
 /datum/surgery_step/proc/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
Fixes #9692 

The line I removed was put there for a reason. The most obvious one being that asimov borgs don't accidently slap their patients senselessly due to mistypes. But it also prevented the use of any healing on the patient.
Needs an explaination of why it was put there and maybe an other way to fix this if the check needs to be there.

:cl: Farie82
fix: borgs can now heal their patients while there is a surgery going on.
/:cl:

