### PR TITLE
Terror spider speed settings now respected when under player control

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/black.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/black.dm
@@ -21,7 +21,6 @@
 	health = 120
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	move_to_delay = 5
 	stat_attack = 1 // ensures they will target people in crit, too!
 	spider_tier = TS_TIER_2
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/empress.dm
@@ -16,7 +16,6 @@
 	health = 1000
 	melee_damage_lower = 30
 	melee_damage_upper = 60
-	move_to_delay = 5
 	ventcrawler = 1
 	idle_ventcrawl_chance = 0
 	ai_playercontrol_allowtype = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/gray.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/gray.dm
@@ -4,7 +4,7 @@
 // --------------------------------------------------------------------------------
 // -------------: ROLE: ambusher
 // -------------: AI: hides in vents, emerges when prey is near to kill it, then hides again. Intended to scare normal crew.
-// -------------: SPECIAL: invisible when on top of a vent, emerges when prey approaches or gets trapped in webs. Bite silences targets.
+// -------------: SPECIAL: invisible when on top of a vent, emerges when prey approaches or gets trapped in webs.
 // -------------: TO FIGHT IT: shoot it through a window, or make it regret ambushing you
 // -------------: SPRITES FROM: FoS, http://nanotrasen.se/phpBB3/memberlist.php?mode=viewprofile&u=386
 
@@ -21,7 +21,6 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	regen_points_per_hp = 2 // 50% higher regen speed
-	move_to_delay = 5 // slightly faster than normal
 	stat_attack = 1 // ensures they will target people in crit, too!
 	wander = 0 // wandering defeats the purpose of stealth
 	idle_vision_range = 3 // very low idle vision range

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/mother.dm
@@ -20,7 +20,6 @@
 	health = 50
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	move_to_delay = 5
 	idle_ventcrawl_chance = 5
 	spider_tier = TS_TIER_3
 	spider_opens_doors = 2

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/prince.dm
@@ -21,7 +21,6 @@
 	regen_points_per_hp = 6 // double the normal - IE halved regen speed
 	melee_damage_lower = 30
 	melee_damage_upper = 40
-	move_to_delay = 4 // faster than normal
 	ventcrawler = 0
 	ai_ventcrawls = 0
 	environment_smash = ENVIRONMENT_SMASH_RWALLS

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/purple.dm
@@ -20,8 +20,9 @@
 	health = 200
 	melee_damage_lower = 15
 	melee_damage_upper = 25
-	move_to_delay = 4
 	spider_tier = TS_TIER_2
+	move_to_delay = 5 // at 20ticks/sec, this is 4 tile/sec movespeed, same as a human. Faster than a normal spider, so it can intercept attacks on queen.
+	speed = 0 // '0' (also the default for human mobs) converts to 2.5 total delay, or 4 tiles/sec.
 	spider_opens_doors = 2
 	ventcrawler = 0
 	ai_ventcrawls = 0

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/queen.dm
@@ -21,7 +21,6 @@
 	regen_points_per_tick = 3
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	move_to_delay = 15 // yeah, this is very slow, but
 	ventcrawler = 1
 	idle_ventcrawl_chance = 0
 	force_threshold = 18 // outright immune to anything of force under 18, this means welders can't hurt it, only guns can

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/red.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/red.dm
@@ -21,7 +21,8 @@
 	health = 200
 	melee_damage_lower = 15
 	melee_damage_upper = 20
-	move_to_delay = 20
+	move_to_delay = 10 // at 20ticks/sec, this is 2 tile/sec movespeed
+	speed = 2 // movement_delay() gives 4.5, or 0.45s between steps, which = about 2.2 tiles/second. Player is slightly faster than AI, but cannot move on diagonals.
 	spider_opens_doors = 2
 	var/enrage = 0
 	var/melee_damage_lower_rage0 = 15

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -37,6 +37,7 @@ var/global/list/ts_spiderling_list = list()
 
 	// Movement
 	pass_flags = PASSTABLE
+	turns_per_move = 5 // number of turns before AI-controlled spiders wander around. No effect on actual player or AI movement speed!
 	move_to_delay = 6
 	// AI spider speed at chasing down targets. Higher numbers mean slower speed. Divide 20 (server tick rate / second) by this to get tiles/sec.
 	// 5 = 4 tiles/sec, 6 = 3.3 tiles/sec. 3 = 6.6 tiles/sec.

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -36,11 +36,21 @@ var/global/list/ts_spiderling_list = list()
 	poison_type = "" // we do not use that silly system.
 
 	// Movement
+	pass_flags = PASSTABLE
 	move_to_delay = 6
-	turns_per_move = 5
+	// AI spider speed at chasing down targets. Higher numbers mean slower speed. Divide 20 (server tick rate / second) by this to get tiles/sec.
+	// 5 = 4 tiles/sec, 6 = 3.3 tiles/sec. 3 = 6.6 tiles/sec.
+
+	// Player spider movement speed is controlled by the 'speed' var.
+	// Higher numbers mean slower speed. Can be negative for major speed increase. Call movement_delay() on mob to convert this var to into a step delay.
+	// '-1' (default for fast humans) converts to 1.5 or 6.6 tiles/sec
+	// '0' (default for human mobs) converts to 2.5, or 4 tiles/sec.
+	// '1' (default for most simple_mobs, including terror spiders) converts to 3.5, or 2.8 tiles/sec.
+	// '2' converts to 4.5, or 2.2 tiles/sec.
+
+	// Atmos
 	pressure_resistance = 50    //50 kPa difference required to push
 	throw_pressure_limit = 100  //100 kPa difference required to throw
-	pass_flags = PASSTABLE
 
 	// Ventcrawling
 	ventcrawler = 1 // allows player ventcrawling

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/white.dm
@@ -19,7 +19,6 @@
 	health = 200
 	melee_damage_lower = 5
 	melee_damage_upper = 15
-	move_to_delay = 4
 	spider_tier = TS_TIER_2
 	web_infects = 1
 


### PR DESCRIPTION
Previously, player-controlled terror spiders did not respect the custom move speeds that terror spiders were meant to have.
This meant:
- The intended tradeoff of some spider classes being slower, but more powerful (like the red), wasn't there, and as a result spiders like the red were more powerful than they should have been. Conversely, some spider classes were slower, hence, weaker, than they should have been.
- Inconsistencies between player and AI controlled spider speed meant that you might go into the gateway (intended to be a tutorial on how to fight player spiders) and find a strategy that worked against AI controlled spiders, but not against player ones, or vice versa, due to move speed differences.

This PR fixes the disparity between AI and player spider move speed:
- Spiders now all move at the same general speed, about 3 tiles / second, regardless of type, and whether they are AI or player controlled.
- There are two exceptions. The slow spider (red) moves at 2 tiles / second, and the fast spider (purple) moves at 4 tiles / second.

In terms of implications for play, this means:
- AI-controlled spiders will be a little slower, except for the red, which will be a lot faster.
- Player-controlled red spiders will be a lot slower.
- Player-controlled purple spiders will be a little faster.

🆑 Kyep
tweak: Terror Spider movement speed settings are no longer ignored when under player control. Instead, movement speed has been unified for both AI and player controlled spiders. Under player control, reds will now be slower, and purples will be faster. Under AI control, all spiders will be slower, except reds, which will be faster.
/🆑