### PR TITLE
Fixes Autotraitor latejoiners not having an uplink

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -361,10 +361,10 @@
 		character.buckled.loc = character.loc
 		character.buckled.dir = character.dir
 
-	ticker.mode.latespawn(character)
-
 	character = job_master.EquipRank(character, rank, 1)					//equips the human
 	EquipCustomItems(character)
+
+	ticker.mode.latespawn(character)
 
 	if(character.mind.assigned_role == "Cyborg")
 		AnnounceCyborg(character, rank, join_message)


### PR DESCRIPTION
By request of the admins who keep having to manually fix this.... Fixes #9712

:cl: Purpose
fix: Latejoining autotraitors should now have their uplinks again.
/:cl: