### PR TITLE
Victims of body swap and mindswap can now re-enter their new bodies after death

### DIFF
--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -68,6 +68,7 @@ Also, you never added distance checking after target is selected. I've went ahea
 
 	ghost.mind.transfer_to(caster)
 	if(ghost.key)
+		non_respawnable_keys -= ghost.ckey //ghostizing with an argument of 0 will make them unable to respawn forever, which is bad
 		caster.key = ghost.key	//have to transfer the key since the mind was not active
 	qdel(ghost)
 

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -49,8 +49,9 @@
 	user.mind.transfer_to(target)
 	if(ghost && ghost.mind)
 		ghost.mind.transfer_to(user)
+		non_respawnable_keys -= ghost.ckey //they have a new body, let them be able to re-enter their corpse if they die
 		user.key = ghost.key
-
+	qdel(ghost)
 	user.Paralyse(2)
 	target.add_language("Changeling")
 	user.remove_language("Changeling")


### PR DESCRIPTION
Fixes #9695 
Fixes a similar issue happening with wizards' mindswap ability. 
Also allows the victims to respawn as NPC or whatever.

The problem is that victims of swap_form and mind_transfer abilities are ghosted temporarily without the ability to re-enter the corpse. This makes sense because if they re-enter the corpse that might break the transfer process. However, ghostize(0) will also add them to the permanent list for ckeys who cannot respawn. The additional code removes them from the list after the mind transfer.

Tested and working! However, I don't know if this is the ideal implementation.

:cl: Squirgenheimer
fix: Victims of changeling swap forms and wizard mindswap can now re-enter their corpses
/:cl:

