### PR TITLE
Fixes incorrect chair assignment

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -138,6 +138,7 @@
 	icon_state = "wooden_chair_wings"
 	name = "wooden chair"
 	desc = "Old is never too old to not be in fashion."
+	item_chair = /obj/item/chair/wood/wings
 
 /obj/structure/chair/comfy
 	name = "comfy chair"


### PR DESCRIPTION
Winged chairs now get placed back down as winged chairs.

:cl: Purpose
fix: Winged chairs now get placed back down correctly as winged chairs.
/ :cl: