### PR TITLE
Grammar Fix for Meat Spike

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -29,7 +29,7 @@
 
 
 /obj/structure/kitchenspike
-	name = "a meat spike"
+	name = "meat spike"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "spike"
 	desc = "A spike for collecting meat from animals."


### PR DESCRIPTION
"a meat spike" resulted in weird stuff like "a meat spike is hit by the laser!"

**What does this PR do:**
Just removes the "a" so that you dont get things like "John Doe has hit the a meat spike"

**Changelog:**
:cl: SkeletalElite
fix: Fixed grammar in meat spike's name
/:cl:

