### PR TITLE
Fixes Chaos Holoparasite

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/fire.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/fire.dm
@@ -30,7 +30,7 @@
 
 /mob/living/simple_animal/hostile/guardian/fire/AttackingTarget()
 	..()
-	if(toggle == TRUE)
+	if(toggle)
 		if(ishuman(target) && !summoner)
 			spawn(0)
 				new /obj/effect/hallucination/delusion(target.loc, target, force_kind = "custom", duration = 200, skip_nearby = 0, custom_icon = icon_state, custom_icon_file = icon)

--- a/code/game/gamemodes/miniantags/guardian/types/fire.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/fire.dm
@@ -29,19 +29,19 @@
 			toggle = TRUE
 
 /mob/living/simple_animal/hostile/guardian/fire/AttackingTarget()
-	if(..())
-		if(toggle)
-			if(ishuman(target) && !summoner)
-				spawn(0)
-					new /obj/effect/hallucination/delusion(target.loc, target, force_kind = "custom", duration = 200, skip_nearby = 0, custom_icon = icon_state, custom_icon_file = icon)
-		else
-			if(prob(45))
-				if(ismovableatom(target))
-					var/atom/movable/M = target
-					if(!M.anchored && M != summoner)
-						new /obj/effect/temp_visual/guardian/phase/out(get_turf(M))
-						do_teleport(M, M, 10)
-						new /obj/effect/temp_visual/guardian/phase/out(get_turf(M))
+	..()
+	if(toggle == TRUE)
+		if(ishuman(target) && !summoner)
+			spawn(0)
+				new /obj/effect/hallucination/delusion(target.loc, target, force_kind = "custom", duration = 200, skip_nearby = 0, custom_icon = icon_state, custom_icon_file = icon)
+	else
+		if(prob(45))
+			if(ismovableatom(target))
+				var/atom/movable/M = target
+				if(!M.anchored && M != summoner)
+					new /obj/effect/temp_visual/guardian/phase/out(get_turf(M))
+					do_teleport(M, M, 10)
+					new /obj/effect/temp_visual/guardian/phase/out(get_turf(M))
 
 /mob/living/simple_animal/hostile/guardian/fire/Crossed(AM as mob|obj)
 	..()


### PR DESCRIPTION
It's described on hit Abilities actually work now

**What does this PR do:**
The chaos holoparasite can actually teleport on hit and cause hallucinations in its targets now.
Fixes #9482 

**Changelog:**
:cl: SkeletalElite
fix: Chaos Holoparasite's abilities actually work 
/:cl:

