### PR TITLE
Odysseus emagging and new equipment

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1150,6 +1150,11 @@ var/global/list/common_tools = list(
 		return 1
 	return 0
 
+/proc/ispowertool(O)//used to check if a tool can force powered doors
+	if(istype(O, /obj/item/crowbar/power) || istype(O, /obj/item/mecha_parts/mecha_equipment/medical/rescue_clamp/))
+		return 1
+	return 0
+
 /proc/iswire(O)
 	if(istype(O, /obj/item/stack/cable_coil))
 		return 1

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -670,12 +670,12 @@ About the new airlock wires panel:
 	return FALSE
 
 //For the tools being used on the door. Since you don't want to call the attack_hand method if you're using hands. That would be silly
-//Also it's a bit inconsistent that when you access the panel you headbutt it. But not while crowbarring 
+//Also it's a bit inconsistent that when you access the panel you headbutt it. But not while crowbarring
 //Try to interact with the panel. If the user can't it'll try activating the door
 /obj/machinery/door/airlock/proc/interact_with_panel(mob/user)
 	if(shock_user(user, 100))
 		return
-	
+
 	if(panel_open)
 		if(security_level)
 			to_chat(user, "<span class='warning'>Wires are protected!</span>")
@@ -1025,7 +1025,7 @@ About the new airlock wires panel:
 	else if(locked)
 		to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")
 	else if(!welded && !operating)
-		if(!beingcrowbarred) //being fireaxe'd
+		if(istype(I, /obj/item/twohanded/fireaxe)) //let's make this more specific
 			var/obj/item/twohanded/fireaxe/F = I
 			if(F.wielded)
 				spawn(0)
@@ -1042,7 +1042,7 @@ About the new airlock wires panel:
 				else
 					close(1)
 
-	if(istype(I, /obj/item/crowbar/power))
+	if(ispowertool(I)) //jaws of life and rescue claw
 		if(isElectrified())
 			shock(user, 100)//it's like sticking a forck in a power socket
 			return
@@ -1325,7 +1325,7 @@ About the new airlock wires panel:
 				user.visible_message("<span class='notice'>[user] removes [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
 				playsound(src, 'sound/items/poster_ripped.ogg', 50, 1)
 			else return FALSE
-		else 
+		else
 			user.visible_message("<span class='notice'>[user] cuts down [note] from [src].</span>", "<span class='notice'>You remove [note] from [src].</span>")
 			playsound(src, 'sound/items/Wirecutter.ogg', 50, 1)
 		note.forceMove(get_turf(user))

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -521,3 +521,34 @@
 		reagents.add_reagent(reagent,amount)
 		chassis.use_power(energy_drain)
 
+/obj/item/mecha_parts/mecha_equipment/medical/rescue_clamp
+	name = "rescue clamp"
+	desc = "Emergency rescue clamp, designed to help first responders reach their patients. Opens doors and removes obstacles."
+	icon_state = "mecha_clamp"	//placeholder for now, add icons later
+	equip_cooldown = 15
+	energy_drain = 10
+	var/dam_force = 20
+
+
+/obj/item/mecha_parts/mecha_equipment/medical/rescue_clamp/action(atom/target)
+	if(!action_checks(target))
+		return
+	if(istype(target,/obj))
+		if(!istype(target,/obj/machinery/door))//early return if we're not trying to open a door
+			return
+		var/obj/machinery/door/D = target	//the door we want to open
+		D.try_to_crowbar(src, chassis.occupant)//use the door's crowbar function
+	if(istype(target,/mob/living))	//interact with living beings
+		var/mob/living/M = target
+		if(chassis.occupant.a_intent == INTENT_HARM)//the patented, medical rescue claw is incapable of doing harm. Worry not.
+			target.visible_message("[chassis] gently boops [target] on the nose, its hydraulics hissing as safety overrides kick in.", \
+								"[chassis] gently boops [target] on the nose, its hydraulics hissing as safety overrides kick in.")
+		else
+			step_away(M,chassis)//out of the way, I have people to save!
+			occupant_message("You gently push [target] out of the way.")
+			chassis.visible_message("[chassis] gently pushes [target] out of the way.")
+		return 1
+
+
+
+

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -87,6 +87,10 @@
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/proc/go_out()
 	if(!patient)
 		return
+	if(chassis.emagged)//you won't escape this easily...
+		to_chat(patient, "<span class = 'userdanger'> The [src]'s internal release level refuses to move. You are trapped! </span>")
+		chassis.visible_message("<span class='warning'>You hear someone bang against the inside of [chassis]'s sleeper.</span>")//at least they'll notice your struggles.
+		return
 	patient.forceMove(get_turf(src))
 	occupant_message("[patient] ejected. Life support functions disabled.")
 	log_message("[patient] ejected. Life support functions disabled.")
@@ -525,6 +529,7 @@
 	name = "rescue clamp"
 	desc = "Emergency rescue clamp, designed to help first responders reach their patients. Opens doors and removes obstacles."
 	icon_state = "mecha_clamp"	//placeholder for now, add icons later
+	origin_tech = "engineering=4;biotech=3"
 	equip_cooldown = 15
 	energy_drain = 10
 	var/dam_force = 20
@@ -540,15 +545,23 @@
 		D.try_to_crowbar(src, chassis.occupant)//use the door's crowbar function
 	if(istype(target,/mob/living))	//interact with living beings
 		var/mob/living/M = target
-		if(chassis.occupant.a_intent == INTENT_HARM)//the patented, medical rescue claw is incapable of doing harm. Worry not.
-			target.visible_message("[chassis] gently boops [target] on the nose, its hydraulics hissing as safety overrides kick in.", \
-								"[chassis] gently boops [target] on the nose, its hydraulics hissing as safety overrides kick in.")
+		if(chassis.occupant.a_intent == INTENT_HARM)//the patented, medical rescue claw is incapable of doing harm. Worry not. (unless it is emagged, of course)
+			if(chassis.emagged == 0)
+				target.visible_message("[chassis] gently boops [target] on the nose, its hydraulics hissing as safety overrides slow a brutal punch down at the last second.", \
+								"[chassis] gently boops [target] on the nose, its hydraulics hissing as safety overrides slow a brutal punch down at the last second.")
+			else
+				M.take_overall_damage(dam_force)//shamelessly stolen from Ripley code. No oxy loss though.
+				if(!M)
+					return
+				M.updatehealth()
+				target.visible_message("<span class='danger'>[chassis] brutally punches [target].</span>", \
+								"<span class='userdanger'>[chassis] brutally punches [target].</span>",\
+								"<span class='italics'>You hear something crack.</span>")
+				add_attack_logs(chassis.occupant, M, "Mech-punched with [src] (INTENT: [uppertext(chassis.occupant.a_intent)]) (DAMTYE: [uppertext(damtype)])")
+				start_cooldown()
 		else
 			step_away(M,chassis)//out of the way, I have people to save!
 			occupant_message("You gently push [target] out of the way.")
 			chassis.visible_message("[chassis] gently pushes [target] out of the way.")
-		return 1
-
-
 
 

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -528,7 +528,7 @@
 /obj/item/mecha_parts/mecha_equipment/medical/rescue_clamp
 	name = "rescue clamp"
 	desc = "Emergency rescue clamp, designed to help first responders reach their patients. Opens doors and removes obstacles."
-	icon_state = "mecha_clamp"	//placeholder for now, add icons later
+	icon_state = "mecha_clamp"	//can work, might use a blue resprite later but I think it works for now
 	origin_tech = "engineering=4;biotech=3"
 	equip_cooldown = 15
 	energy_drain = 10
@@ -539,7 +539,7 @@
 	if(!action_checks(target))
 		return
 	if(istype(target,/obj))
-		if(!istype(target,/obj/machinery/door))//early return if we're not trying to open a door
+		if(!istype(target , /obj/machinery/door))//early return if we're not trying to open a door
 			return
 		var/obj/machinery/door/D = target	//the door we want to open
 		D.try_to_crowbar(src, chassis.occupant)//use the door's crowbar function

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -852,13 +852,7 @@
 
 
 /obj/mecha/emag_act(user as mob)
-	if(istype(src,	/obj/mecha/working/ripley) && emagged == 0)
-		emagged = 1
-		to_chat(usr, "<span class='notice'>You slide the card through the [src]'s ID slot.</span>")
-		playsound(loc, "sparks", 100, 1)
-		desc += "</br><span class='danger'>The mech's equipment slots spark dangerously!</span>"
-	else
-		to_chat(usr, "<span class='warning'>The [src]'s ID slot rejects the card.</span>")
+	to_chat(usr, "<span class='warning'>The [src]'s ID slot rejects the card.</span>")
 	return
 
 

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -54,7 +54,7 @@
 		for(var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/I in equipment)	//you get some juicy traitor chems for this...
 			I.add_known_reagent("initropidril", "Initropidril")
 			I.add_known_reagent("sarin", "Sarin")
-		to_chat(usr, "<span class='notice'>The [src]'s speaker chimes in a distorted voice \"First...do harm.\" as you swipe the card through the ID slot.</span>")
+		to_chat(usr, "<span class='notice'>The [src]'s speaker chimes in a distorted voice \"First, do...harm.\" as you swipe the card through the ID slot.</span>")
 		playsound(loc, "sparks", 100, 1)
 		desc += "</br><span class='danger'>The mech's movement is sudden and jerky!</span>"
 	else

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -44,3 +44,21 @@
 
 	. = ..()
 
+
+
+
+
+/obj/mecha/medical/odysseus/emag_act(user as mob)
+	if(emagged == 0)
+		emagged = 1
+		for(var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/I in equipment)	//you get some juicy traitor chems for this...
+			I.add_known_reagent("initropidril", "Initropidril")
+			I.add_known_reagent("sarin", "Sarin")
+		to_chat(usr, "<span class='notice'>The [src]'s speaker chimes in a distorted voice \"First...do harm.\" as you swipe the card through the ID slot.</span>")
+		playsound(loc, "sparks", 100, 1)
+		desc += "</br><span class='danger'>The mech's movement is sudden and jerky!</span>"
+	else
+		to_chat(usr, "<span class='warning'>The [src]'s ID slot rejects the card.</span>")
+	return
+
+

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -181,3 +181,13 @@
 		step_in = 5
 		for(var/obj/item/mecha_parts/mecha_equipment/drill/drill in equipment)
 			drill.equip_cooldown = initial(drill.equip_cooldown)
+
+/obj/mecha/working/ripley/emag_act(user as mob)
+	if(emagged == 0)
+		emagged = 1
+		to_chat(usr, "<span class='notice'>You slide the card through the [src]'s ID slot.</span>")
+		playsound(loc, "sparks", 100, 1)
+		desc += "</br><span class='danger'>The mech's equipment slots spark dangerously!</span>"
+	else
+		to_chat(usr, "<span class='warning'>The [src]'s ID slot rejects the card.</span>")
+	return

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -653,6 +653,16 @@
 	construction_time = 200
 	category = list("Exosuit Equipment")
 
+/datum/design/medical_clamp
+	name = "Exosuit Medical Equipment (Rescue Clamp)"
+	id = "mech_medical_clamp"
+	build_type = MECHFAB
+	req_tech = list("biotech" = 4, "engineering" = 4)
+	build_path = /obj/item/mecha_parts/mecha_equipment/medical/rescue_clamp
+	materials = list(MAT_METAL=5000,MAT_GLASS=2000,MAT_DIAMOND=1500)
+	construction_time = 200
+	category = list("Exosuit Equipment")
+
 /datum/design/mech_generator
 	name = "Exosuit Equipment (Plasma Generator)"
 	id = "mech_generator"


### PR DESCRIPTION
**What does this PR do:**
This PR attempts to flesh out the Odysseus a tad and hopefully make it a bit more useful, both for paramedics and for traitors.

**Odysseus can now be emagged**
You can now emag an Ody like you can a Ripley. Like with the Ripley, this gives the description of the mech a red, obvious message telling people something's off, so don't rely on stealth. An emagged Ody can't take weapons like a Ripley can. Instead, several of its tools are modified to make them a bit more dangerous.
In more details:

1. The sleepers of an Emagged Ody can no longer be left by resisting out of them. Instead, a message is displayed to all that can see the Ody showing someone banging against the inside of the sleeper.
2.  Syringe guns unlock Initropidril and Sarin when their Ody gets emagged, unlocking two potent toxins for use by the pilot. As usual, they are also made available to the sleeper.
3. The rescue clamp, a new piece of equipment this PR is adding, becomes capable of doing harm and being used as a weapon. It has the same damage as a ripley's clamp, though no oxy loss.

**New equipment: Rescue clamp**
The original idea for this PR came from this. Namely, from my utter frustration at trying to rescue people in an Ody. Do you know what stops any rescue effort cold? Firelocks. Rushing to the site of a hull breach or plasma fire to save the 5 dying crew member there? Well you're out of luck, because you need to get out, crowbar it open, climb back into your mech and hope the firelock hasn't closed yet.

But no more!
With the patented hydraulic rescue clamp, paramedics can now reach their patients even in the middle of a wrecked, burning station. The hydraulic rescue clamp opens unpowered doors and firelocks just like any crowbar would, from the comfort of your mech. What's more, it can even force powered airlocks, like the jaws of life. Only bolted doors will impede you.
What's more, the rescue clamp is completely unable to do harm! Unlike the rough, industrial equipment of a Ripley, the rescue clamp's inbuilt safeties prevent them from being used as a weapon, turning brutal punches into gentle boops on the nose. Until they get emagged and safety protocols overriden, that is.

**Misc code changes**
I had to do some minor changes to make this work. Emagging of mechs is now properly handled in the subclasses instead of having an istype check on the mech.dm level which checks if it's a Ripley or not. A new helper function was made to check if a tool can be used to force a door, and a minor change to the try_crowbar function. 

**Feature freeze**
To thaw this, I'd like to cash in #9661, #9650 and #9647

**Changelog:**
:cl:
add: New exosuit equipment: The rescue clamp for the Odysseus lets it open doors, firelocks and even force powered doors
add: Odysseus can now be emagged, enabling some rather dangerous uses
/:cl:

