### PR TITLE
Mining mobs now update sprites correctly on death

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -25,7 +25,8 @@
 
 /mob/living/simple_animal/hostile/asteroid/LoseAggro()
 	..()
-	icon_state = icon_living
+	if(stat == CONSCIOUS)
+		icon_state = icon_living
 
 /mob/living/simple_animal/hostile/asteroid/bullet_act(var/obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
 	if(!stat)


### PR DESCRIPTION
Fixes #9767 

This seems to be a result of a `LoseAggro` in the `death` of mining mobs - I'm unsure as to why it's there. Is that safe to remove?

**Changelog:**
:cl: Crazylemon
fix: Mining mobs now update their sprites on death.
/:cl:

