### PR TITLE
Syndicate shuttles have unique circuitboards now

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -296,6 +296,15 @@
 /obj/item/circuitboard/white_ship
 	name = "circuit Board (White Ship)"
 	build_path = /obj/machinery/computer/shuttle/white_ship
+/obj/item/circuitboard/shuttle/syndicate
+	name = "circuit board (Syndicate Shuttle)"
+	build_path = /obj/machinery/computer/shuttle/syndicate
+/obj/item/circuitboard/shuttle/syndicate/recall
+	name = "circuit board (Syndicate Shuttle Recall Terminal)"
+	build_path = /obj/machinery/computer/shuttle/syndicate/recall
+/obj/item/circuitboard/shuttle/syndicate/drop_pod
+	name = "circuit board (Syndicate Drop Pod)"
+	build_path = /obj/machinery/computer/shuttle/syndicate/drop_pod
 
 
 /obj/item/circuitboard/HolodeckControl

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -5,6 +5,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	req_access = list(access_syndicate)
+	circuit = /obj/item/circuitboard/shuttle/syndicate
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_z3;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s"
 	var/challenge = FALSE
@@ -12,6 +13,7 @@
 
 /obj/machinery/computer/shuttle/syndicate/recall
 	name = "syndicate shuttle recall terminal"
+	circuit = /obj/item/circuitboard/shuttle/syndicate/recall
 	possible_destinations = "syndicate_away"
 
 /obj/machinery/computer/shuttle/syndicate/Topic(href, href_list)
@@ -27,6 +29,7 @@
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "dorm_available"
 	req_access = list(access_syndicate)
+	circuit = /obj/item/circuitboard/shuttle/syndicate/drop_pod
 	shuttleId = "steel_rain"
 	possible_destinations = null
 


### PR DESCRIPTION
Fixes #7811 by adding unique shuttle consoles. The rest of them had them already (e.g. mining), so I see no reason to not bring syndicate shuttles in line with that too.

:cl:
fix: Deconstructing a syndicate console will no longer ruin it forever.
/:cl: