### PR TITLE
fixes runtime in sentience.dm

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -13,11 +13,11 @@
 		if(!(L in player_list) && !L.mind && (L.sentience_type == sentience_type))
 			potential += L
 
+	if(!candidates.len || !potential.len) //if there are no players or simple animals to choose from, then end
+		return FALSE
+
 	var/mob/living/simple_animal/SA = pick(potential)
 	var/mob/SG = pick(candidates)
-
-	if(!SA || !SG) //if you can't find either a simple animal or a player, end
-		return FALSE
 
 	var/sentience_report = "<font size=3><b>[command_name()] Medium-Priority Update</b></font>"
 


### PR DESCRIPTION
picking from an empty list (which will happen if there are no viable candidates) will runtime so I've moved the sanity checks to before the picking step
Fixes: #9734 

**Changelog:**
:cl: Squirgenheimer
fix: fixed a potential runtime in the sentient animal event
/:cl:

