### PR TITLE
[DNM] You can no longer ride MULEs standing up.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -17,7 +17,7 @@
 	maxHealth = 50
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	a_intent = INTENT_HARM //No swapping
-	buckle_lying = 0
+	buckle_lying = 1
 	mob_size = MOB_SIZE_LARGE
 	radio_channel = "Supply"
 


### PR DESCRIPTION
**What does this PR do:**
Legless mobs no longer scream non-stop when put on a MULE bot.
You can now only ride the MULE bots while laying down.

Fixes #8828

**Changelog:**
:cl: uc_guy
fix: Legless mobs no longer scream non-stop when put on a MULE bot.
tweak: You can now only ride the MULE bot while laying down.
/:cl:

