### PR TITLE
Legless human mobs no longer scream non-stop when buckled into a chair.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -38,7 +38,7 @@
 
 	// Buckled to a bed/chair. Stance damage is forced to 0 since they're sitting on something solid
 	// Not standing, so no need to care about stance
-	if(istype(buckled, /obj/structure/stool/bed) || !isturf(loc))
+	if(istype(buckled, /obj/structure/chair) || !isturf(loc))
 		return
 
 	for(var/limb_tag in list("l_leg","r_leg","l_foot","r_foot"))


### PR DESCRIPTION
**What does this PR do:**
Fixes a small oversight in #9539. Stops the screaming and collapsing when legless and buckled into a chair.

**Changelog:**
:cl: uc_guy
fix: Legless human mobs no longer scream non-stop when buckled into a chair.
/:cl:

