### PR TITLE
Minor text edit. (Reactive teleport armor)

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -295,7 +295,7 @@
 		return 0
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
-		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text], shutting itself off in the process!</span>")
+		owner.visible_message("<span class='danger'>The reactive teleport system flings [H] clear of [attack_text]!</span>")
 		var/list/turfs = new/list()
 		for(var/turf/T in orange(tele_range, H))
 			if(istype(T, /turf/space))


### PR DESCRIPTION
Changed the text to reflect the code better.
There doesn't seem to be a delay in teleporting, rather a simple probability of 50%.

Fixes #9773

:cl: Alonefromhell
spellcheck: Edited the attack text of the teleport armor.
/:cl:

