### PR TITLE
Relighting matches with shoes fix.

### DIFF
--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -183,6 +183,7 @@
 		attack_verb = list("burnt","singed")
 		processing_objects.Add(src)
 		update_icon()
+		return TRUE
 
 /obj/item/match/proc/matchburnout()
 	if(lit)
@@ -196,6 +197,7 @@
 		desc = "A match. This one has seen better days."
 		attack_verb = list("flicked")
 		processing_objects.Remove(src)
+		return TRUE
 
 /obj/item/match/dropped(mob/user)
 	matchburnout()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -387,10 +387,10 @@ BLIND     // can't see anything
 		var/obj/item/match/M = I
 		if(M.matchignite()) // Match isn't lit, but isn't burnt.
 			user.visible_message("<span class='warning'>[user] strikes a [M] on the bottom of [src], lighting it.</span>","<span class='warning'>You strike the [M] on the bottom of [src] to light it.</span>")
-		else if(M.matchburnout()) // Match is lit, not extinguished.
+			playsound(user.loc, 'sound/goonstation/misc/matchstick_light.ogg', 50, 1)
+		else
 			user.visible_message("<span class='warning'>[user] crushes the [M] into the bottom of [src], extinguishing it.</span>","<span class='warning'>You crush the [M] into the bottom of [src], extinguishing it.</span>")
-		else // Match has been previously lit and extinguished.
-			to_chat(user, "<span class='notice'>The [M] has already been extinguished.</span>")
+			M.dropped()
 		return
 
 	if(istype(I, /obj/item/wirecutters))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -385,15 +385,9 @@ BLIND     // can't see anything
 /obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/match) && src.loc == user)
 		var/obj/item/match/M = I
-		if(!M.lit) // Match isn't lit, but isn't burnt.
-			M.lit = 1
-			M.icon_state = "match_lit"
-			processing_objects.Add(M)
-			M.update_icon()
+		if(M.matchignite()) // Match isn't lit, but isn't burnt.
 			user.visible_message("<span class='warning'>[user] strikes a [M] on the bottom of [src], lighting it.</span>","<span class='warning'>You strike the [M] on the bottom of [src] to light it.</span>")
-			playsound(user.loc, 'sound/goonstation/misc/matchstick_light.ogg', 50, 1)
-		else if(M.lit == 1) // Match is lit, not extinguished.
-			M.dropped()
+		else if(M.matchburnout()) // Match is lit, not extinguished.
 			user.visible_message("<span class='warning'>[user] crushes the [M] into the bottom of [src], extinguishing it.</span>","<span class='warning'>You crush the [M] into the bottom of [src], extinguishing it.</span>")
 		else // Match has been previously lit and extinguished.
 			to_chat(user, "<span class='notice'>The [M] has already been extinguished.</span>")


### PR DESCRIPTION
Replaced unneeded code with the already defined procs, added return values to `Matchignite()` and `Matchburnout()`.

Should fix being able to relight an already burned match, by trying to light it with your shoe.

Fixes #9779

:cl: Alonefromhell
fix: You should no longer be able to relight a burned match by using a shoe.
/:cl:

