### PR TITLE
Removes redundancy in emagged locker description

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -91,12 +91,11 @@
 
 /obj/structure/closet/secure_closet/emag_act(mob/user)
 	if(!broken)
-		broken = 1
-		locked = 0
-		desc = "It appears to be broken."
+		broken = TRUE
+		locked = FALSE
 		icon_state = icon_off
 		flick(icon_broken, src)
-		to_chat(user, "<span class='notice'>You unlock \the [src].</span>")
+		to_chat(user, "<span class='notice'>You break the lock on \the [src].</span>")
 
 /obj/structure/closet/secure_closet/attack_hand(mob/user)
 	add_fingerprint(user)


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/18459142/46697590-e21c9d00-cc0c-11e8-927a-93996349cf6d.png)

Now it won't replace the original description.

Also changes `0` and `1` to proper booleans and modifies the emag message slightly.
:cl:
fix: Emagging a locker will keep the original description instead of telling you it was emagged twice.
/:cl: