### PR TITLE
Fixes mulebot teleportation bug

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -401,9 +401,16 @@
 			M.layer = layer + 0.1
 
 	else //post unbuckling
-		load = null
-		M.layer = initial(M.layer)
-		M.pixel_y = initial(M.pixel_y)
+		reset_buckled_mob(M)
+
+/mob/living/simple_animal/bot/mulebot/post_unbuckle_mob(mob/living/M)
+	. = ..()
+	reset_buckled_mob(M)
+
+/mob/living/simple_animal/bot/mulebot/proc/reset_buckled_mob(mob/living/M)
+	load = null
+	M.layer = initial(M.layer)
+	M.pixel_y = initial(M.pixel_y)
 
 // called to unload the bot
 // argument is optional direction to unload


### PR DESCRIPTION
Fixes a bug with mulebots where the `load` would not be cleared properly when mobs unbuckle. Meaning you can exploit mulebots to teleport across the station on demand with a cargo PDA. Think; out of jail etc. :honk:

🆑 Birdtalon
fix: Mulebot teleportation exploit.
/🆑 