### PR TITLE
Fixes the NPCs not being initialised correctly

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -70,6 +70,9 @@
 
 /obj/effect/mob_spawn/proc/create(ckey, flavour = TRUE, name)
 	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
+	var/mob/living/carbon/human/H = M
+	if(H && !H.dna)
+		H.Initialize(null)
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
 		if(!mob_gender)


### PR DESCRIPTION
**What does this PR do:**
Fixed #9742 
Fixes #9738 
Fixes #9737
Fixes #9739
Previously NPC's who spawned dead caused a lot of runtime errors due to them for example not having DNA.
Now it actually initialises the NPC's. Removing the runtime errors.

Previously with the wildwest gateway mission:
![pre wild west](https://user-images.githubusercontent.com/15887760/46761775-aef21080-ccd5-11e8-8808-b3a9c5354a20.PNG)

Now with the wildwest mission:
![after wild west](https://user-images.githubusercontent.com/15887760/46761781-b44f5b00-ccd5-11e8-9383-ada1242a0f35.PNG)

:cl: Farie82
fix: NPC's now initialise correctly. Removing a lot of runtime errors.
/:cl:

