### PR TITLE
Necklace equip location fix

### DIFF
--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -390,7 +390,7 @@
 	icon_state = "necklace"
 	item_state = "necklace"
 	item_color = "necklace"
-	slot_flags = SLOT_MASK | SLOT_TIE
+	slot_flags = SLOT_TIE
 
 /obj/item/clothing/accessory/necklace/locket
 	name = "gold locket"
@@ -398,7 +398,7 @@
 	icon_state = "locket"
 	item_state = "locket"
 	item_color = "locket"
-	slot_flags = SLOT_MASK | SLOT_TIE
+	slot_flags = SLOT_TIE
 	var/base_icon
 	var/open
 	var/obj/item/held //Item inside locket.


### PR DESCRIPTION
When equipped to the mask slot, necklace sprites would lose their inventory sprite and just generally break and be annoying. It also puts them on the wrong sprite layer (Renders over all other sprites except hats).

Also, masks are not necks, you can't hang necklaces off your nose unless you _really_ try

This makes no sense, and unless it gets implemented properly I think it'd be best we just remove this for now.

:cl: Triiodine
del: SLOT_MASK from necklaces.
/:cl:

