### PR TITLE
Fixes #9612 - ert panel not working for carbon mobs

### DIFF
--- a/code/modules/nano/modules/ert_manager.dm
+++ b/code/modules/nano/modules/ert_manager.dm
@@ -11,7 +11,7 @@
 	var/autoclose = 0
 
 
-/datum/nano_module/ert_manager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)
+/datum/nano_module/ert_manager/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = admin_state)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(ui && autoclose)
 		ui.close()

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -34,8 +34,7 @@ var/ert_request_answered = FALSE
 		return
 
 	var/datum/nano_module/ert_manager/E = new()
-	E.ui_interact(usr)
-
+	E.ui_interact(usr, state = admin_state)
 
 /mob/dead/observer/proc/JoinResponseTeam()
 	if(!send_emergency_team)


### PR DESCRIPTION
The admin 'dispatch centcom response team' button is meant to pop up a panel that lets admins dispatch ERTs.
Previously, it did, but only if the admin was a ghost, simple_animal or silicon mob at the time. It did not work for admins whose character was a carbon mob (including humans), due to the ert_manager module incorrectly using default_state access checks, instead of the proper admin_state access check.

🆑 Kyep
fix: Fixed the admin ERT panel not working correctly if the admin using it was playing as a carbon mob.
/🆑