### PR TITLE
Lets agent IDs and ID computers set Skrell names correctly.

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -142,8 +142,8 @@
 				t_out += ascii2text(ascii_char)
 				last_char_group = 2
 
-			// ~   |   @  :  #  $  %  &  *  +
-			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
+			// ~   |   @  :  #  $  %  &  *  +  !
+			if(126,124,64,58,35,36,37,38,42,43,33)			//Other symbols that we'll allow (mainly for AI)
 				if(!last_char_group)		continue	//suppress at start of string
 				if(!allow_numbers)			continue
 				t_out += ascii2text(ascii_char)


### PR DESCRIPTION
**What does this PR do:**
Fixes #9807 by allowing the ! character in names, allowing you to have agent IDs and so on match the names you can get from random names or by using DNA scramblers. Should also affect ID computers and so on.


**Changelog:**
:cl: 
fix: Removed Skrell discrimination, allows ! character in IDs (agent IDs or made via ID computer)
/:cl:

