### PR TITLE
Fixes the giving of required two handed items and chainsaw stuf

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -341,6 +341,10 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 /obj/item/proc/on_found(mob/finder as mob)
 	return
 
+// called when the giver gives it to the receiver
+/obj/item/proc/on_give(mob/living/carbon/giver, mob/living/carbon/receiver)
+	return
+
 // called after an item is placed in an equipment slot
 // user is mob that equipped it
 // slot uses the slot_X defines found in setup.dm

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -147,6 +147,14 @@
 		wield(user)
 	..()
 
+/obj/item/twohanded/required/on_give(mob/living/carbon/giver, mob/living/carbon/receiver)
+	var/obj/item/twohanded/required/H = receiver.get_inactive_hand()
+	if(H != null) //Check if he can wield it
+		receiver.drop_item() //Can't wear it so drop it
+		to_chat(receiver, "<span class='notice'>[src] is too cumbersome to carry in one hand!</span>")
+		return
+	equipped(receiver,receiver.hand ? slot_l_hand : slot_r_hand)
+
 /obj/item/twohanded/required/equipped(mob/user, slot)
 	..()
 	if(slot == slot_l_hand || slot == slot_r_hand)
@@ -438,7 +446,7 @@
 	if(on)
 		playsound(loc, 'sound/weapons/chainsawstart.ogg', 50, 1)
 	force = on ? force_on : initial(force)
-	throwforce = on ? force_on : initial(force)
+	throwforce = on ? force_on : initial(throwforce)
 	icon_state = "gchainsaw_[on ? "on" : "off"]"
 
 	if(hitsound == "swing_hit")
@@ -452,6 +460,16 @@
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
+
+/obj/item/twohanded/required/chainsaw/attack_hand(mob/user)
+	. = ..()
+	force = on ? force_on : initial(force)
+	throwforce = on ? force_on : initial(throwforce)
+
+/obj/item/twohanded/required/chainsaw/on_give(mob/living/carbon/giver, mob/living/carbon/receiver)
+	. = ..()
+	force = on ? force_on : initial(force)
+	throwforce = on ? force_on : initial(throwforce)
 
 /obj/item/twohanded/required/chainsaw/doomslayer
 	name = "OOOH BABY"

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -211,6 +211,7 @@
 	layer = 5
 	w_class = WEIGHT_CLASS_HUGE
 	force = 10
+	force_wielded = 10
 	throwforce = 13
 	throw_speed = 2
 	throw_range = 4
@@ -222,6 +223,7 @@
 		icon_state = "plant-36"
 
 /obj/item/twohanded/required/kirbyplants/equipped(mob/living/user)
+	. = ..()
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)
 	I.override = 1
 	user.add_alt_appearance("sneaking_mission", I, player_list)

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -56,6 +56,7 @@
 				target.update_inv_l_hand()
 				target.update_inv_r_hand()
 				target.visible_message("<span class='notice'> [usr.name] handed \the [I.name] to [target.name].</span>")
+				I.on_give(usr, target)
 			if("No")
 				target.visible_message("<span class='warning'> [usr.name] tried to hand [I.name] to [target.name] but [target.name] didn't want it.</span>")
 	else


### PR DESCRIPTION
Fixes #9813

**What does this PR do:**
If you give a two handed item that requires both hands it'll work correctly now.
- it'll drop the item if you can't wear it.
- it'll apply the two hands used thingy.
- The plants now also work when giving it to others.

Also fixed some minor bugs. As in the DIY and the doomslayer chainsaw not doing damage if dropped and picked up again. Same with giving.

For these fixes I needed to either make a lot of edge cases or make a new proc. I chose the latter.
The on_give proc for items will be fired once the item is fully given to another person.

**Changelog:**
:cl: Farie82
add: Added the on_give proc for items. Was needed for the fixes
fix: Giving two handed items like the DIY chainsaw and potted plants now works correctly
fix: The DIY chainsaw, doomslayer chainsaw and the potted plants now do damage when given to somebody else and when picked up while the chainsaw was on.
/:cl:

