### PR TITLE
Fixes newscaster images and spruces up newscaster feed message formating

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -241,8 +241,12 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			data["censored"] = viewing_channel.censored
 			var/list/messages = list()
 			data["messages"] = messages
+			var/message_number = 0
 			for(var/datum/feed_message/M in viewing_channel.messages)
-				messages[++messages.len] = list("title" = M.title, "body" = M.body, "img" = M.img ? icon2base64(M.img) : null, "message_type" = M.message_type, "author" = M.author, "view_count" = M.view_count)
+				if(M.img)
+					user << browse_rsc(M.img, "tmp_photo[message_number].png")
+				messages[++messages.len] = list("title" = M.title, "body" = M.body, "img" = M.img ? M.img : null, "message_type" = M.message_type, "author" = M.author, "view_count" = M.view_count, "message_number" = message_number)
+				message_number += 1
 		if(8, 9)
 			data["channel_name"] = viewing_channel.channel_name
 			data["ref"] = "\ref[viewing_channel]"
@@ -273,7 +277,9 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 			data["author"] = news_network.wanted_issue.backup_author
 			data["criminal"] = news_network.wanted_issue.author
 			data["description"] = news_network.wanted_issue.body
-			data["photo"] = news_network.wanted_issue.img ? icon2base64(news_network.wanted_issue.img) : 0
+			if(news_network.wanted_issue.img)
+				user << browse_rsc(news_network.wanted_issue.img, "tmp_photow.png")
+			data["photo"] = news_network.wanted_issue.img ? news_network.wanted_issue.img : 0
 		if(12)
 			var/list/jobs = list()
 			data["jobs"] = jobs

--- a/nano/templates/newscaster.tmpl
+++ b/nano/templates/newscaster.tmpl
@@ -139,11 +139,14 @@ Property of Nanotrasen</font><br>
 		{{else}}
 			{{for data.messages}}
 				<div class='statusDisplay'>
-					<b>{{:value.title}}</b><br>
-					{{:value.body}}<br>
+					<p align="center"> 
+					<font size="5">
+					<b>{{:value.title}}</b></font><br>
 					{{if value.img}}
-						<img src='data:image/png;base64,{{:value.img}}' width=180><br>
-					{{/if}}
+					<img src='tmp_photo{{:value.message_number}}.png' width=350><br>
+					{{/if}}		
+					<p align="justify"> 					
+					{{:value.body}}<br>
 					<i><font size=1>[{{:value.message_type}} by <span class='good'>{{:value.author}}</span>]</font></i><br>
 					<i><font size=1>Message view count: {{:value.view_count}}</font></i>
 				</div>
@@ -296,10 +299,10 @@ Property of Nanotrasen</font><br>
 			<div class='itemContent'>{{:data.description}}</div>
 		</div>
 		<div class='item'>
-			<div class='itemLabel'>Photo:</div>
+			<div class='itemLabel'>Photo:</div><br>
 			<div class='itemContent'>
 				{{if data.photo}}
-					<img src='data:image/png;base64,{{:data.photo}}' width=180>
+					<img src='tmp_photow.png' width=350><br>
 				{{else}}
 					None
 				{{/if}}


### PR DESCRIPTION
…ting

**What does this PR do:**
Fixes a longstanding bug regarding images and newscasters (caused by base64 encoding). This change removes the icon2Base64 encoding and instead uses the user cache (similar to its older method, and how newspapers currently work).

I also took the opportunity to improve the formatting of feed messages in the newscaster UI...

Has been tested, compiles, runs, and works.

**Changelog:**
:cl: FlimFlamm
tweak: Tweaked formatting of Newscaster stories
fix: Fixed images displaying improperly on Newscasters
/:cl:

