### PR TITLE
Prevents organs from going necrotic during abductor surgery.

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -736,6 +736,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon_state = "bed"
 	no_icon_updates = 1 //no icon updates for this; it's static.
 	injected_reagents = list("corazone","spaceacillin")
+	injected_target_amount = 31 //the patient needs at least 30u of spaceacillin to prevent necrotization.
 
 /obj/structure/closet/abductor
 	name = "alien locker"

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -736,7 +736,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon_state = "bed"
 	no_icon_updates = 1 //no icon updates for this; it's static.
 	injected_reagents = list("corazone","spaceacillin")
-	injected_target_amount = 31 //the patient needs at least 30u of spaceacillin to prevent necrotization.
+	reagent_target_amount = 31 //the patient needs at least 30u of spaceacillin to prevent necrotization.
+	inject_amount = 10
 
 /obj/structure/closet/abductor
 	name = "alien locker"

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -15,7 +15,8 @@
 	buckle_lying = 90
 	var/no_icon_updates = 0 //set this to 1 if you don't want the icons ever changing
 	var/list/injected_reagents = list()
-	var/injected_target_amount = 1
+	var/reagent_target_amount = 1
+	var/inject_amount = 1
 
 /obj/machinery/optable/New()
 	..()
@@ -107,10 +108,9 @@
 	check_victim()
 	if(LAZYLEN(injected_reagents))
 		for(var/mob/living/carbon/C in get_turf(src))
+			var/datum/reagents/R = C.reagents
 			for(var/chemical in injected_reagents)
-				var/current_amount = C.reagents.get_reagent_amount(chemical)
-				if(current_amount < injected_target_amount)
-					C.reagents.add_reagent(chemical, injected_target_amount - current_amount)
+				R.check_and_add(chemical,reagent_target_amount,inject_amount)
 
 /obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user as mob)
 	if(C == user)

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -15,6 +15,7 @@
 	buckle_lying = 90
 	var/no_icon_updates = 0 //set this to 1 if you don't want the icons ever changing
 	var/list/injected_reagents = list()
+	var/injected_target_amount = 1
 
 /obj/machinery/optable/New()
 	..()
@@ -107,8 +108,9 @@
 	if(LAZYLEN(injected_reagents))
 		for(var/mob/living/carbon/C in get_turf(src))
 			for(var/chemical in injected_reagents)
-				if(C.reagents.get_reagent_amount(chemical) < 1)
-					C.reagents.add_reagent(chemical, 1)
+				var/current_amount = C.reagents.get_reagent_amount(chemical)
+				if(current_amount < injected_target_amount)
+					C.reagents.add_reagent(chemical, injected_target_amount - current_amount)
 
 /obj/machinery/optable/proc/take_victim(mob/living/carbon/C, mob/living/carbon/user as mob)
 	if(C == user)


### PR DESCRIPTION
**What does this PR do:**
Even though the abductor operation table automatically injected spaceacillin it was still not enough to prevent victims from going septic and and dying in certain cases. 

This PR ups the dosage and fixes that.

Fixes #9823

EDIT: If #9827 gets merged I would rewrite this PR to use it. 

**Changelog:**
:cl: uc_guy
fix: You can no longer get an infection and die during abductor surgery.
/:cl:

