### PR TITLE
Gives paranormal gamma a nullrod

### DIFF
--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -411,6 +411,7 @@
 	l_pocket = /obj/item/grenade/clusterbuster/holy
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	glasses = /obj/item/clothing/glasses/night
+	r_pocket = /obj/item/nullrod
 
 	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,


### PR DESCRIPTION
Fixes a small oversight from before and during #9631 

Paranormal ERT is missing a null rod. Arguably the most important part of their kit.

🆑 Birdtalon
fix: Gamma ERT Paranormal gets their null rod.
/🆑 