### PR TITLE
Adds the Honk Brand Infiltration Kit

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -960,6 +960,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	surplus = 20
 
+/datum/uplink_item/stealthy_tools/clownkit
+	name = "Honk Brand Infiltration Kit"
+	desc = "All the tools you need to play the best prank Nanotrasen has ever seen. Includes a voice changer clown mask, magnetic clown shoes, and standard clown outfit, tools, and backpack."
+	reference = "HBIK"
+	item = /obj/item/storage/backpack/clown/syndie
+	cost = 6
+	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
+
 // DEVICE AND TOOLS
 
 /datum/uplink_item/device_tools

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -35,7 +35,7 @@
 			return
 		if(H.mind)
 			span = H.mind.speech_span
-		if((COMIC in H.mutations) || H.get_int_organ(/obj/item/organ/internal/cyberimp/brain/clown_voice))
+		if((COMIC in H.mutations) || H.get_int_organ(/obj/item/organ/internal/cyberimp/brain/clown_voice) || istype(H.get_item_by_slot(slot_wear_mask), /obj/item/clothing/mask/gas/voice/clown))
 			span = "sans"
 	if(spamcheck)
 		to_chat(user, "<span class='warning'>\The [src] needs to recharge!</span>")

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -89,6 +89,24 @@
 	icon_state = "clownpack"
 	item_state = "clownpack"
 
+/obj/item/storage/backpack/clown/syndie
+
+/obj/item/storage/backpack/clown/syndie/New()
+	..()
+	new /obj/item/clothing/under/rank/clown(src)
+	new /obj/item/clothing/shoes/magboots/clown(src)
+	new /obj/item/clothing/mask/gas/voice/clown(src)
+	new /obj/item/radio/headset/headset_service(src)
+	new /obj/item/pda/clown(src)
+	new /obj/item/reagent_containers/food/snacks/grown/banana(src)
+	new /obj/item/stamp/clown(src)
+	new /obj/item/toy/crayon/rainbow(src)
+	new /obj/item/storage/fancy/crayons(src)
+	new /obj/item/reagent_containers/spray/waterflower(src)
+	new /obj/item/reagent_containers/food/drinks/bottle/bottleofbanana(src)
+	new /obj/item/instrument/bikehorn(src)
+	new /obj/item/bikehorn(src)
+
 /obj/item/storage/backpack/mime
 	name = "Parcel Parceaux"
 	desc = "A silent backpack made for those silent workers. Silence Co."

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -29,3 +29,10 @@
 /obj/item/clothing/mask/gas/voice/New()
 	..()
 	changer = new(src)
+
+/obj/item/clothing/mask/gas/voice/clown
+	name = "clown wig and mask"
+	desc = "A true prankster's facial attire. A clown is incomplete without his wig and mask."
+	icon_state = "clown"
+	item_state = "clown_hat"
+	flags = BLOCK_GAS_SMOKE_EFFECT | AIRTIGHT | BLOCKHAIR

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -150,7 +150,7 @@
 				message = uppertext(message)
 				verb = "yells loudly"
 
-	if((COMIC in mutations) || (locate(/obj/item/organ/internal/cyberimp/brain/clown_voice) in internal_organs))
+	if((COMIC in mutations) || (locate(/obj/item/organ/internal/cyberimp/brain/clown_voice) in internal_organs) || istype(get_item_by_slot(slot_wear_mask), /obj/item/clothing/mask/gas/voice/clown))
 		span = "sans"
 
 	if(span)


### PR DESCRIPTION
Adds the Honk Brand Infiltration Kit available to Nuke Ops for 6 TC.

Specialists of "stealthy" infiltration will love the value of this bundle containing : 
A standard clown outfit, backpack, headset, PDA and clown accessories
A pair of magnetic clown shoes
A clown mask voice changer that will change your voice to any you desire, aswell as make your voice sound funnier! Don't forget your starting ID can be modified.

Fixes because feature freeze : #9672 #9549 #9479

🆑
add: Added the Honk Brand Infiltration Kit to Nuke Ops. 
/🆑
