### PR TITLE
Added examine text for borg module

### DIFF
--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -3,6 +3,7 @@
 	..(user)
 
 	var/msg = "<span class='info'>"
+	msg += "It has loaded a [module.name].\n"
 	var/obj/act_module = get_active_hand()
 	if(act_module)
 		msg += "It is holding [bicon(act_module)] \a [act_module].\n"

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -3,7 +3,8 @@
 	..(user)
 
 	var/msg = "<span class='info'>"
-	msg += "It has loaded a [module.name].\n"
+	if(module)
+		msg += "It has loaded a [module.name].\n"
 	var/obj/act_module = get_active_hand()
 	if(act_module)
 		msg += "It is holding [bicon(act_module)] \a [act_module].\n"


### PR DESCRIPTION
**What does this PR do:**
This PR adds a line to the examine text of borgs, telling you what modules they have loaded. So far, the only way to know that was to tell by their colour/sprite or by what equipment they have out. Yes, you can usually tell that way, but it can get hard with custom sprites. Also, this makes it easier for new players that might not even know what borg modules there are.

![untitled](https://user-images.githubusercontent.com/32099540/46918050-31781a00-cfcd-11e8-8f3d-8c175ca5f182.png)


I assume this is a minor feature and would like to cash in #9815 to unfreeze this

**Changelog:**
:cl: 
add: Examining a borg tells you what module it has loaded
/:cl:

