### PR TITLE
Changed max name length

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -18,7 +18,7 @@
 #define MAX_PAPER_MESSAGE_LEN 3072
 #define MAX_PAPER_FIELDS 50
 #define MAX_BOOK_MESSAGE_LEN 9216
-#define MAX_NAME_LEN 26
+#define MAX_NAME_LEN 50 	//diona names can get loooooooong
 
 // Version check, terminates compilation if someone is using a version of BYOND that's too old
 #if DM_VERSION < 510


### PR DESCRIPTION
**What does this PR do:**
This fixes #9850 by raising the max length for allowable names to 50 characters.

I figured there's two ways to fix this, either change Diona name generation or just raise the cap. The long, rambling names are a part of the Diona identity, IMO, so changing that part seemed less than ideal. I don't really see the harm in raising it to 50 characters, since there's a blanket rule against nonsensical and overly silly names.

**Changelog:**
:cl:
tweak: The maximal length of a name that won't be rejected as a 'bad name' has been raised.
/:cl:

