### PR TITLE
You can no longer roll around when dead.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -236,6 +236,8 @@
 	Makes the mob face the direction of the clicked thing
 */
 /mob/proc/MiddleShiftClickOn(atom/A)
+	if(incapacitated())
+		return
 	var/face_dir = get_cardinal_dir(src, A)
 	if(forced_look == face_dir)
 		forced_look = null


### PR DESCRIPTION
**What does this PR do:**
You used to be able to roll around when dead by using Shift + Middle Click
This PR fixes that.

**Changelog:**
:cl: uc_guy
fix: You can no longer roll around when dead.
/:cl:

