### PR TITLE
Borer fixes

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -91,6 +91,7 @@
 			)
 	var/talk_inside_host = FALSE			// So that borers don't accidentally give themselves away on a botched message
 	var/used_dominate
+	var/input_open = FALSE					// To prevent people from spam opening the Dominate Victim input
 	var/chemicals = 10						// Chemicals used for reproduction and chemical injection.
 	var/max_chems = 250
 	var/mob/living/carbon/human/host		// Human host for the brain worm.
@@ -471,7 +472,7 @@
 	set category = "Borer"
 	set name = "Dominate Victim"
 	set desc = "Freeze the limbs of a potential host with supernatural fear."
-
+	
 	if(world.time - used_dominate < 150)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
@@ -483,23 +484,43 @@
 	if(stat)
 		to_chat(src, "You cannot do that in your current state.")
 		return
-
+		
+	if(input_open)
+		to_chat(src, "You're already targetting someone!")
+		return
+	
 	var/list/choices = list()
 	for(var/mob/living/carbon/C in view(3,src))
 		if(C.stat != DEAD)
 			choices += C
-
+	
 	if(world.time - used_dominate < 300)
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
-
+		
+	input_open = TRUE
+	
 	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") in null|choices
 
-	if(!M || !src)
+	if(!M)
+		input_open = FALSE
+		return
+
+	if(!src) //different statement to avoid a runtime since if the source is deleted then input_open would also be deleted
 		return
 
 	if(M.has_brain_worms())
 		to_chat(src, "You cannot dominate someone who is already infested!")
+		input_open = FALSE
+		return
+
+	if(stat == DEAD)
+		input_open = FALSE
+		return 
+		
+	if(get_dist(src, M) > 7) //to avoid people remotely doing from across the map etc, 7 is the default view range
+		to_chat(src, "<span class='warning'>You're too far away!</span>")
+		input_open = FALSE
 		return
 
 	to_chat(src, "<span class='warning'>You focus your psychic lance on [M] and freeze [M.p_their()] limbs with a wave of terrible dread.</span>")
@@ -507,6 +528,7 @@
 	M.Weaken(3)
 
 	used_dominate = world.time
+	input_open = FALSE
 
 /mob/living/simple_animal/borer/verb/release_host()
 	set category = "Borer"

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -326,6 +326,9 @@
 		to_chat(src, "You cannot infest someone who is already infested!")
 		return
 
+	if(stat == DEAD)
+		return
+
 	to_chat(src, "You slither up [M] and begin probing at [M.p_their()] ear canal...")
 
 	if(!do_after(src, 50, target = M))

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -91,7 +91,7 @@
 			)
 	var/talk_inside_host = FALSE			// So that borers don't accidentally give themselves away on a botched message
 	var/used_dominate
-	var/input_open = FALSE					// To prevent people from spam opening the Dominate Victim input
+	var/attempting_to_dominate = FALSE		// To prevent people from spam opening the Dominate Victim input
 	var/chemicals = 10						// Chemicals used for reproduction and chemical injection.
 	var/max_chems = 250
 	var/mob/living/carbon/human/host		// Human host for the brain worm.
@@ -326,7 +326,7 @@
 		to_chat(src, "You cannot infest someone who is already infested!")
 		return
 
-	if(stat == DEAD)
+	if(incapacitated())
 		return
 
 	to_chat(src, "You slither up [M] and begin probing at [M.p_their()] ear canal...")
@@ -488,7 +488,7 @@
 		to_chat(src, "You cannot do that in your current state.")
 		return
 		
-	if(input_open)
+	if(attempting_to_dominate)
 		to_chat(src, "You're already targeting someone!")
 		return
 	
@@ -501,29 +501,29 @@
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 		
-	input_open = TRUE
+	attempting_to_dominate = TRUE
 	
 	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") in null|choices
 
 	if(!M)
-		input_open = FALSE
+		attempting_to_dominate = FALSE
 		return
 
-	if(!src) //different statement to avoid a runtime since if the source is deleted then input_open would also be deleted
+	if(!src) //different statement to avoid a runtime since if the source is deleted then attempting_to_dominate would also be deleted
 		return
 
 	if(M.has_brain_worms())
 		to_chat(src, "You cannot dominate someone who is already infested!")
-		input_open = FALSE
+		attempting_to_dominate = FALSE
 		return
 
-	if(stat == DEAD)
-		input_open = FALSE
+	if(incapacitated())
+		attempting_to_dominate = FALSE
 		return 
 		
 	if(get_dist(src, M) > 7) //to avoid people remotely doing from across the map etc, 7 is the default view range
 		to_chat(src, "<span class='warning'>You're too far away!</span>")
-		input_open = FALSE
+		attempting_to_dominate = FALSE
 		return
 
 	to_chat(src, "<span class='warning'>You focus your psychic lance on [M] and freeze [M.p_their()] limbs with a wave of terrible dread.</span>")
@@ -531,7 +531,7 @@
 	M.Weaken(3)
 
 	used_dominate = world.time
-	input_open = FALSE
+	attempting_to_dominate = FALSE
 
 /mob/living/simple_animal/borer/verb/release_host()
 	set category = "Borer"

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -489,7 +489,7 @@
 		return
 		
 	if(input_open)
-		to_chat(src, "You're already targetting someone!")
+		to_chat(src, "You're already targeting someone!")
 		return
 	
 	var/list/choices = list()


### PR DESCRIPTION
**What does this PR do:**
Stops borers from dominating people more than 7 tiles away
Stops borers from spam opening the targeting window
Stops borers from using their dominate ability after death
Stops borers from "slithering up and probing X's ear canal" if they select the target after death

Fixes: #9791 

🆑 
fix: Borers with their "Dominate" window already open can no longer run across the map and successfully cast the spell on those people, they must be within 7 tiles (default view range)
fix: Borers can no longer spam open the "Dominate" spell
fix: Borers with their "Dominate" target window already open can no longer successfully target someone if they are dead
fix: Borers no longer "slither up and probe people's ear canal" if they select the target of an "infect host" spell after they die
/ 🆑 
