### PR TITLE
fixes changeling regenerative stasis users not waking up

### DIFF
--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -52,7 +52,8 @@
 			IO.rejuvenate()
 			IO.trace_chemicals.Cut()
 		H.remove_all_embedded_objects()
-	user.updatehealth()
+	user.status_flags &= ~(FAKEDEATH)
+	user.updatehealth("revive sting")
 	user.update_blind_effects()
 	user.update_blurry_effects()
 
@@ -60,7 +61,6 @@
 
 	user.regenerate_icons()
 
-	user.status_flags &= ~(FAKEDEATH)
 	user.update_revive() //Handle waking up the changeling after the regenerative stasis has completed.
 	user.mind.changeling.purchasedpowers -= src
 	user.med_hud_set_status()


### PR DESCRIPTION
Fixes #9835 
update_stat, which is called by updatehealth, excludes mobs with the FAKEDEATH flag from waking up, so I thought it would be better to make sure the FAKEDEATH flag is removed earlier.
I also added a reason arg to updatehealth because it gives the debug log more information.
**Changelog:**
:cl: Squirgenheimer
fix: Changelings will now wake up after using Regenerative Stasis.
/:cl:

