### PR TITLE
Newscaster fix: Adds 1.5 second delay to give time for asset cache transfer (img fix)

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -247,6 +247,7 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 					user << browse_rsc(M.img, "tmp_photo[message_number].png")
 				messages[++messages.len] = list("title" = M.title, "body" = M.body, "img" = M.img ? M.img : null, "message_type" = M.message_type, "author" = M.author, "view_count" = M.view_count, "message_number" = message_number)
 				message_number += 1
+			sleep(15)
 		if(8, 9)
 			data["channel_name"] = viewing_channel.channel_name
 			data["ref"] = "\ref[viewing_channel]"


### PR DESCRIPTION
**What does this PR do:**
Adds a `sleep(15)` to the newscaster.dm file which should give adequate time for images to transfer and display correctly. When news channels are opened the UI will now hang for a brief moment to allow photos to be transferred to the user cache.

Without this fix, images tend to not be displayed correctly on the first viewing of a news channel (because the assets take a second to transfer).

**Changelog:**
:cl: FlimFlamm
fix: images should now be reliably displayed on newscaster stories
/:cl:

Fixes: #9840