### PR TITLE
Revert "Lets agent IDs and ID computers set Skrell names correctly."

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -142,8 +142,8 @@
 				t_out += ascii2text(ascii_char)
 				last_char_group = 2
 
-			// ~   |   @  :  #  $  %  &  *  +  !
-			if(126,124,64,58,35,36,37,38,42,43,33)			//Other symbols that we'll allow (mainly for AI)
+			// ~   |   @  :  #  $  %  &  *  +
+			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
 				if(!last_char_group)		continue	//suppress at start of string
 				if(!allow_numbers)			continue
 				t_out += ascii2text(ascii_char)


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#9815

Maybe this'll fix it.