### PR TITLE
Fixes a cause of lag in the timer subsystem

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -122,7 +122,7 @@ SUBSYSTEM_DEF(timer)
 	if(!resumed)
 		timer = null
 
-	while(practical_offset <= BUCKET_LEN && head_offset + (practical_offset*world.tick_lag) <= world.time)
+	while(practical_offset <= BUCKET_LEN && head_offset + ((practical_offset-1)*world.tick_lag) <= world.time)
 		var/datum/timedevent/head = bucket_list[practical_offset]
 		if(!timer || !head || timer == head)
 			head = bucket_list[practical_offset]
@@ -170,7 +170,7 @@ SUBSYSTEM_DEF(timer)
 					qdel(timer)
 				continue
 
-			if(timer.timeToRun < head_offset + TICKS2DS(practical_offset))
+			if(timer.timeToRun < head_offset + TICKS2DS(practical_offset-1))
 				bucket_resolution = null //force bucket recreation
 				CRASH("[i] Invalid timer state: Timer in long run queue that would require a backtrack to transfer to short run queue. [get_timer_debug_string(timer)] world.time: [world.time], head_offset: [head_offset], practical_offset: [practical_offset]")
 				if(timer.callBack && !timer.spent)


### PR DESCRIPTION
MSO caught this while troubleshooting some lag that Citadel & Hippie have with the same timer system that Paradise uses.

```
if you have a timer that is exactly 1 minute long, and it adds a 1 minute long timer when called, this bug would always trigger a infinite loop until the lag caused it to get behind.

sstimer keeps a list with the next 1 minute worth of byond ticks (1200 items), timers less than a minute get put into this list, this list is rolling, so if the current tick is at index 600, the list wraps around to the front, meaning index 599 is really index 1200. as it clears out the current tick, it fills it with any timers in the long timer queue that will have to run in 1200 ticks. this means timers less than (or equal to) a minute are o(1) to insert and fetch, and timers more than a minute are o(log n) to insert (binary search insert sorted array) and o(1) to fetch.
it also means that off by one errors can be fucky as it causes timers to run 1 minute early

```

I suggest testmerging this for a bit to make sure of the maths, but it seems right.

:cl: MrStonedOne
fix: Fixes a cause of lag in the Timer subsystem
/:cl: