### PR TITLE
Add uniform to blueshield locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -253,6 +253,7 @@
 	new /obj/item/clothing/accessory/holster(src)
 	new /obj/item/clothing/accessory/blue(src)
 	new /obj/item/clothing/shoes/jackboots/jacksandals(src)
+	new /obj/item/clothing/under/rank/centcom/blueshield(src)
 
 
 /obj/structure/closet/secure_closet/ntrep


### PR DESCRIPTION
Adds a single uniform (/obj/item/clothing/under/rank/centcom/blueshield)
to blueshields locker (/obj/structure/closet/secure_closet/blueshield/New())

By request of PurpleGenie.

:cl: Alonefromhell
add: Added a Nanotrasen Navy Uniform to the blueshields locker
/:cl:

