### PR TITLE
Re-implements BM offsets in a 511-compatible manner

### DIFF
--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -49,8 +49,9 @@
 		var/x = pos_idx % switch_width
 		var/y = FLOOR(pos_idx / switch_width, 1)
 		var/obj/screen/buildmode/B = new buttontype(src, thing)
-		// extra .5 for a nice offset look
-		B.screen_loc = "NORTH-[(1 + 0.5 + y*1.5)],WEST+[0.5 + x*1.5]"
+		// this stuff is equivalent to the commented out line for 511 compat
+		// B.screen_loc = "NORTH-[(1 + 0.5 + y*1.5)],WEST+[0.5 + x*1.5]"
+		B.screen_loc = "NORTH-[1 + FLOOR(0.5 + 1.5*y, 1) + ((y + 1) % 2)]:[16*((y + 1) % 2)],WEST+[FLOOR(0.5 + 1.5*x, 1)]:[16*((x + 1) % 2)]"
 		buttonslist += B
 		pos_idx++
 


### PR DESCRIPTION
**What does this PR do:**
Admins had trouble using buildmode in 511 due to use of fractional `screen_loc` values. This PR backports this effect in a manner that uses the `integer:pixel_offset` format of older versions.

**Changelog:**
:cl: Crazylemon
fix: Buildmode is now compatible with 511 clients.
/:cl:

