### PR TITLE
Fixes Timer SS Timeouts

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -18,8 +18,6 @@
 //In most cases you want a subsystem instead
 #define TIMER_LOOP			32
 
-#define TIMER_NO_INVOKE_WARNING 600 //number of byond ticks that are allowed to pass before the timer subsystem thinks it hung on something
-
 #define TIMER_ID_NULL -1
 
 //For servers that can't do with any additional lag, set this to none in flightpacks.dm in subsystem/processing.

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(timer)
 
 	flags = SS_TICKER|SS_NO_INIT
 
-	var/list/second_queue = list() //awe, yes, you've had first queue, but what about second queue? Contains: /datum/timedevent
+	var/list/second_queue = list() //awe, yes, you've had first queue, but what about second queue?
 	var/list/hashes = list()
 
 	var/head_offset = 0 //world.time of the first entry in the the bucket.
@@ -38,15 +38,15 @@ SUBSYSTEM_DEF(timer)
 
 /datum/controller/subsystem/timer/fire(resumed = FALSE)
 	var/lit = last_invoke_tick
-	var/last_check = world.time - TIMER_NO_INVOKE_WARNING
+	var/last_check = world.time - TICKS2DS(BUCKET_LEN*1.5)
 	var/list/bucket_list = src.bucket_list
 
 	if(!bucket_count)
 		last_invoke_tick = world.time
 
-	if(lit && lit < last_check && last_invoke_warning < last_check)
+	if(lit && lit < last_check && head_offset < last_check && last_invoke_warning < last_check)
 		last_invoke_warning = world.time
-		var/msg = "No regular timers processed in the last [TIMER_NO_INVOKE_WARNING] ticks[bucket_auto_reset ? ", resetting buckets" : ""]!"
+		var/msg = "No regular timers processed in the last [BUCKET_LEN*1.5] ticks[bucket_auto_reset ? ", resetting buckets" : ""]!"
 		message_admins(msg)
 		WARNING(msg)
 		if(bucket_auto_reset)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/40417

This should stop the Timer SS from notifying everyone, at round start that nothing has been processed.

Basically the SS has no way of knowing "did the SS halt and die and there's a problem, or has nothing been added in a long time and it's just idle?"

:cl: Fox McCloud
fix: Fixes the Timer SS timing out when it shouldn't
/:cl: