### PR TITLE
adds sanity check to show_to for storage items

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -100,6 +100,8 @@
 	return L
 
 /obj/item/storage/proc/show_to(mob/user as mob)
+	if(!user.client)
+		return
 	if(user.s_active != src)
 		for(var/obj/item/I in src)
 			if(I.on_found(user))


### PR DESCRIPTION
This should fix #9881 

:cl: Squirgenheimer
fix: Ghosting from cryopods with an inventory open should no longer cause a runtime
/:cl:

