### PR TITLE
Hover indicator for body zones

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -175,66 +175,111 @@
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
 	var/selecting = "chest"
+	var/static/list/hover_overlays_cache = list()
+	var/hovering
 
 /obj/screen/zone_sel/Click(location, control,params)
+	if(isobserver(usr))
+		return
+
 	var/list/PL = params2list(params)
 	var/icon_x = text2num(PL["icon-x"])
 	var/icon_y = text2num(PL["icon-y"])
-	var/old_selecting = selecting //We're only going to update_icon() if there's been a change
+	var/choice = get_zone_at(icon_x, icon_y)
+	if(!choice)
+		return 1
 
+	return set_selected_zone(choice, usr)
+
+/obj/screen/zone_sel/MouseEntered(location, control, params)
+	MouseMove(location, control, params)
+
+/obj/screen/zone_sel/MouseMove(location, control, params)
+	if(isobserver(usr))
+		return
+
+	var/list/PL = params2list(params)
+	var/icon_x = text2num(PL["icon-x"])
+	var/icon_y = text2num(PL["icon-y"])
+	var/choice = get_zone_at(icon_x, icon_y)
+
+	if(hovering == choice)
+		return
+	cut_overlay(hover_overlays_cache[hovering])
+	hovering = choice
+
+	var/obj/effect/overlay/zone_sel/overlay_object = hover_overlays_cache[choice]
+	if(!overlay_object)
+		overlay_object = new
+		overlay_object.icon_state = "[choice]"
+		hover_overlays_cache[choice] = overlay_object
+	add_overlay(overlay_object)
+
+
+/obj/effect/overlay/zone_sel
+	icon = 'icons/mob/zone_sel.dmi'
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	alpha = 128
+	anchored = TRUE
+	layer = ABOVE_HUD_LAYER
+	plane = ABOVE_HUD_PLANE
+
+/obj/screen/zone_sel/MouseExited(location, control, params)
+	if(!isobserver(usr) && hovering)
+		cut_overlay(hover_overlays_cache[hovering])
+	hovering = null
+
+/obj/screen/zone_sel/proc/get_zone_at(icon_x, icon_y)
 	switch(icon_y)
 		if(1 to 3) //Feet
 			switch(icon_x)
 				if(10 to 15)
-					selecting = "r_foot"
+					return "r_foot"
 				if(17 to 22)
-					selecting = "l_foot"
-				else
-					return 1
+					return "l_foot"
 		if(4 to 9) //Legs
 			switch(icon_x)
 				if(10 to 15)
-					selecting = "r_leg"
+					return "r_leg"
 				if(17 to 22)
-					selecting = "l_leg"
-				else
-					return 1
+					return "l_leg"
 		if(10 to 13) //Hands and groin
 			switch(icon_x)
 				if(8 to 11)
-					selecting = "r_hand"
+					return "r_hand"
 				if(12 to 20)
-					selecting = "groin"
+					return "groin"
 				if(21 to 24)
-					selecting = "l_hand"
-				else
-					return 1
+					return "l_hand"
 		if(14 to 22) //Chest and arms to shoulders
 			switch(icon_x)
 				if(8 to 11)
-					selecting = "r_arm"
+					return "r_arm"
 				if(12 to 20)
-					selecting = "chest"
+					return "chest"
 				if(21 to 24)
-					selecting = "l_arm"
-				else
-					return 1
+					return "l_arm"
 		if(23 to 30) //Head, but we need to check for eye or mouth
 			if(icon_x in 12 to 20)
-				selecting = "head"
 				switch(icon_y)
 					if(23 to 24)
 						if(icon_x in 15 to 17)
-							selecting = "mouth"
+							return "mouth"
 					if(26) //Eyeline, eyes are on 15 and 17
 						if(icon_x in 14 to 18)
-							selecting = "eyes"
+							return "eyes"
 					if(25 to 27)
 						if(icon_x in 15 to 17)
-							selecting = "eyes"
+							return "eyes"
+				return "head"
 
-	if(old_selecting != selecting)
-		update_icon()
+/obj/screen/zone_sel/proc/set_selected_zone(choice, mob/user)
+	if(isobserver(user))
+		return
+
+	if(choice != selecting)
+		selecting = choice
+		update_icon(usr)
 	return 1
 
 /obj/screen/zone_sel/update_icon()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/39830

![https://user-images.githubusercontent.com/222630/44385222-90407c00-a4d3-11e8-83f1-3e0b3228d160.gif](https://user-images.githubusercontent.com/222630/44385222-90407c00-a4d3-11e8-83f1-3e0b3228d160.gif)

🆑 SpaceManiac
add: The body zone selector now indicates which body part you are about to select when hovered over.
/🆑

As an aside, this port is a goddamn mess to make it work properly on 511. We're using half old overlays and half SSoverlays and it's just all uggh. When we transition fully to 512, this should be entirely overwritten with /tg/'s copy.

I don't have any fix tokens, leaving it up to the other maints if this will fly or not. 