### PR TITLE
Fixes Welding_Fuel to Fuel

### DIFF
--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -59,7 +59,7 @@
 			mutations.Remove(pick(temp_mut_list))
 		temp_mut_list.Cut()
 
-	if(S.has_reagent("welding_fuel", 5))
+	if(S.has_reagent("fuel", 5))
 		for(var/datum/spacevine_mutation/SM in mutations)
 			if(SM.quality == POSITIVE)
 				temp_mut_list += SM

--- a/code/modules/hydroponics/sample.dm
+++ b/code/modules/hydroponics/sample.dm
@@ -12,7 +12,7 @@ var/list/chem_t2_reagents = list(
 var/list/chem_t3_reagents = list(
 	"ethanol", "chlorine", "potassium",
 	"aluminium", "radium", "fluorine",
-	"iron", "welding_fuel",	"silver",
+	"iron", "fuel",	"silver",
 	"stable_plasma"
 )
 


### PR DESCRIPTION
Looks like when @fox-mcloud copy pasted from TG, he ddn't catch that our `welding_fuel` reagent is just `fuel`?

I updated sample.dm's reagent tier listing as it was wrong there too... but honestly I don't see where those are being used anywhere and they could probably just be axed...

:cl: Purpose
fix: Fixed an issue with Space Vine mutations
/:cl: