### PR TITLE
[READY] Syndicate communication channel is now pseudonymous.

### DIFF
--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -3,6 +3,21 @@ GLOBAL_LIST_INIT(alphabet_uppercase, list("A","B","C","D","E","F","G","H","I","J
 GLOBAL_LIST_INIT(zero_character_only, list("0"))
 GLOBAL_LIST_INIT(hex_characters, list("0","1","2","3","4","5","6","7","8","9","a","b","c","d","e","f"))
 GLOBAL_LIST_INIT(binary, list("0","1"))
+GLOBAL_LIST_INIT(html_colors, list("Alice Blue","Antique White","Aqua","Aquamarine","Azure","Beige","Bisque","Black","Blanched Almond","Blue","Blue Violet",
+									"Brown","Burly Wood","Cadet Blue","Chartreuse","Chocolate","Coral","Cornflower Blue","Cornsilk","Crimson","Cyan",
+									"Dark Blue","Dark Cyan","Dark Golden Rod","Dark Gray","Dark Green","Dark Khaki","Dark Magenta","Dark Olive Green",
+									"Dark Orange","Dark Orchid","Dark Red","Dark Salmon","Dark Sea Green","Dark Slate Blue","Dark Slate Gray",
+									"Dark Turquoise","Dark Violet","Deep Pink","Deep Sky Blue","Dim Gray","Dodger Blue","Fire Brick","Floral White",
+									"Forest Green","Fuchsia","Gainsboro","Ghost White","Gold","Golden Rod","Gray","Grey","Green","Green Yellow","Honey Dew",
+									"Hot Pink","Indian Red","Indigo","Ivory","Khaki","Lavender","Lavender Blush","Lawn Green","Lemon Chiffon","Light Blue",
+									"Light Coral","Light Cyan","Light Golden Rod Yellow","Light Gray","Light Green","Light Pink","Light Salmon","Light Sea Green",
+									"Light Sky Blue","Light Slate Gray","Light Steel Blue","Light Yellow","Lime","Lime Green","Linen","Magenta","Maroon",
+									"Medium Aquamarine","Medium Blue","Medium Orchid","Medium Purple","Medium Seagreen","Medium Slate Blue","Medium Spring Green",
+									"Medium Turquoise","Medium Violet Red","Midnight Blue","Mint Cream","Misty Rose","Moccasin","Navajo White","Navy","Old Lace",
+									"Olive","Olive Drab","Orange","Orange Red","Orchid","Pale Golden Rod","Pale Green","Pale Turquoise","Pale Violet Red",
+									"Papaya Whip","Peach Puff","Peru","Pink","Plum","Powder Blue","Purple","Red","Rosy Brown","Royal Blue","Saddle Brown",
+									"Salmon","Sandy Brown","Sea Green","Sea Shell","Sienna","Silver","Sky Blue","Slate Blue","Slate Gray","Snow","Spring Green",
+									"Steel Blue","Tan","Teal","Thistle","Tomato","Turquoise","Violet","Wheat","White","White Smoke","Yellow","Yellow Green"))
 
 GLOBAL_LIST_INIT(day_names, list("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"))
 GLOBAL_LIST_INIT(month_names, list("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"))

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -22,6 +22,11 @@
 	channels = list("Syndicate" = 1)
 	origin_tech = "syndicate=1;engineering=3;bluespace=2"
 	syndie = 1 //Signifies that it de-crypts Syndicate transmissions
+	var/fake_name = "Agent ALERT_A_CODER"
+
+/obj/item/encryptionkey/syndicate/New()
+	..()
+	fake_name = "Agent " + pick(GLOB.html_colors)
 
 /obj/item/encryptionkey/syndteam
 	icon_state = "cypherkey"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -7,9 +7,9 @@
 	item_state = ""
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "engineering=2;bluespace=1"
-	var/translate_binary = 0
-	var/translate_hive = 0
-	var/syndie = 0
+	var/translate_binary = FALSE
+	var/translate_hive = FALSE
+	var/syndie = FALSE
 	var/list/channels = list()
 
 
@@ -19,8 +19,8 @@
 	icon_state = "cypherkey"
 	channels = list("Syndicate" = 1)
 	origin_tech = "syndicate=1;engineering=3;bluespace=2"
-	syndie = 1 //Signifies that it de-crypts Syndicate transmissions
-	var/change_voice = 1
+	syndie = TRUE //Signifies that it de-crypts Syndicate transmissions
+	var/change_voice = TRUE
 	var/fake_name = "Agent ALERT_A_CODER"
 	var/static/list/fakename_list
 
@@ -29,22 +29,22 @@
 		fakename_list = GLOB.html_colors.Copy()
 	. = ..()
 	if(change_voice)
-		fake_name = "Agent " + pick_n_take(fakename_list)
+		fake_name = "Agent [pick_n_take(fakename_list)]"
 
 /obj/item/encryptionkey/syndicate/nukeops
-	change_voice = 0
+	change_voice = FALSE
 
 /obj/item/encryptionkey/syndteam
 	icon_state = "cypherkey"
 	channels = list("SyndTeam" = 1, "Syndicate" = 1)
 	origin_tech = "syndicate=4"
-	syndie = 1 //Signifies that it de-crypts Syndicate transmissions
+	syndie = TRUE //Signifies that it de-crypts Syndicate transmissions
 
 /obj/item/encryptionkey/binary
 	name = "binary translator key"
 	desc = "An encryption key for a radio headset. To access the binary channel, use :b."
 	icon_state = "cypherkey"
-	translate_binary = 1
+	translate_binary = TRUE
 	origin_tech = "syndicate=3;engineering=4;bluespace=3"
 
 /obj/item/encryptionkey/headset_sec

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -13,8 +13,6 @@
 	var/list/channels = list()
 
 
-/obj/item/encryptionkey/New()
-
 /obj/item/encryptionkey/attackby(obj/item/W as obj, mob/user as mob, params)
 
 /obj/item/encryptionkey/syndicate
@@ -24,11 +22,14 @@
 	syndie = 1 //Signifies that it de-crypts Syndicate transmissions
 	var/change_voice = 1
 	var/fake_name = "Agent ALERT_A_CODER"
+	var/static/list/fakename_list
 
-/obj/item/encryptionkey/syndicate/New()
-	..()
+/obj/item/encryptionkey/syndicate/Initialize()
+	if(!LAZYLEN(fakename_list))
+		fakename_list = GLOB.html_colors.Copy()
+	. = ..()
 	if(change_voice)
-		fake_name = "Agent " + pick(GLOB.html_colors)
+		fake_name = "Agent " + pick_n_take(fakename_list)
 
 /obj/item/encryptionkey/syndicate/nukeops
 	change_voice = 0

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -22,11 +22,16 @@
 	channels = list("Syndicate" = 1)
 	origin_tech = "syndicate=1;engineering=3;bluespace=2"
 	syndie = 1 //Signifies that it de-crypts Syndicate transmissions
+	var/change_voice = 1
 	var/fake_name = "Agent ALERT_A_CODER"
 
 /obj/item/encryptionkey/syndicate/New()
 	..()
-	fake_name = "Agent " + pick(GLOB.html_colors)
+	if(change_voice)
+		fake_name = "Agent " + pick(GLOB.html_colors)
+
+/obj/item/encryptionkey/syndicate/nukeops
+	change_voice = 0
 
 /obj/item/encryptionkey/syndteam
 	icon_state = "cypherkey"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -353,47 +353,47 @@
 
 
 /obj/item/radio/headset/proc/recalculateChannels(var/setDescription = 0)
-	src.channels = list()
-	src.translate_binary = 0
-	src.translate_hive = 0
-	src.syndiekey = null
+	channels = list()
+	translate_binary = 0
+	translate_hive = 0
+	syndiekey = null
 
 	if(keyslot1)
 		for(var/ch_name in keyslot1.channels)
-			if(ch_name in src.channels)
+			if(ch_name in channels)
 				continue
-			src.channels += ch_name
-			src.channels[ch_name] = keyslot1.channels[ch_name]
+			channels += ch_name
+			channels[ch_name] = keyslot1.channels[ch_name]
 
 		if(keyslot1.translate_binary)
-			src.translate_binary = 1
+			translate_binary = 1
 
 		if(keyslot1.translate_hive)
-			src.translate_hive = 1
+			translate_hive = 1
 
 		if(keyslot1.syndie)
-			src.syndiekey = keyslot1
+			syndiekey = keyslot1
 
 	if(keyslot2)
 		for(var/ch_name in keyslot2.channels)
-			if(ch_name in src.channels)
+			if(ch_name in channels)
 				continue
-			src.channels += ch_name
-			src.channels[ch_name] = keyslot2.channels[ch_name]
+			channels += ch_name
+			channels[ch_name] = keyslot2.channels[ch_name]
 
 		if(keyslot2.translate_binary)
-			src.translate_binary = 1
+			translate_binary = 1
 
 		if(keyslot2.translate_hive)
-			src.translate_hive = 1
+			translate_hive = 1
 
 		if(keyslot2.syndie)
-			src.syndiekey = keyslot2
+			syndiekey = keyslot2
 
 
 	for(var/ch_name in channels)
 		if(!radio_controller)
-			src.name = "broken radio headset"
+			name = "broken radio headset"
 			return
 
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -83,7 +83,7 @@
 
 /obj/item/radio/headset/syndicate
 	origin_tech = "syndicate=3"
-	ks1type = /obj/item/encryptionkey/syndicate
+	ks1type = /obj/item/encryptionkey/syndicate/nukeops
 
 /obj/item/radio/headset/syndicate/alt //undisguised bowman with flash protection
 	name = "syndicate headset"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -5,12 +5,12 @@
 	icon_state = "headset"
 	item_state = "headset"
 	materials = list(MAT_METAL=75)
-	subspace_transmission = 1
+	subspace_transmission = TRUE
 	canhear_range = 0 // can't hear headsets from very far away
 
 	slot_flags = SLOT_EARS
-	var/translate_binary = 0
-	var/translate_hive = 0
+	var/translate_binary = FALSE
+	var/translate_hive = FALSE
 	var/obj/item/encryptionkey/keyslot1 = null
 	var/obj/item/encryptionkey/keyslot2 = null
 
@@ -33,7 +33,7 @@
 		if(keyslot2.syndie)
 			syndiekey = keyslot2
 
-	recalculateChannels(1)
+	recalculateChannels(TRUE)
 
 /obj/item/radio/headset/Destroy()
 	QDEL_NULL(keyslot1)
@@ -352,10 +352,10 @@
 	return
 
 
-/obj/item/radio/headset/proc/recalculateChannels(var/setDescription = 0)
+/obj/item/radio/headset/proc/recalculateChannels(var/setDescription = FALSE)
 	channels = list()
-	translate_binary = 0
-	translate_hive = 0
+	translate_binary = FALSE
+	translate_hive = FALSE
 	syndiekey = null
 
 	if(keyslot1)
@@ -366,10 +366,10 @@
 			channels[ch_name] = keyslot1.channels[ch_name]
 
 		if(keyslot1.translate_binary)
-			translate_binary = 1
+			translate_binary = TRUE
 
 		if(keyslot1.translate_hive)
-			translate_hive = 1
+			translate_hive = TRUE
 
 		if(keyslot1.syndie)
 			syndiekey = keyslot1
@@ -382,10 +382,10 @@
 			channels[ch_name] = keyslot2.channels[ch_name]
 
 		if(keyslot2.translate_binary)
-			translate_binary = 1
+			translate_binary = TRUE
 
 		if(keyslot2.translate_hive)
-			translate_hive = 1
+			translate_hive = TRUE
 
 		if(keyslot2.syndie)
 			syndiekey = keyslot2

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -26,8 +26,12 @@
 
 	if(ks1type)
 		keyslot1 = new ks1type(src)
+		if(keyslot1.syndie)
+			syndiekey = keyslot1
 	if(ks2type)
 		keyslot2 = new ks2type(src)
+		if(keyslot2.syndie)
+			syndiekey = keyslot2
 
 	recalculateChannels(1)
 
@@ -79,7 +83,6 @@
 
 /obj/item/radio/headset/syndicate
 	origin_tech = "syndicate=3"
-	syndie = 1
 	ks1type = /obj/item/encryptionkey/syndicate
 
 /obj/item/radio/headset/syndicate/alt //undisguised bowman with flash protection
@@ -353,7 +356,7 @@
 	src.channels = list()
 	src.translate_binary = 0
 	src.translate_hive = 0
-	src.syndie = 0
+	src.syndiekey = null
 
 	if(keyslot1)
 		for(var/ch_name in keyslot1.channels)
@@ -369,7 +372,7 @@
 			src.translate_hive = 1
 
 		if(keyslot1.syndie)
-			src.syndie = 1
+			src.syndiekey = keyslot1
 
 	if(keyslot2)
 		for(var/ch_name in keyslot2.channels)
@@ -385,7 +388,7 @@
 			src.translate_hive = 1
 
 		if(keyslot2.syndie)
-			src.syndie = 1
+			src.syndiekey = keyslot2
 
 
 	for(var/ch_name in channels)
@@ -414,5 +417,5 @@
 /obj/item/radio/headset/proc/make_syndie() // Turns normal radios into Syndicate radios!
 	qdel(keyslot1)
 	keyslot1 = new /obj/item/encryptionkey/syndicate
-	syndie = 1
+	syndiekey = keyslot1
 	recalculateChannels()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -76,7 +76,7 @@
 	desc = "Talk through this. Evilly"
 	frequency = SYND_FREQ
 	subspace_transmission = 1
-	syndie = 1
+	syndiekey = new /obj/item/encryptionkey/syndicate
 
 /obj/item/radio/intercom/syndicate/New()
 	..()
@@ -129,7 +129,7 @@
 		if(isnull(position) || !(position.z in level))
 			return -1
 	if(freq in ANTAG_FREQS)
-		if(!(src.syndie))
+		if(!(src.syndiekey))
 			return -1//Prevents broadcast of messages over devices lacking the encryption
 
 	return canhear_range

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -129,7 +129,7 @@
 		if(isnull(position) || !(position.z in level))
 			return -1
 	if(freq in ANTAG_FREQS)
-		if(!(src.syndiekey))
+		if(!(syndiekey))
 			return -1//Prevents broadcast of messages over devices lacking the encryption
 
 	return canhear_range

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -76,7 +76,7 @@
 	desc = "Talk through this. Evilly"
 	frequency = SYND_FREQ
 	subspace_transmission = 1
-	syndiekey = new /obj/item/encryptionkey/syndicate
+	syndiekey = new /obj/item/encryptionkey/syndicate/nukeops
 
 /obj/item/radio/intercom/syndicate/New()
 	..()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -75,7 +75,7 @@
 	name = "illicit intercom"
 	desc = "Talk through this. Evilly"
 	frequency = SYND_FREQ
-	subspace_transmission = 1
+	subspace_transmission = TRUE
 	syndiekey = new /obj/item/encryptionkey/syndicate/nukeops
 
 /obj/item/radio/intercom/syndicate/New()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -36,7 +36,7 @@ var/global/list/default_medbay_channels = list(
 	var/listening = 1
 	var/list/channels = list() //see communications.dm for full list. First channes is a "default" for :h
 	var/subspace_transmission = 0
-	var/syndie = 0//Holder to see if it's a syndicate encrpyed radio
+	var/obj/item/encryptionkey/syndicate/syndiekey = null //Holder for the syndicate encryption key if present
 	var/disable_timer = 0 //How many times this is disabled by EMPs
 
 	var/is_special = 0 //For electropacks mostly, skips Topic() checks
@@ -131,7 +131,7 @@ var/global/list/default_medbay_channels = list(
 		data["chan_list"] = chanlist
 		data["chan_list_len"] = chanlist.len
 
-	if(syndie)
+	if(syndiekey)
 		data["useSyndMode"] = 1
 
 	return data
@@ -397,6 +397,10 @@ var/global/list/default_medbay_channels = list(
 		jobname = "Unknown"
 		voicemask = 1
 
+	if(syndiekey && connection.frequency == SYND_FREQ)
+		displayname = syndiekey.fake_name
+		jobname = "Unknown"
+		voicemask = 1
 
 
   /* ###### Radio headsets can only broadcast through subspace ###### */
@@ -552,7 +556,7 @@ var/global/list/default_medbay_channels = list(
 		if(!position || !(position.z in level))
 			return -1
 	if(freq in ANTAG_FREQS)
-		if(!(syndie))//Checks to see if it's allowed on that frequency, based on the encryption keys
+		if(!(syndiekey))//Checks to see if it's allowed on that frequency, based on the encryption keys
 			return -1
 	if(!freq) //recieved on main frequency
 		if(!listening)
@@ -652,7 +656,6 @@ var/global/list/default_medbay_channels = list(
 	subspace_transmission = 1
 
 /obj/item/radio/borg/syndicate
-	syndie = 1
 	keyslot = new /obj/item/encryptionkey/syndicate
 
 /obj/item/radio/borg/syndicate/CanUseTopic(mob/user, datum/topic_state/state)
@@ -669,6 +672,7 @@ var/global/list/default_medbay_channels = list(
 
 /obj/item/radio/borg/syndicate/New()
 	..()
+	syndiekey = keyslot
 	set_frequency(SYND_FREQ)
 
 /obj/item/radio/borg/deathsquad
@@ -727,7 +731,7 @@ var/global/list/default_medbay_channels = list(
 
 /obj/item/radio/borg/proc/recalculateChannels()
 	src.channels = list()
-	src.syndie = 0
+	src.syndiekey = null
 
 	var/mob/living/silicon/robot/D = src.loc
 	if(D.module)
@@ -744,7 +748,7 @@ var/global/list/default_medbay_channels = list(
 			src.channels[ch_name] += keyslot.channels[ch_name]
 
 		if(keyslot.syndie)
-			src.syndie = 1
+			src.syndiekey = keyslot
 
 
 	for(var/ch_name in src.channels)
@@ -814,7 +818,7 @@ var/global/list/default_medbay_channels = list(
 		data["chan_list"] = chanlist
 		data["chan_list_len"] = chanlist.len
 
-	if(syndie)
+	if(syndiekey)
 		data["useSyndMode"] = 1
 
 	data["has_loudspeaker"] = 1

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -395,12 +395,12 @@ var/global/list/default_medbay_channels = list(
 	if(ishuman(M) && M.GetVoice() != real_name)
 		displayname = M.GetVoice()
 		jobname = "Unknown"
-		voicemask = 1
+		voicemask = TRUE
 
 	if(syndiekey && syndiekey.change_voice && connection.frequency == SYND_FREQ)
 		displayname = syndiekey.fake_name
 		jobname = "Unknown"
-		voicemask = 1
+		voicemask = TRUE
 
 
   /* ###### Radio headsets can only broadcast through subspace ###### */

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -730,32 +730,32 @@ var/global/list/default_medbay_channels = list(
 	return
 
 /obj/item/radio/borg/proc/recalculateChannels()
-	src.channels = list()
-	src.syndiekey = null
+	channels = list()
+	syndiekey = null
 
-	var/mob/living/silicon/robot/D = src.loc
+	var/mob/living/silicon/robot/D = loc
 	if(D.module)
 		for(var/ch_name in D.module.channels)
-			if(ch_name in src.channels)
+			if(ch_name in channels)
 				continue
-			src.channels += ch_name
-			src.channels[ch_name] += D.module.channels[ch_name]
+			channels += ch_name
+			channels[ch_name] += D.module.channels[ch_name]
 	if(keyslot)
 		for(var/ch_name in keyslot.channels)
-			if(ch_name in src.channels)
+			if(ch_name in channels)
 				continue
-			src.channels += ch_name
-			src.channels[ch_name] += keyslot.channels[ch_name]
+			channels += ch_name
+			channels[ch_name] += keyslot.channels[ch_name]
 
 		if(keyslot.syndie)
-			src.syndiekey = keyslot
+			syndiekey = keyslot
 
 
-	for(var/ch_name in src.channels)
+	for(var/ch_name in channels)
 		if(!radio_controller)
 			sleep(30) // Waiting for the radio_controller to be created.
 		if(!radio_controller)
-			src.name = "broken radio"
+			name = "broken radio"
 			return
 
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -397,7 +397,7 @@ var/global/list/default_medbay_channels = list(
 		jobname = "Unknown"
 		voicemask = 1
 
-	if(syndiekey && connection.frequency == SYND_FREQ)
+	if(syndiekey && syndiekey.change_voice && connection.frequency == SYND_FREQ)
 		displayname = syndiekey.fake_name
 		jobname = "Unknown"
 		voicemask = 1

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -91,7 +91,7 @@
 
 /mob/living/simple_animal/bot/medbot/syndicate/New()
 	..()
-	Radio.syndie = 1
+	Radio.syndiekey = new /obj/item/encryptionkey/syndicate
 
 /mob/living/simple_animal/bot/medbot/syndicate/emagged
 	emagged = 2


### PR DESCRIPTION
**What does this PR do:**
Syndicate encryption keys now hide your identity on the syndicate channel, similar to the hive chat of changelings.

This allows communications without giving away the identity of the speaker. If such an encryption key falls into wrong hands *cough* security *cough* it will no longer compromise the identities of the syndicate agents.

However such a key could still be used to impersonate its former user.

Example:
![ij9cbvo](https://user-images.githubusercontent.com/181899/47219975-a8882680-d3b0-11e8-93d6-b4830e7ca176.png)


**Changelog:**
:cl: uc_guy
tweak: Syndicate communication channel is now pseudonymous.
/:cl:

