### PR TITLE
Significantly reduces explosion from spacepods

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -234,9 +234,9 @@
 		spawn(0)
 			message_to_riders("<span class='userdanger'>Critical damage to the vessel detected, core explosion imminent!</span>")
 			for(var/i in 1 to 3)
-				var/count = 1
+				var/count = 3
 				message_to_riders("<span class='warning'>[count]</span>")
-				count++
+				count--
 				sleep(10)
 			if(LAZYLEN(pilot) || LAZYLEN(passengers))
 				for(var/M in passengers + pilot)

--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -233,12 +233,19 @@
 	if(!health)
 		spawn(0)
 			message_to_riders("<span class='userdanger'>Critical damage to the vessel detected, core explosion imminent!</span>")
-			for(var/i = 10, i >= 0; --i)
-				message_to_riders("<span class='warning'>[i]</span>")
-				if(i == 0)
-					explosion(loc, 2, 4, 8)
-					qdel(src)
+			for(var/i in 1 to 3)
+				var/count = 1
+				message_to_riders("<span class='warning'>[count]</span>")
+				count++
 				sleep(10)
+			if(LAZYLEN(pilot) || LAZYLEN(passengers))
+				for(var/M in passengers + pilot)
+					var/mob/living/L = M
+					L.adjustBruteLoss(300)
+			explosion(loc, 0, 0, 2)
+			robogibs(loc)
+			robogibs(loc)
+			qdel(src)
 
 	update_icons()
 


### PR DESCRIPTION
This was a request with the intention of preventing spacepods being used offensively to bypass things such as the nukie shuttle blast door or to take out blobs quickly by destroying them.

Reduces explosion from spacepods to an insignificant 2 value light explosion.
All mobs inside are dealt 300 damage.
Mechanical gibs are spread over the area.

🆑 Birdtalon
tweak: Spacepods explosions are significantly reduced.
/🆑 

As this is a balance PR I have cited three fixes below as well as sought approval from Ansari, Spartan sought approval from Tigercat
Fixes: #9827 #9804 #9803