### PR TITLE
Added notifications for the user on the RCD airlock creation

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -156,9 +156,9 @@ RCD
 				if(check_access(ID))
 					locked = 0
 				else 
-					to_chat(user, "<span class='warning'>This ID lacks access.</span>")
+					to_chat(usr, "<span class='warning'>This ID lacks access.</span>")
 			else
-				to_chat(user, "<span class='warning'>You can't swipe without your ID in hand.</span>")
+				to_chat(usr, "<span class='warning'>You can't swipe without your ID in hand.</span>")
 		. = 1
 
 	if(href_list["logout"])

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -152,8 +152,13 @@ RCD
 				var/obj/item/pda/pda = I
 				I = pda.id
 			var/obj/item/card/id/ID = I
-			if(istype(ID) && ID && check_access(ID))
-				locked = 0
+			if(istype(ID) && ID)
+				if(check_access(ID))
+					locked = 0
+				else 
+					to_chat(user, "<span class='warning'>This ID lacks access.</span>")
+			else
+				to_chat(user, "<span class='warning'>You can't swipe without your ID in hand.</span>")
 		. = 1
 
 	if(href_list["logout"])


### PR DESCRIPTION
**What does this PR do:**
When trying to swipe to open the airlock access topic you now get a notification if it failed. And why.

kinda fixes #9907

**Changelog:**
:cl: Farie82
tweak: Added feedback on the RCD airlock access topic.
/:cl:

