### PR TITLE
Borg fire extinguishers and welding tools now get refilled

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -220,6 +220,16 @@
 						var/i = 1
 						for(1, i <= coeff, i++)
 							LR.Charge(occupant)
+					//Fire extinguisher
+					if(istype(O, /obj/item/extinguisher))
+						var/obj/item/extinguisher/ext = O
+						if(ext.reagents.get_reagent_amount("water") < ext.max_water)
+							ext.reagents.add_reagent("water", 5 * coeff)
+					//Welding tools
+					if(istype(O,/obj/item/weldingtool))
+						var/obj/item/weldingtool/weld = O
+						if(weld.reagents.get_reagent_amount("fuel") < weld.max_fuel)
+							weld.reagents.add_reagent("fuel", 2 * coeff)
 				if(R)
 					if(R.module)
 						R.module.respawn_consumable(R)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -227,7 +227,7 @@
 					//Welding tools
 					if(istype(O, /obj/item/weldingtool))
 						var/obj/item/weldingtool/weld = O
-						ext.reagents.check_and_add("fuel", weld.max_fuel, 2 * coeff)
+						weld.reagents.check_and_add("fuel", weld.max_fuel, 2 * coeff)
 				if(R)
 					if(R.module)
 						R.module.respawn_consumable(R)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -223,13 +223,11 @@
 					//Fire extinguisher
 					if(istype(O, /obj/item/extinguisher))
 						var/obj/item/extinguisher/ext = O
-						if(ext.reagents.get_reagent_amount("water") < ext.max_water)
-							ext.reagents.add_reagent("water", 5 * coeff)
+						ext.reagents.check_and_add("water", ext.max_water, 5 * coeff)
 					//Welding tools
-					if(istype(O,/obj/item/weldingtool))
+					if(istype(O, /obj/item/weldingtool))
 						var/obj/item/weldingtool/weld = O
-						if(weld.reagents.get_reagent_amount("fuel") < weld.max_fuel)
-							weld.reagents.add_reagent("fuel", 2 * coeff)
+						ext.reagents.check_and_add("fuel", weld.max_fuel, 2 * coeff)
 				if(R)
 					if(R.module)
 						R.module.respawn_consumable(R)


### PR DESCRIPTION
**What does this PR do:**
Removes the inconsistency with cyborg recharging.
It now also recharges fire extinguishers and welding tools. Both easy to refill but it was a bit odd.

fixes #9901

**Changelog:**
:cl: Farie82
tweak: Cyborgs can now refill welding tools and fire extinguishers using the recharging station
/:cl:

