### PR TITLE
Removing unused atom code

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -11,7 +11,6 @@ SUBSYSTEM_DEF(atoms)
 	var/old_initialized
 
 	var/list/late_loaders
-	var/list/created_atoms
 
 	var/list/BadInitializeCalls = list()
 
@@ -39,13 +38,11 @@ SUBSYSTEM_DEF(atoms)
 	var/count
 	var/list/mapload_arg = list(TRUE)
 	if(atoms)
-		created_atoms = list()
 		count = atoms.len
 		for(var/I in atoms)
 			var/atom/A = I
 			if(A && !A.initialized)
-				if(InitAtom(I, mapload_arg))
-					atoms -= I
+				InitAtom(I, mapload_arg)
 				CHECK_TICK
 	else
 		count = 0
@@ -77,10 +74,6 @@ SUBSYSTEM_DEF(atoms)
 		else
 			log_debug("	Late initialized [late_loaders.len] atoms in [stop_watch(watch)]s")
 		late_loaders.Cut()
-
-	if(atoms)
-		. = created_atoms + atoms
-		created_atoms = null
 
 /datum/controller/subsystem/atoms/proc/InitAtom(atom/A, list/arguments)
 	var/the_type = A.type


### PR DESCRIPTION
Unlikely to have a big effect on performance, but at least it is no longer doing pointless things with lists! TG #39866

:cl: Purpose
del: Atom code will no longer track a list atoms, for literally zero reason.
/:cl: