### PR TITLE
Explosive holoparasite fixes

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -37,32 +37,36 @@
 /obj/item/guardian_bomb/proc/disguise(var/obj/A)
 	A.forceMove(src)
 	stored_obj = A
+	opacity = A.opacity
 	anchored = A.anchored
 	density = A.density
 	appearance = A.appearance
-	spawn(600)
-		if(src)
-			stored_obj.loc = get_turf(loc)
-			if(spawner)
-				to_chat(spawner, "<span class='danger'>Failure! Your trap on [stored_obj] didn't catch anyone this time.</span>")
-			qdel(src)
+	dir = A.dir
+	addtimer(CALLBACK(src, .proc/disable), 600)
+
+/obj/item/guardian_bomb/proc/disable()
+	stored_obj.forceMove(get_turf(src))
+	to_chat(spawner, "<span class='danger'>Failure! Your trap on [stored_obj] didn't catch anyone this time.</span>")
+	qdel(src)
 
 /obj/item/guardian_bomb/proc/detonate(var/mob/living/user)
+	if(!istype(user))
+		return
 	to_chat(user, "<span class='danger'>The [src] was boobytrapped!</span>")
 	if(istype(spawner, /mob/living/simple_animal/hostile/guardian))
 		var/mob/living/simple_animal/hostile/guardian/G = spawner
 		if(user == G.summoner)
 			to_chat(user, "<span class='danger'>You knew this because of your link with your guardian, so you smartly defuse the bomb.</span>")
-			stored_obj.loc = get_turf(loc)
+			stored_obj.forceMove(get_turf(loc))
 			qdel(src)
 			return
 	to_chat(spawner, "<span class='danger'>Success! Your trap on [src] caught [user]!</span>")
-	stored_obj.loc = get_turf(loc)
+	stored_obj.forceMove(get_turf(loc))
 	playsound(get_turf(src),'sound/effects/Explosion2.ogg', 200, 1)
 	user.ex_act(2)
 	qdel(src)
 
-/obj/item/guardian_bomb/attackby(mob/living/user)
+/obj/item/guardian_bomb/attackby(obj/item/W, mob/living/user)
 	detonate(user)
 	return
 

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -68,11 +68,9 @@
 
 /obj/item/guardian_bomb/attackby(obj/item/W, mob/living/user)
 	detonate(user)
-	return
 
 /obj/item/guardian_bomb/pickup(mob/living/user)
 	detonate(user)
-	return
 
 /obj/item/guardian_bomb/examine(mob/user)
 	stored_obj.examine(user)

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -46,7 +46,8 @@
 
 /obj/item/guardian_bomb/proc/disable()
 	stored_obj.forceMove(get_turf(src))
-	to_chat(spawner, "<span class='danger'>Failure! Your trap on [stored_obj] didn't catch anyone this time.</span>")
+	if(spawner)
+		to_chat(spawner, "<span class='danger'>Failure! Your trap on [stored_obj] didn't catch anyone this time.</span>")
 	qdel(src)
 
 /obj/item/guardian_bomb/proc/detonate(var/mob/living/user)


### PR DESCRIPTION
Fixes #9728 

- Bomb traps will now respect direction (and opacity) of the atom they are disguised as
  - This should make them appear more inconspicuous esp if they are windoors
- They will no longer be triggered by objs and will instead trigger on the mob correctly
  - This may have a balance implication but disarming them by making them "explode" on objs in hand does not seem to be intended. Also this would previously runtime because of failed to_chat calls.
- Automatic disarming now uses timer ss so no more deletion of the contained obj after already being triggered
  - This was found during testing, the spawn statement would execute after the trap was triggered causing the atom that was previously inside the bomb to be deleted and the failure msg to be sent
- replaces loc assignments with forceMove
  - I assume this is just better practice to use

:cl: Squirgenheimer
fix: Explosive holoparasite booby traps will now behave better, such as correctly triggering on mobs
/:cl:

