### PR TITLE
Make oculine not expensive

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -551,14 +551,14 @@
 		update_flags |= M.AdjustEyeBlurry(-1, FALSE)
 		update_flags |= M.AdjustEarDamage(-1, FALSE)
 	if(prob(50))
-		update_flags |= M.CureNearsighted()
+		update_flags |= M.CureNearsighted(FALSE)
 	if(prob(30))
-		update_flags |= M.CureBlind()
-		update_flags |= M.SetEyeBlind(0)
+		update_flags |= M.CureBlind(FALSE)
+		update_flags |= M.SetEyeBlind(0, FALSE)
 	if(M.ear_damage <= 25)
 		if(prob(30))
 			M.SetEarDeaf(0)
-	..()
+	return ..() | update_flags
 
 /datum/reagent/medicine/atropine
 	name = "Atropine"


### PR DESCRIPTION
**What does this PR do:**
The previous fix worked but unfortunately, would be quite expensive performance wise. This is best fixed by returning ..() | update_flags

**Changelog:**
:cl: Ansari
tweak: Oculine processing should be less expensive now.
/:cl:

