### PR TITLE
Helps Reagents GC Better

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -333,7 +333,7 @@
 
 /mob/living/is_injectable(allowmobs = TRUE)
 	return (allowmobs && reagents && can_inject())
-	
+
 /mob/living/is_drawable(allowmobs = TRUE)
 	return (allowmobs && reagents && can_inject())
 
@@ -365,9 +365,8 @@
 		C.update_inv_legcuffed()
 
 		if(C.reagents)
-			for(var/datum/reagent/R in C.reagents.reagent_list)
-				C.reagents.clear_reagents()
-			C.reagents.addiction_list.Cut()
+			C.reagents.clear_reagents()
+			QDEL_LIST(C.reagents.addiction_list)
 
 // rejuvenate: Called by `revive` to get the mob into a revivable state
 // the admin "rejuvenate" command calls `revive`, not this proc.

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -764,5 +764,7 @@ var/const/INGEST = 2
 	processing_objects -= src
 	QDEL_LIST(reagent_list)
 	reagent_list = null
+	QDEL_LIST(addiction_list)
+	addiction_list = null
 	if(my_atom && my_atom.reagents == src)
 		my_atom.reagents = null


### PR DESCRIPTION
Helps reagents to collect ever so slightly better by ensuring all reagents in the `addiction_list` are cleared out.

Also makes it so that `clear_reagents` is only called once on a mob that is revived, instead of calling it for each reagent the mob has.

:cl: Fox McCloud
tweak: Reagents now GC slightly better
/:cl: