### PR TITLE
Fixes typo in a warning message

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_parser.dm
@@ -60,7 +60,7 @@
 
 /datum/SDQL_parser/proc/parse_error(error_message)
 	error = 1
-	to_chat(usr, "<span class='danger'>SQDL2 Parsing Error: [error_message]</span>")
+	to_chat(usr, "<span class='danger'>SDQL2 Parsing Error: [error_message]</span>")
 	return query.len + 1
 
 /datum/SDQL_parser/proc/parse()


### PR DESCRIPTION
Really low importance this one.... I only spotted it because I typo'd SDQL in the first place during a search.

:cl: Purpose
spellcheck: Fixes a typo in an SDQL parse warning.
/:cl: