### PR TITLE
fix: autopsy scanner unresponsiveness

### DIFF
--- a/code/game/objects/items/devices/autopsy.dm
+++ b/code/game/objects/items/devices/autopsy.dm
@@ -41,38 +41,37 @@
 	W.time_inflicted = time_inflicted
 	return W
 
-/obj/item/autopsy_scanner/proc/add_data(obj/item/organ/external/O)
-	if(!O.autopsy_data.len && !O.trace_chemicals.len)
-		return
+/obj/item/autopsy_scanner/proc/add_data(obj/item/organ/O)
+	if(O.autopsy_data.len)
+		for(var/V in O.autopsy_data)
+			var/datum/autopsy_data/W = O.autopsy_data[V]
 
-	for(var/V in O.autopsy_data)
-		var/datum/autopsy_data/W = O.autopsy_data[V]
-
-		if(!W.pretend_weapon)
-			if(1)
-				W.pretend_weapon = W.weapon
-			else
-				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
+			if(!W.pretend_weapon)
+				if(1)
+					W.pretend_weapon = W.weapon
+				else
+					W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
 
 
-		var/datum/autopsy_data_scanner/D = wdata[V]
-		if(!D)
-			D = new()
-			D.weapon = W.weapon
-			wdata[V] = D
+			var/datum/autopsy_data_scanner/D = wdata[V]
+			if(!D)
+				D = new()
+				D.weapon = W.weapon
+				wdata[V] = D
 
-		if(!D.organs_scanned[O.name])
-			if(D.organ_names == "")
-				D.organ_names = O.name
-			else
-				D.organ_names += ", [O.name]"
+			if(!D.organs_scanned[O.name])
+				if(D.organ_names == "")
+					D.organ_names = O.name
+				else
+					D.organ_names += ", [O.name]"
 
-		qdel(D.organs_scanned[O.name])
-		D.organs_scanned[O.name] = W.copy()
+			qdel(D.organs_scanned[O.name])
+			D.organs_scanned[O.name] = W.copy()
 
-	for(var/V in O.trace_chemicals)
-		if(O.trace_chemicals[V] > 0 && !chemtraces.Find(V))
-			chemtraces += V
+	if(O.trace_chemicals.len)
+		for(var/V in O.trace_chemicals)
+			if(O.trace_chemicals[V] > 0 && !chemtraces.Find(V))
+				chemtraces += V
 
 /obj/item/autopsy_scanner/attackby(obj/item/P, mob/user)
 	if(istype(P, /obj/item/pen))
@@ -90,71 +89,71 @@
 		user.put_in_hands(R)
 
 /obj/item/autopsy_scanner/attack_self(mob/user)
-	if(!wdata.len && !chemtraces.len)
-		return
-
 	var/scan_data = ""
 
 	if(timeofdeath)
 		scan_data += "<b>Time of death:</b> [station_time_timestamp("hh:mm:ss", timeofdeath)]<br><br>"
+	else
+		scan_data += "<b>Time of death:</b> Unknown / Still alive<br><br>"
 
-	var/n = 1
-	for(var/wdata_idx in wdata)
-		var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
-		var/total_hits = 0
-		var/total_score = 0
-		var/list/weapon_chances = list() // maps weapon names to a score
-		var/age = 0
+	if(wdata.len)
+		var/n = 1
+		for(var/wdata_idx in wdata)
+			var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
+			var/total_hits = 0
+			var/total_score = 0
+			var/list/weapon_chances = list() // maps weapon names to a score
+			var/age = 0
 
-		for(var/wound_idx in D.organs_scanned)
-			var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
-			total_hits += W.hits
+			for(var/wound_idx in D.organs_scanned)
+				var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
+				total_hits += W.hits
 
-			var/wname = W.pretend_weapon
+				var/wname = W.pretend_weapon
 
-			if(wname in weapon_chances)
-				weapon_chances[wname] += W.damage
-			else
-				weapon_chances[wname] = max(W.damage, 1)
-			total_score+=W.damage
+				if(wname in weapon_chances)
+					weapon_chances[wname] += W.damage
+				else
+					weapon_chances[wname] = max(W.damage, 1)
+				total_score+=W.damage
 
 
-			var/wound_age = W.time_inflicted
-			age = max(age, wound_age)
+				var/wound_age = W.time_inflicted
+				age = max(age, wound_age)
 
-		var/damage_desc
+			var/damage_desc
 
-		var/damaging_weapon = (total_score != 0)
+			var/damaging_weapon = (total_score != 0)
 
-		// total score happens to be the total damage
-		switch(total_score)
-			if(0)
-				damage_desc = "Unknown"
-			if(1 to 5)
-				damage_desc = "<font color='green'>negligible</font>"
-			if(5 to 15)
-				damage_desc = "<font color='green'>light</font>"
-			if(15 to 30)
-				damage_desc = "<font color='orange'>moderate</font>"
-			if(30 to 1000)
-				damage_desc = "<font color='red'>severe</font>"
+			// total score happens to be the total damage
+			switch(total_score)
+				if(0)
+					damage_desc = "Unknown"
+				if(1 to 5)
+					damage_desc = "<font color='green'>negligible</font>"
+				if(5 to 15)
+					damage_desc = "<font color='green'>light</font>"
+				if(15 to 30)
+					damage_desc = "<font color='orange'>moderate</font>"
+				if(30 to 1000)
+					damage_desc = "<font color='red'>severe</font>"
 
-		if(!total_score)
-			total_score = D.organs_scanned.len
+			if(!total_score)
+				total_score = D.organs_scanned.len
 
-		scan_data += "<b>Weapon #[n]</b><br>"
-		if(damaging_weapon)
-			scan_data += "Severity: [damage_desc]<br>"
-			scan_data += "Hits by weapon: [total_hits]<br>"
-		scan_data += "Approximate time of wound infliction: [station_time_timestamp("hh:mm", age)]<br>"
-		scan_data += "Affected limbs: [D.organ_names]<br>"
-		scan_data += "Possible weapons:<br>"
-		for(var/weapon_name in weapon_chances)
-			scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
+			scan_data += "<b>Weapon #[n]</b><br>"
+			if(damaging_weapon)
+				scan_data += "Severity: [damage_desc]<br>"
+				scan_data += "Hits by weapon: [total_hits]<br>"
+			scan_data += "Approximate time of wound infliction: [station_time_timestamp("hh:mm", age)]<br>"
+			scan_data += "Affected limbs: [D.organ_names]<br>"
+			scan_data += "Possible weapons:<br>"
+			for(var/weapon_name in weapon_chances)
+				scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
 
-		scan_data += "<br>"
+			scan_data += "<br>"
 
-		n++
+			n++
 
 	if(chemtraces.len)
 		scan_data += "<b>Trace Chemicals: </b><br>"

--- a/code/game/objects/items/devices/autopsy.dm
+++ b/code/game/objects/items/devices/autopsy.dm
@@ -27,7 +27,6 @@
 
 /datum/autopsy_data
 	var/weapon = null
-	var/pretend_weapon = null
 	var/damage = 0
 	var/hits = 0
 	var/time_inflicted = 0
@@ -35,7 +34,6 @@
 /datum/autopsy_data/proc/copy()
 	var/datum/autopsy_data/W = new()
 	W.weapon = weapon
-	W.pretend_weapon = pretend_weapon
 	W.damage = damage
 	W.hits = hits
 	W.time_inflicted = time_inflicted
@@ -45,13 +43,6 @@
 	if(O.autopsy_data.len)
 		for(var/V in O.autopsy_data)
 			var/datum/autopsy_data/W = O.autopsy_data[V]
-
-			if(!W.pretend_weapon)
-				if(1)
-					W.pretend_weapon = W.weapon
-				else
-					W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
-
 
 			var/datum/autopsy_data_scanner/D = wdata[V]
 			if(!D)
@@ -102,19 +93,11 @@
 			var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
 			var/total_hits = 0
 			var/total_score = 0
-			var/list/weapon_chances = list() // maps weapon names to a score
 			var/age = 0
 
 			for(var/wound_idx in D.organs_scanned)
 				var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
 				total_hits += W.hits
-
-				var/wname = W.pretend_weapon
-
-				if(wname in weapon_chances)
-					weapon_chances[wname] += W.damage
-				else
-					weapon_chances[wname] = max(W.damage, 1)
 				total_score+=W.damage
 
 
@@ -122,13 +105,8 @@
 				age = max(age, wound_age)
 
 			var/damage_desc
-
-			var/damaging_weapon = (total_score != 0)
-
 			// total score happens to be the total damage
 			switch(total_score)
-				if(0)
-					damage_desc = "Unknown"
 				if(1 to 5)
 					damage_desc = "<font color='green'>negligible</font>"
 				if(5 to 15)
@@ -137,20 +115,17 @@
 					damage_desc = "<font color='orange'>moderate</font>"
 				if(30 to 1000)
 					damage_desc = "<font color='red'>severe</font>"
+				else
+					damage_desc = "Unknown"
 
-			if(!total_score)
-				total_score = D.organs_scanned.len
-
+			var/damaging_weapon = (total_score != 0)
 			scan_data += "<b>Weapon #[n]</b><br>"
 			if(damaging_weapon)
 				scan_data += "Severity: [damage_desc]<br>"
 				scan_data += "Hits by weapon: [total_hits]<br>"
 			scan_data += "Approximate time of wound infliction: [station_time_timestamp("hh:mm", age)]<br>"
 			scan_data += "Affected limbs: [D.organ_names]<br>"
-			scan_data += "Possible weapons:<br>"
-			for(var/weapon_name in weapon_chances)
-				scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
-
+			scan_data += "Weapon: [D.weapon]<br>"
 			scan_data += "<br>"
 
 			n++

--- a/code/modules/surgery/organs/organ.dm
+++ b/code/modules/surgery/organs/organ.dm
@@ -203,7 +203,7 @@
 						// Let's not drag this on, medbay has only so much antibiotics
 
 //Adds autopsy data for used_weapon.
-/obj/item/organ/proc/add_autopsy_data(var/used_weapon, var/damage)
+/obj/item/organ/proc/add_autopsy_data(var/used_weapon = "Unknown", var/damage)
 	var/datum/autopsy_data/W = autopsy_data[used_weapon]
 	if(!W)
 		W = new()

--- a/code/modules/surgery/organs/organ_external.dm
+++ b/code/modules/surgery/organs/organ_external.dm
@@ -175,6 +175,8 @@
 		owner.handle_splints()
 	if(used_weapon)
 		add_autopsy_data("[used_weapon]", brute + burn)
+	else
+		add_autopsy_data(null, brute + burn)
 
 	// Make sure we don't exceed the maximum damage a limb can take before dismembering
 	if((brute_dam + burn_dam + brute + burn) < max_damage)


### PR DESCRIPTION
**What does this PR do:**
Fixes #7955 
Fixes #7299

The autopsy scanner now works even when it does not know the weapon and/or the time of death. It will produce very minimal results in some cases, particularly when the deceased is perfectly healthy and alive, but at least it will tell the player something. 

I also removed some unused code for determining weapon chance. I tried re-enabling it but it just doesn't work very well. 

**Changelog:**
:cl: name here
fix: The autopsy scanner now works even when it does not know the weapon and/or the time of death. 
del: Unused weapon chance code
/:cl: