### PR TITLE
Removed logging ambiguity for uplink purchases.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		if(I)
 			if(ishuman(user))
 				var/mob/living/carbon/human/A = user
-				log_game("[key_name(user)] purchased [I.name]")
+				log_game("[key_name(user)] purchased [name]")
 				A.put_in_any_hand_if_possible(I)
 
 				if(istype(I,/obj/item/storage/box/) && I.contents.len>0)


### PR DESCRIPTION
**What does this PR do:**
Uplink purchases will show up in admin logs with the same name as in the Uplink.
This resolves ambiguity in the logs: For example "Sleepy Pen", "Poison Pen" and "Energy Dagger" will no longer show up as just "pen" in the logs.

**Changelog:**
:cl: uc_guy
tweak: Removed logging ambiguity for uplink purchases.
/:cl:

