### PR TITLE
Add in shadowling win rate tracking & improve parsability of other round win rate tracking

### DIFF
--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -10,19 +10,19 @@
 
 /datum/game_mode/blob/declare_completion()
 	if(blobwincount <= blobs.len)
-		feedback_set_details("round_end_result","win - blob took over")
+		feedback_set_details("round_end_result","blob win - blob took over")
 		to_chat(world, "<FONT size = 3><B>The blob has taken over the station!</B></FONT>")
 		to_chat(world, "<B>The entire station was eaten by the Blob</B>")
 		log_game("Blob mode completed with a blob victory.")
 
 	else if(station_was_nuked)
-		feedback_set_details("round_end_result","halfwin - nuke")
+		feedback_set_details("round_end_result","blob halfwin - nuke")
 		to_chat(world, "<FONT size = 3><B>Partial Win: The station has been destroyed!</B></FONT>")
 		to_chat(world, "<B>Directive 7-12 has been successfully carried out preventing the Blob from spreading.</B>")
 		log_game("Blob mode completed with a tie (station destroyed).")
 
 	else if(!blob_cores.len)
-		feedback_set_details("round_end_result","loss - blob eliminated")
+		feedback_set_details("round_end_result","blob loss - blob eliminated")
 		to_chat(world, "<FONT size = 3><B>The staff has won!</B></FONT>")
 		to_chat(world, "<B>The alien organism has been eradicated from the station</B>")
 		log_game("Blob mode completed with a crew victory.")

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -273,11 +273,11 @@ var/global/list/all_cults = list()
 	bonus_check()
 
 	if(!check_cult_victory())
-		feedback_set_details("round_end_result","win - cult win")
+		feedback_set_details("round_end_result","cult win - cult win")
 		feedback_set("round_end_result",acolytes_survived)
 		to_chat(world, "<span class='danger'> <FONT size = 3> The cult wins! It has succeeded in serving its dark masters!</FONT></span>")
 	else
-		feedback_set_details("round_end_result","loss - staff stopped the cult")
+		feedback_set_details("round_end_result","cult loss - staff stopped the cult")
 		feedback_set("round_end_result",acolytes_survived)
 		to_chat(world, "<span class='warning'> <FONT size = 3>The staff managed to stop the cult!</FONT></span>")
 

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -54,8 +54,8 @@
 	else
 		to_chat(world, "<span class='boldnotice'>Nobody survived the meteor storm!</span>")
 
-	feedback_set_details("round_end_result","end - evacuation")
-	feedback_set("round_end_result",survivors)
+	feedback_set_details("round_end_result","meteor end - evacuation")
+	feedback_set("round_end_result", "Meteor survivors: [survivors]")
 
 	..()
 	return 1

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -309,51 +309,50 @@ proc/issyndicate(mob/living/M as mob)
 	//derp //Used for tracking if the syndies actually haul the nuke to the station	//no
 	//herp //Used for tracking if the syndies got the shuttle off of the z-level	//NO, DON'T FUCKING NAME VARS LIKE THIS
 
-	if(!disk_rescued &&  station_was_nuked &&          !syndies_didnt_escape)
-		feedback_set_details("round_end_result","win - syndicate nuke")
+	if(!disk_rescued && station_was_nuked && !syndies_didnt_escape)
+		feedback_set_details("round_end_result","nuclear win - syndicate nuke")
 		to_chat(world, "<FONT size = 3><B>Syndicate Major Victory!</B></FONT>")
 		to_chat(world, "<B>[syndicate_name()] operatives have destroyed [station_name()]!</B>")
 
-	else if(!disk_rescued &&  station_was_nuked &&           syndies_didnt_escape)
-		feedback_set_details("round_end_result","halfwin - syndicate nuke - did not evacuate in time")
+	else if(!disk_rescued && station_was_nuked && syndies_didnt_escape)
+		feedback_set_details("round_end_result","nuclear halfwin - syndicate nuke - did not evacuate in time")
 		to_chat(world, "<FONT size = 3><B>Total Annihilation</B></FONT>")
 		to_chat(world, "<B>[syndicate_name()] operatives destroyed [station_name()] but did not leave the area in time and got caught in the explosion.</B> Next time, don't lose the disk!")
 
-	else if(!disk_rescued && !station_was_nuked &&  nuke_off_station && !syndies_didnt_escape)
-		feedback_set_details("round_end_result","halfwin - blew wrong station")
+	else if(!disk_rescued && !station_was_nuked && nuke_off_station && !syndies_didnt_escape)
+		feedback_set_details("round_end_result","nuclear halfwin - blew wrong station")
 		to_chat(world, "<FONT size = 3><B>Crew Minor Victory</B></FONT>")
 		to_chat(world, "<B>[syndicate_name()] operatives secured the authentication disk but blew up something that wasn't [station_name()].</B> Next time, don't lose the disk!")
 
-	else if(!disk_rescued && !station_was_nuked &&  nuke_off_station &&  syndies_didnt_escape)
-		feedback_set_details("round_end_result","halfwin - blew wrong station - did not evacuate in time")
+	else if(!disk_rescued && !station_was_nuked && nuke_off_station && syndies_didnt_escape)
+		feedback_set_details("round_end_result","nuclear halfwin - blew wrong station - did not evacuate in time")
 		to_chat(world, "<FONT size = 3><B>[syndicate_name()] operatives have earned Darwin Award!</B></FONT>")
 		to_chat(world, "<B>[syndicate_name()] operatives blew up something that wasn't [station_name()] and got caught in the explosion.</B> Next time, don't lose the disk!")
 
-	else if( disk_rescued                                         && is_operatives_are_dead())
-		feedback_set_details("round_end_result","loss - evacuation - disk secured - syndi team dead")
+	else if(disk_rescued && is_operatives_are_dead())
+		feedback_set_details("round_end_result","nuclear loss - evacuation - disk secured - syndi team dead")
 		to_chat(world, "<FONT size = 3><B>Crew Major Victory!</B></FONT>")
 		to_chat(world, "<B>The Research Staff has saved the disc and killed the [syndicate_name()] Operatives</B>")
 
-	else if( disk_rescued                                        )
-		feedback_set_details("round_end_result","loss - evacuation - disk secured")
+	else if(disk_rescued)
+		feedback_set_details("round_end_result","nuclear loss - evacuation - disk secured")
 		to_chat(world, "<FONT size = 3><B>Crew Major Victory</B></FONT>")
 		to_chat(world, "<B>The Research Staff has saved the disc and stopped the [syndicate_name()] Operatives!</B>")
 
-	else if(!disk_rescued                                         && is_operatives_are_dead())
-		feedback_set_details("round_end_result","loss - evacuation - disk not secured")
+	else if(!disk_rescued && is_operatives_are_dead())
+		feedback_set_details("round_end_result","nuclear loss - evacuation - disk not secured")
 		to_chat(world, "<FONT size = 3><B>Syndicate Minor Victory!</B></FONT>")
 		to_chat(world, "<B>The Research Staff failed to secure the authentication disk but did manage to kill most of the [syndicate_name()] Operatives!</B>")
 
-	else if(!disk_rescued                                         &&  crew_evacuated)
-		feedback_set_details("round_end_result","halfwin - detonation averted")
+	else if(!disk_rescued && crew_evacuated)
+		feedback_set_details("round_end_result","nuclear halfwin - detonation averted")
 		to_chat(world, "<FONT size = 3><B>Syndicate Minor Victory!</B></FONT>")
 		to_chat(world, "<B>[syndicate_name()] operatives recovered the abandoned authentication disk but detonation of [station_name()] was averted.</B> Next time, don't lose the disk!")
 
-	else if(!disk_rescued                                         && !crew_evacuated)
-		feedback_set_details("round_end_result","halfwin - interrupted")
+	else if(!disk_rescued && !crew_evacuated)
+		feedback_set_details("round_end_result","nuclear halfwin - interrupted")
 		to_chat(world, "<FONT size = 3><B>Neutral Victory</B></FONT>")
 		to_chat(world, "<B>Round was mysteriously interrupted!</B>")
-
 	..()
 	return
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -324,10 +324,10 @@
 //////////////////////////////////////////////////////////////////////
 /datum/game_mode/revolution/declare_completion()
 	if(finished == 1)
-		feedback_set_details("round_end_result","win - heads killed")
+		feedback_set_details("round_end_result","revolution win - heads killed")
 		to_chat(world, "<span class='redtext'>The heads of staff were killed or exiled! The revolutionaries win!</span>")
 	else if(finished == 2)
-		feedback_set_details("round_end_result","loss - rev heads killed")
+		feedback_set_details("round_end_result","revolution loss - rev heads killed")
 		to_chat(world, "<span class='redtext'>The heads of staff managed to stop the revolution!</span>")
 	..()
 	return 1

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -256,12 +256,16 @@ Made by Xhuis
 
 /datum/game_mode/shadowling/declare_completion()
 	if(check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE) //Doesn't end instantly - this is hacky and I don't know of a better way ~X
+		feedback_set_details("round_end_result","shadowling win - shadowling ascension")
 		to_chat(world, "<span class='greentext'><b>The shadowlings have ascended and taken over the station!</b></span>")
 	else if(shadowling_dead && !check_shadow_victory()) //If the shadowlings have ascended, they can not lose the round
+		feedback_set_details("round_end_result","shadowling loss - shadowling killed")
 		to_chat(world, "<span class='redtext'><b>The shadowlings have been killed by the crew!</b></span>")
 	else if(!check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
+		feedback_set_details("round_end_result","shadowling loss - crew escaped")
 		to_chat(world, "<span class='redtext'><b>The crew escaped the station before the shadowlings could ascend!</b></span>")
 	else
+		feedback_set_details("round_end_result","shadowling loss - generic failure")
 		to_chat(world, "<span class='redtext'><b>The shadowlings have failed!</b></span>")
 	..()
 	return 1

--- a/code/game/gamemodes/wizard/raginmages.dm
+++ b/code/game/gamemodes/wizard/raginmages.dm
@@ -180,6 +180,6 @@
 
 /datum/game_mode/wizard/raginmages/declare_completion()
 	if(finished)
-		feedback_set_details("round_end_result","loss - wizard killed")
+		feedback_set_details("round_end_result","raging wizard loss - wizard killed")
 		to_chat(world, "<span class='warning'><FONT size = 3><B> The crew has managed to hold off the wizard attack! The Space Wizards Federation has been taught a lesson they will not soon forget!</B></FONT></span>")
 	..(1)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -192,7 +192,7 @@
 
 /datum/game_mode/wizard/declare_completion(var/ragin = 0)
 	if(finished && !ragin)
-		feedback_set_details("round_end_result","loss - wizard killed")
+		feedback_set_details("round_end_result","wizard loss - wizard killed")
 		to_chat(world, "<span class='warning'><FONT size = 3><B> The wizard[(wizards.len>1)?"s":""] has been killed by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</B></FONT></span>")
 	..()
 	return 1


### PR DESCRIPTION
**What does this PR do:**
This improve the internal database logging for most round type with clearly defined win and loss by turning their format to [gamemode] [win/loss/halfwin] - [reason] instead of [win/loss/halfwin] - [reason] so it is easier to search as a glance.

It also add in such tracking for shadowling. I might consider using game log instead in the future,

**Changelog:**
:cl:
add: Tracking for shadowling win rate. Improved parsability for other win/loss round type's win rate.
/:cl:

