### PR TITLE
Fix reagent dispenser getting attack cooldown

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -13,9 +13,7 @@
 	var/lastrigger = "" // The last person to rig this fuel tank - Stored with the object. Only the last person matter for investigation
 
 /obj/structure/reagent_dispensers/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	if(I.is_refillable())
-		return FALSE //so we can refill them via their afterattack.
+	return FALSE
 
 /obj/structure/reagent_dispensers/New()
 	create_reagents(tank_volume)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -13,7 +13,9 @@
 	var/lastrigger = "" // The last person to rig this fuel tank - Stored with the object. Only the last person matter for investigation
 
 /obj/structure/reagent_dispensers/attackby(obj/item/I, mob/user, params)
-	return FALSE
+	if(I.is_refillable())
+		return FALSE //so we can refill them via their afterattack.
+	. = ..()
 
 /obj/structure/reagent_dispensers/New()
 	create_reagents(tank_volume)


### PR DESCRIPTION
**What does this PR do:**
As per title. Made an error while porting over container type refactor leading to reagent dispenser getting an attack cooldown. This fixes the error.
**Changelog:**
:cl:
fix: Using reagent dispenser like fuel and water tank no longer give you an attack cooldown / animation.
/:cl:

