### PR TITLE
Container_type in food.

### DIFF
--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -14,6 +14,7 @@
 	var/instant_application = 0 //if we want to bypass the forcedfeed delay
 	var/taste = TRUE//whether you can taste eating from this
 	burn_state = FLAMMABLE
+	container_type = INJECTABLE
 
 /obj/item/reagent_containers/food/New()
 	..()


### PR DESCRIPTION
Seems a `Container_type` was missing, this should fix the issue.
Fixes #9948

:cl: Alonefromhell
fix: You should now be able to put all your favorite chems in food again.
/:cl:

