### PR TITLE
Adds data disk to research designs

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -82,10 +82,10 @@
 	category = list("Miscellaneous")
 	
 /datum/design/data_disk
-	name = "Data Disk"
+	name = "Genetics Data Disk"
 	desc = "Disk that allows you to store genetic data."
 	id = "datadisk"
-	req_tech = list("programming" = 3)
+	req_tech = list("programming" = 3, "biotech" = 2)
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL=300, MAT_GLASS=100)
 	build_path = /obj/item/disk/data

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -80,6 +80,7 @@
 	materials = list(MAT_METAL=500, MAT_GLASS=50)
 	build_path = /obj/item/clothing/mask/muzzle/safety/shock
 	category = list("Miscellaneous")
+	
 /datum/design/data_disk
 	name = "Data Disk"
 	desc = "Disk that allows you to store genetic data."

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -80,3 +80,12 @@
 	materials = list(MAT_METAL=500, MAT_GLASS=50)
 	build_path = /obj/item/clothing/mask/muzzle/safety/shock
 	category = list("Miscellaneous")
+/datum/design/data_disk
+	name = "Data Disk"
+	desc = "Disk that allows you to store genetic data."
+	id = "datadisk"
+	req_tech = list("programming" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL=300, MAT_GLASS=100)
+	build_path = /obj/item/disk/data
+	category = list("Miscellaneous")


### PR DESCRIPTION
**What does this PR do:**
This PR allows creation of cloning data disk using the protolathe, which was not possible before. The only disks you could get were from roundstart that appear in genetics, which means if you used up all of your disk you are quite in a pickle.

:cl: 
add: Added data disk to misc designs.
/:cl:

