### PR TITLE
Runtime fix

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -117,7 +117,7 @@
 
 /datum/outfit/job/doctor/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	if(H.mind.role_alt_title)
+	if(H.mind && H.mind.role_alt_title)
 		switch(H.mind.role_alt_title)
 			if("Surgeon")
 				uniform = /obj/item/clothing/under/rank/medical/blue
@@ -269,7 +269,7 @@
 
 /datum/outfit/job/psychiatrist/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	if(H.mind.role_alt_title)
+	if(H.mind && H.mind.role_alt_title)
 		switch(H.mind.role_alt_title)
 			if("Psychiatrist")
 				uniform = /obj/item/clothing/under/rank/psych

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -138,7 +138,7 @@
 
 /datum/outfit/job/detective/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	if(H.mind.role_alt_title)
+	if(H.mind && H.mind.role_alt_title)
 		switch(H.mind.role_alt_title)
 			if("Forensic Technician")
 				suit = /obj/item/clothing/suit/storage/det_suit/forensics/blue


### PR DESCRIPTION
Adds mind checks to `pre_equip`'s, where applicable. Should prevent runtimes.
Fixes #9911

:cl: Alonefromhell
fix: Mind check in pre_quip added, to prevent runtime.
/:cl:

