### PR TITLE
Reformats assembly.dm and proximity.dm

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -5,7 +5,7 @@
 	icon_state = ""
 	flags = CONDUCT
 	w_class = WEIGHT_CLASS_SMALL
-	materials = list(MAT_METAL=100)
+	materials = list(MAT_METAL = 100)
 	throwforce = 2
 	throw_speed = 3
 	throw_range = 10
@@ -18,7 +18,7 @@
 	var/secured = 1
 	var/list/attached_overlays = null
 	var/obj/item/assembly_holder/holder = null
-	var/cooldown = 0//To prevent spam
+	var/cooldown = 0 //To prevent spam
 	var/wires = WIRE_RECEIVE | WIRE_PULSE
 	var/datum/wires/connected = null // currently only used by timer/signaler
 
@@ -28,173 +28,119 @@
 	var/const/WIRE_RADIO_RECEIVE = 8		//Allows Pulsed(1) to call Activate()
 	var/const/WIRE_RADIO_PULSE = 16		//Allows Pulse(1) to send a radio message
 
-	proc/activate()									//What the device does when turned on
-		return
+/obj/item/assembly/proc/activate()									//What the device does when turned on
+	return
 
-	proc/pulsed(var/radio = 0)						//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
-		return
+/obj/item/assembly/proc/pulsed(radio = 0)						//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
+	return
 
-	proc/pulse(var/radio = 0)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
-		return
+/obj/item/assembly/proc/pulse(radio = 0)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
+	return
 
-	proc/toggle_secure()								//Code that has to happen when the assembly is un\secured goes here
-		return
+/obj/item/assembly/proc/toggle_secure()								//Code that has to happen when the assembly is un\secured goes here
+	return
 
-	proc/attach_assembly(var/obj/A, var/mob/user)	//Called when an assembly is attacked by another
-		return
+/obj/item/assembly/proc/attach_assembly(obj/A, mob/user)	//Called when an assembly is attacked by another
+	return
 
-	proc/process_cooldown()							//Called via spawn(10) to have it count down the cooldown var
-		return
+/obj/item/assembly/proc/process_cooldown()							//Called via spawn(10) to have it count down the cooldown var
+	return
 
-	proc/holder_movement()							//Called when the holder is moved
-		return
+/obj/item/assembly/proc/holder_movement()							//Called when the holder is moved
+	return
 
-	proc/describe()                  // Called by grenades to describe the state of the trigger (time left, etc)
-		return "The trigger assembly looks broken!"
+/obj/item/assembly/proc/describe()                  // Called by grenades to describe the state of the trigger (time left, etc)
+	return "The trigger assembly looks broken!"
 
+/obj/item/assembly/interact(mob/user)					//Called when attack_self is called
+	return
 
-	interact(mob/user as mob)					//Called when attack_self is called
-		return
-
-	process_cooldown()
-		cooldown--
-		if(cooldown <= 0)	return 0
-		spawn(10)
-			process_cooldown()
-		return 1
-
-	Destroy()
-		if(istype(src.loc, /obj/item/assembly_holder) || istype(holder))
-			var/obj/item/assembly_holder/A = src.loc
-			if(A.a_left == src)
-				A.a_left = null
-			else if(A.a_right == src)
-				A.a_right = null
-			src.holder = null
-		return ..()
-
-	pulsed(var/radio = 0)
-		if(holder && (wires & WIRE_RECEIVE))
-			activate()
-		if(radio && (wires & WIRE_RADIO_RECEIVE))
-			activate()
-		return 1
-
-
-	pulse(var/radio = 0)
-		if(holder && (wires & WIRE_PULSE))
-			holder.process_activation(src, 1, 0)
-		if(holder && (wires & WIRE_PULSE_SPECIAL))
-			holder.process_activation(src, 0, 1)
-//		if(connected && (wires & WIRE_PULSE))
-//			connected.Pulse(src)
-//		if(radio && (wires & WIRE_RADIO_PULSE))
-			//Not sure what goes here quite yet send signal?
-
-		if(istype(loc,/obj/item/grenade)) // This is a hack.  Todo: Manage this better -Sayu
-			var/obj/item/grenade/G = loc
-			G.prime()                // Adios, muchachos
-
-
-		return 1
-
-
-	activate()
-		if(!secured || (cooldown > 0))	return 0
-		cooldown = 2
-		spawn(10)
-			process_cooldown()
-		return 1
-
-
-	toggle_secure()
-		secured = !secured
-		update_icon()
-		return secured
-
-
-	attach_assembly(var/obj/item/assembly/A, var/mob/user)
-		holder = new/obj/item/assembly_holder(get_turf(src))
-		if(holder.attach(A,src,user))
-			to_chat(user, "<span class='notice'>You attach \the [A] to \the [src]!</span>")
-			return 1
+/obj/item/assembly/process_cooldown()
+	cooldown--
+	if(cooldown <= 0)
 		return 0
+	spawn(10)
+		process_cooldown()
+	return 1
 
+/obj/item/assembly/Destroy()
+	if(istype(loc, /obj/item/assembly_holder) || istype(holder))
+		var/obj/item/assembly_holder/A = loc
+		if(A.a_left == src)
+			A.a_left = null
+		else if(A.a_right == src)
+			A.a_right = null
+		holder = null
+	return ..()
 
-	attackby(obj/item/W as obj, mob/user as mob, params)
-		if(isassembly(W))
-			var/obj/item/assembly/A = W
-			if((!A.secured) && (!secured))
-				attach_assembly(A,user)
-				return
-		if(istype(W, /obj/item/screwdriver))
-			if(toggle_secure())
-				to_chat(user, "<span class='notice'>\The [src] is ready!</span>")
-			else
-				to_chat(user, "<span class='notice'>\The [src] can now be attached!</span>")
+/obj/item/assembly/pulsed(radio = 0)
+	if(holder && (wires & WIRE_RECEIVE))
+		activate()
+	if(radio && (wires & WIRE_RADIO_RECEIVE))
+		activate()
+	return 1
+
+/obj/item/assembly/pulse(radio = 0)
+	if(holder && (wires & WIRE_PULSE))
+		holder.process_activation(src, 1, 0)
+	if(holder && (wires & WIRE_PULSE_SPECIAL))
+		holder.process_activation(src, 0, 1)
+	if(istype(loc, /obj/item/grenade)) // This is a hack.  Todo: Manage this better -Sayu
+		var/obj/item/grenade/G = loc
+		G.prime()                // Adios, muchachos
+	return 1
+
+/obj/item/assembly/activate()
+	if(!secured || (cooldown > 0))
+		return 0
+	cooldown = 2
+	spawn(10)
+		process_cooldown()
+	return 1
+
+/obj/item/assembly/toggle_secure()
+	secured = !secured
+	update_icon()
+	return secured
+
+/obj/item/assembly/attach_assembly(obj/item/assembly/A, mob/user)
+	holder = new /obj/item/assembly_holder(get_turf(src))
+	if(holder.attach(A, src, user))
+		to_chat(user, "<span class='notice'>You attach [A] to [src]!</span>")
+		return 1
+	return 0
+
+/obj/item/assembly/attackby(obj/item/W, mob/user, params)
+	if(isassembly(W))
+		var/obj/item/assembly/A = W
+		if((!A.secured) && (!secured))
+			attach_assembly(A, user)
 			return
-		..()
+	if(isscrewdriver(W))
+		if(toggle_secure())
+			to_chat(user, "<span class='notice'>[src] is ready!</span>")
+		else
+			to_chat(user, "<span class='notice'>[src] can now be attached!</span>")
 		return
+	..()
 
+/obj/item/assembly/process()
+	processing_objects.Remove(src)
 
-	process()
-		processing_objects.Remove(src)
+/obj/item/assembly/examine(mob/user)
+	..()
+	if((in_range(src, user) || loc == user))
+		if(secured)
+			to_chat(user, "[src] is ready!")
+		else
+			to_chat(user, "[src] can be attached!")
+
+/obj/item/assembly/attack_self(mob/user)
+	if(!user)
 		return
+	user.set_machine(src)
+	interact(user)
+	return 1
 
-
-	examine(mob/user)
-		..(user)
-		if((in_range(src, user) || loc == user))
-			if(secured)
-				to_chat(user, "\The [src] is ready!")
-			else
-				to_chat(user, "\The [src] can be attached!")
-
-
-	attack_self(mob/user as mob)
-		if(!user)	return 0
-		user.set_machine(src)
-		interact(user)
-		return 1
-
-
-	interact(mob/user as mob)
-		return //HTML MENU FOR WIRES GOES HERE
-
-/*
-	var/small_icon_state = null//If this obj will go inside the assembly use this for icons
-	var/list/small_icon_state_overlays = null//Same here
-	var/obj/holder = null
-	var/cooldown = 0//To prevent spam
-
-	proc
-		Activate()//Called when this assembly is pulsed by another one
-		Process_cooldown()//Call this via spawn(10) to have it count down the cooldown var
-		Attach_Holder(var/obj/H, var/mob/user)//Called when an assembly holder attempts to attach, sets src's loc in here
-
-
-	Activate()
-		if(cooldown > 0)
-			return 0
-		cooldown = 2
-		spawn(10)
-			Process_cooldown()
-		//Rest of code here
-		return 0
-
-
-	Process_cooldown()
-		cooldown--
-		if(cooldown <= 0)	return 0
-		spawn(10)
-			Process_cooldown()
-		return 1
-
-
-	Attach_Holder(var/obj/H, var/mob/user)
-		if(!H)	return 0
-		if(!H.IsAssemblyHolder())	return 0
-		//Remember to have it set its loc somewhere in here
-
-
-*/
+/obj/item/assembly/interact(mob/user)
+	return

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -2,7 +2,7 @@
 	name = "proximity sensor"
 	desc = "Used for scanning and alerting when someone enters a certain proximity."
 	icon_state = "prox"
-	materials = list(MAT_METAL=800, MAT_GLASS=200)
+	materials = list(MAT_METAL = 800, MAT_GLASS = 200)
 	origin_tech = "magnets=1;engineering=1"
 
 	secured = 0
@@ -13,142 +13,122 @@
 	var/timing = 0
 	var/time = 10
 
-	proc
-		toggle_scan()
-		sense()
+/obj/item/assembly/prox_sensor/describe()
+	if(timing)
+		return "<span class='notice'>The proximity sensor is arming.</span>"
+	return "The proximity sensor is [scanning ? "armed" : "disarmed"]."
 
-	describe()
-		if(timing)
-			return "<span class='notice'>The proximity sensor is arming.</span>"
-		return "The proximity sensor is [scanning?"armed":"disarmed"]."
-
-	activate()
-		if(!..())	return 0//Cooldown check
-		timing = !timing
-		update_icon()
-		return 0
-
-
-	toggle_secure()
-		secured = !secured
-		if(secured)
-			processing_objects.Add(src)
-		else
-			scanning = 0
-			timing = 0
-			processing_objects.Remove(src)
-		update_icon()
-		return secured
-
-
-	HasProximity(atom/movable/AM as mob|obj)
-		if(!isobj(AM) && !isliving(AM))
-			return
-		if(istype(AM, /obj/effect))	return
-		if(AM.move_speed < 12)	sense()
-		return
-
-
-	sense()
-		if((!secured)||(!scanning)||(cooldown > 0))	return 0
-		pulse(0)
-		visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
-		cooldown = 2
-		spawn(10)
-			process_cooldown()
-		return
-
-
-	process()
-		if(timing && (time >= 0))
-			time--
-		if(timing && time <= 0)
-			timing = 0
-			toggle_scan()
-			time = 10
-		return
-
-
-	dropped()
-		..()
-		spawn(0)
-			sense()
-			return
-		return
-
-
-	toggle_scan()
-		if(!secured)	return 0
-		scanning = !scanning
-		update_icon()
-		return
-
-
+/obj/item/assembly/prox_sensor/activate()
+	if(!..())	
+		return 0 //Cooldown check
+	timing = !timing
 	update_icon()
-		overlays.Cut()
-		attached_overlays = list()
-		if(timing)
-			overlays += "prox_timing"
-			attached_overlays += "prox_timing"
-		if(scanning)
-			overlays += "prox_scanning"
-			attached_overlays += "prox_scanning"
-		if(holder)
-			holder.update_icon()
+	return 0
+
+/obj/item/assembly/prox_sensor/toggle_secure()
+	secured = !secured
+	if(secured)
+		processing_objects.Add(src)
+	else
+		scanning = 0
+		timing = 0
+		processing_objects.Remove(src)
+	update_icon()
+	return secured
+
+/obj/item/assembly/prox_sensor/HasProximity(atom/movable/AM)
+	if(!isobj(AM) && !isliving(AM))
 		return
+	if(istype(AM, /obj/effect))	
+		return
+	if(AM.move_speed < 12)
+		sense()
 
+/obj/item/assembly/prox_sensor/proc/sense()
+	if((!secured)||(!scanning)||(cooldown > 0))	
+		return 0
+	pulse(0)
+	visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
+	cooldown = 2
+	spawn(10)
+		process_cooldown()
 
-	Move()
-		..()
+/obj/item/assembly/prox_sensor/process()
+	if(timing && (time >= 0))
+		time--
+	if(timing && time <= 0)
+		timing = 0
+		toggle_scan()
+		time = 10
+
+/obj/item/assembly/prox_sensor/dropped()
+	..()
+	spawn(0)
 		sense()
 		return
 
-	holder_movement()
-		sense()
+/obj/item/assembly/prox_sensor/proc/toggle_scan()
+	if(!secured)
+		return 0
+	scanning = !scanning
+	update_icon()
 
+/obj/item/assembly/prox_sensor/update_icon()
+	overlays.Cut()
+	attached_overlays = list()
+	if(timing)
+		overlays += "prox_timing"
+		attached_overlays += "prox_timing"
+	if(scanning)
+		overlays += "prox_scanning"
+		attached_overlays += "prox_scanning"
+	if(holder)
+		holder.update_icon()
 
-	interact(mob/user as mob)//TODO: Change this to the wires thingy
-		if(!secured)
-			user.show_message("<span class='warning'>The [name] is unsecured!</span>")
-			return 0
-		var/second = time % 60
-		var/minute = (time - second) / 60
-		var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='?src=[UID()];tp=-30'>-</A> <A href='?src=[UID()];tp=-1'>-</A> <A href='?src=[UID()];tp=1'>+</A> <A href='?src=[UID()];tp=30'>+</A>\n</TT>", (timing ? "<A href='?src=[UID()];time=0'>Arming</A>" : "<A href='?src=[UID()];time=1'>Not Arming</A>"), minute, second)
-		dat += "<BR><A href='?src=[UID()];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)"
-		dat += "<BR><BR><A href='?src=[UID()];refresh=1'>Refresh</A>"
-		dat += "<BR><BR><A href='?src=[UID()];close=1'>Close</A>"
-		var/datum/browser/popup = new(user, "prox", name, 400, 400)
-		popup.set_content(dat)
-		popup.open(0)
-		onclose(user, "prox")
+/obj/item/assembly/prox_sensor/Move()
+	..()
+	sense()
+
+/obj/item/assembly/prox_sensor/holder_movement()
+	sense()
+
+/obj/item/assembly/prox_sensor/interact(mob/user)//TODO: Change this to the wires thingy
+	if(!secured)
+		user.show_message("<span class='warning'>The [name] is unsecured!</span>")
+		return 0
+	var/second = time % 60
+	var/minute = (time - second) / 60
+	var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='?src=[UID()];tp=-30'>-</A> <A href='?src=[UID()];tp=-1'>-</A> <A href='?src=[UID()];tp=1'>+</A> <A href='?src=[UID()];tp=30'>+</A>\n</TT>", (timing ? "<A href='?src=[UID()];time=0'>Arming</A>" : "<A href='?src=[UID()];time=1'>Not Arming</A>"), minute, second)
+	dat += "<BR><A href='?src=[UID()];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)"
+	dat += "<BR><BR><A href='?src=[UID()];refresh=1'>Refresh</A>"
+	dat += "<BR><BR><A href='?src=[UID()];close=1'>Close</A>"
+	var/datum/browser/popup = new(user, "prox", name, 400, 400)
+	popup.set_content(dat)
+	popup.open(0)
+	onclose(user, "prox")
+
+/obj/item/assembly/prox_sensor/Topic(href, href_list)
+	..()
+	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
+		usr << browse(null, "window=prox")
+		onclose(usr, "prox")
 		return
 
+	if(href_list["scanning"])
+		toggle_scan()
 
-	Topic(href, href_list)
-		..()
-		if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
-			usr << browse(null, "window=prox")
-			onclose(usr, "prox")
-			return
+	if(href_list["time"])
+		timing = text2num(href_list["time"])
+		update_icon()
 
-		if(href_list["scanning"])
-			toggle_scan()
+	if(href_list["tp"])
+		var/tp = text2num(href_list["tp"])
+		time += tp
+		time = min(max(round(time), 0), 600)
 
-		if(href_list["time"])
-			timing = text2num(href_list["time"])
-			update_icon()
-
-		if(href_list["tp"])
-			var/tp = text2num(href_list["tp"])
-			time += tp
-			time = min(max(round(time), 0), 600)
-
-		if(href_list["close"])
-			usr << browse(null, "window=prox")
-			return
-
-		if(usr)
-			attack_self(usr)
-
-
+	if(href_list["close"])
+		usr << browse(null, "window=prox")
 		return
+
+	if(usr)
+		attack_self(usr)


### PR DESCRIPTION
Reformatting of assembly.dm and proximity.dm

- Converts to absolute pathing
- Tidies up some old code to fit the style guide
- Removes some old commented code
- Removes some \The

🆑 Birdtalon
tweak: Backend cleanup of assembly.dm and proximity.dm
/🆑 