### PR TITLE
Fixed the tablet being spawned with the broken sprite

### DIFF
--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -253,6 +253,7 @@ obj/machinery/lapvend/attackby(obj/item/I, mob/user)
 				fabricated_laptop.forceMove(loc)
 				fabricated_laptop = null
 			else if((devtype == 2) && fabricated_tablet)
+				fabricated_tablet.update_icon()
 				fabricated_tablet.forceMove(loc)
 				fabricated_tablet = null
 			atom_say("Enjoy your new product!")


### PR DESCRIPTION
**What does this PR do:**
Updates the icon of the tablet when it spawns.
Thus removing the idea that you bought a broken tablet. No more getting ripped off

Fixes: #9952

**Changelog:**
:cl: Farie82
fix: Tablets now spawn correctly. No more buying (seemingly) broken tablets
/:cl:

