### PR TITLE
fix runtime CureIfHasDisability and borg repair

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -117,6 +117,9 @@
 
 		parts -= picked
 
+	if(updating_health)
+		updatehealth("heal overall damage")
+
 /mob/living/silicon/robot/take_overall_damage(brute = 0, burn = 0, updating_health = TRUE, used_weapon = null, sharp = 0)
 	if(status_flags & GODMODE)	return	//godmode
 	var/list/datum/robot_component/parts = get_damageable_components()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -572,7 +572,7 @@
 	CureIfHasDisability(TWITCHBLOCK)
 
 /mob/living/proc/CureIfHasDisability(block)
-	if(dna.GetSEState(block))
+	if(dna && dna.GetSEState(block))
 		dna.SetSEState(block, 0, 1) //Fix the gene
 		genemutcheck(src, block,null, MUTCHK_FORCED)
 		dna.UpdateSE()


### PR DESCRIPTION
**What does this PR do:**
- Fix for a runtime error in CureIfHasDisability
- Fix for borg health not updating correctly after being repaired
- Fixes #9836
- Fixes #9780

 Certhic (/client): Rejuvenate(He (/mob/living/silicon/robot))
[2018-10-24T22:24:41] 
Runtime in status_procs.dm,575: Cannot execute null.GetSEState().
  proc name: CureIfHasDisability (/mob/living/proc/CureIfHasDisability)

**Changelog:**
:cl: Certhic
fix: Runtime error in CureIfHasDisability
fix: Borg health is now updated after being repaired
/:cl: