### PR TITLE
Fixed safe noises

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -70,9 +70,9 @@ FLOOR SAFES
 			to_chat(user, "<span class='italics'>You hear a [pick("clack", "scrape", "clank")] from [src].</span>")
 		if(tum2 && (turns_total == 1 || prob(10))) // So multi turns dont super spam the chat
 			to_chat(user, "<span class='italics'>You hear a [pick("click", "chink", "clink")] from [src].</span>")
-		if(tumbler_1_pos == tumbler_1_open && turns_total == 1) // You cant hear tumblers if you spin fast!
+		if(tumbler_1_pos == tumbler_1_open && turns_total == 1 && tum1) // You cant hear tumblers if you spin fast!
 			to_chat(user, "<span class='italics'>You hear a [pick("tonk", "krunk", "plunk")] from [src].</span>")
-		if(tumbler_2_pos == tumbler_2_open && turns_total == 1 ) // You cant hear tumblers if you spin fast!
+		if(tumbler_2_pos == tumbler_2_open && turns_total == 1 && tum2) // You cant hear tumblers if you spin fast!
 			to_chat(user, "<span class='italics'>You hear a [pick("tink", "krink", "plink")] from [src].</span>")
 	if(unlocked)
 		if(user)


### PR DESCRIPTION
Fixed unlock noises coming from tumbler 2 on every turn of tumbler 1, once tumbler 2 was unlocked.

There was a small bug where it would play the tumbler 2 is in the correct position noise over and over while you turned tumbler 2.

**Changelog:**
:cl: Warior4356
fix: Safe tumbler 2 no longer makes I am open noise when turning tumbler 1.
/:cl:

