### PR TITLE
Dusting a mob now dusts all items held and equiped

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -57,9 +57,9 @@
 	add_to_all_human_data_huds()
 
 /mob/living/carbon/human/Destroy()
+	. = ..()
 	QDEL_LIST(bodyparts)
 	splinted_limbs.Cut()
-	return ..()
 
 /mob/living/carbon/human/dummy
 	real_name = "Test Dummy"


### PR DESCRIPTION
**What does this PR do:**
Dusting now destroys all items that the mob holds and has equiped
Gibbing still drops the items.

Fixes: #9966

**Changelog:**
:cl: Farie82
fix: Dusting a mob now dusts everything he holds and has equiped
/:cl:

