### PR TITLE
Runtime in species.dm

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -617,7 +617,7 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 	else
 		H.see_invisible = SEE_INVISIBLE_LIVING
 
-	if(H.client.eye != H)
+	if(H.client && H.client.eye != H)
 		var/atom/A = H.client.eye
 		if(A.update_remote_sight(H)) //returns 1 if we override all other sight updates.
 			return


### PR DESCRIPTION
Fixes a runtime that occured in species.dm, 620 where it didn't check if there was a client in the body.

:cl: Alonefromhell
fix: Runtime in species.dm, 620 fixed
/:cl:

