### PR TITLE
Fixes tickets not appending user responses

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -193,9 +193,8 @@
 			i.addResponse(src, msg) // Add this response to their open tickets.
 		return
 
-	tickets = SStickets.checkForTicket(C)
 	if(check_rights(R_ADMIN|R_MOD, 0, C.mob)) //Is the person being pm'd an admin? If so we check if the pm'er has open tickets
-		tickets = SStickets.checkForTicket(C)
+		tickets = SStickets.checkForTicket(src)
 		if(tickets)
 			for(var/datum/admin_ticket/i in tickets)
 				i.addResponse(src, msg)


### PR DESCRIPTION
Small fix for tickets where user responses were not appended to the chat log.

🆑 Birdtalon
fix: User responses not being appended to admin tickets
/🆑 