### PR TITLE
Assembly devices minor refactor & code cleanup

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -15,10 +15,10 @@
 
 	var/bomb_name = "bomb" // used for naming bombs / mines
 
-	var/secured = 1
+	var/secured = TRUE
 	var/list/attached_overlays = null
 	var/obj/item/assembly_holder/holder = null
-	var/cooldown = 0 //To prevent spam
+	var/cooldown = FALSE //To prevent spam
 	var/wires = WIRE_RECEIVE | WIRE_PULSE
 	var/datum/wires/connected = null // currently only used by timer/signaler
 
@@ -31,10 +31,10 @@
 /obj/item/assembly/proc/activate()									//What the device does when turned on
 	return
 
-/obj/item/assembly/proc/pulsed(radio = 0)						//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
+/obj/item/assembly/proc/pulsed(radio = FALSE)						//Called when another assembly acts on this one, var/radio will determine where it came from for wire calcs
 	return
 
-/obj/item/assembly/proc/pulse(radio = 0)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
+/obj/item/assembly/proc/pulse(radio = FALSE)						//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
 	return
 
 /obj/item/assembly/proc/toggle_secure()								//Code that has to happen when the assembly is un\secured goes here
@@ -73,14 +73,14 @@
 		holder = null
 	return ..()
 
-/obj/item/assembly/pulsed(radio = 0)
+/obj/item/assembly/pulsed(radio = FALSE)
 	if(holder && (wires & WIRE_RECEIVE))
 		activate()
 	if(radio && (wires & WIRE_RADIO_RECEIVE))
 		activate()
 	return TRUE
 
-/obj/item/assembly/pulse(radio = 0)
+/obj/item/assembly/pulse(radio = FALSE)
 	if(holder && (wires & WIRE_PULSE))
 		holder.process_activation(src, 1, 0)
 	if(holder && (wires & WIRE_PULSE_SPECIAL))

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -58,10 +58,10 @@
 /obj/item/assembly/process_cooldown()
 	cooldown--
 	if(cooldown <= 0)
-		return 0
+		return FALSE
 	spawn(10)
 		process_cooldown()
-	return 1
+	return TRUE
 
 /obj/item/assembly/Destroy()
 	if(istype(loc, /obj/item/assembly_holder) || istype(holder))
@@ -78,7 +78,7 @@
 		activate()
 	if(radio && (wires & WIRE_RADIO_RECEIVE))
 		activate()
-	return 1
+	return TRUE
 
 /obj/item/assembly/pulse(radio = 0)
 	if(holder && (wires & WIRE_PULSE))
@@ -88,15 +88,15 @@
 	if(istype(loc, /obj/item/grenade)) // This is a hack.  Todo: Manage this better -Sayu
 		var/obj/item/grenade/G = loc
 		G.prime()                // Adios, muchachos
-	return 1
+	return TRUE
 
 /obj/item/assembly/activate()
-	if(!secured || (cooldown > 0))
-		return 0
+	if(!secured || cooldown > 0)
+		return FALSE
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
-	return 1
+	return TRUE
 
 /obj/item/assembly/toggle_secure()
 	secured = !secured
@@ -107,13 +107,13 @@
 	holder = new /obj/item/assembly_holder(get_turf(src))
 	if(holder.attach(A, src, user))
 		to_chat(user, "<span class='notice'>You attach [A] to [src]!</span>")
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/item/assembly/attackby(obj/item/W, mob/user, params)
 	if(isassembly(W))
 		var/obj/item/assembly/A = W
-		if((!A.secured) && (!secured))
+		if(!A.secured && !secured)
 			attach_assembly(A, user)
 			return
 	if(isscrewdriver(W))
@@ -129,7 +129,7 @@
 
 /obj/item/assembly/examine(mob/user)
 	..()
-	if((in_range(src, user) || loc == user))
+	if(in_range(src, user) || loc == user)
 		if(secured)
 			to_chat(user, "[src] is ready!")
 		else
@@ -140,7 +140,7 @@
 		return
 	user.set_machine(src)
 	interact(user)
-	return 1
+	return TRUE
 
 /obj/item/assembly/interact(mob/user)
 	return

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -42,7 +42,7 @@
 
 		qdel(src)
 		return
-	if((istype(W, /obj/item/weldingtool) && W:welding))
+	if(istype(W, /obj/item/weldingtool) && W:welding)
 		if(!status)
 			status = 1
 			investigate_log("[key_name(user)] welded a single tank bomb. Temperature: [bombtank.air_contents.temperature-T0C]", INVESTIGATE_BOMB)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -24,11 +24,11 @@
 		overlays += bombassembly.overlays
 		overlays += "bomb_assembly"
 
-/obj/item/onetankbomb/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/onetankbomb/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/analyzer))
 		bombtank.attackby(W, user, params)
 		return
-	if(istype(W, /obj/item/wrench) && !status)	//This is basically bomb assembly code inverted. apparently it works.
+	if(iswrench(W) && !status)	//This is basically bomb assembly code inverted. apparently it works.
 
 		to_chat(user, "<span class='notice'>You disassemble [src].</span>")
 
@@ -42,21 +42,23 @@
 
 		qdel(src)
 		return
-	if(istype(W, /obj/item/weldingtool) && W:welding)
-		if(!status)
-			status = 1
-			investigate_log("[key_name(user)] welded a single tank bomb. Temperature: [bombtank.air_contents.temperature-T0C]", INVESTIGATE_BOMB)
-			msg_admin_attack("[key_name_admin(user)] welded a single tank bomb. Temperature: [bombtank.air_contents.temperature-T0C]", ATKLOG_FEW)
-			log_game("[key_name(user)] welded a single tank bomb. Temperature: [bombtank.air_contents.temperature - T0C]")
-			to_chat(user, "<span class='notice'>A pressure hole has been bored to [bombtank] valve. \The [bombtank] can now be ignited.</span>")
-		else
-			status = 0
-			investigate_log("[key_name(user)] unwelded a single tank bomb. Temperature: [bombtank.air_contents.temperature-T0C]", INVESTIGATE_BOMB)
-			to_chat(user, "<span class='notice'>The hole has been closed.</span>")
+	if(iswelder(W))
+		var/obj/item/weldingtool/WT = W
+		if(WT.welding)
+			if(!status)
+				status = TRUE
+				investigate_log("[key_name(user)] welded a single tank bomb. Temperature: [bombtank.air_contents.temperature-T0C]", INVESTIGATE_BOMB)
+				msg_admin_attack("[key_name_admin(user)] welded a single tank bomb. Temperature: [bombtank.air_contents.temperature-T0C]", ATKLOG_FEW)
+				log_game("[key_name(user)] welded a single tank bomb. Temperature: [bombtank.air_contents.temperature - T0C]")
+				to_chat(user, "<span class='notice'>A pressure hole has been bored to [bombtank] valve. [bombtank] can now be ignited.</span>")
+			else
+				status = FALSE
+				investigate_log("[key_name(user)] unwelded a single tank bomb. Temperature: [bombtank.air_contents.temperature-T0C]", INVESTIGATE_BOMB)
+				to_chat(user, "<span class='notice'>The hole has been closed.</span>")
 	add_fingerprint(user)
 	..()
 
-/obj/item/onetankbomb/attack_self(mob/user as mob) //pressing the bomb accesses its assembly
+/obj/item/onetankbomb/attack_self(mob/user) //pressing the bomb accesses its assembly
 	bombassembly.attack_self(user, 1)
 	add_fingerprint(user)
 	return
@@ -71,23 +73,23 @@
 	else
 		bombtank.release()
 
-/obj/item/onetankbomb/HasProximity(atom/movable/AM as mob|obj)
+/obj/item/onetankbomb/HasProximity(atom/movable/AM)
 	if(bombassembly)
 		bombassembly.HasProximity(AM)
 
-/obj/item/onetankbomb/Crossed(atom/movable/AM as mob|obj) //for mousetraps
+/obj/item/onetankbomb/Crossed(atom/movable/AM) //for mousetraps
 	if(bombassembly)
 		bombassembly.Crossed(AM)
 
-/obj/item/onetankbomb/on_found(mob/finder as mob) //for mousetraps
+/obj/item/onetankbomb/on_found(mob/finder) //for mousetraps
 	if(bombassembly)
 		bombassembly.on_found(finder)
 
-/obj/item/onetankbomb/hear_talk(mob/living/M as mob, msg)
+/obj/item/onetankbomb/hear_talk(mob/living/M, msg)
 	if(bombassembly)
 		bombassembly.hear_talk(M, msg)
 
-/obj/item/onetankbomb/hear_message(mob/living/M as mob, msg)
+/obj/item/onetankbomb/hear_message(mob/living/M, msg)
 	if(bombassembly)
 		bombassembly.hear_message(M, msg)
 

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -4,9 +4,9 @@
 	icon_state = "health"
 	materials = list(MAT_METAL=800, MAT_GLASS=200)
 	origin_tech = "magnets=1;biotech=1"
-	secured = 0
+	secured = FALSE
 
-	var/scanning = 0
+	var/scanning = FALSE
 	var/health_scan
 	var/alarm_health = 0
 
@@ -23,13 +23,13 @@
 	if(secured && scanning)
 		processing_objects.Add(src)
 	else
-		scanning = 0
+		scanning = FALSE
 		processing_objects.Remove(src)
 	update_icon()
 	return secured
 
-/obj/item/assembly/health/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/multitool))
+/obj/item/assembly/health/attackby(obj/item/W, mob/user)
+	if(ismultitool(W))
 		if(alarm_health == 0)
 			alarm_health = -90
 			user.show_message("You toggle [src] to \"detect death\" mode.")
@@ -71,7 +71,7 @@
 		processing_objects.Remove(src)
 	return
 
-/obj/item/assembly/health/interact(mob/user as mob)//TODO: Change this to the wires thingy
+/obj/item/assembly/health/interact(mob/user)//TODO: Change this to the wires thingy
 	if(!secured)
 		user.show_message("<span class='warning'>The [name] is unsecured!</span>")
 		return FALSE

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -13,9 +13,10 @@
 
 
 /obj/item/assembly/health/activate()
-	if(!..())	return 0//Cooldown check
+	if(!..())
+		return FALSE//Cooldown check
 	toggle_scan()
-	return 0
+	return FALSE
 
 /obj/item/assembly/health/toggle_secure()
 	secured = !secured
@@ -61,7 +62,8 @@
 	return
 
 /obj/item/assembly/health/proc/toggle_scan()
-	if(!secured)	return 0
+	if(!secured)
+		return FALSE
 	scanning = !scanning
 	if(scanning)
 		processing_objects.Add(src)
@@ -72,7 +74,7 @@
 /obj/item/assembly/health/interact(mob/user as mob)//TODO: Change this to the wires thingy
 	if(!secured)
 		user.show_message("<span class='warning'>The [name] is unsecured!</span>")
-		return 0
+		return FALSE
 	var/dat = text("<TT><B>Health Sensor</B> <A href='?src=[UID()];scanning=1'>[scanning?"On":"Off"]</A>")
 	if(scanning && health_scan)
 		dat += "<BR>Health: [health_scan]"

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -30,7 +30,7 @@
 	return ..()
 
 /obj/item/assembly_holder/attach(var/obj/item/D, var/obj/item/D2, var/mob/user)
-	if(!D||!D2)
+	if(!D || !D2)
 		return FALSE
 	if(!isassembly(D) || !isassembly(D2))
 		return FALSE
@@ -60,7 +60,7 @@
 		for(var/O in a_left.attached_overlays)
 			overlays += "[O]_l"
 	if(a_right)
-		src.overlays += "[a_right.icon_state]_right"
+		overlays += "[a_right.icon_state]_right"
 		for(var/O in a_right.attached_overlays)
 			overlays += "[O]_r"
 	if(master)
@@ -69,8 +69,8 @@
 
 /obj/item/assembly_holder/examine(mob/user)
 	..(user)
-	if(in_range(src, user) || src.loc == user)
-		if(src.secured)
+	if(in_range(src, user) || loc == user)
+		if(secured)
 			to_chat(user, "\The [src] is ready!")
 		else
 			to_chat(user, "\The [src] can be attached!")
@@ -157,8 +157,8 @@
 
 
 /obj/item/assembly_holder/attack_self(mob/user as mob)
-	src.add_fingerprint(user)
-	if(src.secured)
+	add_fingerprint(user)
+	if(secured)
 		if(!a_left || !a_right)
 			to_chat(user, "<span class='warning'>Assembly part missing!</span>")
 			return

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -13,200 +13,201 @@
 	var/obj/item/assembly/a_left = null
 	var/obj/item/assembly/a_right = null
 
-	proc/attach(var/obj/item/D, var/obj/item/D2, var/mob/user)
-		return
+/obj/item/assembly_holder/proc/attach(var/obj/item/D, var/obj/item/D2, var/mob/user)
+	return
 
-	proc/process_activation(var/obj/item/D)
-		return
+/obj/item/assembly_holder/proc/process_activation(var/obj/item/D)
+	return
 
+/obj/item/assembly_holder/IsAssemblyHolder()
+	return TRUE
 
+/obj/item/assembly_holder/Destroy()
+	if(a_left)
+		a_left.holder = null
+	if(a_right)
+		a_right.holder = null
+	return ..()
 
-	IsAssemblyHolder()
-		return 1
-
-	Destroy()
-		if(a_left)
-			a_left.holder = null
-		if(a_right)
-			a_right.holder = null
-		return ..()
-
-	attach(var/obj/item/D, var/obj/item/D2, var/mob/user)
-		if((!D)||(!D2))	return 0
-		if((!isassembly(D))||(!isassembly(D2)))	return 0
-		if((D:secured)||(D2:secured))	return 0
-		if(!D.remove_item_from_storage(src))
-			if(user)
-				user.remove_from_mob(D)
-			D.loc = src
-		if(!D2.remove_item_from_storage(src))
-			if(user)
-				user.remove_from_mob(D2)
-			D2.loc = src
-		D:holder = src
-		D2:holder = src
-		a_left = D
-		a_right = D2
-		name = "[D.name]-[D2.name] assembly"
-		update_icon()
-		return 1
-
-
+/obj/item/assembly_holder/attach(var/obj/item/D, var/obj/item/D2, var/mob/user)
+	if(!D||!D2)
+		return FALSE
+	if(!isassembly(D) || !isassembly(D2))
+		return FALSE
+	if(D:secured || D2:secured)
+		return FALSE
+	if(!D.remove_item_from_storage(src))
+		if(user)
+			user.remove_from_mob(D)
+		D.loc = src
+	if(!D2.remove_item_from_storage(src))
+		if(user)
+			user.remove_from_mob(D2)
+		D2.loc = src
+	D:holder = src
+	D2:holder = src
+	a_left = D
+	a_right = D2
+	name = "[D.name]-[D2.name] assembly"
 	update_icon()
-		overlays.Cut()
-		if(a_left)
-			overlays += "[a_left.icon_state]_left"
-			for(var/O in a_left.attached_overlays)
-				overlays += "[O]_l"
-		if(a_right)
-			src.overlays += "[a_right.icon_state]_right"
-			for(var/O in a_right.attached_overlays)
-				overlays += "[O]_r"
-		if(master)
-			master.update_icon()
+	return TRUE
 
 
-	examine(mob/user)
-		..(user)
-		if((in_range(src, user) || src.loc == user))
-			if(src.secured)
-				to_chat(user, "\The [src] is ready!")
-			else
-				to_chat(user, "\The [src] can be attached!")
+/obj/item/assembly_holder/update_icon()
+	overlays.Cut()
+	if(a_left)
+		overlays += "[a_left.icon_state]_left"
+		for(var/O in a_left.attached_overlays)
+			overlays += "[O]_l"
+	if(a_right)
+		src.overlays += "[a_right.icon_state]_right"
+		for(var/O in a_right.attached_overlays)
+			overlays += "[O]_r"
+	if(master)
+		master.update_icon()
 
 
-	HasProximity(atom/movable/AM as mob|obj)
-		if(a_left)
-			a_left.HasProximity(AM)
-		if(a_right)
-			a_right.HasProximity(AM)
+/obj/item/assembly_holder/examine(mob/user)
+	..(user)
+	if(in_range(src, user) || src.loc == user)
+		if(src.secured)
+			to_chat(user, "\The [src] is ready!")
+		else
+			to_chat(user, "\The [src] can be attached!")
 
 
-	Crossed(atom/movable/AM as mob|obj)
-		if(a_left)
-			a_left.Crossed(AM)
-		if(a_right)
-			a_right.Crossed(AM)
-
-	on_found(mob/finder as mob)
-		if(a_left)
-			a_left.on_found(finder)
-		if(a_right)
-			a_right.on_found(finder)
+/obj/item/assembly_holder/HasProximity(atom/movable/AM as mob|obj)
+	if(a_left)
+		a_left.HasProximity(AM)
+	if(a_right)
+		a_right.HasProximity(AM)
 
 
-	hear_talk(mob/living/M as mob, msg)
-		if(a_left)
-			a_left.hear_talk(M, msg)
-		if(a_right)
-			a_right.hear_talk(M, msg)
+/obj/item/assembly_holder/Crossed(atom/movable/AM as mob|obj)
+	if(a_left)
+		a_left.Crossed(AM)
+	if(a_right)
+		a_right.Crossed(AM)
 
-	hear_message(mob/living/M as mob, msg)
-		if(a_left)
-			a_left.hear_message(M, msg)
-		if(a_right)
-			a_right.hear_message(M, msg)
+/obj/item/assembly_holder/on_found(mob/finder as mob)
+	if(a_left)
+		a_left.on_found(finder)
+	if(a_right)
+		a_right.on_found(finder)
 
-	proc/process_movement() // infrared beams and prox sensors
-		if(a_left && a_right)
-			a_left.holder_movement()
-			a_right.holder_movement()
 
-	Move()
-		..()
-		process_movement()
+/obj/item/assembly_holder/hear_talk(mob/living/M as mob, msg)
+	if(a_left)
+		a_left.hear_talk(M, msg)
+	if(a_right)
+		a_right.hear_talk(M, msg)
+
+/obj/item/assembly_holder/hear_message(mob/living/M as mob, msg)
+	if(a_left)
+		a_left.hear_message(M, msg)
+	if(a_right)
+		a_right.hear_message(M, msg)
+
+/obj/item/assembly_holder/proc/process_movement() // infrared beams and prox sensors
+	if(a_left && a_right)
+		a_left.holder_movement()
+		a_right.holder_movement()
+
+/obj/item/assembly_holder/Move()
+	..()
+	process_movement()
+	return
+
+/obj/item/assembly_holder/pickup()
+	..()
+	process_movement()
+
+/obj/item/assembly_holder/Bump()
+	..()
+	process_movement()
+
+/obj/item/assembly_holder/throw_impact() // called when a throw stops
+	..()
+	process_movement()
+
+/obj/item/assembly_holder/attack_hand()//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
+	if(a_left && a_right)
+		a_left.holder_movement()
+		a_right.holder_movement()
+	..()
+	return
+
+/obj/item/assembly_holder/attackby(obj/item/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/screwdriver))
+		if(!a_left || !a_right)
+			to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
+			return
+		a_left.toggle_secure()
+		a_right.toggle_secure()
+		secured = !secured
+		if(secured)
+			to_chat(user, "<span class='notice'>\The [src] is ready!</span>")
+		else
+			to_chat(user, "<span class='notice'>\The [src] can now be taken apart!</span>")
+		update_icon()
 		return
-
-	pickup()
+	else
 		..()
-		process_movement()
-
-	Bump()
-		..()
-		process_movement()
-
-	throw_impact() // called when a throw stops
-		..()
-		process_movement()
-
-	attack_hand()//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
-		if(a_left && a_right)
-			a_left.holder_movement()
-			a_right.holder_movement()
-		..()
-		return
+	return
 
 
-	attackby(obj/item/W as obj, mob/user as mob, params)
-		if(istype(W, /obj/item/screwdriver))
-			if(!a_left || !a_right)
-				to_chat(user, "<span class='warning'>BUG:Assembly part missing, please report this!</span>")
-				return
-			a_left.toggle_secure()
-			a_right.toggle_secure()
-			secured = !secured
-			if(secured)
-				to_chat(user, "<span class='notice'>\The [src] is ready!</span>")
-			else
-				to_chat(user, "<span class='notice'>\The [src] can now be taken apart!</span>")
-			update_icon()
+/obj/item/assembly_holder/attack_self(mob/user as mob)
+	src.add_fingerprint(user)
+	if(src.secured)
+		if(!a_left || !a_right)
+			to_chat(user, "<span class='warning'>Assembly part missing!</span>")
+			return
+		if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
+			switch(alert("Which side would you like to use?",,"Left","Right"))
+				if("Left")	a_left.attack_self(user)
+				if("Right")	a_right.attack_self(user)
 			return
 		else
-			..()
-		return
+			a_left.attack_self(user)
+			a_right.attack_self(user)
+	else
+		var/turf/T = get_turf(src)
+		if(!T)
+			return FALSE
+		if(a_left)
+			a_left:holder = null
+			a_left.loc = T
+		if(a_right)
+			a_right:holder = null
+			a_right.loc = T
+		spawn(0)
+			qdel(src)
+	return
 
 
-	attack_self(mob/user as mob)
-		src.add_fingerprint(user)
-		if(src.secured)
-			if(!a_left || !a_right)
-				to_chat(user, "<span class='warning'>Assembly part missing!</span>")
-				return
-			if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
-				switch(alert("Which side would you like to use?",,"Left","Right"))
-					if("Left")	a_left.attack_self(user)
-					if("Right")	a_right.attack_self(user)
-				return
-			else
-				a_left.attack_self(user)
-				a_right.attack_self(user)
-		else
-			var/turf/T = get_turf(src)
-			if(!T)	return 0
-			if(a_left)
-				a_left:holder = null
-				a_left.loc = T
-			if(a_right)
-				a_right:holder = null
-				a_right.loc = T
-			spawn(0)
-				qdel(src)
-		return
+/obj/item/assembly_holder/process_activation(var/obj/D, var/normal = 1, var/special = 1)
+	if(!D)
+		return FALSE
+	if(normal && a_right && a_left)
+		if(a_right != D)
+			a_right.pulsed(0)
+		if(a_left != D)
+			a_left.pulsed(0)
+	if(master)
+		master.receive_signal()
+	return TRUE
 
 
-	process_activation(var/obj/D, var/normal = 1, var/special = 1)
-		if(!D)	return 0
-		if((normal) && (a_right) && (a_left))
-			if(a_right != D)
-				a_right.pulsed(0)
-			if(a_left != D)
-				a_left.pulsed(0)
-		if(master)
-			master.receive_signal()
-		return 1
-
-
-	ex_act(severity)
-		switch(severity)
-			if(1.0)
+/obj/item/assembly_holder/ex_act(severity)
+	switch(severity)
+		if(1.0)
+			qdel(src)
+			return
+		if(2.0)
+			if(prob(50))
 				qdel(src)
 				return
-			if(2.0)
-				if(prob(50))
-					qdel(src)
-					return
-			if(3.0)
-				if(prob(25))
-					qdel(src)
-					return
-		return
+		if(3.0)
+			if(prob(25))
+				qdel(src)
+				return

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -21,7 +21,8 @@
 
 
 /obj/item/assembly/igniter/activate()
-	if(!..())	return 0//Cooldown check
+	if(!..())
+		return FALSE//Cooldown check
 	var/turf/location = get_turf(loc)
 	if(location)	location.hotspot_expose(1000,1000)
 	if(istype(src.loc,/obj/item/assembly_holder))
@@ -35,7 +36,7 @@
 				beakerbomb.heat_beaker()
 
 	sparks.start()
-	return 1
+	return TRUE
 
 
 /obj/item/assembly/igniter/attack_self(mob/user as mob)

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -17,29 +17,29 @@
 
 
 /obj/item/assembly/igniter/describe()
-	return "The igniter is [secured?"secured.":"unsecured."]"
+	return "The igniter is [secured ? "secured." : "unsecured."]"
 
 
 /obj/item/assembly/igniter/activate()
 	if(!..())
 		return FALSE//Cooldown check
 	var/turf/location = get_turf(loc)
-	if(location)	location.hotspot_expose(1000,1000)
-	if(istype(loc,/obj/item/assembly_holder))
-		if(istype(loc.loc, /obj/structure/reagent_dispensers/fueltank/))
+	if(location)
+		location.hotspot_expose(1000,1000)
+	if(istype(loc, /obj/item/assembly_holder))
+		if(istype(loc.loc, /obj/structure/reagent_dispensers/fueltank))
 			var/obj/structure/reagent_dispensers/fueltank/tank = loc.loc
 			if(tank)
 				tank.boom(TRUE)
-		if(istype(loc.loc, /obj/item/reagent_containers/glass/beaker/))
+		if(istype(loc.loc, /obj/item/reagent_containers/glass/beaker))
 			var/obj/item/reagent_containers/glass/beaker/beakerbomb = loc.loc
 			if(beakerbomb)
 				beakerbomb.heat_beaker()
-
 	sparks.start()
 	return TRUE
 
 
-/obj/item/assembly/igniter/attack_self(mob/user as mob)
+/obj/item/assembly/igniter/attack_self(mob/user)
 	activate()
 	add_fingerprint(user)
 	return

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -25,13 +25,13 @@
 		return FALSE//Cooldown check
 	var/turf/location = get_turf(loc)
 	if(location)	location.hotspot_expose(1000,1000)
-	if(istype(src.loc,/obj/item/assembly_holder))
-		if(istype(src.loc.loc, /obj/structure/reagent_dispensers/fueltank/))
-			var/obj/structure/reagent_dispensers/fueltank/tank = src.loc.loc
+	if(istype(loc,/obj/item/assembly_holder))
+		if(istype(loc.loc, /obj/structure/reagent_dispensers/fueltank/))
+			var/obj/structure/reagent_dispensers/fueltank/tank = loc.loc
 			if(tank)
 				tank.boom(TRUE)
-		if(istype(src.loc.loc, /obj/item/reagent_containers/glass/beaker/))
-			var/obj/item/reagent_containers/glass/beaker/beakerbomb = src.loc.loc
+		if(istype(loc.loc, /obj/item/reagent_containers/glass/beaker/))
+			var/obj/item/reagent_containers/glass/beaker/beakerbomb = loc.loc
 			if(beakerbomb)
 				beakerbomb.heat_beaker()
 

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -33,10 +33,11 @@
 	to_chat(user, describe())
 
 /obj/item/assembly/infra/activate()
-	if(!..())	return 0//Cooldown check
+	if(!..())
+		return FALSE//Cooldown check
 	on = !on
 	update_icon()
-	return 1
+	return TRUE
 
 /obj/item/assembly/infra/toggle_secure()
 	secured = !secured
@@ -110,9 +111,10 @@
 	qdel(first)
 
 /obj/item/assembly/infra/holder_movement()
-	if(!holder)	return 0
+	if(!holder)
+		return FALSE
 	qdel(first)
-	return 1
+	return TRUE
 
 /obj/item/assembly/infra/equipped(var/mob/user, var/slot)
 	qdel(first)
@@ -124,7 +126,7 @@
 
 /obj/item/assembly/infra/proc/trigger_beam()
 	if(!secured || !on || cooldown > 0)
-		return 0
+		return FALSE
 	pulse(0)
 	audible_message("[bicon(src)] *beep* *beep*", null, 3)
 	if(first)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -7,10 +7,10 @@
 
 	bomb_name = "tripwire mine"
 
-	secured = 0 // toggle_secure()'ed in New() for correct adding to processing_objects, won't work otherwise
+	secured = FALSE // toggle_secure()'ed in New() for correct adding to processing_objects, won't work otherwise
 	dir = EAST
-	var/on = 0
-	var/visible = 1
+	var/on = FALSE
+	var/visible = TRUE
 	var/obj/effect/beam/i_beam/first = null
 	var/obj/effect/beam/i_beam/last = null
 	var/max_nesting_level = 10
@@ -44,7 +44,7 @@
 	if(secured)
 		processing_objects.Add(src)
 	else
-		on = 0
+		on = FALSE
 		if(first)
 			qdel(first)
 		processing_objects.Remove(src)
@@ -95,7 +95,7 @@
 		first = I
 		step(I, I.dir)
 		if(first)
-			I.density = 0
+			I.density = FALSE
 			I.vis_spread(visible)
 			I.limit = 8
 			I.process()
@@ -135,7 +135,7 @@
 	spawn(10)
 		process_cooldown()
 
-/obj/item/assembly/infra/interact(mob/user as mob)//TODO: change this this to the wire control panel
+/obj/item/assembly/infra/interact(mob/user)//TODO: change this this to the wire control panel
 	if(!secured)	return
 	user.set_machine(src)
 	var/dat = {"<TT><B>Infrared Laser</B>
@@ -198,7 +198,7 @@
 		arm()
 
 /obj/item/assembly/infra/armed/stealth
-	visible = 0
+	visible = FALSE
 
 
 /***************************IBeam*********************************/
@@ -211,11 +211,11 @@
 	var/obj/effect/beam/i_beam/previous = null
 	var/obj/item/assembly/infra/master = null
 	var/limit = null
-	var/visible = 0.0
+	var/visible = FALSE
 	var/left = null
 	var/life_cycles = 0
 	var/life_cap = 20
-	anchored = 1.0
+	anchored = TRUE
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
 
@@ -243,9 +243,9 @@
 		if(!(visible))
 			invisibility = 101
 		else
-			invisibility = 0
+			invisibility = FALSE
 	else
-		invisibility = 0
+		invisibility = FALSE
 
 	if(!next && (limit > 0))
 		var/obj/effect/beam/i_beam/I = new /obj/effect/beam/i_beam(loc)
@@ -257,7 +257,7 @@
 		next = I
 		step(I, I.dir)
 		if(next)
-			I.density = 0
+			I.density = FALSE
 			I.vis_spread(visible)
 			I.limit = limit - 1
 			master.last = I
@@ -269,7 +269,7 @@
 /obj/effect/beam/i_beam/Bumped()
 	hit()
 
-/obj/effect/beam/i_beam/Crossed(atom/movable/AM as mob|obj)
+/obj/effect/beam/i_beam/Crossed(atom/movable/AM)
 	if(!isobj(AM) && !isliving(AM))
 		return
 	if(istype(AM, /obj/effect))

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -8,124 +8,118 @@
 
 	bomb_name = "contact mine"
 
-	examine(mob/user)
-		..(user)
-		if(armed)
-			to_chat(user, "It looks like it's armed.")
+/obj/item/assembly/mousetrap/examine(mob/user)
+	..(user)
+	if(armed)
+		to_chat(user, "It looks like it's armed.")
 
-	activate()
-		if(..())
-			armed = !armed
-			if(!armed)
-				if(ishuman(usr))
-					var/mob/living/carbon/human/user = usr
-					if(((user.getBrainLoss() >= 60 || (CLUMSY in user.mutations)) && prob(50)))
-						to_chat(user, "Your hand slips, setting off the trigger.")
-						pulse(0)
-			update_icon()
-			if(usr)
-				playsound(usr.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
-
-	describe()
-		return "The pressure switch is [armed?"primed":"safe"]."
-
-	update_icon()
-		if(armed)
-			icon_state = "mousetraparmed"
-		else
-			icon_state = "mousetrap"
-		if(holder)
-			holder.update_icon()
-
-	proc/triggered(mob/target as mob, var/type = "feet")
-		if(!armed)
-			return
-		var/obj/item/organ/external/affecting = null
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			switch(type)
-				if("feet")
-					if(!H.shoes)
-						affecting = H.get_organ(pick("l_leg", "r_leg"))
-						H.Weaken(3)
-				if("l_hand", "r_hand")
-					if(!H.gloves)
-						affecting = H.get_organ(type)
-						H.Stun(3)
-			if(affecting)
-				affecting.receive_damage(1, 0)
-		else if(ismouse(target))
-			var/mob/living/simple_animal/mouse/M = target
-			visible_message("<span class='danger'>SPLAT!</span>")
-			M.splat()
-		playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
-		layer = MOB_LAYER - 0.2
-		armed = 0
-		update_icon()
-		pulse(0)
-
-
-	attack_self(mob/living/user as mob)
-		if(!armed)
-			to_chat(user, "<span class='notice'>You arm [src].</span>")
-		else
-			if(((user.getBrainLoss() >= 60 || (CLUMSY in user.mutations)) && prob(50)))
-				var/which_hand = "l_hand"
-				if(!user.hand)
-					which_hand = "r_hand"
-				triggered(user, which_hand)
-				user.visible_message("<span class='warning'>[user] accidentally sets off [src], breaking [user.p_their()] fingers.</span>", \
-									 "<span class='warning'>You accidentally trigger [src]!</span>")
-				return
-			to_chat(user, "<span class='notice'>You disarm [src].</span>")
+/obj/item/assembly/mousetrap/activate()
+	if(..())
 		armed = !armed
-		update_icon()
-		playsound(user.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
-
-
-	attack_hand(mob/living/user as mob)
-		if(armed)
-			if(((user.getBrainLoss() >= 60 || CLUMSY in user.mutations)) && prob(50))
-				var/which_hand = "l_hand"
-				if(!user.hand)
-					which_hand = "r_hand"
-				triggered(user, which_hand)
-				user.visible_message("<span class='warning'>[user] accidentally sets off [src], breaking [user.p_their()] fingers.</span>", \
-									 "<span class='warning'>You accidentally trigger [src]!</span>")
-				return
-		..()
-
-
-	Crossed(var/atom/movable/AM as mob|obj)
-		if(armed)
-			if(ishuman(AM))
-				var/mob/living/carbon/H = AM
-				if(H.m_intent == MOVE_INTENT_RUN)
-					triggered(H)
-					H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
-									  "<span class='warning'>You accidentally step on [src]</span>")
-			else if(ismouse(AM))
-				triggered(AM)
-			else if(AM.density) // For mousetrap grenades, set off by anything heavy
-				triggered(AM)
-		..()
-
-
-	on_found(mob/finder as mob)
-		if(armed)
-			finder.visible_message("<span class='warning'>[finder] accidentally sets off [src], breaking [finder.p_their()] fingers.</span>", \
-								   "<span class='warning'>You accidentally trigger [src]!</span>")
-			triggered(finder, finder.hand ? "l_hand" : "r_hand")
-			return 1	//end the search!
-		return 0
-
-
-	hitby(A as mob|obj)
 		if(!armed)
-			return ..()
-		visible_message("<span class='warning'>[src] is triggered by [A].</span>")
-		triggered(null)
+			if(ishuman(usr))
+				var/mob/living/carbon/human/user = usr
+				if((user.getBrainLoss() >= 60 || (CLUMSY in user.mutations)) && prob(50))
+					to_chat(user, "Your hand slips, setting off the trigger.")
+					pulse(0)
+		update_icon()
+		if(usr)
+			playsound(usr.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
 
+/obj/item/assembly/mousetrap/describe()
+	return "The pressure switch is [armed?"primed":"safe"]."
+
+/obj/item/assembly/mousetrap/update_icon()
+	if(armed)
+		icon_state = "mousetraparmed"
+	else
+		icon_state = "mousetrap"
+	if(holder)
+		holder.update_icon()
+
+/obj/item/assembly/mousetrap/proc/triggered(mob/target as mob, var/type = "feet")
+	if(!armed)
+		return
+	var/obj/item/organ/external/affecting = null
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		switch(type)
+			if("feet")
+				if(!H.shoes)
+					affecting = H.get_organ(pick("l_leg", "r_leg"))
+					H.Weaken(3)
+			if("l_hand", "r_hand")
+				if(!H.gloves)
+					affecting = H.get_organ(type)
+					H.Stun(3)
+		if(affecting)
+			affecting.receive_damage(1, 0)
+	else if(ismouse(target))
+		var/mob/living/simple_animal/mouse/M = target
+		visible_message("<span class='danger'>SPLAT!</span>")
+		M.splat()
+	playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
+	layer = MOB_LAYER - 0.2
+	armed = 0
+	update_icon()
+	pulse(0)
+
+/obj/item/assembly/mousetrap/attack_self(mob/living/user as mob)
+	if(!armed)
+		to_chat(user, "<span class='notice'>You arm [src].</span>")
+	else
+		if((user.getBrainLoss() >= 60 || (CLUMSY in user.mutations)) && prob(50))
+			var/which_hand = "l_hand"
+			if(!user.hand)
+				which_hand = "r_hand"
+			triggered(user, which_hand)
+			user.visible_message("<span class='warning'>[user] accidentally sets off [src], breaking [user.p_their()] fingers.</span>", \
+								 "<span class='warning'>You accidentally trigger [src]!</span>")
+			return
+		to_chat(user, "<span class='notice'>You disarm [src].</span>")
+	armed = !armed
+	update_icon()
+	playsound(user.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
+
+/obj/item/assembly/mousetrap/attack_hand(mob/living/user as mob)
+	if(armed)
+		if((user.getBrainLoss() >= 60 || CLUMSY in user.mutations) && prob(50))
+			var/which_hand = "l_hand"
+			if(!user.hand)
+				which_hand = "r_hand"
+			triggered(user, which_hand)
+			user.visible_message("<span class='warning'>[user] accidentally sets off [src], breaking [user.p_their()] fingers.</span>", \
+								 "<span class='warning'>You accidentally trigger [src]!</span>")
+			return
+	..()
+
+/obj/item/assembly/mousetrap/Crossed(var/atom/movable/AM as mob|obj)
+	if(armed)
+		if(ishuman(AM))
+			var/mob/living/carbon/H = AM
+			if(H.m_intent == MOVE_INTENT_RUN)
+				triggered(H)
+				H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
+								  "<span class='warning'>You accidentally step on [src]</span>")
+		else if(ismouse(AM))
+			triggered(AM)
+		else if(AM.density) // For mousetrap grenades, set off by anything heavy
+			triggered(AM)
+	..()
+
+/obj/item/assembly/mousetrap/on_found(mob/finder as mob)
+	if(armed)
+		finder.visible_message("<span class='warning'>[finder] accidentally sets off [src], breaking [finder.p_their()] fingers.</span>", \
+							   "<span class='warning'>You accidentally trigger [src]!</span>")
+		triggered(finder, finder.hand ? "l_hand" : "r_hand")
+		return TRUE	//end the search!
+	return FALSE
+
+/obj/item/assembly/mousetrap/hitby(A as mob|obj)
+	if(!armed)
+		return ..()
+	visible_message("<span class='warning'>[src] is triggered by [A].</span>")
+	triggered(null)
 
 /obj/item/assembly/mousetrap/armed
 	icon_state = "mousetraparmed"

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -4,7 +4,7 @@
 	icon_state = "mousetrap"
 	materials = list(MAT_METAL=100)
 	origin_tech = "combat=1;materials=2;engineering=1"
-	var/armed = 0
+	var/armed = FALSE
 
 	bomb_name = "contact mine"
 
@@ -27,7 +27,7 @@
 			playsound(usr.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
 
 /obj/item/assembly/mousetrap/describe()
-	return "The pressure switch is [armed?"primed":"safe"]."
+	return "The pressure switch is [armed ? "primed" : "safe"]."
 
 /obj/item/assembly/mousetrap/update_icon()
 	if(armed)
@@ -37,7 +37,7 @@
 	if(holder)
 		holder.update_icon()
 
-/obj/item/assembly/mousetrap/proc/triggered(mob/target as mob, var/type = "feet")
+/obj/item/assembly/mousetrap/proc/triggered(mob/target, var/type = "feet")
 	if(!armed)
 		return
 	var/obj/item/organ/external/affecting = null
@@ -60,11 +60,11 @@
 		M.splat()
 	playsound(loc, 'sound/effects/snap.ogg', 50, 1)
 	layer = MOB_LAYER - 0.2
-	armed = 0
+	armed = FALSE
 	update_icon()
 	pulse(0)
 
-/obj/item/assembly/mousetrap/attack_self(mob/living/user as mob)
+/obj/item/assembly/mousetrap/attack_self(mob/living/user)
 	if(!armed)
 		to_chat(user, "<span class='notice'>You arm [src].</span>")
 	else
@@ -81,7 +81,7 @@
 	update_icon()
 	playsound(user.loc, 'sound/weapons/handcuffs.ogg', 30, 1, -3)
 
-/obj/item/assembly/mousetrap/attack_hand(mob/living/user as mob)
+/obj/item/assembly/mousetrap/attack_hand(mob/living/user)
 	if(armed)
 		if((user.getBrainLoss() >= 60 || CLUMSY in user.mutations) && prob(50))
 			var/which_hand = "l_hand"
@@ -93,7 +93,7 @@
 			return
 	..()
 
-/obj/item/assembly/mousetrap/Crossed(var/atom/movable/AM as mob|obj)
+/obj/item/assembly/mousetrap/Crossed(atom/movable/AM)
 	if(armed)
 		if(ishuman(AM))
 			var/mob/living/carbon/H = AM
@@ -107,7 +107,7 @@
 			triggered(AM)
 	..()
 
-/obj/item/assembly/mousetrap/on_found(mob/finder as mob)
+/obj/item/assembly/mousetrap/on_found(mob/finder)
 	if(armed)
 		finder.visible_message("<span class='warning'>[finder] accidentally sets off [src], breaking [finder.p_their()] fingers.</span>", \
 							   "<span class='warning'>You accidentally trigger [src]!</span>")
@@ -115,7 +115,7 @@
 		return TRUE	//end the search!
 	return FALSE
 
-/obj/item/assembly/mousetrap/hitby(A as mob|obj)
+/obj/item/assembly/mousetrap/hitby(atom/movable/A)
 	if(!armed)
 		return ..()
 	visible_message("<span class='warning'>[src] is triggered by [A].</span>")

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -58,7 +58,7 @@
 		var/mob/living/simple_animal/mouse/M = target
 		visible_message("<span class='danger'>SPLAT!</span>")
 		M.splat()
-	playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)
+	playsound(loc, 'sound/effects/snap.ogg', 50, 1)
 	layer = MOB_LAYER - 0.2
 	armed = 0
 	update_icon()

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -19,11 +19,11 @@
 	return "The proximity sensor is [scanning ? "armed" : "disarmed"]."
 
 /obj/item/assembly/prox_sensor/activate()
-	if(!..())	
-		return 0 //Cooldown check
+	if(!..())
+		return FALSE //Cooldown check
 	timing = !timing
 	update_icon()
-	return 0
+	return FALSE
 
 /obj/item/assembly/prox_sensor/toggle_secure()
 	secured = !secured
@@ -39,14 +39,14 @@
 /obj/item/assembly/prox_sensor/HasProximity(atom/movable/AM)
 	if(!isobj(AM) && !isliving(AM))
 		return
-	if(istype(AM, /obj/effect))	
+	if(istype(AM, /obj/effect))
 		return
 	if(AM.move_speed < 12)
 		sense()
 
 /obj/item/assembly/prox_sensor/proc/sense()
-	if((!secured)||(!scanning)||(cooldown > 0))	
-		return 0
+	if(!secured || !scanning || cooldown > 0)
+		return FALSE
 	pulse(0)
 	visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
 	cooldown = 2
@@ -69,7 +69,7 @@
 
 /obj/item/assembly/prox_sensor/proc/toggle_scan()
 	if(!secured)
-		return 0
+		return FALSE
 	scanning = !scanning
 	update_icon()
 
@@ -95,7 +95,7 @@
 /obj/item/assembly/prox_sensor/interact(mob/user)//TODO: Change this to the wires thingy
 	if(!secured)
 		user.show_message("<span class='warning'>The [name] is unsecured!</span>")
-		return 0
+		return FALSE
 	var/second = time % 60
 	var/minute = (time - second) / 60
 	var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='?src=[UID()];tp=-30'>-</A> <A href='?src=[UID()];tp=-1'>-</A> <A href='?src=[UID()];tp=1'>+</A> <A href='?src=[UID()];tp=30'>+</A>\n</TT>", (timing ? "<A href='?src=[UID()];time=0'>Arming</A>" : "<A href='?src=[UID()];time=1'>Not Arming</A>"), minute, second)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -8,7 +8,7 @@
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 
 	secured = 1
-	var/receiving = 0
+	var/receiving = FALSE
 
 	bomb_name = "remote-control bomb"
 
@@ -35,7 +35,7 @@
 	return ..()
 
 /obj/item/assembly/signaler/describe()
-	return "\The [src]'s power light is [receiving?"on":"off"]"
+	return "[src]'s power light is [receiving ? "on" : "off"]"
 
 /obj/item/assembly/signaler/activate()
 	if(cooldown > 0)
@@ -52,7 +52,7 @@
 		holder.update_icon()
 	return
 
-/obj/item/assembly/signaler/interact(mob/user as mob, flag1)
+/obj/item/assembly/signaler/interact(mob/user, flag1)
 	var/t1 = "-------"
 	var/dat = {"
 		<TT>
@@ -84,8 +84,6 @@
 	popup.set_content(dat)
 	popup.open(0)
 	onclose(user, "radio")
-	return
-
 
 /obj/item/assembly/signaler/Topic(href, href_list)
 	..()
@@ -116,10 +114,9 @@
 	if(usr)
 		attack_self(usr)
 
-	return
-
 /obj/item/assembly/signaler/proc/signal()
-	if(!radio_connection) return
+	if(!radio_connection)
+		return
 
 	var/datum/signal/signal = new
 	signal.source = src
@@ -132,9 +129,7 @@
 	if(usr)
 		lastsignalers.Add("[time] <B>:</B> [usr.key] used [src] @ location ([T.x],[T.y],[T.z]) <B>:</B> [format_frequency(frequency)]/[code]")
 
-	return
-
-/obj/item/assembly/signaler/pulse(var/radio = 0)
+/obj/item/assembly/signaler/pulse(var/radio = FALSE)
 	if(connected && wires)
 		connected.Pulse(src)
 	else
@@ -153,7 +148,6 @@
 
 	for(var/mob/O in hearers(1, loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
-	return
 
 /obj/item/assembly/signaler/proc/set_frequency(new_frequency)
 	if(!radio_controller)
@@ -163,7 +157,6 @@
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
-	return
 
 // Embedded signaller used in anomalies.
 /obj/item/assembly/signaler/anomaly
@@ -171,7 +164,7 @@
 	desc = "The neutralized core of an anomaly. It'd probably be valuable for research."
 	icon_state = "anomaly core"
 	item_state = "electronic"
-	receiving = 1
+	receiving = TRUE
 
 /obj/item/assembly/signaler/anomaly/receive_signal(datum/signal/signal)
 	..()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -38,13 +38,14 @@
 	return "\The [src]'s power light is [receiving?"on":"off"]"
 
 /obj/item/assembly/signaler/activate()
-	if(cooldown > 0)	return 0
+	if(cooldown > 0)
+		return FALSE
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
 
 	signal()
-	return 1
+	return TRUE
 
 /obj/item/assembly/signaler/update_icon()
 	if(holder)
@@ -53,10 +54,6 @@
 
 /obj/item/assembly/signaler/interact(mob/user as mob, flag1)
 	var/t1 = "-------"
-//	if((src.b_stat && !( flag1 )))
-//		t1 = text("-------<BR>\nGreen Wire: []<BR>\nRed Wire:   []<BR>\nBlue Wire:  []<BR>\n", (src.wires & 4 ? "<A href='?src=[UID()];wires=4'>Cut Wire</A>" : "<A href='?src=[UID()];wires=4'>Mend Wire</A>"), (src.wires & 2 ? "<A href='?src=[UID()];wires=2'>Cut Wire</A>" : "<A href='?src=[UID()];wires=2'>Mend Wire</A>"), (src.wires & 1 ? "<A href='?src=[UID()];wires=1'>Cut Wire</A>" : "<A href='?src=[UID()];wires=1'>Mend Wire</A>"))
-//	else
-//		t1 = "-------"	Speaker: [src.listening ? "<A href='byond://?src=[UID()];listen=0'>Engaged</A>" : "<A href='byond://?src=[UID()];listen=1'>Disengaged</A>"]<BR>
 	var/dat = {"
 		<TT>
 	"}
@@ -144,13 +141,14 @@
 		return ..(radio)
 
 /obj/item/assembly/signaler/receive_signal(datum/signal/signal)
-	if( !receiving || !signal )
-		return 0
+	if(!receiving || !signal)
+		return FALSE
 
 	if(signal.encryption != code)
-		return 0
+		return FALSE
 
-	if(!(src.wires & WIRE_RADIO_RECEIVE))	return 0
+	if(!(src.wires & WIRE_RADIO_RECEIVE))
+		return FALSE
 	pulse(1)
 
 	for(var/mob/O in hearers(1, src.loc))

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -67,14 +67,14 @@
 		Frequency:
 		<A href='byond://?src=[UID()];freq=-10'>-</A>
 		<A href='byond://?src=[UID()];freq=-2'>-</A>
-		[format_frequency(src.frequency)]
+		[format_frequency(frequency)]
 		<A href='byond://?src=[UID()];freq=2'>+</A>
 		<A href='byond://?src=[UID()];freq=10'>+</A><BR>
 
 		Code:
 		<A href='byond://?src=[UID()];code=-5'>-</A>
 		<A href='byond://?src=[UID()];code=-1'>-</A>
-		[src.code]
+		[code]
 		<A href='byond://?src=[UID()];code=1'>+</A>
 		<A href='byond://?src=[UID()];code=5'>+</A><BR>
 		[t1]
@@ -102,10 +102,10 @@
 		set_frequency(new_frequency)
 
 	if(href_list["code"])
-		src.code += text2num(href_list["code"])
-		src.code = round(src.code)
-		src.code = min(100, src.code)
-		src.code = max(1, src.code)
+		code += text2num(href_list["code"])
+		code = round(code)
+		code = min(100, code)
+		code = max(1, code)
 	if(href_list["receive"])
 		receiving = !receiving
 
@@ -135,7 +135,7 @@
 	return
 
 /obj/item/assembly/signaler/pulse(var/radio = 0)
-	if(src.connected && src.wires)
+	if(connected && wires)
 		connected.Pulse(src)
 	else
 		return ..(radio)
@@ -147,11 +147,11 @@
 	if(signal.encryption != code)
 		return FALSE
 
-	if(!(src.wires & WIRE_RADIO_RECEIVE))
+	if(!(wires & WIRE_RADIO_RECEIVE))
 		return FALSE
 	pulse(1)
 
-	for(var/mob/O in hearers(1, src.loc))
+	for(var/mob/O in hearers(1, loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
 	return
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -5,13 +5,13 @@
 	materials = list(MAT_METAL=500, MAT_GLASS=50)
 	origin_tech = "magnets=1;engineering=1"
 
-	secured = 0
+	secured = FALSE
 
 	bomb_name = "time bomb"
 
-	var/timing = 0
+	var/timing = FALSE
 	var/time = 10
-	var/repeat = 0
+	var/repeat = FALSE
 	var/set_time = 10
 
 /obj/item/assembly/timer/describe()
@@ -31,7 +31,7 @@
 	if(secured)
 		processing_objects.Add(src)
 	else
-		timing = 0
+		timing = FALSE
 		processing_objects.Remove(src)
 	update_icon()
 	return secured
@@ -45,7 +45,6 @@
 	cooldown = 2
 	spawn(10)
 		process_cooldown()
-	return
 
 /obj/item/assembly/timer/process()
 	if(timing && (time > 0))
@@ -54,7 +53,6 @@
 		timing = repeat
 		timer_end()
 		time = set_time
-	return
 
 /obj/item/assembly/timer/update_icon()
 	overlays.Cut()
@@ -64,7 +62,6 @@
 		attached_overlays += "timer_timing"
 	if(holder)
 		holder.update_icon()
-	return
 
 /obj/item/assembly/timer/interact(mob/user as mob)//TODO: Have this use the wires
 	if(!secured)
@@ -94,11 +91,10 @@
 	popup.set_content(dat)
 	popup.open(0)
 	onclose(user, "timer")
-	return
 
 /obj/item/assembly/timer/Topic(href, href_list)
 	..()
-	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
+	if(usr.incapacitated() || !in_range(loc, usr))
 		usr << browse(null, "window=timer")
 		onclose(usr, "timer")
 		return

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -14,127 +14,118 @@
 	var/repeat = 0
 	var/set_time = 10
 
-	proc
-		timer_end()
+/obj/item/assembly/timer/describe()
+	if(timing)
+		return "The timer is counting down from [time]!"
+	return "The timer is set for [time] seconds."
 
-	describe()
-		if(timing)
-			return "The timer is counting down from [time]!"
-		return "The timer is set for [time] seconds."
-
-	activate()
-		if(!..())	return 0//Cooldown check
-		timing = !timing
-		update_icon()
-		return 0
-
-
-	toggle_secure()
-		secured = !secured
-		if(secured)
-			processing_objects.Add(src)
-		else
-			timing = 0
-			processing_objects.Remove(src)
-		update_icon()
-		return secured
-
-
-	timer_end()
-		if((!secured)||(cooldown > 0))	return 0
-		pulse(0)
-		if(loc)
-			loc.visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
-		cooldown = 2
-		spawn(10)
-			process_cooldown()
-		return
-
-
-	process()
-		if(timing && (time > 0))
-			time -= 2 // 2 seconds per process()
-		if(timing && time <= 0)
-			timing = repeat
-			timer_end()
-			time = set_time
-		return
-
-
+/obj/item/assembly/timer/activate()
+	if(!..())
+		return FALSE//Cooldown check
+	timing = !timing
 	update_icon()
-		overlays.Cut()
-		attached_overlays = list()
-		if(timing)
-			overlays += "timer_timing"
-			attached_overlays += "timer_timing"
-		if(holder)
-			holder.update_icon()
+	return FALSE
+
+/obj/item/assembly/timer/toggle_secure()
+	secured = !secured
+	if(secured)
+		processing_objects.Add(src)
+	else
+		timing = 0
+		processing_objects.Remove(src)
+	update_icon()
+	return secured
+
+/obj/item/assembly/timer/proc/timer_end()
+	if(!secured || cooldown > 0)
+		return FALSE
+	pulse(0)
+	if(loc)
+		loc.visible_message("[bicon(src)] *beep* *beep*", "*beep* *beep*")
+	cooldown = 2
+	spawn(10)
+		process_cooldown()
+	return
+
+/obj/item/assembly/timer/process()
+	if(timing && (time > 0))
+		time -= 2 // 2 seconds per process()
+	if(timing && time <= 0)
+		timing = repeat
+		timer_end()
+		time = set_time
+	return
+
+/obj/item/assembly/timer/update_icon()
+	overlays.Cut()
+	attached_overlays = list()
+	if(timing)
+		overlays += "timer_timing"
+		attached_overlays += "timer_timing"
+	if(holder)
+		holder.update_icon()
+	return
+
+/obj/item/assembly/timer/interact(mob/user as mob)//TODO: Have this use the wires
+	if(!secured)
+		user.show_message("<span class='warning'>The [name] is unsecured!</span>")
+		return FALSE
+	var/second = time % 60
+	var/minute = (time - second) / 60
+	var/set_second = set_time % 60
+	var/set_minute = (set_time - set_second) / 60
+	if(second < 10) second = "0[second]"
+	if(set_second < 10) set_second = "0[set_second]"
+
+	var/dat = {"
+	<TT>
+		<center><h2>Timing Unit</h2>
+		[minute]:[second] <a href='?src=[UID()];time=1'>[timing?"Stop":"Start"]</a> <a href='?src=[UID()];reset=1'>Reset</a><br>
+		Repeat: <a href='?src=[UID()];repeat=1'>[repeat?"On":"Off"]</a><br>
+		Timer set for
+		<A href='?src=[UID()];tp=-30'>-</A> <A href='?src=[UID()];tp=-1'>-</A> [set_minute]:[set_second] <A href='?src=[UID()];tp=1'>+</A> <A href='?src=[UID()];tp=30'>+</A>
+		</center>
+	</TT>
+	<BR><BR>
+	<A href='?src=[UID()];refresh=1'>Refresh</A>
+	<BR><BR>
+	<A href='?src=[UID()];close=1'>Close</A>"}
+	var/datum/browser/popup = new(user, "timer", name, 400, 400)
+	popup.set_content(dat)
+	popup.open(0)
+	onclose(user, "timer")
+	return
+
+/obj/item/assembly/timer/Topic(href, href_list)
+	..()
+	if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
+		usr << browse(null, "window=timer")
+		onclose(usr, "timer")
 		return
 
+	if(href_list["time"])
+		timing = !timing
+		if(timing && istype(holder, /obj/item/transfer_valve))
+			message_admins("[key_name_admin(usr)] activated [src] attachment on [holder].")
+			investigate_log("[key_name(usr)] activated [src] attachment for [loc]", INVESTIGATE_BOMB)
+			log_game("[key_name(usr)] activated [src] attachment for [loc]")
+		update_icon()
+	if(href_list["reset"])
+		time = set_time
 
-	interact(mob/user as mob)//TODO: Have this use the wires
-		if(!secured)
-			user.show_message("<span class='warning'>The [name] is unsecured!</span>")
-			return 0
-		var/second = time % 60
-		var/minute = (time - second) / 60
-		var/set_second = set_time % 60
-		var/set_minute = (set_time - set_second) / 60
-		if(second < 10) second = "0[second]"
-		if(set_second < 10) set_second = "0[set_second]"
+	if(href_list["repeat"])
+		repeat = !repeat
 
-		var/dat = {"
-		<TT>
-			<center><h2>Timing Unit</h2>
-			[minute]:[second] <a href='?src=[UID()];time=1'>[timing?"Stop":"Start"]</a> <a href='?src=[UID()];reset=1'>Reset</a><br>
-			Repeat: <a href='?src=[UID()];repeat=1'>[repeat?"On":"Off"]</a><br>
-			Timer set for
-			<A href='?src=[UID()];tp=-30'>-</A> <A href='?src=[UID()];tp=-1'>-</A> [set_minute]:[set_second] <A href='?src=[UID()];tp=1'>+</A> <A href='?src=[UID()];tp=30'>+</A>
-			</center>
-		</TT>
-		<BR><BR>
-		<A href='?src=[UID()];refresh=1'>Refresh</A>
-		<BR><BR>
-		<A href='?src=[UID()];close=1'>Close</A>"}
-		var/datum/browser/popup = new(user, "timer", name, 400, 400)
-		popup.set_content(dat)
-		popup.open(0)
-		onclose(user, "timer")
-		return
-
-
-	Topic(href, href_list)
-		..()
-		if(!usr.canmove || usr.stat || usr.restrained() || !in_range(loc, usr))
-			usr << browse(null, "window=timer")
-			onclose(usr, "timer")
-			return
-
-		if(href_list["time"])
-			timing = !timing
-			if(timing && istype(holder, /obj/item/transfer_valve))
-				message_admins("[key_name_admin(usr)] activated [src] attachment on [holder].")
-				investigate_log("[key_name(usr)] activated [src] attachment for [loc]", INVESTIGATE_BOMB)
-				log_game("[key_name(usr)] activated [src] attachment for [loc]")
-			update_icon()
-		if(href_list["reset"])
+	if(href_list["tp"])
+		var/tp = text2num(href_list["tp"])
+		set_time += tp
+		set_time = min(max(round(set_time), 6), 600)
+		if(!timing)
 			time = set_time
 
-		if(href_list["repeat"])
-			repeat = !repeat
-
-		if(href_list["tp"])
-			var/tp = text2num(href_list["tp"])
-			set_time += tp
-			set_time = min(max(round(set_time), 6), 600)
-			if(!timing)
-				time = set_time
-
-		if(href_list["close"])
-			usr << browse(null, "window=timer")
-			return
-
-		if(usr)
-			attack_self(usr)
-
+	if(href_list["close"])
+		usr << browse(null, "window=timer")
 		return
+
+	if(usr)
+		attack_self(usr)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -41,12 +41,13 @@
 
 
 /obj/item/assembly/voice/attack_self(mob/user)
-	if(!user || !secured)	return 0
+	if(!user || !secured)
+		return FALSE
 
 	listening = !listening
 	var/turf/T = get_turf(src)
 	T.visible_message("[bicon(src)] beeps, \"[listening ? "Now" : "No longer"] recording input.\"")
-	return 1
+	return TRUE
 
 
 /obj/item/assembly/voice/toggle_secure()


### PR DESCRIPTION
List of code changes:

- Removes a tonne of useless brackets (I don't think I removed any vital ones, could be worth a look though)
- `return 1` and `return 0` are now `return TRUE` and `return FALSE`
- Puts a bunch of proc checks on new lines (i.e. 
```
if(X) return

goes to

if(X)
    return
```
- Adds helpers
- Eviscerates all colons from this code
- Goodbye implied vars, `as obj|mob` and `.0`
- Absolutely paths all devices

No CL, entirely backend