### PR TITLE
Fixes #8036

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -113,7 +113,7 @@
 						D.safe = 1
 
 	else
-		for(var/obj/machinery/door/poddoor/M in GLOB.airlocks)
+		for(var/obj/machinery/door/poddoor/M in range(range))
 			if(M.id_tag == id)
 				if(M.density)
 					spawn( 0 )


### PR DESCRIPTION
**What does this PR do:**
Fixes #8036, Door controls not respecting range for pod doors.

**Images of sprite/map changes (IF APPLICABLE):**

**Changelog:**
:cl: Mitchs98
fix: Fixes #8036, Door controls not respecting range for pod doors.
/:cl:

