### PR TITLE
Fixes #9951, RPD Pipes Not Orientating.

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -256,7 +256,7 @@
 		if(PIPE_SIMPLE_BENT, PIPE_INSULATED_BENT, PIPE_HE_BENT, PIPE_SUPPLY_BENT, PIPE_SCRUBBERS_BENT)
 			return dir //dir|acw
 		if(PIPE_CONNECTOR, PIPE_UVENT, PIPE_PASV_VENT, PIPE_SCRUBBER, PIPE_HEAT_EXCHANGE, PIPE_INJECTOR)
-			return dir
+			return dir|flip
 		if(PIPE_MANIFOLD4W, PIPE_SUPPLY_MANIFOLD4W, PIPE_SCRUBBERS_MANIFOLD4W, PIPE_OMNI_MIXER, PIPE_OMNI_FILTER)
 			return dir|flip|cw|acw
 		if(PIPE_MANIFOLD, PIPE_SUPPLY_MANIFOLD, PIPE_SCRUBBERS_MANIFOLD)
@@ -267,7 +267,7 @@
 			else
 				return flip|cw|acw
 		if(PIPE_CAP, PIPE_SUPPLY_CAP, PIPE_SCRUBBERS_CAP)
-			return dir
+			return dir|flip
 	return 0
 
 /obj/item/pipe/proc/get_pdir() //endpoints for regular pipes

--- a/code/game/objects/items/weapons/rpd.dm
+++ b/code/game/objects/items/weapons/rpd.dm
@@ -71,7 +71,7 @@
 		if(!iconrotation && P.is_bent_pipe()) //Automatically rotates dispensed pipes if the user selected auto-rotation
 			P.dir = turn(user.dir, 135)
 		else if(!iconrotation && P.pipe_type in list(PIPE_CONNECTOR, PIPE_UVENT, PIPE_SCRUBBER, PIPE_HEAT_EXCHANGE, PIPE_CAP, PIPE_SUPPLY_CAP, PIPE_SCRUBBERS_CAP, PIPE_INJECTOR, PIPE_PASV_VENT)) //Some pipes dispense oppositely to what you'd expect, but we don't want to do anything if they selected a direction
-			P.flip()
+			P.dir = turn(user.dir, -180)
 		else if(iconrotation && P.is_bent_pipe()) //If user selected a rotation and the pipe is bent
 			P.dir = turn(iconrotation, -45)
 		else if(!iconrotation) //If user selected a rotation


### PR DESCRIPTION
**What does this PR do:**
Fixes certain RPD Pipes not Orientating correctly on Orientate Automatically. 
unary vent fitting
scrubber fitting
passive vent
connector
air injector
all pipe caps (normal, supply, scrubber)

**Changelog:**
:cl: Mitchs98
fix: Unary vents, scrubbers, passive vents, connectors, air injectors, and pipe caps now orientate as intended when using Orientate Automatically with an RPD.
/:cl:

