### PR TITLE
No more magical ghosts flipping tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -274,6 +274,9 @@
 	set category = "Object"
 	set src in oview(1)
 
+	if(!can_touch(usr) || ismouse(usr))
+		return
+
 	if(!unflip())
 		to_chat(usr, "<span class='notice'>It won't budge.</span>")
 		return


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/9977

**What does this PR do:**
No longer lets the ghost unflip flipped tables.

**Changelog:**
:cl:
fix: Fixes ghosts being able to unflip flipped tables.
/:cl:

