### PR TITLE
Injecting cigs (fix?)

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -306,6 +306,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 
 /obj/item/clothing/mask/cigarette/cigar/attackby(obj/item/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/reagent_containers))
+		return
 	if(istype(W, /obj/item/match))
 		..()
 	else
@@ -371,6 +373,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 	return
 
 /obj/item/clothing/mask/cigarette/pipe/attackby(obj/item/W as obj, mob/user as mob, params)
+	if(istype(W, /obj/item/reagent_containers))
+		return
 	if(istype(W, /obj/item/match))
 		..()
 	else

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -51,7 +51,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	processing_objects -= src
 	return ..()
 
-/obj/item/clothing/mask/cigarette/attack(var/mob/living/M, var/mob/living/user, def_zone)
+/obj/item/clothing/mask/cigarette/attack(mob/living/M, mob/living/user, def_zone)
 	if(istype(M) && M.on_fire)
 		user.changeNext_move(CLICK_CD_MELEE)
 		user.do_attack_animation(M)

--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -23,6 +23,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	attack_verb = null
+	container_type = INJECTABLE
 	var/lit = FALSE
 	var/icon_on = "cigon"  //Note - these are in masks.dmi not in cigarette.dmi
 	var/icon_off = "cigoff"


### PR DESCRIPTION
Uncertain if this is an actual bug, but seems legit.
Fixes #9989 

Adds `container_type = INJECTABLE`, and prevents a lighting message showing incorrectly when injecting.

:cl: Alonefromhell
fix: Inject chems into all your favorite types of smokeables, TODAY!
/:cl:

