### PR TITLE
Colorful Reagent Changes Blood Color

### DIFF
--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -275,6 +275,13 @@
 	color = "#FFFFFF"
 	taste_message = "the rainbow"
 
+/datum/reagent/colorful_reagent/on_mob_life(mob/living/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!(NO_BLOOD in H.dna.species.species_traits) && !H.dna.species.exotic_blood)
+			H.dna.species.blood_color = "#[num2hex(rand(0, 255))][num2hex(rand(0, 255))][num2hex(rand(0, 255))]"
+	return ..()
+
 /datum/reagent/colorful_reagent/reaction_mob(mob/living/simple_animal/M, method=TOUCH, volume)
     if(isanimal(M))
         M.color = pick(random_color_list)


### PR DESCRIPTION
Idea taken from Goon.

This wasn't possible prior to making species datum non-global, but now it is!

Colorful reagent changes your blood color; now you can disguise a crime scene, ensure the clown really does bleed rainbows, or paint modern art with your own blood.

![img](https://i.gyazo.com/7e051714d8f3e530de6c02783b957349.png)

:cl: Fox McCloud
add: Colorful Reagent changes your blood color
/:cl: