### PR TITLE
Adds the Security Jacket to Security Lockers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -191,6 +191,7 @@
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/clothing/head/helmet(src)
 	new /obj/item/melee/baton/loaded(src)
+	new /obj/item/clothing/suit/armor/secjacket(src)
 
 
 /obj/structure/closet/secure_closet/brigdoc


### PR DESCRIPTION
**What does this PR do:**
Adds the Security Jacket to the Sec lockers for an alternate to the body armor. Covers more area at a trade off for less damage protection; also looks sexy. Previously the Jacket was only available VIA loadout, many probably don't know it exists. This fixes that. PurpleGenie and Ansari approved this PR also.

**Changelog:**
:cl: Mitchs98
add: Adds the Security Jacket to the standard sec gear lockers, an alternative to the standard armor vest that covers more area but protects less. Style matters.
/:cl:
