### PR TITLE
Dragging won't open containers while incapacitated

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -28,7 +28,7 @@
 	if(ishuman(usr)) //so monkeys can take off their backpacks -- Urist
 		var/mob/M = usr
 
-		if(istype(usr.loc,/obj/mecha)) // stops inventory actions in a mech
+		if(istype(usr.loc,/obj/mecha) || usr.incapacitated(FALSE, TRUE, TRUE)) // Stops inventory actions in a mech as well as while being incapacitated
 			return
 
 		if(over_object == M && Adjacent(M)) // this must come before the screen objects only block

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -28,7 +28,7 @@
 	if(ishuman(usr)) //so monkeys can take off their backpacks -- Urist
 		var/mob/M = usr
 
-		if(istype(usr.loc,/obj/mecha) || usr.incapacitated(FALSE, TRUE, TRUE)) // Stops inventory actions in a mech as well as while being incapacitated
+		if(istype(M.loc,/obj/mecha) || M.incapacitated(FALSE, TRUE, TRUE)) // Stops inventory actions in a mech as well as while being incapacitated
 			return
 
 		if(over_object == M && Adjacent(M)) // this must come before the screen objects only block


### PR DESCRIPTION
Players won't be able to open any containers while while incapacitated, with dragging the container onto them.
fixes: #7950

**Changelog:**
:cl: Normalyman
fix: Fixed being able to open containers via dragging, while being incapacitated.
/:cl:

