### PR TITLE
Fixes the runtime in the piano init

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -296,7 +296,8 @@
 	return ..()
 
 /obj/structure/piano/Initialize()
-	song.tempo = song.sanitize_tempo(song.tempo) // tick_lag isn't set when the map is loaded
+	if(song)
+		song.tempo = song.sanitize_tempo(song.tempo) // tick_lag isn't set when the map is loaded
 	..()
 
 /obj/structure/piano/attack_hand(mob/user as mob)


### PR DESCRIPTION
**What does this PR do:**
Checks if the song is set. If not well don't use it.

fixes: #9998

**Changelog:**
:cl: Farie82
fix: One less piano runtime
/:cl:

