### PR TITLE
No more runtime when you get an unsimulated tile

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -276,7 +276,8 @@
 /obj/effect/landmark/damageturf/New()
 	..()
 	var/turf/simulated/T = get_turf(src)
-	T.break_tile()
+	if(istype(T))
+		T.break_tile()
 
 /obj/effect/landmark/burnturf
 	icon_state = "burned"


### PR DESCRIPTION
**What does this PR do:**
Seems a turf can have an unsimulated tile. Welp it's fixed now.
Might have something to do with the way the map is made. So mappers if you want something broken use a simulated tile or one with a broken sprite.

fixes: #9735

**Changelog:**
:cl: Farie82
fix: Fixes the runtime in Landmarks
/:cl:

