### PR TITLE
Fix for Airlocks Shocking Remotely

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -55,9 +55,12 @@ var/const/AIRLOCK_WIRE_LIGHT = 512
 /datum/wires/airlock/CanUse(mob/living/L)
 	var/obj/machinery/door/airlock/A = holder
 	if(iscarbon(L))
-		if(A.isElectrified())
-			if(A.shock(L, 100))
-				return 0
+		if(A.x - L.x <= 1 && A.x - L.x >= -1 && A.y - L.y <= 1 && A.y - L.y >= -1)
+			if(A.isElectrified())
+				if(A.shock(L, 100))
+					return 0
+		else
+			return 0
 	if(A.panel_open)
 		return 1
 	return 0

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -55,12 +55,10 @@ var/const/AIRLOCK_WIRE_LIGHT = 512
 /datum/wires/airlock/CanUse(mob/living/L)
 	var/obj/machinery/door/airlock/A = holder
 	if(iscarbon(L))
-		if(A.x - L.x <= 1 && A.x - L.x >= -1 && A.y - L.y <= 1 && A.y - L.y >= -1)
+		if(A.Adjacent(L))
 			if(A.isElectrified())
 				if(A.shock(L, 100))
 					return 0
-		else
-			return 0
 	if(A.panel_open)
 		return 1
 	return 0


### PR DESCRIPTION
**What does this PR do:**
Previously electrified airlocks had no adjacency check, only UI.
This led to remote, sometimes repeated, electrocutions if you moved away with UI still open.
The change ensures only players adjacent to the airlock can be electrocuted.
Everything was tested locally and works as intended.

**Changelog:**
:cl: gatchapod
fix: Fixed airlocks electrocuting people remotely through open UI
/:cl: