### PR TITLE
Made the round start time variable using the config.txt

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -22,6 +22,7 @@
 	var/log_hrefs = 0					// logs all links clicked in-game. Could be used for debugging and tracking down exploits
 	var/sql_enabled = 0					// for sql switching
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
+	var/pregame_timestart = 240			// Time it takes for the server to start the game
 	var/allow_vote_restart = 0 			// allow votes to restart
 	var/allow_vote_mode = 0				// allow votes to change mode
 	var/vote_delay = 6000				// minimum time between voting sessions (deciseconds, 10 minute default)
@@ -332,6 +333,9 @@
 
 				if("allow_admin_ooccolor")
 					config.allow_admin_ooccolor = 1
+
+				if("pregame_timestart")
+					config.pregame_timestart = text2num(value)
 
 				if("allow_vote_restart")
 					config.allow_vote_restart = 1

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -29,7 +29,6 @@ var/round_start_time = 0
 	var/list/availablefactions = list()	  // list of factions with openings
 
 	var/pregame_timeleft = 0
-
 	var/delay_end = 0	//if set to nonzero, the round will not restart on it's own
 
 	var/triai = 0//Global holder for Triumvirate
@@ -48,7 +47,7 @@ var/round_start_time = 0
 	'sound/music/Title2.ogg',\
 	'sound/music/Title3.ogg',)
 	do
-		pregame_timeleft = 180
+		pregame_timeleft = config.pregame_timestart
 		to_chat(world, "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>")
 		to_chat(world, "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds")
 		while(current_state == GAME_STATE_PREGAME)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -113,6 +113,9 @@ ALLOW_ADMIN_OOCCOLOR
 ## If metadata is supported
 ALLOW_METADATA
 
+## The time it takes for a round to start in seconds
+PREGAME_TIMESTART 240
+
 ## allow players to initiate a restart vote
 #ALLOW_VOTE_RESTART
 


### PR DESCRIPTION
**What does this PR do:**
The round start time is now variable in the config.txt
Requested by @Necaladun 

**Changelog:**
:cl: Farie82
add: Round start time is now variable. Defaults to 240 if not filled in
/:cl:

