### PR TITLE
Two mech bug fixes (deletion runtime and speech bubbles)

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -31,19 +31,13 @@
 
 /obj/item/mecha_parts/mecha_equipment/Destroy()//missiles detonating, teleporter creating singularity?
 	if(chassis)
-		detach(chassis)
-		chassis.equipment -= src
-		listclearnulls(chassis.equipment)
-		if(chassis.selected == src)
-			chassis.selected = null
-		src.update_chassis_page()
 		chassis.occupant_message("<span class='danger'>The [src] is destroyed!</span>")
 		chassis.log_append_to_last("[src] is destroyed.",1)
 		if(istype(src, /obj/item/mecha_parts/mecha_equipment/weapon))
 			chassis.occupant << sound('sound/mecha/weapdestr.ogg', volume = 50)
 		else
 			chassis.occupant << sound('sound/mecha/critdestr.ogg', volume = 50)
-		chassis = null
+		detach(chassis)
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/proc/critfail()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -274,7 +274,7 @@ proc/get_radio_key_from_channel(var/channel)
 	spawn(0)
 		if(loc && !isturf(loc))
 			var/atom/A = loc //Non-turf, let it handle the speech bubble
-			A.speech_bubble("hR[speech_bubble_test]", A.loc, speech_bubble_recipients)
+			A.speech_bubble("hR[speech_bubble_test]", A, speech_bubble_recipients)
 		else //Turf, leave speech bubbles to the mob
 			speech_bubble("h[speech_bubble_test]", src, speech_bubble_recipients)
 


### PR DESCRIPTION
Fixes #7227
~~Fixes #7478~~
Fixes #3187

**Changelog:**
:cl: Squirgenheimer
fix: Deleting mechs no longer causes a runtime
fix: Mech speech bubbles should now follow the mech.
/:cl:

Edit: removed changes to attack logging
