### PR TITLE
fixed number of mining satchel slots

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -135,7 +135,7 @@
 	origin_tech = "engineering=2"
 	slot_flags = SLOT_BELT | SLOT_POCKET
 	w_class = WEIGHT_CLASS_NORMAL
-	storage_slots = 50
+	storage_slots = 10
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
 	max_w_class = WEIGHT_CLASS_NORMAL
 	can_hold = list(/obj/item/stack/ore)


### PR DESCRIPTION
fixes #10030
**Changelog:**
:cl: Squirgenheimer
fix: regular mining satchels will now only hold 10 slots of ore stacks instead of 50
/:cl:

