### PR TITLE
Mechs now can't be spam repaired

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -43,8 +43,6 @@
 	var/lights_power = 6
 	var/emagged = FALSE
 
-	var/list/repairers = new
-
 	//inner atmos
 	var/use_internal_tank = 0
 	var/internal_tank_valve = ONE_ATMOSPHERE
@@ -778,22 +776,16 @@
 
 	else if(iswelder(W) && user.a_intent != INTENT_HARM)
 		var/obj/item/weldingtool/WT = W
-		if(health<initial(health))
-			if (WT.remove_fuel(0,user))
-				if(!(user in repairers)) // Can only repair it once at a time
-					repairers += user
-					user.visible_message("<span class='notice'>[user] starts repairing some damage to [name].</span>", "<span class='notice'>You start repairing some damage to [name]</span>")
-					playsound(user, WT.usesound, 50, 1)
-					if(do_after(user, 15 * WT.toolspeed, target = src)) // Takes 1.5 seconds to repair
-						if (internal_damage & MECHA_INT_TANK_BREACH)
-							clearInternalDamage(MECHA_INT_TANK_BREACH)
-							user.visible_message("<span class='notice'>[user] repairs the damaged gas tank.</span>", "<span class='notice'>You repair the damaged gas tank.</span>")
-						else
-							user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [name]</span>")
-							health += min(20, initial(health)-health)
-					repairers -= user
-				else
-					to_chat(user, "<span class='warning'>You are already repairing [name]!</span>")
+		if(health < initial(health))
+			if(WT.remove_fuel(0,user))
+				user.visible_message("<span class='notice'>[user] starts repairing some damage to [name].</span>", "<span class='notice'>You start repairing some damage to [name]</span>")
+				if(do_after_once(user, 15 * WT.toolspeed, target = src, attempt_cancel_message = "You stop repairing [name]."))
+					if(internal_damage & MECHA_INT_TANK_BREACH)
+						clearInternalDamage(MECHA_INT_TANK_BREACH)
+						user.visible_message("<span class='notice'>[user] repairs the damaged gas tank.</span>", "<span class='notice'>You repair the damaged gas tank.</span>")
+					else
+						user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [name].</span>")
+						health += min(20, initial(health) - health)
 			else
 				to_chat(user, "<span class='warning'>The welder must be on for this task!</span>")
 		else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -43,6 +43,8 @@
 	var/lights_power = 6
 	var/emagged = FALSE
 
+	var/list/repairers = new
+
 	//inner atmos
 	var/use_internal_tank = 0
 	var/internal_tank_valve = ONE_ATMOSPHERE
@@ -778,15 +780,22 @@
 		var/obj/item/weldingtool/WT = W
 		if(health<initial(health))
 			if (WT.remove_fuel(0,user))
-				if (internal_damage & MECHA_INT_TANK_BREACH)
-					clearInternalDamage(MECHA_INT_TANK_BREACH)
-					to_chat(user, "<span class='notice'>You repair the damaged gas tank.</span>")
+				if(!(user in repairers)) // Can only repair it once at a time
+					repairers += user
+					user.visible_message("<span class='notice'>[user] starts repairing some damage to [name].</span>", "<span class='notice'>You start repairing some damage to [name]</span>")
+					playsound(user, WT.usesound, 50, 1)
+					if(do_after(user, 15 * WT.toolspeed, target = src)) // Takes 1.5 seconds to repair
+						if (internal_damage & MECHA_INT_TANK_BREACH)
+							clearInternalDamage(MECHA_INT_TANK_BREACH)
+							user.visible_message("<span class='notice'>[user] repairs the damaged gas tank.</span>", "<span class='notice'>You repair the damaged gas tank.</span>")
+						else
+							user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [name]</span>")
+							health += min(10, initial(health)-health)
+					repairers -= user
 				else
-					user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>")
-					health += min(10, initial(health)-health)
+					to_chat(user, "<span class='warning'>You are already repairing [name]!</span>")
 			else
 				to_chat(user, "<span class='warning'>The welder must be on for this task!</span>")
-				return 1
 		else
 			to_chat(user, "<span class='warning'>The [name] is at full integrity!</span>")
 		return 1

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -777,7 +777,7 @@
 	else if(iswelder(W) && user.a_intent != INTENT_HARM)
 		var/obj/item/weldingtool/WT = W
 		if(health < initial(health))
-			if(WT.remove_fuel(0,user))
+			if(WT.remove_fuel(0, user))
 				user.visible_message("<span class='notice'>[user] starts repairing some damage to [name].</span>", "<span class='notice'>You start repairing some damage to [name]</span>")
 				if(do_after_once(user, 15 * WT.toolspeed, target = src, attempt_cancel_message = "You stop repairing [name]."))
 					if(internal_damage & MECHA_INT_TANK_BREACH)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -790,7 +790,7 @@
 							user.visible_message("<span class='notice'>[user] repairs the damaged gas tank.</span>", "<span class='notice'>You repair the damaged gas tank.</span>")
 						else
 							user.visible_message("<span class='notice'>[user] repairs some damage to [name].</span>", "<span class='notice'>You repair some damage to [name]</span>")
-							health += min(10, initial(health)-health)
+							health += min(20, initial(health)-health)
 					repairers -= user
 				else
 					to_chat(user, "<span class='warning'>You are already repairing [name]!</span>")


### PR DESCRIPTION
**What does this PR do:**
Mechs now need time to be repaired and you can only repair it once per ... well repair. No spam repairing anymore
Every repair costs 1.5 seconds now.

fixes: #10041

**Changelog:**
:cl: Farie82
tweak: Repairing a mech now says you're doing it to the others
balance: Mechs now take time to repair. No more spam repairing
/:cl:

