### PR TITLE
Items dropped in a pod will now stay in the pod.

### DIFF
--- a/code/modules/spacepods/spacepod.dm
+++ b/code/modules/spacepods/spacepod.dm
@@ -199,6 +199,9 @@
 		deal_damage(P.damage)
 	P.on_hit(src)
 
+/obj/spacepod/AllowDrop()
+	return TRUE
+
 /obj/spacepod/blob_act()
 	deal_damage(30)
 	return


### PR DESCRIPTION
**What does this PR do:**
If you rest or go unconsious in a pod you now drop the items held in the pod.

fixes: #10050

**Changelog:**
:cl: Farie82
fix: Items dropped in a space pod are now under the seat. No more magical dropping out of the pod
/:cl:

