### PR TITLE
Adds speech impediment handling to megaphones

### DIFF
--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -47,6 +47,7 @@
 	message = sanitize(copytext(message, 1, MAX_MESSAGE_LEN))
 	if(!message)
 		return
+	message = user.handle_speech_problems(message)[1]
 	message = capitalize(message)
 	if((loc == user && !user.incapacitated()))
 		if(emagged)


### PR DESCRIPTION
**What does this PR do:**
Fixes the issue #10052 that pointed out drunken slurring did not happen with a megaphone. This makes it so all speech impediments are properly handled, slurring, studdering etc when using a megaphone.

**Changelog:**
:cl: Warior4356
fix: Megaphone now handle speech impediments properly
/:cl:

