### PR TITLE
Solves ghosts re-entering shutdown drones by making the ghost unable to reenter corpses

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -223,6 +223,10 @@
 	health = 35 - (getBruteLoss() + getFireLoss())
 	update_stat("updatehealth([reason])")
 
+/mob/living/silicon/robot/drone/death(gibbed)
+	. = ..(gibbed)
+	ghostize(can_reenter_corpse = 0)
+
 
 //CONSOLE PROCS
 /mob/living/silicon/robot/drone/proc/law_resync()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -243,7 +243,7 @@
 		return
 
 	to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, and you obediently destroy yourself.</span>")
-	gib()
+	death()
 
 /mob/living/silicon/robot/drone/proc/full_law_reset()
 	clear_supplied_laws()

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -243,7 +243,7 @@
 		return
 
 	to_chat(src, "<span class='warning'>You feel a system kill order percolate through your tiny brain, and you obediently destroy yourself.</span>")
-	death()
+	gib()
 
 /mob/living/silicon/robot/drone/proc/full_law_reset()
 	clear_supplied_laws()


### PR DESCRIPTION
**What does this PR do:**
When a drone dies the player is ghosted and is tagged with the inability to enter the corpse. There is a small "quirk" in this fix. You are unable to join as a golem or posibrain. I am open to suggestions on better ways to fix this. 

**Changelog:**
:cl: Warior4356
fix: Ghosts can no longer re-enter a drone that has been shut down.
/:cl:

