### PR TITLE
Fixes ID based runtime on shutting down drones

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -132,7 +132,7 @@
 				to_chat(user, "<span class='warning'>The interface is fried, and a distressing burned smell wafts from the robot's interior. You're not rebooting this one.</span>")
 				return
 
-			if(!allowed(usr))
+			if(!allowed(W))
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 				return
 
@@ -158,7 +158,7 @@
 			if(emagged)
 				return
 
-			if(allowed(usr))
+			if(allowed(W))
 				shut_down()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")


### PR DESCRIPTION
**What does this PR do:**
Fixes the issue in #10035 and stops the runtime, it was a case of two procs with the same name but different definitions. Someone implemented the wrong proc at some point, it's an easy mistake to make.

**Changelog:**
:cl: Warior4356
fix: Swiping an ID through a drone no longer causes a runtime and correctly shuts it down
/:cl:

