### PR TITLE
Fixes silicons pressing door buttons and doors not opening

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -82,7 +82,7 @@
 	add_fingerprint(user)
 
 	if(normaldoorcontrol)
-		for(var/obj/machinery/door/airlock/D in range(range))
+		for(var/obj/machinery/door/airlock/D in range(range, src))
 			if(D.id_tag == id)
 				if(specialfunctions & OPEN)
 					if(D.density)
@@ -113,7 +113,7 @@
 						D.safe = 1
 
 	else
-		for(var/obj/machinery/door/poddoor/M in range(range))
+		for(var/obj/machinery/door/poddoor/M in range(range, src))
 			if(M.id_tag == id)
 				if(M.density)
 					spawn( 0 )


### PR DESCRIPTION
**What does this PR do:**
Fixes the issue in #10060 by telling the button to measure range from the button, not the mob pushing it.
The proc in question is **range(dist, center = user)** and in this case, they forgot about the defaulting center argument, so the door button measured from the usr. With an organic it was fine, but with a silicon they were often too far away.


**Changelog:**
:cl: Warior4356
fix: Silicons are now able to open a door linked to a button regardless of proximity
/:cl:

