### PR TITLE
Paper Bundles No Longer Automatically Display Their Contents

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -71,7 +71,8 @@
 
 
 	update_icon()
-	attack_self(usr) //Update the browsed page.
+	if(winget(usr, "[name]", "is-visible") == "true") // NOT MY FAULT IT IS A BUILT IN PROC PLEASE DO NOT HIT ME
+		attack_self(usr) //Update the browsed page.
 	add_fingerprint(usr)
 	return
 


### PR DESCRIPTION
fixes #10022

:cl:
fix: Adding a paper to a paper bundle no longer automatically opens the bundle.
/:cl:

