### PR TITLE
Contraband Descriptions [WIP]

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -910,7 +910,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/stealthy_tools/agent_card
 	name = "Agent ID Card"
-	desc = "Agent cards prevent artificial intelligences from tracking the wearer, and can copy access from other identification cards. The access is cumulative, so scanning one card does not erase the access gained from another."
+	desc = "Agent cards allow the wearer to forge identities, and can copy access from other identification cards. The access is cumulative, so scanning one card does not erase the access gained from another."
 	reference = "AIDC"
 	item = /obj/item/card/id/syndicate
 	cost = 2

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -85,7 +85,7 @@
 	if(opacity && isturf(loc))
 		var/turf/T = loc
 		T.has_opaque_atom = TRUE // No need to recalculate it in this case, it's guranteed to be on afterwards anyways.
-	
+
 	if(loc)
 		loc.InitializedOn(src) // Used for poolcontroller / pool to improve performance greatly. However it also open up path to other usage of observer pattern on turfs.
 

--- a/code/game/objects/items/dehy_carp.dm
+++ b/code/game/objects/items/dehy_carp.dm
@@ -7,6 +7,7 @@
 /obj/item/toy/carpplushie/dehy_carp
 	var/mob/owner = null	// Carp doesn't attack owner, set when using in hand
 	var/owned = 1	// Boolean, no owner to begin with
+	antag_hints = "<span class='traitorhint'>It conceals a real, live space carp. Just add water.</span>"
 
 
 /obj/item/toy/carpplushie/dehy_carp/Destroy()

--- a/code/game/objects/items/devices/pizza_bomb.dm
+++ b/code/game/objects/items/devices/pizza_bomb.dm
@@ -10,6 +10,7 @@
 	var/wires = list("orange", "green", "blue", "yellow", "aqua", "purple")
 	var/correct_wire
 	var/armer //Used for admin purposes
+	antag_hints = "<span class='traitorhint'>It conceals an explosive charge. Open it to set the explsive, then leave it somewhere conspicuous.</span>"
 
 /obj/item/pizza_bomb/attack_self(mob/user)
 	if(disarmed)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -89,6 +89,7 @@ effective or pretty fucking useless.
 	var/intensity = 5 // how much damage the radiation does
 	var/wavelength = 10 // time it takes for the radiation to kick in, in seconds
 	var/used = 0 // is it cooling down?
+	antag_hints = "<span class='traitorhint'>Scanning someone with this will bathe them with a time-delayed radiation blast.</span>"
 
 /obj/item/rad_laser/attack(mob/living/M, mob/living/user)
 	if(!used)

--- a/code/game/objects/items/weapons/caution.dm
+++ b/code/game/objects/items/weapons/caution.dm
@@ -14,11 +14,12 @@
 	var/timing = 0
 	var/armed = 0
 	var/timepassed = 0
+	antag_hints = "<span class='traitorhint'>This sign has a powerful microexplosive attached to a proximity sensor. Once activated, walk to avoid triggering it.</span>"
 
 /obj/item/caution/proximity_sign/attack_self(mob/user as mob)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.mind.assigned_role != "Janitor")
+		if(H.mind.special_role != SPECIAL_ROLE_TRAITOR) // We like to be able to use your surplus crate gear, thanks!
 			return
 		if(armed)
 			armed = 0

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -107,6 +107,7 @@
 
 /obj/item/dice/d20/e20
 	var/triggered = 0
+	antag_hints = "<span class='traitorhint'>This die conceals a small explosive held in quantum uncertainty. Rolling it collapses the superposition and possibly the building you are in.</span>"
 
 /obj/item/dice/attack_self(mob/user as mob)
 	diceroll(user)

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -12,6 +12,7 @@
 	var/mob/living/carbon/human/strangling
 	var/improvised = 0
 	var/garrote_time
+	antag_hints = "<span class='traitorhint'>Classic. I'd need to be behind someone to use this effectively. Obviously, this won't be very effective if my target doesn't breathe.</span>"
 
 /obj/item/twohanded/garrote/Destroy()
 	strangling = null

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -149,6 +149,7 @@
 	desc = "A huge thing used for chopping and chopping up meat. This includes clowns and clown-by-products."
 	force = 25.0
 	throwforce = 15.0
+	antag_hints = "<span class='traitorhint'>You could easily butcher a person with this thing.</span>"
 
 /obj/item/kitchen/knife/combat
 	name = "combat knife"

--- a/code/game/objects/items/weapons/scissors.dm
+++ b/code/game/objects/items/weapons/scissors.dm
@@ -97,6 +97,7 @@
 	desc = "The blades of the scissors appear to be made of some sort of ultra-strong metal alloy."
 	force = 18 //same as e-daggers
 	var/is_cutting = 0 //to prevent spam clicking this for huge accumulation of losebreath.
+	antag_hints = "<span class='traitorhint'>It has been modified for easy throat-slitting. I could also use these on help intent to give a regular haircut.</span>"
 
 /obj/item/scissors/safety/attack(mob/living/carbon/M as mob, mob/user as mob)
 	if(user.a_intent != INTENT_HELP)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -107,3 +107,4 @@
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
 	icon_state = "soapsyndie"
 	cleanspeed = 10 //much faster than mop so it is useful for traitors who want to clean crime scenes
+	antag_hints = "<span class='traitorhint'>It is perfect for cleaning up after a messy situation - and removing fingerprints.</span>"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -458,6 +458,7 @@
 	name = "box of donk-pockets"
 	desc = "This box feels slightly warm"
 	icon_state = "donk_kit"
+	antag_hints = "<span class='traitorhint'>You notice these were distributed by a Syndicate subsidiary. They probably pack a punch.</span>"
 
 	New()
 		..()

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -719,6 +719,7 @@
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/charged = 1
+	antag_hints = "<span class='traitorhint'>I could recharge this by breaking windows and grilles.</span>"
 
 /obj/item/twohanded/energizedfireaxe/update_icon()
 	if(wielded)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -30,6 +30,9 @@
 	var/on_blueprints = FALSE //Are we visible on the station blueprints at roundstart?
 	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
 
+	var/antag_hints
+	var/antags_get_hints = list(SPECIAL_ROLE_NUKEOPS, SPECIAL_ROLE_TRAITOR, SPECIAL_ROLE_SYNDICATE_DEATHSQUAD, SPECIAL_ROLE_CHANGELING, SPECIAL_ROLE_VAMPIRE)
+
 /obj/New()
 	..()
 	if(!armor)
@@ -42,6 +45,16 @@
 			T.add_blueprints(src)
 		else
 			T.add_blueprints_preround(src)
+
+/obj/proc/get_antag_hints(mob/user)
+	if(antag_hints && user.mind && user.mind.special_role in antags_get_hints)
+		to_chat(user, antag_hints)
+		return 1
+	return 0
+
+/obj/examine(mob/user)
+	. = ..()
+	get_antag_hints(user)
 
 /obj/Topic(href, href_list, var/nowindow = 0, var/datum/topic_state/state = default_state)
 	// Calling Topic without a corresponding window open causes runtime errors

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -94,6 +94,7 @@
 	name = "Chameleon Security HUD"
 	desc = "A stolen security HUD integrated with Syndicate chameleon technology. Toggle to disguise the HUD. Provides flash protection."
 	flash_protect = 1
+	antag_hints = "<span class='traitorhint'>It has a concealed security HUD and chameleon module.</span>"
 
 /obj/item/clothing/glasses/hud/security/chameleon/attack_self(mob/user)
 	chameleon(user)

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -9,9 +9,9 @@
 	burn_state = FIRE_PROOF
 
 /obj/item/clothing/gloves/color/yellow/power
-	description_antag = "These are a pair of power gloves, and can be used to fire bolts of electricity while standing over powered power cables."
 	var/old_mclick_override
 	var/datum/middleClickOverride/power_gloves/mclick_override = new /datum/middleClickOverride/power_gloves
+	antag_hints = "<span class='traitorhint'>These gloves have a set of hyperconductive threads woven into them. Use MMB while standing on a wire to arc flash your target.</span>"
 
 /obj/item/clothing/gloves/color/yellow/power/equipped(mob/user, slot)
 	if(!ishuman(user))
@@ -73,6 +73,7 @@
 
 /obj/item/clothing/gloves/color/black/thief
 	pickpocket = 1
+	antag_hints = "<span class='traitorhint'>These gloves would let you pick pockets without anyone noticing.</span>"
 
 /obj/item/clothing/gloves/color/black/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/wirecutters))

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -765,6 +765,7 @@
 	item_state = "atmos_suit"
 	item_color = "atmos"
 	burn_state = FIRE_PROOF
+	antag_hints = "<span class='traitorhint'>This jumpsuit would let you contort into vents and other tight spaces.</span>"
 
 /obj/item/clothing/under/contortionist/equipped(mob/living/carbon/human/user, slot)
 	if(!user.ventcrawler)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -125,7 +125,13 @@
 /obj/item/pen/sleepy
 	container_type = OPENCONTAINER
 	origin_tech = "engineering=4;syndicate=2"
+	antag_hints = "<span class='traitorhint'>It conceals a hypospray and a chemical cartridge for discretely delivering poisons.</span>"
 
+
+/obj/item/pen/sleepy/get_antag_hints(mob/user)
+	. = ..()
+	if(.)
+		to_chat(user, "<span class='traitorhint'>[src] has [reagents.total_volume] units remaining.")
 
 /obj/item/pen/sleepy/attack(mob/living/M, mob/user)
 	if(!istype(M))	return
@@ -151,6 +157,7 @@
 	var/on = 0
 	var/brightness_on = 2
 	light_color = LIGHT_COLOR_RED
+	antag_hints = "<span class='traitorhint'>It conceals a small energy blade emitter.</span>"
 
 /obj/item/pen/edagger/attack_self(mob/living/user)
 	if(on)
@@ -192,6 +199,12 @@
 
 /obj/item/pen/poison
 	var/uses_left = 3
+	antag_hints = "<span class='traitorhint'>It has a small poison cartridge concealed inside of it. Writing with it will apply a contact poison to the paper.</span>"
+
+/obj/item/pen/poison/get_antag_hints(mob/user)
+	. = ..()
+	if(.)
+		to_chat(user, "<span class='traitorhint>[src] has [uses_left] doses of poison left.")
 
 /obj/item/pen/poison/on_write(obj/item/paper/P, mob/user)
 	if(P.contact_poison_volume)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -381,6 +381,7 @@
 	fire_sound = 'sound/weapons/Gunshot_silenced.ogg'
 	suppressed = 1
 	needs_permit = 0 //its just a cane beepsky.....
+	antag_hints = "<span class='traitorhint'>This cane is a cleverly disguised shotgun.</span>"
 
 /obj/item/gun/projectile/revolver/doublebarrel/improvised/cane/is_crutch()
 	return 1
@@ -392,6 +393,11 @@
 	..()
 	if(istype(A, /obj/item/stack/cable_coil))
 		return
+
+/obj/item/gun/projectile/revolver/doublebarrel/improvised/cane/get_antag_hints(mob/user)
+	. = ..()
+	if(.)
+		to_chat(user, "<span class='traitorhint'>Has [get_ammo()] round\s remaining.</span>")
 
 /obj/item/gun/projectile/revolver/doublebarrel/improvised/cane/examine(mob/user) // HAD TO REPEAT EXAMINE CODE BECAUSE GUN CODE DOESNT STEALTH
 	var/f_name = "\a [src]."
@@ -406,3 +412,4 @@
 
 	if(desc)
 		to_chat(user, desc)
+	get_antag_hints(user) // God this examine code is awful. I'll come back to fix you one day, I promise.

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -37,7 +37,7 @@ a.popt {text-decoration: none;}
 * CUSTOM FONTS
 *
 ******************************************/
-@font-face { font-family: PxPlus IBM MDA; src: url('PxPlus_IBM_MDA.ttf'); } 
+@font-face { font-family: PxPlus IBM MDA; src: url('PxPlus_IBM_MDA.ttf'); }
 
 /*****************************************
 *
@@ -341,6 +341,7 @@ h1.alert, h2.alert			{color: #000000;}
 .drask					{color: #a3d4eb; font-family: "Arial Black";}
 .clown					{color: #ff0000;}
 .shadowling				{color: #3b2769;}
+.traitorhint			{color: #800000; font-stye: italic;}
 .vulpkanin				{color: #B97A57;}
 .abductor				{color: #800080; font-style: italic;}
 .mind_control				{color: #A00D6F; font-size: 3; font-weight: bold; font-style: italic;}


### PR DESCRIPTION
System currently WIP, but I've put all the time I can into it tonight. Will update the PR as soon as I can.

Adds a system where antags of certain types can see secret descriptions on arbitrary items. Used here to convey extra information to the traitor regarding traitor items. The intent here is to give a traitor basic QoL features (Discretely checking if a cane shotgun is loaded, seeing how much is left in a sleepypen, checking what your voice changer is set to, etc) or useful advice about the item (How to avoid the janitor's explosive signs, the proper procedure for arming a pizza bomb, that a garrote has to be used from behind, etc).

Hopefully this improves the quality of the game for everyone and helps new traitors have less frustrating deaths.

To Do:
- [ ] Finish writing descriptions.
- [ ] Make the descriptions tonally consistent.
- [ ] Possibly expand this to other antags.

:cl:
add: Traitor items now have special descriptions only visible to traitors, usually helpful hints or useful information about the item.
/:cl:

