### PR TITLE
Fixes adjacency issues with merch shop, arcade shop and give command

### DIFF
--- a/code/game/machinery/computer/store.dm
+++ b/code/game/machinery/computer/store.dm
@@ -145,6 +145,9 @@ th.cost.toomuch {background:maroon;}
 		var/itemID = text2num(href_list["buy"])
 		var/datum/storeitem/item = centcomm_store.items[itemID]
 		var/sure = alert(usr,"Are you sure you wish to purchase [item.name] for $[item.cost]?","You sure?","Yes","No") in list("Yes","No")
+		if(!Adjacent(usr))
+			to_chat(usr, "<span class='warning'>You are not close enough to do that.</span>")
+			return
 		if(sure=="No")
 			updateUsrDialog()
 			return

--- a/code/modules/arcade/prize_datums.dm
+++ b/code/modules/arcade/prize_datums.dm
@@ -9,6 +9,9 @@ var/global/datum/prizes/global_prizes = new
 		prizes += new itempath()
 
 /datum/prizes/proc/PlaceOrder(var/obj/machinery/prize_counter/prize_counter, var/itemID)
+	if(!prize_counter.Adjacent(usr))
+		to_chat(usr, "<span class='warning'>You need to be closer!</span>")
+		return
 	if(!prize_counter)
 		return 0
 	var/datum/prize_item/item = global_prizes.prizes[itemID]

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -29,7 +29,7 @@
 			if("Yes")
 				if(!I)
 					return
-				if(!Adjacent(usr))
+				if(!Adjacent(target))
 					to_chat(usr, "<span class='warning'> You need to stay in reaching distance while giving an object.</span>")
 					to_chat(target, "<span class='warning'> [usr.name] moved too far away.</span>")
 					return


### PR DESCRIPTION
**What does this PR do:**
Added an adjacency check to the merch shop and arcade shop so that you can't use them from a distance now, also changed the give command to check adjacency of the target.


**Changelog:**
:cl: TatsumakiMagi
fix: fixed merch shop, arcade shop and the give command working from a distance 
/:cl:

Fixes #10039 

