### PR TITLE
Updates desciption on illegal borg upgrades

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -207,7 +207,7 @@
 
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
-	desc = "Unlocks the hidden, deadlier functions of a cyborg"
+	desc = "Unlocks the hidden, deadlier functions of a cyborg. As well as prevent any emag tampering."
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "combat=4;syndicate=1"
 	require_module = 1

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -207,7 +207,7 @@
 
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
-	desc = "Unlocks the hidden, deadlier functions of a cyborg. As well as prevent any emag tampering."
+	desc = "Unlocks the hidden, deadlier functions of a cyborg. Also prevents emag subversion."
 	icon_state = "cyborg_upgrade3"
 	origin_tech = "combat=4;syndicate=1"
 	require_module = 1


### PR DESCRIPTION
Hello. This small PR updates the desciption of the illegal borg module to,

`desc = "Unlocks the hidden, deadlier functions of a cyborg. Also prevents emag subversion."`

This is to make it more obvious that illegal modules prevent emags. I plan to make another PR here later to make that not the case, but since that has balance implications, I think just updating the desciption is enough for the moment.

🆑 Shazbot194
change: The illegal borg module now says it blocks emags.
/🆑 