### PR TITLE
Mechs can now drill mechs

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -15,7 +15,7 @@
 		return
 	if(isobj(target))
 		var/obj/target_obj = target
-		if(target_obj.unacidable)
+		if(target_obj.unacidable && !istype(target_obj, /obj/mecha))
 			return
 	target.visible_message("<span class='warning'>[chassis] starts to drill [target].</span>",
 					"<span class='userdanger'>[chassis] starts to drill [target]...</span>",


### PR DESCRIPTION
**What does this PR do:**
Adds an exception to the mecha drill to allow it to drill mechs. Fixes #3353

Other fix option in #10072 close the fix you dont want.

**Changelog:**
:cl: Wario4356
fix: Mecha can now drill other mecha
/:cl:

