### PR TITLE
Allows slimes to regrow limbs with both legs removed

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -316,7 +316,7 @@ This is always put in the attack log.
 	if(progress)
 		qdel(progbar)
 
-/proc/do_after(mob/user, delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null)
+/proc/do_after(mob/user, delay, needhand = 1, atom/target = null, progress = 1, datum/callback/extra_checks = null, can_be_weakened = 0)
 	if(!user)
 		return 0
 	var/atom/Tloc = null
@@ -351,7 +351,7 @@ This is always put in the attack log.
 			drifting = 0
 			Uloc = user.loc
 
-		if(!user || user.stat || user.weakened || user.stunned  || (!drifting && user.loc != Uloc)|| (extra_checks && !extra_checks.Invoke()))
+		if(!user || user.stat || (user.weakened && !can_be_weakened) || user.stunned  || (!drifting && user.loc != Uloc)|| (extra_checks && !extra_checks.Invoke()))
 			. = 0
 			break
 

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -130,8 +130,8 @@
 	var/chosen_limb = missing_limbs[limb_select]
 
 	H.visible_message("<span class='notice'>[H] begins to hold still and concentrate on [H.p_their()] missing [limb_select]...</span>", "<span class='notice'>You begin to focus on regrowing your missing [limb_select]... (This will take [round(SLIMEPERSON_REGROWTHDELAY/10)] seconds, and you must hold still.)</span>")
-	if(do_after(H, SLIMEPERSON_REGROWTHDELAY, needhand = 0, target = H))
-		if(H.incapacitated())
+	if(do_after(H, SLIMEPERSON_REGROWTHDELAY, needhand = 0, target = H, can_be_weakened = 1))
+		if(H.incapacitated(ignore_lying = TRUE, ignore_weakened = TRUE))
 			to_chat(H, "<span class='warning'>You cannot regenerate missing limbs in your current state.</span>")
 			return
 

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -65,8 +65,8 @@
 	return !(weakened || paralysis || stat || (status_flags & FAKEDEATH))
 
 // Whether the mob is capable of actions or not
-/mob/living/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE, ignore_lying = FALSE)
-	if(stat || paralysis || stunned || weakened || (!ignore_restraints && restrained()) || (!ignore_lying && lying))
+/mob/living/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE, ignore_lying = FALSE, ignore_weakened = FALSE)
+	if(stat || paralysis || stunned || (!ignore_weakened && weakened) || (!ignore_restraints && restrained()) || (!ignore_lying && lying))
 		return TRUE
 
 // wonderful proc names, I know - used to check whether the blur overlay


### PR DESCRIPTION
**What does this PR do:**
Fixes #10066 by adding an argument to both incapacitated and do_after to allow them to function when needed if a mob is lying down with both legs missing.


**Changelog:**
:cl: Warior4356
fix: Slimes can now regrow limbs with both legs removed
/:cl:

