### PR TITLE
Reduces Pool Temp Spam

### DIFF
--- a/code/game/machinery/poolcontroller.dm
+++ b/code/game/machinery/poolcontroller.dm
@@ -62,7 +62,7 @@
 			continue
 		handleTemp(M)	//handles pool temp effects on the swimmers
 		if(ishuman(M)) //Only human types will drown, to keep things simple for non-human mobs that live in the water
-			handleDrowning(M)		
+			handleDrowning(M)
 
 /obj/machinery/poolcontroller/proc/cleanPool()
 	for(var/obj/effect/decal/cleanable/decal in decalinpool)		//Cleans up cleanable decals like blood and such
@@ -79,11 +79,11 @@
 			to_chat(M, "<span class='danger'>The water is searing hot!</span>")
 
 		if(WARM) //Warm the mob.
-			if(prob(50)) //inform the mob of warm water half the time
+			if(prob(5)) //inform the mob of warm water occasionally
 				to_chat(M, "<span class='warning'>The water is quite warm.</span>")//Inform the mob it's warm water.
 
 		if(COOL) //Cool the mob.
-			if(prob(50)) //inform the mob of cold water half the time
+			if(prob(5)) //inform the mob of cold water occasionally
 				to_chat(M, "<span class='warning'>The water is chilly.</span>")//Inform the mob it's chilly water.
 
 		if(FRIGID) //YOU'RE AS COLD AS ICE


### PR DESCRIPTION
**What does this PR do:**
Simply put I reduced the chance of the pool spamming your screen with the water being warm or cold to 5%. Initial fix was going to be a larger number, though it was still annoying. RNG WILL still sometimes proc and spam you a LOT with it, however this should no longer be the case most of the time.

**Changelog:**
:cl: Mitchs98
tweak: Lowers the spam you receive from entering a warm or cold pool. You will no longer receive 'The water is quite warm.' nearly every few seconds.
/:cl:

