### PR TITLE
Changelings can no longer escape lockers VIA Headslug

### DIFF
--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -30,9 +30,9 @@
 	for(var/mob/living/silicon/S in range(2,user))
 		to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")
 		S.Weaken(3)
-	var/turf = get_turf(user)
+	var/new_location = user.loc
 	spawn(5) // So it's not killed in explosion
-		var/mob/living/simple_animal/hostile/headcrab/crab = new(turf)
+		var/mob/living/simple_animal/hostile/headcrab/crab = new(new_location)
 		for(var/obj/item/organ/internal/I in organs)
 			I.loc = crab
 		crab.origin = M

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -30,7 +30,7 @@
 	for(var/mob/living/silicon/S in range(2,user))
 		to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")
 		S.Weaken(3)
-	var/new_location = user.loc
+	var/new_location = user.drop_location()
 	spawn(5) // So it's not killed in explosion
 		var/mob/living/simple_animal/hostile/headcrab/crab = new(new_location)
 		for(var/obj/item/organ/internal/I in organs)


### PR DESCRIPTION
**What does this PR do:**
Fixes #10083. Changelings' head slug no longer teleport outside of closed/locked/welded lockers. Properly traps the headslug as I believe it should of been in the first place.

**Changelog:**
:cl: Mitchs98
fix: Headslugs no longer teleport out of closed lockers upon bursting.
/:cl:

