### PR TITLE
Revert "Solves ghosts re-entering shutdown drones by making the ghost unable to reenter corpses"

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -223,10 +223,6 @@
 	health = 35 - (getBruteLoss() + getFireLoss())
 	update_stat("updatehealth([reason])")
 
-/mob/living/silicon/robot/drone/death(gibbed)
-	. = ..(gibbed)
-	ghostize(can_reenter_corpse = 0)
-
 
 //CONSOLE PROCS
 /mob/living/silicon/robot/drone/proc/law_resync()


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#10057

Was unaware of its side effect.

🆑:
tweak: You can still re-enter a dead drone.
/🆑 