### PR TITLE
Make kidan names less shitty

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -137,13 +137,13 @@
 				last_char_group = 3
 
 			// '  -  . ,
-			if(39,45,46, 44)			//Common name punctuation
+			if(39, 45, 46, 44)			//Common name punctuation
 				if(!last_char_group) continue
 				t_out += ascii2text(ascii_char)
 				last_char_group = 2
 
 			// ~   |   @  :  #  $  %  &  *  +  !
-			if(126,124,64,58,35,36,37,38,42,43,33)			//Other symbols that we'll allow (mainly for AI)
+			if(126, 124, 64, 58, 35, 36, 37, 38, 42, 43, 33)			//Other symbols that we'll allow (mainly for AI)
 				if(!last_char_group)		continue	//suppress at start of string
 				if(!allow_numbers)			continue
 				t_out += ascii2text(ascii_char)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -136,8 +136,8 @@
 				number_of_alphanumeric++
 				last_char_group = 3
 
-			// '  -  .
-			if(39,45,46)			//Common name punctuation
+			// '  -  . ,
+			if(39,45,46, 44)			//Common name punctuation
 				if(!last_char_group) continue
 				t_out += ascii2text(ascii_char)
 				last_char_group = 2

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -284,7 +284,7 @@
 /datum/language/kidan/get_random_name()
 	var/new_name = "[pick(list("Vrax", "Krek", "Vriz", "Zrik", "Zarak", "Click", "Zerk", "Drax", "Zven", "Drexx"))]"
 	new_name += ", "
-	new_name += "[pick(list("Noble", "Worker", "Scout", "Builder", "Farmer", "Gatherer", "Soldier", "Guard", "Miner"))]"
+	new_name += "[pick(list("Noble", "Worker", "Scout", "Builder", "Farmer", "Gatherer", "Soldier", "Guard", "Prospector"))]"
 	new_name += " of Clan "
 	new_name += "[pick(list("Tristan", "Zarlan", "Clack", "Kkraz", "Zramn", "Orlan", "Zrax"))]"	//I ran out of ideas after the first two tbh -_-
 	return new_name

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -281,6 +281,15 @@
 	flags = RESTRICTED | WHITELISTED
 	syllables = list("click","clack")
 
+/datum/language/kidan/get_random_name()
+	var/new_name = "[pick(list("Vraz", "Krek", "Vriz", "Zrik", "Zarak", "Click", "Zerk"))]"
+	new_name += ", "
+	new_name += "[pick(list("Noble", "Worker", "Scientist"))]"
+	new_name += " of Clan "
+	new_name += "[pick(list("Tristan", "Zarlan", "Clack", "Kkraz", "Zramn", "Orlan", "Zrax"))]"	//I ran out of ideas after the first two tbh -_-
+	return new_name
+
+
 /datum/language/slime
 	name = "Bubblish"
 	desc = "The language of slimes. It's a mixture of bubbling noises and pops. Very difficult to speak without mechanical aid for humans."

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -282,9 +282,9 @@
 	syllables = list("click","clack")
 
 /datum/language/kidan/get_random_name()
-	var/new_name = "[pick(list("Vraz", "Krek", "Vriz", "Zrik", "Zarak", "Click", "Zerk"))]"
+	var/new_name = "[pick(list("Vrax", "Krek", "Vriz", "Zrik", "Zarak", "Click", "Zerk", "Drax", "Zven", "Drexx"))]"
 	new_name += ", "
-	new_name += "[pick(list("Noble", "Worker", "Scientist"))]"
+	new_name += "[pick(list("Noble", "Worker", "Scout", "Builder", "Farmer", "Gatherer"))]"
 	new_name += " of Clan "
 	new_name += "[pick(list("Tristan", "Zarlan", "Clack", "Kkraz", "Zramn", "Orlan", "Zrax"))]"	//I ran out of ideas after the first two tbh -_-
 	return new_name

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -284,7 +284,7 @@
 /datum/language/kidan/get_random_name()
 	var/new_name = "[pick(list("Vrax", "Krek", "Vriz", "Zrik", "Zarak", "Click", "Zerk", "Drax", "Zven", "Drexx"))]"
 	new_name += ", "
-	new_name += "[pick(list("Noble", "Worker", "Scout", "Builder", "Farmer", "Gatherer"))]"
+	new_name += "[pick(list("Noble", "Worker", "Scout", "Builder", "Farmer", "Gatherer", "Soldier", "Guard", "Miner"))]"
 	new_name += " of Clan "
 	new_name += "[pick(list("Tristan", "Zarlan", "Clack", "Kkraz", "Zramn", "Orlan", "Zrax"))]"	//I ran out of ideas after the first two tbh -_-
 	return new_name


### PR DESCRIPTION
**What does this PR do:**
Currently, kidan random name generation gives you names that consist entirely of Click and clack. This is in stark contrast to what the lore says is kidan names (X, worker of clan Y) and doesn't reflect actual Kidan player naming. This can be an issue if a Kidan uses a DNA scrambler to get a new identity, as he will end up with a really shitty name. This fixes this.

It also allows , as a character in names so Kidan can properly name themselves.

Considering #9851 was considered a tweak and not a feature, I hope this counts as one too. If it doesn't, let me know.
**Changelog:**
:cl: 
tweak: Allow , in names, Kidan of the world, rejoice
tweak: Made kidan random name generation less shitty
/:cl:

