### PR TITLE
Makes status display font crispy

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -1,7 +1,7 @@
 #define CHARS_PER_LINE 5
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
-#define FONT_STYLE "Arial Black"
+#define FONT_STYLE "Small Fonts"
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 // Brig Door control displays.
@@ -30,6 +30,7 @@
 	var/datum/data/record/prisoner
 	maptext_height = 26
 	maptext_width = 32
+	maptext_y = -1
 
 /obj/machinery/door_timer/proc/print_report()
 	var/logname = input(usr, "Name of the guilty?","[id] log name")
@@ -349,7 +350,7 @@
 	if(timing)
 		var/disp1 = id
 		var/timeleft = timeleft()
-		var/disp2 = "[add_zero(num2text((timeleft / 60) % 60),2)]~[add_zero(num2text(timeleft % 60), 2)]"
+		var/disp2 = "[add_zero(num2text((timeleft / 60) % 60),2)]:[add_zero(num2text(timeleft % 60), 2)]"
 		if(length(disp2) > CHARS_PER_LINE)
 			disp2 = "Error"
 		update_display(disp1, disp2)
@@ -372,6 +373,8 @@
 //Checks to see if there's 1 line or 2, adds text-icons-numbers/letters over display
 // Stolen from status_display
 /obj/machinery/door_timer/proc/update_display(line1, line2)
+	line1 = uppertext(line1)
+	line2 = uppertext(line2)
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -1,7 +1,7 @@
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
 #define WARNING_FONT_COLOR "#f90"
-#define FONT_STYLE "Arial Black"
+#define FONT_STYLE "Small Fonts"
 #define SCROLL_SPEED 2
 
 // Status display
@@ -39,6 +39,7 @@
 
 	maptext_height = 26
 	maptext_width = 32
+	maptext_y = -1
 
 	var/const/CHARS_PER_LINE = 5
 	var/const/STATUS_DISPLAY_BLANK = 0
@@ -157,6 +158,8 @@
 	overlays += image('icons/obj/status_display.dmi', icon_state=picture_state)
 
 /obj/machinery/status_display/proc/update_display(line1, line2, warning = 0)
+	line1 = uppertext(line1)
+	line2 = uppertext(line2)
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[warning ? WARNING_FONT_COLOR : FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text

--- a/code/modules/power/treadmill.dm
+++ b/code/modules/power/treadmill.dm
@@ -115,7 +115,7 @@
 #define CHARS_PER_LINE 5
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
-#define FONT_STYLE "Arial Black"
+#define FONT_STYLE "Small Fonts"
 
 /obj/machinery/treadmill_monitor
 	name = "Treadmill Monitor"
@@ -126,6 +126,7 @@
 	density = 0
 	maptext_height = 26
 	maptext_width = 32
+	maptext_y = -1
 
 	var/on = 0					// if we should be metering or not
 	var/id = null				// id of treadmill
@@ -200,6 +201,8 @@
 //Checks to see if there's 1 line or 2, adds text-icons-numbers/letters over display
 // Stolen from status_display
 /obj/machinery/treadmill_monitor/proc/update_display(var/line1, var/line2)
+	line1 = uppertext(line1)
+	line2 = uppertext(line2)
 	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
 	if(maptext != new_text)
 		maptext = new_text


### PR DESCRIPTION
**What does this PR do:**
Makes status display font crispy, and actually readable now
Also shifts the text down slightly to make the font render inside the box
The font used is `Small Fonts`, a default raster font included in all modern versions of Windows (Vista+ I think)
**Images of sprite/map changes (IF APPLICABLE):**
*Cell timers, treadmills*
![image](https://user-images.githubusercontent.com/25063394/47937284-203d7180-ded8-11e8-806a-bc35691a0aca.png)

*Regular displays*
![image](https://user-images.githubusercontent.com/25063394/47937292-26335280-ded8-11e8-8245-f208585caa77.png)


**Changelog:**
:cl: AffectedArc07
tweak: Makes status display font crispy. mmmmmmmmmmmmm
/:cl:

Port of:
https://github.com/OracleStation/OracleStation/pull/1002