### PR TITLE
Calling makeNormalProcess on a speedy machine no longer breaks it

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -141,16 +141,15 @@ Class Procs:
 /obj/machinery/makeSpeedProcess()
 	if(speed_process)
 		return
-	speed_process = 1
+	speed_process = TRUE
 	STOP_PROCESSING(SSmachines, src)
 	GLOB.fast_processing += src
-	isprocessing = TRUE
 
 // gotta go slow
 /obj/machinery/makeNormalProcess()
 	if(!speed_process)
 		return
-	speed_process = 0
+	speed_process = FALSE
 	START_PROCESSING(SSmachines, src)
 	GLOB.fast_processing -= src
 


### PR DESCRIPTION
**What does this PR do:**
Fixes #10092. Tested on a local server to see if anything breaks, works fine after switching between speedy and normal processes just fine

:cl:
fix: Fixes a bug in machines when switching between speedy and normal processing speeds.
/:cl: