### PR TITLE
Traitor's toolbelt added, replaces military belt in traitor uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1020,12 +1020,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/bonerepair
 	cost = 6
 
-/datum/uplink_item/device_tools/military_belt
-	name = "Military Belt"
-	desc = "A robust seven-slot red belt made for carrying a broad variety of weapons, ammunition and explosives"
+/datum/uplink_item/device_tools/traitor_belt
+	name = "Traitor's Toolbelt"
+	desc = "A robust seven-slot belt made for carrying a broad variety of weapons, ammunition and explosives. It's modelled after the standard NT toolbelt so as to avoid suspicion while wearing it."
 	reference = "SBM"
-	item = /obj/item/storage/belt/military
-	cost = 3
+	item = /obj/item/storage/belt/military/traitor
+	cost = 2
 	excludefrom = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/medkit

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -143,7 +143,7 @@
 				/obj/item/storage/backpack/satchel_flat = 2,
 				/obj/item/storage/toolbox/syndicate = 2,
 				/obj/item/storage/backpack/duffel/syndie/surgery_fake = 2,
-				/obj/item/storage/belt/military = 2,
+				/obj/item/storage/belt/military/traitor = 2,
 				/obj/item/storage/box/syndie_kit/space = 2,
 				/obj/item/multitool/ai_detect = 2,
 				/obj/item/implanter/storage = 1,

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -254,7 +254,7 @@
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/grenade/flashbang(src)
 	update_icon()
-	
+
 /obj/item/storage/belt/soulstone
 	name = "soul stone belt"
 	desc = "Designed for ease of access to the shards during a fight, as to not let a single enemy spirit slip away"
@@ -294,6 +294,13 @@
 	icon_state = "militarybelt"
 	item_state = "military"
 	max_w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/storage/belt/military/traitor
+	name = "tool-belt"
+	desc = "Can hold various tools. This model seems to have additional compartments."
+	icon_state = "utilitybelt"
+	item_state = "utility"
+	use_item_overlays = 1 // So it will still show tools in it in case sec get lazy and just glance at it.
 
 /obj/item/storage/belt/military/abductor
 	name = "agent belt"


### PR DESCRIPTION
**What does this PR do:**
This request replaces the Military Belt uplink item for traitors with the Traitor's Toolbelt and lowers the price of the item to 2TC. I originally put this change out along with some others on the forums, but decided to make a PR for this one on it's own first after someone mentioned doing so on the thread.

The belt will act exactly like that of the military variant in terms of storage, with the added benefit of looking exactly like a normal toolbelt and updating its icon whenever you add tools to it. This gives traitors an extra area to store items without triggering all of sec like the old belt would have done. It has a close examination text as well so that security can identify it when searching:

_"Can hold various tools. This model seems to have additional compartments."_

I lowered the price as well since I felt that even with this change to the item, 3TC is a tad too expensive for something that only really offers convenience at the end of the day. It also matches the price of some other disguised items like the jumpsuit and no-slips.

Note that the military belt itself was not replaced in Belts.dm, the new belt was added as a variant of the original one.

ADDITIONAL NOTE: Also replaced the military belt with the traitor belt in the maintenance loot spawn as per the request in the comment section.

**Images of sprite/map changes (IF APPLICABLE):**
Here's an image of the belt in action if it applies here:

https://i.imgur.com/x4eErsO.png

**Changelog:**
:cl: AzuleUtama
add: Added Traitor's toolbelt
tweak: Replaced Military belt with Traitor's toolbelt in the uplink.
tweak: Price of new belt lowered to 2TC
tweak: Replaced Military belt with Traitor's toolbelt in maintenance loot.
/:cl:

