### PR TITLE
Cling regenerative stasis now appears as if the cling is dead on the med HUDs

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -163,7 +163,7 @@
 /mob/living/carbon/med_hud_set_status()
 	var/image/holder = hud_list[STATUS_HUD]
 	var/mob/living/simple_animal/borer/B = has_brain_worms()
-	if(stat == DEAD)
+	if(stat == DEAD || (status_flags & FAKEDEATH))
 		holder.icon_state = "huddead"
 	else if(status_flags & XENO_HOST)
 		holder.icon_state = "hudxeno"

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -17,7 +17,10 @@
 	user.status_flags |= FAKEDEATH		//play dead
 	user.update_stat("fakedeath sting")
 	user.update_canmove()
-
+	user.med_hud_set_health()
+	user.handle_hud_icons_health()
+	user.med_hud_set_status()
+	
 	addtimer(CALLBACK(src, .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME)
 	feedback_add_details("changeling_powers","FD")
 	return 1

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -527,7 +527,7 @@
 
 /datum/species/proc/handle_hud_icons_health_side(mob/living/carbon/human/H)
 	if(H.healths)
-		if(H.stat == DEAD)
+		if(H.stat == DEAD || (H.status_flags & FAKEDEATH))
 			H.healths.icon_state = "health7"
 		else
 			switch(H.hal_screwyhud)
@@ -546,7 +546,7 @@
 
 /datum/species/proc/handle_hud_icons_health_doll(mob/living/carbon/human/H)
 	if(H.healthdoll)
-		if(H.stat == DEAD)
+		if(H.stat == DEAD || (H.status_flags & FAKEDEATH))
 			H.healthdoll.icon_state = "healthdoll_DEAD"
 			if(H.healthdoll.overlays.len)
 				H.healthdoll.overlays.Cut()


### PR DESCRIPTION
**What does this PR do:**
Clings now appear dead when using the regenerative stasis.
This includes their health bar and their icon.

Fixes: #10100

**Changelog:**
:cl: Farie82
fix: Clings now appear dead on medical huds when using regenerative stasis
/:cl:

