### PR TITLE
Hides the character name from ahelps.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1540,13 +1540,13 @@
 			var/helptype = "ADMINHELP"
 			if(is_mhelp)
 				helptype = "MENTORHELP"
-			var/take_msg = "<span class='notice'><b>[helptype]</b>: <b>[key_name(usr.client)]</b> is attending to <b>[key_name(M)]'s</b> question.</span>"
+			var/take_msg = "<span class='notice'><b>[helptype]</b>: <b>[key_name_hidden(usr.client)]</b> is attending to <b>[key_name(M)]'s</b> question.</span>"
 			for(var/client/X in GLOB.admins)
 				if(check_rights(R_ADMIN, 0, X.mob))
 					to_chat(X, take_msg)
 				else if(is_mhelp && check_rights(R_MOD|R_MENTOR, 0, X.mob))
 					to_chat(X, take_msg)
-			to_chat(M, "<span class='notice'><b>Your question is being attended to by [key_name(usr.client, null, 0)]. Thanks for your patience!</b></span>")
+			to_chat(M, "<span class='notice'><b>Your question is being attended to by [key_name_hidden(usr.client, null, 0)]. Thanks for your patience!</b></span>")
 		else
 			to_chat(usr, "<span class='warning'>Unable to locate mob.</span>")
 


### PR DESCRIPTION
**What does this PR do:**
Fixes  #10093 

**Changelog**
:cl: R1f73r
fix: Admin Character names will no longer appear in adminhelps
/:cl:

