### PR TITLE
Makes conveyors less greedy

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -170,18 +170,21 @@ GLOBAL_LIST_INIT(conveyor_switches, list())
 		if(AM.anchored)
 			continue
 		still_stuff_to_move = TRUE
-		sleep(1)
-		if(AM.loc == loc) // prevents the object from being affected if it's not currently here.
-			step(AM,forwards)
+		addtimer(CALLBACK(src, .proc/move_thing, AM), 1)
 		CHECK_TICK
-	if(!still_stuff_to_move)
+	if(!still_stuff_to_move && speed_process)
 		makeNormalProcess()
-	else
+	else if(still_stuff_to_move && !speed_process)
 		makeSpeedProcess()
 
 /obj/machinery/conveyor/Crossed(atom/movable/AM)
-	makeSpeedProcess()
+	if(!speed_process)
+		makeSpeedProcess()
 	..()
+
+/obj/machinery/conveyor/proc/move_thing(atom/movable/AM)
+	if(!AM.anchored && AM.loc == loc)
+		step(AM, forwards)
 
 /obj/machinery/conveyor/proc/can_conveyor_run()
 	if(stat & BROKEN)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -172,7 +172,7 @@ GLOBAL_LIST_INIT(conveyor_switches, list())
 		still_stuff_to_move = TRUE
 		sleep(1)
 		if(AM.loc == loc) // prevents the object from being affected if it's not currently here.
-			step(A,forwards)
+			step(AM,forwards)
 		CHECK_TICK
 	if(!still_stuff_to_move)
 		makeNormalProcess()


### PR DESCRIPTION
**What does this PR do:**
Makes it so that conveyors that aren't in use process normally rather than being speedy all the time. If something moves onto the conveyor then it will go fast, then slow down once nothing is on it.

Conveyors go from the topmost process in terms of real time to nowhere near the top.

A side-effect of this is that conveyors not doing anything use far less power than they used to.

:cl:
tweak: Conveyors use less power now
/:cl: