### PR TITLE
Rollie changes, grammar fix and target icon update fix 

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -64,7 +64,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 /obj/item/clothing/mask/cigarette/fire_act()
 	light()
 
-/obj/item/clothing/mask/cigarette/attackby(obj/item/W as obj, mob/user as mob, params)
+/obj/item/clothing/mask/cigarette/attackby(obj/item/W as obj, mob/user as mob, mob/living/carbon/target, params)
 	..()
 	if(istype(W, /obj/item/weldingtool))
 		var/obj/item/weldingtool/WT = W
@@ -89,7 +89,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	else if(istype(W, /obj/item/melee/energy/sword/saber))
 		var/obj/item/melee/energy/sword/saber/S = W
 		if(S.active)
-			light("<span class='warning'>[user] swings their [W], barely missing their nose. [user.p_they(TRUE)] light[user.p_s()] [user.p_their()] [name] in the process.</span>")
+			light("<span class='warning'>[user] makes a violent slashing motion, barely missing [user.p_their()] nose as light flashes. [user.p_they(TRUE)] light[user.p_s()] [user.p_their()] [name] with [W] in the process.</span>")
 
 	else if(istype(W, /obj/item/assembly/igniter))
 		light("<span class='notice'>[user] fiddles with [W], and manages to light [user.p_their()] [name].</span>")
@@ -107,6 +107,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 
 	//can't think of any other way to update the overlays :<
 	user.update_inv_wear_mask()
+	target.update_inv_wear_mask()
 	user.update_inv_l_hand()
 	user.update_inv_r_hand()
 	return
@@ -195,7 +196,8 @@ LIGHTERS ARE IN LIGHTERS.DM
 	if(reagents && reagents.total_volume)	//	check if it has any reagents at all
 		if(is_being_smoked) // if it's being smoked, transfer reagents to the mob
 			var/mob/living/carbon/C = loc
-			reagents.trans_to(C, REAGENTS_METABOLISM)
+			for (var/datum/reagent/R in reagents.reagent_list)
+				reagents.trans_to(C, REAGENTS_METABOLISM)
 			if(!reagents.total_volume) // There were reagents, but now they're gone
 				to_chat(C, "<span class='notice'>Your [name] loses its flavor.</span>")
 		else // else just remove some of the reagents
@@ -232,7 +234,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	throw_speed = 0.5
 	item_state = "spliffoff"
 	smoketime = 180
-	chem_volume = 50
+	chem_volume = 100
 
 /obj/item/clothing/mask/cigarette/rollie/New()
 	..()


### PR DESCRIPTION
Previously, rollies processed their reagents by transfering 0.4 Units per tick to the person smoking them. This meant with more reagents in the rollie, less of each reagent would be transferred to the mob as it was doing 0.4/x.

This meant some plant products were not transferred to the mob when too many other products were in the rollie as the amount went below any detectable amount.

This PR changes how rollies work by making them transfer 0.4 Units of each reagent they contain to the mob per tick, it also increases the rollies volume to 100 to bring it in line with the ability to have plants with a volume of 100 via the densifed chems trait.

I understand that this could cause balance concerns but if you have already created a plant you wish to smoke and wanted to get around the current issues of not being able to use all the chems in the plant you could just eat the plant over time or grind it up into a pill form. I feel this PR would bring consistency to the rollies.

I have also changed the flavour text of using an e-sword to light a smokeable as it produces the message "their the energy sword".

I have also fixed the issue where target icons would not update if a user lit another person's smokeable.

fixes #10107 and #10059

**Changelog:**
:cl: TatsumakiMagi
balance: rollie volume = 100, transfers 0.4U / tick to mob
fix: target icon updates when lit by user
/:cl:

