### PR TITLE
adds skip_antag check to autotraitor game mode, cleans up some code

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -78,12 +78,12 @@
 		for(var/mob/living/player in GLOB.mob_list)
 			if(player.client && player.stat != DEAD)
 				playercount += 1
-			if(player.client && player.mind && player.mind.special_role && player.stat != DEAD)
-				traitorcount += 1
-			if(player.client && player.mind && !player.mind.special_role && player.stat != DEAD)
-				if(ishuman(player) || isrobot(player) || isAI(player))
-					if(player.client && (ROLE_TRAITOR in player.client.prefs.be_special) && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
-						possible_traitors += player.mind
+				if(player.mind)
+					if(player.mind.special_role)
+						traitorcount += 1
+					else if(!player.mind.special_role && (ishuman(player) || isrobot(player) || isAI(player)))
+						if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
+							possible_traitors += player.mind
 		for(var/datum/mind/player in possible_traitors)
 			for(var/job in restricted_jobs)
 				if(player.assigned_role == job)
@@ -159,7 +159,7 @@
 	if(SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
 		return
 	//message_admins("Late Join Check")
-	if(character.client && (ROLE_TRAITOR in character.client.prefs.be_special) && !jobban_isbanned(character, ROLE_TRAITOR) && !jobban_isbanned(character, "Syndicate"))
+	if(character.client && (ROLE_TRAITOR in character.client.prefs.be_special) && !player.skip_antag && !jobban_isbanned(character, ROLE_TRAITOR) && !jobban_isbanned(character, "Syndicate"))
 		//message_admins("Late Joiner has Be Syndicate")
 		//message_admins("Checking number of players")
 		var/playercount = 0
@@ -167,8 +167,8 @@
 		for(var/mob/living/player in GLOB.mob_list)
 			if(player.client && player.stat != DEAD)
 				playercount += 1
-			if(player.client && player.mind && player.mind.special_role && player.stat != DEAD)
-				traitorcount += 1
+				if(player.mind && player.mind.special_role)
+					traitorcount += 1
 		//message_admins("Live Players: [playercount]")
 		//message_admins("Live Traitors: [traitorcount]")
 


### PR DESCRIPTION
Fixes #10123 
I also changed some if statements to be nested so as to reduce unnecessary re-checking of certain values

**Changelog:**
:cl: Squirgenheimer
fix: Players will Global Antag Candidacy turned off can no longer be selected for autotraitor after post-roundstart
/:cl:

