### PR TITLE
moves Global Antag Candidacy var to client level, adds check to autotraitor and blob game modes

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -78,12 +78,13 @@
 		for(var/mob/living/player in GLOB.mob_list)
 			if(player.client && player.stat != DEAD)
 				playercount += 1
-			if(player.client && player.mind && player.mind.special_role && player.stat != DEAD)
-				traitorcount += 1
-			if(player.client && player.mind && !player.mind.special_role && player.stat != DEAD)
-				if(ishuman(player) || isrobot(player) || isAI(player))
-					if(player.client && (ROLE_TRAITOR in player.client.prefs.be_special) && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
-						possible_traitors += player.mind
+				if(player.mind)
+					if(player.mind.special_role)
+						traitorcount += 1
+					else
+						if(ishuman(player) || isrobot(player) || isAI(player))
+							if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
+								possible_traitors += player.mind
 		for(var/datum/mind/player in possible_traitors)
 			for(var/job in restricted_jobs)
 				if(player.assigned_role == job)
@@ -159,7 +160,7 @@
 	if(SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
 		return
 	//message_admins("Late Join Check")
-	if(character.client && (ROLE_TRAITOR in character.client.prefs.be_special) && !jobban_isbanned(character, ROLE_TRAITOR) && !jobban_isbanned(character, "Syndicate"))
+	if(character.client && (ROLE_TRAITOR in character.client.prefs.be_special) && !character.client.skip_antag && !jobban_isbanned(character, ROLE_TRAITOR) && !jobban_isbanned(character, "Syndicate"))
 		//message_admins("Late Joiner has Be Syndicate")
 		//message_admins("Checking number of players")
 		var/playercount = 0
@@ -167,8 +168,8 @@
 		for(var/mob/living/player in GLOB.mob_list)
 			if(player.client && player.stat != DEAD)
 				playercount += 1
-			if(player.client && player.mind && player.mind.special_role && player.stat != DEAD)
-				traitorcount += 1
+				if(player.mind && player.mind.special_role)
+					traitorcount += 1
 		//message_admins("Live Players: [playercount]")
 		//message_admins("Live Traitors: [traitorcount]")
 

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -78,23 +78,24 @@
 		for(var/mob/living/player in GLOB.mob_list)
 			if(player.client && player.stat != DEAD)
 				playercount += 1
-				if(player.mind)
-					if(player.mind.special_role)
-						traitorcount += 1
-					else
-						if(ishuman(player) || isrobot(player) || isAI(player))
-							if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
-								possible_traitors += player.mind
+				if(!player.mind)
+					continue
+				if(player.mind.special_role)
+					traitorcount += 1
+					continue
+				if(ishuman(player) || isrobot(player) || isAI(player))
+					if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
+						possible_traitors += player.mind
 		for(var/datum/mind/player in possible_traitors)
 			for(var/job in restricted_jobs)
 				if(player.assigned_role == job)
 					possible_traitors -= player
-			if(player.current) // Remove mindshield-implanted mobs from the list
-				if(ishuman(player.current))
-					var/mob/living/carbon/human/H = player.current
-					for(var/obj/item/implant/mindshield/I in H.contents)
-						if(I && I.implanted)
-							possible_traitors -= player
+			if(!player.current || !ishuman(player.current)) // Remove mindshield-implanted mobs from the list
+				continue
+			var/mob/living/carbon/human/H = player.current
+			for(var/obj/item/implant/mindshield/I in H.contents)
+				if(I && I.implanted)
+					possible_traitors -= player
 
 		//message_admins("Live Players: [playercount]")
 		//message_admins("Live Traitors: [traitorcount]")

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -55,7 +55,7 @@ var/list/blob_nodes = list()
 /datum/game_mode/blob/proc/get_blob_candidates()
 	var/list/candidates = list()
 	for(var/mob/living/carbon/human/player in GLOB.player_list)
-		if(!player.stat && player.mind && !player.mind.special_role && !jobban_isbanned(player, "Syndicate") && (ROLE_BLOB in player.client.prefs.be_special))
+		if(!player.stat && player.mind && !player.client.skip_antag && !player.mind.special_role && !jobban_isbanned(player, "Syndicate") && (ROLE_BLOB in player.client.prefs.be_special))
 			candidates += player
 	return candidates
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -271,7 +271,7 @@
 
 	// Get a list of all the people who want to be the antagonist for this round, except those with incompatible species
 	for(var/mob/new_player/player in players)
-		if(!player.skip_antag)
+		if(!player.client.skip_antag)
 			if((role in player.client.prefs.be_special) && !(player.client.prefs.species in protected_species))
 				player_draft_log += "[player.key] had [roletext] enabled, so we are drafting them."
 				candidates += player.mind

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -12,7 +12,7 @@
 		//OTHER//
 		/////////
 	var/datum/preferences/prefs = null
-	var/skip_antag = FALSE //Decline to be selected as a game mode antagonist.
+	var/skip_antag = FALSE //TRUE when a player declines to be included for the selection process of game mode antagonists.
 	var/move_delay		= 1
 	var/moving			= null
 	var/adminobs		= null

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -12,6 +12,7 @@
 		//OTHER//
 		/////////
 	var/datum/preferences/prefs = null
+	var/skip_antag = FALSE //Decline to be selected as a game mode antagonist.
 	var/move_delay		= 1
 	var/moving			= null
 	var/adminobs		= null

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -1,6 +1,5 @@
 /mob/new_player
 	var/ready = 0
-	var/skip_antag = 0	//For declining an antag roll this round.
 	var/spawning = 0	//Referenced when you want to delete the new_player later on in the code.
 	var/totalPlayers = 0		 //Player counts for the Lobby tab
 	var/totalPlayersReady = 0
@@ -68,9 +67,9 @@
 
 		var/list/antags = client.prefs.be_special
 		if(antags && antags.len)
-			if(!skip_antag) output += "<p><a href='byond://?src=[UID()];skip_antag=1'>Global Antag Candidacy</A>"
+			if(!client.skip_antag) output += "<p><a href='byond://?src=[UID()];skip_antag=1'>Global Antag Candidacy</A>"
 			else	output += "<p><a href='byond://?src=[UID()];skip_antag=2'>Global Antag Candidacy</A>"
-			output += "<br /><small>You are <b>[skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
+			output += "<br /><small>You are <b>[client.skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
 	else
 		output += "<p><a href='byond://?src=[UID()];manifest=1'>View the Crew Manifest</A></p>"
 		output += "<p><a href='byond://?src=[UID()];late_join=1'>Join Game!</A></p>"
@@ -172,7 +171,7 @@
 		new_player_panel_proc()
 
 	if(href_list["skip_antag"])
-		skip_antag = !skip_antag
+		client.skip_antag = !client.skip_antag
 		new_player_panel_proc()
 
 	if(href_list["refresh"])

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -64,15 +64,15 @@
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 		if(!ready)	output += "<p><a href='byond://?src=[UID()];ready=1'>Declare Ready</A></p>"
 		else	output += "<p><b>You are ready</b> (<a href='byond://?src=[UID()];ready=2'>Cancel</A>)</p>"
-
-		var/list/antags = client.prefs.be_special
-		if(antags && antags.len)
-			if(!client.skip_antag) output += "<p><a href='byond://?src=[UID()];skip_antag=1'>Global Antag Candidacy</A>"
-			else	output += "<p><a href='byond://?src=[UID()];skip_antag=2'>Global Antag Candidacy</A>"
-			output += "<br /><small>You are <b>[client.skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
 	else
 		output += "<p><a href='byond://?src=[UID()];manifest=1'>View the Crew Manifest</A></p>"
 		output += "<p><a href='byond://?src=[UID()];late_join=1'>Join Game!</A></p>"
+
+	var/list/antags = client.prefs.be_special
+	if(antags && antags.len)
+		if(!client.skip_antag) output += "<p><a href='byond://?src=[UID()];skip_antag=1'>Global Antag Candidacy</A>"
+		else	output += "<p><a href='byond://?src=[UID()];skip_antag=2'>Global Antag Candidacy</A>"
+		output += "<br /><small>You are <b>[client.skip_antag ? "ineligible" : "eligible"]</b> for all antag roles.</small></p>"
 
 	output += "<p><a href='byond://?src=[UID()];observe=1'>Observe</A></p>"
 


### PR DESCRIPTION
Fixes: #10123
Fixes a similar issue within blob code (although an uncommonly used proc for when someone bursts in space)
Also cleans up some code with unnecessary re-checking of some values
The change to the button showing up after round start is to make sure late-joiners have the chance to not be picked mid-round for autotraitor

I moved it to the client level because making it a preference seemed unnecessary because the original contributor who added the button noted that it is kind of a per-round thing which doesn't need to be saved. If this is a bad idea let me know.

:cl: Squirgenheimer
fix: blob and autotraitor game modes will now check for Global Antag Candidacy when picking new antagonists after round start
tweak: Global Antag Candidacy button will now show up after round start
/:cl:

