### PR TITLE
removed outdated maintainer max in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -517,8 +517,7 @@ There are a few other defines that do other things. `GLOBAL_REAL` shouldn't be u
 `GLOBAL_LIST_INIT` allows you to define a list global var with an initial value. Etc.
 
 ## Maintainers
-The only current official role for GitHub staff are the `Maintainers`. There are up to
-three  `Maintainers` at once, and they share equal power. The `Maintainers` are
+The only current official role for GitHub staff are the `Maintainers`. They share equal power. The `Maintainers` are
 responsible for properly tagging new pull requests and issues, moderating comments in
 pull requests/issues, and merging/closing pull requests.
 


### PR DESCRIPTION
**What does this PR do:**
fixes #10131 by removing outdated reference to max maintainer number.

No changelog since it doesn't affect the server itself.