### PR TITLE
Fixed tranquilite incorrectly being allowed in wall construction.

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -220,6 +220,7 @@ var/global/list/datum/stack_recipe/abductor_recipes = list ( \
 	origin_tech = "materials=4"
 	sheettype = "tranquillite"
 	materials = list(MAT_TRANQUILLITE=MINERAL_MATERIAL_AMOUNT)
+	wall_allowed = FALSE	//no tranquilite walls in code
 
 /obj/item/stack/sheet/mineral/tranquillite/New(loc, amount=null)
 	..()

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -13,6 +13,7 @@
 	var/full_window = null			//moving the var declaration to here so this can be checked cleaner until someone is willing to make them share a base type properly
 	usesound = 'sound/items/Deconstruct.ogg'
 	toolspeed = 1
+	var/wall_allowed = TRUE	//determines if sheet can be used in wall construction or not.
 
 
 // Since the sheetsnatcher was consolidated into weapon/storage/bag we now use

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -313,6 +313,9 @@
 
 		if(S.sheettype)
 			var/M = S.sheettype
+			if(M == "tranquillite")	//tranquilite walls don't exist in the code (yet)
+				to_chat(user, "<span class='warning'>You don't think that is good material for a wall!</span>")
+				return
 			if(state == GIRDER_DISPLACED)
 				if(S.get_amount() < 2)
 					to_chat(user, "<span class='warning'>You need at least two sheets to create a false wall!</span>")

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -201,6 +201,9 @@
 			return
 
 		var/obj/item/stack/sheet/S = W
+		if(!S.wall_allowed)
+			to_chat(user, "<span class='warning'>You don't think that is good material for a wall!</span>")
+			return
 
 		if(istype(S, /obj/item/stack/sheet/wood))
 			if(state == GIRDER_DISPLACED)
@@ -313,9 +316,6 @@
 
 		if(S.sheettype)
 			var/M = S.sheettype
-			if(M == "tranquillite")	//tranquilite walls don't exist in the code (yet)
-				to_chat(user, "<span class='warning'>You don't think that is good material for a wall!</span>")
-				return
 			if(state == GIRDER_DISPLACED)
 				if(S.get_amount() < 2)
 					to_chat(user, "<span class='warning'>You need at least two sheets to create a false wall!</span>")


### PR DESCRIPTION
**What does this PR do:**
Fixes #8358
There simply are no tranquilite walls or false walls in the code, nor are there sprites for them or anything of the sort. In theory this could also have been fixed by adding them, but that would have been more of a feature. This just disallows wasting tranquilite on trying to build impossible to make walls.

**Changelog:**
:cl: 
fix: Can no longer attempt to build tranquilite walls (and delete the wall in the process)
/:cl:

