### PR TITLE
Adds a death text to headslugs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -23,6 +23,10 @@
 	var/datum/mind/origin
 	var/egg_lain = 0
 
+/mob/living/simple_animal/hostile/headcrab/examine(mob/user)
+	..()
+	if(stat == DEAD)
+		to_chat(desc = "It appears to be dead.")
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)
 	egg.insert(victim)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -27,6 +27,7 @@
 	..()
 	if(stat == DEAD)
 		to_chat(desc = "It appears to be dead.")
+
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/internal/body_egg/changeling_egg/egg = new(victim)
 	egg.insert(victim)


### PR DESCRIPTION
**What does this PR do:**
Adds a red text below the examine info in the chat box when a headslug is dead, so to add clarification in a way to know when the headslug dies.
Fixes #9613 

**Changelog:**
:cl: R1f73r
add: Added a death text to headslugs when they die

/:cl:

