### PR TITLE
Adds the toxins payload casing to crafting

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -543,16 +543,24 @@
 		ttv.forceMove(get_turf(src))
 		ttv = null
 	else if(istype(I, /obj/item/transfer_valve))
-		if(!ttv)
+		if(!ttv && !check_attached(I))
 			if(!user.drop_item())
 				return
 			to_chat(user, "<span class='notice'>You load [src] with [I].</span>")
 			ttv = I
 			I.forceMove(src)
-		else
+		else if (ttv)
 			to_chat(user, "<span class='warning'>Another tank transfer valve is already loaded.</span>")
+		else
+			to_chat(user, "<span class='warning'>Remove the attached assembly component first.</span>")
 	else
 		return ..()
+
+/obj/item/bombcore/toxins/proc/check_attached(obj/item/transfer_valve/ttv)
+	if (ttv.attached_device)
+		return TRUE
+	else
+		return FALSE
 
 /obj/item/bombcore/toxins/ex_act(severity) //No chain reactions, the explosion only occurs when gas mixes
 	return

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -537,22 +537,20 @@
 	icon_state = "chemcore"
 	var/obj/item/transfer_valve/ttv = null
 
-/obj/item/bombcore/toxins/attackby(obj/item/I, mob/user, params)
+/obj/item/bombcore/toxins/attackby(obj/item/I, mob/user)
 	if(iscrowbar(I) && ttv)
 		playsound(loc, I.usesound, 50, 1)
-		ttv.loc = get_turf(src)
+		ttv.forceMove(get_turf(src))
 		ttv = null
-		return
 	else if(istype(I, /obj/item/transfer_valve))
 		if(!ttv)
 			if(!user.drop_item())
 				return
 			to_chat(user, "<span class='notice'>You load [src] with [I].</span>")
 			ttv = I
-			I.loc = src
+			I.forceMove(src)
 		else
 			to_chat(user, "<span class='warning'>Another tank transfer valve is already loaded.</span>")
-			return
 	else
 		return ..()
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -530,6 +530,42 @@
 
 		qdel(G)
 
+/obj/item/bombcore/toxins
+	name = "toxins payload"
+	desc = "A payload casing designed to secure a gas based bomb. Must be loaded with a tank transfer valve and installed into a plasteel bomb frame in order to be detonated."
+	origin_tech = "materials=1;engineering=1"
+	icon_state = "chemcore"
+	var/obj/item/transfer_valve/ttv = null
+
+/obj/item/bombcore/toxins/attackby(obj/item/I, mob/user, params)
+	if(iscrowbar(I) && ttv != null)
+		playsound(loc, I.usesound, 50, 1)
+		ttv.loc = get_turf(src)
+		ttv = null
+		return
+	else if(istype(I, /obj/item/transfer_valve))
+		if(!ttv)
+			if(!user.drop_item())
+				return
+			to_chat(user, "<span class='notice'>You load [src] with [I].</span>")
+			ttv = I
+			I.loc = src
+		else
+			to_chat(user, "<span class='warning'>Another tank transfer valve is already loaded.</span>")
+			return
+	else
+		return ..()
+
+/obj/item/bombcore/toxins/ex_act(severity) //No chain reactions, the explosion only occurs when gas mixes
+	return
+
+/obj/item/bombcore/toxins/burn()
+	return
+
+/obj/item/bombcore/toxins/detonate()
+	if(ttv != null)
+		ttv.toggle_valve()
+
 ///Syndicate Detonator (aka the big red button)///
 
 /obj/item/syndicatedetonator

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -538,7 +538,7 @@
 	var/obj/item/transfer_valve/ttv = null
 
 /obj/item/bombcore/toxins/attackby(obj/item/I, mob/user, params)
-	if(iscrowbar(I) && ttv != null)
+	if(iscrowbar(I) && ttv)
 		playsound(loc, I.usesound, 50, 1)
 		ttv.loc = get_turf(src)
 		ttv = null
@@ -563,7 +563,7 @@
 	return
 
 /obj/item/bombcore/toxins/detonate()
-	if(ttv != null)
+	if(ttv)
 		ttv.toggle_valve()
 
 ///Syndicate Detonator (aka the big red button)///

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -339,6 +339,16 @@
 	time = 50
 	category = CAT_WEAPON
 
+/datum/crafting_recipe/toxins_payload
+	name = "Toxins Payload Casing"
+	result = /obj/item/bombcore/toxins
+	reqs = list(
+		/obj/item/stock_parts/matter_bin = 1,
+		/obj/item/assembly/signaler = 1,
+		/obj/item/stack/sheet/metal = 2
+	)
+	category = CAT_WEAPON
+
 /datum/crafting_recipe/bonfire
 	name = "Bonfire"
 	time = 60


### PR DESCRIPTION
Adds a new type of bomb payload : The toxins payload. Crafted with a matter bin, metal, and a remote signaller, it must be loaded with a tank transfer valve and put into a plasteel bomb frame in order to do anything. Once the bomb detonates, the toxins payload will open the TTV (causing an explosion if the mix is correct).

As with syndicate bombs, a bomb with a toxin payload has a minimum 90 second timer, and will beep loudly to warn nearby crew to evacuate the area. It can be defused (or accidentally detonated early) in the same way a syndicate bomb can.

This allows scientists a secure way to test their bombs (less chances of accidental detonations with this method, although it adds extra steps), and antagonists a way to craft their own syndicate bomb, which is better than a simple tank transfer valve if your objective is not killing crew but making sure a specific area is wiped off the station map with little to no casualties.

Fix for freeze : #9479 

🆑
fix: Added the Toxins Payload Casing to crafting recipes, a new method of activating tank transfer valve bombs.
/🆑