### PR TITLE
[WIP] Fixes RCD giving no user feedback when out of ammo

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -255,10 +255,9 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 			var/turf/AT = get_turf(A)
 			AT.ChangeTurf(/turf/simulated/floor/plating)
 			return TRUE
-		else
-			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this floor!</span>")
-			playsound(loc, 'sound/machines/click.ogg', 50, 1)
-			return FALSE
+		to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this floor!</span>")
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		return FALSE
 
 	if(isfloorturf(A))
 		if(checkResource(3, user))
@@ -271,10 +270,12 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				var/turf/AT = A
 				AT.ChangeTurf(/turf/simulated/wall)
 				return TRUE
-		else
-			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this wall!</span>")
-			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return FALSE
+		to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this wall!</span>")
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		return FALSE
+	to_chat(user, "<span class='warning'>ERROR! Location unsuitable for wall construction!</span>")
+	playsound(loc, 'sound/machines/click.ogg', 50, 1)
 	return FALSE
 
 /obj/item/rcd/proc/mode_airlock(atom/A, mob/user)
@@ -296,14 +297,13 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				else
 					T.req_access = door_accesses.Copy()
 				return FALSE
-		else
-			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this airlock!</span>")
-			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return FALSE
-	else
-		to_chat(user, "<span class='warning'>ERROR! No stable floor detected for airlock construction!</span>")
+		to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this airlock!</span>")
 		playsound(loc, 'sound/machines/click.ogg', 50, 1)
 		return FALSE
+	to_chat(user, "<span class='warning'>ERROR! Location unsuitable for airlock construction!</span>")
+	playsound(loc, 'sound/machines/click.ogg', 50, 1)
+	return FALSE
 
 /obj/item/rcd/proc/mode_decon(atom/A, mob/user)
 	if(iswallturf(A))
@@ -319,10 +319,10 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				var/turf/AT = A
 				AT.ChangeTurf(/turf/simulated/floor/plating)
 				return TRUE
-		else
-			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this wall!</span>")
-			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return FALSE
+		to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this wall!</span>")
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		return FALSE
 
 	if(isfloorturf(A))
 		if(checkResource(5, user))
@@ -335,10 +335,10 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				var/turf/AT = A
 				AT.ChangeTurf(/turf/space)
 				return TRUE
-		else
-			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this floor!</span>")
-			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return FALSE
+		to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this floor!</span>")
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		return FALSE
 
 	if(istype(A, /obj/machinery/door/airlock))
 		if(checkResource(20, user))
@@ -350,10 +350,10 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				playsound(loc, usesound, 50, 1)
 				qdel(A)
 				return TRUE
-		else
-			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this airlock!</span>")
-			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return FALSE
+		to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this airlock!</span>")
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		return FALSE
 
 	if(istype(A, /obj/structure/window)) // You mean the grille of course, do you?
 		A = locate(/obj/structure/grille) in A.loc
@@ -419,10 +419,9 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 		var/turf/AT = A
 		AT.ChangeTurf(/turf/simulated/floor/plating) // Platings go under windows.
 		return 1
-	else
-		to_chat(user, "<span class='warning'>ERROR! No stable floor detected for window construction!</span>")
-		playsound(loc, 'sound/machines/click.ogg', 50, 1)
-		return 0
+	to_chat(user, "<span class='warning'>ERROR! Location unsuitable for window construction!</span>")
+	playsound(loc, 'sound/machines/click.ogg', 50, 1)
+	return 0
 
 /obj/item/rcd/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -255,7 +255,10 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 			var/turf/AT = get_turf(A)
 			AT.ChangeTurf(/turf/simulated/floor/plating)
 			return TRUE
-		return FALSE
+		else
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this floor!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
+			return FALSE
 
 	if(isfloorturf(A))
 		if(checkResource(3, user))
@@ -268,28 +271,39 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				var/turf/AT = A
 				AT.ChangeTurf(/turf/simulated/wall)
 				return TRUE
-		return FALSE
+		else
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this wall!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
+			return FALSE
 	return FALSE
 
 /obj/item/rcd/proc/mode_airlock(atom/A, mob/user)
-	if(isfloorturf(A) && checkResource(10, user))
-		to_chat(user, "Building Airlock...")
-		playsound(loc, 'sound/machines/click.ogg', 50, 1)
-		if(do_after(user, 50 * toolspeed, target = A))
-			if(locate(/obj/machinery/door/airlock) in A.contents)
+	if(isfloorturf(A))
+		if(checkResource(10, user))
+			to_chat(user, "Building Airlock...")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
+			if(do_after(user, 50 * toolspeed, target = A))
+				if(locate(/obj/machinery/door/airlock) in A.contents)
+					return FALSE
+				if(!useResource(10, user))
+					return FALSE
+				playsound(loc, usesound, 50, 1)
+				var/obj/machinery/door/airlock/T = new door_type(A)
+				T.name = door_name
+				T.autoclose = TRUE
+				if(one_access)
+					T.req_one_access = door_accesses.Copy()
+				else
+					T.req_access = door_accesses.Copy()
 				return FALSE
-			if(!useResource(10, user))
-				return FALSE
-			playsound(loc, usesound, 50, 1)
-			var/obj/machinery/door/airlock/T = new door_type(A)
-			T.name = door_name
-			T.autoclose = TRUE
-			if(one_access)
-				T.req_one_access = door_accesses.Copy()
-			else
-				T.req_access = door_accesses.Copy()
+		else
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this airlock!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return FALSE
-	return FALSE
+	else
+		to_chat(user, "<span class='warning'>ERROR! No stable floor detected for airlock construction!</span>")
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		return FALSE
 
 /obj/item/rcd/proc/mode_decon(atom/A, mob/user)
 	if(iswallturf(A))
@@ -305,7 +319,10 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				var/turf/AT = A
 				AT.ChangeTurf(/turf/simulated/floor/plating)
 				return TRUE
-		return FALSE
+		else
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this wall!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
+			return FALSE
 
 	if(isfloorturf(A))
 		if(checkResource(5, user))
@@ -318,7 +335,10 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				var/turf/AT = A
 				AT.ChangeTurf(/turf/space)
 				return TRUE
-		return FALSE
+		else
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this floor!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
+			return FALSE
 
 	if(istype(A, /obj/machinery/door/airlock))
 		if(checkResource(20, user))
@@ -330,12 +350,17 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 				playsound(loc, usesound, 50, 1)
 				qdel(A)
 				return TRUE
-		return FALSE
+		else
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this airlock!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
+			return FALSE
 
 	if(istype(A, /obj/structure/window)) // You mean the grille of course, do you?
 		A = locate(/obj/structure/grille) in A.loc
 	if(istype(A, /obj/structure/grille))
 		if(!checkResource(2, user))
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to deconstruct this window!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return 0
 		to_chat(user, "Deconstructing window...")
 		playsound(loc, 'sound/machines/click.ogg', 50, 1)
@@ -367,6 +392,8 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 		if(locate(/obj/structure/grille) in A)
 			return 0 // We already have window
 		if(!checkResource(2, user))
+			to_chat(user, "<span class='warning'>ERROR! Not enough matter in unit to construct this window!</span>")
+			playsound(loc, 'sound/machines/click.ogg', 50, 1)
 			return 0
 		to_chat(user, "Constructing window...")
 		playsound(loc, 'sound/machines/click.ogg', 50, 1)
@@ -392,6 +419,10 @@ GLOBAL_LIST_INIT(rcd_door_types, list(
 		var/turf/AT = A
 		AT.ChangeTurf(/turf/simulated/floor/plating) // Platings go under windows.
 		return 1
+	else
+		to_chat(user, "<span class='warning'>ERROR! No stable floor detected for window construction!</span>")
+		playsound(loc, 'sound/machines/click.ogg', 50, 1)
+		return 0
 
 /obj/item/rcd/afterattack(atom/A, mob/user, proximity)
 	if(!proximity)


### PR DESCRIPTION
**What does this PR do:**
Fix for issue #10021

RCD will now give a low ammo message for what you are trying to build / destroy. Additionally gives messages when trying to build airlocks or windows over space tiles otherwise it would give a low ammo warning when trying to do so when you actually had enough matter in the RCD.

This did require working the original code for building airlocks slightly, originally the check for enough matter and whether or not there was a floor were contained in the same if statement. Now it first checks for the floor and then calls a second if statement for the matter. This is done so it can have separate errors for trying to build without ammo and without a floor underneath.

I tested this out with many airlock variants and trying to build every combination I could with the tool. I also used the RCD variants including the one borgs get, which gave the same messages when the borg was out of power. I didn't experience any errors when doing so and all the new messages displayed as expected.

Please let me know if this all looks okay or if there's anything glaringly wrong with it that I missed.

**Images of sprite/map changes (IF APPLICABLE):**

No changes to sprites.

**Changelog:**
:cl::
fix: RCD now gives visible messages when building without enough ammo or on an invalid tile.
/:cl:

