### PR TITLE
Fixes bluespace crystals deleting entire stack when used to teleport

### DIFF
--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -22,7 +22,8 @@
 	blink_mob(user)
 	user.drop_item()
 	user.visible_message("<span class='notice'>[user] crushes the [src]!</span>")
-	qdel(src)
+	if(!zero_amount())
+		amount -= 1
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(var/mob/living/L)
 	if(!is_teleport_allowed(L.z))

--- a/code/modules/telesci/bscrystal.dm
+++ b/code/modules/telesci/bscrystal.dm
@@ -19,11 +19,9 @@
 	pixel_y = rand(-5, 5)
 
 /obj/item/stack/ore/bluespace_crystal/attack_self(var/mob/user)
-	blink_mob(user)
-	user.drop_item()
-	user.visible_message("<span class='notice'>[user] crushes the [src]!</span>")
-	if(!zero_amount())
-		amount -= 1
+	if(use(1))
+		blink_mob(user)
+		user.visible_message("<span class='notice'>[user] crushes a [singular_name]!</span>")
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(var/mob/living/L)
 	if(!is_teleport_allowed(L.z))


### PR DESCRIPTION
Fixes: #10143

This is my first PR please don't stab me.

:cl: Spartan
fix: Bluespace Crystals no longer use the entire stack when used on self to teleport.
/:cl:

