### PR TITLE
The Revival of the Plastic Bag

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1401,6 +1401,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/secure/briefcase/syndie
 	cost = 1
 
+/datum/uplink_item/badass/plasticbag
+	name = "Plastic Bag"
+	desc = "A simple, plastic bag. Keep out of reach of small children, do not apply to head."
+	reference = "PBAG"
+	item = /obj/item/storage/bag/plasticbag
+	cost = 1
+	excludefrom = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/badass/balloon
 	name = "For showing that you are The Boss"
 	desc = "A useless red balloon with the syndicate logo on it, which can blow the deepest of covers."

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -127,6 +127,8 @@
 				/obj/item/seeds/ambrosia = 20,
 				/obj/item/clothing/under/color/black = 30,
 				/obj/item/stack/tape_roll = 10,
+				/obj/item/storage/bag/plasticbag = 20,
+				/obj/item/caution = 10,
 				////////////////CONTRABAND STUFF//////////////////
 				/obj/item/grenade/clown_grenade = 3,
 				/obj/item/seeds/ambrosia/cruciatus = 3,


### PR DESCRIPTION
For too long has the glory of the plastic bag been neglected, after the box uprising. No longer.

This PR adds plastic bags and wet floor signs to maintenance loot spawning. Because wearing plastic bags on your head is fun and wet floor signs fit thematically.

It also adds the Plastic Bag to the Pointless (Badass) section on the uplink. Now you can find and choke your targets with style. Very slow, drawn out, style.

Fix token: #10145

:cl: Spartan
tweak: Plastic bags and wet floor signs can now spawn in maint.
add: Plastic bags are now supplied to your syndicate uplink. Apply directly to head.
/:cl:

