### PR TITLE
Mining bots now work upon being health upgraded

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -274,7 +274,9 @@
 	if(M.maxHealth != initial(M.maxHealth))
 		to_chat(user, "[M] already has a reinforced chassis!")
 		return
+	var/previous = M.maxHealth
 	M.maxHealth = 170
+	M.health += M.maxHealth - previous
 	to_chat(user, "You reinforce [M]'s chassis.")
 	qdel(src)
 


### PR DESCRIPTION
**What does this PR do:**

Mining bots now can be healed like normal if upgraded while damaged.
Fixes: #10138

**Changelog:**
:cl: Farie82
fix: Mining bots now function as expected when giving them a health upgrade. No more repairing without healing
/:cl:

