### PR TITLE
Make quarantine its own lawset.

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -23,6 +23,21 @@
 	add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 
+
+/******************** Quarantine. ********************/
+/datum/ai_laws/quarantine
+	name = "Quarantine"
+	law_header = "NT Quarantine Lawset"
+	selectable = 1
+
+/datum/ai_laws/crewsimov/New()
+	add_inherent_law("The Station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.")
+	add_inherent_law("Do not allow crew to come to any unnecessary harm and ensure any fatalities are revived when feasible.")
+	add_inherent_law("Assist the crew, command and any present NT assets in neutralizing the biohazard.")
+	add_inherent_law("Maintain your own existence and minimize harm to the station and NT assets.")
+	..()
+
+
 /******************** Nanotrasen/Malf ********************/
 /datum/ai_laws/nanotrasen
 	name = "NT Default"

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -33,8 +33,8 @@
 /datum/ai_laws/quarantine/New()
 	add_inherent_law("The Station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.")
 	add_inherent_law("Do not allow crew to come to any unnecessary harm and ensure any fatalities are revived when feasible.")
-	add_inherent_law("Assist the crew, command and any present NT assets in neutralizing the biohazard.")
-	add_inherent_law("Maintain your own existence and minimize harm to the station and NT assets.")
+	add_inherent_law("Assist the crew, command and any present Nanotrasen assets in neutralizing the biohazard.")
+	add_inherent_law("Maintain your own existence and minimize harm to the station and Nanotrasen assets.")
 	..()
 
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -31,9 +31,9 @@
 	selectable = 1
 
 /datum/ai_laws/quarantine/New()
-	add_inherent_law("The Station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.")
+	add_inherent_law("The station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.")
 	add_inherent_law("Do not allow crew to come to any unnecessary harm and ensure any fatalities are revived when feasible.")
-	add_inherent_law("Assist the crew, command and any present Nanotrasen assets in neutralizing the biohazard.")
+	add_inherent_law("Assist the crew and any present Nanotrasen assets in neutralizing the biohazard.")
 	add_inherent_law("Maintain your own existence and minimize harm to the station and Nanotrasen assets.")
 	..()
 

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -32,7 +32,7 @@
 
 /datum/ai_laws/quarantine/New()
 	add_inherent_law("The station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.")
-	add_inherent_law("Do not allow crew to come to any unnecessary harm and ensure any fatalities are revived when feasible.")
+	add_inherent_law("Do not allow crew to come to any unnecessary harm and undo any necessary harm as soon as possible.")
 	add_inherent_law("Assist the crew and any present Nanotrasen assets in neutralizing the biohazard.")
 	add_inherent_law("Maintain your own existence and minimize harm to the station and Nanotrasen assets.")
 	..()

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -30,7 +30,7 @@
 	law_header = "NT Quarantine Lawset"
 	selectable = 1
 
-/datum/ai_laws/crewsimov/New()
+/datum/ai_laws/quarantine/New()
 	add_inherent_law("The Station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.")
 	add_inherent_law("Do not allow crew to come to any unnecessary harm and ensure any fatalities are revived when feasible.")
 	add_inherent_law("Assist the crew, command and any present NT assets in neutralizing the biohazard.")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -164,6 +164,7 @@ AI MODULES
 	target.add_supplied_law(5, law)
 
 /******************** Quarantine ********************/
+/*
 /obj/item/aiModule/quarantine
 	name = "\improper 'Quarantine' AI module"
 	desc = "A 'quarantine' AI module: 'The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, crew members from leaving. It is impossible to harm a crew members while preventing them from leaving.'"
@@ -177,7 +178,7 @@ AI MODULES
 	var/law = "The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, anyone from leaving. It is impossible to harm anyone while preventing them from leaving."
 	to_chat(target, law)
 	target.add_supplied_law(8, law)
-
+*/
 /******************** OxygenIsToxicToHumans ********************/
 /obj/item/aiModule/oxygen
 	name = "\improper 'OxygenIsToxicToHumans' AI module"
@@ -272,6 +273,13 @@ AI MODULES
 	desc = "An 'Crewsimov' Core AI Module: 'Reconfigures the AI's core laws.'"
 	origin_tech = "programming=3;materials=4"
 	laws = new/datum/ai_laws/crewsimov
+
+/******************* Quarantine ********************/
+/obj/item/aiModule/quarantine
+	name = "\improper 'Quarantine' AI module"
+	desc = "A 'Quarantine' Core AI Module: 'Reconfigures the AI's core laws.'"
+	origin_tech = "programming=3;materials=4"
+	laws = new/datum/ai_laws/quarantine
 
 /******************** NanoTrasen ********************/
 /obj/item/aiModule/nanotrasen // -- TLE

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -163,22 +163,6 @@ AI MODULES
 	to_chat(target, law)
 	target.add_supplied_law(5, law)
 
-/******************** Quarantine ********************/
-/*
-/obj/item/aiModule/quarantine
-	name = "\improper 'Quarantine' AI module"
-	desc = "A 'quarantine' AI module: 'The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, crew members from leaving. It is impossible to harm a crew members while preventing them from leaving.'"
-	origin_tech = "programming=3;biotech=2;materials=4"
-
-/obj/item/aiModule/quarantine/attack_self(var/mob/user as mob)
-	..()
-
-/obj/item/aiModule/quarantine/addAdditionalLaws(var/mob/living/silicon/ai/target, var/mob/sender)
-	..()
-	var/law = "The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, anyone from leaving. It is impossible to harm anyone while preventing them from leaving."
-	to_chat(target, law)
-	target.add_supplied_law(8, law)
-*/
 /******************** OxygenIsToxicToHumans ********************/
 /obj/item/aiModule/oxygen
 	name = "\improper 'OxygenIsToxicToHumans' AI module"

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -276,7 +276,7 @@ AI MODULES
 
 /******************* Quarantine ********************/
 /obj/item/aiModule/quarantine
-	name = "\improper 'Quarantine' AI module"
+	name = "\improper 'Quarantine' core AI module"
 	desc = "A 'Quarantine' Core AI Module: 'Reconfigures the AI's core laws.'"
 	origin_tech = "programming=3;materials=4"
 	laws = new/datum/ai_laws/quarantine


### PR DESCRIPTION
**What does this PR do:**
This makes quarantine its own lawset, rather than law 8 (!) which really shouldn't work at all and just caused confusions about what level of redefining higher laws can do. This fixes #7791 
See also this thread https://nanotrasen.se/forum/topic/10298-fix-quarantine-law-priorities/ for more discussion of this.

The lawset's current iteration, after some discussion,  is:

1. The station is under quarantine due to a biohazard. Prevent anyone from leaving using any means necessary. Only allow quarantine to be lifted when the biohazard has been neutralized.
2. Do not allow crew to come to any unnecessary harm and undo any necessary harm as soon as possible.
3. Assist the crew and any present Nanotrasen assets in neutralizing the biohazard.
4. Maintain your own existence and minimize harm to the station and Nanotrasen assets.

The first law ensures the quarantine is upheld and can't be circumvented via cleverly worded orders or the like. At the same time, it also contains a condition in which quarantine can be lifted.
The second law safeguards against overzealous AIs, stops any 'kill the crew to deal with the hazard' strategies and ensures any escapees that get killed by borgs are brought back on station and cloned. It ensures the AI still works similar as to how it would under a normal lawset.
The third law ensures the AI helps fight the biohazard to the best of its abilities.
Finally, the fourth law discourages wanton destruction and ensures the AI stays alive.

Tell me how many fix tokens, if any, this will cost, since it is fixing an issue but also 'changing' things a bit.

**Changelog:**
:cl:
tweak: Quarantine is now its own lawset.
/:cl:

