### PR TITLE
Gives Space a Name

### DIFF
--- a/code/modules/space_management/space_level.dm
+++ b/code/modules/space_management/space_level.dm
@@ -21,7 +21,8 @@
 	var/dirt_count = 0
 	var/list/init_list = list()
 
-/datum/space_level/New(z, name, transition_type = SELFLOOPING, traits = list(BLOCK_TELEPORT))
+/datum/space_level/New(z, level_name, transition_type = SELFLOOPING, traits = list(BLOCK_TELEPORT))
+	name = level_name
 	zpos = z
 	flags = traits
 	build_space_destination_arrays()


### PR DESCRIPTION
We now name our space_levels. Every space level no longer incorrectly reports a config error.

🆑:
tweak: Space levels is named now.
/🆑 
