### PR TITLE
Small format & grammar tweaks of the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 What is the problem?
 
 **What did you expect to happen**: 
-Why do you think this is a bug?
+Why do you think this is an issue?
 
 **What happened instead**:
 How is what happened different from what you expected?
@@ -14,7 +14,7 @@ Why do you think this is an important issue?
 The most important section. Review everything you did leading up to causing the issue.
 
 **When did the problem start happening**:
-If your report is about something that used to work but no longer does. When was the last time you remember it working?
+If your report is about something that used to work but no longer does, when was the last time you remember it working?
 
-**Possibly related stuff (which gamemode was it? What were you doing at the time? Was
-anything else out of the ordinary happening?)**: Anything else you can tell us.
+**Possibly related stuff (which gamemode was it? What were you doing at the time? Was anything else out of the ordinary happening?)**:
+Anything else you can tell us.


### PR DESCRIPTION
Mostly because I've always been *bugged* when I see `Anything else you can tell us.` left on the same line as the paragraph title. Some other minor changes.

No CL.