### PR TITLE
Fixes Chemical Implants/Allows Injections

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_chem.dm
+++ b/code/game/objects/items/weapons/implants/implant_chem.dm
@@ -55,7 +55,6 @@
 /obj/item/implantcase/chem
 	name = "implant case - 'Remote Chemical'"
 	desc = "A glass case containing a remote chemical implant."
-	container_type = OPENCONTAINER | INJECTABLE | DRAWABLE
 
 /obj/item/implantcase/chem/New()
 	imp = new /obj/item/implant/chem(src)

--- a/code/game/objects/items/weapons/implants/implant_chem.dm
+++ b/code/game/objects/items/weapons/implants/implant_chem.dm
@@ -55,6 +55,7 @@
 /obj/item/implantcase/chem
 	name = "implant case - 'Remote Chemical'"
 	desc = "A glass case containing a remote chemical implant."
+	container_type = OPENCONTAINER | INJECTABLE | DRAWABLE
 
 /obj/item/implantcase/chem/New()
 	imp = new /obj/item/implant/chem(src)

--- a/code/game/objects/items/weapons/implants/implantcase.dm
+++ b/code/game/objects/items/weapons/implants/implantcase.dm
@@ -8,6 +8,7 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = "materials=1;biotech=2"
+	container_type = OPENCONTAINER | INJECTABLE | DRAWABLE
 	materials = list(MAT_GLASS=500)
 	var/obj/item/implant/imp = null
 


### PR DESCRIPTION
**What does this PR do:**
Fixes #10161 You can now properly fill and use Chemical Implants with a syringe as well as a beaker, you can also remove reagents injected with a syringe in-case you do an oopsie. 

**Changelog:**
:cl: Mitchs98
fix: Chemical implants now work and can be properly filled via beaker or syringe. Reagents inside can also be syringed out.
/:cl:

