### PR TITLE
Fixes an infinite metal exploit

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -199,8 +199,8 @@
 		num_ammo++
 	for(var/M in initial_mats) //In case we have multiple types of materials
 		var/materials_per = initial_mats[M] / max_ammo
-		
-		var/value = max(materials_per * num_ammo, 2000) //Enforce a minimum of 2000 units even if empty.
+
+		var/value = max(materials_per * num_ammo, 500) //Enforce a minimum of 500 units even if empty.
 		materials[M] = value
 
 //Behavior for magazines

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -118,10 +118,12 @@
 	icon_state = "foambox"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	max_ammo = 40
+	materials = list(MAT_METAL = 500)
 
 /obj/item/ammo_box/foambox/riot
 	icon_state = "foambox_riot"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
+	materials = list(MAT_METAL = 50000)
 
 /obj/item/ammo_box/caps
 	name = "speed loader (caps)"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -619,7 +619,7 @@
 	name = "Box of Foam Darts"
 	id = "foam_dart"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 500)
 	build_path = /obj/item/ammo_box/foambox
 	category = list("initial", "Miscellaneous")
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -619,7 +619,7 @@
 	name = "Box of Foam Darts"
 	id = "foam_dart"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 500)
+	materials = list(MAT_METAL = 30000)
 	build_path = /obj/item/ammo_box/foambox
 	category = list("initial", "Miscellaneous")
 


### PR DESCRIPTION
Foam dart boxes cost 500 but recycle for 30,000. This PR ups the cost of said item to 30,000.

:cl:
fix: Prevents an infinite metal exploit using the autolathe.
tweak: Minimum returnable metal of ammunition boxes has been lowered from 2000 to 500.
/:cl: