### PR TITLE
Holopad sprite revert fix

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -403,7 +403,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/update_icon()
 	var/total_users = LAZYLEN(masters) + LAZYLEN(holo_calls)
-	if(ringing)
+	if(icon_state == "holopad_open")
+		return
+	else if(ringing)
 		icon_state = "holopad_ringing"
 	else if(total_users)
 		icon_state = "holopad1"


### PR DESCRIPTION
Prevents `update_icon()` from constantly reverting a holopad with an open panel, to it's default sprite state.
Fixes #10120

:cl: Alonefromhell
fix: Holopad should no longer automatically revert to default sprite.
/:cl:

