### PR TITLE
Minor change to cursed heart description in spellbook

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -423,7 +423,7 @@
 
 /datum/spellbook_entry/item/cursed_heart
 	name = "Cursed Heart"
-	desc = "A heart that has been revived by dark magicks, the user must concentrate to ensure the heart beats, but every beat heals them. It must beat every 6 seconds."
+	desc = "A heart that has been revived by dark magicks. The user must ensure the heart is manually beaten or their blood circulation will suffer, but every beat heals their injuries. It must beat every 6 seconds."
 	item_path = /obj/item/organ/internal/heart/cursed/wizard
 	log_name = "CH"
 	cost = 1


### PR DESCRIPTION
**What does this PR do:**
fixes #10155

This isn't really a fix as such due to the item working as intended. This is just a very minor change to the spellbook's description of the item so newer mages better understand the negative effect should they mistime pumping it.

**Changelog:**
:cl: Azule Utama
spellcheck: Small change to cursed heart's spellbook description.
/:cl:

