### PR TITLE
Fulltile plasma windows and large boxes

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -58,7 +58,7 @@
 	name = "large box"
 	desc = "You could build a fort with this."
 	icon_state = "largebox"
-	w_class = 42 // Big, bulky.
+	w_class = 4 // Big, bulky.
 	foldable = /obj/item/stack/sheet/cardboard
 	amt = 4
 	storage_slots = 21

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -673,7 +673,7 @@ obj/structure/window/full/reinforced/ice
 	icon = 'icons/obj/smooth_structures/plastitanium_window.dmi'
 	icon_state = "plastitanium_window"
 	dir = FULLTILE_WINDOW_DIR
-	max_integrity = 100
+	max_integrity = 200
 	fulltile = TRUE
 	reinf = TRUE
 	heat_resistance = 1600

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -600,6 +600,8 @@ var/global/wcCommon = pick(list("#379963", "#0d8395", "#58b5c3", "#49e46e", "#8f
 	max_integrity = 240
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(/obj/structure/window/full/basic, /obj/structure/window/full/reinforced, /obj/structure/window/full/reinforced/tinted, /obj/structure/window/full/plasmabasic, /obj/structure/window/full/plasmareinforced)
+	explosion_block = 1
+	armor = list("melee" = 75, "bullet" = 5, "laser" = 0, "energy" = 0, "bomb" = 45, "bio" = 100, "rad" = 100)
 
 /obj/structure/window/full/plasmareinforced
 	name = "reinforced plasma window"


### PR DESCRIPTION
**What does this PR do:**
Examining large cardboard boxes shows their size now, fulltile plasma glass windows have the same armor values as the directional ones (this should have been on my previous PR but i didn't notice it) and rises the plastitanium windows integrity value so it's no longer lower than the regular titanium windows.

**Changelog:**
:cl: Eschess
fix: large cardboard boxes now show their size when examining
fix: fulltile plasma glass windows now have armor
tweak: rised plastitanium windows integrity
/:cl:

