### PR TITLE
hatching alien embryos now use drop_location

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -91,7 +91,7 @@
 		owner.overlays += overlay
 
 		spawn(6)
-			var/mob/living/carbon/alien/larva/new_xeno = new(owner.loc)
+			var/mob/living/carbon/alien/larva/new_xeno = new(owner.drop_location())
 			new_xeno.key = C.key
 			if(ticker && ticker.mode)
 				ticker.mode.xenos += new_xeno.mind


### PR DESCRIPTION
Fixes #9048

**Changelog:**
:cl: Squirgenheimer
tweak: Hatched alien larvas will default to being created on the turf of the mob instead of the mob's location, unless specifically allowed (like closets and spacepods) 
/:cl:

