### PR TITLE
Lowers Larva Move-Speed

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -132,6 +132,10 @@
 		// add some movement delay
 		move_delay_add = min(move_delay_add + round(amount / 2), 10) // a maximum delay of 10
 
+/mob/living/carbon/alien/movement_delay()
+	. = ..()
+	. += move_delay_add + config.alien_delay //move_delay_add is used to slow aliens with stuns
+
 /mob/living/carbon/alien/getDNA()
 	return null
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -27,11 +27,6 @@
 	add_language("Hivemind")
 	..()
 
-
-/mob/living/carbon/alien/humanoid/movement_delay()
-	. = ..()
-	. += move_delay_add + config.alien_delay //move_delay_add is used to slow aliens with stuns
-
 /mob/living/carbon/alien/humanoid/Process_Spacemove(var/check_drift = 0)
 	if(..())
 		return 1

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -33,12 +33,20 @@
 	..()
 	stat(null, "Progress: [amount_grown]/[max_grown]")
 
-
 /mob/living/carbon/alien/larva/adjustPlasma(amount)
 	if(stat != DEAD && amount > 0)
 		amount_grown = min(amount_grown + 1, max_grown)
 	..(amount)
 
+/mob/living/carbon/alien/larva/movement_delay()
+	. = 1
+
+/mob/living/carbon/alien/larva/start_pulling(var/atom/movable/AM)
+	if(stat || sleeping || paralysis || weakened)
+		return
+	if(istype(AM,/obj/item))
+		to_chat(src, "<span class='warning'>You are far too small to pull anything!</span>")
+	return
 
 /mob/living/carbon/alien/larva/ex_act(severity)
 	..()

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -38,16 +38,6 @@
 		amount_grown = min(amount_grown + 1, max_grown)
 	..(amount)
 
-/mob/living/carbon/alien/larva/movement_delay()
-	. = 1
-
-/mob/living/carbon/alien/larva/start_pulling(var/atom/movable/AM)
-	if(stat || sleeping || paralysis || weakened)
-		return
-	if(istype(AM,/obj/item))
-		to_chat(src, "<span class='warning'>You are far too small to pull anything!</span>")
-	return
-
 /mob/living/carbon/alien/larva/ex_act(severity)
 	..()
 


### PR DESCRIPTION
**What does this PR do:**
Lower's larva move speed to be on par with that of a human mobs. After speaking with Ansari, this was apparently how it was supposed to be originally however it was just incorrectly defined. It is now properly defined.

Initial proposal to remove their ability to pull things has been removed and is now a part of the Move Force TG port.
**Changelog:**
:cl: Mitchs98
balance: Lowers larva move speed. Hopefully balances xenos a tad.
/:cl: