### PR TITLE
Enables the alien screen for AI

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -370,7 +370,8 @@ var/list/ai_verbs_default = list(
 		"Fuzzy",
 		"Glitchman",
 		"House",
-		"Database"
+		"Database",
+		"Alien"
 		)
 	if(custom_sprite)
 		display_choices += "Custom"
@@ -451,6 +452,8 @@ var/list/ai_verbs_default = list(
 			icon_state = "ai-house"
 		if("Database")
 			icon_state = "ai-database"
+		if("Alien")
+			icon_state = "ai-alien"
 		else
 			icon_state = "ai"
 	//else


### PR DESCRIPTION
**What does this PR do:**
As per title. This enables the alien screen for AI which is in the file but for some reason, never enabled. It is also the same as TUC's fluff AI screen 3 years ago.

Gotta see if another maintainer label this as minor or not.

![image](https://user-images.githubusercontent.com/40092670/48301007-81d98d80-e521-11e8-8bb9-c4d9711ee2c6.png)

**Changelog:**
:cl:
add: AI can now select the alien screen display
/:cl:

