### PR TITLE
Fixes suit storage units

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -165,6 +165,44 @@
 		playsound(loc, I.usesound, 100, 1)
 		to_chat(user, text("<span class='notice'>You [panel_open ? "open up" : "close"] the unit's maintenance panel.</span>"))
 		updateUsrDialog()
+		return
+		
+	if(!state_open)
+		to_chat(user, "<span class ='warning'>It's closed!</span>")
+		return
+
+	if(istype(I, /obj/item/clothing/head/helmet)) // Helmets
+		if(helmet)
+			to_chat(user, "<span class='warning'>The unit already contains a helmet!</span>")
+			return
+		user.drop_item()
+		I.forceMove(src)
+		helmet = I
+		update_icon()
+		updateUsrDialog()
+		to_chat(user, "<span class='notice'>You load the [I] into the storage compartment.</span>")
+	
+	if(istype(I, /obj/item/clothing/suit/space)) // Space Suits
+		if(suit)
+			to_chat(user, "<span class='warning'>The unit already contains a suit!</span>")
+			return
+		user.drop_item()
+		I.forceMove(src)
+		suit = I
+		update_icon()
+		updateUsrDialog()
+		to_chat(user, "<span class='notice'>You load the [I] into the storage compartment.</span>")
+	
+	if(istype(I, /obj/item/clothing/mask)) // Masks
+		if(mask)
+			to_chat(user, "<span class='warning'>The unit already contains a mask!</span>")
+			return
+		user.drop_item()
+		I.forceMove(src)
+		mask = I
+		update_icon()
+		updateUsrDialog()
+		to_chat(user, "<span class='notice'>You load the [I] into the storage compartment.</span>")
 
 /obj/machinery/suit_storage_unit/power_change()
 	..()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -181,7 +181,8 @@
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You load the [I] into the storage compartment.</span>")
-	
+		return
+		
 	if(istype(I, /obj/item/clothing/suit/space)) // Space Suits
 		if(suit)
 			to_chat(user, "<span class='warning'>The unit already contains a suit!</span>")
@@ -192,7 +193,8 @@
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You load the [I] into the storage compartment.</span>")
-	
+		return
+		
 	if(istype(I, /obj/item/clothing/mask)) // Masks
 		if(mask)
 			to_chat(user, "<span class='warning'>The unit already contains a mask!</span>")
@@ -203,7 +205,8 @@
 		update_icon()
 		updateUsrDialog()
 		to_chat(user, "<span class='notice'>You load the [I] into the storage compartment.</span>")
-
+		return
+		
 /obj/machinery/suit_storage_unit/power_change()
 	..()
 	if(!is_operational() && state_open)


### PR DESCRIPTION
Fixes suit storage units not being able to have space suits put back inside
Fixes: #10191

#9810 took out the attackby code that handles re-inserting space suit gear.


🆑 
fix: Fixes space suits being unable to go back inside of Suit Storage Units
/ 🆑 