### PR TITLE
Makes a few more machines movable

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -44,6 +44,9 @@
 	return ..()
 
 /obj/machinery/pdapainter/attackby(obj/item/I, mob/user, params)
+	if(default_unfasten_wrench(user, I))
+		power_change()
+		return
 	if(istype(I, /obj/item/pda))
 		if(storedpda)
 			to_chat(user, "There is already a PDA inside.")

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -199,6 +199,9 @@
 	/*if(istype(W,/obj/item/screwdriver))
 		panel = !panel
 		to_chat(user, "<span class='notice'>you [panel ? </span>"open" : "close"] the [src]'s maintenance panel")*/
+	if(default_unfasten_wrench(user, W))
+		power_change()
+		return
 	if(istype(W,/obj/item/toy/crayon) ||istype(W,/obj/item/stamp))
 		if( state in list(	1, 3, 6 ) )
 			if(!crayon)

--- a/code/modules/library/computers/checkout.dm
+++ b/code/modules/library/computers/checkout.dm
@@ -199,6 +199,9 @@
 		to_chat(user, "<span class='notice'>You override the library computer's printing restrictions.</span>")
 
 /obj/machinery/computer/library/checkout/attackby(obj/item/W as obj, mob/user as mob)
+	if(default_unfasten_wrench(user, W))
+		power_change()
+		return
 	if(istype(W, /obj/item/barcodescanner))
 		var/obj/item/barcodescanner/scanner = W
 		scanner.computer = src

--- a/code/modules/library/computers/public.dm
+++ b/code/modules/library/computers/public.dm
@@ -6,6 +6,11 @@
 		return
 	interact(user)
 
+/obj/machinery/computer/library/public/attackby(obj/item/W as obj, mob/user as mob)
+	if(default_unfasten_wrench(user, W))
+		power_change()
+		return
+
 /obj/machinery/computer/library/public/interact(var/mob/user)
 	if(interact_check(user))
 		return

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -151,6 +151,9 @@ var/global/list/library_section_names = list("Any", "Fiction", "Non-Fiction", "A
 	var/obj/item/book/cache		// Last scanned book
 
 /obj/machinery/libraryscanner/attackby(obj/item/I, mob/user)
+	if(default_unfasten_wrench(user, I))
+		power_change()
+		return
 	if(istype(I, /obj/item/book))
 		user.drop_item()
 		I.forceMove(src)
@@ -208,6 +211,9 @@ var/global/list/library_section_names = list("Any", "Fiction", "Non-Fiction", "A
 
 /obj/machinery/bookbinder/attackby(obj/item/I, mob/user)
 	var/obj/item/paper/P = I
+	if(default_unfasten_wrench(user, I))
+		power_change()
+		return
 	if(istype(P))
 		user.drop_item()
 		user.visible_message("[user] loads some paper into [src].", "You load some paper into [src].")

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -69,6 +69,9 @@
 	SSnanoui.update_uis(src)
 
 /obj/machinery/chem_heater/attackby(obj/item/I, mob/user)
+	if(default_unfasten_wrench(user, I))
+		power_change()
+		return
 	if(isrobot(user))
 		return
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -50,6 +50,9 @@
 			stat |= NOPOWER
 
 /obj/machinery/chem_master/attackby(obj/item/B, mob/user, params)
+	if(default_unfasten_wrench(user, B))
+		power_change()
+		return
 
 	if(istype(B, /obj/item/reagent_containers/glass) || istype(B, /obj/item/reagent_containers/food/drinks/drinkingglass))
 

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -185,18 +185,18 @@
 			english_symptoms += S.name
 		var/symtoms = english_list(english_symptoms)
 
-		
+
 		var/signature
 		if(alert(user,"Would you like to add your signature?",,"Yes","No") == "Yes")
 			signature = "<font face=\"[SIGNFONT]\"><i>[user ? user.real_name : "Anonymous"]</i></font>"
-		else 
+		else
 			signature = "<span class=\"paper_field\"></span>"
-		
+
 		printing = 1
 		var/obj/item/paper/P = new /obj/item/paper(loc)
 		visible_message("<span class='notice'>[src] rattles and prints out a sheet of paper.</span>")
 		playsound(loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
-		
+
 		P.info = "<U><font size=\"4\"><B><center> Releasing Virus </B></center></font></U>"
 		P.info += "<HR>"
 		P.info += "<U>Name of the Virus:</U> [D.name] <BR>"
@@ -318,6 +318,9 @@
 
 
 /obj/machinery/computer/pandemic/attackby(obj/item/I, mob/user, params)
+	if(default_unfasten_wrench(user, I))
+		power_change()
+		return
 	if(istype(I, /obj/item/reagent_containers) && (I.container_type & OPENCONTAINER))
 		if(stat & (NOPOWER|BROKEN))
 			return


### PR DESCRIPTION
**What does this PR do:**
This PR makes more machines unwrenchable, so that they can be moved, please tell me if I've done something wrong. I have left it so the chem dispenser cannot be unwrenched since that is the purpose of the portable chem dispenser.
Fixes #9983

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
:cl: CornMyCob
add: You can now unwrench and move the library machines/computers, chem master, chem heater, washing machine, pandemic and PDA painter
/:cl: