### PR TITLE
Borgs now can't get perma stunned by slings or goliaths and what not

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -207,7 +207,6 @@
 		canmove = 0
 	else
 		canmove = 1
-	update_stat("robot/update_canmove")
 	update_transform()
 	if(!delay_action_updates)
 		update_action_buttons_icon()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -9,7 +9,6 @@
 	clamp_values()
 
 	if(..())
-		update_stat("Robot/Life")
 		handle_robot_cell()
 		process_locks()
 		process_queued_alarms()
@@ -208,6 +207,7 @@
 		canmove = 0
 	else
 		canmove = 1
+	update_stat("robot/update_canmove")
 	update_transform()
 	if(!delay_action_updates)
 		update_action_buttons_icon()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -9,6 +9,7 @@
 	clamp_values()
 
 	if(..())
+		update_stat("Robot/Life")
 		handle_robot_cell()
 		process_locks()
 		process_queued_alarms()

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -34,6 +34,31 @@
 	// diag_hud_set_health()
 	// update_health_hud()
 
+/mob/living/silicon/robot/SetStunned(amount, updating = 1, force = 0) //if you REALLY need to set stun to a set amount without the whole "can't go below current stunned"
+	. = STATUS_UPDATE_CANMOVE
+	if((!!amount) == (!!stunned)) // We're not changing from + to 0 or vice versa
+		updating = FALSE
+		. = STATUS_UPDATE_NONE
+
+	if(status_flags & CANSTUN || force)
+		stunned = max(amount, 0)
+		if(updating)
+			update_stat()
+	else
+		return STATUS_UPDATE_NONE
+
+/mob/living/silicon/robot/SetWeakened(amount, updating = 1, force = 0)
+	. = STATUS_UPDATE_CANMOVE
+	if((!!amount) == (!!weakened)) // We're not changing from + to 0 or vice versa
+		updating = FALSE
+		. = STATUS_UPDATE_NONE
+	if(status_flags & CANWEAKEN || force)
+		weakened = max(amount, 0)
+		if(updating)
+			update_stat()
+	else
+		return STATUS_UPDATE_NONE
+
 /mob/living/silicon/robot/update_revive(updating = TRUE)
 	. = ..(updating)
 	if(.)


### PR DESCRIPTION
**What does this PR do:**
Borgs got knocked out by goliath stuns and sling screeches. And never got reset fully.
There surely is a better fix but I can't think of one right now.

fixes: #9871

**Changelog:**
:cl: Farie82
fix: Borgs can't get perma stunned anymore by goliaths and slings and such
/:cl:

