### PR TITLE
Enabled multi-cam at roundstart for AI

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -104,7 +104,7 @@ var/list/ai_verbs_default = list(
 
 	var/arrivalmsg = "$name, $rank, has arrived on the station."
 
-	var/multicam_allowed = FALSE
+	var/multicam_allowed = TRUE
 	var/multicam_on = FALSE
 	var/obj/screen/movable/pic_in_pic/ai/master_multicam
 	var/list/multicam_screens = list()


### PR DESCRIPTION
**What does this PR do:**
After testing over the last few weeks, little to no issues were found with the multicam system and positive feedback given. It is time now to see if we enable it or throw it in the bin.

This PR merely enabled it at round start for AI players.

:cl: Spartan
balance: AI Multi-Cam is now enabled at roundstart. The all seeing eye is unleashed.
/:cl:

