### PR TITLE
Applies repairing time to mining bots

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -79,11 +79,12 @@
 			if(AIStatus != AI_OFF && AIStatus != AI_IDLE)
 				to_chat(user, "<span class='info'>[src] is moving around too much to repair!</span>")
 				return
-			if(maxHealth == health)
-				to_chat(user, "<span class='info'>[src] is at full integrity.</span>")
-			else
-				adjustBruteLoss(-10)
-				to_chat(user, "<span class='info'>You repair some of the armor on [src].</span>")
+			if(do_after_once(user, 15, target = src))
+				if(maxHealth == health)
+					to_chat(user, "<span class='info'>[src] is at full integrity.</span>")
+				else
+					adjustBruteLoss(-20)
+					to_chat(user, "<span class='info'>You repair some of the armor on [src].</span>")
 			return
 	if(istype(I, /obj/item/mining_scanner) || istype(I, /obj/item/t_scanner/adv_mining_scanner))
 		to_chat(user, "<span class='info'>You instruct [src] to drop any collected ore.</span>")


### PR DESCRIPTION
**What does this PR do:**
Does the same thing that was done to mechs a bit back. Give them a repair time but up the healing,

fix points if needed: #9676

**Changelog:**
:cl: Farie82
balance: Healing a mining bot now takes time but heals more
/:cl:

