### PR TITLE
makes you harm mining bots with welders on anything but help

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -73,7 +73,7 @@
 	check_friendly_fire = 0
 
 /mob/living/simple_animal/hostile/mining_drone/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/weldingtool))
+	if(istype(I, /obj/item/weldingtool) && user.a_intent == INTENT_HELP)
 		var/obj/item/weldingtool/W = I
 		if(W.welding && !stat)
 			if(AIStatus != AI_OFF && AIStatus != AI_IDLE)


### PR DESCRIPTION
**What does this PR do:**
As the title says.
Hitting a mining bot on anything but help intent with an on welder now hits them instead.

fixes: #10196

**Changelog:**
:cl: Farie82
fix: You can now hurt mining bots with welders on any attempt other than help
/:cl:

