### PR TITLE
Can now put stuf back in suit storage units and some formatting fixes

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -412,7 +412,7 @@
 			dat+= text("Breathmask storage compartment: <B>[]</B><BR>",(mask ? mask.name : "</font><font color ='grey'>No breathmask detected.") )
 			if(mask && state_open)
 				dat+="<A href='?src=[UID()];dispense_mask=1'>Dispense mask</A><BR>"
-			dat+= text("Jetpack, Magboots storage compartment: <B>[]</B><BR>",(storage ? storage.name : "</font><font color ='grey'>No storage item detected.") )
+			dat+= text("Tank, Magboots storage compartment: <B>[]</B><BR>",(storage ? storage.name : "</font><font color ='grey'>No storage item detected.") )
 			if(storage && state_open)
 				dat+="<A href='?src=[UID()];dispense_storage=1'>Dispense storage item</A><BR>"
 			if(occupant)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -172,9 +172,9 @@
 		return
 	if(state_open)
 		if(store_item(I, user))
-			src.update_icon()
-			src.updateUsrDialog()
-			to_chat(user, "<span class='notice'>You load the [I.name] into the storage compartment.</span>")
+			update_icon()
+			updateUsrDialog()
+			to_chat(user, "<span class='notice'>You load the [I] into the storage compartment.</span>")
 		else
 			to_chat(user, "<span class='notice'>The unit already contains that item.</span>")
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -159,12 +159,44 @@
 
 /obj/machinery/suit_storage_unit/attackby(obj/item/I as obj, mob/user as mob, params)
 	if(!is_operational())
+		if(panel_open)
+			to_chat(usr, "<span class='warning'>Close the maintenance panel first.</span>")
+		else
+			to_chat(usr, "<span class='warning'>The unit is not operational.</span>")
 		return
 	if(isscrewdriver(I))
 		panel_open = !panel_open
 		playsound(loc, I.usesound, 100, 1)
 		to_chat(user, text("<span class='notice'>You [panel_open ? "open up" : "close"] the unit's maintenance panel.</span>"))
 		updateUsrDialog()
+		return
+	if(state_open)
+		if(store_item(I, user))
+			src.update_icon()
+			src.updateUsrDialog()
+			to_chat(user, "<span class='notice'>You load the [I.name] into the storage compartment.</span>")
+		else
+			to_chat(user, "<span class='notice'>The unit already contains that item.</span>")
+
+
+/obj/machinery/suit_storage_unit/proc/store_item(obj/item/I, mob/user)
+	. = FALSE
+	if(istype(I, /obj/item/clothing/suit/space) && !suit)
+		suit = I
+		. = TRUE
+	if(istype(I, /obj/item/clothing/head/helmet) && !helmet)
+		helmet = I
+		. = TRUE
+	if(istype(I, /obj/item/clothing/mask) && !mask)
+		mask = I
+		. = TRUE
+	if((istype(I, /obj/item/tank) || istype(I, /obj/item/clothing/shoes/magboots)) && !storage)
+		storage = I
+		. = TRUE
+	if(.)
+		user.drop_item()
+		I.forceMove(src)
+
 
 /obj/machinery/suit_storage_unit/power_change()
 	..()
@@ -380,7 +412,7 @@
 			dat+= text("Breathmask storage compartment: <B>[]</B><BR>",(mask ? mask.name : "</font><font color ='grey'>No breathmask detected.") )
 			if(mask && state_open)
 				dat+="<A href='?src=[UID()];dispense_mask=1'>Dispense mask</A><BR>"
-			dat+= text("Breathmask storage compartment: <B>[]</B><BR>",(storage ? storage.name : "</font><font color ='grey'>No storage item detected.") )
+			dat+= text("Jetpack, Magboots storage compartment: <B>[]</B><BR>",(storage ? storage.name : "</font><font color ='grey'>No storage item detected.") )
 			if(storage && state_open)
 				dat+="<A href='?src=[UID()];dispense_storage=1'>Dispense storage item</A><BR>"
 			if(occupant)


### PR DESCRIPTION
**What does this PR do:**
You can now put your suit and such back in.
I made it so that every spacesuit, mask,  space helmet and every magboots or tank can be put in.
Small text change since it said Breathmask storage for the magboots/tank storage.
Also changes the feedback you get when it's not working.

fixes: #10191 
Sorry Ty, saw your PR once mine was done :(

**Changelog:**
:cl: Farie82
fix: Can put suits and such back into the suit storage units
spellcheck: Fixed the tank/magboots storage part being called Breathmask storage, lazy copy pasta
/:cl:

