### PR TITLE
Grammar fix for 'booger' cocktail and feral cat grenades

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -232,7 +232,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific/cat_grenade
 	name = "Feral Cat Delivery Grenade"
-	desc = "The feral cat delivery grenade contains 8 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
+	desc = "The feral cat delivery grenade contains 5 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
 	item = /obj/item/grenade/spawnergrenade/feral_cats
 	reference = "CCLG"
 	cost = 4

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -45,7 +45,7 @@
 
 /obj/item/grenade/spawnergrenade/feral_cats
 	name = "feral cat delivery grenade"
-	desc = "This grenade contains 8 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
+	desc = "This grenade contains 5 dehydrated feral cats in a similar manner to dehydrated monkeys, which, upon detonation, will be rehydrated by a small reservoir of water contained within the grenade. These cats will then attack anything in sight."
 	spawner_type = /mob/living/simple_animal/hostile/feral_cat
 	deliveryamt = 5
 	origin_tech = "materials=3;magnets=4;syndicate=3"

--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -396,13 +396,13 @@
 /datum/reagent/consumable/ethanol/booger
 	name = "Booger"
 	id = "booger"
-	description = "Ewww..."
+	description = "Eww..."
 	reagent_state = LIQUID
 	color = "#A68310" // rgb: 166, 131, 16
 	alcohol_perc = 0.2
 	drink_icon = "booger"
 	drink_name = "Booger"
-	drink_desc = "Ewww..."
+	drink_desc = "Eww..."
 	taste_message = "sweet alcohol"
 
 /datum/reagent/consumable/ethanol/bloody_mary


### PR DESCRIPTION
**What does this PR do:**
The 'booger' cocktail's description when examined will attempt to create a hyperlink in the chat window due to it containing "www.":

![image](https://user-images.githubusercontent.com/44248086/48317180-4785f400-e5e6-11e8-8ac4-e7bece2c6c4a.png)

This PR stops that happening through the magic power of the backspace key.

The cat grenade states on both the uplink and grenade itself that is spawns 8 cats when primed and thrown, but actually spawns 5 like the other spawner grenades. Since even the Syndicate aren't evil enough to oversell their own goods, this was updated to 5 for both descriptions.

**Images of sprite/map changes (IF APPLICABLE):**

N/A

**Changelog:**
:cl: Azule Utama
spellcheck: Fixed text errors in the descriptions for Booger cocktails and Feral cat grenades.
/:cl:

