### PR TITLE
Card Deck Fix

### DIFF
--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -220,24 +220,20 @@
 	if(M.incapacitated() || !Adjacent(M))
 		return
 
-	if(over_object == M)
+	if(over_object == M || istype(over_object, /obj/screen))
 		if(!remove_item_from_storage(M))
 			M.unEquip(src)
-		M.put_in_hands(src)
+		if(over_object != M)
+			switch(over_object.name)
+				if("r_hand")
+					M.put_in_r_hand(src)
+				if("l_hand")
+					M.put_in_l_hand(src)
+		else
+			M.put_in_hands(src)
 
-	else if(istype(over_object, /obj/screen))
-		switch(over_object.name)
-			if("r_hand")
-				if(!remove_item_from_storage(M))
-					M.unEquip(src)
-				M.put_in_r_hand(src)
-			if("l_hand")
-				if(!remove_item_from_storage(M))
-					M.unEquip(src)
-				M.put_in_l_hand(src)
-
-	add_fingerprint(M)
-	usr.visible_message("<span class='notice'>[usr] picks up the deck.</span>")
+		add_fingerprint(M)
+		usr.visible_message("<span class='notice'>[usr] picks up the deck.</span>")
 
 /obj/item/pack
 	name = "Card Pack"


### PR DESCRIPTION
Fixes a bug (no associated issue) where decks of cards would display the "[user] picks up the deck" message even if the mouse was dragged onto a non-user object (The ground, a chair, the table. Literally anything).

:cl:
balance: Rewrites the morality core of playing card decks. They are no longer allowed to lie to you.
/:cl:

