### PR TITLE
Fixed 2 issues with old station

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -24,7 +24,7 @@
 "ax" = (/obj/effect/decal/remains/robot{icon_state = "gib5"},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/space/ancientstation/hivebot)
 "ay" = (/obj/structure/shuttle/engine/large{icon_state = "large_engine"; dir = 4},/turf/simulated/wall,/area/ruin/space/ancientstation/hivebot)
 "az" = (/turf/simulated/wall/rust,/area/ruin/space/ancientstation)
-"aA" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/obj/machinery/door_control{id = "ancient"; name = "Charlie Station Lockdown Button"},/turf/simulated/floor/plasteel,/area/ruin/space/ancientstation/comm)
+"aA" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/obj/machinery/door_control{id = "ancient"; name = "Charlie Station Lockdown Button"; range = 30},/turf/simulated/floor/plasteel,/area/ruin/space/ancientstation/comm)
 "aB" = (/obj/effect/decal/cleanable/dirt,/obj/structure/chair{dir = 1},/turf/simulated/floor/plasteel,/area/ruin/space/ancientstation/comm)
 "aC" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/obj/item/toy/cards/deck,/obj/item/folder/blue,/obj/item/pen,/turf/simulated/floor/plasteel,/area/ruin/space/ancientstation/comm)
 "aD" = (/obj/machinery/door/airlock/highsecurity,/turf/simulated/floor/plating,/area/ruin/space/ancientstation/hivebot)
@@ -208,7 +208,7 @@
 "dZ" = (/obj/machinery/computer{desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages."; name = "Broken Computer"},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plasteel{icon_state = "red"; dir = 1},/area/ruin/space/ancientstation/sec)
 "ea" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/firealarm{dir = 4; pixel_x = -28},/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plasteel,/area/ruin/space/ancientstation/deltacorridor)
 "eb" = (/obj/machinery/light{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/plasteel{icon_state = "white"},/area/ruin/space/ancientstation/rnd)
-"ec" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/computer/rdconsole/core,/turf/simulated/floor/plasteel{icon_state = "white"},/area/ruin/space/ancientstation/rnd)
+"ec" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/computer/rdconsole/public,/turf/simulated/floor/plasteel{icon_state = "white"},/area/ruin/space/ancientstation/rnd)
 "ed" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/r_n_d/destructive_analyzer,/turf/simulated/floor/plasteel{icon_state = "white"},/area/ruin/space/ancientstation/rnd)
 "ee" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/mecha_part_fabricator,/turf/simulated/floor/plasteel{icon_state = "white"},/area/ruin/space/ancientstation/rnd)
 "ef" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table,/obj/item/stack/sheet/metal/fifty,/obj/item/stack/sheet/glass/fifty{pixel_x = 2; pixel_y = -2},/turf/simulated/floor/plasteel{icon_state = "white"},/area/ruin/space/ancientstation/rnd)
@@ -660,3 +660,4 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagcaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}
+


### PR DESCRIPTION
**What does this PR do:**
This fixes 2 issues with the ancient station space ruin, making it actually playable
If fixes #10110 by making the RD console public
It fixes #10109 by increasing the range of the button to cover the blast doors.

**Changelog:**
:cl: 
fix: Ancient station's lockdown is now lifted correctly.
fix: Ancient station RD console can now be used.
/:cl:

