### PR TITLE
Internal Bleeding Rework

### DIFF
--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -115,7 +115,7 @@
 			custom_emote(1, "coughs up blood!")
 			add_splatter_floor(loc, 1)
 			return 1
-		else if (amt >= 1 && prob(10 * amt)) // +5% chance per internal bleeding site that we'll cough up blood on a given tick. Must be bleeding internally in more than one place to have a chance at this.
+		else if (amt >= 1 && prob(5 * amt)) // +2.5% chance per internal bleeding site that we'll cough up blood on a given tick. Must be bleeding internally in more than one place to have a chance at this.
 			vomit(0, 1)
 			return 2
 	return 0

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -85,7 +85,7 @@
 		bleed_rate = max(bleed_rate - 0.5, temp_bleed)//if no wounds, other bleed effects (heparin) naturally decreases
 
 		if(internal_bleeding_rate && !(status_flags & FAKEDEATH))
-			bleed(internal_bleeding_rate)
+			bleed_internal(internal_bleeding_rate)
 
 		if(bleed_rate && !bleedsuppress && !(status_flags & FAKEDEATH))
 			bleed(bleed_rate)
@@ -104,6 +104,26 @@
 	if(!(NO_BLOOD in dna.species.species_traits))
 		..()
 		if(dna.species.exotic_blood)
+			var/datum/reagent/R = GLOB.chemical_reagents_list[get_blood_id()]
+			if(istype(R) && isturf(loc))
+				R.reaction_turf(get_turf(src), amt * EXOTIC_BLEED_MULTIPLIER)
+
+/mob/living/carbon/proc/bleed_internal(amt) // Return 1 if we've coughed blood up, 2 if we're vomited it.
+	if(blood_volume)
+		blood_volume = max(blood_volume - amt, 0)
+		if (prob(10 * amt)) // +5% chance per internal bleeding site that we'll cough up blood on a given tick.
+			custom_emote(1, "coughs up blood!")
+			add_splatter_floor(loc, 1)
+			return 1
+		else if (amt >= 1 && prob(10 * amt)) // +5% chance per internal bleeding site that we'll cough up blood on a given tick. Must be bleeding internally in more than one place to have a chance at this.
+			vomit(0, 1)
+			return 2
+	return 0
+
+/mob/living/carbon/human/bleed_internal(amt)
+	if(!(NO_BLOOD in dna.species.species_traits))
+		.=..()
+		if(dna.species.exotic_blood && .) // Do we have exotic blood, and have we left any on the ground?
 			var/datum/reagent/R = GLOB.chemical_reagents_list[get_blood_id()]
 			if(istype(R) && isturf(loc))
 				R.reaction_turf(get_turf(src), amt * EXOTIC_BLEED_MULTIPLIER)


### PR DESCRIPTION
This PR proposes a slight rework to how internal bleeding manifests. Currently internal bleeding is represented by the mob occasionally dripping blood on the floor exact how external bleeding does, which isn't a great way to show the player they're bleeding *internally*. This rework makes internal bleeding manifest in the following ways: There's a 5% chance per internally bleeding wound that the mob will cough up blood on a bleed cycle. If the mob has more than one wound with internal bleeding there's also a 2.5% chance per wound that the mob will vomit blood.

Basically: The more severe the internal bleeding, the more frequently you'll be coughing (Or maybe vomiting) blood!

Note: This PR *does not* change the rate of blood loss for internal bleeding or anything similar, the differences are entirely cosmetic.

Fix(es?), unsure how many the maints want to charge me for this: #10160, #10210, #9922

:cl:
tweak: Internal bleeding is now represented by coughing (And occasionally vomiting) blood! Nifty!
/:cl:

