### PR TITLE
X-ray laser nerf - Falloff and Charge

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -59,7 +59,7 @@
 
 /obj/item/ammo_casing/energy/xray
 	projectile_type = /obj/item/projectile/beam/xray
-	e_cost = 50
+	e_cost = 100
 	fire_sound = 'sound/weapons/laser3.ogg'
 
 /obj/item/ammo_casing/energy/immolator

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -111,7 +111,7 @@
 
 /obj/item/gun/energy/xray
 	name = "xray laser gun"
-	desc = "A high-power laser gun capable of expelling concentrated xray blasts."
+	desc = "A high-power laser gun capable of expelling concentrated xray blasts. These blasts will penetrate solid objects, but will decrease in power the longer they have to travel."
 	icon_state = "xray"
 	origin_tech = "combat=6;materials=4;magnets=4;syndicate=1"
 	ammo_type = list(/obj/item/ammo_casing/energy/xray)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -32,6 +32,8 @@
 	animate_movement = 0
 
 	var/damage = 10
+	var/tile_dropoff = 0	//how much damage should be decremented as the bullet moves
+	var/tile_dropoff_s = 0	//same as above but for stamina
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
 	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb	//Cael - bio and rad are also valid
@@ -60,9 +62,15 @@
 	return ..()
 
 /obj/item/projectile/proc/Range()
-	range--
-	if(range <= 0 && loc)
-		on_range()
+    range--
+    if(damage > 0)
+        damage = max(0, damage - tile_dropoff) // decrement projectile damage based on dropoff value for each tile it moves
+    if(stamina > 0)
+        stamina = max(0, stamina - tile_dropoff_s) // as above, but with stamina
+    if(range <= 0 && loc)
+        on_range()
+    if(damage == 0 && stamina == 0)
+        on_range()
 
 /obj/item/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range
 	qdel(src)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -63,9 +63,9 @@
 
 /obj/item/projectile/proc/Range()
     range--
-    if(damage > 0)
+    if(damage > 0 && tile_dropoff)
         damage = max(0, damage - tile_dropoff) // decrement projectile damage based on dropoff value for each tile it moves
-    if(stamina > 0)
+    if(stamina > 0 && tile_dropoff)
         stamina = max(0, stamina - tile_dropoff_s) // as above, but with stamina
     if(range <= 0 && loc)
         on_range()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -63,13 +63,13 @@
 
 /obj/item/projectile/proc/Range()
     range--
-    if(damage > 0 && tile_dropoff)
+    if(damage && tile_dropoff)
         damage = max(0, damage - tile_dropoff) // decrement projectile damage based on dropoff value for each tile it moves
-    if(stamina > 0 && tile_dropoff)
+    if(stamina && tile_dropoff_s)
         stamina = max(0, stamina - tile_dropoff_s) // as above, but with stamina
     if(range <= 0 && loc)
         on_range()
-    if(damage == 0 && stamina == 0)
+    if(!damage && !stamina)
         on_range()
 
 /obj/item/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -34,6 +34,7 @@
 	name = "xray beam"
 	icon_state = "xray"
 	damage = 15
+	tile_dropoff = 0.75
 	irradiate = 30
 	forcedodge = 1
 	range = 15

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -69,17 +69,8 @@
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
 	damage = 12.5
-	var/tile_dropoff = 0.75
-	var/tile_dropoff_s = 1.25
-
-/obj/item/projectile/bullet/pellet/Range()
-	..()
-	if(damage > 0)
-		damage -= tile_dropoff
-	if(stamina > 0)
-		stamina -= tile_dropoff_s
-	if(damage < 0 && stamina < 0)
-		qdel(src)
+	tile_dropoff = 0.75
+	tile_dropoff_s = 1.25
 
 /obj/item/projectile/bullet/pellet/rubber
 	name = "rubber pellet"


### PR DESCRIPTION
See here for the main reasoning behind the PR -
https://nanotrasen.se/forum/topic/14790-wanted-unwanted-features-refactors-bugfixes-thread/

**What does this PR do:**
This PR increases the charge used by x-ray lasers to 100 and introduces the falloff mechanic to all projectiles that set the _tile_dropoff_ or _tile_dropoff_s_ variable higher than 0. This mechanic is also used to make X-ray shots reduce in damage for every tile they travel (0.75 damage lost per tile). Some old code for shotgun pellets which exclusively used this mechanic before has been removed since it now inherits it directly from the projectiles code (though the values that were used for it remain the same after the change).

As a very minor change in addition to the above, the xray laser's description has been changed to state it will deal lower damage the longer it travels, as well as the fact it penetrates walls as always.

Also I'm aware the forum thread states it was meant to 1 damage reduced per tile, but this was on the basis that shots started at 20 damage when they actually start at 15. This was discussed in Discord and can be changed if needed.

**Images of sprite/map changes (IF APPLICABLE):**
If you did not make a map or sprite edit, you may leave this section blank. You may include a gif of your feature if you want

**Changelog:**
:cl: Azule Utama
tweak: Changed falloff damage to be usable on any desired projectile rather than just shotgun pellets.
balance: X-ray lasers now use 100 charge per shot (previously 50).
balance: X-ray laser guns now have falloff damage. The longer the laser is in the air, the lower its damage becomes.
spellcheck: Slight addition to X-ray laser's description.
/:cl:

