### PR TITLE
Fix for shuttle curse item

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -257,6 +257,7 @@
 		SSshuttle.emergency.setTimer(timer)
 		to_chat(user,"<span class='danger'>You shatter the orb! A dark essence spirals into the air, then disappears.</span>")
 		playsound(user.loc, 'sound/effects/Glassbr1.ogg', 50, 1)
+		curselimit++
 		qdel(src)
 		sleep(20)
 		var/global/list/curses
@@ -270,7 +271,6 @@
 			"Steve repeatedly touched a lightbulb until his hands fell off. The shuttle will be delayed by two minutes.")
 		var/message = pick(curses)
 		command_announcement.Announce("[message]", "System Failure", 'sound/misc/notice1.ogg')
-		curselimit++
 
 /obj/item/cult_shift
 	name = "veil shifter"


### PR DESCRIPTION
**What does this PR do:**
With the shuttle curse, you are supposed to only be able to use it twice before it stops you delaying it any more. On the last round, cultists were able to use the shuttle curse 6 times during the shuttle call and stall the round for another 18 minutes:

![image](https://user-images.githubusercontent.com/44248086/48523300-c479cd80-e873-11e8-9eeb-a0bcdcbae039.png)

I had a dig in the code afterwoods and found what appears to be the issue. The `curselimit` global variable is set to increment at the end of the script, which also involves it waiting on a `sleep` to finish between using the orb and generating the random command message. If cultists are fast enough, they can keep using orbs in this brief `sleep` period and delay the shuttle more than twice.

I simply moved the increment for the variable to just before the delay. Testing both before and after this showed that it now stops you from using it more than twice like it should.

**Images of sprite/map changes (IF APPLICABLE):**

N/A

**Changelog:**
:cl: Azule Utama
fix: Fixed an exploit which allowed cultists to curse the shuttle more than twice. Steve can only take so much punishment ya know...
/:cl:

