### PR TITLE
Asset Cache speed (tgstation/tgstation#35003 + more)

### DIFF
--- a/code/controllers/master_controller.dm
+++ b/code/controllers/master_controller.dm
@@ -55,7 +55,6 @@ var/global/pipe_processing_killed = 0
 
 	space_manager.do_transition_setup()
 
-	setup_asset_cache()
 	setupfactions()
 	setup_economy()
 
@@ -63,9 +62,3 @@ var/global/pipe_processing_killed = 0
 		make_mining_asteroid_secret()
 
 	populate_spawn_points()
-
-/datum/controller/game_controller/proc/setup_asset_cache()
-	var/watch = start_watch()
-	log_startup_progress("Populating asset cache...")
-	populate_asset_cache()
-	log_startup_progress("	Populated [asset_cache.len] assets in [stop_watch(watch)]s.")

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -1,0 +1,17 @@
+SUBSYSTEM_DEF(assets)
+	name = "Assets"
+	init_order = INIT_ORDER_ASSETS
+	flags = SS_NO_FIRE
+	var/list/cache = list()
+	var/list/preload = list()
+
+/datum/controller/subsystem/assets/Initialize(timeofday)
+	for(var/type in typesof(/datum/asset) - list(/datum/asset, /datum/asset/simple))
+		var/datum/asset/A = new type()
+		A.register()
+
+	preload = cache.Copy() //don't preload assets generated during the round
+
+	for(var/client/C in GLOB.clients)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/getFilesSlow, C, preload, FALSE), 10)
+	..()

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -17,8 +17,8 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 //When sending mutiple assets, how many before we give the client a quaint little sending resources message
 #define ASSET_CACHE_TELL_CLIENT_AMOUNT 8
 
-//List of ALL assets for the above, format is list(filename = asset).
-/var/global/list/asset_cache = list()
+//When passively preloading assets, how many to send at once? Too high creates noticable lag where as too low can flood the client's cache with "verify" files 
+#define ASSET_CACHE_PRELOAD_CONCURRENT 3 
 
 /client
 	var/list/cache = list() // List of all assets sent to this client by the asset cache.
@@ -44,13 +44,10 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	if(client.cache.Find(asset_name) || client.sending.Find(asset_name))
 		return 0
 
-	client << browse_rsc(asset_cache[asset_name], asset_name)
-	if(!verify || !winexists(client, "asset_cache_browser")) // Can't access the asset cache browser, rip.
-		if(client)
-			client.cache += asset_name
+	client << browse_rsc(SSassets.cache[asset_name], asset_name)
+	if(!verify) // Can't access the asset cache browser, rip.
+		client.cache += asset_name
 		return 1
-	if(!client)
-		return 0
 
 	client.sending |= asset_name
 	var/job = ++client.last_asset_job
@@ -94,15 +91,13 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	if(unreceived.len >= ASSET_CACHE_TELL_CLIENT_AMOUNT)
 		to_chat(client, "Sending Resources...")
 	for(var/asset in unreceived)
-		if(asset in asset_cache)
-			client << browse_rsc(asset_cache[asset], asset)
+		if(asset in SSassets.cache)
+			client << browse_rsc(SSassets.cache[asset], asset)
 
-	if(!verify || !winexists(client, "asset_cache_browser")) // Can't access the asset cache browser, rip.
-		if(client)
-			client.cache += unreceived
+	if(!verify) // Can't access the asset cache browser, rip.
+		client.cache += unreceived
 		return 1
-	if(!client)
-		return 0
+
 	client.sending |= unreceived
 	var/job = ++client.last_asset_job
 
@@ -127,30 +122,25 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 //This proc will download the files without clogging up the browse() queue, used for passively sending files on connection start.
 //The proc calls procs that sleep for long times.
-proc/getFilesSlow(var/client/client, var/list/files, var/register_asset = TRUE)
+/proc/getFilesSlow(var/client/client, var/list/files, var/register_asset = TRUE)
+	var/concurrent_tracker = 1
 	for(var/file in files)
 		if(!client)
 			break
 		if(register_asset)
-			register_asset(file,files[file])
-		send_asset(client,file)
-		sleep(-1) //queuing calls like this too quickly can cause issues in some client versions
+			register_asset(file, files[file])
+		if(concurrent_tracker >= ASSET_CACHE_PRELOAD_CONCURRENT)
+			concurrent_tracker = 1
+			send_asset(client, file)
+		else
+			concurrent_tracker++
+			send_asset(client, file, verify = FALSE)
+		sleep(0) //queuing calls like this too quickly can cause issues in some client versions
 
 //This proc "registers" an asset, it adds it to the cache for further use, you cannot touch it from this point on or you'll fuck things up.
 //if it's an icon or something be careful, you'll have to copy it before further use.
 /proc/register_asset(var/asset_name, var/asset)
-	asset_cache[asset_name] = asset
-
-//From here on out it's populating the asset cache.
-/proc/populate_asset_cache()
-	for(var/type in typesof(/datum/asset) - list(/datum/asset, /datum/asset/simple))
-		var/datum/asset/A = new type()
-		A.register()
-
-	for(var/client/C in GLOB.clients)
-		//doing this to a client too soon after they've connected can cause issues, also the proc we call sleeps
-		spawn(10)
-			getFilesSlow(C, asset_cache, FALSE)
+	SSassets.cache[asset_name] = asset
 
 //These datums are used to populate the asset cache, the proc "register()" does this.
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -642,9 +642,9 @@
 		'html/search.js', // Used in various non-NanoUI HTML windows for search functionality
 		'html/panels.css' // Used for styling certain panels, such as in the new player panel
 	)
-	spawn (10)
+	spawn (10) //removing this spawn causes all clients to not get verbs.
 		//Precache the client with all other assets slowly, so as to not block other browse() calls
-		getFilesSlow(src, asset_cache, register_asset = FALSE)
+		getFilesSlow(src, SSassets.preload, register_asset = FALSE)
 
 //For debugging purposes
 /client/proc/list_all_languages()

--- a/paradise.dme
+++ b/paradise.dme
@@ -203,6 +203,7 @@
 #include "code\controllers\ProcessScheduler\core\process.dm"
 #include "code\controllers\ProcessScheduler\core\processScheduler.dm"
 #include "code\controllers\subsystem\air.dm"
+#include "code\controllers\subsystem\assets.dm"
 #include "code\controllers\subsystem\atoms.dm"
 #include "code\controllers\subsystem\fires.dm"
 #include "code\controllers\subsystem\garbage.dm"


### PR DESCRIPTION
The primary purpose of this is porting the improvements in tgstation/tgstation#35003. The asset cache now sends files significantly faster during preloading, which should help to avoid the issues we've encounted with NanoUI not having all of it's templates loaded by the time that someone might try to open a UI window.

We should look at porting these PRs in the future;
 - tgstation/tgstation#29690
 - tgstation/tgstation#37399

No screenshots because... what do you want to see? It's an invisible background system.

:cl:
add: SPEEEEEEEED to the asset cache, making preloaded UI assets transfer much faster.
/:cl: