### PR TITLE
Admin SSD tool update

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -115,7 +115,9 @@ var/global/nologevent = 0
 		body += {" | <A href='?_src_=holder;Bless=[M.UID()]'>Bless</A> | <A href='?_src_=holder;Smite=[M.UID()]'>Smite</A>"}
 
 	if(isLivingSSD(M))
-		if(!istype(M.loc, /obj/machinery/cryopod))
+		if(istype(M.loc, /obj/machinery/cryopod))
+			body += {" | <A href='?_src_=holder;cryossd=[M.UID()]'>De-Spawn</A> "}
+		else
 			body += {" | <A href='?_src_=holder;cryossd=[M.UID()]'>Cryo</A> "}
 
 	if(M.client)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1961,8 +1961,12 @@
 		if(!isLivingSSD(H))
 			to_chat(usr, "This can only be used on living, SSD players.")
 			return
-		var/success = cryo_ssd(H)
-		if(success)
+		if(istype(H.loc, /obj/machinery/cryopod))
+			var/obj/machinery/cryopod/P = H.loc
+			P.despawn_occupant()
+			log_admin("[key_name(usr)] despawned [H.job] [H] in cryo.")
+			message_admins("[key_name_admin(usr)] despawned [H.job] [H] in cryo.")
+		else if(cryo_ssd(H))
 			log_admin("[key_name(usr)] sent [H.job] [H] to cryo.")
 			message_admins("[key_name_admin(usr)] sent [H.job] [H] to cryo.")
 	else if(href_list["FaxReplyTemplate"])

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -984,15 +984,22 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		if(job_string in command_positions)
 			job_string = "<U>" + job_string + "</U>"
 		role_string = "-"
+		var/obj_count = 0
+		var/obj_string = ""
 		if(H.mind)
 			if(H.mind.special_role)
 				role_string = "<U>[H.mind.special_role]</U>"
 			if(!H.key && H.mind.key)
 				key_string = H.mind.key
-		msg += "<TR><TD>[key_string]</TD><TD>[H.real_name]</TD><TD>[job_string]</TD><TD>[mins_ssd]</TD><TD>[role_string]</TD>"
+			for(var/datum/objective/O in all_objectives)
+				if(O.target == H.mind)
+					obj_count++
+			if(obj_count > 0)
+				obj_string = "<BR><U>Obj Target</U>"
+		msg += "<TR><TD>[key_string]</TD><TD>[H.real_name]</TD><TD>[job_string]</TD><TD>[mins_ssd]</TD><TD>[role_string][obj_string]</TD>"
 		msg += "<TD>[get_area(H)]</TD><TD>[ADMIN_PP(H,"PP")]</TD>"
 		if(istype(H.loc, /obj/machinery/cryopod))
-			msg += "<TD>In Cryo</TD>"
+			msg += "<TD><A href='?_src_=holder;cryossd=[H.UID()]'>De-Spawn</A></TD>"
 		else
 			msg += "<TD><A href='?_src_=holder;cryossd=[H.UID()]'>Cryo</A></TD>"
 		msg += "</TR>"


### PR DESCRIPTION
:cl: Kyep
add: The admin verb to list SSD players now highlights players who are another player's antag target. Additionally it lets you despawn players whose body is already in cryo.
/:cl:

![new_cryo_options](https://user-images.githubusercontent.com/16434066/48595009-eb570300-e94a-11e8-8e2f-a302e79babd3.PNG)

Improved tool functionality requested by various admins.
Headmin signoff by Free.