### PR TITLE
Fix for floor cluwnes telling admins they failed to find a valid smite target about 100 times

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -151,8 +151,9 @@
 		if(specific)
 			H = specific
 			if((!H || H.stat == DEAD) && smiting)//safety check, target somehow DIED after we sent a smite
-				message_admins("Smiting Floor Cluwne was deleted due to a lack of valid target. Someone killed them first.")
+				message_admins("Smiting Floor Cluwne was deleted due to a lack of valid target. Someone killed them first, or they ceased to exist.")
 				qdel(src)
+				return
 			if(H.stat != DEAD && !isLivingSSD(H) &&  H.client && !H.get_int_organ(/obj/item/organ/internal/honktumor/cursed) && !is_type_in_typecache(get_area(H.loc), invalid_area_typecache))
 				current_victim = H
 				return target = current_victim


### PR DESCRIPTION
I forgot to return out of a while loop...

:cl:
fix:Floorcluwnes will no longer prank admins with logging messages of why they got deleted.
/:cl: