### PR TITLE
Syndicate borgs are no longer pseudonymous on syndie radio. 

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -658,7 +658,7 @@ var/global/list/default_medbay_channels = list(
 	subspace_transmission = 1
 
 /obj/item/radio/borg/syndicate
-	keyslot = new /obj/item/encryptionkey/syndicate
+	keyslot = new /obj/item/encryptionkey/syndicate/nukeops
 
 /obj/item/radio/borg/syndicate/CanUseTopic(mob/user, datum/topic_state/state)
 	. = ..()


### PR DESCRIPTION
**What does this PR do:**
Fixes #10248

**Changelog:**
:cl: uc_guy
fix: Syndicate borgs are no longer pseudonymous on syndie radio. 
/:cl:

