### PR TITLE
NTTC Fixes And Features

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -455,7 +455,7 @@ proc/checkhtml(var/t)
 
 
 // Pencode
-/proc/pencode_to_html(text, mob/user, obj/item/pen/P = null, format = 1, sign = 1, fields = 1, deffont = PEN_FONT, signfont = SIGNFONT, crayonfont = CRAYON_FONT)
+/proc/pencode_to_html(text, mob/user, obj/item/pen/P = null, format = 1, sign = 1, fields = 1, deffont = PEN_FONT, signfont = SIGNFONT, crayonfont = CRAYON_FONT, no_font = FALSE)
 	text = replacetext(text, "\[b\]",		"<B>")
 	text = replacetext(text, "\[/b\]",		"</B>")
 	text = replacetext(text, "\[i\]",		"<I>")
@@ -509,10 +509,12 @@ proc/checkhtml(var/t)
 		text = replacetext(text, "\[cell\]",	"<td>")
 		text = replacetext(text, "\[logo\]",	"<img src = ntlogo.png>")
 		text = replacetext(text, "\[time\]",	"[station_time_timestamp()]") // TO DO
-	if(P)
-		text = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[text]</font>"
-	else
-		text = "<font face=\"[deffont]\">[text]</font>"
+		if(!no_font)
+			if(P)
+				text = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[text]</font>"
+			else
+				text = "<font face=\"[deffont]\">[text]</font>"
+    
 	text = copytext(text, 1, MAX_PAPER_MESSAGE_LEN)
 	return text
 

--- a/code/game/machinery/telecomms/ntsl2.dm
+++ b/code/game/machinery/telecomms/ntsl2.dm
@@ -349,7 +349,7 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 		var/new_message = original
 		for(var/reg in regex)
 			var/replacePattern = pencode_to_html(regex[reg])
-			var/regex/start = regex("\\b[reg]\\b", "gi")
+			var/regex/start = regex("[reg]", "gi")
 			new_message = start.Replace(new_message, replacePattern)
 		signal.data["message"] = new_message
 

--- a/code/game/machinery/telecomms/ntsl2.dm
+++ b/code/game/machinery/telecomms/ntsl2.dm
@@ -25,6 +25,8 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 	/* Simple Toggles */
 	var/toggle_activated = TRUE
 	var/toggle_jobs = FALSE
+	var/toggle_job_color = FALSE
+	var/toggle_name_color = FALSE
 	var/toggle_timecode = FALSE
 	var/toggle_command_bold = FALSE
 	// Hack section
@@ -57,6 +59,8 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 	var/list/to_serialize = list(
 		"toggle_activated",
 		"toggle_jobs",
+		"toggle_job_color",
+		"toggle_name_color",
 		"job_indicator_type",
 		"toggle_timecode",
 		"toggle_command_bold",
@@ -71,6 +75,8 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 	var/list/serialize_sanitize = list(
 		"toggle_activated" = "bool",
 		"toggle_jobs" = "bool",
+		"toggle_job_color" = "bool",
+		"toggle_name_color" = "bool",
 		"job_indicator_type" = "string",
 		"toggle_timecode" = "bool",
 		"toggle_command_bold" = "bool",
@@ -92,6 +98,8 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 	/* Simple Toggles */
 	toggle_activated = initial(toggle_activated)
 	toggle_jobs = initial(toggle_jobs)
+	toggle_job_color = initial(toggle_job_color)
+	toggle_name_color = initial(toggle_name_color)
 	toggle_timecode = initial(toggle_timecode)
 	toggle_command_bold = initial(toggle_command_bold)
 	// Hack section
@@ -171,12 +179,10 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 		if(firewall.Find(signal.data["name"]))
 			signal.data["reject"] = 1
 
-	// These two stack properly.
-	// Simple job indicator switch.
-	if(job_indicator_type)
-		var/new_name = signal.data["name"]
-		var/job = signal.data["job"]
+	// All job and coloring shit 
+	if(toggle_job_color || toggle_name_color)
 		var/job_color = "#000000"
+		var/job = signal.data["job"]
 		if(job in jobs_ai)
 			job_color = "#FF00FF"
 		else if(job in jobs_command)
@@ -185,7 +191,6 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 			job_color = "#A66300"
 		else if(job in jobs_ert)
 			job_color = "#5C5C7C"
-			job = "ERT"
 		else if(job in jobs_medical)
 			job_color = "#009190"
 		else if(job in jobs_science)
@@ -196,18 +201,40 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 			job_color = "#7F6539"
 		else if(job in jobs_service)
 			job_color = "#80A000"
-		switch(job_indicator_type)
-			if(JOB_STYLE_1)
-				new_name = signal.data["name"] + " <font color=\"[job_color]\">([job])</font> "
-			if(JOB_STYLE_2)
-				new_name = signal.data["name"] + " - <font color=\"[job_color]\">[job]</font> "
-			if(JOB_STYLE_3)
-				new_name = "<font color=\"[job_color]\"><small>\[[job]\]</small></font> " + signal.data["name"] + " "
-			if(JOB_STYLE_4)
-				new_name = "<font color=[job_color]>([job])</font> " + signal.data["name"] + " "
-		if(toggle_jobs)
-			signal.data["name"] = new_name
-			signal.data["realname"] = new_name // this is required because the broadcaster uses this directly if the speaker doesn't have a voice changer on
+		
+	if(toggle_name_color)
+		var/new_name = "<font color=\"[job_color]\">" + signal.data["name"] + "</font>"
+		signal.data["name"] = new_name
+		signal.data["realname"] = new_name // this is required because the broadcaster uses this directly if the speaker doesn't have a voice changer on
+
+	if(toggle_jobs)
+		var/new_name = ""
+		var/job = signal.data["job"]
+		if(job in jobs_ert)
+			job = "ERT"
+		if(toggle_job_color)
+			switch(job_indicator_type)
+				if(JOB_STYLE_1)
+					new_name = signal.data["name"] + " <font color=\"[job_color]\">([job])</font> "
+				if(JOB_STYLE_2)
+					new_name = signal.data["name"] + " - <font color=\"[job_color]\">[job]</font> "
+				if(JOB_STYLE_3)
+					new_name = "<font color=\"[job_color]\"><small>\[[job]\]</small></font> " + signal.data["name"] + " "
+				if(JOB_STYLE_4)
+					new_name = "<font color=[job_color]>([job])</font> " + signal.data["name"] + " "
+		else
+			switch(job_indicator_type)
+				if(JOB_STYLE_1)
+					new_name = signal.data["name"] + " ([job]) "
+				if(JOB_STYLE_2)
+					new_name = signal.data["name"] + " - [job] "
+				if(JOB_STYLE_3)
+					new_name = "<small>\[[job]\]</small> " + signal.data["name"] + " "
+				if(JOB_STYLE_4)
+					new_name = "([job]) " + signal.data["name"] + " "
+
+		signal.data["name"] = new_name
+		signal.data["realname"] = new_name // this is required because the broadcaster uses this directly if the speaker doesn't have a voice changer on
 
 	// Add the current station time like a time code.
 	if(toggle_timecode)

--- a/code/game/machinery/telecomms/ntsl2.dm
+++ b/code/game/machinery/telecomms/ntsl2.dm
@@ -179,22 +179,22 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 		var/job_color = "#000000"
 		if(job in jobs_ai)
 			job_color = "#FF00FF"
-		if(job in jobs_command)
+		else if(job in jobs_command)
 			job_color = "#204090"
-		if(job in jobs_engineering)
+		else if(job in jobs_engineering)
 			job_color = "#A66300"
-		if(job in jobs_ert)
+		else if(job in jobs_ert)
 			job_color = "#5C5C7C"
 			job = "ERT"
-		if(job in jobs_medical)
+		else if(job in jobs_medical)
 			job_color = "#009190"
-		if(job in jobs_science)
+		else if(job in jobs_science)
 			job_color = "#993399F"
-		if(job in jobs_security)
+		else if(job in jobs_security)
 			job_color = "#A30000"
-		if(job in jobs_supply)
+		else if(job in jobs_supply)
 			job_color = "#7F6539"
-		if(job in jobs_service)
+		else if(job in jobs_service)
 			job_color = "#80A000"
 		switch(job_indicator_type)
 			if(JOB_STYLE_1)

--- a/code/game/machinery/telecomms/ntsl2.dm
+++ b/code/game/machinery/telecomms/ntsl2.dm
@@ -9,19 +9,111 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
  * as well as allowing users to save and load configurations.
  */
 /datum/nttc_configuration
-	// ALL JOBS
-	var/jobs_ai = list("Personal AI", "AI", "Cyborg", "Android", "Robot"); // All Silicon Jobs
-	var/jobs_command = list("Captain", "Head of Personnel", "Nanotrasen Representative", "Blueshield"); // All command jobs
-	var/jobs_engineering = list("Chief Engineer", "Station Engineer", "Maintenance Technician", "Engine Technician", "Electrician", "Life Support Specialist", "Atmospheric Technician", "Mechanic"); // All Engineering Jobs
-	var/jobs_ert = list("Emergency Response Team Officer", "Emergency Response Team Engineer", "Emergency Response Team Medic", "Emergency Response Team Leader", "Emergency Response Team Member"); // All ERT Jobs
-	var/jobs_medical = list("Chief Medical Officer", "Medical Doctor", "Surgeon", "Nurse", "Coroner", "Chemist", "Pharmacist", "Pharmacologist", "Virologist", "Pathologist", "Microbiologist", "Psychiatrist", "Psychologist", "Therapist", "Paramedic"); // All Medical Jobs
-	var/jobs_science = list("Research Director", "Geneticist", "Scientist", "Xenoarcheologist", "Anomalist", "Plasma Researcher", "Xenobiologist", "Chemical Researcher", "Roboticist", "Biomechanical Engineer", "Mechatronic Engineer"); // All Science Jobs
-	var/jobs_security = list("Internal Affairs Agent", "Human Resources Agent", "Head of Security", "Warden", "Detective", "Magistrate", "Forensic Technician", "Security Officer", "Brig Physician", "Security Pod Pilot"); // All Security Jobs
-	var/jobs_supply = list("Quartermaster", "Cargo Technician", "Shaft Miner", "Spelunker"); // All Supply Jobs
-	var/jobs_service = list("Bartender", "Chef", "Cook", "Culinary Artist", "Butcher", "Botanist", "Hydroponicist", "Botanical Researcher", "Clown", "Mime", "Janitor", "Custodial Technician", "Librarian", "Journalist", "Barber", "Hair Stylist", "Beautician", "Chaplain"); // All Service/Support Jobs
-
+	// ALL OF THE JOB CRAP
+	// Dict of all jobs and their colors
+	var/all_jobs = list(
+		// AI
+		"AI" = "#FF00FF",
+		"Android" = "#FF00FF",
+		"Cyborg" = "#FF00FF",
+		"Personal AI" = "#FF00FF",
+		"Robot" = "#FF00FF",
+		// Civilian + Varients
+		"Assistant" = "#408010",
+		"Businessman" = "#408010",
+		"Civilian" = "#408010",
+		"Tourist" = "#408010",
+		"Trader" = "#408010",
+		// Command (Solo command, not department heads)
+		"Blueshield" = "#204090",
+		"Captain" = "#204090",
+		"Head of Personnel" = "#204090",
+		"Nanotrasen Representative" = "#204090",
+		// Engineeering
+		"Atmospheric Technician" = "#A66300",
+		"Chief Engineer" = "#A66300",
+		"Electrician" = "#A66300",
+		"Engine Technician" = "#A66300",
+		"Life Support Specialist" = "#A66300",
+		"Maintenance Technician" = "#A66300",
+		"Mechanic" = "#A66300",
+		"Station Engineer" = "#A66300",
+		// ERT
+		"Emergency Response Team Engineer" = "#5C5C7C",
+		"Emergency Response Team Leader" = "#5C5C7C",
+		"Emergency Response Team Medic" = "#5C5C7C",
+		"Emergency Response Team Member" = "#5C5C7C",
+		"Emergency Response Team Officer" = "#5C5C7C",
+		// Medical
+		"Chemist" = "#009190",
+		"Chief Medical Officer" = "#009190",
+		"Coroner" = "#009190",
+		"Medical Doctor" = "#009190",
+		"Microbiologist" = "#009190",
+		"Nurse" = "#009190",
+		"Paramedic" = "#009190",
+		"Pharmacologist" = "#009190",
+		"Pharmacist" = "#009190",
+		"Psychiatrist" = "#009190",
+		"Psychologist" = "#009190",
+		"Surgeon" = "#009190",
+		"Therapist" = "#009190",
+		"Virologist" = "#009190",
+		// Science
+		"Anomalist" = "#993399",
+		"Biomechanical Engineer" = "#993399",
+		"Chemical Researcher" = "#993399",
+		"Geneticist" = "#993399",
+		"Mechatronic Engineer" = "#993399",
+		"Plasma Researcher" = "#993399",
+		"Research Director" = "#993399",
+		"Roboticist" = "#993399",
+		"Scientist" = "#993399",
+		"Xenoarcheologist" = "#993399",
+		"Xenobiologist" = "#993399",
+		// Security
+		"Brig Physician" = "#A30000",
+		"Detective" = "#A30000",
+		"Forensic Technician" = "#A30000",
+		"Head of Security" = "#A30000",
+		"Human Resources Agent" = "#A30000",
+		"Internal Affairs Agent" = "#A30000",
+		"Magistrate" = "#A30000",
+		"Security Officer" = "#A30000",
+		"Security Pod Pilot" = "#A30000",
+		"Warden" = "#A30000",
+		// Supply
+		"Quartermaster" = "#7F6539",
+		"Cargo Technician" = "#7F6539",
+		"Shaft Miner" = "#7F6539",
+		"Spelunker" = "#7F6539",
+		// Service
+		"Barber" = "#80A000",
+		"Bartender" = "#80A000",
+		"Beautician" = "#80A000",
+		"Botanical Researcher" = "#80A000",
+		"Botanist" = "#80A000",
+		"Butcher" = "#80A000",
+		"Chaplain" = "#80A000",
+		"Chef" = "#80A000",
+		"Clown" = "#80A000",
+		"Cook" = "#80A000",
+		"Culinary Artist" = "#80A000",
+		"Custodial Technician" = "#80A000",
+		"Hair Stylist" = "#80A000",
+		"Hydroponicist" = "#80A000",
+		"Janitor" = "#80A000",
+		"Journalist" = "#80A000",
+		"Librarian" = "#80A000",
+		"Mime" = "#80A000",
+	)
 	// Just command members
 	var/heads = list("Captain", "Head of Personnel", "Nanotrasen Representative", "Blueshield", "Chief Engineer", "Chief Medical Officer", "Research Director", "Head of Security")
+	// Just ERT
+	var/ert_jobs = list("Emergency Response Team Officer", "Emergency Response Team Engineer", "Emergency Response Team Medic", "Emergency Response Team Leader", "Emergency Response Team Member")
+	// Defined so code compiles and incase someone has a non-standard job
+	var/job_color = "#000000"
+	// NOW FOR ACTUAL TOGGLES
 	/* Simple Toggles */
 	var/toggle_activated = TRUE
 	var/toggle_jobs = FALSE
@@ -181,26 +273,8 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 
 	// All job and coloring shit 
 	if(toggle_job_color || toggle_name_color)
-		var/job_color = "#000000"
 		var/job = signal.data["job"]
-		if(job in jobs_ai)
-			job_color = "#FF00FF"
-		else if(job in jobs_command)
-			job_color = "#204090"
-		else if(job in jobs_engineering)
-			job_color = "#A66300"
-		else if(job in jobs_ert)
-			job_color = "#5C5C7C"
-		else if(job in jobs_medical)
-			job_color = "#009190"
-		else if(job in jobs_science)
-			job_color = "#993399F"
-		else if(job in jobs_security)
-			job_color = "#A30000"
-		else if(job in jobs_supply)
-			job_color = "#7F6539"
-		else if(job in jobs_service)
-			job_color = "#80A000"
+		job_color = all_jobs[job]
 		
 	if(toggle_name_color)
 		var/new_name = "<font color=\"[job_color]\">" + signal.data["name"] + "</font>"
@@ -210,7 +284,7 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 	if(toggle_jobs)
 		var/new_name = ""
 		var/job = signal.data["job"]
-		if(job in jobs_ert)
+		if(job in ert_jobs)
 			job = "ERT"
 		if(toggle_job_color)
 			switch(job_indicator_type)
@@ -245,7 +319,7 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 	// Makes heads of staff bold
 	if(toggle_command_bold)
 		var/job = signal.data["job"]
-		if((job in jobs_ert) || (job in heads))
+		if((job in ert_jobs) || (job in heads))
 			signal.data["message"] = "<b>" + signal.data["message"] + "</b>"
 
 	// Hacks!

--- a/code/game/machinery/telecomms/ntsl2.dm
+++ b/code/game/machinery/telecomms/ntsl2.dm
@@ -427,7 +427,7 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 			var/list/array = vars[href_list["array"]]
 			array.Add(new_value)
 			to_chat(user, "<span class='notice'>Added row [new_value].</span>")
-			log_action(user, "updated [href_list["array"]] - new value [new_value]")
+			log_action(user, "updated [href_list["array"]] - new value [new_value]", TRUE)
 
 	if(href_list["delete_item"])
 		if(href_list["array"] && href_list["array"] in arrays)

--- a/code/game/machinery/telecomms/ntsl2.dm
+++ b/code/game/machinery/telecomms/ntsl2.dm
@@ -1,3 +1,7 @@
+#define JOB_STYLE_1 "Name (Job)"
+#define JOB_STYLE_2 "Name - Job"
+#define JOB_STYLE_3 "\[Job\] Name"
+#define JOB_STYLE_4 "(Job) Name"
 GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 // Custom Implementations for NTTC
 /* NTTC Configuration Datum
@@ -79,10 +83,7 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 
 	// These are the job card styles
 	var/list/job_card_styles = list(
-		"Style 1: Name (Job)",
-		"Style 2: Name - Job",
-		"Style 3: \[Job\] Name",
-		"Style 4: (Job) Name",
+		JOB_STYLE_1, JOB_STYLE_2, JOB_STYLE_3, JOB_STYLE_4
 	)
 	// Used to determine what languages are allowable for conversion. Generated during runtime.
 	var/list/valid_languages = list("--DISABLE--")
@@ -196,13 +197,13 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 		if(job in jobs_service)
 			job_color = "#80A000"
 		switch(job_indicator_type)
-			if("Style 1: Name (Job)")
+			if(JOB_STYLE_1)
 				new_name = signal.data["name"] + " <font color=\"[job_color]\">([job])</font> "
-			if("Style 2: Name - Job")
+			if(JOB_STYLE_2)
 				new_name = signal.data["name"] + " - <font color=\"[job_color]\">[job]</font> "
-			if("Style 3: \[Job\] Name")
+			if(JOB_STYLE_3)
 				new_name = "<font color=\"[job_color]\"><small>\[[job]\]</small></font> " + signal.data["name"] + " "
-			if("Style 4: (Job) Name")
+			if(JOB_STYLE_4)
 				new_name = "<font color=[job_color]>([job])</font> " + signal.data["name"] + " "
 		if(toggle_jobs)
 			signal.data["name"] = new_name
@@ -389,3 +390,4 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 	dat += "window.updateConfig = function(config) { window.config = JSON.parse(config); window.reload_tab() };"
 	dat += "</script>"
 	return dat
+

--- a/html/nttc/dist/index.html
+++ b/html/nttc/dist/index.html
@@ -3,7 +3,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <head>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>NTSL</title>
+    <title>NTTC</title>
     <script type="text/javascript" src="bundle.js"></script>
     <link rel="stylesheet" type="text/css" href="bundle.css">
 </head>
@@ -12,7 +12,7 @@
 <div id="navbar">
     <img src="uiTitleFluff.png">
     <div class="navBtn" data-tab="home">Home</div>
-    <div class="navBtn" data-tab="filtering">Filtering</div>
+    <div class="navBtn" data-tab="filtering">Configuration</div>
     <div class="navBtn" data-tab="regex">Regex</div>
     <div class="navBtn" style="display:none" data-locked="1" data-tab="firewall">Firewall</div>
     <div class="navBtn hackBtn" style="display:none" data-locked="1" data-tab="hack"><span class='hack'>1337</span></div>

--- a/html/nttc/dist/tab_filtering.html
+++ b/html/nttc/dist/tab_filtering.html
@@ -1,21 +1,31 @@
 <div>
 	<h2>Configuration</h2>
 	<table class="tblConfig">
+		<h3>Job Settings</h3>
 		<tr>
 			<td>Announce Jobs?</td>
 			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_jobs"></activeLink></td>
 		</tr>
 		<tr>
-			<td>Job Announcement Format</td>
+			<td>Job Announcement Format:</td>
 			<td><activeLink data-aconfig="job_indicator_type" data-href="setting_job_card_style=1"></activeLink></td>
+		</tr>
+		<tr>
+			<td>Theme Jobs?</td>
+			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_job_color"></activeLink></td>
+		</tr>
+		<tr>
+			<td>Theme Names?</td>
+			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_name_color"></activeLink></td>
+		</tr>
+		<h3>Misc Settings</h3>		
+		<tr>
+			<td>Louder Command Members</td>
+			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Announce Timecodes?</td>
 			<td><activeLink data-sconfig="toggle_timecode" data-href="toggle=toggle_timecode"></activeLink></td>
-		</tr>
-		<tr>
-			<td>Louder Command Members</td>
-			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Language Conversion?</td>

--- a/html/nttc/dist/tab_filtering.html
+++ b/html/nttc/dist/tab_filtering.html
@@ -1,7 +1,6 @@
 <div>
 	<h2>Configuration</h2>
 	<table class="tblConfig">
-		<h3>Job Settings</h3>
 		<tr>
 			<td>Announce Jobs?</td>
 			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_jobs"></activeLink></td>
@@ -12,14 +11,13 @@
 		</tr>
 		<tr>
 			<td>Theme Jobs?</td>
-			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_job_color"></activeLink></td>
+			<td><activeLink data-sconfig="toggle_job_color" data-href="toggle=toggle_job_color"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Theme Names?</td>
-			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_name_color"></activeLink></td>
+			<td><activeLink data-sconfig="toggle_name_color" data-href="toggle=toggle_name_color"></activeLink></td>
 		</tr>
-		<h3>Misc Settings</h3>		
-		<tr>
+		<tr>		
 			<td>Louder Command Members</td>
 			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>

--- a/html/nttc/dist/tab_filtering.html
+++ b/html/nttc/dist/tab_filtering.html
@@ -1,13 +1,21 @@
 <div>
-	<h2>Filtering Settings</h2>
+	<h2>Configuration</h2>
 	<table class="tblConfig">
 		<tr>
 			<td>Announce Jobs?</td>
 			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_jobs"></activeLink></td>
 		</tr>
 		<tr>
+			<td>Job Announcement Format</td>
+			<td><activeLink data-aconfig="job_indicator_type" data-href="setting_job_card_style=1"></activeLink></td>
+		</tr>
+		<tr>
 			<td>Announce Timecodes?</td>
 			<td><activeLink data-sconfig="toggle_timecode" data-href="toggle=toggle_timecode"></activeLink></td>
+		</tr>
+		<tr>
+			<td>Louder Command Members</td>
+			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Language Conversion?</td>

--- a/html/nttc/src/html/tabs/tab_filtering.html
+++ b/html/nttc/src/html/tabs/tab_filtering.html
@@ -1,21 +1,31 @@
 <div>
 	<h2>Configuration</h2>
 	<table class="tblConfig">
+		<h3>Job Settings</h3>
 		<tr>
 			<td>Announce Jobs?</td>
 			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_jobs"></activeLink></td>
 		</tr>
 		<tr>
-			<td>Job Announcement Format</td>
+			<td>Job Announcement Format:</td>
 			<td><activeLink data-aconfig="job_indicator_type" data-href="setting_job_card_style=1"></activeLink></td>
+		</tr>
+		<tr>
+			<td>Theme Jobs?</td>
+			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_job_color"></activeLink></td>
+		</tr>
+		<tr>
+			<td>Theme Names?</td>
+			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_name_color"></activeLink></td>
+		</tr>
+		<h3>Misc Settings</h3>		
+		<tr>
+			<td>Louder Command Members</td>
+			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Announce Timecodes?</td>
 			<td><activeLink data-sconfig="toggle_timecode" data-href="toggle=toggle_timecode"></activeLink></td>
-		</tr>
-		<tr>
-			<td>Louder Command Members</td>
-			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Language Conversion?</td>

--- a/html/nttc/src/html/tabs/tab_filtering.html
+++ b/html/nttc/src/html/tabs/tab_filtering.html
@@ -1,7 +1,6 @@
 <div>
 	<h2>Configuration</h2>
 	<table class="tblConfig">
-		<h3>Job Settings</h3>
 		<tr>
 			<td>Announce Jobs?</td>
 			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_jobs"></activeLink></td>
@@ -12,14 +11,13 @@
 		</tr>
 		<tr>
 			<td>Theme Jobs?</td>
-			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_job_color"></activeLink></td>
+			<td><activeLink data-sconfig="toggle_job_color" data-href="toggle=toggle_job_color"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Theme Names?</td>
-			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_name_color"></activeLink></td>
+			<td><activeLink data-sconfig="toggle_name_color" data-href="toggle=toggle_name_color"></activeLink></td>
 		</tr>
-		<h3>Misc Settings</h3>		
-		<tr>
+		<tr>		
 			<td>Louder Command Members</td>
 			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>

--- a/html/nttc/src/html/tabs/tab_filtering.html
+++ b/html/nttc/src/html/tabs/tab_filtering.html
@@ -1,13 +1,21 @@
 <div>
-	<h2>Filtering Settings</h2>
+	<h2>Configuration</h2>
 	<table class="tblConfig">
 		<tr>
 			<td>Announce Jobs?</td>
 			<td><activeLink data-sconfig="toggle_jobs" data-href="toggle=toggle_jobs"></activeLink></td>
 		</tr>
 		<tr>
+			<td>Job Announcement Format</td>
+			<td><activeLink data-aconfig="job_indicator_type" data-href="setting_job_card_style=1"></activeLink></td>
+		</tr>
+		<tr>
 			<td>Announce Timecodes?</td>
 			<td><activeLink data-sconfig="toggle_timecode" data-href="toggle=toggle_timecode"></activeLink></td>
+		</tr>
+		<tr>
+			<td>Louder Command Members</td>
+			<td><activeLink data-sconfig="toggle_command_bold" data-href="toggle=toggle_command_bold"></activeLink></td>
 		</tr>
 		<tr>
 			<td>Language Conversion?</td>


### PR DESCRIPTION
**What does this PR do:**
Fixes #10244 
Regex now works properly, and doesnt try to replace the font string
Window title is now NTTC instead of NTSL

New features:
The "Filtering" tab is now "Configuration", as it matches a lot better, because it didnt really filter, well anything before.
![image](https://user-images.githubusercontent.com/25063394/48662048-f5c0ec00-ea73-11e8-9bd3-238c54c5fe69.png)

Inside the configuration tab, we have a few new options (highlighted)
![image](https://user-images.githubusercontent.com/25063394/48662062-230d9a00-ea74-11e8-82ba-b9230c11a955.png)

Job Announcement Format brings up a list of formats for job cards, allowing a user to pick one that they like. This option is also admin logged.
![2018-11-17_14-23-37](https://user-images.githubusercontent.com/25063394/48662086-77b11500-ea74-11e8-8843-b90854e41122.gif)

Leading onto the next feature, job cards are now colored. This is achieved in the same way as my previous script, but in native DM instead of NTSL.
![image](https://user-images.githubusercontent.com/25063394/48662097-9d3e1e80-ea74-11e8-918e-ece44d540053.png)
All ERT titles are shortened to ERT to take up less space in chat. I would do this for things like turning `Head of Personnel` into `HoP`, but that would take way too long and too much shitcode. 

The next switch is to make command members louder. This will make all members of command and ERT bold in chat.
![image](https://user-images.githubusercontent.com/25063394/48662110-e2fae700-ea74-11e8-9d63-1918e528e3f9.png)
![image](https://user-images.githubusercontent.com/25063394/48662114-f8701100-ea74-11e8-974d-7221f5697817.png)


**Changelog:**
:cl: AffectedArc07
add: NTTC now has multiple job tag styles
add: NTTC now has option to make job tags colored
add: NTTC now has option to make nametags colored
add: NTTC now has options to make command members louder (bold)
spellcheck: The NTTC window title is no longer NTSL.
/:cl:

