### PR TITLE
Vampires and Changelings are no longer able to use sleeping carp.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -586,7 +586,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/dangerous/guardian
 	name = "Holoparasites"
-	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an organic host as a home base and source of fuel."
+	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an organic host as a home base and source of fuel. \
+			The holoparasites are unable to incoporate themselves to changeling and vampire agents."
 	item = /obj/item/storage/box/syndie_kit/guardian
 	excludefrom = list(/datum/game_mode/nuclear)
 	cost = 12
@@ -755,7 +756,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/stealthy_weapons/martialarts
 	name = "Martial Arts Scroll"
 	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
-			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry."
+			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry. \
+			Unable to be understood by vampire and changeling agents."
 	reference = "SCS"
 	item = /obj/item/sleeping_carp_scroll
 	cost = 17

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -143,6 +143,7 @@
 /obj/item/plasma_fist_scroll/attack_self(mob/user as mob)
 	if(!ishuman(user))
 		return
+
 	if(!used)
 		var/mob/living/carbon/human/H = user
 		var/datum/martial_art/plasma_fist/F = new/datum/martial_art/plasma_fist(null)
@@ -162,6 +163,14 @@
 /obj/item/sleeping_carp_scroll/attack_self(mob/living/carbon/human/user as mob)
 	if(!istype(user) || !user)
 		return
+	if(user.mind && (user.mind.changeling || user.mind.vampire)) //Prevents changelings and vampires from being able to learn it
+		if(user.mind && user.mind.changeling) //Changelings
+			to_chat(user, "We try multiple times, but we are not able to comprehend the contents of the scroll!")
+			return
+		else //Vampires
+			to_chat(user, "Your blood lust distracts you too much to be able to concentrate on the contents of the scroll!")
+			return
+
 	to_chat(user, "<span class='sciradio'>You have learned the ancient martial art of the Sleeping Carp! \
 					Your hand-to-hand combat has become much more effective, and you are now able to deflect any projectiles directed toward you. \
 					However, you are also unable to use any ranged weaponry. \


### PR DESCRIPTION
**What does this PR do:**
Makes it so changelings and vampires are unable to read the sleeping carp scroll (not using it up, but not getting the abilities). Edits the description of the sleeping carp item in the uplink, making it clear that changelings and vampires are unable to learn it.

Also adds to the description of the holoparasite kit that changelings and vampires are unable to use it, something that is already present in the code.

**Images of sprite/map changes (IF APPLICABLE):**
N/A.

**Changelog:**

:cl: Quantum-M
balance: Vampires and changelings are unable to learn sleeping carp.
tweak: Sleeping carp uplink description now points out that it is unable to be learned by vampires or changelings.
tweak: Holoparasite kit uplink description now points out that it doesn't work on vampires or changelings.
/:cl:

**Reasons for the change:** I believe that vampires are horribly unbalanced when paired up with sleeping carp. There is virtually no counter to them in such state, (besides ganging up on them with multiple people, but the chances of people helping you with such is unlikely), as projectiles are deflected, and going in to melee them with a stunbaton is suicide.

The changes for changelings I was unsure about, however, I have heard that it also proved to be bad to some extent.

Description of the sleeping carp now points out that they are unable to use the item.
Also made it clear that holoparasites are unable to be used by said entities, for traitor changelings/traitor vampires don't have to waste their TC without knowing this point.

Has been tested.

