### PR TITLE
Added warning when slings are close to winning

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -51,6 +51,7 @@ Made by Xhuis
 	var/shadowling_ascended = 0 //If at least one shadowling has ascended
 	var/shadowling_dead = 0 //is shadowling kill
 	var/objective_explanation
+	var/warning_threshold
 	var/victory_warning_announced = FALSE
 
 /proc/is_thrall(var/mob/living/M)
@@ -100,6 +101,8 @@ Made by Xhuis
 
 	var/thrall_scaling = round(num_players() / 3)
 	required_thralls = Clamp(thrall_scaling, 15, 25)
+
+	warning_threshold = round(0.66 * required_thralls)
 
 	..()
 	return 1
@@ -164,11 +167,9 @@ Made by Xhuis
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>You may communicate with your allies by speaking in the Shadowling Hivemind (:8).</span>")
 		if(jobban_isbanned(new_thrall_mind.current, ROLE_SHADOWLING) || jobban_isbanned(new_thrall_mind.current, ROLE_SYNDICATE))
 			replace_jobbanned_player(new_thrall_mind.current, ROLE_SHADOWLING)
-		if(!victory_warning_announced && (length(shadowling_thralls) >= (required_thralls - 3)))//are the slings very close to winning?
+		if(!victory_warning_announced && (length(shadowling_thralls) >= warning_threshold))//are the slings very close to winning?
 			victory_warning_announced = TRUE	//then let's give the station a warning
-			command_announcement.Announce("Large concentration of psychic redspace energy detected by long-ranged scanners. Shadowling ascension event imminent. Prevent it at all costs!","Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
-
-
+			command_announcement.Announce("Large concentration of psychic bluespace energy detected by long-ranged scanners. Shadowling ascension event imminent. Prevent it at all costs!","Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
 		return 1
 
 /datum/game_mode/proc/remove_thrall(datum/mind/thrall_mind, var/kill = 0)

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -51,7 +51,7 @@ Made by Xhuis
 	var/shadowling_ascended = 0 //If at least one shadowling has ascended
 	var/shadowling_dead = 0 //is shadowling kill
 	var/objective_explanation
-
+	var/victory_warning_announced = FALSE
 
 /proc/is_thrall(var/mob/living/M)
 	return istype(M) && M.mind && ticker && ticker.mode && (M.mind in ticker.mode.shadowling_thralls)
@@ -164,6 +164,10 @@ Made by Xhuis
 		to_chat(new_thrall_mind.current, "<span class='shadowling'>You may communicate with your allies by speaking in the Shadowling Hivemind (:8).</span>")
 		if(jobban_isbanned(new_thrall_mind.current, ROLE_SHADOWLING) || jobban_isbanned(new_thrall_mind.current, ROLE_SYNDICATE))
 			replace_jobbanned_player(new_thrall_mind.current, ROLE_SHADOWLING)
+		if(!victory_warning_announced && (length(shadowling_thralls) >= (required_thralls - 3)))//are the slings very close to winning?
+			victory_warning_announced = TRUE	//then let's give the station a warning
+			command_announcement.Announce("Large concentration of psychic redspace energy detected by long-ranged scanners. Shadowling ascension event imminent. Prevent it at all costs!","Central Command Higher Dimensional Affairs", 'sound/AI/spanomalies.ogg')
+
 
 		return 1
 


### PR DESCRIPTION
**What does this PR do:**
This PR adds a warning to the sling gamemode in the form of a CC announcement when the slings have almost enough thralls to ascend. It is phrased similar to the warning you get on cult summoning and sent by the same 'agency', Central Command Higher Dimensional Affairs.

This is intended to provide the crew a warning how close slings are to ascension, so that sec (if any is left) know they might have to lethal thralls and that the captain knows he maybe should call an ERT. Quite often, it is the case that you have no indication how close slings are to winning until they've already ascended. This intends to provide at least some last minute warning.

The warning is sent only once so you don't get spammed with it if a single thrall gets deconverted, then another one gets thralled, etc.

I am aware shadowlings have some bigger issues than this and may require a rework, but that's just a tad out of scope right now.


**Changelog:**
:cl: 
add: A warning if slings are very close to ascension, so the crew can potentially still stop them
/:cl:

