### PR TITLE
Fixes safe runtime upon deletion

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -312,8 +312,9 @@ GLOBAL_LIST_EMPTY(safes)
 
 /obj/structure/safe/Destroy()
 	GLOB.safes -= src
-	drill.soundloop.stop()
-	return ..()
+	if(drill?.soundloop)
+		drill.soundloop.stop()
+	..()
 
 /obj/structure/safe/process()
 	if(drill_timer)

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -312,9 +312,8 @@ GLOBAL_LIST_EMPTY(safes)
 
 /obj/structure/safe/Destroy()
 	GLOB.safes -= src
-	if(drill?.soundloop)
-		drill.soundloop.stop()
-	..()
+	drill?.soundloop?.stop()
+	return ..()
 
 /obj/structure/safe/process()
 	if(drill_timer)


### PR DESCRIPTION
Fixes a runtime in `/obj/structure/safe/Destroy()`

#10273 

Destroy() would runtime if there is no `drill` var and hence never complete.

🆑 Birdtalon
fix: Fixes a runtime in safe.dm
/🆑 