### PR TITLE
Amends Plasma Statue Logging & Projectile Ignite Requirements

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -172,31 +172,24 @@
 	if(exposed_temperature > 300)
 		PlasmaBurn(exposed_temperature)
 
-/obj/structure/statue/plasma/bullet_act(obj/item/projectile/Proj)
-	var/burn = FALSE
-	if(Proj.damage == 0)//lasertag guns and so on don't set off plasma anymore. can't use nodamage here because lasertag guns actually don't have it.
-		return
-	if(istype(Proj,/obj/item/projectile/beam))
-		PlasmaBurn(2500)
-		burn = TRUE
-	else if(istype(Proj,/obj/item/projectile/ion))
-		PlasmaBurn(500)
-		burn = TRUE
-	if(burn)
-		if(Proj.firer)
-			message_admins("Plasma statue ignited by [key_name_admin(Proj.firer)]([ADMIN_QUE(Proj.firer,"?")]) ([ADMIN_FLW(Proj.firer,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-			log_game("Plasma statue ignited by [key_name(Proj.firer)] in ([x],[y],[z])")
-			investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(Proj.firer)]","atmos")
-		else
-			message_admins("Plasma statue ignited by [Proj]. No known firer.([ADMIN_QUE(Proj.firer,"?")]) ([ADMIN_FLW(Proj.firer,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-			log_game("Plasma statue ignited by [Proj] in ([x],[y],[z]). No known firer.")
+/obj/structure/statue/plasma/bullet_act(obj/item/projectile/P)
+	if(!QDELETED(src)) //wasn't deleted by the projectile's effects.
+		if(!P.nodamage && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))
+			if(P.firer)
+				message_admins("[key_name_admin(P.firer)] ignited a plasma statue with [P.name] at [COORD(loc)]")
+				log_game("[key_name(P.firer)] ignited a plasma statue with [P.name] at [COORD(loc)]")
+				investigate_log("[key_name(P.firer)] ignited a plasma statue with [P.name] at [COORD(loc)]", "atmos")
+			else
+				message_admins("A plasma statue was ignited with [P.name] at [COORD(loc)]. No known firer.")
+				log_game("A plasma statue was ignited with [P.name] at [COORD(loc)]. No known firer.")
+			PlasmaBurn()
 	..()
 
 /obj/structure/statue/plasma/attackby(obj/item/W, mob/user, params)
 	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
-		message_admins("Plasma statue ignited by [key_name_admin(user)]([ADMIN_QUE(user,"?")]) ([ADMIN_FLW(user,"FLW")]) in ([x],[y],[z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)",0,1)
-		log_game("Plasma statue ignited by [key_name(user)] in ([x],[y],[z])")
-		investigate_log("was <font color='red'><b>ignited</b></font> by [key_name(user)]","atmos")
+		message_admins("[key_name_admin(user)] ignited a plasma statue at [COORD(loc)]")
+		log_game("[key_name(user)] ignited plasma a statue at [COORD(loc)]")
+		investigate_log("[key_name(user)] ignited a plasma statue at [COORD(loc)]", "atmos")
 		ignite(is_hot(W))
 		return
 	..()


### PR DESCRIPTION
Fixes #10265, sorry secborg guy

**What does this PR do:**
This PR brings plasma statue ignition logging up to spec (I think) using welder tanks as a reference.

Refactors plasma statue ignition qualification so disablers can't ignite them.

I ditched the 'burn' argument as it did absolutely nothing. I started a bunch of fires in the admin testing area just to be sure.

**Changelog:**
:cl:
tweak: Brings the logging of plasma statue ignition up to the same spec at as welder tank explosions.
fix: You can no longer ignite plasma statues with disablers.
/:cl:

