### PR TITLE
Moved silencers, gave them their own folder + tech origin

### DIFF
--- a/code/modules/projectiles/gun_attachments.dm
+++ b/code/modules/projectiles/gun_attachments.dm
@@ -1,0 +1,19 @@
+//Put all your tacticool gun gadgets here. So far it's pretty empty
+
+
+/obj/item/suppressor
+	name = "suppressor"
+	desc = "A universal syndicate small-arms suppressor for maximum espionage."
+	icon = 'icons/obj/guns/projectile.dmi'
+	icon_state = "suppressor"
+	item_state = "suppressor"
+	w_class = WEIGHT_CLASS_SMALL
+	var/oldsound = null
+	var/initial_w_class = null
+	origin_tech = "combat=2;engineering=2"
+
+/obj/item/suppressor/specialoffer
+	name = "cheap suppressor"
+	desc = "A foreign knock-off suppressor, it feels flimsy, cheap, and brittle. Still fits all weapons."
+	icon = 'icons/obj/guns/projectile.dmi'
+	icon_state = "suppressor"

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -184,19 +184,3 @@
 		if(AC.BB)
 			process_fire(user, user,0)
 			. = 1
-
-/obj/item/suppressor
-	name = "suppressor"
-	desc = "A universal syndicate small-arms suppressor for maximum espionage."
-	icon = 'icons/obj/guns/projectile.dmi'
-	icon_state = "suppressor"
-	item_state = "suppressor"
-	w_class = WEIGHT_CLASS_SMALL
-	var/oldsound = null
-	var/initial_w_class = null
-
-/obj/item/suppressor/specialoffer
-	name = "cheap suppressor"
-	desc = "A foreign knock-off suppressor, it feels flimsy, cheap, and brittle. Still fits all weapons."
-	icon = 'icons/obj/guns/projectile.dmi'
-	icon_state = "suppressor"

--- a/paradise.dme
+++ b/paradise.dme
@@ -2091,6 +2091,7 @@
 #include "code\modules\projectiles\ammunition.dm"
 #include "code\modules\projectiles\firing.dm"
 #include "code\modules\projectiles\gun.dm"
+#include "code\modules\projectiles\gun_attachments.dm"
 #include "code\modules\projectiles\projectile.dm"
 #include "code\modules\projectiles\ammunition\ammo_casings.dm"
 #include "code\modules\projectiles\ammunition\boxes.dm"


### PR DESCRIPTION
**What does this PR do:**
This is a small PR to give gun silencers a tech origin (combat 2, engineering 2). They end up at the RnD desk quite a bit by people thinking they have illegal techs. After some looking at the stuff that does give illegal techs I decided to not give it actual illegal tech levels as that would make the illegal module too easy to get for robotics.

While doing it I noticed silencers were in a really shitty place codewise and thus moved them to another, newly created file.
**Changelog:**
:cl: 
tweak: Silencers now have a tech origin, give research levels when deconstructed
tweak: Moved gun attachments to their own folder, code-wise.
/:cl:

