### PR TITLE
Fix Nano scrolling issues

### DIFF
--- a/nano/assets/nano.js
+++ b/nano/assets/nano.js
@@ -1379,6 +1379,11 @@ var NanoWindow = function ()
 
     var setupScroll = function() {
         $("#cornerWrapper").focus();
+        $("#uiContent").on("click", function (event) {
+            event = event || window.event;
+            event.stopPropagation();
+            $("#cornerWrapper").focus();
+        })
     };
 
     var fancyChrome = function() {

--- a/nano/scripts/nano/nano_window.js
+++ b/nano/scripts/nano/nano_window.js
@@ -61,6 +61,11 @@ var NanoWindow = function ()
 
     var setupScroll = function() {
         $("#cornerWrapper").focus();
+        $("#uiContent").on("click", function (event) {
+            event = event || window.event;
+            event.stopPropagation();
+            $("#cornerWrapper").focus();
+        })
     };
 
     var fancyChrome = function() {


### PR DESCRIPTION
This is an ugly hack-job, but it makes scrolling work again in most cases. 

Basically, IE is fucking retarded and just won't bother firing scrolling events to the right elements for some ungodly reason... so we just make it so that clicking anywhere other than the scrollable element will immediately reset the focus to the scrollable element.

The reason I say "most cases" is because this only fixes scrolling when you click on text and the background in the large area that makes up the uiContent window... if you click on any `<div>` elements that are within `uiContent`, then scrolling will break again. As an example: Clicking inside the black box with a blue outline that machines like the sleeper have will still break scrolling.

Fixes #10251 (well enough anyways, if someone can make a better fix then this by god please do)

:cl:
fix: Nano scrolling is 95% less buggy
/:cl: