### PR TITLE
multitool fixes

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/dp_vent_pump.dm
@@ -261,4 +261,4 @@
 		return .
 	if("toggleadvcontrol" in href_list)
 		advcontrol = !advcontrol
-		return MT_UPDATE
+		return TRUE

--- a/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_pump.dm
@@ -413,7 +413,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
 	if("toggleadvcontrol" in href_list)
 		advcontrol = !advcontrol
-		return MT_UPDATE
+		return TRUE
 
 	if("set_id" in href_list)
 		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, src.id_tag) as null|text), 1, MAX_MESSAGE_LEN)
@@ -426,7 +426,7 @@
 		id_tag = newid
 		broadcast_status()
 
-		return MT_UPDATE
+		return TRUE
 
 	return ..()
 

--- a/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
+++ b/code/ATMOSPHERICS/components/unary_devices/vent_scrubber.dm
@@ -351,7 +351,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/multitool_topic(var/mob/user, var/list/href_list, var/obj/O)
 	if("toggleadvcontrol" in href_list)
 		advcontrol = !advcontrol
-		return MT_UPDATE
+		return TRUE
 
 	if("set_id" in href_list)
 		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, src:id_tag) as null|text),1,MAX_MESSAGE_LEN)
@@ -365,7 +365,7 @@
 		id_tag = newid
 		broadcast_status()
 
-		return MT_UPDATE
+		return TRUE
 
 	return ..()
 

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -32,11 +32,6 @@
 
 #define HYDRO_SPEED_MULTIPLIER 1
 
-// multitool_topic() shit
-#define MT_ERROR  -1
-#define MT_UPDATE 1
-#define MT_REINIT 2
-
 //Modular computer/NTNet defines
 
 //Modular computer part defines

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -57,14 +57,14 @@
 			output &= ~bitflag_value
 		else//can't not be off
 			output |= bitflag_value
-		return MT_UPDATE
+		return TRUE
 	if("toggle_bolts" in href_list)
 		bolts = !bolts
 		if(bolts)
 			visible_message("You hear a quite click as the [src] bolts to the floor", "You hear a quite click")
 		else
 			visible_message("You hear a quite click as the [src]'s floor bolts raise", "You hear a quite click")
-		return MT_UPDATE
+		return TRUE
 
 /obj/machinery/air_sensor/attackby(var/obj/item/W as obj, var/mob/user as mob)
 	if(istype(W, /obj/item/multitool))
@@ -301,19 +301,19 @@
 				sensor_list|=G.id_tag
 		if(!sensor_list.len)
 			to_chat(user, "<span class=\"warning\">No sensors on this frequency.</span>")
-			return MT_ERROR
+			return FALSE
 
 		// Have the user pick one of them and name its label
 		var/sensor = input(user, "Select a sensor:", "Sensor Data") as null|anything in sensor_list
 		if(!sensor)
-			return MT_ERROR
+			return FALSE
 		var/label = reject_bad_name( input(user, "Choose a sensor label:", "Sensor Label")  as text|null, allow_numbers=1)
 		if(!label)
-			return MT_ERROR
+			return FALSE
 
 		// Add the sensor's information to general_air_controler
 		sensors[sensor] = label
-		return MT_UPDATE
+		return TRUE
 
 	if("edit_sensor" in href_list)
 		var/list/sensor_list = list()
@@ -322,14 +322,14 @@
 				sensor_list|=G.id_tag
 		if(!sensor_list.len)
 			to_chat(user, "<span class=\"warning\">No sensors on this frequency.</span>")
-			return MT_ERROR
+			return FALSE
 		var/label = sensors[href_list["edit_sensor"]]
 		var/sensor = input(user, "Select a sensor:", "Sensor Data", href_list["edit_sensor"]) as null|anything in sensor_list
 		if(!sensor)
-			return MT_ERROR
+			return FALSE
 		sensors.Remove(href_list["edit_sensor"])
 		sensors[sensor] = label
-		return MT_UPDATE
+		return TRUE
 
 /obj/machinery/computer/general_air_control/unlinkFrom(mob/user, obj/O)
 	..()

--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -4,17 +4,17 @@
 	icon = 'icons/obj/meter.dmi'
 	icon_state = "meterX"
 	var/obj/machinery/atmospherics/pipe/target = null
-	anchored = 1
+	anchored = TRUE
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 100, bomb = 0, bio = 100, rad = 100)
 	power_channel = ENVIRON
-	var/frequency = 0
+	var/frequency = ATMOS_DISTRO_FREQ
 	var/id
 	var/id_tag
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 5
 	req_one_access_txt = "24;10"
-	Mtoollink = 1
+	Mtoollink = TRUE
 	settagwhitelist = list("id_tag")
 
 /obj/machinery/meter/New()

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -222,11 +222,11 @@ Class Procs:
 		var/newid = copytext(reject_bad_text(input(usr, "Specify the new ID tag for this machine", src, src:id_tag) as null|text),1,MAX_MESSAGE_LEN)
 		if(newid)
 			src:id_tag = newid
-			return MT_UPDATE|MT_REINIT
+			return TRUE
 	if("set_freq" in href_list)
 		if(!("frequency" in vars))
 			warning("set_freq: [type] has no frequency var.")
-			return 0
+			return FALSE
 		var/newfreq=src:frequency
 		if(href_list["set_freq"]!="-1")
 			newfreq=text2num(href_list["set_freq"])
@@ -235,90 +235,81 @@ Class Procs:
 		if(newfreq)
 			if(findtext(num2text(newfreq), "."))
 				newfreq *= 10 // shift the decimal one place
-			if(newfreq < 10000)
-				src:frequency = newfreq
-				return MT_UPDATE|MT_REINIT
-	return 0
+			src:frequency = sanitize_frequency(newfreq, RADIO_LOW_FREQ, RADIO_HIGH_FREQ)
+			return TRUE
+	return FALSE
 
 /obj/machinery/proc/handle_multitool_topic(var/href, var/list/href_list, var/mob/user)
 	if(!allowed(user))//no, not even HREF exploits
-		return 0
+		return FALSE
 	var/obj/item/multitool/P = get_multitool(usr)
 	if(P && istype(P))
-		var/update_mt_menu=0
-		var/re_init=0
+		var/update_mt_menu = FALSE
 		if("set_tag" in href_list)
 			if(!(href_list["set_tag"] in settagwhitelist))//I see you're trying Href exploits, I see you're failing, I SEE ADMIN WARNING. (seriously though, this is a powerfull HREF, I originally found this loophole, I'm not leaving it in on my PR)
 				message_admins("set_tag HREF (var attempted to edit: [href_list["set_tag"]]) exploit attempted by [key_name_admin(user)] on [src] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
-				return 1
+				return FALSE
 			if(!(href_list["set_tag"] in vars))
 				to_chat(usr, "<span class='warning'>Something went wrong: Unable to find [href_list["set_tag"]] in vars!</span>")
-				return 1
+				return FALSE
 			var/current_tag = vars[href_list["set_tag"]]
 			var/newid = copytext(reject_bad_text(input(usr, "Specify the new value", src, current_tag) as null|text),1,MAX_MESSAGE_LEN)
 			if(newid)
 				vars[href_list["set_tag"]] = newid
-				re_init=1
+				update_mt_menu = TRUE
 
 		if("unlink" in href_list)
 			var/idx = text2num(href_list["unlink"])
 			if(!idx)
-				return 1
+				return FALSE
 
 			var/obj/O = getLink(idx)
 			if(!O)
-				return 1
+				return FALSE
 			if(!canLink(O))
 				to_chat(usr, "<span class='warning'>You can't link with that device.</span>")
-				return 1
+				return FALSE
 
 			if(unlinkFrom(usr, O))
 				to_chat(usr, "<span class='notice'>A green light flashes on \the [P], confirming the link was removed.</span>")
 			else
 				to_chat(usr, "<span class='warning'>A red light flashes on \the [P].  It appears something went wrong when unlinking the two devices.</span>")
-			update_mt_menu=1
+			update_mt_menu = TRUE
 
 		if("link" in href_list)
 			var/obj/O = P.buffer
 			if(!O)
-				return 1
+				return FALSE
 			if(!canLink(O,href_list))
 				to_chat(usr, "<span class='warning'>You can't link with that device.</span>")
-				return 1
+				return FALSE
 			if(isLinkedWith(O))
 				to_chat(usr, "<span class='warning'>A red light flashes on \the [P]. The two devices are already linked.</span>")
-				return 1
+				return FALSE
 
 			if(linkWith(usr, O, href_list))
 				to_chat(usr, "<span class='notice'>A green light flashes on \the [P], confirming the link was added.</span>")
 			else
 				to_chat(usr, "<span class='warning'>A red light flashes on \the [P].  It appears something went wrong when linking the two devices.</span>")
-			update_mt_menu=1
+			update_mt_menu = TRUE
 
 		if("buffer" in href_list)
 			P.buffer = src
 			to_chat(usr, "<span class='notice'>A green light flashes, and the device appears in the multitool buffer.</span>")
-			update_mt_menu=1
+			update_mt_menu = TRUE
 
 		if("flush" in href_list)
 			to_chat(usr, "<span class='notice'>A green light flashes, and the device disappears from the multitool buffer.</span>")
 			P.buffer = null
-			update_mt_menu=1
+			update_mt_menu = TRUE
 
 		var/ret = multitool_topic(usr,href_list,P.buffer)
-		if(ret == MT_ERROR)
-			return 1
-		if(ret & MT_UPDATE)
-			update_mt_menu=1
-		if(ret & MT_REINIT)
-			re_init=1
+		if(ret)
+			update_mt_menu = TRUE
 
-		if(re_init)
-			Initialize()
 		if(update_mt_menu)
-			//usr.set_machine(src)
 			update_multitool_menu(usr)
-			return 1
+			return TRUE
 
 /obj/machinery/Topic(href, href_list, var/nowindow = 0, var/datum/topic_state/state = default_state)
 	if(..(href, href_list, nowindow, state))


### PR DESCRIPTION
**What does this PR do:**
- Fixes a runtime when trying to change tag or frequency with a multitool
- Makes the multitool window update properly when changing the tag or adding/flushing buffer
- Changes some inconsistent return values
- Changes the default frequency of gas flow meters from 0 to ATMOS_DISTRO_FREQ
- Sanitizes frequency better

Runtime in unsorted.dm,2042: Warning: the Central Primary Hallway Vent Pump #1(/obj/machinery/atmospherics/unary/vent_pump) initialized multiple times!

**Changelog:**
:cl: Certhic
fix: Fixes a runtime when using multitool to change a tag or frequency
fix: Makes the multitool window update properly when changing tag or adding/flushing buffer
tweak: Sanitizes device frequency better when changing it with the multitool
tweak: Changes the default frequency of gas flow meters from 0 to ATMOS_DISTRO_FREQ

