### PR TITLE
Fix for chameleon suit allowing you to pick an undefined object

### DIFF
--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -13,11 +13,11 @@
 	New()
 		..()
 		var/blocked = list(/obj/item/clothing/under/color/random, /obj/item/clothing/under/rank/centcom) // Stops random coloured jumpsuit and undefined centcomm suit appearing in the list.
-		for(var/U in subtypesof(/obj/item/clothing/under/color)-blocked)
+		for(var/U in subtypesof(/obj/item/clothing/under/color) - blocked)
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
 
-		for(var/U in subtypesof(/obj/item/clothing/under/rank)-blocked)
+		for(var/U in subtypesof(/obj/item/clothing/under/rank) - blocked)
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
 		return

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -12,11 +12,12 @@
 
 	New()
 		..()
-		for(var/U in subtypesof(/obj/item/clothing/under/color))
+		var/blocked = list(/obj/item/clothing/under/color/random, /obj/item/clothing/under/rank/centcom) // Stops random coloured jumpsuit and undefined centcomm suit appearing in the list.
+		for(var/U in subtypesof(/obj/item/clothing/under/color)-blocked)
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
 
-		for(var/U in subtypesof(/obj/item/clothing/under/rank))
+		for(var/U in subtypesof(/obj/item/clothing/under/rank)-blocked)
 			var/obj/item/clothing/under/V = new U
 			src.clothing_choices += V
 		return


### PR DESCRIPTION
**What does this PR do:**
Fixes two minor bugs with the chameleon suit. The part of code which added every subtype of `rank` and `color` for `under` caused it to add the `../color/random()` and the `../rank/centcomm` suits to the list.

`Random()` would simply place one of the colored suits at the top of the list and remove the one it copied further down. The `centcomm` suit isn't actually defined anywhere and only has subtypes, which resulted in a suit called "under" appearing in the list:

![image](https://user-images.githubusercontent.com/44248086/48783644-ceb72400-ecd8-11e8-97e0-f439f812e957.png)

As you can probably tell this shouldn't be here. This fix adds a new `blocked` variable within New() that's used to prevent either of these from appearing in the list of options when changing color. It also means we can block other options if we feel they shouldn't show up.

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
:cl: Azule Utama
fix: Fixed chameleon suit having two invalid options.
/:cl:

