### PR TITLE
Hardsuit helmet toggling button

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -217,7 +217,7 @@
 			user.drop_item()
 			W.loc = src
 			src.helmet = W
-			helmet.link_suit()
+			helmet:link_suit()
 		return
 
 	else if(istype(W,/obj/item/clothing/shoes/magboots) && can_modify(user))
@@ -344,7 +344,7 @@
 
 	update_icon()
 	playsound(src.loc, 'sound/mecha/mechmove03.ogg', 50, 1)
-	toggle_hardsuit_mode()
+	toggle_hardsuit_mode(user)
 	user.update_inv_head()
 
 	for(var/X in actions)
@@ -357,18 +357,17 @@
 			linkedsuit.name = initial(linkedsuit.name)
 			linkedsuit.desc = initial(linkedsuit.desc)
 			linkedsuit.slowdown = 1
-			linkedsuit.flags |= BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP
+			linkedsuit.flags |= BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL
 			linkedsuit.flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 			linkedsuit.cold_protection |= UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 		else
 			linkedsuit.name += " (combat)"
 			linkedsuit.desc = linkedsuit.alt_desc
 			linkedsuit.slowdown = 0
-			linkedsuit.flags &= ~BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL | NODROP
+			linkedsuit.flags = THICKMATERIAL
 			linkedsuit.cold_protection &= ~(UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS)
 			linkedsuit.flags_inv &= ~(HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL)
 
-		linkedsuit.icon_state = "hardsuit[on]-[item_color]"
 		linkedsuit.update_icon()
 		user.update_inv_wear_suit()
 		user.update_inv_w_uniform()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -326,6 +326,7 @@
 	icon_state = "hardsuit[on]-[item_color]"
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/attack_self(mob/user)
+	toggle_hardsuit_mode()
 	on = !on
 	if(on)
 		to_chat(user, "<span class='notice'>You switch your helmet to travel mode. It will allow you to stand in zero pressure environments, at the cost of speed.</span>")
@@ -378,7 +379,7 @@
 /obj/item/clothing/suit/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
 
-/obj/item/clothing/suit/space/hardsuit/syndi/attack_self(mob/user)
+/obj/item/clothing/suit/space/hardsuit/syndi/proc/toggle_hardsuit_mode(mob/user)
 	on = !on
 	if(on)
 		to_chat(user, "<span class='notice'>You switch your hardsuit to travel mode. It will allow you to stand in zero pressure environments, at the cost of speed.</span>")

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -217,7 +217,7 @@
 			user.drop_item()
 			W.loc = src
 			src.helmet = W
-
+			helmet.link_suit()
 		return
 
 	else if(istype(W,/obj/item/clothing/shoes/magboots) && can_modify(user))
@@ -316,9 +316,9 @@
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
 
-/obj/item/clothing/head/helmet/space/hardsuit/syndi/Initialize()
-		. = ..()
-	if(istype(loc, /obj/item/clothing/suit/space/hardsuit/syndi))
+/obj/item/clothing/head/helmet/space/hardsuit/syndi/proc/link_suit()
+	. = ..()
+	if(istype(loc,/obj/item/clothing/suit/space/hardsuit/syndi))
 		linkedsuit = loc
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/attack_self(mob/user)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -69,6 +69,7 @@
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	allowed = list(/obj/item/flashlight,/obj/item/tank,/obj/item/t_scanner, /obj/item/rcd)
 	siemens_coefficient = 0
+	actions_types = list(/datum/action/item_action/toggle_helmet)
 
 	hide_tail_by_species = list("Vox" , "Vulpkanin" , "Unathi" , "Tajaran")
 	species_restricted = list("exclude","Diona","Wryn")
@@ -99,6 +100,7 @@
 	var/obj/item/clothing/shoes/magboots/boots = null // Deployable boots, if any.
 	var/attached_helmet = 1                           // Can't wear a helmet if one is deployable.
 	var/obj/item/clothing/head/helmet/helmet = null   // Deployable helmet, if any.
+	var/helmettype = /obj/item/clothing/head/helmet/space/hardsuit
 
 	var/list/max_mounted_devices = 0                  // Maximum devices. Easy.
 	var/list/can_mount = null                         // Types of device that can be hardpoint mounted.
@@ -155,6 +157,10 @@
 				boots.flags &= ~NODROP
 				H.unEquip(boots)
 				boots.forceMove(src)
+
+/obj/item/clothing/suit/space/hardsuit/ui_action_click()
+	..()
+	toggle_helmet()
 
 /obj/item/clothing/suit/space/hardsuit/verb/toggle_helmet()
 	set name = "Toggle Helmet"


### PR DESCRIPTION
**What does this PR do:**
It adds a ui button to toggle the hardsuit helmet, it also makes syndi hardsuits combat/EVA mode toggle by just clicking the helmet button.

**Images of sprite/map changes (IF APPLICABLE):**
none

**Changelog:**
:cl: Eschess
add: Adds ui button to toggle hardsuit helmet
tweak: syndicate hardsuit combat mode is activated only bu the helmet button
/:cl:

