### PR TITLE
Makes floorcluwnes dress you up as a cluwne instead

### DIFF
--- a/code/datums/spells/cluwne.dm
+++ b/code/datums/spells/cluwne.dm
@@ -31,6 +31,9 @@
 	genemutcheck(src, NERVOUSBLOCK, null, MUTCHK_FORCED)
 	rename_character(real_name, "cluwne")
 
+	dressCluwne()
+
+/mob/living/carbon/human/proc/dressCluwne()
 	unEquip(w_uniform, 1)
 	unEquip(shoes, 1)
 	unEquip(gloves, 1)

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -371,8 +371,10 @@
 	if(do_after(src, 50, target = H))
 
 
-		if(prob(50) || smiting)
+		if(smiting)
 			H.makeCluwne()
+		else if(prob(50))
+			H.dressCluwne() // Make it a bit less punishing to die to such a magnificent foe
 
 		H.adjustBruteLoss(30)
 		H.adjustBrainLoss(100)


### PR DESCRIPTION
**What does this PR do:**
Felt a bit overkill to fully remove you from the round. Instead it now dresses you up as a cluwne. So they will have to do some work if they want to keep your old body.

**Changelog:**
:cl: Farie82
balance: Floor cluwnes now only dress you up as a cluwne. Their little cluwne pet
/:cl:

