### PR TITLE
Add Syndicate Cigarettes to Maintenance Loot

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -151,6 +151,7 @@
 				/obj/item/implanter/storage = 1,
 				/obj/item/toy/cards/deck/syndicate = 2,
 				/obj/item/storage/secure/briefcase/syndie = 2,
+				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 2,
 				"" = 70
 				)
 


### PR DESCRIPTION
**What does this PR do:**
Adds the Syndi cigs to the maintenance loot spawn table, with a weight of 2.

Currently, there doesn't appear to be any way to get these cigs unless you're a traitor, yet the item itself is completely legal. Metagamey sec might take advantage of this if they find some on you to search you more than they really should.

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
:cl: Azule Utama
add: Syndicate Cigarettes added to maintenance loot.
/:cl:

