### PR TITLE
Added lobby sound default off option to config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -210,6 +210,9 @@
 	// Developer
 	var/developer_express_start = 0
 
+	//when set, lobby sound defaults to off for new players
+	var/lobby_sound_off = 0
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -636,6 +639,8 @@
 					config.disable_high_pop_mc_mode_amount = text2num(value)
 				if("developer_express_start")
 					config.developer_express_start = 1
+				if("lobby_sound_off")
+					config.lobby_sound_off = 1
 				else
 					log_config("Unknown setting in configuration: '[name]'")
 

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -212,7 +212,8 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 				max_save_slots = MAX_SAVE_SLOTS_MEMBER
 			if(C.donator_level >= DONATOR_LEVEL_ONE)
 				max_gear_slots += 5
-
+		if(config.lobby_sound_off)	//if server config is set, defaults to lobby sound being off. useful for test servers without a database setup
+			sound -= SOUND_LOBBY
 		loaded_preferences_successfully = load_preferences(C) // Do not call this with no client/C, it generates a runtime / SQL error
 		if(loaded_preferences_successfully)
 			if(load_character(C))

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -88,7 +88,7 @@
 	feedback_add_details("admin_verb","TKarmabugger") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/toggletitlemusic()
-	set name = "Hear/Silence LobbyMusic"
+	set name = "Hear/Silence Lobby Music"
 	set category = "Preferences"
 	set desc = "Toggles hearing the GameLobby music"
 	prefs.sound ^= SOUND_LOBBY

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -388,4 +388,4 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 ##DEVELOPER_EXPRESS_START
 
 ##Uncomment to have the lobby sound default to off for new players, useful for testing servers without database.
-LOBBY_SOUND_OFF
+#LOBBY_SOUND_OFF

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -386,3 +386,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ##Uncomment to enable developer start. Auto starts the server after initialization
 ##DEVELOPER_EXPRESS_START
+
+##Uncomment to have the lobby sound default to off for new players, useful for testing servers without database.
+LOBBY_SOUND_OFF


### PR DESCRIPTION
**What does this PR do:**
There is now a server config to have lobby sounds default to off for new players.
This is mostly intended for use with test servers which you start/stop a lot, where you don't bother also starting a database. Who doesn't know the frantic 'let's turn off the annoying lobby music' effect when debugging?

Comes with a corresponding option in the example config file, too. Also fixed a typo in the preference menu where  it said "LobbyMusic" instead of Lobby Music


**Changelog:**
:cl: 
add: server option for lobby music to default to off for new players
/:cl:

