### PR TITLE
Made laser tag guns work again

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -79,7 +79,7 @@
 	name = "laser tag beam"
 	icon_state = "omnilaser"
 	hitsound = 'sound/weapons/tap.ogg'
-	damage = 0
+	nodamage = 1
 	damage_type = STAMINA
 	flag = "laser"
 	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)


### PR DESCRIPTION
Soo... turns out laser tag guns have `damage` set to `0` rather than using the `nodamage` variable to do so. This does not mix well with the new falloff code.

Sadly, this means laser tag guns will now work again so be prepared to be blinded by the greytide once more.

**Changelog:**
:cl: Azule Utama
fix: Made laser tag guns work again.
/:cl:

