### PR TITLE
Replace "illegal" and "weapon" in strange objects names

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -619,7 +619,7 @@
 
 /obj/item/relic/New()
 	icon_state = pick("shock_kit","armor-igniter-analyzer","infra-igniter0","infra-igniter1","radio-multitool","prox-radio1","radio-radio","timer-multitool0","radio-igniter-tank")
-	realName = "[pick("broken","twisted","spun","improved","silly","regular","badly made")] [pick("device","object","toy","illegal tech","weapon")]"
+	realName = "[pick("broken","twisted","spun","improved","silly","regular","badly made")] [pick("device","object","toy","suspicious tech","gear")]"
 	floof = pick(/mob/living/simple_animal/pet/corgi, /mob/living/simple_animal/pet/cat, /mob/living/simple_animal/pet/fox, /mob/living/simple_animal/mouse, /mob/living/simple_animal/pet/pug, /mob/living/simple_animal/lizard, /mob/living/simple_animal/diona, /mob/living/simple_animal/butterfly, /mob/living/carbon/human/monkey)
 
 


### PR DESCRIPTION
Holy shit i'm tired of security arresting people over these, and I can't even blame the security officer when the item literally says it's illegal/a weapon. 

"Illegal" replaced with "suspicious" so there might still be some questionning over the item but it's not "obvious" it's "illegal" when it isn't to begin with

"Weapon" replaced with "gear"

🆑
tweak: Replaced "illegal" and "weapon" in strange objects name
/🆑