### PR TITLE
Fixes squeaking

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -17,10 +17,10 @@
 /datum/component/squeak/Initialize(custom_sounds, volume_override, chance_override, step_delay_override, use_delay_override)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_BLOB_ACT, COMSIG_ATOM_HULK_ATTACK, COMSIG_PARENT_ATTACKBY), .proc/play_squeak_check)
+	RegisterSignal(parent, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_BLOB_ACT, COMSIG_ATOM_HULK_ATTACK, COMSIG_PARENT_ATTACKBY), .proc/play_squeak)
 	if(ismovableatom(parent))
-		RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT), .proc/play_squeak_check)
-		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/play_squeak_check)
+		RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT), .proc/play_squeak)
+		RegisterSignal(parent, COMSIG_MOVABLE_CROSSED, .proc/play_squeak_crossed)
 		RegisterSignal(parent, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react)
 		if(isitem(parent))
 			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), .proc/play_squeak)
@@ -60,24 +60,13 @@
 /datum/component/squeak/proc/on_drop(datum/source, mob/user)
 	UnregisterSignal(user, COMSIG_MOVABLE_DISPOSING)
 
-/datum/component/squeak/proc/play_squeak_check(atom/movable/signal_owner, atom/movable/signal_trigger)
-	// Signals are generally of the form SEND_SIGNAL(mob_listening_for_signals, signaltype, triggering_atom). E.g: SEND_SIGNAL(src, COMSIG_MOVABLE_CROSSED, AM)
-	// Since proc/play_squeak_check's second argument is typed as /atom/movable/signal_trigger, it binds to the THIRD signal argument.
-	// Hence what we actually get here is play_squeak_check(mob/themouse, atom/whatever_trigged_the_squeak).... the latter could be a crossing/bumping mob, or collision with a solid object.
-	if(ismob(signal_owner))
-		var/mob/M = signal_owner
-		if(M.stat == DEAD) // Do not squeak if the squeaking mob is dead
-			return
-	if(ismob(signal_trigger))
-		var/mob/M = signal_trigger
-		if(M.stat == DEAD) // Do not squeak if the thing that is interacting with us is dead, e.g: a ghost
-			return
-	if(isitem(signal_trigger))
-		var/obj/item/I = signal_trigger
+/datum/component/squeak/proc/play_squeak_crossed(atom/movable/AM)
+	if(isitem(AM))
+		var/obj/item/I = AM
 		if(I.flags & ABSTRACT)
 			return
-		else if(istype(signal_trigger, /obj/item/projectile))
-			var/obj/item/projectile/P = signal_trigger
+		else if(istype(AM, /obj/item/projectile))
+			var/obj/item/projectile/P = AM
 			if(P.original != parent)
 				return
 	var/atom/current_parent = parent

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -1,0 +1,25 @@
+/mob/dead/forceMove(atom/destination)
+	// Exactly the same as code/game/atoms_movable.dm#141 except doesn't call for(var/atom/movable/AM in destination) AM.Crossed(src)
+	// Overriden to prevent things like mice squeaking when ghosts walk on them.
+	var/turf/old_loc = loc
+	loc = destination
+
+	if(old_loc)
+		old_loc.Exited(src, destination)
+		for(var/atom/movable/AM in old_loc)
+			AM.Uncrossed(src)
+
+	if(destination)
+		destination.Entered(src)
+
+		if(isturf(destination) && opacity)
+			var/turf/new_loc = destination
+			new_loc.reconsider_lights()
+
+	if(isturf(old_loc) && opacity)
+		old_loc.reconsider_lights()
+
+	for(var/datum/light_source/L in light_sources)
+		L.source_atom.update_light()
+
+	return 1

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -1,25 +1,5 @@
 /mob/dead/forceMove(atom/destination)
-	// Exactly the same as code/game/atoms_movable.dm#141 except doesn't call for(var/atom/movable/AM in destination) AM.Crossed(src)
-	// Overriden to prevent things like mice squeaking when ghosts walk on them.
-	var/turf/old_loc = loc
-	loc = destination
-
-	if(old_loc)
-		old_loc.Exited(src, destination)
-		for(var/atom/movable/AM in old_loc)
-			AM.Uncrossed(src)
-
-	if(destination)
-		destination.Entered(src)
-
-		if(isturf(destination) && opacity)
-			var/turf/new_loc = destination
-			new_loc.reconsider_lights()
-
-	if(isturf(old_loc) && opacity)
-		old_loc.reconsider_lights()
-
-	for(var/datum/light_source/L in light_sources)
-		L.source_atom.update_light()
-
-	return 1
+	// Overriden from code/game/atoms_movable.dm#141 to prevent things like mice squeaking when ghosts walk on them.
+    var/oldloc = loc
+    loc = destination
+    Moved(oldloc, NONE, TRUE)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -1,5 +1,23 @@
 /mob/dead/forceMove(atom/destination)
 	// Overriden from code/game/atoms_movable.dm#141 to prevent things like mice squeaking when ghosts walk on them.
-    var/oldloc = loc
-    loc = destination
-    Moved(oldloc, NONE, TRUE)
+	// Same as parent, except that it does not include Uncrossed or Crossed calls.
+	var/turf/old_loc = loc
+	loc = destination
+
+	if(old_loc)
+		old_loc.Exited(src, destination)
+
+	if(destination)
+		destination.Entered(src)
+
+		if(isturf(destination) && opacity)
+			var/turf/new_loc = destination
+			new_loc.reconsider_lights()
+
+	if(isturf(old_loc) && opacity)
+		old_loc.reconsider_lights()
+
+	for(var/datum/light_source/L in light_sources)
+		L.source_atom.update_light()
+
+	return 1

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -35,7 +35,6 @@
 
 /mob/living/simple_animal/mouse/Initialize()
 	. = ..()
-	AddComponent(/datum/component/squeak, list('sound/effects/mousesqueek.ogg' = 1), 50)
 
 /mob/living/simple_animal/mouse/handle_automated_speech()
 	..()
@@ -91,9 +90,10 @@
 
 /mob/living/simple_animal/mouse/Crossed(AM as mob|obj)
 	if(ishuman(AM))
-		if(!stat)
+		if(stat == CONSCIOUS)
 			var/mob/M = AM
 			to_chat(M, "<span class='notice'>[bicon(src)] Squeek!</span>")
+			M << 'sound/effects/mousesqueek.ogg'
 	..()
 
 /mob/living/simple_animal/mouse/death(gibbed)

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -93,7 +93,7 @@
 		if(stat == CONSCIOUS)
 			var/mob/M = AM
 			to_chat(M, "<span class='notice'>[bicon(src)] Squeek!</span>")
-			M << 'sound/effects/mousesqueek.ogg'
+			SEND_SOUND(M, 'sound/effects/mousesqueek.ogg')
 	..()
 
 /mob/living/simple_animal/mouse/death(gibbed)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1612,6 +1612,7 @@
 #include "code\modules\mob\update_icons.dm"
 #include "code\modules\mob\update_status.dm"
 #include "code\modules\mob\camera\camera.dm"
+#include "code\modules\mob\dead\dead.dm"
 #include "code\modules\mob\dead\death.dm"
 #include "code\modules\mob\dead\observer\login.dm"
 #include "code\modules\mob\dead\observer\logout.dm"


### PR DESCRIPTION
:cl: Kyep
fix: Dead mice no longer squeak.
fix: Ghosts walking over living mice no longer makes them squeak.
/:cl:

Q: What happens when people arrange a row of dead mice on the bridge, then organize a bunch of ghosts to constantly run back and forth over them at warp speed, generating an unholy undead mouse squeak opera?
A: This PR.