### PR TITLE
Academy gateway mission + space ruin tweaks

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -43,7 +43,7 @@
 "aQ" = (/obj/structure/window/reinforced{dir = 8},/turf/space,/area/space)
 "aR" = (/obj/machinery/light/small{dir = 4},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/unpowered)
 "aS" = (/obj/machinery/power/apc/worn_out{dir = 8; pixel_x = -24; pixel_y = 0},/obj/structure/cable{icon_state = "0-4"; d2 = 4},/obj/structure/rack,/obj/item/melee/baton/cattleprod,/obj/effect/spawner/lootdrop/maintenance,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/unpowered)
-"aT" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/obj/structure/rack,/obj/item/clothing/suit/space/hardsuit/medical,/obj/item/tank/emergency_oxygen/double,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/unpowered)
+"aT" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"; pixel_y = 0},/obj/structure/rack,/obj/item/clothing/suit/space/hardsuit/medical,/obj/item/tank/emergency_oxygen/double,/obj/item/clothing/head/helmet/space/hardsuit/medical,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/unpowered)
 "aU" = (/obj/structure/rack,/obj/item/crowbar,/obj/item/shield/riot,/obj/machinery/light{dir = 1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/unpowered)
 "aV" = (/obj/machinery/smartfridge/chemistry,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/unpowered)
 "aW" = (/obj/structure/table/reinforced,/obj/item/gun/syringe,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/ruin/unpowered)

--- a/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/onehalf.dmm
@@ -140,7 +140,7 @@
 "cJ" = (/obj/machinery/light/small,/turf/simulated/floor/plasteel,/area/ruin/onehalf/bridge)
 "cK" = (/obj/machinery/door/poddoor/preopen{id_tag = "onehalf bridge"; name = "bridge blast door"},/obj/machinery/door/airlock/command/glass{name = "Bridge"},/turf/simulated/floor/plasteel,/area/ruin/onehalf/bridge)
 "cL" = (/obj/item/crowbar,/obj/item/multitool,/turf/simulated/floor/plating,/area/ruin/onehalf/bridge)
-"cM" = (/obj/structure/safe/floor,/obj/item/tank/oxygen/red,/obj/item/clothing/mask/gas/syndicate,/obj/item/clothing/suit/space/hardsuit/syndi,/obj/item/reagent_containers/food/drinks/bottle/rum,/obj/item/reagent_containers/food/drinks/bottle/rum,/obj/item/folder/syndicate/blue,/turf/simulated/floor/plating,/area/ruin/onehalf/bridge)
+"cM" = (/obj/structure/safe/floor,/obj/item/tank/oxygen/red,/obj/item/clothing/mask/gas/syndicate,/obj/item/clothing/suit/space/hardsuit/syndi,/obj/item/reagent_containers/food/drinks/bottle/rum,/obj/item/reagent_containers/food/drinks/bottle/rum,/obj/item/folder/syndicate/blue,/obj/item/clothing/head/helmet/space/hardsuit/syndi,/turf/simulated/floor/plating,/area/ruin/onehalf/bridge)
 "cN" = (/obj/structure/chair/comfy/black{tag = "icon-comfychair (EAST)"; icon_state = "comfychair"; dir = 4},/turf/simulated/floor/plasteel,/area/ruin/onehalf/bridge)
 "cO" = (/obj/structure/lattice,/obj/item/stack/cable_coil/cut{amount = 2; dir = 2; icon_state = "coil_red2"},/turf/space,/area/ruin/onehalf/hallway)
 "cQ" = (/obj/machinery/light{dir = 8},/obj/machinery/vending/sovietsoda,/turf/simulated/floor/plasteel,/area/ruin/onehalf/bridge)
@@ -189,3 +189,4 @@ aaaaaaaaaaaaaaaaaadgawclbPczdjbTbTbTbTdkdldmdldnbTbTaiaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaacxdodpacacacacacdqacacacdqacacafaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}
+

--- a/_maps/map_files/RandomZLevels/academy.dmm
+++ b/_maps/map_files/RandomZLevels/academy.dmm
@@ -35,7 +35,7 @@
 "aI" = (/obj/structure/table/reinforced,/obj/item/laser_pointer/upgraded,/turf/simulated/floor/carpet,/area/awaymission/academy/headmaster)
 "aJ" = (/obj/structure/cult/tome,/obj/item/twohanded/staff,/obj/item/spellbook/oneuse/charge,/turf/simulated/floor/wood,/area/awaymission/academy/headmaster)
 "aK" = (/obj/structure/chair/wood/wings{dir = 8},/turf/simulated/floor/wood,/area/awaymission/academy/headmaster)
-"aL" = (/obj/item/clothing/suit/space/hardsuit/wizard,/obj/structure/table/wood,/obj/item/stack/sheet/mineral/silver{amount = 20},/turf/simulated/floor/wood,/area/awaymission/academy/headmaster)
+"aL" = (/obj/item/clothing/suit/space/hardsuit/wizard,/obj/structure/table/wood,/obj/item/stack/sheet/mineral/silver{amount = 20},/obj/item/clothing/head/helmet/space/hardsuit/wizard,/turf/simulated/floor/wood,/area/awaymission/academy/headmaster)
 "aM" = (/obj/structure/table/reinforced,/obj/item/storage/briefcase,/turf/simulated/floor/carpet,/area/awaymission/academy/headmaster)
 "aN" = (/obj/structure/table/reinforced,/obj/item/coin/plasma,/turf/simulated/floor/carpet,/area/awaymission/academy/headmaster)
 "aO" = (/obj/machinery/light/small{dir = 1},/obj/machinery/atmospherics/unary/vent_pump,/turf/simulated/floor/carpet,/area/awaymission/academy/headmaster)
@@ -420,17 +420,17 @@
 "id" = (/obj/item/stack/cable_coil/random,/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
 "ie" = (/obj/structure/rack,/obj/item/stack/sheet/mineral/plasma{amount = 50},/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
 "if" = (/turf/simulated/floor/grass,/area/awaymission/academy/academyaft)
-"ig" = (/obj/structure/rack,/obj/item/circuitboard/telecomms/broadcaster,/obj/item/circuitboard/telecomms/receiver,/obj/item/circuitboard/telecomms/relay,/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
+"ig" = (/obj/structure/rack,/obj/item/circuitboard/telecomms/broadcaster,/obj/item/circuitboard/telecomms/receiver,/obj/item/circuitboard/telecomms/processor,/obj/item/circuitboard/telecomms/bus,/obj/item/circuitboard/telecomms/relay,/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
 "ih" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/unary/vent_pump{dir = 4; layer = 2.4; on = 1},/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
 "ii" = (/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
 "ij" = (/obj/structure/mirror{pixel_y = 28},/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
 "ik" = (/obj/effect/decal/cleanable/cobweb2,/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
-"il" = (/obj/structure/rack,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/crystal,/obj/item/stock_parts/subspace/filter,/obj/item/stock_parts/micro_laser/high,/obj/item/stock_parts/micro_laser/high,/turf/simulated/floor/plasteel,/area/awaymission/academy/academyaft)
+"il" = (/obj/structure/rack,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/crystal,/obj/item/stock_parts/micro_laser/high,/obj/item/stock_parts/micro_laser/high,/obj/item/stock_parts/subspace/filter,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/analyzer,/turf/simulated/floor/plasteel,/area/awaymission/academy/academyaft)
 "im" = (/obj/machinery/power/smes/magical,/obj/structure/cable,/turf/simulated/floor/plating,/area/awaymission/academy/academyaft)
 "in" = (/obj/structure/rack,/obj/item/clothing/glasses/welding,/turf/simulated/floor/plasteel,/area/awaymission/academy/academyaft)
 "io" = (/obj/structure/mineral_door/iron,/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
-"ip" = (/obj/structure/rack,/obj/item/stock_parts/scanning_module,/obj/item/stock_parts/micro_laser,/obj/item/stock_parts/subspace/filter,/obj/item/stock_parts/subspace/ansible,/turf/simulated/floor/plasteel,/area/awaymission/academy/academyaft)
-"iq" = (/obj/item/stock_parts/manipulator,/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
+"ip" = (/obj/structure/rack,/obj/item/stock_parts/subspace/ansible,/obj/item/stock_parts/micro_laser/high,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/filter,/obj/item/stock_parts/subspace/amplifier,/obj/item/stock_parts/subspace/filter,/turf/simulated/floor/plasteel,/area/awaymission/academy/academyaft)
+"iq" = (/obj/structure/rack,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/filter,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/filter,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/filter,/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
 "ir" = (/obj/structure/rack,/obj/item/storage/toolbox/mechanical,/turf/simulated/floor/plasteel,/area/awaymission/academy/academyaft)
 "is" = (/obj/structure/sink{icon_state = "sink"; dir = 8; pixel_x = -12; pixel_y = 2},/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
 "it" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
@@ -438,7 +438,7 @@
 "iv" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/turf/simulated/floor/wood,/area/awaymission/academy/academyaft)
 "iw" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
 "ix" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
-"iy" = (/obj/structure/rack,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/subspace/filter,/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
+"iy" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/rack,/obj/item/stack/sheet/metal{amount = 50},/obj/item/stock_parts/subspace/treatment,/obj/item/stock_parts/subspace/treatment,/obj/item/stock_parts/manipulator,/obj/item/stock_parts/manipulator,/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
 "iz" = (/obj/structure/toilet{dir = 8},/obj/machinery/light/small{dir = 1},/obj/effect/landmark{name = "awaystart"},/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
 "iA" = (/obj/structure/toilet{dir = 4},/obj/machinery/light/small{dir = 1},/turf/simulated/floor/plasteel{icon_state = "cafeteria"; dir = 2},/area/awaymission/academy/academyaft)
 "iB" = (/mob/living/simple_animal/hostile/statue,/turf/simulated/floor/plasteel,/area/awaymission/academy/headmaster)
@@ -546,7 +546,6 @@
 "kz" = (/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/plasteel/airless{tag = "icon-whitered (EAST)"; icon_state = "whitered"; dir = 4},/area/awaymission/academy/academyaft)
 "kA" = (/obj/structure/bookcase,/obj/item/spellbook/oneuse/summonitem,/turf/simulated/floor/wood,/area/awaymission/academy/classrooms)
 "kB" = (/mob/living/simple_animal/hostile/carp/megacarp{name = "Elmo"},/turf/simulated/mineral/random/high_chance,/area/awaymission/academy)
-"kC" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/obj/structure/rack,/obj/item/stack/sheet/metal{amount = 50},/turf/simulated/floor/plasteel{icon_state = "hydrofloor"},/area/awaymission/academy/academyaft)
 "kD" = (/obj/effect/landmark{name = "awaystart"},/turf/simulated/floor/engine,/area/awaymission/academy/academyaft)
 "kE" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/plasteel,/area/awaymission/academy/classrooms)
 "kF" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/plasteel{icon_state = "grimy"},/area/awaymission/academy/classrooms)
@@ -678,13 +677,13 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabsbBbBgIgVhqgXgYgXgYdmbEdcdcdcdcdcdcbEfLfDfHfLkUfDfDfLbEgggggLgLgLcAbsbsaPaaaaaaaaaaaaaPaaaPaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZgZgZgZgZgZgZgZgZgZgZgZfBfBfBfBfBfBfBfBfBhrfBkThbfBfBfBfBfBfBfBfBfBgZgZgZgZgZgZgZgZgZgZgZgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchdhehehfhshthigZhDgZhkhlhlhmhlhlhnfDfDfHfDkWfDfDfDhkhlhlhmhlhlhogZhDgZhphFhMhJichuhchcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchvhwheihkXiLixiQiPiQiRiSiSiSiSiSiTiZiZjbjajciZiZiZiRiSiSiSiSiSjdiQjgiQjkjhlplohchchKhcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchvhwheihkXiLixiQiPiQiRiSiSiSiSiSiTiZiZjbjajciZiZiZiRiSiSiSiSiSjdiQjgiQjkjhlplohKhchKhcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaSaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchLhchcjmhphphNgZhOgZhkhPhQhRhShTfBhUhUhUfHkWhUhUhUfBhVhWhXhYhZhngZhOgZiaibhplqhchchchcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaSaSaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchvhwhejpidhliegZgZgZfBfBfBfBfBfBfBhUifhUfHkWhUifhUfBfBfBfBfBfBfBgZgZgZighphplrlshchKhcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaSaSaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchLhchcjChphpiegZaagZiiiiiiijiiikfBhUifhUfHkWhUifhUfBiiiiijiiiiiigZaagZilhplulthchchchcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhcimhwhejFhphpingZaagZiiiiiiiiiiiiiohUifhUfHkWhUifhUioiiiiiiiiiiiigZaagZipiqlulvlshchKhcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchchchchphlhpirgZaagZisiiiiitfBfBfBiuifhUfHkWhUifivfBfBfBiwiiiijGgZaagZiyhpluluhchchchcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZgZhphlidhphphlhNgZaagZiiiiiiiiioizfBhUifhUfHkWhUifhUfBiAioiiiiiiiigZaagZkChlluluhphlhpgZgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaSaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhcimhwhejFhphpingZaagZiiiiiiiiiiiiiohUifhUfHkWhUifhUioiiiiiiiiiiiigZaagZiphplulvlshchKhcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZhchchchchphlhpirgZaagZisiiiiitfBfBfBiuifhUfHkWhUifivfBfBfBiwiiiijGgZaagZiqhpluluhchchchcgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZgZhphlidhphphlhNgZaagZiiiiiiiiioizfBhUifhUfHkWhUifhUfBiAioiiiiiiiigZaagZiyhlluluhphlhpgZgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZgZhphphlhlhpiCgZaagZisiiiiiifBfBfBhUifhUfHkWhUifhUfBfBfBiiiiiijGgZaagZhlhlhphphlhpgZgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZgZhphlhphphlgZaPgZiiiiiiiiioiDfBiEifhUfHkWhUifhUfBiAioiiiiiiiigZaPgZhlhphphpiFgZgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaagZgZgZgZiGgZgZaagZisiiiiitfBfBfBhUifhUfHkWhUifhUfBfBfBiwiiiijGgZaagZgZiGgZgZgZgZaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -733,3 +732,4 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}
+


### PR DESCRIPTION
**What does this PR do:**
This PR fixes two issues I've noticed with the academy gateway mission, one of which was also present on some space ruins.

1. Issue: Hardsuits are placed on the map, intended as loot, but no corresponding hardsuit helmet was provided. This happened in 3 places I found. The academy mission, where there's a gem encrusted hardsuit but no helmet on the 'bridge', the 'abandoned zoo' away mission which contained a medical hardsuit without a helmet, and the one half ruin, which had a syndie hardsuit but again no matching helmet.
I've added a hardsuit helmet to them all.

2. Issue: The academy gateway mission contains a room with an incomplete telecom setup (3 circuit boards and some stock parts). However, there aren't enough stock parts to actually complete it AND it's the wrong circuit board for a functioning setup, anyway. 
This seemed like a rather mean bait and switch on players, that ends up just wasting time. I've added the required circuit boards and stock parts to set up a barebones telecom setup if someone reaches the room and has a multitool handy to set it all up.

(thanks to DTX for telling me which machines are even needed for a barebones telecom setup)

Here's what the new 'setup' looks like.
![untitled](https://user-images.githubusercontent.com/32099540/48922723-0674c600-eea9-11e8-9d9c-a9428312be44.png)


**Changelog:**
:cl:
tweak: Space ruin/gateway hardsuits now should all come with helmets
tweak: Telecom setup in wizard gateway can now be completed with the present stock parts.
/:cl:

