### PR TITLE
Overall fix for projectile falloff

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -69,10 +69,8 @@
 		stamina = max(0, stamina - tile_dropoff_s) // as above, but with stamina
 	if(range <= 0 && loc)
 		on_range()
-	if(!damage && !stamina)
-		if(tile_dropoff || tile_dropoff_s) // does the projectile have falloff to start with
-			on_range()
-
+	if(!damage && !stamina && (tile_dropoff || tile_dropoff_s))
+		on_range()
 
 /obj/item/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range
 	qdel(src)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -62,15 +62,17 @@
 	return ..()
 
 /obj/item/projectile/proc/Range()
-    range--
-    if(damage && tile_dropoff)
-        damage = max(0, damage - tile_dropoff) // decrement projectile damage based on dropoff value for each tile it moves
-    if(stamina && tile_dropoff_s)
-        stamina = max(0, stamina - tile_dropoff_s) // as above, but with stamina
-    if(range <= 0 && loc)
-        on_range()
-    if(!damage && !stamina && !nodamage)
-        on_range()
+	range--
+	if(damage && tile_dropoff)
+		damage = max(0, damage - tile_dropoff) // decrement projectile damage based on dropoff value for each tile it moves
+	if(stamina && tile_dropoff_s)
+		stamina = max(0, stamina - tile_dropoff_s) // as above, but with stamina
+	if(range <= 0 && loc)
+		on_range()
+	if(!damage && !stamina)
+		if(tile_dropoff || tile_dropoff_s) // does the projectile have falloff to start with
+			on_range()
+
 
 /obj/item/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range
 	qdel(src)


### PR DESCRIPTION
**What does this PR do:**
Aims to fix the overall issue of damageless projectiles not working under the new falloff code.  Also fixed some weird indentation in the original version of the range() code.

This was after a couple of other projectiles were reported to not be working, namely cling tentacles and practice lasers. Rather than continue until we replace everything with `nodamage=1`, this new line of code means that if the projectile is to be deleted because its damage and stamina has reached 0, only delete it if it had any kind of falloff to start with. The `nodamage` check is removed as it's no longer needed with this change.

Tested with the cling tentacle, laser tag, practice laser and taser after making this change and they all work fine after doing so.

Also some of the code was indented oddly in the original, so this fix cleans that up.

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
*Remove this line, and appropriate fields from the changelog*
:cl: Azule Utama
fix: Additional check added to damage falloff code, will only delete bullets that reach 0 damage if they actually have a falloff value.
/:cl:

