### PR TITLE
Fixes check_block runtimes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -156,7 +156,7 @@ emp_act
 			return 1
 	return 0
 
-/mob/living/carbon/human/proc/check_block()
+/mob/living/carbon/human/check_block()
 	if(martial_art && prob(martial_art.block_chance) && martial_art.can_use(src) && in_throw_mode && !incapacitated(FALSE, TRUE))
 		return TRUE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -337,3 +337,7 @@
 		if(INTENT_DISARM)
 			M.do_attack_animation(src, ATTACK_EFFECT_DISARM)
 			return TRUE
+
+//defined here, overridden for humans in human_defense. By default, living mobs don't get to block anything
+/mob/living/proc/check_block()
+	return FALSE


### PR DESCRIPTION
**What does this PR do:**
fixes #10318 by defining check_block on the living level and then just overriding it for humans.

**Changelog:**
:cl: 
fix: no more runtime spam each time a simple mob is attacked
/:cl:

