### PR TITLE
a couple of fixes for hardsuit helmets

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -206,8 +206,9 @@
 		else
 			to_chat(user, "You detach \the [helmet] from \the [src]'s helmet mount.")
 			helmet.loc = get_turf(src)
-			var/obj/item/clothing/head/helmet/space/hardsuit/syndi/S = helmet
-			S.linkedsuit = null
+			if(istype(src,/obj/item/clothing/head/helmet/space/hardsuit/syndi))
+				var/obj/item/clothing/head/helmet/space/hardsuit/syndi/S = helmet
+				S.linkedsuit = null
 			src.helmet = null
 			return
 		if(!boots)
@@ -229,10 +230,11 @@
 			user.drop_item()
 			W.loc = src
 			src.helmet = W
-			var/obj/item/clothing/head/helmet/space/hardsuit/syndi/S = W
-			S.forceMove(src)
-			helmet = S
-			S.link_suit()
+			if(istype(src,/obj/item/clothing/head/helmet/space/hardsuit/syndi))
+				var/obj/item/clothing/head/helmet/space/hardsuit/syndi/S = W
+				S.forceMove(src)
+				helmet = S
+				S.link_suit()
 		return
 
 	else if(istype(W,/obj/item/clothing/shoes/magboots) && can_modify(user))

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -206,7 +206,7 @@
 		else
 			to_chat(user, "You detach \the [helmet] from \the [src]'s helmet mount.")
 			helmet.loc = get_turf(src)
-			if(istype(src,/obj/item/clothing/head/helmet/space/hardsuit/syndi))
+			if(istype(helmet,/obj/item/clothing/head/helmet/space/hardsuit/syndi))
 				var/obj/item/clothing/head/helmet/space/hardsuit/syndi/S = helmet
 				S.linkedsuit = null
 			src.helmet = null
@@ -229,8 +229,8 @@
 			to_chat(user, "You attach \the [W] to \the [src]'s helmet mount.")
 			user.drop_item()
 			W.loc = src
-			src.helmet = W
-			if(istype(src,/obj/item/clothing/head/helmet/space/hardsuit/syndi))
+			helmet = W
+			if(istype(helmet,/obj/item/clothing/head/helmet/space/hardsuit/syndi))
 				var/obj/item/clothing/head/helmet/space/hardsuit/syndi/S = W
 				S.forceMove(src)
 				helmet = S

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -206,6 +206,8 @@
 		else
 			to_chat(user, "You detach \the [helmet] from \the [src]'s helmet mount.")
 			helmet.loc = get_turf(src)
+			var/obj/item/clothing/head/helmet/space/hardsuit/syndi/S = helmet
+			S.linkedsuit = null
 			src.helmet = null
 			return
 		if(!boots)
@@ -335,6 +337,11 @@
 		linkedsuit = loc
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/attack_self(mob/user)
+	
+	if(!linkedsuit)
+		to_chat(user, "<span class='notice'>You must attach the helmet to a syndicate hardsuit to toggle combat mode!</span>")
+		return
+
 	on = !on
 	if(on)
 		to_chat(user, "<span class='notice'>You switch your helmet to travel mode. It will allow you to stand in zero pressure environments, at the cost of speed.</span>")


### PR DESCRIPTION
**What does this PR do:**
Hardsuit helmets now unlink when removed from the hardsuit they were attached too. It also adds a chack to prevent toggling combat mode for a syndicate hardsuit helmet while it's in hand, which presumably caused #6197, since toggling it makes the helmet NODROP and can only be fixed by putting it on a hardsuit and then putting it on.

**Images of sprite/map changes (IF APPLICABLE):**
None

**Changelog:**
:cl: Eschess
fix: hardsuit helmets now unlink from the hardsuits upon being detached
fix: syndicate hardsuit helmet combat mode can no longer be toggled on hand
fix: fixes non-syndicate hardsuit helmet attaching/detaching runtimes
/:cl:

