### PR TITLE
Speciesboxes; species specific starting boxes

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -168,8 +168,11 @@
 				back = backpack //Department backpack
 
 	if(box)
-		backpack_contents.Insert(1, box) // Box always takes a first slot in backpack
-		backpack_contents[box] = 1
+		var/spawnbox = box
+		if(H.dna.species.speciesbox)
+			spawnbox = H.dna.species.speciesbox
+		backpack_contents.Insert(1, spawnbox) // Box always takes a first slot in backpack
+		backpack_contents[spawnbox] = 1
 
 	if(allow_loadout && H.client && (H.client.prefs.gear && H.client.prefs.gear.len))
 		for(var/gear in H.client.prefs.gear)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -74,6 +74,26 @@
 		new /obj/item/reagent_containers/hypospray/autoinjector( src )
 		return
 
+/obj/item/storage/box/survival_vox
+	icon_state = "box_civ"
+
+/obj/item/storage/box/survival_vox/New()
+	..()
+	contents = list()
+	new /obj/item/clothing/mask/breath/vox(src)
+	new /obj/item/tank/emergency_oxygen/nitrogen(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector(src)
+
+/obj/item/storage/box/survival_plasmaman
+	icon_state = "box_civ"
+
+/obj/item/storage/box/survival_plasmaman/New()
+	..()
+	contents = list()
+	new /obj/item/clothing/mask/breath(src)
+	new /obj/item/tank/emergency_oxygen/plasma(src)
+	new /obj/item/reagent_containers/hypospray/autoinjector(src)
+
 /obj/item/storage/box/engineer
 	icon_state = "box_eng"
 	New()

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -156,6 +156,9 @@
 	// Mutant pieces
 	var/obj/item/organ/internal/ears/mutantears = /obj/item/organ/internal/ears
 
+	// Species specific boxes
+	var/speciesbox
+
 /datum/species/New()
 	//If the species has eyes, they are the default vision organ
 	if(!vision_organ && has_organ["eyes"])

--- a/code/modules/mob/living/carbon/human/species/human.dm
+++ b/code/modules/mob/living/carbon/human/species/human.dm
@@ -18,5 +18,4 @@
 
 	reagent_tag = PROCESS_ORG
 	//Has standard darksight of 2.
-
-	var/speciesbox // Specific species starting boxes
+	

--- a/code/modules/mob/living/carbon/human/species/human.dm
+++ b/code/modules/mob/living/carbon/human/species/human.dm
@@ -18,3 +18,5 @@
 
 	reagent_tag = PROCESS_ORG
 	//Has standard darksight of 2.
+
+	var/speciesbox // Specific species starting boxes

--- a/code/modules/mob/living/carbon/human/species/plasmaman.dm
+++ b/code/modules/mob/living/carbon/human/species/plasmaman.dm
@@ -39,6 +39,8 @@
 		"eyes" =     /obj/item/organ/internal/eyes
 		)
 
+	speciesbox = /obj/item/storage/box/survival_plasmaman
+
 /datum/species/plasmaman/say_filter(mob/M, message, datum/language/speaking)
 	if(copytext(message, 1, 2) != "*")
 		message = replacetext(message, "s", stutter("ss"))

--- a/code/modules/mob/living/carbon/human/species/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/vox.dm
@@ -78,6 +78,8 @@
 		"is holding their breath!",
 		"is deeply inhaling oxygen!")
 
+	speciesbox = /obj/item/storage/box/survival_vox
+
 /datum/species/vox/handle_death(mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
 


### PR DESCRIPTION
This PR introduces species specific starting boxes.

This will allow Vox to have N2 tanks instead of O2, plasmamen to have plamsa etc.

🆑 Birdtalon
add: Species specific starting boxes.
/🆑 