### PR TITLE
Adds CQC pistol fighting and a CQC syndicate bundle

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,7 +1,7 @@
 /obj/item/storage/box/syndicate/
 	New()
 		..()
-		switch(pickweight(list("bloodyspai" = 1, "thief" = 1, "bond" = 1, "sabotage" = 1, "payday" = 1, "implant" = 1, "hacker" = 1, "darklord" = 1, "gadgets" = 1)))
+		switch(pickweight(list("bloodyspai" = 1, "thief" = 1, "bond" = 1, "sabotage" = 1, "payday" = 1, "implant" = 1, "hacker" = 1, "darklord" = 1, "gadgets" = 1, "tacticalespionageaction" = 1)))
 			if("bloodyspai")
 				new /obj/item/twohanded/garrote(src)
 				new /obj/item/pinpointer/advpinpointer(src)
@@ -78,6 +78,19 @@
 				new /obj/item/clothing/shoes/syndigaloshes(src)
 				new /obj/item/stamp/chameleon(src)
 				new /obj/item/multitool/ai_detect(src)
+				return
+
+			if("tacticalespionageaction")
+				new /obj/item/CQC_manual(src)
+				new /obj/item/gun/projectile/automatic/pistol(src)
+				new /obj/item/suppressor(src)
+				new /obj/item/ammo_box/magazine/m10mm(src)
+				new /obj/item/ammo_box/magazine/m10mm/ap(src)
+				new /obj/item/ammo_box/magazine/m10mm/hp(src)
+				new /obj/item/kitchen/knife/combat(src)
+				new /obj/item/clothing/mask/bandana/black(src)
+				new /obj/item/clothing/glasses/eyepatch(src)
+				new /obj/item/clothing/mask/cigarette/cigar/havana(src)
 				return
 
 /obj/item/storage/box/syndie_kit

--- a/code/modules/martial_arts/adminfu.dm
+++ b/code/modules/martial_arts/adminfu.dm
@@ -9,7 +9,7 @@
 	name = "Way of the Dancing Admin"
 	help_verb = /mob/living/carbon/human/proc/adminfu_help
 
-/datum/martial_art/adminfu/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+/datum/martial_art/adminfu/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(findtext(streak,HEAL_COMBO))
 		streak = ""
 		healPalm(A,D)

--- a/code/modules/martial_arts/cqc.dm
+++ b/code/modules/martial_arts/cqc.dm
@@ -8,6 +8,7 @@
 	name = "CQC"
 	help_verb = /mob/living/carbon/human/proc/CQC_help
 	block_chance = 75
+	pistol_melee = 1
 
 /datum/martial_art/cqc/can_use(mob/living/carbon/human/H)
 	if(istype(H.gloves, /obj/item/clothing/gloves/fingerless/rapid))
@@ -17,7 +18,7 @@
 /datum/martial_art/cqc/proc/drop_restraining()
 	restraining = FALSE
 
-/datum/martial_art/cqc/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
+/datum/martial_art/cqc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE
 	if(findtext(streak, SLAM_COMBO))
@@ -192,7 +193,7 @@
 	set name = "Remember The Basics"
 	set desc = "You try to remember some of the basics of CQC."
 	set category = "CQC"
-	to_chat(usr, "<b><i>You try to remember some of the basics of CQC.</i></b>")
+	to_chat(usr, "<b><i>You try to remember some of the basics of CQC. These moves can be used holding a pistol when fighting in close quarters.</i></b>")
 
 	to_chat(usr, "<span class='notice'>Slam</span>: Harm Grab. Slam opponent into the ground, knocking them down.")
 	to_chat(usr, "<span class='notice'>CQC Kick</span>: Harm Harm. Knocks opponent away. Knocks out stunned or knocked down opponents.")

--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -58,7 +58,7 @@
 	legsweep.Remove(H)
 	lungpunch.Remove(H)
 
-/datum/martial_art/krav_maga/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+/datum/martial_art/krav_maga/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	switch(streak)
 		if("neck_chop")
 			streak = ""

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -8,6 +8,7 @@
 	var/deflection_chance = 0 //Chance to deflect projectiles
 	var/block_chance = 0 //Chance to block melee attacks using items while on throw mode.
 	var/restraining = 0 //used in cqc's disarm_act to check if the disarmed is being restrained and so whether they should be put in a chokehold or not
+	var/pistol_melee = 0 //can you use this martial art while holding a small arm such as a pistol
 	var/help_verb = null
 	var/no_guns = FALSE	//set to TRUE to prevent users of this style from using guns (sleeping carp, highlander). They can still pick them up, but not fire them.
 	var/no_guns_message = ""	//message to tell the style user if they try and use a gun while no_guns = TRUE (DISHONORABRU!)
@@ -34,6 +35,9 @@
 	streak = streak+element
 	if(length(streak) > max_streak_length)
 		streak = copytext(streak,2)
+	return
+
+/datum/martial_art/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	return
 
 /datum/martial_art/proc/basic_hit(var/mob/living/carbon/human/A,var/mob/living/carbon/human/D)

--- a/code/modules/martial_arts/mimejutsu.dm
+++ b/code/modules/martial_arts/mimejutsu.dm
@@ -6,7 +6,7 @@
 	name = "Mimejutsu"
 	help_verb = /mob/living/carbon/human/proc/mimejutsu_help
 
-/datum/martial_art/mimejutsu/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+/datum/martial_art/mimejutsu/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(findtext(streak,MIMECHUCKS_COMBO))
 		streak = ""
 		mimeChuck(A,D)

--- a/code/modules/martial_arts/plasma_fist.dm
+++ b/code/modules/martial_arts/plasma_fist.dm
@@ -7,7 +7,7 @@
 	help_verb = /mob/living/carbon/human/proc/plasma_fist_help
 
 
-/datum/martial_art/plasma_fist/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+/datum/martial_art/plasma_fist/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(findtext(streak,TORNADO_COMBO))
 		streak = ""
 		Tornado(A,D)

--- a/code/modules/martial_arts/sleeping_carp.dm
+++ b/code/modules/martial_arts/sleeping_carp.dm
@@ -11,7 +11,7 @@
 	no_guns = TRUE
 	no_guns_message = "Use of ranged weaponry would bring dishonor to the clan."
 
-/datum/martial_art/the_sleeping_carp/proc/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
+/datum/martial_art/the_sleeping_carp/check_streak(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(findtext(streak,WRIST_WRENCH_COMBO))
 		streak = ""
 		wristWrench(A,D)

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -34,6 +34,7 @@
 	ammo_x_offset = 2
 	charge_sections = 3
 	can_flashlight = 0 // Can't attach or detach the flashlight, and override it's icon update
+	can_cqc = 1
 
 /obj/item/gun/energy/gun/mini/New()
 	gun_light = new /obj/item/flashlight/seclite(src)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -43,6 +43,7 @@
 	item_state = "gun"
 	cell_type = /obj/item/stock_parts/cell/pulse/pistol
 	can_charge = 0
+	can_cqc = 1
 
 /obj/item/gun/energy/pulse/pistol/isHandgun()
 	return 1

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -104,6 +104,7 @@
 	can_flashlight = 0
 	max_mod_capacity = 0
 	empty_state = null
+	can_cqc = 1
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/ninja
 	name = "energy dart thrower"
@@ -117,6 +118,7 @@
 	materials = list(MAT_METAL=4000)
 	origin_tech = "combat=4;magnets=4;syndicate=2"
 	suppressed = 0
+	can_cqc = 0
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/large/cyborg
@@ -124,6 +126,7 @@
 	icon_state = "crossbowlarge"
 	origin_tech = null
 	materials = list()
+	can_cqc = 0
 
 /obj/item/gun/energy/kinetic_accelerator/suicide_act(mob/user)
 	if(!suppressed)

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -6,6 +6,7 @@
 	item_state = "wand"
 	w_class = WEIGHT_CLASS_SMALL
 	can_charge = 0
+	can_cqc = 1 //why not
 	max_charges = 100 //100, 50, 50, 34 (max charge distribution by 25%ths)
 	var/variable_charges = 1
 

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -6,6 +6,7 @@
 	origin_tech = "combat=3;materials=2;syndicate=4"
 	mag_type = /obj/item/ammo_box/magazine/m10mm
 	can_suppress = 1
+	can_cqc = 1
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()


### PR DESCRIPTION
Added using CQC when holding a pistol : 
- Stechkin
- HOP mini energy
- Mini energy crossbow
- Wands
- Pulse pistol 
- Finger gun (if merged, will update)

Added a new syndicate bundle that contains the CQC manual, silenced pistol and ammo (1 mag of each type), a combat knife, and fluff (edit : black bandana, eyepatch, and a cigar)

Changed martial art code so check streak proc is defined in martial and not defined on every single martial art, also added var for gun melee

Added can_cqc var to guns

🆑
add: Added the ability to fight in CQC using a 10mm pistol (and a few others)
add: Added the Tactical Espionage Action bundle to random syndicate bundles.
/🆑