### PR TITLE
[WIP] /tg/ Taste System Port

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -64,11 +64,12 @@
 // Factor of how fast mob nutrition decreases
 #define	HUNGER_FACTOR 0.1
 
-// Taste sensitivity - the more the more reagents you'll taste
-#define TASTE_SENSITIVITY_NORMAL 1
-#define TASTE_SENSITIVITY_SHARP 1.5
-#define TASTE_SENSITIVITY_DULL 0.75
-#define TASTE_SENSITIVITY_NO_TASTE 0
+// Taste sensitivity - lower is more sensitive 
+// Represents the minimum portion of total taste the mob can sense
+#define TASTE_SENSITIVITY_NORMAL 15
+#define TASTE_SENSITIVITY_SHARP 7.5
+#define TASTE_SENSITIVITY_DULL 20
+#define TASTE_SENSITIVITY_NO_TASTE 101
 
 // Reagent type flags, defines the types of mobs this reagent will affect
 #define ORGANIC 1

--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -792,3 +792,32 @@ proc/dd_sortedObjectList(list/incoming)
 			L.Swap(start++, end--)
 
 	return L
+
+//Counterlist procs are used for doing operations on associative arrays that have numeric value entries
+//All of these procs modify in place
+/proc/counterlist_scale(list/L, scalar)
+	var/list/out = list()
+	for(var/key in L)
+		out[key] = L[key] * scalar
+	. = out
+
+/proc/counterlist_sum(list/L)
+	. = 0
+	for(var/key in L)
+		. += L[key]
+
+//normalize here means every value will represent its portion of the total sum in decimal form
+/proc/counterlist_normalize(list/L)
+	var/sum = counterlist_sum(L)
+	if(sum)
+		. = counterlist_scale(L, 1 / sum)
+	else
+		. = L
+
+/proc/counterlist_combine(list/L1, list/L2)
+	for(var/key in L2)
+		var/other_value = L2[key]
+		if(key in L1)
+			L1[key] += other_value
+		else
+			L1[key] = other_value

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -12,7 +12,7 @@
 	var/apply_method = "swallow"
 	var/transfer_efficiency = 1.0
 	var/instant_application = 0 //if we want to bypass the forcedfeed delay
-	var/taste = TRUE//whether you can taste eating from this
+	var/can_taste = TRUE//whether you can taste eating from this
 	burn_state = FLAMMABLE
 	container_type = INJECTABLE
 

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -89,6 +89,7 @@
 	basename = "personal pizza"
 	snack_overlays = 0
 	top = 0
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/pasta
 	name = "spaghetti"
@@ -107,6 +108,7 @@
 	basename = "bread"
 	snack_overlays = 0
 	top = 0
+	tastes = list("bread" = 10)
 
 /obj/item/reagent_containers/food/snacks/customizable/cook/pie
 	name = "pie"
@@ -116,6 +118,7 @@
 	basename = "pie"
 	snack_overlays = 0
 	top = 0
+	tastes = list("pie" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/cook/cake
 	name = "cake"
@@ -153,6 +156,7 @@
 	basename = "kebab"
 	snack_overlays = 0
 	top = 0
+	tastes = list("meat" = 3, "metal" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/cook/salad
 	name = "salad"
@@ -162,6 +166,7 @@
 	basename = "salad"
 	snack_overlays = 0
 	top = 0
+	tastes = list("leaves" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/cook/waffles
 	name = "waffles"
@@ -171,6 +176,7 @@
 	basename = "waffles"
 	snack_overlays = 0
 	top = 0
+	tastes = list("waffles" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/candy/cookie
 	name = "cookie"
@@ -180,6 +186,7 @@
 	basename = "cookie"
 	snack_overlays = 0
 	top = 0
+	tastes = list("cookie" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/candy/cotton
 	name = "flavored cotton candy"
@@ -309,6 +316,7 @@
 	snack_overlays = 0
 	trash = /obj/item/trash/bowl
 	top = 0
+	tastes = list("soup" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/burger
 	name = "burger bun"

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -125,6 +125,7 @@
 	basename = "cake"
 	snack_overlays = 0
 	top = 0
+	tastes = list("cake" = 1)
 
 /obj/item/reagent_containers/food/snacks/customizable/cook/jelly
 	name = "jelly"
@@ -316,6 +317,7 @@
 	baseicon = "burgercustom"
 	basename = "burger"
 	toptype = new /obj/item/reagent_containers/food/snacks/bun()
+	tastes = list("bun" = 4)
 
 /obj/item/reagent_containers/food/snacks/customizable/attackby(obj/item/I, mob/user, params)
 	if(contents.len > sandwich_limit)

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -12,6 +12,7 @@
 	bitesize = 3
 	filling_color = "#FFD675"
 	list_reagents = list("nutriment" = 20, "oculine" = 10, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 2, "carrot" = 1)
 
 /obj/item/reagent_containers/food/snacks/carrotcakeslice
 	name = "carrot cake slice"
@@ -19,6 +20,7 @@
 	icon_state = "carrotcake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFD675"
+	tastes = list("cake" = 5, "sweetness" = 2, "carrot" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/braincake
 	name = "brain cake"
@@ -29,6 +31,7 @@
 	filling_color = "#E6AEDB"
 	bitesize = 3
 	list_reagents = list("protein" = 10, "nutriment" = 10, "mannitol" = 10, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 2, "brains" = 1)
 
 /obj/item/reagent_containers/food/snacks/braincakeslice
 	name = "brain cake slice"
@@ -36,6 +39,7 @@
 	icon_state = "braincakeslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#E6AEDB"
+	tastes = list("cake" = 5, "sweetness" = 2, "brains" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/cheesecake
 	name = "cheese cake"
@@ -46,6 +50,7 @@
 	filling_color = "#FAF7AF"
 	bitesize = 3
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("cake" = 4, "cream cheese" = 3)
 
 /obj/item/reagent_containers/food/snacks/cheesecakeslice
 	name = "cheese cake slice"
@@ -53,6 +58,7 @@
 	icon_state = "cheesecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FAF7AF"
+	tastes = list("cake" = 4, "cream cheese" = 3)
 
 /obj/item/reagent_containers/food/snacks/sliceable/plaincake
 	name = "vanilla cake"
@@ -63,6 +69,7 @@
 	bitesize = 3
 	filling_color = "#F7EDD5"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("vanilla" = 1, "sweetness" = 2,"cake" = 5)
 
 /obj/item/reagent_containers/food/snacks/plaincakeslice
 	name = "vanilla cake slice"
@@ -70,6 +77,7 @@
 	icon_state = "plaincake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#F7EDD5"
+	tastes = list("vanilla" = 1, "sweetness" = 2,"cake" = 5)
 
 /obj/item/reagent_containers/food/snacks/sliceable/orangecake
 	name = "orange cake"
@@ -80,6 +88,7 @@
 	bitesize = 3
 	filling_color = "#FADA8E"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 2, "oranges" = 2)
 
 /obj/item/reagent_containers/food/snacks/orangecakeslice
 	name = "orange cake slice"
@@ -87,6 +96,7 @@
 	icon_state = "orangecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FADA8E"
+	tastes = list("cake" = 5, "sweetness" = 2, "oranges" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/bananacake
 	name = "banana cake"
@@ -114,6 +124,7 @@
 	slices_num = 5
 	filling_color = "#CBFA8E"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 2, "unbearable sourness" = 2)
 
 /obj/item/reagent_containers/food/snacks/limecakeslice
 	name = "lime cake slice"
@@ -121,6 +132,7 @@
 	icon_state = "limecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#CBFA8E"
+	tastes = list("cake" = 5, "sweetness" = 2, "unbearable sourness" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/lemoncake
 	name = "lemon cake"
@@ -131,6 +143,7 @@
 	bitesize = 3
 	filling_color = "#FAFA8E"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 2, "sourness" = 2)
 
 /obj/item/reagent_containers/food/snacks/lemoncakeslice
 	name = "lemon cake slice"
@@ -138,6 +151,7 @@
 	icon_state = "lemoncake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FAFA8E"
+	tastes = list("cake" = 5, "sweetness" = 2, "sourness" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/chocolatecake
 	name = "chocolate cake"
@@ -148,6 +162,7 @@
 	bitesize = 3
 	filling_color = "#805930"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 1, "chocolate" = 4)
 
 /obj/item/reagent_containers/food/snacks/chocolatecakeslice
 	name = "chocolate cake slice"
@@ -155,6 +170,7 @@
 	icon_state = "chocolatecake_slice"
 	trash = /obj/item/trash/plate
 	filling_color = "#805930"
+	tastes = list("cake" = 5, "sweetness" = 1, "chocolate" = 4)
 
 /obj/item/reagent_containers/food/snacks/sliceable/birthdaycake
 	name = "birthday cake"
@@ -165,6 +181,7 @@
 	filling_color = "#FFD6D6"
 	bitesize = 3
 	list_reagents = list("nutriment" = 20, "sprinkles" = 10, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 1)
 
 /obj/item/reagent_containers/food/snacks/birthdaycakeslice
 	name = "birthday cake slice"
@@ -172,6 +189,7 @@
 	icon_state = "birthdaycakeslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#FFD6D6"
+	tastes = list("cake" = 5, "sweetness" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/applecake
 	name = "apple cake"
@@ -182,6 +200,7 @@
 	bitesize = 3
 	filling_color = "#EBF5B8"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("cake" = 5, "sweetness" = 1, "apple" = 1)
 
 /obj/item/reagent_containers/food/snacks/applecakeslice
 	name = "apple cake slice"
@@ -189,6 +208,7 @@
 	icon_state = "applecakeslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#EBF5B8"
+	tastes = list("cake" = 5, "sweetness" = 1, "apple" = 1)
 
 
 //////////////////////

--- a/code/modules/food_and_drinks/food/foods/baked_goods.dm
+++ b/code/modules/food_and_drinks/food/foods/baked_goods.dm
@@ -230,12 +230,14 @@
 	filling_color = "#E8E79E"
 	list_reagents = list("nutriment" = 3)
 	trash = /obj/item/paper/fortune
+	tastes = list("cookie" = 1)
 
 /obj/item/reagent_containers/food/snacks/sugarcookie
 	name = "sugar cookie"
 	desc = "Just like your little sister used to make."
 	icon_state = "sugarcookie"
 	list_reagents = list("nutriment" = 3, "sugar" = 3)
+	tastes = list("sweetness" = 1)
 
 
 //////////////////////
@@ -250,6 +252,7 @@
 	filling_color = "#FBFFB8"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "banana" = 5, "vitamin" = 2)
+	tastes = list("pie" = 1)
 
 /obj/item/reagent_containers/food/snacks/pie/throw_impact(atom/hit_atom)
 	..()
@@ -265,6 +268,7 @@
 	filling_color = "#948051"
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+	tastes = list("pie" = 1, "meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/tofupie
 	name = "tofu-pie"
@@ -274,6 +278,7 @@
 	filling_color = "#FFFEE0"
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+	tastes = list("pie" = 1, "tofu" = 1)
 
 /obj/item/reagent_containers/food/snacks/amanita_pie
 	name = "amanita pie"
@@ -282,6 +287,7 @@
 	filling_color = "#FFCCCC"
 	bitesize = 4
 	list_reagents = list("nutriment" = 6, "amanitin" = 3, "psilocybin" = 1, "vitamin" = 4)
+	tastes = list("pie" = 1, "mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/plump_pie
 	name = "plump pie"
@@ -290,6 +296,7 @@
 	filling_color = "#B8279B"
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+	tastes = list("pie" = 1, "mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/plump_pie/New()
 	..()
@@ -305,6 +312,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#43DE18"
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+	tastes = list("pie" = 1, "meat" = 1, "acid" = 1)
 
 /obj/item/reagent_containers/food/snacks/applepie
 	name = "apple pie"
@@ -313,6 +321,7 @@
 	filling_color = "#E0EDC5"
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+	tastes = list("pie" = 1, "apple" = 1)
 
 /obj/item/reagent_containers/food/snacks/cherrypie
 	name = "cherry pie"
@@ -321,6 +330,7 @@
 	filling_color = "#FF525A"
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
+	tastes = list("pie" = 1, "cherries" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/pumpkinpie
 	name = "pumpkin pie"
@@ -331,6 +341,7 @@
 	bitesize = 3
 	filling_color = "#F5B951"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("pie" = 1, "pumpkin" = 1)
 
 /obj/item/reagent_containers/food/snacks/pumpkinpieslice
 	name = "pumpkin pie slice"
@@ -338,6 +349,7 @@
 	icon_state = "pumpkinpieslice"
 	trash = /obj/item/trash/plate
 	filling_color = "#F5B951"
+	tastes = list("pie" = 1, "pumpkin" = 1)
 
 
 //////////////////////
@@ -353,6 +365,7 @@
 	var/extra_reagent = null
 	filling_color = "#D2691E"
 	var/randomized_sprinkles = 1
+	tastes = list("donut" = 1)
 
 /obj/item/reagent_containers/food/snacks/donut/New()
 	..()
@@ -373,6 +386,7 @@
 	name = "chaos donut"
 	desc = "Like life, it never quite tastes the same."
 	bitesize = 10
+	tastes = list("donut" = 3, "chaos" = 1)
 
 /obj/item/reagent_containers/food/snacks/donut/chaos/New()
 	..()
@@ -389,6 +403,7 @@
 	desc = "You jelly?"
 	icon_state = "jdonut1"
 	extra_reagent = "berryjuice"
+	tastes = list("jelly" = 1, "donut" = 3)
 
 /obj/item/reagent_containers/food/snacks/donut/jelly/New()
 	..()
@@ -423,6 +438,7 @@
 	icon_state = "muffin"
 	filling_color = "#E0CF9B"
 	list_reagents = list("nutriment" = 6)
+	tastes = list("muffin" = 1)
 
 /obj/item/reagent_containers/food/snacks/berryclafoutis
 	name = "berry clafoutis"
@@ -431,6 +447,7 @@
 	trash = /obj/item/trash/plate
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "berryjuice" = 5, "vitamin" = 2)
+	tastes = list("pie" = 1, "blackberries" = 1)
 
 /obj/item/reagent_containers/food/snacks/poppypretzel
 	name = "poppy pretzel"
@@ -438,6 +455,7 @@
 	icon_state = "poppypretzel"
 	filling_color = "#916E36"
 	list_reagents = list("nutriment" = 5)
+	tastes = list("pretzel" = 1)
 
 /obj/item/reagent_containers/food/snacks/plumphelmetbiscuit
 	name = "plump helmet biscuit"
@@ -445,6 +463,7 @@
 	icon_state = "phelmbiscuit"
 	filling_color = "#CFB4C4"
 	list_reagents = list("nutriment" = 5)
+	tastes = list("mushroom" = 1, "biscuit" = 1)
 
 /obj/item/reagent_containers/food/snacks/plumphelmetbiscuit/New()
 	..()
@@ -461,6 +480,7 @@
 	filling_color = "#FFFF00"
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "gold" = 5, "vitamin" = 4)
+	tastes = list("pie" = 1, "apple" = 1, "expensive metal" = 1)
 
 /obj/item/reagent_containers/food/snacks/cracker
 	name = "cracker"
@@ -469,3 +489,4 @@
 	bitesize = 1
 	filling_color = "#F5DEB8"
 	list_reagents = list("nutriment" = 1)
+	tastes = list("cracker" = 1)

--- a/code/modules/food_and_drinks/food/foods/bread.dm
+++ b/code/modules/food_and_drinks/food/foods/bread.dm
@@ -160,6 +160,7 @@
 	filling_color = "#DBCC9A"
 	bitesize = 3
 	list_reagents = list("nutriment" = 2, "vitamin" = 2)
+	tastes = list("bread" = 2)
 
 /obj/item/reagent_containers/food/snacks/jelliedtoast
 	name = "Jellied Toast"
@@ -168,6 +169,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#B572AB"
 	bitesize = 3
+	tastes = list("toast" = 1, "jelly" = 1)
 
 /obj/item/reagent_containers/food/snacks/jelliedtoast/cherry
 	list_reagents = list("nutriment" = 1, "cherryjelly" = 5, "vitamin" = 2)
@@ -183,6 +185,7 @@
 	filling_color = "#FF00F7"
 	bitesize = 4
 	list_reagents = list("nutriment" = 8, "psilocybin" = 2, "vitamin" = 2)
+	tastes = list("waffle" = 1, "mushrooms" = 1)
 
 /obj/item/reagent_containers/food/snacks/waffles
 	name = "waffles"

--- a/code/modules/food_and_drinks/food/foods/bread.dm
+++ b/code/modules/food_and_drinks/food/foods/bread.dm
@@ -11,6 +11,7 @@
 	slices_num = 5
 	filling_color = "#FF7575"
 	list_reagents = list("protein" = 20, "nutriment" = 10, "vitamin" = 5)
+	tastes = list("bread" = 10, "meat" = 10)
 
 /obj/item/reagent_containers/food/snacks/meatbreadslice
 	name = "meatbread slice"
@@ -27,6 +28,7 @@
 	slices_num = 5
 	filling_color = "#8AFF75"
 	list_reagents = list("protein" = 20, "nutriment" = 10, "vitamin" = 5)
+	tastes = list("bread" = 10, "acid" = 10)
 
 /obj/item/reagent_containers/food/snacks/xenomeatbreadslice
 	name = "xenomeatbread slice"
@@ -42,6 +44,7 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/spidermeatbreadslice
 	slices_num = 5
 	list_reagents = list("protein" = 20, "nutriment" = 10, "toxin" = 15, "vitamin" = 5)
+	tastes = list("bread" = 10, "cobwebs" = 5)
 
 /obj/item/reagent_containers/food/snacks/spidermeatbreadslice
 	name = "spider meat bread slice"
@@ -58,6 +61,7 @@
 	slices_num = 5
 	filling_color = "#EDE5AD"
 	list_reagents = list("banana" = 20, "nutriment" = 20)
+	tastes = list("bread" = 10) // banana juice will also flavour
 
 /obj/item/reagent_containers/food/snacks/bananabreadslice
 	name = "Banana-nut bread slice"
@@ -74,6 +78,7 @@
 	slices_num = 5
 	filling_color = "#F7FFE0"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("bread" = 10, "tofu" = 10)
 
 /obj/item/reagent_containers/food/snacks/tofubreadslice
 	name = "Tofubread slice"
@@ -90,6 +95,7 @@
 	slices_num = 6
 	filling_color = "#FFE396"
 	list_reagents = list("nutriment" = 10)
+	tastes = list("bread" = 10)
 
 /obj/item/reagent_containers/food/snacks/breadslice
 	name = "Bread slice"
@@ -98,6 +104,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D27332"
 	list_reagents = list("nutriment" = 2, "bread" = 5)
+	tastes = list("bread" = 10)
 
 /obj/item/reagent_containers/food/snacks/sliceable/creamcheesebread
 	name = "Cream Cheese Bread"
@@ -107,6 +114,7 @@
 	slices_num = 5
 	filling_color = "#FFF896"
 	list_reagents = list("nutriment" = 20, "vitamin" = 5)
+	tastes = list("bread" = 10, "cheese" = 10)
 
 /obj/item/reagent_containers/food/snacks/creamcheesebreadslice
 	name = "Cream Cheese Bread slice"
@@ -127,6 +135,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "bun"
 	list_reagents = list("nutriment" = 1)
+	tastes = list("bun" = 1)
 
 /obj/item/reagent_containers/food/snacks/flatbread
 	name = "flatbread"
@@ -142,6 +151,7 @@
 	filling_color = "#E3D796"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	tastes = list("bread" = 1)
 
 /obj/item/reagent_containers/food/snacks/twobread
 	name = "Two Bread"

--- a/code/modules/food_and_drinks/food/foods/candy.dm
+++ b/code/modules/food_and_drinks/food/foods/candy.dm
@@ -23,6 +23,7 @@
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 2, "chocolate" = 4)
+	tastes = list("chocolate" = 1)
 
 /obj/item/reagent_containers/food/snacks/candy/caramel
 	name = "Caramel"
@@ -107,6 +108,7 @@
 	icon_state = "candycorn"
 	filling_color = "#FFFCB0"
 	list_reagents = list("nutriment" = 4, "sugar" = 2)
+	tastes = list("candy corn" = 1)
 
 // ***********************************************************
 // Candy Products (plain / unflavored)
@@ -130,6 +132,7 @@
 	bitesize = 3
 	junkiness = 25
 	list_reagents = list("nutriment" = 1, "chocolate" = 1)
+	tastes = list("chocolate" = 1)
 
 
 /obj/item/reagent_containers/food/snacks/candy/candycane
@@ -185,6 +188,7 @@
 	filling_color = "#302000"
 	bitesize = 3
 	list_reagents = list("nutriment" = 2, "chocolate" = 4)
+	tastes = list("chocolate" = 1)
 
 /obj/item/reagent_containers/food/snacks/candy/gum
 	name = "bubblegum"

--- a/code/modules/food_and_drinks/food/foods/desserts.dm
+++ b/code/modules/food_and_drinks/food/foods/desserts.dm
@@ -42,6 +42,7 @@
 	desc = "Portable Ice-cream in it's own packaging."
 	icon_state = "icecreamsandwich"
 	list_reagents = list("nutriment" = 2, "ice" = 2)
+	tastes = list("ice cream" = 1)
 
 
 //////////////////////
@@ -61,6 +62,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
 	list_reagents = list("nutriment" = 7, "vitamin" = 2)
+	tastes = list("rice" = 1, "sweetness" = 1)
 
 /obj/item/reagent_containers/food/snacks/spacylibertyduff
 	name = "Spacy Liberty Duff"
@@ -70,6 +72,7 @@
 	filling_color = "#42B873"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "psilocybin" = 6)
+	tastes = list("jelly" = 1, "mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/amanitajelly
 	name = "Amanita Jelly"
@@ -79,6 +82,7 @@
 	filling_color = "#ED0758"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "amanitin" = 6, "psilocybin" = 3)
+	tastes = list("jelly" = 1, "mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/candiedapple
 	name = "Candied Apple"
@@ -87,6 +91,7 @@
 	filling_color = "#F21873"
 	bitesize = 3
 	list_reagents = list("nutriment" = 3, "sugar" = 2)
+	tastes = list("apple" = 2, "sweetness" = 2)
 
 /obj/item/reagent_containers/food/snacks/mint
 	name = "mint"

--- a/code/modules/food_and_drinks/food/foods/ethnic.dm
+++ b/code/modules/food_and_drinks/food/foods/ethnic.dm
@@ -9,6 +9,7 @@
 	icon_state = "taco"
 	bitesize = 3
 	list_reagents = list("nutriment" = 7, "vitamin" = 1)
+	tastes = list("taco" = 4, "meat" = 2, "cheese" = 2, "lettuce" = 1)
 
 /obj/item/reagent_containers/food/snacks/burrito
 	name = "Burrito"
@@ -17,6 +18,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#A36A1F"
 	list_reagents = list("nutriment" = 4, "vitamin" = 1)
+	tastes = list("torilla" = 2, "meat" = 3)
 
 /obj/item/reagent_containers/food/snacks/chimichanga
 	name = "Chimichanga"
@@ -34,6 +36,7 @@
 	filling_color = "#A36A1F"
 	bitesize = 4
 	list_reagents = list("nutriment" = 8, "capsaicin" = 6)
+	tastes = list("hot peppers" = 1, "meat" = 3, "cheese" = 1, "sour cream" = 1)
 
 /obj/item/reagent_containers/food/snacks/cornchips
 	name = "corn chips"
@@ -55,6 +58,7 @@
 	icon_state = "chinese1"
 	junkiness = 25
 	list_reagents = list("nutriment" = 1, "beans" = 3, "msg" = 4, "sugar" = 2)
+	tastes = list("noodle" = 1, "vegetables" = 1)
 
 /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball
 	name = "Sweet & Sour Chicken Balls"
@@ -96,6 +100,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#F0F2E4"
 	list_reagents = list("nutriment" = 5)
+	tastes = list("custard" = 1)
 
 /obj/item/reagent_containers/food/snacks/yakiimo
 	name = "yaki imo"
@@ -104,6 +109,7 @@
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 5, "vitamin" = 4)
 	filling_color = "#8B1105"
+	tastes = list("sweet potato" = 1)
 
 
 //////////////////////

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -10,6 +10,7 @@
 	filling_color = "#FFFEE0"
 	bitesize = 3
 	list_reagents = list("plantmatter" = 2)
+	tastes = list("tofu" = 1)
 
 /obj/item/reagent_containers/food/snacks/fried_tofu
 	name = "Fried Tofu"
@@ -26,6 +27,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#C4BF76"
 	list_reagents = list("nutriment" = 2)
+	tastes = list("soy" = 1)
 
 
 //////////////////////
@@ -40,12 +42,14 @@
 	slices_num = 5
 	filling_color = "#FFF700"
 	list_reagents = list("nutriment" = 15, "vitamin" = 5, "cheese" = 20)
+	tastes = list("cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/cheesewedge
 	name = "Cheese wedge"
 	desc = "A wedge of delicious Cheddar. The cheese wheel it was cut from can't have gone far."
 	icon_state = "cheesewedge"
 	filling_color = "#FFF700"
+	tastes = list("cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/weirdcheesewedge
 	name = "Weird Cheese"
@@ -66,6 +70,7 @@
 	filling_color = "#E0D7C5"
 	bitesize = 6
 	list_reagents = list("plantmatter" = 3, "vitamin" = 1)
+	tastes = list("mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/tomatomeat
 	name = "tomato slice"
@@ -80,6 +85,7 @@
 	desc = "A slice of watery goodness."
 	icon_state = "watermelonslice"
 	filling_color = "#FF3867"
+	tastes = list("watermelon" = 1)
 
 /obj/item/reagent_containers/food/snacks/pineappleslice
 	name = "Pineapple Slices"
@@ -142,6 +148,7 @@
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 2, "sugar" = 2, "cocoa" = 2)
+	tastes = list("chocolate" = 1)
 
 /obj/item/reagent_containers/food/snacks/choc_pile //for reagent chocolate being spilled on turfs
 	name = "Pile of Chocolate"

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -98,6 +98,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "dough"
 	list_reagents = list("nutriment" = 6)
+	tastes = list("dough" = 1)
 
 // Dough + rolling pin = flat dough
 /obj/item/reagent_containers/food/snacks/dough/attackby(obj/item/I, mob/user, params)
@@ -120,6 +121,7 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/doughslice
 	slices_num = 3
 	list_reagents = list("nutriment" = 6)
+	tastes = list("dough" = 1)
 
 /obj/item/reagent_containers/food/snacks/doughslice
 	name = "dough slice"
@@ -127,6 +129,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "doughslice"
 	list_reagents = list("nutriment" = 1)
+	tastes = list("dough" = 1)
 
 
 //////////////////////

--- a/code/modules/food_and_drinks/food/foods/junkfood.dm
+++ b/code/modules/food_and_drinks/food/foods/junkfood.dm
@@ -12,6 +12,7 @@
 	filling_color = "#E8C31E"
 	junkiness = 20
 	list_reagents = list("nutriment" = 1, "sodiumchloride" = 1, "sugar" = 3)
+	tastes = list("crisps" = 1)
 
 /obj/item/reagent_containers/food/snacks/sosjerky
 	name = "Scaredy's Private Reserve Beef Jerky"
@@ -21,6 +22,7 @@
 	filling_color = "#631212"
 	junkiness = 25
 	list_reagents = list("protein" = 1, "sugar" = 3)
+	tastes = list("dried meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/pistachios
 	name = "Pistachios"
@@ -30,6 +32,7 @@
 	filling_color = "#BAD145"
 	junkiness = 20
 	list_reagents = list("plantmatter" = 2, "sodiumchloride" = 1, "sugar" = 4)
+	tastes = list("pistachios" = 1)
 
 /obj/item/reagent_containers/food/snacks/no_raisin
 	name = "4no Raisins"
@@ -39,6 +42,7 @@
 	filling_color = "#343834"
 	junkiness = 25
 	list_reagents = list("plantmatter" = 2, "sugar" = 4)
+	tastes = list("dried raisins" = 1)
 
 /obj/item/reagent_containers/food/snacks/spacetwinkie
 	name = "Space Twinkie"
@@ -56,6 +60,7 @@
 	filling_color = "#FFA305"
 	junkiness = 25
 	list_reagents = list("nutriment" = 1, "fake_cheese" = 2, "sugar" = 3)
+	tastes = list("cheese?" = 3, "crisps" = 2)
 
 /obj/item/reagent_containers/food/snacks/syndicake
 	name = "Syndi-Cakes"
@@ -65,6 +70,7 @@
 	trash = /obj/item/trash/syndi_cakes
 	bitesize = 3
 	list_reagents = list("nutriment" = 4, "salglu_solution" = 5)
+	tastes = list("sweetness" = 3, "cake" = 1)
 
 /obj/item/reagent_containers/food/snacks/tastybread
 	name = "bread tube"
@@ -74,6 +80,7 @@
 	filling_color = "#A66829"
 	junkiness = 20
 	list_reagents = list("nutriment" = 2, "sugar" = 4)
+	tastes = list("bread" = 1)
 
 
 //////////////////////

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -11,6 +11,7 @@
 	filling_color = "#FF1C1C"
 	bitesize = 3
 	list_reagents = list("protein" = 3)
+	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/meat/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/kitchen/knife) || istype(W, /obj/item/scalpel))
@@ -30,6 +31,7 @@
 	name = "-meat"
 	var/subjectname = ""
 	var/subjectjob = null
+	tastes = list("tender meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/meat/slab/meatproduct
 	name = "meat product"
@@ -41,6 +43,7 @@
 /obj/item/reagent_containers/food/snacks/meat/corgi
 	name = "Corgi meat"
 	desc = "Tastes like... well you know..."
+	tastes = list("meat" = 4, "a fondness for wearing hats" = 1)
 
 /obj/item/reagent_containers/food/snacks/meat/pug
 	name = "Pug meat"
@@ -66,6 +69,7 @@
 	icon_state = "rawcutlet"
 	bitesize = 1
 	list_reagents = list("protein" = 1)
+	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/rawcutlet/attackby(obj/item/W, mob/user, params)
 	if(istype(W,/obj/item/kitchen/knife))
@@ -83,6 +87,7 @@
 	filling_color = "#DB0000"
 	bitesize = 3
 	list_reagents = list("protein" = 12, "morphine" = 5, "vitamin" = 2)
+	tastes = list("meat" = 1, "salmon" = 1)
 
 /obj/item/reagent_containers/food/snacks/xenomeat
 	name = "meat"
@@ -91,6 +96,7 @@
 	filling_color = "#43DE18"
 	bitesize = 6
 	list_reagents = list("protein" = 3, "vitamin" = 1)
+	tastes = list("meat" = 1, "acid" = 1)
 
 /obj/item/reagent_containers/food/snacks/spidermeat
 	name = "spider meat"
@@ -98,6 +104,7 @@
 	icon_state = "spidermeat"
 	bitesize = 3
 	list_reagents = list("protein" = 3, "toxin" = 3, "vitamin" = 1)
+	tastes = list("cobwebs" = 1)
 
 /obj/item/reagent_containers/food/snacks/lizardmeat
 	name = "mutant lizard meat"
@@ -118,6 +125,7 @@
 	desc = "It's fleshy and pink!"
 	icon_state = "raw_bacon"
 	list_reagents = list("nutriment" = 1, "porktonium" = 10)
+	tastes = list("bacon" = 1)
 
 /obj/item/reagent_containers/food/snacks/spidereggs
 	name = "spider eggs"
@@ -137,12 +145,14 @@
 	filling_color = "#7A3D11"
 	bitesize = 3
 	list_reagents = list("nutriment" = 5)
+	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/bacon
 	name = "bacon"
 	desc = "It looks juicy and tastes amazing!"
 	icon_state = "bacon2"
 	list_reagents = list("nutriment" = 4, "porktonium" = 10, "msg" = 4)
+	tastes = list("bacon" = 1)
 
 /obj/item/reagent_containers/food/snacks/telebacon
 	name = "Tele Bacon"
@@ -180,6 +190,7 @@
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "cutlet"
 	list_reagents = list("protein" = 2)
+	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/spidereggsham
 	name = "green eggs and ham"

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -119,6 +119,7 @@
 	desc = "A still twitching leg of a giant spider... you don't really want to eat this, do you?"
 	icon_state = "spiderleg"
 	list_reagents = list("protein" = 2, "toxin" = 2)
+	tastes = list("cobwebs" = 1)
 
 /obj/item/reagent_containers/food/snacks/raw_bacon
 	name = "raw bacon"
@@ -132,6 +133,7 @@
 	desc = "A cluster of juicy spider eggs. A great side dish for when you care not for your health."
 	icon_state = "spidereggs"
 	list_reagents = list("protein" = 2, "toxin" = 2)
+	tastes = list("cobwebs" = 1)
 
 //////////////////////
 //	Cooked Meat		//
@@ -183,6 +185,7 @@
 	icon_state = "sausage"
 	filling_color = "#DB0000"
 	list_reagents = list("protein" = 6, "vitamin" = 1, "porktonium" = 10)
+	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/cutlet
 	name = "cutlet"
@@ -199,6 +202,7 @@
 	trash = /obj/item/trash/plate
 	bitesize = 4
 	list_reagents = list("nutriment" = 6)
+	tastes = list("meat" = 1, "the colour green" = 1)
 
 /obj/item/reagent_containers/food/snacks/boiledspiderleg
 	name = "boiled spider leg"
@@ -207,6 +211,7 @@
 	trash = /obj/item/trash/plate
 	bitesize = 3
 	list_reagents = list("nutriment" = 3, "capsaicin" = 2)
+	tastes = list("hot peppers" = 1, "cobwebs" = 1)
 
 /obj/item/reagent_containers/food/snacks/wingfangchu
 	name = "Wing Fang Chu"
@@ -215,6 +220,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#43DE18"
 	list_reagents = list("nutriment" = 6, "soysauce" = 5, "vitamin" = 2)
+	tastes = list("soy" = 1)
 
 
 //////////////////////
@@ -229,6 +235,7 @@
 	filling_color = "#ADAC7F"
 	var/datum/species/monkey_type = /datum/species/monkey
 	list_reagents = list("nutriment" = 2)
+	tastes = list("the jungle" = 1, "bananas" = 1)
 
 /obj/item/reagent_containers/food/snacks/monkeycube/water_act(volume, temperature)
 	if(volume >= 5)
@@ -279,6 +286,7 @@
 	icon_state = "egg"
 	filling_color = "#FDFFD1"
 	list_reagents = list("protein" = 1, "egg" = 5)
+	tastes = list("egg" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/throw_impact(atom/hit_atom)
 	..()
@@ -306,34 +314,42 @@
 /obj/item/reagent_containers/food/snacks/egg/blue
 	icon_state = "egg-blue"
 	item_color = "blue"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/green
 	icon_state = "egg-green"
 	item_color = "green"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/mime
 	icon_state = "egg-mime"
 	item_color = "mime"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/orange
 	icon_state = "egg-orange"
 	item_color = "orange"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/purple
 	icon_state = "egg-purple"
 	item_color = "purple"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/rainbow
 	icon_state = "egg-rainbow"
 	item_color = "rainbow"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/red
 	icon_state = "egg-red"
 	item_color = "red"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/yellow
 	icon_state = "egg-yellow"
 	item_color = "yellow"
+	tastes = list("egg" = 4, "the back of class" = 1)
 
 /obj/item/reagent_containers/food/snacks/egg/gland
 	desc = "An egg! It looks weird..."
@@ -352,6 +368,7 @@
 	filling_color = "#FFDF78"
 	bitesize = 1
 	list_reagents = list("nutriment" = 3, "egg" = 5)
+	tastes = list("egg" = 4, "salt" = 1, "pepper" = 1)
 
 /obj/item/reagent_containers/food/snacks/boiledegg
 	name = "Boiled egg"
@@ -359,6 +376,7 @@
 	icon_state = "egg"
 	filling_color = "#FFFFFF"
 	list_reagents = list("nutriment" = 2, "egg" = 5, "vitamin" = 1)
+	tastes = list("egg" = 1)
 
 /obj/item/reagent_containers/food/snacks/chocolateegg
 	name = "Chocolate Egg"
@@ -366,6 +384,7 @@
 	icon_state = "chocolateegg"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 4, "sugar" = 2, "cocoa" = 2)
+	tastes = list("chocolate" = 4, "sweetness" = 1)
 
 /obj/item/reagent_containers/food/snacks/omelette
 	name = "Omelette Du Fromage"
@@ -375,6 +394,7 @@
 	filling_color = "#FFF9A8"
 	list_reagents = list("nutriment" = 8, "vitamin" = 1)
 	bitesize = 1
+	tastes = list("egg" = 1, "cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/benedict
 	name = "eggs benedict"
@@ -382,6 +402,7 @@
 	icon_state = "benedict"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "egg" = 3, "vitamin" = 4)
+	tastes = list("egg" = 1, "bacon" = 1, "bun" = 1)
 
 
 //////////////////////
@@ -394,6 +415,7 @@
 	icon_state = "hotdog"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "ketchup" = 3, "vitamin" = 3)
+	tastes = list("bun" = 3, "meat" = 2)
 
 /obj/item/reagent_containers/food/snacks/meatbun
 	name = "meat bun"
@@ -401,6 +423,7 @@
 	icon_state = "meatbun"
 	bitesize = 6
 	list_reagents = list("nutriment" = 6, "vitamin" = 2)
+	tastes = list("bun" = 3, "meat" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/turkey
 	name = "Turkey"

--- a/code/modules/food_and_drinks/food/foods/misc.dm
+++ b/code/modules/food_and_drinks/food/foods/misc.dm
@@ -10,6 +10,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#4D2F5E"
 	list_reagents = list("nutriment" = 6, "vitamin" = 2)
+	tastes = list("eggplant" = 3, "cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/soylentgreen
 	name = "Soylent Green"
@@ -18,6 +19,7 @@
 	trash = /obj/item/trash/waffles
 	filling_color = "#B8E6B5"
 	list_reagents = list("nutriment" = 10, "vitamin" = 1)
+	tastes = list("waffles" = 7, "people" = 1)
 
 /obj/item/reagent_containers/food/snacks/soylentviridians
 	name = "Soylent Virdians"
@@ -26,6 +28,7 @@
 	trash = /obj/item/trash/waffles
 	filling_color = "#E6FA61"
 	list_reagents = list("nutriment" = 10, "vitamin" = 1)
+	tastes = list("waffles" = 7, "the colour green" = 1)
 
 /obj/item/reagent_containers/food/snacks/monkeysdelight
 	name = "monkey's Delight"
@@ -65,6 +68,7 @@
 	filling_color = "#468C00"
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "omnizine" = 8, "vitamin" = 6)
+	tastes = list("leaves" = 1)
 
 /obj/item/reagent_containers/food/snacks/herbsalad
 	name = "herb salad"
@@ -74,6 +78,7 @@
 	filling_color = "#76B87F"
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "vitamin" = 2)
+	tastes = list("leaves" = 1, "apple" = 1)
 
 /obj/item/reagent_containers/food/snacks/validsalad
 	name = "valid salad"
@@ -83,6 +88,7 @@
 	filling_color = "#76B87F"
 	bitesize = 3
 	list_reagents = list("nutriment" = 8, "salglu_solution" = 5, "vitamin" = 2)
+	tastes = list("leaves" = 1, "potato" = 1, "meat" = 1, "valids" = 1)
 
 
 //////////////////////
@@ -95,6 +101,7 @@
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
 	list_reagents = list("nutriment" = 4)
+	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
 
 /obj/item/reagent_containers/food/snacks/warmdonkpocket
 	name = "Warm Donk-pocket"
@@ -102,6 +109,7 @@
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
 	list_reagents = list("nutriment" = 4)
+	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)
 
 /obj/item/reagent_containers/food/snacks/warmdonkpocket/Post_Consume(mob/living/M)
 	M.reagents.add_reagent("omnizine", 15)
@@ -150,6 +158,7 @@
 	filling_color = "#FFFAD4"
 	bitesize = 0.1 //this snack is supposed to be eating during looooong time. And this it not dinner food! --rastaf0
 	list_reagents = list("nutriment" = 2)
+	tastes = list("popcorn" = 3, "butter" = 1)
 
 /obj/item/reagent_containers/food/snacks/popcorn/New()
 	..()

--- a/code/modules/food_and_drinks/food/foods/pasta.dm
+++ b/code/modules/food_and_drinks/food/foods/pasta.dm
@@ -10,6 +10,7 @@
 	icon_state = "spaghetti"
 	filling_color = "#EDDD00"
 	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	tastes = list("raw pasta" = 1)
 
 /obj/item/reagent_containers/food/snacks/macaroni
 	name = "Macaroni twists"
@@ -18,6 +19,7 @@
 	icon_state = "macaroni"
 	filling_color = "#EDDD00"
 	list_reagents = list("nutriment" = 1, "vitamin" = 1)
+	tastes = list("raw pasta" = 1)
 
 
 //////////////////////
@@ -32,6 +34,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FCEE81"
 	list_reagents = list("nutriment" = 2, "vitamin" = 1)
+	tastes = list("pasta" = 1)
 
 /obj/item/reagent_containers/food/snacks/pastatomato
 	name = "spaghetti"
@@ -42,6 +45,7 @@
 	filling_color = "#DE4545"
 	bitesize = 4
 	list_reagents = list("nutriment" = 6, "tomatojuice" = 10, "vitamin" = 4)
+	tastes = list("pasta" = 1, "tomato" = 1)
 
 /obj/item/reagent_containers/food/snacks/meatballspaghetti
 	name = "spaghetti & Meatballs"
@@ -51,6 +55,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#DE4545"
 	list_reagents = list("nutriment" = 8, "synaptizine" = 5, "vitamin" = 4)
+	tastes = list("pasta" = 1, "tomato" = 1, "meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/spesslaw
 	name = "Spesslaw"
@@ -59,6 +64,7 @@
 	icon_state = "spesslaw"
 	filling_color = "#DE4545"
 	list_reagents = list("nutriment" = 8, "synaptizine" = 10, "vitamin" = 6)
+	tastes = list("pasta" = 1, "tomato" = 1, "meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/macncheese
 	name = "Macaroni cheese"

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/food/pizza.dmi'
 	slices_num = 6
 	filling_color = "#BAA14C"
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/margherita
 	name = "Margherita"
@@ -22,6 +23,7 @@
 	icon_state = "pizzamargheritaslice"
 	filling_color = "#BAA14C"
 	list_reagents = list("nutriment" = 5)
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/meatpizza
 	name = "Meatpizza"
@@ -29,6 +31,7 @@
 	icon_state = "meatpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/meatpizzaslice
 	list_reagents = list("protein" = 30, "tomatojuice" = 6, "vitamin" = 8)
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/meatpizzaslice
 	name = "Meatpizza slice"
@@ -36,6 +39,7 @@
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "meatpizzaslice"
 	filling_color = "#BAA14C"
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/mushroompizza
 	name = "Mushroompizza"
@@ -43,6 +47,7 @@
 	icon_state = "mushroompizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/mushroompizzaslice
 	list_reagents = list("plantmatter" = 30, "vitamin" = 5)
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/mushroompizzaslice
 	name = "Mushroompizza slice"
@@ -50,6 +55,7 @@
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "mushroompizzaslice"
 	filling_color = "#BAA14C"
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza
 	name = "Vegetable pizza"
@@ -57,6 +63,7 @@
 	icon_state = "vegetablepizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/vegetablepizzaslice
 	list_reagents = list("plantmatter" = 25, "tomatojuice" = 6, "oculine" = 12, "vitamin" = 5)
+	tastes = list("crust" = 1, "tomato" = 2, "cheese" = 1, "carrot" = 1)
 
 /obj/item/reagent_containers/food/snacks/vegetablepizzaslice
 	name = "Vegetable pizza slice"
@@ -64,6 +71,7 @@
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "vegetablepizzaslice"
 	filling_color = "#BAA14C"
+	tastes = list("crust" = 1, "tomato" = 2, "cheese" = 1, "carrot" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/hawaiianpizza
 	name = "Hawaiian Pizza"

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -161,6 +161,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	tastes = list("meat" = 2, "cheese" = 1, "bread" = 2, "lettuce" = 1)
 
 /obj/item/reagent_containers/food/snacks/toastedsandwich
 	name = "Toasted Sandwich"
@@ -169,6 +170,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	list_reagents = list("nutriment" = 6, "carbon" = 2)
+	tastes = list("toast" = 1)
 
 /obj/item/reagent_containers/food/snacks/grilledcheese
 	name = "Grilled Cheese Sandwich"
@@ -177,6 +179,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	list_reagents = list("nutriment" = 7, "vitamin" = 1) //why make a regualr sandwhich when you can make grilled cheese, with this nutriment value?
+	tastes = list("toast" = 1, "cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/jellysandwich
 	name = "Jelly Sandwich"
@@ -185,6 +188,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#9E3A78"
 	bitesize = 3
+	tastes = list("bread" = 1, "jelly" = 1)
 
 /obj/item/reagent_containers/food/snacks/jellysandwich/slime
 	list_reagents = list("nutriment" = 2, "slimejelly" = 5, "vitamin" = 2)
@@ -197,9 +201,11 @@
 	desc = "Something seems to be wrong with this, you can't quite figure what. Maybe it's his moustache."
 	icon_state = "notasandwich"
 	list_reagents = list("nutriment" = 6, "vitamin" = 6)
+	tastes = list("nothing suspicious" = 1)
 
 /obj/item/reagent_containers/food/snacks/wrap
 	name = "egg wrap"
 	desc = "The precursor to Pigs in a Blanket."
 	icon_state = "wrap"
 	list_reagents = list("nutriment" = 5)
+	tastes = list("egg" = 1)

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -10,6 +10,7 @@
 	filling_color = "#F2B6EA"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "prions" = 10, "vitamin" = 1)
+	tastes = list("bun" = 4, "brains" = 2)
 
 /obj/item/reagent_containers/food/snacks/ghostburger
 	name = "Ghost Burger"
@@ -18,6 +19,7 @@
 	filling_color = "#FFF2FF"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	tastes = list("bun" = 4, "ectoplasm" = 2)
 
 /obj/item/reagent_containers/food/snacks/human
 	var/hname = ""
@@ -53,6 +55,7 @@
 	filling_color = "#FFFEE0"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	tastes = list("bun" = 4, "tofu" = 4)
 
 /obj/item/reagent_containers/food/snacks/roburger
 	name = "roburger"
@@ -61,6 +64,7 @@
 	filling_color = "#CCCCCC"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "nanomachines" = 10, "vitamin" = 1)
+	tastes = list("bun" = 4, "lettuce" = 2, "sludge" = 1)
 
 /obj/item/reagent_containers/food/snacks/roburgerbig
 	name = "roburger"
@@ -70,6 +74,7 @@
 	volume = 120
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "nanomachines" = 70, "vitamin" = 5)
+	tastes = list("bun" = 4, "lettuce" = 2, "sludge" = 1)
 
 /obj/item/reagent_containers/food/snacks/xenoburger
 	name = "xenoburger"
@@ -78,6 +83,7 @@
 	filling_color = "#43DE18"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	tastes = list("bun" = 4, "acid" = 4)
 
 /obj/item/reagent_containers/food/snacks/clownburger
 	name = "Clown Burger"
@@ -110,6 +116,7 @@
 	filling_color = "#D505FF"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	tastes = list("bun" = 4, "magic" = 2)
 
 /obj/item/reagent_containers/food/snacks/bigbiteburger
 	name = "Big Bite Burger"
@@ -126,6 +133,7 @@
 	filling_color = "#CCA26A"
 	bitesize = 7
 	list_reagents = list("nutriment" = 40, "vitamin" = 5)
+	tastes = list("bun" = 4, "type two diabetes" = 10)
 
 /obj/item/reagent_containers/food/snacks/jellyburger
 	name = "Jelly Burger"
@@ -133,6 +141,7 @@
 	icon_state = "jellyburger"
 	filling_color = "#B572AB"
 	bitesize = 3
+	tastes = list("bun" = 4, "jelly" = 2)
 
 /obj/item/reagent_containers/food/snacks/jellyburger/slime
 	list_reagents = list("nutriment" = 6, "slimejelly" = 5, "vitamin" = 1)

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -53,6 +53,7 @@
 	filling_color = "#FFDEFE"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
+	tastes = list("bun" = 4, "fish" = 4)
 
 /obj/item/reagent_containers/food/snacks/cubancarp
 	name = "Cuban Carp"

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -7,6 +7,7 @@
 	filling_color = "#FFDEFE"
 	bitesize = 6
 	list_reagents = list("protein" = 3, "carpotoxin" = 2, "vitamin" = 2)
+	tastes = list("fish" = 1)
 
 /obj/item/reagent_containers/food/snacks/salmonmeat
 	name = "raw salmon"
@@ -44,6 +45,7 @@
 	filling_color = "#FFDEFE"
 	bitesize = 1
 	list_reagents = list("nutriment" = 4)
+	tastes = list("fish" = 1, "breadcrumbs" = 1)
 
 /obj/item/reagent_containers/food/snacks/fishburger
 	name = "Fillet -o- Carp Sandwich"
@@ -64,6 +66,7 @@
 	filling_color = "#E9ADFF"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "capsaicin" = 1)
+	tastes = list("fish" = 4, "batter" = 1, "hot peppers" = 1)
 
 /obj/item/reagent_containers/food/snacks/fishandchips
 	name = "Fish and Chips"
@@ -73,6 +76,7 @@
 	filling_color = "#E3D796"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6)
+	tastes = list("fish" = 1, "chips" = 1)
 
 /obj/item/reagent_containers/food/snacks/sashimi
 	name = "carp sashimi"
@@ -81,6 +85,7 @@
 	icon_state = "sashimi"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "capsaicin" = 5)
+	tastes = list("fish" = 1, "hot peppers" = 1)
 
 /obj/item/reagent_containers/food/snacks/fried_shrimp
 	name = "fried shrimp"

--- a/code/modules/food_and_drinks/food/foods/side_dishes.dm
+++ b/code/modules/food_and_drinks/food/foods/side_dishes.dm
@@ -22,6 +22,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
 	list_reagents = list("nutriment" = 4)
+	tastes = list("fries" = 3, "salt" = 1)
 
 /obj/item/reagent_containers/food/snacks/cheesyfries
 	name = "cheesy fries"
@@ -30,6 +31,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#EDDD00"
 	list_reagents = list("nutriment" = 6)
+	tastes = list("fries" = 3, "cheese" = 1)
 
 /obj/item/reagent_containers/food/snacks/tatortot
 	name = "tator tot"
@@ -37,6 +39,7 @@
 	icon_state = "tatortot"
 	list_reagents = list("nutriment" = 4)
 	filling_color = "FFD700"
+	tastes = list("potato" = 3, "valids" = 1)
 
 /obj/item/reagent_containers/food/snacks/onionrings
 	name = "onion rings"
@@ -53,6 +56,7 @@
 	trash = /obj/item/trash/plate
 	filling_color = "#FAA005"
 	list_reagents = list("plantmatter" = 3, "oculine" = 3, "vitamin" = 2)
+	tastes = list("carrots" = 3, "salt" = 1)
 
 
 //////////////////////
@@ -64,6 +68,7 @@
 	desc = "Musical fruit in a slightly less musical container."
 	icon_state = "beans"
 	list_reagents = list("nutriment" = 10, "beans" = 10, "vitamin" = 3)
+	tastes = list("beans" = 1)
 
 /obj/item/reagent_containers/food/snacks/mashed_potatoes //mashed taters
 	name = "mashed potatoes"
@@ -86,6 +91,7 @@
 	icon_state = "loadedbakedpotato"
 	filling_color = "#9C7A68"
 	list_reagents = list("nutriment" = 6)
+	tastes = list("potato" = 1)
 
 /obj/item/reagent_containers/food/snacks/boiledrice
 	name = "Boiled Rice"
@@ -94,6 +100,7 @@
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#FFFBDB"
 	list_reagents = list("nutriment" = 5, "vitamin" = 1)
+	tastes = list("rice" = 1)
 
 
 /obj/item/reagent_containers/food/snacks/roastparsnip
@@ -103,3 +110,4 @@
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 3, "vitamin" = 4)
 	filling_color = "#FF5500"
+	tastes = list("parsnip" = 1)

--- a/code/modules/food_and_drinks/food/foods/soups.dm
+++ b/code/modules/food_and_drinks/food/foods/soups.dm
@@ -11,6 +11,7 @@
 	filling_color = "#785210"
 	bitesize = 5
 	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
+	tastes = list("meat" = 1)
 
 /obj/item/reagent_containers/food/snacks/slimesoup
 	name = "slime soup"
@@ -19,6 +20,7 @@
 	filling_color = "#C4DBA0"
 	bitesize = 5
 	list_reagents = list("nutriment" = 5, "slimejelly" = 5, "water" = 5, "vitamin" = 4)
+	tastes = list("slime" = 1)
 
 /obj/item/reagent_containers/food/snacks/bloodsoup
 	name = "Tomato soup"
@@ -27,6 +29,7 @@
 	filling_color = "#FF0000"
 	bitesize = 5
 	list_reagents = list("nutriment" = 2, "blood" = 10, "water" = 5, "vitamin" = 4)
+	tastes = list("iron" = 1)
 
 /obj/item/reagent_containers/food/snacks/clownstears
 	name = "Clown's Tears"
@@ -35,6 +38,7 @@
 	filling_color = "#C4FBFF"
 	bitesize = 5
 	list_reagents = list("nutriment" = 4, "banana" = 5, "water" = 5, "vitamin" = 8)
+	tastes = list("a bad joke" = 1)
 
 /obj/item/reagent_containers/food/snacks/vegetablesoup
 	name = "Vegetable soup"
@@ -44,6 +48,7 @@
 	filling_color = "#AFC4B5"
 	bitesize = 5
 	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
+	tastes = list("vegetables" = 1)
 
 /obj/item/reagent_containers/food/snacks/nettlesoup
 	name = "Nettle soup"
@@ -53,6 +58,7 @@
 	filling_color = "#AFC4B5"
 	bitesize = 5
 	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
+	tastes = list("nettles" = 1)
 
 /obj/item/reagent_containers/food/snacks/mysterysoup
 	name = "mystery soup"
@@ -61,6 +67,7 @@
 	var/extra_reagent = null
 	bitesize = 5
 	list_reagents = list("nutriment" = 6)
+	tastes = list("chaos" = 1)
 
 /obj/item/reagent_containers/food/snacks/mysterysoup/New()
 	..()
@@ -75,6 +82,7 @@
 	filling_color = "#D1F4FF"
 	bitesize = 5
 	list_reagents = list("water" = 10)
+	tastes = list("wishes" = 1)
 
 /obj/item/reagent_containers/food/snacks/wishsoup/New()
 	..()
@@ -91,6 +99,7 @@
 	filling_color = "#D92929"
 	bitesize = 5
 	list_reagents = list("nutriment" = 5, "tomatojuice" = 10, "vitamin" = 3)
+	tastes = list("tomato" = 1)
 
 /obj/item/reagent_containers/food/snacks/milosoup
 	name = "Milosoup"
@@ -99,6 +108,7 @@
 	trash = /obj/item/trash/snack_bowl
 	bitesize = 5
 	list_reagents = list("nutriment" = 7, "vitamin" = 2)
+	tastes = list("milo" = 1) //purposeful misspelling of miso I guess?
 
 /obj/item/reagent_containers/food/snacks/mushroomsoup
 	name = "chantrelle soup"
@@ -108,6 +118,7 @@
 	filling_color = "#E386BF"
 	bitesize = 5
 	list_reagents = list("nutriment" = 8, "vitamin" = 4)
+	tastes = list("mushroom" = 1)
 
 /obj/item/reagent_containers/food/snacks/beetsoup
 	name = "beet soup"
@@ -121,6 +132,7 @@
 /obj/item/reagent_containers/food/snacks/beetsoup/New()
 	..()
 	name = pick("borsch","bortsch","borstch","borsh","borshch","borscht")
+	tastes = list(name = 1)
 
 
 //////////////////////
@@ -134,6 +146,7 @@
 	filling_color = "#9E673A"
 	bitesize = 7
 	list_reagents = list("nutriment" = 10, "oculine" = 5, "tomatojuice" = 5, "vitamin" = 5)
+	tastes = list("tomato" = 1, "carrot" = 1)
 
 /obj/item/reagent_containers/food/snacks/stewedsoymeat
 	name = "Stewed Soy Meat"
@@ -141,6 +154,7 @@
 	icon_state = "stewedsoymeat"
 	trash = /obj/item/trash/plate
 	list_reagents = list("nutriment" = 8)
+	tastes = list("soy" = 1, "vegetables" = 1)
 
 
 //////////////////////
@@ -155,6 +169,7 @@
 	filling_color = "#FF3C00"
 	bitesize = 5
 	list_reagents = list("nutriment" = 5, "capsaicin" = 1, "tomatojuice" = 2, "vitamin" = 2)
+	tastes = list("hot peppers" = 1)
 
 /obj/item/reagent_containers/food/snacks/coldchili
 	name = "Cold Chili"
@@ -164,3 +179,4 @@
 	trash = /obj/item/trash/snack_bowl
 	bitesize = 5
 	list_reagents = list("nutriment" = 5, "frostoil" = 1, "tomatojuice" = 2, "vitamin" = 2)
+	tastes = list("tomato" = 1, "mint" = 1)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -16,9 +16,22 @@
 	var/cooktype[0]
 	var/cooked_type = null  //for microwave cooking. path of the resulting item after microwaving
 	var/total_w_class = 0 //for the total weight an item of food can carry
+	var/list/tastes  // for example list("crisps" = 2, "salt" = 1)
 
+/obj/item/reagent_containers/food/snacks/add_initial_reagents()
+	if(!list_reagents)
+		return
+	if(!tastes || !tastes.len)
+		return ..()
+	var/list/nutritious_reagents = list("nutriment", "protein", "plantmatter")
+	for(var/reagent_id in list_reagents)
+		var/amount = list_reagents[reagent_id]
+		if(reagent_id in nutritious_reagents)
+			reagents.add_reagent(reagent_id, amount, tastes.Copy())
+		else
+			reagents.add_reagent(reagent_id, amount)
 
-	//Placeholder for effect that trigger on eating that aren't tied to reagents.
+//Placeholder for effect that trigger on eating that aren't tied to reagents.
 /obj/item/reagent_containers/food/snacks/proc/On_Consume(mob/M, mob/user)
 	if(!user)
 		return
@@ -153,11 +166,13 @@
 				C.adjustFireLoss(-5)
 				qdel(src)
 				G.last_eaten = world.time
+				G.taste(reagents)
 			else
 				M.visible_message("[M] takes a bite of [src].","<span class='notice'>You take a bite of [src].</span>")
 				playsound(loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 				bitecount++
 				G.last_eaten = world.time
+				G.taste(reagents)
 		else if(ismouse(M))
 			var/mob/living/simple_animal/mouse/N = M
 			to_chat(N, text("<span class='notice'>You nibble away at [src].</span>"))
@@ -166,6 +181,7 @@
 			//N.emote("nibbles away at the [src]")
 			N.adjustBruteLoss(-1)
 			N.adjustFireLoss(-1)
+			N.taste(reagents)
 
 /obj/item/reagent_containers/food/snacks/sliceable/examine(mob/user)
 	. = ..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -160,15 +160,23 @@
 	return result
 
 
-/obj/item/seeds/proc/prepare_result(var/obj/item/reagent_containers/food/snacks/grown/T)
-	if(T.reagents)
-		for(var/reagent_id in reagents_add)
-			if(reagent_id == "blood") // Hack to make blood in plants always O-
-				T.reagents.add_reagent(reagent_id, 1 + round(potency * reagents_add[reagent_id], 1), list("blood_type"="O-"))
-				continue
+/obj/item/seeds/proc/prepare_result(var/obj/item/T)
+	if(!T.reagents)
+		CRASH("[T] has no reagents.")
+	for(var/reagent_id in reagents_add)
+		var/amount = 1 + round(potency * reagents_add[reagent_id], 1)
+		var/list/data = null
+		if(reagent_id == "blood") // Hack to make blood in plants always O-
+			data = list("blood_type"="O-")
+			continue
+		var/list/nutritious_reagents = list("nutriment", "protein", "plantmatter")
+		if(reagent_id in nutritious_reagents)
+			if(istype(T, /obj/item/reagent_containers/food/snacks/grown))
+				var/obj/item/reagent_containers/food/snacks/grown/grown_edible = T
+				data = grown_edible.tastes
 
-			T.reagents.add_reagent(reagent_id, 1 + round(potency * reagents_add[reagent_id]), 1)
-		return 1
+		T.reagents.add_reagent(reagent_id, amount, data)
+	return 1
 
 
 /// Setters procs ///

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1037,8 +1037,8 @@ so that different stomachs can handle things in different ways VB*/
 	if(toEat.consume_sound)
 		playsound(loc, toEat.consume_sound, rand(10,50), 1)
 	if(toEat.reagents.total_volume)
-		//if(can_taste_container)
-			//TODO: taste here, use reagents.reagent_list
+		if(can_taste_container)
+			taste(toEat.reagents)
 		var/fraction = min(this_bite/toEat.reagents.total_volume, 1)
 		toEat.reagents.reaction(src, toEat.apply_type, fraction)
 		toEat.reagents.trans_to(src, this_bite*toEat.transfer_efficiency)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -977,7 +977,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 	else
 		if(!forceFed(toEat, user, fullness))
 			return 0
-	consume(toEat, bitesize_override, taste = toEat.taste)
+	consume(toEat, bitesize_override, can_taste_container = toEat.can_taste)
 	score_foodeaten++
 	return 1
 
@@ -1028,7 +1028,7 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 
 /*TO DO - If/when stomach organs are introduced, override this at the human level sending the item to the stomach
 so that different stomachs can handle things in different ways VB*/
-/mob/living/carbon/proc/consume(var/obj/item/reagent_containers/food/toEat, var/bitesize_override, var/taste = TRUE)
+/mob/living/carbon/proc/consume(var/obj/item/reagent_containers/food/toEat, var/bitesize_override, var/can_taste_container = TRUE)
 	var/this_bite = bitesize_override ? bitesize_override : toEat.bitesize
 	if(!toEat.reagents)
 		return
@@ -1037,8 +1037,8 @@ so that different stomachs can handle things in different ways VB*/
 	if(toEat.consume_sound)
 		playsound(loc, toEat.consume_sound, rand(10,50), 1)
 	if(toEat.reagents.total_volume)
-		if(taste)
-			taste_reagents(toEat.reagents)
+		//if(can_taste_container)
+			//TODO: taste here, use reagents.reagent_list
 		var/fraction = min(this_bite/toEat.reagents.total_volume, 1)
 		toEat.reagents.reaction(src, toEat.apply_type, fraction)
 		toEat.reagents.trans_to(src, this_bite*toEat.transfer_efficiency)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1933,12 +1933,6 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	.["Make superhero"] = "?_src_=vars;makesuper=[UID()]"
 	. += "---"
 
-/mob/living/carbon/human/get_taste_sensitivity()
-	if(dna.species)
-		return dna.species.taste_sensitivity
-	else
-		return TASTE_SENSITIVITY_NORMAL
-
 /mob/living/carbon/human/proc/special_post_clone_handling()
 	if(mind && mind.assigned_role == "Cluwne") //HUNKE your suffering never stops
 		makeCluwne()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1937,7 +1937,7 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 	if(dna.species)
 		return dna.species.taste_sensitivity
 	else
-		return 1
+		return TASTE_SENSITIVITY_NORMAL
 
 /mob/living/carbon/human/proc/special_post_clone_handling()
 	if(mind && mind.assigned_role == "Cluwne") //HUNKE your suffering never stops

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -902,6 +902,3 @@
 /mob/living/proc/check_pull()
 	if(pulling && !(pulling in orange(1)))
 		stop_pulling()
-
-/mob/living/proc/get_taste_sensitivity()
-	return TASTE_SENSITIVITY_NORMAL

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -904,39 +904,4 @@
 		stop_pulling()
 
 /mob/living/proc/get_taste_sensitivity()
-	return 1
-
-/mob/living/proc/taste_reagents(datum/reagents/tastes)
-	if(!get_taste_sensitivity())//this also works for IPCs and stuff that returns 0 here
-		return
-
-	var/do_not_taste_at_all = 1//so we don't spam with recent tastes
-
-	var/taste_sum = 0
-	var/list/taste_list = list()//associative list so we can stack stuff that tastes the same
-	var/list/final_taste_list = list()//final list of taste strings
-
-	for(var/datum/reagent/R in tastes.reagent_list)
-		taste_sum += R.volume * R.taste_strength
-		if(!R.taste_message)//set to null; no taste, like water
-			continue
-		taste_list[R.taste_message] += R.volume * R.taste_strength
-
-	for(var/R in taste_list)
-		if(recent_tastes[R] && (world.time - recent_tastes[R] < 12 SECONDS))
-			continue
-
-		do_not_taste_at_all = 0//something was fresh enough to taste; could still be bland enough to be unrecognizable
-
-		if(taste_list[R] / taste_sum >= 0.15 / get_taste_sensitivity())//we return earlier if the proc returns a 0; won't break the universe
-			final_taste_list += R
-			recent_tastes[R] = world.time
-
-	if(do_not_taste_at_all)
-		return //no message spam
-
-	if(final_taste_list.len == 0)//too many reagents - none meet their thresholds
-		to_chat(src, "<span class='notice'>You can't really make out what you're tasting...</span>")
-		return
-
-	to_chat(src, "<span class='notice'>You can taste [english_list(final_taste_list)].</span>")
+	return TASTE_SENSITIVITY_NORMAL

--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -1,0 +1,27 @@
+/mob/living
+	var/last_taste_time
+	var/last_taste_text
+
+/mob/living/proc/get_taste_sensitivity()
+	return TASTE_SENSITIVITY_NORMAL
+
+/mob/living/carbon/get_taste_sensitivity()
+	if(dna.species)
+		return dna.species.taste_sensitivity
+	else
+		return TASTE_SENSITIVITY_NORMAL
+
+/mob/living/proc/taste(datum/reagents/holder)
+	if(last_taste_time + 50 >= world.time) //helps us to not spam the same message too much
+		return
+	var/taste_sensitivity = get_taste_sensitivity()
+	var/text_output = holder.generate_taste_message(taste_sensitivity)
+	if(hallucination > 50 && prob(25))
+		text_output = pick("spiders","dreams","nightmares","the future","the past","victory",\
+		"defeat","pain","bliss","revenge","poison","time","space","death","life","truth","lies","justice","memory",\
+		"regrets","your soul","suffering","music","noise","blood","hunger","the american way")
+	//the cooldown for the same taste is 100 deciseconds, but if the taste message is different there is a minimum wait of 50 deciseconds
+	if(text_output != last_taste_text || (last_taste_time + 100) < world.time) 
+		to_chat(src, "<span class='notice'>You can taste [text_output].</span>")
+		last_taste_time = world.time
+		last_taste_text = text_output

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -727,6 +727,55 @@ var/const/INGEST = 2
 
 	return trans_data
 
+/datum/reagents/proc/generate_taste_message(minimum_percent = TASTE_SENSITIVITY_NORMAL)
+	var/list/out = list()
+	var/list/reagent_tastes = list() //in the form reagent_tastes["descriptor"] = strength
+	//mobs should get this message when either they cannot taste, the tastes are all too weak for them to detect, or the tastes somehow don't have any strength
+	var/no_taste_text = "something indescribable"
+	if(minimum_percent > 100)
+		return no_taste_text
+	for(var/datum/reagent/R in reagent_list)
+		if(!R.taste_strength)
+			continue
+		//nutriment carries a list of tastes that originates from the snack food that the nutriment came from
+		if(istype(R, /datum/reagent/consumable/nutriment)) 
+			var/list/nutriment_taste_data = R.data
+			for(var/nutriment_taste in nutriment_taste_data)
+				var/ratio = nutriment_taste_data[nutriment_taste]
+				var/amount = ratio * R.taste_strength * R.volume
+				if(nutriment_taste in reagent_tastes)
+					reagent_tastes[nutriment_taste] += amount
+				else
+					reagent_tastes[nutriment_taste] = amount
+		else
+			var/taste_desc = R.taste_message
+			var/taste_amount = R.volume * R.taste_strength
+			if(taste_desc in reagent_tastes)
+				reagent_tastes[taste_desc] += taste_amount
+			else
+				reagent_tastes[taste_desc] = taste_amount
+	//deal with percentages
+	//TODO: may want to sort these from strong to weak
+	var/total_taste = counterlist_sum(reagent_tastes)
+	if(total_taste <= 0)
+		return no_taste_text
+	for(var/taste_desc in reagent_tastes)
+		var/percent = (reagent_tastes[taste_desc] / total_taste) * 100
+		if(percent < minimum_percent) //the lower the minimum percent, the more sensitive the message is
+			continue
+		var/intensity_desc = "a hint of"
+		if(percent > minimum_percent * 3 && percent != 100)
+			intensity_desc = "a strong flavor of"
+		else if(percent > minimum_percent * 2 || percent == 100)
+			intensity_desc = ""
+		
+		if(intensity_desc != "")
+			out += "[intensity_desc] [taste_desc]"
+		else
+			out += "[taste_desc]"
+	
+	return english_list(out, no_taste_text)
+
 ///////////////////////////////////////////////////////////////////////////////////
 
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -26,7 +26,7 @@
 	var/drink_icon = null
 	var/drink_name = "Glass of ..what?"
 	var/drink_desc = "You can't really tell what this is."
-	var/taste_strength = 1 //how easy it is to taste - the more the easier
+	var/taste_strength = 1 //How this taste compares to other tastes. Higher value means it is more noticeable.
 	var/taste_message = "bitterness" //life's bitter by default. Cool points for using a span class for when you're tasting <span class='userdanger'>LIQUID FUCKING DEATH</span>
 
 /datum/reagent/Destroy()

--- a/code/modules/reagents/chemistry/reagents/disease.dm
+++ b/code/modules/reagents/chemistry/reagents/disease.dm
@@ -180,6 +180,7 @@
 	id = "plasmavirusfood"
 	description = "mutates blood"
 	color = "#A69DA9" // rgb: 166,157,169
+	taste_strength = 1.5
 
 /datum/reagent/plasma_dust/plasmavirusfood/weak
 	name = "weakened virus plasma"

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -39,6 +39,7 @@
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 	taste_message = null
+	taste_strength = 0
 
 /datum/reagent/nitrogen
 	name = "Nitrogen"
@@ -47,6 +48,7 @@
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 	taste_message = null
+	taste_strength = 0
 
 /datum/reagent/hydrogen
 	name = "Hydrogen"
@@ -55,6 +57,7 @@
 	reagent_state = GAS
 	color = "#808080" // rgb: 128, 128, 128
 	taste_message = null
+	taste_strength = 0
 
 /datum/reagent/potassium
 	name = "Potassium"

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -22,6 +22,7 @@
 	reagent_state = LIQUID
 	color = "#7A2B94"
 	taste_message = "corporate assets going to waste"
+	taste_strength = 1.5
 
 /datum/reagent/plasma/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -289,6 +290,7 @@
 	description = "A fine dust of plasma. This chemical has unusual mutagenic properties for viruses and slimes alike."
 	color = "#500064" // rgb: 80, 0, 100
 	taste_message = "corporate assets going to waste"
+	taste_strength = 1.5
 
 /datum/reagent/plasma_dust/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -4,7 +4,7 @@
 	description = "A Toxic chemical."
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
-	taste_mult = 1.2
+	taste_strength = 1.2
 
 /datum/reagent/toxin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -43,7 +43,7 @@
 	reagent_state = LIQUID
 	color = "#801E28" // rgb: 128, 30, 40
 	taste_message = "slimes"
-	taste_mult = 1.3
+	taste_strength = 1.3
 
 /datum/reagent/slimejelly/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -96,7 +96,7 @@
 	metabolization_rate = 0.2
 	penetrates_skin = TRUE
 	taste_message = "metal"
-	taste_mult = 0 //elemental mercury is tasteless
+	taste_strength = 0 //elemental mercury is tasteless
 
 /datum/reagent/mercury/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -159,7 +159,7 @@
 	reagent_state = LIQUID
 	color = "#04DF27"
 	metabolization_rate = 0.3
-	taste_mult = 0.9
+	taste_strength = 0.9
 
 /datum/reagent/mutagen/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(!..())

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -4,6 +4,7 @@
 	description = "A Toxic chemical."
 	reagent_state = LIQUID
 	color = "#CF3600" // rgb: 207, 54, 0
+	taste_mult = 1.2
 
 /datum/reagent/toxin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -42,6 +43,7 @@
 	reagent_state = LIQUID
 	color = "#801E28" // rgb: 128, 30, 40
 	taste_message = "slimes"
+	taste_mult = 1.3
 
 /datum/reagent/slimejelly/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -94,6 +96,7 @@
 	metabolization_rate = 0.2
 	penetrates_skin = TRUE
 	taste_message = "metal"
+	taste_mult = 0 //elemental mercury is tasteless
 
 /datum/reagent/mercury/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -156,6 +159,7 @@
 	reagent_state = LIQUID
 	color = "#04DF27"
 	metabolization_rate = 0.3
+	taste_mult = 0.9
 
 /datum/reagent/mutagen/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(!..())
@@ -689,6 +693,7 @@
 	color = "#1E4664"
 	metabolization_rate = 0.2
 	taste_message = null
+	taste_strength = 0
 
 /datum/reagent/pancuronium/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -204,7 +204,7 @@
 	drink_name = "Glass of Tomato juice"
 	drink_desc = "Are you sure this is tomato juice?"
 	taste_message = "<span class='warning'>blood</span>"
-	taste_mult = 1.3
+	taste_strength = 1.3
 
 /datum/reagent/blood/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(data && data["viruses"])

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -204,6 +204,7 @@
 	drink_name = "Glass of Tomato juice"
 	drink_desc = "Are you sure this is tomato juice?"
 	taste_message = "<span class='warning'>blood</span>"
+	taste_mult = 1.3
 
 /datum/reagent/blood/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(data && data["viruses"])

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -34,6 +34,9 @@
 		var/datum/disease/F = new spawned_disease(0)
 		var/list/data = list("viruses" = list(F), "blood_color" = "#A10808")
 		reagents.add_reagent("blood", disease_amount, data)
+	add_initial_reagents()
+
+/obj/item/reagent_containers/proc/add_initial_reagents()
 	if(list_reagents)
 		reagents.add_reagent_list(list_reagents)
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -10,7 +10,7 @@
 	possible_transfer_amounts = null
 	volume = 50
 	consume_sound = null
-	taste = FALSE
+	can_taste = FALSE
 
 /obj/item/reagent_containers/food/pill/New()
 	..()

--- a/paradise.dme
+++ b/paradise.dme
@@ -1639,6 +1639,7 @@
 #include "code\modules\mob\living\say.dm"
 #include "code\modules\mob\living\stat_states.dm"
 #include "code\modules\mob\living\status_procs.dm"
+#include "code\modules\mob\living\taste.dm"
 #include "code\modules\mob\living\update_status.dm"
 #include "code\modules\mob\living\carbon\_defines.dm"
 #include "code\modules\mob\living\carbon\carbon.dm"


### PR DESCRIPTION
This PR replaces the current taste system with /tg/'s. Hopefully I will get this right.
Relevant PRs: 
https://github.com/tgstation/tgstation/pull/24323
https://github.com/tgstation/tgstation/pull/35606

The key differences:
- Flavors can now also come from foods, which are imparted to nutriment. 
- The taste message will now differentiate between strong and weak flavors.
- Hallucinations will cause you to taste some strange things if you try to eat.

**Changelog:**
:cl: Squirgenheimer
add: Nanotrasen denies allegations that widespread dysgeusia was caused by the presence of carcinogenic aerosols in the workplace. Nanotrasen would like to remind you that your well-being is their number one priority.
add: Our taste system has changed! Less bitterness and more flavor!
add: Lots of foods now have their own tastes (as opposed to only having the taste of their reagents). These are carried by nutriment.
add: Corgis and mice can now taste food.
/:cl:

- [x] implement main tasting procs
- [x] implement nutriment taste acquirement
- [x] add tastes for a lot of foods
- [ ] add tastes for botany grown foods
- [x] add taste strengths for a lot of reagents 
- [ ] add taste functionality to fermentation barrels
- [ ] possible tweaks
- [ ] review reagent tastes
- [ ] local testing

Note: 

- Taste sensitivity defines are still tied to species and have the same relative values, but with a base of 15%. In the end I think the math is functionally the same as before, so I might change this back for sake of simplicity and add a define for the base value.
- Currently only mice, corgis, and carbon mobs will ever taste (before it was only carbons)
- Currently vitamin does not absorb taste like nutriment, may have to be made a subtype of it if this functionality is desired