### PR TITLE
Hotfix for discounts - blacklist job gear & add alternate log if discounted

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -159,6 +159,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/jobspecific
 	category = "Job Specific Tools"
+	cant_discount = TRUE
 
 //Clown
 /datum/uplink_item/jobspecific/clowngrenade
@@ -238,7 +239,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	job = list("Chaplain")
 	surplus = 0 //No lucky chances from the crate; if you get this, this is ALL you're getting
 	hijack_only = TRUE //This is a murderbone weapon, as such, it should only be available in those scenarios.
-	cant_discount = TRUE
 
 //Janitor
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -130,7 +130,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 		if(I)
 			if(ishuman(user))
 				var/mob/living/carbon/human/A = user
-				log_game("[key_name(user)] purchased [name]")
+				if(limited_stock > 0)
+					log_game("[key_name(user)] purchased [name]. [name] was discounted to [cost].")
+				else
+					log_game("[key_name(user)] purchased [name].")
 				A.put_in_any_hand_if_possible(I)
 
 				if(istype(I,/obj/item/storage/box/) && I.contents.len>0)


### PR DESCRIPTION
On spartan's request, stops any job items appearing as a discounted item.

**Additional** - Also added an alternate log entry should the item have a limited stock value higher than 0.

**Changelog:**
:cl: Azule Utama
tweak: Job-specific gear can no longer be discounted.
tweak: Discounted items now get an alternate log entry stating the item's new price.
/:cl:

