### PR TITLE
Reduce power beacon cost to 10 and make it hijack only

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1237,8 +1237,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			sends you a small beacon that will teleport the larger beacon to your location upon activation."
 	reference = "SNGB"
 	item = /obj/item/radio/beacon/syndicate
-	cost = 12
+	cost = 10
 	surplus = 0
+	hijack_only = TRUE //This is an item only useful for a hijack traitor, as such, it should only be available in those scenarios.
+	cant_discount = TRUE
 
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb"


### PR DESCRIPTION
Power beacon is an extremely niche item that is useless for any traitor that doesn't have hijack due to server rules.

This PR buffs the item by reducing the cost to 10 TC, and make it hijack only.

🆑
tweak: Power beacon cost reduced to 10 TC, and is now hijack-exclusive.
/🆑