### PR TITLE
Small refactor for coins

### DIFF
--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -18,7 +18,7 @@
 	pixel_x = rand(0,16)-8
 	pixel_y = rand(0,8)-8
 
-	icon_state = "coin_[cmineral]_heads"
+	icon_state = "coin_[cmineral]_[sideslist[1]]"
 	if(cmineral)
 		name = "[cmineral] coin"
 


### PR DESCRIPTION
On creation, coins did get their icon_state set to their "heads" side. This causes them to spawn with no icon, if they don't have a "heads" side, but rather others, like "valid" and "salad" for the antagtoken coin.
:cl:
fix: Coins will now always show a side on being spawned.
/:cl: