### PR TITLE
Make guillotines deconstructable

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -194,6 +194,28 @@
 			return TRUE
 		else
 			current_action = 0
+	if(iswelder(W))
+		var/obj/item/weldingtool/WT = W
+		if(!WT.remove_fuel(0, user))
+			return
+		to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
+		playsound(loc, WT.usesound, 40, 1)
+		if(do_after(user, 150 * WT.toolspeed, 1, target = src))
+			if(!WT.isOn())
+				return
+			playsound(loc, WT.usesound, 50, 1)
+			visible_message("<span class='notice'>[user] slices apart \the [src].</span>",
+							"<span class='notice'>You cut \the [src] apart with \the [WT].</span>",
+							"<span class='italics'>You hear welding.</span>")
+			var/turf/T = get_turf(src)
+			if (blade_sharpness == GUILLOTINE_BLADE_MAX_SHARP)
+				new /obj/item/stack/sheet/plasteel(T, 3)
+			else
+				new /obj/item/stack/sheet/plasteel(T, 2) //prevents reconstructing to sharpen the guillotine without additional plasteel
+			new /obj/item/stack/sheet/wood(T, 20)
+			new /obj/item/stack/cable_coil(T, 10)
+			qdel(src)
+		return
 	else
 		return ..()
 

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -198,17 +198,17 @@
 		var/obj/item/weldingtool/WT = W
 		if(!WT.remove_fuel(0, user))
 			return
-		to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
+		to_chat(user, "<span class='notice'>You begin cutting [src] apart...</span>")
 		playsound(loc, WT.usesound, 40, 1)
 		if(do_after(user, 150 * WT.toolspeed, 1, target = src))
 			if(!WT.isOn())
 				return
 			playsound(loc, WT.usesound, 50, 1)
-			visible_message("<span class='notice'>[user] slices apart \the [src].</span>",
-							"<span class='notice'>You cut \the [src] apart with \the [WT].</span>",
+			visible_message("<span class='notice'>[user] slices apart [src].</span>",
+							"<span class='notice'>You cut [src] apart with [WT].</span>",
 							"<span class='italics'>You hear welding.</span>")
 			var/turf/T = get_turf(src)
-			if (blade_sharpness == GUILLOTINE_BLADE_MAX_SHARP)
+			if(blade_sharpness == GUILLOTINE_BLADE_MAX_SHARP)
 				new /obj/item/stack/sheet/plasteel(T, 3)
 			else
 				new /obj/item/stack/sheet/plasteel(T, 2) //prevents reconstructing to sharpen the guillotine without additional plasteel


### PR DESCRIPTION
Guillotines can now be deconstructed with a welder, taking 15 seconds. 

If the blade isn't fully sharp, it'll only yield 2 plasteel instead of 3.

🆑
add: Guillotines can now be deconstructed with a welder.
/🆑