### PR TITLE
Ghetto IRC Deafness Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -120,6 +120,8 @@
 			continue
 		qdel(E)
 	for(var/obj/item/organ/O in internal_organs)
+		if(istype(O, /obj/item/organ/internal/ears))
+			continue
 		qdel(O)
 	regenerate_icons()
 	death()


### PR DESCRIPTION
**What does this PR do:**
This prevents the ear from being deleted when an IRC is initialized. To be testmerged until a real solution is found (making them not require ear organ).
