### PR TITLE
Fix a couple of finger gun issues

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -92,7 +92,7 @@
 
 /obj/effect/proc_holder/spell/targeted/mime/fingergun
 	name = "Finger Gun"
-	desc = "Shoot stunning, invisible bullets out of your fingers! 6 bullets available per cast."
+	desc = "Shoot stunning, invisible bullets out of your fingers! 6 bullets available per cast. Use your fingers to holster them manually."
 	school = "mime"
 	panel = "Mime"
 	clothes_req = 0
@@ -116,7 +116,7 @@
 			revert_cast(user)
 
 /obj/effect/proc_holder/spell/targeted/mime/fingergun/fake
-	desc = "Pretend you're shooting bullets out of your fingers! 6 bullets available per cast."
+	desc = "Pretend you're shooting bullets out of your fingers! 6 bullets available per cast. Use your fingers to holster them manually."
 	gun = /obj/item/gun/projectile/revolver/fingergun/fake
 
 // Mime Spellbooks
@@ -130,9 +130,11 @@
 
 /obj/item/spellbook/oneuse/mime/attack_self(mob/user)
 	var/obj/effect/proc_holder/spell/S = new spell
-	if(locate(S) in user.mind.spell_list)
-		to_chat(user, "<span class='notice'>You've already read this one.</span>")
-		return
+	for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
+		if(knownspell.type == S.type)
+			if(user.mind)
+				to_chat(user, "<span class='notice'>You've already read this one.</span>")
+			return
 	if(used)
 		recoil(user)
 	else

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -172,7 +172,7 @@
 
 /obj/item/gun/projectile/revolver/fingergun/afterattack(atom/target, mob/living/user, flag, params)
 	if(!user.mind.miming)
-		to_chat(usr, "<span class='warning'>You must dedicate yourself to silence first.</span>")
+		to_chat(usr, "<span class='warning'>You must dedicate yourself to silence first. Use your fingers if you wish to holster them.</span>")
 		return
 	..()
 


### PR DESCRIPTION
Fixes #10346

Adds the fact you can use finger guns in hand to holster them to vow of silence warning and spell description

Fixes a bug where you couldn't learn finger gun if you already knew fake finger gun

🆑
tweak: Updated description of finger gun to point out you can holster the gun manually by using it in hand.
fix: Fixed a bug where you couldn't learn finger gun if you already knew fake finger gun.
/🆑