### PR TITLE
Adds sleeper agents to nukies

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1125,6 +1125,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 7
 	gamemodes = list(/datum/game_mode/nuclear)
 
+	name = "Activate Sleeper Agent"
+	desc = "Activate a syndicate sleeper agent aboard the station, giving him a custom objective to direct him. He starts with an uplink with 10TC and could, if caught, compromise your coms, so buy with care. On the other hand, the potential mayhem he could cause should weaken the station for your attack."
+	reference = "SLEEP_AGENT"
+	item = /obj/item/antag_spawner/sleeper_activator
+	refund_path = /obj/item/antag_spawner/sleeper_activator
+	cost = 35	//not sure on this pricing just yet
+	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
+	refundable = TRUE
+
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
 	category = "Space Suits and Hardsuits"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1125,8 +1125,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 7
 	gamemodes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/device_tools/sleeper_agent
 	name = "Activate Sleeper Agent"
-	desc = "Activate a syndicate sleeper agent aboard the station, giving him a custom objective to direct him. He starts with an uplink with 10TC and could, if caught, compromise your coms, so buy with care. On the other hand, the potential mayhem he could cause should weaken the station for your attack."
+	desc = "Activate a syndicate sleeper agent aboard the station, giving him a custom objective to direct him. He starts with an uplink with 10 telecrystals. The potential mayhem he could cause should weaken the station for your attack."
 	reference = "SLEEP_AGENT"
 	item = /obj/item/antag_spawner/sleeper_activator
 	refund_path = /obj/item/antag_spawner/sleeper_activator

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1134,6 +1134,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 	refundable = TRUE
+	cant_discount = TRUE
 
 //Space Suits and Hardsuits
 /datum/uplink_item/suits

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1130,7 +1130,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "SLEEP_AGENT"
 	item = /obj/item/antag_spawner/sleeper_activator
 	refund_path = /obj/item/antag_spawner/sleeper_activator
-	cost = 35	//not sure on this pricing just yet
+	cost = 40	//not sure on this pricing just yet
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 	refundable = TRUE

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -8,8 +8,8 @@ proc/issyndicate(mob/living/M as mob)
 /datum/game_mode/nuclear
 	name = "nuclear emergency"
 	config_tag = "nuclear"
-	required_players = 1	// 30 players - 5 players to be the nuke ops = 25 players remaining
-	required_enemies = 1	//for debugging/testing. Note to self: change this back later to 30/5
+	required_players = 30	// 30 players - 5 players to be the nuke ops = 25 players remaining
+	required_enemies = 5	
 	recommended_enemies = 5
 
 	var/const/agents_possible = 5 //If we ever need more syndicate agents.

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -217,6 +217,8 @@ proc/issyndicate(mob/living/M as mob)
 
 /datum/game_mode/proc/forge_sleeper_objectives(datum/mind/sleeper_agent, custom_objective)
 	var/datum/objective/nuclear_helper/syndobj = new
+	if(custom_objective == "")	//if people are too lazy to give a customised objective
+		custom_objective = "Follow all orders given by Nuclear Operatives."
 	var/datum/objective/custom_obj = new(custom_objective)
 	custom_obj.owner = sleeper_agent
 	custom_obj.completed = TRUE	//Defaults to completed, admins can toggle this if the sleeper fucks up
@@ -226,7 +228,7 @@ proc/issyndicate(mob/living/M as mob)
 
 /datum/game_mode/proc/greet_sleeper(datum/mind/sleeper_agent)
 	SEND_SOUND(sleeper_agent.current, 'sound/ambience/antag/tatoralert.ogg')
-	to_chat(sleeper_agent.current, "<span class='notice'>You suddenly realize you are a Syndicate sleeper agent that has been activated in a rush. Nuclear operatives are on their way to destroy the station. Aid them in this task and fulfil your objective.</span>")
+	to_chat(sleeper_agent.current, "<span class='notice'>You suddenly realize you are a Syndicate sleeper agent that has been activated in a rush. Nuclear operatives are on their way to destroy the station. Aid them in this task and fulfil your objective. <b> Be aware that they outrank you, their orders are to be followed</b></span>")
 	var/obj_count = 1
 	for(var/datum/objective/objective in sleeper_agent.objectives)
 		to_chat(sleeper_agent.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
@@ -249,6 +251,8 @@ proc/issyndicate(mob/living/M as mob)
 /datum/game_mode/proc/equip_sleeper(mob/living/carbon/human/sleeper_agent)
 	if(!istype(sleeper_agent))
 		return
+	update_synd_icons_added(sleeper_agent.mind)
+
 	if(sleeper_agent.mind)
 		if(sleeper_agent.mind.assigned_role == "Clown")
 			to_chat(sleeper_agent, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
@@ -436,7 +440,7 @@ proc/issyndicate(mob/living/M as mob)
 
 		if(length(sleeper_agents))
 			text += "<br>"
-			text += "The Syndicate Sleeper Agents were:"
+			text += "<br><FONT size=3><B>The Syndicate Sleeper Agents were:</B></FONT>"
 			for(var/datum/mind/sleeper in sleeper_agents)
 				text += "<br><b>[sleeper.key]</b> was <b>[sleeper.name]</b> ("
 				if(sleeper.current)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -228,7 +228,7 @@ proc/issyndicate(mob/living/M as mob)
 
 /datum/game_mode/proc/greet_sleeper(datum/mind/sleeper_agent)
 	SEND_SOUND(sleeper_agent.current, 'sound/ambience/antag/tatoralert.ogg')
-	to_chat(sleeper_agent.current, "<span class='notice'>You suddenly realize you are a Syndicate sleeper agent that has been activated in a rush. Nuclear operatives are on their way to destroy the station. Aid them in this task and fulfil your objective. <b>Be aware that they outrank you, their orders are to be followed</b></span>")
+	to_chat(sleeper_agent.current, "<span class='notice'>You suddenly realize you are a Syndicate sleeper agent that has been activated in a rush. Nuclear operatives are on their way to destroy the station. Aid them in this task and fulfil your objective. <b>Be aware that they outrank you, their orders are to be followed.</b></span>")
 	var/obj_count = 1
 	for(var/datum/objective/objective in sleeper_agent.objectives)
 		to_chat(sleeper_agent.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -329,6 +329,10 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 	explanation_text = "Destroy the station with a nuclear device."
 	martyr_compatible = 1
 
+/datum/objective/nuclear_helper
+	explanation_text = "Aid in the destruction of the station with a nuclear device."
+	martyr_compatible = TRUE
+
 /datum/objective/steal
 	var/datum/theft_objective/steal_target
 	martyr_compatible = 0

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -426,6 +426,15 @@
 					dat += check_antagonists_line(M)
 				else
 					dat += "<tr><td><i>Nuclear Operative not found!</i></td></tr>"
+			dat += "</table><br><table cellspacing=5><tr><td><B>Sleeper Agents</B></td><td></td></tr>"
+			for(var/datum/mind/N in ticker.mode.sleeper_agents)
+				var/mob/M = N.current
+				if(M)
+					dat += check_antagonists_line(M)
+				else
+					dat += "<tr><td><i>Sleeper Agent not found!</i></td></tr>"
+			
+			
 			dat += "</table><br><table><tr><td><B>Nuclear Disk(s)</B></td></tr>"
 			for(var/obj/item/disk/nuclear/N in GLOB.poi_list)
 				dat += "<tr><td>[N.name], "

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -29,8 +29,8 @@
 	if(checking)
 		to_chat(user, "<span class='warning'>[src] is already checking for sleeper agents to activate!</span>")
 		return
-	desired_objective = stripped_input(user, "What objective do you wish to give the sleeper agent?", "Objective")
 	checking = TRUE
+	desired_objective = stripped_input(user, "What objective do you wish to give the sleeper agent?", "Objective")
 	used = TRUE
 	to_chat(user, "<span class='notice'>Activating sleeper agent, stand by.</span>")
 	var/list/agent_candidates = get_candidate_list()

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -10,6 +10,66 @@
 /obj/item/antag_spawner/proc/equip_antag(mob/target)
 	return
 
+//sleeper agents for nuke ops
+/obj/item/antag_spawner/sleeper_activator
+	name = "sleeper agent activation remote"
+	desc = "A remote used to activate a deep cover sleeper agent aboard the Cyberiad, which will aid us from the inside."
+	icon = 'icons/obj/device.dmi'	//same as borg tele
+	icon_state = "locator"
+	var/checking = FALSE
+	var/TC_cost = 0
+	var/desired_objective
+
+/obj/item/antag_spawner/sleeper_activator/attack_self(mob/user)
+	if(used)
+		to_chat(user, "<span class='warning'>[src] has already been used.</span>")
+		return
+	if(!(user.mind in ticker.mode.syndicates))
+		to_chat(user, "<span class='danger'>AUTHENTICATION FAILURE. ACCESS DENIED.</span>")
+		return FALSE
+	if(checking)
+		to_chat(user, "<span class='warning'>[src] is already checking for sleeper agents to activate!</span>")
+		return
+	desired_objective = stripped_input(user, "What objective do you wish to give the sleeper agent?", "Objective")
+	checking = TRUE
+	used = TRUE
+	to_chat(user, "<span class='notice'>Activating sleeper agent, stand by.</span>")
+	var/list/agent_candidates = get_candidate_list()
+	if(!length(agent_candidates))
+		to_chat(user, "<span class='warning'>[src] failed to locate any potential sleeper agents on the station!</span>")
+		used = FALSE
+		checking = FALSE
+	var/datum/mind/agent = pick(agent_candidates)
+	ticker.mode.sleeper_agents += agent
+	agent.special_role = SPECIAL_ROLE_TRAITOR
+	ticker.mode.forge_sleeper_objectives(agent, desired_objective)	//gives our sleeper his objectives
+	ticker.mode.greet_sleeper(agent)
+	ticker.mode.equip_sleeper(agent.current)
+	to_chat(user, "<span class='notice'>[agent.name] the [agent.assigned_role] has been activated as a Sleeper Agent.</span>")
+
+
+
+
+/obj/item/antag_spawner/sleeper_activator/proc/get_candidate_list()
+	var/list/agent_candidates = new
+	for(var/mob/living/player in GLOB.mob_list)
+		if(!player.client)
+			continue 
+		if(player.stat == DEAD)
+			continue
+		if(player.mind.special_role)
+			continue
+		if(!ishuman(player))
+			continue
+		if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
+			player.mind += agent_candidates
+	for(var/datum/mind/player in agent_candidates)
+		var/mob/living/carbon/human/H = player.current
+		for(var/obj/item/implant/mindshield/I in H.contents)
+			if(I && I.implanted)
+				agent_candidates -= player
+	return agent_candidates
+
 
 /obj/item/antag_spawner/borg_tele
 	name = "syndicate cyborg teleporter"

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -26,7 +26,7 @@
 		return
 	if(!(user.mind in ticker.mode.syndicates))
 		to_chat(user, "<span class='danger'>AUTHENTICATION FAILURE. ACCESS DENIED.</span>")
-		return FALSE
+		return
 	if(checking)
 		to_chat(user, "<span class='warning'>[src] is already checking for sleeper agents to activate!</span>")
 		return
@@ -39,19 +39,21 @@
 		to_chat(user, "<span class='warning'>[src] failed to locate any potential sleeper agents on the station!</span>")
 		used = FALSE
 		checking = FALSE
+		return
 	var/datum/mind/agent = pick(agent_candidates)
 	ticker.mode.sleeper_agents += agent
 	agent.special_role = SPECIAL_ROLE_TRAITOR
 	ticker.mode.forge_sleeper_objectives(agent, desired_objective)	//gives our sleeper his objectives
 	ticker.mode.greet_sleeper(agent)
 	ticker.mode.equip_sleeper(agent.current)
+	agent.current.faction = list("syndicate")
 	to_chat(user, "<span class='notice'>[agent.name] the [agent.assigned_role] has been activated as a Sleeper Agent.</span>")
 
 
 
 
 /obj/item/antag_spawner/sleeper_activator/proc/get_candidate_list()
-	var/list/agent_candidates = new
+	var/list/agent_candidates = list()
 	for(var/mob/living/player in GLOB.mob_list)
 		if(!player.client)
 			continue 
@@ -62,7 +64,7 @@
 		if(!ishuman(player))
 			continue
 		if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
-			player.mind += agent_candidates
+			agent_candidates += player.mind
 	for(var/datum/mind/player in agent_candidates)
 		var/mob/living/carbon/human/H = player.current
 		for(var/obj/item/implant/mindshield/I in H.contents)

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -17,7 +17,6 @@
 	icon = 'icons/obj/device.dmi'	//same as borg tele
 	icon_state = "locator"
 	var/checking = FALSE
-	var/TC_cost = 0
 	var/desired_objective
 
 /obj/item/antag_spawner/sleeper_activator/attack_self(mob/user)
@@ -50,19 +49,14 @@
 	to_chat(user, "<span class='notice'>[agent.name] the [agent.assigned_role] has been activated as a Sleeper Agent.</span>")
 	qdel(src)	//destroys itself after use
 
-
-
-
 /obj/item/antag_spawner/sleeper_activator/proc/get_candidate_list()
 	var/list/agent_candidates = list()
-	for(var/mob/living/player in GLOB.mob_list)
+	for(var/mob/living/carbon/human/player in GLOB.mob_list)
 		if(!player.client)
 			continue 
 		if(player.stat == DEAD)
 			continue
 		if(player.mind.special_role)
-			continue
-		if(!ishuman(player))
 			continue
 		if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
 			agent_candidates += player.mind

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -48,6 +48,7 @@
 	ticker.mode.equip_sleeper(agent.current)
 	agent.current.faction = list("syndicate")
 	to_chat(user, "<span class='notice'>[agent.name] the [agent.assigned_role] has been activated as a Sleeper Agent.</span>")
+	qdel(src)	//destroys itself after use
 
 
 


### PR DESCRIPTION
**What does this PR do:**
Inspired by a few posts in https://nanotrasen.se/forum/topic/14830-fixing-war-rounds-some-suggestions/

This PR adds a new purchase options for nuclear operatives: The activation of a sleeper agent aboard the station. For 40TC, they can activate a sleeper agent aboard the station who will, like a traitor, get a PDA with 10TC (for a net TC cost of 30). Said agent is given an objective to aid the nukies and a custom objective given to him by the nukies when they use the device that activates him.

The agent doesn't get any of the free equipment that nukies get, but since he is undercover, he can aid the nukies from the insides. And since the crew usually decides to hand out weapons and all access to every random civilian during war rounds, he's sure to be useful. Because IMO it is very meta to suddenly trust everyone completely because you know OOC that it's nukies and thus there are no traitors aboard.

The sleeper agent ranks below the nukies and it is made clear he should follow their orders. He also doesn't get the nuke codes and, if he wants to communicate with the nukies, will have to spend some valuable TC on buying syndie coms.

Unsure on how to cost it. We also discussed making it cheaper but not giving him any TC in coderchat, leaving it as is for the moment.


**Changelog:**
:cl: 
add: New purchase option for nukies: Sleeper agent. Activates a traitor with 10 TC aboard the station to wreck havoc and support them from the inside.
/:cl:

