### PR TITLE
Fixes being able to attach the IV drip when incapacitated

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -65,6 +65,9 @@
 			overlays += filling
 
 /obj/machinery/iv_drip/MouseDrop(mob/living/target)
+	if(usr.incapacitated())
+		return
+
 	if(!ishuman(usr) || !iscarbon(target))
 		return
 


### PR DESCRIPTION
Fixes https://github.com/ParadiseSS13/Paradise/issues/10354

**What does this PR do:**
Fixes being able to attach the IV drip when incapacitated

**Changelog:**
:cl: Dovydas12345
fix: Fixes being able to attach IV drips when incapacitated
/:cl:

