### PR TITLE
Fix for power beacon change oversight

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1252,6 +1252,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	hijack_only = TRUE //This is an item only useful for a hijack traitor, as such, it should only be available in those scenarios.
 	cant_discount = TRUE
+	excludefrom = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/device_tools/singularity_beacon/nuke
+	reference = "SNGBN"
+	hijack_only = FALSE // This inherited version exists so nukies can use it while keeping the original hijack only
+	excludefrom = list()
+	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/syndicate_bomb
 	name = "Syndicate Bomb"


### PR DESCRIPTION
**What does this PR do:**
When power beacons were recently changed to be Hijack only at a lower price, this also made them unavailable to Nuclear Operatives as they don't have a Hijack objective.

This fix makes a new version of the beacon that inherits everything from the original, but makes it exclusive to nukies and removes the hijack requirement. The original version was also excluded from nukie uplinks to stop it appearing twice.

**Changelog:**
:cl: Azule Utama
fix: Power beacon made purchasable again in Nuke Ops uplinks.
/:cl:

