### PR TITLE
Adds the syndicate tactical jetpack to the Blood-Red Hardsuit for Traitors.

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1144,7 +1144,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "The feared suit of a syndicate nuclear agent. Features armor and a combat mode \
 			for faster movement on station. Toggling the suit in and out of \
 			combat mode will allow you all the mobility of a loose fitting uniform without sacrificing armoring. \
-			Additionally the suit is collapsible, making it small enough to fit within a backpack. Comes packaged with internals. \
+			Additionally the suit is collapsible, making it small enough to fit within a backpack. Comes packaged with a tactical oxygen jetpack. \
 			Nanotrasen crew who spot these suits are known to panic."
 	reference = "BRHS"
 	item = /obj/item/storage/box/syndie_kit/hardsuit

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -100,7 +100,7 @@
 
 /obj/item/storage/box/syndie_kit/hardsuit
 	name = "Boxed Blood Red Suit and Helmet"
-	can_hold = list(/obj/item/clothing/suit/space/hardsuit/syndi, /obj/item/clothing/head/helmet/space/hardsuit/syndi, /obj/item/tank/emergency_oxygen/syndi, /obj/item/clothing/mask/gas/syndicate)
+	can_hold = list(/obj/item/clothing/suit/space/hardsuit/syndi, /obj/item/clothing/head/helmet/space/hardsuit/syndi, /obj/item/tank/jetpack/oxygen/harness, /obj/item/clothing/mask/gas/syndicate)
 	max_w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/box/syndie_kit/hardsuit/New()
@@ -108,7 +108,7 @@
 	new /obj/item/clothing/suit/space/hardsuit/syndi(src)
 	new /obj/item/clothing/head/helmet/space/hardsuit/syndi(src)
 	new /obj/item/clothing/mask/gas/syndicate(src)
-	new /obj/item/tank/emergency_oxygen/syndi(src)
+	new /obj/item/tank/jetpack/oxygen/harness(src)
 	return
 
 /obj/item/storage/box/syndie_kit/elite_hardsuit


### PR DESCRIPTION
**What does this PR do:**
Replaces the suspicious oxygen tank currently included within the Blood Red Hardsuit traitor kit with the standard nuke ops jetpack. I brought this up in discord quite a while back but only remembered it recently so went ahead and added it in:

![image](https://user-images.githubusercontent.com/44248086/49051050-0d1f7800-f1de-11e8-8cc1-fe1955623f1e.png)

The hardsuit right now is heavily underused as most traitors will either try and find a black and red suit in maintenance or just buy it as a cheaper alternative on the uplink should they need a hardsuit to go to space. The black and red suit also won't get you valided by everyone on the station. Giving the more expensive hardsuit an internals jetpack will make it far superior for space travel over the cheaper one.

I've left the price at 8TC for now, though if adding this would justify a price increase I can adjust this.

**Changelog:**
:cl: Azule Utama
add: Traitor Blood-Red Hardsuit now comes with the standard syndicate jetpack included. Take a suspicious trip into space today!
/:cl:

