### PR TITLE
Sorts callable holopads before displaying

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -206,6 +206,7 @@ var/list/holopads = list()
 				if(A)
 					LAZYADD(callnames[A], I)
 			callnames -= get_area(src)
+			callnames = sortNames(callnames)			//Sorts the now complete callable list for ease of use
 			dialling_input = TRUE
 			var/result = input(usr, "Choose an area to call", "Holocall") as null|anything in callnames
 			dialling_input = FALSE


### PR DESCRIPTION
**What does this PR do:**
When the user attempts to make a holocall, the callable holopads are sorted before being displayed. The goal is to make a specific holopad easier to find.

**Changelog:*
:cl: 
add: Sort callable holopads by name
/:cl:

