### PR TITLE
Fixes ORM Exploit

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -335,6 +335,8 @@
 		var/datum/design/alloy = files.FindDesignByID(alloy_id)
 		if((check_access(inserted_id) || allowed(usr)) && alloy)
 			var/desired = input("How many sheets?", "How many sheets would you like to smelt?", 1) as null|num
+			if(desired < 1) // Stops an exploit that lets you build negative alloys and get free materials
+				return
 			var/smelt_amount = can_smelt_alloy(alloy)
 			var/amount = round(min(desired,50,smelt_amount))
 			materials.use_amount(alloy.materials, amount)


### PR DESCRIPTION
**What does this PR do:**

fixes #10377 (This only affects alloys, unloading the basic materials doesn't have the same issue).

This bug is actually more serious than it looks, since you can currently create negative alloys and "refund" the materials used back into the ORM for infinite resources.

This adds a check after getting the user's input to see if they've entered a value lower than 1. If they have, the code returns and doesn't continue.

**Images of sprite/map changes (IF APPLICABLE):**

**Changelog:**
:cl: Azule Utama
fix: Fixed an ORM exploit which would let you smelt invalid stacks of alloys.
/:cl:

