### PR TITLE
Fix cigarette chem consumption

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -196,7 +196,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 		if(is_being_smoked) // if it's being smoked, transfer reagents to the mob
 			var/mob/living/carbon/C = loc
 			for (var/datum/reagent/R in reagents.reagent_list)
-				reagents.trans_to(C, REAGENTS_METABOLISM)
+				reagents.trans_id_to(C, R.id, max(REAGENTS_METABOLISM / reagents.reagent_list.len, 0.1)) //transfer at least .1 of each chem
 			if(!reagents.total_volume) // There were reagents, but now they're gone
 				to_chat(C, "<span class='notice'>Your [name] loses its flavor.</span>")
 		else // else just remove some of the reagents
@@ -232,7 +232,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	type_butt = /obj/item/cigbutt/roach
 	throw_speed = 0.5
 	item_state = "spliffoff"
-	smoketime = 180
+	smoketime = 250
 	chem_volume = 100
 
 /obj/item/clothing/mask/cigarette/rollie/New()


### PR DESCRIPTION
**What does this PR do:**
https://github.com/ParadiseSS13/Paradise/pull/10122 attempted to fix rollies by transferring .4u of each chem present in them instead of .4u shared between all chems. Prior to this, if a chem took up less than 25% of the chem volume, the user would not metabolize any as they would receive less than .1u of the chem, and amounts less than .1 are ignored.

However, that change caused all cigarettes to burn through their chems at a much faster rate than normal if they had more than one chem inside them. A full cigarette with 2 chems inside it would run out twice as fast, and 3 chems three times as fast, and so on. This means Syndicate cigarettes, for example, now last half as long.

This commit fixes the original problem whilst still maintaining the original chem rate. It still attempts to transfer .4u split between all chems, however if a chem doesn't take up enough of the total volume to transfer at least .1u, it will bump the amount to .1, ensuring each chem will be metabolized.

This also fixes the rollie smoketime to be in line with the new chem volume. The new value is 100 / .4u = 250. The old value, even without the above changes, meant that the rollie would burn out before delivering all of it's volume if it only had one chem in it.

**Changelog:**
:cl: Edefff
balance: revert significantly increased cigarette chem burn rate
fix: increase rollie smoketime to accommodate new chem volume
/:cl:

