### PR TITLE
Radial menu for implants and item_action icon.

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/max_elements
 	var/pages = 1
 	var/current_page = 1
-	
+
 	var/hudfix_method = TRUE //TRUE to change anchor to user, FALSE to shift by py_shift
 	var/py_shift = 0
 	var/entry_animation = TRUE
@@ -74,9 +74,9 @@ GLOBAL_LIST_EMPTY(radial_menus)
 //If we swap to vis_contens inventory these will need a redo
 /datum/radial_menu/proc/check_screen_border(mob/user)
 	var/atom/movable/AM = anchor
-	if(!istype(AM) || !AM.screen_loc)
+	if(!istype(AM))
 		return
-	if(AM in user.client.screen)
+	if((AM in user.client.screen) || !AM.screen_loc)
 		if(hudfix_method)
 			anchor = user
 		else
@@ -84,7 +84,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 			restrict_to_dir(NORTH) //I was going to parse screen loc here but that's more effort than it's worth.
 
 //Sets defaults
-//These assume 45 deg min_angle 
+//These assume 45 deg min_angle
 /datum/radial_menu/proc/restrict_to_dir(dir)
 	switch(dir)
 		if(NORTH)
@@ -105,7 +105,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		zone = ending_angle - starting_angle
 	else
 		zone = 360 - starting_angle + ending_angle
-	
+
 	max_elements = round(zone / min_angle)
 	var/paged = max_elements < choices.len
 	if(elements.len < max_elements)
@@ -172,7 +172,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	else
 		E.pixel_y = py
 		E.pixel_x = px
-	
+
 	//Visuals
 	E.alpha = 255
 	E.mouse_opacity = MOUSE_OPACITY_ICON
@@ -192,7 +192,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		E.next_page = FALSE
 		if(choices_icons[choice_id])
 			E.add_overlay(choices_icons[choice_id])
-	
+
 /datum/radial_menu/New()
 	close_button = new
 	close_button.parent = src
@@ -230,7 +230,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		MA.layer = ABOVE_HUD_LAYER
 		MA.appearance_flags |= RESET_TRANSFORM
 	return MA
-		
+
 
 /datum/radial_menu/proc/next_page()
 	if(pages > 1)
@@ -268,7 +268,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	. = ..()
 
 /*
-	Presents radial menu to user anchored to anchor (or user if the anchor is currently in users screen) 
+	Presents radial menu to user anchored to anchor (or user if the anchor is currently in users screen)
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
 */

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -102,10 +102,14 @@
 /datum/action/item_action
 	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUNNED|AB_CHECK_LYING|AB_CHECK_CONSCIOUS
 	var/use_itemicon = TRUE
-/datum/action/item_action/New(Target)
+/datum/action/item_action/New(Target, custom_icon, custom_icon_state)
 	..()
 	var/obj/item/I = target
 	I.actions += src
+	if(custom_icon && custom_icon_state)
+		use_itemicon = FALSE
+		icon_icon = custom_icon
+		button_icon_state = custom_icon_state
 
 /datum/action/item_action/Destroy()
 	var/obj/item/I = target

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -35,6 +35,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 
 	var/list/actions = list() //list of /datum/action's that this item has.
 	var/list/actions_types = list() //list of paths of action datums to give to the item on New().
+	var/list/action_icon = list() //list of icons-sheets for a given action to override the icon.
+	var/list/action_icon_state = list() //list of icon states for a given action to override the icon_state.
 
 	var/list/materials = list()
 	//Since any item can now be a piece of clothing, this has to be put here so all items share it.
@@ -100,7 +102,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 /obj/item/New()
 	..()
 	for(var/path in actions_types)
-		new path(src)
+		new path(src, action_icon[path], action_icon_state[path])
 
 	if(!hitsound)
 		if(damtype == "fire")

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -133,14 +133,28 @@
 		holder = null
 		if(contents.len == 1)
 			Extend(contents[1])
-		else // TODO: make it similar to borg's storage-like module selection
-			var/obj/item/choise = input("Activate which item?", "Arm Implant", null, null) as null|anything in items_list
-			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !holder && istype(choise) && (choise in contents))
-				// This monster sanity check is a nice example of how bad input() is.
-				Extend(choise)
+		else
+			radial_menu(owner)
 	else
 		Retract()
 
+/obj/item/organ/internal/cyberimp/arm/proc/check_menu(var/mob/user)
+	return (owner && owner == user && owner.stat != DEAD && (src in owner.internal_organs) && !holder)
+
+/obj/item/organ/internal/cyberimp/arm/proc/radial_menu(mob/user)
+	var/list/choices = list()
+	for(var/obj/I in items_list)
+		choices["[I.name]"] = image(icon = I.icon, icon_state = I.icon_state)
+	var/choice = show_radial_menu(user, src, choices, custom_check = CALLBACK(src, .proc/check_menu, user))
+	if(!check_menu(user))
+		return
+	var/obj/item/selected
+	for(var/obj/item in items_list)
+		if(item.name == choice)
+			selected = item
+			break
+	if(istype(selected) && (selected in contents))
+		Extend(selected)
 
 /obj/item/organ/internal/cyberimp/arm/gun/emp_act(severity)
 	if(emp_proof)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -199,6 +199,8 @@
 	origin_tech = "materials=3;engineering=4;biotech=3;powerstorage=4"
 	contents = newlist(/obj/item/screwdriver/cyborg, /obj/item/wrench/cyborg, /obj/item/weldingtool/largetank/cyborg,
 		/obj/item/crowbar/cyborg, /obj/item/wirecutters/cyborg, /obj/item/multitool/cyborg)
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/clothing/belts.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "utilitybelt")
 
 /obj/item/organ/internal/cyberimp/arm/toolset/l
 	parent_organ = "l_arm"
@@ -221,12 +223,16 @@
 	desc = "A cybernetic implant that allows the user to project a healing beam from their hand."
 	contents = newlist(/obj/item/gun/medbeam)
 	origin_tech = "materials=5;combat=2;biotech=5;powerstorage=4;syndicate=1"
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/chronos.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "chronogun")
 
 /obj/item/organ/internal/cyberimp/arm/flash
 	name = "integrated high-intensity photon projector" //Why not
 	desc = "An integrated projector mounted onto a user's arm, that is able to be used as a powerful flash."
 	contents = newlist(/obj/item/flash/armimplant)
 	origin_tech = "materials=4;combat=3;biotech=4;magnets=4;powerstorage=3"
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/device.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "flash")
 
 /obj/item/organ/internal/cyberimp/arm/flash/New()
 	..()
@@ -265,6 +271,8 @@
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm"
 	contents = newlist(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment, /obj/item/bonegel/augment, /obj/item/FixOVein/augment, /obj/item/bonesetter/augment)
 	origin_tech = "materials=3;engineering=3;biotech=3;programming=2;magnets=3"
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/storage.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "duffel-med")
 
 /obj/item/organ/internal/cyberimp/arm/surgery/l
 	parent_organ = "l_arm"
@@ -348,9 +356,13 @@
 	desc = "Telescopic baton implant. Does what it says on the tin" // A better description
 
 	contents = newlist(/obj/item/melee/classic_baton)
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/items.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "baton")
 
 /obj/item/organ/internal/cyberimp/arm/advmop
 	name = "advanced mop implant"
 	desc = "Advanced mop implant. Does what it says on the tin" // A better description
 
 	contents = newlist(/obj/item/mop/advanced)
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/janitor.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "advmop")


### PR DESCRIPTION
**What does this PR do:**
Adds the radial menu as selection tool for arm implants with multiple items. It also refactors item_action and items to allow the action to get a custom icon based on the item, and not just the icon of the item.

**Changelog:**
:cl:
add: Arm implants use radial menues where suitable
tweak: Item actions can have icons different from the icon of the item
/:cl:

