### PR TITLE
Fixes some issues in floor cluwne code

### DIFF
--- a/code/modules/admin/verbs/spawnfloorcluwne.dm
+++ b/code/modules/admin/verbs/spawnfloorcluwne.dm
@@ -19,7 +19,6 @@
 			if(H.mind.assigned_role == "Cluwne")
 				continue
 			potential_targets += H
-		for(var/mob/M in potential_targets)
 		if(!potential_targets.len) //You're probably the only player on this damn station, spawn it yourself
 			to_chat(src, "<span class='notice'>No valid targets!</span>")
 			return

--- a/code/modules/admin/verbs/spawnfloorcluwne.dm
+++ b/code/modules/admin/verbs/spawnfloorcluwne.dm
@@ -13,11 +13,11 @@
 		var/turf/T = get_turf(usr)
 		var/list/potential_targets = list()
 		for(var/mob/M in GLOB.player_list)
-			if(!istype(M, /mob/living/carbon/human))
-				continue
-			if(M.mind.assigned_role == "Cluwne")
-				continue
 			var/mob/living/carbon/human/H = M
+			if(!istype(H))
+				continue
+			if(H.mind.assigned_role == "Cluwne")
+				continue
 			potential_targets += H
 		for(var/mob/M in potential_targets)
 		if(!potential_targets.len) //You're probably the only player on this damn station, spawn it yourself

--- a/code/modules/admin/verbs/spawnfloorcluwne.dm
+++ b/code/modules/admin/verbs/spawnfloorcluwne.dm
@@ -2,25 +2,30 @@
 	set category = "Event"
 	set name = "Unleash Floor Cluwne"
 	set desc = "Pick a specific target or just let it select randomly and spawn the floor cluwne mob on the station. Be warned: spawning more than one may cause issues!"
-	var/target
+	var/mob/living/carbon/human/target
 
 	if(!check_rights(R_EVENT))
 		return
 
-	var/confirm = alert("Are you sure you want to release a floor cluwne and kill alot of people?", "Confirm Massacre", "Yes", "No")
+	var/confirm = alert("Are you sure you want to release a floor cluwne and kill a lot of people?", "Confirm Massacre", "Yes", "No")
 	if(confirm == "Yes")
 
 		var/turf/T = get_turf(usr)
-		target = input("Any specific target in mind? Please note only live, non cluwned, human targets are valid.", "Target", target) as null|anything in GLOB.player_list
-		if(isnull(target))
+		var/list/potential_targets = list()
+		for(var/mob/M in GLOB.player_list)
+			if(!istype(M, /mob/living/carbon/human))
+				continue
+			if(M.mind.assigned_role == "Cluwne")
+				continue
+			var/mob/living/carbon/human/H = M
+			potential_targets += H
+		for(var/mob/M in potential_targets)
+		if(!potential_targets.len) //You're probably the only player on this damn station, spawn it yourself
+			to_chat(src, "<span class='notice'>No valid targets!</span>")
 			return
-		if(target && ishuman(target))
-			var/mob/living/carbon/human/H = target
-			var/mob/living/simple_animal/hostile/floor_cluwne/FC = new /mob/living/simple_animal/hostile/floor_cluwne(T)
-			FC.Acquire_Victim(H)
-		else
-			new /mob/living/simple_animal/hostile/floor_cluwne(T)
-		log_admin("[key_name(usr)] spawned floor cluwne.")
-		message_admins("[key_name(usr)] spawned floor cluwne.")
-	else
-		return
+		target = input("Any specific target in mind? Please note only live, non cluwned, human targets are valid.", "Target", target) as null|anything in potential_targets
+		var/mob/living/simple_animal/hostile/floor_cluwne/FC = new /mob/living/simple_animal/hostile/floor_cluwne(T)
+		if(target)
+			FC.Acquire_Victim(target)
+		log_admin("[key_name(usr)] spawned floor cluwne[target ? ", initially targetting [target]": null].")
+		message_admins("[key_name(usr)] spawned floor cluwne[target ? ", initially targetting [target]": null].")

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -71,10 +71,13 @@
 
 
 /mob/living/simple_animal/hostile/floor_cluwne/Life(seconds, times_fired)
+	if(!ishuman(current_victim)) //Just in case a nonhuman is accidentally chosen. A human will then be chosen later on in Acquire_Victim()
+		current_victim = null
+
 	do_jitter_animation(1000)
 	pixel_y = 8
 
-	if(is_type_in_typecache(get_area(src.loc), invalid_area_typecache))
+	if(is_type_in_typecache(get_area(loc), invalid_area_typecache))
 		var/area = pick(teleportlocs)
 		var/area/tp = teleportlocs[area]
 		forceMove(pick(get_area_turfs(tp.type)))
@@ -153,7 +156,7 @@
 		if(specific)
 			H = specific
 			if((!H || H.stat == DEAD) && smiting)//safety check, target somehow DIED after we sent a smite
-				message_admins("Smiting Floor Cluwne was deleted due to a lack of valid target. Someone killed them first, or they ceased to exist.")
+				message_admins("Smiting floor cluwne was deleted due to a lack of valid target. Someone killed them first, or they ceased to exist.")
 				qdel(src)
 				return
 			if(H.stat != DEAD && !isLivingSSD(H) &&  H.client && !H.get_int_organ(/obj/item/organ/internal/honktumor/cursed) && !is_type_in_typecache(get_area(H.loc), invalid_area_typecache))
@@ -165,8 +168,7 @@
 			interest = 0
 			return target = current_victim
 
-
-	message_admins("Floor Cluwne was deleted due to a lack of valid targets, if this was a manually targeted instance please re-evaluate your choice.")
+	message_admins("Floor cluwne was deleted due to a lack of valid targets[specific ? ", if you spawned this with a specific target please choose another person" : null].")
 	qdel(src)
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/Manifest()//handles disappearing and appearance anim

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -71,7 +71,7 @@
 
 
 /mob/living/simple_animal/hostile/floor_cluwne/Life(seconds, times_fired)
-	if(!ishuman(current_victim)) //Just in case a nonhuman is accidentally chosen. A human will then be chosen later on in Acquire_Victim()
+	if(current_victim && !ishuman(current_victim)) //Just in case a nonhuman is accidentally chosen. A human will then be chosen later on in Acquire_Victim()
 		current_victim = null
 
 	do_jitter_animation(1000)

--- a/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
+++ b/code/modules/mob/living/simple_animal/hostile/floorcluwne.dm
@@ -79,7 +79,7 @@
 		var/area/tp = teleportlocs[area]
 		forceMove(pick(get_area_turfs(tp.type)))
 
-	if(!current_victim && !admincluwne)
+	if((!current_victim && !admincluwne) || QDELETED(current_victim))
 		Acquire_Victim()
 
 	if(stage && !manifested)
@@ -147,6 +147,8 @@
 	var/list/players_copy = GLOB.player_list.Copy()
 	while(players_copy.len)
 		var/mob/living/carbon/human/H = pick_n_take(players_copy)
+		if(!ishuman(H))
+			continue
 
 		if(specific)
 			H = specific
@@ -158,7 +160,7 @@
 				current_victim = H
 				return target = current_victim
 
-		if(H && ishuman(H) && H.stat != DEAD && H != current_victim && !isLivingSSD(H) &&  H.client && !H.get_int_organ(/obj/item/organ/internal/honktumor/cursed) && !is_type_in_typecache(get_area(H.loc), invalid_area_typecache))
+		if(H && H.stat != DEAD && H != current_victim && !isLivingSSD(H) &&  H.client && !H.get_int_organ(/obj/item/organ/internal/honktumor/cursed) && !is_type_in_typecache(get_area(H.loc), invalid_area_typecache))
 			current_victim = H
 			interest = 0
 			return target = current_victim
@@ -195,6 +197,8 @@
 
 /mob/living/simple_animal/hostile/floor_cluwne/proc/On_Stage()
 	var/mob/living/carbon/human/H = current_victim
+	if(!H)
+		Acquire_Victim()
 	switch(stage)
 
 		if(STAGE_HAUNT)


### PR DESCRIPTION
**What does this PR do:**
Applies the following fixes to floorcluwnecode
- QDELETING or gibbing the target causes the cluwne to reacquire a target
- Fixes spelling mistake in the prompt
- You can spawn a floor cluwne without a target via the event now
- Cluwnes can't be initially targetted now
- Initial target is shown to the admins, if one is provided
- Fixes an issue where nonhumans can be chosen / can become the cluwne target, preventing some runtimes
- If there are no potential targets, the event will no longer proceed.

:cl:
fix: Fixes some issues and runtimes in floorcluwne code.
tweak: Admins will now be informed of a new floorcluwne's chosen target if one is provided via the event.
/:cl: