### PR TITLE
Fixes support_chaplain.dm Runtime

### DIFF
--- a/code/game/jobs/job/support_chaplain.dm
+++ b/code/game/jobs/job/support_chaplain.dm
@@ -76,7 +76,7 @@
 		feedback_set_details("religion_name","[new_religion]")
 
 		var/deity_name = "Space Jesus"
-		var/new_deity = sanitize(copytext(input(H, "Who or what do you worship? Default is Space Jesus.", "Name change", deity_name),1,MAX_NAME_LEN))
+		var/new_deity = sanitize(copytext(input(H, "Who or what do you worship? Default is Space Jesus.", "Name change", deity_name), 1, MAX_NAME_LEN))
 
 		if((length(new_deity) == 0) || (new_deity == "Space Jesus") )
 			new_deity = deity_name
@@ -91,9 +91,9 @@
 		var/new_book_style = "Bible"
 
 		while(!accepted)
-			if(!B)
+			if(!B || !H.client)
 				break // prevents possible runtime errors
-			new_book_style = input(H,"Which bible style would you like?") in list("Bible", "Koran", "Scrapbook", "Creeper", "White Bible", "Holy Light", "PlainRed", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "the bible melts", "Necronomicon", "Greentext")
+			new_book_style = input(H, "Which bible style would you like?") in list("Bible", "Koran", "Scrapbook", "Creeper", "White Bible", "Holy Light", "PlainRed", "Tome", "The King in Yellow", "Ithaqua", "Scientology", "the bible melts", "Necronomicon", "Greentext")
 			switch(new_book_style)
 				if("Koran")
 					B.icon_state = "koran"
@@ -153,7 +153,9 @@
 
 			H.update_inv_l_hand() // so that it updates the bible's item_state in his hand
 
-			switch(input(H,"Look at your bible - is this what you want?") in list("Yes","No"))
+			if(!B || !H.client)
+				break // prevents possible runtime errors
+			switch(input(H, "Look at your bible - is this what you want?") in list("Yes", "No"))
 				if("Yes")
 					accepted = 1
 				if("No")
@@ -166,7 +168,7 @@
 			ticker.Bible_item_state = B.item_state
 			ticker.Bible_name = B.name
 			ticker.Bible_deity_name = B.deity_name
-		feedback_set_details("religion_deity","[new_deity]")
-		feedback_set_details("religion_book","[new_book_style]")
+		feedback_set_details("religion_deity", "[new_deity]")
+		feedback_set_details("religion_book", "[new_book_style]")
 
 


### PR DESCRIPTION
Right now, there is a runtime that can happen on round start:
[2018-12-02T02:31:13] Runtime in support_chaplain.dm,96: bad client
   proc name: post equip (/datum/outfit/job/chaplain/post_equip)
   src: Chaplain (/datum/outfit/job/chaplain)
   call stack:
   Chaplain (/datum/outfit/job/chaplain): post equip(CHARNAME (/mob/living/carbon/human), 0)

This PR is my attempt to fix that runtime.
Specifically it adds some checks before calls to input()... so as to prevent a bad client being passed to input. It also fixes some bad spacing in the file.

I'm not actually sure if these checks will prevent the runtime, as I cannot reproduce the runtime locally.
Still, the runtime does need to be fixed, as it can impact roundstart.
If you know of a better way to address the runtime, please comment.

:cl: Kyep
fix: Fixed runtime related to chaplains.
/:cl:

