### PR TITLE
Add power requirement to burglar alarm trigger

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -185,7 +185,7 @@ var/global/list/captain_display_cases = list()
 			playsound(get_turf(src), "shatter", 70, 1)
 			update_icon()
 			spawn(0)
-				if (!alarm_needs_power)
+				if(!alarm_needs_power)
 					burglar_alarm()
 				else
 					var/area/a = get_area(src)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -107,6 +107,7 @@ var/global/list/captain_display_cases = list()
 	var/image/occupant_overlay = null
 	var/obj/item/airlock_electronics/circuit
 	var/start_showpiece_type = null //add type for items on display
+	var/alarm_needs_power = TRUE
 
 /obj/structure/displaycase/New()
 	. = ..()
@@ -184,9 +185,12 @@ var/global/list/captain_display_cases = list()
 			playsound(get_turf(src), "shatter", 70, 1)
 			update_icon()
 			spawn(0)
-				var/area/a = get_area(src)
-				if(isarea(a) && a.power_equip)
+				if (!alarm_needs_power)
 					burglar_alarm()
+				else
+					var/area/a = get_area(src)
+					if(isarea(a) && a.power_equip)
+						burglar_alarm()
 	else
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 	return

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -184,7 +184,9 @@ var/global/list/captain_display_cases = list()
 			playsound(get_turf(src), "shatter", 70, 1)
 			update_icon()
 			spawn(0)
-				burglar_alarm()
+				var/area/a = get_area(src)
+				if(isarea(a) && a.power_equip)
+					burglar_alarm()
 	else
 		playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 75, 1)
 	return


### PR DESCRIPTION
Fixes #10384

Smart tators should be allowed to smartly steal

Burglar alarm won't be triggered if equipment isn't turned on

🆑
tweak: Display case burglar alarm no longer triggered if there's no power to equipment
/🆑