### PR TITLE
Makes ghost spawner menu buttons work.

### DIFF
--- a/nano/templates/spawners_menu.tmpl
+++ b/nano/templates/spawners_menu.tmpl
@@ -11,8 +11,8 @@
 					{{:value.desc}}
 				</div>
 				<div class='floatRight'>
-					{{:helper.link('Jump', null, {'action': 'jump', 'uid': value.uids})}}
-					{{:helper.link('Spawn', null, {'action': 'spawn', 'uid': value.uids})}}
+					{{:helper.link('Jump', null, {'action': 'jump', 'uid': value.uids}, null)}}
+					{{:helper.link('Spawn', null, {'action': 'spawn', 'uid': value.uids},  value.amount_left > 0 ? null : 'disabled')}}
 				</div>
 			</div>
 		{{/for}}


### PR DESCRIPTION
**What does this PR do:**
Thus fixes the template for the mob spawner menu under the ghost tab, currently used for old station. Now the jump and spawn buttons actually work. It seems that for whatever reason the button actually defaults to inactive/disabeled when no status is given and you need to explicitly give it the value null for it to be active 😕 


**Changelog:**
:cl: 
fix: ghost spawn menu jump and spawn buttons now work.
/:cl:

