### PR TITLE
Uplink - Collapsible Categories and Layout Tweaks

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -163,6 +163,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/jobspecific
 	category = "Job Specific Tools"
 	cant_discount = TRUE
+	excludefrom = list(/datum/game_mode/nuclear) // Stops the job specific category appearing for nukies
 
 //Clown
 /datum/uplink_item/jobspecific/clowngrenade

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -24,6 +24,7 @@ var/list/world_uplinks = list()
 
 	var/job = null
 	var/show_descriptions = 0
+	var/temp_category = "Ammunition"
 
 /obj/item/uplink/nano_host()
 	return loc
@@ -233,6 +234,7 @@ var/list/world_uplinks = list()
 	if(!nanoui_items)
 		generate_items(user)
 	data["nano_items"] = nanoui_items
+	data["category_choice"] = temp_category
 	data += nanoui_data
 
 	return data
@@ -271,6 +273,9 @@ var/list/world_uplinks = list()
 			update_nano_data(href_list["id"])
 		if(href_list["descriptions"])
 			show_descriptions = !show_descriptions
+			update_nano_data()
+		if(href_list["category"])
+			temp_category = href_list["category"]
 			update_nano_data()
 
 	SSnanoui.update_uis(src)

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -262,9 +262,6 @@ var/list/world_uplinks = list()
 			hidden_crystals = 0
 			ui.close()
 			return 1
-		if(href_list["return"])
-			nanoui_menu = round(nanoui_menu/10)
-			update_nano_data()
 		if(href_list["menu"])
 			nanoui_menu = text2num(href_list["menu"])
 			update_nano_data(href_list["id"])

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -24,7 +24,7 @@ var/list/world_uplinks = list()
 
 	var/job = null
 	var/show_descriptions = 0
-	var/temp_category = "Ammunition"
+	var/temp_category
 
 /obj/item/uplink/nano_host()
 	return loc

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -12,7 +12,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 	</div>
 	<div class="itemContent">
 		{{:helper.link('Request Items', 'gear', {'menu' : 0}, null, 'fixedLeftWider')}}
-		{{:helper.link(data.descriptions ? 'Hide Descriptions' : 'Show Descriptions', 'gear', {'descriptions' : 1}, data.menu == 0 ? '' : 'disabled', 'fixedLeftWider')}}
+		{{:helper.link(data.descriptions ? 'Hide Descriptions' : 'Show Descriptions', 'gear', {'descriptions' : 1}, data.menu == 2 ? '' : 'disabled', 'fixedLeftWider')}}
 		{{:helper.link('Exploitable Information', 'gear', {'menu' : 1}, null, 'fixedLeftWider')}}
 		{{:helper.link('Return', 'arrow-left', {'return' : 1}, null, 'fixedLeft')}}
 		{{:helper.link('Close', 'gear', {'lock' : "1"}, null, 'fixedLeft')}}
@@ -39,6 +39,10 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 			{{:helper.link ( value.Category, 'gear', {'menu' : 2, 'category' : value.Category}, null, null)}}
 		</div>
 	{{/for}}
+	<br>
+	<div class="item">
+		{{:helper.link('Buy Random (??)' , 'gear', {'buy_item' : 'random'}, data.crystals <= 0 ? 'disabled' : null, null)}}
+	</div>
 
 {{else data.menu == 2}}
     {{for data.nano_items}}
@@ -60,12 +64,8 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 		{{/if}}
     {{/for}}
 {{/if}}
-
-    <div class="item">
-        {{:helper.link('Buy Random (??)' , 'gear', {'buy_item' : 'random'}, data.crystals <= 0 ? 'disabled' : null, null)}}
-    </div>
-
-		<div class="item">
+<br>
+	<div class="item">
         {{:helper.link('Refund item in active hand' , 'gear', {refund : 1}, null, null)}}
     </div>
 

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -11,10 +11,10 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 		<b>Functions</b>:
 	</div>
 	<div class="itemContent">
-		{{:helper.link('Request Items', 'gear', {'menu' : 0, 'category' : null}, null, 'fixedLeftWider')}}
-		{{:helper.link(data.descriptions ? 'Hide Descriptions' : 'Show Descriptions', 'gear', {'descriptions' : 1}, data.menu == 0 ? '' : 'disabled', 'fixedLeftWider')}}
+		{{:helper.link('Purchase Gear', 'gear', {'menu' : 0, 'category' : null}, null, 'fixedLeftWider')}}
 		{{:helper.link('Exploitable Information', 'gear', {'menu' : 1}, null, 'fixedLeftWider')}}
-		{{:helper.link('Close', 'gear', {'lock' : "1"}, null, 'fixedLeft')}}
+		{{:helper.link(data.descriptions ? 'Hide Descriptions' : 'Show Descriptions', 'info-circle', {'descriptions' : 1}, data.menu == 0 ? '' : 'disabled', 'fixedLeftWider')}}
+		{{:helper.link('Lock Uplink', 'power-off', {'lock' : "1"}, null, 'fixedLeftWider')}}
 	</div>
 </div>
 <br>

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -20,7 +20,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 </div>
 <br>
 
-{{if data.menu == 0}}
+{{if data.menu == 0 || data.menu == 2}}
     <H2><span class="white">Request items:</span></H2>
     <span class="white"><i>Each item costs a number of tele-crystals as indicated by the number following their name.</i></span>
 	<div class="item">
@@ -32,23 +32,34 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
         </div>
     </div>
     <br>
-    {{for data.nano_items}}
-        <div class="item">
-            <h3><span class="white">{{:value.Category}}</span></h3>
-        </div>
-        {{for value.items :itemValue:itemIndex}}
-            <div class="item">
-                {{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, null)}} - <span class="white">{{:itemValue.Cost}}</span>
-            </div>
+	
+{{if data.menu == 0}}
+	{{for data.nano_items}}
+		<div class="item">
+			{{:helper.link ( value.Category, 'gear', {'menu' : 2, 'category' : value.Category}, null, null)}}
+		</div>
+	{{/for}}
 
-            {{if itemValue.Cost <= data.crystals && data.descriptions}}
-                <div class="item">
-                    {{:itemValue.Description}}
-                </div>
-            {{/if}}
-        {{/for}}
-        <br>
+{{else data.menu == 2}}
+    {{for data.nano_items}}
+		{{if value.Category == data.category_choice}}
+			<div class="item">
+				<h3><span class="white">{{:value.Category}}</span></h3>
+			</div>
+			{{for value.items :itemValue:itemIndex}}
+				<div class="item">
+					{{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, null)}} - <span class="white">{{:itemValue.Cost}}</span>
+				</div>
+
+				{{if itemValue.Cost <= data.crystals && data.descriptions}}
+					<div class="item">
+						{{:itemValue.Description}}
+					</div>
+				{{/if}}
+			{{/for}}
+		{{/if}}
     {{/for}}
+{{/if}}
 
     <div class="item">
         {{:helper.link('Buy Random (??)' , 'gear', {'buy_item' : 'random'}, data.crystals <= 0 ? 'disabled' : null, null)}}

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -31,8 +31,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
         </div>
     </div>
     <br>
-	
-{{if data.menu == 0}}
+
 	{{for data.nano_items}}
 		{{if value.Category == data.category_choice}}
 		<div class="item">
@@ -47,7 +46,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 			<div class="block">
 			{{for value.items :itemValue:itemIndex}}
 				<div class="item">
-					{{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, 'redButton')}} - <span class="white">{{:itemValue.Cost}}</span>
+					{{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, null)}} - <span class="white">{{:itemValue.Cost}}</span>
 				</div>
 				{{if itemValue.Cost <= data.crystals && data.descriptions}}
 					<div class="item">
@@ -58,7 +57,6 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 			</div>
 		{{/if}}
 	{{/for}}
-	<div class="line"></div>
 	<br>
 	<div class="item">
 		{{:helper.link('Buy Random Item' , 'gear', {'buy_item' : 'random'}, data.crystals <= 0 ? 'disabled' : null, 'white')}}
@@ -66,7 +64,6 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 	<div class="item">
         {{:helper.link('Refund item in active hand' , 'gear', {refund : 1}, null, 'white')}}
     </div>
-{{/if}}
 
 {{else data.menu == 1}}
     <h2><span class="white">Information Record List:</span></h2>

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -11,16 +11,15 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 		<b>Functions</b>:
 	</div>
 	<div class="itemContent">
-		{{:helper.link('Request Items', 'gear', {'menu' : 0}, null, 'fixedLeftWider')}}
-		{{:helper.link(data.descriptions ? 'Hide Descriptions' : 'Show Descriptions', 'gear', {'descriptions' : 1}, data.menu == 2 ? '' : 'disabled', 'fixedLeftWider')}}
+		{{:helper.link('Request Items', 'gear', {'menu' : 0, 'category' : null}, null, 'fixedLeftWider')}}
+		{{:helper.link(data.descriptions ? 'Hide Descriptions' : 'Show Descriptions', 'gear', {'descriptions' : 1}, data.menu == 0 ? '' : 'disabled', 'fixedLeftWider')}}
 		{{:helper.link('Exploitable Information', 'gear', {'menu' : 1}, null, 'fixedLeftWider')}}
-		{{:helper.link('Return', 'arrow-left', {'return' : 1}, null, 'fixedLeft')}}
 		{{:helper.link('Close', 'gear', {'lock' : "1"}, null, 'fixedLeft')}}
 	</div>
 </div>
 <br>
 
-{{if data.menu == 0 || data.menu == 2}}
+{{if data.menu == 0}}
     <H2><span class="white">Request items:</span></H2>
     <span class="white"><i>Each item costs a number of tele-crystals as indicated by the number following their name.</i></span>
 	<div class="item">
@@ -35,39 +34,39 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 	
 {{if data.menu == 0}}
 	{{for data.nano_items}}
-		<div class="item">
-			{{:helper.link ( value.Category, 'gear', {'menu' : 2, 'category' : value.Category}, null, null)}}
-		</div>
-	{{/for}}
-	<br>
-	<div class="item">
-		{{:helper.link('Buy Random (??)' , 'gear', {'buy_item' : 'random'}, data.crystals <= 0 ? 'disabled' : null, null)}}
-	</div>
-
-{{else data.menu == 2}}
-    {{for data.nano_items}}
 		{{if value.Category == data.category_choice}}
-			<div class="item">
-				<h3><span class="white">{{:value.Category}}</span></h3>
-			</div>
+		<div class="item">
+			{{:helper.link ( value.Category, 'arrow-circle-down', {'menu' : 0, 'category' : null}, null, 'white')}}
+		</div>
+		{{else}}
+		<div class="item">
+			{{:helper.link ( value.Category, 'arrow-circle-right', {'menu' : 0, 'category' : value.Category}, null, 'white')}}
+		</div>
+		{{/if}}
+		{{if value.Category == data.category_choice}}
+			<div class="block">
 			{{for value.items :itemValue:itemIndex}}
 				<div class="item">
-					{{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, null)}} - <span class="white">{{:itemValue.Cost}}</span>
+					{{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, 'redButton')}} - <span class="white">{{:itemValue.Cost}}</span>
 				</div>
-
 				{{if itemValue.Cost <= data.crystals && data.descriptions}}
 					<div class="item">
 						{{:itemValue.Description}}
 					</div>
 				{{/if}}
 			{{/for}}
+			</div>
 		{{/if}}
-    {{/for}}
-{{/if}}
-<br>
+	{{/for}}
+	<div class="line"></div>
+	<br>
 	<div class="item">
-        {{:helper.link('Refund item in active hand' , 'gear', {refund : 1}, null, null)}}
+		{{:helper.link('Buy Random Item' , 'gear', {'buy_item' : 'random'}, data.crystals <= 0 ? 'disabled' : null, 'white')}}
+	</div>
+	<div class="item">
+        {{:helper.link('Refund item in active hand' , 'gear', {refund : 1}, null, 'white')}}
     </div>
+{{/if}}
 
 {{else data.menu == 1}}
     <h2><span class="white">Information Record List:</span></h2>


### PR DESCRIPTION
**What does this PR do:**
Adds expandable and collapsible categories to the uplink items page. This makes the list shown to people much shorter than in the current template. New icons are used for the categories to show when they have been expanded and the items / descriptions are now encased in a block layout to better separate them from the buttons used for categories:

_Note that you can only have one category expanded at a time, due to the way this is handled in the uplink devices code. Expanding a new category while another is already open will cause the old one to collapse automatically._

![image](https://user-images.githubusercontent.com/44248086/49578394-8be48580-f941-11e8-95e5-6f6be07cfcb7.png)

Other changes:

- Removed return function from the uplink since this seemingly serves no purpose with only 2 pages to go to. Can add back in if needed.
- Some changes to the layout and two functions renamed to make their purpose a bit more clear.
- Nukies will no longer get a job specific category, as the entire section is now excluded from nuke ops.

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
:cl: Azule Utama
tweak: Syndicate Uplink now uses expandable and collapsible categories. General layout of the uplink has also been changed to work alongside this.
/:cl:

