### PR TITLE
Revert "Sorts callable holopads before displaying"

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -206,7 +206,6 @@ var/list/holopads = list()
 				if(A)
 					LAZYADD(callnames[A], I)
 			callnames -= get_area(src)
-			callnames = sortNames(callnames)			//Sorts the now complete callable list for ease of use
 			dialling_input = TRUE
 			var/result = input(usr, "Choose an area to call", "Holocall") as null|anything in callnames
 			dialling_input = FALSE


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#10369
This caused #10407 which effectively made Holopads useless. Feel free to come up with a fix that keeps the functionality, of course, but it seems nobody's working on that so...

Fixes #10407 

Changelog:
🆑
del: Reverted holopad sorting to make holopads work again.
/🆑
