### PR TITLE
Fix: invincible computer frames / hostile NPC cheese

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -4,9 +4,29 @@
 	name = "computer frame"
 	icon = 'icons/obj/stock_parts.dmi'
 	icon_state = "0"
+	max_integrity = 100
 	var/state = 0
 	var/obj/item/circuitboard/circuit = null
+	var/base_mineral = /obj/item/stack/sheet/metal
 //	weight = 1.0E8
+
+/obj/structure/computerframe/deconstruct(disassembled = TRUE)
+	drop_computer_parts()
+	return ..() // will qdel the frame
+
+/obj/structure/computerframe/obj_break(damage_flag)
+	deconstruct()
+
+/obj/structure/computerframe/proc/drop_computer_parts()
+	new base_mineral(loc, 5)
+	if(circuit)
+		circuit.forceMove(loc)
+		circuit = null
+	if(state >= 3)
+		var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
+		A.amount = 5
+	if(state >= 4)
+		new /obj/item/stack/sheet/glass(loc, 2)
 
 /obj/item/circuitboard
 	density = 0
@@ -420,8 +440,7 @@
 				if(do_after(user, 20 * WT.toolspeed, target = src))
 					if(!src || !WT.isOn()) return
 					to_chat(user, "<span class='notice'>You deconstruct the frame.</span>")
-					new /obj/item/stack/sheet/metal(loc, 5)
-					qdel(src)
+					deconstruct(TRUE)
 		if(1)
 			if(istype(P, /obj/item/wrench))
 				playsound(loc, P.usesound, 50, 1)
@@ -525,6 +544,7 @@
 /obj/structure/computerframe/HONKputer
 	name = "Bananium Computer-frame"
 	icon = 'icons/obj/machines/HONKputer.dmi'
+	base_mineral = /obj/item/stack/sheet/mineral/bananium
 
 /obj/structure/computerframe/HONKputer/attackby(obj/item/P as obj, mob/user as mob, params)
 	switch(state)
@@ -544,8 +564,7 @@
 				if(do_after(user, 20 * WT.toolspeed, target = src))
 					if(!src || !WT.isOn()) return
 					to_chat(user, "<span class='notice'>You deconstruct the frame.</span>")
-					new /obj/item/stack/sheet/mineral/bananium(loc, 5)
-					qdel(src)
+					deconstruct(TRUE)
 		if(1)
 			if(istype(P, /obj/item/wrench))
 				playsound(loc, P.usesound, 50, 1)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -5,6 +5,7 @@
 	density = 1
 	anchored = 1
 	use_power = NO_POWER_USE
+	max_integrity = 100
 	var/obj/item/circuitboard/circuit = null
 	var/list/components = null
 	var/list/req_components = null
@@ -14,6 +15,19 @@
 	// For pods
 	var/list/connected_parts = list()
 	var/pattern_idx=0
+
+/obj/machinery/constructable_frame/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/metal(src.loc, 5)
+	if(state >= 3)
+		var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil(loc)
+		A.amount = 5
+	if(circuit)
+		circuit.forceMove(loc)
+		circuit = null
+	return ..()
+
+/obj/machinery/constructable_frame/obj_break(damage_flag)
+	deconstruct()
 
 // unfortunately, we have to instance the objects really quickly to get the names
 // fortunately, this is only called once when the board is added and the items are immediately GC'd
@@ -89,8 +103,7 @@
 			if(istype(P, /obj/item/wrench))
 				playsound(src.loc, P.usesound, 75, 1)
 				to_chat(user, "<span class='notice'>You dismantle the frame.</span>")
-				new /obj/item/stack/sheet/metal(src.loc, 5)
-				qdel(src)
+				deconstruct(TRUE)
 		if(2)
 			if(istype(P, /obj/item/circuitboard))
 				var/obj/item/circuitboard/B = P

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -41,6 +41,7 @@
 	/obj/structure/grille,
 	/obj/structure/girder,
 	/obj/structure/rack,
+	/obj/structure/computerframe,
 	/obj/structure/barricade) //turned into a typecache in New()
 	var/atom/targets_from = null //all range/attack/etc. calculations should be done from this atom, defaults to the mob itself, useful for Vehicles and such
 	var/list/emote_taunt = list()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -18,7 +18,7 @@
 	var/check_friendly_fire = 0 // Should the ranged mob check for friendlies when shooting
 	var/retreat_distance = null //If our mob runs from players when they're too close, set in tile distance. By default, mobs do not retreat.
 	var/minimum_distance = 1 //Minimum approach distance, so ranged mobs chase targets down, but still keep their distance set in tiles to the target, set higher to make mobs keep distance
-	
+
 //These vars are related to how mobs locate and target
 	var/robust_searching = 0 //By default, mobs have a simple searching method, set this to 1 for the more scrutinous searching (stat_attack, stat_exclusive, etc), should be disabled on most mobs
 	var/vision_range = 9 //How big of an area to search for targets in, a vision of 9 attempts to find targets as soon as they walk into screen view
@@ -42,6 +42,7 @@
 	/obj/structure/girder,
 	/obj/structure/rack,
 	/obj/structure/computerframe,
+	/obj/machinery/constructable_frame,
 	/obj/structure/barricade) //turned into a typecache in New()
 	var/atom/targets_from = null //all range/attack/etc. calculations should be done from this atom, defaults to the mob itself, useful for Vehicles and such
 	var/list/emote_taunt = list()


### PR DESCRIPTION
Currently, computer and machine frames are invincible, and ignored by hostile simple_animals because of this.
This enables you to use them as indefinite cover from hostile NPCs, as well as potentially trapping the NPCs by placing frames around them.

This PR modifies them such that they can now be destroyed - by animal attacks, explosions, and regular projectiles. When they are destroyed, they drop their base material (typically metal), wiring (if wired) and circuit (if one is installed).

This PR also modifies simple_animal AI such that if an NPC is trapped, and it is trying to destroy its surroundings to free itself, it will now damage adjacent frames.

:cl: Kyep
fix: Computer and machine frames are no longer invincible, and can now be destroyed by hostile NPCs.
/:cl:

