### PR TITLE
Adds auto-accent for drask

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -58,6 +58,16 @@
 		)
 	autohiss_exempt = list("Chittin")
 
+/datum/species/drask
+	autohiss_basic_map = list(
+			"o" = list ("oo", "ooo"),
+			"u" = list ("uu", "uuu")			
+		)
+	autohiss_extra_map = list(
+			"m" = list ("mm", "mmm")
+		)
+	autohiss_exempt = list("Orluum")
+
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
 	if(!autohiss_basic_map)


### PR DESCRIPTION
**What does this PR do:**
Adds drask humming to autohiss.dm to let drask players have an accent if they want. Basic autohiss extends o's and u's, while full autohiss extends m's as well. Yay!

![image](https://user-images.githubusercontent.com/38596550/49687651-b3675980-facb-11e8-8e30-f9254baa1e04.png)

**Changelog:**
:cl:
add: Adds drask ability to have auto-accent.
/:cl:

