### PR TITLE
Fixes giant spider bug

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -10,7 +10,7 @@
 
 /mob/living/simple_animal/hostile/poison/AttackingTarget()
 	..()
-	if(isliving(target))
+	if(isliving(target) && (!client || a_intent == INTENT_HARM))
 		var/mob/living/L = target
 		if(L.reagents)
 			L.reagents.add_reagent("spidertoxin", poison_per_bite)


### PR DESCRIPTION
:cl: Kyep
fix: Player-controlled giant spiders will no longer unintentionally poison anyone they nuzzle on help intent. They can still poison people they bite.
/:cl:
