### PR TITLE
Adds flashlight toggle action icon to mini energy gun

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -34,6 +34,7 @@
 	ammo_x_offset = 2
 	charge_sections = 3
 	can_flashlight = 0 // Can't attach or detach the flashlight, and override it's icon update
+	actions_types = list(/datum/action/item_action/toggle_gunlight)
 
 /obj/item/gun/energy/gun/mini/New()
 	gun_light = new /obj/item/flashlight/seclite(src)


### PR DESCRIPTION
As title indicates.

:cl: Alonefromhell
add: Miniature energy gun now has an action icon for it's light toggle(like flashlight).
/:cl:

