### PR TITLE
Remove access requirement on emagged fax

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -61,6 +61,7 @@ var/global/list/fax_blacklist = list()
 /obj/machinery/photocopier/faxmachine/emag_act(mob/user)
 	if(!emagged)
 		emagged = 1
+		req_one_access = list()
 		to_chat(user, "<span class='notice'>The transmitters realign to an unknown source!</span>")
 	else
 		to_chat(user, "<span class='warning'>You swipe the card through [src], but nothing happens.</span>")


### PR DESCRIPTION
I've been told that admins have changed emagged faxes access requirements to allow faxing the syndicate during a round  before. Behaviour makes sense and faxing the syndicate isn't AFAIK a feature used all that often anyway as it is now.
🆑
tweak: Removed access requirement on emagged fax machines
/🆑
