### PR TITLE
Fixes bulldog and c20's low ammo alarms only going off once

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -22,6 +22,8 @@
 /obj/item/gun/projectile/automatic/attackby(var/obj/item/A as obj, mob/user as mob, params)
 	. = ..()
 	if(.)
+		if(alarmed) // Did the empty clip alarm go off already?
+			alarmed = 0 // Reset the alarm once a magazine is loaded
 		return
 	if(istype(A, /obj/item/ammo_box/magazine))
 		var/obj/item/ammo_box/magazine/AM = A
@@ -33,6 +35,8 @@
 				magazine = null
 			else
 				to_chat(user, "<span class='notice'>You insert the magazine into \the [src].</span>")
+			if(alarmed)
+				alarmed = 0
 			user.remove_from_mob(AM)
 			magazine = AM
 			magazine.loc = src


### PR DESCRIPTION
**What does this PR do:**
Both the Bulldog Shotgun and C20 SMG for nukies have a low ammo alarm that goes off when the clip is empty. However, this alarm currently only works once per individual gun since there's no code to tell the alarm to reset after it has gone off.

The code now checks if the alarm has gone off when loading a fresh magazine both with and without one currently in the gun. If it has gone off, it resets it so it can alert the user again.

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
:cl: name here
fix: Fixed Bulldog and C20 having their ammo alarms only go off once per gun.
/:cl:

