### PR TITLE
fixes lightning

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -443,6 +443,9 @@
 		return 0
 	var/obj/effect/proc_holder/spell/spell = target
 
+	if(spell.special_availability_check)
+		return 1
+
 	if(owner)
 		return spell.can_cast(owner)
 	return 0

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -100,6 +100,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	var/action_icon = 'icons/mob/actions/actions.dmi'
 	var/action_icon_state = "spell_default"
 	var/action_background_icon_state = "bg_spell"
+	var/special_availability_check = 0//Whether the spell needs to bypass the action button's IsAvailable()
 
 	var/sound = null //The sound the spell makes when it is cast
 

--- a/code/datums/spells/lightning.dm
+++ b/code/datums/spells/lightning.dm
@@ -10,6 +10,7 @@
 	cooldown_min = 30
 	selection_type = "view"
 	random_target = 1
+	special_availability_check = 1
 	var/start_time = 0
 	var/ready = 0
 	var/image/halo = null


### PR DESCRIPTION
**What does this PR do:**
Adds a new var to spells, `special_availability_check`, which bypasses the action button's `can_cast()`. Added it to the lightning spell to fix not being able to unleash the bolt.

fixes: #10447

**Changelog:**
:cl: McDonald072
fix: Fixed being unable to cast lightning with the action button.
/:cl:

