### PR TITLE
Fixes radial implants

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -76,7 +76,10 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/atom/movable/AM = anchor
 	if(!istype(AM))
 		return
-	if((AM in user.client.screen) || !AM.screen_loc)
+	var/mob/living/carbon/H
+	if(ishuman(user))
+		H = user
+	if((AM in user.client.screen) || !AM.screen_loc || (H && (AM in H.internal_organs)))
 		if(hudfix_method)
 			anchor = user
 		else


### PR DESCRIPTION
**What does this PR do:**
Adds a check to see if the anchor of the radial menu is implanted into the person, and centers it around said person if that's the case. Prior logic was that it shouldn't have a screen_loc during it, but it's not reset when it's not visible again.
Alternative to #10457
Fixes #10453

**Changelog:**
:cl:
fix: radial menu now works for normally implanted implants
/:cl:

