### PR TITLE
Radial Menu: Third time the charm

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -79,7 +79,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/mob/living/carbon/H
 	if(ishuman(user))
 		H = user
-	if((AM in user.client.screen) || !AM.screen_loc || (H && (AM in H.internal_organs)))
+	if((AM in user.client.screen) || (H && (AM in H.internal_organs)))
 		if(hudfix_method)
 			anchor = user
 		else


### PR DESCRIPTION
**What does this PR do:**
Fixes #10462
Removes the check for the anchors screen_loc being null, as it is no indicator where the anchor is, can be null for anchors in an inventory, and such, likely should be anchored around the user, but at the same time, mechs have it set to null, and are outside.

**Changelog:**
:cl:
fix: Restores mech radial menu functionality.
/:cl:

