### PR TITLE
Explosions on a mech's turf kills the mech user

### DIFF
--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -56,7 +56,9 @@
 						// You hear a far explosion if you're outside the blast radius. Small bombs shouldn't be heard all over the station.
 						else if(M.can_hear() && !isspaceturf(M.loc))
 							M << global_boom
-
+		if(devastation_range > 0)
+			for(var/obj/mecha/E in epicenter.contents) //Mech user shouldn't survive an explosion on the same turf he's on, most likely from inside the mech itself
+				E.Destroy()
 		if(heavy_impact_range > 1)
 			if(smoke)
 				var/datum/effect_system/explosion/smoke/E = new/datum/effect_system/explosion/smoke()


### PR DESCRIPTION
... if the explosion is big enough. Previously the mech would completely shield the user, even if the explosion was from inside the mech. Like in the user's backpack, or chest.

Fixes #10460

🆑
tweak: Large explosions now kill a mech's user if the explosion happens on the same tile as a mech (IE from inside the mech, or right under the mech).
/🆑
