### PR TITLE
Fixes #7765 simple_animal vent crawl vision

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -561,17 +561,16 @@
 /mob/living/simple_animal/proc/sentience_act() //Called when a simple animal gains sentience via gold slime potion
 	return
 
-/mob/living/simple_animal/update_sight(reset_sight = FALSE)
+/mob/living/simple_animal/update_sight()
 	if(!client)
 		return
 	if(stat == DEAD)
 		grant_death_vision()
 		return
 
-	if(reset_sight)
-		see_invisible = initial(see_invisible)
-		see_in_dark = initial(see_in_dark)
-		sight = initial(sight)
+	see_invisible = initial(see_invisible)
+	see_in_dark = initial(see_in_dark)
+	sight = initial(sight)
 
 	if(client.eye != src)
 		var/atom/A = client.eye


### PR DESCRIPTION
Fixes #7765

Vision from vent crawling would carry outside the vent for simple animals but not carbon species, causing annoyance for the rest of a round after vent crawling.
This should be fixed now after comparing update_sight() for simple_animals vs carbon mobs.

:cl:
fix: Fixes vent crawl vision sticking around for simple_animals.
/:cl:

