### PR TITLE
Fixed anomalies being disabled by random radio traffic.

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -148,6 +148,7 @@
 
 	for(var/mob/O in hearers(1, loc))
 		O.show_message("[bicon(src)] *beep* *beep*", 3, "*beep* *beep*", 2)
+	return TRUE
 
 /obj/item/assembly/signaler/proc/set_frequency(new_frequency)
 	if(!radio_controller)
@@ -167,9 +168,9 @@
 	receiving = TRUE
 
 /obj/item/assembly/signaler/anomaly/receive_signal(datum/signal/signal)
-	..()
-	for(var/obj/effect/anomaly/A in orange(0, src))
-		A.anomalyNeutralize()
+	if(..())
+		for(var/obj/effect/anomaly/A in orange(0, src))
+			A.anomalyNeutralize()
 
 /obj/item/assembly/signaler/anomaly/attack_self()
 	return


### PR DESCRIPTION
**What does this PR do:**
The anomalies did not check if the code was correct when receiving radio signals.
This led to anomalies being immediately disabled upon spawn if the anomaly in question chose a frequency that had a lot of traffic on it (for example air alarms).

**Changelog:**
:cl: uc_guy
fix: Fixed anomalies being disabled by random radio traffic.
/:cl:

