### PR TITLE
Fixes snow machines being unorderable at roundstart

### DIFF
--- a/code/modules/holiday/christmas.dm
+++ b/code/modules/holiday/christmas.dm
@@ -6,8 +6,10 @@
 				new /obj/item/a_gift(T)
 	for(var/mob/living/simple_animal/pet/corgi/Ian/Ian in GLOB.mob_list)
 		Ian.place_on_head(new /obj/item/clothing/head/helmet/space/santahat(Ian))
-	var/datum/supply_packs/xmas = SSshuttle.supply_packs["[/datum/supply_packs/misc/snow_machine]"] //Snow!
-	xmas.special_enabled = TRUE
+//The following spawn is necessary as both the timer and the shuttle systems initialise after the events system does, so we can't add stuff to the shuttle system as it doesn't exist yet and we can't use a timer
+	spawn(60 SECONDS)
+		var/datum/supply_packs/xmas = SSshuttle.supply_packs["[/datum/supply_packs/misc/snow_machine]"]
+		xmas.special_enabled = TRUE
 
 /datum/holiday/xmas/handle_event()
 	spawnTree()


### PR DESCRIPTION
Fixes an oversight where the `/datum/holiday/xmas/celebrate()` proc would fail to add a snow machine crate to the list of crates. This happened because the event system initialises before the shuttle system does, therefore it would fail to add a crate to the list of crates available.

I didn't notice this initally as I used the proc directly to add the crate to the list, which works perfectly well when the shuttle system is initialised.

:cl:
fix: Fixes a bug preventing snow machine crates from being orderable at roundstart. Ho ho ho!
/:cl: