### PR TITLE
Allows jetpacks to work in suit storage slot

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -13,6 +13,8 @@
 	var/obj/item/tank/jetpack/thrust
 	if(istype(back,/obj/item/tank/jetpack))
 		thrust = back
+	else if(istype(s_store,/obj/item/tank/jetpack))
+		thrust = s_store
 	else if(istype(back,/obj/item/rig))
 		var/obj/item/rig/rig = back
 		for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)


### PR DESCRIPTION
**What does this PR do:**
Makes jetpacks actually work when they are on the suit storage slot.

**Changelog:**
:cl: Eschess
add: Jetpacks work properly when placed on suit slot
/:cl:

