### PR TITLE
Removes "name here" from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ If you did not make a map or sprite edit, you may leave this section blank. You 
 
 **Changelog:**
 *Remove this line, and appropriate fields from the changelog*
-:cl: name here
+:cl:
 add: Added new things
 del: Removed old things
 tweak: tweaked a few things


### PR DESCRIPTION
So many people don't change "name here" for whatever reason and it's not needed since most people have their github name as the name they'd put in "name here" anyways.


:cl:
del: Removes "name here" from PR template
/ 🆑 