### PR TITLE
Added Syndicate Officer to the newscaster job blacklist

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -114,7 +114,8 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 		/datum/job/chaplain,
 		/datum/job/ntnavyofficer,
 		/datum/job/ntspecops,
-		/datum/job/civilian)
+		/datum/job/civilian,
+		/datum/job/syndicateofficer)
 
 	var/static/REDACTED = "<b class='bad'>\[REDACTED\]</b>"
 	light_range = 0


### PR DESCRIPTION
**What does this PR do:**
It blacklists the Syndicate officer from the newscaster job recruitment. fixes #10491

**Changelog:**
:cl:
fix: Syndicate Officer won't show in nt recruitment anymore
/:cl:

