### PR TITLE
[Fix] Flashbangs inside containers now work properly

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -53,7 +53,7 @@
 
 
 //Bang
-	if((loc == M) || loc == M.loc)//Holding on person or being exactly where lies is significantly more dangerous and voids protection
+	if(get_turf(M) == get_turf(src))//Holding on person or being exactly where lies is significantly more dangerous and voids protection
 		M.Stun(10)
 		M.Weaken(10)
 	if(!ear_safety)


### PR DESCRIPTION
**What does this PR do:**
fixes:#10470

Previously flashbangs put into containers would not properly affect those who held the container. loc would be the turf for the mob, but the container for the flashbang. get_turf() fixes this.

**Changelog:**
:cl:

fix: Fixed flashbangs inside containers not interacting properly
/:cl:

