### PR TITLE
[Fix] Mutadone now removes ongoing dizziness when removing Dizzy

### DIFF
--- a/code/game/dna/genes/vg_disabilities.dm
+++ b/code/game/dna/genes/vg_disabilities.dm
@@ -36,3 +36,7 @@
 		return
 	if(DIZZY in M.mutations)
 		M.Dizzy(300)
+
+/datum/dna/gene/disability/dizzy/deactivate(mob/living/M, connected, flags)
+	. = ..()
+	M.SetDizzy(0)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -737,6 +737,10 @@
 	var/needs_update = M.mutations.len > 0 || M.disabilities > 0
 
 	if(needs_update)
+		var/mut
+		for(mut in M.mutations) //can be used to do specific things at mutations. values in _DEFINE/genetics.dm
+			if(mut == 210) //210 is Dizzy
+				M.SetDizzy(0)
 		for(var/block=1;block<=DNA_SE_LENGTH;block++)
 			M.dna.SetSEState(block,0, 1)
 			genemutcheck(M,block,null,MUTCHK_FORCED)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -737,10 +737,6 @@
 	var/needs_update = M.mutations.len > 0 || M.disabilities > 0
 
 	if(needs_update)
-		var/mut
-		for(mut in M.mutations) //can be used to do specific things at mutations. values in _DEFINE/genetics.dm
-			if(mut == 210) //210 is Dizzy
-				M.SetDizzy(0)
 		for(var/block=1;block<=DNA_SE_LENGTH;block++)
 			M.dna.SetSEState(block,0, 1)
 			genemutcheck(M,block,null,MUTCHK_FORCED)


### PR DESCRIPTION
**What does this PR do:**
fixes:#10243

Mutadone now fixes dizziness caused by the Dizzy mutation, instead of having it take 5 minutes to dissipate. The for loop in place can also be used for other on-remove effects to other mutations. A check is in place to make sure that it only removes dizziness if the mob is affected by Dizzy.

**Changelog:**
:cl:
fix: Mutadone removes dizziness immediately instead of taking 5 minutes
/:cl:

