### PR TITLE
Fixed Swedish accent while being muzzled

### DIFF
--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -143,7 +143,8 @@
 	message = replacetextEx(message,"O",pick("Ö","Ø","O"))
 	message = replacetextEx(message,"o",pick("ö","ø","o"))
 	if(prob(30))
-		message += " Bork[pick("",", bork",", bork, bork")]!"
+		if(!M.is_muzzled())
+			message += " Bork[pick("",", bork",", bork, bork")]!"
 	return message
 
 // WAS: /datum/bioEffect/unintelligable

--- a/code/game/dna/genes/goon_disabilities.dm
+++ b/code/game/dna/genes/goon_disabilities.dm
@@ -142,9 +142,8 @@
 	message = replacetextEx(message,"bo","bjo")
 	message = replacetextEx(message,"O",pick("Ö","Ø","O"))
 	message = replacetextEx(message,"o",pick("ö","ø","o"))
-	if(prob(30))
-		if(!M.is_muzzled())
-			message += " Bork[pick("",", bork",", bork, bork")]!"
+	if(prob(30) && !M.is_muzzled())
+		message += " Bork[pick("",", bork",", bork, bork")]!"
 	return message
 
 // WAS: /datum/bioEffect/unintelligable


### PR DESCRIPTION
**What does this PR do:**
Mob will no longer Bork when beeing muzzled with tape while having a Swedish accent. Fixes #10483 

**Changelog:**
:cl:
fix: no bork in swedish accent while muzzled anymore
/:cl: