### PR TITLE
Refactor and buff wizard force wall, add greater force wall

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -79,6 +79,7 @@
 
 	action_icon_state = "mime"
 	action_background_icon_state = "bg_mime"
+	large = TRUE
 
 /obj/effect/proc_holder/spell/targeted/forcewall/mime/Click()
 	if(usr && usr.mind)

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -185,49 +185,41 @@
 	sound1 = 'sound/magic/Teleport_diss.ogg'
 	sound2 = 'sound/magic/Teleport_app.ogg'
 
-/obj/effect/proc_holder/spell/aoe_turf/conjure/forcewall
-	name = "Forcewall"
-	desc = "This spell creates an unbreakable wall that lasts for 30 seconds and does not need wizard garb."
-
-	school = "transmutation"
-	charge_max = 100
-	clothes_req = 0
-	invocation = "TARCOL MINTI ZHERI"
-	invocation_type = "whisper"
-	range = 0
-	cooldown_min = 50 //12 deciseconds reduction per rank
-
-	summon_type = list("/obj/effect/forcefield")
-	summon_lifespan = 300
-
-	action_icon_state = "shield"
-	cast_sound = 'sound/magic/ForceWall.ogg'
-
 /obj/effect/proc_holder/spell/targeted/forcewall
-	name = "Greater Forcewall"
-	desc = "Create a magical barrier that only you can pass through."
+	name = "Force Wall"
+	desc = "This spell creates a small unbreakable wall that only you can pass through, and does not need wizard garb. Lasts 30 seconds."
 
 	school = "transmutation"
 	charge_max = 100
 	clothes_req = FALSE
 	invocation = "TARCOL MINTI ZHERI"
-	invocation_type = "shout"
+	invocation_type = "whisper"
 	sound = 'sound/magic/ForceWall.ogg'
 	action_icon_state = "shield"
 	range = -1
 	include_user = TRUE
 	cooldown_min = 50 //12 deciseconds reduction per rank
 	var/wall_type = /obj/effect/forcefield/wizard
+	var/large = FALSE
 
-/obj/effect/proc_holder/spell/targeted/forcewall/cast(list/targets,mob/user = usr)
-	new wall_type(get_turf(user),user)
-	if(user.dir == SOUTH || user.dir == NORTH)
-		new wall_type(get_step(user, EAST),user)
-		new wall_type(get_step(user, WEST),user)
-	else
-		new wall_type(get_step(user, NORTH),user)
-		new wall_type(get_step(user, SOUTH),user)
+/obj/effect/proc_holder/spell/targeted/forcewall/cast(list/targets, mob/user = usr)
+	new wall_type(get_turf(user), user)
+	if(large) //Extra THICK
+		if(user.dir == SOUTH || user.dir == NORTH)
+			new wall_type(get_step(user, EAST), user)
+			new wall_type(get_step(user, WEST), user)
+		else
+			new wall_type(get_step(user, NORTH), user)
+			new wall_type(get_step(user, SOUTH), user)
 
+/obj/effect/proc_holder/spell/targeted/forcewall/greater
+	name = "Greater Force Wall"
+	desc = "Create a larger magical barrier that only you can pass through, but requires wizard garb. Lasts 30 seconds."
+
+	clothes_req = TRUE
+	invocation = "TARCOL GRANDI ZHERI"
+	invocation_type = "shout"
+	large = TRUE
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	name = "Stop Time"

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -68,7 +68,7 @@
 						to_chat(M, "<B>Your service has not gone unrewarded, however. Studying under [H.real_name], you have learned reality bending mobility spells. You are able to cast teleport and ethereal jaunt.")
 					if("healing")
 						M.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/charge(null))
-						M.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/forcewall(null))
+						M.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/forcewall(null))
 						M.equip_to_slot_or_del(new /obj/item/gun/magic/staff/healing(M), slot_r_hand)
 						to_chat(M, "<B>Your service has not gone unrewarded, however. Studying under [H.real_name], you have learned livesaving survival spells. You are able to cast charge and forcewall.")
 					if("robeless")

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -161,8 +161,15 @@
 
 /datum/spellbook_entry/forcewall
 	name = "Force Wall"
-	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/forcewall
+	spell_type = /obj/effect/proc_holder/spell/targeted/forcewall
 	log_name = "FW"
+	category = "Defensive"
+	cost = 1
+
+/datum/spellbook_entry/greaterforcewall
+	name = "Greater Force Wall"
+	spell_type = /obj/effect/proc_holder/spell/targeted/forcewall/greater
+	log_name = "GFW"
 	category = "Defensive"
 	cost = 1
 
@@ -791,7 +798,7 @@
 	stored_swap = null
 
 /obj/item/spellbook/oneuse/forcewall
-	spell = /obj/effect/proc_holder/spell/aoe_turf/conjure/forcewall
+	spell = /obj/effect/proc_holder/spell/targeted/forcewall
 	spellname = "forcewall"
 	icon_state ="bookforcewall"
 	desc = "This book has a dedication to mimes everywhere inside the front cover."

--- a/code/game/objects/effects/forcefields.dm
+++ b/code/game/objects/effects/forcefields.dm
@@ -7,6 +7,12 @@
 	opacity = 0
 	density = 1
 	unacidable = 1
+	var/lifetime = 30 SECONDS
+
+/obj/effect/forcefield/New()
+	..()
+	if(lifetime)
+		QDEL_IN(src, lifetime)
 
 /obj/effect/forcefield/CanAtmosPass(turf/T)
 	return !density
@@ -29,12 +35,6 @@
 	icon_state = "empty"
 	name = "invisible wall"
 	desc = "You have a bad feeling about this."
-	var/lifetime = 30 SECONDS
-
-/obj/effect/forcefield/mime/New()
-	..()
-	if(lifetime)
-		QDEL_IN(src, lifetime)
 
 /obj/effect/forcefield/mime/advanced
 	name = "invisible blockade"


### PR DESCRIPTION
Wizard forcewalls can now be walked through by the wizard that summoned the wall. Wizard can still be hit if inside the wall.

Refactored wizard forcewall (no gameplay change other than mentioned above), and added greater forcewall as a subtype that spawns a larger wall but requires wizard garb. Cost 1 spellpoint.

![image](https://user-images.githubusercontent.com/22121511/50412765-d438ea00-0801-11e9-9061-8b0d9677bee2.png)

🆑
add: Wizard forcewalls can now be walked through by the wizard summoning them.
add: Added a new spell to the wizard spellbook, "Greater Force Wall". Summons a larger wall than the regular one, but requires wizard robes.
/🆑


