### PR TITLE
Few ERT Tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -88,7 +88,7 @@
 	update_icon()
 
 /obj/item/storage/belt/utility/chief
-	name = "Chief Engineer's toolbelt"
+	name = "advanced toolbelt"
 	desc = "Holds tools, looks snazzy"
 	icon_state = "utilitybelt_ce"
 	item_state = "utility_ce"
@@ -139,7 +139,7 @@
 	max_w_class = WEIGHT_CLASS_NORMAL
 	max_combined_w_class = 17
 	use_to_pickup = 1
-	name = "Surgical Belt"
+	name = "surgical belt"
 	desc = "Can hold various surgical tools."
 	storage_slots = 9
 	use_item_overlays = 1

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -356,10 +356,8 @@
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 		/obj/item/bodyanalyzer/advanced = 1,
 		/obj/item/extinguisher/mini = 1,
-		/obj/item/storage/belt/medical/surgery/loaded = 1,
 		/obj/item/roller = 1,
-		/obj/item/healthanalyzer = 1,
-		/obj/item/healthupgrade = 1
+		/obj/item/healthanalyzer/advanced = 1
 
 		)
 

--- a/code/modules/response_team/ert_outfits.dm
+++ b/code/modules/response_team/ert_outfits.dm
@@ -52,7 +52,8 @@
 		/obj/item/clothing/head/helmet/ert/command = 1,
 		/obj/item/clothing/mask/gas/sechailer = 1,
 		/obj/item/restraints/handcuffs = 1,
-		/obj/item/storage/lockbox/mindshield = 1
+		/obj/item/storage/lockbox/mindshield = 1,
+		/obj/item/flashlight = 1
 	)
 
 /datum/outfit/job/centcom/response_team/commander/red
@@ -216,7 +217,8 @@
 		/obj/item/clothing/mask/gas = 1,
 		/obj/item/t_scanner = 1,
 		/obj/item/stack/sheet/glass/fifty = 1,
-		/obj/item/stack/sheet/metal/fifty = 1
+		/obj/item/stack/sheet/metal/fifty = 1,
+		/obj/item/flashlight = 1
 	)
 
 /datum/outfit/job/centcom/response_team/engineer/red
@@ -224,7 +226,7 @@
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	gloves = /obj/item/clothing/gloves/color/yellow
 	belt = /obj/item/storage/belt/utility/chief/full
-	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/engineer/gamma
 	suit_store = /obj/item/tank/emergency_oxygen/engi
 	glasses = /obj/item/clothing/glasses/meson
 	cybernetic_implants = list(
@@ -235,7 +237,7 @@
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 
 	backpack_contents = list(
-		/obj/item/clothing/head/helmet/space/hardsuit/ert/engineer = 1,
+		/obj/item/clothing/head/helmet/space/hardsuit/ert/engineer/gamma = 1,
 		/obj/item/clothing/mask/gas = 1,
 		/obj/item/rcd/preloaded = 1,
 		/obj/item/rcd_ammo = 3,
@@ -302,7 +304,9 @@
 		/obj/item/storage/firstaid/regular = 1,
 		/obj/item/storage/box/autoinjectors = 1,
 		/obj/item/roller = 1,
-		/obj/item/storage/pill_bottle/ert = 1
+		/obj/item/storage/pill_bottle/ert = 1,
+		/obj/item/flashlight = 1,
+		/obj/item/healthupgrade = 1
 	)
 
 /datum/outfit/job/centcom/response_team/medic/red
@@ -330,7 +334,8 @@
 		/obj/item/storage/box/autoinjectors = 1,
 		/obj/item/roller = 1,
 		/obj/item/clothing/shoes/magboots = 1,
-		/obj/item/bodyanalyzer = 1
+		/obj/item/bodyanalyzer = 1,
+		/obj/item/healthupgrade = 1
 	)
 
 /datum/outfit/job/centcom/response_team/medic/gamma
@@ -352,7 +357,10 @@
 		/obj/item/bodyanalyzer/advanced = 1,
 		/obj/item/extinguisher/mini = 1,
 		/obj/item/storage/belt/medical/surgery/loaded = 1,
-		/obj/item/roller = 1
+		/obj/item/roller = 1,
+		/obj/item/healthanalyzer = 1,
+		/obj/item/healthupgrade = 1
+
 		)
 
 	cybernetic_implants = list(
@@ -379,7 +387,8 @@
 	pda = /obj/item/pda/centcom
 	backpack_contents = list(
 		/obj/item/clothing/mask/gas/sechailer/swat = 1,
-		/obj/item/storage/box/zipties = 1
+		/obj/item/storage/box/zipties = 1,
+		/obj/item/flashlight/seclite = 1
 		)
 
 /datum/outfit/job/centcom/response_team/paranormal/amber


### PR DESCRIPTION
This does a few fixes and tweaks to ERT loadouts.

Amber ERT now spawn with a flashlight.
Paranormal ERT now spawn with a seclite.
Medical ERT now receive a medical analyser upgrade so they can properly help people.
Red Engineering ERT now receive an Elite ERT Hardsuit, to go with the theme that they get an upgraded hardsuit to deal with the toughest conditions.
Fixed surgery belt capitalisation and renamed Chief Engineer's toolbelt to advanced toolbelt, as ERT having CE toolbelts looked a little odd.

:cl: Spartan
tweak: ERT Medics now spawn with a medical analyser upgrade.
tweak: Amber ERT now spawn with a flashlight.
tweak: Red Engineer ERT now have an Elite ERT Hardsuit.
tweak: Paranormal ERT now spawn with a seclite.
tweak: CE toolbelt renamed.
grammar: Surgery Belt > surgery belt
/:cl:

