### PR TITLE
Fixed syndicate officer showing in card modification/identification consoles

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -24,7 +24,8 @@ var/time_last_changed_position = 0
 	var/list/blacklisted_full = list(
 		/datum/job/ntnavyofficer,
 		/datum/job/ntspecops,
-		/datum/job/civilian
+		/datum/job/civilian,
+		/datum/job/syndicateofficer
 	)
 	// Jobs that appear in the list, and you can prioritize, but not open/close slots for
 	var/list/blacklisted_partial = list(

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -34,7 +34,8 @@
 		/datum/job/chaplain,
 		/datum/job/ntnavyofficer,
 		/datum/job/ntspecops,
-		/datum/job/civilian
+		/datum/job/civilian,
+		/datum/job/syndicateofficer
 	)
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %


### PR DESCRIPTION
**What does this PR do:**
Syndicate officer was still showing in the identification computer and id card modification program. Fixes #10510

**Changelog:**
:cl:
fix: Syndicate officer will not show in card modification/identification consoles anymore
/:cl:

