### PR TITLE
Holopara say goes to host communication now

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -161,8 +161,12 @@
 	buckled = null
 	cooldown = world.time + 30
 
-/mob/living/simple_animal/hostile/guardian/proc/Communicate()
-	var/input = stripped_input(src, "Please enter a message to tell your summoner.", "Guardian", "")
+/mob/living/simple_animal/hostile/guardian/proc/Communicate(message)
+	var/input
+	if(!message)
+		input = stripped_input(src, "Please enter a message to tell your summoner.", "Guardian", "")
+	else
+		input = message
 	if(!input) return
 
 	for(var/mob/M in GLOB.mob_list)
@@ -172,6 +176,13 @@
 		else if(M in GLOB.dead_mob_list)
 			to_chat(M, "<span class='changeling'><i>Guardian Communication from <b>[src]</b> ([ghost_follow_link(src, ghost=M)]): [input]</i>")
 	to_chat(src, "<span class='changeling'><i>[src]:</i> [input]</span>")
+
+//override set to true if message should be passed through instead of going to host communication
+/mob/living/simple_animal/hostile/guardian/say(message, override = FALSE)
+	if(adminseal || override)//if it's an admin-spawned guardian without a host it can still talk normally
+		return ..(message)
+	Communicate(message)
+	
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleMode()
 	to_chat(src, "<span class='danger'>You dont have another mode!</span>")

--- a/code/game/gamemodes/miniantags/guardian/types/standard.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/standard.dm
@@ -24,7 +24,7 @@
 		if(length(battlecry) > 11)//no more then 11 letters in a battle cry.
 			visible_message("<span class='danger'>[src] punches [target]!</span>")
 		else
-			say("[battlecry][battlecry][battlecry][battlecry][battlecry]")
+			say("[battlecry][battlecry][battlecry][battlecry][battlecry]", TRUE)
 		playsound(loc, attack_sound, 50, 1, 1)
 		playsound(loc, attack_sound, 50, 1, 1)
 		playsound(loc, attack_sound, 50, 1, 1)


### PR DESCRIPTION
**What does this PR do:**
Holoparas using the say verb/F3 hotkey will now communicate with their host instead of saying it out loud, exposing their host while being totally incomprehensible. The only exception is hostless/adminspawned guardians.

**Changelog:**
:cl:
tweak: Holoparasites/Guardians using the say verb now use host communication
/:cl:

