### PR TITLE
Adds 'Grenades and Explosives' Category to Uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -531,15 +531,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/batterer
 	cost = 5
 
-/datum/uplink_item/dangerous/manhacks
-	name = "Viscerator Delivery Grenade"
-	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred any non-operatives in the area."
-	reference = "VDG"
-	item = /obj/item/grenade/spawnergrenade/manhacks
-	cost = 6
-	gamemodes = list(/datum/game_mode/nuclear)
-	surplus = 35
-
 /datum/uplink_item/ammo/bioterror
 	name = "Box of Bioterror Syringes"
 	desc = "A box full of preloaded syringes, containing various chemicals that seize up the victim's motor and broca system , making it impossible for them to move or speak while in their system."
@@ -547,46 +538,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/bioterror
 	cost = 5
 	gamemodes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/dangerous/saringrenades
-	name = "Sarin Gas Grenades"
-	desc = "A box of four (4) grenades filled with Sarin, a deadly neurotoxin. Use extreme caution when handling and be sure to vacate the premise after using; ensure communication is maintained with team to avoid accidental gassings."
-	reference = "TGG"
-	item = /obj/item/storage/box/syndie_kit/sarin
-	cost = 12
-	gamemodes = list(/datum/game_mode/nuclear)
-	surplus = 0
-
-/datum/uplink_item/dangerous/atmosgrenades
-	name = "Atmos Grenades"
-	desc = "A box of two (2) grenades that wreak havoc with the atmosphere of the target area. Capable of engulfing a large area in lit plasma, or N2O. Deploy with extreme caution!"
-	reference = "AGG"
-	item = /obj/item/storage/box/syndie_kit/atmosgasgrenades
-	cost = 11
-	surplus = 0
-
-/datum/uplink_item/dangerous/grenadier
-	name = "Grenadier's belt"
-	desc = "A belt containing 25 lethally dangerous and destructive grenades."
-	item = /obj/item/storage/belt/grenade/full
-	cost = 30
-	surplus = 0
-	gamemodes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/dangerous/emp
-	name = "EMP Grenades and Implanter Kit"
-	desc = "A box that contains two EMP grenades and an EMP implant. Useful to disrupt communication, \
-			security's energy weapons, and silicon lifeforms when you're in a tight spot."
-	reference = "EMPK"
-	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 2
-
-/datum/uplink_item/dangerous/syndicate_minibomb
-	name = "Syndicate Minibomb"
-	desc = "The minibomb is a grenade with a five-second fuse."
-	reference = "SMB"
-	item = /obj/item/grenade/syndieminibomb
-	cost = 6
 
 /datum/uplink_item/dangerous/gygax
 	name = "Gygax Exosuit"
@@ -891,13 +842,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	gamemodes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/stealthy_weapons/detomatix
-	name = "Detomatix PDA Cartridge"
-	desc = "When inserted into a personal digital assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
-	reference = "DEPC"
-	item = /obj/item/cartridge/syndicate
-	cost = 6
-
 /datum/uplink_item/stealthy_weapons/silencer
 	name = "Universal Suppressor"
 	desc = "Fitted for use on any small caliber weapon with a threaded barrel, this suppressor will silence the shots of the weapon for increased stealth and superior ambushing capability."
@@ -905,14 +849,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/suppressor
 	cost = 1
 	surplus = 10
-
-/datum/uplink_item/stealthy_weapons/pizza_bomb
-	name = "Pizza Bomb"
-	desc = "A pizza box with a bomb taped inside of it. The timer needs to be set by opening the box; afterwards, opening the box again will trigger the detonation."
-	reference = "PB"
-	item = /obj/item/pizza_bomb
-	cost = 5
-	surplus = 8
 
 /datum/uplink_item/stealthy_weapons/dehy_carp
 	name = "Dehydrated Space Carp"
@@ -928,12 +864,104 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/glasses/hud/security/chameleon
 	cost = 2
 
-/datum/uplink_item/stealthy_weapons/chameleonflag
+// GRENADES AND EXPLOSIVES
+
+/datum/uplink_item/explosives
+	category = "Grenades and Explosives"
+
+/datum/uplink_item/explosives/plastic_explosives
+	name = "Composition C-4"
+	desc = "C-4 is plastic explosive of the common variety Composition C. You can use it to breach walls or connect an assembly to its wiring to make it remotely detonable. It has a modifiable timer with a minimum setting of 10 seconds."
+	reference = "C4"
+	item = /obj/item/grenade/plastic/c4
+	cost = 1
+
+/datum/uplink_item/explosives/breaching_charge
+	name = "Composition X-4"
+	desc = "X-4 is a shaped charge designed to be safe to the user while causing maximum damage to the occupants of the room beach breached. It has a modifiable timer with a minimum setting of 10 seconds."
+	reference = "X4"
+	item = /obj/item/grenade/plastic/x4
+	cost = 2
+	gamemodes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/explosives/syndicate_bomb
+	name = "Syndicate Bomb"
+	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 60 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
+	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
+	reference = "SB"
+	item = /obj/item/radio/beacon/syndicate/bomb
+	cost = 11
+
+/datum/uplink_item/explosives/syndicate_minibomb
+	name = "Syndicate Minibomb"
+	desc = "The minibomb is a grenade with a five-second fuse."
+	reference = "SMB"
+	item = /obj/item/grenade/syndieminibomb
+	cost = 6
+
+/datum/uplink_item/explosives/detomatix
+	name = "Detomatix PDA Cartridge"
+	desc = "When inserted into a personal digital assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
+	reference = "DEPC"
+	item = /obj/item/cartridge/syndicate
+	cost = 6
+
+/datum/uplink_item/explosives/pizza_bomb
+	name = "Pizza Bomb"
+	desc = "A pizza box with a bomb taped inside of it. The timer needs to be set by opening the box; afterwards, opening the box again will trigger the detonation."
+	reference = "PB"
+	item = /obj/item/pizza_bomb
+	cost = 5
+	surplus = 8
+
+/datum/uplink_item/explosives/chameleonflag
 	name = "Chameleon Flag"
 	desc = "A flag that can be disguised as any other known flag. There is a heat sensitive bomb loaded into the pole that will be detonated if the flag is lit on fire."
 	reference = "CHFLAG"
 	item = /obj/item/flag/chameleon
 	cost = 7
+
+/datum/uplink_item/explosives/grenadier
+	name = "Grenadier's belt"
+	desc = "A belt containing 25 lethally dangerous and destructive grenades."
+	item = /obj/item/storage/belt/grenade/full
+	cost = 30
+	surplus = 0
+	gamemodes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/explosives/manhacks
+	name = "Viscerator Delivery Grenade"
+	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred any non-operatives in the area."
+	reference = "VDG"
+	item = /obj/item/grenade/spawnergrenade/manhacks
+	cost = 6
+	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 35
+
+/datum/uplink_item/explosives/saringrenades
+	name = "Sarin Gas Grenades"
+	desc = "A box of four (4) grenades filled with Sarin, a deadly neurotoxin. Use extreme caution when handling and be sure to vacate the premise after using; ensure communication is maintained with team to avoid accidental gassings."
+	reference = "TGG"
+	item = /obj/item/storage/box/syndie_kit/sarin
+	cost = 12
+	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
+
+/datum/uplink_item/explosives/atmosgrenades
+	name = "Atmos Grenades"
+	desc = "A box of two (2) grenades that wreak havoc with the atmosphere of the target area. Capable of engulfing a large area in lit plasma, or N2O. Deploy with extreme caution!"
+	reference = "AGG"
+	item = /obj/item/storage/box/syndie_kit/atmosgasgrenades
+	cost = 11
+	surplus = 0
+
+/datum/uplink_item/explosives/emp
+	name = "EMP Grenades and Implanter Kit"
+	desc = "A box that contains two EMP grenades and an EMP implant. Useful to disrupt communication, \
+			security's energy weapons, and silicon lifeforms when you're in a tight spot."
+	reference = "EMPK"
+	item = /obj/item/storage/box/syndie_kit/emp
+	cost = 2
 
 // STEALTHY TOOLS
 
@@ -1227,21 +1255,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	excludefrom = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/device_tools/plastic_explosives
-	name = "Composition C-4"
-	desc = "C-4 is plastic explosive of the common variety Composition C. You can use it to breach walls or connect an assembly to its wiring to make it remotely detonable. It has a modifiable timer with a minimum setting of 10 seconds."
-	reference = "C4"
-	item = /obj/item/grenade/plastic/c4
-	cost = 1
-
-/datum/uplink_item/device_tools/breaching_charge
-	name = "Composition X-4"
-	desc = "X-4 is a shaped charge designed to be safe to the user while causing maximum damage to the occupants of the room beach breached. It has a modifiable timer with a minimum setting of 10 seconds."
-	reference = "X4"
-	item = /obj/item/grenade/plastic/x4
-	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/device_tools/powersink
 	name = "Power Sink"
 	desc = "When screwed to wiring attached to an electric grid, then activated, this large device places excessive load on the grid, causing a stationwide blackout. The sink cannot be carried because of its excessive size. Ordering this sends you a small beacon that will teleport the power sink to your location on activation."
@@ -1268,14 +1281,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	hijack_only = FALSE // This inherited version exists so nukies can use it while keeping the original hijack only
 	excludefrom = list()
 	gamemodes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/device_tools/syndicate_bomb
-	name = "Syndicate Bomb"
-	desc = "The Syndicate Bomb has an adjustable timer with a minimum setting of 60 seconds. Ordering the bomb sends you a small beacon, which will teleport the explosive to your location when you activate it. \
-	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
-	reference = "SB"
-	item = /obj/item/radio/beacon/syndicate/bomb
-	cost = 11
 
 /datum/uplink_item/device_tools/syndicate_detonator
 	name = "Syndicate Detonator"


### PR DESCRIPTION
**What does this PR do:**
Adds a new category to the uplink in which all grenade and explosive related items are stored. Intended as a QOL change to make it easier to find these items rather than trying to remember which tab the emp grenades or syndi bomb is stored in.

The best traitor item is of course at the top of the list, along with anything classed as a grenade or explosive.

Forgot to add this initially, but the idea for this came from a recent PR on tg which redid the entire uplink and added this new category in, so credit goes to them.

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**
:cl:
tweak: "Grenades and Explosives" category added to the uplink. Anything classed as such in the uplink has been moved here for easier access.
/:cl:

