### PR TITLE
fixed missiles spinning when shot from missile racks

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -346,7 +346,7 @@
 	if(heavy_missile)
 		M.heavy_missile = 1
 	playsound(chassis, fire_sound, 50, 1)
-	M.throw_at(target, missile_range, missile_speed)
+	M.throw_at(target, missile_range, missile_speed, spin = FALSE)
 	projectiles--
 	log_message("Fired from [name], targeting [target].")
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
**What does this PR do:**
stops missiles from spinning in air when shot from missile racks. fixes #10518 

**Changelog:**
:cl:
fix: missiles shot from missile racks in mechs will no longer spin in air
/:cl:

