### PR TITLE
Adds mecha voice modification kits

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -322,7 +322,7 @@ Recharging stations are available in robotics, the dormitory bathrooms, and the 
 
 /obj/screen/alert/nymph/Click()
 	if(!usr || !usr.client)
-		return		
+		return
 	if(isnymph(usr))
 		var/mob/living/simple_animal/diona/D = usr
 		return D.resist()
@@ -411,6 +411,21 @@ so as to remain in compliance with the most up-to-date laws."
 		to_chat(usr, "<span class='notice'>[M] disconnects from the port.</span>")
 	else
 		to_chat(usr, "<span class='notice'>[M] is not connected to a port at the moment.</span>")
+
+/obj/screen/alert/mech_nocell
+	name = "Missing Power Cell"
+	desc = "Mech has no power cell."
+	icon_state = "nocell"
+
+/obj/screen/alert/mech_emptycell
+	name = "Out of Power"
+	desc = "Mech is out of power."
+	icon_state = "emptycell"
+
+/obj/screen/alert/mech_lowcell
+	name = "Low Charge"
+	desc = "Mech is running out of power."
+	icon_state = "lowcell"
 
 //GUARDIANS
 /obj/screen/alert/cancharge

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -427,6 +427,11 @@ so as to remain in compliance with the most up-to-date laws."
 	desc = "Mech is running out of power."
 	icon_state = "lowcell"
 
+/obj/screen/alert/mech_maintenance
+	name = "Maintenance Protocols"
+	desc = "Maintenance protocols are currently in effect, most actions disabled."
+	icon_state = "locked"
+
 //GUARDIANS
 /obj/screen/alert/cancharge
 	name = "Charge Ready"

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -48,6 +48,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/gygax/dark
 	max_equip = 4
 	maxsize = 2
+	starting_voice = /obj/item/mecha_modkit/voice/syndicate
 
 /obj/mecha/combat/gygax/dark/loaded/New()
 	..()

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -15,6 +15,7 @@
 	wreckage = /obj/effect/decal/mecha_wreckage/honker
 	add_req_access = 0
 	max_equip = 3
+	starting_voice = /obj/item/mecha_modkit/voice/honk
 	var/squeak = 0
 
 /obj/mecha/combat/honker/loaded/New()

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -17,6 +17,7 @@
 	internal_damage_threshold = 25
 	force = 45
 	max_equip = 5
+	starting_voice = /obj/item/mecha_modkit/voice/nanotrasen
 
 /obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = 0)
 	. = ..()
@@ -89,6 +90,7 @@
 	initial_icon = "mauler"
 	operation_req_access = list(access_syndicate)
 	wreckage = /obj/effect/decal/mecha_wreckage/mauler
+	starting_voice = /obj/item/mecha_modkit/voice/syndicate
 
 /obj/mecha/combat/marauder/mauler/loaded/New()
 	..()

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -15,10 +15,11 @@
 	add_req_access = 0
 	internal_damage_threshold = 60
 	max_equip = 3
-	step_energy_drain = 3 
+	step_energy_drain = 3
 	normal_step_energy_drain = 3
 	stepsound = null
 	turnsound = null
+	starting_voice = /obj/item/mecha_modkit/voice/silent
 
 /obj/mecha/combat/reticence/loaded/New()
 	..()

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -34,9 +34,9 @@
 		chassis.occupant_message("<span class='danger'>The [src] is destroyed!</span>")
 		chassis.log_append_to_last("[src] is destroyed.",1)
 		if(istype(src, /obj/item/mecha_parts/mecha_equipment/weapon))
-			chassis.occupant << sound('sound/mecha/weapdestr.ogg', volume = 50)
+			chassis.occupant << sound(chassis.weapdestrsound, volume = 50)
 		else
-			chassis.occupant << sound('sound/mecha/critdestr.ogg', volume = 50)
+			chassis.occupant << sound(chassis.critdestrsound, volume = 50)
 		detach(chassis)
 	return ..()
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -885,14 +885,14 @@
 		qdel(P)
 
 	else if(istype(W, /obj/item/mecha_modkit))
-		if(add_req_access || maint_access)
-			var/obj/item/mecha_modkit/M = W
-			if(do_after_once(user, M.install_time, target = src))
-				M.install(src, user)
-			else
-				to_chat(user, "<span class='notice'>You stop installing [M].</span>")
-	else
-		return attacked_by(W, user)
+		if(occupant)
+			to_chat(user, "<span class='notice'>You can't access the mech's modification port while it is occupied.</span>")
+			return
+		var/obj/item/mecha_modkit/M = W
+		if(do_after_once(user, M.install_time, target = src))
+			M.install(src, user)
+		else
+			to_chat(user, "<span class='notice'>You stop installing [M].</span>")
 
 /obj/mecha/attacked_by(obj/item/I, mob/user)
 	log_message("Attacked by [I]. Attacker - [user]")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -76,6 +76,14 @@
 
 	var/stepsound = 'sound/mecha/mechstep.ogg'
 	var/turnsound = 'sound/mecha/mechturn.ogg'
+	var/nominalsound = 'sound/mecha/nominal.ogg'
+	var/zoomsound = 'sound/mecha/imag_enh.ogg'
+	var/critdestrsound = 'sound/mecha/critdestr.ogg'
+	var/weapdestrsound = 'sound/mecha/weapdestr.ogg'
+	var/lowpowersound = 'sound/mecha/lowpower.ogg'
+	var/longactivationsound = 'sound/mecha/nominal.ogg'
+	var/starting_voice = /obj/item/mecha_modkit/voice
+	var/activated = FALSE
 
 	var/melee_cooldown = 10
 	var/melee_can_hit = 1
@@ -120,6 +128,10 @@
 	diag_hud_set_mechcell()
 	diag_hud_set_mechstat()
 	diag_hud_set_mechtracking()
+
+	var/obj/item/mecha_modkit/voice/V = new starting_voice(src)
+	V.install(src)
+	qdel(V)
 
 ////////////////////////
 ////// Helpers /////////
@@ -872,6 +884,13 @@
 		user.drop_item()
 		qdel(P)
 
+	else if(istype(W, /obj/item/mecha_modkit))
+		if(add_req_access || maint_access)
+			var/obj/item/mecha_modkit/M = W
+			if(do_after_once(user, M.install_time, target = src))
+				M.install(src, user)
+			else
+				to_chat(user, "<span class='notice'>You stop installing [M].</span>")
 	else
 		return attacked_by(W, user)
 
@@ -993,7 +1012,7 @@
 	icon_state = initial(icon_state)
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
 	if(!hasInternalDamage())
-		occupant << sound('sound/mecha/nominal.ogg',volume=50)
+		occupant << sound(nominalsound, volume=50)
 	AI.cancel_camera()
 	AI.controlled_mech = src
 	AI.remote_control = src
@@ -1151,8 +1170,11 @@
 		icon_state = reset_icon()
 		dir = dir_in
 		playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
-		if(!hasInternalDamage())
-			occupant << sound('sound/mecha/nominal.ogg', volume = 50)
+		if(!activated)
+			occupant << sound(longactivationsound, volume = 50)
+			activated = TRUE
+		else if(!hasInternalDamage())
+			occupant << sound(nominalsound, volume = 50)
 		return 1
 	else
 		return 0
@@ -1208,7 +1230,7 @@
 		dir = dir_in
 		log_message("[mmi_as_oc] moved in as pilot.")
 		if(!hasInternalDamage())
-			to_chat(occupant, sound('sound/mecha/nominal.ogg',volume=50))
+			to_chat(occupant, sound(nominalsound, volume=50))
 		GrantActions(brainmob)
 		return 1
 	else

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1179,6 +1179,8 @@
 			activated = TRUE
 		else if(!hasInternalDamage())
 			occupant << sound(nominalsound, volume = 50)
+		if(state)
+			H.throw_alert("locked", /obj/screen/alert/mech_maintenance)
 		return 1
 	else
 		return 0
@@ -1261,6 +1263,7 @@
 		return
 	var/atom/movable/mob_container
 	occupant.clear_alert("charge")
+	occupant.clear_alert("locked")
 	occupant.clear_alert("mech damage")
 	occupant.clear_alert("mechaport")
 	occupant.clear_alert("mechaport_d")

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -187,7 +187,7 @@
 		chassis.occupant_message("<font color='[chassis.zoom_mode ? "blue" : "red"]'>Zoom mode [chassis.zoom_mode ? "en" : "dis"]abled.</font>")
 		if(chassis.zoom_mode)
 			owner.client.AddViewMod("mecha", 12)
-			SEND_SOUND(owner, sound('sound/mecha/imag_enh.ogg',volume=50))
+			SEND_SOUND(owner, sound(chassis.zoomsound, volume = 50))
 		else
 			owner.client.RemoveViewMod("mecha")
 		UpdateButtonIcon()

--- a/code/game/mecha/mecha_modkit.dm
+++ b/code/game/mecha/mecha_modkit.dm
@@ -1,0 +1,77 @@
+/obj/item/mecha_modkit
+	name = "mecha modification kit"
+	desc = "A kit to modify your mech. This one doesn't do anything."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "harddisk_mini"
+	var/install_time = 15
+
+/obj/item/mecha_modkit/proc/install(var/obj/mecha/mech, var/mob/user)
+	if(user)
+		to_chat(user, "<span class='notice'>You install [src] into [mech].</span>")
+	return TRUE
+
+/obj/item/mecha_modkit/voice
+	name = "mecha voice modification kit : Standard"
+	desc = "This modification kit updates a mech's onboard voice to Standard."
+	var/nominalsound = 'sound/mecha/nominal.ogg'
+	var/zoomsound = 'sound/mecha/imag_enh.ogg'
+	var/critdestrsound = 'sound/mecha/critdestr.ogg'
+	var/weapdestrsound = 'sound/mecha/weapdestr.ogg'
+	var/lowpowersound = 'sound/mecha/lowpower.ogg'
+	var/longactivationsound = 'sound/mecha/nominal.ogg'
+
+/obj/item/mecha_modkit/voice/install(var/obj/mecha/mech, var/mob/living/carbon/user)
+	if(istype(mech, /obj/mecha/combat/reticence) && user)
+		to_chat(user, "<span class='warning'>You attempt to install [src] into [mech], but an invisible barrier prevents you from doing so!</span>")
+		return FALSE
+	if(istype(mech, /obj/mecha/combat/honker) && user)
+		to_chat(user, "<span class='warning'>You attempt to install [src] into [mech], but you somehow trip before you get it in!</span>")
+		user.slip("your own foot", 8, 5, 0, 0, 1, "trip")
+		return FALSE
+	mech.nominalsound = nominalsound
+	mech.zoomsound = zoomsound
+	mech.critdestrsound = critdestrsound
+	mech.weapdestrsound = weapdestrsound
+	mech.lowpowersound = lowpowersound
+	mech.longactivationsound = longactivationsound
+	..()
+
+/obj/item/mecha_modkit/voice/nanotrasen
+	name = "mecha voice modification kit : Nanotrasen"
+	desc = "This modification kit updates a mech's onboard voice to Nanotrasen."
+	nominalsound = 'sound/mecha/nominalnano.ogg'
+	zoomsound = 'sound/mecha/imag_enhnano.ogg'
+	critdestrsound = 'sound/mecha/critdestrnano.ogg'
+	weapdestrsound = 'sound/mecha/weapdestrnano.ogg'
+	lowpowersound = 'sound/mecha/lowpowernano.ogg'
+	longactivationsound = 'sound/mecha/LongNanoActivation.ogg'
+
+/obj/item/mecha_modkit/voice/syndicate
+	name = "mecha voice modification kit : Syndicate"
+	desc = "This suspicious modification kit updates a mech's onboard voice to Syndicate."
+	nominalsound = 'sound/mecha/nominalsyndi.ogg'
+	zoomsound = 'sound/mecha/imag_enhsyndi.ogg'
+	critdestrsound = 'sound/mecha/critdestrsyndi.ogg'
+	weapdestrsound = 'sound/mecha/weapdestrsyndi.ogg'
+	lowpowersound = 'sound/mecha/lowpowersyndi.ogg'
+	longactivationsound = 'sound/mecha/LongSyndiActivation.ogg'
+
+/obj/item/mecha_modkit/voice/honk
+	name = "mecha voice modification kit : Honk"
+	desc = "This modification kit updates a mech's onboard voice to Honk. Why?"
+	nominalsound = 'sound/items/bikehorn.ogg'
+	zoomsound = 'sound/items/bikehorn.ogg'
+	critdestrsound = 'sound/items/Airhorn2.ogg'
+	weapdestrsound = 'sound/items/Airhorn2.ogg'
+	lowpowersound = 'sound/items/Airhorn2.ogg'
+	longactivationsound = 'sound/items/bikehorn.ogg'
+
+/obj/item/mecha_modkit/voice/silent
+	name = "mecha voice modification kit : Silent"
+	desc = "This modification kit silences a mech's onboard voice."
+	nominalsound = null
+	zoomsound = null
+	critdestrsound = null
+	weapdestrsound = null
+	lowpowersound = null
+	longactivationsound = null

--- a/code/game/mecha/mecha_modkit.dm
+++ b/code/game/mecha/mecha_modkit.dm
@@ -49,6 +49,7 @@
 /obj/item/mecha_modkit/voice/syndicate
 	name = "mecha voice modification kit : Syndicate"
 	desc = "This suspicious modification kit updates a mech's onboard voice to Syndicate."
+	origin_tech = "syndicate=1"
 	nominalsound = 'sound/mecha/nominalsyndi.ogg'
 	zoomsound = 'sound/mecha/imag_enhsyndi.ogg'
 	critdestrsound = 'sound/mecha/critdestrsyndi.ogg'

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -195,7 +195,7 @@
 						</head>
 						<body>
 						[add_req_access?"<a href='?src=[UID()];req_access=1;id_card=\ref[id_card];user=\ref[user]'>Edit operation keycodes</a>":null]
-						[maint_access?"<a href='?src=[UID()];maint_access=1;id_card=\ref[id_card];user=\ref[user]'>Initiate maintenance protocol</a>":null]
+						[maint_access?"<a href='?src=[UID()];maint_access=1;id_card=\ref[id_card];user=\ref[user]'>Initiate/Stop maintenance protocol</a>":null]
 						[(state>0) ?"<a href='?src=[UID()];set_internal_tank_valve=1;user=\ref[user]'>Set Cabin Air Pressure</a>":null]
 						</body>
 						</html>"}
@@ -317,9 +317,13 @@
 			if(state==0)
 				state = 1
 				to_chat(user, "The securing bolts are now exposed.")
+				if(occupant)
+					occupant.throw_alert("locked", /obj/screen/alert/mech_maintenance)
 			else if(state==1)
 				state = 0
 				to_chat(user, "The securing bolts are now hidden.")
+				if(occupant)
+					occupant.clear_alert("locked")
 			output_maintenance_dialog(afilter.getObj("id_card"),user)
 		return
 	if(href_list["set_internal_tank_valve"] && state >=1)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1185,3 +1185,54 @@
 	construction_time = 100
 	build_path = /obj/item/flash/synthetic
 	category = list("Misc")
+
+/datum/design/voice_standard
+	name = "Voice Modkit : Standard"
+	desc = "A modification kit that updates a mech's onboard voice to Standard."
+	id = "voice_standard"
+	build_type = MECHFAB
+	materials = list(MAT_METAL = 500)
+	construction_time = 50
+	build_path = /obj/item/mecha_modkit/voice
+	category = list("Misc")
+
+/datum/design/voice_nanotrasen
+	name = "Voice Modkit : Nanotrasen"
+	desc = "A modification kit that updates a mech's onboard voice to Nanotrasen."
+	id = "voice_nanotrasen"
+	build_type = MECHFAB
+	materials = list(MAT_METAL = 500)
+	construction_time = 50
+	build_path = /obj/item/mecha_modkit/voice/nanotrasen
+	category = list("Misc")
+
+/datum/design/voice_silent
+	name = "Voice Modkit : Silent"
+	desc = "A modification kit that silences a mech's onboard voice."
+	id = "voice_silent"
+	build_type = MECHFAB
+	materials = list(MAT_METAL = 500)
+	construction_time = 50
+	build_path = /obj/item/mecha_modkit/voice/silent
+	category = list("Misc")
+
+/datum/design/voice_honk
+	name = "Voice Modkit : Honk"
+	desc = "A modification kit that updates a mech's onboard voice to Honk. This is a terrible idea."
+	id = "voice_honk"
+	build_type = MECHFAB
+	materials = list(MAT_METAL = 400, MAT_BANANIUM = 100)
+	construction_time = 50
+	build_path = /obj/item/mecha_modkit/voice/syndicate
+	category = list("Misc")
+
+/datum/design/voice_syndicate
+	name = "Voice Modkit : Syndicate"
+	desc = "A modification kit that updates a mech's onboard voice to Syndicate."
+	id = "voice_syndicate"
+	build_type = MECHFAB
+	materials = list(MAT_METAL = 500)
+	req_tech = list("syndicate" = 2)
+	construction_time = 50
+	build_path = /obj/item/mecha_modkit/voice/syndicate
+	category = list("Misc")

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1232,6 +1232,7 @@
 	id = "voice_syndicate"
 	build_type = MECHFAB
 	materials = list(MAT_METAL = 400, MAT_TITANIUM = 100)
+	req_tech = list("syndicate" = 2)
 	construction_time = 50
 	build_path = /obj/item/mecha_modkit/voice/syndicate
 	category = list("Misc")

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1223,7 +1223,7 @@
 	build_type = MECHFAB
 	materials = list(MAT_METAL = 400, MAT_BANANIUM = 100)
 	construction_time = 50
-	build_path = /obj/item/mecha_modkit/voice/syndicate
+	build_path = /obj/item/mecha_modkit/voice/honk
 	category = list("Misc")
 
 /datum/design/voice_syndicate
@@ -1231,8 +1231,7 @@
 	desc = "A modification kit that updates a mech's onboard voice to Syndicate."
 	id = "voice_syndicate"
 	build_type = MECHFAB
-	materials = list(MAT_METAL = 500)
-	req_tech = list("syndicate" = 2)
+	materials = list(MAT_METAL = 400, MAT_TITANIUM = 100)
 	construction_time = 50
 	build_path = /obj/item/mecha_modkit/voice/syndicate
 	category = list("Misc")

--- a/paradise.dme
+++ b/paradise.dme
@@ -707,6 +707,7 @@
 #include "code\game\mecha\mecha_actions.dm"
 #include "code\game\mecha\mecha_construction_paths.dm"
 #include "code\game\mecha\mecha_control_console.dm"
+#include "code\game\mecha\mecha_modkit.dm"
 #include "code\game\mecha\mecha_parts.dm"
 #include "code\game\mecha\mecha_topic.dm"
 #include "code\game\mecha\mecha_wreckage.dm"


### PR DESCRIPTION
This PR adds different onboard voicesets, using unused sound files in sounds/mecha : 

- Standard (current, default on any mechs not mentionned below)
- Nanotrasen (Female voice, default on marauder/seraph)
- Syndicate (Male voice, default on syndicate mechs)
- Honk (Honk, honkfault on honk honk honk)
- Silent (...)

These sets can be swapped at will by printing voice modification kits in the exosuit fabricator and installing it on the mech. They have no tech requirements (except for syndicate) and are reusable as many times as you want, although the syndicate/honk kits require a little titanium/bananium respectively.

This PR also adds visual and audio warnings when your mech's running low on power, and a visual warning when your mech is locked by maintenance protocols

🆑
add: Added new, different voice sets to Syndicate, Clown, Mime, and ERT/Dsquad mechs
add: Added voice modification kits to the exosuit fabricator, letting you swap a mech's onboard voice to another.
add: Added visual and audio warnings when your mech is running low on power
add: Added visual warning when your mech is locked by maintenance protocols
/🆑

