### PR TITLE
Adds emergency glowsticks

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -312,9 +312,11 @@ obj/item/flashlight/lamp/bananalamp
 	icon_state = "glowstick"
 	item_state = "glowstick"
 	var/fuel = 0
+	var/fuel_lower = 1600
+	var/fuel_upp = 2000
 
 /obj/item/flashlight/glowstick/Initialize()
-	fuel = rand(1600, 2000)
+	fuel = rand(fuel_lower, fuel_upp)
 	light_color = color
 	. = ..()
 
@@ -388,6 +390,13 @@ obj/item/flashlight/lamp/bananalamp
 /obj/item/flashlight/glowstick/pink
 	name = "pink glowstick"
 	color = LIGHT_COLOR_PINK
+
+/obj/item/flashlight/glowstick/emergency
+	name = "emergency glowstick"
+	desc = "A cheap looking, mass produced glowstick. You can practically feel it was made on a tight budget."
+	color = LIGHT_COLOR_BLUE
+	fuel_lower = 30
+	fuel_upp = 90
 
 /obj/item/flashlight/glowstick/random
 	name = "random colored glowstick"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -11,6 +11,7 @@
 	actions_types = list(/datum/action/item_action/toggle_light)
 	var/on = FALSE
 	var/brightness_on = 4 //luminosity when on
+	var/togglesound = 'sound/weapons/empty.ogg'
 
 /obj/item/flashlight/Initialize()
 	. = ..()
@@ -35,7 +36,7 @@
 
 		return 0
 	on = !on
-	playsound(user, 'sound/weapons/empty.ogg', 100, 1)
+	playsound(user, togglesound, 100, 1)
 	update_brightness(user)
 	for(var/X in actions)
 		var/datum/action/A = X
@@ -158,6 +159,7 @@ obj/item/flashlight/lamp/bananalamp
 	light_color = "#ff0000" // changed colour to a more brighter red.
 	icon_state = "flare"
 	item_state = "flare"
+	togglesound = 'sound/goonstation/misc/matchstick_light.ogg'
 	var/fuel = 0
 	var/on_damage = 7
 	var/produce_heat = 1500
@@ -311,6 +313,7 @@ obj/item/flashlight/lamp/bananalamp
 	color = LIGHT_COLOR_GREEN
 	icon_state = "glowstick"
 	item_state = "glowstick"
+	togglesound = 'sound/effects/bone_break_1.ogg'
 	var/fuel = 0
 	var/fuel_lower = 1600
 	var/fuel_upp = 2000

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -72,6 +72,7 @@
 		new /obj/item/clothing/mask/breath( src )
 		new /obj/item/tank/emergency_oxygen( src )
 		new /obj/item/reagent_containers/hypospray/autoinjector( src )
+		new /obj/item/flashlight/glowstick/emergency( src )
 		return
 
 /obj/item/storage/box/survival_vox
@@ -83,6 +84,7 @@
 	new /obj/item/clothing/mask/breath/vox(src)
 	new /obj/item/tank/emergency_oxygen/nitrogen(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/flashlight/glowstick/emergency(src)
 
 /obj/item/storage/box/survival_plasmaman
 	icon_state = "box_plasma"
@@ -93,6 +95,7 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/emergency_oxygen/plasma(src)
 	new /obj/item/reagent_containers/hypospray/autoinjector(src)
+	new /obj/item/flashlight/glowstick/emergency(src)
 
 /obj/item/storage/box/engineer
 	icon_state = "box_eng"
@@ -102,6 +105,7 @@
 		new /obj/item/clothing/mask/breath( src )
 		new /obj/item/tank/emergency_oxygen/engi( src )
 		new /obj/item/reagent_containers/hypospray/autoinjector( src )
+		new /obj/item/flashlight/glowstick/emergency( src )
 		return
 
 /obj/item/storage/box/survival_mining
@@ -113,6 +117,7 @@
 		new /obj/item/tank/emergency_oxygen/engi(src)
 		new /obj/item/crowbar/red(src)
 		new /obj/item/reagent_containers/hypospray/autoinjector(src)
+		new /obj/item/flashlight/glowstick/emergency(src)
 
 /obj/item/storage/box/gloves
 	name = "box of latex gloves"


### PR DESCRIPTION
This PR should be merged after #10528 to prevent much balance conflict with the one light based gamemode, Slings. While veil does currently work on them, they can currently be snapped again after it is used.

This PR adds emergency glowsticks to the emergency boxes of the crew. This gives them a very temporary light source that lasts between 1-3 minutes after use, is not a spark source and is slightly better than a PDA flashlight but ultimately much worse than using other lighting items such as a flashlight or helmet light.

This also adds better sound effects for the glowstick and flare when used rather than a button click.
:cl: Spartan
add: Adds emergency glowsticks to emergency box.
sound: Glowsticks and flares now make more relevant usage sounds.
/:cl:

