### PR TITLE
Fix RPD not appearing in Autolathe

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -81,7 +81,7 @@
 	build_path = /obj/item/radio/beacon
 	category = list("Bluespace")
 
-/datum/design/rpd
+/datum/design/brpd
 	name = "Bluespace Rapid Pipe Dispenser (BRPD)"
 	desc = "Similar to the Rapid Pipe Dispenser, lets you rapidly dispense pipes. Now at long range!"
 	req_tech = list("bluespace" = 3, "toxins" = 6)


### PR DESCRIPTION
autolathe rpd design and bluespace rpd design in the protolathe had the same path

:cl:
fix: RPDs should be available in hacked autolathes again
/:cl:

