### PR TITLE
Pumps no longer remain on when the inserted tank is removed

### DIFF
--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -146,6 +146,7 @@
 
 	if(href_list["remove_tank"])
 		if(holding)
+			on = FALSE
 			holding.loc = loc
 			holding = null
 		update_icon()


### PR DESCRIPTION
Because a) this is how canisters do it, and b) it's no fun when you accidentally spray burning plasma everywhere because you forgot to turn off the pump before removing the tank

:cl:
tweak: Air pumps will now switch off when the inserted tank is removed.
/:cl: