### PR TITLE
ID lock for Suit Storage Units + SSU hacking

### DIFF
--- a/code/datums/wires/suitstorage.dm
+++ b/code/datums/wires/suitstorage.dm
@@ -1,0 +1,66 @@
+/datum/wires/suitstorage
+	holder_type = /obj/machinery/suit_storage_unit
+	wire_count = 6
+
+var/const/SSU_WIRE_ID = 1
+var/const/SSU_WIRE_SHOCK = 2
+var/const/SSU_WIRE_SAFETY = 4
+var/const/SSU_WIRE_UV = 8
+
+
+/datum/wires/suitstorage/GetWireName(index)
+	switch(index)
+		if(SSU_WIRE_ID)
+			return "ID lock"
+		if(SSU_WIRE_SHOCK)
+			return "Shock wire"
+		if(SSU_WIRE_SAFETY)
+			return "Safety wire"
+		if(SSU_WIRE_UV)
+			return "UV wire"
+
+
+/datum/wires/suitstorage/get_status()
+	. = ..()
+	var/obj/machinery/suit_storage_unit/A = holder
+	. += "The blue light is [A.secure ? "off" : "on"]."
+	. += "The red light is [A.safeties ? "off" : "blinking"]."
+	. += "The green light is [A.shocked ? "on" : "off"]."
+	. += "The UV display shows [A.uv_super ? "185 nm" : "15 nm"]."
+
+datum/wires/suitstorage/CanUse()
+	var/obj/machinery/suit_storage_unit/A = holder
+	if(A.panel_open)
+		return 1
+	return 0
+
+/datum/wires/suitstorage/UpdateCut(index, mended)
+	var/obj/machinery/suit_storage_unit/A = holder
+	switch(index)
+		if(SSU_WIRE_ID)
+			A.secure = mended
+		if(SSU_WIRE_SAFETY)
+			A.safeties = mended
+		if(SSU_WIRE_SHOCK)
+			A.shocked = !mended
+			 A.shock(usr, 50)
+		if(SSU_WIRE_UV)
+			A.uv_super = !mended
+	..()
+
+datum/wires/suitstorage/UpdatePulsed(index)
+	var/obj/machinery/suit_storage_unit/A = holder
+	if(IsIndexCut(index))
+		return
+	switch(index)
+		if(SSU_WIRE_ID)
+			A.secure = !A.secure
+		if(SSU_WIRE_SAFETY)
+			A.safeties = !A.safeties
+		if(SSU_WIRE_SHOCK)
+			A.shocked = !A.shocked
+			if(A.shocked)
+				A.shock(usr, 50)
+		if(SSU_WIRE_UV)
+			A.uv_super = !A.uv_super
+	..()

--- a/code/datums/wires/suitstorage.dm
+++ b/code/datums/wires/suitstorage.dm
@@ -1,6 +1,6 @@
 /datum/wires/suitstorage
 	holder_type = /obj/machinery/suit_storage_unit
-	wire_count = 6
+	wire_count = 8
 
 var/const/SSU_WIRE_ID = 1
 var/const/SSU_WIRE_SHOCK = 2
@@ -23,10 +23,10 @@ var/const/SSU_WIRE_UV = 8
 /datum/wires/suitstorage/get_status()
 	. = ..()
 	var/obj/machinery/suit_storage_unit/A = holder
-	. += "The blue light is [A.secure ? "off" : "on"]."
+	. += "The blue light is [A.secure ? "on" : "off"]."
 	. += "The red light is [A.safeties ? "off" : "blinking"]."
 	. += "The green light is [A.shocked ? "on" : "off"]."
-	. += "The UV display shows [A.uv_super ? "185 nm" : "15 nm"]."
+	. += "The UV display shows [A.uv_super ? "15 nm" : "185 nm"]."
 
 datum/wires/suitstorage/CanUse()
 	var/obj/machinery/suit_storage_unit/A = holder
@@ -43,7 +43,7 @@ datum/wires/suitstorage/CanUse()
 			A.safeties = mended
 		if(SSU_WIRE_SHOCK)
 			A.shocked = !mended
-			 A.shock(usr, 50)
+			A.shock(usr, 50)
 		if(SSU_WIRE_UV)
 			A.uv_super = !mended
 	..()
@@ -60,7 +60,10 @@ datum/wires/suitstorage/UpdatePulsed(index)
 		if(SSU_WIRE_SHOCK)
 			A.shocked = !A.shocked
 			if(A.shocked)
-				A.shock(usr, 50)
+				A.shock(usr, 100)
+				spawn(50)
+					if(A && !IsIndexCut(index))
+						A.shocked = FALSE
 		if(SSU_WIRE_UV)
 			A.uv_super = !A.uv_super
 	..()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -22,9 +22,9 @@
 	var/safeties = TRUE
 	var/broken = FALSE
 	var/secure = FALSE	//set to true to enable ID locking
-	var/shocked = FALSE
+	var/shocked = FALSE//is it shocking anyone that touches it?
 	req_access = list(access_eva)	//the ID needed if ID lock is enabled
-	var/datum/wires/suitstorage/asd
+	var/datum/wires/suitstorage/wires
 
 	var/uv = FALSE
 	var/uv_super = FALSE
@@ -43,50 +43,90 @@
 	helmet_type  = /obj/item/clothing/head/helmet/space/eva
 	mask_type    = /obj/item/clothing/mask/breath
 
+/obj/machinery/suit_storage_unit/standard_unit/secure
+	secure = TRUE	//start with ID lock enabled
+
 /obj/machinery/suit_storage_unit/captain
 	suit_type    = /obj/item/clothing/suit/space/captain
 	helmet_type  = /obj/item/clothing/head/helmet/space/capspace
 	mask_type    = /obj/item/clothing/mask/gas
 	storage_type = /obj/item/tank/jetpack/oxygen/captain
+	req_access = list(access_captain)
+
+/obj/machinery/suit_storage_unit/captain/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/engine
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/engineering
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/engineering
 	mask_type    = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/clothing/shoes/magboots
+	req_access = list(access_engine_equip)
+
+/obj/machinery/suit_storage_unit/engine/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/ce
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/elite
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/elite
 	mask_type    = /obj/item/clothing/mask/gas
 	storage_type = /obj/item/clothing/shoes/magboots/advance
+	req_access = list(access_ce)
+
+/obj/machinery/suit_storage_unit/ce/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/security
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/security
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/security
 	mask_type    = /obj/item/clothing/mask/gas/sechailer
+	req_access = list(access_security)
+
+/obj/machinery/suit_storage_unit/security/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/atmos
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/atmos
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/atmos
 	mask_type    = /obj/item/clothing/mask/gas
 	storage_type = /obj/item/clothing/shoes/magboots
+	req_access = list(access_atmospherics)
+
+/obj/machinery/suit_storage_unit/atmos/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/mining
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/mining
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/mining
 	mask_type    = /obj/item/clothing/mask/breath
+	req_access = list(access_mining_station)
+
+/obj/machinery/suit_storage_unit/mining/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/cmo
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/medical
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/medical
 	mask_type    = /obj/item/clothing/mask/breath
+	req_access = list(access_cmo)
+
+/obj/machinery/suit_storage_unit/cmo/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/syndicate
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/syndi
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	mask_type    = /obj/item/clothing/mask/gas/syndicate
 	storage_type = /obj/item/tank/jetpack/oxygen/harness
+	req_access = list(access_syndicate)
+	safeties = FALSE	//in a syndicate base, everything can be used as a murder weapon at a moment's notice.
+	uv_super = TRUE	//so efficient
+
+/obj/machinery/suit_storage_unit/syndicate/secure
+	secure = TRUE
+
+/obj/machinery/suit_storage_unit/ert
+	req_access = list(access_cent_general)
 
 /obj/machinery/suit_storage_unit/ert/command
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/ert/commander
@@ -94,11 +134,17 @@
 	mask_type    = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/emergency_oxygen/double
 
+/obj/machinery/suit_storage_unit/ert/command/secure
+	secure = TRUE
+
 /obj/machinery/suit_storage_unit/ert/security
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/ert/security
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/ert/security
 	mask_type    = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/emergency_oxygen/double
+
+/obj/machinery/suit_storage_unit/ert/security/secure
+	secure = TRUE
 
 /obj/machinery/suit_storage_unit/ert/engineer
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/ert/engineer
@@ -106,15 +152,21 @@
 	mask_type    = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/emergency_oxygen/double
 
+/obj/machinery/suit_storage_unit/ert/engineer/secure
+	secure = TRUE
+
 /obj/machinery/suit_storage_unit/ert/medical
 	suit_type    = /obj/item/clothing/suit/space/hardsuit/ert/medical
 	helmet_type  = /obj/item/clothing/head/helmet/space/hardsuit/ert/medical
 	mask_type    = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/emergency_oxygen/double
 
+/obj/machinery/suit_storage_unit/ert/medical/secure
+	secure = TRUE
+
 /obj/machinery/suit_storage_unit/New()
 	..()
-	asd = new(src)
+	wires = new(src)
 
 /obj/machinery/suit_storage_unit/Initialize()
 	. = ..()
@@ -137,6 +189,7 @@
 	QDEL_NULL(helmet)
 	QDEL_NULL(mask)
 	QDEL_NULL(storage)
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/machinery/suit_storage_unit/update_icon()
@@ -164,6 +217,9 @@
 		add_overlay("human")
 
 /obj/machinery/suit_storage_unit/attackby(obj/item/I as obj, mob/user as mob, params)
+	if(shocked)
+		if(shock(user, 100))
+			return
 	if(!is_operational())
 		if(panel_open)
 			to_chat(usr, "<span class='warning'>Close the maintenance panel first.</span>")
@@ -176,6 +232,9 @@
 		to_chat(user, text("<span class='notice'>You [panel_open ? "open up" : "close"] the unit's maintenance panel.</span>"))
 		updateUsrDialog()
 		return
+	if(panel_open)
+		wires.Interact(user)
+
 	if(state_open)
 		if(store_item(I, user))
 			update_icon()
@@ -295,11 +354,11 @@
 			dump_contents()
 
 /obj/machinery/suit_storage_unit/shock(mob/user, prb)
-	if(!prob(prb))
+	if(prob(prb))	//why was this inverted before?!?
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(5, 1, src)
 		s.start()
-		if(electrocute_mob(user, src, src, 1, TRUE))
+		if(electrocute_mob(user, get_area(src), src, 1))
 			return 1
 
 /obj/machinery/suit_storage_unit/relaymove(mob/user)
@@ -389,6 +448,9 @@
 
 /obj/machinery/suit_storage_unit/attack_hand(mob/user as mob)
 	var/dat
+	if(shocked)
+		if(shock(usr, 100))
+			return
 	if(..())
 		return
 	if(stat & NOPOWER)
@@ -396,13 +458,8 @@
 	if(!user.IsAdvancedToolUser())
 		return FALSE
 	if(panel_open) //The maintenance panel is open. Time for some shady stuff
-		dat+= "<HEAD><TITLE>Suit storage unit: Maintenance panel</TITLE></HEAD>"
-		dat+= "<B>Maintenance panel controls</B><HR>"
-		dat+= "<font color ='grey'>The panel is ridden with controls, button and meters, labeled in strange signs and symbols that <BR>you cannot understand. Probably the manufactoring world's language.<BR> Among other things, a few controls catch your eye.<BR><BR>"
-		dat+= text("A small dial with an arrow embroidered on it. It's pointing towards a gauge that reads [].<BR> <font color='blue'><A href='?src=[UID()];toggleUV=1'> Turn towards []</A><BR>",(uv_super ? "15nm" : "185nm"),(uv_super ? "185nm" : "15nm") )
-		dat+= text("A thick old-style button, with 2 grimy LED lights next to it. The [] LED is on.<BR><font color ='blue'><A href='?src=[UID()];togglesafeties=1'>Press button</a></font>",(safeties ? "<font color='green'><B>GREEN</B></font>" : "<font color='red'><B>RED</B></font>"))
-		dat+= "<HR><BR><A href='?src=[user.UID()];mach_close=suit_storage_unit'>Close panel</A>"
-	else if(uv) //The thing is running its cauterisation cycle. You have to wait.
+		wires.Interact(user)
+	if(uv) //The thing is running its cauterisation cycle. You have to wait.
 		dat += "<HEAD><TITLE>Suit storage unit</TITLE></HEAD>"
 		dat+= "<font color ='red'><B>Unit is cauterising contents with selected UV ray intensity. Please wait.</font></B><BR>"
 
@@ -444,10 +501,18 @@
 	onclose(user, "suit_storage_unit")
 	return
 
+/obj/machinery/suit_storage_unit/proc/check_allowed(user)
+	if(!(allowed(user) || !secure))
+		to_chat(user, "<span class='warning'>Access denied.</span>")
+		return FALSE
+	return TRUE
 
 /obj/machinery/suit_storage_unit/Topic(href, href_list)
 	if(..())
 		return 1
+	if(shocked)
+		if(shock(usr, 100))
+			return
 	if((usr.contents.Find(src) || ((get_dist(src, usr) <= 1) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon/ai)))
 		usr.set_machine(src)
 		if(href_list["toggleUV"])
@@ -475,10 +540,14 @@
 			updateUsrDialog()
 			update_icon()
 		if(href_list["toggle_open"])
+			if(!check_allowed(usr))
+				return
 			toggle_open(usr)
 			updateUsrDialog()
 			update_icon()
 		if(href_list["toggle_lock"])
+			if(!check_allowed(usr))
+				return
 			toggle_lock(usr)
 			updateUsrDialog()
 			update_icon()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -21,6 +21,10 @@
 	var/locked = FALSE
 	var/safeties = TRUE
 	var/broken = FALSE
+	var/secure = FALSE	//set to true to enable ID locking
+	var/shocked = FALSE
+	req_access = list(access_eva)	//the ID needed if ID lock is enabled
+	var/datum/wires/suitstorage/asd
 
 	var/uv = FALSE
 	var/uv_super = FALSE
@@ -108,7 +112,9 @@
 	mask_type    = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/emergency_oxygen/double
 
-
+/obj/machinery/suit_storage_unit/New()
+	..()
+	asd = new(src)
 
 /obj/machinery/suit_storage_unit/Initialize()
 	. = ..()

--- a/paradise.dme
+++ b/paradise.dme
@@ -386,6 +386,7 @@
 #include "code\datums\wires\radio.dm"
 #include "code\datums\wires\robot.dm"
 #include "code\datums\wires\smartfridge.dm"
+#include "code\datums\wires\suitstorage.dm"
 #include "code\datums\wires\syndicatebomb.dm"
 #include "code\datums\wires\tesla_coil.dm"
 #include "code\datums\wires\vending.dm"


### PR DESCRIPTION
**What does this PR do:**
This PR does two things:

First, it enables **ID locking** for Suit Storage Units. This means that only people with the required access can open, close, lock or unlock those units. They can still start disinfection cycles and dispense objects if the unit happens to be open. The required access defaults to EVA access, but I've adjusted it for the other SSUs defined in the code.

Note that **no** currently placed/mapped in SSUs have this option enabled. I did not want to break any away missions or space ruins that might depend on having access to an SSU. Instead, new variants of all SSUs have been added to the code that can be mapped in. I decided to not map them in with this PR since map merging is always a major PITA and there might be balance discussions slowing down its merging. I will make a separate PR to take advantage of the newly created secure SSUs and map them in to replace the awkward 'hardsuit on a rack' situation that we have in armory, engineering, etc.

Secondly, it changes SSUs to make them **hackable**. They can be opened via a screwdriver and their wires can be pulsed and cut, as should be familiar from other machines. Via this way, the ID lock can be enabled and disabled by anyone with a toolset. The full options are:

- ID lock wire. Wire to enable or disable ID lock. With ID lock disabled, anyone can use the machine.
- Shock wire. Shocks you and electrifies the SSU if pulsed or cut. Temporary if pulsed, permanent if cut.
- Safeties wire. If pulsed or cut disables safeties which allows you to lock people in the SSU and fry them with UV radiation. Gruesome.
- UV wire. Pulse or cut to turn up the UV setting to more damaging levels.
- 4 Dud wires that do nothing

Note that the previous 'maintenance panel' menu of SSUs was removed and replaced with this. There's probably a few things I've overlooked, so code review and feedback is very welcome.

**Changelog:**
:cl:
add: Variants of Suit Storage Units that are ID locked
tweak: SSUs can now be hacked. Old SSU maint panel menu removed.
/:cl:

