### PR TITLE
Fixes death alarms/beepsky/etc. radios.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -256,9 +256,10 @@ var/global/list/default_medbay_channels = list(
 			break
 	if(jammed)
 		message = Gibberish(message, 100)
+	var/list/message_pieces = message_to_multilingual(message)
 	Broadcast_Message(connection, A,
 						0, "*garbled automated announcement*", src,
-						message, from, "Automated Announcement", from, "synthesized voice",
+						message_pieces, from, "Automated Announcement", from, "synthesized voice",
 						4, 0, zlevel, connection.frequency, follow_target = follow_target)
 	qdel(A)
 


### PR DESCRIPTION
**What does this PR do:**
Fixes #10551

**Changelog:**
:cl: uc_guy
fix: Fixed death alarms / cell timer / beepsky radios. 
/:cl:

