### PR TITLE
Adds VSCode directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ data/
 *.db
 stddef.dm
 .atom-build.json
+*.vscode/*


### PR DESCRIPTION
**What does this PR do:**
Adds the `.vscode` directory to our gitignore file, allowing us to have these folders without them lying in our diff

No CL because this doesnt touch a single game file