### PR TITLE
Single HUD implant to heads locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -42,3 +42,4 @@
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/clothing/head/soft(src)
 	new /obj/item/door_remote/quartermaster(src)
+	new /obj/item/organ/internal/cyberimp/eyes/meson(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -36,6 +36,7 @@
 	new /obj/item/door_remote/chief_engineer(src)
 	new /obj/item/rpd(src)
 	new /obj/item/reagent_containers/food/drinks/mug/ce(src)
+	new /obj/item/organ/internal/cyberimp/eyes/meson(src)
 
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -74,6 +74,7 @@
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/reagent_containers/food/drinks/mug/rd(src)
+	new /obj/item/organ/internal/cyberimp/eyes/hud/diagnostic(src)
 
 
 /obj/structure/closet/secure_closet/research_reagents

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -123,6 +123,7 @@
 	new /obj/item/gun/energy/gun/hos(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/reagent_containers/food/drinks/mug/hos(src)
+	new /obj/item/organ/internal/cyberimp/eyes/hud/security(src)
 
 
 /obj/structure/closet/secure_closet/warden


### PR DESCRIPTION
**What does this PR do:**
Adds a single HUD implant to the respective heads locker, just like the CMO currently has.


:cl: Alonefromhell
add: All heads now have a HUD implant according to their department.
/:cl:

