### PR TITLE
Sorium and Dark Matter blob fix

### DIFF
--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -11,6 +11,7 @@
 	invisibility = 101 // No one can see us
 	sight = SEE_SELF
 	move_on_shuttle = 0
+	anchored = 1 //Don't want the camera to be thrown around with blobs sorium and dark matter, do we?
 
 /mob/camera/experience_pressure_difference()
 	return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -15,6 +15,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 	alpha = 127
 	move_resist = INFINITY	//  don't get pushed around
 	invisibility = INVISIBILITY_OBSERVER
+	anchored = 1 //DO. NOT. MOVE.
 	var/can_reenter_corpse
 	var/bootime = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.


### PR DESCRIPTION
**What does this PR do:**
Adds anchor to observers and cameras, so they won't be thrown around when sorium and dark matter blobs do their thing.
Fixes: #10569


:cl: Alonefromhell
fix: Observers and cameras shouldn't be affected by blobs anymore. Even their own cameras.
/:cl:

