### PR TITLE
Capulettium/Capu+ fakes death convincingly

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1079,6 +1079,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/safecracking
 	cost = 1
 
+/datum/uplink_item/stealthy_tools/fakedeathpills
+	name = "Fake Death Pill Bottle"
+	desc = "A regular pill bottle containing three fake death pills. Swallow, then rest on the floor to appear dead to people, medical huds, and health analysers. \
+		Stand up to wake up. Each pill lets you lay dead for four to five minutes, can be cumulated. Side effects include : Silencing, loss of limbs and/or head once security declares you a changeling."
+	reference = "FDP"
+	item = /obj/item/storage/pill_bottle/fakedeath
+	cost = 1
+
 /datum/uplink_item/stealthy_tools/clownkit
 	name = "Honk Brand Infiltration Kit"
 	desc = "All the tools you need to play the best prank Nanotrasen has ever seen. Includes a voice changer clown mask, magnetic clown shoes, and standard clown outfit, tools, and backpack."

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1079,14 +1079,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/safecracking
 	cost = 1
 
-/datum/uplink_item/stealthy_tools/fakedeathpills
-	name = "Fake Death Pill Bottle"
-	desc = "A regular pill bottle containing three fake death pills. Swallow, then rest on the floor to appear dead to people, medical huds, and health analysers. \
-		Stand up to wake up. Each pill lets you lay dead for four to five minutes, can be cumulated. Side effects include : Silencing, loss of limbs and/or head once security declares you a changeling."
-	reference = "FDP"
-	item = /obj/item/storage/pill_bottle/fakedeath
-	cost = 1
-
 /datum/uplink_item/stealthy_tools/clownkit
 	name = "Honk Brand Infiltration Kit"
 	desc = "All the tools you need to play the best prank Nanotrasen has ever seen. Includes a voice changer clown mask, magnetic clown shoes, and standard clown outfit, tools, and backpack."

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -243,6 +243,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	var/changeling_speak = 0
 	var/datum/dna/chosen_dna
 	var/obj/effect/proc_holder/changeling/sting/chosen_sting
+	var/regenerating = FALSE
 
 /datum/changeling/New(gender=FEMALE)
 	..()

--- a/code/game/gamemodes/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/changeling/powers/fakedeath.dm
@@ -20,7 +20,8 @@
 	user.med_hud_set_health()
 	user.handle_hud_icons_health()
 	user.med_hud_set_status()
-	
+	user.mind.changeling.regenerating = TRUE
+
 	addtimer(CALLBACK(src, .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME)
 	feedback_add_details("changeling_powers","FD")
 	return 1

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -55,6 +55,7 @@
 	user.updatehealth("revive sting")
 	user.update_blind_effects()
 	user.update_blurry_effects()
+	user.mind.changeling.regenerating = FALSE
 
 	to_chat(user, "<span class='notice'>We have regenerated.</span>")
 

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -152,7 +152,8 @@
 				/obj/item/toy/cards/deck/syndicate = 2,
 				/obj/item/storage/secure/briefcase/syndie = 2,
 				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 2,
-				"" = 70
+				/obj/item/storage/pill_bottle/fakedeath = 2,
+				"" = 68
 				)
 
 /obj/effect/spawner/lootdrop/crate_spawner // for ruins

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -330,3 +330,9 @@
 	new /obj/item/reagent_containers/food/pill/salicylic(src)
 	new /obj/item/reagent_containers/food/pill/salicylic(src)
 	new /obj/item/reagent_containers/food/pill/salicylic(src)
+
+/obj/item/storage/pill_bottle/fakedeath/New()
+	..()
+	new /obj/item/reagent_containers/food/pill/fakedeath(src)
+	new /obj/item/reagent_containers/food/pill/fakedeath(src)
+	new /obj/item/reagent_containers/food/pill/fakedeath(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -284,3 +284,9 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 	new /obj/item/clothing/mask/balaclava(src)
 	new /obj/item/clothing/accessory/stethoscope(src)
 	new /obj/item/book/manual/engineering_hacking(src)
+
+/obj/item/storage/pill_bottle/fakedeath/New()
+	..()
+	new /obj/item/reagent_containers/food/pill/fakedeath(src)
+	new /obj/item/reagent_containers/food/pill/fakedeath(src)
+	new /obj/item/reagent_containers/food/pill/fakedeath(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -284,9 +284,3 @@ To apply, hold the injector a short distance away from the outer thigh before ap
 	new /obj/item/clothing/mask/balaclava(src)
 	new /obj/item/clothing/accessory/stethoscope(src)
 	new /obj/item/book/manual/engineering_hacking(src)
-
-/obj/item/storage/pill_bottle/fakedeath/New()
-	..()
-	new /obj/item/reagent_containers/food/pill/fakedeath(src)
-	new /obj/item/reagent_containers/food/pill/fakedeath(src)
-	new /obj/item/reagent_containers/food/pill/fakedeath(src)

--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -315,7 +315,7 @@
 /datum/species/proc/help(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(attacker_style && attacker_style.help_act(user, target))//adminfu only...
 		return TRUE
-	if(target.health >= config.health_threshold_crit)
+	if(target.health >= config.health_threshold_crit && !(target.status_flags & FAKEDEATH))
 		target.help_shake_act(user)
 		return TRUE
 	else

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -155,3 +155,32 @@
 	if(prob(5))
 		to_chat(M, "<span class='warning'>You would DIE for some [name] right now!</span>")
 	return update_flags
+
+/datum/reagent/proc/fakedeath(mob/living/M)
+	if(M.status_flags & FAKEDEATH)
+		return
+	if(!(M.status_flags & CANPARALYSE))
+		return
+	if(M.mind && M.mind.changeling && M.mind.changeling.regenerating) //no messing with changeling's fake death
+		return
+	M.visible_message("<B>[M]</B> seizes up and falls limp, [M.p_their()] eyes dead and lifeless...") //so you can't trigger deathgasp emote on people. Edge case, but necessary.
+	M.status_flags |= FAKEDEATH
+	M.update_stat("fakedeath reagent")
+	M.med_hud_set_health()
+	M.med_hud_set_status()
+
+/datum/reagent/proc/fakerevive(mob/living/M)
+	if(!(M.status_flags & FAKEDEATH))
+		return
+	if(M.mind && M.mind.changeling && M.mind.changeling.regenerating)
+		return
+	if(M.resting)
+		M.StopResting()
+	M.status_flags &= ~(FAKEDEATH)
+	M.update_stat("fakedeath reagent end")
+	M.med_hud_set_status()
+	M.med_hud_set_health()
+	if(M.healthdoll)
+		M.healthdoll.cached_healthdoll_overlays.Cut()
+	if(M.dna.species)
+		M.dna.species.handle_hud_icons(M)

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1037,7 +1037,7 @@
 /datum/reagent/capulettium
 	name = "Capulettium"
 	id = "capulettium"
-	description = "A rare drug that causes the user to appear dead for some time."
+	description = "A rare drug that causes the user to fall unconscious and appear dead as long as it's in the body."
 	reagent_state = LIQUID
 	color = "#60A584"
 	heart_rate_stop = 1
@@ -1046,23 +1046,21 @@
 /datum/reagent/capulettium/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	switch(current_cycle)
-		if(1 to 5)
+		if(1 to 10)
 			update_flags |= M.AdjustEyeBlurry(10, FALSE)
-		if(6 to 10)
-			M.Drowsy(10)
 		if(11)
-			update_flags |= M.Paralyse(10, FALSE)
-			M.visible_message("<B>[M]</B> seizes up and falls limp, [M.p_their()] eyes dead and lifeless...") //so you can't trigger deathgasp emote on people. Edge case, but necessary.
-		if(12 to 60)
-			update_flags |= M.Paralyse(10, FALSE)
-		if(61 to INFINITY)
-			update_flags |= M.AdjustEyeBlurry(10, FALSE)
+			fakedeath(M)
 	return ..() | update_flags
+
+/datum/reagent/capulettium/on_mob_delete(mob/living/M)
+	if(M.status_flags & FAKEDEATH)
+		fakerevive(M)
+	..()
 
 /datum/reagent/capulettium_plus
 	name = "Capulettium Plus"
 	id = "capulettium_plus"
-	description = "A rare and expensive drug that causes the user to appear dead for some time while they retain consciousness and vision."
+	description = "A rare and expensive drug that will silence the user and let him appear dead as long as it's in the body. Rest to play dead, stand up to wake up."
 	reagent_state = LIQUID
 	color = "#60A584"
 	heart_rate_stop = 1
@@ -1070,7 +1068,16 @@
 
 /datum/reagent/capulettium_plus/on_mob_life(mob/living/M)
 	M.Silence(2)
+	if((M.status_flags & FAKEDEATH) && !M.resting)
+		fakerevive(M)
+	else if(!(M.status_flags & FAKEDEATH) && M.resting)
+		fakedeath(M)
 	return ..()
+
+/datum/reagent/capulettium_plus/on_mob_delete(mob/living/M)
+	if(M.status_flags & FAKEDEATH)
+		fakerevive(M)
+	..()
 
 /datum/reagent/toxic_slurry
 	name = "Toxic Slurry"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -63,6 +63,12 @@
 	icon_state = "pill21"
 	list_reagents = list("initropidril" = 50)
 
+/obj/item/reagent_containers/food/pill/fakedeath
+	name = "fake death pill"
+	desc = "Swallow then rest to appear dead, stand up to wake up. Also mutes the user's voice."
+	icon_state = "pill4"
+	list_reagents = list("capulettium_plus" = 50)
+
 /obj/item/reagent_containers/food/pill/adminordrazine
 	name = "Adminordrazine pill"
 	desc = "It's magic. We don't have to explain it."


### PR DESCRIPTION
This PR refactors capulettium/capu plus to actually fake the death of the user. 

Capulettium mostly works the same, except that the user will appear dead to their own hud, examine, medhud, and health analyser after passing out. 

Body scanner can tell the user is alive, and a savy doctor with upgraded health analyser can see the capulettium/plus in the body and tell the death is fake.

Defib/cloning won't work on a fake dead guy.

Capulettium plus still silences the user, but now you can also trigger fake death whenever you want by resting, causing you to lose vision and appear dead. You can wake up anytime you want by toggling rest again. This can be done as many times as you wish until the chem is out of your body.

A Fake Death Pill Bottle was added to syndi uplink and to maintance loot spawners, which contains 3 pills with 50u of capulettium plus (~4 to 5 minutes duration), can be bought for 1 TC.

🆑
Add: Capulettium fake death will now actually be convincing, fooling examine, medhud, and health analysers, but not body scanners.
Add: Capulettium plus can now be used to manually fake your own death when you wish by resting, and wake up when you wish by toggling rest again.
Add: Added fake death pill bottle to maintenance loot, contains 3 pills of capulettium plus.
/🆑