### PR TITLE
Added titanium cost to IRC chassis

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1135,7 +1135,7 @@
 	id = "integrated_robotic_chassis"
 	build_type = MECHFAB
 	build_path = /mob/living/carbon/human/machine/created
-	materials = list(MAT_METAL = 40000)
+	materials = list(MAT_METAL = 40000, MAT_TITANIUM = 7000) //for something made from lego, they sure need a lot of metal
 	construction_time = 400
 	category = list("Misc")
 


### PR DESCRIPTION
**What does this PR do:**
While I was working on adding the laser carbine mag, Spartan requested/Suggested making IRC chassis more expensive, saying it was weirdly cheap. Figured since I'm there already might as well do it. IRCs are effectively slaves for whoever builds them, limited only by willingness of ghosts to become posibrains, so giving them a cost beyond metal does make some sense to me.

IRC chassis now need 7 sheets of titanium on top of the previous metal cost.

**Changelog:**
:cl:
tweak: IRC chassis now have titanium cost to produce on top of metal.
/:cl:

