### PR TITLE
Fix mech runtime

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1378,14 +1378,16 @@
 /obj/mecha/proc/use_power(amount)
 	if(get_charge())
 		cell.use(amount)
-		update_cell()
+		if(occupant)
+			update_cell()
 		return 1
 	return 0
 
 /obj/mecha/proc/give_power(amount)
 	if(!isnull(get_charge()))
 		cell.give(amount)
-		update_cell()
+		if(occupant)
+			update_cell()
 		return 1
 	return 0
 


### PR DESCRIPTION
Mechs would try to throw an alert on the occupant's screen when the mech used power, but if there's no occupant, welp. This PR adds a check for that.

🆑
fix: Fixed a mech runtime when an empty mech used power.
/🆑