### PR TITLE
Mime's Cane Shotgun ammo reworked and buffed

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //mime
 /datum/uplink_item/jobspecific/caneshotgun
 	name = "Cane Shotgun and Assassination Shells"
-	desc = "A specialized, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes boxed with 6 specialized shrapnel rounds laced with a silencing toxin and 1 preloaded in the shotgun's chamber."
+	desc = "A specialised, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes boxed with 6 specialised shrapnel rounds laced with a silencing toxin and 1 preloaded in the shotgun's chamber."
 	reference = "MCS"
 	item = /obj/item/storage/box/syndie_kit/caneshotgun
 	cost = 10

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -184,8 +184,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 //mime
 /datum/uplink_item/jobspecific/caneshotgun
-	name = "Cane Shotgun + Assassination Darts"
-	desc = "A specialized, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes with 6 special darts and a preloaded shrapnel round."
+	name = "Cane Shotgun and Assassination Shells"
+	desc = "A specialized, one shell shotgun with a built-in cloaking device to mimic a cane. The shotgun is capable of hiding it's contents and the pin alongside being supressed. Comes boxed with 6 specialized shrapnel rounds laced with a silencing toxin and 1 preloaded in the shotgun's chamber."
 	reference = "MCS"
 	item = /obj/item/storage/box/syndie_kit/caneshotgun
 	cost = 10

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -207,12 +207,12 @@
 
 /obj/item/storage/box/syndie_kit/caneshotgun/New()
 	..()
-	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
-	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
-	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
-	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
-	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
-	new /obj/item/ammo_casing/shotgun/dart/assassination(src)
+	new /obj/item/ammo_casing/shotgun/assassination(src)
+	new /obj/item/ammo_casing/shotgun/assassination(src)
+	new /obj/item/ammo_casing/shotgun/assassination(src)
+	new /obj/item/ammo_casing/shotgun/assassination(src)
+	new /obj/item/ammo_casing/shotgun/assassination(src)
+	new /obj/item/ammo_casing/shotgun/assassination(src)
 	new /obj/item/gun/projectile/revolver/doublebarrel/improvised/cane(src)
 
 /obj/item/storage/box/syndie_kit/mimery

--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -369,12 +369,13 @@
 	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"
 
-/obj/item/ammo_casing/shotgun/dart/assassination
-	desc = "A specialist shotgun dart designed to inncapacitate and kill the target over time, so you can get very far away from your target"
-
-/obj/item/ammo_casing/shotgun/dart/assassination/New()
-	..()
-	reagents.add_reagent("neurotoxin", 6)
+/obj/item/ammo_casing/shotgun/assassination
+	name = "assassination shell"
+	desc = "A specialist shrapnel shell that has been laced with a silencing toxin."
+	projectile_type = /obj/item/projectile/bullet/pellet/assassination
+	icon_state = "gshell"
+	pellets = 6
+	variance = 25
 
 /obj/item/ammo_casing/cap
 	desc = "A cap for children toys."

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -122,6 +122,9 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/improvised
 	max_ammo = 1
 
+/obj/item/ammo_box/magazine/internal/shot/improvised/cane
+	ammo_type = /obj/item/ammo_casing/shotgun/assassination
+
 /obj/item/ammo_box/magazine/internal/shot/riot
 	name = "riot shotgun internal magazine"
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -417,7 +417,7 @@
 	can_unsuppress = 0
 	slot_flags = null
 	origin_tech = "" // NO GIVAWAYS
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised/cane
 	sawn_desc = "I'm sorry, but why did you saw your cane in the first place?"
 	attack_verb = list("bludgeoned", "whacked", "disciplined", "thrashed")
 	fire_sound = 'sound/weapons/Gunshot_silenced.ogg'

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -109,6 +109,15 @@
 	range = rand(1, 10)
 	..()
 
+/obj/item/projectile/bullet/pellet/assassination
+	damage = 12
+	tile_dropoff = 1	// slightly less damage and greater damage falloff compared to normal buckshot
+
+/obj/item/projectile/bullet/pellet/assassination/on_hit(atom/target, blocked = 0)
+	if(..(target, blocked))
+		var/mob/living/M = target
+		M.AdjustSilence(2)	// HELP MIME KILLING ME IN MAINT
+
 /obj/item/projectile/bullet/pellet/overload/on_hit(atom/target, blocked = 0)
  	..()
  	explosion(target, 0, 0, 2)


### PR DESCRIPTION
**What does this PR do:**
Currently, the assassination darts included with the mime exclusive cane shotgun are extremely weak and not worth using at all. They only cause 6 brute damage and inject 6 units of neurotoxin which just makes their screen shake slightly.

This change reworks the assassination dart entirely by changing it into a specialised buckshot shell which will silence the victim for a couple of seconds for each pellet that hits, but deals a little less damage and has greater damage falloff compared to the normal buckshot shell. The silencing effect not only stops them calling for help over the radio, but it also prevents them from screaming when they get shot. This is counterbalanced by the fact that it's almost useless at anything other than point blank range and that you will need more than a single shell to kill a target.

The cane shotgun has also been given it's own internal magazine rather than just using the improvised shotgun's one. This just means it can have an assassination shell preloaded rather than the weak improvised shell it currently starts with.

The cane shotgun otherwise behaves the same as before and can be loaded with other shells should the included ones run out.

**Changelog:**
:cl:
add: New cane shotgun assassination shells. These buckshot shells are coated with a mute toxin which will prevent anyone hit either calling for help or screaming in pain.
del: Old cane shotgun assassination darts.
tweak: Cane shotgun now uses its own internal magazine rather than copying the code for the improvised one. It also now starts with an assassination shell preloaded.
/:cl:
