### PR TITLE
Added self-repair ability for maintenance drones.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -52,7 +52,7 @@
 /mob/living/silicon/robot/drone/verb/self_repair()
 	set name = "Self Repair"
 	set category = "Drone"
-	set desc = "Attempts to repair damage to our body. You will have to remain motionless until repairs are complete."
+	set desc = "Activates a high powered built-in repair module to fix you. You will have to remain motionless until repairs are complete."
 	if(!isturf(loc))
 		return
 	if(cell.charge < 2500)
@@ -60,6 +60,8 @@
 		return
 	to_chat(src, "<span class='info'>Attempting to run repair module. Please stand by.</span>")
 	if(do_mob(src, src, 200)) // Takes longer than the swarmer's self repair
+		if(cell.charge < 2500)
+			return
 		cell.charge -= 2500 // Drones don't have resources, so use their internal battery to give repairing a cost
 		heal_overall_damage(15, 15) // Small heal rather than outright fully repairing them
 		to_chat(src, "<span class='info'>We successfully repaired ourselves.</span>")

--- a/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_abilities.dm
@@ -49,6 +49,21 @@
 	else
 		..()
 
+/mob/living/silicon/robot/drone/verb/self_repair()
+	set name = "Self Repair"
+	set category = "Drone"
+	set desc = "Attempts to repair damage to our body. You will have to remain motionless until repairs are complete."
+	if(!isturf(loc))
+		return
+	if(cell.charge < 2500)
+		to_chat(src, "You do not have enough power in your internal battery to run your repair module!")
+		return
+	to_chat(src, "<span class='info'>Attempting to run repair module. Please stand by.</span>")
+	if(do_mob(src, src, 200)) // Takes longer than the swarmer's self repair
+		cell.charge -= 2500 // Drones don't have resources, so use their internal battery to give repairing a cost
+		heal_overall_damage(15, 15) // Small heal rather than outright fully repairing them
+		to_chat(src, "<span class='info'>We successfully repaired ourselves.</span>")
+
 /mob/living/silicon/robot/drone/verb/customize()
 	set name = "Customize Chassis"
 	set desc = "Reconfigure your chassis into a customized version."


### PR DESCRIPTION
**What does this PR do:**
Adds a new ability for maintenance drones in their verbs tab to allow them to repair themselves. This requires them to stay still for a fair while and will cost them a chunk of their power but will heal them for a small amount of brute and burn damage. This is copied from the swarmer's self-repair ability but is weaker due to the smaller size and less advanced technology the drones use.

This was suggested on discord as a means of allowing maintenance drones to get themselves fixed if damaged without seeking the crew's assistance. This allows them to ignore the crew entirely and remain self-sufficient while keeping the station running smoothly.

I'm not 100% sure on some of the values I've chosen for things like power usage and damage repaired, so I'm open to any better suggestions if people have them.

**Changelog:**
:cl:
add: Added self-repair ability for maintenance drones. Can be found under their verbs tab.
/:cl:

