### PR TITLE
Ghost hud option: All

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -311,21 +311,21 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	switch(data_hud_seen) //give new huds
 		if(0)
-			data_hud_seen = 1
+			data_hud_seen++
 			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			to_chat(src, "<span class='notice'>Security HUD set.</span>")
 		if(1)
-			data_hud_seen = 2
+			data_hud_seen++
 			remove_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>Medical HUD set.</span>")
 		if(2)
-			data_hud_seen = 3
+			data_hud_seen++
 			remove_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			show_me_the_hud(DATA_HUD_DIAGNOSTIC)
 			to_chat(src, "<span class='notice'>Diagnostic HUD set.</span>")
 		if(3)
-			data_hud_seen = 4
+			data_hud_seen++
 			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>All HUDs enabled.</span>")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -25,7 +25,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 	var/image/ghostimage = null //this mobs ghost image, for deleting and stuff
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	var/seedarkness = 1
-	var/data_hud_seen = 0 //this should one of the defines in __DEFINES/hud.dm
+	var/data_hud_seen = FALSE //this should one of the defines in __DEFINES/hud.dm
 
 /mob/dead/observer/New(var/mob/body=null, var/flags=1)
 	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
@@ -310,7 +310,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	switch(data_hud_seen) //give new huds
-		if(0)
+		if(FALSE)
 			data_hud_seen = DATA_HUD_SECURITY_ADVANCED
 			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			to_chat(src, "<span class='notice'>Security HUD set.</span>")
@@ -325,11 +325,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			show_me_the_hud(DATA_HUD_DIAGNOSTIC)
 			to_chat(src, "<span class='notice'>Diagnostic HUD set.</span>")
 		if(DATA_HUD_DIAGNOSTIC)
+			data_hud_seen = data_hud_seen + DATA_HUD_SECURITY_ADVANCED + DATA_HUD_MEDICAL_ADVANCED
 			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>All HUDs enabled.</span>")
 		else
-			data_hud_seen = 0
+			data_hud_seen = FALSE
 			remove_the_hud(DATA_HUD_DIAGNOSTIC)
 			remove_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			remove_the_hud(DATA_HUD_MEDICAL_ADVANCED)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -297,30 +297,43 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/proc/show_me_the_hud(hud_index)
 	var/datum/atom_hud/H = huds[hud_index]
 	H.add_hud_to(src)
-	data_hud_seen = hud_index
+
+/mob/dead/observer/proc/remove_the_hud(hud_index) //remove old huds
+	var/datum/atom_hud/H = huds[hud_index]
+	H.remove_hud_from(src)
 
 /mob/dead/observer/verb/toggle_medHUD()
 	set category = "Ghost"
-	set name = "Toggle Medic/Sec/DiagHUD"
-	set desc = "Toggles the medical HUD."
+	set name = "Toggle Medic/Sec/Diag/All HUDs"
+	set desc = "Toggles the HUDs."
 	if(!client)
 		return
-	if(data_hud_seen) //remove old huds
-		var/datum/atom_hud/H = huds[data_hud_seen]
-		H.remove_hud_from(src)
 
 	switch(data_hud_seen) //give new huds
 		if(0)
+			data_hud_seen = 1
 			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			to_chat(src, "<span class='notice'>Security HUD set.</span>")
-		if(DATA_HUD_SECURITY_ADVANCED)
+		if(1)
+			data_hud_seen = 2
+			remove_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>Medical HUD set.</span>")
-		if(DATA_HUD_MEDICAL_ADVANCED)
+		if(2)
+			data_hud_seen = 3
+			remove_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			show_me_the_hud(DATA_HUD_DIAGNOSTIC)
 			to_chat(src, "<span class='notice'>Diagnostic HUD set.</span>")
-		if(DATA_HUD_DIAGNOSTIC)
+		if(3)
+			data_hud_seen = 4
+			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
+			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
+			to_chat(src, "<span class='notice'>All HUDs enabled.</span>")
+		if(4)
 			data_hud_seen = 0
+			remove_the_hud(DATA_HUD_DIAGNOSTIC)
+			remove_the_hud(DATA_HUD_SECURITY_ADVANCED)
+			remove_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>HUDs disabled.</span>")
 
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -311,25 +311,24 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	switch(data_hud_seen) //give new huds
 		if(0)
-			data_hud_seen++
+			data_hud_seen = DATA_HUD_SECURITY_ADVANCED
 			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			to_chat(src, "<span class='notice'>Security HUD set.</span>")
-		if(1)
-			data_hud_seen++
+		if(DATA_HUD_SECURITY_ADVANCED)
+			data_hud_seen = DATA_HUD_MEDICAL_ADVANCED
 			remove_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>Medical HUD set.</span>")
-		if(2)
-			data_hud_seen++
+		if(DATA_HUD_MEDICAL_ADVANCED)
+			data_hud_seen = DATA_HUD_DIAGNOSTIC
 			remove_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			show_me_the_hud(DATA_HUD_DIAGNOSTIC)
 			to_chat(src, "<span class='notice'>Diagnostic HUD set.</span>")
-		if(3)
-			data_hud_seen++
+		if(DATA_HUD_DIAGNOSTIC)
 			show_me_the_hud(DATA_HUD_SECURITY_ADVANCED)
 			show_me_the_hud(DATA_HUD_MEDICAL_ADVANCED)
 			to_chat(src, "<span class='notice'>All HUDs enabled.</span>")
-		if(4)
+		else
 			data_hud_seen = 0
 			remove_the_hud(DATA_HUD_DIAGNOSTIC)
 			remove_the_hud(DATA_HUD_SECURITY_ADVANCED)


### PR DESCRIPTION
**What does this PR do:**
As title says, adds an option after the other HUD toggles that let you see them all at once.

![ghost_hud](https://user-images.githubusercontent.com/15495375/50730370-f446a280-114b-11e9-85f4-7559f5736c71.png)


**Changelog:**
:cl: Alonefromhell
add: Added an "All" option to ghost hud vision.
/:cl:

