### PR TITLE
Fixes Auto Injectors

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -102,7 +102,8 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(10)
 	volume = 10
-	ignore_flags = 1 //so you can medipen through hardsuits
+	ignore_flags = TRUE //so you can medipen through hardsuits
+	container_type = DRAWABLE
 	flags = null
 	list_reagents = list("epinephrine" = 10)
 


### PR DESCRIPTION
The container refactor broke auto-injectors, making them refillable.

This pretty much has led to auto-injectors being a free parapen that everyone spawns with; all sorts of problems are to be had because of this.

Either case, this corrects the issue.

:cl: Fox McCloud
fix: Fixes auto-injectors being free parapens
/:cl: