### PR TITLE
Reduces the cost of the Binary Key and increases the cost of the Encryption Key

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1191,7 +1191,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary."
 	reference = "BITK"
 	item = /obj/item/encryptionkey/binary
-	cost = 5
+	cost = 2
 	surplus = 75
 
 /datum/uplink_item/device_tools/cipherkey
@@ -1199,7 +1199,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A key, that when inserted into a radio headset, allows you to listen to all station department channels as well as talk on an encrypted Syndicate channel."
 	reference = "SEK"
 	item = /obj/item/encryptionkey/syndicate
-	cost = 2 //Nowhere near as useful as the Binary Key!
+	cost = 4
 	surplus = 75
 
 /datum/uplink_item/device_tools/hacked_module


### PR DESCRIPTION
**What does this PR do:**
Binary Key from 5TC to 2TC
Syndicate Encryption Key from 2TC to 4TC

Let's be honest, the Binary Key is much less useful than having access to all comms and the ability to talk to other traitors without being detected, compared to listening to the AI, which mind is still useful. However, if the AI is not a traitor, talking on robot comms would give yourself away and if it was a traitor, it gets traitor comms anyway, making the Binary key seem moot. These price changes adjust their usefulness to according levels of cost.

:cl:Spartan
balance: Binary Translator Key now costs 2TC instead of 5TC
balance: Syndicate Encryption Key now costs 4TC instead of 2TC
/:cl:

