### PR TITLE
Renames and Reorganises ammunition for the Uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -531,14 +531,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/batterer
 	cost = 5
 
-/datum/uplink_item/ammo/bioterror
-	name = "Box of Bioterror Syringes"
-	desc = "A box full of preloaded syringes, containing various chemicals that seize up the victim's motor and broca system , making it impossible for them to move or speak while in their system."
-	reference = "BTS"
-	item = /obj/item/storage/box/syndie_kit/bioterror
-	cost = 5
-	gamemodes = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/dangerous/gygax
 	name = "Gygax Exosuit"
 	desc = "A lightweight exosuit, painted in a dark scheme. Its speed and equipment selection make it excellent for hit-and-run style attacks. \
@@ -588,15 +580,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
-/datum/uplink_item/ammo/toydarts
-	name = "Box of Riot Darts"
-	desc = "A box of 40 Donksoft foam riot darts, for reloading any compatible foam dart gun. Don't forget to share!"
-	reference = "FOAM"
-	item = /obj/item/ammo_box/foambox/riot
-	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
-	surplus = 0
-
 /datum/uplink_item/dangerous/guardian
 	name = "Holoparasites"
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an organic host as a home base and source of fuel. \
@@ -615,50 +598,35 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 40
 
 /datum/uplink_item/ammo/pistol
-	name = "Magazine - 10mm"
+	name = "Stechkin - 10mm Magazine"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds that are cheap but around half as effective as .357"
 	reference = "10MM"
 	item = /obj/item/ammo_box/magazine/m10mm
 	cost = 1
 
 /datum/uplink_item/ammo/pistolap
-	name = "Magazine - 10mm Armour Piercing"
+	name = "Stechkin - 10mm Armour Piercing Magazine"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds that are less effective at injuring the target but penetrate protective gear."
 	reference = "10MMAP"
 	item = /obj/item/ammo_box/magazine/m10mm/ap
 	cost = 2
 
 /datum/uplink_item/ammo/pistolfire
-	name = "Magazine - 10mm Incendiary"
+	name = "Stechkin - 10mm Incendiary Magazine"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with incendiary rounds which ignite the target."
 	reference = "10MMFIRE"
 	item = /obj/item/ammo_box/magazine/m10mm/fire
 	cost = 2
 
 /datum/uplink_item/ammo/pistolhp
-	name = "Magazine - 10mm Hollow Point"
+	name = "Stechkin - 10mm Hollow Point Magazine"
 	desc = "An additional 8-round 10mm magazine for use in the syndicate pistol, loaded with rounds which are more damaging but ineffective against armour."
 	reference = "10MMHP"
 	item = /obj/item/ammo_box/magazine/m10mm/hp
 	cost = 3
 
-/datum/uplink_item/ammo/revolver
-	name = "Speed Loader - .357"
-	desc = "A speed loader that contains seven additional .357 Magnum rounds for the syndicate revolver. For when you really need a lot of things dead."
-	reference = "357"
-	item = /obj/item/ammo_box/a357
-	cost = 3
-
-/datum/uplink_item/ammo/smg
-	name = "Magazine - .45"
-	desc = "An additional 20-round .45 magazine for use in the C-20r submachine gun. These bullets pack a lot of punch that can knock most targets down, but do limited overall damage."
-	reference = "45"
-	item = /obj/item/ammo_box/magazine/smgm45
-	cost = 2
-	gamemodes = list(/datum/game_mode/nuclear)
-
 /datum/uplink_item/ammo/ammobag
-	name = "Ammo Duffelbag - Shotgun Ammo Grab Bag"
+	name = "Bulldog - Shotgun Ammo Grab Bag"
 	desc = "A duffelbag filled with Bulldog ammo to kit out an entire team, at a discounted price."
 	reference = "SAGL"
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/loaded
@@ -666,7 +634,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bullslug
-	name = "Drum Magazine - 12g Slugs"
+	name = "Bulldog - 12g Slug Magazine"
 	desc = "An additional 8-round slug magazine for use in the Bulldog shotgun. Now 8 times less likely to shoot your pals."
 	reference = "12BSG"
 	item = /obj/item/ammo_box/magazine/m12g
@@ -674,7 +642,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bullbuck
-	name = "Drum Magazine - 12g buckshot"
+	name = "Bulldog - 12g Buckshot Magazine"
 	desc = "An additional 8-round buckshot magazine for use in the Bulldog shotgun. Front towards enemy."
 	reference = "12BS"
 	item = /obj/item/ammo_box/magazine/m12g/buckshot
@@ -682,7 +650,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bullstun
-	name = "Drum Magazine - 12g Stun Slug"
+	name = "Bulldog - 12g Stun Slug Magazine"
 	desc = "An alternative 8-round stun slug magazine for use in the Bulldog shotgun. Saying that they're completely non-lethal would be lying."
 	reference = "12SS"
 	item = /obj/item/ammo_box/magazine/m12g/stun
@@ -690,15 +658,23 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bulldragon
-	name = "Drum Magazine - 12g Dragon's Breath"
+	name = "Bulldog - 12g Dragon's Breath Magazine"
 	desc = "An alternative 8-round dragon's breath magazine for use in the Bulldog shotgun. I'm a fire starter, twisted fire starter!"
 	reference = "12DB"
 	item = /obj/item/ammo_box/magazine/m12g/dragon
 	cost = 2
 	gamemodes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/ammo/smg
+	name = "C-20r - .45 Magazine"
+	desc = "An additional 20-round .45 magazine for use in the C-20r submachine gun. These bullets pack a lot of punch that can knock most targets down, but do limited overall damage."
+	reference = "45"
+	item = /obj/item/ammo_box/magazine/smgm45
+	cost = 2
+	gamemodes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/ammo/carbine
-	name = "Toploader Magazine - 5.56"
+	name = "Carbine - 5.56 Toploader Magazine"
 	desc = "An additional 30-round 5.56 magazine for use in the M-90gl carbine. These bullets don't have the punch to knock most targets down, but dish out higher overall damage."
 	reference = "556"
 	item = /obj/item/ammo_box/magazine/m556
@@ -706,7 +682,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/a40mm
-	name = "Ammo Box - 40mm grenades"
+	name = "Carbine - 40mm Grenade Ammo Box"
 	desc = "A box of 4 additional 40mm HE grenades for use the C-90gl's underbarrel grenade launcher. Your teammates will thank you to not shoot these down small hallways."
 	reference = "40MM"
 	item = /obj/item/ammo_box/a40mm
@@ -714,7 +690,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/machinegun
-	name = "Box Magazine - 5.56x45mm"
+	name = "L6 SAW - 5.56x45mm Box Magazine"
 	desc = "A 50-round magazine of 5.56x45mm ammunition for use in the L6 SAW machine gun. By the time you need to use this, you'll already be on a pile of corpses."
 	reference = "762"
 	item = /obj/item/ammo_box/magazine/mm556x45
@@ -727,32 +703,56 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/sniper/basic
-	name = ".50 Magazine"
+	name = "Sniper - .50 Magazine"
 	desc = "An additional standard 6-round magazine for use with .50 sniper rifles."
 	reference = "50M"
 	item = /obj/item/ammo_box/magazine/sniper_rounds
 
 /datum/uplink_item/ammo/sniper/soporific
-	name = ".50 Soporific Magazine"
+	name = "Sniper - .50 Soporific Magazine"
 	desc = "A 3-round magazine of soporific ammo designed for use with .50 sniper rifles. Put your enemies to sleep today!"
 	reference = "50S"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/soporific
 	cost = 3
 
 /datum/uplink_item/ammo/sniper/haemorrhage
-	name = ".50 Haemorrhage Magazine"
+	name = "Sniper - .50 Haemorrhage Magazine"
 	desc = "A 5-round magazine of haemorrhage ammo designed for use with .50 sniper rifles; causes heavy bleeding \
 			in the target."
 	reference = "50B"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/haemorrhage
 
 /datum/uplink_item/ammo/sniper/penetrator
-	name = ".50 Penetrator Magazine"
+	name = "Sniper - .50 Penetrator Magazine"
 	desc = "A 5-round magazine of penetrator ammo designed for use with .50 sniper rifles. \
 			Can pierce walls and multiple enemies."
 	reference = "50P"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/penetrator
 	cost = 5
+
+/datum/uplink_item/ammo/bioterror
+	name = "Box of Bioterror Syringes"
+	desc = "A box full of preloaded syringes, containing various chemicals that seize up the victim's motor and broca system , making it impossible for them to move or speak while in their system."
+	reference = "BTS"
+	item = /obj/item/storage/box/syndie_kit/bioterror
+	cost = 5
+	gamemodes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/toydarts
+	name = "Box of Riot Darts"
+	desc = "A box of 40 Donksoft foam riot darts, for reloading any compatible foam dart gun. Don't forget to share!"
+	reference = "FOAM"
+	item = /obj/item/ammo_box/foambox/riot
+	cost = 2
+	gamemodes = list(/datum/game_mode/nuclear)
+	surplus = 0
+
+/datum/uplink_item/ammo/revolver
+	name = ".357 Revolver - Speedloader"
+	desc = "A speed loader that contains seven additional .357 Magnum rounds for the syndicate revolver. For when you really need a lot of things dead."
+	reference = "357"
+	item = /obj/item/ammo_box/a357
+	cost = 3
 
 // STEALTHY WEAPONS
 


### PR DESCRIPTION
**What does this PR do:**
The ammunition list for nukies is pretty long and doesn't make it all that obvious which magazine fits which gun. I've added the name of the weapon to the beginning of each ammunition item and reordered some of the items since some of them were in odd locations in the code (bioterror syringes and foam darts were grouped with the dangerous weapons for one).

For reference, here's what the current list looks like for nuke ops:

![image](https://user-images.githubusercontent.com/44248086/50742014-69be7b80-11fd-11e9-84cb-cb077404406f.png)

Here's an image of what it would look like following these changes:

![image](https://user-images.githubusercontent.com/44248086/50741854-28c56780-11fb-11e9-8ec6-1f9d251d7b8c.png)

**Changelog:**
:cl:
spellcheck: Renamed and reorganized the ammunition in the uplink to make it easier for Nuclear Operatives to find the right ammo for their gun.
/:cl:

