### PR TITLE
Fixes BSA size issues

### DIFF
--- a/code/__DEFINES/station_goals.dm
+++ b/code/__DEFINES/station_goals.dm
@@ -1,0 +1,8 @@
+#define BSA_SIZE_FRONT		4
+#define BSA_SIZE_BACK		6
+
+#define VAULT_SPACEIMMUNE "Space Immunity"
+#define VAULT_XRAY "X-Ray Vision"
+#define VAULT_TELEKINESIS "Telekinesis"
+#define VAULT_PSYCHIC "Psychic Powers"
+#define VAULT_SPEED "Speediness"

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -2,6 +2,7 @@
 // Cargo orders part for high price
 // Requires high amount of power
 // Requires high level stock parts
+
 /datum/station_goal/bluespace_cannon
 	name = "Bluespace Artillery"
 
@@ -104,11 +105,11 @@
 	var/x_max
 	switch(cannon_dir)
 		if(EAST)
-			x_min = x - 4 //replace with defines later
-			x_max = x + 6
+			x_min = x - BSA_SIZE_BACK
+			x_max = x + BSA_SIZE_FRONT
 		if(WEST)
-			x_min = x + 4
-			x_max = x - 6
+			x_min = x + BSA_SIZE_BACK
+			x_max = x - BSA_SIZE_FRONT
 
 	for(var/turf/T in block(locate(x_min,y-1,z),locate(x_max,y+1,z)))
 		if(T.density || isspaceturf(T))

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -3,11 +3,6 @@
 // DNA vault requires x animals ,y plants, z human dna
 // DNA vaults require high tier stock parts and cold
 // After completion each crewmember can receive single upgrade chosen out of 2 for the mob.
-#define VAULT_SPACEIMMUNE "Space Immunity"
-#define VAULT_XRAY "X-Ray Vision"
-#define VAULT_TELEKINESIS "Telekinesis"
-#define VAULT_PSYCHIC "Psychic Powers"
-#define VAULT_SPEED "Speediness"
 
 /datum/station_goal/dna_vault
 	name = "DNA Vault"
@@ -17,7 +12,7 @@
 
 /datum/station_goal/dna_vault/New()
 	..()
-	animal_count = rand(15,20) //might be too few given ~15 roundstart stationside ones
+	animal_count = rand(15, 20) //might be too few given ~15 roundstart stationside ones
 	human_count = rand(round(0.75 * ticker.mode.num_players_started()), ticker.mode.num_players_started()) // 75%+ roundstart population.
 	var/non_standard_plants = non_standard_plants_count()
 	plant_count = rand(round(0.5 * non_standard_plants),round(0.7 * non_standard_plants))

--- a/paradise.dme
+++ b/paradise.dme
@@ -57,6 +57,7 @@
 #include "code\__DEFINES\snpc.dm"
 #include "code\__DEFINES\sound.dm"
 #include "code\__DEFINES\stat.dm"
+#include "code\__DEFINES\station_goals.dm"
 #include "code\__DEFINES\status_effects.dm"
 #include "code\__DEFINES\subsystems.dm"
 #include "code\__DEFINES\tick.dm"


### PR DESCRIPTION
Fixes #10612

Fixes the BSA having its values for front and back size checks reversed; causing the BSA to clip through walls and preventing construction when there actually is space.

🆑
Fix: Fixed BSA size checks being reversed, causing the BSA to clip through walls or prevent construction.
/🆑