### PR TITLE
Remove default ID check on ED

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -36,7 +36,7 @@
 	var/target_lastloc //Loc of target when arrested.
 	var/last_found //There's a delay
 	var/declare_arrests = 1 //When making an arrest, should it notify everyone wearing sechuds?
-	var/idcheck = 1 //If true, arrest people with no IDs
+	var/idcheck = 0 //If true, arrest people with no IDs
 	var/weaponscheck = 1 //If true, arrest people for weapons if they don't have access
 	var/check_records = 1 //Does it check security records?
 	var/arrest_type = 0 //If true, don't handcuff


### PR DESCRIPTION
i ded to rads while ziptied pls change

Anyone who has ever interacted with an ED knows how frustrating it is that this dumbass setting is turned on by default

Even robotics is fucked by it since they can't unlock the bot to ACTUALLY REMOVE THE SETTING if it's turned on, because the dumbass bot will stun them as soon as they take the ID out
EDIT : Apparently robotics don't even have access to ED anymore, so they can't even turn it off then change the setting, this makes this PR even more relevant

This also makes no sense because small securitrons have it off by default, so it's inconsistent for no god damn reasons

This doesn't affect the ED syndicate subtype (on the depot)

🆑
tweak: ED bots no longer arrests you just because you have no ID by default
/🆑


