### PR TITLE
Fixes Glasses Not Blocking Eye Shine

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -147,7 +147,7 @@ var/global/list/damage_icon_parts = list()
 		E.update_icon()
 		if(E.damage_state == "00")
 			continue
-		
+
 		var/icon/DI
 		var/cache_index = "[E.damage_state]/[E.icon_name]/[dna.species.blood_color]/[dna.species.name]"
 
@@ -437,7 +437,7 @@ var/global/list/damage_icon_parts = list()
 		else
 			//warning("Invalid f_style for [species.name]: [f_style]")
 
-	
+
 
 /mob/living/carbon/human/update_mutations(var/update_icons=1)
 	remove_overlay(MUTATIONS_LAYER)
@@ -680,6 +680,8 @@ var/global/list/damage_icon_parts = list()
 		else
 			overlays_standing[GLASSES_LAYER] = new_glasses
 			apply_overlay(GLASSES_LAYER)
+
+	update_misc_effects()
 
 /mob/living/carbon/human/update_inv_ears(var/update_icons=1)
 	remove_overlay(EARS_LAYER)
@@ -1035,7 +1037,7 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/proc/update_tail_layer(var/update_icons=1)
 	remove_overlay(TAIL_UNDERLIMBS_LAYER) // SEW direction icons, overlayed by LIMBS_LAYER.
 	remove_overlay(TAIL_LAYER) /* This will be one of two things:
-							If the species' tail is overlapped by limbs, this will be only the N direction icon so tails 
+							If the species' tail is overlapped by limbs, this will be only the N direction icon so tails
 							can still appear on the outside of uniforms and such.
 							Otherwise, since the user's tail isn't overlapped by limbs, it will be a full icon with all directions. */
 
@@ -1110,7 +1112,7 @@ var/global/list/damage_icon_parts = list()
 /mob/living/carbon/human/proc/start_tail_wagging(var/update_icons=1)
 	remove_overlay(TAIL_UNDERLIMBS_LAYER) // SEW direction icons, overlayed by LIMBS_LAYER.
 	remove_overlay(TAIL_LAYER) /* This will be one of two things:
-							If the species' tail is overlapped by limbs, this will be only the N direction icon so tails 
+							If the species' tail is overlapped by limbs, this will be only the N direction icon so tails
 							can still appear on the outside of uniforms and such.
 							Otherwise, since the user's tail isn't overlapped by limbs, it will be a full icon with all directions. */
 


### PR DESCRIPTION
Wearing glasses is meant to block eye shine--but this isn't happening with most glasses. If glasses happen to alter or change any aspect of your icons, then it forces an update and things are ok (mesons, for example). 

That said, if your glasses don't create an update, you're left with a situation where your eyes float over top of your glasses.

This not only means your eyes shine, in the dark, but it makes glasses look weird.

Either case, having glasses icon updates trigger misc icon updates (currently only used for eye shine) is the simplest solution do this.

This means that updating the misc. layer will be done multiple times when `regenerate_icons` is called, but due to the large number of things that impact eye shine (augments, eyes, x-ray), it's just going to have to be in multiple places (currently only two).

:cl: Fox McCloud
fix: Fixes glasses not properly masking eye-shine
/:cl: