### PR TITLE
Nuke ops spawn with their pinpointer

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -266,7 +266,7 @@ proc/issyndicate(mob/living/M as mob)
 	synd_mob.equip_to_slot_or_del(new /obj/item/storage/backpack(synd_mob), slot_back)
 	synd_mob.equip_to_slot_or_del(new /obj/item/gun/projectile/automatic/pistol(synd_mob), slot_belt)
 	synd_mob.equip_to_slot_or_del(new /obj/item/storage/box/survival_syndi(synd_mob.back), slot_in_backpack)
-
+	synd_mob.equip_to_slot_or_del(new /obj/item/pinpointer/nukeop(synd_mob), slot_wear_pda)
 	var/obj/item/radio/uplink/nuclear/U = new /obj/item/radio/uplink/nuclear(synd_mob)
 	U.hidden_uplink.uplink_owner="[synd_mob.key]"
 	U.hidden_uplink.uses = 20

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -47,11 +47,6 @@
 	new /obj/item/gun/projectile/automatic/shotgun/bulldog(src)
 	new /obj/item/gun/projectile/automatic/shotgun/bulldog(src)
 	new /obj/item/gun/projectile/automatic/shotgun/bulldog(src)
-	new /obj/item/pinpointer/nukeop(src)
-	new /obj/item/pinpointer/nukeop(src)
-	new /obj/item/pinpointer/nukeop(src)
-	new /obj/item/pinpointer/nukeop(src)
-	new /obj/item/pinpointer/nukeop(src)
 	new /obj/item/pda/syndicate(src)
 
 /obj/structure/closet/syndicate/resources/


### PR DESCRIPTION
Continuing with changes to make nuke ops less of a clusterfuck to learn for new players...

Nuke ops now spawn with their pinpointer in the PDA slot. There's no reason not to do it, as the pinpointer is a MUST HAVE item for ops, and the PDA slot has no other use for them.

This change also teaches players who wouldn't know it that the pinpointer does fit in that slot, saving them storage.

Admin-outfit operatives already have an advanced pinpointer, so there's no change for them.

🆑
tweak: Nuke ops now spawn with their pinpointer.
/🆑