### PR TITLE
FiXes CaPs iN gUnS

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -379,7 +379,7 @@
 
 /obj/item/ammo_casing/cap
 	desc = "A cap for children toys."
-	caliber = "caps"
+	caliber = "cap"
 	projectile_type = /obj/item/projectile/bullet/cap
 
 /obj/item/ammo_casing/laser


### PR DESCRIPTION
:cl:
bugfix: Cap guns was checking for claiber type 'cap' when the ammo was set to caliber typer 'caps'. Fixed.
/:cl: