### PR TITLE
Fixes the QM cartridge showing the wrong shuttle location

### DIFF
--- a/code/modules/pda/cart_apps.dm
+++ b/code/modules/pda/cart_apps.dm
@@ -317,9 +317,9 @@
 		supplyData["shuttle_moving"] = 1
 
 	if(is_station_level(SSshuttle.supply.z))
-		supplyData["shuttle_loc"] = "station"
+		supplyData["shuttle_loc"] = "Station"
 	else
-		supplyData["shuttle_loc"] = "centcom"
+		supplyData["shuttle_loc"] = "CentCom"
 
 	supplyData["shuttle_time"] = "([SSshuttle.supply.timeLeft(600)] Mins)"
 


### PR DESCRIPTION
**What does this PR do:**
The QMs cartridge now shows the correct location of the cargo shuttle, and has some capitalization.

**Changelog:**
:cl:
fix: Fixed the QMs PDA supply app not showing the correct cargo shuttle location.
tweak: Changed the capitalization of CentCom and Station in the supply PDA cartridge.
/:cl:

