### PR TITLE
Sol Trader Updates 2

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -708,7 +708,8 @@
 	id = /obj/item/card/id/supply
 	pda = /obj/item/pda
 	backpack_contents = list(
-		/obj/item/storage/box/survival = 1
+		/obj/item/storage/box/survival = 1,
+		/obj/item/hand_labeler = 1
 	)
 
 /datum/outfit/admin/sol_trader/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -724,51 +724,18 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 	if(vox_total_kills > vox_allowed_kills) return 0
 	return 1
 
-// Traders
 
-/datum/objective/trade // Yes, I know there's no check_completion. The objectives exist only to tell the traders what to get.
-/datum/objective/trade/proc/choose_target(var/station)
+// Traders
+// These objectives have no check_completion, they exist only to tell Sol Traders what to aim for.
+
+/datum/objective/trade/proc/choose_target()
 	return
 
-/datum/objective/trade/stock // Stock or spare parts.
-	var/target_rating = 1
-/datum/objective/trade/stock/choose_target(var/station)
-	var/itemname
-	switch(rand(1,8))
-		if(1)
-			target = /obj/item/stock_parts/cell
-			target_amount = 10
-			target_rating = 3
-			itemname = "ten high-capacity power cells"
-		if(2)
-			target = /obj/item/stock_parts/manipulator
-			target_amount = 20
-			itemname = "twenty micro manipulators"
-		if(3)
-			target = /obj/item/stock_parts/matter_bin
-			target_amount = 20
-			itemname = "twenty matter bins"
-		if(4)
-			target = /obj/item/stock_parts/micro_laser
-			target_amount = 15
-			itemname = "fifteen micro-lasers"
-		if(5)
-			target = /obj/item/stock_parts/capacitor
-			target_amount = 15
-			itemname = "fifteen capacitors"
-		if(6)
-			target = /obj/item/stock_parts/subspace/filter
-			target_amount = 4
-			itemname = "four hyperwave filters"
-		if(7)
-			target = /obj/item/solar_assembly
-			target_amount = 10
-			itemname = "ten solar panel assemblies"
-		if(8)
-			target = /obj/item/flash
-			target_amount = 6
-			itemname = "six flashes"
-	explanation_text = "We are running low on spare parts. Trade for [itemname]."
+/datum/objective/trade/plasma/choose_target()
+	explanation_text = "Acquire at least 15 sheets of plasma through trade."
+
+/datum/objective/trade/credits/choose_target()
+	explanation_text = "Acquire at least 10,000 credits through trade."
 
 //wizard
 

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -192,23 +192,20 @@
 				/obj/item/clothing/under/psyjump = 50
 				)
 
-
 /obj/effect/spawner/lootdrop/trade_sol/minerals
 	name = "2. minerals"
 	lootdoubles = 1
 	loot = list(
 				// Common stuff you get from mining which isn't already present on the station
+				// Note that plasma and derived hybrid materials are NOT included in this list because plasma is the trader's objective!
 				/obj/item/stack/sheet/mineral/silver = 50,
 				/obj/item/stack/sheet/mineral/gold = 50,
-				/obj/item/stack/sheet/mineral/plasma = 50,
 				/obj/item/stack/sheet/mineral/uranium = 50,
 				/obj/item/stack/sheet/mineral/diamond = 50,
 				/obj/item/stack/sheet/mineral/titanium = 50,
 				/obj/item/stack/sheet/plasteel = 50,
 
 				// Hybrid stuff you could in theory get from mining
-				/obj/item/stack/sheet/plasmaglass = 50,
-				/obj/item/stack/sheet/plasmarglass = 50,
 				/obj/item/stack/sheet/titaniumglass = 50,
 
 				// Rare stuff you can't get from mining

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -256,7 +256,6 @@
 				/obj/item/autoimplanter = 50,
 
 				// Research / Experimentor
-				/obj/item/relic = 150, // strange object
 				/obj/item/paper/researchnotes = 150, // papers that give random R&D levels
 
 				// Xenobio
@@ -312,8 +311,8 @@
 	loot = list(
 				/obj/item/storage/belt/utility/chief/full = 25,
 				/obj/item/rcd/combat = 25,
+				/obj/item/rpd/bluespace = 25,
 				/obj/item/tank/emergency_oxygen/double/full = 25,
-
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/largeitem

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -261,7 +261,6 @@
 				// Xenobio
 				/obj/item/slimepotion/sentience = 50, // Low-value, but we want to encourage getting more players back in the round.
 				/obj/item/slimepotion/transference = 50,
-				/obj/item/slimepotion/speed = 50,
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/med
@@ -298,6 +297,7 @@
 				// Utility
 				/obj/item/storage/belt/military/assault = 50,
 				/obj/item/clothing/mask/gas/sechailer/swat = 50,
+				/obj/item/clothing/glasses/thermal = 50, // see heat-source mobs through walls. Less powerful than already-available xray.
 
 				// Ranged weapons
 				/obj/item/storage/box/enforcer_rubber = 50,
@@ -313,6 +313,10 @@
 				/obj/item/rcd/combat = 25,
 				/obj/item/rpd/bluespace = 25,
 				/obj/item/tank/emergency_oxygen/double/full = 25,
+				/obj/item/slimepotion/speed = 25,
+				/obj/item/storage/backpack/holding = 25,
+				/obj/item/clothing/glasses/meson/night = 25, // NV mesons
+				/obj/item/clothing/glasses/material = 25, // shows objects, but not mobs, through walls
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/largeitem

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -189,7 +189,9 @@
 				/obj/item/soap/syndie = 50,
 				/obj/item/lighter/zippo/gonzofist = 50,
 				/obj/item/stack/nanopaste = 50,
-				/obj/item/clothing/under/psyjump = 50
+				/obj/item/clothing/under/psyjump = 50,
+				/obj/item/immortality_talisman = 50,
+				/obj/item/grenade/clusterbuster/smoke = 50
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/minerals
@@ -213,8 +215,7 @@
 				/obj/item/stack/sheet/mineral/bananium = 50,
 				/obj/item/stack/sheet/wood = 50,
 				/obj/item/stack/sheet/plastic = 50,
-				/obj/item/stack/sheet/mineral/sandstone = 50,
-
+				/obj/item/stack/sheet/mineral/sandstone = 50
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/minerals/New()
@@ -241,7 +242,7 @@
 				/obj/item/gun/projectile/automatic/toy/pistol/enforcer = 50,
 				/obj/item/gun/projectile/shotgun/toy = 50,
 				/obj/item/gun/projectile/shotgun/toy/crossbow = 50,
-				/obj/item/gun/projectile/shotgun/toy/tommygun = 50,
+				/obj/item/gun/projectile/shotgun/toy/tommygun = 50
 				)
 
 
@@ -260,7 +261,7 @@
 
 				// Xenobio
 				/obj/item/slimepotion/sentience = 50, // Low-value, but we want to encourage getting more players back in the round.
-				/obj/item/slimepotion/transference = 50,
+				/obj/item/slimepotion/transference = 50
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/med
@@ -279,12 +280,11 @@
 				// Genetics Research (should really be under science, but I was stuck for items to put in medical)
 				/obj/item/dnainjector/regenerate = 50, // regeneration
 				/obj/item/dnainjector/nobreath = 50,
-				/obj/item/dnainjector/midgit = 50,
 				/obj/item/dnainjector/telemut = 50,
 
 				// Virology
 				/obj/item/reagent_containers/glass/bottle/regeneration = 50,
-				/obj/item/reagent_containers/glass/bottle/sensory_restoration = 50,
+				/obj/item/reagent_containers/glass/bottle/sensory_restoration = 50
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/sec
@@ -304,6 +304,10 @@
 				/obj/item/storage/box/enforcer_lethal = 50,
 				/obj/item/gun/projectile/shotgun/automatic/combat = 50, // combat shotgun, between riot and bulldog in robustness. Not illegal, can be obtained from cargo.
 				/obj/item/gun/projectile/shotgun/automatic/dual_tube = 50, // cycler shotgun, not normally available to crew
+
+				// Cluster grenades
+				/obj/item/grenade/clusterbuster = 50, // cluster flashbang
+				/obj/item/grenade/clusterbuster/teargas = 50
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/eng
@@ -317,6 +321,7 @@
 				/obj/item/storage/backpack/holding = 25,
 				/obj/item/clothing/glasses/meson/night = 25, // NV mesons
 				/obj/item/clothing/glasses/material = 25, // shows objects, but not mobs, through walls
+				/obj/item/grenade/clusterbuster/metalfoam = 25 // cluster metal foam grenade
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/largeitem
@@ -324,7 +329,7 @@
 	lootcount = 1
 	loot = list(
 				/obj/machinery/disco = 20,
-				/obj/mecha/combat/durand/old = 20,
+				/obj/mecha/combat/durand/old = 20
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/vehicle
@@ -353,18 +358,22 @@
 				// Mining
 				/obj/item/mining_voucher = 100,
 				/obj/item/pickaxe/drill/jackhammer = 100,
-				/obj/item/stack/sheet/animalhide/goliath_hide = 100,
 				/obj/item/gun/energy/kinetic_accelerator/experimental = 100,
+				/obj/item/borg/upgrade/modkit/aoe/turfs/andmobs = 100,
 
 				// Botanist
 				/obj/item/seeds/random/labelled = 100,
 
 				// Clown
-				/obj/item/grenade/bananade = 100,
+				/obj/item/grenade/clusterbuster/honk = 100,
 				/obj/item/bikehorn/golden = 100,
 
+				// Bartender
+				/obj/item/storage/box/bartender_rare_ingredients_kit = 100,
 
-				// It would be nice to also have items for other service jobs: Bartender, Mime, Chef, Librarian, Chaplain, etc
+				// Chef
+				/obj/item/storage/box/chef_rare_ingredients_kit = 100
+				// It would be nice to also have items for other service jobs: Mime, Librarian, Chaplain, etc
 				)
 
 

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -276,6 +276,7 @@
 				// Surgery
 				/obj/item/scalpel/laser/manager = 100,
 				/obj/item/organ/internal/heart/gland/ventcrawling = 50,
+				/obj/item/organ/internal/heart/gland/heals = 50,
 
 				// Genetics Research (should really be under science, but I was stuck for items to put in medical)
 				/obj/item/dnainjector/regenerate = 50, // regeneration
@@ -300,15 +301,19 @@
 				/obj/item/clothing/mask/gas/sechailer/swat = 50,
 
 				// Ranged weapons
+				/obj/item/storage/box/enforcer_rubber = 50,
+				/obj/item/storage/box/enforcer_lethal = 50,
 				/obj/item/gun/projectile/shotgun/automatic/combat = 50, // combat shotgun, between riot and bulldog in robustness. Not illegal, can be obtained from cargo.
+				/obj/item/gun/projectile/shotgun/automatic/dual_tube = 50, // cycler shotgun, not normally available to crew
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/eng
 	name = "7. eng gear"
-	lootcount = 3
 	loot = list(
 				/obj/item/storage/belt/utility/chief/full = 25,
 				/obj/item/rcd/combat = 25,
+				/obj/item/tank/emergency_oxygen/double/full = 25,
+
 				)
 
 /obj/effect/spawner/lootdrop/trade_sol/largeitem

--- a/code/game/objects/items/weapons/grenades/clusterbuster.dm
+++ b/code/game/objects/items/weapons/grenades/clusterbuster.dm
@@ -104,7 +104,7 @@
 	payload = /obj/item/grenade/chem_grenade/cleaner
 
 /obj/item/grenade/clusterbuster/teargas
-	name = "Oignon Grenade"
+	name = "Oignon Teargas Grenade"
 	payload = /obj/item/grenade/chem_grenade/teargas
 
 /obj/item/grenade/clusterbuster/facid

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -702,6 +702,34 @@
 	new /obj/item/ammo_box/magazine/enforcer/lethal(src)
 	new /obj/item/ammo_box/magazine/enforcer/lethal(src)
 
+/obj/item/storage/box/bartender_rare_ingredients_kit
+	name = "bartender rare reagents kit"
+	desc = "A box intended for experienced bartenders."
+
+/obj/item/storage/box/bartender_rare_ingredients_kit/New()
+	..()
+	var/list/reagent_list = list("sacid", "radium", "ether", "methamphetamine", "plasma", "gold", "silver", "capsaicin", "psilocybin")
+	for(var/reag in reagent_list)
+		var/obj/item/reagent_containers/glass/bottle/B = new(src)
+		B.reagents.add_reagent(reag, 30)
+		B.name = "[reag] bottle"
+
+/obj/item/storage/box/chef_rare_ingredients_kit
+	name = "chef rare reagents kit"
+	desc = "A box intended for experienced chefs."
+
+/obj/item/storage/box/chef_rare_ingredients_kit/New()
+	..()
+	new /obj/item/reagent_containers/food/condiment/soysauce(src)
+	new /obj/item/reagent_containers/food/condiment/enzyme(src)
+	new /obj/item/reagent_containers/food/condiment/pack/hotsauce(src)
+	new /obj/item/kitchen/knife/butcher(src)
+	var/list/reagent_list = list("msg", "triple_citrus", "salglu_solution", "nutriment", "gravy", "honey", "vitfro")
+	for(var/reag in reagent_list)
+		var/obj/item/reagent_containers/glass/bottle/B = new(src)
+		B.reagents.add_reagent(reag, 30)
+		B.name = "[reag] bottle"
+
 /obj/item/storage/box/mousetraps
 	name = "box of Pest-B-Gon mousetraps"
 	desc = "<B><FONT color='red'>WARNING:</FONT></B> <I>Keep out of reach of children</I>."

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -680,6 +680,28 @@
 		new /obj/item/clothing/head/syndicatefake(src)
 		new /obj/item/clothing/suit/syndicatefake(src)
 
+/obj/item/storage/box/enforcer_rubber
+	name = "enforcer pistol kit (rubber)"
+	desc = "A box marked with pictures of an enforcer pistol, two ammo clips, and the word 'NON-LETHAL'."
+	icon_state = "box_ert"
+
+/obj/item/storage/box/enforcer_rubber/New()
+	..()
+	new /obj/item/gun/projectile/automatic/pistol/enforcer(src) // loaded with rubber by default
+	new /obj/item/ammo_box/magazine/enforcer(src)
+	new /obj/item/ammo_box/magazine/enforcer(src)
+
+/obj/item/storage/box/enforcer_lethal
+	name = "enforcer pistol kit (lethal)"
+	desc = "A box marked with pictures of an enforcer pistol, two ammo clips, and the word 'LETHAL'."
+	icon_state = "box_ert"
+
+/obj/item/storage/box/enforcer_lethal/New()
+	..()
+	new /obj/item/gun/projectile/automatic/pistol/enforcer/lethal(src)
+	new /obj/item/ammo_box/magazine/enforcer/lethal(src)
+	new /obj/item/ammo_box/magazine/enforcer/lethal(src)
+
 /obj/item/storage/box/mousetraps
 	name = "box of Pest-B-Gon mousetraps"
 	desc = "<B><FONT color='red'>WARNING:</FONT></B> <I>Keep out of reach of children</I>."

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -194,7 +194,7 @@ var/list/event_last_fired = list()
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,						list(ASSIGNMENT_ENGINEER =  5),	1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",	/datum/event/abductor, 		    80, is_one_shot = 1),
 		new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			0, is_one_shot = 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			15, is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",			/datum/event/spider_terror, 		0,			list(ASSIGNMENT_SECURITY = 15), is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	15, is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = 1)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -194,7 +194,7 @@ var/list/event_last_fired = list()
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		0,						list(ASSIGNMENT_ENGINEER =  5),	1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Abductor Visit",	/datum/event/abductor, 		    80, is_one_shot = 1),
 		new /datum/event_meta/alien(EVENT_LEVEL_MAJOR, "Alien Infestation",	/datum/event/alien_infestation, 		0,		list(ASSIGNMENT_SECURITY = 15), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			15, is_one_shot = 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			180, is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",			/datum/event/spider_terror, 		0,			list(ASSIGNMENT_SECURITY = 15), is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	15, is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = 1)

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -55,17 +55,14 @@ var/global/list/unused_trade_stations = list("sol")
 		show_objectives(M.mind)
 
 /datum/event/traders/proc/forge_trader_objectives()
-	var/i = 1
-	var/max_objectives = pick(2, 2, 2, 2, 3, 3, 3, 4)
 	var/list/objs = list()
-	var/list/goals = list("stockparts")
-	while(i<= max_objectives)
-		var/goal = pick(goals)
-		var/datum/objective/trade/O
-		if(goal == "stockparts")
-			O = new /datum/objective/trade/stock(station)
-		O.choose_target()
-		objs += O
 
-		i++
+	var/datum/objective/trade/plasma/P = new /datum/objective/trade/plasma
+	P.choose_target()
+	objs += P
+
+	var/datum/objective/trade/credits/C = new /datum/objective/trade/credits
+	C.choose_target()
+	objs += C
+
 	return objs

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -16,6 +16,10 @@ var/global/list/unused_trade_stations = list("sol")
 /datum/event/traders/start()
 	if(!station) // If there are no unused stations, just no.
 		return
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_RED)
+		event_announcement.Announce("A trading shuttle from Jupiter Station has been denied docking permission due to the heightened security alert aboard [station_name()].", "Trader Shuttle Docking Request Refused")
+		return
+
 	var/list/spawnlocs = list()
 	for(var/obj/effect/landmark/landmark in GLOB.landmarks_list)
 		if(landmark.name == "traderstart_[station]")
@@ -44,7 +48,9 @@ var/global/list/unused_trade_stations = list("sol")
 				M.mind.objectives += trader_objectives
 				greet_trader(M)
 				success_spawn = 1
-		if(!success_spawn)
+		if(success_spawn)
+			event_announcement.Announce("A trading shuttle from Jupiter Station has been granted docking permission at [station_name()] arrivals port 4.", "Trader Shuttle Docking Request Accepted")
+		else
 			unused_trade_stations += station // Return the station to the list of usable stations.
 
 /datum/event/traders/proc/greet_trader(var/mob/living/carbon/human/M)

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -6,7 +6,7 @@ var/global/list/unused_trade_stations = list("sol")
 /datum/event/traders
 	var/success_spawn = 0
 	var/station = null
-	var/spawn_count = 3
+	var/spawn_count = 2
 	var/list/trader_objectives = list()
 
 /datum/event/traders/setup()
@@ -39,6 +39,7 @@ var/global/list/unused_trade_stations = list("sol")
 			var/turf/picked_loc = spawnlocs[index]
 			index++
 			var/mob/C = pick_n_take(candidates)
+			spawn_count--
 			if(C)
 				GLOB.respawnable_list -= C.client
 				var/mob/living/carbon/human/M = new /mob/living/carbon/human(picked_loc)

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -221,7 +221,7 @@
 	multiple_sprites = 1
 
 /obj/item/ammo_box/magazine/enforcer
-	name = "handgun magazine (9mm)"
+	name = "handgun magazine (9mm rubber)"
 	icon_state = "enforcer"
 	ammo_type = /obj/item/ammo_casing/rubber9mm
 	max_ammo = 8
@@ -250,6 +250,7 @@
 	return 0
 
 /obj/item/ammo_box/magazine/enforcer/lethal
+	name = "handgun magazine (9mm)"
 	ammo_type = /obj/item/ammo_casing/c9mm
 
 /obj/item/ammo_box/magazine/wt550m9

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -142,11 +142,10 @@
 
 /obj/item/gun/energy/kinetic_accelerator/experimental
 	name = "experimental kinetic accelerator"
-	desc = "A modified, far more dangerous version of the proto-kinetic accelerator, with half the cooldown and twice the modkit space of the standard version."
+	desc = "A modified version of the proto-kinetic accelerator, with twice the modkit space of the standard version."
 	icon_state = "kineticgun_h"
 	item_state = "kineticgun_h"
 	origin_tech = "combat=5;powerstorage=3;engineering=5"
-	overheat_time = 8
 	max_mod_capacity = 200
 
 //Casing


### PR DESCRIPTION
:cl: Kyep
fix: Fixes bug which can cause more than 2 traders to spawn during the Sol Trader event.
tweak: Further improved sol trader event in general.
add: Enabled sol trader event to happen late-round as a randomly chosen event. Can only happen if the alert level is below red.
/:cl:

Major Changes:
- Traders can now happen late-round as a random event. If the event happens during red alert, they won't appear / be spawned, but instead the station crew will get a message about how a sol trade ship was denied docking permission due to the Cyberiad's raised alert status. Admins can still force a trader shuttle to happen even at red or higher alert by manually spawning traders. This change provides an incentive for Command not to leave the station on red alert all the time.
- When traders do happen, they are now announced immediately to the whole crew with an automated 'docking request accepted' message, so the crew know they are coming.
- Traders no longer try to acquire basic items (manipulators, matter bins, etc). Instead, their trade goals are: 10,000 credits, and 15 sheets of plasma. The credits are a trade goal so that the entire crew can trade with them (as opposed to just people able to print items from a protolathe). The plasma is a trade goal so there's still some high-value trade good unique to the Cyberiad that they want.
- Traders now spawn with hand labellers in their backpack, enabling them to label items with prices if they wish.
- The number of traders that can be spawned is now capped at 2.

Item Additions:
- Civil creates can now contain Ninja Vanish, a cluster smoke grenade, and/or the immortality talisman, a lavaland loot item that makes you invincible (but unable to act) for 10 seconds and must recharge between uses.
- Sec crates can now contain cycler shotguns, enforcer pistol+ammo boxes (both lethal and non-lethal versions), thermal glasses (the legal version, not the traitor version) and non-lethal cluster grenades (teargas, flashbang).
- Eng crates now contain 6 items instead of 3, and can contain pressurized pre-filled double oxygen tanks, bluespace RPDs, bags of holding, night vision mesons and optical material scanners (a sort of eyewear that lets you see objects, but not turfs or mobs, through walls), and metal foam cluster grenades (excellent for quickly patching up huge breaches).
- Med crates can now contain the self-heal variant of the abductor 'fleshy mass' item.
- Service crates can now contain bartender/chef rare ingredient kits, which have a variety of useful items/ingredients for those jobs. They can also contain the rare "offensive mining explosion" KA modkit, which is like the "mining explosion" modkit except that its AOE effect applies to both turfs and mobs. The clown item in service crates (clown grenade) has also been upgraded to a cluster banana grenade.

Item Removals:
- Mineral crates can no longer contain plasma, plasmaglass, or reinforced plasmaglass.
- Service crates can no longer contain goliath hide plates, as these are easily obtainable by miners, large (they cover other items) and not worth much.
- Sci crates can no longer contain strange objects, as crew find them to be common and worthless.
- Med crates can no longer contain the 'dwarfism' SE injector, as nobody buys it.

Item Tweaks:
- The experimental KA no longer has innate cooldown reduction. It still gets the orange cosmetic skin upgrade free, and has twice the modkit space. So, it is still the most powerful KA you can get, but it now requires a bit of customizing to be strictly better than a normal KA.
- The red slime speed potion now appears in the eng crate, rather than the science crate, since its purpose (reducing the slowdown of heavy gear) is way more useful for engineers than it is for scientists.
- The rubber 9mm enforcer ammo box now has 'rubber' in its name (ie: "handgun magazine (9mm rubber)" so you can tell it apart from its lethal counterpart.