### PR TITLE
Fix disability removing on ERT/Nuke ops/ayy

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -123,7 +123,7 @@
 	S = H.dna.species
 	S.team = team_number
 	H.real_name = team_name + " Agent"
-	H.dna.ResetSE() //No fat/blind/colourblind/epileptic/whatever ayys.
+	H.cleanSE() //No fat/blind/colourblind/epileptic/whatever ayys.
 	H.overeatduration = 0
 	H.equipOutfit(/datum/outfit/abductor/agent)
 	greet_agent(agent,team_number)

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -123,7 +123,7 @@
 	S = H.dna.species
 	S.team = team_number
 	H.real_name = team_name + " Agent"
-	H.reagents.add_reagent("mutadone", 1) //No fat/blind/colourblind/epileptic/whatever ayys.
+	H.dna.ResetSE() //No fat/blind/colourblind/epileptic/whatever ayys.
 	H.overeatduration = 0
 	H.equipOutfit(/datum/outfit/abductor/agent)
 	greet_agent(agent,team_number)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -169,7 +169,7 @@ proc/issyndicate(mob/living/M as mob)
 	M.set_species(/datum/species/human, TRUE)
 	M.dna.ready_dna(M) // Quadriplegic Nuke Ops won't be participating in the paralympics
 	M.dna.species.create_organs(M)
-	M.reagents.add_reagent("mutadone", 1) //No fat/blind/colourblind/epileptic/whatever ops.
+	M.dna.ResetSE() //No fat/blind/colourblind/epileptic/whatever ops.
 	M.overeatduration = 0
 
 	var/obj/item/organ/external/head/head_organ = M.get_organ("head")

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -169,7 +169,7 @@ proc/issyndicate(mob/living/M as mob)
 	M.set_species(/datum/species/human, TRUE)
 	M.dna.ready_dna(M) // Quadriplegic Nuke Ops won't be participating in the paralympics
 	M.dna.species.create_organs(M)
-	M.dna.ResetSE() //No fat/blind/colourblind/epileptic/whatever ops.
+	M.cleanSE() //No fat/blind/colourblind/epileptic/whatever ops.
 	M.overeatduration = 0
 
 	var/obj/item/organ/external/head/head_organ = M.get_organ("head")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1945,6 +1945,6 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 
 /mob/living/carbon/human/proc/cleanSE()	//remove all disabilities/powers
 	for(var/block = 1; block <= DNA_SE_LENGTH; block++)
-		src.dna.SetSEState(block, FALSE, TRUE)
+		dna.SetSEState(block, FALSE, TRUE)
 		genemutcheck(src, block, null, MUTCHK_FORCED)
-	src.dna.UpdateSE()
+	dna.UpdateSE()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -733,7 +733,7 @@
 									found_record = 1
 									if(R.fields["criminal"] == "*Execute*")
 										to_chat(usr, "<span class='warning'>Unable to modify the sec status of a person with an active Execution order. Use a security computer instead.</span>")
-									else 
+									else
 										var/rank
 										if(ishuman(usr))
 											var/mob/living/carbon/human/U = usr
@@ -1942,3 +1942,9 @@ Eyes need to have significantly high darksight to shine unless the mob has the X
 /mob/living/carbon/human/proc/special_post_clone_handling()
 	if(mind && mind.assigned_role == "Cluwne") //HUNKE your suffering never stops
 		makeCluwne()
+
+/mob/living/carbon/human/proc/cleanSE()	//remove all disabilities/powers
+	for(var/block = 1; block <= DNA_SE_LENGTH; block++)
+		src.dna.SetSEState(block, FALSE, TRUE)
+		genemutcheck(src, block, null, MUTCHK_FORCED)
+	src.dna.UpdateSE()

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -145,7 +145,7 @@ var/ert_request_answered = FALSE
 
 	M.set_species(/datum/species/human, TRUE)
 	M.dna.ready_dna(M)
-	M.reagents.add_reagent("mutadone", 1) //No fat/blind/colourblind/epileptic/whatever ERT.
+	M.dna.ResetSE() //No fat/blind/colourblind/epileptic/whatever ERT.
 	M.overeatduration = 0
 
 	var/hair_c = pick("#8B4513","#000000","#FF4500","#FFD700") // Brown, black, red, blonde

--- a/code/modules/response_team/ert.dm
+++ b/code/modules/response_team/ert.dm
@@ -145,7 +145,7 @@ var/ert_request_answered = FALSE
 
 	M.set_species(/datum/species/human, TRUE)
 	M.dna.ready_dna(M)
-	M.dna.ResetSE() //No fat/blind/colourblind/epileptic/whatever ERT.
+	M.cleanSE() //No fat/blind/colourblind/epileptic/whatever ERT.
 	M.overeatduration = 0
 
 	var/hair_c = pick("#8B4513","#000000","#FF4500","#FFD700") // Brown, black, red, blonde


### PR DESCRIPTION
Fixes #10635

Mutadone was changed not to remove disabilities anymore, and since it was used to do precisely that, welp

🆑
fix: Nuke ops, ERT, and ayyybductors will now properly lose disabilities on spawn.
/🆑