### PR TITLE
Updated uplink description for chef's sauce

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -202,7 +202,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //Chef
 /datum/uplink_item/jobspecific/specialsauce
 	name = "Chef Excellence's Special Sauce"
-	desc = "A custom made sauce made from the toxin glands of 1000 space carp, if somebody ingests enough they'll be dead in 3 minutes or less guaranteed."
+	desc = "A custom sauce made from the highly poisonous fly amanita mushrooms. Anyone who ingests it will take variable toxin damage depending on how long it has been in their system, with a higher dosage taking longer to metabolize."
 	reference = "CESS"
 	item = /obj/item/reagent_containers/food/condiment/syndisauce
 	cost = 2


### PR DESCRIPTION
**What does this PR do:**
The uplink description for the chef exclusive special sauce states that it contains carpotoxin, but it actually contains amanitin and seemingly always has done in the code history. This just fixes the description to be accurate.

**Changelog:**
:cl:
spellcheck: Chef Excellence's Special Sauce uplink description updated to be more accurate.
/:cl:

