### PR TITLE
Stop emergency shield gen from unanchoring themselves when turned off.

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -167,7 +167,6 @@
 
 	active = 0
 	update_icon()
-	anchored = 0
 
 	for(var/obj/machinery/shield/shield_tile in deployed_shields)
 		qdel(shield_tile)


### PR DESCRIPTION
**What does this PR do:**
Stops emer. shield generators from unanchoring themselves when you turn them off.

_why_


**Changelog:**
:cl:
fix: Stopped emergency shield generators from magically unbolting themselves when they get turned off.
/:cl:

