### PR TITLE
[WIP][DNM] Spacesuit equip times

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -8,3 +8,10 @@
 
 #define TV_TRIP "trip"
 #define TV_SLIP "slip"
+
+//EQUIP SPEED FOR obj.equip_speed
+#define EQUIP_SPEED_SLOW 60  //60 == 6 seconds
+#define EQUIP_SPEED_MEDIUM 40 
+#define EQUIP_SPEED_FAST 20 
+#define EQUIP_SPEED_INSTANT 0 
+

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -42,7 +42,7 @@
 	//to be overriden for toggling internals, id binding, access etc
 	return
 
-/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, equip_speed_override = 1)
+/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, equip_speed_override = TRUE)
 	pre_equip(H, visualsOnly)
 
 	//Start with uniform,suit,backpack for additional slots

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -36,13 +36,13 @@
 	if(collect_not_del)
 		H.equip_or_collect(I, slot)
 	else
-		H.equip_to_slot_or_del(I, slot)
+		H.equip_to_slot_or_del(I, slot, equip_speed_override = TRUE)
 
 /datum/outfit/proc/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	//to be overriden for toggling internals, id binding, access etc
 	return
 
-/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, equip_speed_override = 1)
 	pre_equip(H, visualsOnly)
 
 	//Start with uniform,suit,backpack for additional slots

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -30,6 +30,8 @@
 	var/on_blueprints = FALSE //Are we visible on the station blueprints at roundstart?
 	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
 
+	var/equip_speed = EQUIP_SPEED_INSTANT //pre made times in __DEFINES/inventory.dm for EQUIP_SPEED_SLOW, EQUIP_SPEED_MEDIUM, EQUIP_SPEED_FAST, EQUP_SPEED_INSTANT
+
 /obj/New()
 	..()
 	if(!armor)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -30,7 +30,7 @@
 	var/on_blueprints = FALSE //Are we visible on the station blueprints at roundstart?
 	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
 
-	var/equip_speed = EQUIP_SPEED_INSTANT //pre made times in __DEFINES/inventory.dm for EQUIP_SPEED_SLOW, EQUIP_SPEED_MEDIUM, EQUIP_SPEED_FAST, EQUP_SPEED_INSTANT
+	var/equip_speed = EQUIP_SPEED_INSTANT //pre made times in __DEFINES/inventory.dm for EQUIP_SPEED_SLOW, EQUIP_SPEED_MEDIUM, EQUIP_SPEED_FAST, EQUIP_SPEED_INSTANT
 
 /obj/New()
 	..()

--- a/code/modules/clothing/spacesuits/ert.dm
+++ b/code/modules/clothing/spacesuits/ert.dm
@@ -47,7 +47,7 @@
 		"Drask" = 'icons/mob/species/drask/suit.dmi',
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
 		)
-
+	equip_speed = EQUIP_SPEED_FAST
 //Commander
 /obj/item/clothing/head/helmet/space/hardsuit/ert/commander
 	name = "emergency response team commander helmet"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -299,7 +299,7 @@
 	armor = list(melee = 40, bullet = 5, laser = 10, energy = 5, bomb = 50, bio = 100, rad = 90)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
-	equip_speed = EQUIP_SPEED_INSTANT
+	equip_speed = EQUIP_SPEED_FAST
 	
 //Mining hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/mining
@@ -529,6 +529,7 @@
 	item_state = "medical_hardsuit"
 	allowed = list(/obj/item/flashlight,/obj/item/tank,/obj/item/storage/firstaid,/obj/item/healthanalyzer,/obj/item/stack/medical,/obj/item/rad_laser)
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 50)
+	equip_speed = EQUIP_SPEED_MEDIUM
 
 	//Security
 /obj/item/clothing/head/helmet/space/hardsuit/security

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -105,6 +105,9 @@
 	var/list/can_mount = null                         // Types of device that can be hardpoint mounted.
 	var/list/mounted_devices = null                   // Holder for the above device.
 	var/obj/item/active_device = null                 // Currently deployed device, if any.
+	
+	//Equip speed
+	equip_speed = EQUIP_SPEED_SLOW
 
 /obj/item/clothing/suit/space/hardsuit/equipped(mob/M)
 	..()
@@ -296,7 +299,8 @@
 	armor = list(melee = 40, bullet = 5, laser = 10, energy = 5, bomb = 50, bio = 100, rad = 90)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
-
+	equip_speed = EQUIP_SPEED_INSTANT
+	
 //Mining hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/mining
 	name = "mining hardsuit helmet"
@@ -329,7 +333,7 @@
 	actions_types = list(/datum/action/item_action/toggle_helmet_mode)
 	flags = BLOCKHAIR | STOPSPRESSUREDMAGE | THICKMATERIAL
 	visor_flags_inv = HIDEMASK|HIDEEYES|HIDEFACE|HIDETAIL
-
+	
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
 
@@ -419,6 +423,7 @@
 	actions_types = list(/datum/action/item_action/toggle_hardsuit_mode)
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
 	allowed = list(/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/saber,/obj/item/restraints/handcuffs,/obj/item/tank)
+	equip_speed = EQUIP_SPEED_FAST
 
 /obj/item/clothing/suit/space/hardsuit/syndi/update_icon()
 	icon_state = "hardsuit[on]-[item_color]"
@@ -452,6 +457,7 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	sprite_sheets = null
+	equip_speed = EQUIP_SPEED_INSTANT
 
 /obj/item/clothing/suit/space/hardsuit/syndi/elite/attack_self(mob/user)
 	..()
@@ -502,6 +508,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	sprite_sheets = null
 	magical = TRUE
+	equip_speed = EQUIP_SPEED_INSTANT
 
 //Medical hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/medical
@@ -539,7 +546,7 @@
 	item_state = "sec_hardsuit"
 	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50)
 	allowed = list(/obj/item/gun,/obj/item/flashlight,/obj/item/tank,/obj/item/melee/baton,/obj/item/reagent_containers/spray/pepper,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/restraints/handcuffs)
-
+	equip_speed = EQUIP_SPEED_FAST
 
 //Atmospherics hardsuit (BS12)
 /obj/item/clothing/head/helmet/space/hardsuit/atmos
@@ -577,7 +584,7 @@
 	item_state = "singuloth_hardsuit"
 	flags = STOPSPRESSUREDMAGE
 	armor = list(melee = 40, bullet = 5, laser = 20, energy = 5, bomb = 25, bio = 100, rad = 100)
-
+	
 
 /obj/item/clothing/head/helmet/space/hardsuit/security/hos
 	name = "head of security's hardsuit helmet"
@@ -611,7 +618,8 @@
 	var/shield_state = "shield-old"
 	var/shield_on = "shield-old"
 	sprite_sheets = null
-
+	equip_speed = EQUIP_SPEED_INSTANT
+	
 /obj/item/clothing/suit/space/hardsuit/shielded/hit_reaction(mob/living/carbon/human/owner, attack_text)
 	if(current_charges > 0)
 		do_sparks(2, 1, src)
@@ -662,6 +670,7 @@
 		"Vulpkanin" = 'icons/mob/species/vulpkanin/suit.dmi',
 		"Drask" = 'icons/mob/species/drask/suit.dmi'
 		)
+	equip_speed = EQUIP_SPEED_INSTANT
 
 /obj/item/clothing/head/helmet/space/hardsuit/shielded/syndi
 	name = "blood-red hardsuit helmet"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -36,7 +36,7 @@
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
 		)
-	equip_speed = EQUIP_SPEED_INSTANT
+	equip_speed = EQUIP_SPEED_FAST
 
 	//Deathsquad space suit, not hardsuits because no flashlight!
 /obj/item/clothing/head/helmet/space/deathsquad

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -36,6 +36,7 @@
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
 		)
+	equip_speed = EQUIP_SPEED_INSTANT
 
 	//Deathsquad space suit, not hardsuits because no flashlight!
 /obj/item/clothing/head/helmet/space/deathsquad
@@ -61,6 +62,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	unacidable = 1
 	strip_delay = 130
+	equip_speed = EQUIP_SPEED_INSTANT
 
 	//NEW SWAT suit
 /obj/item/clothing/suit/space/swat
@@ -76,7 +78,7 @@
 	sprite_sheets = list(
 		"Vox" = 'icons/mob/species/vox/suit.dmi'
 		)
-
+	
 /obj/item/clothing/head/helmet/space/deathsquad/beret
 	name = "officer's beret"
 	desc = "An armored beret commonly used by special operations officers."
@@ -125,6 +127,7 @@
 	flags = STOPSPRESSUREDMAGE
 	flags_size = ONESIZEFITSALL
 	allowed = list(/obj/item) //for stuffing extra special presents
+	equip_speed = EQUIP_SPEED_INSTANT
 
 //Space pirate outfit
 /obj/item/clothing/head/helmet/space/pirate
@@ -149,7 +152,7 @@
 	armor = list(melee = 30, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
 	strip_delay = 40
 	put_on_delay = 20
-
+	
 //Paramedic EVA suit
 /obj/item/clothing/head/helmet/space/eva/paramedic
 	name = "Paramedic EVA helmet"
@@ -171,7 +174,7 @@
 	sprite_sheets_obj = list(
 		"Vox" = 'icons/obj/clothing/species/vox/hats.dmi'
 		)
-
+	
 /obj/item/clothing/suit/space/eva/paramedic
 	name = "Paramedic EVA suit"
 	icon_state = "paramedic-eva"
@@ -191,6 +194,7 @@
 	sprite_sheets_obj = list(
 		"Vox" = 'icons/obj/clothing/species/vox/suits.dmi'
 		)
+	equip_speed = EQUIP_SPEED_MEDIUM
 
 /obj/item/clothing/suit/space/eva
 	name = "EVA suit"
@@ -212,6 +216,7 @@
 		"Vox" = 'icons/obj/clothing/species/vox/suits.dmi',
 		"Vulpkanin" = 'icons/obj/clothing/species/vulpkanin/suits.dmi'
 		)
+	equip_speed = EQUIP_SPEED_SLOW
 
 /obj/item/clothing/head/helmet/space/eva
 	name = "EVA helmet"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -23,6 +23,7 @@
 	var/extinguish_cooldown = 10 SECONDS
 	var/max_extinguishes = 5
 	var/extinguishes_left = 5 // Yeah yeah, reagents, blah blah blah.  This should be simple.
+	equip_speed = EQUIP_SPEED_INSTANT
 
 /obj/item/clothing/suit/space/eva/plasmaman/proc/Extinguish(var/mob/user)
 	var/mob/living/carbon/human/H=user

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -15,7 +15,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword/saber,/obj/item/restraints/handcuffs,/obj/item/tank)
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 30, bio = 30, rad = 30)
-
+	equip_speed = EQUIP_SPEED_FAST
 
 //Green syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/green
@@ -89,6 +89,7 @@ obj/item/clothing/suit/space/syndicate/black/strike
 	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100) //Matches DS gear.
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	unacidable = 1
+	equip_speed = EQUIP_SPEED_INSTANT
 
 //Black-green syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/green
@@ -162,7 +163,7 @@ obj/item/clothing/suit/space/syndicate/black/red/strike
 	armor = list(melee = 80, bullet = 80, laser = 50, energy = 50, bomb = 100, bio = 100, rad = 100) //Matches DS gear.
 	max_heat_protection_temperature = FIRE_IMMUNITY_HELM_MAX_TEMP_PROTECT
 	unacidable = 1
-
+	equip_speed = EQUIP_SPEED_INSTANT
 
 //Black with yellow/red engineering syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/engie

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -187,10 +187,17 @@
 
 //This is an UNSAFE proc. Use mob_can_equip() before calling this one! Or rather use equip_to_slot_if_possible() or advanced_equip_to_slot_if_possible()
 //set redraw_mob to 0 if you don't wish the hud to be updated - if you're doing it manually in your own proc.
-/mob/living/carbon/human/equip_to_slot(obj/item/W as obj, slot, redraw_mob = 1)
+/mob/living/carbon/human/equip_to_slot(obj/item/W as obj, slot, redraw_mob = 1, equip_speed_override = FALSE)
 	if(!slot) return
 	if(!istype(W)) return
 	if(!has_organ_for_slot(slot)) return
+
+	if(W.equip_speed && !equip_speed_override) //check to see if we want a delay and check to see we don't want an override for uses such as admin equipping (cmd_admin_dress). 
+		if(do_mob(src, src, W.equip_speed))
+			to_chat(src, "<span class='notice'>You put on the [W].</span>")
+		else
+			to_chat(src, "<span class='alert'> You must remain still to equip the [W]!</span>")
+			return FALSE
 
 	if(W == src.l_hand)
 		src.l_hand = null
@@ -424,7 +431,6 @@
 
 	if(istype(I, /obj/item/clothing/under) || istype(I, /obj/item/clothing/suit))
 		if(FAT in mutations)
-			//testing("[M] TOO FAT TO WEAR [src]!")
 			if(!(I.flags_size & ONESIZEFITSALL))
 				if(!disable_warning)
 					to_chat(src, "<span class='alert'>You're too fat to wear the [I].</span>")

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -82,10 +82,18 @@
 	if(istype(O) && O.owner == src)
 		. = 0 // keep a good grip on your heart
 
-/mob/living/carbon/human/unEquip(obj/item/I)
+/mob/living/carbon/human/unEquip(obj/item/I, check_speed)
 	. = ..() //See mob.dm for an explanation on this and some rage about people copypasting instead of calling ..() like they should.
 	if(!. || !I)
 		return
+	
+	if(I.equip_speed && check_speed) //unequip_override = we want to check to make sure it is not being unequiped by someone in the strip panel
+		to_chat(src, "<span class='notice'>You begin to take off the [I]...</span>")
+		if(do_mob(src, src, 20)) //2 seconds across the board. Other idea was to just do (equip_speed / 2). This prevents
+			to_chat(src, "<span class='notice'>You take off the [I].</span>")
+		else
+			to_chat(src, "<span class='alert'> You must remain still to unequip the [I]!</span>")
+			return FALSE
 
 	if(I == wear_suit)
 		if(s_store)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -728,7 +728,7 @@
 	what.add_fingerprint(src)
 	if(do_mob(src, who, what.strip_delay))
 		if(what && what == who.get_item_by_slot(where) && Adjacent(who))
-			who.unEquip(what)
+			who.unEquip(what, TRUE) //TRUE to override the unequip delay on certain items
 			if(silent)
 				put_in_hands(what)
 			add_attack_logs(src, who, "Stripped of [what]")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -749,7 +749,7 @@
 		if(do_mob(src, who, what.put_on_delay))
 			if(what && Adjacent(who))
 				unEquip(what)
-				who.equip_to_slot_if_possible(what, where, 0, 1)
+				who.equip_to_slot_if_possible(what, where, 0, 1, equip_speed_override = TRUE)
 				add_attack_logs(src, who, "Equipped [what]")
 
 /mob/living/singularity_act()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -243,7 +243,7 @@
 
 //This is just a commonly used configuration for the equip_to_slot_if_possible() proc, used to equip people when the rounds tarts and when events happen and such.
 /mob/proc/equip_to_slot_or_del(obj/item/W as obj, slot, equip_speed_override = FALSE)
-	return equip_to_slot_if_possible(W, slot, 1, 1, 0, TRUE)
+	return equip_to_slot_if_possible(W, slot, 1, 1, 0, equip_speed_override)
 
 // Convinience proc.  Collects crap that fails to equip either onto the mob's back, or drops it.
 // Used in job equipping so shit doesn't pile up at the start loc.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -221,7 +221,7 @@
 //set del_on_fail to have it delete W if it fails to equip
 //set disable_warning to disable the 'you are unable to equip that' warning.
 //unset redraw_mob to prevent the mob from being redrawn at the end.
-/mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1)
+/mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1, equip_speed_override = FALSE)
 	if(!istype(W)) return 0
 
 	if(!W.mob_can_equip(src, slot, disable_warning))
@@ -233,17 +233,17 @@
 
 		return 0
 
-	equip_to_slot(W, slot, redraw_mob) //This proc should not ever fail.
+	equip_to_slot(W, slot, redraw_mob, equip_speed_override) //This proc should not ever fail.
 	return 1
 
 //This is an UNSAFE proc. It merely handles the actual job of equipping. All the checks on whether you can or can't eqip need to be done before! Use mob_can_equip() for that task.
 //In most cases you will want to use equip_to_slot_if_possible()
-/mob/proc/equip_to_slot(obj/item/W as obj, slot)
+/mob/proc/equip_to_slot(obj/item/W as obj, slot, equip_speed_override = FALSE)
 	return
 
 //This is just a commonly used configuration for the equip_to_slot_if_possible() proc, used to equip people when the rounds tarts and when events happen and such.
-/mob/proc/equip_to_slot_or_del(obj/item/W as obj, slot)
-	return equip_to_slot_if_possible(W, slot, 1, 1, 0)
+/mob/proc/equip_to_slot_or_del(obj/item/W as obj, slot, equip_speed_override = FALSE)
+	return equip_to_slot_if_possible(W, slot, 1, 1, 0, TRUE)
 
 // Convinience proc.  Collects crap that fails to equip either onto the mob's back, or drops it.
 // Used in job equipping so shit doesn't pile up at the start loc.


### PR DESCRIPTION
# **What does this PR do:**
This adds equip times for all space suits (including hardsuits) and the framework to have an equip time for anything else. You will have to remain uninterrupted while putting on most space suits. Certain advanced suits are still able to be equipped instantly. Certain suits are quicker than others.
Outfit equipping (admin select equipment, ERT spawning in) overrides any time set and will be equipped instantly.


The **slow** time is 6 seconds.
The **medium** time is 4 seconds
The **fast** time is 2 seconds.

### **Instant:**
Elite Syndicate
Shielded Syndicate 
Syndicate _Strike_ Team
Wizard
Deathsquad
All Plasmaman suits

### **Fast:**
Captain
Chief engineer
ERT
Security
Regular syndicate suits including the softsuits

### **Medium:**
Paramedic
Medical

### **Slow:**
Regular EVA
Engineering, mining, and anything else not included is **slow**

![brtgopf](https://user-images.githubusercontent.com/20497797/51087620-96095900-1723-11e9-96f8-22582e390b65.gif)

**Code review appreciated** (especially with the 5 different equip procs calling each other)

**Open to suggestions balance wise too**
🆑 
balance: Spacesuit equip times (including hardsuits). 
You will now have to stand still uninterrupted for a set period of time while equipping most spacesuits. 
Certain suits are faster than others.
For the full list see PR # 10649 on the github
/ 🆑 