### PR TITLE
Goldgrubs now run away from mechas

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
@@ -42,7 +42,7 @@
 	if(target != null)
 		if(istype(target, /obj/item/stack/ore) && loot.len < 10)
 			visible_message("<span class='notice'>The [name] looks at [target.name] with hungry eyes.</span>")
-		else if(isliving(target))
+		else if(isliving(target) || istype(target, /obj/mecha))
 			Aggro()
 			visible_message("<span class='danger'>The [name] tries to flee from [target.name]!</span>")
 			retreat_distance = 10

--- a/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
@@ -42,7 +42,7 @@
 	if(target != null)
 		if(istype(target, /obj/item/stack/ore) && loot.len < 10)
 			visible_message("<span class='notice'>The [name] looks at [target.name] with hungry eyes.</span>")
-		else if(isliving(target) || ismecha(target))
+		else if(isliving(target) || istype(target, /obj/mecha))
 			Aggro()
 			visible_message("<span class='danger'>The [name] tries to flee from [target.name]!</span>")
 			retreat_distance = 10

--- a/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
@@ -42,7 +42,7 @@
 	if(target != null)
 		if(istype(target, /obj/item/stack/ore) && loot.len < 10)
 			visible_message("<span class='notice'>The [name] looks at [target.name] with hungry eyes.</span>")
-		else if(isliving(target) || istype(target, /obj/mecha))
+		else if(isliving(target) || ismecha(target))
 			Aggro()
 			visible_message("<span class='danger'>The [name] tries to flee from [target.name]!</span>")
 			retreat_distance = 10

--- a/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
@@ -42,7 +42,7 @@
 	if(target != null)
 		if(istype(target, /obj/item/stack/ore) && loot.len < 10)
 			visible_message("<span class='notice'>The [name] looks at [target.name] with hungry eyes.</span>")
-		else if(isliving(target) || istype(target, /obj/mecha))
+		else if(isliving(target))
 			Aggro()
 			visible_message("<span class='danger'>The [name] tries to flee from [target.name]!</span>")
 			retreat_distance = 10

--- a/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/goldgrub.dm
@@ -42,7 +42,7 @@
 	if(target != null)
 		if(istype(target, /obj/item/stack/ore) && loot.len < 10)
 			visible_message("<span class='notice'>The [name] looks at [target.name] with hungry eyes.</span>")
-		else if(isliving(target))
+		else if(isliving(target) || ismecha(target))
 			Aggro()
 			visible_message("<span class='danger'>The [name] tries to flee from [target.name]!</span>")
 			retreat_distance = 10


### PR DESCRIPTION
Goldgurbs werent running away from mechas making them easy to be killed with a RIPLEY or any MECH
In fact they were aggro against mechas which made no sense since they do no damage to them.

-Tested: they dont run away from empty mechas.-


:cl:
Fix: Golgrubs now run away from mechas being piloted
/:cl:

