### PR TITLE
Fix syndicate borg spawner spawning saboteur instead of assault

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -58,7 +58,7 @@
 	switch(borg_to_spawn)
 		if("Medical")
 			R = new /mob/living/silicon/robot/syndicate/medical(T)
-		else if("Saboteur")
+		if("Saboteur")
 			R = new /mob/living/silicon/robot/syndicate/saboteur(T)
 		else
 			R = new /mob/living/silicon/robot/syndicate(T) //Assault borg by default


### PR DESCRIPTION
Due to a logic error the spawner would default to syndicate saboteur instead of assault, so you'd get saboteur if you picked assault

This fixes it

🆑
Fix: Syndicate will no longer force you to play with the shiny new saboteur borg and instead send you the assault borg you actually ordered
/🆑