### PR TITLE
Examining backpacks now gives a rough indication of remaining space

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -26,6 +26,23 @@
 	playsound(src.loc, "rustle", 50, 1, -5)
 	return ..()
 
+/obj/item/storage/backpack/examine(mob/user)
+	var/space_used = 0
+	for(var/obj/item/I in contents)
+		space_used += I.w_class
+	if(!..(user, 1))
+		return
+	if(!space_used)
+		to_chat(user, "<span class='notice'> \The [src] is empty.</span>")
+	else if(space_used <= max_combined_w_class*0.6)
+		to_chat(user, "<span class='notice'> \The [src] still has plenty of remaining space.</span>")
+	else if(space_used <= max_combined_w_class*0.8)
+		to_chat(user, "<span class='notice'> \The [src] is beginning to run out of space.</span>")
+	else if(space_used < max_combined_w_class)
+		to_chat(user, "<span class='notice'> \The [src] doesn't have much space left.</span>")
+	else
+		to_chat(user, "<span class='notice'> \The [src] is full.</span>")
+
 /*
  * Backpack Types
  */


### PR DESCRIPTION
**What does this PR do:**
When examining a backpack that either equipped, in your hands or on the floor next to you, an additional message is given in the chat box to give an indication as to how much space is left for items.

![image](https://user-images.githubusercontent.com/44248086/51275032-b1e15900-19c8-11e9-86e0-05a8725ffb36.png)

This mostly intended as a minor QOL change so you have some way of knowing when you're getting close to filling your backpack up rather than only finding out once you try to put something in without enough space for it.

**Changelog:**
*Remove this line, and appropriate fields from the changelog*
:cl:
tweak: Backpacks will now give a rough indication as to how much space they have left when examining them.
/:cl:

