### PR TITLE
Rev(and statue) vision mode fix

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -91,7 +91,12 @@
 	if(essence == 0)
 		to_chat(src, "<span class='revendanger'>You feel your essence fraying!</span>")
 
-
+mob/living/simple_animal/revenant/update_sight()
+	if(!client)
+		return
+	if(stat == DEAD)
+		grant_death_vision()
+		return
 
 /mob/living/simple_animal/revenant/say(message)
 	if(!message)

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -189,6 +189,13 @@
 			L.EyeBlind(4)
 	return
 
+mob/living/simple_animal/hostile/statue/update_sight()
+	if(!client)
+		return
+	if(stat == DEAD)
+		grant_death_vision()
+		return
+
 //Toggle Night Vision
 /obj/effect/proc_holder/spell/targeted/night_vision
 	name = "Toggle Nightvision"


### PR DESCRIPTION
**What does this PR do:**
Should fix rev and statue immediately reverting to their default vision. As a bonus, the revenant can always see itself now.
Fixes: #10516
Fixes: #10667

**Changelog:**
:cl:
fix: Revenant and Statue vision mode fixed.
/:cl:

