### PR TITLE
Body Scanner Wrench Rotation Unsmackening

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -307,6 +307,7 @@
 		else
 			setDir(EAST)
 		playsound(loc, I.usesound, 50, 1)
+		return
 
 	if(exchange_parts(user, I))
 		return


### PR DESCRIPTION
**What does this PR do:**

Reinforces your grip on wrenches when rotating body scanner consoles, so you don't accidentally smack them.

###### Read: Adds in a missing return.
**Changelog:**
:cl:
fix: You will no longer smack body scanner consoles when you rotate them.
/:cl:

