### PR TITLE
Removes useless desc variable in airlock control buttons

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -1,9 +1,8 @@
 /obj/machinery/door_control
 	name = "remote door-control"
-	desc = "It controls doors, remotely."
+	desc = "A remote control-switch for a door."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "doorctrl0"
-	desc = "A remote control-switch for a door."
 	power_channel = ENVIRON
 	var/id = null
 	var/range = 10


### PR DESCRIPTION
**What does this PR do:**

Removes the desc that gets overwritten in Airlock Control Buttons

**Changelog:**
:cl:
del: Removed a description that gets overwritten, moved the current one to it's old location.
/:cl:

