### PR TITLE
Mulebot closet exclusion

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -101,7 +101,9 @@
 	for(var/mob/M in loc)
 		if(itemcount >= storage_capacity)
 			break
-		if(istype (M, /mob/dead/observer))
+		if(istype(M, /mob/dead/observer))
+			continue
+		if(istype(M, /mob/living/simple_animal/bot/mulebot))
 			continue
 		if(M.buckled)
 			continue


### PR DESCRIPTION
**What does this PR do:**
Exclusion for mulebots added to all closets.
Fixes: #10676

**Changelog:**
:cl: Alonefromhell
fix: Mulecloset killing machine has been fixed. Mulebots are no longer able to be put into closets.
/:cl:

