### PR TITLE
Fix deathgasping

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -92,6 +92,9 @@
 	return TRUE
 
 /mob/living/carbon/human/death(gibbed)
+	if(can_die() && !gibbed && deathgasp_on_death)
+		emote("deathgasp") //let the world KNOW WE ARE DEAD
+
 	// Only execute the below if we successfully died
 	. = ..(gibbed)
 	if(!.)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -49,6 +49,9 @@
 
 /mob/living/silicon/robot/death(gibbed)
 	if(can_die())
+		if(!gibbed && deathgasp_on_death)
+			emote("deathgasp")
+
 		if(module)
 			module.handle_death(gibbed)
 


### PR DESCRIPTION
Devil PR #10272 changed the logic for deathgasping, unfortunately it seems not to work for humans as they'd no longer deathgasp.

I'm leaving the changes done by the devil PR in case they are used by some of its mobs, this PR just readds deathgasp behaviour to how it worked before.

This is also what caused nukies not to explode.

Fixes #10682

🆑
fix: Fixed deathgasp emote not being called on death
fix: Fixed nukies no longer exploding on death
/🆑