### PR TITLE
Adds classic baton and a cargo cap to Sol Traders

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -702,6 +702,8 @@
 
 	uniform = /obj/item/clothing/under/rank/cargotech
 	back = /obj/item/storage/backpack/industrial
+	belt = /obj/item/melee/classic_baton
+	head = /obj/item/clothing/head/soft
 	shoes = /obj/item/clothing/shoes/black
 	l_ear = /obj/item/radio/headset
 	glasses = /obj/item/clothing/glasses/sunglasses


### PR DESCRIPTION
Title. Gives them a basic self defence item and a fancy cap to put on their heads.

:cl:Spartan
tweak: Gives Sol Traders a baton and a cargo cap.
/:cl:

