### PR TITLE
Fix greys not getting translator as RD, CMO, CE

### DIFF
--- a/code/modules/mob/living/carbon/human/species/grey.dm
+++ b/code/modules/mob/living/carbon/human/species/grey.dm
@@ -42,7 +42,7 @@
 
 /datum/species/grey/after_equip_job(datum/job/J, mob/living/carbon/human/H)
 	var/translator_pref = H.client.prefs.speciesprefs
-	if(translator_pref || ((ismindshielded(H) || J.is_command) && (WINGDINGS in H.mutations)))
+	if(translator_pref || ((ismindshielded(H) || J.is_command || J.supervisors == "the captain") && (WINGDINGS in H.mutations)))
 		if(J.title == "Mime")
 			return
 		if(J.title == "Clown")


### PR DESCRIPTION
If you're a grey and you got wingdings but no translator, you will now get a translator installed if you're RD, CMO, or CE, as intended.

Fixes #10687

🆑
Fix: RD, CMO, and CE greys will now properly get a translator implant if they need one.
/🆑