### PR TITLE
Stops damp rag having a lid, refactors glass containers to let objects state if they lack a lid

### DIFF
--- a/code/modules/detective_work/footprints_and_rag.dm
+++ b/code/modules/detective_work/footprints_and_rag.dm
@@ -21,6 +21,7 @@
 	can_be_placed_into = null
 	flags = NOBLUDGEON
 	container_type = OPENCONTAINER
+	no_lid = TRUE
 	var/wipespeed = 30
 
 /obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)

--- a/code/modules/reagents/reagent_containers/glass_containers.dm
+++ b/code/modules/reagents/reagent_containers/glass_containers.dm
@@ -12,6 +12,7 @@
 	possible_transfer_amounts = list(5,10,15,25,30,50)
 	volume = 50
 	container_type = OPENCONTAINER
+	var/no_lid = FALSE // Stops certain containers having lids, mainly for damp rag
 
 	var/label_text = ""
 	// the fucking asshole who designed this can go die in a fire - Iamgoofball
@@ -57,13 +58,14 @@
 
 /obj/item/reagent_containers/glass/attack_self()
 	..()
-	if(is_open_container())
-		to_chat(usr, "<span class='notice'>You put the lid on [src].</span>")
-		container_type ^= REFILLABLE | DRAINABLE
-	else
-		to_chat(usr, "<span class='notice'>You take the lid off [src].</span>")
-		container_type |= REFILLABLE | DRAINABLE
-	update_icon()
+	if(!no_lid)
+		if(is_open_container())
+			to_chat(usr, "<span class='notice'>You put the lid on [src].</span>")
+			container_type ^= REFILLABLE | DRAINABLE
+		else
+			to_chat(usr, "<span class='notice'>You take the lid off [src].</span>")
+			container_type |= REFILLABLE | DRAINABLE
+		update_icon()
 
 /obj/item/reagent_containers/glass/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)


### PR DESCRIPTION
**What does this PR do:**

Fixes #10599

Glass containers now have a variable that lets them state whether they lack a lid. If they do, the code for closing/opening lids won't execute.

Decided to do it this way rather than just override the `attack_self` proc() for the damp rag in the event other such containers also wish to be lidless in the future.

**Changelog:**
:cl:
fix: Damp rags no longer have a lid, and must remain inferior to other containers.
/:cl:

