### PR TITLE
Rerename Syndicate Mothership area to Syndicate Forward Base

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -530,7 +530,7 @@ var/list/ghostteleportlocs = list()
 //SYNDICATES
 
 /area/syndicate_mothership
-	name = "\improper Syndicate Mothership"
+	name = "\improper Syndicate Forward Base"
 	icon_state = "syndie-ship"
 	requires_power = 0
 


### PR DESCRIPTION
The area name change was originally done in my syndicate base remap and accidentally (i assume) reverted by Free's northern remap

🆑
fix: Fix accidental revert of the Syndicate Forward Base area name
/🆑