### PR TITLE
Reduce the cost of bomb frames to 3 plasteel

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -167,7 +167,7 @@
 			if(!WT.isOn() || !WT.remove_fuel(5, user))
 				return
 			to_chat(user, "<span class='notice'>You cut the [src] apart.</span>")
-			new /obj/item/stack/sheet/plasteel(loc, 5)
+			new /obj/item/stack/sheet/plasteel(loc, 3)
 			qdel(src)
 	else
 		return ..()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -129,7 +129,7 @@ var/global/list/datum/stack_recipe/metal_recipes = list(
  */
 var/global/list/datum/stack_recipe/plasteel_recipes = list(
 	new /datum/stack_recipe("AI core", /obj/structure/AIcore, 4, time = 50, one_per_turf = 1),
-	new /datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 10, time = 50),
+	new /datum/stack_recipe("bomb assembly", /obj/machinery/syndicatebomb/empty, 3, time = 50),
 	new /datum/stack_recipe("Surgery Table", /obj/machinery/optable, 5, time = 50, one_per_turf = 1, on_floor = 1),
 	new /datum/stack_recipe("Metal crate", /obj/structure/closet/crate, 10, time = 50, one_per_turf = 1),
 	new /datum/stack_recipe("Mass Driver frame", /obj/machinery/mass_driver_frame, 3, time = 50, one_per_turf = 1),


### PR DESCRIPTION
Ghetto syndicate bombs is a barely ever used feature (that could use some more coding work... *cough*), and 10 plasteel feels like way too high a cost for it, considering the other stuff you can build with just 5 plasteel. This PR reduces the cost to 3 plasteel sheets.

🆑
tweak: Reduced the cost of plasteel bomb frame crafting to 3 plasteel sheets (from 10)
/🆑
