### PR TITLE
Add force to books, extra to space law

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -796,6 +796,7 @@
 	name = "Space Law"
 	desc = "A set of Nanotrasen guidelines for keeping law and order on their space stations."
 	icon_state = "bookSpaceLaw"
+	force = 4 //advanced magistrate tactics
 	author = "Nanotrasen"
 	title = "Space Law"
 	dat = {"

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -797,6 +797,7 @@
 	desc = "A set of Nanotrasen guidelines for keeping law and order on their space stations."
 	icon_state = "bookSpaceLaw"
 	force = 4 //advanced magistrate tactics
+	throwforce = 4 //throw the book at em
 	author = "Nanotrasen"
 	title = "Space Law"
 	dat = {"

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -797,7 +797,6 @@
 	desc = "A set of Nanotrasen guidelines for keeping law and order on their space stations."
 	icon_state = "bookSpaceLaw"
 	force = 4 //advanced magistrate tactics
-	throwforce = 4 //throw the book at em
 	author = "Nanotrasen"
 	title = "Space Law"
 	dat = {"

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -168,7 +168,6 @@
 	throw_speed = 1
 	throw_range = 5
 	force = 2
-	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
 	attack_verb = list("bashed", "whacked")
 	burn_state = FLAMMABLE

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -168,6 +168,7 @@
 	throw_speed = 1
 	throw_range = 5
 	force = 2
+	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
 	attack_verb = list("bashed", "whacked", "educated")
 	burn_state = FLAMMABLE

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -170,7 +170,7 @@
 	force = 2
 	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
-	attack_verb = list("bashed", "whacked", "educated")
+	attack_verb = list("bashed", "whacked")
 	burn_state = FLAMMABLE
 
 	var/dat			 // Actual page content
@@ -285,6 +285,14 @@
 	else
 		return ..()
 
+/obj/item/book/attack(mob/M, mob/living/user)
+	if(user.a_intent == INTENT_HELP)
+		force = 0
+		attack_verb = list("educated")
+	else
+		force = initial(force)
+		attack_verb = list("bashed", "whacked")
+	..()
 
 /*
  * Barcode Scanner

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -167,6 +167,7 @@
 	icon_state ="book"
 	throw_speed = 1
 	throw_range = 5
+	force = 2
 	w_class = WEIGHT_CLASS_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
 	attack_verb = list("bashed", "whacked", "educated")
 	burn_state = FLAMMABLE


### PR DESCRIPTION
Books now have 2 force, dealing light damage on hit. Space law has 4.

This is a needed buff to Librarian, IAA, and Magistrate. :book:

If you're on help intent you won't damage the recipient and only educate them. follow SOP and put your clown shoes back on already

🆑
add: Books now deal light damage on hit if you're not on help intent. Space law book deals extra damage.
/🆑

