### PR TITLE
Fixes Null Crafting Recipes

### DIFF
--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -168,6 +168,7 @@
 				/obj/item/stack/tape_roll = 5)
 	tools = list(/obj/item/screwdriver, /obj/item/wirecutters)
 	time = 80
+	category = CAT_MISC
 
 /datum/crafting_recipe/guitar
 	name = "Guitar"
@@ -177,6 +178,7 @@
 				/obj/item/stack/tape_roll = 5)
 	tools = list(/obj/item/screwdriver, /obj/item/wirecutters)
 	time = 80
+	category = CAT_MISC
 
 /datum/crafting_recipe/eguitar
 	name = "Electric Guitar"
@@ -186,3 +188,4 @@
 				/obj/item/stack/tape_roll = 5)
 	tools = list(/obj/item/screwdriver, /obj/item/wirecutters)
 	time = 80
+	category = CAT_MISC

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -6,7 +6,7 @@
 	var/time = 30 //time in deciseconds
 	var/parts[] = list() //type paths of items that will be placed in the result
 	var/chem_catalysts[] = list() //like tools but for reagents
-	var/category = CAT_MISC // Recipe category
+	var/category = CAT_NONE // Recipe category
 	var/roundstart_enabled = TRUE //Set to FALSE if you don't want a particular crafting recipe to be available all the time
 
 /datum/crafting_recipe/proc/AdjustChems(var/obj/resultobj as obj)
@@ -251,6 +251,7 @@
 	reqs = list(/obj/item/camera = 1,
 				/datum/reagent/holywater = 10)
 	parts = list(/obj/item/camera = 1)
+	category = CAT_MISC
 
 /datum/crafting_recipe/papersack
 	name = "Paper Sack"
@@ -273,6 +274,7 @@
 	time = 50
 	reqs = list(/obj/item/stack/tape_roll = 1,
 				/datum/reagent/liquidgibs = 10)
+	category = CAT_MISC
 
 /datum/crafting_recipe/garrote
 	name = "Makeshift Garrote"
@@ -309,6 +311,7 @@
 	time = 15
 	reqs = list(/obj/item/clothing/gloves/color/latex = 1,
 				/obj/item/stack/cable_coil = 5)
+	category = CAT_MISC
 
 /datum/crafting_recipe/gold_horn
 	name = "Golden bike horn"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
@@ -255,7 +255,6 @@
 	category = CAT_FOOD
 
 /datum/crafting_recipe/food
-	category = CAT_FOOD
 
 /datum/crafting_recipe/food/New()
 	parts |= reqs
@@ -272,3 +271,4 @@
 		/datum/reagent/teslium = 1,
 	)
 	result = /mob/living/simple_animal/pet/cat/cak
+	category = CAT_FOOD


### PR DESCRIPTION
This should fix instances of `:` crafting recipes appearing.

We don't use subcategories for our crafting (yet), so we can't have null subtype recipes yet, unfortunately

:cl: Fox McCloud
fix: Fixes null crafting recipes
/:cl: