### PR TITLE
Reworks chameleon flag

### DIFF
--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -625,7 +625,7 @@
 "ma" = (/obj/effect/decal/cleanable/cobweb2,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/outer)
 "mb" = (/obj/effect/landmark{name = "syndi_depot_bot"},/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)
 "mc" = (/obj/machinery/light{dir = 1; on = 1},/obj/item/stack/sheet/metal{layer = 4.1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
-"md" = (/obj/item/flag/chameleon{icon_state = "syndiflag"; name = "Syndicate Flag"; used = 1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
+"md" = (/obj/item/flag/chameleon/prearmed{icon_state = "syndiflag"; name = "Syndicate Flag"; used = 1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
 "me" = (/turf/simulated/wall,/area/syndicate_depot/outer)
 "mf" = (/obj/effect/spawner/random_spawners/syndicate/turret/external,/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)
 "mg" = (/obj/machinery/light,/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -625,7 +625,7 @@
 "ma" = (/obj/effect/decal/cleanable/cobweb2,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/outer)
 "mb" = (/obj/effect/landmark{name = "syndi_depot_bot"},/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)
 "mc" = (/obj/machinery/light{dir = 1; on = 1},/obj/item/stack/sheet/metal{layer = 4.1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
-"md" = (/obj/item/flag/chameleon/prearmed{icon_state = "syndiflag"; name = "Syndicate Flag"; desc = "A flag proudly boasting the logo of the Syndicate, in defiance of NT."; used = 1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
+"md" = (/obj/item/flag/chameleon/depot{icon_state = "syndiflag"; name = "Syndicate Flag"; desc = "A flag proudly boasting the logo of the Syndicate, in defiance of NT."; used = 1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
 "me" = (/turf/simulated/wall,/area/syndicate_depot/outer)
 "mf" = (/obj/effect/spawner/random_spawners/syndicate/turret/external,/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)
 "mg" = (/obj/machinery/light,/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)

--- a/_maps/map_files/cyberiad/z6.dmm
+++ b/_maps/map_files/cyberiad/z6.dmm
@@ -625,7 +625,7 @@
 "ma" = (/obj/effect/decal/cleanable/cobweb2,/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/outer)
 "mb" = (/obj/effect/landmark{name = "syndi_depot_bot"},/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)
 "mc" = (/obj/machinery/light{dir = 1; on = 1},/obj/item/stack/sheet/metal{layer = 4.1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
-"md" = (/obj/item/flag/chameleon/prearmed{icon_state = "syndiflag"; name = "Syndicate Flag"; used = 1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
+"md" = (/obj/item/flag/chameleon/prearmed{icon_state = "syndiflag"; name = "Syndicate Flag"; desc = "A flag proudly boasting the logo of the Syndicate, in defiance of NT."; used = 1},/turf/simulated/floor/plasteel{icon_state = "dark"},/area/syndicate_depot/core)
 "me" = (/turf/simulated/wall,/area/syndicate_depot/outer)
 "mf" = (/obj/effect/spawner/random_spawners/syndicate/turret/external,/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)
 "mg" = (/obj/machinery/light,/turf/simulated/floor/plating/airless/asteroid,/area/syndicate_depot/outer)

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -914,13 +914,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 5
 	surplus = 8
 
-/datum/uplink_item/explosives/chameleonflag
-	name = "Chameleon Flag"
-	desc = "A flag that can be disguised as any other known flag. There is a heat sensitive bomb loaded into the pole that will be detonated if the flag is lit on fire."
-	reference = "CHFLAG"
-	item = /obj/item/flag/chameleon
-	cost = 7
-
 /datum/uplink_item/explosives/grenadier
 	name = "Grenadier's belt"
 	desc = "A belt containing 25 lethally dangerous and destructive grenades."
@@ -981,6 +974,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	it can also be used in a washing machine to forge clothing."
 	reference = "CHST"
 	item = /obj/item/stamp/chameleon
+	cost = 1
+	surplus = 35
+
+/datum/uplink_item/stealthy_tools/chameleonflag
+	name = "Chameleon Flag"
+	desc = "A flag that can be disguised as any other known flag. There is a hidden spot in the pole to boobytrap the flag with a grenade or minibomb, which will detonate some time after the flag is set on fire."
+	reference = "CHFLAG"
+	item = /obj/item/flag/chameleon
 	cost = 1
 	surplus = 35
 

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -216,7 +216,7 @@
 	if(used)
 		return ..()
 
-	var/list/flag_types = typesof(/obj/item/flag) - list(/obj/item/flag, /obj/item/flag/chameleon, /obj/item/flag/chameleon/prearmed)
+	var/list/flag_types = typesof(/obj/item/flag) - list(/obj/item/flag, /obj/item/flag/chameleon, /obj/item/flag/chameleon/depot)
 	var/list/flag = list()
 
 	for(var/flag_type in flag_types)

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -205,6 +205,8 @@
 	origin_tech = "syndicate=4;magnets=4"
 	var/updated_icon_state = null
 	var/used = FALSE
+	var/obj/item/grenade/boobytrap = null
+	var/mob/trapper = null
 
 /obj/item/flag/chameleon/New()
 	updated_icon_state = icon_state
@@ -236,9 +238,39 @@
 			desc = chosen_flag.desc
 			used = TRUE
 
+/obj/item/flag/chameleon/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/grenade) && !boobytrap)
+		if(user.drop_item())
+			boobytrap = I
+			trapper = user
+			I.forceMove(src)
+			to_chat(user, "<span class='notice'>You hide [I] in the [src]. It will detonate some time after the flag is lit on fire.</span>")
+			var/turf/bombturf = get_turf(src)
+			var/area/A = get_area(bombturf)
+			message_admins("[key_name_admin(user)] has hidden [I] in the [src] ready for detonation at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name] (JMP)</a>.")
+			log_game("[key_name(user)] has hidden [I] in the [src] ready for detonation at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]).")
+			investigate_log("[key_name(user)] has hidden [I] in the [src] ready for detonation at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]).", INVESTIGATE_BOMB)
+	else if(isscrewdriver(I) && boobytrap && user == trapper)
+		to_chat(user, "<span class='notice'>You remove [boobytrap] from the [src].</span>")
+		boobytrap.forceMove(get_turf(src))
+		boobytrap = null
+		trapper = null
+	else
+		..()
+
+/obj/item/flag/chameleon/attackby(obj/item/W, mob/user, params)
+	if(is_hot(W) && burn_state != ON_FIRE && boobytrap && trapper)
+		var/turf/bombturf = get_turf(src)
+		var/area/A = get_area(bombturf)
+		message_admins("[key_name_admin(user)] has lit the [src] trapped with [boobytrap] by [key_name_admin(trapper)] at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[bombturf.x];Y=[bombturf.y];Z=[bombturf.z]'>[A.name] (JMP)</a>.")
+		log_game("[key_name_admin(user)] has lit the [src] trapped with [boobytrap] by [key_name_admin(trapper)] at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]).")
+		investigate_log("[key_name_admin(user)] has lit the [src] trapped with [boobytrap] by [key_name_admin(trapper)] at [A.name] ([bombturf.x],[bombturf.y],[bombturf.z]).", INVESTIGATE_BOMB)
+	..()
+
 /obj/item/flag/chameleon/burn()
-	explosion(loc,1,2,4,4, flame_range = 4)
-	qdel(src)
+	if(boobytrap)
+		boobytrap.prime()
+	..()
 
 /obj/item/flag/chameleon/updateFlagIcon()
 	icon_state = updated_icon_state

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -216,7 +216,7 @@
 	if(used)
 		return ..()
 
-	var/list/flag_types = typesof(/obj/item/flag) - list(src.type, /obj/item/flag)
+	var/list/flag_types = typesof(/obj/item/flag) - list(/obj/item/flag, /obj/item/flag/chameleon, /obj/item/flag/chameleon/prearmed)
 	var/list/flag = list()
 
 	for(var/flag_type in flag_types)
@@ -274,3 +274,7 @@
 
 /obj/item/flag/chameleon/updateFlagIcon()
 	icon_state = updated_icon_state
+
+/obj/item/flag/chameleon/prearmed/New()
+	..()
+	boobytrap = new /obj/item/grenade/syndieminibomb(src)

--- a/code/game/objects/items/flag.dm
+++ b/code/game/objects/items/flag.dm
@@ -275,6 +275,6 @@
 /obj/item/flag/chameleon/updateFlagIcon()
 	icon_state = updated_icon_state
 
-/obj/item/flag/chameleon/prearmed/New()
+/obj/item/flag/chameleon/depot/New()
 	..()
-	boobytrap = new /obj/item/grenade/syndieminibomb(src)
+	boobytrap = new /obj/item/grenade/gas/plasma(src)


### PR DESCRIPTION
This PR aims to make the chameleon flag a more versatile tool, while keeping the functionality of the current Chameleon flag.

List of changes : 

- Moved to Stealthy Tools from Explosives

- Cost reduced from 7 TC to 1

- Now start without an explosive, but can be boobytrapped with any grenade. This explosive still detonates once the flag is done burning, as with the current flag.

- The grenade can only be removed by the person who installed it.

- Added admin logging (let me know if this is too much logging, it logs on boobytrapping the flag and on being lit on fire)

Non-exhaustive list of stuff to do with this new flag : 

- Buy a syndicate minibomb and install it in the flag, resulting in the exact same behaviour and TC cost (6 +1) as the old chameleon flag. Wow! It's like nothing changed!

- Use the flag without an explosive to decorate your evil autism fort at an affordable price.

- Buy 20 clown flags.

- Buy less clown flags but traps one of them with a banana grenade instead for extra hilarity.

- Label your flag "Kingdom of the Rumba Beats" and booby trap it with a 300/300 potassium water grenade.

And more! The possibilities are endless! Or at least more than the current chameleon flag.

🆑
add: Chameleon flag reworked : Now cost 1 TC from 7, but starts without an explosive. It can be boobytrapped using any grenade or a syndicate minibomb.
tweak: Chameleon flag moved from "Explosives" to "Stealthy Tools" in the uplink.
fix: Fixed description of syndicate flags on the suspicious supply depot.
/🆑