### PR TITLE
Stops simple animals and silicons being able to do what they shouldn't be able to.

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -273,7 +273,9 @@
 	if(!istype(user) || user.incapacitated())
 		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(!in_range(src, user) || issilicon(usr))
+	if(!in_range(src, user))
+		return
+	if(!ishuman(usr))
 		return
 	if(amount < 1)
 		return

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -59,6 +59,8 @@
 		if(usr.incapacitated())
 			to_chat(usr, "<span class='warning'>You can't do that right now!</span>")
 			return
+		if(!ishuman(usr))
+			return
 		usr.visible_message("<span class='notice'>[usr] grabs \the [src.name].</span>", "<span class='notice'>You grab \the [src.name].</span>")
 		var/C = new item_chair(loc)
 		usr.put_in_hands(C)

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -219,6 +219,8 @@
 	var/mob/M = usr
 	if(M.incapacitated() || !Adjacent(M))
 		return
+	if(!ishuman(M))
+		return
 
 	if(over_object == M || istype(over_object, /obj/screen))
 		if(!remove_item_from_storage(M))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -30,6 +30,8 @@
 	var/mob/M = usr
 	if(M.restrained() || M.stat || !Adjacent(M))
 		return
+	if(!ishuman(M))
+		return
 
 	if(over_object == M)
 		if(!remove_item_from_storage(M))


### PR DESCRIPTION
**What does this PR do:**
Fixes #10707
Fixes #10669

Stops simple animals and silicons from being able to grab decks of cards, paperbins, chairs, stools.
As well stops simple animals and silicons from being able to split stacks of sheets.

**Changelog:**
:cl: Dovydas12345
fix: Fixes simple animals (mice, corgis, etc.) and silicons (borgs, drones) being able to grab decks of cards, paperbins, chairs, stools.
fix: Fixes simple animals (mice, corgis, etc.) and silicons (borgs, drones) being able to split stacks of sheets.
/:cl:

