### PR TITLE
Fixed phantom drill bug

### DIFF
--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -122,7 +122,7 @@ GLOBAL_LIST_EMPTY(safes)
 		switch(alert("What would you like to do?", "Thermal Drill", "Turn [drill_timer ? "Off" : "On"]", "Remove Drill", "Cancel"))
 			if("Turn On")
 				if(do_after(user, 2 SECONDS, target = src))
-					drill_timer = addtimer(CALLBACK(src, .proc/drill_open), time_to_drill)
+					drill_timer = addtimer(CALLBACK(src, .proc/drill_open), time_to_drill, TIMER_STOPPABLE)
 					drill_start_time = world.time
 					drill.soundloop.start()
 					update_icon()


### PR DESCRIPTION
**What does this PR do:**
Fixes a bug in the safes where turning off a drill wont stop the drill... (Whoops)

**Changelog:**
:cl:
fix: Drills now properly stop when turned off.
/:cl:

