### PR TITLE
Changes to C4's explosion handling

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -135,13 +135,13 @@
 	var/turf/location
 	if(target)
 		if(!QDELETED(target))
-			if(istype(target, /obj/))
-				location = get_atom_on_turf(target)
+			if(istype(target, /turf/))
+				location = get_turf(target)	// Set the explosion location to turf if planted directly on a wall or floor
 			else
-				location = get_turf(target)
-				target.overlays -= image_overlay
+				location = get_atom_on_turf(target)	// Otherwise, make sure we're blowing up what's on top of the turf
+			target.overlays -= image_overlay
 	else
-		location = get_turf(src)
+		location = get_atom_on_turf(src)
 	if(location)
 		explosion(location,0,0,3)
 		location.ex_act(2, target)
@@ -165,10 +165,13 @@
 	var/turf/location
 	if(target)
 		if(!QDELETED(target))
-			location = get_turf(target)
+			if(istype(target, /turf/))
+				location = get_turf(target)
+			else
+				location = get_atom_on_turf(target)
 			target.overlays -= image_overlay
 	else
-		location = get_turf(src)
+		location = get_atom_on_turf(src)
 	if(location)
 		if(target && target.density)
 			var/turf/T = get_step(location, aim_dir)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -135,13 +135,16 @@
 	var/turf/location
 	if(target)
 		if(!QDELETED(target))
-			location = get_turf(target)
-			target.overlays -= image_overlay
+			if(istype(target, /obj/))
+				location = get_atom_on_turf(target)
+			else
+				location = get_turf(target)
+				target.overlays -= image_overlay
 	else
 		location = get_turf(src)
 	if(location)
-		location.ex_act(2, target)
 		explosion(location,0,0,3)
+		location.ex_act(2, target)
 	if(istype(target, /mob))
 		var/mob/M = target
 		M.gib()


### PR DESCRIPTION
**What does this PR do:**
This PR changes how c4 determines what to `ex_act` upon being primed. Currently C4 is extremely weak against anything that isn't a wall or floor, with airlocks in particular just sparking a little if you plant one on them. This is due to the fact that when the c4 explodes on an object, the full force of the explosion is currently applied to the turf it's on rather than the actual object and then a weaker explosion goes off in a small radius.

Now it checks to see exactly what the c4 is being placed on. If it's a turf then it behaves as it did before, otherwise if the c4 is applied to anything else then the location of the explosion is set to the atom on the turf, usually the object itself.

Testing has shown that airlocks are almost always destroyed in a single blast after this change, and various machines are much weaker to c4 compared to the low damage it did previously. I haven't noticed any immediate issues with c4 after this but please let me know if something is wrong with the way I've coded this.

**Changelog:**
:cl:
tweak: C4 and X4 are now much better at destroying objects they are directly placed on.
/:cl:

