### PR TITLE
Replaces Kitchen/Botany wall with plating

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -3530,7 +3530,7 @@
 "bpT" = (/obj/machinery/hologram/holopad,/turf/simulated/floor/carpet,/area/crew_quarters/mrchangs)
 "bpU" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 1; on = 1},/turf/simulated/floor/plasteel{icon_state = "green"; dir = 8},/area/hydroponics)
 "bpV" = (/turf/simulated/floor/plasteel{dir = 8; icon_state = "vault"; tag = "icon-vault (WEST)"},/area/hydroponics)
-"bpW" = (/obj/machinery/smartfridge,/turf/simulated/wall,/area/hydroponics)
+"bpW" = (/obj/machinery/smartfridge,/turf/simulated/floor/plating,/area/hydroponics)
 "bpX" = (/obj/machinery/atmospherics/unary/vent_scrubber{dir = 1; on = 1; scrub_N2O = 1; scrub_Toxins = 1},/turf/simulated/floor/plasteel{icon_state = "green"; dir = 4},/area/hydroponics)
 "bpY" = (/obj/machinery/door/window/northright{base_state = "right"; dir = 8; icon_state = "right"; name = "Library Desk Door"; req_access_txt = "37"},/obj/machinery/status_display{density = 0; layer = 4; pixel_x = 0; pixel_y = 32},/turf/simulated/floor/wood,/area/library)
 "bpZ" = (/obj/structure/chair/stool,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/plasteel{dir = 1; icon_state = "chapel"},/area/chapel/main)


### PR DESCRIPTION
**What does this PR do:**

Replaces the wall that's *in* the Kitchen/Botany vendor with a plating, so as to be more like the medchem vendor (and so lone chefs can actually do their job).

**Images of sprite/map changes (IF APPLICABLE):**

A vendor obscures the wall.
![image](https://user-images.githubusercontent.com/44811257/51726960-79c4c080-202f-11e9-9427-ce8da659bdc0.png) (Vendor removed for visiblity.)


**Changelog:**
:cl:
tweak: Changed the wall in the Kitchen/Botany vendor to a plating.
/:cl:

