### PR TITLE
Gives syndie medical borgs hydrocodone instead of ether

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -26,11 +26,11 @@
 
 /obj/item/reagent_containers/borghypo/syndicate
 	name = "syndicate cyborg hypospray"
-	desc = "An experimental piece of Syndicate technology used to produce powerful restorative nanites used to very quickly restore injuries of all types. Also metabolizes potassium iodide, for radiation poisoning, and morphine, for offense."
+	desc = "An experimental piece of Syndicate technology used to produce powerful restorative nanites used to very quickly restore injuries of all types. Also metabolizes potassium iodide, for radiation poisoning, and hydrocodone, for field surgery and pain relief."
 	icon_state = "borghypo_s"
 	charge_cost = 20
 	recharge_time = 2
-	reagent_ids = list("syndicate_nanites", "potass_iodide", "ether")
+	reagent_ids = list("syndicate_nanites", "potass_iodide", "hydrocodone")
 	bypass_protection = 1
 
 /obj/item/reagent_containers/borghypo/New()


### PR DESCRIPTION
**What does this PR do:**
This PR exchanges the ether in the syndie medical borg's hypospray with hydrocodone. It also fixed the description of the spray saying it contained morphine.
So, why hydrocodone:
1. Ether is nearly useless. Trying to use it for surgery is a gigantic pain and no nukie is going to let himself be knocked out long enough with it. Trying to use it on crew is just going to get the borg beaten to death with crowbars, he's far better off using his surgery saw as a melee weapon if he has to, or injecting the actual poison in his hypospray.
2. Hydrocodone is a powerful pain killer with no OD or side effects, letting the borg potentially dose the nukies with it beforehand to prevent pain crit, or using it after they've lost a few limbs to keep them in the fight.
3. Hydrocodone lets the borg potentially do field surgery, if they can drag a fallen nukie away. I admit it's not the easiest thing ever but the nukie staying conscious and able to get up during the surgery will make it a lot more likely than with ether.
4. NT medical droids already get hydrocodone. I see no reason the advanced syndie borg, who has nanites, should have to make do with ether or morphine.


**Changelog:**
:cl:
tweak: ether in syndie medical borg's hypospray replaced with hydrocodone
fix: syndicate medical borg's hypospray no longer incorrectly lists its content
/:cl:

