### PR TITLE
Remove bat swarm from gold slime spawn pool

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -75,3 +75,4 @@
 	pass_flags = PASSTABLE
 	universal_speak = 1
 	universal_understand = 1
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID //badmin only


### PR DESCRIPTION
Fixes #10694

Bat swarm is a simple mob intended for the admin only Ancient Vampire. It is way too robust to be spawned in normal gameplay, and shares the same sprite as the very weak bats.

This PR removes it from the hostile gold slime extract pool. Incidentally, the reality tear event uses that variable to make its pool of hostile mobs, so that also fixes that.

🆑
tweak: Bat swarm can no longer be spawned by gold slime extracts or reality tears. Regular bats can still be spawned.
/🆑