### PR TITLE
Fix put_in_hands putting items in nonexistent hands

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -323,6 +323,26 @@
 	else
 		. = ..()
 
+/mob/living/carbon/human/put_in_r_hand(obj/item/W)
+	var/obj/item/organ/external/temp = bodyparts_by_name["r_hand"]
+	if(!temp)
+		to_chat(src, "<span class='warning'>You try to use your right hand, but it's missing!</span>")
+		return FALSE
+	if(temp && !temp.is_usable())
+		to_chat(src, "<span class='warning'>You try to move your [temp.name], but cannot!</span>")
+		return FALSE
+	..()
+
+/mob/living/carbon/human/put_in_l_hand(obj/item/W)
+	var/obj/item/organ/external/temp = bodyparts_by_name["l_hand"]
+	if(!temp)
+		to_chat(src, "<span class='warning'>You try to use your left hand, but it's missing!</span>")
+		return FALSE
+	if(temp && !temp.is_usable())
+		to_chat(src, "<span class='warning'>You try to move your [temp.name], but cannot!</span>")
+		return FALSE
+	..()
+
 // Return the item currently in the slot ID
 /mob/living/carbon/human/get_item_by_slot(slot_id)
 	switch(slot_id)


### PR DESCRIPTION
Fixes #10730 and fixes #10731

Added a check to two procs to put items in hands for humans to check if the hand's missing, fixing situations where you'd have an item put into a hand that doesn't exist.

:cl:
fix: Added a check to see if the hand's missing in a couple of procs, fixing certain situations where you'd have an item put into a hand that doesn't exist.
/:cl:

