### PR TITLE
Adds the cyborg body analyzer to syndi medborgs

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -569,9 +569,19 @@ REAGENT SCANNER
 	var/ready = TRUE // Ready to scan
 	var/time_to_use = 0 // How much time remaining before next scan is available.
 	var/usecharge = 750
+	var/scan_time = 10 SECONDS //how long does it take to scan
+	var/scan_cd = 60 SECONDS //how long before we can scan again
 
 /obj/item/bodyanalyzer/advanced
 	cell_type = /obj/item/stock_parts/cell/upgraded/plus
+
+/obj/item/bodyanalyzer/borg
+	name = "cyborg body analyzer"
+	desc = "Scan an entire body to prepare for field surgery. Consumes power for each scan."
+
+/obj/item/bodyanalyzer/borg/syndicate
+	scan_time = 5 SECONDS
+	scan_cd = 20 SECONDS
 
 /obj/item/bodyanalyzer/New()
 	..()
@@ -614,29 +624,46 @@ REAGENT SCANNER
 		to_chat(user, "<span class='notice'>The scanner beeps angrily at you! It's out of charge!</span>")
 		playsound(user.loc, 'sound/machines/buzz-sigh.ogg', 50, 1)
 
+/obj/item/bodyanalyzer/borg/attack(mob/living/M, mob/living/silicon/robot/user)
+	if(user.incapacitated() || !user.Adjacent(M))
+		return
+
+	if(!ready)
+		to_chat(user, "<span class='notice'>[src] is currently recharging - [round((time_to_use - world.time) * 0.1)] seconds remaining.</span>")
+		return
+
+	if(user.cell.charge >= usecharge)
+		mobScan(M, user)
+	else
+		to_chat(user, "<span class='notice'>You need to recharge before you can use [src]</span>")
+
 /obj/item/bodyanalyzer/proc/mobScan(mob/living/M, mob/user)
 	if(ishuman(M))
 		var/report = generate_printing_text(M, user)
 		user.visible_message("[user] begins scanning [M] with [src].", "You begin scanning [M].")
-		if(do_after(user, 100, target = M))
+		if(do_after(user, scan_time, target = M))
 			var/obj/item/paper/printout = new
 			printout.info = report
 			printout.name = "Scan report - [M.name]"
 			playsound(user.loc, 'sound/goonstation/machines/printer_dotmatrix.ogg', 50, 1)
 			user.put_in_hands(printout)
-			time_to_use = world.time + 600
-			power_supply.use(usecharge)
+			time_to_use = world.time + scan_cd
+			if(isrobot(user))
+				var/mob/living/silicon/robot/R = user
+				R.cell.use(usecharge)
+			else
+				power_supply.use(usecharge)
 			ready = FALSE
 			update_icon(TRUE)
-			addtimer(CALLBACK(src, /obj/item/bodyanalyzer/.proc/setReady), 600)
+			addtimer(CALLBACK(src, /obj/item/bodyanalyzer/.proc/setReady), scan_cd)
 			addtimer(CALLBACK(src, /obj/item/bodyanalyzer/.proc/update_icon), 20)
 
 	else if(iscorgi(M) && M.stat == DEAD)
 		to_chat(user, "<span class='notice'>You wonder if [M.p_they()] was a good dog. <b>[src] tells you they were the best...</b></span>") // :'(
 		playsound(loc, 'sound/machines/ping.ogg', 50, 0)
 		ready = FALSE
-		addtimer(CALLBACK(src, /obj/item/bodyanalyzer/.proc/setReady), 600)
-		time_to_use = world.time + 600
+		addtimer(CALLBACK(src, /obj/item/bodyanalyzer/.proc/setReady), scan_cd)
+		time_to_use = world.time + scan_cd
 	else
 		to_chat(user, "<span class='notice'>Scanning error detected. Invalid specimen.</span>")
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -408,6 +408,7 @@
 	..()
 	modules += new /obj/item/healthanalyzer/advanced(src)
 	modules += new /obj/item/reagent_scanner/adv(src)
+	modules += new /obj/item/bodyanalyzer/borg/syndicate(src)
 	modules += new /obj/item/borg_defib(src)
 	modules += new /obj/item/roller_holder(src)
 	modules += new /obj/item/reagent_containers/borghypo/syndicate(src)


### PR DESCRIPTION
Syndicate medborgs now get a cyborg body analyzer, which lets you print a full body scan report of whoever you use it on. 

It consumes power from the borg's power cell instead of an internal power cell.

Coupled with the changes to the borg's hypospray provided by #10726, this PR will make the syndi medborg a much more capable field surgeon, and get it closer in provided value to the syndicate assault module.

🆑
add: Syndicate medical cyborgs now get a portable full body analyzer, making them much more effective field surgeons.
/🆑
