### PR TITLE
Can apply tape to some more items, can't apply tape to intercoms

### DIFF
--- a/code/game/objects/items/devices/autopsy.dm
+++ b/code/game/objects/items/devices/autopsy.dm
@@ -78,6 +78,8 @@
 		playsound(loc, 'sound/goonstation/machines/printer_thermal.ogg', 50, 1)
 		sleep(10)
 		user.put_in_hands(R)
+	else
+		return ..()
 
 /obj/item/autopsy_scanner/attack_self(mob/user)
 	var/scan_data = ""

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -309,7 +309,7 @@
 /obj/item/radio/headset/attackby(obj/item/W as obj, mob/user as mob)
 	user.set_machine(src)
 	if(!( istype(W, /obj/item/screwdriver) || (istype(W, /obj/item/encryptionkey/ ))))
-		return
+		return ..()
 
 	if(istype(W, /obj/item/screwdriver))
 		if(keyslot1 || keyslot2)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -135,6 +135,8 @@
 	return canhear_range
 
 /obj/item/radio/intercom/attackby(obj/item/W as obj, mob/user as mob)
+	if(istype(W, /obj/item/stack/tape_roll)) //eww
+		return
 	switch(buildstage)
 		if(3)
 			if(iswirecutter(W) && b_stat && wires.IsAllCut())


### PR DESCRIPTION
Title

You can apply tape to headsets and autopsy scanner now, and can't apply tapes to station intercoms any more

:cl:
fix: Fixes tape being unapplicable to headsets and the autopsy scanner
fix: You can't tape intercoms any more
/:cl: