### PR TITLE
Renames z2's "Bar" to "Bar lounge"

### DIFF
--- a/code/game/area/Dynamic areas.dm
+++ b/code/game/area/Dynamic areas.dm
@@ -20,7 +20,7 @@
 	name = "dynamic area source"
 
 /area/dynamic/source/lobby_bar
-	name = "\improper Bar"
+	name = "\improper Bar Lounge"
 	match_tag = "arrivals"
 	match_width = 5
 	match_height = 4


### PR DESCRIPTION
This always bugged me. Whenever you use the ghost's "teleport" verb, and select to teleport to the bar, it'll send you to the tiny bar lounge instead of the actual bar. This PR fixes that by renaming the Z2 "Bar" to "Bar Lounge".

:cl:
tweak: Renames the "Bar" on the Centcomm level to "Bar Lounge".
/:cl: