### PR TITLE
Fixes hear_say.dm runtime: list index out of bounds

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -70,7 +70,7 @@
 			sound_vol *= 0.5
 
 	if(sleeping || stat == UNCONSCIOUS)
-		hear_sleep(message_pieces)
+		hear_sleep(multilingual_to_message(message_pieces))
 		return 0
 
 	var/speaker_name = speaker.name

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -158,7 +158,7 @@
 		message = strip_html_properly(message)
 		var/list/punctuation = list(",", "!", ".", ";", "?")
 		var/list/messages = splittext(message, " ")
-		if(messages.len > 1)
+		if(messages.len > 0)
 			var/R = rand(1, messages.len)
 			var/heardword = messages[R]
 			if(copytext(heardword,1, 1) in punctuation)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -97,7 +97,7 @@
 
 	if(!can_hear())
 		// INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
-		// if(!language || !(language.flags & INNATE)) 
+		// if(!language || !(language.flags & INNATE))
 		if(speaker == src)
 			to_chat(src, "<span class='warning'>You cannot hear yourself speak!</span>")
 		else
@@ -158,14 +158,16 @@
 		message = strip_html_properly(message)
 		var/list/punctuation = list(",", "!", ".", ";", "?")
 		var/list/messages = splittext(message, " ")
-		var/R = rand(1, messages.len)
-		var/heardword = messages[R]
-		if(copytext(heardword,1, 1) in punctuation)
-			heardword = copytext(heardword,2)
-		if(copytext(heardword,-1) in punctuation)
-			heardword = copytext(heardword,1,lentext(heardword))
-		heard = "<span class='game say'>...<i>You hear something about<i>... '[heardword]'...</span>"
-
+		if(messages.len > 1)
+			var/R = rand(1, messages.len)
+			var/heardword = messages[R]
+			if(copytext(heardword,1, 1) in punctuation)
+				heardword = copytext(heardword,2)
+			if(copytext(heardword,-1) in punctuation)
+				heardword = copytext(heardword,1,lentext(heardword))
+			heard = "<span class='game say'>...<i>You hear something about<i>... '[heardword]'...</span>"
+		else
+			heard = "<span class='game say'>...<i>You almost hear something...</i>...</span>"
 	else
 		heard = "<span class='game say'>...<i>You almost hear someone talking</i>...</span>"
 


### PR DESCRIPTION
:cl: Kyep
fix: fixed a runtime in hear_say.dm
/:cl:

Example of the runtime this fixes:
[2019-01-26T23:42:53] Runtime in hear_say.dm,162: list index out of bounds
   proc name: hear sleep (/mob/proc/hear_sleep)
   usr: CHARNAME (CKEY1) (/mob/living/carbon/human)
   usr.loc: The floor (137,107,1) (/turf/simulated/floor/plasteel)
   src: CHARNAME2 (/mob/living/carbon/human)
   src.loc: the floor (135,106,1) (/turf/simulated/floor/plasteel)
   call stack:
   CHAR2 (/mob/living/carbon/human): hear sleep("")
   CHAR2 (/mob/living/carbon/human): hear say(/list (/list), "says", 0, CHARNAME  (/mob/living/carbon/human), null, null)
   CHARNAME  (/mob/living/carbon/human): say("good, rather", "says", 1, 0, 0)
   CHARNAME  (/mob/living/carbon/human): say("good, rather", 1, 0, 0)
   CHARNAME  (/mob/living/carbon/human): Say("good, rather")

Changes made:

- Fixed call to hear_sleep using hear_sleep(message_pieces) instead of hear_sleep(multilingual_to_message(message_pieces)), which resulted in hear_sleep being passed a list which evaluated to "", which resulted in a runtime.
- Fixed hear_sleep being unable to handle cases where it couldn't split the message properly, which could also cause a runtime.