### PR TITLE
Fixes item_attack.dm / undefined attack_obj runtime

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -21,7 +21,7 @@
 	return FALSE
 
 /obj/attackby(obj/item/I, mob/living/user, params)
-	return ..() || (can_be_hit && I.attack_obj(src, user))
+	return ..() || (can_be_hit && isitem(I) && I.attack_obj(src, user))
 
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
Certain attacks (like trying to click a /obj/machinery/door/window/brigdoor on harm intent with nothing in hand) result in item_attack runtimes like this:

[2019-01-27T00:05:48] Runtime in item_attack.dm,24: undefined proc or verb /mob/living/carbon/human/attack obj(). 
   proc name: attackby (/obj/attackby)
   usr: CHARNAME (CKEY) (/mob/living/carbon/human)
   usr.loc: The floor (151,13,2) (/turf/simulated/floor/plasteel)
   src: the secure door (/obj/machinery/door/window/brigdoor)
   src.loc: the floor (151,13,2) (/turf/simulated/floor/plasteel)
   call stack:
   the secure door (/obj/machinery/door/window/brigdoor): attackby(CHARNAME (/mob/living/carbon/human), CHARNAME (/mob/living/carbon/human), null)
   the secure door (/obj/machinery/door/window/brigdoor): attackby(CHARNAME (/mob/living/carbon/human), CHARNAME (/mob/living/carbon/human), null)
   the secure door (/obj/machinery/door/window/brigdoor): attackby(CHARNAME (/mob/living/carbon/human), CHARNAME (/mob/living/carbon/human), null)
   the secure door (/obj/machinery/door/window/brigdoor): attack hand(CHARNAME (/mob/living/carbon/human))
   CHARNAME (/mob/living/carbon/human): UnarmedAttack(the secure door (/obj/machinery/door/window/brigdoor), 1)
   CHARNAME (/mob/living/carbon/human): ClickOn(the secure door (/obj/machinery/door/window/brigdoor), "icon-x=6;icon-y=5;left=1;scree...")
   the secure door (/obj/machinery/door/window/brigdoor): Click(the floor (151,13,2) (/turf/simulated/floor/plasteel), "mapwindow.map", "icon-x=6;icon-y=5;left=1;scree...")

This PR prevents this runtime. 
Under this PR, attempting to punch such an object does nothing.

:cl: Kyep
fix: Fixed item_attack / attack_obj runtime.
/:cl:

