### PR TITLE
Fixes runtime when double-clicking a stool item in hand

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -321,7 +321,6 @@
 	w_class = WEIGHT_CLASS_HUGE
 	origin_type = /obj/structure/chair/stool
 	break_chance = 0 //It's too sturdy.
-	var/obj/structure/chair/stool/origin = null
 
 /obj/item/chair/stool/bar
 	name = "bar stool"
@@ -377,7 +376,7 @@
 
 /obj/item/chair/stool/attack_self(mob/user as mob)
 	..()
-	origin.loc = get_turf(src)
+	new origin_type(get_turf(loc))
 	user.unEquip(src)
 	user.visible_message("<span class='notice'>[user] puts [src] down.</span>", "<span class='notice'>You put [src] down.</span>")
 	qdel(src)


### PR DESCRIPTION
:cl:
fix: Fixed runtime when double-clicking a stool in-hand.
/:cl:

Previous runtime:
[2019-01-27T00:12:39] Runtime in chairs.dm,380: Cannot modify null.loc.
   proc name: attack self (/obj/item/chair/stool/attack_self)

Caused by 'origin' not being defined.
Solution: remove 'origin' var, and start simply using the origin_type var which is already defined and works.
