### PR TITLE
Fixes #10729 - objectives targeting admin centcom characters

### DIFF
--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -3,6 +3,7 @@
 #define TARGET_INVALID_NOT_HUMAN	2
 #define TARGET_INVALID_DEAD			3
 #define TARGET_INVALID_NOCKEY		4
+#define TARGET_INVALID_ADMINZLEVEL	5
 
 //gamemode istype helpers
 #define GAMEMODE_IS_BLOB		(ticker && istype(ticker.mode, /datum/game_mode/blob))

--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -3,7 +3,7 @@
 #define TARGET_INVALID_NOT_HUMAN	2
 #define TARGET_INVALID_DEAD			3
 #define TARGET_INVALID_NOCKEY		4
-#define TARGET_INVALID_ADMINZLEVEL	5
+#define TARGET_INVALID_UNREACHABLE	5
 
 //gamemode istype helpers
 #define GAMEMODE_IS_BLOB		(ticker && istype(ticker.mode, /datum/game_mode/blob))

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -31,6 +31,10 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 		return TARGET_INVALID_DEAD
 	if(!possible_target.key)
 		return TARGET_INVALID_NOCKEY
+	if(possible_target.current)
+		var/turf/current_location = get_turf(possible_target.current)
+		if(current_location && is_admin_level(current_location.z))
+			return TARGET_INVALID_ADMINZLEVEL
 
 /datum/objective/proc/find_target()
 	var/list/possible_targets = list()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -33,8 +33,8 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 		return TARGET_INVALID_NOCKEY
 	if(possible_target.current)
 		var/turf/current_location = get_turf(possible_target.current)
-		if(current_location && is_admin_level(current_location.z))
-			return TARGET_INVALID_ADMINZLEVEL
+		if(current_location && !is_level_reachable(current_location.z))
+			return TARGET_INVALID_UNREACHABLE
 
 /datum/objective/proc/find_target()
 	var/list/possible_targets = list()


### PR DESCRIPTION
:cl: Kyep
fix: Antag objectives (kill, debrain, etc) can no longer target people on unreachable zlevels, like the admin-only/centcom zlevel. 
/:cl:

Fixes #10729 

