### PR TITLE
Fixes admin co-ord jump

### DIFF
--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -71,6 +71,9 @@
 	var/turf/T = locate(tx, ty, tz)
 	if(T)
 		admin_forcemove(usr, T)
+		if(isobserver(usr))
+			var/mob/dead/observer/O = usr
+			O.ManualFollow(T)
 		feedback_add_details("admin_verb","JC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	if(!isobserver(usr))
 		message_admins("[key_name_admin(usr)] jumped to coordinates [tx], [ty], [tz]")


### PR DESCRIPTION
Right now, if you click on a JMP link as an admin while following something, it teleports you to the destination of the JMP link, then semi-instantly teleports you back due to what you were following previously.

With this PR, if you click on a JMP link overrides existing follows, so you'll teleport to the thing the JMP link is pointing to, and stay there.

This fixes the annoying behavior where you, as an admin ghost, click a JMP link, only to see a half-second flash of what you want to look at, before remembering you have to cancel your follow first and then re-use the link.

I think of this as a fix, because IMHO clicking a 'JMP' button should clearly override your existing follow, but it doesn't.

:cl: Kyep
fix: Admin JMP links now work even if you're already following someone/something.
/:cl:

