### PR TITLE
Update Crossbow.Dm

### DIFF
--- a/code/modules/projectiles/guns/throw/crossbow.dm
+++ b/code/modules/projectiles/guns/throw/crossbow.dm
@@ -163,7 +163,7 @@
 	name = "makeshift bolt"
 	desc = "A sharpened metal rod that can be fired out of a crossbow."
 	icon_state = "metal-rod"
-	throwforce = 8
+	throwforce = 10
 	var/superheated = 0
 
 /obj/item/arrow/rod/removed()


### PR DESCRIPTION
A little bit more damage to the makeshift bolt than before 

Before 8 ==> now 10 

**What does this PR do:**
adds more damage to the makeshifts bolts to be a decent weapon loaded inside a crossbow  since normal bolts cant be found or made in the normal station that makes the powered crossbow really weak and now it will make an apropiate damage for a crossbow (i still think more than a  throwable item  the bolt must be more like a bullet )

**Changelog:**
:cl:
balance: Makeshift Bolt Base Damage Increased 
/:cl:

