### PR TITLE
Binary Key Description Fix

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1216,7 +1216,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/binary
 	name = "Binary Translator Key"
-	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary."
+	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. To talk on the binary channel, type :+= before your radio message."
 	reference = "BITK"
 	item = /obj/item/encryptionkey/binary
 	cost = 5

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -1216,7 +1216,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/binary
 	name = "Binary Translator Key"
-	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. To talk on the binary channel, type :+= before your radio message."
+	desc = "A key, that when inserted into a radio headset, allows you to listen to and talk with artificial intelligences and cybernetic organisms in binary. To talk on the binary channel, type :+ before your radio message."
 	reference = "BITK"
 	item = /obj/item/encryptionkey/binary
 	cost = 5

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -43,7 +43,7 @@
 
 /obj/item/encryptionkey/binary
 	name = "binary translator key"
-	desc = "An encryption key for a radio headset. To access the binary channel, use :+=."
+	desc = "An encryption key for a radio headset. To access the binary channel, use :+."
 	icon_state = "cypherkey"
 	translate_binary = TRUE
 	origin_tech = "syndicate=3;engineering=4;bluespace=3"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -43,7 +43,7 @@
 
 /obj/item/encryptionkey/binary
 	name = "binary translator key"
-	desc = "An encryption key for a radio headset. To access the binary channel, use :b."
+	desc = "An encryption key for a radio headset. To access the binary channel, use :+=."
 	icon_state = "cypherkey"
 	translate_binary = TRUE
 	origin_tech = "syndicate=3;engineering=4;bluespace=3"


### PR DESCRIPTION
Changes the Binary Key description for both the uplink and item versions. It now states the correct prefix to use when communicating with silicons over the radio; `:+`.

**Changelog:**
:cl:
fix: Fixed Binary Key's description to give the correct code to use when communicating with the AI or borgs.
/:cl: