### PR TITLE
Remove flavor text on abductor, add SE clean I missed

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -125,6 +125,7 @@
 	H.real_name = team_name + " Agent"
 	H.cleanSE() //No fat/blind/colourblind/epileptic/whatever ayys.
 	H.overeatduration = 0
+	H.flavor_text = null
 	H.equipOutfit(/datum/outfit/abductor/agent)
 	greet_agent(agent,team_number)
 	update_abductor_icons_added(agent)
@@ -139,8 +140,9 @@
 	S.scientist = TRUE
 	S.team = team_number
 	H.real_name = team_name + " Scientist"
-	H.reagents.add_reagent("mutadone", 1) //No fat/blind/colourblind/epileptic/whatever ayys.
+	H.cleanSE() //No fat/blind/colourblind/epileptic/whatever ayys.
 	H.overeatduration = 0
+	H.flavor_text = null
 	H.equipOutfit(/datum/outfit/abductor/scientist)
 	greet_scientist(scientist,team_number)
 	update_abductor_icons_added(scientist)


### PR DESCRIPTION
Abductors no longer have flavor text. You're an ayyy lmao, now, johnny snowflake. :alien:

Added an SE clean I forgot in #10636, I didn't realise agent and scientist each had their own setup for that.

🆑
fix: Abductors no longer start with your preset character's flavor text.
fix: Abductor scientists now have their SE properly cleaned on spawn.
/🆑