### PR TITLE
Wingdings now garble sentences

### DIFF
--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -202,3 +202,15 @@
 /datum/dna/gene/disability/wingdings/New()
 	block = WINGDINGSBLOCK
 
+/datum/dna/gene/disability/wingdings/OnSay(var/mob/M, var/message)
+	var/list/chars = string2charlist(message)
+	var/garbled_message = ""
+	for(var/C in chars)
+		if(C in GLOB.alphabet_uppercase)
+			garbled_message += pick(GLOB.alphabet_uppercase)
+		else if(C in GLOB.alphabet)
+			garbled_message += pick(GLOB.alphabet)
+		else
+			garbled_message += C
+	message = garbled_message
+	return message


### PR DESCRIPTION
Having the wingdings disability will now randomize the letters in your sentence to random letters (assuming of course you don't have a translator on). Spaces, symbols, and anything else that isn't in the alphabet aren't affected.

This fixes two issues, the first is that you can copy paste wingdings to the chat bar or a text editor to read the sentence when they're not meant to be understood.

The second is that you can use wingdings to say symbols like :thumbsup: or :bomb: , which I've been recently informed is against server rules.

🆑
tweak: Wingdings now garbles sentences.
/🆑
