### PR TITLE
Fixes the virus referencing bug

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -722,9 +722,10 @@ var/const/INGEST = 2
 	// that could possibly eat up a lot of memory needlessly
 	// if most data lists are read-only.
 	if(trans_data["viruses"])
-		var/list/v = trans_data["viruses"]
-		trans_data["viruses"] = v.Copy()
-
+		var/list/temp = list()
+		for(var/datum/disease/v in trans_data["viruses"])
+			temp.Add(v.Copy())
+		trans_data["viruses"] = temp
 	return trans_data
 
 ///////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**What does this PR do:**
Seems byond changed their list.Copy into a shallow copy.
I've hotfixed the copy_data from the reagents.
Fixes #10762 

**Changelog:**
:cl:
fix: fixes the viruses symptom creation being bugged. No more bluespace symptom creation
/:cl:

