### PR TITLE
Updates syndi kits, add armored suit jacket

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1379,7 +1379,7 @@
 	vend_reply = "Thank you for using the ClothesMate!"
 	products = list(/obj/item/clothing/head/that=2,/obj/item/clothing/head/fedora=1,/obj/item/clothing/glasses/monocle=1,
 	/obj/item/clothing/under/suit_jacket/navy=2,/obj/item/clothing/under/kilt=1,/obj/item/clothing/under/overalls=1,
-	/obj/item/clothing/under/suit_jacket/really_black=2,/obj/item/clothing/under/pants/jeans=3,/obj/item/clothing/under/pants/classicjeans=2,
+	/obj/item/clothing/under/suit_jacket/really_black=2,/obj/item/clothing/suit/storage/lawyer/blackjacket=2,/obj/item/clothing/under/pants/jeans=3,/obj/item/clothing/under/pants/classicjeans=2,
 	/obj/item/clothing/under/pants/camo = 1,/obj/item/clothing/under/pants/blackjeans=2,/obj/item/clothing/under/pants/khaki=2,
 	/obj/item/clothing/under/pants/white=2,/obj/item/clothing/under/pants/red=1,/obj/item/clothing/under/pants/black=2,
 	/obj/item/clothing/under/pants/tan=2,/obj/item/clothing/under/pants/blue=1,/obj/item/clothing/under/pants/track=1,/obj/item/clothing/suit/jacket/miljacket = 1,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -23,7 +23,7 @@
 				new /obj/item/storage/box/syndie_kit/safecracking(src)
 				return
 
-			if("bond")	// 29TC + Healing Cocktail
+			if("bond")	// 29TC + Healing Cocktail + armored suit jacket
 				new /obj/item/gun/projectile/automatic/pistol(src)
 				new /obj/item/suppressor(src)
 				new /obj/item/ammo_box/magazine/m10mm/hp(src)
@@ -34,6 +34,8 @@
 				new /obj/item/dnascrambler(src)
 				new /obj/item/storage/box/syndie_kit/emp(src)
 				new /obj/item/CQC_manual(src)
+				new /obj/item/clothing/under/suit_jacket/really_black(src)
+				new /obj/item/clothing/suit/storage/lawyer/blackjacket/armored(src)
 				return
 
 			if("sabotage")	// 31TC + RCD + Insuls
@@ -46,13 +48,15 @@
 				new /obj/item/storage/box/syndie_kit/space(src)
 				return
 
-			if("payday")	// 32TC
+			if("payday")	// 31TC + armored suit jacket
 				new /obj/item/gun/projectile/revolver(src)
 				new /obj/item/ammo_box/a357(src)
 				new /obj/item/ammo_box/a357(src)
 				new /obj/item/card/emag(src)
-				new /obj/item/grenade/plastic/x4(src)
+				new /obj/item/grenade/plastic/c4(src)
 				new /obj/item/card/id/syndicate(src)
+				new /obj/item/clothing/under/suit_jacket/really_black(src)
+				new /obj/item/clothing/suit/storage/lawyer/blackjacket/armored(src)
 				new /obj/item/clothing/gloves/color/latex/nitrile(src)
 				new /obj/item/clothing/mask/gas/clown_hat(src)
 				new /obj/item/thermal_drill(src)
@@ -93,14 +97,15 @@
 				new /obj/item/multitool/ai_detect(src)
 				return
 
-			if("professional")	// 30TC
+			if("professional")	// 29TC + armored suit jacket + insulated combat gloves
 				new /obj/item/gun/projectile/automatic/sniper_rifle/soporific(src)	// Unique version that starts with soporific rounds loaded and cannot be suppressed
 				new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 				new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 				new /obj/item/pen/edagger(src)
-				new /obj/item/clothing/glasses/thermal/syndi(src)
-				new /obj/item/storage/toolbox/syndicate(src)
-				new /obj/item/clothing/under/suit_jacket(src)
+				new /obj/item/clothing/glasses/thermal/syndi/sunglasses(src)
+				new /obj/item/clothing/under/suit_jacket/really_black(src)
+				new /obj/item/clothing/suit/storage/lawyer/blackjacket/armored(src)
+				new /obj/item/clothing/gloves/combat(src)
 				return
 
 /obj/item/storage/box/syndie_kit

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -409,6 +409,18 @@
 	origin_tech = "magnets=3;syndicate=4"
 	prescription_upgradable = 1
 
+/obj/item/clothing/glasses/thermal/syndi/sunglasses
+	name = "sunglasses"
+	desc = "Strangely ancient technology used to help provide rudimentary eye cover."
+	icon_state = "sun"
+	item_state = "sunglasses"
+	species_fit = list("Vox")
+	sprite_sheets = list(
+		"Vox" = 'icons/mob/species/vox/eyes.dmi',
+		"Drask" = 'icons/mob/species/drask/eyes.dmi',
+		"Grey" = 'icons/mob/species/grey/eyes.dmi'
+		)
+
 /obj/item/clothing/glasses/thermal/monocle
 	name = "Thermoncle"
 	desc = "A monocle thermal."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -440,7 +440,7 @@
 	name = "emergency response team security armor"
 	desc = "A set of armor worn by security members of the Nanotrasen Emergency Response Team. Has red highlights."
 	icon_state = "ertarmor_sec"
-	
+
 
 /obj/item/clothing/suit/armor/vest/ert/security/paranormal
 	name = "emergency response team paranormal armor"
@@ -465,3 +465,15 @@
 	name = "emergency response team janitor armor"
 	desc = "A set of armor worn by janitorial members of the Nanotrasen Emergency Response Team. Has red and white highlights."
 	icon_state = "ertarmor_jan"
+
+//same defense as basic sec armor
+/obj/item/clothing/suit/storage/lawyer/blackjacket/armored
+	desc = "A snappy dress jacket, reinforced with a layer of armor protecting the torso."
+	allowed = list(/obj/item/tank/emergency_oxygen, /obj/item/gun/projectile/revolver, /obj/item/gun/projectile/automatic/pistol)
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
+	cold_protection = UPPER_TORSO|LOWER_TORSO
+	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT
+	heat_protection = UPPER_TORSO|LOWER_TORSO
+	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
+	burn_state = FIRE_PROOF
+	armor = list(melee = 25, bullet = 15, laser = 25, energy = 10, bomb = 25, bio = 0, rad = 0)


### PR DESCRIPTION
Hey look somebody is updating these again.

I originally wanted to make the armored suit jacket an uplink item, but seeing as it fits a bunch of syndi kits and it'd be very niche, I figured I'll just make it a unique item for em.

Full list of changes : 

- Adds two suit jackets to the arrivals locker vendor : These are already available for everyone by loadout. Just making them easier to get.
- Adds the armored suit jacket to armors. Same defense as standard security armor.
- Adds the executive suit and armored jacket to Bond, Payday, and Professional syndi kits
- Replaces the X4 in Payday by a C4 : Now that the c4 has been fixed to reliably destroy airlocks, the X4 is way overkill and is actually more of a detriment for a traitor, as it will cause a large breach. The C4 fits better for the idea of "blow up the vault door, drill the safe."
- Reskins the thermal glasses in Professional to look like sunglasses. Does not provide flash protection.
- Replaces the toolbox in professional by a pair of combat gloves.

🆑
add: Added two black suit jackets to the arrivals locker room vendor
add: Added the armored suit jacket to the Bond, Payday, and Professional syndicate bundles.
tweak: Replaced the X4 in the Payday bundles by a C4.
tweak: The professional syndicate bundle now gets thermal fake sunglasses instead of thermal  fake mesons.
tweak: Replaced the toolbox in the professional syndicate bundle by a pair of combat gloves.
/🆑
