### PR TITLE
[Fix] Meat type for cake cat

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_table.dm
@@ -265,7 +265,7 @@
 		/obj/item/organ/internal/brain = 1,
 		/obj/item/organ/internal/heart = 1,
 		/obj/item/reagent_containers/food/snacks/sliceable/birthdaycake  = 1,
-		/obj/item/reagent_containers/food/snacks/meat/slab  = 3,
+		/obj/item/reagent_containers/food/snacks/meat  = 3,
 		/datum/reagent/blood = 30,
 		/datum/reagent/consumable/sprinkles = 5,
 		/datum/reagent/teslium = 1,


### PR DESCRIPTION
**What does this PR do:**
Cake cat wasn't able to be made, because it used an incorrect meat type: `/slab`
This simply removes that subtype, so it can use normal meats, now.

**Changelog:**
:cl: Alonefromhell and Mitchs98 and farie82
fix: Cake cat is now makeable.
/:cl:

