### PR TITLE
Separate Mentor-/Adminhelp messages

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -145,6 +145,7 @@
 	var/discord_channel_admin = ""
 	var/discord_channel_admin_notify = ""
 	var/discord_channel_cidrandomizer = ""
+	var/discord_channel_mentor = ""
 
 	var/default_laws = 0 //Controls what laws the AI spawns with.
 
@@ -517,6 +518,9 @@
 
 				if("discord_channel_cidrandomizer")
 					config.discord_channel_cidrandomizer = value
+
+				if("discord_channel_mentor")
+					config.discord_channel_mentor = value
 
 				if("python_path")
 					if(value)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -134,13 +134,19 @@ var/list/adminhelp_ignored_words = list("unknown","the","a","an","of","monkey","
 
 	var/admin_number_present = adminholders.len - admin_number_afk
 	log_admin("[selected_type]: [key_name(src)]: [original_msg] - heard by [admin_number_present] non-AFK admins.")
+	var/message = "[selected_type] from [key_name(src)]: [original_msg]"
 	if(admin_number_present <= 0)
 		if(!admin_number_afk)
-			send2admindiscord("[selected_type] from [key_name(src)]: [original_msg] - !!No admins online!!")
+			message += " - !!No admins online!!"
 		else
-			send2admindiscord("[selected_type] from [key_name(src)]: [original_msg] - !!All admins AFK ([admin_number_afk])!!")
-	else
-		send2admindiscord("[selected_type] from [key_name(src)]: [original_msg]")
+			message += " - !!All admins AFK ([admin_number_afk])!!"
+	
+	switch(selected_type)
+		if("Mentorhelp")
+			send2mentordiscord(message)
+		if ("Adminhelp")
+			send2admindiscord(message)
+	
 	feedback_add_details("admin_verb","AH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 

--- a/code/modules/ext_scripts/discord.dm
+++ b/code/modules/ext_scripts/discord.dm
@@ -12,6 +12,11 @@
 		send2discord("message", config.discord_channel_admin, message)
 	return
 
+/proc/send2mentordiscord(message)
+	if(config.discord_channel_mentor)
+		send2discord("message", config.discord_channel_mentor, message)
+	return
+
 /hook/startup/proc/discordNotify()
     if(config.discord_channel_main)
         send2discord("startup", config.discord_channel_main, "Server starting up on [station_name()]. Connect to: [config.server? "[config.server]" : "[world.address]:[world.port]"]")

--- a/code/modules/ext_scripts/discord.dm
+++ b/code/modules/ext_scripts/discord.dm
@@ -1,6 +1,7 @@
 /proc/send2discord(command, channel, message)
     if (config.use_discord_bot && config.discord_host)
-        world.Export("http://[config.discord_host]/?command=[command]&channel=[channel]&message=[paranoid_sanitize(message)]")
+		spawn(1)
+        	world.Export("http://[config.discord_host]/?command=[command]&channel=[channel]&message=[paranoid_sanitize(message)]")
 
 /proc/send2maindiscord(message)
 	if(config.discord_channel_main)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -275,6 +275,9 @@ GHOST_INTERACTION
 ## Channel ID where the bot should post its cidrandomizer notifications
 #DISCORD_CHANNEL_CIDRANDOMIZER 0123456789
 
+## Channel ID where the bot should post its mentor notifications
+#DISCORD_CHANNEL_MENTOR 0123456789
+
 ## Path to the python2 executable on the system.  Leave blank for default.
 ## Default is "python" on Windows, "/usr/bin/env python2" on UNIX.
 #PYTHON_PATH pythonw


### PR DESCRIPTION
**What does this PR do:**
This PR separates mentor- and adminhelp messages for the discord bot. this way mentorhelp messages go to the mentor channel and adminhelp messages go to the admin channel.

**Changelog:**
:cl: v0idp
tweak: seperated adminhelp and mentorhelp messages for discord bot
/:cl:

