### PR TITLE
Mobs on help intent no longer push structures or mobs that are pulling structures

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -75,6 +75,9 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 
 #define isslime(A)		(istype((A), /mob/living/carbon/slime))
 
+//Structures
+#define isstructure(A)	(istype((A), /obj/structure))
+
 // Misc
 #define isclient(A) istype(A, /client)
 #define isradio(A) istype(A, /obj/item/radio)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -93,6 +93,7 @@
 		pulling.pulledby = null
 		var/mob/living/ex_pulled = pulling
 		pulling = null
+		pulledby = null
 		if(isliving(ex_pulled))
 			var/mob/living/L = ex_pulled
 			L.update_canmove()// mob gets up if it was lyng down in a chokehold

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -4,7 +4,6 @@
 	var/climbable
 	var/mob/climber
 	var/broken = FALSE
-	#define isstructure(A)	(istype((A), /obj/structure))
 
 /obj/structure/blob_act()
 	if(prob(50))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -4,6 +4,7 @@
 	var/climbable
 	var/mob/climber
 	var/broken = FALSE
+	#define isstructure(A)	(istype((A), /obj/structure))
 
 /obj/structure/blob_act()
 	if(prob(50))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -80,6 +80,10 @@
 	if(moving_diagonally) //no mob swap during diagonal moves.
 		return 1
 
+	if(a_intent == INTENT_HELP) // Help intent doesn't mob swap a mob pulling a structure
+		if(isstructure(M.pulling) || isstructure(pulling))
+			return 1
+
 	if(!M.buckled && !M.has_buckled_mobs())
 		var/mob_swap
 		//the puller can always swap with it's victim if on grab intent
@@ -128,6 +132,13 @@
 
 //Called when we want to push an atom/movable
 /mob/living/proc/PushAM(atom/movable/AM, force = move_force)
+
+	if(isstructure(AM) && AM.pulledby)
+		if(a_intent == INTENT_HELP && AM.pulledby != src) // Help intent doesn't push other peoples pulled structures
+			return FALSE
+		if(get_dist(get_step(AM, get_dir(src, AM)), AM.pulledby)>1)//Release pulled structures beyond 1 distance
+			AM.pulledby.stop_pulling()
+
 	if(now_pushing)
 		return TRUE
 	if(moving_diagonally) // no pushing during diagonal moves


### PR DESCRIPTION
**What does it do:**
Mobs on help intent no longer push structures or mobs that are pulling structures.
This means players now avoid having boxes or other pulled structures come flying out of their hands so long as everyone is on help intent.

**Changelog:**
:cl: MINIMAN10000
add: Mobs in help intent do not push mobs pulling a structure or the structure they are pulling
fix: mobs standing on the same tile when being walked into on help intent.
fix: structures pulled beyond 1 distance call stop_pulling
fix: stop_pulling() now sets pulledby to null
/:cl:

