### PR TITLE
Disables random floor cluwne event

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -197,7 +197,7 @@ var/list/event_last_fired = list()
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Traders",			/datum/event/traders,			180, is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Terror Spiders",			/datum/event/spider_terror, 		0,			list(ASSIGNMENT_SECURITY = 15), is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Slaughter Demon",	/datum/event/spawn_slaughter,	15, is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = 1)
+		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Floor Cluwne",	/datum/event/spawn_floor_cluwne,	15, is_one_shot = 1)
 	)
 
 


### PR DESCRIPTION
**What does this PR do:**
Disables the round random event that spawns floor cluwnes randomly.

My reasoning is that the floor cluwne seems more like a admin punishment than a actual event. Not only that, being killed by one usually leads to you to be cluwned and/or gibbed, which is near impossible to fix/hard to deal with.

Note: Has been tested.

**Images of sprite/map changes (IF APPLICABLE):**
N/A

**Changelog:**

:cl: Quantum-M
tweak: Floor cluwnes will only spawn via admin actions, instead of a random event one.
/:cl:

