### PR TITLE
Added a configuration option for disabling subsystems by name

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -209,6 +209,7 @@
 
 	// Developer
 	var/developer_express_start = 0
+	var/developer_disable_subsystem[]
 
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
@@ -636,6 +637,8 @@
 					config.disable_high_pop_mc_mode_amount = text2num(value)
 				if("developer_express_start")
 					config.developer_express_start = 1
+				if("developer_disable_subsystem")
+					config.developer_disable_subsystem = splittext(value, ",")
 				else
 					log_config("Unknown setting in configuration: '[name]'")
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -176,6 +176,12 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 	to_chat(world, "<span class='boldannounce'>Initializing subsystems...</span>")
 
+	// Config disable subsystem
+	for(var/select=1, select <= subsystems.len, select++)
+		for(var/disable=1, disable <= config.developer_disable_subsystem.len, disable++)
+			if(subsystems[select].name == config.developer_disable_subsystem[disable])
+				subsystems -= subsystems[select]
+
 	// Sort subsystems by init_order, so they initialize in the correct order.
 	sortTim(subsystems, /proc/cmp_subsystem_init)
 

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -388,3 +388,8 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ##Uncomment to enable developer start. Auto starts the server after initialization
 ##DEVELOPER_EXPRESS_START
+
+##Disable subsystems by name comma delimited. Last verified 1-30-2019 list of subsystems
+## Garbage, Atoms, Machines, Timer, Fires, Mobs, Nanoui, NPC AI, NPC Pool, Space Drift, Sun, Throwing, Weather,
+## Atmospherics, Icon Smoothing, Overlay, Tickets, Shuttle, Night Shift, Nano-Mob Hunter GO Server
+DEVELOPER_DISABLE_SUBSYSTEM


### PR DESCRIPTION
**What does it do:**
Adds a configuration option which allows you to disable subsystems by name. 

In particular I rarely deal with atmospherics so while I'm developing unrelated features I can disable atmospherics and save 10 of the 20 seconds it takes for the space station to initialize. But I figured adding a single subsystem hard coded isn't as desirable as being able to choose which subsystems you wish to disable.

:cl: MINIMAN10000
add: Configuration option for disabling subsystems
/:cl:

