### PR TITLE
Darkmode fixes

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -373,15 +373,7 @@
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
 		if(establish_db_connection())
 			to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
-			winset(src, "rpane.changelog", "background-color=#bb7700;font-color=#FFFFFF;font-style=bold")
-	else
-		if(establish_db_connection())
-			if(prefs.toggles & UI_DARKMODE)
-				winset(src, "rpane.changelog", "background-color=#bb7700;font-color=#FFFFFF;font-style=bold") // makes changelog dark if its been set
-			else
-				winset(src, "rpane.changelog", "background-color=#ffffff;font-color=#000000") // makes changelog normal if it hasnt been set
-		else
-			winset(src, "rpane.changelog", "background-color=#ffffff;font-color=#000000") // makes changelog normal if DB isnt connected
+			winset(src, "rpane.changelog", "background-color=#bb7700;text-color=#FFFFFF;font-style=bold")
 
 	if(!void)
 		void = new()
@@ -714,33 +706,33 @@
 /client/proc/deactivate_darkmode()
 	///// BUTTONS /////
 	/* Rpane */
-	winset(src, "rpane.textb", "background-color=#ffffff;text-color=#000000")
-	winset(src, "rpane.infob", "background-color=#ffffff;text-color=#000000")
-	winset(src, "rpane.wikib", "background-color=#ffffff;text-color=#000000")
-	winset(src, "rpane.forumb", "background-color=#ffffff;text-color=#000000")
-	winset(src, "rpane.rulesb", "background-color=#ffffff;text-color=#000000")
-	winset(src, "rpane.githubb", "background-color=#ffffff;text-color=#000000")
+	winset(src, "rpane.textb", "background-color=none;text-color=#000000")
+	winset(src, "rpane.infob", "background-color=none;text-color=#000000")
+	winset(src, "rpane.wikib", "background-color=none;text-color=#000000")
+	winset(src, "rpane.forumb", "background-color=none;text-color=#000000")
+	winset(src, "rpane.rulesb", "background-color=none;text-color=#000000")
+	winset(src, "rpane.githubb", "background-color=none;text-color=#000000")
 	/* Mainwindow */
-	winset(src, "mainwindow.saybutton", "background-color=#ffffff;text-color=#000000")
-	winset(src, "mainwindow.mebutton", "background-color=#ffffff;text-color=#000000")
-	winset(src, "mainwindow.hotkey_toggle", "background-color=#ffffff;text-color=#000000")
+	winset(src, "mainwindow.saybutton", "background-color=none;text-color=#000000")
+	winset(src, "mainwindow.mebutton", "background-color=none;text-color=#000000")
+	winset(src, "mainwindow.hotkey_toggle", "background-color=none;text-color=#000000")
 	///// UI ELEMENTS /////
 	/* Mainwindow */
-	winset(src, "mainwindow", "background-color=#ffffff")
-	winset(src, "mainwindow.mainvsplit", "background-color=#ffffff")
-	winset(src, "mainwindow.tooltip", "background-color=#ffffff")
+	winset(src, "mainwindow", "background-color=none")
+	winset(src, "mainwindow.mainvsplit", "background-color=none")
+	winset(src, "mainwindow.tooltip", "background-color=none")
 	/* Outputwindow */
-	winset(src, "outputwindow.outputwindow", "background-color=#ffffff")
-	winset(src, "outputwindow.browseroutput", "background-color=#ffffff")
+	winset(src, "outputwindow.outputwindow", "background-color=none")
+	winset(src, "outputwindow.browseroutput", "background-color=none")
 	/* Rpane */
-	winset(src, "rpane", "background-color=#ffffff")
-	winset(src, "rpane.rpane", "background-color=#ffffff")
-	winset(src, "rpane.rpanewindow", "background-color=#ffffff")
+	winset(src, "rpane", "background-color=none")
+	winset(src, "rpane.rpane", "background-color=none")
+	winset(src, "rpane.rpanewindow", "background-color=none")
 	/* Browserwindow */
-	winset(src, "browserwindow", "background-color=#ffffff")
-	winset(src, "browserwindow.browser", "background-color=#ffffff")
+	winset(src, "browserwindow", "background-color=none")
+	winset(src, "browserwindow.browser", "background-color=none")
 	/* Infowindow */
-	winset(src, "infowindow", "background-color=#ffffff;text-color=#000000")
-	winset(src, "infowindow.info", "background-color=#ffffff;text-color=#000000;highlight-color=#007700;tab-text-color=#000000;tab-background-color=#ffffff")
+	winset(src, "infowindow", "background-color=none;text-color=#000000")
+	winset(src, "infowindow.info", "background-color=none;text-color=#000000;highlight-color=#007700;tab-text-color=#000000;tab-background-color=none")
 	///// NOTIFY USER /////
 	to_chat(src, "<span class='notice'>Darkmode Disabled</span>") // what a sick fuck

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -482,7 +482,10 @@
 
 /datum/preferences/proc/SetChangelog(client/C,hash)
 	lastchangelog=hash
-	winset(C, "rpane.changelog", "background-color=none;font-style=")
+	if(preferences_datums[C.ckey].toggles & UI_DARKMODE)
+		winset(C, "rpane.changelog", "background-color=#40628a;font-color=#ffffff;font-style=none")
+	else
+		winset(C, "rpane.changelog", "background-color=none;font-style=none")
 	var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET lastchangelog='[lastchangelog]' WHERE ckey='[C.ckey]'")
 	if(!query.Execute())
 		var/err = query.ErrorMsg()
@@ -491,3 +494,9 @@
 		to_chat(C, "Couldn't update your last seen changelog, please try again later.")
 		return
 	return 1
+
+/datum/preferences/proc/UpdateChangelogButton(client/C)
+	if(preferences_datums[C.ckey].toggles & UI_DARKMODE)
+		winset(C, "rpane.changelog", "background-color=#40628a;text-color=#ffffff;font-style=none")
+	else
+		winset(C, "rpane.changelog", "background-color=none;text-color=#000000;font-style=none")

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -38,7 +38,7 @@
 		'html/changelog.html'
 		)
 	src << browse('html/changelog.html', "window=changes;size=675x650")
-
+	prefs.UpdateChangelogButton(src)
 	if(prefs.lastchangelog != changelog_hash) //if it's already opened, no need to tell them they have unread changes
 		prefs.SetChangelog(src,changelog_hash)
 


### PR DESCRIPTION
**What does this PR do:**
Fixes #10782 
Updating changelog button color is now in its own proc

**Changelog:**
:cl: AffectedArc07
tweak: Disabled darkmode is now normal grey, not full white
tweak: Changelog button now respects darkmode and will update when clicked
/:cl:

