### PR TITLE
Removes genetic damage healing from cryoxadone.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -116,7 +116,6 @@
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	if(M.bodytemperature < 265)
-		update_flags |= M.adjustCloneLoss(-4, FALSE)
 		update_flags |= M.adjustOxyLoss(-10, FALSE)
 		update_flags |= M.adjustToxLoss(-3, FALSE)
 		update_flags |= M.adjustBruteLoss(-12, FALSE)


### PR DESCRIPTION
**What does this PR do:**
Firstly, blame @DesolateG for not wanting to do this (so I did it for him.)

## As an alternative to #10773:

This PR removes the genetic healing of cryoxadone, so as to make people use [rezadone](https://nanotrasen.se/wiki/index.php/Guide_to_Chemistry#Rezadone), which clears out genetic damage.
(Reazadone has an OD level of 30u, at which point it deals minor toxin damage.)

The essental ingredient for rezadone is carpotoxin, which, surprisingly, is found in space carp.

In the past Carpotoxin was rarely available due to reliance on the random Space Carp event. This was changed with the recent botany changes. Koibeans were added, allowing for an easily available source of carpotoxin in the form of a soybeans mutation.

Inter-departmental collaberation, woo!

######  ~~And not medical having to break into botany every so often because everyone is dead.~~


**Changelog:**
:cl: DesolateG
del: Cryoxadone no longer heals genetic damage, in favor for rezadone.
/:cl:

