### PR TITLE
Wingdings mutation makes you speak in wingdings again.

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -125,6 +125,9 @@
 		|| GetComponent(/datum/component/jestosterone))
 		span = "sans"
 
+	if(WINGDINGS in mutations)
+		span = "wingdings"
+
 	var/list/parent = ..()
 	verb = parent["verb"]
 


### PR DESCRIPTION
Jestosterone PR accidentally removed the check for wingdings mutation. Reeeeee.

This PR re-adds it.

Fixes #10791
🆑
fix: Wingdings mutation works again.
/🆑