### PR TITLE
Adds dont_save flag to mobs

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -3,6 +3,7 @@
 	layer = 4.0
 	animate_movement = 2
 	pressure_resistance = 8
+	dont_save = TRUE //to avoid it messing up in buildmode saving
 	var/datum/mind/mind
 
 	var/stat = 0 //Whether a mob is alive or dead. TODO: Move this to living - Nodrak


### PR DESCRIPTION
**What does this PR do:**
Fixes a thing with admin buildmode save how if you had ghosts or mobs in your save area it would corrupt the .dmm file

**Images of sprite/map changes (IF APPLICABLE):**
![](https://i.imgur.com/dqrrGkc.png)

there was a guy and a ghost (me) in that area when I saved

**Changelog:**
:cl:
fix: Admin save feature in build mode will ignore mobs
/:cl: