### PR TITLE
Adds Pack of C-4 Explosives

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -869,6 +869,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/grenade/plastic/c4
 	cost = 1
 
+/datum/uplink_item/explosives/plastic_explosives_pack
+	name = "Pack of 5 C-4 Explosives"
+	desc = "A package containing 5 C-4 Explosives at a discounted price. For when you need that little bit extra for your sabotaging needs."
+	reference = "C4P"
+	item = /obj/item/storage/box/syndie_kit/c4
+	cost = 4
+
 /datum/uplink_item/explosives/breaching_charge
 	name = "Composition X-4"
 	desc = "X-4 is a shaped charge designed to be safe to the user while causing maximum damage to the occupants of the room beach breached. It has a modifiable timer with a minimum setting of 10 seconds."

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -184,6 +184,17 @@
 	new /obj/item/grenade/empgrenade(src)
 	new /obj/item/implanter/emp/(src)
 
+/obj/item/storage/box/syndie_kit/c4
+	name = "Pack of C-4 Explosives"
+
+/obj/item/storage/box/syndie_kit/c4/New()
+	..()
+	new /obj/item/grenade/plastic/c4(src)
+	new /obj/item/grenade/plastic/c4(src)
+	new /obj/item/grenade/plastic/c4(src)
+	new /obj/item/grenade/plastic/c4(src)
+	new /obj/item/grenade/plastic/c4(src)
+
 /obj/item/storage/box/syndie_kit/throwing_weapons
 	name = "boxed throwing kit"
 	can_hold = list(/obj/item/throwing_star, /obj/item/restraints/legcuffs/bola/tactical)


### PR DESCRIPTION
**What does this PR do:**
Since C4 explosives will now almost always destroy airlocks and have a much better chance of destroying machinery and lockers, I've added a pack of C4 to uplinks should players wish to take a louder approach to breaking into secure areas for their objectives.

The pack comes with 5 charges and costs 4TC, so you get one of them for free. It can also be eligible for a discount within a discount should you get lucky (something the single C4 charge isn't eligible for since anything that costs 1TC can't be discounted).

This is a little cheaper than using an emag to get through various doors and lockers or sabotage equipment, but obviously is much louder and takes time to set up each charge.

**Changelog:**
:cl:
add: Added Pack of C-4 for Traitors and Nuke ops. Comes with 5 C-4 charges for 4TC.
/:cl: