### PR TITLE
Fixed mob spawner menu, this time for real

### DIFF
--- a/code/datums/spawners_menu.dm
+++ b/code/datums/spawners_menu.dm
@@ -6,10 +6,10 @@
 		qdel(src)
 	owner = new_owner
 
-/datum/spawners_menu/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = FALSE, datum/nanoui/master_ui = null)
+/datum/spawners_menu/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = FALSE, datum/topic_state/state = ghost_state, datum/nanoui/master_ui = null)
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "spawners_menu.tmpl", "Spawners Menu", 700, 600, master_ui)
+		ui = new(user, src, ui_key, "spawners_menu.tmpl", "Spawners Menu", 700, 600, master_ui, state = state)
 		ui.open()
 
 /datum/spawners_menu/ui_data(mob/user)

--- a/code/modules/nano/interaction/ghost.dm
+++ b/code/modules/nano/interaction/ghost.dm
@@ -6,7 +6,7 @@
 /var/global/datum/topic_state/ghost_state/ghost_state = new()
 
 /datum/topic_state/ghost_state/can_use_topic(var/src_object, var/mob/user)
-	if (user.stat == DEAD)
+	if(user.stat == DEAD)
 		return STATUS_INTERACTIVE
 	if(check_rights(R_ADMIN, 0, src))
 		return STATUS_INTERACTIVE

--- a/code/modules/nano/interaction/ghost.dm
+++ b/code/modules/nano/interaction/ghost.dm
@@ -1,0 +1,14 @@
+/*
+	This checks that the user is a ghost or alternatively an admin. Used for the mob spawner. 
+	We don't want any living people somehow getting the menu open and reincarnating while alive
+*/
+
+/var/global/datum/topic_state/ghost_state/ghost_state = new()
+
+/datum/topic_state/ghost_state/can_use_topic(var/src_object, var/mob/user)
+	if (user.stat == DEAD)
+		return STATUS_INTERACTIVE
+	if(check_rights(R_ADMIN, 0, src))
+		return STATUS_INTERACTIVE
+	return STATUS_CLOSE
+

--- a/paradise.dme
+++ b/paradise.dme
@@ -2026,6 +2026,7 @@
 #include "code\modules\nano\interaction\conscious.dm"
 #include "code\modules\nano\interaction\contained.dm"
 #include "code\modules\nano\interaction\default.dm"
+#include "code\modules\nano\interaction\ghost.dm"
 #include "code\modules\nano\interaction\inventory.dm"
 #include "code\modules\nano\interaction\inventory_deep.dm"
 #include "code\modules\nano\interaction\not_incapacitated.dm"


### PR DESCRIPTION
**What does this PR do:**
Fixes #10797 , turns out #10401  never actually fixed the real issue, which was that ghosts by default are disallowed from interacting with nanoUI windows. I never noticed it in testing because being an admin overrides it. Everyone else that tested it I presume also didn't notice for the same reason.

This creates a new kind of topic_state specifically meant for checking if the user is a ghost, only letting them interact if the user is a ghost (or an admin). If they are alive the UI instead closes. I hope I did all the nanoUI stuff correctly.

Many thanks to alexkar598 on the coderbus discord for helping me out.


**Changelog:**
:cl:
fix: Mob spawner menu buttons now work. This time it really works, I swear.
/:cl:

