### PR TITLE
Lack of Breath Incurs Silence

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -91,6 +91,9 @@
 	var/obj/item/organ/internal/L = get_organ_slot("lungs")
 	if((breathes && !L) || breathes && L && (L.status & ORGAN_DEAD))
 		return FALSE
+	if(oxyloss > 10 || losebreath >= 4)
+		emote("gasp")
+		return FALSE
 	if(mind)
 		return !mind.miming
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -430,7 +430,6 @@
 	update_flags |= M.adjustOxyLoss(-25*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 	if(volume >= 4)
 		M.LoseBreath(6)
-		M.Silence(6)
 	if(prob(33))
 		update_flags |= M.adjustBruteLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)
 		update_flags |= M.adjustFireLoss(-1*REAGENTS_EFFECT_MULTIPLIER, FALSE)


### PR DESCRIPTION
No air? No talking. Idea blatantly taken from Goon and their larger functionality related to dying.

Not shockingly, this makes space and a number of areas and encounters more dangerous, as lack of oxygen will quickly render you unable to speak.

Submitted largely for testing

:cl: Fox McCloud
tweak: Lack of breathing will render you unable to speak
/:cl: