### PR TITLE
Non-breathing mobs no longer cause an increase in germ level by not wearing a mask.

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -189,7 +189,7 @@
 
 	for(var/mob/living/carbon/human/H in view(2, E.loc))//germs from people
 		if(AStar(E.loc, H.loc, /turf/proc/Distance, 2, simulated_only = 0))
-			if((!(BREATHLESS in H.mutations) || !(NO_BREATHE in H.dna.species.species_traits)) && !H.wear_mask) //wearing a mask helps preventing people from breathing cooties into open incisions
+			if(!((BREATHLESS in H.mutations) || (NO_BREATHE in H.dna.species.species_traits)) && !H.wear_mask) //wearing a mask helps preventing people from breathing cooties into open incisions
 				germs += H.germ_level * 0.25
 
 	for(var/obj/effect/decal/cleanable/M in view(2, E.loc))//germs from messes


### PR DESCRIPTION
**What does this PR do:**
Fixes: #10801 

**Changelog:**
:cl: uc_guy
fix: Non-breathing mobs no longer cause an increase in germ level by not wearing a mask.
/:cl:

