### PR TITLE
To repair a door, access panel must be open

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -973,19 +973,7 @@ About the new airlock wires panel:
 
 /obj/machinery/door/airlock/try_to_weld(obj/item/weldingtool/W, mob/user)
 	if(!operating && density)
-		if(user.a_intent != INTENT_HELP)
-			if(W.remove_fuel(0, user))
-				user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
-								"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
-								"<span class='italics'>You hear welding.</span>")
-				playsound(loc, W.usesound, 40, 1)
-				if(do_after(user, 40 * W.toolspeed, 1, target = src, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
-					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
-					welded = !welded
-					user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
-										"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
-					update_icon()
-		else
+		if(user.a_intent == INTENT_HELP && panel_open)
 			if(obj_integrity < max_integrity)
 				if(W.remove_fuel(0, user))
 					user.visible_message("[user] is welding the airlock.", \
@@ -999,6 +987,18 @@ About the new airlock wires panel:
 						user.visible_message("[user.name] has repaired [src].", \
 											"<span class='notice'>You finish repairing the airlock.</span>")
 						update_icon()
+		else
+			if(W.remove_fuel(0, user))
+				user.visible_message("[user] is [welded ? "unwelding":"welding"] the airlock.", \
+								"<span class='notice'>You begin [welded ? "unwelding":"welding"] the airlock...</span>", \
+								"<span class='italics'>You hear welding.</span>")
+				playsound(loc, W.usesound, 40, 1)
+				if(do_after(user, 40 * W.toolspeed, 1, target = src, extra_checks = CALLBACK(src, .proc/weld_checks, W, user)))
+					playsound(loc, 'sound/items/welder2.ogg', 50, 1)
+					welded = !welded
+					user.visible_message("[user.name] has [welded? "welded shut":"unwelded"] [src].", \
+										"<span class='notice'>You [welded ? "weld the airlock shut":"unweld the airlock"].</span>")
+					update_icon()
 			else
 				to_chat(user, "<span class='notice'>The airlock doesn't need repairing.</span>")
 


### PR DESCRIPTION
**What does it do:**
Airlock panel must be open in order to repair the door.

After calling for discussion on #9250 in which it was suggested changing repair from being dedicated to help_intent to instead be able to weld a door which is already repaired had failed it was suggested that the panel must be open in order to repair the door.
One of the recommendations within that discussion included requiring the panel be open in order to repair the door.
Thus this PR implements the idea the the panel must be open in order to repair the door.

**Changelog:**
:cl: MINIMAN10000
add: Airlock panel must be open in order to repair the door.
/:cl:

