### PR TITLE
Ensures Some Diseases Cannot Be Cheesed

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -59,6 +59,7 @@ var/list/diseases = subtypesof(/datum/disease)
 	var/cure_chance = 8
 	var/carrier = FALSE //If our host is only a carrier
 	var/bypasses_immunity = FALSE //Does it skip species virus immunity check? Some things may diseases and not viruses
+	var/virus_heal_resistant = FALSE // Some things aren't technically viruses/traditional diseases and should be immune to edge case cure methods, like healing viruses.
 	var/permeability_mod = 1
 	var/severity =	NONTHREAT
 	var/list/required_organs = list()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -69,6 +69,8 @@ Bonus
 	var/cured = 0
 	for(var/thing in M.viruses)
 		var/datum/disease/D = thing
+		if(D.virus_heal_resistant)
+			continue
 		if(D != A)
 			cured = 1
 			cured_diseases += D.GetDiseaseID()

--- a/code/datums/diseases/appendicitis.dm
+++ b/code/datums/diseases/appendicitis.dm
@@ -13,6 +13,7 @@
 	visibility_flags = HIDDEN_PANDEMIC
 	required_organs = list(/obj/item/organ/internal/appendix)
 	bypasses_immunity = TRUE
+	virus_heal_resistant = TRUE
 
 /datum/disease/appendicitis/stage_act()
 	..()

--- a/code/datums/diseases/food_poisoning.dm
+++ b/code/datums/diseases/food_poisoning.dm
@@ -13,6 +13,7 @@
 	severity = MINOR
 	disease_flags = CURABLE
 	spread_flags = NON_CONTAGIOUS
+	virus_heal_resistant = TRUE
 	var/remissive = 0
 
 /datum/disease/food_poisoning/stage_act()

--- a/code/datums/diseases/kuru.dm
+++ b/code/datums/diseases/kuru.dm
@@ -11,7 +11,9 @@
 	desc = "Uncontrollable laughing."
 	severity = BIOHAZARD
 	spread_flags = NON_CONTAGIOUS
+	disease_flags = CAN_CARRY
 	bypasses_immunity = TRUE //Kuru is a prion disorder, not a virus
+	virus_heal_resistant = TRUE
 
 /datum/disease/kuru/stage_act()
 	..()

--- a/code/game/objects/items/weapons/storage/artistic_toolbox.dm
+++ b/code/game/objects/items/weapons/storage/artistic_toolbox.dm
@@ -116,8 +116,9 @@
 	cure_text = "Unknown"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	severity = BIOHAZARD
-	disease_flags = CURABLE
+	disease_flags = CAN_CARRY
 	spread_flags = NON_CONTAGIOUS
+	virus_heal_resistant = TRUE
 	var/obj/item/storage/toolbox/green/memetic/progenitor = null
 
 /datum/disease/memetic_madness/Destroy()


### PR DESCRIPTION
There's a few diseases that are meant to be incurable, or at least only cured by very specific methods.

The anti-bodies metabolism advanced symptom can get around this while also adding resistance to that disease to the mob.

This can lead to all sorts of weird things, like being resistant to food poisoning or kuru if have this virus symptom--which can then be abused to give the crew immunity to kuru or food poisoning.

:cl: Fox McCloud
fix: Fixes a few edge cases of being able to create immunity to a few diseases
/:cl: