### PR TITLE
Boom function now checks for fuel before fuel tank boom.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -85,12 +85,13 @@
 			boom()
 
 /obj/structure/reagent_dispensers/fueltank/boom(var/rigtrigger = FALSE) // Prevent case where someone who rigged the tank is blamed for the explosion when the rig isn't what triggered the explosion
-	if(rigtrigger == TRUE) // If the explosion is triggered by an assembly holder
-		message_admins("A fueltank, last rigged by [lastrigger], exploded at [COORD(loc)]") // Then admin is informed of the last person who rigged the fuel tank
-		log_game("A fueltank, last rigged by [lastrigger], exploded at [COORD(loc)]")
-		investigate_log("A fueltank, last rigged by [lastrigger], exploded at [COORD(loc)]", INVESTIGATE_BOMB)
-	explosion(loc, 0, 1, 5, 7, 10, flame_range = 5)
-	qdel(src)
+	if(reagents.has_reagent("fuel"))
+		if(rigtrigger == TRUE) // If the explosion is triggered by an assembly holder
+			message_admins("A fueltank, last rigged by [lastrigger], exploded at [COORD(loc)]") // Then admin is informed of the last person who rigged the fuel tank
+			log_game("A fueltank, last rigged by [lastrigger], exploded at [COORD(loc)]")
+			investigate_log("A fueltank, last rigged by [lastrigger], exploded at [COORD(loc)]", INVESTIGATE_BOMB)
+		explosion(loc, 0, 1, 5, 7, 10, flame_range = 5)
+		qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/blob_act()
 	boom()


### PR DESCRIPTION
**What does it do:**
Boom function now checks for fuel before fuel tank boom.
fixes #10696
:cl: MINIMAN10000
fix: Boom function now properly checks for fuel
/:cl:

