### PR TITLE
fixes slime emote runtime

### DIFF
--- a/code/modules/mob/living/carbon/slime/emote.dm
+++ b/code/modules/mob/living/carbon/slime/emote.dm
@@ -92,7 +92,7 @@
 			to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")
 	if((message && stat == CONSCIOUS))
 		if(client)
-			log_emote("[name]/[key] : [message]")
+			log_emote("[name]/[key] : [message]", src)
 		if(m_type & 1)
 			visible_message(message)
 		else


### PR DESCRIPTION
:cl: Kyep
fix: fixed a "_logging.dm,85: Cannot execute null.simple info line()" runtime when xenobio slimes emoted.
/:cl:

