### PR TITLE
Add hydro hud to hydroponics lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -24,3 +24,4 @@
 	new /obj/item/cultivator(src)
 	new /obj/item/hatchet(src)
 	new /obj/item/storage/box/disks_plantgene(src)
+	new /obj/item/clothing/glasses/hud/hydroponic(src)


### PR DESCRIPTION
Seems inconsistent to me that every single department gets their appropriate hud/mesons available at roundstart except botany. Rude even, botany powergamers rise up.

This PR adds one hydro hud per hydroponics locker.

The potential for upgrade from RND is still possible and the same as other departments, with the NV huds.

🆑
add: Added one hydroponics hud per botany locker.
/🆑