### PR TITLE
Tweaks some food descriptions/casing.

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -197,13 +197,13 @@
 	list_reagents = list("coffee" = 30)
 
 /obj/item/reagent_containers/food/drinks/ice
-	name = "Ice Cup"
+	name = "ice cup"
 	desc = "Careful, cold ice, do not chew."
 	icon_state = "icecup"
 	list_reagents = list("ice" = 30)
 
 /obj/item/reagent_containers/food/drinks/tea
-	name = "Duke Purple Tea"
+	name = "Duke Purple tea"
 	desc = "An insult to Duke Purple is an insult to the Space Queen! Any proper gentleman will fight you, if you sully this tea."
 	icon_state = "teacup"
 	item_state = "coffee"
@@ -215,34 +215,34 @@
 		reagents.add_reagent("mugwort", 3)
 
 /obj/item/reagent_containers/food/drinks/mugwort
-	name = "Mugwort Tea"
+	name = "mugwort tea"
 	desc = "A bitter herbal tea."
 	icon_state = "manlydorfglass"
 	item_state = "coffee"
 	list_reagents = list("mugwort" = 30)
 
 /obj/item/reagent_containers/food/drinks/h_chocolate
-	name = "Dutch Hot Coco"
+	name = "Dutch hot coco"
 	desc = "Made in Space South America."
 	icon_state = "hot_coco"
 	item_state = "coffee"
 	list_reagents = list("hot_coco" = 30, "sugar" = 5)
 
 /obj/item/reagent_containers/food/drinks/chocolate
-	name = "Hot Chocolate"
+	name = "hot chocolate"
 	desc = "Made in Space Switzerland."
 	icon_state = "hot_coco"
 	item_state = "coffee"
 	list_reagents = list("chocolate" = 30)
 
 /obj/item/reagent_containers/food/drinks/weightloss
-	name = "Weight-Loss Shake"
+	name = "weight-loss shake"
 	desc = "A shake designed to cause weight loss.  The package proudly proclaims that it is 'tapeworm free.'"
 	icon_state = "weightshake"
 	list_reagents = list("lipolicide" = 30, "chocolate" = 5)
 
 /obj/item/reagent_containers/food/drinks/dry_ramen
-	name = "Cup Ramen"
+	name = "cup ramen"
 	desc = "Just add 10ml of water, self heats! A taste that reminds you of your school years."
 	icon_state = "ramen"
 	item_state = "ramen"
@@ -254,7 +254,7 @@
 		reagents.add_reagent("enzyme", 3)
 
 /obj/item/reagent_containers/food/drinks/chicken_soup
-	name = "Canned Chicken Soup"
+	name = "canned chicken soup"
 	desc = "A delicious and soothing can of chicken noodle soup; just like spessmom used to microwave it."
 	icon_state = "soupcan"
 	item_state = "soupcan"
@@ -331,7 +331,7 @@
 	volume = 50
 
 /obj/item/reagent_containers/food/drinks/flask/lithium
-	name = "Lithium Flask"
+	name = "lithium flask"
 	desc = "A flask with a Lithium Atom symbol on it."
 	icon = 'icons/obj/custom_items.dmi'
 	icon_state = "lithiumflask"
@@ -353,13 +353,13 @@
 
 
 /obj/item/reagent_containers/food/drinks/bag
-	name = "Drink bag"
+	name = "drink bag"
 	desc = "Normally put in wine boxes, or down pants at stadium events."
 	icon_state = "goonbag"
 	volume = 70
 
 /obj/item/reagent_containers/food/drinks/bag/goonbag
-	name = "Goon from a Blue Toolbox special edition"
+	name = "goon from a Blue Toolbox special edition"
 	desc = "Wine from the land down under, where the dingos roam and the roos do wander."
 	icon_state = "goonbag"
 	list_reagents = list("wine" = 70)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -192,7 +192,7 @@
 	list_reagents = list("rum" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/holywater
-	name = "Flask of Holy Water"
+	name = "flask of holy water"
 	desc = "A flask of the chaplain's holy water."
 	icon_state = "holyflask"
 	list_reagents = list("holywater" = 100)
@@ -232,8 +232,8 @@
 	list_reagents = list("wine" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/absinthe
-	name = "Extra-Strong Absinthe"
-	desc = "A strong alcoholic drink brewed and distributed by REDACTED."
+	name = "Yellow Marquee Absinthe"
+	desc = "A strong alcoholic drink brewed and distributed by Yellow Marquee."
 	icon_state = "absinthebottle"
 	list_reagents = list("absinthe" = 100)
 
@@ -252,7 +252,7 @@
 //////////////////////////JUICES AND STUFF ///////////////////////
 
 /obj/item/reagent_containers/food/drinks/bottle/orangejuice
-	name = "Orange Juice"
+	name = "orange juice"
 	desc = "Full of vitamins and deliciousness!"
 	icon_state = "orangejuice"
 	item_state = "carton"
@@ -260,7 +260,7 @@
 	list_reagents = list("orangejuice" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/cream
-	name = "Milk Cream"
+	name = "milk cream"
 	desc = "It's cream. Made from milk. What else did you think you'd find in there?"
 	icon_state = "cream"
 	item_state = "carton"
@@ -268,7 +268,7 @@
 	list_reagents = list("cream" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/tomatojuice
-	name = "Tomato Juice"
+	name = "tomato juice"
 	desc = "Well, at least it LOOKS like tomato juice. You can't tell with all that redness."
 	icon_state = "tomatojuice"
 	item_state = "carton"
@@ -276,7 +276,7 @@
 	list_reagents = list("tomatojuice" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/limejuice
-	name = "Lime Juice"
+	name = "lime juice"
 	desc = "Sweet-sour goodness."
 	icon_state = "limejuice"
 	item_state = "carton"
@@ -284,7 +284,7 @@
 	list_reagents = list("limejuice" = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/milk
-	name = "Milk"
+	name = "milk"
 	desc = "Soothing milk."
 	icon_state = "milk"
 	item_state = "carton"

--- a/code/modules/food_and_drinks/drinks/drinks/cans.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/cans.dm
@@ -59,34 +59,34 @@
 		return ..(target, user, proximity)
 
 /obj/item/reagent_containers/food/drinks/cans/cola
-	name = "Space Cola"
+	name = "space cola"
 	desc = "Cola. in space."
 	icon_state = "cola"
 	list_reagents = list("cola" = 30)
 
 /obj/item/reagent_containers/food/drinks/cans/beer
-	name = "Space Beer"
+	name = "space beer"
 	desc = "Contains only water, malt and hops."
 	icon_state = "beer"
 	is_glass = 1
 	list_reagents = list("beer" = 30)
 
 /obj/item/reagent_containers/food/drinks/cans/adminbooze
-	name = "Admin Booze"
+	name = "admin booze"
 	desc = "Bottled Griffon tears. Drink with caution."
 	icon_state = "adminbooze"
 	is_glass = 1
 	list_reagents = list("adminordrazine" = 5, "capsaicin" = 5, "methamphetamine"= 20, "thirteenloko" = 20)
 
 /obj/item/reagent_containers/food/drinks/cans/madminmalt
-	name = "Madmin Malt"
+	name = "madmin malt"
 	desc = "Bottled essence of angry admins. Drink with <i>EXTREME</i> caution."
 	icon_state = "madminmalt"
 	is_glass = 1
 	list_reagents = list("hell_water" = 20, "neurotoxin" = 15, "thirteenloko" = 15)
 
 /obj/item/reagent_containers/food/drinks/cans/badminbrew
-	name = "Badmin Brew"
+	name = "badmin brew"
 	desc = "Bottled trickery and terrible admin work. Probably shouldn't drink this one at all."
 	icon_state = "badminbrew"
 	is_glass = 1
@@ -156,7 +156,7 @@
 	list_reagents = list("tonic" = 50)
 
 /obj/item/reagent_containers/food/drinks/cans/sodawater
-	name = "Soda Water"
+	name = "soda water"
 	desc = "A can of soda water. Still water's more refreshing cousin."
 	icon_state = "sodawater"
 	list_reagents = list("sodawater" = 50)

--- a/code/modules/food_and_drinks/food/foods/candy.dm
+++ b/code/modules/food_and_drinks/food/foods/candy.dm
@@ -18,14 +18,14 @@
 // ***********************************************************
 
 /obj/item/reagent_containers/food/snacks/chocolatebar
-	name = "Chocolate Bar"
+	name = "chocolate bar"
 	desc = "Such sweet, fattening food."
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 2, "chocolate" = 4)
 
 /obj/item/reagent_containers/food/snacks/candy/caramel
-	name = "Caramel"
+	name = "caramel"
 	desc = "Chewy and dense, yet it practically melts in your mouth!"
 	icon_state = "caramel"
 	filling_color = "#DB944D"
@@ -33,21 +33,21 @@
 
 
 /obj/item/reagent_containers/food/snacks/candy/toffee
-	name = "Toffee"
+	name = "toffee"
 	desc = "A hard, brittle candy with a distinctive taste."
 	icon_state = "toffee"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 3, "sugar" = 3)
 
 /obj/item/reagent_containers/food/snacks/candy/nougat
-	name = "Nougat"
+	name = "nougat"
 	desc = "A soft, chewy candy commonly found in candybars."
 	icon_state = "nougat"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 3, "sugar" = 3)
 
 /obj/item/reagent_containers/food/snacks/candy/taffy
-	name = "Saltwater Taffy"
+	name = "saltwater taffy"
 	desc = "Old fashioned saltwater taffy. Chewy!"
 	icon_state = "candy1"
 	filling_color = "#7D5F46"
@@ -58,7 +58,7 @@
 	icon_state = pick("candy1", "candy2", "candy3", "candy4", "candy5")
 
 /obj/item/reagent_containers/food/snacks/candy/fudge
-	name = "Fudge"
+	name = "fudge"
 	desc = "Chocolate fudge, a timeless classic treat."
 	icon_state = "fudge"
 	filling_color = "#7D5F46"
@@ -66,26 +66,26 @@
 	list_reagents = list("cream" = 3, "chocolate" = 6)
 
 /obj/item/reagent_containers/food/snacks/candy/fudge/peanut
-	name = "Peanut Fudge"
+	name = "peanut fudge"
 	desc = "Chocolate fudge, with bits of peanuts mixed in. People with nut allergies shouldn't eat this."
 	icon_state = "fudge_peanut"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/fudge/cherry
-	name = "Chocolate Cherry Fudge"
+	name = "chocolate cherry fudge"
 	desc = "Chocolate fudge surrounding sweet cherries. Good for tricking kids into eating some fruit."
 	icon_state = "fudge_cherry"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/fudge/cookies_n_cream
-	name = "Cookies 'n' Cream Fudge"
+	name = "cookies 'n' cream fudge"
 	desc = "An extra creamy fudge with bits of real chocolate cookie mixed in. Crunchy!"
 	icon_state = "fudge_cookies_n_cream"
 	filling_color = "#7D5F46"
 	list_reagents = list("cream" = 6, "chocolate" = 6)
 
 /obj/item/reagent_containers/food/snacks/candy/fudge/turtle
-	name = "Turtle Fudge"
+	name = "turtle fudge"
 	desc = "Chocolate fudge with caramel and nuts. It doesn't contain real turtles, thankfully."
 	icon_state = "fudge_turtle"
 	filling_color = "#7D5F46"
@@ -95,7 +95,7 @@
 // ***********************************************************
 
 /obj/item/reagent_containers/food/snacks/candy/donor
-	name = "Donor Candy"
+	name = "donor candy"
 	desc = "A little treat for blood donors."
 	trash = /obj/item/trash/candy
 	bitesize = 5
@@ -509,32 +509,32 @@
 	list_reagents = list("nutriment" = 1, "chocolate" = 1)
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/rice
-	name = "Asteroid Crunch Bar"
+	name = "asteroid crunch bar"
 	desc = "Crunchy rice deposits in delicious chocolate! A favorite of miners galaxy-wide."
 	icon_state = "asteroidcrunch"
 	trash = /obj/item/trash/candy
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/toffee
-	name = "Yum-baton Bar"
+	name = "yum-baton bar"
 	desc = "Chocolate and toffee in the shape of a baton. Security sure knows how to pound these down!"
 	icon_state = "yumbaton"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/caramel
-	name = "Malper Bar"
+	name = "malper bar"
 	desc = "A chocolate syringe filled with a caramel injection. Just what the doctor ordered!"
 	icon_state = "malper"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat
-	name = "Toxins Test Bar"
+	name = "toxins test bar"
 	desc = "An explosive combination of chocolate, caramel, and nougat. Research has never been so tasty!"
 	icon_state = "toxinstest"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/nougat
-	name = "Tool-erone Bar"
+	name = "tool-erone bar"
 	desc = "Chocolate-covered nougat, shaped like a wrench. Great for an engineer on the go!"
 	icon_state = "toolerone"
 	filling_color = "#7D5F46"

--- a/code/modules/food_and_drinks/food/foods/candy.dm
+++ b/code/modules/food_and_drinks/food/foods/candy.dm
@@ -509,32 +509,32 @@
 	list_reagents = list("nutriment" = 1, "chocolate" = 1)
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/rice
-	name = "asteroid crunch bar"
+	name = "Asteroid Crunch Bar"
 	desc = "Crunchy rice deposits in delicious chocolate! A favorite of miners galaxy-wide."
 	icon_state = "asteroidcrunch"
 	trash = /obj/item/trash/candy
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/toffee
-	name = "yum-baton bar"
+	name = "Yum-Baton Bar"
 	desc = "Chocolate and toffee in the shape of a baton. Security sure knows how to pound these down!"
 	icon_state = "yumbaton"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/caramel
-	name = "malper bar"
+	name = "Malper Bar"
 	desc = "A chocolate syringe filled with a caramel injection. Just what the doctor ordered!"
 	icon_state = "malper"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/caramel_nougat
-	name = "toxins test bar"
+	name = "Toxins Test Bar"
 	desc = "An explosive combination of chocolate, caramel, and nougat. Research has never been so tasty!"
 	icon_state = "toxinstest"
 	filling_color = "#7D5F46"
 
 /obj/item/reagent_containers/food/snacks/candy/confectionery/nougat
-	name = "tool-erone bar"
+	name = "Tool-erone Bar"
 	desc = "Chocolate-covered nougat, shaped like a wrench. Great for an engineer on the go!"
 	icon_state = "toolerone"
 	filling_color = "#7D5F46"

--- a/code/modules/food_and_drinks/food/foods/ethnic.dm
+++ b/code/modules/food_and_drinks/food/foods/ethnic.dm
@@ -11,7 +11,7 @@
 	list_reagents = list("nutriment" = 7, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/burrito
-	name = "Burrito"
+	name = "burrito"
 	desc = "Meat, beans, cheese, and rice wrapped up as an easy-to-hold meal."
 	icon_state = "burrito"
 	trash = /obj/item/trash/plate
@@ -19,7 +19,7 @@
 	list_reagents = list("nutriment" = 4, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/chimichanga
-	name = "Chimichanga"
+	name = "chimichanga"
 	desc = "Time to eat a chimi-f***ing-changa."
 	icon_state = "chimichanga"
 	trash = /obj/item/trash/plate
@@ -27,8 +27,8 @@
 	list_reagents = list("omnizine" = 4, "cheese" = 2) //Deadpool reference. Deal with it.
 
 /obj/item/reagent_containers/food/snacks/enchiladas
-	name = "Enchiladas"
-	desc = "Viva La Mexico!"
+	name = "enchiladas"
+	desc = "Viva la Mexico!"
 	icon_state = "enchiladas"
 	trash = /obj/item/trash/tray
 	filling_color = "#A36A1F"
@@ -57,7 +57,7 @@
 	list_reagents = list("nutriment" = 1, "beans" = 3, "msg" = 4, "sugar" = 2)
 
 /obj/item/reagent_containers/food/snacks/chinese/sweetsourchickenball
-	name = "Sweet & Sour Chicken Balls"
+	name = "sweet & sour chicken balls"
 	desc = "Is this chicken cooked? The odds are better than wok paper scissors."
 	icon_state = "chickenball"
 	junkiness = 25
@@ -113,13 +113,13 @@
 /obj/item/reagent_containers/food/snacks/human/kabob
 	name = "-kabob"
 	icon_state = "kabob"
-	desc = "A human meat, on a stick."
+	desc = "Human meat, on a stick."
 	trash = /obj/item/stack/rods
 	filling_color = "#A85340"
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/monkeykabob
-	name = "Meat-kabob"
+	name = "meat-kabob"
 	icon_state = "kabob"
 	desc = "Delicious meat, on a stick."
 	trash = /obj/item/stack/rods
@@ -127,7 +127,7 @@
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/tofukabob
-	name = "Tofu-kabob"
+	name = "tofu-kabob"
 	icon_state = "kabob"
 	desc = "Vegan meat, on a stick."
 	trash = /obj/item/stack/rods

--- a/code/modules/food_and_drinks/food/foods/ingredients.dm
+++ b/code/modules/food_and_drinks/food/foods/ingredients.dm
@@ -4,7 +4,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/tofu
-	name = "Tofu"
+	name = "tofu"
 	icon_state = "tofu"
 	desc = "We all love tofu."
 	filling_color = "#FFFEE0"
@@ -12,7 +12,7 @@
 	list_reagents = list("plantmatter" = 2)
 
 /obj/item/reagent_containers/food/snacks/fried_tofu
-	name = "Fried Tofu"
+	name = "fried tofu"
 	icon_state = "tofu"
 	desc = "Proof that even vegetarians crave unhealthy foods."
 	filling_color = "#FFFEE0"
@@ -20,8 +20,8 @@
 	list_reagents = list("plantmatter" = 3)
 
 /obj/item/reagent_containers/food/snacks/soydope
-	name = "Soy Dope"
-	desc = "Dope from a soy."
+	name = "soy dope"
+	desc = "Like regular dope, but for the health concious consumer."
 	icon_state = "soydope"
 	trash = /obj/item/trash/plate
 	filling_color = "#C4BF76"
@@ -33,7 +33,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/sliceable/cheesewheel
-	name = "Cheese wheel"
+	name = "cheese wheel"
 	desc = "A big wheel of delicious Cheddar."
 	icon_state = "cheesewheel"
 	slice_path = /obj/item/reagent_containers/food/snacks/cheesewedge
@@ -42,14 +42,14 @@
 	list_reagents = list("nutriment" = 15, "vitamin" = 5, "cheese" = 20)
 
 /obj/item/reagent_containers/food/snacks/cheesewedge
-	name = "Cheese wedge"
+	name = "cheese wedge"
 	desc = "A wedge of delicious Cheddar. The cheese wheel it was cut from can't have gone far."
 	icon_state = "cheesewedge"
 	filling_color = "#FFF700"
 
 /obj/item/reagent_containers/food/snacks/weirdcheesewedge
-	name = "Weird Cheese"
-	desc = "Some kind of... gooey, messy, gloopy thing. Similar to cheese, but only in the looser sense of the word."
+	name = "weird cheese"
+	desc = "Some kind of... gooey, messy, gloopy thing. Similar to cheese, but only in the broad sense of the word."
 	icon_state = "weirdcheesewedge"
 	filling_color = "#00FF33"
 	list_reagents = list("mercury" = 5, "lsd" = 5, "ethanol" = 5, "weird_cheese" = 5)
@@ -76,13 +76,13 @@
 	list_reagents = list("protein" = 2)
 
 /obj/item/reagent_containers/food/snacks/watermelonslice
-	name = "Watermelon Slice"
+	name = "watermelon slice"
 	desc = "A slice of watery goodness."
 	icon_state = "watermelonslice"
 	filling_color = "#FF3867"
 
 /obj/item/reagent_containers/food/snacks/pineappleslice
-	name = "Pineapple Slices"
+	name = "pineapple slices"
 	desc = "Rings of pineapple."
 	icon_state = "pineappleslice"
 	filling_color = "#e5b437"
@@ -134,14 +134,14 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/chocolatebar
-	name = "Chocolate Bar"
+	name = "chocolate bar"
 	desc = "Such sweet, fattening food."
 	icon_state = "chocolatebar"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 2, "sugar" = 2, "cocoa" = 2)
 
 /obj/item/reagent_containers/food/snacks/choc_pile //for reagent chocolate being spilled on turfs
-	name = "Pile of Chocolate"
+	name = "pile of chocolate"
 	desc = "A pile of pure chocolate pieces."
 	icon_state = "cocoa"
 	filling_color = "#7D5F46"

--- a/code/modules/food_and_drinks/food/foods/junkfood.dm
+++ b/code/modules/food_and_drinks/food/foods/junkfood.dm
@@ -25,7 +25,7 @@
 /obj/item/reagent_containers/food/snacks/pistachios
 	name = "Pistachios"
 	icon_state = "pistachios"
-	desc = "A snack of deliciously salted pistachios. A perfectly valid choice..."
+	desc = "Deliciously salted pistachios. A perfectly valid choice..."
 	trash = /obj/item/trash/pistachios
 	filling_color = "#BAD145"
 	junkiness = 20
@@ -68,7 +68,7 @@
 
 /obj/item/reagent_containers/food/snacks/tastybread
 	name = "bread tube"
-	desc = "Bread in a tube. Chewy...and surprisingly tasty."
+	desc = "Bread in a tube. Chewy and surprisingly tasty."
 	icon_state = "tastybread"
 	trash = /obj/item/trash/tastybread
 	filling_color = "#A66829"

--- a/code/modules/food_and_drinks/food/foods/junkfood.dm
+++ b/code/modules/food_and_drinks/food/foods/junkfood.dm
@@ -23,7 +23,7 @@
 	list_reagents = list("protein" = 1, "sugar" = 3)
 
 /obj/item/reagent_containers/food/snacks/pistachios
-	name = "Pistachios"
+	name = "pistachios"
 	icon_state = "pistachios"
 	desc = "Deliciously salted pistachios. A perfectly valid choice..."
 	trash = /obj/item/trash/pistachios

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -115,7 +115,7 @@
 
 /obj/item/reagent_containers/food/snacks/raw_bacon
 	name = "raw bacon"
-	desc = "God's gift to man, in uncooked form."
+	desc = "God's gift to man in uncooked form."
 	icon_state = "raw_bacon"
 	list_reagents = list("nutriment" = 1, "porktonium" = 10)
 

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -33,22 +33,22 @@
 
 /obj/item/reagent_containers/food/snacks/meat/slab/meatproduct
 	name = "meat product"
-	desc = "A slab of station reclaimed and chemically processed meat product."
+	desc = "A slab of reclaimed and chemically processed meat product."
 
 /obj/item/reagent_containers/food/snacks/meat/monkey
 	//same as plain meat
 
 /obj/item/reagent_containers/food/snacks/meat/corgi
-	name = "Corgi meat"
-	desc = "Tastes like... well you know..."
+	name = "corgi meat"
+	desc = "Tastes like the HoP's hopes and dreams"
 
 /obj/item/reagent_containers/food/snacks/meat/pug
-	name = "Pug meat"
-	desc = "Tastes like... well you know..."
+	name = "pug meat"
+	desc = "Slightly less adorable in sliced form."
 
 /obj/item/reagent_containers/food/snacks/meat/ham
-	name = "Ham"
-	desc = "Taste like bacon."
+	name = "ham"
+	desc = "For when you need to go ham."
 	list_reagents = list("protein" = 3, "porktonium" = 10)
 
 /obj/item/reagent_containers/food/snacks/meat/meatwheat
@@ -61,7 +61,7 @@
 
 /obj/item/reagent_containers/food/snacks/rawcutlet
 	name = "raw cutlet"
-	desc = "A thin piece of raw meat."
+	desc = "A thin strip of raw meat."
 	icon = 'icons/obj/food/food_ingredients.dmi'
 	icon_state = "rawcutlet"
 	bitesize = 1
@@ -86,7 +86,7 @@
 
 /obj/item/reagent_containers/food/snacks/xenomeat
 	name = "meat"
-	desc = "A slab of meat."
+	desc = "A slab of meat. It's green!"
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
 	bitesize = 6
@@ -94,14 +94,14 @@
 
 /obj/item/reagent_containers/food/snacks/spidermeat
 	name = "spider meat"
-	desc = "A slab of spider meat."
+	desc = "A slab of spider meat. Not very appetizing."
 	icon_state = "spidermeat"
 	bitesize = 3
 	list_reagents = list("protein" = 3, "toxin" = 3, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/lizardmeat
 	name = "mutant lizard meat"
-	desc = "Seems to be a slab of meat from some mutant lizard thing?"
+	desc = "A peculiar slab of meat. It looks scaly and radioactive."
 	icon_state = "xenomeat"
 	filling_color = "#43DE18"
 	bitesize = 3
@@ -109,19 +109,19 @@
 
 /obj/item/reagent_containers/food/snacks/spiderleg
 	name = "spider leg"
-	desc = "A still twitching leg of a giant spider... you don't really want to eat this, do you?"
+	desc = "A still twitching leg of a giant spider. You don't really want to eat this, do you?"
 	icon_state = "spiderleg"
 	list_reagents = list("protein" = 2, "toxin" = 2)
 
 /obj/item/reagent_containers/food/snacks/raw_bacon
 	name = "raw bacon"
-	desc = "It's fleshy and pink!"
+	desc = "God's gift to man, in uncooked form."
 	icon_state = "raw_bacon"
 	list_reagents = list("nutriment" = 1, "porktonium" = 10)
 
 /obj/item/reagent_containers/food/snacks/spidereggs
 	name = "spider eggs"
-	desc = "A cluster of juicy spider eggs. A great side dish for when you care not for your health."
+	desc = "A cluster of juicy spider eggs. A great side dish for when you don't care about your health."
 	icon_state = "spidereggs"
 	list_reagents = list("protein" = 2, "toxin" = 2)
 
@@ -130,7 +130,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/meatsteak
-	name = "Meat steak"
+	name = "meat steak"
 	desc = "A piece of hot spicy meat."
 	icon_state = "meatstake"
 	trash = /obj/item/trash/plate
@@ -140,13 +140,13 @@
 
 /obj/item/reagent_containers/food/snacks/bacon
 	name = "bacon"
-	desc = "It looks juicy and tastes amazing!"
+	desc = "It looks juicy and tastes amazing! Mmm... Bacon."
 	icon_state = "bacon2"
 	list_reagents = list("nutriment" = 4, "porktonium" = 10, "msg" = 4)
 
 /obj/item/reagent_containers/food/snacks/telebacon
-	name = "Tele Bacon"
-	desc = "It tastes a little odd but it is still delicious."
+	name = "tele bacon"
+	desc = "It tastes a little odd but it's still delicious."
 	icon_state = "bacon"
 	var/obj/item/radio/beacon/bacon/baconbeacon
 	list_reagents = list("nutriment" = 4, "porktonium" = 10)
@@ -161,15 +161,15 @@
 		baconbeacon.digest_delay()
 
 /obj/item/reagent_containers/food/snacks/meatball
-	name = "Meatball"
+	name = "meatball"
 	desc = "A great meal all round."
 	icon_state = "meatball"
 	filling_color = "#DB0000"
 	list_reagents = list("protein" = 4, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/sausage
-	name = "Sausage"
-	desc = "A piece of mixed, long meat."
+	name = "sausage"
+	desc = "A piece of mixed and cased meat."
 	icon_state = "sausage"
 	filling_color = "#DB0000"
 	list_reagents = list("protein" = 6, "vitamin" = 1, "porktonium" = 10)
@@ -198,8 +198,8 @@
 	list_reagents = list("nutriment" = 3, "capsaicin" = 2)
 
 /obj/item/reagent_containers/food/snacks/wingfangchu
-	name = "Wing Fang Chu"
-	desc = "A savory dish of alien wing wang in soy."
+	name = "wing fang chu"
+	desc = "A savory dish of alien wing wang in soy. Wait, what?"
 	icon_state = "wingfangchu"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#43DE18"
@@ -335,7 +335,7 @@
 	color = reagent_color
 
 /obj/item/reagent_containers/food/snacks/friedegg
-	name = "Fried egg"
+	name = "fried egg"
 	desc = "A fried egg, with a touch of salt and pepper."
 	icon_state = "friedegg"
 	filling_color = "#FFDF78"
@@ -343,21 +343,21 @@
 	list_reagents = list("nutriment" = 3, "egg" = 5)
 
 /obj/item/reagent_containers/food/snacks/boiledegg
-	name = "Boiled egg"
+	name = "boiled egg"
 	desc = "A hard boiled egg."
 	icon_state = "egg"
 	filling_color = "#FFFFFF"
 	list_reagents = list("nutriment" = 2, "egg" = 5, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/chocolateegg
-	name = "Chocolate Egg"
+	name = "chocolate egg"
 	desc = "Such sweet, fattening food."
 	icon_state = "chocolateegg"
 	filling_color = "#7D5F46"
 	list_reagents = list("nutriment" = 4, "sugar" = 2, "cocoa" = 2)
 
 /obj/item/reagent_containers/food/snacks/omelette
-	name = "Omelette Du Fromage"
+	name = "omelette du fromage"
 	desc = "That's all you can say!"
 	icon_state = "omelette"
 	trash = /obj/item/trash/plate
@@ -379,7 +379,7 @@
 
 /obj/item/reagent_containers/food/snacks/hotdog
 	name = "hotdog"
-	desc = "Fresh footlong ready to go down on."
+	desc = "Not made with actual dogs. Hopefully."
 	icon_state = "hotdog"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "ketchup" = 3, "vitamin" = 3)
@@ -392,7 +392,7 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/turkey
-	name = "Turkey"
+	name = "turkey"
 	desc = "A traditional turkey served with stuffing."
 	icon_state = "turkey"
 	slice_path = /obj/item/reagent_containers/food/snacks/turkeyslice
@@ -408,7 +408,7 @@
 
 /obj/item/reagent_containers/food/snacks/organ
 	name = "organ"
-	desc = "It's good for you."
+	desc = "Technically qualifies as organic."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "appendix"
 	filling_color = "#E00D34"

--- a/code/modules/food_and_drinks/food/foods/meat.dm
+++ b/code/modules/food_and_drinks/food/foods/meat.dm
@@ -40,7 +40,7 @@
 
 /obj/item/reagent_containers/food/snacks/meat/corgi
 	name = "corgi meat"
-	desc = "Tastes like the HoP's hopes and dreams"
+	desc = "Tastes like the Head of Personnel's hopes and dreams"
 
 /obj/item/reagent_containers/food/snacks/meat/pug
 	name = "pug meat"
@@ -140,7 +140,7 @@
 
 /obj/item/reagent_containers/food/snacks/bacon
 	name = "bacon"
-	desc = "It looks juicy and tastes amazing! Mmm... Bacon."
+	desc = "It looks crispy and tastes amazing! Mmm... Bacon."
 	icon_state = "bacon2"
 	list_reagents = list("nutriment" = 4, "porktonium" = 10, "msg" = 4)
 

--- a/code/modules/food_and_drinks/food/foods/misc.dm
+++ b/code/modules/food_and_drinks/food/foods/misc.dm
@@ -4,7 +4,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/eggplantparm
-	name = "Eggplant Parmigiana"
+	name = "eggplant parmigiana"
 	desc = "The only good recipe for eggplant."
 	icon_state = "eggplantparm"
 	trash = /obj/item/trash/plate
@@ -12,7 +12,7 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/soylentgreen
-	name = "Soylent Green"
+	name = "soylent green"
 	desc = "Not made of people. Honest." //Totally people.
 	icon_state = "soylent_green"
 	trash = /obj/item/trash/waffles
@@ -20,7 +20,7 @@
 	list_reagents = list("nutriment" = 10, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/soylentviridians
-	name = "Soylent Virdians"
+	name = "soylent virdians"
 	desc = "Not made of people. Honest." //Actually honest for once.
 	icon_state = "soylent_yellow"
 	trash = /obj/item/trash/waffles
@@ -28,7 +28,7 @@
 	list_reagents = list("nutriment" = 10, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/monkeysdelight
-	name = "monkey's Delight"
+	name = "monkey's delight"
 	desc = "Eeee Eee!"
 	icon_state = "monkeysdelight"
 	trash = /obj/item/trash/tray
@@ -38,14 +38,14 @@
 
 /obj/item/reagent_containers/food/snacks/dionaroast
 	name = "roast diona"
-	desc = "It's like an enormous, leathery carrot. With an eye."
+	desc = "It's like an enormous leathery carrot... With an eye."
 	icon_state = "dionaroast"
 	trash = /obj/item/trash/plate
 	filling_color = "#75754B"
 	list_reagents = list("plantmatter" = 4, "nutriment" = 2, "radium" = 2, "vitamin" = 4)
 
 /obj/item/reagent_containers/food/snacks/tofurkey
-	name = "Tofurkey"
+	name = "tofurkey"
 	desc = "A fake turkey made from tofu."
 	icon_state = "tofurkey"
 	filling_color = "#FFFEE0"
@@ -58,7 +58,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/aesirsalad
-	name = "Aesir salad"
+	name = "aesir salad"
 	desc = "Probably too incredible for mortal men to fully enjoy."
 	icon_state = "aesirsalad"
 	trash = /obj/item/trash/snack_bowl
@@ -97,7 +97,7 @@
 	list_reagents = list("nutriment" = 4)
 
 /obj/item/reagent_containers/food/snacks/warmdonkpocket
-	name = "Warm Donk-pocket"
+	name = "warm Donk-pocket"
 	desc = "The food of choice for the seasoned traitor."
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
@@ -107,7 +107,7 @@
 	M.reagents.add_reagent("omnizine", 15)
 
 /obj/item/reagent_containers/food/snacks/warmdonkpocket_weak
-	name = "Lightly Warm Donk-pocket"
+	name = "lightly warm Donk-pocket"
 	desc = "The food of choice for the seasoned traitor. This one is lukewarm."
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"
@@ -135,7 +135,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/boiledslimecore
-	name = "Boiled Slime Core"
+	name = "boiled slime core"
 	desc = "A boiled red thing."
 	icon_state = "boiledrorocore"
 	bitesize = 3
@@ -162,7 +162,7 @@
 	..()
 
 /obj/item/reagent_containers/food/snacks/liquidfood
-	name = "\improper LiquidFood Ration"
+	name = "\improper LiquidFood ration"
 	desc = "A prepackaged grey slurry of all the essential nutrients for a spacefarer on the go. Should this be crunchy?"
 	icon_state = "liquidfood"
 	trash = /obj/item/trash/liquidfood

--- a/code/modules/food_and_drinks/food/foods/misc.dm
+++ b/code/modules/food_and_drinks/food/foods/misc.dm
@@ -107,7 +107,7 @@
 	M.reagents.add_reagent("omnizine", 15)
 
 /obj/item/reagent_containers/food/snacks/warmdonkpocket_weak
-	name = "lightly warm Donk-pocket"
+	name = "lukewarm Donk-pocket"
 	desc = "The food of choice for the seasoned traitor. This one is lukewarm."
 	icon_state = "donkpocket"
 	filling_color = "#DEDEAB"

--- a/code/modules/food_and_drinks/food/foods/misc.dm
+++ b/code/modules/food_and_drinks/food/foods/misc.dm
@@ -58,7 +58,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/aesirsalad
-	name = "aesir salad"
+	name = "Aesir salad"
 	desc = "Probably too incredible for mortal men to fully enjoy."
 	icon_state = "aesirsalad"
 	trash = /obj/item/trash/snack_bowl

--- a/code/modules/food_and_drinks/food/foods/pasta.dm
+++ b/code/modules/food_and_drinks/food/foods/pasta.dm
@@ -44,7 +44,7 @@
 	list_reagents = list("nutriment" = 6, "tomatojuice" = 10, "vitamin" = 4)
 
 /obj/item/reagent_containers/food/snacks/meatballspaghetti
-	name = "spaghetti & Meatballs"
+	name = "spaghetti & meatballs"
 	desc = "Now thats a nice'a meatball!"
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "meatballspaghetti"

--- a/code/modules/food_and_drinks/food/foods/pasta.dm
+++ b/code/modules/food_and_drinks/food/foods/pasta.dm
@@ -53,7 +53,7 @@
 	list_reagents = list("nutriment" = 8, "synaptizine" = 5, "vitamin" = 4)
 
 /obj/item/reagent_containers/food/snacks/spesslaw
-	name = "spesslaw"
+	name = "Spesslaw"
 	desc = "A lawyer's favourite."
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "spesslaw"

--- a/code/modules/food_and_drinks/food/foods/pasta.dm
+++ b/code/modules/food_and_drinks/food/foods/pasta.dm
@@ -4,7 +4,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/spaghetti
-	name = "Spaghetti"
+	name = "spaghetti"
 	desc = "A bundle of raw spaghetti."
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "spaghetti"
@@ -12,7 +12,7 @@
 	list_reagents = list("nutriment" = 1, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/macaroni
-	name = "Macaroni twists"
+	name = "macaroni twists"
 	desc = "These are little twists of raw macaroni."
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "macaroni"
@@ -25,8 +25,8 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/boiledspaghetti
-	name = "Boiled Spaghetti"
-	desc = "A plain dish of noodles, this sucks."
+	name = "boiled spaghetti"
+	desc = "A plain dish of noodles. This sucks."
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "spaghettiboiled"
 	trash = /obj/item/trash/plate
@@ -45,7 +45,7 @@
 
 /obj/item/reagent_containers/food/snacks/meatballspaghetti
 	name = "spaghetti & Meatballs"
-	desc = "Now thats a nic'e meatball!"
+	desc = "Now thats a nice'a meatball!"
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "meatballspaghetti"
 	trash = /obj/item/trash/plate
@@ -53,7 +53,7 @@
 	list_reagents = list("nutriment" = 8, "synaptizine" = 5, "vitamin" = 4)
 
 /obj/item/reagent_containers/food/snacks/spesslaw
-	name = "Spesslaw"
+	name = "spesslaw"
 	desc = "A lawyer's favourite."
 	icon = 'icons/obj/food/pasta.dmi'
 	icon_state = "spesslaw"
@@ -61,7 +61,7 @@
 	list_reagents = list("nutriment" = 8, "synaptizine" = 10, "vitamin" = 6)
 
 /obj/item/reagent_containers/food/snacks/macncheese
-	name = "Macaroni cheese"
+	name = "macaroni cheese"
 	desc = "One of the most comforting foods in the world. Apparently."
 	trash = /obj/item/trash/snack_bowl
 	icon = 'icons/obj/food/pasta.dmi'

--- a/code/modules/food_and_drinks/food/foods/pasta.dm
+++ b/code/modules/food_and_drinks/food/foods/pasta.dm
@@ -61,7 +61,7 @@
 	list_reagents = list("nutriment" = 8, "synaptizine" = 10, "vitamin" = 6)
 
 /obj/item/reagent_containers/food/snacks/macncheese
-	name = "macaroni cheese"
+	name = "mac n cheese"
 	desc = "One of the most comforting foods in the world. Apparently."
 	trash = /obj/item/trash/snack_bowl
 	icon = 'icons/obj/food/pasta.dmi'

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -66,14 +66,14 @@
 	filling_color = "#BAA14C"
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/hawaiianpizza
-	name = "hawaiian pizza"
+	name = "Hawaiian pizza"
 	desc = "Love it or hate it, this pizza divides opinions. Complete with juicy pineapple."
 	icon_state = "hawaiianpizza" //NEEDED
 	slice_path = /obj/item/reagent_containers/food/snacks/hawaiianpizzaslice
 	list_reagents = list("protein" = 15, "tomatojuice" = 6, "plantmatter" = 20, "pineapplejuice" = 6, "vitamin" = 5)
 
 /obj/item/reagent_containers/food/snacks/hawaiianpizzaslice
-	name = "hawaiian pizza slice"
+	name = "Hawaiian pizza slice"
 	desc = "A slice of polarising pizza."
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "hawaiianpizzaslice"

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -80,7 +80,7 @@
 	filling_color = "#e5b437"
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/macpizza
-	name = "macaroni cheese pizza"
+	name = "mac n cheese pizza"
 	desc = "Gastronomists have yet to classify this dish as 'pizza'."
 	icon_state = "macpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/macpizzaslice
@@ -88,7 +88,7 @@
 	filling_color = "#ffe45d"
 
 /obj/item/reagent_containers/food/snacks/macpizzaslice
-	name = "macaroni cheese pizza slice"
+	name = "mac n cheese pizza slice"
 	desc = "A delicious slice of pizza topped with macaroni cheese... wait, what the hell? Who would do this?!"
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "macpizzaslice"

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -251,4 +251,4 @@
 
 /obj/item/pizzabox/hawaiian/New()
 	pizza = new /obj/item/reagent_containers/food/snacks/sliceable/pizza/hawaiianpizza(src)
-	boxtag = "hawaiian feast"
+	boxtag = "Hawaiian feast"

--- a/code/modules/food_and_drinks/food/foods/pizza.dm
+++ b/code/modules/food_and_drinks/food/foods/pizza.dm
@@ -9,14 +9,14 @@
 	filling_color = "#BAA14C"
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/margherita
-	name = "Margherita"
+	name = "margherita pizza"
 	desc = "The golden standard of pizzas."
 	icon_state = "pizzamargherita"
 	slice_path = /obj/item/reagent_containers/food/snacks/margheritaslice
 	list_reagents = list("nutriment" = 30, "tomatojuice" = 6, "vitamin" = 5)
 
 /obj/item/reagent_containers/food/snacks/margheritaslice
-	name = "Margherita slice"
+	name = "margherita slice"
 	desc = "A slice of the classic pizza."
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "pizzamargheritaslice"
@@ -24,63 +24,63 @@
 	list_reagents = list("nutriment" = 5)
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/meatpizza
-	name = "Meatpizza"
+	name = "meat pizza"
 	desc = "A pizza with meat topping."
 	icon_state = "meatpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/meatpizzaslice
 	list_reagents = list("protein" = 30, "tomatojuice" = 6, "vitamin" = 8)
 
 /obj/item/reagent_containers/food/snacks/meatpizzaslice
-	name = "Meatpizza slice"
+	name = "meat pizza slice"
 	desc = "A slice of a meaty pizza."
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "meatpizzaslice"
 	filling_color = "#BAA14C"
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/mushroompizza
-	name = "Mushroompizza"
+	name = "mushroom pizza"
 	desc = "Very special pizza."
 	icon_state = "mushroompizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/mushroompizzaslice
 	list_reagents = list("plantmatter" = 30, "vitamin" = 5)
 
 /obj/item/reagent_containers/food/snacks/mushroompizzaslice
-	name = "Mushroompizza slice"
+	name = "mushroom pizza slice"
 	desc = "Maybe it is the last slice of pizza in your life."
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "mushroompizzaslice"
 	filling_color = "#BAA14C"
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza
-	name = "Vegetable pizza"
-	desc = "No one of Tomato Sapiens were harmed during making this pizza."
+	name = "vegetable pizza"
+	desc = "No Tomato Sapiens were harmed during the making of this pizza."
 	icon_state = "vegetablepizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/vegetablepizzaslice
 	list_reagents = list("plantmatter" = 25, "tomatojuice" = 6, "oculine" = 12, "vitamin" = 5)
 
 /obj/item/reagent_containers/food/snacks/vegetablepizzaslice
-	name = "Vegetable pizza slice"
+	name = "vegetable pizza slice"
 	desc = "A slice of the most green pizza of all pizzas not containing green ingredients."
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "vegetablepizzaslice"
 	filling_color = "#BAA14C"
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/hawaiianpizza
-	name = "Hawaiian Pizza"
+	name = "hawaiian pizza"
 	desc = "Love it or hate it, this pizza divides opinions. Complete with juicy pineapple."
 	icon_state = "hawaiianpizza" //NEEDED
 	slice_path = /obj/item/reagent_containers/food/snacks/hawaiianpizzaslice
 	list_reagents = list("protein" = 15, "tomatojuice" = 6, "plantmatter" = 20, "pineapplejuice" = 6, "vitamin" = 5)
 
 /obj/item/reagent_containers/food/snacks/hawaiianpizzaslice
-	name = "Hawaiian pizza slice"
+	name = "hawaiian pizza slice"
 	desc = "A slice of polarising pizza."
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "hawaiianpizzaslice"
 	filling_color = "#e5b437"
 
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/macpizza
-	name = "Macaroni cheese pizza"
+	name = "macaroni cheese pizza"
 	desc = "Gastronomists have yet to classify this dish as 'pizza'."
 	icon_state = "macpizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/macpizzaslice
@@ -88,7 +88,7 @@
 	filling_color = "#ffe45d"
 
 /obj/item/reagent_containers/food/snacks/macpizzaslice
-	name = "Macaroni cheese pizza slice"
+	name = "macaroni cheese pizza slice"
 	desc = "A delicious slice of pizza topped with macaroni cheese... wait, what the hell? Who would do this?!"
 	icon = 'icons/obj/food/pizza.dmi'
 	icon_state = "macpizzaslice"
@@ -235,20 +235,20 @@
 
 /obj/item/pizzabox/margherita/New()
 	pizza = new /obj/item/reagent_containers/food/snacks/sliceable/pizza/margherita(src)
-	boxtag = "Margherita Deluxe"
+	boxtag = "margherita deluxe"
 
 /obj/item/pizzabox/vegetable/New()
 	pizza = new /obj/item/reagent_containers/food/snacks/sliceable/pizza/vegetablepizza(src)
-	boxtag = "Gourmet Vegatable"
+	boxtag = "gourmet vegatable"
 
 /obj/item/pizzabox/mushroom/New()
 	pizza = new /obj/item/reagent_containers/food/snacks/sliceable/pizza/mushroompizza(src)
-	boxtag = "Mushroom Special"
+	boxtag = "mushroom special"
 
 /obj/item/pizzabox/meat/New()
 	pizza = new /obj/item/reagent_containers/food/snacks/sliceable/pizza/meatpizza(src)
-	boxtag = "Meatlover's Supreme"
+	boxtag = "meatlover's supreme"
 
 /obj/item/pizzabox/hawaiian/New()
 	pizza = new /obj/item/reagent_containers/food/snacks/sliceable/pizza/hawaiianpizza(src)
-	boxtag = "Hawaiian Feast"
+	boxtag = "hawaiian feast"

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -5,14 +5,14 @@
 
 /obj/item/reagent_containers/food/snacks/brainburger
 	name = "brainburger"
-	desc = "A strange looking burger. It looks almost sentient."
+	desc = "A strange looking burger. It appears almost sentient."
 	icon_state = "brainburger"
 	filling_color = "#F2B6EA"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "prions" = 10, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/ghostburger
-	name = "Ghost Burger"
+	name = "ghost burger"
 	desc = "Spooky! It doesn't look very filling."
 	icon_state = "ghostburger"
 	filling_color = "#FFF2FF"
@@ -47,8 +47,8 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/tofuburger
-	name = "Tofu Burger"
-	desc = "What.. is that meat?"
+	name = "tofu burger"
+	desc = "Making this should probably be a criminal offense."
 	icon_state = "tofuburger"
 	filling_color = "#FFFEE0"
 	bitesize = 3
@@ -73,14 +73,14 @@
 
 /obj/item/reagent_containers/food/snacks/xenoburger
 	name = "xenoburger"
-	desc = "Smells caustic. Tastes like heresy."
+	desc = "Smells caustic and tastes like heresy."
 	icon_state = "xburger"
 	filling_color = "#43DE18"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/clownburger
-	name = "Clown Burger"
+	name = "clown burger"
 	desc = "This tastes funny..."
 	icon_state = "clownburger"
 	filling_color = "#FF00FF"
@@ -88,7 +88,7 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/mimeburger
-	name = "Mime Burger"
+	name = "mime burger"
 	desc = "Its taste defies language."
 	icon_state = "mimeburger"
 	filling_color = "#FFFFFF"
@@ -97,14 +97,14 @@
 
 /obj/item/reagent_containers/food/snacks/baseballburger
 	name = "home run baseball burger"
-	desc = "It's still warm. The steam coming off of it looks like baseball."
+	desc = "It's still warm. Batter up!"
 	icon_state = "baseball"
 	filling_color = "#CD853F"
 	bitesize = 3
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/spellburger
-	name = "Spell Burger"
+	name = "spell burger"
 	desc = "This is absolutely Ei Nath."
 	icon_state = "spellburger"
 	filling_color = "#D505FF"
@@ -112,15 +112,15 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/bigbiteburger
-	name = "Big Bite Burger"
-	desc = "Forget the Big Mac. THIS is the future!"
+	name = "big bite burger"
+	desc = "Forget the Big Mac, THIS is the future!"
 	icon_state = "bigbiteburger"
 	filling_color = "#E3D681"
 	bitesize = 3
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/superbiteburger
-	name = "Super Bite Burger"
+	name = "super bite burger"
 	desc = "This is a mountain of a burger. FOOD!"
 	icon_state = "superbiteburger"
 	filling_color = "#CCA26A"
@@ -128,8 +128,8 @@
 	list_reagents = list("nutriment" = 40, "vitamin" = 5)
 
 /obj/item/reagent_containers/food/snacks/jellyburger
-	name = "Jelly Burger"
-	desc = "Culinary delight..?"
+	name = "jelly burger"
+	desc = "Culinary delight...?"
 	icon_state = "jellyburger"
 	filling_color = "#B572AB"
 	bitesize = 3
@@ -146,7 +146,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/sandwich
-	name = "Sandwich"
+	name = "sandwich"
 	desc = "A grand creation of meat, cheese, bread, and several leaves of lettuce! Arthur Dent would be proud."
 	icon_state = "sandwich"
 	trash = /obj/item/trash/plate
@@ -154,7 +154,7 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/toastedsandwich
-	name = "Toasted Sandwich"
+	name = "toasted sandwich"
 	desc = "Now if you only had a pepper bar."
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
@@ -162,15 +162,15 @@
 	list_reagents = list("nutriment" = 6, "carbon" = 2)
 
 /obj/item/reagent_containers/food/snacks/grilledcheese
-	name = "Grilled Cheese Sandwich"
-	desc = "Goes great with Tomato soup!"
+	name = "grilled cheese sandwich"
+	desc = "Goes great with tomato soup!"
 	icon_state = "toastedsandwich"
 	trash = /obj/item/trash/plate
 	filling_color = "#D9BE29"
 	list_reagents = list("nutriment" = 7, "vitamin" = 1) //why make a regualr sandwhich when you can make grilled cheese, with this nutriment value?
 
 /obj/item/reagent_containers/food/snacks/jellysandwich
-	name = "Jelly Sandwich"
+	name = "jelly sandwich"
 	desc = "You wish you had some peanut butter to go with this..."
 	icon_state = "jellysandwich"
 	trash = /obj/item/trash/plate

--- a/code/modules/food_and_drinks/food/foods/sandwiches.dm
+++ b/code/modules/food_and_drinks/food/foods/sandwiches.dm
@@ -112,7 +112,7 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/bigbiteburger
-	name = "big bite burger"
+	name = "BigBite burger"
 	desc = "Forget the Big Mac, THIS is the future!"
 	icon_state = "bigbiteburger"
 	filling_color = "#E3D681"
@@ -120,7 +120,7 @@
 	list_reagents = list("nutriment" = 10, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/superbiteburger
-	name = "super bite burger"
+	name = "SuperBite burger"
 	desc = "This is a mountain of a burger. FOOD!"
 	icon_state = "superbiteburger"
 	filling_color = "#CCA26A"

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -46,7 +46,7 @@
 	list_reagents = list("nutriment" = 4)
 
 /obj/item/reagent_containers/food/snacks/fishburger
-	name = "fillet -o- carp sandwich"
+	name = "Fillet-O-Carp sandwich"
 	desc = "Almost like a carp is yelling somewhere... Give me back that fillet -o- carp, give me that carp."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishburger"

--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -18,8 +18,8 @@
 	list_reagents = list("protein" = 3, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/salmonsteak
-	name = "Salmon steak"
-	desc = "A piece of freshly-grilled salmon meat."
+	name = "salmon steak"
+	desc = "A fillet of freshly-grilled salmon meat."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "salmonsteak"
 	trash = /obj/item/trash/plate
@@ -37,7 +37,7 @@
 	list_reagents = list("protein" = 3, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/fishfingers
-	name = "Fish Fingers"
+	name = "fish fingers"
 	desc = "A finger of fish."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishfingers"
@@ -46,7 +46,7 @@
 	list_reagents = list("nutriment" = 4)
 
 /obj/item/reagent_containers/food/snacks/fishburger
-	name = "Fillet -o- Carp Sandwich"
+	name = "fillet -o- carp sandwich"
 	desc = "Almost like a carp is yelling somewhere... Give me back that fillet -o- carp, give me that carp."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishburger"
@@ -55,7 +55,7 @@
 	list_reagents = list("nutriment" = 6, "vitamin" = 1)
 
 /obj/item/reagent_containers/food/snacks/cubancarp
-	name = "Cuban Carp"
+	name = "Cuban carp"
 	desc = "A grifftastic sandwich that burns your tongue and then leaves it numb!"
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "cubancarp"
@@ -65,8 +65,8 @@
 	list_reagents = list("nutriment" = 6, "capsaicin" = 1)
 
 /obj/item/reagent_containers/food/snacks/fishandchips
-	name = "Fish and Chips"
-	desc = "I do say so myself chap."
+	name = "fish and chips"
+	desc = "I do say so myself old chap. Indubitably!"
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "fishandchips"
 	filling_color = "#E3D796"
@@ -98,7 +98,7 @@
 	list_reagents = list("nutriment" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Ebi_maki
-	name = "Ebi Makiroll"
+	name = "ebi makiroll"
 	desc = "A large unsliced roll of Ebi Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Ebi_maki"
@@ -108,7 +108,7 @@
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/sushi_Ebi
-	name = "Ebi Sushi"
+	name = "ebi sushi"
 	desc = "A simple sushi consisting of cooked shrimp and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Ebi"
@@ -116,7 +116,7 @@
 	list_reagents = list("nutriment" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Ikura_maki
-	name = "Ikura Makiroll"
+	name = "ikura makiroll"
 	desc = "A large unsliced roll of Ikura Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Ikura_maki"
@@ -126,7 +126,7 @@
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 
 /obj/item/reagent_containers/food/snacks/sushi_Ikura
-	name = "Ikura Sushi"
+	name = "ikura sushi"
 	desc = "A simple sushi consisting of salmon roe."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Ikura"
@@ -134,7 +134,7 @@
 	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Sake_maki
-	name = "Sake Makiroll"
+	name = "sake makiroll"
 	desc = "A large unsliced roll of Ebi Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Sake_maki"
@@ -144,7 +144,7 @@
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/sushi_Sake
-	name = "Sake Sushi"
+	name = "sake sushi"
 	desc = "A simple sushi consisting of raw salmon and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Sake"
@@ -152,7 +152,7 @@
 	list_reagents = list("nutriment" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/SmokedSalmon_maki
-	name = "Smoked Salmon Makiroll"
+	name = "smoked salmon makiroll"
 	desc = "A large unsliced roll of Smoked Salmon Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "SmokedSalmon_maki"
@@ -162,7 +162,7 @@
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/sushi_SmokedSalmon
-	name = "Smoked Salmon Sushi"
+	name = "smoked salmon sushi"
 	desc = "A simple sushi consisting of cooked salmon and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_SmokedSalmon"
@@ -170,7 +170,7 @@
 	list_reagents = list("nutriment" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Tamago_maki
-	name = "Tamago Makiroll"
+	name = "tamago makiroll"
 	desc = "A large unsliced roll of Tamago Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tamago_maki"
@@ -180,7 +180,7 @@
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/sushi_Tamago
-	name = "Tamago Sushi"
+	name = "tamago sushi"
 	desc = "A simple sushi consisting of egg and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Tamago"
@@ -188,7 +188,7 @@
 	list_reagents = list("nutriment" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Inari_maki
-	name = "Inari Makiroll"
+	name = "inari makiroll"
 	desc = "A large unsliced roll of Inari Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Inari_maki"
@@ -198,7 +198,7 @@
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/sushi_Inari
-	name = "Inari Sushi"
+	name = "inari sushi"
 	desc = "A piece of fried tofu stuffed with rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Inari"
@@ -206,7 +206,7 @@
 	list_reagents = list("nutriment" = 2)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Masago_maki
-	name = "Masago Makiroll"
+	name = "masago makiroll"
 	desc = "A large unsliced roll of Masago Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Masago_maki"
@@ -216,7 +216,7 @@
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 
 /obj/item/reagent_containers/food/snacks/sushi_Masago
-	name = "Masago Sushi"
+	name = "masago sushi"
 	desc = "A simple sushi consisting of goldfish roe."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Masago"
@@ -224,7 +224,7 @@
 	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Tobiko_maki
-	name = "Tobiko Makiroll"
+	name = "tobiko makiroll"
 	desc = "A large unsliced roll of Tobkio Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tobiko_maki"
@@ -234,7 +234,7 @@
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 
 /obj/item/reagent_containers/food/snacks/sushi_Tobiko
-	name = "Tobiko Sushi"
+	name = "tobiko sushi"
 	desc = "A simple sushi consisting of shark roe."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Masago"
@@ -242,7 +242,7 @@
 	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/TobikoEgg_maki
-	name = "Tobiko and Egg Makiroll"
+	name = "tobiko and egg makiroll"
 	desc = "A large unsliced roll of Tobkio and Egg Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "TobikoEgg_maki"
@@ -252,7 +252,7 @@
 	list_reagents = list("nutriment" = 8, "protein" = 4)
 
 /obj/item/reagent_containers/food/snacks/sushi_TobikoEgg
-	name = "Tobiko and Egg Sushi"
+	name = "tobiko and egg sushi"
 	desc = "A sushi consisting of shark roe and an egg."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_TobikoEgg"
@@ -260,7 +260,7 @@
 	list_reagents = list("nutriment" = 2, "protein" = 1)
 
 /obj/item/reagent_containers/food/snacks/sliceable/Tai_maki
-	name = "Tai Makiroll"
+	name = "tai makiroll"
 	desc = "A large unsliced roll of Tai Sushi."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "Tai_maki"
@@ -270,7 +270,7 @@
 	list_reagents = list("nutriment" = 8)
 
 /obj/item/reagent_containers/food/snacks/sushi_Tai
-	name = "Tai Sushi"
+	name = "tai sushi"
 	desc = "A simple sushi consisting of catfish and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Tai"
@@ -278,7 +278,7 @@
 	list_reagents = list("nutriment" = 2)
 
 /obj/item/reagent_containers/food/snacks/sushi_Unagi
-	name = "Unagi Sushi"
+	name = "unagi sushi"
 	desc = "A simple sushi consisting of eel and rice."
 	icon = 'icons/obj/food/seafood.dmi'
 	icon_state = "sushi_Hokki"

--- a/code/modules/food_and_drinks/food/foods/side_dishes.dm
+++ b/code/modules/food_and_drinks/food/foods/side_dishes.dm
@@ -74,7 +74,7 @@
 	list_reagents = list("nutriment" = 5, "gravy" = 5, "mashedpotatoes" = 10, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/stuffing
-	name = "Stuffing"
+	name = "stuffing"
 	desc = "Moist, peppery breadcrumbs for filling the body cavities of dead birds. Dig in!"
 	icon_state = "stuffing"
 	filling_color = "#C9AC83"
@@ -88,7 +88,7 @@
 	list_reagents = list("nutriment" = 6)
 
 /obj/item/reagent_containers/food/snacks/boiledrice
-	name = "Boiled Rice"
+	name = "boiled rice"
 	desc = "A boring dish of boring rice."
 	icon_state = "boiledrice"
 	trash = /obj/item/trash/snack_bowl

--- a/code/modules/food_and_drinks/food/foods/soups.dm
+++ b/code/modules/food_and_drinks/food/foods/soups.dm
@@ -4,7 +4,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/meatballsoup
-	name = "Meatball soup"
+	name = "meatball soup"
 	desc = "You've got balls kid, BALLS!"
 	icon_state = "meatballsoup"
 	trash = /obj/item/trash/snack_bowl
@@ -21,7 +21,7 @@
 	list_reagents = list("nutriment" = 5, "slimejelly" = 5, "water" = 5, "vitamin" = 4)
 
 /obj/item/reagent_containers/food/snacks/bloodsoup
-	name = "Tomato soup"
+	name = "tomato soup"
 	desc = "Smells like copper."
 	icon_state = "tomatosoup"
 	filling_color = "#FF0000"
@@ -29,7 +29,7 @@
 	list_reagents = list("nutriment" = 2, "blood" = 10, "water" = 5, "vitamin" = 4)
 
 /obj/item/reagent_containers/food/snacks/clownstears
-	name = "Clown's Tears"
+	name = "clown's tears"
 	desc = "Not very funny."
 	icon_state = "clownstears"
 	filling_color = "#C4FBFF"
@@ -37,7 +37,7 @@
 	list_reagents = list("nutriment" = 4, "banana" = 5, "water" = 5, "vitamin" = 8)
 
 /obj/item/reagent_containers/food/snacks/vegetablesoup
-	name = "Vegetable soup"
+	name = "vegetable soup"
 	desc = "A true vegan meal." //TODO
 	icon_state = "vegetablesoup"
 	trash = /obj/item/trash/snack_bowl
@@ -46,8 +46,8 @@
 	list_reagents = list("nutriment" = 8, "water" = 5, "vitamin" = 4)
 
 /obj/item/reagent_containers/food/snacks/nettlesoup
-	name = "Nettle soup"
-	desc = "To think, the botanist would've beat you to death with one of these."
+	name = "nettle soup"
+	desc = "To think, the botanist would've beaten you to death with one of these."
 	icon_state = "nettlesoup"
 	trash = /obj/item/trash/snack_bowl
 	filling_color = "#AFC4B5"
@@ -68,7 +68,7 @@
 	reagents.add_reagent("[extra_reagent]", 5)
 
 /obj/item/reagent_containers/food/snacks/wishsoup
-	name = "Wish Soup"
+	name = "wish soup"
 	desc = "I wish this was soup."
 	icon_state = "wishsoup"
 	trash = /obj/item/trash/snack_bowl
@@ -84,7 +84,7 @@
 		reagents.add_reagent("vitamin", 1)
 
 /obj/item/reagent_containers/food/snacks/tomatosoup
-	name = "Tomato Soup"
+	name = "tomato soup"
 	desc = "Drinking this feels like being a vampire! A tomato vampire..."
 	icon_state = "tomatosoup"
 	trash = /obj/item/trash/snack_bowl
@@ -93,7 +93,7 @@
 	list_reagents = list("nutriment" = 5, "tomatojuice" = 10, "vitamin" = 3)
 
 /obj/item/reagent_containers/food/snacks/milosoup
-	name = "Milosoup"
+	name = "milosoup"
 	desc = "The universe's best soup! Yum!!!"
 	icon_state = "milosoup"
 	trash = /obj/item/trash/snack_bowl
@@ -128,7 +128,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/stew
-	name = "Stew"
+	name = "stew"
 	desc = "A nice and warm stew. Healthy and strong."
 	icon_state = "stew"
 	filling_color = "#9E673A"
@@ -136,7 +136,7 @@
 	list_reagents = list("nutriment" = 10, "oculine" = 5, "tomatojuice" = 5, "vitamin" = 5)
 
 /obj/item/reagent_containers/food/snacks/stewedsoymeat
-	name = "Stewed Soy Meat"
+	name = "stewed soy meat"
 	desc = "Even non-vegetarians will LOVE this!"
 	icon_state = "stewedsoymeat"
 	trash = /obj/item/trash/plate
@@ -148,7 +148,7 @@
 //////////////////////
 
 /obj/item/reagent_containers/food/snacks/hotchili
-	name = "Hot Chili"
+	name = "hot chili"
 	desc = "A five alarm Texan Chili!"
 	icon_state = "hotchili"
 	trash = /obj/item/trash/snack_bowl
@@ -157,7 +157,7 @@
 	list_reagents = list("nutriment" = 5, "capsaicin" = 1, "tomatojuice" = 2, "vitamin" = 2)
 
 /obj/item/reagent_containers/food/snacks/coldchili
-	name = "Cold Chili"
+	name = "cold chili"
 	desc = "This slush is barely a liquid!"
 	icon_state = "coldchili"
 	filling_color = "#2B00FF"

--- a/code/modules/food_and_drinks/food/foods/soups.dm
+++ b/code/modules/food_and_drinks/food/foods/soups.dm
@@ -68,7 +68,7 @@
 	reagents.add_reagent("[extra_reagent]", 5)
 
 /obj/item/reagent_containers/food/snacks/wishsoup
-	name = "wish soup"
+	name = "Wish Soup"
 	desc = "I wish this was soup."
 	icon_state = "wishsoup"
 	trash = /obj/item/trash/snack_bowl

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -264,7 +264,7 @@
 
 
 /obj/item/reagent_containers/food/snacks/badrecipe
-	name = "Burned mess"
+	name = "burned mess"
 	desc = "Someone should be demoted from chef for this."
 	icon_state = "badrecipe"
 	filling_color = "#211F02"


### PR DESCRIPTION
**What does this PR do:**
Polishes/modifies a few food item descriptions and standardizes casing across all food items. All food now has lowercase except in cases where a brand-name or a normally capitalized word is used (IE: Cuban carp). Fixes a couple strange grammatical constructions as well.

**Changelog:**
:cl:
tweak: Food descriptions/casing.
/:cl:

