### PR TITLE
Makes cult shackles dissapear when removed

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -419,4 +419,5 @@
 /obj/item/restraints/handcuffs/energy/cult/used/dropped(mob/user)
 	user.visible_message("<span class='danger'>[user]'s shackles shatter in a discharge of dark magic!</span>", \
 							"<span class='userdanger'>Your [src] shatters in a discharge of dark magic!</span>")
+	qdel(src)
 	. = ..()


### PR DESCRIPTION
Fixes #10799 

**What does this PR do:**
Stops cult shackles from appearing on the ground when taken off.

**Changelog:**
:cl: Dovydas12345
fix: Fixes cult shackles appearing on the ground when removed
/:cl:

