### PR TITLE
Make wallturrets shootable

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -1048,7 +1048,8 @@ var/list/turret_icons
 	return 10 //Syndicate turrets shoot everything not in their faction
 
 /obj/machinery/porta_turret/syndicate/pod
-	health = 40
+	name = "machine gun turret (4.6x30mm)"
+	desc = "Syndicate exterior defense turret chambered for 4.6x30mm rounds. Designed to be fitted to assault pods, it uses low calliber bullets to save space."
 	projectile = /obj/item/projectile/bullet/weakbullet3
 	eprojectile = /obj/item/projectile/bullet/weakbullet3
 
@@ -1069,10 +1070,3 @@ var/list/turret_icons
 	desc = "Syndicate 40mm grenade launcher defense turret. If you've had this much time to look at it, you're probably already dead."
 	projectile = /obj/item/projectile/bullet/a40mm
 	eprojectile = /obj/item/projectile/bullet/a40mm
-
-/obj/machinery/porta_turret/syndicate/assault_pod
-	name = "machine gun turret (4.6x30mm)"
-	desc = "Syndicate exterior defense turret chambered for 4.6x30mm rounds. Designed to be fitted to assault pods, it uses low calliber bullets to save space."
-	health = 100
-	projectile = /obj/item/projectile/bullet/weakbullet3
-	eprojectile = /obj/item/projectile/bullet/weakbullet3

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -88,16 +88,15 @@
 		our_rpd.delete_all_pipes(user, src)
 
 /turf/bullet_act(var/obj/item/projectile/Proj)
+	var/obj/machinery/porta_turret/T = locate(/obj/machinery/porta_turret) in contents
+	if(T && T.health > 0)
+		T.bullet_act(Proj)
+		return FALSE
 	if(istype(Proj ,/obj/item/projectile/beam/pulse))
 		src.ex_act(2)
-	..()
-	return 0
-
-/turf/bullet_act(var/obj/item/projectile/Proj)
 	if(istype(Proj ,/obj/item/projectile/bullet/gyro))
 		explosion(src, -1, 0, 2)
 	..()
-	return 0
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 	if(!mover)


### PR DESCRIPTION
Currently turrets on walls cannot be shot with guns because the turf takes the hit.

Shooting a wall, shuttle wall, etc, will now redirect the projectile to the turret, if there is one on the wall.

To compensate for this fairly significant nerf, the syndicate assault pod turrets' health was doubled from 40 to 80. I'm not sure exactly how turret damage works but the turrets died in a single laser shot... So yeah. Now they die in two.

🆑
tweak: Turrets on a wall can now be shot with guns. (syndicate shuttle/assault pod)
tweak: Syndicate assault pod turrets are tougher to compensate for the above.
/🆑