### PR TITLE
Adds new space ruin, crashed wizard shuttle

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -49,14 +49,14 @@
 "aW" = (/obj/structure/grille,/obj/structure/window/full/reinforced,/turf/simulated/floor/wood{tag = "icon-wood-broken6"; icon_state = "wood-broken6"},/area/ruin/unpowered)
 "aX" = (/obj/structure/grille,/obj/structure/window/full/reinforced,/turf/simulated/floor/wood,/area/ruin/unpowered)
 "aY" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/plating,/area/ruin/unpowered)
-"aZ" = (/obj/effect/spawner/random_spawners/blood_maybe,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aZ" = (/obj/effect/decal/cleanable/blood/old,/turf/simulated/floor/plating,/area/ruin/unpowered)
 "ba" = (/obj/structure/kitchenspike,/turf/simulated/floor/plasteel{dir = 1; icon_state = "chapel"},/area/ruin/unpowered)
 "bb" = (/obj/structure/chair,/turf/simulated/floor/plasteel{dir = 4; icon_state = "chapel"},/area/ruin/unpowered)
 "bc" = (/obj/effect/decal/remains/human,/obj/item/reagent_containers/food/snacks/meat/monkey,/turf/simulated/floor/plating,/area/ruin/unpowered)
 "bd" = (/obj/structure/showcase,/turf/simulated/floor/plasteel{dir = 1; icon_state = "chapel"},/area/ruin/unpowered)
-"be" = (/obj/effect/spawner/random_spawners/blood_often,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"be" = (/obj/structure/grille{density = 0; icon_state = "brokengrille"},/obj/effect/decal/cleanable/blood/old,/turf/simulated/floor/wood,/area/ruin/unpowered)
 "bf" = (/obj/item/shard{icon_state = "medium"},/turf/simulated/floor/plating,/area/ruin/unpowered)
-"bg" = (/obj/effect/spawner/random_spawners/blood_maybe,/obj/structure/grille{density = 0; icon_state = "brokengrille"},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"bg" = (/obj/item/reagent_containers/food/snacks/meat/monkey,/turf/simulated/floor/plating,/area/ruin/unpowered)
 "bh" = (/obj/machinery/door/window,/turf/simulated/floor/wood,/area/ruin/unpowered)
 "bi" = (/turf/simulated/floor/plasteel{dir = 8; icon_state = "chapel"},/area/ruin/unpowered)
 "bj" = (/obj/item/reagent_containers/food/snacks/meat/human,/obj/effect/decal/cleanable/blood/old,/turf/simulated/floor/plasteel{icon_state = "chapel"},/area/ruin/unpowered)
@@ -67,7 +67,6 @@
 "bo" = (/turf/simulated/floor/plasteel{dir = 4; icon_state = "chapel"},/area/ruin/unpowered)
 "bp" = (/obj/structure/rack,/obj/item/twohanded/staff,/turf/simulated/floor/plasteel{dir = 4; icon_state = "chapel"},/area/ruin/unpowered)
 "bq" = (/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/ruin/unpowered)
-"br" = (/obj/effect/spawner/random_spawners/blood_maybe,/obj/item/reagent_containers/food/snacks/meat/monkey,/turf/simulated/floor/plating,/area/ruin/unpowered)
 "bs" = (/turf/simulated/floor/plasteel{icon_state = "chapel"},/area/ruin/unpowered)
 "bt" = (/obj/structure/showcase,/turf/simulated/floor/plasteel{dir = 8; icon_state = "chapel"},/area/ruin/unpowered)
 "bu" = (/obj/structure/rack,/obj/item/twohanded/staff/broom,/turf/simulated/floor/plasteel{icon_state = "chapel"},/area/ruin/unpowered)
@@ -114,9 +113,9 @@ aaaaaaaaaeaNaOaCaCaGaCaCaPaQaeaaaaaaaaaa
 aaaaaaaeaeaRaCaCaAaCaCaCaSaTaeaeaaaaaaaa
 aaaaaeaeaeaUaUaUaVaCaVaWaXaXaeaeaeaaaaaa
 aaaaaeaYbcaZaZaUaCaCaCaXbabbbdbCaeaaaaaa
-aaaaaebebeaSbfbgaCaCaCbhbibjbEbkaeaaaaaa
+aaaaaeaSaSaSbfbeaCaCaCbhbibjbEbkaeaaaaaa
 aaaaaeblaSaZaSaUbmaCaCaXbnbobnbpaeaaaaaa
-aaaaaebqbraZaSaUaCaCaCaXbibsbtbuaeaaaaaa
+aaaaaebqbgaSaSaUaCaCaCaXbibsbtbuaeaaaaaa
 aaaaaeaeaeaeaeaeaebvaeaeaeaeaeaeaeaaaaaa
 aaaaaebwbxbBbxaSbybIbyaSbxbBbxbzaeaaaaaa
 aaaaaebAbJbKbLaSbJbKbLaSbJbKbLbPaeaaaaaa

--- a/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/wizardcrash.dmm
@@ -1,0 +1,132 @@
+"aa" = (/turf/space,/area/space)
+"ab" = (/turf/simulated/floor/plating/airless/asteroid,/area/ruin/unpowered)
+"ac" = (/turf/simulated/mineral,/area/ruin/unpowered)
+"ad" = (/obj/structure/grille{density = 0; icon_state = "brokengrille"},/obj/item/shard{icon_state = "small"},/turf/simulated/floor/wood{tag = "icon-wood-broken3"; icon_state = "wood-broken3"},/area/ruin/unpowered)
+"ae" = (/turf/simulated/wall/mineral/titanium,/area/ruin/unpowered)
+"af" = (/obj/structure/computerframe,/turf/simulated/floor/wood{tag = "icon-wood-broken3"; icon_state = "wood-broken3"},/area/ruin/unpowered)
+"ag" = (/turf/simulated/floor/wood{tag = "icon-wood-broken7"; icon_state = "wood-broken7"},/area/ruin/unpowered)
+"ah" = (/obj/structure/grille{density = 0; icon_state = "brokengrille"},/obj/item/shard,/turf/simulated/floor/wood{tag = "icon-wood-broken3"; icon_state = "wood-broken3"},/area/ruin/unpowered)
+"ai" = (/turf/simulated/floor/wood{broken = 1; icon_state = "wood-broken"},/area/ruin/unpowered)
+"aj" = (/obj/structure/chair{dir = 1},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"ak" = (/obj/item/shard,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"al" = (/obj/structure/shuttle/window,/obj/structure/grille,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"am" = (/obj/structure/table/wood,/obj/item/dice/d20,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"an" = (/obj/item/shard{icon_state = "medium"},/obj/structure/chair/wood/normal{dir = 8},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"ao" = (/obj/item/flag/wiz,/obj/machinery/light{dir = 1; in_use = 1},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"ap" = (/obj/effect/decal/cleanable/blood/oil,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aq" = (/obj/item/clothing/suit/wizrobe,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"ar" = (/obj/item/flag/wiz,/obj/machinery/light{dir = 1; in_use = 1},/turf/simulated/floor/wood{tag = "icon-wood-broken3"; icon_state = "wood-broken3"},/area/ruin/unpowered)
+"as" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/carpet,/area/ruin/unpowered)
+"at" = (/obj/item/bedsheet/wiz,/obj/structure/bed,/turf/simulated/floor/carpet,/area/ruin/unpowered)
+"au" = (/obj/structure/table/wood,/obj/item/pen,/obj/item/paper/fluff/ruins/wizardcrash,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"av" = (/obj/structure/chair/wood/normal{dir = 8},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aw" = (/obj/item/shard{icon_state = "small"},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"ax" = (/turf/simulated/floor/wood{tag = "icon-wood-broken3"; icon_state = "wood-broken3"},/area/ruin/unpowered)
+"ay" = (/obj/effect/decal/remains/robot,/obj/item/clothing/head/wizard,/obj/effect/decal/cleanable/blood/oil,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"az" = (/obj/item/spellbook/oneuse/charge{desc = "For the technology-hating wizard."; spell = /obj/effect/proc_holder/spell/targeted/emplosion/disable_tech; spellname = "Disable Technology"; used = 1},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aA" = (/turf/simulated/floor/wood{tag = "icon-wood-broken6"; icon_state = "wood-broken6"},/area/ruin/unpowered)
+"aB" = (/turf/simulated/floor/carpet,/area/ruin/unpowered)
+"aC" = (/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aD" = (/obj/structure/closet{icon_closed = "cabinet_closed"; icon_opened = "cabinet_open"; icon_state = "cabinet_closed"},/obj/item/storage/backpack/satchel,/obj/item/lighter/zippo,/turf/simulated/floor/carpet,/area/ruin/unpowered)
+"aE" = (/obj/structure/bookcase,/obj/item/book/codex_gigas,/obj/item/book/manual/hydroponics_pod_people,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aF" = (/obj/structure/table/wood,/turf/simulated/floor/wood{tag = "icon-wood-broken6"; icon_state = "wood-broken6"},/area/ruin/unpowered)
+"aG" = (/obj/structure/table/wood,/obj/item/candle/eternal,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aH" = (/obj/structure/chair/wood/normal{dir = 4},/turf/simulated/floor/carpet,/area/ruin/unpowered)
+"aI" = (/obj/structure/table/wood,/obj/item/toy/character/wizard,/obj/item/paper/spells,/turf/simulated/floor/carpet,/area/ruin/unpowered)
+"aJ" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aK" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/window/westleft,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aL" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aM" = (/obj/machinery/door/airlock/external,/turf/space,/area/ruin/unpowered)
+"aN" = (/obj/structure/bookcase,/obj/item/book/manual/barman_recipes,/obj/item/book/manual/engineering_hacking,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aO" = (/obj/item/storage/bag/books,/obj/structure/table/wood,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aP" = (/obj/item/reagent_containers/food/drinks/oilcan,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aQ" = (/obj/machinery/recharge_station,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aR" = (/obj/machinery/light{dir = 8},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aS" = (/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aT" = (/obj/machinery/light{icon_state = "tube1"; dir = 4},/obj/structure/reagent_dispensers/oil,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aU" = (/obj/structure/window/full/reinforced,/obj/structure/grille,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aV" = (/obj/item/flag/wiz,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aW" = (/obj/structure/grille,/obj/structure/window/full/reinforced,/turf/simulated/floor/wood{tag = "icon-wood-broken6"; icon_state = "wood-broken6"},/area/ruin/unpowered)
+"aX" = (/obj/structure/grille,/obj/structure/window/full/reinforced,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"aY" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/plating,/area/ruin/unpowered)
+"aZ" = (/obj/effect/spawner/random_spawners/blood_maybe,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"ba" = (/obj/structure/kitchenspike,/turf/simulated/floor/plasteel{dir = 1; icon_state = "chapel"},/area/ruin/unpowered)
+"bb" = (/obj/structure/chair,/turf/simulated/floor/plasteel{dir = 4; icon_state = "chapel"},/area/ruin/unpowered)
+"bc" = (/obj/effect/decal/remains/human,/obj/item/reagent_containers/food/snacks/meat/monkey,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bd" = (/obj/structure/showcase,/turf/simulated/floor/plasteel{dir = 1; icon_state = "chapel"},/area/ruin/unpowered)
+"be" = (/obj/effect/spawner/random_spawners/blood_often,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bf" = (/obj/item/shard{icon_state = "medium"},/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bg" = (/obj/effect/spawner/random_spawners/blood_maybe,/obj/structure/grille{density = 0; icon_state = "brokengrille"},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"bh" = (/obj/machinery/door/window,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"bi" = (/turf/simulated/floor/plasteel{dir = 8; icon_state = "chapel"},/area/ruin/unpowered)
+"bj" = (/obj/item/reagent_containers/food/snacks/meat/human,/obj/effect/decal/cleanable/blood/old,/turf/simulated/floor/plasteel{icon_state = "chapel"},/area/ruin/unpowered)
+"bk" = (/obj/structure/rack,/turf/simulated/floor/plasteel{icon_state = "chapel"},/area/ruin/unpowered)
+"bl" = (/mob/living/simple_animal/hostile/creature{health = 150; name = "Experiment 17e"},/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bm" = (/obj/item/shard{icon_state = "medium"},/turf/simulated/floor/wood,/area/ruin/unpowered)
+"bn" = (/turf/simulated/floor/plasteel{dir = 1; icon_state = "chapel"},/area/ruin/unpowered)
+"bo" = (/turf/simulated/floor/plasteel{dir = 4; icon_state = "chapel"},/area/ruin/unpowered)
+"bp" = (/obj/structure/rack,/obj/item/twohanded/staff,/turf/simulated/floor/plasteel{dir = 4; icon_state = "chapel"},/area/ruin/unpowered)
+"bq" = (/obj/effect/decal/remains/human,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"br" = (/obj/effect/spawner/random_spawners/blood_maybe,/obj/item/reagent_containers/food/snacks/meat/monkey,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bs" = (/turf/simulated/floor/plasteel{icon_state = "chapel"},/area/ruin/unpowered)
+"bt" = (/obj/structure/showcase,/turf/simulated/floor/plasteel{dir = 8; icon_state = "chapel"},/area/ruin/unpowered)
+"bu" = (/obj/structure/rack,/obj/item/twohanded/staff/broom,/turf/simulated/floor/plasteel{icon_state = "chapel"},/area/ruin/unpowered)
+"bv" = (/obj/machinery/door/airlock/maintenance_hatch,/turf/simulated/floor/wood,/area/ruin/unpowered)
+"bw" = (/obj/item/storage/toolbox/electrical,/obj/structure/table,/obj/item/clothing/gloves/color/yellow,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bx" = (/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"by" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"bz" = (/mob/living/simple_animal/hostile/mimic/crate,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bA" = (/obj/structure/table,/obj/item/wrench,/obj/item/weldingtool,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bB" = (/obj/machinery/light{dir = 1},/obj/structure/window/reinforced,/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"bC" = (/obj/structure/rack,/obj/item/kitchen/knife/ritual,/obj/effect/decal/cleanable/blood/old,/obj/machinery/light{dir = 1},/turf/simulated/floor/plasteel{dir = 4; icon_state = "chapel"},/area/ruin/unpowered)
+"bD" = (/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bE" = (/obj/effect/decal/cleanable/blood/drip,/turf/simulated/floor/plasteel{dir = 8; icon_state = "chapel"},/area/ruin/unpowered)
+"bF" = (/obj/structure/shuttle/engine/heater,/obj/structure/window/reinforced{dir = 1; layer = 2.9},/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"bG" = (/obj/structure/shuttle/engine/propulsion,/turf/space,/area/ruin/unpowered)
+"bH" = (/turf/simulated/wall/mineral/titanium,/area/space)
+"bI" = (/obj/structure/window/reinforced,/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"bJ" = (/obj/structure/window/reinforced{dir = 4; pixel_x = 0},/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"bK" = (/obj/singularity/academy,/turf/space,/area/ruin/unpowered)
+"bL" = (/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"bM" = (/obj/structure/window/reinforced{dir = 1; layer = 2.9},/turf/simulated/floor/mineral/plasma,/area/ruin/unpowered)
+"bN" = (/obj/effect/spawner/lootdrop/wizardcrash,/obj/structure/closet/crate{icon_state = "crateopen"; opened = 1},/turf/simulated/floor/plating,/area/ruin/unpowered)
+"bO" = (/obj/structure/shuttle/window,/obj/structure/grille,/turf/space,/area/ruin/unpowered)
+"bP" = (/obj/item/stack/sheet/mineral/plasma,/obj/item/stack/sheet/mineral/plasma,/obj/structure/table,/turf/simulated/floor/plating,/area/ruin/unpowered)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaababacacacacacaaaaaaaaaaaaaa
+aaaaaaaaacacacacacacacacacabaaaaaaaaaaaa
+aaaaaaaaacacacacacacacacacababacaaaaaaaa
+aaaaaaacacacacacacacacacacacacacacaaaaaa
+aaaaabacacacacacacacacacacacacacacaaaaaa
+aaaaabacacacacacacacacacacacacacacaaaaaa
+aaaaacacacacacacacadaeacacacacacaaaaaaaa
+aaaaacacacacacaeaCafagaeacacacaaaaaaaaaa
+aaaaaaacaeaeahaeaiajakaealaeaeaaaaaaaaaa
+aaaaaaaaaeamanaoapaqaCarasataeaaaaaaaaaa
+aaaaaaaaalauavawaxayazaAasaBalaaaaaaaaaa
+aaaaaaaaaeaCaCaCaCaCaCaCaBaDaeaaaaaaaaaa
+aaaaaaaaaeaEaFaCaCaGaCaCaHaIaeaaaaaaaaaa
+aaaaaaaabOaCaCaCaGaJaGaCaKaLaMaaaaaaaaaa
+aaaaaaaaaeaNaOaCaCaGaCaCaPaQaeaaaaaaaaaa
+aaaaaaaeaeaRaCaCaAaCaCaCaSaTaeaeaaaaaaaa
+aaaaaeaeaeaUaUaUaVaCaVaWaXaXaeaeaeaaaaaa
+aaaaaeaYbcaZaZaUaCaCaCaXbabbbdbCaeaaaaaa
+aaaaaebebeaSbfbgaCaCaCbhbibjbEbkaeaaaaaa
+aaaaaeblaSaZaSaUbmaCaCaXbnbobnbpaeaaaaaa
+aaaaaebqbraZaSaUaCaCaCaXbibsbtbuaeaaaaaa
+aaaaaeaeaeaeaeaeaebvaeaeaeaeaeaeaeaaaaaa
+aaaaaebwbxbBbxaSbybIbyaSbxbBbxbzaeaaaaaa
+aaaaaebAbJbKbLaSbJbKbLaSbJbKbLbPaeaaaaaa
+aaaaaebDbxbMbxaSbxbMbxaSbxbMbxbNaeaaaaaa
+aaaabHaebFbFbFaebFbFbFaebFbFbFaebHaaaaaa
+aaaaaaaebGbGbGaebGbGbGaebGbGbGaeaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -175,3 +175,10 @@
 	description = "The crew of a space station awaken one hundred years after a crisis. Awaking to a derelict space station on the verge of collapse, and a hostile force of invading \
 	hivebots. Can the surviving crew overcome the odds and survive and rebuild, or will the cold embrace of the stars become their new home?"
 	cost = 2
+
+/datum/map_template/ruin/space/wizardcrash
+	id = "wizardcrash"
+	suffix = "wizardcrash.dmm"
+	name = "Crashed Wizard Shuttle"
+	description = "A shuttle of the Wizard Federation, sent out to crush some wandless scum. Unfortunately, the pilot suffered a magic-related accident and the shuttle crashed into a nearby asteroid."
+	cost = 2

--- a/code/modules/awaymissions/mission_code/ruins/wizardcrash.dm
+++ b/code/modules/awaymissions/mission_code/ruins/wizardcrash.dm
@@ -1,0 +1,17 @@
+//stuff for the crashed wizard shuttle space ruin (wizardcrash.dmm)
+
+/obj/item/paper/fluff/ruins/wizardcrash
+	name = "Mission Briefing"
+	info = "To the Magnificent Z.A.P.<BR>A small mining base has been created within our territory by wandless scum. Send them a message from the wizard federation they will not forget. I know your kind is rather fragile, but a group of lightly armed miners should not pose any threat to you at all. Just be warned they have a security cyborg for self defence, you might want to tune your spells to that threat. I look forward to hearing of your success.<BR>Grand Magus Abra the Wonderous"
+
+
+/obj/effect/spawner/lootdrop/wizardcrash
+	loot = list(
+				/obj/item/guardiancreator = 1,   //jackpot. 
+				/obj/item/spellbook/oneuse/knock = 1,    //tresspassing charges incoming
+				/obj/item/gun/magic/wand/resurrection = 1,   //medbay's best friend
+				/obj/item/spellbook/oneuse/charge = 20,  //and now for less useful stuff to dilute the good loot chances
+				/obj/item/spellbook/oneuse/summonitem = 20,
+				/obj/item/spellbook/oneuse/forcewall = 10,
+				/obj/item/soulstone = 15      //spooky wizard stuff
+				)

--- a/paradise.dme
+++ b/paradise.dme
@@ -1247,6 +1247,7 @@
 #include "code\modules\awaymissions\mission_code\UO71-terrorspiders.dm"
 #include "code\modules\awaymissions\mission_code\wildwest.dm"
 #include "code\modules\awaymissions\mission_code\ruins\oldstation.dm"
+#include "code\modules\awaymissions\mission_code\ruins\wizardcrash.dm"
 #include "code\modules\buildmode\bm_mode.dm"
 #include "code\modules\buildmode\buildmode.dm"
 #include "code\modules\buildmode\buttons.dm"


### PR DESCRIPTION
**What does this PR do:**
As I was reading through the wanted features list on the forums, I saw more space ruins are wanted. Since I've been interested in mapping, I decided to start adding some. Which brings us to this PR, which adds a new space ruin, a crashed wizard shuttle. The wizard was sent out on a mission by the wizard federation to terrorize some poor people, but a spellcasting accident spelled his doom.

**If you want to discover the ruin without spoilers, stop reading now.**

The shuttle's pilot was an IPC wizard, the Magnificent Z.A.P. Sadly, he bought the emp spell without thinking and thus fried himself. His shuttle, inspired by the wizard's den, offers some potential rewards for daring explorers, though.

It is guarded by a creature and a crate mimic. It also contains some wizard gateway singularities (They do not grow and they do **not** move. There is no risk of them ending up at the station, unless serious shenanigans are involved)

The shuttle also contains some valuable loot (or the chance of it). I expect this to be the a tad controversial, so let me list out the main loot. There is a loot spawner behind the two monsters guarding it that spawns a random, wizard-themed item. It spawns one item, chosen at random:

Wizard Tarot Deck (Guardian Creator) 1 in 68 chance
Spellbook of Knock 1 in 68
Wand of healing 1 in 68 
Spellbook of Charge 20 in 68
Spellbook of Summon Item 20 in 68
Spellbook of Force Wall 10 in 68
Soulshard 15 in 68

Miners can get guardians just form mining so I figured a very small chance to get a wizard guardian is an appropriate, rare reward. Knock is a non-destructive spell that is nonetheless very desirable. But abusing it will get you arrested. And the wand of healing has 3 charges total. It offers resurrection (which SR can also grant) and full heals (which hivelord remains can grant). ~~something something make death more meaningful~~

Keep in mind that there is just a chance to spawn a space ruin, then a chance to actually find it in space, and **then** a 1 in 68 chance for the great loot, after a fight that will be very challenging for unprepared explorers.

Sidenote, other (somewhat) notable loot includes:
sacrificial dagger, insulated gloves, fancy zippo, some plasma, real wizard outfit (they have pretty decent armor)

**Images of sprite/map changes (IF APPLICABLE):**

![capture2](https://user-images.githubusercontent.com/32099540/52515032-4b420a80-2c17-11e9-83c5-32832f45ef2e.PNG)
![capture1](https://user-images.githubusercontent.com/32099540/52515373-f43e3480-2c1a-11e9-92b2-d98cf5e9f74e.PNG)


**Changelog:**
:cl:
add: New space ruin, the crashed wizard shuttle. Rumored to contain fabulous magical treasures.
/:cl:

