### PR TITLE
Pulls Back Some Medical Powercreep

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -14,18 +14,14 @@
 	dir = WEST
 	var/orient = "LEFT" // "RIGHT" changes the dir suffix to "-r"
 	var/mob/living/carbon/human/occupant = null
-	var/possible_chems = list(list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine"),
-							  list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine", "oculine"),
-							  list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine", "oculine", "charcoal", "mutadone", "mannitol"),
-							  list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine", "oculine", "charcoal", "mutadone", "mannitol", "pen_acid", "omnizine"))
-	var/emergency_chems = list("epinephrine") // Desnowflaking
+	var/possible_chems = list("ephedrine", "salglu_solution", "salbutamol", "charcoal")
+	var/emergency_chems = list("ephedrine") // Desnowflaking
 	var/amounts = list(5, 10)
 	var/obj/item/reagent_containers/glass/beaker = null
 	var/filtering = 0
 	var/max_chem
 	var/initial_bin_rating = 1
 	var/min_health = -25
-	var/injection_chems = list()
 	var/controls_inside = FALSE
 	idle_power_usage = 1250
 	active_power_usage = 2500
@@ -68,13 +64,9 @@
 
 /obj/machinery/sleeper/RefreshParts()
 	var/E
-	var/I
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		E += B.rating
-	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		I += M.rating
 
-	injection_chems = possible_chems[I]
 	max_chem = E * 20
 	min_health = -E * 25
 
@@ -216,7 +208,7 @@
 			data["beakerFreeSpace"] = 0
 
 	var/chemicals[0]
-	for(var/re in injection_chems)
+	for(var/re in possible_chems)
 		var/datum/reagent/temp = GLOB.chemical_reagents_list[re]
 		if(temp)
 			var/reagent_amount = 0
@@ -419,7 +411,7 @@
 		A.forceMove(loc)
 
 /obj/machinery/sleeper/proc/inject_chemical(mob/living/user as mob, chemical, amount)
-	if(!(chemical in injection_chems))
+	if(!(chemical in possible_chems))
 		to_chat(user, "<span class='notice'>The sleeper does not offer that chemical!</span>")
 		return
 
@@ -559,6 +551,8 @@
 /obj/machinery/sleeper/syndie
 	icon_state = "sleeper_s-open"
 	base_icon = "sleeper_s"
+	possible_chems = list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine")
+	emergency_chems = list("epinephrine")
 	controls_inside = TRUE
 
 	light_color = LIGHT_COLOR_DARKRED

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -377,16 +377,10 @@
 			occupant.Sleeping(max(5/efficiency, (1/occupant.bodytemperature)*2000/efficiency))
 			occupant.Paralyse(max(5/efficiency, (1/occupant.bodytemperature)*3000/efficiency))
 			if(air_contents.oxygen > 2)
-				if(occupant.getOxyLoss()) occupant.adjustOxyLoss(-1)
+				if(occupant.getOxyLoss())
+					occupant.adjustOxyLoss(-10)
 			else
-				occupant.adjustOxyLoss(-1)
-			//severe damage should heal waaay slower without proper chemicals
-			if(occupant.bodytemperature < 225)
-				if(occupant.getToxLoss())
-					occupant.adjustToxLoss(max(-efficiency, (-20*(efficiency ** 2)) / occupant.getToxLoss()))
-				var/heal_brute = occupant.getBruteLoss() ? min(efficiency, 20*(efficiency**2) / occupant.getBruteLoss()) : 0
-				var/heal_fire = occupant.getFireLoss() ? min(efficiency, 20*(efficiency**2) / occupant.getFireLoss()) : 0
-				occupant.heal_organ_damage(heal_brute, heal_fire)
+				occupant.adjustOxyLoss(-2)
 		if(beaker && next_trans == 0)
 			var/proportion = 10 * min(1/beaker.volume, 1)
 			// Yes, this means you can get more bang for your buck with a beaker of SF vs a patch


### PR DESCRIPTION
Pulls back some of medical's powercreep.

Sleepers and cryo tubes have both been altered a bit:

- Cryotubes no longer passively heal anything other than O2 damage. O2 damage healing has been increased
  - Cryo can functionally behave as a stabilizer more effectively now, but as passive cure all that doesn't even need medicine? Gone
- Sleepers no longer gain access to a wide range of chemicals when upgraded
- Sleepers have an adjusted range of chemicals
  - Sleepers now have ephedrine, saline, salbutamol, and charcoal. Syndicate sleepers unaffected by chemical selection. This makes sleepers effective at all damage types, but at a reduced impact. Treating patients should primarily be done by what's in the vendors and what chemistry produces

:cl: Fox McCloud
tweak: Cryotubes no longer passively heal patients without chems. Effectiveness at stabilizing critical patients increased
tweak: Sleepers no longer gain additional chemicals when upgraded. Selection of chemicals altered
/:cl:
