### PR TITLE
Strange Reagent Change

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -661,10 +661,7 @@
 	return ..() | update_flags
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/M, method=TOUCH, volume)
-	if(volume < 1)
-		// gotta pay to play
-		return ..()
-	if(isanimal(M))
+	if(isanimal(M) && volume >= 1)
 		if(method == TOUCH)
 			var/mob/living/simple_animal/SM = M
 			if(SM.stat == DEAD)
@@ -672,7 +669,7 @@
 				SM.loot.Cut() //no abusing strange reagent for unlimited farming of resources
 				SM.visible_message("<span class='warning'>[M] seems to rise from the dead!</span>")
 
-	if(iscarbon(M))
+	if(iscarbon(M) && volume >= 10)
 		if(method == INGEST)
 			if(M.stat == DEAD)
 				if(M.getBruteLoss()+M.getFireLoss()+M.getCloneLoss() >= 150)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -185,7 +185,7 @@
 	name = "Strange Reagent"
 	id = "strange_reagent"
 	result = "strange_reagent"
-	required_reagents = list("uranium" = 1, "holywater" = 1, "mutagen" = 1)
+	required_reagents = list("earthsblood" = 1, "holywater" = 1, "mutagen" = 1)
 	result_amount = 1
 	mix_message = "The substance begins moving on its own somehow."
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -185,8 +185,8 @@
 	name = "Strange Reagent"
 	id = "strange_reagent"
 	result = "strange_reagent"
-	required_reagents = list("omnizine" = 1, "holywater" = 1, "mutagen" = 1)
-	result_amount = 3
+	required_reagents = list("uranium" = 1, "holywater" = 1, "mutagen" = 1)
+	result_amount = 1
 	mix_message = "The substance begins moving on its own somehow."
 
 /datum/chemical_reaction/life


### PR DESCRIPTION
**What does this PR do:**
~~This is an alternative that maintains the ability to raise NO_SCAN species but makes SR something difficult to obtain (requires mining). I am admittedly not sold that NO_SCAN should be revived (and personally in favor of #10844 by and large), but there was a lot of people going on about that so I figured I should make an alternative.~~

_To make it clear, this was an idea I've had rolling around in my head for awhile (prior to any of the recent medical reworks). Outside of being initially posted as an alternative, the underlying logic/origins of this idea are detached from the other medical PRs. If you have a concern about the changes, please direct them to me in a comment below (don't bug the maints, bug Shadey). Thanks!_

Right now SR is more or less a throw-away drug which you get a boatload of at roundstart. It not only reduces the point of the hypospray (that being a general cure-all that the CMO can use at their discretion/in emergencies) into little more than a reagent dispenser for making SR.

I also feel as though this is a reasonable change as there's a reciprocal interaction between Botany/Chemistry. Chemistry constantly helps Botany (they are more or less reliant upon them) and now, in turn, Botany can help out Chemistry.

* Strange Reagent is now a reductive reaction (90 units of reagents results in 30 units of SR)
* Strange Reagent now requires earthsblood instead of omnizine.
* Strange Reagent now has a volume floor of 10.

What does this mean?

90 units of reagents (30 Holy Water, 30 Unstable Mutagen, 30 Earthsblood) will result in 3 SR pills. Use them wisely.

**Changelog:**
:cl:
tweak: SR now needs 10 units to revive, simple mobs only need 1.
tweak: SR now requires earthsblood instead of omnizine.
tweak: SR is now a 1:2 reductive reaction.
/:cl:

