### PR TITLE
Fixes discord notify

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -59,9 +59,15 @@
 /proc/sanitize(var/t,var/list/repl_chars = null)
 	return html_encode(sanitize_simple(t,repl_chars))
 
+// Gut ANYTHING that isnt alphanumeric, or brackets
 /proc/paranoid_sanitize(t)
 	var/regex/alphanum_only = regex("\[^a-zA-Z0-9# ,.?!:;()]", "g")
 	return alphanum_only.Replace(t, "#")
+
+// Less agressive, to allow discord features, such as <>, / and @
+/proc/not_as_paranoid_sanitize(t)
+	var/regex/alphanum_slashes_only = regex("\[^a-zA-Z0-9# ,.?!:;()/<>@]", "g")
+	return alphanum_slashes_only.Replace(t, "#")
 
 //Runs sanitize and strip_html_simple
 //I believe strip_html_simple() is required to run first to prevent '<' from displaying as '&lt;' after sanitize() calls byond's html_encode()

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -1,4 +1,4 @@
-/proc/send2irc(var/channel, var/msg, var/lesser_sanitize=0)
+/proc/send2irc(var/channel, var/msg, var/lesser_sanitize = FALSE)
 	if(config.use_irc_bot && config.irc_bot_host.len)
 		for(var/IP in config.irc_bot_host)
 			spawn(0)
@@ -10,7 +10,7 @@
 					ext_python("ircbot_message.py", "[config.comms_password] [IP] [channel] [paranoid_sanitize(msg)]")
 	return
 
-/proc/send2mainirc(var/msg, var/lesser_sanitize=0)
+	/proc/send2mainirc(var/msg, var/lesser_sanitize = FALSE)
 	if(config.main_irc)
 		send2irc(config.main_irc, msg, lesser_sanitize)
 	return

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -1,14 +1,18 @@
-/proc/send2irc(var/channel, var/msg)
+/proc/send2irc(var/channel, var/msg, var/lesser_sanitize=0)
 	if(config.use_irc_bot && config.irc_bot_host.len)
 		for(var/IP in config.irc_bot_host)
 			spawn(0)
-				// I have no means of trusting you, cmd
-				ext_python("ircbot_message.py", "[config.comms_password] [IP] [channel] [paranoid_sanitize(msg)]")
+				if(lesser_sanitize == 7355608) // Super random number because this could be bad if done accidentally
+					// Runs sanitization but allows <> and // (Needed for discord)
+					ext_python("ircbot_message.py", "[config.comms_password] [IP] [channel] [not_as_paranoid_sanitize(msg)]")
+				else
+					// I have no means of trusting you, cmd
+					ext_python("ircbot_message.py", "[config.comms_password] [IP] [channel] [paranoid_sanitize(msg)]")
 	return
 
-/proc/send2mainirc(var/msg)
+/proc/send2mainirc(var/msg, var/lesser_sanitize=0)
 	if(config.main_irc)
-		send2irc(config.main_irc, msg)
+		send2irc(config.main_irc, msg, lesser_sanitize)
 	return
 
 /proc/send2adminirc(var/msg)
@@ -25,7 +29,7 @@
 	else
 		while(pull_notify.NextRow())
 			people_to_ping += "<@" + pull_notify.item[1] + "> "
-	send2mainirc("Server starting up on [station_name()]. Connect to: <byond://[config.server? "[config.server]" : "[world.address]:[world.port]"]> "+people_to_ping)
+	send2mainirc("Server starting up on [station_name()]. Connect to: <byond://[config.server? "[config.server]" : "[world.address]:[world.port]"]> "+people_to_ping, 7355608)
 	// Set notify to 0 so people arent pinged round after round
 	var/DBQuery/reset_notify = dbcon.NewQuery("UPDATE [format_table_name("discord")] SET notify = 0 WHERE notify = 1")
 	if(!reset_notify.Execute())

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -10,7 +10,7 @@
 					ext_python("ircbot_message.py", "[config.comms_password] [IP] [channel] [paranoid_sanitize(msg)]")
 	return
 
-	/proc/send2mainirc(var/msg, var/lesser_sanitize = FALSE)
+/proc/send2mainirc(var/msg, var/lesser_sanitize = FALSE)
 	if(config.main_irc)
 		send2irc(config.main_irc, msg, lesser_sanitize)
 	return


### PR DESCRIPTION
**What does this PR do:**
This PR fixes discord notifcations by allowing a lesser sanitization method.

**THIS CAN ONLY BE APPLIED BY A CODE CHANGE, AND IT IS IMPOSSIBLE TO ACCIDENTLY DO. THE SEND ROUNDSTART NOTIFICATIONS IS THE ONLY INSTANCE WHERE THIS IS USED**

**Changelog:**
:cl:
tweak: Fixed roundstart message in discord so that people are notified instead of characters being replaced
/:cl:

