### PR TITLE
Revert defib time to five minutes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -393,5 +393,5 @@
 #define MOUSE_OPACITY_OPAQUE 2
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 120
-#define DEFIB_TIME_LOSS 60
+#define DEFIB_TIME_LIMIT 300
+#define DEFIB_TIME_LOSS 150


### PR DESCRIPTION
**What does this PR do:**
This PR keeps the HUD changes but reverts the defib time limit back to fix minutes the reasoning for this reversion is because two minutes is a far too unforgiving time limit. There is not much reason to lower the defib time limit especially if the argument is to make death more impactful all this does is punish everyone unlucky enough to be found after two minutes or to die too far away from the medbay. There are other ways to go about making death impactful and making the critical time for defibs shorter is not one of them in my opinion this simply causes more stress for medical and the paramedic specifically and doesn’t work too well unless the paramedic is given a portable defib.
**Changelog:**
:cl:
tweak: revert defib time back to five minutes
/:cl:

