### PR TITLE
Sentience event changes.

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -33,7 +33,9 @@
 	SA.key = SG.key
 	SA.universal_speak = 1
 	SA.sentience_act()
-	SA.maxHealth = max(SA.maxHealth, 200)
+	SA.maxHealth = max(SA.maxHealth + 200)
+	SA.melee_damage_lower = max(SA.melee_damage_lower + 15)
+	SA.melee_damage_upper = max(SA.melee_damage_upper + 15)
 	SA.health = SA.maxHealth
 	SA.del_on_death = FALSE
 	greet_sentient(SA)


### PR DESCRIPTION
**What does this PR do:**
The sentience event will now add health to what the mob's health was, rather than just replacing whatever value there was with 200.
It will also now add 15 brute damage to whatever mob was selected for the event. This means that even passive mobs are able to deal damage now, and those that already did can deal even more damage.

These changes will make the sentience event feel more rewarding to get picked for, because now, even if you get assigned to a mob you could have already controlled with the "Respawn as NPC" option, you'll still be something unique and not useless.
If someone decides to go completely berserk right after obtaining sentience, they can still be killed pretty easily.

**Changelog:**
:cl: EmanTheAlmighty
add: Sentience event now adds some damage to the affected mob.
tweak: Sentience event now adds health to the affected mob, rather than replacing the old value with another value.
/:cl: