### PR TITLE
Removes the nightvision from xray

### DIFF
--- a/code/modules/mob/living/carbon/human/species/_species.dm
+++ b/code/modules/mob/living/carbon/human/species/_species.dm
@@ -709,8 +709,6 @@ It'll return null if the organ doesn't correspond, so include null checks when u
 
 	if(XRAY in H.mutations)
 		H.sight |= (SEE_TURFS|SEE_MOBS|SEE_OBJS)
-		H.see_in_dark = max(H.see_in_dark, 8)
-		H.see_invisible = SEE_INVISIBLE_MINIMUM
 
 	if(H.see_override)	//Override all
 		H.see_invisible = H.see_override


### PR DESCRIPTION
**What does this PR do:**
Removes the nightvision from the genetics version of xray.
Leaves the implant in tact.

Alternative to #10832

**Changelog:**
:cl:
balance: Removes nightvision from the nightvision genetics power
/:cl:

