### PR TITLE
Going to sleep with a reviver no longer heals you

### DIFF
--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -261,7 +261,7 @@
 
 /obj/item/organ/internal/cyberimp/chest/reviver/on_life()
 	if(reviving)
-		if(owner.stat == UNCONSCIOUS)
+		if(owner.stat == UNCONSCIOUS && (owner.sleeping == 0)) //!owner.sleeping didn't work for whatever dumb reason
 			spawn(30)
 				if(prob(90) && owner.getOxyLoss())
 					owner.adjustOxyLoss(-3)


### PR DESCRIPTION
You could go to sleep to just have the reviver implant heal you because it didnt check if you were sleeping. Makes it not so

I tested it with being loaded up on ether and it doesn't seem to make a difference, `sleeping` always just got set to 1 second on and then 0 back and fourth, but you were still unconscious for the whole time.

🆑 
fix: Reviver implant does not heal when you sleep, only when you fall unconscious involuntarily
/ 🆑 