### PR TITLE
Adds an admin panel to force unlink discord accounts

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1067,3 +1067,28 @@ var/gamma_ship_location = 1 // 0 = station , 1 = space
 			continue
 		result[1]++
 	return result
+
+//Discord duplications
+/datum/admins/proc/discord_duplicates()
+	if(!usr.client.holder)
+		return
+	var/dat = "<html><head><title>Discord Duplicates</title></head>"
+	dat += "<body><p><i>Discord IDs with more than one ckey linked are shown below</i></i><table border=1 cellspacing=5><B><tr><th>Discord ID</th><th>CKEYs</th><th>Unlink</th></B>"
+	// If anyone reads this, I spent a whole 30 minutes writing just this fucking query. It is the messiest SQL statement I have ever written
+	// If anyone even thinks about touching this I will impale you on a railroad spike
+	// It hurts to wake up in the morning, -aa07
+	var/DBQuery/discord_ids = dbcon.NewQuery("SELECT a.* FROM [format_table_name("discord")] a JOIN (SELECT discord_id, ckey, COUNT(*) FROM [format_table_name("discord")] GROUP BY discord_id HAVING count(*) > 1 ) b ON a.discord_id = b.discord_id ORDER BY a.discord_id")
+	if(!discord_ids.Execute())
+		var/err = discord_ids.ErrorMsg()
+		log_game("SQL ERROR while selecting discord accounts. Error : \[[err]\]\n")
+		return
+	while(discord_ids.NextRow())
+		var/ckey = discord_ids.item[1]
+		var/id = discord_ids.item[2]
+		dat += "<tr><td><b>" + id + "</b></td>"
+		dat += "<td>" + ckey + "</td>"
+		dat += "<td><a href='?src=[UID()];force_discord_unlink=[ckey]'>Unlink</td></tr>"
+		
+	dat += "</table></body></html>"
+
+	usr << browse(dat, "window=duplicates;size=500x480")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,6 +79,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/list_ssds,
 	/client/proc/cmd_admin_headset_message,
 	/client/proc/spawn_floor_cluwne,
+	/client/proc/show_discord_duplicates,
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -1045,3 +1046,12 @@ var/list/admin_verbs_ticket = list(
 
 	log_admin("[key_name(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
 	message_admins("[key_name_admin(usr)] has [advanced_admin_interaction ? "activated" : "deactivated"] their advanced admin interaction.")
+
+/client/proc/show_discord_duplicates()
+	set name = "Show Duplicate Discord Links"
+	set category = "Admin"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	holder.discord_duplicates()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -3349,6 +3349,20 @@
 		// Refresh the page
 		src.view_flagged_books()
 
+	// Force unlink a discord key
+	else if(href_list["force_discord_unlink"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/target_ckey = href_list["force_discord_unlink"]
+		var/DBQuery/admin_unlink_discord_id = dbcon.NewQuery("DELETE FROM [format_table_name("discord")] WHERE ckey = '[target_ckey]'")
+		if(!admin_unlink_discord_id.Execute())
+			var/err = admin_unlink_discord_id.ErrorMsg()
+			log_game("SQL ERROR while admin-unlinking discord account. Error : \[[err]\]\n")
+			return
+		to_chat(src, "<span class='notice'>Successfully forcefully unlinked discord account from [target_ckey]</span>")
+		message_admins("[key_name_admin(usr)] forcefully unlinked the discord account belonging to [target_ckey]")
+		log_admin("[key_name_admin(usr)] forcefully unlinked the discord account belonging to [target_ckey]")
+
 /client/proc/create_eventmob_for(var/mob/living/carbon/human/H, var/killthem = 0)
 	if(!check_rights(R_EVENT))
 		return


### PR DESCRIPTION
**What does this PR do:**
This PR adds a small admin panel to force unlink a discord account from a ckey. The panel only shows IDs which are in there more than once. But why?

~~My good friend~~ Flattest showed me that any persons ID could be used with no authorisation on the discord side of things. Which led to me being pinged randomly thinking the system was broken.

The panel that this PR adds aims to fix that issue. Players can ahelp that they are being pinged without saying, an admin can ask for their discord account ID, confirm on discord that its **ACTUALY** them, then unlink (and potentially punish) the other ckey. 

**Images of sprite/map changes (IF APPLICABLE):**
Panel with no duplicates:
![image](https://user-images.githubusercontent.com/25063394/52533647-b9c5bc00-2d2e-11e9-8955-fd1487675403.png)

Gif of removing a duplicate:
![2019-02-10_12-20-02](https://user-images.githubusercontent.com/25063394/52533648-c1856080-2d2e-11e9-918c-6c0981d22e66.gif)

Admin log statement:
![image](https://user-images.githubusercontent.com/25063394/52533651-c77b4180-2d2e-11e9-85d6-414cd97e0f19.png)

Does **NOT** require an SQL change, as it is just adding another query to an already existing dataset.

**Changelog:**
:cl: AffectedArc07
add: Added an admin verb that allows admins to forcefully unlink discord accounts
/:cl:

*PS: Flattest can you unlink my discord from your fucking ckey **PLEASE***
