### PR TITLE
Fixes a bug with Surplus Crates & Adds in Super Surplus Crates

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -921,7 +921,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "PB"
 	item = /obj/item/pizza_bomb
 	cost = 5
-	surplus = 8
+	surplus = 80
 
 /datum/uplink_item/explosives/grenadier
 	name = "Grenadier's belt"
@@ -1597,6 +1597,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndicate
 	excludefrom = list(/datum/game_mode/nuclear)
 	cant_discount = TRUE // You fucking wish
+	var/crate_value = 50
+
+/datum/uplink_item/badass/surplus_crate/super
+	name = "Syndicate Super Surplus Crate"
+	desc = "A crate containing 125 telecrystals worth of random syndicate leftovers."
+	reference = "SYSS"
+	cost = 40
+	crate_value = 125
 
 /datum/uplink_item/badass/surplus_crate/spawn_item(turf/loc, obj/item/uplink/U)
 	var/obj/structure/closet/crate/C = new(loc)
@@ -1604,16 +1612,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/list/buyable_items = list()
 	for(var/category in temp_uplink_list)
 		buyable_items += temp_uplink_list[category]
+	var/remaining_TC = crate_value
 	var/list/bought_items = list()
 	var/list/itemlog = list()
 	U.uses -= cost
-	U.used_TC = 20
-	var/remaining_TC = 50
+	U.used_TC = cost
 
 	var/datum/uplink_item/I
 	while(remaining_TC)
 		I = pick(buyable_items)
-		if(!I.surplus)
+		if(!I.surplus || prob(100 - I.surplus))
 			continue
 		if(I.cost > remaining_TC)
 			continue


### PR DESCRIPTION
**What does this PR do:**

This PR brings over a couple of things from TG for the crates:

- Adds in logic for the crates so that the surplus chance value will work correctly if its anything higher than 0. Previously it made no difference - an item with a surplus chance of 10 is just as likely to appear as anything else in the crate. This should hopefully make random ammo and suppressors people can't even use less likely to show up.

- Ports across TG's Super Surplus crates. These things are even more economical than the regular variant, containing 125TC worth of assorted gear. The downside to this is that they cost 40TC - so the only way you'll get one is by interacting with other traitors. Hopefully this should encourage traitors to not grab items and complete objectives the moment the round starts but instead spend some time trying to find out if their co-workers or anyone in their department is also a traitor, hopefully agreeing to team up for a super crate. They cannot be bought in Nuke Ops rounds.

This also adjusts the surplus value for pizza bombs from 8 to 80, since it seems like the 0 was missed by accident (even regular minibombs have a value of 100).

**Changelog:**
:cl:
add: Added Super Surplus Crates from TG. They contain 125TC worth of gear, but cost 40TC meaning you'll need to team up if you want one.
fix: The Surplus chance value for various uplink items will now work when ordering a crate.
/:cl:

