### PR TITLE
Refactors changelog button

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -373,7 +373,8 @@
 	if(prefs.lastchangelog != changelog_hash) //bolds the changelog button on the interface so we know there are updates. -CP
 		if(establish_db_connection())
 			to_chat(src, "<span class='info'>Changelog has changed since your last visit.</span>")
-			winset(src, "rpane.changelog", "background-color=#bb7700;text-color=#FFFFFF;font-style=bold")
+			update_changelog_button()
+			
 
 	if(!void)
 		void = new()
@@ -671,6 +672,7 @@
 // IF YOU CHANGE ANYTHING IN ACTIVATE, MAKE SURE IT HAS A DEACTIVATE METHOD, -AA07
 /client/proc/activate_darkmode()
 	///// BUTTONS /////
+	update_changelog_button()
 	/* Rpane */
 	winset(src, "rpane.textb", "background-color=#40628a;text-color=#FFFFFF")
 	winset(src, "rpane.infob", "background-color=#40628a;text-color=#FFFFFF")
@@ -705,6 +707,7 @@
 
 /client/proc/deactivate_darkmode()
 	///// BUTTONS /////
+	update_changelog_button()
 	/* Rpane */
 	winset(src, "rpane.textb", "background-color=none;text-color=#000000")
 	winset(src, "rpane.infob", "background-color=none;text-color=#000000")
@@ -736,3 +739,19 @@
 	winset(src, "infowindow.info", "background-color=none;text-color=#000000;highlight-color=#007700;tab-text-color=#000000;tab-background-color=none")
 	///// NOTIFY USER /////
 	to_chat(src, "<span class='notice'>Darkmode Disabled</span>") // what a sick fuck
+
+// Better changelog button handling
+/client/proc/update_changelog_button()
+	if(establish_db_connection())
+		if(prefs.lastchangelog != changelog_hash) 
+			winset(src, "rpane.changelog", "background-color=#bb7700;text-color=#FFFFFF;font-style=bold")
+		else
+			if(prefs.toggles & UI_DARKMODE) 
+				winset(src, "rpane.changelog", "background-color=#40628a;text-color=#FFFFFF")
+			else
+				winset(src, "rpane.changelog", "background-color=none;text-color=#000000")
+	else
+		if(prefs.toggles & UI_DARKMODE) 
+			winset(src, "rpane.changelog", "background-color=#40628a;text-color=#FFFFFF")
+		else
+			winset(src, "rpane.changelog", "background-color=none;text-color=#000000")

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -494,9 +494,3 @@
 		to_chat(C, "Couldn't update your last seen changelog, please try again later.")
 		return
 	return 1
-
-/datum/preferences/proc/UpdateChangelogButton(client/C)
-	if(preferences_datums[C.ckey].toggles & UI_DARKMODE)
-		winset(C, "rpane.changelog", "background-color=#40628a;text-color=#ffffff;font-style=none")
-	else
-		winset(C, "rpane.changelog", "background-color=none;text-color=#000000;font-style=none")

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -38,7 +38,7 @@
 		'html/changelog.html'
 		)
 	src << browse('html/changelog.html', "window=changes;size=675x650")
-	prefs.UpdateChangelogButton(src)
+	update_changelog_button()
 	if(prefs.lastchangelog != changelog_hash) //if it's already opened, no need to tell them they have unread changes
 		prefs.SetChangelog(src,changelog_hash)
 


### PR DESCRIPTION
**What does this PR do:**
Updating of the changelog button color is now inside its own proc. This allows it to be updated when toggling darkmode, and will retain its color if it is unread. 

**Changelog:**
:cl: AffectedArc07
tweak: Changelog button loads properly on darkmode now
/:cl:

