### PR TITLE
Fixes adminwho breaking 

### DIFF
--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -3,7 +3,7 @@
     set category = "OOC"
     set name = "Link Discord Account"
     set desc = "Link your discord account to your BYOND account."
-    user_ckey = sanitizeSQL(usr.ckey) // Probably not neccassary but better safe than sorry
+    var/user_ckey = sanitizeSQL(usr.ckey) // Probably not neccassary but better safe than sorry
     if(!config.sql_enabled)
         to_chat(src, "<span class='warning'>This is feature requires the SQL backend</span>")
         return

--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -3,11 +3,11 @@
     set category = "OOC"
     set name = "Link Discord Account"
     set desc = "Link your discord account to your BYOND account."
-    ckey = sanitizeSQL(usr.ckey) // Probably not neccassary but better safe than sorry
+    user_ckey = sanitizeSQL(usr.ckey) // Probably not neccassary but better safe than sorry
     if(!config.sql_enabled)
         to_chat(src, "<span class='warning'>This is feature requires the SQL backend</span>")
         return
-    var/DBQuery/db_discord_id = dbcon.NewQuery("SELECT discord_id FROM [format_table_name("discord")] WHERE ckey = '[ckey]'")
+    var/DBQuery/db_discord_id = dbcon.NewQuery("SELECT discord_id FROM [format_table_name("discord")] WHERE ckey = '[user_ckey]'")
     if(!db_discord_id.Execute())
         var/err = db_discord_id.ErrorMsg()
         log_game("SQL ERROR while selecting discord account. Error : \[[err]\]\n")
@@ -22,18 +22,18 @@
             src << link("https://support.discordapp.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID")
         var/entered_id = input("Please enter your Discord ID.", "Enter Discord ID", null, null) as text|null
         var/sql_id = sanitizeSQL(entered_id)
-        var/DBQuery/store_discord_id = dbcon.NewQuery("INSERT INTO [format_table_name("discord")] (ckey, discord_id, notify) VALUES ('[ckey]', [sql_id], 0)")
+        var/DBQuery/store_discord_id = dbcon.NewQuery("INSERT INTO [format_table_name("discord")] (ckey, discord_id, notify) VALUES ('[user_ckey]', [sql_id], 0)")
         if(!store_discord_id.Execute())
             var/err = db_discord_id.ErrorMsg()
             log_game("SQL ERROR while linking discord account. Error : \[[err]\]\n")
             to_chat(src, "<span class='warning'>Error linking Discord account. Please inform an administrator</span>")
             return
-        to_chat(src, "<span class='notice'>Successfully linked discord account [entered_id] to [ckey]</span>")
+        to_chat(src, "<span class='notice'>Successfully linked discord account [entered_id] to [user_ckey]</span>")
     else // Linked
-        var/choice = alert("You already have the Discord Account [stored_id] linked to [ckey]. Would you like to unlink or replace","Already Linked","Unlink","Replace")
+        var/choice = alert("You already have the Discord Account [stored_id] linked to [user_ckey]. Would you like to unlink or replace","Already Linked","Unlink","Replace")
         switch(choice)
             if("Unlink")
-                var/DBQuery/unlink_discord_id = dbcon.NewQuery("DELETE FROM [format_table_name("discord")] WHERE ckey = '[ckey]'")
+                var/DBQuery/unlink_discord_id = dbcon.NewQuery("DELETE FROM [format_table_name("discord")] WHERE ckey = '[user_ckey]'")
                 if(!unlink_discord_id.Execute())
                     var/err = unlink_discord_id.ErrorMsg()
                     log_game("SQL ERROR while unlinking discord account. Error : \[[err]\]\n")
@@ -43,10 +43,10 @@
             if("Replace")
                 var/entered_id = input("Please enter your Discord ID. Instructions can be found at https://bit.ly/2AfUu40", "Enter Discord ID", null, null) as text|null
                 var/sql_id = sanitizeSQL(entered_id)
-                var/DBQuery/store_discord_id = dbcon.NewQuery("UPDATE [format_table_name("discord")] SET discord_id = '[sql_id]' WHERE ckey='[ckey]'")
+                var/DBQuery/store_discord_id = dbcon.NewQuery("UPDATE [format_table_name("discord")] SET discord_id = '[sql_id]' WHERE ckey='[user_ckey]'")
                 if(!store_discord_id.Execute())
                     var/err = db_discord_id.ErrorMsg()
                     to_chat(src, "<span class='warning'>Error replacing Discord account. Please inform an administrator</span>")
                     log_game("SQL ERROR while linking discord account. Error : \[[err]\]\n")
                     return
-                to_chat(src, "<span class='notice'>Successfully linked discord account [entered_id] to [ckey]</span>")
+                to_chat(src, "<span class='notice'>Successfully linked discord account [entered_id] to [user_ckey]</span>")


### PR DESCRIPTION
**What does this PR do:**
Fixes #10874 
Fixes the weird issue of ckeys in `adminwho` having `the` appended to them, and them all being lowercase. This turned out to be a bug with sql-sanitize somehow overwriting the clients ckey. Because good job BYOND

**Images of sprite/map changes (IF APPLICABLE):**
Before:
![image](https://user-images.githubusercontent.com/25063394/52540491-e35c0300-2d81-11e9-998a-44d6a21edee2.png)

After:
![image](https://user-images.githubusercontent.com/25063394/52540507-02f32b80-2d82-11e9-819e-fe89a15d6720.png)

*Also applies to mentors*
![image](https://user-images.githubusercontent.com/25063394/52540511-08e90c80-2d82-11e9-8112-c891a1a2c855.png)


**Changelog:**
:cl: AffectedArc07
fix: Admins that linked their discord account that round no longer show up as "the adminkey" in adminwho.
/:cl:

