### PR TITLE
Remove HOP access from NT rep, Magistrate

### DIFF
--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -125,7 +125,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_ntrep)
+			            access_clown, access_mime, access_RC_announce, access_keycard_auth, access_gateway, access_weapons, access_ntrep)
 	outfit = /datum/outfit/job/nanotrasenrep
 
 /datum/outfit/job/nanotrasenrep
@@ -205,7 +205,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
 			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
 			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_magistrate)
+			            access_clown, access_mime, access_RC_announce, access_keycard_auth, access_gateway, access_magistrate)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels, access_lawyer, access_magistrate, access_heads)
 	outfit = /datum/outfit/job/judge
 


### PR DESCRIPTION
**What does this PR do:**
This PR removes HOP office access from the NT rep and Magistrate (unless the minimal access option's not set, which is intended for lowpop servers)
Why remove that access?
~~REEEE NT rep keeps shortcutting through my office to get to bridge~~
The NT rep has no reason to have access to the HOP office. He doesn't have access to the office of any other head, either. He and the HOP are equals, he's not his superior, and can always ask to be let in when necessary to discuss something.
The same goes even more for the Magistrate. He should keep an eye on security and ensure space law is followed, he has very little reason to enter the HOP's office.
I recently learned in a conversation on discord that the reason NT rep has it because his access was copied off of the HOP originally. He even used to have ID computer access.


**Changelog:**
:cl:
tweak: NT rep and Magistrate lose access to the HOP office
/:cl:

