### PR TITLE
Redundent cult convert checks

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -353,7 +353,7 @@ var/list/teleport_runes = list()
 	var/turf/T = get_turf(src)
 
 	for(var/mob/living/M in T.contents)
-		if(!iscultist(M) && !ismindshielded(M) && !isgolem(M) && !isanimal(M) && ishuman(M))
+		if(!iscultist(M) && !ismindshielded(M) && !isgolem(M) && ishuman(M))
 			convertees.Add(M)
 	if(!convertees.len)
 		fail_invoke()

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -353,7 +353,7 @@ var/list/teleport_runes = list()
 	var/turf/T = get_turf(src)
 
 	for(var/mob/living/M in T.contents)
-		if(!iscultist(M) && !ismindshielded(M) && ishuman(M))
+		if(!iscultist(M) && !ismindshielded(M) && !isgolem(M) && !isanimal(M) && ishuman(M))
 			convertees.Add(M)
 	if(!convertees.len)
 		fail_invoke()


### PR DESCRIPTION
So uhh way back i had made it so you couldn't convert golems...or animals. (or i thought i did) I am hearing..that broke. I am fixing it now.

I know we got some new golem types but i am not getting runic golems in in this PR (and if anyone else wants to feel free), Mainly as i want a fix and runic golems need me to eval ease to make versus repercussion on round.

:cl:
fix:unbreaks letting golems be cult converts.
/:cl: