### PR TITLE
Flavor Update

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol.dm
@@ -70,6 +70,7 @@
 	drink_icon = "whiskeyglass"
 	drink_name = "Glass of whiskey"
 	drink_desc = "The silky, smokey whiskey goodness inside the glass makes the drink look very classy."
+	taste_message = "whiskey"
 
 /datum/reagent/consumable/ethanol/specialwhiskey
 	name = "Special Blend Whiskey"
@@ -89,6 +90,7 @@
 	drink_icon = "ginvodkaglass"
 	drink_name = "Glass of gin"
 	drink_desc = "A crystal clear glass of Griffeater gin."
+	taste_message = "gin"
 
 /datum/reagent/consumable/ethanol/absinthe
 	name = "Absinthe"
@@ -124,6 +126,7 @@
 	drink_icon = "rumglass"
 	drink_name = "Glass of Rum"
 	drink_desc = "Now you want to Pray for a pirate suit, don't you?"
+	taste_message = "rum"
 
 /datum/reagent/consumable/ethanol/rum/overdose_process(mob/living/M, severity)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -150,6 +153,7 @@
 	drink_icon = "ginvodkaglass"
 	drink_name = "Glass of vodka"
 	drink_desc = "The glass contain wodka. Xynta."
+	taste_message = "vodka"
 
 /datum/reagent/consumable/ethanol/sake
 	name = "Sake"
@@ -171,6 +175,7 @@
 	drink_icon = "tequilaglass"
 	drink_name = "Glass of Tequila"
 	drink_desc = "Now all that's missing is the weird colored shades!"
+	taste_message = "tequila"
 
 /datum/reagent/consumable/ethanol/vermouth
 	name = "Vermouth"
@@ -205,6 +210,7 @@
 	drink_icon = "cognacglass"
 	drink_name = "Glass of cognac"
 	drink_desc = "Damn, you feel like some kind of French aristocrat just by holding this."
+	taste_message = "cognac"
 
 /datum/reagent/consumable/ethanol/suicider //otherwise known as "I want to get so smashed my liver gives out and I die from alcohol poisoning".
 	name = "Suicider"
@@ -278,7 +284,7 @@
 	drink_icon = "atomicbombglass"
 	drink_name = "Atomic Bomb"
 	drink_desc = "Nanotrasen cannot take legal responsibility for your actions after imbibing."
-	taste_message = "fruity alcohol"
+	taste_message = "a long, fiery burn"
 
 /datum/reagent/consumable/ethanol/threemileisland
 	name = "THree Mile Island Iced Tea"
@@ -290,7 +296,7 @@
 	drink_icon = "threemileislandglass"
 	drink_name = "Three Mile Island Ice Tea"
 	drink_desc = "A glass of this is sure to prevent a meltdown."
-	taste_message = "fruity alcohol"
+	taste_message = "a creeping heat"
 
 /datum/reagent/consumable/ethanol/goldschlager
 	name = "Goldschlager"
@@ -302,6 +308,7 @@
 	drink_icon = "ginvodkaglass"
 	drink_name = "Glass of goldschlager"
 	drink_desc = "100 proof that teen girls will drink anything with gold in it."
+	taste_message = "a deep, spicy warmth"
 
 /datum/reagent/consumable/ethanol/patron
 	name = "Patron"
@@ -313,6 +320,7 @@
 	drink_icon = "patronglass"
 	drink_name = "Glass of Patron"
 	drink_desc = "Drinking patron in the bar, with all the subpar ladies."
+	taste_message = "a gift"
 
 /datum/reagent/consumable/ethanol/gintonic
 	name = "Gin and Tonic"
@@ -324,6 +332,7 @@
 	drink_icon = "gintonicglass"
 	drink_name = "Gin and Tonic"
 	drink_desc = "A mild but still great cocktail. Drink up, like a true Englishman."
+	taste_message = "bitter medicine"
 
 /datum/reagent/consumable/ethanol/cuba_libre
 	name = "Cuba Libre"
@@ -336,6 +345,7 @@
 	drink_name = "Cuba Libre"
 	drink_desc = "A classic mix of rum and cola."
 	taste_message = "fruity alcohol"
+	taste_message = "liberation"
 
 /datum/reagent/consumable/ethanol/whiskey_cola
 	name = "Whiskey Cola"
@@ -359,7 +369,7 @@
 	drink_icon = "martiniglass"
 	drink_name = "Classic Martini"
 	drink_desc = "Damn, the bartender even stirred it, not shook it."
-	taste_message = "martini"
+	taste_message = "class"
 
 /datum/reagent/consumable/ethanol/vodkamartini
 	name = "Vodka Martini"
@@ -371,6 +381,7 @@
 	drink_icon = "martiniglass"
 	drink_name = "Vodka martini"
 	drink_desc ="A bastardisation of the classic martini. Still great."
+	taste_message = "class and potatoes"
 
 /datum/reagent/consumable/ethanol/white_russian
 	name = "White Russian"
@@ -382,7 +393,7 @@
 	drink_icon = "whiterussianglass"
 	drink_name = "White Russian"
 	drink_desc = "A very nice looking drink. But that's just, like, your opinion, man."
-	taste_message = "creamy alcohol"
+	taste_message = "very creamy alcohol"
 
 /datum/reagent/consumable/ethanol/screwdrivercocktail
 	name = "Screwdriver"
@@ -394,7 +405,7 @@
 	drink_icon = "screwdriverglass"
 	drink_name = "Screwdriver"
 	drink_desc = "A simple, yet superb mixture of Vodka and orange juice. Just the thing for the tired engineer."
-	taste_message = "fruity alcohol"
+	taste_message = "a naughty secret"
 
 /datum/reagent/consumable/ethanol/booger
 	name = "Booger"
@@ -406,7 +417,7 @@
 	drink_icon = "booger"
 	drink_name = "Booger"
 	drink_desc = "Eww..."
-	taste_message = "sweet alcohol"
+	taste_message = "a fruity mess"
 
 /datum/reagent/consumable/ethanol/bloody_mary
 	name = "Bloody Mary"
@@ -560,7 +571,7 @@
 	drink_icon = "b52glass"
 	drink_name = "B-52"
 	drink_desc = "Kahlua, Irish Cream, and congac. You will get bombed."
-	taste_message = "creamy alcohol"
+	taste_message = "destruction"
 
 /datum/reagent/consumable/ethanol/irishcoffee
 	name = "Irish Coffee"
@@ -584,7 +595,7 @@
 	drink_icon = "margaritaglass"
 	drink_name = "Margarita"
 	drink_desc = "On the rocks with salt on the rim. Arriba~!"
-	taste_message = "fruity alcohol"
+	taste_message = "daisies"
 
 /datum/reagent/consumable/ethanol/black_russian
 	name = "Black Russian"
@@ -608,7 +619,7 @@
 	drink_icon = "manhattanglass"
 	drink_name = "Manhattan"
 	drink_desc = "The Detective's undercover drink of choice. He never could stomach gin..."
-	taste_message = "bitter alcohol"
+	taste_message = "a bustling city"
 
 /datum/reagent/consumable/ethanol/manhattan_proj
 	name = "Manhattan Project"
@@ -620,7 +631,7 @@
 	drink_icon = "proj_manhattanglass"
 	drink_name = "Manhattan Project"
 	drink_desc = "A scientist's drink of choice, for thinking how to blow up the station."
-	taste_message = "bitter alcohol"
+	taste_message = "the apocalypse"
 
 /datum/reagent/consumable/ethanol/whiskeysoda
 	name = "Whiskey Soda"
@@ -661,7 +672,7 @@
 	drink_icon = "b&p"
 	drink_name = "Barefoot"
 	drink_desc = "Barefoot and pregnant"
-	taste_message = "sweet alcohol"
+	taste_message = "pregnancy"
 
 /datum/reagent/consumable/ethanol/snowwhite
 	name = "Snow White"
@@ -673,7 +684,7 @@
 	drink_icon = "snowwhite"
 	drink_name = "Snow White"
 	drink_desc = "A cold refreshment."
-	taste_message = "refreshing alcohol"
+	taste_message = "a poisoned apple"
 
 /datum/reagent/consumable/ethanol/demonsblood
 	name = "Demons Blood"
@@ -699,7 +710,7 @@
 	drink_icon = "vodkatonicglass"
 	drink_name = "Vodka and Tonic"
 	drink_desc = "For when a gin and tonic isn't russian enough."
-	taste_message = "fizzy alcohol"
+	taste_message = "bitter medicine"
 
 /datum/reagent/consumable/ethanol/ginfizz
 	name = "Gin Fizz"
@@ -724,7 +735,7 @@
 	drink_icon = "bahama_mama"
 	drink_name = "Bahama Mama"
 	drink_desc = "Tropic cocktail"
-	taste_message = "fruity alcohol"
+	taste_message = "HONK"
 
 /datum/reagent/consumable/ethanol/singulo
 	name = "Singulo"
@@ -749,7 +760,7 @@
 	drink_icon = "sbitenglass"
 	drink_name = "Sbiten"
 	drink_desc = "A spicy mix of Vodka and Spice. Very hot."
-	taste_message = "spicy alcohol"
+	taste_message = "comforting warmth"
 
 /datum/reagent/consumable/ethanol/sbiten/on_mob_life(mob/living/M)
 	if(M.bodytemperature < 360)
@@ -766,7 +777,7 @@
 	drink_icon = "devilskiss"
 	drink_name = "Devils Kiss"
 	drink_desc = "Creepy time!"
-	taste_message = "blood"
+	taste_message = "naughtiness"
 
 /datum/reagent/consumable/ethanol/red_mead
 	name = "Red Mead"
@@ -791,7 +802,7 @@
 	drink_icon = "meadglass"
 	drink_name = "Mead"
 	drink_desc = "A Vikings Beverage, though a cheap one."
-	taste_message = "sweet alcohol"
+	taste_message = "honey"
 
 /datum/reagent/consumable/ethanol/iced_beer
 	name = "Iced Beer"
@@ -803,7 +814,7 @@
 	drink_icon = "iced_beerglass"
 	drink_name = "Iced Beer"
 	drink_desc = "A beer so frosty, the air around it freezes."
-	taste_message = "refreshing alcohol"
+	taste_message = "cold beer"
 
 /datum/reagent/consumable/ethanol/iced_beer/on_mob_life(mob/living/M)
 	if(M.bodytemperature > 270)
@@ -820,7 +831,7 @@
 	drink_icon = "grogglass"
 	drink_name = "Grog"
 	drink_desc = "A fine and cepa drink for Space."
-	taste_message = "rum"
+	taste_message = "strongly diluted rum"
 
 /datum/reagent/consumable/ethanol/aloe
 	name = "Aloe"
@@ -832,7 +843,7 @@
 	drink_icon = "aloe"
 	drink_name = "Aloe"
 	drink_desc = "Very, very, very good."
-	taste_message = "sweet alcohol"
+	taste_message = "healthy skin"
 
 /datum/reagent/consumable/ethanol/andalusia
 	name = "Andalusia"
@@ -856,7 +867,7 @@
 	drink_icon = "alliescocktail"
 	drink_name = "Allies cocktail"
 	drink_desc = "A drink made from your allies."
-	taste_message = "bitter alcohol"
+	taste_message = "victory"
 
 /datum/reagent/consumable/ethanol/acid_spit
 	name = "Acid Spit"
@@ -916,6 +927,7 @@
 	drink_icon = "hippiesdelightglass"
 	drink_name = "Hippie's Delight"
 	drink_desc = "A drink enjoyed by people during the 1960's."
+	taste_message = "colors"
 
 /datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -966,7 +978,7 @@
 	drink_icon = "irishcarbomb"
 	drink_name = "Irish Car Bomb"
 	drink_desc = "An irish car bomb."
-	taste_message = "creamy alcohol"
+	taste_message = "troubles"
 
 /datum/reagent/consumable/ethanol/syndicatebomb
 	name = "Syndicate Bomb"
@@ -990,7 +1002,7 @@
 	drink_icon = "erikasurprise"
 	name = "Erika Surprise"
 	drink_desc = "The surprise is, it's green!"
-	taste_message = "sweet alcohol"
+	taste_message = "disappointment"
 
 /datum/reagent/consumable/ethanol/driestmartini
 	name = "Driest Martini"
@@ -1003,7 +1015,7 @@
 	drink_icon = "driestmartiniglass"
 	drink_name = "Driest Martini"
 	drink_desc = "Only for the experienced. You think you see sand floating in the glass."
-	taste_message = "bitter alcohol"
+	taste_message = "dust and ashes"
 
 /datum/reagent/consumable/ethanol/driestmartini/on_mob_life(mob/living/M)
 	if(current_cycle >= 55 && current_cycle < 115)
@@ -1019,7 +1031,7 @@
 	drink_icon = "kahluaglass"
 	drink_name = "Glass of RR coffee Liquor"
 	drink_desc = "DAMN, THIS THING LOOKS ROBUST"
-	taste_message = "sweet alcohol"
+	taste_message = "coffee and alcohol"
 
 /datum/reagent/consumable/ethanol/kahlua/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1158,7 +1170,7 @@
 	drink_icon = "synthanolglass"
 	drink_name = "Glass of Synthanol"
 	drink_desc = "The equivalent of alcohol for synthetic crewmembers. They'd find it awful if they had tastebuds too."
-	taste_message = "motor oil mixed with puke"
+	taste_message = "motor oil"
 
 /datum/reagent/consumable/ethanol/synthanol/on_mob_life(mob/living/M)
 	if(!M.isSynthetic())
@@ -1184,6 +1196,7 @@
 	drink_icon = "robottearsglass"
 	drink_name = "Glass of Robot Tears"
 	drink_desc = "No robots were hurt in the making of this drink."
+	taste_message = "existential angst"
 
 /datum/reagent/consumable/ethanol/synthanol/trinary
 	name = "Trinary"
@@ -1195,6 +1208,7 @@
 	drink_icon = "trinaryglass"
 	drink_name = "Glass of Trinary"
 	drink_desc = "Colorful drink made for synthetic crewmembers. It doesn't seem like it would taste well."
+	taste_message = "modem static"
 
 /datum/reagent/consumable/ethanol/synthanol/servo
 	name = "Servo"
@@ -1206,6 +1220,7 @@
 	drink_icon = "servoglass"
 	drink_name = "Glass of Servo"
 	drink_desc = "Chocolate - based drink made for IPCs. Not sure if anyone's actually tried out the recipe."
+	taste_message = "motor oil and cocoa"
 
 /datum/reagent/consumable/ethanol/synthanol/uplink
 	name = "Uplink"
@@ -1217,6 +1232,7 @@
 	drink_icon = "uplinkglass"
 	drink_name = "Glass of Uplink"
 	drink_desc = "An exquisite mix of the finest liquoirs and synthanol. Meant only for synthetics."
+	taste_message = "a GUI in visual basic"
 
 /datum/reagent/consumable/ethanol/synthanol/synthnsoda
 	name = "Synth 'n Soda"
@@ -1228,6 +1244,7 @@
 	drink_icon = "synthnsodaglass"
 	drink_name = "Glass of Synth 'n Soda"
 	drink_desc = "Classic drink altered to fit the tastes of a robot. Bad idea to drink if you're made of carbon."
+	taste_message = "fizzy motor oil"
 
 /datum/reagent/consumable/ethanol/synthanol/synthignon
 	name = "Synthignon"
@@ -1239,6 +1256,7 @@
 	drink_icon = "synthignonglass"
 	drink_name = "Glass of Synthignon"
 	drink_desc = "Someone mixed good wine and robot booze. Romantic, but atrocious."
+	taste_message = "fancy motor oil"
 
 /datum/reagent/consumable/ethanol/fruit_wine
 	name = "Fruit Wine"

--- a/code/modules/reagents/chemistry/reagents/drink_base.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_base.dm
@@ -4,6 +4,7 @@
 	description = "Uh, some kind of drink."
 	reagent_state = LIQUID
 	color = "#E78108" // rgb: 231, 129, 8
+	taste_message = "something which should not exist"
 	var/adj_dizzy = 0
 	var/adj_drowsy = 0
 	var/adj_sleepy = 0

--- a/code/modules/reagents/chemistry/reagents/drink_cold.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_cold.dm
@@ -14,6 +14,7 @@
 	drink_icon = "glass_clear"
 	drink_name = "Glass of Tonic Water"
 	drink_desc = "Quinine tastes funny, but at least it'll keep that Space Malaria away."
+	taste_message = "bitterness"
 
 /datum/reagent/consumable/drink/cold/sodawater
 	name = "Soda Water"
@@ -25,6 +26,7 @@
 	drink_icon = "glass_clear"
 	drink_name = "Glass of Soda Water"
 	drink_desc = "Soda water. Why not make a scotch and soda?"
+	taste_message = "fizz"
 
 /datum/reagent/consumable/drink/cold/ice
 	name = "Ice"
@@ -36,6 +38,7 @@
 	drink_icon = "iceglass"
 	drink_name = "Glass of ice"
 	drink_desc = "Generally, you're supposed to put something else in there too..."
+	taste_message = "cold"
 
 /datum/reagent/consumable/drink/cold/ice/on_mob_life(mob/living/M)
 	M.bodytemperature = max(M.bodytemperature - 5 * TEMPERATURE_DAMAGE_COEFFICIENT, 0)
@@ -62,7 +65,7 @@
 	drink_icon = "nuka_colaglass"
 	drink_name = "Nuka Cola"
 	drink_desc = "Don't cry, Don't raise your eye, It's only nuclear wasteland"
-	taste_message = "cola"
+	taste_message = "radioactive cola"
 
 /datum/reagent/consumable/drink/cold/nuka_cola/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -308,7 +308,7 @@
 	drink_icon = "icedcoffeeglass"
 	drink_name = "Iced Coffee"
 	drink_desc = "A drink to perk you up and refresh you!"
-	taste_message = "coffee"
+	taste_message = "refreshingly cold coffee"
 
 /datum/reagent/consumable/drink/coffee/soy_latte
 	name = "Soy Latte"
@@ -320,6 +320,7 @@
 	drink_icon = "soy_latte"
 	drink_name = "Soy Latte"
 	drink_desc = "A nice and refrshing beverage while you are reading."
+	taste_message = "fake milky coffee"
 
 /datum/reagent/consumable/drink/coffee/soy_latte/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -338,6 +339,7 @@
 	drink_icon = "cafe_latte"
 	drink_name = "Cafe Latte"
 	drink_desc = "A nice, strong and refreshing beverage while you are reading."
+	taste_message = "milky coffee"
 
 /datum/reagent/consumable/drink/coffee/cafe_latte/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -353,6 +355,7 @@
 	color = "#673629"
 	drink_name = "Cafe Mocha"
 	drink_desc = "The perfect blend of coffe, milk, and chocolate."
+	taste_message = "chocolatey coffee"
 
 /datum/reagent/consumable/drink/tea
 	name = "Tea"
@@ -385,6 +388,7 @@
 	drink_icon = "icetea"
 	drink_name = "Iced Tea"
 	drink_desc = "No relation to a certain rap artist/ actor."
+	taste_message = "cold tea"
 
 /datum/reagent/consumable/drink/bananahonk
 	name = "Banana Honk"
@@ -394,7 +398,7 @@
 	drink_icon = "bananahonkglass"
 	drink_name = "Banana Honk"
 	drink_desc = "A drink from Banana Heaven."
-	taste_message = "honks"
+	taste_message = "HONK"
 
 /datum/reagent/consumable/drink/bananahonk/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -462,7 +466,7 @@
 	drink_icon = "bluecherryshake"
 	drink_name = "Blue Cherry Shake"
 	drink_desc = "An exotic blue milkshake."
-	taste_message = "cherry milkshake"
+	taste_message = "blues"
 
 /datum/reagent/consumable/drink/pumpkin_latte
 	name = "Pumpkin Latte"

--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -19,6 +19,7 @@
 	description = "A chemical element."
 	reagent_state = SOLID
 	color = "#808080" // rgb: 128, 128, 128
+	taste_message = "metal"
 
 /datum/reagent/lithium/on_mob_life(mob/living/M)
 	if(isturf(M.loc) && !istype(M.loc, /turf/space))
@@ -34,6 +35,7 @@
 	description = "A highly potent hallucinogenic substance. Far out, maaaan."
 	reagent_state = LIQUID
 	color = "#0000D8"
+	taste_message = "a magical journey"
 
 /datum/reagent/lsd/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -50,6 +52,7 @@
 	metabolization_rate = 0.2
 	addiction_chance = 65
 	heart_rate_decrease = 1
+	taste_message = "a synthetic high"
 
 /datum/reagent/space_drugs/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -66,6 +69,7 @@
 	id = "psilocybin"
 	description = "A strong psycotropic derived from certain species of mushroom."
 	color = "#E700E7" // rgb: 231, 0, 231
+	taste_message = "visions"
 
 /datum/reagent/psilocybin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -101,6 +105,7 @@
 	overdose_threshold = 35
 	addiction_chance = 70
 	heart_rate_increase = 1
+	taste_message = "calm"
 
 /datum/reagent/nicotine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -237,6 +242,7 @@
 	color = "#0264B4"
 	overdose_threshold = 20
 	addiction_chance = 50
+	taste_message = "very poor life choices"
 
 
 /datum/reagent/krokodil/on_mob_life(mob/living/M)
@@ -310,6 +316,7 @@
 	addiction_chance = 60
 	metabolization_rate = 0.6
 	heart_rate_increase = 1
+	taste_message = "speed"
 
 /datum/reagent/methamphetamine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -369,6 +376,7 @@
 	overdose_threshold = 20
 	addiction_chance = 80
 	metabolization_rate = 0.6
+	taste_message = "WAAAAGH"
 
 /datum/reagent/bath_salts/on_mob_life(mob/living/M)
 	var/check = rand(0,100)

--- a/code/modules/reagents/chemistry/reagents/food.dm
+++ b/code/modules/reagents/chemistry/reagents/food.dm
@@ -23,6 +23,7 @@
 	reagent_state = SOLID
 	nutriment_factor = 15 * REAGENTS_METABOLISM
 	color = "#664330" // rgb: 102, 67, 48
+	taste_message = null
 
 /datum/reagent/consumable/nutriment/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -57,7 +58,7 @@
 	description = "All the best vitamins, minerals, and carbohydrates the body needs in pure form."
 	reagent_state = SOLID
 	color = "#664330" // rgb: 102, 67, 48
-	taste_message = null
+	taste_message = "nutrition"
 
 /datum/reagent/consumable/vitamin/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -272,6 +273,7 @@
 	reagent_state = SOLID
 	color = "#B1B0B0"
 	overdose_threshold = 100
+	taste_strength = 2
 	taste_message = "salt"
 
 /datum/reagent/consumable/sodiumchloride/overdose_process(mob/living/M, severity)
@@ -324,7 +326,7 @@
 	id = "sprinkles"
 	description = "Multi-colored little bits of sugar, commonly found on donuts. Loved by cops."
 	color = "#FF00FF" // rgb: 255, 0, 255
-	taste_message = "sweetness"
+	taste_message = "crunchy sweetness"
 
 /datum/reagent/consumable/sprinkles/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -433,7 +435,7 @@
 	description = "Blue and tastier kind of cherry jelly."
 	reagent_state = LIQUID
 	color = "#00F0FF"
-	taste_message = "cherry jelly"
+	taste_message = "the blues"
 
 /datum/reagent/consumable/egg
 	name = "Egg"
@@ -462,7 +464,7 @@
 	description = "A sweet syrup derived from corn starch that has had its starches converted into maltose and other sugars."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
-	taste_message = "sweetness"
+	taste_message = "cheap sugar substitute"
 
 /datum/reagent/consumable/corn_syrup/on_mob_life(mob/living/M)
 	M.reagents.add_reagent("sugar", 1.2)
@@ -502,7 +504,7 @@
 	id = "onionjuice"
 	description = "A strong tasting substance that can induce partial blindness."
 	color = "#c0c9a0"
-	taste_message = "bitterness"
+	taste_message = "pungency"
 
 /datum/reagent/consumable/onion/reaction_mob(mob/living/M, method = TOUCH, volume)
 	if(method == TOUCH)
@@ -708,7 +710,7 @@
 	description = "A paste comprised of highly-processed organic material. Uncomfortably similar to deviled ham spread."
 	reagent_state = LIQUID
 	color = "#EBD7D7"
-	taste_message = "meat"
+	taste_message = "meat?"
 
 /datum/reagent/consumable/meatslurry/on_mob_life(mob/living/M)
 	if(prob(4))
@@ -810,6 +812,7 @@
 	color = "#F5F5F5"
 	metabolization_rate = 0.2
 	taste_message = "excellent cuisine"
+	taste_strength = 4
 
 /datum/reagent/msg/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -14,6 +14,7 @@
 	color = "#C805DC"
 	metabolization_rate = 0.3 // Lasts 1.5 minutes for 15 units
 	shock_reduction = 200
+	taste_message = "numbness"
 
 /datum/reagent/medicine/hydrocodone/on_mob_life(mob/living/M)
 	if(ishuman(M))
@@ -28,6 +29,7 @@
 	description = "Sterilizes wounds in preparation for surgery."
 	reagent_state = LIQUID
 	color = "#C8A5DC" // rgb: 200, 165, 220
+	taste_message = "antiseptic"
 
 	//makes you squeaky clean
 /datum/reagent/medicine/sterilizine/reaction_mob(mob/living/M, method=TOUCH, volume)
@@ -47,6 +49,7 @@
 	reagent_state = LIQUID
 	color = "#FA46FA"
 	overdose_threshold = 40
+	taste_message = "stimulant"
 
 /datum/reagent/medicine/synaptizine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -89,6 +92,7 @@
 	description = "A specialized drug that stimulates the mitochondria of cells to encourage healing of internal organs."
 	reagent_state = LIQUID
 	color = "#C8A5DC" // rgb: 200, 165, 220
+	taste_message = "nurturing"
 
 /datum/reagent/medicine/mitocholide/on_mob_life(mob/living/M)
 	if(ishuman(M))
@@ -112,6 +116,7 @@
 	reagent_state = LIQUID
 	color = "#0000C8" // rgb: 200, 165, 220
 	heart_rate_decrease = 1
+	taste_message = "a safe refuge"
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -135,6 +140,7 @@
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
 	overdose_threshold = 30
+	taste_message = "reformation"
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -163,6 +169,7 @@
 	reagent_state = LIQUID
 	color = "#0AB478"
 	metabolization_rate = 0.2
+	taste_message = "antibiotics"
 
 /datum/reagent/medicine/silver_sulfadiazine
 	name = "Silver Sulfadiazine"
@@ -171,6 +178,7 @@
 	reagent_state = LIQUID
 	color = "#F0C814"
 	metabolization_rate = 3
+	taste_message = "burn cream"
 
 /datum/reagent/medicine/silver_sulfadiazine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -196,6 +204,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 3
+	taste_message = "wound cream"
 
 /datum/reagent/medicine/styptic_powder/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -243,6 +252,7 @@
 	description = "A resorbable microfibrillar collagen and protein mixture that can rapidly heal injuries when applied topically."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
+	taste_message = "blood"
 
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, volume, show_message = 1)
 	if(iscarbon(M))
@@ -264,6 +274,7 @@
 	description = "Activated charcoal helps to absorb toxins."
 	reagent_state = LIQUID
 	color = "#000000"
+	taste_message = "dust"
 
 /datum/reagent/medicine/charcoal/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -283,6 +294,7 @@
 	metabolization_rate = 0.2
 	overdose_threshold = 30
 	addiction_chance = 5
+	taste_message = "health"
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -338,6 +350,7 @@
 	reagent_state = LIQUID
 	color = "#22AB35"
 	metabolization_rate = 0.8
+	taste_message = "a painful cleansing"
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -356,6 +369,7 @@
 	description = "Potassium Iodide is a medicinal drug used to counter the effects of radiation poisoning."
 	reagent_state = LIQUID
 	color = "#B4DCBE"
+	taste_message = "cleansing"
 
 /datum/reagent/medicine/potass_iodide/on_mob_life(mob/living/M)
 	if(prob(80))
@@ -368,6 +382,7 @@
 	description = "Pentetic Acid is an aggressive chelation agent. May cause tissue damage. Use with caution."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	taste_message = "a purge"
 
 /datum/reagent/medicine/pen_acid/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -391,6 +406,7 @@
 	metabolization_rate = 0.1
 	shock_reduction = 25
 	overdose_threshold = 25
+	taste_message = "relief"
 
 /datum/reagent/medicine/sal_acid/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -409,6 +425,7 @@
 	reagent_state = LIQUID
 	color = "#00FFFF"
 	metabolization_rate = 0.2
+	taste_message = "safety"
 
 /datum/reagent/medicine/salbutamol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -424,6 +441,7 @@
 	color = "#C8A5DC"
 	metabolization_rate = 0.2
 	addiction_chance = 20
+	taste_message = "oxygenation"
 
 /datum/reagent/medicine/perfluorodecalin/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -444,6 +462,7 @@
 	metabolization_rate = 0.3
 	overdose_threshold = 35
 	addiction_chance = 25
+	taste_message = "stimulation"
 
 /datum/reagent/medicine/ephedrine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -492,6 +511,7 @@
 	reagent_state = LIQUID
 	color = "#5BCBE1"
 	addiction_chance = 10
+	taste_message = "antihistamine"
 
 /datum/reagent/medicine/diphenhydramine/on_mob_life(mob/living/M)
 	M.AdjustJitter(-20)
@@ -514,6 +534,7 @@
 	overdose_threshold = 20
 	addiction_chance = 50
 	shock_reduction = 50
+	taste_message = "a delightful numbing"
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/M)
 	M.AdjustJitter(-25)
@@ -538,6 +559,7 @@
 	description = "Oculine is a saline eye medication with mydriatic and antibiotic effects."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	taste_message = "clarity"
 
 /datum/reagent/medicine/oculine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -569,6 +591,7 @@
 	color = "#000000"
 	metabolization_rate = 0.2
 	overdose_threshold = 25
+	taste_message = "a moment of respite"
 
 /datum/reagent/medicine/atropine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -596,6 +619,7 @@
 	color = "#96B1AE"
 	metabolization_rate = 0.2
 	overdose_threshold = 20
+	taste_message = "borrowed time"
 
 /datum/reagent/medicine/epinephrine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -651,6 +675,7 @@
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.2
+	taste_message = "life"
 
 /datum/reagent/medicine/strange_reagent/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -716,6 +741,7 @@
 	id = "mannitol"
 	description = "Mannitol is a sugar alcohol that can help alleviate cranial swelling."
 	color = "#D1D1F1"
+	taste_message = "neurogenisis"
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -727,6 +753,7 @@
 	id = "mutadone"
 	description = "Mutadone is an experimental bromide that can cure genetic abnomalities."
 	color = "#5096C8"
+	taste_message = "cleanliness"
 
 /datum/reagent/medicine/mutadone/on_mob_life(mob/living/carbon/human/M)
 	if(M.mind && M.mind.assigned_role == "Cluwne") // HUNKE
@@ -755,6 +782,7 @@
 	id = "antihol"
 	description = "A medicine which quickly eliminates alcohol in the body."
 	color = "#009CA8"
+	taste_message = "sobriety"
 
 /datum/reagent/medicine/antihol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -841,6 +869,7 @@
 	description = "A hormone generated by the pancreas responsible for metabolizing carbohydrates and fat in the bloodstream."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
+	taste_message = "tiredness"
 
 /datum/reagent/medicine/insulin/on_mob_life(mob/living/M)
 	M.reagents.remove_reagent("sugar", 5)
@@ -853,6 +882,7 @@
 	color = "#D782E6"
 	addiction_chance = 20
 	overdose_threshold = 50
+	taste_message = "warmth and stability"
 
 /datum/reagent/medicine/teporone/on_mob_life(mob/living/M)
 	if(M.bodytemperature > 310)
@@ -867,6 +897,7 @@
 	description = "Haloperidol is a powerful antipsychotic and sedative. Will help control psychiatric problems, but may cause brain damage."
 	reagent_state = LIQUID
 	color = "#FFDCFF"
+	taste_message = "stability"
 
 /datum/reagent/medicine/haloperidol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -898,6 +929,7 @@
 	reagent_state = LIQUID
 	color = "#96DEDE"
 	metabolization_rate = 0.1
+	taste_message = "sleepiness"
 
 /datum/reagent/medicine/ether/on_mob_life(mob/living/M)
 	M.AdjustJitter(-25)
@@ -919,6 +951,7 @@
 	reagent_state = SOLID
 	color = "#555555"
 	can_synth = FALSE
+	taste_message = "bodily perfection"
 
 /datum/reagent/medicine/syndicate_nanites/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -938,6 +971,7 @@
 	color = "#DCDCDC"
 	overdose_threshold = 30
 	metabolization_rate = 0.1
+	taste_message = "faint hope"
 
 /datum/reagent/medicine/omnizine_diluted/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -967,6 +1001,7 @@
 	reagent_state = LIQUID
 	color = "#CC7A00"
 	process_flags = SYNTHETIC
+	taste_message = "overclocking"
 
 /datum/reagent/medicine/degreaser/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -997,6 +1032,7 @@
 	reagent_state = LIQUID
 	color = "#D7B395"
 	process_flags = SYNTHETIC
+	taste_message = "heavy metals"
 
 /datum/reagent/medicine/liquid_solder/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1013,6 +1049,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
+	taste_message = "knitting wounds"
 
 /datum/reagent/medicine/bicaridine/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1031,6 +1068,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
+	taste_message = "soothed burns"
 
 /datum/reagent/medicine/kelotane/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1049,6 +1087,7 @@
 	description = "Ichor from an extremely powerful plant. Great for restoring wounds, but it's a little heavy on the brain."
 	color = "#FFAF00"
 	overdose_threshold = 25
+	taste_message = "a gift from nature"
 
 /datum/reagent/medicine/earthsblood/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -1074,6 +1113,7 @@
 	id = "corazone"
 	description = "A medication used to treat pain, fever, and inflammation, along with heart attacks."
 	color = "#F5F5F5"
+	taste_message = "a brief respite"
 
 // This reagent's effects are handled in heart attack handling code
 
@@ -1084,6 +1124,7 @@
 	color = "#9b3401"
 	metabolization_rate = 0.5
 	can_synth = FALSE
+	taste_message = "wholeness"
 
 /datum/reagent/medicine/nanocalcium/on_mob_life(mob/living/carbon/human/M)
 	var/update_flags = STATUS_UPDATE_NONE

--- a/code/modules/reagents/chemistry/reagents/misc.dm
+++ b/code/modules/reagents/chemistry/reagents/misc.dm
@@ -128,7 +128,7 @@
 	description = "A silvery white and ductile member of the boron group of chemical elements."
 	reagent_state = SOLID
 	color = "#A8A8A8" // rgb: 168, 168, 168
-	taste_message = null
+	taste_message = "metal"
 
 
 /datum/reagent/silicon
@@ -176,7 +176,7 @@
 	description = "A perfluoronated sulfonic acid that forms a foam when mixed with water."
 	reagent_state = LIQUID
 	color = "#9E6B38" // rgb: 158, 107, 56
-	taste_message = null
+	taste_message = "extreme discomfort"
 
 // metal foaming agent
 // this is lithium hydride. Add other recipies (e.g. LiH + H2O -> LiOH + H2) eventually
@@ -215,7 +215,7 @@
 	description = "A purple gaseous element."
 	reagent_state = GAS
 	color = "#493062"
-	taste_message = null
+	taste_message = "chemtrail resistance"
 
 /datum/reagent/carpet
 	name = "Carpet"
@@ -261,7 +261,7 @@
 	description = "Pure 100% nail polish remover, also works as an industrial solvent."
 	reagent_state = LIQUID
 	color = "#474747"
-	taste_message = null
+	taste_message = "nail polish remover"
 
 /datum/reagent/acetone/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -274,7 +274,7 @@
 	description = "Volatile."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
-	taste_message = null
+	taste_message = "one third of an explosion"
 
 /datum/reagent/colorful_reagent
 	name = "Colorful Reagent"
@@ -534,7 +534,7 @@
 	description = "Finely ground Coffee beans, used to make coffee."
 	reagent_state = SOLID
 	color = "#5B2E0D" // rgb: 91, 46, 13
-	taste_message = "bitterness"
+	taste_message = "waste"
 
 /datum/reagent/toxin/teapowder
 	name = "Ground Tea Leaves"
@@ -542,7 +542,7 @@
 	description = "Finely shredded Tea leaves, used for making tea."
 	reagent_state = SOLID
 	color = "#7F8400" // rgb: 127, 132, 0"
-	taste_message = "bitterness"
+	taste_message = "the future"
 
 //////////////////////////////////Hydroponics stuff///////////////////////////////
 
@@ -566,6 +566,7 @@
 	description = "Cheap and extremely common type of plant nutriment."
 	color = "#376400" // RBG: 50, 100, 0
 	tox_prob = 10
+	taste_message = "obscurity and toil"
 
 /datum/reagent/plantnutriment/left4zednutriment
 	name = "Left 4 Zed"
@@ -573,6 +574,7 @@
 	description = "Unstable nutriment that makes plants mutate more often than usual."
 	color = "#1A1E4D" // RBG: 26, 30, 77
 	tox_prob = 25
+	taste_message = "evolution"
 
 /datum/reagent/plantnutriment/robustharvestnutriment
 	name = "Robust Harvest"
@@ -580,6 +582,7 @@
 	description = "Very potent nutriment that prevents plants from mutating."
 	color = "#9D9D00" // RBG: 157, 157, 0
 	tox_prob = 15
+	taste_message = "bountifulness"
 
 ///Alchemical Reagents
 

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -78,7 +78,7 @@
 	color = "#FF0000"
 	metabolization_rate = 4
 	process_flags = ORGANIC | SYNTHETIC
-	taste_message = "literally liquid fire"
+	taste_message = null
 
 /datum/reagent/clf3/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -115,7 +115,6 @@
 	description = "Sends everything flying from the detonation point."
 	reagent_state = LIQUID
 	color = "#FFA500"
-	taste_message = "sound and fury"
 
 /datum/reagent/sorium_vortex
 	name = "sorium_vortex"
@@ -158,7 +157,6 @@
 	description = "Makes a very bright flash."
 	reagent_state = LIQUID
 	color = "#FFFF00"
-	taste_message = "even more speed"
 
 /datum/reagent/smoke_powder
 	name = "Smoke Powder"
@@ -166,7 +164,6 @@
 	description = "Makes a large cloud of smoke that can carry reagents."
 	reagent_state = LIQUID
 	color = "#808080"
-	taste_message = "ninjutsu"
 
 /datum/reagent/sonic_powder
 	name = "Sonic Powder"
@@ -174,7 +171,6 @@
 	description = "Makes a deafening noise."
 	reagent_state = LIQUID
 	color = "#0000FF"
-	taste_message = "speed"
 
 /datum/reagent/phlogiston
 	name = "Phlogiston"
@@ -183,7 +179,6 @@
 	reagent_state = LIQUID
 	color = "#FF9999"
 	process_flags = ORGANIC | SYNTHETIC
-	taste_message = "burning"
 
 /datum/reagent/phlogiston/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -204,7 +199,6 @@
 	reagent_state = LIQUID
 	color = "#FF9999"
 	process_flags = ORGANIC | SYNTHETIC
-	taste_message = "flammable goop"
 
 /datum/reagent/napalm/on_mob_life(mob/living/M)
 	M.adjust_fire_stacks(1)
@@ -220,7 +214,6 @@
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Cryostylane slowly cools all other reagents in the mob down to 0K."
 	color = "#B2B2FF" // rgb: 139, 166, 233
 	process_flags = ORGANIC | SYNTHETIC
-	taste_message = "cold"
 
 /datum/reagent/cryostylane/on_mob_life(mob/living/M) //TODO: code freezing into an ice cube
 	if(M.reagents.has_reagent("oxygen"))
@@ -246,7 +239,6 @@
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Pyrosium slowly heats all other reagents."
 	color = "#B20000" // rgb: 139, 166, 233
 	process_flags = ORGANIC | SYNTHETIC
-	taste_message = "heat"
 
 /datum/reagent/pyrosium/on_mob_life(mob/living/M)
 	if(M.reagents.has_reagent("oxygen"))
@@ -268,7 +260,6 @@
 	reagent_state = LIQUID
 	color = "#A0A090"
 	var/cooling_temperature = 3 // more effective than water
-	taste_message = "extreme discomfort"
 
 /datum/reagent/firefighting_foam/reaction_mob(mob/living/M, method=TOUCH, volume)
 // Put out fire

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic.dm
@@ -78,7 +78,7 @@
 	color = "#FF0000"
 	metabolization_rate = 4
 	process_flags = ORGANIC | SYNTHETIC
-	taste_message = null
+	taste_message = "literally liquid fire"
 
 /datum/reagent/clf3/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -115,6 +115,7 @@
 	description = "Sends everything flying from the detonation point."
 	reagent_state = LIQUID
 	color = "#FFA500"
+	taste_message = "sound and fury"
 
 /datum/reagent/sorium_vortex
 	name = "sorium_vortex"
@@ -157,6 +158,7 @@
 	description = "Makes a very bright flash."
 	reagent_state = LIQUID
 	color = "#FFFF00"
+	taste_message = "even more speed"
 
 /datum/reagent/smoke_powder
 	name = "Smoke Powder"
@@ -164,6 +166,7 @@
 	description = "Makes a large cloud of smoke that can carry reagents."
 	reagent_state = LIQUID
 	color = "#808080"
+	taste_message = "ninjutsu"
 
 /datum/reagent/sonic_powder
 	name = "Sonic Powder"
@@ -171,6 +174,7 @@
 	description = "Makes a deafening noise."
 	reagent_state = LIQUID
 	color = "#0000FF"
+	taste_message = "speed"
 
 /datum/reagent/phlogiston
 	name = "Phlogiston"
@@ -179,6 +183,7 @@
 	reagent_state = LIQUID
 	color = "#FF9999"
 	process_flags = ORGANIC | SYNTHETIC
+	taste_message = "burning"
 
 /datum/reagent/phlogiston/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -199,6 +204,7 @@
 	reagent_state = LIQUID
 	color = "#FF9999"
 	process_flags = ORGANIC | SYNTHETIC
+	taste_message = "flammable goop"
 
 /datum/reagent/napalm/on_mob_life(mob/living/M)
 	M.adjust_fire_stacks(1)
@@ -214,6 +220,7 @@
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Cryostylane slowly cools all other reagents in the mob down to 0K."
 	color = "#B2B2FF" // rgb: 139, 166, 233
 	process_flags = ORGANIC | SYNTHETIC
+	taste_message = "cold"
 
 /datum/reagent/cryostylane/on_mob_life(mob/living/M) //TODO: code freezing into an ice cube
 	if(M.reagents.has_reagent("oxygen"))
@@ -239,6 +246,7 @@
 	description = "Comes into existence at 20K. As long as there is sufficient oxygen for it to react with, Pyrosium slowly heats all other reagents."
 	color = "#B20000" // rgb: 139, 166, 233
 	process_flags = ORGANIC | SYNTHETIC
+	taste_message = "heat"
 
 /datum/reagent/pyrosium/on_mob_life(mob/living/M)
 	if(M.reagents.has_reagent("oxygen"))
@@ -260,6 +268,7 @@
 	reagent_state = LIQUID
 	color = "#A0A090"
 	var/cooling_temperature = 3 // more effective than water
+	taste_message = "extreme discomfort"
 
 /datum/reagent/firefighting_foam/reaction_mob(mob/living/M, method=TOUCH, volume)
 // Put out fire

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -116,7 +116,7 @@
 	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	reagent_state = LIQUID
 	color = "#1BB1AB"
-	taste_message = "oil"
+	taste_message = "cherry"
 
 /datum/reagent/lube/reaction_turf(turf/simulated/T, volume)
 	if(volume >= 1 && istype(T))
@@ -340,7 +340,7 @@
 	drink_icon = "glass_clear"
 	drink_name = "Glass of Water"
 	drink_desc = "The father of all refreshments."
-	taste_message = "holiness"
+	taste_message = null
 
 /datum/reagent/holywater/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -508,7 +508,7 @@
 	description = "Can be used to dry things."
 	reagent_state = LIQUID
 	color = "#A70FFF"
-	taste_message = "dryness"
+	taste_message = "dry mouth"
 
 /datum/reagent/drying_agent/reaction_turf(turf/simulated/T, volume)
 	if(istype(T) && T.wet)

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -285,6 +285,7 @@
 	name = "Vaccine"
 	id = "vaccine"
 	color = "#C81040" // rgb: 200, 16, 64
+	taste_message = "antibodies"
 
 /datum/reagent/vaccine/reaction_mob(mob/living/M, method=TOUCH, volume)
 	if(islist(data) && (method == INGEST))
@@ -339,7 +340,7 @@
 	drink_icon = "glass_clear"
 	drink_name = "Glass of Water"
 	drink_desc = "The father of all refreshments."
-	taste_message = null
+	taste_message = "holiness"
 
 /datum/reagent/holywater/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -440,7 +441,7 @@
 	description = "Something that shouldn't exist on this plane of existance."
 	process_flags = ORGANIC | SYNTHETIC //ethereal means everything processes it.
 	metabolization_rate = 1
-	taste_message = null
+	taste_message = "sulfur"
 
 /datum/reagent/fuel/unholywater/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
@@ -507,6 +508,7 @@
 	description = "Can be used to dry things."
 	reagent_state = LIQUID
 	color = "#A70FFF"
+	taste_message = "dryness"
 
 /datum/reagent/drying_agent/reaction_turf(turf/simulated/T, volume)
 	if(istype(T) && T.wet)


### PR DESCRIPTION
**What does this PR do:**
The system in SS13 which describes tastes and flavours is slightly underdeveloped. I have attempted to add a bit of flair to some of the various reagents, whether they be food, drink or something you probably shouldn't be eating. Grants a few more options to chefs and barkeeps.

(almost) every reagent that tastes of "bitterness" or some other generic string has been assigned a new flavor; flavor strength has been tentatively used with salt, msg and most toxins; salt and MSG are more likely to drown out other flavors in large amounts, while toxins are much harder to detect if masked correctly (they are roughly 8 times weaker than MSG, meaning that toxin and MSG in roughly equal proportions will mask the taste of poison, or salt:toxin in a 2:1 ratio). In addition, nutriment's flavor has been changed from "bitterness" to null, making basically everything in the kitchen a little less bitter.

[Thread](https://nanotrasen.se/forum/topic/14569-flavor-update/?tab=comments)
[Spreadsheet](https://docs.google.com/spreadsheets/d/1-Ou9mZtTqLxYGxmtRofNgZl7GRl7jIY6PDFZBAjT80w/)

**Changelog:**
:cl:
tweak: changed a whole bunch of strings to add a bit more flavor to most reagents in the game (most of these can be found in the spreadsheet).
experiment: resurrected the old "flavor_strength" value which appears fully functional in testing but has been entirely unused.
/:cl:

