### PR TITLE
Made lighter size consistent

### DIFF
--- a/code/game/objects/items/weapons/lighters.dm
+++ b/code/game/objects/items/weapons/lighters.dm
@@ -9,7 +9,7 @@
 	item_state = "lighter-g"
 	var/icon_on = "lighter-g-on"
 	var/icon_off = "lighter-g"
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_TINY
 	throwforce = 4
 	flags = CONDUCT
 	slot_flags = SLOT_BELT


### PR DESCRIPTION
**What does this PR do:**
Makes the lighter size consistent before and after first lighting. Before the fix, lighters would be considered small before first lighting and tiny after. Tiny size was chosen so that lighters could fit into cigarette packs.

**Changelog:**
:cl:
fix: made the lighter size consistent before and after first lighting.
/:cl:

