### PR TITLE
Booze/Soda Dispenser Changes.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -1034,6 +1034,15 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	containername = "party equipment"
 	announce_beacons = list("Bar" = list("Bar"))
 
+/datum/supply_packs/organic/bar
+	name = "Bar Starter Kit"
+	contains = list(/obj/item/storage/box/drinkingglasses,
+					/obj/item/circuitboard/soda,
+					/obj/item/circuitboard/beer)
+	cost = 20
+	containername = "beer starter kit"
+	announce_beacons = list("Bar" = list("Bar"))
+
 //////// livestock
 /datum/supply_packs/organic/cow
 	name = "Cow Crate"

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -617,6 +617,30 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stock_parts/manipulator = 2,
 							/obj/item/reagent_containers/glass/beaker = 2)
 
+/obj/item/circuitboard/soda
+	name = "Circuit board (Soda Machine)"
+	build_path = /obj/machinery/chem_dispenser/soda
+	board_type = "machine"
+	frame_desc = "Requires 2 Matter Bins, 1 Manipulators, 1 Capacitor, 1 Console Screen, and 1 Power Cell."
+	req_components = list(
+							/obj/item/stock_parts/matter_bin = 2,
+							/obj/item/stock_parts/manipulator = 1,
+							/obj/item/stock_parts/capacitor = 1,
+							/obj/item/stock_parts/console_screen = 1,
+							/obj/item/stock_parts/cell = 1)
+
+/obj/item/circuitboard/beer
+	name = "Circuit board (Beer Machine)"
+	build_path = /obj/machinery/chem_dispenser/beer
+	board_type = "machine"
+	frame_desc = "Requires 2 Matter Bins, 1 Manipulators, 1 Capacitor, 1 Console Screen, and 1 Power Cell."
+	req_components = list(
+							/obj/item/stock_parts/matter_bin = 2,
+							/obj/item/stock_parts/manipulator = 1,
+							/obj/item/stock_parts/capacitor = 1,
+							/obj/item/stock_parts/console_screen = 1,
+							/obj/item/stock_parts/cell = 1)
+
 
 /obj/item/circuitboard/circuit_imprinter
 	name = "Circuit board (Circuit Imprinter)"

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -264,7 +264,7 @@
 	dispensable_reagents = list("water", "ice", "milk", "soymilk", "coffee", "tea", "hot_coco", "cola", "spacemountainwind", "dr_gibb", "space_up",
 	"tonic", "sodawater", "lemon_lime", "grapejuice", "sugar", "orangejuice", "lemonjuice", "limejuice", "tomatojuice", "banana",
 	"watermelonjuice", "carrotjuice", "potato", "berryjuice")
-	/var/list/special_reagents2 = list(list(""),
+	var/list/special_reagents2 = list(list(""),
 							list("bananahonk", "milkshake", "cafe_latte", "cafe_mocha"),
 							list("triple_citrus", "icecoffe","icetea"))
 	hack_message = "You change the mode from 'McNano' to 'Pizza King'."
@@ -296,9 +296,8 @@
 	RefreshParts()
 
 /obj/machinery/chem_dispenser/soda/RefreshParts()
-	var/i
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		for(i=1, i<=M.rating, i++)
+		for(var/i in 1 to M.rating)
 			dispensable_reagents = sortList(dispensable_reagents | special_reagents2[i])
 
 /obj/machinery/chem_dispenser/soda/attackby(obj/item/I, mob/user, params)
@@ -306,7 +305,7 @@
 		if(panel_open)
 			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 			return
-		..()
+		return ..()
 	else
 		..()
 
@@ -316,23 +315,23 @@
 	if(exchange_parts(user, I))
 		return
 
-	if(istype(I, /obj/item/wrench))
+	if(iswrench(I))
 		playsound(src, I.usesound, 50, 1)
 		if(anchored)
-			anchored = 0
+			anchored = FALSE
 			to_chat(user, "<span class='caution'>[src] can now be moved.</span>")
 		else if(!anchored)
-			anchored = 1
+			anchored = TRUE
 			to_chat(user, "<span class='caution'>[src] is now secured.</span>")
 
 	if(panel_open)
-		if(istype(I, /obj/item/crowbar))
+		if(iscrowbar(I))
 			if(beaker)
 				var/obj/item/reagent_containers/glass/B = beaker
 				B.forceMove(loc)
 				beaker = null
 			default_deconstruction_crowbar(I)
-			return 1
+			return TRUE
 
 
 /obj/machinery/chem_dispenser/beer
@@ -343,7 +342,7 @@
 	max_energy = 100
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
 	dispensable_reagents = list("ice", "cream", "cider", "beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequila", "vermouth", "cognac", "ale", "mead", "synthanol")
-	/var/list/special_reagents3 = list(list("iced_beer"),
+	var/list/special_reagents3 = list(list("iced_beer"),
 								list("irishcream", "manhattan",),
 								list("antihol", "synthignon", "bravebull"))
 	hack_message = "You disable the 'nanotrasen-are-cheap-bastards' lock, enabling hidden and very expensive boozes."
@@ -375,9 +374,8 @@
 	RefreshParts()
 
 /obj/machinery/chem_dispenser/beer/RefreshParts()
-	var/i
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		for(i=1, i<=M.rating, i++)
+		for(var/i in 1 to M.rating)
 			dispensable_reagents = sortList(dispensable_reagents | special_reagents3[i])
 
 /obj/machinery/chem_dispenser/beer/attackby(obj/item/I, mob/user, params)
@@ -385,7 +383,7 @@
 		if(panel_open)
 			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
 			return
-		..()
+		return ..()
 	else
 		..()
 
@@ -395,23 +393,23 @@
 	if(exchange_parts(user, I))
 		return
 
-	if(istype(I, /obj/item/wrench))
+	if(iswrench(I))
 		playsound(src, I.usesound, 50, 1)
 		if(anchored)
-			anchored = 0
+			anchored = FALSE
 			to_chat(user, "<span class='caution'>[src] can now be moved.</span>")
 		else if(!anchored)
-			anchored = 1
+			anchored = TRUE
 			to_chat(user, "<span class='caution'>[src] is now secured.</span>")
 
 	if(panel_open)
-		if(istype(I, /obj/item/crowbar))
+		if(iscrowbar(I))
 			if(beaker)
 				var/obj/item/reagent_containers/glass/B = beaker
 				B.forceMove(loc)
 				beaker = null
 			default_deconstruction_crowbar(I)
-			return 1
+			return TRUE
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -264,9 +264,76 @@
 	dispensable_reagents = list("water", "ice", "milk", "soymilk", "coffee", "tea", "hot_coco", "cola", "spacemountainwind", "dr_gibb", "space_up",
 	"tonic", "sodawater", "lemon_lime", "grapejuice", "sugar", "orangejuice", "lemonjuice", "limejuice", "tomatojuice", "banana",
 	"watermelonjuice", "carrotjuice", "potato", "berryjuice")
+	/var/list/special_reagents2 = list(list(""),
+							list("bananahonk", "milkshake", "cafe_latte", "cafe_mocha"),
+							list("triple_citrus", "icecoffe","icetea"))
 	hack_message = "You change the mode from 'McNano' to 'Pizza King'."
 	unhack_message = "You change the mode from 'Pizza King' to 'McNano'."
 	hacked_reagents = list("thirteenloko")
+
+/obj/machinery/chem_dispenser/soda/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/soda(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stock_parts/capacitor(null)
+	component_parts += new /obj/item/stock_parts/console_screen(null)
+	component_parts += new /obj/item/stock_parts/cell/super(null)
+	RefreshParts()
+
+/obj/machinery/chem_dispenser/soda/upgraded/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/soda(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/super(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/super(null)
+	component_parts += new /obj/item/stock_parts/manipulator/pico(null)
+	component_parts += new /obj/item/stock_parts/capacitor/super(null)
+	component_parts += new /obj/item/stock_parts/console_screen(null)
+	component_parts += new /obj/item/stock_parts/cell/hyper(null)
+	RefreshParts()
+
+/obj/machinery/chem_dispenser/soda/RefreshParts()
+	var/i
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		for(i=1, i<=M.rating, i++)
+			dispensable_reagents = sortList(dispensable_reagents | special_reagents2[i])
+
+/obj/machinery/chem_dispenser/soda/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/reagent_containers/glass))
+		if(panel_open)
+			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
+			return
+		..()
+	else
+		..()
+
+	if(default_deconstruction_screwdriver(user, "minidispenser-o", "minidispenser", I))
+		return
+
+	if(exchange_parts(user, I))
+		return
+
+	if(istype(I, /obj/item/wrench))
+		playsound(src, I.usesound, 50, 1)
+		if(anchored)
+			anchored = 0
+			to_chat(user, "<span class='caution'>[src] can now be moved.</span>")
+		else if(!anchored)
+			anchored = 1
+			to_chat(user, "<span class='caution'>[src] is now secured.</span>")
+
+	if(panel_open)
+		if(istype(I, /obj/item/crowbar))
+			if(beaker)
+				var/obj/item/reagent_containers/glass/B = beaker
+				B.forceMove(loc)
+				beaker = null
+			default_deconstruction_crowbar(I)
+			return 1
+
 
 /obj/machinery/chem_dispenser/beer
 	icon_state = "booze_dispenser"
@@ -276,9 +343,75 @@
 	max_energy = 100
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
 	dispensable_reagents = list("ice", "cream", "cider", "beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequila", "vermouth", "cognac", "ale", "mead", "synthanol")
+	/var/list/special_reagents3 = list(list("iced_beer"),
+								list("irish_cream", "manhattan",),
+								list("antihol", "synthignon", "bravebull"))
 	hack_message = "You disable the 'nanotrasen-are-cheap-bastards' lock, enabling hidden and very expensive boozes."
 	unhack_message = "You re-enable the 'nanotrasen-are-cheap-bastards' lock, disabling hidden and very expensive boozes."
 	hacked_reagents = list("goldschlager", "patron", "absinthe", "ethanol", "nothing", "sake")
+
+/obj/machinery/chem_dispenser/beer/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/beer(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stock_parts/capacitor(null)
+	component_parts += new /obj/item/stock_parts/console_screen(null)
+	component_parts += new /obj/item/stock_parts/cell/super(null)
+	RefreshParts()
+
+/obj/machinery/chem_dispenser/beer/upgraded/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/beer(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/super(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/super(null)
+	component_parts += new /obj/item/stock_parts/manipulator/pico(null)
+	component_parts += new /obj/item/stock_parts/capacitor/super(null)
+	component_parts += new /obj/item/stock_parts/console_screen(null)
+	component_parts += new /obj/item/stock_parts/cell/hyper(null)
+	RefreshParts()
+
+/obj/machinery/chem_dispenser/beer/RefreshParts()
+	var/i
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		for(i=1, i<=M.rating, i++)
+			dispensable_reagents = sortList(dispensable_reagents | special_reagents3[i])
+
+/obj/machinery/chem_dispenser/beer/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/reagent_containers/glass))
+		if(panel_open)
+			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
+			return
+		..()
+	else
+		..()
+
+	if(default_deconstruction_screwdriver(user, "minidispenser-o", "minidispenser", I))
+		return
+
+	if(exchange_parts(user, I))
+		return
+
+	if(istype(I, /obj/item/wrench))
+		playsound(src, I.usesound, 50, 1)
+		if(anchored)
+			anchored = 0
+			to_chat(user, "<span class='caution'>[src] can now be moved.</span>")
+		else if(!anchored)
+			anchored = 1
+			to_chat(user, "<span class='caution'>[src] is now secured.</span>")
+
+	if(panel_open)
+		if(istype(I, /obj/item/crowbar))
+			if(beaker)
+				var/obj/item/reagent_containers/glass/B = beaker
+				B.forceMove(loc)
+				beaker = null
+			default_deconstruction_crowbar(I)
+			return 1
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -344,7 +344,7 @@
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one."
 	dispensable_reagents = list("ice", "cream", "cider", "beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequila", "vermouth", "cognac", "ale", "mead", "synthanol")
 	/var/list/special_reagents3 = list(list("iced_beer"),
-								list("irish_cream", "manhattan",),
+								list("irishcream", "manhattan",),
 								list("antihol", "synthignon", "bravebull"))
 	hack_message = "You disable the 'nanotrasen-are-cheap-bastards' lock, enabling hidden and very expensive boozes."
 	unhack_message = "You re-enable the 'nanotrasen-are-cheap-bastards' lock, disabling hidden and very expensive boozes."

--- a/code/modules/reagents/chemistry/reagents/drinks.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks.dm
@@ -387,7 +387,7 @@
 	drink_desc = "No relation to a certain rap artist/ actor."
 
 /datum/reagent/consumable/drink/bananahonk
-	name = "Banana Mama"
+	name = "Banana Honk"
 	id = "bananahonk"
 	description = "A drink from Clown Heaven."
 	color = "#664300" // rgb: 102, 67, 0


### PR DESCRIPTION
**What does this PR do:**
This PR updates Booze and Soda Dispensers in a few ways. It makes them movable, deconstruct-able, and upgrade-able. You can also now order a crate that comes with both boards from cargo as well as a package of drinking glasses, you'll still need to get the rest of the parts needed from science/cargo to complete it however.

As far as the upgrades the only thing as of current is adding a few more basic drinks to it when upgraded as well as Antihol on max upgrade. The logic behind Antihol is a competent bartender can already make it in a ghetto way, this will make it so you can have it by default if science bothers to upgrade your dispensers. The reasoning behind this was so the bartender can more readily stop the greytide that insist on coming into the bar, drinking everything, and murdering their livers. Which...if greytide do this constantly isn't that interesting for anyone and is more annoying than anything.

Currently it uses the chem dispenser icons for both when unscrewing for the maint panel, sadly not a spriter so I can't really change that. It fits enough as is at the very least.

Iced Beer is also added as a default drink option that requires no upgrades.

This drinks added are as follows;

Beer Dispenser;
![dreamseeker_zkwv9on7gg](https://user-images.githubusercontent.com/12178527/52752693-57342080-2fb9-11e9-8d25-d84b4ac557c0.png)

Default
-Iced Beer

Moderately Upgraded

- Irish Cream
- Manhattan

Max Upgrade

- Antihol
- Brave Bull
- Synthignon

Soda Dispenser

![dreamseeker_i8fan1gnya](https://user-images.githubusercontent.com/12178527/52752658-38ce2500-2fb9-11e9-9944-653fe9a3c901.png)
Default

- None

Moderate Upgrade

- Banana Honk
- Milkshake
- Cafe Latte
- Cafe Mocha

Max Upgrade

- Triple Citrus
- Iced Tea
- Iced Coffee

**Changelog:**
:cl: Mitchs98
add: Bar Starter Kit to Cargo. 20 points for both Beer/Soda Boards and a package of glasses.
tweak: Beer and Soda Machines can now be wrenched to move them.
tweak: Beer and Soda Machines can now be constructed as well as upgraded to include a slightly wider range of drinks.
fix: Properly named the Banana Honk to Banana Honk from Banana Mama.
/:cl: