### PR TITLE
AI's Wipe Core now properly ghosts the player

### DIFF
--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -38,7 +38,7 @@ var/global/list/empty_playable_ai_cores = list()
 			current_mode.possible_traitors.Remove(src)
 
 	// Ghost the current player and disallow them to return to the body
-	ghostize(0)
+	ghostize(FALSE)
 	// Delete the old AI shell
 	qdel(src)
 

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -37,6 +37,9 @@ var/global/list/empty_playable_ai_cores = list()
 			var/datum/game_mode/traitor/autotraitor/current_mode = ticker.mode
 			current_mode.possible_traitors.Remove(src)
 
+	// Ghost the current player and disallow them to return to the body
+	ghostize(0)
+	// Delete the old AI shell
 	qdel(src)
 
 // TODO: Move away from the insane name-based landmark system


### PR DESCRIPTION
**What does this PR do:**
Makes the AI's "Wipe Core" properly ghost the player. Before, the body was simply deleted, resulting in clients seeing only a black void until they reconnect.
Fixes #10721

**Changelog:**
:cl:
fix: AI's "Wipe Core" now properly ghosts the player
/:cl:

