### PR TITLE
Revert "Pulls Back Some Medical Powercreep"

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -14,14 +14,18 @@
 	dir = WEST
 	var/orient = "LEFT" // "RIGHT" changes the dir suffix to "-r"
 	var/mob/living/carbon/human/occupant = null
-	var/possible_chems = list("ephedrine", "salglu_solution", "salbutamol", "charcoal")
-	var/emergency_chems = list("ephedrine") // Desnowflaking
+	var/possible_chems = list(list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine"),
+							  list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine", "oculine"),
+							  list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine", "oculine", "charcoal", "mutadone", "mannitol"),
+							  list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine", "oculine", "charcoal", "mutadone", "mannitol", "pen_acid", "omnizine"))
+	var/emergency_chems = list("epinephrine") // Desnowflaking
 	var/amounts = list(5, 10)
 	var/obj/item/reagent_containers/glass/beaker = null
 	var/filtering = 0
 	var/max_chem
 	var/initial_bin_rating = 1
 	var/min_health = -25
+	var/injection_chems = list()
 	var/controls_inside = FALSE
 	idle_power_usage = 1250
 	active_power_usage = 2500
@@ -64,9 +68,13 @@
 
 /obj/machinery/sleeper/RefreshParts()
 	var/E
+	var/I
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		E += B.rating
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		I += M.rating
 
+	injection_chems = possible_chems[I]
 	max_chem = E * 20
 	min_health = -E * 25
 
@@ -208,7 +216,7 @@
 			data["beakerFreeSpace"] = 0
 
 	var/chemicals[0]
-	for(var/re in possible_chems)
+	for(var/re in injection_chems)
 		var/datum/reagent/temp = GLOB.chemical_reagents_list[re]
 		if(temp)
 			var/reagent_amount = 0
@@ -411,7 +419,7 @@
 		A.forceMove(loc)
 
 /obj/machinery/sleeper/proc/inject_chemical(mob/living/user as mob, chemical, amount)
-	if(!(chemical in possible_chems))
+	if(!(chemical in injection_chems))
 		to_chat(user, "<span class='notice'>The sleeper does not offer that chemical!</span>")
 		return
 
@@ -551,8 +559,6 @@
 /obj/machinery/sleeper/syndie
 	icon_state = "sleeper_s-open"
 	base_icon = "sleeper_s"
-	possible_chems = list("epinephrine", "ether", "salbutamol", "styptic_powder", "silver_sulfadiazine")
-	emergency_chems = list("epinephrine")
 	controls_inside = TRUE
 
 	light_color = LIGHT_COLOR_DARKRED

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -377,10 +377,16 @@
 			occupant.Sleeping(max(5/efficiency, (1/occupant.bodytemperature)*2000/efficiency))
 			occupant.Paralyse(max(5/efficiency, (1/occupant.bodytemperature)*3000/efficiency))
 			if(air_contents.oxygen > 2)
-				if(occupant.getOxyLoss())
-					occupant.adjustOxyLoss(-10)
+				if(occupant.getOxyLoss()) occupant.adjustOxyLoss(-1)
 			else
-				occupant.adjustOxyLoss(-2)
+				occupant.adjustOxyLoss(-1)
+			//severe damage should heal waaay slower without proper chemicals
+			if(occupant.bodytemperature < 225)
+				if(occupant.getToxLoss())
+					occupant.adjustToxLoss(max(-efficiency, (-20*(efficiency ** 2)) / occupant.getToxLoss()))
+				var/heal_brute = occupant.getBruteLoss() ? min(efficiency, 20*(efficiency**2) / occupant.getBruteLoss()) : 0
+				var/heal_fire = occupant.getFireLoss() ? min(efficiency, 20*(efficiency**2) / occupant.getFireLoss()) : 0
+				occupant.heal_organ_damage(heal_brute, heal_fire)
 		if(beaker && next_trans == 0)
 			var/proportion = 10 * min(1/beaker.volume, 1)
 			// Yes, this means you can get more bang for your buck with a beaker of SF vs a patch


### PR DESCRIPTION
Reverts ParadiseSS13/Paradise#10855

Players have given their thoughts on this and they feel that the sleeper nerf was over the top. It removed the vast majority of chems and kept or replaced them with niche chems or chems that only heal minimal damage. A sleeper isn't a first aid kit, and this is not a good solution.

:cl: DesolateG 
tweak: reverts sleepers and cryo tubes back to original stats.
/ :cl:
