### PR TITLE
Robobrain suicide fix

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -19,6 +19,10 @@
 	var/obj/item/radio/radio = null // For use with the radio MMI upgrade
 	var/datum/action/generic/configure_mmi_radio/radio_action = null
 
+	// Used for cases when mmi or one of it's children commits suicide.
+	// Needed to fix a rather insane bug when a posibrain/robotic brain commits suicide
+	var/dead_icon = "mmi_dead"
+
 /obj/item/mmi/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	if(istype(O, /obj/item/organ/internal/brain/crystal ))
 		to_chat(user, "<span class='warning'> This brain is too malformed to be able to use with the [src].</span>")

--- a/code/modules/mob/living/carbon/brain/death.dm
+++ b/code/modules/mob/living/carbon/brain/death.dm
@@ -4,8 +4,12 @@
 	if(!.)
 		return FALSE
 	if(!gibbed && container && istype(container, /obj/item/mmi))//If not gibbed but in a container.
+		var/obj/item/mmi/mmi = container
 		visible_message("<span class='danger'>[src]'s MMI flatlines!</span>", "<span class='warning'>You hear something flatline.</span>")
-		container.icon_state = "mmi_dead"
+		//
+		// Doesn't account for posibrains and robotic brains!
+		//
+		mmi.icon_state = mmi.dead_icon
 
 /mob/living/carbon/brain/gib()
 	// can we muster a parent call here?

--- a/code/modules/mob/living/carbon/brain/death.dm
+++ b/code/modules/mob/living/carbon/brain/death.dm
@@ -6,9 +6,6 @@
 	if(!gibbed && container && istype(container, /obj/item/mmi))//If not gibbed but in a container.
 		var/obj/item/mmi/mmi = container
 		visible_message("<span class='danger'>[src]'s MMI flatlines!</span>", "<span class='warning'>You hear something flatline.</span>")
-		//
-		// Doesn't account for posibrains and robotic brains!
-		//
 		mmi.icon_state = mmi.dead_icon
 
 /mob/living/carbon/brain/gib()

--- a/code/modules/mob/living/carbon/brain/robotic_brain.dm
+++ b/code/modules/mob/living/carbon/brain/robotic_brain.dm
@@ -21,6 +21,8 @@
 	var/mob/living/carbon/human/imprinted_master = null
 	var/ejected_flavor_text = "circuit"
 
+	dead_icon = "boris_blank"
+
 /obj/item/mmi/robotic_brain/Destroy()
 	imprinted_master = null
 	return ..()
@@ -229,3 +231,4 @@
 	silenced = TRUE
 	requires_master = FALSE
 	ejected_flavor_text = "metal cube"
+	dead_icon = "posibrain"


### PR DESCRIPTION
**What does this PR do:**
Fixes robobrains and posibrains losing their sprites if the player suicides while controlling one.
Fixes #10720

**Changelog:**
:cl:
fix: posibrains and robobrains don't vanish upon the controlling player's suicide
/:cl:

