### PR TITLE
Prevent objectives from targeting offstation roles

### DIFF
--- a/code/__DEFINES/gamemode.dm
+++ b/code/__DEFINES/gamemode.dm
@@ -4,6 +4,8 @@
 #define TARGET_INVALID_DEAD			3
 #define TARGET_INVALID_NOCKEY		4
 #define TARGET_INVALID_UNREACHABLE	5
+#define TARGET_INVALID_GOLEM		6
+#define TARGET_INVALID_EVENT		7
 
 //gamemode istype helpers
 #define GAMEMODE_IS_BLOB		(ticker && istype(ticker.mode, /datum/game_mode/blob))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -30,6 +30,7 @@
 
 	var/assigned_role //assigned role is what job you're assigned to when you join the station.
 	var/special_role //special roles are typically reserved for antags or roles like ERT. If you want to avoid a character being automatically announced by the AI, on arrival (becuase they're an off station character or something); ensure that special_role and assigned_role are equal.
+	var/offstation_role = FALSE //set to true for ERT, deathsquad, abductors, etc, that can go from and to z2 at will and shouldn't be antag targets
 	var/list/restricted_roles = list()
 
 	var/list/spell_list = list() // Wizard mode & "Give Spell" badmin button.

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -53,6 +53,7 @@ var/global/list/obj/cortical_stacks = list() //Stacks for 'leave nobody behind' 
 	for(var/datum/mind/raider in raiders)
 		raider.assigned_role = SPECIAL_ROLE_RAIDER
 		raider.special_role = SPECIAL_ROLE_RAIDER
+		raider.offstation_role = TRUE
 	..()
 	return 1
 

--- a/code/game/gamemodes/miniantags/abduction/abduction.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction.dm
@@ -76,10 +76,12 @@
 
 	scientist.assigned_role = SPECIAL_ROLE_ABDUCTOR_SCIENTIST
 	scientist.special_role = SPECIAL_ROLE_ABDUCTOR_SCIENTIST
+	scientist.offstation_role = TRUE
 	log_game("[key_name(scientist)] has been selected as an abductor team [team_number] scientist.")
 
 	agent.assigned_role = SPECIAL_ROLE_ABDUCTOR_AGENT
 	agent.special_role = SPECIAL_ROLE_ABDUCTOR_AGENT
+	agent.offstation_role = TRUE
 	log_game("[key_name(agent)] has been selected as an abductor team [team_number] agent.")
 
 	abductors |= agent

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -54,6 +54,7 @@ proc/issyndicate(mob/living/M as mob)
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_mind.assigned_role = SPECIAL_ROLE_NUKEOPS //So they aren't chosen for other jobs.
 		synd_mind.special_role = SPECIAL_ROLE_NUKEOPS
+		synd_mind.offstation_role = TRUE
 	return 1
 
 
@@ -172,6 +173,7 @@ proc/issyndicate(mob/living/M as mob)
 	M.dna.species.create_organs(M)
 	M.cleanSE() //No fat/blind/colourblind/epileptic/whatever ops.
 	M.overeatduration = 0
+	M.flavor_text = null
 
 	var/obj/item/organ/external/head/head_organ = M.get_organ("head")
 	var/hair_c = pick("#8B4513","#000000","#FF4500","#FFD700") // Brown, black, red, blonde

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -35,6 +35,11 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 		var/turf/current_location = get_turf(possible_target.current)
 		if(current_location && !is_level_reachable(current_location.z))
 			return TARGET_INVALID_UNREACHABLE
+	if(isgolem(possible_target.current))
+		return TARGET_INVALID_GOLEM
+	if(possible_target.offstation_role)
+		return TARGET_INVALID_EVENT
+
 
 /datum/objective/proc/find_target()
 	var/list/possible_targets = list()

--- a/code/game/jobs/job/central.dm
+++ b/code/game/jobs/job/central.dm
@@ -39,6 +39,12 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus
 	)
 
+/datum/outfit/job/ntnavyofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+	H.mind.offstation_role = TRUE
+
 // CC Officials who lead ERTs, Death Squads, etc.
 /datum/job/ntspecops
 	title = "Special Operations Officer"
@@ -89,3 +95,9 @@
 		/obj/item/organ/internal/cyberimp/chest/nutriment/plus,
 		/obj/item/organ/internal/cyberimp/arm/combat/centcom
 	)
+
+/datum/outfit/job/ntspecops/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
+	H.mind.offstation_role = TRUE

--- a/code/game/jobs/job/syndicate.dm
+++ b/code/game/jobs/job/syndicate.dm
@@ -53,5 +53,6 @@
 	H.faction += "syndicate"
 	var/datum/atom_hud/antag/opshud = huds[ANTAG_HUD_OPS]
 	opshud.join_hud(H.mind.current)
+	H.mind.offstation_role = TRUE
 	set_antag_hud(H.mind.current, "hudoperative")
 	H.regenerate_icons()

--- a/code/modules/admin/verbs/gimmick_team.dm
+++ b/code/modules/admin/verbs/gimmick_team.dm
@@ -72,6 +72,7 @@
 		H.mind_initialize()
 		H.mind.assigned_role = "Event Character"
 		H.mind.special_role = "Event Character"
+		H.mind.offstation_role = TRUE
 
 		H.key = thisplayer.key
 

--- a/code/modules/admin/verbs/honksquad.dm
+++ b/code/modules/admin/verbs/honksquad.dm
@@ -93,6 +93,7 @@ var/global/sent_honksquad = 0
 	new_honksquad.mind_initialize()
 	new_honksquad.mind.assigned_role = SPECIAL_ROLE_HONKSQUAD
 	new_honksquad.mind.special_role = SPECIAL_ROLE_HONKSQUAD
+	new_honksquad.mind.offstation_role = TRUE
 	new_honksquad.add_language("Clownish")
 	ticker.mode.traitors |= new_honksquad.mind//Adds them to current traitor list. Which is really the extra antagonist list.
 	new_honksquad.equip_honksquad(honk_leader_selected)

--- a/code/modules/admin/verbs/infiltratorteam_syndicate.dm
+++ b/code/modules/admin/verbs/infiltratorteam_syndicate.dm
@@ -131,6 +131,7 @@ var/global/sent_syndicate_infiltration_team = 0
 	new_syndicate_infiltrator.mind_initialize()
 	new_syndicate_infiltrator.mind.assigned_role = "Syndicate Infiltrator"
 	new_syndicate_infiltrator.mind.special_role = "Syndicate Infiltrator"
+	new_syndicate_infiltrator.mind.offstation_role = TRUE //they can flee to z2 so make them inelligible as antag targets
 	ticker.mode.traitors |= new_syndicate_infiltrator.mind //Adds them to extra antag list
 	new_syndicate_infiltrator.equip_syndicate_infiltrator(syndicate_leader_selected, uplink_tc, is_mgmt)
 	return new_syndicate_infiltrator

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -415,7 +415,7 @@ client/proc/one_click_antag()
 	new_syndicate_commando.mind_initialize()
 	new_syndicate_commando.mind.assigned_role = SPECIAL_ROLE_SYNDICATE_DEATHSQUAD
 	new_syndicate_commando.mind.special_role = SPECIAL_ROLE_SYNDICATE_DEATHSQUAD
-
+	new_syndicate_commando.mind.offstation_role = TRUE
 	//Adds them to current traitor list. Which is really the extra antagonist list.
 	ticker.mode.traitors += new_syndicate_commando.mind
 	new_syndicate_commando.equip_syndicate_commando(syndicate_leader_selected)

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -85,6 +85,7 @@ var/global/sent_strike_team = 0
 				R.mind.original = R
 				R.mind.assigned_role = SPECIAL_ROLE_DEATHSQUAD
 				R.mind.special_role = SPECIAL_ROLE_DEATHSQUAD
+				R.mind.offstation_role = TRUE
 				if(!(R.mind in ticker.minds))
 					ticker.minds += R.mind
 				ticker.mode.traitors += R.mind

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -116,6 +116,7 @@ var/global/sent_syndicate_strike_team = 0
 	new_syndicate_commando.mind_initialize()
 	new_syndicate_commando.mind.assigned_role = SPECIAL_ROLE_SYNDICATE_DEATHSQUAD
 	new_syndicate_commando.mind.special_role = SPECIAL_ROLE_SYNDICATE_DEATHSQUAD
+	new_syndicate_commando.mind.offstation_role = TRUE
 	ticker.mode.traitors |= new_syndicate_commando.mind	//Adds them to current traitor list. Which is really the extra antagonist list.
 	new_syndicate_commando.equip_syndicate_commando(is_leader)
 	qdel(spawn_location)

--- a/code/modules/events/traders.dm
+++ b/code/modules/events/traders.dm
@@ -47,6 +47,7 @@ var/global/list/unused_trade_stations = list("sol")
 				M.equipOutfit(/datum/outfit/admin/sol_trader)
 				M.dna.species.after_equip_job(null, M)
 				M.mind.objectives += trader_objectives
+				M.mind.offstation_role = TRUE
 				greet_trader(M)
 				success_spawn = 1
 		if(success_spawn)


### PR DESCRIPTION
This PR adds a var to all (I hope) offstation roles that travel between z2 and z1 (ERT, deathsquad, abductors, traders, etc.)

This var is checked when an objective (like assassinate) targets somebody

This PR also removes flavor text from nukies and prevent all golems from being targets

Fixes #10886 Fixes #7165

🆑
fix: Golems can no longer be objective targets
fix: Offstation antag/special roles such as the ERT, abductors, etc, can no longer be objectives targets
fix: Nukies no longer retain flavor text from saved character
/🆑