### PR TITLE
fix secbots construction names

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -389,7 +389,7 @@
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "helmet_signaler"
 	item_state = "helmet"
-	var/created_name = "Griefsky" //To preserve the name if it's a unique securitron I guess
+	var/created_name = "Securitron" //To preserve the name if it's a unique securitron I guess
 	var/build_step = 0
 
 /obj/item/clothing/head/helmet/attackby(obj/item/assembly/signaler/S, mob/user, params)

--- a/code/modules/mob/living/simple_animal/bot/griefsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/griefsky.dm
@@ -226,6 +226,6 @@
 			visible_message("[src] deflects [user]'s move with his energy swords!")
 			playsound(loc, 'sound/weapons/blade1.ogg', 50, TRUE, -1)
 		else
-			..()
+			return ..()
 	else
-		..()
+		return ..()

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -287,7 +287,7 @@
 		new /obj/item/robot_parts/r_arm(Tsec)
 		new /obj/item/bikehorn(Tsec)
 		new /obj/item/assembly/prox_sensor(Tsec)
-
+	new /obj/effect/decal/cleanable/blood/oil(loc)
 	var/datum/effect_system/spark_spread/s = new
 	s.set_up(3, 1, src)
 	s.start()


### PR DESCRIPTION
Fixes my previous PR and some returns:
Secbots made by construction method were all named griefsky

https://github.com/ParadiseSS13/Paradise/pull/10750


:cl:
fix: Name of secbots
fix: Honkbot wasnt dropping oil when exploded
/:cl:

