### PR TITLE
Secbot lights fix

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -33,8 +33,6 @@
 	var/check_records = 1 //Does it check security records?
 	var/arrest_type = 0 //If true, don't handcuff
 	var/harmbaton = 0 //If true, beat instead of stun
-	var/flashing_lights = 0 //If true, flash lights
-	var/prev_flashing_lights = 0
 	allow_pai = 0
 
 /mob/living/simple_animal/bot/secbot/beepsky
@@ -233,7 +231,7 @@ Auto Patrol: []"},
 			light_color = LIGHT_COLOR_PURE_RED
 			sleep(3)
 			flash_lights--
-	//	update_light()
+		update_light()
 		light_color = LIGHT_COLOR_WHITE
 
 /mob/living/simple_animal/bot/secbot/proc/cuff(mob/living/carbon/C)
@@ -270,33 +268,9 @@ Auto Patrol: []"},
 	C.visible_message("<span class='danger'>[src] has [harmbaton ? "beaten" : "stunned"] [C]!</span>",\
 							"<span class='userdanger'>[src] has [harmbaton ? "beaten" : "stunned"] you!</span>")
 
-/*/mob/living/simple_animal/bot/secbot/Life(seconds, times_fired)
-	. = ..()
-	if(flashing_lights)
-		switch(light_color)
-			if(LIGHT_COLOR_PURE_RED)
-				light_color = LIGHT_COLOR_PURE_BLUE
-			if(LIGHT_COLOR_PURE_BLUE)
-				light_color = LIGHT_COLOR_PURE_RED
-		update_light()
-	else if(prev_flashing_lights)
-		light_color = LIGHT_COLOR_PURE_RED
-		update_light()
-
-	prev_flashing_lights = flashing_lights
-
-/mob/living/simple_animal/bot/secbot/verb/toggle_flashing_lights()
-	set name = "Toggle Flashing Lights"
-	set category = "Object"
-	set src = usr 
-
-	flashing_lights = !flashing_lights
-
 /mob/living/simple_animal/bot/secbot/handle_automated_action()
 	if(!..())
 		return
-
-	flashing_lights = mode == BOT_HUNT */
 
 	switch(mode)
 		if(BOT_IDLE)		// idle
@@ -306,9 +280,8 @@ Auto Patrol: []"},
 				mode = BOT_START_PATROL	// switch to patrol mode
 
 		if(BOT_HUNT)		// hunting for perp
-			// if can't reach perp for long enough, go idle
 			lights_switch()
-			if(frustration >= 8)
+			if(frustration >= 8)	// if can't reach perp for long enough, go idle
 				walk_to(src,0)
 				back_to_idle()
 				return

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -216,7 +216,6 @@ Auto Patrol: []"},
 	else
 		..()
 
-
 /mob/living/simple_animal/bot/secbot/hitby(atom/movable/AM, skipcatch = 0, hitpush = 1, blocked = 0)
 	if(istype(AM, /obj/item))
 		var/obj/item/I = AM
@@ -225,6 +224,17 @@ Auto Patrol: []"},
 			retaliate(H)
 	..()
 
+/mob/living/simple_animal/bot/secbot/proc/lights_switch()
+	spawn(0)
+		var/flash_lights = 10
+		while(flash_lights)
+			light_color = LIGHT_COLOR_PURE_BLUE
+			sleep(3)
+			light_color = LIGHT_COLOR_PURE_RED
+			sleep(3)
+			flash_lights--
+	//	update_light()
+		light_color = LIGHT_COLOR_WHITE
 
 /mob/living/simple_animal/bot/secbot/proc/cuff(mob/living/carbon/C)
 	mode = BOT_ARREST
@@ -260,7 +270,7 @@ Auto Patrol: []"},
 	C.visible_message("<span class='danger'>[src] has [harmbaton ? "beaten" : "stunned"] [C]!</span>",\
 							"<span class='userdanger'>[src] has [harmbaton ? "beaten" : "stunned"] you!</span>")
 
-/mob/living/simple_animal/bot/secbot/Life(seconds, times_fired)
+/*/mob/living/simple_animal/bot/secbot/Life(seconds, times_fired)
 	. = ..()
 	if(flashing_lights)
 		switch(light_color)
@@ -278,7 +288,7 @@ Auto Patrol: []"},
 /mob/living/simple_animal/bot/secbot/verb/toggle_flashing_lights()
 	set name = "Toggle Flashing Lights"
 	set category = "Object"
-	set src = usr
+	set src = usr 
 
 	flashing_lights = !flashing_lights
 
@@ -286,7 +296,7 @@ Auto Patrol: []"},
 	if(!..())
 		return
 
-	flashing_lights = mode == BOT_HUNT
+	flashing_lights = mode == BOT_HUNT */
 
 	switch(mode)
 		if(BOT_IDLE)		// idle
@@ -297,6 +307,7 @@ Auto Patrol: []"},
 
 		if(BOT_HUNT)		// hunting for perp
 			// if can't reach perp for long enough, go idle
+			lights_switch()
 			if(frustration >= 8)
 				walk_to(src,0)
 				back_to_idle()

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -224,7 +224,7 @@ Auto Patrol: []"},
 
 /mob/living/simple_animal/bot/secbot/proc/lights_switch()
 	spawn(0)
-		var/flash_lights = 10
+		var/flash_lights = 20
 		while(flash_lights)
 			light_color = LIGHT_COLOR_PURE_BLUE
 			sleep(3)
@@ -280,7 +280,6 @@ Auto Patrol: []"},
 				mode = BOT_START_PATROL	// switch to patrol mode
 
 		if(BOT_HUNT)		// hunting for perp
-			lights_switch()
 			if(frustration >= 8)	// if can't reach perp for long enough, go idle
 				walk_to(src,0)
 				back_to_idle()
@@ -392,6 +391,7 @@ Auto Patrol: []"},
 			mode = BOT_HUNT
 			spawn(0)
 				handle_automated_action()	// ensure bot quickly responds to a perp
+			lights_switch()
 			break
 		else
 			continue


### PR DESCRIPTION
Sec Bots and beepsky lights arent working fine.  The first chasing sirens lights dont work at all.
When cuffing they become red and stay like that forever

After the first chase they work like a siren like its intended when chasing a criminal. But red light keeps on even on patrolling or idle mode.

This PR trys to fix that re-writing the lights mess code 

**This seems to be from 2016 _"Ports tg simple_animal bots"_** However TG seems to have removed the lights

https://github.com/ParadiseSS13/Paradise/blob/25195208a96f821f34b30baea9d64da0b84fea12/code/modules/mob/living/simple_animal/bot/secbot.dm


:cl:
fix: Secbot lights were fixed
/:cl:

