### PR TITLE
Adds Compact Sniper Rifle to Uplink

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/dangerous/sniper_compact //For when you really really hate that one guy.
 	name = "Compact Sniper Rifle"
-	desc = "A compact, non-scopable version of the operative sniper rifle. Packs a powerful punch, but ammo is limited."
+	desc = "A compact, unscoped version of the operative sniper rifle. Packs a powerful punch, but ammo is limited."
 	reference = "CSR"
 	item = /obj/item/gun/projectile/automatic/sniper_rifle/compact
 	cost = 16

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -482,6 +482,16 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 25
 	gamemodes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/dangerous/sniper_compact //For when you really really hate that one guy.
+	name = "Compact Sniper Rifle"
+	desc = "A compact, non-scopable version of the operative sniper rifle. Packs a powerful punch, but ammo is limited."
+	reference = "CSR"
+	item = /obj/item/gun/projectile/automatic/sniper_rifle/compact
+	cost = 16
+	surplus = 0
+	cant_discount = TRUE
+	excludefrom = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/dangerous/crossbow
 	name = "Energy Crossbow"
 	desc = "A miniature energy crossbow that is small enough both to fit into a pocket and to slip into a backpack unnoticed by observers. Fires bolts tipped with toxin, a poisonous substance that is the product of a living organism. Stuns enemies for a short period of time. Recharges automatically."

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -39,6 +39,17 @@
 	can_unsuppress = 0
 	can_suppress = 0
 
+/obj/item/gun/projectile/automatic/sniper_rifle/compact //holds very little ammo, lacks zooming, and bullets are primarily damage dealers, but the gun lacks the downsides of the full size rifle
+	name = "compact sniper rifle"
+	desc = "a compact, non-scopable version of the standard issue syndicate sniper rifle. Still capable of sending people crying."
+	recoil = 0
+	weapon_weight = WEAPON_LIGHT
+	fire_delay = 0
+	mag_type = /obj/item/ammo_box/magazine/sniper_rounds/compact
+	can_unsuppress = FALSE
+	can_suppress = FALSE
+	zoomable = FALSE
+
 //Normal Boolets
 /obj/item/ammo_box/magazine/sniper_rounds
 	name = "sniper rounds (.50)"
@@ -158,6 +169,23 @@
 	stun = 0
 	dismemberment = 0
 	weaken = 0
+	breakthings = FALSE
+
+//compact ammo
+/obj/item/ammo_box/magazine/sniper_rounds/compact
+	name = "sniper rounds (compact)"
+	desc = "An extremely powerful round capable of inflicting massive damage on a target."
+	ammo_type = /obj/item/ammo_casing/compact
+	max_ammo = 4
+
+/obj/item/ammo_casing/compact
+	desc = "A .50 caliber compact round casing."
+	caliber = ".50"
+	projectile_type = /obj/item/projectile/bullet/sniper/compact
+	icon_state = ".50"
+
+/obj/item/projectile/bullet/sniper/compact //Can't dismember, and can't break things; just deals massive damage.
+	dismemberment = 0
 	breakthings = FALSE
 
 //toy magazine

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -41,7 +41,7 @@
 
 /obj/item/gun/projectile/automatic/sniper_rifle/compact //holds very little ammo, lacks zooming, and bullets are primarily damage dealers, but the gun lacks the downsides of the full size rifle
 	name = "compact sniper rifle"
-	desc = "a compact, non-scopable version of the standard issue syndicate sniper rifle. Still capable of sending people crying."
+	desc = "a compact, unscoped version of the standard issue syndicate sniper rifle. Still capable of sending people crying."
 	recoil = 0
 	weapon_weight = WEAPON_LIGHT
 	fire_delay = 0


### PR DESCRIPTION
Inspired by Goon's hunting rifle.

Adds the compact sniper rifle to the uplink.

This is just a massively powerful and hugely expensive gun that deals incredible damage to whoever it hits.

Unlike the full syndicate rifle, it can't zoom, and it only holds 4 bullets (can't purchase more either). On the plus side, it doesn't have as much recoil, can fire more rapidly, and doesn't require both hands free to fire. Bullets fired from it don't roll for a chance to dismember and it's not going to explode objects either.

Good for deleting a single target once, but not for much else.

:cl: Fox McCloud
add: Adds the compact syndicate sniper rifle to the uplink. A weaker, low capacity variant of the operative syndicate rifle
/:cl: