### PR TITLE
Prevent golems from using telescience consoles

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -87,7 +87,7 @@
 
 /obj/machinery/computer/telescience/attack_hand(mob/user)
 	if(isgolem(user)) //this is why we can't have nice things free golems
-		to_chat(user, "<span class='warning'>Golem user detected. Access denied.</span>")
+		to_chat(user, "<span class='warning'>You can't make sense of the console or how to use it.</span>")
 		return
 	if(..())
 		return

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -86,6 +86,9 @@
 	src.attack_hand(user)
 
 /obj/machinery/computer/telescience/attack_hand(mob/user)
+	if(isgolem(user)) //this is why we can't have nice things free golems
+		to_chat(user, "<span class='warning'>Golem user detected. Access denied.</span>")
+		return
 	if(..())
 		return
 	interact(user)


### PR DESCRIPTION
This is why we cant have nice things

Golems (free or otherwise) can no longer use telescience consoles

Quantum pads/Teleporters/etc are still fine

This is due to repeated abuse of telesci by free golems despite being instructed not to interfere with the station


🆑
del: Golems can no longer use telescience consoles.
/🆑