### PR TITLE
Allow antag clown to toggle clumsy

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -140,7 +140,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		if(changeling.current.mind.assigned_role == "Clown")
 			to_chat(changeling.current, "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself.")
 			changeling.current.mutations.Remove(CLUMSY)
-
+			var/datum/action/innate/toggle_clumsy/A = new
+			A.Grant(changeling.current)
 	var/obj_count = 1
 	for(var/datum/objective/objective in changeling.objectives)
 		to_chat(changeling.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -157,7 +157,8 @@ var/global/list/all_cults = list()
 		if(mob.mind.assigned_role == "Clown")
 			to_chat(mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 			mob.mutations.Remove(CLUMSY)
-
+			var/datum/action/innate/toggle_clumsy/A = new
+			A.Grant(mob)
 	var/obj/item/paper/talisman/supply/T = new(mob)
 	var/list/slots = list (
 		"backpack" = slot_in_backpack,

--- a/code/game/gamemodes/devil/game_mode.dm
+++ b/code/game/gamemodes/devil/game_mode.dm
@@ -39,6 +39,8 @@
 	if(devil_mind.assigned_role == "Clown")
 		to_chat(devil_mind.current, "Your infernal nature allows you to wield weapons without harming yourself.")
 		devil_mind.current.mutations.Remove(CLUMSY)
+		var/datum/action/innate/toggle_clumsy/A = new
+		A.Grant(devil_mind.current)
 	spawn(10)
 		devil_mind.devilinfo.update_hud()
 	if(issilicon(devil_mind.current))

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -122,7 +122,8 @@
 		if(mob.mind.assigned_role == "Clown")
 			to_chat(mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 			mob.mutations.Remove(CLUMSY)
-
+			var/datum/action/innate/toggle_clumsy/A = new
+			A.Grant(mob)
 
 	var/obj/item/flash/T = new(mob)
 	var/obj/item/toy/crayon/spraycan/R = new(mob)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -299,6 +299,9 @@
 		if(traitor_mob.mind.assigned_role == "Clown")
 			to_chat(traitor_mob, "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 			traitor_mob.mutations.Remove(CLUMSY)
+			var/datum/action/innate/toggle_clumsy/A = new
+			A.Grant(traitor_mob)
+
 
 	// find a radio! toolbox(es), backpack, belt, headset
 	var/obj/item/R = locate(/obj/item/pda) in traitor_mob.contents //Hide the uplink in a PDA if available, otherwise radio

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -186,7 +186,8 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 		if(vampire.current.mind.assigned_role == "Clown")
 			to_chat(vampire.current, "Your lust for blood has allowed you to overcome your clumsy nature allowing you to wield weapons without harming yourself.")
 			vampire.current.mutations.Remove(CLUMSY)
-
+			var/datum/action/innate/toggle_clumsy/A = new
+			A.Grant(vampire.current)
 	var/obj_count = 1
 	for(var/datum/objective/objective in vampire.objectives)
 		to_chat(vampire.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")

--- a/code/game/jobs/job/support.dm
+++ b/code/game/jobs/job/support.dm
@@ -253,6 +253,27 @@
 	if(!ismachine(H))
 		H.mutations.Add(COMIC)
 
+//action given to antag clowns
+/datum/action/innate/toggle_clumsy
+	name = "Toggle Clown Clumsy"
+	button_icon_state = "clown"
+
+/datum/action/innate/toggle_clumsy/Activate()
+	var/mob/living/carbon/human/H = owner
+	H.mutations.Add(CLUMSY)
+	active = TRUE
+	background_icon_state = "bg_spell"
+	UpdateButtonIcon()
+	to_chat(H, "<span class='notice'>You start acting clumsy to throw suspicions off. Focus again before using weapons.</span>")
+
+/datum/action/innate/toggle_clumsy/Deactivate()
+	var/mob/living/carbon/human/H = owner
+	H.mutations.Remove(CLUMSY)
+	active = FALSE
+	background_icon_state = "bg_default"
+	UpdateButtonIcon()
+	to_chat(H, "<span class='notice'>You focus and can now use weapons regularly.</span>")
+
 /datum/job/mime
 	title = "Mime"
 	flag = MIME


### PR DESCRIPTION
This PR adds the ability for antag clowns to toggle clumsy on and off with an action button.

![clumsytoggle1](https://user-images.githubusercontent.com/22121511/53045873-a16c4480-3486-11e9-8007-15e4e90aabdb.png)
![clumsytoggle2](https://user-images.githubusercontent.com/22121511/53045877-a4ffcb80-3486-11e9-8f61-c745ad5abda1.png)
![clumsytoggle3](https://user-images.githubusercontent.com/22121511/53045885-a92be900-3486-11e9-8e60-e8b9cdbeef0d.png)


The purpose is to better pass as a clown. It's also technically possible to meta that a clown is an antag by him never misfiring a shot or other clumsy check right now, although I've never seen this happen in the server.

Shadowlings aren't included because I don't want to deal with hatching and slings shouldn't stay in their original form for too long anyway

🆑
add: Antag clowns can now toggle their clumsiness off and on.
/🆑