### PR TITLE
Adds Stable Mutagen

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -176,6 +176,38 @@
 	return ..()
 
 
+/datum/reagent/stable_mutagen
+	name = "Stable mutagen"
+	id = "stable_mutagen"
+	description = "Just the regular, boring sort of mutagenic compound.  Works in a completely predictable manner."
+	reagent_state = LIQUID
+	color = "#7DFF00"
+
+/datum/reagent/stable_mutagen/on_mob_life(mob/living/M)
+	if(!ishuman(M) || !M.dna)
+		return
+	M.apply_effect(2*REAGENTS_EFFECT_MULTIPLIER, IRRADIATE, negate_armor = 1)
+	if(current_cycle == 10 && islist(data))
+		if(istype(data["dna"], /datum/dna))
+			var/mob/living/carbon/human/H = M
+			var/datum/dna/D = data["dna"]
+			H.set_species(D.species.type, retain_damage = TRUE)
+			H.dna = D.Clone()
+			H.real_name = D.real_name
+			domutcheck(H, null, MUTCHK_FORCED)
+			H.dna.UpdateSE()
+			H.dna.UpdateUI()
+			H.sync_organ_dna(TRUE)
+			H.UpdateAppearance()
+
+	return ..()
+
+/datum/reagent/stable_mutagen/on_tick()
+	var/datum/reagent/blood/B = locate() in holder.reagent_list
+	if(B && islist(B.data) && !data)
+		data = B.data.Copy()
+	..()
+
 /datum/reagent/uranium
 	name ="Uranium"
 	id = "uranium"

--- a/code/modules/reagents/chemistry/reagents/water.dm
+++ b/code/modules/reagents/chemistry/reagents/water.dm
@@ -194,7 +194,7 @@
 
 
 /datum/reagent/blood
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=null,"blood_colour"="#A10808","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null,"blood_type"=null,"blood_colour"="#A10808","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null, "dna" = null)
 	name = "Blood"
 	id = "blood"
 	reagent_state = LIQUID

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -154,6 +154,19 @@
 	result_amount = 3
 	mix_message = "The substance turns neon green and bubbles unnervingly."
 
+/datum/chemical_reaction/stable_mustagen
+	name = "Stable mutagen"
+	id = "stable_mutagen"
+	result = "stable_mutagen"
+	required_reagents = list("mutagen" = 1, "lithium" = 1, "acetone" = 1, "bromine" = 1)
+	result_amount = 3
+	mix_message = "The substance turns a drab green and begins to bubble."
+
+/datum/chemical_reaction/stable_mustagen/stable_mustagen2
+	id = "stable_mutagen2"
+	required_reagents = list("mutadone" = 3, "lithium" = 1)
+	result_amount = 4
+
 /datum/chemical_reaction/heparin
 	name = "Heparin"
 	id = "Heparin"

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -210,6 +210,7 @@
 		blood_data["real_name"] = real_name
 		blood_data["blood_color"] = dna.species.blood_color
 		blood_data["factions"] = faction
+		blood_data["dna"] = dna.Clone()
 		return blood_data
 
 //get the id of the substance this mob use as blood.


### PR DESCRIPTION
From Goon. Credit to them.

Adds in stable mutagen.

Stable mutagen is a mutagenic compound that absorbs the DNA of a blood sample and allows users to become the DNA of the blood sample taken.

As a technical note, this is a bit quirky; once stable mutagen binds with DNA, it binds with it permanently and can't be filtered out; if you want a different identity bound to the compound, injecting it with different blood won't do anything; it'll have to be fresh.

Created by combining mutagen,  lithium, acetone, and bromine or by combining mutadone with lithium.

:cl: Fox McCloud
add: Adds in stable mutagen; a DNA altering compound
/:cl: