### PR TITLE
Adds "voice" option to magic mirror

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -140,7 +140,7 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/choice = input(user, "Something to change?", "Magical Grooming") as null|anything in list("Name", "Body")
+	var/choice = input(user, "Something to change?", "Magical Grooming") as null|anything in list("Name", "Body", "Voice")
 
 	switch(choice)
 		if("Name")
@@ -172,6 +172,25 @@
 				AC.whitelist = race_list
 				ui_users[user] = AC
 			AC.ui_interact(user)
+		if("Voice")
+			var/voice_choice = input(user, "Perhaps...", "Voice effects") as null|anything in list("Comic Sans", "Wingdings", "Swedish", "Chav")
+			var/voice_mutation
+			switch(voice_choice)
+				if("Comic Sans")
+					voice_mutation = COMICBLOCK
+				if("Wingdings")
+					voice_mutation = WINGDINGSBLOCK
+				if("Swedish")
+					voice_mutation = SWEDEBLOCK
+				if("Chav")
+					voice_mutation = CHAVBLOCK
+			if(voice_mutation)
+				if(H.dna.GetSEState(voice_mutation))
+					H.dna.SetSEState(voice_mutation, FALSE)
+					genemutcheck(H, voice_mutation, null, MUTCHK_FORCED)
+				else
+					H.dna.SetSEState(voice_mutation, TRUE)
+					genemutcheck(H, voice_mutation, null, MUTCHK_FORCED)
 
 /obj/structure/mirror/magic/attackby(obj/item/I, mob/living/user, params)
 	return


### PR DESCRIPTION
This PR adds a new option to the magic mirror, "Voice"

This lets the wizard toggle comic sans, wingdings, swedish and chav genes on or off

🆑
add: Added a "voice" option to the magic mirror, letting you toggle comic sans/wingdings/swedish/chav
/🆑