### PR TITLE
Terror spider princess and white update

### DIFF
--- a/code/modules/events/spider_terror.dm
+++ b/code/modules/events/spider_terror.dm
@@ -33,8 +33,8 @@
 			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/queen
 			spawncount = 1
 		if(5)
-			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/mother
-			spawncount = 1
+			spider_type = /mob/living/simple_animal/hostile/poison/terror_spider/princess
+			spawncount = 2
 	while(spawncount >= 1 && vents.len)
 		var/obj/machinery/atmospherics/unary/vent_pump/vent = pick(vents)
 

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/chem.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/chem.dm
@@ -2,7 +2,7 @@
 // Terror Spider, Black, Deadly Venom
 
 /datum/reagent/terror_black_toxin
-	name = "Black Widow venom"
+	name = "Black Terror venom"
 	id = "terror_black_toxin"
 	description = "An incredibly toxic venom injected by the Black Widow spider."
 	color = "#CF3600"

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/princess.dm
@@ -38,7 +38,10 @@
 	evolvequeen_action.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/princess/proc/evolve_to_queen()
-	change_mob_type(/mob/living/simple_animal/hostile/poison/terror_spider/queen, null, null, 1, 1)
+	var/mob/living/simple_animal/hostile/poison/terror_spider/queen/Q = new /mob/living/simple_animal/hostile/poison/terror_spider/queen(loc)
+	if(mind)
+		mind.transfer_to(Q)
+	qdel(src)
 
 /mob/living/simple_animal/hostile/poison/terror_spider/princess/DoWrap()
 	. = ..()

--- a/code/modules/surgery/organs/parasites.dm
+++ b/code/modules/surgery/organs/parasites.dm
@@ -47,65 +47,75 @@
 	name = "terror eggs"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "eggs"
-	var/current_cycle = 0
-	var/awaymission_infection = 0
-	var/alternate_ending = 0
+
+	var/cycle_num = 0 // # of on_life() cycles completed, never reset
+	var/egg_progress = 0 // # of on_life() cycles completed, unlike cycle_num this is reset on each hatch event
+	var/egg_progress_per_hatch = 90 // if egg_progress > this, chance to hatch and reset egg_progress
+	var/eggs_hatched = 0 // num of hatch events completed
+	var/eggs_max = 3 // max possible spiderlings you can get from a single infection if its left to run for a very long time
+	var/awaymission_checked = FALSE
+	var/awaymission_infection = FALSE // TRUE if infection occurred inside gateway
+	var/list/types_basic = list(/mob/living/simple_animal/hostile/poison/terror_spider/red, /mob/living/simple_animal/hostile/poison/terror_spider/gray, /mob/living/simple_animal/hostile/poison/terror_spider/green)
 
 /obj/item/organ/internal/body_egg/terror_eggs/on_life()
-	current_cycle += 1
+	// Safety first.
+	if(!owner)
+		return
+
+	// Parasite growth
+	cycle_num += 1
+	egg_progress += pick(0, 1, 2)
+	egg_progress += calc_variable_progress()
+
+	// Detect & stop people attempting to bring a gateway white spider infection back to the main station.
+	if(!awaymission_checked)
+		awaymission_checked = TRUE
+		if(is_away_level(owner.z))
+			awaymission_infection = TRUE
+	if(awaymission_infection)
+		if(!is_away_level(owner.z))
+			owner.gib()
+			qdel(src)
+			return
+
+	// Detect dying hosts, and try to keep them alive (so spiderlings can hatch) at the cost of some growth progress.
 	if(owner.health < -25)
 		to_chat(owner,"<span class='notice'>You feel a strange, blissful senstation.</span>")
 		owner.adjustBruteLoss(-5)
 		owner.adjustFireLoss(-5)
 		owner.adjustToxLoss(-5)
-		// the spider eggs secrete stimulants to keep their host alive until they hatch
-	switch(current_cycle)
-		if(1) // immediately
-			to_chat(owner,"<span class='danger'>Your wound hurts horribly! </span>")
-			if(is_away_level(owner.z))
-				awaymission_infection = 1
-		if(15) // 30s... enough time for the nerve agent to kick in, the pain to be blocked, and healing to begin
-			to_chat(owner,"<span class='notice'>The pain has faded, and stopped bleeding, though the skin around it has turned black.</span>")
-			owner.adjustBruteLoss(-10)
-		if(30) // 1m... the point where the venom uses and accellerates the healing process, to feed the eggs
-			to_chat(owner,"<span class='notice'>Your wound has completely sealed up, though the skin is still black. You feel significantly better.</span>")
-			owner.adjustBruteLoss(-20)
-		if(90) // 3m... where the eggs are developing, and the wound is turning into a hatching site, but invisibly
-			to_chat(owner,"<span class='notice'>The black flesh around your old spider bite wound has started to peel off.</span>")
-		if(100) // 3m20s... where the victim realizes something is wrong - this is not a normal wound
-			to_chat(owner,"<span class='danger'>The black flesh around your spider bite wound has cracked, and started to split open!</span>")
-		if(110) // 3m40s...
-			to_chat(owner,"<span class='danger'>The black flesh splits open completely, revealing a cluster of small black oval shapes inside you, shapes that seem to be moving!</span>")
-		if(120) // 4m...
-			if(awaymission_infection && !is_away_level(owner.z))
-				// we started in the awaymission, we ended on the station.
-				// To prevent someone bringing an infection back, we're going to trigger an alternate, equally-bad result here.
-				// Actually, let's make it slightly worse... just to discourage people from bringing back infections.
-				alternate_ending = 1
-			to_chat(owner,"<span class='danger'>The shapes extend tendrils out of your wound... no... those are legs! SPIDER LEGS! You have spiderlings growing inside you! You scratch at the wound, but it just aggrivates them - they swarm out of the wound, biting you all over!</span>")
-			owner.visible_message("<span class='danger'>[owner] flails around on the floor as spiderlings erupt from [owner.p_their()] skin and swarm all over them! </span>")
-			owner.Stun(20)
-			owner.Weaken(20)
-			// yes, this is a long stun - that's intentional. Gotta give the spiderlings time to escape.
-			if(alternate_ending)
-				owner.gib()
-			else
-				owner.adjustToxLoss(rand(100,180)) // normal case, range: 100-180, average 140, almost crit (150).
-				if(prob(50))
-					var/obj/structure/spider/spiderling/terror_spiderling/S1 = new(get_turf(owner))
-					S1.grow_as = /mob/living/simple_animal/hostile/poison/terror_spider/red
-					S1.name = "red spiderling"
-				if(prob(50))
-					var/obj/structure/spider/spiderling/terror_spiderling/S2 = new(get_turf(owner))
-					S2.grow_as = /mob/living/simple_animal/hostile/poison/terror_spider/gray
-					S2.name = "gray spiderling"
-				if(prob(50))
-					var/obj/structure/spider/spiderling/terror_spiderling/S3 = new(get_turf(owner))
-					S3.grow_as = /mob/living/simple_animal/hostile/poison/terror_spider/green
-					S3.name = "green spiderling"
-		if(130) // 4m 20s
-			to_chat(owner,"<span class='danger'>The spiderlings are gone. Your wound, though, looks worse than ever. Remnants of tiny spider eggs, and dead spiders, inside your flesh. Disgusting.</span>")
-			qdel(src)
+		egg_progress += 10
+
+	// Once at least one egg has hatched from you, you'll need help to reach medbay.
+	if(eggs_hatched >= 1)
+		owner.Confused(2)
+
+	if(egg_progress > egg_progress_per_hatch && eggs_hatched < eggs_max)
+		egg_progress -= egg_progress_per_hatch
+		hatch_egg()
+
+/obj/item/organ/internal/body_egg/terror_eggs/proc/calc_variable_progress()
+	var/extra_progress = 0
+	if(owner.nutrition > NUTRITION_LEVEL_FULL)
+		extra_progress += 1
+	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
+	if(antibiotics > 50)
+		extra_progress -= 0.5
+	var/boosters = owner.reagents.get_reagent_amount("salglu_solution")
+	if(boosters > 1)
+		extra_progress += 1
+	return extra_progress
+
+/obj/item/organ/internal/body_egg/terror_eggs/proc/hatch_egg()
+	var/obj/structure/spider/spiderling/terror_spiderling/S = new(get_turf(owner))
+	if(eggs_hatched >= 2) // on the third egg...
+		S.grow_as = /mob/living/simple_animal/hostile/poison/terror_spider/princess
+	else
+		S.grow_as = pick(types_basic)
+	S.immediate_ventcrawl = TRUE
+	eggs_hatched++
+	to_chat(owner, "<span class='warning'>A strange prickling sensation moves across your skin... then suddenly the whole world seems to spin around you!</span>")
+	owner.Paralyse(10)
 
 /obj/item/organ/internal/body_egg/terror_eggs/remove(var/mob/living/carbon/M, var/special = 0)
 	..()


### PR DESCRIPTION
This is a followup to https://github.com/ParadiseSS13/Paradise/pull/10847 - which added princesses.

Infestation event changes:
- Infestation events can now create a pair of pink (princess) spiders. It is one of the possible random outcomes of the event.
- Conversely, it is no longer possible for the event to create mother spiders.
- This change is because princesses are more interesting to play as, and against, than mothers are. Mothers still exist in the away mission, and for adminbus, but I'm making this switch in the interest of having more interesting infestation events. I may re-work how mothers work in future to make them more interesting to play as/against, but in the meantime I feel princesses are a better fit for the infestation event.

White spider infection changes
- Less chat spam. Infections now only give you chat messages during major events (like hatching) rather than at regular intervals.
- More varied infection times. Infections can now vary a little in how long they take to mature, rather than being so static you could set a stopwatch to them. This also stops people taking healing drugs seconds before they know the infection will mature.
- More gradual hatching. Infections now produce one spiderling every ~3 minutes from you, rather than producing a burst of up to 3 spiderlings at once, at exactly the 4 minute mark. 
- When infection eggs are hatching, the host loses consciousness for a short time, to allow the spiders to get away. Unlike previously, hosts no longer take massive toxin damage (enough to put them in crit) from hatch events. They do however suffer a permanent confusion effect after the first spider hatches, until the eggs are removed.
- Infections now progress faster if you're very well fed, have saline glucose in your bloodstream, or are in crit. They progress slower if you have 50+ units of spaceacillin in your system.
- Infections can now result in a princess spiderling if the infection remains untreated for a very long time (9 minutes). 

Misc Changes:
- Princesses that evolve to Queens now have their names updated. 
- Black Terror Venom is now called that. Previously it was called "Black Widow Venom", which was still using an out-of-date name for the black spider type.
- Refactored white terror spider egg code in parasites.dm to change 1/0 to TRUE/FALSE and some other optimizations.

:cl: Kyep
fix: Pink terror spiders are now called Queens after they evolve.
tweak: The terror spider major event now has a princess variant, and no longer has a mother variant.
add: White terror spider infestations are now less predictable, more spread out over time, and affected by nutrition and some chems, but also have worse consequences if left completely untreated for a long time.
/:cl:

