### PR TITLE
Capulettium Tweak

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1037,7 +1037,7 @@
 /datum/reagent/capulettium
 	name = "Capulettium"
 	id = "capulettium"
-	description = "A rare drug that causes the user to fall unconscious and appear dead as long as it's in the body."
+	description = "A rare drug that causes the user to appear dead for some time."
 	reagent_state = LIQUID
 	color = "#60A584"
 	heart_rate_stop = 1

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -1046,10 +1046,18 @@
 /datum/reagent/capulettium/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
 	switch(current_cycle)
-		if(1 to 10)
+		if(1 to 5)
 			update_flags |= M.AdjustEyeBlurry(10, FALSE)
+		if(6 to 10)
+			M.Drowsy(10)
 		if(11)
 			fakedeath(M)
+		if(61 to 69)
+			update_flags |= M.AdjustEyeBlurry(10, FALSE)
+		if(70 to INFINITY)
+			update_flags |= M.AdjustEyeBlurry(10, FALSE)
+			if(M.status_flags & FAKEDEATH)
+				fakerevive(M)
 	return ..() | update_flags
 
 /datum/reagent/capulettium/on_mob_delete(mob/living/M)


### PR DESCRIPTION
Just restores capulettium to its closest balance status while letting it retain its new functionality.

This means it's no longer a perma-stun chem as long as its in your system; it will only stun up you to the 69th cycle; on the 70th, it'll wake you back up (just as with capulettium prior to the fakedeath change).

:cl: Fox McCloud
tweak: Capulettium is no longer a perma-stun as long as it's in your system; keeps your paralyzed for the same time as it did previously.
/:cl: