### PR TITLE
Allow hijackers to take hostages

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -180,8 +180,8 @@ var/list/potential_theft_objectives = subtypesof(/datum/theft_objective) - /datu
 
 /datum/objective/hijack
 	martyr_compatible = 0 //Technically you won't get both anyway.
-	explanation_text = "Hijack the shuttle by escaping on it with no loyalist Nanotrasen crew on board and alive. \
-	Syndicate agents, other enemies of Nanotrasen, cyborgs, and pets may be allowed to escape alive."
+	explanation_text = "Hijack the shuttle by escaping on it with no loyalist Nanotrasen crew on board and free. \
+	Syndicate agents, other enemies of Nanotrasen, cyborgs, pets, and cuffed/restrained hostages may be allowed on the shuttle alive."
 
 /datum/objective/hijack/check_completion()
 	if(!owner.current || owner.current.stat)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -180,7 +180,16 @@
 					continue
 				if(isanimal(player)) //Poly does not own the shuttle
 					continue
-
+				if(ishuman(player)) //hostages allowed on the shuttle, check for restraints
+					var/mob/living/carbon/human/H = player
+					if(H.handcuffed) //cuffs
+						continue
+					if(H.wear_suit && H.wear_suit.breakouttime) //straight jacket
+						continue
+					if(istype(H.loc, /obj/structure/closet)) //locked/welded locker, all aboard the clown train honk honk
+						var/obj/structure/closet/C = H.loc
+						if(C.welded || C.locked)
+							continue
 				var/special_role = player.mind.special_role
 				if(special_role)
 					if(special_role == SPECIAL_ROLE_TRAITOR) // traitors can hijack the shuttle


### PR DESCRIPTION
This PR adds a new check to the shuttle hijack proc and update the objective's description.

"Hijack the shuttle by escaping on it with no loyalist Nanotrasen crew on board and free. Syndicate agents, other enemies of Nanotrasen, cyborgs, pets, and cuffed/restrained hostages may be allowed on the shuttle alive."

Code wide, this checks if people on the shuttle are handcuffed, straight jacketed, or locked inside a welded/locked locker. If they are, they will not interrupt the hijack.

This allows a hijacker nonlethal options when dealing with intruders.  Could also let you do a collection of all the head of staff locked inside a  locker with your clown PDA in there too. Honk.

For the more lethal minded, this also allows you to weld all the wall lockers in the shuttle once the shuttle has departed. Anyone who was hiding inside is now locked and won't interrupt your hijack as resisting out of the locker will take longer than the shuttle ride duration. Dealing with people in these is SUPER annoying.


Obviously, the hijacker is still allowed to murder as much as they please if they want to. This is simply an available alternative.

🆑
tweak: Shuttle hijacking is no longer interrupted by people cuffed, straight jacketed, or locked inside a welded/locked locker or wall locker.
tweak: Updated hijack's objective description to reflect the change.
/🆑