### PR TITLE
Virology rework. No more stacking. Virus symptom limit back to 3

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -17,7 +17,7 @@
 	if(HasDisease(D))
 		return FALSE
 
-	if(istype(D, /datum/disease/advance) && count_by_type(viruses, /datum/disease/advance) > 0)
+	if(istype(D, /datum/disease/advance) && count_by_type(viruses, /datum/disease/advance) >= 3)
 		return FALSE
 
 	if(!(type in D.viable_mobtypes))
@@ -35,6 +35,11 @@
 /mob/proc/AddDisease(datum/disease/D)
 	var/datum/disease/DD = new D.type(1, D, 0)
 	viruses += DD
+	if(istype(DD, /datum/disease/advance))
+		var/datum/disease/advance/A = DD
+		for(var/datum/symptom/S in A.symptoms)
+			S.virus = A //Since we made a new one
+			AddSymptom(S)
 	DD.affected_mob = src
 	GLOB.active_diseases += DD //Add it to the active diseases list, now that it's actually in a mob and being processed.
 
@@ -51,6 +56,11 @@
 
 	DD.affected_mob.med_hud_set_status()
 
+//Adds an advanced symptom to the mob
+/mob/proc/AddSymptom(datum/symptom/S)
+	if(!(S.type in advanced_symptoms)) //Fill the entry if the type is not yet in the associative list
+		advanced_symptoms[S.type] = list()
+	advanced_symptoms[S.type].Add(S)
 
 /mob/living/carbon/ContractDisease(datum/disease/D)
 	if(!CanContractDisease(D))

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -24,14 +24,14 @@ BONUS
 	level = 4
 	severity = 1
 
-/datum/symptom/beard/Activate(datum/disease/advance/A)
+/datum/symptom/beard/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/head/head_organ = H.get_organ("head")
-			switch(A.stage)
+			switch(virus.stage)
 				if(1, 2)
 					to_chat(H, "<span class='warning'>Your chin itches.</span>")
 					if(head_organ.f_style == "Shaved")

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -25,29 +25,31 @@ Bonus
 	level = 3
 	severity = 3
 
-/datum/symptom/choking/Activate(datum/disease/advance/A)
+/datum/symptom/choking/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2)
 				to_chat(M, "<span class='warning'>[pick("You're having difficulty breathing.", "Your breathing becomes heavy.")]</span>")
 			if(3, 4)
 				to_chat(M, "<span class='warning'><b>[pick("Your windpipe feels like a straw.", "Your breathing becomes tremendously difficult.")]</span>")
-				Choke_stage_3_4(M, A)
+				Choke(M)
 				M.emote("gasp")
 			else
 				to_chat(M, "<span class='userdanger'>[pick("You're choking!", "You can't breathe!")]</span>")
-				Choke(M, A)
+				Choke(M)
 				M.emote("gasp")
 	return
 
-/datum/symptom/choking/proc/Choke_stage_3_4(mob/living/M, datum/disease/advance/A)
-	var/get_damage = sqrtor0(21+A.totalStageSpeed()*0.5)+sqrtor0(16+A.totalStealth())
+/datum/symptom/choking/proc/Choke(mob/living/M)
+	var/get_damage = GetEfficiency()
 	M.adjustOxyLoss(get_damage)
 	return 1
 
-/datum/symptom/choking/proc/Choke(mob/living/M, datum/disease/advance/A)
-	var/get_damage = sqrtor0(21+A.totalStageSpeed()*0.5)+sqrtor0(16+A.totalStealth()*5)
-	M.adjustOxyLoss(get_damage)
-	return 1
+/datum/symptom/choking/GetEfficiency()
+	switch(virus.stage)
+		if(3, 4)
+			return sqrtor0(21+virus.totalStageSpeed()*0.5)+sqrtor0(16+virus.totalStealth())
+		else
+			return sqrtor0(21+virus.totalStageSpeed()*0.5)+sqrtor0(16+virus.totalStealth()*5)

--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -26,11 +26,11 @@ Bonus
 	severity = 2
 
 
-/datum/symptom/confusion/Activate(datum/disease/advance/A)
+/datum/symptom/confusion/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/carbon/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/carbon/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2, 3, 4)
 				to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your mind blanks for a moment.")]</span>")
 			else

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -28,8 +28,8 @@ BONUS
 /datum/symptom/cough/Activate(datum/disease/advance/A)
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2, 3)
 				to_chat(M, "<span notice='warning'>[pick("You swallow excess mucus.", "You lightly cough.")]</span>")
 			else

--- a/code/datums/diseases/advance/symptoms/damage_converter.dm
+++ b/code/datums/diseases/advance/symptoms/damage_converter.dm
@@ -24,11 +24,11 @@ Bonus
 	transmittable = -2
 	level = 4
 
-/datum/symptom/damage_converter/Activate(datum/disease/advance/A)
+/datum/symptom/damage_converter/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB * 10))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(4, 5)
 				Convert(M)
 	return

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -28,8 +28,8 @@ Bonus
 /datum/symptom/deafness/Activate(datum/disease/advance/A)
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(3, 4)
 				to_chat(M, "<span class='warning'>[pick("You hear a ringing in your ear.", "Your ears pop.")]</span>")
 			if(5)

--- a/code/datums/diseases/advance/symptoms/dizzy.dm
+++ b/code/datums/diseases/advance/symptoms/dizzy.dm
@@ -28,8 +28,8 @@ Bonus
 /datum/symptom/dizzy/Activate(datum/disease/advance/A)
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2, 3, 4)
 				to_chat(M, "<span class='warning'>[pick("You feel dizzy.", "Your head spins.")]</span>")
 			else

--- a/code/datums/diseases/advance/symptoms/fever.dm
+++ b/code/datums/diseases/advance/symptoms/fever.dm
@@ -25,17 +25,20 @@ Bonus
 	level = 2
 	severity = 2
 
-/datum/symptom/fever/Activate(datum/disease/advance/A)
+/datum/symptom/fever/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/carbon/M = A.affected_mob
+		var/mob/living/carbon/M = virus.affected_mob
 		to_chat(M, "<span class='warning'>[pick("You feel hot.", "You feel like you're burning.")]</span>")
 		if(M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT)
-			Heat(M, A)
+			Heat(M)
 
 	return
 
-/datum/symptom/fever/proc/Heat(mob/living/M, datum/disease/advance/A)
-	var/get_heat = (sqrtor0(21+A.totalTransmittable()*2))+(sqrtor0(20+A.totalStageSpeed()*3))
-	M.bodytemperature = min(M.bodytemperature + (get_heat * A.stage), BODYTEMP_HEAT_DAMAGE_LIMIT - 1)
+/datum/symptom/fever/proc/Heat(mob/living/M)
+	var/get_heat = GetEfficiency()
+	M.bodytemperature = min(M.bodytemperature + get_heat, BODYTEMP_HEAT_DAMAGE_LIMIT - 1)
 	return 1
+
+/datum/symptom/fever/GetEfficiency()
+	return (sqrtor0(21+virus.totalTransmittable()*2))+(sqrtor0(20+virus.totalStageSpeed()*3)) * virus.stage

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -25,33 +25,33 @@ Bonus
 	level = 6
 	severity = 5
 
-/datum/symptom/fire/Activate(datum/disease/advance/A)
+/datum/symptom/fire/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(3)
 				to_chat(M, "<span class='warning'>[pick("You feel hot.", "You hear a crackling noise.", "You smell smoke.")]</span>")
 			if(4)
-				Firestacks_stage_4(M, A)
+				Firestacks(M)
 				M.IgniteMob()
 				to_chat(M, "<span class='userdanger'>Your skin bursts into flames!</span>")
 				M.emote("scream")
 			if(5)
-				Firestacks_stage_5(M, A)
+				Firestacks(M)
 				M.IgniteMob()
 				to_chat(M, "<span class='userdanger'>Your skin erupts into an inferno!</span>")
 				M.emote("scream")
 	return
 
-/datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
-	var/get_stacks = (sqrtor0(20+A.totalStageSpeed()*2))-(sqrtor0(16+A.totalStealth()))
+/datum/symptom/fire/proc/Firestacks(mob/living/M)
+	var/get_stacks = GetEfficiency()
 	M.adjust_fire_stacks(get_stacks)
-	M.adjustFireLoss(get_stacks/2)
+	M.adjustFireLoss(virus.stage == 4 ? get_stacks/2 : get_stacks)
 	return 1
 
-/datum/symptom/fire/proc/Firestacks_stage_5(mob/living/M, datum/disease/advance/A)
-	var/get_stacks = (sqrtor0(20+A.totalStageSpeed()*3))-(sqrtor0(16+A.totalStealth()))
-	M.adjust_fire_stacks(get_stacks)
-	M.adjustFireLoss(get_stacks)
-	return 1
+/datum/symptom/fire/GetEfficiency()
+	if(virus.stage == 4)
+		return (sqrtor0(20+virus.totalStageSpeed()*2))-(sqrtor0(16+virus.totalStealth()))
+	else
+		return (sqrtor0(20+virus.totalStageSpeed()*3))-(sqrtor0(16+virus.totalStealth()))

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -25,19 +25,22 @@ Bonus
 	level = 6
 	severity = 5
 
-/datum/symptom/flesh_eating/Activate(datum/disease/advance/A)
+/datum/symptom/flesh_eating/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(2,3)
 				to_chat(M, "<span class='warning'>[pick("You feel a sudden pain across your body.", "Drops of blood appear suddenly on your skin.")]</span>")
 			if(4,5)
 				to_chat(M, "<span class='userdanger'>[pick("You cringe as a violent pain takes over your body.", "It feels like your body is eating itself inside out.", "IT HURTS.")]</span>")
-				Flesheat(M, A)
+				Flesheat(M)
 	return
 
-/datum/symptom/flesh_eating/proc/Flesheat(mob/living/M, datum/disease/advance/A)
-	var/get_damage = ((sqrtor0(16-A.totalStealth()))*5)
+/datum/symptom/flesh_eating/proc/Flesheat(mob/living/M)
+	var/get_damage = sqrtor0(GetEfficiency())*5
 	M.adjustBruteLoss(get_damage)
 	return 1
+
+/datum/symptom/flesh_eating/GetEfficiency()
+	return 16-virus.totalStealth()

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -27,13 +27,13 @@ Bonus
 	var/list/possible_mutations
 	var/archived_dna = null
 
-/datum/symptom/genetic_mutation/Activate(datum/disease/advance/A)
+/datum/symptom/genetic_mutation/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB * 5)) // 15% chance
-		var/mob/living/carbon/M = A.affected_mob
+		var/mob/living/carbon/M = virus.affected_mob
 		if(!M.has_dna())
 			return
-		switch(A.stage)
+		switch(virus.stage)
 			if(4, 5)
 				to_chat(M, "<span class='warning'>[pick("Your skin feels itchy.", "You feel light headed.")]</span>")
 				M.dna.remove_mutation_group(possible_mutations)

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -25,11 +25,11 @@ Bonus
 	level = 5
 	severity = 3
 
-/datum/symptom/hallucigen/Activate(datum/disease/advance/A)
+/datum/symptom/hallucigen/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/carbon/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/carbon/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2)
 				to_chat(M, "<span class='warning'>[pick("Something appears in your peripheral vision, then winks out.", "You hear a faint whispher with no source.", "Your head aches.")]</span>")
 			if(3, 4)

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -26,9 +26,9 @@ BONUS
 	level = 1
 	severity = 1
 
-/datum/symptom/headache/Activate(datum/disease/advance/A)
+/datum/symptom/headache/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your head starts pounding.")]</span>")
 	return

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -125,7 +125,7 @@ Bonus
 /datum/symptom/heal/longevity/Start(datum/disease/advance/A)
 	longevity = rand(initial(longevity) - 5, initial(longevity) + 5)
 
-/datum/symptom/heal/GetEfficiency()
+/datum/symptom/heal/longevity/GetEfficiency()
 	return longevity //Slowly let all viruses gradually heal if they have longevity
 
 /*

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -24,20 +24,22 @@ Bonus
 	transmittable = -4
 	level = 6
 
-/datum/symptom/heal/Activate(datum/disease/advance/A)
+/datum/symptom/heal/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB * 10))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(4, 5)
-				Heal(M, A)
+				Heal(M)
 	return
 
-/datum/symptom/heal/proc/Heal(mob/living/M, datum/disease/advance/A)
-	var/get_damage = (sqrtor0(20+A.totalStageSpeed())*(1+rand()))
+/datum/symptom/heal/proc/Heal(mob/living/M)
+	var/get_damage = (sqrtor0(GetEfficiency())*(1+rand()))
 	M.adjustToxLoss(-get_damage)
 	return 1
 
+/datum/symptom/heal/GetEfficiency()
+	return 20+virus.totalStageSpeed()
 /*
 //////////////////////////////////////
 
@@ -65,13 +67,13 @@ Bonus
 	level = 3
 	var/list/cured_diseases = list()
 
-/datum/symptom/heal/metabolism/Heal(mob/living/M, datum/disease/advance/A)
+/datum/symptom/heal/metabolism/Heal(mob/living/M)
 	var/cured = 0
 	for(var/thing in M.viruses)
 		var/datum/disease/D = thing
 		if(D.virus_heal_resistant)
 			continue
-		if(D != A)
+		if(D != virus)
 			cured = 1
 			cured_diseases += D.GetDiseaseID()
 			D.cure()
@@ -115,13 +117,16 @@ Bonus
 	level = 3
 	var/longevity = 30
 
-/datum/symptom/heal/longevity/Heal(mob/living/M, datum/disease/advance/A)
+/datum/symptom/heal/longevity/Heal(mob/living/M)
 	longevity -= 1
 	if(!longevity)
-		A.cure()
+		virus.cure()
 
 /datum/symptom/heal/longevity/Start(datum/disease/advance/A)
 	longevity = rand(initial(longevity) - 5, initial(longevity) + 5)
+
+/datum/symptom/heal/GetEfficiency()
+	return longevity //Slowly let all viruses gradually heal if they have longevity
 
 /*
 /*

--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -26,9 +26,9 @@ BONUS
 	level = 1
 	severity = 1
 
-/datum/symptom/itching/Activate(datum/disease/advance/A)
+/datum/symptom/itching/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		to_chat(M, "<span class='warning'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")
 	return

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -24,11 +24,11 @@ Bonus
 	transmittable = -4
 	level = 6
 
-/datum/symptom/oxygen/Activate(datum/disease/advance/A)
+/datum/symptom/oxygen/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(4, 5)
 				if(M.reagents.get_reagent_amount("salbutamol") < 20)
 					M.reagents.add_reagent("salbutamol", 20)

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -24,24 +24,24 @@ Bonus
 	level = 5
 	severity = 0
 
-/datum/symptom/mind_restoration/Activate(datum/disease/advance/A)
+/datum/symptom/mind_restoration/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB * 3))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		var/datum/reagents/RD = M.reagents
 
-		if(A.stage >= 3)
+		if(virus.stage >= 3)
 			M.AdjustSlur(-2)
 			M.AdjustDrunk(-4)
 			M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3, 0, 1)
-		if(A.stage >= 4)
+		if(virus.stage >= 4)
 			M.AdjustDrowsy(-2)
 			if(RD.has_reagent("lsd"))
 				RD.remove_reagent("lsd", 5)
 			if(RD.has_reagent("histamine"))
 				RD.remove_reagent("histamine", 5)
 			M.AdjustHallucinate(-10)
-		if(A.stage >= 5)
+		if(virus.stage >= 5)
 			RD.check_and_add("mannitol", 10, 10)
 
 /datum/symptom/sensory_restoration
@@ -52,11 +52,11 @@ Bonus
 	transmittable = -4
 	level = 4
 
-/datum/symptom/sensory_restoration/Activate(datum/disease/advance/A)
+/datum/symptom/sensory_restoration/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(4, 5)
 				if(M.reagents.get_reagent_amount("oculine") < 20)
 					M.reagents.add_reagent("oculine", 20)

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -24,15 +24,15 @@ BONUS
 	level = 4
 	severity = 1
 
-/datum/symptom/shedding/Activate(datum/disease/advance/A)
+/datum/symptom/shedding/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		to_chat(M, "<span class='warning'>[pick("Your scalp itches.", "Your skin feels flakey.")]</span>")
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			var/obj/item/organ/external/head/head_organ = H.get_organ("head")
-			switch(A.stage)
+			switch(virus.stage)
 				if(3, 4)
 					if(!(head_organ.h_style == "Bald") && !(head_organ.h_style == "Balding Hair"))
 						to_chat(H, "<span class='warning'>Your hair starts to fall out in clumps...</span>")

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -25,16 +25,19 @@ Bonus
 	level = 2
 	severity = 2
 
-/datum/symptom/shivering/Activate(datum/disease/advance/A)
+/datum/symptom/shivering/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/carbon/M = A.affected_mob
+		var/mob/living/carbon/M = virus.affected_mob
 		to_chat(M, "<span class='warning'>[pick("You feel cold.", "You start shivering.")]</span>")
-		if(M.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT)
-			Chill(M, A)
+		if(M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT)
+			Chill(M)
 	return
 
-/datum/symptom/shivering/proc/Chill(mob/living/M, datum/disease/advance/A)
-	var/get_cold = (sqrtor0(16+A.totalStealth()*2))+(sqrtor0(21+A.totalResistance()*2))
-	M.bodytemperature = min(M.bodytemperature - (get_cold * A.stage), BODYTEMP_COLD_DAMAGE_LIMIT + 1)
+/datum/symptom/shivering/proc/Chill(mob/living/M)
+	var/get_cold = GetEfficiency()
+	M.bodytemperature = max(M.bodytemperature - get_cold, BODYTEMP_COLD_DAMAGE_LIMIT + 1)
 	return 1
+
+/datum/symptom/shivering/GetEfficiency()
+	return (sqrtor0(16+virus.totalStealth()*2))+(sqrtor0(21+virus.totalResistance()*2)) * virus.stage

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -24,15 +24,15 @@ BONUS
 	level = 4
 	severity = 1
 
-/datum/symptom/vitiligo/Activate(datum/disease/advance/A)
+/datum/symptom/vitiligo/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			if(H.s_tone == -85)
 				return
-			switch(A.stage)
+			switch(virus.stage)
 				if(5)
 					H.s_tone = -85
 					H.update_body(0)
@@ -68,15 +68,15 @@ BONUS
 	level = 4
 	severity = 1
 
-/datum/symptom/revitiligo/Activate(datum/disease/advance/A)
+/datum/symptom/revitiligo/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
 			if(H.s_tone == 85)
 				return
-			switch(A.stage)
+			switch(virus.stage)
 				if(5)
 					H.s_tone = 85
 					H.update_body(0)

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -26,14 +26,14 @@ Bonus
 	level = 1
 	severity = 1
 
-/datum/symptom/sneeze/Activate(datum/disease/advance/A)
+/datum/symptom/sneeze/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2, 3)
 				M.emote("sniff")
 			else
 				M.emote("sneeze")
-				A.spread(5)
+				virus.spread(5)
 	return

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -37,3 +37,8 @@ Bonus
 				M.emote("sneeze")
 				virus.spread(5)
 	return
+
+/datum/symptom/sneeze/GetEfficiency()
+	if(virus.stage > 3)
+		return rand(1, 5) //If more viruses have sneezing you want to rotate the virus spread
+	return 0

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -17,6 +17,7 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 3
 	var/severity = 0
 	// The hash tag for our diseases, we will add it up with our other symptoms to get a unique id! ID MUST BE UNIQUE!!!
 	var/id = ""
+	var/datum/disease/advance/virus = null // Virus it belongs to
 
 /datum/symptom/New()
 	var/list/S = list_symptoms
@@ -34,6 +35,8 @@ var/global/const/SYMPTOM_ACTIVATION_PROB = 3
 /datum/symptom/proc/End(datum/disease/advance/A)
 	return
 
-/datum/symptom/proc/Activate(datum/disease/advance/A)
+/datum/symptom/proc/Activate()
 	return
 
+/datum/symptom/proc/GetEfficiency()
+	return virus.stage

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -21,11 +21,11 @@ BONUS
 	transmittable = 0
 	level = 3
 
-/datum/symptom/viraladaptation/Activate(datum/disease/advance/A)
+/datum/symptom/viraladaptation/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1)
 				to_chat(M, "<span class='notice'>You feel off, but no different from before.</span>")
 			if(5)
@@ -54,11 +54,11 @@ BONUS
 	transmittable = 3
 	level = 3
 
-/datum/symptom/viraladaptation/Activate(datum/disease/advance/A)
+/datum/symptom/viraladaptation/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1)
 				to_chat(M, "<span class='notice'>You feel better, but no different from before.</span>")
 			if(5)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -25,14 +25,14 @@ Bonus
 	level = 5
 	severity = 4
 
-/datum/symptom/visionloss/Activate(datum/disease/advance/A)
+/datum/symptom/visionloss/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/carbon/M = A.affected_mob
+		var/mob/living/carbon/M = virus.affected_mob
 		var/obj/item/organ/internal/eyes/eyes = M.get_int_organ(/obj/item/organ/internal/eyes)
 		if(!eyes) //NO EYES, NO PROBLEM! Rip out your eyes today to prevent future blindness!
 			return
-		switch(A.stage)
+		switch(virus.stage)
 			if(1, 2)
 				to_chat(M, "<span class='warning'>Your eyes itch.</span>")
 			if(3, 4)

--- a/code/datums/diseases/advance/symptoms/voice_change.dm
+++ b/code/datums/diseases/advance/symptoms/voice_change.dm
@@ -25,12 +25,12 @@ Bonus
 	level = 6
 	severity = 2
 
-/datum/symptom/voice_change/Activate(datum/disease/advance/A)
+/datum/symptom/voice_change/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
 
-		var/mob/living/carbon/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/carbon/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2, 3, 4)
 				to_chat(M, "<span class='warning'>[pick("Your throat hurts.", "You clear your throat.")]</span>")
 			else

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -29,11 +29,11 @@ Bonus
 	level = 3
 	severity = 4
 
-/datum/symptom/vomit/Activate(datum/disease/advance/A)
+/datum/symptom/vomit/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB / 2))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2, 3, 4)
 				to_chat(M, "<span class='warning'>[pick("You feel nauseous.", "You feel like you're going to throw up!")]</span>")
 			else

--- a/code/datums/diseases/advance/symptoms/weakness.dm
+++ b/code/datums/diseases/advance/symptoms/weakness.dm
@@ -25,11 +25,11 @@ Bonus
 	level = 3
 	severity = 3
 
-/datum/symptom/weakness/Activate(datum/disease/advance/A)
+/datum/symptom/weakness/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2)
 				to_chat(M, "<span class='warning'>[pick("You feel weak.", "You feel lazy.")]</span>")
 			if(3, 4)

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -26,11 +26,11 @@ Bonus
 	level = 3
 	severity = 1
 
-/datum/symptom/weight_loss/Activate(datum/disease/advance/A)
+/datum/symptom/weight_loss/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
-		var/mob/living/M = A.affected_mob
-		switch(A.stage)
+		var/mob/living/M = virus.affected_mob
+		switch(virus.stage)
 			if(1, 2, 3, 4)
 				to_chat(M, "<span class='warning'>[pick("You feel hungry.", "You crave for food.")]</span>")
 			else

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -24,13 +24,13 @@ BONUS
 	transmittable = -4
 	level = 5
 
-/datum/symptom/youth/Activate(datum/disease/advance/A)
+/datum/symptom/youth/Activate()
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB * 2))
-		var/mob/living/M = A.affected_mob
+		var/mob/living/M = virus.affected_mob
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = M
-			switch(A.stage)
+			switch(virus.stage)
 				if(1)
 					if(H.age > 41)
 						H.age = 41

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -203,6 +203,16 @@
 
 		if(stat != DEAD)
 			D.stage_act()
+	
+	if(stat != DEAD)
+		for(var/symptom_type in advanced_symptoms) //Activate the best symptoms
+			var/datum/symptom/bestSymptom = null
+			for(var/datum/symptom/S in advanced_symptoms[symptom_type])
+				
+				if(!bestSymptom || bestSymptom.GetEfficiency() < S.GetEfficiency())
+					bestSymptom = S
+			if(bestSymptom)
+				bestSymptom.Activate()
 
 //remember to remove the "proc" of the child procs of these.
 /mob/living/carbon/proc/handle_blood()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -142,6 +142,7 @@
 //List of active diseases
 
 	var/list/viruses = list() // list of all diseases in a mob
+	var/list/advanced_symptoms = list() // list of all advanced virus symptoms, saved as: list<symptom_type,list(symptom)>
 	var/list/resistances = list()
 
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER


### PR DESCRIPTION
**What does this PR do:**
Viruses now don't stack. Meaning the best symptom of the 3 viruses will be chosen and activated.
Reverts the virus limit back to 3. Reverted from #10941
Fixes a minor bug with shivering.

Why this instead of the previous nerf?
Virology is boring if you're limited to 1 virus. It makes making interesting viruses impossible or they become useless.
This way you can still experiment but it's also more balanced.

I've tested it and it seems to work as intended.

**Changelog:**
:cl:
balance: Advanced virus limit is reverted to 3
balance: Viruses now don't stack symptoms. The best symptom of the 3 viruses will be chosen
fix: Fixed shivering not activating correctly
/:cl:

