### PR TITLE
Random advanced virus event

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -17,8 +17,10 @@
 	if(HasDisease(D))
 		return FALSE
 
-	if(istype(D, /datum/disease/advance) && count_by_type(viruses, /datum/disease/advance) > 0)
-		return FALSE
+	if(istype(D, /datum/disease/advance))
+		var/datum/disease/advance/A = D
+		if(!A.eventSpawned && count_by_type(viruses, /datum/disease/advance) > 0)
+			return FALSE
 
 	if(!(type in D.viable_mobtypes))
 		return -1 //for stupid fucking monkies

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -34,7 +34,7 @@ var/list/advance_cures = 	list(
 	viable_mobtypes = list(/mob/living/carbon/human)
 
 	// NEW VARS
-
+	var/eventSpawned = FALSE // If the virus will go through the virus limit or not
 	var/list/symptoms = list() // The symptoms of the disease.
 	var/id = ""
 	var/processing = 0

--- a/code/modules/events/advanced_disease_outbreak.dm
+++ b/code/modules/events/advanced_disease_outbreak.dm
@@ -1,0 +1,40 @@
+/datum/event/disease_outbreak/advanced/announce()
+	event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+
+//No need to pick one
+/datum/event/disease_outbreak/advanced/PickVirus()
+	return
+
+/datum/event/disease_outbreak/advanced/Infect(mob/living/carbon/human/H)
+	var/datum/disease/advance/A = GetVirus()
+	A.carrier = TRUE
+	H.AddDisease(A)
+
+/datum/event/disease_outbreak/advanced/proc/GetVirus()
+	var/success = FALSE
+	var/datum/disease/advance/A
+	while(!success)
+		A = new
+		for(var/i = rand(4, 6), i > 0, i--)
+			A.Evolve(1, 6)
+		success = CheckVirus(A)
+	A.AssignName(GenerateName())
+	A.eventSpawned = TRUE
+	return A
+
+/datum/event/disease_outbreak/advanced/proc/CheckVirus(datum/disease/advance/A)
+	if(A.spread_flags == BLOOD)
+		return FALSE //Want it to spread atleast
+	return TRUE
+
+/datum/event/disease_outbreak/advanced/proc/GenerateName()
+	var/base
+	var/end
+	if(prob(50))
+		base = pick("Accessio ", "Spasmus ", "Marasmus ", "Privadrops ", "Colica ", "Exhaustio ")
+		end = pick("Petechialis", "Pulmonum", "Vulnus", "Cavum", "Putrida", "Senilis")
+	else 
+		base = pick("X", "U", "D", "Q", "ADV", "UNKW")
+		end = pick("457", "42", "6583", "001", "043", "948")
+	return base + end
+

--- a/code/modules/events/advanced_disease_outbreak.dm
+++ b/code/modules/events/advanced_disease_outbreak.dm
@@ -18,7 +18,7 @@
 	var/datum/disease/advance/A
 	while(!success)
 		A = new
-		for(var/i = rand(4, 6), i > 0, i--)
+		for(var/i = rand(2, 6), i > 0, i--)
 			A.Evolve(1, 6)
 		success = CheckVirus(A)
 	A.AssignName(GenerateName())

--- a/code/modules/events/advanced_disease_outbreak.dm
+++ b/code/modules/events/advanced_disease_outbreak.dm
@@ -27,7 +27,13 @@
 
 /datum/event/disease_outbreak/advanced/proc/CheckVirus(datum/disease/advance/A)
 	if(A.spread_flags == BLOOD)
-		return FALSE //Want it to spread atleast
+		var/spread = FALSE
+		for(var/datum/symptom/S in A.symptoms)
+			if(istype(S, /datum/symptom/sneeze))
+				spread = TRUE
+				break
+		if(!spread)
+			return FALSE //Want it to spread atleast
 	return TRUE
 
 /datum/event/disease_outbreak/advanced/proc/GenerateName()

--- a/code/modules/events/advanced_disease_outbreak.dm
+++ b/code/modules/events/advanced_disease_outbreak.dm
@@ -1,5 +1,8 @@
 /datum/event/disease_outbreak/advanced/announce()
-	event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+	if(prob(25))
+		event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. Our intel suggests that the Syndicate have released an experimental virus onboard the [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+	else
+		..()
 
 //No need to pick one
 /datum/event/disease_outbreak/advanced/PickVirus()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -5,14 +5,13 @@
 
 /datum/event/disease_outbreak/setup()
 	announceWhen = rand(15, 30)
+	if(!virus_type)
+		PickVirus()
 
 /datum/event/disease_outbreak/announce()
 	event_announcement.Announce("Confirmed outbreak of level 7 major viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 
 /datum/event/disease_outbreak/start()
-	if(!virus_type)
-		virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/fluspanish, /datum/disease/pierrot_throat, /datum/disease/lycan)
-
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.living_mob_list))
 		if(issmall(H)) //don't infect monkies; that's a waste
 			continue
@@ -32,8 +31,14 @@
 		if(H.stat == DEAD || foundAlready)
 			continue
 
+		Infect(H)
+		break
+
+/datum/event/disease_outbreak/proc/PickVirus()
+	virus_type = pick(/datum/disease/advance/flu, /datum/disease/advance/cold, /datum/disease/brainrot, /datum/disease/magnitis, /datum/disease/beesease, /datum/disease/anxiety, /datum/disease/fake_gbs, /datum/disease/fluspanish, /datum/disease/pierrot_throat, /datum/disease/lycan)
+
+/datum/event/disease_outbreak/proc/Infect(mob/living/carbon/human/H)
 		var/datum/disease/D
 		D = new virus_type()
 		D.carrier = TRUE
 		H.AddDisease(D)
-		break

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -181,7 +181,8 @@ var/list/event_last_fired = list()
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Revenant", 				/datum/event/revenant, 					150),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Swarmer Spawn", 			/datum/event/spawn_swarmer, 			150, is_one_shot = 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Morph Spawn", 				/datum/event/spawn_morph, 				40, is_one_shot = 1),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Disease Outbreak",			/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), 1)
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Disease Outbreak",			/datum/event/disease_outbreak, 			0,		list(ASSIGNMENT_MEDICAL = 150), 1),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Advanced Disease Outbreak",/datum/event/disease_outbreak/advanced, 0,		list(ASSIGNMENT_MEDICAL = 175), 1)
 	)
 
 /datum/event_container/major

--- a/paradise.dme
+++ b/paradise.dme
@@ -1391,6 +1391,7 @@
 #include "code\modules\error_handler\error_handler.dm"
 #include "code\modules\error_handler\error_viewer.dm"
 #include "code\modules\events\abductor.dm"
+#include "code\modules\events\advanced_disease_outbreak.dm"
 #include "code\modules\events\alien_infestation.dm"
 #include "code\modules\events\anomaly.dm"
 #include "code\modules\events\anomaly_bluespace.dm"


### PR DESCRIPTION
**What does this PR do:**
Adds the advanced virus outbreak event.
Like the normal virus outbreak event this spawns a virus. But this one is advanced instead of a regular one.
Meaning it has 2 to 6 random symptoms which you can also get from human engineering.
The virus goes through the advanced virus limit and can always spread at least by touch.

**Changelog:**
:cl:
add: Added an advanced virus outbreak. Now besides a normal virus outbreak there is also a chance to get an advanced virus outbreak which has randomised symptoms
/:cl:

