### PR TITLE
AI Doorknob tweak

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -55,7 +55,7 @@
 
 	if(mob_to_track)
 		track = "<a href='byond://?src=[UID()];track=\ref[mob_to_track]'>[speaker_name] ([jobname])</a>"
-		track += "<a href='byond://?src=[UID()];open=\ref[mob_to_track]'>\[O\]</a>"
+		track += "&nbsp;<a href='byond://?src=[UID()];open=\ref[mob_to_track]'>\[Open\]</a>"
 
 	return track
 


### PR DESCRIPTION
**What does this PR do:**
Makes it more obvious that the open nearest airlock button exists

**Changelog:**
:cl:
tweak: open button is separated more from previous href 
/:cl:

