### PR TITLE
No more hitting people with fire extinguishers when trying to put out a fire

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -74,6 +74,12 @@
 	else
 		return 0
 
+/obj/item/extinguisher/attack(mob/living/M, mob/living/user, def_zone)
+	if(!safety && user.a_intent == INTENT_HELP) //No hitting people when wanting to extinguish
+		return 0
+	. = ..()
+	
+
 /obj/item/extinguisher/afterattack(atom/target, mob/user , flag)
 	//TODO; Add support for reagents in water.
 	if(target.loc == user)//No more spraying yourself when putting your extinguisher away

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -76,7 +76,7 @@
 
 /obj/item/extinguisher/attack(mob/living/M, mob/living/user, def_zone)
 	if(!safety && user.a_intent == INTENT_HELP) //No hitting people when wanting to extinguish
-		return 0
+		return FALSE
 	. = ..()
 	
 


### PR DESCRIPTION
**What does this PR do:**
Makes it so that you don't hit a person when on help intent if the safety is off on the fire extinguisher.

However funny it was to see people smack a burning person to pulp. It is not quite what you'd expect when on help mode. Due to the word HELP.

**Changelog:**
:cl:
tweak: You don't hit people anymore with a fire extinguisher when the safety is off and you are on help mode
/:cl:

