### PR TITLE
Re add sensory destruction as a symptom now called neural destruction

### DIFF
--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -50,10 +50,10 @@
 		symptoms = list(new/datum/symptom/sensory_restoration)
 	..(process, D, copy)
 
-// Sensory Destruction
+// Neural Destruction
 
-/datum/disease/advance/sensory_destruction/New(var/process = 1, var/datum/disease/advance/D, var/copy = 0)
+/datum/disease/advance/neural_destruction/New(var/process = 1, var/datum/disease/advance/D, var/copy = 0)
 	if(!D)
 		name = "Reality Destruction"
-		symptoms = list(new/datum/symptom/sensory_destruction)
+		symptoms = list(new/datum/symptom/neural_destruction)
 	..(process, D, copy)

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -49,3 +49,11 @@
 		name = "Reality Enhancer"
 		symptoms = list(new/datum/symptom/sensory_restoration)
 	..(process, D, copy)
+
+// Sensory Destruction
+
+/datum/disease/advance/sensory_destruction/New(var/process = 1, var/datum/disease/advance/D, var/copy = 0)
+	if(!D)
+		name = "Reality Destruction"
+		symptoms = list(new/datum/symptom/sensory_destruction)
+	..(process, D, copy)

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -63,3 +63,54 @@ Bonus
 			else
 				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
 					to_chat(M, "<span class='notice'>[pick("Your eyes feel great.","You feel like your eyes can focus more clearly.", "You don't feel the need to blink.","Your ears feel great.","Your healing feels more acute.")]</span>")
+
+/*
+//////////////////////////////////////
+Sensory-Destruction
+	noticable.
+	Lowers resistance
+	Decreases stage speed tremendously.
+	Decreases transmittablity tremendously.
+	the drugs hit them so hard they have to focus on not dying
+Bonus
+	The body generates Sensory destructive chemicals.
+	You cannot taste anything anymore.
+	ethanol for extremely drunk victim
+	lsd to break the mind
+	impedrezene to ruin the brain
+//////////////////////////////////////
+*/
+/datum/symptom/sensory_destruction
+	name = "Sensory destruction"
+	resistance = -2
+	stage_speed = -3
+	level = 6
+	severity = 5
+
+/datum/symptom/sensory_destruction/Activate(datum/disease/advance/A)
+	..()
+	if(prob(SYMPTOM_ACTIVATION_PROB))
+		var/mob/living/M = A.affected_mob
+		switch(A.stage)
+			if(1)
+				to_chat(M, "<span class='warning'><b>You can't taste a thing.</b></span>")
+			if(2)
+				to_chat(M, "<span class='warning'><b>You can't feel anything.</b></span>")
+				if(prob(10))
+					M.reagents.add_reagent("morphine",rand(5,7))
+			if(3)
+				M.reagents.add_reagent("ethanol",rand(5,7))
+				to_chat(M, "<span class='warning'><b>You feel absolutely hammered.</b></span>")
+				if(prob(15))
+					M.reagents.add_reagent("morphine",rand(5,7))
+			if(4)
+				M.reagents.add_reagent_list(list("ethanol"=rand(7,15),"lsd"=rand(5,10)))
+				to_chat(M, "<span class='warning'><b>You try to focus on not dying.</b></span>")
+				if(prob(20))
+					M.reagents.add_reagent("morphine",rand(5,7))
+			if(5)
+				M.reagents.add_reagent_list(list("haloperidol"=rand(5,15),"ethanol"=rand(7,20),"lsd"=rand(5,15)))
+				to_chat(M, "<span class='warning'><b>u can count 2 potato!</b></span>")
+				if(prob(25))
+					M.reagents.add_reagent("morphine",rand(5,7))
+	return

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -66,7 +66,7 @@ Bonus
 
 /*
 //////////////////////////////////////
-Sensory-Destruction
+Neural-Destruction
 	noticable.
 	Lowers resistance
 	Decreases stage speed tremendously.
@@ -80,14 +80,14 @@ Bonus
 	impedrezene to ruin the brain
 //////////////////////////////////////
 */
-/datum/symptom/sensory_destruction
-	name = "Sensory destruction"
+/datum/symptom/neural_destruction
+	name = "Neural destruction"
 	resistance = -2
 	stage_speed = -3
 	level = 6
 	severity = 5
 
-/datum/symptom/sensory_destruction/Activate(datum/disease/advance/A)
+/datum/symptom/neural_destruction/Activate(datum/disease/advance/A)
 	..()
 	if(prob(SYMPTOM_ACTIVATION_PROB))
 		var/mob/living/M = A.affected_mob


### PR DESCRIPTION
**What does this PR do:**
Re adds sensory destruction as a symptom now named neural destruction to sound more terrifying (because it is).
This symptom is the symptom that makes virology scary. That makes people not always trust the virologist. That makes people fear him. Removing this will make him have to rely on symptoms that are anti stealth such as spontaneous combustion or necrosis.

Do not remove this please. It's the virologists greatest tool of terror.

**Changelog:**
:cl:
add: Re adds sensory destruction now named as neural destruction
/:cl:

