### PR TITLE
Fixes Stacks--Again

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -231,16 +231,10 @@
 	if(amount < used)
 		return FALSE
 	amount -= used
-	if(amount < 1)
-		if(isrobot(loc))
-			var/mob/living/silicon/robot/R = loc
-			if(locate(src) in R.module.modules)
-				R.module.modules -= src
-			if(R)
-				R.unEquip(src, TRUE)
-	zero_amount()
+	if(check)
+		zero_amount()
 	update_icon()
-	return 1
+	return TRUE
 
 /obj/item/stack/proc/get_amount()
 	return amount
@@ -307,6 +301,12 @@
 
 /obj/item/stack/proc/zero_amount()
 	if(amount < 1)
+		if(isrobot(loc))
+			var/mob/living/silicon/robot/R = loc
+			if(locate(src) in R.module.modules)
+				R.module.modules -= src
+		if(usr)
+			usr.unEquip(src, TRUE)
 		qdel(src)
 		return TRUE
 	return FALSE


### PR DESCRIPTION
Fixes stacks failing to garbage collect properly, thus causing all sorts of whacky, weird issues.

Stack code is cancer. So is our inventory code. If everything isn't perfect when dealing with stacks, it'll push you over and fart on your face while telling you your mom has cancer.

fixes https://github.com/ParadiseSS13/Paradise/issues/10933
fixes https://github.com/ParadiseSS13/Paradise/issues/10924

:cl: Fox McCloud
fix: Fixes invisible stacks in hands
fix: Fixes invisible bluespace crystals
/:cl: