### PR TITLE
Hardsuits already allowing RCDs in suit storage slot now allow RPDs too

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -72,7 +72,7 @@
 	icon_state = "hardsuit-engineering"
 	item_state = "eng_hardsuit"
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
-	allowed = list(/obj/item/flashlight,/obj/item/tank,/obj/item/t_scanner, /obj/item/rcd)
+	allowed = list(/obj/item/flashlight,/obj/item/tank,/obj/item/t_scanner, /obj/item/rcd, /obj/item/rpd)
 	siemens_coefficient = 0
 	actions_types = list(/datum/action/item_action/toggle_helmet)
 


### PR DESCRIPTION
:cl:Kyep
add: Hardsuits that can already carry RCDs in their suit storage slot can now also carry RPDs in that slot.
/:cl:

Reasons:

1. Currently, atmos techs are forced to carry their RPD in their hand, as it won't fit anywhere else except their backpack, and while fighting fires/etc they tend to wear their tank on their back slot. This is a QOL upgrade for atmos techs, reducing the amount of inventory juggling they need to do. Similar QOL logic to https://github.com/ParadiseSS13/Paradise/pull/10484

2. Currently, eng/atmos suits can already carry RCDs in suit storage slot. Since RPDs are the same size, same weight, similar shape, and something the suits should also be designed to carry, it makes sense that the suits could carry them as well. 

PR requested by: Odieman.