### PR TITLE
Links wire panels to darkvision

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -87,8 +87,9 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)
-		if(eyes && H.disabilities & COLOURBLIND)
-			replace_colours = eyes.replace_colours
+		if(eyes && (H.disabilities & COLOURBLIND || eyes.dark_view >= 6))
+			if(!eyes.is_robotic())
+				replace_colours = eyes.replace_colours
 
 
 	var/list/W[0]

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -87,7 +87,7 @@ var/list/wireColours = list("red", "blue", "green", "black", "orange", "brown", 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)
-		if(eyes && (H.disabilities & COLOURBLIND || eyes.dark_view >= 6))
+		if(eyes && (H.disabilities & COLOURBLIND || eyes.dark_view >= EYE_SHINE_THRESHOLD))
 			if(!eyes.is_robotic())
 				replace_colours = eyes.replace_colours
 


### PR DESCRIPTION
This PR links dark vision to a limited form of colorblindness that effects wire panels.

Species with a Colorblindness greater then 5 will have species specific replacements.

This does not effect the normal worldview at all, and is NOT the same as the colorblindness disability.

Where a player with a dark sight below 6 would see
![image](https://user-images.githubusercontent.com/8165455/53602814-d9a60e00-3b7d-11e9-804c-26bbcc33bda3.png)

One with a darksight of 6 or more would see
![image](https://user-images.githubusercontent.com/8165455/53602830-e62a6680-3b7d-11e9-9cac-5941c299a4fc.png)


:cl: alffd
balance: extremely high levels of darksight now cause difficulty seeing colors in wire panels. 
/:cl:

