### PR TITLE
Can't use telepathy when unconcious or dead now

### DIFF
--- a/code/game/dna/genes/vg_powers.dm
+++ b/code/game/dna/genes/vg_powers.dm
@@ -227,7 +227,7 @@
 /obj/effect/proc_holder/spell/targeted/remotetalk/cast(list/targets, mob/user = usr)
 	if(!ishuman(user))	return
 	var/say = input("What do you wish to say") as text|null
-	if(!say)
+	if(!say || usr.stat)
 		return
 	say = strip_html(say)
 	say = pencode_to_html(say, usr, format = 0, fields = 0)


### PR DESCRIPTION
**What does this PR do:**
Fixes: #10965

**Changelog:**
:cl:
fix: Can't use telepathy now when unconcious or dead
/:cl:

