### PR TITLE
His Grace Binds His Will

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -176,7 +176,7 @@ var/const/SAFETY_COOLDOWN = 100
 
 	// Remove and recycle the equipped items
 	if(eat_victim_items)
-		for(var/obj/item/I in L.get_equipped_items())
+		for(var/obj/item/I in L.get_equipped_items(TRUE))
 			if(L.unEquip(I))
 				eat(I, sound = 0)
 

--- a/code/game/objects/items/weapons/storage/artistic_toolbox.dm
+++ b/code/game/objects/items/weapons/storage/artistic_toolbox.dm
@@ -31,7 +31,7 @@
 			else
 				flags &= ~NODROP
 	else
-		to_chat(user, "<span class='warning'>You can't see to understand what this does.</span>")
+		to_chat(user, "<span class='warning'>You can't seem to understand what this does.</span>")
 
 
 /obj/item/storage/toolbox/green/memetic/attack_hand(mob/living/carbon/user)

--- a/code/game/objects/items/weapons/storage/artistic_toolbox.dm
+++ b/code/game/objects/items/weapons/storage/artistic_toolbox.dm
@@ -26,10 +26,7 @@
 		var/obj/item/storage/toolbox/green/memetic/M = user.get_active_hand()
 		if(istype(M))
 			to_chat(user, "<span class='warning'>His Grace [flags & NODROP ? "releases from" : "binds to"] your hand!</span>")
-			if(!(flags & NODROP))
-				flags |= NODROP
-			else
-				flags &= ~NODROP
+			flags ^= NODROP
 	else
 		to_chat(user, "<span class='warning'>You can't seem to understand what this does.</span>")
 
@@ -99,6 +96,7 @@
 	H.death()
 	H.ghostize()
 	if(H == original_owner)
+		H.unEquip(src, TRUE)
 		qdel(H)
 		var/obj/item/storage/toolbox/green/fake_toolbox = new(get_turf(src))
 		fake_toolbox.desc = "It looks a lot duller than it used to."
@@ -109,14 +107,10 @@
 		H.forceMove(get_turf(src))
 		visible_message("<span class='warning'>[H] bursts out of [src]!</span>")
 
-	for(var/A in servantlinks)
-		var/datum/disease/memetic_madness/D = A
-		if(D)
-			D.cure()
-			break
+	for(var/datum/disease/memetic_madness/D in servantlinks)
+		D.cure()
 
-	if(servantlinks)
-		servantlinks.Cut()
+	servantlinks.Cut()
 	servantlinks = null
 	original_owner = null
 	visible_message("<span class='userdanger'>[src] screams!</span>")

--- a/code/game/objects/items/weapons/storage/artistic_toolbox.dm
+++ b/code/game/objects/items/weapons/storage/artistic_toolbox.dm
@@ -174,6 +174,12 @@
 		affected_mob.AdjustDizzy(-10)
 		affected_mob.AdjustDrowsy(-10)
 		affected_mob.SetSleeping(0)
+		affected_mob.SetSlowed(0)
+		affected_mob.SetConfused(0)
+		if(ishuman(affected_mob))
+			var/mob/living/carbon/human/H = affected_mob
+			if(H.traumatic_shock < 100)
+				H.shock_stage = 0
 		stage = 1
 		switch(progenitor.hunger)
 			if(10 to 60)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -433,6 +433,7 @@
 		CHECK_TICK
 
 /obj/item/storage/New()
+	..()
 	can_hold = typecacheof(can_hold)
 	cant_hold = typecacheof(cant_hold)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -153,26 +153,50 @@
 
 
 //Outdated but still in use apparently. This should at least be a human proc.
-/mob/proc/get_equipped_items()
-	var/list/items = new/list()
+//Daily reminder to murder this - Remie.
+/mob/proc/get_equipped_items(include_pockets = FALSE)
+	var/list/items = list()
+	if(back)
+		items += back
+	if(wear_mask)
+		items += wear_mask
+	return items
 
-	if(hasvar(src,"back")) if(src:back) items += src:back
-	if(hasvar(src,"belt")) if(src:belt) items += src:belt
-	if(hasvar(src,"l_ear")) if(src:l_ear) items += src:l_ear
-	if(hasvar(src,"r_ear")) if(src:r_ear) items += src:r_ear
-	if(hasvar(src,"glasses")) if(src:glasses) items += src:glasses
-	if(hasvar(src,"gloves")) if(src:gloves) items += src:gloves
-	if(hasvar(src,"head")) if(src:head) items += src:head
-	if(hasvar(src,"shoes")) if(src:shoes) items += src:shoes
-	if(hasvar(src,"wear_id")) if(src:wear_id) items += src:wear_id
-	if(hasvar(src,"wear_mask")) if(src:wear_mask) items += src:wear_mask
-	if(hasvar(src,"wear_suit")) if(src:wear_suit) items += src:wear_suit
-//	if(hasvar(src,"w_radio")) if(src:w_radio) items += src:w_radio  commenting this out since headsets go on your ears now PLEASE DON'T BE MAD KEELIN
-	if(hasvar(src,"w_uniform")) if(src:w_uniform) items += src:w_uniform
+/mob/living/carbon/get_equipped_items(include_pockets = FALSE)
+	var/list/items = ..()
+	if(wear_suit)
+		items += wear_suit
+	if(head)
+		items += head
+	return items
 
-	//if(hasvar(src,"l_hand")) if(src:l_hand) items += src:l_hand
-	//if(hasvar(src,"r_hand")) if(src:r_hand) items += src:r_hand
-
+/mob/living/carbon/human/get_equipped_items(include_pockets = FALSE)
+	var/list/items = ..()
+	if(belt)
+		items += belt
+	if(l_ear)
+		items += l_ear
+	if(r_ear)
+		items += r_ear
+	if(glasses)
+		items += glasses
+	if(gloves)
+		items += gloves
+	if(shoes)
+		items += shoes
+	if(wear_id)
+		items += wear_id
+	if(wear_pda)
+		items += wear_pda
+	if(w_uniform)
+		items += w_uniform
+	if(include_pockets)
+		if(l_store)
+			items += l_store
+		if(r_store)
+			items += r_store
+		if(s_store)
+			items += s_store
 	return items
 
 /obj/item/proc/equip_to_best_slot(mob/M)


### PR DESCRIPTION
This is something I missed when I originally ported His Grace, a while back.

You're not really supposed to be able to remove His Grace unless the user removes it themselves. We don't have such a system on our codebase, so I went with the next best thing; the ability to toggle `NODROP` on/off for His Grace.

This solve the obvious major problem with the item; while it is more than capable of handling both non-lethal and lethal force thrown at His Grace's wielder, a simple disarm or smoke cloud instantly makes you drop the item, thus rendering your rampage ended by the mere spam of greytide.

This also pushes it more in the direction of fitting to its role; a murder-death-kill item. As such, several changes have been made:

- Can pick up His Grace without activating it; attempting to open it while it's in your hands is now how you activate it
- Removes Slowed status
- Removes Confusion
- Sets shock stage to 0 if you're healthy
- Can eat all mobs 
- Mobs eaten are permanently killed
- When you eat a human mob, their inventory is stripped and put in a box inside of His Grace

A few of these were present when I did the original port, but it was tricky to implement.

Other:
- Fixes edge case reference of Memetic Kill Agent if there was somehow multiple instance of the disease referencing the same His Grace
- Refactored `get_equipped_items` so it's not a horrifying violation of OOP.

:cl: Fox McCloud
add: His Grace now allows you to toggle on/off binding to your hand
tweak: Activating his grace is now down by attempting to open it while it's in your hands
tweak: His Grace now removes slowed status, confusion, and resets shock stage if you're healthy
add: His Grace can now consume all mobs. Mobs consumed are permanently killed
add: His Grace will now neatly package up the inventory of people he consumes
/:cl: