### PR TITLE
Adds mousedrop to speed/fire potions

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -359,7 +359,7 @@
 	qdel(src)
 
 /obj/item/slimepotion/speed/MouseDrop(obj/over_object)
-	if(istype(usr.loc, /obj/mecha) || usr.restrained() || usr.stat)
+	if(usr.incapacitated())
 		return
 	if(loc == usr && loc.Adjacent(over_object))
 		afterattack(over_object, usr, TRUE)
@@ -396,7 +396,7 @@
 		qdel(src)
 
 /obj/item/slimepotion/fireproof/MouseDrop(obj/over_object)
-	if(istype(usr.loc, /obj/mecha) || usr.restrained() || usr.stat)
+	if(usr.incapacitated())
 		return
 	if(loc == usr && loc.Adjacent(over_object))
 		afterattack(over_object, usr, TRUE)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -359,6 +359,8 @@
 	qdel(src)
 
 /obj/item/slimepotion/speed/MouseDrop(obj/over_object)
+	if(istype(usr.loc, /obj/mecha) || usr.restrained() || usr.stat)
+		return
 	if(loc == usr && loc.Adjacent(over_object))
 		afterattack(over_object, usr, TRUE)
 
@@ -394,6 +396,8 @@
 		qdel(src)
 
 /obj/item/slimepotion/fireproof/MouseDrop(obj/over_object)
+	if(istype(usr.loc, /obj/mecha) || usr.restrained() || usr.stat)
+		return
 	if(loc == usr && loc.Adjacent(over_object))
 		afterattack(over_object, usr, TRUE)
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -358,6 +358,10 @@
 	C.slowdown = 0
 	qdel(src)
 
+/obj/item/slimepotion/speed/MouseDrop(obj/over_object)
+	if(loc == usr && loc.Adjacent(over_object))
+		afterattack(over_object, usr, TRUE)
+
 /obj/item/slimepotion/fireproof
 	name = "slime chill potion"
 	desc = "A potent chemical mix that will fireproof any article of clothing. Has three uses."
@@ -388,6 +392,10 @@
 	uses --
 	if(!uses)
 		qdel(src)
+
+/obj/item/slimepotion/fireproof/MouseDrop(obj/over_object)
+	if(loc == usr && loc.Adjacent(over_object))
+		afterattack(over_object, usr, TRUE)
 
 /obj/effect/timestop
 	anchored = 1


### PR DESCRIPTION
**What does this PR do:**
As of right now you have to fill the storage object with junk *then* you can apply speed/fire potions. This adds the ability to simply drag and drop the potion on top of the item.

**Changelog:**
:cl:
add: Mousedrop applies slime speed/chill potions.
/:cl:

