### PR TITLE
Auto admin for localhost

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -213,6 +213,9 @@
 	// Developer
 	var/developer_express_start = 0
 
+	// Automatic localhost admin disable
+	var/disable_localhost_admin = 0
+
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
 		var/datum/game_mode/M = T
@@ -645,6 +648,8 @@
 					config.disable_high_pop_mc_mode_amount = text2num(value)
 				if("developer_express_start")
 					config.developer_express_start = 1
+				if("disable_localhost_admin")
+					config.disable_localhost_admin = 1
 				else
 					log_config("Unknown setting in configuration: '[name]'")
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -311,9 +311,10 @@
 
 	//Admin Authorisation
 	// Automatically makes localhost connection an admin
-	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses
-	if(!isnull(address) && address in localhost_addresses)
-		new /datum/admins("!LOCALHOST!", R_HOST, ckey) // Makes localhost rank
+	if(!config.disable_localhost_admin)
+		var/localhost_addresses = list("127.0.0.1", "::1") // Adresses
+		if(!isnull(address) && address in localhost_addresses)
+			new /datum/admins("!LOCALHOST!", R_HOST, ckey) // Makes localhost rank
 	holder = admin_datums[ckey]
 	if(holder)
 		GLOB.admins += src

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -310,6 +310,10 @@
 	GLOB.directory[ckey] = src
 
 	//Admin Authorisation
+	// Automatically makes localhost connection an admin
+	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses
+	if(isnull(address) || (address in localhost_addresses))
+		new /datum/admins("!LOCALHOST!", R_HOST, ckey) // Makes localhost rank
 	holder = admin_datums[ckey]
 	if(holder)
 		GLOB.admins += src

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -312,7 +312,7 @@
 	//Admin Authorisation
 	// Automatically makes localhost connection an admin
 	var/localhost_addresses = list("127.0.0.1", "::1") // Adresses
-	if(isnull(address) || (address in localhost_addresses))
+	if(!isnull(address) && address in localhost_addresses)
 		new /datum/admins("!LOCALHOST!", R_HOST, ckey) // Makes localhost rank
 	holder = admin_datums[ckey]
 	if(holder)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -394,3 +394,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ##Uncomment to enable developer start. Auto starts the server after initialization
 ##DEVELOPER_EXPRESS_START
+
+## Uncomment to disable automatic admin for localhost
+#DISABLE_LOCALHOST_ADMIN


### PR DESCRIPTION
**What does this PR do:**
This PR will automatically give full admin rights if you are connecting via localhost. This is to save time and also to help with saving time for people who just want to test out the code locally. I have gotten someone to test this externally connecting (Thanks `DoctorDrugs`) and they were not automatically adminned.

**Changelog:**
:cl: AffectedArc07
add: You will now automatically be given admin rights if you connect to your local server
/:cl:

