### PR TITLE
Reworks Giant Spider Venom

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -4,22 +4,6 @@
 #define MOVING_TO_TARGET 3
 #define SPINNING_COCOON 4
 
-/mob/living/simple_animal/hostile/poison
-	var/poison_per_bite = 5
-	var/poison_type = "spidertoxin"
-
-/mob/living/simple_animal/hostile/poison/AttackingTarget()
-	..()
-	if(isliving(target) && (!client || a_intent == INTENT_HARM))
-		var/mob/living/L = target
-		if(L.reagents)
-			L.reagents.add_reagent("spidertoxin", poison_per_bite)
-			if(prob(poison_per_bite))
-				to_chat(L, "<span class='danger'>You feel a tiny prick.</span>")
-				L.reagents.add_reagent(poison_type, poison_per_bite)
-
-
-
 //basic spider mob, these generally guard nests
 /mob/living/simple_animal/hostile/poison/giant_spider
 	name = "giant spider"
@@ -45,12 +29,22 @@
 	heat_damage_per_tick = 20	//amount of damage applied if animal's body temperature is higher than maxbodytemp
 	cold_damage_per_tick = 20	//same as heat_damage_per_tick, only if the bodytemperature it's lower than minbodytemp
 	faction = list("spiders")
-	var/busy = 0
 	pass_flags = PASSTABLE
 	move_to_delay = 6
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
 	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
+	var/venom_per_bite = 0 // While the /poison/ type path remains as-is for consistency reasons, we're really talking about venom, not poison.
+	var/busy = 0
+
+/mob/living/simple_animal/hostile/poison/giant_spider/AttackingTarget()
+	// This is placed here, NOT on /poison, because the other subtypes of /poison/ already override AttackingTarget() completely, and as such it would do nothing but confuse people there.
+	..()
+	if(venom_per_bite > 0 && iscarbon(target) && (!client || a_intent == INTENT_HARM))
+		var/mob/living/carbon/C = target
+		var/inject_target = pick("chest", "head")
+		if(C.can_inject(null, 0, inject_target, 0))
+			C.reagents.add_reagent("spidertoxin", venom_per_bite)
 
 //nursemaids - these create webs and eggs
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse
@@ -64,9 +58,8 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	poison_per_bite = 10
+	venom_per_bite = 30
 	var/atom/cocoon_target
-	poison_type = "ether"
 	var/fed = 0
 
 //hunters have the most poison and move the fastest, so they can find prey
@@ -79,7 +72,7 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	poison_per_bite = 5
+	venom_per_bite = 10
 	move_to_delay = 5
 
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/handle_automated_action()

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -33,7 +33,6 @@ var/global/list/ts_spiderling_list = list()
 	melee_damage_upper = 20
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
-	poison_type = "" // we do not use that silly system.
 	a_intent = INTENT_HARM
 
 	// Movement


### PR DESCRIPTION
This PR modifies the way that venom attacks work on giant space spiders.
Terror spiders, and other venom simple_animals like bees, are not affected by this PR.

Major changes:
- Clothing that grants you immunity to injection via needle (like hardsuits) now also protects you from the venomous attack of giant space spiders. This was already the case for terror spiders - this just applies the same logic to giant spiders. This change is mainly for consistency, but I think it also makes gameplay more interesting (spiders are now more of a threat to unarmored crew versus armored ones).
- Refactored venom injection code to make it clearer, and specifically to make it clear that it is only used for the giant_spider subtype of /poison/. Bees, terror spiders, etc have their own venom handling. Also, this refactor stops the code doing confusing things like misusing a 'poison_per_bite' var to mean different things at different places in the code. It also starts referring to venom correctly as venom (something you inject into a target) rather than "poison" (something the target suffers from after it eats you). I'm not changing the /poison/ mob type path to reflect this (not worth it - don't want to repath mobs without a very good reason) but I am accurately naming the vars 'venom' rather than 'poison', since the current use of 'poison' is arguably misleading to people who know the difference.
- Minor balance tweaks. Guard spiders (red eyes) are actually nerfed slightly, since they no longer get a poison attack at all in this PR. This is a good thing because they're already by far the strongest of the regular giant spider types, to the point that they're often the only one that gives crew trouble. Hunter spiders (purple eyes) are buffed a bit, delivering more poison per bite, but since they have only around 60% of a guard spider's health, and half their damage is DoT from poison, they're still very killable. Nurse spiders are buffed considerably, delivering a lot of poison per attack, but their absolutely pathetic health of 40 (20% of a guard spider!) and brute damage of 7.5 means they're useless against anything poison-immune, and die in 2-3 hits. They also no longer get the ability to inject ether with their venom. Still, it does mean that if ordinary crew attack nurse spiders, they may die from the larger venom dose afterwards... if they never go to medbay.

Resolves #10964 

:cl: Kyep
refactor: Refactored giant space spider venom handling code to make it clearer and eliminate some weirdness.
balance: Tweaked giant space spider balance. Guard spiders (red eyes) are now slightly weaker (no venom). Hunter (purple eyes) and nurse (green eyes) spiders are now a little stronger (more venom).
/:cl:

