### PR TITLE
Medical QOL Bugfix - Round 2

### DIFF
--- a/code/game/machinery/defib_mount.dm
+++ b/code/game/machinery/defib_mount.dm
@@ -132,9 +132,7 @@
 	if(clamps_locked)
 		to_chat(user, "<span class='warning'>You try to tug out [defib], but the mount's clamps are locked tight!</span>")
 		return
-	if(!user.put_in_hands(defib))
-		to_chat(user, "<span class='warning'>You need a free hand!</span>")
-		return
+	user.put_in_hands(defib)
 	user.visible_message("<span class='notice'>[user] unhooks [defib] from [src].</span>", \
 	"<span class='notice'>You slide out [defib] from [src] and unhook the charging cables.</span>")
 	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -17,7 +17,7 @@
 		if(bag.reagents.total_volume)
 			var/image/filling = image('icons/goonstation/objects/iv.dmi', src, "hangingbag-fluid")
 			filling.icon += mix_color_from_reagents(bag.reagents.reagent_list)
-			add_overlay(overlays)
+			add_overlay(filling)
 
 /obj/machinery/iv_drip/MouseDrop(mob/living/target)
 	if(usr.incapacitated())


### PR DESCRIPTION
Defibs no longer create a ghost copy if you try to remove it from the mount with your hands full.
IV drips now have a colored overlay reflecting the reagent filling.