### PR TITLE
Moves discord verbs to "Special Verbs" instead of "OOC"

### DIFF
--- a/code/modules/discord/accountlink.dm
+++ b/code/modules/discord/accountlink.dm
@@ -1,6 +1,6 @@
 // DONT TOUCH ANYTHING IN HERE UNLESS YOU KNOW WHAT YOU ARE DOING -affected
 /client/verb/linkdiscord()
-    set category = "OOC"
+    set category = "Special Verbs"
     set name = "Link Discord Account"
     set desc = "Link your discord account to your BYOND account."
     var/user_ckey = sanitizeSQL(usr.ckey) // Probably not neccassary but better safe than sorry

--- a/code/modules/discord/notify.dm
+++ b/code/modules/discord/notify.dm
@@ -1,6 +1,6 @@
 // DONT TOUCH ANYTHING IN HERE UNLESS YOU KNOW WHAT YOU ARE DOING -affected
 /client/verb/notify_restart()
-    set category = "OOC"
+    set category = "Special Verbs"
     set name = "Notify Restart"
     set desc = "Notifies you on Discord when the server restarts."
     if(!config.sql_enabled)


### PR DESCRIPTION
**What does this PR do:**
This moves the discord verbs to the `Special Verbs` tab instead of `OOC`. Why? 
![image](https://user-images.githubusercontent.com/25063394/53744592-3d3d7d80-3e95-11e9-8bd5-112c72347eca.png)
*Theres less room for it to be lost and its paradise specific*

![image](https://user-images.githubusercontent.com/25063394/53744642-51817a80-3e95-11e9-93f6-457e699e629d.png)

**Changelog:**
:cl: AffectedArc07
tweak: Discord-related verbs are now under "Special Verbs" instead of "OOC"
/:cl:

