### PR TITLE
Cyber implant bundle fix and Discount balancing

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -642,6 +642,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/backpack/duffel/syndie/ammo/loaded
 	cost = 10 //bulk buyer's discount. Very useful if you're buying a mech and dont have TC left to buy people non-shotgun guns
 	gamemodes = list(/datum/game_mode/nuclear)
+	cant_discount = TRUE
 
 /datum/uplink_item/ammo/bullslug
 	name = "Bulldog - 12g Slug Magazine"
@@ -1461,10 +1462,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	category = "Cybernetic Implants"
 	surplus = 0
 	gamemodes = list(/datum/game_mode/nuclear)
+	var/cyber_bundle = FALSE
 
 /datum/uplink_item/cyber_implants/spawn_item(turf/loc, obj/item/uplink/U)
 	if(item)
-		if(findtext(item, /obj/item/organ/internal/cyberimp))
+		if(findtext(item, /obj/item/organ/internal/cyberimp) && !cyber_bundle)
 			U.uses -= max(cost, 0)
 			U.used_TC += cost
 			feedback_add_details("traitor_uplink_items_bought", name) //this one and the line before copypasted because snowflaek code
@@ -1508,6 +1510,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	reference = "CIB"
 	item = /obj/item/storage/box/cyber_implants/bundle
 	cost = 40
+	cyber_bundle = TRUE
+	cant_discount = TRUE
 
 // POINTLESS BADASSERY
 

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -326,6 +326,7 @@
 /obj/item/storage/box/cyber_implants/bundle/New()
 	..()
 	var/implant
-	while(contents.len <= amount + 1) // +1 for the autoimplanter.
+	while(amount > 0)
 		implant = pick(boxed)
 		new implant(src)
+		amount--


### PR DESCRIPTION
**What does this PR do:**
Fixes a couple of bugs with the cybernetics implant bundle. Previously it would deliver the implants in a box that was then packaged inside **another** box. Also it would give 6 implants in the bundle rather than the 5 advertised.

It also flags both the cybernetics bundle and the ammo bag bundles as being non-discountable, since both items are discounts already (decent ones at that), something I should have caught when I added discounts in originally.

**Changelog:**
:cl:
fix: Fixed nuke ops cybernetic bundles giving 6 implants rather than 5.
fix: Fixed nuke ops cybernetic bundles being delivered in a box that was then delivered inside another box.
balance: Nuke ops shotgun ammo bags and cybernetic bundles can no longer be discounted.
/:cl:

