### PR TITLE
Fixes Neo-Russkiya Lang key

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -433,7 +433,7 @@
 	whisper_verb = "mutters"
 	exclaim_verb = "exaggerates"
 	colour = "com_srus"
-	key = ">"
+	key = "?"
 	space_chance = 65
 	english_names = 1
 	syllables = list("dyen","bar","bota","vyek","tvo","slov","slav","syen","doup","vah","laz","gloz","yet",


### PR DESCRIPTION
Because we can't have sane key assignments.
Changes the key from `>` to `?`

![image](https://user-images.githubusercontent.com/15992551/53837772-37ed3b00-3f48-11e9-9391-7c1be2d11c37.png)

Someone should figure out key assignment.

:cl: Triiodine
fix: changes Neo-Russkiya Lang key to ?
/:cl:

