### PR TITLE
Tweaks Ghost Verb

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -769,3 +769,12 @@
 			target_cryopod.take_occupant(person_to_cryo, 1)
 			return 1
 	return 0
+
+/proc/force_cryo_human(var/mob/living/carbon/person_to_cryo)
+	if(!istype(person_to_cryo))
+		return
+	if(!istype(person_to_cryo.loc, /obj/machinery/cryopod))
+		cryo_ssd(person_to_cryo)
+	if(istype(person_to_cryo.loc, /obj/machinery/cryopod))
+		var/obj/machinery/cryopod/P = person_to_cryo.loc
+		P.despawn_occupant()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -194,7 +194,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			return
 
 	if(stat == CONSCIOUS)
-		player_ghosted = 1
+		if(!is_admin_level(z))
+			player_ghosted = 1
+		if(mind && mind.special_role)
+			message_admins("[key_name_admin(src)] has ghosted while alive, with special_role: [mind.special_role]")
 
 	if(warningmsg)
 		// Not respawnable

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -181,18 +181,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		warningmsg = "You have committed suicide too early in the round"
 	else if(stat != DEAD)
 		warningmsg = "You are alive"
+		if(isAI(src))
+			warningmsg = "You are a living AI! You should probably use OOC -> Wipe Core instead."
 	else if(GLOB.non_respawnable_keys[ckey])
 		warningmsg = "You have lost your right to respawn"
-
-	if(stat == CONSCIOUS)
-
-		if(isAI(src))
-			to_chat(src, "<span class='userdanger'>AIs cannot ghost while alive. If you must leave the round, use OOC -> Wipe Core instead.</span>")
-			return
-
-		if(sees_someone_nearby())
-			to_chat(src, "<span class='userdanger'>You cannot ghost while alive with another player nearby. Go somewhere more secluded first.</span>")
-			return
 
 	if(warningmsg)
 		var/response
@@ -201,15 +193,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if(response != "Ghost")
 			return
 
-	var/move_to_cryo = ishuman(src) && stat == CONSCIOUS && !P && !restrained()
-	if(move_to_cryo)
-		if(!do_after(src, 600, 0, target = src))
-			return
-		if(restrained())
-			move_to_cryo = FALSE
+	if(stat == CONSCIOUS)
+		player_ghosted = 1
 
-	if(move_to_cryo)
-		cryo_ssd(src)
 	if(warningmsg)
 		// Not respawnable
 		var/mob/dead/observer/ghost = ghostize(0)	// 0 parameter stops them re-entering their body
@@ -217,8 +203,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else
 		// Respawnable
 		ghostize(1)
-	if(move_to_cryo)
-		force_cryo_human(src)
 
 	// If mob in morgue tray, update tray
 	var/obj/structure/morgue/Morgue = locate() in M.loc

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -49,7 +49,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 		T = get_turf(body)				//Where is the body located?
 		attack_log = body.attack_log	//preserve our attack logs by copying them to our ghost
 
-		var/mutable_appearance/MA = copy_appearance(body) 
+		var/mutable_appearance/MA = copy_appearance(body)
 		if(body.mind && body.mind.name)
 			MA.name = body.mind.name
 		else if(body.real_name)
@@ -185,8 +185,18 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else if(GLOB.non_respawnable_keys[ckey])
 		warningmsg = "You have lost your right to respawn"
 
+	var/is_seen = FALSE
+	for(var/mob/living/L in oviewers(7, src))
+		if(L.ckey && L.client && && L.stat != DEAD)
+			is_seen = TRUE
+			break
+	if(is_seen)
+		to_chat(src, "<span class='userdanger'>You cannot do this while observed by another player. Go somewhere more secluded first.</span>")
+		return
+
 	if(!warningmsg)
 		ghostize(1)
+		force_cryo_human(src)
 	else
 		var/response
 		var/alertmsg = "Are you -sure- you want to ghost?\n([warningmsg]. If you ghost now, you probably won't be able to rejoin the round! You can't change your mind, so choose wisely!)"
@@ -196,6 +206,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		StartResting()
 		var/mob/dead/observer/ghost = ghostize(0)            //0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
+		force_cryo_human(src)
 	var/obj/structure/morgue/Morgue = locate() in M.loc
 	if(istype(M.loc, /obj/structure/morgue))
 		Morgue = M.loc

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -185,21 +185,22 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else if(GLOB.non_respawnable_keys[ckey])
 		warningmsg = "You have lost your right to respawn"
 
-	var/sees_someone = FALSE
-	for(var/mob/living/L in oviewers(7, src))
-		if(!L.ckey)
-			continue
-		if(!L.client)
-			continue
-		if(L.stat == DEAD)
-			continue
-		if(L.invisibility >= see_invisible)
-			continue
-		sees_someone = TRUE
-		break
-	if(sees_someone)
-		to_chat(src, "<span class='userdanger'>You cannot do this while another player is nearby. Go somewhere more secluded first.</span>")
-		return
+	if(stat == CONSCIOUS)
+		var/sees_someone = FALSE
+		for(var/mob/living/L in oviewers(7, src))
+			if(!L.ckey)
+				continue
+			if(!L.client)
+				continue
+			if(L.stat == DEAD)
+				continue
+			if(L.invisibility >= see_invisible)
+				continue
+			sees_someone = TRUE
+			break
+		if(sees_someone)
+			to_chat(src, "<span class='userdanger'>You cannot do this while another player is nearby. Go somewhere more secluded first.</span>")
+			return
 
 	if(!warningmsg)
 		if(stat == CONSCIOUS)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -202,19 +202,23 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	if(!warningmsg)
-		cryo_ssd(src)
+		if(stat == CONSCIOUS)
+			cryo_ssd(src)
 		ghostize(1)
-		force_cryo_human(src)
+		if(stat == CONSCIOUS)
+			force_cryo_human(src)
 	else
 		var/response
 		var/alertmsg = "Are you -sure- you want to ghost?\n([warningmsg]. If you ghost now, you probably won't be able to rejoin the round! You can't change your mind, so choose wisely!)"
 		response = alert(src, alertmsg,"Are you sure you want to ghost?","Stay in body","Ghost")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
-		cryo_ssd(src)
+		if(stat == CONSCIOUS)
+			cryo_ssd(src)
 		var/mob/dead/observer/ghost = ghostize(0)            //0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
-		force_cryo_human(src)
+		if(stat == CONSCIOUS)
+			force_cryo_human(src)
 	var/obj/structure/morgue/Morgue = locate() in M.loc
 	if(istype(M.loc, /obj/structure/morgue))
 		Morgue = M.loc

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -185,16 +185,24 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	else if(GLOB.non_respawnable_keys[ckey])
 		warningmsg = "You have lost your right to respawn"
 
-	var/is_seen = FALSE
+	var/sees_someone = FALSE
 	for(var/mob/living/L in oviewers(7, src))
-		if(L.ckey && L.client && && L.stat != DEAD)
-			is_seen = TRUE
-			break
-	if(is_seen)
-		to_chat(src, "<span class='userdanger'>You cannot do this while observed by another player. Go somewhere more secluded first.</span>")
+		if(!L.ckey)
+			continue
+		if(!L.client)
+			continue
+		if(L.stat == DEAD)
+			continue
+		if(L.invisibility >= see_invisible)
+			continue
+		sees_someone = TRUE
+		break
+	if(sees_someone)
+		to_chat(src, "<span class='userdanger'>You cannot do this while another player is nearby. Go somewhere more secluded first.</span>")
 		return
 
 	if(!warningmsg)
+		cryo_ssd(src)
 		ghostize(1)
 		force_cryo_human(src)
 	else
@@ -203,7 +211,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		response = alert(src, alertmsg,"Are you sure you want to ghost?","Stay in body","Ghost")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
-		StartResting()
+		cryo_ssd(src)
 		var/mob/dead/observer/ghost = ghostize(0)            //0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
 		force_cryo_human(src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -219,18 +219,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			P.despawn_occupant()
 	return
 
-/mob/living/proc/sees_someone_nearby()
-	for(var/mob/living/L in oviewers(7, src))
-		if(!L.ckey)
-			continue
-		if(!L.client)
-			continue
-		if(L.stat == DEAD)
-			continue
-		if(L.invisibility >= see_invisible)
-			continue
-		return TRUE
-
 /mob/dead/observer/Move(NewLoc, direct)
 	following = null
 	dir = direct

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -42,7 +42,7 @@
 	handle_ghosted()
 
 /mob/living/carbon/human/proc/handle_ghosted()
-	if(player_ghosted > 0 && stat == CONSCIOUS && !restrained())
+	if(player_ghosted > 0 && stat == CONSCIOUS && job && !restrained())
 		if(key)
 			player_ghosted = 0
 		else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -39,6 +39,17 @@
 		if(life_tick == 1)
 			regenerate_icons() // Make sure the inventory updates
 
+	handle_ghosted()
+
+/mob/living/carbon/human/proc/handle_ghosted()
+	if(player_ghosted > 0 && stat == CONSCIOUS && !restrained())
+		if(key)
+			player_ghosted = 0
+		else
+			player_ghosted++
+			if(player_ghosted % 150 == 0)
+				force_cryo_human(src)
+
 /mob/living/carbon/human/calculate_affecting_pressure(var/pressure)
 	..()
 	var/pressure_difference = abs( pressure - ONE_ATMOSPHERE )

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -173,6 +173,9 @@
 	//SSD var, changed it up some so people can have special things happen for different mobs when SSD.
 	var/player_logged = 0
 
+	//Ghosted var, set only if a player has manually ghosted out of this mob.
+	var/player_ghosted = 0
+
 	var/turf/listed_turf = null  //the current turf being examined in the stat panel
 	var/list/shouldnt_see = list(/atom/movable/lighting_overlay)	//list of objects that this mob shouldn't see in the stat panel. this silliness is needed because of AI alt+click and cult blood runes
 


### PR DESCRIPTION
**Updated 2019/Mar/12th, please re-read, as features have changed.**

This PR changes the OOC -> Ghost verb, so that:
- When ghosting as a living, conscious AI, you get a special warning, suggesting using OOC -> Wipe Core instead. This warning can be dismissed, like the normal warning for ghosting while alive. It exists to inform people of the preferred way to leave the round as AI. It won't stop you ghosting, it will just inform you that you should probably use Wipe Core instead.
- When ghosting as a living, conscious human, your mob will get a special var, player_ghosted. Once your mob has this var, the game will attempt to despawn it via cryogenics every ~300 seconds (5 minutes) it remains in that state. While your mob is dead, or restrained, this timer is paused. If another player inhabits your mob after you leave it, the timer is stopped entirely. Admins using aghost to leave their mob do NOT cause this var to be set. Nor does anyone ghosting on the admin zlevel (centcom). Nor does anyone ghosting from a mob that isn't crew (no mob.job var defined).
- When ghosting out as a living, conscious mob with an antag role, admins are informed, so that they can appoint a new antag for the round if it needs one.

This means:
- AIs are less likely to leave the round via ghosting, and more likely to leave the round via wipe core, which frees their AI job slot.
- If a player ghosts out a human mob, assuming the mob isn't dead or kept restrained, then eventually, it will be teleported to cryo, despawned, its job slot freed, its name removed from the manifest, its entry taken off the PDA list, any objectives that target it changed to target other mobs instead, and generally its entire presence in the round will be cleaned up. A "so-and-so has moved to long term storage" notice will be broadcast when this happens. This should prevent people ghosting while alive from keeping job slots, antag objectives, etc indefinitely.

:cl: Kyep
add: Ghosting while alive, conscious, and a member of the crew will now result in your body being moved to cryo after 5 minutes, assuming your body isn't killed or restrained in any way in the meantime.
add: An AI that ghosts while alive gets a dismissable hint that they might consider using OOC -> Wipe Core instead.
add: Ghosting out of your body while you are alive, and an antag, will result in admins being informed, so that they may replace you as an antag if needed.
/:cl:

