### PR TITLE
Adds Missing simple_animal Emote Help Text

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/emote.dm
+++ b/code/modules/mob/living/simple_animal/bot/emote.dm
@@ -1,4 +1,4 @@
-/mob/living/simple_animal/bot/emote(var/act, var/m_type=1, var/message = null)
+/mob/living/simple_animal/bot/emote(act, m_type=1, message = null)
 	var/param = null
 	if(findtext(act, "-", 1, null))
 		var/t1 = findtext(act, "-", 1, null)
@@ -69,4 +69,6 @@
 			playsound(src.loc, 'sound/goonstation/voice/robot_scream.ogg', 80, 0)
 			m_type = 2
 
+		if("help")
+			to_chat(src, "scream(s), yes, no, beep, buzz, ping")
 	..(act, m_type, message)

--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -278,5 +278,7 @@
 			message = "<B>\The [src]</B> chirps!"
 			m_type = 2 //audible
 			playsound(src, chirp_sound, 40, 1, 1)
+		if("help")
+			to_chat(src, "scream, chirp")
 
 	..(act, m_type, message)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -265,6 +265,8 @@
 		if("scream")
 			message = "<B>\The [src]</B> whimpers."
 			m_type = 2
+		if("help")
+			to_chat(src, "scream")
 
 	..(act, m_type, message)
 


### PR DESCRIPTION
Some simple animals were missing help text for emotes.
Happy to add or adjust anything I've missed.

:cl:
add: Added missing simple_animal emote help text.
/:cl: