### PR TITLE
Toggle Karma Hotfix

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -384,7 +384,7 @@
 		if(establish_db_connection())
 			to_chat(src,"<span class='notice'>You have disabled karma gains.") // reminds those who have it disabled
 	else
-		if (establish_db_connection())
+		if(establish_db_connection())
 			to_chat(src,"<span class='notice'>You have enabled karma gains.")
 
 	if(!void)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -383,6 +383,9 @@
 	if(prefs.toggles & DISABLE_KARMA) // activates if karma is disabled
 		if(establish_db_connection())
 			to_chat(src,"<span class='notice'>You have disabled karma gains.") // reminds those who have it disabled
+	else
+		if (establish_db_connection())
+			to_chat(src,"<span class='notice'>You have enabled karma gains.")
 
 	if(!void)
 		void = new()

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -224,10 +224,10 @@
 	set name = "Toggle Karma Gains"
 	set category = "Special Verbs"
 	set desc = "This button will allow you to stop other people giving you karma."
+	prefs.toggles ^= DISABLE_KARMA
+	prefs.save_preferences(src)
 	if (prefs.toggles & DISABLE_KARMA)
 		to_chat(usr, "<span class='notice'>You have disabled karma gains.")
 	else
 		to_chat(usr, "<span class='notice'>You have enabled karma gains.")
-	prefs.toggles ^= DISABLE_KARMA
-	prefs.save_preferences(src)
 	return

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -226,7 +226,7 @@
 	set desc = "This button will allow you to stop other people giving you karma."
 	prefs.toggles ^= DISABLE_KARMA
 	prefs.save_preferences(src)
-	if (prefs.toggles & DISABLE_KARMA)
+	if(prefs.toggles & DISABLE_KARMA)
 		to_chat(usr, "<span class='notice'>You have disabled karma gains.")
 	else
 		to_chat(usr, "<span class='notice'>You have enabled karma gains.")


### PR DESCRIPTION
**What does this PR do:**
send proper message about karma gains, display a message about whether it's enabled or not at roundstart for less confusion
**Changelog:**
:cl:
tweak: Display if karma gains are enabled or not on round start(instead of just disabled)
fix: Fix wrong message when toggling karma
/:cl:

