### PR TITLE
Swaps public RnD console board for a science RnD console board in Tech storage

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -72185,9 +72185,6 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/rdconsole/public{
-	pixel_x = -4
-	},
 /obj/item/circuitboard/rdserver{
 	pixel_x = 4;
 	pixel_y = -2
@@ -72207,6 +72204,7 @@
 	pixel_x = -4;
 	pixel_y = -3
 	},
+/obj/item/circuitboard/rdconsole,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "cyx" = (


### PR DESCRIPTION
**What does this PR do:**
Swaps out the public RnD console board in tech storage to a science access RnD console board.

Alternative to: #11018

**Images of sprite/map changes (IF APPLICABLE):**
N/A.

**Changelog:**

:cl:
tweak: The RnD console board in tech storage has been changed to one that requires science access to use.
/:cl:

