### PR TITLE
AntagHUD fixes for pure Vampires/Changelings in Traitor+Vampire and Traitor+Changeling gamemodes

### DIFF
--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -38,5 +38,6 @@
 		changeling.special_role = SPECIAL_ROLE_CHANGELING
 		forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
+		update_change_icons_added(changeling)
 	..()
 	return

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -43,4 +43,5 @@
 		vampire.special_role = SPECIAL_ROLE_VAMPIRE
 		forge_vampire_objectives(vampire)
 		greet_vampire(vampire)
+		update_vampire_icons_added(vampire)
 	..()


### PR DESCRIPTION
**What does this PR do:**
Fixes #10261 - Pure Vampires in Traitor+Vampire gamemode will now properly show in AntagHUD
Fixes #9494 - Pure Changelings in Traitor+Changeling gamemode will now properly show in AntagHUD

In some circumstances, for example when player had enabled vampire preference, but not traitor preference in Traitor+Vampire gamemode, he only gets pure vampire (not traitor) if he is chosen for antagonist. If that happens, he shows no antag icon in AntagHUD, this PR fixes that. Also fixes the same problem for pure changeling in Traitor+Changeling gamemode.

Currently, If the player gets both Vampire/Changeling AND Traitor, he will still show only Syndicate icon in AntagHUD, as that one overrides the Vampire/Changeling one. But that is an issue is for another PR.

**Changelog:**
:cl: Arkatos
fix: Fixes #10261 - Pure Vampires in Traitor+Vampire gamemode will now properly show in AntagHUD
fix: Fixes #9494 - Pure Changelings in Traitor+Changeling gamemode will now properly show in AntagHUD
/:cl: