### PR TITLE
Gives the option to limit the text popups to 1

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -29,6 +29,8 @@
 #define UI_DARKMODE 131072
 #define DISABLE_KARMA 262144
 
+#define TYPING_ONCE 1048576
+
 #define TOGGLES_DEFAULT (CHAT_OOC|CHAT_DEAD|CHAT_GHOSTEARS|CHAT_GHOSTSIGHT|CHAT_PRAYER|CHAT_RADIO|CHAT_LOOC|MEMBER_PUBLIC|DONATOR_PUBLIC)
 
 // Admin attack logs filter system, see /proc/add_attack_logs and /proc/msg_admin_attack

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -109,6 +109,15 @@
 	else
 		return trim(html_encode(name), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
 
+// Uses client.typing to check if the popup should appear or not
+/proc/typing_input(mob/user, message = "", title = "", default = "")
+	if(user.client.checkTyping()) // Prevent double windows
+		return null
+	user.client.typing = TRUE
+	var/msg = input(user, message, title, default) as text|null
+	user.client.typing = FALSE
+	return msg
+
 //Filters out undesirable characters from names
 /proc/reject_bad_name(var/t_in, var/allow_numbers=0, var/max_length=MAX_NAME_LEN)
 	if(!t_in || length(t_in) > max_length)

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -4,25 +4,21 @@ var/global/mentor_ooc_colour = "#0099cc"
 var/global/moderator_ooc_colour = "#184880"
 var/global/admin_ooc_colour = "#b82e00"
 
-/client/verb/ooc(msg as text)
+//Checks if the client already has a text input open
+/client/proc/checkTyping()
+	return (prefs.toggles & TYPING_ONCE && typing)
+
+/client/verb/ooc(msg = "" as text)
 	set name = "OOC"
 	set category = "OOC"
-
+	
 	if(!mob)
 		return
 	if(IsGuestKey(key))
 		to_chat(src, "<span class='danger'>Guests may not use OOC.</span>")
 		return
 
-	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
-	if(!msg)
-		return
-
-	if(!(prefs.toggles & CHAT_OOC))
-		to_chat(src, "<span class='danger'>You have OOC muted.</span>")
-		return
-
-	if(!check_rights(R_ADMIN|R_MOD,0))
+	if(!check_rights(R_ADMIN|R_MOD, 0))
 		if(!config.ooc_allowed)
 			to_chat(src, "<span class='danger'>OOC is globally muted.</span>")
 			return
@@ -32,6 +28,19 @@ var/global/admin_ooc_colour = "#b82e00"
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return
+	
+	if(!msg)
+		msg = typing_input(src.mob, "", "ooc (text)")
+		
+	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
+	if(!msg)
+		return
+
+	if(!(prefs.toggles & CHAT_OOC))
+		to_chat(src, "<span class='danger'>You have OOC muted.</span>")
+		return
+
+	if(!check_rights(R_ADMIN|R_MOD,0))
 		if(handle_spam_prevention(msg, MUTE_OOC, OOC_COOLDOWN))
 			return
 		if(findtext(msg, "byond://"))
@@ -150,7 +159,7 @@ var/global/admin_ooc_colour = "#b82e00"
 
 	feedback_add_details("admin_verb","ROC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/verb/looc(msg as text)
+/client/verb/looc(msg = "" as text)
 	set name = "LOOC"
 	set desc = "Local OOC, seen only by those in view."
 	set category = "OOC"
@@ -159,14 +168,6 @@ var/global/admin_ooc_colour = "#b82e00"
 		return
 	if(IsGuestKey(key))
 		to_chat(src, "<span class='danger'>Guests may not use OOC.</span>")
-		return
-
-	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
-	if(!msg)
-		return
-
-	if(!(prefs.toggles & CHAT_LOOC))
-		to_chat(src, "<span class='danger'>You have LOOC muted.</span>")
 		return
 
 	if(!check_rights(R_ADMIN|R_MOD,0))
@@ -179,6 +180,19 @@ var/global/admin_ooc_colour = "#b82e00"
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='danger'>You cannot use LOOC (muted).</span>")
 			return
+
+	if(!msg)
+		msg = typing_input(src.mob, "", "LOOC (text)")
+
+	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
+	if(!msg)
+		return
+
+	if(!(prefs.toggles & CHAT_LOOC))
+		to_chat(src, "<span class='danger'>You have LOOC muted.</span>")
+		return
+
+	if(!check_rights(R_ADMIN|R_MOD,0))
 		if(handle_spam_prevention(msg, MUTE_OOC, OOC_COOLDOWN))
 			return
 		if(findtext(msg, "byond://"))

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -30,7 +30,7 @@ var/global/admin_ooc_colour = "#b82e00"
 			return
 	
 	if(!msg)
-		msg = typing_input(src.mob, "", "ooc (text)")
+		msg = typing_input(src.mob, "", "ooc \"text\"")
 		
 	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
 	if(!msg)
@@ -182,7 +182,7 @@ var/global/admin_ooc_colour = "#b82e00"
 			return
 
 	if(!msg)
-		msg = typing_input(src.mob, "", "LOOC (text)")
+		msg = typing_input(src.mob, "Local OOC, seen only by those in view.", "looc \"text\"")
 
 	msg = trim(sanitize(copytext(msg, 1, MAX_MESSAGE_LEN)))
 	if(!msg)

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -19,6 +19,8 @@
 	var/area			= null
 	var/time_died_as_mouse = null //when the client last died as a mouse
 
+	var/typing = FALSE // Prevents typing window stacking
+
 	var/adminhelped = 0
 
 	var/gc_destroyed //Time when this object was destroyed.

--- a/code/modules/client/preference/preferences_mysql.dm
+++ b/code/modules/client/preference/preferences_mysql.dm
@@ -55,7 +55,7 @@
 	ooccolor		= sanitize_hexcolor(ooccolor, initial(ooccolor))
 	UI_style		= sanitize_inlist(UI_style, list("White", "Midnight"), initial(UI_style))
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
-	toggles			= sanitize_integer(toggles, 0, 524287, initial(toggles))
+	toggles			= sanitize_integer(toggles, 0, 2097151, initial(toggles))
 	sound			= sanitize_integer(sound, 0, 65535, initial(sound))
 	UI_style_color	= sanitize_hexcolor(UI_style_color, initial(UI_style_color))
 	UI_style_alpha	= sanitize_integer(UI_style_alpha, 0, 255, initial(UI_style_alpha))

--- a/code/modules/client/preference/preferences_toggles.dm
+++ b/code/modules/client/preference/preferences_toggles.dm
@@ -231,3 +231,15 @@
 	else
 		to_chat(usr, "<span class='notice'>You have enabled karma gains.")
 	return
+
+/client/verb/toggle_popup_limiter()
+	set name = "Toggle Text Popup Limiter"
+	set category = "Preferences"
+	set desc = "Will let you limit the text input popups to one at a time."
+	prefs.toggles ^= TYPING_ONCE
+	prefs.save_preferences(src)
+	if(prefs.toggles & TYPING_ONCE)
+		to_chat(usr, "<span class='notice'>You have enabled text popup limiting.")
+	else
+		to_chat(usr, "<span class='notice'>You have disabled text popup limiting.")
+	return

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -39,7 +39,7 @@ var/global/image/typing_indicator
 
 	set_typing_indicator(1)
 	hud_typing = 1
-	var/message = input("","say (text)") as null|text
+	var/message = typing_input(src, "", "say (text)")
 	hud_typing = 0
 	set_typing_indicator(0)
 	if(message)
@@ -49,9 +49,10 @@ var/global/image/typing_indicator
 	set name = ".Me"
 	set hidden = 1
 
+	
 	set_typing_indicator(1)
 	hud_typing = 1
-	var/message = input("","me (text)") as null|text
+	var/message = typing_input(src, "", "me (text)")
 	hud_typing = 0
 	set_typing_indicator(0)
 	if(message)


### PR DESCRIPTION
**What does this PR do:**
Bad naming if somebody has a better name for this do let me know.
Ever had a lagspike where you just started typing and had a sentence with a lot of t's or m's? I did. A lot.
This meant that after you pressed enter a lot of other chats would open and fuck your day up.
This PR gives you the option to limit the maximum called popups to the one active. Meaning the situation before can't happen anymore.
Also checks if OOC/LOOC are allowed before showing the popup.
The textbox below is tested and works the same for say and me.
For OOC and LOOC it excludes the " after LOOC for instance:
was: looc "text
is: looc text

Short extra explanation:
Itll prevent the hotkeys such as T, O and M from triggering when you already have a textbox of those types open. In lag spikes your game focus is still on the game when you start typing. So if you press T to talk then type something with a m or t in a lag spike you'll open emote and talk text boxes instead of typing. This pr prevents the text boxes from opening. It wont prevent the input not showing up.

The config option is given so that people can still have two popups open to for example say something and then immediately do a custom emote that they prepped in another window.

**Changelog:**
:cl:
add: Gives you the option to disable text popup spam. Aka if enabled you won't get popups after you pressed T and had a lagspike and you typed a sentence containing a lot of T's. Default is off
tweak: Now checks if OOC and LOOC are enabled before showing the popup
/:cl:

