### PR TITLE
Tcomms no longer translates emotes!

### DIFF
--- a/code/game/machinery/telecomms/ntsl2.dm
+++ b/code/game/machinery/telecomms/ntsl2.dm
@@ -346,7 +346,8 @@ GLOBAL_DATUM_INIT(nttc_config, /datum/nttc_configuration, new())
 			setting_language = null
 		else
 			for(var/datum/multilingual_say_piece/S in message_pieces)
-				S.speaking = GLOB.all_languages[setting_language]
+				if(S.speaking != GLOB.all_languages["Noise"]) // check if they are emoting, these do not need to be translated
+					S.speaking = GLOB.all_languages[setting_language]
 
 	// Regex replacements
 	if(islist(regex) && regex.len > 0)


### PR DESCRIPTION
**What does this PR do:**
Make it possible to emote while an universal translator is active

![image](https://user-images.githubusercontent.com/30060146/54243503-1fa88d80-44ff-11e9-9eaf-dbacf8357242.png)

**Changelog:**
:cl:
tweak: universal translate no longer makes emotes over comms impossible
/:cl:

