### PR TITLE
Adds plasmaman and Vox crates with emergency life support supplies.

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -149,6 +149,27 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 	access = access_hydroponics
 	announce_beacons = list("Hydroponics" = list("Hydroponics"))
 
+/datum/supply_packs/emergency/voxsupport
+	name = "Vox Life Support Supplies"
+	contains = list(/obj/item/clothing/mask/breath/vox,
+					/obj/item/clothing/mask/breath/vox,
+					/obj/item/tank/emergency_oxygen/vox,
+					/obj/item/tank/emergency_oxygen/vox)
+	cost = 50
+	containertype = /obj/structure/closet/crate/medical
+	containername = "vox life support supplies crate"
+
+/datum/supply_packs/emergency/plasmamansupport
+	name = "Plasmaman Life Support Supplies"
+	contains = list(/obj/item/clothing/mask/breath,
+					/obj/item/tank/emergency_oxygen/plasma,
+					/obj/item/clothing/suit/space/eva/plasmaman,
+					/obj/item/clothing/head/helmet/space/eva/plasmaman)
+	cost = 75
+	containertype = /obj/structure/closet/crate/secure/plasma
+	containername = "plasmaman life support supplies crate"
+	access = access_eva
+
 /datum/supply_packs/emergency/specialops
 	name = "Special Ops Supplies"
 	contains = list(/obj/item/storage/box/emps,


### PR DESCRIPTION
**What does this PR do:**
Adds emergency supply crates for Vox and plasmamans.

The vox crate contains two vox masks and two vox tanks, costing at 50 cargo points.

The plasmaman crate has one orange plasmaman space suit and orange plasmaman helmet, with a emergency plasmaman tank and regular mask included. Crate costs 75 cargo points and requires EVA access to open.

My reasoning is that if a vox loses their tank somehow, or a plasmaman their tank, or especially their suit, they are pretty much set for death, especially plasmaman. This allows cargo to order these emergency supplies without waiting for science to actually get to work to make a empty tank, or a plasmaman to have their suit found.

**Images of sprite/map changes (IF APPLICABLE):**
![image](https://user-images.githubusercontent.com/32376559/54408722-2e7a7600-46a0-11e9-8bf3-b10b9d17f982.png)


**Changelog:**

:cl: Quantum-M
add: Vox Cargo Crate - Contains two vox tanks and two vox masks. Costs 50 cargo points.
add: Plasmaman Cargo Crate - Contains a Orange plasmaman space suit and helmet, along with a breathing mask and a emergency plasmaman tank. Costs 75 cargo points and requires EVA access.
/:cl:

