### PR TITLE
Fixes buckled ventcrawl

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -442,6 +442,10 @@ var/list/ventcrawl_machinery = list(/obj/machinery/atmospherics/unary/vent_pump,
 			if(!do_after(src, 45, target = src))
 				return
 
+			if(buckled)
+				to_chat(src, "<span class='warning'>You cannot crawl into a vent while buckled to something!</span>")
+				return
+
 			if(!client)
 				return
 


### PR DESCRIPTION
:cl: Kyep
fix: It is no longer possible to crawl into a vent while you are simultaneously buckled to a chair or other solid object.
/:cl:
