### PR TITLE
Adds a scythe to the janitor's closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -32,7 +32,7 @@
 	new /obj/item/clothing/head/soft/black(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/clothing/shoes/black(src)
-
+	new /obj/item/scythe(src)
 /*
  * Chef
  */


### PR DESCRIPTION
Adds a scythe to the janitor's closet (locker)

**What does this PR do:**
Adds a scythe to the janitor's closet. The janitor will now be nicely equipped to help combat space vines, but more importantly, shroom outbreaks, which at times happen even in non-shadowling rounds, and are incredibly annoying and also against SoP. Botany never does anything about it, the janitor is the hero we all need.


**Changelog:**
:cl:
add: Adds a scythe to the janitor's locker
/:cl:

