### PR TITLE
Allows Wizards to choose the type of Guardian Spirit they want from a Tarot Deck

### DIFF
--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -182,7 +182,7 @@
 	if(adminseal || override)//if it's an admin-spawned guardian without a host it can still talk normally
 		return ..(message)
 	Communicate(message)
-	
+
 
 /mob/living/simple_animal/hostile/guardian/proc/ToggleMode()
 	to_chat(src, "<span class='danger'>You dont have another mode!</span>")
@@ -261,7 +261,7 @@
 	var/failure_message = "..And draw a card! It's...blank? Maybe you should try again later."
 	var/ling_failure = "The deck refuses to respond to a souless creature such as you."
 	var/list/possible_guardians = list("Chaos", "Standard", "Ranged", "Support", "Explosive", "Assassin", "Lightning", "Charger", "Protector")
-	var/random = TRUE
+	var/random = FALSE
 	var/color_list = list("Pink" = "#FFC0CB",
 		"Red" = "#FF0000",
 		"Orange" = "#FFA500",
@@ -358,7 +358,7 @@
 	G.icon_state = "[theme][color]"
 	G.icon_dead = "[theme][color]"
 	to_chat(user, "[G.magic_fluff_string].")
-	
+
 /obj/item/guardiancreator/choose
 	random = FALSE
 

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -411,7 +411,8 @@
 
 /datum/spellbook_entry/item/tarotdeck
 	name = "Tarot Deck"
-	desc = "A deck of tarot cards that can be used to summon a spirit companion for the wizard."
+	desc = "A deck of guardian tarot cards, capable of binding a personal guardian to your body. There are multiple types of guardian available, but all of them will transfer some amount of damage to you. \
+	It would be wise to avoid buying these with anything capable of causing you to swap bodies with others."
 	item_path = /obj/item/guardiancreator
 	log_name = "TD"
 	limit = 1


### PR DESCRIPTION
**What does this PR do:**
Wizards can buy an item called Tarot Deck for 2 magic points, which basically summons holoparasite bound to them. These are called Guardian Spirits and have unique set of gorgeous sprites for their types. Yet, in my several hundred playtime here, I dont think I have ever seen them on live server, that is, for wizard to buy them.
 
One reason for that is maybe the fact it chooses the Guardian type randomly, wizard cannot choose it himself, like for normal holoparasites, possibly hindering his plan if he did not get the type he wanted.
This PR allows wizards to choose the type of Guardian Spirit they want.

Also updates a description of Tarot Deck in Wizard's spellbook accordingly to better reflect what does it do, description is taken from /tg/station13, so credits to them.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
balance: Wizards can now choose the type of Guardian Spirit they want from a Tarot Deck, instead of it being randomly chosen for them
tweak: Updated Tarot Deck description in Wizard's spellbook, credits to /tg/station13
/:cl: