### PR TITLE
Lockbox now kicks user out upon locking #11046

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -133,5 +133,5 @@
 
 /obj/item/storage/lockbox/t4/New()
 	..()
-	for(var/i in 0 to 3)
+	for(var/i in 0 to 2)
 		new /obj/item/grenade/plastic/x4/thermite(src)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -24,6 +24,8 @@
 			if(locked)
 				icon_state = icon_locked
 				to_chat(user, "<span class='warning'>You lock \the [src]!</span>")
+				if(user.s_active)
+					user.s_active.close(user)
 				return
 			else
 				icon_state = icon_closed
@@ -131,5 +133,5 @@
 
 /obj/item/storage/lockbox/t4/New()
 	..()
-	for(var/i = 0, i < 3, i++)
+	for(var/i in 0 to 3)
 		new /obj/item/grenade/plastic/x4/thermite(src)


### PR DESCRIPTION
Fixes #11046 being able to have a locked lockbox open indefinitely if you had it open before locking

:cl:
fix: Lockboxes actually close when locked now.
/:cl:

