### PR TITLE
Shadowlings now can't use abilities affecting other beings while Shadow walking

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -2,6 +2,9 @@
 
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H)) return
+	if(H.incorporeal_move == 1)
+		to_chat(usr, "<span class='warning'>You can't use your abilities while you are traversing between worlds!</span>")
+		return 0
 	if(isshadowling(H) && is_shadow(H))
 		return 1
 	if(isshadowlinglesser(H) && is_thrall(H))

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -3,7 +3,7 @@
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H)) return
 	if(H.incorporeal_move == 1)
-		to_chat(usr, "<span class='warning'>You can't use your abilities while you are traversing between worlds!</span>")
+		to_chat(usr, "<span class='warning'>You can't use abilities affecting others while you are traversing between worlds!</span>")
 		return 0
 	if(isshadowling(H) && is_shadow(H))
 		return 1

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -4,7 +4,7 @@
 	if(!H || !istype(H)) return
 	if(H.incorporeal_move == 1)
 		to_chat(usr, "<span class='warning'>You can't use abilities affecting others while you are traversing between worlds!</span>")
-		return 0
+		return FALSE
 	if(isshadowling(H) && is_shadow(H))
 		return 1
 	if(isshadowlinglesser(H) && is_thrall(H))


### PR DESCRIPTION
**What does this PR do:**
Shadowlings are able to use all of their abilites while shadow walking, creating quite silly and unbalanced situations when Shadowling can do a repeatable "drive-by attacks" with AOE abilities like Ice Veins or Drain Life without even exposing themselves. This PR changes that.

Shadowlings now cannot use abilities affecting other beings or space around them while shadow walking, for example Glare, Veil, Ice Veins and others, but still can use abilities affecting only them, like Shadowling Darksight or Rapid Re-Hatch. Lore-wise, Shadowlings that are using Shadow walk ability are entering space between worlds, so it would make sense that they could not affect others, but still could affect themselves.

Tested locally without any issue found.

Interesting tidbit: This PR does not affect Ascendant Shadowlings, as they already could not use their abilities while phasing with their upgraded Shadow Walk ability.

**Changelog:**
:cl: Arkatos
balance: Shadowlings now can't use abilities affecting other beings or space around them while Shadow walking
/:cl: