### PR TITLE
Should make it so that dview can not bump into alive people anymore

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -311,7 +311,7 @@
 /atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 	if(last_forced_movement >= SSair.times_fired)
 		return 0
-	else if(!anchored && !pulledby)
+	else if((!anchored || move_resist == INFINITY) && !pulledby)
 		var/turf/target = get_turf(src)
 		var/datum/gas_mixture/target_air = target.return_air()
 		if(isspaceturf(target) || isunsimulatedturf(target) || pressure_resistance > target_air.return_pressure())

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -311,7 +311,7 @@
 /atom/movable/proc/experience_pressure_difference(pressure_difference, direction)
 	if(last_forced_movement >= SSair.times_fired)
 		return 0
-	else if((!anchored || move_resist == INFINITY) && !pulledby)
+	else if((!anchored || move_resist != INFINITY) && !pulledby)
 		var/turf/target = get_turf(src)
 		var/datum/gas_mixture/target_air = target.return_air()
 		if(isspaceturf(target) || isunsimulatedturf(target) || pressure_resistance > target_air.return_pressure())

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1494,9 +1494,6 @@ var/mob/dview/dview_mob = new
 	canmove = FALSE
 	see_in_dark = 1e6
 
-/mob/dview/experience_pressure_difference()
-	return 0
-
 /mob/dview/New() //For whatever reason, if this isn't called, then BYOND will throw a type mismatch runtime when attempting to add this to the mobs list. -Fox
 
 /mob/dview/Destroy()

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1491,7 +1491,7 @@ var/mob/dview/dview_mob = new
 	pull_force = 0
 	move_resist = INFINITY
 	simulated = 0
-
+	canmove = FALSE
 	see_in_dark = 1e6
 
 /mob/dview/New() //For whatever reason, if this isn't called, then BYOND will throw a type mismatch runtime when attempting to add this to the mobs list. -Fox

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1487,7 +1487,8 @@ var/mob/dview/dview_mob = new
 /mob/dview
 	invisibility = 101
 	density = 0
-
+	move_force = 0
+	pull_force = 0
 	move_resist = INFINITY
 	simulated = 0
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1494,6 +1494,9 @@ var/mob/dview/dview_mob = new
 	canmove = FALSE
 	see_in_dark = 1e6
 
+/mob/dview/experience_pressure_difference()
+	return 0
+
 /mob/dview/New() //For whatever reason, if this isn't called, then BYOND will throw a type mismatch runtime when attempting to add this to the mobs list. -Fox
 
 /mob/dview/Destroy()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -235,9 +235,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	..()
 
-/mob/dead/observer/experience_pressure_difference()
-	return 0
-
 /mob/dead/observer/can_use_hands()	return 0
 
 /mob/dead/observer/Stat()


### PR DESCRIPTION
**What does this PR do:**
Should make dview not bump into alive people anymore. I've not fully tested this since I don't know when it is caused.
It is tested to see if everything works as it worked before.

should fix: #11056

**Changelog:**
:cl:
fix: The invisible bumping into something should be fixed now
/:cl:

