### PR TITLE
Refactored pickup code and fixed the bomb guardian bug

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -26,7 +26,7 @@
 	..()
 
 /obj/item/melee/cultblade/pickup(mob/living/user)
-	..()
+	. = ..()
 	if(!iscultist(user))
 		to_chat(user, "<span class='cultlarge'>\"I wouldn't advise that.\"</span>")
 		to_chat(user, "<span class='warning'>An overwhelming sense of nausea overpowers you!</span>")
@@ -34,7 +34,7 @@
 
 	if(HULK in user.mutations)
 		to_chat(user, "<span class='danger'>You can't seem to hold the blade properly!</span>")
-		user.unEquip(src, 1)
+		return FALSE
 
 /obj/item/melee/cultblade/dagger
 	name = "sacrificial dagger"

--- a/code/game/gamemodes/miniantags/guardian/types/bomb.dm
+++ b/code/game/gamemodes/miniantags/guardian/types/bomb.dm
@@ -72,6 +72,7 @@
 
 /obj/item/guardian_bomb/pickup(mob/living/user)
 	detonate(user)
+	return FALSE // Disarm or blow up. No picking up
 
 /obj/item/guardian_bomb/examine(mob/user)
 	stored_obj.examine(user)

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -39,7 +39,7 @@
 	optional = TRUE
 
 /obj/item/soulstone/pickup(mob/living/user)
-	..()
+	. = ..()
 	if(!can_use(user))
 		to_chat(user, "<span class='danger'>An overwhelming feeling of dread comes over you as you pick up the soulstone. It would be wise to be rid of this quickly.</span>")
 		user.Dizzy(120)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -255,11 +255,10 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	else
 		if(isliving(loc))
 			return 0
-
-	pickup(user)
-
 	add_fingerprint(user)
-	user.put_in_active_hand(src)
+	if(pickup(user)) // Pickup succeeded
+		user.put_in_active_hand(src)
+	
 	return 1
 
 /obj/item/attack_alien(mob/user as mob)
@@ -355,6 +354,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
 	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
+	return TRUE
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
 /obj/item/proc/on_exit_storage(obj/item/storage/S as obj)

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -47,4 +47,4 @@
 			H.reagents.add_reagent(poison_type, poison_dose)
 			poison_total -= poison_dose
 			add_attack_logs(src, user, "Picked up [src], the trapped syndicate documents")
-	..()
+	return ..()

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -235,7 +235,7 @@
 		nadeassembly.process_movement()
 
 /obj/item/grenade/chem_grenade/pickup()
-	..()
+	. = ..()
 	if(nadeassembly)
 		nadeassembly.process_movement()
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -800,6 +800,7 @@
 	return (BRUTELOSS)
 
 /obj/item/twohanded/pitchfork/demonic/pickup(mob/user)
+	. = ..()
 	if(istype(user, /mob/living))
 		var/mob/living/U = user
 		if(U.mind && !U.mind.devilinfo && (U.mind.soulOwner == U.mind)) //Burn hands unless they are a devil or have sold their soul

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -121,7 +121,7 @@
 	return
 
 /obj/item/assembly_holder/pickup()
-	..()
+	. = ..()
 	process_movement()
 
 /obj/item/assembly_holder/Bump()

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -478,4 +478,5 @@
 		update_icon()
 
 /obj/item/cardhand/pickup(mob/user as mob)
+	. = ..()
 	update_icon()

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -199,7 +199,7 @@
 		qdel(src)
 
 /obj/item/grown/novaflower/pickup(mob/living/carbon/human/user)
-	..()
+	. = ..()
 	if(!user.gloves)
 		to_chat(user, "<span class='danger'>The [name] burns your bare hand!</span>")
 		user.adjustFireLoss(rand(1, 5))

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -50,17 +50,17 @@
 /obj/item/grown/nettle/pickup(mob/living/user)
 	..()
 	if(!ishuman(user))
-		return 0
+		return TRUE
 	var/mob/living/carbon/human/H = user
 	if(H.gloves)
-		return 0
+		return TRUE
 	var/organ = ((H.hand ? "l_":"r_") + "arm")
 	var/obj/item/organ/external/affecting = H.get_organ(organ)
 	if(affecting)
 		if(affecting.receive_damage(0, force))
 			H.UpdateDamageIcon()
 	to_chat(H, "<span class='userdanger'>The nettle burns your bare hand!</span>")
-	return 1
+	return TRUE
 
 
 
@@ -95,8 +95,9 @@
 	force = round((5 + seed.potency / 2.5), 1)
 
 /obj/item/grown/nettle/death/pickup(mob/living/carbon/user)
-	if(..())
-		if(prob(50))
+	if(..() && ishuman(user)) // If the pickup succeeded and is humanoid
+		var/mob/living/carbon/human/H = user
+		if(!H.gloves && prob(50))
 			user.Paralyse(5)
 			to_chat(user, "<span class='userdanger'>You are stunned by the Deathnettle when you try picking it up!</span>")
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -157,6 +157,7 @@ old_ue: Set this to a UE string, and this proc will overwrite the dna of organs 
 	var/list/all_bits = internal_organs|bodyparts
 	for(var/obj/item/organ/O in all_bits)
 		if(assimilate || O.dna.unique_enzymes == ue_to_compare)
+			message_admins("organ: [O.name]")
 			O.set_dna(dna)
 
 /*

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -711,7 +711,7 @@
 			H.reagents.add_reagent(contact_poison, contact_poison_volume)
 			contact_poison = null
 			add_attack_logs(src, user, "Picked up [src], the paper poisoned by [contact_poison_poisoner]")
-	..()
+	. = ..()
 
 /obj/item/paper/researchnotes
 	name = "paper - 'Research Notes'"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -311,7 +311,7 @@ obj/item/gun/proc/newshot()
 		visible_message("<span class='danger'>[src]'s light fades and turns off.</span>")
 
 /obj/item/gun/pickup(mob/user)
-	..()
+	. = ..()
 	if(azoom)
 		azoom.Grant(user)
 

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -24,7 +24,7 @@
 	update_icon()
 
 /obj/item/reagent_containers/iv_bag/pickup(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/reagent_containers/iv_bag/dropped(mob/user)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -31,7 +31,7 @@
 	update_icon()
 
 /obj/item/reagent_containers/syringe/pickup(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/reagent_containers/syringe/dropped(mob/user)
@@ -197,7 +197,7 @@
 	update_icon()
 
 /obj/item/reagent_containers/ld50_syringe/pickup(mob/user)
-	..()
+	. = ..()
 	update_icon()
 
 /obj/item/reagent_containers/ld50_syringe/dropped(mob/user)


### PR DESCRIPTION
**What does this PR do:**
Fixes the guardian bomb pickup bug where you pick up the bomb. And refactored the pickup code so when pickup returns false it actually won't pick the item up. No more unequiping in the pickup proc.

#fixes: #11067 

**Changelog:**
:cl:
fix: When disarming a bomb from a guardian you now don't pickup an empty object.
/:cl:

