### PR TITLE
Alphabetical preferences menu

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -48,32 +48,33 @@
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough
 //(in game days played) to play that role
 var/global/list/special_roles = list(
-	ROLE_TRAITOR = /datum/game_mode/traitor,
-	ROLE_OPERATIVE = /datum/game_mode/nuclear,
-	ROLE_CHANGELING = /datum/game_mode/changeling,
-	ROLE_WIZARD = /datum/game_mode/wizard,
-	ROLE_REV = /datum/game_mode/revolution,
-	ROLE_ALIEN,
-	ROLE_PAI,
-	ROLE_CULTIST = /datum/game_mode/cult,
-	ROLE_BLOB = /datum/game_mode/blob,
-	ROLE_NINJA,
-//	ROLE_MONKEY = /datum/game_mode/monkey, Sooner or later these are going to get ported
-//	ROLE_GANG = /datum/game_mode/gang,
-	ROLE_SHADOWLING = /datum/game_mode/shadowling,
-	ROLE_ABDUCTOR = /datum/game_mode/abduction,
+	ROLE_ABDUCTOR = /datum/game_mode/abduction, 		// Abductor
+	ROLE_BLOB = /datum/game_mode/blob, 					// Blob
+	ROLE_CHANGELING = /datum/game_mode/changeling, 		// Changeling
+	ROLE_BORER, 										// Cortical borer
+	ROLE_CULTIST = /datum/game_mode/cult, 				// Cultist
+	ROLE_DEVIL = /datum/game_mode/devil/devil_agents, 	// Devil
+	ROLE_GSPIDER, 										// Giant spider
+	ROLE_GUARDIAN, 										// Guardian
+	ROLE_MORPH, 										// Morph
+	ROLE_OPERATIVE = /datum/game_mode/nuclear, 			// Operative
+	ROLE_PAI, 											// PAI
+	ROLE_POSIBRAIN, 									// Positronic brain
+	ROLE_REVENANT, 										// Revenant
+	ROLE_REV = /datum/game_mode/revolution, 			// Revolutionary
+	ROLE_SENTIENT, 										// Sentient animal
+	ROLE_SHADOWLING = /datum/game_mode/shadowling, 		// Shadowling
+	ROLE_DEMON, 										// Slaguther demon
+	ROLE_NINJA, 										// Space ninja
+	ROLE_TRADER, 										// Trader
+	ROLE_TRAITOR = /datum/game_mode/traitor, 			// Traitor
+	ROLE_VAMPIRE = /datum/game_mode/vampire, 			// Vampire
+	ROLE_RAIDER = /datum/game_mode/heist, 				// Vox raider
+	ROLE_ALIEN, 										// Xenomorph
+	ROLE_WIZARD = /datum/game_mode/wizard, 				// Wizard
+	// UNUSED/BROKEN ANTAGS
 //	ROLE_HOG_GOD = /datum/game_mode/hand_of_god,
 //	ROLE_HOG_CULTIST = /datum/game_mode/hand_of_god,
-	ROLE_RAIDER = /datum/game_mode/heist,
-	ROLE_VAMPIRE = /datum/game_mode/vampire,
-	ROLE_BORER,
-	ROLE_DEMON,
-	ROLE_SENTIENT,
-	ROLE_POSIBRAIN,
-	ROLE_REVENANT,
-	ROLE_GUARDIAN,
-	ROLE_MORPH,
-	ROLE_TRADER,
-	ROLE_GSPIDER,
-	ROLE_DEVIL = /datum/game_mode/devil/devil_agents,
+//	ROLE_MONKEY = /datum/game_mode/monkey, Sooner or later these are going to get ported
+//	ROLE_GANG = /datum/game_mode/gang,
 )

--- a/code/modules/client/preference/preferences.dm
+++ b/code/modules/client/preference/preferences.dm
@@ -435,37 +435,35 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 			dat += "</td></tr></table>"
 
 		if(TAB_GAME) // General Preferences
+			// LEFT SIDE OF THE PAGE
 			dat += "<table><tr><td width='340px' height='300px' valign='top'>"
 			dat += "<h2>General Settings</h2>"
-			dat += "<b>Fancy NanoUI:</b> <a href='?_src_=prefs;preference=nanoui'>[(nanoui_fancy) ? "Yes" : "No"]</a><br>"
-			dat += "<b>Ghost-Item Attack Animation:</b> <a href='?_src_=prefs;preference=ghost_att_anim'>[(show_ghostitem_attack) ? "Yes" : "No"]</a><br>"
-			dat += "<b>Window Flashing:</b> <a href='?_src_=prefs;preference=winflash'>[(windowflashing) ? "Yes" : "No"]</a><br>"
-			dat += "<b>Custom UI settings:</b><br>"
-			dat += " - <b>UI Style:</b> <a href='?_src_=prefs;preference=ui'><b>[UI_style]</b></a><br>"
-			dat += " - <b>Color:</b> <a href='?_src_=prefs;preference=UIcolor'><b>[UI_style_color]</b></a> <table style='display:inline;' bgcolor='[UI_style_color]'<tr><td>__</td></tr></table><br>"
-			dat += " - <b>Alpha (transparency):</b> <a href='?_src_=prefs;preference=UIalpha'><b>[UI_style_alpha]</b></a><br>"
-			dat += "<br>"
-			dat += "<b>Play admin midis:</b> <a href='?_src_=prefs;preference=hear_midis'><b>[(sound & SOUND_MIDI) ? "Yes" : "No"]</b></a><br>"
-			dat += "<b>Play lobby music:</b> <a href='?_src_=prefs;preference=lobby_music'><b>[(sound & SOUND_LOBBY) ? "Yes" : "No"]</b></a><br>"
+			dat += "<b>Attack Animations:</b> <a href='?_src_=prefs;preference=ghost_att_anim'>[(show_ghostitem_attack) ? "Yes" : "No"]</a><br>"
 			if(user.client.holder)
-				dat += "<b>Adminhelp sound:</b> "
-				dat += "<a href='?_src_=prefs;preference=hear_adminhelps'><b>[(sound & SOUND_ADMINHELP)?"On":"Off"]</b></a><br>"
-
-			if(check_rights(R_ADMIN,0))
-				dat += "<b>OOC:</b> <span style='border: 1px solid #161616; background-color: [ooccolor ? ooccolor : normal_ooc_colour];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=ooccolor;task=input'><b>Change</b></a><br>"
-			if(config.allow_Metadata)
-				dat += "<b>OOC notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'><b>Edit</b></a><br>"
+				dat += "<b>Adminhelp sound:</b> <a href='?_src_=prefs;preference=hear_adminhelps'><b>[(sound & SOUND_ADMINHELP)?"On":"Off"]</b></a><br>"
 			if(unlock_content)
 				dat += "<b>BYOND Membership Publicity:</b> <a href='?_src_=prefs;preference=publicity'><b>[(toggles & MEMBER_PUBLIC) ? "Public" : "Hidden"]</b></a><br>"
+			dat += "<b>Custom UI settings:</b><br>"
+			dat += " - <b>Alpha (transparency):</b> <a href='?_src_=prefs;preference=UIalpha'><b>[UI_style_alpha]</b></a><br>"
+			dat += " - <b>Color:</b> <a href='?_src_=prefs;preference=UIcolor'><b>[UI_style_color]</b></a> <span style='border: 1px solid #161616; background-color: [UI_style_color];'>&nbsp;&nbsp;&nbsp;</span><br>"
+			dat += " - <b>UI Style:</b> <a href='?_src_=prefs;preference=ui'><b>[UI_style]</b></a><br>"
+			dat += "<b>Deadchat Anonymity:</b> <a href='?_src_=prefs;preference=ghost_anonsay'><b>[ghost_anonsay ? "Anonymous" : "Not Anonymous"]</b></a><br>"
 			if(user.client.donator_level >= DONATOR_LEVEL_ONE)
 				dat += "<b>Donator Publicity:</b> <a href='?_src_=prefs;preference=donor_public'><b>[(toggles & DONATOR_PUBLIC) ? "Public" : "Hidden"]</b></a><br>"
-
-			dat += "<b>Randomized character slot:</b> <a href='?_src_=prefs;preference=randomslot'><b>[randomslot ? "Yes" : "No"]</b></a><br>"
-			dat += "<b>Ghost ears:</b> <a href='?_src_=prefs;preference=ghost_ears'><b>[(toggles & CHAT_GHOSTEARS) ? "All Speech" : "Nearest Creatures"]</b></a><br>"
-			dat += "<b>Ghost sight:</b> <a href='?_src_=prefs;preference=ghost_sight'><b>[(toggles & CHAT_GHOSTSIGHT) ? "All Emotes" : "Nearest Creatures"]</b></a><br>"
-			dat += "<b>Ghost radio:</b> <a href='?_src_=prefs;preference=ghost_radio'><b>[(toggles & CHAT_GHOSTRADIO) ? "All Chatter" : "Nearest Speakers"]</b></a><br>"
-			dat += "<b>Deadchat anonymity:</b> <a href='?_src_=prefs;preference=ghost_anonsay'><b>[ghost_anonsay ? "Anonymous" : "Not Anonymous"]</b></a><br>"
+			dat += "<b>Fancy NanoUI:</b> <a href='?_src_=prefs;preference=nanoui'>[(nanoui_fancy) ? "Yes" : "No"]</a><br>"
 			dat += "<b>FPS:</b> <a href='?_src_=prefs;preference=clientfps;task=input'>[clientfps]</a><br>"
+			dat += "<b>Ghost Ears:</b> <a href='?_src_=prefs;preference=ghost_ears'><b>[(toggles & CHAT_GHOSTEARS) ? "All Speech" : "Nearest Creatures"]</b></a><br>"
+			dat += "<b>Ghost Sight:</b> <a href='?_src_=prefs;preference=ghost_sight'><b>[(toggles & CHAT_GHOSTSIGHT) ? "All Emotes" : "Nearest Creatures"]</b></a><br>"
+			dat += "<b>Ghost Radio:</b> <a href='?_src_=prefs;preference=ghost_radio'><b>[(toggles & CHAT_GHOSTRADIO) ? "All Chatter" : "Nearest Speakers"]</b></a><br>"
+			if(check_rights(R_ADMIN,0))
+				dat += "<b>OOC Color:</b> <span style='border: 1px solid #161616; background-color: [ooccolor ? ooccolor : normal_ooc_colour];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=ooccolor;task=input'><b>Change</b></a><br>"
+			if(config.allow_Metadata)
+				dat += "<b>OOC Notes:</b> <a href='?_src_=prefs;preference=metadata;task=input'><b>Edit</b></a><br>"
+			dat += "<b>Play Admin MIDIs:</b> <a href='?_src_=prefs;preference=hear_midis'><b>[(sound & SOUND_MIDI) ? "Yes" : "No"]</b></a><br>"
+			dat += "<b>Play Lobby Music:</b> <a href='?_src_=prefs;preference=lobby_music'><b>[(sound & SOUND_LOBBY) ? "Yes" : "No"]</b></a><br>"
+			dat += "<b>Randomized Character Slot:</b> <a href='?_src_=prefs;preference=randomslot'><b>[randomslot ? "Yes" : "No"]</b></a><br>"
+			dat += "<b>Window Flashing:</b> <a href='?_src_=prefs;preference=winflash'>[(windowflashing) ? "Yes" : "No"]</a><br>"
+			// RIGHT SIDE OF THE PAGE
 			dat += "</td><td width='300px' height='300px' valign='top'>"
 			dat += "<h2>Special Role Settings</h2>"
 			if(jobban_isbanned(user, "Syndicate"))
@@ -554,7 +552,7 @@ var/global/list/special_role_times = list( //minimum age (in days) for accounts 
 	dat += "<a href='?_src_=prefs;preference=reset_all'>Reset Setup</a>"
 	dat += "</center>"
 
-	var/datum/browser/popup = new(user, "preferences", "<div align='center'>Character Setup</div>", 820, 640)
+	var/datum/browser/popup = new(user, "preferences", "<div align='center'>Character Setup</div>", 820, 660)
 	popup.set_content(dat)
 	popup.open(0)
 


### PR DESCRIPTION
**What does this PR do:**
Re-orders the preferences menu to be alphabetical. The window is also slightly taller so you dont have to scroll now
Requested as part of Ansari's list
![image](https://user-images.githubusercontent.com/25063394/54550195-7866a300-49a3-11e9-85f8-b1022de03529.png)


**Images of sprite/map changes:**
Before (Taken on live server, so I dont see the admin options):
![image](https://user-images.githubusercontent.com/25063394/54550287-a3e98d80-49a3-11e9-86c0-5588feec4ea7.png)

After:
![image](https://user-images.githubusercontent.com/25063394/54550316-b1067c80-49a3-11e9-864c-c81535157d6f.png)
*Some things are also reworded slightly to make more sense*
**Changelog:**
:cl:
tweak: Preferences are now in alphabetical order
/:cl:

