### PR TITLE
Removes MMI from uplink surgery kit - makes it a separate purchase for Roboticists

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -352,6 +352,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	job = list("Research Director")
 
 //Roboticist
+/datum/uplink_item/jobspecific/syndiemmi
 	name = "Syndicate MMI"
 	desc = "A syndicate developed man-machine-interface which will make any cyborg it is inserted into follow the standard syndicate lawset."
 	reference = "SMMI"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -351,6 +351,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 12
 	job = list("Research Director")
 
+//Roboticist
+	name = "Syndicate MMI"
+	desc = "A syndicate developed man-machine-interface which will make any cyborg it is inserted into follow the standard syndicate lawset."
+	reference = "SMMI"
+	item = /obj/item/mmi/syndie
+	cost = 2
+	job = list("Roboticist")
+	surplus = 0
+
 //Librarian
 /datum/uplink_item/jobspecific/etwenty
 	name = "The E20"
@@ -1160,10 +1169,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/surgerybag
 	name = "Syndicate Surgery Duffelbag"
-	desc = "The Syndicate surgery duffelbag is a toolkit containing all surgery tools, a straitjacket, and a muzzle."
+	desc = "The Syndicate surgery duffelbag comes with a full set of surgery tools, a straightjacket and a muzzle. The bag itself is also made of very light materials and won't slow you down while it is equipped."
 	reference = "SSDB"
 	item = /obj/item/storage/backpack/duffel/syndie/surgery
-	cost = 4
+	cost = 2
 
 /datum/uplink_item/device_tools/bonerepair
 	name = "Prototype Bone Repair Kit"

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -367,7 +367,6 @@
 	new /obj/item/FixOVein(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
-	new /obj/item/mmi/syndie(src)
 
 /obj/item/storage/backpack/duffel/syndie/surgery_fake //for maint spawns
 	name = "surgery duffelbag"


### PR DESCRIPTION
**What does this PR do:**
The Syndie surgery kit does not seem to be bought very much by traitors due to it fulfilling two roles which aren't always going to be carried out by a single traitor at rather expensive price. People who just want it for either the bag or the tools get a very illegal MMI they either don't want to or cannot figure out how to use and those who can use it, namely Roboticists, already have access to a surgery kit and likely have no need for most of the other items in the bag.

This PR splits the two items up and lowers the price of each one. The surgery kit no longer comes with an MMI but has been reduced to 2TC making it a better purchase for traitors who need it for an objective or a gimmick they want to run and the MMI is now a job specific item for Roboticists priced at 2TC to make it somewhat worth getting over an emag.

**Changelog:**
:cl:
add: Added Syndicate MMI for Roboticist Traitors, priced at 2TC.
balance: Removed Syndicate MMI from the traitor surgery duffelbag. Price reduced to 2TC.
/:cl:

