### PR TITLE
Buffs pickpocket gloves

### DIFF
--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -8787,7 +8787,7 @@
 /area/admin)
 "vc" = (
 /obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow/thief{
+/obj/item/clothing/gloves/color/yellow/fake/thief{
 	pixel_x = -3;
 	pixel_y = 3
 	},

--- a/_maps/map_files/cyberiad/z2.dmm
+++ b/_maps/map_files/cyberiad/z2.dmm
@@ -8787,7 +8787,7 @@
 /area/admin)
 "vc" = (
 /obj/structure/rack,
-/obj/item/clothing/gloves/color/black/thief{
+/obj/item/clothing/gloves/color/yellow/thief{
 	pixel_x = -3;
 	pixel_y = 3
 	},

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -294,11 +294,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //Assistant
 
 /datum/uplink_item/jobspecific/pickpocketgloves
-	name = "Pickpocket's Gloves"
-	desc = "A pair of sleek gloves to aid in pickpocketing. While wearing these, you can loot your target without them knowing. Pickpocketing puts the item directly into your hand."
+	name = "Pickpocket's Insulated Gloves"
+	desc = "A pair of sleek insulated gloves to aid in pickpocketing. While wearing these, you can loot your target without them knowing. Pickpocketing puts the item directly into your hand."
 	reference = "PG"
-	item = /obj/item/clothing/gloves/color/black/thief
-	cost = 6
+	item = /obj/item/clothing/gloves/color/yellow/thief
+	cost = 3
 	job = list("Civilian")
 
 //Bartender

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -294,10 +294,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //Assistant
 
 /datum/uplink_item/jobspecific/pickpocketgloves
-	name = "Pickpocket's Insulated Gloves"
-	desc = "A pair of sleek insulated gloves to aid in pickpocketing. While wearing these, you can loot your target without them knowing. Pickpocketing puts the item directly into your hand."
+	name = "Pickpocket's Gloves"
+	desc = "A pair of sleek yellow gloves to aid in pickpocketing. While wearing these, you can loot your target without them knowing. Pickpocketing puts the item directly into your hand. These gloves will NOT protect from electric shock."
 	reference = "PG"
-	item = /obj/item/clothing/gloves/color/yellow/thief
+	item = /obj/item/clothing/gloves/color/yellow/fake/thief
 	cost = 3
 	job = list("Civilian")
 

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -141,8 +141,7 @@
 					G.icon_state = new_glove_icon_state
 					G.item_color = wash_color
 					G.name = new_glove_name
-					if(!istype(G, /obj/item/clothing/gloves/color/black/thief))
-						G.desc = new_desc
+					G.desc = new_desc
 			if(new_shoe_icon_state && new_shoe_name)
 				for(var/obj/item/clothing/shoes/S in contents)
 					if(S.chained == 1)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -17,7 +17,7 @@
 			if("thief")	// 27TC
 				new /obj/item/gun/energy/kinetic_accelerator/crossbow(src)
 				new /obj/item/chameleon(src)
-				new /obj/item/clothing/gloves/color/yellow/thief(src)
+				new /obj/item/clothing/gloves/color/yellow/fake/thief(src)
 				new /obj/item/card/id/syndicate(src)
 				new /obj/item/clothing/shoes/syndigaloshes(src)
 				new /obj/item/storage/box/syndie_kit/safecracking(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -14,10 +14,10 @@
 				new /obj/item/camera_bug(src)
 				return
 
-			if("thief")	// 30TC
+			if("thief")	// 27TC
 				new /obj/item/gun/energy/kinetic_accelerator/crossbow(src)
 				new /obj/item/chameleon(src)
-				new /obj/item/clothing/gloves/color/black/thief(src)
+				new /obj/item/clothing/gloves/color/yellow/thief(src)
 				new /obj/item/card/id/syndicate(src)
 				new /obj/item/clothing/shoes/syndigaloshes(src)
 				new /obj/item/storage/box/syndie_kit/safecracking(src)

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -38,6 +38,9 @@
 	desc = "These gloves will protect the wearer from electric shock. They don't feel like rubber..."
 	siemens_coefficient = 1
 
+/obj/item/clothing/gloves/color/yellow/thief
+	pickpocket = 1
+
 /obj/item/clothing/gloves/color/fyellow                             //Cheap Chinese Crap
 	desc = "These gloves are cheap copies of the coveted gloves, no way this can end badly."
 	name = "budget insulated gloves"
@@ -79,9 +82,6 @@
 
 /obj/item/clothing/gloves/color/black/ce
 	item_color = "chief"			//Exists for washing machines. Is not different from black gloves in any way.
-
-/obj/item/clothing/gloves/color/black/thief
-	pickpocket = 1
 
 /obj/item/clothing/gloves/color/black/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/wirecutters))

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -38,7 +38,7 @@
 	desc = "These gloves will protect the wearer from electric shock. They don't feel like rubber..."
 	siemens_coefficient = 1
 
-/obj/item/clothing/gloves/color/yellow/thief
+/obj/item/clothing/gloves/color/yellow/fake/thief
 	pickpocket = 1
 
 /obj/item/clothing/gloves/color/fyellow                             //Cheap Chinese Crap


### PR DESCRIPTION
This PR buffs pickpocket gloves by reducing their TC cost to 3 and making them look like yellow insulated gloves (actual insulation not included)

6 tc seems way too high for an item that is 1. Job specific 2. Kind of gimmicky so I reduced the cost to 3. Could be 4 or 5 gimme your feedback.

The typical tider will be wearing insulated gloves so making them look like it seems appropriate. It will also be hilarious when people shock themselves because they dont read the description carefully. (Both the uplink description and the item description mentions the lack of insulation.)

🆑
balance: Reduced cost of pickpocket gloves to 3 TC from 6
tweak; Pickpocket gloves now look like yellow insulated gloves. Actual insulation not included.
/🆑