### PR TITLE
Fixes blobbernaut exploit

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -24,13 +24,6 @@
 	return
 
 
-/mob/living/simple_animal/hostile/blob/AttackingTarget()
-	if(ckey)
-		if(istype(target, /obj/structure/blob))
-			return FALSE
-	return ..()
-
-
 ////////////////
 // BLOB SPORE //
 ////////////////

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -13,6 +13,7 @@
 	maxbodytemp = 360
 	universal_speak = 1 //So mobs can understand them when a blob uses Blob Broadcast
 	sentience_type = SENTIENCE_OTHER
+	gold_core_spawnable = CHEM_MOB_SPAWN_INVALID
 	var/mob/camera/blob/overmind = null
 
 /mob/living/simple_animal/hostile/blob/proc/adjustcolors(var/a_color)

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -12,6 +12,7 @@
 	minbodytemp = 0
 	maxbodytemp = 360
 	universal_speak = 1 //So mobs can understand them when a blob uses Blob Broadcast
+	sentience_type = SENTIENCE_OTHER
 	var/mob/camera/blob/overmind = null
 
 /mob/living/simple_animal/hostile/blob/proc/adjustcolors(var/a_color)
@@ -20,6 +21,14 @@
 
 /mob/living/simple_animal/hostile/blob/blob_act()
 	return
+
+
+/mob/living/simple_animal/hostile/blob/AttackingTarget()
+	if(ckey)
+		if(istype(target, /obj/structure/blob))
+			return FALSE
+	return ..()
+
 
 ////////////////
 // BLOB SPORE //

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -34,9 +34,6 @@
 	if(height==0)
 		return 1
 	if(istype(mover) && mover.checkpass(PASSBLOB))
-		var/mob/living/L = mover
-		if(istype(L) && L.ckey)
-			return 0
 		return 1
 	return 0
 

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -31,8 +31,13 @@
 
 
 /obj/structure/blob/CanPass(atom/movable/mover, turf/target, height=0)
-	if(height==0)	return 1
-	if(istype(mover) && mover.checkpass(PASSBLOB))	return 1
+	if(height==0)
+		return 1
+	if(istype(mover) && mover.checkpass(PASSBLOB))
+		var/mob/living/L = mover
+		if(istype(L) && L.ckey)
+			return 0
+		return 1
 	return 0
 
 /obj/structure/blob/CanAStarPass(ID, dir, caller)


### PR DESCRIPTION
:cl: Kyep
tweak: Blob mobs can no longer be spawned in xenobio.
tweak: Blob mobs spawned by blob cores can no longer have sentience potions used on them, which would allow whoever controls them to kill the blob with no countermeasure.
/:cl:

Fixes #11079 
