### PR TITLE
Syndie Uplink changes (better interface, hijack-only firegrenades)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -912,6 +912,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/radio/beacon/syndicate/bomb
 	hijack_only = TRUE
 	cost = 10
+	surplus = 0
+	cant_discount = TRUE
 
 /datum/uplink_item/explosives/syndicate_minibomb
 	name = "Syndicate Minibomb"
@@ -976,6 +978,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	hijack_only = TRUE
 	cost = 12
 	surplus = 0
+	cant_discount = TRUE
 
 /datum/uplink_item/explosives/emp
 	name = "EMP Grenades and Implanter Kit"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 	if(hijack_only)
 		if(!(locate(/datum/objective/hijack) in usr.mind.objectives))
-			to_chat(usr, "<span class='warning'>The Syndicate lacks resources to provide you with this item.</span>")
+			to_chat(usr, "<span class='warning'>The Syndicate will only issue this extremely dangerous item to agents assigned the Hijack objective.</span>")
 			return
 
 	if(item)
@@ -910,7 +910,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	reference = "SB"
 	item = /obj/item/radio/beacon/syndicate/bomb
-	cost = 11
+	hijack_only = TRUE
+	cost = 10
 
 /datum/uplink_item/explosives/syndicate_minibomb
 	name = "Syndicate Minibomb"
@@ -960,12 +961,20 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
-/datum/uplink_item/explosives/atmosgrenades
-	name = "Atmos Grenades"
-	desc = "A box of two (2) grenades that wreak havoc with the atmosphere of the target area. Capable of engulfing a large area in lit plasma, or N2O. Deploy with extreme caution!"
-	reference = "AGG"
-	item = /obj/item/storage/box/syndie_kit/atmosgasgrenades
-	cost = 11
+/datum/uplink_item/explosives/atmosn2ogrenades
+	name = "Knockout Gas Grenades"
+	desc = "A box of two (2) grenades that spread knockout gas over a large area. Equip internals before using one of these."
+	reference = "ANG"
+	item = /obj/item/storage/box/syndie_kit/atmosn2ogrenades
+	cost = 8
+
+/datum/uplink_item/explosives/atmosfiregrenades
+	name = "Plasma Fire Grenades"
+	desc = "A box of two (2) grenades that cause large plasma fires. Can be used to deny access to a large area. Most useful if you have an atmospherics hardsuit."
+	reference = "APG"
+	item = /obj/item/storage/box/syndie_kit/atmosfiregrenades
+	hijack_only = TRUE
+	cost = 12
 	surplus = 0
 
 /datum/uplink_item/explosives/emp

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -910,7 +910,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	reference = "SB"
 	item = /obj/item/radio/beacon/syndicate/bomb
-	cost = 10
+	cost = 11
 	surplus = 0
 	cant_discount = TRUE
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -910,7 +910,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	You can wrench the bomb down to prevent removal. The crew may attempt to defuse the bomb."
 	reference = "SB"
 	item = /obj/item/radio/beacon/syndicate/bomb
-	hijack_only = TRUE
 	cost = 10
 	surplus = 0
 	cant_discount = TRUE

--- a/code/game/objects/effects/spawners/random_spawners.dm
+++ b/code/game/objects/effects/spawners/random_spawners.dm
@@ -279,7 +279,7 @@
 		/obj/item/clothing/glasses/thermal = 1,
 		/obj/item/chameleon = 1,
 		/obj/item/reagent_containers/hypospray/autoinjector/stimulants = 1,
-		/obj/item/storage/box/syndie_kit/atmosgasgrenades = 1,
+		/obj/item/storage/box/syndie_kit/atmosn2ogrenades = 1,
 		/obj/item/grenade/plastic/x4 = 1)
 
 

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -72,7 +72,10 @@ var/list/world_uplinks = list()
 			if(I.job && I.job.len)
 				if(!(I.job.Find(job)))
 					continue
-			dat += "<A href='byond://?src=[UID()];buy_item=[I.reference];cost=[I.cost]'>[I.name]</A> ([I.cost])<BR>"
+			dat += "<A href='byond://?src=[UID()];buy_item=[I.reference];cost=[I.cost]'>[I.name]</A> ([I.cost])"
+			if(I.hijack_only)
+				dat += " (HIJACK ONLY)"
+			dat += " <BR>"
 			category_items++
 
 	dat += "<A href='byond://?src=[UID()];buy_item=random'>Random Item (??)</A><br>"
@@ -95,7 +98,7 @@ var/list/world_uplinks = list()
 			if(I.job && I.job.len)
 				if(!(I.job.Find(job)))
 					continue
-			nano[nano.len]["items"] += list(list("Name" = sanitize(I.name), "Description" = sanitize(I.description()),"Cost" = I.cost, "obj_path" = I.reference))
+			nano[nano.len]["items"] += list(list("Name" = sanitize(I.name), "Description" = sanitize(I.description()),"Cost" = I.cost, "hijack_only" = I.hijack_only, "obj_path" = I.reference))
 			reference[I.reference] = I
 
 	var/datum/nano_item_lists/result = new

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -262,13 +262,24 @@
 	new /obj/item/spellbook/oneuse/mime/greaterwall(src)
 	new	/obj/item/spellbook/oneuse/mime/fingergun(src)
 
-/obj/item/storage/box/syndie_kit/atmosgasgrenades
-	name = "Atmos Grenades"
 
-/obj/item/storage/box/syndie_kit/atmosgasgrenades/New()
+/obj/item/storage/box/syndie_kit/atmosn2ogrenades
+	name = "Atmos N2O Grenades"
+
+/obj/item/storage/box/syndie_kit/atmosn2ogrenades/New()
+	..()
+	new /obj/item/grenade/clusterbuster/n2o(src)
+	new /obj/item/grenade/clusterbuster/n2o(src)
+
+
+/obj/item/storage/box/syndie_kit/atmosfiregrenades
+	name = "Plasma Fire Grenades"
+
+/obj/item/storage/box/syndie_kit/atmosfiregrenades/New()
 	..()
 	new /obj/item/grenade/clusterbuster/plasma(src)
-	new /obj/item/grenade/clusterbuster/n2o(src)
+	new /obj/item/grenade/clusterbuster/plasma(src)
+
 
 /obj/item/storage/box/syndie_kit/missionary_set
 	name = "Missionary Starter Kit"

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -46,7 +46,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 					{{for value.items :itemValue:itemIndex}}
 						<tr>
 						<td><div class='floatLeft tooltipRight' data-tooltip='{{:tooltiptext(itemValue.Description)}}'>
-						{{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, null)}} - <span class="white">{{:itemValue.Cost}}</span>
+						{{:helper.link( itemValue.Name, 'gear', {'buy_item' : itemValue.obj_path, 'cost' : itemValue.Cost}, itemValue.Cost > data.crystals ? 'disabled' : null, null)}} - <span class="white">{{:itemValue.Cost}}</span> {{if itemValue.hijack_only}}(HIJACK AGENTS ONLY){{/if}}
 						</div></td>
 						</tr>
 					{{/for}}


### PR DESCRIPTION
:cl: Kyep
tweak: Improved the interface for Syndicate Uplinks. They now clearly mark which items are hijack-only and which are not. If you attempt to purchase a hijack-only item without hijack,  they will explain why you can't.
tweak: Atmos Gas Grenades (the uplink grenade kit) are now split into Knockout grenades (2 N2O grenades, 8 TC, available to all agents), and Plasma Fire grenades (2 plasma fire grenades, 12 TC, only available if you have hijack). This both makes knockout grenades more useful for normal traitors, and also prevents non-hijackers using a plasma fire grenade to cause massive casualties/damage.
tweak: Plasma Grenades and the Syndicate Bomb can no longer show up in surplus crates, or be discounted. This means while you can buy one if you intend to, you're not randomly encouraged to bomb your target.
/:cl:

![altered_uplink](https://user-images.githubusercontent.com/16434066/54603473-49e8d680-4a3c-11e9-9cb9-7f5825396308.PNG)
Note: screenshot shows syndi bomb as hijack only. That was the case in a prior version of this PR, but it has since been changed to be available for all agents again.

Reasoning:

1. The interface for the uplink was unnecessarily confusing, not identifying hijack-only items in any obvious way, and producing a confusing, unclear message about the syndicate lacking supplies when you failed to buy one.

2. The syndicate bomb and plasma fire grenade are not really useful for non-hijack antags, as they cause such a large amount of damage that realistically only hijackers can use them without probably getting bwoinked. We (admins) see them used most often outside a job's room to try to kill someone in that job. This almost never works, usually causes very excessive damage to the station, and often ends with the antag being bwoinked, and possibly job banned from syndicate. Instead of having new traitors make this mistake and get punished, its better to just disallow them from buying these items without hijack, and steer them towards more appropriate purchases.
