### PR TITLE
Remove chat message telling user to check My Tickets

### DIFF
--- a/code/controllers/subsystem/tickets.dm
+++ b/code/controllers/subsystem/tickets.dm
@@ -72,7 +72,6 @@ SUBSYSTEM_DEF(tickets)
 	var/datum/admin_ticket/existingTicket = checkForOpenTicket(C)
 	if(existingTicket)
 		existingTicket.setCooldownPeriod()
-		to_chat(C.mob, "<span class='adminticket'>Your ticket #[existingTicket.ticketNum] remains open! Visit \"My tickets\" under the Admin Tab to view it.</span>")
 		return
 
 	if(!title)


### PR DESCRIPTION
Fixes #10976

Removed the chat message telling you to go check tickets when users cant

🆑
del: Removed message telling you to go check your tickets on a 2nd ahelp when you cant as a user
/🆑