### PR TITLE
Fixes Krav Maga Disarms

### DIFF
--- a/code/modules/martial_arts/krav_maga.dm
+++ b/code/modules/martial_arts/krav_maga.dm
@@ -132,13 +132,13 @@ datum/martial_art/krav_maga/grab_act(var/mob/living/carbon/human/A, var/mob/livi
 		if(D.hand)
 			if(istype(D.l_hand, /obj/item))
 				var/obj/item/I = D.l_hand
-				D.drop_item()
-				A.put_in_hands(I)
+				if(D.drop_item())
+					A.put_in_hands(I)
 		else
 			if(istype(D.r_hand, /obj/item))
 				var/obj/item/I = D.r_hand
-				D.drop_item()
-				A.put_in_hands(I)
+				if(D.drop_item())
+					A.put_in_hands(I)
 		D.visible_message("<span class='danger'>[A] has disarmed [D]!</span>", \
 							"<span class='userdanger'>[A] has disarmed [D]!</span>")
 		playsound(D, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)


### PR DESCRIPTION
Fixes #11084
Fixes #11005

Forgive the use of the web editor, not at home to make the changes properly.

:cl:
fix: Krav Maga gloves can no longer steal the unstealable.
/:cl:

