### PR TITLE
Fixes "Do you want to play as ?"

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -715,10 +715,7 @@
 		log_admin("[key_name(usr)] has offered control of ([key_name(M)]) to ghosts.")
 		var/minhours = input(usr, "Minimum hours required to play [M]?", "Set Min Hrs", 10) as num
 		message_admins("[key_name_admin(usr)] has offered control of ([key_name_admin(M)]) to ghosts with [minhours] hrs playtime")
-		var/mname = M.name
-		if(M.real_name)
-			mname = M.real_name
-		var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [mname]?", poll_time = 100, min_hours = minhours)
+		var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name ? M.real_name : M.name]?", poll_time = 100, min_hours = minhours)
 		var/mob/dead/observer/theghost = null
 
 		if(candidates.len)

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -715,7 +715,10 @@
 		log_admin("[key_name(usr)] has offered control of ([key_name(M)]) to ghosts.")
 		var/minhours = input(usr, "Minimum hours required to play [M]?", "Set Min Hrs", 10) as num
 		message_admins("[key_name_admin(usr)] has offered control of ([key_name_admin(M)]) to ghosts with [minhours] hrs playtime")
-		var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [M.real_name]?", poll_time = 100, min_hours = minhours)
+		var/mname = M.name
+		if(M.real_name)
+			mname = M.real_name
+		var/list/mob/dead/observer/candidates = pollCandidates("Do you want to play as [mname]?", poll_time = 100, min_hours = minhours)
 		var/mob/dead/observer/theghost = null
 
 		if(candidates.len)


### PR DESCRIPTION
:cl: Kyep
fix: Admins offering control of a mob with no real_name to ghosts will no longer cause a "Do you want to play as ?" popup. Instead, the ? will be replaced with a descriptive string, such as "the blobbernaut".
/:cl:

