### PR TITLE
Players who enable AntagHUD are now unable to join the round as swarmers + Adds a message for Antag-banned player trying to play as borer

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -129,6 +129,7 @@
 		to_chat(user, "<span class='boldnotice'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
 		return
 	if(jobban_isbanned(user, "Syndicate"))
+		to_chat(user, "<span class='warning'>You are banned from antagonists!</span>")
 		return
 	if(key)
 		return

--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -36,17 +36,22 @@
 		to_chat(user, "<span class='warning'>This swarmer shell is completely depowered. You cannot activate it.</span>")
 		return
 
-	var/be_swarmer = alert("Become a swarmer? (Warning, You can no longer be cloned!)",,"Yes","No")
-	if(be_swarmer == "No")
-		return
-
 	if(jobban_isbanned(user, "Syndicate"))
 		to_chat(user, "<span class='warning'>You are banned from antagonists!</span>")
+		return
+
+	if(cannotPossess(user))
+		to_chat(user, "<span class='boldnotice'>Upon using the antagHUD you forfeited the ability to join the round.</span>")
+		return
+
+	var/be_swarmer = alert("Become a swarmer? (Warning, You can no longer be cloned!)",,"Yes","No")
+	if(be_swarmer == "No")
 		return
 
 	if(crit_fail)//in case it depowers while ghost is looking at yes/no
 		to_chat(user, "<span class='warning'>This swarmer shell is completely depowered. You cannot activate it.</span>")
 		return
+
 	if(QDELETED(src))
 		to_chat(user, "Swarmer has been occupied by someone else.")
 		return


### PR DESCRIPTION
**What does this PR do:**
Players who enable AntagHUD (while AntagHUD respawnability restrictions are active, of course) are now unable to join the round as swarmers, staying consistent with similiar midround antagonists, like cortical borers or terror spiders. 

Also adds a message explaining why Antag-banned players cannot join the round as cortical borer when trying to possess one, previously they did not get any message or explanation whatsover, again for consistency with similiar antagonists.

Tested locally without any issue found.

**Changelog:**
:cl: Arkatos
fix: Players who enable AntagHUD are now unable to join the round as swarmers
add: Adds a message explaining why Antag-banned players cannot join the round as cortical borer
/:cl: