### PR TITLE
Hatching as a shadowling will reset your HUD.

### DIFF
--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -107,6 +107,8 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/collective_mind(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_regenarmor(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle(null))
+				H.hud_used = new /datum/hud/human(H, ui_style2icon(H.client.prefs.UI_style), H.client.prefs.UI_style_color, H.client.prefs.UI_style_alpha)
+				H.hud_used.show_hud(H.hud_used.hud_version)
 
 /obj/effect/proc_holder/spell/targeted/shadowling_ascend
 	name = "Ascend"


### PR DESCRIPTION
**What does this PR do:**
Small change that makes it so that if for any reason you use the "Hatch" ability as a shadowling but are also a monkey, your HUD will be changed to be the human one. Does not affect anything else.
(Code was copy and pasted from the Monkey to Human transformation code)

**Changelog:**
:cl: EmanTheAlmighty
tweak: Using the Shadowling ability "Hatch" as a monkey will change your HUD to be the human one.
/:cl:

