### PR TITLE
Terror Spiders can no longer be offered sentience potions.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_spiders.dm
@@ -71,6 +71,9 @@ var/global/list/ts_spiderling_list = list()
 	speak_emote = list("hisses")
 	emote_hear = list("hisses")
 
+	// Sentience Type
+	sentience_type = SENTIENCE_OTHER
+
 	// Languages are handled in terror_spider/New()
 
 	// Interaction keywords


### PR DESCRIPTION
**What does this PR do:**
Gateway mission terror spiders can currently be effortlessly gibbed by giving them a sentience potion and waiting for them to "become sentient", except that when that happens, they explode. Easily abusable, eh? This commit changes this.

**Changelog:**
:cl: EmanTheAlmighty
tweak: Can no longer offer Gateway Terror Spiders sentience potions. ( They literally exploded if you did, and that could have been used to effortlessly clear out hordes of them. )
/:cl: