### PR TITLE
Fixes a few atmos bugs when structures get destroyed/removed

### DIFF
--- a/code/game/machinery/doors/spacepod.dm
+++ b/code/game/machinery/doors/spacepod.dm
@@ -16,9 +16,8 @@
 
 /obj/structure/spacepoddoor/Destroy()
 	var/turf/T = get_turf(src)
-	spawn(0)
-		T.air_update_turf(TRUE)
-	return ..()
+	. = ..()
+	T.air_update_turf(TRUE)
 
 /obj/structure/spacepoddoor/CanPass(atom/movable/A, turf/T)
 	if(istype(A, /obj/spacepod))

--- a/code/game/machinery/doors/spacepod.dm
+++ b/code/game/machinery/doors/spacepod.dm
@@ -15,7 +15,9 @@
 	return 0
 
 /obj/structure/spacepoddoor/Destroy()
-	air_update_turf(1)
+	var/turf/T = get_turf(src)
+	spawn(0)
+		T.air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/spacepoddoor/CanPass(atom/movable/A, turf/T)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -179,9 +179,8 @@
 
 /obj/structure/foamedmetal/Destroy()
 	var/turf/T = get_turf(src)
-	spawn(0)
-		T.air_update_turf(TRUE)
-	return ..()
+	. = ..()
+	T.air_update_turf(TRUE)
 
 /obj/structure/foamedmetal/Move()
 	var/turf/T = loc

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -178,7 +178,9 @@
 	air_update_turf(1)
 
 /obj/structure/foamedmetal/Destroy()
-	air_update_turf(1)
+	var/turf/T = get_turf(src)
+	spawn(0)
+		T.air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/foamedmetal/Move()

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -57,9 +57,8 @@
 
 /obj/structure/alien/resin/Destroy()
 	var/turf/T = get_turf(src)
-	spawn(0)
-		T.air_update_turf(TRUE)
-	return ..()
+	. = ..()
+	T.air_update_turf(TRUE)
 
 /obj/structure/alien/resin/Move()
 	var/turf/T = loc

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -56,7 +56,9 @@
 	..()
 
 /obj/structure/alien/resin/Destroy()
-	air_update_turf(1)
+	var/turf/T = get_turf(src)
+	spawn(0)
+		T.air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/alien/resin/Move()

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -82,7 +82,8 @@
 
 /obj/structure/holosign/barrier/atmos/Destroy()
 	var/turf/T = get_turf(src)
-	T.air_update_turf(TRUE)
+	spawn(0)
+		T.air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/holosign/barrier/cyborg

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -82,9 +82,8 @@
 
 /obj/structure/holosign/barrier/atmos/Destroy()
 	var/turf/T = get_turf(src)
-	spawn(0)
-		T.air_update_turf(TRUE)
-	return ..()
+	. = ..()
+	T.air_update_turf(TRUE)
 
 /obj/structure/holosign/barrier/cyborg
 	name = "Energy Field"

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -125,13 +125,13 @@
 	playsound(loc, 'sound/machines/hiss.ogg', 75, 1)
 	if(violent)
 		visible_message("[src] rapidly deflates!")
-		var/obj/item/inflatable/torn/R = new torn(loc)///obj/item/inflatable/torn(loc)
+		var/obj/item/inflatable/torn/R = new torn(loc)
 		src.transfer_fingerprints_to(R)
 		qdel(src)
 	else
 		visible_message("[src] slowly deflates.")
 		spawn(50)
-			var/obj/item/inflatable/R = new intact(loc)///obj/item/inflatable(loc)
+			var/obj/item/inflatable/R = new intact(loc)
 			src.transfer_fingerprints_to(R)
 			qdel(src)
 

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -27,10 +27,12 @@
 
 /obj/structure/inflatable/Initialize(location)
 	..()
-	air_update_turf(1)
+	air_update_turf(TRUE)
 
 /obj/structure/inflatable/Destroy()
-	air_update_turf(1)
+	var/turf/T = get_turf(src)
+	spawn(0)
+		T.air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -167,6 +167,8 @@
 
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "door_closed"
+	torn = /obj/item/inflatable/door/torn
+	intact = /obj/item/inflatable/door
 
 	var/state = 0 //closed, 1 == open
 	var/isSwitchingStates = 0

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -32,9 +32,8 @@
 
 /obj/structure/inflatable/Destroy()
 	var/turf/T = get_turf(src)
-	spawn(0)
-		T.air_update_turf(TRUE)
-	return ..()
+	. = ..()
+	T.air_update_turf(TRUE)
 
 /obj/structure/inflatable/CanPass(atom/movable/mover, turf/target, height=0)
 	return 0

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -22,7 +22,8 @@
 
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "wall"
-
+	var/torn = /obj/item/inflatable/torn
+	var/intact = /obj/item/inflatable
 	var/health = 50.0
 
 /obj/structure/inflatable/Initialize(location)
@@ -124,13 +125,13 @@
 	playsound(loc, 'sound/machines/hiss.ogg', 75, 1)
 	if(violent)
 		visible_message("[src] rapidly deflates!")
-		var/obj/item/inflatable/torn/R = new /obj/item/inflatable/torn(loc)
+		var/obj/item/inflatable/torn/R = new torn(loc)///obj/item/inflatable/torn(loc)
 		src.transfer_fingerprints_to(R)
 		qdel(src)
 	else
 		visible_message("[src] slowly deflates.")
 		spawn(50)
-			var/obj/item/inflatable/R = new /obj/item/inflatable(loc)
+			var/obj/item/inflatable/R = new intact(loc)///obj/item/inflatable(loc)
 			src.transfer_fingerprints_to(R)
 			qdel(src)
 
@@ -239,21 +240,6 @@
 		icon_state = "door_open"
 	else
 		icon_state = "door_closed"
-
-/obj/structure/inflatable/door/deflate(var/violent=0)
-	playsound(loc, 'sound/machines/hiss.ogg', 75, 1)
-	if(violent)
-		visible_message("[src] rapidly deflates!")
-		var/obj/item/inflatable/door/torn/R = new /obj/item/inflatable/door/torn(loc)
-		src.transfer_fingerprints_to(R)
-		qdel(src)
-	else
-		visible_message("[src] slowly deflates.")
-		spawn(50)
-			var/obj/item/inflatable/door/R = new /obj/item/inflatable/door(loc)
-			src.transfer_fingerprints_to(R)
-			qdel(src)
-	air_update_turf(1)
 
 /obj/item/inflatable/torn
 	name = "torn inflatable wall"

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -125,12 +125,14 @@
 	desc = "Heavy duty, airtight, plastic flaps."
 
 /obj/structure/plasticflaps/mining/Initialize()
-	air_update_turf(1)
+	air_update_turf(TRUE)
 	..()
 
 /obj/structure/plasticflaps/mining/Destroy()
-	air_update_turf(1)
+	var/turf/T = get_turf(src)
+	spawn(0)
+		T.air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/plasticflaps/mining/CanAtmosPass(turf/T)
-	return 0
+	return FALSE

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -130,9 +130,8 @@
 
 /obj/structure/plasticflaps/mining/Destroy()
 	var/turf/T = get_turf(src)
-	spawn(0)
-		T.air_update_turf(TRUE)
-	return ..()
+	. = ..()
+	T.air_update_turf(TRUE)
 
 /obj/structure/plasticflaps/mining/CanAtmosPass(turf/T)
 	return FALSE

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -529,7 +529,9 @@
 
 /obj/structure/fans/Destroy()
 	arbitraryatmosblockingvar = 0
-	air_update_turf(1)
+	var/turf/T = get_turf(src)
+	spawn(0)
+		T.air_update_turf(TRUE)
 	return ..()
 
 /obj/structure/fans/CanAtmosPass(turf/T)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -529,9 +529,7 @@
 
 /obj/structure/fans/Destroy()
 	arbitraryatmosblockingvar = 0
-	var/turf/T = get_turf(src)
-	spawn(0)
-		T.air_update_turf(TRUE)
+	air_update_turf(1)
 	return ..()
 
 /obj/structure/fans/CanAtmosPass(turf/T)


### PR DESCRIPTION
**What does this PR do:**
Fixes the atmos not updating for the following structures:
Atmos holo fans
Inflatable walls/doors
Foamed metal
space pod doors (shouldn't ever happen but)
Alien resin walls
mining plastic flaps

And I refactored the inflatable walls/doors code a bit

fixes: #9036

**Changelog:**
:cl:
fix: Holo firedoors now update atmos correctly after being destroyed
fix: Inflatable walls/doors now update atmos correctly after being destroyed
fix: Alien resin walls now update atmos correctly after being destroyed
fix: Foamed metal walls now update atmos correctly after being destroyed
fix: Pod doors (shouldn't ever happen) now update atmos correctly after being destroyed
fix: Mining flaps now update atmos correctly after being destroyed
/:cl:

