### PR TITLE
Swarmers are now locked to their default action intent and are able to open airlocks and windoors

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -96,10 +96,12 @@
 	attack_sound = 'sound/effects/empulse.ogg'
 	friendly = "pinches"
 	speed = 0
+	a_intent = INTENT_HARM
+	can_change_intents = 0
 	faction = list("swarmer")
 	projectiletype = /obj/item/projectile/beam/disabler
 	pass_flags = PASSTABLE
-	mob_size = MOB_SIZE_TINY
+	mob_size = MOB_SIZE_SMALL
 	ventcrawler = 2
 	ranged = 1
 	light_color = LIGHT_COLOR_CYAN


### PR DESCRIPTION
**What does this PR do:**
This PR contains 2 changes to swarmers:

1) Fixes #11087 - Swarmers are now locked to their default action intent. Previously, swarmers could switch between HELP and HARM action intents, without any UI or other indicator telling them that. This PR locks them to their supposed action intent - HARM intent. Practically, this means two things:
a) They will be unable to help intent switch with other mobs. This does not affect their interaction with other swarmers, as they can walk by each other freely already.
b) Instead of them usually pinching their target in melee range, they will make SHOCK attack on them. SHOCK attack does only stamina damage, stunning the target when certain threshold is reached. For swarmers, its basically a melee alternative to their disabler. They could already do exactly this, but not many players knew this due to lack of any indication of the action intents.

2) Swarmers are now able to open airlocks and windoors (airlock and windoor access restrictions still apply, of course) - Previously, swarmers were considered to be in a same size category as mouse, bee, larva and cortical borer, and were unable to open anything, even though they are several times bigger than any other mob in that category, this PR changes that.

Lastly, I would like to add that both of these changes are already on /tg/station13, probably for similiar reasons that I stated above.

Tested locally without any issue found.

**Changelog:** 
:cl: Arkatos
fix: Fixes #11087 - Swarmers are now locked to their default action intent
tweak: Swarmers are now able to open airlocks and windoors (access restrictions still apply)
/:cl: