### PR TITLE
Adds Shrimp & Fish Skewers and Cheeseburgers.

### DIFF
--- a/code/modules/food_and_drinks/food/foods/seafood.dm
+++ b/code/modules/food_and_drinks/food/foods/seafood.dm
@@ -97,6 +97,24 @@
 	bitesize = 3
 	list_reagents = list("nutriment" = 2)
 
+/obj/item/reagent_containers/food/snacks/shrimp_skewer
+	name = "shrimp skewer"
+	desc = "Four shrimp lightly grilled on a skewer. Yummy!"
+	trash = /obj/item/stack/rods
+	icon = 'icons/obj/food/seafood.dmi'
+	icon_state = "shrimpskewer"
+	bitesize = 3 
+	list_reagents = list("nutriment" = 8)
+
+/obj/item/reagent_containers/food/snacks/fish_skewer
+	name = "fish skewer"
+	desc = "A whole fish battered and grilled on a skewer. Hope you're hungry!"
+	trash = /obj/item/stack/rods
+	icon = 'icons/obj/food/seafood.dmi'
+	icon_state = "fishskewer"
+	bitesize = 3
+	list_reagents = list("protein" = 6, "vitamin" = 4)
+
 /obj/item/reagent_containers/food/snacks/sliceable/Ebi_maki
 	name = "ebi makiroll"
 	desc = "A large unsliced roll of Ebi Sushi."

--- a/code/modules/food_and_drinks/recipes/recipes_grill.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_grill.dm
@@ -226,3 +226,22 @@
 		/obj/item/reagent_containers/food/snacks/catfishmeat,
 	)
 	result = /obj/item/reagent_containers/food/snacks/sushi_Tai
+
+/datum/recipe/grill/shrimp_skewer
+	items = list(
+		/obj/item/reagent_containers/food/snacks/shrimp,
+		/obj/item/reagent_containers/food/snacks/shrimp,
+		/obj/item/reagent_containers/food/snacks/shrimp,
+		/obj/item/reagent_containers/food/snacks/shrimp,
+		/obj/item/stack/rods,
+	)
+	result = /obj/item/reagent_containers/food/snacks/shrimp_skewer
+
+/datum/recipe/grill/fish_skewer
+	reagents = list("flour" = 10)
+	items = list(
+		/obj/item/reagent_containers/food/snacks/salmonmeat,
+		/obj/item/reagent_containers/food/snacks/salmonmeat,
+		/obj/item/stack/rods,
+	)
+	result = /obj/item/reagent_containers/food/snacks/fish_skewer

--- a/code/modules/food_and_drinks/recipes/recipes_microwave.dm
+++ b/code/modules/food_and_drinks/recipes/recipes_microwave.dm
@@ -133,6 +133,13 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/baseballburger
 
+/datum/recipe/microwave/cheeseburger
+	items = list(
+		/obj/item/reagent_containers/food/snacks/monkeyburger,
+		/obj/item/reagent_containers/food/snacks/cheesewedge,
+	)
+	result = /obj/item/reagent_containers/food/snacks/cheeseburger
+
 /datum/recipe/microwave/hotdog
 	items = list(
 		/obj/item/reagent_containers/food/snacks/bun,


### PR DESCRIPTION
**What does this PR do:**
Basically what it says on the tin. Adds in recipes for the three items mentioned in the title that we had sprites for, and in the case of cheeseburgers was coded in, but no actual recipe for them. And well, now we do. No sprites were changed or added, so I didn't include that part of the PR. I do, however, have screenshots of the finished items.

![dreamseeker_Qm20113dPx](https://user-images.githubusercontent.com/12178527/54870746-7e300000-4d78-11e9-88b1-544914ed944c.png)


Recipes as follows:

Shrimp Skewer(Grill): 4 Shrimp + 1 Metal Rod

Fish Skewer(Grill): 2 Salmon Meats + Metal Rod + 10u Flour

Cheese Burger(Microwave): Burger + Cheese Wedge


**Changelog:**
:cl:
add: Adds in Shrimp & Fish Skewers as well as Cheeseburgers. Shrimp Skewer(Grill): 4 Shrimp(uncooked) + 1 Metal Rod, Fish Skewer(Grill): 2 Salmon Meat + Metal Rod + 10u Flour, Cheese Burger(Microwave): Burger + Cheese Wedge. 
/:cl:

