### PR TITLE
Adds in the Culinary Implant

### DIFF
--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -123,6 +123,10 @@
 						"<span class='suicide'>[user] is slitting [user.p_their()] stomach open with the [name]! It looks like [user.p_theyre()] trying to commit seppuku.</span>"))
 	return (BRUTELOSS)
 
+/obj/item/kitchen/knife/augment
+	desc = "A small Chef's Knife, guarunteed to stay sharp slice after slice!"
+	w_class = WEIGHT_CLASS_TINY
+
 /obj/item/kitchen/knife/plastic
 	name = "plastic knife"
 	desc = "The bluntest of blades."
@@ -146,6 +150,10 @@
 	throwforce = 8
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/kitchen/knife/butcher/augment
+	desc = "A smaller Cleaver used for chopping up meat."
+	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/kitchen/knife/butcher/meatcleaver
 	name = "Meat Cleaver"
@@ -198,6 +206,10 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
+
+/obj/item/kitchen/rollingpin/augment
+	desc = "A small rolling pin, useful for knocking out Bartenders."
+	w_class = WEIGHT_CLASS_TINY
 
 /* Trays moved to /obj/item/storage/bag */
 
@@ -270,7 +282,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("rolled", "cracked", "battered", "thrashed")
 
-
+/obj/item/kitchen/sushimat/augment
+	desc = "A small wooden make to make sushi with."
+	w_class = WEIGHT_CLASS_TINY
 
 /// circular cutter by Ume
 
@@ -285,3 +299,7 @@
 	throw_range = 3
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("bashed", "slashed", "pricked", "thrashed")
+
+/obj/item/kitchen/cutter/augment
+	desc = "A small circular cutter to shape cookies and dough."
+	w_class = WEIGHT_CLASS_TINY

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -283,7 +283,7 @@
 	attack_verb = list("rolled", "cracked", "battered", "thrashed")
 
 /obj/item/kitchen/sushimat/augment
-	desc = "A small wooden make to make sushi with."
+	desc = "A small wooden mat to make sushi with."
 	w_class = WEIGHT_CLASS_TINY
 
 /// circular cutter by Ume

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -279,13 +279,13 @@
 
 /obj/item/organ/internal/cyberimp/arm/chef
 	name = "culinary implant"
-	desc = "A set of culinary tools hidden behind a concealed panel on the user's arm"
+	desc = "A set of culinary tools hidden behind a concealed panel on the user's arm."
 	contents = newlist(/obj/item/kitchen/knife/augment, /obj/item/kitchen/rollingpin/augment, /obj/item/kitchen/sushimat/augment, /obj/item/kitchen/cutter/augment)
 	origin_tech = "materials=3;engineering=3;biotech=3;programming=2;magnets=3"
 	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/clothing/hats.dmi')
 	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "chef")
 
-/obj/item/organ/internal/cyberimp/arm/toolset/l
+/obj/item/organ/internal/cyberimp/arm/chef/l
 	parent_organ = "l_arm"
 
 /obj/item/organ/internal/cyberimp/arm/chef/emag_act(mob/user)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -277,6 +277,24 @@
 	parent_organ = "l_arm"
 	slot = "l_arm_device"
 
+/obj/item/organ/internal/cyberimp/arm/chef
+	name = "culinary implant"
+	desc = "A set of culinary tools hidden behind a concealed panel on the user's arm"
+	contents = newlist(/obj/item/kitchen/knife/augment, /obj/item/kitchen/rollingpin/augment, /obj/item/kitchen/sushimat/augment, /obj/item/kitchen/cutter/augment)
+	origin_tech = "materials=3;engineering=3;biotech=3;programming=2;magnets=3"
+	action_icon = list(/datum/action/item_action/organ_action/toggle = 'icons/obj/clothing/hats.dmi')
+	action_icon_state = list(/datum/action/item_action/organ_action/toggle = "chef")
+
+/obj/item/organ/internal/cyberimp/arm/toolset/l
+	parent_organ = "l_arm"
+
+/obj/item/organ/internal/cyberimp/arm/chef/emag_act(mob/user)
+	if(!(locate(/obj/item/kitchen/knife/butcher/augment) in items_list))
+		to_chat(user, "<span class='notice'>You unlock [src]'s integrated cleaver!</span>")
+		items_list += new /obj/item/kitchen/knife/butcher/augment(src)
+		return TRUE
+	return FALSE
+
 // lets make IPCs even *more* vulnerable to EMPs!
 /obj/item/organ/internal/cyberimp/arm/power_cord
 	name = "APC-compatible power adapter implant"


### PR DESCRIPTION
**What does this PR do:**
Adds in a Culinary Implant. Basically like any other implant. A Quality of Life improvement for the chef, frees up pack space, keeps everything nice and organized in one button. Comes with a knife, rolling pin, Sushi Mat, and cookie cutter. Can be emagged to receive a Butcher's Cleaver(Not the antag Meat Cleaver). Requires the same research levels as the surgical and toolset implants.

**Changelog:**
:cl:
add: Adds in the Culinary Implant, researchable and printable at science. Same tech levels as Surgical and Toolset Implants.
/:cl:

