### PR TITLE
Disallows xeno larva from pulling.

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -93,6 +93,9 @@
 /mob/living/carbon/alien/larva/show_inv(mob/user as mob)
 	return
 
+/mob/living/carbon/alien/larva/start_pulling(atom/movable/AM, state, force = move_force, supress_message = FALSE)
+	return FALSE
+
 /* Commented out because it's duplicated in life.dm
 /mob/living/carbon/alien/larva/proc/grow() // Larvae can grow into full fledged Xenos if they survive long enough -- TLE
 	if(icon_state == "larva_l" && !canmove) // This is a shit death check. It is made of shit and death. Fix later.


### PR DESCRIPTION
**What does this PR do:**
Been meaning to/was told to do this after my Move Resist PR, but I never got around to it. Basically, larva are small and lack limbs to pull things. Much like a pAI. Following that logic as well as minor balance concerns with them being able to drag things, this removes the possibility entirely. Personally think xenos need balancing, and this is one of the many smaller things that could be done to do it. Feedback appreciated, won't be upset either way this goes really :man_shrugging: 

**Changelog:**
:cl:
balance: Xeno Larva can no longer pull objects or people.
/:cl: