### PR TITLE
Fixes some antidrop edge cases and can't give items to resting people now

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -35,7 +35,7 @@
 /mob/proc/put_in_l_hand(var/obj/item/W)
 	if(!put_in_hand_check(W))
 		return 0
-	if(!l_hand)
+	if(!l_hand && has_left_hand())
 		W.forceMove(src)		//TODO: move to equipped?
 		l_hand = W
 		W.layer = 20	//TODO: move to equipped?
@@ -51,7 +51,7 @@
 /mob/proc/put_in_r_hand(var/obj/item/W)
 	if(!put_in_hand_check(W))
 		return 0
-	if(!r_hand)
+	if(!r_hand && has_right_hand())
 		W.forceMove(src)
 		r_hand = W
 		W.layer = 20

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -4,22 +4,15 @@
 
 	if(!iscarbon(target)) //something is bypassing the give arguments, no clue what, adding a sanity check JIC
 		to_chat(usr, "<span class='danger'>Wait a second... \the [target] HAS NO HANDS! AHH!</span>")//cheesy messages ftw
+		return
 
+	if(target.incapacitated() || usr.incapacitated() || target.client == null)
 		return
-	if(target.stat == 2 || usr.stat == 2|| target.client == null)
-		return
-	var/obj/item/I
-	if(!usr.hand && usr.r_hand == null)
-		to_chat(usr, "<span class='warning'> You don't have anything in your right hand to give to [target.name]</span>")
-		return
-	if(usr.hand && usr.l_hand == null)
-		to_chat(usr, "<span class='warning'> You don't have anything in your left hand to give to [target.name]</span>")
-		return
-	if(usr.hand)
-		I = usr.l_hand
-	else if(!usr.hand)
-		I = usr.r_hand
+	
+	var/obj/item/I = get_active_hand()
+
 	if(!I)
+		to_chat(usr, "<span class='warning'> You don't have anything in your hand to give to [target.name]</span>")
 		return
 	if((I.flags & NODROP) || (I.flags & ABSTRACT))
 		to_chat(usr, "<span class='notice'>That's not exactly something you can give.</span>")
@@ -29,6 +22,8 @@
 			if("Yes")
 				if(!I)
 					return
+				if(target.incapacitated() || usr.incapacitated())
+					return
 				if(!Adjacent(target))
 					to_chat(usr, "<span class='warning'> You need to stay in reaching distance while giving an object.</span>")
 					to_chat(target, "<span class='warning'> [usr.name] moved too far away.</span>")
@@ -37,32 +32,17 @@
 					to_chat(usr, "<span class='warning'>\the [I.name] stays stuck to your hand when you try to give it!</span>")
 					to_chat(target, "<span class='warning'>\the [I.name] stays stuck to [usr.name]'s hand when you try to take it!</span>")
 					return
-				if((usr.hand && usr.l_hand != I) || (!usr.hand && usr.r_hand != I))
+				if(I != get_active_hand())
 					to_chat(usr, "<span class='warning'> You need to keep the item in your active hand.</span>")
 					to_chat(target, "<span class='warning'> [usr.name] seem to have given up on giving \the [I.name] to you.</span>")
-					return
-				if(target.resting)
-					to_chat(usr, "<span class='warning'> They are resting and can't accept \the [I.name].</span>")
-					to_chat(target, "<span class='warning'> You can't can't accept \the [I.name] while resting.</span>")
 					return
 				if(target.r_hand != null && target.l_hand != null)
 					to_chat(target, "<span class='warning'> Your hands are full.</span>")
 					to_chat(usr, "<span class='warning'> Their hands are full.</span>")
 					return
-				else
-					usr.drop_item()
-					if(target.r_hand == null)
-						target.r_hand = I
-					else
-						target.l_hand = I
-				I.loc = target
-				I.layer = 20
-				I.plane = HUD_PLANE
+				usr.unEquip(I)
+				target.put_in_hands(I)
 				I.add_fingerprint(target)
-				src.update_inv_l_hand()
-				src.update_inv_r_hand()
-				target.update_inv_l_hand()
-				target.update_inv_r_hand()
 				target.visible_message("<span class='notice'> [usr.name] handed \the [I.name] to [target.name].</span>")
 				I.on_give(usr, target)
 			if("No")

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -33,9 +33,17 @@
 					to_chat(usr, "<span class='warning'> You need to stay in reaching distance while giving an object.</span>")
 					to_chat(target, "<span class='warning'> [usr.name] moved too far away.</span>")
 					return
+				if((I.flags & NODROP) || (I.flags & ABSTRACT))
+					to_chat(usr, "<span class='warning'>\the [I.name] stays stuck to your hand when you try to give it!</span>")
+					to_chat(target, "<span class='warning'>\the [I.name] stays stuck to [usr.name]'s hand when you try to take it!</span>")
+					return
 				if((usr.hand && usr.l_hand != I) || (!usr.hand && usr.r_hand != I))
 					to_chat(usr, "<span class='warning'> You need to keep the item in your active hand.</span>")
 					to_chat(target, "<span class='warning'> [usr.name] seem to have given up on giving \the [I.name] to you.</span>")
+					return
+				if(target.resting)
+					to_chat(usr, "<span class='warning'> They are resting and can't accept \the [I.name].</span>")
+					to_chat(target, "<span class='warning'> You can't can't accept \the [I.name] while resting.</span>")
 					return
 				if(target.r_hand != null && target.l_hand != null)
 					to_chat(target, "<span class='warning'> Your hands are full.</span>")

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -29,12 +29,12 @@
 					to_chat(target, "<span class='warning'> [usr.name] moved too far away.</span>")
 					return
 				if((I.flags & NODROP) || (I.flags & ABSTRACT))
-					to_chat(usr, "<span class='warning'>\the [I.name] stays stuck to your hand when you try to give it!</span>")
-					to_chat(target, "<span class='warning'>\the [I.name] stays stuck to [usr.name]'s hand when you try to take it!</span>")
+					to_chat(usr, "<span class='warning'>[I] stays stuck to your hand when you try to give it!</span>")
+					to_chat(target, "<span class='warning'>[I] stays stuck to [usr.name]'s hand when you try to take it!</span>")
 					return
 				if(I != get_active_hand())
 					to_chat(usr, "<span class='warning'> You need to keep the item in your active hand.</span>")
-					to_chat(target, "<span class='warning'> [usr.name] seem to have given up on giving \the [I.name] to you.</span>")
+					to_chat(target, "<span class='warning'> [usr.name] seem to have given up on giving [I] to you.</span>")
 					return
 				if(target.r_hand != null && target.l_hand != null)
 					to_chat(target, "<span class='warning'> Your hands are full.</span>")
@@ -43,9 +43,9 @@
 				usr.unEquip(I)
 				target.put_in_hands(I)
 				I.add_fingerprint(target)
-				target.visible_message("<span class='notice'> [usr.name] handed \the [I.name] to [target.name].</span>")
+				target.visible_message("<span class='notice'> [usr.name] handed [I] to [target.name].</span>")
 				I.on_give(usr, target)
 			if("No")
-				target.visible_message("<span class='warning'> [usr.name] tried to hand [I.name] to [target.name] but [target.name] didn't want it.</span>")
+				target.visible_message("<span class='warning'> [usr.name] tried to hand [I] to [target.name] but [target.name] didn't want it.</span>")
 	else
 		to_chat(usr, "<span class='warning'> [target.name]'s hands are full.</span>")

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -434,11 +434,11 @@
 		if(slot_l_hand)
 			if(l_hand)
 				return 0
-			return !resting
+			return !incapacitated()
 		if(slot_r_hand)
 			if(r_hand)
 				return 0
-			return !resting
+			return !incapacitated()
 		if(slot_wear_mask)
 			if(wear_mask)
 				return 0

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -434,11 +434,11 @@
 		if(slot_l_hand)
 			if(l_hand)
 				return 0
-			return 1
+			return !resting
 		if(slot_r_hand)
 			if(r_hand)
 				return 0
-			return 1
+			return !resting
 		if(slot_wear_mask)
 			if(wear_mask)
 				return 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -749,19 +749,25 @@
 // Override if a certain mob should be behave differently when placing items (can't, for example)
 /mob/living/stripPanelEquip(obj/item/what, mob/who, where, var/silent = 0)
 	what = get_active_hand()
-	if(what && (what.flags & NODROP))
-		to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
-		return
 	if(what)
+		if(what.flags & NODROP)
+			to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
+			return
 		if(!what.mob_can_equip(who, where, 1))
+			if(isliving(who))
+				var/mob/living/L = who
+				if(L.resting)
+					to_chat(src, "<span class='warning'>[who.name] can't hold \the [what.name] while resting.</span>")
+					return
 			to_chat(src, "<span class='warning'>\The [what.name] doesn't fit in that place!</span>")
 			return
 		if(!silent)
 			visible_message("<span class='notice'>[src] tries to put [what] on [who].</span>")
 		if(do_mob(src, who, what.put_on_delay))
-			if(what && Adjacent(who))
-				unEquip(what)
-				who.equip_to_slot_if_possible(what, where, 0, 1)
+			if(what && Adjacent(who) && !(what.flags & NODROP))
+				unEquip(what)	
+				if(!who.equip_to_slot_if_possible(what, where, 0, 1))
+					what.loc = who.loc
 				add_attack_logs(src, who, "Equipped [what]")
 
 /mob/living/singularity_act()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -749,7 +749,7 @@
 // Override if a certain mob should be behave differently when placing items (can't, for example)
 /mob/living/stripPanelEquip(obj/item/what, mob/who, where, var/silent = 0)
 	what = get_active_hand()
-	if(what && what.flags & NODROP)
+	if(what && (what.flags & NODROP))
 		to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
 		return
 	if(what)
@@ -760,7 +760,7 @@
 			visible_message("<span class='notice'>[src] tries to put [what] on [who].</span>")
 		if(do_mob(src, who, what.put_on_delay))
 			if(what && Adjacent(who) && !(what.flags & NODROP))
-				unEquip(what)	
+				unEquip(what)
 				who.equip_to_slot_if_possible(what, where, 0, 1)
 				add_attack_logs(src, who, "Equipped [what]")
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -749,16 +749,11 @@
 // Override if a certain mob should be behave differently when placing items (can't, for example)
 /mob/living/stripPanelEquip(obj/item/what, mob/who, where, var/silent = 0)
 	what = get_active_hand()
+	if(what && what.flags & NODROP)
+		to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
+		return
 	if(what)
-		if(what.flags & NODROP)
-			to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
-			return
 		if(!what.mob_can_equip(who, where, 1))
-			if((where == slot_l_hand || where == slot_r_hand) && isliving(who))
-				var/mob/living/L = who
-				if(L.resting)
-					to_chat(src, "<span class='warning'>[who.name] can't hold \the [what.name] while resting.</span>")
-					return
 			to_chat(src, "<span class='warning'>\The [what.name] doesn't fit in that place!</span>")
 			return
 		if(!silent)
@@ -766,8 +761,7 @@
 		if(do_mob(src, who, what.put_on_delay))
 			if(what && Adjacent(who) && !(what.flags & NODROP))
 				unEquip(what)	
-				if(!who.equip_to_slot_if_possible(what, where, 0, 1))
-					what.loc = who.loc
+				who.equip_to_slot_if_possible(what, where, 0, 1)
 				add_attack_logs(src, who, "Equipped [what]")
 
 /mob/living/singularity_act()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -754,7 +754,7 @@
 			to_chat(src, "<span class='warning'>You can't put \the [what.name] on [who], it's stuck to your hand!</span>")
 			return
 		if(!what.mob_can_equip(who, where, 1))
-			if(isliving(who))
+			if((where == slot_l_hand || where == slot_r_hand) && isliving(who))
 				var/mob/living/L = who
 				if(L.resting)
 					to_chat(src, "<span class='warning'>[who.name] can't hold \the [what.name] while resting.</span>")


### PR DESCRIPTION
**What does this PR do:**
Does what the title says and refactored the give verb a bit.
It also fixes put_in_hands. If you lack hands it'll drop it on the ground below you now. Should be changed for some occurrences such as picking up chairs.

fixes: #10024
fixes: #10730 it'll now drop items on the floor. Still not quite what you want but that will need another PR due to the amount it is used and it all needing different kind of behaviours.

**Changelog:**
:cl:
fix: Antidrop give edge case fixed
fix: Can't give items to resting people now
fix: put_in_hands now checks if you actually have hands
/:cl:

