### PR TITLE
Fixes Chem Smoke Lag and Reagent Garbage Collection Edge Case

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -104,6 +104,7 @@
 			if(prob(addiction_removal_chance))
 				to_chat(occupant, "<span class='notice'>You no longer feel reliant on [R.name]!</span>")
 				occupant.reagents.addiction_list.Remove(R)
+				qdel(R)
 
 	for(var/mob/M as mob in src) // makes sure that simple mobs don't get stuck inside a sleeper when they resist out of occupant's grasp
 		if(M == occupant)

--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -18,7 +18,7 @@
 	var/spread_amount = 96
 
 /obj/effect/particle_effect/chem_smoke/New(location, chem_color)
-	..()
+	..(location)
 	color = chem_color
 	pixel_x += -16 + rand(-3, 3)
 	pixel_y += -16 + rand(-3, 3)
@@ -65,6 +65,7 @@
 	else
 		location = get_turf(loca)
 	carry.copy_to(chemholder, carry.total_volume)
+	carry.clear_reagents()
 	if(!silent)
 		var/contained = ""
 		for(var/reagent in carry.reagent_list)
@@ -105,7 +106,7 @@
 				new /obj/effect/particle_effect/chem_smoke(location, color)
 
 		if(x % 10 == 0) //Once every 10 ticks.
-			SmokeEm(effect_range)
+			INVOKE_ASYNC(src, .proc/SmokeEm, effect_range)
 
 		sleep(1)
 	qdel(src)

--- a/code/game/objects/effects/effect_system/effects_chem_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_chem_smoke.dm
@@ -113,6 +113,8 @@
 
 /datum/effect_system/smoke_spread/chem/proc/SmokeEm(effect_range = 2)
 	for(var/atom/A in view(effect_range, get_turf(location)))
+		if(istype(A, /obj/effect/particle_effect)) // Don't impact particle effects, as there can be hundreds of them in a small area. Also, we don't want smoke particles adding themselves to this list. Major performance issue.
+			continue
 		if(A in smoked_atoms)
 			continue
 		smoked_atoms += A

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -411,8 +411,6 @@
 	var/smoke_amount = round(sqrt(G.seed.potency * 0.1), 1)
 	S.set_up(G.reagents, splat_location)
 	S.start(smoke_amount)
-	if(G && G.reagents)
-		G.reagents.clear_reagents()
 
 /datum/plant_gene/trait/plant_type // Parent type
 	name = "you shouldn't see this"

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -292,6 +292,8 @@ var/const/INGEST = 2
 			if(prob(20) && (world.timeofday > (R.last_addiction_dose + ADDICTION_TIME))) //Each addiction lasts 8 minutes before it can end
 				to_chat(M, "<span class='notice'>You no longer feel reliant on [R.name]!</span>")
 				addiction_list.Remove(R)
+				qdel(R)
+
 	if(update_flags & STATUS_UPDATE_HEALTH)
 		M.updatehealth("reagent metabolism")
 	else if(update_flags & STATUS_UPDATE_STAT)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -32,6 +32,9 @@
 /datum/reagent/Destroy()
 	. = ..()
 	holder = null
+	if(islist(data))
+		data.Cut()
+	data = null
 
 /datum/reagent/proc/reaction_temperature(exposed_temperature, exposed_volume) //By default we do nothing.
 	return

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -279,8 +279,6 @@ datum/chemical_reaction/flash_powder
 			S.start(3)
 		if(created_volume >=15)
 			S.start(4)
-	if(holder && holder.my_atom)
-		holder.clear_reagents()
 
 /datum/chemical_reaction/smoke/smoke_powder
 	name = "smoke_powder_smoke"


### PR DESCRIPTION
This is all edge case, but I want to ensure all reagents pass through the garbage collector, as opposed to GC'ing naturally.

Also ensure that if reagent data is a list (like with blood or stable mutagen), the list gets `Cut` then nulled out.

This won't really help the reagent itself GC better, but blood and stable mutagen hold a crap ton of references to other things.

Also fixes chem smoke causing major server lag under some circumstances, largely due to the smoke datum adding the smoke particles to a list of itself.

Also helps smoke garbage collect a bit better.

:cl: Fox McCloud
fix: Fixes some reagent performance edges cases
fix: Fixes chem smoke lagging under some circumstances
fix: Fixes smoke not wanting to garbage collect
/:cl: