### PR TITLE
Diona nymphs are now eatable and punchable

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/diona.dm
+++ b/code/modules/mob/living/simple_animal/friendly/diona.dm
@@ -109,6 +109,8 @@
 			forceMove(M)
 		else
 			get_scooped(M)
+	else 
+		..()
 
 /mob/living/simple_animal/diona/proc/merge()
 	if(stat != CONSCIOUS)


### PR DESCRIPTION
**What does this PR do:**
Does what the title says
fixes: #11073
fixes: #10691

**Changelog:**
:cl:
fix: Diona nymphs are grabbable and punchable again
/:cl:

