### PR TITLE
Fixese Flares not Returning a qdel hint

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -187,7 +187,7 @@
 
 /obj/item/flashlight/flare/Destroy()
 	processing_objects.Remove(src)
-	..()
+	return ..()
 
 /obj/item/flashlight/flare/proc/turn_off()
 	on = 0


### PR DESCRIPTION
Flares aren't returning a `qdel` hint, which is...well, bad.

:cl: Fox McCloud
fix: Fixes flares not returning a qdel hint
/:cl: