### PR TITLE
Adds Medical Beamgun to a Syndicate Medical Cyborg

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -427,6 +427,7 @@
 	modules += new /obj/item/bonesetter(src)
 	modules += new /obj/item/surgicaldrill(src)
 	modules += new /obj/item/gripper/medical(src)
+	modules += new /obj/item/gun/medbeam(src)
 	modules += new /obj/item/melee/energy/sword/cyborg/saw(src) //Energy saw -- primary weapon
 	modules += new /obj/item/card/emag(src)
 	modules += new /obj/item/crowbar/cyborg(src)

--- a/code/modules/projectiles/guns/medbeam.dm
+++ b/code/modules/projectiles/guns/medbeam.dm
@@ -54,8 +54,8 @@
 	feedback_add_details("gun_fired","[type]")
 
 /obj/item/gun/medbeam/process()
-	var/mob/living/carbon/human/H = loc
-	if(!istype(H))
+	var/source = loc
+	if(!ishuman(source) && !isrobot(source))
 		LoseTarget()
 		return
 
@@ -68,9 +68,9 @@
 
 	last_check = world.time
 
-	if(get_dist(H,current_target)>max_range || !los_check(H,current_target))
+	if(get_dist(source,current_target)>max_range || !los_check(source,current_target))
 		LoseTarget()
-		to_chat(H, "<span class='warning'>You lose control of the beam!</span>")
+		to_chat(source, "<span class='warning'>You lose control of the beam!</span>")
 		return
 
 	if(current_target)


### PR DESCRIPTION
**What does this PR do:**
Adds Medical Beamgun to a Syndicate Medical Cyborg. Also tweaks a few lines in code to even allow them to properly use it.

Syndicate Medical Cyborg is really underused in Nuclear Emergency rounds, and for good reason. To even buy a cyborg as nuclear operative you need to spend 50 TC, which is quite considerable investment, and medical module is simply not worth it for its cost, especially compared to Assault module.

Their offensive capabalities are limited to their unique energy saw (which also serves them as surgery tool) and situational hypospray filled with potassium iodide, which takes a while to even take effect. Both of which puts them in melee range of their enemies, which incredibly dangerous for cyborgs, as it takes one flash to completely disable them and eliminate them.

Which would be alright, as they are primarily supposed to support their team, right? Problem is, nuclear emergency rounds are more often than not very fast-paced, and they are simply not equipped for that. They have full surgery set, which they probably wont use for the whole round, very limited supply of trauma, burn and splint kits and limited amount of healing chemicals in their hypospray. While they can refill their supplies at Rechargers, in practice that is really not happening, as they end up in hostile teritory  in often largely damaged station, leaving them with very little to work with.

This PR adds a standard Medical Beamgun to their arsenal, so they can adequately support their allies in combat, and always have some form of heal at their disposal.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
add: Added Medical Beamgun to a Syndicate Medical Cyborg
/:cl: