### PR TITLE
Fixes Two Ancient LINDA Bugs

### DIFF
--- a/code/LINDA/LINDA_fire.dm
+++ b/code/LINDA/LINDA_fire.dm
@@ -141,7 +141,7 @@
 						W.adjacent_fire_act(W, radiated_temperature)
 					continue
 				var/turf/simulated/T = get_step(src, direction)
-				if(istype(T) && T.active_hotspot)
+				if(istype(T) && !T.active_hotspot)
 					T.hotspot_expose(radiated_temperature, CELL_VOLUME/4)
 
 	else

--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -215,9 +215,9 @@
 			item.temperature_expose(air, air.temperature, CELL_VOLUME)
 		temperature_expose(air, air.temperature, CELL_VOLUME)
 
-		if(air.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION)
-			if(consider_superconductivity(starting = 1))
-				remove = 0
+	if(air.temperature > MINIMUM_TEMPERATURE_START_SUPERCONDUCTION)
+		if(consider_superconductivity(starting = 1))
+			remove = 0
 
 	if(air.temperature < T0C && air.return_pressure() > 10)
 		icy = 1


### PR DESCRIPTION
Fixes two ancient LINDA bugs.

@tigercat2000 you may be interested in this (sorry to ping you if you don't want to be pestered).

Both of these were present in the first iteration of LINDA on TG, and we inherited them.

I've been digging into the workings of both LINDA and FEA, and it seems there was a few mistakes.

With FEA, hotspots would call `hotspot_expose` on adjacent neighboring turfs that *didn't* have a hotspot.

With LINDA, this logic was accidentally inversed, which results in those fires you see sometimes that just won't catch.

The second one I suspected, but wasn't positive about @MrStonedOne helped me with it and confirmed it. 

super conduction isn't happening, at all, seemingly, which means that thermal heat isn't properly radiating through objects (most noteworthy are windows, doors, and windoors).

Indenting it fixes that issue; I suspected that this had to be done, but I wasn't positive, but @MrStonedOne confirmed it.

:cl: Fox McCloud
fix: Fixes hotspots being slow to ignite turfs around them
fix: Fixes LINDA not conducting temperature through things.
/:cl:
 

