### PR TITLE
Makes the Master Controller Actually Shutdown

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -322,6 +322,7 @@ var/world_topic_spam_protect_time = world.timeofday
 	//kick_clients_in_lobby("<span class='boldannounce'>The round came to an end with you in the lobby.</span>", 1)
 
 	processScheduler.stop()
+	Master.Shutdown()	//run SS shutdowns
 	shutdown_logging() // Past this point, no logging procs can be used, at risk of data loss.
 
 	for(var/client/C in GLOB.clients)


### PR DESCRIPTION
Makes the master controller actually shut down, which makes subsystems actually shut down.

I was wondering why we had literally 0 `qdel` logs from prior rounds. Thousands of rounds worth of data lost because this proc wasn't being called.

This also meant that nano UI wasn't closing at round end, making it persist into next round.

Welp.

:cl: Fox McCloud
fix: Fixes the Master Controller not actually shutting down on round end
/:cl: