### PR TITLE
Removes a unneeded dot from diamond statue names

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -256,18 +256,18 @@
 /obj/structure/statue/diamond
 	hardness = 10
 	material_drop_type = /obj/item/stack/sheet/mineral/diamond
-	desc = "This is a very expensive diamond statue"
+	desc = "This is a very expensive diamond statue."
 
 /obj/structure/statue/diamond/captain
-	name = "statue of THE captain."
+	name = "statue of THE captain"
 	icon_state = "cap"
 
 /obj/structure/statue/diamond/ai1
-	name = "statue of the AI hologram."
+	name = "statue of the AI hologram"
 	icon_state = "ai1"
 
 /obj/structure/statue/diamond/ai2
-	name = "statue of the AI core."
+	name = "statue of the AI core"
 	icon_state = "ai2"
 
 /obj/structure/statue/bananium


### PR DESCRIPTION
**What does this PR do:**
Removes the extra unneeded dot in diamond statue names. For example: "statue of the AI hologram."
As well adds the missing dot at the end of the description.

**Changelog:**
:cl:
spellcheck: Fixed diamond statue names and description.
/:cl:

