### PR TITLE
Fixes broken logic of the camera spook

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -325,7 +325,7 @@ var/list/SpookyGhosts = list("ghost","shade","shade2","ghost-narsie","horror","s
 	to_chat(user, "<span class='notice'>[pictures_left] photos left.</span>")
 	icon_state = icon_off
 	on = 0
-	if(user.mind && !(user.mind.assigned_role == "Chaplain"))
+	if(user.mind && user.mind.assigned_role == "Chaplain")
 		if(prob(24))
 			handle_haunt(user)
 	spawn(64)


### PR DESCRIPTION
**What does this PR do:**
Fixes incorrect logic of the spook of the camera. It checks if the person who i using the camera is a chaplain correctly now.
Fixes: #11007 

**Changelog:**
:cl:
fix: Camera now properly spooks the chaplain instead of non-chaplain people
/:cl:

