### PR TITLE
Auto processing doesn't clone people twice (or more)

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -36,12 +36,25 @@
 
 	if(scanner.occupant && can_autoprocess())
 		scan_mob(scanner.occupant)
-
+	
+	if(!length(records))
+		return
+	var/list/toClone = records.Copy()
+	var/datum/dna2/record/lastEntry = toClone[length(toClone)] // Most recently added record
+	// Prevent double cloning
+	for(var/obj/machinery/clonepod/pod in pods)
+		if(pod.occupant)
+			for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
+				if(hook.soulowner.ckey == lastEntry.ckey)
+					toClone.Remove(lastEntry) // Fucker is getting cloned. No two bodies greedy shit
+					break
+	
 	for(var/obj/machinery/clonepod/pod in pods)
 		if(!(pod.occupant || pod.mess) && (pod.efficiency > 5))
-			for(var/datum/dna2/record/R in src.records)
+			for(var/datum/dna2/record/R in toClone)
 				if(!(pod.occupant || pod.mess))
 					if(pod.growclone(R))
+						toClone.Remove(R)
 						records.Remove(R)
 
 /obj/machinery/computer/cloning/proc/updatemodules()

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -396,13 +396,12 @@
 		return
 
 	for(var/obj/machinery/clonepod/pod in pods)
-		if(pod.occupant)
-			if(pod.occupant.ckey == null) // Uses soulhooks
-				for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
-					if(hook.soulowner.ckey == subject.ckey)
-						scantemp = "Subject already getting cloned."
-						SSnanoui.update_uis(src)
-						return
+		if(pod.occupant && pod.occupant.ckey == null)
+			for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
+				if(hook.soulowner.ckey == subject.ckey)
+					scantemp = "Subject already getting cloned."
+					SSnanoui.update_uis(src)
+					return
 
 	subject.dna.check_integrity()
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -37,7 +37,7 @@
 	if(scanner.occupant && can_autoprocess())
 		scan_mob(scanner.occupant)
 	
-	if(!length(records))
+	if(!LAZYLEN(records))
 		return
 	
 	for(var/obj/machinery/clonepod/pod in pods)
@@ -403,10 +403,6 @@
 						scantemp = "Subject already getting cloned."
 						SSnanoui.update_uis(src)
 						return
-			else if(pod.occupant.ckey == subject.ckey) // Directly put in body
-				scantemp = "Subject already getting cloned."
-				SSnanoui.update_uis(src)
-				return
 
 	subject.dna.check_integrity()
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -39,26 +39,12 @@
 	
 	if(!length(records))
 		return
-	var/list/toClone = records.Copy()
-	var/datum/dna2/record/lastEntry = toClone[length(toClone)] // Most recently added record
-	// Prevent double cloning
-	for(var/obj/machinery/clonepod/pod in pods)
-		if(pod.occupant)
-			if(pod.occupant.ckey == null) // Uses soulhooks
-				for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
-					if(hook.soulowner.ckey == lastEntry.ckey)
-						toClone.Remove(lastEntry) // Guy is getting cloned so remove the entry
-						break
-			else if(pod.occupant.ckey == lastEntry.ckey) // Directly put in body
-				toClone.Remove(lastEntry) // Guy is getting cloned so remove the entry
-				break
 	
 	for(var/obj/machinery/clonepod/pod in pods)
 		if(!(pod.occupant || pod.mess) && (pod.efficiency > 5))
-			for(var/datum/dna2/record/R in toClone)
+			for(var/datum/dna2/record/R in records)
 				if(!(pod.occupant || pod.mess))
 					if(pod.growclone(R))
-						toClone.Remove(R)
 						records.Remove(R)
 
 /obj/machinery/computer/cloning/proc/updatemodules()
@@ -408,6 +394,19 @@
 		scantemp = "Subject already in database."
 		SSnanoui.update_uis(src)
 		return
+
+	for(var/obj/machinery/clonepod/pod in pods)
+		if(pod.occupant)
+			if(pod.occupant.ckey == null) // Uses soulhooks
+				for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
+					if(hook.soulowner.ckey == subject.ckey)
+						scantemp = "Subject already getting cloned."
+						SSnanoui.update_uis(src)
+						return
+			else if(pod.occupant.ckey == subject.ckey) // Directly put in body
+				scantemp = "Subject already getting cloned."
+				SSnanoui.update_uis(src)
+				return
 
 	subject.dna.check_integrity()
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -44,10 +44,14 @@
 	// Prevent double cloning
 	for(var/obj/machinery/clonepod/pod in pods)
 		if(pod.occupant)
-			for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
-				if(hook.soulowner.ckey == lastEntry.ckey)
-					toClone.Remove(lastEntry) // Fucker is getting cloned. No two bodies greedy shit
-					break
+			if(pod.occupant.ckey == null) // Uses soulhooks
+				for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
+					if(hook.soulowner.ckey == lastEntry.ckey)
+						toClone.Remove(lastEntry) // Guy is getting cloned so remove the entry
+						break
+			else if(pod.occupant.ckey == lastEntry.ckey) // Directly put in body
+				toClone.Remove(lastEntry) // Guy is getting cloned so remove the entry
+				break
 	
 	for(var/obj/machinery/clonepod/pod in pods)
 		if(!(pod.occupant || pod.mess) && (pod.efficiency > 5))

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -396,12 +396,10 @@
 		return
 
 	for(var/obj/machinery/clonepod/pod in pods)
-		if(pod.occupant && pod.occupant.ckey == null)
-			for(var/datum/soullink/soulhook/hook in pod.sharedSoulhooks) //Check the soul hooks to see if the to be cloned person is in here
-				if(hook.soulowner.ckey == subject.ckey)
-					scantemp = "Subject already getting cloned."
-					SSnanoui.update_uis(src)
-					return
+		if(pod.occupant && pod.occupant.ckey == null && pod.clonemind == subject.mind)
+			scantemp = "Subject already getting cloned."
+			SSnanoui.update_uis(src)
+			return
 
 	subject.dna.check_integrity()
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -396,7 +396,7 @@
 		return
 
 	for(var/obj/machinery/clonepod/pod in pods)
-		if(pod.occupant && pod.occupant.ckey == null && pod.clonemind == subject.mind)
+		if(pod.occupant && pod.clonemind == subject.mind)
 			scantemp = "Subject already getting cloned."
 			SSnanoui.update_uis(src)
 			return


### PR DESCRIPTION
**What does this PR do:**
Auto processing now doesn't clone a person more than once.
fixes: #11145
A person in the scanner won't be scanned if it's already cloning.

**Changelog:**
:cl:
fix: Auto cloning now doesn't clone a person more than once. 
tweak: A person in the cloning scanner won't be scanned if he's already being cloned
/:cl:

