### PR TITLE
Added a blending in delay for antags and a small refactor

### DIFF
--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -56,8 +56,6 @@
 			traitor.special_role = SPECIAL_ROLE_TRAITOR
 			traitor.restricted_roles = restricted_jobs
 
-//	if(!traitors.len)
-//		return 0
 	return 1
 
 
@@ -86,25 +84,7 @@
 				if(ishuman(player) || isrobot(player) || isAI(player))
 					if((ROLE_TRAITOR in player.client.prefs.be_special) && !player.client.skip_antag && !jobban_isbanned(player, ROLE_TRAITOR) && !jobban_isbanned(player, "Syndicate"))
 						possible_traitors += player.mind
-		for(var/datum/mind/player in possible_traitors)
-			for(var/job in restricted_jobs)
-				if(player.assigned_role == job)
-					possible_traitors -= player
-			if(!player.current || !ishuman(player.current)) // Remove mindshield-implanted mobs from the list
-				continue
-			var/mob/living/carbon/human/H = player.current
-			for(var/obj/item/implant/mindshield/I in H.contents)
-				if(I && I.implanted)
-					possible_traitors -= player
 
-		//message_admins("Live Players: [playercount]")
-		//message_admins("Live Traitors: [traitorcount]")
-//		message_admins("Potential Traitors:")
-//		for(var/mob/living/traitorlist in possible_traitors)
-//			message_admins("[traitorlist.real_name]")
-
-//		var/r = rand(5)
-//		var/target_traitors = 1
 		var/max_traitors = 1
 		var/traitor_prob = 0
 		max_traitors = round(playercount / 10) + 1
@@ -114,10 +94,18 @@
 
 
 		if(traitorcount < max_traitors)
-			//message_admins("Number of Traitors is below maximum.  Rolling for new Traitor.")
-			//message_admins("The probability of a new traitor is [traitor_prob]%")
 
 			if(prob(traitor_prob))
+				for(var/datum/mind/player in possible_traitors)
+					for(var/job in restricted_jobs)
+						if(player.assigned_role == job)
+							possible_traitors -= player
+					if(!player.current || !ishuman(player.current)) // Remove mindshield-implanted mobs from the list
+						continue
+					var/mob/living/carbon/human/H = player.current
+					for(var/obj/item/implant/mindshield/I in H.contents)
+						if(I && I.implanted)
+							possible_traitors -= player
 				message_admins("Making a new Traitor.")
 				if(!possible_traitors.len)
 					message_admins("No potential traitors.  Cancelling new traitor.")
@@ -142,15 +130,7 @@
 				tatorhud.join_hud(newtraitor)
 				set_antag_hud(newtraitor, "hudsyndicate")
 
-				var/obj_count = 1
-				to_chat(newtraitor, "<span class='notice'>Your current objectives:</span>")
-				for(var/datum/objective/objective in newtraitor.mind.objectives)
-					to_chat(newtraitor, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
-					obj_count++
-			//else
-				//message_admins("No new traitor being added.")
-		//else
-			//message_admins("Number of Traitors is at maximum.  Not making a new Traitor.")
+				show_objectives(newtraitor)
 
 		traitorcheckloop()
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -65,10 +65,14 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 /datum/game_mode/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)
 		grant_changeling_powers(changeling.current)
-		forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
 		update_change_icons_added(changeling)
 
+	..()
+
+//Used by to give objectives with a delay from the start
+/datum/game_mode/changeling/delayed_objectives(var/datum/mind/antag)
+	forge_changeling_objectives(antag)
 	..()
 
 /datum/game_mode/proc/forge_changeling_objectives(datum/mind/changeling)
@@ -142,11 +146,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			changeling.current.mutations.Remove(CLUMSY)
 			var/datum/action/innate/toggle_clumsy/A = new
 			A.Grant(changeling.current)
-	var/obj_count = 1
-	for(var/datum/objective/objective in changeling.objectives)
-		to_chat(changeling.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
-		obj_count++
-	return
+	to_chat(changeling.current, "<B>The hivemind will contact you within 10 minutes to give you your objectives. Lay low till then.</B>")
 
 /datum/game_mode/proc/remove_changeling(datum/mind/changeling_mind)
 	if(changeling_mind in changelings)

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -36,8 +36,6 @@
 	for(var/datum/mind/changeling in changelings)
 		grant_changeling_powers(changeling.current)
 		changeling.special_role = SPECIAL_ROLE_CHANGELING
-		forge_changeling_objectives(changeling)
 		greet_changeling(changeling)
 		update_change_icons_added(changeling)
 	..()
-	return

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -70,6 +70,8 @@
 ///post_setup()
 ///Everyone should now be on the station and have their normal gear.  This is the place to give the special roles extra things
 /datum/game_mode/proc/post_setup()
+	for(var/datum/mind/traitor in traitors + changelings + vampires)
+		addtimer(CALLBACK(src, .proc/delayed_objectives, traitor), rand(3000, 6000)) // 5-10 minutes callback
 
 	spawn (ROUNDSTART_LOGOUT_REPORT_TIME)
 		display_roundstart_logout_report()
@@ -85,6 +87,12 @@
 	start_state = new /datum/station_state()
 	start_state.count()
 	return 1
+
+//Used by to give objectives with a delay from the start
+/datum/game_mode/proc/delayed_objectives(var/datum/mind/antag)
+	to_chat(antag.current, "<span class='warning'>You've received new objectives.</span>")
+	show_objectives(antag)
+	return
 
 ///process()
 ///Called by the gameticker

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -62,12 +62,16 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in traitors)
-		forge_traitor_objectives(traitor)
 		update_traitor_icons_added(traitor)
 		spawn(rand(10,100))
 			finalize_traitor(traitor)
 			greet_traitor(traitor)
 	modePlayer += traitors
+	..()
+
+//Used by to give objectives with a delay from the start
+/datum/game_mode/traitor/delayed_objectives(var/datum/mind/antag)
+	forge_traitor_objectives(antag)
 	..()
 
 /datum/game_mode/proc/forge_traitor_objectives(datum/mind/traitor)
@@ -179,12 +183,7 @@
 	else
 		SEND_SOUND(traitor.current, 'sound/ambience/antag/tatoralert.ogg')
 	to_chat(traitor.current, "<B><font size=3 color=red>You are the traitor.</font></B>")
-	var/obj_count = 1
-	for(var/datum/objective/objective in traitor.objectives)
-		to_chat(traitor.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
-		obj_count++
-	return
-
+	to_chat(traitor.current, "<B>The Syndicate will contact you within 10 minutes to give you your objectives. Lay low till then.</B>")
 
 /datum/game_mode/proc/finalize_traitor(var/datum/mind/traitor)
 	if(istype(traitor.current, /mob/living/silicon))
@@ -412,12 +411,6 @@
 	//Spawn and equip documents
 	var/mob/living/carbon/human/mob = owner.current
 
-	var/obj/item/folder/syndicate/folder
-	if(owner == exchange_red)
-		folder = new/obj/item/folder/syndicate/red(mob.locs)
-	else
-		folder = new/obj/item/folder/syndicate/blue(mob.locs)
-
 	var/list/slots = list (
 		"backpack" = slot_in_backpack,
 		"left pocket" = slot_l_store,
@@ -425,10 +418,16 @@
 		"left hand" = slot_l_hand,
 		"right hand" = slot_r_hand,
 	)
-
-	var/where = "At your feet"
-	var/equipped_slot = mob.equip_in_one_of_slots(folder, slots)
-	if(equipped_slot)
-		where = "In your [equipped_slot]"
-	to_chat(mob, "<BR><BR><span class='info'>[where] is a folder containing <b>secret documents</b> that another Syndicate group wants. We have set up a meeting with one of their agents on station to make an exchange. Exercise extreme caution as they cannot be trusted and may be hostile.</span><BR>")
-	mob.update_icons()
+	to_chat(mob, "<span class='warning'>You've been tasked of keeping hold of a folder containing <b>secret documents</b>. A nearby syndicate operative will teleport the documents into your backback in about 10 seconds. Make sure there is room.</span><BR>")
+	spawn(100)
+		var/obj/item/folder/syndicate/folder
+		if(owner == exchange_red)
+			folder = new/obj/item/folder/syndicate/red(mob.locs)
+		else
+			folder = new/obj/item/folder/syndicate/blue(mob.locs)
+		var/where = "At your feet"
+		var/equipped_slot = mob.equip_in_one_of_slots(folder, slots)
+		if(equipped_slot)
+			where = "In your [equipped_slot]"
+		to_chat(mob, "<BR><BR><span class='info'>[where] is a folder containing <b>secret documents</b> that another Syndicate group wants. We have set up a meeting with one of their agents on station to make an exchange. Exercise extreme caution as they cannot be trusted and may be hostile.</span><BR>")
+		mob.update_icons()

--- a/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -41,7 +41,6 @@
 	for(var/datum/mind/vampire in vampires)
 		grant_vampire_powers(vampire.current)
 		vampire.special_role = SPECIAL_ROLE_VAMPIRE
-		forge_vampire_objectives(vampire)
 		greet_vampire(vampire)
 		update_vampire_icons_added(vampire)
 	..()

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -67,9 +67,13 @@
 /datum/game_mode/vampire/post_setup()
 	for(var/datum/mind/vampire in vampires)
 		grant_vampire_powers(vampire.current)
-		forge_vampire_objectives(vampire)
 		greet_vampire(vampire)
 		update_vampire_icons_added(vampire)
+	..()
+
+//Used by to give objectives with a delay from the start
+/datum/game_mode/vampire/delayed_objectives(var/datum/mind/antag)
+	forge_vampire_objectives(antag)
 	..()
 
 /datum/game_mode/proc/auto_declare_completion_vampire()
@@ -180,7 +184,7 @@
 	dat += {"To bite someone, target the head and use harm intent with an empty hand. Drink blood to gain new powers.
 You are weak to holy things and starlight. Don't go into space and avoid the Chaplain, the chapel and especially Holy Water."}
 	to_chat(vampire.current, dat)
-	to_chat(vampire.current, "<B>You must complete the following tasks:</B>")
+	to_chat(vampire.current, "<B>The Syndicate will contact you within 10 minutes to give you your objectives. Lay low till then.</B>")
 
 	if(vampire.current.mind)
 		if(vampire.current.mind.assigned_role == "Clown")
@@ -188,11 +192,6 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			vampire.current.mutations.Remove(CLUMSY)
 			var/datum/action/innate/toggle_clumsy/A = new
 			A.Grant(vampire.current)
-	var/obj_count = 1
-	for(var/datum/objective/objective in vampire.objectives)
-		to_chat(vampire.current, "<B>Objective #[obj_count]</B>: [objective.explanation_text]")
-		obj_count++
-	return
 
 /datum/vampire
 	var/bloodtotal = 0 // CHANGE TO ZERO WHEN PLAYTESTING HAPPENS

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+traitorvamp

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-traitorvamp
+extended


### PR DESCRIPTION
**What does this PR do:**
>Necaladun
Adding a default objective to most antags that consists of "Blending in" for a delayed amount (5-10 minutes). When the delay ends, they get their real objectives.

Does exactly that. Clings, vampires and agents now get a 5 till 10 minute delay before getting objectives.
It will notify them that they are said antag and that they will receive objectives within 10 minutes.
Only matters for roundstart antags.

**Changelog:**
:cl:
balance: Changelings, vampires and agents now get a 5 till 10 minute delay before getting their objectives.
/:cl:

