### PR TITLE
Racial Tweaks to promote a more accurate atmosphere on the server

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -479,6 +479,10 @@
 		var/mob/living/M = G.affecting
 		time_till_despawn = initial(time_till_despawn)
 
+		if(ismachine(M))
+			to_chat(user, "<span class='notice'>IPCs cannot be put into cryo.</span>")
+			return
+
 		if(!istype(M) || M.stat == DEAD)
 			to_chat(user, "<span class='notice'>Dead people can not be put into cryo.</span>")
 			return
@@ -547,7 +551,9 @@
 	var/mob/living/L = O
 	if(!istype(L) || L.buckled)
 		return
-
+	if(ismachine(L))
+		to_chat(user, "<span class='notice'>IPCs cannot be put into cryo.</span>")
+		return
 	if(L.stat == DEAD)
 		to_chat(user, "<span class='notice'>Dead people can not be put into cryo.</span>")
 		return

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -140,7 +140,9 @@
 			user.create_attack_log("[key_name(user)] EMPd a camera with a laser pointer")
 		else
 			outmsg = "<span class='info'>You missed the lens of [C] with [src].</span>"
-
+	for(var/mob/living/carbon/M in orange(10,targloc))
+		if(istajaran(M) || isfarwa(M))
+			step_to(M, targloc)
 	//laser pointer image
 	icon_state = "pointer_[pointer_icon_state]"
 	var/list/showto = list()

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -153,10 +153,7 @@
 	colour = "soghun"
 	key = "o"
 	flags = RESTRICTED
-	syllables = list("za","az","ze","ez","zi","iz","zo","oz","zu","uz","zs","sz","ha","ah","he","eh","hi","ih", \
-	"ho","oh","hu","uh","hs","sh","la","al","le","el","li","il","lo","ol","lu","ul","ls","sl","ka","ak","ke","ek", \
-	"ki","ik","ko","ok","ku","uk","ks","sk","sa","as","se","es","si","is","so","os","su","us","ss","ss","ra","ar", \
-	"re","er","ri","ir","ro","or","ru","ur","rs","sr","a","a","e","e","i","i","o","o","u","u","s","s" )
+	syllables = list("owo","wats dis")
 
 /datum/language/unathi/get_random_name()
 
@@ -174,10 +171,7 @@
 	colour = "tajaran"
 	key = "j"
 	flags = RESTRICTED
-	syllables = list("rr","rr","tajr","kir","raj","kii","mir","kra","ahk","nal","vah","khaz","jri","ran","darr", \
-	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r", \
-	"ka","aasi","far","wa","baq","ara","qara","zir","sam","mak","hrar","nja","rir","khan","jun","dar","rik","kah", \
-	"hal","ket","jurl","mah","tul","cresh","azu","ragh")
+	syllables = list("owo","wats dis")
 
 /datum/language/tajaran/get_random_name(gender)
 	var/new_name = ..(gender,1)
@@ -196,10 +190,7 @@
 	colour = "vulpkanin"
 	key = "7"
 	flags = RESTRICTED
-	syllables = list("rur","ya","cen","rawr","bar","kuk","tek","qat","uk","wu","vuh","tah","tch","schz","auch", \
-	"ist","ein","entch","zwichs","tut","mir","wo","bis","es","vor","nic","gro","lll","enem","zandt","tzch","noch", \
-	"hel","ischt","far","wa","baram","iereng","tech","lach","sam","mak","lich","gen","or","ag","eck","gec","stag","onn", \
-	"bin","ket","jarl","vulf","einech","cresthz","azunein","ghzth")
+	syllables = list("owo","wats dis")
 
 /datum/language/skrell
 	name = "Skrellian"
@@ -210,7 +201,7 @@
 	colour = "skrell"
 	key = "k"
 	flags = RESTRICTED
-	syllables = list("qr","qrr","xuq","qil","quum","xuqm","vol","xrim","zaoo","qu-uu","qix","qoo","zix","*","!")
+	syllables = list("owo","wats dis")
 
 /datum/language/vox
 	name = "Vox-pidgin"
@@ -221,8 +212,7 @@
 	colour = "vox"
 	key = "v"
 	flags = RESTRICTED | WHITELISTED
-	syllables = list("ti","ti","ti","hi","hi","ki","ki","ki","ki","ya","ta","ha","ka","ya", "yi", "chi","cha","kah", \
-	"SKRE","AHK","EHK","RAWK","KRA","AAA","EEE","KI","II","KRI","KA")
+	syllables = list("owo","wats dis")
 
 /datum/language/vox/get_random_name()
 	var/sounds = rand(2, 8)
@@ -243,7 +233,7 @@
 	colour = "diona"
 	key = "q"
 	flags = RESTRICTED
-	syllables = list("hs","zt","kr","st","sh")
+	syllables = list("owo","wats dis")
 
 /datum/language/diona/get_random_name()
 	var/new_name = "[pick(list("To Sleep Beneath", "Wind Over", "Embrace of", "Dreams of", "Witnessing", "To Walk Beneath", "Approaching the", "Glimmer of", "The Ripple of", "Colors of", "The Still of", "Silence of", "Gentle Breeze of", "Glistening Waters under", "Child of", "Blessed Plant-ling of", "Grass-Walker of", "Element of", "Spawn of"))]"
@@ -259,7 +249,7 @@
 	colour = "trinary"
 	key = "5"
 	flags = RESTRICTED | WHITELISTED
-	syllables = list("02011","01222","10100","10210","21012","02011","21200","1002","2001","0002","0012","0012","000","120","121","201","220","10","11","0")
+	syllables = list("o","w","wo","ow")
 
 /datum/language/trinary/get_random_name()
 	var/new_name
@@ -278,7 +268,7 @@
 	colour = "kidan"
 	key = "4"
 	flags = RESTRICTED | WHITELISTED
-	syllables = list("click","clack")
+	syllables = list("owo","wats dis")
 
 /datum/language/kidan/get_random_name()
 	var/new_name = "[pick(list("Vrax", "Krek", "Vriz", "Zrik", "Zarak", "Click", "Zerk", "Drax", "Zven", "Drexx"))]"
@@ -298,7 +288,7 @@
 	colour = "slime"
 	key = "f"
 	flags = RESTRICTED | WHITELISTED
-	syllables = list("blob","plop","pop","bop","boop")
+	syllables = list("owo","wats dis")
 
 /datum/language/grey
 	name = "Psionic Communication"
@@ -343,7 +333,7 @@
 	colour = "drask"
 	key = "%"
 	flags = RESTRICTED | WHITELISTED
-	syllables = list("hoorb","vrrm","ooorm","urrrum","ooum","ee","ffm","hhh","mn","ongg")
+	syllables = list("owo","wats dis")
 
 /datum/language/drask/get_random_name()
 	var/new_name = "[pick(list("Hoorm","Viisk","Saar","Mnoo","Oumn","Fmong","Gnii","Vrrm","Oorm","Dromnn","Ssooumn","Ovv", "Hoorb","Vaar","Gaar","Goom","Ruum","Rumum"))]"
@@ -378,7 +368,7 @@
 	colour = "solcom"
 	key = "1"
 	flags = RESTRICTED
-	syllables = list("tao","shi","tzu","yi","com","be","is","i","op","vi","ed","lec","mo","cle","te","dis","e")
+	syllables = list("owo","wats dis")
 	english_names = 1
 
 /datum/language/human/get_spoken_verb(msg_end)
@@ -397,14 +387,7 @@
 	colour = "say_quote"
 	key = "2"
 	space_chance = 100
-	syllables = list("lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit",
-					 "sed", "do", "eiusmod", "tempor", "incididunt", "ut", "labore", "et", "dolore",
-					 "magna", "aliqua", "ut", "enim", "ad", "minim", "veniam", "quis", "nostrud",
-					 "exercitation", "ullamco", "laboris", "nisi", "ut", "aliquip", "ex", "ea", "commodo",
-					 "consequat", "duis", "aute", "irure", "dolor", "in", "reprehenderit", "in",
-					 "voluptate", "velit", "esse", "cillum", "dolore", "eu", "fugiat", "nulla",
-					 "pariatur", "excepteur", "sint", "occaecat", "cupidatat", "non", "proident", "sunt",
-					 "in", "culpa", "qui", "officia", "deserunt", "mollit", "anim", "id", "est", "laborum")
+	syllables = list("owo","wats dis")
 
 /datum/language/gutter
 	name = "Gutter"
@@ -414,7 +397,7 @@
 	exclaim_verb = "snarls"
 	colour = "gutter"
 	key = "3"
-	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh","gra")
+	syllables = list("owo","wats dis")
 
 /datum/language/clown
 	name = "Clownish"
@@ -436,15 +419,7 @@
 	key = "?"
 	space_chance = 65
 	english_names = 1
-	syllables = list("dyen","bar","bota","vyek","tvo","slov","slav","syen","doup","vah","laz","gloz","yet",
-					 "nyet","da","sky","glav","glaz","netz","doomat","zat","moch","boz",
-					 "comy","vrad","vrade","tay","bli","ay","nov","livn","tolv","glaz","gliz",
-					 "ouy","zet","yevt","dat","botat","nev","novy","vzy","nov","sho","obsh","dasky",
-					 "key","skey","ovsky","skaya","bib","kiev","studen","var","bul","vyan",
-					 "tzion","vaya","myak","gino","volo","olam","miti","nino","menov","perov",
-					 "odasky","trov","niki","ivano","dostov","sokol","oupa","pervom","schel",
-					 "tizan","chka","tagan","dobry","okt","boda","veta","idi","cyk","blyt","hui","na",
-					 "udi","litchki","casa","linka","toly","anatov","vich","vech","vuch","toi","ka","vod")
+	syllables = list("owo","wats dis")
 
 /datum/language/wryn
 	name = "Wryn Hivemind"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -802,7 +802,9 @@
 						playsound(loc, "[dna.species.female_scream_sound]", 80, 1, frequency = get_age_pitch())
 					else
 						playsound(loc, "[dna.species.male_scream_sound]", 80, 1, frequency = get_age_pitch()) //default to male screams if no gender is present.
-
+					if(isvox(M))
+						for(var/mob/living/C in hearers(7, M))
+							C.BecomeDeaf()
 				else
 					message = "<B>[src]</B> makes a very loud noise[M ? " at [M]" : ""]."
 					m_type = 2

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -73,6 +73,9 @@
 /mob/living/carbon/human/tajaran/Initialize(mapload)
 	..(mapload, /datum/species/tajaran)
 
+/mob/living/carbon/human/vulpkanin
+	name += "McCloud"
+
 /mob/living/carbon/human/vulpkanin/Initialize(mapload)
 	..(mapload, /datum/species/vulpkanin)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -27,6 +27,8 @@
 		name = real_name
 		if(mind)
 			mind.name = real_name
+	if(isvulpkanin(src))
+		real_name += "McCloud"
 
 	create_reagents(330)
 
@@ -72,9 +74,6 @@
 
 /mob/living/carbon/human/tajaran/Initialize(mapload)
 	..(mapload, /datum/species/tajaran)
-
-/mob/living/carbon/human/vulpkanin
-	name += "McCloud"
 
 /mob/living/carbon/human/vulpkanin/Initialize(mapload)
 	..(mapload, /datum/species/vulpkanin)

--- a/code/modules/mob/living/carbon/human/species/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/machine.dm
@@ -31,7 +31,7 @@
 	flesh_color = "#AAAAAA"
 
 	blood_color = "#3C3C3C"
-	exotic_blood = "oil"
+	exotic_blood = "beer"
 	blood_damage_type = STAMINA
 
 	//Default styles for created mobs.

--- a/code/modules/mob/living/carbon/human/species/slime.dm
+++ b/code/modules/mob/living/carbon/human/species/slime.dm
@@ -33,7 +33,7 @@
 	reagent_tag = PROCESS_ORG
 
 	blood_color = "#0064C8"
-	exotic_blood = "water"
+	exotic_blood = "lube"
 	blood_damage_type = TOX
 
 	butt_sprite = "slime"
@@ -83,7 +83,7 @@
 			H.update_body()
 	..()
 
-/datum/species/slime/can_hear() // fucking snowflakes 
+/datum/species/slime/can_hear() // fucking snowflakes
 	. = TRUE
 
 /datum/action/innate/slimecolor


### PR DESCRIPTION
See change log for details, As always taking ideas.

:cl:
tweak: all races: all racial languages has been altered to be more fitting for the server.
tweak: Slime:Water blood is now space lube
tweak: IPC:Due to the unpopularity of oil for blood the blood is now beer
tweak: IPC: Can no longer use cryo sleepers and must now be disaembled or EMPed to leave the round.
tweak: Taj:More interactivity with laser pointers.
tweak: Vulpakanin: All vulpakanin will now have 'McCloud' appended to thier names.
tweak: Vox:Vox screams make people deaf.
/:cl: