### PR TITLE
Automatic faster cryodorms when highpop

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -217,6 +217,9 @@
 
 	// Automatic localhost admin disable
 	var/disable_localhost_admin = 0
+	
+	//Automatic cryodorm time
+	var/enable_auto_cryodorm_time = 0
 
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
@@ -640,6 +643,9 @@
 
 				if("disable_karma")
 					config.disable_karma = 1
+
+				if("enable_auto_cryodorm_time")
+					config.enable_auto_cryodorm_time = 1
 
 				if("tick_limit_mc_init")
 					config.tick_limit_mc_init = text2num(value)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -205,7 +205,7 @@
 	var/mob/living/occupant = null       // Person waiting to be despawned.
 	var/orient_right = null       // Flips the sprite.
 	// 15 minutes-ish safe period before being despawned.
-	var/time_till_despawn = 3000 // This is reduced by 90% if a player manually enters cryo
+	var/time_till_despawn  //This is set in take_occupant and move_inside
 	var/willing_time_divisor = 10
 	var/time_entered = 0          // Used to keep track of the safe period.
 	var/obj/item/radio/intercom/announce
@@ -477,7 +477,6 @@
 
 		var/willing = null //We don't want to allow people to be forced into despawning.
 		var/mob/living/M = G.affecting
-		time_till_despawn = initial(time_till_despawn)
 
 		if(!istype(M) || M.stat == DEAD)
 			to_chat(user, "<span class='notice'>Dead people can not be put into cryo.</span>")
@@ -559,7 +558,6 @@
 
 
 	var/willing = null //We don't want to allow people to be forced into despawning.
-	time_till_despawn = initial(time_till_despawn)
 
 	if(L.client)
 		if(alert(L,"Would you like to enter cryosleep?",,"Yes","No") == "Yes")
@@ -593,7 +591,7 @@
 	if(!E)
 		return
 	E.forceMove(src)
-	time_till_despawn = initial(time_till_despawn) / willing_factor
+	time_till_despawn = (((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_factor) //Calculate population to see if we want a quicker despawn time
 	if(orient_right)
 		icon_state = "[occupied_icon_state]-r"
 	else
@@ -675,7 +673,7 @@
 		usr.stop_pulling()
 		usr.forceMove(src)
 		occupant = usr
-		time_till_despawn = initial(time_till_despawn) / willing_time_divisor
+		time_till_despawn = ((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_time_divisor //If there is a high population then we decrease the amount of time it takes to despawn. 
 
 		if(orient_right)
 			icon_state = "[occupied_icon_state]-r"

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -680,7 +680,7 @@
 		usr.stop_pulling()
 		usr.forceMove(src)
 		occupant = usr
-		time_till_despawn = (calculate_time()/ willing_time_divisor) //If there is a high population then we decrease the amount of time it takes to despawn. 
+		time_till_despawn = (calculate_time() / willing_time_divisor) //If there is a high population then we decrease the amount of time it takes to despawn. 
 
 		if(orient_right)
 			icon_state = "[occupied_icon_state]-r"

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -308,6 +308,9 @@
 #define CRYO_DESTROY 0
 #define CRYO_PRESERVE 1
 #define CRYO_OBJECTIVE 2
+/obj/machinery/cryopod/proc/calculate_time()
+	var/calculated_time = (length(GLOB.clients) >= 80) ? 3000 : 9000  //calculated with a D
+	return calculated_time
 
 /obj/machinery/cryopod/proc/should_preserve_item(obj/item/I)
 	for(var/datum/theft_objective/T in control_computer.theft_cache)
@@ -478,7 +481,7 @@
 		var/willing = null //We don't want to allow people to be forced into despawning.
 		var/mob/living/M = G.affecting
 		
-		time_till_despawn = (((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_factor)
+		time_till_despawn = calculate_time()
 		
 		if(!istype(M) || M.stat == DEAD)
 			to_chat(user, "<span class='notice'>Dead people can not be put into cryo.</span>")
@@ -561,7 +564,7 @@
 
 	var/willing = null //We don't want to allow people to be forced into despawning.
 
-	time_till_despawn = (((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_factor)
+	time_till_despawn = calculate_time()
 	
 	if(L.client)
 		if(alert(L,"Would you like to enter cryosleep?",,"Yes","No") == "Yes")
@@ -595,7 +598,7 @@
 	if(!E)
 		return
 	E.forceMove(src)
-	time_till_despawn = (((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_factor) //Calculate population to see if we want a quicker despawn time
+	time_till_despawn = (calculate_time() / willing_factor) //Calculate population to see if we want a quicker despawn time
 	if(orient_right)
 		icon_state = "[occupied_icon_state]-r"
 	else
@@ -677,7 +680,7 @@
 		usr.stop_pulling()
 		usr.forceMove(src)
 		occupant = usr
-		time_till_despawn = ((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_time_divisor //If there is a high population then we decrease the amount of time it takes to despawn. 
+		time_till_despawn = (calculate_time()/ willing_time_divisor) //If there is a high population then we decrease the amount of time it takes to despawn. 
 
 		if(orient_right)
 			icon_state = "[occupied_icon_state]-r"

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -309,7 +309,13 @@
 #define CRYO_PRESERVE 1
 #define CRYO_OBJECTIVE 2
 /obj/machinery/cryopod/proc/calculate_time()
-	var/calculated_time = (length(GLOB.clients) >= 80) ? 3000 : 9000  //calculated with a D
+	var/calculated_time //calculated with a D
+	
+	if(config.enable_auto_cryodorm_time)
+		calculated_time  = (length(GLOB.clients) >= 80) ? 3000 : 9000  
+	else
+		calculated_time = 9000
+
 	return calculated_time
 
 /obj/machinery/cryopod/proc/should_preserve_item(obj/item/I)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -477,7 +477,9 @@
 
 		var/willing = null //We don't want to allow people to be forced into despawning.
 		var/mob/living/M = G.affecting
-
+		
+		time_till_despawn = (((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_factor)
+		
 		if(!istype(M) || M.stat == DEAD)
 			to_chat(user, "<span class='notice'>Dead people can not be put into cryo.</span>")
 			return
@@ -559,6 +561,8 @@
 
 	var/willing = null //We don't want to allow people to be forced into despawning.
 
+	time_till_despawn = (((length(GLOB.clients) >= 80) ? 3000 : 9000) / willing_factor)
+	
 	if(L.client)
 		if(alert(L,"Would you like to enter cryosleep?",,"Yes","No") == "Yes")
 			if(!L) return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -205,7 +205,7 @@
 	var/mob/living/occupant = null       // Person waiting to be despawned.
 	var/orient_right = null       // Flips the sprite.
 	// 15 minutes-ish safe period before being despawned.
-	var/time_till_despawn = 9000 // This is reduced by 90% if a player manually enters cryo
+	var/time_till_despawn = 3000 // This is reduced by 90% if a player manually enters cryo
 	var/willing_time_divisor = 10
 	var/time_entered = 0          // Used to keep track of the safe period.
 	var/obj/item/radio/intercom/announce

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -400,3 +400,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ## Uncomment to disable automatic admin for localhost
 #DISABLE_LOCALHOST_ADMIN
+
+##Uncomment to enable quicker cryodorm despawns on high pop
+#ENABLE_AUTO_CRYODORM_TIME


### PR DESCRIPTION
**What does this PR do:**
If playercount is above 80, cryo takes 5 minutes to move people to long term storage. Else, 15. Willing occupants will be faster as usual. Calculated when someone enters.

:cl:
tweak: When there is 80 or more players, the time to move a player to long term storage is reduced by 2/3rds. From 15 minutes to 5 minutes. Willing occupants will continue be faster. This is calculated at the time the person enters a cryopod.
/:cl:

