### PR TITLE
Suicide Refactor

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -26,6 +26,7 @@
 #define TOXLOSS 4
 #define OXYLOSS 8
 #define SHAME 16
+#define OBLITERATION 32
 
 //Bitflags defining which status effects could be or are inflicted on a mob
 #define CANSTUN		1

--- a/code/game/gamemodes/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/changeling/powers/mutations.dm
@@ -220,7 +220,7 @@
 
 /obj/item/gun/magic/tentacle/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] coils [src] tightly around [user.p_their()] neck! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (OXYLOSS)
+	return OXYLOSS
 
 /obj/item/ammo_casing/magic/tentacle
 	name = "tentacle"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -16,6 +16,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	var/inhand_y_dimension = 32
 
 	can_be_hit = FALSE
+	suicidal_hands = TRUE
 
 	var/r_speed = 1.0
 	var/health = null
@@ -145,16 +146,6 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 /obj/item/blob_act()
 	qdel(src)
 
-//user: The mob that is suiciding
-//damagetype: The type of damage the item will inflict on the user
-//BRUTELOSS = 1
-//FIRELOSS = 2
-//TOXLOSS = 4
-//OXYLOSS = 8
-//Output a creative message and then return the damagetype done
-/obj/item/proc/suicide_act(mob/user)
-	return
-
 /obj/item/verb/move_to_top()
 	set name = "Move To Top"
 	set category = null
@@ -258,7 +249,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/goonstation/effects/fire.d
 	add_fingerprint(user)
 	if(pickup(user)) // Pickup succeeded
 		user.put_in_active_hand(src)
-	
+
 	return 1
 
 /obj/item/attack_alien(mob/user as mob)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -23,7 +23,7 @@
 
 /obj/item/toy/crayon/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is jamming the [name] up [user.p_their()] nose and into [user.p_their()] brain. It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (BRUTELOSS|OXYLOSS)
+	return BRUTELOSS|OXYLOSS
 
 /obj/item/toy/crayon/New()
 	..()

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -19,7 +19,7 @@
 
 /obj/item/instrument/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] begins to play 'Gloomy Sunday'! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/instrument/Initialize(mapload)
 	song.tempo = song.sanitize_tempo(song.tempo) // tick_lag isn't set when the map is loaded

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -231,7 +231,7 @@
 /obj/item/toy/katana/suicide_act(mob/user)
 	var/dmsg = pick("[user] tries to stab \the [src] into [user.p_their()] abdomen, but it shatters! [user.p_they(TRUE)] look[user.p_s()] as if [user.p_they()] might die from the shame.","[user] tries to stab \the [src] into [user.p_their()] abdomen, but \the [src] bends and breaks in half! [user.p_they(TRUE)] look[user.p_s()] as if [user.p_they()] might die from the shame.","[user] tries to slice [user.p_their()] own throat, but the plastic blade has no sharpness, causing [user.p_them()] to lose [user.p_their()] balance, slip over, and break [user.p_their()] neck with a loud snap!")
 	user.visible_message("<span class='suicide'>[dmsg] It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 
 /*
@@ -1377,7 +1377,7 @@ obj/item/toy/cards/deck/syndicate/black
 /obj/item/toy/russian_revolver/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] quickly loads six bullets into [src]'s cylinder and points it at [user.p_their()] head before pulling the trigger! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	playsound(loc, 'sound/weapons/gunshots/gunshot_strong.ogg', 50, 1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/toy/russian_revolver/New()
 	spin_cylinder()

--- a/code/game/objects/items/weapons/courtroom.dm
+++ b/code/game/objects/items/weapons/courtroom.dm
@@ -16,7 +16,7 @@
 /obj/item/gavelhammer/suicide_act(mob/user)
 	user.visible_message("<span class='warning'>[user] has sentenced [user.p_them()]self to death with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	playsound(loc, 'sound/items/gavel.ogg', 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/gavelblock
 	name = "gavel block"

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -283,7 +283,7 @@
 	user.visible_message("<span class='danger'>[user] is putting the live paddles on [user.p_their()] chest! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	defib.deductcharge(revivecost)
 	playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)
-	return (OXYLOSS)
+	return OXYLOSS
 
 /obj/item/twohanded/shockpaddles/dropped(mob/user as mob)
 	if(user)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -116,6 +116,7 @@
 	sleep(10)
 	prime()
 	user.gib()
+	return OBLITERATION
 
 /obj/item/grenade/plastic/update_icon()
 	if(nadeassembly)

--- a/code/game/objects/items/weapons/garrote.dm
+++ b/code/game/objects/items/weapons/garrote.dm
@@ -168,4 +168,4 @@
 /obj/item/twohanded/garrote/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is wrapping the [src] around [user.p_their()] neck and pulling the handles! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	playsound(src.loc, 'sound/weapons/cablecuff.ogg', 15, 1, -1)
-	return (OXYLOSS)
+	return OXYLOSS

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -15,7 +15,7 @@
 
 /obj/item/nullrod/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is killing [user.p_them()]self with \the [src.name]! It looks like [user.p_theyre()] trying to get closer to god!</span>")
-	return (BRUTELOSS|FIRELOSS)
+	return BRUTELOSS|FIRELOSS
 
 /obj/item/nullrod/attack(mob/M, mob/living/carbon/user)
 	..()

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -121,7 +121,7 @@
 	user.visible_message(pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>", \
 						"<span class='suicide'>[user] is slitting [user.p_their()] throat with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>", \
 						"<span class='suicide'>[user] is slitting [user.p_their()] stomach open with the [name]! It looks like [user.p_theyre()] trying to commit seppuku.</span>"))
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/kitchen/knife/plastic
 	name = "plastic knife"

--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -35,7 +35,7 @@
 /obj/item/restraints/legcuffs/beartrap/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is sticking [user.p_their()] head in the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/restraints/legcuffs/beartrap/attack_self(mob/user)
 	..()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -16,7 +16,7 @@
 /obj/item/melee/energy/suicide_act(mob/user)
 	user.visible_message(pick("<span class='suicide'>[user] is slitting [user.p_their()] stomach open with the [name]! It looks like [user.p_theyre()] trying to commit seppuku.</span>", \
 						"<span class='suicide'>[user] is falling on the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>"))
-	return (BRUTELOSS|FIRELOSS)
+	return BRUTELOSS|FIRELOSS
 
 /obj/item/melee/energy/attack_self(mob/living/carbon/user)
 	if(user.disabilities & CLUMSY && prob(50))
@@ -81,7 +81,7 @@
 
 /obj/item/melee/energy/axe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swings the [name] towards [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (BRUTELOSS|FIRELOSS)
+	return BRUTELOSS|FIRELOSS
 
 /obj/item/melee/energy/sword
 	name = "energy sword"

--- a/code/game/objects/items/weapons/melee/misc.dm
+++ b/code/game/objects/items/weapons/melee/misc.dm
@@ -17,8 +17,8 @@
 
 
 /obj/item/melee/chainofcommand/suicide_act(mob/user)
-		to_chat(viewers(user), "<span class='suicide'>[user] is strangling [user.p_them()]self with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-		return (OXYLOSS)
+	to_chat(viewers(user), "<span class='suicide'>[user] is strangling [user.p_them()]self with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
+	return OXYLOSS
 
 /obj/item/melee/rapier
 	name = "captain's rapier"

--- a/code/game/objects/items/weapons/shards.dm
+++ b/code/game/objects/items/weapons/shards.dm
@@ -18,7 +18,7 @@
 /obj/item/shard/suicide_act(mob/user)
 		to_chat(viewers(user), pick("<span class='danger'>[user] is slitting [user.p_their()] wrists with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>",
 									"<span class='danger'>[user] is slitting [user.p_their()] throat with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>"))
-		return (BRUTELOSS)
+		return BRUTELOSS
 
 /obj/item/shard/New()
 	..()

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -42,7 +42,7 @@
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts the [name] over [user.p_their()] head and starts chomping at the insides! Disgusting!</span>")
 	playsound(loc, 'sound/items/eatfood.ogg', 50, 1, -1)
-	return (TOXLOSS)
+	return TOXLOSS
 
 /obj/item/storage/bag/trash/update_icon()
 	if(contents.len == 0)

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -10,7 +10,7 @@
 	var/deity_name = "Christ"
 
 /obj/item/storage/bible/suicide_act(mob/user)
-	to_chat(viewers(user), "<span class='warning'><b>[user] stares into [src.name] and attempts to trascend understanding of the universe!</b></span>")
+	to_chat(viewers(user), "<span class='warning'><b>[user] stares into [src.name] and attempts to transcend understanding of the universe!</b></span>")
 	user.dust()
 	return OBLITERATION
 

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -9,9 +9,10 @@
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 
-	suicide_act(mob/user)
-		to_chat(viewers(user), "<span class='warning'><b>[user] stares into [src.name] and attempts to trascend understanding of the universe!</b></span>")
-		return (user.dust())
+/obj/item/storage/bible/suicide_act(mob/user)
+	to_chat(viewers(user), "<span class='warning'><b>[user] stares into [src.name] and attempts to trascend understanding of the universe!</b></span>")
+	user.dust()
+	return OBLITERATION
 
 
 /obj/item/storage/bible/booze

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -18,7 +18,7 @@
 
 /obj/item/melee/baton/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting the live [name] in [user.p_their()] mouth! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (FIRELOSS)
+	return FIRELOSS
 
 /obj/item/melee/baton/New()
 	..()

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -32,7 +32,7 @@
 /obj/item/wrench/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is beating [user.p_them()]self to death with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/weapons/genhit.ogg', 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/wrench/cyborg
 	name = "automatic wrench"
@@ -76,7 +76,7 @@
 
 /obj/item/wrench/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is pressing [src] against [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!")
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/wrench/medical
 	name = "medical wrench"
@@ -113,7 +113,7 @@
 		return
 
 	user.dust()
-	return OXYLOSS
+	return OBLITERATION
 
 //Screwdriver
 /obj/item/screwdriver
@@ -143,7 +143,7 @@
 
 /obj/item/screwdriver/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is stabbing [src] into [user.p_their()] [pick("temple", "heart")]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return(BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/screwdriver/New(loc, var/param_color = null)
 	..()
@@ -199,7 +199,7 @@
 
 /obj/item/screwdriver/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return(BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/screwdriver/power/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/items/change_drill.ogg', 50, 1)
@@ -256,7 +256,7 @@
 /obj/item/wirecutters/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is cutting at [user.p_their()] arteries with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, usesound, 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/wirecutters/brass
 	name = "brass wirecutters"
@@ -299,7 +299,7 @@
 		if(head)
 			head.droplimb(0, DROPLIMB_BLUNT, FALSE, TRUE)
 			playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/wirecutters/power/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
@@ -349,7 +349,7 @@
 
 /obj/item/weldingtool/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] welds [user.p_their()] every orifice closed! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return (FIRELOSS)
+	return FIRELOSS
 
 /obj/item/weldingtool/proc/update_torch()
 	overlays.Cut()
@@ -738,7 +738,7 @@ obj/item/weldingtool/experimental/process()
 /obj/item/crowbar/power/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src]. It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/crowbar/power/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -797,7 +797,7 @@
 
 /obj/item/twohanded/pitchfork/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] impales \himself in \his abdomen with [src]! It looks like \he's trying to commit suicide...</span>")
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/twohanded/pitchfork/demonic/pickup(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -12,8 +12,8 @@
 
 
 /obj/item/banhammer/suicide_act(mob/user)
-		to_chat(viewers(user), "<span class='suicide'>[user] is hitting [user.p_them()]self with the [src.name]! It looks like [user.p_theyre()] trying to ban [user.p_them()]self from life.</span>")
-		return (BRUTELOSS|FIRELOSS|TOXLOSS|OXYLOSS)
+	to_chat(viewers(user), "<span class='suicide'>[user] is hitting [user.p_them()]self with the [src.name]! It looks like [user.p_theyre()] trying to ban [user.p_them()]self from life.</span>")
+	return BRUTELOSS|FIRELOSS|TOXLOSS|OXYLOSS
 
 /obj/item/sord
 	name = "\improper SORD"
@@ -49,7 +49,7 @@
 
 /obj/item/claymore/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is falling on the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return(BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/claymore/ceremonial
 	name = "ceremonial claymore"
@@ -76,7 +76,7 @@
 
 /obj/item/katana/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku.</span>")
-	return(BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/harpoon
 	name = "harpoon"

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -29,6 +29,7 @@
 
 	var/on_blueprints = FALSE //Are we visible on the station blueprints at roundstart?
 	var/force_blueprints = FALSE //forces the obj to be on the blueprints, regardless of when it was created.
+	var/suicidal_hands = FALSE // Does it requires you to hold it to commit suicide with it?
 
 /obj/New()
 	..()
@@ -75,6 +76,16 @@
 	set waitfor = 0
 	processing_objects.Remove(src)
 	return 0
+
+//user: The mob that is suiciding
+//damagetype: The type of damage the item will inflict on the user
+//BRUTELOSS = 1
+//FIRELOSS = 2
+//TOXLOSS = 4
+//OXYLOSS = 8
+//Output a creative message and then return the damagetype done
+/obj/proc/suicide_act(mob/user)
+	return FALSE
 
 /obj/assume_air(datum/gas_mixture/giver)
 	if(loc)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -83,6 +83,9 @@
 //FIRELOSS = 2
 //TOXLOSS = 4
 //OXYLOSS = 8
+//SHAME = 16
+//OBLITERATION = 32
+
 //Output a creative message and then return the damagetype done
 /obj/proc/suicide_act(mob/user)
 	return FALSE

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -55,8 +55,6 @@
 	be_suicidal()
 
 /mob/living/carbon/human/proc/be_suicidal(forced = FALSE)
-	set hidden = 1
-
 	if(stat == DEAD)
 		to_chat(src, "You're already dead!")
 		return

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -52,6 +52,11 @@
 /mob/living/carbon/human/verb/suicide()
 	set hidden = 1
 
+	be_suicidal()
+
+/mob/living/carbon/human/proc/be_suicidal(forced = FALSE)
+	set hidden = 1
+
 	if(stat == DEAD)
 		to_chat(src, "You're already dead!")
 		return
@@ -69,20 +74,39 @@
 		to_chat(src, "You're already committing suicide! Be patient!")
 		return
 
-	var/confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
 
-	if(confirm == "Yes")
-		suiciding = 1
+	var/confirm = null
+	if(!forced)
+		confirm = alert("Are you sure you want to commit suicide?", "Confirm Suicide", "Yes", "No")
+
+	if(forced || (confirm == "Yes"))
+		suiciding = TRUE
 		var/obj/item/held_item = get_active_hand()
 		if(held_item)
 			var/damagetype = held_item.suicide_act(src)
 			if(damagetype)
 				if(damagetype & SHAME)
 					adjustStaminaLoss(200)
-					suiciding = 0
+					suiciding = FALSE
+					return
+				if(damagetype & OBLITERATION) // Does it gib or something? Don't deal damage
 					return
 				do_suicide(damagetype, held_item)
 				return
+		else
+			for(var/obj/O in orange(1, src))
+				if(O.suicidal_hands)
+					continue
+				var/damagetype = O.suicide_act(src)
+				if(damagetype)
+					if(damagetype & SHAME)
+						adjustStaminaLoss(200)
+						suiciding = FALSE
+						return
+					if(damagetype & OBLITERATION)
+						return
+					do_suicide(damagetype, O)
+					return
 
 		to_chat(viewers(src), "<span class='danger'>[src] [replacetext(pick(dna.species.suicide_messages), "their", p_their())] It looks like [p_theyre()] trying to commit suicide.</span>")
 		do_suicide(0)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -491,5 +491,6 @@
 /obj/item/clothing/mask/cursedclown/suicide_act(mob/user)
 	user.visible_message("<span class='danger'>[user] gazes into the eyes of [src]. [src] gazes back!</span>")
 	spawn(10)
-		user.gib()
-	return BRUTELOSS
+		if(user)
+			user.gib()
+	return OBLITERATION

--- a/code/modules/customitems/item_defines.dm
+++ b/code/modules/customitems/item_defines.dm
@@ -154,7 +154,7 @@
 
 /obj/item/fluff/rsik_katana/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] tries to stab [src] into [user.p_their()] stomach! Except [src] shatters! [user.p_they(TRUE)] look[user.p_s()] as if [user.p_they()] might die from the shame.</span>")
-	return(BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/crowbar/fluff/zelda_creedy_1 // Zomgponies: Griffin Rowley
 	name = "Zelda's Crowbar"

--- a/code/modules/fish/fish_items.dm
+++ b/code/modules/fish/fish_items.dm
@@ -25,9 +25,9 @@
 	throw_speed = 3
 	throw_range = 7
 
-	suicide_act(mob/user)			//"A tiny net is a death sentence: it's a net and it's tiny!" https://www.youtube.com/watch?v=FCI9Y4VGCVw
-		to_chat(viewers(user), "<span class='warning'>[user] places the [src.name] on top of [user.p_their()] head, [user.p_their()] fingers tangled in the netting! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-		return(OXYLOSS)
+/obj/item/fish_net/suicide_act(mob/user)			//"A tiny net is a death sentence: it's a net and it's tiny!" https://www.youtube.com/watch?v=FCI9Y4VGCVw
+	to_chat(viewers(user), "<span class='warning'>[user] places the [src.name] on top of [user.p_their()] head, [user.p_their()] fingers tangled in the netting! It looks like [user.p_theyre()] trying to commit suicide.</span>")
+	return OXYLOSS
 
 /obj/item/fishfood
 	name = "fish food can"
@@ -51,9 +51,9 @@
 	throw_range = 7
 	attack_verb = list("scrubbed", "brushed", "scraped")
 
-	suicide_act(mob/user)
-		to_chat(viewers(user), "<span class='warning'>[user] is vigorously scrubbing [user.p_them()]self raw with the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-		return(BRUTELOSS|FIRELOSS)
+/obj/item/tank_brush/suicide_act(mob/user)
+	to_chat(viewers(user), "<span class='warning'>[user] is vigorously scrubbing [user.p_them()]self raw with the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
+	return BRUTELOSS|FIRELOSS
 
 //////////////////////////////////////////////
 //				Fish Items					//

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -131,7 +131,7 @@
 	user.name = newname
 	user.real_name = newname
 	desc = "Salt. From dead crew, presumably."
-	return (TOXLOSS)
+	return TOXLOSS
 
 /obj/item/reagent_containers/food/condiment/peppermill
 	name = "pepper mill"

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -24,6 +24,18 @@
 	idle_power_usage = 2
 	active_power_usage = 500
 
+/obj/machinery/gibber/suicide_act(mob/user)
+	if(occupant || locked)
+		return FALSE
+	user.visible_message("<span class='danger'>[user] climbs into [src] and turns it on!</b></span>")
+	user.Stun(10)
+	user.forceMove(src)
+	occupant = user
+	update_icon()
+	feedinTopanim()
+	addtimer(CALLBACK(src, .proc/startgibbing, user), 33)
+	return OBLITERATION
+
 /obj/machinery/gibber/Destroy()
 	if(contents.len)
 		for(var/atom/movable/A in contents)
@@ -145,7 +157,7 @@
 	set name = "Empty Gibber"
 	set src in oview(1)
 
-	if(usr.stat != CONSCIOUS)
+	if(usr.incapacitated())
 		return
 
 	go_out()

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -30,13 +30,13 @@
 	playsound(loc, 'sound/items/bikehorn.ogg', 50, 1, -1)
 	sleep(25)
 	if(!user)
-		return (OXYLOSS)
+		return OXYLOSS
 	user.say("BANG!")
 	sleep(25)
 	if(!user)
-		return (OXYLOSS)
+		return OXYLOSS
 	user.visible_message("<B>[user]</B> laughs so hard [user.p_they()] begin[user.p_s()] to suffocate!")
-	return (OXYLOSS)
+	return OXYLOSS
 
 /obj/item/grown/bananapeel
 	seed = /obj/item/seeds/banana
@@ -52,7 +52,7 @@
 /obj/item/grown/bananapeel/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is deliberately slipping on the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	playsound(loc, 'sound/misc/slip.ogg', 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 
 // Mimana - invisible sprites are totally a feature!

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -24,7 +24,7 @@
 /obj/item/seeds/kudzu/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swallows the pack of kudzu seeds! It looks like [user.p_theyre()] trying to commit suicide..</span>")
 	plant(user)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/seeds/kudzu/proc/plant(mob/user)
 	if(istype(user.loc, /turf/space))

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -45,7 +45,7 @@
 
 /obj/item/grown/nettle/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is eating some of the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (BRUTELOSS|TOXLOSS)
+	return BRUTELOSS|TOXLOSS
 
 /obj/item/grown/nettle/pickup(mob/living/user)
 	..()

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -34,7 +34,7 @@
 
 /obj/item/reagent_containers/spray/weedspray/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is huffing the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (TOXLOSS)
+	return TOXLOSS
 
 /obj/item/reagent_containers/spray/pestspray // -- Skie
 	desc = "It's some pest eliminator spray! <I>Do not inhale!</I>"
@@ -56,7 +56,7 @@
 
 /obj/item/reagent_containers/spray/pestspray/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is huffing the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (TOXLOSS)
+	return TOXLOSS
 
 /obj/item/cultivator
 	name = "cultivator"
@@ -91,7 +91,7 @@
 /obj/item/hatchet/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is chopping at [user.p_them()]self with the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/hatchet/unathiknife
 	name = "duelling knife"
@@ -126,7 +126,7 @@
 		if(affecting)
 			affecting.droplimb(1, DROPLIMB_SHARP)
 			playsound(loc, pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg'), 50, 1, -1)
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/scythe/pre_attackby(atom/A, mob/living/user, params)
 	if(swiping || !istype(A, /obj/structure/spacevine) || get_turf(A) == get_turf(user))

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -59,7 +59,7 @@
 	if(!gibbed && deathgasp_on_death)
 		emote("deathgasp")
 
-	if(suiciding)
+	if(mind && suiciding)
 		mind.suicided = TRUE
 	clear_fullscreens()
 	update_sight()

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -104,7 +104,7 @@
 		H.visible_message("<span class='suicide'>[H] holds up a contract claiming his soul, then immediately catches fire.  It looks like \he's trying to commit suicide!</span>")
 		H.adjust_fire_stacks(20)
 		H.IgniteMob()
-		return(FIRELOSS)
+		return FIRELOSS
 	else
 		..()
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -26,7 +26,7 @@
 
 /obj/item/pen/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='suicide'>[user] starts scribbling numbers over [user.p_them()]self with the [name]! It looks like [user.p_theyre()] trying to commit sudoku.</span>")
-	return (BRUTELOSS)
+	return BRUTELOSS
 
 /obj/item/pen/blue
 	name = "blue-ink pen"

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -15,7 +15,7 @@
 
 /obj/item/stamp/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] stamps 'VOID' on [user.p_their()] forehead, then promptly falls over, dead.</span>")
-	return (OXYLOSS)
+	return OXYLOSS
 
 /obj/item/stamp/qm
 	name = "Quartermaster's rubber stamp"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -504,7 +504,7 @@ var/global/list/datum/stack_recipe/cable_coil_recipes = list(
 		user.visible_message("<span class='suicide'>[user] is making a noose with the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
 	else
 		user.visible_message("<span class='suicide'>[user] is strangling [user.p_them()]self with the [name]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return(OXYLOSS)
+	return OXYLOSS
 
 /obj/item/stack/cable_coil/New(loc, length = MAXCOIL, paramcolor = null)
 	..()

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -90,7 +90,7 @@
 
 /obj/item/stock_parts/cell/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='suicide'>[user] is licking the electrodes of the [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>")
-	return (FIRELOSS)
+	return FIRELOSS
 
 /obj/item/stock_parts/cell/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/reagent_containers/syringe))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -154,14 +154,14 @@
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 			power_supply.use(shot.e_cost)
 			update_icon()
-			return(FIRELOSS)
+			return FIRELOSS
 		else
 			user.visible_message("<span class='suicide'>[user] panics and starts choking to death!</span>")
-			return(OXYLOSS)
+			return OXYLOSS
 	else
 		user.visible_message("<span class='suicide'>[user] is pretending to blow [user.p_their()] brains out with the [name]! It looks like [user.p_theyre()] trying to commit suicide!</b></span>")
 		playsound(loc, 'sound/weapons/empty.ogg', 50, 1, -1)
-		return (OXYLOSS)
+		return OXYLOSS
 
 /obj/item/gun/energy/vv_edit_var(var_name, var_value)
 	switch(var_name)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -137,7 +137,7 @@
 		playsound(loc, 'sound/weapons/kenetic_reload.ogg', 60, 1)
 	user.visible_message("<span class='suicide'>[user] cocks the [name] and pretends to blow [user.p_their()] brains out! It looks like [user.p_theyre()] trying to commit suicide!</b></span>")
 	shoot_live_shot()
-	return (OXYLOSS)
+	return OXYLOSS
 
 // Plasma Cutters //
 /obj/item/gun/energy/plasmacutter

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -55,7 +55,7 @@
 /obj/item/gun/projectile/proc/can_reload()
 	return !magazine
 
-/obj/item/gun/projectile/proc/reload(obj/item/ammo_box/magazine/AM, mob/user as mob)	
+/obj/item/gun/projectile/proc/reload(obj/item/ammo_box/magazine/AM, mob/user as mob)
 		user.remove_from_mob(AM)
 		magazine = AM
 		magazine.loc = src
@@ -81,7 +81,7 @@
 				to_chat(user, "<span class='notice'>You perform a tactical reload on \the [src], replacing the magazine.</span>")
 				magazine.loc = get_turf(loc)
 				magazine.update_icon()
-				magazine = null		
+				magazine = null
 				reload(AM, user)
 				return TRUE
 		else
@@ -165,14 +165,14 @@
 		if(user.l_hand == src || user.r_hand == src)
 			process_fire(user, user, 0, zone_override = "head")
 			user.visible_message("<span class='suicide'>[user] blows [user.p_their()] brains out with the [name]!</span>")
-			return(BRUTELOSS)
+			return BRUTELOSS
 		else
 			user.visible_message("<span class='suicide'>[user] panics and starts choking to death!</span>")
-			return(OXYLOSS)
+			return OXYLOSS
 	else
 		user.visible_message("<span class='suicide'>[user] is pretending to blow [user.p_their()] brains out with the [name]! It looks like [user.p_theyre()] trying to commit suicide!</b></span>")
 		playsound(loc, 'sound/weapons/empty.ogg', 50, 1, -1)
-		return (OXYLOSS)
+		return OXYLOSS
 
 /obj/item/gun/projectile/proc/sawoff(mob/user)
 	if(sawn_state == SAWN_OFF)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -57,10 +57,10 @@
 	origin_tech = "materials=1;biotech=1"
 	attack_verb = list("drilled")
 
-	suicide_act(mob/user)
-		to_chat(viewers(user), pick("<span class='suicide'>[user] is pressing [src] to [user.p_their()] temple and activating it! It looks like [user.p_theyre()] trying to commit suicide.</span>",
-							"<span class='suicide'>[user] is pressing [src] to [user.p_their()] chest and activating it! It looks like [user.p_theyre()] trying to commit suicide.</span>"))
-		return (BRUTELOSS)
+/obj/item/surgicaldrill/suicide_act(mob/user)
+	to_chat(viewers(user), pick("<span class='suicide'>[user] is pressing [src] to [user.p_their()] temple and activating it! It looks like [user.p_theyre()] trying to commit suicide.</span>",
+						"<span class='suicide'>[user] is pressing [src] to [user.p_their()] chest and activating it! It looks like [user.p_theyre()] trying to commit suicide.</span>"))
+	return BRUTELOSS
 
 /obj/item/surgicaldrill/augment
 	desc = "Effectively a small power drill contained within your arm, edges dulled to prevent tissue damage. May or may not pierce the heavens."
@@ -87,11 +87,11 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
-	suicide_act(mob/user)
-		to_chat(viewers(user), pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>",
-							"<span class='suicide'>[user] is slitting [user.p_their()] throat with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>",
-							"<span class='suicide'>[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku.</span>"))
-		return (BRUTELOSS)
+/obj/item/scalpel/suicide_act(mob/user)
+	to_chat(viewers(user), pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>",
+						"<span class='suicide'>[user] is slitting [user.p_their()] throat with [src]! It looks like [user.p_theyre()] trying to commit suicide.</span>",
+						"<span class='suicide'>[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku.</span>"))
+	return BRUTELOSS
 
 
 /obj/item/scalpel/augment


### PR DESCRIPTION
Refactors suicide a bit and allow for further expanded functionality with more items.

the boring stuff;
- Cleaned up `suicide_act` code to account for a few runtime potentials
- Made all `suicide_acts`s absolute pathed and got rid of the ugly parenthesis in all their returns

Fix:
- Fixes some suicides gibbing/dusting you while also dealing damage to you.
  - This was accomplished by adding a new return value, `OBLITERATE` to suicide; if something returns this, then no damage will be dealt to the mob. Reserved for things that gib you or do special things to you

Refactor:
- Human suicide verb calls a `be_suicidal` proc that has the option to be forced. If admins want to make everyone in the world commit suicide at once and not give players the popup of "are you sure you want to commit suicide?", they absolutely can. May be potentially useful for diseases or other things in the future.

Feature:
- Can now suicide with a wider range of objects; this allows you to potentially suicide with, say, a window, chair, or what have you; objects that you can't necessarily pick up. Items that you can pick up are excluded from this; this is meant more for machines, structures, and the likes.
- Gibber has a `suicide_act`. It makes you climb into it and automatically turn it on.

:cl: Fox McCloud
fix: Fixes some suicides dealing damage and gibbing you at the same time
add: Allows you to suicide with more object types. Currently the only new object type you can suicide with is the gibber
/:cl: