### PR TITLE
Spontaneous combustion now has a minimal stack of 1 it applies

### DIFF
--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -45,13 +45,13 @@ Bonus
 	return
 
 /datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
-	var/get_stacks = (sqrtor0(20+A.totalStageSpeed()*2))-(sqrtor0(16+A.totalStealth()))
+	var/get_stacks = max((sqrtor0(20 + A.totalStageSpeed() * 2)) - (sqrtor0(16 + A.totalStealth())), 1)
 	M.adjust_fire_stacks(get_stacks)
-	M.adjustFireLoss(get_stacks/2)
+	M.adjustFireLoss(get_stacks / 2)
 	return 1
 
 /datum/symptom/fire/proc/Firestacks_stage_5(mob/living/M, datum/disease/advance/A)
-	var/get_stacks = (sqrtor0(20+A.totalStageSpeed()*3))-(sqrtor0(16+A.totalStealth()))
+	var/get_stacks = max((sqrtor0(20 + A.totalStageSpeed() * 3))-(sqrtor0(16 + A.totalStealth())), 1)
 	M.adjust_fire_stacks(get_stacks)
 	M.adjustFireLoss(get_stacks)
 	return 1

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -47,7 +47,7 @@ Bonus
 /datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
 	var/get_stacks = max((sqrtor0(20 + A.totalStageSpeed() * 2)) - (sqrtor0(16 + A.totalStealth())), 1)
 	M.adjust_fire_stacks(get_stacks)
-	M.adjustFireLoss(get_stacks / 2)
+	M.adjustFireLoss(get_stacks * 0.5)
 	return 1
 
 /datum/symptom/fire/proc/Firestacks_stage_5(mob/living/M, datum/disease/advance/A)


### PR DESCRIPTION
**What does this PR do:**
Gives spontaneous combustion a minimum stack size of 1. Preventing the fire virus to make you wet instead.
fixes: #11152

**Changelog:**
:cl:
tweak: Spontaneous combustion now has a minimum stacksize of 1. No more getting wet from the fire virus
/:cl:

