### PR TITLE
Wrapping big objects and welding lockers now takes time

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -281,6 +281,8 @@
 		if(!WT.remove_fuel(0,user))
 			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
+		if(!do_after_once(usr, 15, target = target ))
+			return
 		welded = !welded
 		update_icon()
 		for(var/mob/M in viewers(src))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -281,7 +281,7 @@
 		if(!WT.remove_fuel(0, user))
 			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
-		if(!do_after_once(usr, 15, target = target))
+		if(!do_after_once(user, 15, target = src))
 			return
 		welded = !welded
 		update_icon()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -278,10 +278,10 @@
 		if(src == user.loc)
 			to_chat(user, "<span class='notice'>You can not [welded?"unweld":"weld"] the locker from inside.</span>")
 			return
-		if(!WT.remove_fuel(0,user))
+		if(!WT.remove_fuel(0, user))
 			to_chat(user, "<span class='notice'>You need more welding fuel to complete this task.</span>")
 			return
-		if(!do_after_once(usr, 15, target = target ))
+		if(!do_after_once(usr, 15, target = target))
 			return
 		welded = !welded
 		update_icon()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -177,7 +177,9 @@
 		var/obj/structure/closet/crate/O = target
 		if(O.opened)
 			return
-		if(use(3))
+		if(amount >= 3 && do_after_once(src, 15, target = target))
+			if(O.opened || !use(3))
+				return
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
 			P.icon_state = "deliverycrate"
 			P.wrapped = O
@@ -189,7 +191,9 @@
 		var/obj/structure/closet/O = target
 		if(O.opened)
 			return
-		if(use(3))
+		if(amount >= 3 && do_after_once(src, 15, target = target))
+			if(O.opened || !use(3))
+				return
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
 			P.wrapped = O
 			P.init_welded = O.welded

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -177,7 +177,7 @@
 		var/obj/structure/closet/crate/O = target
 		if(O.opened)
 			return
-		if(amount >= 3 && do_after_once(usr, 15, target = target))
+		if(amount >= 3 && do_after_once(user, 15, target = target))
 			if(O.opened || !use(3))
 				return
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
@@ -191,7 +191,7 @@
 		var/obj/structure/closet/O = target
 		if(O.opened)
 			return
-		if(amount >= 3 && do_after_once(usr, 15, target = target))
+		if(amount >= 3 && do_after_once(user, 15, target = target))
 			if(O.opened || !use(3))
 				return
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -177,7 +177,7 @@
 		var/obj/structure/closet/crate/O = target
 		if(O.opened)
 			return
-		if(amount >= 3 && do_after_once(src, 15, target = target))
+		if(amount >= 3 && do_after_once(usr, 15, target = target))
 			if(O.opened || !use(3))
 				return
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
@@ -191,7 +191,7 @@
 		var/obj/structure/closet/O = target
 		if(O.opened)
 			return
-		if(amount >= 3 && do_after_once(src, 15, target = target))
+		if(amount >= 3 && do_after_once(usr, 15, target = target))
 			if(O.opened || !use(3))
 				return
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))


### PR DESCRIPTION
**What does this PR do:**
Makes wrapping a locker and crates take time. No more locker catching cheese.
Guy asked for this and it made sense:
https://nanotrasen.se/forum/topic/15602-wrapping-lockers/

Makes welding lockers take time as well.

Both take 1.5 seconds to do.

Code of the wrapping is a mess but that's not what this PR is about.

**Changelog:**
:cl:
tweak: Wrapping lockers and crates now takes 1.5 seconds to do
tweak: Welding lockers now takes 1.5 seconds to do
/:cl:

