### PR TITLE
ChemMaster Refactor

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -554,14 +554,33 @@ to destroy them and players will be able to make replacements.
 							/obj/item/stock_parts/cell = 1)
 
 /obj/item/circuitboard/chem_master
-	name = "circuit board (Chem Master 2999)"
-	build_path = /obj/machinery/chem_master/constructable
+	name = "circuit board (ChemMaster 3000)"
+	build_path = /obj/machinery/chem_master
 	board_type = "machine"
 	origin_tech = "materials=3;programming=2;biotech=3"
 	req_components = list(
 							/obj/item/reagent_containers/glass/beaker = 2,
 							/obj/item/stock_parts/manipulator = 1,
 							/obj/item/stock_parts/console_screen = 1)
+
+/obj/item/circuitboard/chem_master/attackby(obj/item/I, mob/user, params)
+	if(isscrewdriver(I))
+		var/new_name = "ChemMaster"
+		var/new_path = /obj/machinery/chem_master
+
+		if(build_path == /obj/machinery/chem_master)
+			new_name = "CondiMaster"
+			new_path = /obj/machinery/chem_master/condimaster
+
+		build_path = new_path
+		name = "circuit board ([new_name] 3000)"
+		to_chat(user, "<span class='notice'>You change the circuit board setting to \"[new_name]\".</span>")
+	else
+		return ..()
+
+/obj/item/circuitboard/chem_master/condi_master
+	name = "circuit board (CondiMaster 3000)"
+	build_path = /obj/machinery/chem_master/condimaster
 
 /obj/item/circuitboard/chem_heater
 	name = "circuit board (Chemical Heater)"

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -88,6 +88,10 @@
 /obj/machinery/chem_heater/attack_hand(mob/user)
 	ui_interact(user)
 
+/obj/machinery/chem_heater/attack_ghost(mob/user)
+	if(user.can_admin_interact())
+		return attack_hand(user)
+
 /obj/machinery/chem_heater/attack_ai(mob/user)
 	add_hiddenprint(user)
 	return attack_hand(user)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -21,7 +21,24 @@
 /obj/machinery/chem_master/New()
 	..()
 	create_reagents(100)
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/chem_master(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stock_parts/console_screen(null)
+	component_parts += new /obj/item/reagent_containers/glass/beaker(null)
+	component_parts += new /obj/item/reagent_containers/glass/beaker(null)
+	RefreshParts()
 	update_icon()
+
+/obj/machinery/chem_master/Destroy()
+	QDEL_NULL(beaker)
+	QDEL_NULL(loaded_pill_bottle)
+	return ..()
+
+/obj/machinery/chem_master/RefreshParts()
+	reagents.maximum_volume = 0
+	for(var/obj/item/reagent_containers/glass/beaker/B in component_parts)
+		reagents.maximum_volume += B.reagents.maximum_volume
 
 /obj/machinery/chem_master/ex_act(severity)
 	switch(severity)
@@ -50,6 +67,27 @@
 	update_icon()
 
 /obj/machinery/chem_master/attackby(obj/item/I, mob/user, params)
+	if(default_deconstruction_screwdriver(user, "mixer0_nopower", "mixer0", I))
+		if(beaker)
+			beaker.forceMove(get_turf(src))
+			beaker = null
+			reagents.clear_reagents()
+		if(loaded_pill_bottle)
+			loaded_pill_bottle.forceMove(get_turf(src))
+			loaded_pill_bottle = null
+		return
+
+	if(exchange_parts(user, I))
+		return
+
+	if(panel_open)
+		if(iscrowbar(I))
+			default_deconstruction_crowbar(I)
+			return TRUE
+		else
+			to_chat(user, "<span class='warning'>You can't use the [name] while it's panel is opened!</span>")
+			return TRUE
+
 	if(default_unfasten_wrench(user, I))
 		power_change()
 		return
@@ -334,7 +372,8 @@
 	return attack_hand(user)
 
 /obj/machinery/chem_master/attack_ghost(mob/user)
-	return attack_hand(user)
+	if(user.can_admin_interact())
+		return attack_hand(user)
 
 /obj/machinery/chem_master/attack_hand(mob/user)
 	if(..())
@@ -399,40 +438,12 @@
 	name = "\improper CondiMaster 3000"
 	condi = TRUE
 
-/obj/machinery/chem_master/constructable
-	name = "ChemMaster 2999"
-	desc = "Used to seperate chemicals and distribute them in a variety of forms."
-
-/obj/machinery/chem_master/constructable/New()
+/obj/machinery/chem_master/condimaster/New()
 	..()
-	component_parts = list()
-	component_parts += new /obj/item/circuitboard/chem_master(null)
+	QDEL_LIST(component_parts)
+	component_parts += new /obj/item/circuitboard/chem_master/condi_master(null)
 	component_parts += new /obj/item/stock_parts/manipulator(null)
 	component_parts += new /obj/item/stock_parts/console_screen(null)
 	component_parts += new /obj/item/reagent_containers/glass/beaker(null)
 	component_parts += new /obj/item/reagent_containers/glass/beaker(null)
-
-/obj/machinery/chem_master/constructable/attackby(obj/item/I, mob/user, params)
-
-	if(default_deconstruction_screwdriver(user, "mixer0_nopower", "mixer0", I))
-		if(beaker)
-			beaker.forceMove(get_turf(src))
-			beaker = null
-			reagents.clear_reagents()
-		if(loaded_pill_bottle)
-			loaded_pill_bottle.forceMove(get_turf(src))
-			loaded_pill_bottle = null
-		return
-
-	if(exchange_parts(user, I))
-		return
-
-	if(panel_open)
-		if(iscrowbar(I))
-			default_deconstruction_crowbar(I)
-			return TRUE
-		else
-			to_chat(user, "<span class='warning'>You can't use the [name] while it's panel is opened!</span>")
-			return TRUE
-	else
-		return ..()
+	RefreshParts()

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -173,8 +173,8 @@
 	category = list("Medical Machinery")
 
 /datum/design/chem_master
-	name = "Machine Design (Chem Master Board)"
-	desc = "The circuit board for a Chem Master 2999."
+	name = "Machine Design (ChemMaster Board)"
+	desc = "The circuit board for a ChemMaster 3000."
 	id = "chem_master"
 	req_tech = list("biotech" = 3, "materials" = 3, "programming" = 2)
 	build_type = IMPRINTER


### PR DESCRIPTION
Refactors the ChemMaster.

Similar to the Chem Dispenser refactor, this does a few things:

- Removes constructable ChemMaster subtype
- All ChemMasters are now constructable (yes, this means mapped in type)
- Can upgrade ChemMasters (the total volume of their resevoir is now equal to the size of the volume of the beakers inside them)
- Can use a screwdriver on ChemMaster boards to change them to CondiMaster boards
- Ghost viewing ChemMasters requires admin status

:cl: Fox McCloud
add: Roundstart ChemMasters are now constructable/deconstructable
tweak: Can upgrade ChemMasters. Larger beakers mean a larger reservoir
/:cl: