### PR TITLE
New Crit Balance Tweaks--Blobs and Stands

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -65,15 +65,17 @@
 /mob/living/simple_animal/hostile/blob/blobspore/Life(seconds, times_fired)
 
 	if(!is_zombie && isturf(src.loc))
-		for(var/mob/living/carbon/human/H in oview(src,1)) //Only for corpse right next to/on same tile
-			if(H.stat == DEAD)
+		for(var/mob/living/carbon/human/H in oview(src, 1)) //Only for corpse right next to/on same tile
+			if(H.stat == DEAD || (!H.check_death_method() && H.health <= HEALTH_THRESHOLD_DEAD))
 				Zombify(H)
 				break
 	..()
 
-/mob/living/simple_animal/hostile/blob/blobspore/proc/Zombify(var/mob/living/carbon/human/H)
+/mob/living/simple_animal/hostile/blob/blobspore/proc/Zombify(mob/living/carbon/human/H)
+	if(!H.check_death_method())
+		H.death()
 	var/obj/item/organ/external/head/head_organ = H.get_organ("head")
-	is_zombie = 1
+	is_zombie = TRUE
 	if(H.wear_suit)
 		var/obj/item/clothing/suit/armor/A = H.wear_suit
 		if(A.armor && A.armor["melee"])
@@ -87,14 +89,15 @@
 	icon = H.icon
 	speak_emote = list("groans")
 	icon_state = "zombie2_s"
-	head_organ.h_style = null
+	if(head_organ)
+		head_organ.h_style = null
 	H.update_hair()
 	human_overlays = H.overlays
 	update_icons()
-	H.loc = src
+	H.forceMove(src)
 	pressure_resistance = 20  //5 kPa difference required to push lowered
 	throw_pressure_limit = 30  //15 kPa difference required to throw lowered
-	loc.visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
+	visible_message("<span class='warning'>The corpse of [H.name] suddenly rises!</span>")
 
 /mob/living/simple_animal/hostile/blob/blobspore/death(gibbed)
 	// Only execute the below if we successfuly died

--- a/code/game/gamemodes/miniantags/guardian/guardian.dm
+++ b/code/game/gamemodes/miniantags/guardian/guardian.dm
@@ -60,9 +60,9 @@
 /mob/living/simple_animal/hostile/guardian/Life(seconds, times_fired) //Dies if the summoner dies
 	..()
 	if(summoner)
-		if(summoner.stat == DEAD)
+		if(summoner.stat == DEAD || (!summoner.check_death_method() && summoner.health <= HEALTH_THRESHOLD_DEAD))
 			to_chat(src, "<span class='danger'>Your summoner has died!</span>")
-			visible_message("<span class='danger'>The [src] dies along with its user!</span>")
+			visible_message("<span class='danger'>[src] dies along with its user!</span>")
 			ghostize()
 			qdel(src)
 	snapback()


### PR DESCRIPTION
For the most part, players being more durable under some circumstances is an intended part of newcrit.

That said, for some very specific situations, it causes problems, the most obvious of which are holoparasites and blobspores.

- Blobspores will zombify people if the person they are zombifying is dead *or* if the infected person utilizes the new crit method and their health is below -100 (200 total damage)
- Holoparasites will die if their host is dead *or* if their host utilizes new crit and their host's health is below -100 (200 total damage).

Reason: Stands last way too long with newcrit users. Holoparas are already ridiculously OP, even with old crit; this got worse with new crit. 

Blobspores end up having to wail on people forever and waiting for them to die before they can infect new players. 

Also fixes blobspores being invisible if they infect someone who doesn't have a head.

fixes: https://github.com/ParadiseSS13/Paradise/issues/11132

:cl: Fox McCloud
tweak: Blobspores will additionally zomify all players who have 200 damage or more
tweak: Holoparasites will additionally die once their host has 200 damage or more
fix: Fixes blob zombies who infect players who have no head being invisible
/:cl: