### PR TITLE
Department head jobs now require playtime in that department

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -18,8 +18,8 @@
 			            access_heads, access_construction, access_sec_doors,
 			            access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_minisat, access_mechanic, access_mineral_storeroom)
 	minimal_player_age = 21
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 300
+	exp_type = EXP_TYPE_ENGINEERING
 	outfit = /datum/outfit/job/chief_engineer
 
 /datum/outfit/job/chief_engineer

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -16,8 +16,8 @@
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_maint_tunnels, access_paramedic, access_mineral_storeroom)
 	minimal_player_age = 21
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 300
+	exp_type = EXP_TYPE_MEDICAL
 	outfit = /datum/outfit/job/cmo
 
 /datum/outfit/job/cmo

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -18,8 +18,8 @@
 					access_research, access_robotics, access_xenobiology, access_ai_upload,
 					access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_minisat, access_maint_tunnels, access_mineral_storeroom, access_network)
 	minimal_player_age = 21
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 300
+	exp_type = EXP_TYPE_SCIENCE
 	// All science-y guys get bonuses for maxing out their tech.
 	required_objectives = list(
 		/datum/job_objective/further_research

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -18,8 +18,8 @@
 			            access_research, access_engine, access_mining, access_medical, access_construction, access_mailsorting,
 			            access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_pilot, access_weapons)
 	minimal_player_age = 21
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 300
+	exp_type = EXP_TYPE_SECURITY
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/hos
 

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -9,8 +9,8 @@
 	department_head = list("Captain")
 	req_admin_notify = 1
 	minimal_player_age = 30
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 300
+	exp_type = EXP_TYPE_SILICON
 
 /datum/job/ai/equip(mob/living/carbon/human/H)
 	if(!H)

--- a/code/game/jobs/job/supervisor.dm
+++ b/code/game/jobs/job/supervisor.dm
@@ -13,8 +13,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	access = list() 			//See get_access()
 	minimal_access = list() 	//See get_access()
 	minimal_player_age = 30
-	exp_requirements = 2400
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 300
+	exp_type = EXP_TYPE_COMMAND
 	disabilities_allowed = 0
 	outfit = /datum/outfit/job/captain
 
@@ -68,8 +68,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 0)
 	req_admin_notify = 1
 	is_command = 1
 	minimal_player_age = 21
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 300
+	exp_type = EXP_TYPE_COMMAND
 	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
 			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
 			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -100,6 +100,7 @@ var/global/list/role_playtime_requirements = list(
 // Procs
 
 /proc/role_available_in_playtime(client/C, role)
+	// "role" is a special role defined in role_playtime_requirements above. e.g: ROLE_ERT. This is *not* a job title.
 	if(!C)
 		return 0
 	if(!role)
@@ -108,11 +109,18 @@ var/global/list/role_playtime_requirements = list(
 		return 0
 	if(config.use_exp_restrictions_admin_bypass && check_rights(R_ADMIN, 0, C.mob))
 		return 0
-
-	var/datum/job/job = job_master.GetJob(role)
-	if(!job)
+	var/list/play_records = params2list(C.prefs.exp)
+	var/isexempt = text2num(play_records[EXP_TYPE_EXEMPT])
+	if(isexempt)
 		return 0
-	return job.available_in_playtime(C)
+	var/minimal_player_hrs = role_playtime_requirements[role]
+	if(!minimal_player_hrs)
+		return 0
+	var/req_mins = minimal_player_hrs * 60
+	var/my_exp = text2num(play_records[EXP_TYPE_CREW])
+	if(!isnum(my_exp))
+		return req_mins
+	return max(0, req_mins - my_exp)
 
 
 /datum/job/proc/available_in_playtime(client/C)

--- a/code/game/jobs/job_exp.dm
+++ b/code/game/jobs/job_exp.dm
@@ -108,18 +108,12 @@ var/global/list/role_playtime_requirements = list(
 		return 0
 	if(config.use_exp_restrictions_admin_bypass && check_rights(R_ADMIN, 0, C.mob))
 		return 0
-	var/list/play_records = params2list(C.prefs.exp)
-	var/isexempt = text2num(play_records[EXP_TYPE_EXEMPT])
-	if(isexempt)
+
+	var/datum/job/job = job_master.GetJob(role)
+	if(!job)
 		return 0
-	var/minimal_player_hrs = role_playtime_requirements[role]
-	if(!minimal_player_hrs)
-		return 0
-	var/req_mins = minimal_player_hrs * 60
-	var/my_exp = text2num(play_records[EXP_TYPE_CREW])
-	if(!isnum(my_exp))
-		return req_mins
-	return max(0, req_mins - my_exp)
+	return job.available_in_playtime(C)
+
 
 /datum/job/proc/available_in_playtime(client/C)
 	if(!C)


### PR DESCRIPTION
:cl: Kyep
tweak: Changed playtime requirements for command jobs. HoS/RD/CE/CMO/AI now require 5h played in their department to be playable. HoP/Captain now require 5h played as a member of the command staff.
/:cl:

More detailed overview:
- HoS/RD/CE/CMO now require 5h played in their department. So for example HoS requires at least 5h played as security.
- AI is treated as a head for this, meaning playing AI now requires playing 5h in the "silicon" department (ie: as a cyborg)
- Captain/HoP require 5h played as a member of the command staff (ie: HoS/CE/RD/CMO/NTRep)
- Overall, this means that playing a head of a department now requires you to have spent a little time in that department, and commanding the station (as Captain or Acting Captain) now requires you to have spent a little time playing a head of a department.

Combined Breakdown:
- HoS/RD/CE/CMO/AI: previously required 20h as crew. Now requires 5h in their department. Their department requires 3-10h to get into (3h for med, 5h for eng/sci/silicon, 10h for sec). So, 8-15h combined, which is close to the previous 20h as crew requirement, except that it now focuses on time in their department, rather than time overall.
- Captain/HoP: previously required 40h as crew. Now requires 5h as command. Since playing command now requires 8-15h combined (depending on department), an additional 5h as command brings the total here to 13-20h. This is significantly less than the previous 40h as crew requirement... but in exchange it requires most of that time to be not civilian, and more than a third to be in a command job. Since some people rarely play command jobs, I think this is a fair trade.