### PR TITLE
Blobbernaut 2

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -45,7 +45,6 @@
 	var/obj/structure/blob/factory/factory = null
 	var/list/human_overlays = list()
 	var/is_zombie = 0
-	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 	pressure_resistance = 100    //100 kPa difference required to push
 	throw_pressure_limit = 120  //120 kPa difference required to throw
 
@@ -174,7 +173,6 @@
 	force_threshold = 10
 	mob_size = MOB_SIZE_LARGE
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
-	gold_core_spawnable = CHEM_MOB_SPAWN_HOSTILE
 	pressure_resistance = 100    //100 kPa difference required to push
 	throw_pressure_limit = 120  //120 kPa difference required to throw
 


### PR DESCRIPTION
:cl: Kyep
fix: Blob mobs can definitely no longer be spawned in xenobio.
/:cl:

As part of https://github.com/ParadiseSS13/Paradise/pull/11080 I sought to remove blobbernauts, and blob mobs more generally, from the pool of monsters that can be spawned from gold core reactions.

Unfortunately, I forgot to remove the gold_core_spawnable tag from the mobs under the parent type /mob/living/simple_animal/hostile/blob, which means they did not inherit the gold_core_spawnable = CHEM_MOB_SPAWN_INVALID I put on the parent type. Yeah, I know, silly omission.

This PR simply corrects my mistake, and finishes making them unspawnable in xenobio.