### PR TITLE
Stops ghosts from having ZZZ bubbles

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -148,6 +148,8 @@ Works together with spawning an observer, noted above.
 
 /mob/proc/ghostize(var/flags = GHOST_CAN_REENTER)
 	if(key)
+		if(player_logged) //if they have disconnected we want to remove their SSD overlay
+			overlays -= image('icons/effects/effects.dmi', icon_state = "zzz_glow")
 		if(GLOB.non_respawnable_keys[ckey])
 			flags &= ~GHOST_CAN_REENTER
 		var/mob/dead/observer/ghost = new(src, flags)	//Transfer safety to observer spawning proc.


### PR DESCRIPTION
**What does this PR do:**
Removes ZZZ bubbles from people who are deleted and ghosted, aka moved to long term storage in a cryopod.

Fixes: #11098

Results in their ghost not having the ZZZ overlay.

🆑 
tweak: Removes SSD sleep bubbles from ghosts
/ 🆑 