### PR TITLE
Makes "Start Now"'s confirmation meaningful

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -213,6 +213,9 @@
 
 	// Automatic localhost admin disable
 	var/disable_localhost_admin = 0
+	
+	//Start now warning
+	var/start_now_confirmation = 0
 
 /datum/configuration/New()
 	for(var/T in subtypesof(/datum/game_mode))
@@ -636,6 +639,9 @@
 
 				if("disable_karma")
 					config.disable_karma = 1
+					
+				if("start_now_confirmation")
+					config.start_now_confirmation = 1
 
 				if("tick_limit_mc_init")
 					config.tick_limit_mc_init = text2num(value)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -671,8 +671,9 @@ var/global/nologevent = 0
 		alert("Unable to start the game as it is not set up.")
 		return
 	if(ticker.current_state == GAME_STATE_PREGAME)
-		if(alert(usr, "Are you sure you want to start now?", "Start game", "Yes", "No") != "Yes")
-			return
+		if(config.start_now_confirmation)
+			if(alert(usr, "This is a live server. Are you sure you want to start now?", "Start game", "Yes", "No") != "Yes")
+				return
 		ticker.current_state = GAME_STATE_SETTING_UP
 		log_admin("[key_name(usr)] has started the game.")
 		message_admins("[key_name_admin(usr)] has started the game.")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -400,3 +400,6 @@ DISABLE_HIGH_POP_MC_MODE_AMOUNT 60
 
 ## Uncomment to disable automatic admin for localhost
 #DISABLE_LOCALHOST_ADMIN
+
+## Uncomment to give a confirmation before hitting start now
+#START_NOW_CONFIRMATION


### PR DESCRIPTION
**What does this PR do:**
Makes start_now meaningful by making it a config option for live servers so that the human brain doesn't just ignore it every time and treat it as spam.

Needs config update

:cl:
tweak: Start now confirmation is now a config option
/:cl: