### PR TITLE
Stops vending machines from attacking SSD people and spamming the logs

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -708,9 +708,13 @@
 /obj/machinery/vending/proc/throw_item()
 	var/obj/throw_item = null
 	var/mob/living/target = locate() in view(7,src)
-	if(!target || !target.client)
+	if(!target)
 		return 0
-
+	if(istype(target, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = target
+		if(H.player_logged)
+			return 0
+	
 	for(var/datum/data/vending_product/R in product_records)
 		if(R.amount <= 0) //Try to use a record that actually has something to dump.
 			continue

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -708,7 +708,7 @@
 /obj/machinery/vending/proc/throw_item()
 	var/obj/throw_item = null
 	var/mob/living/target = locate() in view(7,src)
-	if(!target)
+	if(!target || !target.client)
 		return 0
 
 	for(var/datum/data/vending_product/R in product_records)


### PR DESCRIPTION
**What does this PR do:**
Stops vending machines creating attack logs by throwing stuff at SSD players.

:cl:
tweak: Vending Machines will no longer throw items at SSD people.
/ :cl: