### PR TITLE
Shadowling Glare ability rework [Second Version]

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -56,11 +56,11 @@
 			var/loss = 10 - distance
 			var/duration = 10 - loss
 			if(loss <= 0)
-				to_chat(user, "<span class='danger'>Your glare had no effect over such long distance!</span>")
+				to_chat(user, "<span class='danger'>Your glare had no effect over a such long distance!</span>")
 				return
 			target.slowed = duration
 			M.AdjustSilence(10)
-			to_chat(target, "<span class='userdanger'>A red light flashes across your vision, and your mind tries to resist them.. you are exhausted..</span>")
+			to_chat(target, "<span class='userdanger'>A red light flashes across your vision, and your mind tries to resist them.. you are exhausted.. you are not able to speak..</span>")
 			sleep(duration*10)
 			target.Stun(loss)
 			target.visible_message("<span class='danger'>[target] freezes in place, [target.p_their()] eyes glazing over...</span>")

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -18,9 +18,9 @@
 	return 0
 
 
-/obj/effect/proc_holder/spell/targeted/glare //Stuns and mutes a human target for 10 seconds
+/obj/effect/proc_holder/spell/targeted/glare //Stuns and mutes a human target, depending on the distance relative to the shadowling
 	name = "Glare"
-	desc = "Stuns and mutes a target for a decent duration."
+	desc = "Stuns and mutes a target for a decent duration. Duration depends on the proximity to the target."
 	panel = "Shadowling Abilities"
 	charge_max = 300
 	clothes_req = 0

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -46,13 +46,26 @@
 			return
 		var/mob/living/carbon/human/M = target
 		user.visible_message("<span class='warning'><b>[user]'s eyes flash a blinding red!</b></span>")
-		target.visible_message("<span class='danger'>[target] freezes in place, [target.p_their()] eyes glazing over...</span>")
-		if(in_range(target, user))
+		var/distance = get_dist(target, user)
+		if (distance <= 1) //Melee glare
+			target.visible_message("<span class='danger'>[target] freezes in place, [target.p_their()] eyes glazing over...</span>")
 			to_chat(target, "<span class='userdanger'>Your gaze is forcibly drawn into [user]'s eyes, and you are mesmerized by [user.p_their()] heavenly beauty...</span>")
-		else //Only alludes to the shadowling if the target is close by
+			target.Stun(10)
+			M.AdjustSilence(10)
+		else //Distant glare
+			var/loss = 10 - distance
+			var/duration = 10 - loss
+			if(loss <= 0)
+				to_chat(user, "<span class='danger'>Your glare had no effect over such long distance!</span>")
+				return
+			target.slowed = duration
+			target.stuttering = duration
+			to_chat(target, "<span class='userdanger'>A red light flashes across your vision, and your mind tries to resist them.. you are exhausted..</span>")
+			sleep(duration*10)
+			target.Stun(loss)
+			M.AdjustSilence(loss)
+			target.visible_message("<span class='danger'>[target] freezes in place, [target.p_their()] eyes glazing over...</span>")
 			to_chat(target, "<span class='userdanger'>Red lights suddenly dance in your vision, and you are mesmerized by the heavenly lights...</span>")
-		target.Stun(10)
-		M.AdjustSilence(10)
 
 /obj/effect/proc_holder/spell/aoe_turf/veil
 	name = "Veil"

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -59,11 +59,10 @@
 				to_chat(user, "<span class='danger'>Your glare had no effect over such long distance!</span>")
 				return
 			target.slowed = duration
-			target.stuttering = duration
+			M.AdjustSilence(10)
 			to_chat(target, "<span class='userdanger'>A red light flashes across your vision, and your mind tries to resist them.. you are exhausted..</span>")
 			sleep(duration*10)
 			target.Stun(loss)
-			M.AdjustSilence(loss)
 			target.visible_message("<span class='danger'>[target] freezes in place, [target.p_their()] eyes glazing over...</span>")
 			to_chat(target, "<span class='userdanger'>Red lights suddenly dance in your vision, and you are mesmerized by the heavenly lights...</span>")
 


### PR DESCRIPTION
**What does this PR do:**
This PR reworks the Shadowling Glare ability. Instead of being "I stun, I win" button for the Shadowling, it's effectiveness now depends on the distance to the glared target.

Inspired by some proposed changes, before they removed Shadowlings as a gamemode on /tg/station13.

Glare ability is now completely depedendent on the distance from the Shadowling to the glared target.

If Shadowling glares their target on the tile next to them, glare will function completely same as it currently does - Stuns and mutes the target for 10 seconds.

But, if the target is further away than that, following will happen:

**PHASE 1:**
1) Target will be slowed, duration depends on the distance, the further the Shadowling was when he glared, the **LONGER** it will be.
2) Target will be still muted for 10 seconds, which is the entire duration of combined PHASES 1 and 2.

**PHASE 2:**
After the duration is over, target will be stunned,  duration depends on on the distance, the further the Shadowling was when he glared, the **SHORTER** it will be.

The combined durations of PHASES 1 and 2 will **ALWAYS** be 10 seconds, no matter the distance.

**Practical examples:**
Shadowling glares their target from 7 tiles away. Target will be slow for 7 seconds. After 7 seconds, the target will be stunned for 3 seconds. The target is muted for the entire duration.

Shadowling glares their target from 2 tiles away. Target will be slow for 2 seconds. After 2 seconds, the target will be stunned for 8 seconds. The target is muted for the entire duration.

This change asssures that shadowlings just cannot stun their targets for whole 10 seconds just because someone opened airlock to the maintenance, while they are safely half a screen (!) away. If shadowlings want their full 10 second stun, they will need to get close to their target, and expose themselves for the potentional reward.

Tested locally without any issue.

**Changelog:**
:cl: Arkatos
tweak: Shadowling Glare ability reworked - The further Shadowling is from their glared target, the shorter stun their target gets. Stuns also have a delay before they kick in, based on the distance, however targets will be slowed and muted before stun takes effect. Targets on the tile just next to them are still stunned and muted for 10 seconds without any delay.
/:cl: