### PR TITLE
Makes genetics less painful to do

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -939,7 +939,7 @@
 					if(connected)
 						I.damage_coeff = connected.damage_coeff
 					src.injector_ready = 0
-					spawn(300)
+					spawn(30) // 3 seconds
 						src.injector_ready = 1
 			return 1
 


### PR DESCRIPTION
**What does this PR do:**
Genetics has become even more of a RNG hell due to the recent genetics bug fix.
This PR reduces the cooldown of a DNA injector creation from 30 seconds to 3 seconds. It's still RNG hell and annoying but it's less annoying now

**Changelog:**
:cl:
tweak: DNA injectors can be created every 3 seconds now instead of every 30 seconds
/:cl:

