### PR TITLE
Fixes Sound

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -22,7 +22,7 @@
 		if(!M || !M.client)
 			continue
 
-		var/turf/T = get_turf(M)
+		var/turf/T = get_turf(M) // These checks need to be changed if z-levels are ever further refactored
 		if(!T)
 			continue
 		if(T.z != turf_source.z)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -19,15 +19,19 @@
 		listeners = listeners & hearers(maxdistance, turf_source)
 	for(var/P in listeners)
 		var/mob/M = P
-		if(!M || !M.client || M.z != turf_source.z)
+		if(!M || !M.client)
 			continue
+
+		var/turf/T = get_turf(M)
+		if(!T)
+			continue
+		if(T.z != turf_source.z)
+			continue
+
 		var/distance = get_dist(M, turf_source)
 
 		if(distance <= maxdistance)
-			var/turf/T = get_turf(M)
-
-			if(T && T.z == turf_source.z)
-				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S)
+			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S)
 
 /mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S)
 	if(!client || !can_hear())


### PR DESCRIPTION
Fixes some mobs not being able to hear sound

At 1,000,000 calls, `get_turf` seems to have an everrrr so slight edge of performance over `get_dist`, so it's better to get the turf first and then check the z-level before checking the distance.

Who knows the internal working of either of these procs. `get_dist` is native, and `get_turf` is a define which uses `get_step` which is also native, but it would make sense that `get_dist` is more expensive.

alternative to: https://github.com/ParadiseSS13/Paradise/pull/11175

:cl: Fox McCloud
fix: Fixes some mobs not being able to hear sounds
/:cl: